### PR TITLE
add dumping of FLIRT signatures to rasign2

### DIFF
--- a/test/db/tools/rasign2
+++ b/test/db/tools/rasign2
@@ -94,3 +94,21 @@ EXPECT=<<EOF
 za main v b-24 b-16 b-32 b-28 b-8
 EOF
 RUN
+
+NAME=rasign2 -f libc-v7.sig
+FILE=
+CMDS=!rasign2 -f bins/other/sigs/libc-v7.sig
+EXPECT=<<EOF
+41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
+ 0. 16 D2A2 0298 0000:__libc_start_main
+EOF
+RUN
+
+NAME=rasign2 -f libc-v10.sig
+FILE=
+CMDS=!rasign2 -f bins/other/sigs/libc-v10.sig
+EXPECT=<<EOF
+41564155B8........4154554D89C4534889CD4D89CD4881EC900000004885C0:
+ 0. 16 D2A2 0298 0000:__libc_start_main
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

I will send a PR for the radare2book once my other radare2book PR is accepted.

**Detailed description**

This pull adds the `-f` option to rasign2 which just acts as a shortcut to the `zfd` command. So `-f` will dump the provided FLIRT signature file using FLIRT syntax.

**Test plan**

The included tests are the pretty much the same tests done for `zfd`.

**Closing issues**

This feature is pretty weak. Rasign2 does not yet match signatures, so implementing `zfs` is out. The `zfz` command does not currently do anything in r2. So you may not consider #16930 closed yet.