### PR TITLE
Fix static build

### DIFF
--- a/binr/radare2/Makefile
+++ b/binr/radare2/Makefile
@@ -93,4 +93,5 @@ include ../../shlr/bochs/deps.mk
 include ../../shlr/grub/deps.mk
 include ../../shlr/qnx/deps.mk
 include ../../shlr/ar/deps.mk
+include ../../shlr/yxml/deps.mk
 LDFLAGS+=$(LINK)

--- a/binr/rasign2/Makefile
+++ b/binr/rasign2/Makefile
@@ -1,10 +1,6 @@
 BIN=rasign2
 BINDEPS=r_anal r_util r_core r_search r_main
+LDFLAGS+=$(LINK)
 
 include ../../libr/main/deps.mk
 include ../rules.mk
-#include ../../libr/socket/deps.mk
-#include ../../shlr/zip/deps.mk
-#include ../../shlr/gdb/deps.mk
-#include ../../shlr/bochs/deps.mk
-#include ../../shlr/qnx/deps.mk

--- a/libr/Makefile
+++ b/libr/Makefile
@@ -110,6 +110,7 @@ libr.${EXT_AR}: .libr2
 ifeq (1,$(WITH_GPL))
 E+=../shlr/grub/libgrubfs.${EXT_AR}
 endif
+E+=../shlr/yxml/libyxml.${EXT_AR}
 E+=../shlr/ar/libr_ar.${EXT_AR}
 E+=../shlr/windbg/libr_windbg.${EXT_AR}
 E+=../shlr/qnx/lib/libqnxr.${EXT_AR}

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -396,8 +396,7 @@ SHLRS+=grub/libgrubfs.a
 SHLRS+=java/libr_java.a
 SHLRS+=lz4/liblz4.a
 SHLRS+=qnx/lib/libqnxr.a
-#SHLRS+=sdb/src/libsdb.a
-#SHLRS+=tcc/libr_tcc.a
+SHLRS+=yxml/libyxml.a
 SHLRS+=windbg/libr_windbg.a
 SHLRS+=zip/librz.a
 

--- a/shlr/yxml/deps.mk
+++ b/shlr/yxml/deps.mk
@@ -1,0 +1,1 @@
+LINK+=$(SHLR)/yxml/libyxml.$(EXT_AR)


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Static build is broken because the yxml PR was merged without any proper review and because the static builds got rid from the CI

**Test plan**

run sys/static.sh

**Closing issues**

Fixes clusterfuzz, sdk, android and static builds, but no one filled an issue or complained even if i spotted this a week ago.