### PR TITLE
Add r_strf API to create short strings on the stack as they are needed

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -174,6 +174,7 @@ R_API void public() {}     ## public apis starting with constructor/destructor
 
 ```
 
+* Use `r_strf` and `r_strf_multi` when you need to construct strings with a size that is short and known at programming time. These functions allocate strings on the stack, so do not abuse them.
 
 * Why return int vs enum
 

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -22,14 +22,14 @@
 #define MU_TEST_UNBROKEN 0
 #define MU_TEST_BROKEN 1
 
-void sprint_mem(char *out, const ut8 *buf, size_t len) {
+void snprint_mem(char *out, size_t out_sz, const ut8 *buf, size_t len) {
 	size_t i;
 	*out = '\0';
 	for (i = 0; i < len; i++) {
 		if (i > 0) {
-			sprintf(out + strlen(out), " ");
+			snprintf(out + strlen(out), out_sz - strlen (out), " ");
 		}
-		sprintf (out + strlen(out), "%02x", buf[i]);
+		snprintf (out + strlen(out), out_sz - strlen (out), "%02x", buf[i]);
 	}
 }
 
@@ -71,7 +71,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		__typeof__(expected) exp__ = (expected); \
 		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
-			sprintf(_meqstr, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
+			snprintf(_meqstr, sizeof (_meqstr), "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
@@ -80,7 +80,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		char _meqstr[2048]; \
 		__typeof__(actual) act__ = (actual); \
 		__typeof__(expected) exp__ = (expected); \
-		sprintf(_meqstr, "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (exp__), (act__)); \
+		snprintf(_meqstr, sizeof (_meqstr), "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (exp__), (act__)); \
 		mu_assert(_meqstr, (exp__) != (act__)); \
 	} while(0)
 
@@ -88,7 +88,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		char _meqstr[2048]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
-		sprintf (_meqstr, "%s: expected %p, got %p.", (message), (exp__), (act__)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected %p, got %p.", (message), (exp__), (act__)); \
 		mu_assert (_meqstr, (exp__) == (act__)); \
 	} while (0)
 
@@ -96,21 +96,21 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		char _meqstr[2048]; \
 		const void *act__ = (actual); \
 		const void *exp__ = (expected); \
-		sprintf (_meqstr, "%s: expected not %p, got %p.", (message), (exp__), (act__)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected not %p, got %p.", (message), (exp__), (act__)); \
 		mu_assert (_meqstr, (exp__) != (act__)); \
 	} while (0)
 
 #define mu_assert_null(actual, message) do {			\
 		char _meqstr[2048];					\
 		const void *act__ = (actual); \
-		sprintf(_meqstr, "%s: expected to be NULL but it wasn't.", (message)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected to be NULL but it wasn't.", (message)); \
 		mu_assert(_meqstr, (act__) == NULL);		\
 	} while(0)
 
 #define mu_assert_notnull(actual, message) do {				\
 		char _meqstr[2048];					\
 		const void *act__ = (actual); \
-		sprintf(_meqstr, "%s: expected to not be NULL but it was.", (message)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected to not be NULL but it was.", (message)); \
 		mu_assert(_meqstr, (act__) != NULL);			\
 	} while(0)
 
@@ -119,7 +119,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		__typeof__(expected) exp__ = (expected); \
 		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
-			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \
+			snprintf (_meqstr, sizeof (_meqstr), "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \
 			mu_assert(_meqstr, false); \
 		} \
 	} while(0)
@@ -128,15 +128,23 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		char _meqstr[2048]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
-		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__), (act__)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected %s, got %s.", (message), (exp__), (act__)); \
 		mu_assert(_meqstr, strcmp((exp__), (act__)) == 0); \
 } while(0)
+
+#define mu_assert_strneq(actual, expected, message) do { \
+		char _meqstr[2048]; \
+		const char *act__ = (actual); \
+		const char *exp__ = (expected); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected %s, got %s.", (message), (exp__), (act__)); \
+		mu_assert (_meqstr, strcmp ((exp__), (act__)) != 0); \
+	} while (0)
 
 #define mu_assert_nullable_streq(actual, expected, message) do { \
 		char _meqstr[2048]; \
 		const char *act__ = (actual); \
 		const char *exp__ = (expected); \
-		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__ ? exp__ : "NULL"), (act__ ? act__ : "NULL")); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected %s, got %s.", (message), (exp__ ? exp__ : "NULL"), (act__ ? act__ : "NULL")); \
 		mu_assert(_meqstr, ((act__) == NULL && (exp__) == NULL) || ((act__) != NULL && (exp__) != NULL && strcmp((exp__), (act__)) == 0)); \
 } while(0)
 
@@ -144,10 +152,10 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		char _meqstr[2048]; \
 		const ut8 *act__ = (actual); \
 		const ut8 *exp__ = (expected); \
-		sprintf(_meqstr, "%s: expected ", message); \
-		sprint_mem(_meqstr + strlen(_meqstr), (exp__), (len)); \
-		sprintf(_meqstr + strlen(_meqstr), ", got "); \
-		sprint_mem(_meqstr + strlen(_meqstr), (act__), (len)); \
+		snprintf (_meqstr, sizeof (_meqstr), "%s: expected ", message); \
+		snprint_mem(_meqstr + strlen(_meqstr), sizeof (_meqstr), (exp__), (len)); \
+		snprintf(_meqstr + strlen(_meqstr), sizeof (_meqstr) - strlen (_meqstr), ", got "); \
+		snprint_mem(_meqstr + strlen(_meqstr), sizeof (_meqstr), (act__), (len)); \
 		mu_assert(_meqstr, memcmp((exp__), (act__), (len)) == 0); \
 } while(0)
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Alternative implementation to what's done in https://github.com/radareorg/radare2/pull/16112 . There are comments in the file for additional details and full tests. This has the advantage of not having to define a fixed size, but it reallocates as needed. All the code in the macro is easily removed/reduced by the compiler itself when compiled with optimizations.