### PR TITLE
A fix for issue #936 - mips analyser not honouring endian

### DIFF
--- a/libr/anal/p/anal_mips.c
+++ b/libr/anal/p/anal_mips.c
@@ -21,7 +21,7 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b_in, int len
 	op->delay = 0;
 	r_strbuf_init (&op->esil);
 
-	// Reminder: r_mem_copyendian swaps if arg `endian` !=0 ...
+	// Reminder: r_mem_copyendian swaps if arg `endian` ==0 ...
 	// When anal->big_endian is "false", as for mipsel architecture, we NEED to swap here for the below analysis to work.
 	r_mem_copyendian ((ut8*)&opcode, b_in, 4, anal->big_endian ? 1 : 0);
 	r_mem_copyendian (b, b_in, 4, anal->big_endian ? 1 : 0);


### PR DESCRIPTION
For some reason, the mips analyser is ignoring the endian flag, as described in #936.

Someone had commented that out and just used a direct memcpy.
