### PR TITLE
Fix autodetection dbdir in r2r @unit ##tests

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -97,10 +97,13 @@ static bool r2r_chdir(const char *argv0) {
 }
 
 static void r2r_test_run_unit(void) {
-	system ("make -C ../unit all run");
+	system ("make -C unit all run");
 }
 
 static bool r2r_chdir_fromtest(const char *test_path) {
+	if (*test_path == '@') {
+		test_path = "";
+	}
 	char *abs_test_path = r_file_abspath (test_path);
 	if (!r_file_is_directory (abs_test_path)) {
 		char *last_slash = (char *)r_str_lchr (abs_test_path, R_SYS_DIR[0]);
@@ -118,6 +121,15 @@ static bool r2r_chdir_fromtest(const char *test_path) {
 		cwd = r_sys_getdir ();
 		if (old_cwd && !strcmp (old_cwd, cwd)) {
 			break;
+		}
+		if (r_file_is_directory ("test")) {
+			r_sys_chdir ("test");
+			if (r_file_is_directory ("db")) {
+				found = true;
+				eprintf ("Running from %s\n", cwd);
+				break;
+			}
+			r_sys_chdir ("..");
 		}
 		if (r_file_is_directory ("db")) {
 			found = true;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Right now you get this:

```
$ r2r @unit
Cannot find db/ directory related to the given test. 
```
**Test plan**

just apply this pr and run r2r @unit and see that after the fix the command above works

**Closing issues**

There's no open issue for this. imho travis and such should use r2r to run all the tests