### PR TITLE
Remove debug leftovers in cbin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1868,7 +1868,6 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		} else {
 			const char *bind = import->bind? import->bind: "NONE";
 			const char *type = import->type? import->type: "NONE";
-			eprintf ("nth: %d, %s\n", import->ordinal, symname);
 			if (import->classname && import->classname[0]) {
 				r_table_add_rowf (table, "nXssss", (ut64)import->ordinal, addr, bind, type, libname ? libname : "", sdb_fmt ("%s.%s", import->classname, symname));
 			} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)

**Detailed description**

A small fix to remove a debug message printed on `ii`

Before:
```
[0x08048370]> ii
nth: 1, strcmp
nth: 2, strcpy
nth: 3, puts
nth: 4, __gmon_start__
nth: 5, __libc_start_main
[Imports]
nth vaddr      bind   type   lib name
―――――――――――――――――――――――――――――――――――――
1   0x08048320 GLOBAL FUNC       strcmp
2   0x08048330 GLOBAL FUNC       strcpy
3   0x08048340 GLOBAL FUNC       puts
4   0x00000000 WEAK   NOTYPE     __gmon_start__
5   0x08048350 GLOBAL FUNC       __libc_start_main

```


After:

```
[0x08048370]> ii
[Imports]
nth vaddr      bind   type   lib name
―――――――――――――――――――――――――――――――――――――
1   0x08048320 GLOBAL FUNC       strcmp
2   0x08048330 GLOBAL FUNC       strcpy
3   0x08048340 GLOBAL FUNC       puts
4   0x00000000 WEAK   NOTYPE     __gmon_start__
5   0x08048350 GLOBAL FUNC       __libc_start_main

```


**Test plan**

- open a binary in r2 and print the imports using `ii`
