### PR TITLE
Fixes #575.

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -472,9 +472,6 @@ fcn->name = r_str_newf ("fcn.%08"PFMT64x, at);
 						break;
 				if (i==nexti) {
 					// TODO: ensure next address is function after padding (nop or trap or wat)
-					r_cons_clear_line ();
-					eprintf ("FUNC 0x%08"PFMT64x" > 0x%08"PFMT64x"\r",
-							fcn->addr, fcn->addr + fcn->size);
 					next_append (fcn->addr+fcn->size);
 				}
 			}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -495,6 +495,11 @@ static char *filter_refline2(RCore *core, const char *str) {
 	char *p, *s = strdup (str);
 	char n = '|';
 	for (p=s; *p; p++) {
+		if (!strncmp(p, core->cons->vline[LINE_VERT],
+					strlen(core->cons->vline[LINE_VERT]))) {
+			p += strlen(core->cons->vline[LINE_VERT]) - 1;
+			continue;
+		}
 		switch (*p) {
 		case '`':
 		case '|':
@@ -754,8 +759,8 @@ static void handle_show_functions (RCore *core, RDisasmState *ds) {
 						r_cons_printf ("%s%s "Color_RESET,
 							ds->color_fline, core->cons->vline[LINE_VERT]); // |
 					} else {
-						r_cons_printf ("%s %s %d\n| ", core->cons->vline[LINE_CROSS],
-							f->name, f->size); // |-
+						r_cons_printf ("%s %s %d\n%s ", core->cons->vline[LINE_CROSS],
+							f->name, f->size, core->cons->vline[LINE_VERT]); // |-
 
 					}
 				} else {


### PR DESCRIPTION
@radare @XVilka please take a look and review.
Don't think that this is the correct solution but it fixes the test.
First of all printing in libr/cons/cons.c produces some sequence of chars that breaks the diff.

secondly, the output FUNC > is not expected.

thirdly, filter_refline2 does some ugly shit and this was the main case to the #575 mess.

And lastly there was a dash hardcoded instead of proper LINE_VERT.
