### PR TITLE
Fix double free in r_bp_del_index and other breakpoint index bugs

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -236,8 +236,12 @@ R_API RBreakpointItem* r_bp_add_hw(RBreakpoint *bp, ut64 addr, int size, int per
 }
 
 R_API int r_bp_del_all(RBreakpoint *bp) {
+	int i;
 	if (!r_list_empty (bp->bps)) {
 		r_list_purge (bp->bps);
+		for (i = 0; i < bp->bps_idx_count; i++) {
+			bp->bps_idx[i] = NULL;
+		}
 		return true;
 	}
 	return false;
@@ -388,7 +392,7 @@ R_API int r_bp_get_index_at (RBreakpoint *bp, ut64 addr) {
 R_API int r_bp_del_index(RBreakpoint *bp, int idx) {
 	if (idx >= 0 && idx < bp->bps_idx_count) {
 		r_list_delete_data (bp->bps, bp->bps_idx[idx]);
-		R_FREE (bp->bps_idx[idx]);
+		bp->bps_idx[idx] = 0;
 		return true;
 	}
 	return false;

--- a/test/new/db/archos/linux-x64/dbg_bps
+++ b/test/new/db/archos/linux-x64/dbg_bps
@@ -217,3 +217,33 @@ EXPECT=<<RUN
 "valid"
 EOF
 RUN
+
+NAME='dbg.bp_remove_index'
+FILE=../bins/elf/analysis/x86-helloworld-gcc
+ARGS=-d
+CMDS=<<EOF
+db main
+db main+1
+db main+2
+db main+4
+dbi~[0,2]
+db-*
+dbi
+db main
+db main+1
+dbi- 1
+?e ----------
+dbi~[0,2]
+dbi- 0
+dbi~[0,2]
+EOF
+EXPECT=<<EOF
+0 E:1
+1 E:1
+2 E:1
+3 E:1
+----------
+0 E:1
+Hello world!
+EOF
+RUN


### PR DESCRIPTION
* Lack of cleanup in r_bp_del_all causing use after free in other dbi
commands
* Copy paste error turning dbix into dbx
* Add dbi- command
* Allow dbi commands to operate with index 0