### PR TITLE
Add support for hex escaped litterals in regular expressions

### DIFF
--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -1059,8 +1059,16 @@ special(struct parse *p, int ch) {
 	char *oldnext = p->next;
 	char *oldend = p->end;
 	char bracket[16] = {0};
+	char digits[3] = {0};
+	char c;
 	int num = 0;
 	switch (ch) {
+	case 'x':
+		digits[0] = GETNEXT ();
+		digits[1] = GETNEXT ();
+		c = (char)strtol (digits, NULL, 16);
+		ordinary (p, c);
+		return;
 	case 'n':
 		ordinary (p, '\n');
 		return;


### PR DESCRIPTION
Example: /e /(\x77\x30\x30\x74){2}/ searches for "w00tw00t"