### PR TITLE
hotfix of recursion stack overflow in Vbc/

### DIFF
--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -972,6 +972,7 @@ static bool r_core_visual_config_hud(RCore *core) {
 // TODO: show only N elements of the list
 // TODO: wrap index when out of boundaries
 // TODO: Add support to show class fields too
+// Segfaults - stack overflow, because of recursion
 static void *show_class(RCore *core, int mode, int *idx, RBinClass *_c, const char *grep, RList *list) {
 	bool show_color = r_config_get_i (core->config, "scr.color");
 	RListIter *iter;
@@ -1079,8 +1080,8 @@ static void *show_class(RCore *core, int mode, int *idx, RBinClass *_c, const ch
 			if (r_list_empty (_c->fields)) {
 				return NULL;
 			}
-			r_cons_clear00 ();
-			return show_class (core, mode, idx, _c, grep, list);
+			// r_cons_clear00 ();
+			return NULL; // show_class (core, mode, idx, _c, grep, list);
 		}
 		return fur;
 		break;
@@ -1140,8 +1141,8 @@ static void *show_class(RCore *core, int mode, int *idx, RBinClass *_c, const ch
 			if (r_list_empty (_c->methods)) {
 				return NULL;
 			}
-			r_cons_clear00 ();
-			return show_class (core, mode, idx, _c, grep, list);
+			// r_cons_clear00 ();
+			return NULL; // show_class (core, mode, idx, _c, grep, list);
 		}
 		return mur;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

I've noticed a segfault due StackOverflow because of a recursion https://github.com/radareorg/radare2/blob/master/libr/core/vmenus.c#L1138 

I was digging around it and then saw that Pancake already hot-fixed part of this 9 days ago, but only the part for classes, the methods and fields still had the segfaulting recursion, so I've mimicked the fix for now.

To replicate, just open a binary that has an object and a some methods to them, then just
```
Vbc
// pick a class to show methods
// grep anything that matches nothing, for example:
/asdasdas 
```