### PR TITLE
Added reverse step and continue support to gdbr ##debug

### DIFF
--- a/shlr/gdb/src/common.c
+++ b/shlr/gdb/src/common.c
@@ -113,6 +113,10 @@ int handle_qSupported(libgdbr_t *g) {
 		} else if (r_str_startswith (tok, "qEcho")) {
 			g->remote_type = GDB_REMOTE_TYPE_LLDB;
 			g->stub_features.lldb.qEcho = (tok[strlen ("qEcho")] == '+');
+		} else if (r_str_startswith (tok, "ReverseStep")) {
+			g->stub_features.ReverseStep = (tok[strlen ("ReverseStep")] == '+');
+		} else if (r_str_startswith (tok, "ReverseContinue")) {
+			g->stub_features.ReverseContinue = (tok[strlen ("ReverseContinue")] == '+');
 		}
 		// TODO
 		tok = strtok (NULL, ";");


### PR DESCRIPTION
This feature only works with server implementations that have ReverseStep and ReverseContinue enabled, such as mozilla's [rr](https://github.com/mozilla/rr)(used to test this feature). The official gdbserver doesn't support it. `=!rd` was added so that external tools will be able to check support.

ref #8966, don't close it though since these commands only work for special gdbservers.