### PR TITLE
Include last line when greping using foo~n..

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -285,7 +285,7 @@ while_end:
 			if (p[2]) {
 				grep->l_line = r_num_get (cons->num, p + 2);
 			} else {
-				grep->l_line = -1;
+				grep->l_line = 0;
 			}
 		}
 	}
@@ -584,7 +584,7 @@ R_API void r_cons_grepbuf() {
 		if (grep->f_line < 0) {
 			grep->f_line = total_lines + grep->f_line;
 		}
-		if (grep->l_line < 0) {
+		if (grep->l_line <= 0) {
 			grep->l_line = total_lines + grep->l_line;
 		}
 	}


### PR DESCRIPTION
Line range is exclusive so setting end to -1 results in last line being skipped.

After the changes doing `foo~:n..` shows all the lines starting with n until end.

Minor side effect is that `~:0..0` shows full range instead of empty. If it's necessary to support interpreting `n..0` as empty range the values stored in parsed grep description can be offset by one. That would make the code less obvious in my opinion.

Tests in radareorg/radare2-regressions#2030