### PR TITLE
Make r_reg_get_list() search harder 

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -3479,35 +3479,35 @@ static char *get_reg_profile(RAnal *anal) {
 		 "fpu    st6 .64 128  0\n"
 		 "fpu    st7 .64 144  0\n"
 
-		 "fpu    xmm0  .64 160  4\n"
+		 "xmm@fpu    xmm0  .128 160  4\n"
 		 "fpu    xmm0h .64 160  0\n"
 		 "fpu    xmm0l .64 168  0\n"
 
-		 "fpu    xmm1  .64 176  4\n"
+		 "xmm@fpu    xmm1  .128 176  4\n"
 		 "fpu    xmm1h .64 176  0\n"
 		 "fpu    xmm1l .64 184  0\n"
 
-		 "fpu    xmm2  .64 192  4\n"
+		 "xmm@fpu    xmm2  .128 192  4\n"
 		 "fpu    xmm2h .64 192  0\n"
 		 "fpu    xmm2l .64 200  0\n"
 
-		 "fpu    xmm3  .64 208  4\n"
+		 "xmm@fpu    xmm3  .128 208  4\n"
 		 "fpu    xmm3h .64 208  0\n"
 		 "fpu    xmm3l .64 216  0\n"
 
-		 "fpu    xmm4  .64 224  4\n"
+		 "xmm@fpu    xmm4  .128 224  4\n"
 		 "fpu    xmm4h .64 224  0\n"
 		 "fpu    xmm4l .64 232  0\n"
 
-		 "fpu    xmm5  .64 240  4\n"
+		 "xmm@fpu    xmm5  .128 240  4\n"
 		 "fpu    xmm5h .64 240  0\n"
 		 "fpu    xmm5l .64 248  0\n"
 
-		 "fpu    xmm6  .64 256  4\n"
+		 "xmm@fpu    xmm6  .128 256  4\n"
 		 "fpu    xmm6h .64 256  0\n"
 		 "fpu    xmm6l .64 264  0\n"
 
-		 "fpu    xmm7  .64 272  4\n"
+		 "xmm@fpu    xmm7  .128 272  4\n"
 		 "fpu    xmm7h .64 272  0\n"
 		 "fpu    xmm7l .64 280  0\n"
 		 "fpu    x64   .64 288  0\n");

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3921,11 +3921,10 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 			r_list_free (list);
 		}
 		break;
