### PR TITLE
Fix socket connection issue

### DIFF
--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -108,9 +108,17 @@ R_API bool r_socket_is_connected(RSocket *s) {
 	r_socket_block_time (s, 1, 0, 0);
 	return ret == 1;
 #else
-	char buf[2];
-	int ret = recv (s->fd, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
-	return ret == 1;
+	int error = 0;
+	socklen_t len = sizeof (error);
+	int ret = getsockopt (s->fd, SOL_SOCKET, SO_ERROR, &error, &len);
+	if (ret != 0) {
+		perror ("getsockopt");
+		return false;
+	}
+	if (error != 0) {
+		return false;
+	}
+	return true;
 #endif
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

PR #16073 exposed that the linux implementation of r_socket_is_connected returned -1 from recv with errno set to EAGAIN. This broke gdbr and probably other remote capabilities since r_socket_connect would fail. I switched the implementation to getsockopt which is more reliable instead of playing with non blocking settings.
Windows doesn't have this issue.

**Test plan**

Connect to gdbserver with `oodf gdb://ip:port` and see that it didn't fail.