### PR TITLE
Fix r_table_sort if column type is NULL

### DIFF
--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -4,7 +4,7 @@
 #include "r_cons.h"
 
 // cant do that without globals because RList doesnt have void *user :(
-static bool Ginc = false;
+static bool Gdec = false;
 static int Gnth = 0;
 static RListComparator Gcmp = NULL;
 
@@ -552,20 +552,22 @@ static int cmp(const void *_a, const void *_b) {
 	const char *wa = r_list_get_n (a->items, Gnth);
 	const char *wb = r_list_get_n (b->items, Gnth);
 	int res = Gcmp (wa, wb);
-	if (Ginc) {
+	if (Gdec) {
 		res = -res;
 	}
 	return res;
 }
 
-R_API void r_table_sort(RTable *t, int nth, bool inc) {
+R_API void r_table_sort(RTable *t, int nth, bool dec) {
 	RTableColumn *col = r_list_get_n (t->cols, nth);
 	if (col) {
-		Ginc = inc;
+		Gdec = dec;
 		Gnth = nth;
-		Gcmp = col->type->cmp;
-		r_list_sort (t->rows, cmp);
-		Gnth = Ginc = 0;
+		if (col->type && col->type->cmp) {
+			Gcmp = col->type->cmp;
+			r_list_sort (t->rows, cmp);
+		}
+		Gnth = Gdec = 0;
 		Gcmp = NULL;
 	}
 }
@@ -576,20 +578,20 @@ static int cmplen(const void *_a, const void *_b) {
 	const char *wa = r_list_get_n (a->items, Gnth);
 	const char *wb = r_list_get_n (b->items, Gnth);
 	int res = strlen (wa) - strlen (wb);
-	if (Ginc) {
+	if (Gdec) {
 		res = -res;
 	}
 	return res;
 }
 
-R_API void r_table_sortlen(RTable *t, int nth, bool inc) {
+R_API void r_table_sortlen(RTable *t, int nth, bool dec) {
 	RTableColumn *col = r_list_get_n (t->cols, nth);
 	if (col) {
-		Ginc = inc;
+		Gdec = dec;
 		Gnth = nth;
 		Gcmp = cmplen;
 		r_list_sort (t->rows, Gcmp);
-		Gnth = Ginc = 0;
+		Gnth = Gdec = 0;
 		Gcmp = NULL;
 	}
 }

--- a/test/unit/test_table.c
+++ b/test/unit/test_table.c
@@ -30,6 +30,36 @@ bool test_r_table(void) {
 	mu_end;
 }
 
+RTable *__table_test_data1() {
+	RTable *t = r_table_new ();
+
+	r_table_add_column (t, r_table_type ("string"), "ascii", 0);
+	r_table_add_column (t, r_table_type ("number"), "code", 0);
+
+	r_table_add_row (t, "a", "97", NULL);
+	r_table_add_row (t, "b", "98", NULL);
+	r_table_add_row (t, "c", "99", NULL);
+
+	return t;
+}
+
+bool test_r_table_column_type(void) {
+	RTable *t = __table_test_data1 ();
+	RTableColumn *c = r_list_get_n (t->cols, 1);
+	c->type = r_table_type ("NUMBER");
+	r_table_sort (t, 1, true);
+	char *s = r_table_tostring (t);
+	mu_assert_streq (s,
+		"ascii code\n"
+		"----------\n"
+		"a     97\n"
+		"b     98\n"
+		"c     99\n", "not sorted by second column due to undefined type");
+	free (s);
+	r_table_free (t);
+	mu_end;
+}
+
 bool test_r_table_columns() {
 	RTable *t = NULL;
 #define CREATE_TABLE \
@@ -97,6 +127,7 @@ bool test_r_table_columns() {
 
 bool all_tests() {
 	mu_run_test(test_r_table);
+	mu_run_test(test_r_table_column_type);
 	mu_run_test(test_r_table_columns);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fix r_table_sort will seg fault if column type is NULL
* Do not sort if column type is NULL
* Rename argument to 'dec' (decreasing) to reflect existing output
* Add test

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

* r_table_sort does not seg fault if column type is NULL 

