### PR TITLE
debug improves, win32 native debugger fixed.

### DIFF
--- a/libr/debug/reg.c
+++ b/libr/debug/reg.c
@@ -6,7 +6,6 @@
 
 R_API int r_debug_reg_sync(RDebug *dbg, int type, int write) {
 	int i, size;
-
 	if (!dbg || !dbg->reg || !dbg->h)
 		return R_FALSE;
 
@@ -44,8 +43,7 @@ R_API int r_debug_reg_sync(RDebug *dbg, int type, int write) {
 			free (buf);
 		}
 		// Continue the syncronization or just stop if it was asked only for a single type of regs 
-	} while(i++ < R_REG_TYPE_LAST && type != R_REG_TYPE_ALL);
-
+	} while(i++ < R_REG_TYPE_LAST && type == R_REG_TYPE_ALL);
 	return R_TRUE;
 }
 

--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -36,10 +36,9 @@ static int __read(struct r_io_t *io, RIODesc *fd, ut8 *buf, int len) {
 	return debug_os_read_at (fd->data, buf, len, io->off);
 }
 
-static int w32dbg_write_at(RIODesc *fd, const ut8 *buf, int len, ut64 addr) {
+static int w32dbg_write_at(RIOW32Dbg *dbg, const ut8 *buf, int len, ut64 addr) {
 	DWORD ret;
-	RIOW32Dbg *dbg = fd->data;
-        return 0 != WriteProcessMemory (dbg->pi.hProcess, (void *)(size_t)addr, buf, len, &ret)? len: 0;
+    return 0 != WriteProcessMemory (dbg->pi.hProcess, (void *)(size_t)addr, buf, len, &ret)? len: 0;
 }
 
 static int __write(struct r_io_t *io, RIODesc *fd, const ut8 *buf, int len) {


### PR DESCRIPTION
- Fixed trap flag for windows native debug, the return value must be tid.
- Implemented write DRX regs under windows.
- Fixed r_debug_reg_sync alway loop for all registers types, now correctly get the selected one.
- Fiexed w32dbg_write_at now take the params correctly not need fd->data.
