### PR TITLE
visual: Refactor print format

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -66,17 +66,24 @@ static const char *print5Formats[PRINT_5_FORMATS] = {
 };
 
 R_API void r_core_visual_applyHexMode(RCore *core, int hexMode) {
-	currentFormat = R_ABS(hexMode) % 3;
+	currentFormat = R_ABS(hexMode) % PRINT_HEX_FORMATS;
 	switch (currentFormat) {
-	case 0:
+	case 0: /* px */
+	case 3: /* prx */
+	case 6: /* pxw */
+	case 9: /* pxr */
 		r_config_set (core->config, "hex.compact", "false");
 		r_config_set (core->config, "hex.comments", "true");
 		break;
-	case 1:
+	case 1: /* pxa */
+	case 4: /* pxb */
+	case 7: /* pxq */
 		r_config_set (core->config, "hex.compact", "true");
 		r_config_set (core->config, "hex.comments", "true");
 		break;
-	case 2:
+	case 2: /* pxr */
+	case 5: /* pxh */
+	case 8: /* pxd */
 		r_config_set (core->config, "hex.compact", "false");
 		r_config_set (core->config, "hex.comments", "false");
 		break;
@@ -171,13 +178,13 @@ R_API void r_core_visual_applyDisMode(RCore *core, int disMode) {
 	}
 }
 
-static void nextPrintCommand() {
+static void nextPrintCommand(void) {
 	current0format++;
 	current0format %= PRINT_HEX_FORMATS;
 	currentFormat = current0format;
 }
 
-static void prevPrintCommand() {
+static void prevPrintCommand(void) {
 	current0format--;
 	if (current0format < 0) {
 		current0format = 0;
@@ -430,6 +437,66 @@ R_API void r_core_visual_showcursor(RCore *core, int x) {
 		r_cons_enable_mouse (false);
 	}
 	r_cons_flush ();
+}
+
+static void nextPrintFormat(RCore *core) {
+	switch (core->printidx) {
+	case R_CORE_VISUAL_MODE_PX: // 0 // xc
+		r_core_visual_applyHexMode (core, ++hexMode);
+		printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
+		break;
+	case R_CORE_VISUAL_MODE_PD: // pd
+		r_core_visual_applyDisMode (core, ++disMode);
+		printfmtSingle[1] = rotateAsmemu (core);
+		break;
+	case R_CORE_VISUAL_MODE_DB: // debugger
+		r_core_visual_applyDisMode (core, ++disMode);
+		printfmtSingle[1] = rotateAsmemu (core);
+		current3format++;
+		currentFormat = R_ABS (current3format) % PRINT_3_FORMATS;
+		printfmtSingle[2] = print3Formats[currentFormat];
+		break;
+	case R_CORE_VISUAL_MODE_OV: // overview
+		current4format++;
+		currentFormat = R_ABS (current4format) % PRINT_4_FORMATS;
+		printfmtSingle[3] = print4Formats[currentFormat];
+		break;
+	case R_CORE_VISUAL_MODE_CD: // code
+		current5format++;
+		currentFormat = R_ABS (current5format) % PRINT_5_FORMATS;
+		printfmtSingle[4] = print5Formats[currentFormat];
+		break;
+	}
+}
+
+static void prevPrintFormat(RCore *core) {
+	switch (core->printidx) {
+	case R_CORE_VISUAL_MODE_PX: // 0 // xc
+		r_core_visual_applyHexMode (core, --hexMode);
+		printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
+		break;
+	case R_CORE_VISUAL_MODE_PD: // pd
+		r_core_visual_applyDisMode (core, --disMode);
+		printfmtSingle[1] = rotateAsmemu (core);
+		break;
+	case R_CORE_VISUAL_MODE_DB: // debugger
+		r_core_visual_applyDisMode (core, --disMode);
+		printfmtSingle[1] = rotateAsmemu (core);
+		current3format--;
+		currentFormat = R_ABS (current3format) % PRINT_3_FORMATS;
+		printfmtSingle[2] = print3Formats[currentFormat];
+		break;
+	case R_CORE_VISUAL_MODE_OV: // overview
+		current4format--;
+		currentFormat = R_ABS (current4format) % PRINT_4_FORMATS;
+		printfmtSingle[3] = print4Formats[currentFormat];
+		break;
+	case R_CORE_VISUAL_MODE_CD: // code
+		current5format--;
+		currentFormat = R_ABS (current5format) % PRINT_5_FORMATS;
+		printfmtSingle[4] = print5Formats[currentFormat];
+		break;
+	}
 }
 
 static int color = 1;
@@ -1083,6 +1150,7 @@ R_API void r_core_visual_seek_animation(RCore *core, ut64 addr) {
 
 static void setprintmode(RCore *core, int n) {
 	RAsmOp op;
+
 	if (n > 0) {
 		core->printidx = R_ABS ((core->printidx + 1) % NPF);
 	} else {
@@ -1093,17 +1161,14 @@ static void setprintmode(RCore *core, int n) {
 		}
 	}
 	switch (core->printidx) {
-	case 0:
+	case R_CORE_VISUAL_MODE_PX:
 		core->inc = 16;
 		break;
-	case 1:
-	case 2:
+	case R_CORE_VISUAL_MODE_PD:
+	case R_CORE_VISUAL_MODE_DB:
 		r_asm_op_init (&op);
 		core->inc = r_asm_disassemble (core->assembler, &op, core->block, R_MIN (32, core->blocksize));
 		r_asm_op_fini (&op);
-		break;
-	case 5:
-		core->inc = r_config_get_i (core->config, "hex.cols");
 		break;
 	}
 }
@@ -2369,32 +2434,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 		}
 		break;
 		case 'o': // tab TAB
-			{
-				switch (core->printidx) {
-				case R_CORE_VISUAL_MODE_PX: // 0 // xc
-					r_core_visual_applyHexMode (core, --hexMode);
-					printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
-					break;
-				case R_CORE_VISUAL_MODE_PD: // pd
-					r_core_visual_applyDisMode (core, --disMode);
-					printfmtSingle[1] = rotateAsmemu (core);
-					break;
-				case R_CORE_VISUAL_MODE_DB: // debugger
-					r_core_visual_applyDisMode (core, --disMode);
-					printfmtSingle[1] = rotateAsmemu (core);
-					current3format++;
-					printfmtSingle[2] = print3Formats[R_ABS (current3format) % PRINT_3_FORMATS];
-					break;
-				case R_CORE_VISUAL_MODE_OV: // overview
-					current4format--;
-					printfmtSingle[3] = print4Formats[R_ABS (current4format) % PRINT_4_FORMATS];
-					break;
-				case R_CORE_VISUAL_MODE_CD: // code
-					current5format--;
-					printfmtSingle[4] = print5Formats[R_ABS (current5format) % PRINT_5_FORMATS];
-					break;
-				}
-			}
+			nextPrintFormat(core);
 			break;
 		case 'O': // tab TAB
 		case 9: // tab TAB
@@ -2433,30 +2473,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 						}
 					}
 				} else {
-					switch (core->printidx) {
-					case R_CORE_VISUAL_MODE_PX: // 0 // xc
-						r_core_visual_applyHexMode (core, ++hexMode);
-						printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
-						break;
-					case R_CORE_VISUAL_MODE_PD: // pd
-						r_core_visual_applyDisMode (core, ++disMode);
-						printfmtSingle[1] = rotateAsmemu (core);
-						break;
-					case R_CORE_VISUAL_MODE_DB: // debugger
-						r_core_visual_applyDisMode (core, ++disMode);
-						printfmtSingle[1] = rotateAsmemu (core);
-						currentFormat = ++current3format;
-						printfmtSingle[2] = print3Formats[R_ABS(current3format) % PRINT_3_FORMATS];
-						break;
-					case R_CORE_VISUAL_MODE_OV: // overview
-						currentFormat = ++current4format;
-						printfmtSingle[3] = print4Formats[R_ABS(current4format) % PRINT_4_FORMATS];
-						break;
-					case R_CORE_VISUAL_MODE_CD: // code
-						currentFormat = ++current5format;
-						printfmtSingle[4] = print5Formats[R_ABS(current5format) % PRINT_5_FORMATS];
-						break;
-					}
+					prevPrintFormat(core);
 				}
 			}
 			break;
