### PR TITLE
Remove hardcoded supported encoders names

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -382,21 +382,27 @@ static void cmd_write_op (RCore *core, const char *input) {
 				for (i = 0; ; i++) {
 					bits = ((ut64)1) << i;
 					const char *name = r_hash_name (bits);
-					if (!name || !*name) break;
+					if R_STR_ISEMPTY (name) {
+						break;
+					}
 					printf ("  %s\n", name);
 				}
 				eprintf ("Available Encoders/Decoders: \n");
 				for (i = 0; ; i++) {
-					bits = ((ut64)1) << i;
+					bits = (1ULL) << i;
 					const char *name = r_crypto_codec_name ((const RCryptoSelector)bits);
-					if (!name || !*name) break;
+					if R_STR_ISEMPTY (name) {
+						break;
+					}
 					printf ("  %s\n", name);
 				}
 				eprintf ("Currently supported crypto algos:\n");
 				for (i = 0; ; i++) {
-					bits = ((ut64)1) << i;
+					bits = (1ULL) << i;
 					const char *name = r_crypto_name ((const RCryptoSelector)bits);
-					if (!name || !*name) break;
+					if R_STR_ISEMPTY (name) {
+						break;
+					}
 					printf ("  %s\n", name);
 				}
 			}

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -386,14 +386,16 @@ static void cmd_write_op (RCore *core, const char *input) {
 					printf ("  %s\n", name);
 				}
 				eprintf ("Available Encoders/Decoders: \n");
