### PR TITLE
fix wasm iE

### DIFF
--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -208,8 +208,9 @@ static RList *symbols(RBinFile *bf) {
 		}
 
 		ptr->forwarder = r_str_const ("NONE");
-		if (!ptr->bind)
+		if (!ptr->bind) {
 			ptr->bind = r_str_const ("NONE");
+		}
 		ptr->type = r_str_const (R_BIN_TYPE_FUNC_STR);
 		ptr->size = func->len;
 		ptr->vaddr = (ut64)func->code;


### PR DESCRIPTION
```
[0x000000bb]> iE
[Exports]
Num Paddr      Vaddr      Bind     Type Size Name
010 0x00000d23 0x00000d23 GLOBAL   FUNC  229 Match
011 0x00000e0d 0x00000e0d GLOBAL   FUNC  427 writev_c

[0x000000bb]> is
[Symbols]
Num Paddr      Vaddr      Bind     Type Size Name
000 ---------- 0xffffffffffffffff   NONE   FUNC    0 imp.env.putc_js
001 0x000000bb 0x000000bb   NONE   FUNC    1 fcn.1
002 0x000000c1 0x000000c1   NONE   FUNC  278 fcn.2
003 0x000001dc 0x000001dc   NONE   FUNC  301 fcn.3
004 0x0000030e 0x0000030e   NONE   FUNC  323 fcn.4
005 0x00000456 0x00000456   NONE   FUNC  323 fcn.5
006 0x0000059e 0x0000059e   NONE   FUNC  323 fcn.6
007 0x000006e6 0x000006e6   NONE   FUNC  323 fcn.7
008 0x0000082e 0x0000082e   NONE   FUNC  335 fcn.8
009 0x00000982 0x00000982   NONE   FUNC  924 fcn.9
010 0x00000d23 0x00000d23 GLOBAL   FUNC  229 Match
011 0x00000e0d 0x00000e0d GLOBAL   FUNC  427 writev_c
```