### PR TITLE
Improve newshell.yaml and use better names for GH builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,23 +12,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [linux-acr-gcc, linux-acr-clang, linux-meson-gcc, macos-clang]
+        name: [linux-acr-gcc-tests, linux-acr-clang-tests, linux-meson-gcc-tests, macos-clang-tests]
         include:
-          - name: linux-acr-gcc
+          - name: linux-acr-gcc-tests
             os: ubuntu-latest
             build_system: acr
             compiler: gcc
-          - name: linux-acr-clang
+          - name: linux-acr-clang-tests
             os: ubuntu-latest
             build_system: acr
             compiler: clang
-          - name: linux-meson-gcc
+          - name: linux-meson-gcc-tests
             os: ubuntu-latest
             build_system: meson
             compiler: gcc
             meson_options: -Db_coverage=true
             coverage: 1
-          - name: macos-clang
+          - name: macos-clang-tests
             os: macos-latest
             build_system: acr
             compiler: clang

--- a/.github/workflows/newshell.yml
+++ b/.github/workflows/newshell.yml
@@ -3,7 +3,7 @@ name: Radare2 CI newshell
 on:
   pull_request:
     branches:
-    - 'newshell-*'
+    - master
   push:
     branches:
     - master
@@ -48,6 +48,7 @@ jobs:
         ninja -C build install
     - name: Run tests
       continue-on-error: true
+      if: startswith(github.event.pull_request.head.ref, 'newshell-') || github.event_name == 'push'
       run: |
         # Running the test suite
         export PATH=${HOME}/bin:${HOME}/.local/bin:${PATH}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux-acr-gcc, linux-acr-clang, linux-meson-gcc, macos-clang]
+        name: [linux-acr-gcc-tests, linux-acr-clang-build, linux-meson-gcc-build, macos-clang-tests]
         include:
-          - name: linux-acr-gcc
+          - name: linux-acr-gcc-tests
             os: ubuntu-latest
             build_system: acr
             compiler: gcc
             run_tests: true
-          - name: linux-acr-clang
+          - name: linux-acr-clang-build
             os: ubuntu-latest
             build_system: acr
             compiler: clang
-          - name: linux-meson-gcc
+          - name: linux-meson-gcc-build
             os: ubuntu-latest
             build_system: meson
             compiler: gcc
-          - name: macos-clang
+          - name: macos-clang-tests
             os: macos-latest
             build_system: acr
             compiler: clang


### PR DESCRIPTION
Unfortunately GH action does not directly support filtering of PRs by branch name (the name you specify in `on.branches` is the "base" branch. With this PR, newshell is always built on every PR, but only those that are named `newshell-*` run the full tests.