### PR TITLE
Fixed gdbr warnings and a dpt crash after debug was over ##debug

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -315,8 +315,6 @@ static int r_debug_gdb_reg_write(RDebug *dbg, int type, const ut8 *buf, int size
 	RRegItem* current = NULL;
 	// We default to little endian if there's no way to get the configuration,
 	// since this was the behaviour prior to the change.
-	bool bigendian = dbg->corebind.core && \
-					 dbg->corebind.cfggeti (dbg->corebind.core, "cfg.bigendian");
 	RRegArena *arena = dbg->reg->regset[type].arena;
 	for (;;) {
 		current = r_reg_next_diff (dbg->reg, type, reg_buf, buflen, current, bits);
@@ -1055,13 +1053,13 @@ static bool r_debug_gdb_kill(RDebug *dbg, int pid, int tid, int sig) {
 	return true;
 }
 
-static bool r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
+static int r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
 	if (!desc || !*origriogdb) {
 		desc = NULL;	//TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
-		return false;
+		return -1;
 	}
 
-	return gdbr_select (desc, pid, tid) >= 0;
+	return gdbr_select (desc, pid, tid);
 }
 
 static RDebugInfo* r_debug_gdb_info(RDebug *dbg, const char *arg) {

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -1729,7 +1729,7 @@ RList* gdbr_pids_list(libgdbr_t *g, int pid) {
 	int tpid = -1, ttid = -1;
 	char *ptr, *ptr2, *exec_file;
 	RDebugPid *dpid = NULL;
-	RListIter *iter;
+	RListIter *iter = NULL;
 
 	if (!g) {
 		return NULL;
@@ -1834,8 +1834,8 @@ RList* gdbr_threads_list(libgdbr_t *g, int pid) {
 	RList *list = NULL;
 	int tpid = -1, ttid = -1;
 	char *ptr, *ptr2, *exec_file;
-	RDebugPid *dpid;
-	RListIter *iter;
+	RDebugPid *dpid = NULL;
+	RListIter *iter = NULL;
 
 	if (!g) {
 		return NULL;


### PR DESCRIPTION
RDebugPid not being initialized with NULL resulted in a free on an invalid pointer after gdbr_threads_list failed(since there were no threads to report for a dead pid).