### PR TITLE
Add more null checks and fix a lock when no r2 in path ##r2pipe

### DIFF
--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -169,6 +169,7 @@ static int w32_createPipe(R2Pipe *r2pipe, const char *cmd) {
 
 static R2Pipe* r2p_open_spawn(R2Pipe* r2p, const char *cmd) {
 	r_return_val_if_fail (r2p, NULL);
+#if __UNIX__ || defined(__CYGWIN__)
 	char *out = r_sys_getenv ("R2PIPE_IN");
 	char *in = r_sys_getenv ("R2PIPE_OUT");
 	int done = false;
@@ -176,18 +177,18 @@ static R2Pipe* r2p_open_spawn(R2Pipe* r2p, const char *cmd) {
 		int i_in = atoi (in);
 		int i_out = atoi (out);
 		if (i_in >= 0 && i_out >= 0) {
-			r2pipe->input[0] = r2pipe->input[1] = i_in;
-			r2pipe->output[0] = r2pipe->output[1] = i_out;
+			r2p->input[0] = r2p->input[1] = i_in;
+			r2p->output[0] = r2p->output[1] = i_out;
 			done = true;
 		}
 	}
 	if (!done) {
 		eprintf ("Cannot find R2PIPE_IN or R2PIPE_OUT environment\n");
-		R_FREE (r2pipe);
+		R_FREE (r2p);
 	}
 	free (in);
 	free (out);
-	return r2pipe;
+	return r2p;
 #else
 	eprintf ("r2pipe_open(NULL) not supported on windows\n");
 	return NULL;
@@ -233,92 +234,101 @@ R_API R2Pipe *r2pipe_open_dl(const char *libr_path) {
 }
 
 R_API R2Pipe *r2pipe_open(const char *cmd) {
-	R2Pipe *r2pipe = r2pipe_new ();
-	if (!r2pipe) {
+	R2Pipe *r2p = r2pipe_new ();
+	if (!r2p) {
 		return NULL;
 	}
-	r2p->magic = R2P_MAGIC;
+	// r2p->magic = R2P_MAGIC;
 	if (R_STR_ISEMPTY (cmd)) {
 		r2p->child = -1;
 		return r2p_open_spawn (r2p, cmd);
 	}
 #if __WINDOWS__
-	w32_createPipe (r2pipe, cmd);
-	r2pipe->child = (int)(r2pipe->pipe);
+	w32_createPipe (r2p, cmd);
+	r2pipe->child = (int)(r2p->pipe);
 #else
-	int r = pipe (r2pipe->input);
+	int r = pipe (r2p->input);
 	if (r != 0) {
 		eprintf ("pipe failed on input\n");
-		r2pipe_close (r2pipe);
+		r2pipe_close (r2p);
 		return NULL;
 	}
-	r = pipe (r2pipe->output);
+	r = pipe (r2p->output);
 	if (r != 0) {
 		eprintf ("pipe failed on output\n");
-		r2pipe_close (r2pipe);
+		r2pipe_close (r2p);
 		return NULL;
 	}
 #if LIBC_HAVE_FORK
-	r2pipe->child = fork ();
+	r2p->child = fork ();
 #else
-	r2pipe->child = -1;
+	r2p->child = -1;
 #endif
-	if (r2pipe->child == -1) {
-		r2pipe_close (r2pipe);
+	if (r2p->child == -1) {
+		r2pipe_close (r2p);
 		return NULL;
 	}
-	env ("R2PIPE_IN", r2pipe->input[0]);
-	env ("R2PIPE_OUT", r2pipe->output[1]);
+	env ("R2PIPE_IN", r2p->input[0]);
+	env ("R2PIPE_OUT", r2p->output[1]);
 
-	if (r2pipe->child) {
+	if (r2p->child) {
 		char ch = 1;
 		// eprintf ("[+] r2pipeipe child is %d\n", r2pipe->child);
-		if (read (r2pipe->output[0], &ch, 1) != 1) {
+		if (read (r2p->output[0], &ch, 1) != 1) {
 			eprintf ("Failed to read 1 byte\n");
-			r2pipe_close (r2pipe);
+			r2pipe_close (r2p);
 			return NULL;
 		}
 		if (ch) {
 			eprintf ("[+] r2pipeipe-io link failed. Expected two null bytes.\n");
-			r2pipe_close (r2pipe);
+			r2pipe_close (r2p);
 			return NULL;
 		}
 		// Close parent's end of pipes
-		close (r2pipe->input[0]);
-		close (r2pipe->output[1]);
-		r2pipe->input[0] = -1;
-		r2pipe->output[1] = -1;
+		close (r2p->input[0]);
+		close (r2p->output[1]);
+		r2p->input[0] = -1;
+		r2p->output[1] = -1;
 	} else {
 		int rc = 0;
 		if (cmd && *cmd) {
 			close (0);
 			close (1);
-			dup2 (r2pipe->input[0], 0);
-			dup2 (r2pipe->output[1], 1);
-			close (r2pipe->input[1]);
-			close (r2pipe->output[0]);
-			r2pipe->input[1] = -1;
-			r2pipe->output[0] = -1;
-			rc = r_sandbox_system (cmd, 0);
+			dup2 (r2p->input[0], 0);
+			dup2 (r2p->output[1], 1);
+			close (r2p->input[1]);
+			close (r2p->output[0]);
+			r2p->input[1] = -1;
+			r2p->output[0] = -1;
+			rc = r_sandbox_system (cmd, 1);
+			fprintf (stderr, "return code %d for %s\n", rc, cmd);
+			fflush (stderr);
+			// trigger the blocking read
+			write (1, "\xff", 1);
+			close (r2p->output[0]);
+			close (r2p->output[1]);
+			close (0);
+			close (1);
 		}
-		r2pipe_close (r2pipe);
+		r2p->child = -1;
+		r2pipe_close (r2p);
 		exit (rc);
 		return NULL;
 	}
 #endif
-	return r2pipe;
+	return r2p;
 }
 
-R_API char *r2p_cmd(R2Pipe *r2p, const char *str) {
+R_API char *r2pipe_cmd(R2Pipe *r2p, const char *str) {
 	r_return_val_if_fail (r2p && str, NULL);
-	if (!*str || !r2p_write (r2p, str)) {
-		perror ("r2p_write");
+	if (!*str || !r2pipe_write (r2p, str)) {
+		perror ("r2pipe_write");
 		return NULL;
 	}
-	return r2pipe_read (r2pipe);
+	return r2pipe_read (r2p);
 }
 
-R_API char *r2pipe_cmdf(R2Pipe *r2pipe, const char *fmt, ...) {
+R_API char *r2pipe_cmdf(R2Pipe *r2p, const char *fmt, ...) {
 	int ret, ret2;
 	char *p, string[1024];
 	va_list ap, ap2;
@@ -339,10 +349,10 @@ R_API char *r2pipe_cmdf(R2Pipe *r2pipe, const char *fmt, ...) {
 			va_end (ap);
 			return NULL;
 		}
-		fmt = r2pipe_cmd (r2pipe, p);
+		fmt = r2pipe_cmd (r2p, p);
 		free (p);
 	} else {
-		fmt = r2pipe_cmd (r2pipe, string);
+		fmt = r2pipe_cmd (r2p, string);
 	}
 	va_end (ap2);
 	va_end (ap);

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -272,14 +272,14 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 	env ("R2PIPE_OUT", r2p->output[1]);
 
 	if (r2p->child) {
-		char ch = 1;
+		char ch = -1;
 		// eprintf ("[+] r2pipeipe child is %d\n", r2pipe->child);
 		if (read (r2p->output[0], &ch, 1) != 1) {
 			eprintf ("Failed to read 1 byte\n");
 			r2pipe_close (r2p);
 			return NULL;
 		}
-		if (ch) {
+		if (ch==-1) {
 			eprintf ("[+] r2pipeipe-io link failed. Expected two null bytes.\n");
 			r2pipe_close (r2p);
 			return NULL;

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -245,7 +245,7 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 	}
 #if __WINDOWS__
 	w32_createPipe (r2p, cmd);
-	r2pipe->child = (int)(r2p->pipe);
+	r2p->child = (int)(r2p->pipe);
 #else
 	int r = pipe (r2p->input);
 	if (r != 0) {

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -238,7 +238,6 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 	if (!r2p) {
 		return NULL;
 	}
-	// r2p->magic = R2P_MAGIC;
 	if (R_STR_ISEMPTY (cmd)) {
 		r2p->child = -1;
 		return r2p_open_spawn (r2p, cmd);
@@ -280,7 +279,7 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 			return NULL;
 		}
 		if (ch == -1) {
-			eprintf ("[+] r2pipeipe-io link failed. Expected two null bytes.\n");
+			eprintf ("[+] r2pipe link error.\n");
 			r2pipe_close (r2p);
 			return NULL;
 		}

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -279,7 +279,7 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 			r2pipe_close (r2p);
 			return NULL;
 		}
-		if (ch==-1) {
+		if (ch == -1) {
 			eprintf ("[+] r2pipeipe-io link failed. Expected two null bytes.\n");
 			r2pipe_close (r2p);
 			return NULL;

--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -169,7 +169,6 @@ static int w32_createPipe(R2Pipe *r2pipe, const char *cmd) {
 
 static R2Pipe* r2p_open_spawn(R2Pipe* r2p, const char *cmd) {
 	r_return_val_if_fail (r2p, NULL);
-#if __UNIX__ || defined(__CYGWIN__)
 	char *out = r_sys_getenv ("R2PIPE_IN");
 	char *in = r_sys_getenv ("R2PIPE_OUT");
 	int done = false;

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -15,6 +15,7 @@ if get_option('enable_tests')
     'bitmap',
     'buf',
     'cmd',
+    'r2pipe',
     'cons',
     'contrbtree',
     'debruijn',

--- a/test/unit/test_r2pipe.c
+++ b/test/unit/test_r2pipe.c
@@ -1,0 +1,23 @@
+#include <r_util.h>
+#include <r_socket.h>
+#include "minunit.h"
+
+bool test_r2pipe(void) {
+	// R2Pipe *r = r2pipe_open ("/usr/local/bin/r2");
+	R2Pipe *r = r2pipe_open ("r2 -q0 -");
+	mu_assert("r2pipe can spawn", r);
+	char *hello = r2pipe_cmd (r, "?e hello world");
+	mu_assert_streq(hello, "hello world\n", "r2pipe hello world");
+	free (hello);
+	r2pipe_close (r);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test(test_r2pipe);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}

--- a/test/unit/test_r2pipe.c
+++ b/test/unit/test_r2pipe.c
@@ -13,8 +13,16 @@ bool test_r2pipe(void) {
 	mu_end;
 }
 
+bool test_r2pipe_404(void) {
+	// R2Pipe *r = r2pipe_open ("/usr/local/bin/r2");
+	R2Pipe *r = r2pipe_open ("rodoro2 -q0 -");
+	mu_assert("r2pipe can spawn", !r);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test(test_r2pipe);
+	mu_run_test(test_r2pipe_404);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_r2pipe.c
+++ b/test/unit/test_r2pipe.c
@@ -4,7 +4,7 @@
 
 bool test_r2pipe(void) {
 	// R2Pipe *r = r2pipe_open ("/usr/local/bin/r2");
-	R2Pipe *r = r2pipe_open ("r2 -q0 -");
+	R2Pipe *r = r2pipe_open ("radare2 -q0 -");
 	mu_assert("r2pipe can spawn", r);
 	char *hello = r2pipe_cmd (r, "?e hello world");
 	mu_assert_streq(hello, "hello world\n", "r2pipe hello world");

--- a/test/unit/test_r2pipe.c
+++ b/test/unit/test_r2pipe.c
@@ -2,30 +2,28 @@
 #include <r_socket.h>
 #include "minunit.h"
 
-bool test_r2pipe(void) {
-	// R2Pipe *r = r2pipe_open ("/usr/local/bin/r2");
+static bool test_r2pipe(void) {
 	R2Pipe *r = r2pipe_open ("radare2 -q0 -");
-	mu_assert("r2pipe can spawn", r);
+	mu_assert ("r2pipe can spawn", r);
 	char *hello = r2pipe_cmd (r, "?e hello world");
-	mu_assert_streq(hello, "hello world\n", "r2pipe hello world");
+	mu_assert_streq (hello, "hello world\n", "r2pipe hello world");
 	free (hello);
 	r2pipe_close (r);
 	mu_end;
 }
 
-bool test_r2pipe_404(void) {
-	// R2Pipe *r = r2pipe_open ("/usr/local/bin/r2");
+static bool test_r2pipe_404(void) {
 	R2Pipe *r = r2pipe_open ("rodoro2 -q0 -");
-	mu_assert("r2pipe can spawn", !r);
+	mu_assert ("r2pipe can spawn", !r);
 	mu_end;
 }
 
-int all_tests() {
-	mu_run_test(test_r2pipe);
-	mu_run_test(test_r2pipe_404);
+static int all_tests() {
+	mu_run_test (test_r2pipe);
+	mu_run_test (test_r2pipe_404);
 	return tests_passed != tests_run;
 }
 
 int main(int argc, char **argv) {
-	return all_tests();
+	return all_tests ();
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Passing null on failed initializations caused an unhandled crash, this patch aims to r_return_ify the r2pipe C API.

**Test plan**

There are no tests for the C api of r2pipe, and i am aware of some improvements that must be done in this API to be considered stable. But having a null deref is a no-go. I will update the PR adding tests and improving the capabilities of the client side api for r2pipe.

**Closing issues**

None
