### PR TITLE
Add some extern C to headers.

### DIFF
--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -4,6 +4,10 @@
 
 #include <r_util/r_strbuf.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct pj_t {
 	RStrBuf sb;
 	bool is_first;
@@ -49,5 +53,10 @@ R_API PJ *pj_d(PJ *j, double d);
 R_API PJ *pj_f(PJ *j, float d);
 R_API PJ *pj_i(PJ *j, int d);
 R_API PJ *pj_j(PJ *j, const char *k);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 

--- a/libr/include/r_util/r_table.h
+++ b/libr/include/r_util/r_table.h
@@ -3,6 +3,10 @@
 
 #include <r_util.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	const char *name;
 	RListComparator cmp;
@@ -85,5 +89,9 @@ R_API void r_table_transpose(RTable *t);
 R_API void r_table_format(RTable *t, int nth, RTableColumnType *type);
 R_API ut64 r_table_reduce(RTable *t, int nth);
 R_API void r_table_columns(RTable *t, RList *cols); // const char *name, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Add some ifdef cplusplus extern c to headers. There are quite a few left.
```
[karlis@desktop1 libr]$ grep -r -L "extern" . | grep "\.h" | wc -l
255
[karlis@desktop1 libr]$ grep -r  "extern" . | grep "\.h" | wc -l
1508
```

For now only fixed the ones  causing r2ghidra compilation problems on windows.

**Test plan**



**Closing issues**

