### PR TITLE
Add pdz, to auto-seek to end of disassembly

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1569,8 +1569,6 @@ static int cmd_print(void *data, const char *input) {
 					block = malloc (R_MAX(l*10, bs));
 					memcpy (block, core->block, bs);
 					r_core_read_at (core, addr+bs, block+bs, (l*10)-bs); //core->blocksize);
-					//core->num->value = r_core_print_disasm (core->print,
-					//	core, addr, block, l*10, l, 0, 0);
 					core->num->value = r_core_print_disasm (core->print,
 							core, addr, block, l*10, l, 0, 0);
 				}


### PR DESCRIPTION
This makes it work a bit like gdb:

```
[0x12345678] pd 0x10
(... disassembled 16 instructions, but position doesn't change)
[0x12345678] pd 0x20
(... disassembled 32 at same place, but position doesn't change)
[0x12345678] pdz 0x10
(... disassembled 16 instructions, but moved seek to end of disassembly)
[0x123456b8] pdz 0x20
(... disassembled 16 instructions, but moved seek to end of disassembly)
[0x12345738] pdz 0x20
```

Also same for pDz with bytes
