### PR TITLE
Fix the way linux debugging options are set

### DIFF
--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -251,7 +251,7 @@ bool linux_set_options(RDebug *dbg, int pid) {
 	return true;
 }
 
-static void linux_detach_all (RDebug *dbg) {
+static void linux_detach_all(RDebug *dbg) {
 	RList *th_list = dbg->threads;
 	if (th_list) {
 		RDebugPid *th;
@@ -428,16 +428,16 @@ static bool linux_attach_single_pid(RDebug *dbg, int ptid) {
 			perror ("ptrace (PT_ATTACH)");
 			return false;
 		}
-
-		if (!linux_set_options (dbg, ptid)) {
-			return false;
-		}
 	}
 
+	if (!linux_set_options (dbg, ptid)) {
+		eprintf("failed set_options on %d\n", ptid);
+		return false;
+	}
 	return true;
 }
 
-static RList *get_pid_thread_list (RDebug *dbg, int main_pid) {
+static RList *get_pid_thread_list(RDebug *dbg, int main_pid) {
 	RList *list = r_list_new ();
 	if (list) {
 		list = linux_thread_list (main_pid, list);
@@ -446,7 +446,7 @@ static RList *get_pid_thread_list (RDebug *dbg, int main_pid) {
 	return list;
 }
 
-static void linux_attach_all (RDebug *dbg) {
+static void linux_attach_all(RDebug *dbg) {
 	linux_attach_single_pid (dbg, dbg->main_pid);
 
 	RList *list = dbg->threads;


### PR DESCRIPTION
In linux_attach_single_pid there is a check to avoid calling PT_ATTACH
multiple times on an already traced pid, which is an operation that
should be done only one time. The old code supposedly tried to set the
options only the first time you attach to a process, however when
debugging a process through the io_ptrace plugin, the process uses
TRACEME and the code never set the options of ptrace to intercept the
process before dying, amongst other things.

This patch tries to address the issue by using a boolean in RDebug that
keep tracks of whether the options were set or not for the process being
debugged.