### PR TITLE
Fix segfault when p cmd is mistyped

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -321,7 +321,6 @@ static int cmd_print(void *data, const char *input) {
 	RCoreAnalStats *as;
 	ut64 n;
 
-	/* TODO: Change also blocksize for 'pd'.. */
 	l = len = core->blocksize;
 	if (input[0] && input[1]) {
 		const char *p = strchr (input, ' ');
@@ -331,7 +330,11 @@ static int cmd_print(void *data, const char *input) {
 			if (input[0] != 'd' && input[0] != 'm') {
 				if (l>0) len = l;
 				if (l>tbs) {
-					r_core_block_size (core, l);
+					if (!r_core_block_size (core, l)) {
+						eprintf ("This block size is too big. Did you mean 'p%c @ %s' instead?\n",
+							 *input, input+2);
+						return R_FALSE;
+					}
 					l = core->blocksize;
 				} else {
 					l = len;


### PR DESCRIPTION
This commit changes this behavior:

```
$ r2 /bin/true 
 -- Invert the block bytes using the 'I' key in visual mode
[0x00008e80]> ps 0x08049434
Block size 134517812 is too big
Segmentation fault
```

For this one:

```
$ r2 /bin/true 
 -- Execute commands on a temporally offset appending '@ offset' to your command
[0x00401124]> ps 0x08049434
Block size 134517812 is too big
This block size is too big. Did you mean 'ps @ 0x08049434' instead?
[0x00401124]>
```

The comment line removal is because that TODO seems to be done.

As a side comment, that block of code (before the switch statement) is kind of messy, specially with var assignments.

Kind!
