### PR TITLE
Add support for setting xmm registers on linux

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -400,7 +400,7 @@ static const char *help_msg_drx[] = {
 static const char *help_msg_drm[] = {
 	"Usage: drm", " [reg] [idx] [wordsize] [= value]", "Show multimedia packed registers",
 	"drm", " xmm0", "Show all packings of xmm0",
-	//	"drm", " xmm0 0 32 = 12", "Set the first 32 bit word of the xmm0 reg to 12", //broken
+	"drm", " xmm0 0 32 = 12", "Set the first 32 bit word of the xmm0 reg to 12",
 	"drmb", " [reg]", "Show registers as bytes",
 	"drmw", " [reg]", "Show registers as words",
 	"drmd", " [reg]", "Show registers as doublewords",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2565,7 +2565,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 #define NUM_PACK_TYPES 4
 			int pack_sizes[NUM_PACK_TYPES] = { 8, 16, 32, 64 };
 			char *pack_format[NUM_PACK_TYPES] = { "%s0x%02" PFMT64x, "%s0x%04" PFMT64x, "%s0x%08" PFMT64x, "%s0x%016" PFMT64x };
-#define pack_print(i, reg, pack_type_index) r_cons_printf (pack_format[pack_type_index], i != 0? " ": "", reg);
+#define pack_print(i, reg, pack_type_index) r_cons_printf (pack_format[pack_type_index], i != 0 ? " " : "", reg);
 			char pack_show[NUM_PACK_TYPES] = { 0, 0, 0, 0 };
 			int index = 0;
 			int size = 0; // auto
@@ -2574,6 +2574,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			if (str[1] == ' ' && str[2] != '\x00') {
 				name = strdup (str + 2);
 				explicit_name = 1;
+				eq = strchr (name, '=');
 				if (eq) {
 					*eq++ = 0;
 				}
@@ -2628,11 +2629,9 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 					if (eq) { // TODO: fix setting xmm registers
 						ut64 val = r_num_math(core->num, eq);
 						r_reg_set_pack(core->dbg->reg, item, index, size, val);
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_GPR, true);
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_MMX, true);
+						r_debug_reg_sync(core->dbg, R_REG_TYPE_XMM, true);
 					} else {
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_GPR, false);
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_MMX, false);
+						r_debug_reg_sync(core->dbg, R_REG_TYPE_XMM, false);
 						ut64 res = r_reg_get_pack(core->dbg->reg, item, index, size);
 						// TODO: handle mm
 						if (!explicit_index) {

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1015,6 +1015,12 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 #else
 #warning r_debug_native_reg_write not implemented
 #endif
+	} else if (type == R_REG_TYPE_FPU) {
+#if __linux__
+		return linux_reg_write (dbg, type, buf, size);
+#else
+#warning r_debug_native_reg_write FPU not implemented
+#endif
 	} //else eprintf ("TODO: reg_write_non-gpr (%d)\n", type);
 	return false;
 }

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1018,8 +1018,6 @@ static int r_debug_native_reg_write (RDebug *dbg, int type, const ut8* buf, int 
 	} else if (type == R_REG_TYPE_FPU) {
 #if __linux__
 		return linux_reg_write (dbg, type, buf, size);
-#else
-#warning r_debug_native_reg_write FPU not implemented
 #endif
 	} //else eprintf ("TODO: reg_write_non-gpr (%d)\n", type);
 	return false;

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -984,6 +984,12 @@ int linux_reg_write (RDebug *dbg, int type, const ut8 *buf, int size) {
 #endif
 		return (ret != 0) ? false : true;
 	}
+	if (type == R_REG_TYPE_FPU) {
+#if __i386__ || __x86_64__
+		int ret = r_debug_ptrace (dbg, PTRACE_SETFPREGS, pid, 0, (void*)buf);
+		return (ret != 0) ? false : true;
+#endif
+	}
 	return false;
 }
 

--- a/libr/include/r_util/r_mem.h
+++ b/libr/include/r_util/r_mem.h
@@ -44,7 +44,6 @@ R_API int r_mem_protect(void *ptr, int size, const char *prot);
 R_API int r_mem_set_num(ut8 *dest, int dest_size, ut64 num);
 R_API int r_mem_eq(ut8 *a, ut8 *b, int len);
 R_API void r_mem_copybits(ut8 *dst, const ut8 *src, int bits);
-R_API void r_mem_copybits(ut8 *dst, const ut8 *src, int bits);
 R_API void r_mem_copybits_delta(ut8 *dst, int doff, const ut8 *src, int soff, int bits);
 R_API void r_mem_copyloop(ut8 *dest, const ut8 *orig, int dsize, int osize);
 R_API void r_mem_swaporcopy(ut8 *dest, const ut8 *src, int len, bool big_endian);

--- a/libr/reg/value.c
+++ b/libr/reg/value.c
@@ -275,19 +275,15 @@ R_API int r_reg_set_pack(RReg *reg, RRegItem *item, int packidx, int packbits, u
 	packbits = R_MIN (64, R_MAX (0, packbits));
 
 	int packbytes = packbits / 8;
-	int packmod = packbits % 8;
 	if (packidx * packbits > item->size) {
 		eprintf ("Packed index is beyond the register size\n");
 		return false;
 	}
-	if (packmod) {
-		eprintf ("Invalid bit size for packet register\n");
-		return false;
-	}
-	int off = item->offset;
+	int off = BITS2BYTES (item->offset);
+	off += (packidx * packbytes);
 	if (reg->regset[item->arena].arena->size - BITS2BYTES (off) - BITS2BYTES (packbytes) >= 0) {
-		ut8 *dst = reg->regset[item->arena].arena->bytes + BITS2BYTES (off);
-		r_mem_copybits (dst, (ut8 *)&val, packbytes);
+		ut8 *dst = reg->regset[item->arena].arena->bytes + off;
+		memcpy (dst, (ut8*)&val, packbytes);
 		return true;
 	}
 	eprintf ("r_reg_set_value: Cannot set %s to 0x%" PFMT64x "\n", item->name, val);


### PR DESCRIPTION
This adds the functionality to set xmm registers with the `drm` command. Right now it is not possible to set the whole register at a time for that we would need to have some bignum support to handle the input. 

```
[0x004000b0]> drm xmm0 1 64 = 0x0001020304050607
[0x004000b0]> drm xmm0 0 64 = 0x08090a0b0c0d0e0f
[0x004000b0]> drm~:0
xmm0 = 0x000102030405060708090a0b0c0d0e0f
```