### PR TITLE
Extend RCmdDesc with different types

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7063,7 +7063,7 @@ R_API void r_core_cmd_init(RCore *core) {
 	struct {
 		const char *cmd;
 		const char *description;
-		r_cmd_callback (cb);
+		RCmdCb cb;
 		void (*descriptor_init)(RCore *core);
 	} cmds[] = {
 		{"!",        "run system command", cmd_system},
@@ -7081,40 +7081,40 @@ R_API void r_core_cmd_init(RCore *core) {
 		{"?",        "help message", cmd_help, cmd_help_init},
 		{"\\",       "alias for =!", cmd_rap_run},
 		{"'",        "alias for =!", cmd_rap_run},
-		{"0x",       "alias for s 0x", cmd_ox},
-		{"analysis", "analysis", cmd_anal, cmd_anal_init},
-		{"bsize",    "change block size", cmd_bsize},
-		{"cmp",      "compare memory", cmd_cmp, cmd_cmp_init},
-		{"Code",     "code metadata", cmd_meta, cmd_meta_init},
-		{"debug",    "debugger operations", cmd_debug, cmd_debug_init},
-		{"eval",     "evaluate configuration variable", cmd_eval, cmd_eval_init},
-		{"flag",     "get/set flags", cmd_flag, cmd_flag_init},
+		{"0",       "alias for s 0x", cmd_ox},
+		{"a", "analysis", cmd_anal, cmd_anal_init},
+		{"b",    "change block size", cmd_bsize},
+		{"c",      "compare memory", cmd_cmp, cmd_cmp_init},
+		{"C",     "code metadata", cmd_meta, cmd_meta_init},
+		{"d",    "debugger operations", cmd_debug, cmd_debug_init},
+		{"e",     "evaluate configuration variable", cmd_eval, cmd_eval_init},
+		{"f",     "get/set flags", cmd_flag, cmd_flag_init},
 		{"g",        "egg manipulation", cmd_egg, cmd_egg_init},
-		{"info",     "get file info", cmd_info, cmd_info_init},
-		{"kuery",    "perform sdb query", cmd_kuery},
+		{"i",     "get file info", cmd_info, cmd_info_init},
+		{"k",    "perform sdb query", cmd_kuery},
 		{"l",       "list files and directories", cmd_ls},
-		{"join",    "join the contents of the two files", cmd_join},
-		{"head",    "show the top n number of line in file", cmd_head},
+		{"j",    "join the contents of the two files", cmd_join},
+		{"h",    "show the top n number of line in file", cmd_head},
 		{"L",        "manage dynamically loaded plugins", cmd_plugins},
-		{"mount",    "mount filesystem", cmd_mount, cmd_mount_init},
-		{"open",     "open or map file", cmd_open, cmd_open_init},
-		{"print",    "print current block", cmd_print, cmd_print_init},
-		{"Project",  "project", cmd_project, cmd_project_init},
-		{"quit",     "exit program session", cmd_quit, cmd_quit_init},
+		{"m",    "mount filesystem", cmd_mount, cmd_mount_init},
+		{"o",     "open or map file", cmd_open, cmd_open_init},
+		{"p",    "print current block", cmd_print, cmd_print_init},
+		{"P",  "project", cmd_project, cmd_project_init},
+		{"q",     "exit program session", cmd_quit, cmd_quit_init},
 		{"Q",        "alias for q!", cmd_Quit},
 		{":",        "long commands starting with :", cmd_colon},
-		{"resize",   "change file size", cmd_resize},
-		{"seek",     "seek to an offset", cmd_seek, cmd_seek_init},
+		{"r",   "change file size", cmd_resize},
+		{"s",     "seek to an offset", cmd_seek, cmd_seek_init},
 		{"t",        "type information (cparse)", cmd_type, cmd_type_init},
-		{"Text",     "Text log utility", cmd_log, cmd_log_init},
+		{"T",     "Text log utility", cmd_log, cmd_log_init},
 		{"u",        "uname/undo", cmd_undo},
 		{"<",        "pipe into RCons.readChar", cmd_pipein},
-		{"Visual",   "enter visual mode", cmd_visual},
-		{"visualPanels",   "enter visual mode", cmd_panels},
-		{"write",    "write bytes", cmd_write, cmd_write_init},
+		{"V",   "enter visual mode", cmd_visual},
+		{"v",   "enter visual mode", cmd_panels},
+		{"w",    "write bytes", cmd_write, cmd_write_init},
 		{"x",        "alias for px", cmd_hexdump},
-		{"yank",     "yank bytes", cmd_yank},
-		{"zign",     "zignatures", cmd_zign, cmd_zign_init},
+		{"y",     "yank bytes", cmd_yank},
+		{"z",     "zignatures", cmd_zign, cmd_zign_init},
 	};
 
 	core->rcmd = r_cmd_new ();
@@ -7125,9 +7125,11 @@ R_API void r_core_cmd_init(RCore *core) {
 	core->rcmd->macro.cb_printf = (PrintfCallback)r_cons_printf;
 	r_cmd_set_data (core->rcmd, core);
 	core->cmd_descriptors = r_list_newf (free);
+	RCmdDesc *root = r_cmd_get_root (core->rcmd);
 	int i;
 	for (i = 0; i < R_ARRAY_SIZE (cmds); i++) {
-		r_cmd_add (core->rcmd, cmds[i].cmd, cmds[i].description, cmds[i].cb);
+		r_cmd_add (core->rcmd, cmds[i].cmd, cmds[i].cb);
+		(void)r_cmd_desc_oldinput_new (core->rcmd, root, cmds[i].cmd, cmds[i].cb);
 		if (cmds[i].descriptor_init) {
 			cmds[i].descriptor_init (core);
 		}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7129,7 +7129,6 @@ R_API void r_core_cmd_init(RCore *core) {
 	int i;
 	for (i = 0; i < R_ARRAY_SIZE (cmds); i++) {
 		r_cmd_add (core->rcmd, cmds[i].cmd, cmds[i].cb);
-		(void)r_cmd_desc_oldinput_new (core->rcmd, root, cmds[i].cmd, cmds[i].cb);
 		if (cmds[i].descriptor_init) {
 			cmds[i].descriptor_init (core);
 		}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7125,7 +7125,6 @@ R_API void r_core_cmd_init(RCore *core) {
 	core->rcmd->macro.cb_printf = (PrintfCallback)r_cons_printf;
 	r_cmd_set_data (core->rcmd, core);
 	core->cmd_descriptors = r_list_newf (free);
-	RCmdDesc *root = r_cmd_get_root (core->rcmd);
 	int i;
 	for (i = 0; i < R_ARRAY_SIZE (cmds); i++) {
 		r_cmd_add (core->rcmd, cmds[i].cmd, cmds[i].cb);

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -20,7 +20,7 @@ static bool cmd_desc_set_parent(RCmdDesc *cd, RCmdDesc *parent) {
 	return true;
 }
 
-static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char *name, const char *help) {
+static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char *name) {
 	RCmdDesc *res = R_NEW0 (RCmdDesc);
 	if (!res) {
 		return NULL;
@@ -29,12 +29,6 @@ static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char
 	res->name = strdup (name);
 	if (!res->name) {
 		goto err;
-	}
-	if (help) {
-		res->help = strdup (help);
-		if (!res->help) {
-			goto err;
-		}
 	}
 	res->n_children = 0;
 	r_pvector_init (&res->children, (RPVectorFree)r_cmd_desc_free);
@@ -62,7 +56,7 @@ R_API RCmd *r_cmd_new () {
 		cmd->cmds[i] = NULL;
 	}
 	cmd->nullcallback = cmd->data = NULL;
-	cmd->root_cmd_desc = create_cmd_desc (NULL, R_CMD_DESC_TYPE_INNER, "", NULL);
+	cmd->root_cmd_desc = create_cmd_desc (NULL, R_CMD_DESC_TYPE_INNER, "");
 	cmd->ht_cmds = ht_pp_new0 ();
 	r_core_plugin_init (cmd);
 	r_cmd_macro_init (&cmd->macro);
@@ -939,10 +933,10 @@ R_API const char *r_cmd_parsed_args_cmd(RCmdParsedArgs *a) {
 
 /* RCmdDescriptor */
 
-R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help, RCmdArgvCb cb) {
-	r_return_val_if_fail (cmd && parent && name && help && cb, NULL);
+R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb) {
+	r_return_val_if_fail (cmd && parent && name && cb, NULL);
 	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_ARGV, name, help);
+	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_ARGV, name);
 	if (!res) {
 		return NULL;
 	}
@@ -955,16 +949,16 @@ R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *nam
 	return res;
 }
 
-R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help) {
-	r_return_val_if_fail (cmd && parent && name && help, NULL);
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name) {
+	r_return_val_if_fail (cmd && parent && name, NULL);
 	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	return create_cmd_desc (parent, R_CMD_DESC_TYPE_INNER, name, help);
+	return create_cmd_desc (parent, R_CMD_DESC_TYPE_INNER, name);
 }
 
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb) {
 	r_return_val_if_fail (cmd && parent && name && cb, NULL);
 	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_OLDINPUT, name, NULL);
+	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_OLDINPUT, name);
 	if (!res) {
 		return NULL;
 	}
@@ -980,7 +974,6 @@ R_API void r_cmd_desc_free(RCmdDesc *cd) {
 	if (!cd) {
 		return;
 	}
-	free (cd->help);
 	free (cd->name);
 	free (cd);
 }

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -325,9 +325,11 @@ R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 	RCorePlugin *cp;
 	char *exec_string = r_cmd_parsed_args_execstr (args);
 	r_list_foreach (cmd->plist, iter, cp) {
-		res = cp->call (cmd->data, exec_string);
-		if (res) {
-			break;
+		if (cp->call) {
+			res = cp->call (cmd->data, exec_string);
+			if (res) {
+				break;
+			}
 		}
 	}
 	free (exec_string);

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -12,6 +12,38 @@ static int value = 0;
 #define NCMDS (sizeof (cmd->cmds)/sizeof(*cmd->cmds))
 R_LIB_VERSION (r_cmd);
 
+static bool cmd_desc_set_parent(RCmdDesc *cd, RCmdDesc *parent) {
+	r_return_val_if_fail (cd && parent && !cd->parent, false);
+	cd->parent = parent;
+	r_pvector_push (&parent->children, cd);
+	parent->n_children++;
+	return true;
+}
+
+static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char *name, const char *help) {
+	RCmdDesc *res = R_NEW0 (RCmdDesc);
+	if (!res) {
+		return NULL;
+	}
+	res->type = type;
+	res->name = strdup (name);
+	if (!res->name) {
+		goto err;
+	}
+	if (help) {
+		res->help = strdup (help);
+		if (!res->help) {
+			goto err;
+		}
+	}
+	res->n_children = 0;
+	r_pvector_init (&res->children, (RPVectorFree)r_cmd_desc_free);
+	cmd_desc_set_parent (res, parent);
+	return res;
+err:
+	r_cmd_desc_free (res);
+	return NULL;
+}
 
 R_API void r_cmd_alias_init(RCmd *cmd) {
 	cmd->aliases.count = 0;
@@ -30,6 +62,8 @@ R_API RCmd *r_cmd_new () {
 		cmd->cmds[i] = NULL;
 	}
 	cmd->nullcallback = cmd->data = NULL;
+	cmd->root_cmd_desc = create_cmd_desc (NULL, R_CMD_DESC_TYPE_INNER, "", NULL);
+	cmd->ht_cmds = ht_pp_new0 ();
 	r_core_plugin_init (cmd);
 	r_cmd_macro_init (&cmd->macro);
 	r_cmd_alias_init (cmd);
@@ -53,8 +87,37 @@ R_API RCmd *r_cmd_free(RCmd *cmd) {
 			R_FREE (cmd->cmds[i]);
 		}
 	}
+	r_cmd_desc_free (cmd->root_cmd_desc);
 	free (cmd);
 	return NULL;
+}
+
+R_API RCmdDesc *r_cmd_get_root(RCmd *cmd) {
+	return cmd->root_cmd_desc;
+}
+
+static bool is_valid_desc(RCmdDesc *cd, const char *name) {
+	return cd->type == R_CMD_DESC_TYPE_OLDINPUT ||
+		(cd->type == R_CMD_DESC_TYPE_ARGV && !strcmp (cd->name, name));
+}
+
+R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier) {
+	r_return_val_if_fail (cmd && cmd_identifier, NULL);
+	char *cmdid = strdup (cmd_identifier);
+	char *end_cmdid = cmdid + strlen (cmdid);
+	RCmdDesc *res = NULL;
+	// match longer commands first
+	while (*cmdid) {
+		res = ht_pp_find (cmd->ht_cmds, cmdid, NULL);
+		r_warn_if_fail (!res || res->type == R_CMD_DESC_TYPE_OLDINPUT || res->type == R_CMD_DESC_TYPE_ARGV);
+		if (res && is_valid_desc (res, cmd_identifier)) {
+			goto out;
+		}
+		*(--end_cmdid) = '\0';
+	}
+out:
+	free (cmdid);
+	return res;
 }
 
 R_API char **r_cmd_alias_keys(RCmd *cmd, int *sz) {
@@ -173,7 +236,7 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data) {
 	return 1;
 }
 
-R_API int r_cmd_add(RCmd *c, const char *cmd, const char *desc, r_cmd_callback(cb)) {
+R_API int r_cmd_add(RCmd *c, const char *cmd, RCmdCb cb) {
 	int idx = (ut8)cmd[0];
 	RCmdItem *item = c->cmds[idx];
 	if (!item) {
@@ -181,7 +244,6 @@ R_API int r_cmd_add(RCmd *c, const char *cmd, const char *desc, r_cmd_callback(c
 		c->cmds[idx] = item;
 	}
 	strncpy (item->cmd, cmd, sizeof (item->cmd)-1);
-	strncpy (item->desc, desc, sizeof (item->desc)-1);
 	item->callback = cb;
 	return true;
 }
@@ -236,11 +298,39 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	return ret;
 }
 
+static int cmdstatus2int(RCmdStatus s) {
+	switch (s) {
+	case R_CMD_STATUS_OK:
+		return 0;
+	case R_CMD_STATUS_INVALID:
+		return -1;
+	case R_CMD_STATUS_EXIT:
+	default:
+		return -2;
+	}
+}
+
 R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
-	char *exec_string = r_cmd_parsed_args_execstr (args);
-	R_LOG_DEBUG ("r_cmd_call_parsed_args exec_string = '%s'\n", exec_string);
-	int res = r_cmd_call (cmd, exec_string);
-	free (exec_string);
+	RCmdDesc *cd = r_cmd_get_desc (cmd, r_cmd_parsed_args_cmd (args));
+	if (!cd) {
+		return -1;
+	}
+
+	int res = -1;
+	switch (cd->type) {
+	case R_CMD_DESC_TYPE_ARGV:
+		res = cmdstatus2int (cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv));
+		break;
+	case R_CMD_DESC_TYPE_OLDINPUT: {
+		char *exec_string = r_cmd_parsed_args_execstr (args);
+		res = cd->d.oldinput_data.cb (cmd->data, exec_string + strlen (cd->name));
+		free (exec_string);
+		break;
+	}
+	default:
+		R_LOG_ERROR ("RCmdDesc type not handled\n");
+		break;
+	}
 	return res;
 }
 
@@ -812,4 +902,62 @@ R_API char *r_cmd_parsed_args_execstr(RCmdParsedArgs *a) {
 	}
 	parsed_args_iterateargs (a, sb);
 	return r_strbuf_drain (sb);
+}
+
+R_API const char *r_cmd_parsed_args_cmd(RCmdParsedArgs *a) {
+	r_return_val_if_fail (a && a->argv && a->argv[0], NULL);
+	return a->argv[0];
+}
+
+/* RCmdDescriptor */
+
+R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help, RCmdArgvCb cb) {
+	r_return_val_if_fail (cmd && parent && name && help && cb, NULL);
+	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
+	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_ARGV, name, help);
+	if (!res) {
+		return NULL;
+	}
+
+	res->d.argv_data.cb = cb;
+	if (!ht_pp_insert (cmd->ht_cmds, name, res)) {
+		r_cmd_desc_free (res);
+		return NULL;
+	}
+	return res;
+}
+
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help) {
+	r_return_val_if_fail (cmd && parent && name && help, NULL);
+	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
+	return create_cmd_desc (parent, R_CMD_DESC_TYPE_INNER, name, help);
+}
+
+R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb) {
+	r_return_val_if_fail (cmd && parent && name && cb, NULL);
+	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
+	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_OLDINPUT, name, NULL);
+	if (!res) {
+		return NULL;
+	}
+	res->d.oldinput_data.cb = cb;
+	if (!ht_pp_insert (cmd->ht_cmds, name, res)) {
+		r_cmd_desc_free (res);
+		return NULL;
+	}
+	return res;
+}
+
+R_API void r_cmd_desc_free(RCmdDesc *cd) {
+	if (!cd) {
+		return;
+	}
+	free (cd->help);
+	free (cd->name);
+	free (cd);
+}
+
+R_API RCmdDesc *r_cmd_desc_parent(RCmdDesc *cd) {
+	r_return_val_if_fail (cd, NULL);
+	return cd->parent;
 }

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -315,7 +315,7 @@ static int cmdstatus2int(RCmdStatus s) {
 }
 
 R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
