### PR TITLE
Convert cmd_pd* tests from <<KEYWORD to <<EOF

### DIFF
--- a/test/new/db/cmd/cmd_pd
+++ b/test/new/db/cmd/cmd_pd
@@ -427,16 +427,18 @@ RUN
 
 NAME=pdj -1
 FILE=malloc://1024
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=32
 wx 56687cd3400090
 aaa
 s 6
 pdj -1
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 [{"offset":1,"ptr":4248444,"val":4248444,"esil":"4248444,4,esp,-,=[4],4,esp,-=","refptr":false,"fcn_addr":0,"fcn_last":1020,"size":5,"opcode":"push 0x40d37c","disasm":"push 0x40d37c","bytes":"687cd34000","family":"cpu","type":"push","reloc":false,"type_num":13,"type2_num":0}]
 
+EOF
 RUN
 
 NAME=pdj 3 @ main
@@ -645,7 +647,7 @@ RUN
 
 NAME=pdf fcnline
 FILE=../bins/pe/a.exe
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.lines.fcn=true
 s 0x004017c0
 af+ 0x004017c0 fcn2.0x004017c0
@@ -654,7 +656,8 @@ pdf
 ?e
 e asm.lines.fcn=false
 pdf
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 / 13: fcn2.0x004017c0 ();
 |           0x004017c0      51             push ecx
 |           0x004017c1      89e1           mov ecx, esp
@@ -668,6 +671,7 @@ EXPECT=<<RUN
           0x004017c3      83c108         add ecx, 8
           0x004017c6      3d00100000     cmp eax, 0x1000
       ,=< 0x004017cb      7210           jb 0x4017dd
+EOF
 RUN
 
 NAME=r_str_escape anal
@@ -1343,11 +1347,13 @@ RUN
 
 NAME=pdJ asm.emu=1 comment
 FILE=../bins/elf/crackme0x05
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.emu=1
 pdJ 1 @ 0x08048566
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 [{"offset":134514022,"text":"            0x08048566      e829feffff     call sym.imp.printf         ; esp=0xfffffffffffffffc ; eip=0x8048394 -> 0xa00c25ff"},{"offset":134514022,"text":"                                                                       ; int printf(-1)"}]
+EOF
 RUN
 
 NAME=pdJ asm.emu=1 string
@@ -1637,7 +1643,7 @@ RUN
 
 NAME=emu.strinv
 FILE=../bins/elf/redpill
-CMDS=<<EXPECT
+CMDS=<<EOF
 e scr.color=1
 e asm.bytes=false
 e emu.pre=true
