### PR TITLE
Fix coverity-scan GitHub Action for forked repos

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -7,6 +7,10 @@ jobs:
   latest:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine current repository
+        id: "determine-repo"
+        run: "echo \"::set-output name=repo::${GITHUB_REPOSITORY}\""
+
       - uses: actions/checkout@v2
       - name: Download Coverity Build Tool
         run: |
@@ -15,19 +19,23 @@ jobs:
           tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        if: steps.determine-repo.outputs.repo == 'radareorg/radare2'
 
       - name: Fixed world writable dirs
         run: |
           chmod go-w $HOME
           sudo chmod -R go-w /usr/share
+        if: steps.determine-repo.outputs.repo == 'radareorg/radare2'
 
       - name: Configure
         run: ./configure
+        if: steps.determine-repo.outputs.repo == 'radareorg/radare2'
 
       - name: Build with cov-build
         run: |
           export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
           cov-build --dir cov-int make
+        if: steps.determine-repo.outputs.repo == 'radareorg/radare2'
 
       # TODO: Make it GitHub Action instead
       - name: Submit the result to Coverity Scan
@@ -43,3 +51,4 @@ jobs:
             https://scan.coverity.com/builds?project=radare2
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        if: steps.determine-repo.outputs.repo == 'radareorg/radare2'


### PR DESCRIPTION
Makes the coverity scan neither download of the Coverity Build Tool nor
execute any of the following steps for forked repositories, avoiding
sending GitHub alerts to those repo owners.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [N/A] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [N/A] I've added tests that prove my fix is effective or that my feature works (if possible), **but I tested it on forked repo.**
- [N/A] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Forked radare2 repo owners receive e-mails from the execution of the coverity GitHub action, because those repositories can't download the tool with the original Github token. This PR makes the coverity action steps run conditionally, avoiding running them whenever it detects being run on a forked repo.

**Test plan**

I tested the modified action on a forked repo and it works fine.

**Closing issues**

This PR doesn't close any (known) issue.
