### PR TITLE
Honor scr.html in pxa, pdsf and fix some ansi glitches in scr.color=0 ##cons

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2537,7 +2537,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	r_config_set_i (core->config, "scr.html", 0);
 	r_config_set_i (core->config, "asm.cmt.right", true);
 
-	r_cons_push();
+	r_cons_push ();
 	line = NULL;
 	s = NULL;
 	if (!strncmp (input, "dsb", 3)) {
@@ -2560,7 +2560,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	} else {
 		line = s = r_core_cmd_str (core, "pd");
 	}
-	r_cons_pop();
+	r_cons_pop ();
 
 	r_config_set_i (core->config, "scr.html", scr_html);
 	r_config_set_i (core->config, "scr.color", use_color);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1743,8 +1743,10 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 				r_cons_printf (".format %s ; size=", meta->str);
 				r_core_cmdf (core, "pfs %s", meta->str);
 				r_core_cmdf (core, "pf %s @ 0x%08"PFMT64x, meta->str, meta_node->start);
-				append (ebytes, Color_INVERT);
-				append (echars, Color_INVERT);
+				if (usecolor) {
+					append (ebytes, Color_INVERT);
+					append (echars, Color_INVERT);
+				}
 				hadflag = true;
 			}
 			if (meta) {
@@ -1775,8 +1777,10 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 					r_cons_printf ("%20s ", "");
 				}
 				if (flag->offset == addr + j) {
-					append (ebytes, Color_INVERT);
-					append (echars, Color_INVERT);
+					if (usecolor) {
+						append (ebytes, Color_INVERT);
+						append (echars, Color_INVERT);
+					}
 					hadflag = true;
 				}
 			} else {
@@ -1790,17 +1794,16 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 					setcolor = false;
 				}
 			}
