### PR TITLE
Fix anal.timeout calculation in r_cons_break_timeout

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -390,7 +390,7 @@ R_API void r_cons_break_timeout(int timeout) {
 		I.timeout = 0;
 	} else {
 		if (timeout) {
-			I.timeout = r_sys_now () + (timeout * 1000000);
+			I.timeout = r_sys_now () + ((ut64) timeout << 20);
 		} else {
 			I.timeout = 0;
 		}


### PR DESCRIPTION
anal.timeout is calculated by r_sys_now() + timeout value in seconds. Since r_sys_now() provides the current time in the format [44 bit seconds][20 bit micro seconds], the timeout value must be shifted 20 bits to the left (as done in r_sys_now) instead of multiplying by 1000000. Besides, timeout is a signed integer so even "short" timeout values like 1h (3600 seconds) result in an integer overflow when multiplied by 1000000. This causes unexpected behavior.