-	int res = -1;
+	int res = 0;
 
 	// As old RCorePlugin do not register new commands in RCmd, we have no
 	// way of knowing if one of those is able to handle the input, so we
@@ -352,6 +352,7 @@ R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 		free (exec_string);
 		break;
 	default:
+		res = -1;
 		R_LOG_ERROR ("RCmdDesc type not handled\n");
 		break;
 	}

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -70,6 +70,15 @@ R_API RCmd *r_cmd_new () {
 	return cmd;
 }
 
+static void free_cmd_desc_tree(RCmdDesc *cd) {
+	void **it;
+	r_cmd_desc_children_foreach (cd, it) {
+		RCmdDesc *in_cd = *(RCmdDesc **)it;
+		free_cmd_desc_tree (in_cd);
+	}
+	r_cmd_desc_free (cd);
+}
+
 R_API RCmd *r_cmd_free(RCmd *cmd) {
 	int i;
 	if (!cmd) {
@@ -87,7 +96,7 @@ R_API RCmd *r_cmd_free(RCmd *cmd) {
 			R_FREE (cmd->cmds[i]);
 		}
 	}
-	r_cmd_desc_free (cmd->root_cmd_desc);
+	free_cmd_desc_tree (cmd->root_cmd_desc);
 	free (cmd);
 	return NULL;
 }

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -83,7 +83,6 @@ typedef enum {
 typedef struct r_cmd_desc_t {
 	RCmdDescType type;
 	char *name;
-	char *help;
 	struct r_cmd_desc_t *parent;
 	int n_children;
 	RPVector children;
@@ -150,8 +149,8 @@ R_API RCmdDesc *r_cmd_get_root(RCmd *cmd);
 R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier);
 
 /* RCmdDescriptor */
-R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help);
-R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help, RCmdArgvCb cb);
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name);
+R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb);
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb);
 R_API void r_cmd_desc_free(RCmdDesc *cd);
 R_API RCmdDesc *r_cmd_desc_parent(RCmdDesc *cd);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -15,8 +15,15 @@ extern "C" {
 #define MACRO_LABELS 20
 #define R_CMD_MAXLEN 4096
 
-#define r_cmd_callback(x) int (*x)(void *data, const char *input)
-#define r_cmd_nullcallback(x) int (*x)(void *data)
+typedef enum r_cmd_status_t {
+	R_CMD_STATUS_OK = 0,
+	R_CMD_STATUS_INVALID,
+	R_CMD_STATUS_EXIT
+} RCmdStatus;
+
+typedef int (*RCmdCb) (void *user, const char *input);
+typedef RCmdStatus (*RCmdArgvCb) (void *user, int argc, const char **argv);
+typedef int (*RCmdNullCb) (void *user);
 
 typedef struct r_cmd_parsed_args_t {
 	int argc;
@@ -52,20 +59,10 @@ typedef struct r_cmd_macro_t {
 	RList *macros;
 } RCmdMacro;
 
-typedef int (*RCmdCallback)(void *user, const char *cmd);
-
 typedef struct r_cmd_item_t {
 	char cmd[64];
-	char desc[128];
-	r_cmd_callback (callback);
+	RCmdCb callback;
 } RCmdItem;
-
-typedef struct r_cmd_long_item_t {
-	char cmd[64]; /* long command */
-	int cmd_len;
-	char cmd_short[32]; /* short command */
-	char desc[128];
-} RCmdLongItem;
 
 typedef struct r_cmd_alias_t {
 	int count;
@@ -74,9 +71,36 @@ typedef struct r_cmd_alias_t {
 	int *remote;
 } RCmdAlias;
 
+typedef enum {
+	// for old handlers that parse their own input and accept a single string
+	R_CMD_DESC_TYPE_OLDINPUT,
+	// for handlers that accept argc/argv
+	R_CMD_DESC_TYPE_ARGV,
+	// for middle nodes in the tree
+	R_CMD_DESC_TYPE_INNER,
+} RCmdDescType;
+
+typedef struct r_cmd_desc_t {
+	RCmdDescType type;
+	char *name;
+	char *help;
+	struct r_cmd_desc_t *parent;
+	int n_children;
+	RPVector children;
+
+	union {
+		struct {
+			RCmdCb cb;
+		} oldinput_data;
+		struct {
+			RCmdArgvCb cb;
+		} argv_data;
+	} d;
+} RCmdDesc;
+
 typedef struct r_cmd_t {
 	void *data;
-	r_cmd_nullcallback (nullcallback);
+	RCmdNullCb nullcallback;
 	RCmdItem *cmds[UT8_MAX];
 	RCmdMacro macro;
 	RList *lcmds;
@@ -84,9 +108,11 @@ typedef struct r_cmd_t {
 	RCmdAlias aliases;
 	void *language; // used to store TSLanguage *
 	HtUP *ts_symbols_ht;
+	RCmdDesc *root_cmd_desc;
+	HtPP *ht_cmds;
 } RCmd;
 
-// TODO WIP
+// TODO: remove this once transitioned to RCmdDesc
 typedef struct r_cmd_descriptor_t {
 	const char *cmd;
 	const char **help_msg;
@@ -102,9 +128,9 @@ typedef struct r_core_plugin_t {
 	const char *license;
 	const char *author;
 	const char *version;
-	RCmdCallback call;
-	RCmdCallback init;
-	RCmdCallback fini;
+	RCmdCb call;
+	RCmdCb init;
+	RCmdCb fini;
 } RCorePlugin;
 
 #ifdef R_API
@@ -113,14 +139,24 @@ R_API int r_core_plugin_add(RCmd *cmd, RCorePlugin *plugin);
 R_API int r_core_plugin_check(RCmd *cmd, const char *a0);
 R_API int r_core_plugin_fini(RCmd *cmd);
 
-/* review api */
 R_API RCmd *r_cmd_new(void);
 R_API RCmd *r_cmd_free(RCmd *cmd);
 R_API int r_cmd_set_data(RCmd *cmd, void *data);
-R_API int r_cmd_add(RCmd *cmd, const char *command, const char *desc, r_cmd_callback(callback));
+R_API int r_cmd_add(RCmd *cmd, const char *command, RCmdCb callback);
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
 R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args);
+R_API RCmdDesc *r_cmd_get_root(RCmd *cmd);
+R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier);
+
+/* RCmdDescriptor */
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help);
+R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, const char *help, RCmdArgvCb cb);
+R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb);
+R_API void r_cmd_desc_free(RCmdDesc *cd);
+R_API RCmdDesc *r_cmd_desc_parent(RCmdDesc *cd);
+
+#define r_cmd_desc_children_foreach(root, it_cd) r_pvector_foreach (&root->children, it_cd)
 
 /* RCmdParsedArgs */
 R_API RCmdParsedArgs *r_cmd_parsed_args_new(const char *cmd, int n_args, char **args);
