### PR TITLE
Fix json generate bug in parse dwarf

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1646,9 +1646,9 @@ static int bin_relocs(RCore *r, int mode, int va) {
 	db = NULL;
 
 	R_TIME_END;
-    if (IS_MODE_JSON (mode) && relocs == NULL) {
-        return true;
-    }
+	if (IS_MODE_JSON (mode) && relocs == NULL) {
+	    return true;
+	}
 	return relocs != NULL;
 }
 

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1647,7 +1647,7 @@ static int bin_relocs(RCore *r, int mode, int va) {
 
 	R_TIME_END;
 	if (IS_MODE_JSON (mode) && relocs == NULL) {
-	    return true;
+		return true;
 	}
 	return relocs != NULL;
 }

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3278,6 +3278,8 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 	const char *format_string = "%s/string%d";
 	if (!IS_MODE_JSON (mode)) {
 		r_cons_printf ("=== VS_VERSIONINFO ===\n\n");
+	} else {
+		r_cons_print ("{");
 	}
 	bool firstit_dowhile = true;
 	do {
@@ -3289,7 +3291,7 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 			r_cons_printf (",");
 		}
 		if (IS_MODE_JSON (mode)) {
-			r_cons_printf ("{\"VS_FIXEDFILEINFO\":{");
+			r_cons_printf ("\"VS_FIXEDFILEINFO\":{");
 		} else {
 			r_cons_printf ("# VS_FIXEDFILEINFO\n\n");
 		}
@@ -3387,11 +3389,14 @@ static void bin_pe_versioninfo(RCore *r, int mode) {
 			free (path_stringtable);
 		}
 		if (IS_MODE_JSON (mode)) {
-			r_cons_printf ("}}");
+			r_cons_printf ("}");
 		}
 		num_version++;
 		firstit_dowhile = false;
 	} while (sdb);
+	if (IS_MODE_JSON (mode)) {
+		r_cons_printf ("}");
+	}
 }
 
 static void bin_elf_versioninfo(RCore *r, int mode) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -442,6 +442,7 @@ static bool bin_raw_strings(RCore *r, int mode, int va) {
 		eprintf ("Core file not open\n");
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print ("[]");
+			return true;
 		}
 		return false;
 	}
@@ -494,6 +495,7 @@ static bool bin_strings(RCore *r, int mode, int va) {
 		if (strcmp (plugin->name, "any") == 0 && !rawstr) {
 			if (IS_MODE_JSON (mode)) {
 				r_cons_print ("[]");
+				return true;
 			}
 			return false;
 		}
@@ -619,6 +621,7 @@ static int bin_info(RCore *r, int mode, ut64 laddr) {
 	if (!bf || !info || !obj) {
 		if (mode & R_MODE_JSON) {
 			r_cons_printf ("{}");
+			return true;
 		}
 		return false;
 	}
@@ -1643,6 +1646,9 @@ static int bin_relocs(RCore *r, int mode, int va) {
 	db = NULL;
 
 	R_TIME_END;
+    if (IS_MODE_JSON (mode) && relocs == NULL) {
+        return true;
+    }
 	return relocs != NULL;
 }
 
@@ -2984,6 +2990,7 @@ static int bin_classes(RCore *r, int mode) {
 	if (!cs) {
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print ("[]");
+			return true;
 		}
 		return false;
 	}
@@ -3246,6 +3253,7 @@ static int bin_mem(RCore *r, int mode) {
 	if (!(mem = r_bin_get_mem (r->bin))) {
 		if (IS_MODE_JSON (mode)) {
 			r_cons_print("[]");
+			return true;
 		}
 		return false;
 	}

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -984,8 +984,8 @@ static int bin_dwarf(RCore *core, int mode) {
 				free (cmt);
 #endif
 			} else if(IS_MODE_JSON(mode)) {
-				r_cons_printf("%s[", last_processed ? "," : "");
-				r_cons_printf("{\"name\":\"%s\","
+				r_cons_printf ("%s[", last_processed ? "," : "");
+				r_cons_printf ("{\"name\":\"%s\","
 						"\"file\":\"%s\","
 						"\"line_num\":%d,"
 						"\"addr\":%" PFMT64d "},"


### PR DESCRIPTION
invalid json:
➜  tmp rabin2 -d -j radare2_elf
{"dwarf":CL radare2.c:88 0x00000ca8
CL radare2.c:94 0x00000ce9
"CC radare2.c:94 "@0xce9
CL types.h:5603 0x0000393b
..........
"CC types.h:5603 "@0x393b
CL radare2.c:48 0x00000ac2
"CC radare2.c:48 "@0xac2
}%         

valid json:
{
    "dwarf": [
        [
            {
                "name": "CC",
                "file": "radare2.c",
                "line_num": 64,
                "addr": 2939
            },
            {
                "name": "CL",
                "file": "radare2.c",
                "line_num": 64,
                "line": "",
                "addr": 2939
            }
        ],
        [
            {
                "name": "CC",
                "file": "types.h",
                "line_num": 5603,
                "addr": 14433
            },
            {
                "name": "CL",
                "file": "types.h",
                "line_num": 5603,
                "line": "",
                "addr": 14433
            }
        ],
        ..........
        [
            {
                "name": "CC",
                "file": "radare2.c",
                "line_num": 48,
                "addr": 2754
            },
            {
                "name": "CL",
                "file": "radare2.c",
                "line_num": 48,
                "line": "",
                "addr": 2754
            }
        ]
    ]
}                                                                                                                                                                                                    