### PR TITLE
#15304 Fix radare2 build for kernels without THP support

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1114,7 +1114,7 @@ static int io_perms_to_prot (int io_perms) {
 
 
 static int linux_map_thp (RDebug *dbg, ut64 addr, int size) {
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && defined(MADV_HUGEPAGE)
 	RBuffer *buf = NULL;
 	char code[1024];
 	int ret = true;


### PR DESCRIPTION
Fixes Issue #15304 caused by PR #14730 by guarding the body of `linux_map_thp` against the absence of the `MADV_HUGEPAGE` macro. For older kernels without THP support, this function will simply fail.

One might also think to  check THP support by kernel version (e.g. by checking `LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 38)` but this would not work for modern kernels which were explicitly configured without the `CONFIG_TRANSPARENT_HUGEPAGE` option. 

In all practical cases `MADV_HUGEPAGE` is likely to be a macro so I belive further checks are unnecessary, though if such a necessity were discovered one might like to build this check into `configure`.