### PR TITLE
Pass 64-bit sdb_fmt parameters as 64-bit

### DIFF
--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -98,7 +98,7 @@ R_API void r_bin_filter_sym(RBinFile *bf, HtPP *ht, ut64 vaddr, RBinSymbol *sym)
 	}
 	sym->dup_count = 0;
 
-	const char *oname = sdb_fmt ("o.%" PFMT64x ".%s", (ut64) 0, name);
+	const char *oname = sdb_fmt ("o.0.%s", name);
 	RBinSymbol *prev_sym = ht_pp_find (ht, oname, NULL);
 	if (!prev_sym) {
 		if (!ht_pp_insert (ht, oname, sym)) {

--- a/libr/bin/filter.c
+++ b/libr/bin/filter.c
@@ -98,7 +98,7 @@ R_API void r_bin_filter_sym(RBinFile *bf, HtPP *ht, ut64 vaddr, RBinSymbol *sym)
 	}
 	sym->dup_count = 0;
 
-	const char *oname = sdb_fmt ("o.%" PFMT64x ".%s", 0, name);
+	const char *oname = sdb_fmt ("o.%" PFMT64x ".%s", (ut64) 0, name);
 	RBinSymbol *prev_sym = ht_pp_find (ht, oname, NULL);
 	if (!prev_sym) {
 		if (!ht_pp_insert (ht, oname, sym)) {


### PR DESCRIPTION
sdb_fmt(PFMT64x, 0) is undefined behavior if int is 32 bits, because the integer constant 0 is an int and vsnprintf will try to read a long long off the stack, resulting in overflow.