### PR TITLE
WIP Fix less (~...) with the mouse ##cons

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1285,7 +1285,8 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		__print_prompt ();
 	}
 	r_cons_break_push (NULL, NULL);
-	r_cons_enable_mouse (I.hud);
+	// r_cons_enable_mouse (I.hud);
+	r_cons_enable_mouse (false);
 	for (;;) {
 		yank_flag = 0;
 		if (r_cons_is_breaked ()) {

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1285,7 +1285,6 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		__print_prompt ();
 	}
 	r_cons_break_push (NULL, NULL);
-	// r_cons_enable_mouse (I.hud);
 	r_cons_enable_mouse (false);
 	for (;;) {
 		yank_flag = 0;

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -45,7 +45,9 @@ R_API char *r_cons_hud_string(const char *s) {
 			os = o + i + 1;
 		}
 	}
+
 	ret = r_cons_hud (fl, NULL);
+
 	free (o);
 	r_list_free (fl);
 	return ret;

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -45,7 +45,6 @@ R_API char *r_cons_hud_string(const char *s) {
 			os = o + i + 1;
 		}
 	}
-
 	ret = r_cons_hud (fl, NULL);
 
 	free (o);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
When using ~... with a cmd, if we use the mouse we get weird input. The error comme from line 1288 of the file libr/cons/dietline.c. We need to call r_cons_enable_mouse with false. The only problem
is the weird hack which interpret the struct I.Hud as a boolen (WTF ...).
We can't set this value to null. Indeed it is used to bufferize the input.
So i set the value to false but i need your help to understand why the line exist?

**Test plan**

aa
afl~... (click with your mouse)

**Closing issues**
#16790 
