### PR TITLE
Some cppcheck reports fixed:

### DIFF
--- a/libr/asm/arch/arc/gnu/arc-ext.c
+++ b/libr/asm/arch/arc/gnu/arc-ext.c
@@ -394,7 +394,7 @@ arcExtMap_instName (int opcode, int insn, int *flags)
 const char *
 arcExtMap_coreRegName (int regnum)
 {
-  if (regnum < FIRST_EXTENSION_CORE_REGISTER || regnum > LAST_EXTENSION_CONDITION_CODE)
+  if (regnum < FIRST_EXTENSION_CORE_REGISTER || regnum > LAST_EXTENSION_CORE_REGISTER)
     return NULL;
   return arc_extension_map.coreRegisters[regnum - FIRST_EXTENSION_CORE_REGISTER].name;
 }
@@ -404,7 +404,7 @@ arcExtMap_coreRegName (int regnum)
 enum ExtReadWrite
 arcExtMap_coreReadWrite (int regnum)
 {
-  if (regnum < FIRST_EXTENSION_CORE_REGISTER || regnum > LAST_EXTENSION_CONDITION_CODE)
+  if (regnum < FIRST_EXTENSION_CORE_REGISTER || regnum > LAST_EXTENSION_CORE_REGISTER)
     return REG_INVALID;
   return arc_extension_map.coreRegisters[regnum - FIRST_EXTENSION_CORE_REGISTER].rw;
 }

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -323,11 +323,6 @@ static int dex_loadcode(RBinFile *arch, RBinDexObj *bin) {
 		return R_FALSE;
 	}
 
-	if (bin->header.strings_size > bin->size) {
-		eprintf ("Invalid strings size\n");
-		return R_FALSE;
-	}
-
 	dprintf ("Walking %d classes\n", bin->header.class_size);
 	if (bin->classes)
 	for (i=0; i<bin->header.class_size; i++) {

--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -746,7 +746,6 @@ static int build_format_flags(R_PDB *pdb, char *type, int pos, char *res_field, 
 					(!strcmp(tmp, "nesttype")) ||
 					(!strcmp(tmp, "mfunction")) ||
 					(!strcmp(tmp, "proc")) ||
-					(!strcmp(tmp, "nesttype")) ||
 					(!strcmp(tmp, "arglist"))) {
 				break;
 			} else {

--- a/libr/cons/output.c
+++ b/libr/cons/output.c
@@ -199,20 +199,6 @@ R_API int r_cons_w32_print(ut8 *ptr, int empty) {
 				str = ptr + 1;
 				continue;
 			} else
-			if (ptr[0]=='0'&&ptr[1]==';'&&ptr[2]=='0') {
-				// \x1b[0;0H
-				/** clear screen if gotoxy **/
-				if (empty) {
-					// fill row here
-					fill_tail(cols, lines);
-				}
-				w32_gotoxy (0, 0);
-				lines = 0;
-				esc = 0;
-				ptr += 3;
-				str = ptr + 1;
-				continue;
-			} else
 			if (ptr[0]=='0'&&(ptr[1]=='m' || ptr [1]=='K')) {
 				SetConsoleTextAttribute (hConsole, 1|2|4|8);
 				fg = 1|2|4|8;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2627,7 +2627,7 @@ R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int 
 			handle_print_ptr (core, ds, len, idx);
 			handle_print_comments_right (core, ds);
 			if ( !(ds->show_comments && ds->show_comment_right &&
-					ds->show_comment_right && ds->comment))
+					ds->comment))
 				r_cons_newline ();
 
 			if (ds->line) {


### PR DESCRIPTION
(warning) Logical disjunction always evaluates to true: regnum < 32 || regnum > 31
(style) Same expression on both sides of '||'
(style) Same expression on both sides of '&&'
(style) Expression is always false because 'else if' condition matches previous condition at line 180
