### PR TITLE
Enforce newshell build from now on

### DIFF
--- a/.github/workflows/newshell.yml
+++ b/.github/workflows/newshell.yml
@@ -47,7 +47,6 @@ jobs:
         export PKG_CONFIG_PATH=${HOME}/lib/pkgconfig:${HOME}/lib/$(uname -m)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}
         ninja -C build install
     - name: Run tests
-      continue-on-error: true
       if: startswith(github.event.pull_request.head.ref, 'newshell-') || github.event_name == 'push'
       run: |
         # Running the test suite

--- a/test/db/cmd/cmd_hash
+++ b/test/db/cmd/cmd_hash
@@ -41,21 +41,3 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
-
-NAME=hash_subcommands_not_noop
-FILE=-
-CMDS=<<EOF
-?! `#! ~?`
-?v
-?! `#? ~? `
-?v
-?! `#a ~? `
-?v
-EOF
-EXPECT=<<EOF
-0
-0
-0x0
-0
-EOF
-RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -471,14 +471,6 @@ func.foo.ret=int32_t
 EOF
 RUN
 
-NAME=tk - crash
-FILE=-
-CMDS=tk -!!!! d'B%CCCC!9!!!!_
-EXPECT=<<EOF
-0x0
-EOF
-RUN
-
 NAME=struct of struct with ts and pf
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
build should be completely green with newshell now, so we can make sure it will always be.

I removed two tests that were "wrong".

- `tk - crash` was just checking that a particular command was not crashing. Returning 0 is wrong in those case, because if the command is invalid the parser should just say "Invalid command" (or something like that) and not return 0. The new parser correctly complains about the invalid command, but the old one does not so I just removed the test.

- `hash_subcommands_not_noop` was executing (invalid) commands that are treated as comments in the new parser. Everything after `#` is a comment in the new parser, apart from commands that start with `#!` (and `#?`). The test was using `#a`, which just makes everything after `#` being treated as a comment.