### PR TITLE
Cleanup RAnalOp after disassembly (#16113)

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6524,6 +6524,7 @@ toro:
 					}
 					r_cons_println (opstr);
 				}
+				r_anal_op_fini (&analop);
 			} else {
 				char opstr[128] = {
 					0


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

My recent fix (#16102) uncovered a memory leak; `r_anal_op_fini` isn't called after printing disassembly.

**Test plan**

Ran radare2 under valgrind both before and after fix; before fix, there was one extra leaked block corresponding to the longer ESIL statement that required allocation for an `RStrBuf`.

**Closing issues**

closes #16113