### PR TITLE
Honor segments in DEX files

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -2029,7 +2029,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->size = ptr->vsize = sizeof (struct dex_header_t);
 		ptr->paddr= ptr->vaddr = 0;
 		ptr->perm = R_PERM_R;
-		ptr->add = true;
+		ptr->add = false;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -2045,7 +2045,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = ptr->size;
 		ptr->format = r_str_newf ("Cd %d[%d]", 4, ptr->vsize / 4);
 		ptr->perm = R_PERM_R;
-		ptr->add = true;
+		ptr->add = false;
 		r_list_append (ret, ptr);
 		// Define as dwords!
 	}
@@ -2055,7 +2055,7 @@ static RList *sections(RBinFile *bf) {
 		ptr->size = bin->code_to - ptr->paddr;
 		ptr->vsize = ptr->size;
 		ptr->perm = R_PERM_RX;
-		ptr->add = true;
+		ptr->add = false;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -2071,7 +2071,7 @@ static RList *sections(RBinFile *bf) {
 			//ptr->size = ptr->vsize = 1024;
 		}
 		ptr->perm = R_PERM_R; //|2;
-		ptr->add = true;
+		ptr->add = false;
 		r_list_append (ret, ptr);
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
@@ -2081,6 +2081,27 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = ptr->size;
 		ptr->perm = R_PERM_R;
 		// ptr->format = strdup ("Cs 4");
+		ptr->add = false;
+		r_list_append (ret, ptr);
+	}
+
+	if ((ptr = R_NEW0 (RBinSection))) {
+		ptr->name = strdup ("code");
+		ptr->vaddr = ptr->paddr = bin->code_from;
+		ptr->size = bin->code_to - ptr->paddr;
+		ptr->vsize = ptr->size;
+		ptr->perm = R_PERM_RX;
+		ptr->is_segment = true;
+		ptr->add = true;
+		r_list_append (ret, ptr);
+	}
+	if ((ptr = R_NEW0 (RBinSection))) {
+		ptr->name = strdup ("file");
+		ptr->vaddr = ptr->paddr = 0;
+		ptr->size = r_buf_size (bf->buf);
+		ptr->vsize = ptr->size;
+		ptr->perm = R_PERM_R;
+		ptr->is_segment = true;
 		ptr->add = true;
 		r_list_append (ret, ptr);
 	}

--- a/test/new/db/formats/dex
+++ b/test/new/db/formats/dex
@@ -1,9 +1,6 @@
 NAME=invalid codesize DEX file
 FILE=../bins/dex/Call.dex
 EXPECT=<<EOF
- 4 fd: 3 +0x00000000 0x00000000 - 0x0000006f r-- fmap.header
- 3 fd: 3 +0x00000070 0x00000070 - 0x0000035c r-- fmap.constpool
- 2 fd: 3 +0x00000000 0x00000000 - 0x0000041b r-- fmap.data
  1 fd: 3 +0x00000000 0x00000000 - 0x0000041b r-- fmap.file
 0x35d
 EOF
@@ -172,6 +169,7 @@ FILE=../bins/dex/HelloWorld.dex
 EXPECT=<<EOF
 0x00000000 112 section.header
 0x00000000 1460 section.file
+0x00000000 1460 segment.file
 0x00000070 440 section.constpool
 0x00000160 0 sym.LHello.ifield_localVar:I
 0x00000168 0 sym.LHello.sfield_localVar2:I
@@ -187,6 +185,7 @@ EXPECT=<<EOF
 0x000001e8 1 class.LHello
 0x00000208 1 class.LWorld
 0x00000228 308 section.code
+0x00000228 308 segment.code
 0x00000238 20 sym.LHello.method._init___V
 0x00000238 1 method.public.constructor.LHello.LHello.method._init___V
 0x0000025c 1 entry0


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

It honors segments in DEX files by adding header, code, and data segments similar to the sections.

**Test plan**

```
$ r2 /tmp/classes.dex
[0x0034b3c8]> iSS
[Segments]

nth paddr           size vaddr          vsize perm name
―――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00000000      0x70 0x00000000      0x70 -r-- header
1   0x00344188  0x676c70 0x00344188  0x676c70 -r-x code
2   0x00aac3f1   0x29007 0x00aac3f1   0x29007 -r-- data


[0x0034b3c8]> iS
[Sections]

nth paddr           size vaddr          vsize perm name
―――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00000000      0x70 0x00000000      0x70 -r-- header
1   0x00000070  0x344118 0x00000070  0x344118 -r-- constpool
2   0x00344188  0x676c70 0x00344188  0x676c70 -r-x code
3   0x00aac3f1   0x29007 0x00aac3f1   0x29007 -r-- data
4   0x00000000  0xad53f8 0x00000000  0xad53f8 -r-- file


[0x0034b3c8]> 
```

**Closing issues**

close #14325 
