### PR TITLE
fix crash in asm.c

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -489,9 +489,10 @@ R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf) {
 
 	/* Tokenize */
 	for (tokens[0] = lbuf, ctr = 0;
-		(ptr = strchr (tokens[ctr], ';')) ||
+		ctr < R_ASM_BUFSIZE - 1 &&
+		((ptr = strchr (tokens[ctr], ';')) ||
 		(ptr = strchr (tokens[ctr], '\n')) ||
-		(ptr = strchr (tokens[ctr], '\r'));
+		(ptr = strchr (tokens[ctr], '\r')));
 		tokens[++ctr] = ptr+1) {
 			*ptr = '\0';
 	}


### PR DESCRIPTION
asm.c could assemble more instructions than spots in the token array,
this fixes it.

example base64 input to rasm2 that caused crashes.

```
bm9wb3AKciRwZ3AKcjokJCQKCgokJCAgICAgICAKCgoKCgoJ/woKCiQkJCQJCQkJCQkJCQkJCSQK
IPLy8vLy8vLyICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCCgoKCf8KCkoJJAog8vLy8vLy8vIgIAoK
Cf8KCgokJCQkICAgICALICAKCgIKCgoJ/woKSiQkJCQJCQkJCQkJCQkkJCQKDyAgICAK83YKCgoJ
/wry8vLy8vLyICAKCgn/CgoJCSRyOiQkCQkkCiDy8vLy8vLy8iAgCiQgICAgICAgIAoKCgoKCgn/
CgoKJCQkJAkJCQkJCQny8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoVCgn/CgpKJBokJAkJCQkJ
CQkJCQkKCf8KCvgjJCQkICAgcApyJHBncApyOiQkJAoKCiQkICAgICAgICAKCgoKCgoJ/woKCiQk
JCQJCQkkCiDy8vLy8vLy8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKJCQkJAkJCQkJ
CQkJCSQkJAoPICAnIArzdgoKCgn/CgpKJCQkJAkJCQkJCQkJCQkJJHI6CQkJCQkJCQkJJHI6JCQk
CgoKJCQgICAgIAoKJCQkJAkJCQk8JAkJCQkJCQkJCQkJJAog8vLy8vLy8vIgIAoKCfcKCgokJCQk
ICAgICALICAKIAoKCgoKCgn/CgoKJCQkJAkJCSQKIPLy8vLy8vLyICAKJCAgICAgICAgCgoKCgoK
Cf8KCgokJCQkCQkJJAog8vLy8vLy8vIgIAoKCgokJCAgICAgIAkJJAog8vLy8vLy8vIgIAoKCf8K
CgokJCQkICAgICALICAKCgIKCgoJ/woKSiQkJCQJCQkJCQkJCQkkJCQKDyAgICAK83YKCgoJ/woK
SiQkJCQJCQkJCQkJCQkJCSRyOiQkCQkkCiDy8vLy8vLy8iAgCiQgICAgICAgIAoKCgoKCgn/CgoK
JCQkJAkJCQkJCQny8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoVCgn/CgpKJBokJAkJCQkJ//3/
/wkKCf8KCwcjJCQkICAgcApyJHBncApyOiQkJAoKCiQkICAgICAgICAKCgoKCgoJ/woKCiQkJCQJ
CQkkCiDy8vLy8vLy8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKCSQKIPLy8vLy8vLy
ICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCCgoKCf8KCkokJCQkCQkJCQkJCQkJCgoKCgn/CgoKJCQk
JAkJCSQKIPLy8vLy8vLyICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCCgoKCf8KCkokJCQkCQkJCQkJ
CQkJJCQkCg8gICcgCvN2CgoKCf8KCkokJCQkCQkJCQkJCQkJCQkkcjoJCQkJCQkJCQkkcjokJCQK
CgokJCAgICAgCgokJCQkCQkJCTwkCQkJCQkJCQkJCQkkCiDy8vLy8vLy8iAgCgoJ9woKCiQkJCQg
ICAgIAsgIAogCgoKCgoKCf8KCgokJCQkCQkJJAog8vLy8vLy8vIgIAokICAgICAgICAKCgoKCgoJ
/woKCiQkJCQJCQkkCiDy8vLy8vLy8iAgCgoKCiQkICAgICAgCQkkCiDy8vLy8vLy8iAgCgoJ/woK
CiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKJCQkJAkJCQkJCQkJCSQkJAoPICAgIArzdgoKCgn/CgpK
JCQkJAkJCQkJCQkJCQkJJHI6JCQJCSQKIPLy8vLy8vLyICAKJCAgICAgICAgCgoKCgoKCf8KCgok
JCQkCQkJCQkJCfLyICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCChUKCf8KCkokGiQkCQkJCQn//f//
CQoJ/woK+CMkJCQgICBwCnIkcGdwCnI6JCQkCgoKJCQgICAgICAgIAoKCgoKCgn/CgoKJCQkJAkJ
CSQKIPLy8vLy8vLyICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCCgoKCf8KCkoJJAog8vLy8vLy8vIg
IAoKCf8KCgokJCQkICAgICALICAKCgIKCgoJ/woKSiQkJCQJCQkJCQkJCQkkJCQKDyAgICAK83YK
CgoJ/woKSiQkJCQJCQkJCQkJCfUJCSRyOiQkCQkkCiDy8vLy8vLy8iAgCiQgICAgICAgIAoKCgoK
Cgn/CgoKJCQkJAkJCQkJCQny8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoVCgn/CgpKJBokJAkJ
CQkJCQkJCQkKCf8KCvgjJCQkICAgJCAgICAgICAgCgoKCgoKCf8KCgokJCQkCQkJCQkJCQkJCQkk
CiDy8vLy8vLy8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKJCQkJAkJCQkJCQkJCSQk
JAoPICAnIArzdgoKCgn/CgpKJCQkJAkJCQkJCQkJCQkJJHI6JCQkCgoKJCQgICAkJCQKDyAgICAK
83YKCgoJ/woKSiQkJCQJCQkJCQkJCfUJCSRyOiQkCQkkCiDy8vLy8vLy8iAgCiQgICAgICAgIAoK
CgoKCgn/CgoKJCQkJAkJCQkJCQny8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoVCgn/CgpKJBok
JAkJCQkJCQkJCQkKCf8KCvgjJCQkICAgJCAgICAgICAgCgoKCgoKCf8KCgokJCQkCQkJCQkJCQkJ
CQkkCiDy8vLy8vLy8iAgCgoJ/woKCiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKJCQkJAkJCQkJCQkJ
CSQkJAoPICAnIArzdgoKCgn/CgpKJCQkJAkJCQkJCQkJCQkJJHI6JCQkCgoKJCQgICAgICAgIAoK
CgoKCgn/CgoKJCQkJAkJCQk8JAkJCQkJCQkJCQkJJAog8vLy8vLy8vIgIAoKCfcKCgokJCQkICAg
ICALICAKCgIKFQoJ/woKSiQaJCQJCQkJCQkJCQkJCgn/Cgr4IyQkJCAgIHAKciRwZ3AKcjokJCQK
CgokJCAgICAgICAgCgoKCgoKCf8KCgokJCQkCQkJCQkJCQkJCQkkCiDy8vLy8vLy8iAgCgoJ/woK
CiQkJCQgICAgIAsgIAoKAgoKCgn/CgpKJCQkJAkJCQkJCQkJCSQkJAoPICAgIArzdgoKCgn/CgpK
JCQkJAkJCSQkJAkJCQkJCQkJCQkJJCQkCiQkJCQJCQkJCQkJCQkkJCQKDyAgJyAK83YKCgoJ/woK
SiQkJCQJCQkJCQkJCQkJCSRyOiQkJAoKCiQkICAgICAgICAKCgoKCgoJ/woKCiQkJCQJCQkJPCQJ
CQkJCQkJCQkJCSQKIPLy8vLy8vLyICAKCgn/CgoKJCQkJCAgICAgCyAgCgoCChUKCf8KCkokGiQk
CQkJCQkJAQkJCQoJ/woK+CMkJCQgICBwCnIkcGdwCnI6JCQkCgoKJCQgICAgICAgIAoKCgoKCgn/
CgoKJCQkJAkJCQkJCQkJCQkJJAog8vLy8vLy8vIgIAoKCf8KCgokJCQkICAgICALICAKCgIKCgoJ
/woKSiQkJCQJCQkJCQkJCQkkJCQKDyAgICAK83YKCgoJ/woKSiQkJCQJCQkJCQkJCQkJCSQkJAkJ
CSQkJApyZYAK
```
