### PR TITLE
Update radare2-shell-parser and improve tree-sitter related code in cmd.c

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4532,6 +4532,25 @@ DEFINE_HANDLE_TS_FCN(redirect_command) {
 
 DEFINE_HANDLE_TS_FCN(help_command) {
 	// TODO: traverse command tree to print help
+	// FIXME: once we have a command tree, this special handling should be removed
+	if (node_string[0] == '@') {
+		if (node_string[1] == '?') {
+			r_core_cmd_help (core, help_msg_at);
+			return true;
+		}
+		if (node_string[1] == '@') {
+			if (node_string[2] == '?') {
+				r_core_cmd_help (core, help_msg_at_at);
+				return true;
+			}
+			if (node_string[2] == '@') {
+				if (node_string[3] == '?') {
+					r_core_cmd_help (core, help_msg_at_at_at);
+					return true;
+				}
+			}
+		}
+	}
 	return r_cmd_call (core->rcmd, node_string) != -1;
 }
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -400,7 +400,6 @@ R_API void r_core_prompt_loop(RCore *core);
 R_API ut64 r_core_pava(RCore *core, ut64 addr);
 R_API void run_pending_anal(RCore *core);
 R_API int r_core_cmd(RCore *core, const char *cmd, int log);
-R_API void r_core_cmd_repeat(RCore *core, int next);
 R_API int r_core_cmd_task_sync(RCore *core, const char *cmd, bool log);
 R_API char *r_core_editor (const RCore *core, const char *file, const char *str);
 R_API int r_core_fgets(char *buf, int len);

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -34,7 +34,7 @@ TS_TIP=aef62b4bc6b9654e54bd59bee1cb8cea16e3aa96
 # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/meson.build
 SHELLPARSER_URL=https://github.com/ret2libc/radare2-shell-parser.git
 SHELLPARSER_BRA=master
-SHELLPARSER_TIP=dfb12492f4052b5a6c64fc626e9bf65ccb7b5522
+SHELLPARSER_TIP=29e46de9b7087cae140335d71e5ecf410c3bc067
 
 ifeq ($(CS_RELEASE),1)
 CS_VER=4.0.1

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -34,7 +34,7 @@ TS_TIP=aef62b4bc6b9654e54bd59bee1cb8cea16e3aa96
 # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/meson.build
 SHELLPARSER_URL=https://github.com/ret2libc/radare2-shell-parser.git
 SHELLPARSER_BRA=master
-SHELLPARSER_TIP=29e46de9b7087cae140335d71e5ecf410c3bc067
+SHELLPARSER_TIP=2c9d98d4be3bfddb30fe8b00f467ae2ff56a22e3
 
 ifeq ($(CS_RELEASE),1)
 CS_VER=4.0.1

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -295,7 +295,7 @@ if get_option('use_treesitter')
     endif
 
     # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/Makefile
-    SHELLPARSER_TIP = 'aef62b4bc6b9654e54bd59bee1cb8cea16e3aa96'
+    SHELLPARSER_TIP = '29e46de9b7087cae140335d71e5ecf410c3bc067'
     SHELLPARSER_BRA = 'master'
     shell_parser_user = 'ret2libc'
 

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -295,7 +295,7 @@ if get_option('use_treesitter')
     endif
 
     # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/Makefile
-    SHELLPARSER_TIP = '29e46de9b7087cae140335d71e5ecf410c3bc067'
+    SHELLPARSER_TIP = '2c9d98d4be3bfddb30fe8b00f467ae2ff56a22e3'
     SHELLPARSER_BRA = 'master'
     shell_parser_user = 'ret2libc'
 


### PR DESCRIPTION
Still improving the grammar in radare2-shell-parser.
I refactored a bit the code in cmd.c.

The grammar is able to parse most commands (simple commands like `pd 10`, commands with temporary changes like `pd 10 @ 0xdeadbeef @a:x86`, iterators like `pd 10 @@b`, `@@@s`, grep commands with `~`, repeat commands with a number in front of the command, interpret commands with a dot in front of it, command substitution, pipe, redirection, quoted arguments, etc.)

The integration with r2, however, is still incomplete. Only simple commands, temporary seeks, interpret commands and redirection are supported for now. I will add the other things soon enough.

By the way, to test the new command parser you should:
- compile r2 with: `meson -Duse_treesitter=true build; ninja -C build;`
- run r2 with `./build/binr/radare2/radare2 -e cfg.newshell=true /bin/ls` (actually, to debug i often use `./build/binr/radare2/radare2 -e cfg.newshell=true -elog.level=1 /bin/ls`)