### PR TITLE
#15302 [rasm2/armass] Correctly propagate errors from thumb_assemble

### DIFF
--- a/libr/asm/arch/arm/armass.c
+++ b/libr/asm/arch/arm/armass.c
@@ -6583,7 +6583,7 @@ ut32 armass_assemble(const char *str, ut64 off, int thumb) {
 	if (thumb < 0 || thumb > 1) {
 		return -1;
 	}
-	if (!assemble[thumb] (&aop, off, buf)) {
+	if (assemble[thumb] (&aop, off, buf) <= 0) {
 		//eprintf ("armass: Unknown opcode (%s)\n", buf);
 		return -1;
 	}


### PR DESCRIPTION
Fix #15302.

The `arm_assemble` function returns zero on error, but `thumb_assemble` returns -1. The condition prior to this patch masked all encoding errors from assembling thumb ops. This will propagate the errors from `thumb_assemble` so assembling bad instructions like 'bl 0x101' appropriately issues an error (i.e. from `rasm2`).

I intend to commit a regression test to [radare2-regressions](/radareorg/radare2-regressions) shortly.