### PR TITLE
Fixed an issue with detached child breakpoint inheretence ##debug

### DIFF
--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -536,6 +536,7 @@ R_API bool r_debug_arg_set(RDebug *dbg, int fast, int num, ut64 value);
 /* breakpoints (most in r_bp, this calls those) */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, bool watch, int rw, char *module, st64 m_delta);
 R_API void r_debug_bp_rebase(RDebug *dbg, ut64 baddr);
+R_API void r_debug_bp_update(RDebug *dbg);
 
 /* pid */
 R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt);


### PR DESCRIPTION
Previously, forked children would instantly die if the fork was stepped over using a breakpoint that would be accessible to the child process.

This change causes the debug to stop after forking even when trace_fork isn't set but this behavior matches native windows debug. I think that it's more logical to interpret "trace fork" as "apply ptrace tracing" and not just "handle the event" which should be mandatory.