### PR TITLE
Validate bp addr on rebase and restore instead of preventing creation

### DIFF
--- a/libr/bp/bp_io.c
+++ b/libr/bp/bp_io.c
@@ -46,6 +46,11 @@ R_API bool r_bp_restore_except(RBreakpoint *bp, bool set, ut64 addr) {
 		if (set && !b->enabled) {
 			continue;
 		}
+		// Check if the breakpoint is in a valid map
+		if (set && !r_bp_is_valid (bp, b)) {
+			b->valid = false;
+			continue;
+		}
 		if (bp->breakpoint && bp->breakpoint (bp, b, set)) {
 			continue;
 		}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -3023,23 +3023,6 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 	}
 }
 
-static int validAddress(RCore *core, ut64 addr) {
-	RDebugMap *map;
-	RListIter *iter;
-	if (!r_config_get_i (core->config, "dbg.bpinmaps")) {
-		return core->num->value = 1;
-	}
-	r_debug_map_sync (core->dbg);
-	r_list_foreach (core->dbg->maps, iter, map) {
-		if (addr >= map->addr && addr < map->addr_end) {
-			return core->num->value = 1;
-		}
-	}
-	// TODO: try to read memory, expect no 0xffff
-	// TODO: check map permissions
-	return core->num->value = 0;
-}
-
 static void backtrace_vars(RCore *core, RList *frames) {
 	RDebugFrame *f;
 	RListIter *iter;
@@ -3367,13 +3350,9 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 	case '.':
 		if (input[2]) {
 			ut64 addr = r_num_tail (core->num, core->offset, input + 2);
-			if (validAddress (core, addr)) {
-				bpi = r_debug_bp_add (core->dbg, addr, hwbp, false, 0, NULL, 0);
-				if (!bpi) {
-					eprintf ("Unable to add breakpoint (%s)\n", input + 2);
-				}
-			} else {
-				eprintf ("Invalid address\n");
+			bpi = r_debug_bp_add (core->dbg, addr, hwbp, false, 0, NULL, 0);
+			if (!bpi) {
+				eprintf ("Unable to add breakpoint (%s)\n", input + 2);
 			}
 		} else {
 			bpi = r_bp_get_at (core->dbg->bp, core->offset);
@@ -3780,30 +3759,25 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 					}
 				}
 				addr = r_num_math (core->num, DB_ARG (i));
-				if (validAddress (core, addr)) {
-					bpi = r_debug_bp_add (core->dbg, addr, hwbp, watch, rw, NULL, 0);
-					if (bpi) {
-						free (bpi->name);
-						if (!strcmp (DB_ARG (i), "$$")) {
-							RFlagItem *f = r_core_flag_get_by_spaces (core->flags, addr);
-							if (f) {
-								if (addr > f->offset) {
-									bpi->name = r_str_newf ("%s+0x%" PFMT64x, f->name, addr - f->offset);
-								} else {
-									bpi->name = strdup (f->name);
-								}
+				bpi = r_debug_bp_add (core->dbg, addr, hwbp, watch, rw, NULL, 0);
+				if (bpi) {
+					free (bpi->name);
+					if (!strcmp (DB_ARG (i), "$$")) {
+						RFlagItem *f = r_core_flag_get_by_spaces (core->flags, addr);
+						if (f) {
+							if (addr > f->offset) {
+								bpi->name = r_str_newf ("%s+0x%" PFMT64x, f->name, addr - f->offset);
 							} else {
-								bpi->name = r_str_newf ("0x%08" PFMT64x, addr);
+								bpi->name = strdup (f->name);
 							}
 						} else {
-							bpi->name = strdup (DB_ARG (i));
+							bpi->name = r_str_newf ("0x%08" PFMT64x, addr);
 						}
 					} else {
-						eprintf ("Cannot set breakpoint at '%s'\n", DB_ARG (i));
+						bpi->name = strdup (DB_ARG (i));
 					}
 				} else {
-					eprintf ("Cannot place a breakpoint on 0x%08"PFMT64x" unmapped memory."
-								"See e? dbg.bpinmaps\n", addr);
+					eprintf ("Cannot set breakpoint at '%s'\n", DB_ARG (i));
 				}
 			}
 		}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2701,6 +2701,7 @@ R_API bool r_core_init(RCore *core) {
 	r_io_bind (core->io, &(core->dbg->iob));
 	r_io_bind (core->io, &(core->dbg->bp->iob));
 	r_core_bind (core, &core->dbg->corebind);
+	r_core_bind (core, &core->dbg->bp->corebind);
 	core->dbg->anal = core->anal; // XXX: dupped instance.. can cause lost pointerz
 	//r_debug_use (core->dbg, "native");
 // XXX pushing uninitialized regstate results in trashed reg values

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1727,5 +1727,11 @@ R_API void r_debug_bp_rebase(RDebug *dbg, ut64 old_base, ut64 new_base) {
 	r_list_foreach (dbg->bp->bps, iter, bp) {
 		bp->addr += diff;
 		bp->delta = bp->addr - dbg->bp->baddr;
+		// Check if the breakpoints are in valid maps after the rebase
+		if (r_bp_is_valid (dbg->bp, bp)) {
+			bp->valid = true;
+		} else {
+			bp->valid = false;
+		}
 	}
 }

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -48,6 +48,7 @@ typedef struct r_bp_item_t {
 	int size; /* size of breakpoint area */
 	int recoil; /* recoil */
 	bool swstep; 	/* is this breakpoint from a swstep? */
+	bool valid; /* Whether the breakpoint in a valid map */
 	int perm;
 	int hw;
 	int trace;
@@ -71,6 +72,7 @@ typedef struct r_bp_t {
 	int stepcont;
 	int endian;
 	int bits;
+	RCoreBind corebind;
 	RIOBind iob; // compile time dependency
 	RBreakpointPlugin *cur;
 	RList *traces; // XXX
@@ -137,6 +139,8 @@ R_API RBreakpointItem *r_bp_item_new (RBreakpoint *bp);
 
 R_API RBreakpointItem *r_bp_get_at (RBreakpoint *bp, ut64 addr);
 R_API RBreakpointItem *r_bp_get_in (RBreakpoint *bp, ut64 addr, int perm);
+
+R_API bool r_bp_is_valid(RBreakpoint *bp, RBreakpointItem *b);
 
 R_API int r_bp_add_cond(RBreakpoint *bp, const char *cond);
 R_API int r_bp_del_cond(RBreakpoint *bp, int idx);


### PR DESCRIPTION
This way it is possible to set breakpoints before starting debug through 'db' and the user will be notified when a breakpoint points to an invalid map.

ref [#1975](https://github.com/radareorg/cutter/pull/1975)