### PR TITLE
renamed r_io_section_get as r_io_section_mget

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -369,7 +369,7 @@ static int cmd_search(void *data, const char *input) {
 	searchflags = r_config_get_i (core->config, "search.flags");
 	//TODO: handle section ranges if from&&to==0
 /*
-	section = r_io_section_get (core->io, core->offset);
+	section = r_io_section_mget (core->io, core->offset);
 	if (section) {
 		from += section->vaddr;
 		//fin = ini + s->size;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -352,7 +352,7 @@ R_API void r_io_section_clear(RIO *io);
 R_API int r_io_section_rm(RIO *io, int idx);
 R_API void r_io_section_list(RIO *io, ut64 offset, int rad);
 R_API void r_io_section_list_visual(RIO *io, ut64 seek, ut64 len);
-R_API RIOSection *r_io_section_get(RIO *io, ut64 offset);
+R_API RIOSection *r_io_section_mget(RIO *io, ut64 offset);
 R_API ut64 r_io_section_get_offset(RIO *io, ut64 offset);
 R_API ut64 r_io_section_get_vaddr(RIO *io, ut64 offset);
 R_API int r_io_section_get_rwx(RIO *io, ut64 offset);


### PR DESCRIPTION
Seems like these should be r_io_section_mget after all the current refactoring
