### PR TITLE
Tricore analysis support.

### DIFF
--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -81,6 +81,7 @@ r_anal_sources = [
   'p/anal_tms320.c',
   'p/anal_tms320_c55x_plus.c',
   #'p/anal_tms320c64x.c',
+  'p/anal_tricore.c',
   'p/anal_v810.c',
   'p/anal_v850.c',
   'p/anal_vax.c',

--- a/libr/anal/p/Makefile
+++ b/libr/anal/p/Makefile
@@ -12,7 +12,7 @@ all: ${ALL_TARGETS}
 
 ALL_TARGETS=
 # TODO: rename to enabled plugins
-ARCHS=null.mk ppc_gnu.mk ppc_cs.mk arm_gnu.mk avr.mk xap.mk dalvik.mk sh.mk ebc.mk gb.mk malbolge.mk ws.mk h8300.mk cr16.mk v850.mk msp430.mk sparc_gnu.mk sparc_cs.mk x86_cs.mk cris.mk 6502.mk snes.mk riscv.mk vax.mk xtensa.mk rsp.mk mcore.mk
+ARCHS=null.mk ppc_gnu.mk ppc_cs.mk arm_gnu.mk avr.mk xap.mk dalvik.mk sh.mk ebc.mk gb.mk malbolge.mk ws.mk h8300.mk cr16.mk v850.mk msp430.mk sparc_gnu.mk sparc_cs.mk x86_cs.mk cris.mk 6502.mk snes.mk riscv.mk vax.mk xtensa.mk rsp.mk mcore.mk tricore.mk
 include $(ARCHS)
 
 clean:

--- a/libr/anal/p/anal_tricore.c
+++ b/libr/anal/p/anal_tricore.c
@@ -1,0 +1,91 @@
+#include <string.h>
+#include <r_types.h>
+#include <r_lib.h>
+#include <r_asm.h>
+#include <r_anal.h>
+#include "../../asm/arch/tricore/gnu/tricore-opc.c"
+
+static bool set_reg_profile(RAnal *anal) {
+
+	const char *p =
+		"=PC	pc\n"
+		"=SP	a10\n"
+		"gpr	p0	.64	0	0\n"
+		"gpr	a0	.32	0	0\n"
+		"gpr	a1	.32	4	0\n"
+		"gpr	p2	.64	8	0\n"
+		"gpr	a2	.32	8	0\n"
+		"gpr	a3	.32	12	0\n"
+		"gpr	p4	.64	16	0\n"
+		"gpr	a4	.32	16	0\n"
+		"gpr	a5	.32	20	0\n"
+		"gpr	p6	.64	24	0\n"
+		"gpr	a6	.32	24	0\n"
+		"gpr	a7	.32	28	0\n"
+		"gpr	p8	.64	32	0\n"
+		"gpr	a8	.32	32	0\n"
+		"gpr	a9	.32	36	0\n"
+		"gpr	p10	.64	40	0\n"
+		"gpr	a10	.32	40	0\n"
+		"gpr	a11	.32	44	0\n"
+		"gpr	p12	.64	48	0\n"
+		"gpr	a12	.32	48	0\n"
+		"gpr	a13	.32	52	0\n"
+		"gpr	p14	.64	56	0\n"
+		"gpr	a14	.32	56	0\n"
+		"gpr	a15	.32	60	0\n"
+		"gpr	e0	.64	64	0\n"
+		"gpr	d0	.32	64	0\n"
+		"gpr	d1	.32	68	0\n"
+		"gpr	e2	.64	72	0\n"
+		"gpr	d2	.32	72	0\n"
+		"gpr	d3	.32	76	0\n"
+		"gpr	e4	.64	80	0\n"
+		"gpr	d4	.32	80	0\n"
+		"gpr	d5	.32	84	0\n"
+		"gpr	e6	.64	88	0\n"
+		"gpr	d6	.32	88	0\n"
+		"gpr	d7	.32	92	0\n"
+		"gpr	e8	.64	96	0\n"
+		"gpr	d8	.32	96	0\n"
+		"gpr	d9	.32	100	0\n"
+		"gpr	e10	.64	104	0\n"
+		"gpr	d10	.32	104	0\n"
+		"gpr	d11	.32	108	0\n"
+		"gpr	e12	.64	112	0\n"
+		"gpr	d12	.32	112	0\n"
+		"gpr	d13	.32	114	0\n"
+		"gpr	e14	.64	118	0\n"
+		"gpr	d14	.32	118	0\n"
+		"gpr	d15	.32	120	0\n"
+		"gpr	PSW	.32	124	0\n"
+		"gpr	PCXI	.32	128	0\n"
+		"gpr	FCX	.32	132	0\n"
+		"gpr	LCX	.32	136	0\n"
+		"gpr	ISP	.32	140	0\n"
+		"gpr	ICR	.32	144	0\n"
+		"gpr	PIPN	.32	148	0\n"
+		"gpr	BIV	.32	152	0\n"
+		"gpr	BTV	.32	156	0\n"
+		"gpr	pc	.32	160	0\n";
+
+	return r_reg_set_profile_string (anal->reg, p);
+}
+
+struct r_anal_plugin_t r_anal_plugin_tricore = {
+	.name = "tricore",
+	.desc = "TRICORE analysis plugin",
+	.license = "LGPL3",
+	.arch = "tricore",
+	.bits = 32,
+	.set_reg_profile = set_reg_profile,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_ANAL,
+	.data = &r_anal_plugin_tricore,
+	.version = R2_VERSION
+};
+#endif
+

--- a/libr/anal/p/tricore.mk
+++ b/libr/anal/p/tricore.mk
@@ -1,0 +1,10 @@
+OBJ_TRICORE=anal_tricore.o
+
+STATIC_OBJ+=${OBJ_TRICORE}
+TARGET_TRICORE=anal_tricore.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_TRICORE}
+
+${TARGET_TRICORE}: ${OBJ_TRICORE}
+	${CC} $(call libname,anal_tricore) ${LDFLAGS} ${CFLAGS} \
+		-o $(TARGET_TRICORE) $(OBJ_TRICORE)

