### PR TITLE
Use free() instead of R_FREE() in r_list_free()

### DIFF
--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -80,7 +80,7 @@ R_API void r_list_purge(RList *list) {
 R_API void r_list_free(RList *list) {
 	if (list) {
 		r_list_purge (list);
-		R_FREE (list);
+		free (list);
 	}
 }
 


### PR DESCRIPTION
Since pointers are passed-by-value, setting `list` to NULL using `R_FREE` actually has no effect in the calling function, and can mislead code readers.