### PR TITLE
Added `dp` processes info support to gdbr ##debug

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -45,6 +45,11 @@ static RList* r_debug_gdb_threads(RDebug *dbg, int pid) {
 	return list;
 }
 
+static RList* r_debug_gdb_pids(RDebug *dbg, int pid) {
+	RList *list;
+	return gdbr_pids_list (desc, pid);
+}
+
 static int r_debug_gdb_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 	int copy_size;
 	int buflen = 0;
@@ -1111,6 +1116,7 @@ RDebugPlugin r_debug_plugin_gdb = {
 	.attach = &r_debug_gdb_attach,
 	.detach = &r_debug_gdb_detach,
 	.threads = &r_debug_gdb_threads,
+	.pids = &r_debug_gdb_pids,
 	.canstep = 1,
 	.wait = &r_debug_gdb_wait,
 	.map_get = r_debug_gdb_map_get,

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -47,7 +47,10 @@ static RList* r_debug_gdb_threads(RDebug *dbg, int pid) {
 
 static RList* r_debug_gdb_pids(RDebug *dbg, int pid) {
 	RList *list;
-	return gdbr_pids_list (desc, pid);
+	if ((list = gdbr_pids_list (desc, pid))) {
+		list->free = (RListFree) &r_debug_pid_free;
+	}
+	return list;
 }
 
 static int r_debug_gdb_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {

--- a/shlr/gdb/include/gdbclient/commands.h
+++ b/shlr/gdb/include/gdbclient/commands.h
@@ -132,6 +132,11 @@ int gdbr_close_file(libgdbr_t *g);
 RList* gdbr_threads_list(libgdbr_t *g, int pid);
 
 /*!
+ * \brief get a list of the child processes of the given pid
+ */
+RList* gdbr_pids_list(libgdbr_t *g, int pid);
+
+/*!
  * Get absolute name of file executed to create a process
  */
 char* gdbr_exec_file_read(libgdbr_t *g, int pid);

--- a/shlr/gdb/include/gdbclient/xml.h
+++ b/shlr/gdb/include/gdbclient/xml.h
@@ -6,5 +6,6 @@
 #include "libgdbr.h"
 
 int gdbr_read_target_xml(libgdbr_t *g);
+int gdbr_read_processes_xml(libgdbr_t *g, int pid, RList* list);
 
 #endif  // GDBCLIENT_XML_H

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -1754,7 +1754,6 @@ RList* gdbr_pids_list(libgdbr_t *g, int pid) {
 	// gdb `info inferiors` behavior that can only be avoided using xml.
 	eprintf ("WARNING: Showing possibly incomplete pid list due to xml protocol failure\n");
 
-	list->free = &r_debug_pid_free;
 	if (!g->stub_features.qXfer_exec_file_read
 		    || !(exec_file = gdbr_exec_file_read (g, pid))) {
 		exec_file = "";
@@ -1815,7 +1814,14 @@ end:
 		if (dpid) {
 			free (dpid);
 		}
+		// We can't use r_debug_pid_free here
 		if (list) {
+			r_list_foreach (list, iter, dpid) {
+				if (dpid->path) {
+					free (dpid->path);
+				}
+				free (dpid);
+			}
 			r_list_free (list);
 		}
 		return NULL;
@@ -1829,6 +1835,7 @@ RList* gdbr_threads_list(libgdbr_t *g, int pid) {
 	int tpid = -1, ttid = -1;
 	char *ptr, *ptr2, *exec_file;
 	RDebugPid *dpid;
+	RListIter *iter;
 
 	if (!g) {
 		return NULL;
@@ -1895,7 +1902,6 @@ RList* gdbr_threads_list(libgdbr_t *g, int pid) {
 			break;
 		}
 	}
-	RListIter *iter;
 	// This is the all I've been able to extract from gdb so far
 	r_list_foreach (list, iter, dpid) {
 		if (gdbr_is_thread_dead (g, pid, dpid->pid)) {
@@ -1910,7 +1916,14 @@ end:
 		if (dpid) {
 			free (dpid);
 		}
+		// We can't use r_debug_pid_free here
 		if (list) {
+			r_list_foreach (list, iter, dpid) {
+				if (dpid->path) {
+					free (dpid->path);
+				}
+				free (dpid);
+			}
 			r_list_free (list);
 		}
 		return NULL;

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -1,11 +1,15 @@
 /* libgdbr - LGPL - Copyright 2017-2018 - srimanta.barua1 */
 
 #include "gdbclient/xml.h"
+#include "gdbclient/commands.h"
 #include "gdbclient/core.h"
 #include "arch.h"
 #include "gdbr_common.h"
 #include "packet.h"
 #include <r_util.h>
+#include <r_debug.h>
+
+#define MAX_PID_CHARS (5)
 
 static char *gdbr_read_feature(libgdbr_t *g, const char *file, ut64 *tot_len) {
 	ut64 retlen = 0, retmax = 0, off = 0, len = g->stub_features.pkt_sz - 2,
@@ -103,6 +107,47 @@ exit_err:
 	return NULL;
 }
 
+static char *gdbr_read_osdata(libgdbr_t *g, const char *file, ut64 *tot_len) {
+	ut64 retlen = 0, retmax = 0, off = 0, len = g->stub_features.pkt_sz - 2,
+		blksz = g->data_max, subret_space = 0, subret_len = 0;
+	char *tmp, *tmp2, *tmp3, *ret = NULL, *subret = NULL, msg[128] = { 0 }, status, tmpchar;
+	while (1) {
+		snprintf (msg, sizeof (msg), "qXfer:osdata:read:%s:%" PFMT64x ",%" PFMT64x, file, off, len);
+		if (send_msg (g, msg) < 0 || read_packet (g, false) < 0 || send_ack (g) < 0) {
+			goto exit_err;
+		}
+		if (g->data_len == 0) {
+			goto exit_err;
+		}
+		if (g->data_len == 1 && g->data[0] == 'l') {
+			break;
+		}
+		status = g->data[0];
+		if (retmax - retlen < g->data_len) {
+			if (!(tmp = realloc (ret, retmax + blksz))) {
+				goto exit_err;
+			}
+			retmax += blksz;
+			ret = tmp;
+		}
+		strcpy (ret + retlen, g->data + 1);
+		retlen += g->data_len - 1;
+		off = retlen;
+		if (status == 'l') {
+			break;
+		}
+	}
+	if (!ret) {
+		*tot_len = 0;
+		return NULL;
+	}
+	*tot_len = retlen;
+	return ret;
+exit_err:
+	free (ret);
+	*tot_len = 0;
+	return NULL;
+}
 
 typedef struct {
 	char type[32];
@@ -124,8 +169,9 @@ typedef struct {
 
 static void _write_flag_bits(char *buf, const gdbr_xml_flags_t *flags);
 static int _resolve_arch(libgdbr_t *g, char *xml_data);
-static RList* _extract_flags(char *flagstr);
-static RList* _extract_regs(char *regstr, RList *flags, char *pc_alias);
+static RList *_extract_flags(char *flagstr);
+static RList *_extract_regs(char *regstr, RList *flags, char *pc_alias);
+static RDebugPid *_extract_pid_info(const char *info, const char *path, int tid);
 
 static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 	char *regstr, *flagstr, *tmp, *profile = NULL, pc_alias[64], flag_bits[65];
@@ -294,6 +340,97 @@ exit_err:
 	return -1;
 }
 
+/* Reference:
+<osdata type="processes">
+<item>
+<column name="pid">1</column>
+<column name="user">root</column>
+<column name="command">/sbin/init maybe-ubiquity </column>
+<column name="cores">0</column>
+</item>
+</osdata>
+*/
+static RList *gdbr_parse_processes_xml(libgdbr_t *g, char *xml_data, ut64 len, int pid, RList *list) {
+	list->free = (RListFree)&r_debug_pid_free;
+	char pidstr[MAX_PID_CHARS + 1], status[1024], cmdline[1024];
+	char *itemstr, *itemstr_end, *column, *column_end, *proc_filename;
+	int ipid, column_data_len;
+	RDebugPid *pid_info = NULL;
+
+	// Make sure the given xml is valid
+	if (!r_str_startswith (xml_data, "<osdata type=\"processes\">")) {
+		goto exit_err;
+	}
+
+	column = xml_data;
+	while ((itemstr = strstr (column, "<item>"))) {
+		if (!(itemstr_end = strstr (itemstr, "</item>"))) {
+			goto exit_err;
+		}
+		// Get PID
+		if (!(column = strstr (itemstr, "<column name=\"pid\">"))) {
+			goto exit_err;
+		}
+		if (!(column_end = strstr (column, "</column>"))) {
+			goto exit_err;
+		}
+
+		column += sizeof ("<column name=\"pid\">") - 1;
+		column_data_len = column_end - column;
+
+		memcpy (pidstr, column, column_data_len);
+		pidstr[column_data_len] = '\0';
+
+		ipid = atoi (pidstr);
+
+		// Get cmdline
+		if (!(column = strstr (itemstr, "<column name=\"command\">"))) {
+			goto exit_err;
+		}
+		if (!(column_end = strstr (column, "</column>"))) {
+			goto exit_err;
+		}
+
+		column += sizeof ("<column name=\"command\">") - 1;
+		column_data_len = column_end - column;
+
+		memcpy (cmdline, column, column_data_len);
+		cmdline[column_data_len] = '\0';
+
+		// Attempt to read the pid's info from /proc. Non UNIX systems will have the
+		// correct pid and cmdline from the xml with everything else set to default
+		proc_filename = r_str_newf ("/proc/%d/status", ipid);
+		if (gdbr_open_file (g, proc_filename, O_RDONLY, 0) == 0) {
+			if (gdbr_read_file (g, status, sizeof (status)) != -1) {
+				pid_info = _extract_pid_info (status, cmdline, ipid);
+			} else {
+				eprintf ("Failed to read from data from procfs file of pid (%d)\n", ipid);
+			}
+			if (gdbr_close_file (g) != 0) {
+				eprintf ("Failed to close procfs file of pid (%d)\n", ipid);
+			}
+		} else {
+			eprintf ("Failed to open procfs file of pid (%d)\n", ipid);
+			pid_info = r_debug_pid_new (cmdline, ipid, 0, R_DBG_PROC_STOP, 0);
+		}
+		// Unless pid 0 is requested, only add the requested pid and it's child processes
+		if (0 == pid || ipid == pid || pid_info->ppid == pid) {
+			r_list_append (list, pid_info);
+		} else {
+			if (pid_info) {
+				free (pid_info);
+			}
+		}
+	}
+
+	return list;
+exit_err:
+	if (list) {
+		r_list_free (list);
+	}
+	return NULL;
+}
+
 // If xml target description is supported, read it
 int gdbr_read_target_xml(libgdbr_t *g) {
 	if (!g->stub_features.qXfer_features_read) {
@@ -305,6 +442,23 @@ int gdbr_read_target_xml(libgdbr_t *g) {
 		return -1;
 	}
 	gdbr_parse_target_xml (g, data, len);
+	free (data);
+	return 0;
+}
+
+int gdbr_read_processes_xml(libgdbr_t *g, int pid, RList *list) {
+	if (!g->stub_features.qXfer_features_read) {
+		return -1;
+	}
+	ut64 len;
+	char *data;
+
+	if (!(data = gdbr_read_osdata (g, "processes", &len))) {
+		return -1;
+	}
+
+	list = gdbr_parse_processes_xml (g, data, len, pid, list);
+
 	free (data);
 	return 0;
 }
@@ -378,7 +532,7 @@ static int _resolve_arch(libgdbr_t *g, char *xml_data) {
 	return 0;
 }
 
-static RList* _extract_flags(char *flagstr) {
+static RList *_extract_flags(char *flagstr) {
 	char *tmp1, *tmp2, *flagsend, *field_start, *field_end;
 	ut64 num_fields, type_sz, name_sz;
 	gdbr_xml_flags_t *tmpflag = NULL;
@@ -485,7 +639,55 @@ exit_err:
 	return NULL;
 }
 
-static RList* _extract_regs(char *regstr, RList *flags, char *pc_alias) {
+static RDebugPid *_extract_pid_info(const char *info, const char *path, int tid) {
+	RDebugPid *pid_info = R_NEW0 (RDebugPid);
+	if (!pid_info) {
+		return NULL;
+	}
+	char *ptr = strstr (info, "State:");
+	if (ptr) {
+		switch (*(ptr + 7)) {
+		case 'R':
+			pid_info->status = R_DBG_PROC_RUN;
+			break;
+		case 'S':
+			pid_info->status = R_DBG_PROC_SLEEP;
+			break;
+		case 'T':
+		case 't':
+			pid_info->status = R_DBG_PROC_STOP;
+			break;
+		case 'Z':
+			pid_info->status = R_DBG_PROC_ZOMBIE;
+			break;
+		case 'X':
+			pid_info->status = R_DBG_PROC_DEAD;
+			break;
+		default:
+			pid_info->status = R_DBG_PROC_SLEEP;
+			break;
+		}
+	}
+	ptr = strstr (info, "PPid:");
+	if (ptr) {
+		pid_info->ppid = atoi (ptr + 5);
+	}
+	ptr = strstr (info, "Uid:");
+	if (ptr) {
+		pid_info->uid = atoi (ptr + 5);
+	}
+	ptr = strstr (info, "Gid:");
+	if (ptr) {
+		pid_info->gid = atoi (ptr + 5);
+	}
+	pid_info->pid = tid;
+	pid_info->path = path ? strdup (path) : NULL;
+	pid_info->runnable = true;
+	pid_info->pc = 0;
+	return pid_info;
+}
+
+static RList *_extract_regs(char *regstr, RList *flags, char *pc_alias) {
 	char *regstr_end, *regname, *regtype, *tmp1, *tmpregstr, *feature_end, *typegroup;
 	ut32 flagnum, regname_len, regsize, regnum;
 	RList *regs;


### PR DESCRIPTION
Most servers/clients should have xml support by now so it should behave like `dp` in any other debugger. ThreadsInfo is used as a fallback.
vFile is the only way to get detailed pid info unfortunately.