### PR TITLE
Don't use r2 shell commands to implemnt an.

### DIFF
--- a/test/new/db/cmd/cmd_an
+++ b/test/new/db/cmd/cmd_an
@@ -1,0 +1,34 @@
+NAME=an flag
+FILE=../bins/elf/hello_world
+CMDS=<<EOF
+# create flag
+an test_label1 @ 0x804
+fi 0x844 0x845
+# rename flag
+an test_label2 @ 0x804
+fi 0x844 0x845
+anj @ 0x804
+EOF
+EXPECT=<<EOF
+0x00000844 1 test_label1
+0x00000844 1 test_label2
+[{"name":"test_label2","realname":"test_label2","type":"flag","offset":2116}]
+EOF
+RUN
+
+NAME=an function
+FILE=../bins/elf/hello_world
+CMDS=<<EOF
+aa
+s 0x7cf
+anj
+an renamed_strlen
+anj
+afi. @ 1632
+EOF
+EXPECT=<<EOF
+[{"name":"sym.imp.strlen","type":"function","offset":1632}]
+[{"name":"renamed_strlen","type":"function","offset":1632}]
+renamed_strlen
+EOF
+RUN


### PR DESCRIPTION
Avoids some of the problems with command injection.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible) - TODO: find out if there are any relevant existing tests
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

For "an" command implementation use r2 api functions directly instead of building a command string and evaluating it using r2 shell.

Reduces problems with command injection.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

* run "an name" on an instruction where referenced address has no flag -> create flag
* run "an name" on an instruction where referenced address has  flag -> rename flag
* run "an name" on function call instruction -> rename function
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
