### PR TITLE
r_buffer: do not move seek when using _at APIs

### DIFF
--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1226,7 +1226,8 @@ static void print_header(idasig_v5_t *header) {
 #endif
 
 static int parse_header(RBuffer *buf, idasig_v5_t *header) {
-	if (r_buf_read_at (buf, 0, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
+	r_buf_seek (buf, 0, R_BUF_SET);
+	if (r_buf_read (buf, header->magic, sizeof(header->magic)) != sizeof(header->magic)) {
 		return false;
 	}
 	if (r_buf_read (buf, &header->version, sizeof(header->version)) != sizeof(header->version)) {

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -219,6 +219,7 @@ static int r_io_def_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (r < 0) {
 		return r;
 	}
+	r_buf_seek (mmo->buf, r, R_BUF_CUR);
 	io->off += r;
 	return r;
 }

--- a/libr/io/p/io_ihex.c
+++ b/libr/io/p/io_ihex.c
@@ -65,6 +65,7 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 		fclose (out);
 		return -1;
 	}
+	r_buf_seek (rih->rbuf, count, R_BUF_CUR);
 
 	/* disk write : process each sparse chunk */
 	//TODO : sort addresses + check overlap?
@@ -189,7 +190,11 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	}
 	Rihex *rih = fd->data;
 	memset (buf, io->Oxff, count);
-	return r_buf_read_at (rih->rbuf, io->off, buf, count);
+	int r = r_buf_read_at (rih->rbuf, io->off, buf, count);
+	if (r >= 0) {
+		r_buf_seek (rih->rbuf, r, R_BUF_CUR);
+	}
+	return r;
 }
 
 static int __close(RIODesc *fd) {

--- a/libr/io/p/io_mmap.c
+++ b/libr/io/p/io_mmap.c
@@ -98,7 +98,11 @@ static int r_io_mmap_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (r_buf_size (mmo->buf) < io->off) {
 		io->off = r_buf_size (mmo->buf);
 	}
-	return r_buf_read_at (mmo->buf, io->off, buf, count);
+	int r = r_buf_read_at (mmo->buf, io->off, buf, count);
+	if (r >= 0) {
+		r_buf_seek (mmo->buf, r, R_BUF_CUR);
+	}
+	return r;
 }
 
 static int r_io_mmap_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {

--- a/libr/io/p/io_sparse.c
+++ b/libr/io/p/io_sparse.c
@@ -25,7 +25,11 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	}
 	b = RIOSPARSE_BUF(fd);
 	o = RIOSPARSE_OFF(fd);
-	return r_buf_write_at (b, o, buf, count);
+	int r = r_buf_write_at (b, o, buf, count);
+	if (r >= 0) {
+		r_buf_seek (b, r, R_BUF_CUR);
+	}
+	return r;
 }
 
 static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
@@ -36,7 +40,10 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	}
 	b = RIOSPARSE_BUF(fd);
 	o = RIOSPARSE_OFF(fd);
-	(void)r_buf_read_at (b, o, buf, count);
+	int r = r_buf_read_at (b, o, buf, count);
+	if (r >= 0) {
+		r_buf_seek (b, count, R_BUF_CUR);
+	}
 	return count;
 }
 

--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -556,7 +556,11 @@ static int r_io_zip_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (r_buf_size (zfo->b) < io->off) {
 		io->off = r_buf_size (zfo->b);
 	}
-	return r_buf_read_at (zfo->b, io->off, buf, count);
+	int r = r_buf_read_at (zfo->b, io->off, buf, count);
+	if (r >= 0) {
+		r_buf_seek (zfo->b, r, R_BUF_CUR);
+	}
+	return r;
 }
 
 static int r_io_zip_realloc_buf(RIOZipFileObj *zfo, int count) {
@@ -599,6 +603,9 @@ static int r_io_zip_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	}
 	zfo->modified = 1;
 	ret = r_buf_write_at (zfo->b, io->off, buf, count);
+	if (ret >= 0) {
+		r_buf_seek (zfo->b, ret, R_BUF_CUR);
+	}
 	// XXX - Implement a flush of some sort, but until then, lets
 	// just write through
 	r_io_zip_flush_file (zfo);

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -537,11 +537,14 @@ R_API st64 r_buf_fread(RBuffer *b, ut8 *buf, const char *fmt, int n) {
 
 R_API st64 r_buf_fread_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int n) {
 	r_return_val_if_fail (b && buf && fmt, -1);
+	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	int r = r_buf_seek (b, addr, R_BUF_SET);
 	if (r < 0) {
 		return r;
 	}
-	return r_buf_fread (b, buf, fmt, n);
+	r = r_buf_fread (b, buf, fmt, n);
+	r_buf_seek (b, o_addr, R_BUF_SET);
+	return r;
 }
 
 R_API st64 r_buf_fwrite(RBuffer *b, const ut8 *buf, const char *fmt, int n) {
@@ -555,31 +558,40 @@ R_API st64 r_buf_fwrite(RBuffer *b, const ut8 *buf, const char *fmt, int n) {
 
 R_API st64 r_buf_fwrite_at(RBuffer *b, ut64 addr, const ut8 *buf, const char *fmt, int n) {
 	r_return_val_if_fail (b && buf && fmt && !b->readonly, -1);
+	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
 	if (r < 0) {
 		return r;
 	}
-	return r_buf_fwrite (b, buf, fmt, n);
+	r = r_buf_fwrite (b, buf, fmt, n);
+	r_buf_seek (b, o_addr, R_BUF_SET);
+	return r;
 }
 
 R_API st64 r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, ut64 len) {
 	r_return_val_if_fail (b && buf, -1);
+	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
 	if (r < 0) {
 		return r;
 	}
 
-	return r_buf_read (b, buf, len);
+	r = r_buf_read (b, buf, len);
+	r_buf_seek (b, o_addr, R_BUF_SET);
+	return r;
 }
 
 R_API st64 r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, ut64 len) {
 	r_return_val_if_fail (b && buf && !b->readonly, -1);
+	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
 	if (r < 0) {
 		return r;
 	}
 
-	return r_buf_write (b, buf, len);
+	r = r_buf_write (b, buf, len);
+	r_buf_seek (b, o_addr, R_BUF_SET);
+	return r;
 }
 
 R_API bool r_buf_fini(RBuffer *b) {


### PR DESCRIPTION
This allows to use r_buf_read/r_buf_write to read/write sequentially but
at the same time having random reads/writes in the buffer if needed,
without the need to save/restore the seek every time.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Sometimes you may want to use the sequential API like `r_buf_read`/`r_buf_write` but you may also need to read/write in random places (e.g. in bin_dex.c). This makes sure that the read_at/write_at APIs restore the original seek after reading/writing data.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Everything should still work as usual.