### PR TITLE
Use r_core_cmd_lines() for -c

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -257,7 +257,7 @@ static bool run_commands(RCore *r, RList *cmds, RList *files, bool quiet, int do
 	/* -c */
 	r_list_foreach (cmds, iter, cmdn) {
 		//r_core_cmd0 (r, cmdn);
-		r_core_cmd (r, cmdn, false);
+		r_core_cmd_lines (r, cmdn);
 		r_cons_flush ();
 	}
 beach:


### PR DESCRIPTION
**Detailed description**

This enables multiline scripts in `-c`. Before, it kind of worked, but sometimes did weird stuff (see example below)

**Test plan**

Run r2 with the following multiline arg:
```
r2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc "
e asm.bits=64
wx ff2572962100   
af             
pdf~jmp[0]
afi~size[1]" malloc://1024
```

Result before (wrong):
```
\ 0x00000000
size: 6
```

Result after (right):
```
\
6
```