### PR TITLE
r2r.c: Replace \x## emoji seqs with #defines

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -717,7 +717,7 @@ static void interact(R2RState *state) {
 #endif
 	printf ("\n");
 	printf ("#####################\n");
-	printf (" %"PFMT64u" failed test(s) \xf0\x9f\x9a\xa8\n", (ut64)r_pvector_len (&failed_results));
+	printf (" %"PFMT64u" failed test(s) 🚨\n", (ut64)r_pvector_len (&failed_results));
 
 	r_pvector_foreach (&failed_results, it) {
 		R2RTestResultInfo *result = *it;
@@ -730,11 +730,11 @@ static void interact(R2RState *state) {
 		print_result_diff (&state->run_config, result);
 inval:
 		printf ("Wat do?    "
-				"(f)ix \xe2\x9c\x85\xef\xb8\x8f\xef\xb8\x8f\xef\xb8\x8f    "
-				"(i)gnore \xf0\x9f\x99\x88    "
-				"(b)roken \xe2\x98\xa0\xef\xb8\x8f\xef\xb8\x8f\xef\xb8\x8f    "
-				"(c)ommands \xe2\x8c\xa8\xef\xb8\x8f    "
-				"(q)uit \xf0\x9f\x9a\xaa\n");
+				"(f)ix ✅"UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
+				"(i)gnore 🙈    "
+				"(b)roken ☠"UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
+				"(c)ommands ⌨"UTF8_VS16"    "
+				"(q)uit 🚪\n");
 		printf ("> ");
 		char buf[0x30];
 		if (!fgets (buf, sizeof (buf), stdin)) {

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -717,7 +717,8 @@ static void interact(R2RState *state) {
 #endif
 	printf ("\n");
 	printf ("#####################\n");
-	printf (" %"PFMT64u" failed test(s) 🚨\n", (ut64)r_pvector_len (&failed_results));
+	printf (" %"PFMT64u" failed test(s) "UTF8_POLICE_CARS_REVOLVING_LIGHT"\n",
+	        (ut64)r_pvector_len (&failed_results));
 
 	r_pvector_foreach (&failed_results, it) {
 		R2RTestResultInfo *result = *it;
@@ -730,11 +731,11 @@ static void interact(R2RState *state) {
 		print_result_diff (&state->run_config, result);
 inval:
 		printf ("Wat do?    "
-				"(f)ix ✅"UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
-				"(i)gnore 🙈    "
-				"(b)roken ☠"UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
-				"(c)ommands ⌨"UTF8_VS16"    "
-				"(q)uit 🚪\n");
+				"(f)ix "UTF8_WHITE_HEAVY_CHECK_MARK UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
+				"(i)gnore "UTF8_SEE_NO_EVIL_MONKEY"    "
+				"(b)roken "UTF8_SKULL_AND_CROSSBONES UTF8_VS16 UTF8_VS16 UTF8_VS16"    "
+				"(c)ommands "UTF8_KEYBOARD UTF8_VS16"    "
+				"(q)uit "UTF8_DOOR"\n");
 		printf ("> ");
 		char buf[0x30];
 		if (!fgets (buf, sizeof (buf), stdin)) {

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -421,6 +421,14 @@ typedef struct r_cons_canvas_t {
 #define UTF_CIRCLE "\u25EF"
 #define UTF_BLOCK "\u2588"
 
+// Emoji
+#define UTF8_POLICE_CARS_REVOLVING_LIGHT "🚨"
+#define UTF8_WHITE_HEAVY_CHECK_MARK "✅"
+#define UTF8_SEE_NO_EVIL_MONKEY "🙈"
+#define UTF8_SKULL_AND_CROSSBONES "☠"
+#define UTF8_KEYBOARD "⌨"
+#define UTF8_DOOR "🚪"
+
 // Variation Selectors
 #define UTF8_VS16 "\xef\xb8\x8f"
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -421,6 +421,9 @@ typedef struct r_cons_canvas_t {
 #define UTF_CIRCLE "\u25EF"
 #define UTF_BLOCK "\u2588"
 
+// Variation Selectors
+#define UTF8_VS16 "\xef\xb8\x8f"
+
 typedef char *(*RConsEditorCallback)(void *core, const char *file, const char *str);
 typedef int (*RConsClickCallback)(void *core, int x, int y);
 typedef void (*RConsBreakCallback)(void *core);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr replaces the `\x##` emoji sequences in r2r.c with actual emoji so that it's clear what the `\x##` emoji sequences represent, and also adds a `#define` for Variation Selector-16.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The emojis should still appear when doing `r2r -i` with failing tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
