### PR TITLE
remove a useless conditional

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -440,9 +440,7 @@ repeat:
 #endif
 			break;
 		case R_ANAL_OP_TYPE_CALL:
-			if (!r_anal_fcn_xref_add (anal, fcn, op.addr, op.jump,
-					op.type == R_ANAL_OP_TYPE_CALL?
-					R_ANAL_REF_TYPE_CALL : R_ANAL_REF_TYPE_CODE)) {
+			if (!r_anal_fcn_xref_add (anal, fcn, op.addr, op.jump, R_ANAL_REF_TYPE_CALL)) {
 				//fcn->size = bbsum (fcn);
 				FITFCNSZ ();
 #if 0


### PR DESCRIPTION
we're in a switch (op.type) here, so there is no need to check op.type in an case
