### PR TITLE
Making install call not dir dependent

### DIFF
--- a/sys/sanitize.sh
+++ b/sys/sanitize.sh
@@ -3,6 +3,8 @@
 # SANITIZE="address signed-integer-overflow"  # Faster build
 SANITIZE=${SANITIZE:="address undefined signed-integer-overflow"}
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 printf "\033[32m"
 echo "========================================================================="
 printf "\033[33m"
@@ -48,4 +50,4 @@ if [ "$1" = "-u" ]; then
 	shift
 	SCRIPT=user.sh
 fi
-exec sys/${SCRIPT} $*
+exec ${DIR}/${SCRIPT} $*


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**
When I attempted to build sanitize version previously I got an error about not finding sys/install.sh. Looks like there's an assumption that sanitize is called from the root dir. I've removed this assumption so it can be called from anywhere.

**Test plan**
```bash
cd sys
./sanitize.sh # This should work
```

**Closing issues**
