### PR TITLE
Fix the undisplayed strings when using rabin2 -z

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -210,7 +210,7 @@ static void get_strings_range(RBinFile *arch, RList *list, int min, ut64 from, u
 		min = plugin? plugin->minstrlen: 4;
 	/* Some plugins return zero, fix it up */
 	if (min == 0)
-		min = 4;
+		min = 1;
 	if (min < 0)
 		return;
 


### PR DESCRIPTION
This fix the undisplayed strings when using rabin -z or the "iz" command from r2 command line.
Not sure if this was the right way to do it though. Hope this helps.