-	case 'r':
-		// registers
+	case 'r': // @@@r
 		{
 			ut64 offorig = core->offset;
-			for (i = 0; i < 128; i++) {
+			for (i = 0; i < R_REG_TYPE_LAST; i++) {
 				RRegItem *item;
 				ut64 value;
 				head = r_reg_get_list (dbg->reg, i);
@@ -3934,6 +3933,9 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 				}
 				r_list_foreach (head, iter, item) {
 					if (item->size != core->anal->bits) {
+						continue;
+					}
+					if (item->type != i) {
 						continue;
 					}
 					value = r_reg_get_value (dbg->reg, item);
@@ -3946,7 +3948,6 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 		}
 		break;
 	case 'i': // @@@i
-		// imports
 		{
 			RBinImport *imp;
 			ut64 offorig = core->offset;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2768,7 +2768,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 						} else {
 							ut64 val = r_num_math (core->num, eq);
 							r_reg_set_pack (core->dbg->reg, item, index, size, val);
-							r_debug_reg_sync (core->dbg, R_REG_TYPE_XMM, true);
+							r_debug_reg_sync (core->dbg, reg_type, true);
 						}
 					} else {
 						r_debug_reg_sync (core->dbg, reg_type, false);
@@ -2790,12 +2790,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 				RRegItem *item;
 				RList *head;
 				r_debug_reg_sync (core->dbg, reg_type, false);
-				if (reg_type == R_REG_TYPE_XMM) {
-					head = r_reg_get_list (core->dbg->reg,
-						R_REG_TYPE_FPU); // TODO: r_reg_get_list does not follow indirection
-				} else {
-					head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_YMM);
-				}
+				head = r_reg_get_list (core->dbg->reg, reg_type);
 				if (head) {
 					r_list_foreach (head, iter, item) {
 						if (item->type != reg_type) {

--- a/libr/core/cmd_search_rop.c
+++ b/libr/core/cmd_search_rop.c
@@ -170,7 +170,7 @@ static void fillRegisterValues (RCore *core) {
 	RRegItem *reg_item;
 	int nr = 10;
 
-	regs = r_reg_get_list (core->dbg->reg, 0);
+	regs = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 	if (!regs) {
 		return;
 	}
@@ -247,7 +247,7 @@ static char* rop_classify_constant(RCore *core, RList *ropList) {
 		}
 		// init regs with known values
 		fillRegisterValues (core);
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			ct = NULL;
 			goto continue_error;
@@ -268,7 +268,7 @@ static char* rop_classify_constant(RCore *core, RList *ropList) {
 		if (!r_list_find (ops_list, "=", (RListComparator)strcmp)) {
 			goto continue_error;
 		}
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			goto out_error;
 		}
@@ -327,7 +327,7 @@ static char* rop_classify_mov(RCore *core, RList *ropList) {
 	r_list_foreach (ropList, iter_r, esil_str) {
 		// init regs with known values
 		fillRegisterValues (core);
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			goto out_error;
 		}
@@ -350,7 +350,7 @@ static char* rop_classify_mov(RCore *core, RList *ropList) {
 			goto continue_error;
 		}
 
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			goto out_error;
 		}
@@ -426,7 +426,7 @@ static char* rop_classify_arithmetic(RCore *core, RList *ropList) {
 	r_list_foreach (ropList, iter_r, esil_str) {
 		// init regs with known values
 		fillRegisterValues (core);
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			goto out_error;
 		}
@@ -558,7 +558,7 @@ static char* rop_classify_arithmetic_const(RCore *core, RList *ropList) {
 		}
 		// init regs with known values
 		fillRegisterValues (core);
-		head = r_reg_get_list (core->dbg->reg, 0);
+		head = r_reg_get_list (core->dbg->reg, R_REG_TYPE_GPR);
 		if (!head) {
 			arithmetic = NULL;
 			continue;

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -83,7 +83,7 @@ R_API int r_debug_reg_sync(RDebug *dbg, int type, int write) {
 }
 
 R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char *use_color) {
-	int i, delta, from, to, cols, n = 0;
+	int delta, from, to, cols, n = 0;
 	const char *fmt, *fmt2, *kwhites;
 	RPrint *pr = NULL;
 	int colwidth = 20;
@@ -130,10 +130,9 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 
 	int itmidx = -1;
 	dbg->creg = NULL;
-	for (i = from; i < to; i++) {
-		head = r_reg_get_list (dbg->reg, i);
+		head = r_reg_get_list (dbg->reg, type);
 		if (!head) {
-			continue;
+			return false;
 		}
 		r_list_foreach (head, iter, item) {
 			ut64 value;
@@ -278,7 +277,6 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 			}
 			n++;
 		}
-	}
 beach:
 	if (rad == 'j') {
 		dbg->cb_printf ("}\n");

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -130,62 +130,62 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 
 	int itmidx = -1;
 	dbg->creg = NULL;
-		head = r_reg_get_list (dbg->reg, type);
-		if (!head) {
-			return false;
+	head = r_reg_get_list (dbg->reg, type);
+	if (!head) {
+		return false;
+	}
+	r_list_foreach (head, iter, item) {
+		ut64 value;
+		utX valueBig;
+		if (type != -1) {
+			if (type != item->type && R_REG_TYPE_FLG != item->type) {
+				continue;
+			}
+			if (size != 0 && size != item->size) {
+				continue;
+			}
 		}
-		r_list_foreach (head, iter, item) {
-			ut64 value;
-			utX valueBig;
-			if (type != -1) {
-				if (type != item->type && R_REG_TYPE_FLG != item->type) {
+		// Is this register being asked?
+		if (dbg->q_regs) {
+			if (!r_list_empty (dbg->q_regs)) {
+				RListIter *iterreg;
+				RList *q_reg = dbg->q_regs;
+				char *q_name;
+				bool found = false;
+				r_list_foreach (q_reg, iterreg, q_name) {
+					if (!strcmp (item->name, q_name)) {
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
 					continue;
 				}
-				if (size != 0 && size != item->size) {
-					continue;
-				}
-			}
-			// Is this register being asked?
-			if (dbg->q_regs) {
-				if (!r_list_empty (dbg->q_regs)) {
-					RListIter *iterreg;
-					RList *q_reg = dbg->q_regs;
-					char *q_name;
-					bool found = false;
-					r_list_foreach (q_reg, iterreg, q_name) {
-						if (!strcmp (item->name, q_name)) {
-							found = true;
-							break;
-						}
-					}
-					if (!found) {
-					        continue;
-					}
-					r_list_delete (q_reg, iterreg);
-				} else {
-					// List is empty, all requested regs were taken, no need to go further
-					goto beach;
-				}
-			}
-			int regSize = item->size;
-			if (regSize < 80) {
-				value = r_reg_get_value (dbg->reg, item);
-				r_reg_arena_swap (dbg->reg, false);
-				diff = r_reg_get_value (dbg->reg, item);
-				r_reg_arena_swap (dbg->reg, false);
-				delta = value-diff;
-				if (tolower ((ut8)rad) == 'j') {
-					snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
-				} else {
-					if (pr && pr->wide_offsets && dbg->bits & R_SYS_BITS_64) {
-						snprintf (strvalue, sizeof (strvalue),"0x%016"PFMT64x, value);
-					} else {
-						snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);
-					}
-				}
+				r_list_delete (q_reg, iterreg);
 			} else {
-				value = r_reg_get_value_big (dbg->reg, item, &valueBig);
-				switch (regSize) {
+				// List is empty, all requested regs were taken, no need to go further
+				goto beach;
+			}
+		}
+		int regSize = item->size;
+		if (regSize < 80) {
+			value = r_reg_get_value (dbg->reg, item);
+			r_reg_arena_swap (dbg->reg, false);
+			diff = r_reg_get_value (dbg->reg, item);
+			r_reg_arena_swap (dbg->reg, false);
+			delta = value-diff;
+			if (tolower ((ut8)rad) == 'j') {
+				snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
+			} else {
+				if (pr && pr->wide_offsets && dbg->bits & R_SYS_BITS_64) {
+					snprintf (strvalue, sizeof (strvalue),"0x%016"PFMT64x, value);
+				} else {
+					snprintf (strvalue, sizeof (strvalue),"0x%08"PFMT64x, value);
+				}
+			}
+		} else {
+			value = r_reg_get_value_big (dbg->reg, item, &valueBig);
+			switch (regSize) {
 				case 80:
 					snprintf (strvalue, sizeof (strvalue), "0x%04x%016"PFMT64x"", valueBig.v80.High, valueBig.v80.Low);
 					break;
@@ -197,20 +197,20 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 					break;
 				case 256:
 					snprintf (strvalue, sizeof (strvalue), "0x%016"PFMT64x"%016"PFMT64x"%016"PFMT64x"%016"PFMT64x"",
-						valueBig.v256.High.High, valueBig.v256.High.Low, valueBig.v256.Low.High, valueBig.v256.Low.Low);
+							valueBig.v256.High.High, valueBig.v256.High.Low, valueBig.v256.Low.High, valueBig.v256.Low.Low);
 					break;
 				default:
 					snprintf (strvalue, sizeof (strvalue), "ERROR");
-				}
-				delta = 0; // TODO: calculate delta with big values.
 			}
-			itmidx++;
+			delta = 0; // TODO: calculate delta with big values.
+		}
+		itmidx++;
 
-			switch (rad) {
+		switch (rad) {
 			case 'J':
 			case 'j':
 				dbg->cb_printf ("%s\"%s\":%s",
-					n?",":"", item->name, strvalue);
+						n?",":"", item->name, strvalue);
 				break;
 			case '-':
 				dbg->cb_printf ("f-%s\n", item->name);
@@ -240,7 +240,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 						dbg->cb_printf ("%s", use_color);
 					}
 					snprintf (content, sizeof (content),
-						fmt2, "", item->name, "", strvalue, "");
+							fmt2, "", item->name, "", strvalue, "");
 					len = colwidth - strlen (content);
 					if (len < 0) {
 						len = 0;
@@ -262,7 +262,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				if (delta) {
 					char woot[512];
 					snprintf (woot, sizeof (woot),
-						" was 0x%"PFMT64x" delta %d\n", diff, delta);
+							" was 0x%"PFMT64x" delta %d\n", diff, delta);
 					dbg->cb_printf (fmt, item->name, strvalue, woot);
 				}
 				break;
@@ -274,9 +274,9 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 					dbg->cb_printf (fmt, item->name, strvalue, "\n");
 				}
 				break;
-			}
-			n++;
 		}
+		n++;
+	}
 beach:
 	if (rad == 'j') {
 		dbg->cb_printf ("}\n");

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -328,10 +328,24 @@ R_API RRegItem *r_reg_get(RReg *reg, const char *name, int type) {
 }
 
 R_API RList *r_reg_get_list(RReg *reg, int type) {
+	RList *regs;
+	int i, mask;
+
 	if (type < 0 || type > (R_REG_TYPE_LAST - 1)) {
 		return NULL;
 	}
-	return reg->regset[type].regs;
+
+	regs = reg->regset[type].regs;
+	if (r_list_length (regs) == 0) {
+		mask = ((int)1 << type);
+		for (i = 0; i < R_REG_TYPE_LAST; i++) {
+			if (reg->regset[i].maskregstype & mask) {
+				regs = reg->regset[i].regs;
+			}
+		}
+	}
+
+	return regs;
 }
 
 // TODO regsize is in bits, delta in bytes, maybe we should standarize this..

--- a/test/new/db/cmd/cmd_repeats
+++ b/test/new/db/cmd/cmd_repeats
@@ -14,6 +14,20 @@ CMDS=<<EOF
 EOF
 RUN
 
+NAME=repeat registers
+FILE=-
+EXPECT=<<EOF
+xmm0h: 
+xmm0l: 
+EOF
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+?e @@@r~xmm0
+EOF
+RUN
+
+
 NAME=3p8
 FILE=-
 EXPECT=<<EOF

--- a/test/unit/test_reg.c
+++ b/test/unit/test_reg.c
@@ -167,6 +167,31 @@ bool test_r_reg_get(void) {
 	mu_end;
 }
 
+bool test_r_reg_get_list(void) {
+	RReg *reg;
+	RList *l;
+	int mask;
+
+	reg = r_reg_new ();
+	mu_assert_notnull (reg, "r_reg_new () failed");
+
+	bool success = r_reg_set_profile_string (reg,
+		"gpr		eax		.32	24	0\n\
+		fpu			sf0		.32	304	0\n\
+		xmm@fpu		xmm0	.64	160	4");
+	mu_assert_eq (success, true, "define eax, sf0 and xmm0 register");
+
+	mask = ((int)1 << R_REG_TYPE_XMM);
+	mu_assert_eq ((reg->regset[R_REG_TYPE_FPU].maskregstype & mask), mask,
+		"xmm0 stored as R_REG_TYPE_FPU");
+
+	l = r_reg_get_list (reg, R_REG_TYPE_XMM);
+	mu_assert_eq (r_list_length (l), 2, "sf0 and xmm0 stored as R_REG_TYPE_FPU");
+
+	r_reg_free (reg);
+	mu_end;
+}
+
 bool test_r_reg_get_pack(void) {
 	RReg *reg;
 	RRegItem *r;
@@ -215,6 +240,7 @@ int all_tests() {
 	mu_run_test (test_r_reg_get_value_gpr);
 	mu_run_test (test_r_reg_get_value_flag);
 	mu_run_test (test_r_reg_get);
+	mu_run_test (test_r_reg_get_list);
 	mu_run_test (test_r_reg_get_pack);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* Several register profiles use `@` for register type indirection
```
$ grep -IR "xmm@" libr/* | grep xmm0
libr/anal/p/anal_x86_cs.c:               "xmm@fpu    xmm0  .64 160  4\n"
libr/debug/p/native/reg/windows-x86.h:"xmm@gpr  xmm0    .128    364     0\n"
libr/debug/p/native/linux/reg/linux-x64.h:"xmm@fpu    xmm0    .128      160 16\n"
```
* This PR implement register type indirection in r_reg_get_list() using type mask
* Remove forced type indirection search from r_debug_reg_list() and `@@@r`  

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

* Added unit test for register type indirection should pass
* Added @@@r test should pass 
