### PR TITLE
Fix Spaces Interference in r_flag_get_at()

### DIFF
--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -600,13 +600,14 @@ static bool isFunctionFlag(const char *n) {
 R_API RFlagItem *r_flag_get_at(RFlag *f, ut64 off, bool closest) {
 	r_return_val_if_fail (f, NULL);
 
-	RFlagItem *item, *nice = NULL;
+	RFlagItem *nice = NULL;
 	RListIter *iter;
 	const RFlagsAtOffset *flags_at = r_flag_get_nearest_list (f, off, -1);
 	if (!flags_at) {
 		return NULL;
 	}
 	if (flags_at->off == off) {
+		RFlagItem *item;
 		r_list_foreach (flags_at->flags, iter, item) {
 			if (IS_FI_NOTIN_SPACE (f, item)) {
 				continue;
@@ -619,13 +620,16 @@ R_API RFlagItem *r_flag_get_at(RFlag *f, ut64 off, bool closest) {
 				nice = item;
 			}
 		}
-		return nice;
+		if (nice) {
+			return evalFlag (f, nice);
+		}
 	}
 
 	if (!closest) {
 		return NULL;
 	}
 	while (!nice && flags_at) {
+		RFlagItem *item;
 		r_list_foreach (flags_at->flags, iter, item) {
 			if (IS_FI_NOTIN_SPACE (f, item)) {
 				continue;
@@ -637,7 +641,7 @@ R_API RFlagItem *r_flag_get_at(RFlag *f, ut64 off, bool closest) {
 			nice = item;
 			break;
 		}
-		if (flags_at->off) {
+		if (!nice && flags_at->off) {
 			flags_at = r_flag_get_nearest_list (f, flags_at->off - 1, -1);
 		} else {
 			flags_at = NULL;

--- a/test/unit/test_flags.c
+++ b/test/unit/test_flags.c
@@ -58,9 +58,79 @@ bool test_r_flag_by_spaces(void) {
 	mu_end;
 }
 
+bool test_r_flag_get_at() {
+	RFlag *flag = r_flag_new ();
+
+	r_flag_space_set (flag, "sp1");
+	RFlagItem *foo = r_flag_set (flag, "foo", 1024, 0);
+
+	RFlagItem *fi;
+	fi = r_flag_get_at (flag, 1024, false);
+	mu_assert_ptreq (fi, foo, "flag at exact");
+	fi = r_flag_get_at (flag, 1023, false);
+	mu_assert_null (fi, "no flag at -1");
+	fi = r_flag_get_at (flag, 1025, false);
+	mu_assert_null (fi, "no flag at +1");
+
+	fi = r_flag_get_at (flag, 1024, true);
+	mu_assert_ptreq (fi, foo, "flag at exact");
+	fi = r_flag_get_at (flag, 1023, true);
+	mu_assert_null (fi, "no flag at -1");
+	fi = r_flag_get_at (flag, 1025, true);
+	mu_assert_ptreq (fi, foo, "flag at +1");
+	fi = r_flag_get_at (flag, 1234, true);
+	mu_assert_ptreq (fi, foo, "flag at +more");
+
+	r_flag_space_set (flag, "sp2");
+
+	fi = r_flag_get_at (flag, 1024, false);
+	mu_assert_null (fi, "space mask");
+	fi = r_flag_get_at (flag, 1023, false);
+	mu_assert_null (fi, "space mask");
+	fi = r_flag_get_at (flag, 1025, false);
+	mu_assert_null (fi, "space mask");
+
+	fi = r_flag_get_at (flag, 1024, true);
+	mu_assert_null (fi, "space mask");
+	fi = r_flag_get_at (flag, 1023, true);
+	mu_assert_null (fi, "space mask");
+	fi = r_flag_get_at (flag, 1025, true);
+	mu_assert_null (fi, "space mask");
+	fi = r_flag_get_at (flag, 1234, true);
+	mu_assert_null (fi, "space mask");
+
+	RFlagItem *oof = r_flag_set (flag, "oof", 1234, 0);
+
+	fi = r_flag_get_at (flag, 1234, false);
+	mu_assert_ptreq (fi, oof, "other space");
+
+	r_flag_space_set (flag, "sp1");
+
+	fi = r_flag_get_at (flag, 1024, false);
+	mu_assert_ptreq (fi, foo, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 1023, false);
+	mu_assert_null (fi, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 1025, false);
+	mu_assert_null (fi, "non-interference of spaces");
+
+	fi = r_flag_get_at (flag, 1024, true);
+	mu_assert_ptreq (fi, foo, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 1023, true);
+	mu_assert_null (fi, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 1025, true);
+	mu_assert_ptreq (fi, foo, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 1234, true);
+	mu_assert_ptreq (fi, foo, "non-interference of spaces");
+	fi = r_flag_get_at (flag, 2048, true);
+	mu_assert_ptreq (fi, foo, "non-interference of spaces");
+
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_r_flag_get_set);
 	mu_run_test (test_r_flag_by_spaces);
+	mu_run_test (test_r_flag_get_at);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
**Detailed description**

This fixes a case where `r_flag_get_at()`/`fd` would return NULL/print nothing when there was a flag in a non-selected flagspace at exactly the query addr.

**Test plan**

```r2 -Qc "fs x; f test.x @ 0x42; fs y; f test.y @ 0x0; fd @ 0x42" -```
Before: nothing
After: `test.y + 66`
