### PR TITLE
Add cbnz and cbz instruction for arm64 assembler

### DIFF
--- a/libr/asm/d/arm.sdb.txt
+++ b/libr/asm/d/arm.sdb.txt
@@ -153,3 +153,5 @@ brab=branch with pointer authentication using B key
 brabz=variant of brabz
 stadd=atomic add word (arm v8.1)
 staddl=atomic add dword (arm v8.1)
+cbnz=compare and branch on non-zero
+cbz=compare and branch on zero

--- a/test/new/db/asm/arm_64
+++ b/test/new/db/asm/arm_64
@@ -258,3 +258,5 @@ a "mrs x3, SP_EL0" 034138d5
 a "msr 0xc208, x3" 034118d5
 a "msr SP_EL0, x3" 034118d5
 a "msr sp_el0, x3" 034118d5
+a "cbnz w3, 0x1fffd4" a3feff35
+a "cbz x3, 0x1fffe8" 43ffffb4


### PR DESCRIPTION
Resolving #15855. Add both instructions, updated unit test and opcode description