### PR TITLE
Remove realname from strings

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -391,10 +391,15 @@ static void type_match(RCore *core, ut64 addr, char *fcn_name, ut64 baddr, const
 					if ((op->ptr && op->ptr != UT64_MAX) && !strcmp (name, "format")) {
 						RFlagItem *f = r_flag_get_i (core->flags, op->ptr);
 						if (f && !strncmp (f->name, "str", 3)) {
-							if ((types = parse_format (core, f->realname))) {
-								max += r_list_length (types);
+							char formatstr[0x200];
+							int read = r_io_nread_at (core->io, f->size, (ut8 *)formatstr, R_MIN (sizeof (formatstr) - 1, f->size));
+							if (read > 0) {
+								formatstr[read] = '\0';
+								if ((types = parse_format (core, f->realname))) {
+									max += r_list_length (types);
+								}
+								format = true;
 							}
-							format = true;
 						}
 					}
 				}

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -390,12 +390,12 @@ static void type_match(RCore *core, ut64 addr, char *fcn_name, ut64 baddr, const
 					cmt_set = true;
 					if ((op->ptr && op->ptr != UT64_MAX) && !strcmp (name, "format")) {
 						RFlagItem *f = r_flag_get_i (core->flags, op->ptr);
-						if (f && !strncmp (f->name, "str", 3)) {
+						if (f && f->space && !strcmp (f->space->name, R_FLAGS_FS_STRINGS)) {
 							char formatstr[0x200];
-							int read = r_io_nread_at (core->io, f->size, (ut8 *)formatstr, R_MIN (sizeof (formatstr) - 1, f->size));
+							int read = r_io_nread_at (core->io, f->offset, (ut8 *)formatstr, R_MIN (sizeof (formatstr) - 1, f->size));
 							if (read > 0) {
 								formatstr[read] = '\0';
-								if ((types = parse_format (core, f->realname))) {
+								if ((types = parse_format (core, formatstr))) {
 									max += r_list_length (types);
 								}
 								format = true;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -292,7 +292,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 			}
 		}
 		if (IS_MODE_SET (mode)) {
-			char *f_name, *f_realname, *str;
+			char *f_name, *str;
 			if (r_cons_is_breaked ()) {
 				break;
 			}
@@ -301,16 +301,12 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 			r_name_filter (f_name, -1);
 			if (r->bin->prefix) {
 				str = r_str_newf ("%s.str.%s", r->bin->prefix, f_name);
-				f_realname = r_str_newf ("%s.\"%s\"", r->bin->prefix, string->string);
 			} else {
 				str = r_str_newf ("str.%s", f_name);
-				f_realname = r_str_newf ("\"%s\"", string->string);
 			}
 			RFlagItem *flag = r_flag_set (r->flags, str, vaddr, string->size);
-			r_flag_item_set_realname (flag, f_realname);
 			free (str);
 			free (f_name);
-			free (f_realname);
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_printf ("0x%"PFMT64x" %d %d %s\n", vaddr,
 				string->size, string->length, string->string);

--- a/test/new/db/cmd/cmd_pd
+++ b/test/new/db/cmd/cmd_pd
@@ -1399,7 +1399,7 @@ RUN
 
 NAME=pdJ escape flagname
 FILE=../bins/elf/crackme
-EXPECT='[{"offset":4196399,"text":"            ;-- \"Password Correct!\":"},{"offset":4196399,"text":"            0x0040082f     .string \"Password Correct!\" ; len=18"}]
+EXPECT='[{"offset":4196399,"text":"            ;-- str.Password_Correct:"},{"offset":4196399,"text":"            0x0040082f     .string \"Password Correct!\" ; len=18"}]
 '
 CMDS='pdJ 1 @ 0x0040082f
 '

--- a/test/new/db/cmd/comments
+++ b/test/new/db/cmd/comments
@@ -14,7 +14,7 @@ RUN
 NAME=#3829 remove comment where another meta is already defined
 FILE=../bins/elf/analysis/main
 EXPECT=<<EOF
-            ;-- "Hello World":
+            ;-- str.Hello_World:
             0x004005c4     .string "Hello World" ; len=12
 EOF
 CMDS=<<EOF

--- a/test/new/db/cmd/metadata
+++ b/test/new/db/cmd/metadata
@@ -450,12 +450,12 @@ EXPECT=<<EOF
 Csa 2 @ 0x140016018 # \t
 "\t"
 ascii[2] "\t"
-            ;-- "\twide\\esc: \e[0m":
+            ;-- str.wide__esc:__e_0m:
             0x140016018     .string "\t" ; len=2
 Cs 19 @ 0x140016018 # \twide\\esc: \x1b[0m\xa1\r\n
 "\twide\\esc: \x1b[0m\xa1\r\n"
 latin1[19] "\twide\\esc: \x1b[0m\xa1\r\n"
-            ;-- "\twide\\esc: \e[0m":
+            ;-- str.wide__esc:__e_0m:
             0x140016018     .string "\twide\\esc: \x1b[0m\xa1\r\n" ; len=19
 ascii[4] "\t"
 ascii[4] "\twid"
@@ -506,12 +506,12 @@ EXPECT=<<EOF
 Cs 61 @ 0x004021ff # utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m \xc2\xa2\xe2\x82\xac\xf0\x90\x8d\x88 \e[0m\n
 "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m \xc2\xa2\xe2\x82\xac\xf0\x90\x8d\x88 \e[0m\n"
 latin1[61] "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m \xc2\xa2\xe2\x82\xac\xf0\x90\x8d\x88 \e[0m\n"
-            ;-- "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m ¢€𐍈 \e[0m\n":
+            ;-- str.utf8____u00a2__u20ac__U00010348_in_yellow:_e_33m____________e_0m:
             0x004021ff     .string "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m \xc2\xa2\xe2\x82\xac\xf0\x90\x8d\x88 \e[0m\n" ; len=61
 Cs8 61 @ 0x004021ff # utf8> \\u00a2\\u20ac\\U00010348 in yellow:\x1b[33m \u00a2\u20ac\U00010348 \x1b[0m\n
 "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\x1b[33m \u00a2\u20ac\U00010348 \x1b[0m\n"
 utf8[61] "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\x1b[33m \u00a2\u20ac\U00010348 \x1b[0m\n"
-            ;-- "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\e[33m ¢€𐍈 \e[0m\n":
+            ;-- str.utf8____u00a2__u20ac__U00010348_in_yellow:_e_33m____________e_0m:
             0x004021ff     .string "utf8> \\u00a2\\u20ac\\U00010348 in yellow:\x1b[33m \u00a2\u20ac\U00010348 \x1b[0m\n" ; len=61
 EOF
 CMDS=<<EOF
@@ -549,12 +549,12 @@ FILE=../bins/pe/testapp-msvc64.exe
 EXPECT=<<EOF
 "\tANSI\\esc: \x1b[33m\r\n"
 ascii[19] "\tANSI\\esc: \x1b[33m\r\n"
-            ;-- "\tANSI\\esc: \e[33m\r\n":
+            ;-- str.ANSI__esc:__e_33m:
             ;-- section..data:
             0x140016000     .string "\tANSI\\esc: \x1b[33m\r\n" ; len=19 ; [02] -rw- section size 8192 named .data
 "\tANSI\esc: \x1b[33m\r\n"
 ascii[19] "\tANSI\esc: \x1b[33m\r\n"
-            ;-- "\tANSI\\esc: \e[33m\r\n":
+            ;-- str.ANSI__esc:__e_33m:
             ;-- section..data:
             0x140016000     .string "\tANSI\esc: \x1b[33m\r\n" ; len=19 ; [02] -rw- section size 8192 named .data
 EOF


### PR DESCRIPTION
After discussions, this PR will make sure that real name isn't shown for strings.

This will return the good old `
```
mov ebx, str.Think_you_can_make_it
```
instead of 
```
mov ebx, "Think you can make it????!!!!>>?"
```
which was added recently in the realname PR.