### PR TITLE
Fix radare2 -i -Q output when script has no nl at eof

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4891,6 +4891,7 @@ R_API int r_core_cmd_lines(RCore *core, const char *lines) {
 	}
 	if (ret >= 0 && data && *data) {
 		r_core_cmd (core, data, 0);
+		r_cons_flush ();
 		r_core_task_yield (&core->tasks);
 	}
 	free (odata);

--- a/test/new/db/tools/r2
+++ b/test/new/db/tools/r2
@@ -95,3 +95,10 @@ ONE_STREAM=1
 CMDS=e scr.onestream
 EXPECT=true
 RUN
+
+NAME=no-nl-at-eof script
+FILE=-
+CMDS=!radare2 -i scripts/no-nl-at-eof.r2 -NQ -
+EXPECT=1
+EXPECT_ERR=
+RUN

--- a/test/new/scripts/no-nl-at-eof.r2
+++ b/test/new/scripts/no-nl-at-eof.r2
@@ -1,0 +1,1 @@
+!!rahash2 -v~commit?


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

There is no output when running `radare2 -i <script> -NQ -` when the script is a single-liner with no newline at the end. This pr fixes that.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See test.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Issue in description. The `-N` is not relevant here.
