### PR TITLE
Fix #15653: Silence MSVC XP deprecation warning

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -233,7 +233,10 @@ def build(args):
             xp_compat(r2_builddir)
         if not args.project:
             project = os.path.join(r2_builddir, 'radare2.sln')
-            msbuild(project, '/m')
+            params = ['/m']
+            if args.backend == 'vs2017' and args.xp:
+                params.append('/p:XPDeprecationWarning=false')
+            msbuild(project, *params)
     else:
         ninja(r2_builddir)
 


### PR DESCRIPTION
Blindfix for #15653. Blind since msbuild is achingly slow on local machine. Hopefully will hog AppVeyor only once.