### PR TITLE
More better English - Fortunes review

### DIFF
--- a/doc/fortunes
+++ b/doc/fortunes
@@ -31,7 +31,7 @@ In soviet russia, radare2 debugs you!
 Add comments using the ';' key in visual mode or the 'C' command from the radare2 shell
 Assemble opcodes with the 'a' and 'A' keys in visual mode, which are bindings to the 'wa' and 'wA' commands
 Find expanded AES keys in memory with '/Ca'
-Find wide-char strings with '/w <string> command'
+Find wide-char strings with the '/w <string>' command
 Enable ascii-art jump lines in disassembly by setting 'e asm.lines=true'. asm.linesout and asm.linestyle may interest you as well
 Control the signal handlers of the child process with the 'dk' command
 Get a free shell with 'ragg2 -i exec -x'


### PR DESCRIPTION
r2 - Now with more better English

Bellow are some fortunes that either didn't make sense, may be outdated, or just didn't work. For these cases, it is better for those more familiar with r2 to help clarify and fix (bad commands, vars, etc.) before even trying to cleanup grammar :)

01: Do you want to perform more than one search at a time? '> /k0 keyword1', '> /k1 keyword2' and '> /r 0-1'
42: Use hasher to calculate hashes of portion blocks of a file
43: Use zoom.byte=entropy and press 'z' in visual mode to zoom out to see the entropy of the whole file
47: Move the comments to the right changing their margin with asm.cmtmargin
48: Execute a command on the visual prompt with cmd.vprompt
49: Reduce the delta where flag resolving by address is used with cfg.delta
52: Follow a flag in disassembly view (avoids to disasemble out of the visibility of the flag) with asm.follow
55: Change the UID of the debugged process with child.uid (requires root)
56: Enable full backtrace with dbg.fullbt
58: Find cp850 strings with 'e cfg.encoding=cp850' and '/s'
59: Enhace your graphs by increasing the size of the block and graph.depth eval variable.
60: Control the height of the terminal on serial consoles with e scr.height
61: Use e file.id=true and e file.flag=true in your ~/.radare2rc to get symbols, strings, .. when loading
62: Emulate the base address of a file with e file.baddr.
63: Bindiff two files with '$ bdiff /bin/true /bin/false'
65: Temporally drop the verbosity prefixing the commands with ':'
66: Change the graph block definition with graph.callblocks, graph.jmpblocks, graph.flagblocks
67: Use the '<' and '>' keys in visual cursor mode (V->c) to folder selected bytes.
68: Use scr.accel to browse the file faster!
70: Use the 'pR' command to see the source line related to the current seek
75: Setup dbg.fpregs to true to visualize the fpu registers in the debugger view.
80: To remove this message, put `dbxenv suppress_startup_message 7.5' in your .dbxrc
