### PR TITLE
Fix #14919: truncate long function names in Vv

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -580,6 +580,7 @@ R_API RCons *r_cons_new() {
 #endif
 	I.pager = NULL; /* no pager by default */
 	I.mouse = 0;
+	I.show_vals = false;
 	r_cons_reset ();
 	r_cons_rgb_init ();
 

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2725,13 +2725,13 @@ static ut64 var_functions_show(RCore *core, int idx, int show) {
 			}
 			if (show) {
 				if (color) {
-					r_cons_printf ("%c%c %s0x%08"PFMT64x"" Color_RESET" %4d %s%s"Color_RESET"\n",
+					r_cons_printf ("%c%c %s0x%08"PFMT64x"" Color_RESET" %4d %s%.40s"Color_RESET"\n",
 							(seek == fcn->addr)?'>':' ',
 							(idx==i)?'*':' ',
 							color_addr, fcn->addr, r_anal_fcn_realsize (fcn),
 							color_fcn, fcn->name);
 				} else {
-					r_cons_printf ("%c%c 0x%08"PFMT64x" %4d %s\n",
+					r_cons_printf ("%c%c 0x%08"PFMT64x" %4d %.40s\n",
 							(seek == fcn->addr)?'>':' ',
 							(idx==i)?'*':' ',
 							fcn->addr, r_anal_fcn_realsize (fcn), fcn->name);

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -2932,7 +2932,7 @@ static ut64 r_core_visual_anal_refresh (RCore *core) {
 	RStrBuf *buf;
 	char old[1024];
 	bool color = r_config_get_i (core->config, "scr.color");
-	int cols = r_cons_get_size (NULL);
+	int h, cols = r_cons_get_size (&h);
 	old[0] = '\0';
 	addr = core->offset;
 	cols -= 50;
@@ -2989,7 +2989,19 @@ static ut64 r_core_visual_anal_refresh (RCore *core) {
 		}
 		// TODO: filter only the callrefs. but we cant grep here
 		sprintf (old, "afi @ 0x%08"PFMT64x, addr);
-		r_core_cmd0 (core, old);
+		char *output = r_core_cmd_str (core, old);
+		if (output) {
+			// 'h - 2' because we have two new lines in r_cons_printf
+			if (!show_vars) {
+				char *out = r_str_ansi_crop(output, 0, 0, cols, h - 2);
+				r_cons_printf("\n%s\n", out);
+				free(out);
+				R_FREE (output);
+			} else {
+				r_cons_printf("\n%s\n", output);
+				R_FREE (output);
+			}
+		}
 		break;
 	default:
 		// assert

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -29,8 +29,6 @@ typedef struct {
 	const char *optword;
 } RCoreVisualTypes;
 
-static bool show_vars = false;
-
 // TODO: move this helper into r_cons
 static char *prompt(const char *str, const char *txt) {
 	char cmd[1024];
@@ -2742,12 +2740,12 @@ static ut64 var_functions_show(RCore *core, int idx, int show, int cols) {
 							fcn->addr, r_anal_fcn_realsize (fcn), fcn->name);
 				}
 				if (var_functions) {
-					if (!show_vars) {
+					if (!r_cons_singleton ()->show_vals) {
 						int fun_len = r_str_ansi_len (var_functions);
 						int columns = fun_len > cols ? cols - 2 : cols;
 						tmp = r_str_ansi_crop (var_functions, 0, 0, columns, window);
 						if (r_str_ansi_len (tmp) < fun_len) {
-							r_cons_printf("%s..%s\n", tmp, Color_RESET);
+							r_cons_printf ("%s..%s\n", tmp, Color_RESET);
 							print_full_func = false;
 						}
 						r_free (tmp);
@@ -2992,13 +2990,13 @@ static ut64 r_core_visual_anal_refresh (RCore *core) {
 		char *output = r_core_cmd_str (core, old);
 		if (output) {
 			// 'h - 2' because we have two new lines in r_cons_printf
-			if (!show_vars) {
+			if (!r_cons_singleton ()->show_vals) {
 				char *out = r_str_ansi_crop(output, 0, 0, cols, h - 2);
-				r_cons_printf("\n%s\n", out);
-				free(out);
+				r_cons_printf ("\n%s\n", out);
+				free (out);
 				R_FREE (output);
 			} else {
-				r_cons_printf("\n%s\n", output);
+				r_cons_printf ("\n%s\n", output);
 				R_FREE (output);
 			}
 		}
@@ -3168,10 +3166,10 @@ R_API void r_core_visual_anal(RCore *core, const char *input) {
 		ch = r_cons_arrow_to_hjkl (ch); // get ESC+char, return 'hjkl' char
 		switch (ch) {
 		case '[':
-			show_vars = true;
+			r_cons_singleton ()->show_vals = true;
 			break;
 		case ']':
-			show_vars = false;
+			r_cons_singleton ()->show_vals = false;
 			break;
 		case '?':
 			r_cons_clear00 ();

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -522,6 +522,7 @@ typedef struct r_cons_t {
 	bool click_set;
 	int click_x;
 	int click_y;
+	bool show_vals;		// show which section in Vv
 	// TODO: move into instance? + avoid unnecessary copies
 } RCons;
 


### PR DESCRIPTION
After change:
Actual function name: sym.android_app_Activity.onCreateOptionsMenu (as seen as fcn in disasm)

<img width="1283" alt="Screen Shot 2019-09-09 at 11 16 33 PM" src="https://user-images.githubusercontent.com/20895544/64553915-eb037a80-d357-11e9-998c-3c6f90fbc6c5.png">
