### PR TITLE
Move UTF-8 setting logic to scr.utf8 config callback on Windows

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1451,6 +1451,31 @@ R_API void r_cons_set_raw(bool is_raw) {
 	oldraw = is_raw;
 }
 
+R_API void r_cons_set_utf8(bool b) {
+	I.use_utf8 = b;
+#if __WINDOWS__
+	if (b) {
+		if (IsValidCodePage (CP_UTF8)) {
+			if (!SetConsoleOutputCP (CP_UTF8)) {
+				r_sys_perror ("r_cons_set_utf8");
+			}
+#if UNICODE
+			if (!SetConsoleCP (CP_UTF8)) {
+				r_sys_perror ("r_cons_set_utf8");
+			}
+#endif
+		} else {
+			R_LOG_WARN ("UTF-8 Codepage not installed.\n");
+		}
+	} else {
+		UINT acp = GetACP ();
+		if (!SetConsoleCP (acp) || !SetConsoleOutputCP (acp)) {
+			r_sys_perror ("r_cons_set_utf8");
+		}
+	}
+#endif
+}
+
 R_API void r_cons_invert(int set, int color) {
 	r_cons_strcat (R_CONS_INVERT (set, color));
 }

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -543,21 +543,6 @@ R_API RCons *r_cons_new() {
 	I.null = 0;
 #if __WINDOWS__
 	I.ansicon = r_cons_is_ansicon ();
-#if UNICODE
-	if (IsValidCodePage (CP_UTF8)) {
-		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
-			r_sys_perror ("r_cons_new");
-		}
-	} else {
-		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
-	}
-#else
-	UINT CP_IN = GetACP ();
-	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
-	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
-		r_sys_perror ("r_cons_new");
-	}
-#endif
 #endif
 #if EMSCRIPTEN
 	/* do nothing here :? */

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -9,9 +9,7 @@
 #if __WINDOWS__
 #include <windows.h>
 #define printf(...) r_cons_win_printf (false, __VA_ARGS__)
-#ifdef UNICODE
 #define USE_UTF8 1
-#endif
 #else
 #include <sys/ioctl.h>
 #include <termios.h>

--- a/libr/cons/utf8.c
+++ b/libr/cons/utf8.c
@@ -242,3 +242,30 @@ R_API int r_cons_is_utf8() {
 }
 
 #endif
+
+#if __WINDOWS__
+R_API void r_cons_win_set_cp(bool utf8) {
+	if (utf8) {
+#if UNICODE
+	if (IsValidCodePage (CP_UTF8)) {
+		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
+			r_sys_perror ("r_cons_set_cp_w32");
+		}
+	} else {
+		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
+	}
+#else
+	UINT CP_IN = GetACP ();
+	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
+	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
+		r_sys_perror ("r_cons_set_cp_w32");
+	}
+#endif
+	} else {
+		UINT acp = GetACP ();
+		if (!SetConsoleOutputCP (acp) || !SetConsoleCP (acp)) {
+			r_sys_perror ("r_cons_set_cp_w32");
+		}
+	}
+}
+#endif

--- a/libr/cons/utf8.c
+++ b/libr/cons/utf8.c
@@ -240,32 +240,4 @@ R_API int r_cons_is_utf8() {
 	return 0;
 #endif
 }
