### PR TITLE
Fix segfault when passing null string to "r_listinfo_new"

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4337,11 +4337,11 @@ dodo:
 R_API RListInfo *r_listinfo_new(const char *name, RInterval pitv, RInterval vitv, int perm, const char *extra) {
 	RListInfo *info = R_NEW (RListInfo);
 	if (info) {
-		info->name = strdup (name);
+		info->name = name ? strdup (name) : NULL;
 		info->pitv = pitv;
 		info->vitv = vitv;
 		info->perm = perm;
-		info->extra = strdup (extra);
+		info->extra = extra ? strdup (extra) : NULL;
 	}
 	return info;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Using `om=` in debug mode will cause segfault.
```
$ r2 -d rax2
Process with PID 31203 started...
= attach 31203 31203
bin.baddr 0x56254d888000
Using 0x56254d888000
asm.bits 64
Warning: r_bin_file_hash: file exceeds bin.hashlimit
 -- I C dead bugs everywhere!
[0x7f1769e54090]> om
 1 fd: 3 +0x00000000 0x00000000 - 0x7ffffffffffffffe rwx 
[0x7f1769e54090]> om=
Segmentation fault (core dumped)
```
Because a default `RIOMap` is created without setting its name when r2 is in debug mode.
https://github.com/radareorg/radare2/blob/35290dd51d815ed0e36623b1fba63c6f8a93bd84/libr/core/cfile.c#L688-L691

Thefore, when calling `om=`, it passes `map->name` (NULL) to `r_listinfo_new` and the function calls `strdup (NULL)`, which causes the segfault.
https://github.com/radareorg/radare2/blob/35290dd51d815ed0e36623b1fba63c6f8a93bd84/libr/core/cmd_open.c#L829-L838

A quick fix is to check the `name` and `extra` args.
