### PR TITLE
Fix Field Seek in Visual Menus

### DIFF
--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1261,6 +1261,10 @@ R_API int r_core_visual_classes(RCore *core) {
 				r_core_seek (core, mur->vaddr, true);
 				return true;
 			}
+			if (fur) {
+				r_core_seek (core, fur->vaddr, true);
+				return true;
+			}
 			if (cur) {
 				oldcur = index;
 				index = 0;


### PR DESCRIPTION
To get rid of this `fur` warning