### PR TITLE
Add r_debug_trace_op() API

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -4572,7 +4572,7 @@ repeat:
 		if (core->dbg->trace->enabled) {
 			RReg *reg = core->dbg->reg;
 			core->dbg->reg = core->anal->reg;
-			r_debug_trace_pc (core->dbg, addr);
+			r_debug_trace_op (core->dbg, &op);
 			core->dbg->reg = reg;
 		} else if (R_STR_ISNOTEMPTY (e)) {
 			r_anal_esil_parse (esil, e);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -549,6 +549,7 @@ R_API void r_debug_tracenodes_reset(RDebug *dbg);
 
 R_API void r_debug_trace_reset(RDebug *dbg);
 R_API int r_debug_trace_pc(RDebug *dbg, ut64 pc);
+R_API void r_debug_trace_op(RDebug *dbg, RAnalOp *op);
 R_API void r_debug_trace_at(RDebug *dbg, const char *str);
 R_API RDebugTracepoint *r_debug_trace_get(RDebug *dbg, ut64 addr);
 R_API void r_debug_trace_list(RDebug *dbg, int mode, ut64 offset);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This allows to avoid extra call of `r_anal_op()` in `r_core_esil_step()`. But yes, new API for a single case is a really hackish solution.

`aaft` time for `/usr/bin/snap` (~18MB): 95s vs 88s
                      `/bin/ls`: 1.25s vs 1.16s
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
