### PR TITLE
Updated Symbols and Strings Retrieval

### DIFF
--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -34,7 +34,7 @@ static ut64 baddr(RBinArch *arch) {
 }
 
 static RList* classes(RBinArch *arch) {
-	char *p;
+	/*char *p;
 	RBinClass *c;
 	RList *ret = r_list_new ();
 	if (!ret) return NULL;
@@ -48,8 +48,9 @@ static RList* classes(RBinArch *arch) {
 	p = (char*)r_str_lchr (c->name, '/');
 	if (p) strcpy (c->name, p+1);
 	c->super = strdup ("Object"); //XXX
-	r_list_append (ret, c);
-
+	r_list_append (ret, c);*/
+	RList *ret;
+	ret = r_bin_java_get_classes((struct r_bin_java_obj_t*)arch->bin_obj);
 	return ret;
 }
 
@@ -150,41 +151,12 @@ static RList* lines(RBinArch *arch) {
 }
 
 static RList* sections(RBinArch *arch) {
-	RList *ret = NULL;
-	RBinSection *ptr = NULL;
-	struct r_bin_java_sym_t *s = NULL;
-	RBinJavaObj *b = arch->bin_obj;
-
-	if (!(ret = r_list_new ()))
-		return NULL;
-	ret->free = free;
-	if ((s = r_bin_java_get_symbols (arch->bin_obj))) {
-		if ((ptr = R_NEW0 (RBinSection))) {
-			strcpy (ptr->name, "code");
-			ptr->size = ptr->vsize = b->fsymsz;
-			ptr->offset = ptr->rva = b->fsym;
-			ptr->srwx = 4|1;
-			r_list_append (ret, ptr);
-		}
-		if ((ptr = R_NEW0 (RBinSection))) {
-			strcpy (ptr->name, "constpool");
-			ptr->size = ptr->vsize = b->fsym;
-			ptr->offset = ptr->rva = 0;
-			ptr->srwx = 4;
-			r_list_append (ret, ptr);
-		}
-		if ((ptr = R_NEW0 (RBinSection))) {
-			strcpy (ptr->name, "data");
-			ptr->offset = ptr->rva = b->fsymsz+b->fsym;
-			ptr->size = ptr->vsize = arch->buf->length - ptr->rva;
-			ptr->srwx = 4|2;
-			r_list_append (ret, ptr);
-		}
-		free (s);
-	}
-	return ret;
+	return r_bin_java_get_sections (arch->bin_obj);
 }
 
