### PR TITLE
Hide flag comments when realname is shown

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3951,11 +3951,11 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 				ut64 relsub_addr = core->parser->relsub_addr;
 				if (relsub_addr && relsub_addr != p) {
 					f2 = r_core_flag_get_by_spaces (core->flags, relsub_addr);
-					f2_in_opstr = f2 && ds->opstr && strstr (ds->opstr, f2->name);
+					f2_in_opstr = f2 && ds->opstr && (strstr (ds->opstr, f2->name) || strstr (ds->opstr, f2->realname)) ;
 				}
 				refaddr = p;
 				if (!flag_printed && !is_filtered_flag (ds, f->name)
-				    && (!ds->opstr || !strstr (ds->opstr, f->name))
+				    && (!ds->opstr || (!strstr (ds->opstr, f->name) && !strstr (ds->opstr, f->realname)))
 				    && !f2_in_opstr) {
 					ds_begin_comment (ds);
 					ds_comment (ds, true, "; %s", f->name);
@@ -4091,7 +4091,8 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					ds_print_str (ds, msg, len, refaddr);
 					string_printed = true;
 				}
-			} else if (!flag_printed && (!ds->opstr || !strstr (ds->opstr, f->name))) {
+			} else if (!flag_printed && (!ds->opstr || 
+						(!strstr (ds->opstr, f->name) && !strstr (ds->opstr, f->realname)))) {
 				ds_begin_nl_comment (ds);
 				ds_comment (ds, true, "; %s", f->name);
 				ds->printed_flag_addr = refaddr;


### PR DESCRIPTION
Currently, when `e asm.flags.real` is enabled, radare2 will print a comment with the full name of the flag because it thinks that the flag wasn't printed. This Pull Request make sure that r2 will know that the flag was printed by its real name.

**Before** ( notice the `sym.imp.KERNEL32.dll_LoadResource` prints)
```
0x004014fd      call dword [FindResourceW]          ; sym.imp.KERNEL32.dll_FindResourceW
                                                    ; 0x403028 ; HRSRC FindResourceW(HMODULE hModule, LPCWSTR lpName, LPCWSTR lpType)
0x00401503      mov esi, eax
0x00401505      push esi                            ; HRSRC hResInfo
0x00401506      push 0                              ; HMODULE hModule
0x00401508      call dword [LoadResource]           ; sym.imp.KERNEL32.dll_LoadResource
                                                    ; 0x40302c ; HGLOBAL LoadResource(HMODULE hModule, HRSRC hResInfo)
0x0040150e      push esi                            ; HRSRC hResInfo
0x0040150f      push 0                              ; HMODULE hModule
0x00401511      mov edi, eax
0x00401513      call dword [SizeofResource]         ; sym.imp.KERNEL32.dll_SizeofResource
                                                    ; 0x403030 ; DWORD SizeofResource(HMODULE hModule, HRSRC hResInfo)
0x00401519      push edi                            ; HGLOBAL hResData
0x0040151a      mov esi, eax
0x0040151c      call dword [LockResource]           ; sym.imp.KERNEL32.dll_LockResource

```


**After:**
```
0x004014fd      call dword [FindResourceW]          ; 0x403028 ; HRSRC FindResourceW(HMODULE hModule, LPCWSTR lpName, LPCWSTR lpType)
0x00401503      mov esi, eax
0x00401505      push esi                            ; HRSRC hResInfo
0x00401506      push 0                              ; HMODULE hModule
0x00401508      call dword [LoadResource]           ; 0x40302c ; HGLOBAL LoadResource(HMODULE hModule, HRSRC hResInfo)
0x0040150e      push esi                            ; HRSRC hResInfo
0x0040150f      push 0                              ; HMODULE hModule
0x00401511      mov edi, eax
0x00401513      call dword [SizeofResource]         ; 0x403030 ; DWORD SizeofResource(HMODULE hModule, HRSRC hResInfo)
0x00401519      push edi                            ; HGLOBAL hResData
0x0040151a      mov esi, eax
0x0040151c      call dword [LockResource]           ; 0x403034 ; LPVOID LockResource(HGLOBAL hResData)

```




