### PR TITLE
check for null on core file

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -203,7 +203,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 		if (input[2]) {
 			r_debug_attach (core->dbg, (int) r_num_math (
 				core->num, input+2));
-		} else r_debug_attach (core->dbg, core->file->desc->fd);
+		} else if (core->file) r_debug_attach (core->dbg, core->file->desc->fd);
 		r_debug_select (core->dbg, core->dbg->pid, core->dbg->tid);
 		r_config_set_i (core->config, "dbg.swstep",
 			(core->dbg->h && !core->dbg->h->canstep));


### PR DESCRIPTION
fix  #1761
core->file was a null, so this caused a crash
