### PR TITLE
Fix GCC warnings: array subscript has type 'char'

### DIFF
--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -794,7 +794,7 @@ ut32 armass_assemble(const char *str, ut64 off, int thumb) {
 	ArmOpcode aop = {.off = off};
 	for (i=j=0; i<sizeof (buf)-1 && str[i]; i++, j++) {
 		if (str[j]=='#') { i--; continue; }
-		buf[i] = tolower (str[j]);
+		buf[i] = tolower ((const unsigned char)str[j]);
 	}
 	buf[i] = 0;
 	arm_opcode_parse (&aop, buf);

--- a/libr/asm/arch/dcpu16/asm.c
+++ b/libr/asm/arch/dcpu16/asm.c
@@ -50,7 +50,7 @@ static void clean_line(char* oline, const char* line) {
 			
 			/* Convert to upper case */
 			if (current_char >= 'a' && current_char <= 'z')
-				current_char = toupper (current_char);
+				current_char = toupper ((unsigned char)current_char);
 				
 			/* Place in cleaned line */
 			oline[n] = current_char;

--- a/libr/asm/arch/psosvm/vmas/vmas.c
+++ b/libr/asm/arch/psosvm/vmas/vmas.c
@@ -428,7 +428,7 @@ static int getInt(char* s, unsigned *number)
 				if(isxdigit((int)*s)==0)
 					return -1;
 				*number*=16;
-				*number+=*s-((isdigit(*s)!=0)?'0':((isupper(*s)!=0)?'A'-10:'a'-10));
+				*number+=*s-((isdigit((unsigned char)*s)!=0)?'0':((isupper((unsigned char)*s)!=0)?'A'-10:'a'-10));
 				s++;
 			}
 		}else{
@@ -494,4 +494,3 @@ int psosvmasm_init()
 	/* INIT PSOSVM DISASSEMBLER */
 	return 0;
 }
-

