### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ language: c
 compiler:
   - gcc
   - clang
-  # TODO: add ASan (+LSan), MSan, TSan, ...
+  # With this scarry double quotation the strings will be passed to the shell
+  # still quoted, which is necessary here.
+  - '"clang -fsanitize=address"'
+  - '"clang -fsanitize=memory -fsanitize-memory-track-origins"'
+  - '"clang -fsanitize=thread"'
 
 # Additional depencies like capstone are downloaded by the r2 makefiles.
 install:
@@ -16,6 +20,15 @@ install:
   - sed -i 's/\\r//' radare2-regressions/tests.sh
 
 script:
+  # llvm-symbolizer isn't in PATH, so we need this.
+  # (Also, YAML doesn't like underscores)
+  - export SYMBOLIZER=/usr/local/clang-3.4/bin/llvm-symbolizer
+  - export ASAN_SYMBOLIZER_PATH=$SYMBOLIZER
+  - export MSAN_SYMBOLIZER_PATH=$SYMBOLIZER
+  - 'export TSAN_OPTIONS=external_symbolizer_path=$SYMBOLIZER'
+  # Limit the stack size (to 32MiB) to make ThreadSanitizer happy.
+  - ulimit -s 32768
+  # Now on to actually building stuff...
   - ./configure   # TODO: Might enable some of the additional features.
   - make
   - sudo make install


### PR DESCRIPTION
This pull request adds a .travis.yml file that builds r2 and runs the test suite under AddressSanitizer, MemorySanitizer and ThreadSanitizer. Valgrind isn't yet run.

Travis can easily be enabled for pull requests, I don't know how well that works with Jenkins.

Preliminary results can be viewed at https://travis-ci.org/neuschaefer/radare2/builds/27454564.
