### PR TITLE
Move rasign2 into RMain

### DIFF
--- a/binr/Makefile
+++ b/binr/Makefile
@@ -6,7 +6,7 @@ BTOP=$(shell pwd)
 
 .PHONY: all clean install install-symlink deinstall uninstall mrproper preload
 
-BINS=rax2 rasm2 rabin2 rahash2 radiff2 radare2 rafind2 rarun2 ragg2 r2agent r2r
+BINS=rax2 rasm2 rabin2 rahash2 radiff2 radare2 rafind2 rarun2 ragg2 r2agent r2r rasign2
 
 LIBR2=$(call libname-version,libr2.$(EXT_SO),${LIBVERSION})
 

--- a/binr/rasign2/Makefile
+++ b/binr/rasign2/Makefile
@@ -1,5 +1,5 @@
 BIN=rasign2
-BINDEPS=r_anal r_util r_search r_main
+BINDEPS=r_anal r_util r_core r_search r_main
 
 include ../../libr/main/deps.mk
 include ../rules.mk

--- a/binr/rasign2/Makefile
+++ b/binr/rasign2/Makefile
@@ -1,5 +1,5 @@
 BIN=rasign2
-BINDEPS=r_anal r_util r_search
+BINDEPS=r_anal r_util r_search r_main
 
 include ../../libr/main/deps.mk
 include ../rules.mk

--- a/binr/rasign2/meson.build
+++ b/binr/rasign2/meson.build
@@ -1,0 +1,13 @@
+executable('rasign', 'rasign.c',
+  include_directories: [platform_inc],
+  dependencies: [
+    r_util_dep,
+    r_main_dep,
+    r_search_dep,
+    r_core_dep,
+    r_bin_dep,
+  ],
+  install: true,
+  install_rpath: rpath,
+  implicit_include_directories: false
+)

--- a/binr/rasign2/rasign2.c
+++ b/binr/rasign2/rasign2.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2019 - pancake */
+/* radare - LGPL - Copyright 2009-2020 - pancake */
 
 #include <r_main.h>
 

--- a/binr/rasign2/rasign2.c
+++ b/binr/rasign2/rasign2.c
@@ -1,69 +1,7 @@
 /* radare - LGPL - Copyright 2009-2019 - pancake */
 
-#include <stdio.h>
-#include <string.h>
-#include <r_getopt.h>
+#include <r_main.h>
 
-#include "r_userconf.h"
-#include "r_sign.h"
-
-static int rasign_show_help() {
-	printf ("Usage: rasign2 [options] [file]\n"
-	" -r            show output in radare commands\n"
-	" -j            show output in json\n"
-	" -s [sigfile]  specify one or more signature files\n"
-	"Examples:\n"
-	"  rasign2 libc.so.6 > libc.sig\n"
-	"  rasign2 -s libc.sig ls.static\n");
-	return 0;
-}
-
-int main(int argc, char **argv) {
-	int c;
-	int action = 0;
-	int rad = 0;
-	int json = 0;
-	//RSign *sig = r_sign_new ();
-
-	while ((c=getopt (argc, argv, "o:hrsj:iV")) !=-1) {
-		switch (c) {
-		case 'o':
-			//r_sign_option (&sig, optarg);
-			break;
-		case 's':
-			action = c;
-			//r_sign_load_file (&sig, optarg);
-			break;
-		case 'r':
-			rad = 1;
-			break;
-		case 'j':
-			json = 1;
-			break;
-		case 'V':
-			return blob_version ("rasign2");
-		default:
-			return rasign_show_help ();
-		}
-	}
-
-	if (argv[optind]==NULL)
-		return rasign_show_help ();
-
-	//r_sign_list (sig, rad, json);
-
-	switch (action) {
-	case 's':
-		/* check sigfiles in optarg file */
-	//	r_sign_check (&sig, argv[optind]);
-		break;
-	default:
-		/* generate signature file */
-		//r_sign_generate (&sig, argv[optind], stdout);
-		break;
-	}
-
-	//r_sign_free (sig);
-
-	return 0;
+int main(int argc, const char **argv) {
+	return r_main_rasign2 (argc, argv);
 }

--- a/libr/include/r_main.h
+++ b/libr/include/r_main.h
@@ -31,5 +31,6 @@ R_API int r_main_r2agent(int argc, const char **argv);
 R_API int r_main_rafind2(int argc, const char **argv);
 R_API int r_main_radiff2(int argc, const char **argv);
 R_API int r_main_ragg2(int argc, const char **argv);
+R_API int r_main_rasign2(int argc, const char **argv);
 
 #endif

--- a/libr/main/Makefile
+++ b/libr/main/Makefile
@@ -8,6 +8,7 @@ OBJS+=rasm2.o
 OBJS+=ragg2.o
 OBJS+=rarun2.o
 OBJS+=rabin2.o
+OBJS+=rasign2.o
 OBJS+=rafind2.o
 OBJS+=r2agent.o
 OBJS+=radiff2.o

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -84,7 +84,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	}
 
 	const char *ifile = NULL;
