### PR TITLE
Use rpvector for storing esil pc trace

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -96,6 +96,7 @@ R_API RAnalEsil *r_anal_esil_new(int stacksize, int iotrap, unsigned int addrsiz
 	r_anal_esil_interrupts_init (esil);
 	esil->sessions = r_list_newf (r_anal_esil_session_free);
 	esil->addrmask = genmask (addrsize - 1);
+	r_pvector_init (&esil->trace_vec, r_anal_op_free);
 	return esil;
 }
 
@@ -183,6 +184,7 @@ R_API void r_anal_esil_free(RAnalEsil *esil) {
 		esil->anal->cur->esil_fini (esil);
 	}
 	r_list_free (esil->sessions);
+	r_pvector_clear (&esil->trace_vec);
 	free (esil->cmd_intr);
 	free (esil->cmd_trap);
 	free (esil->cmd_mdev);

--- a/libr/anal/esil_trace.c
+++ b/libr/anal/esil_trace.c
@@ -107,8 +107,7 @@ R_API void r_anal_esil_trace (RAnalEsil *esil, RAnalOp *op) {
 	if (!DB) {
 		DB = sdb_new0 ();
 	}
-	sdb_num_set (DB, "idx", esil->trace_idx, 0);
-	sdb_num_set (DB, KEY ("addr"), op->addr, 0);
+	r_pvector_push (&esil->trace_vec, op);
 //	sdb_set (DB, KEY ("opcode"), op->mnemonic, 0);
 //	sdb_set (DB, KEY ("addr"), expr, 0);
 

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4931,7 +4931,7 @@ static int cmd_debug(void *data, const char *input) {
 				if (op) {
 					r_anal_esil_trace (core->anal->esil, op);
 				}
-				r_anal_op_free (op);
+				//r_anal_op_free (op);
 			} break;
 			case '-': // "dte-"
 				if (!strcmp (input + 3, "*")) {

--- a/libr/debug/trace.c
+++ b/libr/debug/trace.c
@@ -49,20 +49,20 @@ R_API int r_debug_trace_tag (RDebug *dbg, int tag) {
  */
 R_API int r_debug_trace_pc(RDebug *dbg, ut64 pc) {
 	ut8 buf[32];
-	RAnalOp op = {0};
+	RAnalOp *op = r_anal_op_new ();
 	static ut64 oldpc = UT64_MAX; // Must trace the previously traced instruction
 	if (!dbg->iob.is_valid_offset (dbg->iob.io, pc, 0)) {
 		eprintf ("trace_pc: cannot read memory at 0x%"PFMT64x"\n", pc);
 		return false;
 	}
 	(void)dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf));
-	if (r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_ESIL) < 1) {
+	if (r_anal_op (dbg->anal, op, pc, buf, sizeof (buf), R_ANAL_OP_MASK_BASIC | R_ANAL_OP_MASK_VAL | R_ANAL_OP_MASK_ESIL) < 1) {
 		eprintf ("trace_pc: cannot get opcode size at 0x%"PFMT64x"\n", pc);
 		return false;
 	}
 	if (dbg->trace->enabled) {
 		if (dbg->anal->esil) {
-			r_anal_esil_trace (dbg->anal->esil, &op);
+			r_anal_esil_trace (dbg->anal->esil, op);
 		} else {
 			if (dbg->verbose) {
 				eprintf ("Run aeim to get dbg->anal->esil initialized\n");
@@ -70,10 +70,10 @@ R_API int r_debug_trace_pc(RDebug *dbg, ut64 pc) {
 		}
 	}
 	if (oldpc != UT64_MAX) {
-		r_debug_trace_add (dbg, oldpc, op.size); //XXX review what this line really do
+		r_debug_trace_add (dbg, oldpc, op->size); //XXX review what this line really do
 	}
 	oldpc = pc;
-	r_anal_op_fini (&op);
+	//r_anal_op_fini (&op);
 	return true;
 }
 

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1111,6 +1111,7 @@ typedef struct r_anal_esil_t {
 	/* deep esil parsing fills this */
 	Sdb *stats;
 	Sdb *db_trace;
+	RPVector trace_vec;
 	int trace_idx;
 	RAnalEsilCallbacks cb;
 	RAnalReil *Reil;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The main idea here is to use RPVector for storing some parts of esil trace instead of sdb since they anyway are accessed by index.
Also by using that vector as cache for RAnalOp objects we can improve speed of type analysis (`aaft`). But I don't know how it can affect the esil emulaton. Also these changes breaks some commands for quering trace db.

Analysis time (`aaa`) of a 18MB binary: 3m10s vs 2m25s (master vs current branch).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
