### PR TITLE
Fixing the issue where file size exceeds size of an integer

### DIFF
--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -111,7 +111,7 @@ typedef struct r_bin_object_t {
 	ut64 baddr;
 	ut64 loadaddr;
 	ut64 boffset;
-	int size;
+	ut64 size;
 	ut64 obj_size;
 	RList/*<RBinSection>*/ *sections;
 	RList/*<RBinImport>*/ *imports;
@@ -137,7 +137,7 @@ typedef struct r_bin_object_t {
 typedef struct r_bin_file_t {
 	char *file;
 	int fd;
-	int size;
+	ut64 size;
 	int rawstr;
 	ut32 id;
 	RBuffer *buf;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -178,8 +178,8 @@ struct r_io_bind_t;
 /* TODO: find better name... RIOSetFd_Callback? ..Func? .. too camels here */
 typedef RIO * (*RIOGetIO) (struct r_io_bind_t *iob);
 typedef int (*RIOSetFd)(RIO *io, int fd);
-typedef int (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, int size);
-typedef int (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int size);
+typedef int (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, ut64 size);
+typedef int (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, ut64 size);
 typedef ut64 (*RIOSize)(RIO *io);
 typedef ut64 (*RIOSeek)(RIO *io, ut64 offset, int whence);
 
@@ -220,7 +220,7 @@ typedef struct r_io_bind_t {
 typedef struct r_io_cache_t {
 	ut64 from;
 	ut64 to;
-	int size;
+	ut64 size;
 	ut8 *data;
 } RIOCache;
 

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -79,7 +79,7 @@ typedef struct r_mem_pool_factory_t {
 typedef struct r_mmap_t {
 	ut8 *buf;
 	ut64 base;
-	int len;
+	off_t len;
 	int fd;
 	int rw;
 #if __WINDOWS__
@@ -90,8 +90,8 @@ typedef struct r_mmap_t {
 
 typedef struct r_buf_t {
 	ut8 *buf;
-	int length;
-	int cur;
+	ut64 length;
+	ut64 cur;
 	ut64 base;
 	RMmap *mmap;
 	ut8 empty;
@@ -233,7 +233,7 @@ R_API void r_graph_push (RGraph *t, ut64 addr, void *data);
 R_API RGraphNode* r_graph_pop(RGraph *t);
 
 R_API boolt r_file_truncate (const char *filename, ut64 newsize);
-R_API int r_file_size(const char *str);
+R_API off_t r_file_size(const char *str);
 R_API char *r_file_root(const char *root, const char *path);
 R_API boolt r_file_is_directory(const char *str);
 R_API boolt r_file_is_regular(const char *str);
@@ -267,21 +267,21 @@ R_API RBuffer *r_buf_new();
 R_API RBuffer *r_buf_file (const char *file);
 R_API RBuffer *r_buf_mmap (const char *file, int flags);
 R_API int r_buf_set_bits(RBuffer *b, int bitoff, int bitsize, ut64 value);
-R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, int length);
+R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, ut64 length);
 R_API int r_buf_append_string(RBuffer *b, const char *str);
 R_API int r_buf_append_buf(RBuffer *b, RBuffer *a);
-R_API int r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length);
-R_API int r_buf_append_nbytes(RBuffer *b, int length);
+R_API int r_buf_append_bytes(RBuffer *b, const ut8 *buf, ut64 length);
+R_API int r_buf_append_nbytes(RBuffer *b, ut64 length);
 R_API int r_buf_append_ut32(RBuffer *b, ut32 n);
 R_API int r_buf_append_ut64(RBuffer *b, ut64 n);
 R_API int r_buf_append_ut16(RBuffer *b, ut16 n);
-R_API int r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, int length);
+R_API int r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, ut64 length);
 R_API char *r_buf_to_string(RBuffer *b);
-R_API ut8 *r_buf_get_at(RBuffer *b, ut64 addr, int *len);
-R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len);
-R_API int r_buf_fread_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n);
-R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len);
-R_API int r_buf_fwrite_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n);
+R_API ut8 *r_buf_get_at(RBuffer *b, ut64 addr, ut64 *len);
+R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, ut64 len);
+R_API int r_buf_fread_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, ut64 n);
+R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, ut64 len);
+R_API int r_buf_fwrite_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, ut64 n);
 R_API void r_buf_free(RBuffer *b);
 R_API char *r_buf_free_to_string (RBuffer *b);
 R_API const ut8 *r_buf_buffer (RBuffer *b);
@@ -457,7 +457,7 @@ R_API const char *r_file_basename (const char *path);
 R_API char *r_file_abspath(const char *file);
 R_API ut8 *r_inflate(const ut8 *src, int srcLen, int *dstLen);
 R_API ut8 *r_file_gzslurp(const char *str, int *outlen, int origonfail);
-R_API char *r_file_slurp(const char *str, int *usz);
+R_API char *r_file_slurp(const char *str, ut64 *usz);
 //R_API char *r_file_slurp_range(const char *str, ut64 off, ut64 sz);
 R_API char *r_file_slurp_range(const char *str, ut64 off, int sz, int *osz);
 R_API char *r_file_slurp_random_line(const char *file);

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -134,6 +134,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		return count;
 	}
 	mmo = fd->data;
+	//eprintf ("r_io_def_mmap_read: fd: %d buf: %p count: %d.\n", mmo->fd, mmo->buf, count);
 	if (mmo->rawio) {
 		return read (mmo->fd, buf, count);
 	}

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -71,7 +71,7 @@ R_API int r_buf_set_bits(RBuffer *b, int bitoff, int bitsize, ut64 value) {
 	return R_FALSE;
 }
 
