### PR TITLE
Overhauled how files are loaded.  Now *all* files use an IO plugin the d...

### DIFF
--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -930,6 +930,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF("file.type", "", "Type of current file");
 	SETCB("file.loadmethod", "fail", &cb_fileloadmethod, "What to do when load addresses overlap: fail, overwrite, or append (next available)");
 	SETI("file.loadalign", 1024, "Alignment of load addresses");
+	SETI("file.openmany", 1, "How many files to open at once.");
 	SETPREF("file.nowarn", "true", "Suppress file loading warning messages if true");
 	SETPREF("file.location", "", "Is the file 'local', 'remote', or 'memory'");
 	/* magic */

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -577,6 +577,7 @@ R_API int r_core_init(RCore *core) {
 	r_io_bind (core->io, &(core->print->iob));
 	r_io_bind (core->io, &(core->anal->iob));
 	r_io_bind (core->io, &(core->fs->iob));
+	r_io_bind (core->io, &(core->bin->iob));
 
 	core->file = NULL;
 	core->files = r_list_new ();

--- a/libr/core/file.c
+++ b/libr/core/file.c
@@ -6,7 +6,9 @@
 
 static int r_core_file_do_load_for_debug (RCore *r, ut64 loadaddr, const char *filenameuri);
 static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 loadaddr);