@@ -131,6 +167,7 @@ R_API bool r_cmd_parsed_args_setargs(RCmdParsedArgs *arg, int n_args, char **arg
 R_API bool r_cmd_parsed_args_setcmd(RCmdParsedArgs *arg, const char *cmd);
 R_API char *r_cmd_parsed_args_argstr(RCmdParsedArgs *arg);
 R_API char *r_cmd_parsed_args_execstr(RCmdParsedArgs *arg);
+R_API const char *r_cmd_parsed_args_cmd(RCmdParsedArgs *arg);
 
 #define r_cmd_parsed_args_foreach_arg(args, i, arg) for ((i) = 1; (i) < (args->argc) && ((arg) = (args)->argv[i]); (i)++)
 

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -66,6 +66,25 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 
 #define mu_sysfail(message) do { perror(message); mu_fail(message); } while(0)
 
+#define mu_assert_true(actual, message) do { \
+		__typeof__ (actual) act__ = (actual); \
+		if (!(act__)) { \
+			char _meqstr[2048]; \
+			sprintf (_meqstr, "%s: expected true, got false", (message)); \
+			mu_assert (_meqstr, false); \
+		} \
+	} while (0)
+
+#define mu_assert_false(actual, message) \
+	do { \
+		__typeof__ (actual) act__ = (actual); \
+		if ((act__)) { \
+			char _meqstr[2048]; \
+			sprintf (_meqstr, "%s: expected false, got true", (message)); \
+			mu_assert (_meqstr, false); \
+		} \
+	} while (0)
+
 #define mu_assert_eq(actual, expected, message) do { \
 		__typeof__(actual) act__ = (actual); \
 		__typeof__(expected) exp__ = (expected); \

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -77,6 +77,148 @@ bool test_parsed_args_newargs(void) {
 	mu_end;
 }
 
