### PR TITLE
Fix #15873 arm64 mov instruction

### DIFF
--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -196,20 +196,32 @@ static ut32 mov(ArmOp *op) {
 		}
 	} else if (!strncmp (op->mnemonic, "mov", 3)) {
 		//printf ("%d - %d [%d]\n", op->operands[0].type, op->operands[1].type, ARM_GPR);
+		if (op->operands[0].reg_type & ARM_REG64) {
+            if (op->operands[1].reg_type & ARM_REG64) {
+                k = 0xe00300aa;
+            } else if (op->operands[1].type & ARM_CONSTANT) {
+                k = 0x80d2;
+            } else {
+                return data;
+            }
+        } else if (op->operands[0].reg_type & ARM_REG32) {
+            if (op->operands[1].reg_type & ARM_REG32) {
+                k = 0xe003002a;
+            } else if (op->operands[1].type & ARM_CONSTANT) {
+                k = 0x8052;
+            } else {
+                return data;
+            }
+        }
 		if (op->operands[0].type & ARM_GPR) {
-			if (op->operands[1].type & ARM_GPR) {
-				if (op->operands[1].reg_type & ARM_REG64) {
-					k = 0xe00300aa;
-				} else {
-					k = 0xe003002a;
-				}
-				data = k | op->operands[1].reg << 8;
-			} else if (op->operands[1].type & ARM_CONSTANT) {
-				k = 0x80d2;
-				data = k | op->operands[1].immediate << 29;
-			}
+            if (op->operands[1].type & ARM_GPR) {
+                data = k | op->operands[1].reg << 8;
+            } else if (op->operands[1].type & ARM_CONSTANT) {
+                ut32 imm = op->operands[1].immediate << 1;
+                data = k | ((imm & 0xf) << 28) | ((imm & 0x1f0) << 12) ;
+            }
 			data |=  op->operands[0].reg << 24;
-		}
+        }
 		return data;
 	}
 

--- a/test/new/db/asm/arm_64
+++ b/test/new/db/asm/arm_64
@@ -158,6 +158,8 @@ a "ldrsh w3, [x8, 236]" 03d9c179
 a "ldrsh w3, [x8, x3]" 0369e378
 a "mov x20, x0" f40300aa
 a "mov x9, 5" a90080d2
+a "mov x7, 0x51" 270a80d2
+a "mov w19, 0x9a" 53138052
 a "movk x16, 15" f00180f2
 a "movn x6, 2" 46008092
 a "movz x1, 5" a10080d2


### PR DESCRIPTION
- Fix mov to load 8bit immediate value
- While at it prevent mixing 32bit and 64bit register operands
- Added new test