### PR TITLE
Fix crash issue induced by an integer overflow in the mach0 parser ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2931,7 +2931,7 @@ static int reloc_comparator(struct reloc_t *a, struct reloc_t *b) {
 }
 
 static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList * relocs, ut32 offset, ut32 num) {
-	if (!num || !offset) {
+	if (!num || !offset || (st32)num < 0) {
 		return;
 	}
 
@@ -2946,7 +2946,7 @@ static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList * relocs,
 		return;
 	}
 
-	int i;
+	size_t i;
 	for (i = 0; i < num; i++) {
 		struct relocation_info a_info = info[i];
 		ut32 sym_num = a_info.r_symbolnum;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

fixes another fufzz test

**Test plan**

run the fuzzz tests

**Closing issues**
yes