### PR TITLE
Correct VdS when operating on a selected region

### DIFF
--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1418,17 +1418,20 @@ R_API void r_core_visual_define (RCore *core) {
 	case 'S':
 		do {
 			n = r_str_nlen ((const char*)p+ntotal, plen-ntotal)+1;
+			if (n<2) break;
+			if (p[ntotal + n - 1])
+				break; // Not a \0 terminated string
 			name = malloc (n+10);
 			strcpy (name, "str.");
-			strncpy (name+4, (const char *)p+ntotal, n);
+			memcpy (name+4, (const char *)p+ntotal, n);
+			name[4+n] = '\0';
+			r_meta_add (core->anal, R_META_TYPE_STRING,
+				off+ntotal, off+n+ntotal, (const char *)name+4);
 			r_name_filter(name, n+10);
 			r_flag_set (core->flags, name, off+ntotal, n, 0);
-			r_meta_add (core->anal, R_META_TYPE_STRING,
-				off+ntotal, off+n+ntotal, (const char *)p+ntotal);
 			free (name);
-			if (n<2) break;
 			ntotal+= n;
-		} while (ntotal<core->blocksize);
+		} while (ntotal<plen);
 		break;
 	case 's':
 		{


### PR DESCRIPTION
- only accept \0 terminated strings
- unify code mostly with style of Vds. Not strictly needed
  when only \0 terminated strings are accepted.
- don't care about block boundary. Upper code already defines
  the region for us which may or may not be a block.
  Another piece of #1621.
