### PR TITLE
Improve gdb dynamic register creation and fix drt ##debug

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2848,15 +2848,12 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			size = atoi (regname);
 			if (size < 1) {
 				char *arg = strchr (str + 2, ' ');
-				size = -1;
+				size = 0;
 				if (arg) {
 					*arg++ = 0;
 					size = atoi (arg);
 				}
 				type = r_reg_type_by_name (str + 2);
-				if (size < 0) {
-					size = core->dbg->bits * 8;
-				}
 				r_debug_reg_sync (core->dbg, type, false);
 				r_debug_reg_list (core->dbg, type, size, rad, use_color);
 			} else {

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -179,6 +179,7 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 	RListIter *iter;
 	gdbr_xml_flags_t *tmpflag;
 	gdbr_xml_reg_t *tmpreg;
+	int packed_size = 0;
 	ut64 profile_len = 0, profile_max_len, regnum = 0, regoff = 0;
 	pc_alias[0] = '\0';
 	gdb_reg_t *arch_regs = NULL;
@@ -224,9 +225,17 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 			tmpflag = r_list_get_n (flags, tmpreg->flagnum);
 			_write_flag_bits (flag_bits, tmpflag);
 		}
-		profile_len += snprintf (profile + profile_len, 128, "%s\t%s\t"
-					".%u\t%"PFMT64d"\t0\t%s\n", tmpreg->type,
-					tmpreg->name, tmpreg->size * 8, regoff, flag_bits);
+		packed_size = 0;
+		if (tmpreg->size >= 8 && (strstr (tmpreg->type, "fpu") ||
+			  strstr (tmpreg->type, "mmx") || strstr (tmpreg->type, "xmm") ||
+			  strstr (tmpreg->type, "ymm"))) {
+			packed_size = tmpreg->size;
+		}
+		profile_len += snprintf (profile + profile_len, 128,
+			"%s\t%s\t.%u\t%" PFMT64d "\t%d\t%s\n", tmpreg->type,
+			tmpreg->name, tmpreg->size * 8, regoff,
+			packed_size,
+			flag_bits);
 		// TODO write flag subregisters
 		if (tmpflag) {
 			int i;
@@ -746,7 +755,7 @@ static RList *_extract_regs(char *regstr, RList *flags, char *pc_alias) {
 			} else if ((tmp1 = strstr (regstr, "avx")) != NULL && tmp1 < feature_end) {
 				typegroup = "ymm";
 			} else if ((tmp1 = strstr (regstr, "mpx")) != NULL && tmp1 < feature_end) {
-				typegroup = "flg";
+				typegroup = "seg";
 			// - arm
 			} else if ((tmp1 = strstr (regstr, "m-profile")) != NULL && tmp1 < feature_end) {
 				typegroup = "gpr";
@@ -841,6 +850,10 @@ static RList *_extract_regs(char *regstr, RList *flags, char *pc_alias) {
 		// registers doesn't support >64bit registers atm(but it's still possible to
 		// read them using gdbr's implementation through dr/drt)
 		if (regsize > 64 && !strcmp (regtype, "gpr")) {
+			regtype = "xmm";
+		}
+		// Move appropriately sized unidentified xmm registers from fpu to xmm
+		if (regsize == 128 && !strcmp (regtype, "fpu")) {
 			regtype = "xmm";
 		}
 		if (!(tmpreg = calloc (1, sizeof (gdbr_xml_reg_t)))) {


### PR DESCRIPTION
`drt` didn't print most registers due to the arch size restriction.

Gdbr - Some xmm registers were printed as fpu and bnd registers were shown in all drt categories since they were marked as flags, moved to seg since we don't have a more appropriate section.