### PR TITLE
x86_32/64: Don't assemble overlarge MOV imm32

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1798,6 +1798,10 @@ static int opmov(RAsm *a, ut8 *data, const Opcode *op) {
 		}
 		immediate = op->operands[1].immediate * op->operands[1].sign;
 		if (op->operands[0].type & OT_GPREG && !(op->operands[0].type & OT_MEMORY)) {
+			if ((op->operands[0].type & OT_DWORD) &&
+			    immediate > UT32_MAX && immediate < 0xffffffff80000000ULL /* -0x80000000 */) {
+				return -1;
+			}
 			bool imm32in64 = false;
 			if (a->bits == 64 && (op->operands[0].type & OT_QWORD)) {
 				if (op->operands[0].extended) {

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -183,12 +183,27 @@ invalid
 EOF
 RUN
 
+NAME=rasm2 x86_32 overlarge operand
+FILE=-
+CMDS=!rasm2 -a x86 -b 32 "mov eax, 0x1122334455"
+EXPECT=
+EXPECT_ERR=<<EOF
+Cannot assemble 'mov eax, 0x1122334455' at line 3
+invalid
+EOF
+RUN
+
 NAME=rasm2 x86_64 overlarge operand
 FILE=-
-CMDS=!rasm2 -a x86 -b 64 "mov rax, 0x112233445566778899"
+CMDS=<<EOF
+!rasm2 -a x86 -b 64 "mov rax, 0x112233445566778899"
+!rasm2 -a x86 -b 64 "mov eax, 0x1122334455"
+EOF
 EXPECT=
 EXPECT_ERR=<<EOF
 Cannot assemble 'mov rax, 0x112233445566778899' at line 3
+invalid
+Cannot assemble 'mov eax, 0x1122334455' at line 3
 invalid
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr prevents the x86_32/64 assembler from assembling overlarge MOV imm32 assembly constants.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green with attached test.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
