### PR TITLE
Fix r2r -i fix for single-line EXPECT=

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -162,7 +162,7 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 			} \
 			test->field.line_begin = linenum; \
 			test->field.value = read_string_val (&nextline, val, &linenum); \
-			test->field.line_end = linenum; \
+			test->field.line_end = linenum + 1; \
 			if (!test->field.value) { \
 				eprintf (LINEFMT "Error: Failed to read value for key \"%s\"\n", file, linenum, key); \
 				goto fail; \

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -794,17 +794,12 @@ static char *replace_lines(char *src, ut64 from, ut64 to, char *news) {
 		end++;
 		line++;
 	}
-	if (end && to != from) {
-		end = strchr (end, '\n');
-	}
 
 	RStrBuf buf;
 	r_strbuf_init (&buf);
 	r_strbuf_append_n (&buf, src, begin - src);
 	r_strbuf_append (&buf, news);
-	if (to == from) {
-		r_strbuf_append (&buf, "\n");
-	}
+	r_strbuf_append (&buf, "\n");
 	if (end) {
 		r_strbuf_append (&buf, end);
 	}


### PR DESCRIPTION
r2r -i and fix on the following:
```
CMDS=?e hello
EXPECT=
RUN
```

**Result Before:**
```
CMDS=?e hello
EXPECT=<<EOF
hello
EOF
EXPECT=
RUN
```

**Result After**
```
CMDS=?e hello
EXPECT=<<EOF
hello
EOF
RUN
```