### PR TITLE
Change Semantics of r_rbtree_upper_bound() and simplify Iter Fcns

### DIFF
--- a/libr/include/r_util/r_rbtree.h
+++ b/libr/include/r_util/r_rbtree.h
@@ -67,21 +67,18 @@ R_API void r_rbtree_free(RBNode *root, RBNodeFree freefn, void *user);
 R_API void r_rbtree_insert(RBNode **root, void *data, RBNode *node, RBComparator cmp, void *user);
 // Return the smallest node that is greater than or equal to `data`
 R_API RBNode *r_rbtree_lower_bound(RBNode *root, void *data, RBComparator cmp, void *user);
-// Return the smallest node that is greater than `data`
+// Return the greatest node that is less than or equal to `data`
 R_API RBNode *r_rbtree_upper_bound(RBNode *root, void *data, RBComparator cmp, void *user);
 
 // Create a forward iterator starting from the leftmost node
 R_API RBIter r_rbtree_first(RBNode *root);
 // Create a backward iterator starting from the rightmost node
 R_API RBIter r_rbtree_last(RBNode *root);
-// Iterate [lower_bound, end) forward, used with r_rbtree_iter_next
-R_API RBIter r_rbtree_lower_bound_backward(RBNode *root, void *data, RBComparator cmp, void *user);
-// Iterate [begin, lower_bound) backward, used with r_rbtree_iter_prev
+
+// Iterate [lower_bound, end] forward, used with r_rbtree_iter_next
 R_API RBIter r_rbtree_lower_bound_forward(RBNode *root, void *data, RBComparator cmp, void *user);
-// Iterate [upper_bound, end) forward, used with r_rbtree_iter_next
+// Iterate [begin, upper_bound] backward, used with r_rbtree_iter_prev
 R_API RBIter r_rbtree_upper_bound_backward(RBNode *root, void *data, RBComparator cmp, void *user);
-// Iterate [begin, upper_bound) backward, used with r_rbtree_iter_prev
-R_API RBIter r_rbtree_upper_bound_forward(RBNode *root, void *data, RBComparator cmp, void *user);
 
 // struct Node { int key; RBNode rb; };
 // r_rbtree_iter_get (it, struct Node, rb)

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -36,23 +36,28 @@ static inline RBNode *zig_zag(RBNode *x, int dir, RBNodeSum sum) {
 	return z;
 }
 
-static inline RBIter bound_iter(RBNode *x, void *data, RBComparator cmp, bool upper, bool backward, void *user) {
+static inline RBIter bound_iter(RBNode *x, void *data, RBComparator cmp, bool upper, void *user) {
 	RBIter it;
 	it.len = 0;
 	while (x) {
 		int d = cmp (data, x, user);
-		if (upper ? d < 0 : d <= 0) {
-			if (!backward) {
+		if (d == 0) {
+			it.path[it.len++] = x;
+			return it;
+		}
+		if (d <= 0) {
+			if (!upper) {
 				it.path[it.len++] = x;
 			}
 			x = x->child[0];
 		} else {
-			if (backward) {
+			if (upper) {
 				it.path[it.len++] = x;
 			}
 			x = x->child[1];
 		}
 	}
+
 	return it;
 }
 
@@ -323,12 +328,8 @@ R_API RBNode *r_rbtree_lower_bound(RBNode *x, void *data, RBComparator cmp, void
 	return ret;
 }
 
-R_API RBIter r_rbtree_lower_bound_backward(RBNode *root, void *data, RBComparator cmp, void *user) {
-	return bound_iter (root, data, cmp, false, true, user);
-}
-
 R_API RBIter r_rbtree_lower_bound_forward(RBNode *root, void *data, RBComparator cmp, void *user) {
-	return bound_iter (root, data, cmp, false, false, user);
+	return bound_iter (root, data, cmp, false, user);
 }
 
 R_API RBNode *r_rbtree_upper_bound(RBNode *x, void *data, RBComparator cmp, void *user) {
@@ -336,9 +337,9 @@ R_API RBNode *r_rbtree_upper_bound(RBNode *x, void *data, RBComparator cmp, void
 	while (x) {
 		int d = cmp (data, x, user);
 		if (d < 0) {
-			ret = x;
 			x = x->child[0];
 		} else {
+			ret = x;
 			x = x->child[1];
 		}
 	}
@@ -346,11 +347,7 @@ R_API RBNode *r_rbtree_upper_bound(RBNode *x, void *data, RBComparator cmp, void
 }
 
 R_API RBIter r_rbtree_upper_bound_backward(RBNode *root, void *data, RBComparator cmp, void *user) {
-	return bound_iter (root, data, cmp, true, true, user);
-}
-
-R_API RBIter r_rbtree_upper_bound_forward(RBNode *root, void *data, RBComparator cmp, void *user) {
-	return bound_iter (root, data, cmp, true, false, user);
+	return bound_iter (root, data, cmp, true, user);
 }
 
 static RBIter _first(RBNode *x, int dir) {

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -41,11 +41,13 @@ static inline RBIter bound_iter(RBNode *x, void *data, RBComparator cmp, bool up
 	it.len = 0;
 	while (x) {
 		int d = cmp (data, x, user);
+
 		if (d == 0) {
 			it.path[it.len++] = x;
 			return it;
 		}
-		if (d <= 0) {
+
+		if (d < 0) {
 			if (!upper) {
 				it.path[it.len++] = x;
 			}


### PR DESCRIPTION
For `r_rbtree_upper_bound()`,  "the smallest node that is greater than data" would mean "**smallest** node that is **outside** of the set given by the upper bound". For me, "**greatest** node that is **inside** the set given by the upper bound" makes more sense and is also much more useful next to the lower bound function.
The function was used nowhere before and had no tests, so that semantics change should be fine.

I also adjusted `r_rbtree_upper_bound_backward()` to go along with this meaning and removed `lower_bound_backward` and `upper_bound_forward` because they are complicated and I can't imagine a single use case for them right now. These functions also are not used anywhere except tests.