### PR TITLE
fix crash on quit for hacklu gameboy rom

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -182,7 +182,7 @@ R_API int r_asm_filter_output(RAsm *a, const char *f) {
 
 R_API RAsm *r_asm_free(RAsm *a) {
 	if (a) {
-		if (a->cur) {
+		if (a->cur && a->cur->user) {
 			a->cur->fini (a->cur->user);
 		}
 		if (a->plugins) {


### PR DESCRIPTION
```
minishwoods hacklu/gunpoint » r2 ./gunslinger.gb                                                                                                                                                                              139 ↵
 -- Show offsets in graphs with 'e graph.offset = true'
[0x00000100]> q
[1]    6263 segmentation fault (core dumped)  r2 ./gunslinger.gb
```

```
gdb-peda$ bt
#0  0x0000000000000000 in ?? ()
#1  0x00007f20f32b9f4d in r_asm_free (a=0x1a33f20) at asm.c:186
#2  0x00007f20f5836a56 in r_core_fini (c=0x607560 <r>) at core.c:835
#3  0x000000000040519e in main (argc=0x2, argv=0x7fff212da7a8, envp=0x7fff212da7c0) at radare2.c:756
#4  0x00007f20f1cb6ec5 in __libc_start_main (main=0x402fdc <main>, argc=0x2, argv=0x7fff212da7a8, init=<optimized
#5  0x0000000000402939 in _start ()
```

This fixes the crash
