### PR TITLE
Terminate on missing script when doing radare2 -i -Q

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -252,7 +252,7 @@ static bool run_commands(RList *cmds, RList *files, bool quiet) {
 	r_list_foreach (files, iter, file) {
 		if (!r_file_exists (file)) {
 			eprintf ("Script '%s' not found.\n", file);
-			return false;
+			goto beach;
 		}
 		ret = r_core_run_script (&r, file);
 		if (ret == -2) {
@@ -269,6 +269,7 @@ static bool run_commands(RList *cmds, RList *files, bool quiet) {
 		r_core_cmd (&r, cmdn, false);
 		r_cons_flush ();
 	}
+beach:
 	if (quiet) {
 		if (do_analysis) {
 			return true;

--- a/test/new/db/tools/r2
+++ b/test/new/db/tools/r2
@@ -102,3 +102,14 @@ CMDS=!radare2 -i scripts/no-nl-at-eof.r2 -NQ -
 EXPECT=1
 EXPECT_ERR=
 RUN
+
+NAME=radare2 -i -Q with missing script
+FILE=-
+CMDS=<<EOF
+# Should not hang
+!radare2 -i script/missing.r2 -NQ -
+EOF
+EXPECT=<<EOF
+EOF
+EXPECT_ERR=Script 'script/missing.r2' not found.
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, `radare2 -i <script> -Q <binary>` will drop into a hidden prompt with no console echo if `<script>` is missing. This causes automated scripts to hang. This pr fixes this by terminating radare2 instead. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See test.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Issue in description.
