### PR TITLE
Fix hardware bp restoring and fix hwbp repeating errors ##debug

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1449,23 +1449,23 @@ static bool arm64_hwbp_del (RDebug *dbg, RBreakpoint *bp, RBreakpointItem *b) {
  * we only handle the case for hardware breakpoints here. otherwise,
  * we let the caller handle the work.
  */
-static int r_debug_native_bp (RBreakpoint *bp, RBreakpointItem *b, bool set) {
+static int r_debug_native_bp(RBreakpoint *bp, RBreakpointItem *b, bool set) {
 	RDebug *dbg = bp->user;
 	if (b && b->hw) {
 #if __i386__ || __x86_64__
-	return set
-		? drx_add (dbg, bp, b)
-		: drx_del (dbg, bp, b);
+		return set
+			? drx_add (dbg, bp, b)
+			: drx_del (dbg, bp, b);
 #elif __arm64__ || __aarch64__
-# if __linux__
-	return set
-		? arm64_hwbp_add (dbg, bp, b)
-		: arm64_hwbp_del (dbg, bp, b);
-# endif
+#if __linux__
+		return set
+			? arm64_hwbp_add (dbg, bp, b)
+			: arm64_hwbp_del (dbg, bp, b);
+#endif
 #elif __arm__
-	return set
-		? arm32_hwbp_add (dbg, bp, b)
-		: arm32_hwbp_del (dbg, bp, b);
+		return set
+			? arm32_hwbp_add (dbg, bp, b)
+			: arm32_hwbp_del (dbg, bp, b);
 #endif
 	}
 	return false;

--- a/libr/debug/p/native/drx.c
+++ b/libr/debug/p/native/drx.c
@@ -218,12 +218,11 @@ bool drx_add(RDebug *dbg, RBreakpoint *bp, RBreakpointItem *b) {
 bool drx_del(RDebug *dbg, RBreakpoint *bp, RBreakpointItem *b) {
 	if (bp->nhwbps > 0) {
 		r_debug_reg_sync (dbg, R_REG_TYPE_DRX, false);
-		r_debug_drx_set (dbg, bp->nhwbps, 0, 0, 0, 0);
+		r_debug_drx_unset (dbg, bp->nhwbps - 1);
 		r_debug_reg_sync (dbg, R_REG_TYPE_DRX, true);
 		bp->nhwbps--;
-		return true;
 	}
-	return false;
+	return true;
 }
 
 #if MAIN


### PR DESCRIPTION
Instead of unsetting breakpoints they were set again without removing the previous drx values, which also caused the "Invalid DRX length (0) must be 1, 2, 4, 8 bytes" error because of the wrong len values.
Also, when resetting twice, del failed since there weren't any hw registers to delete, which prompted the "hw breakpoints not yet supported" error by the fallback bp restore function.

ref [#1975](https://github.com/radareorg/cutter/pull/1975)