### PR TITLE
Remove INNER nodes and merge inner node with the command with same name

### DIFF
--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -20,14 +20,7 @@ static bool cmd_desc_set_parent(RCmdDesc *cd, RCmdDesc *parent) {
 	return true;
 }
 
-static bool cmd_desc_remove_parent(RCmdDesc *cd) {
-	r_return_val_if_fail (cd && cd->parent, false);
-	r_pvector_remove_data (&cd->parent->children, cd);
-	cd->parent = NULL;
-	return NULL;
-}
-
-static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char *name) {
+static RCmdDesc *create_cmd_desc(RCmd *cmd, RCmdDesc *parent, RCmdDescType type, const char *name) {
 	RCmdDesc *res = R_NEW0 (RCmdDesc);
 	if (!res) {
 		return NULL;
@@ -39,6 +32,9 @@ static RCmdDesc *create_cmd_desc(RCmdDesc *parent, RCmdDescType type, const char
 	}
 	res->n_children = 0;
 	r_pvector_init (&res->children, (RPVectorFree)r_cmd_desc_free);
+	if (!ht_pp_insert (cmd->ht_cmds, name, res)) {
+		goto err;
+	}
 	cmd_desc_set_parent (res, parent);
 	return res;
 err:
@@ -63,8 +59,8 @@ R_API RCmd *r_cmd_new () {
 		cmd->cmds[i] = NULL;
 	}
 	cmd->nullcallback = cmd->data = NULL;
-	cmd->root_cmd_desc = create_cmd_desc (NULL, R_CMD_DESC_TYPE_INNER, "");
 	cmd->ht_cmds = ht_pp_new0 ();
+	cmd->root_cmd_desc = create_cmd_desc (cmd, NULL, R_CMD_DESC_TYPE_ARGV, "");
 	r_core_plugin_init (cmd);
 	r_cmd_macro_init (&cmd->macro);
 	r_cmd_alias_init (cmd);
@@ -115,10 +111,10 @@ R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier) {
 	bool is_exact_match = true;
 	// match longer commands first
 	while (*cmdid) {
-		res = ht_pp_find (cmd->ht_cmds, cmdid, NULL);
-		r_warn_if_fail (!res || res->type == R_CMD_DESC_TYPE_OLDINPUT || res->type == R_CMD_DESC_TYPE_ARGV);
-		if (res && (res->type == R_CMD_DESC_TYPE_OLDINPUT ||
-			(res->type == R_CMD_DESC_TYPE_ARGV && is_exact_match))) {
+		RCmdDesc *cd = ht_pp_find (cmd->ht_cmds, cmdid, NULL);
+		if (cd && (cd->type == R_CMD_DESC_TYPE_OLDINPUT ||
+			(cd->type == R_CMD_DESC_TYPE_ARGV && is_exact_match))) {
+			res = cd;
 			goto out;
 		}
 		is_exact_match = false;
@@ -346,9 +342,12 @@ R_API RCmdStatus r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 		return R_CMD_STATUS_INVALID;
 	}
 
+	res = R_CMD_STATUS_INVALID;
 	switch (cd->type) {
 	case R_CMD_DESC_TYPE_ARGV:
-		res = cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv);
+		if (cd->d.argv_data.cb) {
+			res = cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv);
+		}
 		break;
 	case R_CMD_DESC_TYPE_OLDINPUT:
 		exec_string = r_cmd_parsed_args_execstr (args);
@@ -941,41 +940,23 @@ R_API const char *r_cmd_parsed_args_cmd(RCmdParsedArgs *a) {
 /* RCmdDescriptor */
 
 R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb) {
-	r_return_val_if_fail (cmd && parent && name && cb, NULL);
-	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_ARGV, name);
+	r_return_val_if_fail (cmd && parent && name, NULL);
+	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_ARGV, name);
 	if (!res) {
 		return NULL;
 	}
 
 	res->d.argv_data.cb = cb;
-	if (!ht_pp_insert (cmd->ht_cmds, name, res)) {
-		cmd_desc_remove_parent (res);
-		r_cmd_desc_free (res);
-		return NULL;
-	}
 	return res;
-}
-
-R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name) {
-	r_return_val_if_fail (cmd && parent && name, NULL);
-	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	return create_cmd_desc (parent, R_CMD_DESC_TYPE_INNER, name);
 }
 
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb) {
 	r_return_val_if_fail (cmd && parent && name && cb, NULL);
-	r_return_val_if_fail (parent->type == R_CMD_DESC_TYPE_INNER, NULL);
-	RCmdDesc *res = create_cmd_desc (parent, R_CMD_DESC_TYPE_OLDINPUT, name);
+	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_OLDINPUT, name);
 	if (!res) {
 		return NULL;
 	}
 	res->d.oldinput_data.cb = cb;
-	if (!ht_pp_insert (cmd->ht_cmds, name, res)) {
-		cmd_desc_remove_parent (res);
-		r_cmd_desc_free (res);
-		return NULL;
-	}
 	return res;
 }
 

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -76,8 +76,6 @@ typedef enum {
 	R_CMD_DESC_TYPE_OLDINPUT,
 	// for handlers that accept argc/argv
 	R_CMD_DESC_TYPE_ARGV,
-	// for middle nodes in the tree
-	R_CMD_DESC_TYPE_INNER,
 } RCmdDescType;
 
 typedef struct r_cmd_desc_t {
@@ -149,7 +147,6 @@ R_API RCmdDesc *r_cmd_get_root(RCmd *cmd);
 R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier);
 
 /* RCmdDescriptor */
