### PR TITLE
Add PIE flag check in kernelcache detection ##bin

### DIFF
--- a/libr/bin/format/mach0/mach064_is_kernelcache.c
+++ b/libr/bin/format/mach0/mach064_is_kernelcache.c
@@ -1,3 +1,5 @@
+#include "mach0_defines.h"
+
 static bool is_kernelcache_buffer(RBuffer *b) {
 	ut64 length = r_buf_size (b);
 	if (length < sizeof (struct MACH0_(mach_header))) {
@@ -9,7 +11,7 @@ static bool is_kernelcache_buffer(RBuffer *b) {
 	}
 
 	ut32 flags = r_buf_read_le32_at (b, 24);
-	if (!(flags & 0x200000)) {
+	if (!(flags & MH_PIE)) {
 		return false;
 	}
 

--- a/libr/bin/format/mach0/mach064_is_kernelcache.c
+++ b/libr/bin/format/mach0/mach064_is_kernelcache.c
@@ -8,6 +8,11 @@ static bool is_kernelcache_buffer(RBuffer *b) {
 		return false;
 	}
 
+	ut32 flags = r_buf_read_le32_at (b, 24);
+	if (!(flags & 0x200000)) {
+		return false;
+	}
+
 	int i, ncmds = r_buf_read_le32_at (b, 16);
 	bool has_unixthread = false;
 	bool has_negative_vaddr = false;


### PR DESCRIPTION
In this way 64-bit SEP kernels aren’t wrongly detected as XNU kernel caches.