### PR TITLE
Fix r2r -i and add Tests

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -879,7 +879,7 @@ static void replace_cmd_kv_file(const char *path, ut64 line_begin, ut64 line_end
 		eprintf ("Failed to read file \"%s\"\n", path);
 		return;
 	}
-	char *newc = replace_cmd_kv(path, content, line_begin, line_end, key, value, fixup_results);
+	char *newc = replace_cmd_kv (path, content, line_begin, line_end, key, value, fixup_results);
 	free (content);
 	if (!newc) {
 		return;

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -782,8 +782,8 @@ static char *format_cmd_kv(const char *key, const char *val) {
 	return r_strbuf_drain_nofree (&buf);
 }
 
-static char *replace_lines(char *src, ut64 from, ut64 to, char *news) {
-	char *begin = src;
+static char *replace_lines(const char *src, ut64 from, ut64 to, char *news) {
+	const char *begin = src;
 	ut64 line = 1;
 	while (line < from) {
 		begin = strchr (begin, '\n');
@@ -797,7 +797,7 @@ static char *replace_lines(char *src, ut64 from, ut64 to, char *news) {
 		return NULL;
 	}
 
-	char *end = begin;
+	const char *end = begin;
 	while (line < to) {
 		end = strchr (end, '\n');
 		if (!end) {
@@ -853,20 +853,33 @@ static void fixup_tests(RPVector *results, const char *edited_file, ut64 start_l
 	}
 }
 
-static void replace_cmd_kv(const char *path, ut64 line_begin, ut64 line_end, const char *key, const char *value, RPVector *fixup_results) {
+static char *replace_cmd_kv(const char *path, const char *content, ut64 line_begin, ut64 line_end, const char *key, const char *value, RPVector *fixup_results) {
+	char *kv = format_cmd_kv (key, value);
+	if (!kv) {
+		return NULL;
+	}
+	ut64 kv_lines = r_str_char_count (kv, '\n') + 1;
+	char *newc = replace_lines (content, line_begin, line_end, kv);
+	free (kv);
+	if (!newc) {
+		return NULL;
+	}
+	ut64 lines_before = line_end - line_begin;
+	st64 delta = (st64)kv_lines - lines_before;
+	if (line_end == line_begin) {
+		delta++;
+	}
+	fixup_tests (fixup_results, path, line_end, delta);
+	return newc;
+}
+
+static void replace_cmd_kv_file(const char *path, ut64 line_begin, ut64 line_end, const char *key, const char *value, RPVector *fixup_results) {
 	char *content = r_file_slurp (path, NULL);
 	if (!content) {
 		eprintf ("Failed to read file \"%s\"\n", path);
 		return;
 	}
-	char *kv = format_cmd_kv (key, value);
-	if (!kv) {
-		free (content);
-		return;
-	}
-	ut64 kv_lines = r_str_char_count (kv, '\n');
-	char *newc = replace_lines (content, line_begin, line_end, kv);
-	free (kv);
+	char *newc = replace_cmd_kv(path, content, line_begin, line_end, key, value, fixup_results);
 	free (content);
 	if (!newc) {
 		return;
@@ -875,16 +888,9 @@ static void replace_cmd_kv(const char *path, ut64 line_begin, ut64 line_end, con
 #if __UNIX__
 		sync ();
 #endif
-		ut64 lines_before = line_end - line_begin;
-		st64 delta = (st64)kv_lines - lines_before;
-		if (line_end == line_begin) {
-			delta++;
-		}
-		fixup_tests (fixup_results, path, line_end, delta);
 	} else {
 		eprintf ("Failed to write file \"%s\"\n", path);
 	}
-	free (newc);
 }
 
 static void interact_fix(R2RTestResultInfo *result, RPVector *fixup_results) {
@@ -892,10 +898,10 @@ static void interact_fix(R2RTestResultInfo *result, RPVector *fixup_results) {
 	R2RCmdTest *test = result->test->cmd_test;
 	R2RProcessOutput *out = result->proc_out;
 	if (test->expect.value && out->out) {
-		replace_cmd_kv (result->test->path, test->expect.line_begin, test->expect.line_end, "EXPECT", out->out, fixup_results);
+		replace_cmd_kv_file (result->test->path, test->expect.line_begin, test->expect.line_end, "EXPECT", out->out, fixup_results);
 	}
 	if (test->expect_err.value && out->err) {
-		replace_cmd_kv (result->test->path, test->expect_err.line_begin, test->expect_err.line_end, "EXPECT_ERR", out->err, fixup_results);
+		replace_cmd_kv_file (result->test->path, test->expect_err.line_begin, test->expect_err.line_end, "EXPECT_ERR", out->err, fixup_results);
 	}
 }
 
@@ -910,7 +916,7 @@ static void interact_break(R2RTestResultInfo *result, RPVector *fixup_results) {
 	} else {
 		line_begin = line_end = test->run_line;
 	}
-	replace_cmd_kv (result->test->path, line_begin, line_end, "BROKEN", "1", fixup_results);
+	replace_cmd_kv_file (result->test->path, line_begin, line_end, "BROKEN", "1", fixup_results);
 }
 
 static void interact_commands(R2RTestResultInfo *result, RPVector *fixup_results) {
@@ -966,7 +972,7 @@ static void interact_commands(R2RTestResultInfo *result, RPVector *fixup_results
 		}
 	}
 
-	replace_cmd_kv (result->test->path, test->cmds.line_begin, test->cmds.line_end, "CMDS", newcmds, fixup_results);
+	replace_cmd_kv_file (result->test->path, test->cmds.line_begin, test->cmds.line_end, "CMDS", newcmds, fixup_results);
 	free (name);
 	free (newcmds);
 }

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -782,9 +782,9 @@ static char *format_cmd_kv(const char *key, const char *val) {
 	return r_strbuf_drain_nofree (&buf);
 }
 
-static char *replace_lines(const char *src, ut64 from, ut64 to, char *news) {
+static char *replace_lines(const char *src, size_t from, size_t to, const char *news) {
 	const char *begin = src;
-	ut64 line = 1;
+	size_t line = 1;
 	while (line < from) {
 		begin = strchr (begin, '\n');
 		if (!begin) {
@@ -853,19 +853,19 @@ static void fixup_tests(RPVector *results, const char *edited_file, ut64 start_l
 	}
 }
 
-static char *replace_cmd_kv(const char *path, const char *content, ut64 line_begin, ut64 line_end, const char *key, const char *value, RPVector *fixup_results) {
+static char *replace_cmd_kv(const char *path, const char *content, size_t line_begin, size_t line_end, const char *key, const char *value, RPVector *fixup_results) {
 	char *kv = format_cmd_kv (key, value);
 	if (!kv) {
 		return NULL;
 	}
-	ut64 kv_lines = r_str_char_count (kv, '\n') + 1;
+	size_t kv_lines = r_str_char_count (kv, '\n') + 1;
 	char *newc = replace_lines (content, line_begin, line_end, kv);
 	free (kv);
 	if (!newc) {
 		return NULL;
 	}
-	ut64 lines_before = line_end - line_begin;
-	st64 delta = (st64)kv_lines - lines_before;
+	size_t lines_before = line_end - line_begin;
+	st64 delta = (st64)kv_lines - (st64)lines_before;
 	if (line_end == line_begin) {
 		delta++;
 	}

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -29,6 +29,7 @@ if get_option('enable_tests')
     'parse_ctype',
     'pj',
     'queue',
+    'r2r',
     'range',
     'rbtree',
     'skiplist',

--- a/test/unit/r2r_cmd_test
+++ b/test/unit/r2r_cmd_test
@@ -1,0 +1,38 @@
+NAME=multiline0
+FILE=-
+CMDS=<<EOF
+rm -rf /
+EOF
+EXPECT=<<EOF
+expected
+output
+EOF
+RUN
+
+NAME=singleline0
+FILE=-
+CMDS=<<EOF
+rm -rf
+EOF
+EXPECT=
+RUN
+
+NAME=multiline1
+FILE=-
+CMDS=<<EOF
+rm -rf
+EOF
+EXPECT=<<EOF
+more
+expected
+output
+EOF
+RUN
+
+NAME=singleline1
+FILE=-
+CMDS=<<EOF
+rm -rf
+EOF
+EXPECT=
+RUN

--- a/test/unit/test_r2r.c
+++ b/test/unit/test_r2r.c
@@ -1,0 +1,190 @@
+
+#define main not_main
+#include "../../binr/r2r/r2r.c"
+#include "../../binr/r2r/load.c"
+#include "../../binr/r2r/run.c"
+#undef main
+
+#include "minunit.h"
+
+#define FILENAME "unit/r2r_cmd_test"
+
+bool test_r2r_database_load_cmd(void) {
+	R2RTestDatabase *db = r2r_test_database_new ();
+	database_load (db, FILENAME, 1);
+
+	mu_assert_eq (r_pvector_len (&db->tests), 4, "tests count");
+
+	R2RTest *test = r_pvector_at (&db->tests, 0);
+	mu_assert_eq (test->type, R2R_TEST_TYPE_CMD, "test type");
+	R2RCmdTest *cmd_test = test->cmd_test;
+	mu_assert_streq (cmd_test->name.value, "multiline0", "name");
+	mu_assert_streq (cmd_test->file.value, "-", "file");
+	mu_assert_streq (cmd_test->cmds.value, "rm -rf /\n", "cmds");
+	mu_assert_streq (cmd_test->expect.value, "expected\noutput\n", "expect");
+	mu_assert_eq (cmd_test->expect.line_begin, 6, "line begin");
+	mu_assert_eq (cmd_test->expect.line_end, 10, "line begin");
+
+	test = r_pvector_at (&db->tests, 1);
+	mu_assert_eq (test->type, R2R_TEST_TYPE_CMD, "test type");
+	cmd_test = test->cmd_test;
+	mu_assert_streq (cmd_test->name.value, "singleline0", "name");
+	mu_assert_streq (cmd_test->expect.value, "", "expect");
+	mu_assert_eq (cmd_test->expect.line_begin, 17, "line begin");
+	mu_assert_eq (cmd_test->expect.line_end, 18, "line begin");
+
+	test = r_pvector_at (&db->tests, 2);
+	mu_assert_eq (test->type, R2R_TEST_TYPE_CMD, "test type");
+	cmd_test = test->cmd_test;
+	mu_assert_streq (cmd_test->name.value, "multiline1", "name");
+	mu_assert_streq (cmd_test->expect.value, "more\nexpected\noutput\n", "expect");
+	mu_assert_eq (cmd_test->expect.line_begin, 25, "line begin");
+	mu_assert_eq (cmd_test->expect.line_end, 30, "line begin");
+
+	test = r_pvector_at (&db->tests, 3);
+	mu_assert_eq (test->type, R2R_TEST_TYPE_CMD, "test type");
+	cmd_test = test->cmd_test;
+	mu_assert_streq (cmd_test->name.value, "singleline1", "name");
+	mu_assert_streq (cmd_test->expect.value, "", "expect");
+	mu_assert_eq (cmd_test->expect.line_begin, 37, "line begin");
+	mu_assert_eq (cmd_test->expect.line_end, 38, "line begin");
+
+	r2r_test_database_free (db);
+	mu_end;
+}
+
+bool test_r2r_fix(void) {
+	R2RTestDatabase *db = r2r_test_database_new ();
+	database_load (db, FILENAME, 1);
+
+	RPVector *results = r_pvector_new ((RPVectorFree)r2r_test_result_info_free);
+
+	R2RTestResultInfo *result0 = R_NEW0 (R2RTestResultInfo);
+	r_pvector_push (results, result0);
+	result0->test = r_pvector_at (&db->tests, 0);
+	result0->result = R2R_TEST_RESULT_FAILED;
+	result0->proc_out = R_NEW0 (R2RProcessOutput);
+	result0->proc_out->out = strdup ("fixed\nresult\nfor\n0\n");
+	result0->proc_out->err = strdup ("");
+
+	R2RTestResultInfo *result1 = R_NEW0 (R2RTestResultInfo);
+	r_pvector_push (results, result1);
+	result1->test = r_pvector_at (&db->tests, 1);
+	result1->result = R2R_TEST_RESULT_FAILED;
+	result1->proc_out = R_NEW0 (R2RProcessOutput);
+	result1->proc_out->out = strdup ("fixed\nresult\nfor\n1\n");
+	result1->proc_out->err = strdup ("");
+
+	R2RTestResultInfo *result2 = R_NEW0 (R2RTestResultInfo);
+	r_pvector_push (results, result2);
+	result2->test = r_pvector_at (&db->tests, 2);
+	result2->result = R2R_TEST_RESULT_FAILED;
+	result2->proc_out = R_NEW0 (R2RProcessOutput);
+	result2->proc_out->out = strdup ("fixed\nresult\nfor\n2\n");
+	result2->proc_out->err = strdup ("");
+
+	R2RTestResultInfo *result3 = R_NEW0 (R2RTestResultInfo);
+	r_pvector_push (results, result3);
+	result3->test = r_pvector_at (&db->tests, 3);
+	result3->result = R2R_TEST_RESULT_FAILED;
+	result3->proc_out = R_NEW0 (R2RProcessOutput);
+	result3->proc_out->out = strdup ("fixed\nresult\nfor\n3\n");
+	result3->proc_out->err = strdup ("");
+
+	char *content = r_file_slurp (FILENAME, NULL);
+	mu_assert ("test file", content);
+
+	char *newc = replace_cmd_kv (result0->test->path, content, result0->test->cmd_test->expect.line_begin,
+			result0->test->cmd_test->expect.line_end, "EXPECT", result0->proc_out->out, results);
+	mu_assert ("fixed", newc);
+	free (content);
+	content = newc;
+
+	newc = replace_cmd_kv (result1->test->path, content, result1->test->cmd_test->expect.line_begin,
+			result1->test->cmd_test->expect.line_end, "EXPECT", result1->proc_out->out, results);
+	mu_assert ("fixed", newc);
+	free (content);
+	content = newc;
+
+	newc = replace_cmd_kv (result2->test->path, content, result2->test->cmd_test->expect.line_begin,
+			result2->test->cmd_test->expect.line_end, "EXPECT", result2->proc_out->out, results);
+	mu_assert ("fixed", newc);
+	free (content);
+	content = newc;
+
+	newc = replace_cmd_kv (result3->test->path, content, result3->test->cmd_test->expect.line_begin,
+			result3->test->cmd_test->expect.line_end, "EXPECT", result3->proc_out->out, results);
+	mu_assert ("fixed", newc);
+	free (content);
+	content = newc;
+
+	r_pvector_free (results);
+
+	mu_assert_streq (content,
+		"NAME=multiline0\n"
+		"FILE=-\n"
+		"CMDS=<<EOF\n"
+		"rm -rf /\n"
+		"EOF\n"
+		"EXPECT=<<EOF\n"
+		"fixed\n"
+		"result\n"
+		"for\n"
+		"0\n"
+		"EOF\n"
+		"RUN\n"
+		"\n"
+		"NAME=singleline0\n"
+		"FILE=-\n"
+		"CMDS=<<EOF\n"
+		"rm -rf\n"
+		"EOF\n"
+		"EXPECT=<<EOF\n"
+		"fixed\n"
+		"result\n"
+		"for\n"
+		"1\n"
+		"EOF\n"
+		"RUN\n"
+		"\n"
+		"NAME=multiline1\n"
+		"FILE=-\n"
+		"CMDS=<<EOF\n"
+		"rm -rf\n"
+		"EOF\n"
+		"EXPECT=<<EOF\n"
+		"fixed\n"
+		"result\n"
+		"for\n"
+		"2\n"
+		"EOF\n"
+		"RUN\n"
+		"\n"
+		"NAME=singleline1\n"
+		"FILE=-\n"
+		"CMDS=<<EOF\n"
+		"rm -rf\n"
+		"EOF\n"
+		"EXPECT=<<EOF\n"
+		"fixed\n"
+		"result\n"
+		"for\n"
+		"3\n"
+		"EOF\n"
+		"RUN", "fixed contents");
+
+	free (content);
+
+	r2r_test_database_free (db);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_r2r_database_load_cmd);
+	mu_run_test(test_r2r_fix);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}

--- a/test/unit/test_r2r.c
+++ b/test/unit/test_r2r.c
@@ -180,8 +180,8 @@ bool test_r2r_fix(void) {
 }
 
 int all_tests() {
-	mu_run_test(test_r2r_database_load_cmd);
-	mu_run_test(test_r2r_fix);
+	mu_run_test (test_r2r_database_load_cmd);
+	mu_run_test (test_r2r_fix);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
Fixing tests from `r2r -i` was messing up the line numbers when multiple tests were fixed in the same file, resulting in broken tests.