### PR TITLE
Fix windows breakpoint rebasing and debug reopening ##debug

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -109,7 +109,10 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 			newtid = newpid;
 #endif
 		}
-		//reopen and attach
+		// Reset previous pid and tid
+		core->dbg->pid = -1;
+		core->dbg->tid = -1;
+		// Reopen and attach
 		r_core_setup_debugger (core, "native", true);
 		r_debug_select (core->dbg, newpid, newtid);
 	}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1045,7 +1045,7 @@ static void __rebase_everything(RCore *core, RList *old_sections, ut64 old_base)
 	ht_up_free (old_xrefs);
 
 	// BREAKPOINTS
-	r_debug_bp_rebase (core->dbg, new_base);
+	r_debug_bp_rebase (core->dbg, old_base, new_base);
 }
 
 R_API void r_core_file_reopen_remote_debug(RCore *core, char *uri, ut64 addr) {

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -572,10 +572,15 @@ R_API int r_debug_start(RDebug *dbg, const char *cmd) {
 }
 
 R_API int r_debug_detach(RDebug *dbg, int pid) {
+	int ret = 0;
 	if (dbg->h && dbg->h->detach) {
-		return dbg->h->detach (dbg, pid);
+		ret = dbg->h->detach (dbg, pid);
+		if (dbg->pid == pid) {
+			dbg->pid = -1;
+			dbg->tid = -1;
+		}
 	}
-	return false;
+	return ret;
 }
 
 R_API bool r_debug_select(RDebug *dbg, int pid, int tid) {

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1711,14 +1711,16 @@ R_API ut64 r_debug_get_baddr(RDebug *dbg, const char *file) {
 	return 0LL;
 }
 
-R_API void r_debug_bp_rebase(RDebug *dbg, ut64 baddr) {
+R_API void r_debug_bp_rebase(RDebug *dbg, ut64 old_base, ut64 new_base) {
 	RBreakpointItem *bp;
 	RListIter *iter;
+	ut64 diff = new_base - old_base;
 	// update bp->baddr
-	dbg->bp->baddr = baddr;
+	dbg->bp->baddr = new_base;
 
 	// update bp's address
 	r_list_foreach (dbg->bp->bps, iter, bp) {
-		bp->addr = baddr + bp->delta;
+		bp->addr += diff;
+		bp->delta = bp->addr - dbg->bp->baddr;
 	}
 }

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -537,7 +537,7 @@ R_API bool r_debug_arg_set(RDebug *dbg, int fast, int num, ut64 value);
 
 /* breakpoints (most in r_bp, this calls those) */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, bool watch, int rw, char *module, st64 m_delta);
-R_API void r_debug_bp_rebase(RDebug *dbg, ut64 baddr);
+R_API void r_debug_bp_rebase(RDebug *dbg, ut64 old_base, ut64 new_base);
 R_API void r_debug_bp_update(RDebug *dbg);
 
 /* pid */


### PR DESCRIPTION
Windows breakpoint rebasing issue - bp->delta is calculated with the dbg->bp->baddr at the time of breakpoint creation, which may not reflect the correct baddr and break the rebase.

Windows debug reopen issue - attach_new_process was called(and failed if we already detached) instead of regular attach because the saved pid and tid in core->dbg weren't reset before calling r_debug_select in a new session. Made sure this won't be a problem when using dp= after dp- either.