@@ -3541,29 +3558,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 						core->seltab = 2;
 					}
 				} else {
-					switch (core->printidx) {
-					case R_CORE_VISUAL_MODE_PX: // 0 // xc
-						r_core_visual_applyHexMode (core, --hexMode);
-						printfmtSingle[0] = printHexFormats[R_ABS(hexMode) % PRINT_HEX_FORMATS];
-						break;
-					case R_CORE_VISUAL_MODE_PD: // pd
-						printfmtSingle[1] = rotateAsmemu (core);
-						r_core_visual_applyDisMode (core, --disMode);
-						break;
-					case R_CORE_VISUAL_MODE_DB: // debugger
-						currentFormat = --current3format;
-						printfmtSingle[2] = print3Formats[R_ABS(current3format) % PRINT_3_FORMATS];
-						r_core_visual_applyDisMode (core, --disMode);
-						break;
-					case R_CORE_VISUAL_MODE_OV: // overview
-						currentFormat = --current4format;
-						printfmtSingle[3] = print4Formats[R_ABS(current4format)% PRINT_4_FORMATS];
-						break;
-					case R_CORE_VISUAL_MODE_CD: // code
-						currentFormat = --current5format;
-						printfmtSingle[4] = print5Formats[R_ABS(current5format) % PRINT_5_FORMATS];
-						break;
-					}
+					prevPrintFormat(core);
 				}
 			} else { // "Z"
 				ut64 addr = core->print->cur_enabled? core->offset + core->print->cur: core->offset;


### PR DESCRIPTION
This is an attempt to clean how visual mode cycle through the different printing formats.
this is far from perfect:
 - when cycling between different print mode the format index is not updated
 - the format cycling in debug print mode is a bit funky, if cursor mode is enabled the print mode index is displayed instead of the format index when cycling through print modes.