### PR TITLE
fix exports parsing (Corkami test)

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -693,7 +693,12 @@ export_dir_vaddr = data_dir_export->VirtualAddress;
 		}
 		exports[i].last = 1;
 	}
-	return parse_symbol_table (bin, exports, exports_sz - 1);
+
+	if (parse_symbol_table (bin, exports, exports_sz - 1) == 0) {
+		eprintf("Warning: bad symbol table\n");
+	}
+
+	return exports;
 }
 
 int PE_(r_bin_pe_get_file_alignment)(struct PE_(r_bin_pe_obj_t)* bin) {


### PR DESCRIPTION
I dont know why need to parse symbol table here, but this was problem why `rabin2 -s CoST.exe` gave wrong output. It is correct now and looks like: (that correspond to f.e. CFF Explorer)

```
[Symbols]
addr=0x0000007e off=0x0000007e ord=000 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_0_TLS_START
addr=0x000000a4 off=0x000000a4 ord=001 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_1_TLS_2
addr=0x00000000 off=0x00000000 ord=002 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_2_EntryPoint
addr=0x00000120 off=0x00000120 ord=003 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_3_EntryPoint2
addr=0x000001b0 off=0x000001b0 ord=004 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_4_Main
addr=0x00001868 off=0x00001868 ord=005 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_antis
addr=0x00000520 off=0x00000520 ord=006 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_classics
addr=0x000020b0 off=0x000020b0 ord=007 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_disassembly
addr=0x000012e0 off=0x000012e0 ord=008 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_encodings
addr=0x000000b0 off=0x000000b0 ord=009 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_erased_call_operand
addr=0x000019de off=0x000019de ord=010 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_exceptions
addr=0x000018f0 off=0x000018f0 ord=011 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_getips
addr=0x000003e0 off=0x000003e0 ord=012 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_jumps
addr=0x000015f8 off=0x000015f8 ord=013 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_nops
addr=0x00000ca0 off=0x00000ca0 ord=014 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_rares
addr=0x00002130 off=0x00002130 ord=015 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_sixtyfour
addr=0x00001120 off=0x00001120 ord=016 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_specifics
addr=0x00000003 off=0x00000003 ord=017 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_the_dragon
addr=0x00001060 off=0x00001060 ord=018 fwd=NONE sz=0 bind=NONE type=FUNC name=CoST.exe_undocumented

19 symbols
```
