### PR TITLE
Idea for fixing id? and idp? etc commands

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -493,8 +493,8 @@ static int cmd_info(void *data, const char *input) {
 	}
 	if (question < space && question > input) {
 		question--;
-		char *prefix = strdup(input);
-		char *tmp = strchr(prefix, '?');
+		char *prefix = strdup (input);
+		char *tmp = strchr (prefix, '?');
 		*tmp = 0;
 		r_core_cmdf (core, "i?~& i%s", prefix);
 		free(prefix);

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -24,8 +24,11 @@ static const char *help_msg_i[] = {
 	"icq", "", "List classes, in quiet mode (just the classname)",
 	"icqq", "", "List classes, in quieter mode (only show non-system classnames)",
 	"iC", "[j]", "Show signature info (entitlements, ...)",
-	"id", "[?]", "Debug information (source lines)",
-	"idp", "", "Load pdb file information",
+	"id", "", "Show DWARF source lines information",
+	"idp", " [file.pdb]", "Load pdb file information",
+	"idpi", " [file.pdb]", "Show pdb file information",
+	"idpi*", "", "Show symbols from pdb as flags (prefix with dot to import)",
+	"idpd", "", "Download pdb file on remote server",
 	"iD", " lang sym", "demangle symbolname for given language",
 	"ie", "", "Entrypoint",
 	"iee", "", "Show Entry and Exit (preinit, init and fini)",
@@ -490,7 +493,11 @@ static int cmd_info(void *data, const char *input) {
 	}
 	if (question < space && question > input) {
 		question--;
-		r_core_cmdf (core, "i?~& i%c", *question);
+		char *prefix = strdup(input);
+		char *tmp = strchr(prefix, '?');
+		*tmp = 0;
+		r_core_cmdf (core, "i?~& i%s", prefix);
+		free(prefix);
 		goto done;
 	}
 	R_FREE (core->table_query);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

So I've noticed some weird input on id? and idp? commands (id? give incomplete output and idp? gives nothing) so I had a look into cmd_info.c, looked into the state machine and it didn't make sense, because the handling of ? there should print something else, but it didn't even get executed.

Then I noticed that there is handling of commands that have '?' in them right before the state machine starts, problem is that command only uses "help_msg_i" array and id... command info is inside "help_msg_id", second problem was it takes only last char that it appends to the 'i', so "idp?" would result in search for commands that start with "ip". I guess this wasn't intentional so I've PRed this hopefully fix, that takes the strings from "help_msg_id" into the "help_msg_i", keeping the "help_msg_id", because its still being used in the state machine and instead of taking the last char I  search for the whole string prefix before '?', so "idp?" prints everything that start with "idp" now. Right now also "idp???" prints everything starting on "idp" and not "idp??" because I am taking everything before the first '?', but I can switch it to use the last one.

Before
```
[0x00001100]> id?
| id[?]              Debug information (source lines)
| idp                Load pdb file information
[0x00001100]> idp?
[0x00001100]>
```
Now
```
[0x00001100]> id?
| id                 Show DWARF source lines information
| idp [file.pdb]     Load pdb file information
| idpi [file.pdb]    Show pdb file information
| idpi*              Show symbols from pdb as flags (prefix with dot to import)
| idpd               Download pdb file on remote server
[0x00001100]> idp?
| idp [file.pdb]     Load pdb file information
| idpi [file.pdb]    Show pdb file information
| idpi*              Show symbols from pdb as flags (prefix with dot to import)
| idpd               Download pdb file on remote server
[0x00001100]> 
```