### PR TITLE
Refactor Meta out of SDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ __pycache__
 # Dynamic docker building folder to minimize docker context
 .docker_alpine
 .ccls-cache/
+vgcore.*

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -817,7 +817,7 @@ repeat:
 		case R_ANAL_OP_TYPE_LOAD:
 			if (anal->opt.loads) {
 				if (anal->iob.is_valid_offset (anal->iob.io, op.ptr, 0)) {
-					r_meta_add (anal, R_META_TYPE_DATA, op.ptr, op.ptr + 4, "");
+					r_meta_set (anal, R_META_TYPE_DATA, op.ptr, 4, "");
 				}
 			}
 			break;
@@ -1249,20 +1249,21 @@ R_API void r_anal_del_jmprefs(RAnal *anal, RAnalFunction *fcn) {
 
 /* Does NOT invalidate read-ahead cache. */
 R_API int r_anal_fcn(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int reftype) {
-	RListIter *iter;
-	RAnalMetaItem *meta;
-
-	RList *list = r_meta_find_list_in (anal, addr, -1, 4);
-	r_list_foreach (list, iter, meta) {
+	RPVector *metas = r_meta_get_all_in(anal, addr, R_META_TYPE_ANY);
+	void **it;
+	r_pvector_foreach (metas, it) {
+		RAnalMetaItem *meta = ((RIntervalNode *)*it)->data;
 		switch (meta->type) {
 		case R_META_TYPE_DATA:
 		case R_META_TYPE_STRING:
 		case R_META_TYPE_FORMAT:
-			r_list_free (list);
+			r_pvector_free (metas);
 			return 0;
+		default:
+			break;
 		}
 	}
-	r_list_free (list);
+	r_pvector_free (metas);
 	if (anal->opt.norevisit) {
 		if (!anal->visited) {
 			anal->visited = set_u_new ();

--- a/libr/anal/meta.c
+++ b/libr/anal/meta.c
@@ -1,510 +1,222 @@
-/* radare - LGPL - Copyright 2008-2020 - nibble, pancake */
-
-#if 0
-    TODO
-    ====
-    - handle sync to synchronize all the data on disk.
-    - actually listing only works in memory
-    - array_add doesnt needs index, right?
-    - remove unused arguments from r_meta_find (where ?)
-    - implement r_meta_find
-#endif
-#if 0
-  SDB SPECS
-
-DatabaseName:
-  'anal.meta'
-Keys:
-  'meta.<type>.count=<int>'     number of added metas where 'type' is a single char
-  'meta.<type>.<last>=<array>'  split array, each block contains K elements
-  'meta.<type>.<addr>=<string>' string representing extra information of the meta type at given address
-  'range.<baddr>=<array>'       store valid addresses in a base range array
-#endif
+/* radare - LGPL - Copyright 2008-2020 - nibble, pancake, thestr4ng3r */
 
 #include <r_anal.h>
 #include <r_core.h>
 
-#define META_RANGE_BASE(x) ((x)>>5)
-#undef DB
-#define DB a->sdb_meta
-
-static char *meta_inrange_get(RAnal *a, ut64 addr, int size) {
-	if (size <= 0) {
-		return NULL;
-	}
-	ut64 base = META_RANGE_BASE (addr);
-	ut64 base2 = META_RANGE_BASE (addr + size - 1);
-	char *res = NULL;
-	// return string array of all the offsets where there are stuff
-	for (; base <= base2; base++) {
-		const char *key = sdb_fmt ("range.0x%"PFMT64x, base);
-		const char *r = sdb_const_get (DB, key, 0);
-		if (r) {
-			if (res) {
-				res = r_str_append (res, ",");
-			}
-			res = r_str_append (res, r);
-		}
-	}
-	return res;
+static bool item_matches_filter(RAnalMetaItem *item, RAnalMetaType type, R_NULLABLE const RSpace *space) {
+	return (type == R_META_TYPE_ANY || item->type == type)
+		   && (!space || item->space == space);
 }
 
-static bool meta_inrange_add(RAnal *a, ut64 addr, int size) {
-	if (size <= 0) {
+typedef struct {
+	RAnalMetaType type;
+	const RSpace *space;
+
+	RIntervalNode *node;
+} FindCtx;
+
+static bool find_node_cb(RIntervalNode *node, void *user) {
+	FindCtx *ctx = user;
+	if (item_matches_filter (node->data, ctx->type, ctx->space)) {
+		ctx->node = node;
 		return false;
 	}
-	bool set = false;
-	ut64 base, base2;
-	base = META_RANGE_BASE (addr);
-	base2 = META_RANGE_BASE (addr + size - 1);
-	for (; base <= base2; base++) {
-		const char *key = sdb_fmt ("range.0x%"PFMT64x, base);
-		if (sdb_array_add_num (DB, key, addr, 0)) {
-			set = true;
-		}
-	}
-	return set;
+	return true;
 }
 
-static bool meta_inrange_del(RAnal *a, ut64 addr, int size) {
-	if (size <= 0) {
-		return false;
-	}
-	bool set = false;
-	ut64 base = META_RANGE_BASE (addr);
-	ut64 base2 = META_RANGE_BASE (addr + size - 1);
-	for (; base <= base2; base++) {
-		const char *key = sdb_fmt ("range.0x%"PFMT64x, base);
-		if (sdb_array_remove_num (DB, key, addr, 0)) {
-			set = true;
-		}
-	}
-	return set;
-}
-
-// 512 = 1.5s
-// 256 = 1.3s
-// 128 = 1.2s
-// 64 = 1.14
-// 32 = 1.12
-// not storing any = 1
-#define K 256
-
-static int meta_type_add(RAnal *a, char type, ut64 addr) {
-	char key[32];
-	ut32 count, last;
-	snprintf (key, sizeof (key)-1, "meta.%c.count", type);
-	count = (ut32)sdb_num_inc (DB, key, 1, 0);
-	last = count/K;
-
-	snprintf (key, sizeof (key)-1, "meta.%c.%d", type, last);
-	sdb_array_add_num (DB, key, addr, 0);
-	return count;
-}
-
-// TODO: Add APIs to resize meta? nope, just del and add
-R_API bool r_meta_set_string(RAnal *a, int type, ut64 addr, const char *s) {
-	char key[100], val[2048];
-	bool ret;
-	ut64 size;
-	const char *space = r_spaces_current_name (&a->meta_spaces);
-	meta_type_add (a, type, addr);
-
-	snprintf (key, sizeof (key)-1, "meta.%c.0x%"PFMT64x, type, addr);
-	size = sdb_array_get_num (DB, key, 0, 0);
-	if (!size && s) {
-		size = strlen (s);
-		meta_inrange_add (a, addr, size);
-		ret = true;
-	} else {
-		ret = false;
-	}
-	if (a->log) {
-		char *msg = r_str_newf (":C%c %s @ 0x%"PFMT64x, type, s, addr);
-		a->log (a, msg);
-		free (msg);
-	}
-
-	char *z = sdb_encode ((const void*)s, -1);
-	snprintf (val, sizeof (val) - 1, "%d,%s,%s", (int)size, space, z);
-	sdb_set (DB, key, val, 0);
-	free (z);
-
-	/* send event */
-	REventMeta rems = {
+static RIntervalNode *find_node_at(RAnal *anal, RAnalMetaType type, R_NULLABLE const RSpace *space, ut64 addr) {
+	FindCtx ctx = {
 		.type = type,
-		.addr = addr,
-		.string = s
+		.space = space,
+		.node = NULL
 	};
-	r_event_send (a->ev, R_EVENT_META_SET, &rems);
-
-	return ret;
+	r_interval_tree_all_at (&anal->meta, addr, find_node_cb, &ctx);
+	return ctx.node;
 }
 
-R_API char *r_meta_get_string(RAnal *a, int type, ut64 addr) {
-	char key[100];
-	const char *k, *p, *p2, *p3;
-	snprintf (key, sizeof (key)-1, "meta.%c.0x%"PFMT64x, type, addr);
-	k = sdb_const_get (DB, key, NULL);
-	if (!k) {
-		return NULL;
-	}
-	p = strchr (k, SDB_RS);
-	if (!p) {
-		return NULL;
-	}
-	k = p + 1;
-	p2 = strchr (k, SDB_RS);
-	if (!p2) {
-		return (char *)sdb_decode (k, NULL);
-	}
-	k = p2 + 1;
-	if (type == R_META_TYPE_STRING) {
-		p3 = strchr (k, SDB_RS);
-		if (p3) {
-			return (char *)sdb_decode (p3 + 1, NULL);
-		}
-	}
-	return (char *)sdb_decode (k, NULL);
-}
-
-static bool mustDeleteMetaEntry(RAnal *a, ut64 addr) {
-	const char *tt = sdb_const_get (DB, sdb_fmt ("meta.t.0x%"PFMT64x, addr), NULL);
-	const char *ss = sdb_const_get (DB, sdb_fmt ("meta.s.0x%"PFMT64x, addr), NULL);
-	const char *dd = sdb_const_get (DB, sdb_fmt ("meta.d.0x%"PFMT64x, addr), NULL);
-	const char *cc = sdb_const_get (DB, sdb_fmt ("meta.C.0x%"PFMT64x, addr), NULL);
-	int count = 0;
-	if (tt) count++;
-	if (ss) count++;
-	if (dd) count++;
-	if (cc) count++;
-	return (count == 0);
-}
-
-// delete all the metas of a specific type, addr is ignored,
-static void r_meta_del_cb(RAnal *a, int type, int rad, SdbForeachCallback cb, void *user, ut64 addr) {
-	SdbList *ls = sdb_foreach_list (DB, true);
-	SdbListIter *lsi;
-	SdbKv *kv;
-	ls_foreach (ls, lsi, kv) {
-		if (type == R_META_TYPE_ANY || (strlen (sdbkv_key (kv)) > 5 && sdbkv_key (kv)[5] == type)) {
-			sdb_set (DB, sdbkv_key (kv), NULL, 0);
-		}
-	}
-	ls_free (ls);
-}
-
-R_API int r_meta_del(RAnal *a, int type, ut64 addr, ut64 size) {
-	char key[100];
-	const char *val;
-	/* send event */
-	REventMeta rems = {
+static RIntervalNode *find_node_in(RAnal *anal, RAnalMetaType type, R_NULLABLE const RSpace *space, ut64 addr) {
+	FindCtx ctx = {
 		.type = type,
-		.addr = addr,
-		.string = NULL
+		.space = space,
+		.node = NULL
 	};
-	r_event_send (a->ev, R_EVENT_META_DEL, &rems);
-	if (size == UT64_MAX) {
-		// FULL CLEANUP
-		// XXX: this thing ignores the type
-		if (type == R_META_TYPE_ANY) {
-			sdb_reset (DB);
-		} else {
-			r_meta_del_cb (a, type, type, NULL, NULL, UT64_MAX);
-		}
+	r_interval_tree_all_in (&anal->meta, addr, true, find_node_cb, &ctx);
+	return ctx.node;
+}
+
+typedef struct {
+	RAnalMetaType type;
+	const RSpace *space;
+
+	RPVector/*RIntervalNode*/ *result;
+} CollectCtx;
+
+static bool collect_nodes_cb(RIntervalNode *node, void *user) {
+	CollectCtx *ctx = user;
+	if (item_matches_filter (node->data, ctx->type, ctx->space)) {
+		r_pvector_push (ctx->result, node);
+	}
+	return true;
+}
+
+static RPVector *collect_nodes_at(RAnal *anal, RAnalMetaType type, R_NULLABLE const RSpace *space, ut64 addr) {
+	CollectCtx ctx = {
+		.type = type,
+		.space = space,
+		.result = r_pvector_new (NULL)
+	};
+	if (!ctx.result) {
+		return NULL;
+	}
+	r_interval_tree_all_at (&anal->meta, addr, collect_nodes_cb, &ctx);
+	return ctx.result;
+}
+
+static RPVector *collect_nodes_in(RAnal *anal, RAnalMetaType type, R_NULLABLE const RSpace *space, ut64 addr) {
+	CollectCtx ctx = {
+		.type = type,
+		.space = space,
+		.result = r_pvector_new (NULL)
+	};
+	if (!ctx.result) {
+		return NULL;
+	}
+	r_interval_tree_all_in (&anal->meta, addr, true, collect_nodes_cb, &ctx);
+	return ctx.result;
+}
+
+static RPVector *collect_nodes_intersect(RAnal *anal, RAnalMetaType type, R_NULLABLE const RSpace *space, ut64 start, ut64 end) {
+	CollectCtx ctx = {
+		.type = type,
+		.space = space,
+		.result = r_pvector_new (NULL)
+	};
+	if (!ctx.result) {
+		return NULL;
+	}
+	r_interval_tree_all_intersect (&anal->meta, start, end, true, collect_nodes_cb, &ctx);
+	return ctx.result;
+}
+
+static bool meta_set(RAnal *a, RAnalMetaType type, int subtype, ut64 from, ut64 to, const char *str) {
+	if (to < from) {
 		return false;
 	}
-	if (type == R_META_TYPE_ANY) {
-		/* special case */
-		r_meta_del (a, R_META_TYPE_COMMENT, addr, size);
-		r_meta_del (a, R_META_TYPE_VARTYPE, addr, size);
+	RSpace *space = r_spaces_current (&a->meta_spaces);
+	RIntervalNode *node = find_node_at (a, type, space, from);
+	RAnalMetaItem *item = node ? node->data : R_NEW0 (RAnalMetaItem);
+	if (!item) {
+		return false;
 	}
-	if (type == R_META_TYPE_COMMENT || type == R_META_TYPE_VARTYPE  || type == R_META_TYPE_HIGHLIGHT) {
-		snprintf (key, sizeof (key)-1, "meta.%c.0x%"PFMT64x, type, addr);
-	} else {
-		snprintf (key, sizeof (key)-1, "meta.0x%"PFMT64x, addr);
-	}
-	val = sdb_const_get (DB, key, 0);
-	if (val) {
-		if (type == R_META_TYPE_ANY) {
-			char item_key[100];
-			const char *ptr = val;
-			while (*ptr) {
-				snprintf (item_key, sizeof (item_key), "meta.%c.0x%" PFMT64x, *ptr, addr);
-				sdb_unset (DB, item_key, 0);
-				ptr++;
-				if (*ptr) {
-					ptr++;
-				}
-			}
-			sdb_unset (DB, key, 0);
-			return false;
-		}
-		if (strchr (val, ',')) {
-			char type_fld[] = "##";
-			if (val[0] == type) {
-				type_fld[0] = type;
-				type_fld[1] = ',';
-			} else {
-				type_fld[0] = ',';
-				type_fld[1] = type;
-			}
-			sdb_uncat (DB, key, type_fld, 0);
-		} else {
-			sdb_unset (DB, key, 0);
-		}
-		snprintf (key, sizeof (key), "meta.%c.0x%" PFMT64x, type, addr);
-		sdb_unset (DB, key, 0);
-	}
-	sdb_unset (DB, key, 0);
-	if (mustDeleteMetaEntry (a, addr)) {
-		meta_inrange_del (a, addr, size);
-	}
-	return false;
-}
-
-R_API int r_meta_cleanup(RAnal *a, ut64 from, ut64 to) {
-	return r_meta_del (a, R_META_TYPE_ANY, from, (to-from));
-}
-
-static void r_meta_item_fini(RAnalMetaItem *item) {
+	item->type = type;
+	item->subtype = subtype;
+	item->space = space;
 	free (item->str);
-}
-
-R_API void r_meta_item_free(void *_item) {
-	if (_item) {
-		RAnalMetaItem *item = _item;
-		r_meta_item_fini (item);
-		free (item);
+	item->str = str ? strdup (str) : NULL;
+	if (str && !item->str) {
+		if (!node) { // If we just created this
+			free (item);
+		}
+		return false;
 	}
-}
-
-R_API RAnalMetaItem *r_meta_item_new(int type) {
-	RAnalMetaItem *mi = R_NEW0 (RAnalMetaItem);
-	if (mi) {
-		mi->type = type;
+	if (!node) {
+		r_interval_tree_insert (&a->meta, from, to, item);
+	} else if (node->end != to) {
+		r_interval_tree_resize (&a->meta, node, from, to);
 	}
-	return mi;
+	return true;
 }
 
-static void meta_serialize(RAnalMetaItem *it, char *k, size_t k_size, char *v, size_t v_size) {
-	snprintf (k, k_size, "meta.%c.0x%" PFMT64x, it->type, it->from);
-	const char *name = it->space? it->space->name: "*";
-	if (it->subtype) {
-		snprintf (v, v_size, "%d,%s,%c,%s", (int)it->size, name, it->subtype, it->str);
+R_API bool r_meta_set_string(RAnal *a, RAnalMetaType type, ut64 addr, const char *s) {
+	return meta_set (a, type, 0, addr, addr, s);
+}
+
+R_API const char *r_meta_get_string(RAnal *a, RAnalMetaType type, ut64 addr) {
+	RIntervalNode *node = find_node_at (a, type, r_spaces_current (&a->meta_spaces), addr);
+	if (!node) {
+		return NULL;
+	}
+	RAnalMetaItem *item = node->data;
+	return item->str;
+}
+
+
+static void del(RAnal *a, RAnalMetaType type, const RSpace *space, ut64 addr, ut64 size) {
+	RPVector *victims = NULL;
+	if (size == UT64_MAX) {
+		// delete everything
+		victims = r_pvector_new (NULL);
+		if (!victims) {
+			return;
+		}
+		RIntervalTreeIter it;
+		RAnalMetaItem *item;
+		r_interval_tree_foreach (&a->meta, it, item) {
+			if (item_matches_filter (item, type, space)) {
+				r_pvector_push (victims, r_interval_tree_iter_get (&it));
+			}
+		}
 	} else {
-		snprintf (v, v_size, "%d,%s,%s", (int)it->size, name, it->str);
-	}
-}
-
-static bool meta_deserialize(RAnal *a, RAnalMetaItem *it, const char *k, const char *v) {
-	if (strlen (k) < 8) {
-		return false;
-	}
-	if (memcmp (k + 6, ".0x", 3)) {
-		return false;
-	}
-	return r_meta_deserialize_val (a, it, k[5], sdb_atoi (k + 7), v);
-}
-
-R_API bool r_meta_deserialize_val(RAnal *a, RAnalMetaItem *it, int type, ut64 from, const char *v) {
-	const char *v2;
-	char *v3;
-	it->type = type;
-	it->subtype = 0;
-	it->size = sdb_atoi (v);
-	it->from = from;
-	it->to = from + it->size;
-	v2 = strchr (v, ',');
-	if (!v2) {
-		return false;
-	}
-	v3 = strchr (v2 + 1, ',');
-	if (!v3) {
-		return false;
-	}
-	char *tmp = r_str_ndup (v2 + 1, v3 - v2 - 1);
-	it->space = r_spaces_add (&a->meta_spaces, tmp);
-	free (tmp);
-	it->str = strchr (v2 + 1, ',');
-	if (it->str) {
-		if (it->type == R_META_TYPE_STRING) {
-			v3 = strchr (it->str + 1, ',');
-			if (v3) {
-				it->subtype = *(it->str + 1);
-				it->str = v3;
-			}
+		ut64 end = size ? addr + size - 1 : addr;
+		if (end < addr) {
+			end = UT64_MAX;
 		}
-		it->str = (char *)sdb_decode ((const char*)it->str + 1, 0);
-	}
-	return true;
-}
-
-static int meta_add(RAnal *a, int type, int subtype, ut64 from, ut64 to, const char *str) {
-	const RSpace *space = r_spaces_current (&a->meta_spaces);
-	char key[100], val[2048];
-	if (from > to) {
-		return false;
-	}
-	if (from == to) {
-		to = from + 1;
-	}
-	if (type == 100 && (to - from) < 1) {
-		return false;
-	}
-	/* set entry */
-	char *e_str = sdb_encode ((const void*)str, -1);
-	RAnalMetaItem mi = {from, to, (int)(to - from), type, subtype, e_str, space};
-	meta_serialize (&mi, key, sizeof (key), val, sizeof (val));
-	bool exists = sdb_exists (DB, key);
-
-	sdb_set (DB, key, val, 0);
-	free (e_str);
-
-	// XXX: This is totally inefficient, using array_add withuot
-	// checking return value is wrong practice, also it may lead
-	// to inconsistent DB, and pretty bad performance. We should
-	// store this list in a different storage that doesnt have
-	// those limits and it's O(1) instead of O(n)
-	snprintf (key, sizeof (key) - 1, "meta.0x%"PFMT64x, from);
-	if (exists) {
-		const char *value = sdb_const_get (DB, key, 0);
-		if (value) {
-			int idx = sdb_array_indexof (DB, key, value, 0);
-			if (idx >= 0) {
-				sdb_array_delete (DB, key, idx, 0);
-			}
+		victims = collect_nodes_intersect (a, type, space, addr, end);
+		if (!victims) {
+			return;
 		}
 	}
-	val[0] = type;
-	val[1] = '\0';
-	sdb_array_add (DB, key, val, 0);
-	meta_inrange_add (a, from, to - from);
-	return true;
+	void **it;
+	r_pvector_foreach (victims, it) {
+		r_interval_tree_delete (&a->meta, *it, true);
+	}
+	r_pvector_free (victims);
 }
 
-R_API int r_meta_add(RAnal *a, int type, ut64 from, ut64 to, const char *str) {
-	return meta_add (a, type, 0, from, to, str);
+R_API void r_meta_del(RAnal *a, RAnalMetaType type, ut64 addr, ut64 size) {
+	del (a, type, r_spaces_current (&a->meta_spaces), addr, size);
 }
 
-R_API int r_meta_add_with_subtype(RAnal *a, int type, int subtype, ut64 from, ut64 to, const char *str) {
-	return meta_add (a, type, subtype, from, to, str);
+R_API bool r_meta_set(RAnal *a, RAnalMetaType type, ut64 addr, ut64 size, const char *str) {
+	return r_meta_set_with_subtype (a, type, 0, addr, size, str);
 }
 
-static RAnalMetaItem *r_meta_find_(RAnal *a, ut64 at, int type, int where, int excl_type) {
-	const char *infos, *metas;
-	char key[100];
-	Sdb *s = a->sdb_meta;
-	RAnalMetaItem *mi = NULL;
-	if (where != R_META_WHERE_HERE) {
-		eprintf ("THIS WAS NOT SUPPOSED TO HAPPEN\n");
-		return NULL;
+R_API bool r_meta_set_with_subtype(RAnal *m, RAnalMetaType type, int subtype, ut64 addr, ut64 size, const char *str) {
+	r_return_val_if_fail (m && size, false);
+	ut64 end = addr + size - 1;
+	if (end < addr) {
+		end = UT64_MAX;
 	}
-
-	snprintf (key, sizeof (key), "meta.0x%" PFMT64x, at);
-	infos = sdb_const_get (s, key, 0);
-	if (!infos) {
-		return NULL;
-	}
-	mi =  R_NEW0 (RAnalMetaItem);
-	for (; *infos; infos++) {
-		if (*infos == ',') {
-			continue;
-		}
-		if (type != R_META_TYPE_ANY && type != *infos) {
-			continue;
-		}
-		if (excl_type && excl_type == *infos) {
-			continue;
-		}
-		snprintf (key, sizeof (key), "meta.%c.0x%" PFMT64x, *infos, at);
-		metas = sdb_const_get (s, key, 0);
-		if (metas) {
-			if (!r_meta_deserialize_val (a, mi, *infos, at, metas)) {
-				continue;
-			}
-			return mi;
-		}
-	}
-	r_meta_item_free (mi);
-	return NULL;
+	return meta_set (m, type, subtype, addr, end, str);
 }
 
-// TODO should be named get imho
-R_API RAnalMetaItem *r_meta_find(RAnal *a, ut64 at, int type, int where) {
-	return r_meta_find_ (a, at, type, where, R_META_TYPE_NONE);
+R_API RAnalMetaItem *r_meta_get_at(RAnal *a, ut64 addr, RAnalMetaType type, R_OUT R_NULLABLE ut64 *size) {
+	RIntervalNode *node = find_node_at (a, type, r_spaces_current (&a->meta_spaces), addr);
+	if (node && size) {
+		*size = r_meta_item_size (node->start, node->end);
+	}
+	return node ? node->data : NULL;
 }
 
-R_API RAnalMetaItem *r_meta_find_any_except(RAnal *a, ut64 at, int type, int where) {
-	return r_meta_find_ (a, at, R_META_TYPE_ANY, where, type);
+R_API RIntervalNode *r_meta_get_in(RAnal *a, ut64 addr, RAnalMetaType type) {
+	return find_node_in (a, type, r_spaces_current (&a->meta_spaces), addr);
 }
 
-R_API RAnalMetaItem *r_meta_find_in(RAnal *a, ut64 at, int type, int where) {
-	char *res = meta_inrange_get (a, at, 1);
-	if (!res) {
-		return NULL;
-	}
-	RList *list = r_str_split_list (res, ",", 0);
-	RListIter *iter;
-	const char *meta;
-	r_list_foreach (list, iter, meta) {
-		ut64 mia = r_num_math (NULL, meta);
-		RAnalMetaItem *mi = r_meta_find (a, mia, type, where);
-		if (mi) {
-			if ((at >= mi->from && at < mi->to)) {
-				free (res);
-				return mi;
-			}
-			r_meta_item_free (mi);
-		}
-	}
-	r_list_free (list);
-	free (res);
-	return NULL;
+R_API RPVector/*<RIntervalNode<RMetaItem> *>*/ *r_meta_get_all_at(RAnal *a, ut64 at) {
+	return collect_nodes_at (a, R_META_TYPE_ANY, r_spaces_current (&a->meta_spaces), at);
 }
 
-R_API RList *r_meta_find_list_in(RAnal *a, ut64 at, int type, int where) {
-	char *res = meta_inrange_get (a, at, 1);
-	if (!res) {
-		return NULL;
+R_API RPVector *r_meta_get_all_in(RAnal *a, ut64 at, RAnalMetaType type) {
+	return collect_nodes_in (a, type, r_spaces_current (&a->meta_spaces), at);
+}
+
+R_API RPVector *r_meta_get_all_intersect(RAnal *a, ut64 start, ut64 size, RAnalMetaType type) {
+	r_return_val_if_fail (size, NULL);
+	ut64 end = start + size - 1;
+	if (end < start) {
+		end = UT64_MAX;
 	}
-	RList *list = r_str_split_list (res, ",", 0);
-	RList *out = r_list_newf (r_meta_item_free);
-	if (!out) {
-		return NULL;
-	}
-	RListIter *iter;
-	const char *meta;
-	r_list_foreach (list, iter, meta) {
-		Sdb *s = a->sdb_meta;
-		ut64 mia = r_num_math (NULL, meta);
-		const char *key = sdb_fmt ("meta.0x%" PFMT64x, mia);
-		const char *infos = sdb_const_get (s, key, 0);
-		if (!infos) {
-			continue;
-		}
-		for (; *infos; infos++) {
-			if (*infos == ',') {
-				continue;
-			}
-			const char *key = sdb_fmt ("meta.%c.0x%" PFMT64x, *infos, mia);
-			const char *metas = sdb_const_get (s, key, 0);
-			if (metas) {
-				RAnalMetaItem *mi = R_NEW0 (RAnalMetaItem);
-				if (mi) {
-					if (r_meta_deserialize_val (a, mi, *infos, mia, metas) &&
-						(at >= mi->from && at < mi->to)) {
-						r_list_append (out, mi);
-					} else {
-						r_meta_item_free (mi);
-					}
-				}
-			}
-		}
-	}
-	r_list_free (list);
-	free (res);
-	return out;
+	return collect_nodes_intersect (a, type, r_spaces_current (&a->meta_spaces), start, end);
 }
 
 R_API const char *r_meta_type_to_string(int type) {
@@ -524,29 +236,32 @@ R_API const char *r_meta_type_to_string(int type) {
 	return "# unknown meta # ";
 }
 
-R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_full) {
+R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, ut64 start, ut64 size, int rad, PJ *pj, bool show_full) {
 	r_return_if_fail (!(rad == 'j' && !pj)); // rad == 'j' => pj != NULL
-	char *pstr, *str, *base64_str;
+	char *pstr, *base64_str;
 	RCore *core = a->coreb.core;
 	bool esc_bslash = core ? core->print->esc_bslash : false;
 	if (r_spaces_current (&a->meta_spaces) &&
 	    r_spaces_current (&a->meta_spaces) != d->space) {
 		return;
 	}
-	if (d->type == 's') {
-		if (d->subtype == R_STRING_ENC_UTF8) {
-			str = r_str_escape_utf8 (d->str, false, esc_bslash);
-		} else {
-			if (!d->subtype) {  /* temporary legacy workaround */
-				esc_bslash = false;
+	char *str = NULL;
+	if (d->str) {
+		if (d->type == R_META_TYPE_STRING) {
+			if (d->subtype == R_STRING_ENC_UTF8) {
+				str = r_str_escape_utf8 (d->str, false, esc_bslash);
+			} else {
+				if (!d->subtype) {  /* temporary legacy workaround */
+					esc_bslash = false;
+				}
+				str = r_str_escape_latin1 (d->str, false, esc_bslash, false);
 			}
-			str = r_str_escape_latin1 (d->str, false, esc_bslash, false);
+		} else {
+			str = r_str_escape (d->str);
 		}
-	} else {
-		str = r_str_escape (d->str);
 	}
-	if (str || d->type == 'd') {
-		if (d->type=='s' && !*str) {
+	if (str || d->type == R_META_TYPE_DATA) {
+		if (d->type == R_META_TYPE_STRING && !*str) {
 			free (str);
 			return;
 		}
@@ -572,7 +287,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 		switch (rad) {
 		case 'j':
 			pj_o (pj);
-			pj_kn (pj, "offset", d->from);
+			pj_kn (pj, "offset", start);
 			pj_ks (pj, "type", r_meta_type_to_string (d->type));
 
 			if (d->type == 'H') {
@@ -602,7 +317,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 				}
 			}
 			if (d->type == 'd') {
-				pj_kn (pj, "size", d->size);
+				pj_kn (pj, "size", size);
 			} else if (d->type == 's') {
 				const char *enc;
 				switch (d->subtype) {
@@ -626,12 +341,7 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 		case '*':
 		default:
 			switch (d->type) {
-			case 'a': //var and arg comments
-			case 'v':
-			case 'e':
-				//XXX I think they do not belong to here
-				break;
-			case 'C':
+			case R_META_TYPE_COMMENT:
 				{
 				const char *type = r_meta_type_to_string (d->type);
 				char *s = sdb_encode ((const ut8*)pstr, -1);
@@ -641,26 +351,26 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 				if (rad) {
 					if (!strcmp (type, "CCu")) {
 						a->cb_printf ("%s base64:%s @ 0x%08"PFMT64x"\n",
-							type, s, d->from);
+							type, s, start);
 					} else {
 						a->cb_printf ("%s %s @ 0x%08"PFMT64x"\n",
-							type, pstr, d->from);
+							type, pstr, start);
 					}
 				} else {
 					if (!strcmp (type, "CCu")) {
 						char *mys = r_str_escape (pstr);
 						a->cb_printf ("0x%08"PFMT64x" %s \"%s\"\n",
-								d->from, type, mys);
+								start, type, mys);
 						free (mys);
 					} else {
 						a->cb_printf ("0x%08"PFMT64x" %s \"%s\"\n",
-								d->from, type, pstr);
+								start, type, pstr);
 					}
 				}
 				free (s);
 				}
 				break;
-			case 's': /* string */
+			case R_META_TYPE_STRING:
 				if (rad) {
 					char cmd[] = "Cs#";
 					switch (d->subtype) {
@@ -671,8 +381,8 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 					default:
 						cmd[2] = 0;
 					}
-					a->cb_printf ("%s %d @ 0x%08"PFMT64x" # %s\n",
-							cmd, (int)d->size, d->from, pstr);
+					a->cb_printf ("%s %"PFMT64u" @ 0x%08"PFMT64x" # %s\n",
+							cmd, size, start, pstr);
 				} else {
 					const char *enc;
 					switch (d->subtype) {
@@ -683,74 +393,74 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 						enc = r_str_is_ascii (d->str) ? "ascii" : "latin1";
 					}
 					if (show_full) {
-						a->cb_printf ("0x%08"PFMT64x" %s[%d] \"%s\"\n",
-						              d->from, enc, (int)d->size, pstr);
+						a->cb_printf ("0x%08"PFMT64x" %s[%"PFMT64u"] \"%s\"\n",
+						              start, enc, size, pstr);
 					} else {
-						a->cb_printf ("%s[%d] \"%s\"\n",
-						              enc, (int)d->size, pstr);
+						a->cb_printf ("%s[%"PFMT64u"] \"%s\"\n",
+						              enc, size, pstr);
 					}
 				}
 				break;
-			case 'h': /* hidden */
-			case 'd': /* data */
+			case R_META_TYPE_HIDE:
+			case R_META_TYPE_DATA:
 				if (rad) {
-					a->cb_printf ("%s %d @ 0x%08"PFMT64x"\n",
+					a->cb_printf ("%s %"PFMT64u" @ 0x%08"PFMT64x"\n",
 							r_meta_type_to_string (d->type),
-							(int)d->size, d->from);
+							size, start);
 				} else {
 					if (show_full) {
 						const char *dtype = d->type == 'h' ? "hidden" : "data";
-						a->cb_printf ("0x%08" PFMT64x " %s %s %d\n",
-						              d->from, dtype,
-						              r_meta_type_to_string (d->type), (int)d->size);
+						a->cb_printf ("0x%08" PFMT64x " %s %s %"PFMT64u"\n",
+						              start, dtype,
+						              r_meta_type_to_string (d->type), size);
 					} else {
-						a->cb_printf ("%d\n", (int)d->size);
+						a->cb_printf ("%"PFMT64u"\n", size);
 					}
 				}
 				break;
-			case 'm': /* magic */
-			case 'f': /* formatted */
+			case R_META_TYPE_MAGIC:
+			case R_META_TYPE_FORMAT:
 				if (rad) {
-					a->cb_printf ("%s %d %s @ 0x%08"PFMT64x"\n",
+					a->cb_printf ("%s %"PFMT64u" %s @ 0x%08"PFMT64x"\n",
 							r_meta_type_to_string (d->type),
-							(int)d->size, pstr, d->from);
+							size, pstr, start);
 				} else {
 					if (show_full) {
 						const char *dtype = d->type == 'm' ? "magic" : "format";
-						a->cb_printf ("0x%08" PFMT64x " %s %d %s\n",
-						              d->from, dtype, (int)d->size, pstr);
+						a->cb_printf ("0x%08" PFMT64x " %s %"PFMT64u" %s\n",
+						              start, dtype, size, pstr);
 					} else {
-						a->cb_printf ("%d %s\n", (int)d->size, pstr);
+						a->cb_printf ("%"PFMT64u" %s\n", size, pstr);
 					}
 				}
 				break;
-			case 't': /* vartype */
+			case R_META_TYPE_VARTYPE:
 				if (rad) {
 					a->cb_printf ("%s %s @ 0x%08"PFMT64x"\n",
-						r_meta_type_to_string (d->type), pstr, d->from);
+						r_meta_type_to_string (d->type), pstr, start);
 				} else {
-					a->cb_printf ("0x%08"PFMT64x" %s\n", d->from, pstr);
+					a->cb_printf ("0x%08"PFMT64x" %s\n", start, pstr);
 				}
 				break;
-			case 'H':
+			case R_META_TYPE_HIGHLIGHT:
 				{
 					ut8 r = 0, g = 0, b = 0, A = 0;
 					const char *esc = strchr (d->str, '\x1b');
 					r_cons_rgb_parse (esc, &r, &g, &b, &A);
 					a->cb_printf ("%s rgb:%02x%02x%02x @ 0x%08"PFMT64x"\n",
-						r_meta_type_to_string (d->type), r, g, b, d->from);
+						r_meta_type_to_string (d->type), r, g, b, start);
 					// TODO: d->size
 				}
 				break;
 			default:
 				if (rad) {
-					a->cb_printf ("%s %d 0x%08"PFMT64x" # %s\n",
+					a->cb_printf ("%s %"PFMT64u" 0x%08"PFMT64x" # %s\n",
 						r_meta_type_to_string (d->type),
-						(int)d->size, d->from, pstr);
+						size, start, pstr);
 				} else {
 					// TODO: use b64 here
-					a->cb_printf ("0x%08"PFMT64x" array[%d] %s %s\n",
-						d->from, (int)d->size,
+					a->cb_printf ("0x%08"PFMT64x" array[%"PFMT64u"] %s %s\n",
+						start, size,
 						r_meta_type_to_string (d->type), pstr);
 				}
 				break;
@@ -763,90 +473,49 @@ R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_f
 	}
 }
 
-static int meta_print_item(void *user, const char *k, const char *v) {
-	RAnalMetaUserItem *ui = user;
-	RAnalMetaItem it;
-	if (!meta_deserialize (ui->anal, &it, k, v)) {
-		return 1;
+R_API void r_meta_print_list_at(RAnal *a, ut64 addr, int rad) {
+	RPVector *nodes = collect_nodes_at (a, R_META_TYPE_ANY, r_spaces_current (&a->meta_spaces), addr);
+	if (!nodes) {
+		return;
 	}
-	if (ui->fcn && !r_anal_function_contains (ui->fcn, it.from)) {
-		goto beach;
+	void **it;
+	r_pvector_foreach (nodes, it) {
+		RIntervalNode *node = *it;
+		r_meta_print (a, node->data, node->start, r_meta_node_size (node), rad, NULL, true);
 	}
-	if (!it.str) {
-		it.str = strdup (""); // don't break in free
-		if (!it.str) {
-			goto beach;
-		}
-	}
-	r_meta_print (ui->anal, &it, ui->rad, ui->pj, true);
-beach:
-	free (it.str);
-	return 1;
+	r_pvector_free (nodes);
 }
 
-R_API void r_meta_list_offset(RAnal *a, ut64 addr, char input) {
-	const int types[] = {
-		R_META_TYPE_VARTYPE,
-		R_META_TYPE_HIGHLIGHT,
-		R_META_TYPE_RUN,
-		R_META_TYPE_COMMENT,
-		R_META_TYPE_HIDE,
-		R_META_TYPE_MAGIC,
-		R_META_TYPE_FORMAT,
-		R_META_TYPE_STRING,
-		R_META_TYPE_CODE,
-		R_META_TYPE_DATA,
-	};
-
-	char key[100];
-	int i;
-
-	for (i = 0; i < sizeof (types) / sizeof (types[0]); i ++) {
-		snprintf (key, sizeof (key)-1, "meta.%c.0x%"PFMT64x, types[i], addr);
-		const char *k = sdb_const_get (DB, key, 0);
-		if (!k) {
-			continue;
-		}
-
-		RAnalMetaUserItem ui = { a };
-
-		meta_print_item ((void *)&ui, key, k);
-	}
-}
-
-
-R_API int r_meta_list_cb(RAnal *a, int type, int rad, SdbForeachCallback cb, void *user, ut64 addr) {
+static void print_meta_list(RAnal *a, int type, int rad, ut64 addr) {
 	PJ *pj = NULL;
 	if (rad == 'j') {
 		pj = pj_new ();
 		if (!pj) {
-			return 0;
+			return;
 		}
 		pj_a (pj);
 	}
 
-	RAnalMetaUserItem ui = { a, type, rad, cb, user, 0, NULL, pj };
-
+	RAnalFunction *fcn = NULL;
 	if (addr != UT64_MAX) {
-		ui.fcn = r_anal_get_fcn_in (a, addr, 0);
-		if (!ui.fcn) {
+		fcn = r_anal_get_fcn_in (a, addr, 0);
+		if (!fcn) {
 			goto beach;
 		}
 	}
 
-	SdbList *ls = sdb_foreach_list (DB, true);
-	SdbListIter *lsi;
-	SdbKv *kv;
-	ls_foreach (ls, lsi, kv) {
-		if (type == R_META_TYPE_ANY || (strlen (sdbkv_key (kv)) > 5 && sdbkv_key (kv)[5] == type)) {
-			if (cb) {
-				cb ((void *)&ui, sdbkv_key (kv), sdbkv_value (kv));
-			} else {
-				meta_print_item ((void *)&ui, sdbkv_key (kv), sdbkv_value (kv));
-			}
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&a->meta, it, item) {
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		if (type != R_META_TYPE_ANY && item->type != type) {
+			continue;
 		}
+		if (fcn && !r_anal_function_contains (fcn, node->start)) {
+			continue;
+		}
+		r_meta_print (a, item, node->start, r_meta_node_size (node), rad, pj, true);
 	}
-	ls_free (ls);
 
 beach:
 	if (pj) {
@@ -854,135 +523,73 @@ beach:
 		r_cons_printf ("%s\n", pj_string (pj));
 		pj_free (pj);
 	}
-	return ui.count;
 }
 
-R_API int r_meta_list(RAnal *a, int type, int rad) {
-	return r_meta_list_cb (a, type, rad, NULL, NULL, UT64_MAX);
+R_API void r_meta_print_list_all(RAnal *a, int type, int rad) {
+	print_meta_list (a, type, rad, UT64_MAX);
 }
 
-R_API int r_meta_list_at(RAnal *a, int type, int rad, ut64 addr) {
-	return r_meta_list_cb (a, type, rad, NULL, NULL, addr);
+R_API void r_meta_print_list_in_function(RAnal *a, int type, int rad, ut64 addr) {
+	print_meta_list (a, type, rad, addr);
 }
 
-static int meta_enumerate_cb(void *user, const char *k, const char *v) {
-	RAnalMetaUserItem *ui = user;
-	RList *list = ui->user;
-	RAnalMetaItem *it = R_NEW0 (RAnalMetaItem);
-	if (!it) {
-		return 0;
+R_API void r_meta_rebase(RAnal *anal, ut64 diff) {
+	if (!diff) {
+		return;
 	}
-	if (!meta_deserialize (ui->anal, it, k, v)) {
-		free (it);
-		goto beach;
+	RIntervalTree old = anal->meta;
+	r_interval_tree_init (&anal->meta, old.free);
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&old, it, item) {
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		ut64 newstart = node->start + diff;
+		ut64 newend = node->end + diff;
+		if (newend < newstart) {
+			// Can't rebase this
+			newstart = node->start;
+			newend = node->end;
+		}
+		r_interval_tree_insert (&anal->meta, newstart, newend, item);
 	}
-	if (!it->str) {
-		free (it);
-		goto beach;
-	}
-	r_list_append (list, it);
-beach:
-	return 1;
-}
-
-R_API RList *r_meta_enumerate(RAnal *a, int type) {
-	RList *list = r_list_newf (r_meta_item_free);
-	r_meta_list_cb (a, type, 0, meta_enumerate_cb, list, UT64_MAX);
-	return list;
-}
-
-static int meta_unset_cb(void *user, const char *k, const char *v) {
-	char nk[128], nv[4096];
-	RAnalMetaUserItem *ui = user;
-	RAnal *a = ui->anal;
-	RAnalMetaItem it = {0};
-	if (!strstr (k, ".0x")) {
-		return 1;
-	}
-	meta_deserialize (ui->anal, &it, k, v);
-	if (it.space && it.space == ui->user) {
-		it.space = NULL;
-		meta_serialize (&it, nk, sizeof (nk), nv, sizeof (nv));
-		sdb_set (DB, nk, nv, 0);
-	}
-	return 1;
+	old.free = NULL;
+	r_interval_tree_fini (&old);
 }
 
 R_API void r_meta_space_unset_for(RAnal *a, const RSpace *space) {
-	RAnalMetaUserItem ui = { .anal = a, .user = (void *)space };
-	r_meta_list_cb (a, R_META_TYPE_ANY, 0, meta_unset_cb, &ui, UT64_MAX);
+	del (a, R_META_TYPE_ANY, space, 0, UT64_MAX);
 }
 
-typedef struct {
-	int count;
-	int index;
-	const RSpace *ctx;
-} myMetaUser;
-
-static int meta_count_cb(void *user, const char *k, const char *v) {
-	RAnalMetaUserItem *ui = user;
-	myMetaUser *mu = ui->user;
-	RAnalMetaItem it = {0};
-	if (!strstr (k, ".0x")) {
-		return 1;
-	}
-	meta_deserialize (ui->anal, &it, k, v);
-	if (mu && it.space == mu->ctx) {
-		mu->count++;
-	}
-	r_meta_item_fini (&it);
-	return 1;
-}
-
-static int get_meta_size(void *user, const char *k, const char *v) {
-	RAnalMetaUserItem *ui = user;
-	RAnalMetaItem it;
-	if (!meta_deserialize (ui->anal, &it, k, v)) {
-		return -1;
-	}
-	if (ui->fcn && !r_anal_function_contains (ui->fcn, it.from)) {
-		goto beach;
-	}
-	if (!it.str) {
-		it.str = strdup (""); // don't break in free
-		if (!it.str) {
-			goto beach;
+R_API ut64 r_meta_get_size(RAnal *a, RAnalMetaType type) {
+	ut64 sum = 0;
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	RIntervalNode *prev = NULL;
+	r_interval_tree_foreach (&a->meta, it, item) {
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		if (type != R_META_TYPE_ANY && item->type != type) {
+			continue;
 		}
+		ut64 start = R_MAX (prev ? prev->end : 0, node->start);
+		sum += node->end - start + 1;
+		prev = node;
 	}
-	return it.size;
-beach:
-	free (it.str);
-	return -1;
+	return sum;
 }
-
-R_API int r_meta_get_size(RAnal *a, int type) {
-	RAnalMetaUserItem ui = { a, type, 0, NULL, NULL, 0, NULL };
-	SdbList *ls = sdb_foreach_list (DB, true);
-	SdbListIter *lsi;
-	SdbKv *kv;
-	int tot_size = 0;
-	int meta_size;
-	ls_foreach (ls, lsi, kv) {
-		if ((strlen (sdbkv_key (kv)) > 5 && sdbkv_key (kv)[5] == type)) {
-			meta_size = get_meta_size ((void *)&ui, sdbkv_key (kv), sdbkv_value (kv));
-			tot_size += meta_size > -1 ? meta_size : 0;
-		}
-	}
-	ls_free (ls);
-	return tot_size;
-}
-
 
 R_API int r_meta_space_count_for(RAnal *a, const RSpace *space) {
-	myMetaUser mu = { .ctx = space };
-	r_meta_list_cb (a, R_META_TYPE_ANY, 0, meta_count_cb, &mu, UT64_MAX);
-	return mu.count;
+	int r = 0;
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&a->meta, it, item) {
+		if (item->space == space) {
+			r++;
+		}
+	}
+	return r;
 }
 
 R_API void r_meta_set_data_at(RAnal *a, ut64 addr, ut64 wordsz) {
-	char val[0x10];
-	if (snprintf (val, sizeof (val), "%"PFMT64u, wordsz) < 1) {
-		return;
-	}
-	r_meta_add (a, R_META_TYPE_DATA, addr, addr + wordsz, val);
+	r_return_if_fail (wordsz);
+	r_meta_set (a, R_META_TYPE_DATA, addr, wordsz, NULL);
 }

--- a/libr/core/anal_objc.c
+++ b/libr/core/anal_objc.c
@@ -228,7 +228,7 @@ static bool objc_find_refs(RCore *core) {
 	total = 0;
 	ut64 a;
 	for (a = from; a < to; a += objc.word_size) {
-		r_meta_add (core->anal, R_META_TYPE_DATA, a, a + 8, NULL);
+		r_meta_set (core->anal, R_META_TYPE_DATA, a, 8, NULL);
 		total ++;
 	}
 	oldstr = r_print_rowlog (core->print, sdb_fmt ("Set %d dwords at 0x%08"PFMT64x, total, from));

--- a/libr/core/blaze.c
+++ b/libr/core/blaze.c
@@ -49,21 +49,24 @@ static int __isdata(RCore *core, ut64 addr) {
 		return 1;
 	}
 
-	RList *list = r_meta_find_list_in (core->anal, addr, -1, 4);
-	RListIter *iter;
-	RAnalMetaItem *meta;
+	RPVector *list = r_meta_get_all_in (core->anal, addr, R_META_TYPE_ANY);
+	void **it;
 	int result = 0;
-	r_list_foreach (list, iter, meta) {
+	r_pvector_foreach (list, it) {
+		RIntervalNode *node = *it;
+		RAnalMetaItem *meta = node->data;
 		switch (meta->type) {
 		case R_META_TYPE_DATA:
 		case R_META_TYPE_STRING:
 		case R_META_TYPE_FORMAT:
-			result = meta->size - (addr - meta->from);
+			result = node->end - addr + 1;
 			goto exit;
+		default:
+			break;
 		}
 	}
 exit:
-	r_list_free (list);
+	r_pvector_free (list);
 	return result;
 }
 

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4275,7 +4275,7 @@ R_API RCoreAnalStats* r_core_anal_get_stats(RCore *core, ut64 from, ut64 to, ut6
 		piece = (S->vaddr - from) / step;
 		as->block[piece].symbols++;
 	}
-	RPVector *metas = to >= from ? r_meta_get_all_intersect (core->anal, from, to - from, R_META_TYPE_ANY) : NULL;
+	RPVector *metas = to > from ? r_meta_get_all_intersect (core->anal, from, to - from, R_META_TYPE_ANY) : NULL;
 	if (metas) {
 		void **it;
 		r_pvector_foreach (metas, it) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -292,7 +292,7 @@ static void _print_strings(RCore *r, RList *list, int mode, int va) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-			r_meta_add (r->anal, R_META_TYPE_STRING, vaddr, vaddr + string->size, string->string);
+			r_meta_set (r->anal, R_META_TYPE_STRING, vaddr, string->size, string->string);
 			f_name = strdup (string->string);
 			r_name_filter (f_name, -1);
 			if (r->bin->prefix) {
@@ -1236,8 +1236,8 @@ static int bin_entry(RCore *r, int mode, ut64 laddr, int va, bool inifin) {
 			}
 			r_flag_set (r->flags, str, at, 1);
 			if (is_initfini (entry) && hvaddr != UT64_MAX) {
-				r_meta_add (r->anal, R_META_TYPE_DATA, hvaddr,
-				            hvaddr + entry->bits / 8, NULL);
+				r_meta_set (r->anal, R_META_TYPE_DATA, hvaddr,
+							entry->bits / 8, NULL);
 			}
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_printf ("0x%08"PFMT64x"\n", at);
@@ -1427,7 +1427,7 @@ static void set_bin_relocs(RCore *r, RBinReloc *reloc, ut64 addr, Sdb **db, char
 			}
 		}
 		r_anal_hint_set_size (r->anal, reloc->vaddr, 4);
-		r_meta_add (r->anal, R_META_TYPE_DATA, reloc->vaddr, reloc->vaddr+4, NULL);
+		r_meta_set (r->anal, R_META_TYPE_DATA, reloc->vaddr, 4, NULL);
 	}
 
 	char flagname[R_FLAG_NAME_SIZE];
@@ -1479,7 +1479,7 @@ static void add_metadata(RCore *r, RBinReloc *reloc, ut64 addr, int mode) {
 		return;
 	}
 	if (IS_MODE_SET (mode)) {
-		r_meta_add (r->anal, R_META_TYPE_DATA, reloc->vaddr, reloc->vaddr + cdsz, NULL);
+		r_meta_set (r->anal, R_META_TYPE_DATA, reloc->vaddr, cdsz, NULL);
 	} else if (IS_MODE_RAD (mode)) {
 		r_cons_printf ("Cd %d @ 0x%08" PFMT64x "\n", cdsz, addr);
 	}
@@ -1836,7 +1836,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 			// TODO(eddyb) symbols that are imports.
 			// Add a dword/qword for PE imports
 			if (libname && strstr (libname, ".dll") && cdsz) {
-				r_meta_add (r->anal, R_META_TYPE_DATA, addr, addr + cdsz, NULL);
+				r_meta_set (r->anal, R_META_TYPE_DATA, addr, cdsz, NULL);
 			}
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_printf ("%s%s%s\n",
@@ -2205,8 +2205,8 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 				free (fnp);
 			}
 			if (sn.demname) {
-				r_meta_add (r->anal, R_META_TYPE_COMMENT,
-					addr, symbol->size, sn.demname);
+				r_meta_set (r->anal, R_META_TYPE_COMMENT,
+							addr, symbol->size, sn.demname);
 			}
 			r_flag_space_pop (r->flags);
 		} else if (IS_MODE_JSON (mode)) {
@@ -2759,7 +2759,7 @@ static int bin_sections(RCore *r, int mode, ut64 laddr, int va, ut64 at, const c
 				str = r_str_newf ("[%02d] %s %s size %" PFMT64d" named %s%s%s",
 				                  i, perms, type, size,
 				                  pfx? pfx: "", pfx? ".": "", section->name);
-				r_meta_add (r->anal, R_META_TYPE_COMMENT, addr, addr, str);
+				r_meta_set (r->anal, R_META_TYPE_COMMENT, addr, 1, str);
 				R_FREE (str);
 			}
 			if (section->add) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1236,8 +1236,7 @@ static int bin_entry(RCore *r, int mode, ut64 laddr, int va, bool inifin) {
 			}
 			r_flag_set (r->flags, str, at, 1);
 			if (is_initfini (entry) && hvaddr != UT64_MAX) {
-				r_meta_set (r->anal, R_META_TYPE_DATA, hvaddr,
-							entry->bits / 8, NULL);
+				r_meta_set (r->anal, R_META_TYPE_DATA, hvaddr, entry->bits / 8, NULL);
 			}
 		} else if (IS_MODE_SIMPLE (mode)) {
 			r_cons_printf ("0x%08"PFMT64x"\n", at);

--- a/libr/core/citem.c
+++ b/libr/core/citem.c
@@ -11,22 +11,25 @@ R_API RCoreItem *r_core_item_at (RCore *core, ut64 addr) {
 		// TODO: honor section perms too?
 		if (map->perm & R_PERM_X) {
 			// if theres a meta consider it data
-			RAnalMetaItem *item = r_meta_find (core->anal, addr, R_META_TYPE_ANY, 0);
+			ut64 size;
+			RAnalMetaItem *item = r_meta_get_at (core->anal, addr, R_META_TYPE_ANY, &size);
 			if (item) {
 				switch (item->type) {
 				case R_META_TYPE_DATA:
 					ci->type = "data";
-					ci->size = item->size;
+					ci->size = size;
 					ci->data = r_core_cmd_strf (core, "pdi 1 @e:asm.flags=0@e:asm.lines=0@e:scr.color=0@0x%08"PFMT64x, addr);
 					r_str_trim (ci->data);
 					break;
 				case R_META_TYPE_FORMAT:
 					ci->type = "format"; // struct :?
-					ci->size = item->size;
+					ci->size = size;
 					break;
 				case R_META_TYPE_STRING:
 					ci->type = "string";
-					ci->size = item->size;
+					ci->size = size;
+					break;
+				default:
 					break;
 				}
 				if (item->str) {
@@ -34,7 +37,6 @@ R_API RCoreItem *r_core_item_at (RCore *core, ut64 addr) {
 						ci->data = strdup (item->str);
 					}
 				}
-				r_meta_item_free (item);
 			}
 		}
 	}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -6070,10 +6070,9 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_comment_command) {
 	RCore *core = state->core;
 	TSNode command = ts_node_named_child (node, 0);
 	TSNode filter_node = ts_node_named_child (node, 1);
-	char *glob = NULL;
-	if (!ts_node_is_null (filter_node)) {
-		glob = ts_node_sub_string (filter_node, state->input);
-	}
+	char *glob = !ts_node_is_null (filter_node)
+			? ts_node_sub_string (filter_node, state->input)
+			: NULL;
 	ut64 off = core->offset;
 	RCmdStatus res = R_CMD_STATUS_OK;
 	RIntervalTreeIter it;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7265,14 +7265,25 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 						ref->addr, ref->type, addr, iter->n? ",": "");
 			} else { // axt
 				RAnalFunction *fcn;
-				char *comment;
 				r_list_foreach (list, iter, ref) {
 					fcn = r_anal_get_fcn_in (core->anal, ref->addr, 0);
 					char *buf_asm = get_buf_asm (core, addr, ref->addr, fcn, true);
-					comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
+					const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
+					char *print_comment = NULL;
+					if (comment && strchr (comment, '\n')) { // display only until the first newline
+						print_comment = strdup (comment);
+						if (print_comment) {
+							comment = print_comment;
+							char *nl = strchr (print_comment, '\n');
+							if (nl) {
+								*nl = '\0';
+							}
+						}
+					}
 					char *buf_fcn = comment
-						? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", strtok (comment, "\n"))
+						? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", comment)
 						: r_str_newf ("%s", fcn ? fcn->name : "(nofunc)");
+					free (print_comment);
 					r_cons_printf ("%s 0x%" PFMT64x " [%s] %s\n",
 						buf_fcn, ref->addr, r_anal_xrefs_type_tostring (ref->type), buf_asm);
 					free (buf_asm);
@@ -8711,7 +8722,7 @@ static void _CbInRangeAav(RCore *core, ut64 from, ut64 to, int vsize, int count,
 		r_cons_printf ("f+ aav.0x%08"PFMT64x "= 0x%08"PFMT64x, to, to);
 	} else {
 		r_anal_xrefs_set (core->anal, from, to, R_ANAL_REF_TYPE_NULL);
-		// r_meta_add (core->anal, 'd', from, from + vsize, NULL);
+		// r_meta_set (core->anal, 'd', from, from + vsize, NULL);
 		r_core_cmdf (core, "Cd %d @ 0x%"PFMT64x "\n", vsize, from);
 		if (!r_flag_get_at (core->flags, to, false)) {
 			char *name = r_str_newf ("aav.0x%08"PFMT64x, to);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7270,15 +7270,9 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 					char *buf_asm = get_buf_asm (core, addr, ref->addr, fcn, true);
 					const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
 					char *print_comment = NULL;
-					if (comment && strchr (comment, '\n')) { // display only until the first newline
-						print_comment = strdup (comment);
-						if (print_comment) {
-							comment = print_comment;
-							char *nl = strchr (print_comment, '\n');
-							if (nl) {
-								*nl = '\0';
-							}
-						}
+					const char *nl = comment ? strchr (comment, '\n') : NULL;
+					if (nl) { // display only until the first newline
+						comment = print_comment = r_str_ndup (comment, nl - comment);
 					}
 					char *buf_fcn = comment
 						? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", comment)

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -473,19 +473,19 @@ static int cmd_eval(void *data, const char *input) {
 				r_str_argv_free (argv);
 				return false;
 			case '.':
-				r_meta_list_at (core->anal, R_META_TYPE_HIGHLIGHT, 0, core->offset);
+				r_meta_print_list_in_function (core->anal, R_META_TYPE_HIGHLIGHT, 0, core->offset);
 				r_str_argv_free (argv);
 				return false;
 			case '\0':
-				r_meta_list (core->anal, R_META_TYPE_HIGHLIGHT, 0);
+				r_meta_print_list_all (core->anal, R_META_TYPE_HIGHLIGHT, 0);
 				r_str_argv_free (argv);
 				return false;
 			case 'j':
-				r_meta_list (core->anal, R_META_TYPE_HIGHLIGHT, 'j');
+				r_meta_print_list_all (core->anal, R_META_TYPE_HIGHLIGHT, 'j');
 				r_str_argv_free (argv);
 				return false;
 			case '*':
-				r_meta_list (core->anal, R_META_TYPE_HIGHLIGHT, '*');
+				r_meta_print_list_all (core->anal, R_META_TYPE_HIGHLIGHT, '*');
 				r_str_argv_free (argv);
 				return false;
 			case ' ':
@@ -526,7 +526,7 @@ static int cmd_eval(void *data, const char *input) {
 				return true;
 			}
 			r_meta_set_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset, "");
-			char *str = r_meta_get_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset);
+			const char *str = r_meta_get_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset);
 			char *dup = r_str_newf ("%s \"%s%s\"", str?str:"", word?word:"", color_code?color_code:r_cons_singleton ()->context->pal.wordhl);
 			r_meta_set_string (core->anal, R_META_TYPE_HIGHLIGHT, core->offset, dup);
 			r_str_argv_free (argv);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1019,14 +1019,7 @@ static void __rebase_everything(RCore *core, RList *old_sections, ut64 old_base)
 	r_flag_foreach (core->flags, __rebase_flags, &reb);
 
 	// META
-	RList *meta_list = r_meta_enumerate (core->anal, R_META_TYPE_ANY);
-	RAnalMetaItem *item;
-	r_list_foreach (meta_list, it, item) {
-		r_meta_del (core->anal, item->type, item->from, item->size);
-		item->from += diff;
-		r_meta_add_with_subtype (core->anal, item->type, item->subtype, item->from, item->from + item->size, item->str);
-	}
-	r_list_free (meta_list);
+	r_meta_rebase (core->anal, diff);
 
 	// REFS
 	HtUP *old_refs = core->anal->dict_refs;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1245,8 +1245,7 @@ static void print_rop(RCore *core, RList *hitlist, char mode, bool *json_first) 
 	default:
 		// Print gadgets with new instruction on a new line.
 		r_list_foreach (hitlist, iter, hit) {
-			char *comment = rop_comments? r_meta_get_string (core->anal,
-				R_META_TYPE_COMMENT, hit->addr): NULL;
+			const char *comment = rop_comments? r_meta_get_string (core->anal, R_META_TYPE_COMMENT, hit->addr): NULL;
 			if (hit->len < 0) {
 				eprintf ("Invalid hit length here\n");
 				continue;
@@ -1907,7 +1906,6 @@ beach:
 static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct search_parameters *param) {
 	const int size = 12;
 	char str[512];
-	char *comment;
 	RAnalFunction *fcn;
 	RAnalRef *ref;
 	RListIter *iter;
@@ -1924,10 +1922,22 @@ static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct sear
 			r_parse_filter (core->parser, ref->addr, core->flags, hint, r_strbuf_get (&asmop.buf_asm),
 				str, sizeof (str), core->print->big_endian);
 			r_anal_hint_free (hint);
-			comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
+			const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
+			char *print_comment = NULL;
+			if (comment && strchr (comment, '\n')) { // display only until the first newline
+				print_comment = strdup (comment);
+				if (print_comment) {
+					comment = print_comment;
+					char *nl = strchr (print_comment, '\n');
+					if (nl) {
+						*nl = '\0';
+					}
+				}
+			}
 			char *buf_fcn = comment
-				? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", strtok (comment, "\n"))
+				? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", comment)
 				: r_str_newf ("%s", fcn ? fcn->name : "(nofunc)");
+			free (print_comment);
 			if (from <= ref->addr && to >= ref->addr) {
 				r_cons_printf ("%s 0x%" PFMT64x " [%s] %s\n",
 						buf_fcn, ref->addr, r_anal_xrefs_type_tostring (ref->type), str);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -1924,15 +1924,9 @@ static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct sear
 			r_anal_hint_free (hint);
 			const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ref->addr);
 			char *print_comment = NULL;
-			if (comment && strchr (comment, '\n')) { // display only until the first newline
-				print_comment = strdup (comment);
-				if (print_comment) {
-					comment = print_comment;
-					char *nl = strchr (print_comment, '\n');
-					if (nl) {
-						*nl = '\0';
-					}
-				}
+			const char *nl = comment ? strchr (comment, '\n') : NULL;
+			if (nl) { // display only until the first newline
+				comment = print_comment = r_str_ndup (comment, nl - comment);
 			}
 			char *buf_fcn = comment
 				? r_str_newf ("%s; %s", fcn ?  fcn->name : "(nofunc)", comment)

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2232,17 +2232,14 @@ static char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, int depth) {
 
 R_API char *r_core_anal_get_comments(RCore *core, ut64 addr) {
 	if (core) {
-		char *type = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
-		char *cmt = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+		const char *type = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, addr);
+		const char *cmt = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
 		if (type && cmt) {
-			char *ret = r_str_newf ("%s %s", type, cmt);
-			free (type);
-			free (cmt);
-			return ret;
+			return r_str_newf ("%s %s", type, cmt);
 		} else if (type) {
-			return type;
+			return strdup (type);
 		} else if (cmt) {
-			return cmt;
+			return strdup (cmt);
 		}
 	}
 	return NULL;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -895,9 +895,8 @@ static void ds_free(RDisasmState *ds) {
 /* XXX move to r_print */
 static char *colorize_asm_string(RCore *core, RDisasmState *ds, bool print_color) {
 	char *source = ds->opstr? ds->opstr: r_asm_op_get_asm (&ds->asmop);
-	char *hlstr = r_meta_get_string (ds->core->anal, R_META_TYPE_HIGHLIGHT, ds->at);
+	const char *hlstr = r_meta_get_string (ds->core->anal, R_META_TYPE_HIGHLIGHT, ds->at);
 	bool partial_reset = line_highlighted (ds) ? true : ((hlstr && *hlstr) ? true : false);
-	free (hlstr);
 	RAnalFunction *f = ds->show_color_args ? fcnIn (ds, ds->vat, R_ANAL_FCN_TYPE_NULL) : NULL;
 
 	if (!ds->show_color || !ds->colorop) {
@@ -1118,7 +1117,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		int i = 0;
 		char *word = NULL;
 		char *bgcolor = NULL;
-		char *wcdata = r_meta_get_string (ds->core->anal, R_META_TYPE_HIGHLIGHT, ds->at);
+		const char *wcdata = r_meta_get_string (ds->core->anal, R_META_TYPE_HIGHLIGHT, ds->at);
 		int argc = 0;
 		char **wc_array = r_str_argv (wcdata, &argc);
 		for (i = 0; i < argc; i++) {
@@ -1239,7 +1238,7 @@ static void ds_show_refs(RDisasmState *ds) {
 	RList *list = r_anal_xrefs_get_from (ds->core->anal, ds->at);
 
 	r_list_foreach (list, iter, ref) {
-		char *cmt = r_meta_get_string (ds->core->anal, R_META_TYPE_COMMENT, ref->addr);
+		const char *cmt = r_meta_get_string (ds->core->anal, R_META_TYPE_COMMENT, ref->addr);
 		const RList *fls = r_flag_get_list (ds->core->flags, ref->addr);
 		RListIter *iter2;
 		RFlagItem *fis;
@@ -1255,7 +1254,6 @@ static void ds_show_refs(RDisasmState *ds) {
 		if (cmt) {
 			ds_begin_comment (ds);
 			ds_comment (ds, true, "; (%s)", cmt);
-			free (cmt);
 		}
 		if (ref->type & R_ANAL_REF_TYPE_CALL) {
 			RAnalOp aop;
@@ -2090,23 +2088,19 @@ static void ds_show_comments_right(RDisasmState *ds) {
 		return;
 	}
 	RFlagItem *item = r_flag_get_i (core->flags, ds->at);
-	char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ds->at);
-	char *vartype = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, ds->at);
+	const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ds->at);
+	const char *vartype = r_meta_get_string (core->anal, R_META_TYPE_VARTYPE, ds->at);
 	if (!comment) {
 		if (vartype) {
 			ds->comment = r_str_newf ("%s; %s", COLOR_ARG (ds, color_func_var_type), vartype);
-			free (vartype);
 		} else if (item && item->comment && *item->comment) {
 			ds->ocomment = item->comment;
 			ds->comment = strdup (item->comment);
 		}
 	} else if (vartype) {
 		ds->comment = r_str_newf ("%s; %s %s%s; %s", COLOR_ARG (ds, color_func_var_type), vartype, Color_RESET, COLOR (ds, color_usrcmt), comment);
-		free (vartype);
-		free (comment);
 	} else {
 		ds->comment = r_str_newf ("%s; %s", COLOR_ARG (ds, color_usrcmt), comment);
-		free (comment);
 	}
 	if (!ds->comment || !*ds->comment) {
 		return;
@@ -2405,30 +2399,31 @@ static void ds_update_ref_lines(RDisasmState *ds) {
 static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 	RCore *core = ds->core;
 	int ret;
-	const char *info;
-	Sdb *s = core->anal->sdb_meta;
-	char key[100];
-	ut64 mt_sz = UT64_MAX;
 
-	//handle meta info to fix ds->oplen
-	snprintf (key, sizeof (key) - 1, "meta.0x%"PFMT64x, ds->at);
-	info = sdb_const_get (s, key, 0);
-	if (info) {
-		for (;*info; info++) {
-			switch (*info) {
+	// find the meta item at this offset if any
+	RPVector *metas = r_meta_get_all_at (ds->core->anal, ds->at); // TODO: do in range
+	RAnalMetaItem *meta = NULL;
+	ut64 meta_size = UT64_MAX;
+	if (metas) {
+		void **it;
+		r_pvector_foreach (metas, it) {
+			RIntervalNode *node = *it;
+			RAnalMetaItem *mi = node->data;
+			switch (mi->type) {
 			case R_META_TYPE_DATA:
 			case R_META_TYPE_STRING:
 			case R_META_TYPE_FORMAT:
 			case R_META_TYPE_MAGIC:
 			case R_META_TYPE_HIDE:
-				snprintf (key, sizeof (key) - 1,
-						"meta.%c.0x%"PFMT64x, *info, ds->at);
-				sdb_const_get (s, key, 0);
-				mt_sz = sdb_array_get_num (s, key, 0, 0);
-				//if (mt_sz) { break; }
+			case R_META_TYPE_RUN:
+				meta = mi;
+				meta_size = r_meta_item_size (node->start, node->end);
+				break;
+			default:
 				break;
 			}
 		}
+		r_pvector_free (metas);
 	}
 	if (ds->hint && ds->hint->bits) {
 		if (!ds->core->anal->opt.ignbithints) {
@@ -2450,33 +2445,33 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 	// handle meta here //
 	if (!ds->asm_meta) {
 		int i = 0;
-		// TODO: do in range
-		RAnalMetaItem *meta = r_meta_find_in (core->anal, ds->at, R_META_TYPE_ANY, R_META_WHERE_HERE);
-		if (meta && meta->size > 0) {
+		if (meta && meta_size > 0 && meta->type != R_META_TYPE_HIDE) {
 			// XXX this is just noise. should be rewritten
 			switch (meta->type) {
 			case R_META_TYPE_DATA:
 				if (meta->str) {
 					r_cons_printf (".data: %s\n", meta->str);
 				}
-				i += meta->size;
+				i += meta_size;
 				break;
 			case R_META_TYPE_STRING:
-				i += meta->size;
+				i += meta_size;
 				break;
 			case R_META_TYPE_FORMAT:
 				r_cons_printf (".format : %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				break;
 			case R_META_TYPE_MAGIC:
 				r_cons_printf (".magic : %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				break;
 			case R_META_TYPE_RUN:
 				r_core_cmd0 (core, meta->str);
 				break;
+			default:
+				break;
 			}
-			int sz = R_MIN (16, meta->size - (ds->at - meta->from));
+			int sz = R_MIN (16, meta_size);
 			ds->asmop.size = sz;
 			r_asm_op_set_hexbuf (&ds->asmop, buf, sz);
 			switch (meta->type) {
@@ -2494,9 +2489,6 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 			}
 			ds->oplen = sz; //ds->asmop.size;
 			return i;
-		}
-		if (meta) {
-			r_meta_item_free (meta);
 		}
 	}
 
@@ -2557,8 +2549,8 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 		char *ba = r_asm_op_get_asm (&ds->asmop);
 		*ba = toupper ((ut8)*ba);
 	}
-	if (info && mt_sz != UT64_MAX) {
-		ds->oplen = mt_sz;
+	if (meta && meta_size != UT64_MAX) {
+		ds->oplen = meta_size;
 	}
 	return ret;
 }
@@ -2934,9 +2926,8 @@ static bool ds_print_data_type(RDisasmState *ds, const ut8 *buf, int ib, int siz
 
 static bool ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx, int *mi_type) {
 	bool ret = false;
-	RAnalMetaItem *mi, *fmi;
+	RAnalMetaItem *fmi;
 	RCore *core = ds->core;
-	RListIter *iter;
 	if (!ds->asm_meta) {
 		return false;
 	}
@@ -2947,132 +2938,143 @@ static bool ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx, in
 	snprintf (key, sizeof (key), "meta.0x%" PFMT64x, ds->at);
 	const char *infos = sdb_const_get (s, key, 0);
 #endif
-	RList *list = r_meta_find_list_in (core->anal, ds->at, R_META_TYPE_ANY, R_META_WHERE_HERE);
-	if (list) {
-		bool once = true;
-		fmi = NULL;
-		r_list_foreach (list, iter, mi) {
-			switch (mi->type) {
-			case R_META_TYPE_DATA:
-				if (once) {
-					if (ds->asm_hint_pos == 0) {
-						if (ds->asm_hint_lea) {
-							ds_print_shortcut (ds, mi->from, 0);
-						} else {
-							r_cons_strcat ("   ");
-						}
-					}
-					once = false;
-				}
-				break;
-			case R_META_TYPE_STRING:
-				fmi = mi;
-				break;
-			}
-		}
-		r_list_foreach (list, iter, mi) {
-			char *out = NULL;
-			int hexlen;
-			int delta;
-			if (fmi && mi != fmi) {
-				continue;
-			}
-			if (mi_type) {
-				*mi_type = mi->type;
-			}
-			switch (mi->type) {
-			case R_META_TYPE_STRING:
-			if (mi->str) {
-				bool esc_bslash = core->print->esc_bslash;
-
-				switch (mi->subtype) {
-				case R_STRING_ENC_UTF8:
-					out = r_str_escape_utf8 (mi->str, false, esc_bslash);
-					break;
-				case 0:  /* temporary legacy workaround */
-					esc_bslash = false;
-					/* fallthrough */
-				default:
-					out = r_str_escape_latin1 (mi->str, false, esc_bslash, false);
-				}
-				if (!out) {
-					break;
-				}
-				r_cons_printf ("    .string %s\"%s\"%s ; len=%"PFMT64d,
-						COLOR (ds, color_btext), out, COLOR_RESET (ds),
-						mi->size);
-				free (out);
-				delta = ds->at - mi->from;
-				ds->oplen = mi->size - delta;
-				ds->asmop.size = (int)mi->size;
-				//i += mi->size-1; // wtf?
-				R_FREE (ds->line);
-				R_FREE (ds->line_col);
-				R_FREE (ds->refline);
-				R_FREE (ds->refline2);
-				R_FREE (ds->prev_line_col);
-				ret = true;
-				break;
-			}
-			case R_META_TYPE_HIDE:
-				r_cons_printf ("(%"PFMT64d" bytes hidden)", mi->size);
-				ds->asmop.size = mi->size;
-				ds->oplen = mi->size;
-				ret = true;
-				break;
-			case R_META_TYPE_RUN:
-				r_core_cmdf (core, "%s @ 0x%"PFMT64x, mi->str, ds->at);
-				ds->asmop.size = mi->size;
-				ds->oplen = mi->size;
-				ret = true;
-				break;
-			case R_META_TYPE_DATA:
-				hexlen = len - idx;
-				delta = ds->at - mi->from;
-				if (mi->size < hexlen) {
-					hexlen = mi->size;
-				}
-				ds->oplen = mi->size - delta;
-				core->print->flags &= ~R_PRINT_FLAGS_HEADER;
-				// TODO do not pass a copy in parameter buf that is possibly to small for this
-				// print operation
-				int size = R_MIN (mi->size, len - idx);
-				if (!ds_print_data_type (ds, buf + idx, ds->hint? ds->hint->immbase: 0, size)) {
-					r_cons_printf ("hex length=%" PFMT64d " delta=%d\n", size , delta);
-					r_print_hexdump (core->print, ds->at, buf+idx, hexlen-delta, 16, 1, 1);
-				}
-				core->print->flags |= R_PRINT_FLAGS_HEADER;
-				ds->asmop.size = (int)mi->size;
-				R_FREE (ds->line);
-				R_FREE (ds->line_col);
-				R_FREE (ds->refline);
-				R_FREE (ds->refline2);
-				R_FREE (ds->prev_line_col);
-				ret = true;
-				break;
-			case R_META_TYPE_FORMAT:
-				{
-					r_cons_printf ("pf %s # size=%d\n", mi->str, mi->size);
-					int len_before = r_cons_get_buffer_len ();
-					r_print_format (core->print, ds->at, buf + idx,
-							len - idx, mi->str, R_PRINT_MUSTSEE, NULL, NULL);
-					int len_after = r_cons_get_buffer_len ();
-					const char *cons_buf = r_cons_get_buffer ();
-					if (len_after > len_before && buf && cons_buf[len_after - 1] == '\n') {
-						r_cons_drop (1);
-					}
-					ds->oplen = ds->asmop.size = (int)mi->size;
-					R_FREE (ds->line);
-					R_FREE (ds->refline);
-					R_FREE (ds->refline2);
-					R_FREE (ds->prev_line_col);
-					ret = true;
-				}
-				break;
-			}
-		}
-		r_list_free (list);
+	RPVector *metas = r_meta_get_all_in (core->anal, ds->at, R_META_TYPE_ANY);
+	if (!metas) {
+		return false;
 	}
+	bool once = true;
+	fmi = NULL;
+	void **it;
+	r_pvector_foreach (metas, it) {
+		RIntervalNode *node = *it;
+		RAnalMetaItem *mi = node->data;
+		switch (mi->type) {
+		case R_META_TYPE_DATA:
+			if (once) {
+				if (ds->asm_hint_pos == 0) {
+					if (ds->asm_hint_lea) {
+						ds_print_shortcut (ds, node->start, 0);
+					} else {
+						r_cons_strcat ("   ");
+					}
+				}
+				once = false;
+			}
+			break;
+		case R_META_TYPE_STRING:
+			fmi = mi;
+			break;
+		default:
+			break;
+		}
+	}
+	r_pvector_foreach (metas, it) {
+		RIntervalNode *node = *it;
+		RAnalMetaItem *mi = node->data;
+		ut64 mi_size = r_meta_node_size (node);
+		char *out = NULL;
+		int hexlen;
+		int delta;
+		if (fmi && mi != fmi) {
+			continue;
+		}
+		if (mi_type) {
+			*mi_type = mi->type;
+		}
+		switch (mi->type) {
+		case R_META_TYPE_STRING:
+		if (mi->str) {
+			bool esc_bslash = core->print->esc_bslash;
+
+			switch (mi->subtype) {
+			case R_STRING_ENC_UTF8:
+				out = r_str_escape_utf8 (mi->str, false, esc_bslash);
+				break;
+			case 0:  /* temporary legacy workaround */
+				esc_bslash = false;
+				/* fallthrough */
+			default:
+				out = r_str_escape_latin1 (mi->str, false, esc_bslash, false);
+			}
+			if (!out) {
+				break;
+			}
+			r_cons_printf ("    .string %s\"%s\"%s ; len=%"PFMT64d,
+					COLOR (ds, color_btext), out, COLOR_RESET (ds),
+					mi_size);
+			free (out);
+			delta = ds->at - node->start;
+			ds->oplen = mi_size - delta;
+			ds->asmop.size = (int)mi_size;
+			//i += mi->size-1; // wtf?
+			R_FREE (ds->line);
+			R_FREE (ds->line_col);
+			R_FREE (ds->refline);
+			R_FREE (ds->refline2);
+			R_FREE (ds->prev_line_col);
+			ret = true;
+			break;
+		}
+		case R_META_TYPE_HIDE:
+			r_cons_printf ("(%"PFMT64d" bytes hidden)", mi_size);
+			ds->asmop.size = mi_size;
+			ds->oplen = mi_size;
+			ret = true;
+			break;
+		case R_META_TYPE_RUN:
+			r_core_cmdf (core, "%s @ 0x%"PFMT64x, mi->str, ds->at);
+			ds->asmop.size = mi_size;
+			ds->oplen = mi_size;
+			ret = true;
+			break;
+		case R_META_TYPE_DATA:
+			hexlen = len - idx;
+			delta = ds->at - node->start;
+			if (mi_size < hexlen) {
+				hexlen = mi_size;
+			}
+			ds->oplen = mi_size - delta;
+			core->print->flags &= ~R_PRINT_FLAGS_HEADER;
+			// TODO do not pass a copy in parameter buf that is possibly to small for this
+			// print operation
+			int size = R_MIN (mi_size, len - idx);
+			if (!ds_print_data_type (ds, buf + idx, ds->hint? ds->hint->immbase: 0, size)) {
+				r_cons_printf ("hex length=%" PFMT64d " delta=%d\n", size , delta);
+				r_print_hexdump (core->print, ds->at, buf+idx, hexlen-delta, 16, 1, 1);
+			}
+			core->print->flags |= R_PRINT_FLAGS_HEADER;
+			ds->asmop.size = (int)mi_size;
+			R_FREE (ds->line);
+			R_FREE (ds->line_col);
+			R_FREE (ds->refline);
+			R_FREE (ds->refline2);
+			R_FREE (ds->prev_line_col);
+			ret = true;
+			break;
+		case R_META_TYPE_FORMAT:
+			{
+				r_cons_printf ("pf %s # size=%d\n", mi->str, mi_size);
+				int len_before = r_cons_get_buffer_len ();
+				r_print_format (core->print, ds->at, buf + idx,
+						len - idx, mi->str, R_PRINT_MUSTSEE, NULL, NULL);
+				int len_after = r_cons_get_buffer_len ();
+				const char *cons_buf = r_cons_get_buffer ();
+				if (len_after > len_before && buf && cons_buf[len_after - 1] == '\n') {
+					r_cons_drop (1);
+				}
+				ds->oplen = ds->asmop.size = (int)mi_size;
+				R_FREE (ds->line);
+				R_FREE (ds->refline);
+				R_FREE (ds->refline2);
+				R_FREE (ds->prev_line_col);
+				ret = true;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+	r_pvector_free (metas);
 	return ret;
 }
 
@@ -3515,16 +3517,14 @@ static bool ds_print_core_vmode(RDisasmState *ds, int pos) {
 		}
 	}
 	if (ds->asm_hint_lea) {
-		RAnalMetaItem *mi = r_meta_find (ds->core->anal, ds->at, R_META_TYPE_ANY, R_META_WHERE_HERE);
-		if (mi && mi->from) {
+		ut64 size;
+		RAnalMetaItem *mi = r_meta_get_at (ds->core->anal, ds->at, R_META_TYPE_ANY, &size);
+		if (mi) {
 			int obits = ds->core->assembler->bits;
-			ds->core->assembler->bits = mi->size * 8;
-			getPtr (ds, mi->from, pos);
+			ds->core->assembler->bits = size * 8;
+			getPtr (ds, ds->at, pos);
 			ds->core->assembler->bits = obits;
 			gotShortcut = true;
-		}
-		if (mi) {
-			r_meta_item_free (mi);
 		}
 	}
 	switch (ds->analop.type) {
@@ -3830,16 +3830,14 @@ static inline bool is_filtered_flag(RDisasmState *ds, const char *name) {
 		return false;
 	}
 	ut64 refaddr = ds->analop.ptr;
-	char *anal_flag = r_meta_get_string (ds->core->anal, R_META_TYPE_STRING, refaddr);
+	const char *anal_flag = r_meta_get_string (ds->core->anal, R_META_TYPE_STRING, refaddr);
 	if (anal_flag) {
-		anal_flag = strdup (anal_flag);
-		if (anal_flag) {
-			r_name_filter (anal_flag, -1);
-			if (!strcmp (&name[4], anal_flag)) {
-				free (anal_flag);
+		char *dupped = strdup (anal_flag);
+		if (dupped) {
+			r_name_filter (dupped, -1);
+			if (!strcmp (&name[4], dupped)) {
 				return true;
 			}
-			free (anal_flag);
 		}
 	}
 	return false;
@@ -4562,26 +4560,21 @@ static void delete_last_comment(RDisasmState *ds) {
 	}
 }
 
-static bool can_emulate_metadata(RCore * core, ut64 at) {
+static bool can_emulate_metadata(RCore *core, ut64 at) {
+	// check if there is a meta at the addr that is unemulateable
 	const char *emuskipmeta = r_config_get (core->config, "emu.skip");
-	char key[32];
-	Sdb *s = core->anal->sdb_meta;
-	snprintf (key, sizeof (key)-1, "meta.0x%"PFMT64x, at);
-	const char *infos = sdb_const_get (s, key, 0);
-	if (!infos) {
-		/* no metadata: let's emulate this */
-		return true;
-	}
-	for (; *infos; infos++) {
-		/*
-		 * don't emulate if at least one metadata type
-		 * can't be emulated
-		 */
-		if (*infos != ',' && strchr(emuskipmeta, *infos)) {
-			return false;
+	bool ret = true;
+	RPVector *metas = r_meta_get_all_at (core->anal, at);
+	void **it;
+	r_pvector_foreach (metas, it) {
+		RAnalMetaItem *item = ((RIntervalNode *)*it)->data;
+		if (strchr (emuskipmeta, (char)item->type)) {
+			ret = false;
+			break;
 		}
 	}
-	return true;
+	r_pvector_free (metas);
+	return ret;
 }
 
 static void mipsTweak(RDisasmState *ds) {
@@ -4870,10 +4863,9 @@ static void ds_print_comments_right(RDisasmState *ds) {
 	RCore *core = ds->core;
 	ds_print_relocs (ds);
 	bool is_code = (!ds->hint) || (ds->hint && ds->hint->type != 'd');
-	RAnalMetaItem *mi = r_meta_find (ds->core->anal, ds->at, R_META_TYPE_ANY, R_META_WHERE_HERE);
+	RAnalMetaItem *mi = r_meta_get_at (ds->core->anal, ds->at, R_META_TYPE_ANY, NULL);
 	if (mi) {
 		is_code = mi->type != 'd';
-		r_meta_item_free (mi);
 		mi = NULL;
 	}
 	if (is_code && ds->asm_describe && !ds->has_description) {
@@ -5274,11 +5266,10 @@ toro:
 			if (of != f) {
 				char cmt[32];
 				get_bits_comment (core, f, cmt, sizeof (cmt));
-				char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ds->at);
+				const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ds->at);
 				if (comment) {
 					ds_pre_xrefs (ds, true);
 					r_cons_printf ("; %s\n", comment);
-					free (comment);
 				}
 				r_cons_printf ("%s%s%s (fcn) %s%s%s\n",
 					COLOR (ds, color_fline), core->cons->vline[CORNER_TL],
@@ -6113,12 +6104,11 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 		}
 		/* add comments */
 		{
-			// TODO: slow because we are decoding and encoding b64
-			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, at);
+			// TODO: slow because we are encoding b64
+			const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, at);
 			if (comment) {
 				char *b64comment = sdb_encode ((const ut8*)comment, -1);
 				pj_ks (pj, "comment", b64comment);
-				free (comment);
 				free (b64comment);
 			}
 		}
@@ -6402,27 +6392,27 @@ toro:
 			unsigned int seggrn = r_config_get_i (core->config, "asm.seggrn");
 			r_print_offset_sg (core->print, at, 0, show_offseg, seggrn, show_offdec, 0, NULL);
 		}
-		r_meta_item_free (meta);
-		meta = r_meta_find (core->anal, core->offset + i,
-			R_META_TYPE_ANY, R_META_WHERE_HERE);
-		if (meta && meta->size > 0) {
+		ut64 meta_start = core->offset + i;
+		ut64 meta_size;
+		meta = r_meta_get_at (core->anal, meta_start, R_META_TYPE_ANY, &meta_size);
+		if (meta) {
 			switch (meta->type) {
 			case R_META_TYPE_DATA:
 				//r_cons_printf (".data: %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				{
 					int idx = i;
 					ut64 at = core->offset + i;
 					int hexlen = len - idx;
-					int delta = at - meta->from;
-					if (meta->size < hexlen) {
-						hexlen = meta->size;
+					int delta = at - meta_start;
+					if (meta_size < hexlen) {
+						hexlen = meta_size;
 					}
 					// int oplen = meta->size - delta;
 					core->print->flags &= ~R_PRINT_FLAGS_HEADER;
 					// TODO do not pass a copy in parameter buf that is possibly to small for this
 					// print operation
-					int size = R_MIN (meta->size, len - idx);
+					int size = R_MIN (meta_size, len - idx);
 					ut8 *buf = calloc (size, 1);
 					if (buf) {
 						r_io_read_at (core->io, at, buf, size);
@@ -6441,18 +6431,20 @@ toro:
 				continue;
 			case R_META_TYPE_STRING:
 				//r_cons_printf (".string: %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				continue;
 			case R_META_TYPE_FORMAT:
 				//r_cons_printf (".format : %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				continue;
 			case R_META_TYPE_MAGIC:
 				//r_cons_printf (".magic : %s\n", meta->str);
-				i += meta->size;
+				i += meta_size;
 				continue;
 			case R_META_TYPE_RUN:
 				/* TODO */
+				break;
+			default:
 				break;
 			}
 		}
@@ -6480,10 +6472,9 @@ toro:
 			}
 		}
 		if (fmt == 'C') {
-			char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, core->offset + i);
+			const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, core->offset + i);
 			if (comment) {
 				r_cons_printf ("0x%08"PFMT64x " %s\n", core->offset + i, comment);
-				free (comment);
 			}
 			i += ret;
 			continue;
@@ -6575,7 +6566,6 @@ toro:
 		goto toro;
 	}
 	r_config_set_i (core->config, "asm.marks", asmmarks);
-	r_meta_item_free (meta);
 	r_cons_break_pop ();
 	r_core_seek (core, old_offset, true);
 	return err;

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -602,7 +602,7 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 	}
 	if (opts & R_CORE_PRJ_META) {
 		r_str_write (fd, "# meta\n");
-		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
+		r_meta_print_list_all (core->anal, R_META_TYPE_ANY, 1);
 		r_cons_flush ();
 		r_core_cmd (core, "fV*", 0);
 		r_cons_flush ();
@@ -688,7 +688,7 @@ static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	}
 	if (opts & R_CORE_PRJ_META) {
 		r_str_write (fd, "# meta\n");
-		r_meta_list (core->anal, R_META_TYPE_ANY, 1);
+		r_meta_print_list_all (core->anal, R_META_TYPE_ANY, 1);
 		r_cons_flush ();
 		r_core_cmd (core, "fV*", 0);
 		r_cons_flush ();

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1661,7 +1661,8 @@ static void visual_comma(RCore *core) {
 	bool mouse_state = __holdMouseState (core);
 	ut64 addr = core->offset + (core->print->cur_enabled? core->print->cur: 0);
 	char *comment, *cwd, *cmtfile;
-	comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+	const char *prev_cmt = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
+	comment = prev_cmt ? strdup (prev_cmt) : NULL;
 	cmtfile = r_str_between (comment, ",(", ")");
 	cwd = getcommapath (core);
 	if (!cmtfile) {
@@ -2935,17 +2936,17 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 				} else {
 					int times = R_MAX (1, wheelspeed);
 					// Check if we have a data annotation.
-					RAnalMetaItem *ami = r_meta_find (core->anal,
-							core->offset, R_META_TYPE_DATA,
-							R_META_WHERE_HERE);
+					ut64 amisize;
+					RAnalMetaItem *ami = r_meta_get_at (core->anal,
+														core->offset, R_META_TYPE_DATA,
+														&amisize);
 					if (!ami) {
-						ami = r_meta_find (core->anal,
-								core->offset, R_META_TYPE_STRING,
-								R_META_WHERE_HERE);
+						ami = r_meta_get_at (core->anal,
+											 core->offset, R_META_TYPE_STRING,
+											 &amisize);
 					}
 					if (ami) {
-						r_core_seek_delta (core, ami->size);
-						r_meta_item_free (ami);
+						r_core_seek_delta (core, amisize);
 					} else {
 						int distance = numbuf_pull ();
 						if (distance > 1) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2937,13 +2937,9 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 					int times = R_MAX (1, wheelspeed);
 					// Check if we have a data annotation.
 					ut64 amisize;
-					RAnalMetaItem *ami = r_meta_get_at (core->anal,
-														core->offset, R_META_TYPE_DATA,
-														&amisize);
+					RAnalMetaItem *ami = r_meta_get_at (core->anal, core->offset, R_META_TYPE_DATA, &amisize);
 					if (!ami) {
-						ami = r_meta_get_at (core->anal,
-											 core->offset, R_META_TYPE_STRING,
-											 &amisize);
+						ami = r_meta_get_at (core->anal, core->offset, R_META_TYPE_STRING, &amisize);
 					}
 					if (ami) {
 						r_core_seek_delta (core, amisize);

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -902,7 +902,7 @@ R_API bool r_core_visual_hudstuff(RCore *core) {
 	RAnalMetaItem *mi;
 	r_interval_tree_foreach (&core->anal->meta, it, mi) {
 		if (mi->type == R_META_TYPE_COMMENT) {
-			char *s = r_str_newf ("0x%"PFMT64x" %s", r_interval_tree_iter_get (&it)->start, mi->str);
+			char *s = r_str_newf ("0x%08"PFMT64x" %s", r_interval_tree_iter_get (&it)->start, mi->str);
 			if (s) {
 				r_list_push (list, s);
 			}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -35,17 +35,6 @@ R_LIB_VERSION_HEADER(r_anal);
    bb_has_ops=0 -> 350MB
  */
 
-/* meta */
-typedef struct r_anal_meta_item_t {
-	ut64 from;
-	ut64 to;
-	ut64 size;
-	int type;
-	int subtype;
-	char *str;
-	const RSpace *space;
-} RAnalMetaItem;
-
 typedef struct {
 	struct r_anal_t *anal;
 	int type;
@@ -284,14 +273,7 @@ struct r_anal_type_t {
 	RList *content;
 };
 
-enum {
-	R_META_WHERE_PREV = -1,
-	R_META_WHERE_HERE = 0,
-	R_META_WHERE_NEXT = 1,
-};
-
-enum {
-	R_META_TYPE_NONE = 0,
+typedef enum {
 	R_META_TYPE_ANY = -1,
 	R_META_TYPE_DATA = 'd',
 	R_META_TYPE_CODE = 'c',
@@ -303,7 +285,15 @@ enum {
 	R_META_TYPE_RUN = 'r',
 	R_META_TYPE_HIGHLIGHT = 'H',
 	R_META_TYPE_VARTYPE = 't',
-};
+} RAnalMetaType;
+
+/* meta */
+typedef struct r_anal_meta_item_t {
+	RAnalMetaType type;
+	int subtype;
+	char *str;
+	const RSpace *space;
+} RAnalMetaItem;
 
 // anal
 typedef enum {
@@ -602,12 +592,10 @@ typedef struct r_anal_t {
 	RList *plugins;
 	Sdb *sdb_types;
 	Sdb *sdb_fmts;
-	Sdb *sdb_meta; // TODO: Future r_meta api
 	Sdb *sdb_zigns;
 	HtUP *dict_refs;
 	HtUP *dict_xrefs;
 	bool recursive_noreturn;
-	RSpaces meta_spaces;
 	RSpaces zign_spaces;
 	char *zign_path;
 	PrintfCallback cb_printf;
@@ -624,6 +612,8 @@ typedef struct r_anal_t {
 	RBTree/*<RAnalArchHintRecord>*/ arch_hints;
 	RBTree/*<RAnalArchBitsRecord>*/ bits_hints;
 	RHintCb hint_cbs;
+	RIntervalTree meta;
+	RSpaces meta_spaces;
 	Sdb *sdb_fcnsign; // OK
 	Sdb *sdb_cc; // calling conventions
 	Sdb *sdb_classes;
@@ -1727,33 +1717,77 @@ R_API void r_anal_data_free (RAnalData *d);
 #include <r_cons.h>
 R_API char *r_anal_data_to_string(RAnalData *d, RConsPrintablePalette *pal);
 
-R_API void r_meta_free(RAnal *m);
-R_API RList *r_meta_find_list_in(RAnal *a, ut64 at, int type, int where);
-R_API void r_meta_space_unset_for(RAnal *a, const RSpace *space);
-R_API int r_meta_space_count_for(RAnal *a, const RSpace *space_name);
-R_API RList *r_meta_enumerate(RAnal *a, int type);
-R_API int r_meta_count(RAnal *m, int type, ut64 from, ut64 to);
-R_API char *r_meta_get_string(RAnal *m, int type, ut64 addr);
-R_API bool r_meta_set_string(RAnal *m, int type, ut64 addr, const char *s);
-R_API int r_meta_get_size(RAnal *a, int type);
-R_API int r_meta_del(RAnal *m, int type, ut64 from, ut64 size);
-R_API int r_meta_add(RAnal *m, int type, ut64 from, ut64 to, const char *str);
-R_API int r_meta_add_with_subtype(RAnal *m, int type, int subtype, ut64 from, ut64 to, const char *str);
-R_API RAnalMetaItem *r_meta_find(RAnal *m, ut64 off, int type, int where);
-R_API RAnalMetaItem *r_meta_find_any_except(RAnal *m, ut64 at, int type, int where);
-R_API RAnalMetaItem *r_meta_find_in(RAnal *m, ut64 off, int type, int where);
-R_API int r_meta_cleanup(RAnal *m, ut64 from, ut64 to);
-R_API const char *r_meta_type_to_string(int type);
-R_API RList *r_meta_enumerate(RAnal *a, int type);
-R_API int r_meta_list(RAnal *m, int type, int rad);
-R_API int r_meta_list_at(RAnal *m, int type, int rad, ut64 addr);
-R_API int r_meta_list_cb(RAnal *m, int type, int rad, SdbForeachCallback cb, void *user, ut64 addr);
-R_API void r_meta_list_offset(RAnal *m, ut64 addr, char input);
-R_API void r_meta_item_free(void *_item);
-R_API RAnalMetaItem *r_meta_item_new(int type);
-R_API bool r_meta_deserialize_val(RAnal *a, RAnalMetaItem *it, int type, ut64 from, const char *v);
-R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, int rad, PJ *pj, bool show_full);
+/* meta
+ *
+ * Meta uses Condret's Klemmbaustein Priciple, i.e. intervals are defined inclusive/inclusive.
+ * A meta item from 0x42 to 0x42 has a size of 1. Items with size 0 do not exist.
+ * Meta items are allowed to overlap and the internal data structure allows for multiple meta items
+ * starting at the same address.
+ * Meta items are saved in an RIntervalTree. To access the interval of an item, use the members of RIntervalNode.
+ */
+
+static inline ut64 r_meta_item_size(ut64 start, ut64 end) {
+	// meta items use inclusive/inclusive intervals
+	return end - start + 1;
+}
+
+static inline ut64 r_meta_node_size(RIntervalNode *node) {
+	return r_meta_item_size (node->start, node->end);
+}
+
+// Set a meta item at addr with the given contents in the current space.
+// If there already exists an item with this type and space at addr (regardless of its size) it will be overwritten.
+R_API bool r_meta_set(RAnal *a, RAnalMetaType type, ut64 addr, ut64 size, const char *str);
+
+// Same as r_meta_set() but also sets the subtype.
+R_API bool r_meta_set_with_subtype(RAnal *m, RAnalMetaType type, int subtype, ut64 addr, ut64 size, const char *str);
+
+// Delete all meta items in the current space that intersect with the given interval.
+// If size == UT64_MAX, everything in the current space will be deleted.
+R_API void r_meta_del(RAnal *a, RAnalMetaType type, ut64 addr, ut64 size);
+
+// Same as r_meta_set() with a size of 1.
+R_API bool r_meta_set_string(RAnal *a, RAnalMetaType type, ut64 addr, const char *s);
+
+// Convenience function to get the str content of the item at addr with given type in the current space.
+R_API const char *r_meta_get_string(RAnal *a, RAnalMetaType type, ut64 addr);
+
+// Convenience function to add an R_META_TYPE_DATA item at the given addr in the current space.
 R_API void r_meta_set_data_at(RAnal *a, ut64 addr, ut64 wordsz);
+
+// Returns the item with given type that starts at addr in the current space or NULL. The size of this item  optionally returned through size.
+R_API RAnalMetaItem *r_meta_get_at(RAnal *a, ut64 addr, RAnalMetaType type, R_OUT R_NULLABLE ut64 *size);
+
+// Returns the node for one meta item with the given type that contains addr in the current space or NULL.
+// To get all the nodes, use r_meta_get_all_in().
+R_API RIntervalNode *r_meta_get_in(RAnal *a, ut64 addr, RAnalMetaType type);
+
+// Returns all nodes for items starting at the given address in the current space.
+R_API RPVector/*<RIntervalNode<RMetaItem> *>*/ *r_meta_get_all_at(RAnal *a, ut64 at);
+
+// Returns all nodes for items with the given type containing the given address in the current space.
+R_API RPVector/*<RIntervalNode<RMetaItem> *>*/ *r_meta_get_all_in(RAnal *a, ut64 at, RAnalMetaType type);
+
+// Returns all nodes for items with the given type intersecting the given interval in the current space.
+R_API RPVector/*<RIntervalNode<RMetaItem> *>*/ *r_meta_get_all_intersect(RAnal *a, ut64 start, ut64 size, RAnalMetaType type);
+
+// Delete all meta items in the given space
+R_API void r_meta_space_unset_for(RAnal *a, const RSpace *space);
+
+// Returns the number of meta items in the given space
+R_API int r_meta_space_count_for(RAnal *a, const RSpace *space);
+
+// Shift all meta items by the given delta, for rebasing between different memory layouts.
+R_API void r_meta_rebase(RAnal *anal, ut64 diff);
+
+// Calculate the total size covered by meta items of the given type.
+R_API ut64 r_meta_get_size(RAnal *a, RAnalMetaType type);
+
+R_API const char *r_meta_type_to_string(int type);
+R_API void r_meta_print(RAnal *a, RAnalMetaItem *d, ut64 start, ut64 size, int rad, PJ *pj, bool show_full);
+R_API void r_meta_print_list_all(RAnal *a, int type, int rad);
+R_API void r_meta_print_list_at(RAnal *a, ut64 addr, int rad);
+R_API void r_meta_print_list_in_function(RAnal *a, int type, int rad, ut64 addr);
 
 /* hints */
 

--- a/test/db/cmd/cmd_repeats
+++ b/test/db/cmd/cmd_repeats
@@ -23,6 +23,19 @@ xmm0l:
 EOF
 RUN
 
+NAME=repeat comments
+FILE=-
+CMDS=<<EOF
+CC aero@0x42
+CC pause@0x43
+CC plus@0x1337
+s@@@C:p*
+EOF
+EXPECT=<<EOF
+0x43
+0x1337
+EOF
+RUN
 
 NAME=3p8
 FILE=-

--- a/test/db/cmd/metadata
+++ b/test/db/cmd/metadata
@@ -373,12 +373,12 @@ EXPECT=<<EOF
 ----
 0x00000380 magic 8 wwww
 ----
+0x00000000 ascii[12] "hello world"
 0x00000000 CCu "Hello!"
 0x00000100 data Cd 3
-0x00000300 format 4 x
 0x00000200 hidden Ch 2
+0x00000300 format 4 x
 0x00000380 magic 8 wwww
-0x00000000 ascii[12] "hello world"
 ----
 Cs 12 @ 0x00000000 # hello world
 ----
@@ -392,12 +392,12 @@ CCu base64:SGVsbG8h @ 0x00000000
 ----
 Cm 8 wwww @ 0x00000380
 ----
+Cs 12 @ 0x00000000 # hello world
 CCu base64:SGVsbG8h @ 0x00000000
 Cd 3 @ 0x00000100
-Cf 4 x @ 0x00000300
 Ch 2 @ 0x00000200
+Cf 4 x @ 0x00000300
 Cm 8 wwww @ 0x00000380
-Cs 12 @ 0x00000000 # hello world
 ----
 [{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"latin1","ascii":true}]
 ----
@@ -411,7 +411,7 @@ Cs 12 @ 0x00000000 # hello world
 ----
 [{"offset":896,"type":"Cm","name":"wwww"}]
 ----
-[{"offset":0,"type":"CCu","name":"Hello!"},{"offset":256,"type":"Cd","name":"3","size":3},{"offset":768,"type":"Cf","name":"x"},{"offset":512,"type":"Ch","name":"2"},{"offset":896,"type":"Cm","name":"wwww"},{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"latin1","ascii":true}]
+[{"offset":0,"type":"Cs","name":"aGVsbG8gd29ybGQ=","enc":"latin1","ascii":true},{"offset":0,"type":"CCu","name":"Hello!"},{"offset":256,"type":"Cd","name":"3","size":3},{"offset":512,"type":"Ch","name":"2"},{"offset":768,"type":"Cf","name":"x"},{"offset":896,"type":"Cm","name":"wwww"}]
 EOF
 RUN
 
@@ -615,8 +615,8 @@ Cf-
 C
 EOF
 EXPECT=<<EOF
-0x00000100 format 8 xx
 0x00000100 ascii[4] "abcd"
+0x00000100 format 8 xx
 ----
 0x00000100 format 8 xx
 ----
@@ -637,9 +637,9 @@ C-
 C
 EOF
 EXPECT=<<EOF
-0x00000100 CCu "a string"
-0x00000100 format 8 xx
 0x00000100 ascii[4] "abcd"
+0x00000100 format 8 xx
+0x00000100 CCu "a string"
 ----
 EOF
 RUN
@@ -700,7 +700,7 @@ C.
 EOF
 EXPECT=<<EOF
 0x0007a23c ascii[13] "match_symbol"
-0x00083fc4 CCu "[14] -rw- section size 4 named .init_array"
 0x00083fc4 data Cd 4
+0x00083fc4 CCu "[14] -rw- section size 4 named .init_array"
 EOF
 RUN

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -72,26 +72,26 @@ EXPECT=<<EOF
 0x08048300 CCu "[13] -r-x section size 404 named .text"
 0x08048494 CCu "[14] -r-x section size 20 named .fini"
 0x080484a8 CCu "[15] -r-- section size 21 named .rodata"
+0x080484b0 ascii[13] "Hello world!"
 0x080484c0 CCu "[16] -r-- section size 44 named .eh_frame_hdr"
 0x080484ec CCu "[17] -r-- section size 176 named .eh_frame"
+0x0804959c data Cd 4
 0x0804959c CCu "[18] -rw- section size 4 named .init_array"
+0x080495a0 data Cd 4
 0x080495a0 CCu "[19] -rw- section size 4 named .fini_array"
 0x080495a4 CCu "[20] -rw- section size 4 named .jcr"
 0x080495a8 CCu "[21] -rw- section size 232 named .dynamic"
-0x08049690 CCu "[22] -rw- section size 4 named .got"
-0x08049694 CCu "[23] -rw- section size 24 named .got.plt"
-0x080496ac CCu "[24] -rw- section size 8 named .data"
-0x080496b4 CCu "[25] -rw- section size 4 named .bss"
-0x0804959c data Cd 4
-0x080495a0 data Cd 4
 0x08049690 data Cd 4
+0x08049690 CCu "[22] -rw- section size 4 named .got"
 0x08049694 data Cd 4
+0x08049694 CCu "[23] -rw- section size 24 named .got.plt"
 0x08049698 data Cd 4
 0x0804969c data Cd 4
 0x080496a0 data Cd 4
 0x080496a4 data Cd 4
 0x080496a8 data Cd 4
-0x080484b0 ascii[13] "Hello world!"
+0x080496ac CCu "[24] -rw- section size 8 named .data"
+0x080496b4 CCu "[25] -rw- section size 4 named .bss"
 EOF
 RUN
 
@@ -115,26 +115,26 @@ CCu base64:WzEyXSAtci14IHNlY3Rpb24gc2l6ZSA2NCBuYW1lZCAucGx0 @ 0x080482c0
 CCu base64:WzEzXSAtci14IHNlY3Rpb24gc2l6ZSA0MDQgbmFtZWQgLnRleHQ= @ 0x08048300
 CCu base64:WzE0XSAtci14IHNlY3Rpb24gc2l6ZSAyMCBuYW1lZCAuZmluaQ== @ 0x08048494
 CCu base64:WzE1XSAtci0tIHNlY3Rpb24gc2l6ZSAyMSBuYW1lZCAucm9kYXRh @ 0x080484a8
+Cs 13 @ 0x080484b0 # Hello world!
 CCu base64:WzE2XSAtci0tIHNlY3Rpb24gc2l6ZSA0NCBuYW1lZCAuZWhfZnJhbWVfaGRy @ 0x080484c0
 CCu base64:WzE3XSAtci0tIHNlY3Rpb24gc2l6ZSAxNzYgbmFtZWQgLmVoX2ZyYW1l @ 0x080484ec
+Cd 4 @ 0x0804959c
 CCu base64:WzE4XSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5pbml0X2FycmF5 @ 0x0804959c
+Cd 4 @ 0x080495a0
 CCu base64:WzE5XSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5maW5pX2FycmF5 @ 0x080495a0
 CCu base64:WzIwXSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5qY3I= @ 0x080495a4
 CCu base64:WzIxXSAtcnctIHNlY3Rpb24gc2l6ZSAyMzIgbmFtZWQgLmR5bmFtaWM= @ 0x080495a8
-CCu base64:WzIyXSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5nb3Q= @ 0x08049690
-CCu base64:WzIzXSAtcnctIHNlY3Rpb24gc2l6ZSAyNCBuYW1lZCAuZ290LnBsdA== @ 0x08049694
-CCu base64:WzI0XSAtcnctIHNlY3Rpb24gc2l6ZSA4IG5hbWVkIC5kYXRh @ 0x080496ac
-CCu base64:WzI1XSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5ic3M= @ 0x080496b4
-Cd 4 @ 0x0804959c
-Cd 4 @ 0x080495a0
 Cd 4 @ 0x08049690
+CCu base64:WzIyXSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5nb3Q= @ 0x08049690
 Cd 4 @ 0x08049694
+CCu base64:WzIzXSAtcnctIHNlY3Rpb24gc2l6ZSAyNCBuYW1lZCAuZ290LnBsdA== @ 0x08049694
 Cd 4 @ 0x08049698
 Cd 4 @ 0x0804969c
 Cd 4 @ 0x080496a0
 Cd 4 @ 0x080496a4
 Cd 4 @ 0x080496a8
-Cs 13 @ 0x080484b0 # Hello world!
+CCu base64:WzI0XSAtcnctIHNlY3Rpb24gc2l6ZSA4IG5hbWVkIC5kYXRh @ 0x080496ac
+CCu base64:WzI1XSAtcnctIHNlY3Rpb24gc2l6ZSA0IG5hbWVkIC5ic3M= @ 0x080496b4
 EOF
 RUN
 

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -5,6 +5,7 @@ if get_option('enable_tests')
     'anal_block',
     'anal_function',
     'anal_hints',
+    'anal_meta',
     'anal_var',
     'anal_xrefs',
     'base64',

--- a/test/unit/test_anal_meta.c
+++ b/test/unit/test_anal_meta.c
@@ -1,0 +1,609 @@
+
+#include <r_anal.h>
+
+#include "minunit.h"
+
+bool test_meta_set() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "summer of love");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	bool found[3] = { 0 };
+	size_t count = 0;
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x103, "node end (inclusive)");
+			mu_assert_null (item->str, "no string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x100, "node end (inclusive)");
+			mu_assert_streq (item->str, "summer of love", "comment string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[1] = true;
+			break;
+		case R_META_TYPE_STRING:
+			mu_assert_eq (node->start, 0x200, "node start");
+			mu_assert_eq (node->end, 0x22f, "node end (inclusive)");
+			mu_assert_streq (item->str, "true confessions", "string string");
+			mu_assert_eq (item->subtype, R_STRING_ENC_UTF8, "subtype");
+			found[2] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert_eq (count, 3, "set count");
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	mu_assert ("meta 2", found[2]);
+
+	// Override an item, changing only its size
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 8, NULL);
+
+	count = 0;
+	found[0] = found[1] = found[2] = false;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x107, "node end (inclusive)");
+			mu_assert_null (item->str, "no string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x100, "node end (inclusive)");
+			mu_assert_streq (item->str, "summer of love", "comment string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[1] = true;
+			break;
+		case R_META_TYPE_STRING:
+			mu_assert_eq (node->start, 0x200, "node start");
+			mu_assert_eq (node->end, 0x22f, "node end (inclusive)");
+			mu_assert_streq (item->str, "true confessions", "string string");
+			mu_assert_eq (item->subtype, R_STRING_ENC_UTF8, "subtype");
+			found[2] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert_eq (count, 3, "set count");
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	mu_assert ("meta 2", found[2]);
+
+	// Override items, changing their contents
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "this ain't the summer of love");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF16LE, 0x200, 0x40, "e.t.i. (extra terrestrial intelligence)");
+
+	count = 0;
+	found[0] = found[1] = found[2] = false;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x107, "node end (inclusive)");
+			mu_assert_null (item->str, "no string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x100, "node end (inclusive)");
+			mu_assert_streq (item->str, "this ain't the summer of love", "comment string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[1] = true;
+			break;
+		case R_META_TYPE_STRING:
+			mu_assert_eq (node->start, 0x200, "node start");
+			mu_assert_eq (node->end, 0x23f, "node end (inclusive)");
+			mu_assert_streq (item->str, "e.t.i. (extra terrestrial intelligence)", "string string");
+			mu_assert_eq (item->subtype, R_STRING_ENC_UTF16LE, "subtype");
+			found[2] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert_eq (count, 3, "set count");
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	mu_assert ("meta 2", found[2]);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_get_at() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	RAnalMetaItem *item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_notnull (item, "get item");
+	mu_assert_streq (item->str, "vera gemini", "get contents");
+
+	ut64 size;
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, &size);
+	mu_assert_notnull (item, "get item");
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "get contents");
+	mu_assert_eq (size, 4, "get size");
+
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_ANY, NULL);
+	mu_assert_notnull (item, "get item");
+	mu_assert_streq (item->str, "true confessions", "get contents");
+
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_ANY, NULL);
+	mu_assert_notnull (item, "get item");
+	// which one we get is undefined here (intended)
+
+	item = r_meta_get_at (anal, 0x1ff, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "get item");
+	item = r_meta_get_at (anal, 0x201, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "get item");
+	item = r_meta_get_at (anal, 0xff, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "get item");
+	item = r_meta_get_at (anal, 0x101, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "get item");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_get_in() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+
+	RIntervalNode *node = r_meta_get_in (anal, 0x100, R_META_TYPE_COMMENT);
+	mu_assert_notnull (node, "get item");
+	RAnalMetaItem *item = node->data;
+	mu_assert_streq (item->str, "vera gemini", "get contents");
+	node = r_meta_get_in (anal, 0xff, R_META_TYPE_COMMENT);
+	mu_assert_null (node, "get item");
+	node = r_meta_get_in (anal, 0x101, R_META_TYPE_COMMENT);
+	mu_assert_null (node, "get item");
+
+	node = r_meta_get_in (anal, 0x100, R_META_TYPE_DATA);
+	mu_assert_notnull (node, "get item");
+	item = node->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "get contents");
+	node = r_meta_get_in (anal, 0xff, R_META_TYPE_DATA);
+	mu_assert_null (node, "get item");
+	node = r_meta_get_in (anal, 0x103, R_META_TYPE_DATA);
+	mu_assert_notnull (node, "get item");
+	item = node->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "get contents");
+	node = r_meta_get_in (anal, 0x104, R_META_TYPE_DATA);
+	mu_assert_null (node, "get item");
+
+	node = r_meta_get_in (anal, 0x103, R_META_TYPE_ANY);
+	mu_assert_notnull (node, "get item");
+	item = node->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "get contents");
+
+	node = r_meta_get_in (anal, 0x100, R_META_TYPE_ANY);
+	mu_assert_notnull (node, "get item");
+	// which one we get is undefined here (intended)
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_get_all_at() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	RPVector *items = r_meta_get_all_at (anal, 0x100);
+	mu_assert_eq (r_pvector_len (items), 2, "all count");
+	void **it;
+	bool found[2] = { 0 };
+	r_pvector_foreach (items, it) {
+		RAnalMetaItem *item = ((RIntervalNode *)*it)->data;
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			found[1] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	r_pvector_free (items);
+
+	items = r_meta_get_all_at (anal, 0xff);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_at (anal, 0x101);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_get_all_in() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	RPVector *items = r_meta_get_all_in (anal, 0x100, R_META_TYPE_ANY);
+	mu_assert_eq (r_pvector_len (items), 2, "all count");
+	void **it;
+	bool found[2] = { 0 };
+	r_pvector_foreach (items, it) {
+		RAnalMetaItem *item = ((RIntervalNode *)*it)->data;
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			found[1] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0x100, R_META_TYPE_COMMENT);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	RAnalMetaItem *item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_streq (item->str, "vera gemini", "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0x100, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0xff, R_META_TYPE_ANY);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0x101, R_META_TYPE_COMMENT);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0x103, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_in (anal, 0x104, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_get_all_intersect() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	RPVector *items = r_meta_get_all_intersect (anal, 0x100, 1, R_META_TYPE_ANY);
+	mu_assert_eq (r_pvector_len (items), 2, "all count");
+	void **it;
+	bool found[2] = { 0 };
+	r_pvector_foreach (items, it) {
+		RAnalMetaItem *item = ((RIntervalNode *)*it)->data;
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			found[1] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x100, 1, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	RAnalMetaItem *item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x100, 0x300, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x0, 0x300, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x0, 0x100, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x103, 0x300, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 1, "all count");
+	item = ((RIntervalNode *)r_pvector_at (items, 0))->data;
+	mu_assert_eq (item->type, R_META_TYPE_DATA, "contents");
+	r_pvector_free (items);
+
+	items = r_meta_get_all_intersect (anal, 0x104, 0x300, R_META_TYPE_DATA);
+	mu_assert_eq (r_pvector_len (items), 0, "all count");
+	r_pvector_free (items);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_del() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	r_meta_del (anal, R_META_TYPE_COMMENT, 0x100, 1);
+	RAnalMetaItem *item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_notnull (item, "item not deleted");
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_STRING, NULL);
+	mu_assert_notnull (item, "item not deleted");
+
+	// reset
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+
+	r_meta_del (anal, R_META_TYPE_COMMENT, 0x0, 0x500);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_notnull (item, "item not deleted");
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_STRING, NULL);
+	mu_assert_notnull (item, "item not deleted");
+
+	// reset
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+
+	r_meta_del (anal, R_META_TYPE_COMMENT, 0, UT64_MAX);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_notnull (item, "item not deleted");
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_STRING, NULL);
+	mu_assert_notnull (item, "item not deleted");
+
+	// reset
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+
+	r_meta_del (anal, R_META_TYPE_ANY, 0, 0x500);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_STRING, NULL);
+	mu_assert_null (item, "item deleted");
+
+	// reset
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "vera gemini");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	r_meta_del (anal, R_META_TYPE_ANY, 0, UT64_MAX);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_COMMENT, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_null (item, "item deleted");
+	item = r_meta_get_at (anal, 0x200, R_META_TYPE_STRING, NULL);
+	mu_assert_null (item, "item deleted");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_rebase() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x200, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x200, "summer of love");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x300, 0x30, "true confessions");
+	r_meta_rebase (anal, -0x100);
+
+	bool found[3] = { 0 };
+	size_t count = 0;
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+		RIntervalNode *node = r_interval_tree_iter_get (&it);
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x103, "node end (inclusive)");
+			mu_assert_null (item->str, "no string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			mu_assert_eq (node->start, 0x100, "node start");
+			mu_assert_eq (node->end, 0x100, "node end (inclusive)");
+			mu_assert_streq (item->str, "summer of love", "comment string");
+			mu_assert_eq (item->subtype, 0, "no subtype");
+			found[1] = true;
+			break;
+		case R_META_TYPE_STRING:
+			mu_assert_eq (node->start, 0x200, "node start");
+			mu_assert_eq (node->end, 0x22f, "node end (inclusive)");
+			mu_assert_streq (item->str, "true confessions", "string string");
+			mu_assert_eq (item->subtype, R_STRING_ENC_UTF8, "subtype");
+			found[2] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert_eq (count, 3, "set count");
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	mu_assert ("meta 2", found[2]);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool test_meta_spaces() {
+	RAnal *anal = r_anal_new ();
+
+	r_meta_set (anal, R_META_TYPE_DATA, 0x100, 4, NULL);
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "summer of love");
+	r_meta_set_with_subtype (anal, R_META_TYPE_STRING, R_STRING_ENC_UTF8, 0x200, 0x30, "true confessions");
+
+	r_spaces_set (&anal->meta_spaces, "fear");
+
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "reaper");
+
+	bool found[4] = { 0 };
+	size_t count = 0;
+	RIntervalTreeIter it;
+	RAnalMetaItem *item;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+		switch (item->type) {
+		case R_META_TYPE_DATA:
+			mu_assert_null (item->space, "space");
+			found[0] = true;
+			break;
+		case R_META_TYPE_COMMENT:
+			if (item->space) {
+				mu_assert_streq (item->str, "reaper", "comment string");
+				mu_assert_ptreq (item->space, r_spaces_get (&anal->meta_spaces, "fear"), "space");
+				found[3] = true;
+			} else {
+				mu_assert_streq (item->str, "summer of love", "comment string");
+				found[1] = true;
+			}
+			break;
+		case R_META_TYPE_STRING:
+			mu_assert_null (item->space, "space");
+			found[2] = true;
+			break;
+		default:
+			break;
+		}
+	}
+	mu_assert_eq (count, 4, "set count");
+	mu_assert ("meta 0", found[0]);
+	mu_assert ("meta 1", found[1]);
+	mu_assert ("meta 2", found[2]);
+	mu_assert ("meta 3", found[3]);
+
+	RAnalMetaItem *reaper_item = r_meta_get_at (anal, 0x100, R_META_TYPE_ANY, NULL);
+	mu_assert_notnull (reaper_item, "get item");
+	mu_assert_streq (reaper_item->str, "reaper", "comment string");
+
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_DATA, NULL);
+	mu_assert_null (item, "masked by space");
+
+	RIntervalNode *node = r_meta_get_in (anal, 0x100, R_META_TYPE_COMMENT);
+	mu_assert_notnull (node, "get item");
+	mu_assert_ptreq (node->data, reaper_item, "masked by space");
+	node = r_meta_get_in (anal, 0x100, R_META_TYPE_DATA);
+	mu_assert_null (node, "masked by space");
+
+	RPVector *nodes = r_meta_get_all_at (anal, 0x100);
+	mu_assert_eq (r_pvector_len (nodes), 1, "all count");
+	mu_assert_ptreq (((RIntervalNode *)r_pvector_at (nodes, 0))->data, reaper_item, "all masked");
+	r_pvector_free (nodes);
+
+	nodes = r_meta_get_all_in (anal, 0x100, R_META_TYPE_ANY);
+	mu_assert_eq (r_pvector_len (nodes), 1, "all count");
+	mu_assert_ptreq (((RIntervalNode *)r_pvector_at (nodes, 0))->data, reaper_item, "all masked");
+	r_pvector_free (nodes);
+
+	nodes = r_meta_get_all_intersect (anal, 0x0, 0x500, R_META_TYPE_ANY);
+	mu_assert_eq (r_pvector_len (nodes), 1, "all count");
+	mu_assert_ptreq (((RIntervalNode *)r_pvector_at (nodes, 0))->data, reaper_item, "all masked");
+	r_pvector_free (nodes);
+
+	// delete
+	r_meta_del (anal, R_META_TYPE_ANY, 0, 0x500);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "reaper deleted");
+	count = 0;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+	}
+	mu_assert_eq (count, 3, "masked untouched");
+
+	// reset
+	r_meta_set_string (anal, R_META_TYPE_COMMENT, 0x100, "reaper");
+
+	r_meta_del (anal, R_META_TYPE_ANY, 0, UT64_MAX);
+	item = r_meta_get_at (anal, 0x100, R_META_TYPE_ANY, NULL);
+	mu_assert_null (item, "reaper deleted");
+	count = 0;
+	r_interval_tree_foreach (&anal->meta, it, item) {
+		count++;
+	}
+	mu_assert_eq (count, 3, "masked untouched");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test(test_meta_set);
+	mu_run_test(test_meta_get_at);
+	mu_run_test(test_meta_get_in);
+	mu_run_test(test_meta_get_all_at);
+	mu_run_test(test_meta_get_all_in);
+	mu_run_test(test_meta_get_all_intersect);
+	mu_run_test(test_meta_del);
+	mu_run_test(test_meta_rebase);
+	mu_run_test(test_meta_spaces);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}


### PR DESCRIPTION
This removes meta from SDB and instead stores it in an RIntervalTree. More info on the storage can be found in the comments in `r_anal.h`.

One important change in the API is that it now returns weak references into the existing RAnalMetaItems, so callers must not free the returned stuff anymore!

This also includes some minor convenience changes in RIntervalTree and fixes for `@@@C:` in both old and new shells because that had to be refactored somehow to conform to the new API but it was completely broken so I fixed it as a side effect.