### PR TITLE
More improvements for cygwin building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 -include config-user.mk
 include global.mk
 
+DESTDIR:=$(call rmbdlslash,$(DESTDIR))
+WWWROOT:=$(call rmbdlslash,$(WWWROOT))
 R2R=radare2-regressions
 R2R_URL=$(shell doc/repo REGRESSIONS)
-DLIBDIR=$(DESTDIR)/$(LIBDIR)
+DLIBDIR=$(call rmdblslash,$(DESTDIR)/$(LIBDIR))
 R2BINS=$(shell cd binr ; echo r*2)
 DATADIRS=libr/cons/d libr/asm/d libr/syscall/d libr/magic/d
 #binr/ragg2/d
@@ -61,7 +63,7 @@ w32dist:
 	#mkdir -p w32dist/include/libr/sflib
 	cp -f doc/fortunes w32dist/share/doc/radare2
 	mv w32dist radare2-w32-${VERSION}
-	rm -f radare2-w32-${VERSION}.zip 
+	rm -f radare2-w32-${VERSION}.zip
 	zip -r radare2-w32-${VERSION}.zip radare2-w32-${VERSION}
 
 clean:
@@ -104,22 +106,22 @@ install: install-doc install-man install-www
 	done
 	mkdir -p ${DLIBDIR}/radare2/${VERSION}/hud
 	cp -f doc/hud ${DLIBDIR}/radare2/${VERSION}/hud/main
-	mkdir -p ${DESTDIR}/${PREFIX}/share/radare2/${VERSION}/
-	cp -fr shlr/yara/ ${DESTDIR}/${PREFIX}/share/radare2/${VERSION}/yara/
+	mkdir -p $(call rmdblslash,${DESTDIR}/${PREFIX}/share/radare2/${VERSION}/)
+	cp -fr shlr/yara/ $(call rmdblslash,${DESTDIR}/${PREFIX}/share/radare2/${VERSION}/yara/)
 	#cp ${PWD}/libr/lang/p/radare.lua ${DLIBDIR}/radare2/${VERSION}/radare.lua
 	sys/ldconfig.sh
 
 install-www:
-	rm -rf ${DESTDIR}/${WWWROOT}
+	rm -rf $(call rmdblslash,${DESTDIR}/${WWWROOT})
 	rm -rf ${DLIBDIR}/radare2/${VERSION}/www # old dir
