### PR TITLE
Fix c99 construct for pyc

### DIFF
--- a/libr/bin/p/bin_pyc.c
+++ b/libr/bin/p/bin_pyc.c
@@ -28,7 +28,8 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 static ut64 get_entrypoint(RBuffer *buf) {
 	ut8 b;
 	ut64 result;
-	for (int addr = 0x8; addr <= 0x10; addr += 0x4) {
+	int addr;
+	for (addr = 0x8; addr <= 0x10; addr += 0x4) {
 		r_buf_read_at (buf, addr, &b, sizeof (b));
 		if (pyc_is_code (b, version.magic)) {
 			code_start_offset = addr;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

radare2 fail to build with default option on RHEL 7 with a error due to C99 constucts without -c99.
See #14593, #14550 and #12879.


