### PR TITLE
Add Certificate Table parsing and Authentihash support for PE

### DIFF
--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -96,6 +96,7 @@ struct PE_(r_bin_pe_obj_t) {
 	PE_(image_tls_directory) * tls_directory;
 	Pe_image_resource_directory* resource_directory;
 	PE_(image_delay_import_directory) * delay_import_directory;
+	Pe_image_security_directory * security_directory;
 
 	// these pointers pertain to the .net relevant sections
 	PE_(image_clr_header) * clr_hdr;
@@ -127,6 +128,9 @@ struct PE_(r_bin_pe_obj_t) {
 	RBuffer* b;
 	Sdb *kv;
 	RCMS* cms;
+	SpcIndirectDataContent *spcinfo;
+	char *authentihash;
+	bool is_authhash_valid;
 	bool is_signed;
 };
 
@@ -158,6 +162,8 @@ struct PE_(r_bin_pe_obj_t)* PE_(r_bin_pe_new_buf)(RBuffer* buf, bool verbose);
 int PE_(r_bin_pe_get_debug_data)(struct PE_(r_bin_pe_obj_t)* bin, struct SDebugInfo* res);
 int PE_(bin_pe_get_claimed_checksum)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin);
+const char* PE_(bin_pe_get_authentihash)(struct PE_(r_bin_pe_obj_t)* bin);
+int PE_(bin_pe_is_authhash_valid)(struct PE_(r_bin_pe_obj_t)* bin);
 int PE_(bin_pe_get_overlay)(struct PE_(r_bin_pe_obj_t)* bin, ut64* size);
 void PE_(r_bin_pe_check_sections)(struct PE_(r_bin_pe_obj_t)* bin, struct r_bin_pe_section_t** sects);
 struct r_bin_pe_addr_t *PE_(check_unknow) (struct PE_(r_bin_pe_obj_t) *bin);

