### PR TITLE
Clean drx/drt/drp help message

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -362,9 +362,7 @@ static const char *help_msg_dr[] = {
 	"drt", " flg", "Show flag registers",
 	"drt", "[?]", "Show all register types",
 	"drw"," <hexnum>", "Set contents of the register arena",
-	"drx", "[?]", "Show all debug registers",
-	"drx", " idx addr len perm", "Modify hardware breakpoint",
-	"drx-", "number", "Clear hardware breakpoint",
+	"drx", "[?]", "Show debug registers",
 	".dr", "*", "Include common register values in flags",
 	".dr", "-", "Unflag all registers",
 	NULL

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -345,12 +345,7 @@ static const char *help_msg_dr[] = {
 	"drm", "[?]", "Show multimedia packed registers",
 	//	"drm", " xmm0 0 32 = 12", "Set the first 32 bit word of the xmm0 reg to 12", // Do not advertise - broken
 	"dro", "", "Show previous (old) values of registers",
-	"drp", "", "Display current register profile",
-	"drp", "[?] <file>", "Load register metadata file",
-	"drpc", "", "Show register profile comments",
-	"drpi", "", "Display current internal representation of the register profile",
-	"drps", "", "Fake register profile size",
-	"drpj", "", "Show the current register profile (JSON)",
+	"drp", "[?] ", "Display current register profile",
 	"drr", "", "Show registers references (telescoping)",
 	"drrj", "", "Show registers references (telescoping) in JSON format",
 	// TODO: 'drs' to swap register arenas and display old register valuez
@@ -368,6 +363,7 @@ static const char *help_msg_drp[] = {
 	"drp", "", "Show the current register profile",
 	"drp", " [regprofile-file]", "Set the current register profile",
 	"drp", " [gdb] [regprofile-file]", "Parse gdb register profile and dump an r2 profile string",
+	"drpc", "", "Show register profile comments",
 	"drpi", "", "Show internal representation of the register profile",
 	"drp.", "", "Show the current fake size",
 	"drpj", "", "Show the current register profile (JSON)",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -355,11 +355,6 @@ static const char *help_msg_dr[] = {
 	"drrj", "", "Show registers references (telescoping) in JSON format",
 	// TODO: 'drs' to swap register arenas and display old register valuez
 	"drs", "[?]", "Stack register states",
-	"drt", " 16", "Show 16 bit registers",
-	"drt", " 32", "Show 32 bit registers",
-	"drt", " 80", "Show 80 bit registers (long double)",
-	"drt", " all", "Show all registers",
-	"drt", " flg", "Show flag registers",
 	"drt", "[?]", "Show all register types",
 	"drw"," <hexnum>", "Set contents of the register arena",
 	"drx", "[?]", "Show debug registers",
@@ -390,11 +385,15 @@ static const char *help_msg_drs[] = {
 
 static const char *help_msg_drt[] = {
 	"Usage:", "drt", " [type] [size]    # debug register types",
-	"drt", "[*j]", "List all available register types",
-	"drt", "[*j] [size]", "Show all regs in the profile of size",
-	"drt", "[*j] [type]", "Show all regs in the profile of this type",
-	"drt", "[*j] [type] [size]", "Same as above for type and size",
-	"drt", "[*j] [type] [size]", "Same as above for type and size",
+	"drt", "", "List all available register types",
+	"drt", " [size]", "Show all regs in the profile of size",
+	"drt", " 16", "Show 16 bit registers",
+	"drt", " [type]", "Show all regs in the profile of this type",
+	"drt", " all", "Show all registers",
+	"drt", " fpu", "Show fpu registers",
+	"drt", " [type] [size]", "Same as above for type and size",
+	"drt", " [type] [size]", "Same as above for type and size",
+	"drt*", "", "List flags in r commands",
 	NULL
 };
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* `drx` before 
```
[0x7fcc122ba100]> dr?~drx
| drx[?]                 Show all debug registers
| drx idx addr len perm  Modify hardware breakpoint
| drx-number             Clear hardware breakpoint
[0x7fcc122ba100]> drx?
Usage: drx   Hardware breakpoints commands
| drx                                      List all (x86?) hardware breakpoints
| drx <number> <address> <length> <perms>  Modify hardware breakpoint
| drx-<number>                             Clear hardware breakpoint
[0x7fcc122ba100]> 
```
* `drx` after 
```
[0x7f33d7dc8100]> dr?~drx
| drx[?]               Show debug registers
[0x7f33d7dc8100]> drx?
Usage: drx   Hardware breakpoints commands
| drx                                      List all (x86?) hardware breakpoints
| drx <number> <address> <length> <perms>  Modify hardware breakpoint
| drx-<number>                             Clear hardware breakpoint
[0x7f33d7dc8100]> 
```
* `drt` before 
```
[0x7f33d7dc8100]> dr?~drt
| drt 16               Show 16 bit registers
| drt 32               Show 32 bit registers
| drt 80               Show 80 bit registers (long double)
| drt all              Show all registers
| drt flg              Show flag registers
| drt[?]               Show all register types
[0x7f33d7dc8100]> drt?
Usage: drt   [type] [size]    # debug register types
| drt[*j]                List all available register types
| drt[*j] [size]         Show all regs in the profile of size
| drt[*j] [type]         Show all regs in the profile of this type
| drt[*j] [type] [size]  Same as above for type and size
| drt[*j] [type] [size]  Same as above for type and size
[0x7f33d7dc8100]> 

```
* `drt` after 
```
[0x7f86d11b9100]> dr?~drt
| drt[?]               Show all register types
[0x7f86d11b9100]> drt?
Usage: drt   [type] [size]    # debug register types
| drt                List all available register types
| drt [size]         Show all regs in the profile of size
| drt 16             Show 16 bit registers
| drt [type]         Show all regs in the profile of this type
| drt all            Show all registers
| drt fpu            Show fpu registers
| drt [type] [size]  Same as above for type and size
| drt [type] [size]  Same as above for type and size
| drt*               List flags in r commands
[0x7f86d11b9100]> 

```
* `drp` before
```
[0x7f86d11b9100]> dr?~drp
| dr??                 Same as dr?`drp~=[0]+` # list all reg roles alias names and values
| drp                  Display current register profile
| drp[?] <file>        Load register metadata file
| drpc                 Show register profile comments
| drpi                 Display current internal representation of the register profile
| drps                 Fake register profile size
| drpj                 Show the current register profile (JSON)
[0x7f86d11b9100]> drp?
Usage: drp   # Register profile commands
| drp                          Show the current register profile
| drp [regprofile-file]        Set the current register profile
| drp [gdb] [regprofile-file]  Parse gdb register profile and dump an r2 profile string
| drpi                         Show internal representation of the register profile
| drp.                         Show the current fake size
| drpj                         Show the current register profile (JSON)
| drps [new fake size]         Set the fake size
[0x7f86d11b9100]>
``` 
* `drp` after
```
[0x7f5c40f95100]> dr?~drp
| dr??                 Same as dr?`drp~=[0]+` # list all reg roles alias names and values
| drp[?]               Display current register profile
[0x7f5c40f95100]> drp?
Usage: drp   # Register profile commands
| drp                          Show the current register profile
| drp [regprofile-file]        Set the current register profile
| drp [gdb] [regprofile-file]  Parse gdb register profile and dump an r2 profile string
| drpc                         Show register profile comments
| drpi                         Show internal representation of the register profile
| drp.                         Show the current fake size
| drpj                         Show the current register profile (JSON)
| drps [new fake size]         Set the fake size
[0x7f5c40f95100]> 
```