### PR TITLE
bin: Delete the list of objs instead of deleting current object

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -619,7 +619,7 @@ static void r_bin_file_free (void /*RBinFile*/ *bf_) {
 	if (a->curxtr && a->curxtr->destroy)
 		a->curxtr->free_xtr ((void *) (a->xtr_obj));
 
-	r_bin_object_free (a->o);
+	r_list_free (a->objs);
 	a->o = NULL;
 	r_buf_free (a->buf);
 	// TODO: unset related sdb namespaces


### PR DESCRIPTION
Fixes #971

Note, that after r_bin_reload a->o pointer still points to previously freed RBinObject, that also needs to be fixed.
