### PR TITLE
Recognize symbols with type SECTION

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1215,6 +1215,7 @@ if (
 				return NULL;
 			}
 			for (j = k = ret_ctr = 0; j < bin->shdr[i].sh_size; j += sizeof (Elf_(Sym)), k++) {
+				int nidx;
 				if (k == 0)
 					continue;
 				if (type == R_BIN_ELF_IMPORTS && sym[k].st_shndx == STN_UNDEF) {
@@ -1228,6 +1229,30 @@ if (
 					//int idx = sym[k].st_shndx;
 					tsize = sym[k].st_size;
 					toffset = (ut64)sym[k].st_value; //-sym_offset; // + (ELF_ST_TYPE(sym[k].st_info) == STT_FUNC?sym_offset:data_offset);
+				} else if (ELF_ST_TYPE(sym[k].st_info == STT_SECTION)) {
+					Elf_(Section) sect = sym[k].st_shndx;
+
+					if (sect >= bin->ehdr.e_shnum)
+						continue;
+
+					if (bin->shdr == NULL)
+						continue;
+
+					nidx = bin->shdr[sect].sh_name;
+
+					if (nidx < 0 || !bin->shstrtab_section ||
+						!bin->shstrtab_section->sh_size ||
+						nidx > bin->shstrtab_section->sh_size) {
+						continue;
+					} else {
+						if (bin->shstrtab && (bin->shdr[sect].sh_name > 0) &&
+							(bin->shdr[sect].sh_name + 8 < bin->strtab_size)) {
+							tsize = sym[k].st_size;
+							toffset = (ut64)sym[k].st_value;
+							sym[k].st_name = nidx;
+						} else continue;
+					}
+					//printf ("Section %d\n", sym[k].st_shndx);
 				} else continue;
 				if ((ret = realloc (ret, (ret_ctr + 1) * sizeof (struct r_bin_elf_symbol_t))) == NULL) {
 					perror ("realloc (symbols|imports)");
@@ -1257,11 +1282,18 @@ if (
 					free (sym);
 					return NULL;
 				}
-				if (bin->strtab) {
-					strncpy (ret[ret_ctr].name, bin->strtab+sym[k].st_name, ELF_STRING_LENGTH);
+
+				//len = r_str_nlen (strtab+sym[k].st_name, ELF_STRING_LENGTH-1);
+				if (ELF_ST_TYPE(sym[k].st_info) != STT_SECTION) {
+					if (bin->strtab) {
+						strncpy (ret[ret_ctr].name, bin->strtab+sym[k].st_name, ELF_STRING_LENGTH);
+					} else {
+						sprintf (ret[ret_ctr].name, "unk%d", j);
+					}
 				} else {
-					sprintf (ret[ret_ctr].name, "unk%d", j);
+					strncpy (ret[ret_ctr].name, &bin->shstrtab[nidx], ELF_STRING_LENGTH);
 				}
+
 				ret[ret_ctr].ordinal = k;
 				ret[ret_ctr].name[ELF_STRING_LENGTH-2] = '\0';
 				#define s_bind(x) snprintf (ret[ret_ctr].bind, ELF_STRING_LENGTH, x);


### PR DESCRIPTION
Sections must also be symbols so relocations referring to the addrs of those sections (as symbols) work.
See the following code:

```
0000000000000000 <init_module>:
   0:   55                      push   %rbp
   1:   48 c7 c7 00 00 00 00    mov    $0x0,%rdi
                        4: R_X86_64_32S .rodata.str1.1
   8:   31 c0                   xor    %eax,%eax
   a:   48 89 e5                mov    %rsp,%rbp
   d:   e8 00 00 00 00          callq  12 <init_module+0x12>
                        e: R_X86_64_PC32        printk-0x4
  12:   31 c0                   xor    %eax,%eax
  14:   5d                      pop    %rbp
  15:   c3                      retq  
```

First relocation is to a section .rodata.str1.1, second one is to printk.
r2 could only detect the symbol for the second one, but now also the first one:

```
   ;      [1] va=0x00000064 pa=0x00000064 sz=22 vsz=22 rwx=-r-x .init.text
╒ (fcn) sym.imp.printk 22
│          ;-- section..init.text:
│          0x00000064    55           push rbp
│          0x00000065    48c7c700000. mov rdi, 0x0  ;  RELOC 32 .rodata.str1.1
│          0x0000006c    31c0         xor eax, eax
│          0x0000006e    4889e5       mov rbp, rsp
│          0x00000071    e800000000   call 0x76 ; (sym.imp.printk)
│             sym.imp.printk(unk) ; sym.__UNIQUE_ID_author1+1  ;  RELOC 32 printk
│          ; CALL XREF from 0x00000071 (unk)
│          0x00000076    31c0         xor eax, eax
│          0x00000078    5d           pop rbp
╘          0x00000079    c3           ret
```
