### PR TITLE
Fix aggressive name filtering for PDB types

### DIFF
--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -1031,7 +1031,7 @@ static void print_types(R_PDB *pdb, int mode) {
 				sym = (lt == eLF_ENUM)? ',': ' ';
 				for (i = 0; i < members_amount; i++) {
 					char *eq = (lt == eLF_ENUM) ? strchr (members_name_field[i], '=') : NULL;
-					r_name_filter (members_name_field[i], -1);
+					r_name_filter2 (members_name_field[i]);
 					if (eq) {
 						*eq = '=';
 					}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This fixes types that start/end with underlines being trimmed

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

