### PR TITLE
Pass parsed arguments directly to RCmd

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4876,7 +4876,9 @@ static RCmdParsedArgs *parse_args(struct tsr2cmd_state *state, TSNode args) {
 		return res;
 	} else {
 		char *unescaped_args[] = { do_handle_ts_unescape_arg (state, args) };
-		return r_cmd_parsed_args_newargs (1, unescaped_args);
+		RCmdParsedArgs *res = r_cmd_parsed_args_newargs (1, unescaped_args);
+		free (unescaped_args[0]);
+		return res;
 	}
 }
 

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -252,31 +252,6 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	return ret;
 }
 
-R_API int r_cmd_call_long(RCmd *cmd, const char *input) {
-	char *inp;
-	RListIter *iter;
-	RCmdLongItem *c;
-	int ret, inplen = strlen (input)+1;
-
-	r_list_foreach (cmd->lcmds, iter, c) {
-		if (inplen >= c->cmd_len && !r_str_cmp (input, c->cmd, c->cmd_len)) {
-			int lcmd = strlen (c->cmd_short);
-			int linp = strlen (input+c->cmd_len);
-			/// SLOW malloc on most situations. use stack
-			inp = malloc (lcmd+linp+2); // TODO: use static buffer with R_CMD_MAXLEN
-			if (!inp) {
-				return -1;
-			}
-			memcpy (inp, c->cmd_short, lcmd);
-			memcpy (inp + lcmd, input + c->cmd_len, linp + 1);
-			ret = r_cmd_call (cmd, inp);
-			free (inp);
-			return ret;
-		}
-	}
-	return -1;
-}
-
 /** macro.c **/
 
 R_API RCmdMacroItem *r_cmd_macro_item_new() {

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -173,22 +173,6 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data) {
 	return 1;
 }
 
-R_API int r_cmd_add_long(RCmd *cmd, const char *lcmd, const char *scmd, const char *desc) {
-	RCmdLongItem *item = R_NEW (RCmdLongItem);
-	if (!item) {
-		return false;
-	}
-	strncpy (item->cmd, lcmd, sizeof (item->cmd)-1);
-	strncpy (item->cmd_short, scmd, sizeof (item->cmd_short)-1);
-	item->cmd_len = strlen (lcmd);
-	strncpy (item->desc, desc, sizeof (item->desc)-1);
-	if (!r_list_append (cmd->lcmds, item)){
-		free (item);
-		return false;
-	}
-	return true;
-}
-
 R_API int r_cmd_add(RCmd *c, const char *cmd, const char *desc, r_cmd_callback(cb)) {
 	int idx = (ut8)cmd[0];
 	RCmdItem *item = c->cmds[idx];

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -747,7 +747,7 @@ R_API void r_cmd_parsed_args_free(RCmdParsedArgs *a) {
 
 static void free_array(char **arr, int n) {
 	int i;
-	for (i = 0; i < n; ++i) {
+	for (i = 0; i < n; i++) {
 		free (arr[i]);
 	}
 	free (arr);

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -236,6 +236,14 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	return ret;
 }
 
+R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
+	char *exec_string = r_cmd_parsed_args_execstr (args);
+	R_LOG_DEBUG ("r_cmd_call_parsed_args exec_string = '%s'\n", exec_string);
+	int res = r_cmd_call (cmd, exec_string);
+	free (exec_string);
+	return res;
+}
+
 /** macro.c **/
 
 R_API RCmdMacroItem *r_cmd_macro_item_new() {

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -112,7 +112,6 @@ R_API RCmd *r_cmd_new(void);
 R_API RCmd *r_cmd_free(RCmd *cmd);
 R_API int r_cmd_set_data(RCmd *cmd, void *data);
 R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_callback(callback));
-R_API int r_cmd_add_long(RCmd *cmd, const char *longcmd, const char *shortcmd, const char *desc);
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
 R_API char **r_cmd_args(RCmd *cmd, int *argc);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -115,7 +115,6 @@ R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_call
 R_API int r_cmd_add_long(RCmd *cmd, const char *longcmd, const char *shortcmd, const char *desc);
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
-R_API int r_cmd_call_long(RCmd *cmd, const char *input);
 R_API char **r_cmd_args(RCmd *cmd, int *argc);
 
 /* r_cmd_macro */

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -114,7 +114,6 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data);
 R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_callback(callback));
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
-R_API char **r_cmd_args(RCmd *cmd, int *argc);
 
 /* r_cmd_macro */
 R_API RCmdMacroItem *r_cmd_macro_item_new(void);
@@ -127,11 +126,11 @@ R_API void r_cmd_macro_meta(RCmdMacro *mac);
 R_API int r_cmd_macro_call(RCmdMacro *mac, const char *name);
 R_API int r_cmd_macro_break(RCmdMacro *mac, const char *value);
 
