### PR TITLE
asm.symbol: Fix flag name when disasm from non-flag addr with no anal

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2674,7 +2674,7 @@ static void ds_print_lines_left(RDisasmState *ds) {
 			sfi.name = ds->fcn->name;
 			ds->lastflag = &sfi;
 		} else {
-			RFlagItem *fi = r_flag_get_at (core->flags, ds->at, false);
+			RFlagItem *fi = r_flag_get_at (core->flags, ds->at, true);
 			if (fi) { // && (!ds->lastflag || fi->offset != ds->at))
 				sfi.offset = fi->offset;
 				sfi.name = fi->name;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2674,7 +2674,10 @@ static void ds_print_lines_left(RDisasmState *ds) {
 			sfi.name = ds->fcn->name;
 			ds->lastflag = &sfi;
 		} else {
-			RFlagItem *fi = r_flag_get_at (core->flags, ds->at, true);
+			RFlagItem *fi = r_flag_get_at (core->flags, ds->at, false);
+			if (!fi && !ds->lastflag) {
+				fi = r_flag_get_at (core->flags, ds->at, true);
+			}
 			if (fi) { // && (!ds->lastflag || fi->offset != ds->at))
 				sfi.offset = fi->offset;
 				sfi.name = fi->name;

--- a/test/new/db/cmd/cmd_pd2
+++ b/test/new/db/cmd/cmd_pd2
@@ -782,10 +782,10 @@ s segment.LOAD0 + 83
 pd 4
 EOF
 EXPECT=<<EOF
-    + 0                   xor eax, eax
-    + 0                   inc eax
+   entry0 + 2                   xor eax, eax
+   entry0 + 4                   inc eax
 
-    + 0               ~   add byte [ebx + 0x40c0312a], dh
+   segment.LOAD0 + 83              ~   add byte [ebx + 0x40c0312a], dh
    entry0 + 0                   ;-- entry0:
    entry0 + 0                   mov bl, 0x2a
    entry0 + 2                   xor eax, eax

--- a/test/new/db/cmd/cmd_pd2
+++ b/test/new/db/cmd/cmd_pd2
@@ -767,3 +767,28 @@ EXPECT=<<RUN
                  mov esi, obj.utf32be_bom                              ; 0x4041e0 ; Ub"\ufeffUTF32BE_BOM"
                  mov esi, obj.utf32be_bom                              ; Ub"\ufeffUTF32BE_BOM"
 RUN
+
+NAME=no-anal asm.symbol from fcn mid
+FILE=../bins/elf/analysis/tiny1
+CMDS=<<EOF
+e asm.symbol=true
+e asm.bytes=false
+e asm.offset=false
+e asm.comments=false
+s entry0 + 2
+pd 2
+?e
+s segment.LOAD0 + 83
+pd 4
+EOF
+EXPECT=<<EOF
+    + 0                   xor eax, eax
+    + 0                   inc eax
+
+    + 0               ~   add byte [ebx + 0x40c0312a], dh
+   entry0 + 0                   ;-- entry0:
+   entry0 + 0                   mov bl, 0x2a
+   entry0 + 2                   xor eax, eax
+   entry0 + 4                   inc eax
+EOF
+RUN


### PR DESCRIPTION
https://github.com/radareorg/radare2/commit/2c44b263dc935714a9fcad06dbd0c54eb3bf4dda#diff-bc8bf85d0cb3d8909bef69fb94c6b1aa