+static RCmdStatus afl_argv_handler(void *user, int argc, const char **argv) {
+	return R_CMD_STATUS_OK;
+}
+
+bool test_cmd_descriptor_argv(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, root, "afl", "list functions", afl_argv_handler);
+	mu_assert_notnull (cd, "cmddesc created");
+	mu_assert_streq (cd->name, "afl", "command descriptor name is afl");
+	mu_assert_eq (cd->type, R_CMD_DESC_TYPE_ARGV, "type of command descriptor is argv");
+	mu_assert_ptreq (r_cmd_desc_parent (cd), root, "root parent descriptor");
+	mu_assert_eq (root->n_children, 1, "root has 1 child");
+	mu_assert_eq (cd->n_children, 0, "no children");
+	mu_assert_streq (cd->help, "list functions", "help was set");
+	r_cmd_free (cmd);
+	mu_end;
+}
+
+bool test_cmd_descriptor_argv_nested(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *af_cd = r_cmd_desc_inner_new (cmd, root, "af", "analyze functions");
+	r_cmd_desc_inner_new (cmd, root, "af2", "analyze functions2");
+	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, af_cd, "afl", "list functions", afl_argv_handler);
+	mu_assert_ptreq (r_cmd_desc_parent (cd), af_cd, "parent of afl is af");
+	mu_assert_true (r_pvector_contains (&af_cd->children, cd), "afl is child of af");
+	r_cmd_free (cmd);
+	mu_end;
+}
+
+static int a_oldinput_cb(void *user, const char *input) {
+	return 0;
+}
+
+bool test_cmd_descriptor_oldinput(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *cd = r_cmd_desc_oldinput_new (cmd, root, "a", a_oldinput_cb);
+	mu_assert_notnull (cd, "cmddesc created");
+	mu_assert_streq (cd->name, "a", "command descriptor name is a");
+	mu_assert_eq (cd->type, R_CMD_DESC_TYPE_OLDINPUT, "type of command descriptor is oldinput");
+	mu_assert_ptreq (r_cmd_desc_parent (cd), root, "root parent descriptor");
+	mu_assert_eq (cd->n_children, 0, "no children");
+	r_cmd_free (cmd);
+	mu_end;
+}
+
+static RCmdStatus ap_handler(void *user, int argc, const char **argv) {
+	return R_CMD_STATUS_OK;
+}
+
+static int ae_handler(void *user, const char *input) {
+	return 0;
+}
+
+static int w_handler(void *user, const char *input) {
+	return 0;
+}
+
+bool test_cmd_descriptor_tree(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a", "analysis commands");
+	r_cmd_desc_argv_new (cmd, a_cd, "ap", "find prelude", ap_handler);
+	r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
+
+	void **it_cd;
+	r_cmd_desc_children_foreach (root, it_cd) {
+		RCmdDesc *cd = *it_cd;
+		mu_assert_ptreq (r_cmd_desc_parent (cd), root, "root is the parent");
+	}
+
+	r_cmd_free (cmd);
+	mu_end;
+}
+
+bool test_cmd_get_desc(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a", "analysis commands");
+	RCmdDesc *ap_cd = r_cmd_desc_argv_new (cmd, a_cd, "ap", "find prelude", ap_handler);
+	RCmdDesc *ae_cd = r_cmd_desc_oldinput_new (cmd, a_cd, "ae", ae_handler);
+	RCmdDesc *w_cd = r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
+
+	mu_assert_null (r_cmd_get_desc (cmd, "afl"), "afl does not have any handler");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "ap"), ap_cd, "ap will be handled by ap");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "wx"), w_cd, "wx will be handled by w");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "wao"), w_cd, "wao will be handled by w");
+	mu_assert_null (r_cmd_get_desc (cmd, "apx"), "apx does not have any handler");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "ae"), ae_cd, "ae will be handled by ae");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "aeim"), ae_cd, "aeim will be handled by ae");
+
+	r_cmd_free (cmd);
+	mu_end;
+}
+
+static RCmdStatus pd_handler(void *user, int argc, const char **argv) {
+	mu_assert_eq (argc, 2, "pd_handler called with 2 arguments (name and arg)");
+	mu_assert_streq (argv[0], "pd", "pd is argv[0]");
+	mu_assert_streq (argv[1], "10", "10 is argv[1]");
+	return R_CMD_STATUS_OK;
+}
+
+static int p_handler(void *user, const char *input) {
+	mu_assert_streq (input, "x 10", "input is +1");
+	return -1;
+}
+
+static int wv_handler(void *user, const char *input) {
+	mu_assert_streq (input, "8 0xdeadbeef", "input is +2");
+	return 1;
+}
+
+bool test_cmd_call_desc(void) {
+	RCmd *cmd = r_cmd_new ();
+	RCmdDesc *root = r_cmd_get_root (cmd);
+	RCmdDesc *p_cd = r_cmd_desc_inner_new (cmd, root, "p", "p commands");
+	r_cmd_desc_argv_new (cmd, p_cd, "pd", "print disasm", pd_handler);
+	r_cmd_desc_oldinput_new (cmd, p_cd, "p", p_handler);
+	r_cmd_desc_oldinput_new (cmd, root, "wv", wv_handler);
+
+	char *pd_args[] = {"10"};
+	char *px_args[] = {"10"};
+	char *wv8_args[] = {"0xdeadbeef"};
+
+	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 1, pd_args);
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), 0, "pd was called correctly");
+	r_cmd_parsed_args_free (a);
+
+	a = r_cmd_parsed_args_new ("px", 1, px_args);
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), -1, "p was called correctly");
+	r_cmd_parsed_args_free (a);
+
+	a = r_cmd_parsed_args_new ("wv8", 1, wv8_args);
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), 1, "wv was called correctly");
+	r_cmd_parsed_args_free (a);
+
+	r_cmd_free (cmd);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_parsed_args_noargs);
 	mu_run_test (test_parsed_args_onearg);
