### PR TITLE
Fix the static build by dynamically resolving libutil symbols ##build

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,33 @@
+name: Radare2 CI - static build
+
+on:
+  schedule:
+    # “At 00:00 on every 7th day-of-week.”
+    - cron:  '0 0 * * */7'
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: ubuntu-static-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name != 'pull_request' || contains(github.event.pull_request.head.ref, 'static')
+    - name: Checkout our Testsuite Binaries
+      if: github.event_name != 'pull_request' || contains(github.event.pull_request.head.ref, 'static')
+      uses: actions/checkout@v2
+      with:
+          repository: radareorg/radare2-testbins
+          path: test/bins
+    - name: Install static
+      if: github.event_name != 'pull_request' || contains(github.event.pull_request.head.ref, 'static')
+      run: |
+        ./sys/static.sh
+        sudo make symstall
+    - name: Run tests
+      if: github.event_name != 'pull_request' || contains(github.event.pull_request.head.ref, 'static')
+      run: |
+        r2 -v
+        r2r -v

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -58,6 +58,12 @@
 
 #define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !__sun
 
+#if HAVE_PTY
+static int (*dyn_openpty)(int *amaster, int *aslave, char *name, struct termios *termp, struct winsize *winp) = NULL;
+static int (*dyn_login_tty)(int fd) = NULL;
+static id_t (*dyn_forkpty)(int *amaster, char *name, struct termios *termp, struct winsize *winp) = NULL;
+#endif
+
 #if EMSCRIPTEN
 #undef HAVE_PTY
 #define HAVE_PTY 0
@@ -278,6 +284,10 @@ static void restore_saved_fd(int saved, bool restore, int fd) {
 
 static int handle_redirection_proc(const char *cmd, bool in, bool out, bool err) {
 #if HAVE_PTY
+	if (!dyn_forkpty) {
+		// No forkpty api found, maybe we should fallback to just fork without any pty allocated
+		return -1;
+	}
 	// use PTY to redirect I/O because pipes can be problematic in
 	// case of interactive programs.
 	int saved_stdin = dup (STDIN_FILENO);
@@ -285,11 +295,12 @@ static int handle_redirection_proc(const char *cmd, bool in, bool out, bool err)
 		return -1;
 	}
 	int saved_stdout = dup (STDOUT_FILENO);
-	if (saved_stdout== -1) {
+	if (saved_stdout == -1) {
 		close (saved_stdin);
 		return -1;
 	}
-	int fdm, pid = forkpty (&fdm, NULL, NULL, NULL);
+	
+	int fdm, pid = dyn_forkpty (&fdm, NULL, NULL, NULL);
 	if (pid == -1) {
 		close (saved_stdin);
 		close (saved_stdout);
@@ -357,7 +368,7 @@ static int handle_redirection_proc(const char *cmd, bool in, bool out, bool err)
 }
 
 static int handle_redirection(const char *cmd, bool in, bool out, bool err) {
-	if (!cmd || cmd[0] == '\0') {
+	if (!cmd || !*cmd) {
 		return 0;
 	}
 
@@ -686,7 +697,7 @@ static int redirect_socket_to_pty(RSocket *sock) {
 	// in case of interactive applications
 	int fdm, fds;
 
-	if (openpty (&fdm, &fds, NULL, NULL, NULL) == -1) {
+	if (dyn_openpty && dyn_openpty (&fdm, &fds, NULL, NULL, NULL) == -1) {
 		perror ("opening pty");
 		return -1;
 	}
@@ -740,7 +751,9 @@ static int redirect_socket_to_pty(RSocket *sock) {
 
 	// parent
 	r_socket_close_fd (sock);
-	login_tty (fds);
+	if (dyn_login_tty) {
+		dyn_login_tty (fds);
+	}
 	close (fdm);
 
 	// disable the echo on slave stdin
@@ -756,8 +769,27 @@ static int redirect_socket_to_pty(RSocket *sock) {
 #endif
 }
 
+
+
+#if HAVE_PTY
+
+static void dyn_init(void) {
+	if (!dyn_openpty) {
+		dyn_openpty = r_lib_dl_sym (NULL, "openpty");
+	}
+	if (!dyn_login_tty) {
+		dyn_openpty = r_lib_dl_sym (NULL, "login_tty");
+	}
+	if (!dyn_forkpty) {
+		dyn_openpty = r_lib_dl_sym (NULL, "forkpty");
+	}
+}
+#endif
+
 R_API int r_run_config_env(RRunProfile *p) {
 	int ret;
+
+	dyn_init ();
 
 	if (!p->_program && !p->_system && !p->_runlib) {
 		printf ("No program, system or runlib rule defined\n");

--- a/sys/static.sh
+++ b/sys/static.sh
@@ -42,7 +42,7 @@ if [ 1 = "${DOCFG}" ]; then
 	./configure --prefix="$PREFIX" --without-gpl --with-libr --without-libuv || exit 1
 fi
 ${MAKE} -j 8 || exit 1
-BINS="rarun2 rasm2 radare2 ragg2 rabin2 rax2 rahash2 rafind2 r2agent radiff2"
+BINS="rarun2 rasm2 radare2 ragg2 rabin2 rax2 rahash2 rafind2 r2agent radiff2 r2r"
 # shellcheck disable=SC2086
 for a in ${BINS} ; do
 (


### PR DESCRIPTION
Debian/Ubuntu doesn't seems to provide libutil.a so symbols are missing and libr.a is not purely static
We should provide a fallback with just fork imho, but at least this will keep it working

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
