### PR TITLE
Fix in a dwarf line information parsing implementation

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -783,6 +783,9 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 
 		// this deals with a case that there is compilation unit with any line information
 		if (buf_size == bytes_read) { 
+			if (mode == R_MODE_PRINT) {
+				fprintf(f, "Line table is present, but no lines present\n");
+			}
 			r_bin_dwarf_header_fini (&hdr);
 			continue;
 		}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -751,6 +751,7 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 	const ut8 *buf = obuf;
 	const ut8 *buf_end = obuf + len;
 	const ut8 *tmpbuf = NULL;
+	
 	RBinDwarfLNPHeader hdr = { { 0 } };
 	size_t buf_size;
 

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -783,7 +783,8 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 
 		// this deals with a case that there is compilation unit with any line information
 		if (buf_size == bytes_read) { 
-			break;
+			r_bin_dwarf_header_fini (&hdr);
+			continue;
 		}
 		// we read the whole compilation unit (that might be composed of more sequences)
 		do {

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -469,7 +469,7 @@ static const ut8* r_bin_dwarf_parse_ext_opcode(const RBin *a, const ut8 *obuf,
 
 	opcode = *buf++;
 
-	// Maybe add offset to the print later?
+	// TODO - Maybe add offset to the print later?
 	if (f) {
 		fprintf (f, "  Extended opcode %d: ", opcode);
 	}
@@ -798,7 +798,8 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 		RBinDwarfSMRegisters regs;
 		r_bin_dwarf_set_regs_default (&hdr, &regs);
 
-		ut64 unit_length = (hdr.unit_length.part1 == DWARF_INIT_LEN_64) ? hdr.unit_length.part2 + 4 : hdr.unit_length.part1 + 4;
+		ut64 unit_length = (hdr.unit_length.part1 == DWARF_INIT_LEN_64) ? 
+					hdr.unit_length.part2 + 4 : hdr.unit_length.part1 + 4;
 
 		// If there is more bytes in the buffer than size of the header
 		// It means that there has to be another header/comp.unit

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -781,6 +781,10 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 			buf_size = unit_length;
 		}
 
+		// this deals with a case that there is compilation unit with any line information
+		if (buf_size == bytes_read) { 
+			break;
+		}
 		// we read the whole compilation unit (that might be composed of more sequences)
 		do {
 			// reads one whole sequence

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -565,7 +565,7 @@ static const ut8* r_bin_dwarf_parse_spec_opcode(
 	regs->line += hdr->line_base + (adj_opcode % hdr->line_range);
 	if (f) {
 		fprintf (f, "  Special opcode %d: ", adj_opcode);
-		fprintf (f, "advance Address by %"PFMT64d" to %"PFMT64x" and Line by %d to %"PFMT64d"\n",
+		fprintf (f, "advance Address by %"PFMT64d" to 0x%"PFMT64x" and Line by %d to %"PFMT64d"\n",
 			advance_adr, regs->address, hdr->line_base +
 			(adj_opcode % hdr->line_range), regs->line);
 	}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -759,7 +759,7 @@ static size_t r_bin_dwarf_parse_opcodes(const RBin *a, const ut8 *obuf,
 }
 
 // Is it problem to rename to raw? I don't know why its raw2
-R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
+R_API int r_bin_dwarf_parse_line_raw(const RBin *a, const ut8 *obuf,
 				       size_t len, int mode) {
 	RBinFile *binfile = a ? a->cur : NULL;
 	if (!binfile || !obuf) {
@@ -1732,7 +1732,7 @@ R_API RList *r_bin_dwarf_parse_line(RBin *a, int mode) {
 			return NULL;
 		}
 		// Actually parse the section
-		r_bin_dwarf_parse_line_raw2 (a, buf, len, mode);
+		r_bin_dwarf_parse_line_raw (a, buf, len, mode);
 		// k bin/cur/addrinfo/*
 		SdbListIter *iter;
 		SdbKv *kv;

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -756,7 +756,7 @@ R_API int r_bin_dwarf_parse_line_raw2(const RBin *a, const ut8 *obuf,
 	size_t buf_size;
 
 	// each iteration we read one header AKA comp. unit
-	while (buf + 1 < buf_end) {
+	while (buf <= buf_end) {
 		// How much did we read from the compilation unit
 		size_t bytes_read = 0;
 		// calculate how much we've read by parsing header

--- a/test/db/formats/mangling/bin
+++ b/test/db/formats/mangling/bin
@@ -80,7 +80,7 @@ NAME=C++ demangle relocs
 FILE=bins/elf/libstdc++.so.6
 CMDS=pd 1 @0x00091004
 EXPECT=<<EOF
-            0x00091004      488b159d880f.  mov rdx, qword [reloc.vtable_for_std::bad_alloc] ; [0x1898a8:8]=0
+            0x00091004      488b159d880f.  mov rdx, qword [reloc.vtable_for_std::bad_alloc] ; /build/gcc/src/gcc/libstdc++-v3/libsupc++/new:57 ; [0x1898a8:8]=0
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

#16975 
Compilation unit can have multiple line information sequences, radare2 parsed only one because the algorithm was wrong. 

There is one header per compilation unit, and there can be multiple sequences, in the algorithm there wasn't any tracking of read length (there was a loop that was always executed only once, because at the end it appended the length between start to end to the start) 

So I've changed `r_bin_dwarf_parse_opcodes` to return read length so I know if there are still more sequences left. Move the header creation outside the loop, because it's created only once per unit. And I read a sequence every loop.

Tests in #16965  (WIP)

(Compared to previous output shown in the #16975 )
Now:
```
$ r2 cpp_dwarf3
> id

...
Set column to 3
Extended opcode 2: set Address to 0x11ee
Special opcode 6: advance Address by 0 to 11ee and Line by 1 to 2
Set column to 12
Special opcode 173: advance Address by 12 to 11fa and Line by 0 to 2
Set column to 15
Special opcode 201: advance Address by 14 to 1208 and Line by 0 to 2
Advance PC by 3 to 0x120b
Extended opcode 1: End of Sequence
Set column to 11
Extended opcode 2: set Address to 0x120c
Special opcode 7: advance Address by 0 to 120c and Line by 2 to 3
Set column to 21
Special opcode 173: advance Address by 12 to 1218 and Line by 0 to 3
Set column to 22
Special opcode 201: advance Address by 14 to 1226 and Line by 0 to 3
Advance PC by 3 to 0x1229
Extended opcode 1: End of Sequence
Set column to 11
Extended opcode 2: set Address to 0x122a
Special opcode 7: advance Address by 0 to 122a and Line by 2 to 3
Set column to 22
..... // rest, matches output of readelf utility
```