### PR TITLE
Fix var rebasing ##debug

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -967,19 +967,7 @@ static void __rebase_everything(RCore *core, RList *old_sections, ut64 old_base)
 			if (!__is_inside_section (fcn->addr, old_section)) {
 				continue;
 			}
-			RList *var_list = r_anal_var_all_list (core->anal, fcn);
-			RAnalVar *var;
-			r_list_foreach (var_list, ititit, var) {
-				const char *var_access = sdb_fmt ("var.0x%"PFMT64x ".%d.%d.access", var->addr, 1, var->delta);
-				char *access = sdb_get (core->anal->sdb_fcns, var_access, NULL);
-				r_anal_var_delete (core->anal, var->addr, var->kind, 1, var->delta);
-				var->addr += diff;
-				r_anal_var_add (core->anal, var->addr, 1, var->delta, var->kind, var->type, var->size, var->isarg, var->name);
-				var_access = sdb_fmt ("var.0x%"PFMT64x ".%d.%d.access", var->addr, 1, var->delta);
-				sdb_set (core->anal->sdb_fcns, var_access, access, 0);
-				free (access);
-			}
-			r_list_free (var_list);
+			r_anal_var_rebase (core->anal, fcn, diff);
 			r_anal_fcn_tree_delete (core->anal, fcn);
 			fcn->addr += diff;
 			if (fcn->meta.max) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -779,11 +779,12 @@ typedef const char *(*RAnalLabelAt) (RAnal *a, RAnalFunction *fcn, ut64);
 
 // generic for args and locals
 typedef struct r_anal_var_t {
-	char *name;  /* name of the variable */
-	char *type;  // cparse type of the variable
-	char kind;   // reg , stack ...
-	ut64 addr;   // not used correctly?
-	ut64 eaddr;  // not used correctly?
+	char *name; // name of the variable
+	char *regname; // name of the register
+	char *type; // cparse type of the variable
+	char kind; // reg , stack ...
+	ut64 addr; // not used correctly?
+	ut64 eaddr; // not used correctly?
 	int size;
 	bool isarg;
 	int argnum;
@@ -1622,6 +1623,7 @@ R_API int r_anal_var_access (RAnal *a, ut64 var_addr, char kind, int scope, int 
 R_API RAnalVar *r_anal_var_new(void);
 R_API int r_anal_var_rename (RAnal *a, ut64 var_addr, int scope, char kind,
 		const char *old_name, const char *new_name, bool verbose);
+R_API bool r_anal_var_rebase(RAnal *a, RAnalFunction *fcn, ut64 diff);
 R_API int r_anal_var_retype (RAnal *a, ut64 addr, int scope, int delta, char kind,
 		const char *type, int size, bool isarg, const char *name);
 R_API RAnalVarAccess *r_anal_var_access_new(void);


### PR DESCRIPTION
After starting debug the register deltas weren't mapped to the same registers in remote and native debug. This made wrong registers appear as vars in native debug and no registers were shown in remote gdb since the remote's list is much shorter than r2 reg lists.

Rebasing before the fix:
```
┌ 101: int main (int argc, char **argv, char **envp);
│           ; arg int argc @ rdi
│           ; arg char **argv @ rsi

┌ 101: int main (int argc, char **argv, char **envp);
│           ; arg int argc @ cf
│           ; arg char **argv @ rip
```

Rebasing in remote gdb before the fix:
```
┌ 101: int main (int argc, char **argv, char **envp);
│           ; arg int argc @ rdi
│           ; arg char **argv @ rsi

┌ 101: int main (int argc, char **argv, char **envp);
│           ; 
│           ; 
```

Now pre and post `ood`/`oodf` output should be the same.