### PR TITLE
Fix typo in ios-syscalls.txt

### DIFF
--- a/libr/include/sflib/darwin-arm-64/ios-syscalls.txt
+++ b/libr/include/sflib/darwin-arm-64/ios-syscalls.txt
@@ -1,5 +1,5 @@
 1	__exit
-1	__exit
+2	fork
 3	read
 4	write
 5	__open


### PR DESCRIPTION
`__exit` was listed twice with same number (1), and fork was missing.

Reference:
https://github.com/apple/darwin-xnu/blob/a449c6a3b8014d9406c2ddbdc81795da24aa7443/bsd/kern/syscalls.master