### PR TITLE
r2r.v: Fix EXPECT_ERR handling

### DIFF
--- a/test/new/db/cmd/cmd_pd
+++ b/test/new/db/cmd/cmd_pd
@@ -1070,7 +1070,6 @@ EOF
 RUN
 
 NAME=bin.str.enc error handling
-BROKEN=1 # Unbreak this and r2r.v goes XX
 FILE=-
 CMDS=<<EOF
 (test_str.enc enc, e bin.str.enc=$0, e bin.str.enc)

--- a/test/new/db/tools/r2r
+++ b/test/new/db/tools/r2r
@@ -1,5 +1,4 @@
 NAME=Only EXPECT_ERR<<EOF
-BROKEN=1 # Unbreak this and r2r.v goes XX
 FILE=-
 CMDS=<<EOF
 pf?cat_sat_on_keyboard
@@ -12,7 +11,6 @@ EOF
 RUN
 
 NAME=EXPECT<<EOF empty and EXPECT_ERR<<EOF non-empty
-BROKEN=1 # Unbreak this and r2r.v goes XX
 FILE=-
 CMDS=<<EOF
 pf?cat_sat_on_keyboard

--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -551,11 +551,11 @@ fn (r2r mut R2R) run_cmd_test(test R2RCmdTest) {
 		mark = r2r.test_failed(test, test_expect, res)
 	}
 	else {
-		if test.broken {
-			mark = r2r.test_fixed(test)
-		}
-		else if test.expect_err != '' && errstr.trim_space() != test.expect_err {
+		if test.expect_err != '' && errstr.trim_space() != test.expect_err {
 			mark = r2r.test_failed(test, test.expect_err, errstr)
+		}
+		else if test.broken {
+			mark = r2r.test_fixed(test)
 		}
 		else {
 			r2r.success++

--- a/test/src/r2r.v
+++ b/test/src/r2r.v
@@ -551,7 +551,7 @@ fn (r2r mut R2R) run_cmd_test(test R2RCmdTest) {
 		mark = r2r.test_failed(test, test_expect, res)
 	}
 	else {
-		if test.expect_err != '' && errstr.trim_space() != test.expect_err {
+		if test.expect_err != '' && errstr.trim_space() != test.expect_err.trim_space() {
 			mark = r2r.test_failed(test, test.expect_err, errstr)
 		}
 		else if test.broken {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

1. Broken only-on-EXPECT_ERR tests are now marked BR instead of FX.
1. Both EXPECT_ERR and stderr are space-trimmed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

r2r.v is OK on all tools/r2r and cmd/cmd_pd tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

See description.
