### PR TITLE
Refactorization of RAnalOp.esil to make it work with RStrBuf

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -14,7 +14,10 @@ R_API RAnalOp *r_anal_op_new() {
 		op->fail = -1;
 		op->ptr = -1;
 		op->val = -1;
-		op->esil[0] = 0;
+		if ((op->esil = r_strbuf_new ()) == NULL) {
+			r_anal_op_free (op);
+			return NULL;
+		}
 		op->next = NULL;
 	}
 	return op;
@@ -31,6 +34,8 @@ R_API void r_anal_op_fini(RAnalOp *op) {
 	r_anal_value_free (op->src[1]);
 	r_anal_value_free (op->src[2]);
 	r_anal_value_free (op->dst);
+	if (op->esil != NULL)
+		r_strbuf_free (op->esil);
 	op->src[0] = NULL;
 	op->src[1] = NULL;
 	op->src[2] = NULL;
@@ -65,6 +70,11 @@ R_API RAnalOp *r_anal_op_copy (RAnalOp *op) {
 	nop->src[1] = r_anal_value_copy (op->src[1]);
 	nop->src[2] = r_anal_value_copy (op->src[2]);
 	nop->dst = r_anal_value_copy (op->dst);
+	if ((nop->esil = r_strbuf_new ()) == NULL) {
+		r_anal_op_free (nop);
+		return NULL;
+	}
+	r_strbuf_set (nop->esil, r_strbuf_get (op->esil));
 	return nop;
 }
 

--- a/libr/anal/p/anal_bf.c
+++ b/libr/anal/p/anal_bf.c
@@ -9,26 +9,29 @@
 static int bf_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (op == NULL)
 		return 1;
-	memset (op, 0, sizeof (RAnalOp));
+	/* Ayeeee! What's inside op? Do we have an initialized RAnalOp? Are we going to have a leak here? :-( */
+	memset (op, 0, sizeof (RAnalOp)); /* We need to refactorize this. Something like r_anal_op_init would be more appropiate */
+	if ((op->esil = r_strbuf_new ()) == NULL)
+		return 1;
+	r_strbuf_init (op->esil);
 	op->size = 1;
-	op->esil[0] = 0;
 	switch (buf[0]) {
 	case '[': op->type = R_ANAL_OP_TYPE_CMP; break;
 	case ']': op->type = R_ANAL_OP_TYPE_UJMP; break;
 	case '>': op->type = R_ANAL_OP_TYPE_ADD;
-		strcpy (op->esil, "ptr++");
+		r_strbuf_set (op->esil, "ptr++");
 		break;
 	case '<': op->type = R_ANAL_OP_TYPE_SUB;
-		strcpy (op->esil, "ptr--");
+		r_strbuf_set (op->esil, "ptr--");
 		break;
 	case '+': op->type = R_ANAL_OP_TYPE_ADD;
-		strcpy (op->esil, "*ptr++");
+		r_strbuf_set (op->esil, "*ptr++");
 		break;
 	case '-': op->type = R_ANAL_OP_TYPE_SUB;
-		strcpy (op->esil, "*ptr--");
+		r_strbuf_set (op->esil, "*ptr--");
 		break;
 	case '.': op->type = R_ANAL_OP_TYPE_STORE;
-		strcpy (op->esil, "=*ptr");
+		r_strbuf_set (op->esil, "=*ptr");
 		break;
 	case ',': op->type = R_ANAL_OP_TYPE_LOAD; break;
 	case 0x00:

--- a/libr/anal/p/anal_mips.c
+++ b/libr/anal/p/anal_mips.c
@@ -18,8 +18,9 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
         op->type = R_ANAL_OP_TYPE_UNK;
 	op->size = oplen;
 	op->delay = 4;
-	op->esil[0] = 0;
-
+	if ((op->esil = r_strbuf_new ()) == NULL)
+		return oplen;
+	r_strbuf_init (op->esil);
 	//r_mem_copyendian ((ut8*)&opcode, b, 4, !anal->big_endian);
 	memcpy (&opcode, b, 4);
 
@@ -140,13 +141,13 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
 		case 2: // j
 			op->type = R_ANAL_OP_TYPE_JMP;
 			op->jump = address;
-			sprintf (op->esil, "pc=0x%08x", address);
+			r_strbuf_setf (op->esil, "pc=0x%08x", address);
 			break;
 		case 3: // jal
 			op->type = R_ANAL_OP_TYPE_CALL;
 			op->jump = address;
 			op->fail = addr+8;
-			sprintf (op->esil, "lr=pc+4,pc=0x%08x", address);
+			r_strbuf_setf (op->esil, "lr=pc+4,pc=0x%08x", address);
 			break;
 		}
 		family = 'J';

--- a/libr/anal/p/esil.h
+++ b/libr/anal/p/esil.h
@@ -2,7 +2,7 @@
 #define _UDIS86_ESIL_H
 
 /* This may be useful for other architectures */
-#define esilprintf(op, fmt, arg...) snprintf (op->esil, sizeof (op->esil) - 3, fmt, ##arg)
+#define esilprintf(op, fmt, arg...) r_strbuf_setf (op->esil, fmt, ##arg)
 
 #define UDIS86_ESIL_ARGUMENTS const UDis86OPInfo *info, RAnalOp *op, const char *dst, const char *src, const char *src2
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -201,8 +201,8 @@ static void r_core_anal_bytes (RCore *core, const ut8 *buf, int len, int nops) {
 		r_cons_printf ("size: %d\n", size);
 		r_cons_printf ("type: %d (%s)\n", (int)(op.type & 0xffff),
 			r_anal_optype_to_string (op.type)); // TODO: string
-		if (op.esil)
-			r_cons_printf ("esil: %s\n", op.esil);
+		if (*R_STRBUF_SAFEGET (op.esil))
+		  r_cons_printf ("esil: %s\n", R_STRBUF_SAFEGET (op.esil));
 		r_cons_printf ("eob: %d\n", op.eob);
 
 		if (hint && hint->jump != UT64_MAX)

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -416,7 +416,7 @@ static int pdi(RCore *core, int l, int len, int ilen) {
 				if (decode) {
 					opstr = (tmpopstr)? tmpopstr: strdup (asmop.buf_asm);
 				} else if (esil) {
-					opstr = strdup (analop.esil);
+					opstr = strdup (R_STRBUF_SAFEGET (analop.esil));
 				} else opstr = strdup (asmop.buf_asm);
 				r_cons_printf ("%s\n", opstr);
 				free (opstr);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -601,7 +601,10 @@ toro:
 		if (!lastfail)
 			r_anal_op (core->anal, &analop, at, buf+idx, (int)(len-idx));
 		if (ret<1) {
-			*analop.esil = 0;
+			if (analop.esil != NULL)
+				r_strbuf_free (analop.esil);
+			if ((analop.esil = r_strbuf_new ()) != NULL)
+				r_strbuf_init (analop.esil);
 			analop.type = R_ANAL_OP_TYPE_ILL;
 		}
 		if (hint) {
@@ -1036,11 +1039,11 @@ toro:
 			}
 		}
 		if (use_esil) {
-			if (*analop.esil) {
+			if (*R_STRBUF_SAFEGET (analop.esil)) {
 				free (opstr);
-				opstr = strdup (analop.esil);
+				opstr = strdup (R_STRBUF_SAFEGET (analop.esil));
 			} else {
-				char *p = malloc (strlen (opstr)+2);
+				char *p = malloc (strlen (opstr)+3); /* What's up '\0' ? */
 				strcpy (p, ": ");
 				strcpy (p+2, opstr);
 				free (opstr);
@@ -1418,8 +1421,8 @@ R_API int r_core_print_disasm_instructions (RCore *core, int len, int l) {
 		} else {
 			if (esil) {
 				r_anal_op (core->anal, &analop, at, buf+i, core->blocksize-i);
-				if (*analop.esil)
-					opstr = strdup (analop.esil);
+				if (*R_STRBUF_SAFEGET (analop.esil))
+					opstr = strdup (R_STRBUF_SAFEGET (analop.esil));
 			} else
 			if (decode) {
 				r_anal_op (core->anal, &analop, at, buf+i, core->blocksize-i);

--- a/libr/debug/p/debug_esil.c
+++ b/libr/debug/p/debug_esil.c
@@ -32,8 +32,8 @@ memset (buf, 0, sizeof (buf));
 eprintf ("READ 0x%08"PFMT64x" %02x %02x %02x\n", pc, buf[0], buf[1], buf[2]);
 	oplen = r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf));
 	if (oplen>0) {
-		if (op.esil) {
-			eprintf ("ESIL: %s\n", op.esil);
+		if (*R_STRBUF_SAFEGET (op.esil)) {
+			eprintf ("ESIL: %s\n", R_STRBUF_SAFEGET (op.esil));
 		}
 	}
 	eprintf ("TODO: ESIL STEP\n");

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -571,7 +571,7 @@ value->val
 	ut64 val;     /* reference to value */ /* XXX signed? */
 	st64 stackptr;  /* stack pointer */
 	int refptr;
-	char esil[64];
+	RStrBuf *esil;
 	RAnalValue *src[3];
 	RAnalValue *dst;
 	struct r_anal_op_t *next; // XXX deprecate

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -614,6 +614,7 @@ typedef struct {
 	char buf[64];
 } RStrBuf;
 
+#define R_STRBUF_SAFEGET(sb) (r_strbuf_get (sb) == NULL ? "" : r_strbuf_get (sb))
 R_API RStrBuf *r_strbuf_new();
 R_API void r_strbuf_set(RStrBuf *sb, const char *s);
 R_API void r_strbuf_setf(RStrBuf *sb, const char *fmt, ...);


### PR DESCRIPTION
It still needs to be tested with more architectures than x86. The R_STRBUF_SAFEGET hack to avoid messing up with every single file in libr/anal/p should work, but this is still a workaround.
