### PR TITLE
3.5x faster DEX loading parsing debug_info section ##bin

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -373,10 +373,7 @@ out_error:
 // XXX. this is using binfile->buf directly :(
 // https://github.com/android/platform_dalvik/blob/0641c2b4836fae3ee8daf6c0af45c316c84d5aeb/libdex/DexDebugInfo.cpp#L312
 // https://github.com/android/platform_dalvik/blob/0641c2b4836fae3ee8daf6c0af45c316c84d5aeb/libdex/DexDebugInfo.cpp#L141
-static void dex_parse_debug_item(RBinFile *bf,
-				  RBinDexClass *c, int MI, int MA, int paddr, int ins_size,
-				  int insns_size, char *class_name, int regsz,
-				  int debug_info_off) {
+static void dex_parse_debug_item(RBinFile *bf, RBinDexClass *c, int MI, int MA, int paddr, int ins_size, int insns_size, char *class_name, int regsz, int debug_info_off) {
 	RBin *rbin = bf->rbin;
 	RBinDexObj *dex = bf->o->bin_obj; //  bin .. unnecessary arg
 	// runtime error: pointer index expression with base 0x000000004402 overflowed to 0xffffffffff0043fc
@@ -441,7 +438,6 @@ static void dex_parse_debug_item(RBinFile *bf,
 			free (emitted_debug_locals);
 			return;
 		}
-		// p4 = r_uleb128 (p4, p4_end - p4, &param_type_idx); // read uleb128p1
 		(void)r_buf_uleb128 (bf->buf, &res);
 		param_type_idx = res - 1;
 		name = getstr (dex, param_type_idx);
@@ -464,12 +460,12 @@ static void dex_parse_debug_item(RBinFile *bf,
 		}
 		parameters_size--;
 	}
-	ut8 opcode = 0; // = *(p4++) & 0xff;
+	ut8 opcode = 0;
 	if (r_buf_read (bf->buf, &opcode, 1) != 1) {
 		// error
 		return;
 	}
-	while (keep) {//  && p4 + 1 < p4_end) {
+	while (keep) {
 		switch (opcode) {
 		case 0x0: // DBG_END_SEQUENCE
 			keep = false;
@@ -477,14 +473,12 @@ static void dex_parse_debug_item(RBinFile *bf,
 		case 0x1: // DBG_ADVANCE_PC
 			{
 			ut64 addr_diff;
-			// p4 = r_uleb128 (p4, p4_end - p4, &addr_diff);
 			r_buf_uleb128 (bf->buf, &addr_diff);
 			address += addr_diff;
 			}
 			break;
 		case 0x2: // DBG_ADVANCE_LINE
 			{
-			//  st64 line_diff = r_sleb128 (&p4, p4_end);
 			st64 line_diff;
 			r_buf_sleb128 (bf->buf, &line_diff);
 			line += line_diff;
@@ -625,7 +619,6 @@ static void dex_parse_debug_item(RBinFile *bf,
 			break;
 		case 0x9:
 			{
-		//	p4 = r_uleb128 (p4, p4_end - p4, &source_file_idx);
 			ut64 res;
 			r_buf_uleb128 (bf->buf, &res);
 			source_file_idx = res - 1;


### PR DESCRIPTION
* Use proper RBuf api instead of doing bulk reads in DEX ##bin
* Loading an 8MB DEX file: Before:  48s,  After: 17s

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Before it was read the whole file for every entry in the debug info section. then parsing it by using the uleb apis. translating this to use the reading just the necessary bytes makes it much faster (about 3.5x in a 8MB dex file)

**Test plan**

time r2 -qcq classes.dex

**Closing issues**

no issue tracking this