### PR TITLE
Properly fix incorrect handling of branch delay in analysis.

### DIFF
--- a/libr/core/anal.c
+++ b/libr/core/anal.c
@@ -510,6 +510,7 @@ R_API int r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dept
 		goto error;
 	}
 
+	//r_cons_clear_line (1);
 	//eprintf ("FUNC 0x%08"PFMT64x"\n", at+fcnlen);
 	do {
 		int delta = fcn->size;


### PR DESCRIPTION
This fixes function length and flag detection properly for all cases for a branch delay processor (i.e. MIPS)
The previous fix I submitted only made a workaround for functions that had no internal branches or conditional jumps.
Also submitting pull request for radare-regressions
