### PR TITLE
try to make r_io_mread work as expected

### DIFF
--- a/libr/io/vio.c
+++ b/libr/io/vio.c
@@ -202,19 +202,27 @@ R_API int r_io_vread (RIO *io, ut64 vaddr, ut8 *buf, int len) {
 
 R_API int r_io_mread (RIO *io, ut64 maddr, ut8 *buf, int len) {
 	int ret;						//return stat
-	ut64 endaddr = maddr + len;				//end-of-read-address
+	ut64 endaddr;						//end-of-read-address
 	ut64 paddr;						//physical address in the map
 	RIODesc *desc;
 	RIOMap *map;
-	assert (len>=0);					//this can only happen if there is a bug somewhere else, so aborting is reasonable
+	if (len>=0) {						//this can only happen if there is a bug somewhere else, so aborting is reasonable
+		eprintf ("wrong usage of r_io_mread: len is smaller than 0. len: %i\n", len);
+		return R_FAIL;
+	}
+	if ((UT64_MAX - len) < maddr) {				//say no to integer-overflows
+		eprintf ("sorry, but I won't let you overflow this ut64\n");
+		len = UT64_MAX - maddr;				//adjust len
+	}
+	endaddr = maddr + len;					//set endaddr
 	map = r_io_map_get(io, maddr);				//get the map at current offset
 	if (!map) {
 		eprintf ("cannot get map at 0x%08"PFMT64x" in r_io_mread\n", maddr);
 		return 0;					//return 0, because 0 bytes are read here
 	}
 	if (endaddr > map->to) {				//prevent reading out of the map
-		endaddr = map->to;				//fix endaddr
-		len = endaddr - maddr;				//fix len
+		endaddr = map->to;				//adjust endaddr
+		len = endaddr - maddr;				//adjust len
 	}
 	paddr = maddr - map->from + map->delta;			//resolve paddr
 	desc = io->desc;					//save current desc


### PR DESCRIPTION
I hope that this is correct. I expect mread to read len bytes from map at maddr, or unitl the end of map if len + maddr is greater than map->to, and then return the number of bytes read.

I hope that my comments help others, who want to help fixing io or just want to understand io-code.
