### PR TITLE
Fix in /R command

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -319,7 +319,7 @@ static RList* construct_rop_gadget(RCore *core, ut64 addr, ut8 *buf, int idx, co
 			addr += aop.size;
 
 			//Handle (possible) grep
-			if (end && grep && r_strncasestr (asmop.buf_asm, start, end - start)) {
+			if (end && grep && r_str_ncasestr (asmop.buf_asm, start, end - start)) {
 				if (end[0] == ',') { // fields are comma-seperated
 					start = end + 1; // skip the comma
 					end = strchr (start, ',');

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -372,6 +372,7 @@ R_API int r_str_write (int fd, const char *b);
 R_API void r_str_ncpy(char *dst, const char *src, int n);
 R_API void r_str_sanitize(char *c);
 R_API const char *r_str_casestr(const char *a, const char *b);
+R_API const char *r_str_ncasestr(const char *a, const char *b, size_t s);
 R_API const char *r_str_lastbut (const char *s, char ch, const char *but);
 R_API int r_str_split(char *str, char ch);
 R_API char* r_str_replace(char *str, const char *key, const char *val, int g);
@@ -420,9 +421,6 @@ R_API int r_str_inject(char *begin, char *end, char *str, int maxlen);
 R_API int r_str_delta(char *p, char a, char b);
 R_API void r_str_filter(char *str, int len);
 R_API const char * r_str_tok (const char *str1, const char b, size_t len);
-R_API const char * r_strnstr (const char *str, const char *substr, size_t len);
-R_API const char * r_strncasestr (const char *str, const char *substr, size_t len);
-R_API const char * r_strcasestr (const char *str, const char *substr);
 
 R_API int r_str_re_match(const char *str, const char *reg);
 R_API int r_str_re_replace(const char *str, const char *reg, const char *sub);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1115,6 +1115,15 @@ R_API const char *r_str_casestr(const char *a, const char *b) {
 	return NULL;
 }
 
+R_API const char *r_str_ncasestr(const char *a, const char *b, size_t s) {
+	while(*a) {
+		if(strncasecmp(a, b, s) == 0)
+			return a;
+		a++;
+	}
+	return NULL;
+}
+
 R_API int r_str_write (int fd, const char *b) {
 	return write (fd, b, strlen (b));
 }
@@ -1430,34 +1439,4 @@ R_API const char * r_str_tok (const char *str1, const char b, size_t len) {
 	for ( ; i < len; i++,p++) if (*p == b) break;
 	if (i == len) p = NULL;
 	return p;
-}
-
-R_API const char * r_strnstr (const char *str, const char *substr, size_t len) {
-
-	while(*str && len) {
-		if(!strncmp(str, substr, len))
-			return str;
-		str++;
-	}
-	return NULL;
-}
-
-R_API const char * r_strncasestr (const char *str, const char *substr, size_t len) {
-
-	while(*str) {
-		if(!strncasecmp(str, substr, len))
-			return str;
-		str++;
-	}
-	return NULL;
-}
-
-R_API const char * r_strcasestr (const char *str, const char *substr) {
-
-	while(*str) {
-		if(!strcasecmp(str, substr))
-			return str;
-		str++;
-	}
-	return NULL;
 }


### PR DESCRIPTION
Hello,
there is a segfault in /R command caused by a dereferencing of NULL pointer.

This patch fix it.

I did also changes in comparison function for ROP grep matching. 
strncasecmp test only the first characters, but for ROP searching, sometimes we want to look for a specific register.

For example, the gadget `mov ecx, [rax]` was not matched by /R rax.

To do this, I implemented some string functions in the radare API : r_strncasestr, r_strnstr, r_strcasecmp which can be used in other way.

I hope this patch will be useful for radare project and radare users :) 

-TOSH-
