### PR TITLE
Fix bounds check for flag registers in last byte of arena (#12949)

### DIFF
--- a/libr/reg/value.c
+++ b/libr/reg/value.c
@@ -79,7 +79,7 @@ R_API ut64 r_reg_get_value(RReg *reg, RRegItem *item) {
 	switch (item->size) {
 	case 1: {
 		int offset = item->offset / 8;
-		if (offset + item->size >= regset->arena->size) {
+		if (offset >= regset->arena->size) {
 			break;
 		}
 		return (regset->arena->bytes[offset] &


### PR DESCRIPTION
No adjustments are necessary when bounds checking the byte offset of a flag register against the arena's size. Previously, we had an off-by-one that prevented flag registers in the last byte of the arena from being read, as reported in #12949.

Please let me know whether a test case is warranted to prevent regressions.