### PR TITLE
Accept newer magic bytes for dex files

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -19,12 +19,16 @@ static ut64 baddr(RBinArch *arch) {
 static int check(RBinArch *arch) {
 	if (!arch->buf || !arch->buf->buf)
 		return R_FALSE;
-	if (!memcmp (arch->buf->buf, "dex\n035\0", 8))
-		return R_TRUE;
+	if (!memcmp (arch->buf->buf, "dex\n035\0", 8)) // Non-extended opcode dex file
+	        return R_TRUE;
+	else if (!memcmp (arch->buf->buf, "dex\n036\0", 8)) // Extended (jumnbo) opcode dex file, ICS+ only (sdk level 14+)
+	        return R_TRUE;
 	else if (!memcmp (arch->buf->buf, "dex\n009\0", 8)) // M3 (Nov-Dec 07)
-		return R_TRUE;
-	else if (!memcmp (arch->buf->buf, "dex\n009\0", 8)) // M5 (Feb-Mar 08)
-		return R_TRUE;
+	        return R_TRUE;
+        else if (!memcmp (arch->buf->buf, "dex\n009\0", 8)) // M5 (Feb-Mar 08)
+	        return R_TRUE;
+	else if (!memcmp (arch->buf->buf, "dex\n", 4)) // Default fall through, should still be a dex file
+                return R_TRUE;
 	return R_FALSE;
 }
 


### PR DESCRIPTION
Currently if a ICS+ extended opcode file was passed to radare2 it
would fail to parse it properly. This checks for the two conditions
'dex\n035\0' and 'dex\n036\0' - and will also just attempt to parse
it if the magic bytes 'dex\n' are available. This should suffice since
the last four bytes are the versioning bytes.
