### PR TITLE
Run Fuzz Tests with r2r

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -467,6 +467,14 @@ R_API RPVector *r2r_load_json_test_file(const char *file) {
 	return ret;
 }
 
+R_API void r2r_fuzz_test_free(R2RFuzzTest *test) {
+	if (!test) {
+		return;
+	}
+	free (test->file);
+	free (test);
+}
+
 R_API void r2r_test_free(R2RTest *test) {
 	if (!test) {
 		return;
@@ -480,6 +488,9 @@ R_API void r2r_test_free(R2RTest *test) {
 		break;
 	case R2R_TEST_TYPE_JSON:
 		r2r_json_test_free (test->json_test);
+		break;
+	case R2R_TEST_TYPE_FUZZ:
+		r2r_fuzz_test_free (test->fuzz_test);
 		break;
 	}
 	free (test);
@@ -644,6 +655,9 @@ static bool database_load(R2RTestDatabase *db, const char *path, int depth) {
 		r_pvector_free (json_tests);
 		break;
 	}
+	case R2R_TEST_TYPE_FUZZ:
+		// shouldn't come here, fuzz tests are loaded differently
+		break;
 	}
 
 	return true;
@@ -651,4 +665,62 @@ static bool database_load(R2RTestDatabase *db, const char *path, int depth) {
 
 R_API bool r2r_test_database_load(R2RTestDatabase *db, const char *path) {
 	return database_load (db, path, 4);
+}
+
+static void database_load_fuzz_file(R2RTestDatabase *db, const char *path, const char *file) {
+	R2RFuzzTest *fuzz_test = R_NEW (R2RFuzzTest);
+	if (!fuzz_test) {
+		return;
+	}
+	fuzz_test->file = strdup (file);
+	if (!fuzz_test->file) {
+		return;
+	}
+	R2RTest *test = R_NEW (R2RTest);
+	if (!test) {
+		free (fuzz_test->file);
+		free (fuzz_test);
+		return;
+	}
+	test->type = R2R_TEST_TYPE_FUZZ;
+	test->fuzz_test = fuzz_test;
+	test->path = r_str_constpool_get (&db->strpool, path);
+	r_pvector_push (&db->tests, test);
+}
+
+R_API bool r2r_test_database_load_fuzz(R2RTestDatabase *db, const char *path) {
+	if (r_file_is_directory (path)) {
+		RList *dir = r_sys_dir (path);
+		if (!dir) {
+			return false;
+		}
+		RListIter *it;
+		const char *subname;
+		RStrBuf subpath;
+		r_strbuf_init (&subpath);
+		bool ret = true;
+		r_list_foreach (dir, it, subname) {
+			if (*subname == '.') {
+				continue;
+			}
+			r_strbuf_setf (&subpath, "%s%s%s", path, R_SYS_DIR, subname);
+			if (r_file_is_directory (r_strbuf_get (&subpath))) {
+				// only load 1 level deep
+				continue;
+			}
+			database_load_fuzz_file (db, path, r_strbuf_get (&subpath));
+		}
+		r_strbuf_fini (&subpath);
+		r_list_free (dir);
+		return ret;
+	}
+
+	if (!r_file_exists (path)) {
+		eprintf ("Path \"%s\" does not exist\n", path);
+		return false;
+	}
+
+	// Just a single file
+	database_load_fuzz_file (db, path, path);
+	return true;
 }

--- a/binr/r2r/r2r.h
+++ b/binr/r2r/r2r.h
@@ -86,10 +86,15 @@ typedef struct r2r_json_test_t {
 	bool load_plugins;
 } R2RJsonTest;
 
+typedef struct r2r_fuzz_test_t {
+	char *file;
+} R2RFuzzTest;
+
 typedef enum r2r_test_type_t {
 	R2R_TEST_TYPE_CMD,
 	R2R_TEST_TYPE_ASM,
-	R2R_TEST_TYPE_JSON
+	R2R_TEST_TYPE_JSON,
+	R2R_TEST_TYPE_FUZZ
 } R2RTestType;
 
 typedef struct r2r_test_t {
@@ -99,6 +104,7 @@ typedef struct r2r_test_t {
 		R2RCmdTest *cmd_test;
 		R2RAsmTest *asm_test;
 		R2RJsonTest *json_test;
+		R2RFuzzTest *fuzz_test;
 	};
 } R2RTest;
 
@@ -142,7 +148,7 @@ typedef struct r2r_test_result_info_t {
 	bool timeout;
 	bool run_failed; // something went seriously wrong (e.g. r2 not found)
 	union {
-		R2RProcessOutput *proc_out; // for test->type == R2R_TEST_TYPE_CMD or R2R_TEST_TYPE_JSON
+		R2RProcessOutput *proc_out; // for test->type == R2R_TEST_TYPE_CMD, R2R_TEST_TYPE_JSON or R2R_TEST_TYPE_FUZZ
 		R2RAsmTestOutput *asm_out;  // for test->type == R2R_TEST_TYPE_ASM
 	};
 } R2RTestResultInfo;
@@ -162,6 +168,7 @@ R_API RPVector *r2r_load_json_test_file(const char *file);
 R_API R2RTestDatabase *r2r_test_database_new(void);
 R_API void r2r_test_database_free(R2RTestDatabase *db);
 R_API bool r2r_test_database_load(R2RTestDatabase *db, const char *path);
+R_API bool r2r_test_database_load_fuzz(R2RTestDatabase *db, const char *path);
 
 typedef struct r2r_subprocess_t R2RSubprocess;
 
@@ -182,10 +189,11 @@ R_API bool r2r_check_cmd_test(R2RProcessOutput *out, R2RCmdTest *test);
 R_API bool r2r_check_jq_available(void);
 R_API R2RProcessOutput *r2r_run_json_test(R2RRunConfig *config, R2RJsonTest *test, R2RCmdRunner runner, void *user);
 R_API bool r2r_check_json_test(R2RProcessOutput *out, R2RJsonTest *test);
-
 R_API R2RAsmTestOutput *r2r_run_asm_test(R2RRunConfig *config, R2RAsmTest *test);
 R_API bool r2r_check_asm_test(R2RAsmTestOutput *out, R2RAsmTest *test);
 R_API void r2r_asm_test_output_free(R2RAsmTestOutput *out);
+R_API R2RProcessOutput *r2r_run_fuzz_test(R2RRunConfig *config, R2RFuzzTest *test, R2RCmdRunner runner, void *user);
+R_API bool r2r_check_fuzz_test(R2RProcessOutput *out);
 
 R_API void r2r_test_free(R2RTest *test);
 R_API char *r2r_test_name(R2RTest *test);

--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -25,6 +25,7 @@ R_API char *r_file_temp(const char *prefix);
 R_API char *r_file_path(const char *bin);
 R_API const char *r_file_basename(const char *path);
 R_API char *r_file_dirname(const char *path);
+R_API char *r_file_abspath_rel(const char *cwd, const char *file);
 R_API char *r_file_abspath(const char *file);
 R_API ut8 *r_inflate(const ut8 *src, int srcLen, int *srcConsumed, int *dstLen);
 R_API ut8 *r_file_gzslurp(const char *str, int *outlen, int origonfail);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -201,15 +201,14 @@ R_API int r_file_is_abspath(const char *file) {
 	return ((*file && file[1]==':') || *file == '/');
 }
 
-R_API char *r_file_abspath(const char *file) {
-	char *cwd, *ret = NULL;
+R_API char *r_file_abspath_rel(const char *cwd, const char *file) {
+	char *ret = NULL;
 	if (!file || !strcmp (file, ".") || !strcmp (file, "./")) {
 		return r_sys_getdir ();
 	}
 	if (strstr (file, "://")) {
 		return strdup (file);
 	}
-	cwd = r_sys_getdir ();
 	if (!strncmp (file, "~/", 2) || !strncmp (file, "~\\", 2)) {
 		ret = r_str_home (file + 2);
 	} else {
@@ -240,7 +239,6 @@ R_API char *r_file_abspath(const char *file) {
 		}
 #endif
 	}
-	free (cwd);
 	if (!ret) {
 		ret = strdup (file);
 	}
@@ -251,6 +249,13 @@ R_API char *r_file_abspath(const char *file) {
 		ret = abspath;
 	}
 #endif
+	return ret;
+}
+
+R_API char *r_file_abspath(const char *file) {
+	char *cwd = r_sys_getdir ();
+	char *ret = r_file_abspath_rel (cwd, file);
+	free (cwd);
 	return ret;
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,3 @@
-R2R=$(shell cd new ; npm bin)/r2r
-RUNTEST=cd new && npm install ; $(R2R)
-
 all: r2r-tests unit_tests
 
 bins:
@@ -18,6 +15,9 @@ RUNTEST=cd new && r2r -L
 
 r2r-tests: bins
 	${RUNTEST}
+
+fuzz-tests: bins
+	r2r -LF bins/fuzzed @fuzz
 
 keystone: bins
 	${RUNTEST} db/extras/asm/x86.ks_


### PR DESCRIPTION
**Detailed description**

Usage: `r2r -F bins/fuzzed @fuzz` or `make fuzz-tests` in `test/`
Unfortunately it is currently necessary to manually pass the path to the tests since we only search for `db` and going from db to the fuzz tests automatically would be `../bins/fuzzed` which seems very dirty to me.
There are still many segfaulting files there so this should be fixed before going in the CI.