### PR TITLE
Remove all traces of prefix override

### DIFF
--- a/sys/build.sh
+++ b/sys/build.sh
@@ -59,7 +59,6 @@ A=$(dirname "$PWD/$0")
 cd "$A" && cd .. || exit 1
 
 if [ "`uname`" = Darwin ]; then
-	DEFAULT_PREFIX=/usr/local
 	# purge previous installations on other common paths
 	if [ -f /usr/bin/r2 ]; then
 		type sudo || NOSUDO=1
@@ -67,16 +66,11 @@ if [ "`uname`" = Darwin ]; then
 		[ -n "${NOSUDO}" ] && SUDO=
 		# purge first
 		echo "Purging r2 installation..."
-		./configure --prefix=/usr > /dev/null
+		./configure > /dev/null
 		${SUDO} ${MAKE} uninstall > /dev/null
 	fi
-else
-	DEFAULT_PREFIX=/usr
-	[ -n "${PREFIX}" -a "${PREFIX}" != /usr ] && \
-		CFGARG="${CFGARG} --with-rpath"
 fi
 
-[ -z "${PREFIX}" ] && PREFIX="${DEFAULT_PREFIX}"
 
 case "$1" in
 -h)
@@ -91,7 +85,6 @@ case "$1" in
 	CFGARG="${CFGARG} $*"
 	;;
 *)
-	PREFIX="$1"
 	;;
 esac
 
@@ -140,7 +133,7 @@ if [ -z "${KEEP_PLUGINS_CFG}" ]; then
 fi
 unset DEPS
 pwd
-./configure ${CFGARG} --prefix="${PREFIX}" || exit 1
+./configure ${CFGARG} || exit 1
 ${MAKE} -s -j${MAKE_JOBS} MAKE_JOBS=${MAKE_JOBS} || exit 1
 if [ "`uname`" = Darwin ]; then
 	./sys/macos-cert.sh


### PR DESCRIPTION
This removes all traces of the improperly set `PREFIX`. If `PREFIX` is set wrong for your platform or distro, file a bug and we'll fix it in the `./configure` script. However the default *should* be correct in all cases, as that's the explicit goal of autotools and how **EVERY** GNU utility works. This can actually be set in your distro too, so if for some reason your whole distro wants its users to install somewhere other than `/usr/local` they can simply [update the copy of `general.m4` with a different `ac_default_prefix`](https://github.com/autotools-mirror/autoconf/blob/487d6aaaa4fe45001d30c439ea6240fc74f1b5d7/lib/autoconf/general.m4#L405)

Either way, [randomly guessing and asserting that Radare install into `/usr/bin` is just wrong](https://github.com/radare/radare2/issues/9240#issuecomment-404976781). Moreover, if the distro installs to `/usr/bin` and manages those files (as most do) Radare installing there (via `build.sh`) can actually break the system entirely, as in the case of Ubuntu and Debian. Almost as bad, this also leaves the distro free to fuck up radare with it's own copy or with files named poorly that conflict with radare's own poorly named files.

* When the user installs utilities for the system, they should be installed in `/usr/local/bin`.
* When the system installs utilities for the system, they should be installed in `/usr/bin`

This brings `/sys/build.sh` which `install.sh` calls, in alignment with the result of `./configure; make; make install;`