@@ -84,6 +226,12 @@ int all_tests() {
 	mu_run_test (test_parsed_args_nospace);
 	mu_run_test (test_parsed_args_newcmd);
 	mu_run_test (test_parsed_args_newargs);
+	mu_run_test (test_cmd_descriptor_argv);
+	mu_run_test (test_cmd_descriptor_argv_nested);
+	mu_run_test (test_cmd_descriptor_oldinput);
+	mu_run_test (test_cmd_descriptor_tree);
+	mu_run_test (test_cmd_get_desc);
+	mu_run_test (test_cmd_call_desc);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -84,14 +84,13 @@ static RCmdStatus afl_argv_handler(void *user, int argc, const char **argv) {
 bool test_cmd_descriptor_argv(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, root, "afl", "list functions", afl_argv_handler);
+	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, root, "afl", afl_argv_handler);
 	mu_assert_notnull (cd, "cmddesc created");
 	mu_assert_streq (cd->name, "afl", "command descriptor name is afl");
 	mu_assert_eq (cd->type, R_CMD_DESC_TYPE_ARGV, "type of command descriptor is argv");
 	mu_assert_ptreq (r_cmd_desc_parent (cd), root, "root parent descriptor");
 	mu_assert_eq (root->n_children, 1, "root has 1 child");
 	mu_assert_eq (cd->n_children, 0, "no children");
-	mu_assert_streq (cd->help, "list functions", "help was set");
 	r_cmd_free (cmd);
 	mu_end;
 }
