### PR TITLE
Fix compilation with tree-sitter support

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5875,7 +5875,7 @@ DEFINE_HANDLE_TS_FCN(grep_command) {
 	r_strbuf_prepend (sb, "~");
 	char *specifier_str = r_cons_grep_strip (r_strbuf_get (sb), "`");
 	r_strbuf_free (sb);
-	specified_str = unescape_special_chars (specifier_str, SPECIAL_CHARS_REGULAR);
+	specifier_str = unescape_special_chars (specifier_str, SPECIAL_CHARS_REGULAR);
 	R_LOG_DEBUG ("grep_command processed specifier: '%s'\n", specifier_str);
 	r_cons_grep_process (specifier_str);
 	free (arg_str);


### PR DESCRIPTION
Fixes compilation when `-Duse_treesitter=true` is used.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes https://github.com/radareorg/radare2/issues/16196
