### PR TITLE
WIP: Fix ELF relocs parsing overflow

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2540,8 +2540,9 @@ static bool has_valid_section_header(ELFOBJ *bin, size_t pos) {
 
 static void fix_rva_and_offset_relocable_file(ELFOBJ *bin, RBinElfReloc *r, size_t pos) {
 	if (has_valid_section_header (bin, pos)) {
-		r->rva = bin->shdr[bin->g_sections[pos].info].sh_offset + r->offset;
-		r->rva = Elf_(r_bin_elf_p2v) (bin, r->rva);
+		ut64 pa = bin->shdr[bin->g_sections[pos].info].sh_offset + r->offset;
+		r->rva = Elf_(r_bin_elf_p2v_new) (bin, pa);
+		r->offset = pa;
 	} else {
 		r->rva = r->offset;
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -8,14 +8,6 @@
 #include <r_util.h>
 #include "elf.h"
 
-#ifdef IFDBG
-#undef IFDBG
-#endif
-
-#define DO_THE_DBG 0
-#define IFDBG if (DO_THE_DBG)
-#define IFINT if (0)
-
 #define MIPS_PLT_OFFSET 0x20
 #define RISCV_PLT_OFFSET 0x20
 
@@ -2850,7 +2842,7 @@ static void create_section_from_phdr(ELFOBJ *bin, RBinElfSection *ret, int *i, c
 
 static RBinElfSection *get_sections_from_phdr(ELFOBJ *bin) {
 	RBinElfSection *ret;
-	int i, num_sections = 0;
+	int num_sections = 0;
 	ut64 reldyn = 0, relava = 0, pltgotva = 0, relva = 0;
 	ut64 reldynsz = 0, relasz = 0, pltgotsz = 0;
 	r_return_val_if_fail (bin && bin->phdr, NULL);
@@ -2885,16 +2877,24 @@ static RBinElfSection *get_sections_from_phdr(ELFOBJ *bin) {
 		num_sections++;
 	}
 
-	ret = calloc (num_sections + 1, sizeof(RBinElfSection));
+	ret = calloc (num_sections + 1, sizeof (RBinElfSection));
 	if (!ret) {
 		return NULL;
 	}
 
-	i = 0;
-	create_section_from_phdr (bin, ret, &i, ".rel.dyn", reldyn, reldynsz);
-	create_section_from_phdr (bin, ret, &i, ".rela.plt", relava, pltgotsz);
-	create_section_from_phdr (bin, ret, &i, ".rel.plt", relva, relasz);
-	create_section_from_phdr (bin, ret, &i, ".got.plt", pltgotva, pltgotsz);
+	size_t i = 0;
+	if (i < num_sections) {
+		create_section_from_phdr (bin, ret, &i, ".rel.dyn", reldyn, reldynsz);
+	}
+	if (i < num_sections) {
+		create_section_from_phdr (bin, ret, &i, ".rela.plt", relava, pltgotsz);
+	}
+	if (i < num_sections) {
+		create_section_from_phdr (bin, ret, &i, ".rel.plt", relva, relasz);
+	}
+	if (i < num_sections) {
+		create_section_from_phdr (bin, ret, &i, ".got.plt", pltgotva, pltgotsz);
+	}
 	ret[i].last = 1;
 
 	return ret;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2650,13 +2650,15 @@ static size_t get_num_relocs_sections(ELFOBJ *bin) {
 }
 
 static size_t get_num_relocs_approx(ELFOBJ *bin) {
-	return get_num_relocs_dynamic (bin) + get_num_relocs_sections (bin);
+	size_t rd = get_num_relocs_dynamic (bin);
+	size_t rs = get_num_relocs_sections (bin);
+	return rd + rs;
 }
 
 static void populate_relocs_record_from_dynamic(ELFOBJ *bin, RBinElfReloc *relocs, size_t num_relocs, size_t *pos) {
 	size_t offset;
 	size_t size = get_size_rel_mode (bin->dyn_info.dt_pltrel);
-	size_t p = 0;
+	size_t p = *pos;
 
 	for (offset = 0; offset < bin->dyn_info.dt_pltrelsz && p < num_relocs; offset += size) {
 		if (!read_reloc (bin, relocs + pos, bin->dyn_info.dt_pltrel, bin->dyn_info.dt_jmprel + offset)) {
@@ -2682,7 +2684,7 @@ static void populate_relocs_record_from_dynamic(ELFOBJ *bin, RBinElfReloc *reloc
 		fix_rva_and_offset_exec_file (bin, relocs + p);
 		p++;
 	}
-	*pos += p;
+	*pos = p;
 }
 
 static size_t get_next_not_analysed_offset(ELFOBJ *bin, size_t section_vaddr, size_t offset) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2833,10 +2833,9 @@ RBinElfLib* Elf_(r_bin_elf_get_libs)(ELFOBJ *bin) {
 }
 
 static void create_section_from_phdr(ELFOBJ *bin, RBinElfSection *ret, int *i, const char *name, ut64 addr, ut64 sz) {
-	if (!addr) {
+	if (addr == UT64_MAX) {
 		return;
 	}
-
 	ret[*i].offset = Elf_(r_bin_elf_v2p_new) (bin, addr);
 	ret[*i].rva = addr;
 	ret[*i].size = sz;

--- a/libr/bin/format/elf/glibc_elf.h
+++ b/libr/bin/format/elf/glibc_elf.h
@@ -198,6 +198,7 @@ typedef struct
 #define EM_RH32		38		/* TRW RH-32 */
 #define EM_RCE		39		/* Motorola RCE */
 #define EM_ARM		40		/* ARM */
+#define EM_ARM64        183             /* AArch64 */
 #define EM_FAKE_ALPHA	41		/* Digital Alpha */
 #define EM_SH		42		/* Hitachi SH */
 #define EM_SPARCV9	43		/* SPARC v9 64-bit */
@@ -2510,6 +2511,7 @@ enum
 #define R_AARCH64_P32_TLS_TPREL		186	/* TP-relative offset, 32 bit.  */
 #define R_AARCH64_P32_TLSDESC		187	/* TLS Descriptor.  */
 #define R_AARCH64_P32_IRELATIVE		188	/* STT_GNU_IFUNC relocation. */
+#define R_AARCH64_COPY                  1024
 
 /* LP64 AArch64 relocs.  */
 #define R_AARCH64_ABS64         257	/* Direct 64 bit. */
@@ -2633,6 +2635,8 @@ enum
 #define R_AARCH64_TLS_DTPREL   1029	/* Module-relative offset, 64 bit.  */
 #define R_AARCH64_TLS_TPREL    1030	/* TP-relative offset, 64 bit.  */
 #define R_AARCH64_TLSDESC      1031	/* TLS Descriptor.  */
+// #define R_AARCH64_TLS_TPREL64           1030
+// #define R_AARCH64_TLS_DTPREL32          1031
 #define R_AARCH64_IRELATIVE	1032	/* STT_GNU_IFUNC relocation.  */
 
 /* ARM relocs.  */
@@ -2914,6 +2918,133 @@ enum
 #define R_IA64_DTPREL64MSB	0xb6	/* @dtprel(sym + add), data8 MSB */
 #define R_IA64_DTPREL64LSB	0xb7	/* @dtprel(sym + add), data8 LSB */
 #define R_IA64_LTOFF_DTPREL22	0xba	/* @ltoff(@dtprel(s+a)), imm22 */
+
+/*
+ * RISC-V relocation types.
+ */
+
+/* Relocation types used by the dynamic linker. */
+#define	R_RISCV_NONE		0
+#define	R_RISCV_32		1
+#define	R_RISCV_64		2
+#define	R_RISCV_RELATIVE	3
+#define	R_RISCV_COPY		4
+#define	R_RISCV_JUMP_SLOT	5
+#define	R_RISCV_TLS_DTPMOD32	6
+#define	R_RISCV_TLS_DTPMOD64	7
+#define	R_RISCV_TLS_DTPREL32	8
+#define	R_RISCV_TLS_DTPREL64	9
+#define	R_RISCV_TLS_TPREL32	10
+#define	R_RISCV_TLS_TPREL64	11
+
+/* Relocation types not used by the dynamic linker. */
+#define	R_RISCV_BRANCH		16
+#define	R_RISCV_JAL		17
+#define	R_RISCV_CALL		18
+#define	R_RISCV_CALL_PLT	19
+#define	R_RISCV_GOT_HI20	20
+#define	R_RISCV_TLS_GOT_HI20	21
+#define	R_RISCV_TLS_GD_HI20	22
+#define	R_RISCV_PCREL_HI20	23
+#define	R_RISCV_PCREL_LO12_I	24
+#define	R_RISCV_PCREL_LO12_S	25
+#define	R_RISCV_HI20		26
+#define	R_RISCV_LO12_I		27
+#define	R_RISCV_LO12_S		28
+#define	R_RISCV_TPREL_HI20	29
+#define	R_RISCV_TPREL_LO12_I	30
+#define	R_RISCV_TPREL_LO12_S	31
+#define	R_RISCV_TPREL_ADD	32
+#define	R_RISCV_ADD8		33
+#define	R_RISCV_ADD16		34
+#define	R_RISCV_ADD32		35
+#define	R_RISCV_ADD64		36
+#define	R_RISCV_SUB8		37
+#define	R_RISCV_SUB16		38
+#define	R_RISCV_SUB32		39
+#define	R_RISCV_SUB64		40
+#define	R_RISCV_GNU_VTINHERIT	41
+#define	R_RISCV_GNU_VTENTRY	42
+#define	R_RISCV_ALIGN		43
+#define	R_RISCV_RVC_BRANCH	44
+#define	R_RISCV_RVC_JUMP	45
+#define	R_RISCV_RVC_LUI		46
+#define	R_RISCV_GPREL_I		47
+#define	R_RISCV_GPREL_S		48
+#define	R_RISCV_TPREL_I		49
+#define	R_RISCV_TPREL_S		50
+#define	R_RISCV_RELAX		51
+#define	R_RISCV_SUB6		52
+#define	R_RISCV_SET6		53
+#define	R_RISCV_SET8		54
+#define	R_RISCV_SET16		55
+#define	R_RISCV_SET32		56
+#define	R_RISCV_32_PCREL	57
+#define	R_RISCV_IRELATIVE	58
+
+/* csky */
+#define R_CKCORE_NONE               0	/* no reloc */
+#define R_CKCORE_ADDR32             1	/* direct 32 bit (S + A) */
+#define R_CKCORE_PCRELIMM8BY4       2	/* disp ((S + A - P) >> 2) & 0xff   */
+#define R_CKCORE_PCRELIMM11BY2      3	/* disp ((S + A - P) >> 1) & 0x7ff  */
+#define R_CKCORE_PCREL32            5	/* 32-bit rel (S + A - P)           */
+#define R_CKCORE_PCRELJSR_IMM11BY2  6	/* disp ((S + A - P) >>1) & 0x7ff   */
+#define R_CKCORE_RELATIVE           9	/* 32 bit adjust program base(B + A)*/
+#define R_CKCORE_COPY               10	/* 32 bit adjust by program base    */
+#define R_CKCORE_GLOB_DAT           11	/* off between got and sym (S)      */
+#define R_CKCORE_JUMP_SLOT          12	/* PLT entry (S) */
+#define R_CKCORE_GOTOFF             13	/* offset to GOT (S + A - GOT)      */
+#define R_CKCORE_GOTPC              14	/* PC offset to GOT (GOT + A - P)   */
+#define R_CKCORE_GOT32              15	/* 32 bit GOT entry (G) */
+#define R_CKCORE_PLT32              16	/* 32 bit PLT entry (G) */
+#define R_CKCORE_ADDRGOT            17	/* GOT entry in GLOB_DAT (GOT + G)  */
+#define R_CKCORE_ADDRPLT            18	/* PLT entry in GLOB_DAT (GOT + G)  */
+#define R_CKCORE_PCREL_IMM26BY2     19	/* ((S + A - P) >> 1) & 0x3ffffff   */
+#define R_CKCORE_PCREL_IMM16BY2     20	/* disp ((S + A - P) >> 1) & 0xffff */
+#define R_CKCORE_PCREL_IMM16BY4     21	/* disp ((S + A - P) >> 2) & 0xffff */
+#define R_CKCORE_PCREL_IMM10BY2     22	/* disp ((S + A - P) >> 1) & 0x3ff  */
+#define R_CKCORE_PCREL_IMM10BY4     23	/* disp ((S + A - P) >> 2) & 0x3ff  */
+#define R_CKCORE_ADDR_HI16          24	/* high & low 16 bit ADDR */
+                                        /* ((S + A) >> 16) & 0xffff */
+#define R_CKCORE_ADDR_LO16          25	/* (S + A) & 0xffff */
+#define R_CKCORE_GOTPC_HI16         26	/* high & low 16 bit GOTPC */
+                                        /* ((GOT + A - P) >> 16) & 0xffff */
+#define R_CKCORE_GOTPC_LO16         27	/* (GOT + A - P) & 0xffff */
+#define R_CKCORE_GOTOFF_HI16        28	/* high & low 16 bit GOTOFF */
+                                        /* ((S + A - GOT) >> 16) & 0xffff */
+#define R_CKCORE_GOTOFF_LO16        29	/* (S + A - GOT) & 0xffff */
+#define R_CKCORE_GOT12              30	/* 12 bit disp GOT entry (G) */
+#define R_CKCORE_GOT_HI16           31	/* high & low 16 bit GOT */
+                                        /* (G >> 16) & 0xffff */
+#define R_CKCORE_GOT_LO16           32	/* (G & 0xffff) */
+#define R_CKCORE_PLT12              33	/* 12 bit disp PLT entry (G) */
+#define R_CKCORE_PLT_HI16           34	/* high & low 16 bit PLT */
+                                        /* (G >> 16) & 0xffff */
+#define R_CKCORE_PLT_LO16           35	/* G & 0xffff */
+#define R_CKCORE_ADDRGOT_HI16       36	/* high & low 16 bit ADDRGOT */
+                                        /* (GOT + G * 4) & 0xffff */
+#define R_CKCORE_ADDRGOT_LO16       37	/* (GOT + G * 4) & 0xffff */
+#define R_CKCORE_ADDRPLT_HI16       38	/* high & low 16 bit ADDRPLT */
+                                        /* ((GOT + G * 4) >> 16) & 0xFFFF */
+#define R_CKCORE_ADDRPLT_LO16       39	/* (GOT+G*4) & 0xffff */
+#define R_CKCORE_PCREL_JSR_IMM26BY2 40	/* disp ((S+A-P) >>1) & x3ffffff */
+#define R_CKCORE_TOFFSET_LO16       41	/* (S+A-BTEXT) & 0xffff */
+#define R_CKCORE_DOFFSET_LO16       42	/* (S+A-BTEXT) & 0xffff */
+#define R_CKCORE_PCREL_IMM18BY2     43	/* disp ((S+A-P) >>1) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18      44	/* disp (S+A-BDATA) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18BY2   45	/* disp ((S+A-BDATA)>>1) & 0x3ffff */
+#define R_CKCORE_DOFFSET_IMM18BY4   46	/* disp ((S+A-BDATA)>>2) & 0x3ffff */
+#define R_CKCORE_GOT_IMM18BY4       48	/* disp (G >> 2) */
+#define R_CKCORE_PLT_IMM18BY4       49	/* disp (G >> 2) */
+#define R_CKCORE_PCREL_IMM7BY4      50	/* disp ((S+A-P) >>2) & 0x7f */
+#define R_CKCORE_TLS_LE32           51  /* 32 bit offset to TLS block */
+#define R_CKCORE_TLS_IE32           52
+#define R_CKCORE_TLS_GD32           53
+#define R_CKCORE_TLS_LDM32          54
+#define R_CKCORE_TLS_LDO32          55
+#define R_CKCORE_TLS_DTPMOD32       56
+#define R_CKCORE_TLS_DTPOFF32       57
+#define R_CKCORE_TLS_TPOFF32        58
 
 /* SH specific declarations */
 

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2009-2019 - pancake, nibble, dso */
+/* radare2 - LGPL - Copyright 2009-2020 - pancake, nibble, dso */
 
 #include "bin_elf.inc"
 

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -569,6 +569,9 @@ static RList* libs(RBinFile *bf) {
 
 static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc *rel, ut64 GOT) {
 	r_return_val_if_fail (bin && rel, NULL);
+	if (GOT == UT64_MAX) {
+		GOT = 0;
+	}
 
 	ut64 B = bin->baddr;
 	ut64 P = rel->rva; // rva has taken baddr into account
@@ -590,8 +593,8 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 	r->vaddr = rel->rva;
 	r->paddr = rel->offset;
 
-	#define SET(T) r->type = R_BIN_RELOC_ ## T; r->additive = 0; return r
-	#define ADD(T, A) r->type = R_BIN_RELOC_ ## T; r->addend += A; r->additive = rel->rel_mode == DT_RELA; return r
+#	define SET(T) r->type = R_BIN_RELOC_ ## T; r->additive = 0; return r
+#	define ADD(T, A) r->type = R_BIN_RELOC_ ## T; r->addend += A; r->additive = rel->rel_mode == DT_RELA; return r
 
 	switch (bin->ehdr.e_machine) {
 	case EM_386: switch (rel->type) {

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -693,40 +693,35 @@ static RList* relocs(RBinFile *bf) {
 	RList *ret = NULL;
 	RBinReloc *ptr = NULL;
 	RBinElfReloc *relocs = NULL;
-	struct Elf_(r_bin_elf_obj_t) *bin = NULL;
-	ut64 got_addr;
-	int i;
 	if (!bf || !bf->o || !bf->o->bin_obj) {
 		return NULL;
 	}
-	bin = bf->o->bin_obj;
+	struct Elf_(r_bin_elf_obj_t) *bin = bf->o->bin_obj;
 	if (!(ret = r_list_newf (free))) {
 		return NULL;
 	}
 	/* FIXME: This is a _temporary_ fix/workaround to prevent a use-after-
 	 * free detected by ASan that would corrupt the relocation names */
 	r_list_free (imports (bf));
+	ut64 got_addr;
 	if ((got_addr = Elf_(r_bin_elf_get_section_addr) (bin, ".got")) == -1) {
 		got_addr = Elf_(r_bin_elf_get_section_addr) (bin, ".got.plt");
-		if (got_addr == -1) {
-			got_addr = 0;
-		}
 	}
-	if (got_addr < 1 && bin->ehdr.e_type == ET_REL) {
+	if (got_addr == UT64_MAX && bin->ehdr.e_type == ET_REL) {
 		got_addr = Elf_(r_bin_elf_get_section_addr) (bin, ".got.r2");
-		if (got_addr == -1) {
-			got_addr = 0;
-		}
 	}
 	if (bf->o) {
 		if (!(relocs = Elf_(r_bin_elf_get_relocs) (bin))) {
 			return ret;
 		}
+		size_t i;
 		for (i = 0; !relocs[i].last; i++) {
 			if (!(ptr = reloc_convert (bin, &relocs[i], got_addr))) {
 				continue;
 			}
-			r_list_append (ret, ptr);
+			if (ptr->paddr) {
+				r_list_append (ret, ptr);
+			}
 		}
 	}
 	return ret;
@@ -920,9 +915,8 @@ static RList* patch_relocs(RBin *b) {
 	if (!g) {
 		return NULL;
 	}
-	n_vaddr = g->itv.addr + g->itv.size;
+	ut64 n_vaddr = g->itv.addr + g->itv.size;
 	//reserve at least that space
-	size = bin->g_reloc_num * 4;
 	char *muri = r_str_newf ("malloc://%" PFMT64u, size);
 	RIODesc *gotr2desc = b->iob.open_at (io, muri, R_PERM_R, 0664, n_vaddr);
 	free (muri);
@@ -947,9 +941,10 @@ static RList* patch_relocs(RBin *b) {
 		r_list_free (ret);
 		return NULL;
 	}
-	vaddr = n_vaddr;
+	ut64 vaddr = n_vaddr;
+	size_t i;
 	for (i = 0; !relcs[i].last; i++) {
-		ut64 sym_addr = 0;
+		ut64 sym_addr = UT64_MAX;
 
 		if (relcs[i].sym) {
 			if (relcs[i].sym < bin->imports_by_ord_size && bin->imports_by_ord[relcs[i].sym]) {
@@ -959,12 +954,12 @@ static RList* patch_relocs(RBin *b) {
 			}
 		}
 		// TODO relocation types B, L
-		_patch_reloc (bin->ehdr.e_machine, &b->iob, &relcs[i], sym_addr? sym_addr: vaddr, 0, n_vaddr);
+		_patch_reloc (bin->ehdr.e_machine, &b->iob, &relcs[i], sym_addr != UT64_MAX? sym_addr: vaddr, 0, n_vaddr);
 		if (!(ptr = reloc_convert (bin, &relcs[i], n_vaddr))) {
 			continue;
 		}
 
-		if (sym_addr) {
+		if (sym_addr != UT64_MAX) {
 			ptr->vaddr = sym_addr;
 		} else {
 			ptr->vaddr = vaddr;

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -574,7 +574,7 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 	ut64 P = rel->rva; // rva has taken baddr into account
 	RBinReloc *r = R_NEW0 (RBinReloc);
 	if (!r) {
-		return r;
+		return NULL;
 	}
 	r->import = NULL;
 	r->symbol = NULL;
@@ -664,8 +664,7 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 	#undef SET
 	#undef ADD
 
-	free (r);
-	return 0;
+	return r;
 }
 
 static RList* relocs(RBinFile *bf) {
@@ -865,11 +864,13 @@ static RList* patch_relocs(RBin *b) {
 	int i;
 	ut64 n_vaddr, vaddr, size, offset = 0;
 
-	if (!b)
+	if (!b) {
 		return NULL;
+	}
 	io = b->iob.io;
-	if (!io || !io->desc)
+	if (!io || !io->desc) {
 		return NULL;
+	}
 	obj = r_bin_cur_object (b);
 	if (!obj) {
 	   	return NULL;

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -610,9 +610,9 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 		case R_386_PC16:     ADD(16,-P);
 		case R_386_8:        ADD(8,  0);
 		case R_386_PC8:      ADD(8, -P);
-		case R_386_COPY:     ADD(64, 0); // XXX: copy symbol at runtime
+		case R_386_COPY:     ADD(32, 0); // XXX: copy symbol at runtime
 		case R_386_IRELATIVE: r->is_ifunc = true; SET(32);
-		default: break; //eprintf("TODO(eddyb): uninmplemented ELF/x86 reloc type %i\n", rel->type);
+		default: break;
 		}
 		break;
 	case EM_X86_64: switch (rel->type) {
@@ -633,11 +633,12 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 		case R_X86_64_GOTPCREL:	ADD(64, GOT-P);
 		case R_X86_64_COPY:	ADD(64, 0); // XXX: copy symbol at runtime
 		case R_X86_64_IRELATIVE: r->is_ifunc = true; SET(64);
-		default: break; ////eprintf("TODO(eddyb): uninmplemented ELF/x64 reloc type %i\n", rel->type);
+		default: break;
 		}
 		break;
-	case EM_ARM: switch (rel->type) {
-		case R_ARM_NONE:	break; // malloc then free. meh. then again, there's no real world use for _NONE.
+	case EM_ARM:
+		switch (rel->type) {
+		case R_ARM_NONE:	break;
 		case R_ARM_ABS32:	ADD(32, 0);
 		case R_ARM_REL32:	ADD(32,-P);
 		case R_ARM_ABS16:	ADD(16, 0);
@@ -648,7 +649,25 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 		case R_ARM_RELATIVE:	ADD(32, B);
 		case R_ARM_GOTOFF:	ADD(32,-GOT);
 		default: ADD(32,GOT); break; // reg relocations
-		 ////eprintf("TODO(eddyb): uninmplemented ELF/ARM reloc type %i\n", rel->type);
+		}
+		break;
+	case EM_RISCV:
+		switch (rel->type) {
+		case R_RISCV_NONE: break;
+		case R_RISCV_JUMP_SLOT: ADD(64, 0);
+		case R_RISCV_RELATIVE: ADD(64, B);
+		default: ADD(64, GOT); break; // reg relocations
+		}
+		break;
+	case EM_ARM64:
+		switch (rel->type) {
+		case R_AARCH64_NONE: break;
+		case R_AARCH64_ABS32: ADD(32, 0);
+		case R_AARCH64_ABS16: ADD(16, 0);
+		case R_AARCH64_GLOB_DAT: SET(64);
+		case R_AARCH64_JUMP_SLOT: SET(64);
+		case R_AARCH64_RELATIVE: ADD(64, B);
+		default: break; // reg relocations
 		}
 		break;
 	case EM_AARCH64: switch (rel->type) {
@@ -664,8 +683,8 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 	default: break;
 	}
 
-	#undef SET
-	#undef ADD
+#	undef SET
+#	undef ADD
 
 	return r;
 }

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -868,32 +868,29 @@ static void _patch_reloc(ut16 e_machine, RIOBind *iob, RBinElfReloc *rel, ut64 S
 }
 
 static RList* patch_relocs(RBin *b) {
+	r_return_val_if_fail (b, NULL);
 	RList *ret = NULL;
 	RBinReloc *ptr = NULL;
-	RIO *io = NULL;
-	RBinObject *obj = NULL;
-	struct Elf_(r_bin_elf_obj_t) *bin = NULL;
 	RIOMap *g = NULL;
 	HtUU *relocs_by_sym;
 	RBinElfReloc *relcs = NULL;
 	RBinInfo *info;
-	int cdsz;
-	int i;
-	ut64 n_vaddr, vaddr, size, offset = 0;
+	ut64 size, offset = 0;
 
-	if (!b) {
-		return NULL;
-	}
-	io = b->iob.io;
+	RIO *io = b->iob.io;
 	if (!io || !io->desc) {
 		return NULL;
 	}
-	obj = r_bin_cur_object (b);
+	RBinObject *obj = r_bin_cur_object (b);
 	if (!obj) {
 	   	return NULL;
 	}
-	bin = obj->bin_obj;
+	struct Elf_(r_bin_elf_obj_t) *bin = obj->bin_obj;
 	if (bin->ehdr.e_type != ET_REL) {
+		return NULL;
+	}
+	size = bin->g_reloc_num * 4;
+	if (size == 0) {
 		return NULL;
 	}
 	if (!io->cached) {
@@ -902,7 +899,7 @@ static RList* patch_relocs(RBin *b) {
 	}
 
 	info = obj ? obj->info: NULL;
-	cdsz = info? (info->bits == 64? 8: info->bits == 32? 4: info->bits == 16 ? 4: 0): 0;
+	size_t cdsz = info? (info->bits == 64? 8: info->bits == 32? 4: info->bits == 16 ? 4: 0): 0;
 
 	void **it;
 	r_pvector_foreach (&io->maps, it) {
@@ -985,10 +982,12 @@ static void lookup_symbols(RBinFile *bf, RBinInfo *ret) {
 			if (!strcmp (symbol->name, "_NSConcreteGlobalBlock")) {
 				ret->lang = (ret->lang && !strcmp (ret->lang, "c++"))? "c++ blocks ext.": "c blocks ext.";
 			}
-			if (strstr (symbol->name, "__stack_chk_fail") || strstr (symbol->name, "__stack_smash_handler")) {
-				ret->has_canary = true;
+			if (!ret->has_canary) {
+				if (strstr (symbol->name, "__stack_chk_fail") || strstr (symbol->name, "__stack_smash_handler")) {
+					ret->has_canary = true;
+				}
 			}
-			if (!strcmp (symbol->name, "__rust_oom")) {
+			if (!is_rust && !strcmp (symbol->name, "__rust_oom")) {
 				is_rust = true;
 				ret->lang = "rust";
 			}

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1313,10 +1313,10 @@ static int bin_entry(RCore *r, int mode, ut64 laddr, int va, bool inifin) {
 static const char *bin_reloc_type_name(RBinReloc *reloc) {
 #define CASE(T) case R_BIN_RELOC_ ## T: return reloc->additive ? "ADD_" #T : "SET_" #T
 	switch (reloc->type) {
-		CASE(8);
-		CASE(16);
-		CASE(32);
-		CASE(64);
+	CASE(8);
+	CASE(16);
+	CASE(32);
+	CASE(64);
 	}
 	return "UNKNOWN";
 #undef CASE
@@ -1325,10 +1325,10 @@ static const char *bin_reloc_type_name(RBinReloc *reloc) {
 static ut8 bin_reloc_size(RBinReloc *reloc) {
 #define CASE(T) case R_BIN_RELOC_ ## T: return (T) / 8
 	switch (reloc->type) {
-		CASE(8);
-		CASE(16);
-		CASE(32);
-		CASE(64);
+	CASE(8);
+	CASE(16);
+	CASE(32);
+	CASE(64);
 	}
 	return 0;
 #undef CASE

--- a/test/db/formats/elf/elf-relro
+++ b/test/db/formats/elf/elf-relro
@@ -32,7 +32,6 @@ vaddr      paddr      type   name
 0x0000e288 0x0000e288 SET_64 memset
 0x0000e290 0x0000e290 SET_64 dlsym
 
-
 17 relocations
 EOF
 RUN


### PR DESCRIPTION
**TODO**

* [x] Add type `R_AARCH64_JUMP_SL` for those relocs
* [x] Fix the relocs listing regression that affects 4-5 tests

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Loading the librsjni_androix.so bin from the testsuite into r2 makes it crash.

This PR fixes the parsing of the relocs by fixing the overflow and getting  back the relocs to work

**Test plan**

I have added the binary that makes r2 crash into the testsuite and just loading with r2 makes it crash. But also after the fix, the output of the relocs is empty. while it shuold be what readelf shows:

```
$ readelf -r librsjni_androix.so

Relocation section '.rela.plt' at offset 0xb600 contains 17 entries:
  Offset          Info           Type           Sym. Value    Sym. Name + Addend
00000000e210  000100000402 R_AARCH64_JUMP_SL 0000000000000000 __cxa_finalize@LIBC + 0
00000000e218  000600000402 R_AARCH64_JUMP_SL 0000000000000000 __stack_chk_fail@LIBC + 0
00000000e220  000a00000402 R_AARCH64_JUMP_SL 0000000000000000 dlopen@LIBC + 0
00000000e228  001100000402 R_AARCH64_JUMP_SL 000000000000736c _Z11loadSymbolsPvR13di + 0
00000000e230  000900000402 R_AARCH64_JUMP_SL 0000000000000000 dlerror@LIBC + 0
00000000e238  000500000402 R_AARCH64_JUMP_SL 0000000000000000 __android_log_print + 0
00000000e240  000800000402 R_AARCH64_JUMP_SL 0000000000000000 dlclose@LIBC + 0
00000000e248  001200000402 R_AARCH64_JUMP_SL 000000000000851c _Z14loadIOSuppSymsPvR8 + 0
00000000e250  000d00000402 R_AARCH64_JUMP_SL 0000000000000000 malloc@LIBC + 0
00000000e258  000700000402 R_AARCH64_JUMP_SL 0000000000000000 calloc@LIBC + 0
00000000e260  000c00000402 R_AARCH64_JUMP_SL 0000000000000000 free@LIBC + 0
00000000e268  000300000402 R_AARCH64_JUMP_SL 0000000000000000 AndroidBitmap_lockPixe + 0
00000000e270  000200000402 R_AARCH64_JUMP_SL 0000000000000000 AndroidBitmap_getInfo + 0
00000000e278  000400000402 R_AARCH64_JUMP_SL 0000000000000000 AndroidBitmap_unlockPi + 0
00000000e280  000e00000402 R_AARCH64_JUMP_SL 0000000000000000 memcpy@LIBC + 0
00000000e288  000f00000402 R_AARCH64_JUMP_SL 0000000000000000 memset@LIBC + 0
00000000e290  000b00000402 R_AARCH64_JUMP_SL 0000000000000000 dlsym@LIBC + 0
$
```

I have fixed the relocs parsing, now r2 prints this:

```
[0x00000200]> ir
[Relocations]

vaddr      paddr      type    name
――――――――――――――――――――――――――――――――――
0x0000e210 0x0000e210 UNKNOWN __cxa_finalize
0x0000e218 0x0000e218 UNKNOWN __stack_chk_fail
0x0000e220 0x0000e220 UNKNOWN dlopen
0x0000e228 0x0000e228 UNKNOWN loadSymbols(void*, dispatchTable&, int)
0x0000e230 0x0000e230 UNKNOWN dlerror
0x0000e238 0x0000e238 UNKNOWN __android_log_print
0x0000e240 0x0000e240 UNKNOWN dlclose
0x0000e248 0x0000e248 UNKNOWN loadIOSuppSyms(void*, ioSuppDT&)
0x0000e250 0x0000e250 UNKNOWN malloc
0x0000e258 0x0000e258 UNKNOWN calloc
0x0000e260 0x0000e260 UNKNOWN free
0x0000e268 0x0000e268 UNKNOWN AndroidBitmap_lockPixels
0x0000e270 0x0000e270 UNKNOWN AndroidBitmap_getInfo
0x0000e278 0x0000e278 UNKNOWN AndroidBitmap_unlockPixels
0x0000e280 0x0000e280 UNKNOWN memcpy
0x0000e288 0x0000e288 UNKNOWN memset
0x0000e290 0x0000e290 UNKNOWN dlsym


17 relocations

[0x00000200]> 
```

**Closing issues**

There's no issue filled for this