### PR TITLE
x86_64: Use MOV opcode C7 for MOV r64, -<1 to 0x80000000>

### DIFF
--- a/test/new/db/asm/x86_64
+++ b/test/new/db/asm/x86_64
@@ -38,6 +38,17 @@ a "mov rax, 0x1122334455667788" 48b88877665544332211
 aB "mov rax, 0x112233445566778899" 00
 a "mov rax, 3" 48c7c003000000
 a "mov rax, 33" 48c7c021000000
+ad "mov rax, 0x7fffffff" 48c7c0ffffff7f
+ad "mov rax, 0" 48c7c000000000
+a "mov rax, -1" 48c7c0ffffffff
+adB "mov rax, 0xffffffffffffffff" 48c7c0ffffffff
+a "mov rax, -2" 48c7c0feffffff
+a "mov rax, -0x2" 48c7c0feffffff
+ad "mov rax, 0xfffffffffffffffe" 48c7c0feffffff
+a "mov rax, -0x80000000" 48c7c000000080
+ad "mov rax, 0xffffffff80000000" 48c7c000000080
+a "mov rax, -0x80000001" 48b8ffffff7fffffffff
+ad "movabs rax, 0xffffffff7fffffff" 48b8ffffff7fffffffff
 a "mov rax, [rax+0]" 488b00
 a "mov rax, [rax+1]" 488b4001
 a "mov rax, [rax-0]" 488b00


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes the x86_64 assembler use the shorter MOV C7 encoding (MOV r/m64, imm32) when the immediate is between -1 and -0x80000000.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Travis and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

For https://github.com/radareorg/radare2/issues/16433#issuecomment-612592213.
