### PR TITLE
Fix off by one in "dr*" matching

### DIFF
--- a/libr/io/p/io_winedbg.c
+++ b/libr/io/p/io_winedbg.c
@@ -291,7 +291,7 @@ const char *msg =
 "flg	rf	.1	.202	0\n"\
 "flg	vm	.1	.203	0\n";
 		return strdup (msg);
-	} else if (!strncmp (cmd, "dr*", 2)) {
+	} else if (!strncmp (cmd, "dr*", 3)) {
 		struct winedbg_x86_32 r = regState ();
 		io->cb_printf ("f eip = 0x%08x\n", r.eip);
 		io->cb_printf ("f esp = 0x%08x\n", r.esp);


### PR DESCRIPTION
The string literal `"dr*"` has a length of 3 so the strncmp used should have size argument of 3 instead of 2.

PS: I am not sure if this fix is correct but it seems so. If it is not, please close this PR. However, if the fix is incorrect it seems there could be some bug as next `else if` checks for `"dr"` too.

Since this PR is so small I hope the PR template/checklist is not needed.
