### PR TITLE
Fix the 'is' command, which is broken due to a bad format string passed ...

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -181,8 +181,8 @@ static int bin_strings (RCore *r, int mode, ut64 baddr, int va) {
 					string->string, size, va?baddr+string->vaddr:string->paddr,
 					string->size, va?baddr+string->vaddr:string->paddr);
 			} else r_cons_printf ("addr=0x%08"PFMT64x" off=0x%08"PFMT64x
-				" ordinal=%03"PFMT64d" "
-				"sz=%d len=%d section=%s type=%c string=%s\n",
+				" ordinal=%03u "
+				"sz=%u len=%u section=%s type=%c string=%s\n",
 				baddr+string->vaddr, string->paddr,
 				string->ordinal, string->size, string->length,
 				section?section->name:"unknown",


### PR DESCRIPTION
The `is` command (used to list symbols) result to a segfault in the master branch and the stable branch, but not in the ArchLinux package (the version is 0.9.7).
I didn't find which commit broke it, but the segfault is due to a bad format string passed to r_cons_printf : a format PFMT64 is used to print ut32 integer.

This patch try to fix this behavior.

-TOSH-
