### PR TITLE
Add dt needed inside dt dynamic struct

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -671,6 +671,10 @@ static bool allocate_dt_needed_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 d
 		return false;
 	}
 
+	if (!number_of_dt_needed) {
+		return true;
+	}
+
 	Elf_(Xword) *dt_needed = R_NEWS0 (Elf_(Xword), number_of_dt_needed);
 	if (!dt_needed) {
 		return false;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3751,10 +3751,7 @@ void Elf_(r_bin_elf_free)(ELFOBJ* bin) {
 	free (bin->phdr);
 	free (bin->shdr);
 	free (bin->strtab);
-
-	if (bin->dyn_info.dt_needed) {
-		free(bin->dyn_info.dt_needed);
-	}
+	free(bin->dyn_info.dt_needed);
 
 	free (bin->shstrtab);
 	free (bin->dynstr);

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -53,7 +53,6 @@
 #define BREADWORD(x, i) BREAD64 (x, i)
 #define ELF_ADDR_MAX UT64_MAX
 #define ELF_XWORD_MAX UT64_MAX
-#define ELF_WORD_FORMAT "%ld"
 #else
 #define WORDSIZE 0x4
 #define WORD_MAX UT32_MAX
@@ -61,7 +60,6 @@
 #define BREADWORD(x, i) BREAD32 (x, i)
 #define ELF_ADDR_MAX UT32_MAX
 #define ELF_XWORD_MAX UT64_MAX
-#define ELF_WORD_FORMAT "%d"
 #endif
 
 #define NUMENTRIES_ROUNDUP(sectionsize, entrysize) (((sectionsize) + (entrysize)-1) / (entrysize))
@@ -635,7 +633,7 @@ static void fill_dynamic_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_siz
 				bin->version_info[DT_VERSIONTAGIDX (d.d_tag)] = d.d_un.d_val;
 			} else {
 
-				eprintf("Dynamic tag " ELF_WORD_FORMAT " not handled\n", d.d_tag);
+				eprintf("Dynamic tag %" PFMT64d " not handled\n", (ut64) d.d_tag);
 			}
 			break;
 		}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -549,6 +549,8 @@ static void set_default_value_dynamic_info(ELFOBJ *bin) {
 	bin->dyn_info.dt_flags_1 = ELF_XWORD_MAX;
 	bin->dyn_info.dt_rpath = ELF_XWORD_MAX;
 	bin->dyn_info.dt_runpath = ELF_XWORD_MAX;
+	bin->dyn_info.dt_needed = NULL;
+	bin->dyn_info.number_of_dt_needed = 0;
 }
 
 static int init_dynamic_section(ELFOBJ *bin) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -53,6 +53,7 @@
 #define BREADWORD(x, i) BREAD64 (x, i)
 #define ELF_ADDR_MAX UT64_MAX
 #define ELF_XWORD_MAX UT64_MAX
+#define ELF_WORD_FORMAT "%ld"
 #else
 #define WORDSIZE 0x4
 #define WORD_MAX UT32_MAX
@@ -60,6 +61,7 @@
 #define BREADWORD(x, i) BREAD32 (x, i)
 #define ELF_ADDR_MAX UT32_MAX
 #define ELF_XWORD_MAX UT64_MAX
+#define ELF_WORD_FORMAT "%d"
 #endif
 
 #define NUMENTRIES_ROUNDUP(sectionsize, entrysize) (((sectionsize) + (entrysize)-1) / (entrysize))
@@ -655,6 +657,9 @@ static void fill_dynamic_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_siz
 		default:
 			if ((d.d_tag >= DT_VERSYM) && (d.d_tag <= DT_VERNEEDNUM)) {
 				bin->version_info[DT_VERSIONTAGIDX (d.d_tag)] = d.d_un.d_val;
+			} else {
+
+				eprintf("Dynamic tag " ELF_WORD_FORMAT " not handled\n", d.d_tag);
 			}
 			break;
 		}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -537,7 +537,7 @@ static size_t get_maximum_number_of_dynamic_entries(ut64 dyn_size) {
 	return dyn_size / sizeof (Elf_(Dyn));
 }
 
