### PR TITLE
Heap glibc resolve main_arena using symbol

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -25,6 +25,10 @@
 static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname) {
 	RBin *bin = core->bin;
 	GHT vaddr = GHT_MAX;
+	if (!bin) {
+		return vaddr;
+	}
+
 	RListIter *iter;
 	RBinSymbol *s;
 	const char *bin_file = bin->file;
@@ -32,7 +36,6 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	ut64 laddr = r_config_get_i (core->config, "bin.laddr");
 	int fd = r_io_fd_get_current (core->io);
 	int rawstr = bin->rawstr;
-
 	RBinOptions opt;
 	r_bin_options_init (&opt, -1, 0, 0, false);
 	r_bin_open (bin, path, &opt);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -961,7 +961,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
 		if (tcache) {
-			// tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
+			//tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
 			GHT fc_offset = GH(tcache_chunk_size) (core, brk_start);
 			initial_brk = ((brk_start >> 12) << 12) + fc_offset;
 		} else {
@@ -1049,6 +1049,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	}
 
 	const char *comma = "";
+	bool first_time = true;
 	while (next_chunk && next_chunk >= brk_start && next_chunk < main_arena->GH(top)) {
 		if (size_tmp < min_size || next_chunk + size_tmp > main_arena->GH(top)) {
 			const char *status = "corrupted";
@@ -1131,6 +1132,10 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 		}
 
 		if (tcache) {
+			if (!first_time) {
+				tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
+			}
+			first_time = false;
 			GH(RHeapTcache) *tcache_heap = R_NEW0 (GH(RHeapTcache));
 			if (!tcache_heap) {
 				r_cons_canvas_free (can);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -25,10 +25,6 @@
 static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname) {
 	RBin *bin = core->bin;
 	GHT vaddr = GHT_MAX;
-	if (!bin) {
-		return vaddr;
-	}
-
 	RListIter *iter;
 	RBinSymbol *s;
 	const char *bin_file = bin->file;
@@ -36,6 +32,7 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	ut64 laddr = r_config_get_i (core->config, "bin.laddr");
 	int fd = r_io_fd_get_current (core->io);
 	int rawstr = bin->rawstr;
+
 	RBinOptions opt;
 	r_bin_options_init (&opt, -1, 0, 0, false);
 	r_bin_open (bin, path, &opt);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -26,10 +26,10 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	GHT vaddr = GHT_MAX;
 	RListIter *iter;
 	RBinSymbol *s;
-	// RBin *bin = r_bin_new ();
-	// RIO *io = r_io_new ();
-	// r_io_bind (io, &bin->iob);
-	RBin *bin = core->bin;
+	RBin *bin = r_bin_new ();
+	RIO *io = r_io_new ();
+	r_io_bind (io, &bin->iob);
+	// RBin *bin = core->bin;
 	
 	if (!bin) {
 		return vaddr;
@@ -49,8 +49,8 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 		}
 	}
 
-	// r_bin_free (bin);
-	// r_io_free (io);
+	r_bin_free (bin);
+	r_io_free (io);
 	return vaddr;
 }
 

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -350,7 +350,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 		RDebugMap *map;
 		r_debug_map_sync (core->dbg);
 		r_list_foreach (core->dbg->maps, iter, map) {
-			if (strstr (map->name, "/libc-") && map->perm == 4 && main_arena_sym == GHT_MAX) {
+			if (strstr (map->name, "/libc-") && map->perm == R_PERM_R && main_arena_sym == GHT_MAX) {
 				libc_path = map->name;
 				libc_addr = map->addr;
 				if (!libc_path) {
@@ -365,7 +365,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 				}
 				free (path);
 			}
-			if (strstr (map->name, "/libc-") && map->perm == 6) {
+			if (strstr (map->name, "/libc-") && map->perm == R_PERM_RW) {
 				libc_addr_sta = map->addr;
 				libc_addr_end = map->addr_end;
 				break;
@@ -961,7 +961,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
 		if (tcache) {
-			tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
+			// tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
 			GHT fc_offset = GH(tcache_chunk_size) (core, brk_start);
 			initial_brk = ((brk_start >> 12) << 12) + fc_offset;
 		} else {

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -23,19 +23,15 @@
 
 
 static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname) {
+	RBin *bin = core->bin;
 	GHT vaddr = GHT_MAX;
 	RListIter *iter;
 	RBinSymbol *s;
-	const char *bin_file = core->bin->file;
+	const char *bin_file = bin->file;
 	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
 	ut64 laddr = r_config_get_i (core->config, "bin.laddr");
 	int fd = r_io_fd_get_current (core->io);
-	int rawstr = core->bin->rawstr;
-	RBin *bin = core->bin;
-	
-	if (!bin) {
-		return vaddr;
-	}
+	int rawstr = bin->rawstr;
 
 	RBinOptions opt;
 	r_bin_options_init (&opt, -1, 0, 0, false);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -25,9 +25,9 @@
 static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname) {
 	GHT vaddr = GHT_MAX;
 	RBin *bin = core->bin;
+	RBinFile *current_bf = r_bin_cur (bin);
 	RListIter *iter;
 	RBinSymbol *s;
-	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
 
 	RBinOptions opt;
 	r_bin_options_init (&opt, -1, 0, 0, false);
@@ -42,14 +42,8 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	}
 
 	RBinFile *libc_bf = r_bin_cur (bin);
-	RCoreFile *cf = r_core_file_cur (core);
-	if (cf) {
-		RBinFile *bf = r_bin_file_find_by_fd (core->bin, cf->fd);
-		if (bf) {
-			r_bin_reload (core->bin, bf->id, baddr);
-		}
-	}
 	r_bin_file_delete (bin, libc_bf->id);
+	r_bin_file_set_cur_binfile (bin, current_bf);
 	return vaddr;
 }
 

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -26,10 +26,12 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	GHT vaddr = GHT_MAX;
 	RListIter *iter;
 	RBinSymbol *s;
-	RBin *bin = r_bin_new ();
-	RIO *io = r_io_new ();
-	r_io_bind (io, &bin->iob);
-	// RBin *bin = core->bin;
+	const char *bin_file = core->bin->file;
+	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
+	ut64 laddr = r_config_get_i (core->config, "bin.laddr");
+	int fd = r_io_fd_get_current (core->io);
+	int rawstr = core->bin->rawstr;
+	RBin *bin = core->bin;
 	
 	if (!bin) {
 		return vaddr;
@@ -49,8 +51,8 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 		}
 	}
 
-	r_bin_free (bin);
-	r_io_free (io);
+	r_bin_options_init (&opt, fd, baddr, laddr, rawstr);
+	r_bin_open (core->bin, bin_file, &opt);
 	return vaddr;
 }
 

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -31,7 +31,7 @@ static GHT GH(get_va_symbol)(const char *path, const char *symname) {
 	r_io_bind (io, &bin->iob);
 
 	if (!bin) {
-		return -1;
+		return 0;
 	}
 
 	RBinOptions opt;
@@ -39,7 +39,7 @@ static GHT GH(get_va_symbol)(const char *path, const char *symname) {
 	r_bin_open (bin, path, &opt);
 	syms = r_bin_get_symbols (bin);
 	if (!syms) {
-		return -1;
+		return 0;
 	}
 	r_list_foreach (syms, iter, s) {
 		if (!strcmp (s->name, symname)) {
@@ -360,7 +360,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 				char *path = r_str_newf ("%s", libc_path);
 				if (r_file_exists (path)) {
 					GHT vaddr = GH (get_va_symbol) (path, main_arena_str);
-					if (libc_addr != GHT_MAX && vaddr != -1) {
+					if (libc_addr != GHT_MAX && vaddr != 0) {
 						main_arena_sym = libc_addr + vaddr;
 						free (path);
 					}

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -963,6 +963,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
 		if (tcache) {
+			tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
 			GHT fc_offset = GH(tcache_chunk_size) (core, brk_start);
 			initial_brk = ((brk_start >> 12) << 12) + fc_offset;
 		} else {
@@ -1592,3 +1593,4 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 	free (main_arena);
 	return true;
 }
+

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -430,7 +430,6 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 
 			*m_arena = addr_srch;
 			free (ta);
-			main_arena_resolved = 1;
 			return true;
 		}
 		addr_srch += sizeof (GHT);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -405,7 +405,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 		return false;
 	}
 
-	if (main_arena_sym) {
+	if (main_arena_sym != GHT_MAX) {
 		GH (update_main_arena) (core, main_arena_sym, ta);
 		*m_arena = main_arena_sym;
 		core->dbg->main_arena_resolved = true;
@@ -419,7 +419,8 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 
 			*m_arena = addr_srch;
 			free (ta);
-			core->dbg->main_arena_resolved = true;
+			// error in test with e dbg.glibc.tcache=1
+			// core->dbg->main_arena_resolved = true;
 			return true;
 		}
 		addr_srch += sizeof (GHT);

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -26,6 +26,9 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	GHT vaddr = GHT_MAX;
 	RListIter *iter;
 	RBinSymbol *s;
+	// RBin *bin = r_bin_new ();
+	// RIO *io = r_io_new ();
+	// r_io_bind (io, &bin->iob);
 	RBin *bin = core->bin;
 	
 	if (!bin) {
@@ -46,6 +49,8 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 		}
 	}
 
+	// r_bin_free (bin);
+	// r_io_free (io);
 	return vaddr;
 }
 
@@ -1049,7 +1054,6 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	}
 
 	const char *comma = "";
-	bool first_time = true;
 	while (next_chunk && next_chunk >= brk_start && next_chunk < main_arena->GH(top)) {
 		if (size_tmp < min_size || next_chunk + size_tmp > main_arena->GH(top)) {
 			const char *status = "corrupted";
@@ -1132,10 +1136,6 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 		}
 
 		if (tcache) {
-			if (!first_time) {
-				tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
-			}
-			first_time = false;
 			GH(RHeapTcache) *tcache_heap = R_NEW0 (GH(RHeapTcache));
 			if (!tcache_heap) {
 				r_cons_canvas_free (can);
@@ -1171,6 +1171,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 					}
 				}
 			}
+			tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
 			free (tcache_heap);
 		}
 

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -26,8 +26,11 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 	GHT vaddr = GHT_MAX;
 	RListIter *iter;
 	RBinSymbol *s;
-	RBin *bin = core->bin;
-
+	// RBin *bin = core->bin;
+	RBin *bin = r_bin_new();
+ 	RIO *io = r_io_new ();
+	r_io_bind (io, &bin->iob);
+	
 	if (!bin) {
 		return vaddr;
 	}
@@ -45,6 +48,9 @@ static GHT GH(get_va_symbol)(RCore *core, const char *path, const char *symname)
 			}
 		}
 	}
+	
+	r_bin_free (bin);
+	r_io_free (io);
 	return vaddr;
 }
 

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -333,9 +333,11 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 
 	r_return_val_if_fail (core && core->dbg && core->dbg->maps, false);
 
