### PR TITLE
Fix crash in 'C{fd..}.', reproducible with r2dec

### DIFF
--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -694,6 +694,9 @@ static int cmd_meta_others(RCore *core, const char *input) {
 		}
 		ut64 size;
 		RAnalMetaItem *mi = r_meta_get_at (core->anal, addr, type, &size);
+		if (!mi) {
+			break;
+		}
 		if (type == 's') {
 			char *esc_str;
 			bool esc_bslash = core->print->esc_bslash;

--- a/test/db/cmd/cmd_meta
+++ b/test/db/cmd/cmd_meta
@@ -1,3 +1,11 @@
+NAME=Cf. crash
+FILE=-
+CMDS=<<EOF
+Cf.
+EOF
+EXPECT=<<EOF
+EOF
+RUN
 
 NAME=vars commenting
 FILE=malloc://1024


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This is a regression introduced in edf1be10d1

**Test plan**
```
$ r2 /bin/ls
 -- radare2 is like windows 7 but even better.
[0x000067d0]> af
[0x000067d0]> Cf.
Segmentation fault (core dumped)
$
```
**Closing issues**
none