### PR TITLE
Fix ret op type for riscv

### DIFF
--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -538,8 +538,10 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		op->type = R_ANAL_OP_TYPE_JMP;
 	} else if (is_any ("j", "jump")) {
 		op->type = R_ANAL_OP_TYPE_JMP;
-	} else if (is_any ("jalr", "ret")) { // ?
-		op->type = R_ANAL_OP_TYPE_UCALL;
+	} else if (is_any ("jalr")) {
+		// decide whether it's ret or call
+		int rd = (word >> OP_SH_RD) & OP_MASK_RD;
+		op->type = (rd == 0) ? R_ANAL_OP_TYPE_RET: R_ANAL_OP_TYPE_UCALL;
 	} else if (is_any ("ret")) {
 		op->type = R_ANAL_OP_TYPE_RET;
 	} else if (is_any ("beqz", "beq", "blez", "bgez", "ble",

--- a/test/db/anal/riscv
+++ b/test/db/anal/riscv
@@ -1,0 +1,10 @@
+NAME=ret
+FILE=bins/elf/analysis/guess-number-riscv64
+CMDS=<<EOF
+af @ sym._printf_r
+afl~_printf_r
+EOF
+EXPECT=<<EOF
+0x00010330    1 68           sym._printf_r
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Analysis doesn't stop when `ret` op is reached because it is marked as `R_ANAL_OP_TYPE_UCALL`.

Copypaste from `jal` handler
https://github.com/radareorg/radare2/blob/6e401547a745fd191e066275bc5a373a2d808b8e/libr/anal/p/anal_riscv.c#L531-L534

Related: #16834
