### PR TITLE
Implement the comma command to load,dump,query tables ##util

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1288,30 +1288,34 @@ static void load_table(RTable *t, const char *file) {
 	const char *separator = "|";
 	int ncols = 0;
 	r_list_foreach (lines, iter, line) {
-		if (r_str_startswith (line, ".-")) {
-			expect_header = true;
-			continue;
-		}
-		if (r_str_startswith (line, "┌")) {
-			expect_header = true;
-			separator = "│";
-			continue;
-		}
-		if (r_str_startswith (line, ")─")) {
-			expect_rows = true;
-			continue;
-		}
-		if (r_str_startswith (line, "│─")) {
-			expect_rows = true;
-			separator = "│";
-			continue;
+		if (!expect_rows) {
+			if (r_str_startswith (line, ".--")) {
+				expect_header = true;
+				separator = "|";
+				continue;
+			}
+			if (r_str_startswith (line, "┌")) {
+				expect_header = true;
+				separator = "│";
+				continue;
+			}
+			if (r_str_startswith (line, ")-")) {
+				expect_rows = true;
+				separator = "|";
+				continue;
+			}
+			if (r_str_startswith (line, "│─")) {
+				expect_rows = true;
+				separator = "│";
+				continue;
+			}
 		}
 
 		RTableColumnType *typeString = r_table_type ("string");
 		RTableColumnType *typeNumber = r_table_type ("number");
 		if (expect_header) {
 			char *arg;
-			RList *args = r_str_split_list (line, separator, 0);
+			RList *args = r_str_split_list (line + strlen (separator), separator, 0);
 			RListIter *iter2;
 			ncols = 0;
 			if (r_list_length (t->cols) > 0) {
@@ -1320,15 +1324,18 @@ static void load_table(RTable *t, const char *file) {
 			}
 			r_list_foreach (args, iter2, arg) {
 				char *s = strchr (arg, ' ');
-				if (s) {
-					r_table_add_column (t, typeString, s + 1, 0);
-					ncols ++;
+				char *ss = r_str_trim_dup (s? s + 1: arg);
+				if (!*ss) {
+					free (ss);
+					continue;
 				}
+				r_table_add_column (t, typeString, ss, 0);
+				ncols ++;
 			}
 			expect_header = false;
 		} else if (expect_rows) {
 			char *arg;
-			RList *args = r_str_split_list (line, separator, 0);
+			RList *args = r_str_split_list (line + strlen (separator), separator, 0);
 			RList *items = r_list_newf (free);
 			RListIter *iter2;
 			if (r_list_length (args) < ncols) {
@@ -1336,17 +1343,19 @@ static void load_table(RTable *t, const char *file) {
 				continue;
 			}
 			r_list_foreach (args, iter2, arg) {
-				char *s = strchr (arg, ' ');
-				if (s) {
-					if (isdigit (s[1])) {
-						int col = r_list_length (items);
-						RTableColumn *c = r_list_get_n (t->cols, col);
-						if (c) {
-							c->type = typeNumber;
-						}
-					}
-					r_list_append (items, strdup (s + 1));
+				char *ss = r_str_trim_dup (arg);
+				if (!*ss) {
+					free (ss);
+					continue;
 				}
+				if (isdigit (*ss)) {
+					int col = r_list_length (items);
+					RTableColumn *c = r_list_get_n (t->cols, col);
+					if (c) {
+						c->type = typeNumber;
+					}
+				}
+				r_list_append (items, ss);
 			}
 			RTableRow *row = r_table_row_new (items);
 			r_list_append (t->rows, row);
@@ -1366,7 +1375,6 @@ static int cmd_table(void *data, const char *input) {
 
 	switch (*input) {
 	case 'h': // table header
-		// r_table_set_columnsf (t, "xdxx", "addr", "size", "jump", "fail");
 		{
 			RTableColumnType *typeString = r_table_type ("string");
 			char *s = r_str_trim_dup (input + 1);
@@ -1380,7 +1388,6 @@ static int cmd_table(void *data, const char *input) {
 		}
 		break;
 	case 'r': // add row
-		// r_table_add_rowf (t, "xdxx", b->addr, b->size, b->jump, b->fail);
 		{
 			char *args = r_str_trim_dup (input + 1);
 			RList *list = r_str_split_list (args, " ", 0);
@@ -1403,11 +1410,7 @@ static int cmd_table(void *data, const char *input) {
 		}
 		break;
 	case ' ':
-		{
-			// load from file (can be a $file too)
-			const char *fn = r_str_trim_head_ro (input + 1);
-			load_table (t, fn);
-		}
+		load_table (t, r_str_trim_head_ro (input + 1));
 		break;
 	case 0:
 		// print table

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1274,8 +1274,17 @@ static int cmd_stdin(void *data, const char *input) {
 	return r_core_run_script (core, "-");
 }
 
-static void load_table(RTable *t, const char *file) {
-	char *data = r_file_slurp (file, NULL);
+static void load_table(RCore *core, RTable *t, const char *file) {
+	char *data = NULL;
+
+	if (*file == '$') {
+		const char *cdata = r_cmd_alias_get (core->rcmd, file, 1);
+		if (cdata) {
+			data = strdup (cdata + 1);
+		}
+	} else {
+		data = r_file_slurp (file, NULL);
+	}
 	if (!data) {
 		eprintf ("Error: Cannot slurp '%s'\n", file);
 		return;
@@ -1409,8 +1418,11 @@ static int cmd_table(void *data, const char *input) {
 			free (ts);
 		}
 		break;
+	case '$':
+		load_table (core, t, input);
+		break;
 	case ' ':
-		load_table (t, r_str_trim_head_ro (input + 1));
+		load_table (core, t, r_str_trim_head_ro (input + 1));
 		break;
 	case 0:
 		// print table

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1367,6 +1367,17 @@ static int cmd_table(void *data, const char *input) {
 	switch (*input) {
 	case 'h': // table header
 		// r_table_set_columnsf (t, "xdxx", "addr", "size", "jump", "fail");
+		{
+			RTableColumnType *typeString = r_table_type ("string");
+			char *s = r_str_trim_dup (input + 1);
+			RList *list = r_str_split_list (s, " ", 0);
+			RListIter *iter;
+			r_list_foreach (list, iter, s) {
+				r_table_add_column (t, typeString, s, 0);
+			}
+			r_list_free (list);
+	//		free (s);
+		}
 		break;
 	case 'r': // add row
 		// r_table_add_rowf (t, "xdxx", b->addr, b->size, b->jump, b->fail);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1435,6 +1435,10 @@ static int cmd_table(void *data, const char *input) {
 			free (ts);
 		}
 		break;
+	case '?':
+		r_core_cmd_help (core, help_msg_comma);
+		r_cons_printf ("%s\n", r_table_help ());
+		break;
 	default:
 		r_core_cmd_help (core, help_msg_comma);
 		break;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7163,27 +7163,24 @@ R_API char *r_core_cmd_str_pipe(RCore *core, const char *cmd) {
 
 R_API char *r_core_cmd_strf(RCore *core, const char *fmt, ...) {
 	char string[4096];
-	char *ret;
 	va_list ap;
 	va_start (ap, fmt);
 	vsnprintf (string, sizeof (string), fmt, ap);
-	ret = r_core_cmd_str (core, string);
+	char *ret = r_core_cmd_str (core, string);
 	va_end (ap);
 	return ret;
 }
 
 /* return: pointer to a buffer with the output of the command */
 R_API char *r_core_cmd_str(RCore *core, const char *cmd) {
-	const char *static_str;
-	char *retstr = NULL;
 	r_cons_push ();
 	if (r_core_cmd (core, cmd, 0) == -1) {
 		//eprintf ("Invalid command: %s\n", cmd);
 		return NULL;
 	}
 	r_cons_filter ();
-	static_str = r_cons_get_buffer ();
-	retstr = strdup (static_str? static_str: "");
+	const char *static_str = r_cons_get_buffer ();
+	char *retstr = strdup (static_str? static_str: "");
 	r_cons_pop ();
 	r_cons_echo (NULL);
 	return retstr;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -148,7 +148,7 @@ static const char *help_msg_star[] = {
 	NULL
 };
 
-static const char *help_msg_comma[] = {
+static const char *help_msg_table[] = {
 	"Usage:", ",[/] [file]", "# load table data",
 	",", "", "display table",
 	".", "$foo", "aflt > $foo (files starting with '$' are saved in memory)",
@@ -1451,11 +1451,11 @@ static int cmd_table(void *data, const char *input) {
 		}
 		break;
 	case '?':
-		r_core_cmd_help (core, help_msg_comma);
+		r_core_cmd_help (core, help_msg_table);
 		r_cons_printf ("%s\n", r_table_help ());
 		break;
 	default:
-		r_core_cmd_help (core, help_msg_comma);
+		r_core_cmd_help (core, help_msg_table);
 		break;
 	}
 	return 0;

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -76,6 +76,7 @@ static const char *help_msg_root[] = {
 	"*", "[?] off[=[0x]value]", "pointer read/write data/values (see ?v, wx, wv)",
 	"(macro arg0 arg1)",  "", "manage scripting macros",
 	".", "[?] [-|(m)|f|!sh|cmd]", "Define macro or load r2, cparse or rlang file",
+	",", "[?] [/jhr]", "create a dummy table import from file and query it to filter/sort",
 	"_", "[?]", "Print last output",
 	"=","[?] [cmd]", "send/listen for remote commands (rap://, raps://, udp://, http://, <fd>)",
 	"<","[...]", "push escaped string into the RCons.readChar buffer",

--- a/libr/include/r_util/r_table.h
+++ b/libr/include/r_util/r_table.h
@@ -71,6 +71,7 @@ R_API char *r_table_tofancystring(RTable *t);
 R_API char *r_table_tostring(RTable *t);
 R_API char *r_table_tocsv(RTable *t);
 R_API char *r_table_tojson(RTable *t);
+R_API const char *r_table_help(void);
 R_API void r_table_filter(RTable *t, int nth, int op, const char *un);
 R_API void r_table_sort(RTable *t, int nth, bool inc);
 R_API void r_table_uniq(RTable *t);

--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -174,7 +174,7 @@ R_API void r_table_add_rowf(RTable *t, const char *fmt, ...) {
 		case 's':
 		case 'z':
 			arg = va_arg (ap, const char *);
-			r_list_append (list, strdup (arg?arg:""));
+			r_list_append (list, strdup (arg? arg: ""));
 			break;
 		case 'i':
 		case 'd':
@@ -206,7 +206,7 @@ R_API void r_table_add_rowf(RTable *t, const char *fmt, ...) {
 			break;
 		}
 	}
-	va_end(ap);
+	va_end (ap);
 	r_table_add_row_list (t, list);
 }
 

--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -826,6 +826,26 @@ R_API void r_table_filter_columns(RTable *t, RList *list) {
 	}
 }
 
+R_API const char *r_table_help(void) {
+	return \
+	"RTableQuery> comma separated\n" \
+	" colname/sort/inc     sort rows by given colname\n"
+	" name/sortlen/inc     sort rows by strlen()\n"
+	" col0/cols/col1/col2  select cols\n"
+	" col0/gt/0x800        grep rows matching col0 > 0x800\n"
+	" col0/lt/0x800        grep rows matching col0 < 0x800\n"
+	" col0/eq/0x800        grep rows matching col0 == 0x800\n"
+	" col0/uniq            get the first row of each that col0 is unique\n"
+	" /uniq                same as | uniq (match all columns)\n"
+	" name/str/warn        grep rows matching col(name).str(warn)\n"
+	" name/strlen/3        grep rows matching strlen(col) == X\n"
+	" name/minlen/3        grep rows matching strlen(col) > X\n"
+	" name/maxlen/3        grep rows matching strlen(col) < X\n"
+	" size/sum             sum all the values of given column\n"
+	" :json                .tostring() == .tojson()\n"
+	" :quiet               do not print column names header\n";
+}
+
 static bool __table_special(RTable *t, const char *columnName) {
 	if (!strcmp (columnName, ":quiet")) {
 		t->showHeader = true;
@@ -849,22 +869,8 @@ R_API bool r_table_query(RTable *t, const char *q) {
 		return true;
 	}
 	if (*q == '?') {
-		eprintf ("RTableQuery> comma separated \n");
-		eprintf (" colname/sort/inc     sort rows by given colname\n");
-		eprintf (" name/sortlen/inc     sort rows by strlen()\n");
-		eprintf (" col0/cols/col1/col2  select cols\n");
-		eprintf (" col0/gt/0x800        grep rows matching col0 > 0x800\n");
-		eprintf (" col0/lt/0x800        grep rows matching col0 < 0x800\n");
-		eprintf (" col0/eq/0x800        grep rows matching col0 == 0x800\n");
-		eprintf (" col0/uniq            get the first row of each that col0 is unique\n");
-		eprintf (" /uniq                same as | uniq (match all columns)\n");
-		eprintf (" name/str/warn        grep rows matching col(name).str(warn)\n");
-		eprintf (" name/strlen/3        grep rows matching strlen(col) == X\n");
-		eprintf (" name/minlen/3        grep rows matching strlen(col) > X\n");
-		eprintf (" name/maxlen/3        grep rows matching strlen(col) < X\n");
-		eprintf (" size/sum             sum all the values of given column\n");
-		eprintf (" :json                .tostring() == .tojson()\n");
-		eprintf (" :quiet               do not print column names header\n");
+		const char *th = r_table_help ();
+		eprintf ("%s\n", th);
 		return false;
 	}
 

--- a/test/db/cmd/cmd_table
+++ b/test/db/cmd/cmd_table
@@ -1,0 +1,50 @@
+NAME=comma table
+FILE=bins/mach0/mac-ls
+CMDS=<<EOF
+afr
+e scr.utf8=true
+aflt > .tt
+cat .tt~?
+, .tt
+rm .tt
+,~?
+EOF
+EXPECT=<<EOF
+37
+37
+EOF
+RUN
+
+NAME=comma table
+FILE=bins/mach0/mac-ls
+CMDS=<<EOF
+afr
+e scr.utf8=false
+aflt > .tt2
+cat .tt2~?
+, .tt2
+rm .tt2
+,~?
+EOF
+EXPECT=<<EOF
+37
+37
+EOF
+RUN
+
+NAME=comma table
+FILE=bins/mach0/mac-ls
+CMDS=<<EOF
+afr
+aflt > $a
+cat $a~?
+, $a
+,
+rm $a
+,~?
+EOF
+EXPECT=<<EOF
+37
+37
+EOF
+RUN

--- a/test/db/cmd/cmd_table
+++ b/test/db/cmd/cmd_table
@@ -39,7 +39,6 @@ afr
 aflt > $a
 cat $a~?
 , $a
-,
 rm $a
 ,~?
 EOF


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This command allows to load tables (in ascii art for now, but should support csv and json in the future) and display or filter/query them by using subcommands of it. It aims to be an agn/age replacement for tables (instead of graphs), the JOIN operation can be implemented in this user table

**Test plan**

For example:

```
> af;aflt > $a
> , $a        # load the aflt table
> ,/size/sum  # sum the size of all the functions
```

**Closing issues**

There's one but im lazy to search for it now