### PR TITLE
Support Mach-O arm64e threaded binding

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -518,11 +518,12 @@ R_IPI RBinFile *r_bin_file_new_from_buffer(RBin *bin, const char *file, RBuffer 
 
 	RBinFile *bf = r_bin_file_new (bin, file, r_buf_size (buf), rawstr, fd, pluginname, NULL, false);
 	if (bf) {
+		RListIter *item = r_list_append (bin->binfiles, bf);
 		bf->buf = r_buf_ref (buf);
 		RBinPlugin *plugin = get_plugin_from_buffer (bin, pluginname, bf->buf);
 		RBinObject *o = r_bin_object_new (bf, plugin, baseaddr, loadaddr, 0, r_buf_size (bf->buf));
 		if (!o) {
-			r_bin_file_free (bf);
+			r_list_delete (bin->binfiles, item);
 			return NULL;
 		}
 		// size is set here because the reported size of the object depends on
@@ -530,7 +531,6 @@ R_IPI RBinFile *r_bin_file_new_from_buffer(RBin *bin, const char *file, RBuffer 
 		if (!o->size) {
 			o->size = r_buf_size (buf);
 		}
-		r_list_append (bin->binfiles, bf);
 	}
 	return bf;
 }

--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -169,9 +169,9 @@ R_IPI RBinObject *r_bin_object_new(RBinFile *bf, RBinPlugin *plugin, ut64 basead
 	// the object is created from. The reason for this is to prevent
 	// mis-reporting when the file is loaded from impartial bytes or is
 	// extracted from a set of bytes in the file
-	r_bin_object_set_items (bf, o);
 	r_bin_file_set_obj (bf->rbin, bf, o);
 	r_bin_set_baddr (bf->rbin, o->baddr);
+	r_bin_object_set_items (bf, o);
 
 	bf->sdb_info = o->kv;
 	sdb = bf->rbin->sdb;

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -116,6 +116,7 @@ struct MACH0_(obj_t) {
 	char *intrp;
 	char *compiler;
 	int nsegs;
+	struct r_dyld_chained_starts_in_segment **chained_starts;
 	struct MACH0_(section) *sects;
 	int nsects;
 	struct MACH0_(nlist) *symtab;
@@ -172,6 +173,8 @@ struct MACH0_(obj_t) {
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
 	struct symbol_t *symbols;
 	ut64 main_addr;
+	int (*original_io_read)(RIO *io, RIODesc *fd, ut8 *buf, int count);
+	bool rebasing_buffer;
 };
 
 void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile *bf);

--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -167,7 +167,9 @@ enum LoadCommandType {
 	LC_VERSION_MIN_TVOS     = 0x0000002Fu,
 	LC_VERSION_MIN_WATCHOS  = 0x00000030u,
 	LC_NOTE                 = 0x00000031u,
-	LC_BUILD_VERSION        = 0x00000032u
+	LC_BUILD_VERSION        = 0x00000032u,
+	LC_DYLD_EXPORTS_TRIE    = 0x80000033u,
+	LC_DYLD_CHAINED_FIXUPS  = 0x80000034u,
 /*
 Load command 9
        cmd LC_BUILD_VERSION
@@ -1434,5 +1436,80 @@ sizeof(struct x86_exception_state_t) / sizeof(uint32_t);
 #define EXPORT_SYMBOL_FLAGS_WEAK_DEFINITION 0x04
 #define EXPORT_SYMBOL_FLAGS_REEXPORT 0x08
 #define EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER 0x10
+
+struct dyld_chained_starts_in_image {
+	uint32_t seg_count;
+};
+
+struct dyld_chained_starts_in_segment {
+	uint32_t size;
+	uint16_t page_size;
+	uint16_t pointer_format;
+	uint64_t segment_offset;
+	uint32_t max_valid_pointer;
+	uint16_t page_count;
+};
+
+struct r_dyld_chained_starts_in_segment {
+	uint32_t size;
+	uint16_t page_size;
+	uint16_t pointer_format;
+	uint64_t segment_offset;
+	uint32_t max_valid_pointer;
+	uint16_t page_count;
+	ut16 * page_start;
+};
+
+enum {
+	DYLD_CHAINED_PTR_START_NONE   = 0xFFFF,
+	DYLD_CHAINED_PTR_START_MULTI  = 0x8000,
+	DYLD_CHAINED_PTR_START_LAST   = 0x8000,
+};
+
+enum {
+	DYLD_CHAINED_PTR_ARM64E      = 1,
+	DYLD_CHAINED_PTR_64          = 2,
+	DYLD_CHAINED_PTR_32          = 3,
+	DYLD_CHAINED_PTR_32_CACHE    = 4,
+	DYLD_CHAINED_PTR_32_FIRMWARE = 5,
+};
+
+struct dyld_chained_ptr_arm64e_rebase {
+	uint64_t target : 43,
+		high8 : 8,
+		next : 11,
+		bind : 1, // == 0
+		auth : 1; // == 0
+};
+
+struct dyld_chained_ptr_arm64e_bind {
+	uint64_t ordinal : 16,
+		zero : 16,
+		addend : 19,
+		next : 11,
+		bind : 1, // == 1
+		auth : 1; // == 0
+};
+
+struct dyld_chained_ptr_arm64e_auth_rebase {
+	uint64_t target : 32,
+		diversity : 16,
+		addrDiv : 1,
+		key : 2,
+		next : 11,
+		bind : 1, // == 0
+		auth : 1; // == 1
+};
+
+struct dyld_chained_ptr_arm64e_auth_bind {
+	uint64_t ordinal : 16,
+		zero : 16,
+		diversity : 16,
+		addrDiv : 1,
+		key : 2,
+		next : 11,
+		bind : 1, // == 1
+		auth : 1; // == 1
+};
 
 #endif

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -4,6 +4,7 @@
 #include <r_util.h>
 #include <r_lib.h>
 #include <r_bin.h>
+#include <r_core.h>
 #include "../i/private.h"
 #include "mach0/mach0.h"
 #include "objc/mach0_classes.h"
@@ -14,6 +15,13 @@
 extern RBinWrite r_bin_write_mach0;
 
 static RBinInfo *info(RBinFile *bf);
+
+static void swizzle_io_read(struct MACH0_(obj_t) *obj, RIO *io);
+static int rebasing_and_stripping_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count);
+static void rebase_buffer(struct MACH0_(obj_t) *obj, ut64 off, RIODesc *fd, ut8 *buf, int count);
+
+#define IS_PTR_AUTH(x) ((x & (1ULL << 63)) != 0)
+#define IS_PTR_BIND(x) ((x & (1ULL << 62)) != 0)
 
 static Sdb *get_sdb (RBinFile *bf) {
 	RBinObject *o = bf->o;
@@ -30,13 +38,16 @@ static char *entitlements(RBinFile *bf, bool json) {
 	return r_str_dup (NULL, (const char*)bin->signature);
 }
 
-
 static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb){
 	r_return_val_if_fail (bf && bin_obj && buf, false);
 	struct MACH0_(opts_t) opts;
 	MACH0_(opts_set_default) (&opts, bf);
 	struct MACH0_(obj_t) *res = MACH0_(new_buf) (buf, &opts);
 	if (res) {
+		if (res->chained_starts) {
+			RIO *io = bf->rbin->iob.io;
+			swizzle_io_read (res, io);
+		}
 		sdb_ns_set (sdb, "info", res->kv);
 		*bin_obj = res;
 		return true;
@@ -420,14 +431,14 @@ static RList *relocs(RBinFile *bf) {
 		}
 		ptr->type = reloc->type;
 		ptr->additive = 0;
-		if (reloc->ord >= 0 && bin->imports_by_ord && reloc->ord < bin->imports_by_ord_size) {
-			ptr->import = bin->imports_by_ord[reloc->ord];
-		} else if (reloc->name[0]) {
+		if (reloc->name[0]) {
 			RBinImport *imp;
 			if (!(imp = import_from_name (bf->rbin, (char*) reloc->name, bin->imports_by_name))) {
 				break;
 			}
 			ptr->import = imp;
+		} else if (reloc->ord >= 0 && bin->imports_by_ord && reloc->ord < bin->imports_by_ord_size) {
+			ptr->import = bin->imports_by_ord[reloc->ord];
 		} else {
 			ptr->import = NULL;
 		}
@@ -676,6 +687,138 @@ beach:
 	r_list_free (ret);
 	ht_uu_free (relocs_by_sym);
 	return NULL;
+}
+
+static void swizzle_io_read(struct MACH0_(obj_t) *obj, RIO *io) {
+	r_return_if_fail (io && io->desc && io->desc->plugin);
+	RIOPlugin *plugin = io->desc->plugin;
+	obj->original_io_read = plugin->read;
+	plugin->read = &rebasing_and_stripping_io_read;
+}
+
+static int rebasing_and_stripping_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	r_return_val_if_fail (io, -1);
+	RCore *core = (RCore*) io->corebind.core;
+	if (!core || !core->bin || !core->bin->binfiles) {
+		return -1;
+	}
+	struct MACH0_(obj_t) *obj = NULL;
+	RListIter *iter;
+	RBinFile *bf;
+	r_list_foreach (core->bin->binfiles, iter, bf) {
+		if (bf->fd == fd->fd ) {
+			/* The first field of MACH0_(obj_t) is
+			 * the mach_header, whose first field is
+			 * the MH magic.
+			 * This code assumes that bin objects are
+			 * at least 4 bytes long.
+			 */
+			ut32 *magic = bf->o->bin_obj;
+			if (magic && (*magic == MH_MAGIC ||
+					*magic == MH_CIGAM ||
+					*magic == MH_MAGIC_64 ||
+					*magic == MH_CIGAM_64)) {
+				obj = bf->o->bin_obj;
+			}
+			break;
+		}
+	}
+	if (!obj || !obj->original_io_read) {
+		if (fd->plugin->read == &rebasing_and_stripping_io_read) {
+			return -1;
+		}
+		return fd->plugin->read (io, fd, buf, count);
+	}
+	if (obj->rebasing_buffer) {
+		return obj->original_io_read (io, fd, buf, count);
+	}
+	static ut8 *internal_buffer = NULL;
+	static int internal_buf_size = 0;
+	if (count > internal_buf_size) {
+		if (internal_buffer) {
+			R_FREE (internal_buffer);
+			internal_buffer = NULL;
+		}
+		internal_buf_size = R_MAX (count, 8);
+		internal_buffer = (ut8 *) malloc (internal_buf_size);
+	}
+	ut64 io_off = io->off;
+	int result = obj->original_io_read (io, fd, internal_buffer, count);
+	if (result == count) {
+		rebase_buffer (obj, io_off, fd, internal_buffer, count);
+		memcpy (buf, internal_buffer, result);
+	}
+	return result;
+}
+
+static void rebase_buffer(struct MACH0_(obj_t) *obj, ut64 off, RIODesc *fd, ut8 *buf, int count) {
+	if (obj->rebasing_buffer) {
+		return;
+	}
+	obj->rebasing_buffer = true;
+	ut64 eob = off + count;
+	int i = 0;
+	for (; i < obj->nsegs; i++) {
+		if (!obj->chained_starts[i]) {
+			continue;
+		}
+		ut64 page_size = obj->chained_starts[i]->page_size;
+		ut64 start = obj->segs[i].fileoff;
+		ut64 end = start + obj->segs[i].filesize;
+		if (end >= off && start <= eob) {
+			ut64 page_idx = (R_MAX (start, off) - start) / page_size;
+			ut64 page_end_idx = (R_MIN (eob, end) - start) / page_size;
+			for (; page_idx <= page_end_idx; page_idx++) {
+				if (page_idx >= obj->chained_starts[i]->page_count) {
+					break;
+				}
+				ut16 page_start = obj->chained_starts[i]->page_start[page_idx];
+				if (page_start == DYLD_CHAINED_PTR_START_NONE) {
+					continue;
+				}
+				ut64 cursor = start + page_idx * page_size + page_start;
+				while (cursor < eob && cursor < end) {
+					ut8 tmp[8];
+					if (r_buf_read_at (obj->b, cursor, tmp, 8) != 8) {
+						break;
+					}
+					ut64 raw_ptr = r_read_le64 (tmp);
+					bool is_auth = IS_PTR_AUTH (raw_ptr);
+					bool is_bind = IS_PTR_BIND (raw_ptr);
+					ut64 ptr_value = raw_ptr;
+					ut64 delta;
+					if (is_auth && is_bind) {
+						struct dyld_chained_ptr_arm64e_auth_bind *p =
+								(struct dyld_chained_ptr_arm64e_auth_bind *) &raw_ptr;
+						delta = p->next;
+					} else if (!is_auth && is_bind) {
+						struct dyld_chained_ptr_arm64e_bind *p =
+								(struct dyld_chained_ptr_arm64e_bind *) &raw_ptr;
+						delta = p->next;
+					} else if (is_auth && !is_bind) {
+						struct dyld_chained_ptr_arm64e_auth_rebase *p =
+								(struct dyld_chained_ptr_arm64e_auth_rebase *) &raw_ptr;
+						delta = p->next;
+						ptr_value = p->target + obj->baddr;
+					} else {
+						struct dyld_chained_ptr_arm64e_rebase *p =
+								(struct dyld_chained_ptr_arm64e_rebase *) &raw_ptr;
+						delta = p->next;
+						ptr_value = ((ut64)p->high8 << 56) | p->target;
+					}
+					ut64 in_buf = cursor - off;
+					if (cursor >= off && cursor <= eob - 8) {
+						r_write_le64 (&buf[in_buf], ptr_value);
+					}
+					cursor += delta * 8;
+					if (!delta) {
+						break;
+					}
+				}
+			}
+		}
+	}
+	obj->rebasing_buffer = false;
 }
 
 #if !R_BIN_MACH064

