### PR TITLE
Don't start panel mode when noninteractive.

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1872,6 +1872,10 @@ static int cmd_panels(void *data, const char *input) {
 		eprintf ("vi ...    # launch 'cfg.editor'\n");
 		return false;
 	}
+	if (!r_cons_is_interactive ()) {
+		eprintf ("Panel mode requires scr.interactive=true.\n");
+		return false;
+	}
 	if (*input == ' ') {
 		if (core->panels) {
 			r_load_panels_layout (core, input + 1);
@@ -1907,6 +1911,7 @@ static int cmd_visual(void *data, const char *input) {
 		return false;
 	}
 	if (!r_cons_is_interactive ()) {
+		eprintf ("Visual mode requires scr.interactive=true.\n");
 		return false;
 	}
 	return r_core_visual ((RCore *)data, input);

--- a/test/db/cmd/cmd_visual
+++ b/test/db/cmd/cmd_visual
@@ -65,3 +65,16 @@ EXPECT=<<EOF
 0x10
 EOF
 RUN
+
+NAME=visual noninteractive
+FILE=-
+CMDS=<<EOF
+e scr.interactive=false
+V
+v
+EOF
+EXPECT_ERR=<<EOF
+Visual mode requires scr.interactive=true.
+Panel mode requires scr.interactive=true.
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Visual mode was already disabled when scr.interactive=false. This PR adds similar behavior for panels.

**Test plan**

* Test case added to the tests - set `e scr.interactive=false` and try to enter `v` and `V`. It should fail and print a message.
* Manually test that sure `v` and `V` still work when scr.interactive isn't disabled.

**Closing issues**

Closes #16689