### PR TITLE
Fix compilation error on OS X 10.7.5 (undefined symbol _environ)

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -10,6 +10,7 @@
 #if __APPLE__
 #include <errno.h>
 #include <execinfo.h>
+#include <crt_externs.h>
 # ifndef PROC_PIDPATHINFO_MAXSIZE
 #  define PROC_PIDPATHINFO_MAXSIZE 1024
 int proc_pidpath(int pid, void * buffer, ut32 buffersize);
@@ -636,8 +637,7 @@ static char** env = NULL;
 
 R_API char **r_sys_get_environ () {
 #if __APPLE__
-	extern char **environ;
-	env = environ;
+	env = *_NSGetEnviron();
 #endif
 	// return environ if available??
 	if (!env)


### PR DESCRIPTION
Building radare on OS X 10.7.5 fails with the following error:

Undefined symbols for architecture x86_64:
  "_environ", referenced from:
      _r_sys_get_environ in sys.o
     (maybe you meant: _r_sys_get_environ, _r_sys_set_environ )
ld: symbol(s) not found for architecture x86_64
collect2: ld returned 1 exit status
make[1]: **\* [libr_util.dylib] Error 1
make: **\* [all] Error 2

This is most likely affecting other versions of OS X as well.

Here is info from the ENVIRON(7) manual page:
"Shared libraries and bundles don't have direct access to environ, which is only available to the loader ld(1) when a complete program is being linked.The environment routines can still be used, but if direct access to environ is needed, the _NSGetEnviron() routine, defined in <crt_externs.h>, can be used to retrieve the address of environ at runtime."
https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man7/environ.7.html

GHC has had the same issue:
https://ghc.haskell.org/trac/ghc/ticket/2458

According to the Gnulib manual, the shared library issue has been around since OS X 10.5.
https://www.gnu.org/software/gnulib/manual/html_node/environ.html

I have tried the patch on my machine as well as tested the environ access in a separate program to make sure everything is in order with the pointers. As far as I understand, this shouldn't break anything on any version of OS X.
