### PR TITLE
Function r_anal_cc_arg should just return NULL when nothing is available

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -215,7 +215,7 @@ R_API RAnal *r_anal_free(RAnal *a) {
 	ht_up_free (a->dict_refs);
 	ht_up_free (a->dict_xrefs);
 	r_list_free (a->leaddrs);
-	sdb_ns_free (a->sdb);
+	sdb_free (a->sdb);
 	if (a->esil) {
 		r_anal_esil_free (a->esil);
 		a->esil = NULL;

--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -90,25 +90,18 @@ R_API bool r_anal_cc_exist (RAnal *anal, const char *convention) {
 	return x && *x && !strcmp (x, "cc");
 }
 
-// TODO: all callers to this function expect NON-NULL, so lets return "" on fail for now
 R_API const char *r_anal_cc_arg(RAnal *anal, const char *convention, int n) {
 	r_return_val_if_fail (anal && convention, NULL);
 	if (n < 0) {
-		return "";
+		return NULL;
 	}
 	const char *query = sdb_fmt ("cc.%s.arg%d", convention, n);
 	const char *ret = sdb_const_get (DB, query, 0);
 	if (!ret) {
 		query = sdb_fmt ("cc.%s.argn", convention);
 		ret = sdb_const_get (DB, query, 0);
-#if 0
-		if (!strcmp (ret, "stack")) {
-			// TODO handle stack arguments here
-			return NULL;
-		}
-#endif
 	}
-	return r_str_constpool_get (&anal->constpool, ret ? ret : "");
+	return ret? r_str_constpool_get (&anal->constpool, ret): NULL;
 }
 
 R_API int r_anal_cc_max_arg(RAnal *anal, const char *cc) {

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -312,10 +312,10 @@ static void type_match(RCore *core, ut64 addr, char *fcn_name, ut64 baddr, const
 	const char *place = r_anal_cc_arg (anal, cc, 0);
 	r_cons_break_push (NULL, NULL);
 
-	if (!strcmp (place, "stack_rev")) {
+	if (place && !strcmp (place, "stack_rev")) {
 		stack_rev = true;
 	}
-	if (!strncmp (place, "stack", 5)) {
+	if (place && !strncmp (place, "stack", 5)) {
 		in_stack = true;
 	}
 	if (verbose && !strncmp (fcn_name, "sym.imp.", 8)) {
@@ -374,7 +374,7 @@ static void type_match(RCore *core, ut64 addr, char *fcn_name, ut64 baddr, const
 			const char *key = NULL;
 			RAnalVar *var = op->var;
 			if (!in_stack) {
-				key = sdb_fmt ("fcn.0x%08"PFMT64x".arg.%s", caddr, place);
+				key = sdb_fmt ("fcn.0x%08"PFMT64x".arg.%s", caddr, place? place: "");
 			} else {
 				key = sdb_fmt ("fcn.0x%08"PFMT64x".arg.%d", caddr, size);
 			}

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -394,6 +394,7 @@ bool test_r_buf_slice_too_big(void) {
 	mu_assert ("the resize should be successful", res);
 	sz = r_buf_size (sl);
 	mu_assert_eq (sz, 3, "but it should just use the biggest value");
+	r_buf_free (sl);
 	r_buf_free (buf);
 	mu_end;
 }


### PR DESCRIPTION
Callers should be able to handle NULLs

(a new PR, sorry... this should enable the ASAN tests because of the `asan-*` branch name)