-static int r_core_file_do_load_for_hex (RCore *r, ut64 baddr, ut64 loadaddr, const char *filenameuri);
+// After June 2014, if no problems delete r_core_file_do_load_for_hex
+//static int r_core_file_do_load_for_hex (RCore *r, ut64 baddr, ut64 loadaddr, const char *filenameuri);
+static void r_core_file_init_list_archs (RCore *r, RBinFile *binfile);
 
 R_API ut64 r_core_file_resize(struct r_core_t *core, ut64 newsize) {
 	if (newsize==0 && core->file)
@@ -227,7 +229,8 @@ R_API int r_core_bin_reload(RCore *r, const char *file, ut64 baseaddr) {
 
 // XXX - need to handle index selection during debugging
 static int r_core_file_do_load_for_debug (RCore *r, ut64 loadaddr, const char *filenameuri) {
-	RIODesc *desc = r->file && r->file->fd ? r->file->fd : NULL;
+	RCoreFile *cf = r_core_file_cur (r);
+	RIODesc *desc = cf ? cf->fd : NULL;
 	RBinFile *binfile = NULL;
 	RBinObject *binobj = NULL;
 	ut64 baseaddr = 0;
@@ -236,7 +239,7 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 loadaddr, const char *f
 	int treat_as_rawstr = R_FALSE;
 
 	if (!desc) return R_FALSE;
-	if (r->file && desc) {
+	if (cf && desc) {
 		int newpid = desc->fd;
 		r_debug_select (r->dbg, newpid, newpid);
 	}
@@ -244,7 +247,9 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 loadaddr, const char *f
 
 	if (!r_bin_load (r->bin, filenameuri, baseaddr, loadaddr, xtr_idx, desc->fd, treat_as_rawstr)) {
 		treat_as_rawstr ++;
-		if (!r_bin_load (r->bin, filenameuri, baseaddr, loadaddr, xtr_idx, desc->fd, treat_as_rawstr))
+		// attempt to load the file from the local disk
+		const char *name = filenameuri && strstr (filenameuri, "://") ? filenameuri+3 : filenameuri;
+		if (name && *name && !r_bin_load (r->bin, name, baseaddr, loadaddr, xtr_idx, -1, treat_as_rawstr))
 			return R_FALSE;
 	}
 
@@ -274,8 +279,35 @@ static int r_core_file_do_load_for_debug (RCore *r, ut64 loadaddr, const char *f
 
 }
 
+static void r_core_file_init_list_archs (RCore *r, RBinFile *binfile) {
+	if (binfile &&
+		binfile->narch > 1 &&
+		r_config_get_i (r->config, "scr.prompt")) {
+
+		int narch = binfile->narch;
+		int i = 0;
+		eprintf ("NOTE: Fat binary found. Selected sub-bin is: -a %s -b %d\n",
+					r->assembler->cur->arch, r->assembler->bits);
+		eprintf ("NOTE: Use -a and -b to select sub binary in fat binary\n");
+
+		for (i=0; i<narch; i++) {
+			RBinFile *lbinfile = r_bin_file_find_by_name_n (r->bin, binfile->file, i);
+			RBinObject *lbinobj = lbinfile ? lbinfile->o : NULL;
+			if (lbinobj && lbinobj->info) {
+				eprintf ("  $ r2 -a %s -b %d %s  # 0x%08"PFMT64x"\n",
+						lbinobj->info->arch,
+						lbinobj->info->bits,
+						binfile->file,
+						lbinobj->boffset);
+			} else
+				eprintf ("No extract info found for index: %d.\n", i);
+		}
+	}
+}
+
 static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 loadaddr) {
-	RIODesc *desc = r->file && r->file->fd ? r->file->fd : NULL;
+	RCoreFile *cf = r_core_file_cur (r);
+	RIODesc *desc = cf ? cf->fd : NULL;
 	RBinFile *binfile = NULL;
 	RBinObject *binobj = NULL;
 	int xtr_idx = 0; // if 0, load all if xtr is used
@@ -283,8 +315,8 @@ static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 load
 
 	if (!desc) return R_FALSE;
 	r_io_set_fd (r->io, desc);
-	if ( !r_bin_io_load (r->bin, r->io, desc, baseaddr, loadaddr, xtr_idx)) {
-		eprintf ("Failed to load the bin with an IO Plugin.\n");
+	if ( !r_bin_load_io (r->bin, desc, baseaddr, loadaddr, xtr_idx)) {
+		//eprintf ("Failed to load the bin with an IO Plugin.\n");
 		return R_FALSE;
 	}
 
@@ -310,14 +342,16 @@ static int r_core_file_do_load_for_io_plugin (RCore *r, ut64 baseaddr, ut64 load
 
 	if (binobj && binobj->info && binobj->info->bits) {
 		r_config_set_i (r->config, "asm.bits", binobj->info->bits);
-		//r->file->binfile = r->bin->cur;
+		//cf->binfile = r->bin->cur;
 	}
-	if (binobj) binobj->baddr = baseaddr;
+
+
 
 	return R_TRUE;
 }
 
-
+#if 0 
+// XXX - remove this code after June 2014, because current code setup is sufficient
 static int r_core_file_do_load_for_hex (RCore *r, ut64 baddr, ut64 loadaddr, const char *filenameuri) {
 	// HEXEDITOR
 	RBinFile * binfile = NULL;
@@ -373,27 +407,29 @@ static int r_core_file_do_load_for_hex (RCore *r, ut64 baddr, ut64 loadaddr, con
 
 	return R_TRUE;
 }
+#endif
 
 R_API int r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	const char *suppress_warning = r_config_get (r->config, "file.nowarn");
 	int va = r->io->va || r->io->debug;
 	ut64 loadaddr = 0;
+	RCoreFile *cf = r_core_file_cur (r);
 	RBinFile *binfile = NULL;
 	RBinObject * binobj = NULL;
-	RIODesc *desc = r->file && r->file->fd ? r->file->fd : NULL;
+	RIODesc *desc = cf ? cf->fd : NULL;
 
 	int is_io_load = desc && desc->plugin;
 
-	if ( (filenameuri == NULL || !*filenameuri) && r->file)
-		filenameuri = r->file->filename;
-	else if (r->file && strcmp (filenameuri, r->file->filename) ) {
+	if ( (filenameuri == NULL || !*filenameuri) && cf)
+		filenameuri = cf->filename;
+	else if (cf && strcmp (filenameuri, cf->filename) ) {
 		// XXX - this needs to be handled appropriately
-		// if the r->file does not match the filenameuri then
+		// if the cf does not match the filenameuri then
 		// either that RCoreFIle * needs to be loaded or a
 		// new RCoreFile * should be opened.
 		if (!strcmp (suppress_warning, "false"))
 			eprintf ("Error: The filenameuri %s is not the same as the current RCoreFile: %s\n",
-			    filenameuri, r->file->filename);
+			    filenameuri, cf->filename);
 	}
 
 	if (!filenameuri) {
@@ -401,8 +437,8 @@ R_API int r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		return R_FALSE;
 	}
 
-	if (r->file && r->file->map) {
-		loadaddr = r->file->map->from;
+	if (cf && cf->map) {
+		loadaddr = cf->map->from;
 	}
 
 	r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
@@ -414,19 +450,19 @@ R_API int r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		} else {
 			r_core_file_do_load_for_io_plugin (r, baddr, loadaddr);
 		}
-	} else if ( !r_core_file_do_load_for_hex (r, baddr, loadaddr, filenameuri) ) { // --->
-		return R_FALSE;
-	}
+	} //else if ( !r_core_file_do_load_for_hex (r, baddr, loadaddr, filenameuri) ) { // --->
+	//	return R_FALSE;
+	//}
 
 	binobj = r_bin_get_object (r->bin);
 	binfile = r_core_bin_cur (r);
 	//r_bin_set_baddr(r->bin, r_config_get_i (r->config, "bin.baddr"));
-	if (r->file && binfile && desc) binfile->fd = desc->fd;
-	else eprintf ("Error: No file descriptor defined for current file: %s\n", filenameuri);
+	if (cf && binfile && desc) binfile->fd = desc->fd;
+	//else eprintf ("Error: No file descriptor defined for current bin file: %s\n", filenameuri);
 	if (r->bin) r_core_bin_bind (r, r_core_bin_cur (r));
 
 
-	if (!r->file) {
+	if (!cf) {
 		if (binobj && binobj->info && binobj->info->bits) {
 			r_config_set_i (r->config, "asm.bits", binobj->info->bits);
 		}
@@ -475,12 +511,15 @@ R_API RIOMap *r_core_file_get_next_map (RCore *core, RCoreFile * fh, int mode, u
 
 R_API RCoreFile *r_core_file_open_many(RCore *r, const char *file, int mode, ut64 loadaddr) {
 	RList *list_fds = NULL;
-	list_fds = r_io_open_many (r->io, file, mode, 0644);
 	RCoreFile *fh, *top_file = NULL;
 	RIODesc *fd;
-	RListIter *fd_iter;
+	RListIter *fd_iter, *iter2;
 	ut64 current_loadaddr = loadaddr;
 	const char *suppress_warning = r_config_get (r->config, "file.nowarn");
+	int openmany = r_config_get_i (r->config, "file.openmany"), opened_count = 0;
+
+
+	list_fds = r_io_open_many (r->io, file, mode, 0644);
 
 	const char *cp = NULL;
 	char *loadmethod = NULL;
@@ -494,7 +533,16 @@ R_API RCoreFile *r_core_file_open_many(RCore *r, const char *file, int mode, ut6
 	if (cp) loadmethod = strdup (cp);
 	r_config_set (r->config, "file.loadmethod", "append");
 
-	r_list_foreach (list_fds, fd_iter, fd) {
+	r_list_foreach_safe (list_fds, fd_iter, iter2, fd) {
+		opened_count++;
+		if (opened_count > openmany) {
+			// XXX - Open Many should limit the number of files
+			// loaded in io plugin area this needs to be more premptive
+			// like down in the io plugin layer.
+			// start closing down descriptors
+			r_list_delete (list_fds, fd_iter);
+			continue;
+		}
 		fh = R_NEW0 (RCoreFile);
 		if (!fh) {
 			eprintf ("file.c:r_core_many failed to allocate new RCoreFile.\n");
@@ -549,6 +597,7 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int mode, ut64 loa
 	RCoreFile *fh;
 	RIODesc *fd;
 	const char *suppress_warning = r_config_get (r->config, "file.nowarn");
+	const int openmany = r_config_get_i (r->config, "file.openmany");
 
 	if (!strcmp (file, "-")) {
 		file = "malloc://512";
@@ -556,7 +605,7 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int mode, ut64 loa
 	}
 	r->io->bits = r->assembler->bits; // TODO: we need an api for this
 	fd = r_io_open (r->io, file, mode, 0644);
-	if (fd == NULL) {
+	if (fd == NULL && openmany > 2) {
 		// XXX - make this an actual option somewhere?
 		fh = r_core_file_open_many (r, file, mode, loadaddr);
 		if (fh) return fh;
@@ -758,9 +807,10 @@ R_API int r_core_hash_load(RCore *r, const char *file) {
 	ut8 *buf = NULL;
 	RHash *ctx;
 	ut64 limit;
+	RCoreFile *cf = r_core_file_cur (r);
 
 	limit = r_config_get_i (r->config, "cfg.hashlimit");
-	if (r->file->size > limit)
+	if (cf->size > limit)
 		return R_FALSE;
 	buf = (ut8*)r_file_slurp (file, &buf_len);
 	if (buf==NULL)
@@ -842,4 +892,9 @@ R_API ut32 r_core_file_cur_fd (RCore *core) {
 		return desc->fd;
 	}
 	return (ut32)-1;
+}
+
+R_API RCoreFile * r_core_file_cur (RCore *r) {
+	// Add any locks here
+	return r->file;
 }

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -151,6 +151,7 @@ typedef struct r_bin_t {
 	RList/*<RBinFile>*/ *binfiles;
 	PrintfCallback printf;
 	int loadany;
+	RIOBind iob;
 } RBin;
 
 typedef int (*FREE_XTR)(void *xtr_obj);
@@ -174,6 +175,7 @@ typedef struct r_bin_xtr_plugin_t {
 	int (*init)(void *user);
 	int (*fini)(void *user);
 	int (*check)(RBin *bin);
+	int (*check_bytes)(const ut8 *bytes, ut64 sz);
 	RBinXtrData * (*extract_from_bytes)(const ut8 *buf, ut64 size, int idx);
 	RList * (*extractall_from_bytes)(const ut8 *buf, ut64 size);
 	RBinXtrData * (*extract)(RBin *bin, int idx);
@@ -326,6 +328,8 @@ typedef struct r_bin_bind_t {
 #define r_bin_class_free(x) { free(x->name);free(x->super);free (x); }
 
 /* bin.c */
+// XXX - delete r_bin_load after June 2014 if no issues arise
+//R_API int r_bin_load(RBin *bin, const char *file, ut64 baseaddr, ut64 loadaddr, int xtr_idx, int fd, int rawstr);
 R_API void r_bin_bind(RBin *b, RBinBind *bnd);
 R_API int r_bin_add(RBin *bin, RBinPlugin *foo);
 R_API int r_bin_xtr_add(RBin *bin, RBinXtrPlugin *foo);
@@ -335,7 +339,6 @@ R_API int r_bin_file_deref (RBin *bin, RBinFile * a);
 R_API int r_bin_file_ref_by_bind (RBinBind * binb);
 R_API int r_bin_file_ref (RBin *bin, RBinFile * a);
 R_API int r_bin_list(RBin *bin);
-R_API int r_bin_load(RBin *bin, const char *file, ut64 baseaddr, ut64 loadaddr, int xtr_idx, int fd, int rawstr);
 R_API RBinObject *r_bin_get_object(RBin *bin);
 R_API ut64 r_bin_get_baddr(RBin *bin);
 R_API void r_bin_set_baddr(RBin *bin, ut64 baddr);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -216,6 +216,7 @@ R_API int r_core_serve(RCore *core, RIODesc *fd);
 R_API int r_core_file_reopen(RCore *core, const char *args, int perm);
 R_API RCoreFile * r_core_file_find_by_fd(RCore* core, ut64 fd);
 R_API RCoreFile * r_core_file_find_by_name (RCore * core, const char * name);
+R_API RCoreFile * r_core_file_cur (RCore *r);
 R_API int r_core_file_set_by_fd(RCore *core, ut64 fd);
 R_API int r_core_file_set_by_name(RCore *core, const char * name);
 R_API int r_core_file_set_by_file (RCore * core, RCoreFile *cf);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -168,22 +168,39 @@ typedef struct r_io_list_t {
 	struct list_head list;
 } RIOList;
 
+struct r_io_bind_t;
 /* TODO: find better name... RIOSetFd_Callback? ..Func? .. too camels here */
+typedef RIO * (*RIOGetIO) (struct r_io_bind_t *iob);
 typedef int (*RIOSetFd)(RIO *io, int fd);
 typedef int (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, int size);
 typedef int (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int size);
 typedef ut64 (*RIOSize)(RIO *io);
 typedef ut64 (*RIOSeek)(RIO *io, ut64 offset, int whence);
 
+typedef RIODesc* (*RIODescGetFD)(RIO *io, int fd);
+typedef RIODesc* (*RIODescOpen)(RIO *io, const char *file, int flags, int mode);
+typedef int (*RIODescClose)(RIO *io, RIODesc *);
+typedef ut8 * (*RIODescRead)(RIO *io, RIODesc *desc, ut64 *sz);
+typedef ut64 (*RIODescSeek)(RIO *io, RIODesc *desc, ut64 offset, int whence);
+typedef ut64 (*RIODescSize)(RIO *io, RIODesc *desc);
+
 /* compile time dependency */
 typedef struct r_io_bind_t {
 	int init;
 	RIO *io;
+	RIOGetIO get_io;
 	RIOSetFd set_fd; // XXX : this is conceptually broken with the new RIODesc foo
 	RIOReadAt read_at;
 	RIOWriteAt write_at;
 	RIOSize size;
 	RIOSeek seek;
+
+	RIODescOpen desc_open;
+	RIODescClose desc_close;
+	RIODescRead desc_read;
+	RIODescSize desc_size;
+	RIODescSeek desc_seek;
+	RIODescGetFD desc_get_by_fd;
 } RIOBind;
 
 typedef struct r_io_cache_t {
@@ -236,6 +253,7 @@ R_API int r_io_is_listener(RIO *io);
 // TODO: _del ??
 R_API RIOPlugin *r_io_plugin_resolve(RIO *io, const char *filename, ut8 many);
 R_API RIOPlugin *r_io_plugin_resolve_fd(RIO *io, int fd);
+R_API RIOPlugin *r_io_plugin_get_default(RIO *io, const char *filename, ut8 many);
 
 /* io/io.c */
 R_API int r_io_set_write_mask(RIO *io, const ut8 *buf, int len);
@@ -373,6 +391,7 @@ extern RIOPlugin r_io_plugin_w32;
 extern RIOPlugin r_io_plugin_ewf;
 extern RIOPlugin r_io_plugin_zip;
 extern RIOPlugin r_io_plugin_mmap;
+extern RIOPlugin r_io_plugin_default;
 extern RIOPlugin r_io_plugin_ihex;
 extern RIOPlugin r_io_plugin_self;
 #endif

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -94,6 +94,7 @@ typedef struct r_buf_t {
 	int cur;
 	ut64 base;
 	RMmap *mmap;
+	ut8 empty;
 } RBuffer;
 
 /* r_cache */
@@ -231,6 +232,7 @@ R_API void r_graph_plant(RGraph *t);
 R_API void r_graph_push (RGraph *t, ut64 addr, void *data);
 R_API RGraphNode* r_graph_pop(RGraph *t);
 
+R_API boolt r_file_truncate (const char *filename, ut64 newsize);
 R_API int r_file_size(const char *str);
 R_API char *r_file_root(const char *root, const char *path);
 R_API boolt r_file_is_directory(const char *str);

--- a/libr/io/p/default.mk
+++ b/libr/io/p/default.mk
@@ -1,0 +1,16 @@
+OBJ_DEFAULT=io_default.o
+
+STATIC_OBJ+=${OBJ_DEFAULT}
+TARGET_DEFAULT=io_default.${EXT_SO}
+ALL_TARGETS+=${TARGET_DEFAULT}
+
+ifeq (${WITHPIC},0)
+LINKFLAGS+=../../util/libr_util.a
+LINKFLAGS+=../../io/libr_io.a
+else
+LINKFLAGS+=-L../../util -lr_util
+LINKFLAGS+=-L.. -lr_io
+endif
+
+${TARGET_DEFAULT}: ${OBJ_DEFAULT}
+	${CC_LIB} $(call libname,io_default) ${CFLAGS} -o ${TARGET_DEFAULT} ${OBJ_DEFAULT} ${LINKFLAGS}

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -1,0 +1,232 @@
+#include <r_userconf.h>
+#include <r_io.h>
+#include <r_lib.h>
+
+typedef struct r_io_mmo_t {
+	char * filename;
+	int mode;
+	int rw;
+	int fd;
+	int opened;
+	ut8 modified;
+	RBuffer *buf;
+	RIO * io_backref;
+} RIOMMapFileObj;
+
+static int r_io_def_mmap_refresh_def_mmap_buf(RIOMMapFileObj *mmo);
+static void r_io_def_mmap_free (RIOMMapFileObj *mmo);
+static int r_io_def_mmap_close(RIODesc *fd);
+static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count);
+static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count);
+static RIODesc *r_io_def_mmap_open(RIO *io, const char *file, int rw, int mode);
+static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence);
+static ut64 r_io_def_mmap_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence);
+static int r_io_def_mmap_truncate(RIOMMapFileObj *mmo, ut64 size);
+static int r_io_def_mmap_resize(RIO *io, RIODesc *fd, ut64 size);
+
+static int __plugin_open_default(RIO *io, const char *file, ut8 many);
+static RIODesc *__open_default(RIO *io, const char *file, int rw, int mode);
+static int __read(RIO *io, RIODesc *fd, ut8 *buf, int len);
+static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int len);
+static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence);
+static int __close(RIODesc *fd);
+static int __resize(RIO *io, RIODesc *fd, ut64 newsize);
+
+
+static int r_io_def_mmap_refresh_def_mmap_buf(RIOMMapFileObj *mmo) {
+	RIO* io = mmo->io_backref;
+	ut64 cur = mmo->buf ? mmo->buf->cur : 0;
+	if (mmo->buf) {
+		r_buf_free (mmo->buf);
+		mmo->buf = NULL;
+	}
+	mmo->buf = r_buf_mmap (mmo->filename, mmo->rw);
+	if (mmo->buf)
+		r_io_def_mmap_seek (io, mmo, cur, SEEK_SET);
+	return (mmo->buf ? R_TRUE : R_FALSE);
+}
+
+RIOMMapFileObj *r_io_def_mmap_create_new_file(RIO  *io, const char *filename, int mode, int rw) {
+	RIOMMapFileObj *mmo = R_NEW0 (RIOMMapFileObj);
+	if (!mmo || !io)
+		return NULL;
+
+	mmo->filename = strdup (filename);
+	mmo->fd = r_num_rand (0xFFFF); // XXX: Use r_io_fd api
+	mmo->mode = mode;
+	mmo->rw = rw & R_IO_WRITE ? 1 : 0;
+	mmo->io_backref = io;
+
+	if (!r_io_def_mmap_refresh_def_mmap_buf (mmo)) {
+		r_io_def_mmap_free (mmo);
+		mmo = NULL;
+	}
+	return mmo;
+}
+
+static void r_io_def_mmap_free (RIOMMapFileObj *mmo) {
+	free (mmo->filename);
+	r_buf_free (mmo->buf);
+	memset (mmo, 0, sizeof (RIOMMapFileObj));
+	free (mmo);
+}
+
+static int r_io_def_mmap_close(RIODesc *fd) {
+	if (!fd || !fd->data)
+		return -1;
+	r_io_def_mmap_free ( (RIOMMapFileObj *) fd->data);
+	fd->data = NULL;
+	return 0;
+}
+
+static int r_io_def_mmap_check_default (const char *filename) {
+	char * peekaboo = strstr (filename, "://");
+	if ( (filename && !peekaboo) ||
+		( (peekaboo-filename) > 10 ) )
+		return 1;
+	return 0;
+}
+
+static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	RIOMMapFileObj *mmo = NULL;
+	if (!fd || !fd->data || !buf)
+		return -1;
+	mmo = fd->data;
+	if (mmo->buf->length < io->off)
+		io->off = mmo->buf->length;
+	return r_buf_read_at (mmo->buf, io->off, buf, count);
+}
+
+static int r_io_def_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
+	RIOMMapFileObj *mmo;
+	int len = -1;
+	ut64 addr = io->off;
+
+	if (!(fd->flags & R_IO_WRITE) || !fd || !fd->data || !buf) return -1;
+
+	mmo = fd->data;
+
+	if ( (count + addr > mmo->buf->length) || mmo->buf->empty) {
+		ut64 sz = count + addr;
+		r_file_truncate (mmo->filename, sz);
+	}
+
+	len = r_file_mmap_write (mmo->filename, io->off, buf, count);
+	if (!r_io_def_mmap_refresh_def_mmap_buf (mmo) ) {
+		eprintf ("io_def_mmap: failed to refresh the def_mmap backed buffer.\n");
+		// XXX - not sure what needs to be done here (error handling).
+	}
+	return len;
+}
+
+static RIODesc *r_io_def_mmap_open(RIO *io, const char *file, int rw, int mode) {
+	const char* name = NULL;
+	RIOMMapFileObj *mmo;
+
+	name = file;
+	mmo = r_io_def_mmap_create_new_file (io, name, mode, rw);
+
+	if (!mmo) return NULL;
+	return r_io_desc_new (&r_io_plugin_default, mmo->fd,
+				mmo->filename, rw, mode, mmo);
+}
+
+static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
+	ut64 seek_val = mmo->buf->cur;
+	switch (whence) {
+	case SEEK_SET:
+		seek_val = (mmo->buf->length < offset) ?
+			mmo->buf->length : offset;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	case SEEK_CUR:
+		seek_val = (mmo->buf->length < (offset + mmo->buf->cur)) ?
+			mmo->buf->length : offset + mmo->buf->cur;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	case SEEK_END:
+		seek_val = mmo->buf->length;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	}
+	return seek_val;
+}
+
+static ut64 r_io_def_mmap_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
+	RIOMMapFileObj *mmo;
+
+	if (!fd || !fd->data)
+		return -1;
+
+	mmo = fd->data;
+	return r_io_def_mmap_seek(io, mmo, offset, whence);
+}
+
+static int r_io_def_mmap_truncate(RIOMMapFileObj *mmo, ut64 size) {
+	int res = r_file_truncate (mmo->filename, size);
+
+	if (res && !r_io_def_mmap_refresh_def_mmap_buf (mmo) ) {
+		eprintf ("r_io_def_mmap_truncate: Error trying to refresh the def_mmap'ed file.");
+		res = R_FALSE;
+	}
+	else if (!res) eprintf ("r_io_def_mmap_truncate: Error trying to resize the file.");
+	return res;
+}
+
+static int r_io_def_mmap_resize(RIO *io, RIODesc *fd, ut64 size) {
+	RIOMMapFileObj *mmo;
+	if (!fd || !fd->data)
+		return -1;
+
+	mmo = fd->data;
+	return r_io_def_mmap_truncate(mmo, size);
+}
+
+static int __plugin_open_default(RIO *io, const char *file, ut8 many) {
+	return r_io_def_mmap_check_default (file);
+}
+
+static RIODesc *__open_default(RIO *io, const char *file, int rw, int mode) {
+	if (!r_io_def_mmap_check_default (file) ) return NULL;
+	return r_io_def_mmap_open (io, file, rw, mode);
+}
+
+static int __read(RIO *io, RIODesc *fd, ut8 *buf, int len) {
+	return r_io_def_mmap_read (io, fd, buf, len);
+}
+
+static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int len) {
+	return r_io_def_mmap_write(io, fd, buf, len);
+}
+
+static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
+	return r_io_def_mmap_lseek (io, fd, offset, whence);
+}
+
+static int __close(RIODesc *fd) {
+	return r_io_def_mmap_close (fd);
+}
+
+static int __resize(RIO *io, RIODesc *fd, ut64 size) {
+	return r_io_def_mmap_resize (io, fd, size);
+}
+
+struct r_io_plugin_t r_io_plugin_default = {
+	.name = "default",
+	.desc = "open local files using def_mmap://",
+	.license = "LGPL3",
+	.open = __open_default,
+	.close = __close,
+	.read = __read,
+	.plugin_open = __plugin_open_default,
+	.lseek = __lseek,
+	.write = __write,
+	.resize = __resize,
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_IO,
+	.data = &r_io_plugin_default
+};
+#endif

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -4,55 +4,240 @@
 #include <r_io.h>
 #include <r_lib.h>
 
+typedef struct r_io_mmo_t {
+	char * filename;
+	int mode;
+	int rw;
+	int fd;
+	int opened;
+	ut8 modified;
+	RBuffer *buf;
+	RIO * io_backref;
+} RIOMMapFileObj;
+
+static int r_io_mmap_refresh_buf(RIOMMapFileObj *mmo);
+static void r_io_mmap_free (RIOMMapFileObj *mmo);
+static int r_io_mmap_close(RIODesc *fd);
+static int r_io_mmap_check (const char *filname);
+static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count);
+static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count);
+static RIODesc *r_io_mmap_open(RIO *io, const char *file, int rw, int mode);
+static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence);
+static ut64 r_io_mmap_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence);
+static int r_io_mmap_truncate(RIOMMapFileObj *mmo, ut64 size);
+static int r_io_mmap_resize(RIO *io, RIODesc *fd, ut64 size);
+static int __plugin_open(RIO *io, const char *file, ut8 many);
+static RIODesc *__open(RIO *io, const char *file, int rw, int mode);
+static int __read(RIO *io, RIODesc *fd, ut8 *buf, int len);
+static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int len);
+static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence);
+static int __close(RIODesc *fd);
+static int __resize(RIO *io, RIODesc *fd, ut64 newsize);
+
+
+static int r_io_mmap_refresh_buf(RIOMMapFileObj *mmo) {
+	RIO* io = mmo->io_backref;
+	ut64 cur = mmo->buf ? mmo->buf->cur : 0;
+	if (mmo->buf) {
+		r_buf_free (mmo->buf);
+		mmo->buf = NULL;
+	}
+	mmo->buf = r_buf_mmap (mmo->filename, mmo->rw);
+	if (mmo->buf)
+		r_io_mmap_seek (io, mmo, cur, SEEK_SET);
+	return (mmo->buf ? R_TRUE : R_FALSE);
+}
+
+RIOMMapFileObj *r_io_mmap_create_new_file(RIO  *io, const char *filename, int mode, int rw) {
+	RIOMMapFileObj *mmo = R_NEW0 (RIOMMapFileObj);
+	if (!mmo || !io)
+		return NULL;
+
+	mmo->filename = strdup (filename);
+	mmo->fd = r_num_rand (0xFFFF); // XXX: Use r_io_fd api
+	mmo->mode = mode;
+	mmo->rw = rw & R_IO_WRITE ? 1 : 0;
+	mmo->io_backref = io;
+
+	if (!r_io_mmap_refresh_buf (mmo)) {
+		r_io_mmap_free (mmo);
+		mmo = NULL;
+	}
+	return mmo;
+}
+
+static void r_io_mmap_free (RIOMMapFileObj *mmo) {
+	free (mmo->filename);
+	r_buf_free (mmo->buf);
+	memset (mmo, 0, sizeof (RIOMMapFileObj));
+	free (mmo);
+}
+
+static int r_io_mmap_close(RIODesc *fd) {
+	if (!fd || !fd->data)
+		return -1;
+	r_io_mmap_free ( (RIOMMapFileObj *) fd->data);
+	fd->data = NULL;
+	return 0;
+}
+
+static int r_io_mmap_check (const char *filename) {
+	if ( filename &&
+		!strncmp (filename, "mmap://", 7) &&
+		*(filename+7))
+		return 1;
+	return 0;
+}
+
+static int r_io_mmap_check_default (const char *filename) {
+	char * peekaboo = strstr (filename, "://");
+	if ( (filename && !peekaboo) ||
+		( (peekaboo-filename) > 10 ) )
+		return 1;
+	return 0;
+}
+
+static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	RIOMMapFileObj *mmo = NULL;
+	if (!fd || !fd->data || !buf)
+		return -1;
+	mmo = fd->data;
+	if (mmo->buf->length < io->off)
+		io->off = mmo->buf->length;
+	return r_buf_read_at (mmo->buf, io->off, buf, count);
+}
+
+static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
+	RIOMMapFileObj *mmo;
+	int len = count;
+	ut64 addr = io->off;
+
+	if (!(fd->flags & R_IO_WRITE) || !fd || !fd->data || !buf) return -1;
+
+	mmo = fd->data;
+
+	if ( (count + addr > mmo->buf->length) || mmo->buf->empty) {
+		ut64 sz = count + addr;
+		r_file_truncate (mmo->filename, sz);
+	}
+
+	len = r_file_mmap_write (mmo->filename, io->off, buf, len);
+	if (!r_io_mmap_refresh_buf (mmo) ) {
+		eprintf ("io_mmap: failed to refresh the mmap backed buffer.\n");
+		// XXX - not sure what needs to be done here (error handling).
+	}
+	return len;
+}
+
+static RIODesc *r_io_mmap_open(RIO *io, const char *file, int rw, int mode) {
+	const char* name = NULL;
+	RIOMMapFileObj *mmo;
+
+	name = !strncmp (file, "mmap://", 7) ? file+7 : file;
+	mmo = r_io_mmap_create_new_file (io, name, mode, rw);
+
+	if (!mmo) return NULL;
+	return r_io_desc_new (&r_io_plugin_mmap, mmo->fd,
+				mmo->filename, rw, mode, mmo);
+}
+
+static ut64 r_io_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
+	ut64 seek_val = mmo->buf->cur;
+	switch (whence) {
+	case SEEK_SET:
+		seek_val = (mmo->buf->length < offset) ?
+			mmo->buf->length : offset;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	case SEEK_CUR:
+		seek_val = (mmo->buf->length < (offset + mmo->buf->cur)) ?
+			mmo->buf->length : offset + mmo->buf->cur;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	case SEEK_END:
+		seek_val = mmo->buf->length;
+		mmo->buf->cur = io->off = seek_val;
+		return seek_val;
+	}
+	return seek_val;
+}
+
+static ut64 r_io_mmap_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
+	RIOMMapFileObj *mmo;
+
+	if (!fd || !fd->data)
+		return -1;
+
+	mmo = fd->data;
+	return r_io_mmap_seek(io, mmo, offset, whence);
+}
+
+static int r_io_mmap_truncate(RIOMMapFileObj *mmo, ut64 size) {
+	int res = r_file_truncate (mmo->filename, size);
+
+	if (res && !r_io_mmap_refresh_buf (mmo) ) {
+		eprintf ("r_io_mmap_truncate: Error trying to refresh the mmap'ed file.");
+		res = R_FALSE;
+	}
+	else if (res) eprintf ("r_io_mmap_truncate: Error trying to resize the file.");
+	return res;
+}
+
+static int r_io_mmap_resize(RIO *io, RIODesc *fd, ut64 size) {
+	RIOMMapFileObj *mmo;
+	if (!fd || !fd->data)
+		return -1;
+
+	mmo = fd->data;
+	return r_io_mmap_truncate(mmo, size);
+}
+
+
 static int __plugin_open(RIO *io, const char *file, ut8 many) {
-	return (!strncmp (file, "mmap://", 7));
+	return r_io_mmap_check (file);
 }
 
 static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
