### PR TITLE
Do the prefix check after prefix argument has been processed.

### DIFF
--- a/sys/build.sh
+++ b/sys/build.sh
@@ -66,9 +66,6 @@ if [ "`uname`" = Darwin ]; then
 		[ "$(id -u)" = 0 ] || SUDO=sudo
 		[ -n "${NOSUDO}" ] && SUDO=
 	fi
-else
-	[ -n "${PREFIX}" -a "${PREFIX}" != /usr ] && \
-		CFGARG="${CFGARG} --with-rpath"
 fi
 
 [ -z "${PREFIX}" ] && PREFIX="${DEFAULT_PREFIX}"
@@ -94,6 +91,10 @@ done
 
 if [ "${USE_CS5}" = 1 ]; then
 	CFGARG="${CFGARG} --with-capstone5"
+fi
+
+if [ "`uname`" != Darwin -a -n "${PREFIX}" -a "${PREFIX}" != /usr ]; then
+	CFGARG="${CFGARG} --with-rpath"
 fi
 
 ccache --help > /dev/null 2>&1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Do the check for need to use rpath based on PREFIX after PREFIX has been set by command line argument.

**Test plan**
* Do `sys/user.sh` in a VM preferably on Ubuntu 18.04 or other distro that uses `--enable-new-dtags` by default
* make sure running ~/bin/prefix/radare2/bin/r2 directly works
* using `readelf -d binary` check that RUNPATH is correctly set for r2 and lib/libr_core.so
* compile Cutter against ~/bin/prefix/radare2 r2 and make sure it opens without problems loading any of r2 libraries

**Closing issues**
