### PR TITLE
r2r.v: Allow '=' in keyword argument

### DIFF
--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -178,10 +178,10 @@ mut:
 }
 
 fn get_kw_arg(line string) (string,string) {
-	pos_eq := line.index('=') or {
+	i := line.index('=') or {
 		return line,''
 	}
-	return line.substr(0, pos_eq),line.substr(pos_eq + 1, line.len)
+	return line.substr(0, i),line.substr(i + 1, line.len)
 }
 
 fn (test R2RCmdTest) parse_slurp(v string) (string,string) {

--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -177,6 +177,13 @@ mut:
 	name string
 }
 
+fn (test R2RCmdTest) get_kw_arg(line string) (string,string) {
+	pos_eq := line.index('=') or {
+		return line,''
+	}
+	return line.substr(0, pos_eq),line.substr(pos_eq + 1, line.len)
+}
+
 fn (test R2RCmdTest) parse_slurp(v string) (string,string) {
 	mut res := ''
 	mut slurp_token := ''
@@ -233,14 +240,11 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 			}
 			continue
 		}
-		kv := line.split_nth('=', 2)
-		if kv.len == 0 {
-			continue
-		}
-		match kv[0] {
+		kw,arg := test.get_kw_arg(line)
+		match kw {
 			'CMDS' {
-				if kv.len > 1 {
-					a,b := test.parse_slurp(kv[1])
+				if arg.len > 0 {
+					a,b := test.parse_slurp(arg)
 					test.cmds = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -252,8 +256,8 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'EXPECT' {
-				if kv.len > 1 {
-					a,b := test.parse_slurp(kv[1])
+				if arg.len > 0 {
+					a,b := test.parse_slurp(arg)
 					test.expect = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -265,8 +269,8 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'EXPECT_ERR' {
-				if kv.len > 1 {
-					a,b := test.parse_slurp(kv[1])
+				if arg.len > 0 {
+					a,b := test.parse_slurp(arg)
 					test.expect_err = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -278,15 +282,15 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'BROKEN' {
-				if kv.len > 1 {
-					test.broken = kv[1].len > 0 && kv[1] == '1'
+				if arg.len > 0 {
+					test.broken = arg == '1'
 				}
 				else {
 					eprintln('Warning: Missing value for BROKEN in ${test.source}')
 				}
 			}
 			'ARGS' {
-				if kv.len > 0 {
+				if arg.len > 0 {
 					test.args = line[5..line.len]
 				}
 				else {
@@ -318,7 +322,7 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			else {}
-	}
+		}
 	}
 }
 

--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -177,7 +177,7 @@ mut:
 	name string
 }
 
-fn get_kw_arg(line string) (string,string) {
+fn get_kv(line string) (string,string) {
 	i := line.index('=') or {
 		return line,''
 	}
@@ -240,11 +240,11 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 			}
 			continue
 		}
-		kw,arg := get_kw_arg(line)
-		match kw {
+		k,v := get_kv(line)
+		match k {
 			'CMDS' {
-				if arg.len > 0 {
-					a,b := test.parse_slurp(arg)
+				if v.len > 0 {
+					a,b := test.parse_slurp(v)
 					test.cmds = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -256,8 +256,8 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'EXPECT' {
-				if arg.len > 0 {
-					a,b := test.parse_slurp(arg)
+				if v.len > 0 {
+					a,b := test.parse_slurp(v)
 					test.expect = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -269,8 +269,8 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'EXPECT_ERR' {
-				if arg.len > 0 {
-					a,b := test.parse_slurp(arg)
+				if v.len > 0 {
+					a,b := test.parse_slurp(v)
 					test.expect_err = a
 					slurp_token = b
 					if slurp_token.len > 0 {
@@ -282,15 +282,15 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 				}
 			}
 			'BROKEN' {
-				if arg.len > 0 {
-					test.broken = arg == '1'
+				if v.len > 0 {
+					test.broken = v == '1'
 				}
 				else {
 					eprintln('Warning: Missing value for BROKEN in ${test.source}')
 				}
 			}
 			'ARGS' {
-				if arg.len > 0 {
+				if v.len > 0 {
 					test.args = line[5..line.len]
 				}
 				else {

--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -177,7 +177,7 @@ mut:
 	name string
 }
 
-fn (test R2RCmdTest) get_kw_arg(line string) (string,string) {
+fn get_kw_arg(line string) (string,string) {
 	pos_eq := line.index('=') or {
 		return line,''
 	}
@@ -240,7 +240,7 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 			}
 			continue
 		}
-		kw,arg := test.get_kw_arg(line)
+		kw,arg := get_kw_arg(line)
 		match kw {
 			'CMDS' {
 				if arg.len > 0 {


### PR DESCRIPTION
Otherwise the following test in `tools/rahash2`, which should fail since current r2r.v doesn't support '...' tests yet:

```
NAME=rahash2 -D base64 -s "YWRtaW4="
FILE=-
CMDS=!rahash2 -D base64 -s "YWRtaW4="
EXPECT='admin'
RUN
```

actually succeeds.