### PR TITLE
Add ESIL weak eq support to `aetr` command

### DIFF
--- a/libr/anal/esil2reil.c
+++ b/libr/anal/esil2reil.c
@@ -1176,6 +1176,7 @@ R_API int r_anal_esil_to_reil_setup(RAnalEsil *esil, RAnal *anal, int romem,
 #define	OT_MEMR	R_ANAL_ESIL_OP_TYPE_MEM_READ
 
 	r_anal_esil_set_op(esil, "=", reil_eq, 0, 2, OT_REGW);
+	r_anal_esil_set_op(esil, ":=", reil_eq, 0, 2, OT_REGW);
 	r_anal_esil_set_op(esil, "+", reil_add, 1, 2, OT_MATH);
 	r_anal_esil_set_op(esil, "+=", reil_addeq, 0, 2, OT_MATH | OT_REGW);
 	r_anal_esil_set_op(esil, "-", reil_sub, 1, 2, OT_MATH);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Add "weak equality" ESIL operation (`:=`) in ESIL to REIL converter.

**Test plan**

Before:
```
[0x00006930]> "aetr 0,cf,:="
:=
cf
 0
^C
[0x00006930]> 
```
After:
```
[0x000068d0]> "aetr 0,cf,:="
0000.00:      STR      R_cf:01 ,              ,      V_00:01
0000.01:       OR         0:64 ,         0:01 ,      V_01:01
0000.02:      STR      V_01:01 ,              ,      R_cf:01
[0x000068d0]> 
```
...

