### PR TITLE
Fix DWARF v4 parsing ##bin

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -363,7 +363,7 @@ static void get_ivar_list_t(mach0_ut p, RBinFile *bf, RBinClass *klass) {
 		}
 		prev_offset = field->offset;
 	}
-	if (field->offset > 0) {
+	if (first_offset > 0) {
 		RBinField *field = R_NEW0 (RBinField);
 		field->name = strdup ("_padding");
 		field->size = first_offset;

--- a/libr/include/r_util/r_uleb128.h
+++ b/libr/include/r_util/r_uleb128.h
@@ -9,7 +9,7 @@ R_API const ut8 *r_uleb128(const ut8 *data, int datalen, ut64 *v);
 R_API const ut8 *r_uleb128_decode(const ut8 *data, int *datalen, ut64 *v);
 R_API int r_uleb128_len (const ut8 *data, int size);
 R_API ut8 *r_uleb128_encode(const ut64 s, int *len);
-R_API const ut8 *r_leb128(const ut8 *data, st64 *v);
+R_API const ut8 *r_leb128(const ut8 *data, int datalen, st64 *v);
 R_API st64 r_sleb128(const ut8 **data, const ut8 *end);
 R_API size_t read_u32_leb128(const ut8 *p, const ut8 *max, ut32 *out_val);
 R_API size_t read_i32_leb128(const ut8 *p, const ut8 *max, st32 *out_val);

--- a/libr/util/uleb128.c
+++ b/libr/util/uleb128.c
@@ -102,11 +102,16 @@ R_API ut8 *r_uleb128_encode(const ut64 s, int *len) {
 	return otarget;
 }
 
-R_API const ut8 *r_leb128(const ut8 *data, st64 *v) {
+R_API const ut8 *r_leb128(const ut8 *data, int datalen, st64 *v) {
 	ut8 c = 0;
 	st64 s = 0, sum = 0;
-	if (data) {
-		for (s = 0; *data;) {
+	const ut8 *data_end = data + datalen;
+	if (data && datalen > 0) {
+		if (!*data) {
+			data++;
+			goto beach;
+		}
+		while (data < data_end) {
 			c = *(data++) & 0x0ff;
 			sum |= ((st64) (c & 0x7f) << s);
 			s += 7;
@@ -118,6 +123,7 @@ R_API const ut8 *r_leb128(const ut8 *data, st64 *v) {
 	if ((s < (8 * sizeof (sum))) && (c & 0x40)) {
 		sum |= -((st64)1 << s);
 	}
+beach:
 	if (v) {
 		*v = sum;
 	}

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -431,7 +431,7 @@ pd 1
 EOF
 EXPECT=<<EOF
            .blah:
-               31ed           xor ebp, ebp
+               31ed           xor ebp, ebp           ; /builddir/glibc-2.19/csu/../sysdeps/x86_64//start.S:67
 EOF
 RUN
 

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -13,3 +13,14 @@ EXPECT=<<EOF
 |           0x0040052d      55             push rbp                    ; /tmp/r2-regressions/.//dwarftest.c:4
 EOF
 RUN
+
+NAME="Mach-O dSYM lines (armv7)"
+FILE=bins/mach0/TestRTTI-armv7-dSYM
+CMDS=<<EOF
+CL 0x0000a24e
+EOF
+EXPECT=<<EOF
+file: TestRTTI/TestRTTI.cpp
+line: 18
+EOF
+RUN

--- a/test/db/cmd/lea_intel
+++ b/test/db/cmd/lea_intel
@@ -8,22 +8,22 @@ s 0x00402c43
 pd 30
 EOF
 EXPECT=<<EOF
-  0x00402c43      lea rax, [rbp - 0xa0]
+  0x00402c43      lea rax, [rbp - 0xa0]                                ; .//ezpz.cpp:265
   0x00402c4a      mov rdi, rax
   0x00402c4d      call sym MD5_Init(MD5_CTX*)
-  0x00402c52      mov eax, dword [rbp - 0xb4]
+  0x00402c52      mov eax, dword [rbp - 0xb4]                          ; .//ezpz.cpp:266
   0x00402c58      add eax, 1
   0x00402c5b      movsxd rdx, eax
   0x00402c5e      lea rax, [rbp - 0xa0]
   0x00402c65      mov esi, obj.Password
   0x00402c6a      mov rdi, rax
   0x00402c6d      call sym MD5_Update(MD5_CTX*, void const*, unsigned long)
-  0x00402c72      lea rdx, [rbp - 0xa0]
+  0x00402c72      lea rdx, [rbp - 0xa0]                                ; .//ezpz.cpp:267
   0x00402c79      lea rax, [rbp - 0xb0]
   0x00402c80      mov rsi, rdx
   0x00402c83      mov rdi, rax
   0x00402c86      call sym MD5_Final(unsigned char*, MD5_CTX*)
-  0x00402c8b      mov eax, dword [rbp - 0xb4]
+  0x00402c8b      mov eax, dword [rbp - 0xb4]                          ; .//ezpz.cpp:269
   0x00402c91      cdqe
   0x00402c93      shl rax, 4
   0x00402c97      lea rcx, [rax + obj.GoodHashes]
@@ -34,9 +34,9 @@ EXPECT=<<EOF
   0x00402cb0      call sym.imp.memcmp
   0x00402cb5      test eax, eax
   0x00402cb7      je 0x402cc2
-  0x00402cb9      mov byte [obj.DrawGoodWork], 0
+  0x00402cb9      mov byte [obj.DrawGoodWork], 0                       ; .//ezpz.cpp:270
   0x00402cc0      jmp 0x402cdd
-  0x00402cc2      add dword [rbp - 0xb4], 1
+  0x00402cc2      add dword [rbp - 0xb4], 1                            ; .//ezpz.cpp:263
   0x00402cc9      cmp dword [rbp - 0xb4], 0x14
 EOF
 RUN

--- a/test/unit/test_uleb128.c
+++ b/test/unit/test_uleb128.c
@@ -77,11 +77,21 @@ bool test_sleb128_big(void) {
 	mu_end;
 }
 
+bool test_leb128_correctness(void) {
+	st64 val;
+	const ut8 *data = (ut8 *)"\xc5\x00";
+	const ut8 *buf = r_leb128 (data, 2, &val);
+	mu_assert_eq (val, 69, "leb128 decoded");
+	mu_assert_eq (buf, data + 2, "leb128 decoded");
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_uleb128_small);
 	mu_run_test (test_sleb128_small);
 	mu_run_test (test_uleb128_big);
 	mu_run_test (test_sleb128_big);
+	mu_run_test (test_leb128_correctness);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

What was the problem: DWARF parsing with large dSYM files for iOS had both stability and correctness issues, here's the solution:

- fix `r_leb128` decoding logic and add support for boundary checking
- support up to v4
- ensure all v4 line number program header fields are parsed
- remove wrong assumptions about the content of included directories
- ensure unit length calculation is correct
- ensure all leb128 / uleb128 have boundary checking

Along the way also fixed what i think it's typo in `mach0_classes.c` which caused a NULL dereference.

**Test plan**

Added a test in `test/db/cmd/dwarf` which relies on a binary added here: https://github.com/radareorg/radare2-testbins/pull/19
