### PR TITLE
Add support for printing xmm* as packed floats and doubles

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2558,15 +2558,18 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 	case 'm': // "drm"
 		if (str[1]=='?') {
 			r_core_cmd_help (core, help_msg_drm);
-		} else if (str[1] == ' ' || str[1] == 'b' || str[1] == 'd' || str[1] == 'w' || str[1] == 'q') {
+		} else if (str[1] == ' ' || str[1] == 'b' || str[1] == 'd' || str[1] == 'w' || str[1] == 'q' || str[1] == 'l'
+				   || str[1] == 'f') {
 			char explicit_index = 0;
 			char explicit_size = 0;
 			char explicit_name = 0;
-#define NUM_PACK_TYPES 4
-			int pack_sizes[NUM_PACK_TYPES] = { 8, 16, 32, 64 };
-			char *pack_format[NUM_PACK_TYPES] = { "%s0x%02" PFMT64x, "%s0x%04" PFMT64x, "%s0x%08" PFMT64x, "%s0x%016" PFMT64x };
+#define NUM_PACK_TYPES 6
+#define NUM_INT_PACK_TYPES 4
+			int pack_sizes[NUM_PACK_TYPES] = { 8, 16, 32, 64, 32, 64 };
+			char *pack_format[NUM_PACK_TYPES] = { "%s0x%02" PFMT64x, "%s0x%04" PFMT64x, "%s0x%08" PFMT64x,
+												  "%s0x%016" PFMT64x, "%s%lf" , "%s%lf" };
 #define pack_print(i, reg, pack_type_index) r_cons_printf (pack_format[pack_type_index], i != 0 ? " " : "", reg);
-			char pack_show[NUM_PACK_TYPES] = { 0, 0, 0, 0 };
+			char pack_show[NUM_PACK_TYPES] = { 0, 0, 0, 0, 0, 0};
 			int index = 0;
 			int size = 0; // auto
 			char *q, *p, *name;
@@ -2620,13 +2623,19 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				} else if (str[1] == 'q') { // "drmq"
 					size = pack_sizes[3];
 					pack_show[3] = 1;
+				} else if (str[1] == 'f') { // "drmf"
+					size = pack_sizes[4];
+					pack_show[4] = 1;
+				} else if (str[1] == 'l') { // "drml"
+					size = pack_sizes[5];
+					pack_show[5] = 1;
 				}
 			}
 			if(explicit_name) {
 				// TODO: sanity check index, size against item->packed_size
 				RRegItem *item = r_reg_get(core->dbg->reg, name, -1);
 				if (item) {
-					if (eq) { // TODO: fix setting xmm registers
+					if (eq) {
 						ut64 val = r_num_math(core->num, eq);
 						r_reg_set_pack(core->dbg->reg, item, index, size, val);
 						r_debug_reg_sync(core->dbg, R_REG_TYPE_XMM, true);
@@ -2636,11 +2645,24 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 						// TODO: handle mm
 						if (!explicit_index) {
 							int pi;
+							// TODO: factor out these inner loops
 							for (pi = 0; pi < NUM_PACK_TYPES; pi++) {
 								if (!explicit_size || pack_show[pi]) {
 									for (i = 0; i < item->packed_size / pack_sizes[pi]; i++) {
 										ut64 res = r_reg_get_pack(core->dbg->reg, item, i, pack_sizes[pi]);
-										pack_print (i, res, pi);
+										if( pi > NUM_INT_PACK_TYPES-1)	{ // are we printing int or double?
+											if (pack_sizes[pi] == 64)	{
+												double dres;
+												memcpy ((void*)&dres, (void*)&res, 8);
+												pack_print (i, dres, pi);
+											} else if (pack_sizes[pi] == 32) {
+												float fres;
+												memcpy ((void*)&fres, (void*)&res, 4);
+												pack_print (i, fres, pi);
+											}
+										} else {
+											pack_print (i, res, pi);
+										}
 									}
 									r_cons_printf("\n");
 								}
@@ -2668,11 +2690,24 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 						}
 						int pi;
 						r_cons_printf("%-5s = ", item->name);
+						// TODO: factor out these inner loops
 						for (pi = 0; pi < NUM_PACK_TYPES; pi++) {
 							if (pack_show[pi]) {
 								for (i = 0; i < item->packed_size / pack_sizes[pi]; i++) {
 									ut64 res = r_reg_get_pack(core->dbg->reg, item, i, pack_sizes[pi]);
-									pack_print (i, res, pi);
+									if( pi > NUM_INT_PACK_TYPES-1)	{ // are we printing int or double?
+										if (pack_sizes[pi] == 64)	{
+											double dres;
+											memcpy ((void*)&dres, (void*)&res, 8);
+											pack_print (i, dres, pi);
+										} else if (pack_sizes[pi] == 32) {
+											float fres;
+											memcpy ((void*)&fres, (void*)&res, 4);
+											pack_print (i, fres, pi);
+										}
+									} else {
+										pack_print (i, res, pi);
+									}
 								}
 								r_cons_printf("\n");
 							}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2607,10 +2607,11 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				}
 			} else {
 				explicit_size = 1;
-				if(str[2] == ' ' && str[3] != '\x00')	{
+				if (str[2] == ' ' && str[3] != '\x00')	{
 					name = strdup (str + 3);
 					explicit_name = 1;
 				}
+				// TODO use switch statement here
 				if (str[1] == 'b') { // "drmb"
 					size = pack_sizes[0];
 					pack_show[0] = 1;
@@ -2631,17 +2632,17 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 					pack_show[5] = 1;
 				}
 			}
-			if(explicit_name) {
+			if (explicit_name) {
 				// TODO: sanity check index, size against item->packed_size
-				RRegItem *item = r_reg_get(core->dbg->reg, name, -1);
+				RRegItem *item = r_reg_get (core->dbg->reg, name, -1);
 				if (item) {
 					if (eq) {
-						ut64 val = r_num_math(core->num, eq);
-						r_reg_set_pack(core->dbg->reg, item, index, size, val);
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_XMM, true);
+						ut64 val = r_num_math (core->num, eq);
+						r_reg_set_pack (core->dbg->reg, item, index, size, val);
+						r_debug_reg_sync (core->dbg, R_REG_TYPE_XMM, true);
 					} else {
-						r_debug_reg_sync(core->dbg, R_REG_TYPE_XMM, false);
-						ut64 res = r_reg_get_pack(core->dbg->reg, item, index, size);
+						r_debug_reg_sync (core->dbg, R_REG_TYPE_XMM, false);
+						ut64 res = r_reg_get_pack (core->dbg->reg, item, index, size);
 						// TODO: handle mm
 						if (!explicit_index) {
 							int pi;
@@ -2664,18 +2665,18 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 											pack_print (i, res, pi);
 										}
 									}
-									r_cons_printf("\n");
+									r_cons_newline ();
 								}
 							}
 						} else {
 							// print selected index / wordsize
-							r_cons_printf("0x%08" PFMT64x "\n", res);
+							r_cons_printf ("0x%08" PFMT64x "\n", res);
 						}
 					}
 				} else {
 					eprintf ("cannot find multimedia register '%s'\n", name);
 				}
-				free(name);
+				free (name);
 			} else {
 				// explicit size no name
 				RListIter *iter;
@@ -2689,7 +2690,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 							continue;
 						}
 						int pi;
-						r_cons_printf("%-5s = ", item->name);
+						r_cons_printf ("%-5s = ", item->name);
 						// TODO: factor out these inner loops
 						for (pi = 0; pi < NUM_PACK_TYPES; pi++) {
 							if (pack_show[pi]) {
@@ -2709,7 +2710,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 										pack_print (i, res, pi);
 									}
 								}
-								r_cons_printf("\n");
+								r_cons_newline ();
 							}
 						}
 					}
