### PR TITLE
Remove prev, jumpbb and failbb from RAnalBlock ##anal

### DIFF
--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -43,44 +43,6 @@ R_API RAnalBlock *r_anal_bb_from_offset(RAnal *anal, ut64 off) {
 	return ret;
 }
 
-R_API RAnalBlock *r_anal_bb_get_jumpbb(RAnalFunction *fcn, RAnalBlock *bb) {
-	if (bb->jump == UT64_MAX) {
-		return NULL;
-	}
-	if (bb->jumpbb) {
-		return bb->jumpbb;
-	}
-	RListIter *iter;
-	RAnalBlock *b;
-	r_list_foreach (fcn->bbs, iter, b) {
-		if (b->addr == bb->jump) {
-			bb->jumpbb = b;
-			b->prev = bb;
-			return b;
-		}
-	}
-	return NULL;
-}
-
-R_API RAnalBlock *r_anal_bb_get_failbb(RAnalFunction *fcn, RAnalBlock *bb) {
-	RListIter *iter;
-	RAnalBlock *b;
-	if (bb->fail == UT64_MAX) {
-		return NULL;
-	}
-	if (bb->failbb) {
-		return bb->failbb;
-	}
-	r_list_foreach (fcn->bbs, iter, b) {
-		if (b->addr == bb->fail) {
-			bb->failbb = b;
-			b->prev = bb;
-			return b;
-		}
-	}
-	return NULL;
-}
-
 /* return the offset of the i-th instruction in the basicblock bb.
  * If the index of the instruction is not valid, it returns UT16_MAX */
 R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i) {

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2155,8 +2155,8 @@ static char *get_bb_body(RCore *core, RAnalBlock *b, int opts, RAnalFunction *fc
 	char *body = get_body (core, b->addr, b->size, opts);
 	if (b->jump != UT64_MAX) {
 		if (b->jump > b->addr) {
-			RAnalBlock *jumpbb = r_anal_bb_get_jumpbb (fcn, b);
-			if (jumpbb) {
+			RAnalBlock *jumpbb = r_anal_get_block_at (b->anal, b->jump);
+			if (jumpbb && r_list_contains (jumpbb->fcns, fcn)) {
 				if (emu && core->anal->last_disasm_reg != NULL && !jumpbb->parent_reg_arena) {
 					jumpbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 				}
@@ -2168,8 +2168,8 @@ static char *get_bb_body(RCore *core, RAnalBlock *b, int opts, RAnalFunction *fc
 	}
 	if (b->fail != UT64_MAX) {
 		if (b->fail > b->addr) {
-			RAnalBlock *failbb = r_anal_bb_get_failbb (fcn, b);
-			if (failbb) {
+			RAnalBlock *failbb = r_anal_get_block_at (b->anal, b->fail);
+			if (failbb && r_list_contains (failbb->fcns, fcn)) {
 				if (emu && core->anal->last_disasm_reg != NULL && !failbb->parent_reg_arena) {
 					failbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 				}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4086,8 +4086,8 @@ static void pr_bb(RCore *core, RAnalFunction *fcn, RAnalBlock *b, bool emu, ut64
 
 	if (b->jump != UT64_MAX) {
 		if (b->jump > b->addr) {
-			RAnalBlock *jumpbb = r_anal_bb_get_jumpbb (fcn, b);
-			if (jumpbb) {
+			RAnalBlock *jumpbb = r_anal_get_block_at (b->anal, b->jump);
+			if (jumpbb && r_list_contains (jumpbb->fcns, fcn)) {
 				if (emu && core->anal->last_disasm_reg && !jumpbb->parent_reg_arena) {
 					jumpbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 				}
@@ -4102,8 +4102,8 @@ static void pr_bb(RCore *core, RAnalFunction *fcn, RAnalBlock *b, bool emu, ut64
 	}
 	if (b->fail != UT64_MAX) {
 		if (b->fail > b->addr) {
-			RAnalBlock *failbb = r_anal_bb_get_failbb (fcn, b);
-			if (failbb) {
+			RAnalBlock *failbb = r_anal_get_block_at (b->anal, b->fail);
+			if (failbb && r_list_contains (failbb->fcns, fcn)) {
 				if (emu && core->anal->last_disasm_reg && !failbb->parent_reg_arena) {
 					failbb->parent_reg_arena = r_reg_arena_dup (core->anal->reg, core->anal->last_disasm_reg);
 				}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -909,10 +909,6 @@ typedef struct r_anal_bb_t {
 	// size of the op_pos array
 	int op_pos_size;
 	ut8 *op_bytes;
-	/* these are used also in pdr: */
-	RAnalBlock *prev;
-	RAnalBlock *failbb;
-	RAnalBlock *jumpbb;
 	RList /*struct r_anal_bb_t*/ *cases;
 	ut8 *parent_reg_arena;
 	int stackptr;
@@ -1489,8 +1485,6 @@ R_API ut16 r_anal_bb_offset_inst(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_i(RAnalBlock *bb, int i);
 R_API ut64 r_anal_bb_opaddr_at(RAnalBlock *bb, ut64 addr);
 R_API bool r_anal_bb_op_starts_at(RAnalBlock *bb, ut64 addr);
-R_API RAnalBlock *r_anal_bb_get_failbb(RAnalFunction *fcn, RAnalBlock *bb);
-R_API RAnalBlock *r_anal_bb_get_jumpbb(RAnalFunction *fcn, RAnalBlock *bb);
 
 /* op.c */
 R_API const char *r_anal_stackop_tostring(int s);


### PR DESCRIPTION
**Detailed description**

These members were only used for printing graph and pdr. Also they caused a uaf when a basic block is removed since they keep pointers to basic blocks, see test plan.

**Test plan**

**Before:** `r2 -Qc "s main; af; agf; afb- 0x8048643; agf" megabeets_0x1` (can be any bin, just remove a basic block between two agf calls)
causes:
```
==68045== Invalid read of size 4
==68045==    at 0x5BB9E25: get_bb_body (agraph.c:2176)
==68045==    by 0x5BBA6F6: get_bbnodes (agraph.c:2343)
==68045==    by 0x5BBADD2: reload_nodes (agraph.c:2483)
==68045==    by 0x5BBD23C: agraph_reload_nodes (agraph.c:3162)
==68045==    by 0x5BBDBDF: check_changes (agraph.c:3357)
==68045==    by 0x5BBDF74: agraph_print (agraph.c:3417)
==68045==    by 0x5BBE6B6: agraph_refresh (agraph.c:3554)
==68045==    by 0x5BC09EB: r_core_visual_graph (agraph.c:4145)
==68045==    by 0x5B2006D: cmd_anal_graph (cmd_anal.c:7997)
==68045==    by 0x5B266AF: cmd_anal (cmd_anal.c:9857)
==68045==    by 0x5B82838: r_cmd_call (cmd_api.c:244)
==68045==    by 0x5B7ADD9: r_core_cmd_subst_i (cmd.c:3643)
==68045==  Address 0xa3fd37c is 188 bytes inside a block of size 240 free'd
==68045==    at 0x48399AB: free (vg_replace_malloc.c:540)
==68045==    by 0x5F740B9: block_free (block.c:79)
==68045==    by 0x5F740E2: __block_free_rb (block.c:84)
==68045==    by 0x48C3629: r_rbtree_aug_delete (rbtree.c:170)
==68045==    by 0x5F74FB2: r_anal_block_unref (block.c:366)
==68045==    by 0x5F75EF7: r_anal_function_remove_block (function.c:237)
==68045==    by 0x5B0A0DA: anal_fcn_del_bb (cmd_anal.c:2320)
==68045==    by 0x5B0ECC2: cmd_anal_fcn (cmd_anal.c:3543)
==68045==    by 0x5B265C4: cmd_anal (cmd_anal.c:9822)
==68045==    by 0x5B82838: r_cmd_call (cmd_api.c:244)
==68045==    by 0x5B7ADD9: r_core_cmd_subst_i (cmd.c:3643)
==68045==    by 0x5B77174: r_core_cmd_subst (cmd.c:2585)
==68045==  Block was alloc'd at
==68045==    at 0x483AB65: calloc (vg_replace_malloc.c:762)
==68045==    by 0x5F73F27: block_new (block.c:46)
==68045==    by 0x5F744DF: r_anal_create_block (block.c:179)
==68045==    by 0x5F96805: fcn_append_basic_block (fcn.c:185)
==68045==    by 0x5F97B3D: fcn_recurse (fcn.c:519)
==68045==    by 0x5F9A76E: r_anal_fcn_bb (fcn.c:1208)
==68045==    by 0x5F999C9: fcn_recurse (fcn.c:989)
==68045==    by 0x5F9A76E: r_anal_fcn_bb (fcn.c:1208)
==68045==    by 0x5F999C9: fcn_recurse (fcn.c:989)
==68045==    by 0x5F9A76E: r_anal_fcn_bb (fcn.c:1208)
==68045==    by 0x5F9ADA9: r_anal_fcn (fcn.c:1319)
==68045==    by 0x5A933FB: __core_anal_fcn (canal.c:778)
==68045== 
```

**After:** no uaf