### PR TITLE
Issue #861. configure option to disable warnings.

### DIFF
--- a/configure.acr
+++ b/configure.acr
@@ -127,10 +127,8 @@ IFEQ LIBVERSION xxx ; {
 }
 
 ARG_DISABLE WARN_UNUSED warning-unused hide warnings of unused parameters/functions/variables ;
-IFNULL HOST_CC {
-	IFNOT WARN_UNUSED {
-		CFLAGS += -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wunused-but-set-parameter ;
-	}
+IFNOT WARN_UNUSED {
+	CFLAGS += -Wno-unused-variable -Wno-unused-parameter -Wno-unused-function -Wunused-but-set-parameter ;
 }
 
 REPORT PREFIX HAVE_LIB_EWF HAVE_LIB_GMP HAVE_OPENSSL


### PR DESCRIPTION
Added an option --disable-warning-unused that hides compiler warnings about unused variables, parameters and functions. -Wunused-but-set-parameter is explicitly enabled because it may indicate more serious error. The option is not available when HOST_CC is defined.
