### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ shlr/sdb/sdb.exe
 shlr/sdb/src/sdb
 shlr/sdb/src/sdb.exe
 shlr/sdb/src/sdb-version.h
+shlr/sdb/src/libsdb.so*
+shlr/capstone/


### PR DESCRIPTION
shlr/sdb/src/libsdb.so*
shlr/capstone/

Also there is a `"main" file in the root directory which is added when using ./sys/install.sh`,

```
main: broken symbolic link to /home/maijin/radare2/doc/hud /usr/lib/radare2/0.9.8.git/hud/main
```
