### PR TITLE
Make the elf parser use the phdrs and the DT_DYNAMIC contents

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -10,6 +10,7 @@
 #if __APPLE__
 #include <errno.h>
 #include <execinfo.h>
+#include <crt_externs.h>
 # ifndef PROC_PIDPATHINFO_MAXSIZE
 #  define PROC_PIDPATHINFO_MAXSIZE 1024
 int proc_pidpath(int pid, void * buffer, ut32 buffersize);
@@ -636,8 +637,7 @@ static char** env = NULL;
 
 R_API char **r_sys_get_environ () {
 #if __APPLE__
-	extern char **environ;
-	env = environ;
+	env = *_NSGetEnviron();
 #endif
 	// return environ if available??
 	if (!env)


### PR DESCRIPTION
No regressions at all (and no tests fixed)
New sections are created for some entries in the DT_DYNAMIC section, we should add the got/rel ones too and hope everything clicks.
The whole elf parser sucks though and this is an horrible solution :(
