### PR TITLE
Fix parsing of floating point instructions in x86_64 assembler

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4528,15 +4528,15 @@ static Register parseReg(RAsm *a, const char *str, size_t *pos, ut32 *type) {
 			}
 		}
 	}
-	if (length == 2 && (token[1] == 'l' || token[1] == 'h')) {
-		for (i = 0; regs8[i]; i++) {
-			if (!r_str_ncasecmp (regs8[i], token, length)) {
-				*type = (OT_GPREG & OT_REG (i)) | OT_BYTE;
-				return i;
+	if (length == 2) {
+		if (token[1] == 'l' || token[1] == 'h') {
+			for (i = 0; regs8[i]; i++) {
+				if (!r_str_ncasecmp (regs8[i], token, length)) {
+					*type = (OT_GPREG & OT_REG (i)) | OT_BYTE;
+					return i;
+				}
 			}
 		}
-	}
-	if (length == 2) {
 		for (i = 0; regs16[i]; i++) {
 			if (!r_str_ncasecmp (regs16[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_WORD;
@@ -4589,30 +4589,25 @@ static Register parseReg(RAsm *a, const char *str, size_t *pos, ut32 *type) {
 		*type = (OT_XMMREG & ~OT_REGALL);
 		*pos = 3;
 	}
-
 	// Now read number, possibly with parentheses
 	if (*type & (OT_FPUREG | OT_MMXREG | OT_XMMREG) & ~OT_REGALL) {
 		Register reg = X86R_UNDEFINED;
-
-        // pass by '(',if there is one
+		// pass by '(',if there is one
 		if (getToken (token, pos, &nextpos) == TT_SPECIAL && token[*pos] == '(') {
 			*pos = nextpos;
 		}
-
 		// read number
 		// const int maxreg = (a->bits == 64) ? 15 : 7;
 		if (getToken (token, pos, &nextpos) != TT_NUMBER) {
-            eprintf("Expected register number '%s'\n", str + *pos);
-            return X86R_UNDEFINED;
-        }
-
-        reg = getnum (a, token + *pos);
+			eprintf ("Expected register number '%s'\n", str + *pos);
+			return X86R_UNDEFINED;
+		}
+		reg = getnum (a, token + *pos);
 		// st and mm go up to 7, xmm up to 15
-        if ((reg > 15) || ((*type & (OT_FPUREG | OT_MMXREG ) & ~OT_REGALL) && reg > 7))   {
-            eprintf ("Too large register index!\n");
-            return X86R_UNDEFINED;
-        }
-
+		if ((reg > 15) || ((*type & (OT_FPUREG | OT_MMXREG ) & ~OT_REGALL) && reg > 7))   {
+			eprintf ("Too large register index!\n");
+			return X86R_UNDEFINED;
+		}
 		*pos = nextpos;
 
 		// pass by ')'
@@ -4622,7 +4617,6 @@ static Register parseReg(RAsm *a, const char *str, size_t *pos, ut32 *type) {
 		*type |= (OT_REG (reg) & ~OT_REGTYPE);
 		return reg;
 	}
-
 	return X86R_UNDEFINED;
 }
 


### PR DESCRIPTION
Added tests in https://github.com/radareorg/radare2-regressions/pull/1966
