### PR TITLE
- Fixed an issue where r_bin_java_get_entrypoints  will return an RList*

### DIFF
--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -17,16 +17,7 @@ static int destroy(RBinArch *arch) {
 }
 
 static RList* entries(RBinArch *arch) {
-	RBinAddr *ptr;
-	RList *ret = r_list_new ();
-	if (!ret) return NULL;
-	ret->free = free;
-	if (!(ptr = R_NEW (RBinAddr)))
-		return ret;
-	memset (ptr, '\0', sizeof (RBinAddr));
-	ptr->offset = ptr->rva = r_bin_java_get_entrypoint (arch->bin_obj);
-	r_list_append (ret, ptr);
-	return ret;
+	return r_bin_java_get_entrypoints (arch->bin_obj);
 }
 
 static ut64 baddr(RBinArch *arch) {
@@ -34,21 +25,6 @@ static ut64 baddr(RBinArch *arch) {
 }
 
 static RList* classes(RBinArch *arch) {
-	/*char *p;
-	RBinClass *c;
-	RList *ret = r_list_new ();
-	if (!ret) return NULL;
-	
-	// TODO: add proper support for inner classes in Java
-	c = R_NEW0 (RBinClass);
-	c->visibility = R_BIN_CLASS_PUBLIC;
-	c->name = strdup (arch->file);
-	p = strchr (c->name, '.');
-	if (p) *p = 0;
-	p = (char*)r_str_lchr (c->name, '/');
-	if (p) strcpy (c->name, p+1);
-	c->super = strdup ("Object"); //XXX
-	r_list_append (ret, c);*/
 	RList *ret;
 	ret = r_bin_java_get_classes((struct r_bin_java_obj_t*)arch->bin_obj);
 	return ret;

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -1281,11 +1281,32 @@ R_API ut64 r_bin_java_get_main(RBinJavaObj* bin) {
 	return 0;
 }
 
-R_API ut64 r_bin_java_get_entrypoint(RBinJavaObj* bin) {
+R_API RList * r_bin_java_get_entrypoints(RBinJavaObj* bin) {
+	RList *ret = r_list_new ();	
+	RBinAddr *addr;
+
 	if (bin->entrypoint_code_attr){
-		return bin->entrypoint_code_attr->info.code_attr.code_offset;
+		if (!ret) 
+			return NULL;
+		
+		ret->free = free;
+		
+		addr = R_NEW (RBinAddr);
+
+		if (addr){
+			memset (addr, '\0', sizeof (RBinAddr));
+			addr->offset = addr->rva = bin->entrypoint_code_attr->info.code_attr.code_offset;		
+		}
 	}
-	return 0;
+	return ret;
+}
+
+R_API ut64 r_bin_java_get_entrypoint(RBinJavaObj* bin) {
+	ut64 result = 0;
+	if (bin->entrypoint_code_attr){
+		result = bin->entrypoint_code_attr->info.code_attr.code_offset;		
+	}
+	return result;
 }
 
 R_API ut64 r_bin_java_get_class_entrypoint(RBinJavaObj* bin) {

--- a/shlr/java/class.h
+++ b/shlr/java/class.h
@@ -745,6 +745,7 @@ R_API RList* r_bin_java_get_sections(RBinJavaObj *bin);
 R_API RList* r_bin_java_get_fields(RBinJavaObj *bin);
 R_API char* r_bin_java_get_version(RBinJavaObj* bin);
 R_API ut64 r_bin_java_get_entrypoint(RBinJavaObj* bin);
+R_API RList* r_bin_java_get_entrypoints(RBinJavaObj* bin);
 R_API ut64 r_bin_java_get_main(RBinJavaObj* bin);
 R_API RList* r_bin_java_get_symbols(RBinJavaObj* bin);
 R_API RList* r_bin_java_get_strings(RBinJavaObj* bin);


### PR DESCRIPTION
  directly rather than relying on the entries in libr/bin/p/bin_java to
  perform the conversion.
