### PR TITLE
Fix consecutive call to r_table_sort 

### DIFF
--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -4,7 +4,6 @@
 #include "r_cons.h"
 
 // cant do that without globals because RList doesnt have void *user :(
-static bool Gdec = false;
 static int Gnth = 0;
 static RListComparator Gcmp = NULL;
 
@@ -552,22 +551,22 @@ static int cmp(const void *_a, const void *_b) {
 	const char *wa = r_list_get_n (a->items, Gnth);
 	const char *wb = r_list_get_n (b->items, Gnth);
 	int res = Gcmp (wa, wb);
-	if (Gdec) {
-		res = -res;
-	}
 	return res;
 }
 
 R_API void r_table_sort(RTable *t, int nth, bool dec) {
 	RTableColumn *col = r_list_get_n (t->cols, nth);
 	if (col) {
-		Gdec = dec;
 		Gnth = nth;
 		if (col->type && col->type->cmp) {
 			Gcmp = col->type->cmp;
+			t->rows->sorted = false; //force sorting
 			r_list_sort (t->rows, cmp);
+			if (dec) {
+				r_list_reverse (t->rows);
+			}
 		}
-		Gnth = Gdec = 0;
+		Gnth = 0;
 		Gcmp = NULL;
 	}
 }
@@ -578,20 +577,20 @@ static int cmplen(const void *_a, const void *_b) {
 	const char *wa = r_list_get_n (a->items, Gnth);
 	const char *wb = r_list_get_n (b->items, Gnth);
 	int res = strlen (wa) - strlen (wb);
-	if (Gdec) {
-		res = -res;
-	}
 	return res;
 }
 
 R_API void r_table_sortlen(RTable *t, int nth, bool dec) {
 	RTableColumn *col = r_list_get_n (t->cols, nth);
 	if (col) {
-		Gdec = dec;
 		Gnth = nth;
 		Gcmp = cmplen;
+		t->rows->sorted = false; //force sorting
 		r_list_sort (t->rows, Gcmp);
-		Gnth = Gdec = 0;
+		if (dec) {
+			r_list_reverse (t->rows);
+		}
+		Gnth = 0;
 		Gcmp = NULL;
 	}
 }

--- a/test/unit/test_table.c
+++ b/test/unit/test_table.c
@@ -1,5 +1,6 @@
 #include <r_util.h>
 #include "minunit.h"
+#define BUF_LENGTH 100
 
 //TODO test r_str_chop_path
 
@@ -56,6 +57,51 @@ bool test_r_table_column_type(void) {
 		"b     98\n"
 		"c     99\n", "not sorted by second column due to undefined type");
 	free (s);
+	r_table_free (t);
+	mu_end;
+}
+
+bool test_r_table_tostring(void) {
+	RTable *t = __table_test_data1 ();
+	char buf[BUF_LENGTH];
+
+	for (int i = 0; i < 4; ++i) {
+		char *s = r_table_tostring (t);
+		snprintf (buf, BUF_LENGTH, "%d-th call to r_table_tostring", i);
+		mu_assert_streq (s,
+			"ascii code\n"
+			"----------\n"
+			"a     97\n"
+			"b     98\n"
+			"c     99\n", buf);
+		free (s);
+	}
+	r_table_free (t);
+	mu_end;
+}
+
+bool test_r_table_sort1(void) {
+	RTable *t = __table_test_data1 ();
+
+	r_table_sort (t, 1, true);
+	char *strd = r_table_tostring (t);
+	mu_assert_streq (strd,
+		"ascii code\n"
+		"----------\n"
+		"c     99\n"
+		"b     98\n"
+		"a     97\n", "sort decreasing second column using number type");
+	free (strd);
+
+	r_table_sort (t, 1, false);
+	char *stri = r_table_tostring (t);
+	mu_assert_streq (stri,
+		"ascii code\n"
+		"----------\n"
+		"a     97\n"
+		"b     98\n"
+		"c     99\n", "sort increasing second column using number type");
+	free (stri);
 	r_table_free (t);
 	mu_end;
 }
@@ -124,10 +170,11 @@ bool test_r_table_columns() {
 #undef CREATE_TABLE
 }
 
-
 bool all_tests() {
 	mu_run_test(test_r_table);
 	mu_run_test(test_r_table_column_type);
+	mu_run_test(test_r_table_tostring);
+	mu_run_test(test_r_table_sort1);
 	mu_run_test(test_r_table_columns);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

r_table sort will not sort after the first call
- Force sorting of rows in the event of consecutive sort
- Remove global Gdec and use r_list_reverse for sort in decreasing order

Add test for r_table_tostring and r_table_sort

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Sort the same column in a table in decreasing order and followed by increasing order 
