### PR TITLE
Renaming cs_disasm_ex to cs_disasm

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -130,7 +130,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	op->delay = 0;
 	r_strbuf_init (&op->esil);
 	if (ret == CS_ERR_OK) {
-		n = cs_disasm_ex (handle, (ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -197,7 +197,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	op->size = 4;
 	if (ret != CS_ERR_OK) goto fin;
 	cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
-	n = cs_disasm_ex (handle, (ut8*)buf, len, addr, 1, &insn);
+	n = cs_disasm (handle, (ut8*)buf, len, addr, 1, &insn);
 	if (n<1 || insn->size<1)
 		goto beach;
 	op->type = R_ANAL_OP_TYPE_NULL;

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -17,7 +17,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
-		n = cs_disasm_ex (handle, (const ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -27,7 +27,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
-		n = cs_disasm_ex (handle, (const ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/anal/p/anal_sysz.c
+++ b/libr/anal/p/anal_sysz.c
@@ -27,7 +27,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
-		n = cs_disasm_ex (handle, (const ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -26,7 +26,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
-		n = cs_disasm_ex (handle, (const ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/anal/p/anal_xcore_cs.c
+++ b/libr/anal/p/anal_xcore_cs.c
@@ -27,7 +27,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
-		n = cs_disasm_ex (handle, (const ut8*)buf, len, addr, 1, &insn);
+		n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n<1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		} else {

--- a/libr/asm/p/asm_arm_cs.c
+++ b/libr/asm/p/asm_arm_cs.c
@@ -28,7 +28,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		cs_option (cd, CS_OPT_SYNTAX, CS_OPT_SYNTAX_NOREGNAME);
 	} else cs_option (cd, CS_OPT_SYNTAX, CS_OPT_SYNTAX_DEFAULT);
 	cs_option (cd, CS_OPT_DETAIL, CS_OPT_OFF);
-	n = cs_disasm_ex (cd, buf, R_MIN (4, len),
+	n = cs_disasm (cd, buf, R_MIN (4, len),
 		a->pc, 1, &insn);
 	if (n<1) {
 		ret = -1;

--- a/libr/asm/p/asm_mips_cs.c
+++ b/libr/asm/p/asm_mips_cs.c
@@ -28,7 +28,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		cs_option (handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_NOREGNAME);
 	} else cs_option (handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_DEFAULT);
 	cs_option (handle, CS_OPT_DETAIL, CS_OPT_OFF);
-	n = cs_disasm_ex (handle, (ut8*)buf, len, a->pc, 1, &insn);
+	n = cs_disasm (handle, (ut8*)buf, len, a->pc, 1, &insn);
 	if (n<1) {
 		strcpy (op->buf_asm, "invalid");
 		op->size = 4;

--- a/libr/asm/p/asm_ppc_cs.c
+++ b/libr/asm/p/asm_ppc_cs.c
@@ -32,7 +32,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		if (ret) return 0;
 	}
 	cs_option (handle, CS_OPT_DETAIL, CS_OPT_OFF);
-	n = cs_disasm_ex (handle, (const ut8*)buf, len, off, 1, &insn);
+	n = cs_disasm (handle, (const ut8*)buf, len, off, 1, &insn);
 	if (n>0) {
 		if (insn->size>0) {
 			op->size = insn->size;

--- a/libr/asm/p/asm_sparc_cs.c
+++ b/libr/asm/p/asm_sparc_cs.c
@@ -19,7 +19,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	ret = cs_open (CS_ARCH_SPARC, mode, &handle);
 	if (ret) goto fin;
 	cs_option (handle, CS_OPT_DETAIL, CS_OPT_OFF);
-	n = cs_disasm_ex (handle, (ut8*)buf, len, a->pc, 1, &insn);
+	n = cs_disasm (handle, (ut8*)buf, len, a->pc, 1, &insn);
 	if (n<1) {
 		strcpy (op->buf_asm, "invalid");
 		op->size = 4;

--- a/libr/asm/p/asm_sysz.c
+++ b/libr/asm/p/asm_sysz.c
@@ -33,7 +33,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		if (ret) return 0;
 		cs_option (cd, CS_OPT_DETAIL, CS_OPT_OFF);
 	}
-	n = cs_disasm_ex (cd, (const ut8*)buf, len, off, 1, &insn);
+	n = cs_disasm (cd, (const ut8*)buf, len, off, 1, &insn);
 	if (n>0) {
 		if (insn->size>0) {
 			op->size = insn->size;

--- a/libr/asm/p/asm_x86_cs.c
+++ b/libr/asm/p/asm_x86_cs.c
@@ -93,7 +93,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 #endif
 		cs_option (cd, CS_OPT_DETAIL, CS_OPT_OFF);
 	}
-	n = cs_disasm_ex (cd, (const ut8*)buf, len, off, 1, &insn);
+	n = cs_disasm (cd, (const ut8*)buf, len, off, 1, &insn);
 	if (n>0) {
 		if (insn->size>0) {
 			char *ptrstr;

--- a/libr/asm/p/asm_xcore_cs.c
+++ b/libr/asm/p/asm_xcore_cs.c
@@ -14,7 +14,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	ret = cs_open (CS_ARCH_XCORE, mode, &handle);
 	if (ret) goto fin;
 	cs_option (handle, CS_OPT_DETAIL, CS_OPT_OFF);
-	n = cs_disasm_ex (handle, (ut8*)buf, len, a->pc, 1, &insn);
+	n = cs_disasm (handle, (ut8*)buf, len, a->pc, 1, &insn);
 	if (n<1) {
 		strcpy (op->buf_asm, "invalid");
 		op->size = 4;


### PR DESCRIPTION
Renaming the function according to Capstone changelog : https://github.com/aquynh/capstone/wiki/ChangeLog

To fix ‘cs_disasm_ex’ is deprecated (declared at ../../shlr/capstone/include/capstone.h:403) [-Wdeprecated-declarations] warnings
