### PR TITLE
Fix solib file name on MacOS X

### DIFF
--- a/libr/Makefile
+++ b/libr/Makefile
@@ -108,12 +108,11 @@ install: install-includes install-pkgconfig
 	# TODO :Use INSTALL_DATA_DIR instead of mkdir
 	# libraries
 	@${INSTALL_DIR} ${LFX}
-	@for a in `find * -type f | grep -e '\.${EXT_SO}$$' | grep -Ev '(lib|parse)/t/' | grep lib | grep -v /bin/ | grep -v /p/` ; do \
-	  b=`echo $$a|cut -d / -f 2`; \
-	  echo " ${LFX}/$$b.${LIBVERSION}"; \
-	  ${INSTALL_LIB} $$a ${LFX}/$$b.${LIBVERSION} ; \
-	  ( cd ${LFX} ; ln -fs $$b.${LIBVERSION} $$b ) ; \
-	done
+	@$(foreach lib,$(shell find * -type f | grep -e '\.${EXT_SO}$$' | grep -Ev '(lib|parse)/t/' | grep lib | grep -v /bin/ | grep -v /p/), \
+	  echo " ${LFX}/$(call libpath-to-name-version,$(lib))"; \
+	  ${INSTALL_LIB} $(lib) ${LFX}/$(call libpath-to-name-version,$(lib)); \
+	  ( cd ${LFX} ; ln -fs $(call libpath-to-name-version,$(lib)) $(call libpath-to-name,$(lib)) ) ; \
+	)
 	# object archives
 	@for a in `find * -type f | grep -e '\.a$$' | grep -v fs/p` ; do \
 	  echo " ${LFX}/$$a"; ${INSTALL_DATA} $$a ${LFX} ; done

--- a/libr/config.mk.tail
+++ b/libr/config.mk.tail
@@ -175,8 +175,19 @@ else
 ifeq (${OSTYPE},windows)
 libname=-shared -o $1.${EXT_SO}
 else
+ifeq (${OSTYPE},darwin)
+libname=-shared -o $1.${EXT_SO} ${LDFLAGS_SONAME}$1.${LIBVERSION}.${EXT_SO}
+else
 libname=-shared -o $1.${EXT_SO} ${LDFLAGS_SONAME}$1.${EXT_SO}.${LIBVERSION}
 endif
+endif
+endif
+
+libpath-to-name = $(word 2,$(subst /, ,$(1)))
+ifeq ($(OSTYPE),darwin)
+libpath-to-name-version = $(subst ${EXT_SO},${LIBVERSION}.${EXT_SO},$(call libpath-to-name,$(1)))
+else
+libpath-to-name-version = $(call lib-name,$(1)).${LIBVERSION}
 endif
 
 # -- singleton

--- a/libr/rules.mk
+++ b/libr/rules.mk
@@ -28,7 +28,11 @@ endif
 ifeq (${OSTYPE},gnulinux)
 LIBNAME=${LDFLAGS_SONAME}${LIBSO}.${LIBVERSION}
 else
+ifeq (${OSTYPE},darwin)
+LIBNAME=${LDFLAGS_SONAME}${LIB}.${LIBVERSION}.${EXT_SO}
+else
 LIBNAME=${LDFLAGS_SONAME}${LIBSO}
+endif
 endif
 
 ifeq (${OSTYPE},haiku)


### PR DESCRIPTION
On MacOS X the library version goes before the library extension (dylib).  This
patch adds two helper functions that are used by the install rule to get the
correct library file name.
