### PR TITLE
WIP: Fix r_list_set_n() to allow empty element

### DIFF
--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -418,7 +418,7 @@ R_API int r_list_set_n(RList *list, int n, void *p) {
 	r_return_val_if_fail (list, false);
 	for (it = list->head, i = 0; it ; it = it->n, i++) {
 		if (i == n) {
-			if (list->free && it->data) {
+			if (list->free) {
 				list->free (it->data);
 			}
 			it->data = p;

--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -416,9 +416,9 @@ R_API int r_list_set_n(RList *list, int n, void *p) {
 	int i;
 
 	r_return_val_if_fail (list, false);
-	for (it = list->head, i = 0; it && it->data; it = it->n, i++) {
+	for (it = list->head, i = 0; it ; it = it->n, i++) {
 		if (i == n) {
-			if (list->free) {
+			if (list->free && it->data) {
 				list->free (it->data);
 			}
 			it->data = p;


### PR DESCRIPTION
`r_list_set_n` is used to replace `n`'th element in a given list. If one element in the list is empty, the iteration will be terminated and no chance to compare tailing indexes.

(see related issue: https://github.com/radareorg/radare2/issues/15815)

Thus, I changed this function to allow an `empty` list object. and compare the `data` just before `free`.
