### PR TITLE
Fixes to graphviz related code

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1595,7 +1595,7 @@ static int core_anal_graph_construct_nodes (RCore *core, RAnalFunction *fcn, int
                                                 : (current && color_current)
                                                 ? pal_curr
                                                 : pal_box4;
-                                        const char *fill_color = (current || label_color == pal_traced)? pal_traced: "white";
+                                        const char *fill_color = ((current && color_current) || label_color == pal_traced)? pal_traced: "white";
                                         nodes++;
                                         if (is_star) {
                                                 char *title = get_title (bbi->addr);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1319,7 +1319,7 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                         free(from);
                                         free(to);
                                 } else {
-                                        r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
+                                        r_cons_printf ("        \"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                         "[color=\"%s\"];\n", bbi->addr, bbi->jump,
                                                         bbi->fail != -1 ? pal_jump : pal_trfa);
                                         core_anal_color_curr_node (core, bbi);
@@ -1340,7 +1340,7 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                         free(from);
                                         free(to);
                                 } else {
-                                        r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
+                                        r_cons_printf ("        \"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                         "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
                                         core_anal_color_curr_node (core, bbi);
                                 }
@@ -1363,7 +1363,7 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                                 free(from);
                                                 free(to);
                                         } else {
-                                                r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
+                                                r_cons_printf ("        \"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                                        "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
                                                 core_anal_color_curr_node (core, bbi);
                                         }
@@ -1392,7 +1392,7 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                                 free(from);
                                                 free(to);
                                         } else {
-                                                r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" " \
+                                                r_cons_printf ("        \"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" " \
                                                 "[color2=\"%s\"];\n", caseop->addr, caseop->jump, pal_fail);
                                                 core_anal_color_curr_node (core, bbi);
                                         }

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1311,36 +1311,36 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                 r_cons_printf ("<div class=\"connector _0x%08"PFMT64x" _0x%08"PFMT64x"\">\n"
                                         "  <img class=\"connector-end\" src=\"img/arrow.gif\" /></div>\n",
                                         bbi->addr, bbi->jump);
-                                } else if (!is_json && !is_keva) {
-                                        if (is_star) {
-                                                char *from = get_title (bbi->addr);
-                                                char *to = get_title (bbi->jump);
-                                                r_cons_printf ("age %s %s\n", from, to);
-                                        } else {
-                                                r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
-                                                               "[color=\"%s\"];\n", bbi->addr, bbi->jump,
-                                                               bbi->fail != -1 ? pal_jump : pal_trfa);
-                                                core_anal_color_curr_node (core, bbi);
-                                        }
+                        } else if (!is_json && !is_keva) {
+                                if (is_star) {
+                                        char *from = get_title (bbi->addr);
+                                        char *to = get_title (bbi->jump);
+                                        r_cons_printf ("age %s %s\n", from, to);
+                                } else {
+                                        r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
+                                                        "[color=\"%s\"];\n", bbi->addr, bbi->jump,
+                                                        bbi->fail != -1 ? pal_jump : pal_trfa);
+                                        core_anal_color_curr_node (core, bbi);
                                 }
+                        }
                 }
                 if (bbi->fail != -1) {
                         nodes++;
                         if (is_html) {
                                 r_cons_printf ("<div class=\"connector _0x%08"PFMT64x" _0x%08"PFMT64x"\">\n"
-                                                       "  <img class=\"connector-end\" src=\"img/arrow.gif\"/></div>\n",
-                                                       bbi->addr, bbi->fail);
-                                } else if (!is_keva && !is_json) {
-                                        if (is_star) {
-                                                char *from = get_title (bbi->addr);
-                                                char *to = get_title (bbi->fail);
-                                                r_cons_printf ("age %s %s\n", from, to);
-                                        } else {
-                                                r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
-                                                               "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
-                                                core_anal_color_curr_node (core, bbi);
-                                        }
+                                                    "  <img class=\"connector-end\" src=\"img/arrow.gif\"/></div>\n",
+                                                    bbi->addr, bbi->fail);
+                        } else if (!is_keva && !is_json) {
+                                if (is_star) {
+                                        char *from = get_title (bbi->addr);
+                                        char *to = get_title (bbi->fail);
+                                        r_cons_printf ("age %s %s\n", from, to);
+                                } else {
+                                        r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
+                                                        "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
+                                        core_anal_color_curr_node (core, bbi);
                                 }
+                        }
                 }
                 if (bbi->switch_op) {
                         RAnalCaseOp *caseop;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1316,6 +1316,8 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                         char *from = get_title (bbi->addr);
                                         char *to = get_title (bbi->jump);
                                         r_cons_printf ("age %s %s\n", from, to);
+                                        free(from);
+                                        free(to);
                                 } else {
                                         r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                         "[color=\"%s\"];\n", bbi->addr, bbi->jump,
@@ -1335,6 +1337,8 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                         char *from = get_title (bbi->addr);
                                         char *to = get_title (bbi->fail);
                                         r_cons_printf ("age %s %s\n", from, to);
+                                        free(from);
+                                        free(to);
                                 } else {
                                         r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                         "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
@@ -1356,6 +1360,8 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                                 char *from = get_title (bbi->addr);
                                                 char *to = get_title (bbi->fail);
                                                 r_cons_printf ("%age %s %s\n", from, to);
+                                                free(from);
+                                                free(to);
                                         } else {
                                                 r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" "
                                                                        "[color=\"%s\"];\n", bbi->addr, bbi->fail, pal_fail);
@@ -1383,6 +1389,8 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                                                 char *from = get_title (caseop->addr);
                                                 char *to = get_title (caseop->jump);
                                                 r_cons_printf ("age %s %s\n", from ,to);
+                                                free(from);
+                                                free(to);
                                         } else {
                                                 r_cons_printf ("\t\"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" " \
                                                 "[color2=\"%s\"];\n", caseop->addr, caseop->jump, pal_fail);
@@ -1392,6 +1400,9 @@ static int core_anal_graph_construct_edges (RCore *core, RAnalFunction *fcn, int
                         }
                 }
         }
+        free(pal_jump);
+        free(pal_fail);
+        free(pal_trfa);
         return nodes;
 }
 


### PR DESCRIPTION
`d05e816 `: The current block in graphviz output is highlighted even when `graph.gv.current` is `false`. Added a logical check to fix it.
`f5e3f60 `: else if blocks are off by one indentation level