### PR TITLE
Reduce memory usage in DEX files by caching the getstr calls ##bin

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -964,7 +964,6 @@ R_API int r_meta_get_size(RAnal *a, int type) {
 	int meta_size;
 	ls_foreach (ls, lsi, kv) {
 		if ((strlen (sdbkv_key (kv)) > 5 && sdbkv_key (kv)[5] == type)) {
-
 			meta_size = get_meta_size ((void *)&ui, sdbkv_key (kv), sdbkv_value (kv));
 			tot_size += meta_size > -1 ? meta_size : 0;
 		}

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2019 - pancake, h4ng3r */
+/* radare - LGPL - Copyright 2009-2020 - pancake, h4ng3r */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -14,6 +14,12 @@ char* r_bin_dex_get_version(RBinDexObj *bin) {
 	return NULL;
 }
 
+// XXX this is never called
+void r_bin_dex_free(RBinDexObj *dex) {
+	r_pvector_fini (&dex->vec_strings);
+	free (dex);
+}
+
 RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	r_return_val_if_fail (buf, NULL);
 	RBinDexObj *bin = R_NEW0 (RBinDexObj);
@@ -25,6 +31,8 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	bin->size = r_buf_size (buf);
 	bin->b = r_buf_ref (buf);
 	/* header */
+	r_pvector_init (&bin->vec_strings, free);
+	bin->htup_strings = ht_up_new0 ();
 	if (bin->size < sizeof (struct dex_header_t)) {
 		goto fail;
 	}
@@ -63,34 +71,36 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 
 	/* strings */
 	#define STRINGS_SIZE ((dexhdr->strings_size + 1) * sizeof (ut32))
+	if (dexhdr->strings_size > bin->size) {
+		goto fail;
+	}
 	bin->strings = (ut32 *) calloc (dexhdr->strings_size + 1, sizeof (ut32));
 	if (!bin->strings) {
 		goto fail;
 	}
-	if (dexhdr->strings_size > bin->size) {
-		free (bin->strings);
-		goto fail;
-	}
+	r_buf_read_at (bin->b, dexhdr->strings_offset, (ut8*)bin->strings, dexhdr->strings_size * sizeof (ut32));
+	// TODO: this is unnecessary on Big endian machines
 	for (i = 0; i < dexhdr->strings_size; i++) {
-		ut64 offset = dexhdr->strings_offset + i * sizeof (ut32);
+		ut64 offset = dexhdr->strings_offset + (i * sizeof (ut32));
 		if (offset + 4 > bin->size) {
-			free (bin->strings);
-			goto fail;
+			break;
 		}
-		bin->strings[i] = r_buf_read_le32_at (bin->b, offset);
+		bin->strings[i] = r_read_le32 (&bin->strings[i]);
 	}
 	/* classes */
 	// TODO: not sure about if that is needed
-	int classes_size = dexhdr->class_size * DEX_CLASS_SIZE;
+	size_t classes_size = dexhdr->class_size * DEX_CLASS_SIZE;
 	if (dexhdr->class_offset + classes_size >= bin->size) {
-		classes_size = bin->size - dexhdr->class_offset;
-	}
-	if (classes_size < 0) {
-		classes_size = 0;
+		if (dexhdr->class_offset < bin->size) {
+			classes_size = bin->size - dexhdr->class_offset;
+		} else {
+			classes_size = 0;
+		}
 	}
 
 	dexhdr->class_size = classes_size / DEX_CLASS_SIZE;
-	bin->classes = (struct dex_class_t *) calloc (dexhdr->class_size, sizeof (struct dex_class_t));
+	bin->classes = (struct dex_class_t *) calloc (dexhdr->class_size + 1,
+		sizeof (struct dex_class_t));
 	for (i = 0; i < dexhdr->class_size; i++) {
 		ut64 offset = dexhdr->class_offset + i * DEX_CLASS_SIZE;
 		if (offset + 32 > bin->size) {
@@ -110,12 +120,13 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	}
 
 	/* methods */
-	int methods_size = dexhdr->method_size * sizeof (struct dex_method_t);
+	size_t methods_size = dexhdr->method_size * sizeof (struct dex_method_t);
 	if (dexhdr->method_offset + methods_size >= bin->size) {
-		methods_size = bin->size - dexhdr->method_offset;
-	}
-	if (methods_size < 0) {
-		methods_size = 0;
+		if (dexhdr->method_offset < bin->size) {
+			methods_size = bin->size - dexhdr->method_offset;
+		} else {
+			methods_size = 0;
+		}
 	}
 	dexhdr->method_size = methods_size / sizeof (struct dex_method_t);
 	bin->methods = (struct dex_method_t *) calloc (methods_size + 1, 1);
@@ -134,12 +145,9 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	}
 
 	/* types */
-	int types_size = dexhdr->types_size * sizeof (struct dex_type_t);
+	size_t types_size = dexhdr->types_size * sizeof (struct dex_type_t);
 	if (dexhdr->types_offset + types_size >= bin->size) {
 		types_size = bin->size - dexhdr->types_offset;
-	}
-	if (types_size < 0) {
-		types_size = 0;
 	}
 	dexhdr->types_size = types_size / sizeof (struct dex_type_t);
 	bin->types = (struct dex_type_t *) calloc (types_size + 1, 1);
@@ -156,12 +164,13 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	}
 
 	/* fields */
-	int fields_size = dexhdr->fields_size * sizeof (struct dex_field_t);
+	size_t fields_size = dexhdr->fields_size * sizeof (struct dex_field_t);
 	if (dexhdr->fields_offset + fields_size >= bin->size) {
-		fields_size = bin->size - dexhdr->fields_offset;
-	}
-	if (fields_size < 0) {
-		fields_size = 0;
+		if (bin->size > dexhdr->fields_offset) {
+			fields_size = bin->size - dexhdr->fields_offset;
+		} else {
+			fields_size = 0;
+		}
 	}
 	dexhdr->fields_size = fields_size / sizeof (struct dex_field_t);
 	bin->fields = (struct dex_field_t *) calloc (fields_size + 1, 1);
@@ -182,16 +191,16 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	}
 
 	/* proto */
