### PR TITLE
io_ihex: Lets remove infinite cycle

### DIFF
--- a/libr/io/p/io_ihex.c
+++ b/libr/io/p/io_ihex.c
@@ -157,6 +157,13 @@ static int ihex2bin(ut8 *mem, char *str) {
 			break;
 		case 1: // EOF
 			ptr = NULL;
+			break;
+		case 2:
+		case 3:
+		case 4:
+		case 5:
+			ptr = strchr(ptr + 1, ':');
+			break;
 		}
 	} while (ptr);
 


### PR DESCRIPTION
There are several record types: http://en.wikipedia.org/wiki/Intel_HEX

Their lack in the case causes an infinite loop. Those records define some segment information and so on. IDK how to implement this in RIO data types, maybe RIO->sections?
