### PR TITLE
Fix #16281 - Do not load system-wide plugins twice ##core

### DIFF
--- a/libr/core/libs.c
+++ b/libr/core/libs.c
@@ -43,10 +43,12 @@ CB (egg, egg)
 CB (fs, fs)
 
 static void __openPluginsAt(RCore *core, const char *arg) {
-	char *pdir = r_str_r2_prefix (arg);
-	if (pdir) {
-		r_lib_opendir (core->lib, pdir);
-		free (pdir);
+	if (arg && *arg) {
+		char *pdir = r_str_r2_prefix (arg);
+		if (pdir) {
+			r_lib_opendir (core->lib, pdir);
+			free (pdir);
+		}
 	}
 }
 
@@ -58,8 +60,9 @@ static void __loadSystemPlugins(RCore *core, int where, const char *path) {
 	if (path) {
 		r_lib_opendir (core->lib, path);
 	}
+	const char *dir_plugins = r_config_get (core->config, "dir.plugins");
 	if (where & R_CORE_LOADLIBS_CONFIG) {
-		r_lib_opendir (core->lib, r_config_get (core->config, "dir.plugins"));
+		r_lib_opendir (core->lib, dir_plugins);
 	}
 	if (where & R_CORE_LOADLIBS_ENV) {
 		char *p = r_sys_getenv (R_LIB_ENV);
@@ -76,7 +79,9 @@ static void __loadSystemPlugins(RCore *core, int where, const char *path) {
 		}
 	}
 	if (where & R_CORE_LOADLIBS_SYSTEM) {
-		__openPluginsAt (core, R2_PLUGINS);
+		if (strstr (R2_PLUGINS, dir_plugins)) {
+			__openPluginsAt (core, R2_PLUGINS);
+		}
 		__openPluginsAt (core, R2_EXTRAS);
 		__openPluginsAt (core, R2_BINDINGS);
 	}


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

see the issue

**Test plan**

complicated and boring to test in the CI

**Closing issues**

yes