### PR TITLE
Check if debug is dead in r_debug_kill function.

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -451,6 +451,8 @@ R_API int r_debug_syscall(RDebug *dbg, int num) {
 
 R_API int r_debug_kill(RDebug *dbg, int pid, int tid, int sig) {
 	int ret = R_FALSE;
+	if (r_debug_is_dead (dbg))
+		return R_FALSE;
 	if (dbg->h && dbg->h->kill)
 		ret = dbg->h->kill (dbg, pid, tid, sig);
 	else eprintf ("Backend does not implements kill()\n");


### PR DESCRIPTION
You forgot to check if debug is dead in r_debug_kill function and the result was kill(-1, sig) (i.e. send sig to every process that calling process has permission).
