### PR TITLE
Reset anal regs in every iteration of aaft

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -886,7 +886,6 @@ static bool cmd_anal_aaft(RCore *core) {
 		}
 		__add_vars_sdb (core, fcn);
 	}
-	r_core_cmd0 (core, "aeim-;aei-");
 	r_core_seek (core, seek, true);
 	r_reg_arena_pop (core->anal->reg);
 	r_config_set_i (core->config, io_cache_key, io_cache);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -869,26 +869,28 @@ static bool cmd_anal_aaft(RCore *core) {
 	}
 	seek = core->offset;
 	r_reg_arena_push (core->anal->reg);
+	r_reg_arena_zero (core->anal->reg);
+	r_core_cmd0 (core, "aei;aeim");
+	ut8 *saved_arena = r_reg_arena_peek (core->anal->reg);
 	// Iterating Reverse so that we get function in top-bottom call order
 	r_list_foreach_prev (core->anal->fcns, it, fcn) {
-		r_core_cmd0 (core, "aei");
-		r_core_cmd0 (core, "aeim");
 		int ret = r_core_seek (core, fcn->addr, true);
 		if (!ret) {
 			continue;
 		}
+		r_reg_arena_poke (core->anal->reg, saved_arena);
 		r_anal_esil_set_pc (core->anal->esil, fcn->addr);
 		r_core_anal_type_match (core, fcn);
-		r_core_cmd0 (core, "aeim-");
-		r_core_cmd0 (core, "aei-");
 		if (r_cons_is_breaked ()) {
 			break;
 		}
 		__add_vars_sdb (core, fcn);
 	}
+	r_core_cmd0 (core, "aeim-;aei-");
 	r_core_seek (core, seek, true);
 	r_reg_arena_pop (core->anal->reg);
 	r_config_set_i (core->config, io_cache_key, io_cache);
+	free (saved_arena);
 	return true;
 }
 

--- a/test/db/cmd/cmd_fnj
+++ b/test/db/cmd/cmd_fnj
@@ -2,8 +2,8 @@ NAME=fnj shows demangled symbols
 FILE=bins/elf/demangle-test-cpp
 CMDS=<<EOF
 aaa
-fj~{268}
-fnj~{268}
+fj~{269}
+fnj~{269}
 EOF
 EXPECT=<<EOF
 {"name":"reloc.operator_delete_void","realname":"reloc.operator delete(void*)","size":8,"offset":16432}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Anal regs is not reseted between iterations of `aaft`. For example this can cause unnecessary loops during emulation of `rep stos*` instructions.
In my case `rdx = 0xffffffffffffffff` on entry of this function:
```
/ 21: sym.r_util.dll_r_mem_memzero (int64_t arg1, int64_t arg2);
|           ; var int64_t var_20h @ rsp+0x8
|           ; arg int64_t arg1 @ rcx
|           ; arg int64_t arg2 @ rdx
|           0x180014f90      48897c2408     mov qword [var_20h], rdi
|           0x180014f95      488bf9         mov rdi, rcx               ; arg1
|           0x180014f98      33c0           xor eax, eax
|           0x180014f9a      488bca         mov rcx, rdx               ; arg2
|           0x180014f9d      f3aa           rep stosb byte [rdi], al
|           0x180014f9f      488b7c2408     mov rdi, qword [var_20h]
\           0x180014fa4      c3             ret
```
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
