### PR TITLE
fix crash in rasm2 'add eax, /'

### DIFF
--- a/libr/util/calc.c
+++ b/libr/util/calc.c
@@ -83,7 +83,7 @@ static RNumCalcValue term(RNum *num, RNumCalc *nc, int get) {
 		} else
 		if (nc->curr_tok == RNCDIV) {
 			RNumCalcValue d = prim (num, nc, 1);
-			if (!d.d || !d.n) {
+			if (num != NULL && (!d.d || !d.n)) {
 				num->dbz = 1;
 				return d;
 			}


### PR DESCRIPTION
```
jeff@minishwoods:~$ rasm2 "mov eax,/"
Segmentation fault (core dumped)
```

```
gdb-peda$ bt
#0  0x00007faa1d5eeb74 in term (num=0x0, nc=0x7fff5a86e710, get=0x0) at calc.c:87
#1  0x00007faa1d5ee703 in expr (num=0x0, nc=0x7fff5a86e710, get=0x0) at calc.c:55
#2  0x00007faa1d5ef9f8 in r_num_calc (num=0x0, str=0x7fff5a86fa78 "/", err=0x7fff5a86f790) at calc.c:337
#3  0x00007faa1d5d505b in r_num_math (num=0x0, str=0x7fff5a86fa78 "/") at num.c:226
#4  0x00007faa1e26559b in assemble (a=0x11e6010, ao=0x7fff5a870e50, str=0x120d430 "mov eax,/") at p/asm_x86_nz.c:797
#5  0x00007faa1e27e704 in r_asm_assemble (a=0x11e6010, op=0x7fff5a870e50, buf=0x7fff5a870c50 "mov eax,/") at asm.c:350
#6  0x00007faa1e27fe1e in r_asm_massemble (a=0x11e6010, buf=0x7fff5a872325 "mov eax,/") at asm.c:628
#7  0x00000000004020aa in rasm_asm (buf=0x7fff5a872325 "mov eax,/", offset=0x0, len=0x0, bits=0x20, bin=0x0) at rasm2.c:168
#8  0x000000000040313f in main (argc=0x2, argv=0x7fff5a8718a8) at rasm2.c:422
#9  0x00007faa1d223ec5 in __libc_start_main (main=0x402218 <main>, argc=0x2, argv=0x7fff5a8718a8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fff5a871898) at libc-start.c:287
#10 0x0000000000401689 in _start ()
```

This fixes it