--- a/libr/asm/arch/tms320/c55x_plus/c55plus.c
+++ b/libr/asm/arch/tms320/c55x_plus/c55plus.c
@@ -39,7 +39,7 @@ int c55x_plus_disassemble(tms320_dasm_t *dasm, const ut8 *buf, int len) {
 	dasm->length = next_ins_pos;
 	ins_decoded_len = strlen(ins_decoded);
 	for (i = 0; i < ins_decoded_len; i++)
-		ins_decoded[i] = tolower(ins_decoded[i]);
+		ins_decoded[i] = tolower((unsigned char)ins_decoded[i]);
 	snprintf (dasm->syntax, sizeof(dasm->syntax), "%s", ins_decoded);
 	free (ins_decoded);
 	

--- a/libr/asm/arch/x86/ollyasm/assembl.c
+++ b/libr/asm/arch/x86/ollyasm/assembl.c
@@ -130,9 +130,9 @@ static void Scanasm(int mode) {
     asmcmd++;                          // Skip leading spaces
   if (*asmcmd=='\0' || *asmcmd==';') {
     scan=SCAN_EOL; return; };          // Empty line
-  if (isalpha(*asmcmd) || *asmcmd=='_' || *asmcmd=='@') {
+  if (isalpha((unsigned char)*asmcmd) || *asmcmd=='_' || *asmcmd=='@') {
     sdata[0]=*asmcmd++; i=1;           // Some keyword or identifier
-    while ((isalnum(*asmcmd) || *asmcmd=='_' || *asmcmd=='@') &&
+    while ((isalnum((unsigned char)*asmcmd) || *asmcmd=='_' || *asmcmd=='@') &&
       i<sizeof(sdata))
       sdata[i++]=*asmcmd++;
     if (i>=sizeof(sdata)) {
@@ -210,20 +210,20 @@ static void Scanasm(int mode) {
       asmcmd++;
       while (*asmcmd==' ' || *asmcmd=='\t')
         asmcmd++;                      // Skip trailing spaces
-      if (!isdigit(*asmcmd)) {
+      if (!isdigit((unsigned char)*asmcmd)) {
         asmerror="Integer number expected";
         scan=SCAN_ERR; return; };
-      while (isdigit(*asmcmd))         // LOCAL index is decimal number!
+      while (isdigit((unsigned char)*asmcmd))         // LOCAL index is decimal number!
         idata=idata*10+(*asmcmd++)-'0';
       scan=SCAN_LOCAL; return; };
     if (strcmp(s,"ARG")==0 && *asmcmd=='.') {
       asmcmd++;
       while (*asmcmd==' ' || *asmcmd=='\t')
         asmcmd++;                      // Skip trailing spaces
-      if (!isdigit(*asmcmd)) {
+      if (!isdigit((unsigned char)*asmcmd)) {
         asmerror="Integer number expected";
         scan=SCAN_ERR; return; };
-      while (isdigit(*asmcmd))         // ARG index is decimal number!
+      while (isdigit((unsigned char)*asmcmd))         // ARG index is decimal number!
         idata=idata*10+(*asmcmd++)-'0';
       scan=SCAN_ARG; return; };
     if (strcmp(s,"REP")==0) {
@@ -261,27 +261,27 @@ static void Scanasm(int mode) {
       return; }
     asmerror="Unknown identifier";
     scan=SCAN_ERR; return; }
-  else if (isdigit(*asmcmd)) {         // Constant
+  else if (isdigit((unsigned char)*asmcmd)) {         // Constant
     base=10; maxdigit=0; decimal=hex=0L; floating=0.0;
-    if (asmcmd[0]=='0' && toupper(asmcmd[1])=='X') {
+    if (asmcmd[0]=='0' && toupper((unsigned char)asmcmd[1])=='X') {
       base=16; asmcmd+=2; };           // Force hexadecimal number
 //printf("DIGIT (%s) %d\n", asmcmd, base);
     while (1) {
-      if (isdigit(*asmcmd)) {
+      if (isdigit((unsigned char)*asmcmd)) {
         decimal=decimal*10+(*asmcmd)-'0';
         floating=floating*10.0+(*asmcmd)-'0';
         //hex=hex*16+(*asmcmd)-'0';
         hex=hex*base+(*asmcmd)-'0';
         if (maxdigit==0) maxdigit=9;
         asmcmd++; }
-      else if (isxdigit(*asmcmd)) {
-        hex=hex*16+toupper(*asmcmd++)-'A'+10;
+      else if (isxdigit((unsigned char)*asmcmd)) {
+        hex=hex*16+toupper((unsigned char)*asmcmd++)-'A'+10;
         maxdigit=15; }
       else break; };
     if (maxdigit==0) {
       asmerror="Hexadecimal digits after 0x... expected";
       scan=SCAN_ERR; return; };
-    if (toupper(*asmcmd)=='H') {       // Force hexadecimal number
+    if (toupper((unsigned char)*asmcmd)=='H') {       // Force hexadecimal number
       if (base==16) {
         asmerror="Please don't mix 0xXXXX and XXXXh forms";
         scan=SCAN_ERR; return; };
@@ -295,20 +295,20 @@ static void Scanasm(int mode) {
       if (base==16 || maxdigit>9) {
         asmerror="Not a decimal number"; scan=SCAN_ERR; return; };
       asmcmd++;
-      if (isdigit(*asmcmd) || toupper(*asmcmd)=='E') {
+      if (isdigit((unsigned char)*asmcmd) || toupper((unsigned char)*asmcmd)=='E') {
         divisor=1.0;
-        while (isdigit(*asmcmd)) {     // Floating-point number
+        while (isdigit((unsigned char)*asmcmd)) {     // Floating-point number
           divisor/=10.0;
           floating+=divisor*(*asmcmd-'0');
           asmcmd++; };
-        if (toupper(*asmcmd)=='E') {
+        if (toupper((unsigned char)*asmcmd)=='E') {
           asmcmd++;
           if (*asmcmd=='-') { base=-1; asmcmd++; }
           else base=1;
-          if (!isdigit(*asmcmd)) {
+          if (!isdigit((unsigned char)*asmcmd)) {
             asmerror="Invalid exponent"; scan=SCAN_ERR; return; };
           decimal=0;
-          while (isdigit(*asmcmd)) {
+          while (isdigit((unsigned char)*asmcmd)) {
             if (decimal<65536L) decimal=decimal*10+(*asmcmd++)-'0'; };
           floating*=pow10l(decimal*base); };
         fdata=floating;
@@ -1421,4 +1421,3 @@ error:
 };
 
 //#pragma option -O.                     // Restore old optimization options
-

--- a/libr/asm/arch/x86/ollyasm/disasm.c
+++ b/libr/asm/arch/x86/ollyasm/disasm.c
@@ -58,8 +58,8 @@ strupr (a)
 
   while (*a != '\0')
     {
-      if (islower (*a))
-	*a = toupper (*a);
+      if (islower ((unsigned char)*a))
+	*a = toupper ((unsigned char)*a);
       ++a;
     }
 
@@ -69,8 +69,8 @@ strupr (a)
 char * strlwr (char *a) {
 	char *ret = a;
 	while (*a != '\0') {
-		if (isupper (*a))
-			*a = tolower (*a);
+		if (isupper ((unsigned char)*a))
+			*a = tolower ((unsigned char)*a);
 		++a;
 	}
 	return ret;
@@ -1282,4 +1282,3 @@ ulong Disasm(const unsigned char *src,ulong srcsize,ulong srcip,
   };
   return (srcsize-size);               // Returns number of recognized bytes
 };
-

--- a/libr/asm/arch/z80/expressions.c
+++ b/libr/asm/arch/z80/expressions.c
@@ -48,7 +48,7 @@ rd_number (const char **p, const char **endp, int base)
 	     "(string=%s).\n", stack[sp].line, addr, base, *p);
   num[base] = '\0';
   *p = delspc (*p);
-  while (**p && (c = strchr (num, tolower (**p))))
+  while (**p && (c = strchr (num, tolower ((const unsigned char)**p))))
     {
       i = c - num;
       if (verbose >= 7)
@@ -83,7 +83,7 @@ rd_otherbasenumber (const char **p, int *valid, int print_errors)
 	printerr (1, "unexpected end of line after `@'\n");
       return 0;
     }
-  if (**p == '0' || !isalnum (**p))
+  if (**p == '0' || !isalnum ((const unsigned char)**p))
     {
       if (valid)
 	*valid = 0;
@@ -93,8 +93,8 @@ rd_otherbasenumber (const char **p, int *valid, int print_errors)
     }
   c = **p;
   (*p)++;
-  if (isalpha (**p))
-    return rd_number (p, NULL, tolower (c) - 'a' + 1);
+  if (isalpha ((const unsigned char)**p))
+    return rd_number (p, NULL, tolower ((unsigned char)c) - 'a' + 1);
   return rd_number (p, NULL, c - '0' + 1);
 }
 
@@ -189,7 +189,7 @@ check_label (struct label *labels, const char **p, struct label **ret,
   const char *c;
   unsigned s2;
   *p = delspc (*p);
-  for (c = *p; isalnum (*c) || *c == '_' || *c == '.'; ++c)
+  for (c = *p; isalnum ((const unsigned char)*c) || *c == '_' || *c == '.'; ++c)
     {
     }
   s2 = c - *p;

--- a/libr/asm/arch/z80/z80asm.c
+++ b/libr/asm/arch/z80/z80asm.c
@@ -111,7 +111,7 @@ static void printerr (int error, const char *fmt, ...) {
 
 /* skip over spaces in string */
 static const char * delspc (const char *ptr) {
-	while (*ptr && isspace (*ptr))
+	while (*ptr && isspace ((const unsigned char)*ptr))
 		ptr++;
 	if (*ptr == ';')
 		ptr = "";
@@ -184,7 +184,7 @@ static int indx (const char **ptr, const char **list, int error, const char **ex
 
 			++check;
 		}
-		if (*check || (isalnum (check[-1]) && isalnum (input[0])))
+		if (*check || (isalnum ((const unsigned char)check[-1]) && isalnum ((const unsigned char)input[0])))
 			continue;
 		if (had_expr) {
 			input = delspc (input);

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -94,7 +94,7 @@ R_API char *r_cons_hud(RList *list, const char *prompt) {
 					p = strdup (pos);
 					for (j=0; p[j]; j++) {
 						if (strchr (buf, p[j]))
-							p[j] = toupper (p[j]);
+							p[j] = toupper ((unsigned char)p[j]);
 					}
 					r_cons_printf (" %c %s\n", first?'-':' ', p);
 					free (p);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1327,7 +1327,7 @@ ignore:
 		offstr = r_str_trim_head (ptr+1);
 
 		addr = r_num_math (core->num, offstr);
-                if (isalpha (ptr[1]) && addr== 0) {
+                if (isalpha ((unsigned char)ptr[1]) && addr== 0) {
                         if (!r_flag_get (core->flags, ptr+1)) {
                                 eprintf ("Invalid address (%s)\n", ptr+1);
                                 return R_FALSE;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1338,7 +1338,7 @@ static int cmd_search(void *data, const char *input) {
 			str = malloc ((len+1)*2);
 			for (p2=input+strstart, p=str; *p2; p+=2, p2++) {
 				if (ignorecase)
-					p[0] = tolower(*p2);
+					p[0] = tolower((const unsigned char)*p2);
 				else
 					p[0] = *p2;
 				p[1] = 0;

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -561,9 +561,9 @@ static int apprentice_load(RMagic *ms, struct r_magic **magicp, ut32 *nmagicp, c
 #define SYMBOL "text"
 #define SYMLEN sizeof(SYMBOL)
 					char *p = strstr(marray[i].mp->desc, "text");
-					if (p && (p == marray[i].mp->desc || isspace(p[-1])) &&
+					if (p && (p == marray[i].mp->desc || isspace((unsigned char)p[-1])) &&
 					    (p + SYMLEN - marray[i].mp->desc == MAXstring ||
-					     (p[SYMLEN] == '\0' || isspace(p[SYMLEN])))) {
+					     (p[SYMLEN] == '\0' || isspace((unsigned char)p[SYMLEN])))) {
 						(void)fprintf(stderr,
 							      "*** Possible binary test for text type\n");
 					}

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -244,7 +244,7 @@ R_API int r_reg_set_profile_string(RReg *reg, const char *str) {
 				break;
 			// Gather a handful of chars
 			// Use isgraph instead of isprint because the latter considers ' ' printable
-			for (i = 0; isgraph (*p) && i < sizeof(tmp) - 1;)
+			for (i = 0; isgraph ((const unsigned char)*p) && i < sizeof(tmp) - 1;)
 				tmp[i++] = *p++;
 			tmp[i] = '\0';
 			// Limit the number of tokens 

--- a/libr/search/keyword.c
+++ b/libr/search/keyword.c
@@ -117,7 +117,7 @@ R_API RSearchKeyword *r_search_keyword_new_regexp (const char *str, const char *
 	RSearchKeyword *kw;
 	int i = 0, start, length;
 
-	while (isspace(str[i]))
+	while (isspace((const unsigned char)str[i]))
 		i++;
 
 	if (str[i++] != '/')
@@ -164,5 +164,3 @@ R_API RSearchKeyword *r_search_keyword_new_regexp (const char *str, const char *
 
 	return kw;
 }
-
-

--- a/libr/util/calc.c
+++ b/libr/util/calc.c
@@ -179,7 +179,7 @@ static int cin_get_num(RNum *num, RNumCalc *nc, RNumCalcValue *n) {
 	char c;
 	str[0] = 0;
 	while (cin_get (num, nc, &c)) {
-		if (c!=':' && c!='.' && !isalnum (c)) {
+		if (c!=':' && c!='.' && !isalnum ((unsigned char)c)) {
 			cin_putback (num, nc, c);
 			break;
 		}
@@ -220,7 +220,7 @@ static RNumCalcToken get_token(RNum *num, RNumCalc *nc) {
 	char ch = 0, c = 0;
 
 	do { if (!cin_get (num, nc, &ch)) return nc->curr_tok = RNCEND;
-	} while (ch!='\n' && isspace (ch));
+	} while (ch!='\n' && isspace ((unsigned char)ch));
 
 	switch (ch) {
 	case 0:
@@ -282,7 +282,7 @@ static RNumCalcToken get_token(RNum *num, RNumCalc *nc) {
 				}
 				nc->string_value[i++] = ch;
 			} else {
-				while (cin_get (num, nc, &ch) && isvalidchar (ch)) {
+				while (cin_get (num, nc, &ch) && isvalidchar ((unsigned char)ch)) {
 					if (i>=R_NUMCALC_STRSZ) {
 						error (num, nc, "string too long");
 						return 0;

--- a/libr/util/regex/engine.c
+++ b/libr/util/regex/engine.c
@@ -526,8 +526,8 @@ backref(struct match *m, char *start, char *stop, sopno startst, sopno stopst,
 					(sp < m->endp && *(sp-1) == '\n' &&
 						(m->g->cflags&R_REGEX_NEWLINE)) ||
 					(sp > m->beginp &&
-							!ISWORD(*(sp-1))) ) &&
-					(sp < m->endp && ISWORD(*sp)) )
+							!ISWORD((unsigned char)*(sp-1))) ) &&
+					(sp < m->endp && ISWORD((unsigned char)*sp)) )
 				{ /* yes */ }
 			else
 				return(NULL);
@@ -536,8 +536,8 @@ backref(struct match *m, char *start, char *stop, sopno startst, sopno stopst,
 			if (( (sp == m->endp && !(m->eflags&R_REGEX_NOTEOL)) ||
 					(sp < m->endp && *sp == '\n' &&
 						(m->g->cflags&R_REGEX_NEWLINE)) ||
-					(sp < m->endp && !ISWORD(*sp)) ) &&
-					(sp > m->beginp && ISWORD(*(sp-1))) )
+					(sp < m->endp && !ISWORD((unsigned char)*sp)) ) &&
+					(sp > m->beginp && ISWORD((unsigned char)*(sp-1))) )
 				{ /* yes */ }
 			else
 				return(NULL);

--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -823,7 +823,7 @@ p_b_cclass(struct parse *p, cset *cs)
 	char *u;
 	char c;
 
-	while (MORE() && isalpha(PEEK()))
+	while (MORE() && isalpha((unsigned char)PEEK()))
 		NEXT();
 	len = p->next - sp;
 	for (cp = cclasses; cp->name != NULL; cp++)

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -101,7 +101,7 @@ R_API int r_str_bits (char *strout, const ut8 *buf, int len, const char *bitz) {
 			if (i>0 && (i%8)==0)
 				buf++;
 	                if (*buf&(1<<(i%8)))
-				strout[j++] = toupper (bitz[i]);
+				strout[j++] = toupper ((const unsigned char)bitz[i]);
 		}
 	} else {
 		for (i=j=0; i<len; i++) {
@@ -122,8 +122,8 @@ R_API ut64 r_str_bits_from_string(const char *buf, const char *bitz) {
 	ut64 out = 0LL;
 	/* return the numberic value associated to a string (rflags) */
 	for (; *buf; buf++) {
-		char *ch = strchr (bitz, toupper (*buf));
-		if (!ch) ch = strchr (bitz, tolower (*buf));
+		char *ch = strchr (bitz, toupper ((const unsigned char)*buf));
+		if (!ch) ch = strchr (bitz, tolower ((const unsigned char)*buf));
 		if (ch) {
 			int bit = (int)(size_t)(ch - bitz);
 			out |= (ut64)(1LL << bit);
@@ -202,10 +202,10 @@ R_API void r_str_case(char *str, int up) {
 	if (up) {
 		char oc = 0;
 		for (; *str; oc = *str++)
-			*str = (*str=='x' && oc=='0') ? 'x': toupper (*str);
+			*str = (*str=='x' && oc=='0') ? 'x': toupper ((unsigned char)*str);
 	} else
 		for (; *str; str++)
-			*str = tolower (*str);
+			*str = tolower ((unsigned char)*str);
 }
 
 R_API char *r_str_home(const char *str) {


### PR DESCRIPTION
Reported at NetBSD-current/amd64
GCC 4.8.4 (nb1 20141012)
