### PR TITLE
Make the generated r2.bat use bat path_relative syntax instead of hardcoding

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -170,7 +170,7 @@ def win_dist(args):
     r2_bat_fname = args.install + r'\bin\r2.bat'
     log.debug('create "%s"', r2_bat_fname)
     with open(r2_bat_fname, 'w') as r2_bat:
-        r2_bat.write('@"%s\\bin\\radare2" %%*\n' % os.path.abspath(args.install))
+        r2_bat.write('@"%~dp0\\radare2" %*\n')
 
     copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}\bin')
     makedirs(r'{DIST}\{R2_LIBDIR}')


### PR DESCRIPTION
This makes calling `r2.bat` from the path (or should be anywhere else) "just work" as long as radare2 is in the same directory.

This produces an `r2.bat` like:

```bat
@"%~dp0\radare2" %*
```