### PR TITLE
(elf) avoid truncating binary length to 32 bits

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3703,7 +3703,7 @@ ELFOBJ* Elf_(r_bin_elf_new_buf)(RBuffer *buf, bool verbose) {
 	ELFOBJ *bin = R_NEW0 (ELFOBJ);
 	if (bin) {
 		bin->kv = sdb_new0 ();
-		bin->size = (ut32)r_buf_size (buf);
+		bin->size = r_buf_size (buf);
 		bin->verbose = verbose;
 		bin->b = r_buf_ref (buf);
 		if (!elf_init (bin)) {


### PR DESCRIPTION
I was trying r2 out on a very large binary (5.6G) [debug symbols take up a lot of space!] and noticed that rabin2 was unable to parse most of the symbol table.

This fixed the issue for me and looks sane enough. I couldn't track the blame on the 32-bit cast far enough to find a reason not to get rid of it. Let me know if that sounds Wrong and Bad.