### PR TITLE
Fixed dpt= on linux by adding support for thread switching

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -187,11 +187,13 @@ static int r_debug_native_detach (RDebug *dbg, int pid) {
 #endif
 }
 
+static int r_debug_native_select(RDebug *dbg, int pid, int tid) {
 #if __WINDOWS__
-static int r_debug_native_select (RDebug *dbg, int pid, int tid) {
 	return w32_select (dbg, pid, tid);
-}
+#elif __linux__
+	return linux_select_thread (dbg, pid, tid);
 #endif
+}
 
 static int r_debug_native_continue_syscall (RDebug *dbg, int pid, int num) {
 // XXX: num is ignored
@@ -2112,7 +2114,7 @@ RDebugPlugin r_debug_plugin_native = {
 	.attach = &r_debug_native_attach,
 	.detach = &r_debug_native_detach,
 // TODO: add native select for other platforms?
-#if __WINDOWS__
+#if __WINDOWS__ || __linux__
 	.select = &r_debug_native_select,
 #endif
 	.pids = &r_debug_native_pids,

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -97,6 +97,7 @@ RDebugReasonType linux_ptrace_event (RDebug *dbg, int pid, int status);
 int linux_attach (RDebug *dbg, int pid);
 RDebugInfo *linux_info (RDebug *dbg, const char *arg);
 RList *linux_thread_list (int pid, RList *list);
+bool linux_select_thread (RDebug *dbg, int pid, int tid);
 RDebugPid *fill_pid_info (const char *info, const char *path, int tid);
 int linux_reg_read (RDebug *dbg, int type, ut8 *buf, int size);
 int linux_reg_write (RDebug *dbg, int type, const ut8 *buf, int size);


### PR DESCRIPTION
Tested with a multi threaded binary on Ubuntu, everything seems to work well.

With these changes, all 'select' implementation should properly resync after switching threads using `dpt=` without having to run `ds` as was previously required.