### PR TITLE
Fix socket timeout in r_socket_connect

### DIFF
--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -370,8 +370,11 @@ R_API bool r_socket_connect(RSocket *s, const char *host, const char *port, int 
 				struct timeval tv;
 				tv.tv_sec = timeout;
 				tv.tv_usec = 0;
+				fd_set wfds;
+				FD_ZERO(&wfds);
+				FD_SET(s->fd, &wfds);
 
-				if ((ret = select (s->fd + 1, NULL, NULL, NULL, &tv)) != -1) {
+				if ((ret = select (s->fd + 1, NULL, &wfds, NULL, &tv)) != -1) {
 					if (r_socket_is_connected (s)) {
 						freeaddrinfo (res);
 						return true;


### PR DESCRIPTION
Signed-off-by: Paul Fertser <fercerpav@gmail.com>

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
This problem is detailed fully in #16788. This patch (provided by Paul) fixes the timing issue found when trying to connect to OpenOCD's GDB server using r2. The patch adds the socket fd to the writefds set, allowing `select` to return when the socket is ready. Testing with this patch allows r2 to connect to an unmodified version of OpenOCD consistently.

**Test plan**

See #16788 