--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -132,7 +132,7 @@ static void swizzle_io_read(RKernelCacheObj *obj, RIO *io);
 static int kernelcache_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count);
 static bool r_parse_pointer(RParsedPointer *ptr, ut64 decorated_addr, RKernelCacheObj *obj);
 static bool on_rebase_pointer (ut64 offset, ut64 decorated_addr, RRebaseCtx *ctx);
-static void rebase_buffer(RKernelCacheObj *obj, RIO *io, RIODesc *fd, ut8 *buf, int count);
+static void rebase_buffer(RKernelCacheObj *obj, ut64 off, RIODesc *fd, ut8 *buf, int count);
 
 static RPrelinkRange *get_prelink_info_range_from_mach0(struct MACH0_(obj_t) *mach0);
 static RList *filter_kexts(RKernelCacheObj *obj);
@@ -1916,23 +1916,23 @@ static int kernelcache_io_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 		internal_buf_size = count;
 	}
 
+	ut64 io_off = io->off;
 	int result = cache->original_io_read (io, fd, internal_buffer, count);
 
 	if (result == count) {
-		rebase_buffer (cache, io, fd, internal_buffer, count);
+		rebase_buffer (cache, io_off, fd, internal_buffer, count);
 		memcpy (buf, internal_buffer, result);
 	}
 
 	return result;
 }
 
