### PR TITLE
Added detailed location info to dpt using pc instead of path ##debug

### DIFF
--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -565,13 +565,11 @@ RList *bsd_thread_list(RDebug *dbg, int pid, RList *list) {
 	max = len / sizeof(*kp);
 	for (i = 0; i < max; i ++) {
 		RDebugPid *pid_info;
-		char tpath[64];
 		int pid_stat;
 
-		snprintf(tpath, sizeof (tpath), "%lx:%s", (long)kp[i].ki_wchan, kp[i].ki_comm);
 		pid_stat = get_r2_status (kp[i].ki_stat);
-		pid_info = r_debug_pid_new (tpath, kp[i].ki_tid,
-			kp[i].ki_uid, pid_stat, 0);
+		pid_info = r_debug_pid_new (kp[i].ki_comm, kp[i].ki_tid,
+			kp[i].ki_uid, pid_stat, (ut64)kp[i].ki_wchan);
 		r_list_append (list, pid_info);
 	}
 

--- a/libr/debug/pid.c
+++ b/libr/debug/pid.c
@@ -74,6 +74,9 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt) {
 	RList *list;
 	RListIter *iter;
 	RDebugPid *p;
+	RAnalFunction *fcn = NULL;
+	RDebugMap *map = NULL;
+	RStrBuf *path = NULL;
 	if (pid == -1) {
 		return false;
 	}
@@ -85,21 +88,36 @@ R_API int r_debug_thread_list(RDebug *dbg, int pid, char fmt) {
 		PJ *j = pj_new ();
 		pj_a (j);
 		r_list_foreach (list, iter, p) {
+			path = r_strbuf_new ("");
+			if (p->pc != 0) {
+				map = r_debug_map_get (dbg, p->pc);
+				if (map && map->name && map->name[0]) {
+					r_strbuf_appendf (path, "%s ", map->name);
+				}
+
+				r_strbuf_appendf (path, "(0x%" PFMT64x ")", p->pc);
+
+				fcn = r_anal_get_fcn_in (dbg->anal, p->pc, 0);
+				if (fcn) {
+					r_strbuf_appendf (path, " in %s+0x%" PFMT64x, fcn->name, (p->pc - fcn->addr));
+				}
+			}
 			switch (fmt) {
 			case 'j':
 				pj_o (j);
 				pj_kb (j, "current", dbg->tid == p->pid);
 				pj_ki (j, "pid", p->pid);
 				pj_ks (j, "status", &p->status);
-				pj_ks (j, "path", p->path);
+				pj_ks (j, "path", r_strbuf_get (path));
 				pj_end (j);
 				break;
 			default:
 				dbg->cb_printf (" %c %d %c %s\n",
 					dbg->tid == p->pid? '*': '-',
-					p->pid, p->status, p->path);
+					p->pid, p->status, r_strbuf_get (path));
 				break;
 			}
+			r_strbuf_free (path);
 		}
 		pj_end (j);
 		if (fmt == 'j') {


### PR DESCRIPTION
Same as #15744 which added code location data for linux debug. Instead of formatting the path string for each debug plugin, the path is based on the program counter if it was provided in pid info.
There is no point in showing the binary's path in `dpt` for each thread anyways, the user should use `dp` for that.

Windows:
```
 * 12620 r IMAGE    ConsoleApplication1.exe | .text (0x13e1307) in fcn.00411307+0x0
 - 29012 r IMAGE    ntdll.dll | .text (0x7ffd65299214)
 - 28832 r IMAGE    ntdll.dll | .text (0x7ffd65299214)
 - 23364 r IMAGE    ntdll.dll | .text (0x7ffd65299214)
```

Linux:
```
 * 33225 s /home/yossi/workspace/tests/main (0x5585485d2cc5) in main+0x95
 - 33226 s /lib/x86_64-linux-gnu/libc-2.27.so (0x7f64539da9d0)
 - 33227 s /lib/x86_64-linux-gnu/libc-2.27.so (0x7f64539da9d0)
```

Gdbr is a bit complicated and will require more work in a future PR. It will simply show an empty path field for now.

@devnexen please review the FreeBSD changes.