### PR TITLE
Fix `;` at the end of the value of eq_sep_args

### DIFF
--- a/shlr/radare2-shell-parser/corpus/special_commands.txt
+++ b/shlr/radare2-shell-parser/corpus/special_commands.txt
@@ -31,11 +31,21 @@ Environment variable command
 %
 %SHELL
 %TMPDIR=/tmp
+%SHELL;
+%TMPDIR=/tmp;
 
 ---
 
 (commands
   (arged_command (cmd_identifier))
+  (arged_command (cmd_identifier)
+    (args
+      (args (arg (arg_identifier)))))
+  (arged_command (cmd_identifier)
+    (args
+      (args (arg (arg_identifier)))
+      (arg_identifier)
+      (args (arg (arg_identifier)))))
   (arged_command (cmd_identifier)
     (args
       (args (arg (arg_identifier)))))

--- a/shlr/radare2-shell-parser/src/scanner.c
+++ b/shlr/radare2-shell-parser/src/scanner.c
@@ -76,6 +76,10 @@ static bool is_concat_pf_dot(const int32_t ch) {
 	return is_concat(ch) && ch != '=';
 }
 
+static bool is_concat_eq_sep(const int32_t ch) {
+	return is_concat(ch) && ch != '=';
+}
+
 static bool is_recursive_help(int id_len, const int32_t before_last_ch, const int32_t last_ch) {
 	return id_len >= 2 && before_last_ch == '?' && last_ch == '*';
 }
@@ -112,10 +116,6 @@ static bool scan_number(TSLexer *lexer, const bool *valid_symbols) {
 
 bool tree_sitter_r2cmd_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
 	// FIXME: /* in the shell should become a multiline comment
-	if (valid_symbols[EQ_SEP_CONCAT] && !isspace(lexer->lookahead) && lexer->lookahead != '=' && lexer->lookahead != '\0') {
-		lexer->result_symbol = EQ_SEP_CONCAT;
-		return true;
-	}
 	if (valid_symbols[CONCAT] && is_concat (lexer->lookahead)) {
 		lexer->result_symbol = CONCAT;
 		return true;
@@ -125,8 +125,11 @@ bool tree_sitter_r2cmd_external_scanner_scan(void *payload, TSLexer *lexer, cons
 	} else if (valid_symbols[CONCAT_PF_DOT] && is_concat_pf_dot (lexer->lookahead)) {
 		lexer->result_symbol = CONCAT_PF_DOT;
 		return true;
+	} else if (valid_symbols[EQ_SEP_CONCAT] && is_concat_eq_sep (lexer->lookahead)) {
+		lexer->result_symbol = EQ_SEP_CONCAT;
+		return true;
 	}
-        if (valid_symbols[CMD_IDENTIFIER] || valid_symbols[HELP_COMMAND]) {
+	if (valid_symbols[CMD_IDENTIFIER] || valid_symbols[HELP_COMMAND]) {
 		char res[CMD_IDENTIFIER_MAX_LENGTH + 1];
 		int i_res = 0;
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In https://github.com/radareorg/radare2/pull/16966#issuecomment-636436231 it was reported that with cfg.newshell=true:
`%R2_CURL=1 ;idpd` does not,
`%R2_CURL=1;idpd` works

This PR fixes this behaviour by making sure EQ_SEP_CONCAT is implemented by reusing `is_concat`.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Added new commands in the corpus files.