### PR TITLE
Fix address representation minbound maxbound in afij

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2838,8 +2838,8 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn, PJ *pj) {
 		}
 
 	}
-	pj_ki (pj, "minbound", r_anal_function_min_addr (fcn));
-	pj_ki (pj, "maxbound", r_anal_function_max_addr (fcn));
+	pj_kn (pj, "minbound", r_anal_function_min_addr (fcn));
+	pj_kn (pj, "maxbound", r_anal_function_max_addr (fcn));
 
 	int outdegree = 0;
 	refs = r_anal_fcn_get_refs (core->anal, fcn);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
`minbound` and `maxbound` fields should be unsigned integers in `afij`. So use `pj_kn` instead of `pj_ki` to print.