### PR TITLE
Fix gdbr regressions ##debug

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -888,16 +888,19 @@ static RList *var_generate_list(RAnal *a, RAnalFunction *fcn, int kind, bool dyn
 				av->size = vt.size;
 				av->type = strdup (vt.type);
 				if (av->isarg && kind == 'r') {
-					RRegItem *reg = r_reg_index_get (a->reg, delta);
-					int i;
-					int arg_max = fcn->cc ? r_anal_cc_max_arg (a, fcn->cc) : 0;
 					bool found = false;
-					for (i = 0; i < arg_max; i++) {
-						if (!strcmp (reg->name, r_anal_cc_arg (a, fcn->cc, i))) {
-							av->argnum = i;
-							found = true;
-							break;
+					RRegItem *reg = r_reg_index_get (a->reg, delta);
+					if (reg) {
+						int i;
+						int arg_max = fcn->cc ? r_anal_cc_max_arg (a, fcn->cc) : 0;
+						for (i = 0; i < arg_max; i++) {
+							if (!strcmp (reg->name, r_anal_cc_arg (a, fcn->cc, i))) {
+								av->argnum = i;
+								found = true;
+								break;
+							}
 						}
+
 					}
 					if (!found) {
 						av->argnum = delta;

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -1060,13 +1060,13 @@ static bool r_debug_gdb_kill(RDebug *dbg, int pid, int tid, int sig) {
 	return true;
 }
 
-static int r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
+static bool r_debug_gdb_select(RDebug *dbg, int pid, int tid) {
 	if (!desc || !*origriogdb) {
 		desc = NULL;	//TODO hacky fix, please improve. I would suggest using a **desc instead of a *desc, so it is automatically updated
-		return -1;
+		return false;
 	}
 
-	return gdbr_select (desc, pid, tid);
+	return gdbr_select (desc, pid, tid) >= 0;
 }
 
 static RDebugInfo* r_debug_gdb_info(RDebug *dbg, const char *arg) {

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -45,9 +45,9 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 
 R_API int r_th_lock_tryenter(RThreadLock *thl) {
 #if HAVE_PTHREAD
-	return pthread_mutex_trylock (&thl->lock);
+	return !pthread_mutex_trylock (&thl->lock);
 #elif __WINDOWS__
-	return TryEnterCriticalSection (&thl->lock) ? 0 : -1;
+	return TryEnterCriticalSection (&thl->lock);
 #endif
 }
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -118,6 +118,7 @@ void gdbr_lock_leave(libgdbr_t *g) {
 	assert (g->gdbr_lock_depth > 0);
 	bool last_leave = g->gdbr_lock_depth == 1;
 	r_th_lock_leave (g->gdbr_lock);
+	g->gdbr_lock_depth--;
 	// if this is the last lock this thread holds make sure that we disable the break
 	if (last_leave) {
 		g->isbreaked = false;


### PR DESCRIPTION
7d19556001153e04d7f03afbaf9a4b416810b3f2 changed var behavior and it broke rebasing in gdb.
~With this change rebase reanalyzes the variables since the remote targets don't necessarily have the same registers as the originally analyzed code.~ Fixed the crash for now, reanalyzing loses type information so I reverted. We need a better solution based on deltas instead of names.

Thanks @GustavoLCR for the help 👍 