### PR TITLE
Fix #16433 - Use MOV opcode B8+ for MOV r64, <0x80000000 to 0xffffffff>

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1818,14 +1818,13 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 				data[l++] = immediate;
 			} else {
 				if (a->bits == 64 &&
-					((((op->operands[0].type & OT_QWORD) |
-					(op->operands[1].type & OT_QWORD)) &&
-					immediate < UT32_MAX) ||
-					 ((op->operands[0].type & OT_QWORD) &&
-					  immediate >= 0xffffffff80000000 /* -0x80000000 */))) {
-						data[l++] = 0xc7;
-				 		data[l++] = 0xc0 | op->operands[0].reg;
-						imm32in64 = true;
+				    ((!(op->operands[0].type & OT_QWORD) && (op->operands[1].type & OT_QWORD) &&
+				      immediate < UT32_MAX) ||
+				     ((op->operands[0].type & OT_QWORD) &&
+				      (immediate <= ST32_MAX || immediate >= 0xffffffff80000000LL /* -0x80000000 */)))) {
+					data[l++] = 0xc7;
+					data[l++] = 0xc0 | op->operands[0].reg;
+					imm32in64 = true;
 				} else {
 					data[l++] = 0xb8 | op->operands[0].reg;
 				}
@@ -1835,7 +1834,8 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 					data[l++] = immediate >> 16;
 					data[l++] = immediate >> 24;
 				}
-				if (a->bits == 64 && immediate > UT32_MAX && !imm32in64) {
+				if (a->bits == 64 && (immediate > UT32_MAX || (op->operands[0].type & OT_QWORD)) &&
+				    !imm32in64) {
 					data[l++] = immediate >> 32;
 					data[l++] = immediate >> 40;
 					data[l++] = immediate >> 48;

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -39,6 +39,14 @@ aB "mov rax, 0x112233445566778899" 00
 a "mov rax, 3" 48c7c003000000
 a "mov rax, 33" 48c7c021000000
 ad "mov rax, 0x7fffffff" 48c7c0ffffff7f
+a "mov rax, 0x80000000" 48b80000008000000000
+ad "movabs rax, 0x80000000" 48b80000008000000000
+a "mov rax, 0xdeadbeef" 48b8efbeadde00000000
+ad "movabs rax, 0xdeadbeef" 48b8efbeadde00000000
+a "mov rax, 0xffffffff" 48b8ffffffff00000000
+ad "movabs rax, 0xffffffff" 48b8ffffffff00000000
+a "mov rax, 0x100000000" 48b80000000001000000
+ad "movabs rax, 0x100000000" 48b80000000001000000
 ad "mov rax, 0" 48c7c000000000
 a "mov rax, -1" 48c7c0ffffffff
 adB "mov rax, 0xffffffffffffffff" 48c7c0ffffffff
@@ -740,7 +748,6 @@ aB "mov qword[r12], rsp" 49892424
 aB "mov qword[r8 + 0x20], rax" 49894020
 aB "mov r12, qword[r12]" 4d8b2424
 a "mov eax,r12d" 4489e0
-ad "movabs rax, 0xdeadbeef" 48b8efbeadde00000000
 ad "movabs r12, 1" 49bc0100000000000000
 a "inc al" fec0
 a "inc BYTE PTR [r12]" 41fe0424


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I've confirmed https://github.com/radareorg/radare2/issues/16433#issuecomment-612592213 (including the nasm `rax` -> `eax` bug) and thus this pr makes the x86_64 assembler use the MOV B8+ encoding (MOV r64, imm64) when the immediate is between 0x80000000 and 0xffffffff for both:

1. Consistency with GNU assembler.
1. It actually does seem to be the expected encoding.

This does mean that `mov eax, 0xffffffff` and `mov rax, 0xffffffff` will have very different semantics.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHub Actions and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #16433.