--- a/libr/asm/arch/tricore/README.md
+++ b/libr/asm/arch/tricore/README.md
@@ -1,2 +1,8 @@
-Based on code from https://www.hightec-rt.com/en/downloads/sources/14-sources-for-tricore-v3-3-7-9-binutils-1.html
+Tricore ISA 1.3: https://www.infineon.com/dgdl/tc_v131_corearchitecture_v__138.pdf?fileId=db3a304412b407950112b409c4500359
+
+Tricore ISA 1.6: https://www.infineon.com/dgdl/tc1_6__architecture_vol1.pdf?fileId=db3a3043372d5cc801373b0f374d5d67
+
+Tricore 1.6P and 1.6E: https://www.infineon.com/dgdl/Infineon-TC2xx_Architecture_vol2-UM-v01_00-EN.pdf?fileId=5546d46269bda8df0169ca1bf33124a8
+
+EABI: https://www.infineon.com/dgdl/TriCore_EABI_v2_3.pdf?fileId=db3a304412b407950112b40f8d7a142b
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -2043,6 +2043,7 @@ extern RAnalPlugin r_anal_plugin_sparc_gnu;
 extern RAnalPlugin r_anal_plugin_sysz;
 extern RAnalPlugin r_anal_plugin_tms320;
 extern RAnalPlugin r_anal_plugin_tms320c64x;
