### PR TITLE
Add r_config_node_desc to fix potential null derefs in core/config.c

### DIFF
--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -207,8 +207,15 @@ R_API RConfigNode *r_config_set(RConfig *cfg, const char *name, const char *valu
 	return node;
 }
 
+/* r_config_desc takes a RConfig and a name,
+ * r_config_node_desc takes a RConfigNode
+ * Both set and return node->desc */
 R_API const char *r_config_desc(RConfig *cfg, const char *name, const char *desc) {
 	RConfigNode *node = r_config_node_get (cfg, name);
+	return r_config_node_desc (node, desc);
+}
+
+R_API const char *r_config_node_desc(RConfigNode *node, const char *desc) {
 	if (node) {
 		if (desc) {
 			free (node->desc);

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -2,10 +2,10 @@
 
 #include <r_core.h>
 
-#define SETI(x,y,z) r_config_set_i(cfg,x,y)->desc = strdup(z);
-#define SETICB(w,x,y,z) r_config_set_i_cb(cfg,w,x,y)->desc = strdup(z);
-#define SETPREF(x,y,z) r_config_set(cfg,x,y)->desc = strdup(z);
-#define SETCB(w,x,y,z) r_config_set_cb(cfg,w,x,y)->desc = strdup(z);
+#define SETI(x,y,z) r_config_node_desc(r_config_set_i(cfg,x,y), z);
+#define SETICB(w,x,y,z) r_config_node_desc(r_config_set_i_cb(cfg,w,x,y), z);
+#define SETPREF(x,y,z) r_config_node_desc(r_config_set(cfg,x,y), z);
+#define SETCB(w,x,y,z) r_config_node_desc(r_config_set_cb(cfg,w,x,y), z);
 
 // copypasta from binr/rasm2/rasm2.c
 static void rasm2_list(RAsm *a, const char *arch) {

--- a/libr/include/r_config.h
+++ b/libr/include/r_config.h
@@ -57,6 +57,7 @@ R_API int r_config_rm(RConfig *cfg, const char *name);
 R_API ut64 r_config_get_i(RConfig *cfg, const char *name);
 R_API const char *r_config_get(RConfig *cfg, const char *name);
 R_API const char *r_config_desc(RConfig *cfg, const char *name, const char *desc);
+R_API const char *r_config_node_desc(RConfigNode *node, const char *desc);
 R_API void r_config_list(RConfig *cfg, const char *str, int rad);
 R_API RConfigNode *r_config_node_get(RConfig *cfg, const char *name);
 R_API RConfigNode *r_config_node_new(const char *name, const char *value);


### PR DESCRIPTION
It's the same as r_config_desc but takes a node instead of a name.

And adapt the macros in core/config.c to use this function instead of
just doing r_config_node_set_etc()->desc.

(This is the proper fix for the issue mentioned in the comments of #1093)
