### PR TITLE
Add ESIL flag update for adds and subs instructions

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2084,6 +2084,12 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		case ARM_INS_CMP:
 		case ARM_INS_CMN:
 			break;
+		case ARM_INS_SUB:
+			r_strbuf_appendf (&op->esil, ",$z,zf,:=,31,$s,nf,:=,32,$b,!,cf,=,31,$o,vf,=");
+			break;
+		case ARM_INS_ADD:
+			r_strbuf_appendf (&op->esil, ",$z,zf,:=,1,$c,cf,=,31,$o,vf,=");
+			break;
 		default:
 			r_strbuf_appendf (&op->esil, ",$z,zf,:=,31,$s,nf,:=");
 		}

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -448,6 +448,40 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=adds with carry and zero
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+wa adds r1, 1
+aer r1=0xffffffff
+aes
+ar r1
+ar cpsr
+EOF
+EXPECT=<<EOF
+0x00000000
+0x60000000
+EOF
+RUN
+
+NAME=subs with carry and zero
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+wa subs r1, 1
+aer r1=1
+aes
+ar r1
+ar cpsr
+EOF
+EXPECT=<<EOF
+0x00000000
+0x60000000
+EOF
+RUN
+
 NAME=smmla
 FILE=malloc://0x200
 CMDS=<<EOF

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -377,7 +377,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=subs triggers zf
+NAME=subs triggers zf and cf
 FILE=-
 CMDS=<<EOF
 e esil.debug=true
@@ -390,11 +390,11 @@ aes
 aer?cpsr
 EOF
 EXPECT=<<EOF
-0x40000000
+0x60000000
 EOF
 RUN
 
-NAME=subs triggers zf off
+NAME=subs triggers cf and zf off
 FILE=-
 CMDS=<<EOF
 e esil.debug=true
@@ -407,7 +407,7 @@ aes
 aer?cpsr
 EOF
 EXPECT=<<EOF
-0x00000000
+0x20000000
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Carry and overflow flags were not updated after adds or subs instructions in ESIL,

**Test plan**
Test added.

**Closing issues**
#10577 should be closed.
