### PR TITLE
Prevent the restoration of disabled breakpoints ##debug

### DIFF
--- a/libr/bp/bp_io.c
+++ b/libr/bp/bp_io.c
@@ -42,6 +42,10 @@ R_API bool r_bp_restore_except(RBreakpoint *bp, bool set, ut64 addr) {
 		if (addr && b->addr == addr) {
 			continue;
 		}
+		// Avoid restoring disabled breakpoints
+		if (set && !b->enabled) {
+			continue;
+		}
 		if (bp->breakpoint && bp->breakpoint (bp, b, set)) {
 			continue;
 		}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3696,7 +3696,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			}
 		}
 		break;
-	case 'e':
+	case 'e': // "dbe"
 		for (p = input + 2; *p == ' '; p++);
 		if (*p == '*') r_bp_enable_all (core->dbg->bp,true);
 		else {
@@ -3704,7 +3704,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			r_bp_enable (core->dbg->bp, r_num_math (core->num, input + 2), true, r_num_math (core->num, p));
 		}
 		break;
-	case 'd':
+	case 'd': // "dbd"
 		for (p = input + 2; *p == ' '; p++);
 		if (*p == '*') r_bp_enable_all (core->dbg->bp, false);
 		else {
@@ -3712,7 +3712,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			r_bp_enable (core->dbg->bp, r_num_math (core->num, input + 2), false, r_num_math (core->num, p));
 		}
 		break;
-	case 'h':
+	case 'h': // "dbh"
 		switch (input[2]) {
 		case 0:
 			r_bp_plugin_list (core->dbg->bp);


### PR DESCRIPTION
Previously, disabled breakpoints were restored and then hit during execution. The debug logic ignored them and continued but that's an unnecessary slow down. To achieve this type of behavior the user should use tracepoints.

ref #1967