### PR TITLE
Remove Variable Linking and replace with Info from Accesses

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -755,7 +755,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	RAnalVar *rvar, *bp_var;
 	RListIter *iter , *iter2;
 	r_list_foreach (list, iter, rvar) {
-		RAnalVar *lvar = r_anal_get_link_function_var (anal, fcn->addr, rvar);
+		RAnalVar *lvar = r_anal_var_get_dst_var (rvar);
 		RRegItem *i = r_reg_index_get (anal->reg, rvar->delta);
 		if (!i) {
 			continue;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1612,11 +1612,19 @@ R_API void r_anal_var_delete(RAnalVar *var);
 R_API ut64 r_anal_var_addr(RAnalVar *var);
 R_API void r_anal_var_set_access(RAnalVar *var, ut64 access_addr, int access_type, st64 stackptr);
 R_API void r_anal_var_clear_accesses(RAnalVar *var);
+
+// Get the access to var at exactly addr if there is one
+R_API RAnalVarAccess *r_anal_var_get_access_at(RAnalVar *var, ut64 addr);
+
 R_API int r_anal_var_get_argnum(RAnalVar *var);
 
 R_API void r_anal_extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op);
 R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count);
-R_API RAnalVar *r_anal_get_link_function_var(RAnal *anal, ut64 faddr, RAnalVar *var);
+
+// Get the variable that var is written to at one of its accesses
+// Useful for cases where a register-based argument is written away into a stack variable,
+// so if var is the reg arg then this will return the stack var.
+R_API RAnalVar *r_anal_var_get_dst_var(RAnalVar *var);
 
 typedef struct r_anal_fcn_vars_cache {
 	RList *bvars;


### PR DESCRIPTION
**Detailed description**

Previously, this "linking" was used to add information that in a case like this, where `ecx` is an argument and it is directly saved in `var_3ch`, these variables are linked together.
```
0x00083e83      894c240c       mov dword [var_3ch], ecx    ; arg4
```
However this is now completely unnecessary and we can recover the info directly from the accesses by checking which is a read and which is a write.

This is also the last step to remove everything var-related from sdb, unless I overlooked something.

**Test plan**

`db/cmd/types` contains tests for exactly these cases
