### PR TITLE
Do not print malformed table if no columns are set

### DIFF
--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -278,6 +278,9 @@ static void __computeTotal(RTable *t) {
 }
 
 R_API char *r_table_tofancystring(RTable *t) {
+	if (r_list_length (t->cols) == 0) {
+		return NULL;
+	}
 	RStrBuf *sb = r_strbuf_new ("");
 	RTableRow *row;
 	RTableColumn *col;
@@ -285,10 +288,10 @@ R_API char *r_table_tofancystring(RTable *t) {
 	RListIter *iter, *iter2;
 	bool useUtf8 = (cons && cons->use_utf8);
 	bool useUtf8Curvy = (cons && cons->use_utf8_curvy);
-	const char *v_line = useUtf8 ||  useUtf8Curvy ? RUNE_LINE_VERT : "|";
+	const char *v_line = useUtf8 || useUtf8Curvy ? RUNE_LINE_VERT : "|";
 	const char *h_line = useUtf8 || useUtf8Curvy ? RUNE_LINE_HORIZ : "-";
-	const char *l_intersect = useUtf8 ||  useUtf8Curvy ? RUNE_LINE_VERT : ")";
-	const char *r_intersect = useUtf8 ||  useUtf8Curvy ? RUNE_LINE_VERT : "(";
+	const char *l_intersect = useUtf8 || useUtf8Curvy ? RUNE_LINE_VERT : ")";
+	const char *r_intersect = useUtf8 || useUtf8Curvy ? RUNE_LINE_VERT : "(";
 	const char *tl_corner = useUtf8 ? (useUtf8Curvy ? RUNE_CURVE_CORNER_TL : RUNE_CORNER_TL) : ".";
 	const char *tr_corner = useUtf8 ? (useUtf8Curvy ? RUNE_CURVE_CORNER_TR : RUNE_CORNER_TR) : ".";
 	const char *bl_corner = useUtf8 ? (useUtf8Curvy ? RUNE_CURVE_CORNER_BL : RUNE_CORNER_BL) : "`";

--- a/libr/util/table.c
+++ b/libr/util/table.c
@@ -279,7 +279,7 @@ static void __computeTotal(RTable *t) {
 
 R_API char *r_table_tofancystring(RTable *t) {
 	if (r_list_length (t->cols) == 0) {
-		return NULL;
+		return strdup ("");
 	}
 	RStrBuf *sb = r_strbuf_new ("");
 	RTableRow *row;


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Printing a table in fancy mode results in a glitchy ascii art, this patch makes it not print anything

![Screenshot from 2020-05-18 10-52-48](https://user-images.githubusercontent.com/917142/82193510-c5227280-98f5-11ea-85b5-b4ae3032c151.png)


**Test plan**

I have to create some unit tests for it

**Closing issues**

I have spotted this bug while doing the comma(nd)