### PR TITLE
Fix a glitch of W + j in panels

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -2497,7 +2497,7 @@ beach:
 void __move_panel_to_dir(RCore *core, RPanel *panel, int src) {
 	RPanels *panels = core->panels;
 	__dismantle_panel (panels, panel);
-	int key = __show_status (core, "Move the current panel to direction (h/l): ");
+	int key = __show_status (core, "Move the current panel to direction (h/j/k/l): ");
 	key = r_cons_arrow_to_hjkl (key);
 	__set_refresh_all (core, false, true);
 	switch (key) {
@@ -2585,7 +2585,7 @@ void __move_panel_to_down(RCore *core, RPanel *panel, int src) {
 	int h, w = r_cons_get_size (&h);
 	int p_h = h / 2;
 	int new_h = h - p_h;
-	__set_geometry (&panel->view->pos, 0, p_h - 1, w, p_h - 1);
+	__set_geometry (&panel->view->pos, 0, new_h, w, p_h);
 	int i = 0;
 	for (; i < panels->n_panels - 1; i++) {
 		RPanel *tmp = __get_panel (panels, i);


### PR DESCRIPTION
Issue:
Glitch happens when using W + j and moving a panel to bottom like the screenshot attached


![image](https://user-images.githubusercontent.com/29271244/83320276-d87ff700-a280-11ea-87d5-34bef93cfdd3.png)

Fix:
Calculation of height and position of the panels was not right so fixed it.