### PR TITLE
Fix crash on oom when command line is too long

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2446,6 +2446,10 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	 * nested call of this function */
 	ut64 orig_offset = core->offset;
 	icmd = strdup (cmd);
+	if (!icmd) {
+		eprintf ("Command line too long\n");
+		goto beach;
+	}
 
 	if (core->max_cmd_depth - core->cons->context->cmd_depth == 1) {
 		core->prompt_offset = core->offset;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2447,7 +2447,6 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	ut64 orig_offset = core->offset;
 	icmd = strdup (cmd);
 	if (!icmd) {
-		eprintf ("Command line too long\n");
 		goto beach;
 	}
 


### PR DESCRIPTION
Probably the fix to #15543. Tested on 4GB VM.