### PR TITLE
Do not use r_buf_data in DEX results in 1.5x faster parsing (22s vs 33s) ##bin

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -280,6 +280,8 @@ R_API bool r_bin_open_buf(RBin *bin, RBuffer *buf, RBinOptions *opt) {
 		}
 	}
 	if (!bf) {
+		// Uncomment for this speedup: 20s vs 22s
+		// RBuffer *buf = r_buf_new_slurp (bin->file);
 		bf = r_bin_file_new_from_buffer (bin, bin->file, buf, bin->rawstr,
 			opt->baseaddr, opt->loadaddr, opt->fd, opt->pluginname);
 		if (!bf) {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -851,10 +851,13 @@ static RBinInfo *info(RBinFile *bf) {
 	h = &ret->sum[2];
 	h->type = 0;
 	r_buf_read_at (bf->buf, 8, h->buf, 4);
+	// this is slow but computed once, so we can use r_buf_data or just do r_buf_read()
+	// not sure if we want to expose the computed checksum everytime we open the file
+	// also the checksum is computed by other methods in RBin, so maybe good to generalize
 	{
 		ut32 fc = r_buf_read_le32_at (bf->buf, 8);
 		ut64 tmpsz;
-		const ut8 *tmp = r_buf_data (bf->buf, &tmpsz);
+		const ut8 *tmp = r_buf_data_cached (bf->buf, &tmpsz);
 		ut32 cc = __adler32 (tmp + 12, tmpsz - 12);
 		if (fc != cc) {
 			eprintf ("# adler32 checksum doesn't match. Type this to fix it:\n");
@@ -1002,9 +1005,9 @@ static char *dex_field_name(RBinDexObj *bin, int fid) {
 	const char *c = getstr (bin, bin->types[type_id].descriptor_id);
 	if (simplifiedDemangling) {
 		if (a && b && c) {
-			char *_a = simplify(strdup (a));
-			char *_b = simplify(strdup (b));
-			char *_c = simplify(strdup (c));
+			char *_a = simplify (strdup (a));
+			char *_b = simplify (strdup (b));
+			char *_c = simplify (strdup (c));
 			char *str =  r_str_newf ("(%s) %s.%s", _c, _a, _b);
 			free (_a);
 			free (_b);
@@ -1014,8 +1017,7 @@ static char *dex_field_name(RBinDexObj *bin, int fid) {
 		return r_str_newf ("(%d) %d.%d",
 				bin->types[type_id].descriptor_id,
 				tid,
-				bin->types[cid].descriptor_id
-			     );
+				bin->types[cid].descriptor_id);
 	}
 	return (a && b && c)
 		? r_str_newf ("%s->%s %s", a, b, c)
@@ -1070,7 +1072,6 @@ static char *dex_method_fullname(RBinDexObj *bin, int method_idx) {
 			simplify (flagname);
 		}
 	}
-
 	return flagname;
 }
 
@@ -1085,7 +1086,7 @@ static ut64 dex_get_type_offset(RBinFile *bf, int type_idx) {
 	return bin->header.types_offset + type_idx * 0x04; //&bin->types[type_idx];
 }
 
-static const char *dex_class_super_name(RBinDexObj *bin, RBinDexClass *c) {
+static char *dex_class_super_name(RBinDexObj *bin, RBinDexClass *c) {
 	r_return_val_if_fail (bin && bin->types && c, NULL);
 
 	int cid = c->super_class;
@@ -1096,27 +1097,44 @@ static const char *dex_class_super_name(RBinDexObj *bin, RBinDexClass *c) {
 	return getstr (bin, tid);
 }
 
-static const ut8 *parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
-		const ut8 *p, const ut8 *p_end, int *sym_count, ut64 fields_count, bool is_sfield) {
+static ut64 peek_uleb(RBuffer *b, bool *err, size_t *nn) {
+	ut64 n = UT64_MAX;
+	int len = r_buf_uleb128 (b, &n);
+	if (len < 0) {
+		if (err) {
+			*err |= true;
+		}
+	} else {
+		*nn += len;
+	}
+	return n;
+}
+
+static size_t parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
+		const ut64 offset, int *sym_count, ut64 fields_count, bool is_sfield) {
 	RBinDexObj *dex = bf->o->bin_obj;
 	RBin *bin = bf->rbin;
 	ut64 lastIndex = 0;
 	ut8 ff[sizeof (DexField)] = {0};
-	int total, i, tid;
+	int total, tid;
 	DexField field;
 	const char* type_str;
-	for (i = 0; i < fields_count; i++) {
-		ut64 fieldIndex, accessFlags;
+	size_t i, skip = 0;
 
-		p = r_uleb128 (p, p_end - p, &fieldIndex); // fieldIndex
-		p = r_uleb128 (p, p_end - p, &accessFlags); // accessFlags
+	r_buf_seek (bf->buf, offset, R_BUF_SET);
+	for (i = 0; i < fields_count; i++) {
+		bool err = false;
+		ut64 fieldIndex = peek_uleb (bf->buf, &err, &skip);
+		ut64 accessFlags = peek_uleb (bf->buf, &err, &skip);
+		if (err) {
+			break;
+		}
 		fieldIndex += lastIndex;
 		total = dex->header.fields_offset + (sizeof (DexField) * fieldIndex);
 		if (total >= dex->size || total < dex->header.fields_offset) {
 			break;
 		}
-		if (r_buf_read_at (bf->buf, total, ff,
-				sizeof (DexField)) != sizeof (DexField)) {
+		if (r_buf_read_at (bf->buf, total, ff, sizeof (DexField)) != sizeof (DexField)) {
 			break;
 		}
 		field.class_id = r_read_le16 (ff);
@@ -1165,13 +1183,13 @@ static const ut8 *parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClas
 		}
 		lastIndex = fieldIndex;
 	}
-	return p;
+	return skip;
 }
 
 // TODO: refactor this method
 // XXX it needs a lot of love!!!
-static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *cls, const ut8 *p, const ut8 *p_end,
-		int *sym_count, ut64 DM, int *methods, bool is_direct, const ut8 *bufbuf) {
+static size_t parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *cls, ut64 offset,
+		int *sym_count, ut64 DM, int *methods, bool is_direct) {
 	PrintfCallback cb_printf = bf->rbin->cb_printf;
 	RBinDexObj *dex = bf->o->bin_obj;
 	bool bin_dbginfo = bf->rbin->want_dbginfo;
@@ -1181,7 +1199,6 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 	ut16 regsz = 0, ins_size = 0, outs_size = 0, tries_size = 0;
 	ut16 start_addr, insn_count = 0;
 	ut32 debug_info_off = 0, insns_size = 0;
-	const ut8 *encoded_method_addr = NULL;
 
 	if (!dex->trycatch_list) {
 		dex->trycatch_list = r_list_newf ((RListFree)r_bin_trycatch_free);
@@ -1190,14 +1207,24 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 		eprintf ("This DEX is probably corrupted. Chopping DM from %d to 4KB\n", (int)DM);
 		DM = 4096;
 	}
+	size_t skip = 0;
+	ut64 bufsz = r_buf_size (bf->buf);
+	r_buf_seek (bf->buf, offset, R_BUF_SET);
 	for (i = 0; i < DM; i++) {
-		encoded_method_addr = p;
-		ut64 MI, MA, MC;
-		p = r_uleb128 (p, p_end - p, &MI);
+		ut64 encoded_method_addr = offset; //  + skip;
+		bool err = false;
+		skip = 0;
+		r_buf_seek (bf->buf, offset, R_BUF_SET);
+		ut64 MI = peek_uleb (bf->buf, &err, &skip);
 		MI += omi;
 		omi = MI;
-		p = r_uleb128 (p, p_end - p, &MA);
-		p = r_uleb128 (p, p_end - p, &MC);
+		ut64 MA = peek_uleb (bf->buf, &err, &skip);
+		ut64 MC = peek_uleb (bf->buf, &err, &skip);
+		if (err) {
+			eprintf ("Error\n");
+			break;
+		}
+		offset += skip;
 		// TODO: MOVE CHECKS OUTSIDE!
 		if (MI < dex->header.method_size) {
 			if (methods) {
@@ -1207,7 +1234,7 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 		char *method_name = dex_method_name (dex, MI);
 		char *signature = dex_method_signature (dex, MI);
 		if (!method_name) {
-			method_name = "unknown";
+			method_name = strdup ("unknown");
 		}
 		char *flag_name = r_str_newf ("%s.method.%s%s", cls->name, method_name, signature);
 		if (!flag_name || !*flag_name) {
@@ -1229,7 +1256,6 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 				R_FREE (signature);
 				continue;
 			}
-			ut64 bufsz = r_buf_size (bf->buf);
 			if (bufsz < MC || bufsz < MC + 16) {
 				//R_FREE (method_name);
 				R_FREE (flag_name);
@@ -1379,7 +1405,7 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 			RBinSymbol *sym = R_NEW0 (RBinSymbol);
 			if (!sym) {
 				R_FREE (flag_name);
-				return NULL;
+				break;
 			}
 			sym->name = flag_name;
 			// is_direct is no longer used
@@ -1391,8 +1417,8 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 				sym->vaddr = MC;// + 0x10;
 			} else {
 				sym->type = R_BIN_TYPE_METH_STR;
-				sym->paddr = encoded_method_addr - bufbuf;
-				sym->vaddr = encoded_method_addr - bufbuf;
+				sym->paddr = encoded_method_addr;
+				sym->vaddr = encoded_method_addr;
 			}
 			dex->code_from = R_MIN (dex->code_from, sym->paddr);
 			sym->bind = ((MA & 1) == 1) ? R_BIN_BIND_GLOBAL_STR : R_BIN_BIND_LOCAL_STR;
@@ -1468,73 +1494,54 @@ static const ut8 *parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClas
 		R_FREE (signature);
 		//R_FREE (method_name);
 	}
-	return p;
+	return skip;
 }
 
 static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *methods, int *sym_count) {
-	struct r_bin_dex_obj_t *dex = bf->o->bin_obj;
+	r_return_if_fail (bf && bf->o && c);
+
+	RBinDexObj *dex = bf->o->bin_obj;
 	RBin *rbin = bf->rbin;
 	int z;
-	const ut8 *p, *p_end;
-
-	r_return_if_fail (bf && c);
-	if (!c) {
-		return;
-	}
-	char *class_name = dex_class_name (dex, c);
-	if (!class_name || !*class_name) {
-		return;
-	}
-	const char *superClass = dex_class_super_name (dex, c);
-	if (!superClass) {
-		return;
-	}
-	class_name = strdup (class_name);
-	r_str_replace_char (class_name, ';', 0);
-
-	if (!class_name || !*class_name) {
-		return;
-	}
 	RBinClass *cls = R_NEW0 (RBinClass);
 	if (!cls) {
-		free (class_name);
-		return;
+		goto beach;
 	}
-	cls->name = class_name;
+	cls->name = dex_class_name (dex, c);
+	if (!cls->name) {
+		goto beach;
+	}
+	r_str_replace_char (cls->name, ';', 0);
 	cls->index = class_index;
-	cls->addr = dex->header.class_offset + class_index * DEX_CLASS_SIZE;
+	cls->addr = dex->header.class_offset + (class_index * DEX_CLASS_SIZE);
 	cls->methods = r_list_new ();
-	cls->super = strdup (superClass);
+	cls->super = dex_class_super_name (dex, c);
 	if (!cls->methods) {
 		free (cls);
-		free (class_name);
-		return;
+		goto beach;
 	}
 	cls->fields = r_list_new ();
 	if (!cls->fields) {
 		r_list_free (cls->methods);
-		free (class_name);
-		free (cls);
-		return;
+		goto beach;
 	}
 	const char *str = createAccessFlagStr (c->access_flags, kAccessForClass);
 	cls->visibility_str = strdup (str? str: "");
 	r_list_append (dex->classes_list, cls);
 	if (dexdump) {
-		rbin->cb_printf ("  Class descriptor  : '%s;'\n", class_name);
+		rbin->cb_printf ("  Class descriptor  : '%s;'\n", cls->name);
 		rbin->cb_printf ("  Access flags      : 0x%04x (%s)\n", c->access_flags,
 			createAccessFlagStr (c->access_flags, kAccessForClass));
-		rbin->cb_printf ("  Superclass        : '%s'\n", dex_class_super_name (dex, c));
+		rbin->cb_printf ("  Superclass        : '%s'\n", cls->super);
 		rbin->cb_printf ("  Interfaces        -\n");
 	}
 
 	if (c->interfaces_offset > 0 &&
 	    dex->header.data_offset < c->interfaces_offset &&
-	    c->interfaces_offset <
-		    dex->header.data_offset + dex->header.data_size) {
+	    c->interfaces_offset < dex->header.data_offset + dex->header.data_size) {
 		int types_list_size = r_buf_read_le32_at (bf->buf, c->interfaces_offset);
 		if (types_list_size < 0 || types_list_size >= dex->header.types_size ) {
-			return;
+			goto beach;
 		}
 		for (z = 0; z < types_list_size; z++) {
 			ut16 le16;
@@ -1544,9 +1551,9 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 			if (t > 0 && t < dex->header.types_size ) {
 				int tid = dex->types[t].descriptor_id;
 				if (dexdump) {
-					rbin->cb_printf (
-						"    #%d              : '%s'\n",
-						z, getstr (dex, tid));
+					char *cn = getstr (dex, tid);
+					rbin->cb_printf ("    #%d              : '%s'\n", z, cn);
+					free (cn);
 				}
 			}
 		}
@@ -1567,85 +1574,42 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 		    c->class_data_offset <
 			    dex->header.class_offset +
 				    dex->header.class_size * DEX_CLASS_SIZE) {
-			return;
+			goto beach;
 		}
 
-		ut64 bufbufsz;
-		const ut8 *bufbuf = r_buf_data (bf->buf, &bufbufsz);
-		p = bufbuf + c->class_data_offset;
-		// XXX may overflow
-		if (bufbufsz < c->class_data_offset) {
-			return;
+		RBinDexClassData *dc = R_NEW0 (RBinDexClassData);
+		if (!dc) {
+			goto beach;
 		}
-		ut32 p_size = (bufbufsz - c->class_data_offset);
-		p_end = p + p_size;
-		//XXX check for NULL!!
-		c->class_data = (struct dex_class_data_item_t *)malloc (
-			sizeof (struct dex_class_data_item_t));
-		if (!c->class_data) {
-			return;
-		}
-		if (p >= p_end) {
-			free (c->class_data);
-			return;
-		}
-		ut64 eof;
 
-		p = r_uleb128 (p, p_end - p, &eof);
-		if (p >= p_end) {
-			free (c->class_data);
-			return;
+		bool err = false;
+		size_t skip = 0;
+		r_buf_seek (bf->buf, c->class_data_offset, R_BUF_SET);
+		dc->static_fields_size   = peek_uleb (bf->buf, &err, &skip);
+		dc->instance_fields_size = peek_uleb (bf->buf, &err, &skip);
+		dc->direct_methods_size  = peek_uleb (bf->buf, &err, &skip);
+		dc->virtual_methods_size = peek_uleb (bf->buf, &err, &skip);
+		if (err) {
+			free (dc);
+			goto beach;
 		}
-		c->class_data->static_fields_size = eof;
+		c->class_data = dc;
 
-		p = r_uleb128 (p, p_end - p, &eof);
-		if (p >= p_end) {
-			free (c->class_data);
-			return;
-		}
-		c->class_data->instance_fields_size = eof;
+		ut64 offset = c->class_data_offset + skip;
 
-		p = r_uleb128 (p, p_end - p, &eof);
-		if (p >= p_end) {
-			free (c->class_data);
-			return;
-		}
-		c->class_data->direct_methods_size = eof;
+		if (dexdump) { rbin->cb_printf ("  Static fields     -\n"); }
+		offset += parse_dex_class_fields (bf, c, cls, offset, sym_count, dc->static_fields_size, true);
 
-		p = r_uleb128 (p, p_end - p, &eof);
-		if (p >= p_end) {
-			free (c->class_data);
-			return;
-		}
-		c->class_data->virtual_methods_size = eof;
+		if (dexdump) { rbin->cb_printf ("  Instance fields   -\n"); }
+		offset += parse_dex_class_fields (bf, c, cls, offset, sym_count, dc->instance_fields_size, false);
 
-		if (dexdump) {
-			rbin->cb_printf ("  Static fields     -\n");
-		}
-		p = parse_dex_class_fields (
-			bf, c, cls, p, p_end, sym_count,
-			c->class_data->static_fields_size, true);
+		if (dexdump) { rbin->cb_printf ("  Direct methods    -\n"); }
+		offset += parse_dex_class_method (bf, c, cls, offset, sym_count,
+			c->class_data->direct_methods_size, methods, true);
 
-		if (dexdump) {
-			rbin->cb_printf ("  Instance fields   -\n");
-		}
-		p = parse_dex_class_fields (
-			bf, c, cls, p, p_end, sym_count,
-			c->class_data->instance_fields_size, false);
-
-		if (dexdump) {
-			rbin->cb_printf ("  Direct methods    -\n");
-		}
-		p = parse_dex_class_method (
-			bf, c, cls, p, p_end, sym_count,
-			c->class_data->direct_methods_size, methods, true, bufbuf);
-
-		if (dexdump) {
-			rbin->cb_printf ("  Virtual methods   -\n");
-		}
-		parse_dex_class_method (
-			bf, c, cls, p, p_end, sym_count,
-			c->class_data->virtual_methods_size, methods, false, bufbuf);
+		if (dexdump) { rbin->cb_printf ("  Virtual methods   -\n"); }
+		offset += parse_dex_class_method (bf, c, cls, offset, sym_count,
+			c->class_data->virtual_methods_size, methods, false);
 	}
 
 	if (dexdump) {
@@ -1658,9 +1622,11 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 			rbin->cb_printf ("  source_file_idx   : %d (%s)\n\n",
 					 c->source_file, source_file);
 		}
+		free (source_file);
 	}
-	// TODO: fix memleaks
-	//free (class_name);
+	cls = NULL;
+beach:
+	r_bin_class_free (cls);
 }
 
 static bool is_class_idx_in_code_classes(RBinDexObj *bin, int class_idx) {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -857,7 +857,7 @@ static RBinInfo *info(RBinFile *bf) {
 	{
 		ut32 fc = r_buf_read_le32_at (bf->buf, 8);
 		ut64 tmpsz;
-		const ut8 *tmp = r_buf_data_cached (bf->buf, &tmpsz);
+		const ut8 *tmp = r_buf_data (bf->buf, &tmpsz);
 		ut32 cc = __adler32 (tmp + 12, tmpsz - 12);
 		if (fc != cc) {
 			eprintf ("# adler32 checksum doesn't match. Type this to fix it:\n");

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1110,7 +1110,7 @@ static ut64 peek_uleb(RBuffer *b, bool *err, size_t *nn) {
 	return n;
 }
 
-static size_t parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
+static void parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
 		int *sym_count, ut64 fields_count, bool is_sfield) {
 	RBinDexObj *dex = bf->o->bin_obj;
 	RBin *bin = bf->rbin;
@@ -1119,7 +1119,7 @@ static size_t parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *c
 	int total, tid;
 	DexField field;
 	const char* type_str;
-	size_t i, skip = 0, skipped = 0;
+	size_t i, skip = 0;
 
 	for (i = 0; i < fields_count; i++) {
 		bool err = false;
@@ -1182,12 +1182,11 @@ static size_t parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *c
 		}
 		lastIndex = fieldIndex;
 	}
-	return skip;
 }
 
 // TODO: refactor this method
 // XXX it needs a lot of love!!!
-static size_t parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
+static void parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *cls,
 		int *sym_count, ut64 DM, int *methods, bool is_direct) {
 	PrintfCallback cb_printf = bf->rbin->cb_printf;
 	RBinDexObj *dex = bf->o->bin_obj;
@@ -1207,7 +1206,6 @@ static size_t parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *c
 		DM = 4096;
 	}
 	size_t skip = 0;
-	size_t skipped = 0;
 	ut64 bufsz = r_buf_size (bf->buf);
 	ut64 encoded_method_addr;
 	bool err = false;
@@ -1226,7 +1224,6 @@ static size_t parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *c
 			eprintf ("Error\n");
 			break;
 		}
-		skipped += skip;
 		// TODO: MOVE CHECKS OUTSIDE!
 		if (MI < dex->header.method_size) {
 			if (methods) {
@@ -1495,7 +1492,6 @@ static size_t parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *c
 		R_FREE (signature);
 		//R_FREE (method_name);
 	}
-	return skipped;
 }
 
 static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *methods, int *sym_count) {

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -420,7 +420,7 @@ static int haschr(const RBinFile* bf, ut16 dllCharacteristic) {
 	if (!bf) {
 		return false;
 	}
-	buf = r_buf_data (bf->buf, &sz);
+	buf = r_buf_data_cached (bf->buf, &sz);
 	if (!buf) {
 		return false;
 	}

--- a/libr/bin/p/bin_pe.inc
+++ b/libr/bin/p/bin_pe.inc
@@ -420,7 +420,7 @@ static int haschr(const RBinFile* bf, ut16 dllCharacteristic) {
 	if (!bf) {
 		return false;
 	}
-	buf = r_buf_data_cached (bf->buf, &sz);
+	buf = r_buf_data (bf->buf, &sz);
 	if (!buf) {
 		return false;
 	}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1393,14 +1393,13 @@ static void anal_class_print(RAnal *anal, const char *class_name) {
 	}
 }
 
-
 static const char *show_anal_classes(RCore *core, char mode, int *idx, SdbList *list, const char *class_name) {
 	bool show_color = r_config_get_i (core->config, "scr.color");
 	SdbListIter *iter;
 	SdbKv *kv;
 	int i = 0;
 	int skip = *idx - 10;
-	const char * cur_class;
+	const char * cur_class = NULL;
 	r_cons_printf ("[hjkl_/Cfm]> anal classes:\n\n");
 
 	if (mode == 'd' && class_name) {

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -42,6 +42,7 @@ struct r_buf_t {
 	const RBufferMethods *methods;
 	void *priv;
 	ut8 *whole_buf;
+	ut64 whole_bufsz;
 	bool readonly;
 	int Oxff_priv;
 	int refctr;
@@ -100,7 +101,7 @@ R_API st64 r_buf_fwrite_at(RBuffer *b, ut64 addr, const ut8 *buf, const char *fm
 // WARNING: this function should be used with care because it may allocate the
 // entire buffer in memory. Consider using the r_buf_read* APIs instead and read
 // only the chunks you need.
-R_API const ut8 *r_buf_data(RBuffer *b, ut64 *size);
+R_DEPRECATE R_API const ut8 *r_buf_data(RBuffer *b, ut64 *size);
 R_API ut64 r_buf_size(RBuffer *b);
 R_API bool r_buf_resize(RBuffer *b, ut64 newsize);
 R_API RBuffer *r_buf_ref(RBuffer *b);

--- a/libr/include/r_util/r_buf.h
+++ b/libr/include/r_util/r_buf.h
@@ -42,7 +42,6 @@ struct r_buf_t {
 	const RBufferMethods *methods;
 	void *priv;
 	ut8 *whole_buf;
-	ut64 whole_bufsz;
 	bool readonly;
 	int Oxff_priv;
 	int refctr;

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -74,7 +74,6 @@ static ut8 *get_whole_buf(RBuffer *b, ut64 *sz) {
 		return NULL;
 	}
 	r_buf_read_at (b, 0, b->whole_buf, bsz);
-	b->whole_bufsz = bsz;
 	if (sz) {
 		*sz = bsz;
 	}

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -42,9 +42,7 @@ static st64 buf_read(RBuffer *b, ut8 *buf, size_t len) {
 
 static st64 buf_write(RBuffer *b, const ut8 *buf, size_t len) {
 	r_return_val_if_fail (b && b->methods, -1);
-	if (b->whole_buf) {
-		R_FREE (b->whole_buf);
-	}
+	R_FREE (b->whole_buf);
 	return b->methods->write? b->methods->write (b, buf, len): -1;
 }
 

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2019 - pancake */
+/* radare - LGPL - Copyright 2009-2020 - ret2libc, pancake */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -42,6 +42,9 @@ static st64 buf_read(RBuffer *b, ut8 *buf, size_t len) {
 
 static st64 buf_write(RBuffer *b, const ut8 *buf, size_t len) {
 	r_return_val_if_fail (b && b->methods, -1);
+	if (b->whole_buf) {
+		R_FREE (b->whole_buf);
+	}
 	return b->methods->write? b->methods->write (b, buf, len): -1;
 }
 
@@ -71,6 +74,7 @@ static ut8 *get_whole_buf(RBuffer *b, ut64 *sz) {
 		return NULL;
 	}
 	r_buf_read_at (b, 0, b->whole_buf, bsz);
+	b->whole_bufsz = bsz;
 	if (sz) {
 		*sz = bsz;
 	}
@@ -190,7 +194,7 @@ R_API RBuffer *r_buf_new(void) {
 	return new_buffer (R_BUFFER_BYTES, &u);
 }
 
-R_API const ut8 *r_buf_data(RBuffer *b, ut64 *size) {
+R_DEPRECATE R_API const ut8 *r_buf_data(RBuffer *b, ut64 *size) {
 	r_return_val_if_fail (b, NULL);
 	b->whole_buf = get_whole_buf (b, size);
 	return b->whole_buf;

--- a/libr/util/buf_bytes.c
+++ b/libr/util/buf_bytes.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_util.h>
 
 struct buf_bytes_user {

--- a/libr/util/buf_file.c
+++ b/libr/util/buf_file.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_types.h>
 #include <r_util.h>
 

--- a/libr/util/buf_io.c
+++ b/libr/util/buf_io.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_util.h>
 #include <r_io.h>
 

--- a/libr/util/buf_mmap.c
+++ b/libr/util/buf_mmap.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_util.h>
 
 struct buf_mmap_user {

--- a/libr/util/buf_ref.c
+++ b/libr/util/buf_ref.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_util.h>
 
 struct buf_ref_user {

--- a/libr/util/buf_sparse.c
+++ b/libr/util/buf_sparse.c
@@ -1,3 +1,5 @@
+/* radare - LGPL - Copyright 2009-2020 - ret2libc */
+
 #include <r_util.h>
 
 struct buf_sparse_priv {


### PR DESCRIPTION
* Fix two memleaks in the dex parser

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Loading DEX files is slow for several reasons, most of them described, with their proposed solutions in https://github.com/radareorg/radare2/issues/16387

This PR just make RBuffer.data() cache the contents to avoid having to re-read, alloc and copy everytime this is called, which in the case of DEX is a lot of times. I know its a bad practice to use this API, and even more when used with the IO backend. but there are at least 3 bin plugins using it right now and i think it's worth the simple fix.

As I said, it will be good to add a new API `r_buf_data_cache` and use it with this behaviour to avoid surprises in the case the backend changes the data and the frontend can't be updated because of the non-invalidated cache. This situation can happen when using the IO backend for RBuffer because the RBuffer is not the only api that can be used to modify the underlying memory contents.


**Test plan**

Grab this dex [classes.dex.zip](https://github.com/radareorg/radare2/files/4414087/classes.dex.zip)

And run that line
```
time r2 -zqcq classes.dex
```

**Closing issues**

Fixes this issue https://github.com/radareorg/radare2/issues/16387