### PR TITLE
x86_64: Fix REX.B for MOV r64-extended, imm32/64

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1799,8 +1799,8 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 		immediate = op->operands[1].immediate * op->operands[1].sign;
 		if (op->operands[0].type & OT_GPREG && !(op->operands[0].type & OT_MEMORY)) {
 			bool imm32in64 = false;
-			if (a->bits == 64 && ((op->operands[0].type & OT_QWORD) | (op->operands[1].type & OT_QWORD))) {
-				if (!(op->operands[1].type & OT_CONSTANT) && op->operands[1].extended) {
+			if (a->bits == 64 && (op->operands[0].type & OT_QWORD)) {
+				if (op->operands[0].extended) {
 					data[l++] = 0x49;
 				} else {
 					data[l++] = 0x48;

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -62,6 +62,15 @@ a "mov rax, -0x80000000" 48c7c000000080
 ad "mov rax, 0xffffffff80000000" 48c7c000000080
 a "mov rax, -0x80000001" 48b8ffffff7fffffffff
 ad "movabs rax, 0xffffffff7fffffff" 48b8ffffff7fffffffff
+ad "mov r9, 0x7fffffff" 49c7c1ffffff7f
+a "mov r10, 0x80000000" 49ba0000008000000000
+ad "movabs r10, 0x80000000" 49ba0000008000000000
+a "mov r11, 0x100000000" 49bb0000000001000000
+ad "movabs r11, 0x100000000" 49bb0000000001000000
+a "mov r14, -0x80000000" 49c7c600000080
+ad "mov r14, 0xffffffff80000000" 49c7c600000080
+a "mov r15, -0x80000001" 49bfffffff7fffffffff
+ad "movabs r15, 0xffffffff7fffffff" 49bfffffff7fffffffff
 a "mov rax, [rax+0]" 488b00
 a "mov rax, [rax+1]" 488b4001
 a "mov rax, [rax-0]" 488b00


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr makes the x86_64 assembler set REX.B to 1 when encoding a MOV r64, imm32/64 instruction when r64 is from r8 to r15.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
