### PR TITLE
Fix @@s 'to' param so that it's inclusive

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4254,7 +4254,7 @@ R_API int r_core_cmd_foreach(RCore *core, const char *cmd, char *each) {
 				ut64 from = r_num_math (core->num, r_str_word_get0 (str, 0));
 				ut64 to = r_num_math (core->num, r_str_word_get0 (str, 1));
 				ut64 step = r_num_math (core->num, r_str_word_get0 (str, 2));
-				for (cur = from; cur < to; cur += step) {
+				for (cur = from; cur <= to; cur += step) {
 					(void) r_core_seek (core, cur, true);
 					r_core_cmd (core, cmd, 0);
 					if (r_cons_is_breaked ()) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5898,7 +5898,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_step_command) {
 	free (step_str);
 
 	ut64 cur;
-	for (cur = from; cur < to; cur += step) {
+	for (cur = from; cur <= to; cur += step) {
 		r_core_seek (core, cur, true);
 		r_core_block_size (core, step);
 		RCmdStatus cmd_res = handle_ts_command_tmpseek (state, command);

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -747,7 +747,7 @@ CMDS=<<EOF
 . scripts/palette.r2
 woe 0 0xff 1
 (test_flag; f `p8 1`)
-.(test_flag) @@s:0 0x100 1
+.(test_flag) @@s:0 0xff 1
 e scr.color=3
 prc 256
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the `@@s` `to` param so that it's inclusive, bringing it in line with its own help message (`run 'x' on all offsets from, to incrementing by step`) and `woe`. Also, UT64_MAX + 1 < UT64_MAX which is mathematically improper.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
