### PR TITLE
Proposed fix to printing function disassembly

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1,5 +1,5 @@
 /* radare - LGPL - Copyright 2009-2013 - pancake */
-
+//#include <r_anal_ex.h>
 
 static int is_valid_input_num_value(RCore *core, char *input_value){
 	ut64 value = input_value ? r_num_math (core->num, input_value) : 0;
@@ -839,7 +839,7 @@ static int cmd_print(void *data, const char *input) {
 		}
 
 		switch (input[1]) {
-		case 'i': 
+		case 'i':
 			processed_cmd = R_TRUE;
 			pdi (core, l, len, (*input=='D')? len: core->blocksize);
 			pd_result = 0;
@@ -973,8 +973,18 @@ static int cmd_print(void *data, const char *input) {
 						if (b->size > f->size) b->size = f->size;
 					}
 					// TODO: sort by addr
+					//r_list_sort (f->bbs, &r_anal_ex_bb_address_comparator);
 					r_list_foreach (f->bbs, iter, b) {
 						r_core_cmdf (core, "pD %"PFMT64d" @0x%"PFMT64x, b->size, b->addr);
+						/*switch (control_type) {
+							case R_ANAL_OP_TYPE_CALL:
+								break;
+							case R_ANAL_OP_TYPE_JMP:
+								break;
+							case R_ANAL_OP_TYPE_CJMP:
+								break;
+							case R_ANAL_OP_TYPE_SWITCH:
+						}*/
 						if (b->jump != UT64_MAX)
 							r_cons_printf ("-[true]-> 0x%08"PFMT64x"\n", b->jump);
 						if (b->fail != UT64_MAX)
@@ -1008,6 +1018,9 @@ static int cmd_print(void *data, const char *input) {
 				RAnalFunction *f = r_anal_fcn_find (core->anal, core->offset,
 						R_ANAL_FCN_TYPE_FCN|R_ANAL_FCN_TYPE_SYM);
 				if (f) {
+					//RPrint *p, RCore *core, ut64 addr, int l, int invbreak, int cbytes
+					core->num->value = r_core_print_fcn_disasm (core->print, core, f->addr, 9999, 0, 2);
+					/*
 					ut8 *block = malloc (f->size+1);
 					if (block) {
 						r_core_read_at (core, f->addr, block, f->size);
@@ -1016,7 +1029,7 @@ static int cmd_print(void *data, const char *input) {
 							f->size, 9999, 0, 2);
 						free (block);
 						pd_result = 0;
-					}
+					}*/
 				} else eprintf ("Cannot find function at 0x%08"PFMT64x"\n", core->offset);
 			}
 			l = 0;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -997,7 +997,8 @@ R_API RAnalRefline *r_anal_reflines_get(RAnal *anal,
 	ut64 addr, const ut8 *buf, ut64 len, int nlines, int linesout, int linescall);
 R_API int r_anal_reflines_middle(RAnal *anal, RAnalRefline *list, ut64 addr, int len);
 R_API char* r_anal_reflines_str(void *core, ut64 addr, int opts);
-
+R_API struct r_anal_refline_t *r_anal_reflines_fcn_get( struct r_anal_t *anal, RAnalFunction *fcn, 
+    int nlines, int linesout, int linescall);
 /* TODO move to r_core */
 R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, ut64 addr);
 R_API void r_anal_var_list(RAnal *anal, RAnalFunction *fcn, ut64 addr, int delta);

--- a/libr/include/r_anal_ex.h
+++ b/libr/include/r_anal_ex.h
@@ -18,7 +18,7 @@ typedef struct r_anal_ex_op_to_str_t {
 enum {
 	R_ANAL_EX_ILL_OP  =-1,   /* illegal instruction // trap */
 	R_ANAL_EX_NULL_OP = 0,
-	R_ANAL_EX_NOP = 1, /* does nothing */	
+	R_ANAL_EX_NOP = 1, /* does nothing */
 	R_ANAL_EX_STORE_OP  = 1 << 20,  // Load or Store memory operation
 	R_ANAL_EX_LOAD_OP   = 1 << 21,  // Load or Store memory operation
 	R_ANAL_EX_REG_OP	= 1 << 22,  // register operation

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -278,6 +278,7 @@ R_API RList *r_core_asm_back_disassemble_byte (RCore *core, ut64 addr, int len, 
 R_API int r_core_print_disasm(RPrint *p, RCore *core, ut64 addr, ut8 *buf, int len, int lines, int invbreak, int nbytes);
 R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len);
 R_API int r_core_print_disasm_instructions (RCore *core, int len, int l);
+R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int invbreak, int cbytes);
 
 R_API void r_core_bin_bind(RCore *core);
 R_API void r_core_bin_set_by_fd (RCore *core, ut64 bin_fd);


### PR DESCRIPTION
This patch supports walking function BBs to print the disassembly rather than relying on function size and reading a continuous block of bytes, which may not really represent all the code flow in the function. 
