### PR TITLE
Correct save of metadata in project file

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -264,12 +264,14 @@ R_API const char *r_meta_type_to_string(int type) {
 
 static void printmetaitem(RAnal *a, RAnalMetaItem *d, int rad) {
 	char *pstr, *str = r_str_escape (d->str);
-	if (str) {
+	if (str || d->type == 'd') {
 		if (d->type=='s' && !*str) {
 			free (str);
 			return;
 		}
-		if (d->type != 'C') {
+		if (!str)
+			pstr = "";
+		else if (d->type != 'C') {
 			r_name_filter (str, 0);
 			pstr = str;
 		} else pstr = d->str;
@@ -285,17 +287,37 @@ static void printmetaitem(RAnal *a, RAnalMetaItem *d, int rad) {
 		case 1:
 		case '*':
 		default:
-			if (d->type == 'C') {
+			switch (d->type) {
+			case 'C':
 				a->printf ("\"%s %s\" @ 0x%08"PFMT64x"\n",
 					r_meta_type_to_string (d->type), pstr, d->from);
-			} else {
+				break;
+			case 'h': /* hidden */
+			case 's': /* string */
+				a->printf ("%s %d @ 0x%08"PFMT64x" # %s\n",
+					r_meta_type_to_string (d->type),
+					d->size, d->from, pstr);
+				break;
+			case 'd': /* data */
+				a->printf ("%s %d @ 0x%08"PFMT64x"\n",
+					r_meta_type_to_string (d->type),
+					d->size, d->from);
+				break;
+			case 'm': /* magic */
+			case 'f': /* formatted */
+				a->printf ("%s %d %s @ 0x%08"PFMT64x"\n",
+					r_meta_type_to_string (d->type),
+					d->size, pstr, d->from);
+				break;
+			default:
 				a->printf ("%s %d 0x%08"PFMT64x" # %s\n",
 					r_meta_type_to_string (d->type),
 					d->size, d->from, pstr);
 			}
 			break;
 		}
-		free (str);
+		if (str)
+			free (str);
 	}
 }
 

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -412,6 +412,10 @@ static int cmd_meta_hsdmf (RCore *core, const char *input) {
 							core->blocksize, p+1, -1, NULL);
 			}
 			if (type == 's') {
+				/* This is kept for compatibility with old projects.
+				 * Somewhat broken, but project will get corrected on
+				 * save and reload.
+				 */
 				p = strchr (t, ' ');
 				if (p)
 					addr = r_num_math (core->num, p+1);
@@ -488,17 +492,17 @@ static int cmd_meta(void *data, const char *input) {
 			const char* help_msg[] = {
 				"Usage:", "C[-LCvsdfm?] [...]", " # Metadata management",
 				"C*", "", "list meta info in r2 commands",
-				"C-", " [len] [@][ addr]", "delete metadata at given address range",
+				"C-", " [len] [[@]addr]", "delete metadata at given address range",
 				"CL", "[-][*] [file:line] [addr]", "show or add 'code line' information (bininfo)",
-				"CC", "[-] [comment-text]", "add/remove comment",
-				"CC!", "", "edit comment with $EDITOR",
-				"CCa", "[-at]|[at] [text]", "add/remove comment at given address",
-				"CCu", " [comment-text]", "add unique comment",
-				"Cs", "[-] [size] [[addr]]", "add string",
+				"CC", "[-] [comment-text] [@addr]", "add/remove comment",
+				"CC!", " [@addr]", "edit comment with $EDITOR",
+				"CCa", "[-at]|[at] [text] [@addr]", "add/remove comment at given address",
+				"CCu", " [comment-text] [@addr]", "add unique comment",
+				"Cs", "[-] [size] [@addr]", "add string",
 				"Ch", "[-] [size] [@addr]", "hide data",
-				"Cd", "[-] [size]", "hexdump data",
-				"Cf", "[-] [sz] [fmt..]", "format memory (see pf?)",
-				"Cm", "[-] [sz] [fmt..]", "magic parse (see pm?)",
+				"Cd", "[-] [size] [@addr]", "hexdump data",
+				"Cf", "[-] [sz] [fmt..] [@addr]", "format memory (see pf?)",
+				"Cm", "[-] [sz] [fmt..] [@addr]", "magic parse (see pm?)",
 				NULL};
 			r_core_cmd_help (core, help_msg);
 			}


### PR DESCRIPTION
Corrects save of Cs, Cd, Cf, Cm meta commands

help text also slightly updated to match actual
working commands and syntax.
