### PR TITLE
rasm2 fix for -D

### DIFF
--- a/binr/rasm2/rasm2.c
+++ b/binr/rasm2/rasm2.c
@@ -75,10 +75,9 @@ static int rasm_disasm(char *buf, ut64 offset, ut64 len, int ascii, int bin, int
 	if (hex) {
 		RAsmOp op;
 		r_asm_set_pc (a, offset);
-		while (r_asm_disassemble (a, &op, data+ret, len-ret) != -1) {
+		while (len-ret > 0 && r_asm_disassemble (a, &op, data+ret, len-ret) != -1) {
 			printf ("0x%08"PFMT64x"  %d %12s %s\n", 
 				a->pc, op.inst_len, op.buf_hex, op.buf_asm);
-			if (ret<1) break;
 			ret += op.inst_len;
 			r_asm_set_pc (a, offset+ret);
 		}
@@ -272,7 +271,7 @@ int main(int argc, char *argv[]) {
 				else ret = rasm_asm (buf, offset, len, bin);
 				idx += ret;
 				offset += ret;
-				if (ret<1) {
+				if (!ret) {
 					eprintf ("invalid\n");
 					return 0;
 				}
@@ -283,7 +282,7 @@ int main(int argc, char *argv[]) {
 		}
 		if (dis) ret = rasm_disasm (argv[optind], offset, len, ascii, bin, dis-1);
 		else ret = rasm_asm (argv[optind], offset, len, bin);
-		//if (!ret) eprintf ("invalid\n");
+		if (!ret) eprintf ("invalid\n");
 		return ret;
 	}
 	return 0;


### PR DESCRIPTION
The fix in commit d843506ae1eacefc0f5631c48824a58075c633ae was checking for ret < 0, but as ret is initialized with 0 rasm -D would always finish after a single instruction.
This commit reverts to the previous commit and adds a check to see if the end of the buffer was reached.
