### PR TITLE
Apply types on matching zignature data ##signatures

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -833,6 +833,11 @@ static void __add_vars_sdb(RCore *core, RAnalFunction *fcn) {
 			arg_count++;
 		}
 	}
+	if (arg_count > 0) {
+		char *query = r_str_newf ("anal/types/func.%s.args=%d", fcn->name, arg_count);
+		sdb_querys (core->sdb, NULL, 0, query);
+		free (query);
+	}
 }
 
 static bool cmd_anal_aaft(RCore *core) {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -161,7 +161,7 @@ static bool addFcnVars(RCore *core, RAnalFunction *fcn, const char *name) {
 }
 
 static bool addFcnTypes(RCore *core, RAnalFunction *fcn, const char *name) {
-	RList *types = r_anal_types_from_fcn (core->anal, fcn);
+	RList *types = r_sign_fcn_types (core->anal, fcn);
 	if (!types) {
 		return false;
 	}
@@ -884,7 +884,7 @@ static bool search(RCore *core, bool rad, bool only_func) {
 	}
 
 	// Function search
-	// TODO (oxcabe): This big conditionals should be refactored into a variable
+	// TODO (oxcabe): Refactor big conditional
 	if (useGraph || useOffset || useRefs || useHash || (useBytes && only_func) || useTypes) {
 		eprintf ("[+] searching function metrics\n");
 		r_cons_break_push (NULL, NULL);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -806,7 +806,6 @@ static const char *types_list_to_fcnstr(RList *types) {
 	return ret;
 }
 
-// TODO (oxcabe):
 static void addFlag(RCore *core, RSignItem *it, ut64 addr, int size, int count, const char* prefix, bool rad) {
 	RAnalFunction *fcn = NULL;
 	const char *zign_prefix = r_config_get (core->config, "zign.prefix");
@@ -815,7 +814,7 @@ static void addFlag(RCore *core, RSignItem *it, ut64 addr, int size, int count, 
 	if (it->types) {
 		const char *fcnstr = types_list_to_fcnstr (it->types);
 		char *fcnstr_copy = strdup (fcnstr);
-		fcn = r_anal_get_fcn_at (core->anal, it->addr, 0);
+		fcn = r_anal_get_fcn_in (core->anal, it->addr, 0);
 		if (fcn) {
 			const char *fcn_name = strrchr (r_str_trim_tail (strtok (fcnstr_copy, "(")), ' ');
 			// __setFunctionName() ; cmd_anal.c:2535 ; Expand into R_API function
@@ -830,7 +829,7 @@ static void addFlag(RCore *core, RSignItem *it, ut64 addr, int size, int count, 
 			free (fcnstr_copy);
 		}
 	}
-	name = r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count);
+	name = r_name_filter2 (r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count));
 	if (name) {
 		if (rad) {
 			r_cons_printf ("f %s %d @ 0x%08"PFMT64x"\n", name, size, addr);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -2083,7 +2083,6 @@ R_API void r_anal_class_list(RAnal *anal, int mode);
 R_API void r_anal_class_list_bases(RAnal *anal, const char *class_name);
 R_API void r_anal_class_list_vtables(RAnal *anal, const char *class_name);
 
-R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn);
 R_API RAnalEsilCFG *r_anal_esil_cfg_expr(RAnalEsilCFG *cfg, RAnal *anal, const ut64 off, char *expr);
 R_API RAnalEsilCFG *r_anal_esil_cfg_op(RAnalEsilCFG *cfg, RAnal *anal, RAnalOp *op);
 R_API void r_anal_esil_cfg_merge_blocks(RAnalEsilCFG *cfg);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -132,6 +132,7 @@ R_API void r_sign_item_free(RSignItem *item);
 R_API RList *r_sign_fcn_refs(RAnal *a, RAnalFunction *fcn);
 R_API RList *r_sign_fcn_xrefs(RAnal *a, RAnalFunction *fcn);
 R_API RList *r_sign_fcn_vars(RAnal *a, RAnalFunction *fcn);
+R_API RList *r_sign_fcn_types(RAnal *a, RAnalFunction *fcn);
 
 R_API int r_sign_is_flirt(RBuffer *buf);
 R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file);

--- a/test/new/db/cmd/cmd_zignature
+++ b/test/new/db/cmd/cmd_zignature
@@ -424,7 +424,7 @@ zigs:main:
   realname: main
   refs: sym.print
   vars: b-4, b-16, r110, r114
-  types: int, char **, int64_t
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
   bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
 EOF
 CMDS=<<EOF
@@ -447,7 +447,7 @@ zigs:main:
   realname: main
   refs: sym.print
   vars: b-4, b-16, r110, r114
-  types: int, char **, int64_t
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
   bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
 EOF
 CMDS=<<EOF
@@ -469,7 +469,7 @@ main:
   addr: 0x0040055b
   refs: sym.print
   vars: b-4, b-16, r110, r114
-  types: int, char **, int64_t
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
   bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
 EOF
 CMDS=<<EOF
@@ -491,7 +491,7 @@ foobar:
   realname: main
   refs: sym.print
   vars: b-4, b-16, r110, r114
-  types: int, char **, int64_t
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
   bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
 EOF
 CMDS=<<EOF
@@ -514,7 +514,7 @@ foobar:
   realname: main
   refs: sym.print
   vars: b-4, b-16, r110, r114
-  types: int, char **, int64_t
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
   bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
 EOF
 CMDS=<<EOF


### PR DESCRIPTION
This is still WIP - don't merge yet, there are unnecessary comments and prints.

PR status:
- [x] Serialize types fields into zignatures:
Example: `types: main.ret=int, main.args=2, main.arg.0="int,argc", main.arg.1="char **,argv"`

- [x] Deserialize zignature types field into key-value strings. Done in `RList *zign_types_to_list(RAnal *a, char *types)`. 

- [x] Apply types information on matching functions.

Edit: Closes #15372