### PR TITLE
add some x86 instruction description (*q x86_64)

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -901,7 +901,7 @@ static char *find_eoq (char *p) {
 static int r_core_cmd_subst_i(RCore *core, char *cmd) {
 	const char *quotestr = "`";
 	const char *tick = NULL;
-	char *ptr, *ptr2, *str = NULL;
+	char *ptr, *ptr2, *str;
 	char *arroba = NULL;
 	int i, ret, pipefd;
 	int usemyblock = 0;


### PR DESCRIPTION
only pull   23a18d8 add some x86 instruction description (*q x86_64), 

ignore 27207f7 ( libr/core/cmd.c)
