### PR TITLE
Add realname to anj

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1069,6 +1069,9 @@ static int cmd_an(RCore *core, bool use_json, const char *name)
 				} else {
 					pj_ks (pj, "name", f->name);
 				}
+				if (f->realname) {
+					pj_ks (pj, "realname", f->realname);
+				}
 				pj_ks (pj, "type", "flag");
 				pj_kn (pj, "offset", tgt_addr);
 				pj_end (pj);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
Currently, `anj` did not show the "realname" entry of a flag. This makes it harder to access this information in places which rely on `anj`, like Cutter.

This pull request adds "realname" to the JSON output.


**Test plan**

Before:

```
[0x004015f5]> anj~{}
[
  {
    "name": "sym.imp.KERNEL32.dll_GlobalFindAtomA",
    "type": "flag",
    "offset": 4206660
  }
]

```

After:
```
[0x004015f5]> anj~{}
[
  {
    "name": "sym.imp.KERNEL32.dll_GlobalFindAtomA",
    "realname": "GlobalFindAtomA",
    "type": "flag",
    "offset": 4206660
  }
]
```

1. Open a binary in radare2 before the change
2. Use `anj` on instruction using a flag with a real-name. e.g a call to an imported function in PE
3. Execute `anj~{}` and see that realname isn't available
4. Update radare2 to this PR
5. Repeat steps (1) and (2)
6. Execute `anj~{}` and see that realname is now available



**Closing issues**

None
