### PR TITLE
Rename  or1k `insns` global

### DIFF
--- a/libr/anal/p/anal_or1k.c
+++ b/libr/anal/p/anal_or1k.c
@@ -169,7 +169,7 @@ static int or1k_op(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *data, int len, R
 	}
 
 	/* if instruction is marked as invalid finish processing now */
-	insn_descr = &insns[opcode_idx];
+	insn_descr = &or1k_insns[opcode_idx];
 	if (insn_descr->type == INSN_INVAL) {
 		return op->size;
 	}

--- a/libr/asm/arch/or1k/or1k_disas.c
+++ b/libr/asm/arch/or1k/or1k_disas.c
@@ -263,7 +263,7 @@ insn_extra_t extra_0x39[] = {
 	{0}
 };
 
-insn_t insns[] = {
+insn_t or1k_insns[] = {
 	[0x00] = {(0x00<<26), "l.j", INSN_N, R_ANAL_OP_TYPE_JMP},
 	[0x01] = {(0x01<<26), "l.jal", INSN_N, R_ANAL_OP_TYPE_CALL},
 	[0x02] = {(0x02<<26), "l.adrp", INSN_DN},
@@ -330,7 +330,7 @@ insn_t insns[] = {
 	[0x3f] = {(0x3f<<26), "l.cust8", INSN_X},
 };
 
-size_t insns_count = sizeof(insns) / sizeof(insn_t);
+size_t insns_count = sizeof(or1k_insns) / sizeof(insn_t);
 
 insn_extra_t *find_extra_descriptor(insn_extra_t *extra_descr, ut32 insn) {
 	ut32 opcode;

--- a/libr/asm/arch/or1k/or1k_disas.h
+++ b/libr/asm/arch/or1k/or1k_disas.h
@@ -130,7 +130,7 @@ extern insn_extra_t extra_0x32[];
 extern insn_extra_t extra_0x38[];
 extern insn_extra_t extra_0x39[];
 
-extern insn_t insns[];
+extern insn_t or1k_insns[];
 extern size_t insns_count;
 
 insn_extra_t *find_extra_descriptor(insn_extra_t *extra_descr, ut32 insn);

--- a/libr/asm/p/asm_or1k.c
+++ b/libr/asm/p/asm_or1k.c
@@ -133,7 +133,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	}
 
 	/* if instruction is marked as invalid finish processing now */
-	insn_descr = &insns[opcode_idx];
+	insn_descr = &or1k_insns[opcode_idx];
 	if (insn_descr->type == INSN_INVAL) {
 		line = sdb_fmt("invalid");
 		r_strbuf_set (&op->buf_asm, line);


### PR DESCRIPTION
As in certain build configurations it conflicts with the Capstone’s symbol of the same name, raising errors in the linking phase.

<img width="819" alt="Screenshot 2019-12-11 at 10 18 17" src="https://user-images.githubusercontent.com/4139069/70622477-4e819a80-1c1c-11ea-9569-43ad1396ccf4.png">

this is a quick fix, 'cause i'm not familiar with this arch.

the ideal solution would be not to rely on globals at all.