-			if (usecolor && !setcolor) {
-				const char *bytecolor = r_print_byte_color (core->print, ch);
-				if (bytecolor) {
-					append (ebytes, bytecolor);
-					append (echars, bytecolor);
+			if (usecolor) {
+				if (!setcolor) {
+					const char *bytecolor = r_print_byte_color (core->print, ch);
+					if (bytecolor) {
+						append (ebytes, bytecolor);
+						append (echars, bytecolor);
+						hascolor = true;
+					}
+				} else if (!hascolor) {
 					hascolor = true;
-				}
-			}
-			if (setcolor && !hascolor) {
-				hascolor = true;
-				if (usecolor) {
 					if (current_flag && current_flag->color) {
 						char *ansicolor = r_cons_pal_parse (current_flag->color, NULL);
 						if (ansicolor) {
@@ -1811,12 +1814,6 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 					} else { // Use "random" colours
 						append (ebytes, colors[color_idx]);
 						append (echars, colors[color_idx]);
-					}
-				} else {
-					if (html) {
-						append (ebytes, "[");
-					} else {
-						append (ebytes, Color_INVERT);
 					}
 				}
 			}
@@ -1831,7 +1828,7 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 			if (core->print->cur_enabled) {
 				if (low == max) {
 					if (low == here) {
-						if (html) {
+						if (html || !usecolor) {
 							append (ebytes, "[");
 							append (echars, "[");
 						} else {
@@ -1841,12 +1838,14 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 					}
 				} else {
 					if (here >= low && here < max) {
-						if (html) {
+						if (html || !usecolor) {
 							append (ebytes, "[");
 							append (echars, "[");
 						} else {
-							append (ebytes, Color_INVERT);
-							append (echars, Color_INVERT);
+							if (usecolor) {
+								append (ebytes, Color_INVERT);
+								append (echars, Color_INVERT);
+							}
 						}
 					}
 				}
@@ -1855,14 +1854,16 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 			// r_print_byte (core->print, "%02x ", j, ch);
 			ebytes += strlen (ebytes);
 			if (hadflag) {
-				append (ebytes, Color_INVERT_RESET);
-				append (echars, Color_INVERT_RESET);
+				if (usecolor) {
+					append (ebytes, Color_INVERT_RESET);
+					append (echars, Color_INVERT_RESET);
+				}
 				hadflag = false;
 			}
 			sprintf (echars, "%c", IS_PRINTABLE (ch)? ch: '.');
 			echars++;
 			if (core->print->cur_enabled && max == here) {
-				if (!html) {
+				if (!html && usecolor) {
 					append (ebytes, Color_RESET);
 					append (echars, Color_RESET);
 				}
@@ -1874,7 +1875,7 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 			}
 
 			if (fend != UT64_MAX && fend == addr + j + 1) {
-				if (!html) {
+				if (!html && usecolor) {
 					append (ebytes, Color_RESET);
 					append (echars, Color_RESET);
 				}
@@ -1882,7 +1883,7 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 				hascolor = false;
 			}
 		}
-		if (!html) {
+		if (!html && usecolor) {
 			append (ebytes, Color_RESET);
 			append (echars, Color_RESET);
 		}
@@ -2486,12 +2487,8 @@ static void printraw(RCore *core, int len, int mode) {
 	core->cons->newline = core->cmd_in_backticks ? false : true;
 }
 
-
 static void _handle_call(RCore *core, char *line, char **str) {
-	if (!core || !core->rasm || !core->rasm->cur) {
-		*str = NULL;
-		return;
-	}
+	r_return_if_fail (core && line && str && core->rasm && core->rasm->cur);
 	if (strstr (core->rasm->cur->arch, "x86")) {
 		*str = strstr (line, "call ");
 	} else if (strstr (core->rasm->cur->arch, "arm")) {
@@ -2524,6 +2521,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	bool show_comments = r_config_get_i (core->config, "asm.comments");
 	bool show_offset = r_config_get_i (core->config, "asm.offset");
 	bool asm_tabs = r_config_get_i (core->config, "asm.tabs");
+	bool scr_html = r_config_get_i (core->config, "scr.html");
 	bool asm_dwarf = r_config_get_i (core->config, "asm.dwarf");
 	bool asm_flags = r_config_get_i (core->config, "asm.flags");
 	bool asm_cmt_right = r_config_get_i (core->config, "asm.cmt.right");
@@ -2536,7 +2534,9 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	r_config_set_i (core->config, "asm.dwarf", true);
 	r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
 	r_config_set_i (core->config, "asm.tabs", 0);
+	r_config_set_i (core->config, "scr.html", 0);
 	r_config_set_i (core->config, "asm.cmt.right", true);
+
 	r_cons_push();
 	line = NULL;
 	s = NULL;
@@ -2560,7 +2560,9 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	} else {
 		line = s = r_core_cmd_str (core, "pd");
 	}
-r_cons_pop();
+	r_cons_pop();
+
+	r_config_set_i (core->config, "scr.html", scr_html);
 	r_config_set_i (core->config, "scr.color", use_color);
 	r_config_set_i (core->config, "asm.cmt.right", asm_cmt_right);
 	count = r_str_split (s, '\n');
@@ -2835,6 +2837,7 @@ restore_conf:
 	r_config_set_i (core->config, "asm.offset", show_offset);
 	r_config_set_i (core->config, "asm.dwarf", asm_dwarf);
 	r_config_set_i (core->config, "asm.tabs", asm_tabs);
+	r_config_set_i (core->config, "scr.html", scr_html);
 	r_config_set_i (core->config, "asm.emu", asm_emu);
 	r_config_set_i (core->config, "emu.str", emu_str);
 }

--- a/test/db/esil/apple
+++ b/test/db/esil/apple
@@ -16,14 +16,27 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=iphone-arm-esil pdsf scr.html=true
+FILE=bins/mach0/FileDP
+CMDS=<<EOF
+e scr.html=true
+e asm.flags=false
+s main
+e emu.str=true
+af
+pdsf
+EOF
+EXPECT=<<EOF
+0x00002900&nbsp;argc<br />0x00002904&nbsp;argv<br />0x00002918&nbsp;"alloc"<br />0x00002920&nbsp;str.alloc<br />0x00002928&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002934&nbsp;"init"<br />0x0000293c&nbsp;str.init<br />0x00002940&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x0000294c&nbsp;"X\x10\x9d\xe5"<br />0x0000295c&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002970&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002998&nbsp;"Usage:&nbsp;FileDP&nbsp;[-f/-d]&nbsp;[Full&nbsp;path&nbsp;to&nbsp;file/directory]&nbsp;"<br />0x0000299c&nbsp;bl&nbsp;sym.imp.puts<br />0x000029c8&nbsp;bl&nbsp;sym.imp.strcmp<br />0x00002a1c&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002a38&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002a64&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002a90&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002aa4&nbsp;bl&nbsp;sym.imp.NSLog<br />0x00002ab0&nbsp;str.File_Not_Found<br />0x00002ab4&nbsp;bl&nbsp;sym.imp.puts<br />0x00002b00&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002b1c&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002b48&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002b64&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002ba4&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002c00&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002c54&nbsp;bl&nbsp;sym.imp.objc_enumerationMutation<br />0x00002ca0&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002cc0&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002cec&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002cfc&nbsp;str.cstr.file_name_is:_____protection_class:<br />0x00002d04&nbsp;bl&nbsp;sym.imp.NSLog<br />0x00002d50&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002d84&nbsp;str.Directory_Not_found<br />0x00002d88&nbsp;bl&nbsp;sym.imp.puts<br />0x00002dac&nbsp;bl&nbsp;sym.imp.objc_msgSend<br />0x00002dcc&nbsp;bx&nbsp;lr
+EOF
+RUN
+
 NAME=iphone-arm-esil pdsf
 FILE=bins/mach0/FileDP
 CMDS=<<EOF
 e asm.flags=false
 s main
-e io.sectonly=true
-e asm.emu=true
-e asm.emustr=true
+e emu.str=true
 af
 pdsf
 EOF


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

When using the webui and displaying the output of pdsf it was totally messed up because the inner disassembly was containing html tags which broke the parser of pds. So, in order to fix that 

As a bonus, this pr fixes problems in pxa when scr.color=0 or scr.html=true

**Test plan**
```
e scr.html=1
af
pdsf
```

**Closing issues**

nope