### PR TITLE
Get cursor position only if screen_bounds == 1

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -716,7 +716,9 @@ R_API void r_print_hexii(RPrint *rp, ut64 addr, const ut8 *buf, int len, int ste
 R_API void r_print_set_screenbounds(RPrint *p, ut64 addr) {
 	int r, rc;
 
-	if (!p || !p->screen_bounds) {
+	r_return_if_fail (p);
+
+	if (!p->screen_bounds) {
 		return;
 	}
 	if (!p->consbind.get_size) {
@@ -726,11 +728,13 @@ R_API void r_print_set_screenbounds(RPrint *p, ut64 addr) {
 		return;
 	}
 
-	(void) p->consbind.get_size (&r);
-	(void) p->consbind.get_cursor (&rc);
+	if (p->screen_bounds == 1) {
+		(void)p->consbind.get_size (&r);
+		(void)p->consbind.get_cursor (&rc);
 
-	if (rc > r - 1 && p->screen_bounds == 1) {
-		p->screen_bounds = addr;
+		if (rc > r - 1) {
+			p->screen_bounds = addr;
+		}
 	}
 }
 


### PR DESCRIPTION
This fix slightly improves the situation wrt #11815 . The cursor is now get only when scree_bounds == 1.

I also tried to stop the `pd` loop when core->print->screen_bounds has been set, but for some weird reasons it doesn't work as I would like it to. No time to debug that approach further right now. This fix is anyway good to have and makes things run a bit smoother on my machine.