### PR TITLE
Fix formatting of long function names in radiff2

### DIFF
--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -34,12 +34,12 @@ R_API int r_core_gdiff(RCore *c, RCore *c2) {
 }
 
 /* copypasta from radiff2 */
-static void diffrow(ut64 addr, const char *name, ut64 addr2, const char *name2, const char *match, double dist) {
+static void diffrow(ut64 addr, const char *name, int maxnamelen, ut64 addr2, const char *name2, const char *match, double dist) {
 	if (addr2 == UT64_MAX || name2 == NULL)
-		printf ("%20s  0x%"PFMT64x" |%8s  (%f)\n",
-			name, addr, match, dist);
-	else printf ("%20s  0x%"PFMT64x" |%8s  (%f) | 0x%"PFMT64x"  %s\n",
-                name, addr, match, dist, addr2, name2);
+		printf ("%*s  0x%"PFMT64x" |%8s  (%f)\n",
+			maxnamelen, name, addr, match, dist);
+	else printf ("%*s  0x%"PFMT64x" |%8s  (%f) | 0x%"PFMT64x"  %s\n",
+                maxnamelen, name, addr, match, dist, addr2, name2);
 }
 
 R_API void r_core_diff_show(RCore *c, RCore *c2) {
@@ -47,6 +47,18 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
         RListIter *iter;
         RAnalFunction *f;
         RList *fcns = r_anal_get_fcns (c->anal);
+        int maxnamelen = 0;
+        int len;
+        r_list_foreach (fcns, iter, f) {
+                if (f->name && (len = strlen(f->name)) > maxnamelen)
+                        maxnamelen = len;
+        }
+        fcns = r_anal_get_fcns (c2->anal);
+        r_list_foreach (fcns, iter, f) {
+                if (f->name && (len = strlen(f->name)) > maxnamelen)
+                        maxnamelen = len;
+        }
+        fcns = r_anal_get_fcns (c->anal);
         r_list_foreach (fcns, iter, f) {
                 switch (f->type) {
                 case R_ANAL_FCN_TYPE_FCN:
@@ -61,7 +73,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                         default:
                                 match = "NEW";
                         }
-                        diffrow (f->addr, f->name,
+                        diffrow (f->addr, f->name, maxnamelen,
 				f->diff->addr, f->diff->name,
 				match, f->diff->dist);
                         break;
@@ -73,7 +85,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                 case R_ANAL_FCN_TYPE_FCN:
                 case R_ANAL_FCN_TYPE_SYM:
                         if (f->diff->type == R_ANAL_DIFF_TYPE_NULL)
-                                diffrow (f->addr, f->name,
+                                diffrow (f->addr, f->name, maxnamelen,
 					f->diff->addr, f->diff->name,
 					"NEW", f->diff->dist);
                 }


### PR DESCRIPTION
This is a fix to #79
