### PR TITLE
Add get_vaddr to RBinPlugin and fix vaddr calculation for PE files

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -711,6 +711,17 @@ R_API ut64 r_bin_get_offset (RBin *bin) {
 	return bin->cur.offset;
 }
 
+R_API ut64 r_bin_get_vaddr (RBin *bin, ut64 baddr, ut64 paddr, ut64 vaddr) {
+	RBinPlugin *cp = bin->cur.curplugin;
+	if(cp && cp->get_vaddr)
+	    return cp->get_vaddr (baddr, paddr, vaddr);
+
+	ut32 delta;
+	if (!baddr) return vaddr;
+ 	delta = (paddr & 0xfffff000) | (vaddr & 0xfff);
+	return baddr + delta;
+}
+
 R_API ut64 r_bin_get_size (RBin *bin) {
 	return bin->cur.o->size;
 }

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -323,6 +323,11 @@ static RBuffer* create(RBin* bin, const ut8 *code, int codelen, const ut8 *data,
 	return buf;
 }
 
+static ut64 get_vaddr (ut64 baddr, ut64 paddr, ut64 vaddr) {
+	if (!baddr) return vaddr;
+	return baddr + vaddr;
+}
+
 struct r_bin_plugin_t r_bin_plugin_pe = {
 	.name = "pe",
 	.desc = "PE bin plugin",
@@ -346,6 +351,7 @@ struct r_bin_plugin_t r_bin_plugin_pe = {
 	.write = NULL,
 	.minstrlen = 4,
 	.create = &create,
+	.get_vaddr = &get_vaddr
 };
 
 #ifndef CORELIB

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -175,6 +175,7 @@ typedef struct r_bin_plugin_t {
 	struct r_bin_meta_t *meta;
 	struct r_bin_write_t *write;
 	int (*get_offset)(RBinArch *arch, int type, int idx);
+	ut64 (*get_vaddr)(ut64 baddr, ut64 paddr, ut64 vaddr);
 	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
 	int minstrlen;
 } RBinPlugin;
@@ -329,10 +330,11 @@ R_API int r_bin_select_idx(RBin *bin, int idx);
 R_API void r_bin_list_archs(RBin *bin);
 R_API void r_bin_set_user_ptr(RBin *bin, void *user);
 R_API RBuffer *r_bin_create (RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen);
+R_API ut64 r_bin_get_offset (RBin *bin);
+R_API ut64 r_bin_get_vaddr (RBin *bin, ut64 baddr, ut64 paddr, ut64 vaddr);
 /* bin_meta.c */
 R_API int r_bin_meta_get_line(RBin *bin, ut64 addr, char *file, int len, int *line);
 R_API char *r_bin_meta_get_source_line(RBin *bin, ut64 addr);
-R_API ut64 r_bin_get_offset (RBin *bin);
 /* bin_write.c */
 R_API ut64 r_bin_wr_scn_resize(RBin *bin, const char *name, ut64 size);
 R_API int r_bin_wr_rpath_del(RBin *bin);


### PR DESCRIPTION
This patch fixes the issue https://github.com/radare/radare2/issues/365 and makes test https://github.com/radare/r2-regressions/commit/7062c508b1a10d57daad87ad97eb70577ef4b29b succeed (BROKEN flag no longer needed), and doesn't break anything else in r2-regressions.
