### PR TITLE
PE: Get actual checksum speedup ##bin

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -795,7 +795,7 @@ int PE_(bin_pe_get_claimed_checksum)(struct PE_(r_bin_pe_obj_t)* bin) {
 }
 
 int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin) {
-	int i, j, checksum_offset = 0;
+	size_t i, j, checksum_offset = 0;
 	ut64 computed_cs = 0;
 	int remaining_bytes;
 	int shift;
@@ -803,9 +803,15 @@ int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin) {
 	if (!bin || !bin->nt_header_offset) {
 		return 0;
 	}
+	const size_t buf_sz = 0x1000;
+	ut32 *buf = malloc (buf_sz);
+	if (!buf) {
+		return 0;
+	}
+	r_buf_read_at (bin->b, 0, (ut8 *)buf, buf_sz);
 	checksum_offset = bin->nt_header_offset + 4 + sizeof(PE_(image_file_header)) + 0x40;
-	for (i = 0; i < bin->size / 4; i++) {
-		cur = r_buf_read_le32_at (bin->b, i * 4);
+	for (i = 0, j = 0; i < bin->size / 4; i++) {
+		cur = r_read_at_ble32 (buf, sizeof (ut32) * j++, bin->endian);
 
 		// skip the checksum bytes
 		if (i * 4 == checksum_offset) {
@@ -815,6 +821,10 @@ int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin) {
 		computed_cs = (computed_cs & 0xFFFFFFFF) + cur + (computed_cs >> 32);
 		if (computed_cs >> 32) {
 			computed_cs = (computed_cs & 0xFFFFFFFF) + (computed_cs >> 32);
+		}
+		if (j == buf_sz / 4) {
+			r_buf_read_at (bin->b, (i + 1) * 4, (ut8 *)buf, buf_sz);
+			j = 0;
 		}
 	}
 
@@ -840,6 +850,7 @@ int PE_(bin_pe_get_actual_checksum)(struct PE_(r_bin_pe_obj_t)* bin) {
 
 	// add filesize
 	computed_cs += bin->size;
+	free (buf);
 	return computed_cs;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Especially noticeable in multi-megabyte bins

Before:
```
time r2 -qq /mnt/c/Windows/System32/MRT.exe
8.20s user 1.23s system 99% cpu 9.440 total
```

After:
```
time r2 -qq /mnt/c/Windows/System32/MRT.exe
1.55s user 1.20s system 100% cpu 2.749 total
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

