### PR TITLE
Avoid reloading of cc sdb

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -594,12 +594,19 @@ R_API void r_core_anal_type_init(RCore *core) {
 
 R_API void r_core_anal_cc_init(RCore *core) {
 	const char *dir_prefix = r_config_get (core->config, "dir.prefix");
-	sdb_reset (core->anal->sdb_cc);
 	const char *anal_arch = r_config_get (core->config, "anal.arch");
 	int bits = core->anal->bits;
-	char *dbpath = sdb_fmt ("%s/"R2_SDB_FCNSIGN"/cc-%s-%d.sdb", dir_prefix, anal_arch, bits);
+	char *dbpath = sdb_fmt (R_JOIN_3_PATHS ("%s", R2_SDB_FCNSIGN, "cc-%s-%d.sdb"),
+		dir_prefix, anal_arch, bits);
+	// Avoid sdb reloading
+	if (core->anal->sdb_cc->path && !strcmp (core->anal->sdb_cc->path, dbpath)) {
+		return;
+	}
+	sdb_reset (core->anal->sdb_cc);
+	R_FREE (core->anal->sdb_cc->path);
 	if (r_file_exists (dbpath)) {
 		sdb_concat_by_path (core->anal->sdb_cc, dbpath);
+		core->anal->sdb_cc->path = strdup (dbpath);
 	}
 }
 


### PR DESCRIPTION
Related issue: https://github.com/radareorg/cutter/issues/1765

`time radare2 -A -qq -Q libcrackme.so`

Before:
```
real	1m49,847s
user	1m19,119s
sys	0m30,339s
```
After:
```
real	0m37,498s
user	0m36,761s
sys	0m0,715s
```

But `r_core_anal_cc_init()` still spends some cpu time on switching between 16/32 bits. Data caching can give ~5% analysis speedup (for the given binary).