### PR TITLE
Minor Fixes and Tests for NSO/NRO

### DIFF
--- a/libr/bin/format/nxo/nxo.h
+++ b/libr/bin/format/nxo/nxo.h
@@ -63,9 +63,7 @@ typedef struct {
 	RList *classes_list;
 } RBinNXOObj;
 
-ut32 readLE32(RBuffer *buf, int off);
-ut64 readLE64(RBuffer *buf, int off);
-void parseMod (RBuffer *buf, RBinNXOObj *bin, ut32 mod0, ut64 baddr);
+void parseMod(RBuffer *buf, RBinNXOObj *bin, ut32 mod0, ut64 baddr);
 const char *fileType(const ut8 *buf);
 
 #endif

--- a/libr/bin/p/bin_nro.c
+++ b/libr/bin/p/bin_nro.c
@@ -27,7 +27,7 @@ typedef struct {
 } NROHeader;
 
 static ut64 baddr(RBinFile *bf) {
-	return bf? readLE32 (bf->buf, NRO_OFFSET_MODMEMOFF): 0;
+	return bf? r_buf_read_le32_at (bf->buf, NRO_OFFSET_MODMEMOFF): 0;
 }
 
 static bool check_buffer(RBuffer *b) {
@@ -46,7 +46,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 		bin->methods_list = r_list_newf ((RListFree)free);
 		bin->imports_list = r_list_newf ((RListFree)free);
 		bin->classes_list = r_list_newf ((RListFree)free);
-		ut32 mod0 = readLE32 (b, NRO_OFFSET_MODMEMOFF);
+		ut32 mod0 = r_buf_read_le32_at (b, NRO_OFFSET_MODMEMOFF);
 		parseMod (b, bin, mod0, ba);
 		*bin_obj = bin;
 	}
