### PR TITLE
Fix #15498 - Fix stdcall stack calling convention

### DIFF
--- a/libr/anal/d/cc-x86-32.sdb.txt
+++ b/libr/anal/d/cc-x86-32.sdb.txt
@@ -17,7 +17,7 @@ cc.optlink.argn=stack
 cc.optlink.ret=eax
 
 stdcall=cc
-cc.stdcall.argn=stack_rev
+cc.stdcall.argn=stack
 cc.stdcall.ret=eax
 
 fastcall=cc


### PR DESCRIPTION
R2R: https://github.com/radareorg/radare2-regressions/pull/2025