### PR TITLE
Fix #16543 - bin.str.enc affects izz + ascii is now alias for latin1

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -407,7 +407,23 @@ static void get_strings_range(RBinFile *bf, RList *list, int min, int raw, ut64 
 			return;
 		}
 	}
-	string_scan_range (list, bf, min, from, to, -1, raw, section);
+	int type;
+	const char *enc = bf->rbin->strenc;
+	if (!enc) {
+		type = R_STRING_TYPE_DETECT;
+	} else if (!strcmp (enc, "latin1")) {
+		type = R_STRING_TYPE_ASCII;
+	} else if (!strcmp (enc, "utf8")) {
+		type = R_STRING_TYPE_UTF8;
+	} else if (!strcmp (enc, "utf16le")) {
+		type = R_STRING_TYPE_WIDE;
+	} else if (!strcmp (enc, "utf32le")) {
+		type = R_STRING_TYPE_WIDE32;
+	} else { // TODO utf16be, utf32be
+		eprintf ("ERROR: encoding %s not supported\n", enc);
+		return;
+	}
+	string_scan_range (list, bf, min, from, to, type, raw, section);
 }
 
 R_IPI RBinFile *r_bin_file_new(RBin *bin, const char *file, ut64 file_sz, int rawstr, int fd, const char *xtrname, Sdb *sdb, bool steal_ptr) {

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -465,6 +465,7 @@ R_API void r_bin_free(RBin *bin) {
 		bin->file = NULL;
 		free (bin->force);
 		free (bin->srcdir);
+		free (bin->strenc);
 		//r_bin_free_bin_files (bin);
 		r_list_free (bin->binfiles);
 		r_list_free (bin->binxtrs);
@@ -848,6 +849,7 @@ R_API RBin *r_bin_new() {
 	bin->plugins = r_list_newf ((RListFree)r_bin_plugin_free);
 	bin->minstrlen = 0;
 	bin->strpurge = NULL;
+	bin->strenc = NULL;
 	bin->want_dbginfo = true;
 	bin->cur = NULL;
 	bin->ids = r_id_storage_new (0, ST32_MAX);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -894,6 +894,7 @@ typedef struct {
 } namealiases_pair;
 
 static bool cb_binstrenc (void *user, void *data) {
+	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode *)data;
 	if (node->value[0] == '?') {
 		print_node_options (node);
@@ -904,7 +905,7 @@ static bool cb_binstrenc (void *user, void *data) {
 	}
 	const namealiases_pair names[] = {
 		{ "guess", NULL },
-		{ "latin1", NULL },
+		{ "latin1", "ascii" },
 		{ "utf8", "utf-8" },
 		{ "utf16le", "utf-16le,utf16-le" },
 		{ "utf32le", "utf-32le,utf32-le" },
@@ -922,6 +923,8 @@ static bool cb_binstrenc (void *user, void *data) {
 			free (node->value);
 			node->value = strdup (pair->name);
 			free (enc);
+			free (core->bin->strenc);
+			core->bin->strenc = !strcmp (node->value, "guess") ? NULL : strdup (node->value);
 			return true;
 		}
 	}
@@ -3154,7 +3157,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("bin.maxstrbuf", 1024*1024*10, & cb_binmaxstrbuf, "Maximum size of range to load strings from");
 	n = NODECB ("bin.str.enc", "guess", &cb_binstrenc);
 	SETDESC (n, "Default string encoding of binary");
-	SETOPTIONS (n, "latin1", "utf8", "utf16le", "utf32le", "utf16be", "utf32be", "guess", NULL);
+	SETOPTIONS (n, "ascii", "latin1", "utf8", "utf16le", "utf32le", "utf16be", "utf32be", "guess", NULL);
 	SETCB ("bin.prefix", "", &cb_binprefix, "Prefix all symbols/sections/relocs with a specific string");
 	SETCB ("bin.rawstr", "false", &cb_rawstr, "Load strings from raw binaries");
 	SETCB ("bin.strings", "true", &cb_binstrings, "Load strings from rbin on startup");

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -330,6 +330,7 @@ typedef struct r_bin_t {
 	char *strpurge; // purge false positive strings
 	char *srcdir; // dir.source
 	char *prefix; // bin.prefix
+	char *strenc;
 	ut64 filter_rules;
 	bool demanglercmd;
 	bool verbose;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3527,6 +3527,26 @@ nth paddr      vaddr      len size section type  string
 EOF
 RUN
 
+NAME=izz and bin.str.enc
+FILE=-
+CMDS=<<EOF
+wz k\0i\0abcdefgh
+(izzenc enc; e bin.str.enc=$0; izz~:3..)
+.(izzenc guess)
+?e
+.(izzenc ascii)
+?e
+.(izzenc utf16le)
+EOF
+EXPECT=<<EOF
+0   0x00000000 0x00000000 6   14           utf16le ki扡摣晥桧 blocks=Basic Latin,CJK Unified Ideographs
+
+0   0x00000004 0x00000004 8   9            ascii abcdefgh
+
+0   0x00000000 0x00000000 6   14           utf16le ki扡摣晥桧 blocks=Basic Latin,CJK Unified Ideographs
+EOF
+RUN
+
 NAME=ik-relro
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=ik info/elf.relro


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr allows `bin.str.enc` to affect `izz` (though not `iz` for some reason), and `ascii` is now an alias for `latin1`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Fixes #16543.