@@ -99,9 +98,9 @@ bool test_cmd_descriptor_argv(void) {
 bool test_cmd_descriptor_argv_nested(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *af_cd = r_cmd_desc_inner_new (cmd, root, "af", "analyze functions");
-	r_cmd_desc_inner_new (cmd, root, "af2", "analyze functions2");
-	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, af_cd, "afl", "list functions", afl_argv_handler);
+	RCmdDesc *af_cd = r_cmd_desc_inner_new (cmd, root, "af");
+	r_cmd_desc_inner_new (cmd, root, "af2");
+	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, af_cd, "afl", afl_argv_handler);
 	mu_assert_ptreq (r_cmd_desc_parent (cd), af_cd, "parent of afl is af");
 	mu_assert_true (r_pvector_contains (&af_cd->children, cd), "afl is child of af");
 	r_cmd_free (cmd);
@@ -140,8 +139,8 @@ static int w_handler(void *user, const char *input) {
 bool test_cmd_descriptor_tree(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a", "analysis commands");
-	r_cmd_desc_argv_new (cmd, a_cd, "ap", "find prelude", ap_handler);
+	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a");
+	r_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler);
 	r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
 
 	void **it_cd;
@@ -157,8 +156,8 @@ bool test_cmd_descriptor_tree(void) {
 bool test_cmd_get_desc(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a", "analysis commands");
-	RCmdDesc *ap_cd = r_cmd_desc_argv_new (cmd, a_cd, "ap", "find prelude", ap_handler);
+	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a");
+	RCmdDesc *ap_cd = r_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler);
 	RCmdDesc *ae_cd = r_cmd_desc_oldinput_new (cmd, a_cd, "ae", ae_handler);
 	RCmdDesc *w_cd = r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
 
@@ -194,8 +193,8 @@ static int wv_handler(void *user, const char *input) {
 bool test_cmd_call_desc(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *p_cd = r_cmd_desc_inner_new (cmd, root, "p", "p commands");
-	r_cmd_desc_argv_new (cmd, p_cd, "pd", "print disasm", pd_handler);
+	RCmdDesc *p_cd = r_cmd_desc_inner_new (cmd, root, "p");
+	r_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler);
 	r_cmd_desc_oldinput_new (cmd, p_cd, "p", p_handler);
 	r_cmd_desc_oldinput_new (cmd, root, "wv", wv_handler);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The idea is to use RCmdDesc to hold info about different kinds of commands. RCmdDesc will be structured in a tree, used to keep the structure of the commands as we have now. Moreover, some of RCmdDesc are also stored in a hashtable for quick retrieval when you need to execute a command.

To keep supporting existing command handlers, there will be different kinds of RCmdDesc.
* `R_CMD_DESC_TYPE_OLDINPUT`: this is used to store info about the existing handlers. Those handlers accept `(void *user, const char *input)` and they do the parsing of input themselves. In a distant future, we should probably convert all these to something else, but it will require time.

* `R_CMD_DESC_TYPE_ARGV`: this store info about the new kind of command handlers, that accept argc/argv. There will be one RCmdDesc of this type for each command e.g. `agf`, `afl`, `af`, `wx`, `wv8`, etc.

* `R_CMD_DESC_TYPE_INNER`: this will represent an inner node in the help tree. For example, when you do `?` you see that `a[?]    analysis commands`. But then if you do `a?` you see that there is another "a", which is `a   alias for aai - analysis information`. The first "a" will be an inner node, which does not do anything special apart from providing some help msg and group together other nodes. The second "a" will be a R_CMD_DESC_TYPE_ARGV with the right handler for that command.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

So far I have just added some unit tests and adapted a bit the existing code to make it compile, but apart from that everything should still be working.