### PR TITLE
Add endbr64 as a function prelude for x86-64 binaries ##anal

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -3596,6 +3596,7 @@ static RList *anal_preludes(RAnal *anal) {
 	case 64:
 		KW ("\x55\x48\x89\xe5", 4, NULL, 0);
 		KW ("\x55\x48\x8b\xec", 4, NULL, 0);
+		KW ("\xf3\x0f\x1e\xfa", 4, NULL, 0); // endbr64
 		break;
 	default:
 		r_list_free (l);

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1,4 +1,15 @@
 NAME=got switch cases
+FILE=bins/elf/fedora_32_bin_ls
+CMDS=<<EOF
+aap
+aflc
+EOF
+EXPECT=<<EOF
+439
+EOF
+RUN
+
+NAME=got switch cases
 FILE=bins/elf/game_of_thrones
 CMDS=<<EOF
 s main


### PR DESCRIPTION
Improves and aims to fix #16985 , but as long as the previous function have a tailcall optimization the the function is owned by the previosu one. Anyway with this line the binary in #16985 finds 439 functions with just `aap` (instead of 1 without this patch)

i have commited the bin in test-bins

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

endb64 instruction is used as function prelude to protect against side channel attacks. all the bins in fedora use this thing

**Test plan**

see #16985

**Closing issues**

Maybe #16985 at some point