### PR TITLE
Fix invalid pointer dereference in classname field of RBinSymbol

### DIFF
--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -183,6 +183,7 @@ static RList* symbols(RBinArch *arch) {
 		strncpy (ptr->forwarder, "NONE", R_BIN_SIZEOF_STRINGS);
 		strncpy (ptr->bind, symbol[i].bind, R_BIN_SIZEOF_STRINGS);
 		strncpy (ptr->type, symbol[i].type, R_BIN_SIZEOF_STRINGS);
+		ptr->classname = 0;
 		ptr->rva = symbol[i].offset + base;
 		ptr->offset = symbol[i].offset + base;
 		ptr->size = symbol[i].size;


### PR DESCRIPTION
There is a bit of uninitialized pointer deref:

```

Program received signal SIGSEGV, Segmentation fault.
__strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:31
31  ../sysdeps/x86_64/multiarch/../strlen.S: Нет такого файла или каталога.
(gdb) bt
#0  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/../strlen.S:31
#1  0x00007ffff3ef0d86 in __GI___strdup (s=0x5e8 <Address 0x5e8 out of bounds>) at strdup.c:41
#2  0x00007ffff7bb96b1 in bin_symbols (r=0x606980 <r>, mode=2, baddr=4194304, va=1, at=0, name=0x0) at bin.c:626
#3  0x00007ffff7bbb257 in r_core_bin_info (core=0x606980 <r>, action=4095, mode=2, va=1, filter=0x0, offset=0) at bin.c:1015
#4  0x00007ffff7b98dc1 in r_core_bin_load (r=0x606980 <r>, file=0x6c0940 "/home/theodor/test/test1", baddr=0) at file.c:283
#5  0x0000000000403bb7 in main (argc=2, argv=0x7fffffffea68) at radare2.c:430

```

It's dereferencing an uninitialized pointer to classname field of RBinSymbol when calling strdup in bin_symbols. Let's fix this.
