### PR TITLE
Fix wrong string literal in core.c

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1087,7 +1087,7 @@ static void autocomplete_ms_path(RLineCompletion *completion, RCore *core, const
 	}
 	list= r_fs_dir (core->fs, dirname);
 	n = strlen (basename);
-	bool chgdir = !strncmp (str, "cd  ", 3);
+	bool chgdir = !strncmp (str, "cd ", 3);
 	if (list) {
 		r_list_foreach (list, iter, file) {
 			if (!file) {


### PR DESCRIPTION
In `bool chgdir = !strncmp (str, "cd  ", 3);` the string literal passed has a length of 4 but the size argument passed is 3.

I believe this is a typo in the string literal and it should be `"cd "` instead of `"cd  "` (note the two spaces).

Since this PR is so small I hope the PR template/checklist is not needed.