### PR TITLE
Some bug fixes and tweaks

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -174,6 +174,7 @@ R_API char *r_anal_optype_to_string(int t) {
 	case R_ANAL_OP_TYPE_XCHG  : return "xchg";
 	case R_ANAL_OP_TYPE_MOD   : return "mod";
 	case R_ANAL_OP_TYPE_SWITCH : return "switch";
+	case R_ANAL_OP_TYPE_CASE:	return "case";
 	}
 	return "undefined";
 }
@@ -314,6 +315,7 @@ R_API char *r_anal_op_to_string(RAnal *anal, RAnalOp *op) {
 	case R_ANAL_OP_TYPE_ROL:
 	case R_ANAL_OP_TYPE_ROR:
 	case R_ANAL_OP_TYPE_SWITCH:
+	case R_ANAL_OP_TYPE_CASE:
 		eprintf ("Command not implemented.\n");
 		free (r0);
 		free (a0);

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -51,6 +51,10 @@ typedef struct r_anal_ex_java_lin_sweep {
 
 ut64 METHOD_START = 0;
 
+// XXX - TODO add code in the java_op that is aware of when it is in a
+// switch statement, like in the shlr/java/code.c so that this does not 
+// report bad blocks.  currently is should be easy to ignore these blocks,
+// in output for the pdj
 
 //static int java_print_ssa_fcn (RAnal *anal, char *addr);
 //static int java_print_ssa_bb (RAnal *anal, char *addr);
@@ -778,7 +782,25 @@ static int java_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 	// handle lookup and table switch offsets
 	if (op_byte == 0xaa || op_byte == 0xab) {
 		java_switch_op (anal, op, addr, data, len);
+		// IN_SWITCH_OP = 1;
 	}
+	/* TODO: 
+	// not sure how to handle the states for IN_SWITCH_OP, SWITCH_OP_CASES,
+	// and NUM_CASES_SEEN, because these are dependent on whether or not we
+	// are in a switch, and given the non-reentrant state of opcode analysis
+	// this can't always be guaranteed.  Below is the pseudo code for handling
+	// the easy parts though
+	if (IN_SWITCH_OP) {
+		NUM_CASES_SEEN++;
+		if (NUM_CASES_SEEN == SWITCH_OP_CASES) IN_SWITCH_OP=0;
+		op->addr = addr;
+		op->size = 4;
+		op->type2 = 0;
+		op->type = R_ANAL_OP_TYPE_CASE
+		op->eob = 0;
+		return op->sizes;
+	}
+	*/
 
 	op->eob = r_anal_ex_is_op_type_eop (op->type2);
 	IFDBG {

--- a/libr/anal/switch.c
+++ b/libr/anal/switch.c
@@ -27,7 +27,7 @@ R_API void r_anal_switch_op_free(RAnalSwitchOp * swop) {
 	free(swop);
 }
 
-R_API RAnalCaseOp* r_anal_switch_op_add_case(RAnalSwitchOp * swop, ut64 addr, ut64 jump, ut64 value) {
+R_API RAnalCaseOp* r_anal_switch_op_add_case(RAnalSwitchOp * swop, ut64 addr, ut64 value, ut64 jump) {
 	RAnalCaseOp * caseop = R_NEW0(RAnalCaseOp);
 	caseop->addr = addr;
 	caseop->value = value;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1936,6 +1936,9 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len) {
 		r_cons_printf (",\"type2_num\":%"PFMT64d, analop.type2);
 		// handle switch statements
 		if (analop.switch_op && r_list_length (analop.switch_op->cases) > 0) {
+			// XXX - the java caseop will still be reported in the assembly,
+			// this is an artifact to make ensure the disassembly is properly
+			// represented during the analysis
 			RListIter *iter;
 			RAnalCaseOp *caseop;
 			int cnt = r_list_length (analop.switch_op->cases);
@@ -1950,8 +1953,6 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len) {
 				if (cnt > 0) r_cons_printf (",");
 			}
 			r_cons_printf ("]");
-		} else {
-			r_cons_printf (",\"is_switch\":0");
 		}
 		if (analop.jump != UT64_MAX ) {
 			r_cons_printf (",\"next\":%"PFMT64d, analop.jump);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -416,6 +416,7 @@ typedef enum {
 	R_ANAL_OP_TYPE_XCHG  = 36,
 	R_ANAL_OP_TYPE_MOD   = 37,
 	R_ANAL_OP_TYPE_SWITCH = 38,
+	R_ANAL_OP_TYPE_CASE = 39,
 } _RAnalOpType;
 
 /* TODO: what to do with signed/unsigned conditionals? */
@@ -1206,7 +1207,7 @@ R_API int r_anal_esil_eval(RAnal *anal, const char *str);
 /* switch.c APIs */
 R_API RAnalSwitchOp * r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 max_val);
 R_API void r_anal_switch_op_free(RAnalSwitchOp * swop);
-R_API RAnalCaseOp* r_anal_switch_op_add_case(RAnalSwitchOp * swop, ut64 addr, ut64 jump, ut64 value);
+R_API RAnalCaseOp* r_anal_switch_op_add_case(RAnalSwitchOp * swop, ut64 addr, ut64 value, ut64 jump);
 
 /* cycles.c */
 R_API RAnalCycleFrame* r_anal_cycle_frame_new ();

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -316,7 +316,7 @@ static RBinJavaAccessFlags FIELD_ACCESS_FLAGS[] = {
 	{"public", R_BIN_JAVA_FIELD_ACC_PUBLIC, 6},
 	{"private", R_BIN_JAVA_FIELD_ACC_PRIVATE, 7},
 	{"protected", R_BIN_JAVA_FIELD_ACC_PROTECTED, 9},
-	{"R_API", R_BIN_JAVA_FIELD_ACC_STATIC, 6},
+	{"static", R_BIN_JAVA_FIELD_ACC_STATIC, 6},
 	{"final", R_BIN_JAVA_FIELD_ACC_FINAL, 5},
 	{"undefined.0x0020", 0x0020, 16},
 	{"volatile", R_BIN_JAVA_FIELD_ACC_VOLATILE, 8},
@@ -335,7 +335,7 @@ static RBinJavaAccessFlags METHOD_ACCESS_FLAGS[] = {
 	{"public", R_BIN_JAVA_METHOD_ACC_PUBLIC, 6},
 	{"private", R_BIN_JAVA_METHOD_ACC_PRIVATE, 7},
 	{"protected", R_BIN_JAVA_METHOD_ACC_PROTECTED, 9},
-	{"R_API", R_BIN_JAVA_METHOD_ACC_STATIC, 6},
+	{"static", R_BIN_JAVA_METHOD_ACC_STATIC, 6},
 	{"final", R_BIN_JAVA_METHOD_ACC_FINAL, 5},
 	{"synchronized", R_BIN_JAVA_METHOD_ACC_SYNCHRONIZED, 12},
 	{"bridge", R_BIN_JAVA_METHOD_ACC_BRIDGE, 6},
@@ -2046,7 +2046,7 @@ R_API RList * r_bin_java_get_entrypoints(RBinJavaObj* bin) {
 		if (strcmp (fm_type->name, "main") == 0 ||
 			strcmp (fm_type->name, "<init>") == 0 ||
 			strcmp (fm_type->name, "<clinit>") == 0 ||
-			strstr (fm_type->flags_str, "R_API") != 0 ) {
+			strstr (fm_type->flags_str, "static") != 0 ) {
 			addr = R_NEW (RBinAddr);
 			if (addr) {
 				memset (addr, 0, sizeof (RBinAddr));


### PR DESCRIPTION
Bug in the code flipped jump and case value of the switch op, remove dangling in_switch key, and add a formal "case" op-type and changed some strings back to "static" from "R_API" (https://github.com/radare/radare2/issues/1198).  Also added comments for appropriately handling the misreported caseop in the java_op function.  Note this is only used when doing sequential disassembly without following control flow in code.
