### PR TITLE
x86_64: Fix MOV r32, -imm32 encoding

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1831,8 +1831,9 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 					data[l++] = immediate >> 16;
 					data[l++] = immediate >> 24;
 				}
-				if (a->bits == 64 && (immediate > UT32_MAX || (op->operands[0].type & OT_QWORD)) &&
-				    !imm32in64) {
+				if (a->bits == 64 &&
+				    (((op->operands[0].type & OT_QWORD) && !imm32in64) ||
+				     (immediate > UT32_MAX && immediate < 0xffffffff80000000ULL /* -0x80000000 */))) {
 					data[l++] = immediate >> 32;
 					data[l++] = immediate >> 40;
 					data[l++] = immediate >> 48;

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -36,9 +36,9 @@ aB "lea rax, 0x803" 488d042503080000
 a "mov [rsi], rbx" 48891e
 ad "mov eax, 0" b800000000
 ad "mov ecx, 0x7fffffff" b9ffffff7f
-aB "mov esi, -0x80000000" be00000080
+a "mov esi, -0x80000000" be00000080
 ad "mov esi, 0x80000000" be00000080
-aB "mov edi, -1" bfffffffff
+a "mov edi, -1" bfffffffff
 ad "mov edi, 0xffffffff" bfffffffff
 a "mov rax, 0x1122334455667788" 48b88877665544332211
 a "mov rax, 3" 48c7c003000000


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the x86_64 assembler encoding when the MOV r32, -imm32 notation is used.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
