### PR TITLE
x86 pseudo for LEA is wrong

### DIFF
--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -261,6 +261,10 @@ static int parse(RParse *p, const char *data, char *str) {
 
 		replace (nw, wa, str);
 
+	} else if (strstr (w0, "lea")) {
+		r_str_replace_char (w2, '[', 0);
+		r_str_replace_char (w2, ']', 0);
+		replace (nw, wa, str);
 	} else if ((strstr (w1, "ax") || strstr (w1, "ah") || strstr (w1, "al")) && !p->retleave_asm) {
 		if (!(p->retleave_asm = (char *) malloc (sz))) {
 			return false;
@@ -303,9 +307,9 @@ static void parse_localvar (RParse *p, char *newstr, size_t newstr_len, const ch
 			r_strbuf_setf (sb, " + %s", ireg);
 		}
 		if (p->localvar_only) {
-			snprintf (newstr, newstr_len - 1, "[%s%s]", var, r_strbuf_get (sb));
+			snprintf (newstr, newstr_len - 1, "%s%s", var, r_strbuf_get (sb));
 		} else {
-			snprintf (newstr, newstr_len - 1, "[%s%s %c %s]", reg, r_strbuf_get (sb), sign, var);
+			snprintf (newstr, newstr_len - 1, "%s%s %c %s", reg, r_strbuf_get (sb), sign, var);
 		}
 	}
 	r_strbuf_free (sb);
@@ -327,9 +331,9 @@ static inline void mk_reg_str(const char *regname, int delta, bool sign, bool at
 			r_strbuf_setf (sb, " + %s", ireg);
 		}
 		if (delta < 10) {
-			snprintf (dest, len - 1, "[%s%s %c %d]", regname, r_strbuf_get (sb), sign ? '+':'-', delta);
+			snprintf (dest, len - 1, "%s%s %c %d", regname, r_strbuf_get (sb), sign ? '+':'-', delta);
 		} else {
-			snprintf (dest, len - 1, "[%s%s %c 0x%x]", regname, r_strbuf_get (sb), sign ? '+':'-', delta);
+			snprintf (dest, len - 1, "%s%s %c 0x%x", regname, r_strbuf_get (sb), sign ? '+':'-', delta);
 		}
 	}
 	r_strbuf_free (sb);

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -65,6 +65,7 @@ static int replace (int argc, char *argv[], char *newstr) {
 		{ "jne", "if (var) goto #", {1}},
 		{ "lea",  "# = #", {1, 2}},
 		{ "mov",  "# = #", {1, 2}},
+		{ "movabs", "# = #", {1, 2}},
 		{ "movq",  "# = #", {1, 2}},
 		{ "movaps",  "# = #", {1, 2}},
 		{ "movups",  "# = #", {1, 2}},

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -3474,3 +3474,85 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=lea pseudo improvements (pseudo disabled)
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+e asm.comments=false
+e asm.pseudo=false
+wx 544889e5b40266b83333b85555444448b8bebafecaefbeadde4889d8488d03488b4308488d4308488d041b488d441b0a488d430a488d44240c488d450b488d45f5488d442404488d4508488d45f8
+aa
+pd 19
+EOF
+EXPECT=<<EOF
+/ 512: fcn.00000000 (int64_t arg_8h, int64_t arg_bh, int64_t arg_ch);
+|           ; var int64_t var_bh @ rbp-0xb
+|           ; var int64_t var_8h @ rbp-0x8
+|           ; arg int64_t arg_8h @ rbp+0x8
+|           ; arg int64_t arg_bh @ rbp+0xb
+|           ; var int64_t var_4h @ rsp+0x4
+|           ; arg int64_t arg_ch @ rsp+0xc
+|           0x00000000      54             push rsp
+|           0x00000001      4889e5         mov rbp, rsp
+|           0x00000004      b402           mov ah, 2
+|           0x00000006      66b83333       mov ax, 0x3333
+|           0x0000000a      b855554444     mov eax, 0x44445555
+|           0x0000000f      48b8bebafeca.  movabs rax, 0xdeadbeefcafebabe
+|           0x00000019      4889d8         mov rax, rbx
+|           0x0000001c      488d03         lea rax, [rbx]
+|           0x0000001f      488b4308       mov rax, qword [rbx + 8]
+|           0x00000023      488d4308       lea rax, [rbx + 8]
+|           0x00000027      488d041b       lea rax, [rbx + rbx]
+|           0x0000002b      488d441b0a     lea rax, [rbx + rbx + 0xa]
+|           0x00000030      488d430a       lea rax, [rbx + 0xa]
+|           0x00000034      488d44240c     lea rax, [arg_ch]
+|           0x00000039      488d450b       lea rax, [arg_bh]
+|           0x0000003d      488d45f5       lea rax, [var_bh]
+|           0x00000041      488d442404     lea rax, [var_4h]
+|           0x00000046      488d4508       lea rax, [arg_8h]
+|           0x0000004a      488d45f8       lea rax, [var_8h]
+EOF
+RUN
+
+NAME=lea pseudo improvements (pseudo enabled)
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+e asm.comments=false
+e asm.pseudo=true
+wx 544889e5b40266b83333b85555444448b8bebafecaefbeadde4889d8488d03488b4308488d4308488d041b488d441b0a488d430a488d44240c488d450b488d45f5488d442404488d4508488d45f8
+aa
+pd 19
+EOF
+EXPECT=<<EOF
+/ 512: fcn.00000000 (int64_t arg_8h, int64_t arg_bh, int64_t arg_ch);
+|           ; var int64_t var_bh @ rbp-0xb
+|           ; var int64_t var_8h @ rbp-0x8
+|           ; arg int64_t arg_8h @ rbp+0x8
+|           ; arg int64_t arg_bh @ rbp+0xb
+|           ; var int64_t var_4h @ rsp+0x4
+|           ; arg int64_t arg_ch @ rsp+0xc
+|           0x00000000      54             push rsp
+|           0x00000001      4889e5         rbp = rsp
+|           0x00000004      b402           ah = 2
+|           0x00000006      66b83333       ax = 0x3333
+|           0x0000000a      b855554444     eax = 0x44445555
+|           0x0000000f      48b8bebafeca.  movabs rax,0xdeadbeefcafebabe
+|           0x00000019      4889d8         rax = rbx
+|           0x0000001c      488d03         rax = rbx
+|           0x0000001f      488b4308       rax = qword [rbx + 8]
+|           0x00000023      488d4308       rax = rbx + 8
+|           0x00000027      488d041b       rax = rbx + rbx
+|           0x0000002b      488d441b0a     rax = rbx + rbx + 0xa
+|           0x00000030      488d430a       rax = rbx + 0xa
+|           0x00000034      488d44240c     rax = arg_ch
+|           0x00000039      488d450b       rax = arg_bh
+|           0x0000003d      488d45f5       rax = var_bh
+|           0x00000041      488d442404     rax = var_4h
+|           0x00000046      488d4508       rax = arg_8h
+|           0x0000004a      488d45f8       rax = var_8h
+EOF
+RUN

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -3540,7 +3540,7 @@ EXPECT=<<EOF
 |           0x00000004      b402           ah = 2
 |           0x00000006      66b83333       ax = 0x3333
 |           0x0000000a      b855554444     eax = 0x44445555
-|           0x0000000f      48b8bebafeca.  movabs rax,0xdeadbeefcafebabe
+|           0x0000000f      48b8bebafeca.  rax = 0xdeadbeefcafebabe
 |           0x00000019      4889d8         rax = rbx
 |           0x0000001c      488d03         rax = rbx
 |           0x0000001f      488b4308       rax = qword [rbx + 8]


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
PR alters pseudo code for lea operator to not include brackets. Variable resolution is preserved.

Example:
```
> e asm.pseudo = false
0x0804843c      8d45f8         lea eax, [var_8h]
```
```
> e asm.pseudo = true
0x0804843c      8d45f8         eax = var_8h
```

**Test plan**

Use e.g. crackme0x02 from IOLI crackmes series. Run ```e asm.pseudo = true``` and confirm pseudo code for lea looks as described in example.

**Closing issues**

closes #16777 