### PR TITLE
Fix #16433 - Support movabs for x86_64's MOV r64, imm64

### DIFF
--- a/test/new/db/asm/x86_64
+++ b/test/new/db/asm/x86_64
@@ -729,6 +729,8 @@ aB "mov qword[r12], rsp" 49892424
 aB "mov qword[r8 + 0x20], rax" 49894020
 aB "mov r12, qword[r12]" 4d8b2424
 a "mov eax,r12d" 4489e0
+ad "movabs rax, 0xdeadbeef" 48b8efbeadde00000000
+ad "movabs r12, 1" 49bc0100000000000000
 a "inc al" fec0
 a "inc BYTE PTR [r12]" 41fe0424
 a "inc BYTE PTR [rbx+0x18]" fe4318


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr adds support for the `movabs` instruction, equivalent to the x86_64 MOV r64, imm64 instruction (opcode B8+ rd). This is consistent with both capstone (via the tests) and objdump:

`objdump -D -b binary -m i386:x86-64 -M intel ./testbin`
![movabs](https://user-images.githubusercontent.com/12002672/79042065-1f5d5300-7c27-11ea-9503-0c1df29f1b42.png)
![movabs_2](https://user-images.githubusercontent.com/12002672/79042117-91359c80-7c27-11ea-8cbe-844f30424372.png)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Travis and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #16433.
