### PR TITLE
Preserve "functions" flagspace when saving projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -590,6 +590,7 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 
 	if (opts & R_CORE_PRJ_FCNS) {
 		r_str_write (fd, "# functions\n");
+		r_str_write (fd, "fs functions\n");
 		r_core_cmd (core, "afl*", 0);
 		r_cons_flush ();
 	}
@@ -663,6 +664,8 @@ static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	}
 
 	if (opts & R_CORE_PRJ_FCNS) {
+		r_str_write (fd, "# functions\n");
+		r_str_write (fd, "fs functions\n");
 		r_core_cmd (core, "afl*", 0);
 		r_cons_flush ();
 	}


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

### Detailed description ###

This tiny patch fixes a bug with how *projects* interact with *flagspaces*. With the `functions` flagspace specifically.

Normally, all flags are saved in the project `rc`-file under their respective flagspace, eg:

    # flags
    fs symbols
    f ssl_sprintf_buf 1 0x6e727574 
    f sprintf 1 0x80990556 
    fs functions
    f fcn.1c6f8 314 0x80c1c6f8 
    fs strings
    f str.SSL_Debug__secure_sock_clr_ctx__version____d 46 0x80c32f6e 

So there's that. However, since the `# functions` rc section comes **before** `# flags` section, and uses the `f` command too, an unintended (I believe) side-effect occurs: **`fcn.1234` flags migrate from `fs functions` to `fs *`** during save-exit-start-load cycle.

Consequences are subtle.
 * User can get the impression that saving&reloading a project *loses functions*, by observing `functions` number in `fs` output goes down after reload.
 * The `rc` file gains extra junk on *second* saving, in the form of `fs *`⇿`fs functions` back-and-forth switching and duplicate flags [in different flagspaces].
 * Analysis starts feeling wonky; I didn't investigate in detail.

The bug is trivially fixed by putting `fs functions` before the `afl*` output in the `# functions` rc section.

Both `e prj.simple=true` and `e prj.simple=false` are affected & fixed.

### Test plan ###

Here's one way to reproduce.
```
$ dd if=/dev/zero of=/tmp/testbin bs=512 count=1
$ r2 -w -a arm -b 32 /tmp/testbin
[0x00000000]> s 16
[0x00000010]> "wa mvn r3, 0; pop {lr, pc}"
Written 8 byte(s) (mvn r3, 0; pop {lr, pc}) = wx 0030e0e300c0bde8
[0x00000010]> pd 2
            0x00000010      0030e0e3       mvn r3, 0
            0x00000014      00c0bde8       pop {lr, pc}
[0x00000010]> fs
    0 * classes
    0 * relocs
    0 * sections
    0 * segments
    0 * symbols
[0x00000010]> af
[0x00000010]> pd 2
╭ 8: fcn.00000010 ();
│ bp: 0 (vars 0, args 0)
│ sp: 0 (vars 0, args 0)
│ rg: 0 (vars 0, args 0)
│           0x00000010      0030e0e3       mvn r3, 0
╰           0x00000014      00c0bde8       pop {lr, pc}
[0x00000010]> fs
    0 * classes
    1 * functions
    0 * relocs
    0 * sections
    0 * segments
    0 * symbols
[0x00000010]> Ps test
test
[0x00000010]> exit
Do you want to save the 'test' project? (Y/n) n
```
This creates project `test` with just a single function, and a single respective flag.

#### Before this PR ####
```
ulidtko@pasocon ~/s/radare2> grep -A5 -B10 '# flags' ~/.local/share/radare2/projects/test/rc
"e zoom.in = io.map"
"e zoom.maxsz = 512"
"e zoom.to = 0"
"f fcn.00000010 8 0x00000010"
"af+ 0x00000010 fcn.00000010 f n"
afb+ 0x00000010 0x00000010 8 0xffffffffffffffff 0xffffffffffffffff
afB 32 @ 0x00000010
afc arm32 @ 0x00000010
afS 0 @ 0x10

# flags
fs functions
f fcn.00000010 8 0x00000010 
"obf /tmp/testbin"
"ofs \"/tmp/testbin\" rwx"
om 3 0x0 0x200 0x0 rwx
```
Observe how `f fcn.00000010 8 0x00000010` line appears both in `# flags` section (after `fs functions`), and once more before that. Merely loading and re-saving the project mangles function flags:
```
$ r2 -p test
[0x00000010]> fs
    1 * functions
    0 * symbols
^D
Do you want to save the 'test' project? (Y/n) y
$ r2 -p test
[0x00000010]> fs
    0 * functions
    0 * symbols
^D
Do you want to save the 'test' project? (Y/n) y
$ grep -A5 -B10 '# flags' ~/.local/share/radare2/projects/test/rc
"e zoom.in = io.map"
"e zoom.maxsz = 512"
"e zoom.to = 0"
"f fcn.00000010 8 0x00000010"
"af+ 0x00000010 fcn.00000010 f n"
afb+ 0x00000010 0x00000010 8 0xffffffffffffffff 0xffffffffffffffff
afB 32 @ 0x00000010
afc arm32 @ 0x00000010
afS 0 @ 0x10

# flags
fs *
f fcn.00000010 8 0x00000010 
"obf /tmp/testbin"
"ofs \"/tmp/testbin\" rwx"
om 3 0x0 0x200 0x0 rwx
```
— `fcn.00000010` has migrated from `fs functions` to `fs *` simply by load-save.

#### After this PR ####
Observe that `fs functions` now appears just before function analysis data.
```
ulidtko@pasocon ~/s/radare2> grep -A5 -B10 '# flags' ~/.local/share/radare2/projects/test/rc
"e zoom.to = 0"
# functions
fs functions
"f fcn.00000010 8 0x00000010"
"af+ 0x00000010 fcn.00000010 f n"
afb+ 0x00000010 0x00000010 8 0xffffffffffffffff 0xffffffffffffffff
afB 32 @ 0x00000010
afc arm32 @ 0x00000010
afS 0 @ 0x10

# flags
fs functions
f fcn.00000010 8 0x00000010 
"obf /tmp/testbin"
"ofs \"/tmp/testbin\" rwx"
om 3 0x0 0x200 0x0 rwx
```
Re-saving and re-loading correctly preserves the `fcn.00000010` flag under `functions` now.
```
$ r2 -p test
[0x00000010]> fs
    1 * functions
    0 * symbols
[0x00000010]> f
0x00000010 8 fcn.00000010
Do you want to save the 'test' project? (Y/n) y
$ r2 -p test
[0x00000010]> fs
    1 * functions
    0 * symbols
[0x00000010]> f
0x00000010 8 fcn.00000010
```