### PR TITLE
Use RPVector for io->maps

### DIFF
--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -848,9 +848,8 @@ static RList* patch_relocs(RBin *b) {
 	RIO *io = NULL;
 	RBinObject *obj = NULL;
 	struct Elf_(r_bin_elf_obj_t) *bin = NULL;
-	RIOMap *g = NULL, *s = NULL;
+	RIOMap *g = NULL;
 	HtUU *relocs_by_sym;
-	SdbListIter *iter;
 	RBinElfReloc *relcs = NULL;
 	RBinInfo *info;
 	int cdsz;
@@ -878,10 +877,12 @@ static RList* patch_relocs(RBin *b) {
 	info = obj ? obj->info: NULL;
 	cdsz = info? (info->bits == 64? 8: info->bits == 32? 4: info->bits == 16 ? 4: 0): 0;
 
-	ls_foreach (io->maps, iter, s) {
-		if (s->itv.addr > offset) {
-			offset = s->itv.addr;
-			g = s;
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
+		if (map->itv.addr > offset) {
+			offset = map->itv.addr;
+			g = map;
 		}
 	}
 	if (!g) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -556,7 +556,7 @@ static RList* patch_relocs(RBin *b) {
 	RIO *io = NULL;
 	RBinObject *obj = NULL;
 	struct MACH0_(obj_t) *bin = NULL;
-	RIOMap *g = NULL, *s = NULL;
+	RIOMap *g = NULL;
 	HtUU *relocs_by_sym = NULL;
 	RIODesc *gotr2desc = NULL;
 
@@ -600,12 +600,13 @@ static RList* patch_relocs(RBin *b) {
 
 	int cdsz = obj->info ? obj->info->bits / 8 : 8;
 
-	SdbListIter *iter;
 	ut64 offset = 0;
-	ls_foreach (io->maps, iter, s) {
-		if (s->itv.addr > offset) {
-			offset = s->itv.addr;
-			g = s;
+	void **vit;
+	r_pvector_foreach (&io->maps, vit) {
+		RIOMap *map = *vit;
+		if (map->itv.addr > offset) {
+			offset = map->itv.addr;
+			g = map;
 		}
 	}
 	if (!g) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -288,11 +288,11 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 		}
 	} else {
 		int _perm = -1;
-		RIOMap *s;
-		SdbListIter *iter;
 		if (core->io) {
 			// sections
-			ls_foreach (core->io->maps, iter, s) {
+			void **it;
+			r_pvector_foreach (&core->io->maps, it) {
+				RIOMap *s = *it;
 				if (addr >= s->itv.addr && addr < (s->itv.addr + s->itv.size)) {
 					// sections overlap, so we want to get the one with lower perms
 					_perm = (_perm != -1) ? R_MIN (_perm, s->perm) : s->perm;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -8576,13 +8576,13 @@ static const char *oldstr = NULL;
 
 static int compute_coverage(RCore *core) {
 	RListIter *iter;
-	SdbListIter *iter2;
 	RAnalFunction *fcn;
-	RIOMap *map;
 	int cov = 0;
 	cov += r_meta_get_size(core->anal, R_META_TYPE_DATA);
 	r_list_foreach (core->anal->fcns, iter, fcn) {
-		ls_foreach (core->io->maps, iter2, map) {
+		void **it;
+		r_pvector_foreach (&core->io->maps, it) {
+			RIOMap *map = *it;
 			if (map->perm & R_PERM_X) {
 				ut64 section_end = map->itv.addr + map->itv.size;
 				ut64 s = r_anal_function_realsize (fcn);
@@ -8597,9 +8597,9 @@ static int compute_coverage(RCore *core) {
 
 static int compute_code (RCore* core) {
 	int code = 0;
-	SdbListIter *iter;
-	RIOMap *map;
-	ls_foreach (core->io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach (&core->io->maps, it) {
+		RIOMap *map = *it;
 		if (map->perm & R_PERM_X) {
 			code += map->itv.size;
 		}

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -647,9 +647,9 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 			RIOMap *m = r_io_map_get (core->io, from);
 			int rwx = m? m->perm: part->map->perm;
 #else
-		RIOMap *map;
-		SdbListIter *iter;
-		ls_foreach  (core->io->maps, iter, map) {
+		void **it;
+		r_pvector_foreach (&core->io->maps, it) {
+			RIOMap *map = *it;
 			ut64 from = r_itv_begin (map->itv);
 			ut64 to = r_itv_end (map->itv);
 			int rwx = map->perm;
@@ -679,9 +679,9 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 		int mask = (mode[len - 1] == '.')? r_str_rwx (mode + len): 0;
 		// bool only = (bool)(size_t)strstr (mode, ".only");
 
-		SdbListIter *iter;
-		RIOMap *map;
-		ls_foreach  (core->io->maps, iter, map) {
+		void **it;
+		r_pvector_foreach (&core->io->maps, it) {
+			RIOMap *map = *it;
 			ut64 from = r_itv_begin (map->itv);
 			//ut64 to = r_itv_end (map->itv);
 			int rwx = map->perm;
@@ -766,10 +766,10 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 				to = R_MAX (to, addr + size);
 			}
 			if (from == UT64_MAX) {
-				SdbListIter *iter;
-				RIOMap *map;
 				int mask = 1;
-				ls_foreach  (core->io->maps, iter, map) {
+				void **it;
+				r_pvector_foreach (&core->io->maps, it) {
+					RIOMap *map = *it;
 					ut64 from = r_itv_begin (map->itv);
 					ut64 size = r_itv_size (map->itv);
 					int rwx = map->perm;

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -137,9 +137,9 @@ static void GH(get_brks)(RCore *core, GHT *brk_start, GHT *brk_end) {
 			}
 		}
 	} else {
-		RIOMap *map;
-		SdbListIter *iter;
-		ls_foreach (core->io->maps, iter, map) {
+		void **it;
+		r_pvector_foreach (&core->io->maps, it) {
+			RIOMap *map = *it;
 			if (map->name) {
 				if (strstr (map->name, "[heap]")) {
 					*brk_start = map->itv.addr;
@@ -323,9 +323,9 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 			}
 		}
 	} else {
-		RIOMap *map;
-		SdbListIter *iter;
-		ls_foreach (core->io->maps, iter, map) {
+		void **it;
+		r_pvector_foreach (&core->io->maps, it) {
+			RIOMap *map = *it;
 			if (map->name && strstr (map->name, "arena")) {
 				libc_addr_sta = map->itv.addr;
 				libc_addr_end = map->itv.addr + map->itv.size;

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -231,11 +231,8 @@ static bool __core_visual_gogo (RCore *core, int ch) {
 	case 'g':
 		if (core->io->va) {
 			RIOMap *map = r_io_map_get (core->io, core->offset);
-			if (!map) {
-				SdbListIter *i = ls_tail (core->io->maps);
-				if (i) {
-					map = ls_iter_get (i);
-				}
+			if (!map && !r_pvector_empty (&core->io->maps)) {
+				map = r_pvector_at (&core->io->maps, r_pvector_len (&core->io->maps) - 1);
 			}
 			if (map) {
 				r_core_seek (core, r_itv_begin (map->itv), 1);
@@ -247,11 +244,8 @@ static bool __core_visual_gogo (RCore *core, int ch) {
 		return true;
 	case 'G':
 		map = r_io_map_get (core->io, core->offset);
-		if (!map) {
-			SdbListIter *i = ls_head (core->io->maps);
-			if (i) {
-				map = ls_iter_get (i);
-			}
+		if (!map && !r_pvector_empty (&core->io->maps)) {
+			map = r_pvector_at (&core->io->maps, 0);
 		}
 		if (map) {
 			RPrint *p = core->print;
@@ -3431,13 +3425,13 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 						if (s) {
 							entry = s->vaddr;
 						} else {
-							RIOMap *map = ls_pop (core->io->maps);
+							RIOMap *map = r_pvector_pop (&core->io->maps);
 							if (map) {
 								entry = map->itv.addr;
 							} else {
 								entry = r_config_get_i (core->config, "bin.baddr");
 							}
-							ls_prepend (core->io->maps, map);
+							r_pvector_push_front (&core->io->maps, map);
 						}
 					}
 					if (entry != UT64_MAX) {

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -90,7 +90,7 @@ typedef struct r_io_t {
 	int debug;
 //#warning remove debug from RIO
 	RIDPool *map_ids;
-	SdbList *maps; //from tail backwards maps with higher priority are found
+	RPVector maps; //from tail backwards maps with higher priority are found
 	RPVector map_skyline; // map parts that are not covered by others
 	RPVector map_skyline_shadow; // map parts that are not covered by others
 	RIDStorage *files;

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -229,6 +229,10 @@ static inline void **r_pvector_shrink(RPVector *vec) {
 #define r_pvector_foreach(vec, it) \
 	for (it = (void **)(vec)->v.a; it != (void **)(vec)->v.a + (vec)->v.len; it++)
 
+// like r_pvector_foreach() but inverse
+#define r_pvector_foreach_prev(vec, it) \
+	for (it = (void **)(vec)->v.a + (vec)->v.len - 1; it != (void **)(vec)->v.a - 1; it--)
+
 /*
  * example:
  *

--- a/libr/io/desc.c
+++ b/libr/io/desc.c
@@ -223,8 +223,6 @@ R_API bool r_io_desc_is_chardevice(RIODesc *desc) {
 
 R_API bool r_io_desc_exchange(RIO* io, int fd, int fdx) {
 	RIODesc* desc, * descx;
-	SdbListIter* iter;
-	RIOMap* map;
 	if (!(desc = r_io_desc_get (io, fd)) || !(descx = r_io_desc_get (io, fdx))) {
 		return false;
 	}
@@ -239,13 +237,13 @@ R_API bool r_io_desc_exchange(RIO* io, int fd, int fdx) {
 		r_io_desc_cache_cleanup (desc);
 		r_io_desc_cache_cleanup (descx);
 	}
-	if (io->maps) {
-		ls_foreach (io->maps, iter, map) {
-			if (map->fd == fdx) {
-				map->perm &= (desc->perm | R_PERM_X);
-			} else if (map->fd == fd) {
-				map->perm &= (descx->perm | R_PERM_X);
-			}
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
+		if (map->fd == fdx) {
+			map->perm &= (desc->perm | R_PERM_X);
+		} else if (map->fd == fd) {
+			map->perm &= (descx->perm | R_PERM_X);
 		}
 	}
 	return true;

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -339,9 +339,6 @@ R_API RIOMap* r_io_map_get_paddr(RIO* io, ut64 paddr) {
 	return NULL;
 }
 
-#define CMP_SKYLINE(addr, part) ((addr) < r_itv_end (((RIOMapSkyline *)(part))->itv) - 1 ? -1 : \
-			(addr) > r_itv_end (((RIOMapSkyline *)(part))->itv) - 1 ? 1 : 0)
-
 // gets first map where addr fits in
 R_API RIOMap *r_io_map_get(RIO* io, ut64 addr) {
 	r_return_val_if_fail (io, NULL);

--- a/libr/io/map.c
+++ b/libr/io/map.c
@@ -72,8 +72,6 @@ static bool _map_skyline_push(RPVector *map_skyline, ut64 from, ut64 to, RIOMap 
 
 // Store map parts that are not covered by others into io->map_skyline
 void io_map_calculate_skyline(RIO *io) {
-	SdbListIter *iter;
-	RIOMap *map;
 	RPVector events;
 	RBinHeap heap;
 	struct map_event_t *ev;
@@ -81,15 +79,17 @@ void io_map_calculate_skyline(RIO *io) {
 	r_pvector_clear (&io->map_skyline);
 	r_pvector_clear (&io->map_skyline_shadow);
 	r_pvector_init (&events, free);
-	if (!r_pvector_reserve (&events, ls_length (io->maps) * 2) ||
-			!(deleted = calloc (ls_length (io->maps), 1))) {
+	if (!r_pvector_reserve (&events, r_pvector_len (&io->maps) * 2) ||
+			!(deleted = calloc (r_pvector_len (&io->maps), 1))) {
 		goto out;
 	}
 
 	int i = 0;
 	// Last map has highest priority (it shadows previous maps),
 	// we assign 0 to its event id.
-	ls_foreach_prev (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach_prev (&io->maps, it) {
+		RIOMap *map = *it;
 		if (!(ev = R_NEW (struct map_event_t))) {
 			goto out;
 		}
@@ -126,7 +126,7 @@ void io_map_calculate_skyline(RIO *io) {
 			r_binheap_pop (&heap);
 		}
 		ut64 to = ev->addr;
-		map = r_binheap_empty (&heap) ? NULL : ((struct map_event_t *)r_binheap_top (&heap))->map;
+		RIOMap *map = r_binheap_empty (&heap) ? NULL : ((struct map_event_t *)r_binheap_top (&heap))->map;
 		if (!i) {
 			last = to;
 			last_map = map;
@@ -196,7 +196,7 @@ out:
 }
 
 RIOMap* io_map_new(RIO* io, int fd, int perm, ut64 delta, ut64 addr, ut64 size, bool do_skyline) {
-	if (!size || !io || !io->maps || !io->map_ids) {
+	if (!size || !io || !io->map_ids) {
 		return NULL;
 	}
 	RIOMap* map = R_NEW0 (RIOMap);
@@ -216,7 +216,7 @@ RIOMap* io_map_new(RIO* io, int fd, int perm, ut64 delta, ut64 addr, ut64 size, 
 	map->perm = perm;
 	map->delta = delta;
 	// new map lives on the top, being top the list's tail
-	ls_append (io->maps, map);
+	r_pvector_push (&io->maps, map);
 	if (do_skyline) {
 		io_map_calculate_skyline (io);
 	}
@@ -266,23 +266,20 @@ static void _map_free(void* p) {
 }
 
 R_API void r_io_map_init(RIO* io) {
-	if (io && !io->maps) {
-		io->maps = ls_newf ((SdbListFree)_map_free);
-		if (io->map_ids) {
-			r_id_pool_free (io->map_ids);
-		}
-		io->map_ids = r_id_pool_new (1, END_OF_MAP_IDS);
+	r_return_if_fail (io);
+	r_pvector_init (&io->maps, _map_free);
+	if (io->map_ids) {
+		r_id_pool_free (io->map_ids);
 	}
+	io->map_ids = r_id_pool_new (1, END_OF_MAP_IDS);
 }
 
 // check if a map with exact the same properties exists
-R_API bool r_io_map_exists(RIO* io, RIOMap* map) {
-	SdbListIter* iter;
-	RIOMap* m;
-	if (!io || !io->maps || !map) {
-		return false;
-	}
-	ls_foreach (io->maps, iter, m) {
+R_API bool r_io_map_exists(RIO *io, RIOMap *map) {
+	r_return_val_if_fail (io && map, false);
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *m = *it;
 		if (!memcmp (m, map, sizeof (RIOMap))) {
 			return true;
 		}
@@ -295,13 +292,11 @@ R_API bool r_io_map_exists_for_id(RIO* io, ut32 id) {
 	return r_io_map_resolve (io, id) != NULL;
 }
 
-R_API RIOMap* r_io_map_resolve(RIO* io, ut32 id) {
-	SdbListIter* iter;
-	RIOMap* map;
-	if (!io || !io->maps || !id) {
-		return NULL;
-	}
-	ls_foreach (io->maps, iter, map) {
+R_API RIOMap* r_io_map_resolve(RIO *io, ut32 id) {
+	r_return_val_if_fail (io && id, false);
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
 		if (map->id == id) {
 			return map;
 		}
@@ -334,9 +329,9 @@ R_API void r_io_update(RIO *io) {
 
 R_API RIOMap* r_io_map_get_paddr(RIO* io, ut64 paddr) {
 	r_return_val_if_fail (io, NULL);
-	RIOMap* map;
-	SdbListIter* iter;
-	ls_foreach_prev (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach_prev (&io->maps, it) {
+		RIOMap *map = *it;
 		if (map->delta <= paddr && paddr <= map->delta + map->itv.size - 1) {
 			return map;
 		}
@@ -344,12 +339,15 @@ R_API RIOMap* r_io_map_get_paddr(RIO* io, ut64 paddr) {
 	return NULL;
 }
 
+#define CMP_SKYLINE(addr, part) ((addr) < r_itv_end (((RIOMapSkyline *)(part))->itv) - 1 ? -1 : \
+			(addr) > r_itv_end (((RIOMapSkyline *)(part))->itv) - 1 ? 1 : 0)
+
 // gets first map where addr fits in
-R_API RIOMap* r_io_map_get(RIO* io, ut64 addr) {
+R_API RIOMap *r_io_map_get(RIO* io, ut64 addr) {
 	r_return_val_if_fail (io, NULL);
-	RIOMap* map;
-	SdbListIter* iter;
-	ls_foreach_prev (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach_prev (&io->maps, it) {
+		RIOMap *map = *it;
 		if (r_itv_contain (map->itv, addr)) {
 			return map;
 		}
@@ -378,13 +376,14 @@ R_API void r_io_map_reset(RIO* io) {
 	io_map_calculate_skyline (io);
 }
 
-R_API bool r_io_map_del(RIO* io, ut32 id) {
+R_API bool r_io_map_del(RIO *io, ut32 id) {
 	r_return_val_if_fail (io, false);
-	RIOMap* map;
-	SdbListIter* iter;
-	ls_foreach (io->maps, iter, map) {
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps); i++) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		if (map->id == id) {
-			ls_delete (io->maps, iter);
+			r_pvector_remove_at (&io->maps, i);
+			_map_free (map);
 			r_id_pool_kick_id (io->map_ids, id);
 			io_map_calculate_skyline (io);
 			return true;
@@ -396,17 +395,20 @@ R_API bool r_io_map_del(RIO* io, ut32 id) {
 //delete all maps with specified fd
 R_API bool r_io_map_del_for_fd(RIO* io, int fd) {
 	r_return_val_if_fail (io, false);
-	SdbListIter* iter, * ator;
-	RIOMap* map;
 	bool ret = false;
-	ls_foreach_safe (io->maps, iter, ator, map) {
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps);) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		if (!map) {
-			ls_delete (io->maps, iter);
+			r_pvector_remove_at (&io->maps, i);
 		} else if (map->fd == fd) {
 			r_id_pool_kick_id (io->map_ids, map->id);
 			//delete iter and map
-			ls_delete (io->maps, iter);
+			r_pvector_remove_at (&io->maps, i);
+			_map_free (map);
 			ret = true;
+		} else {
+			i++;
 		}
 	}
 	if (ret) {
@@ -419,15 +421,14 @@ R_API bool r_io_map_del_for_fd(RIO* io, int fd) {
 //return a boolean denoting whether is was possible to priorized
 R_API bool r_io_map_priorize(RIO* io, ut32 id) {
 	r_return_val_if_fail (io, false);
-	RIOMap *map;
-	SdbListIter *iter;
-	ls_foreach (io->maps, iter, map) {
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps); i++) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		// search for iter with the correct map
 		if (map->id == id) {
-			ls_split_iter (io->maps, iter);
-			ls_append (io->maps, map);
+			r_pvector_remove_at (&io->maps, i);
+			r_pvector_push (&io->maps, map);
 			io_map_calculate_skyline (io);
-			free (iter);
 			return true;
 		}
 	}
@@ -436,55 +437,45 @@ R_API bool r_io_map_priorize(RIO* io, ut32 id) {
 
 R_API bool r_io_map_depriorize(RIO* io, ut32 id) {
 	r_return_val_if_fail (io, false);
-	RIOMap *map;
-	SdbListIter *iter;
-	ls_foreach (io->maps, iter, map) {
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps); i++) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		// search for iter with the correct map
 		if (map->id == id) {
-			ls_split_iter (io->maps, iter);
-			ls_prepend (io->maps, map);
+			r_pvector_remove_at (&io->maps, i);
+			r_pvector_push_front (&io->maps, map);
 			io_map_calculate_skyline (io);
-			free (iter);
 			return true;
 		}
 	}
 	return false;
 }
 
-R_API bool r_io_map_priorize_for_fd(RIO* io, int fd) {
-	SdbListIter* iter, * ator;
-	RIOMap *map;
-	SdbList* list;
-	if (!io || !io->maps) {
-		return false;
-	}
-	if (!(list = ls_new ())) {
-		return false;
-	}
+R_API bool r_io_map_priorize_for_fd(RIO *io, int fd) {
+	r_return_val_if_fail (io, false);
 	//we need a clean list for this, or this becomes a segfault-field
 	r_io_map_cleanup (io);
-	//temporary set to avoid free the map and to speed up ls_delete a bit
-	io->maps->free = NULL;
-	ls_foreach_safe (io->maps, iter, ator, map) {
+	RPVector temp;
+	r_pvector_init (&temp, NULL);
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps);) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		if (map->fd == fd) {
-			ls_prepend (list, map);
-			ls_delete (io->maps, iter);
+			r_pvector_push (&temp, map);
+			r_pvector_remove_at (&io->maps, i);
+			continue;
 		}
+		i++;
 	}
-	ls_join (io->maps, list);
-	ls_free (list);
-	io->maps->free = _map_free;
+	r_pvector_insert_range (&io->maps, r_pvector_len (&io->maps), temp.v.a, r_pvector_len (&temp));
+	r_pvector_clear (&temp);
 	io_map_calculate_skyline (io);
 	return true;
 }
 
 //may fix some inconsistencies in io->maps
 R_API void r_io_map_cleanup(RIO* io) {
-	SdbListIter* iter, * ator;
-	RIOMap* map;
-	if (!io || !io->maps) {
-		return;
-	}
+	r_return_if_fail (io);
 	//remove all maps if no descs exist
 	if (!io->files) {
 		r_io_map_fini (io);
@@ -492,16 +483,20 @@ R_API void r_io_map_cleanup(RIO* io) {
 		return;
 	}
 	bool del = false;
-	ls_foreach_safe (io->maps, iter, ator, map) {
+	size_t i;
+	for (i = 0; i < r_pvector_len (&io->maps);) {
+		RIOMap *map = r_pvector_at (&io->maps, i);
 		//remove iter if the map is a null-ptr, this may fix some segfaults
 		if (!map) {
-			ls_delete (io->maps, iter);
+			r_pvector_remove_at (&io->maps, i);
 			del = true;
 		} else if (!r_io_desc_get (io, map->fd)) {
 			//delete map and iter if no desc exists for map->fd in io->files
 			r_id_pool_kick_id (io->map_ids, map->id);
-			ls_delete (io->maps, iter);
+			r_pvector_remove_at (&io->maps, i);
 			del = true;
+		} else {
+			i++;
 		}
 	}
 	if (del) {
@@ -511,8 +506,7 @@ R_API void r_io_map_cleanup(RIO* io) {
 
 R_API void r_io_map_fini(RIO* io) {
 	r_return_if_fail (io);
-	ls_free (io->maps);
-	io->maps = NULL;
+	r_pvector_clear (&io->maps);
 	r_id_pool_free (io->map_ids);
 	io->map_ids = NULL;
 	r_pvector_clear (&io->map_skyline);
@@ -538,11 +532,11 @@ R_API ut64 r_io_map_next_available(RIO* io, ut64 addr, ut64 size, ut64 load_alig
 	if (load_align == 0) {
 		load_align = 1;
 	}
-	RIOMap* map;
-	SdbListIter* iter;
 	ut64 next_addr = addr,
 	end_addr = next_addr + size;
-	ls_foreach (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
 		ut64 to = r_itv_end (map->itv);
 		next_addr = R_MAX (next_addr, to + (load_align - (to % load_align)) % load_align);
 		// XXX - This does not handle when file overflow 0xFFFFFFFF000 -> 0x00000FFF
@@ -559,11 +553,10 @@ R_API ut64 r_io_map_next_available(RIO* io, ut64 addr, ut64 size, ut64 load_alig
 
 // TODO: very similar to r_io_map_next_available. decide which one to use
 R_API ut64 r_io_map_next_address(RIO* io, ut64 addr) {
-	RIOMap* map;
-	SdbListIter* iter;
 	ut64 lowest = UT64_MAX;
-
-	ls_foreach (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
 		ut64 from = r_itv_begin (map->itv);
 		if (from > addr && addr < lowest) {
 			lowest = from;
@@ -578,12 +571,12 @@ R_API ut64 r_io_map_next_address(RIO* io, ut64 addr) {
 
 R_API RList* r_io_map_get_for_fd(RIO* io, int fd) {
 	RList* map_list = r_list_newf (NULL);
-	SdbListIter* iter;
-	RIOMap* map;
 	if (!map_list) {
 		return NULL;
 	}
-	ls_foreach (io->maps, iter, map) {
+	void **it;
+	r_pvector_foreach (&io->maps, it) {
+		RIOMap *map = *it;
 		if (map && map->fd == fd) {
 			r_list_append (map_list, map);
 		}


### PR DESCRIPTION
**Detailed description**

Replace the SdbList of RIO.maps by an RPVector for better cache-friendliness in #14024.
Of course this does not change the `O(n^2)` complexity in that test but at least removes the linked list overhead. There are many other places where this list is linearly iterated, so using a vector is a good choice.
RVector instead of RPVector would be even better, but then the pointers wouldn't be stable anymore.

**Test plan**

Run the `db/formats/pe/65535sects` test.
Before: 26s
After: 15s

**Related issues**

#14024