-R_API bool r_cmd_alias_del (RCmd *cmd, const char *k);
+R_API bool r_cmd_alias_del(RCmd *cmd, const char *k);
 R_API char **r_cmd_alias_keys(RCmd *cmd, int *sz);
-R_API int r_cmd_alias_set (RCmd *cmd, const char *k, const char *v, int remote);
-R_API char *r_cmd_alias_get (RCmd *cmd, const char *k, int remote);
-R_API void r_cmd_alias_free (RCmd *cmd);
+R_API int r_cmd_alias_set(RCmd *cmd, const char *k, const char *v, int remote);
+R_API char *r_cmd_alias_get(RCmd *cmd, const char *k, int remote);
+R_API void r_cmd_alias_free(RCmd *cmd);
 R_API void r_cmd_macro_fini(RCmdMacro *mac);
 
 #ifdef __cplusplus

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -120,6 +120,7 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data);
 R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_callback(callback));
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
+R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args);
 
 /* RCmdParsedArgs */
 R_API RCmdParsedArgs *r_cmd_parsed_args_new(const char *cmd, int n_args, char **args);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -18,6 +18,12 @@ extern "C" {
 #define r_cmd_callback(x) int (*x)(void *data, const char *input)
 #define r_cmd_nullcallback(x) int (*x)(void *data)
 
+typedef struct r_cmd_parsed_args_t {
+	int argc;
+	char **argv;
+	bool has_space_after_cmd;
+} RCmdParsedArgs;
+
 typedef struct r_cmd_macro_label_t {
 	char name[80];
 	char *ptr;
@@ -114,6 +120,18 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data);
 R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_callback(callback));
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
+
+/* RCmdParsedArgs */
+R_API RCmdParsedArgs *r_cmd_parsed_args_new(const char *cmd, int n_args, char **args);
+R_API RCmdParsedArgs *r_cmd_parsed_args_newcmd(const char *cmd);
+R_API RCmdParsedArgs *r_cmd_parsed_args_newargs(int n_args, char **args);
+R_API void r_cmd_parsed_args_free(RCmdParsedArgs *args);
+R_API bool r_cmd_parsed_args_setargs(RCmdParsedArgs *arg, int n_args, char **args);
+R_API bool r_cmd_parsed_args_setcmd(RCmdParsedArgs *arg, const char *cmd);
+R_API char *r_cmd_parsed_args_argstr(RCmdParsedArgs *arg);
+R_API char *r_cmd_parsed_args_execstr(RCmdParsedArgs *arg);
+
+#define r_cmd_parsed_args_foreach_arg(args, i, arg) for ((i) = 1; (i) < (args->argc) && ((arg) = (args)->argv[i]); (i)++)
 
 /* r_cmd_macro */
 R_API RCmdMacroItem *r_cmd_macro_item_new(void);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -11,6 +11,7 @@ if get_option('enable_tests')
     'bin',
     'bitmap',
     'buf',
+    'cmd',
     'cons',
     'contrbtree',
     'debruijn',

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -132,6 +132,12 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 		mu_assert(_meqstr, strcmp((exp__), (act__)) == 0); \
 } while(0)
 
