### PR TITLE
Add Windows argv Formatting

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -155,6 +155,7 @@ R_API char *r_str_escape_utf32le(const char *buf, int buf_size, bool show_asciid
 R_API char *r_str_escape_utf16be(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);
 R_API char *r_str_escape_utf32be(const char *buf, int buf_size, bool show_asciidot, bool esc_bslash);
 R_API void r_str_byte_escape(const char *p, char **dst, int dot_nl, bool default_dot, bool esc_bslash);
+R_API char *r_str_format_msvc_argv(size_t argc, const char **argv);
 R_API void r_str_uri_decode(char *buf);
 R_API char *r_str_uri_encode(const char *buf);
 R_API char *r_str_utf16_decode(const ut8 *s, int len);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1592,6 +1592,66 @@ R_API char *r_str_escape_utf8_for_json(const char *buf, int buf_size) {
 	return new_buf;
 }
 
+// http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULES
+// https://docs.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?redirectedfrom=MSDN&view=vs-2019#parsing-c-command-line-arguments
+R_API char *r_str_format_msvc_argv(size_t argc, const char **argv) {
+	RStrBuf sb;
+	r_strbuf_init (&sb);
+
+	size_t i;
+	for (i = 0; i < argc; i++) {
+		if (i > 0) {
+			r_strbuf_append (&sb, " ");
+		}
+		const char *arg = argv[i];
+		bool must_escape = strchr (arg, '\"') != NULL;
+		bool must_quote = strpbrk (arg, " \t") != NULL || !*arg;
+		if (!must_escape && must_quote && *arg && arg[strlen (arg) - 1] == '\\') {
+			// if the last char is a bs and we would quote it, we must also escape
+			must_escape = true;
+		}
+		if (must_quote) {
+			r_strbuf_append (&sb, "\"");
+		}
+		if (must_escape) {
+			size_t bs_count = 0; // bullshit counter
+			for (; *arg; arg++) {
+				switch (*arg) {
+				case '\"':
+					for (; bs_count; bs_count--) {
+						// backslashes must be escaped iff they precede a "
+						// so just duplicate the number of backslashes already printed
+						r_strbuf_append (&sb, "\\");
+					}
+					r_strbuf_append (&sb, "\\\"");
+					break;
+				case '\\':
+					bs_count++;
+					r_strbuf_append (&sb, "\\");
+					break;
+				default:
+					bs_count = 0;
+					r_strbuf_append_n (&sb, arg, 1);
+					break;
+				}
+			}
+			if (must_quote) {
+				// there will be a quote after this so we have to escape bs here as well
+				for (; bs_count; bs_count--) {
+					r_strbuf_append (&sb, "\\");
+				}
+			}
+		} else {
+			r_strbuf_append (&sb, arg);
+		}
+		if (must_quote) {
+			r_strbuf_append (&sb, "\"");
+		}
+	}
+
+	return r_strbuf_drain_nofree (&sb);
+}
+
 static int __str_ansi_length (char const *str) {
 	int i = 1;
 	if (str[0] == 0x1b) {

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -371,32 +371,78 @@ bool test_r_str_constpool(void) {
 	mu_end;
 }
 
+bool test_r_str_format_msvc_argv() {
+	// Examples from http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULES
+	const char *a = "CallMePancake";
+	char *str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "CallMePancake", "no escaping");
+	free (str);
+
+	a = "Call Me Pancake";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "\"Call Me Pancake\"", "just quoting");
+	free (str);
+
+	a = "CallMe\"Pancake";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "CallMe\\\"Pancake", "just escaping");
+	free (str);
+
+	a = "CallMePancake\\";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "CallMePancake\\", "no escaping of backslashes");
+	free (str);
+
+	a = "Call Me Pancake\\";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "\"Call Me Pancake\\\\\"", "escaping of backslashes before closing quote");
+	free (str);
+
+	a = "CallMe\\\"Pancake";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "CallMe\\\\\\\"Pancake", "escaping of backslashes before literal quote");
+	free (str);
+
+	a = "Call Me\\\"Pancake";
+	str = r_str_format_msvc_argv (1, &a);
+	mu_assert_streq (str, "\"Call Me\\\\\\\"Pancake\"", "escaping of backslashes before literal quote in quote");
+	free (str);
+
+	const char *args[] = { "rm", "-rf", "\\"};
+	str = r_str_format_msvc_argv (3, args);
+	mu_assert_streq (str, "rm -rf \\", "multiple args");
+	free (str);
+
+	mu_end;
+}
+
 bool all_tests() {
-	mu_run_test(test_r_str_newf);
-	mu_run_test(test_r_str_replace_char_once);
-	mu_run_test(test_r_str_replace_char);
-	mu_run_test(test_r_str_replace);
-	mu_run_test(test_r_str_bits64);
-	mu_run_test(test_r_str_rwx);
-	mu_run_test(test_r_str_rwx_i);
-	mu_run_test(test_r_str_bool);
-	mu_run_test(test_r_str_case);
-	mu_run_test(test_r_str_split);
-	mu_run_test(test_r_str_tokenize);
-	mu_run_test(test_r_str_char_count);
-	mu_run_test(test_r_str_word_count);
-	mu_run_test(test_r_str_ichr);
-	mu_run_test(test_r_str_lchr);
-	mu_run_test(test_r_sub_str_lchr);
-	mu_run_test(test_r_sub_str_rchr);
-	mu_run_test(test_r_str_rchr);
-	mu_run_test(test_r_str_ansi_len);
-	mu_run_test(test_r_str_len_utf8_ansi);
-	mu_run_test(test_r_str_utf8_charsize);
-	mu_run_test(test_r_str_utf8_charsize_prev);
-	mu_run_test(test_r_str_sanitize_sdb_key);
-	mu_run_test(test_r_str_unescape);
-	mu_run_test(test_r_str_constpool);
+	mu_run_test (test_r_str_newf);
+	mu_run_test (test_r_str_replace_char_once);
+	mu_run_test (test_r_str_replace_char);
+	mu_run_test (test_r_str_replace);
+	mu_run_test (test_r_str_bits64);
+	mu_run_test (test_r_str_rwx);
+	mu_run_test (test_r_str_rwx_i);
+	mu_run_test (test_r_str_bool);
+	mu_run_test (test_r_str_case);
+	mu_run_test (test_r_str_split);
+	mu_run_test (test_r_str_tokenize);
+	mu_run_test (test_r_str_char_count);
+	mu_run_test (test_r_str_word_count);
+	mu_run_test (test_r_str_ichr);
+	mu_run_test (test_r_str_lchr);
+	mu_run_test (test_r_sub_str_lchr);
+	mu_run_test (test_r_sub_str_rchr);
+	mu_run_test (test_r_str_rchr);
+	mu_run_test (test_r_str_ansi_len);
+	mu_run_test (test_r_str_len_utf8_ansi);
+	mu_run_test (test_r_str_utf8_charsize);
+	mu_run_test (test_r_str_utf8_charsize_prev);
+	mu_run_test (test_r_str_sanitize_sdb_key);
+	mu_run_test (test_r_str_unescape);
+	mu_run_test (test_r_str_constpool);
+	mu_run_test (test_r_str_format_msvc_argv);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] ~~I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)~~

**Detailed description**

This is needed because Windows processes do not receive an array of arguments like on unix but only a single string which is then split by the called program. So to call a subprocess which should get exactly the argv we want, this formatter is needed.

Reference:
http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULES
https://docs.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?redirectedfrom=MSDN&view=vs-2019#parsing-c-command-line-arguments

**Test plan**

run the tests