### PR TITLE
Fix #13737 - Mark ELF segments as data ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -234,6 +234,9 @@ static RList* sections(RBinFile *bf) {
 				ptr->perm |= R_PERM_R;
 				found_load = 1;
 				ptr->add = true;
+				if (!(phdr[i].p_flags & PF_X)) {
+					ptr->is_data = true;
+				}
 				break;
 			case PT_INTERP:
 				ptr->name = strdup ("INTERP");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When there are no sections in a FILE, you cannot find any string, because no section/segment is marked as "has_strings" or "is_data" and those are used to filter the sections to parse in `r_bin_file_get_strings`.

**Test plan**

The binary boa-mips should now have a lot of strings. Let's see if this doesn't enable too many strings in other binary of the tests suite.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #13737