### PR TITLE
dwarf: Implement it.

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1,7 +1,9 @@
 /* radare - LGPL - Copyright 2012 - pancake */
 
-#define D0 if(0)
+#define D0 if(1)
 #define D1 if(1)
+
+#include <errno.h>
 
 #include <r_bin.h>
 #include <r_bin_dwarf.h>
@@ -10,292 +12,1212 @@
 #define STANDARD_OPERAND_COUNT_DWARF3 12
 #define R_BIN_DWARF_INFO 1
 
-#define READ(x,y) *((y *)x); x += sizeof (y)
+#define READ(x,y) *((y*)x); x += sizeof (y)
 
-R_API RList *r_bin_dwarf_parse_line(RBin *a);
-
-// XXX wtf
-R_API RList *r_bin_dwarf_parse(RBin *bin, int type) {
-	return r_bin_dwarf_parse_line (bin);
-}
-
-struct Line_Table_File_Entry_s {
-	ut8 *lte_filename;
-	ut32 lte_directory_index;
-	ut32 lte_last_modification_time;
-	ut32 lte_length_of_file;
+static const char *dwarf_tag_name_encodings[] = {
+	[DW_TAG_array_type] = "DW_TAG_array_type",
+	[DW_TAG_class_type] = "DW_TAG_class_type",
+	[DW_TAG_entry_point] = "DW_TAG_entry_point",
+	[DW_TAG_enumeration_type] = "DW_TAG_enumeration_type",
+	[DW_TAG_formal_parameter] = "DW_TAG_formal_parameter",
+	[DW_TAG_imported_declaration] = "DW_TAG_imported_declaration",
+	[DW_TAG_label] = "DW_TAG_label",
+	[DW_TAG_lexical_block] = "DW_TAG_lexical_block",
+	[DW_TAG_member] = "DW_TAG_member",
+	[DW_TAG_pointer_type] = "DW_TAG_pointer_type",
+	[DW_TAG_reference_type] = "DW_TAG_reference_type",
+	[DW_TAG_compile_unit] = "DW_TAG_compile_unit",
+	[DW_TAG_string_type] = "DW_TAG_string_type",
+	[DW_TAG_structure_type] = "DW_TAG_structure_type",
+	[DW_TAG_subroutine_type] = "DW_TAG_subroutine_type",
+	[DW_TAG_typedef] = "DW_TAG_typedef",
+	[DW_TAG_union_type] = "DW_TAG_union_type",
+	[DW_TAG_unspecified_parameters] = "DW_TAG_unspecified_parameters",
+	[DW_TAG_variant] = "DW_TAG_variant",
+	[DW_TAG_common_block] = "DW_TAG_common_block",
+	[DW_TAG_common_inclusion] = "DW_TAG_common_inclusion",
+	[DW_TAG_inheritance] = "DW_TAG_inheritance",
+	[DW_TAG_inlined_subroutine] = "DW_TAG_inlined_subroutine",
+	[DW_TAG_module] = "DW_TAG_module",
+	[DW_TAG_ptr_to_member_type] = "DW_TAG_ptr_to_member_type",
+	[DW_TAG_set_type] = "DW_TAG_set_type",
+	[DW_TAG_subrange_type] = "DW_TAG_subrange_type",
+	[DW_TAG_with_stmt] = "DW_TAG_with_stmt",
+	[DW_TAG_access_declaration] = "DW_TAG_access_declaration",
+	[DW_TAG_base_type] = "DW_TAG_base_type",
+	[DW_TAG_catch_block] = "DW_TAG_catch_block",
+	[DW_TAG_const_type] = "DW_TAG_const_type",
+	[DW_TAG_constant] = "DW_TAG_constant",
+	[DW_TAG_enumerator] = "DW_TAG_enumerator",
+	[DW_TAG_file_type] = "DW_TAG_file_type",
+	[DW_TAG_friend] = "DW_TAG_friend",
+	[DW_TAG_namelist] = "DW_TAG_namelist",
+	[DW_TAG_namelist_item] = "DW_TAG_namelist_item",
+	[DW_TAG_packed_type] = "DW_TAG_packed_type",
+	[DW_TAG_subprogram] = "DW_TAG_subprogram",
+	[DW_TAG_template_type_param] = "DW_TAG_template_type_param",
+	[DW_TAG_template_value_param] = "DW_TAG_template_value_param",
+	[DW_TAG_thrown_type] = "DW_TAG_thrown_type",
+	[DW_TAG_try_block] = "DW_TAG_try_block",
+	[DW_TAG_variant_part] = "DW_TAG_variant_part",
+	[DW_TAG_variable] = "DW_TAG_variable",
+	[DW_TAG_volatile_type] = "DW_TAG_volatile_type"
 };
 
-R_API int r_bin_dwarf_parse_info_raw(const ut8 *obuf) {
+static const char *dwarf_attr_encodings[] = {
+	[DW_AT_sibling] = "DW_AT_siblings",
+	[DW_AT_location] = "DW_AT_location",
+	[DW_AT_name] = "DW_AT_name",
+	[DW_AT_ordering] = "DW_AT_ordering",
+	[DW_AT_byte_size] = "DW_AT_byte_size",
+	[DW_AT_bit_size] = "DW_AT_bit_size",
+	[DW_AT_stmt_list] = "DW_AT_stmt_list",
+	[DW_AT_low_pc] = "DW_AT_low_pc",
+	[DW_AT_high_pc] = "DW_AT_high_pc",
+	[DW_AT_language] = "DW_AT_language",
+	[DW_AT_discr] = "DW_AT_discr",
+	[DW_AT_discr_value] = "DW_AT_discr_value",
+	[DW_AT_visibility] = "DW_AT_visibility",
+	[DW_AT_import] = "DW_AT_import",
+	[DW_AT_string_length] = "DW_AT_string_length",
+	[DW_AT_common_reference] = "DW_AT_common_reference",
+	[DW_AT_comp_dir] = "DW_AT_comp_dir",
+	[DW_AT_const_value] = "DW_AT_const_value",
+	[DW_AT_containing_type] = "DW_AT_containig_type",
+	[DW_AT_default_value] = "DW_AT_default_value",
+	[DW_AT_inline] = "DW_AT_inline",
+	[DW_AT_is_optional] = "DW_AT_is_optional",
+	[DW_AT_lower_bound] = "DW_AT_lower_bound",
+	[DW_AT_producer] = "DW_AT_producer",
+	[DW_AT_prototyped] = "DW_AT_prototyped",
+	[DW_AT_return_addr] = "DW_AT_return_addr",
+	[DW_AT_start_scope] = "DW_AT_start_scope",
+	[DW_AT_stride_size] = "DW_AT_stride_size",
+	[DW_AT_upper_bound] = "DW_AT_upper_bound",
+	[DW_AT_abstract_origin] = "DW_AT_abstract_origin",
+	[DW_AT_accessibility] = "DW_AT_accessibility",
+	[DW_AT_address_class] = "DW_AT_address_class",
+	[DW_AT_artificial] = "DW_AT_artificial",
+	[DW_AT_base_types] = "DW_AT_base_types",
+	[DW_AT_calling_convention] = "DW_AT_calling_convention",
+	[DW_AT_count] = "DW_AT_count",
+	[DW_AT_data_member_location] = "DW_AT_data_member_location",
+	[DW_AT_decl_column] = "DW_AT_decl_column",
+	[DW_AT_decl_file] = "DW_AT_decl_file",
+	[DW_AT_decl_line] = "DW_AT_decl_line",
+	[DW_AT_declaration] = "DW_AT_declaration",
+	[DW_AT_discr_list] = "DW_AT_discr_list",
+	[DW_AT_encoding] = "DW_AT_encoding",
+	[DW_AT_external] = "DW_AT_external",
+	[DW_AT_frame_base] = "DW_AT_frame_base",
+	[DW_AT_friend] = "DW_AT_friend",
+	[DW_AT_identifier_case] = "DW_AT_identifier_case",
+	[DW_AT_macro_info] = "DW_AT_macro_info",
+	[DW_AT_namelist_item] = "DW_AT_namelist_item",
+	[DW_AT_priority] = "DW_AT_priority",
+	[DW_AT_segment] = "DW_AT_segment",
+	[DW_AT_specification] = "DW_AT_specification",
+	[DW_AT_static_link] = "DW_AT_static_link",
+	[DW_AT_type] = "DW_AT_type",
+	[DW_AT_use_location] = "DW_AT_use_location",
+	[DW_AT_variable_parameter] = "DW_AT_variable_parameter",
+	[DW_AT_virtuality] = "DW_AT_virtuality",
+	[DW_AT_vtable_elem_location] = "DW_AT_vtable_elem_location"
+};
+
+static const char *dwarf_attr_form_encodings[] = {
+	[DW_FORM_addr] = "DW_FORM_addr",
+	[DW_FORM_block2] = "DW_FORM_block2",
+	[DW_FORM_block4] = "DW_FORM_block4",
+	[DW_FORM_data2] = "DW_FORM_data2",
+	[DW_FORM_data4] = "DW_FORM_data4",
+	[DW_FORM_data8] = "DW_FORM_data8",
+	[DW_FORM_string] = "DW_FORM_string",
+	[DW_FORM_block] = "DW_FORM_block",
+	[DW_FORM_block1] = "DW_FORM_block1",
+	[DW_FORM_data1] = "DW_FORM_data1",
+	[DW_FORM_flag] = "DW_FORM_flag",
+	[DW_FORM_sdata] = "DW_FORM_sdata",
+	[DW_FORM_strp] = "DW_FORM_strp",
+	[DW_FORM_udata] = "DW_FORM_udata",
+	[DW_FORM_ref_addr] = "DW_FORM_ref_addr",
+	[DW_FORM_ref1] = "DW_FORM_ref1",
+	[DW_FORM_ref2] = "DW_FORM_ref2",
+	[DW_FORM_ref4] = "DW_FORM_ref4",
+	[DW_FORM_ref8] = "DW_FORM_ref8",
+	[DW_FORM_ref_udata] = "DW_FORM_ref_udata",
+	[DW_FORM_indirect] = "DW_FORM_indirect"
+};
+
+static const char *dwarf_langs[] = {
+	[DW_LANG_C89] = "C89",
+	[DW_LANG_C] = "C",
+	[DW_LANG_Ada83] = "Ada83",
+	[DW_LANG_C_plus_plus] = "C++",
+	[DW_LANG_Cobol74] = "Cobol74",
+	[DW_LANG_Cobol85] = "Cobol85",
+	[DW_LANG_Fortran77] = "Fortran77",
+	[DW_LANG_Fortran90] = "Fortran90",
+	[DW_LANG_Pascal83] = "Pascal83",
+	[DW_LANG_Modula2] = "Modula2",
+	[DW_LANG_Java] = "Java",
+	[DW_LANG_C99] = "C99",
+	[DW_LANG_Ada95] = "Ada95",
+	[DW_LANG_Fortran95] = "Fortran95",
+	[DW_LANG_PLI] = "PLI",
+	[DW_LANG_ObjC] = "ObjC",
+	[DW_LANG_ObjC_plus_plus] = "ObjC_plus_plus",
+	[DW_LANG_UPC] = "UPC",
+	[DW_LANG_D] = "D",
+	[DW_LANG_Python] = "Python",
+};
+
+static const ut8 *r_bin_dwarf_parse_lnp_header (const ut8 *buf,
+		RBinDwarfLNPHeader *hdr, FILE *f) {
 	int i;
-	const char *buf = (const char *)obuf;
-	ut32 len, version, addr_size, abbr_offset;
+	size_t count;
+	const ut8 *tmp_buf;
 
-	len = READ (buf, ut32);
-	version = READ (buf, ut16);
-	abbr_offset = READ (buf, ut32);
-	addr_size = READ (buf, ut8);
-	//nextcu = READ (buf, ut8);
-
-	D0 {
-		eprintf ("Compile unit: 0x%x\n", len);
-		eprintf ("Version: %d\n", version);
-		eprintf ("abbr offset: 0x%x\n", abbr_offset);
-		eprintf ("addr size: 0x%x\n", addr_size);
-		//eprintf ("nextcu: 0x%x\n", nextcu);
-
-		for (i=0;i<256; i++) { eprintf ("%02x ", buf[i]); } eprintf("\n");
-
-		eprintf ("Compile Unit: length = 0x000000f1  version = 0x0002\n");
-		eprintf ("abbr_offset = 0x00000000  addr_size = 0x04  (next CU at 0x000000f5)\n");
+	hdr->unit_length.part1 = READ (buf, ut32);
+	if (hdr->unit_length.part1 == DWARF_INIT_LEN_64) {
+		hdr->unit_length.part2 = READ (buf, ut32);
 	}
-	return R_TRUE;
-}
 
-static const ut8 *r_bin_dwarf_parse_header (const ut8 *buf, RBinDwarfInfoHeader *hdr) {
-	int count, i, imax, oops;
-	hdr->total_length = READ (buf, ut32);
 	hdr->version = READ (buf, ut16);
-	hdr->plen = READ (buf, ut32); // end of payload is buf + plen
-	hdr->mininstlen = READ (buf, ut8);
-	hdr->is_stmt = READ (buf, ut8);
+
+	if (hdr->unit_length.part1 == DWARF_INIT_LEN_64) {
+		hdr->header_length = READ (buf, ut64);
+	} else {
+		hdr->header_length = READ (buf, ut32);
+	}
+
+	hdr->min_inst_len = READ (buf, ut8);
+	//hdr->max_ops_per_inst = READ (buf, ut8);
+	hdr->default_is_stmt = READ (buf, ut8);
 	hdr->line_base = READ (buf, char);
 	hdr->line_range = READ (buf, ut8);
 	hdr->opcode_base = READ (buf, ut8);
 
-	D0 {
-		eprintf ("DWARF LINE HEADER\n");
-		eprintf ("  payload length: %d\n", hdr->total_length);
-		eprintf ("  version: %d\n", hdr->version);
-		eprintf ("  plen: %d\n", hdr->plen);
-		eprintf ("  mininstlen: %d\n", hdr->mininstlen);
-		eprintf ("  is_stmt: %d\n", hdr->is_stmt);
-		eprintf ("  line_base: %d\n", hdr->line_base);
-		eprintf ("  line_range: %d\n", hdr->line_range);
-		eprintf ("  opcode_base: %d\n", hdr->opcode_base);
+	if (f) {
+		fprintf(f, "DWARF LINE HEADER\n");
+		fprintf(f, "  total_length: %d\n", hdr->unit_length.part1);
+		fprintf(f, "  version: %d\n", hdr->version);
+		fprintf(f, "  header_length: : %lld\n", hdr->header_length);
+		fprintf(f, "  mininstlen: %d\n", hdr->min_inst_len);
+		fprintf(f, "  is_stmt: %d\n", hdr->default_is_stmt);
+		fprintf(f, "  line_base: %d\n", hdr->line_base);
+		fprintf(f, "  line_range: %d\n", hdr->line_range);
+		fprintf(f, "  opcode_base: %d\n", hdr->opcode_base);
 	}
 
-	count = hdr->opcode_base - 1;
-	D0 eprintf ("-opcode arguments:\n");
-	/* parse opcode lengths table */
-	for (i = 0; i<count; i++) {
-		hdr->oplentable[i] = READ (buf, ut8);
-		D0 eprintf (" op %d %d\n", i, hdr->oplentable[i]);
+	hdr->std_opcode_lengths = calloc(sizeof(ut8), hdr->opcode_base);
+
+	for (i = 1; i <= hdr->opcode_base - 1; i++) {
+		hdr->std_opcode_lengths[i] = READ (buf, ut8);
+		if (f) {
+			fprintf(f, " op %d %d\n", i, hdr->std_opcode_lengths[i]);
+		}
 	}
-	/* parse include dirs */
-	while (*buf++) {
-		int len = strlen ((const char*)buf);
+
+	while (1) {
+		size_t len = strlen((const char*)buf);
 		if (!len) {
-			buf += 3;
+			buf += 1;
 			break;
 		}
-		D0 eprintf ("INCLUDEDIR (%s)\n", buf);
-		buf += len+3;
-	}
-	/* parse filenames */
-#if 0
-	- null-terminated string
-		- uleb128 with directory index
-		- leb128 with last modification time
-		- uleb128 with length of file
-#endif
-	oops = i = 0;
-	imax = R_BIN_DWARF_INFO_HEADER_FILE_LENGTH(hdr);
-	while (*buf) {
-		const char *filename = (const char *)buf;
-		ut32 didx, flen;
-		int tmod;
-		int len = strlen (filename);
-		if (!len) {
-			buf++;
-			break;
+		if (f) {
+			fprintf(f, "INCLUDEDIR (%s)\n", buf);
 		}
-		buf += len+1;
-		buf = r_uleb128 (buf, &didx);
-		buf = r_leb128 (buf, &tmod);
-		buf = r_uleb128 (buf, &flen);
-		D0 eprintf ("FILE (%s)\n", filename);
-		D0 eprintf ("| dir idx %d\n", didx);
-		D0 eprintf ("| lastmod %d\n", tmod);
-		D0 eprintf ("| filelen %d\n", flen);
-		if (i>=imax) {
-			// TODO remove any limit
-			if (!oops)
-				eprintf ("r_bin_dwarf: too many referenced files in dwarf header\n");
-			oops = 1;
-		} else hdr->file[i++] = filename;
+		buf += len + 1;
 	}
-	hdr->file[i] = 0;
+
+	tmp_buf = buf;
+	count = 0;
+	for (i = 0; i < 2; i++) {
+		while (1) {
+			const char *filename = (const char *)buf;
+			ut64 id_idx, mod_time, file_len;
+			size_t len = strlen(filename);
+
+			if (!len) {
+				buf++;
+				break;
+			}
+			buf += len + 1;
+			buf = r_uleb128 (buf, &id_idx);
+			buf = r_uleb128 (buf, &mod_time);
+			buf = r_uleb128 (buf, &file_len);
+
+
+			if (i) {
+				hdr->file_names[count].name = strdup (filename);
+				hdr->file_names[count].id_idx = id_idx;
+				hdr->file_names[count].mod_time = mod_time;
+				hdr->file_names[count].file_len = file_len;
+			}
+			count++;
+			if (f && i) {
+				fprintf(f, "FILE (%s)\n", filename);
+				fprintf(f, "| dir idx %lld\n", id_idx);
+				fprintf(f, "| lastmod %lld\n", mod_time);
+				fprintf(f, "| filelen %lld\n", file_len);
+			}
+		}
+		if (i == 0) {
+			hdr->file_names = calloc(sizeof(file_entry), count);
+			hdr->file_names_count = count;
+			buf = tmp_buf;
+			count = 0;
+		}
+	}
+
 	return buf;
 }
 
-R_API int r_bin_dwarf_parse_line_raw(const ut8 *obuf, int len, RList *list) {
-	RBinDwarfInfoHeader hdr;
-	ut64 address = 0;
-	int line = 1;
-	const ut8 *buf_end, *buf; //, *code;
-	int type;
+static const ut8* r_bin_dwarf_parse_ext_opcode(const RBin *a, const ut8 *obuf,
+		size_t len, const RBinDwarfLNPHeader *hdr,
+		RBinDwarfSMRegisters *regs, RList *list, FILE *f)
+{
+	const ut8 *buf;
 	ut8 opcode;
-	const char *types[] = {
-		"dw_extended_opcode", "extended",
-		"discard", "standard", "special"
-	};
+	ut64 addr;
+	buf = obuf;
+	st64 op_len;
+	buf = r_leb128(buf, &op_len);
+	ut32 addr_size = a->cur->o->info->bits / 8;
+	const char *filename;
 
-	buf = r_bin_dwarf_parse_header (obuf, &hdr);
-	//code = obuf+hdr.total_length;
+	opcode = *buf++;
 
-	buf_end = obuf + hdr.total_length;
-	// XXX
-	buf_end = obuf+len;
-	while (buf < buf_end) {
-		opcode = *buf++;
-		if (opcode == 0) {
-			type = 0; // extended!
-		} else
-		if (opcode < hdr.opcode_base) {
-			if (opcode == DW_EXTENDED_OPCODE)
-				type = LOP_EXTENDED;
-			else type = LOP_STANDARD;
-		} else type = LOP_SPECIAL;
-
-		D0	printf ("------ 0x%x type %d (%s) opcode %d\n",
-				(int)(size_t)(buf-obuf-1), type, types[type], opcode);
-		switch (type) {
-		case DW_EXTENDED_OPCODE: // 0
-			{ // extended (type=2)
-			ut8 oplen = *buf++;
-			opcode = *buf++;
-			D0 eprintf ("Next opcode %d is extended of size %d\n", opcode, oplen);
-			switch (opcode) {
-			case DW_LNE_set_discriminator:
-			case DW_LNE_define_file:
-				eprintf ("extended opcode %d not supported\n", opcode);
-				break;
-			case DW_LNE_end_sequence:
-				eprintf ("end_sequence\n");
-				break;
-			case DW_LNE_set_address:
-				if (oplen == 9) {
-					address = READ (buf, ut64);
-				} else {
-					address = (ut32) READ (buf, ut32);
-				}
-				D0 eprintf ("set address\n");
-				//eprintf ("0x%08"PFMT64x"\t%s:%d\n", address, hdr.file[0], line);
-				if (list) {
-					RBinDwarfRow *row = R_NEW (RBinDwarfRow);
-					r_bin_dwarf_line_new (row, address, hdr.file[0], line);
-					r_list_append (list, row);
-				}
-				break;
-			default:
-				eprintf ("Invalid extended opcode %d in dwarf's debug_line\n", opcode);
-				break;
-			}
-			} break;
-		case LOP_STANDARD: // 1?
-			switch (opcode) {
-			case DW_LNS_advance_pc:
-				{
-				int didx;
-				//buf = r_leb128 (buf, &didx);
-				didx = *buf++;
-				D0 eprintf ("advance pc %d\n", didx);
-				address += didx;
-				}
-				break;
-			default:
-				eprintf ("XXX : unimplemented dwarf opcode '%02x'\n", opcode);
-				break;
-			}
-			break;
-		case LOP_SPECIAL: // 4
-			{
-				/*
-				   int adjop = opcode - opcode_base
-				   int opadv = adjop / line_range
-				   new_address = address + mininstlen * (opidx + opadvance) % maxopsperinst
-				   new_opidx = (op_idx + opadv) % maopsperinst;
-				 */
-				int maxopsperinst = 1; //
-				int opidx = 0;
-				int adjop = opcode - hdr.opcode_base;
-				int opadv = adjop / hdr.line_range;
-				address += hdr.mininstlen * (opidx + opadv) % maxopsperinst;
-				int new_opidx = (opidx + opadv) % maxopsperinst;
-
-				int addr = (opcode / hdr.line_range) * hdr.mininstlen-1;
-				int delt = hdr.line_base + (adjop % hdr.line_range);
-
-				address += addr;
-				line += delt;
-				//eprintf ("0x%08"PFMT64x"\t%s:%d\n", address, hdr.file[0], line);
-				if (list) {
-					RBinDwarfRow *row = R_NEW (RBinDwarfRow);
-					r_bin_dwarf_line_new (row, address, hdr.file[0], line);
-					r_list_append (list, row);
-				}
-				D0 {
-					eprintf ("LINE += %d  ADDR += %d\n", delt, addr);
-					D0 eprintf ("opcode=%d ADJOP %d opadv=%d opidx=%d\n",
-							opcode, adjop, opadv, new_opidx);
-				}
-			} 
-			break;
-		case LOP_DISCARD: // 2
-			eprintf ("DISCARD!\n");
-			break;
-		}
+	if (f) {
+		fprintf(f, "Extended opcode %d: ", opcode);
 	}
-#if 0
-	case LOP_STANDARD:
-		eprintf ("standard opcode\n");
-		switch (opcode) {
-		case DW_LNS_copy:
-			break;
-		case DW_LNS_advance_pc:
 
-			break;
-		case DW_LNS_advance_line:
-			st32 *b = ptr; // little endian foo
-			line = line + *b;
-			break;
-		case DW_LNS_set_file:
-			ut32 *b = ptr; // little endian foo
-			file = *b;
-			break;
-		case DW_LNS_set_column:
-			ut32 *b = ptr; // little endian foo
-			column = *b;
-			break;
-		case DW_LNS_negate_stmt:
-			is_stmt = !is_stmt;
-			break;
-		case DW_LNS_set_basic_block:
-			bb = 1;
-			break;
-		case DW_LNS_const_add_pc:
-			opcode = MAX_LINE_OP_CODE - opcode_base;
-			address = address + mininslen * (opcode / line_range);
-			break;
-		case DW_LNS_fixed_advance_pc:
-			ut16 *w = ptr;
-			opcode = MAX_LINE_OP_CODE - opcode_base;
-			address = address + mininslen * (opcode / line_range);
-			break;
-		case DW_LNS_set_prologue_end:
-			prologue_end = 1;
-			break;
-		case DW_LNS_set_prologue_begin:
-			epilogue_begin = 1;
-			break;
-		case DW_LNS_set_isa:
-			break;
+	switch (opcode) {
+	case DW_LNE_end_sequence:
+		regs->end_sequence = DWARF_TRUE;
+
+		if (list) {
+			RBinDwarfRow *row = R_NEW (RBinDwarfRow);
+			r_bin_dwarf_line_new (row, regs->address,
+					hdr->file_names[0].name, regs->line);
+		}
+
+		if (f) {
+			fprintf(f, "End of Sequence\n");
+		}
+		break;
+	case DW_LNE_set_address:
+		if (addr_size == 8) {
+			addr = READ (buf, ut64);
+		} else {
+			addr = READ (buf, ut32);
+		}
+
+		regs->address = addr;
+
+		if (f) {
+			fprintf(f, "set Address to 0x%llx\n", addr);
+		}
+		break;
+	case DW_LNE_define_file:
+		filename = (const char*)buf;
+
+		if (f) {
+			fprintf(f, "define_file\n");
+			fprintf(f, "filename %s\n", filename);
+		}
+
+		buf += (strlen (filename) + 1);
+		ut64 dir_idx;
+		buf = r_uleb128(buf, &dir_idx);
+		break;
+	case DW_LNE_set_discriminator:
+		buf = r_uleb128(buf, &addr);
+		if (f) {
+			fprintf(f, "set Discriminator to %lld\n", addr);
+		}
+		regs->discriminator = addr;
+		break;
+	default:
+		if (f) {
+			fprintf(f, "Unexpeced opcode %d\n", opcode);
 		}
 		break;
 	}
-#endif
-	return R_TRUE;
+
+	return buf;
+}
+
+static const ut8* r_bin_dwarf_parse_spec_opcode(const ut8 *obuf, size_t len,
+		const RBinDwarfLNPHeader *hdr, RBinDwarfSMRegisters *regs,
+		ut8 opcode, RList *list, FILE *f)
+{
+	const ut8 *buf;
+	buf = obuf;
+	ut8 adj_opcode = opcode - hdr->opcode_base;
+	ut64 advance_adr;
+
+	advance_adr = adj_opcode / hdr->line_range;
+	regs->address += advance_adr;
+
+	regs->line += hdr->line_base + (adj_opcode % hdr->line_range);
+	if (f) {
+		fprintf(f, "Special opcode %d: ", adj_opcode);
+		fprintf(f, "advance Address by %lld to %llx and Line by %d to %lld\n",
+			advance_adr, regs->address, hdr->line_base +
+			(adj_opcode % hdr->line_range), regs->line);
+	}
+
+	regs->basic_block = DWARF_FALSE;
+	regs->prologue_end = DWARF_FALSE;
+	regs->epilogue_begin = DWARF_FALSE;
+	regs->discriminator = 0;
+
+	return buf;
+}
+
+static const ut8* r_bin_dwarf_parse_std_opcode(const ut8 *obuf, size_t len,
+		const RBinDwarfLNPHeader *hdr, RBinDwarfSMRegisters *regs,
+		ut8 opcode, RList *list, FILE *f)
+{
+	const ut8* buf = obuf;
+	ut64 addr;
+	st64 sbuf;
+	ut8 adj_opcode;
+	ut64 op_advance;
+	ut16 operand;
+
+	switch (opcode) {
+	case DW_LNS_copy:
+		if (f) {
+			fprintf(f, "Copy\n");
+		}
+		if (list) {
+			RBinDwarfRow *row = R_NEW (RBinDwarfRow);
+			r_bin_dwarf_line_new (row, regs->address,
+					hdr->file_names[0].name, regs->line);
+		}
+		regs->basic_block = DWARF_FALSE;
+		break;
+	case DW_LNS_advance_pc:
+		buf = r_uleb128(buf, &addr);
+		regs->address += addr * hdr->min_inst_len;
+
+		if (f) {
+			fprintf(f, "Advance PC by %lld to 0x%llx\n",
+				addr * hdr->min_inst_len, regs->address);
+		}
+		break;
+	case DW_LNS_advance_line:
+		buf = r_leb128(buf, &sbuf);
+		regs->line += sbuf;
+		if (f) {
+			fprintf(f, "Advance line by %lld, to %lld\n", sbuf, regs->line);
+		}
+		break;
+	case DW_LNS_set_file:
+		buf = r_uleb128(buf, &addr);
+		if (f) {
+			fprintf(f, "Set file to %lld\n", addr);
+		}
+		regs->file = addr;
+		break;
+	case DW_LNS_set_column:
+		buf = r_uleb128(buf, &addr);
+		if (f) {
+			fprintf(f, "Set column to %lld\n", addr);
+		}
+		regs->column = addr;
+		break;
+	case DW_LNS_negate_stmt:
+		regs->is_stmt = regs->is_stmt ? DWARF_FALSE : DWARF_TRUE;
+		if (f) {
+			fprintf(f, "Set is_stmt to %d\n", regs->is_stmt);
+		}
+		break;
+	case DW_LNS_set_basic_block:
+		if (f) {
+			fprintf(f, "set_basic_block\n");
+		}
+		regs->basic_block = DWARF_TRUE;
+		break;
+	case DW_LNS_const_add_pc:
+		adj_opcode = 255 - hdr->opcode_base;
+		op_advance = adj_opcode / hdr->line_range;
+		regs->address += op_advance;
+		if (f) {
+			fprintf(f, "Advance PC by constant %lld to 0x%llx\n",
+				op_advance, regs->address);
+		}
+	case DW_LNS_fixed_advance_pc:
+		operand = READ (buf, ut16);
+		regs->address += operand;
+		if (f) {
+			fprintf(f,"Fixed advance pc to %lld\n", regs->address);
+		}
+		break;
+	case DW_LNS_set_prologue_end:
+		regs->prologue_end = ~0;
+		if (f) {
+			fprintf(f, "set_prologue_end\n");
+		}
+		break;
+	case DW_LNS_set_epilogue_begin:
+		regs->epilogue_begin = ~0;
+		if (f) {
+			fprintf(f, "set_epilogue_begin\n");
+		}
+		break;
+	case DW_LNS_set_isa:
+		buf = r_uleb128(buf, &addr);
+		regs->isa = addr;
+		if (f) {
+			fprintf(f, "set_isa\n");
+		}
+		break;
+	default:
+		if (f) {
+			fprintf(f, "Unexpected opcode\n");
+		}
+		break;
+	}
+	return buf;
+}
+
+static const ut8* r_bin_dwarf_parse_opcodes (const RBin *a, const ut8 *obuf,
+		size_t len, const RBinDwarfLNPHeader *hdr,
+		RBinDwarfSMRegisters *regs, RList *list, FILE *f) {
+	const ut8 *buf, *buf_end;
+	ut8 opcode, ext_opcode;
+
+	buf = obuf;
+	buf_end = obuf + len;
+
+	while (buf < buf_end) {
+		opcode = *buf++;
+		if (opcode == 0) {
+			ext_opcode = *buf;
+			buf = r_bin_dwarf_parse_ext_opcode(a, buf, len, hdr, regs, list,f );
+			if (ext_opcode == DW_LNE_end_sequence)
+				break;
+		} else if (opcode >= hdr->opcode_base) {
+			buf = r_bin_dwarf_parse_spec_opcode(buf, len, hdr, regs, opcode, list, f);
+		} else {
+			buf = r_bin_dwarf_parse_std_opcode(buf, len, hdr, regs, opcode, list, f);
+		}
+	}
+
+	return buf;
+}
+
+static void r_bin_dwarf_set_regs_default (const RBinDwarfLNPHeader *hdr,
+		RBinDwarfSMRegisters *regs) {
+	regs->address = 0;
+	regs->file = 1;
+	regs->line = 1;
+	regs->column = 0;
+	regs->is_stmt = hdr->default_is_stmt;
+	regs->basic_block = DWARF_FALSE;
+	regs->end_sequence = DWARF_FALSE;
+}
+
+R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
+		size_t len, RList *list, FILE *f) {
+	RBinDwarfLNPHeader hdr;
+	const ut8 *buf, *buf_tmp, *buf_end;
+	RBinDwarfSMRegisters regs;
+
+	buf = obuf;
+	buf_end = obuf + len;
+	while (buf < buf_end) {
+		buf_tmp = buf;
+		buf = r_bin_dwarf_parse_lnp_header (buf, &hdr, f);
+		r_bin_dwarf_set_regs_default (&hdr, &regs);
+		r_bin_dwarf_parse_opcodes (a, buf, 4 + hdr.unit_length.part1,
+				&hdr, &regs, list, f);
+		buf = buf_tmp + 4 + hdr.unit_length.part1;
+	}
+
+	return 0;
+}
+
+R_API int r_bin_dwarf_parse_aranges_raw(const ut8 *obuf, int len)
+{
+	uint32_t length = *(uint32_t*)obuf;
+	uint16_t version;
+	uint32_t debug_info_offset;
+	uint8_t address_size, segment_size;
+	const ut8 *buf = obuf;
+
+	printf("parse_aranges\n");
+	printf("length 0x%x\n", length);
+
+	if (length >= 0xfffffff0) {
+		buf += 4;
+		buf += 8;
+	} else {
+		buf += 4;
+	}
+
+	version = *(uint16_t*)buf;
+
+	buf += 2;
+
+	printf("Version %d\n", version);
+
+	debug_info_offset = *(uint32_t*)buf;
+
+	printf("Debug info offset %d\n", debug_info_offset);
+
+	buf += 4;
+
+	address_size = *(uint8_t*)buf;
+
+	printf("address size %d\n", (int)address_size);
+
+	buf += 1;
+
+	segment_size = *(uint8_t*)buf;
+
+	printf("segment size %d\n", (int)segment_size);
+
+	buf += 1;
+
+	size_t offset = segment_size + address_size * 2;
+
+	buf += (((uint64_t) buf / offset) + 1) * offset - ((uint64_t)buf);
+
+	while (buf - obuf < len) {
+		uint64_t adr, length;
+
+		adr = *(uint64_t*)buf;
+		buf += 8;
+		length = *(uint64_t*)buf;
+		buf += 8;
+
+		printf("length 0x%llx address 0x%llx\n", length, adr);
+	}
+
+	return 0;
+}
+
+static int r_bin_dwarf_init_debug_info(RBinDwarfDebugInfo *inf) {
+	inf->comp_units = calloc(sizeof(RBinDwarfCompUnit), DEBUG_INFO_CAPACITY);
+
+	if (!inf->comp_units)
+		return -ENOMEM;
+
+	inf->capacity = DEBUG_INFO_CAPACITY;
+	inf->length = 0;
+
+	return 0;
+}
+
+static int r_bin_dwarf_init_die(RBinDwarfDIE *die) {
+	die->attr_values = calloc(sizeof(RBinDwarfAttrValue), 8);
+
+	if (!die->attr_values)
+		return -ENOMEM;
+
+	die->capacity = 8;
+	die->length = 0;
+
+	return 0;
+}
+
+static int r_bin_dwarf_expand_die(RBinDwarfDIE* die) {
+	RBinDwarfAttrValue *tmp;
+
+	if (die->capacity != die->length)
+		return -EINVAL;
+
+	tmp = (RBinDwarfAttrValue*)realloc(die->attr_values,
+			die->capacity * 2 * sizeof(RBinDwarfAttrValue));
+
+	if (!tmp)
+		return -ENOMEM;
+
+	die->attr_values = tmp;
+	die->capacity *= 2;
+	return 0;
+}
+
+static int r_bin_dwarf_init_comp_unit(RBinDwarfCompUnit *cu) {
+	cu->dies = calloc(sizeof(RBinDwarfDIE), COMP_UNIT_CAPACITY);
+
+	if (!cu->dies)
+		return -ENOMEM;
+
+	cu->capacity = COMP_UNIT_CAPACITY;
+	cu->length = 0;
+
+	return 0;
+}
+
+static int r_bin_dwarf_expand_cu(RBinDwarfCompUnit *cu) {
+	RBinDwarfDIE *tmp;
+
+	if (cu->capacity != cu->length)
+		return -EINVAL;
+
+	tmp = (RBinDwarfDIE*)realloc(cu->dies,
+			cu->capacity * 2 * sizeof(RBinDwarfDIE));
+
+	if (!tmp)
+		return -ENOMEM;
+
+	cu->dies = tmp;
+	cu->capacity *= 2;
+
+	return 0;
+}
+
+static int r_bin_dwarf_init_abbrev_decl(RBinDwarfAbbrevDecl *ad) {
+	ad->specs = calloc(sizeof(RBinDwarfAttrSpec), ABBREV_DECL_CAP);
+
+	if (!ad->specs)
+		return -ENOMEM;
+
+	ad->capacity = ABBREV_DECL_CAP;
+	ad->length = 0;
+
+	return 0;
+}
+
+static int r_bin_dwarf_expand_abbrev_decl(RBinDwarfAbbrevDecl *ad) {
+	RBinDwarfAttrSpec *tmp;
+
+	if (ad->capacity != ad->length)
+		return -EINVAL;
+
+	tmp = (RBinDwarfAttrSpec*)realloc(ad->specs,
+			ad->capacity * 2 * sizeof(RBinDwarfAttrSpec));
+
+	if (!tmp)
+		return -ENOMEM;
+
+	ad->specs = tmp;
+	ad->capacity *= 2;
+
+	return 0;
+}
+
+static int r_bin_dwarf_init_debug_abbrev(RBinDwarfDebugAbbrev *da) {
+	da->decls = calloc(sizeof(RBinDwarfAbbrevDecl), DEBUG_ABBREV_CAP);
+
+	if (!da->decls)
+		return -ENOMEM;
+
+	da->capacity = DEBUG_ABBREV_CAP;
+	da->length = 0;
+
+	return 0;
+}
+
+static int r_bin_dwarf_expand_debug_abbrev(RBinDwarfDebugAbbrev *da) {
+	RBinDwarfAbbrevDecl *tmp;
+
+	if (da->capacity != da->length)
+		return -EINVAL;
+
+	tmp = (RBinDwarfAbbrevDecl*)realloc(da->decls,
+			da->capacity * 2 * sizeof(RBinDwarfAbbrevDecl));
+
+	if (!tmp)
+		return -ENOMEM;
+
+	da->decls = tmp;
+	da->capacity *= 2;
+
+	return 0;
+}
+
+static void dump_r_bin_dwarf_debug_abbrev(FILE *f, RBinDwarfDebugAbbrev *da) {
+	size_t i, j;
+	ut64 attr_name, attr_form;
+
+	for (i = 0; i < da->length; i++) {
+		fprintf(f, "Abbreviation Code %lld ", da->decls[i].code);
+		fprintf(f, "Tag %s ", dwarf_tag_name_encodings[da->decls[i].tag]);
+		fprintf(f, "[%s]\n", da->decls[i].has_children ?
+				"has children" : "no children");
+		fprintf(f, "Offset 0x%llx\n", da->decls[i].offset);
+
+		for (j = 0; j < da->decls[i].length; j++) {
+			attr_name = da->decls[i].specs[j].attr_name;
+			attr_form = da->decls[i].specs[j].attr_form;
+			if (attr_name && attr_form &&
+				attr_name <= DW_AT_vtable_elem_location &&
+				attr_form <= DW_TAG_volatile_type) {
+					fprintf(f, "    %s %s\n",
+						dwarf_attr_encodings[attr_name],
+						dwarf_attr_form_encodings[attr_form]);
+			}
+		}
+	}
+}
+
+R_API void r_bin_dwarf_free_debug_abbrev(RBinDwarfDebugAbbrev *da) {
+	size_t i;
+
+	for (i = 0; i < da->length; i++)
+		free(da->decls[i].specs);
+
+	free (da->decls);
+}
+
+static void r_bin_dwarf_free_attr_value (RBinDwarfAttrValue *val)
+{
+	switch (val->form) {
+	case DW_FORM_strp:
+	case DW_FORM_string:
+		if (val->encoding.str_struct.string) {
+			free (val->encoding.str_struct.string);
+		}
+		break;
+	case DW_FORM_block:
+	case DW_FORM_block1:
+	case DW_FORM_block2:
+	case DW_FORM_block4:
+		if (val->encoding.block.data) {
+			free (val->encoding.block.data);
+		}
+		break;
+	default:
+		break;
+	};
+}
+
+static void r_bin_dwarf_free_die (RBinDwarfDIE *die)
+{
+	size_t i;
+
+	for (i = 0; i < die->length; i++) {
+		r_bin_dwarf_free_attr_value (&die->attr_values[i]);
+	}
+
+	free (die->attr_values);
+}
+
+static void r_bin_dwarf_free_comp_unit (RBinDwarfCompUnit *cu)
+{
+	size_t i;
+
+	for (i = 0; i < cu->length; i++) {
+		r_bin_dwarf_free_die (&cu->dies[i]);
+	}
+
+	free (cu->dies);
+}
+
+static void r_bin_dwarf_free_debug_info (RBinDwarfDebugInfo *inf)
+{
+	size_t i;
+
+	for (i = 0; i < inf->length; i++) {
+		r_bin_dwarf_free_comp_unit (&inf->comp_units[i]);
+	}
+
+	free (inf->comp_units);
+}
+
+static void r_bin_dwarf_dump_attr_value(const RBinDwarfAttrValue *val, FILE *f)
+{
+	size_t i;
+
+	switch (val->form) {
+	case DW_FORM_addr:
+		fprintf(f, "0x%llx", val->encoding.address);
+		break;
+	case DW_FORM_block:
+	case DW_FORM_block1:
+	case DW_FORM_block2:
+	case DW_FORM_block4:
+		fprintf (f, "%llu byte block:", val->encoding.block.length);
+		for (i = 0; i < val->encoding.block.length; i++) {
+			fprintf (f, "%02x", val->encoding.block.data[i]);
+		}
+		break;
+	case DW_FORM_data1:
+	case DW_FORM_data2:
+	case DW_FORM_data4:
+	case DW_FORM_data8:
+		fprintf (f, "%llu", val->encoding.data);
+		if (val->name == DW_AT_language) {
+			fprintf (f, "   (%s)", dwarf_langs[val->encoding.data]);
+		}
+		break;
+	case DW_FORM_strp:
+		fprintf (f, "(indirect string, offset: 0x%llx): ",
+				val->encoding.str_struct.offset);
+	case DW_FORM_string:
+		fprintf (f, "%s", val->encoding.str_struct.string);
+		break;
+	case DW_FORM_flag:
+		fprintf (f, "%u", val->encoding.flag);
+		break;
+	case DW_FORM_sdata:
+		fprintf (f, "%lld", val->encoding.sdata);
+		break;
+	case DW_FORM_udata:
+		fprintf (f, "%llu", val->encoding.data);
+		break;
+	case DW_FORM_ref_addr:
+		fprintf (f, "<0x%llx>", val->encoding.reference);
+		break;
+	case DW_FORM_ref1:
+	case DW_FORM_ref2:
+	case DW_FORM_ref4:
+	case DW_FORM_ref8:
+		fprintf (f, "<0x%llx>", val->encoding.reference);
+		break;
+	default:
+		fprintf (f, "Unknown attr value form %lld\n", val->form);
+	};
+}
+
+static void r_bin_dwarf_dump_debug_info (FILE *f, const RBinDwarfDebugInfo *inf)
+{
+	size_t i, j, k;
+	RBinDwarfDIE *dies;
+	RBinDwarfAttrValue *values;
+
+	for (i = 0; i < inf->length; i++) {
+		fprintf(f, "  Compilation Unit @ offset 0x%llx:\n", inf->comp_units [i].offset);
+		fprintf(f, "   Length:        0x%x\n", inf->comp_units [i].hdr.length);
+		fprintf(f, "   Version:       %d\n", inf->comp_units [i].hdr.version);
+		fprintf(f, "   Abbrev Offset: 0x%x\n", inf->comp_units [i].hdr.abbrev_offset);
+		fprintf(f, "   Pointer Size:  %d\n", inf->comp_units [i].hdr.pointer_size);
+
+		dies = inf->comp_units[i].dies;
+
+		for (j = 0; j < inf->comp_units[i].length; j++) {
+			fprintf(f, "    Abbrev Number: %llu ", dies[j].abbrev_code);
+
+			if (dies[j].tag && dies[j].tag <= DW_TAG_volatile_type &&
+				       dwarf_tag_name_encodings[dies[j].tag]) {
+				fprintf(f, "(%s)\n", dwarf_tag_name_encodings[dies[j].tag]);
+			} else {
+				fprintf(f, "(Unknown abbrev tag)\n");
+			}
+
+			if (!dies[j].abbrev_code)
+				continue;
+			values = dies[j].attr_values;
+
+			for (k = 0; k < dies[j].length; k++) {
+				if (!values[k].name)
+					continue;
+
+				if (values[k].name < DW_AT_vtable_elem_location &&
+						dwarf_attr_encodings[values[k].name]) {
+					fprintf(f, "     %-18s : ", dwarf_attr_encodings[values[k].name]);
+				} else {
+					fprintf(f, "     TODO\t");
+				}
+				r_bin_dwarf_dump_attr_value (&values[k], f);
+				fprintf(f, "\n");
+			}
+		}
+	}
+}
+
+static const ut8 *r_bin_dwarf_parse_attr_value (const ut8 *obuf,
+		RBinDwarfAttrSpec *spec, RBinDwarfAttrValue *value,
+		const RBinDwarfCompUnitHdr *hdr,
+		const ut8 *debug_str, size_t debug_str_len)
+{
+	const ut8 *buf = obuf;
+	size_t j;
+
+	value->form = spec->attr_form;
+	value->name = spec->attr_name;
+
+	switch (spec->attr_form) {
+	case DW_FORM_addr:
+		switch (hdr->pointer_size) {
+		case 1:
+			value->encoding.address = READ (buf, ut8);
+			break;
+		case 2:
+			value->encoding.address = READ (buf, ut16);
+			break;
+		case 4:
+			value->encoding.address = READ (buf, ut32);
+			break;
+		case 8:
+			value->encoding.address = READ (buf, ut64);
+			break;
+		default:
+			fprintf(stderr, "DWARF: Unexpected pointer size: %u\n",
+					(unsigned)hdr->pointer_size);
+			return NULL;
+		}
+
+		break;
+
+	case DW_FORM_block2:
+		value->encoding.block.length = READ (buf, ut16);
+		value->encoding.block.data = calloc(sizeof(ut8),
+				value->encoding.block.length);
+
+		for (j = 0; j < value->encoding.block.length; j++) {
+			value->encoding.block.data[j] = READ (buf, ut8);
+		}
+		break;
+
+	case DW_FORM_block4:
+		value->encoding.block.length = READ (buf, ut32);
+		value->encoding.block.data = calloc(sizeof(ut8),
+				value->encoding.block.length);
+
+		for (j = 0; j < value->encoding.block.length; j++) {
+			value->encoding.block.data[j] = READ (buf, ut8);
+		}
+		break;
+
+	case DW_FORM_data2:
+		value->encoding.data = READ (buf, ut16);
+		break;
+
+	case DW_FORM_data4:
+		value->encoding.data = READ (buf, ut32);
+		break;
+
+	case DW_FORM_data8:
+		value->encoding.data = READ (buf, ut64);
+		break;
+
+	case DW_FORM_string:
+		value->encoding.str_struct.string = strdup((const char*)buf);
+		buf += (strlen((const char*)buf) + 1);
+		break;
+
+	case DW_FORM_block:
+		buf = r_uleb128 (buf, &value->encoding.block.length);
+
+		value->encoding.block.data = calloc(sizeof(ut8),
+				value->encoding.block.length);
+
+		for (j = 0; j < value->encoding.block.length; j++) {
+			value->encoding.block.data[j] = READ (buf, ut8);
+		}
+		break;
+
+	case DW_FORM_block1:
+		value->encoding.block.length = READ (buf, ut8);
+
+		value->encoding.block.data = calloc(sizeof(ut8),
+				value->encoding.block.length);
+
+		for (j = 0; j < value->encoding.block.length; j++) {
+			value->encoding.block.data[j] = READ (buf, ut8);
+		}
+		break;
+
+	case DW_FORM_flag:
+		value->encoding.flag = READ (buf, ut8);
+		break;
+
+	case DW_FORM_sdata:
+		buf = r_leb128 (buf, &value->encoding.sdata);
+		break;
+
+	case DW_FORM_strp:
+		value->encoding.str_struct.offset = READ (buf, ut32);
+		if (value->encoding.str_struct.offset < debug_str_len) {
+			value->encoding.str_struct.string = strdup (
+				(const char *)(debug_str +
+					value->encoding.str_struct.offset));
+		}
+		break;
+
+	case DW_FORM_udata:
+		buf = r_uleb128 (buf, &value->encoding.data);
+		break;
+
+	case DW_FORM_ref_addr:
+		value->encoding.reference = READ (buf, ut64); // addr size of machine
+		break;
+
+	case DW_FORM_ref1:
+		value->encoding.reference = READ (buf, ut8);
+		break;
+
+	case DW_FORM_ref2:
+		value->encoding.reference = READ (buf, ut16);
+		break;
+
+	case DW_FORM_ref4:
+		value->encoding.reference = READ (buf, ut32);
+		break;
+
+	case DW_FORM_ref8:
+		value->encoding.reference = READ (buf, ut64);
+		break;
+
+	case DW_FORM_data1:
+		value->encoding.data = READ (buf, ut8);
+		break;
+
+	default:
+		return buf;
+	}
+
+	return buf;
+}
+
+static const ut8 *r_bin_dwarf_parse_comp_unit(const ut8 *obuf,
+		RBinDwarfCompUnit *cu, const RBinDwarfDebugAbbrev *da,
+		size_t offset, const ut8 *debug_str, size_t debug_str_len)
+{
+	const ut8 *buf = obuf, *buf_end = obuf + (cu->hdr.length - 7);
+	ut64 abbr_code;
+	size_t i;
+
+	while (buf < buf_end) {
+		if (cu->length && cu->capacity == cu->length)
+			r_bin_dwarf_expand_cu (cu);
+
+		buf = r_uleb128 (buf, &abbr_code);
+
+		r_bin_dwarf_init_die (&cu->dies[cu->length]);
+
+		if (!abbr_code) {
+			cu->dies[cu->length].abbrev_code = 0;
+			cu->length++;
+			continue;
+		}
+
+		cu->dies[cu->length].abbrev_code = abbr_code;
+		cu->dies[cu->length].tag = da->decls[abbr_code - 1].tag;
+		abbr_code += offset;
+
+		for (i = 0; i < da->decls[abbr_code - 1].length; i++) {
+			if (cu->dies[cu->length].length ==
+				cu->dies[cu->length].capacity)
+				r_bin_dwarf_expand_die (&cu->dies[cu->length]);
+			buf = r_bin_dwarf_parse_attr_value (buf,
+					&da->decls[abbr_code - 1].specs[i],
+					&cu->dies[cu->length].attr_values[i],
+					&cu->hdr, debug_str, debug_str_len);
+
+			cu->dies[cu->length].length++;
+		}
+
+		cu->length++;
+	}
+
+	return buf;
+}
+
+R_API int r_bin_dwarf_parse_info_raw(RBinDwarfDebugAbbrev *da,
+		const ut8 *obuf, size_t len,
+		const ut8 *debug_str, size_t debug_str_len)
+{
+	const ut8 *buf = obuf, *buf_end = obuf + len;
+	size_t curr_unit = 0, k, offset = 0;
+
+	RBinDwarfDebugInfo *inf, di;
+	inf = &di;
+
+	r_bin_dwarf_init_debug_info (inf);
+
+	while (buf < buf_end) {
+		if (inf->length >= inf->capacity)
+			break;
+
+		r_bin_dwarf_init_comp_unit (&inf->comp_units[curr_unit]);
+
+		inf->comp_units[curr_unit].offset = buf - obuf;
+		inf->comp_units[curr_unit].hdr.length = READ (buf, ut32);
+		inf->comp_units[curr_unit].hdr.version = READ (buf, ut16);
+
+		if (inf->comp_units[curr_unit].hdr.version != 2) {
+			fprintf(stderr, "DWARF: version %d is yet not supported\n",
+					inf->comp_units[curr_unit].hdr.version);
+
+			return -1;
+		}
+
+		inf->comp_units[curr_unit].hdr.abbrev_offset = READ (buf, ut32);
+		inf->comp_units[curr_unit].hdr.pointer_size = READ (buf, ut8);
+		inf->length++;
+
+		/* Linear search FIXME */
+		for (k = 0; k < da->decls->length; k++) {
+			if (da->decls[k].offset ==
+				inf->comp_units[curr_unit].hdr.abbrev_offset) {
+				offset = k;
+				break;
+			}
+		}
+
+		buf = r_bin_dwarf_parse_comp_unit(buf, &inf->comp_units[curr_unit],
+				da, offset, debug_str, debug_str_len);
+
+		curr_unit++;
+	}
+
+	r_bin_dwarf_dump_debug_info (stdout, inf);
+	r_bin_dwarf_free_debug_info (inf);
+
+	return 0;
+}
+
+static RBinDwarfDebugAbbrev *r_bin_dwarf_parse_abbrev_raw(const ut8 *obuf,
+		size_t len)
+{
+	const ut8 *buf = obuf, *buf_end = obuf + len;
+	ut64 tmp, spec1, spec2, offset;
+	ut8 has_children;
+	RBinDwarfAbbrevDecl *tmpdecl;
+
+	RBinDwarfDebugAbbrev *da = (RBinDwarfDebugAbbrev*)
+		malloc(sizeof(RBinDwarfDebugAbbrev));
+
+	r_bin_dwarf_init_debug_abbrev (da);
+
+	while (buf < buf_end) {
+		offset = buf - obuf;
+		buf = r_uleb128(buf, &tmp);
+		if (!tmp)
+			continue;
+
+		if (da->length == da->capacity)
+			r_bin_dwarf_expand_debug_abbrev(da);
+
+		tmpdecl = &da->decls[da->length];
+
+		r_bin_dwarf_init_abbrev_decl(tmpdecl);
+
+		tmpdecl->code = tmp;
+		buf = r_uleb128(buf, &tmp);
+		tmpdecl->tag = tmp;
+
+		tmpdecl->offset = offset;
+		has_children = READ (buf, ut8);
+		tmpdecl->has_children = has_children;
+		do {
+			if (tmpdecl->length == tmpdecl->capacity)
+				r_bin_dwarf_expand_abbrev_decl(tmpdecl);
+
+			buf = r_uleb128(buf, &spec1);
+			buf = r_uleb128(buf, &spec2);
+
+			tmpdecl->specs[tmpdecl->length].attr_name = spec1;
+			tmpdecl->specs[tmpdecl->length].attr_form = spec2;
+
+			tmpdecl->length++;
+		} while (spec1 && spec2);
+
+		da->length++;
+	}
+
+	dump_r_bin_dwarf_debug_abbrev(stdout, da);
+
+	return da;
 }
 
 RBinSection *getsection(RBin *a, const char *sn) {
@@ -311,15 +1233,28 @@ RBinSection *getsection(RBin *a, const char *sn) {
 	return NULL;
 }
 
-R_API int r_bin_dwarf_parse_info(RBin *a) {
-	ut8 *buf;
-	int len, ret;
+R_API int r_bin_dwarf_parse_info(RBinDwarfDebugAbbrev *da, RBin *a) {
+	ut8 *buf, *debug_str_buf = 0;
+	int len, debug_str_len, ret;
+	RBinSection *debug_str;
 	RBinSection *section = getsection (a, "debug_info");
 	if (section) {
+		debug_str = getsection (a, "debug_str");
+		if (debug_str) {
+			debug_str_len = debug_str->size;
+			debug_str_buf = malloc (debug_str_len);
+			r_buf_read_at (a->cur->buf, debug_str->offset,
+					debug_str_buf, debug_str_len);
+		}
+
 		len = section->size;
 		buf = malloc (len);
 		r_buf_read_at (a->cur->buf, section->offset, buf, len);
-		ret = r_bin_dwarf_parse_info_raw (buf);
+		ret = r_bin_dwarf_parse_info_raw (da, buf, len,
+				debug_str_buf, debug_str_len);
+		if (debug_str_buf) {
+			free (debug_str_buf);
+		}
 		free (buf);
 		return ret;
 	}
@@ -331,13 +1266,46 @@ R_API RList *r_bin_dwarf_parse_line(RBin *a) {
 	int len;
 	RBinSection *section = getsection (a, "debug_line");
 	if (section) {
-		RList *list = r_list_new ();
+		//RList *list = r_list_new ();
 		len = section->size;
 		buf = malloc (len);
 		r_buf_read_at (a->cur->buf, section->offset, buf, len);
-		r_bin_dwarf_parse_line_raw (buf, len, list);
+		r_bin_dwarf_parse_line_raw2 (a, buf, len, NULL, stdout);
 		free (buf);
-		return list;
+		return NULL;
 	}
 	return NULL;
+}
+
+R_API RList *r_bin_dwarf_parse_aranges(RBin *a) {
+	ut8 *buf;
+	size_t len;
+	RBinSection *section = getsection (a, "debug_aranges");
+
+	if (section) {
+		len = section->size;
+		buf = malloc (len);
+		r_buf_read_at (a->cur->buf, section->offset, buf, len);
+		r_bin_dwarf_parse_aranges_raw (buf, len);
+		free(buf);
+	}
+
+	return NULL;
+}
+
+R_API RBinDwarfDebugAbbrev *r_bin_dwarf_parse_abbrev(RBin *a) {
+	ut8 *buf;
+	size_t len;
+	RBinSection *section = getsection (a, "debug_abbrev");
+	RBinDwarfDebugAbbrev *da;
+
+	if (section) {
+		len = section->size;
+		buf = malloc (len);
+		r_buf_read_at (a->cur->buf, section->offset, buf, len);
+		da = r_bin_dwarf_parse_abbrev_raw (buf, len);
+		free (buf);
+	}
+
+	return da;
 }

--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -276,8 +276,14 @@ static int bin_dwarf (RCore *core, int mode) {
 	} else {
 		// TODO: complete and speed-up support for dwarf
 		if (r_config_get_i (core->config, "bin.dwarf")) {
-			r_bin_dwarf_parse_info (core->bin);
+			RBinDwarfDebugAbbrev *da;
+			da = r_bin_dwarf_parse_abbrev (core->bin);
+			r_bin_dwarf_parse_info (da, core->bin);
+			r_bin_dwarf_parse_aranges (core->bin);
 			list = r_bin_dwarf_parse_line (core->bin);
+
+			r_bin_dwarf_free_debug_abbrev(da);
+			free(da);
 		}
 	}
 	if (!list) return R_FALSE;

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -357,8 +357,10 @@ R_API char *r_bin_meta_get_source_line(RBin *bin, ut64 addr);
 R_API ut64 r_bin_wr_scn_resize(RBin *bin, const char *name, ut64 size);
 R_API int r_bin_wr_rpath_del(RBin *bin);
 R_API int r_bin_wr_output(RBin *bin, const char *filename);
-R_API int r_bin_dwarf_parse_info(RBin *a);
+R_API int r_bin_dwarf_parse_info(RBinDwarfDebugAbbrev *da, RBin *a);
 R_API RList *r_bin_dwarf_parse_line(RBin *a);
+R_API RList *r_bin_dwarf_parse_aranges(RBin *a);
+R_API RBinDwarfDebugAbbrev *r_bin_dwarf_parse_abbrev(RBin *a);
 
 /* plugin pointers */
 extern RBinPlugin r_bin_plugin_any;

--- a/libr/include/r_bin_dwarf.h
+++ b/libr/include/r_bin_dwarf.h
@@ -28,6 +28,8 @@ extern "C" {
 #define DW_LNE_set_address              0x02
 #define DW_LNE_define_file              0x03
 #define DW_LNE_set_discriminator        0x04  /* DWARF4 */
+#define DW_LNE_lo_user			0x80
+#define DW_LNE_hi_user			0xff
 
 /* HP extensions. */
 #define DW_LNE_HP_negate_is_UV_update       0x11 /* 17 HP */
@@ -114,6 +116,414 @@ extern "C" {
 #define DW_TAG_type_unit                0x41  /* DWARF4 */
 #define DW_TAG_rvalue_reference_type    0x42  /* DWARF4 */
 #define DW_TAG_template_alias           0x43  /* DWARF4 */
+#define DW_TAG_lo_user			0x4080
+#define DW_TAG_hi_user			0xffff
+
+#define DW_CHILDREN_no			0x00
+#define DW_CHILDREN_yes			0x01
+
+#define DW_AT_sibling			0x01
+#define DW_AT_location			0x02
+#define DW_AT_name			0x03
+#define DW_AT_ordering			0x09
+#define DW_AT_byte_size			0x0b
+#define DW_AT_bit_offset		0x0c
+#define DW_AT_bit_size			0x0d
+#define DW_AT_stmt_list			0x10
+#define DW_AT_low_pc			0x11
+#define DW_AT_high_pc			0x12
+#define DW_AT_language			0x13
+#define DW_AT_discr			0x15
+#define DW_AT_discr_value		0x16
+#define DW_AT_visibility		0x17
+#define DW_AT_import			0x18
+#define DW_AT_string_length		0x19
+#define DW_AT_common_reference		0x1a
+#define DW_AT_comp_dir			0x1b
+#define DW_AT_const_value		0x1c
+#define DW_AT_containing_type		0x1d
+#define DW_AT_default_value		0x1e
+#define DW_AT_inline			0x20
+#define DW_AT_is_optional		0x21
+#define DW_AT_lower_bound		0x22
+#define DW_AT_producer			0x25
+#define DW_AT_prototyped		0x27
+#define DW_AT_return_addr		0x2a
+#define DW_AT_start_scope		0x2c
+#define DW_AT_stride_size		0x2e
+#define DW_AT_upper_bound		0x2f
+#define DW_AT_abstract_origin		0x31
+#define DW_AT_accessibility		0x32
+#define DW_AT_address_class		0x33
+#define DW_AT_artificial		0x34
+#define DW_AT_base_types		0x35
+#define DW_AT_calling_convention	0x36
+#define DW_AT_count			0x37
+#define DW_AT_data_member_location	0x38
+#define DW_AT_decl_column		0x39
+#define DW_AT_decl_file			0x3a
+#define DW_AT_decl_line			0x3b
+#define DW_AT_declaration		0x3c
+#define DW_AT_discr_list		0x3d
+#define DW_AT_encoding			0x3e
+#define DW_AT_external			0x3f
+#define DW_AT_frame_base		0x40
+#define DW_AT_friend			0x41
+#define DW_AT_identifier_case		0x42
+#define DW_AT_macro_info		0x43
+#define DW_AT_namelist_item		0x44
+#define DW_AT_priority			0x45
+#define DW_AT_segment			0x46
+#define DW_AT_specification		0x47
+#define DW_AT_static_link		0x48
+#define DW_AT_type			0x49
+#define DW_AT_use_location		0x4a
+#define DW_AT_variable_parameter	0x4b
+#define DW_AT_virtuality		0x4c
+#define DW_AT_vtable_elem_location	0x4d
+#define DW_AT_allocated			0x4e
+#define DW_AT_associated		0x4f
+#define DW_AT_data_location		0x50
+#define DW_AT_byte_stride		0x51
+#define DW_AT_entry_pc			0x52
+#define DW_AT_use_UTF8			0x53
+#define DW_AT_extension			0x54
+#define DW_AT_ranges			0x55
+#define DW_AT_trampoline		0x56
+#define DW_AT_call_column		0x57
+#define DW_AT_call_file			0x58
+#define DW_AT_call_line			0x59
+#define DW_AT_description		0x5a
+#define DW_AT_binary_scale		0x5b
+#define DW_AT_decimal_scale		0x5c
+#define DW_AT_small			0x5d
+#define DW_AT_decimal_sign		0x5e
+#define DW_AT_digit_count		0x5f
+#define DW_AT_picture_string		0x60
+#define DW_AT_mutable			0x61
+#define DW_AT_threads_scaled		0x62
+#define DW_AT_explicit			0x63
+#define DW_AT_object_pointer		0x64
+#define DW_AT_endianity			0x65
+#define DW_AT_elemental			0x66
+#define DW_AT_pure			0x67
+#define DW_AT_recursive			0x68
+#define DW_AT_signature			0x69
+#define DW_AT_main_subprogram		0x6a
+#define DW_AT_data_big_offset		0x6b
+#define DW_AT_const_expr		0x6c
+#define DW_AT_enum_class		0x6d
+#define DW_AT_linkage_name		0x6e
+#define DW_AT_lo_user			0x2000
+#define DW_AT_hi_user			0x3fff
+
+#define DW_FORM_addr			0x01
+#define DW_FORM_block2			0x03
+#define DW_FORM_block4			0x04
+#define DW_FORM_data2			0x05
+#define DW_FORM_data4			0x06
+#define DW_FORM_data8			0x07
+#define DW_FORM_string			0x08
+#define DW_FORM_block			0x09
+#define DW_FORM_block1			0x0a
+#define DW_FORM_data1			0x0b
+#define DW_FORM_flag			0x0c
+#define DW_FORM_sdata			0x0d
+#define DW_FORM_strp			0x0e
+#define DW_FORM_udata			0x0f
+#define DW_FORM_ref_addr		0x10
+#define DW_FORM_ref1			0x11
+#define DW_FORM_ref2			0x12
+#define DW_FORM_ref4			0x13
+#define DW_FORM_ref8			0x14
+#define DW_FORM_ref_udata		0x15
+#define DW_FORM_indirect		0x16
+#define DW_FORM_sec_offset		0x17
+#define DW_FORM_exprloc			0x18
+#define DW_FORM_flag_present		0x19
+#define DW_FORM_ref_sig8		0x20
+
+#define DW_OP_addr			0x03
+#define DW_OP_deref			0x06
+#define DW_OP_const1u			0x08
+#define DW_OP_const1s			0x09
+#define DW_OP_const2u			0x0a
+#define DW_OP_const2s			0x0b
+#define DW_OP_const4u			0x0c
+#define DW_OP_const4s			0x0d
+#define DW_OP_const8u			0x0e
+#define DW_OP_const8s			0x0f
+#define DW_OP_constu			0x10
+#define DW_OP_consts			0x11
+#define DW_OP_dup			0x12
+#define DW_OP_drop			0x13
+#define DW_OP_over			0x14
+#define DW_OP_pick			0x15
+#define DW_OP_swap			0x16
+#define DW_OP_rot			0x17
+#define DW_OP_xderef			0x18
+#define DW_OP_abs			0x19
+#define DW_OP_and			0x1a
+#define DW_OP_div			0x1b
+#define DW_OP_minus			0x1c
+#define DW_OP_mod			0x1d
+#define DW_OP_mul			0x1e
+#define DW_OP_neg			0x1f
+#define DW_OP_not			0x20
+#define DW_OP_or			0x21
+#define DW_OP_plus			0x22
+#define DW_OP_plus_uconst		0x23
+#define DW_OP_shl			0x24
+#define DW_OP_shr			0x25
+#define DW_OP_shra			0x26
+#define DW_OP_xor			0x27
+#define DW_OP_skip			0x2f
+#define DW_OP_bra			0x28
+#define DW_OP_eq			0x29
+#define DW_OP_ge			0x2a
+#define DW_OP_gt			0x2b
+#define DW_OP_le			0x2c
+#define DW_OP_lt			0x2d
+#define DW_OP_ne			0x2e
+#define DW_OP_lit0			0x30
+#define DW_OP_lit1			0x31
+#define DW_OP_lit2			0x32
+#define DW_OP_lit3			0x33
+#define DW_OP_lit4			0x34
+#define DW_OP_lit5			0x35
+#define DW_OP_lit6			0x36
+#define DW_OP_lit7			0x37
+#define DW_OP_lit8			0x38
+#define DW_OP_lit9			0x39
+#define DW_OP_lit10			0x3a
+#define DW_OP_lit11			0x3b
+#define DW_OP_lit12			0x3c
+#define DW_OP_lit13			0x3d
+#define DW_OP_lit14			0x3e
+#define DW_OP_lit15			0x3f
+#define DW_OP_lit16			0x40
+#define DW_OP_lit17			0x41
+#define DW_OP_lit18			0x42
+#define DW_OP_lit19			0x43
+#define DW_OP_lit20			0x44
+#define DW_OP_lit21			0x45
+#define DW_OP_lit22			0x46
+#define DW_OP_lit23			0x47
+#define DW_OP_lit24			0x48
+#define DW_OP_lit25			0x49
+#define DW_OP_lit26			0x4a
+#define DW_OP_lit27			0x4b
+#define DW_OP_lit28			0x4c
+#define DW_OP_lit29			0x4d
+#define DW_OP_lit30			0x4e
+#define DW_OP_lit31			0x4f
+#define DW_OP_reg0			0x50
+#define DW_OP_reg1			0x51
+#define DW_OP_reg2			0x52
+#define DW_OP_reg3			0x53
+#define DW_OP_reg4			0x54
+#define DW_OP_reg5			0x55
+#define DW_OP_reg6			0x56
+#define DW_OP_reg7			0x57
+#define DW_OP_reg8			0x58
+#define DW_OP_reg9			0x59
+#define DW_OP_reg10			0x5a
+#define DW_OP_reg11			0x5b
+#define DW_OP_reg12			0x5c
+#define DW_OP_reg13			0x5d
+#define DW_OP_reg14			0x5e
+#define DW_OP_reg15			0x5f
+#define DW_OP_reg16			0x60
+#define DW_OP_reg17			0x61
+#define DW_OP_reg18			0x62
+#define DW_OP_reg19			0x63
+#define DW_OP_reg20			0x64
+#define DW_OP_reg21			0x65
+#define DW_OP_reg22			0x66
+#define DW_OP_reg23			0x67
+#define DW_OP_reg24			0x68
+#define DW_OP_reg25			0x69
+#define DW_OP_reg26			0x6a
+#define DW_OP_reg27			0x6b
+#define DW_OP_reg28			0x6c
+#define DW_OP_reg29			0x6d
+#define DW_OP_reg30			0x6e
+#define DW_OP_reg31			0x6f
+#define DW_OP_breg0			0x70
+#define DW_OP_breg1			0x71
+#define DW_OP_breg2			0x72
+#define DW_OP_breg3			0x73
+#define DW_OP_breg4			0x74
+#define DW_OP_breg5			0x75
+#define DW_OP_breg6			0x76
+#define DW_OP_breg7			0x77
+#define DW_OP_breg8			0x78
+#define DW_OP_breg9			0x79
+#define DW_OP_breg10			0x7a
+#define DW_OP_breg11			0x7b
+#define DW_OP_breg12			0x7c
+#define DW_OP_breg13			0x7d
+#define DW_OP_breg14			0x7e
+#define DW_OP_breg15			0x7f
+#define DW_OP_breg16			0x80
+#define DW_OP_breg17			0x81
+#define DW_OP_breg18			0x82
+#define DW_OP_breg19			0x83
+#define DW_OP_breg20			0x84
+#define DW_OP_breg21			0x85
+#define DW_OP_breg22			0x86
+#define DW_OP_breg23			0x87
+#define DW_OP_breg24			0x88
+#define DW_OP_breg25			0x89
+#define DW_OP_breg26			0x8a
+#define DW_OP_breg27			0x8b
+#define DW_OP_breg28			0x8c
+#define DW_OP_breg29			0x8d
+#define DW_OP_breg30			0x8e
+#define DW_OP_breg31			0x8f
+#define DW_OP_regx			0x90
+#define DW_OP_fbreg			0x91
+#define DW_OP_bregx			0x92
+#define DW_OP_piece			0x93
+#define DW_OP_deref_size		0x94
+#define DW_OP_xderef_size		0x95
+#define DW_OP_nop			0x96
+#define DW_OP_push_object_address	0x97
+#define DW_OP_call2			0x98
+#define DW_OP_call4			0x99
+#define DW_OP_call_ref			0x9a
+#define DW_OP_form_tls_address		0x9b
+#define DW_OP_call_frame_cfa		0x9c
+#define DW_OP_bit_piece			0x9d
+#define DW_OP_implicit_value		0x9e
+#define DW_OP_stack_value		0x9f
+#define DW_OP_lo_user			0xe0
+#define DW_OP_hi_user			0xff
+
+
+#define DW_ATE_address			0x01
+#define DW_ATE_boolean			0x02
+#define DW_ATE_complex_float		0x03
+#define DW_ATE_float			0x04
+#define DW_ATE_signed			0x05
+#define DW_ATE_signed_char		0x06
+#define DW_ATE_unsigned			0x07
+#define DW_ATE_unsigned_char		0x08
+#define DW_ATE_imaginary_float		0x09
+#define DW_ATE_packed_decimal		0x0a
+#define DW_ATE_numeric_string		0x0b
+#define DW_ATE_edited			0x0c
+#define DW_ATE_signed_fixed		0x0d
+#define DW_ATE_unsigned_fixed		0x0e
+#define DW_ATE_decimal_float		0x0f
+#define DW_ATE_UTF			0x10
+#define DW_ATE_lo_user			0x80
+#define DW_ATE_hi_user			0xff
+
+#define DW_DS_unsigned			0x01
+#define DW_DS_leading_overpunch		0x02
+#define DW_DS_trailing_overpunch	0x03
+#define DW_DS_leading_separate		0x04
+#define DW_DS_trailing_separate		0x05
+
+#define DW_END_default			0x00
+#define DW_END_big			0x01
+#define DW_END_little			0x02
+#define DW_END_lo_user			0x40
+#define DW_END_hi_user			0xff
+
+#define DW_ACCESS_public		0x01
+#define DW_ACCESS_protected		0x02
+#define DW_ACCESS_private		0x03
+
+#define DW_VIS_local			0x01
+#define DW_VIS_exported			0x02
+#define DW_VIS_qualified		0x03
+
+#define DW_VIRTUALITY_none		0x00
+#define DW_VIRTUALITY_virtual		0x01
+#define DW_VIRTUALITY_pure_virtual	0x02
+
+#define DW_LANG_C89			0x0001
+#define DW_LANG_C			0x0002
+#define DW_LANG_Ada83			0x0003
+#define DW_LANG_C_plus_plus		0x0004
+#define DW_LANG_Cobol74			0x0005
+#define DW_LANG_Cobol85			0x0006
+#define DW_LANG_Fortran77		0x0007
+#define DW_LANG_Fortran90		0x0008
+#define DW_LANG_Pascal83		0x0009
+#define DW_LANG_Modula2			0x000a
+#define DW_LANG_Java			0x000b
+#define DW_LANG_C99			0x000c
+#define DW_LANG_Ada95			0x000d
+#define DW_LANG_Fortran95		0x000e
+#define DW_LANG_PLI			0x000f
+#define DW_LANG_ObjC			0x0010
+#define DW_LANG_ObjC_plus_plus		0x0011
+#define DW_LANG_UPC			0x0012
+#define DW_LANG_D			0x0013
+#define DW_LANG_Python			0x0014
+#define DW_LANG_lo_user			0x8000
+#define DW_LANG_hi_user			0xffff
+
+#define DW_ID_case_sensitive		0x00
+#define DW_ID_up_case			0x01
+#define DW_ID_down_case			0x02
+#define DW_ID_case_insensitive		0x03
+
+#define DW_CC_normal			0x01
+#define DW_CC_program			0x02
+#define DW_CC_nocall			0x03
+#define DW_CC_lo_user			0x40
+#define DW_CC_hi_user			0xff
+
+#define DW_INL_not_inlined		0x00
+#define DW_INL_inlined			0x01
+#define DW_INL_declared_not_inlined	0x02
+#define DW_INL_declared_inlined		0x03
+
+#define DW_ORD_row_major		0x00
+#define DW_ORD_col_major		0x01
+
+#define DW_DSC_label			0x00
+#define DW_DSC_range			0x01
+
+#define DW_MACINFO_define		0x01
+#define DW_MACINFO_undef		0x02
+#define DW_MACINFO_start_file		0x03
+#define DW_MACINFO_end_file		0x04
+#define DW_MACINFO_vendor_ext		0xff
+
+#define DW_CFA_advance_loc		0x40
+#define DW_CFA_offset			0x80
+#define DW_CFA_restore			0xc0
+
+#define DW_CFA_nop			0x00
+#define DW_CFA_set_loc			0x01
+#define DW_CFA_advance_loc1		0x02
+#define DW_CFA_advance_loc2		0x03
+#define DW_CFA_advance_loc4		0x04
+#define DW_CFA_offse_extended		0x05
+#define DW_CFA_restore_extended		0x06
+#define DW_CFA_undefined		0x07
+#define DW_CFA_same_value		0x08
+#define DW_CFA_register			0x09
+#define DW_CFA_remember_state		0x0a
+#define DW_CFA_restore_state		0x0b
+#define DW_CFA_def_cfa			0x0c
+#define DW_CFA_def_cfa_register		0x0d
+#define DW_CFA_def_cfa_offset		0x0e
+#define DW_CFA_def_cfa_expression	0x0f
+#define DW_CFA_expression		0x10
+#define DW_CFA_offset_extended_sf	0x11
+#define DW_CFA_def_cfa_sf		0x12
+#define DW_CFA_def_cfa_offset_sf	0x13
+#define DW_CFA_val_offset		0x14
+#define DW_CFA_val_offset_sf		0x15
+#define DW_CFA_val_expression		0x16
+#define DW_CFA_lo_user			0x1c
+#define DW_CFA_hi_user			0x3f
 
 typedef struct {
 	ut32 total_length;
@@ -147,10 +557,169 @@ typedef struct {
 	unsigned int line;
 	unsigned int column;
 } RBinDwarfRow;
+
+typedef struct {
+	ut32 part1;
+	ut64 part2;
+} initial_length;
+
+#define DWARF_INIT_LEN_64	0xffffffff
+typedef union {
+	ut32 offset32;
+	ut64 offset64;
+} section_offset;
+
+typedef struct {
+	initial_length unit_length;
+	ut16 version;
+	section_offset debug_abbrev_offset;
+	ut8 address_size;
+} RBinDwarfCompilationUnitHeader;
+
+typedef struct {
+	initial_length unit_length;
+	ut16 version;
+	section_offset debug_abbrev_offset;
+	ut8 address_size;
+	ut64 type_signature;
+	section_offset type_offset;
+} RBinDwarfTypeUnitHeader;
+
+typedef struct {
+	initial_length unit_length;
+	ut16 version;
+	section_offset debug_info_offset;
+	ut8 address_size;
+	ut8 segment_size;
+} RBinDwarfAddressRangeTable;
+
+typedef struct {
+	ut64	attr_name;
+	ut64	attr_form;
+} RBinDwarfAttrSpec;
+
+typedef struct {
+	ut64	length;
+	ut8	*data;
+} RBinDwarfBlock;
+
+typedef union {
+	ut64	address;
+	RBinDwarfBlock block;
+	ut64	constant;
+	ut8	flag;
+	ut64	data;
+	st64	sdata;
+	ut64	reference;
+	struct str_structt {
+		char	*string;
+		ut64	offset;
+	} str_struct;
+} RBinDwarfAttrEnc;
+
+typedef struct {
+	ut64 name;
+	ut64 form;
+	RBinDwarfAttrEnc encoding;
+} RBinDwarfAttrValue;
+
+typedef struct {
+	ut32	length;
+	ut16	version;
+	ut32	abbrev_offset;
+	ut8	pointer_size;
+} RBinDwarfCompUnitHdr;
+
+typedef struct {
+	ut64	tag;
+	ut64	abbrev_code;
+	size_t	length;
+	size_t	capacity;
+	RBinDwarfAttrValue *attr_values;
+} RBinDwarfDIE;
+
+typedef struct {
+	RBinDwarfCompUnitHdr hdr;
+	ut64	offset;
+	size_t	length;
+	size_t	capacity;
+	RBinDwarfDIE *dies;
+} RBinDwarfCompUnit;
+
+#define COMP_UNIT_CAPACITY	8
+#define DEBUG_INFO_CAPACITY	8
+typedef struct {
+	size_t length;
+	size_t capacity;
+	RBinDwarfCompUnit *comp_units;
+} RBinDwarfDebugInfo;
+
+#define	ABBREV_DECL_CAP		8
+
+typedef struct {
+	ut64 code;
+	ut64 tag;
+	ut64 offset;
+	ut8 has_children;
+	size_t length;
+	size_t capacity;
+	RBinDwarfAttrSpec *specs;
+} RBinDwarfAbbrevDecl;
+
+#define DEBUG_ABBREV_CAP	16
+
+typedef struct {
+	size_t length;
+	size_t capacity;
+	RBinDwarfAbbrevDecl *decls;
+} RBinDwarfDebugAbbrev;
+
+#define		DWARF_FALSE	0
+#define		DWARF_TRUE	1
+
+typedef struct {
+	ut64 address;
+	ut64 op_index;
+	ut64 file;
+	ut64 line;
+	ut64 column;
+	ut8 is_stmt;
+	ut8 basic_block;
+	ut8 end_sequence;
+	ut8 prologue_end;
+	ut8 epilogue_begin;
+	ut64 isa;
+	ut64 discriminator;
+} RBinDwarfSMRegisters;
+
+typedef struct {
+	char *name;
+	ut32 id_idx, mod_time, file_len;
+} file_entry;
+
+typedef struct {
+	initial_length unit_length;
+	ut16 version;
+	ut64 header_length;
+	ut8 min_inst_len;
+	ut8 max_ops_per_inst;
+	ut8 default_is_stmt;
+	char line_base;
+	ut8 line_range;
+	ut8 opcode_base;
+	ut8 *std_opcode_lengths;
+	char **include_directories;
+	file_entry *file_names;
+	size_t file_names_count;
+} RBinDwarfLNPHeader;
+
 #define r_bin_dwarf_line_new(o,a,f,l) o->address=a, o->file = strdup (f?f:""), o->line = l, o->column =0,o
 
-R_API int r_bin_dwarf_parse_info_raw(const ut8 *obuf);
+R_API int r_bin_dwarf_parse_info_raw(RBinDwarfDebugAbbrev *da,
+		const ut8 *obuf, size_t len,
+		const ut8 *debug_str, size_t debug_str_len);
 
+R_API void r_bin_dwarf_free_debug_abbrev(RBinDwarfDebugAbbrev *da);
 #ifdef __cplusplus
 }
 #endif

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -550,8 +550,8 @@ R_API void r_big_mod(RNumBig *c, RNumBig *a, RNumBig *b);
 #endif
 
 /* uleb */
-R_API const ut8 *r_uleb128 (const ut8 *data, ut32 *v);
-R_API const ut8 *r_leb128 (const ut8 *data, st32 *v);
+R_API const ut8 *r_uleb128 (const ut8 *data, ut64 *v);
+R_API const ut8 *r_leb128 (const ut8 *data, st64 *v);
 #endif
 
 /* constr */

--- a/libr/util/uleb128.c
+++ b/libr/util/uleb128.c
@@ -2,9 +2,9 @@
 
 /* dex/dwarf uleb128 implementation */
 
-R_API const ut8 *r_uleb128 (const ut8 *data, ut32 *v) {
+R_API const ut8 *r_uleb128 (const ut8 *data, ut64 *v) {
 	ut8 c;
-	ut32 s, sum;
+	ut64 s, sum;
 	for (s = sum = 0; ; s += 7) {
 		c = *(data++) & 0xff;
 		sum |= ((ut32) (c&0x7f) << s);
@@ -14,16 +14,18 @@ R_API const ut8 *r_uleb128 (const ut8 *data, ut32 *v) {
 	return data;
 }
 
-R_API const ut8 *r_leb128 (const ut8 *data, st32 *v) {
+R_API const ut8 *r_leb128 (const ut8 *data, st64 *v) {
 	ut8 c;
-	st32 s, sum;
-	for (s = sum = 0; ;  s+= 7) {
-		c = *data++ & 0x0ff;
-		sum |= ((st32) ((*data++) & 0x7f) << s);
-		if (!(c&0x80)) break;
+	st64 s, sum;
+	for (s = sum = 0;;) {
+		c = *(data++) & 0x0ff;
+		sum |= ((st64) (c & 0x7f) << s);
+		s += 7;
+		if (!(c & 0x80)) break;
 	}
-	if ((s < (8 * sizeof (sum))) && (c & 0x40))
-		sum |= -(((long)1) << s);
+	if ((s < (8 * sizeof (sum))) && (c & 0x40)) {
+		sum |= -(1 << s);
+	}
 	if (v) *v = sum;
 	return data;
 }


### PR DESCRIPTION
Better support for DWARF. What works now: DWARF 2 debug_info, debug_abbrev, debug_lines parsing. gcc always generates debug_lines in version 2 format, so it should work well for most of the binaries.

Testing done: Compared output of 'id' command with objdump -g on r2 binary itself (compiled with -gdwarf-2 flag). DWARF {3,4} are to follow.