-	if (r_file_mmap_read (file+7, 0, NULL, 0)==0)
-		return r_io_desc_new (&r_io_plugin_mmap,
-			-1, file+7, rw, mode, NULL);
-	return NULL;
+	if (!r_io_mmap_check (file) ) return NULL;
+	return r_io_mmap_open (io, file, rw, mode);
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int len) {
-        return r_file_mmap_read (fd->name, io->off, buf, len);
+	return r_io_mmap_read (io, fd, buf, len);
 }
 
 static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int len) {
-	if (fd->flags & 2)
-        	return r_file_mmap_write (fd->name, io->off, buf, len);
-	return -1;
+	return r_io_mmap_write(io, fd, buf, len);
 }
 
 static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
-	switch (whence) {
-	case SEEK_SET: return offset;
-	case SEEK_CUR: return io->off + offset;
-	case SEEK_END: return r_file_size (fd->name);
-	}
-	return offset;
+	return r_io_mmap_lseek (io, fd, offset, whence);
 }
 
 static int __close(RIODesc *fd) {
-	return 0;
+	return r_io_mmap_close (fd);
+}
+
+static int __resize(RIO *io, RIODesc *fd, ut64 size) {
+	return r_io_mmap_resize (io, fd, size);
 }
 
 struct r_io_plugin_t r_io_plugin_mmap = {
 	.name = "mmap",
-        .desc = "open file using mmap://",
+	.desc = "open file using mmap://",
 	.license = "LGPL3",
-        .open = __open,
-        .close = __close,
+	.open = __open,
+	.close = __close,
 	.read = __read,
-        .plugin_open = __plugin_open,
+	.plugin_open = __plugin_open,
 	.lseek = __lseek,
 	.write = __write,
+	.resize = __resize,
 };
 
 #ifndef CORELIB
 struct r_lib_struct_t radare_plugin = {
 	.type = R_LIB_TYPE_IO,
-	.data = &r_io_plugin_mach
+	.data = &r_io_plugin_mmap
 };
 #endif

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -412,7 +412,7 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	RIOZipFileObj *zfo;
 	ut64 seek_val = 0;
 
