### PR TITLE
r2r: Enable ANSI esc seqs on Windows

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -151,6 +151,19 @@ int main(int argc, char **argv) {
 	ut64 timeout_sec = TIMEOUT_DEFAULT;
 	int ret = 0;
 
+#if __WINDOWS__
+	{
+		HANDLE streams[] = { GetStdHandle (STD_OUTPUT_HANDLE), GetStdHandle (STD_ERROR_HANDLE) };
+		DWORD mode;
+		int i;
+		for (i = 0; i < R_ARRAY_SIZE (streams); i++) {
+			GetConsoleMode (streams[i], &mode);
+			SetConsoleMode (streams[i],
+			                mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+		}
+	}
+#endif
+
 	RGetopt opt;
 	r_getopt_init (&opt, argc, (const char **)argv, "hqvj:r:m:f:C:LnVt:F:i");
 
@@ -633,6 +646,9 @@ static void print_state_counts(R2RState *state) {
 }
 
 static void print_state(R2RState *state, ut64 prev_completed) {
+#if __WINDOWS__
+	setvbuf (stdout, NULL, _IOFBF, 8192);
+#endif
 	printf (R_CONS_CLEAR_LINE);
 
 	print_new_results (state, prev_completed);
@@ -646,6 +662,9 @@ static void print_state(R2RState *state, ut64 prev_completed) {
 	printf (" ");
 	print_state_counts (state);
 	fflush (stdout);
+#if __WINDOWS__
+	setvbuf (stdout, NULL, _IONBF, 0);
+#endif
 }
 
 static void print_log(R2RState *state, ut64 prev_completed, ut64 prev_paths_completed) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

With r2r on Windows:

Before:

![r2r_before](https://user-images.githubusercontent.com/12002672/80278470-17260d00-8729-11ea-95e5-8d344bde029a.png)

After

![r2r_after](https://user-images.githubusercontent.com/12002672/80278473-1e4d1b00-8729-11ea-9159-a40953231e4f.png)

The `setvbuf()`s are there since otherwise there can be horrible flickering of the status line, especially noticeable with something like `r2r -i db/asm/x86_64`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested with both cmd and Windows Terminal. Tested also `r2r -V db/asm/x86_64`, and not sure which terminal better handles things.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
