### PR TITLE
Fix test for ARM64 builds

### DIFF
--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -108,6 +108,8 @@ RUN
 NAME=Detect register args used only by callee
 FILE=-
 CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
 afc=ms
 wx 40534883ec20418bd8e80a00000003c34883c4205bc3cccc2bca8bc1c3
 aa


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix the test for running ARMv8 64 bit built radare2

https://travis-ci.com/github/radareorg/radare2/jobs/345486453