### PR TITLE
Added a way to break while in linux_dbg_wait and fixed dpk

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1075,7 +1075,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			ptr = strchr (ptr, ' ');
 			sig = ptr? atoi (ptr + 1): 0;
 			eprintf ("Sending signal '%d' to pid '%d'\n", sig, pid);
-			r_debug_kill (core->dbg, 0, false, sig);
+			r_debug_kill (core->dbg, pid, false, sig);
 		} else eprintf ("cmd_debug_pid: Invalid arguments (%s)\n", input);
 		break;
 	case 'n': // "dpn"

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1577,7 +1577,7 @@ R_API int r_debug_kill(RDebug *dbg, int pid, int tid, int sig) {
 		return false;
 	}
 	if (dbg->h && dbg->h->kill) {
-		if (pid > 0 && tid > 0) {
+		if (pid > 0) {
 			return dbg->h->kill (dbg, pid, tid, sig);
 		}
 		return -1;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1514,7 +1514,7 @@ static RList *r_debug_native_modules_get (RDebug *dbg) {
 	return last;
 }
 
-static bool r_debug_native_kill (RDebug *dbg, int pid, int tid, int sig) {
+static bool r_debug_native_kill(RDebug *dbg, int pid, int tid, int sig) {
 	bool ret = false;
 	if (pid == 0) {
 		pid = dbg->pid;


### PR DESCRIPTION
Added break functionality to around waitpid since there's no normal way to replace waitpid with a timeout-able function without using WHOHANG + sleep which isn't ideal. This change was required by cutter to suspend debug tasks that were ran with `&`.

dpk just called pid 0 so I went ahead and fixed it. Regarding `/* XXX: not for threads? signal is for a whole process!! */` - you have tkill for that, I would suggest restoring this functionality in a future PR for debugging.