### PR TITLE
Minor Fixes for XRefs

### DIFF
--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1589,7 +1589,7 @@ R_API bool r_anal_function_purity(RAnalFunction *fcn);
 
 typedef bool (* RAnalRefCmp)(RAnalRef *ref, void *data);
 R_API RList *r_anal_ref_list_new(void);
-R_API int r_anal_xrefs_count(RAnal *anal);
+R_API ut64 r_anal_xrefs_count(RAnal *anal);
 R_API const char *r_anal_xrefs_type_tostring(RAnalRefType type);
 R_API RAnalRefType r_anal_xrefs_type(char ch);
 R_API RList *r_anal_xrefs_get(RAnal *anal, ut64 to);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -5,6 +5,7 @@ if get_option('enable_tests')
     'anal_block',
     'anal_function',
     'anal_hints',
+    'anal_xrefs',
     'base64',
     'bin',
     'bitmap',

--- a/test/unit/test_anal_xrefs.c
+++ b/test/unit/test_anal_xrefs.c
@@ -1,0 +1,28 @@
+#include <r_anal.h>
+#include "minunit.h"
+
+bool test_r_anal_xrefs_count() {
+	RAnal *anal = r_anal_new ();
+
+	mu_assert_eq (r_anal_xrefs_count (anal), 0, "xrefs count");
+
+	r_anal_xrefs_set (anal, 0x1337, 42, R_ANAL_REF_TYPE_NULL);
+	r_anal_xrefs_set (anal, 0x1337, 43, R_ANAL_REF_TYPE_CODE);
+	r_anal_xrefs_set (anal, 1234, 43, R_ANAL_REF_TYPE_CALL);
+	r_anal_xrefs_set (anal, 12345, 43, R_ANAL_REF_TYPE_CALL);
+	r_anal_xrefs_set (anal, 4321, 4242, R_ANAL_REF_TYPE_CALL);
+
+	mu_assert_eq (r_anal_xrefs_count (anal), 5, "xrefs count");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_r_anal_xrefs_count);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] ~~I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)~~

**Detailed description**

About `r_anal_xrefs_set()`:
I need to be able to use this to test RAnal without having to set up RIO.

About `r_anal_xrefs_count()`:
When you have the following xrefs:
0x42 -> 1234
0x42 -> 4567
0x1337 -> 123456
`r_anal_xrefs_count()` should return 3, but before it was 2.

**Test plan**

see the unit test
