### PR TITLE
When configuring root RCmdDesc node, parent may be NULL

### DIFF
--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -13,10 +13,12 @@ static int value = 0;
 R_LIB_VERSION (r_cmd);
 
 static bool cmd_desc_set_parent(RCmdDesc *cd, RCmdDesc *parent) {
-	r_return_val_if_fail (cd && parent && !cd->parent, false);
-	cd->parent = parent;
-	r_pvector_push (&parent->children, cd);
-	parent->n_children++;
+	r_return_val_if_fail (cd && !cd->parent, false);
+	if (parent) {
+		cd->parent = parent;
+		r_pvector_push (&parent->children, cd);
+		parent->n_children++;
+	}
 	return true;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

`parent` of `RCmdDesc` is NULL when creating the root node. This was not detected because the command initialization happen before cfg.level takes place, so the assertion was not printed.