### PR TITLE
Added a command to load reload a bin at least once

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -144,6 +144,14 @@ static int cmd_open(void *data, const char *input) {
 		if (!r_core_bin_load (core, NULL, baddr))
 			r_config_set (core->config, "io.va", "false");
 		break;
+	case 'b':
+		// XXX: this will reload the bin using the buffer.
+		// An assumption is made that assumes there is an underlying
+		// plugin that will be used to load the bin (e.g. malloc://)
+		// TODO: Might be nice to reload a bin at a specified offset?
+		r_core_bin_reload (core, NULL, baddr);
+		r_core_block_read (core, 0);
+		break;
 	case '?':
 	default:
 		eprintf ("Usage: o[com- ] [file] ([offset])\n"
@@ -157,7 +165,8 @@ static int cmd_open(void *data, const char *input) {
 		" o+/bin/ls          open /bin/ls file in read-write mode\n"
 		" o /bin/ls 0x4000   map file at 0x4000\n"
 		" on /bin/ls 0x4000  map raw file at 0x4000 (no r_bin involved)\n"
-		" om[?]              create, list, remove IO maps\n");
+		" om[?]              create, list, remove IO maps\n"
+		" ob                 reload the buffer for analysis\n");
 		break;
 	}
 	return 0;

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -163,6 +163,13 @@ static ut64 get_base_from_maps(RCore *core, const char *file) {
 	return b;
 }
 
+R_API int r_core_bin_reload(RCore *r, const char *file, ut64 baddr) {
+	r_bin_free (r->bin);
+	r->bin = r_bin_new ();
+	r_bin_set_user_ptr (r->bin, r);
+	r_core_bin_load (r, file, baddr);
+}
+
 R_API int r_core_bin_load(RCore *r, const char *file, ut64 baddr) {
 	int i, va = r->io->va || r->io->debug;
 	RListIter *iter;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -276,6 +276,8 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len);
 R_API int r_core_print_disasm_instructions (RCore *core, int len, int l);
 
 R_API int r_core_bin_load(RCore *core, const char *file, ut64 baddr);
+// XXX - gross attempt to reload a bin
+R_API int r_core_bin_reload(RCore *core, const char *file, ut64 baddr);
 R_API int r_core_hash_load(RCore *core, const char *file);
 
 // XXX - this is kinda hacky, maybe there should be a way to 


### PR DESCRIPTION
This is just a preliminary command to load a bin while using something like malloc://.  Basically, this will free the current bin (r_core_bin_free), create a new bin (r_bin_new), set the current core, and then call bin_load.  I believe this will only work for malloc:// atm.  this does not try to clean up the core at all, there is other stuff that would need to be fixed up, like asm, anal, etc.

Example use case: https://gist.github.com/deeso/8085000
