### PR TITLE
Workaround to ensure mips / branch delayed code calculates function size correctly

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -380,8 +380,17 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut8 *buf, ut6
 
 			anal->iob.read_at (anal->iob.io, op.fail, bbuf, sizeof (bbuf));
 			FITFCNSZ();
-			// TODO: Discuss this 'return' statement, is this only necessary for mips?
-			return fcn_recurse (anal, fcn, op.fail, bbuf, sizeof (bbuf), depth-1);
+			// TODO: Discuss bypassing this 'return' statement,
+			//       is this only necessary for branch delayed instructions?
+			ret = fcn_recurse (anal, fcn, op.fail, bbuf, sizeof (bbuf), depth-1);
+			if (!op.delay) {
+				// this will be all x86, arm (at least)
+				// without which the analysis is really slow,
+				// presumably because each opcode would get revisited
+				// (and already covered by a bb) many times
+				return ret;
+			}
+                        // For some reason, branch delayed code (MIPS) needs to continue
 #if 0
 		// do not add xrefs for cjmps?
 				r_anal_op_fini (&op);


### PR DESCRIPTION
OK - in follow up to my previous introduced regression.

Although I am not quite sure why this is needed, but it doesn't work without it.

I also added some tests to radare-regressions
