### PR TITLE
Fix out-of-bounds write

### DIFF
--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -121,7 +121,7 @@ gdb_reg_t *arch_parse_reg_profile(const char * reg_profile) {
 		}
 	} while (*p++);
 
-	gdb_reg_t *gdb_regs = malloc (r_list_length (gdb_regs_list) + 1 * sizeof (gdb_reg_t));
+	gdb_reg_t *gdb_regs = malloc ((r_list_length (gdb_regs_list) + 1) * sizeof (gdb_reg_t));
 	if (!gdb_regs) {
 		return NULL;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I missed a pair of parenthesis in the `gdb_reg_t` array size calculation, which causes out-of-bounds write in `memcpy`.

**Test plan**


**Closing issues**
closes https://github.com/radareorg/cutter/issues/2194
