### PR TITLE
Implement function names with dots in signatures ##anal

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3312,6 +3312,11 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 						}
 					}
 					fcnname = strdup (fcnname_aux + last_space);
+
+					// Replace dots in function name with underscores
+					for (i = last_space; i < strlen (fcnname) + last_space; i++) {
+						fcnstr[i] = (fcnstr[i] == '.') ? '_' : fcnstr[i];
+					}
 					if (fcnname) {
 						// TODO: move this into r_anal_str_to_fcn()
 						if (strcmp (fcn->name, fcnname)) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3312,11 +3312,6 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 						}
 					}
 					fcnname = strdup (fcnname_aux + last_space);
-
-					// Replace dots in function name with underscores
-					for (i = last_space; i < strlen (fcnname) + last_space; i++) {
-						fcnstr[i] = (fcnstr[i] == '.') ? '_' : fcnstr[i];
-					}
 					if (fcnname) {
 						// TODO: move this into r_anal_str_to_fcn()
 						if (strcmp (fcn->name, fcnname)) {

--- a/shlr/tcc/tcc.h
+++ b/shlr/tcc/tcc.h
@@ -814,6 +814,11 @@ static inline int isnum(int c)
     return c >= '0' && c <= '9';
 }
 
+static inline int isdot(int c)
+{
+	return c == '.';
+}
+
 static inline int isoct(int c)
 {
     return c >= '0' && c <= '7';

--- a/shlr/tcc/tccpp.c
+++ b/shlr/tcc/tccpp.c
@@ -59,7 +59,7 @@ static int unget_saved_buffer[TOK_MAX_SIZE + 1];
 static int unget_buffer_enabled;
 static TokenSym *hash_ident[TOK_HASH_SIZE];
 static char token_buf[STRING_MAX_SIZE + 1];
-/* true if isid(c) || isnum(c) */
+/* true if isid(c) || isnum(c) || isdot(c) */
 static unsigned char isidnum_table[256 - CH_EOF];
 
 static const char tcc_keywords[] =
@@ -2353,7 +2353,7 @@ maybe_newline:
 	case 'Q': case 'R': case 'S': case 'T':
 	case 'U': case 'V': case 'W': case 'X':
 	case 'Y': case 'Z':
-	case '_':
+	case '_': case '.':
 parse_ident_fast:
 		p1 = p;
 		h = TOK_HASH_INIT;
@@ -2361,10 +2361,21 @@ parse_ident_fast:
 		p++;
 		for (;;) {
 			c = *p;
-			if (!isidnum_table[c - CH_EOF]) {
+			if (!isidnum_table[*p - CH_EOF]) {
 				break;
 			}
-			h = TOK_HASH_FUNC (h, c);
+			// dot handling here too
+			if (isdot (c)) {
+				PEEKC (c, p);
+				if (isnum (c)) {
+					cstr_reset (&tokcstr);
+					cstr_ccat (&tokcstr, '.');
+					goto parse_num;
+				} else if (isdot (c)) {
+					goto parse_dots;
+				}
+			}
+			h = TOK_HASH_FUNC (h, *p);
 			p++;
 		}
 		if (c != '\\') {
@@ -2437,7 +2448,7 @@ parse_num:
 			t = c;
 			cstr_ccat (&tokcstr, c);
 			PEEKC (c, p);
-			if (!(isnum (c) || isid (c) || c == '.' ||
+			if (!(isnum (c) || isid (c) || isdot (c) ||
 			      ((c == '+' || c == '-') &&
 			       (t == 'e' || t == 'E' || t == 'p' || t == 'P')))) {
 				break;
@@ -2448,24 +2459,14 @@ parse_num:
 		tokc.cstr = &tokcstr;
 		tok = TOK_PPNUM;
 		break;
-	case '.':
 		/* special dot handling because it can also start a number */
-		PEEKC (c, p);
-		if (isnum (c)) {
-			cstr_reset (&tokcstr);
-			cstr_ccat (&tokcstr, '.');
-			goto parse_num;
-		} else if (c == '.') {
-			PEEKC (c, p);
-			if (c != '.') {
-				expect ("'.'");
-				return;
-			}
-			PEEKC (c, p);
-			tok = TOK_DOTS;
-		} else {
-			tok = '.';
+parse_dots:
+		if (!isdot (c)) {
+			expect ("'.'");
+			return;
 		}
+		PEEKC (c, p);
+		tok = TOK_DOTS;
 		break;
 	case '\'':
 	case '\"':
@@ -3256,7 +3257,7 @@ ST_FUNC void preprocess_new(void)
 
 	/* init isid table */
 	for (i = CH_EOF; i < 256; i++) {
-		isidnum_table[i - CH_EOF] = isid (i) || isnum (i);
+		isidnum_table[i - CH_EOF] = isid (i) || isnum (i) || isdot (i);
 	}
 
 	/* add all tokens */

--- a/test/new/db/cmd/types
+++ b/test/new/db/cmd/types
@@ -1482,6 +1482,23 @@ char type (int32_t a, char **b);
 EOF
 RUN
 
+NAME=afs fcnname with dots
+FILE=../bins/elf/hello_world
+CMDS=<<EOF
+af
+afs
+"afs foo.bar();"
+afs
+"afs char foo.bar(int a, ...);"
+afs
+EOF
+EXPECT=<<EOF
+entry0 (int64_t arg3);
+foo.bar (int64_t arg3);
+foo.bar (int64_t arg3);
+EOF
+RUN
+
 NAME=td crash
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**

- [x] I've read the guidelines for contributing to this repository
- [x] I made sure to follow the project's coding style
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the radare2 book with the relevant information (if needed)

**Detailed description**

Merging this Pull Request would allow setting function names containing dots in function signatures.

Current state of this PR is:
- [x] User can set function signatures with dots in the function name using `afs`.
- [ ] Signatures with dots in function name are stored properly in the anal/types SDB.
The current issue (addressed by the second milestone) now is that functions with dots don't get the function type and arguments correctly.

~~In order to fix this, we might need some kind of structure that annotates where the dots were replaced by underscores in the function name, so it can find the proper keys in SDB when querying it.~~. 

Fix functions not getting right arguments in a **new** issue and PR.

**Test plan**
Include a test that asserts if adding dots in the function name of a signature works as intended.

**Closing issues**
Closes https://github.com/radareorg/radare2/issues/15954