### PR TITLE
Improve itanium RTTI parsing ##anal

### DIFF
--- a/libr/anal/class.c
+++ b/libr/anal/class.c
@@ -815,10 +815,13 @@ R_API RAnalClassErr r_anal_class_vtable_get(RAnal *anal, const char *class_name,
 
 	vtable->offset = r_num_math (NULL, cur);
 
-	cur = next;
-	sdb_anext (cur, NULL);
-
-	vtable->size = r_num_math (NULL, cur);
+	if (next) {
+		cur = next;
+		sdb_anext (cur, NULL);
+		vtable->size = r_num_get (NULL, cur);
+	} else {
+		vtable->size = 0;
+	}
 
 	free (content);
 

--- a/libr/anal/rtti.c
+++ b/libr/anal/rtti.c
@@ -8,8 +8,7 @@ R_API char *r_anal_rtti_demangle_class_name(RAnal *anal, const char *name) {
 	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
 		return r_anal_rtti_msvc_demangle_class_name (&context, name);
 	}
-	// TODO: implement class name demangling for itanium
-	return NULL;
+	return r_anal_rtti_itanium_demangle_class_name (&context, name);
 }
 
 R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode) {
@@ -31,14 +30,17 @@ R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode) {
 	}
 }
 
-static void rtti_msvc_print_all(RVTableContext *context, int mode) {
+R_API void r_anal_rtti_print_all(RAnal *anal, int mode) {
+	RVTableContext context;
+	r_anal_vtable_begin (anal, &context);
+
 	bool use_json = mode == 'j';
 	if (use_json) {
 		r_cons_print ("[");
 	}
 
 	r_cons_break_push (NULL, NULL);
-	RList *vtables = r_anal_vtable_search (context);
+	RList *vtables = r_anal_vtable_search (&context);
 	RListIter *vtableIter;
 	RVTableInfo *table;
 
@@ -49,12 +51,15 @@ static void rtti_msvc_print_all(RVTableContext *context, int mode) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-
 			if (use_json && success) {
 				r_cons_print (",");
 				comma = true;
 			}
-			success = r_anal_rtti_msvc_print_at_vtable (context, table->saddr, mode, true);
+			if (context.abi == R_ANAL_CPP_ABI_MSVC) {
+				success = r_anal_rtti_msvc_print_at_vtable (&context, table->saddr, mode, true);
+			} else {
+				success = r_anal_rtti_itanium_print_at_vtable (&context, table->saddr, mode);
+			}
 			if (success) {
 				comma = false;
 				if (!use_json) {
@@ -76,56 +81,6 @@ static void rtti_msvc_print_all(RVTableContext *context, int mode) {
 	r_cons_break_pop ();
 }
 
-static void rtti_itanium_print_all(RVTableContext *context, int mode) {
-	bool use_json = mode == 'j';
-	bool json_first = true;
-	if (use_json) {
-		r_cons_print ("[");
-	}
-
-	r_cons_break_push (NULL, NULL);
-	RList *vtables = r_anal_vtable_search (context);
-	RListIter *vtableIter;
-	RVTableInfo *table;
-
-	if (vtables) {
-		r_list_foreach (vtables, vtableIter, table) {
-			if (r_cons_is_breaked ()) {
-				break;
-			}
-
-			if (use_json) {
-				if (json_first) {
-					json_first = false;
-				} else {
-					r_cons_print (",");
-				}
-			}
-			r_anal_rtti_itanium_print_at_vtable (context, table->saddr, mode);
-			if (!use_json) {
-				r_cons_print ("\n");
-			}
-		}
-	}
-	r_list_free (vtables);
-
-	if (use_json) {
-		r_cons_print ("]\n");
-	}
-
-	r_cons_break_pop ();
-}
-
-R_API void r_anal_rtti_print_all(RAnal *anal, int mode) {
-	RVTableContext context;
-	r_anal_vtable_begin (anal, &context);
-	if (context.abi == R_ANAL_CPP_ABI_MSVC) {
-		rtti_msvc_print_all (&context, mode);
-	} else {
-		rtti_itanium_print_all (&context, mode);
-	}
-}
-
 R_API void r_anal_rtti_recover_all(RAnal *anal) {
 	RVTableContext context;
 	r_anal_vtable_begin (anal, &context);
@@ -136,10 +91,9 @@ R_API void r_anal_rtti_recover_all(RAnal *anal) {
 		if (context.abi == R_ANAL_CPP_ABI_MSVC) {
 			r_anal_rtti_msvc_recover_all (&context, vtables);
 		} else {
-			// TODO: recovery for itanium
+			r_anal_rtti_itanium_recover_all (&context, vtables);
 		}
 	}
 	r_list_free (vtables);
 	r_cons_break_pop ();
 }
-

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2830,11 +2830,19 @@ const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin) {
 	return symbols;
 }
 
+static size_t get_word_size(struct MACH0_(obj_t) *bin) {
+	size_t word_size = MACH0_(get_bits)(bin) / 8;
+	if (word_size < 4) {
+		return 4;
+	}
+	return word_size;
+}
+
 static int parse_import_ptr(struct MACH0_(obj_t) *bin, struct reloc_t *reloc, int idx) {
 	int i, j, sym;
 	size_t wordsize;
 	ut32 stype;
-	wordsize = MACH0_(get_bits)(bin) / 8;
+	wordsize = get_word_size (bin);
 	if (idx < 0 || idx >= bin->nsymtab) {
 		return 0;
 	}
@@ -2981,7 +2989,7 @@ static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList * relocs,
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 	RSkipList *relocs = NULL;
 	ulebr ur = {NULL};
-	int wordsize = MACH0_(get_bits)(bin) / 8;
+	size_t wordsize = get_word_size (bin);
 	if (bin->dyld_info) {
 		ut8 *opcodes,*end, type = 0, rel_type = 0;
 		int lib_ord, seg_idx = -1, sym_ord = -1;

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -905,6 +905,7 @@ R_API void r_flag_bind(RFlag *f, RFlagBind *fb) {
 	fb->exist_at = r_flag_exist_at;
 	fb->get = r_flag_get;
 	fb->get_at = r_flag_get_at;
+	fb->get_list = r_flag_get_list;
 	fb->set = r_flag_set;
 	fb->unset = r_flag_unset;
 	fb->unset_name = r_flag_unset_name;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1885,10 +1885,12 @@ R_API void r_anal_rtti_msvc_print_base_class_descriptor(RVTableContext *context,
 R_API bool r_anal_rtti_msvc_print_at_vtable(RVTableContext *context, ut64 addr, int mode, bool strict);
 R_API void r_anal_rtti_msvc_recover_all(RVTableContext *vt_context, RList *vtables);
 
+R_API char *r_anal_rtti_itanium_demangle_class_name(RVTableContext *context, const char *name);
 R_API void r_anal_rtti_itanium_print_class_type_info(RVTableContext *context, ut64 addr, int mode);
 R_API void r_anal_rtti_itanium_print_si_class_type_info(RVTableContext *context, ut64 addr, int mode);
 R_API void r_anal_rtti_itanium_print_vmi_class_type_info(RVTableContext *context, ut64 addr, int mode);
-R_API void r_anal_rtti_itanium_print_at_vtable(RVTableContext *context, ut64 addr, int mode);
+R_API bool r_anal_rtti_itanium_print_at_vtable(RVTableContext *context, ut64 addr, int mode);
+R_API void r_anal_rtti_itanium_recover_all(RVTableContext *vt_context, RList *vtables);
 
 R_API char *r_anal_rtti_demangle_class_name(RAnal *anal, const char *name);
 R_API void r_anal_rtti_print_at_vtable(RAnal *anal, ut64 addr, int mode);

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -70,6 +70,7 @@ typedef bool (*RFlagExistAt)(RFlag *f, const char *flag_prefix, ut16 fp_size, ut
 typedef RFlagItem* (*RFlagGet)(RFlag *f, const char *name);
 typedef RFlagItem* (*RFlagGetAtAddr) (RFlag *f, ut64);
 typedef RFlagItem* (*RFlagGetAt)(RFlag *f, ut64 addr, bool closest);
+typedef const RList* (*RFlagGetList)(RFlag *f, ut64 addr);
 typedef RFlagItem* (*RFlagSet)(RFlag *f, const char *name, ut64 addr, ut32 size);
 typedef bool (*RFlagUnset)(RFlag *f, RFlagItem *item);
 typedef bool (*RFlagUnsetName)(RFlag *f, const char *name);
@@ -86,6 +87,7 @@ typedef struct r_flag_bind_t {
 	RFlagExistAt exist_at;
 	RFlagGet get;
 	RFlagGetAt get_at;
+	RFlagGetList get_list;
 	RFlagSet set;
 	RFlagUnset unset;
 	RFlagUnsetName unset_name;

--- a/test/db/anal/classes
+++ b/test/db/anal/classes
@@ -19,3 +19,100 @@ type_info
   virtual_0 @ 0x1400011ea (vtable + 0x0)
 EOF
 RUN
+
+NAME=anal classes armv7
+FILE=bins/mach0/TestRTTI-armv7
+CMDS=<<EOF
+avrr
+acl
+acll~\@
+avra~0x0000c1c8:0
+avra~vmi:0
+?e `avraj~{[0]}`~{:
+EOF
+EXPECT=<<EOF
+A
+B
+C
+D
+  virtual_0 @ 0xa235 (vtable + 0x0)
+  virtual_4 @ 0xa24f (vtable + 0x4)
+  virtual_8 @ 0xa269 (vtable + 0x8)
+  virtual_0 @ 0xa29d (vtable + 0x0)
+  virtual_4 @ 0xa24f (vtable + 0x4)
+  virtual_8 @ 0xa2cb (vtable + 0x8)
+  virtual_0 @ 0xa235 (vtable + 0x0)
+  virtual_4 @ 0xa2f9 (vtable + 0x4)
+  virtual_8 @ 0xa327 (vtable + 0x8)
+  virtual_0 @ 0xa29d (vtable + 0x0)
+  virtual_4 @ 0xa2f9 (vtable + 0x4)
+  virtual_8 @ 0xa363 (vtable + 0x8)
+Type Info at 0x0000c1c8:
+  Type Info type: __vmi_class_type_info
+type: __class_type_info
+found_at: 49228
+class_vtable: 49216
+ref_to_type_class: 8
+ref_to_type_name: 49137
+name: A
+name_unique: true
+EOF
+RUN
+
+NAME=anal classes arm64
+FILE=bins/mach0/TestRTTI-arm64
+CMDS=<<EOF
+avrr
+acl
+acll~\@
+avra~0x100008378:0
+avra~vmi:0
+?e `avraj~{[0]}`~{:
+EOF
+EXPECT=<<EOF
+A
+B
+C
+D
+  virtual_0 @ 0x100005f1c (vtable + 0x0)
+  virtual_8 @ 0x100005f44 (vtable + 0x8)
+  virtual_16 @ 0x100005f6c (vtable + 0x10)
+  virtual_0 @ 0x100005fbc (vtable + 0x0)
+  virtual_8 @ 0x100005f44 (vtable + 0x8)
+  virtual_16 @ 0x100006008 (vtable + 0x10)
+  virtual_0 @ 0x100005f1c (vtable + 0x0)
+  virtual_8 @ 0x100006054 (vtable + 0x8)
+  virtual_16 @ 0x1000060a0 (vtable + 0x10)
+  virtual_0 @ 0x100005fbc (vtable + 0x0)
+  virtual_8 @ 0x100006054 (vtable + 0x8)
+  virtual_16 @ 0x100006108 (vtable + 0x10)
+Type Info at 0x100008378:
+  Type Info type: __vmi_class_type_info
+type: __class_type_info
+found_at: 4295000208
+class_vtable: 4295000184
+ref_to_type_class: 16
+ref_to_type_name: 4294999928
+name: A
+name_unique: true
+EOF
+RUN
+
+NAME=anal classes arm64e
+FILE=bins/mach0/TestRTTI-arm64e
+BROKEN=1
+CMDS=<<EOF
+avrr
+acl
+avra~0x100008370:0
+avra~vmi:0
+EOF
+EXPECT=<<EOF
+A
+B
+C
+D
+Type Info at 0x100008370:
+  Type Info type: __vmi_class_type_info
+EOF
+RUN

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -543,49 +543,67 @@ aaa
 avra
 EOF
 EXPECT=<<EOF
-VMI Type Info at 0x08048f4c:
+Type Info at 0x08048f4c:
+  Type Info type: __vmi_class_type_info
+  Belongs to class vtable: 0x08048edc
   Reference to RTTI's type class: 0x0804b140
   Reference to type's name: 0x08048f6c
   Type Name: Bat
+  Name unique: true
   Flags: 0x0
   Count of base classes: 0x2
-      Base class type descriptor address: 0x08048f74
-      Base class flags: 0x2
-      Base class type descriptor address: 0x08048fac
-      Base class flags: 0x402
+    Base class type descriptor address: 0x08048f74
+    Base class flags: 0x2
+    Base class type descriptor address: 0x08048fac
+    Base class flags: 0x402
 
-VMI Type Info at 0x08048f4c:
+Type Info at 0x08048f4c:
+  Type Info type: __vmi_class_type_info
+  Belongs to class vtable: 0x08048ef0
   Reference to RTTI's type class: 0x0804b140
   Reference to type's name: 0x08048f6c
   Type Name: Bat
+  Name unique: true
   Flags: 0x0
   Count of base classes: 0x2
-      Base class type descriptor address: 0x08048f74
-      Base class flags: 0x2
-      Base class type descriptor address: 0x08048fac
-      Base class flags: 0x402
+    Base class type descriptor address: 0x08048f74
+    Base class flags: 0x2
+    Base class type descriptor address: 0x08048fac
+    Base class flags: 0x402
 
 Type Info at 0x08048f74:
+  Type Info type: __class_type_info
+  Belongs to class vtable: 0x08048f04
   Reference to RTTI's type class: 0x0804b048
   Reference to type's name: 0x08048f7c
   Type Name: Bird
+  Name unique: true
 
-SI Type Info at 0x08048f84:
+Type Info at 0x08048f84:
+  Type Info type: __si_class_type_info
+  Belongs to class vtable: 0x08048f18
   Reference to RTTI's type class: 0x0804b114
   Reference to type's name: 0x08048f90
   Type Name: Dog
-  Reference to parent's type name: 0x08048fac
+  Name unique: true
+  Reference to parent's type info: 0x08048fac
 
-SI Type Info at 0x08048f98:
+Type Info at 0x08048f98:
+  Type Info type: __si_class_type_info
+  Belongs to class vtable: 0x08048f2c
   Reference to RTTI's type class: 0x0804b114
   Reference to type's name: 0x08048fa4
   Type Name: Cat
-  Reference to parent's type name: 0x08048fac
+  Name unique: true
+  Reference to parent's type info: 0x08048fac
 
 Type Info at 0x08048fac:
+  Type Info type: __class_type_info
+  Belongs to class vtable: 0x08048f40
   Reference to RTTI's type class: 0x0804b048
   Reference to type's name: 0x08048fb4
   Type Name: Mammal
+  Name unique: true
 
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

- Improve itanium RTTI parsing, to work on MachO arm/arm64, to allow class recovery and to work even without symbols
- Improve vtable search, making it compatible with arm/arm64 and using simpler heuristics for carving the tables from the data section (inspired by paper "Devil is Virtual: Reversing Virtual Inheritance in C++ Binaries" (Rukayat, Erinfolami 2020) [arXiv:2003.05039](https://arxiv.org/abs/2003.05039))
- Fixed a bug in Mach-O parsing of relocs, for which on arm/thumb the pointers were wrongly aligned to 16 bits
- Fixed a NULL dereference in class.c for which incomplete vtables caused a segfault

NOTE: added tests, but the binaries are here: https://github.com/radareorg/radare2-testbins/pull/18