### PR TITLE
Added correct parsing for all gdb registers and fixed writing multiple registers in gdbr for reverse stepping

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -486,7 +486,6 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 				"gpr	foseg	.32	164	0\n"
 				"gpr	fooff	.32	168	0\n"
 				"gpr	fop	.32	172	0\n"
-			/* Commented until the long registers will be implemented
 				"gpr	xmm0	.128	176	0\n"
 				"gpr	xmm1	.128	192	0\n"
 				"gpr	xmm2	.128	208	0\n"
@@ -496,7 +495,6 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 				"gpr	xmm6	.128	272	0\n"
 				"gpr	xmm7	.128	288	0\n"
 				"gpr	mxcsr	.32	304	0\n"
-			*/
 				);
 		} else if (dbg->anal->bits == 64) {
 			return strdup (
@@ -549,25 +547,23 @@ static const char *r_debug_gdb_reg_profile(RDebug *dbg) {
 				"gpr	foseg	.32	264	0\n"
 				"gpr	fooff	.32	268	0\n"
 				"gpr	fop	.32	272	0\n"
-			/* Commented until the long registers will be implemented
-				"gpr	xmm0	.128	276	0\n"
-				"gpr	xmm1	.128	292	0\n"
-				"gpr	xmm2	.128	308	0\n"
-				"gpr	xmm3	.128	324	0\n"
-				"gpr	xmm4	.128	340	0\n"
-				"gpr	xmm5	.128	356	0\n"
-				"gpr	xmm6	.128	372	0\n"
-				"gpr	xmm7	.128	388	0\n"
-				"gpr	xmm8	.128	404	0\n"
-				"gpr	xmm9	.128	420	0\n"
-				"gpr	xmm10	.128	436	0\n"
-				"gpr	xmm11	.128	452	0\n"
-				"gpr	xmm12	.128	468	0\n"
-				"gpr	xmm13	.128	484	0\n"
-				"gpr	xmm14	.128	500	0\n"
-				"gpr	xmm15	.128	516	0\n"
-				"gpr	mxcsr	.32	532	0\n"
-			*/
+				"fpu	xmm0	.128	276	0\n"
+				"fpu	xmm1	.128	292	0\n"
+				"fpu	xmm2	.128	308	0\n"
+				"fpu	xmm3	.128	324	0\n"
+				"fpu	xmm4	.128	340	0\n"
+				"fpu	xmm5	.128	356	0\n"
+				"fpu	xmm6	.128	372	0\n"
+				"fpu	xmm7	.128	388	0\n"
+				"fpu	xmm8	.128	404	0\n"
+				"fpu	xmm9	.128	420	0\n"
+				"fpu	xmm10	.128	436	0\n"
+				"fpu	xmm11	.128	452	0\n"
+				"fpu	xmm12	.128	468	0\n"
+				"fpu	xmm13	.128	484	0\n"
+				"fpu	xmm14	.128	500	0\n"
+				"fpu	xmm15	.128	516	0\n"
+				"fpu	mxcsr	.32	532	0\n"
 			);
 		} else {
 			return strdup (

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -94,7 +94,7 @@ int gdbr_read_registers(libgdbr_t *g);
  * i.e. eax=0x123,ebx=0x234
  * \returns a failurre code (currently -1) or 0 if call successfully
  */
-int gdbr_write_bin_registers(libgdbr_t *g);
+int gdbr_write_bin_registers(libgdbr_t *g, const char *regs, int len);
 int gdbr_write_reg(libgdbr_t *g, const char *name, char *value, int len);
 int gdbr_write_register(libgdbr_t *g, int index, char *value, int len);
 int gdbr_write_registers(libgdbr_t *g, char *registers);

--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -27,7 +27,6 @@ gdb_reg_t gdb_regs_x86_64[] = {
 	{ "es", 152, 4 },
 	{ "fs", 156, 4 },
 	{ "gs", 160, 4 },
-/* Commented until the long registers are implemented
 	{ "st0", 164, 10 },
 	{ "st1", 174, 10 },
 	{ "st2", 184, 10 },
@@ -61,7 +60,6 @@ gdb_reg_t gdb_regs_x86_64[] = {
 	{ "xmm14", 500, 16 },
 	{ "xmm15", 516, 16 },
 	{ "mxcsr", 532, 4 },
-*/
 	{ "", 0, 0 }
 };
 
@@ -83,7 +81,6 @@ gdb_reg_t gdb_regs_x86_32[] = {
 	{ "es", 52, 4 },
 	{ "fs", 56, 4 },
 	{ "gs", 60, 4 },
-/* Commented until the long registers are implemented
 	{ "st0", 64, 10 },
 	{ "st1", 74, 10 },
 	{ "st2", 84, 10 },
@@ -109,7 +106,6 @@ gdb_reg_t gdb_regs_x86_32[] = {
 	{ "xmm6", 272, 16 },
 	{ "xmm7", 288, 16 },
 	{ "mxcsr", 304, 4 },
-*/
 	{ "", 0, 0 }
 };
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -965,9 +965,9 @@ end:
 	return ret;
 }
 
-int gdbr_write_bin_registers(libgdbr_t *g){
+int gdbr_write_bin_registers(libgdbr_t *g, const char *regs, int len) {
 	int ret = -1;
-	uint64_t buffer_size;
+	uint64_t buffer_size = 0;
 	char *command = NULL;
 
 	if (!g) {
@@ -978,7 +978,7 @@ int gdbr_write_bin_registers(libgdbr_t *g){
 		goto end;
 	}
 
-	buffer_size = g->data_len * 2 + 8;
+	buffer_size = len * 2 + 8;
 	reg_cache.valid = false;
 
 	command = calloc (buffer_size, sizeof (char));
@@ -987,7 +987,7 @@ int gdbr_write_bin_registers(libgdbr_t *g){
 		goto end;
 	}
 	snprintf (command, buffer_size, "%s", CMD_WRITEREGS);
-	pack_hex (g->data, g->data_len, command + 1);
+	pack_hex (regs, len, command + 1);
 	if (send_msg (g, command) < 0) {
 		ret = -1;
 		goto end;
@@ -1078,7 +1078,7 @@ int gdbr_write_reg(libgdbr_t *g, const char *name, char *value, int len) {
 	// Use 'G' if write_register failed/isn't supported
 	gdbr_read_registers (g);
 	memcpy (g->data + g->registers[i].offset, value, len);
-	gdbr_write_bin_registers (g);
+	gdbr_write_bin_registers (g, g->data, g->data_len);
 
 	ret = 0;
 end:


### PR DESCRIPTION
Writing registers with gdbr worked with single registers because reg_next_diff started at delta 0 and only had to run the diff once for the single register that was changed. When running reverse stepping/continue multiple registers are changed at once so r_reg_next_diff would fail every time due to incorrect offset calculation. The new r_reg_next_diff also supports diff'ing different register sizes to restore all registers correctly.
The endianity swapping part from reg_write isn't needed since the arena is the return value of 'g' which is already in the correct target byte order (see: https://sourceware.org/gdb/onlinedocs/gdb/Packets.html#read-registers-packet).

Also, fixed and improved r_reg_next_diff which is currently only used by qnx and gdb but could be adopted in windbg(and probably qnx doesn't work as well but I am not sure how to set it up on my machine, wouldn't mind doing it with some guidance).

ref #8966 - reverse debugging still isn't ideal but this makes it functional. `dcb` doesn't work for some reason and multiple `dsb` set invalid registers at some point, I'll try to look into both issues later.

I have attached an example xml file as a reference to the new parsing additions:
[gdbclient_xml.txt](https://github.com/radareorg/radare2/files/3860911/gdbclient_xml.txt)