-	if ( opt.ind < argc ) {
+	if ( opt.ind >= argc ) {
 		eprintf("must provide a file\n");
 		return rasign_show_help ();
 	}

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -64,7 +64,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	const char *ifile = NULL;
 	int c;
 	int a_cnt = 0;
-	int rad = 0;
+	bool rad = false;
 	RGetopt opt;
 
 	r_getopt_init (&opt, argc, argv, "ao:rvh");
@@ -77,7 +77,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 			ofile = opt.arg;
 			break;
 		case 'r':
-			rad = 1;
+			rad = true;
 			break;
 		case 'v':
 			return r_main_version_print ("rasign2");

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -53,7 +53,6 @@ static int find_functions(int count, RCore *core) {
 		rasign_show_help ();
 		return -1;
 	}
-	r_cons_flush ();
 	r_core_cmd0 (core, cmd);
 	return 0;
 }

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -1,3 +1,4 @@
+/* radare - LGPL - Copyright 2009-2020 - pancake */
 #include <stdio.h>
 #include <string.h>
 #include <r_getopt.h>

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -2,7 +2,7 @@
 #include <r_main.h>
 #include <r_core.h>
 
-static int rasign_show_help() {
+static void rasign_show_help() {
 	printf ("Usage: rasign2 [options] [file]\n"
 		" -a [-a]          add extra 'a' to analysis command\n"
 		" -o sigs.sdb      add signatures to file, create if it does not exist\n"
@@ -13,7 +13,6 @@ static int rasign_show_help() {
 		" -h               help menu\n"
 		"Examples:\n"
 		"  rasign2 -o libc.sdb libc.so.6\n");
-	return 0;
 }
 
 static RCore *opencore(const char *fname) {
@@ -79,8 +78,12 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 			break;
 		case 'v':
 			return r_main_version_print ("rasign2");
+		case 'h':
+			rasign_show_help ();
+			return 0;
 		default:
-			return rasign_show_help ();
+			rasign_show_help ();
+			return -1;
 		}
 	}
 

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -16,6 +16,7 @@ static void rasign_show_help() {
 }
 
 static RCore *opencore(const char *fname) {
+	RCoreFile * rfile = NULL;
 	RCore *c = r_core_new ();
 	if (!c) {
 		eprintf ("Count not get core\n");
@@ -25,9 +26,14 @@ static RCore *opencore(const char *fname) {
 	r_config_set_i (c->config, "scr.interactive", false);
 	if (fname) {
 #if __WINDOWS__
-		fname = r_acp_to_utf8 (fname);
+		char *winf = r_acp_to_utf8 (fname);
+		rfile = r_core_file_open (c, winf, 0, 0);
+		free (winf);
+#else
+		rfile = r_core_file_open (c, fname, 0, 0);
 #endif
-		if (!r_core_file_open (c, fname, 0, 0)) {
+
+		if (!rfile) {
 			eprintf ("Could not open file %s\n", fname);
 			r_core_free (c);
 			return NULL;

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -31,8 +31,8 @@ static RCore *opencore(const char *fname) {
 		fname = r_acp_to_utf8 (fname);
 #endif
 		if (!r_core_file_open (c, fname, 0, 0)) {
-			r_core_free (c);
 			eprintf ("Could not open file %s\n", fname);
+			r_core_free (c);
 			return NULL;
 		}
 		(void)r_core_bin_load (c, NULL, UT64_MAX);

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -19,7 +19,6 @@ static int rasign_show_help() {
 }
 
 static RCore *opencore(const char *fname) {
-	const ut64 baddr = UT64_MAX;
 	RCore *c = r_core_new ();
 	if (!c) {
 		eprintf ("Count not get core\n");
@@ -36,7 +35,7 @@ static RCore *opencore(const char *fname) {
 			eprintf ("Could not open file %s\n", fname);
 			return NULL;
 		}
-		(void)r_core_bin_load (c, NULL, baddr);
+		(void)r_core_bin_load (c, NULL, UT64_MAX);
 		(void)r_core_bin_update_arch_bits (c);
 		r_cons_flush ();
 	}

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -1,0 +1,119 @@
+#include <stdio.h>
+#include <string.h>
+#include <r_getopt.h>
+#include <r_main.h>
+#include <r_sign.h>
+#include <r_core.h>
+
+#include "r_userconf.h"
+
+static int rasign_show_help() {
+	printf ("Usage: rasign2 [options] [file]\n"
+		" -a [-a]          add extra 'a' to analysis command\n"
+		" -o sigs.sdb      add signatures to file, create if it does not exist\n"
+		" -r               show output in radare commands\n"
+		"Examples:\n"
+		"  rasign2 -o libc.sdb libc.so.6\n");
+	return 0;
+}
+
+static RCore *opencore(const char *fname) {
+	const ut64 baddr = UT64_MAX;
+	RCore *c = r_core_new ();
+	if (!c) {
+		eprintf ("Count not get core\n");
+		return NULL;
+	}
+	r_core_loadlibs (c, R_CORE_LOADLIBS_ALL, NULL);
+	r_config_set_i (c->config, "scr.interactive", false);
+	if (fname) {
+#if __WINDOWS__
+		fname = r_acp_to_utf8 (fname);
+#endif
+		if (!r_core_file_open (c, fname, 0, 0)) {
+			r_core_free (c);
+			eprintf ("Could not open file %s\n", fname);
+			return NULL;
+		}
+		(void)r_core_bin_load (c, NULL, baddr);
+		(void)r_core_bin_update_arch_bits (c);
+		r_cons_flush ();
+	}
+	return c;
+}
+
+static int find_functions(int count, RCore *core) {
+	const char *cmd = NULL;
+	switch (count) {
+	case 0: cmd = "aa"; break;
+	case 1: cmd = "aaa"; break;
+	case 2: cmd = "aaaa"; break;
+	default:
+		eprintf ("Invalid analysis (too many -a's?)\n");
+		rasign_show_help ();
+		return -1;
+	}
+	r_cons_flush ();
+	r_core_cmd0 (core, cmd);
+	return 0;
+}
+
+R_API int r_main_rasign2(int argc, const char **argv) {
+	const char *ofile = NULL;
+	const char *ifile = NULL;
+	int c;
+	int a_cnt = 0;
+	int rad = 0;
+	RCore *core;
+	RGetopt opt;
+
+	r_getopt_init (&opt, argc, argv, "ao:rvh");
+	while ((c = r_getopt_next (&opt)) != -1) {
+		switch (c) {
+		case 'a':
+			a_cnt++;
+			break;
+		case 'o':
+			ofile = opt.arg;
+			break;
+		case 'r':
+			rad = 1;
+			break;
+		case 'v':
+			return r_main_version_print ("rasign2");
+		default:
+			return rasign_show_help ();
+		}
+	}
+
+	ifile = (opt.ind < argc)? argv[opt.ind]: NULL;
+	if (ifile == NULL) {
+		return rasign_show_help ();
+	}
+
+	// get the core
+	if ((core = opencore (ifile)) == NULL) {
+		return -1;
+	}
+
+	// run analysis to find functions
+	if (find_functions (a_cnt, core)) {
+		r_core_free (core);
+		return -1;
+	}
+
+	// create zignatures
+	r_core_cmd0 (core, "zg");
+
+	// write sigs to file
+	if (ofile) {
+		r_core_cmdf (core, "zos %s", ofile);
+	}
+
+	if (rad) {
+		r_core_flush (core, "z*");
+	}
+
+	r_core_free (core);
+	return 0;
+}

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -65,7 +65,6 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	int c;
 	int a_cnt = 0;
 	int rad = 0;
-	RCore *core;
 	RGetopt opt;
 
 	r_getopt_init (&opt, argc, argv, "ao:rvh");
@@ -93,8 +92,9 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	}
 
 	// get the core
-	if ((core = opencore (ifile)) == NULL) {
-		return -1;
+	RCore *core = opencore (ifile);
+	if (!core) {
+	  return -1;
 	}
 
 	// run analysis to find functions

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -85,8 +85,8 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	}
 
 	const char *ifile = NULL;
-	if ( opt.ind >= argc ) {
-		eprintf("must provide a file\n");
+	if (opt.ind >= argc) {
+		eprintf ("must provide a file\n");
 		rasign_show_help ();
 		return -1;
 	}
@@ -95,7 +95,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	// get the core
 	RCore *core = opencore (ifile);
 	if (!core) {
-	  return -1;
+		return -1;
 	}
 
 	// run analysis to find functions

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -60,7 +60,6 @@ static int find_functions(int count, RCore *core) {
 
 R_API int r_main_rasign2(int argc, const char **argv) {
 	const char *ofile = NULL;
-	const char *ifile = NULL;
 	int c;
 	int a_cnt = 0;
 	bool rad = false;
@@ -85,10 +84,12 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 		}
 	}
 
-	ifile = (opt.ind < argc)? argv[opt.ind]: NULL;
-	if (ifile == NULL) {
+	const char *ifile = NULL;
+	if ( opt.ind < argc ) {
+		eprintf("must provide a file\n");
 		return rasign_show_help ();
 	}
+	ifile = argv[opt.ind];
 
 	// get the core
 	RCore *core = opencore (ifile);

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -1,12 +1,6 @@
 /* radare - LGPL - Copyright 2009-2020 - pancake */
-#include <stdio.h>
-#include <string.h>
-#include <r_getopt.h>
 #include <r_main.h>
-#include <r_sign.h>
 #include <r_core.h>
-
-#include "r_userconf.h"
 
 static int rasign_show_help() {
 	printf ("Usage: rasign2 [options] [file]\n"

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -42,7 +42,7 @@ static RCore *opencore(const char *fname) {
 	return c;
 }
 
-static int find_functions(int count, RCore *core) {
+static int find_functions(RCore *core, size_t count) {
 	const char *cmd = NULL;
 	switch (count) {
 	case 0: cmd = "aa"; break;
@@ -60,7 +60,7 @@ static int find_functions(int count, RCore *core) {
 R_API int r_main_rasign2(int argc, const char **argv) {
 	const char *ofile = NULL;
 	int c;
-	int a_cnt = 0;
+	size_t a_cnt = 0;
 	bool rad = false;
 	RGetopt opt;
 
@@ -97,7 +97,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	}
 
 	// run analysis to find functions
-	if (find_functions (a_cnt, core)) {
+	if (find_functions (core, a_cnt)) {
 		r_core_free (core);
 		return -1;
 	}

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -42,19 +42,14 @@ static RCore *opencore(const char *fname) {
 	return c;
 }
 
-static int find_functions(RCore *core, size_t count) {
+static void find_functions(RCore *core, size_t count) {
 	const char *cmd = NULL;
 	switch (count) {
 	case 0: cmd = "aa"; break;
 	case 1: cmd = "aaa"; break;
 	case 2: cmd = "aaaa"; break;
-	default:
-		eprintf ("Invalid analysis (too many -a's?)\n");
-		rasign_show_help ();
-		return -1;
 	}
 	r_core_cmd0 (core, cmd);
-	return 0;
 }
 
 R_API int r_main_rasign2(int argc, const char **argv) {
@@ -83,10 +78,17 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 		}
 	}
 
+	if (a_cnt > 2) {
+		eprintf ("Invalid analysis (too many -a's?)\n");
+		rasign_show_help ();
+		return -1;
+	}
+
 	const char *ifile = NULL;
 	if ( opt.ind >= argc ) {
 		eprintf("must provide a file\n");
-		return rasign_show_help ();
+		rasign_show_help ();
+		return -1;
 	}
 	ifile = argv[opt.ind];
 
@@ -97,10 +99,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	}
 
 	// run analysis to find functions
-	if (find_functions (core, a_cnt)) {
-		r_core_free (core);
-		return -1;
-	}
+	find_functions (core, a_cnt);
 
 	// create zignatures
 	r_core_cmd0 (core, "zg");

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -108,7 +108,7 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 
 	// write sigs to file
 	if (ofile) {
-		r_core_cmdf (core, "zos %s", ofile);
+		r_core_cmdf (core, "\"zos %s\"", ofile);
 	}
 
 	if (rad) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This is the first steps toward making rasign2 useful. This updates the build so rasign2 will be compiled but not installed to the users path. The rasign2 binary will once again be able to make signature files. This almost closes issue #9336.  

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

I pretty much stole the zignature code from `libr/main/radiff.c`. Here are some examples of the tool running:

help menu
```
[rasign2]$ ./rasign2
Usage: rasign2 [options] [file]
 -a [-a]          add extra 'a' to analysis command
 -o sigs.sdb      add signatures to file, create if it does not exist
 -r               show output in radare commands
Examples:
  rasign2 -o libc.sdb libc.so.6
```

Without flags the number of signatures are displayed. This also shows extra analysis.
```
[rasign2]$ ./rasign2 /usr/lib/libc.so.6 
[x] Analyze all flags starting with sym. and entry0 (aa)
generated zignatures: 2918
```

-r to output radare2 commands, extra analysis used
```
[rasign2]$ ./rasign2 -ar /usr/lib/libc.so.6 |head -n4 
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for objc references
[x] Check for vtables
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
generated zignatures: 3020
zs *
za sym.fgetsgent_r b f30f1efa4157....
za sym.fgetsgent_r g cc=26 nbbs=43 edges=67 ebbs=1 bbsum=661
za sym.fgetsgent_r o 0x00106b30
```
The -o flag writes a signature file
```# writes a signature file
[rasign2]$ ./rasign2 -aa -o /tmp/out.sdb /usr/lib/libc.so.6 
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for objc references
[x] Check for vtables
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Finding function preludes
[x] Enable constraint types analysis for variables
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
WARNING: r_sign_add_anal: assertion 'a && name && size > 0 && bytes' failed (line 736)
generated zignatures: 3020
```
**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...