### PR TITLE
Fix windows dp showing the parent's path for all processes

### DIFF
--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -1366,12 +1366,12 @@ RList *w32_pid_list(RDebug *dbg, int pid, RList *list) {
 	pe.dwSize = sizeof (pe);
 	if (Process32First (sh, &pe)) {
 		RIOW32Dbg *rio = dbg->user;
-		bool all = pid == 0, b = false;
+		bool all = pid == 0;
 		do {
-			if (all || pe.th32ProcessID == pid || (b = pe.th32ParentProcessID == pid)) {
+			if (all || pe.th32ProcessID == pid || pe.th32ParentProcessID == pid) {
 				// Returns NULL if process is inaccessible unless if its a child process of debugged process
 				RDebugPid *dbg_pid = __build_debug_pid (pe.th32ProcessID, pe.th32ParentProcessID,
-					b ? rio->pi.hProcess : NULL, pe.szExeFile);
+					dbg->pid == pe.th32ProcessID ? rio->pi.hProcess : NULL, pe.szExeFile);
 				if (dbg_pid) {
 					r_list_append (list, dbg_pid);
 				}


### PR DESCRIPTION
b was true for all of the child processes so the parent's handle was used to get the path of each child instead of opening a new handle for the given pid in __build_debug_pid.

Previous output:

```
 * 19328 ppid:1316 uid:2 s C:\workspace\radare2\build\priv_install_dir\bin\radare2.exe
 - 10372 ppid:19328 uid:2 s C:\workspace\radare2\build\priv_install_dir\bin\radare2.exe
```

After fix:

```
 * 19328 ppid:1316 uid:2 s C:\workspace\radare2\build\priv_install_dir\bin\radare2.exe
 - 10372 ppid:19328 uid:2 s C:\Windows\System32\conhost.exe
```