### PR TITLE
Show realnames on function's signature when enabled

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1891,7 +1891,9 @@ static void ds_show_functions(RDisasmState *ds) {
 		// show function's realname in the signature if realnames are enabled 
 		if (core->flags->realnames) {
 			RFlagItem *flag = r_flag_get (core->flags, fcn_name);
-			fcn_name = flag->realname;
+			if (flag && flag->realname) {
+				fcn_name = flag->realname;
+			}
 		}
 	    
 		char *sig = r_anal_fcn_format_sig (core->anal, f, fcn_name, &vars_cache, COLOR (ds, color_fname), COLOR_RESET (ds));

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1887,6 +1887,13 @@ static void ds_show_functions(RDisasmState *ds) {
 			r_cons_printf ("%s  ", COLOR_RESET (ds));
 		}
 		r_cons_printf ("%d: ", r_anal_function_realsize (f));
+
+		// show function's realname in the signature if realnames are enabled 
+		if (core->flags->realnames) {
+			RFlagItem *flag = r_flag_get (core->flags, fcn_name);
+			fcn_name = flag->realname;
+		}
+	    
 		char *sig = r_anal_fcn_format_sig (core->anal, f, fcn_name, &vars_cache, COLOR (ds, color_fname), COLOR_RESET (ds));
 		if (sig) {
 			r_cons_print (sig);

--- a/test/new/db/cmd/cmd_pd
+++ b/test/new/db/cmd/cmd_pd
@@ -2172,3 +2172,30 @@ e asm.bits=64
 wx 90905152539090 ; pd 7 ~ 5 ~ push
 EOF
 RUN
+
+NAME=print fcn header without asm.flags.real
+FILE=../bins/elf/crackme0x05
+EXPECT=<<EOF
+66: sym.parell (char *s);
+EOF
+CMDS=<<EOF
+e asm.flags.real=false
+e asm.lines.fcn=false
+aaa
+pdf @ 0x08048484~:1
+EOF
+RUN
+
+
+NAME=print fcn header with asm.flags.real
+FILE=../bins/elf/crackme0x05
+EXPECT=<<EOF
+66: parell (char *s);
+EOF
+CMDS=<<EOF
+e asm.flags.real=true
+e asm.lines.fcn=false
+aaa
+pdf @ 0x08048484~:1
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
This pull request will fix a problem in which the printed function signature did not honor the config `asm.flags.real`. 

In the following examples, notice how the name of the function changes from `sym.beet` to `beet` before and after the fix when `asm.flags.real` enabled.

**Before:**
```
[0x08048585]> e asm.flags.real=true
[0x08048585]> 
[0x08048585]> pdf
            ; CALL XREF from main @ 0x8048637
            ;-- eip:
╭ 112: sym.beet (char *src);
│           ; var char *s2 @ ebp-0x92
│           ; var int32_t var_8eh @ ebp-0x8e
│           ; var int32_t var_8ah @ ebp-0x8a
│           ; var char *dest @ ebp-0x88
│           ; arg char *src @ ebp+0x8
│           0x08048585      55             push ebp
│           0x08048586      89e5           mov ebp, esp
│           0x08048588      81ec98000000   sub esp, 0x98
│           0x0804858e      83ec08         sub esp, 8
```

**After**
```
[0x08048585]> e asm.flags.real=true
[0x08048585]> pdf
            ; CALL XREF from main @ 0x8048637
            ;-- eip:
╭ 112: beet (char *src);
│           ; var char *s2 @ ebp-0x92
│           ; var int32_t var_8eh @ ebp-0x8e
│           ; var int32_t var_8ah @ ebp-0x8a
│           ; var char *dest @ ebp-0x88
│           ; arg char *src @ ebp+0x8
│           0x08048585      55             push ebp
│           0x08048586      89e5           mov ebp, esp
│           0x08048588      81ec98000000   sub esp, 0x98
│           0x0804858e      83ec08         sub esp, 8

```

**Test plan**

- Open a binary that has realnames (e.g calls to imports in PE)
- Go to a function that has realname
- Print it with `asm.flags.real` disabled and see that the printed name is the non-realname
- Print it with `asm.flags.real` enabled and see that the printed name is the realname