### PR TITLE
Fix #16413 - Analyze code refs spotted with aae ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5154,6 +5154,8 @@ repeat:
 							? R_ANAL_REF_TYPE_CALL
 							: R_ANAL_REF_TYPE_CODE;
 						r_anal_xrefs_set (core->anal, cur, dst, ref);
+						r_core_anal_fcn (core, dst, UT64_MAX, R_ANAL_REF_TYPE_NULL, 1);
+// analyze function here
 #if 0
 						if (op.type == R_ANAL_OP_TYPE_UCALL || op.type == R_ANAL_OP_TYPE_RCALL) {
 							eprintf ("0x%08"PFMT64x"  RCALL TO %llx\n", cur, dst);

--- a/test/new/db/anal/mips
+++ b/test/new/db/anal/mips
@@ -10,6 +10,17 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=mozi aae functions
+FILE=../bins/elf/mips-mozi
+CMDS=<<EOF
+aae
+aflc
+EOF
+EXPECT=<<EOF
+428
+EOF
+RUN
+
 NAME=mips hello ref anal
 FILE=../bins/elf/analysis/mips.elf
 ARGS=-e bin.strings=false -e anal.strings=true

--- a/test/new/db/formats/elf/helloworld-gcc-elf
+++ b/test/new/db/formats/elf/helloworld-gcc-elf
@@ -32,6 +32,7 @@ push {r7, lr}
 add ip, pc, 0, 12
 push {r3, lr}
 add ip, pc, 0, 12
+str lr, [sp, -4]!
 EOF
 RUN
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

run af on each UJMP/UCALL spotted when doing esil emulation to find out the register value

**Test plan**

see the test

**Closing issues**

fixes #16423