### PR TITLE
new parser: fix multiple words in grep and add support for > $alias

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5024,7 +5024,10 @@ DEFINE_HANDLE_TS_FCN(grep_command) {
 	char *specifier_str = ts_node_sub_string (specifier, state->input);
 	bool res = handle_ts_command (state, command);
 	R_LOG_DEBUG ("grep_command specifier: '%s'\n", specifier_str);
-	char *specifier_str_processed = r_cons_grep_strip (specifier_str, "`");
+	RStrBuf *sb = r_strbuf_new (specifier_str);
+	r_strbuf_prepend (sb, "~");
+	char *specifier_str_processed = r_cons_grep_strip (r_strbuf_get (sb), "`");
+	r_strbuf_free (sb);
 	R_LOG_DEBUG ("grep_command processed specifier: '%s'\n", specifier_str_processed);
 	r_cons_grep_process (specifier_str_processed);
 	free (specifier_str);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4472,14 +4472,16 @@ DEFINE_IS_TS_FCN(cmd_substitution_arg)
 DEFINE_IS_TS_FCN(args)
 DEFINE_IS_TS_FCN(arg)
 DEFINE_IS_TS_FCN(arg_identifier)
-DEFINE_IS_TS_FCN(quoted_arg)
+DEFINE_IS_TS_FCN(double_quoted_arg)
+DEFINE_IS_TS_FCN(single_quoted_arg)
 
 // NOTE: this should be in sync with SPECIAL_CHARACTERS in
 //       radare2-shell-parser grammar, except for ", ' and
 //       whitespaces, because we let cmd_substitution_arg create
 //       new arguments
-static const char *SPECIAL_CHARS_REGULAR = "@;~$#|`()<";
+static const char *SPECIAL_CHARS_REGULAR = "@;~$#|`\"'()<>";
 static const char *SPECIAL_CHARS_DOUBLE_QUOTED = "\"";
+static const char *SPECIAL_CHARS_SINGLE_QUOTED = "'";
 
 static struct tsr2cmd_edit *create_cmd_edit(struct tsr2cmd_state *state, TSNode arg, char *new_text) {
 	struct tsr2cmd_edit *e = R_NEW0 (struct tsr2cmd_edit);
@@ -4580,7 +4582,7 @@ static void do_handle_substitution_arg(struct tsr2cmd_state *state, TSNode arg, 
 	replace_whitespaces (out, ' ');
 	// escape special chars to prevent creation of new tokens when parsing again
 	const char *special_chars;
-	if (is_ts_quoted_arg (ts_node_parent (arg))) {
+	if (is_ts_double_quoted_arg (ts_node_parent (arg))) {
 		special_chars = SPECIAL_CHARS_DOUBLE_QUOTED;
 	} else {
 		special_chars = SPECIAL_CHARS_REGULAR;
@@ -4595,7 +4597,7 @@ static void handle_substitution_arg(struct tsr2cmd_state *state, TSNode arg, RLi
 	r_return_if_fail (!ts_node_is_null (arg));
 	if (is_ts_cmd_substitution_arg (arg)) {
 		do_handle_substitution_arg (state, arg, edits);
-	} else if (is_ts_quoted_arg (arg)) {
+	} else if (is_ts_double_quoted_arg (arg)) {
 		uint32_t n_children = ts_node_named_child_count (arg);
 		uint32_t i;
 		for (i = 0; i < n_children; ++i) {
@@ -4631,7 +4633,13 @@ static char *do_handle_ts_unescape_arg(struct tsr2cmd_state *state, TSNode arg) 
 		return do_handle_ts_unescape_arg (state, ts_node_named_child (arg, 0));
 	} else if (is_ts_arg_identifier (arg)) {
 		return unescape_arg (state, arg, SPECIAL_CHARS_REGULAR);
-	} else if (is_ts_quoted_arg (arg)) {
+	} else if (is_ts_single_quoted_arg (arg)) {
+		char *c = unescape_arg (state, arg, SPECIAL_CHARS_SINGLE_QUOTED);
+		c[strlen (c) - 1] = '\0';
+		char *res = strdup (c + 1);
+		free (c);
+		return res;
+	} else if (is_ts_double_quoted_arg (arg)) {
 		char *c = unescape_arg (state, arg, SPECIAL_CHARS_DOUBLE_QUOTED);
 		c[strlen (c) - 1] = '\0';
 		char *res = strdup (c + 1);
@@ -4887,17 +4895,38 @@ DEFINE_HANDLE_TS_FCN(redirect_command) {
 	TSNode arg = ts_node_child_by_field_name (node, "arg", strlen ("arg"));
 	char *arg_str = ts_node_sub_string (arg, state->input);
 
-	int pipefd = r_cons_pipe_open (arg_str, fdn, is_append);
-	if (pipefd != -1) {
-		if (!pipecolor) {
-			r_config_set_i (state->core->config, "scr.color", COLOR_MODE_DISABLED);
-		}
+	if (arg_str[0] == '$') {
+		// redirect output of command to an alias variable
 		TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
-		res = handle_ts_command (state, command);
-		r_cons_flush ();
-		r_cons_pipe_close (pipefd);
+		char *command_str = ts_node_sub_string (command, state->input);
+
+		char *output = r_core_cmd_str (state->core, command_str);
+		char *old_alias_value = r_cmd_alias_get (state->core->rcmd, arg_str, 1);
+		char *new_alias_value;
+		const char *start_char = "$";
+		if (is_append && old_alias_value) {
+			start_char = "";
+		} else {
+			old_alias_value = "";
+		}
+		new_alias_value = r_str_newf ("%s%s%s", start_char, old_alias_value, output);
+		r_cmd_alias_set (state->core->rcmd, arg_str, new_alias_value, 1);
+		free (new_alias_value);
+		free (command_str);
+		res = true;
 	} else {
-		R_LOG_WARN ("Could not open pipe to %d", fdn);
+		int pipefd = r_cons_pipe_open (arg_str, fdn, is_append);
+		if (pipefd != -1) {
+			if (!pipecolor) {
+				r_config_set_i (state->core->config, "scr.color", COLOR_MODE_DISABLED);
+			}
+			TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
+			res = handle_ts_command (state, command);
+			r_cons_flush ();
+			r_cons_pipe_close (pipefd);
+		} else {
+			R_LOG_WARN ("Could not open pipe to %d", fdn);
+		}
 	}
 	free (arg_str);
 	r_cons_set_last_interactive ();
@@ -4994,8 +5023,11 @@ DEFINE_HANDLE_TS_FCN(grep_command) {
 	TSNode specifier = ts_node_child_by_field_name (node, "specifier", strlen ("specifier"));
 	char *specifier_str = ts_node_sub_string (specifier, state->input);
 	bool res = handle_ts_command (state, command);
-	// FIXME: this does not work for nested grep commands
-	r_cons_grep_process (specifier_str);
+	R_LOG_DEBUG ("grep_command specifier: '%s'\n", specifier_str);
+	char *specifier_str_processed = r_cons_grep_strip (specifier_str, "`");
+	R_LOG_DEBUG ("grep_command processed specifier: '%s'\n", specifier_str_processed);
+	r_cons_grep_process (specifier_str_processed);
+	free (specifier_str);
 	return res;
 }
 

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -34,7 +34,7 @@ TS_TIP=aef62b4bc6b9654e54bd59bee1cb8cea16e3aa96
 # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/meson.build
 SHELLPARSER_URL=https://github.com/ret2libc/radare2-shell-parser.git
 SHELLPARSER_BRA=master
-SHELLPARSER_TIP=188be67ff6211de12e83b849938c3bc8daa18c66
+SHELLPARSER_TIP=8adfc39331d99b369be869d85a2fbb624fe75d75
 
 ifeq ($(CS_RELEASE),1)
 CS_VER=4.0.1

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -295,7 +295,7 @@ if get_option('use_treesitter')
     endif
 
     # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/Makefile
-    SHELLPARSER_TIP = '188be67ff6211de12e83b849938c3bc8daa18c66'
+    SHELLPARSER_TIP = '8adfc39331d99b369be869d85a2fbb624fe75d75'
     SHELLPARSER_BRA = 'master'
     shell_parser_user = 'ret2libc'
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR adds support for redirect to alias (e.g. `om* > $myalias`) in new parser and fix grep with multiple words (e.g. `pd 10~xor~eax`)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Some of the regression tests use these features, so they should now pass with the new parser. 