### PR TITLE
Escape broken UTF-8 in Filename

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -289,7 +289,11 @@ static void r_core_file_info(RCore *core, int mode) {
 			pair ("fd", sdb_fmt ("%d", desc->fd));
 		}
 		if (fn || (desc && desc->uri)) {
-			pair ("file", fn? fn: desc->uri);
+			char *escaped = r_str_escape_utf8_keep_printable (fn? fn: desc->uri, false, false);
+			if (escaped) {
+				pair ("file", escaped);
+				free (escaped);
+			}
 		}
 		if (desc) {
 			ut64 fsz = r_io_desc_size (desc);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -149,6 +149,7 @@ R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_dot(const char *buf);
 R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool esc_bslash, bool colors);
 R_API char *r_str_escape_utf8(const char *buf, bool show_asciidot, bool esc_bslash);
+R_API char *r_str_escape_utf8_keep_printable(const char *buf, bool show_asciidot, bool esc_bslash); // like escape_utf8 but leaves valid \uXXXX chars directly in utf-8
 R_API char *r_str_escape_utf16le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);
 R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);
 R_API char *r_str_escape_utf16be(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1351,7 +1351,7 @@ R_API char *r_str_escape_latin1(const char *buf, bool show_asciidot, bool esc_bs
 	return r_str_escape_ (buf, false, colors, !colors, show_asciidot, esc_bslash);
 }
 
-static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool show_asciidot, bool esc_bslash) {
+static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool show_asciidot, bool esc_bslash, bool keep_printable) {
 	char *new_buf, *q;
 	const char *p, *end;
 	RRune ch;
@@ -1414,11 +1414,15 @@ static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool s
 		if (show_asciidot && !IS_PRINTABLE(ch)) {
 			*q++ = '.';
 		} else if (ch_bytes > 1) {
-			*q++ = '\\';
-			*q++ = ch_bytes == 4 ? 'U' : 'u';
-			for (i = ch_bytes == 4 ? 6 : 2; i >= 0; i -= 2) {
-				*q++ = "0123456789abcdef"[ch >> 4 * (i + 1) & 0xf];
-				*q++ = "0123456789abcdef"[ch >> 4 * i & 0xf];
+			if (keep_printable) {
+				q += r_utf8_encode ((ut8 *)q, ch);
+			} else {
+				*q++ = '\\';
+				*q++ = ch_bytes == 4 ? 'U' : 'u';
+				for (i = ch_bytes == 4 ? 6 : 2; i >= 0; i -= 2) {
+					*q++ = "0123456789abcdef"[ch >> 4 * (i + 1) & 0xf];
+					*q++ = "0123456789abcdef"[ch >> 4 * i & 0xf];
+				}
 			}
 		} else {
 			int offset = enc == R_STRING_ENC_UTF16BE ? 1 : enc == R_STRING_ENC_UTF32BE ? 3 : 0;
@@ -1442,23 +1446,27 @@ static char *r_str_escape_utf(const char *buf, int buf_size, RStrEnc enc, bool s
 }
 
 R_API char *r_str_escape_utf8(const char *buf, bool show_asciidot, bool esc_bslash) {
-	return r_str_escape_utf (buf, -1, R_STRING_ENC_UTF8, show_asciidot, esc_bslash);
+	return r_str_escape_utf (buf, -1, R_STRING_ENC_UTF8, show_asciidot, esc_bslash, false);
+}
+
+R_API char *r_str_escape_utf8_keep_printable(const char *buf, bool show_asciidot, bool esc_bslash) {
+	return r_str_escape_utf (buf, -1, R_STRING_ENC_UTF8, show_asciidot, esc_bslash, true);
 }
 
 R_API char *r_str_escape_utf16le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash) {
-	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF16LE, show_asciidot, esc_bslash);
+	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF16LE, show_asciidot, esc_bslash, false);
 }
 
 R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash) {
-	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF32LE, show_asciidot, esc_bslash);
+	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF32LE, show_asciidot, esc_bslash, false);
 }
 
 R_API char *r_str_escape_utf16be(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash) {
-	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF16BE, show_asciidot, esc_bslash);
+	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF16BE, show_asciidot, esc_bslash, false);
 }
 
 R_API char *r_str_escape_utf32be(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash) {
-	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF32BE, show_asciidot, esc_bslash);
+	return r_str_escape_utf (buf, buf_size, R_STRING_ENC_UTF32BE, show_asciidot, esc_bslash, false);
 }
 
 // JSON has special escaping requirements

--- a/test/new/db/archos/darwin-x64/cmd_i
+++ b/test/new/db/archos/darwin-x64/cmd_i
@@ -10,9 +10,9 @@ e io.cache=true
 # INVALID FILENAME .(show_fname B\x1b¢\302\200\200€𝄞\363\240\201\201\\.bin)
 EOF
 EXPECT=<<EOF
-file     A�€𝄞󠁁\.bin
+file     A\x1b¢€𝄞󠁁\.bin
 {"core":{"type":"","file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":256,"humansz":"256","iorw":true,"mode":"r-x","obsz":0,"block":256,"format":"any"}}
-file     B�€𝄞󠁁\.bin
+file     B\x1b¢€𝄞󠁁\.bin
 {"core":{"type":"","file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":256,"humansz":"256","iorw":true,"mode":"r-x","obsz":0,"block":256,"format":"any"}}
 EOF
 RUN

--- a/test/new/db/archos/linux-x64/cmd_i
+++ b/test/new/db/archos/linux-x64/cmd_i
@@ -10,9 +10,9 @@ e io.cache=true
 # INVALID FILENAME .(show_fname B\x1b¢\302\200\200€𝄞\363\240\201\201\\.bin)
 EOF
 EXPECT=<<EOF
-file     A�€𝄞󠁁\.bin
+file     A\x1b¢€𝄞󠁁\.bin
 {"core":{"type":"","file":"A\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":4,"size":256,"humansz":"256","iorw":true,"mode":"r-x","obsz":0,"block":256,"format":"any"}}
-file     B�€𝄞󠁁\.bin
+file     B\x1b¢€𝄞󠁁\.bin
 {"core":{"type":"","file":"B\u001b¢\u0080€𝄞\udb40\udc41\\.bin","fd":5,"size":256,"humansz":"256","iorw":true,"mode":"r-x","obsz":0,"block":256,"format":"any"}}
 EOF
 RUN


### PR DESCRIPTION
This test was a bit hard to fix. It seems like r2r.js and v check r2's output only after interpreting it as utf-8, effectively cleaning up broken encoding to a certain degree. This meant here that the bytes in `db/archos/*-x64/cmd_i` did not actually match the bytes outputted by r2.

I think it makes more sense for r2 to only output valid utf-8, so if something is broken in the filename, it should escape it. But if it's valid utf-8, we still want to print it normally, which is what `r_str_escape_utf8_keep_printable()` does here.