### PR TITLE
Add pj_r api to print raw data

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1216,7 +1216,6 @@ static int cmdSearch(void *data, const char *input) {
 		eprintf ("usage: z/[*]\n");
 		return false;
 	}
-
 	return true;
 }
 
@@ -1233,38 +1232,39 @@ static int cmdInfo(void *data, const char *input) {
 
 static int cmd_zign(void *data, const char *input) {
 	RCore *core = (RCore *) data;
+	const char *arg = input + 1;
 
 	switch (*input) {
 	case '\0':
 	case '*':
 	case 'q':
 	case 'j': // "zj"
-		r_sign_list (core->anal, input[0]);
+		r_sign_list (core->anal, *input);
 		break;
 	case 'k': // "zk"
 		r_core_cmd0 (core, "k anal/zigns/*");
 		break;
 	case '-': // "z-"
-		r_sign_delete (core->anal, input + 1);
+		r_sign_delete (core->anal, arg);
 		break;
 	case '.': // "z."
-		return cmdCheck (data, input + 1);
+		return cmdCheck (data, arg);
 	case 'o': // "zo"
-		return cmdOpen (data, input + 1);
+		return cmdOpen (data, arg);
 	case 'g': // "zg"
 		return cmdAdd (data, "F");
 	case 'a': // "za"
-		return cmdAdd (data, input + 1);
+		return cmdAdd (data, arg);
 	case 'f': // "zf"
-		return cmdFlirt (data, input + 1);
+		return cmdFlirt (data, arg);
 	case '/': // "z/"
-		return cmdSearch (data, input + 1);
+		return cmdSearch (data, arg);
 	case 'c': // "zc"
-		return cmdCompare (data, input + 1);
+		return cmdCompare (data, arg);
 	case 's': // "zs"
-		return cmdSpace (data, input + 1);
+		return cmdSpace (data, arg);
 	case 'i': // "zi"
-		return cmdInfo (data, input + 1);
+		return cmdInfo (data, arg);
 	case '?': // "z?"
 		r_core_cmd_help (core, help_msg_z);
 		break;

--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -39,6 +39,8 @@ R_API PJ *pj_kd(PJ *j, const char *k, double d);
 R_API PJ *pj_kf(PJ *j, const char *k, float d);
 R_API PJ *pj_kb(PJ *j, const char *k, bool v);
 R_API PJ *pj_null(PJ *j);
+R_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len);
+R_API PJ *pj_kr(PJ *j, const char *name, const unsigned char *v, size_t v_len);
 R_API PJ *pj_b(PJ *j, bool v);
 R_API PJ *pj_s(PJ *j, const char *k);
 R_API PJ *pj_n(PJ *j, ut64 n);

--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -40,7 +40,7 @@ R_API PJ *pj_kf(PJ *j, const char *k, float d);
 R_API PJ *pj_kb(PJ *j, const char *k, bool v);
 R_API PJ *pj_null(PJ *j);
 R_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len);
-R_API PJ *pj_kr(PJ *j, const char *name, const unsigned char *v, size_t v_len);
+R_API PJ *pj_kr(PJ *j, const char *k, const unsigned char *v, size_t v_len);
 R_API PJ *pj_b(PJ *j, bool v);
 R_API PJ *pj_s(PJ *j, const char *k);
 R_API PJ *pj_n(PJ *j, ut64 n);

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -194,9 +194,27 @@ R_API PJ *pj_s(PJ *j, const char *k) {
 		pj_raw (j, ek);
 		free (ek);
 	} else {
-		eprintf ("damn\n");
+		eprintf ("cannot escape string\n");
 	}
 	pj_raw (j, "\"");
+	return j;
+}
+
+R_API PJ *pj_r(PJ *j, const unsigned char *v, size_t v_len) {
+	r_return_val_if_fail (j && v, j);
+	size_t i;
+	pj_a (j);
+	for (i = 0; i < v_len; i++) {
+		pj_i (j, v[i]);
+	}
+	pj_end (j);
+	return j;
+}
+
+R_API PJ *pj_kr(PJ *j, const char *k, const unsigned char *v, size_t v_len) {
+	r_return_val_if_fail (j && k && v, j);
+	pj_k (j, k);
+	pj_r (j, v, v_len);
 	return j;
 }
 


### PR DESCRIPTION
not sure if it will be better to print raw data as an array of numbers like [2,34,32,159,..] and just keep that string function as is, with null terminated strings only.

another option would be to have another api for non-null terminated strings