### PR TITLE
Debian package scripts fixes

### DIFF
--- a/sys/debian.sh
+++ b/sys/debian.sh
@@ -5,6 +5,10 @@ if [ -z "${ARCH}" ]; then
   ARCH=`uname -m`
 fi
 
+if [ "${ARCH}" = "x86_64" ]; then
+  ARCH=amd64
+fi
+
 echo "[debian] preparing radare2 package..."
 PKGDIR=sys/debian/radare2/root
 DEVDIR=sys/debian/radare2-dev/root
@@ -15,9 +19,15 @@ mv "${PKGDIR}/usr/include/"* "${DEVDIR}/usr/include"
 mkdir -p "${DEVDIR}/usr/lib"
 mv "${PKGDIR}/usr/lib/"lib*a "${DEVDIR}/usr/lib"
 mv "${PKGDIR}/usr/lib/pkgconfig" "${DEVDIR}/usr/lib"
+
 for a in ${PKGDIR}/usr/bin/* ; do
   echo "[debian] strip $a"
-  strip -s "$a" 2> /dev/null || strip "$a" 2>/dev/null
+  strip --strip-all "$a" 2> /dev/null || true
+done
+
+for a in ${PKGDIR}/usr/lib/libr*.so.* ; do
+  echo "[debian] strip $a"
+  strip --strip-unneeded "$a" 2> /dev/null || true
 done
 
 echo "[debian] building radare2 package..."

--- a/sys/debian/arch.mk
+++ b/sys/debian/arch.mk
@@ -1,4 +1,0 @@
-ARCH=$(shell uname -m)
-ifeq ($(ARCH),x86_64)
-ARCH=amd64
-endif

--- a/sys/debian/deb_hand.mak
+++ b/sys/debian/deb_hand.mak
@@ -79,7 +79,7 @@ endif
 #endif
 #       Make md5sums.
 	cd ${PACKAGE_DIR}/data && find . -type f -exec ${MD5SUM} {} \; \
-		| sed -e 's| \./||' \
+		| sed -e 's| \./| |' \
 		> $@/md5sums
 
 ${PACKAGE_DIR}/debian-binary:
@@ -93,16 +93,16 @@ ${PACKAGE_DIR}/build: ${PACKAGE_DIR}/debian-binary ${PACKAGE_DIR}/control \
 	rm -rf $@
 	mkdir $@
 	cp ${PACKAGE_DIR}/debian-binary $@/
-	cd ${PACKAGE_DIR}/control && tar czvf $@/control.tar.gz *
+	cd ${PACKAGE_DIR}/control && tar cJvf $@/control.tar.xz *
 	cd ${PACKAGE_DIR}/data && \
 		COPY_EXTENDED_ATTRIBUTES_DISABLE=true \
 		COPYFILE_DISABLE=true \
-		tar cpzvf $@/data.tar.gz ./*
+		tar cpJvf $@/data.tar.xz ./*
 
 # Convert GNU ar to BSD ar that debian requires.
 # Note: Order of files within ar archive is important!
 ${PACKAGE_DIR}/${PACKAGE}_${VERSION}_${ARCH}.deb: ${PACKAGE_DIR}/build
-	ar -rc $@ $</debian-binary $</control.tar.gz $</data.tar.gz
+	ar -rc $@ $</debian-binary $</control.tar.xz $</data.tar.xz
 	#sed -e 's|^\([^/]\+\)/ \(.*\)|\1  \2|g' $@tmp > $@fail
 	#rm -f $@tmp
 	#mv $@fail $@

--- a/sys/debian/radare2-dev/CONFIG
+++ b/sys/debian/radare2-dev/CONFIG
@@ -4,4 +4,3 @@ PRIORITY=optional
 MAINTAINER=pancake <pancake@nopcode.org>
 
 include ../../../config-user.mk
-include ../arch.mk

--- a/sys/debian/radare2/CONFIG
+++ b/sys/debian/radare2/CONFIG
@@ -4,4 +4,3 @@ PRIORITY=optional
 MAINTAINER=pancake <pancake@nopcode.org>
 
 include ../../../config-user.mk
-include ../arch.mk


### PR DESCRIPTION
Hi guys. My ex wife (ohcanada) begged me to ask you to consider this pull request that addresses issues with the debian package scripts in sys/

This is tested by myself also and works fine thus far.

The first issue is the md5sums file in the debian control dir, which is corrected to have 2 spaces between sum and filename. The net result is that the dpkg -V radare2 (for verify) completes successfully.

Also fixed is stripping the executables and libraries, and finally using xz instead of gz in the tar process, which is part of the manual build. The net result of that is a huge reduction in package and installed sizes.