### PR TITLE
Added oodf\doof to enable rebasing for remote debug ##debug

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -29,7 +29,8 @@ static const char *help_msg_d[] = {
 	"dL", "[?]", "List or set debugger handler",
 	"dm", "[?]", "Show memory maps",
 	"do", "[?]", "Open process (reload, alias for 'oo')",
-	"doo", "[args]", "Reopen in debugger mode with args (alias for 'ood')",
+	"doo", "[args]", "Reopen in debug mode with args (alias for 'ood')",
+	"doof", "[file]", "Reopen in debug mode from file (alias for 'oodf')",
 	"dp", "[?]", "List, attach to process or thread id",
 	"dr", "[?]", "Cpu registers",
 	"ds", "[?]", "Step, over, source line",
@@ -286,7 +287,8 @@ static const char *help_msg_do[] = {
 	"Usage:", "do", " # Debug (re)open commands",
 	"do", "", "Open process (reload, alias for 'oo')",
 	"dor", " [rarun2]", "Comma separated list of k=v rarun2 profile options (e dbg.profile)",
-	"doo", " [args]", "Reopen in debugger mode with args (alias for 'ood')",
+	"doo", " [args]", "Reopen in debug mode with args (alias for 'ood')",
+	"doof", " [args]", "Reopen in debug mode from file (alias for 'oodf')",
 	NULL
 };
 
@@ -5301,7 +5303,7 @@ static int cmd_debug(void *data, const char *input) {
 		case '\0': // "do"
 			r_core_file_reopen (core, input[1] ? input + 2: NULL, 0, 1);
 			break;
-		case 'r': //"dor" : rarun profile
+		case 'r': // "dor" : rarun profile
 			if (input[2] == ' ') {
 				setRarunProfileString (core, input + 3);
 			} else {
@@ -5309,8 +5311,12 @@ static int cmd_debug(void *data, const char *input) {
 				r_sys_cmd ("rarun2 -h");
 			}
 			break;
-		case 'o': //"doo" : reopen in debugger
-			r_core_file_reopen_debug (core, input + 2);
+		case 'o': // "doo" : reopen in debug mode
+			if (input[2] == 'f') { // "doof" : reopen in debug mode from the given file
+				r_core_cmd0 (core, sdb_fmt ("oodf %s", input + 3));
+			} else {
+				r_core_file_reopen_debug (core, input + 2);
+			}
 			break;
 		case '?': // "do?"
 		default:

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -143,8 +143,10 @@ static const char *help_msg_oob[] = {
 };
 
 static const char *help_msg_ood[] = {
-	"Usage:", "ood [args]", " # reopen in debugger mode (with args)",
-	"oodr"," [rarun2]","same as dor ..;ood",
+	"Usage:", "ood", " # Debug (re)open commands",
+	"ood", " [args]", " # reopen in debug mode (with args)",
+	"oodf", " [file]", " # reopen in debug mode using the given file",
+	"oodr", " [rarun2]", " # same as dor ..;ood",
 	NULL
 };
 
@@ -1051,6 +1053,51 @@ static void __rebase_everything(RCore *core, RList *old_sections, ut64 old_base)
 	r_debug_bp_rebase (core->dbg, new_base);
 }
 
+R_API void r_core_file_reopen_remote_debug(RCore *core, char *uri, ut64 addr) {
+	RCoreFile *ofile = core->file;
+	RIODesc *desc;
+	RCoreFile *file;
+	int fd;
+
+	if (!ofile || !(desc = r_io_desc_get (core->io, ofile->fd)) || !desc->uri) {
+		eprintf ("No file open?\n");
+		return;
+	}
+
+	RList *old_sections = __save_old_sections (core);
+	ut64 old_base = core->bin->cur->o->baddr_shift;
+	int bits = core->assembler->bits;
+	r_config_set_i (core->config, "asm.bits", bits);
+	r_config_set_i (core->config, "cfg.debug", true);
+	// Set referer as the original uri so we could return to it with `oo`
+	desc->referer = desc->uri;
+	desc->uri = strdup (uri);
+
+	if ((file = r_core_file_open (core, uri, R_PERM_R | R_PERM_W, addr))) {
+		fd = file->fd;
+		core->num->value = fd;
+		// if no baddr is defined, use the one provided by the file
+		if (addr == 0) {
+			desc = r_io_desc_get (core->io, file->fd);
+			if (desc->plugin->isdbg) {
+				addr = r_debug_get_baddr(core->dbg, desc->name);
+			} else {
+				addr = r_bin_get_baddr (file->binb.bin);
+			}
+		}
+		r_core_bin_load (core, uri, addr);
+	} else {
+		eprintf ("cannot open file %s\n", uri);
+		return;
+	}
+	r_core_block_read (core);
+	if (r_config_get_i (core->config, "dbg.rebase")) {
+		__rebase_everything (core, old_sections, old_base);
+	}
+	r_list_free (old_sections);
+	r_core_cmd0 (core, "sr PC");
+}
+
 R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	RCoreFile *ofile = core->file;
 	RIODesc *desc;
@@ -1586,6 +1633,22 @@ static int cmd_open(void *data, const char *input) {
 			if (input[2] == 'r') { // "oodr"
 				r_core_cmdf (core, "dor %s", input + 3);
 				r_core_file_reopen_debug (core, "");
+			} else if (input[2] == 'f') { // "oodf"
+				char **argv = NULL;
+				int addr = 0;
+				argv = r_str_argv (input + 3, &argc);
+				if (argc == 0) {
+					eprintf ("Usage: oodf (uri://)[/path/to/file] (addr)\n");
+					r_str_argv_free (argv);
+					return 0;
+				}
+				if (argc == 2) {
+					if (r_num_is_valid_input (core->num, argv[1])) {
+						addr = r_num_math (core->num, argv[1]);
+					}
+				}
+				r_core_file_reopen_remote_debug (core, argv[0], addr);
+				r_str_argv_free (argv);
 			} else if ('?' == input[2]) {
 				r_core_cmd_help (core, help_msg_ood);
 			} else {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -485,6 +485,7 @@ R_API int r_core_search_cb(RCore *core, ut64 from, ut64 to, RCoreSearchCallback 
 R_API bool r_core_serve(RCore *core, RIODesc *fd);
 R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int binload);
 R_API void r_core_file_reopen_debug(RCore *core, const char *args);
+R_API void r_core_file_reopen_remote_debug(RCore *core, char *uri, ut64 addr);
 R_API RCoreFile * r_core_file_find_by_fd(RCore* core, ut64 fd);
 R_API RCoreFile * r_core_file_find_by_name (RCore * core, const char * name);
 R_API RCoreFile * r_core_file_cur (RCore *r);


### PR DESCRIPTION
This is mainly relevant for gdb and windbg but I have only tested with gdb since I am not sure how to extract a windows kernel binary from my qemu image to make sure this works with windbg. Should work though since windbg returns what seems to be a valid baddr.

This could also be used to overlay a different binary over the analyzed binary with a given baddr.

Please try to merge this before the coming release so we could use it in Cutter.