### PR TITLE
Fix tccj, tccl, tcc* output errors

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -195,6 +195,7 @@ static void __core_cmd_tcc(RCore *core, const char *input) {
 	case 'j':
 		{
 			char *ccs = r_core_cmd_strf (core, "afcl");
+			r_str_trim_head_tail (ccs);
 			RList *list = r_str_split_list (ccs, "\n", 0);
 			RListIter *iter;
 			const char *cc;
@@ -216,6 +217,7 @@ static void __core_cmd_tcc(RCore *core, const char *input) {
 	case 'l':
 		{
 			char *ccs = r_core_cmd_strf (core, "afcl");
+			r_str_trim_head_tail (ccs);
 			RList *list = r_str_split_list (ccs, "\n", 0);
 			RListIter *iter;
 			const char *cc;
@@ -231,6 +233,7 @@ static void __core_cmd_tcc(RCore *core, const char *input) {
 	case '*':
 		{
 			char *ccs = r_core_cmd_strf (core, "afcl");
+			r_str_trim_head_tail (ccs);
 			RList *list = r_str_split_list (ccs, "\n", 0);
 			RListIter *iter;
 			const char *cc;

--- a/test/new/db/cmd/cmd_tcc
+++ b/test/new/db/cmd/cmd_tcc
@@ -1,0 +1,27 @@
+NAME=tcc
+FILE=../bins/elf/ls
+CMDS=<<EOF
+tcc
+EOF
+EXPECT=<<EOF
+amd64
+ms
+EOF
+RUN
+
+NAME=tccj, tccl, tcc* outputs
+FILE=../bins/elf/ls
+CMDS=<<EOF
+tccj
+tccl
+tcc*
+EOF
+EXPECT=<<EOF
+["rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax ms (rcx, rdx, r8, r9, stack);"]
+rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+rax ms (rcx, rdx, r8, r9, stack);
+tfc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+tfc rax ms (rcx, rdx, r8, r9, stack);
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

```
$ r2 /bin/ls
[0x000067d0]> tccj                                                                                                                                                                            
This is not a valid calling convention name                                                    
WARNING: pj_s: assertion 'j && k' failed (line 176)                                            
["rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax ms (rcx, rdx, r8, r9, stack);"]
[0x000067d0]> tccl
This is not a valid calling convention name
rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
rax ms (rcx, rdx, r8, r9, stack);
(null)
[0x000067d0]> tcc*
This is not a valid calling convention name
tfc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
tfc rax ms (rcx, rdx, r8, r9, stack);
tfc (null)
```

The problem lies in `cmd_type.c`
```
char *ccs = r_core_cmd_strf (core, "afcl");
RList *list = r_str_split_list (ccs, "\n", 0);
```
`r_core_cmd_strf` returns the result string that ends with a newline,  so trim whitespaces before passing to `r_str_split_list`.