### PR TITLE
WIP: signal -> sigaction

### DIFF
--- a/binr/preload/libr2.c
+++ b/binr/preload/libr2.c
@@ -37,8 +37,10 @@ static void sigusr2(int s) {
 static void _libwrap_init() __attribute__ ((constructor));
 static void _libwrap_init() {
 	char *web;
-	signal (SIGUSR1, sigusr1);
-	signal (SIGUSR2, sigusr2);
+	sigset_t mask;
+	sigemptyset (&mask);
+	r_sys_sigaction (SIGUSR1, sigusr1, &mask, 0);
+	r_sys_sigaction (SIGUSR2, sigusr2, &mask, 0);
 	printf ("libr2 initialized. send SIGUSR1 to %d in order to reach the r2 prompt\n", getpid ());
 	printf ("kill -USR1 %d\n", getpid ());
 	fflush (stdout);

--- a/binr/rarun2/rarun2.c
+++ b/binr/rarun2/rarun2.c
@@ -9,11 +9,15 @@ static void fwd(int sig) {
 }
 
 static void rarun2_tty() {
+	sigset_t mask;
+	sigemptyset (&mask);
+	sigaddset (&mask, SIGINT);
+
 	/* TODO: Implement in native code */
 	r_sys_cmd ("tty");
 	close(1);
 	dup2(2, 1);
-	signal (SIGINT, fwd);
+	r_sys_sigaction (SIGINT, fwd, &mask, 0);
 	for (;;) {
 		sleep (1);
 	}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1738,6 +1738,9 @@ R_API int r_core_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 #if __UNIX__ || __CYGWIN__
 	int stdout_fd, fds[2];
 	int child;
+
+	sigset_t mask;
+	sigemptyset (&mask);
 #endif
 	int si, olen, ret = -1, pipecolor = -1;
 	char *str, *out = NULL;
@@ -1768,7 +1771,7 @@ R_API int r_core_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd) {
 	radare_cmd = (char*)r_str_trim_head (radare_cmd);
 	shell_cmd = (char*)r_str_trim_head (shell_cmd);
 
-	signal (SIGPIPE, SIG_IGN);
+	r_sys_sigaction (SIGPIPE, SIG_IGN, &mask, 0);
 	stdout_fd = dup (1);
 	if (stdout_fd != -1) {
 		pipe (fds);

--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -401,7 +401,10 @@ static void activateDieTime (RCore *core) {
 	int dt = r_config_get_i (core->config, "http.dietime");
 	if (dt > 0) {
 #if __UNIX__
-		signal (SIGALRM, dietime);
+		sigset_t mask;
+		sigemptyset (&mask);
+		sigaddset (&mask, SIGALRM);
+		r_sys_sigaction (SIGALRM, dietime, &mask, 0);
 		alarm (dt);
 #else
 		eprintf ("http.dietime only works on *nix systems\n");

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -38,6 +38,7 @@ R_API void r_sys_perror_str(const char *fun);
 #define r_sys_mkdir_failed() (GetLastError () != ERROR_ALREADY_EXISTS)
 #else
 #define r_sys_mkdir_failed() (errno != EEXIST)
+R_API int r_sys_sigaction(int sig, void(*handler) (int), sigset_t *mask, int flags);
 #endif
 R_API const char *r_sys_prefix(const char *pfx);
 R_API bool r_sys_mkdir(const char *dir);

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -293,7 +293,10 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		free (argv);
 #if (!defined(__WINDOWS__)) || defined(__CYGWIN__)
 	} else if (!strncmp (cmd, "alarm ", 6)) {
-		signal (SIGALRM, got_alarm);
+		sigset_t mask;
+		sigemptyset (&mask);
+		sigaddset (&mask, SIGALRM);
+		r_sys_sigaction (SIGALRM, got_alarm, &mask, 0);
 		// TODO: use setitimer
 		alarm (atoi (cmd + 6));
 #else

--- a/libr/io/p/io_tcp.c
+++ b/libr/io/p/io_tcp.c
@@ -74,10 +74,14 @@ static inline int getmalfd (RIOMalloc *mal) {
 }
 
 static ut8 *tcpme (const char *pathname, int *code, int *len) {
+#if __UNIX__
+	sigset_t mask;
+	sigemptyset (&mask);
+#endif
 	pathname += 6;
 	*code = 404;
 #if __UNIX__
-	signal (SIGINT, 0);
+	r_sys_sigaction (SIGINT, SIG_DFL, &mask, 0);
 #endif
 	if (*pathname == ':') {
 		/* listen and wait for connection */

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -376,12 +376,7 @@ R_API int r_sys_crash_handler(const char *cmd) {
 
 	free (crash_handler_cmd);
 	crash_handler_cmd = strdup (cmd);
-	sigemptyset (&mask);
-	sigaddset (&mask, SIGINT);
-	sigaddset (&mask, SIGSEGV);
-	sigaddset (&mask, SIGBUS);
-	sigaddset (&mask, SIGQUIT);
-	sigaddset (&mask, SIGHUP);
+	sigfillset (&mask);
 
 	r_sys_sigaction (SIGINT, signal_handler, &mask, 0);
 	r_sys_sigaction (SIGSEGV, signal_handler, &mask, 0);


### PR DESCRIPTION
The signal function is underspecified and deprecated in favor of
sigaction, make the replacement.

Also added <signal.h> includes wheremissing, and fixed a "__UNIX_" to
"__UNIX__".