### PR TITLE
Fix assembling of pop r8-r15

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -2360,6 +2360,9 @@ static int oppop(RAsm *a, ut8 *data, const Opcode *op) {
 			}
 			data[l++] = base + (8 * op->operands[0].reg);
 		} else {
+			if (op->operands[0].extended && a->bits == 64) {
+				data[l++] = 0x41;
+			}
 			ut8 base = 0x58;
 			data[l++] = base + op->operands[0].reg;
 		}

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -111,6 +111,8 @@ aB "mov sil, 0" 40b600
 aB "mov dil, -5" 40b7fb
 aB "mov spl, bpl" 4088ec
 a "pop rax" 58
+ad "pop r8" 4158
+ad "pop r15" 415f
 aB "prefetcht1 [eax]" 670f1810
 aB "prefetcht1 [rax]" 0f1810
 aB "prefetcht1 byte [eax]" 670f1810


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Previously, for x86-64, rasm2 incorrectly assembled `pop rn` where rn is an extended register (i.e. `r8-r15`). This pull request fixes that.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
