### PR TITLE
Fix io plugin bin loading

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -7,6 +7,7 @@
 #include <r_lib.h>
 #include <r_list.h>
 #include <r_bin.h>
+#include <r_io.h>
 #include <list.h>
 #include "../config.h"
 
@@ -146,7 +147,80 @@ R_API int r_bin_load_languages(RBin *bin) {
 	return R_BIN_NM_NONE;
 }
 
-static int r_bin_init_items(RBin *bin, int dummy) {
+R_API int r_bin_io_load(RBin *bin, RIO *io, RIODesc *desc, int dummy) {
+	int rawstr = 0;
+	RBuffer *bin_buf = NULL;
+	ut64 start, end, 
+		 sz = -1, 
+		 offset = 0;
+	
+	ut8* buf_bytes;
+
+	if (!io || !io->plugin || !io->plugin->read || !io->plugin->lseek) {
+		return R_FALSE;
+	} else if (!desc || !desc->fd) {
+		return R_FALSE;
+	}
+
+	buf_bytes = NULL;
+	end = io->plugin->lseek(io, desc, 0, SEEK_END);
+	start = io->plugin->lseek(io, desc, 0, SEEK_SET);
+	sz = -1;
+	offset = 0;
+	
+	if (end == -1 || start == -1) return R_FALSE;
+
+	sz = end - start;
+	buf_bytes = malloc(sz);
+	
+	if (!buf_bytes || !io->plugin->read(io, desc, buf_bytes, sz)) {
+		free(buf_bytes);
+		return R_FALSE;
+	}
+
+	memcpy(&rawstr, buf_bytes, 4);
+	bin->cur.file = strdup (desc->name);
+	bin->cur.buf = bin_buf;			
+	bin->cur.rawstr = rawstr;
+		
+	bin_buf = r_buf_new();
+	if (bin_buf) {	
+		r_buf_set_bytes(bin_buf, buf_bytes, sz);
+	}
+
+	if (buf_bytes)	free(buf_bytes);
+
+	//r_config_set_i (r->config, "bin.rawstr", rawstr);
+	bin->cur.file = strdup (desc->name);
+	bin->cur.buf = bin_buf;			
+	bin->cur.rawstr = rawstr;
+	// Here is the pertinent code from r_bin_init
+	// we can't call r_bin_init, because it will
+	// deref all work done previously by IO Plugin.
+	{
+		RListIter *it;
+		RBinXtrPlugin *xtr;
+		bin->cur.o = R_NEW0 (RBinObject);
+		memset (bin->cur.o, 0, sizeof (RBinObject));
+		bin->curxtr = NULL;
+		r_list_foreach (bin->binxtrs, it, xtr) {
+			if (xtr->check && xtr->check (bin)) {
+				bin->curxtr = xtr;
+				break;
+			}
+		}
+		if (bin->curxtr && bin->curxtr->load)
+			bin->curxtr->load (bin);
+	}
+	r_bin_init_items(bin, R_FALSE);
+
+	return R_TRUE;
+}
+
+// XXX - r_bin_load needs to be modified so that it
+// respects the IO Plugin data sources, and does not
+// try to open files that do not exist.
+R_API int r_bin_init_items(RBin *bin, int dummy) {
 	int i, minlen = bin->minstrlen;
 	RListIter *it;
 	RBinPlugin *plugin, *cp;
@@ -215,11 +289,14 @@ static void r_bin_free_items(RBin *bin) {
 	free (o->info);
 	o->info = NULL;
 	if (o->binsym)
-		for (i=0; i<R_BIN_SYM_LAST; i++)
+		for (i=0; i<R_BIN_SYM_LAST; i++){
 			free (o->binsym[i]);
+			o->binsym[i] = NULL;
+		}
 	if (a->curplugin && a->curplugin->destroy)
 		a->curplugin->destroy (a);
 }
+
 
 static void r_bin_init(RBin *bin, int rawstr) {
 	RListIter *it;
@@ -315,7 +392,9 @@ R_API int r_bin_load(RBin *bin, const char *file, int dummy) {
 		return R_FALSE;
 	bin->file = r_file_abspath (file);
 	r_bin_init (bin, bin->cur.rawstr);
+	
 	bin->narch = r_bin_extract (bin, 0);
+	
 	if (bin->narch == 0)
 		return R_FALSE;
 	/* FIXME: temporary hack to fix malloc:// */

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -143,6 +143,7 @@ R_API int r_core_bin_load(RCore *r, const char *file, ut64 baddr) {
 	const char *p;
 	ut64 offset;
 	RIOMap *im;
+	int is_io_load = r && r->file && r->file->fd && r->file->fd->plugin;
 
 	if (file == NULL || !*file)
 		if (r->file)
@@ -151,13 +152,23 @@ R_API int r_core_bin_load(RCore *r, const char *file, ut64 baddr) {
 		eprintf ("r_core_bin_load: no file specified\n");
 		return R_FALSE;
 	}
-	p = strstr (file, "://");
-	if (p) file = p+3;
-	while (*file==' ') file++;
+
+	// XXX - TODO determine if the following three lines are meaningful
+	// after adding an IO aware API to core_bin_load
+	//p = strstr (file, "://");
+	//if (p) file = p+3;
+	//while (*file==' ') file++;
+	// XXX - end of dead code -- deeso
+
 	/* TODO: fat bins are loaded multiple times, this is a problem that must be fixed . see '-->' marks. */
 	/* r_bin_select, r_bin_select_idx and r_bin_load end up loading the bin */
-        r->bin->cur.rawstr = r_config_get_i (r->config, "bin.rawstr");
-	if (r_bin_load (r->bin, file, R_FALSE)) { // --->
+    r->bin->cur.rawstr = r_config_get_i (r->config, "bin.rawstr");
+	if( is_io_load && r_bin_io_load(r->bin, r->io, r->file->fd, R_FALSE)) {
+		// NOTE: we are using the current RCore RCoreFile
+		// handle to load the binary, not the RIO's current FD, which can be
+		// different. 
+		 
+	} else if(r_bin_load (r->bin, file, R_FALSE)) { // --->
 		if (r->bin->narch>1 && r_config_get_i (r->config, "scr.prompt")) {
 			RBinObject *o = r->bin->cur.o;
 			eprintf ("NOTE: Fat binary found. Selected sub-bin is: -a %s -b %d\n",
@@ -200,14 +211,13 @@ R_API int r_core_bin_load(RCore *r, const char *file, ut64 baddr) {
 		(r->file->obj->info)? r->file->obj->info->has_va: 0);
 	offset = r_bin_get_offset (r->bin);
 	r_core_bin_info (r, R_CORE_BIN_ACC_ALL, R_CORE_BIN_SET, va, NULL, offset);
-	if (!strcmp (r->bin->cur.curplugin->name, "dex")) {
+	if (r->bin->cur.curplugin && !strcmp (r->bin->cur.curplugin->name, "dex")) {
 		r_core_cmd0 (r, "\"(fix-dex,wx `#sha1 $s-32 @32` @12 ; wx `#adler32 $s-12 @12` @8)\"\n");
 	}
 	if (r_config_get_i (r->config, "file.analyze"))
 		r_core_cmd0 (r, "aa");
 	return R_TRUE;
 }
-
 R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int mode, ut64 loadaddr) {
 	const char *cp;
 	RCoreFile *fh;
@@ -232,20 +242,14 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int mode, ut64 loa
 		return NULL;
 	}
 
-	fh = R_NEW (RCoreFile);
+	fh = malloc(sizeof(RCoreFile));
+	memset(fh, 0, sizeof(RCoreFile));
+
+	fh->uri = strdup(file);
+	
 	fh->fd = fd;
-	fh->map = NULL;
-	fh->uri = strdup (file); //fd->name);
-	fh->size = r_file_size (fh->uri);
-	if (!fh->size)
-		fh->size = r_io_size (r->io);
+	fh->size = r_io_desc_size(r->io, fh);
 	fh->filename = strdup (fd->name);
-	p = strstr (fh->filename, "://");
-	if (p != NULL) {
-		char *s = strdup (p+3);
-		free (fh->filename);
-		fh->filename = s;
-	}
 	fh->rwx = mode;
 	r->file = fh;
 	r->io->plugin = fd->plugin;
@@ -263,13 +267,38 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int mode, ut64 loa
 	return fh;
 }
 
+R_API RCoreFile * r_core_file_find_by_fd(RCore* core, int fd){
+	RCoreFile *result = NULL, *cf = NULL;
+	RListIter *iter;
+
+	if (!core || !core->files){
+		return result;
+	}
+
+	r_list_foreach(core->files, iter, cf){
+		if(cf && cf->fd->fd == fd){
+			result = cf;
+			break;
+		}
+	}
+	return cf;
+}
+
 R_API void r_core_file_free(RCoreFile *cf) {
-	if (!cf) return;
-	R_FREE (cf->uri);
-	R_FREE (cf->filename);
-	R_FREE (cf->map);
-	r_io_desc_free (cf->fd);
-	cf->fd = NULL;
+	if (cf){
+		if (cf->map) free(cf->map);
+		if (cf->filename) free(cf->filename);
+		if (cf->uri) free(cf->uri);
+		r_io_desc_free (cf->fd);
+		
+		cf->fd = NULL;
+		cf->map = NULL;
+		cf->filename = NULL;
+		cf->uri = NULL;
+		
+		//free(cf);
+	}
+	cf = NULL;
 }
 
 R_API int r_core_file_close(struct r_core_t *r, struct r_core_file_t *fh) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -206,6 +206,7 @@ R_API void r_core_visual_colors(RCore *core);
 R_API int r_core_search_cb(RCore *core, ut64 from, ut64 to, RCoreSearchCallback cb);
 R_API int r_core_serve(RCore *core, RIODesc *fd);
 R_API int r_core_file_reopen(RCore *core, const char *args, int perm);
+R_API RCoreFile * r_core_file_find_by_fd(RCore* core, int fd);
 R_API void r_core_file_free(RCoreFile *cf);
 R_API struct r_core_file_t *r_core_file_open(RCore *core, const char *file, int mode, ut64 loadaddr);
 R_API struct r_core_file_t *r_core_file_get_fd(RCore *core, int fd);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -146,6 +146,7 @@ typedef struct r_io_plugin_t {
         int (*init)();
 	RIOUndo undo;
         struct r_debug_t *debug;
+        int (*is_file_opened)(RIO *io, RIODesc *fd, const char *);
         int (*system)(RIO *io, RIODesc *fd, const char *);
         RIODesc* (*open)(RIO *io, const char *, int rw, int mode);
         int (*read)(RIO *io, RIODesc *fd, ut8 *buf, int count);
@@ -322,6 +323,8 @@ R_API RIODesc *r_io_desc_get(RIO *io, int fd);
 R_API int r_io_desc_add(RIO *io, RIODesc *desc);
 R_API int r_io_desc_del(RIO *io, int fd);
 R_API RIODesc *r_io_desc_get(RIO *io, int fd);
+R_API ut64 r_io_desc_size(RIO *io, RIODesc *desc);
+R_API ut64 r_io_fd_size(RIO *io, int fd);
 //R_API int r_io_desc_generate(RIO *io);
 
 /* buffer.c */

--- a/libr/io/desc.c
+++ b/libr/io/desc.c
@@ -12,6 +12,24 @@ R_API void r_io_desc_fini(RIO *io) {
 	r_list_free (io->desc);
 }
 
+R_API ut64 r_io_desc_size(RIO *io, RIODesc *desc){
+	RIODesc *old = NULL;
+    	ut64 sz = -1;
+	
+	if (desc && io->fd != desc){
+		old = io->fd;
+		r_io_set_fd(io, desc);
+	}
+        
+	if (desc) sz = r_io_size(io);
+	
+	if(old){
+		r_io_set_fd(io, old);
+	}
+	return sz;
+}
+
+
 R_API RIODesc *r_io_desc_new(RIOPlugin *plugin, int fd, const char *name, int flags, int mode, void *data) {
 	int i;
 	RIODesc *desc = R_NEW (RIODesc);

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -403,6 +403,11 @@ R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence) {
 	return ret;
 }
 
+R_API ut64 r_io_fd_size(RIO *io, int fd){
+	RIODesc *desc = r_io_desc_get(io, fd);
+	return r_io_desc_size(io, desc);
+}
+
 R_API ut64 r_io_size(RIO *io) {
 	int iova;
 	ut64 size, here;


### PR DESCRIPTION
r_bin_load currently clobbers all structures created by an IO Plugin, and this patch creates some checks and additional functions to initialize a core bin object from the IO Plugin structures.
