### PR TITLE
Check version for pkgname correctly

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -306,8 +306,9 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 			if (stru->pkgname) {
 				const char *dot = strchr (stru->version, '.');
 				int major = atoi (stru->version);
-				int minor = atoi (dot + 1);
-				if (major >= R2_VERSION_MAJOR && minor >= R2_VERSION_MINOR) {
+				int minor = dot ? atoi (dot + 1) : 0;
+				// The pkgname member was introduced in 4.2.0
+				if (major >= 4 || (major == 4 && minor >= 2)) {
 					printf ("r2pm -ci %s\n", stru->pkgname);
 				}
 			}


### PR DESCRIPTION
* dot can be null
* Using R2_VERSION_MAJOR/MINOR is wrong because they will be continuously updated and we want to check for exactly 4.2.0
* The version check logic itself was wrong