### PR TITLE
Add usage on p6e, p6d, pb6* and p6e default is now core-blocksize

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1917,11 +1917,10 @@ static int cmd_print(void *data, const char *input) {
 			if (input[2] == '?') {
 				r_cons_printf ("|Usage: p6e [len]    base 64 encode\n");
 				break;
-			}
-			else {
-				len = len > core->blocksize ? core->blocksize : len;
-				r_base64_encode (buf, core->block, len);
-				r_cons_printf ("%s", buf);
+			}	else {
+					len = len > core->blocksize ? core->blocksize : len;
+					r_base64_encode (buf, core->block, len);
+					r_cons_printf ("%s", buf);
 			}
 			break;
 		default:


### PR DESCRIPTION
Add usage on p6e, p6d, pb6\* and p6e default is now core-blocksize