-	int protos_size = dexhdr->prototypes_size * sizeof (struct dex_proto_t);
+	size_t protos_size = dexhdr->prototypes_size * sizeof (struct dex_proto_t);
 	if (dexhdr->prototypes_offset + protos_size >= bin->size) {
-		protos_size = bin->size - dexhdr->prototypes_offset;
-	}
-	if (protos_size < 1) {
-		dexhdr->prototypes_size = 0;
-		return bin;
+		if (bin->size > dexhdr->prototypes_offset) {
+			protos_size = bin->size - dexhdr->prototypes_offset;
+		} else {
+			protos_size = 0;
+		}
 	}
 	dexhdr->prototypes_size = protos_size / sizeof (struct dex_proto_t);
-	bin->protos = (struct dex_proto_t *) calloc (protos_size, 1);
+	bin->protos = (struct dex_proto_t *) calloc (protos_size + 1, 1);
 	for (i = 0; i < dexhdr->prototypes_size; i++) {
 		ut64 offset = dexhdr->prototypes_offset + i * sizeof (struct dex_proto_t);
 		if (offset + 12 > bin->size) {

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -77,7 +77,7 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	if (dexhdr->strings_size > bin->size) {
 		goto fail;
 	}
-	bin->strings = (ut32 *) calloc (dexhdr->strings_size + 1, sizeof (ut32));
+	bin->strings = R_NEWS0 (ut32, dexhdr->strings_size);
 	if (!bin->strings) {
 		goto fail;
 	}

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -77,7 +77,7 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	if (dexhdr->strings_size > bin->size) {
 		goto fail;
 	}
-	bin->strings = R_NEWS0 (ut32, dexhdr->strings_size);
+	bin->strings = R_NEWS0 (ut32, dexhdr->strings_size + 1);
 	if (!bin->strings) {
 		goto fail;
 	}

--- a/libr/bin/format/dex/dex.c
+++ b/libr/bin/format/dex/dex.c
@@ -16,7 +16,12 @@ char* r_bin_dex_get_version(RBinDexObj *bin) {
 
 // XXX this is never called
 void r_bin_dex_free(RBinDexObj *dex) {
-	r_pvector_fini (&dex->vec_strings);
+	size_t i;
+	struct dex_header_t *dexhdr = &dex->header;
+	for (i = 0; i < dexhdr->strings_size; i++) {
+		free (dex->cal_strings[i]);
+	}
+	free (dex->cal_strings);
 	free (dex);
 }
 
@@ -31,8 +36,6 @@ RBinDexObj *r_bin_dex_new_buf(RBuffer *buf) {
 	bin->size = r_buf_size (buf);
 	bin->b = r_buf_ref (buf);
 	/* header */
-	r_pvector_init (&bin->vec_strings, free);
-	bin->htup_strings = ht_up_new0 ();
 	if (bin->size < sizeof (struct dex_header_t)) {
 		goto fail;
 	}

--- a/libr/bin/format/dex/dex.h
+++ b/libr/bin/format/dex/dex.h
@@ -120,6 +120,8 @@ typedef struct r_bin_dex_obj_t {
 	ut64 code_to;
 	char *version;
 	Sdb *kv;
+	RPVector vec_strings;
+	HtUP *htup_strings;
 } RBinDexObj;
 
 struct r_bin_dex_str_t {

--- a/libr/bin/format/dex/dex.h
+++ b/libr/bin/format/dex/dex.h
@@ -120,6 +120,7 @@ typedef struct r_bin_dex_obj_t {
 	ut64 code_to;
 	char *version;
 	Sdb *kv;
+	char **cal_strings;
 	RPVector vec_strings;
 	HtUP *htup_strings;
 } RBinDexObj;

--- a/libr/bin/format/dex/dex.h
+++ b/libr/bin/format/dex/dex.h
@@ -121,8 +121,6 @@ typedef struct r_bin_dex_obj_t {
 	char *version;
 	Sdb *kv;
 	char **cal_strings;
-	RPVector vec_strings;
-	HtUP *htup_strings;
 } RBinDexObj;
 
 struct r_bin_dex_str_t {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -76,8 +76,8 @@ static ut64 dex_field_offset(RBinDexObj *bin, int fid) {
 	return bin->header.fields_offset + (fid * 8); // (sizeof (DexField) * fid);
 }
 
-#define USE_PVECTOR 0
-#define USE_HTUP 1
+#define USE_PVECTOR 1
+#define USE_HTUP 0
 
 static char *getstr(RBinDexObj *dex, int idx) {
 	ut8 buf[LEB_MAX_SIZE];

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -76,20 +76,39 @@ static ut64 dex_field_offset(RBinDexObj *bin, int fid) {
 	return bin->header.fields_offset + (fid * 8); // (sizeof (DexField) * fid);
 }
 
+#define USE_PVECTOR 0
+#define USE_HTUP 1
+
 static char *getstr(RBinDexObj *dex, int idx) {
 	ut8 buf[LEB_MAX_SIZE];
+	if (idx < 0 || idx >= dex->header.strings_size || !dex->strings) {
+		return NULL;
+	}
+#if USE_PVECTOR
+	if (dex->vec_strings.v.capacity > 0) {
+		void **res = r_pvector_index_ptr (&dex->vec_strings, idx);
+		if (res && (char*)*res) {
+			return (char *)*res;
+		}
+	} else {
+		r_pvector_reserve (&dex->vec_strings, dex->header.strings_size);
+	}
+#endif
+#if USE_HTUP
+	char *res = ht_up_find (dex->htup_strings, idx, NULL);
+	if (res) {
+		return res;
+	}
+#endif
+	const ut32 string_index = dex->strings[idx];
+	if (string_index >= dex->size) {
+		return NULL;
+	}
+	if (r_buf_read_at (dex->b, string_index, buf, sizeof (buf)) != sizeof (buf)) {
+		return NULL;
+	}
 	ut64 len;
-	int uleblen;
-	if (!dex || idx < 0 || idx >= dex->header.strings_size || !dex->strings) {
-		return NULL;
-	}
-	if (dex->strings[idx] >= dex->size) {
-		return NULL;
-	}
-	if (r_buf_read_at (dex->b, dex->strings[idx], buf, sizeof (buf)) != sizeof (buf)) {
-		return NULL;
-	}
-	uleblen = r_uleb128 (buf, sizeof (buf), &len) - buf;
+	int uleblen = r_uleb128 (buf, sizeof (buf), &len) - buf;
 	if (!uleblen || uleblen >= dex->size || uleblen >= dex->header.strings_size) {
 		return NULL;
 	}
@@ -97,12 +116,18 @@ static char *getstr(RBinDexObj *dex, int idx) {
 		return NULL;
 	}
 	ut8 *ptr = malloc (len + 1);
-	if (!ptr) {
-		return NULL;
+	if (ptr) {
+		r_buf_read_at (dex->b, string_index + uleblen, ptr, len);
+		ptr[len] = 0;
+#if USE_PVECTOR
+		r_pvector_insert (&dex->vec_strings, idx, ptr);
+#endif
+#if USE_HTUP
+		ht_up_insert (dex->htup_strings, idx, ptr);
+#endif
+		return (char *)ptr;
 	}
-	r_buf_read_at (dex->b, dex->strings[idx] + uleblen, ptr, len);
-	ptr[len] = 0;
-	return (char *)ptr;
+	return NULL;
 }
 
 static int countOnes(ut32 val) {
@@ -195,7 +220,7 @@ static char *createAccessFlagStr(ut32 flags, AccessFor forWhat) {
 			"?", /* 0x20000 */
 		},
 	};
-	int i, count = countOnes (flags);
+	size_t i, count = countOnes (flags);
 	const int kLongest = 21;
 	const int maxSize = (count + 1) * (kLongest + 1);
 	char* str, *cp;
@@ -227,7 +252,7 @@ static char *createAccessFlagStr(ut32 flags, AccessFor forWhat) {
 	return str;
 }
 
-static char *dex_type_descriptor(RBinDexObj *bin, int type_idx) {
+static const char *dex_type_descriptor(RBinDexObj *bin, int type_idx) {
 	if (type_idx < 0 || type_idx >= bin->header.types_size) {
 		return NULL;
 	}
@@ -654,6 +679,7 @@ static void dex_parse_debug_item(RBinFile *bf, RBinDexClass *c, int MI, int MA, 
 	RListIter *iter1;
 	struct dex_debug_position_t *pos;
 // Loading the debug info takes too much time and nobody uses this afaik
+// 0.5s of 5s is spent in this loop
 #if 1
 	r_list_foreach (debug_positions, iter1, pos) {
 		const char *line = getstr (dex, pos->source_file_idx);
@@ -939,19 +965,20 @@ static char *simplify(char *s) {
 }
 
 static char *dex_class_name_byid(RBinDexObj *bin, int cid) {
-	int tid;
-	if (!bin || !bin->types) {
-		return NULL;
-	}
+	r_return_val_if_fail (bin && bin->types, NULL);
 	if (cid < 0 || cid >= bin->header.types_size) {
 		return NULL;
 	}
-	tid = bin->types[cid].descriptor_id;
-	char *s = getstr (bin, tid);
-	if (simplifiedDemangling) {
-		simplify (s);
+	int tid = bin->types[cid].descriptor_id;
+	const char *s = getstr (bin, tid);
+	if (s) {
+		char *r = strdup (s);
+		if (simplifiedDemangling) {
+			simplify (r);
+		}
+		return r;
 	}
-	return s;
+	return NULL;
 }
 
 static char *dex_class_name(RBinDexObj *bin, RBinDexClass *c) {
@@ -1068,7 +1095,7 @@ static ut64 dex_get_type_offset(RBinFile *bf, int type_idx) {
 	return bin->header.types_offset + type_idx * 0x04; //&bin->types[type_idx];
 }
 
-static char *dex_class_super_name(RBinDexObj *bin, RBinDexClass *c) {
+static const char *dex_class_super_name(RBinDexObj *bin, RBinDexClass *c) {
 	r_return_val_if_fail (bin && bin->types && c, NULL);
 
 	int cid = c->super_class;
@@ -1100,7 +1127,6 @@ static void parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls
 	ut8 ff[sizeof (DexField)] = {0};
 	int total, tid;
 	DexField field;
-	const char* type_str;
 	size_t i, skip = 0;
 
 	for (i = 0; i < fields_count; i++) {
@@ -1126,7 +1152,7 @@ static void parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls
 			break;
 		}
 		tid = dex->types[field.type_id].descriptor_id;
-		type_str = getstr (dex, tid);
+		const char *type_str = getstr (dex, tid);
 		RBinSymbol *sym = R_NEW0 (RBinSymbol);
 		if (!sym) {
 			break;
@@ -1151,7 +1177,7 @@ static void parse_dex_class_fields(RBinFile *bf, RBinDexClass *c, RBinClass *cls
 			bin->cb_printf ("      name          : '%s'\n", fieldName);
 			bin->cb_printf ("      type          : '%s'\n", type_str);
 			bin->cb_printf ("      access        : 0x%04x (%s)\n",
-					 (unsigned int)accessFlags, accessStr? accessStr: "");
+					 (ut32)accessFlags, accessStr? accessStr: "");
 		}
 		r_list_append (dex->methods_list, sym);
 
@@ -1352,7 +1378,7 @@ static void parse_dex_class_method(RBinFile *bf, RBinDexClass *c, RBinClass *cls
 									s,
 									handler_addr);
 							}
-							free (s);
+							s = NULL;
 						} else {
 							if (dexdump) {
 								cb_printf ("          (error) -> 0x%04"PFMT64x"\n", handler_addr);
@@ -1496,7 +1522,8 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 	cls->index = class_index;
 	cls->addr = dex->header.class_offset + (class_index * DEX_CLASS_SIZE);
 	cls->methods = r_list_new ();
-	cls->super = dex_class_super_name (dex, c);
+	const char *super = dex_class_super_name (dex, c);
+	cls->super = super? strdup (super): NULL;
 	if (!cls->methods) {
 		free (cls);
 		goto beach;
@@ -1533,9 +1560,8 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 			if (t > 0 && t < dex->header.types_size ) {
 				int tid = dex->types[t].descriptor_id;
 				if (dexdump) {
-					char *cn = getstr (dex, tid);
+					const char *cn = getstr (dex, tid);
 					rbin->cb_printf ("    #%d              : '%s'\n", z, cn);
-					free (cn);
 				}
 			}
 		}
@@ -1593,7 +1619,7 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 	}
 
 	if (dexdump) {
-		char *source_file = getstr (dex, c->source_file);
+		const char *source_file = getstr (dex, c->source_file);
 		if (!source_file) {
 			rbin->cb_printf (
 				"  source_file_idx   : %d (unknown)\n\n",
@@ -1602,7 +1628,6 @@ static void parse_class(RBinFile *bf, RBinDexClass *c, int class_index, int *met
 			rbin->cb_printf ("  source_file_idx   : %d (%s)\n\n",
 					 c->source_file, source_file);
 		}
-		free (source_file);
 	}
 	cls = NULL;
 beach:
@@ -1970,11 +1995,11 @@ static RList *sections(RBinFile *bf) {
 			ptr->size = ptr->vaddr; // fix size
 		}
 		ptr->vsize = ptr->size;
+		// Commenting this line speedups loading from 4.5s to 3s
 		ptr->format = r_str_newf ("Cd %d[%d]", 4, ptr->vsize / 4);
 		ptr->perm = R_PERM_R;
 		ptr->add = false;
 		r_list_append (ret, ptr);
-		// Define as dwords!
 	}
 	if ((ptr = R_NEW0 (RBinSection))) {
 		ptr->name = strdup ("code");

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -76,16 +76,11 @@ static ut64 dex_field_offset(RBinDexObj *bin, int fid) {
 	return bin->header.fields_offset + (fid * 8); // (sizeof (DexField) * fid);
 }
 
-#define USE_PVECTOR 0
-#define USE_HTUP 0
-#define USE_CALLOC 1
-
 static const char *getstr(RBinDexObj *dex, int idx) {
 	ut8 buf[LEB_MAX_SIZE];
 	if (idx < 0 || idx >= dex->header.strings_size || !dex->strings) {
 		return NULL;
 	}
-#if USE_CALLOC
 	if (dex->cal_strings) {
 		if (idx >= 0 ||  idx < dex->header.strings_size) {
 			const char *p = dex->cal_strings[idx];
@@ -96,24 +91,6 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 	} else {
 		dex->cal_strings = calloc (dex->header.strings_size, sizeof (void*));
 	}
-#endif
-#if USE_PVECTOR
-	if (dex->vec_strings.v.capacity > 0) {
-		void **res = r_pvector_index_ptr (&dex->vec_strings, idx);
-		if (res && (const char*)*res) {
-			return (const char *)*res;
-		}
-	} else {
-		r_pvector_reserve (&dex->vec_strings, dex->header.strings_size);
-		memset (dex->vec_strings.v.a, 0, dex->vec_strings.v.capacity * sizeof(void*));
-	}
-#endif
-#if USE_HTUP
-	char *res = ht_up_find (dex->htup_strings, idx, NULL);
-	if (res) {
-		return res;
-	}
-#endif
 	const ut32 string_index = dex->strings[idx];
 	if (string_index >= dex->size) {
 		return NULL;
@@ -133,17 +110,7 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 	if (ptr) {
 		r_buf_read_at (dex->b, string_index + uleblen, ptr, len);
 		ptr[len] = 0;
-#if USE_CALLOC
 		dex->cal_strings[idx] = ptr;
-#endif
-#if USE_PVECTOR
-		// eprintf ("ins %p\n", &dex->vec_strings);
-printf ("%d %s\n", idx, ptr);
-//		r_pvector_insert (&dex->vec_strings, idx, ptr);
-#endif
-#if USE_HTUP
-		ht_up_insert (dex->htup_strings, idx, ptr);
-#endif
 		return (char *)ptr;
 	}
 	return NULL;

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -83,7 +83,7 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 	}
 	if (dex->cal_strings) {
 		const char *p = dex->cal_strings[idx];
-		if (R_STR_ISEMPTY (p)) {
+		if (!R_STR_ISEMPTY (p)) {
 			return p;
 		}
 	} else {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -82,11 +82,9 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 		return NULL;
 	}
 	if (dex->cal_strings) {
-		if (idx >= 0 ||  idx < dex->header.strings_size) {
-			const char *p = dex->cal_strings[idx];
-			if (p && *p) {
-				return p;
-			}
+		const char *p = dex->cal_strings[idx];
+		if (p && *p) {
+			return p;
 		}
 	} else {
 		dex->cal_strings = calloc (dex->header.strings_size, sizeof (void*));

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -83,11 +83,11 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 	}
 	if (dex->cal_strings) {
 		const char *p = dex->cal_strings[idx];
-		if (p && *p) {
+		if (R_STR_ISEMPTY (p)) {
 			return p;
 		}
 	} else {
-		dex->cal_strings = calloc (dex->header.strings_size, sizeof (void*));
+		dex->cal_strings = R_NEWS0 (void*, dex->header.strings_size);
 	}
 	const ut32 string_index = dex->strings[idx];
 	if (string_index >= dex->size) {
@@ -109,7 +109,7 @@ static const char *getstr(RBinDexObj *dex, int idx) {
 		r_buf_read_at (dex->b, string_index + uleblen, ptr, len);
 		ptr[len] = 0;
 		dex->cal_strings[idx] = ptr;
-		return (char *)ptr;
+		return (const char *)ptr;
 	}
 	return NULL;
 }

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -158,6 +158,7 @@ R_API void *r_vector_shrink(RVector *vec);
 // RPVector
 
 R_API void r_pvector_init(RPVector *vec, RPVectorFree free);
+R_API void r_pvector_fini(RPVector *vec);
 
 R_API RPVector *r_pvector_new(RPVectorFree free);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Benchmark results**

```
type    top    vsz     rss      time
------------------------------------
calloc  339M   4732640 365452   48s
pvector 338M   4731012 371484   48s // XXX fails somehow with trash indexes
htup    338M   4731556 371620   58s
nocache 350M   4742936 376156   52s
```

nocache -> calloc = 8% faster and 3% less memory usage

![IMAGE 2020-04-27 20:02:31](https://user-images.githubusercontent.com/917142/80404800-08bf2900-88c2-11ea-81f3-4ecb961c89ec.jpg)
![IMAGE 2020-04-27 20:02:35](https://user-images.githubusercontent.com/917142/80404808-0b218300-88c2-11ea-987c-6075a7755a11.jpg)
