### PR TITLE
 Use r_str_trim_head_ro instead of hacky while loops

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2884,10 +2884,7 @@ static int r_core_cmd_subst_i(RCore *core, char *cmd, char *colon, bool *tmpseek
 			line = strdup (cmd);
 			line = r_str_replace (line, "\\\"", "\"", true);
 			if (p && *p && p[1] == '|') {
-				str = p + 2;
-				while (IS_WHITESPACE (*str)) {
-					str++;
-				}
+				str = r_str_trim_head_ro (p + 2);
 				r_core_cmd_pipe (core, cmd, str);
 			} else {
 				r_cmd_call (core->rcmd, line);

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -789,7 +789,7 @@ static void set_offset_hint(RCore *core, RAnalOp *op, const char *type, ut64 lad
 	}
 }
 
-R_API int r_core_get_stacksz (RCore *core, ut64 from, ut64 to) {
+R_API int r_core_get_stacksz(RCore *core, ut64 from, ut64 to) {
 	int stack = 0, maxstack = 0;
 	ut64 at = from;
 
@@ -816,7 +816,7 @@ R_API int r_core_get_stacksz (RCore *core, ut64 from, ut64 to) {
 	return maxstack;
 }
 
-static void set_retval (RCore *core, ut64 at) {
+static void set_retval(RCore *core, ut64 at) {
 	RAnal *anal = core->anal;
 	RAnalHint *hint = r_anal_hint_get (anal, at);
 	RAnalFunction *fcn = r_anal_get_fcn_in (anal, at, 0);
@@ -1645,8 +1645,7 @@ static int cmd_type(void *data, const char *input) {
 			sdb_reset (TDB);
 			r_parse_c_reset (core->parser);
 		} else {
-			const char *name = input + 1;
-			while (IS_WHITESPACE (*name)) name++;
+			const char *name = r_str_trim_head_ro (input + 1);
 			if (*name) {
 				r_anal_remove_parsed_type (core->anal, name);
 			} else {
@@ -1767,8 +1766,9 @@ static int cmd_type(void *data, const char *input) {
 		if (istypedef && !strncmp (istypedef, "typedef", 7)) {
 			const char *q = sdb_fmt ("typedef.%s", s);
 			const char *res = sdb_const_get (TDB, q, 0);
-			if (res)
+			if (res) {
 				r_cons_println (res);
+			}
 		} else {
 			eprintf ("This is not an typedef\n");
 		}

--- a/libr/reg/arena.c
+++ b/libr/reg/arena.c
@@ -1,6 +1,7 @@
-/* radare - LGPL - Copyright 2009-2018 - pancake */
+/* radare - LGPL - Copyright 2009-2020 - pancake */
 
 #include <r_reg.h>
+#include <r_util/r_str.h>
 
 /* non-endian safe - used for raw mapping with system registers */
 R_API ut8 *r_reg_get_bytes(RReg *reg, int type, int *size) {
@@ -294,9 +295,7 @@ R_API ut8 *r_reg_arena_dup(RReg *reg, const ut8 *source) {
 }
 
 R_API int r_reg_arena_set_bytes(RReg *reg, const char *str) {
-	while (IS_WHITESPACE (*str)) {
-		str++;
-	}
+	str = r_str_trim_head_ro (str);
 	int len = r_hex_str_is_valid (str);
 	if (len == -1) {
 		eprintf ("Invalid input\n");

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -95,6 +95,20 @@ bool test_r_str_rwx_i(void) {
 	mu_end;
 }
 
+bool test_r_str_trim(void) {
+	//  1
+	const char* one = r_str_trim_head_ro ("  hello  ");
+	mu_assert_streq (one, "hello  ", "one");
+	//  2
+	char* two = strdup ("  hello  ");
+	r_str_trim_head (two);
+	mu_assert_streq (two, "hello  ", "two");
+	r_str_trim (two);
+	//  2
+	mu_assert_streq (two, "hello", "three");
+	free (two);
+	mu_end;
+}
 //TODO find a way to test r_str_home.
 
 bool test_r_str_bool(void) {
@@ -425,6 +439,7 @@ bool all_tests() {
 	mu_run_test (test_r_str_rwx);
 	mu_run_test (test_r_str_rwx_i);
 	mu_run_test (test_r_str_bool);
+	mu_run_test (test_r_str_trim);
 	mu_run_test (test_r_str_case);
 	mu_run_test (test_r_str_split);
 	mu_run_test (test_r_str_tokenize);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Some code still uses pointers to mess with strings where we can use generic r_util apis.

**Test plan**

we have no tests for this in test/unit


**Closing issues**

none