### PR TITLE
Fix bug in windbg_read_reg()

### DIFF
--- a/shlr/windbg/windbg.c
+++ b/shlr/windbg/windbg.c
@@ -477,7 +477,7 @@ RList *windbg_list_modules(WindCtx *ctx) {
 
 	// LIST_ENTRY InMemoryOrderModuleList
 	ut64 mlistoff = ctx->is_x64 ? 0x20 : 0x14;
-	
+
 	base = ptr + mlistoff;
 
 	windbg_read_at_uva (ctx, (uint8_t *) &ptr, base, 4 << ctx->is_x64);
@@ -1003,7 +1003,7 @@ int windbg_read_reg(WindCtx *ctx, uint8_t *buf, int size) {
 		return 0;
 	}
 
-	memcpy (buf, rr->data, R_MIN (size, pkt->length - sizeof (rr)));
+	memcpy (buf, rr->data, R_MIN (size, pkt->length - sizeof (*rr)));
 
 	free (pkt);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
`sizeof(rr)` gives pointer size.

But `windbg_read_reg()` and `r_debug_windbg_reg_read()` still look broken.
