### PR TITLE
Fix #16336 - Correct a segfault

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -1062,7 +1062,7 @@ static int cmd_type(void *data, const char *input) {
 			const char *type = r_str_trim_head_ro (input + 1);
 			const char *name = type ? strchr (type, '.') : NULL;
 			if (name && type) {
-                name++; // skip the '.'
+				name++; // skip the '.'
 				if (r_str_startswith (type, "struct")) {
 					r_core_cmdf (core, "tsc %s", name);
 				} else if (r_str_startswith (type, "union")) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -15,7 +15,7 @@ static const char *help_msg_t[] = {
 	"t-", " <name>", "Delete types by its name",
 	"t-*", "", "Remove all types",
 	"tail", " [filename]", "Output the last part of files",
-	"tc", "[type.name]", "List all/given types in C output format",
+	"tc", " [type.name]", "List all/given types in C output format",
 	"te", "[?]", "List all loaded enums",
 	"td", "[?] <string>", "Load types from string",
 	"tf", "", "List all loaded functions signatures",
@@ -24,7 +24,7 @@ static const char *help_msg_t[] = {
 	"tn", "[?] [-][addr]", "manage noreturn function attributes and marks",
 	"to", " -", "Open cfg.editor to load types",
 	"to", " <path>", "Load types from C header file",
-	"toe", "[type.name]", "Open cfg.editor to edit types",
+	"toe", " [type.name]", "Open cfg.editor to edit types",
 	"tos", " <path>", "Load types from parsed Sdb database",
 	"tp", "  <type> [addr|varname]", "cast data at <address> to <type> and print it (XXX: type can contain spaces)",
 	"tpv", " <type> @ [value]", "Show offset formatted for given type",
@@ -74,7 +74,7 @@ static const char *help_msg_to[] = {
 
 static const char *help_msg_tc[] = {
 	"Usage: tc[...]", " [cctype]", "",
-	"tc", "[type.name]", "List all/given loaded types in C output format with newlines",
+	"tc", " [type.name]", "List all/given loaded types in C output format with newlines",
 	"tcd", "", "List all loaded types in C output format without newlines",
 	"tcc", "?", "Manage calling conventions types",
 	"tc?", "", "show this help",
@@ -1060,8 +1060,9 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case ' ': {
 			const char *type = r_str_trim_head_ro (input + 1);
-			const char *name = type ? strchr (type, '.') + 1: NULL;
+			const char *name = type ? strchr (type, '.') : NULL;
 			if (name && type) {
+                name++; // skip the '.'
 				if (r_str_startswith (type, "struct")) {
 					r_core_cmdf (core, "tsc %s", name);
 				} else if (r_str_startswith (type, "union")) {


### PR DESCRIPTION
* Change a condition returning always true even when it shouldn't
* Correct typos in tc help

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Segmentation fault when using `tc struct`. The expected command looks like `tc struct.foo`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`tc struct` should not triggers a segmentation fault.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #16336.
