### PR TITLE
Introduction of hash comparison api #mem

### DIFF
--- a/libr/include/r_util/r_mem.h
+++ b/libr/include/r_util/r_mem.h
@@ -43,6 +43,7 @@ R_API void r_mem_reverse(ut8 *b, int l);
 R_API int r_mem_protect(void *ptr, int size, const char *prot);
 R_API int r_mem_set_num(ut8 *dest, int dest_size, ut64 num);
 R_API int r_mem_eq(ut8 *a, ut8 *b, int len);
+R_API int r_mem_safe_cmp(const ut8 *a, const ut8 *b, int len);
 R_API void r_mem_copybits(ut8 *dst, const ut8 *src, int bits);
 R_API void r_mem_copybits(ut8 *dst, const ut8 *src, int bits);
 R_API void r_mem_copybits_delta(ut8 *dst, int doff, const ut8 *src, int soff, int bits);

--- a/libr/main/rahash2.c
+++ b/libr/main/rahash2.c
@@ -5,6 +5,7 @@
 #include <r_io.h>
 #include <r_main.h>
 #include <r_hash.h>
+#include <r_util/r_mem.h>
 #include <r_util/r_print.h>
 #include <r_util.h>
 #include <r_crypto.h>
@@ -21,7 +22,7 @@ static RHashSeed s = {
 static void compare_hashes(const RHash *ctx, const ut8 *compare, int length, int *ret) {
 	if (compare) {
 		// algobit has only 1 bit set
-		if (!memcmp (ctx->digest, compare, length)) {
+		if (!r_mem_safe_cmp (ctx->digest, compare, length)) {
 			printf ("rahash2: Computed hash matches the expected one.\n");
 		} else {
 			eprintf ("rahash2: Computed hash doesn't match the expected one.\n");

--- a/libr/util/mem.c
+++ b/libr/util/mem.c
@@ -28,6 +28,19 @@ R_API int r_mem_eq(ut8 *a, ut8 *b, int len) {
 	return true;
 }
 
+R_API int r_mem_safe_cmp(const ut8 *a, const ut8 *b, int len)
+{
+	const volatile ut8* volatile ua = (const volatile ut8* volatile)a;
+	const volatile ut8* volatile ub = (const volatile ut8* volatile)b;
+	int d = 0, i = 0;
+	while (i < len) {
+		d |= ua[i] ^ ub[i];
+		i++;
+	}
+
+	return d;
+}
+
 R_API void r_mem_copyloop(ut8 *dest, const ut8 *orig, int dsize, int osize) {
 	int i = 0, j;
 	while (i < dsize) {


### PR DESCRIPTION
Unlike bcmp/memcmp, goes through the whole buffer and using
volatile pointers to discard possible compiler optimisations
making it more suitable for sensitive data comparisons.