### PR TITLE
Add option to radiff to suppress names

### DIFF
--- a/binr/radiff2/radiff2.c
+++ b/binr/radiff2/radiff2.c
@@ -15,6 +15,7 @@ static ut32 count = 0;
 static int showcount = 0;
 static int useva = R_TRUE;
 static int delta = 0;
+static int showbare = R_FALSE;
 
 static int cb(RDiff *d, void *user, RDiffOp *op) {
 	int i, rad = (int)(size_t)user;
@@ -77,6 +78,7 @@ static int show_help(int v) {
 		"  -c         count of changes\n"
 		"  -C         graphdiff code (columns: off-A, match-ratio, off-B)\n"
 		"  -d         use delta diffing\n"
+		"  -f         print bare addresses only (diff.bare=1)\n"
 		"  -g [sym|off1,off2]   graph diff of given symbol, or between two offsets\n"
 		"  -O         code diffing with opcode bytes only\n"
 		"  -p         use physical addressing (io.va=0)\n"
@@ -136,7 +138,7 @@ int main(int argc, char **argv) {
 	int threshold = -1;
 	double sim;
 
-	while ((o = getopt (argc, argv, "a:b:Cpg:Orhcdsvxt:")) != -1) {
+	while ((o = getopt (argc, argv, "a:b:Cfpg:Orhcdsvxt:")) != -1) {
 		switch (o) {
 		case 'a':
 			arch = optarg;
@@ -159,6 +161,9 @@ int main(int argc, char **argv) {
 			break;
 		case 'C':
 			mode = MODE_CODE;
+			break;
+		case 'f':
+			showbare = R_TRUE;
 			break;
 		case 'O':
 			diffops = 1;
@@ -208,6 +213,10 @@ int main(int argc, char **argv) {
 		if (bits) {
 			r_config_set_i (c->config, "asm.bits", bits);
 			r_config_set_i (c2->config, "asm.bits", bits);
+		}
+		if (showbare) {
+			r_config_set_i (c->config, "diff.bare", showbare);
+			r_config_set_i (c2->config, "diff.bare", showbare);
 		}
 		r_anal_diff_setup_i (c->anal, diffops, threshold, threshold);
 		r_anal_diff_setup_i (c2->anal, diffops, threshold, threshold);

--- a/libr/core/config.c
+++ b/libr/core/config.c
@@ -971,6 +971,7 @@ R_API int r_core_config_init(RCore *core) {
 	/* diff */
 	SETI("diff.from", 0, "Set source diffing address for px (uses cc command)");
 	SETI("diff.to", 0, "Set destination diffing address for px (uses cc command)");
+	SETPREF("diff.bare", "false", "Never show function names in diff output");
 
 	/* dir */
 	SETPREF("dir.magic", R_MAGIC_PATH, "Path to r_magic files");

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -55,7 +55,13 @@ R_API int r_core_gdiff(RCore *c, RCore *c2, int anal_all) {
 }
 
 /* copypasta from radiff2 */
-static void diffrow(ut64 addr, const char *name, int maxnamelen, ut64 addr2, const char *name2, const char *match, double dist) {
+static void diffrow(ut64 addr, const char *name, int maxnamelen, ut64 addr2, const char *name2, const char *match, double dist, int bare) {
+	if (bare) {
+		if (addr2 == UT64_MAX || name2 == NULL)
+			printf ("0x%016"PFMT64x" |%8s  (%f)\n", addr, match, dist);
+		else printf ("0x%016"PFMT64x" |%8s  (%f) | 0x%016"PFMT64x"\n", addr, match, dist, addr2);
+		return;
+	}
 	if (addr2 == UT64_MAX || name2 == NULL)
 		printf ("%*s  0x%"PFMT64x" |%8s  (%f)\n",
 			maxnamelen, name, addr, match, dist);
@@ -70,6 +76,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
         RList *fcns = r_anal_get_fcns (c->anal);
         int maxnamelen = 0;
         int len;
+        int bare = r_config_get_i (c->config, "diff.bare") || r_config_get_i (c2->config, "diff.bare");
         r_list_foreach (fcns, iter, f) {
                 if (f->name && (len = strlen(f->name)) > maxnamelen)
                         maxnamelen = len;
@@ -96,7 +103,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                         }
                         diffrow (f->addr, f->name, maxnamelen,
 				f->diff->addr, f->diff->name,
-				match, f->diff->dist);
+				match, f->diff->dist, bare);
                         break;
                 }
         }
@@ -108,7 +115,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
                         if (f->diff->type == R_ANAL_DIFF_TYPE_NULL)
                                 diffrow (f->addr, f->name, maxnamelen,
 					f->diff->addr, f->diff->name,
-					"NEW", f->diff->dist);
+					"NEW", f->diff->dist, bare);
                 }
         }
 }

--- a/man/radiff2.1
+++ b/man/radiff2.1
@@ -22,6 +22,8 @@ Select register size bits for given arch
 Count number of differences.
 .It Fl C
 Code diffing using graphdiff algorithm. Output columns are: file-a-address, percentatge of most similar function in B file | file-b-address.
+.It Fl f
+Suppress address names (show only addresses) when code diffing.
 .It Fl d
 Use delta diffing (slower).
 .It Fl g Ar sym | off1,off2


### PR DESCRIPTION
The default output produced by `radiff2 -C file1 file2 is

```
                   entry0  0x400586 |   MATCH  (0.071429) | 0x400585  entry0
sym.imp.__libc_start_main  0x4004e0 |   MATCH  (1.000000) | 0x4004e0  sym.imp.__libc_start_main
             fcn.004004e6  0x4004e6 |   MATCH  (1.000000) | 0x4004e6  fcn.004004e6
          sym.imp.putchar  0x4004c0 |   MATCH  (1.000000) | 0x4004c0  sym.imp.putchar
```

This new option '-f' changes the output, such that `radiff2 -C -f file1 file2` is

```
0x0000000000400586 |   MATCH  (0.071429) | 0x0000000000400585
0x00000000004004e0 |   MATCH  (1.000000) | 0x00000000004004e0
0x00000000004004e6 |   MATCH  (1.000000) | 0x00000000004004e6
0x00000000004004c0 |   MATCH  (1.000000) | 0x00000000004004c0
```

I found this useful for cases where large files with fcn.xxxx just gets in the way
