### PR TITLE
Remove RCoreCmdStatus and just use RCmdStatus

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4566,7 +4566,7 @@ struct tsr2cmd_edit {
 	TSPoint end_point;
 };
 
-typedef RCoreCmdStatus (*ts_handler)(struct tsr2cmd_state *state, TSNode node);
+typedef RCmdStatus (*ts_handler)(struct tsr2cmd_state *state, TSNode node);
 
 struct ts_data_symbol_map {
 	const char *name;
@@ -4605,29 +4605,29 @@ static char *ts_node_sub_parent_string(TSNode parent, TSNode node, const char *c
 	DEFINE_IS_TS_FCN (name)
 
 #define DEFINE_HANDLE_TS_FCN(name) \
-	static RCoreCmdStatus handle_ts_##name##_internal(struct tsr2cmd_state *state, TSNode node, char *node_string); \
-	static RCoreCmdStatus handle_ts_##name(struct tsr2cmd_state *state, TSNode node) { \
+	static RCmdStatus handle_ts_##name##_internal(struct tsr2cmd_state *state, TSNode node, char *node_string); \
+	static RCmdStatus handle_ts_##name(struct tsr2cmd_state *state, TSNode node) { \
 		char *node_string = ts_node_sub_string (node, state->input); \
 		R_LOG_DEBUG (#name ": '%s'\n", node_string); \
-		RCoreCmdStatus res = handle_ts_##name##_internal (state, node, node_string); \
+		RCmdStatus res = handle_ts_##name##_internal (state, node, node_string); \
 		free (node_string); \
 		return res; \
 	} \
-	static RCoreCmdStatus handle_ts_##name##_internal(struct tsr2cmd_state *state, TSNode node, char *node_string)
+	static RCmdStatus handle_ts_##name##_internal(struct tsr2cmd_state *state, TSNode node, char *node_string)
 
 #define DEFINE_HANDLE_TS_FCN_AND_SYMBOL(name) \
 	DEFINE_SYMBOL_TS_FCN (name); \
 	DEFINE_HANDLE_TS_FCN (name)
 
 #define UPDATE_CMD_STATUS_RES(res, cmd_res, label) \
-	if ((cmd_res) == R_CORE_CMD_STATUS_EXIT || (cmd_res) == R_CORE_CMD_STATUS_INVALID) { \
+	if ((cmd_res) == R_CMD_STATUS_EXIT || (cmd_res) == R_CMD_STATUS_INVALID) { \
 		res = cmd_res; \
 		goto label; \
 	}
 
-static RCoreCmdStatus handle_ts_command(struct tsr2cmd_state *state, TSNode node);
-static RCoreCmdStatus handle_ts_command_tmpseek(struct tsr2cmd_state *state, TSNode node);
-static RCoreCmdStatus core_cmd_tsr2cmd(RCore *core, const char *cstr, bool split_lines, bool log);
+static RCmdStatus handle_ts_command(struct tsr2cmd_state *state, TSNode node);
+static RCmdStatus handle_ts_command_tmpseek(struct tsr2cmd_state *state, TSNode node);
+static RCmdStatus core_cmd_tsr2cmd(RCore *core, const char *cstr, bool split_lines, bool log);
 
 DEFINE_IS_TS_FCN_AND_SYMBOL(fdn_redirect_operator)
 DEFINE_IS_TS_FCN_AND_SYMBOL(fdn_append_operator)
@@ -4648,23 +4648,23 @@ DEFINE_IS_TS_FCN_AND_SYMBOL(concatenation)
 DEFINE_IS_TS_FCN_AND_SYMBOL(grep_specifier)
 DEFINE_IS_TS_FCN_AND_SYMBOL(commands)
 
-static RCoreCmdStatus int2cmdstatus(int v) {
+static RCmdStatus int2cmdstatus(int v) {
 	if (v == R_CORE_CMD_EXIT) {
-		return R_CORE_CMD_STATUS_EXIT;
+		return R_CMD_STATUS_EXIT;
 	} else if (v < 0) {
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	} else {
-		return R_CORE_CMD_STATUS_OK;
+		return R_CMD_STATUS_OK;
 	}
 }
 
-static int cmdstatus2int(RCoreCmdStatus s) {
+static int cmdstatus2int(RCmdStatus s) {
 	switch (s) {
-	case R_CORE_CMD_STATUS_OK:
+	case R_CMD_STATUS_OK:
 		return 0;
-	case R_CORE_CMD_STATUS_INVALID:
+	case R_CMD_STATUS_INVALID:
 		return -1;
-	case R_CORE_CMD_STATUS_EXIT:
+	case R_CMD_STATUS_EXIT:
 	default:
 		return R_CORE_CMD_EXIT;
 	}
@@ -4992,7 +4992,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(arged_command) {
 	char *command_str = ts_node_sub_string (command, state->input);
 	R_LOG_DEBUG ("arged_command command: '%s'\n", command_str);
 	TSNode args = ts_node_child_by_field_name (node, "args", strlen ("args"));
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID;
+	RCmdStatus res = R_CMD_STATUS_INVALID;
 
 	// FIXME: this special handling should be removed once we have a proper
 	//        command tree
@@ -5027,7 +5027,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(arged_command) {
 	}
 
 	pr_args->has_space_after_cmd = !ts_node_is_null (args) && ts_node_end_byte (command) < ts_node_start_byte (args);
-	res = int2cmdstatus (r_cmd_call_parsed_args (state->core->rcmd, pr_args));
+	res = r_cmd_call_parsed_args (state->core->rcmd, pr_args);
 
 err:
 	r_cmd_parsed_args_free (pr_args);
@@ -5048,18 +5048,18 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(repeat_command) {
 	TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
 	if (rep > 1 && r_sandbox_enable (0)) {
 		eprintf ("Command repeat sugar disabled in sandbox mode (%s)\n", node_string);
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 	if (rep > INTERACTIVE_MAX_REP && r_cons_is_interactive ()) {
 		if (!r_cons_yesno ('n', "Are you sure to repeat this %" PFMT64d " times? (y/N)", rep)) {
-			return R_CORE_CMD_STATUS_INVALID;
+			return R_CMD_STATUS_INVALID;
 		}
 	}
 
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	size_t i;
 	for (i = 0; i < rep; i++) {
-		RCoreCmdStatus cmd_res = handle_ts_command (state, command);
+		RCmdStatus cmd_res = handle_ts_command (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
 err:
@@ -5070,7 +5070,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(redirect_command) {
 	int pipecolor = r_config_get_i (state->core->config, "scr.color.pipe");
 	int ocolor = r_config_get_i (state->core->config, "scr.color");
 	int scr_html = -1;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID, is_append = false, is_html = false;
+	RCmdStatus res = R_CMD_STATUS_INVALID, is_append = false, is_html = false;
 	int fdn = 1;
 
 	TSNode redirect_op = ts_node_child_by_field_name (node, "redirect_operator", strlen ("redirect_operator"));
@@ -5127,7 +5127,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(redirect_command) {
 		r_cmd_alias_set (state->core->rcmd, arg_str, new_alias_value, 1);
 		free (new_alias_value);
 		free (command_str);
-		res = R_CORE_CMD_STATUS_OK;
+		res = R_CMD_STATUS_OK;
 	} else {
 		r_cons_flush ();
 		R_LOG_DEBUG ("redirect_command: fdn = %d, is_append = %d\n", fdn, is_append);
@@ -5182,13 +5182,13 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_command) {
 		}
 		node_string[node_len - 2 - detail] = '\0';
 		recursive_help (state->core, detail, node_string);
-		return R_CORE_CMD_STATUS_OK;
+		return R_CMD_STATUS_OK;
 	} else {
 		TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
 		char *command_str = ts_node_sub_string (command, state->input);
 		TSNode args = ts_node_child_by_field_name (node, "args", strlen ("args"));
 		RCmdParsedArgs *pr_args = NULL;
-		int res = -1;
+		RCmdStatus res = R_CMD_STATUS_INVALID;
 		if (!ts_node_is_null (args)) {
 			pr_args = ts_node_handle_arg_prargs (state, node, args, 1);
 			if (!pr_args) {
@@ -5205,9 +5205,9 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_command) {
 	err_else:
 		r_cmd_parsed_args_free (pr_args);
 		free (command_str);
-		return int2cmdstatus (res);
+		return res;
 	}
-	return R_CORE_CMD_STATUS_OK;
+	return R_CMD_STATUS_OK;
 }
 
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_seek_command) {
@@ -5221,7 +5221,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_seek_command) {
 	}
 	R_LOG_DEBUG ("tmp_seek_command, changing offset to %" PFMT64x "\n", offset_val);
 	r_core_seek (state->core, offset_val, true);
-	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
+	RCmdStatus res = handle_ts_command_tmpseek (state, command);
 	r_core_seek (state->core, orig_offset, true);
 	free (offset_string);
 	return res;
@@ -5234,7 +5234,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_blksz_command) {
 	ut64 orig_blksz = state->core->blocksize;
 	R_LOG_DEBUG ("tmp_blksz_command, changing blksz to %s\n", blksz_string);
 	r_core_block_size (state->core, r_num_math (state->core->num, blksz_string));
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	r_core_block_size (state->core, orig_blksz);
 	free (blksz_string);
 	return res;
@@ -5267,7 +5267,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_fromto_command) {
 		r_config_set_i (core->config, tovars[i], to_val);
 	}
 
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 
 	r_config_hold_restore (hc);
 
@@ -5297,7 +5297,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_arch_command) {
 	is_arch_set = set_tmp_arch (core, arg_str, &tmparch);
 
 	// execute command with changed settings
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 
 	// restore original settings
 	if (is_arch_set) {
@@ -5329,7 +5329,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_bits_command) {
 	int bits = r_num_math (core->num, arg_str);
 	set_tmp_bits (core, bits, &tmpbits, &cmd_ignbithints);
 
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 
 	r_config_set (core->config, "asm.bits", tmpbits);
 	core->fixedbits = oldfixedbits;
@@ -5365,7 +5365,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_nthi_command) {
 		eprintf ("Can't find a basic block for 0x%08" PFMT64x "\n", core->offset);
 	}
 
-	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
+	RCmdStatus res = handle_ts_command_tmpseek (state, command);
 
 	r_core_seek (core, orig_offset, true);
 
@@ -5395,7 +5395,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_eval_command) {
 		free (arg_str);
 	}
 
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 
 	r_config_hold_restore (hc);
 	r_config_hold_free (hc);
@@ -5408,7 +5408,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_fs_command) {
 	TSNode arg = ts_node_named_child (node, 1);
 	char *arg_str = ts_node_handle_arg (state, node, arg, 1);
 	r_flag_space_push (core->flags, arg_str);
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	r_flag_space_pop (core->flags);
 	free (arg_str);
 	return res;
@@ -5424,7 +5424,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_reli_command) {
 	if (addr) {
 		r_core_cmdf (core, "so %" PFMT64d, addr);
 	}
-	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
+	RCmdStatus res = handle_ts_command_tmpseek (state, command);
 	r_core_seek (state->core, orig_offset, true);
 	free (arg_str);
 	return res;
@@ -5441,7 +5441,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_kuery_command) {
 		r_core_seek (core, r_num_math(core->num, out), true);
 		free (out);
 	}
-	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
+	RCmdStatus res = handle_ts_command_tmpseek (state, command);
 	r_core_seek (state->core, orig_offset, true);
 	free (arg_str);
 	return res;
@@ -5454,7 +5454,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_fd_command) {
 	char *arg_str = ts_node_handle_arg (state, node, arg, 1);
 	int tmpfd = core->io->desc? core->io->desc->fd: -1;
 	r_io_use_fd (core->io, atoi (arg_str));
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	r_io_use_fd (core->io, tmpfd);
 	free (arg_str);
 	return res;
@@ -5469,7 +5469,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_reg_command) {
 	// TODO: add support for operations (e.g. @r:PC+10)
 	ut64 regval = r_debug_reg_get (core->dbg, arg_str);
 	r_core_seek (core, regval, true);
-	RCoreCmdStatus res = handle_ts_command_tmpseek (state, command);
+	RCmdStatus res = handle_ts_command_tmpseek (state, command);
 	r_core_seek (core, orig_offset, true);
 	free (arg_str);
 	return res;
@@ -5478,7 +5478,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_reg_command) {
 static bool handle_tmp_desc(struct tsr2cmd_state *state, TSNode command, const ut8 *buf, int sz) {
 	RCore *core = state->core;
 	int pamode = !core->io->va;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID, o_fixedblock = core->fixedblock;
+	RCmdStatus res = R_CMD_STATUS_INVALID, o_fixedblock = core->fixedblock;
 	RBuffer *b = r_buf_new_with_bytes (buf, sz);
 	RIODesc *d = r_io_open_buffer (core->io, b, R_PERM_RWX, 0);
 	if (!d) {
@@ -5511,7 +5511,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_file_command) {
 	TSNode arg = ts_node_named_child (node, 1);
 	char *arg_str = ts_node_handle_arg (state, node, arg, 1);
 	size_t sz;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID;
+	RCmdStatus res = R_CMD_STATUS_INVALID;
 
 	char *f = r_file_slurp (arg_str, &sz);
 	if (!f) {
@@ -5536,7 +5536,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_string_command) {
 	sz = strlen (arg_str);
 	const ut8 *buf = (const ut8 *)arg_str;
 
-	RCoreCmdStatus res = handle_tmp_desc (state, command, buf, sz);
+	RCmdStatus res = handle_tmp_desc (state, command, buf, sz);
 
 	free (arg_str);
 	return res;
@@ -5552,7 +5552,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(tmp_hex_command) {
 	ut8 *buf = R_NEWS (ut8, len + 1);
 	sz = r_hex_str2bin (arg_str, buf);
 
-	RCoreCmdStatus res = handle_tmp_desc (state, command, buf, sz);
+	RCmdStatus res = handle_tmp_desc (state, command, buf, sz);
 
 	free (buf);
 	free (arg_str);
@@ -5567,10 +5567,10 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_flags_command) {
 	const RSpace *flagspace = r_flag_space_cur (core->flags);
 	RFlagItem *flag;
 	RListIter *iter;
-	RCoreCmdStatus ret = R_CORE_CMD_STATUS_OK;
+	RCmdStatus ret = R_CMD_STATUS_OK;
 	RList *match_flag_items = r_list_newf ((RListFree)r_flag_item_free);
 	if (!match_flag_items) {
-		return R_CORE_CMD_STATUS_OK;
+		return R_CMD_STATUS_OK;
 	}
 
 	/* duplicate flags that match word, to be sure the command is going to
@@ -5593,7 +5593,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_flags_command) {
 		R_LOG_DEBUG ("iter_flags_command: seek to %" PFMT64x "\n", flag->offset);
 		r_core_seek (core, flag->offset, true);
 		r_cons_push ();
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		tmp = r_cons_get_buffer ();
 		buf = tmp? strdup (tmp): NULL;
 		r_cons_pop ();
@@ -5622,7 +5622,7 @@ static bool iter_dbt_commands(struct tsr2cmd_state *state, TSNode node, enum dbt
 	ut64 orig_offset = core->offset;
 	RDebugFrame *frame;
 	RListIter *iter;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 
 	r_list_foreach (list, iter, frame) {
 		switch (mode) {
@@ -5637,9 +5637,9 @@ static bool iter_dbt_commands(struct tsr2cmd_state *state, TSNode node, enum dbt
 			break;
 		default:
 			r_warn_if_reached ();
-			return R_CORE_CMD_STATUS_INVALID;
+			return R_CMD_STATUS_INVALID;
 		}
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		r_cons_newline ();
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
@@ -5664,14 +5664,14 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_dbts_command) {
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_file_lines_command) {
 	// TODO: old implementation has some unknown check on '('
 	RCore *core = state->core;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	TSNode command = ts_node_named_child (node, 0);
 	TSNode arg = ts_node_named_child (node, 1);
 	char *arg_str = ts_node_handle_arg(state, node, arg, 1);
 	ut64 orig_offset = core->offset;
 	FILE *fd = r_sandbox_fopen (arg_str, "r");
 	if (!fd) {
-		res = R_CORE_CMD_STATUS_INVALID;
+		res = R_CMD_STATUS_INVALID;
 		goto arg_out;
 	}
 
@@ -5684,7 +5684,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_file_lines_command) {
 		}
 		ut64 addr = r_num_math (core->num, buf);
 		r_core_seek (core, addr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		core->rcmd->macro.counter++;
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
@@ -5699,11 +5699,11 @@ arg_out:
 
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_offsets_command) {
 	RCore *core = state->core;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	TSNode command = ts_node_named_child (node, 0);
 	if (ts_node_named_child_count (node) < 2) {
 		// no offsets provided, all's good.
-		return R_CORE_CMD_STATUS_OK;
+		return R_CMD_STATUS_OK;
 	}
 
 	TSNode args = ts_node_named_child (node, 1);
@@ -5712,7 +5712,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_offsets_command) {
 	RCmdParsedArgs *a = ts_node_handle_arg_prargs (state, node, args, 1);
 	if (!a) {
 		R_LOG_ERROR ("Cannot parse args\n");
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 
 	const char *s;
@@ -5721,7 +5721,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_offsets_command) {
 		ut64 addr = r_num_math (core->num, s);
 		R_LOG_DEBUG ("iter_offsets_command: seek to %" PFMT64x "\n", addr);
 		r_core_seek (core, addr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		r_cons_flush ();
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
@@ -5741,11 +5741,11 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_sdbquery_command) {
 
 	char *out = sdb_querys (core->sdb, NULL, 0, arg_str);
 	if (!out) {
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 	char *str, *each = out;
 	ut64 addr;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	do {
 		while (*each == ' ') {
 			each++;
@@ -5763,7 +5763,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_sdbquery_command) {
 		}
 		each = str + 1;
 		r_core_seek (core, addr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		r_cons_flush ();
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	} while (str != NULL);
@@ -5779,17 +5779,17 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_threads_command) {
 	TSNode command = ts_node_named_child (node, 0);
 	int pid = core->dbg->pid;
 	if (!core->dbg->h || !core->dbg->h->pids) {
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	RList *list = core->dbg->h->pids (core->dbg, R_MAX (0, pid));
 	RListIter *iter;
 	RDebugPid *p;
 	r_list_foreach (list, iter, p) {
 		r_cons_printf ("# PID %d\n", p->pid);
 		r_debug_select (core->dbg, p->pid, p->pid);
-		RCoreCmdStatus cmd_res = handle_ts_command (state, command);
+		RCmdStatus cmd_res = handle_ts_command (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		r_cons_newline ();
 	}
@@ -5806,17 +5806,17 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_bbs_command) {
 	RAnalBlock *bb;
 	int bs = core->blocksize;
 	ut64 orig_offset = core->offset;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, core->offset);
 	if (!fcn) {
 		eprintf ("No function at current address\n");
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 	r_list_sort (fcn->bbs, bb_cmp);
 	r_list_foreach (fcn->bbs, iter, bb) {
 		r_core_block_size (core, bb->size);
 		r_core_seek (core, bb->addr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		if (r_cons_is_breaked ()) {
 			break;
@@ -5834,13 +5834,13 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_instrs_command) {
 	RListIter *iter;
 	RAnalBlock *bb;
 	int i;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	ut64 orig_offset = core->offset;
 	int bs = core->blocksize;
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, core->offset);
 	if (!fcn) {
 		eprintf ("No function at current address\n");
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 	r_list_sort (fcn->bbs, bb_cmp);
 	r_list_foreach (fcn->bbs, iter, bb) {
@@ -5849,7 +5849,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_instrs_command) {
 			int sz = r_anal_bb_size_i (bb, i);
 			r_core_block_size (core, sz);
 			r_core_seek (core, addr, true);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 			if (r_cons_is_breaked ()) {
 				break;
@@ -5868,7 +5868,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_functions_command) {
 	TSNode arg = ts_node_named_child (node, 1);
 	char *arg_str = NULL;
 	RCore *core = state->core;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	ut64 orig_offset = core->offset;
 	int bs = core->blocksize;
 	RAnalFunction *fcn;
@@ -5886,7 +5886,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_functions_command) {
 		r_core_block_size (core, r_anal_function_linear_size (fcn));
 		r_core_seek (core, fcn->addr, true);
 		r_cons_push ();
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		buf = (char *)r_cons_get_buffer ();
 		if (buf) {
 			buf = strdup (buf);
@@ -5913,7 +5913,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_step_command) {
 	TSNode to_n = ts_node_named_child (node, 2);
 	TSNode step_n = ts_node_named_child (node, 3);
 	RCore *core = state->core;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	ut64 orig_offset = core->offset;
 	int bs = core->blocksize;
 
@@ -5931,7 +5931,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_step_command) {
 	for (cur = from; cur < to; cur += step) {
 		r_core_seek (core, cur, true);
 		r_core_block_size (core, step);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		if (r_cons_is_breaked ()) {
 			break;
@@ -5966,7 +5966,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_command) {
 	if (!ok) {
 		r_list_free (edits);
 		substitute_args_fini (state);
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 	TSNode args = ts_node_named_child (new_command, 1);
 
@@ -5974,7 +5974,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_command) {
 	if (!a) {
 		r_list_free (edits);
 		substitute_args_fini (state);
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 
 	r_list_free (edits);
@@ -5983,12 +5983,12 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_command) {
 	const char *s;
 	int i;
 	ut64 orig_offset = core->offset;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	r_cmd_parsed_args_foreach_arg (a, i, s) {
 		ut64 addr = r_num_math (core->num, s);
 		R_LOG_DEBUG ("iter_interpret_command: seek to %" PFMT64x "\n", addr);
 		r_core_seek (core, addr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		r_cons_flush ();
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
@@ -6005,7 +6005,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_hit_command) {
 	char *command_str = ts_node_sub_string (command, state->input);
 	char *cmdhit = strdup (r_config_get (core->config, "cmd.hit"));
 	r_config_set (core->config, "cmd.hit", command_str);
-	RCoreCmdStatus res = handle_ts_command (state, search_cmd);
+	RCmdStatus res = handle_ts_command (state, search_cmd);
 	r_config_set (core->config, "cmd.hit", cmdhit);
 	free (command_str);
 	return res;
@@ -6015,7 +6015,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_addrsize_command) {
 	RCore *core = state->core;
 	TSNode command = ts_node_named_child (node, 0);
 	uint32_t i = 1;
-	RCoreCmdStatus ret = R_CORE_CMD_STATUS_OK;
+	RCmdStatus ret = R_CMD_STATUS_OK;
 	TSNode seek_addr_node = ts_node_named_child (node, i);
 	TSNode blk_sz_node = ts_node_named_child (node, i + 1);
 	ut64 orig_offset = core->offset;
@@ -6029,7 +6029,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_addrsize_command) {
 		free (blk_sz_str);
 		r_core_seek (core, seek_addr_val, true);
 		r_core_block_size (core, blk_sz_val);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (ret, cmd_res, err);
 		i += 2;
 		seek_addr_node = ts_node_named_child (node, i);
@@ -6048,16 +6048,16 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_bb_command) {
 	ut64 offorig = core->offset;
 	ut64 obs = core->blocksize;
 	if (!fcn) {
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 
 	RListIter *iter;
 	RAnalBlock *bb;
-	RCoreCmdStatus ret = R_CORE_CMD_STATUS_OK;
+	RCmdStatus ret = R_CMD_STATUS_OK;
 	r_list_foreach (fcn->bbs, iter, bb) {
 		r_core_seek (core, bb->addr, true);
 		r_core_block_size (core, bb->size);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (ret, cmd_res, err);
 	}
 err:
@@ -6075,7 +6075,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_cmd_command) {
 	RList *edits = r_list_newf ((RListFree)free_tsr2cmd_edit);
 	if (!edits) {
 		substitute_args_fini (state);
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
 
 	char *in_cmd_out = do_handle_substitution_cmd (state, in_cmd);
@@ -6091,9 +6091,9 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_cmd_command) {
 	if (!substitute_args_do (state, edits, &new_command)) {
 		r_list_free (edits);
 		substitute_args_fini (state);
-		return R_CORE_CMD_STATUS_INVALID;
+		return R_CMD_STATUS_INVALID;
 	}
-	RCoreCmdStatus res = handle_ts_command (state, new_command);
+	RCmdStatus res = handle_ts_command (state, new_command);
 	r_list_free (edits);
 	substitute_args_fini (state);
 	return res;
@@ -6106,7 +6106,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_comment_command) {
 		.state = state,
 	};
 	r_meta_list_cb (state->core->anal, R_META_TYPE_COMMENT, 0, foreach_comment_newshell, (void *)&cmt_t, UT64_MAX);
-	return R_CORE_CMD_STATUS_OK;
+	return R_CMD_STATUS_OK;
 }
 
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_import_command) {
@@ -6116,7 +6116,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_import_command) {
 	ut64 offorig = core->offset;
 	RList *list = r_bin_get_imports (core->bin);
 	if (!list) {
-		return R_CORE_CMD_STATUS_OK;
+		return R_CMD_STATUS_OK;
 	}
 
 	RList *lost = r_list_newf (free);
@@ -6130,12 +6130,12 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_import_command) {
 		free (impflag);
 	}
 	ut64 *naddr;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	r_list_foreach (lost, iter, naddr) {
 		ut64 addr = *naddr;
 		if (addr && addr != UT64_MAX) {
 			r_core_seek (core, addr, true);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	}
@@ -6150,7 +6150,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_register_command) {
 	TSNode command = ts_node_named_child (node, 0);
 	ut64 offorig = core->offset;
 	int i;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	for (i = 0; i < R_REG_TYPE_LAST; i++) {
 		RRegItem *item;
 		ut64 value;
@@ -6174,7 +6174,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_register_command) {
 			value = r_reg_getv (core->dbg->reg, item_name);
 			r_core_seek (core, value, true);
 			r_cons_printf ("%s: ", item_name);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	err:
@@ -6198,14 +6198,14 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_symbol_command) {
 		RBinSymbol *bs = r_mem_dup (sym, sizeof (RBinSymbol));
 		r_list_append (lost, bs);
 	}
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	r_list_foreach (lost, iter, sym) {
 		if (r_cons_is_breaked ()) {
 			break;
 		}
 		r_core_block_size (core, sym->size);
 		r_core_seek (core, sym->vaddr, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
 err:
@@ -6220,7 +6220,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_string_command) {
 	RCore *core = state->core;
 	TSNode command = ts_node_named_child (node, 0);
 	RList *list = r_bin_get_strings (core->bin);
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	if (list) {
 		ut64 offorig = core->offset;
 		ut64 obs = core->blocksize;
@@ -6234,7 +6234,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_string_command) {
 		r_list_foreach (lost, iter, s) {
 			r_core_block_size (core, s->size);
 			r_core_seek (core, s->vaddr, true);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	err:
@@ -6252,7 +6252,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_section_command) {
 	if (!obj) {
 		return false;
 	}
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	ut64 offorig = core->offset;
 	ut64 bszorig = core->blocksize;
 	RBinSection *sec;
@@ -6260,7 +6260,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_section_command) {
 	r_list_foreach (obj->sections, iter, sec) {
 		r_core_seek (core, sec->vaddr, true);
 		r_core_block_size (core, sec->vsize);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
 err:
@@ -6276,13 +6276,13 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_iomap_command) {
 	// only iterate maps of current fd
 	RList *maps = r_io_map_get_for_fd (core->io, fd);
 	RIOMap *map;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	if (maps) {
 		RListIter *iter;
 		r_list_foreach (maps, iter, map) {
 			r_core_seek (core, map->itv.addr, true);
 			r_core_block_size (core, map->itv.size);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	err:
@@ -6295,13 +6295,13 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_dbgmap_command) {
 	RCore *core = state->core;
 	TSNode command = ts_node_named_child (node, 0);
 	RDebug *dbg = core->dbg;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	if (dbg && dbg->h && dbg->maps) {
 		RDebugMap *map;
 		RListIter *iter;
 		r_list_foreach (dbg->maps, iter, map) {
 			r_core_seek (core, map->addr, true);
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	}
@@ -6323,11 +6323,11 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_flag_command) {
 	r_flag_foreach_glob (core->flags, glob, copy_into_flagitem_list, flags);
 	RListIter *iter;
 	RFlagItem *f;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	r_list_foreach (flags, iter, f) {
 		r_core_block_size (core, f->size);
 		r_core_seek (core, f->offset, true);
-		RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 		UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 	}
 err:
@@ -6350,7 +6350,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_function_command) {
 	RAnalFunction *fcn;
 	RList *list = core->anal->fcns;
 	RListIter *iter;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	r_cons_break_push (NULL, NULL);
 	r_list_foreach (list, iter, fcn) {
 		if (r_cons_is_breaked ()) {
@@ -6359,7 +6359,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_function_command) {
 		if (!filter || r_str_glob (fcn->name, filter)) {
 			r_core_seek (core, fcn->addr, true);
 			r_core_block_size (core, r_anal_function_linear_size (fcn));
-			RCoreCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
+			RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	}
@@ -6374,19 +6374,19 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_thread_command) {
 	RCore *core = state->core;
 	TSNode command = ts_node_named_child (node, 0);
 	RDebug *dbg = core->dbg;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	if (dbg && dbg->h && dbg->h->threads) {
 		int origtid = dbg->tid;
 		RDebugPid *p;
 		RList *list = dbg->h->threads (dbg, dbg->pid);
 		if (!list) {
-			return R_CORE_CMD_STATUS_INVALID;
+			return R_CMD_STATUS_INVALID;
 		}
 		RListIter *iter;
 		r_list_foreach (list, iter, p) {
 			r_debug_select (dbg, dbg->pid, p->pid);
 			r_cons_printf ("PID %d\n", p->pid);
-			RCoreCmdStatus cmd_res = handle_ts_command (state, command);
+			RCmdStatus cmd_res = handle_ts_command (state, command);
 			UPDATE_CMD_STATUS_RES (res, cmd_res, err);
 		}
 	err:
@@ -6399,7 +6399,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(foreach_thread_command) {
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(last_command) {
 	TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
 	char *command_str = ts_node_sub_string (command, state->input);
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID;
+	RCmdStatus res = R_CMD_STATUS_INVALID;
 	state->is_last_cmd = true;
 	if (!strcmp (command_str, ".")) {
 		res = lastcmd_repeat (state->core, 0);
@@ -6416,7 +6416,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(grep_command) {
 	TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
 	TSNode arg = ts_node_child_by_field_name (node, "specifier", strlen ("specifier"));
 	char *arg_str = ts_node_handle_arg (state, node, arg, 1);
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	R_LOG_DEBUG ("grep_command specifier: '%s'\n", arg_str);
 	RStrBuf *sb = r_strbuf_new (arg_str);
 	r_strbuf_prepend (sb, "~");
@@ -6435,7 +6435,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(html_disable_command) {
 	r_config_set_i (state->core->config, "scr.html", 0);
 	int scr_color = r_config_get_i (state->core->config, "scr.color");
 	r_config_set_i (state->core->config, "scr.color", COLOR_MODE_DISABLED);
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	if (scr_html != -1) {
 		r_cons_flush ();
 		r_config_set_i (state->core->config, "scr.html", scr_html);
@@ -6450,7 +6450,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(html_enable_command) {
 	TSNode command = ts_node_child_by_field_name (node, "command", strlen ("command"));
 	int scr_html = r_config_get_i (state->core->config, "scr.html");
 	r_config_set_i (state->core->config, "scr.html", true);
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	if (scr_html != -1) {
 		r_cons_flush ();
 		r_config_set_i (state->core->config, "scr.html", scr_html);
@@ -6466,7 +6466,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(pipe_command) {
 	char *first_str = ts_node_sub_string (first_cmd, state->input);
 	char *second_str = ts_node_sub_string (second_cmd, state->input);
 	int value = state->core->num->value;
-	RCoreCmdStatus res = r_core_cmd_pipe (state->core, first_str, second_str);
+	RCmdStatus res = r_core_cmd_pipe (state->core, first_str, second_str);
 	state->core->num->value = value;
 	free (first_str);
 	free (second_str);
@@ -6478,7 +6478,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(scr_tts_command) {
 	int scr_color = r_config_get_i (state->core->config, "scr.color");
 	r_config_set_i (state->core->config, "scr.color", COLOR_MODE_DISABLED);
 	state->core->cons->use_tts = true;
-	RCoreCmdStatus res = handle_ts_command (state, command);
+	RCmdStatus res = handle_ts_command (state, command);
 	if (scr_color != -1) {
 		r_config_set_i (state->core->config, "scr.color", scr_color);
 	}
@@ -6494,11 +6494,11 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(task_command) {
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(number_command) {
 	ut64 addr = r_num_math (state->core->num, node_string);
 	r_core_seek (state->core, addr, true);
-	return R_CORE_CMD_STATUS_OK;
+	return R_CMD_STATUS_OK;
 }
 
-static RCoreCmdStatus handle_ts_command(struct tsr2cmd_state *state, TSNode node) {
-	RCoreCmdStatus ret = R_CORE_CMD_STATUS_INVALID;
+static RCmdStatus handle_ts_command(struct tsr2cmd_state *state, TSNode node) {
+	RCmdStatus ret = R_CMD_STATUS_INVALID;
 	RCmd *cmd = state->core->rcmd;
 
 	TSSymbol node_symbol = ts_node_symbol (node);
@@ -6517,18 +6517,18 @@ static RCoreCmdStatus handle_ts_command(struct tsr2cmd_state *state, TSNode node
 	return ret;
 }
 
-static RCoreCmdStatus handle_ts_command_tmpseek(struct tsr2cmd_state *state, TSNode node) {
+static RCmdStatus handle_ts_command_tmpseek(struct tsr2cmd_state *state, TSNode node) {
 	RCore *core = state->core;
 	bool saved_tmpseek = core->tmpseek;
 	core->tmpseek = true;
-	RCoreCmdStatus ret = handle_ts_command (state, node);
+	RCmdStatus ret = handle_ts_command (state, node);
 	core->tmpseek = saved_tmpseek;
 	return ret;
 }
 
 DEFINE_HANDLE_TS_FCN(commands) {
 	RCore *core = state->core;
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_OK;
+	RCmdStatus res = R_CMD_STATUS_OK;
 	ut32 child_count = ts_node_named_child_count (node);
 	int i;
 
@@ -6536,12 +6536,12 @@ DEFINE_HANDLE_TS_FCN(commands) {
 	if (child_count == 0 && !*state->input) {
 		if (core->cons->context->breaked) {
 			core->cons->context->breaked = false;
-			return R_CORE_CMD_STATUS_INVALID;
+			return R_CMD_STATUS_INVALID;
 		}
 		if (!core->cmdrepeat) {
-			return R_CORE_CMD_STATUS_OK;
+			return R_CMD_STATUS_OK;
 		}
-		return lastcmd_repeat (core, true)? R_CORE_CMD_STATUS_OK: R_CORE_CMD_STATUS_INVALID;
+		return lastcmd_repeat (core, true)? R_CMD_STATUS_OK: R_CMD_STATUS_INVALID;
 	}
 	if (state->split_lines) {
 		r_cons_break_push (NULL, NULL);
@@ -6549,7 +6549,7 @@ DEFINE_HANDLE_TS_FCN(commands) {
 	for (i = 0; i < child_count; i++) {
 		if (core->cons->context->cmd_depth < 1) {
 			R_LOG_ERROR ("handle_ts_commands: That was too deep...\n");
-			return R_CORE_CMD_STATUS_INVALID;
+			return R_CMD_STATUS_INVALID;
 		}
 		core->cons->context->cmd_depth--;
 		if (core->max_cmd_depth - core->cons->context->cmd_depth == 1) {
@@ -6561,19 +6561,19 @@ DEFINE_HANDLE_TS_FCN(commands) {
 			return res;
 		}
 		TSNode command = ts_node_named_child (node, i);
-		RCoreCmdStatus cmd_res = handle_ts_command (state, command);
+		RCmdStatus cmd_res = handle_ts_command (state, command);
 		if (state->split_lines) {
 			r_cons_flush ();
 			r_core_task_yield (&core->tasks);
 		}
 		core->cons->context->cmd_depth++;
-		if (cmd_res == R_CORE_CMD_STATUS_INVALID) {
+		if (cmd_res == R_CMD_STATUS_INVALID) {
 			char *command_str = ts_node_sub_string (command, state->input);
 			eprintf ("Error while executing command: %s\n", command_str);
 			free (command_str);
 			res = cmd_res;
 			goto err;
-		} else if (cmd_res == R_CORE_CMD_STATUS_EXIT) {
+		} else if (cmd_res == R_CMD_STATUS_EXIT) {
 			res = cmd_res;
 			goto err;
 		}
@@ -6623,7 +6623,7 @@ static void ts_symbols_init(RCmd *cmd) {
 	}
 }
 
-static RCoreCmdStatus core_cmd_tsr2cmd(RCore *core, const char *cstr, bool split_lines, bool log) {
+static RCmdStatus core_cmd_tsr2cmd(RCore *core, const char *cstr, bool split_lines, bool log) {
 	char *input = strdup (r_str_trim_head_ro (cstr));
 
 	ts_symbols_init (core->rcmd);
@@ -6634,7 +6634,7 @@ static RCoreCmdStatus core_cmd_tsr2cmd(RCore *core, const char *cstr, bool split
 	TSTree *tree = ts_parser_parse_string (parser, NULL, input, strlen (input));
 	TSNode root = ts_tree_root_node (tree);
 
-	RCoreCmdStatus res = R_CORE_CMD_STATUS_INVALID;
+	RCmdStatus res = R_CMD_STATUS_INVALID;
 	struct tsr2cmd_state state;
 	state.parser = parser;
 	state.core = core;

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -308,20 +308,18 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	return ret;
 }
 
-static int cmdstatus2int(RCmdStatus s) {
-	switch (s) {
-	case R_CMD_STATUS_OK:
-		return 0;
-	case R_CMD_STATUS_INVALID:
-		return -1;
-	case R_CMD_STATUS_EXIT:
-	default:
-		return -2;
+static RCmdStatus int2cmdstatus(int v) {
+	if (v == -2) {
+		return R_CMD_STATUS_EXIT;
+	} else if (v < 0) {
+		return R_CMD_STATUS_INVALID;
+	} else {
+		return R_CMD_STATUS_OK;
 	}
 }
 
-R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
-	int res = 0;
+R_API RCmdStatus r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
+	RCmdStatus res = R_CMD_STATUS_INVALID;
 
 	// As old RCorePlugin do not register new commands in RCmd, we have no
 	// way of knowing if one of those is able to handle the input, so we
@@ -332,33 +330,34 @@ R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 	char *exec_string = r_cmd_parsed_args_execstr (args);
 	r_list_foreach (cmd->plist, iter, cp) {
 		if (cp->call) {
-			res = cp->call (cmd->data, exec_string);
-			if (res) {
+			int ires = cp->call (cmd->data, exec_string);
+			if (ires) {
+				res = int2cmdstatus (ires);
 				break;
 			}
 		}
 	}
 	R_FREE (exec_string);
-	if (res) {
-		return 1;
+	if (res != R_CMD_STATUS_INVALID) {
+		return res;
 	}
 
 	RCmdDesc *cd = r_cmd_get_desc (cmd, r_cmd_parsed_args_cmd (args));
 	if (!cd) {
-		return -1;
+		return R_CMD_STATUS_INVALID;
 	}
 
 	switch (cd->type) {
 	case R_CMD_DESC_TYPE_ARGV:
-		res = cmdstatus2int (cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv));
+		res = cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv);
 		break;
 	case R_CMD_DESC_TYPE_OLDINPUT:
 		exec_string = r_cmd_parsed_args_execstr (args);
-		res = cd->d.oldinput_data.cb (cmd->data, exec_string + strlen (cd->name));
+		res = int2cmdstatus (cd->d.oldinput_data.cb (cmd->data, exec_string + strlen (cd->name)));
 		R_FREE (exec_string);
 		break;
 	default:
-		res = -1;
+		res = R_CMD_STATUS_INVALID;
 		R_LOG_ERROR ("RCmdDesc type not handled\n");
 		break;
 	}

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -330,15 +330,14 @@ R_API RCmdStatus r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 	char *exec_string = r_cmd_parsed_args_execstr (args);
 	r_list_foreach (cmd->plist, iter, cp) {
 		if (cp->call) {
-			int ires = cp->call (cmd->data, exec_string);
-			if (ires) {
-				res = int2cmdstatus (ires);
+			if (cp->call (cmd->data, exec_string)) {
+				res = R_CMD_STATUS_OK;
 				break;
 			}
 		}
 	}
 	R_FREE (exec_string);
-	if (res != R_CMD_STATUS_INVALID) {
+	if (res == R_CMD_STATUS_OK) {
 		return res;
 	}
 

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -144,7 +144,7 @@ R_API int r_cmd_set_data(RCmd *cmd, void *data);
 R_API int r_cmd_add(RCmd *cmd, const char *command, RCmdCb callback);
 R_API int r_core_del(RCmd *cmd, const char *command);
 R_API int r_cmd_call(RCmd *cmd, const char *command);
-R_API int r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args);
+R_API RCmdStatus r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args);
 R_API RCmdDesc *r_cmd_get_root(RCmd *cmd);
 R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier);
 

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -127,7 +127,7 @@ typedef struct r_core_plugin_t {
 	const char *license;
 	const char *author;
 	const char *version;
-	RCmdCb call;
+	RCmdCb call; // returns true if command was handled, false otherwise.
 	RCmdCb init;
 	RCmdCb fini;
 } RCorePlugin;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -84,12 +84,6 @@ R_LIB_VERSION_HEADER(r_core);
 
 #define RTR_MAX_HOSTS 255
 
-typedef enum {
-	R_CORE_CMD_STATUS_OK = R_CORE_CMD_OK,
-	R_CORE_CMD_STATUS_INVALID = R_CORE_CMD_INVALID,
-	R_CORE_CMD_STATUS_EXIT = R_CORE_CMD_EXIT
-} RCoreCmdStatus;
-
 /* visual mode */
 typedef enum {
 	R_CORE_VISUAL_MODE_PX = 0,

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -190,6 +190,10 @@ static int wv_handler(void *user, const char *input) {
 	return 1;
 }
 
+static int q_handler(void *user, const char *input) {
+	return -2;
+}
+
 bool test_cmd_call_desc(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
@@ -197,21 +201,26 @@ bool test_cmd_call_desc(void) {
 	r_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler);
 	r_cmd_desc_oldinput_new (cmd, p_cd, "p", p_handler);
 	r_cmd_desc_oldinput_new (cmd, root, "wv", wv_handler);
+	r_cmd_desc_oldinput_new (cmd, root, "q", q_handler);
 
 	char *pd_args[] = {"10"};
 	char *px_args[] = {"10"};
 	char *wv8_args[] = {"0xdeadbeef"};
 
 	RCmdParsedArgs *a = r_cmd_parsed_args_new ("pd", 1, pd_args);
-	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), 0, "pd was called correctly");
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), R_CMD_STATUS_OK, "pd was called correctly");
 	r_cmd_parsed_args_free (a);
 
 	a = r_cmd_parsed_args_new ("px", 1, px_args);
-	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), -1, "p was called correctly");
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), R_CMD_STATUS_INVALID, "p was called correctly");
 	r_cmd_parsed_args_free (a);
 
 	a = r_cmd_parsed_args_new ("wv8", 1, wv8_args);
-	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), 1, "wv was called correctly");
+	mu_assert_eq(r_cmd_call_parsed_args (cmd, a), R_CMD_STATUS_OK, "wv was called correctly");
+	r_cmd_parsed_args_free (a);
+
+	a = r_cmd_parsed_args_new ("quit", 0, NULL);
+	mu_assert_eq (r_cmd_call_parsed_args (cmd, a), R_CMD_STATUS_EXIT, "quit is going to exit");
 	r_cmd_parsed_args_free (a);
 
 	r_cmd_free (cmd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

RCoreCmdStatus is the same as RCmdStatus. That enum belongs more to r_cmd.h than to core in general, so this PR removes RCoreCmdStatus and just uses RCmdStatus. It also changes the API of r_cmd_call_parsed_args so that it directly returns RCmdStatus.