### PR TITLE
Stop function analysis at jump

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -146,6 +146,13 @@ R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut64 
 		}
 		switch (op.type) {
 		case R_ANAL_OP_TYPE_JMP:
+			if (!r_anal_fcn_xref_add (anal, fcn, op.addr, op.jump,
+					R_ANAL_REF_TYPE_CODE)) {
+				r_anal_op_fini (&op);
+				return R_ANAL_RET_ERROR;
+			} else {
+				return R_ANAL_RET_END;
+			}
 		case R_ANAL_OP_TYPE_CJMP:
 #if 0
 		// do not add xrefs for cjmps?


### PR DESCRIPTION
Function analysis will now stop at the arm "b" instruction and other unconditional jumps.
