### PR TITLE
Switch labeler to periodic-labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,14 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+  schedule:
+    - cron: '*/30 * * * *'
 
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: paulfantom/periodic-labeler@v0.0.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        LABEL_MAPPINGS_FILE: .github/labeler.yml


### PR DESCRIPTION
With https://github.com/actions/labeler/issues/12 being an issue, the action's labeler is useless for PRs that come from a fork.
This one runs on a cron timer instead and doesn't suffer from the same issue.