### PR TITLE
Proper multiplication overflow test

### DIFF
--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -117,13 +117,13 @@ static RList *patch_relocs(RBin *b) {
 	return list;
 }
 
-static int get_ngot_entries(struct r_bin_bflt_obj *obj) {
+static ut32 get_ngot_entries(struct r_bin_bflt_obj *obj) {
 	ut32 data_size = obj->hdr->data_end - obj->hdr->data_start;
-	int i = 0, n_got = 0;
+	ut32 i = 0, n_got = 0;
 	if (data_size > obj->size) {
 		return 0;
 	}
-	for (i = 0, n_got = 0; i < data_size; i += 4, n_got++) {
+	for (; i < data_size; i += 4, n_got++) {
 		ut32 entry, offset = obj->hdr->data_start;
 		if (offset + i + sizeof (ut32) > obj->size ||
 		    offset + i + sizeof (ut32) < offset) {
@@ -144,7 +144,7 @@ static int get_ngot_entries(struct r_bin_bflt_obj *obj) {
 static RList *relocs(RBinFile *bf) {
 	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj *) bf->o->bin_obj;
 	RList *list = r_list_newf ((RListFree) free);
-	int i, len, n_got, amount;
+	ut32 i, len, n_got, amount;
 	if (!list || !obj) {
 		r_list_free (list);
 		return NULL;
@@ -152,12 +152,11 @@ static RList *relocs(RBinFile *bf) {
 	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
 		n_got = get_ngot_entries (obj);
 		if (n_got) {
-			amount = n_got * sizeof(ut32);
-			if (amount / sizeof (ut32) != n_got) {
+			if (n_got > UT32_MAX / sizeof (struct reloc_struct_t)) {
 				goto out_error;
 			}
-			struct reloc_struct_t *got_table = calloc (
-				1, n_got * sizeof (struct reloc_struct_t));
+			amount = n_got * sizeof (struct reloc_struct_t);
+			struct reloc_struct_t *got_table = calloc (1, amount);
 			if (got_table) {
 				ut32 offset = 0;
 				for (i = 0; i < n_got; offset += 4, i++) {
@@ -181,22 +180,17 @@ static RList *relocs(RBinFile *bf) {
 	}
 
 	if (obj->hdr->reloc_count > 0) {
-		int n_reloc = obj->hdr->reloc_count;
-
-		amount = n_reloc * sizeof (struct reloc_struct_t);
-		if (amount / sizeof (struct reloc_struct_t) != n_reloc) {
+		ut32 n_reloc = obj->hdr->reloc_count;
+		if (n_reloc > UT32_MAX / sizeof (struct reloc_struct_t)) {
 			goto out_error;
 		}
-		struct reloc_struct_t *reloc_table = calloc (1, amount + 1);
+		amount = n_reloc * sizeof (struct reloc_struct_t);
+		struct reloc_struct_t *reloc_table = calloc (1, amount);
 		if (!reloc_table) {
 			goto out_error;
 		}
 		amount = n_reloc * sizeof (ut32);
-		if (amount / sizeof (ut32) != n_reloc) {
-			free (reloc_table);
-			goto out_error;
-		}
-		ut32 *reloc_pointer_table = calloc (1, amount + 1);
+		ut32 *reloc_pointer_table = calloc (1, amount);
 		if (!reloc_pointer_table) {
 			free (reloc_table);
 			goto out_error;

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -152,8 +152,8 @@ static RList *relocs(RBinFile *bf) {
 	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
 		n_got = get_ngot_entries (obj);
 		if (n_got) {
-			amount = n_got * sizeof (ut32);
-			if (amount < n_got || amount > UT32_MAX) {
+			amount = n_got * sizeof(ut32);
+			if (amount / sizeof(ut32) != n_got) {
 				goto out_error;
 			}
 			struct reloc_struct_t *got_table = calloc (
@@ -183,16 +183,16 @@ static RList *relocs(RBinFile *bf) {
 	if (obj->hdr->reloc_count > 0) {
 		int n_reloc = obj->hdr->reloc_count;
 
-		amount = n_reloc * sizeof (struct reloc_struct_t);
-		if (amount < n_reloc || amount > UT32_MAX) {
+		amount = n_reloc * sizeof(struct reloc_struct_t);
+		if (amount / sizeof(struct reloc_struct_t) != n_reloc) {
 			goto out_error;
 		}
 		struct reloc_struct_t *reloc_table = calloc (1, amount + 1);
 		if (!reloc_table) {
 			goto out_error;
 		}
-		amount = n_reloc * sizeof (ut32);
-		if (amount < n_reloc || amount > UT32_MAX) {
+		amount = n_reloc * sizeof(ut32);
+		if (amount / sizeof(ut32) != n_reloc) {
 			free (reloc_table);
 			goto out_error;
 		}

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -153,7 +153,7 @@ static RList *relocs(RBinFile *bf) {
 		n_got = get_ngot_entries (obj);
 		if (n_got) {
 			amount = n_got * sizeof(ut32);
-			if (amount / sizeof(ut32) != n_got) {
+			if (amount / sizeof (ut32) != n_got) {
 				goto out_error;
 			}
 			struct reloc_struct_t *got_table = calloc (
@@ -183,16 +183,16 @@ static RList *relocs(RBinFile *bf) {
 	if (obj->hdr->reloc_count > 0) {
 		int n_reloc = obj->hdr->reloc_count;
 
-		amount = n_reloc * sizeof(struct reloc_struct_t);
-		if (amount / sizeof(struct reloc_struct_t) != n_reloc) {
+		amount = n_reloc * sizeof (struct reloc_struct_t);
+		if (amount / sizeof (struct reloc_struct_t) != n_reloc) {
 			goto out_error;
 		}
 		struct reloc_struct_t *reloc_table = calloc (1, amount + 1);
 		if (!reloc_table) {
 			goto out_error;
 		}
-		amount = n_reloc * sizeof(ut32);
-		if (amount / sizeof(ut32) != n_reloc) {
+		amount = n_reloc * sizeof (ut32);
+		if (amount / sizeof (ut32) != n_reloc) {
 			free (reloc_table);
 			goto out_error;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Even `a * 4 >= a`, the multiplication may still overflow.
Eg: `a = 0x58000000, a * 4 = 0x60000000`
Instead, we should use division to test whether a*b overflows.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
