### PR TITLE
Minor Restructuring of RAnalVar

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -167,7 +167,6 @@ R_API RAnalVar *r_anal_function_set_var(RAnalFunction *fcn, int delta, char kind
 	var->regname = reg ? strdup (reg->name) : NULL; // TODO: no strdup here? pool? or not keep regname at all?
 	var->type = strdup (type);
 	var->kind = kind;
-	var->size = size;
 	var->isarg = isarg;
 	var->delta = delta;
 	shadow_var_struct_members (var);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -745,14 +745,13 @@ typedef struct r_anal_var_t {
 	char *name; // name of the variable
 	char *type; // cparse type of the variable
 	RAnalVarKind kind;
-	int size;
 	bool isarg;
 	int delta;   /* delta offset inside stack frame */
+	char *regname; // name of the register
 	RVector/*<RAnalVarAccess>*/ accesses; // ordered by offset, touch this only through API or expect uaf
 
 	// below members are just for caching, TODO: remove them and do it better
 	int argnum;
-	char *regname; // name of the register
 } RAnalVar;
 
 // Refers to a variable or a struct field inside a variable, only for varsub


### PR DESCRIPTION
size is never used and regname shouldn't be deprecated that hard, it is useful for rebasing at least.