### PR TITLE
ahi 10 does signed decimal with 32-bit gp regs + ahi 10u for unsigned decimal

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -580,7 +580,7 @@ static const char *help_msg_ah[] = {
 	"ahf", " 0x804840", "override fallback address for call",
 	"ahF", " 0x10", "set stackframe size at current offset",
 	"ahh", " 0x804840", "highlight this address offset in disasm",
-	"ahi", "[?] 10", "define numeric base for immediates (2, 8, 10, 16, i, p, S, s)",
+	"ahi", "[?] 10", "define numeric base for immediates (2, 8, 10, 10u, 16, i, p, S, s)",
 	"ahj", "", "list hints in JSON",
 	"aho", " call", "change opcode type (see aho?) (deprecated, moved to \"ahd\")",
 	"ahp", " addr", "set pointer hint",
@@ -593,11 +593,12 @@ static const char *help_msg_ah[] = {
 };
 
 static const char *help_msg_ahi[] = {
-	"Usage:", "ahi [2|8|10|16|bodhipSs] [@ offset]", " Define numeric base",
+	"Usage:", "ahi [2|8|10|10u|16|bodhipSs] [@ offset]", " Define numeric base",
 	"ahi", " <base>", "set numeric base (2, 8, 10, 16)",
+	"ahi", " 10|d", "set base to signed decimal (10), sign bit should depend on receiver size",
+	"ahi", " 10u|du", "set base to unsigned decimal (11)",
 	"ahi", " b", "set base to binary (2)",
 	"ahi", " o", "set base to octal (8)",
-	"ahi", " d", "set base to decimal (10)",
 	"ahi", " h", "set base to hexadecimal (16)",
 	"ahi", " i", "set base to IP address (32)",
 	"ahi", " p", "set base to htons(port) (3)",
@@ -7615,16 +7616,20 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 		}
 		if (input[1] == ' ') {
 			// You can either specify immbase with letters, or numbers
-			const int base =
-				(input[2] == 's') ? 1 :
-				(input[2] == 'b') ? 2 :
-				(input[2] == 'p') ? 3 :
-				(input[2] == 'o') ? 8 :
-				(input[2] == 'd') ? 10 :
-				(input[2] == 'h') ? 16 :
-				(input[2] == 'i') ? 32 : // ip address
-				(input[2] == 'S') ? 80 : // syscall
-				(int) r_num_math (core->num, input + 1);
+			int base;
+			if (r_str_startswith (input + 2, "10u") || r_str_startswith (input + 2, "du")) {
+				base = 11;
+			} else {
+				base = (input[2] == 's') ? 1 :
+				       (input[2] == 'b') ? 2 :
+				       (input[2] == 'p') ? 3 :
+				       (input[2] == 'o') ? 8 :
+				       (input[2] == 'd') ? 10 :
+				       (input[2] == 'h') ? 16 :
+				       (input[2] == 'i') ? 32 : // ip address
+				       (input[2] == 'S') ? 80 : // syscall
+				       (int) r_num_math (core->num, input + 1);
+			}
 			r_anal_hint_set_immbase (core->anal, core->offset, base);
 		} else if (input[1] != '?' && input[1] != '-') {
 			eprintf ("|ERROR| Usage: ahi <base>\n");

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -479,7 +479,26 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 				snprintf (num, sizeof (num), "0%o", (int)off);
 				break;
 			case 10:
-				snprintf (num, sizeof (num), "%" PFMT64d, (st64)off);
+				if (x86) {
+					const char *regs[] = {
+						"eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi" };
+					bool bits32 = false;
+					int i;
+					for (i = 0; i < R_ARRAY_SIZE (regs); i++) {
+						if (r_str_casestr (data, regs[i])) {
+							bits32 = true;
+							break;
+						}
+					}
+					if (bits32) {
+						snprintf (num, sizeof (num), "%"PFMT32d, (st32)off);
+						break;
+					}
+				}
+				snprintf (num, sizeof (num), "%"PFMT64d, (st64)off);
+				break;
+			case 11:
+				snprintf (num, sizeof (num), "%"PFMT64u, off);
 				break;
 			case 32:
 				{

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -479,23 +479,23 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 				snprintf (num, sizeof (num), "0%o", (int)off);
 				break;
 			case 10:
-				if (x86) {
-					const char *regs[] = {
-						"eax", "ecx", "edx", "ebx", "esp", "ebp", "esi", "edi" };
-					bool bits32 = false;
-					int i;
-					for (i = 0; i < R_ARRAY_SIZE (regs); i++) {
-						if (r_str_casestr (data, regs[i])) {
-							bits32 = true;
+				{
+					RList *regs = r_reg_get_list (p->analb.anal->reg, R_REG_TYPE_GPR);
+					RRegItem *reg;
+					RListIter *iter;
+					bool imm32 = false;
+					r_list_foreach (regs, iter, reg) {
+						if (reg->size == 32 && r_str_casestr (data, reg->name)) {
+							imm32 = true;
 							break;
 						}
 					}
-					if (bits32) {
+					if (imm32) {
 						snprintf (num, sizeof (num), "%"PFMT32d, (st32)off);
 						break;
 					}
+					snprintf (num, sizeof (num), "%"PFMT64d, (st64)off);
 				}
-				snprintf (num, sizeof (num), "%"PFMT64d, (st64)off);
 				break;
 			case 11:
 				snprintf (num, sizeof (num), "%"PFMT64u, off);

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -357,3 +357,53 @@ EXPECT=<<EOF
 0x00000000 mov dword [rbp - 0x78], 16762435
 EOF
 RUN
+
+NAME=ahi 10 and 10u imm (x86_32)
+ARGS=-a x86 -b 32
+FILE=-
+CMDS=<<EOF
+e asm.bytes=false
+"wa cmp eax, -1"
+pd 1
+ahi 10
+pd 1
+ahi 10u
+pd 1
+EOF
+EXPECT=<<EOF
+            0x00000000      cmp eax, 0xffffffff
+            0x00000000      cmp eax, -1
+            0x00000000      cmp eax, 4294967295
+EOF
+RUN
+
+NAME=ahi 10 and 10u imm (x86_64)
+ARGS=-a x86 -b 64
+FILE=-
+CMDS=<<EOF
+e asm.bytes=false
+"wa cmp eax, -1"
+pd 1
+ahi 10
+pd 1
+ahi 10u
+pd 1
+?e
+ah-
+"wa cmp rax, -1"
+pd 1
+ahi 10
+pd 1
+ahi 10u
+pd 1
+EOF
+EXPECT=<<EOF
+            0x00000000      cmp eax, 0xffffffff
+            0x00000000      cmp eax, -1
+            0x00000000      cmp eax, 4294967295
+
+            0x00000000      cmp rax, 0xffffffffffffffff
+            0x00000000      cmp rax, -1
+            0x00000000      cmp rax, 18446744073709551615
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr does 2 things:

1. `ahi 10` or `ahi d` does signed decimal if it detects an x86 32-bit register (see https://github.com/radareorg/radare2/compare/master...kazarmy:ahi-10-signed-ahi-10u?expand=1#diff-0147cd662e9a03b59a8deb98c5e3b400R375 for an example).
1. `ahi 10u` or `ahi du` forces unsigned decimal if needed.

Method used is somewhat hacky but since this is a deliberate hint, it isn't enabled by default and the hint can be removed. Unfortunately only supporting x86 for now -- support for other archs is somewhere in the distant future.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
