### PR TITLE
Fix r_cons_rgb_parse() harder

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -767,7 +767,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 				break;
 			case 'H':
 				{
-					ut8 r, g, b, A;
+					ut8 r = 0, g = 0, b = 0, A = 0;
 					const char *esc = strchr (d->str, '\x1b');
 					r_cons_rgb_parse (esc, &r, &g, &b, &A);
 					a->cb_printf ("%s rgb:%02x%02x%02x @ 0x%08"PFMT64x"\n",

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -9,6 +9,7 @@ if get_option('build_tests')
     'bin',
     'bitmap',
     'buf',
+    'cons',
     'contrbtree',
     'debruijn',
     'diff',

--- a/test/unit/test_cons.c
+++ b/test/unit/test_cons.c
@@ -5,21 +5,116 @@ bool test_r_cons() {
 	// NOTE: not initializing a value here results in UB
 	ut8 r = 0, g = 0, b = 0, a = 0;
 
-	const char *foo = "___"; // should crash in asan mode
+	r_cons_rgb_init();
+
+	// all these strdup are for asan/valgrind to have some exact bounds to work with
+
+	char *foo = strdup ("___"); // should crash in asan mode
 	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
 
 	mu_assert_eq (r, 0, "red color");
 	mu_assert_eq (g, 0, "green color");
 	mu_assert_eq (b, 0, "blue color");
 	mu_assert_eq (a, 0, "alpha color");
 
-	foo = "\x1b[32mhello\x1b[0m";
+	// old school
+	foo = strdup ("\x1b[32mhello\x1b[0m");
+	r = g = b = a = 0;
 	r_cons_rgb_parse (foo, &r, &g, &b, &a);
-
+	free (foo);
 	mu_assert_eq (r, 0, "red color");
 	mu_assert_eq (g, 127, "green color");
 	mu_assert_eq (b, 0, "blue color");
 	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("[32mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 0, "red color");
+	mu_assert_eq (g, 127, "green color");
+	mu_assert_eq (b, 0, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("32mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 0, "red color");
+	mu_assert_eq (g, 127, "green color");
+	mu_assert_eq (b, 0, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	// 256
+	foo = strdup ("\x1b[38;5;213mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 255, "red color");
+	mu_assert_eq (g, 135, "green color");
+	mu_assert_eq (b, 255, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("[38;5;213mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 255, "red color");
+	mu_assert_eq (g, 135, "green color");
+	mu_assert_eq (b, 255, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("38;5;213mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 255, "red color");
+	mu_assert_eq (g, 135, "green color");
+	mu_assert_eq (b, 255, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	// 24 bit
+	foo = strdup ("\x1b[38;2;42;13;37mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 42, "red color");
+	mu_assert_eq (g, 13, "green color");
+	mu_assert_eq (b, 37, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("[38;2;42;13;37mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 42, "red color");
+	mu_assert_eq (g, 13, "green color");
+	mu_assert_eq (b, 37, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	foo = strdup ("38;2;42;13;37mhello\x1b[0m");
+	r = g = b = a = 0;
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+	mu_assert_eq (r, 42, "red color");
+	mu_assert_eq (g, 13, "green color");
+	mu_assert_eq (b, 37, "blue color");
+	mu_assert_eq (a, 0, "alpha color");
+
+	// no over-read
+	foo = strdup ("38;2");
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+
+	foo = strdup ("38;5");
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+
+	foo = strdup ("3");
+	r_cons_rgb_parse (foo, &r, &g, &b, &a);
+	free (foo);
+
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] ~~I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)~~

**Detailed description**

This fixes the broken color themes in Cutter and some read beyond the given string.

**Test plan**

* Use Cutter
* Run the added unit tests

**Closing issues**

Fix #16060