### PR TITLE
[WIP] Fix issue with cmp & test in x86 ESIL

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -921,7 +921,7 @@ static bool esil_interrupt(RAnalEsil *esil) {
 }
 
 // This function also sets internal vars which is used in flag calculations.
-static bool esil_cmp(RAnalEsil *esil) {
+static bool esil_cmp(RAnalEsil *esil, int bits) {
 	ut64 num, num2;
 	bool ret = false;
 	char *dst = r_anal_esil_pop (esil);
@@ -937,13 +937,29 @@ static bool esil_cmp(RAnalEsil *esil) {
 				esil->lastsz = esil_internal_sizeof_reg (esil, src);
 			} else {
 				// default size is set to 64 as internally operands are ut64
-				esil->lastsz = 64;
+				esil->lastsz = bits;
 			}
 		}
 	}
 	free (dst);
 	free (src);
 	return ret;
+}
+
+static bool esil_cmp8(RAnalEsil *esil) {
+    return esil_cmp(esil, 64);
+}
+
+static bool esil_cmp4(RAnalEsil *esil) {
+    return esil_cmp(esil, 32);
+}
+
+static bool esil_cmp2(RAnalEsil *esil) {
+    return esil_cmp(esil, 16);
+}
+
+static bool esil_cmp1(RAnalEsil *esil) {
+    return esil_cmp(esil, 8);
 }
 
 #if 0
@@ -3102,7 +3118,10 @@ static void r_anal_esil_setup_ops(RAnalEsil *esil) {
 	OP ("$js", esil_js, 1, 0, OT_UNK);
 	OP ("$r", esil_rs, 1, 0, OT_UNK);
 	OP ("$$", esil_address, 1, 0, OT_UNK);
-	OP ("==", esil_cmp, 0, 2, OT_MATH);
+	OP ("==", esil_cmp8, 0, 2, OT_MATH);
+	OP ("==4", esil_cmp4, 0, 2, OT_MATH);
+	OP ("==2", esil_cmp2, 0, 2, OT_MATH);
+	OP ("==1", esil_cmp2, 0, 2, OT_MATH);
 	OP ("<", esil_smaller, 1, 2, OT_MATH);
 	OP (">", esil_bigger, 1, 2, OT_MATH);
 	OP ("<=", esil_smaller_equal, 1, 2, OT_MATH);

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -908,17 +908,35 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 	case X86_INS_CMPSB:
 	case X86_INS_CMPSS:
 	case X86_INS_TEST:
+    {
+        const char *opname;
+        switch (INSOP(0).size) {
+            case 1:
+                opname="==1";
+                break;
+            case 2:
+                opname="==2";
+                break;
+            case 4:
+                opname="==4";
+                break;
+            case 8:
+            default:
+                opname="==";
+                break;
+        }
 		if (insn->id == X86_INS_TEST) {
 			src = getarg (&gop, 1, 0, NULL, SRC_AR);
 			dst = getarg (&gop, 0, 0, NULL, DST_AR);
-			esilprintf (op, "0,%s,%s,&,==,$z,zf,:=,$p,pf,:=,$s,sf,:=,0,cf,:=,0,of,:=",
-				src, dst);
+			esilprintf (op, "0,%s,%s,&,%s,$z,zf,:=,$p,pf,:=,$s,sf,:=,0,cf,:=,0,of,:=",
+				src, dst, opname);
 		} else {
 			src = getarg (&gop, 1, 0, NULL, SRC_AR);
 			dst = getarg (&gop, 0, 0, NULL, DST_AR);
-			esilprintf (op,  "%s,%s,==,$z,zf,:=,%d,$b,cf,:=,$p,pf,:=,$s,sf,:=,$o,of,:=",
-				src, dst, (INSOP(0).size*8));
+			esilprintf (op,  "%s,%s,%s,$z,zf,:=,%d,$b,cf,:=,$p,pf,:=,$s,sf,:=,$o,of,:=",
+				src, dst, opname, (INSOP(0).size*8));
 		}
+    }
 		break;
 	case X86_INS_LEA:
 		{


### PR DESCRIPTION
This PR fixes #14249 by adding new operators to ESIl (`==4`, `==2` and `==1`), which might be not best solution. Maybe radare2 community can provide some feedback regarding adding new ESIL operators vs adding some bitness information to data.

Please don't merge this PR at this moment, cause at least ESIL docs should be extended with new operators.