### PR TITLE
Add initial sparc regression tests (#15602)

### DIFF
--- a/test/new/db/anal/sparc
+++ b/test/new/db/anal/sparc
@@ -1,0 +1,281 @@
+NAME=disass_Linux_sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+pi 10 @ entry0
+EOF
+EXPECT=<<EOF
+mov g0, fp
+sub sp, 0x18, sp
+ld [sp+0x58], o1
+add sp, 0x5c, o2
+sethi 0xaf, o0
+sethi 0x30b, o3
+sethi 0x30b, o4
+or o0, 0xa0, o0
+or o3, 0x80, o3
+or o4, 0x60, o4
+EOF
+RUN
+
+NAME=disass_Solaris_sparc
+FILE=../bins/elf/elf-solaris-sparc-ls
+CMDS=<<EOF
+pi 10 @ entry0
+EOF
+EXPECT=<<EOF
+mov 0, fp
+ld [sp+0x40], l0
+add sp, 0x44, l1
+sub sp, 0x20, sp
+orcc g0, g1, g0
+be loc..nope
+mov g1, o0
+call sym.imp.atexit
+nop
+sethi 0xb0, o0
+EOF
+RUN
+
+NAME=print sparc disassembly ld
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+pad d0006354
+pad bc100000
+pad 9c23a018
+pad 9403a05c
+pad 110000af
+EOF
+EXPECT=<<EOF
+ld [g1+0x354], o0
+mov g0, fp
+sub sp, 0x18, sp
+add sp, 0x5c, o2
+sethi 0xaf, o0
+EOF
+RUN
+
+NAME=cyclomatic sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+s main
+af
+afi~complex[1]
+afb.@main
+EOF
+EXPECT=<<EOF
+165
+0x0002bca0 0x0002bccc 00:0000 44 j 0x0002c534 f 0x0002bccc
+EOF
+
+NAME=afb sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+s sym.zwrite
+af
+afb
+?e
+pdf
+EOF
+EXPECT=<<EOF
+0x000a0d80 0x000a0d94 00:0000 20 j 0x000a0d94
+0x000a0d94 0x000a0d98 00:0000 4 j 0x000a0d98
+0x000a0d98 0x000a0db0 00:0000 24 j 0x000a0dc8 f 0x000a0db0
+0x000a0db0 0x000a0dc0 00:0000 16 j 0x000a0d94 f 0x000a0dc0
+0x000a0dc0 0x000a0dc8 00:0000 8
+0x000a0dc8 0x000a0dd0 00:0000 8 j 0x000a0dec f 0x000a0dd0
+0x000a0dd0 0x000a0de0 00:0000 16 j 0x000a0d98 f 0x000a0de0
+0x000a0de0 0x000a0dec 00:0000 12
+0x000a0dec 0x000a0e04 00:0000 24 j 0x000a0d98 f 0x000a0e04
+0x000a0e04 0x000a0e0c 00:0000 8
+
+/ 140: sym.zwrite ();
+|           0x000a0d80      9de3bfa0       save sp, -0x60, sp
+|           0x000a0d84      a0100018       mov i0, l0
+|           0x000a0d88      a210001a       mov i2, l1
+|           0x000a0d8c      b010001a       mov i2, i0
+|           0x000a0d90      a4102000       mov 0, l2
+|       .-> 0x000a0d94      92100019       mov i1, o1
+|     ..--> 0x000a0d98      94100011       mov l1, o2
+|     :::   0x000a0d9c      40012d10       call sym.imp.write          ; ssize_t write(int fd, const char *ptr, size_t nbytes)
+|     :::   0x000a0da0      90100010       mov l0, o0
+|     :::   0x000a0da4      80a22000       cmp o0, 0
+|    ,====< 0x000a0da8      04400008       ble,pn icc, 0xa0dc8
+|    |:::   0x000a0dac      01000000       nop
+|    |:::   0x000a0db0      a2244008       sub l1, o0, l1
+|    |:::   0x000a0db4      80a46000       cmp l1, 0
+|    |::`=< 0x000a0db8      144ffff7       bg icc, 0xa0d94
+|    |::    0x000a0dbc      b2064008       add i1, o0, i1
+|    |::    0x000a0dc0      81cfe008       rett i7+8
+|    |::    0x000a0dc4      01000000       nop
+|    `--,=< 0x000a0dc8      12400009       bne,pn icc, 0xa0dec
+|     ::|   0x000a0dcc      01000000       nop
+|     ::|   0x000a0dd0      a404a001       add l2, 1, l2
+|     ::|   0x000a0dd4      80a4a003       cmp l2, 3
+|     `===< 0x000a0dd8      044ffff0       ble icc, 0xa0d98
+|      :|   0x000a0ddc      92100019       mov i1, o1
+|      :|   0x000a0de0      b0268011       sub i2, l1, i0
+|      :|   0x000a0de4      81cfe008       rett i7+8
+|      :|   0x000a0de8      01000000       nop
+|      :`-> 0x000a0dec      40012c9f       call sym.imp.__errno_location
+|      :    0x000a0df0      01000000       nop
+|      :    0x000a0df4      c2020000       ld [o0], g1
+|      :    0x000a0df8      80a06004       cmp g1, 4
+|      `==< 0x000a0dfc      024fffe7       be icc, 0xa0d98
+|           0x000a0e00      92100019       mov i1, o1
+|           0x000a0e04      81cfe008       rett i7+8
+\           0x000a0e08      90103fff       mov -1, o0
+EOF
+RUN
+
+NAME=af anal.endsize sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+e anal.endsize=0
+aaa
+s 0x0002bca0
+afi~name
+EOF
+EXPECT=<<EOF
+name: main
+EOF
+RUN
+
+NAME=af anal.endsize sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+e anal.endsize=1
+aaa
+s 0x0002bca0
+afi~name
+EOF
+EXPECT=<<EOF
+name: main
+EOF
+RUN
+
+NAME=anal.fcnprefix sparc
+FILE=../bins/elf/elf-solaris-sparc-ls
+CMDS=<<EOF
+s 0x00018c08
+e anal.fcnprefix=root
+af
+afl
+EOF
+EXPECT=<<EOF
+0x00018c08  350 8388 -> 7116 main
+EOF
+RUN
+
+NAME=anal.recont=true
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+e anal.recont=true
+s 0x0002bca0
+af
+afb
+EOF
+EXPECT=<<EOF
+0x0002bca0 0x0002bccc 00:0000 44 f 0x0002bccc
+0x0002bccc 0x0002bcec 00:0000 32 j 0x0002bd04 f 0x0002bcec
+0x0002bcec 0x0002bd04 00:0000 24 j 0x0002bcec f 0x0002bd04
+0x0002bd04 0x0002bd2c 00:0000 40 j 0x0002bd90 f 0x0002bd2c
+0x0002bd2c 0x0002bd3c 00:0000 16 j 0x0002bd48 f 0x0002bd3c
+0x0002bd3c 0x0002bd48 00:0000 12 j 0x0002bd48
+0x0002bd48 0x0002bd58 00:0000 16 j 0x0002bd64 f 0x0002bd58
+0x0002bd58 0x0002bd64 00:0000 12 j 0x0002bd64
+0x0002bd64 0x0002bd74 00:0000 16 j 0x0002bd80 f 0x0002bd74
+0x0002bd74 0x0002bd80 00:0000 12 j 0x0002bd80
+0x0002bd80 0x0002bd90 00:0000 16 j 0x0002bd90
+0x0002bd90 0x0002bdc8 00:0000 56 f 0x0002bdc8
+0x0002bdc8 0x0002bde8 00:0000 32 f 0x0002bde8
+0x0002bde8 0x0002bdec 00:0000 4 j 0x0002bdec
+0x0002bdec 0x0002bdf8 00:0000 12 j 0x0002bdf8
+0x0002bdf8 0x0002be10 00:0000 24 j 0x0002be40 f 0x0002be10
+0x0002be10 0x0002be40 00:0000 48 j 0x0002be40
+0x0002be40 0x0002be60 00:0000 32 j 0x0002be60 f 0x0002be60
+0x0002be60 0x0002bebc 00:0000 92 f 0x0002bebc
+0x0002bebc 0x0002bed4 00:0000 24 f 0x0002bed4
+0x0002bed4 0x0002bed8 00:0000 4 j 0x0002bed8
+0x0002bed8 0x0002bfdc 00:0000 260 f 0x0002bfdc
+0x0002bfdc 0x0002bff4 00:0000 24 f 0x0002bff4
+0x0002bff4 0x0002c014 00:0000 32 f 0x0002c014
+0x0002c014 0x0002c024 00:0000 16 f 0x0002c024
+0x0002c024 0x0002c028 00:0000 4 j 0x0002c028
+0x0002c028 0x0002c030 00:0000 8 f 0x0002c030
+0x0002c030 0x0002c048 00:0000 24 j 0x0002c054 f 0x0002c048
+0x0002c048 0x0002c054 00:0000 12 j 0x0002c054
+0x0002c054 0x0002c084 00:0000 48 j 0x0002c094 f 0x0002c084
+0x0002c084 0x0002c094 00:0000 16 f 0x0002c094
+0x0002c094 0x0002c098 00:0000 4 j 0x0002c098
+0x0002c098 0x0002c0a4 00:0000 12 j 0x0002c0a4
+0x0002c0a4 0x0002c0c4 00:0000 32 f 0x0002c0c4
+0x0002c0c4 0x0002c0dc 00:0000 24 j 0x0002c200 f 0x0002c0dc
+0x0002c0dc 0x0002c0ec 00:0000 16 j 0x0002c200 f 0x0002c0ec
+0x0002c0ec 0x0002c108 00:0000 28 j 0x0002c108
+0x0002c108 0x0002c118 00:0000 16 f 0x0002c118
+0x0002c118 0x0002c128 00:0000 16 f 0x0002c128
+0x0002c128 0x0002c12c 00:0000 4 j 0x0002c12c
+0x0002c12c 0x0002c13c 00:0000 16 j 0x0002c14c
+0x0002c13c 0x0002c14c 00:0000 16 f 0x0002c14c
+0x0002c14c 0x0002c15c 00:0000 16 j 0x0002c13c f 0x0002c15c
+0x0002c15c 0x0002c174 00:0000 24 j 0x0002c13c f 0x0002c174
+0x0002c174 0x0002c18c 00:0000 24 f 0x0002c18c
+0x0002c18c 0x0002c1a4 00:0000 24 f 0x0002c1a4
+0x0002c1a4 0x0002c1b8 00:0000 20 j 0x0002c1b8
+0x0002c1b8 0x0002c1cc 00:0000 20 f 0x0002c1cc
+0x0002c1cc 0x0002c1dc 00:0000 16 f 0x0002c1dc
+0x0002c1dc 0x0002c1f0 00:0000 20 j 0x0002c200 f 0x0002c1f0
+0x0002c1f0 0x0002c200 00:0000 16 j 0x0002c108 f 0x0002c200
+0x0002c200 0x0002c218 00:0000 24 f 0x0002c218
+0x0002c218 0x0002c228 00:0000 16 f 0x0002c228
+0x0002c228 0x0002c244 00:0000 28 f 0x0002c244
+0x0002c244 0x0002c25c 00:0000 24 j 0x0002c384 f 0x0002c25c
+0x0002c25c 0x0002c284 00:0000 40 j 0x0002c380 f 0x0002c284
+0x0002c284 0x0002c2b8 00:0000 52 j 0x0002c340
+0x0002c2b8 0x0002c2c0 00:0000 8 j 0x0002c2c0
+0x0002c2c0 0x0002c2e0 00:0000 32 j 0x0002c2e0
+0x0002c2e0 0x0002c2f4 00:0000 20 f 0x0002c2f4
+0x0002c2f4 0x0002c304 00:0000 16 j 0x0002c380 f 0x0002c304
+0x0002c304 0x0002c318 00:0000 20 j 0x0002c384 f 0x0002c318
+0x0002c318 0x0002c340 00:0000 40 j 0x0002c380 f 0x0002c340
+0x0002c340 0x0002c354 00:0000 20 j 0x0002c2b8 f 0x0002c354
+0x0002c354 0x0002c364 00:0000 16 j 0x0002c380 f 0x0002c364
+0x0002c364 0x0002c370 00:0000 12 j 0x0002c2c0 f 0x0002c370
+0x0002c370 0x0002c380 00:0000 16 j 0x0002c2c0 f 0x0002c380
+0x0002c380 0x0002c384 00:0000 4 j 0x0002c384
+0x0002c384 0x0002c398 00:0000 20 f 0x0002c398
+0x0002c398 0x0002c3a8 00:0000 16 j 0x0002c3a8
+0x0002c3a8 0x0002c3d0 00:0000 40 f 0x0002c3d0
+0x0002c3d0 0x0002c3dc 00:0000 12 j 0x0002c3dc
+0x0002c3dc 0x0002c3e8 00:0000 12 j 0x0002c3e8
+0x0002c3e8 0x0002c3f8 00:0000 16 j 0x0002c410 f 0x0002c3f8
+0x0002c3f8 0x0002c40c 00:0000 20 f 0x0002c40c
+0x0002c40c 0x0002c410 00:0000 4 j 0x0002c410
+0x0002c410 0x0002c420 00:0000 16 j 0x0002c450 f 0x0002c420
+0x0002c420 0x0002c440 00:0000 32 f 0x0002c440
+0x0002c440 0x0002c450 00:0000 16 j 0x0002c450
+0x0002c450 0x0002c46c 00:0000 28 f 0x0002c46c
+0x0002c46c 0x0002c480 00:0000 20 f 0x0002c480
+0x0002c480 0x0002c488 00:0000 8 j 0x0002c488
+0x0002c488 0x0002c49c 00:0000 20 j 0x0002c4b4 f 0x0002c49c
+0x0002c49c 0x0002c4b0 00:0000 20 f 0x0002c4b0
+0x0002c4b0 0x0002c4b4 00:0000 4 j 0x0002c4b4
+0x0002c4b4 0x0002c4c4 00:0000 16 f 0x0002c4c4
+0x0002c4c4 0x0002c4c8 00:0000 4 j 0x0002c4c8
+0x0002c4c8 0x0002c4d8 00:0000 16 f 0x0002c4d8
+0x0002c4d8 0x0002c4e8 00:0000 16
+EOF
+RUN
+
+NAME=af anal.endsize sparc
+FILE=../bins/elf/elf-Linux-SparcV8-bash
+CMDS=<<EOF
+e anal.endsize=0
+aaa
+s 0x0002bca0
+afi~name
+EOF
+EXPECT=<<EOF
+name: main
+EOF
+RUN


### PR DESCRIPTION
#15563
Basic Sparc regressions tests.

Note: relates to [https://github.com/radareorg/radare2/issues/15602#issue-534934335](url) as I took two Sparc binaries from there.

Inspired by regressions tests found in anal/x86_32