### PR TITLE
Remove unnecessary newline in version

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3670,7 +3670,7 @@ R_API char *r_str_version(const char *program) {
 			(R_SYS_BITS & 8)? 64: 32,
 			*R2_GITTAP ? R2_GITTAP: "");
 	if (*R2_GITTIP) {
-		s = r_str_appendf (s, "commit: "R2_GITTIP" build: "R2_BIRTH"\n");
+		s = r_str_appendf (s, "commit: "R2_GITTIP" build: "R2_BIRTH);
 	}
 	return s;
 }


### PR DESCRIPTION
Do not print additional newline in `-v` output.

Before this PR it added one more newline:
```
radare2 on  fix-version-nl took 7s 
[i] ℤ r2 -v                                                                                                                                                                                                                        18:24:11 
radare2 4.4.0-git 26469 @ linux-x86-64 git.4.3.1-256-g871b68bb8
commit: 871b68bb8c9031c9df42f2fdb1b2cd528628476f build: 2020-04-09__18:16:32

radare2 on  fix-version-nl 
```
Obviously, it's unnecessary