### PR TITLE
Fix incomplete drr/drrj formatting of registers with invalid values

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2083,6 +2083,12 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 				r_cons_printf (" %s\n", rrstr);
 			}
 			free (rrstr);
+		} else {
+			if (mode == 'j') {
+				r_cons_printf (",\"ref\":\"\"}");
+			} else {
+				r_cons_printf ("\n");
+			}
 		}
 	}
 	if (mode == 'j') {


### PR DESCRIPTION
Drr/Drrj([r_core_debug_rr](https://github.com/radareorg/radare2/blob/master/libr/core/cmd_debug.c#L1998)) calls [r_core_anal_hasrefs](https://github.com/radareorg/radare2/blob/master/libr/core/core.c#L2053) which may fail due to an invalid value in a register with the following message:

[WARNING: r_core_anal_hasrefs_to_depth: assertion 'core && value != UT64_MAX' failed (line 2063)](https://github.com/radareorg/radare2/blob/master/libr/core/core.c#L2063)

The execution of r_core_debug_rr continues regardless of the failure and the value is taken from r_reg_get_bvalue later on. 
While value and reg are printed/populated in the JSON, ["ref" is skipped](https://github.com/radareorg/radare2/blob/master/libr/core/cmd_debug.c#L2079), breaking the JSON format from that point onwards and messing up the printed format.

Before the changes(Look for `orax`):

Printed(No new line before `ss`):

    rflags 1I                  514
    SN  orax 0xffffffffffffffff       ss 0x2b                43 ascii ('+')
    fs_base 0x0                 0 class.std


JSON(No closing bracket after `orax`'s value field):

        {
            "reg":"rflags",
            "value":"1I",
            "ref":" 514"
        },
        {
            "reg":"orax",
            "value":"0xffffffffffffffff",
        {
            "reg":"ss",
            "value":"0x2b",
            "ref":" 43 ascii ('+')"
        },


After:

Printed(Ref is replaced with \n"):

        rflags 1I                  514
        SN  orax 0xffffffffffffffff
        ss 0x2b                43 ascii ('+')

JSON(Ref is replaced with an empty string):

    {
        "reg":"rflags",
        "value":"1I",
        "ref":" 514"
    },
    {
        "reg":"orax",
        "value":"0xffffffffffffffff",
        "ref":""
    },
    {
        "reg":"ss",
        "value":"0x2b",
        "ref":" 43 ascii ('+')"
    }