### PR TITLE
Echi bad color

### DIFF
--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -465,6 +465,11 @@ static int cmd_eval(void *data, const char *input) {
 					char *dup = r_str_newf ("bgonly %s", argv[0]);
 					color_code = r_cons_pal_parse (dup, NULL);
 					R_FREE (dup);
+					if (!color_code) {
+						eprintf ("Unknown color %s\n", argv[0]);
+						r_str_argv_free (argv);
+						return true;
+					}
 				}
 				break;
 			case 'w': // "ecHw"
@@ -477,14 +482,13 @@ static int cmd_eval(void *data, const char *input) {
 				if (argc > 1) {
 					char *dup = r_str_newf ("bgonly %s", argv[1]);
 					color_code = r_cons_pal_parse (dup, NULL);
+					R_FREE (dup);
 					if (!color_code) {
 						eprintf ("Unknown color %s\n", argv[1]);
 						r_str_argv_free (argv);
-						free (dup);
 						free (word);
 						return true;
 					}
-					R_FREE (dup);
 				}
 				break;
 			default:

--- a/test/new/db/cmd/cmd_ec
+++ b/test/new/db/cmd/cmd_ec
@@ -278,3 +278,13 @@ ec comment rgb:001296 . italic
 ec fname rgb:8d0004 . bold italic
 EOF
 RUN
+
+NAME=ecHi
+FILE=-
+CMDS=<<EOF
+ecHi xxxx
+EOF
+EXPECT_ERR=<<EOF
+Unknown color xxxx
+EOF
+RUN


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
PR is simply to output an error on invalid color selection with `ecHi`. It's the same thing `ecHw` does, but `ecHi` was not outputting it.

Also pulled the `free` up above the print since it was duplicated code that only really needed to be called once.

...

**Test plan**

Just type `ecHi blerg` and note that there's now an error about the color.

...

**Closing issues**

...
