### PR TITLE
Fix #16233 - ~{} works on colorized JSONs ##json

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -514,9 +514,12 @@ R_API void r_cons_grepbuf() {
 				Color_RESET,
 				NULL
 			};
+			char *bb = strdup (buf);
+			r_str_ansi_filter (bb, NULL, NULL, -1);
 			char *out = (cons->context->grep.human)
-				? r_print_json_human (buf)
-				: r_print_json_indent (buf, I (context->color_mode), "  ", palette);
+				? r_print_json_human (bb)
+				: r_print_json_indent (bb, I (context->color_mode), "  ", palette);
+			free (bb);
 			if (!out) {
 				return;
 			}

--- a/libr/util/json_indent.c
+++ b/libr/util/json_indent.c
@@ -326,11 +326,13 @@ R_API char* r_print_json_indent(const char* s, bool color, const char* tab, cons
 		case ':':
 			*o++ = *s;
 			*o++ = ' ';
-			if (!strncmp (s + 1, "true", 4)) {
+			s = r_str_trim_head_ro (s + 1);
+			if (!strncmp (s, "true", 4)) {
 				EMIT_ESC (o, colors[JC_TRUE]);
-			} else if (!strncmp (s + 1, "false", 5)) {
+			} else if (!strncmp (s, "false", 5)) {
 				EMIT_ESC (o, colors[JC_FALSE]);
 			}
+			s--;
 			isValue = true;
 			break;
 		case ',':


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

see the issue

**Test plan**

see the issue

**Closing issues**

see the issue