### PR TITLE
Fix for #15459

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -2227,7 +2227,7 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 					if (op->operands[1].offset > 127) {
 						data[l++] = 0x80 | op->operands[0].reg << 3 | op->operands[1].regs[0];
 					} else {
-						data[l++] = 0x40 | op->operands[1].regs[0];
+						data[l++] = 0x40 | op->operands[0].reg << 3 | op->operands[1].regs[0];
 					}
 				}
 				if (op->operands[1].offset > 127) {

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -2224,11 +2224,8 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 				if (op->operands[1].regs[0] == X86R_RIP) {
 					data[l++] = 0x5;
 				} else {
-					if (op->operands[1].offset > 127) {
-						data[l++] = 0x80 | op->operands[0].reg << 3 | op->operands[1].regs[0];
-					} else {
-						data[l++] = 0x40 | op->operands[0].reg << 3 | op->operands[1].regs[0];
-					}
+					const ut8 pfx = (op->operands[1].offset > 127)? 0x80: 0x40;
+					data[l++] = pfx | op->operands[0].reg << 3 | op->operands[1].regs[0];
 				}
 				if (op->operands[1].offset > 127) {
 					mod = 0x1;


### PR DESCRIPTION
The x86 assembler wasn't setting the first operand on mov instructions from memory with an offset correctly. This fixes that. See #15459 for more details.