### PR TITLE
fixing memory leaks

### DIFF
--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -609,9 +609,7 @@ static bool __init_header(r_bin_le_obj_t *bin, RBuffer *buf) {
 }
 
 void r_bin_le_free(r_bin_le_obj_t *bin) {
-	if (!bin) {
-		return;
-	}
+	r_return_if_fail (bin);
 	if (bin->header) {
 		free (bin->header);
 	}

--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -609,9 +609,19 @@ static bool __init_header(r_bin_le_obj_t *bin, RBuffer *buf) {
 }
 
 void r_bin_le_free(r_bin_le_obj_t *bin) {
-	free (bin->header);
-	free (bin->objtbl);
-	free (bin->filename);
+	if (!bin) {
+		return;
+	}
+	if (bin->header) {
+		free (bin->header);
+	}
+	if (bin->objtbl) {
+		free (bin->objtbl);
+	}
+	if (bin->filename) {
+		free (bin->filename);
+	}
+	free (bin);
 }
 
 r_bin_le_obj_t *r_bin_le_new_buf(RBuffer *buf) {
@@ -631,6 +641,7 @@ r_bin_le_obj_t *r_bin_le_new_buf(RBuffer *buf) {
 	bin->arch = __get_arch (bin);
 	bin->objtbl = calloc (h->objcnt, sizeof (LE_object_entry));
 	if (!bin->objtbl) {
+		r_bin_le_free (bin);
 		return NULL;
 	}
 	ut64 offset = (ut64)bin->headerOff + h->restab;

--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -610,15 +610,9 @@ static bool __init_header(r_bin_le_obj_t *bin, RBuffer *buf) {
 
 void r_bin_le_free(r_bin_le_obj_t *bin) {
 	r_return_if_fail (bin);
-	if (bin->header) {
-		free (bin->header);
-	}
-	if (bin->objtbl) {
-		free (bin->objtbl);
-	}
-	if (bin->filename) {
-		free (bin->filename);
-	}
+	free (bin->header);
+	free (bin->objtbl);
+	free (bin->filename);
 	free (bin);
 }
 


### PR DESCRIPTION
we forgot to free the bin object leaking it if we bail out, plus improved the r_bin_le_free to actually free the root object