### PR TITLE
Fix RRegisterType sign for drm command

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2811,7 +2811,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				r_debug_reg_sync (core->dbg, R_REG_TYPE_YMM, false);
 				r_debug_reg_list (core->dbg, R_REG_TYPE_YMM, 256, 0, 0);
 			} else { // drm
-				r_debug_reg_sync (core->dbg, -R_REG_TYPE_XMM, false);
+				r_debug_reg_sync (core->dbg, R_REG_TYPE_XMM, false);
 				r_debug_reg_list (core->dbg, R_REG_TYPE_XMM, 128, 0, 0);
 			}
 		}
@@ -2857,6 +2857,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			}
 			free (name);
 		} else {
+			//TODO: Do not use this hack to print fpu register
 			r_debug_reg_sync (core->dbg, -R_REG_TYPE_FPU, false);
 		}
 		break;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

- A negative RRegType is a hack used in linux_reg_read() to print fpu/xmm registers. This is not required for `drm` since it uses r_debug_reg_list() to print 
https://github.com/radareorg/radare2/blob/c1c54be39e3dc61367d5d08ab87bf11623fe8355/libr/debug/p/native/linux/linux_debug.c#L978-L986

- This hack is still required for `drf`

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Existing drm test in should not fail