### PR TITLE
elf32 pf.elf_header: w -> N2 for phnum, shnum, shstrndx, ehsize, phentsize and shentsize

### DIFF
--- a/libr/bin/d/elf32
+++ b/libr/bin/d/elf32
@@ -1,5 +1,5 @@
 pfo elf_enums
 pf.elf_ident [4]z[1]E[1]E[1]E.:: magic (elf_class)class (elf_data)data (elf_hdr_version)version
-pf.elf_header ?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+pf.elf_header ?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 pf.elf_phdr [4]Exxxxx[4]Ex (elf_p_type)type offset vaddr paddr filesz memsz (elf_p_flags)flags align
 pf.elf_shdr x[4]E[4]Exxxxxxx name (elf_s_type)type (elf_s_flags_32)flags addr offset size link info addralign entsize

--- a/libr/bin/d/elf32
+++ b/libr/bin/d/elf32
@@ -1,5 +1,5 @@
 pfo elf_enums
 pf.elf_ident [4]z[1]E[1]E[1]E.:: magic (elf_class)class (elf_data)data (elf_hdr_version)version
-pf.elf_header ?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+pf.elf_header ?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 pf.elf_phdr [4]Exxxxx[4]Ex (elf_p_type)type offset vaddr paddr filesz memsz (elf_p_flags)flags align
 pf.elf_shdr x[4]E[4]Exxxxxxx name (elf_s_type)type (elf_s_flags_32)flags addr offset size link info addralign entsize

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -187,7 +187,7 @@ static bool init_ehdr(ELFOBJ *bin) {
 		" (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version"
 		" entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx", 0);
 #else
