### PR TITLE
fix pvzj output.

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -3001,7 +3001,7 @@ static void cmd_print_pv(RCore *core, const char *input, bool useBytes) {
 					  r_cons_printf (",");
 				  }
 				  r_core_seek (core, at, 0);
-				  char *str = r_core_cmd_str (core, "ps @ [$$]");
+				  char *str = r_core_cmd_str (core, "ps");
 				  r_str_trim (str);
 				  char *p = str;
 				  if (p) {


### PR DESCRIPTION
Fixes #15237 

``` 
[0x00000000]> pvzj @0x080485ac
[{"value":542976859,"string":"[+] Running program with username : %s"}]
```