### PR TITLE
Rename the Function Flag on afn

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2554,6 +2554,16 @@ static bool __setFunctionName(RCore *core, ut64 addr, const char *_name, bool pr
 	// RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_ANY);
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, addr);
 	if (fcn) {
+		RFlagItem *flag = r_flag_get (core->flags, fcn->name);
+		if (flag->space && strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS) == 0) {
+			// Only flags in the functions fs should be renamed, e.g. we don't want to rename symbol flags.
+			r_flag_rename (core->flags, flag, name);
+		} else {
+			// No flag or not specific to the function, create a new one.
+			r_flag_space_push (core->flags, R_FLAGS_FS_FUNCTIONS);
+			r_flag_set (core->flags, name, fcn->addr, r_anal_function_size_from_entry (fcn));
+			r_flag_space_pop (core->flags);
+		}
 		r_anal_function_rename (fcn, name);
 		if (core->anal->cb.on_fcn_rename) {
 			core->anal->cb.on_fcn_rename (core->anal, core->anal->user, fcn, name);

--- a/test/new/db/cmd/cmd_afn
+++ b/test/new/db/cmd/cmd_afn
@@ -25,3 +25,48 @@ EXPECT=<<EOF
 foobar
 EOF
 RUN
+
+NAME=afn with flag
+FILE=../bins/elf/crackme0x05
+CMDS=<<EOF
+aa
+f@F:functions~483f4,48540
+?e --
+f@F:*~483f4,48540
+afn mymain @ 0x08048540
+afn @ 0x08048540
+?e The main flag shouldn't be renamed, it comes from bin:
+f@F:functions~483f4,48540
+?e --
+f@F:*~483f4,48540
+afn myfunc @ 0x080483f4
+afn @ 0x080483f4
+?e Here the flag is owned by the fcn and should be renamed:
+f@F:functions~483f4,48540
+?e --
+f@F:*~483f4,48540
+EOF
+EXPECT="0x080483f4 33 fcn.080483f4
+--
+0x080483f4 33 fcn.080483f4
+0x08048540 92 main
+0x08048540 92 sym.main
+mymain
+The main flag shouldn't be renamed, it comes from bin:
+0x080483f4 33 fcn.080483f4
+0x08048540 92 mymain
+--
+0x080483f4 33 fcn.080483f4
+0x08048540 92 main
+0x08048540 92 sym.main
+0x08048540 92 mymain
+myfunc
+Here the flag is owned by the fcn and should be renamed:
+0x080483f4 33 myfunc
+0x08048540 92 mymain
+--
+0x080483f4 33 myfunc
+0x08048540 92 main
+0x08048540 92 sym.main
+0x08048540 92 mymain"
+RUN


### PR DESCRIPTION
**Detailed description**

Before, when you renamed a function, you would get something like this:
![Screenshot from 2020-02-29 17-54-11](https://user-images.githubusercontent.com/1460997/75611632-83ff9b00-5b1c-11ea-9d9f-68b33aeadf94.png)
The `fcn...` flag is useless at this point and you would have to manually delete it.
This pr automatically renames it, but only if the matching flag is in the "functions" namespace. Otherwise we might rename flags that could have another purpose, like for symbols. In such a case, a new flag is created.

I think that the entire flag setting code for functions should be refactored, maybe using REvent, but this patch is simple and clear and helps us define the desired behavior in the form of tests.

**Test plan**

see screenshot