### PR TITLE
Support for Tricore cpu type argument

### DIFF
--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -15,8 +15,36 @@
 static unsigned long Offset = 0;
 static RStrBuf *buf_global = NULL;
 static ut8 bytes[128];
+enum {
+  TRICORE_GENERIC = 0x00000000,
+  TRICORE_RIDER_A = 0x00000001,
+  TRICORE_RIDER_B = 0x00000002,
+  TRICORE_RIDER_D = TRICORE_RIDER_B,
+  TRICORE_V2      = 0x00000004,
+  TRICORE_PCP     = 0x00000010,
+  TRICORE_PCP2    = 0x00000020
+};
 
-static int tricore_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
+static int cpu_to_mach(char *cpu_type) {
+	if (cpu_type && *cpu_type) {
+		if (!strcmp (cpu_type, "generic")) {
+			return TRICORE_GENERIC;
+		} else if (!strcmp (cpu_type, "rider-a")) {
+			return TRICORE_RIDER_A;
+		} else if ((!strcmp (cpu_type, "rider-b")) || (!strcmp (cpu_type, "rider-d"))) {
+			return TRICORE_RIDER_B;
+		} else if (!strcmp (cpu_type, "v2")) {
+			return TRICORE_V2;
+		} else if (!strcmp (cpu_type, "pcp")) {
+			return TRICORE_PCP;
+		} else if (!strcmp (cpu_type, "pcp2")) {
+			return TRICORE_PCP2;
+		}
+	}
+	return TRICORE_RIDER_B;
+}
+
+static int tricore_buffer_read_memory(bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
 	int delta = memaddr - Offset;
 	if (delta >= 0 && length + delta < sizeof(bytes)) {
 		memcpy (myaddr, bytes + delta, length);
@@ -53,7 +81,8 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = stdout;
 
-	disasm_obj.mach = 2; // select CPU TYPE
+	// cpu type
+	disasm_obj.mach = cpu_to_mach (a->cpu);
 
 	op->size = print_insn_tricore ((bfd_vma)Offset, &disasm_obj);
 	if (op->size == -1) {

--- a/libr/asm/p/asm_tricore.c
+++ b/libr/asm/p/asm_tricore.c
@@ -16,28 +16,33 @@ static unsigned long Offset = 0;
 static RStrBuf *buf_global = NULL;
 static ut8 bytes[128];
 enum {
-  TRICORE_GENERIC = 0x00000000,
-  TRICORE_RIDER_A = 0x00000001,
-  TRICORE_RIDER_B = 0x00000002,
-  TRICORE_RIDER_D = TRICORE_RIDER_B,
-  TRICORE_V2      = 0x00000004,
-  TRICORE_PCP     = 0x00000010,
-  TRICORE_PCP2    = 0x00000020
+	TRICORE_GENERIC = 0x00000000,
+	TRICORE_RIDER_A = 0x00000001,
+	TRICORE_RIDER_B = 0x00000002,
+	TRICORE_RIDER_D = TRICORE_RIDER_B,
+	TRICORE_V2      = 0x00000004,
+	TRICORE_PCP     = 0x00000010,
+	TRICORE_PCP2    = 0x00000020
 };
 
 static int cpu_to_mach(char *cpu_type) {
 	if (cpu_type && *cpu_type) {
 		if (!strcmp (cpu_type, "generic")) {
 			return TRICORE_GENERIC;
-		} else if (!strcmp (cpu_type, "rider-a")) {
+		}
+		if (!strcmp (cpu_type, "rider-a")) {
 			return TRICORE_RIDER_A;
-		} else if ((!strcmp (cpu_type, "rider-b")) || (!strcmp (cpu_type, "rider-d"))) {
+		}
+		if ((!strcmp (cpu_type, "rider-b")) || (!strcmp (cpu_type, "rider-d"))) {
 			return TRICORE_RIDER_B;
-		} else if (!strcmp (cpu_type, "v2")) {
+		}
+		if (!strcmp (cpu_type, "v2")) {
 			return TRICORE_V2;
-		} else if (!strcmp (cpu_type, "pcp")) {
+		}
+		if (!strcmp (cpu_type, "pcp")) {
 			return TRICORE_PCP;
-		} else if (!strcmp (cpu_type, "pcp2")) {
+		}
+		if (!strcmp (cpu_type, "pcp2")) {
 			return TRICORE_PCP2;
 		}
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Before, Cpu type was default to Rider-B when disassembling an instruction via rasm2
We have the option -c for cpu type that we can use for Tricore variant ISA.
Added support to get the cpu type argument for Tricore arch.

<img width="588" alt="Screenshot 2020-03-07 at 11 38 59 PM" src="https://user-images.githubusercontent.com/14140421/76150847-86419680-60d4-11ea-9a6c-c131b7f2e62b.png">

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**
#15912 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
