### PR TITLE
Add location in file to linux dpt output ##debug

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -640,7 +640,7 @@ static RList *r_debug_native_threads (RDebug *dbg, int pid) {
 #elif __WINDOWS__
 	return w32_thread_list (dbg, pid, list);
 #elif __linux__
-	return linux_thread_list (pid, list);
+	return linux_thread_list (dbg, pid, list);
 #else
 	return bsd_thread_list (dbg, pid, list);
 #endif

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -98,7 +98,7 @@ int linux_attach(RDebug *dbg, int pid);
 bool linux_attach_new_process(RDebug *dbg, int pid);
 RDebugInfo *linux_info(RDebug *dbg, const char *arg);
 RList *linux_pid_list(int pid, RList *list);
-RList *linux_thread_list(int pid, RList *list);
+RList *linux_thread_list(RDebug *dbg, int pid, RList *list);
 bool linux_select(RDebug *dbg, int pid, int tid);
 RDebugPid *fill_pid_info(const char *info, const char *path, int tid);
 int linux_reg_read(RDebug *dbg, int type, ut8 *buf, int size);


### PR DESCRIPTION
Shows the module, offset and function name instead of showing the executable's
path for all threads.

```
 * 33225 s /home/yossi/workspace/tests/main (0x5585485d2cc5) in main+0x95
 - 33226 s /lib/x86_64-linux-gnu/libc-2.27.so (0x7f64539da9d0)
 - 33227 s /lib/x86_64-linux-gnu/libc-2.27.so (0x7f64539da9d0)
```