### PR TITLE
Fix debug rebase regressions

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -77,6 +77,7 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 	if (isdebug) {
 		r_debug_kill (core->dbg, core->dbg->pid, core->dbg->tid, 9); // SIGKILL
 		r_debug_continue (core->dbg);
+		r_debug_detach (core->dbg, core->dbg->pid);
 		perm = 7;
 	} else {
 		if (!perm) {

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1118,9 +1118,9 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 	char *newfile = r_str_newf ("dbg://%s %s", escaped_path, args);
 	desc->uri = newfile;
 	desc->referer = NULL;
-	r_core_file_reopen (core, newfile, 0, 2);
 	r_config_set_i (core->config, "asm.bits", bits);
 	r_config_set_i (core->config, "cfg.debug", true);
+	r_core_file_reopen (core, newfile, 0, 2);
 	if (r_config_get_i (core->config, "dbg.rebase")) {
 		__rebase_everything (core, old_sections, old_base);
 	}

--- a/test/new/db/archos/linux-x64/dbg_aslr
+++ b/test/new/db/archos/linux-x64/dbg_aslr
@@ -8,3 +8,88 @@ pop esi
 mov ecx, esp
 EOF
 RUN
+
+NAME=function rebase
+FILE=../bins/elf/analysis/pie
+ARGS=-d
+CMDS=<<EOF
+?v main-`dmm~pie[0]`
+doc
+?v main-`dmm~pie[0]`
+EOF
+EXPECT=<<EOF
+0x5c5
+0x5c5
+EOF
+RUN
+
+NAME=bp rebase
+FILE=../bins/elf/analysis/pie
+ARGS=-d
+CMDS=<<EOF
+aa
+db main
+?v main-`db~main[0]`
+doc
+?v main-`db~main[0]`
+EOF
+EXPECT=<<EOF
+0x0
+0x0
+EOF
+RUN
+
+NAME=ref rebase
+FILE=../bins/elf/hello_world
+ARGS=-d
+CMDS=<<EOF
+aa
+?v `axt main~entry0[1]`-`e bin.baddr`
+doc
+?v `axt main~entry0[1]`-`e bin.baddr`
+EOF
+EXPECT=<<EOF
+0x6bd
+0x6bd
+EOF
+RUN
+
+NAME=flag rebase
+FILE=../bins/elf/analysis/pie
+ARGS=-d
+CMDS=<<EOF
+aa
+fs test
+f testflag @ main+10
+?v `f~testflag[0]`-`e bin.baddr`
+doc
+?v `f~testflag[0]`-`e bin.baddr`
+EOF
+EXPECT=<<EOF
+0x5cf
+0x5cf
+EOF
+RUN
+
+NAME=var rebase
+FILE=../bins/elf/hello_world
+ARGS=-d
+CMDS=<<EOF
+aa
+afv @ main
+doc
+afv @ main
+EOF
+EXPECT=<<EOF
+var int64_t var_20h @ rbp-0x20
+var int64_t var_1ch @ rbp-0x1c
+var int64_t var_18h @ rbp-0x18
+var int64_t var_10h @ rbp-0x10
+var int64_t var_8h @ rbp-0x8
+var int64_t var_20h @ rbp-0x20
+var int64_t var_1ch @ rbp-0x1c
+var int64_t var_18h @ rbp-0x18
+var int64_t var_10h @ rbp-0x10
+var int64_t var_8h @ rbp-0x8
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

PR #16131 broke debug rebase by changing the order in which cfg.debug was set, causing r_core_file_reopen to treat the debugee as a regular file and skip the baseaddr calculation.

Working on improving `rb` to add rebase tests.

**Test plan**

Execute `ood` and see that xrefs, breakpoints, functions, vars and flags are properly rebased.

**Closing issues**
closes #16159 
