### PR TITLE
Windows sys/meson.py: Add r2 shell script

### DIFF
--- a/sys/meson.py
+++ b/sys/meson.py
@@ -172,6 +172,11 @@ def win_dist(args):
     with open(r2_bat_fname, 'w') as r2_bat:
         r2_bat.write('@"%~dp0\\radare2" %*\n')
 
+    r2_sh_fname = args.install + r'\bin\r2'
+    log.debug('create "%s"', r2_sh_fname)
+    with open(r2_sh_fname, 'w') as r2_sh:
+        r2_sh.write('#!/bin/sh\n$(dirname "$0")/radare2 "$@"\n')
+
     copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}\bin')
     makedirs(r'{DIST}\{R2_LIBDIR}')
     if args.shared:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

During Windows installation, this pr adds an `r2` shell script that calls `radare2`, for shells that don't recognize .bat or .cmd extensions (e.g. git bash). This is to support #16747.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Running `r2` on the git bash prompt works (assuming that it's in PATH ofc).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
