### PR TITLE
Check return of r_anal_cc_func

### DIFF
--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -232,6 +232,9 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 	}
 	const char *sp = r_reg_get_name (core->anal->reg, R_REG_NAME_SP);
 	int nargs = r_type_func_args_count (TDB, key);
+	if (!r_anal_cc_func (core->anal, key)){
+		return NULL;
+	}
 	char *cc = strdup (r_anal_cc_func (core->anal, key));
 	const char *src = r_anal_cc_arg (core->anal, cc, 0); // src of first argument
 	if (!cc) {


### PR DESCRIPTION
Otherwise Vvjjjjj crashes with strdup null deref.

Fixes #15093 