### PR TITLE
Add repeat_command, concatenation and fix system_command

### DIFF
--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -34,7 +34,7 @@ TS_TIP=aef62b4bc6b9654e54bd59bee1cb8cea16e3aa96
 # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/meson.build
 SHELLPARSER_URL=https://github.com/ret2libc/radare2-shell-parser.git
 SHELLPARSER_BRA=master
-SHELLPARSER_TIP=8adfc39331d99b369be869d85a2fbb624fe75d75
+SHELLPARSER_TIP=4bc342424550e02879722716a65a4c0d46344845
 
 ifeq ($(CS_RELEASE),1)
 CS_VER=4.0.1

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -295,7 +295,7 @@ if get_option('use_treesitter')
     endif
 
     # NOTE: when you update SHELLPARSER_TIP or SHELLPARSER_BRA, also update them in shlr/Makefile
-    SHELLPARSER_TIP = '8adfc39331d99b369be869d85a2fbb624fe75d75'
+    SHELLPARSER_TIP = '4bc342424550e02879722716a65a4c0d46344845'
     SHELLPARSER_BRA = 'master'
     shell_parser_user = 'ret2libc'
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR adds support for the repeat_command (e.g. `2pd 10`) and it adds support for the "concatenation" rule defined in updated radare2-shell-parser, which is a single argument without any space, but that may be composed of quoted parts, command substitution, and other identifiers (e.g. in `?e 100$(?e 123)`, `100$(?e 123)` is a concatenation, because it is composed by a arg_identifier part (the first part) and a cmd_substitution_arg (the second part)). It also fixes issues when handling system_commands (e.g. `!rahash2 ....`), where arguments were not correctly split.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Still work in progress, but the number of tests in the travis job should decrease.

To test, as usual, you can compile with `meson -Duse_treesitter=true build; ninja -C build; ./build/binr/radare2/radare2 -ecfg.newshell=true /bin/ls`.

Now commands like `3pd 3` or `?e Hello"Wor$(?e ld)"', This is 'me$(?e Riccardo)` should work.