### PR TITLE
Fix broken pkg uninstall command on macOS

### DIFF
--- a/doc/macos.md
+++ b/doc/macos.md
@@ -88,7 +88,7 @@ To create a macOS .pkg just run the following command:
 Uninstall
 ---------
 
-To uninstall the .pkg downloaded from the r2 website or the one you have generated with `sys/osx-pkg.sh`
+To uninstall the .pkg downloaded from the r2 website or the one you have generated with `sys/osx-pkg.sh`, run the following as root:
 
-	$ pkgutil --only-files --files radare2.pkg | tr '\n' '\0' | xargs -n 1 -0 sudo rm -i
+	$ pkgutil --only-files --files org.radare.radare2 | sed 's/^/\//' | tr '\n' '\0' | xargs -o -n 1 -0 rm -i
 


### PR DESCRIPTION
I tried to clean up my r2 install on macOS 10.15.1 before building the latest version it from master.
The old r2 install was installed using [radare2-4.0.0.pkg](https://radare.mikelloc.com/get/4.0.0/radare2-4.0.0.pkg).
The command to uninstall in the docs did not execute properly, but succeeds with the following changes:

- Provide a proper package ID to get rid of the following error: `No receipt for 'radare2.pkg' found at '/'.`
- Prepend a `/` for each returned path by the `pkgutil` command, to make it an absolute path instead of a relative one.
- Avoid invoking the `sudo` command for each file, which speeds up the command significantly.