### PR TITLE
Fix dmht for glibc caused by wrong tcache offset and definition

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2936,7 +2936,7 @@ R_API int r_core_config_init(RCore *core) {
 #endif
 #if __x86_64__
 	SETI ("dbg.glibc.ma_offset", 0x000000, "Main_arena offset from his symbol");
-	SETI ("dbg.glibc.fc_offset", 0x00240, "First chunk offset from brk_start");
+	SETI ("dbg.glibc.fc_offset", 0x00280, "First chunk offset from brk_start");
 #else
 	SETI ("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
 	SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -792,8 +792,9 @@ static void GH(print_tcache_instance)(RCore *core, GHT m_arena, MallocState *mai
 	const int offset = r_config_get_i (core->config, "dbg.glibc.fc_offset");
 	RConsPrintablePalette *pal = &r_cons_singleton ()->context->pal;
 
-	tcache_start = ((brk_start >> 12) << 12) + TC_HDR_SZ;
-	initial_brk = tcache_start + offset;
+	tcache_start = ((brk_start >> 12) << 12) + GH(HDR_SZ);
+	GHT fc_offset = GH(tcache_chunk_size) (core, brk_start);
+	initial_brk = brk_start + fc_offset;
 	if (brk_start == GHT_MAX || brk_end == GHT_MAX || initial_brk == GHT_MAX) {
 		eprintf ("No heap section\n");
 		return;

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -141,12 +141,12 @@ typedef struct r_malloc_state_64 {
 } RHeap_MallocState_64;
 
 typedef struct r_tcache_perthread_struct_32 {
-	ut8 counts[TCACHE_MAX_BINS];
+	ut16 counts[TCACHE_MAX_BINS];
 	ut32 entries[TCACHE_MAX_BINS];
 } RHeapTcache_32;
 
 typedef struct r_tcache_perthread_struct_64 {
-	ut8 counts[TCACHE_MAX_BINS];
+	ut16 counts[TCACHE_MAX_BINS];
 	ut64 entries[TCACHE_MAX_BINS];
 } RHeapTcache_64;
 

--- a/test/new/db/archos/linux-x64/dbg_dmh
+++ b/test/new/db/archos/linux-x64/dbg_dmh
@@ -50,3 +50,22 @@ EXPECT=<<EOF
 2
 EOF
 RUN
+
+NAME=dmht with memory dump
+FILE=../bins/heap/linux_glibc_x64.bin
+ARGS=-n
+CMDS=<<EOF
+#re-map arena and [heap]
+om 3 0x7ffff7f8a000 0x898 0x0 rw- arena
+om 3 0x555555559000 0x3200 0x898 rw- [heap]
+
+e dbg.glibc.tcache=0
+dmht~?items[5]
+e dbg.glibc.tcache=1
+dmht~?items[5]
+EOF
+EXPECT=<<EOF
+0
+1
+EOF
+RUN

--- a/test/new/db/archos/linux-x64/dbg_dmh
+++ b/test/new/db/archos/linux-x64/dbg_dmh
@@ -31,7 +31,7 @@ EOF
 RUN
 
 NAME=dmh/dmha with memory dump
-FILE=../bins/heap/linux_glibc_x64.bin
+FILE=../bins/heap/linux_glibc-2.30_x64.bin
 ARGS=-n
 CMDS=<<EOF
 #re-map arena and [heap]
@@ -52,7 +52,7 @@ EOF
 RUN
 
 NAME=dmht with memory dump
-FILE=../bins/heap/linux_glibc_x64.bin
+FILE=../bins/heap/linux_glibc-2.30_x64.bin
 ARGS=-n
 CMDS=<<EOF
 #re-map arena and [heap]


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Related to PR #16239, `dmht` does not show freed tcache chunk  due to wrong tcache size and definition. 
...

**Test plan**
- Result has been compared with gdb-gef
- Pass added test
