### PR TITLE
Add Python bytecode magic number

### DIFF
--- a/libr/magic/d/default/python
+++ b/libr/magic/d/default/python
@@ -1,20 +1,149 @@
-#	$OpenBSD: python,v 1.2 2008/05/08 01:40:57 chl Exp $
+#   $OpenBSD: python,v 1.2 2008/05/08 01:40:57 chl Exp $
 
 #------------------------------------------------------------------------------
 # python:  file(1) magic for python
 #
 # From: David Necas <yeti@physics.muni.cz>
 # often the module starts with a multiline string
-# 0	string		"""	a python script text executable
+# 0 string      """ a python script text executable
 # MAGIC as specified in Python/import.c (1.5 to 2.3.0a)
 # 20121  ( YEAR - 1995 ) + MONTH  + DAY (little endian followed by "\r\n"
-0	belong		0x994e0d0a	python 1.5/1.6 byte-compiled
-0	belong		0x87c60d0a	python 2.0 byte-compiled
-0	belong		0x2aeb0d0a	python 2.1 byte-compiled
-0	belong		0x2ded0d0a	python 2.2 byte-compiled
-0	belong		0x3bf20d0a	python 2.3 byte-compiled
-0	belong		0x6df20d0a	python 2.4 byte-compiled
-0	belong		0xb3f20d0a	python 2.5 byte-compiled
+0   belong      0x94949400  python 0.9.4 byte-compiled
+0   belong      0x2abe9900  python 0.9.9-v0 byte-compiled
+0   belong      0x3abe9900  python 0.9.9-v1 byte-compiled
+0   belong      0x01999900  python 0.9.9-v2 byte-compiled
+0   belong      0x02999900  python 1.0.1 byte-compiled
+0   belong      0x03999900  python 1.1 byte-compiled
+0   belong      0x27410d0a  python 1.2 byte-compiled
+0   belong      0x892e0d0a  python 1.3b1 byte-compiled
+0   belong      0x67070d0a  python 1.4b1-v0 byte-compiled
+0   belong      0x04170d0a  python 1.4b1-v1 byte-compiled
+0   belong      0x954e0d0a  python 1.4 byte-compiled
+0   belong      0x994e0d0a  python 1.5 byte-compiled
+0   belong      0xfcc40d0a  python 1.6 byte-compiled
+0   belong      0x1bc60d0a  python 2.0b1-v0 byte-compiled
+0   belong      0xfcc40d0a  python 2.0b1-v1 byte-compiled
+0   belong      0xfdc40d0a  python 2.0b1-v1-U byte-compiled
+0   belong      0x7bc60d0a  python 2.0b1-v2 byte-compiled
+0   belong      0x7cc60d0a  python 2.0b1-v2-U byte-compiled
+0   belong      0x7fc60d0a  python 2.0b1-v3 byte-compiled
+0   belong      0x80c60d0a  python 2.0b1-v3-U byte-compiled
+0   belong      0x86c60d0a  python 2.0b1_v5 byte-compiled
+0   belong      0x87c60d0a  python 2.0 byte-compiled
+0   belong      0x88c60d0a  python 2.0b1 byte-compiled
+0   belong      0xdcea0d0a  python 2.1a1 byte-compiled
+0   belong      0xddea0d0a  python 2.1a1_U byte-compiled
+0   belong      0x2aeb0d0a  python 2.1 byte-compiled
+0   belong      0x2beb0d0a  python 2.1a2_U byte-compiled
+0   belong      0x04ec0d0a  python 2.2a0 byte-compiled
+0   belong      0x05ec0d0a  python 2.2a0_U byte-compiled
+0   belong      0x2ded0d0a  python 2.2a1 byte-compiled
+0   belong      0x2eed0d0a  python 2.2a1_U byte-compiled
+0   belong      0x31f20d0a  python 2.3a0_v0 byte-compiled
+0   belong      0x32f20d0a  python 2.3a0_v0_U byte-compiled
+0   belong      0x3bf20d0a  python 2.3 byte-compiled
+0   belong      0x3cf20d0a  python 2.3a0-v1_U byte-compiled
+0   belong      0x45f20d0a  python 2.3a0-v2 byte-compiled
+0   belong      0x46f20d0a  python 2.3a0-v2_U byte-compiled
+0   belong      0x3bf20d0a  python 2.3a0-v3 byte-compiled
+0   belong      0x3cf20d0a  python 2.3a0-v3_U byte-compiled
+0   belong      0x4ff20d0a  python 2.4a0-v0 byte-compiled
+0   belong      0x50f20d0a  python 2.4a0-v0_U byte-compiled
+0   belong      0x59f20d0a  python 2.4a0-v1 byte-compiled
+0   belong      0x5af20d0a  python 2.4a0-v1_U byte-compiled
+0   belong      0x63f20d0a  python 2.4a2 byte-compiled
+0   belong      0x64f20d0a  python 2.4a2_U byte-compiled
+0   belong      0x6df20d0a  python 2.4 byte-compiled
+0   belong      0x6ef20d0a  python 2.4a3_U byte-compiled
+0   belong      0x77f20d0a  python 2.5a0_v0 byte-compiled
+0   belong      0x78f20d0a  python 2.5a0_v0_U byte-compiled
+0   belong      0x81f20d0a  python 2.5a0_v1 byte-compiled
+0   belong      0x82f20d0a  python 2.5a0_v1_U byte-compiled
+0   belong      0x8bf20d0a  python 2.5a0_v2 byte-compiled
+0   belong      0x8cf20d0a  python 2.5a0_v2_U byte-compiled
+0   belong      0x8cf20d0a  python 2.5a0_v3 byte-compiled
+0   belong      0x8df20d0a  python 2.5a0_v3_U byte-compiled
+0   belong      0x95f20d0a  python 2.5b2_v0 byte-compiled
+0   belong      0x96f20d0a  python 2.5b2_v0_U byte-compiled
+0   belong      0x9ff20d0a  python 2.5b2_v1 byte-compiled
+0   belong      0xa0f20d0a  python 2.5b2_v1_U byte-compiled
+0   belong      0xa9f20d0a  python 2.5c3 byte-compiled
+0   belong      0xaaf20d0a  python 2.5c3_U byte-compiled
+0   belong      0xb3f20d0a  python 2.6 byte-compiled
+0   belong      0xb4f20d0a  python 2.6a0_v0_U byte-compiled
+0   belong      0xbdf20d0a  python 2.6a0_v1 byte-compiled
+0   belong      0xbef20d0a  python 2.6a0_v1_U byte-compiled
+0   belong      0xc7f20d0a  python 2.6a0_v2 byte-compiled
+0   belong      0xc8f20d0a  python 2.6a0_v2_U byte-compiled
+0   belong      0xd1f20d0a  python 2.6a1_v0 byte-compiled
+0   belong      0xd2f20d0a  python 2.6a1_v0_U byte-compiled
+0   belong      0xd3f20d0a  python 2.6a1_v1 byte-compiled
+0   belong      0xd4f20d0a  python 2.6a1_v1_U byte-compiled
+0   belong      0xd1f20d0a  python 2.6a1_v2 byte-compiled
+0   belong      0xd2f20d0a  python 2.6a1_v2_U byte-compiled
+0   belong      0xdbf20d0a  python 2.7a0_v0 byte-compiled
+0   belong      0xdcf20d0a  python 2.7a0_v0_U byte-compiled
+0   belong      0xe5f20d0a  python 2.7a0_v1 byte-compiled
+0   belong      0xe6f20d0a  python 2.7a0_v1_U byte-compiled
+0   belong      0xeff20d0a  python 2.7a0_v2 byte-compiled
+0   belong      0xf0f20d0a  python 2.7a0_v2_U byte-compiled
+0   belong      0xf9f20d0a  python 2.7a2_v0 byte-compiled
+0   belong      0xfaf20d0a  python 2.7a2_v0_U byte-compiled
+0   belong      0x03f30d0a  python 2.7a2_v1 byte-compiled
+0   belong      0x04f30d0a  python 2.7a2_v1_U byte-compiled
+0   belong      0xb80b0d0a  python 3.0X_v0 byte-compiled
+0   belong      0xb90b0d0a  python 3.0X_v0_U byte-compiled
+0   belong      0xc20b0d0a  python 3.0X_v1 byte-compiled
+0   belong      0xc30b0d0a  python 3.0X_v1_U byte-compiled
+0   belong      0xcc0b0d0a  python 3.0X_v2 byte-compiled
+0   belong      0xcd0b0d0a  python 3.0X_v2_U byte-compiled
+0   belong      0xd60b0d0a  python 3.0X_v3 byte-compiled
+0   belong      0xd70b0d0a  python 3.0X_v3_U byte-compiled
+0   belong      0xe00b0d0a  python 3.0X_v4 byte-compiled
+0   belong      0xe10b0d0a  python 3.0X_v4_U byte-compiled
+0   belong      0xea0b0d0a  python 3.0X_v5 byte-compiled
+0   belong      0xeb0b0d0a  python 3.0X_v5_U byte-compiled
+0   belong      0xf40b0d0a  python 3.0X_v6 byte-compiled
+0   belong      0xf50b0d0a  python 3.0X_v6_U byte-compiled
+0   belong      0xfe0b0d0a  python 3.0a1_v0 byte-compiled
+0   belong      0xff0b0d0a  python 3.0a1_v0_U byte-compiled
+0   belong      0x080c0d0a  python 3.0a1_v1 byte-compiled
+0   belong      0x090c0d0a  python 3.0a1_v1_U byte-compiled
+0   belong      0x120c0d0a  python 3.0a1 byte-compiled
+0   belong      0x130c0d0a  python 3.0a1_U byte-compiled
+0   belong      0x1c0c0d0a  python 3.0a2 byte-compiled
+0   belong      0x1d0c0d0a  python 3.0a2_U byte-compiled
+0   belong      0x1e0c0d0a  python 3.0a2 byte-compiled
+0   belong      0x1f0c0d0a  python 3.0a2_U byte-compiled
+0   belong      0x3a0c0d0a  python 3.0a5 byte-compiled
+0   belong      0x3b0c0d0a  python 3.0a5_U byte-compiled
+0   belong      0x440c0d0a  python 3.1a0_v0 byte-compiled
+0   belong      0x450c0d0a  python 3.1a0_v0_U byte-compiled
+0   belong      0x4e0c0d0a  python 3.1a0_v1 byte-compiled
+0   belong      0x4f0c0d0a  python 3.1a0_v1_U byte-compiled
+0   belong      0x580c0d0a  python 3.2a0 byte-compiled
+0   belong      0x590c0d0a  python 3.2a0_U byte-compiled
+0   belong      0x620c0d0a  python 3.2a1_U byte-compiled
+0   belong      0x6c0c0d0a  python 3.2a2_U byte-compiled
+0   belong      0x760c0d0a  python 3.3a0_U byte-compiled
+0   belong      0x800c0d0a  python 3.3.0a0_v0_U  byte-compiled
+0   belong      0x8a0c0d0a  python 3.3.0a0_v1_U  byte-compiled
+0   belong      0x940c0d0a  python 3.3.0a1_U byte-compiled
+0   belong      0x9e0c0d0a  python 3.3.0a3_U byte-compiled
+0   belong      0xa80c0d0a  python 3.4.0a0_v0_U byte-compiled
+0   belong      0xb20c0d0a  python 3.4.0a0_v1_U byte-compiled
+0   belong      0xbc0c0d0a  python 3.4.0a0_v2_U byte-compiled
+0   belong      0xc60c0d0a  python 3.4.0a0_v3_U byte-compiled
+0   belong      0xd00c0d0a  python 3.4.0a0_v4_U byte-compiled
+0   belong      0xda0c0d0a  python 3.4.0a3_v0_U byte-compiled
+0   belong      0xe40c0d0a  python 3.4.0a3_v1_U byte-compiled
+0   belong      0xee0c0d0a  python 3.4.0rc1_U byte-compiled
+0   belong      0xf80c0d0a  python 3.5.0a0_U byte-compiled
+0   belong      0x020d0d0a  python 3.5.0a4_U byte-compiled
+0   belong      0x0c0d0d0a  python 3.5.0b1_U byte-compiled
+0   belong      0x160d0d0a  python 3.5.0b2_U byte-compiled
+0   belong      0x200d0d0a  python 3.6.0a0_v0_U byte-compiled
+0   belong      0x210d0d0a  python 3.6.0a0_v1_U byte-compiled
+0   belong      0x420d0d0a  python 3.7.5 byte-compiled
 
-0	string/b  #!\ /usr/bin/python	python script text executable
-
+0   string/b  #!\ /usr/bin/python   Python script text executable


### PR DESCRIPTION
- Majority of the magic was taken from [here](https://github.com/radareorg/radare2-extras/blob/5eb18b3e3b358e814edf33e4cbc79fd8dca8ee1c/libr/bin/format/pyc/pyc_magic.)
- Added Python 3.7.5 bytecode magic number