### PR TITLE
Fix a null-deref in afn

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2555,7 +2555,7 @@ static bool __setFunctionName(RCore *core, ut64 addr, const char *_name, bool pr
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, addr);
 	if (fcn) {
 		RFlagItem *flag = r_flag_get (core->flags, fcn->name);
-		if (flag->space && strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS) == 0) {
+		if (flag && flag->space && strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS) == 0) {
 			// Only flags in the functions fs should be renamed, e.g. we don't want to rename symbol flags.
 			r_flag_rename (core->flags, flag, name);
 		} else {

--- a/test/new/db/cmd/cmd_afn
+++ b/test/new/db/cmd/cmd_afn
@@ -45,6 +45,12 @@ afn @ 0x080483f4
 f@F:functions~483f4,48540
 ?e --
 f@F:*~483f4,48540
+f- myfunc
+afn createdflag @ 0x080483f4
+?e Non-existing flags should be created
+f@F:functions~483f4,48540
+?e --
+f@F:*~483f4,48540
 EOF
 EXPECT=<<EOF
 0x080483f4 33 fcn.080483f4
@@ -67,6 +73,14 @@ Here the flag is owned by the fcn and should be renamed:
 0x08048540 92 mymain
 --
 0x080483f4 33 myfunc
+0x08048540 92 main
+0x08048540 92 sym.main
+0x08048540 92 mymain
+Non-existing flags should be created
+0x080483f4 33 createdflag
+0x08048540 92 mymain
+--
+0x080483f4 33 createdflag
 0x08048540 92 main
 0x08048540 92 sym.main
 0x08048540 92 mymain


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] ~~I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)~~

**Detailed description**

`afn` would segfault if there is no flag at the function address

**Test plan**

run the test