### PR TITLE
Support real names in "fd" command

### DIFF
--- a/test/new/db/cmd/cmd_flags
+++ b/test/new/db/cmd/cmd_flags
@@ -305,6 +305,24 @@ fd. 0x5
 EOF
 RUN
 
+NAME=fd with realname
+FILE=malloc://1024
+EXPECT='pingas
+pingas + 4853
+Snooping as usual I see...
+Snooping as usual I see... + 4853'
+CMDS=<<EOF
+f pingas @ 0x42
+fN pingas Snooping as usual I see...
+e asm.flags.real=0
+fd @ 0x42
+fd @ 0x1337
+e asm.flags.real=1
+fd @ 0x42
+fd @ 0x1337
+EOF
+RUN
+
 NAME=fC
 FILE=malloc://1024
 EXPECT=<<EOF

--- a/test/new/db/json/json2
+++ b/test/new/db/json/json2
@@ -23,6 +23,8 @@ ecj
 ecoj
 ej
 fj
+fdj
+fd.j
 fsj
 iaj
 iAj


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](../DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](../DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](../../radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pull reuqests adds support for realname in the different `fd` subcommands. Now, if `asm.flags.real` is enabled, `fd` and `fd.` will show the flag's realname. In addition, `fdj` and `fd.j` are now showing `realname` if available.

In addition, this PR ports the json printing to the `pj` object.


**Test plan**

1. Open a binary and seek to an address with realname.
2. Use `fd` and see the flag is printed
3. Run `fdj` and see a list of all flags, including the relanme of each
4. Run `fd.j` and see that it works and shows the realname in addition to name
5. Enable `asm.flags.real`
6. Run `fd` and `fd.` and see that realname is displayed.


**Closing issues**

closes #16026 
