### PR TITLE
Fix a null deref in ds_print_relocs()

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4202,6 +4202,9 @@ static void ds_print_relocs(RDisasmState *ds) {
 	if (rel) {
 		int cstrlen = 0;
 		char *ll = r_cons_lastline (&cstrlen);
+		if (!ll) {
+			return;
+		}
 		int ansilen = r_str_ansi_len (ll);
 		int utf8len = r_utf8_strlen ((const ut8*)ll);
 		int cells = utf8len - (cstrlen - ansilen);


### PR DESCRIPTION
Reproducer:
```
r2 -N -Qc 'e scr.interactive=1; e scr.null=1; Vprdfq' ../bins/mach0/arm-or-thumb
```
In fact, this is part of this test:
https://github.com/radareorg/radare2/blob/master/test/new/db/anal/arm#L173-L176
I have no clue how this can be successful in current r2rs.