### PR TITLE
Fix assembling of xchg and bswap

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -2769,16 +2769,10 @@ static int opxchg(RAsm *a, ut8 *data, const Opcode *op) {
 			if (op->operands[0].type & OT_WORD) {
 				data[l++] = 0x66;
 			}
-			int rex = 0x40;
-			if (op->operands[0].extended) {
-				rex |= 1 << 2;
-			}
-			if (op->operands[1].extended) {
-				rex |= 1;
-			}
-			if (op->operands[0].type & OT_QWORD) {
-				rex |= 1 << 3;
-			}
+			ut8 rex = 0x40
+				| op->operands[0].extended
+				| op->operands[1].extended << 2
+				| !!(op->operands[0].type & OT_QWORD) << 3;
 			if (rex != 0x40) {
 				data[l++] = rex;
 			}
@@ -2788,8 +2782,8 @@ static int opxchg(RAsm *a, ut8 *data, const Opcode *op) {
 				data[l++] = 0x87;
 			}
 			mod_byte = 3;
-			reg = op->operands[0].reg;
-			rm = op->operands[1].reg;
+			reg = op->operands[1].reg;
+			rm = op->operands[0].reg;
 		}
 	}
 	data[l++] = mod_byte << 6 | reg << 3 | rm;

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -742,10 +742,17 @@ static int opbswap(RAsm *a, ut8 *data, const Opcode *op) {
 		}
 
 		if (op->operands[0].type & OT_QWORD) {
-			data[l++] = 0x48;
+			if (op->operands[0].extended) {
+				data[l++] = 0x49;
+			} else {
+				data[l++] = 0x48;
+			}
 			data[l++] = 0x0f;
 			data[l++] = 0xc8 + op->operands[0].reg;
 		} else if (op->operands[0].type & OT_DWORD) {
+			if (op->operands[0].extended) {
+				data[l++] = 0x41;
+			}
 			data[l++] = 0x0f;
 			data[l++] = 0xc8 + op->operands[0].reg;
 		} else {

--- a/test/db/asm/x86_32
+++ b/test/db/asm/x86_32
@@ -2147,25 +2147,25 @@ aB "xadd byte [eax], al" 0fc000
 aB "xadd dword [eax], eax" 0fc100
 aB "xchg byte [eax], al" 8600
 a "xchg dword [eax], eax" 8700
-a "xchg al, dl" 86c2
-a "xchg dl, al" 86d0
-a "xchg ax, dx" 6692
+ad "xchg al, dl" 86d0
+ad "xchg dl, al" 86c2
+ad "xchg ax, dx" 6692
 a "xchg dx, ax" 6692
-a "xchg ah, dh" 86e6
-a "xchg dh, ah" 86f4
+ad "xchg ah, dh" 86f4
+ad "xchg dh, ah" 86e6
 a "xchg eax, eax" 90
-a "xchg eax, ebp" 95
-a "xchg eax, ebx" 93
-a "xchg eax, ebx" 93
-a "xchg eax, ecx" 91
-a "xchg eax, edi" 97
-a "xchg eax, edx" 92
-a "xchg eax, esi" 96
-a "xchg eax, esp" 94
-a "xchg ebx, ecx" 87d9
-a "xchg ecx, ebp" 87cd
-a "xchg ecx, ebx" 87cb
-a "xchg ecx, ecx" 87c9
+ad "xchg eax, ebp" 95
+ad "xchg eax, ebx" 93
+ad "xchg eax, ebx" 93
+ad "xchg eax, ecx" 91
+ad "xchg eax, edi" 97
+ad "xchg eax, edx" 92
+ad "xchg eax, esi" 96
+ad "xchg eax, esp" 94
+ad "xchg ebx, ecx" 87cb
+ad "xchg ecx, ebp" 87e9
+ad "xchg ecx, ebx" 87d9
+ad "xchg ecx, ecx" 87c9
 a "xgetbv" 0f01d0
 a "xlatb" d7
 a "xor al, 0" 3400

--- a/test/db/asm/x86_32
+++ b/test/db/asm/x86_32
@@ -2147,6 +2147,12 @@ aB "xadd byte [eax], al" 0fc000
 aB "xadd dword [eax], eax" 0fc100
 aB "xchg byte [eax], al" 8600
 a "xchg dword [eax], eax" 8700
+a "xchg al, dl" 86c2
+a "xchg dl, al" 86d0
+a "xchg ax, dx" 6692
+a "xchg dx, ax" 6692
+a "xchg ah, dh" 86e6
+a "xchg dh, ah" 86f4
 a "xchg eax, eax" 90
 a "xchg eax, ebp" 95
 a "xchg eax, ebx" 93
@@ -2156,9 +2162,9 @@ a "xchg eax, edi" 97
 a "xchg eax, edx" 92
 a "xchg eax, esi" 96
 a "xchg eax, esp" 94
-a "xchg ebx, ecx" 87cb
-a "xchg ecx, ebp" 87e9
-a "xchg ecx, ebx" 87d9
+a "xchg ebx, ecx" 87d9
+a "xchg ecx, ebp" 87cd
+a "xchg ecx, ebx" 87cb
 a "xchg ecx, ecx" 87c9
 a "xgetbv" 0f01d0
 a "xlatb" d7

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -960,6 +960,20 @@ a "bswap rax" 480fc8
 a "bswap r15" 490fcf
 a "bswap eax" 0fc8
 a "bswap r15d" 410fcf
+a "xchg eax, r8d" 4190
+a "xchg r8d, eax" 4190
+a "xchg rax, rdx" 4892
+a "xchg rdx, rax" 4892
+a "xchg rax, r8" 4990
+a "xchg r8, rax" 4990
+a "xchg rdx, rbx" 4887d3
+a "xchg rbx, rdx" 4887da
+a "xchg r8, r15" 4d87c7
+a "xchg r15, r8" 4d87f8
+a "xchg r8d, r15d" 4587c7
+a "xchg r15d, r8d" 4587f8
+a "xchg rdx, r8" 4987d0
+a "xchg r15, rdx" 4c87fa
 d "call qword [rip + 0x3a8f3e]" 48ff153e8f3a00
 d "call qword [rip + 0x1d638f]" 48ff158f631d00
 a "fmul st2, st0" dcca

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -956,6 +956,10 @@ a "dec rdi" 48ffcf
 a "dec rdx" 48ffca
 a "dec rsi" 48ffce
 a "dec WORD PTR [rdi+0x88]" 66ff8f88000000
+a "bswap rax" 480fc8
+a "bswap r15" 490fcf
+a "bswap eax" 0fc8
+a "bswap r15d" 410fcf
 d "call qword [rip + 0x3a8f3e]" 48ff153e8f3a00
 d "call qword [rip + 0x1d638f]" 48ff158f631d00
 a "fmul st2, st0" dcca

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -960,20 +960,20 @@ a "bswap rax" 480fc8
 a "bswap r15" 490fcf
 a "bswap eax" 0fc8
 a "bswap r15d" 410fcf
-a "xchg eax, r8d" 4190
+ad "xchg eax, r8d" 4190
 a "xchg r8d, eax" 4190
-a "xchg rax, rdx" 4892
+ad "xchg rax, rdx" 4892
 a "xchg rdx, rax" 4892
-a "xchg rax, r8" 4990
+ad "xchg rax, r8" 4990
 a "xchg r8, rax" 4990
-a "xchg rdx, rbx" 4887d3
-a "xchg rbx, rdx" 4887da
-a "xchg r8, r15" 4d87c7
-a "xchg r15, r8" 4d87f8
-a "xchg r8d, r15d" 4587c7
-a "xchg r15d, r8d" 4587f8
-a "xchg rdx, r8" 4987d0
-a "xchg r15, rdx" 4c87fa
+ad "xchg rdx, rbx" 4887da
+ad "xchg rbx, rdx" 4887d3
+ad "xchg r8, r15" 4d87f8
+ad "xchg r15, r8" 4d87c7
+ad "xchg r8d, r15d" 4587f8
+ad "xchg r15d, r8d" 4587c7
+ad "xchg rdx, r8" 4c87c2
+ad "xchg r15, rdx" 4987d7
 d "call qword [rip + 0x3a8f3e]" 48ff153e8f3a00
 d "call qword [rip + 0x1d638f]" 48ff158f631d00
 a "fmul st2, st0" dcca


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Previously, rasm2 incorrectly assembled `bswap` and `xchg` for x86-64 as shown below.

```
$ rasm2 -b 64 -
bswap r15
480fcf
bswap r15d
0fcf
xchg al, dl
92
xchg dl, al
92
xchg ax, dx
92
xchg rax, rdx
92
xchg rdx, rbx
87da
xchg rbx, rdx
87d3
xchg r8, r15
97
xchg r15, r8
97
xchg r8d, r15d
97
xchg r15d, r8d
97
```

While the expected behavior is as follows.

```
$ rasm2 -b 64 -
bswap r15
490fcf
bswap r15d
410fcf
xchg al, dl
86c2
xchg dl, al
86d0
xchg ax, dx
6692
xchg rax, rdx
4892
xchg rdx, rbx
4887d3
xchg rbx, rdx
4887da
xchg r8, r15
4d87c7
xchg r15, r8
4d87f8
xchg r8d, r15d
4587c7
xchg r15d, r8d
4587f8
```

This pull request fixes this problem.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
