### PR TITLE
Add r_th_lock_tryenter

### DIFF
--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -109,6 +109,7 @@ R_API void r_th_sem_wait(RThreadSemaphore *sem);
 R_API RThreadLock *r_th_lock_new(bool recursive);
 R_API int r_th_lock_wait(RThreadLock *th);
 R_API int r_th_lock_check(RThreadLock *thl);
+R_API int r_th_lock_tryenter(RThreadLock *thl);
 R_API int r_th_lock_enter(RThreadLock *thl);
 R_API int r_th_lock_leave(RThreadLock *thl);
 R_API void *r_th_lock_free(RThreadLock *thl);

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -45,6 +45,17 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 	return ++thl->refs;
 }
 
+R_API int r_th_lock_tryenter(RThreadLock *thl) {
+#if HAVE_PTHREAD
+	if (pthread_mutex_trylock (&thl->lock) == 0) {
+#elif __WINDOWS__
+	if (TryEnterCriticalSection (&thl->lock)) {
+#endif
+		return ++thl->refs;
+	}
+	return 0;
+}
+
 R_API int r_th_lock_leave(RThreadLock *thl) {
 #if HAVE_PTHREAD
 	pthread_mutex_unlock (&thl->lock);


### PR DESCRIPTION
r_th_lock_check only returns the refcount which isn't enough to know if the current thread is holding the mutex when a recursive mutex is enabled. This is useful in places like [gdbr's read registers](https://github.com/radareorg/radare2/blob/master/shlr/gdb/src/gdbclient/core.c#L671) that might be called recursively.