### PR TITLE
Fix runaway scrolling in Visual mode after mashing down movement key on Windows Terminal

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4265,34 +4265,34 @@ dodo:
 #ifdef __WINDOWS__
 			if (I->vtmode == 2 && !I->term_xterm) {
 #endif
-			if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
+				if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
 #ifdef __WINDOWS__
-				while (r_cons_readchar_timeout (1) != -1) ;
+					while (r_cons_readchar_timeout (1) != -1) ;
 #else
-				tcflush (STDIN_FILENO, TCIFLUSH);
+					tcflush (STDIN_FILENO, TCIFLUSH);
 #endif
-			} else if (ch == 0x1b) {
-				char chrs[2];
-				int chrs_read = 1;
-				chrs[0] = r_cons_readchar ();
-				if (chrs[0] == '[') {
-					chrs[1] = r_cons_readchar ();
-					chrs_read++;
-					if (chrs[1] >= 'A' && chrs[1] <= 'D') { // arrow keys
+				} else if (ch == 0x1b) {
+					char chrs[2];
+					int chrs_read = 1;
+					chrs[0] = r_cons_readchar ();
+					if (chrs[0] == '[') {
+						chrs[1] = r_cons_readchar ();
+						chrs_read++;
+						if (chrs[1] >= 'A' && chrs[1] <= 'D') { // arrow keys
 #ifdef __WINDOWS__
-						while (r_cons_readchar_timeout (1) != -1) ;
+							while (r_cons_readchar_timeout (1) != -1) ;
 #else
-						tcflush (STDIN_FILENO, TCIFLUSH);
-						// Following seems to fix an issue where scrolling slows
-						// down to a crawl after some time mashing the up and down
-						// arrow keys
-						r_cons_set_raw (false);
-						r_cons_set_raw (true);
+							tcflush (STDIN_FILENO, TCIFLUSH);
+							// Following seems to fix an issue where scrolling slows
+							// down to a crawl after some time mashing the up and down
+							// arrow keys
+							r_cons_set_raw (false);
+							r_cons_set_raw (true);
 #endif
+						}
 					}
+					(void)r_cons_readpush (chrs, chrs_read);
 				}
-				(void)r_cons_readpush (chrs, chrs_read);
-			}
 #ifdef __WINDOWS__
 			}
 #endif

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4285,6 +4285,7 @@ dodo:
 				ch = r_cons_readchar ();
 			}
 			if (I->vtmode == 2 && !is_mintty (core->cons)) {
+				// Prevent runaway scrolling
 				if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
 					flush_stdin ();
 				} else if (ch == 0x1b) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4262,9 +4262,15 @@ dodo:
 			} else {
 				ch = r_cons_readchar ();
 			}
-#ifndef __WINDOWS__
+#ifdef __WINDOWS__
+			if (I->vtmode == 2 && !I->term_xterm) {
+#endif
 			if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
+#ifdef __WINDOWS__
+				while (r_cons_readchar_timeout (1) != -1) ;
+#else
 				tcflush (STDIN_FILENO, TCIFLUSH);
+#endif
 			} else if (ch == 0x1b) {
 				char chrs[2];
 				int chrs_read = 1;
@@ -4273,15 +4279,21 @@ dodo:
 					chrs[1] = r_cons_readchar ();
 					chrs_read++;
 					if (chrs[1] >= 'A' && chrs[1] <= 'D') { // arrow keys
+#ifdef __WINDOWS__
+						while (r_cons_readchar_timeout (1) != -1) ;
+#else
 						tcflush (STDIN_FILENO, TCIFLUSH);
 						// Following seems to fix an issue where scrolling slows
 						// down to a crawl after some time mashing the up and down
 						// arrow keys
 						r_cons_set_raw (false);
 						r_cons_set_raw (true);
+#endif
 					}
 				}
 				(void)r_cons_readpush (chrs, chrs_read);
