### PR TITLE
Add first version of /m search with hits

### DIFF
--- a/libr/core/cmd_magic.c
+++ b/libr/core/cmd_magic.c
@@ -46,8 +46,8 @@ static int r_core_magic_at(RCore *core, const char *file, ut64 addr, int depth, 
 		}
 	}
 	if (((addr&7)==0) && ((addr&(7<<8))==0))
-		if (!json) {
-			eprintf ("0x%08"PFMT64x"\r", addr);
+		if (!json) { // update search display
+			eprintf ("0x%08" PFMT64x " [%d matches found]\r", addr, *hits);
 		}
 	if (file) {
 		if (*file == ' ') file++;


### PR DESCRIPTION
PR related to #16264
Simple example with global counting.

```
[0x0000000]> /m
-- 0 8e6fe4
0x0051345 [5 matches found]
```