-R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, int length) {
+R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	if (length<=0 || !buf) return R_FALSE;
 	free (b->buf);
 	if (!(b->buf = malloc (length)))
@@ -82,7 +82,7 @@ R_API int r_buf_set_bytes(RBuffer *b, const ut8 *buf, int length) {
 	return R_TRUE;
 }
 
-R_API int r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, int length) {
+R_API int r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	if (!(b->buf = realloc (b->buf, b->length+length)))
 		return R_FALSE;
 	memmove (b->buf+length, b->buf, b->length);
@@ -104,7 +104,7 @@ R_API char *r_buf_to_string(RBuffer *b) {
 	return s;
 }
 
-R_API int r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length) {
+R_API int r_buf_append_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	if (b->empty) b->length = b->empty = 0;
 	if (!(b->buf = realloc (b->buf, b->length+length)))
 		return R_FALSE;
@@ -114,7 +114,7 @@ R_API int r_buf_append_bytes(RBuffer *b, const ut8 *buf, int length) {
 	return R_TRUE;
 }
 
-R_API int r_buf_append_nbytes(RBuffer *b, int length) {
+R_API int r_buf_append_nbytes(RBuffer *b, ut64 length) {
 	if (b->empty) b->length = b->empty = 0;
 	if (!(b->buf = realloc (b->buf, b->length+length)))
 		return R_FALSE;
@@ -162,13 +162,13 @@ R_API int r_buf_append_buf(RBuffer *b, RBuffer *a) {
 	return R_TRUE;
 }
 
-static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, int len, int write) {
-	int end;
+static int r_buf_cpy(RBuffer *b, ut64 addr, ut8 *dst, const ut8 *src, ut64 len, int write) {
+	ut64 end;
 	if (!b || b->empty) return 0;
 	addr = (addr==R_BUF_CUR)? b->cur: addr-b->base;
 	if (len<1 || dst == NULL || addr > b->length)
 		return -1;
- 	end = (int)(addr+len);
+ 	end = (addr+len);
 	if (end > b->length)
 		len -= end-b->length;
 	if (write)
@@ -232,7 +232,7 @@ static int r_buf_fcpy_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 	return len;
 }
 
-R_API ut8 *r_buf_get_at (RBuffer *b, ut64 addr, int *left) {
+R_API ut8 *r_buf_get_at (RBuffer *b, ut64 addr, ut64 *left) {
 	if (b->empty) return 0;
 	if (addr == R_BUF_CUR)
 		addr = b->cur;
@@ -244,16 +244,16 @@ R_API ut8 *r_buf_get_at (RBuffer *b, ut64 addr, int *left) {
 	return b->buf+addr;
 }
 
-R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, int len) {
+R_API int r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, ut64 len) {
 	if (!b) return 0;
 	return r_buf_cpy (b, addr, buf, b->buf, len, R_FALSE);
 }
 
-R_API int r_buf_fread_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n) {
+R_API int r_buf_fread_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, ut64 n) {
 	return r_buf_fcpy_at (b, addr, buf, fmt, n, R_FALSE);
 }
 
-R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
+R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, ut64 len) {
 	if (!b) return 0;
 	if (b->empty) {
 		b->empty = 0;
@@ -263,7 +263,7 @@ R_API int r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, int len) {
 	return r_buf_cpy (b, addr, b->buf, buf, len, R_TRUE);
 }
 
-R_API int r_buf_fwrite_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n) {
+R_API int r_buf_fwrite_at (RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, ut64 n) {
 	return r_buf_fcpy_at (b, addr, buf, fmt, n, R_TRUE);
 }
 

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -83,7 +83,7 @@ R_API boolt r_file_exists(const char *str) {
 	return (S_ISREG (buf.st_mode))? R_TRUE: R_FALSE;
 }
 
-R_API int r_file_size(const char *str) {
+R_API off_t r_file_size(const char *str) {
 	struct stat buf = {0};
 	if (stat (str, &buf)==-1)
 		return 0;
@@ -133,11 +133,11 @@ R_API char *r_file_path(const char *bin) {
 	return strdup (bin);
 }
 
-R_API char *r_file_slurp(const char *str, int *usz) {
+R_API char *r_file_slurp(const char *str, ut64 *usz) {
 	size_t rsz;
 	char *ret;
 	FILE *fd;
-	long sz;
+	ut64 sz;
 	if (!r_file_exists (str))
 		return NULL;
 	fd = r_sandbox_fopen (str, "rb");
@@ -166,7 +166,7 @@ R_API char *r_file_slurp(const char *str, int *usz) {
 }
 
 R_API ut8 *r_file_gzslurp(const char *str, int *outlen, int origonfail) {
-	int sz;
+	ut64 sz;
 	ut8 *in, *out;
 	if (outlen) *outlen = 0;
 	in = (ut8*)r_file_slurp (str, &sz);
@@ -248,7 +248,8 @@ R_API char *r_file_slurp_range(const char *str, ut64 off, int sz, int *osz) {
 
 R_API char *r_file_slurp_random_line(const char *file) {
 	char *ptr = NULL, *str;
-	int sz, i, lines = 0;
+	ut64 sz;
+	int i, lines = 0;
 	struct timeval tv;
 
 	if ((str = r_file_slurp (file, &sz))) {
@@ -528,7 +529,7 @@ R_API RMmap *r_file_mmap (const char *file, boolt rw, ut64 base) {
 	m->base = base;
 	m->rw = rw;
 	m->fd = fd;
-	m->len = fd != -1? lseek (fd, (off_t)0, SEEK_END) : 0;
+	m->len = fd != -1? r_file_size (file) : 0;
 
 	if (m->fd == -1) {
 		return m;


### PR DESCRIPTION
Here is an initial patch to enable larger file support.   Several functions and structures had fields that were of type 'int', so going of 0x7fffffff resulted in an overflow condition. Some of the issues have been resolved.
