### PR TITLE
Sync default sanitizer list of sys/asan.sh and sys/meson.py

### DIFF
--- a/sys/asan.sh
+++ b/sys/asan.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # ASAN="address leak memory undefined"
-ASAN=${ASAN:="address undefined signed-integer-overflow"}
+# ASAN="address signed-integer-overflow"  # Faster build
+ASAN=${ASAN:="address undefined"}
 
 printf "\033[32m"
 echo "========================================================================="

--- a/sys/asan.sh
+++ b/sys/asan.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # ASAN="address leak memory undefined"
 # ASAN="address signed-integer-overflow"  # Faster build
-ASAN=${ASAN:="address undefined"}
+ASAN=${ASAN:="address undefined signed-integer-overflow"}
 
 printf "\033[32m"
 echo "========================================================================="

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -299,7 +299,7 @@ def main():
             log.error("Asan insupported under OpenBSD")
             sys.exit(1)
         # sanitizers = 'address,signed-integer-overflow'  # Faster build
-        sanitizers = 'address,undefined'
+        sanitizers = 'address,undefined,signed-integer-overflow'
         cflags = os.environ.get('CFLAGS')
         if not cflags:
             cflags = ''

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -298,15 +298,17 @@ def main():
         if os.uname().sysname == 'OpenBSD':
             log.error("Asan insupported under OpenBSD")
             sys.exit(1)
+        # sanitizers = 'address,signed-integer-overflow'  # Faster build
+        sanitizers = 'address,undefined'
         cflags = os.environ.get('CFLAGS')
         if not cflags:
             cflags = ''
-        os.environ['CFLAGS'] = cflags + ' -fsanitize=address'
+        os.environ['CFLAGS'] = cflags + ' -fsanitize=' + sanitizers
         if os.uname().sysname != 'Darwin':
           ldflags = os.environ.get('LDFLAGS')
           if not ldflags:
               ldflags = ''
-          os.environ['LDFLAGS'] = ldflags + ' -fsanitize=address'
+          os.environ['LDFLAGS'] = ldflags + ' -fsanitize=' + sanitizers
 
     # Check arguments
     if args.pull:


### PR DESCRIPTION
Also, the [manual](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks) says that `-fsanitize=undefined` implies `-fsanitize=signed-integer-overflow` (confirmed with gcc 9.2.1).