--- a/libr/bin/format/pe/pe_specs.h
+++ b/libr/bin/format/pe/pe_specs.h
@@ -443,6 +443,26 @@ typedef struct {
 } Pe32_image_tls_directory, Pe64_image_tls_directory;
 
 typedef struct {
+	ut32 dwLength;
+	ut16 wRevision;
+	ut16 wCertificateType;
+	ut8 *bCertificate;
+} Pe_certificate;
+
+typedef struct {
+	ut32 length;
+	Pe_certificate **certificates;
+} Pe_image_security_directory;
+
+#define PE_WIN_CERT_REVISION_1_0	0x0100
+#define PE_WIN_CERT_REVISION_2_0	0x0200
+
+#define PE_WIN_CERT_TYPE_X509			0x0001
+#define PE_WIN_CERT_TYPE_PKCS_SIGNED_DATA	0x0002
+#define PE_WIN_CERT_TYPE_RESERVED_1		0x0003
+#define PE_WIN_CERT_TYPE_TS_STACK_SIGNED	0x0004
+
+typedef struct {
 	ut32 Signature;
 	Pe32_image_file_header file_header;
 	Pe32_image_optional_header optional_header;

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -475,6 +475,16 @@ static RBinInfo* info(RBinFile *bf) {
 	ret->actual_checksum  = strdup (sdb_fmt ("0x%08x", actual_checksum));
 	ret->pe_overlay = pe_overlay > 0;
 	ret->signature = bin ? bin->is_signed : false;
+	ret->file_hashes = r_list_newf ((RListFree) r_bin_file_hash_free);
+	const char *authentihash = PE_(bin_pe_get_authentihash) (bf->o->bin_obj);
+	if (authentihash) {
+		RBinFileHash *authhash = R_NEW0 (RBinFileHash);
+		if (authhash) {
+			authhash->type = strdup ("authentihash");
+			authhash->hex = strdup (authentihash);
+			r_list_push (ret->file_hashes, authhash);
+		}
+	}
 	Sdb *db = sdb_ns (bf->sdb, "pe", true);
 	sdb_bool_set (db, "canary", has_canary (bf), 0);
 	sdb_bool_set (db, "highva", haschr (bf, IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA), 0);
@@ -491,6 +501,8 @@ static RBinInfo* info(RBinFile *bf) {
 	sdb_num_set (db, "bits", ret->bits, 0);
 	sdb_set (db, "claimed_checksum", ret->claimed_checksum, 0);
 	sdb_set (db, "actual_checksum", ret->actual_checksum, 0);
+	sdb_set (db, "authentihash", PE_(bin_pe_get_authentihash) (bf->o->bin_obj), 0);
+	sdb_bool_set (db, "is_authhash_valid", PE_(bin_pe_is_authhash_valid) (bf->o->bin_obj), 0);
 
 	ret->has_va = true;
 

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -762,7 +762,7 @@ R_API bool r_bin_file_set_cur_by_id(RBin *bin, ut32 bin_id);
 R_API bool r_bin_file_set_cur_by_name(RBin *bin, const char *name);
 R_API ut64 r_bin_file_delete_all(RBin *bin);
 R_API bool r_bin_file_delete(RBin *bin, ut32 bin_id);
-R_API bool r_bin_file_hash(RBin *bin, ut64 limit, const char *file, RList/*<RBinFileHash>*/ **old_file_hashes);
+R_API RList *r_bin_file_hash(RBin *bin, ut64 limit);
 R_API RBinPlugin *r_bin_file_cur_plugin(RBinFile *binfile);
 R_API void r_bin_file_hash_free(RBinFileHash *fhash);
 

--- a/libr/include/r_util/r_pkcs7.h
+++ b/libr/include/r_util/r_pkcs7.h
@@ -69,10 +69,27 @@ typedef struct r_pkcs7_container_t {
 	RPKCS7SignedData signedData;
 } RCMS;
 
+typedef struct {
+	RASN1String *type; //OID
+	RASN1Binary *data; // optional.
+} SpcAttributeTypeAndOptionalValue;
+
+typedef struct {
+	RX509AlgorithmIdentifier digestAlgorithm;
+	RASN1Binary *digest;
+} SpcDigestInfo;
+
+typedef struct {
+	SpcAttributeTypeAndOptionalValue data;
+	SpcDigestInfo messageDigest;
+} SpcIndirectDataContent;
+
 R_API RCMS *r_pkcs7_parse_cms(const ut8 *buffer, ut32 length);
 R_API void r_pkcs7_free_cms(RCMS* container);
 R_API char *r_pkcs7_cms_to_string(RCMS* container);
 R_API PJ *r_pkcs7_cms_json(RCMS* container);
+R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms);
+R_API void r_pkcs7_free_spcinfo(SpcIndirectDataContent *spcinfo);
 
 #ifdef __cplusplus
 }

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1221,8 +1221,15 @@ R_API int r_main_radare2(int argc, char **argv) {
 			if (compute_hashes && iod) {
 				// TODO: recall with limit=0 ?
 				ut64 limit = r_config_get_i (r->config, "bin.hashlimit");
-				(void)r_bin_file_hash (r->bin, limit, iod->name, NULL);
-				//eprintf ("WARNING: File hash not calculated\n");
+				RList *file_hashes = r_bin_file_hash (r->bin, limit);
+				if (file_hashes) {
+					if (r->bin->cur->o->info->file_hashes) {
+						r_list_join (r->bin->cur->o->info->file_hashes, file_hashes);
+						free (file_hashes);
+					} else {
+						r->bin->cur->o->info->file_hashes = file_hashes;
+					}
+				}
 			}
 			npath = r_config_get (r->config, "file.path");
 			if (!quiet && path && *path && npath && strcmp (path, npath)) {

--- a/test/new/db/formats/pe/authentihash
+++ b/test/new/db/formats/pe/authentihash
@@ -1,0 +1,33 @@
+NAME=check invalid authentihash
+FILE=../bins/pe/signature.exe
+EXPECT=<<EOF
+false
+authentihash c31534a14726a96a54602c3cb9eaa916412223d5
+md5 23ea4cc8f6e59aa5121bdeb3394150ae
+sha1 e2462a381cc60582efcf4dab129f4f08ff396bec
+sha256 327ef49480f2fd20bb5f46f7f384ea1ae6ab405a16b17fc575a5e4598a42b570
+{"authentihash":"c31534a14726a96a54602c3cb9eaa916412223d5","md5":"23ea4cc8f6e59aa5121bdeb3394150ae","sha1":"e2462a381cc60582efcf4dab129f4f08ff396bec","sha256":"327ef49480f2fd20bb5f46f7f384ea1ae6ab405a16b17fc575a5e4598a42b570"}
+EOF
+CMDS=<<EOF
+k bin/cur/pe/is_authhash_valid
+it
+itj
+EOF
+RUN
+
+NAME=check valid authentihash
+FILE=../bins/pe/authentihash.exe
+EXPECT=<<EOF
+true
+authentihash 2f425cda5b8d590f868a2f0cdbdae4d8c9d31bf7
+md5 dbd0a3bf85cc041794480df9a8dd34a8
+sha1 ae34b7b949997d6c65a1549cf234c53a7184a262
+sha256 ea4b1a9b05b70c00e56d1939c3037d5aa07117ff871f01caa84f049f9766ae9e
+{"authentihash":"2f425cda5b8d590f868a2f0cdbdae4d8c9d31bf7","md5":"dbd0a3bf85cc041794480df9a8dd34a8","sha1":"ae34b7b949997d6c65a1549cf234c53a7184a262","sha256":"ea4b1a9b05b70c00e56d1939c3037d5aa07117ff871f01caa84f049f9766ae9e"}
+EOF
+CMDS=<<EOF
+k bin/cur/pe/is_authhash_valid
+it
+itj
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
Add Authentihash and Authentihash check support for Portable Executable. Currently, the Authentihash information are stored in the `pe` sdb.

**Missing steps**
- [x] A signed binary with valid Authentihash to test true case. There seems to be only `signature.exe` in testbins which has an invalid Authentihash.
- [x] Include Authentihash in `it` output (?)

Imo, Authentihash information should be displayed at somewhere specific to the file format. For now, `it` seems to generate general hashes (md5, sha1, sha256). Adding Authentihash into the command will complicate the code (checking if `rclass == pe`, get authentihash with `sdb_querys`, output directly) while the existing code is using a `RList` of `RBinHash`, which makes me wonder if there is a cleaner way to do this. For Authentihash check, I thought about adding it into `RBinInfo`, but that makes the structure less general, so I am looking forward to some feedbacks.

**Closing issues**
#921 
