### PR TITLE
When computing relocations, use DYNAMIC segment if available

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2794,7 +2794,7 @@ RBinElfReloc* Elf_(r_bin_elf_get_relocs)(ELFOBJ *bin) {
 
 	struct dynamic_relocation_section *info = get_dynamic_info (bin);
 	size_t num_relocs = get_num_relocs (info);
-	ret = malloc ((num_relocs + 1) * sizeof (RBinElfReloc));
+	ret = calloc (num_relocs + 1, sizeof (RBinElfReloc));
 	populate_relocs_record (bin, ret, info);
 	ret[num_relocs].last = 1;
 	free (info);

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2858,7 +2858,7 @@ static RBinElfReloc *populate_relocs_record(ELFOBJ *bin, struct dynamic_relocati
 static struct dynamic_relocation_section *get_dynamic_info(ELFOBJ *bin) {
 	struct dynamic_relocation_section *res = calloc (1, sizeof (struct dynamic_relocation_section));
 
-	for (size_t i = 0; i < bin->dyn_entries; ++i) {
+	for (size_t i = 0; i < bin->dyn_entries; i++) {
 		Elf_(Dyn) *dyn_struct = bin->dyn_buf + i;
 
 		switch (dyn_struct->d_tag) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2676,9 +2676,9 @@ static int read_reloc(ELFOBJ *bin, RBinElfReloc *r, int is_rela, ut64 offset) {
 
 	if (is_rela == DT_RELA) {
 		reloc_info.r_addend = READWORD (buf, i);
+	    r->addend = reloc_info.r_addend;
 	}
 
-	r->addend = reloc_info.r_addend;
 	r->is_rela = is_rela;
 	r->last = 0;
 	r->offset = reloc_info.r_offset;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2719,10 +2719,10 @@ static size_t get_num_relocs_sections(ELFOBJ *bin) {
 		if (sectionIsInvalid (bin, &bin->g_sections[i])) {
 			continue;
 		}
-		if (!strncmp (bin->g_sections[i].name, ".rela.", strlen (".rela."))) {
+		if (r_str_startswith (bin->g_sections[i].name, ".rela.")) {
 			size = sizeof (Elf_(Rela));
 			ret += NUMENTRIES_ROUNDUP (bin->g_sections[i].size, size);
-		} else if (!strncmp (bin->g_sections[i].name, ".rel.", strlen (".rel."))) {
+		} else if (r_str_startswith (bin->g_sections[i].name, ".rel.")) {
 			size = sizeof (Elf_(Rel));
 			ret += NUMENTRIES_ROUNDUP (bin->g_sections[i].size, size);
 		}
@@ -2761,9 +2761,9 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *bin,
 }
 
 static size_t get_section_mode(ELFOBJ *bin, size_t pos) {
-	if (!strncmp (bin->g_sections[pos].name, ".rela.", strlen (".rela."))) {
+	if (r_str_startswith (bin->g_sections[pos].name, ".rela.")) {
 		return DT_RELA;
-	} else if (!strncmp (bin->g_sections[pos].name, ".rel.", strlen (".rel."))) {
+	} else if (r_str_startswith (bin->g_sections[pos].name, ".rel.")) {
 		return DT_REL;
 	}
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2671,7 +2671,7 @@ static bool read_reloc(ELFOBJ *bin, RBinElfReloc *r, size_t rel_mode, ut64 offse
 	ut8 buf[sizeof (Elf_(Rela))] = { 0 };
 	int res = r_buf_read_at (bin->b, offset, buf, size_struct);
 	if (res != size_struct) {
-		return 0;
+		return false;
 	}
 
 	size_t i = 0;
@@ -2691,7 +2691,7 @@ static bool read_reloc(ELFOBJ *bin, RBinElfReloc *r, size_t rel_mode, ut64 offse
 	r->sym = ELF_R_SYM (reloc_info.r_info);
 	r->type = ELF_R_TYPE (reloc_info.r_info);
 
-	return 1;
+	return true;
 }
 
 static size_t get_num_relocs_dynamic(struct dynamic_relocation_section *info) {
@@ -2738,6 +2738,9 @@ static size_t get_num_relocs_sections(ELFOBJ *bin) {
 			continue;
 		}
 		rel_mode = get_section_mode (bin, i);
+		if (!is_reloc_section (rel_mode)) {
+			continue;
+		}
 		size = get_size_rel_mode (rel_mode);
 		ret += NUMENTRIES_ROUNDUP (bin->g_sections[i].size, size);
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2671,28 +2671,19 @@ static int read_reloc(ELFOBJ *bin, RBinElfReloc *r, int is_rela, ut64 offset) {
 	size_t i = 0;
 	Elf_(Rela) reloc_info;
 
-#if R_BIN_ELF64
-	reloc_info.r_offset = READ64 (buf, i);
-	reloc_info.r_info = READ64 (buf, i);
-#else
-	reloc_info.r_offset = READ32 (buf, i);
-	reloc_info.r_info = READ32 (buf, i);
-#endif
-
-	r->offset = reloc_info.r_offset;
-	r->type = ELF_R_TYPE (reloc_info.r_info);
-	r->sym = ELF_R_SYM (reloc_info.r_info);
-	r->is_rela = is_rela;
-	r->last = 0;
+	reloc_info.r_offset = READWORD (buf, i);
+	reloc_info.r_info = READWORD (buf, i);
 
 	if (is_rela == DT_RELA) {
-#if R_BIN_ELF64
-		reloc_info.r_addend = READ64 (buf, i);
-#else
-		reloc_info.r_addend = READ32 (buf, i);
-#endif
-		r->addend = reloc_info.r_addend;
+		reloc_info.r_addend = READWORD (buf, i);
 	}
+
+	r->addend = reloc_info.r_addend;
+	r->is_rela = is_rela;
+	r->last = 0;
+	r->offset = reloc_info.r_offset;
+	r->sym = ELF_R_SYM (reloc_info.r_info);
+	r->type = ELF_R_TYPE (reloc_info.r_info);
 
 	return 1;
 }

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2726,6 +2726,10 @@ static size_t get_section_mode(ELFOBJ *bin, size_t pos) {
 	return 0;
 }
 
+static bool is_reloc_section(size_t rel_mode) {
+	return rel_mode == DT_REL || rel_mode == DT_RELA;
+}
+
 static size_t get_num_relocs_sections(ELFOBJ *bin) {
 	size_t i, rel_mode, size, ret = 0;
 
@@ -2775,10 +2779,6 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *bin,
 	}
 
 	return pos;
-}
-
-static bool is_reloc_section(size_t rel_mode) {
-	return rel_mode == DT_REL || rel_mode == DT_RELA;
 }
 
 static size_t get_next_not_analysed_offset(size_t section_offset, size_t offset,

--- a/test/new/db/formats/elf/reloc
+++ b/test/new/db/formats/elf/reloc
@@ -42,19 +42,6 @@ EOF
 RUN
 
 NAME=ELF: use reloc table in dyn entry
-FILE=../bins/elf/ls-linux-wrong-rela
-BROKEN=1
-CMDS=<<EOF
-e asm.comments=false
-e asm.lines=false
-pd 15 @ entry0~call
-EOF
-EXPECT=<<EOF
-0x000068e8      ff15b2c60100   call qword [reloc.__libc_start_main]
-EOF
-RUN
-
-NAME=ELF: use reloc table in dyn entry
 FILE=../bins/elf/simple-hello-world-with-wrong-rela-section-name
 CMDS=<<EOF
 e asm.comments=false

--- a/test/new/db/formats/elf/reloc
+++ b/test/new/db/formats/elf/reloc
@@ -54,6 +54,18 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ELF: use reloc table in dyn entry
+FILE=../bins/elf/simple-hello-world-with-wrong-rela-section-name
+CMDS=<<EOF
+e asm.comments=false
+e asm.lines=false
+pd 15 @ entry0~call
+EOF
+EXPECT=<<EOF
+0x00001068      ff15722f0000   call qword [reloc.__libc_start_main]
+EOF
+RUN
+
 NAME=ELF: R_X86_64_PLT32 patch reloc
 FILE=../bins/elf/radare2.c.obj
 ARGS=-e io.cache=true


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I start working on the dynamic section, the ir command found all the relocations. I don't know why the pd 15 command doesn't use all the relocs (new/db/formats/elf/reloc). I used readelf to test the relocation. Maybe later we could move the struct dynamic_relocation_section in the struct ELFOBJ?

**Test plan**
```
ir
```

**Closing issues**

#12732
