### PR TITLE
Memory fix on error path on win mangled named handling ##bin

### DIFF
--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -1607,6 +1607,7 @@ static EDemanglerErr parse_microsoft_rtti_mangled_name(char *sym, char **demangl
 	int len = get_namespace_and_name (sym + 2, &type_code_str, NULL);
 	if (!len) {
 		err = eDemanglerErrUncorrectMangledSymbol;
+		free (type_code_str.type_str);
 		goto parse_microsoft_rtti_mangled_name_err;
 	}
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)
