### PR TITLE
Add breaking to gdbr connect to avoid waiting on invalid connections

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -850,6 +850,9 @@ R_API RCoreFile *r_core_file_open(RCore *r, const char *file, int flags, ut64 lo
 	}
 	r->io->bits = r->assembler->bits; // TODO: we need an api for this
 	RIODesc *fd = r_io_open_nomap (r->io, file, flags, 0644);
+	if (r_cons_is_breaked()) {
+		goto beach;
+	}
 	if (!fd && openmany) {
 		// XXX - make this an actual option somewhere?
 		fh = r_core_file_open_many (r, file, flags, loadaddr);

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -135,6 +135,7 @@ end:
 int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	const char *message = "qSupported:multiprocess+;qRelocInsn+;xmlRegisters=i386";
 	int ret, i;
+
 	if (!g || !host) {
 		return -1;
 	}
@@ -164,8 +165,9 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	}
 	read_packet (g, true); // vcont=true lets us skip if we get no reply
 	g->connected = 1;
+	void *bed = r_cons_sleep_begin ();
 	// TODO add config possibility here
-	for (i = 0; i < QSUPPORTED_MAX_RETRIES; i++) {
+	for (i = 0; i < QSUPPORTED_MAX_RETRIES && !_isbreaked; i++) {
 		ret = send_msg (g, message);
 		if (ret < 0) {
 			continue;
@@ -179,6 +181,12 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 			continue;
 		}
 		break;
+	}
+	r_cons_sleep_end (bed);
+	if (_isbreaked) {
+		_isbreaked = false;
+		ret = -1;
+		goto end;
 	}
 	if (ret < 0) {
 		goto end;


### PR DESCRIPTION
R2 will hang while waiting for any resolvable port to respond(even if it's not actually gdbserver, which is okay since you're verifying gdbserver's handshake), this takes a long while since read_packet has a high number of retries and the entire connection process is attempted twice in r_core_file_open. This is currently also an issue in [1874](https://github.com/radareorg/cutter/pull/1874) since it freezes cutter without any way to suspend the task.

Testing:

Start a valid tcp server with `nc -l -p 12345`, connect using `e cfg.debug=true; o+ gdb://127.0.0.1:12345` and attempt to break during the first/second connection attempt. 