### PR TITLE
Windows r2r: Actually display emojis (on consoles that support them)

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -164,6 +164,7 @@ int main(int argc, char **argv) {
 	int ret = 0;
 
 #if __WINDOWS__
+	UINT old_cp = GetConsoleOutputCP ();
 	{
 		HANDLE streams[] = { GetStdHandle (STD_OUTPUT_HANDLE), GetStdHandle (STD_ERROR_HANDLE) };
 		DWORD mode;
@@ -462,6 +463,15 @@ beach:
 	free (rasm2_cmd);
 	free (json_test_file);
 	free (fuzz_dir);
+#if __WINDOWS__
+	(void)SetConsoleOutputCP (old_cp);
+	// chcp doesn't pick up the code page switch for some reason
+	char *chcp = r_str_newf ("chcp %u > NUL", old_cp);
+	if (chcp) {
+		system (chcp);
+		free (chcp);
+	}
+#endif
 	return ret;
 }
 
@@ -702,6 +712,9 @@ static void interact(R2RState *state) {
 		goto beach;
 	}
 
+#if __WINDOWS__
+	(void)SetConsoleOutputCP (65001); // UTF-8
+#endif
 	printf ("\n");
 	printf ("#####################\n");
 	printf (" %"PFMT64u" failed test(s) \xf0\x9f\x9a\xa8\n", (ut64)r_pvector_len (&failed_results));


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes Windows r2r so that it actually tries to display its emojis.

Seen on Windows Terminal 0.11.1251.0:
![Windows_Terminal_emoji](https://user-images.githubusercontent.com/12002672/81548273-9e24e780-93af-11ea-9cd2-416b2693f397.png)

Seen on alacritty 0.5.0-dev (7901b45):
![Alacritty_emoji](https://user-images.githubusercontent.com/12002672/81548358-c0b70080-93af-11ea-83d2-90704a8cf6d6.png)

There appears to be full support from Windows Terminal, and partial support from alacritty and mintty (3.1.0), though this could be due to my lack of knowledge regarding font setup for them. Support for Conhost is somewhere ["in the future"](https://github.com/microsoft/terminal/issues/190#issuecomment-562731321) apparently.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Do `r2r -i` with failing `cmd` tests. The emojis should be displayed like on Linux.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
