### PR TITLE
Fix #16327 - Search in range with io.va=false ##search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2934,6 +2934,11 @@ static int cmd_search(void *data, const char *input) {
 	// {.addr = UT64_MAX, .size = 0} means search range is unspecified
 	RInterval search_itv = {search_from, search_to - search_from};
 	bool empty_search_itv = search_from == search_to && search_from != UT64_MAX;
+	if (empty_search_itv) {
+		eprintf ("WARNING from == to?\n");
+		ret = false;
+		goto beach;
+	}
 	// TODO full address cannot be represented, shrink 1 byte to [0, UT64_MAX)
 	if (search_from == UT64_MAX && search_to == UT64_MAX) {
 		search_itv.addr = 0;
@@ -2963,21 +2968,8 @@ static int cmd_search(void *data, const char *input) {
 	core->search->maxhits = r_config_get_i (core->config, "search.maxhits");
 	searchprefix = r_config_get (core->config, "search.prefix");
 	core->search->overlap = r_config_get_i (core->config, "search.overlap");
-	if (!core->io->va) {
-		RInterval itv = {0, r_io_size (core->io)};
-		if (!r_itv_overlap (search_itv, itv)) {
-			empty_search_itv = true;
-		} else {
-			search_itv = r_itv_intersect (search_itv, itv);
-		}
-	}
 	core->search->bckwrds = false;
 
-	if (empty_search_itv) {
-		eprintf ("WARNING from == to?\n");
-		ret = false;
-		goto beach;
-	}
 	/* Quick & dirty check for json output */
 	if (input[0] && (input[1] == 'j') && (input[0] != ' ')) {
 		param.outmode = R_MODE_JSON;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The condition im removing here doesnt make any sense and this issue is affecting r2frida and native debugger as well

**Test plan**

cant write test because -m is broken ,the phisical files are always bound to 0, we can no longer map files outside that address, so unless we do a modified malloc that covers all memory or gets mapped in a higher address

**Closing issues**

the #16327 