### PR TITLE
sys/asan.sh: Use -fsanitize=... instead of -lasan when linking

### DIFF
--- a/sys/asan.sh
+++ b/sys/asan.sh
@@ -27,8 +27,9 @@ for a in $ASAN ; do
 	export CFLAGS="${CFLAGS} -fsanitize=$a"
 done
 if [ "`uname`" != Darwin ]; then
-	export CFLAGS="${CFLAGS} -lasan"
-	export LDFLAGS="-lasan"
+	for a in $ASAN ; do
+		export LDFLAGS="${LDFLAGS} -fsanitize=$a"
+	done
 fi
 
 echo 'int main(){return 0;}' > .a.c


### PR DESCRIPTION
As per the [instructions](https://clang.llvm.org/docs/AddressSanitizer.html#usage) (and as recommended [here](https://stackoverflow.com/a/40215639) and [here](https://groups.google.com/d/msg/address-sanitizer/SD590XDinfQ/NMUPj_G0BgAJ)). 