### PR TITLE
bugfix in ^x^e with last character chopping (while using with emacs),

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -437,7 +437,7 @@ R_API char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 					if (I.buffer.length < R_LINE_BUFSIZE) {
 						I.buffer.index = I.buffer.length;
 						// XXX may overflow here
-						strcpy (I.buffer.data, tmp_ed_cmd);
+						strncpy (I.buffer.data, tmp_ed_cmd, I.buffer.length);
 					} else I.buffer.length -= strlen (tmp_ed_cmd);
 					free (tmp_ed_cmd);
 				}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1125,7 +1125,8 @@ R_API char *r_core_editor (RCore *core, const char *str) {
 		r_cons_editor (name);
 	} else r_sys_cmdf ("%s '%s'", editor, name);
 	ret = r_file_slurp (name, &len);
-	ret[len-1] = 0; // chop
+	if( strncmp(editor, "emacs", 5) )
+		ret[len-1] = 0; // chop
 	r_file_rm (name);
 	free (name);
 	return ret;


### PR DESCRIPTION
changed strcpy to strncpy (safety?)

IDK if this fix is needed. Let the devs decide.
AFAIK vim appends a newline at the end of file and doesn't show it to the user.
Emacs doesn't do that so the last significant char gets chopped off.
Needs more testing!
