### PR TITLE
Fixed opcodes not being associated with the current thread in gdbr

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -607,7 +607,7 @@ R_API bool r_debug_select(RDebug *dbg, int pid, int tid) {
 		return false;
 	}
 
-	r_io_system (dbg->iob.io, sdb_fmt ("pid %d", pid));
+	r_io_system (dbg->iob.io, sdb_fmt ("pid %d", tid));
 
 	dbg->pid = pid;
 	dbg->tid = tid;

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -33,7 +33,7 @@ static int r_debug_gdb_step(RDebug *dbg) {
 	if (!desc) {
 		return R_DEBUG_REASON_UNKNOWN;
 	}
-	gdbr_step (desc, -1); // TODO handle thread specific step?
+	gdbr_step (desc, dbg->tid);
 	return true;
 }
 
@@ -1065,11 +1065,12 @@ static bool r_debug_gdb_kill(RDebug *dbg, int pid, int tid, int sig) {
 	return true;
 }
 
-static int r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
-	if (!desc  || !*origriogdb ) {
+static bool r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
+	if (!desc || !*origriogdb) {
 		desc = NULL;	//TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
 		return false;
 	}
+
 	return gdbr_select (desc, pid, tid) >= 0;
 }
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -100,8 +100,6 @@ static int gdbr_connect_lldb(libgdbr_t *g) {
 
 int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	const char *message = "qSupported:multiprocess+;qRelocInsn+;xmlRegisters=i386";
-	RStrBuf tmp;
-	r_strbuf_init (&tmp);
 	int ret, i;
 	if (!g || !host) {
 		return -1;
@@ -115,14 +113,10 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 			g->stub_features.pkt_sz = R_MAX (env_pktsz, GDB_MAX_PKTSZ);
 		}
 	}
-	ret = snprintf (tmp.buf, sizeof (tmp.buf) - 1, "%d", port);
-	if (!ret) {
-		return -1;
-	}
 	if (*host == '/') {
 		ret = r_socket_connect_serial (g->sock, host, port, 1);
 	} else {
-		ret = r_socket_connect_tcp (g->sock, host, tmp.buf, 400);
+		ret = r_socket_connect_tcp (g->sock, host, sdb_fmt("%d", port), 400);
 	}
 	if (!ret) {
 		return -1;
@@ -188,8 +182,7 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 		// return -1;
 	}
 	// Set thread for "step" and "continue" operations
-	snprintf (tmp.buf, sizeof (tmp.buf) - 1, "Hc-1");
-	ret = send_msg (g, tmp.buf);
+	ret = send_msg (g, "Hc-1");
 	if (ret < 0) {
 		return ret;
 	}
@@ -689,16 +682,11 @@ fail:
 }
 
 int gdbr_step(libgdbr_t *g, int tid) {
-	RStrBuf tmp;
 	char thread_id[64] = { 0 };
 	if (tid <= 0 || write_thread_id (thread_id, sizeof (thread_id) - 1, g->pid, tid,
 			     g->stub_features.multiprocess) < 0) {
-		r_strbuf_init (&tmp);
-		snprintf (tmp.buf, sizeof (tmp.buf) - 1, "Hc%d", tid);
-
 		send_vcont (g, "vCont?", NULL);
-		send_vcont (g, tmp.buf, NULL);
-
+		send_vcont (g, sdb_fmt ("Hc%d", tid), NULL);
 		return send_vcont (g, CMD_C_STEP, NULL);
 	}
 	return send_vcont (g, CMD_C_STEP, thread_id);

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -689,11 +689,16 @@ fail:
 }
 
 int gdbr_step(libgdbr_t *g, int tid) {
-	char thread_id[64] = {0};
+	RStrBuf tmp;
+	char thread_id[64] = { 0 };
 	if (tid <= 0 || write_thread_id (thread_id, sizeof (thread_id) - 1, g->pid, tid,
 			     g->stub_features.multiprocess) < 0) {
+		r_strbuf_init (&tmp);
+		snprintf (tmp.buf, sizeof (tmp.buf) - 1, "Hc%d", tid);
+
 		send_vcont (g, "vCont?", NULL);
-		send_vcont (g, "Hc0", NULL);
+		send_vcont (g, tmp.buf, NULL);
+
 		return send_vcont (g, CMD_C_STEP, NULL);
 	}
 	return send_vcont (g, CMD_C_STEP, thread_id);


### PR DESCRIPTION
Prior to these fixes, running step/continue and their variation would switch back to the original pid.