### PR TITLE
Add current thread field to dptj

### DIFF
--- a/libr/debug/pid.c
+++ b/libr/debug/pid.c
@@ -86,7 +86,7 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt) {
 			switch (fmt) {
 			case 'j':
 				pj_o (j);
-				pj_ki (j, "current", dbg->tid == p->pid? true: false);
+				pj_kb (j, "current", dbg->tid == p->pid);
 				pj_ki (j, "pid", p->pid);
 				pj_ks (j, "status", &p->status);
 				pj_ks (j, "path", p->path);

--- a/libr/debug/pid.c
+++ b/libr/debug/pid.c
@@ -86,6 +86,7 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt) {
 			switch (fmt) {
 			case 'j':
 				pj_o (j);
+				pj_ki (j, "current", dbg->tid == p->pid? true: false);
 				pj_ki (j, "pid", p->pid);
 				pj_ks (j, "status", &p->status);
 				pj_ks (j, "path", p->path);


### PR DESCRIPTION
While fixing JSON support for dpt I didn't notice that the JSON packing implementation was missing a field that was [available](https://github.com/radareorg/radare2/blob/82bff79820abc796c43cf46de6359f4eed3e5b9b/libr/debug/pid.c#L56) in the printed version. This small patch takes care of it.