### PR TITLE
Fixed memory leak in r_core_anal_fcn()

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -522,31 +522,31 @@ error:
 	if (fcn) {
 		if (fcn->size == 0 || fcn->addr == UT64_MAX) {
 			r_anal_fcn_free (fcn);
-			return R_FALSE;
-		}
+		} else {
 		// TODO: mark this function as not properly analyzed
 #if 0
-		eprintf ("Analysis of function 0x%08"PFMT64x
-			" has failed at 0x%08"PFMT64x"\n",
-			fcn->addr, fcn->addr+fcn->size);
+			eprintf ("Analysis of function 0x%08"PFMT64x
+				" has failed at 0x%08"PFMT64x"\n",
+				fcn->addr, fcn->addr+fcn->size);
 #endif
-		if (!fcn->name) {
-			// XXX dupped code.
-			fcn->name = r_str_newf ("%s.%08"PFMT64x,
-					fcn->type == R_ANAL_FCN_TYPE_LOC? "loc":
-					fcn->type == R_ANAL_FCN_TYPE_SYM? "sym":
-					fcn->type == R_ANAL_FCN_TYPE_IMP? "imp": "fcn", at);
-			/* Add flag */
-			r_flag_space_set (core->flags, "functions");
-			r_flag_set (core->flags, fcn->name, at, fcn->size, 0);
-		}
-		r_anal_fcn_insert (core->anal, fcn);
+			if (!fcn->name) {
+				// XXX dupped code.
+				fcn->name = r_str_newf ("%s.%08"PFMT64x,
+						fcn->type == R_ANAL_FCN_TYPE_LOC? "loc":
+						fcn->type == R_ANAL_FCN_TYPE_SYM? "sym":
+						fcn->type == R_ANAL_FCN_TYPE_IMP? "imp": "fcn", at);
+				/* Add flag */
+				r_flag_space_set (core->flags, "functions");
+				r_flag_set (core->flags, fcn->name, at, fcn->size, 0);
+			}
+			r_anal_fcn_insert (core->anal, fcn);
 #if 0
-		// unlink from list to avoid double free later when we call r_anal_free()
-		r_list_unlink (core->anal->fcns, fcn);
-		if (core->anal->fcns->free == NULL)
-			r_anal_fcn_free (fcn);
+			// unlink from list to avoid double free later when we call r_anal_free()
+			r_list_unlink (core->anal->fcns, fcn);
+			if (core->anal->fcns->free == NULL)
+				r_anal_fcn_free (fcn);
 #endif
+		}
 	}
 	if (next) {
 		if (nexti<MAXNEXT)


### PR DESCRIPTION
In certain situations the function would return early after an error
occurred without freeing the next array first, thus leading to a leak.