+extern RAnalPlugin r_anal_plugin_tricore;
 extern RAnalPlugin r_anal_plugin_v810;
 extern RAnalPlugin r_anal_plugin_v850;
 extern RAnalPlugin r_anal_plugin_vax;

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -41,6 +41,7 @@ anal_plugins = [
   'sysz',
   'tms320',
   #'tms320c64x',
+  'tricore',
   'v810',
   'v850',
   'vax',

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -34,6 +34,7 @@ anal.sparc_cs
 anal.sparc_gnu
 anal.sysz
 anal.tms320
+anal.tricore
 anal.v850
 anal.ws
 anal.xap

--- a/test/new/db/anal/tricore
+++ b/test/new/db/anal/tricore
@@ -45,3 +45,71 @@ EXPECT=<<EOF
 arch     tricore
 EOF
 RUN
+
+NAME=TriCore return_0.elf
+FILE=../bins/tricore/return_0.elf
+CMDS=drp
+EXPECT=<<EOF
+=PC	pc
+=SP	a10
+gpr	p0	.64	0	0
+gpr	a0	.32	0	0
+gpr	a1	.32	4	0
+gpr	p2	.64	8	0
+gpr	a2	.32	8	0
+gpr	a3	.32	12	0
+gpr	p4	.64	16	0
+gpr	a4	.32	16	0
+gpr	a5	.32	20	0
+gpr	p6	.64	24	0
+gpr	a6	.32	24	0
+gpr	a7	.32	28	0
+gpr	p8	.64	32	0
+gpr	a8	.32	32	0
+gpr	a9	.32	36	0
+gpr	p10	.64	40	0
+gpr	a10	.32	40	0
+gpr	a11	.32	44	0
+gpr	p12	.64	48	0
+gpr	a12	.32	48	0
+gpr	a13	.32	52	0
+gpr	p14	.64	56	0
+gpr	a14	.32	56	0
+gpr	a15	.32	60	0
+gpr	e0	.64	64	0
+gpr	d0	.32	64	0
+gpr	d1	.32	68	0
+gpr	e2	.64	72	0
+gpr	d2	.32	72	0
+gpr	d3	.32	76	0
+gpr	e4	.64	80	0
+gpr	d4	.32	80	0
+gpr	d5	.32	84	0
+gpr	e6	.64	88	0
+gpr	d6	.32	88	0
+gpr	d7	.32	92	0
+gpr	e8	.64	96	0
+gpr	d8	.32	96	0
+gpr	d9	.32	100	0
+gpr	e10	.64	104	0
+gpr	d10	.32	104	0
+gpr	d11	.32	108	0
+gpr	e12	.64	112	0
+gpr	d12	.32	112	0
+gpr	d13	.32	114	0
+gpr	e14	.64	118	0
+gpr	d14	.32	118	0
+gpr	d15	.32	120	0
+gpr	PSW	.32	124	0
+gpr	PCXI	.32	128	0
+gpr	FCX	.32	132	0
+gpr	LCX	.32	136	0
+gpr	ISP	.32	140	0
+gpr	ICR	.32	144	0
+gpr	PIPN	.32	148	0
+gpr	BIV	.32	152	0
+gpr	BTV	.32	156	0
+gpr	pc	.32	160	0
+
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)

**Detailed description**
Added tricore register profile support.
Still works need to be done in giving alias to some special registers.
The 64 bit case is due to, tricore for arguments size 64 uses E[0] or (d[0]/d[1]) data registers. Same for address registers.
Also added some documentation links for tricore in asm README. Just tell me if we want this at different place. I will add more clarity to it.
```[0x80000000]> drp
=PC	pc
=SP	a10
gpr	a0	.32	0	0
gpr	a1	.32	32	0
gpr	a2	.32	64	0
gpr	a3	.32	96	0
gpr	a4	.32	128	0
gpr	a5	.32	160	0
gpr	a6	.32	192	0
gpr	a7	.32	224	0
gpr	a8	.32	256	0
gpr	a9	.32	288	0
gpr	a10	.32	320	0
gpr	a11	.32	352	0
gpr	a12	.32	384	0
gpr	a13	.32	416	0
gpr	a14	.32	448	0
gpr	a15	.32	480	0
gpr	d0	.32	512	0
gpr	d1	.32	544	0
gpr	d2	.32	576	0
gpr	d3	.32	608	0
gpr	d4	.32	640	0
gpr	d5	.32	672	0
gpr	d6	.32	704	0
gpr	d7	.32	736	0
gpr	d8	.32	768	0
gpr	d9	.32	800	0
gpr	d10	.32	832	0
gpr	d11	.32	864	0
gpr	d12	.32	896	0
gpr	d13	.32	928	0
gpr	d14	.32	960	0
gpr	d15	.32	992	0
gpr	PSW	.32	1024	0
gpr	PCXI	.32	1056	0
gpr	FCX	.32	1088	0
gpr	LCX	.32	1120	0
gpr	ISP	.32	1152	0
gpr	ICR	.32	1184	0
gpr	PIPN	.32	1216	0
gpr	BIV	.32	1248	0
gpr	BTV	.32	1280	0
gpr	pc	.32	1312	0

[0x80000000]>

```
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Closing issues**
#11900 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