+#define mu_assert_streq_free(actual, expected, message) do { \
+		char *act2__ = (actual); \
+		mu_assert_streq (act2__, (expected), (message)); \
+		free (act2__); \
+} while (0)
+
 #define mu_assert_nullable_streq(actual, expected, message) do { \
 		char _meqstr[2048]; \
 		const char *act__ = (actual); \

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -5,8 +5,8 @@
 bool test_parsed_args_noargs(void) {
 	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 0, NULL);
 	mu_assert_streq (a->argv[0], "pd", "pd is the command");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "", "empty arguments");
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd", "only command");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "", "empty arguments");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "pd", "only command");
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }
@@ -15,8 +15,8 @@ bool test_parsed_args_onearg(void) {
 	char *args[] = {"10"};
 	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 1, args);
 	mu_assert_streq (a->argv[0], "pd", "pd is the command");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "10", "one argument");
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + arg");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "10", "one argument");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + arg");
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }
@@ -25,8 +25,8 @@ bool test_parsed_args_args(void) {
 	char *args[] = { "d", "0" };
 	RCmdParsedArgs *a = r_cmd_parsed_args_new ("wA", 2, args);
 	mu_assert_streq (a->argv[0], "wA", "wA is the command");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "d 0", "two args");
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), "wA d 0", "cmd + args");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "d 0", "two args");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "wA d 0", "cmd + args");
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }
@@ -36,8 +36,8 @@ bool test_parsed_args_nospace(void) {
 	RCmdParsedArgs *a = r_cmd_parsed_args_new (".", 1, args);
 	a->has_space_after_cmd = false;
 	mu_assert_streq (a->argv[0], ".", ". is the command");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "dr*", "arg");
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), ".dr*", "cmd + args without space");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "dr*", "arg");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), ".dr*", "cmd + args without space");
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }
@@ -49,8 +49,15 @@ bool test_parsed_args_newcmd(void) {
 	bool res = r_cmd_parsed_args_setargs (a, 1, args);
 	mu_assert ("args should be added", res);
 	mu_assert_eq (a->argc, 2, "argc == 2");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "10", "arg");
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + args");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "10", "arg");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + args");
+
+	char *args2[] = { "2", "3" };
+	res = r_cmd_parsed_args_setargs (a, 2, args2);
+	mu_assert_eq (a->argc, 3, "argc == 3");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "2 3", "arg");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "pd 2 3", "cmd + args");
+
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }
@@ -59,13 +66,13 @@ bool test_parsed_args_newargs(void) {
 	char *args[] = { "0", "1", "2" };
 	RCmdParsedArgs *a = r_cmd_parsed_args_newargs (3, args);
 	mu_assert_eq (a->argc, 4, "argc == 4");
-	mu_assert_streq (r_cmd_parsed_args_argstr (a), "0 1 2", "args");
+	mu_assert_streq_free (r_cmd_parsed_args_argstr (a), "0 1 2", "args");
 	mu_assert_streq (a->argv[1], "0", "first arg");
 	mu_assert_streq (a->argv[2], "1", "second arg");
 
 	bool res = r_cmd_parsed_args_setcmd (a, "pd");
 	mu_assert ("cmd should be added", res);
-	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 0 1 2", "cmd + args");
+	mu_assert_streq_free (r_cmd_parsed_args_execstr (a), "pd 0 1 2", "cmd + args");
 	r_cmd_parsed_args_free (a);
 	mu_end;
 }

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -1,0 +1,85 @@
+#include <r_cmd.h>
+#include <stdlib.h>
+#include "minunit.h"
+
+bool test_parsed_args_noargs(void) {
+	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 0, NULL);
+	mu_assert_streq (a->argv[0], "pd", "pd is the command");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "", "empty arguments");
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd", "only command");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+bool test_parsed_args_onearg(void) {
+	char *args[] = {"10"};
+	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 1, args);
+	mu_assert_streq (a->argv[0], "pd", "pd is the command");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "10", "one argument");
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + arg");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+bool test_parsed_args_args(void) {
+	char *args[] = { "d", "0" };
+	RCmdParsedArgs *a = r_cmd_parsed_args_new ("wA", 2, args);
+	mu_assert_streq (a->argv[0], "wA", "wA is the command");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "d 0", "two args");
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), "wA d 0", "cmd + args");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+bool test_parsed_args_nospace(void) {
+	char *args[] = { "dr*" };
+	RCmdParsedArgs *a = r_cmd_parsed_args_new (".", 1, args);
+	a->has_space_after_cmd = false;
+	mu_assert_streq (a->argv[0], ".", ". is the command");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "dr*", "arg");
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), ".dr*", "cmd + args without space");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+bool test_parsed_args_newcmd(void) {
+	RCmdParsedArgs *a = r_cmd_parsed_args_newcmd ("pd");
+	mu_assert_streq (a->argv[0], "pd", "pd is the command");
+	char *args[] = { "10" };
+	bool res = r_cmd_parsed_args_setargs (a, 1, args);
+	mu_assert ("args should be added", res);
+	mu_assert_eq (a->argc, 2, "argc == 2");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "10", "arg");
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 10", "cmd + args");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+bool test_parsed_args_newargs(void) {
+	char *args[] = { "0", "1", "2" };
+	RCmdParsedArgs *a = r_cmd_parsed_args_newargs (3, args);
+	mu_assert_eq (a->argc, 4, "argc == 4");
+	mu_assert_streq (r_cmd_parsed_args_argstr (a), "0 1 2", "args");
+	mu_assert_streq (a->argv[1], "0", "first arg");
+	mu_assert_streq (a->argv[2], "1", "second arg");
+
+	bool res = r_cmd_parsed_args_setcmd (a, "pd");
+	mu_assert ("cmd should be added", res);
+	mu_assert_streq (r_cmd_parsed_args_execstr (a), "pd 0 1 2", "cmd + args");
+	r_cmd_parsed_args_free (a);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_parsed_args_noargs);
+	mu_run_test (test_parsed_args_onearg);
+	mu_run_test (test_parsed_args_args);
+	mu_run_test (test_parsed_args_nospace);
+	mu_run_test (test_parsed_args_newcmd);
+	mu_run_test (test_parsed_args_newargs);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Right now the new shell just parse the arguments and then put them back together to call `r_cmd_call`. However, in the future  our command handlers (defined in RCmd) will receive argc/argv, so we need RCmd to be able to merge argv together only when needed (that is when we want to call an "old" command handler that does its own parsing).

This PR introduces RCmdParsedArgs and moves the responsability of creating a single "exec string" to RCmd and not in arged_command function.