### PR TITLE
Fix r_table_tostring no pad

### DIFF
--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -29,7 +29,6 @@ R_API RTableColumnType *r_table_type (const char *name) {
 	return NULL;
 }
 
-// TODO: unused for now, maybe good to call after filter :?
 static void __table_adjust(RTable *t) {
 	RListIter *iter, *iter2;
 	RTableColumn *col;
@@ -379,8 +378,7 @@ R_API char *r_table_tostring(RTable *t) {
 	int maxlen = 0;
 	if (t->showHeader) {
 		r_list_foreach (t->cols, iter, col) {
-			bool nopad = !iter->n;
-			int ll = __strbuf_append_col_aligned (sb, col, col->name, nopad);
+			int ll = __strbuf_append_col_aligned (sb, col, col->name, false);
 			maxlen = R_MAX (maxlen, ll);
 		}
 		int len = r_str_len_utf8_ansi (r_strbuf_get (sb));
@@ -394,10 +392,9 @@ R_API char *r_table_tostring(RTable *t) {
 		char *item;
 		int c = 0;
 		r_list_foreach (row->items, iter2, item) {
-			bool nopad = !iter2->n;
 			RTableColumn *col = r_list_get_n (t->cols, c);
 			if (col) {
-				(void)__strbuf_append_col_aligned (sb, col, item, nopad);
+				(void)__strbuf_append_col_aligned (sb, col, item, false);
 			}
 			c++;
 		}
@@ -414,8 +411,7 @@ R_API char *r_table_tostring(RTable *t) {
 			}
 		}
 		r_list_foreach (t->cols, iter, col) {
-			bool nopad = !iter->n;
-			(void)__strbuf_append_col_aligned (sb, col, sdb_itoa (col->total, tmp, 10), nopad);
+			(void)__strbuf_append_col_aligned (sb, col, sdb_itoa (col->total, tmp, 10), false);
 		}
 	}
 	return r_strbuf_drain (sb);

--- a/test/unit/test_table.c
+++ b/test/unit/test_table.c
@@ -80,6 +80,24 @@ bool test_r_table_tostring(void) {
 	mu_end;
 }
 
+bool test_r_table_tostring2(void) {
+	RTable *t = __table_test_data1 ();
+	char buf[BUF_LENGTH];
+
+	r_table_add_rowf (t, "sd", "aaaaa", "9797979797");
+	char *s = r_table_tostring (t);
+	mu_assert_streq (s,
+		"ascii code\n"
+		"----------\n"
+		"a     97\n"
+		"b     98\n"
+		"c     99\n", "adjust column width");
+	free (s);
+
+	r_table_free (t);
+	mu_end;
+}
+
 bool test_r_table_sort1(void) {
 	RTable *t = __table_test_data1 ();
 
@@ -174,6 +192,7 @@ bool all_tests() {
 	mu_run_test(test_r_table);
 	mu_run_test(test_r_table_column_type);
 	mu_run_test(test_r_table_tostring);
+	mu_run_test(test_r_table_tostring2);
 	mu_run_test(test_r_table_sort1);
 	mu_run_test(test_r_table_columns);
 	return tests_passed != tests_run;

--- a/test/unit/test_table.c
+++ b/test/unit/test_table.c
@@ -51,11 +51,11 @@ bool test_r_table_column_type(void) {
 	r_table_sort (t, 1, true);
 	char *s = r_table_tostring (t);
 	mu_assert_streq (s,
-		"ascii code\n"
-		"----------\n"
-		"a     97\n"
-		"b     98\n"
-		"c     99\n", "not sorted by second column due to undefined type");
+		"ascii code \n"
+		"-----------\n"
+		"a     97   \n"
+		"b     98   \n"
+		"c     99   \n", "not sorted by second column due to undefined type");
 	free (s);
 	r_table_free (t);
 	mu_end;
@@ -69,11 +69,11 @@ bool test_r_table_tostring(void) {
 		char *s = r_table_tostring (t);
 		snprintf (buf, BUF_LENGTH, "%d-th call to r_table_tostring", i);
 		mu_assert_streq (s,
-			"ascii code\n"
-			"----------\n"
-			"a     97\n"
-			"b     98\n"
-			"c     99\n", buf);
+			"ascii code \n"
+			"-----------\n"
+			"a     97   \n"
+			"b     98   \n"
+			"c     99   \n", buf);
 		free (s);
 	}
 	r_table_free (t);
@@ -84,15 +84,28 @@ bool test_r_table_tostring2(void) {
 	RTable *t = __table_test_data1 ();
 	char buf[BUF_LENGTH];
 
-	r_table_add_rowf (t, "sd", "aaaaa", "9797979797");
-	char *s = r_table_tostring (t);
-	mu_assert_streq (s,
-		"ascii code\n"
-		"----------\n"
-		"a     97\n"
-		"b     98\n"
-		"c     99\n", "adjust column width");
-	free (s);
+	r_table_add_rowf (t, "ss", "aaaaa", "9797979797");
+	char *s1 = r_table_tostring (t);
+	mu_assert_streq (s1,
+		"ascii code       \n"
+		"-----------------\n"
+		"a     97         \n"
+		"b     98         \n"
+		"c     99         \n"
+		"aaaaa 9797979797 \n", "adjust last column width");
+	free (s1);
+
+	r_table_add_rowf (t, "ss", "bbbbbbbb", "9898989898");
+	char *s2 = r_table_tostring (t);
+	mu_assert_streq (s2,
+		"ascii    code       \n"
+		"--------------------\n"
+		"a        97         \n"
+		"b        98         \n"
+		"c        99         \n"
+		"aaaaa    9797979797 \n"
+		"bbbbbbbb 9898989898 \n", "adjust first column width");
+	free (s2);
 
 	r_table_free (t);
 	mu_end;
@@ -104,21 +117,21 @@ bool test_r_table_sort1(void) {
 	r_table_sort (t, 1, true);
 	char *strd = r_table_tostring (t);
 	mu_assert_streq (strd,
-		"ascii code\n"
-		"----------\n"
-		"c     99\n"
-		"b     98\n"
-		"a     97\n", "sort decreasing second column using number type");
+		"ascii code \n"
+		"-----------\n"
+		"c     99   \n"
+		"b     98   \n"
+		"a     97   \n", "sort decreasing second column using number type");
 	free (strd);
 
 	r_table_sort (t, 1, false);
 	char *stri = r_table_tostring (t);
 	mu_assert_streq (stri,
-		"ascii code\n"
-		"----------\n"
-		"a     97\n"
-		"b     98\n"
-		"c     99\n", "sort increasing second column using number type");
+		"ascii code \n"
+		"-----------\n"
+		"a     97   \n"
+		"b     98   \n"
+		"c     99   \n", "sort increasing second column using number type");
 	free (stri);
 	r_table_free (t);
 	mu_end;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

- r_table_tostring does not pad header line for the last column even if the row content is longer than the column
- remove __table_adjust TODO note since it has been used in several places to adjust column width

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

- Add test to verify that last column has padding
- Update other r_table_tostring test to reflect fix