### PR TITLE
Run newshell tests when PR is newshell-*

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [linux-acr-gcc, linux-acr-clang, linux-meson-gcc, linux-meson-newshell, macos-clang]
+        name: [linux-acr-gcc, linux-acr-clang, linux-meson-gcc, macos-clang]
         include:
           - name: linux-acr-gcc
             os: ubuntu-latest
@@ -28,12 +28,6 @@ jobs:
             compiler: gcc
             meson_options: -Db_coverage=true
             coverage: 1
-          - name: linux-meson-newshell
-            os: ubuntu-latest
-            build_system: meson
-            compiler: gcc
-            meson_options: -Duse_treesitter=true
-            newshell: newshell
           - name: macos-clang
             os: macos-latest
             build_system: acr
@@ -84,23 +78,11 @@ jobs:
         export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
         ninja -C build install
     - name: Run tests
-      if: matrix.newshell != 'newshell'
       run: |
         # Running the test suite
         export PATH=${HOME}/bin:${HOME}/.local/bin:${PATH}
         export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
         export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
-        cd test
-        make
-    - name: Run tests with newshell
-      if: matrix.newshell == 'newshell'
-      continue-on-error: true
-      run: |
-        # Running the test suite
-        export PATH=${HOME}/bin:${HOME}/.local/bin:${PATH}
-        export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
-        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
-        export R2_CFG_NEWSHELL=1
         cd test
         make
     - name: Upload coverage info

--- a/.github/workflows/newshell.yml
+++ b/.github/workflows/newshell.yml
@@ -1,0 +1,58 @@
+name: Radare2 CI newshell
+
+on:
+  pull_request:
+    branches:
+    - 'newshell-*'
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [linux-meson-newshell]
+        include:
+          - name: linux-meson-newshell
+            os: ubuntu-latest
+            build_system: meson
+            compiler: gcc
+            meson_options: -Duse_treesitter=true
+            newshell: newshell
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install meson and ninja
+      run: sudo apt-get --assume-yes install python3-wheel python3-setuptools && pip3 install --user meson ninja
+    - name: Checkout our Testsuite Binaries
+      uses: actions/checkout@v2
+      with:
+          repository: radareorg/radare2-testbins
+          path: test/bins
+    - name: Build with Meson
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        meson ${{ matrix.meson_options }} --prefix=${HOME} build && ninja -C build
+      env:
+        CC: ${{ matrix.compiler }}
+    - name: Install with meson
+      run: |
+        # Install the radare2
+        export PATH=${HOME}/bin:${HOME}/.local/bin:${PATH}
+        export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
+        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
+        ninja -C build install
+    - name: Run tests
+      continue-on-error: true
+      run: |
+        # Running the test suite
+        export PATH=${HOME}/bin:${HOME}/.local/bin:${PATH}
+        export LD_LIBRARY_PATH=${HOME}/lib/$(uname -m)-linux-gnu:${HOME}/lib:${HOME}/lib64:${LD_LIBRARY_PATH}
+        export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
+        export R2_CFG_NEWSHELL=1
+        cd test
+        make


### PR DESCRIPTION
Split the workflow for newshell in a separate file so that it can be run also on pull-requests with branch name starting with `newshell-*`