### PR TITLE
Fix segfault in Authenticode hash check (#16042)

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -2857,8 +2857,14 @@ static int bin_pe_init_security(struct PE_(r_bin_pe_obj_t) * bin) {
 	if (bin->cms && bin->spcinfo) {
 		const char *actual_authentihash = PE_(bin_pe_compute_authentihash) (bin);
 		const char *claimed_authentihash = PE_(bin_pe_get_claimed_authentihash) (bin);
-		bin->is_authhash_valid = !strcmp (actual_authentihash, claimed_authentihash);
-		free ((void *)actual_authentihash);
+		if (actual_authentihash && claimed_authentihash) {
+			bin->is_authhash_valid = !strcmp (actual_authentihash, claimed_authentihash);
+		} else {
+			bin->is_authhash_valid = NULL;
+		}
+		if (actual_authentihash) {
+			free ((void *)actual_authentihash);
+		}
 		free ((void *)claimed_authentihash);
 	}
 	bin->is_signed = bin->cms != NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
First off, I apologize for no tests atm. I can add later but it will take more time than the patch.

I noticed that `r2` will crash when loading a PE file with
Authenticode digest algorithm other than SHA-1 or MD5. I traced
it down to the `PE_(bin_pe_compute_authentihash)` function returning
`NULL` if it encounters an unsupported digest function. This results
in `NULL` being passed to `strcmp` which causes the segfault.

Solution was to add a check for `PE_(bin_pe_compute_authentihash)`
returning `NULL` and to set `bin->is_authhash_valid` to `NULL`.
The real solution is to add support for more algorithms but this will
stop crashes for now.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Find a PE file with an Authenticode digest format other than SHA-1/MD5 and open it.
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #16042 
