### PR TITLE
Add support for Mach-O external relocs ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2892,8 +2892,56 @@ static int reloc_comparator(struct reloc_t *a, struct reloc_t *b) {
 	return a->addr - b->addr;
 }
 
+static void parse_relocation_info (struct MACH0_(obj_t) *bin, RSkipList * relocs, ut32 offset, ut32 num) {
+	if (!num || !offset) {
+		return;
+	}
+
+	ut64 total_size = num * sizeof (struct relocation_info);
+	struct relocation_info *info = calloc (1, total_size);
+	if (!info) {
+		return;
+	}
+
+	if (r_buf_read_at (bin->b, offset, (ut8 *) info, total_size) < total_size) {
+		R_FREE (info);
+		return;
+	}
+
+	int i;
+	for (i = 0; i < num; i++) {
+		struct relocation_info a_info = info[i];
+		ut32 sym_num = a_info.r_symbolnum;
+		if (sym_num > bin->nsymtab) {
+			continue;
+		}
+
+		ut32 stridx = bin->symtab[sym_num].n_strx;
+		char *sym_name = get_name (bin, stridx, false);
+		if (!sym_name) {
+			continue;
+		}
+
+		struct reloc_t *reloc = R_NEW0 (struct reloc_t);
+		if (!reloc) {
+			return;
+		}
+
+		reloc->addr = offset_to_vaddr (bin, a_info.r_address);
+		reloc->offset = a_info.r_address;
+		reloc->ord = sym_num;
+		reloc->type = a_info.r_type; // enum RelocationInfoType
+		reloc->external = a_info.r_extern;
+		reloc->pc_relative = a_info.r_pcrel;
+		reloc->size = a_info.r_length;
+		r_str_ncpy (reloc->name, sym_name, 256);
+
+		r_skiplist_insert (relocs, reloc);
+	}
+}
+
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
-	RSkipList *relocs;
+	RSkipList *relocs = NULL;
 	ulebr ur = {NULL};
 	int wordsize = MACH0_(get_bits)(bin) / 8;
 	if (bin->dyld_info) {
@@ -3097,25 +3145,42 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 			}
 		}
 		R_FREE (opcodes);
-	} else {
+	}
+
+	if (bin->symtab && bin->symstr && bin->sects && bin->indirectsyms) {
 		int j;
-		if (!bin->symtab || !bin->symstr || !bin->sects || !bin->indirectsyms) {
-			return NULL;
-		}
 		int amount = bin->dysymtab.nundefsym;
 		if (amount < 0) {
 			amount = 0;
 		}
-		relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
 		if (!relocs) {
-			return NULL;
+			relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
+			if (!relocs) {
+				return NULL;
+			}
 		}
 		for (j = 0; j < amount; j++) {
 			struct reloc_t *reloc = R_NEW0 (struct reloc_t);
+			if (!reloc) {
+				break;
+			}
 			if (parse_import_ptr (bin, reloc, bin->dysymtab.iundefsym + j)) {
 				reloc->ord = j;
+				r_skiplist_insert (relocs, reloc);
+			} else {
+				R_FREE (reloc);
 			}
 		}
+	}
+
+	if (bin->symtab && bin->dysymtab.extreloff && bin->dysymtab.nextrel) {
+		if (!relocs) {
+			relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
+			if (!relocs) {
+				return NULL;
+			}
+		}
+		parse_relocation_info (bin, relocs, bin->dysymtab.extreloff, bin->dysymtab.nextrel);
 	}
 beach:
 	return relocs;

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2898,13 +2898,13 @@ static void parse_relocation_info (struct MACH0_(obj_t) *bin, RSkipList * relocs
 	}
 
 	ut64 total_size = num * sizeof (struct relocation_info);
