### PR TITLE
r2r: Use git diff on Windows

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -519,9 +519,10 @@ static RThreadFunctionRet worker_th(RThread *th) {
 }
 
 static void print_diff(const char *actual, const char *expected) {
-#define DO_DIFF !__WINDOWS__
-#if DO_DIFF
 	RDiff *d = r_diff_new ();
+#ifdef __WINDOWS__
+	d->diff_cmd = "git diff --no-index";
+#endif
 	char *uni = r_diff_buffers_to_string (d, (const ut8 *)expected, (int)strlen (expected), (const ut8 *)actual, (int)strlen (actual));
 	r_diff_free (d);
 
@@ -548,20 +549,6 @@ static void print_diff(const char *actual, const char *expected) {
 	r_list_free (lines);
 	free (uni);
 	printf ("\n");
-#else
-	RList *lines = r_str_split_duplist (expected, "\n");
-	RListIter *it;
-	char *line;
-	r_list_foreach (lines, it, line) {
-		printf (Color_RED"- %s"Color_RESET"\n", line);
-	}
-	r_list_free (lines);
-	lines = r_str_split_duplist (actual, "\n");
-	r_list_foreach (lines, it, line) {
-		printf (Color_GREEN"+ %s"Color_RESET"\n", line);
-	}
-	r_list_free (lines);
-#endif
 }
 
 static R2RProcessOutput *print_runner(const char *file, const char *args[], size_t args_size,

--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -31,6 +31,7 @@ typedef struct r_diff_t {
 	void *user;
 	bool verbose;
 	int type;
+	const char *diff_cmd;
 	int (*callback)(struct r_diff_t *diff, void *user, RDiffOp *op);
 } RDiff;
 

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -13,6 +13,7 @@ R_API RDiff *r_diff_new_from(ut64 off_a, ut64 off_b) {
 		d->user = NULL;
 		d->off_a = off_a;
 		d->off_b = off_b;
+		d->diff_cmd = "diff -u";
 	}
 	return d;
 }
@@ -149,7 +150,11 @@ R_API char *r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b,
 	char* err = NULL;
 	char* out = NULL;
 	int out_len;
-	(void)r_sys_cmd_str_full ("diff -u .a .b", NULL, &out, &out_len, &err);
+	char* diff_cmdline = r_str_newf ("%s .a .b", d->diff_cmd);
+	if (diff_cmdline) {
+		(void)r_sys_cmd_str_full (diff_cmdline, NULL, &out, &out_len, &err);
+		free (diff_cmdline);
+	}
 	r_file_rm (".a");
 	r_file_rm (".b");
 	free (err);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr patches r2r so that it uses `git diff --no-index` on Windows, for nicer diff output. I think it's safe to assume that every r2r Windows developer has git installed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

On Windows, mess up a single line of test output, run `r2r -i` on the test, and then see whether the messed-up line is highlighted.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
