### PR TITLE
WIP - Fix #13861 - for recursive noreturn function tagging ##anal

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -996,6 +996,12 @@ repeat:
 				if (f) {
 					f->is_noreturn = true;
 				}
+				{
+					// wait at the end of the function analnysis to chk if all the
+					// exit points are noreturn otherwise that wont be right
+					r_anal_noreturn_add (anal, fcn->name, fcn->addr);
+					fcn->is_noreturn = true;
+				}
 				gotoBeach (R_ANAL_RET_END);
 			}
 			break;


### PR DESCRIPTION
Currently this patch works for a simple testcase, but it will fail
on functions that have multple returns and at least one of them
is not noreturn. This patch should be modified to run at the end
of the function and then register the noreturn of the fcn->addr.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
