### PR TITLE
Add pj_reset()

### DIFF
--- a/libr/include/r_util/pj.h
+++ b/libr/include/r_util/pj.h
@@ -19,6 +19,7 @@ typedef struct pj_t {
 /* lifecycle */
 R_API PJ *pj_new(void);
 R_API void pj_free(PJ *j);
+R_API void pj_reset(PJ *j); // clear the pj contents, but keep the buffer allocated to re-use it
 R_API char *pj_drain(PJ *j);
 R_API const char *pj_string(PJ *pj);
 // R_API void pj_print(PJ *j, PrintfCallback cb);

--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -37,6 +37,14 @@ R_API void pj_free(PJ *pj) {
 	}
 }
 
+R_API void pj_reset(PJ *j) {
+	r_return_if_fail (j);
+	r_strbuf_set (&j->sb, "");
+	j->level = 0;
+	j->is_first = true;
+	j->is_key = false;
+}
+
 R_API char *pj_drain(PJ *pj) {
 	r_return_val_if_fail (pj && pj->level == 0, NULL);
 	char *res = r_strbuf_drain_nofree (&pj->sb);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -26,6 +26,7 @@ if get_option('enable_tests')
     'io',
     'list',
     'parse_ctype',
+    'pj',
     'queue',
     'range',
     'rbtree',

--- a/test/unit/test_pj.c
+++ b/test/unit/test_pj.c
@@ -1,0 +1,29 @@
+#include <r_types.h>
+#include <r_util/pj.h>
+#include "minunit.h"
+
+bool test_pj_reset() {
+	PJ *j = pj_new ();
+	pj_o (j);
+	pj_ks (j, "test", "object");
+	pj_end (j);
+	mu_assert_streq (pj_string (j), "{\"test\":\"object\"}", "before reset");
+	pj_reset (j);
+	mu_assert_streq (pj_string (j), "", "empty after reset");
+	pj_a (j);
+	pj_s (j, "test");
+	pj_s (j, "array");
+	pj_end (j);
+	mu_assert_streq (pj_string (j), "[\"test\",\"array\"]", "reuse after reset");
+	pj_free (j);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_pj_reset);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}


### PR DESCRIPTION
**Detailed description**

This can be used to re-use the same pj instance for creating multiple jsons without re-allocating the string buffer all the time.