-	sdb_set (bin->kv, "elf_header.format", "?[2]E[2]E[4]Exxxxwwwwww"
+	sdb_set (bin->kv, "elf_header.format", "?[2]E[2]E[4]ExxxxwwN2wN2N2"
 		" (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version"
 		" entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx", 0);
 #endif

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -187,7 +187,7 @@ static bool init_ehdr(ELFOBJ *bin) {
 		" (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version"
 		" entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx", 0);
 #else
-	sdb_set (bin->kv, "elf_header.format", "?[2]E[2]E[4]ExxxxwwN2wN2N2"
+	sdb_set (bin->kv, "elf_header.format", "?[2]E[2]E[4]ExxxxN2N2N2N2N2N2"
 		" (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version"
 		" entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx", 0);
 #endif

--- a/test/db/cmd/cmd_pf2
+++ b/test/db/cmd/cmd_pf2
@@ -455,8 +455,8 @@ pf?elf_header
 pf? elf_header
 EOF
 EXPECT=<<EOF
-?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 EOF
 RUN
 
@@ -491,11 +491,10 @@ EXPECT=<<EOF
      flags : 0x00000024 = 0x00000000
     ehsize : 0x00000028 = 0x0034
  phentsize : 0x0000002a = 0x0020
-     phnum : 0x0000002c = 0x0001
+     phnum : 0x0000002c = 1
  shentsize : 0x0000002e = 0x0000
-     shnum : 0x00000030 = 0x0000
-  shstrndx : 0x00000032 = 0x0000
+     shnum : 0x00000030 = 0
+  shstrndx : 0x00000032 = 0
 EOF
-EXPECT_ERR=<<EOF
-EOF
+EXPECT_ERR=
 RUN

--- a/test/db/cmd/cmd_pf2
+++ b/test/db/cmd/cmd_pf2
@@ -455,8 +455,8 @@ pf?elf_header
 pf? elf_header
 EOF
 EXPECT=<<EOF
-?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
-?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 EOF
 RUN
 
@@ -489,10 +489,10 @@ EXPECT=<<EOF
      phoff : 0x0000001c = 0x00000034
      shoff : 0x00000020 = 0x00000000
      flags : 0x00000024 = 0x00000000
-    ehsize : 0x00000028 = 0x0034
- phentsize : 0x0000002a = 0x0020
+    ehsize : 0x00000028 = 52
+ phentsize : 0x0000002a = 32
      phnum : 0x0000002c = 1
- shentsize : 0x0000002e = 0x0000
+ shentsize : 0x0000002e = 0
      shnum : 0x00000030 = 0
   shstrndx : 0x00000032 = 0
 EOF

--- a/test/db/cmd/cmd_pf_elf
+++ b/test/db/cmd/cmd_pf_elf
@@ -167,10 +167,10 @@ EXPECT=<<EOF
      flags : 0x08048024 = 0x00000000
     ehsize : 0x08048028 = 0x0034
  phentsize : 0x0804802a = 0x0020
-     phnum : 0x0804802c = 0x0001
+     phnum : 0x0804802c = 1
  shentsize : 0x0804802e = 0x0000
-     shnum : 0x08048030 = 0x0000
-  shstrndx : 0x08048032 = 0x0000
+     shnum : 0x08048030 = 0
+  shstrndx : 0x08048032 = 0
 EOF
 RUN
 
@@ -228,10 +228,10 @@ EXPECT=<<EOF
      flags : 0x00000024 = 0x00000000
     ehsize : 0x00000028 = 0x0034
  phentsize : 0x0000002a = 0x0020
-     phnum : 0x0000002c = 0x0001
+     phnum : 0x0000002c = 1
  shentsize : 0x0000002e = 0x0000
-     shnum : 0x00000030 = 0x0000
-  shstrndx : 0x00000032 = 0x0000
+     shnum : 0x00000030 = 0
+  shstrndx : 0x00000032 = 0
 
 [
   {
@@ -333,7 +333,7 @@ EXPECT=<<EOF
   },
   {
     "name": "phnum",
-    "type": "w",
+    "type": "N2",
     "offset": 44,
     "value": 1
   },
@@ -345,13 +345,13 @@ EXPECT=<<EOF
   },
   {
     "name": "shnum",
-    "type": "w",
+    "type": "N2",
     "offset": 48,
     "value": 0
   },
   {
     "name": "shstrndx",
-    "type": "w",
+    "type": "N2",
     "offset": 50,
     "value": 0
   }
@@ -403,13 +403,42 @@ wz `pf? elf_header`
 .(pfelf 2)
 EOF
 EXPECT=<<EOF
-?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 52
 
-{1}?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+{1}?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 52
 
-{2}?[2]E[2]E[4]Exxxxwwwwww (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+{2}?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 104
+EOF
+RUN
+
+NAME=32: normal elf header
+FILE=bins/elf/hello_world32
+CMDS=<<EOF
+pfo elf32
+pf.elf_header @ segment.ehdr
+EOF
+EXPECT=<<EOF
+     ident : 
+                struct<elf_ident>
+           magic : 0x00000000 = "\x7fELF"
+           class : 0x00000004 = class (enum elf_class) = 0x1 ; ELFCLASS32
+            data : 0x00000005 = data (enum elf_data) = 0x1 ; ELFDATA2LSB
+         version : 0x00000006 = version (enum elf_hdr_version) = 0x1 ; EV_CURRENT
+      type : 0x00000010 = type (enum elf_type) = 0x3 ; ET_DYN
+   machine : 0x00000012 = machine (enum elf_machine) = 0x3 ; EM_386
+   version : 0x00000014 = version (enum elf_obj_version) = 0x1 ; EV_CURRENT
+     entry : 0x00000018 = 0x000004d0
+     phoff : 0x0000001c = 0x00000034
+     shoff : 0x00000020 = 0x0000182c
+     flags : 0x00000024 = 0x00000000
+    ehsize : 0x00000028 = 0x0034
+ phentsize : 0x0000002a = 0x0020
+     phnum : 0x0000002c = 9
+ shentsize : 0x0000002e = 0x0028
+     shnum : 0x00000030 = 29
+  shstrndx : 0x00000032 = 28
 EOF
 RUN

--- a/test/db/cmd/cmd_pf_elf
+++ b/test/db/cmd/cmd_pf_elf
@@ -165,10 +165,10 @@ EXPECT=<<EOF
      phoff : 0x0804801c = 0x00000034
      shoff : 0x08048020 = 0x00000000
      flags : 0x08048024 = 0x00000000
-    ehsize : 0x08048028 = 0x0034
- phentsize : 0x0804802a = 0x0020
+    ehsize : 0x08048028 = 52
+ phentsize : 0x0804802a = 32
      phnum : 0x0804802c = 1
- shentsize : 0x0804802e = 0x0000
+ shentsize : 0x0804802e = 0
      shnum : 0x08048030 = 0
   shstrndx : 0x08048032 = 0
 EOF
@@ -226,10 +226,10 @@ EXPECT=<<EOF
      phoff : 0x0000001c = 0x00000034
      shoff : 0x00000020 = 0x00000000
      flags : 0x00000024 = 0x00000000
-    ehsize : 0x00000028 = 0x0034
- phentsize : 0x0000002a = 0x0020
+    ehsize : 0x00000028 = 52
+ phentsize : 0x0000002a = 32
      phnum : 0x0000002c = 1
- shentsize : 0x0000002e = 0x0000
+ shentsize : 0x0000002e = 0
      shnum : 0x00000030 = 0
   shstrndx : 0x00000032 = 0
 
@@ -321,13 +321,13 @@ EXPECT=<<EOF
   },
   {
     "name": "ehsize",
-    "type": "w",
+    "type": "N2",
     "offset": 40,
     "value": 52
   },
   {
     "name": "phentsize",
-    "type": "w",
+    "type": "N2",
     "offset": 42,
     "value": 32
   },
@@ -339,7 +339,7 @@ EXPECT=<<EOF
   },
   {
     "name": "shentsize",
-    "type": "w",
+    "type": "N2",
     "offset": 46,
     "value": 0
   },
@@ -403,13 +403,13 @@ wz `pf? elf_header`
 .(pfelf 2)
 EOF
 EXPECT=<<EOF
-?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 52
 
-{1}?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+{1}?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 52
 
-{2}?[2]E[2]E[4]ExxxxwwN2wN2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
+{2}?[2]E[2]E[4]ExxxxN2N2N2N2N2N2 (elf_ident)ident (elf_type)type (elf_machine)machine (elf_obj_version)version entry phoff shoff flags ehsize phentsize phnum shentsize shnum shstrndx
 104
 EOF
 RUN
@@ -434,10 +434,10 @@ EXPECT=<<EOF
      phoff : 0x0000001c = 0x00000034
      shoff : 0x00000020 = 0x0000182c
      flags : 0x00000024 = 0x00000000
-    ehsize : 0x00000028 = 0x0034
- phentsize : 0x0000002a = 0x0020
+    ehsize : 0x00000028 = 52
+ phentsize : 0x0000002a = 32
      phnum : 0x0000002c = 9
- shentsize : 0x0000002e = 0x0028
+ shentsize : 0x0000002e = 40
      shnum : 0x00000030 = 29
   shstrndx : 0x00000032 = 28
 EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr does 2 things to the elf32 pf.elf_header format:
1. Change w -> N2 for phnum, shnum and shstrndx (600f051da5b93b20aa99cb481cf47cdcbc52f277), because array indexing is usually done in decimal.
1. Change w -> N2 for ehsize, phentsize and shentsize (0a137ae4e9f435cd6b539cb6d054bf784c8c62d8), because data structure sizes are usually stated in decimal bytes.

This pr removes the need to convert between hex and decimal.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

**TODO** (if pr is accepted)

- [X] elf32 pf.elf_header: w -> N2 for phnum, shnum, shstrndx, ehsize, phentsize and shentsize
- [ ] elf64 pf.elf_header: w -> N2 for phnum, shnum, shstrndx, ehsize, phentsize and shentsize
