### PR TITLE
gdb arch reg profile memory leak fix ##debug

### DIFF
--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -105,6 +105,9 @@ gdb_reg_t *arch_parse_reg_profile(const char * reg_profile) {
 				// Warn the user if something went wrong
 				if (!reg) {
 					eprintf ("gdb_regs: Parse error @ line %d\n", l);
+					for (i = 0; i < j; i++) {
+						free (tok[i]);
+					}
 					// Clean up
 					r_list_free (gdb_regs_list);
 					return NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)
