### PR TITLE
Move #endif (HAVE_PTRACE) after functions which use it

### DIFF
--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -672,8 +672,6 @@ R_API pid_t r_io_ptrace_fork(RIO *io, void (*child_callback)(void *), void *chil
 	return r;
 #endif
 }
-#endif
-
 
 R_API void *r_io_ptrace_func(RIO *io, void *(*func)(void *), void *user) {
 #if USE_PTRACE_WRAP
@@ -684,6 +682,7 @@ R_API void *r_io_ptrace_func(RIO *io, void *(*func)(void *), void *user) {
 #endif
 	return func (user);
 }
+#endif
 
 
 //remove all descs and maps


### PR DESCRIPTION
When built with --disable-debugger, HAVE_PTRACE is not defined. The
function r_io_ptrace_func() is outside of an "#if HAVE_PTRACE" block and
uses ptrace_* functions. This causes a build failure because the
functions are only defined under HAVE_PTRACE.

Move the adjacent "#endif" for a HAVE_PTRACE guard to include this
function too.

This bug was introduced in 7c0687b8fb.