### PR TITLE
[Bugfix] rax: arguments that start with 'h', 'q' or '?' are now ignored...

### DIFF
--- a/binr/rax2/rax2.c
+++ b/binr/rax2/rax2.c
@@ -146,12 +146,9 @@ static int rax (char *str, int len, int last) {
 			return !use_stdin ();
 		return R_TRUE;
 	}
-	if (*str=='q')
-		return R_FALSE;
-	if (*str=='h' || *str=='?')
-		return help ();
+
 	dotherax:
-	
+
 	if (flags & 1) { // -s
 		ut64 n = ((strlen (str))>>1)+1;
 		buf = malloc (n);


### PR DESCRIPTION
Fixes #1910 
