### PR TITLE
Add possibility to specify time zone with rax2 -t

### DIFF
--- a/libr/main/rax2.c
+++ b/libr/main/rax2.c
@@ -355,10 +355,20 @@ dotherax:
 		printf ("%s\n", buf);
 		return true;
 	} else if (flags & (1 << 11)) { // -t
-		ut32 n = r_num_math (num, str);
+		RList *split = r_str_split_list (str, "GMT", 0);
+		char *ts = r_list_head (split)->data;
+		char *gmt = NULL;
+		if (r_list_length (split) >= 2 && strlen (r_list_head (split)->n->data) > 2) {
+			gmt = r_list_head (split)->n->data + 2;
+		}
+		ut32 n = r_num_math (num, ts);
 		RPrint *p = r_print_new ();
+		if (gmt) {
+			p->datezone = r_num_math (num, gmt);
+		}
 		r_print_date_unix (p, (const ut8 *) &n, sizeof (ut32));
 		r_print_free (p);
+		r_list_free (split);
 		return true;
 	} else if (flags & (1 << 12)) { // -E
 		const int len = strlen (str);


### PR DESCRIPTION
The following test kept failing on my machine over and over because of timezone issues. 

```
[XX] db/tools/rax2 rax2 -t 1234567890  166
$ r2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Q -i /tmp/tmp-10988viBOBuJrS7XP -
!rax2 -t 1234567890 | cut -d " " -f 1,2

-Fri Feb
+Sat Feb

EXPECT=<<RUN
Sat Feb
```
This was annoying me for quite some time now. This PR adds the possibility to specify the timezone with the timestamp. I thought this might be also useful in other situations. Examples:
```
$ rax2 -t "1234567890"         
Sat Feb 14 00:31:30 2009
$ rax2 -t "1234567890 GMT0"  
Sat Feb 14 00:31:30 2009
$ rax2 -t "1234567890 GMT-1" 
Fri Feb 13 23:31:30 2009
$ rax2 -t 1234567890GMT-1
Fri Feb 13 23:31:30 2009
$ rax2 -t "1234567890 GMT+10" 
Sat Feb 14 10:31:30 2009
```
I also opened a PR that fixes the test...