### PR TITLE
Fix #10651 - ARM assembler for 'sub sp, sp, 0x1000' ##asm

### DIFF
--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -6279,9 +6279,24 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				}
 				ao->o |= reg << 8;
 				reg = getreg (ao->a[2]);
-				ao->o |= (reg != -1)? reg << 24 : 2 | getnum (ao->a[2]) << 24;
+				if (reg == -1) {
+					int imm = getnum(ao->a[2]);
+					if (imm && !(imm & (imm - 1)) && imm > 255) {
+						for (int r = 0; r != 32; r += 2) {
+							if (!(imm & ~0xff)) {
+								ao->o |= (r << 15) | (imm << 24) | 2;
+								break;
+							}
+							imm = (imm << 2) | (imm >> 30);
+						}
+					} else {
+						ao->o |= (imm << 24) | 2;
+					}
+				} else {
+					ao->o |= reg << 24;
+				}
 				if (ao->a[3]) {
-					ao->o |= getshift (ao->a[3]);
+					ao->o |= getshift(ao->a[3]);
 				}
 				break;
 			case TYPE_SWP:


### PR DESCRIPTION
Tests: https://github.com/radareorg/radare2/issues/10651#issuecomment-538160017

```
   0:	e24dda01 	sub	sp, sp, #4096	; 0x1000
   4:	e24ddb01 	sub	sp, sp, #1024	; 0x400
   8:	e21ddb01 	ands	sp, sp, #1024	; 0x400
   c:	e24ddb01 	sub	sp, sp, #1024	; 0x400
  10:	e24dda01 	sub	sp, sp, #4096	; 0x1000
  14:	e24dd901 	sub	sp, sp, #16384	; 0x4000
  18:	e24dd401 	sub	sp, sp, #16777216	; 0x1000000
  1c:	e24dd201 	sub	sp, sp, #268435456	; 0x10000000
  20:	e24dd00a 	sub	sp, sp, #10
```