### PR TITLE
Refactor Variable comments from SDB into RAnalVar 

### DIFF
--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -141,30 +141,6 @@ R_API bool r_meta_set_string(RAnal *a, int type, ut64 addr, const char *s) {
 	return ret;
 }
 
-// XXX very similar to set_string
-R_API bool r_meta_set_var_comment(RAnal *a, int type, ut64 idx, ut64 addr, const char *s) {
-	char key[100], val[2048], *e_str;
-	bool ret;
-	ut64 size;
-	const char *space = r_spaces_current_name (&a->meta_spaces);
-	meta_type_add (a, type, addr);
-
-	snprintf (key, sizeof (key)-1, "meta.%c.0x%"PFMT64x".0x%"PFMT64x, type, addr, idx);
-	size = sdb_array_get_num (DB, key, 0, 0);
-	if (!size) {
-		size = strlen (s);
-		meta_inrange_add (a, addr, size);
-		ret = true;
-	} else {
-		ret = false;
-	}
-	e_str = sdb_encode ((const void*)s, -1);
-	snprintf (val, sizeof (val)-1, "%d,%s,%s", (int)size, space, e_str);
-	sdb_set (DB, key, val, 0);
-	free ((void*)e_str);
-	return ret;
-}
-
 R_API char *r_meta_get_string(RAnal *a, int type, ut64 addr) {
 	char key[100];
 	const char *k, *p, *p2, *p3;
@@ -190,26 +166,6 @@ R_API char *r_meta_get_string(RAnal *a, int type, ut64 addr) {
 		}
 	}
 	return (char *)sdb_decode (k, NULL);
