### PR TITLE
Fix long PPC ESIL (#16102)

### DIFF
--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -1229,7 +1229,9 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 		if (mask & R_ANAL_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);
 		}
-		r_strbuf_fini (&op->esil);
+		if (!(mask & R_ANAL_OP_MASK_ESIL)) {
+			r_strbuf_fini (&op->esil);
+		}
 		cs_free (insn, n);
 		//cs_close (&handle);
 	}

--- a/test/new/db/esil/ppc_32
+++ b/test/new/db/esil/ppc_32
@@ -27,3 +27,18 @@ e cfg.bigendian=true
 .(pi 9421fff8)
 EOF
 RUN
+
+NAME=long ESIL ppc-32
+FILE=-
+EXPECT=<<EOF
+bdnz 0xfffffffffffffff0
+0x00000000 1,ctr,-=,$z,!,?{,0xfffffffffffffff0,pc,=,}
+EOF
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+"(pi bytes,wx $0,pi 1,pie 1)"
+.(pi 4200fff0)
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Unlike other analysis plugins, the PPC analysis (`libr/anal/p/anal_ppc_cs.c`) doesn't have a separate `analop_esil` function; instead, ESIL is unconditionally generated in the main `analop` function. Instead of refactoring the code and extracting out a separate `analop_esil` function, this PR just fixes the linked issue by discarding the generated ESIL (via a call to `r_strbuf_fini`) only if the corresponding mask bit isn't set.

**Test plan**

Added test case to db/esil/ppc_32 to verify ESIL statements longer than 30 characters are printed

**Closing issues**

closes #16102