+static RList* fields(RBinArch *arch) {
+	return r_bin_java_get_fields (arch->bin_obj);
+}
 struct r_bin_plugin_t r_bin_plugin_java = {
 	.name = "java",
 	.desc = "java bin plugin",
@@ -201,7 +173,7 @@ struct r_bin_plugin_t r_bin_plugin_java = {
 	.imports = NULL,
 	.strings = &strings,
 	.info = &info,
-	.fields = NULL,
+	.fields = fields,
 	.libs = NULL,
 	.relocs = NULL,
 	.meta = NULL,

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -216,6 +216,7 @@ typedef struct r_bin_symbol_t {
 	ut64 offset;
 	ut64 size;
 	ut64 ordinal;
+	ut32 visibility;
 } RBinSymbol;
 
 typedef struct r_bin_import_t {
@@ -223,6 +224,7 @@ typedef struct r_bin_import_t {
 	char bind[R_BIN_SIZEOF_STRINGS];
 	char type[R_BIN_SIZEOF_STRINGS];
 	ut64 ordinal;
+	ut32 visibility;
 } RBinImport;
 
 typedef struct r_bin_reloc_t {
@@ -232,6 +234,7 @@ typedef struct r_bin_reloc_t {
 	st64 addend;
 	ut64 rva;
 	ut64 offset;
+	ut32 visibility;
 } RBinReloc;
 
 typedef struct r_bin_string_t {
@@ -247,6 +250,7 @@ typedef struct r_bin_field_t {
 	char name[R_BIN_SIZEOF_STRINGS];
 	ut64 rva;
 	ut64 offset;
+	ut32 visibility;
 } RBinField;
 
 typedef struct r_bin_meta_t {
@@ -268,6 +272,7 @@ typedef struct r_bin_bind_t {
 	RBin *bin;
 	RBinGetOffset get_offset;
 	RBinGetName get_name;
+	ut32 visibility;
 } RBinBind;
 
 #ifdef R_API

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -62,6 +62,50 @@ RBinJavaObj * R_BIN_JAVA_GLOBAL_BIN = NULL;
 // NOTE: must be initialized for safe use
 //static struct r_bin_java_cp_item_t cp_null_item = {0};
 
+
+static RBinJavaAccessFlags METHOD_ACCESS_FLAGS[] = {
+	{"Public", R_BIN_JAVA_METHOD_ACC_PUBLIC},
+	{"Private", R_BIN_JAVA_METHOD_ACC_PRIVATE},
+	{"Protected", R_BIN_JAVA_METHOD_ACC_PROTECTED},
+	{"Static", R_BIN_JAVA_METHOD_ACC_STATIC},
+
+	{"Final", R_BIN_JAVA_METHOD_ACC_FINAL},
+	{"Synchronized", R_BIN_JAVA_METHOD_ACC_SYNCHRONIZED},
+	{"Bridge", R_BIN_JAVA_METHOD_ACC_BRIDGE},
+	{"Var Args", R_BIN_JAVA_METHOD_ACC_VARARGS},
+	
+	{"Native", R_BIN_JAVA_METHOD_ACC_NATIVE},
+	{"Interface", R_BIN_JAVA_METHOD_ACC_INTERFACE},
+	{"Abstract", R_BIN_JAVA_METHOD_ACC_ABSTRACT},
+	{"Strict", R_BIN_JAVA_METHOD_ACC_STRICT},
+	
+	{"Synthetic", R_BIN_JAVA_METHOD_ACC_SYNTHETIC},
+	{"Annotation", R_BIN_JAVA_METHOD_ACC_ANNOTATION},
+	{"Enum", R_BIN_JAVA_METHOD_ACC_ENUM}
+};
+
+static RBinJavaAccessFlags CLASS_ACCESS_FLAGS[] = {
+	{"Public", R_BIN_JAVA_CLASS_ACC_PUBLIC},
+	{"Private", R_BIN_JAVA_CLASS_ACC_PRIVATE},
+	{"Protected", R_BIN_JAVA_CLASS_ACC_PROTECTED},
+	{"Static", R_BIN_JAVA_CLASS_ACC_STATIC},
+
+	{"Final", R_BIN_JAVA_CLASS_ACC_FINAL},
+	{"Synchronized", R_BIN_JAVA_CLASS_ACC_SUPER},
+	{"Bridge", R_BIN_JAVA_CLASS_ACC_BRIDGE},
+	{"Var Args", R_BIN_JAVA_CLASS_ACC_VARARGS},
+	
+	{"Native", R_BIN_JAVA_CLASS_ACC_NATIVE},
+	{"Interface", R_BIN_JAVA_CLASS_ACC_INTERFACE},
+	{"Abstract", R_BIN_JAVA_CLASS_ACC_ABSTRACT},
+	{"Strict", R_BIN_JAVA_CLASS_ACC_STRICT},
+	
+	{"Synthetic", R_BIN_JAVA_CLASS_ACC_SYNTHETIC},
+	{"Annotation", R_BIN_JAVA_CLASS_ACC_ANNOTATION},
+	{"Enum", R_BIN_JAVA_CLASS_ACC_ENUM}
+};
+
+
 static RBinJavaRefMetas R_BIN_JAVA_REF_METAS[] = {
 	{"Unknown", R_BIN_JAVA_REF_UNKNOWN}, 
 	{"GetField", R_BIN_JAVA_REF_GETFIELD}, 
@@ -350,14 +394,14 @@ R_API RBinJavaField * r_bin_java_read_next_method(RBinJavaObj *bin, ut64 offset)
 
 	method->name = r_bin_java_get_utf8_from_bin_cp_list(bin, (ut32) (method->name_idx));
 	if(method->name == NULL){
-		method->name = (ut8 *)malloc(21);
+		method->name = (char *)malloc(21);
 		snprintf((char *) method->name, 20, "sym.method_%08x", method->metas->ord);
 		eprintf("r_bin_java_read_next_method: Unable to find the name for 0x%02x index.\n", method->name_idx);
 	}
 
 	method->descriptor = r_bin_java_get_utf8_from_bin_cp_list(bin, (ut32) method->descriptor_idx);
 	if(method->descriptor == NULL){
-		method->descriptor = (ut8 *) r_str_dup (NULL, "NULL");
+		method->descriptor = r_str_dup (NULL, "NULL");
 		eprintf("r_bin_java_read_next_method: Unable to find the descriptor for 0x%02x index.\n", method->descriptor_idx);
 	}
 	
@@ -421,13 +465,13 @@ R_API RBinJavaField * r_bin_java_read_next_field(RBinJavaObj *bin, ut64 offset){
 
 	field->name = r_bin_java_get_utf8_from_bin_cp_list(bin, field->name_idx);
 	if(field->name == NULL){
-		field->name = (ut8 *) r_str_dup (NULL, "NULL");
+		field->name = r_str_dup (NULL, "NULL");
 		eprintf("r_bin_java_read_next_field: Unable to find the name for %d index.\n", field->name_idx);
 	}
 
 	field->descriptor = r_bin_java_get_utf8_from_bin_cp_list(bin, field->descriptor_idx);
 	if(field->descriptor == NULL){
-		field->descriptor = (ut8 *) r_str_dup (NULL, "NULL");
+		field->descriptor = r_str_dup (NULL, "NULL");
 		eprintf("r_bin_java_read_next_field: Unable to find the descriptor for %d index.\n", field->descriptor_idx);
 	}
 	
@@ -596,7 +640,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_get_item_from_cp(RBinJavaObj *bin, int i) {
 	return obj;
 }
 
-R_API ut8 * r_bin_java_get_utf8_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
+R_API char * r_bin_java_get_utf8_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
 	/*
 		Search through the Constant Pool list for the given CP Index.
 		If the idx not found by directly going to the list index,
@@ -611,7 +655,7 @@ R_API ut8 * r_bin_java_get_utf8_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
 	return r_bin_java_get_utf8_from_cp_item_list(bin->cp_list, idx);
 }
 
-R_API ut8 * r_bin_java_get_name_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
+R_API char * r_bin_java_get_name_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
 	/*
 		Search through the Constant Pool list for the given CP Index.
 		If the idx not found by directly going to the list index,
@@ -626,7 +670,7 @@ R_API ut8 * r_bin_java_get_name_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
 	return r_bin_java_get_name_from_cp_item_list(bin->cp_list, idx);
 }
 
-R_API ut8 * r_bin_java_get_desc_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
+R_API char * r_bin_java_get_desc_from_bin_cp_list(RBinJavaObj *bin, ut64 idx){
 	/*
 		Search through the Constant Pool list for the given CP Index.
 		If the idx not found by directly going to the list index,
@@ -656,7 +700,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_get_item_from_bin_cp_list(RBinJavaObj *bin,
 	return r_bin_java_get_item_from_cp_item_list(bin->cp_list, idx);
 }
 
-R_API ut8 * r_bin_java_get_item_name_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj){
+R_API char * r_bin_java_get_item_name_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj){
 	/*
 		Given a constant poool object Class, FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -670,7 +714,7 @@ R_API ut8 * r_bin_java_get_item_name_from_bin_cp_list(RBinJavaObj *bin, RBinJava
 	return r_bin_java_get_item_name_from_cp_item_list(bin->cp_list, obj);
 }
 
-R_API ut8 * r_bin_java_get_item_desc_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj){
+R_API char * r_bin_java_get_item_desc_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj){
 	/*
 		Given a constant poool object Class, FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -685,7 +729,7 @@ R_API ut8 * r_bin_java_get_item_desc_from_bin_cp_list(RBinJavaObj *bin, RBinJava
 }
 
 
-R_API ut8 * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx){
+R_API char * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx){
 	/*
 		Search through the Constant Pool list for the given CP Index.
 		If the idx not found by directly going to the list index,
@@ -695,7 +739,7 @@ R_API ut8 * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx){
 	
 	*/
 
-	ut8 *value = NULL;
+	char *value = NULL;
 	RListIter *iter; 
 	RBinJavaCPTypeObj *item = NULL;
 	
@@ -704,13 +748,13 @@ R_API ut8 * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx){
 
 	item = (RBinJavaCPTypeObj *) r_list_get_n(cp_list, idx);
 	if (item && (item->tag == R_BIN_JAVA_CP_UTF8) && item->metas->ord == idx){
-		value = (ut8 *) r_str_dup (NULL, (const char *) item->info.cp_utf8.bytes);
+		value = r_str_dup (NULL, (const char *) item->info.cp_utf8.bytes);
 	}
 
 	if (value == NULL){
         r_list_foreach (cp_list, iter, item ) {
             if (item && (item->tag == R_BIN_JAVA_CP_UTF8) && item->metas->ord == idx){
-				value = (ut8 *) r_str_dup (NULL, (const char *) item->info.cp_utf8.bytes);
+				value = r_str_dup (NULL, (const char *) item->info.cp_utf8.bytes);
 				break;
 	        }
         }
@@ -737,7 +781,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_get_item_from_cp_item_list(RList *cp_list, 
 
 
 
-R_API ut8 * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj){
+R_API char * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj){
 	/*
 		Given a constant poool object Class, FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -746,7 +790,7 @@ R_API ut8 * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaC
 		@rvalue ut8 * (user frees) or NULL
 	*/
 
-	ut8 *value = NULL;
+	char *value = NULL;
 	ut32 idx = 0;
 
 	if(obj == NULL || cp_list == NULL)
@@ -787,7 +831,7 @@ R_API ut8 * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaC
 
 }
 
-R_API ut8 * r_bin_java_get_name_from_cp_item_list(RList *cp_list, ut64 idx){
+R_API char * r_bin_java_get_name_from_cp_item_list(RList *cp_list, ut64 idx){
 	/*
 		Given a constant poool object Class, FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -804,7 +848,7 @@ R_API ut8 * r_bin_java_get_name_from_cp_item_list(RList *cp_list, ut64 idx){
 
 }
 
-R_API ut8 * r_bin_java_get_item_desc_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj){
+R_API char * r_bin_java_get_item_desc_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj){
 	/*
 		Given a constant poool object FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -843,7 +887,7 @@ R_API ut8 * r_bin_java_get_item_desc_from_cp_item_list(RList *cp_list, RBinJavaC
 	return r_bin_java_get_name_from_cp_item_list(cp_list, idx); 
 }
 
-R_API ut8 * r_bin_java_get_desc_from_cp_item_list(RList *cp_list, ut64 idx){
+R_API char * r_bin_java_get_desc_from_cp_item_list(RList *cp_list, ut64 idx){
 	/*
 		Given a constant poool object FieldRef, MethodRef, or InterfaceMethodRef
 		return the actual descriptor string.  
@@ -851,7 +895,7 @@ R_API ut8 * r_bin_java_get_desc_from_cp_item_list(RList *cp_list, ut64 idx){
 		@rvalue ut8 * (user frees) or NULL
 	*/
 
-	ut8 *value = NULL;
+	char *value = NULL;
 
 	RBinJavaCPTypeObj *obj = NULL;
 
@@ -944,46 +988,6 @@ R_API ut8 * r_bin_java_get_attr_buf(RBinJavaObj *bin, ut64 offset, ut64 sz){
 	}
 	return attr_buf;
 }
-/*
-R_API RBinJavaAttrInfo * r_bin_java_default_attr_new(RBinJavaObj *bin, ut64 offset){
-	RBinJavaAttrInfo *attr = (RBinJavaAttrInfo *) malloc(sizeof(RBinJavaAttrInfo));
-	ut8 buf[10];
-	R_BIN_JAVA_ATTR_TYPE type_val = R_BIN_JAVA_ATTR_TYPE_UNKNOWN_ATTR;
-	// read the offset now, before we make modifications or read from the buffer
-	if (offset == R_BUF_CUR )
-		offset = bin->b->cur;
-
-	memset(attr, 0, sizeof(RBinJavaAttrInfo));
-	attr->metas = (RBinJavaMetaInfo *)malloc(sizeof(RBinJavaMetaInfo));
-	if (attr->metas == NULL){
-		free(attr);
-		return NULL;
-	}
-	
-	memset(attr->metas, 0, sizeof(RBinJavaMetaInfo));
-	
-	attr->file_offset = offset;
-	
-	r_buf_read_at (bin->b, offset, (ut8*)buf, 6);
-	attr->name_idx = R_BIN_JAVA_USHORT(buf, 0);
-	attr->length = R_BIN_JAVA_UINT(buf, 2);
-	attr->name = r_bin_java_get_utf8_from_bin_cp_list(bin, attr->name_idx);
-	if(attr->name == NULL){
-		// Something bad has happened
-		attr->name = (ut8 *) r_str_dup (NULL, "NULL");
-		eprintf("r_bin_java_default_attr_new: Unable to find the name for %d index.\n", attr->name_idx);
-	}
-
-
-	type_val = r_bin_java_get_attr_type_by_name(attr->name);
-
-	attr->metas->ord = (bin->attr_idx++);
-	attr->metas->type_info = (void *) &RBIN_JAVA_ATTRS_METAS[type_val];
-	//IFDBG printf("      Addrs for type_info [tag=%d]: 0x%08"PFMT64x"\n", type_val, &attr->metas->type_info);
-
-	return attr;
-}
-*/
 
 R_API RBinJavaAttrInfo * r_bin_java_default_attr_new(ut8* buffer, ut64 sz, ut64 buf_offset){
 	
@@ -1014,7 +1018,7 @@ R_API RBinJavaAttrInfo * r_bin_java_default_attr_new(ut8* buffer, ut64 sz, ut64 
 	attr->name = r_bin_java_get_utf8_from_bin_cp_list(R_BIN_JAVA_GLOBAL_BIN, attr->name_idx);
 	if(attr->name == NULL){
 		// Something bad has happened
-		attr->name = (ut8 *) r_str_dup (NULL, "NULL");
+		attr->name = r_str_dup (NULL, "NULL");
 		eprintf("r_bin_java_default_attr_new: Unable to find the name for %d index.\n", attr->name_idx);
 	}
 
@@ -1154,10 +1158,10 @@ static int javasm_init(RBinJavaObj *bin) {
 		eprintf ("Java CLASS with MACH0 header?\n");
 		return R_FALSE;
 	}
-	bin->cp_count = r_bin_java_swap_ushort (bin->cf.cp_count)-1;
-
-	IFDBG printf ("ConstantPoolCount %d\n", bin->cp_count);
 	
+	bin->cp_count = r_bin_java_swap_ushort (bin->cf.cp_count)-1;
+	IFDBG printf ("ConstantPoolCount %d\n", bin->cp_count);
+	bin->cp_offset = bin->b->cur;
 	for (i=0; i < bin->cp_count; i++, bin->cp_idx++) {        
 		obj = r_bin_java_read_next_constant_pool_item(bin, bin->b->cur);		
 		if (obj){
@@ -1175,6 +1179,9 @@ static int javasm_init(RBinJavaObj *bin) {
 		}
 		
 	}
+	bin->cp_size = bin->b->cur - bin->cp_offset;
+	
+	
 	bin->cf2 = r_bin_java_read_class_file2(bin, bin->b->cur);
 	if (bin->cf2 == NULL){
 		eprintf ("Unable to read the class file info: bin->cf2 is NULL Failing?\n");
@@ -1189,18 +1196,19 @@ static int javasm_init(RBinJavaObj *bin) {
 
 
 	IFDBG printf("Interfaces count: %d\n", bin->interfaces_count);
+	bin->interfaces_offset = bin->b->cur;
 	if (bin->interfaces_count > 0) {
 		for (i = 0; i < bin->fields_count; i++, bin->field_idx++){
 			interfaces_obj = r_bin_java_read_next_interface_item(bin, bin->b->cur);
 			r_list_append(bin->interfaces_list, interfaces_obj);			
 		}		
-		
-
 	} 
+	bin->interfaces_size = bin->b->cur - bin->interfaces_offset;
 
 	bin->fields_count = r_bin_java_read_short (bin, bin->b->cur);
 	bin->fields_list = r_list_new();
 
+	bin->fields_offset = bin->b->cur;
 	IFDBG printf ("Fields count: %d\n", bin->fields_count);
 	if (bin->fields_count > 0) {
 		for (i = 0; i < bin->fields_count; i++, bin->field_idx++){
@@ -1215,7 +1223,9 @@ static int javasm_init(RBinJavaObj *bin) {
 			}
 		}
 	}
-
+	bin->fields_size = bin->b->cur - bin->fields_offset;
+	
+	bin->methods_offset = bin->b->cur;
 	bin->methods_count = r_bin_java_read_short (bin,bin->b->cur);
 	bin->methods_list = r_list_new();
 
@@ -1249,6 +1259,19 @@ static int javasm_init(RBinJavaObj *bin) {
 
 		}
 	}
+	bin->methods_size = bin->b->cur - bin->methods_offset;
+	
+	bin->attributes_offset = bin->b->cur;
+	bin->attributes_count = r_bin_java_read_short (bin,bin->b->cur);
+
+	if (bin->attributes_count > 0) {
+		for ( i=0; i<bin->attributes_count; i++,bin->attributes_idx++) {
+			RBinJavaAttrInfo * attr = r_bin_java_read_next_attr(bin, bin->b->cur);
+			if (attr)
+				r_list_append(bin->attributes, attr);
+		}
+	}
+	bin->methods_size = bin->b->cur - bin->methods_offset;	
 	return R_TRUE;
 }
 
@@ -1330,6 +1353,33 @@ R_API ut64 r_bin_java_get_method_code_offset(RBinJavaField *fm_type){
 	}
 	return offset;
 }
+/*
+typedef struct r_bin_field_t {
+	char name[R_BIN_SIZEOF_STRINGS];
+	ut64 rva;
+	ut64 offset;
+} RBinField;
+*/
+RBinField * r_bin_java_allocate_rbinfield(){
+	RBinField * t = (RBinField *) malloc(sizeof(RBinField));
+	
+	if (t)
+		memset(t, 0, sizeof(RBinField));
+	
+	return t;
+}
+
+R_API RBinField * r_bin_java_create_new_rbinfield_from_field(RBinJavaField *fm_type){
+
+	RBinField *field = r_bin_java_allocate_rbinfield();
+
+	if (field){
+		strncpy(field->name, fm_type->name, R_BIN_SIZEOF_STRINGS);
+		field->offset = fm_type->file_offset;
+		field->visibility = fm_type->flags;
+	}
+	return field;
+}
 
 R_API RBinSymbol * r_bin_java_create_new_symbol_from_field(RBinJavaField *fm_type){
 
@@ -1339,10 +1389,11 @@ R_API RBinSymbol * r_bin_java_create_new_symbol_from_field(RBinJavaField *fm_typ
 		strncpy(sym->name, fm_type->name, R_BIN_SIZEOF_STRINGS);
 		strncpy(sym->type, fm_type->descriptor, R_BIN_SIZEOF_STRINGS);
 		sym->classname = r_str_dup(NULL, fm_type->class_name);
-		sym->offset = fm_type->method_number;
+		sym->offset = fm_type->file_offset;
 		sym->rva = r_bin_java_get_method_code_offset(fm_type);
 		sym->ordinal = fm_type->metas->ord;
 		sym->size = r_bin_java_get_method_code_size(fm_type);
+		sym->visibility = fm_type->flags;
 	}
 	return sym;
 }
@@ -1357,7 +1408,8 @@ R_API RBinSymbol * r_bin_java_create_new_symbol_from_ref(RBinJavaCPTypeObj *obj)
 		               obj->tag != R_BIN_JAVA_CP_FIELDREF) ){
 		if (sym)
 			free(sym);
-		return;
+		sym = NULL;
+		return sym;
 	}
 
 
@@ -1386,6 +1438,178 @@ R_API RBinSymbol * r_bin_java_create_new_symbol_from_ref(RBinJavaCPTypeObj *obj)
 	}
 	return sym;
 }
+/*
+typedef struct r_bin_section_t {
+	char name[R_BIN_SIZEOF_STRINGS];
+	ut64 size;
+	ut64 vsize;
+	ut64 rva;
+	ut64 offset;
+	ut64 srwx;
+	// per section platform info
+	const char *arch;
+	int bits;
+} RBinSection;
+*/
+
+R_API RBinSection * r_bin_java_allocate_section(){
+	RBinSection * section = (RBinSection *) malloc(sizeof(RBinSection));
+	if(section)
+		memset(section, 0, sizeof(RBinSection));
+	return section;
+}
+
+R_API RList * r_bin_java_get_sections(RBinJavaObj *bin){
+	RBinSection * section = NULL;
+	RList *sections = r_list_new();
+
+
+	if (bin->cp_count > 0){
+		section = r_bin_java_allocate_section();
+		if(section){
+			strcpy (section->name, "constant_pool");
+			section->size = bin->cp_size;
+			section->offset = bin->cp_offset;
+			section->srwx = 0;
+			r_list_append (sections, section);
+		}
+		section = NULL;
+	}
+	if (bin->fields_count > 0){
+		section = r_bin_java_allocate_section();
+		if(section){
+			strcpy (section->name, "fields");
+			section->size = bin->fields_size;
+			section->offset = bin->fields_offset;
+			section->srwx = 0;
+			r_list_append (sections, section);
+		}
+		section = NULL;			
+	}
+	if (bin->methods_count > 0){
+		section = r_bin_java_allocate_section();
+		if(section){
+			strcpy (section->name, "methods");
+			section->size = bin->methods_size;
+			section->offset = bin->methods_offset;
+			section->srwx = 0;
+			r_list_append (sections, section);
+		}
+		section = NULL;			
+	}
+	if (bin->interfaces_count > 0){
+		section = r_bin_java_allocate_section();
+		if(section){
+			strcpy (section->name, "interfaces");
+			section->size = bin->interfaces_size;
+			section->offset = bin->interfaces_offset;
+			section->srwx = 0;
+			r_list_append (sections, section);
+		}
+		section = NULL;			
+		
+	}
+	if (bin->attributes_count > 0){
+		section = r_bin_java_allocate_section();
+		if(section){
+			strcpy (section->name, "attributes");
+			section->size = bin->attributes_size;
+			section->offset = bin->attributes_offset;
+			r_list_append (sections, section);
+		}
+		section = NULL;			
+	}
+	return sections;
+}
+
+R_API RList * r_bin_java_enum_class_methods(RBinJavaObj *bin, ut16 class_idx){
+	RList * methods = r_list_new();
+	RListIter *iter, *iter_tmp;
+	RBinJavaField *fm_type;
+	RBinSymbol *sym = NULL;
+	r_list_foreach_safe(bin->methods_list, iter, iter_tmp, fm_type){
+		if(fm_type){
+			if (fm_type && fm_type->field_ref_cp_obj 
+				&& fm_type->field_ref_cp_obj->metas->ord == class_idx){
+				
+				sym = r_bin_java_create_new_symbol_from_ref(fm_type);
+				if(sym){
+					r_list_append(methods, sym);
+				}
+			}
+		}
+	}
+	return methods; 
+}
+
+R_API RList * r_bin_java_enum_class_fields(RBinJavaObj *bin, ut16 class_idx){
+	RList * fields = r_list_new();
+	RListIter *iter, *iter_tmp;
+	RBinJavaField *fm_type;
+	RBinField *field = NULL;
+	r_list_foreach_safe(bin->fields_list, iter, iter_tmp, fm_type){
+		if(fm_type){
+			if (fm_type && fm_type->field_ref_cp_obj 
+				&& fm_type->field_ref_cp_obj->metas->ord == class_idx){
+				
+				field = r_bin_java_create_new_rbinfield_from_field(fm_type);
+				if(field){
+					r_list_append(fields, field);
+				}
+
+			}
+		}
+
+	}
+	return fields; 
+}
+
+R_API RList * r_bin_java_allocate_r_bin_class(){
+	RBinClass * class_ = (RBinClass *) malloc(sizeof(RBinClass));
+	if (class_){
+		memset(class_, 0, sizeof(RBinClass));
+		//class_->methods = r_list_new();
+		//class_->fields = r_list_new();
+	}
+	return class_;
+}
+
+R_API RList * r_bin_java_get_classes(RBinJavaObj *bin){
+	RBinSection * rclass = NULL;
+	RList *classes = r_list_new();
+	RListIter *iter, *iter_tmp;
+	RBinJavaCPTypeObj *cp_obj = NULL;
+	ut32 idx = 0;
+	RBinClass *class_;
+
+
+	
+	class_ = r_bin_java_allocate_r_bin_class();
+	class_->visibility = bin->cf2->access_flags;
+	class_->methods = r_bin_java_enum_class_methods(bin, bin->cf2->this_class);
+	class_->fields = r_bin_java_enum_class_fields(bin, bin->cf2->this_class);
+	class_->name = r_bin_java_get_item_name_from_bin_cp_list(bin, cp_obj);
+	class_->super = r_bin_java_get_name_from_bin_cp_list(bin, bin->cf2->super_class);	
+	class_->index = (idx++);
+	r_list_append(classes, class_);
+
+
+	r_list_foreach_safe(bin->cp_list, iter, iter_tmp, cp_obj){
+		if (cp_obj && 
+			cp_obj->tag == R_BIN_JAVA_CP_CLASS &&
+			bin->cf2->this_class != cp_obj->info.cp_class.name_idx){
+			
+			class_ = r_bin_java_allocate_r_bin_class();
+			class_->methods = r_bin_java_enum_class_methods(bin, cp_obj->info.cp_class.name_idx);
+			class_->fields = r_bin_java_enum_class_fields(bin, cp_obj->info.cp_class.name_idx);
+			class_->index = idx;
+			class_->name = r_bin_java_get_item_name_from_bin_cp_list(bin, cp_obj);
+			r_list_append(classes, class_);
+			idx++;
+		}
+	}
+	return classes;
+}
 
 
 R_API RBinSymbol * r_bin_java_create_new_symbol_from_invoke_dynamic(RBinJavaCPTypeObj *obj){
@@ -1394,7 +1618,6 @@ R_API RBinSymbol * r_bin_java_create_new_symbol_from_invoke_dynamic(RBinJavaCPTy
 	if (obj == NULL || (obj->tag != R_BIN_JAVA_CP_INVOKEDYNAMIC)){
 		return sym;
 	}
-
 	return r_bin_java_create_new_symbol_from_cp_idx(obj->info.cp_invoke_dynamic.name_and_type_index);
 }
 
@@ -1420,23 +1643,28 @@ R_API RBinSymbol * r_bin_java_create_new_symbol_from_cp_idx(ut32 cp_idx){
 	return sym;
 }
 
+RList * r_bin_java_get_fields(RBinJavaObj* bin) {
+	RListIter *iter = NULL, *iter_tmp=NULL;
+	RList *fields = r_list_new();
+	RBinField *field;
+	RBinJavaField *fm_type;
 
+	r_list_foreach_safe(bin->fields_list, iter, iter_tmp, fm_type){	
+		field = r_bin_java_create_new_rbinfield_from_field(fm_type);
+		if(field){
+			r_list_append(fields, field);
+		}
+	}
+	return fields;
+}
 
 
 RList * r_bin_java_get_symbols(RBinJavaObj* bin) {
-	RListIter *iter = NULL, *iter_tmp=NULL, *attr_iter=NULL, *attr_iter_tmp=NULL;
-	RBinJavaAttrInfo *attr = NULL, *code_attr = NULL;
+	RListIter *iter = NULL, *iter_tmp=NULL;
 	RList *symbols = r_list_new();
 	RBinSymbol *sym;
 	RBinJavaField *fm_type;
 
-
-	r_list_foreach_safe(bin->fields_list, iter, iter_tmp, fm_type){	
-		sym = r_bin_java_create_new_symbol_from_field(fm_type);
-		if(sym){
-			r_list_append(symbols, sym);
-		}
-	}
 	sym = NULL;
 	r_list_foreach_safe(bin->methods_list, iter, iter_tmp, fm_type){	
 		sym = r_bin_java_create_new_symbol_from_field(fm_type);
@@ -2412,7 +2640,7 @@ R_API RBinJavaAttrInfo * r_bin_java_inner_classes_attr_new(ut8* buffer, ut64 sz,
 
 		icattr->name = r_bin_java_get_utf8_from_bin_cp_list(R_BIN_JAVA_GLOBAL_BIN, icattr->inner_name_idx);
 		if(icattr->name == NULL){
-			icattr->name = (ut8 *) r_str_dup (NULL, "NULL");
+			icattr->name = r_str_dup (NULL, "NULL");
 			eprintf("r_bin_java_inner_classes_attr: Unable to find the name for %d index.\n", icattr->inner_name_idx);
 		}
 		
@@ -2666,13 +2894,13 @@ R_API RBinJavaAttrInfo * r_bin_java_local_variable_table_attr_new(ut8 * buffer, 
 		lvattr->size = 10;
 
 		if(lvattr->name == NULL){
-			lvattr->name = (ut8 *) r_str_dup (NULL, "NULL");
+			lvattr->name = r_str_dup (NULL, "NULL");
 			eprintf("r_bin_java_local_variable_table_attr_new: Unable to find the name for %d index.\n", lvattr->name_idx);
 		}
 
 		lvattr->descriptor = r_bin_java_get_utf8_from_bin_cp_list(R_BIN_JAVA_GLOBAL_BIN, lvattr->descriptor_idx);
 		if(lvattr->descriptor == NULL){
-			lvattr->descriptor = (ut8 *) r_str_dup (NULL, "NULL");
+			lvattr->descriptor = r_str_dup (NULL, "NULL");
 			eprintf("r_bin_java_local_variable_table_attr_new: Unable to find the descriptor for %d index.\n", lvattr->descriptor_idx);
 		}
 		
@@ -2771,13 +2999,13 @@ R_API RBinJavaAttrInfo * r_bin_java_local_variable_type_table_attr_new(ut8* buff
 		lvattr->size = 10;
 
 		if(lvattr->name == NULL){
-			lvattr->name = (ut8 *) r_str_dup (NULL, "NULL");
+			lvattr->name = r_str_dup (NULL, "NULL");
 			eprintf("r_bin_java_local_variable_type_table_attr_new: Unable to find the name for %d index.\n", lvattr->name_idx);
 		}
 
 		lvattr->signature = r_bin_java_get_utf8_from_bin_cp_list(R_BIN_JAVA_GLOBAL_BIN, lvattr->signature_idx);
 		if(lvattr->signature == NULL){
-			lvattr->signature = (ut8 *) r_str_dup (NULL, "NULL");
+			lvattr->signature = r_str_dup (NULL, "NULL");
 			eprintf("r_bin_java_local_variable_type_table_attr_new: Unable to find the descriptor for %d index.\n", lvattr->signature_idx);
 		}
 		
@@ -2865,11 +3093,11 @@ R_API RBinJavaInterfaceInfo * r_bin_java_interface_new(RBinJavaObj *bin, ut8 *bu
 		if (interface_obj->cp_class){
 			interface_obj->name = r_bin_java_get_item_name_from_bin_cp_list(bin, interface_obj->cp_class);
 		}else{
-			interface_obj->name = (ut8 *) r_str_dup(NULL, "NULL");
+			interface_obj->name = r_str_dup(NULL, "NULL");
 		}
 	}else{
 		interface_obj->class_info_idx = 0xffff;
-		interface_obj->name = (ut8 *) r_str_dup(NULL, "NULL");
+		interface_obj->name = r_str_dup(NULL, "NULL");
 	}
 	return interface_obj;
 
@@ -3353,7 +3581,6 @@ R_API RBinJavaStackMapFrame * r_bin_java_build_stack_frame_from_local_variable_t
 
 	r_list_foreach_safe(attr->info.local_variable_table_attr.local_variable_table, iter, iter_tmp, lvattr){
 		ut32 pos = 0;
-		ut64 cur_location = 0;
 		ut8 value = 'N';
 		if ( lvattr == NULL)
 			continue;
@@ -3647,7 +3874,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_interfacemethodref_cp_new(RBinJavaObj *bin,
 		
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 
 		obj->info.cp_interface.class_idx = R_BIN_JAVA_USHORT (buffer, 1);
@@ -3687,7 +3914,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_string_cp_new(RBinJavaObj *bin, ut8* buffer
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 		obj->info.cp_string.string_idx = R_BIN_JAVA_USHORT (buffer, 1);
 		
@@ -3719,7 +3946,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_integer_cp_new(RBinJavaObj *bin, ut8* buffe
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 		
 		memset(&obj->info.cp_integer.bytes, 0, sizeof(obj->info.cp_integer.bytes));
 		memcpy(&obj->info.cp_integer.bytes.raw, buffer+1, 4);
@@ -3752,7 +3979,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_float_cp_new(RBinJavaObj *bin, ut8* buffer,
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 		memset(&obj->info.cp_float.bytes, 0, sizeof(obj->info.cp_float.bytes));
 		memcpy(&obj->info.cp_float.bytes.raw, buffer, 4);
@@ -3786,7 +4013,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_long_cp_new(RBinJavaObj *bin, ut8* buffer, 
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 		memset(&obj->info.cp_long.bytes, 0, sizeof(obj->info.cp_long.bytes));
 		memcpy(&(obj->info.cp_long.bytes), buffer+1, 8);
@@ -3820,7 +4047,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_double_cp_new(RBinJavaObj *bin, ut8* buffer
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 		memset(&obj->info.cp_double.bytes, 0, sizeof(obj->info.cp_double.bytes));
 		memcpy(&obj->info.cp_double.bytes, buffer+1, 8);
@@ -3858,7 +4085,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_utf8_cp_new(RBinJavaObj *bin, ut8* buffer, 
 		obj->tag = tag;
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);
 
 		obj->info.cp_utf8.length = R_BIN_JAVA_USHORT (buffer, 1);
 		obj->info.cp_utf8.bytes = (ut8 *) malloc(obj->info.cp_utf8.length+1);
@@ -3908,7 +4135,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_name_and_type_cp_new(RBinJavaObj *bin, ut8*
 		
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
 
 		obj->tag = tag;
 		obj->info.cp_name_and_type.name_idx = R_BIN_JAVA_USHORT (buffer, 1);
@@ -3947,7 +4174,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_methodtype_cp_new(RBinJavaObj *bin, ut8* bu
 		
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
 
 		obj->tag = tag;
 		obj->info.cp_method_type.descriptor_index = R_BIN_JAVA_USHORT (buffer, 1);
@@ -3981,7 +4208,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_methodhandle_cp_new(RBinJavaObj *bin, ut8* 
 		
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
 
 		obj->tag = tag;
 		obj->info.cp_method_handle.reference_kind = buffer[1];
@@ -4013,7 +4240,7 @@ R_API RBinJavaCPTypeObj * r_bin_java_invokedynamic_cp_new(RBinJavaObj *bin, ut8*
 		
 		obj->metas = (RBinJavaMetaInfo *) malloc(sizeof(RBinJavaMetaInfo));
 		obj->metas->type_info = (void *)&R_BIN_JAVA_CP_METAS[tag];
-		obj->name = (ut8 *) r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
+		obj->name = r_str_dup(NULL, (const char *) R_BIN_JAVA_CP_METAS[tag].name);;
 
 		obj->tag = tag;
 		obj->info.cp_invoke_dynamic.bootstrap_method_attr_index = R_BIN_JAVA_USHORT(buffer, 1);
@@ -6057,7 +6284,7 @@ R_API RBinJavaCPTypeObj *r_bin_java_find_cp_ref_info_from_name_and_type(ut16 nam
 
 R_API RBinJavaCPTypeObj *r_bin_java_find_cp_ref_info(ut16 name_and_type_idx){
 	RListIter *iter, *iter_tmp;
-	RBinJavaCPTypeObj *result= NULL, *obj = NULL, name_and_type_obj;
+	RBinJavaCPTypeObj *result= NULL, *obj = NULL;
 
 	r_list_foreach_safe(R_BIN_JAVA_GLOBAL_BIN->cp_list, iter, iter_tmp, obj){
 		if(obj == NULL){

--- a/shlr/java/class.h
+++ b/shlr/java/class.h
@@ -37,6 +37,53 @@ R_API ut64 rbin_java_raw_to_long(ut8* raw, ut64 offset);
 
 #define R_BIN_JAVA_DOUBLE(x,y) rbin_java_raw_to_double(x, y)
 
+typedef enum{
+	R_BIN_JAVA_METHOD_ACC_PUBLIC= 0x0001,
+	R_BIN_JAVA_METHOD_ACC_PRIVATE = 0x0002,
+	R_BIN_JAVA_METHOD_ACC_PROTECTED = 0x0004,
+	R_BIN_JAVA_METHOD_ACC_STATIC = 0x0008,
+
+	R_BIN_JAVA_METHOD_ACC_FINAL = 0x0010,
+	R_BIN_JAVA_METHOD_ACC_SYNCHRONIZED = 0x0020,
+	R_BIN_JAVA_METHOD_ACC_BRIDGE = 0x0040,
+	R_BIN_JAVA_METHOD_ACC_VARARGS = 0x0080,
+	
+	R_BIN_JAVA_METHOD_ACC_NATIVE = 0x0100,
+	R_BIN_JAVA_METHOD_ACC_INTERFACE = 0x0200,
+	R_BIN_JAVA_METHOD_ACC_ABSTRACT = 0x0400,
+	R_BIN_JAVA_METHOD_ACC_STRICT= 0x0800,
+	
+	R_BIN_JAVA_METHOD_ACC_SYNTHETIC = 0x1000,
+	R_BIN_JAVA_METHOD_ACC_ANNOTATION = 0x2000,
+	R_BIN_JAVA_METHOD_ACC_ENUM = 0x4000
+}R_BIN_JAVA_METHOD_ACCESS;
+
+typedef enum{
+	R_BIN_JAVA_CLASS_ACC_PUBLIC= 0x0001,
+	R_BIN_JAVA_CLASS_ACC_PRIVATE = 0x0002,
+	R_BIN_JAVA_CLASS_ACC_PROTECTED = 0x0004,
+	R_BIN_JAVA_CLASS_ACC_STATIC = 0x0008,
+
+	R_BIN_JAVA_CLASS_ACC_FINAL = 0x0010,
+	R_BIN_JAVA_CLASS_ACC_SUPER = 0x0020,
+	R_BIN_JAVA_CLASS_ACC_BRIDGE = 0x0040,
+	R_BIN_JAVA_CLASS_ACC_VARARGS = 0x0080,
+	
+	R_BIN_JAVA_CLASS_ACC_NATIVE = 0x0100,
+	R_BIN_JAVA_CLASS_ACC_INTERFACE = 0x0200,
+	R_BIN_JAVA_CLASS_ACC_ABSTRACT = 0x0400,
+	R_BIN_JAVA_CLASS_ACC_STRICT= 0x0800,
+	
+	R_BIN_JAVA_CLASS_ACC_SYNTHETIC = 0x1000,
+	R_BIN_JAVA_CLASS_ACC_ANNOTATION = 0x2000,
+	R_BIN_JAVA_CLASS_ACC_ENUM = 0x4000
+}R_BIN_JAVA_CLASS_ACCESS;
+
+
+typedef struct {
+	char *str;
+	ut16 value;
+} RBinJavaAccessFlags;
 
 typedef enum{
 	R_BIN_JAVA_REF_UNKNOWN = 0, 
@@ -264,7 +311,7 @@ typedef struct  r_bin_java_cp_object_t {
 		RBinJavaCPTypeMethodType cp_method_type;
 		RBinJavaCPTypeInvokeDynamic cp_invoke_dynamic;
 	} info;
-	ut8 * name;
+	char * name;
 	ut8 * value;
 
 } RBinJavaCPTypeObj;
@@ -297,9 +344,9 @@ typedef struct r_bin_java_source_debugging_extension_attr_t {
 typedef struct r_bin_java_enclosing_method_attr_t { 
 	ut16 class_idx;
 	ut16 method_idx;
-	ut8 *class_name;
-	ut8 *method_name;
-	ut8 *method_descriptor;
+	char *class_name;
+	char *method_name;
+	char *method_descriptor;
 }RBinJavaEnclosingMethodAttr;
 
 typedef struct r_bin_java_boot_strap_arg_t{   
@@ -401,7 +448,7 @@ typedef struct r_bin_java_element_value_pair_t{
 	ut64 file_offset;
 	ut64 size;
 	ut16 element_name_idx;
-	ut8 * name;
+	char * name;
     RBinJavaElementValue *value;
 }RBinJavaElementValuePair;
 
@@ -440,7 +487,7 @@ typedef struct r_bin_java_stack_map_table_attr_t { // attribute StackMap
 
 typedef struct r_bin_java_signature_attr_t {
 	ut16 signature_idx;
-	ut8 *signature;
+	char *signature;
 }RBinJavaSignatureAttr;
 
 typedef struct r_bin_java_stack_verification_t{
@@ -484,7 +531,7 @@ typedef struct r_bin_java_fm_t {
 
 
 typedef struct r_bin_java_interface_info_desc_t{
-	ut8 *name;
+	char *name;
 	ut64 size;
 	ut64 file_offset;
 	ut16 class_info_idx;
@@ -557,8 +604,8 @@ typedef struct r_bin_java_attr_linenum_t {
 }RBinJavaLineNumberTableAttribute;
 
 typedef struct r_bin_java_attr_localvariabletype_t{  
-	ut8 *name;
-	ut8 *signature;
+	char *name;
+	char *signature;
 
 	ut64 file_offset;
 	ut16 start_pc;
@@ -577,8 +624,8 @@ typedef struct r_bin_java_attr_localvariable_type_table_t {
 
 
 typedef struct r_bin_java_attr_localvariable_t{  
-	ut8 *name;
-	ut8 *descriptor;
+	char *name;
+	char *descriptor;
 
 	ut64 file_offset;
 	ut16 start_pc;
@@ -599,7 +646,7 @@ typedef struct r_bin_java_attr_t {
 	ut8 *bytes;
 	ut64 pos;
 	ut64 size;
-    ut8 *name;
+    char *name;
     ut64 file_offset; 
     RBinJavaMetaInfo *metas;
 	int type;
@@ -635,7 +682,7 @@ typedef struct r_bin_java_attr_t {
 
 
 typedef struct r_bin_java_attr_classes_t {
-	ut8 *name;
+	char *name;
 	ut64 file_offset;
 	RBinJavaAttrInfo *clint_attr;
 	RBinJavaField *clint_field;
@@ -673,12 +720,14 @@ typedef struct r_bin_java_obj_t {
 	struct r_bin_java_classfile_t cf;
 	RBinJavaClass2 * cf2;
 	
-	ut32 cp_count;
-	ut32 fields_count;
-	ut32 interfaces_count;
-	ut32 methods_count;
-	ut32 classes_count;
-	
+
+	ut32 cp_offset, cp_size, cp_count;
+	ut32 fields_offset, fields_size, fields_count;
+	ut32 interfaces_offset, interfaces_size, interfaces_count;
+	ut32 methods_offset, methods_size, methods_count;
+	ut32 classes_offset, classes_size, classes_count;
+	ut32 attributes_offset, attributes_size, attributes_count;
+
 	int size;
 	const char* file;
 	RBinJavaLines lines;
@@ -697,6 +746,7 @@ typedef struct r_bin_java_obj_t {
 	ut32 field_idx;
 	ut32 cp_idx;
 	ut32 interface_idx;
+	ut32 attributes_idx;
 
 	//ut32 classes_idx; //TODO: when classes list is being used, update this value
 
@@ -714,10 +764,11 @@ typedef struct r_bin_java_obj_t {
 	RList * methods_list;
 	RList * cp_list;
 	RList * interfaces_list;
-	RList * all_attributes;
+	RList * attributes;
 } RBinJavaObj;
 
-
+R_API RList * r_bin_java_get_sections(RBinJavaObj *bin);
+R_API RList * r_bin_java_get_fields(RBinJavaObj *bin);
 R_API char * r_bin_java_get_version(RBinJavaObj* bin);
 R_API ut64 r_bin_java_get_entrypoint(RBinJavaObj* bin);
 R_API ut64 r_bin_java_get_main(RBinJavaObj* bin);
@@ -811,19 +862,19 @@ inline ut16 r_bin_java_read_short_from_buffer(ut8 *buf, ut64 offset);
 
 
 R_API ut8 * r_bin_java_get_attr_buf(RBinJavaObj *bin, ut64 offset, ut64 sz);
-R_API ut8 * r_bin_java_get_name_from_cp_item_list(RList *cp_list, ut64 idx);
-R_API ut8 * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx);
-R_API ut8 * r_bin_java_get_desc_from_cp_item_list(RList *cp_list, ut64 idx);
-R_API ut8 * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj);
-R_API ut8 * r_bin_java_get_item_desc_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj);
+R_API char * r_bin_java_get_name_from_cp_item_list(RList *cp_list, ut64 idx);
+R_API char * r_bin_java_get_utf8_from_cp_item_list(RList *cp_list, ut64 idx);
+R_API char * r_bin_java_get_desc_from_cp_item_list(RList *cp_list, ut64 idx);
+R_API char * r_bin_java_get_item_name_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj);
+R_API char * r_bin_java_get_item_desc_from_cp_item_list(RList *cp_list, RBinJavaCPTypeObj *obj);
 R_API RBinJavaCPTypeObj * r_bin_java_get_item_from_cp_item_list(RList *cp_list, ut64 idx);
 
 
-R_API ut8 * r_bin_java_get_name_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
-R_API ut8 * r_bin_java_get_utf8_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
-R_API ut8 * r_bin_java_get_desc_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
-R_API ut8 * r_bin_java_get_item_name_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj);
-R_API ut8 * r_bin_java_get_item_desc_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj);
+R_API char * r_bin_java_get_name_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
+R_API char * r_bin_java_get_utf8_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
+R_API char * r_bin_java_get_desc_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
+R_API char * r_bin_java_get_item_name_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj);
+R_API char * r_bin_java_get_item_desc_from_bin_cp_list(RBinJavaObj *bin, RBinJavaCPTypeObj *obj);
 R_API RBinJavaCPTypeObj * r_bin_java_get_item_from_bin_cp_list(RBinJavaObj *bin, ut64 idx);
 
 // Allocs for objects
@@ -1110,5 +1161,11 @@ R_API ut64 r_bin_java_get_method_code_size(RBinJavaField *fm_type);
 R_API RBinJavaCPTypeObj *r_bin_java_find_cp_ref_info(ut16 name_and_typeidx);
 R_API RBinJavaCPTypeObj *r_bin_java_find_cp_ref_info_from_name_and_type(ut16 name_idx, ut16 descriptor_idx);
 R_API RBinJavaCPTypeObj *r_bin_java_find_cp_name_and_type_info(ut16 name_idx, ut16 descriptor_idx);
+
+R_API RList * r_bin_java_allocate_r_bin_class();
+R_API RList * r_bin_java_get_classes(RBinJavaObj *bin);
+R_API RList * r_bin_java_enum_class_methods(RBinJavaObj *bin, ut16 class_idx);
+R_API RList * r_bin_java_enum_class_fields(RBinJavaObj *bin, ut16 class_idx);
+
 
 #endif


### PR DESCRIPTION
Updated the Java class parsing to pull strings and symbols into the radare environment.  Rather than use custom RBinStrings and RBinSymbols, the functions return an RList \* of RBinString \* or RBinSymbol *.
