### PR TITLE
Add register comment support and drC/j to view them

### DIFF
--- a/libr/include/r_reg.h
+++ b/libr/include/r_reg.h
@@ -94,6 +94,7 @@ typedef struct r_reg_item_t {
 	int packed_size; /* 0 means no packed register, 1byte pack, 2b pack... */
 	bool is_float;
 	char *flags;
+	char *comment;
 	int index;
 	int arena; /* in which arena is this reg living */
 } RRegItem;

--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -97,7 +97,12 @@ static const char *parse_def(RReg *reg, char **tok, const int n) {
 
 	// This is optional
 	if (n == 6) {
-		item->flags = strdup (tok[5]);
+		if (*tok[5] == '#') {
+			// Remove # from the comment
+			item->comment = strdup (tok[5] + 1);
+		} else {
+			item->flags = strdup (tok[5]);
+		}
 	}
 
 	item->arena = type2;
@@ -166,20 +171,23 @@ R_API bool r_reg_set_profile_string(RReg *reg, const char *str) {
 			while (*p == ' ' || *p == '\t') {
 				p++;
 			}
-			// Skip the rest of the line is a comment is encountered
-			if (*p == '#') {
-				while (*p != '\n') {
-					p++;
-				}
-			}
 			// EOL ?
 			if (*p == '\n') {
 				break;
 			}
-			// Gather a handful of chars
-			// Use isgraph instead of isprint because the latter considers ' ' printable
-			for (i = 0; isgraph ((const unsigned char)*p) && i < sizeof (tmp) - 1;) {
-				tmp[i++] = *p++;
+			if (*p == '#') {
+				// Place the rest of the line in the token if a comment is encountered
+				for (i = 0; *p != '\n'; p++) {
+					if (i < sizeof (tmp) - 1) {
+						tmp[i++] = *p;
+					}
+				}
+			} else {
+				// Save all characters up to a space/tab
+				// Use isgraph instead of isprint because the latter considers ' ' printable
+				for (i = 0; isgraph ((const unsigned char)*p) && i < sizeof (tmp) - 1;) {
+					tmp[i++] = *p++;
+				}
 			}
 			tmp[i] = '\0';
 			// Limit the number of tokens


### PR DESCRIPTION
We are planning to add documentation on register hover to Cutter's register widget((Mainly for FPU regs), this change enables it.

The profile comment command was moved from drC to drcp.