-
-#endif
-
-#if __WINDOWS__
-R_API void r_cons_win_set_cp(bool utf8) {
-	if (utf8) {
-#if UNICODE
-	if (IsValidCodePage (CP_UTF8)) {
-		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
-			r_sys_perror ("r_cons_set_cp_w32");
-		}
-	} else {
-		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
-	}
-#else
-	UINT CP_IN = GetACP ();
-	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
-	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
-		r_sys_perror ("r_cons_set_cp_w32");
-	}
-#endif
-	} else {
-		UINT acp = GetACP ();
-		if (!SetConsoleOutputCP (acp) || !SetConsoleCP (acp)) {
-			r_sys_perror ("r_cons_set_cp_w32");
-		}
-	}
-}
 #endif

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2278,7 +2278,7 @@ static bool cb_utf8(void *user, void *data) {
 #if UNICODE
 	if (IsValidCodePage (CP_UTF8)) {
 		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
-			r_sys_perror ("r_cons_new");
+			r_sys_perror ("cb_utf8");
 		}
 	} else {
 		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
@@ -2287,13 +2287,13 @@ static bool cb_utf8(void *user, void *data) {
 	UINT CP_IN = GetACP ();
 	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
 	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
-		r_sys_perror ("r_cons_new");
+		r_sys_perror ("cb_utf8");
 	}
 #endif
 	} else {
 		UINT acp = GetACP ();
 		if (!SetConsoleOutputCP (acp) || !SetConsoleCP (acp)) {
-			r_sys_perror ("r_cons_new");
+			r_sys_perror ("cb_utf8");
 		}
 	}
 #endif

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2274,28 +2274,7 @@ static bool cb_utf8(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 	core->cons->use_utf8 = node->i_value;
 #if __WINDOWS__
-	if (core->cons->use_utf8) {
-#if UNICODE
-	if (IsValidCodePage (CP_UTF8)) {
-		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
-			r_sys_perror ("cb_utf8");
-		}
-	} else {
-		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
-	}
-#else
-	UINT CP_IN = GetACP ();
-	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
-	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
-		r_sys_perror ("cb_utf8");
-	}
-#endif
-	} else {
-		UINT acp = GetACP ();
-		if (!SetConsoleOutputCP (acp) || !SetConsoleCP (acp)) {
-			r_sys_perror ("cb_utf8");
-		}
-	}
+	r_cons_win_set_cp (core->cons->use_utf8);
 #endif
 	return true;
 }

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2270,12 +2270,8 @@ static bool cb_tracetag(void *user, void *data) {
 }
 
 static bool cb_utf8(void *user, void *data) {
-	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
-	core->cons->use_utf8 = node->i_value;
-#if __WINDOWS__
-	r_cons_win_set_cp (core->cons->use_utf8);
-#endif
+	r_cons_set_utf8 ((bool)node->i_value);
 	return true;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2273,6 +2273,30 @@ static bool cb_utf8(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
 	core->cons->use_utf8 = node->i_value;
+#if __WINDOWS__
+	if (core->cons->use_utf8) {
+#if UNICODE
+	if (IsValidCodePage (CP_UTF8)) {
+		if (!SetConsoleOutputCP (CP_UTF8) || !SetConsoleCP (CP_UTF8)) {
+			r_sys_perror ("r_cons_new");
+		}
+	} else {
+		R_LOG_WARN ("UTF-8 Codepage not installed.\n");
+	}
+#else
+	UINT CP_IN = GetACP ();
+	UINT CP_OUT = IsValidCodePage (CP_UTF8) ? CP_UTF8 : CP_IN;
+	if (!SetConsoleOutputCP (CP_OUT) || !SetConsoleCP (CP_IN)) {
+		r_sys_perror ("r_cons_new");
+	}
+#endif
+	} else {
+		UINT acp = GetACP ();
+		if (!SetConsoleOutputCP (acp) || !SetConsoleCP (acp)) {
+			r_sys_perror ("r_cons_new");
+		}
+	}
+#endif
 	return true;
 }
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -822,6 +822,7 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, bool vmode);
 R_API int r_cons_win_printf(bool vmode, const char *fmt, ...);
 R_API int r_cons_win_eprintf(bool vmode, const char *fmt, ...);
 R_API int r_cons_win_vhprintf(DWORD hdl, bool vmode, const char *fmt, va_list ap);
+R_API void r_cons_win_set_cp(bool utf8);
 #endif
 
 R_API void r_cons_push(void);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -822,7 +822,6 @@ R_API int r_cons_w32_print(const ut8 *ptr, int len, bool vmode);
 R_API int r_cons_win_printf(bool vmode, const char *fmt, ...);
 R_API int r_cons_win_eprintf(bool vmode, const char *fmt, ...);
 R_API int r_cons_win_vhprintf(DWORD hdl, bool vmode, const char *fmt, va_list ap);
-R_API void r_cons_win_set_cp(bool utf8);
 #endif
 
 R_API void r_cons_push(void);
@@ -863,6 +862,7 @@ R_API void r_cons_chop(void);
 R_API void r_cons_set_raw(bool b);
 R_API void r_cons_set_interactive(bool b);
 R_API void r_cons_set_last_interactive(void);
+R_API void r_cons_set_utf8(bool b);
 
 /* output */
 R_API int r_cons_printf(const char *format, ...);


### PR DESCRIPTION
This should fix tests on Appveyor