### PR TITLE
sys/meson.py: Use -fsanitize=... instead of -lasan when linking

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -306,7 +306,7 @@ def main():
           ldflags = os.environ.get('LDFLAGS')
           if not ldflags:
               ldflags = ''
-          os.environ['LDFLAGS'] = ldflags + ' -lasan'
+          os.environ['LDFLAGS'] = ldflags + ' -fsanitize=address'
 
     # Check arguments
     if args.pull:


### PR DESCRIPTION
Like #15375 but for Meson.