### PR TITLE
Fix chunk listing with tcache

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -380,7 +380,7 @@ void GH(print_heap_chunk)(RCore *core) {
 	free (cnk);
 }
 
-static bool GH(is_arena) (RCore *core, GHT m_arena, GHT m_state) {
+static bool GH(is_arena)(RCore *core, GHT m_arena, GHT m_state) {
 	if (m_arena == m_state) {
 		return true;
 	}
@@ -857,8 +857,14 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
 		if (tcache) {
-			tcache_initial_brk = ((brk_start >> 12) << 12) + TC_HDR_SZ;
-			initial_brk = tcache_initial_brk + offset;
+			GH(RHeapChunk) *cnk = R_NEW0 (GH(RHeapChunk));
+			if (!cnk) {
+				return;
+			}
+			(void)r_io_read_at (core->io, brk_start, (ut8 *)cnk, sizeof (GH(RHeapChunk)));
+			int tc_chunk_size = (cnk->size >> 3) << 3;
+			tcache_initial_brk = ((brk_start >> 12) << 12) + tc_chunk_size;
+			initial_brk = tcache_initial_brk;
 		} else {
 			initial_brk = (brk_start >> 12) << 12;
 		}

--- a/test/new/db/archos/linux-x64/cmd_dmh
+++ b/test/new/db/archos/linux-x64/cmd_dmh
@@ -13,3 +13,19 @@ EXPECT=<<EOF
 p=3
 EOF
 RUN
+
+NAME=dmh allocated
+FILE=../bins/elf/simple_malloc_x86_64
+ARGS=-d
+CMDS=<<EOF
+dcu main
+dmh~?allocated
+7dso
+dmh~?allocated
+EOF
+EXPECT=<<EOF
+1
+2
+p=3
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
- `dmh` was broken because it uses a hardcoded offset from dbg.glibc.fc_offset
- This PR use tcache chunk size to find the next chunk
- Please do not close yet. There are several other places that uses fc_offset that I would like to fix in this PR
```
$ grep -IR fc_offset libr/*
libr/core/cconfig.c:    SETI ("dbg.glibc.fc_offset", 0x00240, "First chunk offset from brk_start");
libr/core/cconfig.c:    SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
libr/core/linux_heap_glibc.c:           const int fc_offset = r_config_get_i (core->config, "dbg.glibc.fc_offset");
libr/core/linux_heap_glibc.c:           initial_brk = ( (brk_start >> 12) << 12 ) + fc_offset;
libr/core/linux_heap_glibc.c:   const int offset = r_config_get_i (core->config, "dbg.glibc.fc_offset");
libr/core/linux_heap_glibc.c:   const int offset = r_config_get_i (core->config, "dbg.glibc.fc_offset");
libr/main/radare2.c:                                                    eprintf ("glibc.fc_offset = 0x00148\n");
libr/main/radare2.c:                                                    r_config_set_i (r->config, "dbg.glibc.fc_offset", 0x00148);
```
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

- A test has been added to count allocated chunk. Result has been compared with gdb-gef

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #16206 
