### PR TITLE
Fix json generate bug

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1646,9 +1646,9 @@ static int bin_relocs(RCore *r, int mode, int va) {
 	db = NULL;
 
 	R_TIME_END;
-    if (IS_MODE_JSON (mode) && relocs == NULL) {
-        return true;
-    }
+	if (IS_MODE_JSON (mode) && relocs == NULL) {
+	    return true;
+	}
 	return relocs != NULL;
 }
 

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1647,7 +1647,7 @@ static int bin_relocs(RCore *r, int mode, int va) {
 
 	R_TIME_END;
 	if (IS_MODE_JSON (mode) && relocs == NULL) {
-	    return true;
+		return true;
 	}
 	return relocs != NULL;
 }

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3278,6 +3278,8 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 	const char *format_string = "%s/string%d";
 	if (!IS_MODE_JSON (mode)) {
 		r_cons_printf ("=== VS_VERSIONINFO ===\n\n");
+	} else {
+		r_cons_print ("{");
 	}
 	bool firstit_dowhile = true;
 	do {
@@ -3289,7 +3291,7 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 			r_cons_printf (",");
 		}
 		if (IS_MODE_JSON (mode)) {
-			r_cons_printf ("{\"VS_FIXEDFILEINFO\":{");
+			r_cons_printf ("\"VS_FIXEDFILEINFO\":{");
 		} else {
 			r_cons_printf ("# VS_FIXEDFILEINFO\n\n");
 		}
@@ -3387,11 +3389,14 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 			free (path_stringtable);
 		}
 		if (IS_MODE_JSON (mode)) {
-			r_cons_printf ("}}");
+			r_cons_printf ("}");
 		}
 		num_version++;
 		firstit_dowhile = false;
 	} while (sdb);
+	if (IS_MODE_JSON (mode)) {
+		r_cons_printf ("}");
+	}
 }
 
 static void bin_elf_versioninfo(RCore *r, int mode) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -442,6 +442,7 @@ static bool bin_raw_strings(RCore *r, int mode, int va) {
 		eprintf ("Core file not open\n");
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print ("[]");
+			return true;
 		}
 		return false;
 	}
@@ -494,6 +495,7 @@ static bool bin_strings(RCore *r, int mode, int va) {
 		if (strcmp (plugin->name, "any") == 0 && !rawstr) {
 			if (IS_MODE_JSON (mode)) {
 				r_cons_print ("[]");
+				return true;
 			}
 			return false;
 		}
@@ -619,6 +621,7 @@ static int bin_info(RCore *r, int mode, ut64 laddr) {
 	if (!bf || !info || !obj) {
 		if (mode & R_MODE_JSON) {
 			r_cons_printf ("{}");
+			return true;
 		}
 		return false;
 	}
@@ -1643,6 +1646,9 @@ static int bin_relocs(RCore *r, int mode, int va) {
 	db = NULL;
 
 	R_TIME_END;
+    if (IS_MODE_JSON (mode) && relocs == NULL) {
+        return true;
+    }
 	return relocs != NULL;
 }
 
@@ -2984,6 +2990,7 @@ static int bin_classes(RCore *r, int mode) {
 	if (!cs) {
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print ("[]");
+			return true;
 		}
 		return false;
 	}
@@ -3246,6 +3253,7 @@ static int bin_mem(RCore *r, int mode) {
 	if (!(mem = r_bin_get_mem (r->bin))) {
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print("[]");
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
I found here are a bug in rabin2 generate json, when I use rabin2 -j -g to analyize a file, sometime I would get a invalid json.
For example , your can use rabin2 -j -g configure . ( configure it's a file under this repo root path ), and you would get this json:

```
{"sections":[]
,"segments":[]
,"entries":[]
,"initfini":[]
,"main":false,"imports":[],"classes":[],"symbols":[{}],"strings":[]false,"info":{"arch":"","baddr":0,"binsz":21691,"bintype":"","bits":64,"canary":false,"class":"","compiled":"","compiler":"","crypto":false,"dbg_file":"","endian":"little","havecode":false,"guid":"","intrp":"","laddr":0,"lang":"","linenum":false,"lsyms":false,"machine":"","maxopsz":16,"minopsz":1,"nx":false,"os":"","pcalign":0,"pic":false,"relocs":false,"rpath":"","sanitiz":false,"static":true,"stripped":false,"subsys":"","va":false,"checksums":{}},"fields":false,"libs":false,"relocs":[]
false,"dwarf":false,"size":21691
,"versioninfo":false}
```
please check "strings" field and "relocs" field , they both have a extra value : "false" , Obviously, this a invalid json. 

I try to found the code of generate json , this code make the bug: (here just use "strings" key for example)
```
 libr/core/cbin.c
static bool bin_strings(RCore *r, int mode, int va) {
	RList *list;
	RBinFile *binfile = r_bin_cur (r->bin);
	RBinPlugin *plugin = r_bin_file_cur_plugin (binfile);
	int rawstr = r_config_get_i (r->config, "bin.rawstr");
	if (!binfile || !plugin) {
		return false;
	}
	if (!r_config_get_i (r->config, "bin.strings")) {
		return false;
	}
	if (plugin->info && plugin->name) {
		if (strcmp (plugin->name, "any") == 0 && !rawstr) {
			if (IS_MODE_JSON (mode)) {
				r_cons_print ("[]");    // in json mode , it would print "[]" ,but bin_strings return false.
			}
			return false;
		}
	}
	if (!(list = r_bin_get_strings (r->bin))) {
		return false;
	}
	_print_strings (r, list, mode, va);
	return true;
}

libr/main/rabin2.c
#define run_action(n,x,y) {\
	if (action&(x)) {\
		if (isradjson) r_cons_printf ("%s\"%s\":",actions_done?",":"",n);\
		if (!r_core_bin_info (&core, y, rad, va, &filter, chksum)) {\
 //but here add a extra "false" , becase of "bin_strings" return false
			if (isradjson) r_cons_print ("false");\    
		};\
		actions_done++;\
	}\
}

```

I try to fix it with this pull request, return true in json mode, to fix all case about it, and now, I get valid json string
```
{"sections":[]
,"segments":[]
,"entries":[]
,"initfini":[]
,"main":false,"imports":[],"classes":[],"symbols":[{}],"strings":[],"info":{"arch":"","baddr":0,"binsz":21691,"bintype":"","bits":64,"canary":false,"class":"","compiled":"","compiler":"","crypto":false,"dbg_file":"","endian":"little","havecode":false,"guid":"","intrp":"","laddr":0,"lang":"","linenum":false,"lsyms":false,"machine":"","maxopsz":16,"minopsz":1,"nx":false,"os":"","pcalign":0,"pic":false,"relocs":false,"rpath":"","sanitiz":false,"static":true,"stripped":false,"subsys":"","va":false,"checksums":{}},"fields":false,"libs":false,"relocs":[]
,"dwarf":false,"size":21691
,"versioninfo":false}
```







