### PR TITLE
Enable unit tests compilation by default in meson

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -271,7 +271,7 @@ static inline void **r_pvector_shrink(RPVector *vec) {
 		size_t h = (vec)->v.len, m; \
 		for (i = 0; i < h; ) { \
 			m = i + ((h - i) >> 1); \
-			if ((cmp (x, ((void **)(vec)->v.a)[m])) > 0) { \
+			if ((cmp ((x), ((void **)(vec)->v.a)[m])) > 0) { \
 				i = m + 1; \
 			} else { \
 				h = m; \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,7 +32,7 @@ option('debugger', type: 'boolean', value: true)
 
 option('use_webui', type: 'boolean', value: false, description: 'install different WebUIs for radare2')
 
-option('enable_tests', type: 'boolean', value: false, description: 'Build unit tests in test/unit')
+option('enable_tests', type: 'boolean', value: true, description: 'Build unit tests in test/unit')
 option('enable_r2r', type: 'boolean', value: true, description: 'Build r2r executable for regression testing')
 
 option('tree-sitter-sync', type: 'boolean', value: false, description: 'Force a sync of shlr/tree-sitter before building')

--- a/test/unit/minunit.h
+++ b/test/unit/minunit.h
@@ -67,7 +67,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 #define mu_sysfail(message) do { perror(message); mu_fail(message); } while(0)
 
 #define mu_assert_true(actual, message) do { \
-		__typeof__ (actual) act__ = (actual); \
+		bool act__ = (actual); \
 		if (!(act__)) { \
 			char _meqstr[2048]; \
 			sprintf (_meqstr, "%s: expected true, got false", (message)); \
@@ -77,7 +77,7 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 
 #define mu_assert_false(actual, message) \
 	do { \
-		__typeof__ (actual) act__ = (actual); \
+		bool act__ = (actual); \
 		if ((act__)) { \
 			char _meqstr[2048]; \
 			sprintf (_meqstr, "%s: expected false, got true", (message)); \
@@ -86,8 +86,8 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	} while (0)
 
 #define mu_assert_eq(actual, expected, message) do { \
-		__typeof__(actual) act__ = (actual); \
-		__typeof__(expected) exp__ = (expected); \
+		ut64 act__ = (ut64)(actual); \
+		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
 			sprintf(_meqstr, "%s: expected %" PFMT64d ", got %" PFMT64d ".", (message), (ut64)(exp__), (ut64)(act__)); \
@@ -97,8 +97,8 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 
 #define mu_assert_neq(actual, expected, message) do { \
 		char _meqstr[2048]; \
-		__typeof__(actual) act__ = (actual); \
-		__typeof__(expected) exp__ = (expected); \
+		ut64 act__ = (ut64)(actual); \
+		ut64 exp__ = (ut64)(expected); \
 		sprintf(_meqstr, "%s: expected not %" PFMT64d ", got %" PFMT64d ".", (message), (exp__), (act__)); \
 		mu_assert(_meqstr, (exp__) != (act__)); \
 	} while(0)
@@ -134,8 +134,8 @@ void sprint_mem(char *out, const ut8 *buf, size_t len) {
 	} while(0)
 
 #define mu_assert_eq_fmt(actual, expected, message, fmt) do { \
-		__typeof__(actual) act__ = (actual); \
-		__typeof__(expected) exp__ = (expected); \
+		ut64 act__ = (ut64)(actual); \
+		ut64 exp__ = (ut64)(expected); \
 		if ((exp__) != (act__)) { \
 			char _meqstr[2048]; \
 			sprintf(_meqstr, "%s: expected "fmt", got "fmt".", (message), (exp__), (act__)); \

--- a/test/unit/test_addr_interval.c
+++ b/test/unit/test_addr_interval.c
@@ -1,7 +1,7 @@
 #include <r_util/r_itv.h>
 #include "minunit.h"
 
-#define I(begin, end) ((RInterval){begin, end-begin})
+#define I(begin, end) ((RInterval){(begin), (end)-(begin)})
 
 int test_r_itv_contain(void) {
 	mu_assert ("contain", r_itv_contain (I (0, 3), 0));

--- a/test/unit/test_annotated_code.c
+++ b/test/unit/test_annotated_code.c
@@ -8,7 +8,7 @@
 
 static RCodeAnnotation make_code_annotation(int st, int en, RCodeAnnotationType typec,
 	ut64 offset, RSyntaxHighlightType types) {
-	RCodeAnnotation annotation = {};
+	RCodeAnnotation annotation = { 0 };
 	annotation.start = st;
 	annotation.end = en;
 	annotation.type = typec;

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -102,12 +102,12 @@ bool test_buf(RBuffer *b) {
 
 bool test_r_buf_file(void) {
 	RBuffer *b;
-	char filename[] = "r2-XXXXXX";
+	char *filename = "r2-XXXXXX";
 	const char *content = "Something To\nSay Here..";
 	const int length = 23;
 
 	// Prepare file
-	int fd = mkstemp (filename);
+	int fd = r_file_mkstemp ("", &filename);
 	mu_assert_neq ((ut64)fd, (ut64)-1, "mkstemp failed...");
 	write (fd, content, length);
 	close (fd);
@@ -144,12 +144,12 @@ bool test_r_buf_bytes(void) {
 
 bool test_r_buf_mmap(void) {
 	RBuffer *b;
-	char filename[] = "r2-XXXXXX";
+	char *filename = "r2-XXXXXX";
 	const char *content = "Something To\nSay Here..";
 	const int length = 23;
 
 	// Prepare file
-	int fd = mkstemp (filename);
+	int fd = r_file_mkstemp ("", &filename);
 	mu_assert_neq ((long long)fd, -1LL, "mkstemp failed...");
 	write (fd, content, length);
 	close (fd);

--- a/test/unit/test_event.c
+++ b/test/unit/test_event.c
@@ -18,7 +18,7 @@ static void callback_test(REvent *ev, int type, void *user, void *data) {
 bool test_r_event(void) {
 	REvent *ev = r_event_new ((void *)0x1337);
 	mu_assert_notnull (ev, "r_event_new ()");
-	mu_assert_eq_fmt (ev->user, (void *)0x1337, "ev->user", "%p");
+	mu_assert_ptreq (ev->user, (void *)0x1337, "ev->user");
 
 	EventTestAcc acc_all = { 0 };
 	EventTestAcc acc_specific = { 0 };
@@ -30,36 +30,36 @@ bool test_r_event(void) {
 
 	mu_assert_eq (acc_all.count, 1, "all count after event");
 	mu_assert_eq (acc_all.last_type, R_EVENT_META_DEL, "all type after event");
-	mu_assert_eq_fmt (acc_all.last_data, (void *)0x4242, "all type after event", "%p");
+	mu_assert_ptreq (acc_all.last_data, (void *)0x4242, "all type after event");
 	mu_assert_eq (acc_specific.count, 0, "specific count after other event");
 
 	r_event_send (ev, R_EVENT_META_SET, (void *)0xdeadbeef);
 
 	mu_assert_eq (acc_all.count, 2, "all count after event");
 	mu_assert_eq (acc_all.last_type, R_EVENT_META_SET, "all type after event");
-	mu_assert_eq_fmt (acc_all.last_data, (void *)0xdeadbeef, "all type after event", "%p");
+	mu_assert_ptreq (acc_all.last_data, (void *)0xdeadbeef, "all type after event");
 
 	mu_assert_eq (acc_specific.count, 1, "specific count after event");
 	mu_assert_eq (acc_specific.last_type, R_EVENT_META_SET, "specific type after event");
-	mu_assert_eq_fmt (acc_specific.last_data, (void *)0xdeadbeef, "specific type after event", "%p");
+	mu_assert_ptreq (acc_specific.last_data, (void *)0xdeadbeef, "specific type after event");
 
 	r_event_unhook (ev, handle_all);
 	r_event_send (ev, R_EVENT_META_SET, (void *)0xc0ffee);
 
 	mu_assert_eq (acc_all.count, 2, "all count after event after being removed");
 	mu_assert_eq (acc_all.last_type, R_EVENT_META_SET, "all type after event after being removed");
-	mu_assert_eq_fmt (acc_all.last_data, (void *)0xdeadbeef, "all type after event after being removed", "%p");
+	mu_assert_ptreq (acc_all.last_data, (void *)0xdeadbeef, "all type after event after being removed");
 
 	mu_assert_eq (acc_specific.count, 2, "specific count after event");
 	mu_assert_eq (acc_specific.last_type, R_EVENT_META_SET, "specific type after event");
-	mu_assert_eq_fmt (acc_specific.last_data, (void *)0xc0ffee, "specific type after event", "%p");
+	mu_assert_ptreq (acc_specific.last_data, (void *)0xc0ffee, "specific type after event");
 
 	r_event_unhook (ev, handle_specific);
 	r_event_send (ev, R_EVENT_META_SET, (void *)0xc0ffee);
 
 	mu_assert_eq (acc_specific.count, 2, "specific count after event after being removed");
 	mu_assert_eq (acc_specific.last_type, R_EVENT_META_SET, "specific type after event after being removed");
-	mu_assert_eq_fmt (acc_specific.last_data, (void *)0xc0ffee, "specific type after event after being removed", "%p");
+	mu_assert_ptreq (acc_specific.last_data, (void *)0xc0ffee, "specific type after event after being removed");
 
 	r_event_free (ev);
 

--- a/test/unit/test_intervaltree.c
+++ b/test/unit/test_intervaltree.c
@@ -154,7 +154,7 @@ bool test_r_interval_tree_in(bool end_inclusive, bool intervals) {
 	return true;
 }
 
-#define TEST_IN(name, args...) bool name() { if(!test_r_interval_tree_in (args)) return false; mu_end; }
+#define TEST_IN(name, end_inclusive, intervals) bool name() { if(!test_r_interval_tree_in (end_inclusive, intervals)) return false; mu_end; }
 TEST_IN (test_r_interval_tree_in_end_exclusive_point, false, false)
 TEST_IN (test_r_interval_tree_in_end_inclusive_point, true, false)
 TEST_IN (test_r_interval_tree_in_end_exclusive_interval, false, true)

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1062,7 +1062,7 @@ static bool test_pvector_lower_bound() {
 	s.v.len = 5;
 
 	size_t l;
-#define CMP(x, y) x - y
+#define CMP(x, y) (x) - (y)
 	r_pvector_lower_bound (&s, (void *)4, l, CMP);
 	mu_assert_eq (r_pvector_at (&s, l), (void *)4, "lower_bound");
 	r_pvector_lower_bound (&s, (void *)5, l, CMP);

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1062,14 +1062,14 @@ static bool test_pvector_lower_bound() {
 	s.v.len = 5;
 
 	size_t l;
-#define CMP(x, y) (x) - (y)
-	r_pvector_lower_bound (&s, (void *)4, l, CMP);
-	mu_assert_eq (r_pvector_at (&s, l), (void *)4, "lower_bound");
-	r_pvector_lower_bound (&s, (void *)5, l, CMP);
-	mu_assert_eq (r_pvector_at (&s, l), (void *)6, "lower_bound 2");
-	r_pvector_lower_bound (&s, (void *)6, l, CMP);
-	mu_assert_eq (r_pvector_at (&s, l), (void *)6, "lower_bound 3");
-	r_pvector_lower_bound (&s, (void *)9, l, CMP);
+#define CMP(x, y) ((char *)(x) - (char *)(y))
+	r_pvector_lower_bound (&s, 4, l, CMP);
+	mu_assert_ptreq (r_pvector_at (&s, l), (void *)4, "lower_bound");
+	r_pvector_lower_bound (&s, 5, l, CMP);
+	mu_assert_ptreq (r_pvector_at (&s, l), (void *)6, "lower_bound 2");
+	r_pvector_lower_bound (&s, 6, l, CMP);
+	mu_assert_ptreq (r_pvector_at (&s, l), (void *)6, "lower_bound 3");
+	r_pvector_lower_bound (&s, 9, l, CMP);
 	mu_assert_eq (l, s.v.len, "lower_bound 3");
 #undef CMP
 


### PR DESCRIPTION
 **Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

I found myself always enabling unit tests when compiling in meson, am I the only one? I think package maintainer can easily add that one flag the one time they need to create the spec file (or whatever for their distro), but for us as upstream developer it's quite annoying, at least to me, to have to specify that every time, since I often create different build directories for various PRs, tests, etc.

This PR makes enable_tests default to true.