### PR TITLE
Fix file reopen in debug mode ood/doo

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -75,7 +75,8 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 	int newpid = odesc? odesc->fd: -1;
 
 	if (isdebug) {
-		r_debug_kill (core->dbg, core->dbg->pid, core->dbg->tid, 9); // KILL
+		r_debug_kill (core->dbg, core->dbg->pid, core->dbg->tid, 9); // SIGKILL
+		r_debug_continue (core->dbg);
 		perm = 7;
 	} else {
 		if (!perm) {

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1117,9 +1117,9 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	char *newfile = r_str_newf ("dbg://%s %s", escaped_path, args);
 	desc->uri = newfile;
 	desc->referer = NULL;
+	r_core_file_reopen (core, newfile, 0, 2);
 	r_config_set_i (core->config, "asm.bits", bits);
 	r_config_set_i (core->config, "cfg.debug", true);
-	r_core_file_reopen (core, newfile, 0, 2);
 	if (r_config_get_i (core->config, "dbg.rebase")) {
 		__rebase_everything (core, old_sections, old_base);
 	}

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -427,6 +427,8 @@ repeat:
 			if (WIFEXITED (status)) {
 				eprintf ("child exited with status %d\n", WEXITSTATUS (status));
 				if (pid == dbg->main_pid) {
+					r_list_free (dbg->threads);
+					dbg->threads = NULL;
 					reason = R_DEBUG_REASON_DEAD;
 				} else {
 					reason = R_DEBUG_REASON_EXIT_TID;

--- a/test/new/db/archos/linux-x64/dbg_oo
+++ b/test/new/db/archos/linux-x64/dbg_oo
@@ -26,6 +26,21 @@ dbg:///bin/ls
 EOF
 RUN
 
+NAME= ood after open in debug mode
+FILE=../bins/elf/analysis/x86-helloworld-gcc
+ARGS=-d
+CMDS=<<EOF
+ood > $_
+dc
+ood > $_
+dc
+EOF
+EXPECT=<<EOF
+Hello world!
+Hello world!
+EOF
+RUN
+
 NAME=oo ; dc
 FILE=../bins/elf/analysis/x86-helloworld-gcc
 ARGS=-d


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This PR focuses on the Linux native debugger.

#### Problem
1. In `ood`, `r_core_file_reopen_debug` sends a kill signal to the current child process/debuggee, but it is stopped so it does not terminate. As a result, calling the next `r_debug_continue` would receive the child killed signal instead of continuing the new process.
2. r2 will attach to the process every time `cfg.debug` is set to true due to its callback. If `ood` is used during an active debug session and the process terminated, calling `r_config_set_i (core->config, "cfg.debug", true)` before `r_core_file_reopen` will attach to the terminated process pid again and cause `PT_ATTACH failed`.
3. When the process terminated, it does not free the `dbg->threads`, using `ood; dc` later will cause:
    ```
    tkill: No such process
    Could not stop pid (81404)
    ```
    Because `r_debug_continue` will stop all threads in the end and try to stop old threads.

#### Fix
1. Do `r_debug_continue` after `r_debug_kill` to continue the process and receive the signal.
2. Set `cfg.debug` to `true` after calling `r_core_file_reopen`
3. Free `dbg->threads` and set it to null when the process terminated

**Test plan**

~We could bring back `db/archos/linux-x64/dbg_oo`. But, pid value does not always stay the same, I would like to know if there is a way to write a test for this kind of situation by ignoring parts of the outputs. (?)~
1. Open file in debug mode `-d`
2. `ood` -> `dc` -> check if the program outputs correctly.
3. Repeat step 2 again once.

**Closing issues**

closes #13404 