@@ -112,12 +112,12 @@ static RList *sections(RBinFile *bf) {
 
 	int bufsz = r_buf_size (bf->buf);
 
-	ut32 mod0 = readLE32 (bf->buf, NRO_OFFSET_MODMEMOFF);
+	ut32 mod0 = r_buf_read_le32_at (bf->buf, NRO_OFFSET_MODMEMOFF);
 	if (mod0 && mod0 + 8 < bufsz) {
 		if (!(ptr = R_NEW0 (RBinSection))) {
 			return ret;
 		}
-		ut32 mod0sz = readLE32 (bf->buf, mod0 + 4);
+		ut32 mod0sz = r_buf_read_le32_at (bf->buf, mod0 + 4);
 		ptr->name = strdup ("mod0");
 		ptr->size = mod0sz;
 		ptr->vsize = mod0sz;
@@ -130,12 +130,12 @@ static RList *sections(RBinFile *bf) {
 		eprintf ("Invalid MOD0 address\n");
 	}
 
-	ut32 sig0 = readLE32 (bf->buf, 0x18);
+	ut32 sig0 = r_buf_read_le32_at (bf->buf, 0x18);
 	if (sig0 && sig0 + 8 < bufsz) {
 		if (!(ptr = R_NEW0 (RBinSection))) {
 			return ret;
 		}
-		ut32 sig0sz = readLE32 (bf->buf, sig0 + 4);
+		ut32 sig0sz = r_buf_read_le32_at (bf->buf, sig0 + 4);
 		ptr->name = strdup ("sig0");
 		ptr->size = sig0sz;
 		ptr->vsize = sig0sz;
@@ -153,9 +153,9 @@ static RList *sections(RBinFile *bf) {
 		return ret;
 	}
 	ptr->name = strdup ("text");
-	ptr->vsize = readLE32 (b, NRO_OFF (text_size));
+	ptr->vsize = r_buf_read_le32_at (b, NRO_OFF (text_size));
 	ptr->size = ptr->vsize;
-	ptr->paddr = readLE32 (b, NRO_OFF (text_memoffset));
+	ptr->paddr = r_buf_read_le32_at (b, NRO_OFF (text_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
 	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
@@ -166,9 +166,9 @@ static RList *sections(RBinFile *bf) {
 		return ret;
 	}
 	ptr->name = strdup ("ro");
-	ptr->vsize = readLE32 (b, NRO_OFF (ro_size));
+	ptr->vsize = r_buf_read_le32_at (b, NRO_OFF (ro_size));
 	ptr->size = ptr->vsize;
-	ptr->paddr = readLE32 (b, NRO_OFF (ro_memoffset));
+	ptr->paddr = r_buf_read_le32_at (b, NRO_OFF (ro_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
 	ptr->perm = R_PERM_R; // r-x
 	ptr->add = true;
@@ -179,15 +179,15 @@ static RList *sections(RBinFile *bf) {
 		return ret;
 	}
 	ptr->name = strdup ("data");
-	ptr->vsize = readLE32 (b, NRO_OFF (data_size));
+	ptr->vsize = r_buf_read_le32_at (b, NRO_OFF (data_size));
 	ptr->size = ptr->vsize;
-	ptr->paddr = readLE32 (b, NRO_OFF (data_memoffset));
+	ptr->paddr = r_buf_read_le32_at (b, NRO_OFF (data_memoffset));
 	ptr->vaddr = ptr->paddr + ba;
 	ptr->perm = R_PERM_RW;
 	ptr->add = true;
 	eprintf ("Base Address 0x%08"PFMT64x "\n", ba);
 	eprintf ("BSS Size 0x%08"PFMT64x "\n", (ut64)
-			readLE32 (bf->buf, NRO_OFF (bss_size)));
+			r_buf_read_le32_at (bf->buf, NRO_OFF (bss_size)));
 	r_list_append (ret, ptr);
 	return ret;
 }

--- a/test/new/db/formats/nro
+++ b/test/new/db/formats/nro
@@ -1,9 +1,51 @@
-NAME=NRO: Open/iI
+NAME=nro detection
 FILE=../bins/nro/appstore.nro
 EXPECT=<<EOF
 1
 EOF
 CMDS=<<EOF
 iI~?switch
+EOF
+RUN
+
+
+NAME=nro sections
+ARGS=-e io.cache=true
+FILE=../bins/nro/appstore.nro
+EXPECT=<<EOF
+[Sections]
+
+nth paddr           size vaddr          vsize perm name
+-------------------------------------------------------
+0   0x00000000      0x80 0x00000000      0x80 -r-- header
+1   0x0021d000       0x0 0x0021d000       0x0 -r-- sig0
+2   0x00000000  0x1b4000 0x00000000  0x1b4000 -r-x text
+3   0x001b4000   0x5a000 0x001b4000   0x5a000 -r-- ro
+4   0x0020e000    0xf000 0x0020e000    0xf000 -rw- data
+
+EOF
+CMDS=<<EOF
+iS
+EOF
+RUN
+
+NAME=nro entry
+ARGS=-e io.cache=true
+FILE=../bins/nro/appstore.nro
+EXPECT='[Entrypoints]
+vaddr=0x00000080 paddr=0x00000080 haddr=-1 type=program
+
+1 entrypoints'
+CMDS=<<EOF
+ie
+EOF
+RUN
+
+NAME=nro data
+ARGS=-e io.cache=true
+FILE=../bins/nro/appstore.nro
+EXPECT='fb031eaa01000094dc2302d1f90300aafa0301aae0100090c11100d00000199121e02191210000cb211c009121f07d92'
+CMDS=<<EOF
+p8 0x30 @ 0x80
 EOF
 RUN

--- a/test/new/db/formats/nso
+++ b/test/new/db/formats/nso
@@ -1,4 +1,4 @@
-NAME=NSO: Open/iI
+NAME=nso detection
 ARGS=-e io.cache=true
 FILE=../bins/nso/application.nso
 EXPECT=<<EOF
@@ -6,5 +6,45 @@ EXPECT=<<EOF
 EOF
 CMDS=<<EOF
 iI~?switch
+EOF
+RUN
+
+NAME=nso sections
+ARGS=-e io.cache=true
+FILE=../bins/nso/application.nso
+EXPECT=<<EOF
+[Sections]
+
+nth paddr          size vaddr         vsize perm name
+-----------------------------------------------------
+0   0x00000000    0x100 0x00000000    0x100 -r-- header
+1   0x00000100  0x20e18 0x08000000  0x20e18 -r-x text
+2   0x0001718f   0xdb0c 0x08021000   0xdb0c -r-- ro
+3   0x0001f856   0x4218 0x0802f000   0x4218 -rw- data
+
+EOF
+CMDS=<<EOF
+iS
+EOF
+RUN
+
+NAME=nso entry
+ARGS=-e io.cache=true
+FILE=../bins/nso/application.nso
+EXPECT='[Entrypoints]
+vaddr=0x08000000 paddr=0x00000100 haddr=-1 type=program
+
+1 entrypoints'
+CMDS=<<EOF
+ie
+EOF
+RUN
+
+NAME=nso data
+ARGS=-e io.cache=true
+FILE=../bins/nso/application.nso
+EXPECT='e7031eaa01000094c62302d1e50300aae40301aabf0000f1841841ba400000544a240014fb0307aaf90305aafa0304aa'
+CMDS=<<EOF
+p8 0x30 @ 0x08000080
 EOF
 RUN


### PR DESCRIPTION
**Detailed description**

`readLE32()` didn't load explicitly as LE and these two functions are redundant too.