### PR TITLE
Fix pfo command without arguments

### DIFF
--- a/.github/workflows/newshell-treesitter-tests.yml
+++ b/.github/workflows/newshell-treesitter-tests.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     paths:
       - 'shlr/tree-sitter/*'
+      - 'shlr/tree-sitter/lib/*'
+      - 'shlr/tree-sitter/lib/**/*'
       - 'shlr/radare2-shell-parser/*'
+      - 'shlr/radare2-shell-parser/**/*'
     branches:
       - master
 

--- a/shlr/radare2-shell-parser/corpus/pf_commands.txt
+++ b/shlr/radare2-shell-parser/corpus/pf_commands.txt
@@ -179,12 +179,14 @@ Pf load from file
 =================
 
 pfo /tmp/myfile
+pfo
 
 ---
 
 (commands
   (arged_command (cmd_identifier)
-    (args (arg (arg_identifier)))))
+    (args (arg (arg_identifier))))
+  (arged_command (cmd_identifier)))
 
 
 ==========================

--- a/shlr/radare2-shell-parser/src/scanner.c
+++ b/shlr/radare2-shell-parser/src/scanner.c
@@ -30,7 +30,7 @@ void tree_sitter_r2cmd_external_scanner_deserialize(void *payload, const char *b
 }
 
 static bool is_pf_cmd(const char *s) {
-	return !strncmp (s, "pf", 2) || !strcmp (s, "Cf");
+	return (strcmp (s, "pfo") && !strncmp (s, "pf", 2)) || !strcmp (s, "Cf");
 }
 
 static bool is_env_cmd(const char *s) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When using cfg.newshell=true, `pfo` without arguments was not working as it was not identified as a `cmd_identifier` but neither as a `pf_command`. This PR makes sure the scanner considers `pfo` as a regular `cmd_identifier`, so that it can be handled like others `arged_command`s.

It also fixes a problem with the github action for testing tree-sitter corpus files. Changed to inner directories in shlr/radare2-shell-parser were not monitored.