### PR TITLE
JSON output for dpt

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -307,7 +307,9 @@ static const char *help_msg_dp[] = {
 	"dpn", "", "Create new process (fork)",
 	"dptn", "", "Create new thread (clone)",
 	"dpt", "", "List threads of current pid",
+	"dptj", "", "List threads of current pid in JSON format",
 	"dpt", " <pid>", "List threads of process",
+	"dptj", " <pid>", "List threads of process in JSON format",
 	"dpt=", "<thread>", "Attach to thread",
 	NULL
 };
@@ -1071,10 +1073,17 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 	case 't': // "dpt"
 		switch (input[2]) {
 		case '\0': // "dpt"
-			r_debug_thread_list (core->dbg, core->dbg->pid);
+			r_debug_thread_list (core->dbg, core->dbg->pid, 0);
+			break;
+		case 'j': // "dptj"
+			if (input[3] != ' ') { // "dptj"
+				r_debug_thread_list (core->dbg, core->dbg->pid, 'j');
+			} else { // "dptj "
+				r_debug_thread_list (core->dbg, atoi (input + 3), 'j');
+			}
 			break;
 		case ' ': // "dpt "
-			r_debug_thread_list (core->dbg, atoi (input + 2));
+			r_debug_thread_list (core->dbg, atoi (input + 2), 0);
 			break;
 		case '=': // "dpt="
 			r_debug_select (core->dbg, core->dbg->pid,

--- a/libr/debug/pid.c
+++ b/libr/debug/pid.c
@@ -68,7 +68,7 @@ R_API int r_debug_pid_list(RDebug *dbg, int pid, char fmt) {
 	return false;
 }
 
-R_API int r_debug_thread_list(RDebug *dbg, int pid) {
+R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt) {
 	RList *list;
 	RListIter *iter;
 	RDebugPid *p;
@@ -80,26 +80,29 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid) {
 		if (!list) {
 			return false;
 		}
-		if (pid == -'j') {
-			PJ *j = pj_new ();
-			pj_a (j);
-			r_list_foreach (list, iter, p) {
+		PJ *j = pj_new ();
+		pj_a (j);
+		r_list_foreach (list, iter, p) {
+			switch (fmt) {
+			case 'j':
 				pj_o (j);
 				pj_ki (j, "pid", p->pid);
 				pj_ks (j, "status", &p->status);
 				pj_ks (j, "path", p->path);
 				pj_end (j);
-			}
-			pj_end (j);
-			dbg->cb_printf (pj_string (j));
-			pj_free (j);
-		} else {
-			r_list_foreach (list, iter, p) {
+				break;
+			default:
 				dbg->cb_printf (" %c %d %c %s\n",
-						dbg->tid == p->pid ? '*' : '-',
-						p->pid, p->status, p->path);
+					dbg->tid == p->pid? '*': '-',
+					p->pid, p->status, p->path);
+				break;
 			}
 		}
+		pj_end (j);
+		if (fmt == 'j') {
+			dbg->cb_printf (pj_string (j));
+		}
+		pj_free (j);
 		r_list_free (list);
 	}
 	return false;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -536,7 +536,7 @@ R_API bool r_debug_arg_set(RDebug *dbg, int fast, int num, ut64 value);
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, bool watch, int rw, char *module, st64 m_delta);
 
 /* pid */
-R_API int r_debug_thread_list(RDebug *dbg, int pid);
+R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt);
 
 R_API void r_debug_tracenodes_reset(RDebug *dbg);
 


### PR DESCRIPTION
dpt handled 'j' by getting it from the pid field in "dpt ", this wasn't intuitive(or documented) and it wasn't viable in case an actual pid was provided.

[0x7fcefa5a7090]> dptj
[{"pid":5928,"status":"s","path":"ls"}]
[0x7fcefa5a7090]> dptj 1
[{"pid":1,"status":"S","path":"systemd"}]