-static void rebase_buffer(RKernelCacheObj *obj, RIO *io, RIODesc *fd, ut8 *buf, int count) {
+static void rebase_buffer(RKernelCacheObj *obj, ut64 off, RIODesc *fd, ut8 *buf, int count) {
 	if (obj->rebasing_buffer) {
 		return;
 	}
 	obj->rebasing_buffer = true;
 
-	ut64 off = io->off;
 	ut64 eob = off + count;
 	int i = 0;
 	RRebaseCtx ctx;

--- a/test/db/anal/classes
+++ b/test/db/anal/classes
@@ -100,19 +100,39 @@ RUN
 
 NAME=anal classes arm64e
 FILE=bins/mach0/TestRTTI-arm64e
-BROKEN=1
 CMDS=<<EOF
 avrr
 acl
+acll~\@
 avra~0x100008370:0
 avra~vmi:0
+?e `avraj~{[0]}`~{:
 EOF
 EXPECT=<<EOF
 A
 B
 C
 D
+  virtual_0 @ 0x100005f50 (vtable + 0x0)
+  virtual_8 @ 0x100005f7c (vtable + 0x8)
+  virtual_16 @ 0x100005fa8 (vtable + 0x10)
+  virtual_0 @ 0x100006000 (vtable + 0x0)
+  virtual_8 @ 0x100005f7c (vtable + 0x8)
+  virtual_16 @ 0x100006050 (vtable + 0x10)
+  virtual_0 @ 0x100005f50 (vtable + 0x0)
+  virtual_8 @ 0x1000060a0 (vtable + 0x8)
+  virtual_16 @ 0x1000060f0 (vtable + 0x10)
+  virtual_0 @ 0x100006000 (vtable + 0x0)
+  virtual_8 @ 0x1000060a0 (vtable + 0x8)
+  virtual_16 @ 0x10000615c (vtable + 0x10)
 Type Info at 0x100008370:
   Type Info type: __vmi_class_type_info
+type: __class_type_info
+found_at: 4295000200
+class_vtable: 4295000176
+ref_to_type_class: 13838435755002691596
+ref_to_type_name: 4294999928
+name: A
+name_unique: true
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Support BIND_OPCODE_THREADED and its sub-opcodes, for both parsing relocs correctly and reconstruct the pointer-rebasing chains.

Rebasing and stripping happens on-the-fly by swizzling the IO read function and leveraging the chain starts generated by supporting the BIND_OPCODE_THREADED machinery. (This feature is enabled only when opening arm64 binaries)

Add “informational” support for new load commands (but didn't manage to find a sample binary to actually go on and implement them yet):
- LC_DYLD_EXPORTS_TRIE
- LC_DYLD_CHAINED_FIXUPS

Along the way also fixed a bug in the xnu kernelcache rebasing of pointers.

NOTE: these are the sources of truth i used to implement this:
- https://opensource.apple.com/source/dyld/dyld-733.6/dyld3/MachOAnalyzer.cpp.auto.html for reconstructing the chain starts per-segment per-page
- https://opensource.apple.com/source/ld64/ld64-512.4/src/other/dyldinfo.cpp.auto.html for actual chained binding

**Test plan**

The `test/db/anal/classes` test is now working, and also improved. This test covers both rebasing and relocs correctness.
