### PR TITLE
Fix r_anal_switch_op_new() args

### DIFF
--- a/libr/anal/block.c
+++ b/libr/anal/block.c
@@ -458,7 +458,7 @@ R_API RList *r_anal_block_recurse_list(RAnalBlock *block) {
 
 R_API void r_anal_block_add_switch_case(RAnalBlock *block, ut64 switch_addr, ut64 case_addr) {
 	if (!block->switch_op) {
-		block->switch_op = r_anal_switch_op_new (switch_addr, 0, 0);
+		block->switch_op = r_anal_switch_op_new (switch_addr, 0, 0, 0);
 	}
 	r_anal_switch_op_add_case (block->switch_op, case_addr, 0, case_addr);
 }

--- a/libr/anal/p/anal_java.c
+++ b/libr/anal/p/anal_java.c
@@ -54,7 +54,7 @@ static int java_switch_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, 
 		const int max_val = (ut32)(UINT (data, pos + 8));
 
 		ut32 default_loc = (ut32) (UINT (data, pos)), cur_case = 0;
-		op->switch_op = r_anal_switch_op_new (addr, min_val, default_loc);
+		op->switch_op = r_anal_switch_op_new (addr, min_val, max_val, default_loc);
 		RAnalCaseOp *caseop = NULL;
 		pos += 12;
 		if (max_val > min_val && ((max_val - min_val)<(UT16_MAX/4))) {

--- a/libr/anal/switch.c
+++ b/libr/anal/switch.c
@@ -16,13 +16,13 @@ static RAnalSwitchOp *__switch_op_new() {
 	return swop;
 }
 
-R_API RAnalSwitchOp * r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 def_val) {
+R_API RAnalSwitchOp *r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 max_val, ut64 def_val) {
 	RAnalSwitchOp *swop = __switch_op_new ();
 	if (swop) {
 		swop->addr = addr;
 		swop->min_val = min_val;
-		swop->def_val = min_val;
-		swop->max_val = min_val;
+		swop->def_val = def_val;
+		swop->max_val = max_val;
 	}
 	return swop;
 }

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1846,7 +1846,7 @@ R_API int r_anal_hint_bits_at(RAnal *anal, ut64 addr, R_NULLABLE ut64 *hint_addr
 R_API RAnalHint *r_anal_hint_get(RAnal *anal, ut64 addr); // accumulate all available hints affecting the given address
 
 /* switch.c APIs */
-R_API RAnalSwitchOp * r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 max_val);
+R_API RAnalSwitchOp *r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 max_val, ut64 def_val);
 R_API void r_anal_switch_op_free(RAnalSwitchOp * swop);
 R_API RAnalCaseOp* r_anal_switch_op_add_case(RAnalSwitchOp * swop, ut64 addr, ut64 value, ut64 jump);
 

--- a/test/unit/test_anal_block.c
+++ b/test/unit/test_anal_block.c
@@ -508,7 +508,11 @@ bool test_r_anal_block_successors() {
 	blocks[1]->fail = 0x50;
 	blocks[2]->jump = 0x10;
 
-	RAnalSwitchOp *sop = r_anal_switch_op_new (0x55, 0, 10);
+	RAnalSwitchOp *sop = r_anal_switch_op_new (0x55, 0x13, 0x15, 0x42);
+	mu_assert_eq (sop->addr, 0x55, "addr");
+	mu_assert_eq (sop->min_val, 0x13, "addr");
+	mu_assert_eq (sop->max_val, 0x15, "addr");
+	mu_assert_eq (sop->def_val, 0x42, "addr");
 	r_anal_switch_op_add_case (sop, 0x55, 1, 0x100);
 	r_anal_switch_op_add_case (sop, 0x55, 2, 0x110);
 	r_anal_switch_op_add_case (sop, 0x55, 3, 0x120);


### PR DESCRIPTION
Previous declaration was
```RAnalSwitchOp *r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 max_val);```
but with the definition
```RAnalSwitchOp *r_anal_switch_op_new(ut64 addr, ut64 min_val, ut64 def_val)```
and `def_val` was just ignored and everything set to `min_val` 🤯
