### PR TITLE
[RFC] Add anal.null, a new fallback analysis plugin

### DIFF
--- a/libr/anal/p/Makefile
+++ b/libr/anal/p/Makefile
@@ -10,7 +10,7 @@ all: ${ALL_TARGETS} ;
 
 ALL_TARGETS=
 # TODO: rename to enabled plugins
-ARCHS=x86_udis.mk ppc.mk arm_gnu.mk avr.mk csr.mk dalvik.mk sh.mk ebc.mk gb.mk malbolge.mk ws.mk h8300.mk cr16.mk v850.mk msp430.mk
+ARCHS=null.mk x86_udis.mk ppc.mk arm_gnu.mk avr.mk csr.mk dalvik.mk sh.mk ebc.mk gb.mk malbolge.mk ws.mk h8300.mk cr16.mk v850.mk msp430.mk
 include $(ARCHS)
 
 clean:

--- a/libr/anal/p/anal_null.c
+++ b/libr/anal/p/anal_null.c
@@ -1,0 +1,26 @@
+#include <r_anal.h>
+#include <r_types.h>
+#include <r_lib.h>
+
+static int null_anal(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len)
+{
+	memset(op, '\0', sizeof(RAnalOp));
+	/* This should better follow the dissembler */
+	return op->size = 1;
+}
+
+struct r_anal_plugin_t r_anal_plugin_null = {
+	.name = "null",
+	.desc = "Fallback/Null analysis plugin",
+	.arch = R_SYS_ARCH_NONE,
+	.license = "LGPL3",
+	.bits = 8|16|32|64,	/* is this used? */
+	.op = &null_anal,
+};
+
+#ifndef CORELIB
+struct r_lib_struct_t radare_plugin = {
+	.type = R_LIB_TYPE_ANAL,
+	.data = &r_anal_plugin_null
+};
+#endif

--- a/libr/anal/p/null.mk
+++ b/libr/anal/p/null.mk
@@ -1,0 +1,10 @@
+OBJ_NULL=anal_null.o
+
+STATIC_OBJ+=${OBJ_NULL}
+TARGET_NULL=anal_null.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_NULL}
+
+${TARGET_NULL}: ${OBJ_NULL}
+	${CC} $(call libname,anal_null) ${LDFLAGS} \
+		${CFLAGS} -o anal_null.${EXT_SO} ${OBJ_NULL}

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -114,7 +114,7 @@ static int cb_asmarch(void *user, void *data) {
 
 	if (*node->value=='?') {
 		rasm2_list (core, NULL);
-		return 0;
+		return R_FALSE;
 	}
 	r_egg_setup (core->egg, node->value, core->anal->bits, 0, R_SYS_OS);
 	if (*node->value) {
@@ -122,7 +122,7 @@ static int cb_asmarch(void *user, void *data) {
 			eprintf ("asm.arch: cannot find (%s)\n", node->value);
 			return R_FALSE;
 		}
-	} else return 0;
+	} else return R_FALSE;
 
 	snprintf (asmparser, sizeof (asmparser), "%s.pseudo", node->value);
 	r_config_set (core->config, "asm.parser", asmparser);
@@ -138,7 +138,10 @@ static int cb_asmarch(void *user, void *data) {
 		char *p, *s = strdup (node->value);
 		p = strchr (s, '.');
 		if (p) *p = 0;
-		r_config_set (core->config, "anal.arch", s);
+		if (!r_config_set (core->config, "anal.arch", s)) {
+			/* fall back to the anal.null plugin */
+			r_config_set (core->config, "anal.arch", "null");
+		}
 		free (s);
 	}
 	if (!r_syscall_setup (core->anal->syscall, node->value,

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1220,6 +1220,7 @@ R_API int r_anal_fcn_labels (RAnal *anal, RAnalFunction *fcn, int rad);
 
 
 /* plugin pointers */
+extern RAnalPlugin r_anal_plugin_null;
 extern RAnalPlugin r_anal_plugin_csr;
 extern RAnalPlugin r_anal_plugin_tms320;
 extern RAnalPlugin r_anal_plugin_avr;

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -49,6 +49,7 @@ asm.ws
 asm.cr16
 asm.v850
 asm.spc700
+anal.null
 anal.sh
 anal.x86_cs
 anal.x86_udis


### PR DESCRIPTION
Without this fallback, architectures that only have a disassembler will be analyzed by x86.
