### PR TITLE
Remove some useless members from RAnalVar

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -202,14 +202,14 @@ static _RAnalCond cond_invert(RAnal *anal, _RAnalCond cond) {
 #define RKEY(a,k,d) sdb_fmt ("var.range.0x%"PFMT64x ".%c.%d", a, k, d)
 #define ADB a->sdb_fcns
 
-static void var_add_range(RAnal *a, RAnalVar *var, _RAnalCond cond, ut64 val) {
-	const char *key = RKEY (var->addr, var->kind, var->delta);
+static void var_add_range(RAnal *a, RAnalFunction *fcn, RAnalVar *var, _RAnalCond cond, ut64 val) {
+	const char *key = RKEY (fcn->addr, var->kind, var->delta);
 	sdb_array_append_num (ADB, key, cond, 0);
 	sdb_array_append_num (ADB, key, val, 0);
 }
 
-R_API RStrBuf *var_get_constraint(RAnal *a, RAnalVar *var) {
-	const char *key = RKEY (var->addr, var->kind, var->delta);
+R_API RStrBuf *var_get_constraint(RAnal *a, RAnalFunction *fcn, RAnalVar *var) {
+	const char *key = RKEY (fcn->addr, var->kind, var->delta);
 	int i, n = sdb_array_length (ADB, key);
 
 	if (n < 2) {
@@ -706,7 +706,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 						r_anal_op_free (jmp_op);
 					}
 					_RAnalCond cond = jmp? cond_invert (anal, next_op->cond): next_op->cond;
-					var_add_range (anal, var, cond, aop.val);
+					var_add_range (anal, fcn, var, cond, aop.val);
 				}
 			}
 			prev_var = (var && aop.direction == R_ANAL_OP_DIR_READ);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -974,12 +974,12 @@ static char *get_op_ireg (void *user, ut64 addr) {
 	return res;
 }
 
-static int get_ptr_at(void *user, RAnalVar *var, ut64 addr) {
+static int get_ptr_at(void *user, RAnalFunction *fcn, RAnalVar *var, ut64 addr) {
 	RCore *core = (RCore *)user;
 	const char *var_access = sdb_fmt ("var.0x%"PFMT64x ".%d.%d.access",
-			var->addr, 1, var->delta);
+			fcn->addr, 1, var->delta);
 	char *vars = sdb_get (core->anal->sdb_fcns, var_access, NULL);
-	const ut64 offset = addr - var->addr;
+	const ut64 offset = addr - fcn->addr;
 	if (vars) {
 		char *next = NULL, *ptr = vars;
 		sdb_anext (vars, &next);
@@ -1650,13 +1650,13 @@ static ut32 tmp_get_realsize (RAnalFunction *f) {
 	return (size > 0) ? size : r_anal_function_linear_size (f);
 }
 
-static void ds_show_functions_argvar(RDisasmState *ds, RAnalVar *var, const char *base, bool is_var, char sign) {
+static void ds_show_functions_argvar(RDisasmState *ds, RAnalFunction *fcn, RAnalVar *var, const char *base, bool is_var, char sign) {
 	int delta = sign == '+' ? var->delta : -var->delta;
 	const char *pfx = is_var ? "var" : "arg", *constr = NULL;
 	RStrBuf *constr_buf = NULL;
 	bool cond = false;
 	if (ds->core && ds->core->anal) {
-		constr_buf = var_get_constraint (ds->core->anal, var);
+		constr_buf = var_get_constraint (ds->core->anal, fcn, var);
 		if (constr_buf) {
 			constr = r_strbuf_get (constr_buf);
 			if (constr[0]) {
@@ -1937,7 +1937,7 @@ static void ds_show_functions(RDisasmState *ds) {
 				case R_ANAL_VAR_KIND_BPV: {
 					char sign = var->delta > 0 ? '+' : '-';
 					bool is_var = !var->isarg;
-					ds_show_functions_argvar (ds, var,
+					ds_show_functions_argvar (ds, f, var,
 						anal->reg->name[R_REG_NAME_BP], is_var, sign);
 					}
 					break;
@@ -1965,7 +1965,7 @@ static void ds_show_functions(RDisasmState *ds) {
 					bool is_var = !var->isarg;
 					int saved_delta = var->delta;
 					var->delta = f->maxstack + var->delta;
-					ds_show_functions_argvar (ds, var,
+					ds_show_functions_argvar (ds, f, var,
 						anal->reg->name[R_REG_NAME_SP],
 						is_var, '+');
 					var->delta = saved_delta;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -759,8 +759,6 @@ typedef struct r_anal_var_t {
 	char *regname; // name of the register
 	char *type; // cparse type of the variable
 	char kind; // reg , stack ...
-	ut64 addr; // not used correctly?
-	ut64 eaddr; // not used correctly?
 	int size;
 	bool isarg;
 	int argnum;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -614,7 +614,7 @@ R_API RList *r_core_anal_fcn_get_calls (RCore *core, RAnalFunction *fcn); // get
 
 /*tp.c*/
 R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn);
-R_API RStrBuf *var_get_constraint (RAnal *a, RAnalVar *var);
+R_API RStrBuf *var_get_constraint(RAnal *a, RAnalFunction *fcn, RAnalVar *var);
 
 /* asm.c */
 #define R_MIDFLAGS_SHOW 1

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -32,7 +32,7 @@ typedef struct r_parse_t {
 	// RAnal *anal; // weak anal ref XXX do not use. use analb.anal
 	RList *parsers;
 	RAnalVarList varlist;
-	int (*get_ptr_at)(void *user, RAnalVar *var, ut64 addr);
+	int (*get_ptr_at)(void *user, RAnalFunction *fcn, RAnalVar *var, ut64 addr);
 	char* (*get_op_ireg)(void *user, ut64 addr);
 	RAnalBind analb;
 	RFlagGetAtAddr flag_get; // XXX

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -377,7 +377,7 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 	}
 	r_list_foreach (spargs, iter, var) {
 		if (p->get_ptr_at) {
-			var->delta = p->get_ptr_at (p->user, var, addr);
+			var->delta = p->get_ptr_at (p->user, f, var, addr);
 		}
 		if (var->delta > -10 && var->delta < 10) {
 			oldstr = r_str_newf ("[sp, %d]", var->delta);

--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -266,7 +266,7 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 	const bool ucase = IS_UPPER (*tstr);
 	r_list_foreach (spargs, iter, var) {
 		if (p->get_ptr_at) {
-			var->delta = p->get_ptr_at (p->user, var, addr);
+			var->delta = p->get_ptr_at (p->user, f, var, addr);
 		}
 		char *tmpf;
 		//TODO: honor asm pseudo

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -416,7 +416,7 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 	r_list_foreach (spargs, spiter, sparg) {
 		// assuming delta always positive?
 		if (p->get_ptr_at) {
-			sparg->delta = p->get_ptr_at (p->user, sparg, addr);
+			sparg->delta = p->get_ptr_at (p->user, f, sparg, addr);
 		}
 		mk_reg_str (anal->reg->name[R_REG_NAME_SP], sparg->delta, true, att, ireg, oldstr, sizeof (oldstr));
 


### PR DESCRIPTION
This should probably be merged only AFTER the release.

**Detailed description**

`RAnalVar.addr` was always set to the function's addr. No need to keep it there. Especially as a preparation for #16547.

**Test plan**

Check that rebasing of variables still works (Open file, `aaa`, `ood`, check vars)
