### PR TITLE
Fix dup af+ removing function from hts

### DIFF
--- a/libr/anal/function.c
+++ b/libr/anal/function.c
@@ -89,8 +89,12 @@ R_API void r_anal_function_free(void *_fcn) {
 	r_list_free (fcn->bbs);
 
 	RAnal *anal = fcn->anal;
-	ht_up_delete (anal->ht_addr_fun, fcn->addr);
-	ht_pp_delete (anal->ht_name_fun, fcn->name);
+	if (ht_up_find (anal->ht_addr_fun, fcn->addr, NULL) == _fcn) {
+		ht_up_delete (anal->ht_addr_fun, fcn->addr);
+	}
+	if (ht_pp_find (anal->ht_name_fun, fcn->name, NULL) == _fcn) {
+		ht_pp_delete (anal->ht_name_fun, fcn->name);
+	}
 
 	free (fcn->name);
 	free (fcn->attr);

--- a/test/new/db/anal/x86_64
+++ b/test/new/db/anal/x86_64
@@ -597,7 +597,7 @@ aac
 afl~?
 EOF
 EXPECT=<<EOF
-1279
+1268
 EOF
 RUN
 

--- a/test/new/db/cmd/cmd_af
+++ b/test/new/db/cmd/cmd_af
@@ -338,3 +338,22 @@ arg int arg2 @ xmm1
 diff: type: new
 EOF
 RUN
+
+NAME=duplicate af+
+FILE=-
+CMDS=<<EOF
+af+ 0x1337 func
+af+ 0x1337 func
+af+ 0x1337 func
+afl
+EOF
+EXPECT=<<EOF
+0x00001337    0 0            func
+EOF
+EXPECT_ERR=<<EOF
+Invalid function name 'func' at 0x00001337
+Cannot add function (duplicated)
+Invalid function name 'func' at 0x00001337
+Cannot add function (duplicated)
+EOF
+RUN

--- a/test/new/db/cmd/cmd_zignature
+++ b/test/new/db/cmd/cmd_zignature
@@ -775,8 +775,8 @@ EXPECT=<<EOF
 0x0040ea50 288 flirt.__new_exitfn
 0x0040ec70 250 flirt.__cxa_atexit
 0x0040f430 542 flirt.__correctly_grouped_prefixmb
-0x0040f710 368 flirt.locked_vfxprintf
-0x0040f880 784 flirt.__fxprintf
+0x0040f710 1722 flirt.locked_vfxprintf
+0x0040f880 0 flirt.__fxprintf
 0x0040fe20 33103 flirt._IO_fflush
 0x00410210 429 flirt._IO_puts
 0x00410410 1898 flirt.adjust_wide_data
@@ -848,15 +848,14 @@ EXPECT=<<EOF
 0x0044e310 528 flirt.__gconv
 0x0044e520 4508 flirt.__gconv_close
 0x0044f6c0 1168 flirt.insert_module
-0x0044fb50 2512 flirt.__gconv_get_path
+0x0044fb50 3114 flirt.__gconv_get_path
 0x0044ff40 0 flirt.__gconv_read_conf
-0x00450520 602 flirt.__gconv_get_builtin_trans
 0x00458320 18 flirt.release_libc_mem
 0x004585d0 692 flirt.new_composite_name
 0x00459170 2074 flirt._nl_find_locale
 0x00459990 1821 flirt._nl_intern_locale_data
 0x00459bd0 1488 flirt._nl_load_locale
-0x0045a1a0 94 flirt._nl_unload_locale
+0x0045a1a0 238798 flirt._nl_unload_locale
 0x0045a200 1312 flirt._nl_load_locale_from_archive
 0x0045a870 80 flirt.__setfpucw
 0x0045a8c0 132 flirt.__sigsetjmp
@@ -867,7 +866,8 @@ EXPECT=<<EOF
 0x00462b80 976 flirt.hack_digit
 0x00465a50 11033 flirt.___printf_fp
 0x00468470 192 flirt.___asprintf
-0x00468530 11072 flirt._i18n_number_rewrite
+0x00468530 34069 flirt._i18n_number_rewrite
+0x004687d0 10400 flirt.printf_positional
 0x0046b070 13435 flirt._IO_vfwprintf
 0x0046e540 1929 flirt.__parse_one_specmb
 0x0046ecd0 2211 flirt.__parse_one_specwc
@@ -879,7 +879,7 @@ EXPECT=<<EOF
 0x00470230 320 flirt._IO_wpadn
 0x00470370 637 flirt.save_for_wbackup.isra.0
 0x004706b0 109 flirt._IO_wsetb
-0x004709d0 117 flirt.__woverflow
+0x004709d0 0 flirt.__woverflow
 0x00470e40 685 flirt._IO_wdefault_xsputn
 0x00471530 155 flirt._IO_wdoallocbuf
 0x00471640 114 flirt._IO_switch_to_wget_mode
@@ -919,7 +919,7 @@ EXPECT=<<EOF
 0x0047d260 2000 flirt._dl_important_hwcaps
 0x0047da30 1446 flirt._dl_debug_vdprintf
 0x0047dfe0 138 flirt._dl_sysdep_read_whole_file
-0x0047e070 162 flirt._dl_debug_printf
+0x0047e070 0 flirt._dl_debug_printf
 0x0047e120 162 flirt._dl_debug_printf_c
 0x0047e1d0 148 flirt._dl_dprintf
 0x0047e270 102 flirt._dl_name_match_p
@@ -963,7 +963,7 @@ EXPECT=<<EOF
 0x004857c0 144 flirt._dl_find_dso_for_object
 0x00485850 528 flirt._dl_open
 0x00485a60 298 flirt._dl_show_scope
-0x004863b0 4000 flirt.remove_slotinfo
+0x004863b0 37600 flirt.remove_slotinfo
 0x00487350 0 flirt._dl_close_worker
 0x004874d0 751 flirt._dl_sort_maps
 0x004877c0 416 flirt._dl_tlsdesc_resolve_rela_fixup


### PR DESCRIPTION
**Detailed description**

This fixes the following issue:
```
$ r2 /bin/ls
> af;.afi*
# cannot add basic block errors
> af;.afi*
# no errors at all
> af;.afi*
# cannot add basic block errors again
```

or more narrowed down:
```
[0x00000000]> af+ 0x1337 func
[0x00000000]> af+ 0x1337 func
Invalid function name 'func' at 0x00001337
Cannot add function (duplicated)
[0x00000000]> af+ 0x1337 func
[0x00000000]> af+ 0x1337 func
Invalid function name 'func' at 0x00001337
Cannot add function (duplicated)
[0x00000000]>
```

The expected behavior is that all subsequent `af+` calls show the error.
This is however not only about error printing, in fact the duplicated `af+` would remove the function from the address and name hashtables which is a problem.

**Closing issues**

#15453 (doesn't directly solve the project-related issue but I think we can close with r2db coming soon^TM)