### PR TITLE
Fix compilation warnings

### DIFF
--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -115,16 +115,16 @@ R_API const char *r_anal_cc_arg(RAnal *anal, const char *convention, int n) {
 
 R_API const char *r_anal_cc_self(RAnal *anal, const char *convention) {
 	r_return_val_if_fail (anal && convention, NULL);
-	char *query = sdb_fmt ("cc.%s.self", convention);
-	char *ret = sdb_const_get (DB, query, 0);
-	return ret? r_str_constpool_get (&anal->constpool, ret): NULL;
+	const char *query = sdb_fmt ("cc.%s.self", convention);
+	const char *self = sdb_const_get (DB, query, 0);
+	return self? r_str_constpool_get (&anal->constpool, self): NULL;
 }
 
 R_API const char *r_anal_cc_error(RAnal *anal, const char *convention) {
 	r_return_val_if_fail (anal && convention, NULL);
-	char *query = sdb_fmt ("cc.%s.error", convention);
-	char *ret = sdb_const_get (DB, query, 0);
-	return ret? r_str_constpool_get (&anal->constpool, ret): NULL;
+	const char *query = sdb_fmt ("cc.%s.error", convention);
+	const char *error = sdb_const_get (DB, query, 0);
+	return error? r_str_constpool_get (&anal->constpool, error): NULL;
 }
 
 R_API int r_anal_cc_max_arg(RAnal *anal, const char *cc) {

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -730,7 +730,7 @@ beach:
 static bool is_reg_in_src (const char *regname, RAnal *anal, RAnalOp *op);
 
 static bool is_used_like_arg(const char *regname, const char *opsreg, const char *opdreg, RAnalOp *op, RAnal *anal) {
-	#define STR_EQUAL(s1, s2) s1 && s2 && !strcmp (s1, s2)
+	#define STR_EQUAL(s1, s2) (s1 && s2 && !strcmp (s1, s2))
 	RAnalValue *dst = op->dst;
 	RAnalValue *src = op->src[0];
 	switch (op->type) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
Fix compilation warnings introduced by me in my previous pull request for Swift calling convention:

```
var.c: In function ‘r_anal_extract_rarg’:                                                                        
var.c:733:37: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  #define STR_EQUAL(s1, s2) s1 && s2 && !strcmp (s1, s2)
                                     ^
var.c:837:46: note: in expansion of macro ‘STR_EQUAL’                                                            
     if (is_reg_in_src (regname, anal, op) || STR_EQUAL (opdreg, regname)) {
                                              ^~~~~~~~~
var.c:733:37: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]                                                    #define STR_EQUAL(s1, s2) s1 && s2 && !strcmp (s1, s2)                                                                                                                 ^                                                                                             
var.c:842:45: note: in expansion of macro ‘STR_EQUAL’                                                                                   if (is_reg_in_src (regname, anal, op) || STR_EQUAL (regname, opdreg)) {
                                             ^~~~~~~~~
var.c:733:37: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
  #define STR_EQUAL(s1, s2) s1 && s2 && !strcmp (s1, s2)
                                     ^
var.c:868:45: note: in expansion of macro ‘STR_EQUAL’
    if (is_reg_in_src (selfreg, anal, op) || STR_EQUAL (opdreg, selfreg)) {
                                             ^~~~~~~~~
-----------------------------------------------------------------------------
cc.c: In function ‘r_anal_cc_self’:
cc.c:119:14: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  char *ret = sdb_const_get (DB, query, 0);
              ^~~~~~~~~~~~~
cc.c: In function ‘r_anal_cc_error’:
cc.c:126:14: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  char *ret = sdb_const_get (DB, query, 0);
              ^~~~~~~~~~~~~
```
