### PR TITLE
Fixes #16214

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -757,6 +757,7 @@ R_API void r_core_rtr_add(RCore *core, const char *_input) {
 		} else {
 			*ptr++ = '\0';
 			port = ptr;
+			r_str_trim (port);
 		}
 	} else {
 		port = NULL;
@@ -775,7 +776,6 @@ R_API void r_core_rtr_add(RCore *core, const char *_input) {
 		}
 	}
 
-	r_str_trim (port);
 	if (r_sandbox_enable (0)) {
 		eprintf ("sandbox: connect disabled\n");
 		return;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The segmentation fault was caused when the user inputs `=+`, which calls the `r_core_rtr_add(..)` function in `../libr/core/rtc.c`. 

Since the host and port weren't specified, the `port` variable was set to `"80"`.

`r_str_trim (port)` was called later in the function, which was causing the segmentation fault. To be specific, `r_str_trim(...)` calls `r_str_trim_head(...)` which calls `memmove(...)` which was causing the segmentation fault.

I'm not really sure why it is causing a crash yet, but moving the r_str_trim to a more relevant if-else branch solved the problem.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #16214 
