### PR TITLE
Fix minunit.h to compute macro arguments just one time

### DIFF
--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -67,72 +67,88 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 #define mu_sysfail(message) do { perror(message); mu_fail(message); } while(0)
 
 #define mu_assert_eq(actual, expected, message) do { \
-		if ((expected) != (actual)) { \
+		__typeof__(actual) act__ = (actual); \
+		__typeof__(expected) exp__ = (expected); \
+		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
-			sprintf(_meqstr, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(expected), (ut64)(actual)); \
+			sprintf(_meqstr, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
 			mu_assert(_meqstr, false); \
 		} \
-} while(0)
+	} while(0)
 
 #define mu_assert_neq(actual, expected, message) do { \
 		char _meqstr[2048]; \
-		sprintf(_meqstr, "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (expected), (actual)); \
-		mu_assert(_meqstr, (expected) != (actual)); \
-} while(0)
+		__typeof__(actual) act__ = (actual); \
+		__typeof__(expected) exp__ = (expected); \
+		sprintf(_meqstr, "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (exp__), (act__)); \
+		mu_assert(_meqstr, (exp__) != (act__)); \
+	} while(0)
 
 #define mu_assert_ptreq(actual, expected, message) do {	\
-	char _meqstr[2048]; \
-	sprintf (_meqstr, "%s: expected %p, got %p.", (message), (expected), (actual)); \
-	mu_assert (_meqstr, (expected) == (actual)); \
-} while (0)
+		char _meqstr[2048]; \
+		const void *act__ = (actual); \
+		const void *exp__ = (expected); \
+		sprintf (_meqstr, "%s: expected %p, got %p.", (message), (exp__), (act__)); \
+		mu_assert (_meqstr, (exp__) == (act__)); \
+	} while (0)
 
 #define mu_assert_ptrneq(actual, expected, message) do { \
-	char _meqstr[2048]; \
-	sprintf (_meqstr, "%s: expected not %p, got %p.", (message), (expected), (actual)); \
-	mu_assert (_meqstr, (expected) != (actual)); \
-} while (0)
+		char _meqstr[2048]; \
+		const void *act__ = (actual); \
+		const void *exp__ = (expected); \
+		sprintf (_meqstr, "%s: expected not %p, got %p.", (message), (exp__), (act__)); \
+		mu_assert (_meqstr, (exp__) != (act__)); \
+	} while (0)
 
 #define mu_assert_null(actual, message) do {			\
-	char _meqstr[2048];					\
-	sprintf(_meqstr, "%s: expected to be NULL but it wasn't.", (message)); \
-	mu_assert(_meqstr, (actual) == NULL);		\
-} while(0)
+		char _meqstr[2048];					\
+		const void *act__ = (actual); \
+		sprintf(_meqstr, "%s: expected to be NULL but it wasn't.", (message)); \
+		mu_assert(_meqstr, (act__) == NULL);		\
+	} while(0)
 
 #define mu_assert_notnull(actual, message) do {				\
-	char _meqstr[2048];					\
-	sprintf(_meqstr, "%s: expected to not be NULL but it was.", (message)); \
-	mu_assert(_meqstr, (actual) != NULL);			\
-} while(0)
+		char _meqstr[2048];					\
+		const void *act__ = (actual); \
+		sprintf(_meqstr, "%s: expected to not be NULL but it was.", (message)); \
+		mu_assert(_meqstr, (act__) != NULL);			\
+	} while(0)
 
 #define mu_assert_eq_fmt(actual, expected, message, fmt) do { \
-		if ((expected) != (actual)) { \
+		__typeof__(actual) act__ = (actual); \
+		__typeof__(expected) exp__ = (expected); \
+		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
-			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (expected), (actual)); \
+			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \
 			mu_assert(_meqstr, false); \
 		} \
-} while(0)
+	} while(0)
 
 #define mu_assert_streq(actual, expected, message) do { \
 		char _meqstr[2048]; \
-		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (expected), (actual)); \
-		mu_assert(_meqstr, strcmp((expected), (actual)) == 0); \
+		const char *act__ = (actual); \
+		const char *exp__ = (expected); \
+		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__), (act__)); \
+		mu_assert(_meqstr, strcmp((exp__), (act__)) == 0); \
 } while(0)
 
 #define mu_assert_nullable_streq(actual, expected, message) do { \
 		char _meqstr[2048]; \
-		const char *_expected_str = expected; \
-		const char *_actual_str = actual; \
-		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (_expected_str ? _expected_str : "NULL"), (_actual_str ? _actual_str : "NULL")); \
-		mu_assert(_meqstr, ((_actual_str) == NULL && (_expected_str) == NULL) || ((_actual_str) != NULL && (_expected_str) != NULL && strcmp((_expected_str), (_actual_str)) == 0)); \
+		const char *act__ = (actual); \
+		const char *exp__ = (expected); \
+		sprintf(_meqstr, "%s: expected %s, got %s.", (message), (exp__ ? exp__ : "NULL"), (act__ ? act__ : "NULL")); \
+		mu_assert(_meqstr, ((act__) == NULL && (exp__) == NULL) || ((act__) != NULL && (exp__) != NULL && strcmp((exp__), (act__)) == 0)); \
 } while(0)
 
 #define mu_assert_memeq(actual, expected, len, message) do { \
 		char _meqstr[2048]; \
+		const ut8 *act__ = (actual); \
+		const ut8 *exp__ = (expected); \
 		sprintf(_meqstr, "%s: expected ", message); \
-		sprint_mem(_meqstr + strlen(_meqstr), (expected), (len)); \
+		sprint_mem(_meqstr + strlen(_meqstr), (exp__), (len)); \
 		sprintf(_meqstr + strlen(_meqstr), ", got "); \
-		sprint_mem(_meqstr + strlen(_meqstr), (actual), (len)); \
-		mu_assert(_meqstr, memcmp((expected), (actual), (len)) == 0); \
+		sprint_mem(_meqstr + strlen(_meqstr), (act__), (len)); \
+		mu_assert(_meqstr, memcmp((exp__), (act__), (len)) == 0); \
 } while(0)
 
 #define mu_run_test(test) do { int result; \


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Many of the minunit macros used in unit tests were using the arguments multiple time, thus in case the argument of the macro is not a variable but a function call, the function would be called two times.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Existing tests should still work.