### PR TITLE
Fix gdb reopen and `doc`

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5331,14 +5331,16 @@ static int cmd_debug(void *data, const char *input) {
 				break;
 			}
 			// Kill debugee and all child processes
-			if (core->dbg && core->dbg->h && core->dbg->h->pids && core->dbg->pid == -1) {
+			if (core->dbg && core->dbg->h && core->dbg->h->pids && core->dbg->pid != -1) {
 				list = core->dbg->h->pids (core->dbg, core->dbg->pid);
 				if (list) {
 					r_list_foreach (list, iter, p) {
 						r_debug_kill (core->dbg, p->pid, p->pid, SIGKILL);
+						r_debug_detach (core->dbg, p->pid);
 					}
 				} else {
 					r_debug_kill (core->dbg, core->dbg->pid, core->dbg->pid, SIGKILL);
+					r_debug_detach (core->dbg, core->dbg->pid);
 				}
 			}
 			// Reopen and rebase the original file

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -437,10 +437,17 @@ static int r_debug_gdb_attach(RDebug *dbg, int pid) {
 }
 
 static int r_debug_gdb_detach(RDebug *dbg, int pid) {
+	int ret = 0;
+
 	if (pid <= 0 || !desc->stub_features.multiprocess) {
-		return gdbr_detach (desc);
+		ret = gdbr_detach (desc);
 	}
-	return gdbr_detach_pid (desc, pid);
+	ret = gdbr_detach_pid (desc, pid);
+
+	if (dbg->pid == pid) {
+		desc = NULL;
+	}
+	return ret;
 }
 
 static const char *r_debug_gdb_reg_profile(RDebug *dbg) {

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -17,7 +17,6 @@ typedef struct {
 
 static int __close(RIODesc *fd);
 static libgdbr_t *desc = NULL;
-static RIODesc *riogdb = NULL;
 
 static bool __plugin_open(RIO *io, const char *file, bool many) {
 	return (!strncmp (file, "gdb://", 6));
@@ -52,6 +51,7 @@ static int debug_gdb_write_at(const ut8 *buf, int sz, ut64 addr) {
 }
 
 static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
+	RIODesc *riogdb = NULL;
 	RIOGdb *riog;
 	char host[128], *port, *pid;
 	int i_port = -1;
@@ -59,10 +59,6 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 
 	if (!__plugin_open (io, file, 0)) {
 		return NULL;
-	}
-	if (riogdb) {
-		// FIX: Don't allocate more than one gdb RIODesc
-		return riogdb;
 	}
 	strncpy (host, file + 6, sizeof (host) - 1);
 	host [sizeof (host) - 1] = '\0';
@@ -179,9 +175,6 @@ static int __close(RIODesc *fd) {
 	}
 	gdbr_disconnect (desc);
 	gdbr_cleanup (desc);
-	if (riogdb) {	//TODO is there a less band-aid fix to do this?
-		riogdb->data = NULL;
-	}
 	R_FREE (desc);
 	return -1;
 }


### PR DESCRIPTION
The plugin would try work with an old version of desc, that was already freed by r_io_close_all after closing the session, and crash. 
I set debug_gdb's global 'desc' to NULL in detach as a temporary solution since I want this to be ready for release. In the future, we should convert to **desc to keep an updated copy of the pointer or think of a more clever idea since the code will look really messy and become error prone if the user has to handle double derefrences to access struct members.

#### Testing:

Run 'oodf gdb://ip:port'->'doc' multiple times and see that r2 doesn't crash and that the session opened by oodf works(run ds, dc, drr)