-	mkdir -p ${DESTDIR}/${WWWROOT}
-	cp -rf shlr/www/* ${DESTDIR}/${WWWROOT}
+	mkdir -p $(call rmdblslash,${DESTDIR}/${WWWROOT})
+	cp -rf shlr/www/* $(call rmdblslash,${DESTDIR}/${WWWROOT})
 
 symstall-www:
-	rm -rf ${DESTDIR}/${WWWROOT}
+	rm -rf $(call rmdblslash,${DESTDIR}/${WWWROOT})
 	rm -rf ${DLIBDIR}/radare2/${VERSION}/www # old dir
-	mkdir -p ${DESTDIR}/${WWWROOT}
-	cd ${DESTDIR}/${WWWROOT} ; for a in ${PWD}/shlr/www/* ; do \
+	mkdir -p $(call rmdblslash,${DESTDIR}/${WWWROOT})
+	cd $(call rmdblslash,${DESTDIR}/${WWWROOT}) ; for a in ${PWD}/shlr/www/* ; do \
 		ln -fs $$a ${DESTDIR}/${DATADIR}/radare2/${VERSION}/www ; done
 
 install-pkgconfig-symlink:

--- a/binr/Makefile
+++ b/binr/Makefile
@@ -1,13 +1,14 @@
 include ../global.mk
 include ../libr/config.mk
 
+DESTDIR:=$(call rmbdlslash,$(DESTDIR))
 BTOP=$(shell pwd)
 
 .PHONY: all clean install install-symlink deinstall uninstall mrproper preload
 
-PFX=${DESTDIR}/${PREFIX}
-BFX=${DESTDIR}/${BINDIR}
-LFX=${DESTDIR}/${LIBDIR}
+PFX=$(call rmdblslash,${DESTDIR}/${PREFIX})
+BFX=$(call rmdblslash,${DESTDIR}/${BINDIR})
+LFX=$(call rmdblslash,${DESTDIR}/${LIBDIR})
 
 BINS=rax2 rasm2 rabin2 rahash2 radiff2 radare2 rafind2 rarun2 ragg2 r2agent
 

--- a/global.mk
+++ b/global.mk
@@ -25,6 +25,10 @@ PREFIX=${PWD}/prefix
 VERSION=`date '+%Y%m%d'`
 endif
 
+define rmdblslash
+        @echo '$1' | sed -e 's,//,/,g' -e 's,//,/,g' -e 's,/$$,,'
+endef
+
 PFX=${DESTDIR}${PREFIX}
 MDR=${DESTDIR}${MANDIR}
 

--- a/libr/Makefile
+++ b/libr/Makefile
@@ -2,11 +2,12 @@ include ../global.mk
 include config.mk
 include ../mk/${COMPILER}.mk
 
+DESTDIR:=$(call rmbdlslash,$(DESTDIR))
 PREFIX?=${PWD}/../prefix
-PFX=${DESTDIR}/${PREFIX}
-LFX=${DESTDIR}/${LIBDIR}
-IFX=${DESTDIR}/${INCLUDEDIR}
-PWD=$(shell pwd)
+PFX=$(call rmdblslash,${DESTDIR}/${PREFIX})
+LFX=$(call rmdblslash,${DESTDIR}/${LIBDIR})
+IFX=$(call rmdblslash,${DESTDIR}/${INCLUDEDIR})
+PWD=$(call rmdblslash,$(shell pwd))
 
 LIBS0=util hash
 LIBS1=reg cons db magic diff bp search config socket

--- a/libr/config.mk.tail
+++ b/libr/config.mk.tail
@@ -108,13 +108,7 @@ EXT_SO=dll
 EXT_EXE=.exe
 TH_LIBS=
 endif
-ifeq (${OSTYPE},cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin)
+ifneq (,$(findstring cygwin,${OSTYPE}))
 CFLAGS+=-D__CYGWIN__=1
 EXT_AR=lib
 EXT_SO=dll

--- a/mk/gcc.mk
+++ b/mk/gcc.mk
@@ -18,13 +18,7 @@ CFLAGS_DEBUG=-g
 ifeq ($(OSTYPE),auto)
 OSTYPE=$(shell uname | tr 'A-Z' 'a-z')
 endif
-ifeq ($(OSTYPE),cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin)
+ifneq (,$(findstring cygwin,${OSTYPE}))
 PIC_CFLAGS=
 else
 PIC_CFLAGS=-fPIC

--- a/mk/tcc.mk
+++ b/mk/tcc.mk
@@ -15,13 +15,7 @@ CFLAGS_OPT3=-O3
 ifeq ($(OSTYPE),auto)
 OSTYPE=$(shell uname | tr 'A-Z' 'a-z')
 endif
-ifeq ($(OSTYPE),cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin)
+ifneq (,$(findstring cygwin,$(OSTYPE)))
 PIC_CFLAGS=
 else
 PIC_CFLAGS=-fPIC

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -163,5 +163,5 @@ capstone-build: capstone
 	cd capstone && CFLAGS="-Dmips=mips $(CFLAGS)" LDFLAGS="$(LDFLAGS)" \
 		$(MAKE) CC="$(CC)" AR_EXT=a IS_CYGWIN=0 \
 		RANLIB="$(RANLIB)" AR="$(AR)" \
-		libcapstone.a 
+		libcapstone.a
 endif

--- a/shlr/grub/Makefile
+++ b/shlr/grub/Makefile
@@ -4,7 +4,7 @@ include ../../config-user.mk
 CC?=gcc
 CC_AR?=ar q
 RANLIB?=ranlib
-OSTYPE?=$(shell uname -s)
+OSTYPE=$(shell uname | tr 'A-Z' 'a-z')
 ifeq (${OSTYPE},)
 all:
 	echo LE FAIL
@@ -57,17 +57,11 @@ CFLAGS+=-Iinclude
 CFLAGS+=-I../../libr/include -DGRUB_TARGET_NO_MODULES
 CFLAGS+=-g
 
-ifeq ($(OSTYPE),cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifneq ($(OSTYPE),cygwin)
+ifneq (,$(findstring cygwin,${OSTYPE}))
 CFLAGS+=-fPIC
 endif
 # This fixes a silly GNU gcc build problem in OSX - BLAME! :D
-ifeq ($(OSTYPE),darwin)
+ifeq (${OSTYPE},darwin)
 CFLAGS+=-DAPPLE_CC
 endif
 

--- a/shlr/java/Makefile
+++ b/shlr/java/Makefile
@@ -2,20 +2,14 @@ include ../../config-user.mk
 include ../../mk/${COMPILER}.mk
 SHLR?=$(shell pwd)/..
 
-OSTYPE?=$(shell uname -s)
+OSTYPE?=$(shell uname | tr 'A-Z' 'a-z')
 ifeq (${OSTYPE},)
 all:
 	echo LE FAIL
 	exit 1
 endif
 
-ifeq ($(OSTYPE),cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq ($(OSTYPE),cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifneq ($(OSTYPE),cygwin)
+ifeq (,$(findstring cygwin,${OSTYPE}))
 CFLAGS+=-fPIC
 endif
 

--- a/shlr/tcc/Makefile
+++ b/shlr/tcc/Makefile
@@ -2,10 +2,20 @@ include ../../config-user.mk
 include ../../mk/${COMPILER}.mk
 OFILES=libtcc.o tccgen.o tccpp.o
 
-CFLAGS+=-I../../libr/include
-CFLAGS+=-fPIC -Wall -g -ggdb
+ifneq (,$(findstring cygwin,${OSTYPE}))
+CFLAGS+=-D__CYGWIN__=1
+EXT_SO=dll
+SOVER=${EXT_SO}
 LDFLAGS+=-shared
-ifeq ($(OSNAME),darwin)
+LDFLAGS_SHARED?=-shared
+else
+CFLAGS+=-fPIC
+endif
+
+CFLAGS+=-I../../libr/include
+CFLAGS+=-Wall -g -ggdb
+LDFLAGS+=-shared
+ifeq (${OSNAME},darwin)
 SOEXT?=dylib
 else
 SOEXT?=so

--- a/shlr/zip/zip/Makefile
+++ b/shlr/zip/zip/Makefile
@@ -2,13 +2,7 @@ include ../../../config-user.mk
 include ../../../libr/config.mk
 include ../../../mk/${COMPILER}.mk
 
-ifeq (${OSTYPE},cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin)
+ifneq (,$(findstring cygwin,${OSTYPE}))
 CFLAGS+=-D__CYGWIN__=1
 EXT_SO=dll
 SOVER=${EXT_SO}

--- a/shlr/zip/zlib/Makefile
+++ b/shlr/zip/zlib/Makefile
@@ -2,13 +2,7 @@ include ../../../config-user.mk
 include ../../../libr/config.mk
 include ../../../mk/${COMPILER}.mk
 
-ifeq (${OSTYPE},cygwin_nt-6.1)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin_nt-6.1-wow64)
-OSTYPE=cygwin
-endif
-ifeq (${OSTYPE},cygwin)
+ifneq (,$(findstring cygwin,${OSTYPE}))
 CFLAGS+=-D__CYGWIN__=1
 EXT_SO=dll
 SOVER=${EXT_SO}


### PR DESCRIPTION
Removed more -fPIC for cygwin builds, included stuff from https://github.com/radare/radare2/pull/847

But! Installation still doesn't work properly:

```
 ~/radare/radare2
$ make install
/usr/bin/install -d /usr/local/share/doc/radare2
for a in doc/* ; do /usr/bin/install -m 644 $a /usr/local/share/doc/radare2 ; done
mkdir -p /usr/local/share/man/man1
for a in man/*.1 ; do /usr/bin/install -m 444 $a /usr/local/share/man/man1 ; done
cd /usr/local/share/man/man1 && ln -fs radare2.1 r2.1
rm -rf         @echo '/' | sed -e 's,//,/,g' -e 's,//,/,g' -e 's,/$,,'
rm: it is dangerous to operate recursively on `/'
rm: use --no-preserve-root to override this failsafe
rm -rf         @echo '//usr/local/lib' | sed -e 's,//,/,g' -e 's,//,/,g' -e 's,/$,,'/radare2/0.9.8.git/www # old dir
sed: -e expression #3, char 7: unknown option to `s'
Makefile:115: recipe for target 'install-www' failed
make: *** [install-www] Error 1
```