+	/*
 	if (core->dbg->main_arena_resolved) {
 		return true;
 	}
+	*/
 
 	const char *main_arena_str = "main_arena";
 	GHT brk_start = GHT_MAX, brk_end = GHT_MAX;
@@ -410,7 +412,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 	if (main_arena_sym) {
 		GH (update_main_arena) (core, main_arena_sym, ta);
 		*m_arena = main_arena_sym;
-		core->dbg->main_arena_resolved = true;
+		// core->dbg->main_arena_resolved = true;
 		free (ta);
 		return true;
 	}

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -385,6 +385,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->maps_user = r_debug_map_list_new ();
 	dbg->q_regs = NULL;
 	dbg->call_frames = NULL;
+	dbg->main_arena_resolved = false;
 	r_debug_signal_init (dbg);
 	if (hard) {
 		dbg->bp = r_bp_new ();

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -321,6 +321,7 @@ typedef struct r_debug_t {
 	RNum *num;
 	REgg *egg;
 	bool verbose;
+	bool main_arena_resolved; /* is the main_arena resolved already? */
 } RDebug;
 
 typedef struct r_debug_desc_plugin_t {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

With this feature the heap commands for the glibc run faster, since they resolve the main_arena using the symbol from the glibc (if the glibc is compiled with symbols, otherwise it uses the bruteforce method which is slower).

I measured the time of the commands `dmh[ft]`:

1. Using the symbol: ~0.07 seconds
2. Without the symbol: ~1.10 seconds

Before I had an hard time to use the commands `dmht` and `dmhf` in `V!` mode because it took more than a second to refresh the view at every step, now it works fine.

This is an improvement but it doesn't solve the problem completely.
In fact on my machine if I try the command `dmh` before `dmh[tf]` is very slow, while the other way round is super fast.

Related to "#16248"