-				// TODO: do not hardcode
-				eprintf ("  base64\n");
-				eprintf ("  base91\n");
-				eprintf ("  punycode\n");
+				for (i = 0; ; i++) {
+					bits = ((ut64)1) << i;
+					const char *name = r_crypto_codec_name ((const RCryptoSelector)bits);
+					if (!name || !*name) break;
+					printf ("  %s\n", name);
+				}
 				eprintf ("Currently supported crypto algos:\n");
 				for (i = 0; ; i++) {
 					bits = ((ut64)1) << i;
-					const char *name = r_crypto_name (bits);
+					const char *name = r_crypto_name ((const RCryptoSelector)bits);
 					if (!name || !*name) break;
 					printf ("  %s\n", name);
 				}

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -391,7 +391,7 @@ static void cmd_write_op (RCore *core, const char *input) {
 				for (i = 0; ; i++) {
 					bits = (1ULL) << i;
 					const char *name = r_crypto_codec_name ((const RCryptoSelector)bits);
-					if R_STR_ISEMPTY (name) {
+					if (R_STR_ISEMPTY (name)) {
 						break;
 					}
 					printf ("  %s\n", name);

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -7,7 +7,7 @@ R_LIB_VERSION (r_crypto);
 
 static const struct {
 	const char *name;
-	const RCryptoSelector bit;
+	RCryptoSelector bit;
 } crypto_name_bytes[] = {
 	{ "all", UT64_MAX },
 	{ "rc2", R_CRYPTO_RC2 },
@@ -28,7 +28,7 @@ static const struct {
 
 static const struct {
 	const char *name;
-	const RCryptoSelector bit;
+	RCryptoSelector bit;
 } codec_name_bytes[] = {
 	{ "all", UT64_MAX },
 	{ "base64", R_CODEC_B64 },

--- a/libr/crypto/crypto.c
+++ b/libr/crypto/crypto.c
@@ -7,30 +7,51 @@ R_LIB_VERSION (r_crypto);
 
 static const struct {
 	const char *name;
-	ut64 bit;
+	const RCryptoSelector bit;
 } crypto_name_bytes[] = {
-	{"all", UT64_MAX},
-	{"rc2", R_CRYPTO_RC2},
-	{"rc4", R_CRYPTO_RC4},
-	{"rc6", R_CRYPTO_RC6},
-	{"aes-ecb", R_CRYPTO_AES_ECB},
-	{"aes-cbc", R_CRYPTO_AES_CBC},
-	{"ror", R_CRYPTO_ROR},
-	{"rol", R_CRYPTO_ROL},
-	{"rot", R_CRYPTO_ROT},
-	{"blowfish", R_CRYPTO_BLOWFISH},
-	{"cps2", R_CRYPTO_CPS2},
-	{"des-ecb", R_CRYPTO_DES_ECB},
-	{"xor", R_CRYPTO_XOR},
-	{"serpent-ecb", R_CRYPTO_SERPENT},
-	{NULL, 0}
+	{ "all", UT64_MAX },
+	{ "rc2", R_CRYPTO_RC2 },
+	{ "rc4", R_CRYPTO_RC4 },
+	{ "rc6", R_CRYPTO_RC6 },
+	{ "aes-ecb", R_CRYPTO_AES_ECB },
+	{ "aes-cbc", R_CRYPTO_AES_CBC },
+	{ "ror", R_CRYPTO_ROR },
+	{ "rol", R_CRYPTO_ROL },
+	{ "rot", R_CRYPTO_ROT },
+	{ "blowfish", R_CRYPTO_BLOWFISH },
+	{ "cps2", R_CRYPTO_CPS2 },
+	{ "des-ecb", R_CRYPTO_DES_ECB },
+	{ "xor", R_CRYPTO_XOR },
+	{ "serpent-ecb", R_CRYPTO_SERPENT },
+	{ NULL, 0 }
 };
 
-R_API const char *r_crypto_name(ut64 bit) {
-	int i;
+static const struct {
+	const char *name;
+	const RCryptoSelector bit;
+} codec_name_bytes[] = {
+	{ "all", UT64_MAX },
+	{ "base64", R_CODEC_B64 },
+	{ "base91", R_CODEC_B91 },
+	{ "punycode", R_CODEC_PUNYCODE },
+	{ NULL, 0 }
+};
+
+R_API const char *r_crypto_name(const RCryptoSelector bit) {
+	size_t i;
 	for (i = 1; crypto_name_bytes[i].bit; i++) {
 		if (bit & crypto_name_bytes[i].bit) {
 			return crypto_name_bytes[i].name;
+		}
+	}
+	return "";
+}
+
+R_API const char *r_crypto_codec_name(const RCryptoSelector bit) {
+	size_t i;
+	for (i = 1; codec_name_bytes[i].bit; i++) {
+		if (bit & codec_name_bytes[i].bit) {
+			return codec_name_bytes[i].name;
 		}
 	}
 	return "";

--- a/libr/include/r_crypto.h
+++ b/libr/include/r_crypto.h
@@ -48,6 +48,8 @@ typedef struct r_crypto_plugin_t {
 	int (*fini)(RCrypto *cry);
 } RCryptoPlugin;
 
+typedef ut64 RCryptoSelector;
+
 #ifdef R_API
 R_API RCrypto *r_crypto_init(RCrypto *cry, int hard);
 R_API RCrypto *r_crypto_as_new(RCrypto *cry);
@@ -61,7 +63,8 @@ R_API int r_crypto_update(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_final(RCrypto *cry, const ut8 *buf, int len);
 R_API int r_crypto_append(RCrypto *cry, const ut8 *buf, int len);
 R_API ut8 *r_crypto_get_output(RCrypto *cry, int *size);
-R_API const char *r_crypto_name(ut64 bit);
+R_API const char *r_crypto_name(const RCryptoSelector bit);
+R_API const char *r_crypto_codec_name(const RCryptoSelector bit);
 #endif
 
 /* plugin pointers */
@@ -82,21 +85,27 @@ extern RCryptoPlugin r_crypto_plugin_rc6;
 extern RCryptoPlugin r_crypto_plugin_cps2;
 extern RCryptoPlugin r_crypto_plugin_serpent;
 
-#define R_CRYPTO_NONE 0
-#define R_CRYPTO_RC2 1
-#define R_CRYPTO_RC4 1<<1
-#define R_CRYPTO_RC6 1<<2
-#define R_CRYPTO_AES_ECB 1<<3
-#define R_CRYPTO_AES_CBC 1<<4
-#define R_CRYPTO_ROR 1<<5
-#define R_CRYPTO_ROL 1<<6
-#define R_CRYPTO_ROT 1<<7
-#define R_CRYPTO_BLOWFISH 1<<8
-#define R_CRYPTO_CPS2 1<<9
-#define R_CRYPTO_DES_ECB 1<<10
-#define R_CRYPTO_XOR 1<<11
-#define R_CRYPTO_SERPENT 1<<12
+#define R_CRYPTO_NONE 0ULL
+#define R_CRYPTO_RC2 1ULL
+#define R_CRYPTO_RC4 1ULL<<1
+#define R_CRYPTO_RC6 1ULL<<2
+#define R_CRYPTO_AES_ECB 1ULL<<3
+#define R_CRYPTO_AES_CBC 1ULL<<4
+#define R_CRYPTO_ROR 1ULL<<5
+#define R_CRYPTO_ROL 1ULL<<6
+#define R_CRYPTO_ROT 1ULL<<7
+#define R_CRYPTO_BLOWFISH 1ULL<<8
+#define R_CRYPTO_CPS2 1ULL<<9
+#define R_CRYPTO_DES_ECB 1ULL<<10
+#define R_CRYPTO_XOR 1ULL<<11
+#define R_CRYPTO_SERPENT 1ULL<<12
 #define R_CRYPTO_ALL 0xFFFF
+
+#define R_CODEC_NONE 0ULL
+#define R_CODEC_B64 1ULL
+#define R_CODEC_B91 1ULL<<1
+#define R_CODEC_PUNYCODE 1ULL<<2
+#define R_CODEC_ALL 0xFFFF
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

- Add a structure of supported encoder names
- Add a function to get the name of the encoder corresponding to the id given as parameter
- Change the way `woD` command prints supported encoders names

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`woD` should print the same help message as before.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
