### PR TITLE
Fix r_type_del() for typedefs (Fix #15337) ##anal

### DIFF
--- a/libr/util/ctype.c
+++ b/libr/util/ctype.c
@@ -488,8 +488,15 @@ R_API void r_type_del(Sdb *TDB, const char *name) {
 		}
 		sdb_unset (TDB, name, 0);
 		r_list_free (list);
+	} else if (!strcmp (kind, "typedef")) {
+		RStrBuf buf;
+		r_strbuf_init (&buf);
+		r_strbuf_setf (&buf, "typedef.%s", name);
+		sdb_unset (TDB, r_strbuf_get (&buf), 0);
+		r_strbuf_fini (&buf);
+		sdb_unset (TDB, name, 0);
 	} else {
-		eprintf ("Unrecognized type \"%s\"\n", kind);
+		eprintf ("Unrecognized type kind \"%s\"\n", kind);
 	}
 }
 


### PR DESCRIPTION
Fix #15337