### PR TITLE
added ^x^e with  a temporary workaround for '\n' command delimiter

### DIFF
--- a/binr/r2agent/Makefile
+++ b/binr/r2agent/Makefile
@@ -1,4 +1,4 @@
 BIN=r2agent
-BINDEPS=r_socket r_cons r_util
+BINDEPS=r_socket r_cons r_util r_core
 
 include ../rules.mk

--- a/binr/rafind2/Makefile
+++ b/binr/rafind2/Makefile
@@ -1,6 +1,6 @@
 BIN=rafind2
 BINDEPS=r_search r_io r_lib r_asm r_anal r_reg r_cons
-BINDEPS+=r_socket r_db r_parse r_util r_syscall r_diff r_flags
+BINDEPS+=r_socket r_db r_parse r_util r_syscall r_diff r_flags r_core
 
 include ../rules.mk
 

--- a/binr/ragg2/Makefile
+++ b/binr/ragg2/Makefile
@@ -1,4 +1,5 @@
 BIN=ragg2
-BINDEPS=r_egg r_bin r_syscall r_asm r_db r_parse r_lib r_flags r_anal r_reg r_diff r_cons r_util
+BINDEPS=r_egg r_bin r_syscall r_asm r_db r_parse r_lib r_flags r_anal 
+BINDEPS+=r_reg r_diff r_cons r_util r_core
 
 include ../rules.mk

--- a/binr/rahash2/Makefile
+++ b/binr/rahash2/Makefile
@@ -1,7 +1,7 @@
 BIN=rahash2
 BINDEPS=r_io r_hash r_util r_socket r_asm r_cons
 BINDEPS+=r_anal r_lib r_syscall r_reg r_diff r_db r_parse
-BINDEPS+=r_flags
+BINDEPS+=r_flags r_core
 
 include ../rules.mk
 

--- a/binr/rasm2/Makefile
+++ b/binr/rasm2/Makefile
@@ -1,4 +1,5 @@
 BIN=rasm2
-BINDEPS=r_asm r_parse r_lib r_syscall r_anal r_reg r_diff r_db r_flags r_cons r_util
+BINDEPS=r_asm r_parse r_lib r_syscall r_anal r_reg r_diff r_db r_flags 
+BINDEPS+=r_cons r_util r_core
 
 include ../rules.mk

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -764,7 +764,7 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 		}
 	}
 	if (colon && colon[1]) {
-		for (++colon; *colon==';'; colon++);
+	        for (++colon; *colon==';'; colon++);
 		r_core_cmd_subst (core, colon);
 	} else {
 		if (icmd && !*icmd)

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1110,9 +1110,12 @@ R_API char *r_core_editor (RCore *core, const char *str) {
 	if (str) write (fd, str, strlen (str));
 	close (fd);
 
-	editor = r_config_get (core->config, "cfg.editor");
+	if(core)
+	        editor = r_config_get (core->config, "cfg.editor");
+	else editor = 0;
+	
 	if (!editor || !*editor || !strcmp (editor, "-")) {
-		r_cons_editor (name);
+	        r_cons_editor (name);
 	} else {
 		r_sys_cmdf ("%s '%s'", editor, name);
 	}


### PR DESCRIPTION
works only with radare2 native editor
