### PR TITLE
fixes the time argument at r_socket_ready for the poll part

### DIFF
--- a/libr/socket/http_server.c
+++ b/libr/socket/http_server.c
@@ -17,7 +17,7 @@ R_API RSocketHTTPRequest *r_socket_http_accept (RSocket *s, int timeout) {
 	for (;;) {
 		memset (buf, 0, sizeof (buf));
 		xx = r_socket_gets (hr->s, buf, sizeof (buf));
-		yy = r_socket_ready (hr->s, 0, 20);
+		yy = r_socket_ready (hr->s, 0, 20 * 1000); //this function uses usecs as argument
 //		eprintf ("READ %d (%s) READY %d\n", xx, buf, yy);
 		if (!yy || (!xx && !pxx)) {
 			break;

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -435,11 +435,12 @@ R_API int r_socket_flush(RSocket *s) {
 /* returns -1 on error, 0 is false, 1 is true */
 R_API int r_socket_ready(RSocket *s, int secs, int usecs) {
 #if __UNIX__
+	int msecs = usecs / 1000;
 	struct pollfd fds[1];
 	fds[0].fd = s->fd;
 	fds[0].events = POLLIN|POLLPRI;
 	fds[0].revents = POLLNVAL|POLLHUP|POLLERR;
-	return poll ((struct pollfd *)&fds, 1, usecs);
+	return poll ((struct pollfd *)&fds, 1, msecs);
 #elif __WINDOWS__
 	return 1;
 #if XXX_THIS_IS_NOT_WORKING_WELL


### PR DESCRIPTION
poll and select uses different arguments for the time value. 
Poll uses msecs and select is using usecs. I assume that the call of r_socket_ready in http_server is msecs so i
have multiplied the value with 1000.
