### PR TITLE
Fix leaddrs leak

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -173,6 +173,7 @@ R_API RAnal *r_anal_new(void) {
 	anal->fcn_tree = NULL;
 	anal->fcn_addr_tree = NULL;
 	anal->refs = r_anal_ref_list_new ();
+	anal->leaddrs = NULL;
 	r_anal_set_bits (anal, 32);
 	anal->plugins = r_list_newf ((RListFree) r_anal_plugin_free);
 	if (anal->plugins) {
@@ -213,6 +214,7 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	r_rbtree_free (a->rb_hints_ranges, __anal_hint_range_tree_free);
 	ht_up_free (a->dict_refs);
 	ht_up_free (a->dict_xrefs);
+	r_list_free (a->leaddrs);
 	a->sdb = NULL;
 	sdb_ns_free (a->sdb);
 	if (a->esil) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -894,6 +894,8 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 			}
 		}
 	} while (fcnlen != R_ANAL_RET_END);
+	r_list_free (core->anal->leaddrs);
+	core->anal->leaddrs = NULL;
 	if (has_next) {
 		for (i = 0; i < nexti; i++) {
 			if (!next[i] || r_anal_get_fcn_in (core->anal, next[i], 0)) {
@@ -913,6 +915,8 @@ static int core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth
 	return true;
 
 error:
+	r_list_free (core->anal->leaddrs);
+	core->anal->leaddrs = NULL;
 	// ugly hack to free fcn
 	if (fcn) {
 		if (!r_anal_fcn_size (fcn) || fcn->addr == UT64_MAX) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -728,6 +728,7 @@ typedef struct r_anal_t {
 	RList *imports; // global imports
 	SetU *visited;
 	RStrConstPool constpool;
+	RList *leaddrs;
 } RAnal;
 
 typedef struct r_anal_hint_t {


### PR DESCRIPTION
Fixes the following leak:

```
$ r2 bins/elf/analysis/ls-alxchk 
[0x00005e24]> s main; aF
[0x00003bd0]> q

...

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7fa5815d4ca8 in __interceptor_malloc (/lib64/libasan.so.5+0x10dca8)
    #1 0x7fa57df8c06e in fcn_recurse ../libr/anal/fcn.c:1017
    #2 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #3 0x7fa57df8de3f in fcn_recurse ../libr/anal/fcn.c:1190
    #4 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #5 0x7fa57df8de3f in fcn_recurse ../libr/anal/fcn.c:1190
    #6 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #7 0x7fa57df8de3f in fcn_recurse ../libr/anal/fcn.c:1190
    #8 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #9 0x7fa57df8de3f in fcn_recurse ../libr/anal/fcn.c:1190
    #10 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #11 0x7fa57df8d503 in fcn_recurse ../libr/anal/fcn.c:1135
    #12 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #13 0x7fa57df8de3f in fcn_recurse ../libr/anal/fcn.c:1190
    #14 0x7fa57df90005 in r_anal_fcn_bb ../libr/anal/fcn.c:1404
    #15 0x7fa57df91219 in r_anal_fcn ../libr/anal/fcn.c:1566
    #16 0x7fa57ed38529 in core_anal_fcn ../libr/core/canal.c:791
    #17 0x7fa57ed41ca1 in r_core_anal_fcn ../libr/core/canal.c:1898
    #18 0x7fa57ee68b65 in cmd_anal ../libr/core/cmd_anal.c:9767
    #19 0x7fa57ef1f71c in r_cmd_call ../libr/core/cmd_api.c:244
    #20 0x7fa57ef12348 in r_core_cmd_subst_i ../libr/core/cmd.c:3642
    #21 0x7fa57ef0a317 in r_core_cmd_subst ../libr/core/cmd.c:2520
    #22 0x7fa57ef0a6c4 in r_core_cmd_subst ../libr/core/cmd.c:2552
    #23 0x7fa57ef185c5 in r_core_cmd ../libr/core/cmd.c:4477
    #24 0x7fa57ef3c9c7 in r_core_prompt_exec ../libr/core/core.c:3102
    #25 0x7fa5811441c7 in r_main_radare2 ../libr/main/radare2.c:1459
    #26 0x4014c3 in main ../binr/radare2/radare2.c:95
    #27 0x7fa580f791a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)

...
```