### PR TITLE
When getting terminal size on mintty, reuse prev vals if rows=0

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1332,8 +1332,13 @@ static bool __xterm_get_size(void) {
 	if (write (I.fdout, R_CONS_CURSOR_SAVE, sizeof (R_CONS_CURSOR_SAVE)) < 1) {
 		return false;
 	}
+	int rows, columns;
 	(void)write (I.fdout, "\x1b[999;999H", sizeof ("\x1b[999;999H"));
-	I.rows = __xterm_get_cur_pos (&I.columns);
+	rows = __xterm_get_cur_pos (&columns);
+	if (rows) {
+		I.rows = rows;
+		I.columns = columns;
+	} // otherwise reuse previous values
 	(void)write (I.fdout, R_CONS_CURSOR_RESTORE, sizeof (R_CONS_CURSOR_RESTORE));
 	return true;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Occasionally on mintty, `__xterm_get_size()` will get a value of 0 for rows which can disrupt the Visual mode display. This pr fixes that by reusing previous values if so, and assumes that all is fine and dandy at time = 0.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Expand the mintty terminal window to full size, run `r2 --`, go to Visual mode (`V`) and hold down the arrow-down key. The display should not flicker.

I use the mintty from git bash.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