+			}
+#ifdef __WINDOWS__
 			}
 #endif
 			if (r_cons_is_breaked()) {

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4141,6 +4141,16 @@ R_API void r_core_visual_disasm_down(RCore *core, RAsmOp *op, int *cols) {
 	}
 }
 
+#ifdef __WINDOWS__
+static bool is_mintty(RCons *cons) {
+	return cons->term_xterm;
+}
+#else
+static bool is_mintty(RCons *cons) {
+	return false;
+}
+#endif
+
 R_API int r_core_visual(RCore *core, const char *input) {
 	const char *teefile;
 	ut64 scrseek;
@@ -4262,9 +4272,7 @@ dodo:
 			} else {
 				ch = r_cons_readchar ();
 			}
-#ifdef __WINDOWS__
-			if (I->vtmode == 2 && !I->term_xterm) {
-#endif
+			if (I->vtmode == 2 && !is_mintty (core->cons)) {
 				if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
 #ifdef __WINDOWS__
 					while (r_cons_readchar_timeout (1) != -1) ;
@@ -4293,9 +4301,7 @@ dodo:
 					}
 					(void)r_cons_readpush (chrs, chrs_read);
 				}
-#ifdef __WINDOWS__
 			}
-#endif
 			if (r_cons_is_breaked()) {
 				break;
 			}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4142,13 +4142,25 @@ R_API void r_core_visual_disasm_down(RCore *core, RAsmOp *op, int *cols) {
 }
 
 #ifdef __WINDOWS__
+
 static bool is_mintty(RCons *cons) {
 	return cons->term_xterm;
 }
+
+static void flush_stdin(void) {
+	while (r_cons_readchar_timeout (1) != -1) ;
+}
+
 #else
+
 static bool is_mintty(RCons *cons) {
 	return false;
 }
+
+static void flush_stdin(void) {
+	tcflush (STDIN_FILENO, TCIFLUSH);
+}
+
 #endif
 
 R_API int r_core_visual(RCore *core, const char *input) {
@@ -4274,11 +4286,7 @@ dodo:
 			}
 			if (I->vtmode == 2 && !is_mintty (core->cons)) {
 				if (IS_PRINTABLE (ch) || ch == '\t' || ch == '\n') {
-#ifdef __WINDOWS__
-					while (r_cons_readchar_timeout (1) != -1) ;
-#else
-					tcflush (STDIN_FILENO, TCIFLUSH);
-#endif
+					flush_stdin ();
 				} else if (ch == 0x1b) {
 					char chrs[2];
 					int chrs_read = 1;
@@ -4287,13 +4295,11 @@ dodo:
 						chrs[1] = r_cons_readchar ();
 						chrs_read++;
 						if (chrs[1] >= 'A' && chrs[1] <= 'D') { // arrow keys
-#ifdef __WINDOWS__
-							while (r_cons_readchar_timeout (1) != -1) ;
-#else
-							tcflush (STDIN_FILENO, TCIFLUSH);
+							flush_stdin ();
+#ifndef __WINDOWS__
 							// Following seems to fix an issue where scrolling slows
-							// down to a crawl after some time mashing the up and down
-							// arrow keys
+							// down to a crawl for some terminals after some time
+							// mashing the up and down arrow keys
 							r_cons_set_raw (false);
 							r_cons_set_raw (true);
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr (basically 9ac00d93f98a2d4ada66cd1ce4bf9fdd9391ddbd) prevents runaway scrolling in Visual mode after mashing down hjkl or an arrow key on Windows Terminal, by clearing the stdin buffer. It is #12761, #12764 and #12823 ported over to Windows.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested with keyboard and mouse wheel with default `scr.vtmode` and the following:

- Conhost Windows 10 1903
- Windows Terminal 1.0.1401.0
- Alacritty 0.5.0-dev (e6475c6) -- apparently currently no mouse support even with `e scr.vtmode = 2`
- mintty 3.1.6

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
