### PR TITLE
prc: Remove num. prefix

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -687,8 +687,22 @@ static void cmd_prc(RCore *core, const ut8* block, int len) {
 				if (show_flags) {
 					RFlagItem *fi = r_flag_get_i (core->flags, core->offset + j);
 					if (fi) {
-						ch = fi->name[0];
-						ch2 = fi->name[1];
+						size_t fst = 0, snd = 1;
+						if (r_str_startswith (fi->name, "num.")) {
+							fst = 4;
+							snd = 5;
+						}
+						if (fi->name[fst]) {
+							if (fi->name[snd]) {
+								ch = fi->name[fst];
+								ch2 = fi->name[snd];
+							} else {
+								ch = ' ';
+								ch2 = fi->name[fst];
+							}
+						} else {
+							ch2 = ch;
+						}
 					} else {
 						ch2 = ch;
 					}

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -746,7 +746,7 @@ FILE=-
 CMDS=<<EOF
 . scripts/palette.r2
 woe 0 0xff 1
-(test_flag; f `p8 1`)
+(test_flag; f num.`p8 1`)
 .(test_flag) @@s:0 0x100 1
 e scr.color=3
 prc 256


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr patches `prc` by having it remove the `num.` prefix if it is encountered in a flag, otherwise current `prc` behavior is preserved (except for single-char flags but that's a minor fix). This was done mainly so that the color table in https://github.com/radareorg/radare2/pull/16838#discussion_r426268189 will still appear even after the restriction of #16843 is imposed. It's possible that there are other situations where (ab)using this is useful.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
