### PR TITLE
Support relative temporary seek in cfg.newshell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5229,13 +5229,16 @@ DEFINE_HANDLE_TS_FCN(help_command) {
 }
 
 DEFINE_HANDLE_TS_FCN(tmp_seek_command) {
-	// TODO: handle offsets like "+30", "-13", etc.
 	TSNode command = ts_node_named_child (node, 0);
 	TSNode offset = ts_node_named_child (node, 1);
 	char *offset_string = ts_node_handle_arg (state, node, offset, 1);
+	ut64 offset_val = r_num_math (state->core->num, offset_string);
 	ut64 orig_offset = state->core->offset;
-	R_LOG_DEBUG ("tmp_seek_command, changing offset to %s\n", offset_string);
-	r_core_seek (state->core, r_num_math(state->core->num, offset_string), true);
+	if (offset_string[0] == '-' || offset_string[0] == '+') {
+		offset_val += state->core->offset;
+	}
+	R_LOG_DEBUG ("tmp_seek_command, changing offset to %" PFMT64x "\n", offset_val);
+	r_core_seek (state->core, offset_val, true);
 	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
 	r_core_seek (state->core, orig_offset, true);
 	free (offset_string);

--- a/test/db/cmd/cmd_seek
+++ b/test/db/cmd/cmd_seek
@@ -344,3 +344,14 @@ EXPECT=<<EOF
             0x00560e95  ~   ba0f31e914     mov edx, 0x14e9310f
 EOF
 RUN
+
+NAME=relative tmp seek
+FILE=-
+CMDS=<<EOF
+s 0x10
+?v $$ @ +0x10
+EOF
+EXPECT=<<EOF
+0x20
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Old parser supports `<cmd> @ +<val>`, but new parser did not. This PR adds support for it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

```
pd 10 @ +0x10
```

should move the seek to `$$ + 0x10`

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

closes #16682