### PR TITLE
Integrate types field in zignature operations ##signatures

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3189,6 +3189,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("zign.offset", "true", "Use original offset for matching");
 	SETPREF ("zign.refs", "true", "Use references for matching");
 	SETPREF ("zign.hash", "true", "Use Hash for matching");
+	SETPREF ("zign.types", "true", "Use types for matching");
 	SETPREF ("zign.autoload", "false", "Autoload all zignatures located in " R_JOIN_2_PATHS ("~", R2_HOME_ZIGNS));
 	SETPREF ("zign.diff.bthresh", "1.0", "Threshold for diffing zign bytes [0, 1] (see zc?)");
 	SETPREF ("zign.diff.gthresh", "1.0", "Threshold for diffing zign graphs [0, 1] (see zc?)");

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -117,6 +117,8 @@ R_API bool r_sign_match_graph(RAnal *a, RAnalFunction *fcn, int mincc, RSignGrap
 R_API bool r_sign_match_addr(RAnal *a, RAnalFunction *fcn, RSignOffsetMatchCallback cb, void *user);
 R_API bool r_sign_match_hash(RAnal *a, RAnalFunction *fcn, RSignHashMatchCallback cb, void *user);
 R_API bool r_sign_match_refs(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
+R_API bool r_sign_match_vars(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
+R_API bool r_sign_match_types(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
 
 R_API bool r_sign_load(RAnal *a, const char *file);
 R_API bool r_sign_load_gz(RAnal *a, const char *filename);


### PR DESCRIPTION
Integrated types in the most significant 'z' commands.

By the way, is the "vars" field implemented into the commands? 
When I  `git grep "r_sign_match_vars"`, can only see the definition and the implementation, but not even a single use for this fcn.