### PR TITLE
Fix some Race Conditions

### DIFF
--- a/libr/core/task.c
+++ b/libr/core/task.c
@@ -334,8 +334,6 @@ R_API void r_core_task_schedule(RCoreTask *current, RTaskState next_state) {
 		} else {
 			r_cons_context_reset ();
 		}
-	} else {
-		r_cons_context_reset ();
 	}
 }
 

--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -57,7 +57,6 @@ typedef struct r_th_sem_t {
 } RThreadSemaphore;
 
 typedef struct r_th_lock_t {
-	int refs;
 	R_TH_LOCK_T lock;
 } RThreadLock;
 
@@ -102,7 +101,6 @@ R_API void r_th_sem_wait(RThreadSemaphore *sem);
 
 R_API RThreadLock *r_th_lock_new(bool recursive);
 R_API int r_th_lock_wait(RThreadLock *th);
-R_API int r_th_lock_check(RThreadLock *thl);
 R_API int r_th_lock_tryenter(RThreadLock *thl);
 R_API int r_th_lock_enter(RThreadLock *thl);
 R_API int r_th_lock_leave(RThreadLock *thl);

--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -189,6 +189,7 @@ typedef struct libgdbr_t {
 	libgdbr_stop_reason_t stop_reason;
 
 	RThreadLock *gdbr_lock;
+	int gdbr_lock_depth; // current depth inside the recursive lock
 
 	// parsed from target
 	struct {

--- a/shlr/gdb/src/libgdbr.c
+++ b/shlr/gdb/src/libgdbr.c
@@ -32,6 +32,7 @@ int gdbr_init(libgdbr_t *g, bool is_server) {
 	}
 	g->sock = r_socket_new (0);
 	g->gdbr_lock = r_th_lock_new (true);
+	g->gdbr_lock_depth = 0;
 	g->last_code = MSG_OK;
 	g->connected = 0;
 	g->data_len = 0;


### PR DESCRIPTION
As reported by helgrind.
RThreadLock.refs was broken beyond and only used in one place, so I removed it.