-	struct relocation_info *info = calloc (1, total_size);
+	struct relocation_info *info = calloc (num, sizeof (struct relocation_info));
 	if (!info) {
 		return;
 	}
 
 	if (r_buf_read_at (bin->b, offset, (ut8 *) info, total_size) < total_size) {
-		R_FREE (info);
+		free (info);
 		return;
 	}
 

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -71,6 +71,9 @@ struct reloc_t {
 	int ord;
 	int last;
 	char name[256];
+	bool external;
+	bool pc_relative;
+	ut8 size;
 };
 
 struct addr_t {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -7,6 +7,7 @@
 #include "../i/private.h"
 #include "mach0/mach0.h"
 #include "objc/mach0_classes.h"
+#include <sdb/ht_uu.h>
 
 // wip settings
 
@@ -409,6 +410,9 @@ static RList *relocs(RBinFile *bf) {
 	RSkipListNode *it;
 	struct reloc_t *reloc;
 	r_skiplist_foreach (relocs, it, reloc) {
+		if (reloc->external) {
+			continue;
+		}
 		RBinReloc *ptr = NULL;
 		if (!(ptr = R_NEW0 (RBinReloc))) {
 			break;
@@ -501,6 +505,179 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->has_pi = MACH0_(is_pie) (bf->o->bin_obj);
 	ret->has_nx = MACH0_(has_nx) (bf->o->bin_obj);
 	return ret;
+}
+
+static bool _patch_reloc(struct MACH0_(obj_t) *bin, RIOBind *iob, struct reloc_t * reloc, ut64 symbol_at) {
+	ut64 pc = reloc->addr;
+	ut64 ins_len = 0;
+
+	switch (bin->hdr.cputype) {
+	case CPU_TYPE_X86_64: {
+		switch (reloc->type) {
+		case X86_64_RELOC_UNSIGNED:
+			break;
+		case X86_64_RELOC_BRANCH:
+			pc -= 1;
+			ins_len = 5;
+			break;
+		default:
+			eprintf ("Warning: unsupported reloc type for X86_64 (%d), please file a bug.\n", reloc->type);
+			return false;
+		}
+		break;
+	}
+	case CPU_TYPE_ARM64:
+	case CPU_TYPE_ARM64_32:
+		pc = reloc->addr & ~3;
+		ins_len = 4;
+		break;
+	case CPU_TYPE_ARM:
+		break;
+	default:
+		eprintf ("Warning: unsupported architecture for patching relocs, please file a bug. %s\n", MACH0_(get_cputype_from_hdr)(&bin->hdr));
+		return false;
+	}
+
+	ut64 val = symbol_at;
+	if (reloc->pc_relative) {
+		val = symbol_at - pc - ins_len;
+	}
+
+	ut8 buf[8];
+	r_write_ble(buf, val, false, reloc->size * 8);
+	iob->write_at (iob->io, reloc->addr, buf, reloc->size);
+
+	return true;
+}
+
+static RList* patch_relocs(RBin *b) {
+	RList *ret = NULL;
+	RIO *io = NULL;
+	RBinObject *obj = NULL;
+	struct MACH0_(obj_t) *bin = NULL;
+	RIOMap *g = NULL, *s = NULL;
+	HtUU *relocs_by_sym = NULL;
+	SdbListIter *iter;
+	RBinInfo *info;
+	int cdsz;
+	ut64 n_vaddr, vaddr, size, offset = 0;
+	RIODesc *gotr2desc = NULL;
+
+	if (!b) {
+		return NULL;
+	}
+	io = b->iob.io;
+	if (!io || !io->desc)
+		return NULL;
+	obj = r_bin_cur_object (b);
+	if (!obj) {
+		return NULL;
+	}
+	bin = obj->bin_obj;
+
+	RSkipList * all_relocs = MACH0_(get_relocs)(bin);
+	if (!all_relocs) {
+		return NULL;
+	}
+	RList * ext_relocs = r_list_new ();
+	if (!ext_relocs) {
+		goto beach;
+	}
+	RSkipListNode *it;
+	struct reloc_t * reloc;
+	r_skiplist_foreach (all_relocs, it, reloc) {
+		if (!reloc->external) {
+			continue;
+		}
+		r_list_append (ext_relocs, reloc);
+	}
+	int num_ext_relocs = r_list_length (ext_relocs);
+	if (!num_ext_relocs) {
+		goto beach;
+	}
+
+	if (!io->cached) {
+		eprintf ("Warning: run r2 with -e io.cache=true to fix relocations in disassembly\n");
+		goto beach;
+	}
+
+	info = obj ? obj->info: NULL;
+	cdsz = info? info->bits / 8 : 8;
+
+	ls_foreach (io->maps, iter, s) {
+		if (s->itv.addr > offset) {
+			offset = s->itv.addr;
+			g = s;
+		}
+	}
+	if (!g) {
+		goto beach;
+	}
+	n_vaddr = g->itv.addr + g->itv.size;
+	size = num_ext_relocs * cdsz;
+	char *muri = r_str_newf ("malloc://%" PFMT64u, size);
+	gotr2desc = b->iob.open_at (io, muri, R_PERM_R, 0664, n_vaddr);
+	free (muri);
+	if (!gotr2desc) {
+		goto beach;
+	}
+
+	RIOMap *gotr2map = b->iob.map_get (io, n_vaddr);
+	if (!gotr2map) {
+		goto beach;
+	}
+	gotr2map->name = strdup (".got.r2");
+
+	if (!(ret = r_list_newf ((RListFree)free))) {
+		goto beach;
+	}
+	HtUUOptions opt = { 0 };
+	if (!(relocs_by_sym = ht_uu_new_opt (&opt))) {
+		goto beach;
+	}
+	vaddr = n_vaddr;
+	RListIter *liter;
+	r_list_foreach (ext_relocs, liter, reloc) {
+		ut64 sym_addr = 0;
+		sym_addr = ht_uu_find (relocs_by_sym, reloc->ord, NULL);
+		if (!sym_addr) {
+			sym_addr = vaddr;
+			ht_uu_insert (relocs_by_sym, reloc->ord, vaddr);
+			vaddr += cdsz;
+		}
+		if (!_patch_reloc (bin, &b->iob, reloc, sym_addr)) {
+			continue;
+		}
+		RBinReloc *ptr = NULL;
+		if (!(ptr = R_NEW0 (RBinReloc))) {
+			goto beach;
+		}
+		ptr->type = reloc->type;
+		ptr->additive = 0;
+		RBinImport *imp;
+		if (!(imp = import_from_name (b, (char*) reloc->name, bin->imports_by_name))) {
+			R_FREE (ptr);
+			goto beach;
+		}
+		ptr->vaddr = sym_addr;
+		ptr->import = imp;
+		r_list_append (ret, ptr);
+	}
+	if (!r_list_length (ret)) {
+		goto beach;
+	}
+	ht_uu_free (relocs_by_sym);
+	r_list_free (ext_relocs);
+	r_skiplist_free (all_relocs);
+	return ret;
+
+beach:
+	r_list_free (ext_relocs);
+	r_skiplist_free (all_relocs);
+	r_io_desc_free (gotr2desc);
+	r_list_free (ret);
+	ht_uu_free (relocs_by_sym);
+	return NULL;
 }
 
 #if !R_BIN_MACH064
@@ -840,6 +1017,7 @@ RBinPlugin r_bin_plugin_mach0 = {
 	.fields = MACH0_(mach_fields),
 	.libs = &libs,
 	.relocs = &relocs,
+	.patch_relocs = &patch_relocs,
 	.create = &create,
 	.classes = &MACH0_(parse_classes),
 	.write = &r_bin_write_mach0,

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -586,7 +586,7 @@ static RList* patch_relocs(RBin *b) {
 		}
 		r_list_append (ext_relocs, reloc);
 	}
-	int num_ext_relocs = r_list_length (ext_relocs);
+	ut64 num_ext_relocs = r_list_length (ext_relocs);
 	if (!num_ext_relocs) {
 		goto beach;
 	}

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -544,7 +544,7 @@ static bool _patch_reloc(struct MACH0_(obj_t) *bin, RIOBind *iob, struct reloc_t
 	}
 
 	ut8 buf[8];
-	r_write_ble(buf, val, false, reloc->size * 8);
+	r_write_ble (buf, val, false, reloc->size * 8);
 	iob->write_at (iob->io, reloc->addr, buf, reloc->size);
 
 	return true;
@@ -562,8 +562,9 @@ static RList* patch_relocs(RBin *b) {
 	r_return_val_if_fail (b, NULL);
 
 	io = b->iob.io;
-	if (!io || !io->desc)
+	if (!io || !io->desc) {
 		return NULL;
+	}
 	obj = r_bin_cur_object (b);
 	if (!obj) {
 		return NULL;

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -298,6 +298,7 @@ RBinPlugin r_bin_plugin_mach064 = {
 	.libs = &libs,
 	.header = &MACH0_(mach_headerfields),
 	.relocs = &relocs,
+	.patch_relocs = &patch_relocs,
 	.fields = &MACH0_(mach_fields),
 	.create = &create,
 	.classes = &MACH0_(parse_classes),


### PR DESCRIPTION
Add initial support for parsing and patching Mach-O relocs. It supports only the arch / reloc type combinations i've been able to test, but at least it's a starting point.

As i ported the patching code from ELF plugin, the way it works it's more or less the same. So to enable relocs patching, the binary should be opened like this:

```
r2 -e io.cache=true /path/to/binary
```

Fixes https://github.com/radareorg/radare2/issues/15279
