### PR TITLE
Fix #16455 - iij asserts for ld-uclibc with a null import ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1849,13 +1849,16 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 			str = r_str_replace (str, "\"", "\\\"", 1);
 
 			pj_ki (pj, "ordinal", import->ordinal);
-			pj_ks (pj, "bind", import->bind);
-			pj_ks (pj, "type", import->type);
+			if (import->bind) {
+				pj_ks (pj, "bind", import->bind);
+			}
+			if (import->type) {
+				pj_ks (pj, "type", import->type);
+			}
 			if (import->classname && import->classname[0]) {
 				pj_ks (pj, "classname", import->classname);
 				pj_ks (pj, "descriptor", import->descriptor);
 			}
-
 			pj_ks (pj, "name", str);
 			if (libname) {
 				pj_ks (pj, "libname", libname);

--- a/test/new/db/formats/elf/crash
+++ b/test/new/db/formats/elf/crash
@@ -13,3 +13,19 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=ELF: ld-uclibc
+FILE=../bins/elf/ld-uClibc-0.9.33.2.so
+CMDS=<<EOF
+ii
+iij
+EOF
+EXPECT=<<EOF
+[Imports]
+nth vaddr      bind type lib name
+---------------------------------
+0   0x00000000 NONE NONE     
+
+[{"ordinal":0,"name":"","plt":0}]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

listing imports on ld-uclibc results on 1 entry which is filled by zeros. maybe t shouldnt be there, but in case is there it shouldnt be asserting because of null strings.

**Test plan**

i added a test which shows the current output

**Closing issues**

fixes #16455
