### PR TITLE
Setting the upper address limit for OpenBSD ##io_self

### DIFF
--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -601,6 +601,8 @@ exit:
 		eprintf ("sysctl failed: %s\n", strerror (errno));
 		return false;
 	}
+	endq = size;
+
 	while (sysctl (mib, 3, &entry, &size, NULL, 0) != -1) {
 		int perm = 0;
 		if (entry.kve_end == endq) {


### PR DESCRIPTION
Here it is more an additional 'safety blanket' as sysctl
call would fail once reached then end of the address mapping
anyway.