### PR TITLE
Fix tp and tpx to accept types with spaces ##types

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -1584,42 +1584,47 @@ static int cmd_type(void *data, const char *input) {
 		} else if (input[1] == ' ' || input[1] == 'x' || !input[1]) {
 			char *tmp = strdup (input);
 			char *type_begin = strchr (tmp, ' ');
-			r_str_trim (type_begin);
-			const char *type_end = r_str_rchr (type_begin, NULL, ' ') + 1;
-			if (!type_begin) {
-				free (tmp);
-				break;
-			}
-			int type_len = (type_end)
-				? (int)(type_end -  type_begin - 1)
-				: strlen (type_begin);
-			char *type = strdup (type_begin);
-			if (!type) {
-				free (tmp);
-				break;
-			}
-			snprintf (type, type_len + 1, "%s", type_begin);
-			const char *arg = type_end;
-			char *fmt = r_type_format (TDB, type);
-			if (!fmt) {
-				eprintf ("Cannot find '%s' type\n", type);
-				break;
-			}
-			if (input[1] == 'x' && arg) { // "tpx"
-				r_core_cmdf (core, "pf %s @x:%s", fmt, arg);
-				// eprintf ("pf %s @x:%s", fmt, arg);
+			if (type_begin) {
+				r_str_trim (type_begin);
+				const char *type_end = r_str_rchr (type_begin, NULL, ' ');
+				int type_len = (type_end)
+					? (int)(type_end - type_begin)
+					: strlen (type_begin);
+				char *type = strdup (type_begin);
+				if (!type) {
+					free (tmp);
+					break;
+				}
+				snprintf (type, type_len + 1, "%s", type_begin);
+				const char *arg = (type_end) ? type_end + 1 : NULL;
+				char *fmt = r_type_format (TDB, type);
+				if (!fmt) {
+					eprintf ("Cannot find '%s' type\n", type);
+					free (tmp);
+					free (type);
+					break;
+				}
+				if (input[1] == 'x' && arg) { // "tpx"
+					r_core_cmdf (core, "pf %s @x:%s", fmt, arg);
+					// eprintf ("pf %s @x:%s", fmt, arg);
+				} else {
+					ut64 addr = arg ? r_num_math (core->num, arg): core->offset;
+					ut64 original_addr = addr;
+					if (!addr && arg) {
+						RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, -1);
+						addr = r_anal_var_addr (core->anal, fcn, arg);
+					}
+					if (addr != UT64_MAX) {
+						r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x, fmt, addr);
+					} else if (original_addr == 0) {
+						r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x, fmt, original_addr);
+					}
+				}
+				free (fmt);
+				free (type);
 			} else {
-				ut64 addr = arg ? r_num_math (core->num, arg): core->offset;
-				if (!addr && arg) {
-					RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, -1);
-					addr = r_anal_var_addr (core->anal, fcn, arg);
-				}
-				if (addr != UT64_MAX) {
-					r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x "\n", fmt, addr);
-				}
+				eprintf ("Usage: tp?\n");
 			}
-			free (fmt);
-			free (type);
 			free (tmp);
 		} else { // "tp"
 			eprintf ("Usage: tp?\n");

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -1583,15 +1583,20 @@ static int cmd_type(void *data, const char *input) {
 			}
 		} else if (input[1] == ' ' || input[1] == 'x' || !input[1]) {
 			char *tmp = strdup (input);
-			char *ptr = strchr (tmp, ' ');
-			if (!ptr) {
+			char *type_begin = strchr (tmp, ' ');
+			if (!type_begin) {
 				break;
 			}
-			r_str_trim (ptr);
-			int nargs = r_str_word_set0 (ptr);
-			if (nargs > 0) {
-				const char *type = r_str_word_get0 (ptr, 0);
-				const char *arg = (nargs > 1)? r_str_word_get0 (ptr, 1): NULL;
+			r_str_trim (type_begin);
+			char *type_end = strrchr (type_begin, ' ');
+			int type_len = (int)(type_end - type_begin);
+			char *type = (char *)malloc (type_len * sizeof (char) + 1);
+			snprintf (type, type_len + 1, "%s", type_begin);
+			if (!type) {
+				break;
+			}
+			const char *arg = type_end;
+			if (arg) {
 				char *fmt = r_type_format (TDB, type);
 				if (!fmt) {
 					eprintf ("Cannot find '%s' type\n", type);
@@ -1612,9 +1617,9 @@ static int cmd_type(void *data, const char *input) {
 				}
 				free (fmt);
 			} else {
-				eprintf ("see t?\n");
-				break;
+				eprintf ("Usage: tp?");
 			}
+			free (type);
 			free (tmp);
 		} else { // "tp"
 			eprintf ("Usage: tp?\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Commands `tp` and `tpx` were not prepared to accept types like "char *". This Pull Request changes that behavior.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
Write a test using the `tp` command with `char *` as the first argument.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Closes https://github.com/radareorg/radare2/issues/16195.
