### PR TITLE
r2r.v, BROKEN: Ignore everything after first space

### DIFF
--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -281,7 +281,8 @@ fn (r2r mut R2R) load_cmd_test(testfile string) {
 			}
 			'BROKEN' {
 				if v.len > 0 {
-					test.broken = v == '1'
+					first_token := v.split_nth(' ', 2)[0]
+					test.broken = first_token == '1'
 				}
 				else {
 					eprintln('Warning: Missing value for BROKEN in ${test.source}')


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Current r2r.v treats
```
BROKEN=1
```
correctly but
```
BROKEN=1 # Only at Windows
```
wrongly. This pr fixes that by ignoring everything after the first space.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`./r2r -j 1 tools /r2`  on r2 commit 8850bc6aaf858c6f189bddb0c44d7043676e8e32. There should be 4 `[FX]`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Issue in description.
