### PR TITLE
Truncate strings to their field size

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -430,6 +430,8 @@ static int cmd_meta_hsdmf (RCore *core, const char *input) {
 							// TODO: filter \n and so on :)
 							strncpy (name, t, sizeof (name)-1);
 							r_core_read_at (core, addr, (ut8*)name, sizeof (name)-1);
+							if (n < sizeof(name))
+								name[n] = '\0';
 							break;
 						default:
 							fi = r_flag_get_i (core->flags, addr);


### PR DESCRIPTION
not all strings are zero terminated. Truncate strings to their
specified size.
