### PR TITLE
Fix afs not showing signatures correctly with preloaded sdb types ##types

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1565,9 +1565,12 @@ R_API char *r_anal_function_get_json(RAnalFunction *function) {
 }
 
 R_API char *r_anal_function_get_signature(RAnal *a, const char *name) {
+	const char *fcnname = (r_str_startswith (name, "sym.imp."))
+		? name + 8
+		: name;
 	char *ret = NULL, *args = strdup ("");
-	char *sdb_ret = r_str_newf ("func.%s.ret", name);
-	char *sdb_args = r_str_newf ("func.%s.args", name);
+	char *sdb_ret = r_str_newf ("func.%s.ret", fcnname);
+	char *sdb_args = r_str_newf ("func.%s.args", fcnname);
 	// RList *args_list = r_list_newf ((RListFree) free);
 	unsigned int i, j;
 	const char *ret_type = sdb_const_get (a->sdb_types, sdb_ret, 0);
@@ -1576,7 +1579,7 @@ R_API char *r_anal_function_get_signature(RAnal *a, const char *name) {
 	int argc = argc_str? atoi (argc_str): 0;
 
 	for (i = 0; i < argc; i++) {
-		char *sdb_arg_i = r_str_newf ("func.%s.arg.%d", name, i);
+		char *sdb_arg_i = r_str_newf ("func.%s.arg.%d", fcnname, i);
 		char *arg_i = sdb_get (a->sdb_types, sdb_arg_i, 0);
 		// parse commas
 		int arg_i_len = strlen (arg_i);
@@ -1599,7 +1602,7 @@ R_API char *r_anal_function_get_signature(RAnal *a, const char *name) {
 		free (arg_i);
 		free (sdb_arg_i);
 	}
-	ret = r_str_newf ("%s %s (%s);", ret_type? ret_type: "void", name, args);
+	ret = r_str_newf ("%s %s (%s);", ret_type? ret_type: "void", fcnname, args);
 
 	free (sdb_args);
 	free (sdb_ret);

--- a/test/new/db/cmd/types
+++ b/test/new/db/cmd/types
@@ -1495,6 +1495,18 @@ char foo.bar (int32_t a);
 EOF
 RUN
 
+NAME=afs sym.imp.*
+FILE=../bins/elf/hello_world
+CMDS=<<EOF
+s sym.imp.strlen
+af
+afs
+EOF
+EXPECT=<<EOF
+size_t strlen (const char *s);
+EOF
+RUN
+
 NAME=td crash
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**

- [x]  I've read the guidelines for contributing to this repository
- [x] I made sure to follow the project's coding style
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the radare2 book with the relevant information (if needed)

**Detailed description**

afs was not showing return type and arguments for preloaded functions that start with sym.imp. This Pull Request fixes this.

**Test plan**

Write a test that shows the output of afs on a preloaded function signature, like sym.imp.puts.

**Closing issues**

...