### PR TITLE
Refactor r_flag_color() to r_flag_item_set_color()

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -1134,7 +1134,7 @@ rep:
 			}
 			fi = r_flag_get (core->flags, arg);
 			if (fi) {
-				ret = r_flag_color (core->flags, fi, color);
+				ret = r_flag_item_set_color (fi, color);
 				if (!color && ret)
 					r_cons_println (ret);
 			} else {

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -3824,7 +3824,7 @@ onemoretime:
 				r_cons_flush ();
 				r_line_set_prompt ("color: ");
 				if (r_cons_fgets (cmd, sizeof (cmd)-1, 0, NULL) > 0) {
-					r_flag_color (core->flags, item, cmd);
+					r_flag_item_set_color (item, cmd);
 					r_cons_set_raw (1);
 					r_cons_show_cursor (false);
 				}

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -765,6 +765,14 @@ R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname) {
 	item->realname = R_STR_ISEMPTY (realname)? NULL: strdup (realname);
 }
 
+/* add/replace/remove the color of a flag item */
+R_API const char *r_flag_item_set_color(RFlagItem *item, const char *color) {
+	r_return_val_if_fail (item, NULL);
+	free (item->color);
+	item->color = (color && *color) ? strdup (color) : NULL;
+	return item->color;
+}
+
 /* change the name of a flag item, if the new name is available.
  * true is returned if everything works well, false otherwise */
 R_API int r_flag_rename(RFlag *f, RFlagItem *item, const char *name) {
@@ -883,16 +891,6 @@ R_API bool r_flag_move(RFlag *f, ut64 at, ut64 to) {
 		return true;
 	}
 	return false;
-}
-
-R_API const char *r_flag_color(RFlag *f, RFlagItem *it, const char *color) {
-	r_return_val_if_fail (f && it, NULL);
-	if (!color) {
-		return it->color;
-	}
-	free (it->color);
-	it->color = *color ? strdup (color) : NULL;
-	return it->color;
 }
 
 // BIND

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -120,6 +120,7 @@ R_API void r_flag_item_set_alias(RFlagItem *item, const char *alias);
 R_API void r_flag_item_free (RFlagItem *item);
 R_API void r_flag_item_set_comment(RFlagItem *item, const char *comment);
 R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname);
+R_API const char *r_flag_item_set_color(RFlagItem *item, const char *color);
 R_API RFlagItem *r_flag_item_clone(RFlagItem *item);
 R_API int r_flag_unset_glob(RFlag *f, const char *name);
 R_API int r_flag_rename(RFlag *f, RFlagItem *item, const char *name);


### PR DESCRIPTION
To be consistent with `r_flag_item_set_realname()`, etc. The RFlag arg was completely unused.