### PR TITLE
Correct RISC-V ESIL for jumps

### DIFF
--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -469,9 +469,17 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		}
 		// jumps
 		else if (!strcmp (name, "jalr")) {
-			esilprintf (op, "%d,pc,+,%s,=,%s,%s,+,pc,=", op->size, ARG (0), ARG (2), ARG (1));
+			if (ARG (0) != "0") {
+				esilprintf (op, "%d,$$,+,%s,=,%s,%s,+,pc,=", op->size, ARG (0), ARG (2), ARG (1));
+			} else {
+				esilprintf (op, "%s,%s,+,pc,=", ARG (2), ARG (1));
+			}
 		} else if (!strcmp (name, "jal")) {
-			esilprintf (op, "%d,pc,+,%s,=,%s,pc,+,pc,=", op->size, ARG (0), ARG (1));
+			if (ARG (0) != "0") {
+				esilprintf (op, "%d,$$,+,%s,=,%s,pc,=", op->size, ARG (0), ARG (1));
+			} else {
+				esilprintf (op, "%s,pc,=", ARG (1));
+			}
 		} else if (!strcmp (name, "jr") || !strcmp (name, "j")) {
 			esilprintf (op, "%s,pc,=", ARG (0));
 		} else if (!strcmp (name, "ecall") || !strcmp (name, "ebreak")) {

--- a/test/db/esil/riscv_32
+++ b/test/db/esil/riscv_32
@@ -12,3 +12,20 @@ EXPECT=<<EOF
 0x00000005
 EOF
 RUN
+
+NAME=RISC-V ESIL for jump instructions
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch=riscv
+e asm.bits=32
+wx ef00c0006f00000113000000938676006780000093c6f6ff6ff01fff
+aei
+5aes
+ar pc
+ar a3
+EOF
+EXPECT=<<EOF
+0x00000018
+0xfffffff8
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Previous jump offset and return address were not computed right in ESIL for RISC-V.

**Test plan**
One test added.