@@ -1657,7 +1663,8 @@ e emu.str.inv=true
 pd 1 @ 0x161d
 e emu.str.inv=false
 pd 1 @ 0x161d
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m[31m                 ; 0x21f7[31m ; "abcdefghi"[0m[31m ; [7m"\n  Blue Pill"[27m str.Blue_Pill[0m
             [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m[31m                 ; 0x21f7[31m ; [7m"abcdefghi"[27m[0m[31m ; "\n  Blue Pill" str.Blue_Pill[0m
 
@@ -1669,11 +1676,12 @@ EXPECT=<<RUN
             [31m; [7m"abcdefghi"[27m
 [0m[31m[0m               [31m; "\n  Blue Pill" str.Blue_Pill
 [0m            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m
+EOF
 RUN
 
 NAME=emu.strflag
 FILE=../bins/elf/redpill
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e emu.pre=true
 e emu.str=true
@@ -1682,10 +1690,12 @@ pd 1 @ 0x161d
 e emu.str.flag=false
 pd 1 @ 0x161d
 pd 1 @ 0x1447
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x0000161d      lea eax, [esi - 0x21f7]                    ; "\n  Blue Pill" str.Blue_Pill
             0x0000161d      lea eax, [esi - 0x21f7]                    ; "\n  Blue Pill"
             0x00001447      add esi, 0x2bb9                            ; section..got.plt
+EOF
 RUN
 
 NAME=ctrl chars
@@ -1747,7 +1757,7 @@ RUN
 
 NAME=two-operand line highlight; asm.highlight ecHw fix; ec wordhl/linehl
 FILE=../bins/elf/redpill
-CMDS=<<EXPECT
+CMDS=<<EOF
 . ../bins/other/palette.r2
 e scr.color=3
 e emu.str=true
@@ -1769,7 +1779,8 @@ ecHw eax
 e asm.highlight=0x1457
 s 0
 pd 1 @ 0x1457
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             [48;2;0;0;128m[38;2;19;161;14m0x00001457[27;22;24;25;28;39m      [38;2;204;204;204m8d[38;2;204;204;204m86[38;2;204;204;204m89[38;2;204;204;204mdd[38;2;197;15;31mff[38;2;197;15;31mff[27;22;24;25;28;39m   [38;2;204;204;204mlea[38;2;58;150;221m eax[27;22;24;25;28;39m,[38;2;58;150;221m [27;22;24;25;28;39m[[38;2;58;150;221mesi [27;22;24;25;28;39m-[38;2;58;150;221m[38;2;58;150;221m [38;2;193;156;0m0x2277[27;22;24;25;28;39m][38;2;58;150;221m[27;22;24;25;28;39m[0m[0m[0m[38;2;197;15;31m     ; " Take the Red Pill!! \n"[0m
             [38;2;19;161;14m0x0000145d[27;22;24;25;28;39m      [38;2;193;156;0m50[27;22;24;25;28;39m             [38;2;136;23;152mpush[38;2;58;150;221m eax[0m[0m[0m[38;2;197;15;31m[0m
             [38;2;19;161;14m0x0000145e[27;22;24;25;28;39m      [38;2;204;204;204m8b[38;2;204;204;204m86[38;2;204;204;204mf0[38;2;197;15;31mff[38;2;197;15;31mff[38;2;197;15;31mff[27;22;24;25;28;39m   [38;2;204;204;204mmov[38;2;58;150;221m eax[0m,[38;2;58;150;221m dword [0m[[38;2;58;150;221mesi [0m-[38;2;58;150;221m[38;2;58;150;221m [38;2;193;156;0m0x10[0m][38;2;58;150;221m[0m[0m[0m[38;2;197;15;31m[0m
@@ -1777,11 +1788,12 @@ EXPECT=<<RUN
             [48;2;0;0;0m[38;2;19;161;14m0x00001457[27;22;24;25;28;39m      [38;2;204;204;204m8d[38;2;204;204;204m86[38;2;204;204;204m89[38;2;204;204;204mdd[38;2;197;15;31mff[38;2;197;15;31mff[27;22;24;25;28;39m   [38;2;204;204;204mlea[38;2;58;150;221m eax[27;22;24;25;28;39m,[38;2;58;150;221m [27;22;24;25;28;39m[[38;2;58;150;221mesi [27;22;24;25;28;39m-[38;2;58;150;221m[38;2;58;150;221m [38;2;193;156;0m0x2277[27;22;24;25;28;39m][38;2;58;150;221m[27;22;24;25;28;39m[0m[0m[0m[38;2;197;15;31m     ; " Take the Red Pill!! \n"[0m
             [48;2;0;47;0m[38;2;19;161;14m0x00001457[27;22;24;25;28;39m      [38;2;204;204;204m8d[38;2;204;204;204m86[38;2;204;204;204m89[38;2;204;204;204mdd[38;2;197;15;31mff[38;2;197;15;31mff[27;22;24;25;28;39m   [38;2;204;204;204mlea[38;2;58;150;221m eax[27;22;24;25;28;39m,[38;2;58;150;221m [27;22;24;25;28;39m[[38;2;58;150;221mesi [27;22;24;25;28;39m-[38;2;58;150;221m[38;2;58;150;221m [38;2;193;156;0m0x2277[27;22;24;25;28;39m][38;2;58;150;221m[27;22;24;25;28;39m[0m[0m[0m[38;2;197;15;31m     ; " Take the Red Pill!! \n"[0m
             [48;2;0;47;0m[38;2;19;161;14m0x00001457[27;22;24;25;28;39m      [38;2;204;204;204m8d[38;2;204;204;204m86[38;2;204;204;204m89[38;2;204;204;204mdd[38;2;197;15;31mff[38;2;197;15;31mff[27;22;24;25;28;39m   [38;2;204;204;204mlea[38;2;58;150;221m [48;2;128;0;0meax[48;2;0;47;0m[27;22;24;25;28;39m,[38;2;58;150;221m [27;22;24;25;28;39m[[38;2;58;150;221mesi [27;22;24;25;28;39m-[38;2;58;150;221m[38;2;58;150;221m [38;2;193;156;0m0x2277[27;22;24;25;28;39m][38;2;58;150;221m[27;22;24;25;28;39m[0m[0m[0m[38;2;197;15;31m     ; " Take the Red Pill!! \n"[0m
+EOF
 RUN
 
 NAME=pdJ with backslashes, quotation marks, str.escbslash and bin.str.enc
 FILE=-
-CMDS=<<EXPECT
+CMDS=<<EOF
 e io.cache=true
 e asm.arch=x86
 e asm.bits=32
@@ -1815,7 +1827,8 @@ pdJ 1
 e str.escbslash=false
 pd 1
 pdJ 1
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x00002000      mov eax, 0x1000                            ; ansi_str ; "path\"C:\\Program\n"
 [{"offset":8192,"text":"            0x00002000      mov eax, 0x1000                            ; ansi_str ; \"path\\\"C:\\\\Program\\n\""}]
             0x00002000      mov eax, 0x1000                            ; ansi_str ; "path\"C:\Program\n"
@@ -1828,11 +1841,12 @@ EXPECT=<<RUN
 [{"offset":16384,"text":"            0x00004000      mov ebx, 0x3000                            ; wide_str ; u\"path\\\"C:\\\\Program\\r\""}]
             0x00004000      mov ebx, 0x3000                            ; wide_str ; u"path\"C:\Program\r"
 [{"offset":16384,"text":"            0x00004000      mov ebx, 0x3000                            ; wide_str ; u\"path\\\"C:\\Program\\r\""}]
+EOF
 RUN
 
 NAME=arm asm.var.sub, asm.ucase and asm.pseudo (fp)
 FILE=../bins/elf/analysis/armcall
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.comments=false
 e io.cache=true
@@ -1858,7 +1872,8 @@ s main
 afvn local2 var_ch
 afvn arg1 arg_8h
 pd 4 @ 0x0001045c
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 |           0x0001045c      STR R0, [var_8h]
 |           0x00010460      STR R1, [var_ch]
 |           0x00010464      LDR R0, [arg_8h]
@@ -1878,15 +1893,17 @@ EXPECT=<<RUN
 |           0x00010460      [local2] = r1
 |           0x00010464      r0 = [arg1]
 |           0x00010468      r1 = [arg_ch]
+EOF
 RUN
 
 NAME=pdfj with padding
 FILE=../bins/elf/padding_in_func
-CMDS=<<EXPECT
+CMDS=<<EOF
 s main
 af
 pdfj~{} | grep opcode
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
       "opcode": "push rbp",
       "opcode": "push rbx",
       "opcode": "push rax",
@@ -1927,51 +1944,58 @@ EXPECT=<<RUN
       "opcode": "pop rbp",
       "opcode": "ret",
       "opcode": "jmp 0x4005d0",
+EOF
 RUN
 
 NAME=asm.imm.str, mov and movabs (#10473)
 FILE=../bins/elf/echo-bin
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.imm.str=true
 pd 1 @ 0x9a2
 pd 1 @ 0x9a9
 pd 1 @ 0x9b3
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x000009a2      mov dword [rbp - 0x30], 0x3c3c2b3e         ; '>+<<'
             0x000009a9      mov word [rbp - 0x2c], 0x3e5d              ; ']>'
             0x000009b3      movabs rax, 0x3c2b3c3c5b3e3e3e             ; '>>>[<<+<'
+EOF
 RUN
 
 NAME=asm.imm.str, asm.cmd.right=false, pd and pdJ
 FILE=../bins/elf/echo-bin
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.imm.str=true
 e asm.cmt.right=false
 pd 1 @ 0x9b3
 ?e
 pdJ 1 @ 0x9b3
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             ; '>>>[<<+<'
             0x000009b3      48b83e3e3e5b.  movabs rax, 0x3c2b3c3c5b3e3e3e
 
 [{"offset":2483,"text":"            ; '>>>[<<+<'"},{"offset":2483,"text":"            0x000009b3      48b83e3e3e5b.  movabs rax, 0x3c2b3c3c5b3e3e3e"}]
+EOF
 RUN
 
 NAME=asm.imm.str short false positive
 FILE=../bins/elf/analysis/fast
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.imm.str=true
 f- @ 0x08048574
 pd 1 @ 0x08048444
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x08048444      push 0x8048574
+EOF
 RUN
 
 NAME=asm.imm.str and flag
 FILE=../bins/elf/strenc
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.imm.str=true
 e bin.str.enc=utf16le
@@ -1979,28 +2003,33 @@ pd 1 @ 0x004016ca
 f str.fence @ 0x40235a
 e asm.cmt.off=false
 pd 1 @ 0x004016ca
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x004016ca      mov edi, 0x40235a                          ; 'Z#@' ; u"\u2520\u2542-\u2500-\u2500\u2542\u2528 is a fence with embedded double zeros\n"
             0x004016ca      mov edi, str.fence                         ; u"\u2520\u2542-\u2500-\u2500\u2542\u2528 is a fence with embedded double zeros\n"
+EOF
 RUN
 
 NAME=#10989 double pre-disasm
 FILE=../bins/elf/echo-bin
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.cmt.right=false
 pd 1 @ 0xe78
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             ; 'f'
             0x00000e78      mov byte [rbp - 0x274e], 0x66
+EOF
 RUN
 
 NAME=pdf show entry0 disasm instead of main
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 aa
 pdf
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 / 46: entry0 (int64_t arg3);
 |           ; arg int64_t arg3 @ rdx
 |           0x00005ae0      f30f1efa       endbr64
@@ -2015,22 +2044,25 @@ EXPECT=<<RUN
 |           0x00005afa      488d0def0b01.  lea rcx, [0x000166f0]
 |           0x00005b01      488d3d68e5ff.  lea rdi, [main]             ; 0x4070 ; "AWAVAUATU\x89\xfdSH\x89\xf3H\x83\xecXH\x8b>dH\x8b\x04%("
 \           0x00005b08      ff150ac30100   call qword [reloc.__libc_start_main] ; [0x21e18:8]=0
+EOF
 RUN
 
 NAME=asm.lines.ret, pd and pdJ
 FILE=../bins/elf/crackme0x05
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.lines.ret=1
 s 0x08048414
 pd 2
 ?e
 pdJ 2
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x08048414      c3             ret
             ; --------------------------------------
             0x08048415      90             nop
 
 [{"offset":134513684,"text":"            0x08048414      c3             ret"},{"offset":134513684,"text":"            ; --------------------------------------"},{"offset":134513685,"text":"            0x08048415      90             nop"}]
+EOF
 RUN
 
 

--- a/test/new/db/cmd/cmd_pd2
+++ b/test/new/db/cmd/cmd_pd2
@@ -18,24 +18,26 @@ RUN
 
 NAME=bytes for invalid insn (#11434)
 FILE=-
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 wx 60; pd 2
 ?e
 wx 906090; pd 3
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x00000000      60             invalid
             0x00000001      0000           add byte [rax], al
 
             0x00000000      90             nop
             0x00000001      60             invalid
             0x00000002      90             nop
+EOF
 RUN
 
 NAME=arm indirect relsub fix (#11780)
 FILE=../bins/elf/analysis/arm_32_flags0
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.cmt.right=true
 pd 1 @ 0x000102e0
@@ -44,7 +46,8 @@ pd 1 @ 0x000102e8
 e asm.cmt.right=false
 pd 1 @ 0x000102e0
 pd 1 @ 0x000102e8
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x000102e0      ldr ip, sym.__libc_csu_fini                ; [0x102f8:4]=0x10494 sym.__libc_csu_fini
             0x000102e8      ldr r0, main                               ; [0x102fc:4]=0x10408 sym.main
 
@@ -52,11 +55,12 @@ EXPECT=<<RUN
             0x000102e0      ldr ip, sym.__libc_csu_fini
             ; [0x102fc:4]=0x10408 sym.main
             0x000102e8      ldr r0, main
+EOF
 RUN
 
 NAME=realign after sparse (#11810)
 FILE=../bins/pe/cmd_adf_sample0.exe
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.comments=false
 s 0x560e67
@@ -66,7 +70,8 @@ afb+ 0x00560e67 0x00560e7d 8 0x00560e96
 afb+ 0x00560e67 0x00560e96 7 0x00560eb1
 afb+ 0x00560e67 0x00560eb1 297
 pdf
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 / 318: fcn.00560e67 (int32_t arg_0h);
 |       :   ; var int32_t var_1ch @ esp+0x4
 |       :   ; var int32_t var_ch @ esp+0x14
@@ -175,11 +180,12 @@ EXPECT=<<RUN
 |       :   0x00560fcf      xchg dword [esp], eax
 |       :   0x00560fd2      mov esp, dword [esp]
 \       `=< 0x00560fd5      jmp 0x43d3f7
+EOF
 RUN
 
 NAME=pdf hidden code in sparse fix
 FILE=../bins/pe/cmd_adf_sample0.exe
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.var=false
 e io.cache=true
 wx 90eb09 @ 0x560e71
@@ -195,7 +201,8 @@ afb+ 0x00560e67 0x00560eb1 6
 pdf
 ?e
 pdr.
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 / 30: fcn.00560e67 ();
 |       :   0x00560e67      56             push esi
 |      ,==< 0x00560e68      e904000000     jmp 0x560e71
@@ -240,11 +247,12 @@ EXPECT=<<RUN
 | 0x00560eb1      5a             pop edx
 \ 0x00560eb2      e940c5edff     jmp 0x43d3f7
 
+EOF
 RUN
 
 NAME=esil func cmts
 FILE=../bins/elf/arm1.bin
-CMDS=<<EXPECT
+CMDS=<<EOF
 tn- __libc_start_main
 e asm.emu=true
 e emu.write=true
@@ -257,7 +265,8 @@ e asm.cmt.right=false
 pdf
 ?e
 agf
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 / 8: fcn.00008174 ();
 |           0x00008174      b80000eb       bl sym.__libc_start_main    ; lr=0x8178 -> 0xeb0002a4 ; pc=0x845c -> 0xe92d41f0
 |                                                                      ; int __libc_start_main(?, -1, ?, ?, ?, ?, -1)
@@ -287,27 +296,30 @@ EXPECT=<<RUN
 |    ; void abort(void)                              |
 | bl sym.abort;[ob]                                  |
 `----------------------------------------------------'
+EOF
 RUN
 
 NAME=esil func cmt refline
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 e io.cache=true
 e asm.emu=true
 e asm.types=2
 wx 7d0a7f08eb00 @ 0x5b02
 pd 4 @ 0x5b02
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
         ,=< 0x00005b02      7d0a           jge 0x5b0e                  ; rip=0x5b0e -> 0x8d4890f4 ; likely
        ,==< 0x00005b04      7f08           jg 0x5b0e                   ; rip=0x5b0e -> 0x8d4890f4 ; likely
       ,===< 0x00005b06      eb00           jmp 0x5b08                  ; rip=0x5b08 -> 0xc30a15ff
       `---> 0x00005b08      ff150ac30100   call qword [reloc.__libc_start_main] ; [0x21e18:8]=0 ; rsp=0xfffffffffffffff8 ; rip=0x0
        ||                                                              ; int __libc_start_main(func: unk_size_format, -1, char **: unk_size_format, func: unk_size_format, func: unk_size_format, func: unk_size_format, -1)
+EOF
 RUN
 
 NAME=aht asm.cmt.right=false fix (#12330)
 FILE=-
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 e io.cache=true
@@ -318,14 +330,16 @@ e asm.cmt.right=true
 pd 1
 e asm.cmt.right=false
 pd 1
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x00000000      488b4608       mov rax, qword [rsi + ms.member1]
             0x00000000      488b4608       mov rax, qword [rsi + ms.member1]
+EOF
 RUN
 
 NAME=asm.bb.line fcnline glitches fix, bblines btw bb & non-bb
 FILE=../bins/elf/before-after-main
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bb.line=true
 e asm.bytes=false
 e asm.comments=false
@@ -343,7 +357,8 @@ s entry.fini0
 aF
 s entry.fini0+32
 pd 3
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x080483cf      nop
 / (fcn) sym.deregister_tm_clones 40
 |   40: sym.deregister_tm_clones ();
@@ -362,6 +377,7 @@ EXPECT=<<RUN
             0x08048471      lea esi, [esi]
             |
 \           0x08048478      ret
+EOF
 RUN
 
 # asm.bb.line with no analysis is not supported, since backward jump targets
@@ -369,7 +385,7 @@ RUN
 # (assuming no jumps from outside the function into the middle)
 NAME=asm.bb.line no-anal
 FILE=../bins/elf/lab2
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bb.line=true
 e asm.bytes=false
 e asm.comments=false
@@ -378,7 +394,8 @@ wx 907f04 @ 0x08048597
 wx 75f3909090 @ 0x080485bc
 s 0x08048598
 pd 11
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
         ,=< 0x08048598      jg 0x804859e
         |   0x0804859a      cmp al, byte [esp + 0x27]
        ,`-> 0x0804859e      je 0x80485b3
@@ -390,11 +407,12 @@ EXPECT=<<RUN
       | :   0x080485b8      mov ebx, dword [esp + 0x20]
       | `=< 0x080485bc      jne 0x80485b1
       |     0x080485be      nop
+EOF
 RUN
 
 NAME=asm.bb.line glitch fix (#12516)
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bb.line=true
 e asm.bytes=false
 e asm.comments=false
@@ -407,7 +425,8 @@ s 0x4233
 pd 9
 ?e
 pdJ 9~{}
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 |       ,=< 0x00004233      jg 0x4238
 |       |   |
 |       |   0x00004235      test rax, rax
@@ -492,11 +511,12 @@ EXPECT=<<RUN
     "text": "|     |     0x0000424c      nop"
   }
 ]
+EOF
 RUN
 
 NAME=flag-func_sig order
 FILE=../bins/elf/abcde-qt32
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.demangle=true
 e asm.bytes=false
 e asm.filter=false
@@ -509,7 +529,8 @@ pd 1 @ 0x080493ca
 e asm.cmt.right=false
 pd 1 @ 0x080493b4
 pd 1 @ 0x080493ca
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 |           0x080493b4      call 0x80490b0                             ; sym.imp.strlen ; size_t strlen(const char *s)
 |           0x080493ca      call 0x80490e0                             ; sym.imp.QString::fromAscii_helper_char_const___int
 |                                                                      ; QString::fromAscii_helper(char const*, int)
@@ -520,11 +541,12 @@ EXPECT=<<RUN
 |           ; sym.imp.QString::fromAscii_helper_char_const___int
 |           ; QString::fromAscii_helper(char const*, int)
 |           0x080493ca      call 0x80490e0
+EOF
 RUN
 
 NAME=newlined-comment-refline fix (#14627), wayward rip-relative flag fixes
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.filter=true
 (pd_tests, e asm.relsub=true, pd 15, ?e, e asm.relsub=false, pd 1 @ 0x000041ee, pd 1 @ 0x00004225)
@@ -540,7 +562,8 @@ e io.cache=true
 wx 483b1592770100483b354bd80100 @ 0x000041e7  # cmp rdx, [rip + 0x17792]; cmp rsi, [rip + 0x1d84b]
 wx 483b3df6470100 @ 0x00004225  # cmp rdi, [rip + 0x147f6]
 .(insn_tests)
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
         ,=< 0x000041e0      je 0x421a
         |   0x000041e2      mov ecx, 4
         |   0x000041e7      lea rdx, [0x0001b980]
@@ -666,28 +689,32 @@ EXPECT=<<RUN
             [32m0x000041ee[0m      [36mcmp[36m rsi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m             ; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m             ; str.COLUMNS
             [31m                                                           ; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m ; "COLUMNS"[0m
+EOF
 RUN
 
 NAME=lea section flag bracket fix
 FILE=../bins/elf/analysis/ls-alxchk
-CMDS=<<EXPECT
+CMDS=<<EOF
 s 0x5e6e
 e scr.color=0
 pd 1
 e scr.color=1
 pd 1
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x00005e6e      488d3d339b01.  lea rdi, section..fini_array ; 0x1f9a8
             [32m0x00005e6e[0m      [33m48[37m8d[33m3d[33m33[37m9b[37m01[37m.[0m  [37mlea[36m rdi[0m,[36m[36m [0m[36msection..fini_array[0m[36m[0m[0m[31m ; 0x1f9a8[0m
+EOF
 RUN
 
 NAME=pi no-color rip-relative addr fix
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 e scr.color=0
 s 0x000041e0
 pi 15
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 je 0x421a
 mov ecx, 4
 lea rdx, [0x0001b980]
@@ -703,22 +730,25 @@ mov esi, dword [rdx + rax*4]
 call 0x13c50
 mov qword [0x000232b0], 0x50
 lea rdi, str.COLUMNS
+EOF
 RUN
 
 NAME=esil call no-fcn-name cmt alignment
 FILE=../bins/elf/analysis/arm-ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e emu.pre=true
 e emu.str=true
 pd 1 @ 0x00011ee4
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
             0x00011ee4      bl 0x2258c                                 ; 0x2258c(0x19ac0, 0x25c0c, 0x0, 0x372cc)
+EOF
 RUN
 
 NAME=bin.str.enc no-guess with initial null
 FILE=../bins/elf/utfbe&bom
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=false
 e asm.offset=false
 e asm.cmt.off=false
@@ -728,7 +758,8 @@ aar
 .(pdstr 16)
 ?e
 .(pdstr 32)
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
                  mov esi, obj.utf16be
                  mov esi, obj.utf16be                                  ; u"\u5500\u5400\u4600\u3100\u3600\u4200\u4500"
                  mov esi, obj.utf16be                                  ; ub"UTF16BE"
@@ -736,11 +767,12 @@ EXPECT=<<RUN
                  mov esi, obj.utf32be
                  mov esi, obj.utf32be                                  ; U"\U55000000\U54000000\U46000000\U33000000\U32000000\U42000000\U45000000"
                  mov esi, obj.utf32be                                  ; Ub"UTF32BE"
+EOF
 RUN
 
 NAME=bin.str.enc guess bom, asm.cmt.off=0/1
 FILE=../bins/elf/utfbe&bom
-CMDS=<<EXPECT
+CMDS=<<EOF
 e asm.bytes=0
 e asm.offset=0
 e asm.cmt.off=0
@@ -757,7 +789,8 @@ e asm.cmt.off=1
 .(pdstr utf32be_bom)
 e asm.cmt.off=off
 .(pdstr utf32be_bom)
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
                  mov esi, obj.utf8_bom                                 ; "\ufeffUTF8_BOM"
                  mov esi, obj.utf16le_bom                              ; u"\ufeffUTF16LE_BOM"
                  mov esi, obj.utf16be_bom                              ; ub"\ufeffUTF16BE_BOM"
@@ -766,6 +799,7 @@ EXPECT=<<RUN
 
                  mov esi, obj.utf32be_bom                              ; 0x4041e0 ; Ub"\ufeffUTF32BE_BOM"
                  mov esi, obj.utf32be_bom                              ; Ub"\ufeffUTF32BE_BOM"
+EOF
 RUN
 
 NAME=no-anal asm.symbol from fcn mid

--- a/test/new/db/cmd/cmd_pdr
+++ b/test/new/db/cmd/cmd_pdr
@@ -49,7 +49,7 @@ RUN
 
 NAME=pdrj and pirj ignore asm.bb.middle
 FILE=-
-CMDS=<<EXPECT
+CMDS=<<EOF
 e anal.nopskip=false
 e anal.jmp.mid=true
 e io.cache=true
@@ -65,6 +65,7 @@ pdrj~{}
 pir
 ?e
 pirj~{}
+EOF
 EXPECT=%
 / 24: fcn.00000000 ();
 | 0x00000000      0f1f440000     nop dword [rax + rax]
@@ -402,10 +403,11 @@ RUN
 
 NAME=pdr with backwards jmp
 FILE=../bins/elf/ls
-CMDS=<<EXPECT
+CMDS=<<EOF
 aa
 pdr @ entry.init0
-EXPECT=<<RUN
+EOF
+EXPECT=<<EOF
 | ; CODE XREF from entry.init0 @ 0x5bd4
 | 0x00005b40      488d3d21c701.  lea rdi, loc._edata                   ; loc.__bss_start
 |                                                                      ; 0x22268
@@ -431,4 +433,5 @@ EXPECT=<<RUN
 | 0x00005bd0      f30f1efa       endbr64
 | 0x00005bd4      e967ffffff     jmp 0x5b40
 | ----------- true: 0x00005b40
+EOF
 RUN


### PR DESCRIPTION
Done using `--to-eof` by radare/node-r2r#12.