### PR TITLE
Use ONE_STREAM=1 instead and assume it sets scr.onestream

### DIFF
--- a/test/new/db/cmd/cmd_pd
+++ b/test/new/db/cmd/cmd_pd
@@ -1025,8 +1025,7 @@ EOF
 RUN
 
 NAME=bin.str.enc alias and error handling
-ONE_STREAM=true
-ARGS=-e scr.onestream=true
+ONE_STREAM=1
 FILE=../bins/elf/strenc
 CMDS=<<EOF
 e asm.filter=false

--- a/test/new/db/cmd/cmd_pf2
+++ b/test/new/db/cmd/cmd_pf2
@@ -438,7 +438,7 @@ RUN
 
 NAME=pf?
 FILE=-
-ONE_STREAM=true
+ONE_STREAM=1
 CMDS=<<EXPECT
 pfo elf32
 pf?elf_header

--- a/test/new/db/cmd/feat_foreach
+++ b/test/new/db/cmd/feat_foreach
@@ -49,7 +49,7 @@ RUN
 
 NAME=@@= `prz` fix
 FILE=-
-ONE_STREAM=true
+ONE_STREAM=1
 CMDS=<<EXPECT
 wz 1 2 3 4
 pd 1 @@= `prz`

--- a/test/new/db/tools/r2
+++ b/test/new/db/tools/r2
@@ -87,3 +87,10 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=ONE_STREAM sets scr.onestream
+FILE=-
+ONE_STREAM=1
+CMDS=e scr.onestream
+EXPECT=true
+RUN


### PR DESCRIPTION
Clone of radareorg/radare2-regressions#2037, which apparently is frozen in Archiveland ＦＯＲＥＶＥＲ．