### PR TITLE
Allow esil to use negative numbers as arguments

### DIFF
--- a/libr/anal/rpnesil.c
+++ b/libr/anal/rpnesil.c
@@ -181,7 +181,9 @@ R_API int r_anal_esil_get_parm_type (RAnalEsil *esil, const char *str) {
 	}
 	if (!strncmp (str, "0x", 2))
 		return R_ANAL_ESIL_PARM_NUM;
-	for (i = 0; i < len; i++)
+	if (!((str[0] >= '0' && str[0] <= '9')||str[0]=='-'))
+		goto not_a_number;
+	for (i = 1; i < len; i++)
 		if (!(str[i] >= '0' && str[i] <= '9'))
 			goto not_a_number;
 	return R_ANAL_ESIL_PARM_NUM;


### PR DESCRIPTION
Don't know if there was a reason negative numbers weren't allowed.
