### PR TITLE
Reduce flicker when doing r2r -V (for some consoles)

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -626,6 +626,7 @@ static void print_new_results(R2RState *state, ut64 prev_completed) {
 		if (!name) {
 			continue;
 		}
+		printf ("\n"R_CONS_CURSOR_UP R_CONS_CLEAR_LINE);
 		switch (result->result) {
 		case R2R_TEST_RESULT_OK:
 			printf (Color_GREEN"[OK]"Color_RESET);
@@ -649,7 +650,6 @@ static void print_new_results(R2RState *state, ut64 prev_completed) {
 		}
 		free (name);
 	}
-
 }
 
 static void print_state_counts(R2RState *state) {
@@ -661,11 +661,10 @@ static void print_state(R2RState *state, ut64 prev_completed) {
 #if __WINDOWS__
 	setvbuf (stdout, NULL, _IOFBF, 8192);
 #endif
-	printf (R_CONS_CLEAR_LINE);
-
 	print_new_results (state, prev_completed);
 
 	// [x/x] OK  42 BR  0 ...
+	printf (R_CONS_CLEAR_LINE);
 	int w = printf ("[%"PFMT64u"/%"PFMT64u"]", (ut64)r_pvector_len (&state->results), (ut64)r_pvector_len (&state->db->tests));
 	while (w >= 0 && w < 20) {
 		printf (" ");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -568,6 +568,10 @@ typedef struct r_cons_t {
 #define R_CONS_CURSOR_SAVE "\x1b[s"
 #define R_CONS_CURSOR_RESTORE "\x1b[u"
 #define R_CONS_GET_CURSOR_POSITION "\x1b[6n"
+#define R_CONS_CURSOR_UP "\x1b[A"
+#define R_CONS_CURSOR_DOWN "\x1b[B"
+#define R_CONS_CURSOR_RIGHT "\x1b[C"
+#define R_CONS_CURSOR_LEFT "\x1b[D"
 
 #define Color_BLINK        "\x1b[5m"
 #define Color_INVERT       "\x1b[7m"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr reduces flicker of the summary line for some consoles when doing `r2r -V`, without mangling the scrollback buffer.

Example before:

![r2r-V_before](https://user-images.githubusercontent.com/12002672/81493681-0652cb00-92d5-11ea-82ce-d2f4d87de2b5.gif)

Example after:

![r2r-V_after](https://user-images.githubusercontent.com/12002672/81493736-76615100-92d5-11ea-96c5-ba5a2559eb2f.gif)

Apparently some terminals are line-buffered at their core and thus it appears line clearing and printing of new content should be done in 1 go for each line.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested on Conhost (Windows 10 1903), Windows Terminal, alacritty and mintty [Windows], and gnome_terminal, konsole, xfce4_terminal, mlterm and xterm [Linux].

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
