### PR TITLE
Fix wrong return value in error path

### DIFF
--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -92,7 +92,7 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	}
 	new_buf = malloc (count);
 	if (!new_buf) {
-		return -1;
+		return false;
 	}
 	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
 	if (count > mallocsz) {

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -92,7 +92,7 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	}
 	new_buf = malloc (count);
 	if (!new_buf) {
-		return -1;
+		return false;
 	}
 	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
 	if (count > mallocsz) {

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -184,7 +184,7 @@ static int __close(RIODesc *fd) {
 
 static bool __resize(RIO *io, RIODesc *fd, ut64 size) {
 	if (!fd || !fd->data) {
-		return -1;
+		return false;
 	}
 	return r_io_mmap_truncate ((RIOMMapFileObj*)fd->data, size);
 }


### PR DESCRIPTION
Returning -1 in a function with bool as return type is the same as returning
true. This is not the intended behaviour when e.g. allocation fails.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
If allocation fails, the functions should return false to indicate error. However, returning -1 in a boolean function is the same as returning true (since everything that is non-zero is true).
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
