### PR TITLE
Fix #16343 - Do not generate numeric structs from unnamed typedefs in "ts" ##types

### DIFF
--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -406,13 +406,13 @@ static Sdb *TDB_ = NULL; // HACK
 
 static int stdifstruct(void *user, const char *k, const char *v) {
 	r_return_val_if_fail (TDB_, false);
-	if (!strcmp (v, "struct")) {
+	if (!strcmp (v, "struct") && !r_str_startswith (k, "typedef")) {
 		return true;
 	}
 	if (!strcmp (v, "typedef")) {
 		const char *typedef_key = sdb_fmt ("typedef.%s", k);
 		const char *type = sdb_const_get (TDB_, typedef_key, NULL);
-		if (type && r_str_startswith (type, "struct ")) {
+		if (type && r_str_startswith (type, "struct")) {
 			return true;
 		}
 	}

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -440,7 +440,6 @@ static int print_struct_union_list_json(Sdb *TDB, SdbForeachCallback filter) {
 		if (!k || !*k) {
 			continue;
 		}
-
 		pj_o (pj); // {
 		char *sizecmd = r_str_newf ("%s.%s.!size", sdbkv_value (kv), k);
 		if (!sizecmd) {
@@ -1129,10 +1128,10 @@ static int cmd_type(void *data, const char *input) {
 		case 0:
 			print_keys (TDB, core, stdifstruct, printkey_cb, false);
 			break;
-		case 'c':
+		case 'c': // "tsc"
 			print_struct_union_in_c_format (TDB, stdifstruct, r_str_trim_head_ro (input + 2), true);
 			break;
-		case 'd':
+		case 'd': // "tsd"
 			print_struct_union_in_c_format (TDB, stdifstruct, r_str_trim_head_ro (input + 2), false);
 			break;
 		case 'j': // "tsj"

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -379,16 +379,15 @@ static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
 	char *fields = r_str_newf("%s.fields", var);
 	char *nfields = (is_typedef) ? fields : var;
 	for (n = 0; (p = sdb_array_get (TDB, nfields, n, NULL)); n++) {
-		char *type;
 		char *struct_name;
 		const char *tfmt = NULL;
 		bool isStruct = false;
 		bool isEnum = false;
 		bool isfp = false;
 		snprintf (var2, sizeof (var2), "%s.%s", var, p);
-		type = sdb_array_get (TDB, var2, 0, NULL);
 		int alen = sdb_array_size (TDB, var2);
 		int elements = sdb_array_get_num (TDB, var2, alen - 1, NULL);
+		char *type = sdb_array_get (TDB, var2, 0, NULL);
 		if (type) {
 			char var3[128] = {0};
 			// Handle general pointers except for char *
@@ -477,7 +476,7 @@ R_API char *r_type_format(Sdb *TDB, const char *t) {
 		const char *type = sdb_const_get (TDB, var2, NULL);
 		// only supports struct atm
 		if (type && r_str_startswith (type, "struct ")) {
-			return fmt_struct_union(TDB, var, true);
+			return fmt_struct_union (TDB, var, true);
 		}
 	}
 	return NULL;

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -372,11 +372,92 @@ static void filter_type(char *t) {
 	}
 }
 
-R_API char *r_type_format(Sdb *TDB, const char *t) {
+static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
+	// assumes var list is sorted by offset.. should do more checks here
+	char *p = NULL, *vars = NULL, var2[132], *fmt = NULL;
 	int n;
-	char *p, var[130], var2[132];
-	char *fmt = NULL;
-	char *vars = NULL;
+	char *fields = r_str_newf("%s.fields", var);
+	char *nfields = (is_typedef) ? fields : var;
+	for (n = 0; (p = sdb_array_get (TDB, nfields, n, NULL)); n++) {
+		char *type;
+		char *struct_name;
+		const char *tfmt = NULL;
+		bool isStruct = false;
+		bool isEnum = false;
+		bool isfp = false;
+		snprintf (var2, sizeof (var2), "%s.%s", var, p);
+		type = sdb_array_get (TDB, var2, 0, NULL);
+		int alen = sdb_array_size (TDB, var2);
+		int elements = sdb_array_get_num (TDB, var2, alen - 1, NULL);
+		if (type) {
+			char var3[128] = {0};
+			// Handle general pointers except for char *
+			if ((strstr (type, "*(") || strstr (type, " *")) &&
+			  strncmp (type, "char *", 7)) {
+				isfp = true;
+			} else if (!strncmp (type, "struct ", 7)) {
+				struct_name = type + 7;
+				// TODO: iterate over all the struct fields, and format the format and vars
+				snprintf (var3, sizeof (var3), "struct.%s", struct_name);
+				tfmt = sdb_const_get (TDB, var3, NULL);
+				isStruct = true;
+			} else {
+				// special case for char[]. Use char* format type without *
+				if (!strncmp (type, "char", 5) && elements > 0) {
+					tfmt = sdb_const_get (TDB, "type.char *", NULL);
+					if (tfmt && *tfmt == '*') {
+						tfmt++;
+					}
+				} else {
+					if (!strncmp (type, "enum ", 5)) {
+						snprintf (var3, sizeof (var3), "%s", type + 5);
+						isEnum = true;
+					} else {
+						snprintf (var3, sizeof (var3), "type.%s", type);
+					}
+					tfmt = sdb_const_get (TDB, var3, NULL);
+				}
+
+			}
+			if (isfp) {
+				// consider function pointer as void * for printing
+				fmt = r_str_append (fmt, "p");
+				vars = r_str_append (vars, p);
+				vars = r_str_append (vars, " ");
+			} else if (tfmt) {
+				filter_type (type);
+				if (elements > 0) {
+					fmt = r_str_appendf (fmt, "[%d]", elements);
+				}
+				if (isStruct) {
+					fmt = r_str_append (fmt, "?");
+					vars = r_str_appendf (vars, "(%s)%s", struct_name, p);
+					vars = r_str_append (vars, " ");
+				} else if (isEnum) {
+					fmt = r_str_append (fmt, "E");
+					vars = r_str_appendf (vars, "(%s)%s", type + 5, p);
+					vars = r_str_append (vars, " ");
+				} else {
+					fmt = r_str_append (fmt, tfmt);
+					vars = r_str_append (vars, p);
+					vars = r_str_append (vars, " ");
+				}
+			} else {
+				eprintf ("Cannot resolve type '%s'\n", var3);
+			}
+		free (type);
+		}
+		free (p);
+	}
+	free (fields);
+	fmt = r_str_append (fmt, " ");
+	fmt = r_str_append (fmt, vars);
+	free (vars);
+	return fmt;
+}
+
+R_API char *r_type_format(Sdb *TDB, const char *t) {
+	char var[130], var2[132];
 	const char *kind = sdb_const_get (TDB, t, NULL);
 	if (!kind) {
 		return NULL;
@@ -389,89 +470,14 @@ R_API char *r_type_format(Sdb *TDB, const char *t) {
 			return strdup (fmt);
 		}
 	} else if (!strcmp (kind, "struct") || !strcmp (kind, "union")) {
-		// assumes var list is sorted by offset.. should do more checks here
-		for (n = 0; (p = sdb_array_get (TDB, var, n, NULL)); n++) {
-			char *type;
-			char *struct_name;
-			const char *tfmt = NULL;
-			bool isStruct = false;
-			bool isEnum = false;
-			bool isfp = false;
-			snprintf (var2, sizeof (var2), "%s.%s", var, p);
-			type = sdb_array_get (TDB, var2, 0, NULL);
-			int alen = sdb_array_size (TDB, var2);
-			int elements = sdb_array_get_num (TDB, var2, alen - 1, NULL);
-			if (type) {
-				char var3[128] = {0};
-				// Handle general pointers except for char *
-				if ((strstr (type, "*(") || strstr (type, " *")) &&
-						strncmp (type, "char *", 7)) {
-					isfp = true;
-				} else if (!strncmp (type, "struct ", 7)) {
-					struct_name = type + 7;
-					// TODO: iterate over all the struct fields, and format the format and vars
-					snprintf (var3, sizeof (var3), "struct.%s", struct_name);
-					tfmt = sdb_const_get (TDB, var3, NULL);
-					isStruct = true;
-				} else {
-					// special case for char[]. Use char* format type without *
-					if (!strncmp (type, "char", 5) && elements > 0) {
-						tfmt = sdb_const_get (TDB, "type.char *", NULL);
-						if (tfmt && *tfmt == '*') {
-							tfmt++;
-						}
-					} else {
-						if (!strncmp (type, "enum ", 5)) {
-							snprintf (var3, sizeof (var3), "%s", type + 5);
-							isEnum = true;
-						} else {
-							snprintf (var3, sizeof (var3), "type.%s", type);
-						}
-						tfmt = sdb_const_get (TDB, var3, NULL);
-					}
-
-				}
-				if (isfp) {
-					// consider function pointer as void * for printing
-					fmt = r_str_append (fmt, "p");
-					vars = r_str_append (vars, p);
-					vars = r_str_append (vars, " ");
-				} else if (tfmt) {
-					filter_type (type);
-					if (elements > 0) {
-						fmt = r_str_appendf (fmt, "[%d]", elements);
-					}
-					if (isStruct) {
-						fmt = r_str_append (fmt, "?");
-						vars = r_str_appendf (vars, "(%s)%s", struct_name, p);
-						vars = r_str_append (vars, " ");
-					} else if (isEnum) {
-						fmt = r_str_append (fmt, "E");
-						vars = r_str_appendf (vars, "(%s)%s", type + 5, p);
-						vars = r_str_append (vars, " ");
-					} else {
-						fmt = r_str_append (fmt, tfmt);
-						vars = r_str_append (vars, p);
-						vars = r_str_append (vars, " ");
-					}
-				} else {
-					eprintf ("Cannot resolve type '%s'\n", var3);
-				}
-			}
-			free (type);
-			free (p);
-		}
-		fmt = r_str_append (fmt, " ");
-		fmt = r_str_append (fmt, vars);
-		free (vars);
-		return fmt;
+		return fmt_struct_union(TDB, var, false);
 	}
 	if (!strcmp (kind, "typedef")) {
 		snprintf (var2, sizeof (var2), "typedef.%s", t);
 		const char *type = sdb_const_get (TDB, var2, NULL);
 		// only supports struct atm
-		if (type && r_str_startswith (type, "struct ") && strcmp (type + 7, t)) {
-			return r_type_format (TDB, type + 7);
+		if (type && r_str_startswith (type, "struct ")) {
+			return fmt_struct_union(TDB, var, true);
 		}
 	}
 	return NULL;

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -376,7 +376,7 @@ static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
 	// assumes var list is sorted by offset.. should do more checks here
 	char *p = NULL, *vars = NULL, var2[132], *fmt = NULL;
 	int n;
-	char *fields = r_str_newf("%s.fields", var);
+	char *fields = r_str_newf ("%s.fields", var);
 	char *nfields = (is_typedef) ? fields : var;
 	for (n = 0; (p = sdb_array_get (TDB, nfields, n, NULL)); n++) {
 		char *struct_name;
@@ -475,7 +475,7 @@ R_API char *r_type_format(Sdb *TDB, const char *t) {
 		snprintf (var2, sizeof (var2), "typedef.%s", t);
 		const char *type = sdb_const_get (TDB, var2, NULL);
 		// only supports struct atm
-		if (type && r_str_startswith (type, "struct ")) {
+		if (type && !strcmp (type, "struct")) {
 			return fmt_struct_union (TDB, var, true);
 		}
 	}

--- a/shlr/tcc/libtcc.c
+++ b/shlr/tcc/libtcc.c
@@ -805,7 +805,7 @@ PUB_FUNC void tcc_appendf(const char *fmt, ...) {
 PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...) {
 	char **typedefs_start;
 	if (!tcc_typedefs) {
-		tcc_typedefs = (char **)malloc (100);
+		tcc_typedefs = (char **)calloc (50, 1024);
 		typedefs_start = tcc_typedefs;
 	} else {
 		typedefs_start = tcc_typedefs;

--- a/shlr/tcc/libtcc.c
+++ b/shlr/tcc/libtcc.c
@@ -801,3 +801,23 @@ PUB_FUNC void tcc_appendf(const char *fmt, ...) {
 	tcc_cb (b, tcc_cb_ptr);
 	va_end (ap);
 }
+
+PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...) {
+	char **typedefs_start;
+	if (!tcc_typedefs) {
+		tcc_typedefs = (char **)malloc (100);
+		typedefs_start = tcc_typedefs;
+	} else {
+		typedefs_start = tcc_typedefs;
+		while (*tcc_typedefs) {
+			tcc_typedefs++;
+		}
+	}
+	char typedefs_tail[1024];
+	va_list ap;
+	va_start (ap, fmt);
+	vsnprintf (typedefs_tail, sizeof (typedefs_tail), fmt, ap);
+	*tcc_typedefs = strdup (typedefs_tail);
+	tcc_typedefs = typedefs_start;
+	va_end (ap);
+}

--- a/shlr/tcc/libtcc.h
+++ b/shlr/tcc/libtcc.h
@@ -94,7 +94,6 @@ LIBTCCAPI int tcc_relocate(TCCState *s1, void *ptr);
 LIBTCCAPI void *tcc_get_symbol(TCCState *s, const char *name);
 
 extern char **tcc_cb_ptr;
-extern char **tcc_typedefs;
 
 void tcc_set_callback (TCCState *s, void (*cb)(const char *,char**), char **p);
 

--- a/shlr/tcc/libtcc.h
+++ b/shlr/tcc/libtcc.h
@@ -94,6 +94,7 @@ LIBTCCAPI int tcc_relocate(TCCState *s1, void *ptr);
 LIBTCCAPI void *tcc_get_symbol(TCCState *s, const char *name);
 
 extern char **tcc_cb_ptr;
+extern char **tcc_typedefs;
 
 void tcc_set_callback (TCCState *s, void (*cb)(const char *,char**), char **p);
 

--- a/shlr/tcc/tcc.h
+++ b/shlr/tcc/tcc.h
@@ -1059,7 +1059,8 @@ ST_FUNC int classify_x86_64_va_arg(CType *ty);
 #define ST_DATA
 #endif
 /********************************************************/
-PUB_FUNC void tcc_appendf (const char *fmt, ...);
+PUB_FUNC void tcc_appendf(const char *fmt, ...);
+PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...);
 
 extern void (*tcc_cb)(const char *, char **);
 

--- a/shlr/tcc/tcc.h
+++ b/shlr/tcc/tcc.h
@@ -1061,6 +1061,7 @@ ST_FUNC int classify_x86_64_va_arg(CType *ty);
 /********************************************************/
 PUB_FUNC void tcc_appendf(const char *fmt, ...);
 PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...);
+PUB_FUNC void tcc_typedef_alias_fields(const char *alias);
 
 extern void (*tcc_cb)(const char *, char **);
 

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -26,7 +26,6 @@
 } while (0)
 /* callback pointer */
 ST_DATA char **tcc_cb_ptr;
-ST_DATA char **tcc_typedefs;
 
 /********************************************************/
 /* global variables */
@@ -40,6 +39,7 @@ ST_DATA int rsym, anon_sym = SYM_FIRST_ANOM, ind, loc;
 ST_DATA Sym *sym_free_first;
 ST_DATA void **sym_pools;
 ST_DATA int nb_sym_pools;
+
 static int arraysize = 0;
 
 static const char *global_symname = NULL;
@@ -3195,13 +3195,7 @@ func_error1:
 					type_to_str(buf, sizeof(buf), &sym->type, NULL);
 					tcc_appendf ("%s=typedef\n", alias);
 					tcc_appendf ("typedef.%s=%s\n", alias, buf);
-					if (tcc_typedefs) {
-						while (*tcc_typedefs) { // XXX it should not enter here
-							tcc_appendf (*tcc_typedefs, alias);
-							free (*tcc_typedefs);
-							tcc_typedefs++;
-						}
-					}
+					tcc_typedef_alias_fields (alias);
 				} else {
 					r = 0;
 					if ((type.t & VT_BTYPE) == VT_FUNC) {

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -756,15 +756,16 @@ add_tstr:
 	case VT_STRUCT:
 	case VT_UNION:
 		if (bt == VT_STRUCT) {
-			tstr = "struct ";
+			tstr = "struct";
 		} else if (bt == VT_UNION) {
-			tstr = "union ";
+			tstr = "union";
 		} else {
-			tstr = "enum ";
+			tstr = "enum";
 		}
 		pstrcat (buf, buf_size, tstr);
 		v = type->ref->v & ~SYM_STRUCT;
 		if (v < SYM_FIRST_ANOM) {
+			pstrcat (buf, buf_size, " ");
 			pstrcat (buf, buf_size, get_tok_str (v, NULL));
 		}
 		break;

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -3195,7 +3195,7 @@ func_error1:
 					tcc_appendf ("%s=typedef\n", alias);
 					tcc_appendf ("typedef.%s=%s\n", alias, buf);
 					if (tcc_typedefs) {
-						while (*tcc_typedefs != NULL) { // XXX it should not enter here
+						while (*tcc_typedefs) { // XXX it should not enter here
 							tcc_appendf (*tcc_typedefs, alias);
 							free (*tcc_typedefs);
 							tcc_typedefs++;

--- a/shlr/tcc/tccgen.c
+++ b/shlr/tcc/tccgen.c
@@ -1184,9 +1184,9 @@ do_decl:
 							int type_bt = type1.t & VT_BTYPE;
 							//eprintf("2: %s.%s = %s\n", ctype, name, varstr);
 							if (is_typedef && autonamed) {
-								tcc_typedef_appendf ("[+]typedef.%%1$s.fields=%s\n", varstr);
-								tcc_typedef_appendf ("typedef.%%1$s.%s.meta=%d\n", varstr, type_bt);
-								tcc_typedef_appendf ("typedef.%%1$s.%s=%s,%d,%d\n", varstr, b, offset, arraysize);
+								tcc_typedef_appendf ("[+]typedef.%%s.fields=%s\n", varstr);
+								tcc_typedef_appendf ("typedef.%%s.%s.meta=%d\n", varstr, type_bt);
+								tcc_typedef_appendf ("typedef.%%s.%s=%s,%d,%d\n", varstr, b, offset, arraysize);
 							} else {
 								tcc_appendf ("[+]%s.%s=%s\n",
 									ctype, name, varstr);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1,3 +1,20 @@
+NAME=td anonymous struct in typedef
+FILE=--
+CMDS=<<EOF
+"td typedef struct {int a;} Foo;"
+"td typedef struct { char *hello; int world[]; } Bar;"
+ts~Foo,Bar
+ts Foo
+ts Bar
+EOF
+EXPECT=<<EOF
+Bar
+Foo
+pf d a
+pf zd hello world
+EOF
+RUN
+
 NAME=typelinks
 FILE=-
 CMDS=<<EOF
@@ -887,22 +904,15 @@ NAME=typedef struct
 FILE=-
 CMDS=<<EOF
 to bins/headers/12272.h
-ts 0
-ts 1
-?e ----
 ts A
 ts B
 ts O  # Broken but shouldn't hang
 ?e ----
-tk~^0,1
-tk~typedef.A=,typedef.B=,typedef.O=,struct.0,struct.1,struct.A,struct.B,struct.O
+tk~typedef.A=,typedef.B=,typedef.O=,struct.A,struct.B,struct.O
 ?e
-ts~0,1,A,B,O
+ts~A,B,O
 EOF
 EXPECT=<<EOF
-pf dF num num2
-pf c ch
-----
 pf dF num num2
 pf c ch
 ----
@@ -954,27 +964,7 @@ EXPECT=<<EOF
 pf f num
 pf c ch
 
-struct.0=num
-struct.0.!size=32
-struct.0.num=float,0,0
-struct.0.num.meta=9
-struct.1=ch
-struct.1.!size=8
-struct.1.ch=char,0,0
-struct.1.ch.meta=2
-struct.2=num
-struct.2.!size=32
-struct.2.num=float,0,0
-struct.2.num.meta=9
-struct.3=ch
-struct.3.!size=8
-struct.3.ch=char,0,0
-struct.3.ch.meta=2
 
-0
-1
-2
-3
 A
 B
 EOF

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -915,31 +915,18 @@ EOF
 EXPECT=<<EOF
 pf dF num num2
 pf c ch
+pf
 ----
-0=struct
-1=struct
-struct.0=num,num2
-struct.0.!size=96
-struct.0.num=int32_t,0,0
-struct.0.num.meta=0
-struct.0.num2=double,8,0
-struct.0.num2.meta=10
-struct.1=ch
-struct.1.!size=8
-struct.1.ch=char,0,0
-struct.1.ch.meta=2
 struct.A=num
 struct.A.num=float,0,0
 struct.A.num.meta=9
 struct.O=ptr
 struct.O.ptr=char *,0,0
 struct.O.ptr.meta=4
-typedef.A=struct 0
-typedef.B=struct 1
+typedef.A=struct
+typedef.B=struct
 typedef.O=struct O
 
-0
-1
 A
 B
 O

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -915,7 +915,6 @@ EOF
 EXPECT=<<EOF
 pf dF num num2
 pf c ch
-pf 
 ----
 struct.A=num
 struct.A.num=float,0,0

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -915,7 +915,7 @@ EOF
 EXPECT=<<EOF
 pf dF num num2
 pf c ch
-pf
+pf 
 ----
 struct.A=num
 struct.A.num=float,0,0


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Numeric named structs shouldn't be appearing in "ts" commands.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
Create a test asserting that a numeric named struct generated after typedeffing anonymous struct does not show up in "ts" commands.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Closes https://github.com/radareorg/radare2/issues/16343.
