### PR TITLE
Add ppid to dp and fix dp= for windows

### DIFF
--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -1298,7 +1298,7 @@ RDebugInfo *w32_info(RDebug *dbg, const char *arg) {
 	return rdi;
 }
 
-static RDebugPid *__build_debug_pid(int pid, HANDLE ph, const TCHAR* name) {
+static RDebugPid *__build_debug_pid(int pid, int ppid, HANDLE ph, const TCHAR* name) {
 	char *path = NULL;
 	int uid = -1;
 	if (!ph) {
@@ -1325,6 +1325,7 @@ static RDebugPid *__build_debug_pid(int pid, HANDLE ph, const TCHAR* name) {
 	}
 	// it is possible to get pc for a non debugged process but the operation is expensive and might be risky
 	RDebugPid *ret = r_debug_pid_new (path, pid, uid, 's', 0);
+	ret->ppid = ppid;
 	free (path);
 	return ret;
 }
@@ -1343,7 +1344,8 @@ RList *w32_pid_list(RDebug *dbg, int pid, RList *list) {
 		do {
 			if (all || pe.th32ProcessID == pid || (b = pe.th32ParentProcessID == pid)) {
 				// Returns NULL if process is inaccessible unless if its a child process of debugged process
-				RDebugPid *dbg_pid = __build_debug_pid (pe.th32ProcessID, b ? rio->pi.hProcess : NULL, pe.szExeFile);
+				RDebugPid *dbg_pid = __build_debug_pid (pe.th32ProcessID, pe.th32ParentProcessID,
+					b ? rio->pi.hProcess : NULL, pe.szExeFile);
 				if (dbg_pid) {
 					r_list_append (list, dbg_pid);
 				}

--- a/libr/debug/p/native/windows/windows_debug.h
+++ b/libr/debug/p/native/windows/windows_debug.h
@@ -149,6 +149,7 @@ int w32_reg_write(RDebug *dbg, int type, const ut8 *buf, int size);
 
 int w32_attach(RDebug *dbg, int pid);
 int w32_detach(RDebug *dbg, int pid);
+int w32_attach_new_process(RDebug* dbg, int pid);
 int w32_select(RDebug *dbg, int pid, int tid);
 int w32_kill(RDebug *dbg, int pid, int tid, int sig);
 void w32_break_process(void *user);

--- a/libr/debug/pid.c
+++ b/libr/debug/pid.c
@@ -46,6 +46,7 @@ R_API int r_debug_pid_list(RDebug *dbg, int pid, char fmt) {
 			case 'j':
 				pj_o (j);
 				pj_kb (j, "current", dbg->pid == p->pid);
+				pj_ki (j, "ppid", p->ppid);
 				pj_ki (j, "pid", p->pid);
 				pj_ki (j, "uid", p->uid);
 				pj_ks (j, "status", &p->status);
@@ -53,9 +54,9 @@ R_API int r_debug_pid_list(RDebug *dbg, int pid, char fmt) {
 				pj_end (j);
 				break;
 			default:
-				dbg->cb_printf (" %c %d uid:%d %c %s\n",
+				dbg->cb_printf (" %c %d ppid:%d uid:%d %c %s\n",
 					dbg->pid == p->pid? '*': '-',
-					p->pid, p->uid, p->status, p->path);
+					p->pid, p->ppid, p->uid, p->status, p->path);
 				break;
 			}
 		}


### PR DESCRIPTION
`dp=` fixes for windows - same idea as the linux dp= fix.
PPID in `dp/j` - added ppid info parsing to gdb, windbg and linux in previous commits. Very useful after attaching to a child process with `dp` if you want to easily find the way back.

```
[0x7fc722535b1c]> dp
 * 37011 ppid:37009 uid:1000 s /home/yossi/workspace/tests/main
 - 37012 ppid:37011 uid:1000 S /home/yossi/workspace/tests/main
[0x7fc722535b1c]> dpj
[{"current":true,"ppid":37009,"pid":37011,"uid":1000,"status":"s","path":"/home/yossi/workspace/tests/main"},{"current":false,"ppid":37011,"pid":37012,"uid":1000,"status":"S","path":"/home/yossi/workspace/tests/main"}
```

```
[0x7ffd65295ac4]> dp
Selected: 17140 13108
 * 17140 ppid:10536 uid:2 s C:\workspace\cutter\radare2\dest\bin\ConsoleApplication1.exe
 - 17564 ppid:17140 uid:2 s C:\workspace\cutter\radare2\dest\bin\ConsoleApplication1.exe
 - 6364 ppid:17140 uid:2 s C:\workspace\cutter\radare2\dest\bin\ConsoleApplication1.exe
[0x7ffd65295ac4]> dpj
[{"current":true,"ppid":10536,"pid":17140,"uid":2,"status":"s","path":"C:\\workspace\\cutter\\radare2\\dest\\bin\\ConsoleApplication1.exe"},{"current":false,"ppid":17140,"pid":17564,"uid":2,"status":"s","path":"C:\\workspace\\cutter\\radare2\\dest\\bin\\ConsoleApplication1.exe"},{"current":false,"ppid":17140,"pid":6364,"uid":2,"status":"s","path":"C:\\workspace\\cutter\\radare2\\dest\\bin\\ConsoleApplication1.exe"}
```