### PR TITLE
Fix issues in windows thread switching

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -230,11 +230,7 @@ static int r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 	}
 	return tid;
 #elif __WINDOWS__
-	bool ret = w32_continue (dbg, pid, tid, sig);
-	if (!ret) {
-		return -1;
-	}
-	return tid;
+	return w32_continue (dbg, pid, tid, sig);
 #elif __BSD__
 	void *data = (void*)(size_t)((sig != -1) ? sig : dbg->reason.signum);
 	ut64 pc = r_debug_reg_get (dbg, "PC");

--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -878,7 +878,8 @@ int w32_dbg_wait(RDebug *dbg, int pid) {
 					return -1;
 				}
 				if (!__is_thread_alive (dbg, dbg->tid)) {
-					if (!w32_select (dbg, dbg->pid, dbg->tid)) {
+					ret = w32_select (dbg, dbg->pid, dbg->tid);
+					if (ret == -1) {
 						return R_DEBUG_REASON_DEAD;
 					}
 				}
@@ -1050,12 +1051,12 @@ int w32_continue(RDebug *dbg, int pid, int tid, int sig) {
 
 	// Don't continue with a thread that wasn't requested
 	if (dbg->tid != tid) {
-		return false;
+		return -1;
 	}
 
 	if (breaked) {
 		breaked = false;
-		return false;
+		return -1;
 	}
 	w32dbg_wrap_instance *inst = rio->inst;
 	inst->params->type = W32_CONTINUE;
@@ -1066,7 +1067,7 @@ int w32_continue(RDebug *dbg, int pid, int tid, int sig) {
 	if (!w32dbgw_intret (inst)) {
 		w32dbgw_err (inst);
 		r_sys_perror ("w32_continue/ContinueDebugEvent");
-		return false;
+		return -1;
 	}
 
 	return tid;

--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -1046,9 +1046,16 @@ int w32_continue(RDebug *dbg, int pid, int tid, int sig) {
 	DWORD continue_status = (sig == DBG_EXCEPTION_NOT_HANDLED)
 		? DBG_EXCEPTION_NOT_HANDLED : DBG_EXCEPTION_HANDLED;
 	dbg->tid = w32_select (dbg, pid, tid);
+	r_io_system (dbg->iob.io, sdb_fmt ("pid %d", dbg->tid));
+
+	// Don't continue with a thread that wasn't requested
+	if (dbg->tid != tid) {
+		return false;
+	}
+
 	if (breaked) {
 		breaked = false;
-		return tid;
+		return false;
 	}
 	w32dbg_wrap_instance *inst = rio->inst;
 	inst->params->type = W32_CONTINUE;
@@ -1061,6 +1068,7 @@ int w32_continue(RDebug *dbg, int pid, int tid, int sig) {
 		r_sys_perror ("w32_continue/ContinueDebugEvent");
 		return false;
 	}
+
 	return tid;
 }
 

--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -192,15 +192,14 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	} else if (!strncmp (cmd, "pid", 3)) {
 		if (cmd[3] == ' ') {
 			int pid = atoi (cmd + 3);
-			if (pid > 0 && pid != iop->pi.dwProcessId) {
-				iop->pi.hProcess = OpenProcess (PROCESS_ALL_ACCESS, false, pid);
-				if (iop->pi.hProcess) {
-					iop->pi.dwProcessId = iop->pi.dwThreadId = pid;
+			if (pid > 0 && pid != iop->pi.dwThreadId && pid != iop->pi.dwProcessId) {
+				iop->pi.hThread = OpenThread (PROCESS_ALL_ACCESS, FALSE, pid);
+				if (iop->pi.hThread) {
+					iop->pi.dwThreadId = pid;
 				} else {
 					eprintf ("Cannot attach to %d\n", pid);
 				}
 			}
-			/* TODO: Implement child attach */
 		}
 		return r_str_newf ("%d", iop->pi.dwProcessId);
 	} else {


### PR DESCRIPTION
Previously `!=pid <pid>` attempted to OpenProcess even though the main pid is already opened by __open and the fact that re-opening the main pid wouldn't do anything. This way it attaches to new threads when called by r_debug_select.