### PR TITLE
Add user Pointer to RBNodeFree

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -71,7 +71,7 @@ static int __anal_hint_range_tree_cmp(const void *a_, const RBNode *b_, void *us
 	return 0;
 }
 
-static void __anal_hint_range_tree_free(RBNode *node) {
+static void __anal_hint_range_tree_free(RBNode *node, void *user) {
 	free (container_of (node, RAnalRange, rb));
 }
 
@@ -211,7 +211,7 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	r_syscall_free (a->syscall);
 	r_reg_free (a->reg);
 	r_anal_op_free (a->queued);
-	r_rbtree_free (a->rb_hints_ranges, __anal_hint_range_tree_free);
+	r_rbtree_free (a->rb_hints_ranges, __anal_hint_range_tree_free, NULL);
 	ht_up_free (a->dict_refs);
 	ht_up_free (a->dict_xrefs);
 	r_list_free (a->leaddrs);
@@ -771,7 +771,7 @@ R_API void r_anal_merge_hint_ranges(RAnal *a) {
 		SdbKv *kv;
 		SdbList *sdb_range = sdb_foreach_list (a->sdb_hints, true);
 		int range_bits = 0;
-		r_rbtree_free (a->rb_hints_ranges, __anal_hint_range_tree_free);
+		r_rbtree_free (a->rb_hints_ranges, __anal_hint_range_tree_free, NULL);
 		a->rb_hints_ranges = NULL;
 		ls_foreach (sdb_range, iter, kv) {
 			ut64 addr = sdb_atoi (sdbkv_key (kv) + 5);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -230,12 +230,12 @@ R_API bool r_anal_fcn_tree_delete(RAnal *anal, RAnalFunction *fcn) {
 }
 
 R_API void r_anal_fcn_tree_insert(RAnal *anal, RAnalFunction *fcn) {
-	r_rbtree_aug_insert (&anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp, _fcn_tree_calc_max_addr, NULL);
+	r_rbtree_aug_insert (&anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp, NULL, _fcn_tree_calc_max_addr);
 	r_rbtree_insert (&anal->fcn_addr_tree, fcn, &(fcn->addr_rb), _fcn_addr_tree_cmp, NULL);
 }
 
 static void _fcn_tree_update_size(RAnal *anal, RAnalFunction *fcn) {
-	r_rbtree_aug_update_sum (anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp, _fcn_tree_calc_max_addr, NULL);
+	r_rbtree_aug_update_sum (anal->fcn_tree, fcn, &(fcn->rb), _fcn_tree_cmp, NULL, _fcn_tree_calc_max_addr);
 }
 
 #if 0

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -183,7 +183,7 @@ static void _fcn_tree_calc_max_addr(RBNode *node) {
 	}
 }
 
-static void _fcn_tree_free(RBNode *node) {
+static void _fcn_tree_free(RBNode *node, void *user) {
 	// TODO RB tree is an intrusive data structure by embedding RBNode into RAnalFunction.
 	// Currently fcns takes the ownership of the resources.
 	// If the ownership transfers from fcns to fcn_tree:
@@ -219,8 +219,8 @@ static RBNode *_fcn_tree_probe(FcnTreeIter *it, RBNode *x_, ut64 from, ut64 to) 
 }
 
 R_API bool r_anal_fcn_tree_delete(RAnal *anal, RAnalFunction *fcn) {
-	bool ret_min = !!r_rbtree_aug_delete (&anal->fcn_tree, fcn, _fcn_tree_cmp, _fcn_tree_free, _fcn_tree_calc_max_addr, NULL);
-	bool ret_addr = !!r_rbtree_delete (&anal->fcn_addr_tree, fcn, _fcn_addr_tree_cmp, NULL, NULL);
+	bool ret_min = !!r_rbtree_aug_delete (&anal->fcn_tree, fcn, _fcn_tree_cmp, NULL, _fcn_tree_free, NULL, _fcn_tree_calc_max_addr);
+	bool ret_addr = !!r_rbtree_delete (&anal->fcn_addr_tree, fcn, _fcn_addr_tree_cmp, NULL, NULL, NULL);
 	if (ret_min != ret_addr) {
 		eprintf ("WARNING: r_anal_fcn_tree_delete: check 'ret_min == ret_addr' failed\n");
 		return false;

--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -26,7 +26,7 @@ static int reloc_cmp(const void *a, const RBNode *b, void *user) {
 	return 0;
 }
 
-static void reloc_free(RBNode *rbn) {
+static void reloc_free(RBNode *rbn, void *user) {
 	free (container_of (rbn, RBinReloc, vrb));
 }
 
@@ -38,7 +38,7 @@ static void object_delete_items(RBinObject *o) {
 	r_list_free (o->fields);
 	r_list_free (o->imports);
 	r_list_free (o->libs);
-	r_rbtree_free (o->relocs, reloc_free);
+	r_rbtree_free (o->relocs, reloc_free, NULL);
 	r_list_free (o->sections);
 	r_list_free (o->strings);
 	ht_up_free (o->strings_db);
@@ -420,7 +420,7 @@ R_IPI RBNode *r_bin_object_patch_relocs(RBin *bin, RBinObject *o) {
 		if (!tmp) {
 			return o->relocs;
 		}
-		r_rbtree_free (o->relocs, reloc_free);
+		r_rbtree_free (o->relocs, reloc_free, NULL);
 		REBASE_PADDR (o, tmp, RBinReloc);
 		o->relocs = list2rbtree (tmp);
 		first = false;

--- a/libr/include/r_util/r_rbtree.h
+++ b/libr/include/r_util/r_rbtree.h
@@ -23,7 +23,11 @@ typedef struct r_rb_node_t {
 
 typedef RBNode* RBTree;
 
-typedef int (*RBComparator)(const void *incoming, const RBNode *in_tree, void *user);		//here needs to be a void *user
+// incoming < in_tree  => return < 0
+// incoming == in_tree => return == 0
+// incoming > in_tree  => return > 0
+typedef int (*RBComparator)(const void *incoming, const RBNode *in_tree, void *user);
+
 typedef void (*RBNodeFree)(RBNode *node, void *user);
 typedef void (*RBNodeSum)(RBNode *node);
 
@@ -52,8 +56,8 @@ typedef struct r_containing_rb_tree_t {
 // Routines for augmented red-black trees. The user should provide an aggregation (monoid sum) callback `sum`
 // to calculate extra information such as size, sum, ...
 R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user, RBNodeSum sum);
-R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user);
-R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user);
+R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, void *cmp_user, RBNodeSum sum);
+R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBComparator cmp, void *cmp_user, RBNodeSum sum);
 
 R_API bool r_rbtree_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user);
 R_API RBNode *r_rbtree_find(RBNode *root, void *data, RBComparator cmp, void *user);

--- a/libr/include/r_util/r_rbtree.h
+++ b/libr/include/r_util/r_rbtree.h
@@ -24,8 +24,8 @@ typedef struct r_rb_node_t {
 typedef RBNode* RBTree;
 
 typedef int (*RBComparator)(const void *incoming, const RBNode *in_tree, void *user);		//here needs to be a void *user
-typedef void (*RBNodeFree)(RBNode *);
-typedef void (*RBNodeSum)(RBNode *);
+typedef void (*RBNodeFree)(RBNode *node, void *user);
+typedef void (*RBNodeSum)(RBNode *node);
 
 typedef struct r_rb_iter_t {
 	// current depth
@@ -51,13 +51,13 @@ typedef struct r_containing_rb_tree_t {
 
 // Routines for augmented red-black trees. The user should provide an aggregation (monoid sum) callback `sum`
 // to calculate extra information such as size, sum, ...
-R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, RBNodeFree freefn, RBNodeSum sum, void *user);
+R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user, RBNodeSum sum);
 R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user);
 R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user);
 
-R_API bool r_rbtree_delete(RBNode **root, void *data, RBComparator cmp, RBNodeFree freefn, void *user);
+R_API bool r_rbtree_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user);
 R_API RBNode *r_rbtree_find(RBNode *root, void *data, RBComparator cmp, void *user);
-R_API void r_rbtree_free(RBNode *root, RBNodeFree freefn);
+R_API void r_rbtree_free(RBNode *root, RBNodeFree freefn, void *user);
 R_API void r_rbtree_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, void *user);
 // Return the smallest node that is greater than or equal to `data`
 R_API RBNode *r_rbtree_lower_bound(RBNode *root, void *data, RBComparator cmp, void *user);

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -175,7 +175,7 @@ R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, void
 }
 
 // Returns true if stuff got inserted, else false
