### PR TITLE
Make the bp api slightly saner

### DIFF
--- a/libr/bp/io.c
+++ b/libr/bp/io.c
@@ -59,7 +59,7 @@ R_API int r_bp_restore(struct r_bp_t *bp, int set) {
 	RBreakpointItem *b;
 
 	r_list_foreach (bp->bps, iter, b) {
-		if (bp->breakpoint && bp->breakpoint (bp->user, set, b->addr, b->hw, b->rwx))
+		if (bp->breakpoint && bp->breakpoint (b, set, bp->user))
 			continue;
 		/* write obytes from every breakpoint in r_bp if not handled by plugin */
 		if (set) {

--- a/libr/debug/p/debug_bf.c
+++ b/libr/debug/p/debug_bf.c
@@ -153,7 +153,7 @@ static char *r_debug_bf_reg_profile(RDebug *dbg) {
 	);
 }
 
-static int r_debug_bf_breakpoint (void *user, int type, ut64 addr, int hw, int rwx) {
+static int r_debug_bf_breakpoint (RBreakpointItem *bp, int set, void *user) {
 	//r_io_system (dbg->iob.io, "db");
 	return R_FALSE;
 }

--- a/libr/debug/p/debug_esil.c
+++ b/libr/debug/p/debug_esil.c
@@ -100,7 +100,7 @@ static char *r_debug_esil_reg_profile(RDebug *dbg) {
 	);
 }
 
-static int r_debug_esil_breakpoint (void *user, int type, ut64 addr, int hw, int rwx) {
+static int r_debug_esil_breakpoint (RBreakpointItem *bp, int set, void *user) {
 	//r_io_system (dbg->iob.io, "db");
 	return R_FALSE;
 }

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -518,24 +518,23 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 	return NULL;
 }
 
-static int r_debug_gdb_breakpoint (void *user, int type, ut64 addr, int hw, int rwx){
-	int ret = 0;
+static int r_debug_gdb_breakpoint (RBreakpointItem *bp, int set, void *user) {
+	int ret;
+
+	if (!bp)
+		return R_FALSE;
+
 	// TODO handle rwx and conditions
-	if (type != R_FALSE) { // set bp
-		if (hw) {
-			ret = gdbr_set_hwbp (desc, addr, "");
-		} else {
-			ret = gdbr_set_bp (desc, addr, "");
-		}
-	} else { // unset bp
-		if (hw) {
-			ret = gdbr_remove_hwbp (desc, addr);
-		} else {
-			ret = gdbr_remove_bp (desc, addr);
-		}
-	}
-	if (ret) return R_FALSE;
-	return R_TRUE;
+	if (set)
+		ret = bp->hw?
+			gdbr_set_hwbp (desc, bp->addr, ""):
+			gdbr_set_bp (desc, bp->addr, "");
+	else
+		ret = bp->hw?
+			gdbr_remove_hwbp (desc, bp->addr):
+			gdbr_remove_bp (desc, bp->addr);
+
+	return ret? R_FALSE: R_TRUE;
 }
 
 struct r_debug_plugin_t r_debug_plugin_gdb = {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1819,13 +1819,19 @@ static int r_debug_native_drx(RDebug *dbg, int n, ut64 addr, int sz, int rwx, in
 	return R_FALSE;
 }
 
-static int r_debug_native_bp(void *user, int add, ut64 addr, int hw, int rwx) {
+static int r_debug_native_bp(RBreakpointItem *bp, int set, void *user) {
+	if (!bp)
+		return R_FALSE;
+
 #if __i386__ || __x86_64__
 	RDebug *dbg = user;
-	if (hw) {
-		if (add) return drx_add (dbg, addr, rwx);
-		return drx_del (dbg, addr, rwx);
-	}
+
+	if (!bp->hw)
+		return R_FALSE;
+
+	return set?
+		drx_add (dbg, bp->addr, bp->rwx):
+		drx_del (dbg, bp->addr, bp->rwx);
 #endif
 	return R_FALSE;
 }

--- a/libr/debug/p/debug_rap.c
+++ b/libr/debug/p/debug_rap.c
@@ -59,7 +59,7 @@ static char *r_debug_rap_reg_profile(RDebug *dbg) {
 	return out;
 }
 
-static int r_debug_rap_breakpoint (void *user, int type, ut64 addr, int hw, int rwx){
+static int r_debug_rap_breakpoint (RBreakpointItem *bp, int set, void *user){
 	//r_io_system (dbg->iob.io, "db");
 	return R_FALSE;
 }

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -37,9 +37,6 @@ typedef struct r_bp_plugin_t {
 	RBreakpointArch *bps;
 } RBreakpointPlugin;
 
-// XXX: type is add() or del()
-typedef int (*RBreakpointCallback)(void *user, int type, ut64 addr, int hw, int rwx);
-
 typedef struct r_bp_item_t {
 	ut64 addr;
 	int size; /* size of breakpoint area */
@@ -53,8 +50,9 @@ typedef struct r_bp_item_t {
 	ut8 *bbytes; /* breakpoint bytes */
 	int pids[R_BP_MAXPIDS];
 	char *data;
-	RBreakpointCallback callback; // per-bp callback
 } RBreakpointItem;
+
+typedef int (*RBreakpointCallback)(RBreakpointItem *bp, int set, void *user);
 
 typedef struct r_bp_t {
 	void *user;


### PR DESCRIPTION
Been holding this back for too long that I forgot about this.
This is needed for the windbg backend which associates an id to every breakpoint, the solution I hacked up was using a simple hashtable but it can be done in a cleaner way by abusing the 'data' pointer for this.
(This exploits the fact that the data pointer is never used/freed, definitely not a great assumption. Feel free to suggest something cleaner)
(As a side note, many of the ints in RBreakpointItem could be bit-packed for some memory efficency)
