### PR TITLE
Fix #16305 - UAF in @@@{r,i,s,S,b} as well as add some help for `oc`

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4020,7 +4020,7 @@ R_API int r_core_cmd_foreach3(RCore *core, const char *cmd, char *each) { // "@@
 		}
 #endif
 		break;
-	case 's': // XXX this command will crash when used with 'oc' (ocm'@@@s)
+	case 's':
 		if (each[1] == 't') { // strings
 			list = r_bin_get_strings (core->bin);
 			if (list) {


### PR DESCRIPTION
This oneliner still segfaults:

$ r2 -c "ocm'@@@f:sym*" /bin/ls

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix crash because the core is recreated and all the references are broken, so anything that can call ocm' can lead to a crash. which is really painful to do. but will improve overall stability

**Test plan**

* ocm'@@@i
* ocm'@@@S
* ocm'@@@b

do we want tests for those?

**Closing issues**

#16305
...
