### PR TITLE
Implement #6431 to support gdb:// with debug_io handler

### DIFF
--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -140,13 +140,7 @@ static RList *r_debug_gdb_map_get(RDebug* dbg) { //TODO
 	// If /proc/%d/maps is not valid for gdbserver, we return NULL, as of now
 	snprintf (path, sizeof (path) - 1, "/proc/%d/maps", desc->pid);
 
-#ifdef _MSC_VER
-#define GDB_FILE_OPEN_MODE (_S_IREAD | _S_IWRITE)
-#else
-#define GDB_FILE_OPEN_MODE (S_IRUSR | S_IWUSR | S_IXUSR)
-#endif
-
-	if (gdbr_open_file (desc, path, O_RDONLY, GDB_FILE_OPEN_MODE) < 0) {
+	if (gdbr_open_file (desc, path, O_RDONLY, 0) < 0) {
 		return NULL;
 	}
 	if (!(buf = malloc (buflen))) {

--- a/libr/debug/p/debug_io.c
+++ b/libr/debug/p/debug_io.c
@@ -123,7 +123,13 @@ static int __reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 
 // "dc" continue execution
 static int __io_continue(RDebug *dbg, int pid, int tid, int sig) {
-	dbg->iob.system (dbg->iob.io, "dc");
+	const char *cmd;
+	if (sig != 0) {
+		cmd = sdb_fmt ("dck %d %d", sig, pid);
+	} else {
+		cmd = "dc";
+	}
+	dbg->iob.system (dbg->iob.io, cmd);
 	r_cons_flush ();
 	return true;
 }

--- a/libr/debug/p/debug_io.c
+++ b/libr/debug/p/debug_io.c
@@ -123,12 +123,7 @@ static int __reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 
 // "dc" continue execution
 static int __io_continue(RDebug *dbg, int pid, int tid, int sig) {
-	const char *cmd;
-	if (sig != 0) {
-		cmd = sdb_fmt ("dck %d %d", sig, pid);
-	} else {
-		cmd = "dc";
-	}
+	const char *cmd = sig > 0 ? sdb_fmt ("dck %d %d", sig, pid) : "dc";
 	dbg->iob.system (dbg->iob.io, cmd);
 	r_cons_flush ();
 	return true;


### PR DESCRIPTION
…bugger handler

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I have added the support for the following commands in order to use debug_io handler `dL io` with gdb:
`dm`, `dr8`, `drp`, `ds`, `dc`, `dck`

```
r2 -d gdb://localhost:4444
= attach 2699 1
= attach 2699 0
 -- Good morning, pal *<:-)
[0x7ffff7dd6ea1]> =!?
Usage: =!cmd args
 =!dm              - list memory maps of target process
 =!dr8             - display hexdump of gpr arena
 =!drp             - get register profles
 =!ds              - step one instruction
 =!dsb             - step backwards
 =!dc              - continue execution
 =!dcb             - continue backwards
 =!dck <sig>       - continue execution with sig signal
 =!pid             - show targeted pid
 =!pkt s           - send packet 's'
 =!rd              - show reverse debugging availability
 =!monitor cmd     - hex-encode monitor command and pass to target interpreter
 =!detach [pid]    - detach from remote/detach specific pid
 =!inv.reg         - invalidate reg cache
 =!pktsz           - get max packet size used
 =!pktsz bytes     - set max. packet size as 'bytes' bytes
 =!exec_file [pid] - get file which was executed for current/specified pid
[0x7ffff7dd6ea1]> =!dm
0x555555554000 - 0x555555573000 r-xp /bin/ls
0x555555772000 - 0x555555775000 rw-p /bin/ls
0x555555775000 - 0x555555776000 rw-p [heap]
0x7ffff7dd5000 - 0x7ffff7dfc000 r-xp /lib/x86_64-linux-gnu/ld-2.27.so
0x7ffff7ff8000 - 0x7ffff7ffb000 r--p [vvar]
0x7ffff7ffb000 - 0x7ffff7ffc000 r-xp [vdso]
0x7ffff7ffc000 - 0x7ffff7ffe000 rw-p /lib/x86_64-linux-gnu/ld-2.27.so
0x7ffff7ffe000 - 0x7ffff7fff000 rw-p 
0x7ffffffde000 - 0x7ffffffff000 rw-p [stack]
0xffffffffff600000 - 0xffffffffff601000 --xp [vsyscall]
```

Users can also switch to debug.io `dL io` and perform debugging.
```
$ r2 -d gdb://localhost:4444
= attach 2699 1
= attach 2699 0
 -- Connection lost with the license server, your r2 session will terminate in 30 minutes.
[0x7ffff7dd6ea1]> dL io
[0x7ffff7dd6ea1]> dm
0x0000555555554000 - 0x0000555555573000 - usr   124K s r-x /bin/ls ? ; loc.imp._ITM_registerTMCloneTable
0x0000555555772000 - 0x0000555555775000 - usr    12K s rw- /bin/ls ?
0x0000555555775000 - 0x0000555555776000 - usr     4K s rw- [heap] ?
0x00007ffff7dd5000 - 0x00007ffff7dfc000 * usr   156K s r-x /lib/x86_64-linux-gnu/ld-2.27.so ?
0x00007ffff7ff8000 - 0x00007ffff7ffb000 - usr    12K s r-- [vvar] ?
0x00007ffff7ffb000 - 0x00007ffff7ffc000 - usr     4K s r-x [vdso] ?
0x00007ffff7ffc000 - 0x00007ffff7ffe000 - usr     8K s rw- /lib/x86_64-linux-gnu/ld-2.27.so ?
0x00007ffff7ffe000 - 0x00007ffff7fff000 - usr     4K s rw-  ?
0x00007ffffffde000 - 0x00007ffffffff000 - usr   132K s rw- [stack] ?
0xffffffffff600000 - 0xffffffffff601000 - usr     4K s --x [vsyscall] ?
```

**Test plan**
Currently, there is no way to test remote gdb features until #3574 is implemented. To validate the result of the io.gdb system commands, we can compare it with `d` debug commands which uses debug.gdb

Start a gdbserver
```
$ gdbserver host:4444 /bin/ls
```
Connect to gdbserver and test the followings commands and their equivalent `io` commands to confirm they produce the same output:
* `dm`  `=!dm`
* `dr8`  `=!dr8`
* `drp`  `=!drp`
```
$ r2 -d gdb://localhost:4444
= attach 2723 1
= attach 2723 0
 -- Enhance your graphs by increasing the size of the block and graph.depth eval variable.
[0x7ffff7dd6090]> dr8
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080dfffffff7f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009060ddf7ff7f000000020000330000002b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002220000062690000efea000032380000653d22313d2200007479706569020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006e7431323b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
[0x7ffff7dd6090]> =!dr8
000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080dfffffff7f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009060ddf7ff7f000000020000330000002b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002220000062690000efea000032380000653d22313d2200007479706569020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006e7431323b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
We can step a few instructions and check the `PC` register to confirm `=!ds` is working. For `dc`, we could call the command to confirm the process continue to end or a breakpoint.
* `ds` = `=!ds`
* `dc` = `=!dc`
* `dck 9` = `=!dck 9`

**Closing issues**
closes #6431 
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->