### PR TITLE
Do not ignore UNDEF symbols

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1225,8 +1225,9 @@ if (
 					else if ((toffset = Elf_(get_import_addr) (bin, k)) == -1)
 						toffset = 0;
 					tsize = 16;
-				} else if (type == R_BIN_ELF_SYMBOLS && sym[k].st_shndx != STN_UNDEF &&
-						ELF_ST_TYPE(sym[k].st_info) != STT_SECTION && ELF_ST_TYPE(sym[k].st_info) != STT_FILE) {
+				} else if (type == R_BIN_ELF_SYMBOLS &&
+						ELF_ST_TYPE(sym[k].st_info) != STT_SECTION &&
+						ELF_ST_TYPE(sym[k].st_info) != STT_FILE) {
 					//int idx = sym[k].st_shndx;
 					tsize = sym[k].st_size;
 					toffset = (ut64)sym[k].st_value; //-sym_offset; // + (ELF_ST_TYPE(sym[k].st_info) == STT_FUNC?sym_offset:data_offset);


### PR DESCRIPTION
Those symbols that are ignored are UNDEF, as you may see in readelf's output.

Fixes #1542 
