### PR TITLE
Implement w32dbg_wrap

### DIFF
--- a/libr/debug/meson.build
+++ b/libr/debug/meson.build
@@ -60,11 +60,12 @@ if host_machine.system() == 'linux'
 endif
 
 if host_machine.system() == 'windows'
- r_debug_sources += [
-  'p/native/maps/windows_maps.c',
-  'p/native/windows/windows_debug.c',
-  'p/native/windows/windows_message.c',
- ]
+  r_debug_sources += [
+    'p/native/maps/windows_maps.c',
+    'p/native/windows/windows_debug.c',
+    'p/native/windows/windows_message.c',
+  ]
+  r_debug_deps += w32dbg_wrap_dep
 endif
 
 if host_machine.system() != 'windows'

--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -422,17 +422,15 @@ int w32_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 	bool alive = __is_thread_alive (dbg, dbg->tid);
 	HANDLE th = rio->pi.hThread;
 	if (!th || th == INVALID_HANDLE_VALUE) {
-		if (alive) {
-			DWORD flags = THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT;
-			if (dbg->bits == R_SYS_BITS_64) {
-					flags |= THREAD_QUERY_INFORMATION;
-			}
-			th = w32_OpenThread (flags, FALSE, dbg->tid);
-			if (!th) {
-				r_sys_perror ("w32_reg_read/OpenThread");
-				return 0;
-			}
-		} else {
+		DWORD flags = THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT;
+		if (dbg->bits == R_SYS_BITS_64) {
+				flags |= THREAD_QUERY_INFORMATION;
+		}
+		th = w32_OpenThread (flags, FALSE, dbg->tid);
+		if (!th && alive) {
+			r_sys_perror ("w32_reg_read/OpenThread");
+		}
+		if (!th) {
 			return 0;
 		}
 	}

--- a/libr/debug/p/native/windows/windows_debug.h
+++ b/libr/debug/p/native/windows/windows_debug.h
@@ -15,6 +15,7 @@
 #include <tlhelp32.h> // CreateToolhelp32Snapshot
 #include <psapi.h> // GetModuleFileNameEx, GetProcessImageFileName
 #include <tchar.h>
+#include <w32dbg_wrap.h>
 
 #ifndef XSTATE_GSSE
 #define XSTATE_GSSE 2
@@ -95,11 +96,6 @@ typedef struct _OBJECT_TYPE_INFORMATION {
 	ULONG PagedPoolUsage;
 	ULONG NonPagedPoolUsage;
 } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
-
-typedef struct {
-	ut64 winbase;
-	PROCESS_INFORMATION pi;
-} RIOW32Dbg;
 
 // thread list
 typedef struct {

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -102,8 +102,11 @@ typedef struct r_io_t {
 	RIOUndo undo;
 	SdbList *plugins;
 	char *runprofile;
-#ifdef USE_PTRACE_WRAP
+#if USE_PTRACE_WRAP
 	struct ptrace_wrap_instance_t *ptrace_wrap;
+#endif
+#if __WINDOWS__
+	struct w32dbg_wrap_instance_t *w32dbg_wrap;
 #endif
 	char *args;
 	void *user;

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -60,6 +60,10 @@ r_io_deps = [
   pth
 ]
 
+if host_machine.system() == 'windows'
+  r_io_deps += w32dbg_wrap_dep
+endif
+
 if host_machine.system() == 'linux'
   r_io_sources += [
     'p/io_r2k_linux.c',

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -650,6 +650,9 @@ if use_ptrace_wrap
   subdir('ptrace-wrap')
 endif
 
+if host_machine.system() == 'windows'
+  subdir('w32dbg_wrap')
+endif
 
 # handle mpc dependency
 mpc_files = [

--- a/shlr/w32dbg_wrap/include/w32dbg_wrap.h
+++ b/shlr/w32dbg_wrap/include/w32dbg_wrap.h
@@ -1,0 +1,54 @@
+#ifndef W32DBG_WRAP
+#define W32DBG_WRAP
+
+typedef enum {
+	W32_NONE,
+	W32_CONTINUE,
+	W32_ATTACH,
+	W32_DETTACH,
+	W32_WAIT,
+	W32_STOP,
+	W32_CALL_FUNC
+} w32dbg_wrap_req;
+
+typedef struct {
+	w32dbg_wrap_req type;
+	DWORD pid;
+	DWORD tid;
+	union {
+		DWORD continue_status;
+		struct {
+			DEBUG_EVENT *de;
+			DWORD wait_time;
+		} wait;
+		struct {
+			int (*func)(void *);
+			void *user;
+		} func;
+	};
+	void *ret;
+	DWORD err;
+} w32dbg_wrap_params;
+
+typedef struct w32dbg_wrap_instance_t {
+	HANDLE debugThread;
+	w32dbg_wrap_params *params;
+	HANDLE request_sem;
+	HANDLE result_sem;
+} w32dbg_wrap_instance;
+
+typedef struct {
+	ULONG_PTR winbase;
+	PROCESS_INFORMATION pi;
+	w32dbg_wrap_instance *inst;
+} RIOW32Dbg;
+
+#define w32dbgw_ret(inst) inst->params->ret
+#define w32dbgw_intret(inst) PtrToInt (w32dbgw_ret(inst))
+#define w32dbgw_err(inst) (SetLastError (inst->params->err), inst->params->err)
+
+w32dbg_wrap_instance *w32dbg_wrap_new(void);
+int w32dbg_wrap_wait_ret(w32dbg_wrap_instance *inst);
+void w32dbg_wrap_fini(w32dbg_wrap_instance *inst);
+
+#endif

--- a/shlr/w32dbg_wrap/meson.build
+++ b/shlr/w32dbg_wrap/meson.build
@@ -1,0 +1,11 @@
+w32dbg_wrap_inc = include_directories('include')
+w32dbg_wrap_src = ['src/w32dbg_wrap.c']
+w32dbg_wrap_lib = static_library(
+  'r2w32dbg_wrap',
+  w32dbg_wrap_src,
+  include_directories : w32dbg_wrap_inc,
+)
+w32dbg_wrap_dep = declare_dependency(
+  link_with : w32dbg_wrap_lib,
+  include_directories: w32dbg_wrap_inc,
+)

--- a/shlr/w32dbg_wrap/src/w32dbg_wrap.c
+++ b/shlr/w32dbg_wrap/src/w32dbg_wrap.c
@@ -1,0 +1,65 @@
+#include <windows.h>
+#include <w32dbg_wrap.h>
+
+static DWORD WINAPI __w32dbg_thread(LPVOID param) {
+	w32dbg_wrap_instance *inst = param;
+	w32dbg_wrap_params *params = inst->params;
+	while (1) {
+		WaitForSingleObject (inst->request_sem, INFINITE);
+		switch (params->type) {
+		case W32_CONTINUE:
+			params->ret = ContinueDebugEvent (params->pid, params->tid, params->continue_status);
+			break;
+		case W32_WAIT:
+			params->ret = WaitForDebugEvent (params->wait.de, params->wait.wait_time);
+			break;
+		case W32_CALL_FUNC:
+			params->ret = params->func.func (params->func.user);
+			break;
+		case W32_ATTACH:
+			params->ret = DebugActiveProcess (params->pid);
+			break;
+		case W32_DETTACH:
+		case W32_STOP:
+			params->ret = DebugActiveProcessStop (params->pid);
+			break;
+		}
+		if (!params->ret) {
+			params->err = GetLastError ();
+		}
+		ReleaseSemaphore (inst->result_sem, 1, NULL);
+		if (params->type == W32_STOP) {
+			break;
+		}
+	}
+	return 0;
+}
+
+w32dbg_wrap_instance *w32dbg_wrap_new(void) {
+	w32dbg_wrap_instance *inst = calloc (1, sizeof (w32dbg_wrap_instance));
+	if (inst) {
+		inst->params = calloc (1, sizeof (w32dbg_wrap_params));
+		if (!inst->params) {
+			return NULL;
+		}
+		inst->request_sem = CreateSemaphore (NULL, 0, 1, NULL);
+		inst->result_sem = CreateSemaphore (NULL, 0, 1, NULL);
+		inst->debugThread = CreateThread (NULL, 0, __w32dbg_thread, inst, 0, NULL);
+	}
+	return inst;
+}
+
+void w32dbg_wrap_fini(w32dbg_wrap_instance *inst) {
+	inst->params->type = W32_STOP;
+	ReleaseSemaphore (inst->request_sem, 1, NULL);
+	CloseHandle (inst->request_sem);
+	CloseHandle (inst->result_sem);
+	free (inst->params);
+	free (inst);
+}
+
+int w32dbg_wrap_wait_ret(w32dbg_wrap_instance *inst) {
+	ReleaseSemaphore (inst->request_sem, 1, NULL);
+	WaitForSingleObject (inst->result_sem, INFINITE);
+	return w32dbgw_intret(inst);
+}


### PR DESCRIPTION
Basically the same as ptrace_wrap, but in windows, only receiving debug events is limited to the thread that started the debug session.