### PR TITLE
fix undefined behavior in r_pvector_foreach_prev

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -231,7 +231,7 @@ static inline void **r_pvector_shrink(RPVector *vec) {
 
 // like r_pvector_foreach() but inverse
 #define r_pvector_foreach_prev(vec, it) \
-	for (it = (void **)(vec)->v.a + (vec)->v.len - 1; it != (void **)(vec)->v.a - 1; it--)
+	for (it = ((vec)->v.len == 0 ? NULL : (void **)(vec)->v.a + (vec)->v.len - 1); it != NULL && it != (void **)(vec)->v.a - 1; it--)
 
 /*
  * example:


### PR DESCRIPTION
if the for loop starts at count 0, we have UB from pointer overflow

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

there was a pointer overflow if the count was 0, in the count-1 is pointer overflow in `r_pvector_foreach_prev`

...

**Test plan**

run r2r, same results

...

**Closing issues**

closes #16550

...
