### PR TITLE
Fix bug #666

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -266,7 +266,7 @@ static int PE_(r_bin_pe_init_sections)(struct PE_(r_bin_pe_obj_t)* bin) {
 	if (r_buf_read_at (bin->b, bin->dos_header->e_lfanew + 4 + sizeof (PE_(image_file_header)) +
 				bin->nt_headers->file_header.SizeOfOptionalHeader,
 				(ut8*)bin->section_header, sections_size) == -1) {
-		eprintf ("Error: read (import directory)\n");
+        eprintf ("Error: read (sections)\n");
 		return R_FALSE;
 	}
 #if 0


### PR DESCRIPTION
https://github.com/radare/radare2/issues/666
1. Wrong print message.
2. If number of section equal to 0, it does not mean that we can not load file. Correpond to this - https://code.google.com/p/corkami/wiki/PE (required elements, a more extreme PE can rely on even less elements:).

All another may be load without any section correspond to above link.