-}
-
-R_API char *r_meta_get_var_comment (RAnal *a, int type, ut64 idx, ut64 addr) {
-	char key[100];
-	const char *k, *p, *p2;
-	snprintf (key, sizeof (key) - 1, "meta.%c.0x%"PFMT64x".0x%"PFMT64x, type, addr, idx);
-	k = sdb_const_get (DB, key, NULL);
-	if (!k) {
-		return NULL;
-	}
-	p = strchr (k, SDB_RS);
-	if (!p) {
-		return NULL;
-	}
-	k = p + 1;
-	p2 = strchr (k, SDB_RS);
-	if (!p2) {
-		return (char *)sdb_decode (k, NULL);
-	}
-	return (char *)sdb_decode (p2+1, NULL);
 }
 
 static bool mustDeleteMetaEntry(RAnal *a, ut64 addr) {
@@ -305,13 +261,6 @@ R_API int r_meta_del(RAnal *a, int type, ut64 addr, ut64 size) {
 		meta_inrange_del (a, addr, size);
 	}
 	return false;
-}
-
-
-R_API int r_meta_var_comment_del(RAnal *a, int type, ut64 idx, ut64 addr) {
-	char *key = r_str_newf ("meta.%c.0x%"PFMT64x".0x%"PFMT64x, type, addr, idx);
-	sdb_unset (DB, key, 0);
-	return 0;
 }
 
 R_API int r_meta_cleanup(RAnal *a, ut64 from, ut64 to) {

--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -309,7 +309,7 @@ R_API int r_meta_del(RAnal *a, int type, ut64 addr, ut64 size) {
 
 
 R_API int r_meta_var_comment_del(RAnal *a, int type, ut64 idx, ut64 addr) {
-	char *key = r_str_newf ("meta.%c.0x%"PFMT64x"0x%"PFMT64x, type, addr, idx);
+	char *key = r_str_newf ("meta.%c.0x%"PFMT64x".0x%"PFMT64x, type, addr, idx);
 	sdb_unset (DB, key, 0);
 	return 0;
 }

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -191,6 +191,7 @@ static void var_free(RAnalVar *var) {
 	free (var->name);
 	free (var->regname);
 	free (var->type);
+	free (var->comment);
 	free (var);
 }
 

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -931,11 +931,7 @@ void r_comment_var_help(RCore *core, char type) {
 void r_comment_vars(RCore *core, const char *input) {
 	//TODO enable base64 and make it the default for C*
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
-	int idx;
 	char *oname = NULL, *name = NULL;
-	char *oldcomment = NULL;
-	char *heap_comment = NULL;
-	RAnalVar *var;
 
 	if (input[1] == '?' || (input[0] != 'b' && input[0] != 'r' && input[0] != 's') ) {
 		r_comment_var_help (core, input[0]);
@@ -952,26 +948,28 @@ void r_comment_vars(RCore *core, const char *input) {
 	switch (input[1]) {
 	case '*': // "Cv*"
 	case '\0': { // "Cv"
-		RList *var_list;
-		RListIter *iter;
-		var_list = r_anal_var_list (core->anal, fcn, input[0]);
-		r_list_foreach (var_list, iter, var) {
-			oldcomment = r_meta_get_var_comment (core->anal, input[0], var->delta, fcn->addr);
-			if (!oldcomment) {
+		void **it;
+		char kind = input[0];
+		r_pvector_foreach (&fcn->vars, it) {
+			RAnalVar *var = *it;
+			if (var->kind != kind || !var->comment) {
 				continue;
 			}
 			if (!input[1]) {
-				r_cons_printf ("%s : %s\n", var->name, oldcomment);
+				r_cons_printf ("%s : %s\n", var->name, var->comment);
 			} else {
-				r_cons_printf ("\"Cv%c %s base64:%s @ 0x%08"PFMT64x"\"\n", input[0], var->name,
-					sdb_encode ((const ut8 *) oldcomment, strlen(oldcomment)), fcn->addr);
+				char *b64 = sdb_encode ((const ut8 *)var->comment, strlen (var->comment));
+				if (!b64) {
+					continue;
+				}
+				r_cons_printf ("\"Cv%c %s base64:%s @ 0x%08"PFMT64x"\"\n", kind, var->name, b64, fcn->addr);
 			}
 		}
 		}
 		break;
 	case ' ': { // "Cv "
-		// TODO check that idx exist
 		char *comment = strchr (name, ' ');
+		char *heap_comment = NULL;
 		if (comment) { // new comment given
 			if (*comment) {
 				*comment++ = 0;
@@ -981,57 +979,54 @@ void r_comment_vars(RCore *core, const char *input) {
 				comment = heap_comment;
 			}
 		}
-		var = r_anal_function_get_var_byname (fcn, name);
+		RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
 		if (!var) {
-			idx = (int)strtol (name, NULL, 0);
+			int idx = (int)strtol (name, NULL, 0);
 			var = r_anal_function_get_var (fcn, input[0], idx);
 		}
 		if (!var) {
 			eprintf ("can't find variable at given offset\n");
 		} else {
-			idx = var->delta;
-			oldcomment = r_meta_get_var_comment (core->anal, input[0], idx, fcn->addr);
-			if (oldcomment) {
+			if (var->comment) {
 				if (comment && *comment) {
-					char *text = r_str_newf ("%s\n%s", oldcomment, comment);
-					r_meta_set_var_comment (core->anal, input[0], idx, fcn->addr, text);
-					free (text);
+					char *text = r_str_newf ("%s\n%s", var->comment, comment);
+					free (var->comment);
+					var->comment = text;
 				} else {
-					r_cons_println (oldcomment);
+					r_cons_println (var->comment);
 				}
 			} else {
-				r_meta_set_var_comment (core->anal, input[0], idx, fcn->addr, comment);
+				var->comment = strdup (comment);
 			}
 		}
 		free (heap_comment);
 		}
 		break;
-	case '-': // "Cv-"
-		var = r_anal_function_get_var_byname (fcn, name);
+	case '-': { // "Cv-"
+		RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
 		if (!var) {
-			idx = (int)strtol (name, NULL, 0);
+			int idx = (int)strtol (name, NULL, 0);
 			var = r_anal_function_get_var (fcn, input[0], idx);
 		}
 		if (!var) {
 			eprintf ("can't find variable at given offset\n");
 			break;
 		}
-		idx = var->delta;
-		r_meta_var_comment_del (core->anal, input[0], idx, fcn->addr);
+		free (var->comment);
+		var->comment = NULL;
 		break;
+	}
 	case '!': { // "Cv!"
 		char *comment;
-		var = r_anal_function_get_var_byname (fcn, name);
+		RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
 		if (!var) {
 			eprintf ("can't find variable named `%s`\n",name);
 			break;
 		}
-		oldcomment = r_meta_get_var_comment (core->anal, input[0], var->delta, fcn->addr);
-		comment = r_core_editor (core, NULL, oldcomment);
+		comment = r_core_editor (core, NULL, var->comment);
 		if (comment) {
-			r_meta_var_comment_del (core->anal, input[0], var->delta, fcn->addr);
-			r_meta_set_var_comment (core->anal, input[0], var->delta, fcn->addr, comment);
-			free (comment);
+			free (var->comment);
+			var->comment = comment;
 		}
 		}
 		break;

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -982,20 +982,14 @@ void r_comment_vars(RCore *core, const char *input) {
 			}
 		}
 		var = r_anal_function_get_var_byname (fcn, name);
-		if (var) {
-			idx = var->delta;
-		} else if (!strncmp (name, "0x", 2))  {
-			idx = (int) r_num_get (NULL, name);
-		} else if (!strncmp (name, "-0x", 3)) {
-			idx = -(int) r_num_get (NULL, name+1);
-		} else {
-			eprintf ("can't find variable named `%s`\n",name);
-			free (heap_comment);
-			break;
+		if (!var) {
+			idx = (int)strtol (name, NULL, 0);
+			var = r_anal_function_get_var (fcn, input[0], idx);
 		}
-		if (!r_anal_function_get_var (fcn, input[0], idx)) {
+		if (!var) {
 			eprintf ("can't find variable at given offset\n");
 		} else {
+			idx = var->delta;
 			oldcomment = r_meta_get_var_comment (core->anal, input[0], idx, fcn->addr);
 			if (oldcomment) {
 				if (comment && *comment) {
@@ -1013,21 +1007,16 @@ void r_comment_vars(RCore *core, const char *input) {
 		}
 		break;
 	case '-': // "Cv-"
-		var = r_anal_function_get_var_byname(fcn, name);
-		if (var) {
-			idx = var->delta;
-		} else if (!strncmp (name, "0x", 2)) {
-			idx = (int) r_num_get (NULL, name);
-		} else if (!strncmp (name, "-0x", 3)) {
-			idx = -(int) r_num_get (NULL, name+1);
-		 }else {
-			eprintf ("can't find variable named `%s`\n",name);
-			break;
+		var = r_anal_function_get_var_byname (fcn, name);
+		if (!var) {
+			idx = (int)strtol (name, NULL, 0);
+			var = r_anal_function_get_var (fcn, input[0], idx);
 		}
-		if (!r_anal_function_get_var (fcn, input[0], idx)) {
+		if (!var) {
 			eprintf ("can't find variable at given offset\n");
 			break;
 		}
+		idx = var->delta;
 		r_meta_var_comment_del (core->anal, input[0], idx, fcn->addr);
 		break;
 	case '!': { // "Cv!"

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1951,9 +1951,8 @@ static void ds_show_functions(RDisasmState *ds) {
 					}
 					break;
 				}
-				char *comment = r_meta_get_var_comment (anal, var->kind, var->delta, f->addr);
-				if (comment) {
-					r_cons_printf ("    %s; %s", COLOR (ds, color_comment), comment);
+				if (var->comment) {
+					r_cons_printf ("    %s; %s", COLOR (ds, color_comment), var->comment);
 				}
 				r_cons_print (COLOR_RESET (ds));
 				ds_newline (ds);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -749,6 +749,7 @@ typedef struct r_anal_var_t {
 	int delta;   /* delta offset inside stack frame */
 	char *regname; // name of the register
 	RVector/*<RAnalVarAccess>*/ accesses; // ordered by offset, touch this only through API or expect uaf
+	char *comment;
 
 	// below members are just for caching, TODO: remove them and do it better
 	int argnum;
@@ -1733,12 +1734,9 @@ R_API int r_meta_space_count_for(RAnal *a, const RSpace *space_name);
 R_API RList *r_meta_enumerate(RAnal *a, int type);
 R_API int r_meta_count(RAnal *m, int type, ut64 from, ut64 to);
 R_API char *r_meta_get_string(RAnal *m, int type, ut64 addr);
-R_API char *r_meta_get_var_comment (RAnal *a, int type, ut64 idx, ut64 addr);
 R_API bool r_meta_set_string(RAnal *m, int type, ut64 addr, const char *s);
-R_API bool r_meta_set_var_comment (RAnal *a, int type, ut64 idx, ut64 addr, const char *s);
 R_API int r_meta_get_size(RAnal *a, int type);
 R_API int r_meta_del(RAnal *m, int type, ut64 from, ut64 size);
-R_API int r_meta_var_comment_del(RAnal *a, int type, ut64 idx, ut64 addr);
 R_API int r_meta_add(RAnal *m, int type, ut64 from, ut64 to, const char *str);
 R_API int r_meta_add_with_subtype(RAnal *m, int type, int subtype, ut64 from, ut64 to, const char *str);
 R_API RAnalMetaItem *r_meta_find(RAnal *m, ut64 off, int type, int where);

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1847,21 +1847,6 @@ var int64_t newname @ rbp-0x30
 EOF
 RUN
 
-NAME=vars commenting
-FILE=malloc://1024
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=64
-af
-afvb 8 var_8h int
-Cvb 0x8 comment
-pd1~comment
-EOF
-EXPECT=<<EOF
-|           ; arg int var_8h @ rbp+0x8    ; comment
-EOF
-RUN
-
 NAME=vars display in debugger
 FILE=bins/elf/analysis/fast
 CMDS=<<EOF

--- a/test/db/cmd/cmd_meta
+++ b/test/db/cmd/cmd_meta
@@ -1,3 +1,80 @@
+
+NAME=vars commenting
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+
+s 0x10
+af
+
+afvb 8 arg_8h int
+afvb -8 var_8h uint32_t
+afvs 8 var_sp_8h uint32_t
+afvr rax var_rax uint64_t
+
+Cvb 0x8 comment for arg_8h
+Cvb -8 comment for var_8h
+Cvr var_rax comment for var_rax
+Cvs var_sp_8h comment for var_sp_8h
+
+pd1~comment
+?e --
+Cvb
+Cvb*
+?e --
+Cvr
+Cvr*
+?e --
+Cvs
+Cvs*
+?e --
+
+Cvb- arg_8h
+pd1~comment
+?e --
+Cvb- -8
+pd1~comment
+?e --
+Cvs- 8
+pd1~comment
+?e --
+Cvr- var_rax
+pd1~comment
+?e --
+
+EOF
+EXPECT=<<EOF
+|           ; var uint32_t var_8h @ rbp-0x8    ; comment for var_8h
+|           ; arg int arg_8h @ rbp+0x8    ; comment for arg_8h
+|           ; arg uint32_t var_sp_8h @ rsp+0x8    ; comment for var_sp_8h
+|           ; arg uint64_t var_rax @ rax    ; comment for var_rax
+--
+arg_8h : comment for arg_8h
+var_8h : comment for var_8h
+"Cvb arg_8h base64:Y29tbWVudCBmb3IgYXJnXzho @ 0x00000010"
+"Cvb var_8h base64:Y29tbWVudCBmb3IgdmFyXzho @ 0x00000010"
+--
+var_rax : comment for var_rax
+"Cvr var_rax base64:Y29tbWVudCBmb3IgdmFyX3JheA== @ 0x00000010"
+--
+var_sp_8h : comment for var_sp_8h
+"Cvs var_sp_8h base64:Y29tbWVudCBmb3IgdmFyX3NwXzho @ 0x00000010"
+--
+|           ; var uint32_t var_8h @ rbp-0x8    ; comment for var_8h
+|           ; arg uint32_t var_sp_8h @ rsp+0x8    ; comment for var_sp_8h
+|           ; arg uint64_t var_rax @ rax    ; comment for var_rax
+--
+|           ; arg uint32_t var_sp_8h @ rsp+0x8    ; comment for var_sp_8h
+|           ; arg uint64_t var_rax @ rax    ; comment for var_rax
+--
+|           ; arg uint64_t var_rax @ rax    ; comment for var_rax
+--
+--
+EOF
+RUN
+
+
 NAME=Cvb variable null pointer deref
 FILE=bins/elf/analysis/x64-simple
 CMDS=<<EOF


### PR DESCRIPTION
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

Variable comments make no sense in meta. Also they completely ignored the "normal" meta sdb format that is used for everything else. Having a single `char *` in RAnalVar is enough here.

**Test plan**

run the tests