### PR TITLE
Fix off by one errors in asm_bf

### DIFF
--- a/libr/asm/p/asm_bf.c
+++ b/libr/asm/p/asm_bf.c
@@ -114,7 +114,7 @@ static int assemble(RAsm *a, RAsmOp *op, const char *buf) {
 	} else if (!strncmp (buf, "loop", 4))        {
 		opbuf[0] = ']';
 		n = 1;
-	} else if (!strncmp (buf, "in", 4))        {
+	} else if (!strncmp (buf, "in", 2))        {
 		if (arg) {
 			n = atoi (arg + 1);
 			memset (opbuf, ',', n);
@@ -122,7 +122,7 @@ static int assemble(RAsm *a, RAsmOp *op, const char *buf) {
 			opbuf[0] = ',';
 			n = 1;
 		}
-	} else if (!strncmp (buf, "out", 4))        {
+	} else if (!strncmp (buf, "out", 3))        {
 		if (arg) {
 			n = atoi (arg + 1);
 			memset (opbuf, '.', n);


### PR DESCRIPTION
The `strncmp` calls with `"in"` and `"out"` string literals seems to have wrong size argument passed. This PR fixes it.

Since this PR is so small I hope the PR template/checklist is not needed.

