### PR TITLE
Add R_INVALID_SOCKET macro

### DIFF
--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -44,6 +44,13 @@ R_LIB_VERSION_HEADER (r_socket);
 #define SD_SEND 1
 #define SD_BOTH 2
 #endif
+
+#if _MSC_VER
+#define R_INVALID_SOCKET INVALID_SOCKET
+#else
+#define R_INVALID_SOCKET -1
+#endif
+
 typedef struct {
 	int child;
 #if __WINDOWS__

--- a/libr/socket/proc.c
+++ b/libr/socket/proc.c
@@ -115,7 +115,7 @@ R_API void r_socket_proc_printf (RSocketProc *sp, const char *fmt, ...) {
 	va_list ap;
 	s.is_ssl = false;
 	s.fd = sp->fd0[1];
-	if (s.fd >= 0) {
+	if (s.fd != R_INVALID_SOCKET) {
 		va_start (ap, fmt);
 		vsnprintf (buf, BUFFER_SIZE, fmt, ap);
 		r_socket_write (&s, buf, strlen(buf));


### PR DESCRIPTION
On Windows SOCKET is unsigned int so compiler optimize some checks out.