### PR TITLE
rabin2 could not detect go in macho binaries

### DIFF
--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -42,10 +42,7 @@ static bool check_swift(RBinSymbol *sym) {
 }
 
 static bool check_golang(RBinSymbol *sym) {
-	if (!strncmp (sym->name, "go.", 3)) {
-		return true;
-	}
-	return false;
+	return !strncmp (sym->name, "go.", 3);
 }
 
 static inline bool is_cxx_symbol (const char *name) {
@@ -114,11 +111,9 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 				return R_BIN_NM_RUST;
 			}
 		}
-		if (!cantbe.go) {
-			if (check_golang (sym)) {
-				info->lang = "go";
-				return R_BIN_NM_GO;
-			}
+		if (check_golang (sym)) {
+			info->lang = "go";
+			return R_BIN_NM_GO;
 		}
 		if (!cantbe.swift) {
 			bool hasswift = false;

--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -42,7 +42,7 @@ static bool check_swift(RBinSymbol *sym) {
 }
 
 static bool check_golang(RBinSymbol *sym) {
-	if (sym->name && strstr (sym->name, "go.buildid")) {
+	if (!strncmp (sym->name, "go.", 3)) {
 		return true;
 	}
 	return false;

--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -9,7 +9,6 @@ typedef struct {
 	bool swift;
 	bool cxx;
 	bool msvc;
-	bool go;
 } Langs;
 
 static inline bool check_rust(RBinSymbol *sym) {

--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -9,6 +9,7 @@ typedef struct {
 	bool swift;
 	bool cxx;
 	bool msvc;
+	bool go;
 } Langs;
 
 static inline bool check_rust(RBinSymbol *sym) {
@@ -35,6 +36,13 @@ static bool check_dlang(RBinSymbol *sym) {
 
 static bool check_swift(RBinSymbol *sym) {
 	if (sym->name && strstr (sym->name, "swift_once")) {
+		return true;
+	}
+	return false;
+}
+
+static bool check_golang(RBinSymbol *sym) {
+	if (sym->name && strstr (sym->name, "go.buildid")) {
 		return true;
 	}
 	return false;
@@ -104,6 +112,12 @@ R_API int r_bin_load_languages(RBinFile *binfile) {
 			if (check_rust (sym)) {
 				info->lang = "rust";
 				return R_BIN_NM_RUST;
+			}
+		}
+		if (!cantbe.go) {
+			if (check_golang (sym)) {
+				info->lang = "go";
+				return R_BIN_NM_GO;
 			}
 		}
 		if (!cantbe.swift) {
@@ -213,6 +227,8 @@ R_API const char *r_bin_lang_tostring(int lang) {
 	switch (lang & 0xffff) {
 	case R_BIN_NM_SWIFT:
 		return "swift";
+	case R_BIN_NM_GO:
+		return "go";
 	case R_BIN_NM_JAVA:
 		return "java";
 	case R_BIN_NM_KOTLIN:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [] I've added tests that prove my fix is effective or that my feature works (if possible)
- [] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

rabin2 only detects go language for ELF binaries. This update now detects golang when using the `-I` flag with rabin2 against a go binary built for macho.

...

**Test plan**

1. Build a go binary with any of the following: `GOOS=darwin GOARCH=amd64 go build`
2. Run `rabin2 -I <binary> | grep lang`
3. The result should be `lang     go` (previously it returned `lang     c`

...

**Closing issues**

N/A

...
