### PR TITLE
WIP: Add callbacks API in RFlag, for future optimizations ##flags

### DIFF
--- a/libr/bin/Makefile
+++ b/libr/bin/Makefile
@@ -21,7 +21,7 @@ include $(LIBR)/magic/deps.mk
 
 STATIC_OBJS=$(addprefix $(LTOP)/bin/p/, $(STATIC_OBJ))
 OBJS=bin.o dbginfo.o bin_ldr.o bin_write.o demangle.o
-OBJS+=dwarf.o filter.o bfile.o obj.o blang.o
+OBJS+=dwarf.o filter.o bfile.o obj.o blang.o bflag.o
 OBJS+=mangling/cxx/cp-demangle.o ${STATIC_OBJS}
 OBJS+=mangling/demangler.o
 OBJS+=mangling/microsoft_demangle.o

--- a/libr/bin/bflag.c
+++ b/libr/bin/bflag.c
@@ -1,0 +1,34 @@
+/* radare2 - LGPL - Copyright 2018 - pancake, nibble, dso */
+
+
+#include <r_bin.h>
+
+// primitives for r_flag_set_callbacks()
+
+R_API const char *r_bin_flag_i(RBin *bin, ut64 addr) {
+	r_return_val_if_fail (bin, NULL);
+	if (bin->cur && bin->cur->o) {
+		RListIter *iter;
+		RBinSymbol *s;
+		r_list_foreach (bin->cur->o->symbols, iter, s) {
+			if (s->vaddr == addr) {
+				return s->name;
+			}
+		}
+	}
+	return NULL;
+}
+
+R_API ut64 r_bin_flag(RBin *bin, const char *name) {
+	// TODO: we should iterate over all the BinFiles
+	if (!strncmp (name, "sym.", 4)) {
+		RListIter *iter;
+		RBinSymbol *s;
+		r_list_foreach (bin->cur->o->symbols, iter, s) {
+			if (!strcmp (name + 4, s->name)) {
+				return s->vaddr;
+			}
+		}
+	}
+	return UT64_MAX;
+}

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -7,6 +7,7 @@ files = [
   'blang.c',
   'filter.c',
   'bfile.c',
+  'bflag.c',
   'obj.c',
   'p/bin_any.c',
   'p/bin_art.c',

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -138,9 +138,11 @@ static RList *flag_cbi(RCore *core, ut64 addr) {
 R_API bool r_core_bin_set_env(RCore *r, RBinFile *binfile) {
 	RBinObject *binobj = binfile ? binfile->o: NULL;
 	RBinInfo *info = binobj ? binobj->info: NULL;
-	if (!r_config_get_i (r->config, "bin.flags")) {
+	bool bin_flags = r_config_get_i (r->config, "bin.flags");
+	ut64 mask = R_CORE_BIN_ACC_ALL;
+	if (!bin_flags) {
 		r_flag_set_callbacks (r->flags, flag_cb, flag_cbi, r);
-		return 0;
+		mask = R_CORE_BIN_ACC_INFO | R_CORE_BIN_ACC_MAIN | R_CORE_BIN_ACC_SECTIONS | R_CORE_BIN_ACC_SEGMENTS | R_CORE_BIN_ACC_LIBS | R_CORE_BIN_ACC_ENTRIES;
 	}
 	if (info) {
 		int va = info->has_va;
@@ -158,7 +160,7 @@ R_API bool r_core_bin_set_env(RCore *r, RBinFile *binfile) {
 			r_config_set (r->config, "anal.cpu", arch);
 		}
 		r_asm_use (r->assembler, arch);
-		r_core_bin_info (r, R_CORE_BIN_ACC_ALL, R_MODE_SET, va, NULL, NULL);
+		r_core_bin_info (r, mask, R_MODE_SET, va, NULL, NULL);
 		r_core_bin_set_cur (r, binfile);
 		return true;
 	}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2634,6 +2634,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETOPTIONS (n, "latin1", "utf8", "utf16le", "utf32le", "guess", NULL);
 
 	/* bin */
+	SETPREF("bin.flags", "true", "Load bin info as flags");
 	SETCB ("bin.usextr", "true", &cb_usextr, "Use extract plugins when loading files");
 	SETCB ("bin.useldr", "true", &cb_useldr, "Use loader plugins when loading files");
 	SETCB ("bin.strpurge", "", &cb_strpurge, "Purge strings (e bin.strpurge=? provides more detail)");

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2331,6 +2331,7 @@ R_API bool r_core_init(RCore *core) {
 	r_io_undo_enable (core->io, 1, 0); // TODO: configurable via eval
 	core->fs = r_fs_new ();
 	core->flags = r_flag_new ();
+	r_flag_set_callbacks (core->flags, NULL, NULL, NULL);
 	core->flags->cb_printf = r_cons_printf;
 	core->graph = r_agraph_new (r_cons_canvas_new (1, 1));
 	core->graph->need_reload_nodes = false;

--- a/libr/core/graph.c
+++ b/libr/core/graph.c
@@ -300,7 +300,6 @@ static void mini_RANode_print(const RAGraph *g, const RANode *n, int cur, bool d
 			cur? "[ %s ]": "  %s  ", n->title);
 		W (title);
 	}
-	return;
 }
 
 static void tiny_RANode_print(const RAGraph *g, const RANode *n, int cur) {

--- a/libr/core/hack.c
+++ b/libr/core/hack.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2011-2012 - pancake */
+/* radare - LGPL - Copyright 2011-2018 - pancake */
 
 #include <r_core.h>
 

--- a/libr/flag/Makefile
+++ b/libr/flag/Makefile
@@ -2,6 +2,6 @@ include ../config.mk
 
 NAME=r_flag
 DEPS=r_util
-OBJS=flag.o sort.o spaces.o zones.o tags.o
+OBJS=flag.o sort.o spaces.o zones.o tags.o item.o
 
 include ../rules.mk

--- a/libr/flag/item.c
+++ b/libr/flag/item.c
@@ -2,8 +2,6 @@
 
 #include <r_flag.h>
 
-#define ISNULLSTR(x) (!(x) || !*(x))
-
 R_API RFlagItem *r_flag_item_new (void) {
 	return R_NEW0 (RFlagItem);
 }
@@ -45,14 +43,14 @@ R_API void r_flag_item_free(RFlagItem *item) {
 R_API void r_flag_item_set_alias(RFlagItem *item, const char *alias) {
 	r_return_if_fail (item);
 	free (item->alias);
-	item->alias = ISNULLSTR (alias)? NULL: strdup (alias);
+	item->alias = R_STR_ISEMPTY (alias)? NULL: strdup (alias);
 }
 
 /* add/replace/remove the comment of a flag item */
 R_API void r_flag_item_set_comment(RFlagItem *item, const char *comment) {
 	r_return_if_fail (item);
 	free (item->comment);
-	item->comment = ISNULLSTR (comment) ? NULL : strdup (comment);
+	item->comment = R_STR_ISEMPTY (comment) ? NULL : strdup (comment);
 }
 
 /* add/replace/remove the realname of a flag item */
@@ -61,5 +59,5 @@ R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname) {
 	if (item->name != item->realname) {
 		free (item->realname);
 	}
-	item->realname = ISNULLSTR (realname) ? NULL : strdup (realname);
+	item->realname = R_STR_ISEMPTY (realname) ? NULL : strdup (realname);
 }

--- a/libr/flag/item.c
+++ b/libr/flag/item.c
@@ -1,0 +1,65 @@
+/* radare - LGPL - Copyright 2007-2018 - pancake */
+
+#include <r_flag.h>
+
+#define ISNULLSTR(x) (!(x) || !*(x))
+
+R_API RFlagItem *r_flag_item_new (void) {
+	return R_NEW0 (RFlagItem);
+}
+
+R_API RFlagItem *r_flag_item_clone(RFlagItem *item) {
+	r_return_val_if_fail (item, NULL);
+
+	RFlagItem *n = R_NEW0 (RFlagItem);
+	if (!n) {
+		return NULL;
+	}
+	n->color = item->color ? strdup (item->color) : NULL;
+	n->comment = item->comment ? strdup (item->comment) : NULL;
+	n->alias = item->alias ? strdup (item->alias) : NULL;
+	n->name = item->name ? strdup (item->name) : NULL;
+	n->realname = item->realname ? strdup (item->realname) : NULL;
+	n->offset = item->offset;
+	n->size = item->size;
+	n->space = item->space;
+	return n;
+}
+
+R_API void r_flag_item_free(RFlagItem *item) {
+	if (!item) {
+		return;
+	}
+	free (item->color);
+	free (item->comment);
+	free (item->alias);
+	/* release only one of the two pointers if they are the same */
+	if (item->name != item->realname) {
+		free (item->name);
+	}
+	free (item->realname);
+	free (item);
+}
+
+/* add/replace/remove the alias of a flag item */
+R_API void r_flag_item_set_alias(RFlagItem *item, const char *alias) {
+	r_return_if_fail (item);
+	free (item->alias);
+	item->alias = ISNULLSTR (alias)? NULL: strdup (alias);
+}
+
+/* add/replace/remove the comment of a flag item */
+R_API void r_flag_item_set_comment(RFlagItem *item, const char *comment) {
+	r_return_if_fail (item);
+	free (item->comment);
+	item->comment = ISNULLSTR (comment) ? NULL : strdup (comment);
+}
+
+/* add/replace/remove the realname of a flag item */
+R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname) {
+	r_return_if_fail (item);
+	if (item->name != item->realname) {
+		free (item->realname);
+	}
+	item->realname = ISNULLSTR (realname) ? NULL : strdup (realname);
+}

--- a/libr/flag/meson.build
+++ b/libr/flag/meson.build
@@ -2,6 +2,7 @@ files = [
   'flag.c',
   'sort.c',
   'tags.c',
+  'item.c',
   'spaces.c',
   'zones.c'
 ]

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -611,6 +611,8 @@ R_API RBinSymbol *r_bin_symbol_clone(RBinSymbol *o);
 typedef void (*RBinSymbolCallback)(RBinObject *obj, RBinSymbol *symbol);
 
 R_API void r_bin_options_init(RBinOptions *opt, int fd, ut64 baseaddr, ut64 loadaddr, int rawstr);
+R_API const char *r_bin_flag_i(RBin *bf, ut64 addr);
+R_API ut64 r_bin_flag(RBin *bf, const char *name);
 
 R_API RBin *r_bin_new(void);
 R_API void *r_bin_free(RBin *bin);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -544,7 +544,7 @@ R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt);
 R_API int r_core_print_fcn_disasm(RPrint *p, RCore *core, ut64 addr, int l, int invbreak, int cbytes);
 R_API int r_core_file_bin_raise (RCore *core, ut32 binfile_idx);
 //R_API int r_core_bin_bind(RCore *core, RBinFile *bf);
-R_API int r_core_bin_set_env (RCore *r, RBinFile *binfile);
+R_API bool r_core_bin_set_env (RCore *r, RBinFile *binfile);
 R_API int r_core_bin_set_by_fd (RCore *core, ut64 bin_fd);
 R_API int r_core_bin_set_by_name (RCore *core, const char *name);
 R_API int r_core_bin_reload(RCore *core, const char *file, ut64 baseaddr);

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -30,6 +30,7 @@ typedef struct r_flag_zone_item_t {
 #endif
 } RFlagZoneItem;
 
+
 /* flag.c */
 
 typedef struct r_flags_at_offset_t {
@@ -48,6 +49,14 @@ typedef struct r_flag_item_t {
 	char *alias;    /* used to define a flag based on a math expression (e.g. foo + 3) */
 } RFlagItem;
 
+// forward declaration magic
+struct r_flag_t;
+
+typedef RFlagItem *(*RFlagCallback)(struct r_flag_t *f, const char *name);
+typedef RList *(*RFlagCallbackI)(struct r_flag_t *f, ut64 addr);
+
+R_API void r_flag_set_callbacks(struct r_flag_t *f, RFlagCallback cb, RFlagCallbackI cbi, void *user);
+
 typedef struct r_flag_t {
 	st64 base;         /* base address for all flag items */
 	int space_idx;     /* index of the selected space in spaces array */
@@ -59,6 +68,9 @@ typedef struct r_flag_t {
 	RSkipList *by_off; /* flags sorted by offset, value=RFlagsAtOffset */
 	SdbHt *ht_name; /* hashmap key=item name, value=RList of items */
 	RList *flags;   /* list of RFlagItem contained in the flag */
+	RFlagCallback callback;
+	RFlagCallbackI callback_i;
+	void *user;
 	RList *spacestack;
 	PrintfCallback cb_printf;
 #if R_FLAG_ZONE_USE_SDB
@@ -90,6 +102,7 @@ typedef struct r_flag_bind_t {
 	RFlagPopSpace pop_fs;
 } RFlagBind;
 
+
 #define r_flag_bind_init(x) memset(&x,0,sizeof(x))
 R_API void r_flag_bind(RFlag *io, RFlagBind *bnd);
 
@@ -115,6 +128,7 @@ R_API void r_flag_item_set_alias(RFlagItem *item, const char *alias);
 R_API void r_flag_item_free (RFlagItem *item);
 R_API void r_flag_item_set_comment(RFlagItem *item, const char *comment);
 R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname);
+R_API RFlagItem *r_flag_item_new (void);
 R_API RFlagItem *r_flag_item_clone(RFlagItem *item);
 R_API int r_flag_unset_glob(RFlag *f, const char *name);
 R_API int r_flag_rename(RFlag *f, RFlagItem *item, const char *name);


### PR DESCRIPTION
The idea behind this new feature of RFlag is to allow RCore to attach a callback that uses RBin to resolve the name of an offset and the offset for a name). This way we can save a lot of time when loading the binary because we wont need to create any flag.

To do this we have to switch from RList to another data structure (or add companion hashtables) to allow such queries by filtering with strncmp (flagname, "sym.imp.", 8); ...