### PR TITLE
Improve macOS installation documentation

### DIFF
--- a/doc/macos.md
+++ b/doc/macos.md
@@ -21,7 +21,7 @@ To install bindings you will need to install r2, valac, valabind and swig. The w
 Code Signing
 ------------
 
-After Mac OS X 10.6, binaries that need permissions to debug require to be signed and include a .plist describing them. In order to do this you can follow the following steps:
+After Mac OS X 10.6, binaries that need permissions to debug require to be signed and include a .plist describing them. The aforementioned `install.sh` script will install a new code signing certificate into the system keychain and sign r2 with it. Alternatively, you can manually create a code signing certificate by following the following steps:
 
 (Based on https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt)
 
@@ -44,7 +44,6 @@ After Mac OS X 10.6, binaries that need permissions to debug require to be signe
 1. Switch to Terminal, and run the following:
 1. $ sudo security add-trust -d -r trustRoot -p basic -p codeSign -k /Library/Keychains/System.keychain ~/Desktop/org.radare.radare2.cer
 1. $ rm -f ~/Desktop/org.radare.radare2.cer
-1. Drag the "org.radare.radare2" certificate from the "System" keychain back into the "login" keychain
 1. Quit Keychain Access
 1. Reboot
 1. Run sys/install.sh (or follow the next steps if you want to install and sign radare2 manually)


### PR DESCRIPTION
Avoid ambiguous signing certificates on macOS.
If a user manually installed a new code signing certificate into the
login keychain as documented, the install script will fail to sign r2 
because the `sys/macos-cert.sh` script generates a new certificate in
the System keychain. This results in the following error when signing:
```
org.radare.radare2: ambiguous (matches "org.radare.radare2" in /Users/user/Library/Keychains/login.keychain-db and "org.radare.radare2" in /Library/Keychains/System.keychain)
```
To be constistent with `sys/macos-cert.sh`, change manual certificate
generation steps to install to System keychain instead of login
keychain.

Mention that code signing certificate generation is automated by the
install script before listing the manual steps to generate a new
code signing certificate.