### PR TITLE
Fix crash in graph where you print the current node twice.

### DIFF
--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -361,10 +361,14 @@ static void r_core_graph_refresh (RCore *core) {
 		Edge_print (can, a, b, edges[i].nth);
 	}
 	for (i=0; i<n_nodes; i++) {
-		Node_print (can, &nodes[i], i==curnode);
+		if (i != curnode) {
+			Node_print (can, &nodes[i], i==curnode);
+		}
 	}
 	// redraw current node to make it appear on top
-	Node_print (can, &nodes[curnode], 1);
+	if (curnode >= 0 && curnode < n_nodes) {
+		Node_print (can, &nodes[curnode], 1);
+	}
 
 	G (-can->sx, -can->sy);
 	snprintf (title, sizeof (title)-1,


### PR DESCRIPTION
Thanks to cokesme for the bug report.

https://www.dropbox.com/s/qa58v3kpw1pri30/r2_testing.tar.gz?dl=0
1. `r2 csaw[...].exe`
2. `aa`
3. `VV`
4. `V`
5. tab to section .text 
6. `q`
7. `V`
8. crash
