### PR TITLE
Fix #13626 - Only check for major and minor version numbers when loading plugins #core

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -314,7 +314,10 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 	if (stru->version) {
 		char *mm0 = major_minor (stru->version);
 		char *mm1 = major_minor (R2_VERSION);
-		if (strcmp (mm0 ,mm1)) {
+		bool mismatch = strcmp (mm0, mm1);
+		free (mm0);
+		free (mm1);
+		if (mismatch) {
 			eprintf ("Module version mismatch %s (%s) vs (%s)\n",
 				file, stru->version, R2_VERSION);
 			if (stru->pkgname) {
@@ -328,8 +331,6 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 			}
 			return -1;
 		}
-		free (mm0);
-		free (mm1);
 	}
 	RLibPlugin *p = R_NEW0 (RLibPlugin);
 	p->type = stru->type;

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -297,10 +297,24 @@ R_API int r_lib_open(RLib *lib, const char *file) {
 	return res;
 }
 
+static char *major_minor(const char *s) {
+	char *a = strdup (s);
+	char *p = strchr (a, '.');
+	if (p) {
+		p = strchr (p + 1, '.');
+		if (p) {
+			*p = 0;
+		}
+	}
+	return a;
+}
+
 R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct *stru) {
 	r_return_val_if_fail (lib && file && stru, -1);
 	if (stru->version) {
-		if (strcmp (stru->version, R2_VERSION)) {
+		char *mm0 = major_minor (stru->version);
+		char *mm1 = major_minor (R2_VERSION);
+		if (strcmp (mm0 ,mm1)) {
 			eprintf ("Module version mismatch %s (%s) vs (%s)\n",
 				file, stru->version, R2_VERSION);
 			if (stru->pkgname) {
@@ -314,6 +328,8 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 			}
 			return -1;
 		}
+		free (mm0);
+		free (mm1);
 	}
 	RLibPlugin *p = R_NEW0 (RLibPlugin);
 	p->type = stru->type;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

read the issue

**Test plan**

install a plugin for 4.3.0 and use r2 4.3.1 and get no warnings

**Closing issues**

the #13626
...
