### PR TITLE
Don't use colors in json mode and fix some bugs.

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2008,7 +2008,8 @@ R_API void r_core_debug_ri(RCore *core, RReg *reg, int mode) {
 R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 	char *color = "";
 	char *colorend = "";
-	int use_colors = r_config_get_i (core->config, "scr.color");
+	int had_colors = r_config_get_i (core->config, "scr.color");
+	bool use_colors = had_colors != 0;
 	int delta = 0;
 	ut64 diff, value;
 	int bits = core->assembler->bits;
@@ -2017,14 +2018,17 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 	RListIter *iter;
 	RRegItem *r;
 	RTable *t = r_core_table (core);
+
+	if (mode == 'j') {
+		r_config_set_i (core->config, "scr.color", false);
+		use_colors = 0;
+	}
+
 	if (use_colors) {
 #undef ConsP
 #define ConsP(x) (core->cons && core->cons->context->pal.x) ? core->cons->context->pal.x
 		color = ConsP(creg): Color_BWHITE;
-	}
-
-	if (mode == 'j') {
-		r_config_set_i (core->config, "scr.color", false);
+		colorend = Color_RESET;
 	}
 
 	r_table_set_columnsf (t, "ssss", "role", "reg", "value", "ref");
@@ -2043,8 +2047,6 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 			r_reg_arena_swap (core->dbg->reg, false);
 			delta = value-diff;
 		}
-		color = (delta && use_colors)? color: "";
-		colorend = (delta && use_colors)? Color_RESET: "";
 
 		const char *role = "";
 		int i;
@@ -2055,13 +2057,19 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 			}
 		}
 
-		char *namestr = r_str_newf ("%s%s%s", color, r->name, colorend);
-		char *valuestr = r_str_newf ("%s%"PFMT64x"%s", color, value, colorend);
+		char *namestr = NULL;
+		char *valuestr = NULL;
+		if (delta && use_colors) {
+			namestr = r_str_newf ("%s%s%s", color, r->name, colorend);
+			valuestr = r_str_newf ("%s%"PFMT64x"%s", color, value, colorend);
+		} else {
+			namestr = r_str_new (r->name);
+			valuestr = r_str_newf ("%"PFMT64x, value);
+		}
 
-		char *rrstr = strdup ("");
-		char *refs = r_core_anal_hasrefs (core, value, true);
-		if (refs) {
-			rrstr = refs;
+		char *rrstr = r_core_anal_hasrefs (core, value, true);
+		if (!rrstr) {
+			rrstr = strdup ("");
 		}
 
 		r_table_add_rowf (t, "ssss", role, namestr, valuestr, rrstr);
@@ -2075,8 +2083,8 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 	free (s);
 	r_table_free (t);
 
-	if (use_colors) {
-		r_config_set_i (core->config, "scr.color", use_colors);
+	if (had_colors) {
+		r_config_set_i (core->config, "scr.color", had_colors);
 	}
 }
 

--- a/test/new/db/cmd/cmd_dr
+++ b/test/new/db/cmd/cmd_dr
@@ -1,0 +1,12 @@
+NAME=drrj color
+FILE=-
+ARGS=-a x86 -b 32 -m 0x10000
+CMDS=<<EOF
+e scr.color=1
+dr ebx=0x10
+drrj~{2}
+EOF
+EXPECT=<<EOF
+{"role":"A1","reg":"ebx","value":"10","ref":" 16"}
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Don't use color codes in JSON mode. There was code that tried to disable it but parts of it were still printed. While making the changes also fix:
* Changed value highlighting in the human readable mode. When a register which didn't need highlighting was  reached color got overwritten with empty preventing further registers from being highlighted.
* fix memory leak when handling `rrstr`


**Test plan**

* There is a test for json mode

Does color printing in human readable mode also need test case. How to specify the color codes in r2r?

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->


