### PR TITLE
Fix sj current position marker after buffer wrapping.

### DIFF
--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -558,7 +558,7 @@ static int cmd_seek(void *data, const char *input) {
 				if (name && *name) {
 					pj_ks (pj, "name", name);
 				}
-				if (core->io->undo.idx == i) {
+				if (core->io->undo.undos == i) {
 					pj_kb (pj, "current", true);
 				}
 				pj_end (pj);


### PR DESCRIPTION
One more seek history bug missed in previous PR.
Test was added in last commit of radareorg/radare2-regressions#2028 .

Lesson test everything, features that are not tested will not work.