### PR TITLE
Avoid switching threads for irrelevant events in windows ##debug

### DIFF
--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1188,6 +1188,7 @@ repeat:
 		if (reason == R_DEBUG_REASON_NEW_LIB ||
 			reason == R_DEBUG_REASON_EXIT_LIB ||
 			reason == R_DEBUG_REASON_NEW_TID ||
+			reason == R_DEBUG_REASON_NONE ||
 			reason == R_DEBUG_REASON_EXIT_TID ) {
 			goto repeat;
 		}

--- a/shlr/w32dbg_wrap/include/w32dbg_wrap.h
+++ b/shlr/w32dbg_wrap/include/w32dbg_wrap.h
@@ -41,6 +41,8 @@ typedef struct {
 	ULONG_PTR winbase;
 	PROCESS_INFORMATION pi;
 	w32dbg_wrap_instance *inst;
+	// Stores the TID of the thread DebugBreakProcess creates to ignore it's breakpoint
+	DWORD break_tid;
 } RIOW32Dbg;
 
 #define w32dbgw_ret(inst) inst->params->ret


### PR DESCRIPTION
Currently, the debugger has to switch threads to handle each event but it never returns to the thread that the user originally ran continue on. This results in a pretty confusing and annoying debugging experience. Plus, breaking the current task suspends execution twice because DebugBreakProcess' breakpoint is triggered once you continue, forcing you to run continue twice each time you break.

These changes handle break's behavior to avoid bothering the user and set R_DEBUG_REASON_[NEW_TID, EXIT_TID, NEW_LIB, EXIT_LIB] as events that don't require switching to the effected thread.

@GustavoLCR 