### PR TITLE
rasm2: treat reading from stdin the same as reading from a file

### DIFF
--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -765,6 +765,7 @@ R_API int r_main_rasm2(int argc, char *argv[]) {
 				ret = print_assembly_output (as, (char *)buf, offset, len,
 					as->a->bits, bin, use_spp, rad, hexwords, arch);
 			}
+			ret = !ret;
 			free (buf);
 		} else {
 			content = r_file_slurp (file, &length);


### PR DESCRIPTION
Add the missing return flag inversion so reading from stdin and a regular
file both return zero on success.