### PR TITLE
Fix crash and warnings when opening an iOS/arm64e DSC

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2204,8 +2204,9 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 				free (fnp);
 			}
 			if (sn.demname) {
+				ut64 size = symbol->size? symbol->size: 1;
 				r_meta_set (r->anal, R_META_TYPE_COMMENT,
-							addr, symbol->size, sn.demname);
+							addr, size, sn.demname);
 			}
 			r_flag_space_pop (r->flags);
 		} else if (IS_MODE_JSON (mode)) {

--- a/test/db/formats/mach0/swift
+++ b/test/db/formats/mach0/swift
@@ -12,9 +12,9 @@ RUN
 NAME=mach0 swift-x86-64 aav
 FILE=bins/mach0/swift-main
 CMDS=<<EOF
-C*~Cd?
+C*~^Cd?
 aav
-C*~Cd?
+C*~^Cd?
 Cd~?
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Running r2 on the `dyld_shared_cache_arm64e` from my iOS/arm64e device running iOS 13.5, I ran into the following issues:
1. It crashes because the `THREADED` opcode is encountered before the usually preceding `SET_SEGMENT_AND_OFFSET_ULEB` opcode. Apple's state machinery handles this case.
2. The reason 1) happens is because parsing doesn't stop when encountering the `DONE` opcode, so it goes ahead and parses “junk”.
3. With 1) and 2) out of the way, a lot of warnings were printed to the console: `WARNING: r_meta_set_with_subtype: assertion 'm && size' failed (line 185)`. This happens because of [this](https://github.com/radareorg/radare2/blob/f255a82a1bb45614a921e3cf156ac37b2b40811d/libr/core/cbin.c#L2206-L2209) logic in `bin_symbols`, which attempts to add an `R_META_TYPE_COMMENT` using a symbol where `symbol->size == 0`.

I've solved these three issues in two separate commits:

1. Improve handling of Mach-O bind opcodes
    * Reset state between regular binds, lazy binds, and weak binds.
    * Stop parsing when encountering the DONE opcode, except for when
      processing lazy binds.
    * Rework handling of THREADED opcode to match Apple's behavior, where
      the segment index isn't used. Also fix the page_count calculation.
    * Eliminate redundant boundary checks to improve clarity.

2. Fix symbol comment logic for zero-sized symbols

**Test plan**
```sh
$ R_DYLDCACHE_FILTER=OSAnalytics r2 dyld_shared_cache_arm64e-ios-13.5-iphone-xsmax
```

**Closing issues**
None that I'm aware of.