### PR TITLE
Fix memleak in r_print_date_unix

### DIFF
--- a/libr/util/date.c
+++ b/libr/util/date.c
@@ -103,8 +103,12 @@ R_API int r_print_date_unix(RPrint *p, const ut8 *buf, int len) {
 	if (p && len >= sizeof (ut32)) {
 		t = r_read_ble32 (buf, p->big_endian);
 		if (p->datefmt[0]) {
-			t += p->datezone * (60*60); 
-			p->cb_printf ("%s\n", r_time_stamp_to_str (t));
+			t += p->datezone * (60*60);
+			char *datestr = r_time_stamp_to_str (t);
+			if (datestr) {
+				p->cb_printf ("%s\n", datestr);
+				free (datestr);
+			}
 			ret = sizeof (time_t);
 		}
 	}


### PR DESCRIPTION
Before:
```
$ valgrind rax2 -t 1234567890
==25880== Memcheck, a memory error detector
==25880== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25880== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==25880== Command: rax2 -t 1234567890
==25880== 
Sat Feb 14 00:31:30 2009
==25880== 
==25880== HEAP SUMMARY:
==25880==     in use at exit: 26 bytes in 1 blocks
==25880==   total heap usage: 19 allocs, 18 frees, 21,070 bytes allocated
==25880== 
==25880== LEAK SUMMARY:
==25880==    definitely lost: 26 bytes in 1 blocks
==25880==    indirectly lost: 0 bytes in 0 blocks
==25880==      possibly lost: 0 bytes in 0 blocks
==25880==    still reachable: 0 bytes in 0 blocks
==25880==         suppressed: 0 bytes in 0 blocks
==25880== Rerun with --leak-check=full to see details of leaked memory
==25880== 
==25880== For counts of detected and suppressed errors, rerun with: -v
==25880== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
After:
```
$ valgrind rax2 -t 1234567890  
==29706== Memcheck, a memory error detector
==29706== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==29706== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==29706== Command: rax2 -t 1234567890
==29706== 
Sat Feb 14 00:31:30 2009
==29706== 
==29706== HEAP SUMMARY:
==29706==     in use at exit: 0 bytes in 0 blocks
==29706==   total heap usage: 19 allocs, 19 frees, 21,070 bytes allocated
==29706== 
==29706== All heap blocks were freed -- no leaks are possible
==29706== 
==29706== For counts of detected and suppressed errors, rerun with: -v
==29706== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
