### PR TITLE
sys/meson.py: Use == 'vs2017' instead

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -229,7 +229,7 @@ def build(args):
               release=args.release, shared=args.shared, options=options)
     if args.backend != 'ninja':
         # XP support was dropped in Visual Studio 2019 v142 platform
-        if args.backend != 'vs2019' and args.xp:
+        if args.backend == 'vs2017' and args.xp:
             xp_compat(r2_builddir)
         if not args.project:
             project = os.path.join(r2_builddir, 'radare2.sln')


### PR DESCRIPTION
So that there is no need to update the code when VS 2021 comes around. Also, I think it's safe to assume that:

1. Microsoft will not reinstate XP support, ever.
1. There's no good reason to compile r2 using VS 2015 and below, instead of VS 2017.