### PR TITLE
Add Unit Tests to Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -485,6 +485,8 @@ if get_option('use_webui')
   )
 endif
 
+subdir('test/unit')
+
 install_data(
   'doc/fortunes.creepy',
   'doc/fortunes.fun',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -34,3 +34,5 @@ option('use_webui', type: 'boolean', value: false, description: 'install differe
 
 option('shell_parser_in_builddir', type: 'boolean', value: true, description: 'When true, radare2-shell-parser is downloaded in the build directory')
 option('tree_sitter_in_builddir', type: 'boolean', value: true, description: 'When true, tree-sitter is downloaded in the build directory')
+
+option('build_tests', type: 'boolean', value: false, description: 'Build unit tests in test/unit')

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -1,0 +1,72 @@
+
+if get_option('build_tests')
+  tests = [
+    'addr_interval',
+    'anal_block',
+    'anal_function',
+    'base64',
+    'bin',
+    'bitmap',
+    'buf',
+    'contrbtree',
+    'debruijn',
+    'diff',
+    'esil_dfg_filter',
+    'event',
+    'flags',
+    'glob',
+    'hex',
+    'intervaltree',
+    'io',
+    'list',
+    'parse_ctype',
+    'queue',
+    'range',
+    'rbtree',
+    'skiplist',
+    'spaces',
+    'sparse',
+    'stack',
+    'str',
+    'strbuf',
+    'table',
+    'tree',
+    'uleb128',
+    'unum',
+    'util',
+    'vector'
+  ]
+
+  foreach test : tests
+    exe = executable('test_@0@'.format(test), 'test_@0@.c'.format(test),
+      include_directories: [platform_inc],
+      dependencies: [
+        r_util_dep,
+        r_main_dep,
+        r_socket_dep,
+        r_core_dep,
+        r_io_dep,
+        r_fs_dep,
+        r_bin_dep,
+        r_flag_dep,
+        r_cons_dep,
+        r_asm_dep,
+        r_debug_dep,
+        r_config_dep,
+        r_bp_dep,
+        r_reg_dep,
+        r_syscall_dep,
+        r_anal_dep,
+        r_parse_dep,
+        r_egg_dep,
+        r_search_dep,
+        r_hash_dep,
+        r_crypto_dep,
+        r_magic_dep
+      ],
+      install: false,
+      install_rpath: rpath,
+      implicit_include_directories: false)
+    test(test, exe, workdir: join_paths(meson.current_source_dir(), '..'))
+  endforeach
+endif


### PR DESCRIPTION
**Detailed description**

This enables the unit tests to be built and run directly as part of the meson project.
It is disabled by default an can be enabled with the `build_tests` option.

**Test plan**

* run meson with `-Dbuild_tests=true` or reconfigure an existing build dir like `meson configure -Dbuild_tests=true`
* `ninja test`
* You should get something like this:
```
[florian@florian-laptop build]$ ninja test
[0/1] Running all tests.
 1/34 addr_interval                           OK       0.02 s 
 2/34 anal_block                              OK       0.02 s 
 3/34 anal_function                           OK       0.02 s 
 4/34 base64                                  OK       0.02 s 
 5/34 bin                                     OK       0.03 s 
 6/34 bitmap                                  OK       0.01 s 
 7/34 buf                                     OK       0.01 s 
 8/34 contrbtree                              OK       0.02 s 
 9/34 debruijn                                OK       0.01 s 
10/34 diff                                    OK       0.01 s 
11/34 esil_dfg_filter                         OK       0.02 s 
12/34 event                                   OK       0.01 s 
13/34 flags                                   OK       0.01 s 
14/34 glob                                    OK       0.01 s 
15/34 hex                                     OK       0.01 s 
16/34 intervaltree                            OK       0.24 s 
17/34 io                                      OK       0.02 s 
18/34 list                                    OK       0.01 s 
19/34 parse_ctype                             OK       0.02 s 
20/34 queue                                   OK       0.02 s 
21/34 range                                   OK       0.01 s 
22/34 rbtree                                  OK       0.08 s 
23/34 skiplist                                OK       0.02 s 
24/34 spaces                                  OK       0.01 s 
25/34 sparse                                  OK       0.01 s 
26/34 stack                                   OK       0.01 s 
27/34 str                                     OK       0.01 s 
28/34 strbuf                                  OK       0.01 s 
29/34 table                                   OK       0.01 s 
30/34 tree                                    OK       0.01 s 
31/34 uleb128                                 OK       0.01 s 
32/34 unum                                    OK       0.01 s 
33/34 util                                    OK       0.01 s 
34/34 vector                                  OK       0.01 s 

Ok:                   34
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0

Full log written to /home/florian/dev/radare2/build/meson-logs/testlog.txt
```