### PR TITLE
izz: Fix printing of string with backslash if str.escbslash=false

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -369,10 +369,6 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 				}
 			}
 
-
-			if (str == no_dbl_bslash_str) {
-				R_FREE (str);
-			}
 			RStrBuf *buf = r_strbuf_new (str);
 			switch (string->type) {
 			case R_STRING_TYPE_UTF8:
@@ -403,6 +399,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 				(int)string->length, (int)string->size, section_name,
 				type_string, bufstr);
 			free (bufstr);
+			free (no_dbl_bslash_str);
 		}
 		last_processed = iter;
 	}

--- a/test/new/db/cmd/cmd_i
+++ b/test/new/db/cmd/cmd_i
@@ -3536,6 +3536,7 @@ NAME=str.escbslash and iz
 FILE=../bins/elf/strenc
 EXPECT=<<EOF
 16  0x00002528 0x00402528 24  100  .rodata utf32le \tLinux_wide\\esc: \e[0m¡\r\n blocks=Basic Latin,Latin-1 Supplement
+16  0x00002528 0x00402528 24  100  .rodata utf32le \tLinux_wide\esc: \e[0m¡\r\n blocks=Basic Latin,Latin-1 Supplement
 EOF
 CMDS=<<EOF
 e str.escbslash=true
@@ -3556,6 +3557,34 @@ CMDS=<<EOF
 iz~ABCDEF
 iz~abcdef
 iz~123456
+EOF
+RUN
+
+NAME=izz escaping backslash
+FILE=-
+CMDS=<<EOF
+wz QUVWXWYZ[\\]^_R
+px 16
+?e
+e str.escbslash=false  # default
+izz
+?e
+e str.escbslash=true
+izz
+EOF
+EXPECT=<<EOF
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000000  5155 5657 5857 595a 5b5c 5d5e 5f52 0000  QUVWXWYZ[\]^_R..
+
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x00000000 0x00000000 14  15           ascii QUVWXWYZ[\]^_R
+
+[Strings]
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x00000000 0x00000000 14  15           ascii QUVWXWYZ[\\]^_R
 EOF
 RUN
 


### PR DESCRIPTION
Fix for empty strings seen in https://github.com/radareorg/radare2/pull/15727#issue-357668117.