### PR TITLE
Deprecate cmdtail and kill r_anal_case()

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -324,36 +324,6 @@ static int skip_hp(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, RAnalBlock *bb,
 	return 0;
 }
 
-R_API int r_anal_case(RAnal *anal, RAnalFunction *fcn, ut64 addr_bbsw, ut64 addr, ut8 *buf, ut64 len, int reftype) {
-	RAnalOp op = { 0 };
-	int oplen, idx = 0;
-	while (idx < len) {
-		if ((len - idx) < 5) {
-			break;
-		}
-		r_anal_op_fini (&op);
-		if ((oplen = r_anal_op (anal, &op, addr + idx, buf + idx, len - idx, R_ANAL_OP_MASK_BASIC)) < 1) {
-			return 0;
-		}
-		switch (op.type) {
-		case R_ANAL_OP_TYPE_TRAP:
-		case R_ANAL_OP_TYPE_RET:
-		case R_ANAL_OP_TYPE_JMP:
-			// eprintf ("CASE AT 0x%llx size %d\n", addr, idx + oplen);
-			r_strbuf_appendf (anal->cmdtail, "afb+ 0x%"PFMT64x " 0x%"PFMT64x " %d\n",
-				fcn->addr, addr, idx + oplen);
-			r_strbuf_appendf (anal->cmdtail, "afbe 0x%"PFMT64x " 0x%"PFMT64x "\n",
-				addr_bbsw, addr);
-			return idx + oplen;
-		default:
-			// do nothing here
-			break;
-		}
-		idx += oplen;
-	}
-	return idx;
-}
-
 static bool purity_checked(HtUP *ht, RAnalFunction *fcn) {
 	bool checked;
 	ht_up_find (ht, fcn->addr, &checked);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -676,7 +676,7 @@ typedef struct r_anal_t {
 	bool (*log)(struct r_anal_t *anal, const char *msg);
 	bool (*read_at)(struct r_anal_t *anal, ut64 addr, ut8 *buf, int len);
 	bool verbose;
-	RStrBuf *cmdtail;
+	R_DEPRECATE RStrBuf *cmdtail;
 	int seggrn;
 	RFlagGetAtAddr flag_get;
 	REvent *ev;


### PR DESCRIPTION
**Detailed description**

This `cmdtail` us an ugly hack, we should move away from it. Since there aren't too many places where it is used, this shouldn't be too hard.
`r_anal_case()` was one of the places, but it has been dead code since 2018: adaf135dc66d3004237aed9b857da65d62e77190