### PR TITLE
Fix null-deref on afv[rbs]-* without function

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1349,6 +1349,10 @@ static int var_cmd(RCore *core, const char *str) {
 		r_anal_var_list_show (core->anal, fcn, core->offset, 0, NULL);
 		break;
 	case '-': // "afv[bsr]-"
+		if (!fcn) {
+			eprintf ("Cannot find function\n");
+			return false;
+		}
 		if (str[2] == '*') {
 			r_anal_var_delete_all (core->anal, fcn->addr, type);
 		} else {

--- a/test/new/db/cmd/cmd_afv
+++ b/test/new/db/cmd/cmd_afv
@@ -1,0 +1,10 @@
+NAME=avr[rbs]- without function
+FILE=-
+CMDS=<<EOF
+afvr-*
+afvb-42
+afvb- ulumulu
+?e not segfaulted
+EOF
+EXPECT='not segfaulted'
+RUN


### PR DESCRIPTION
**Test plan**

`r2 -c "afvr-*" -`