### PR TITLE
First version of stale file to automatically close old issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -33,10 +33,10 @@ staleLabel: wontfix
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. Considering a lot has changed since its creation, we kindly
-  ask you to check again if the bug you reported is still relevant in the
+  ask you to check again if the issue you reported is still relevant in the
   current version of radare2. If it is, update this issue with a comment,
-  otherwise the issue will be automatically closed if no further activity
-  occurs. Thank you for your contributions.
+  otherwise it will be automatically closed if no further activity occurs.
+  Thank you for your contributions.
 
 # Comment to post when removing the stale label.
 # unmarkComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,8 @@ onlyLabels: []
 exemptLabels:
   - architectures-enhancements
   - enhancement
+  - New Architecture
+  - New File-Format
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -42,9 +44,9 @@ markComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-  This issue has been automatically closed because stale and no activity
-  occurred. If the issue is still relevant, feel free to re-open it or open a
-  new one.
+  This issue has been automatically closed because marked as stale and it has
+  not been updated since then. If the issue is still relevant, feel free to
+  re-open it or open a new one.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,9 @@ daysUntilClose: 60
 onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+exemptLabels:
+  - architectures-enhancements
+  - enhancement
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -40,7 +40,9 @@ markComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-  This issue has been automatically closed because stale and no activity occurred.
+  This issue has been automatically closed because stale and no activity
+  occurred. If the issue is still relevant, feel free to re-open it or open a
+  new one.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,61 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 700
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 60
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. Considering a lot has changed since its creation, we kindly
+  ask you to check again if the bug you reported is still relevant in the
+  current version of radare2. If it is, update this issue with a comment,
+  otherwise the issue will be automatically closed if no further activity
+  occurs. Thank you for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been automatically closed because stale and no activity occurred.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
This enables the stale bot https://github.com/probot/stale .

## The workflow is more or less like this -

### What considered a stale issue?

The bot checks all issues that didn't have **activity** in the last 700 days (2 years). Activity including any comments, reference from other issues, adding to milestones, etc.

### Is there any exclusion list?
In addition, issues with one of these Labels would not be closed. And you can suggest labels to the list by reviewing the PR
```
exemptLabels:
  - architectures-enhancements
  - enhancement
  - New Architecture
  - New File-Format
```

### Notification to the community

For these inactive issues that do not have one or more of these labels, it is adding a "_stale_" label, and adds a comment telling the community that this is an old issue and ask them to check whether it is still relevant:

_"This issue has been automatically marked as stale because it has not had recent activity. Considering a lot has changed since its creation, we kindly ask you to check again if the issue you reported is still relevant "_

### I think the issue is still relevant, what now?

If someone in the community thinks it is still relevant, it is simple - as stated in the comment by the bot:

_"If it is [still relevant], **update this issue with a comment**, otherwise, the issue will be automatically closed if no further activity occurs."_


### And what then?
Since this comment, the bot gives 60 days (2 months) for the community to interact with this '_stale'_ issue. Once someone is commenting or engaging with the issue (referencing it, adding it to a milestone, add labels, ...) in these 60 days, the bot will understand that it is not a stale issue and would not bother about this issue. Until the next time that 2 years will pass without engagement with it.
