### PR TITLE
Fix the duplicate information when using "i"

### DIFF
--- a/libr/core/bin.c
+++ b/libr/core/bin.c
@@ -343,7 +343,6 @@ static int bin_info (RCore *r, int mode) {
 			// if type is 'fs' show something different?
 			//r_cons_printf ("# File info\n");
 			r_cons_printf ("file\t%s\n"
-					"type\t%s\n"
 					"pic\t%s\n"
 					"canary\t%s\n"
 					"nx\t%s\n"
@@ -354,8 +353,6 @@ static int bin_info (RCore *r, int mode) {
 					"lang\t%s\n"
 					"arch\t%s\n"
 					"bits\t%i\n"
-					"machine\t%s\n"
-					"os\t%s\n"
 					"subsys\t%s\n"
 					"endian\t%s\n"
 					"strip\t%s\n"
@@ -364,14 +361,14 @@ static int bin_info (RCore *r, int mode) {
 					"lsyms\t%s\n"
 					"relocs\t%s\n"
 					"rpath\t%s\n",
-					info->file, info->type,
+					info->file,
 					r_str_bool (info->has_pi),
 					r_str_bool (info->has_canary),
 					r_str_bool (info->has_nx),
 					r_str_bool (info->has_crypto),
 					r_str_bool (info->has_va),
 					info->rclass, info->bclass, info->lang?info->lang:"unknown",
-					info->arch, info->bits, info->machine, info->os,
+					info->arch, info->bits,
 					info->subsystem, info->big_endian? "big": "little",
 					r_str_bool (R_BIN_DBG_STRIPPED &info->dbg_info),
 					r_str_bool (r_bin_is_static (r->bin)),

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -20,29 +20,24 @@ static void r_core_file_info (RCore *core, int mode) {
 			"\"os\":\"%s\","
 			"\"arch\":\"%s\","
 			"\"bits\":%d,"
-			"\"endian\":\"%s\","
 			, STR(info->type)
 			, STR(info->os)
 			, STR(info->machine)
-			, info->bits
-			, info->big_endian? "big": "little");
+			, info->bits);
 			break;
 		default:
 		r_cons_printf ("type\t%s\n"
 			"os\t%s\n"
 			"arch\t%s\n"
 			"bits\t%d\n"
-			"endian\t%s\n"
 			, STR(info->type)
 			, STR(info->os)
 			, STR(info->machine)
-			, info->bits
-			, info->big_endian? "big": "little");
+			, info->bits);
 			break;
 		}
 	} else fn = (cf && cf->desc) ? cf->desc->name : NULL;
 	if (cf && mode == R_CORE_BIN_JSON) {
-		r_cons_printf ("\"file\":\"%s\"", fn);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;
 		if (cf->desc) {
 			r_cons_printf (",\"fd\":%d", cf->desc->fd);
@@ -64,7 +59,6 @@ static void r_core_file_info (RCore *core, int mode) {
 		r_cons_printf ("}");
 	} else if (cf) {
 		//r_cons_printf ("# Core file info\n");
-		r_cons_printf ("file\t%s\n", fn);
 		if (dbg) dbg = R_IO_WRITE | R_IO_EXEC;
 		if (cf->desc) {
 			r_cons_printf ("fd\t%d\n", cf->desc->fd);


### PR DESCRIPTION
I just delete the duplicated info in the two functions bin_info and r_core_file_info.

Regards
