### PR TITLE
Fix clang build (unicode characters outside of literals)

### DIFF
--- a/binr/preload/alloc.c
+++ b/binr/preload/alloc.c
@@ -10,7 +10,7 @@
 #include <string.h>
 
 #if USE_MALLOC
-R_API void r_initmem(char *p, size_t s) { }
+R_API void r_initmem(char *p, size_t s) { }
 R_API void* r_malloc(size_t s) { return malloc (s); }
 R_API void r_free(void *p) { free (s); }
 #else

--- a/binr/r2agent/r2agent.c
+++ b/binr/r2agent/r2agent.c
@@ -14,7 +14,7 @@ int main() {
 #include "index.h"
 
 static int usage (int v) {
-	printf ("Usage: r2agent [-adhs] [-p port]\n"
+	printf ("Usage: r2agent [-adhs] [-p port]\n"
 	"  -a       listen for everyone (localhost by default)\n"
 	"  -d       run in daemon mode (background)\n"
 	"  -h       show this help message\n"

--- a/libr/asm/arch/8051/8051.c
+++ b/libr/asm/arch/8051/8051.c
@@ -7,7 +7,7 @@ http://www.keil.com/support/man/docs/is51/is51_opcodes.htm
 
 The classic 8051 provides 4 register banks of 8 registers each.
 These register banks are mapped into the DATA memory area at
-address 0 – 0x1F. In addition the CPU provides a 8-bit A
+address 0 - 0x1F. In addition the CPU provides a 8-bit A
 (accumulator) and B register and a 16-bit DPTR (data pointer)
 for addressing XDATA and CODE memory. These registers are also
 mapped into the SFR space as special function registers.
@@ -139,9 +139,9 @@ R_AII Op8051 do8051struct(const ut8 *buf, int len) {
 	case 0xc3: return _{ "clr c", 1, NONE };
 	case 0xd3: return _{ "setb c", 1, NONE };
 
-	case 0xe0: return _{ "movx a, @dptr", 1, NONE };
-	case 0xe2: return _{ "movx a, @r0", 1, NONE };
-	case 0xe3: return _{ "movx a, @r1", 1, NONE };
+	case 0xe0: return _{ "movx a, @dptr", 1, NONE };
+	case 0xe2: return _{ "movx a, @r0", 1, NONE };
+	case 0xe3: return _{ "movx a, @r1", 1, NONE };
 	case 0xf0: return _{ "movx @dptr, a", 1, NONE };
 	case 0xf2: return _{ "movx @r0, a", 1, NONE };
 	case 0xf3: return _{ "movx @r1, a", 1, NONE };

--- a/libr/asm/arch/tms320/c55x/table_e.h
+++ b/libr/asm/arch/tms320/c55x/table_e.h
@@ -691,7 +691,7 @@
 		.i_list = NULL,
 		.m_list = NULL,
 		.f_list = (insn_flag_t []) { INSN_FLAG(0,E), INSN_FLAG(8,FDDD), INSN_FLAG(12,k4),  LIST_END },
-		.syntax = INSN_SYNTAX(MOV –k4, dst),
+		.syntax = INSN_SYNTAX(MOV -k4, dst),
 	},
 },
 {
@@ -733,7 +733,7 @@
 				.i_list = NULL,
 				.m_list = (insn_mask_t []) { INSN_MASK(12,1,0), INSN_MASK(14,2,1),  LIST_END },
 				.f_list = (insn_flag_t []) { INSN_FLAG(0,E), INSN_FLAG(8,FDDD),  LIST_END },
-				.syntax = INSN_SYNTAX(SFTS dst, #−1),
+				.syntax = INSN_SYNTAX(SFTS dst, #-1),
 			},
 			{
 				// 01x1FDDD0100010E
@@ -971,7 +971,7 @@
 				.i_list = NULL,
 				.m_list = (insn_mask_t []) { INSN_MASK(8,3,1),  LIST_END },
 				.f_list = (insn_flag_t []) { INSN_FLAG(0,E), INSN_FLAG(12,FDDD),  LIST_END },
-				.syntax = INSN_SYNTAX(SFTL dst, #−1),
+				.syntax = INSN_SYNTAX(SFTL dst, #-1),
 			},
 			{
 				// FDDDx0100101000E

--- a/libr/asm/arch/tms320/tms320_dasm.c
+++ b/libr/asm/arch/tms320/tms320_dasm.c
@@ -473,7 +473,7 @@ const char * get_smem_str(ut8 key, char * str)
 	case 0x51: return "port(#k16)";
 	case 0x71: return "*CDP";
 	case 0x91: return "*CDP+";
-	case 0xB1: return "*CDP−";
+	case 0xB1: return "*CDP-";
 	case 0xD1: return "*CDP(#K16)";
 	case 0xF1: return "*+CDP(#K16)";
 	}
@@ -481,15 +481,15 @@ const char * get_smem_str(ut8 key, char * str)
 	switch (key & 0x1F) {
 	case 0x01: return "*ARn";
 	case 0x03: return "*ARn+";
-	case 0x05: return "*ARn−";
+	case 0x05: return "*ARn-";
 		// TODO:
 		//	C54CM:0 => *(ARn + T0)
 		//	C54CM:1 => *(ARn + AR0)
 	case 0x07: return "*(ARn + T0)";
 		// TODO:
-		//	C54CM:0 => *(ARn – T0)
-		//	C54CM:1 => *(ARn – AR0)
-	case 0x09: return "*(ARn – T0)";
+		//	C54CM:0 => *(ARn - T0)
+		//	C54CM:1 => *(ARn - AR0)
+	case 0x09: return "*(ARn - T0)";
 		// TODO:
 		//	C54CM:0 => *ARn(T0)
 		//	C54CM:1 => *ARn(AR0)
@@ -535,7 +535,7 @@ const char * get_mmm_str(ut8 key, char * str)
 	default:
 	case 0x00: return "*ARn";
 	case 0x01: return "*ARn+";
-	case 0x02: return "*ARn−";
+	case 0x02: return "*ARn-";
 		// TODO:
 		//	C54CM:0 => *(ARn + T0)
 		//	C54CM:1 => *(ARn + AR0)

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1469,7 +1469,7 @@ R_API int r_core_cmd_foreach(RCore *core, const char *cmd, char *each) {
 						r_core_seek (core, flag->offset, 1);
 						//r_cons_printf ("# @@ 0x%08"PFMT64x" (%s)\n", core->offset, flag->name);
 					//	r_cons_printf ("0x%08"PFMT64x" %s\n", core->offset, flag->name);
-						eprintf ("# 0x%08"PFMT64x": %s\n", flag->offset, cmd);
+						eprintf ("# 0x%08"PFMT64x": %s\n", flag->offset, cmd);
 						r_core_cmd (core, cmd, 0);
 					}
 				}

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -49,7 +49,7 @@ static int cmd_flag(void *data, const char *input) {
 			ret = r_flag_relocate (core->flags, from, mask, to);
 			eprintf ("Relocated %d flags\n", ret);
 		} else {
-			eprintf ("Usage: fR [from] [to] ([mask])\n");
+			eprintf ("Usage: fR [from] [to] ([mask])\n");
 			eprintf ("Example to relocate PIE flags on debugger:\n"
 				" > fR entry0 `dm~:1[1]`\n");
 		}

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -119,7 +119,7 @@ static int cmd_help(void *data, const char *input) {
 		n = (input[1] != '\0') ? r_num_math (core->num, input+2) : 0;
 		switch (input[1]) {
 		case '?':
-			r_cons_printf ("|Usage: ?v[id][ num]  # Show value\n"
+			r_cons_printf ("|Usage: ?v[id][ num]  # Show value\n"
 				"| No argument shows $? value\n"
 				"|?vi will show in decimal instead of hex\n");
 			break;

--- a/libr/debug/p/native/arm.c
+++ b/libr/debug/p/native/arm.c
@@ -24,7 +24,7 @@ Flags
 
 	// signed
 	GE = NV || nv          ((n&&v) || (!n&&!v))
-	GT = NzV || nzv        ((n&&!z&&v) || (!n&&!z&&!v))
+	GT = NzV || nzv        ((n&&!z&&v) || (!n&&!z&&!v))
 	LT = Nv || nV          ((n&&!v)|| (!n&&v))
 	LE = Z || Nv || nV     z || (n&&!v) || (!n && v)
 

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -543,7 +543,7 @@ R_API void r_print_hexdiff(RPrint *p, ut64 aa, const ut8* _a, ut64 ba, const ut8
 			r_print_cursor (p, i+j, 0);
 		}
 		if (scndcol) {
-			p->printf (" %c 0x%08"PFMT64x" ", linediff, ba+i);
+			p->printf (" %c 0x%08"PFMT64x" ", linediff, ba+i);
 			for (j=0;j<min;j++) {
 				*fmt = color; 
 				r_print_cursor (p, i+j, 1);

--- a/shlr/rar/bin.c
+++ b/shlr/rar/bin.c
@@ -60,12 +60,12 @@ typedef struct rar_block_archive_t {
 	unsigned char rarversion; // datetime
 	unsigned char packmethod;
 #if 0
-	0×30 – storing
-	0×31 – fastest compression
-	0×32 – fast compression
-	0×33 – normal compression
-	0×34 – good compression
-	0×35 – best compression
+	0x30 - storing
+	0x31 - fastest compression
+	0x32 - fast compression
+	0x33 - normal compression
+	0x34 - good compression
+	0x35 - best compression
 #endif
 	unsigned short filenamesize;
 	unsigned int file_attr;
@@ -99,19 +99,19 @@ struct filehdr {
 };
 #if 0
 HIGH_PACK_SIZE  High 4 bytes of 64 bit value of compressed file size.
-4 bytes         Optional value, presents only if bit 0×100 in HEAD_FLAGS
+4 bytes         Optional value, presents only if bit 0x100 in HEAD_FLAGS
 is set.
 
 HIGH_UNP_SIZE   High 4 bytes of 64 bit value of uncompressed file size.
-4 bytes         Optional value, presents only if bit 0×100 in HEAD_FLAGS
+4 bytes         Optional value, presents only if bit 0x100 in HEAD_FLAGS
 is set.
 
-FILE_NAME       File name – string of NAME_SIZE bytes size
+FILE_NAME       File name - string of NAME_SIZE bytes size
 
-SALT            present if (HEAD_FLAGS & 0×400) != 0
+SALT            present if (HEAD_FLAGS & 0x400) != 0
 8 bytes
 
-EXT_TIME        present if (HEAD_FLAGS & 0×1000) != 0
+EXT_TIME        present if (HEAD_FLAGS & 0x1000) != 0
 variable size
 #endif
 
@@ -131,8 +131,8 @@ HEAD_CRC       2 bytes     CRC of total block or block part
 HEAD_TYPE      1 byte      Block type
 HEAD_FLAGS     2 bytes     Block flags
 HEAD_SIZE      2 bytes     Block size
-ADD_SIZE       4 bytes     Optional field – added block size
-Field ADD_SIZE present only if (HEAD_FLAGS & 0×8000) != 0
+ADD_SIZE       4 bytes     Optional field - added block size
+Field ADD_SIZE present only if (HEAD_FLAGS & 0x8000) != 0
 #endif
 struct filehdr *fhdr;
 	RarBlockArchive *rba;
@@ -151,7 +151,7 @@ struct filehdr *fhdr;
 #endif
 	 switch (rb->type) {
 	 case 0x72:
-		 //sequence: 0×52 0×61 0×72 0×21 0x1a 0×07 0×00
+		 //sequence: 0x52 0x61 0x72 0x21 0x1a 0x07 0x00
 		 eprintf ("   + marker block\n");
 		 break;
 	 case 0x73:
@@ -184,24 +184,24 @@ printf ("SZ %x %x %x\n", fhdr->PackSize, fhdr->UnpSize , fhdr->FileCRC);
 		if (rb->flags & 0x200) {
 			printf ("utf8\n");
 		}
-		//sequence: 0×52 0×61 0×72 0×21 0x1a 0×07 0×00
+		//sequence: 0x52 0x61 0x72 0x21 0x1a 0x07 0x00
 #if 0
 HEAD_FLAGS      Bit flags:
 2 bytes
-0×0001  – Volume attribute (archive volume)
-0×0002  – Archive comment present
+0x0001  - Volume attribute (archive volume)
+0x0002  - Archive comment present
 RAR 3.x uses the separate comment block
 and does not set this flag.
 
-0×0004  – Archive lock attribute
-0×0008  – Solid attribute (solid archive)
-0×0010  – New volume naming scheme (‘volname.partN.rar’)
-0×0020  – Authenticity information present
+0x0004  - Archive lock attribute
+0x0008  - Solid attribute (solid archive)
+0x0010  - New volume naming scheme (‘volname.partN.rar’)
+0x0020  - Authenticity information present
 RAR 3.x does not set this flag.
 
-0×0040  – Recovery record present
-0×0080  – Block headers are encrypted
-0×0100  – First volume (set only by RAR 3.0 and later)
+0x0040  - Recovery record present
+0x0080  - Block headers are encrypted
+0x0100  - First volume (set only by RAR 3.0 and later)
 #endif
 		break;
 	case 0x74:
@@ -221,14 +221,14 @@ return 32;
 		break;
 	}
 #if 0
-HEAD_TYPE=0×72          marker block
-HEAD_TYPE=0×73          archive header
-HEAD_TYPE=0×74          file header
-HEAD_TYPE=0×75          old style comment header
-HEAD_TYPE=0×76          old style authenticity information
-HEAD_TYPE=0×77          old style subblock
-HEAD_TYPE=0×78          old style recovery record
-HEAD_TYPE=0×79          old style authenticity information
+HEAD_TYPE=0x72          marker block
+HEAD_TYPE=0x73          archive header
+HEAD_TYPE=0x74          file header
+HEAD_TYPE=0x75          old style comment header
+HEAD_TYPE=0x76          old style authenticity information
+HEAD_TYPE=0x77          old style subblock
+HEAD_TYPE=0x78          old style recovery record
+HEAD_TYPE=0x79          old style authenticity information
 HEAD_TYPE=0x7a          subblock
 #endif
 	if (rb->flags & 0x8000) {


### PR DESCRIPTION
Changes various unicode characters to their ASCII equivalents so that clang/llvm will compile properly.
