### PR TITLE
Add F9 continue key to ESIL

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -838,10 +838,8 @@ static void visual_breakpoint(RCore *core) {
 static void visual_continue(RCore *core) {
 	if (r_config_get_i (core->config, "cfg.debug")) {
 		r_core_cmd (core, "dc", 0);
-	}
-	else {
-		r_core_cmd (core, "aec", 0);
-		r_core_cmd (core, ".ar*", 0);
+	} else {
+		r_core_cmd (core, "aec;.ar*", 0);
 	}
 }
 

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -836,7 +836,13 @@ static void visual_breakpoint(RCore *core) {
 }
 
 static void visual_continue(RCore *core) {
-	r_core_cmd (core, "dc", 0);
+	if (r_config_get_i (core->config, "cfg.debug")) {
+		r_core_cmd (core, "dc", 0);
+	}
+	else {
+		r_core_cmd (core, "aec", 0);
+		r_core_cmd (core, ".ar*", 0);
+	}
 }
 
 static int visual_nkey(RCore *core, int ch) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
<kbd>F9</kbd> key was to bind to continue if no debugger were attached. Now it will perform the `aec` command for ESIL.

**Test plan**

I could not find how to simulate the press of <kbd>F9</kbd> key in a test.
