### PR TITLE
Fix ELF symbols for names just before the end of strtab ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3528,9 +3528,9 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 					}
 				}
 				ret[ret_ctr].size = tsize;
-				if (sym[k].st_name + 2 > strtab_section->sh_size) {
+				if (sym[k].st_name + 1 > strtab_section->sh_size) {
 					bprintf ("index out of strtab range\n");
-					goto beach;
+					continue;
 				}
 				{
 					int rest = ELF_STRING_LENGTH - 1;

--- a/test/new/db/formats/elf/symbols
+++ b/test/new/db/formats/elf/symbols
@@ -202,3 +202,11 @@ CMDS=<<EOF
 pd 5 @ 0x464
 EOF
 RUN
+
+NAME=symname just before end of dynstr section of size 1
+FILE=../bins/elf/switch-hello-world.elf
+EXPECT='1732'
+CMDS=<<EOF
+isq~?
+EOF
+RUN


### PR DESCRIPTION
**Detailed description**

This bin (`elf/switch-hello-world.elf` in testbins) has a `.dynstr` section of size 1 with only one zero byte and a symbol in `.dynsym` whose name refers to `.dynstr + 0`.
The `sym[k].st_name + 2 > strtab_section->sh_size` check (I assume +2 meant 1 readable char + 1 null byte, but why not allow empty strings with just the null byte?) would reject this and break out of the entire symbol loading loop, so no symbols would be loaded.

**Test plan**

`r2 -c "is" elf/switch-hello-world.elf`
Before: no symbols, after: symbols \0/
