### PR TITLE
Fix #13908 - x86 aoj for instruction with hidden operand ##asm

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -63,7 +63,9 @@ struct Getarg {
 	int bits;
 };
 
-static void hidden_op(csh handle, cs_insn *insn, cs_x86 *x, int mode) {
+static csh handle = 0;
+
+static void hidden_op(cs_insn *insn, cs_x86 *x, int mode) {
 	unsigned int id = insn->id;
 	int regsz = 4;
 	switch (mode) {
@@ -105,13 +107,13 @@ static void hidden_op(csh handle, cs_insn *insn, cs_x86 *x, int mode) {
 	}
 }
 
-static void opex(RStrBuf *buf, csh handle, cs_insn *insn, int mode) {
+static void opex(RStrBuf *buf, cs_insn *insn, int mode) {
 	int i;
 	r_strbuf_init (buf);
 	r_strbuf_append (buf, "{");
 	cs_x86 *x = &insn->detail->x86;
 	if (x->op_count == 0) {
-		hidden_op (handle, insn, x, mode);
+		hidden_op (insn, x, mode);
 	}
 	r_strbuf_appendf (buf, "\"operands\":[", x->op_count);
 	for (i = 0; i < x->op_count; i++) {
@@ -333,8 +335,6 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop, int sel, ut
 	}
 	return NULL;
 }
-
-static csh handle = 0;
 
 static int cond_x862r2(int id) {
 	switch (id) {
@@ -3092,7 +3092,7 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 			anop_esil (a, op, addr, buf, len, &handle, insn);
 		}
 		if (mask & R_ANAL_OP_MASK_OPEX) {
-			opex (&op->opex, handle, insn, mode);
+			opex (&op->opex, insn, mode);
 		}
 		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (a, op, &handle, insn);

--- a/test/new/db/anal/x86_16
+++ b/test/new/db/anal/x86_16
@@ -32,3 +32,51 @@ wx ea34002001
 EOF
 EXPECT=0x1234
 RUN
+
+NAME=aoj pushf
+FILE=-
+EXPECT=<<EOF
+[
+  {
+    "opcode": "pushf",
+    "disasm": "pushf",
+    "pseudo": "pushf ",
+    "description": "push flags register onto the stack",
+    "mnemonic": "pushf",
+    "mask": "ff",
+    "esil": "2,sp,-=,eflags,sp,=[2]",
+    "sign": false,
+    "prefix": 0,
+    "id": 591,
+    "opex": {
+      "operands": [
+        {
+          "size": 2,
+          "rw": 1,
+          "type": "reg",
+          "value": "flags"
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "9c",
+    "size": 1,
+    "type": "upush",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 2,
+    "failcycles": 0,
+    "delay": 0,
+    "stack": "inc",
+    "stackptr": 2,
+    "family": "cpu"
+  }
+]
+EOF
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+wx 9c
+aoj~{}
+EOF
+RUN

--- a/test/new/db/anal/x86_32
+++ b/test/new/db/anal/x86_32
@@ -3147,6 +3147,54 @@ aoj~{}
 EOF
 RUN
 
+NAME=aoj pushf
+FILE=-
+EXPECT=<<EOF
+[
+  {
+    "opcode": "pushf",
+    "disasm": "pushf",
+    "pseudo": "pushf ",
+    "description": "push flags register onto the stack",
+    "mnemonic": "pushf",
+    "mask": "ffff",
+    "esil": "4,esp,-=,eflags,esp,=[4]",
+    "sign": false,
+    "prefix": 0,
+    "id": 591,
+    "opex": {
+      "operands": [
+        {
+          "size": 4,
+          "rw": 1,
+          "type": "reg",
+          "value": "eflags"
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "669c",
+    "size": 2,
+    "type": "upush",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 2,
+    "failcycles": 0,
+    "delay": 0,
+    "stack": "inc",
+    "stackptr": 4,
+    "family": "cpu"
+  }
+]
+EOF
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 669c
+aoj~{}
+EOF
+RUN
+
 NAME=reflines offset
 FILE=malloc://1023
 CMDS=<<EOF

--- a/test/new/db/anal/x86_64
+++ b/test/new/db/anal/x86_64
@@ -2037,6 +2037,54 @@ ao~^ptr[1]
 EOF
 RUN
 
+NAME=aoj pushf
+FILE=-
+EXPECT=<<EOF
+[
+  {
+    "opcode": "pushf",
+    "disasm": "pushf",
+    "pseudo": "pushf ",
+    "description": "push flags register onto the stack",
+    "mnemonic": "pushf",
+    "mask": "ffff",
+    "esil": "8,rsp,-=,eflags,rsp,=[8]",
+    "sign": false,
+    "prefix": 0,
+    "id": 591,
+    "opex": {
+      "operands": [
+        {
+          "size": 8,
+          "rw": 1,
+          "type": "reg",
+          "value": "rflags"
+        }
+      ]
+    },
+    "addr": 0,
+    "bytes": "669c",
+    "size": 2,
+    "type": "upush",
+    "scale": 0,
+    "refptr": 0,
+    "cycles": 2,
+    "failcycles": 0,
+    "delay": 0,
+    "stack": "inc",
+    "stackptr": 8,
+    "family": "cpu"
+  }
+]
+EOF
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 669c
+aoj~{}
+EOF
+RUN
+
 NAME=strings xref issue
 FILE=../bins/elf/redpill
 EXPECT=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->


Fix for aoj on x86 to handle instructions with hidden operand
- Add hidden_op()
- Added operands info for pushf, popf, pushfd, popfd, pushfq, popfq
- Add test for aoj pushf


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added test cases

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #13908
...
