### PR TITLE
R2R in C Enhancements

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -529,6 +529,10 @@ static bool database_load(R2RTestDatabase *db, const char *path, int depth) {
 			if (*subname == '.') {
 				continue;
 			}
+			if (strcmp (subname, "extras") == 0) {
+				// Only load "extras" dirs if explicitly specified
+				continue;
+			}
 			r_strbuf_setf (&subpath, "%s%s%s", path, R_SYS_DIR, subname);
 			if (!database_load (db, r_strbuf_get (&subpath), depth - 1)) {
 				ret = false;

--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -92,6 +92,7 @@ static char *read_string_val(char **nextline, const char *val, ut64 *linenum) {
 		r_strbuf_free (buf);
 		return NULL;
 	}
+
 	return strdup (val);
 }
 
@@ -172,9 +173,9 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 				eprintf (LINEFMT "Warning: Duplicate key \"%s\"\n", file, linenum, key); \
 			} \
 			test->field.set = true; \
-			if (strcmp (val, "1") != 0) { \
+			if (strcmp (val, "1") == 0) { \
 				test->field.value = true; \
-			} else if (strcmp (val, "0") != 0) { \
+			} else if (strcmp (val, "0") == 0) { \
                 test->field.value = false; \
 			} else { \
 				eprintf (LINEFMT "Error: Invalid value \"%s\" for boolean key \"%s\", only \"1\" or \"0\" allowed.\n", file, linenum, val, key); \

--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -173,9 +173,9 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 				eprintf (LINEFMT "Warning: Duplicate key \"%s\"\n", file, linenum, key); \
 			} \
 			test->field.set = true; \
-			if (strcmp (val, "1") == 0) { \
+			if (!strcmp (val, "1")) { \
 				test->field.value = true; \
-			} else if (strcmp (val, "0") == 0) { \
+			} else if (!strcmp (val, "0")) { \
                 test->field.value = false; \
 			} else { \
 				eprintf (LINEFMT "Error: Invalid value \"%s\" for boolean key \"%s\", only \"1\" or \"0\" allowed.\n", file, linenum, val, key); \
@@ -494,15 +494,15 @@ static R2RTestType test_type_for_path(const char *path, bool *load_plugins) {
 	char *token;
 	*load_plugins = false;
 	r_list_foreach (tokens, it, token) {
-		if (strcmp (token, "asm") == 0) {
+		if (!strcmp (token, "asm")) {
 			ret = R2R_TEST_TYPE_ASM;
 			continue;
 		}
-		if (strcmp (token, "json") == 0) {
+		if (!strcmp (token, "json")) {
 			ret = R2R_TEST_TYPE_JSON;
 			continue;
 		}
-		if (strcmp (token, "extras") == 0) {
+		if (!strcmp (token, "extras")) {
 			*load_plugins = true;
 		}
 	}

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -185,24 +185,24 @@ static void print_diff(const char *actual, const char *expected) {
 	char *uni = r_diff_buffers_to_string (d, (const ut8 *)expected, (int)strlen (expected), (const ut8 *)actual, (int)strlen (actual));
 	r_diff_free (d);
 
-	RList *lines = r_str_split_duplist(uni, "\n");
+	RList *lines = r_str_split_duplist (uni, "\n");
 	RListIter *it;
 	char *line;
 	r_list_foreach (lines, it, line) {
 		char c = *line;
 		switch (c) {
-			case '+':
-				printf (Color_GREEN);
-				break;
-			case '-':
-				printf (Color_RED);
-				break;
-			default:
-				break;
+		case '+':
+			printf ("%s", Color_GREEN);
+			break;
+		case '-':
+			printf ("%s", Color_RED);
+			break;
+		default:
+			break;
 		}
 		printf ("%s\n", line);
 		if (c == '+' || c == '-') {
-			printf (Color_RESET);
+			printf ("%s", Color_RESET);
 		}
 	}
 	r_list_free (lines);

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -179,19 +179,49 @@ static RThreadFunctionRet worker_th(RThread *th) {
 }
 
 static void print_diff(const char *actual, const char *expected) {
-	// TODO: do an actual diff
+#define DO_DIFF !__WINDOWS__
+#if DO_DIFF
+	RDiff *d = r_diff_new ();
+	char *uni = r_diff_buffers_to_string (d, (const ut8 *)expected, (int)strlen (expected), (const ut8 *)actual, (int)strlen (actual));
+	printf ("%s\n", uni);
+	r_diff_free (d);
+
+	RList *lines = r_str_split_duplist(uni, "\n");
+	RListIter *it;
+	char *line;
+	r_list_foreach (lines, it, line) {
+		char c = *line;
+		switch (c) {
+			case '+':
+				printf (Color_GREEN);
+				break;
+			case '-':
+				printf (Color_RED);
+				break;
+			default:
+				break;
+		}
+		printf ("%s\n", line);
+		if (c == '+' || c == '-') {
+			printf (Color_RESET);
+		}
+	}
+	r_list_free (lines);
+	free (uni);
+#else
 	RList *lines = r_str_split_duplist (expected, "\n");
 	RListIter *it;
 	char *line;
 	r_list_foreach (lines, it, line) {
-		printf (Color_RED"-"Color_RESET" %s\n", line);
+		printf (Color_RED"- %s"Color_RESET"\n", line);
 	}
 	r_list_free (lines);
 	lines = r_str_split_duplist (actual, "\n");
 	r_list_foreach (lines, it, line) {
-		printf (Color_GREEN"+"Color_RESET" %s\n", line);
+		printf (Color_GREEN"+ %s"Color_RESET"\n", line);
 	}
 	r_list_free (lines);
+#endif
 }
 
 static void print_result_diff(R2RTestResultInfo *result) {
@@ -231,7 +261,7 @@ static void print_state(R2RState *state, ut64 prev_completed) {
 	ut64 i;
 	for (i = prev_completed; i < completed; i++) {
 		R2RTestResultInfo *result = r_pvector_at (&state->results, (size_t)i);
-		if (!state->verbose && (result->result == R2R_TEST_RESULT_OK || result->result == R2R_TEST_RESULT_FIXED)) {
+		if (!state->verbose && (result->result == R2R_TEST_RESULT_OK || result->result == R2R_TEST_RESULT_FIXED || result->result == R2R_TEST_RESULT_BROKEN)) {
 			continue;
 		}
 		char *name = r2r_test_name (result->test);

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -183,7 +183,6 @@ static void print_diff(const char *actual, const char *expected) {
 #if DO_DIFF
 	RDiff *d = r_diff_new ();
 	char *uni = r_diff_buffers_to_string (d, (const ut8 *)expected, (int)strlen (expected), (const ut8 *)actual, (int)strlen (actual));
-	printf ("%s\n", uni);
 	r_diff_free (d);
 
 	RList *lines = r_str_split_duplist(uni, "\n");
@@ -208,6 +207,7 @@ static void print_diff(const char *actual, const char *expected) {
 	}
 	r_list_free (lines);
 	free (uni);
+	printf ("\n");
 #else
 	RList *lines = r_str_split_duplist (expected, "\n");
 	RListIter *it;

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -356,8 +356,8 @@ R_API bool r2r_check_cmd_test(R2RProcessOutput *out, R2RCmdTest *test) {
 	if (out->ret != 0 || !out->out || !out->err) {
 		return false;
 	}
-	const char *expect_out = test->expect.value ? test->expect.value : "";
-	if (strcmp (out->out, expect_out) != 0) {
+	const char *expect_out = test->expect.value;
+	if (expect_out && strcmp (out->out, expect_out) != 0) {
 		return false;
 	}
 	const char *expect_err = test->expect_err.value;

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -1173,7 +1173,7 @@ R_API int r_main_rabin2(int argc, char **argv) {
 		rabin_do_operation (bin, op, rad, output, file);
 	}
 	if (isradjson) {
-		r_cons_print ("}");
+		r_cons_print ("}\n");
 	}
 	r_cons_flush ();
 	r_core_file_free (fh);

--- a/test/new/db/tools/r2
+++ b/test/new/db/tools/r2
@@ -104,7 +104,9 @@ RUN
 NAME=no-nl-at-eof script
 FILE=-
 CMDS=!radare2 -i scripts/no-nl-at-eof.r2 -NQ -
-EXPECT=1
+EXPECT=<<EOF
+1
+EOF
 EXPECT_ERR=<<EOF
 EOF
 RUN
@@ -117,5 +119,7 @@ CMDS=<<EOF
 EOF
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=Script 'script/missing.r2' not found.
+EXPECT_ERR=<<EOF
+Script 'script/missing.r2' not found.
+EOF
 RUN

--- a/test/new/db/tools/r2r
+++ b/test/new/db/tools/r2r
@@ -28,5 +28,7 @@ NAME=BROKEN=0 with comment
 BROKEN=0 # Use BROKEN=0 to unbreak this. Don't remove this line!
 FILE=-
 CMDS=?e Test for BROKEN=0
-EXPECT=Test for BROKEN=0
+EXPECT=<<EOF
+Test for BROKEN=0
+EOF
 RUN

--- a/test/new/db/tools/rabin2
+++ b/test/new/db/tools/rabin2
@@ -52,7 +52,9 @@ FILE=../bins/elf/analysis/hello-linux-x86_64
 CMDS=!rabin2 -k ${R2_FILE}
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=Missing file.
+EXPECT_ERR=<<EOF
+Missing file.
+EOF
 RUN
 
 NAME=rabin2 -K md5 -S file

--- a/test/new/db/tools/ragg2
+++ b/test/new/db/tools/ragg2
@@ -20,7 +20,9 @@ CMDS=!ragg2 -a x86 -b 64 -p A10 -d 50:0xcb
 EXPECT=<<EOF
 41414141414141414141
 EOF
-EXPECT_ERR=Cannot patch outside
+EXPECT_ERR=<<EOF
+Cannot patch outside
+EOF
 RUN
 
 NAME=ragg2 -a x86 -b 64 -p A20 -w 10:cb

--- a/test/new/db/tools/rahash2
+++ b/test/new/db/tools/rahash2
@@ -130,7 +130,9 @@ FILE=-
 CMDS=!rahash2 -a md5 -x "61646d696e" -s "admin"
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=Hashstring already defined
+EXPECT_ERR=<<EOF
+Hashstring already defined
+EOF
 RUN
 
 NAME=rahash2 -a luhn -s "5105105105105100"
@@ -405,7 +407,9 @@ CMDS=!rahash2 -a md5 -s "admin" -c 21232f297a57a5a743894a0e4a801fc4
 EXPECT=<<EOF
 0x00000000-0x00000004 md5: 21232f297a57a5a743894a0e4a801fc3
 EOF
-EXPECT_ERR=rahash2: Computed hash doesn't match the expected one.
+EXPECT_ERR=<<EOF
+rahash2: Computed hash doesn't match the expected one.
+EOF
 RUN
 
 NAME=rahash2 -c with correct expected hash and quiet
@@ -422,7 +426,9 @@ FILE=-
 CMDS=!rahash2 -a md5 -s "admin" -c 21232f297a57a5a743894a0e4a801fc
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Invalid -c hex hash
+EXPECT_ERR=<<EOF
+rahash2: Invalid -c hex hash
+EOF
 RUN
 
 NAME=rahash2 -c with incorrect md5 hash length
@@ -430,7 +436,9 @@ FILE=-
 CMDS=!rahash2 -a md5 -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Given -c hash has 15 byte(s) but the selected algorithm returns 16 byte(s).
+EXPECT_ERR=<<EOF
+rahash2: Given -c hash has 15 byte(s) but the selected algorithm returns 16 byte(s).
+EOF
 RUN
 
 NAME=rahash2 -c with incorrect sha1 hash length
@@ -438,7 +446,9 @@ FILE=-
 CMDS=!rahash2 -a sha1 -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Given -c hash has 15 byte(s) but the selected algorithm returns 20 byte(s).
+EXPECT_ERR=<<EOF
+rahash2: Given -c hash has 15 byte(s) but the selected algorithm returns 20 byte(s).
+EOF
 RUN
 
 NAME=rahash2 -c with 2 hash algorithms
@@ -446,7 +456,9 @@ FILE=-
 CMDS=!rahash2 -a md5,sha1 -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Option -c incompatible with multiple algorithms in -a.
+EXPECT_ERR=<<EOF
+rahash2: Option -c incompatible with multiple algorithms in -a.
+EOF
 RUN
 
 NAME=rahash2 -c with all hash algorithms
@@ -454,7 +466,9 @@ FILE=-
 CMDS=!rahash2 -a all -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Option -c incompatible with multiple algorithms in -a.
+EXPECT_ERR=<<EOF
+rahash2: Option -c incompatible with multiple algorithms in -a.
+EOF
 RUN
 
 NAME=rahash2 -c with custom block size and per-block hash
@@ -462,7 +476,9 @@ FILE=-
 CMDS=!rahash2 -b 1 -B -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Option -c incompatible with -b and -B options.
+EXPECT_ERR=<<EOF
+rahash2: Option -c incompatible with -b and -B options.
+EOF
 RUN
 
 NAME=rahash2 -c with base64 encoding
@@ -470,7 +486,9 @@ FILE=-
 CMDS=!rahash2 -E base64 -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Option -c incompatible with -E base64, -E base91, -D base64 or -D base91 options.
+EXPECT_ERR=<<EOF
+rahash2: Option -c incompatible with -E base64, -E base91, -D base64 or -D base91 options.
+EOF
 RUN
 
 NAME=rahash2 -c with base64 decoding
@@ -478,7 +496,9 @@ FILE=-
 CMDS=!rahash2 -D base64 -s "admin" -c 21232f297a57a5a743894a0e4a801f
 EXPECT=<<EOF
 EOF
-EXPECT_ERR=rahash2: Option -c incompatible with -E base64, -E base91, -D base64 or -D base91 options.
+EXPECT_ERR=<<EOF
+rahash2: Option -c incompatible with -E base64, -E base91, -D base64 or -D base91 options.
+EOF
 RUN
 
 # Taken from "Descriptions of SHA-256, SHA-384, and SHA-512" by NIST

--- a/test/new/db/tools/rasm2
+++ b/test/new/db/tools/rasm2
@@ -373,7 +373,9 @@ RUN
 NAME=rasm2 bswap x64 #8095
 FILE=-
 CMDS="!rasm2 -a x86 -b 64 \"bswap rax;bswap rbx;bswap rcx;bswap rdx\""
-EXPECT=480fc8480fcb480fc9480fca
+EXPECT=<<EOF
+480fc8480fcb480fc9480fca
+EOF
 RUN
 
 NAME=rasm2 bswap x64 #8095 (with single quotes)

--- a/test/new/db/tools/rax2
+++ b/test/new/db/tools/rax2
@@ -23,9 +23,7 @@ RUN
 NAME=rax2 -E | rax2 -D 2
 FILE=-
 CMDS=!rax2 -E hello |rax2 -D |rax2 -E | rax2 -D  |rax2 -E|rax2 -D |rax2 -E | rax2 -Dl
-EXPECT=<<EOF
-hello
-EOF
+EXPECT=hello
 RUN
 
 NAME=rax2 -E | rax2 -D 3


### PR DESCRIPTION
see commit descriptions for info.

r2r-c reads a string specified without `<<EOF` syntax like `EXPECT_ERR=Missing file.` as `"Missing file."` without a trailing newline while r2r.js doesn't seem to care at all. So I had to change these to use `<<EOF` instead.