### PR TITLE
Fix dyldcache malformed local symbol ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -248,7 +248,7 @@ static void r_dyld_locsym_entries_by_offset(RDyldCache *cache, RList *symbols, H
 		}
 
 		if (entry->nlistStartIndex >= locsym->nlists_count ||
-				entry->nlistStartIndex + entry->nlistCount >= locsym->nlists_count) {
+				entry->nlistStartIndex + entry->nlistCount > locsym->nlists_count) {
 			eprintf ("dyldcache: malformed local symbol entry\n");
 			break;
 		}


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

It was a false positive due to wrong boundary check.
