### PR TITLE
Automatically set the debug plugin when opening debug uris

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -907,9 +907,11 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 			swstep = false;
 		}
 		r_config_set_i (r->config, "dbg.swstep", swstep);
-		// Set the correct debug plugin
-		if (fd->plugin && fd->plugin->name && fd->plugin->isdbg) {
-			r_debug_use (r->dbg, fd->plugin->name);
+		// Set the correct debug handle
+		if (fd->plugin && fd->plugin->isdbg) {
+			const char *dh = strndup(file, (strstr(file, "://") - file));
+			r_debug_use (r->dbg, dh);
+			free(dh);
 		}
 	}
 	//used by r_core_bin_load otherwise won't load correctly

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -909,10 +909,10 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 		r_config_set_i (r->config, "dbg.swstep", swstep);
 		// Set the correct debug handle
 		if (fd->plugin && fd->plugin->isdbg) {
-			const char *dh = r_str_ndup (file, (strstr (file, "://") - file));
+			char *dh = r_str_ndup (file, (strstr (file, "://") - file));
 			if (dh) {
 				r_debug_use (r->dbg, dh);
-				free(dh);
+				free (dh);
 			}
 		}
 	}

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -907,6 +907,10 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 			swstep = false;
 		}
 		r_config_set_i (r->config, "dbg.swstep", swstep);
+		// Set the correct debug plugin
+		if (fd->plugin && fd->plugin->name && fd->plugin->isdbg) {
+			r_debug_use (r->dbg, fd->plugin->name);
+		}
 	}
 	//used by r_core_bin_load otherwise won't load correctly
 	//this should be argument of r_core_bin_load <shrug>

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -909,9 +909,11 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 		r_config_set_i (r->config, "dbg.swstep", swstep);
 		// Set the correct debug handle
 		if (fd->plugin && fd->plugin->isdbg) {
-			const char *dh = strndup(file, (strstr(file, "://") - file));
-			r_debug_use (r->dbg, dh);
-			free(dh);
+			const char *dh = r_str_ndup (file, (strstr (file, "://") - file));
+			if (dh) {
+				r_debug_use (r->dbg, dh);
+				free(dh);
+			}
 		}
 	}
 	//used by r_core_bin_load otherwise won't load correctly


### PR DESCRIPTION
closes #15399 

Solves the gdbserver issue and fixes errors that might derive from forgetting `dL` or setting the wrong debug handler.