### PR TITLE
Fix off by one when checking for "zzz"

### DIFF
--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -477,7 +477,7 @@ static int cmd_info(void *data, const char *input) {
 		if (strlen (input + 1 + suffix_shift) > 1) {
 			is_array = 1;
 		}
-		if (!strncmp (input, "zzz", 2)) {
+		if (!strncmp (input, "zzz", 3)) {
 			is_izzzj = true;
 		}
 	}


### PR DESCRIPTION
The string literal "zzz" has a length of 3 so the `strcnmp` used should have size argument of 3 instead of 2.

Since this PR is so small I hope the PR template/checklist is not needed.