### PR TITLE
Fix #16109 - Add R_SYS_ARCH for s390x ##ports

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -370,7 +370,7 @@ R_API int r_asm_set_bits(RAsm *a, int bits) {
 
 R_API bool r_asm_set_big_endian(RAsm *a, bool b) {
 	r_return_val_if_fail (a && a->cur, false);
-	a->big_endian = false; //little endian by default
+	a->big_endian = false; // little endian by default
 	switch (a->cur->endian) {
 	case R_SYS_ENDIAN_NONE:
 	case R_SYS_ENDIAN_BI:

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -481,7 +481,7 @@ static inline void *r_new_copy(int size, void *data) {
 #define R_SYS_BITS R_SYS_BITS_32
 #define R_SYS_ENDIAN 0
 #elif __s390x__
-#define R_SYS_ARCH "s390x"
+#define R_SYS_ARCH "sysz"
 #define R_SYS_BITS R_SYS_BITS_64
 #define R_SYS_ENDIAN 1
 #elif __sparc__

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -480,6 +480,10 @@ static inline void *r_new_copy(int size, void *data) {
 #define R_SYS_ARCH "arc"
 #define R_SYS_BITS R_SYS_BITS_32
 #define R_SYS_ENDIAN 0
+#elif __s390x__
+#define R_SYS_ARCH "s390x"
+#define R_SYS_BITS R_SYS_BITS_64
+#define R_SYS_ENDIAN 1
 #elif __sparc__
 #define R_SYS_ARCH "sparc"
 #define R_SYS_BITS R_SYS_BITS_32


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

should fix the problems in travis-s390x related to setting the endianness because there's no such arch if it's not in the .h.

**Test plan**
wait for travis

**Closing issues**

#16109 