-static bool fill_the_dynamic_entrie(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_size, size_t pos, Elf_(Dyn) *d) {
+static bool fill_dynamic_entry(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_size, size_t pos, Elf_(Dyn) *d) {
 	ut8 sdyn[sizeof (Elf_(Dyn))] = { 0 };
 	int j = 0;
 	int len = r_buf_read_at (bin->b, dyn_phdr->p_offset + pos * sizeof (Elf_(Dyn)), sdyn, sizeof (Elf_(Dyn)));
@@ -557,7 +557,9 @@ static void fill_dynamic_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_siz
 	size_t number_of_entries = get_maximum_number_of_dynamic_entries(dyn_size);
 
 	for (i = 0; i < number_of_entries; i++) {
-		fill_the_dynamic_entrie(bin, dyn_phdr, dyn_size, i, &d);
+		if (!fill_dynamic_entry(bin, dyn_phdr, dyn_size, i, &d)) {
+			break;
+		}
 
 		switch (d.d_tag) {
 		case DT_NULL:

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2786,8 +2786,12 @@ static RBinElfReloc *populate_relocs_record(ELFOBJ *bin) {
 	size_t num_relocs = get_num_relocs_approx (bin);
 	RBinElfReloc *relocs = calloc (num_relocs + 1, sizeof (RBinElfReloc));
 
-	i = populate_relocs_record_from_dynamic (bin, relocs, i);
-	i = populate_relocs_record_from_section (bin, relocs, i);
+	// FIXME Ugly fix until https://github.com/radareorg/radare2/pull/17004
+	if (num_relocs > 0) {
+		i = populate_relocs_record_from_dynamic (bin, relocs, i);
+		i = populate_relocs_record_from_section (bin, relocs, i);
+	}
+
 	relocs[i].last = 1;
 
 	bin->g_reloc_num = i;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -530,7 +530,7 @@ static void set_default_value_dynamic_info(ELFOBJ *bin) {
 	bin->dyn_info.dt_flags_1 = ELF_XWORD_MAX;
 	bin->dyn_info.dt_rpath = ELF_XWORD_MAX;
 	bin->dyn_info.dt_runpath = ELF_XWORD_MAX;
-	bin->dyn_info.dt_needed = r_vector_new(sizeof(Elf_(Off)), NULL, NULL);
+	r_vector_init(&bin->dyn_info.dt_needed, sizeof(Elf_(Off)), NULL, NULL);
 }
 
 static size_t get_maximum_number_of_dynamic_entries(ut64 dyn_size) {
@@ -626,7 +626,7 @@ static void fill_dynamic_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_siz
 			bin->dyn_info.dt_runpath = d.d_un.d_val;
 			break;
 		case DT_NEEDED:
-			r_vector_push(bin->dyn_info.dt_needed, &d.d_un.d_val);
+			r_vector_push(&bin->dyn_info.dt_needed, &d.d_un.d_val);
 			break;
 		default:
 			if ((d.d_tag >= DT_VERSYM) && (d.d_tag <= DT_VERNEEDNUM)) {
@@ -2780,7 +2780,7 @@ RBinElfLib* Elf_(r_bin_elf_get_libs)(ELFOBJ *bin) {
 		return NULL;
 	}
 
-	r_vector_foreach(bin->dyn_info.dt_needed, it) {
+	r_vector_foreach(&bin->dyn_info.dt_needed, it) {
 		Elf_(Off) val = *it;
 
 		RBinElfLib *r = realloc (ret, (k + 1) * sizeof (RBinElfLib));
@@ -3712,7 +3712,7 @@ void Elf_(r_bin_elf_free)(ELFOBJ* bin) {
 	free (bin->phdr);
 	free (bin->shdr);
 	free (bin->strtab);
-	r_vector_free(bin->dyn_info.dt_needed);
+	r_vector_fini(&bin->dyn_info.dt_needed);
 
 	free (bin->shstrtab);
 	free (bin->dynstr);

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -632,7 +632,6 @@ static void fill_dynamic_entries(ELFOBJ *bin, Elf_(Phdr) *dyn_phdr, ut64 dyn_siz
 			if ((d.d_tag >= DT_VERSYM) && (d.d_tag <= DT_VERNEEDNUM)) {
 				bin->version_info[DT_VERSIONTAGIDX (d.d_tag)] = d.d_un.d_val;
 			} else {
-
 				eprintf("Dynamic tag %" PFMT64d " not handled\n", (ut64) d.d_tag);
 			}
 			break;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -94,6 +94,8 @@ typedef struct Elf_(r_bin_elf_dynamic_info) {
 	Elf_(Xword) dt_flags_1;
 	Elf_(Xword) dt_rpath;
 	Elf_(Xword) dt_runpath;
+	Elf_(Xword) *dt_needed;
+	size_t number_of_dt_needed;
 } RBinElfDynamicInfo;
 
 typedef struct r_bin_elf_lib_t {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -116,8 +116,6 @@ struct Elf_(r_bin_elf_obj_t) {
 	ut64 shstrtab_size;
 	char *shstrtab;
 
-	Elf_(Dyn) *dyn_buf;
-	int dyn_entries;
 	RBinElfDynamicInfo dyn_info;
 
 	ut64 version_info[DT_VERSIONTAGNUM];

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -94,8 +94,7 @@ typedef struct Elf_(r_bin_elf_dynamic_info) {
 	Elf_(Xword) dt_flags_1;
 	Elf_(Xword) dt_rpath;
 	Elf_(Xword) dt_runpath;
-	Elf_(Xword) *dt_needed;
-	size_t number_of_dt_needed;
+	RVector *dt_needed;
 } RBinElfDynamicInfo;
 
 typedef struct r_bin_elf_lib_t {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -94,7 +94,7 @@ typedef struct Elf_(r_bin_elf_dynamic_info) {
 	Elf_(Xword) dt_flags_1;
 	Elf_(Xword) dt_rpath;
 	Elf_(Xword) dt_runpath;
-	RVector *dt_needed;
+	RVector dt_needed;
 } RBinElfDynamicInfo;
 
 typedef struct r_bin_elf_lib_t {

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4027,6 +4027,18 @@ EXPECT=<<EOF
             0x08049efc      .dword 0x080485ce ; entry.fini3 ; sym.fini
             0x08049f00      .dword 0x080485e7 ; entry.fini4 ; sym.destructor
 EOF
+EXPECT_ERR=<<EOF
+Dynamic tag 12 not handled
+Dynamic tag 13 not handled
+Dynamic tag 32 not handled
+Dynamic tag 33 not handled
+Dynamic tag 25 not handled
+Dynamic tag 27 not handled
+Dynamic tag 26 not handled
+Dynamic tag 28 not handled
+Dynamic tag 1879047925 not handled
+Dynamic tag 21 not handled
+EOF
 RUN
 
 NAME=iee elf Cd (64-bit)
@@ -4050,6 +4062,14 @@ EXPECT=<<EOF
             0x0021bfb0      .qword 0x0000000000005ce0 ; entry.fini0    ; RELOC 64  ; [19] -rw- section size 8 named .fini_array
 EOF
 EXPECT_ERR=<<EOF
+Dynamic tag 12 not handled
+Dynamic tag 13 not handled
+Dynamic tag 25 not handled
+Dynamic tag 27 not handled
+Dynamic tag 26 not handled
+Dynamic tag 28 not handled
+Dynamic tag 1879047925 not handled
+Dynamic tag 21 not handled
 Cannot seek to unknown address 'section..preinit_array'
 EOF
 RUN

--- a/test/db/tools/r2r
+++ b/test/db/tools/r2r
@@ -40,5 +40,7 @@ EXPECT=<<EOF
 file     bins/elf/_Exit (42)
 EOF
 EXPECT_ERR=<<EOF
+Dynamic tag 1879047925 not handled
+Dynamic tag 21 not handled
 EOF
 RUN

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -53,6 +53,14 @@ CMDS=!rabin2 -k ${R2_FILE}
 EXPECT=<<EOF
 EOF
 EXPECT_ERR=<<EOF
+Dynamic tag 12 not handled
+Dynamic tag 13 not handled
+Dynamic tag 25 not handled
+Dynamic tag 27 not handled
+Dynamic tag 26 not handled
+Dynamic tag 28 not handled
+Dynamic tag 1879047925 not handled
+Dynamic tag 21 not handled
 Missing file.
 EOF
 RUN
@@ -893,6 +901,16 @@ NAME=rabin2 -D Unsupported
 FILE=bins/elf/libc.so.0
 CMDS=!rabin2 -D XXX LOLILOL
 EXPECT_ERR=<<EOF
+Dynamic tag 14 not handled
+Dynamic tag 12 not handled
+Dynamic tag 21 not handled
+Dynamic tag 1879048193 not handled
+Dynamic tag 1879048197 not handled
+Dynamic tag 1879048198 not handled
+Dynamic tag 1879048202 not handled
+Dynamic tag 1879048209 not handled
+Dynamic tag 1879048210 not handled
+Dynamic tag 1879048211 not handled
 Unsupported demangler
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Add the dt_needed array.
So i could remove the old dyn entries buffer.

This PR need the validation of the pr #17004

**Test plan**
One regression test fail. But for me the test is false.

The expected value for the test suite
```
-vaddr      paddr      type   name
----------------------------------
-0x00600988 0x00000988 SET_64 __gmon_start__
-0x006009a8 0x000009a8 SET_64 write
-0x006009b0 0x000009b0 SET_64 close
-0x006009b8 0x000009b8 SET_64 __libc_start_main
-0x006009c0 0x000009c0 SET_64 open
```
```
❯ readelf --relocs --use-dynamic ./test/bins/elf/analysis/dynamic-poffset

'RELA' relocation section at offset 0x0 contains 17179869188 bytes:
readelf: Warning: Virtual address 0x0 not located in any PT_LOAD segment.
readelf: Error: Reading 17179869188 bytes extends past end of file for 64-bit relocation data
```

The dynamic section is invalid.

**Closing issues**
Work on  #12732
