### PR TITLE
Remove asm.linesup in test

### DIFF
--- a/test/new/db/cmd/cmd_pd_bytes
+++ b/test/new/db/cmd/cmd_pd_bytes
@@ -9,7 +9,6 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 e anal.hasnext=0
-e asm.linesup=0
 wx b8010000004839ca7f00
 pD -10 @ 0xa
 EOF
@@ -26,7 +25,6 @@ CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 e anal.hasnext=0
-e asm.linesup=false
 wx b8010000004839ca7f00
 pD -10 @ 10
 EOF
@@ -77,7 +75,6 @@ EOF
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
-e asm.linesup=0
 wx 90909090909090909090 ; s 10 ; pD -10
 EOF
 RUN

--- a/test/new/db/cmd/metadata
+++ b/test/new/db/cmd/metadata
@@ -125,7 +125,6 @@ EXPECT=<<EOF
 EOF
 CMDS=<<EOF
 w hello\x00world
-e asm.linesup=0
 Cs 6
 Cs 6@6
 pd 2
@@ -140,7 +139,6 @@ EXPECT=<<EOF
 EOF
 CMDS=<<EOF
 w hello\x00world
-e asm.linesup=0
 Cs 6
 Cs 6@6
 pd 2


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
- `asm.linesup` has been removed in 932ba399785d3e488aed2eeb92ee0b0d2c9a9d3c
- This PR remove any several `asm.linesup` configuration in test