### PR TITLE
Added arm64 ESIL for bic 

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1200,6 +1200,21 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		}
 		break;
 		}
+	case ARM64_INS_BIC:
+        if (OPCOUNT64 () == 2) {
+            if (REGSIZE64(0) == 4) {
+                r_strbuf_appendf (&op->esil, "%s,0xffffffff,^,%s,&=",REG64 (1),REG64 (0));
+            } else {
+                r_strbuf_appendf (&op->esil, "%s,0xffffffffffffffff,^,%s,&=",REG64 (1),REG64 (0));
+            }
+        } else {
+            if (REGSIZE64(0) == 4) {
+                r_strbuf_appendf (&op->esil, "%s,0xffffffff,^,%s,&,%s,=",REG64 (2),REG64 (1),REG64 (0));
+            } else {
+                r_strbuf_appendf (&op->esil, "%s,0xffffffffffffffff,^,%s,&,%s,=",REG64 (2),REG64 (1),REG64 (0));
+            }
+        }
+        break;
 	case ARM64_INS_CBZ:
 		r_strbuf_setf (&op->esil, "%s,!,?{,%"PFMT64d",pc,=,}",
 			REG64(0), IMM64(1));

--- a/test/new/db/esil/arm_64
+++ b/test/new/db/esil/arm_64
@@ -770,6 +770,38 @@ pd 8
 EOF
 RUN
 
+NAME=bic 64-bit register
+FILE=malloc://0x200
+EXPECT=<<EOF
+0x1122334455667700
+EOF
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+wx 4a012b8a #bic x10, x11
+aer x10=0x1122334455667788
+aer x11=0xff
+aes
+aer x10
+EOF
+RUN
+
+NAME=bic 32-bit register
+FILE=malloc://0x200
+EXPECT=<<EOF
+0x12345670
+EOF
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+wx 4a012b0a #bic w10, w11
+aer x10=0x12345678
+aer x11=0xf
+aes
+aer x10
+EOF
+RUN
+
 NAME=rev 64-bit register
 FILE=malloc://0x200
 EXPECT=<<EOF


### PR DESCRIPTION
- fix #15265 
- ESIL for bic with 32 and 64 bit register
- ESIL test case for 32 and 64 bit register