### PR TITLE
Fix /j in r2 when there is no input argument

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -3601,7 +3601,7 @@ reread:
 		}
 		ignorecase = true;
 	case 'j': // "/j"
-		if (input[0] == 'j') {
+		if (input[0] == 'j' && input[1] == ' ') {
 			param.outmode = R_MODE_JSON;
 		}
 		// fallthrough


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
- /j without argument returns empty result
- /j with space and without argument return stray new line
```
$> r2 /bin/ls
 -- Execute commands on a temporary offset by appending '@ offset' to your command.
[0x000067d0]> /j<---- no space and no argument
[]
[0x000067d0]> /j <---- space and no argument
Invalid keyword

[0x000067d0]>
```

After patch 
```
$> r2 /bin/ls
 -- The stripping process is not deep enough
[0x000067d0]> /j
Invalid keyword
[0x000067d0]> /j 
Invalid keyword
[0x000067d0]>
```
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