-R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user) {
+R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, void *cmp_user, RBNodeSum sum) {
 	node->child[0] = node->child[1] = NULL;
 	if (!*root) {
 		*root = node;
@@ -220,7 +220,7 @@ R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBCompar
 		if (done) {
 			break;
 		}
-		d = cmp (data, q, user);
+		d = cmp (data, q, cmp_user);
 		t = g;
 		g = p;
 		p = q;
@@ -247,7 +247,7 @@ R_API bool r_rbtree_aug_insert(RBNode **root, void *data, RBNode *node, RBCompar
 }
 
 // returns true if the sum has been updated, false if node has not been found
-R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBComparator cmp, RBNodeSum sum, void *user) {
+R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBComparator cmp, void *cmp_user, RBNodeSum sum) {
 	int dep = 0;
 	RBNode *path[R_RBTREE_MAX_HEIGHT];
 	RBNode *cur = root;
@@ -265,7 +265,7 @@ R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBCom
 			break;
 		}
 
-		int d = cmp (data, cur, user);
+		int d = cmp (data, cur, cmp_user);
 		if (d < 0) {
 			cur = cur->child[0];
 		} else {
@@ -306,7 +306,7 @@ R_API void r_rbtree_free(RBNode *x, RBNodeFree freefn, void *user) {
 }
 
 R_API void r_rbtree_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, void *user) {
-	r_rbtree_aug_insert (root, data, node, cmp, NULL, user);
+	r_rbtree_aug_insert (root, data, node, cmp, user, NULL);
 }
 
 R_API RBNode *r_rbtree_lower_bound(RBNode *x, void *data, RBComparator cmp, void *user) {
@@ -447,7 +447,7 @@ R_API bool r_rbtree_cont_insert(RContRBTree *tree, void *data, RContRBCmp cmp, v
 	RCRBCmpWrap cmp_wrap = { cmp, NULL, user };
 	RBNode *root_node = &tree->root->node;
 	const bool ret = r_rbtree_aug_insert (&root_node, incoming_node,
-		&incoming_node->node, cont_rbtree_cmp_wrapper, NULL, &cmp_wrap);
+		&incoming_node->node, cont_rbtree_cmp_wrapper, &cmp_wrap, NULL);
 	if (root_node != (&tree->root->node)) {
 		tree->root = container_of (root_node, RContRBNode, node); //cursed augmentation garbage
 	}

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -79,7 +79,7 @@ static void _check(RBNode *x) {
 */
 
 // Returns true if a node with an equal key is deleted
-R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, RBNodeFree freefn, RBNodeSum sum, void *user) {
+R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user, RBNodeSum sum) {
 	RBNode head, *del = NULL, **del_link = NULL, *g = NULL, *p = NULL, *q = &head, *path[R_RBTREE_MAX_HEIGHT];
 	int d = 1, d2, dep = 0;
 	head.child[0] = NULL;
@@ -91,7 +91,7 @@ R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, RBNo
 		if (del_link) {
 			d = 1;
 		} else {
-			d = cmp (data, q->child[d2], user);
+			d = cmp (data, q->child[d2], cmp_user);
 			if (d < 0) {
 				d = 0;
 			} else if (d > 0) {
@@ -160,7 +160,7 @@ R_API bool r_rbtree_aug_delete(RBNode **root, void *data, RBComparator cmp, RBNo
 			*del_link = q;
 		}
 		if (freefn) {
-			freefn (del);
+			freefn (del, free_user);
 		}
 	}
 	if (sum) {
@@ -279,8 +279,8 @@ R_API bool r_rbtree_aug_update_sum(RBNode *root, void *data, RBNode *node, RBCom
 	return true;
 }
 
-R_API bool r_rbtree_delete(RBNode **root, void *data, RBComparator cmp, RBNodeFree freefn, void *user) {
-	return r_rbtree_aug_delete (root, data, cmp, freefn, NULL, user);
+R_API bool r_rbtree_delete(RBNode **root, void *data, RBComparator cmp, void *cmp_user, RBNodeFree freefn, void *free_user) {
+	return r_rbtree_aug_delete (root, data, cmp, cmp_user, freefn, free_user, NULL);
 }
 
 R_API RBNode *r_rbtree_find(RBNode *x, void *data, RBComparator cmp, void *user) {
@@ -297,11 +297,11 @@ R_API RBNode *r_rbtree_find(RBNode *x, void *data, RBComparator cmp, void *user)
 	return NULL;
 }
 
-R_API void r_rbtree_free(RBNode *x, RBNodeFree freefn) {
+R_API void r_rbtree_free(RBNode *x, RBNodeFree freefn, void *user) {
 	if (x) {
-		r_rbtree_free (x->child[0], freefn);
-		r_rbtree_free (x->child[1], freefn);
-		freefn (x);
+		r_rbtree_free (x->child[0], freefn, user);
+		r_rbtree_free (x->child[1], freefn, user);
+		freefn (x, user);
 	}
 }
 
@@ -458,8 +458,12 @@ R_API bool r_rbtree_cont_insert(RContRBTree *tree, void *data, RContRBCmp cmp, v
 	return ret;
 }
 
-static void cont_node_free(RBNode *node) {
-	free (container_of (node, RContRBNode, node));
+static void cont_node_free(RBNode *node, void *user) {
+	RContRBNode *contnode = container_of (node, RContRBNode, node);
+	if (user) {
+		((RContRBFree)user) (contnode->data);
+	}
+	free (contnode);
 }
 
 R_API bool r_rbtree_cont_delete(RContRBTree *tree, void *data, RContRBCmp cmp, void *user) {
@@ -469,7 +473,7 @@ R_API bool r_rbtree_cont_delete(RContRBTree *tree, void *data, RContRBCmp cmp, v
 	RCRBCmpWrap cmp_wrap = { cmp, tree->free, user };
 	RContRBNode data_wrap = { { { NULL, NULL }, false }, data };
 	RBNode *root_node = &tree->root->node;
-	const bool ret = r_rbtree_aug_delete (&root_node, &data_wrap, cont_rbtree_free_cmp_wrapper, cont_node_free, NULL, &cmp_wrap);
+	const bool ret = r_rbtree_aug_delete (&root_node, &data_wrap, cont_rbtree_free_cmp_wrapper, &cmp_wrap, cont_node_free, NULL, NULL);
 	if (root_node != (&tree->root->node)) {	//can this crash?
 		tree->root = container_of (root_node, RContRBNode, node); //cursed augmentation garbage
 	}
@@ -488,18 +492,8 @@ R_API void *r_rbtree_cont_find(RContRBTree *tree, void *data, RContRBCmp cmp, vo
 }
 
 R_API void r_rbtree_cont_free(RContRBTree *tree) {
-	r_return_if_fail (tree);
-	if (tree->root) {
-		if (tree->free) {
-			// first we iterate overall elements to free the contained data
-			// this can be done much better, but E_TOO_LAZY
-			RBIter ator;
-			void *free_me;
-			r_rbtree_cont_foreach (tree, ator, free_me) {
-				tree->free (free_me);
-			}
-		}
-		r_rbtree_free (&tree->root->node, cont_node_free);
+	if (tree && tree->root) {
+		r_rbtree_free (&tree->root->node, cont_node_free, tree->free);
 	}
 	free (tree);
 }

--- a/libr/util/spaces.c
+++ b/libr/util/spaces.c
@@ -49,7 +49,7 @@ static void space_free(RSpace *s) {
 	}
 }
 
-static void space_node_free(RBNode *n) {
+static void space_node_free(RBNode *n, void *user) {
 	RSpace *s = container_of (n, RSpace, rb);
 	space_free (s);
 }
@@ -57,7 +57,7 @@ static void space_node_free(RBNode *n) {
 R_API void r_spaces_fini(RSpaces *sp) {
 	r_list_free (sp->spacestack);
 	sp->spacestack = NULL;
-	r_rbtree_free (sp->spaces, space_node_free);
+	r_rbtree_free (sp->spaces, space_node_free, NULL);
 	sp->spaces = NULL;
 	r_event_free (sp->event);
 	sp->event = NULL;
@@ -68,7 +68,7 @@ R_API void r_spaces_fini(RSpaces *sp) {
 R_API void r_spaces_purge(RSpaces *sp) {
 	sp->current = NULL;
 	r_list_purge (sp->spacestack);
-	r_rbtree_free (sp->spaces, space_node_free);
+	r_rbtree_free (sp->spaces, space_node_free, NULL);
 	sp->spaces = NULL;
 }
 
@@ -133,7 +133,7 @@ static bool spaces_unset_single(RSpaces *sp, const char *name) {
 	if (sp->current == space) {
 		sp->current = NULL;
 	}
-	return r_rbtree_delete (&sp->spaces, (void *)name, name_space_cmp, space_node_free, NULL);
+	return r_rbtree_delete (&sp->spaces, (void *)name, name_space_cmp, NULL, space_node_free, NULL);
 }
 
 R_API bool r_spaces_unset(RSpaces *sp, const char *name) {
@@ -218,7 +218,7 @@ R_API bool r_spaces_rename(RSpaces *sp, const char *oname, const char *nname) {
 	};
 	r_event_send (sp->event, R_SPACE_EVENT_RENAME, &ev);
 
-	r_rbtree_delete (&sp->spaces, (void *)s->name, name_space_cmp, NULL, NULL);
+	r_rbtree_delete (&sp->spaces, (void *)s->name, name_space_cmp, NULL, NULL, NULL);
 	free (s->name);
 	s->name = strdup (nname);
 	r_rbtree_insert (&sp->spaces, s, &s->rb, space_cmp, NULL);


### PR DESCRIPTION
This makes stuff like `r_rbtree_cont_free()` easier to write.
I also reordered some args to make more sense. Now the user pointer for a callback always follows the callback itself.
Tests: https://github.com/radareorg/radare2-regressions/pull/2032