### PR TITLE
Silence drr warning on UT64_MAX registers ##debug

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2059,8 +2059,8 @@ R_API char *r_core_anal_hasrefs(RCore *core, ut64 value, bool verbose) {
 }
 
 static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
-	r_return_val_if_fail (core && value != UT64_MAX, NULL);
-	if (depth < 1) {
+	r_return_val_if_fail (core, NULL);
+	if (depth < 1 || value == UT64_MAX) {
 		return NULL;
 	}
 	RStrBuf *s = r_strbuf_new (NULL);


### PR DESCRIPTION
The warning:
WARNING: r_core_anal_hasrefs_to_depth: assertion 'core && value != UT64_MAX'
failed (line 2062)
This way registers like 'orax' will simply have an empty reference like before, just without an annoying warning when there really is nothing to telescope.
{"reg":"orax","value":"0xffffffffffffffff","ref":""}


That warning is constantly printed in Cutter since drrj happens with every step for the Registers Reference Widget. I don't see a reason to keep it.