### PR TITLE
Fix ahi help msgs

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -580,7 +580,7 @@ static const char *help_msg_ah[] = {
 	"ahf", " 0x804840", "override fallback address for call",
 	"ahF", " 0x10", "set stackframe size at current offset",
 	"ahh", " 0x804840", "highlight this address offset in disasm",
-	"ahi", "[?] 10", "define numeric base for immediates (1, 8, 10, 16, s)",
+	"ahi", "[?] 10", "define numeric base for immediates (2, 8, 10, 16, i, p, S, s)",
 	"ahj", "", "list hints in JSON",
 	"aho", " call", "change opcode type (see aho?) (deprecated, moved to \"ahd\")",
 	"ahp", " addr", "set pointer hint",
@@ -593,14 +593,14 @@ static const char *help_msg_ah[] = {
 };
 
 static const char *help_msg_ahi[] = {
-	"Usage:", "ahi [sbodh] [@ offset]", " Define numeric base",
-	"ahi", " [base]", "set numeric base (1, 2, 8, 10, 16)",
+	"Usage:", "ahi [2|8|10|16|bodhipSs] [@ offset]", " Define numeric base",
+	"ahi", " <base>", "set numeric base (2, 8, 10, 16)",
 	"ahi", " b", "set base to binary (2)",
+	"ahi", " o", "set base to octal (8)",
 	"ahi", " d", "set base to decimal (10)",
 	"ahi", " h", "set base to hexadecimal (16)",
-	"ahi", " o", "set base to octal (8)",
-	"ahi", " p", "set base to htons(port) (3)",
 	"ahi", " i", "set base to IP address (32)",
+	"ahi", " p", "set base to htons(port) (3)",
 	"ahi", " S", "set base to syscall (80)",
 	"ahi", " s", "set base to string (1)",
 	NULL

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7627,7 +7627,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 				(int) r_num_math (core->num, input + 1);
 			r_anal_hint_set_immbase (core->anal, core->offset, base);
 		} else if (input[1] != '?' && input[1] != '-') {
-			eprintf ("|ERROR| Usage: ahi [base]\n");
+			eprintf ("|ERROR| Usage: ahi <base>\n");
 		}
 		break;
 	case 'h': // "ahh"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr with regard to the ahi help messages:

- Removes 1 as a numeric base (base s still exists).
- Fixes ahi topline.
- Uses `<base>` instead of `[base]` since it's required.
- Adds some missing items to man ahi help message i.e. `i, p, S`.
- Sorts ahi help items according to main ahi help message `(2, 8, 10, 16, i, p, S, s)`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Emm ahi help is more accurate and consistent?

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