-R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name);
 R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb);
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb);
 R_API void r_cmd_desc_free(RCmdDesc *cd);

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -128,6 +128,10 @@ static RCmdStatus ap_handler(void *user, int argc, const char **argv) {
 	return R_CMD_STATUS_OK;
 }
 
+static RCmdStatus aeir_handler(void *user, int argc, const char **argv) {
+	return R_CMD_STATUS_OK;
+}
+
 static int ae_handler(void *user, const char *input) {
 	return 0;
 }
@@ -160,6 +164,7 @@ bool test_cmd_get_desc(void) {
 	RCmdDesc *ap_cd = r_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler);
 	RCmdDesc *apd_cd = r_cmd_desc_argv_new (cmd, ap_cd, "apd", ap_handler);
 	RCmdDesc *ae_cd = r_cmd_desc_oldinput_new (cmd, a_cd, "ae", ae_handler);
+	RCmdDesc *aeir_cd = r_cmd_desc_argv_new (cmd, a_cd, "aeir", aeir_handler);
 	RCmdDesc *w_cd = r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
 
 	mu_assert_null (r_cmd_get_desc (cmd, "afl"), "afl does not have any handler");
@@ -170,6 +175,8 @@ bool test_cmd_get_desc(void) {
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "apd"), apd_cd, "apd will be handled by apd");
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "ae"), ae_cd, "ae will be handled by ae");
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "aeim"), ae_cd, "aeim will be handled by ae");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "aeir"), aeir_cd, "aeir will be handled by aeir");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "aei"), ae_cd, "aei will be handled by ae");
 
 	r_cmd_free (cmd);
 	mu_end;

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -98,8 +98,8 @@ bool test_cmd_descriptor_argv(void) {
 bool test_cmd_descriptor_argv_nested(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *af_cd = r_cmd_desc_inner_new (cmd, root, "af");
-	r_cmd_desc_inner_new (cmd, root, "af2");
+	RCmdDesc *af_cd = r_cmd_desc_argv_new (cmd, root, "af", NULL);
+	r_cmd_desc_argv_new (cmd, root, "af2", NULL);
 	RCmdDesc *cd = r_cmd_desc_argv_new (cmd, af_cd, "afl", afl_argv_handler);
 	mu_assert_ptreq (r_cmd_desc_parent (cd), af_cd, "parent of afl is af");
 	mu_assert_true (r_pvector_contains (&af_cd->children, cd), "afl is child of af");
@@ -139,7 +139,7 @@ static int w_handler(void *user, const char *input) {
 bool test_cmd_descriptor_tree(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a");
+	RCmdDesc *a_cd = r_cmd_desc_argv_new (cmd, root, "a", NULL);
 	r_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler);
 	r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
 
@@ -156,8 +156,9 @@ bool test_cmd_descriptor_tree(void) {
 bool test_cmd_get_desc(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *a_cd = r_cmd_desc_inner_new (cmd, root, "a");
+	RCmdDesc *a_cd = r_cmd_desc_argv_new (cmd, root, "a", NULL);
 	RCmdDesc *ap_cd = r_cmd_desc_argv_new (cmd, a_cd, "ap", ap_handler);
+	RCmdDesc *apd_cd = r_cmd_desc_argv_new (cmd, ap_cd, "apd", ap_handler);
 	RCmdDesc *ae_cd = r_cmd_desc_oldinput_new (cmd, a_cd, "ae", ae_handler);
 	RCmdDesc *w_cd = r_cmd_desc_oldinput_new (cmd, root, "w", w_handler);
 
@@ -166,6 +167,7 @@ bool test_cmd_get_desc(void) {
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "wx"), w_cd, "wx will be handled by w");
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "wao"), w_cd, "wao will be handled by w");
 	mu_assert_null (r_cmd_get_desc (cmd, "apx"), "apx does not have any handler");
+	mu_assert_ptreq (r_cmd_get_desc (cmd, "apd"), apd_cd, "apd will be handled by apd");
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "ae"), ae_cd, "ae will be handled by ae");
 	mu_assert_ptreq (r_cmd_get_desc (cmd, "aeim"), ae_cd, "aeim will be handled by ae");
 
@@ -197,7 +199,7 @@ static int q_handler(void *user, const char *input) {
 bool test_cmd_call_desc(void) {
 	RCmd *cmd = r_cmd_new ();
 	RCmdDesc *root = r_cmd_get_root (cmd);
-	RCmdDesc *p_cd = r_cmd_desc_inner_new (cmd, root, "p");
+	RCmdDesc *p_cd = r_cmd_desc_argv_new (cmd, root, "p", NULL);
 	r_cmd_desc_argv_new (cmd, p_cd, "pd", pd_handler);
 	r_cmd_desc_oldinput_new (cmd, p_cd, "p", p_handler);
 	r_cmd_desc_oldinput_new (cmd, root, "wv", wv_handler);


### PR DESCRIPTION
Maybe after all we don't need this inner nodes :D

While working on PR #16782 I realized I could have multiple RCmdDesc with the same name in the hashtable by having both inner and argv nodes. Shall we just remove the inner nodes and consider them as ARGV node?