### PR TITLE
Fix #689

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -846,12 +846,8 @@ static void handle_show_comments_right (RCore *core, RDisasmState *ds) {
 			if (ds->show_comment_right_default)
 			if (ds->ocols+maxclen < core->cons->columns) {
 				if (ds->comment && *ds->comment && strlen (ds->comment)<maxclen) {
-					char *p = strchr (ds->comment, '\n');
-					if (p) {
-						linelen = p-ds->comment;
-						if (!strchr (p+1, '\n')) // more than one line?
-							ds->show_comment_right = 1;
-					}
+					if (!strchr (ds->comment, '\n')) // more than one line?
+						ds->show_comment_right = 1;
 				}
 			}
 			if (!ds->show_comment_right) {


### PR DESCRIPTION
You suppose there is a '\n'  in a single-line comment and there isn't. There is still a failure in case there is smth appended to disas, like

0x08048457    c7042402000. mov dword [esp], 0x2 ;  0x00000002 

in this case the number of free columns to append a comment will not be counted correctly.