-	if (fd == NULL || fd->data == NULL)
+	if (!fd || !fd->data)
 		return -1;
 
 	zfo = fd->data;
@@ -439,7 +439,7 @@ static ut64 r_io_zip_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 
 static int r_io_zip_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	RIOZipFileObj *zfo = NULL;
-	if (fd == NULL || fd->data == NULL || buf == NULL)
+	if (!fd || !fd->data || !buf)
 		return -1;
 	zfo = fd->data;
 	if (zfo->b->length < io->off)
@@ -484,7 +484,7 @@ static int r_io_zip_resize(RIO *io, RIODesc *fd, ut64 size) {
 	RIOZipFileObj *zfo;
 	int res = R_FALSE;
 	ut64 cur_off = io->off;
-	if (fd == NULL || fd->data == NULL)
+	if (!fd || !fd->data)
 		return -1;
 	zfo = fd->data;
 	res = r_io_zip_truncate_buf(zfo, size);
@@ -501,7 +501,7 @@ static int r_io_zip_resize(RIO *io, RIODesc *fd, ut64 size) {
 static int r_io_zip_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	RIOZipFileObj *zfo;
 	int ret = 0;
-	if (fd == NULL || fd->data == NULL || buf == NULL)
+	if (!(fd->flags & R_IO_WRITE) || !fd || !fd->data || !buf)
 		return -1;
 	zfo = fd->data;
 	if (zfo->b->cur + count >= zfo->b->length)
@@ -521,7 +521,7 @@ static int r_io_zip_close(RIODesc *fd) {
 	RIOZipFileObj *zfo = NULL;
 	//eprintf("Am I called 2x?\n");
 	// this api will be called multiple times :/
-	if (fd == NULL || fd->data)
+	if (!fd || !fd->data)
 		return -1;
 	zfo = fd->data;
 	r_io_zip_free_zipfileobj (zfo);

--- a/libr/io/plugin.c
+++ b/libr/io/plugin.c
@@ -9,8 +9,10 @@
 #include "list.h"
 #include <stdio.h>
 
+volatile static RIOPlugin *DEFAULT = NULL;
 static RIOPlugin *io_static_plugins[] = 
 	{ R_IO_STATIC_PLUGINS };
+
 
 R_API int r_io_plugin_add(RIO *io, RIOPlugin *plugin) {
 	struct r_io_list_t *li;
@@ -35,9 +37,23 @@ R_API int r_io_plugin_init(RIO *io) {
 		static_plugin = R_NEW (RIOPlugin);
 		// memory leak here: static_plugin never freed
 		memcpy (static_plugin, io_static_plugins[i], sizeof (RIOPlugin));
+		if (!strncmp (static_plugin->name, "default", 7)) {
+			DEFAULT = static_plugin;
+			continue;
+		}
 		r_io_plugin_add (io, static_plugin);
 	}
 	return R_TRUE;
+}
+
+R_API RIOPlugin *r_io_plugin_get_default(RIO *io, const char *filename, ut8 many) {
+
+	if (!DEFAULT ||
+		!DEFAULT->plugin_open ||
+		!DEFAULT->plugin_open (io, filename, many) ) return NULL;
+
+	return DEFAULT;
+
 }
 
 R_API RIOPlugin *r_io_plugin_resolve(RIO *io, const char *filename, ut8 many) {

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -129,6 +129,7 @@ io.bfdbg
 io.gdb
 io.haret
 io.mmap
+io.default
 io.self
 io.mach
 io.w32


### PR DESCRIPTION
I cleaned up the previous commit and removed unnecessary changes to the build files.  I also incorporated the missing NULL Pointer reference pointed out by montekki.    This was cherry-picked and rebased against the current master.  The previous pull request looked like it include work from others, so I wanted to make sure this was a clean commit.

Now all files use an IO plugin the default one is mmap'ed. This is a major overhaul of all the IO layer that forces all local file loading done by RBin and RCore to use IO Plugins, which is why it has been submitted as a separate pull request. Mac OSX and Linux have both built and passed most tests successfully (io ff and enum 32 tests failed on Mac and io ff failed on Linux).

The purpose for this overhaul is to ensure that testing can be conducted and we can ensure consistent results whether the file is loaded locally or remotely. The default file plugin is a clone of the io_mmap plugin. Both have been fixed and should work for loading files on the local filesystem.

In order to facilitate this change, a hook was added to the IO such that RBin can grab and RIO Component and perform file opens and reads. This is not ideal because it could lead to race conditions in the future, since the RIO component becomes an unprotected resource (e.g. others may be reading and writing at the same time). This issue can be addressed in the future.
