### PR TITLE
Fix signedness issue in the DWARF line parser on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       dist: bionic
       env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1"
     # Linux with GCC on ARMv8 (64bit)
-    - if: (branch = master AND type = push) OR head_branch =~ ^arm64-*
+    - if: true
       os: linux
       name: ARM64
       arch: arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       dist: bionic
       env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1"
     # Linux with GCC on ARMv8 (64bit)
-    - if: true
+    - if: (branch = master AND type = push) OR head_branch =~ ^arm64-*
       os: linux
       name: ARM64
       arch: arm64

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -251,7 +251,7 @@ static const ut8 *r_bin_dwarf_parse_lnp_header(
 	}
 	hdr->file_names = NULL;
 	hdr->default_is_stmt = READ8 (buf);
-	hdr->line_base = READ (buf, signed char);
+	hdr->line_base = READ (buf, st8);
 	hdr->line_range = READ8 (buf);
 	hdr->opcode_base = READ8 (buf);
 

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -251,7 +251,7 @@ static const ut8 *r_bin_dwarf_parse_lnp_header(
 	}
 	hdr->file_names = NULL;
 	hdr->default_is_stmt = READ8 (buf);
-	hdr->line_base = READ (buf, signed char);
+	hdr->line_base = READ (buf, int8_t);
 	hdr->line_range = READ8 (buf);
 	hdr->opcode_base = READ8 (buf);
 

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -251,7 +251,7 @@ static const ut8 *r_bin_dwarf_parse_lnp_header(
 	}
 	hdr->file_names = NULL;
 	hdr->default_is_stmt = READ8 (buf);
-	hdr->line_base = READ (buf, char);
+	hdr->line_base = READ (buf, signed char);
 	hdr->line_range = READ8 (buf);
 	hdr->opcode_base = READ8 (buf);
 
@@ -562,12 +562,12 @@ static const ut8* r_bin_dwarf_parse_spec_opcode(
 	}
 	advance_adr = adj_opcode / hdr->line_range;
 	regs->address += advance_adr;
-	regs->line += hdr->line_base + (adj_opcode % hdr->line_range);
+	int line_increment =  hdr->line_base + (adj_opcode % hdr->line_range);
+	regs->line += line_increment;
 	if (f) {
 		fprintf (f, "  Special opcode %d: ", adj_opcode);
 		fprintf (f, "advance Address by %"PFMT64d" to 0x%"PFMT64x" and Line by %d to %"PFMT64d"\n",
-			advance_adr, regs->address, hdr->line_base +
-			(adj_opcode % hdr->line_range), regs->line);
+			advance_adr, regs->address, line_increment, regs->line);
 	}
 	if (binfile && binfile->sdb_addrinfo && hdr->file_names) {
 		int idx = regs->file -1;

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -247,11 +247,11 @@ static const ut8 *r_bin_dwarf_parse_lnp_header(
 	}
 	hdr->min_inst_len = READ8 (buf);
 	if (hdr->version >= 4) {
-		hdr->max_ops_per_inst = READ (buf, ut8);
+		hdr->max_ops_per_inst = READ8 (buf);
 	}
 	hdr->file_names = NULL;
 	hdr->default_is_stmt = READ8 (buf);
-	hdr->line_base = READ (buf, st8);
+	hdr->line_base = READ (buf, signed char);
 	hdr->line_range = READ8 (buf);
 	hdr->opcode_base = READ8 (buf);
 

--- a/libr/include/r_bin_dwarf.h
+++ b/libr/include/r_bin_dwarf.h
@@ -715,7 +715,7 @@ typedef struct {
 	ut8 min_inst_len;
 	ut8 max_ops_per_inst;
 	ut8 default_is_stmt;
-	char line_base;
+	signed char line_base;
 	ut8 line_range;
 	ut8 opcode_base;
 	ut8 *std_opcode_lengths;

--- a/libr/include/r_bin_dwarf.h
+++ b/libr/include/r_bin_dwarf.h
@@ -715,7 +715,7 @@ typedef struct {
 	ut8 min_inst_len;
 	ut8 max_ops_per_inst;
 	ut8 default_is_stmt;
-	signed char line_base;
+	st32 line_base;
 	ut8 line_range;
 	ut8 opcode_base;
 	ut8 *std_opcode_lengths;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
(tests are already there)

I am abusing PR so I can run tests on ARM to check if I found the error  for #15688 
I think it might be because signedness of `char` is implementation defined and the line_base is supposed to be -5, but instead it's 251 which is -5 on 8bit 2's complement
