### PR TITLE
ONE_STREAM_HACK & scr.onestream: Force expected ONE_STREAM order if necessary

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ install:
 build_script:
   - appveyor AddMessage "Compiling radare2 %R2_VERSION% (%builder%)"
 
-  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && python sys\meson.py --backend vs2017 --release --xp --install="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && set CL=/DONE_STREAM_HACK#1 && python sys\meson.py --backend vs2017 --release --xp --install="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
   - cmd: if %builder% == vs2019_64 ( choco install mingw && refreshenv && set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && python sys\meson.py --backend vs2019 --release --install="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 

--- a/libr/asm/meson.build
+++ b/libr/asm/meson.build
@@ -183,7 +183,7 @@ r_asm_inc = [
 
 r_asm = library('r_asm', r_asm_sources,
   include_directories: r_asm_inc,
-  c_args: library_cflags,
+  c_args: library_cflags + ['-DR_ASM_SRC=1'],
   dependencies: [
     r_util_dep,
     r_syscall_dep,

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -130,7 +130,7 @@ r_bin_inc = [platform_inc, include_directories('mangling', 'format')]
 
 r_bin = library('r_bin', r_bin_sources,
   include_directories: r_bin_inc,
-  c_args: ['-DR_API_BIN_ONLY=1'] + library_cflags,
+  c_args: ['-DR_API_BIN_ONLY=1'] + library_cflags + ['-DR_BIN_SRC=1'],
   dependencies: [
     r_util_dep,
     r_io_dep,

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -562,6 +562,7 @@ R_API RCons *r_cons_new() {
 #endif
 	I.pager = NULL; /* no pager by default */
 	I.mouse = 0;
+	I.onestream = false;
 	I.show_vals = false;
 	r_cons_reset ();
 	r_cons_rgb_init ();
@@ -1137,6 +1138,24 @@ R_API int r_cons_printf(const char *format, ...) {
 
 	return 0;
 }
+
+#if ONE_STREAM_HACK
+R_API int r_cons_onestream_printf(const char *format, ...) {
+	va_list ap;
+	if (!format || !*format) {
+		return -1;
+	}
+	va_start (ap, format);
+	if (I.onestream) {
+		r_cons_printf_list (format, ap);
+	} else {
+		vfprintf (stderr, format, ap);
+	}
+	va_end (ap);
+
+	return 0;
+}
+#endif
 
 R_API int r_cons_get_column() {
 	char *line = strrchr (I.context->buffer, '\n');

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2297,6 +2297,12 @@ static bool cb_teefile(void *user, void *data) {
 	return true;
 }
 
+static bool cb_onestream(void *user, void *data) {
+	RConfigNode *node = (RConfigNode *) data;
+	r_cons_singleton ()->onestream = node->i_value;
+	return true;
+}
+
 static bool cb_trace(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -3580,6 +3586,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETDESC (n, "Convert string before display");
 	SETOPTIONS (n, "asciiesc", "asciidot", NULL);
 	SETPREF ("scr.confirmquit", "false", "Confirm on quit");
+	SETCB ("scr.onestream", "false", &cb_onestream, "Force stderr output into stdout (works only if -DONE_STREAM_HACK=1)");
 
 	/* str */
 	SETCB ("str.escbslash", "false", &cb_str_escbslash, "Escape the backslash");

--- a/libr/egg/meson.build
+++ b/libr/egg/meson.build
@@ -16,7 +16,7 @@ r_egg_sources = [
 
 r_egg = library('r_egg', r_egg_sources,
   include_directories: [platform_inc],
-  c_args: library_cflags,
+  c_args: library_cflags + ['-DR_EGG_SRC=1'],
   dependencies: [
     r_util_dep,
     r_asm_dep,

--- a/libr/flag/meson.build
+++ b/libr/flag/meson.build
@@ -6,7 +6,7 @@ r_flag_sources = [
 
 r_flag = library('r_flag', r_flag_sources,
   include_directories: [platform_inc],
-  c_args: library_cflags,
+  c_args: library_cflags + ['-DR_FLAG_SRC=1'],
   dependencies: [
     r_util_dep
   ],

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -524,6 +524,7 @@ typedef struct r_cons_t {
 	bool click_set;
 	int click_x;
 	int click_y;
+	bool onestream;
 	bool show_vals;		// show which section in Vv
 	// TODO: move into instance? + avoid unnecessary copies
 } RCons;
@@ -1194,6 +1195,13 @@ typedef struct r_panels_root_t {
 
 #ifdef __cplusplus
 }
+#endif
+
+#if ONE_STREAM_HACK && !R_UTIL_SRC && !R_SEARCH_SRC && !R_FLAG_SRC && !R_BIN_SRC \
+	&& !R_JAVA_SRC && !R_ASM_SRC && !R_EGG_SRC
+R_API int r_cons_onestream_printf(const char *format, ...);
+#undef eprintf
+#define eprintf(...) r_cons_onestream_printf(__VA_ARGS__)
 #endif
 
 #endif

--- a/libr/search/meson.build
+++ b/libr/search/meson.build
@@ -12,7 +12,7 @@ r_search_sources = [
 
 r_search = library('r_search', r_search_sources,
   include_directories: [platform_inc],
-  c_args: library_cflags,
+  c_args: library_cflags + ['-DR_SEARCH_SRC=1'],
   dependencies: [r_util_dep],
   install: true,
   implicit_include_directories: false,

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -91,7 +91,7 @@ endif
 
 r_util = library('r_util', r_util_sources,
   include_directories: platform_inc,
-  c_args: library_cflags,
+  c_args: library_cflags + ['-DR_UTIL_SRC=1'],
   dependencies: r_util_deps,
   install: true,
   implicit_include_directories: false,

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -360,6 +360,7 @@ java_inc = [platform_inc, include_directories('java')]
 
 libr2java = static_library('r2java', java_files,
   include_directories: java_inc,
+  c_args: ['-DR_JAVA_SRC=1'],
   implicit_include_directories: false
 )
 


### PR DESCRIPTION
Attempted workaround for failed build in https://ci.appveyor.com/project/radareorg/radare2/builds/29154687 ([failed test](https://ci.appveyor.com/project/radareorg/radare2/builds/29154687/job/vh1aixjlkvke5ni8#L14453)). Example of expected order is [here](https://github.com/kazarmy/radare2-regressions/blob/6cb2fd1901422297bc26ef0bf7d38a4ba7b0ddb8/new/db/cmd/cmd_pd#L1057-L1063).