@@ -2726,7 +2727,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 		if (str[1]=='?') {
 			eprintf ("usage: drf [fpureg] [= value]\n");
 		} else if (str[1]==' ') {
-			char *p, *name = strdup (str+2);
+			char *p, *name = strdup (str + 2);
 			char *eq = strchr (name, '=');
 			if (eq) {
 				*eq++ = 0;
@@ -2780,7 +2781,8 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			rad = str[1];
 			str++;
 			if (rad == 'j' && !str[1]) {
-				r_cons_print("[");
+				// TODO use pj api here
+				r_cons_print ("[");
 				for (i = 0; (name = r_reg_get_type (i)); i++) {
 					if (i) {
 						r_cons_print (",");


### PR DESCRIPTION
This adds support for printing xmm registers as packed floats and doubles.
The `d` was taken already so I am using `drmf` and `drml` right now. (better cmd name feedback appreciated).

A problem I see right now is that I got two pretty identical inner loops, and I am unsure about where to put a function to refactor them out. maybe into `debug_native.c` or stay in `cmd_debug.c` ?
And also maybe not `memcpy`ing but doing a `r_reg_get_pack_double` etc?

```
r2 -d radare2-regressions/bins/elf/allxmm -c "16ds; drmf" 
Process with PID 22572 started...
xmm0  = 1.100000 2.200000 3.300000 4.400000
xmm1  = 5.500000 6.600000 7.700000 8.800000
xmm2  = 0.300000 1.300000 2.300000 3.300000
xmm3  = 0.400000 1.400000 2.400000 3.400000
xmm4  = 0.500000 1.500000 2.500000 3.500000
xmm5  = 0.600000 1.600000 2.600000 3.600000
xmm6  = 0.700000 1.700000 2.700000 3.700000
xmm7  = 8.100000 8.200000 8.300000 8.400000
xmm8  = 9.100000 9.200000 9.300000 9.400000
xmm9  = 10.100000 10.200000 10.300000 10.400000
xmm10 = 11.100000 11.200000 11.300000 11.400000
xmm11 = 12.100000 12.200000 12.300000 12.400000
xmm12 = 13.100000 13.200000 13.300000 13.400000
xmm13 = 14.100000 14.200000 14.300000 14.400000
xmm14 = 15.100000 15.200000 15.300000 15.400000
xmm15 = 16.100000 16.200001 16.299999 16.400000
[0x004000f9]> drml
xmm0  = 3.600001 921.600220
xmm1  = 19660.800823 235929.656720
xmm2  = 0.043750 76.800003
xmm3  = 0.075000 102.400040
xmm4  = 0.125000 128.000031
xmm5  = 0.225000 179.199982
xmm6  = 0.400000 230.400055
xmm7  = 157286.406741 183500.781747
xmm8  = 314572.813544 367001.563556
xmm9  = 629145.627209 734003.127234
xmm10 = 1258291.254663 1468006.254712
xmm11 = 2516582.509814 2936012.509912
xmm12 = 5033165.020605 5872025.020801
xmm13 = 10066330.043164 11744050.043555
xmm14 = 20132660.090234 23488100.091016
xmm15 = 36909896.187891 40265320.188672
```