### PR TITLE
Implement assembler endbr32 and endbr64 instructions for x86-32/64 ##asm

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2008-2018 - pancake, unlogic, emvivre */
+/* Copyright (C) 2008-2020 - pancake, unlogic, emvivre */
 
 #include <r_flag.h>
 #include <r_core.h>
@@ -644,6 +644,16 @@ static int opneg(RAsm *a, ut8 * data, const Opcode *op) {
         return l;
     }
     return -1;
+}
+
+static int endbr64(RAsm *a, ut8 * data, const Opcode *op) {
+	memcpy (data, "\xf3\x0f\x1e\xfa", 4);
+	return 4;
+}
+
+static int endbr32(RAsm *a, ut8 * data, const Opcode *op) {
+	memcpy (data, "\xf3\x0f\x1e\xfb", 4);
+	return 4;
 }
 
 static int opnot(RAsm *a, ut8 * data, const Opcode *op) {
@@ -4268,6 +4278,8 @@ LookupTable oplookup[] = {
 	{"dec", 0, &opdec, 0},
 	{"div", 0, &opdiv, 0},
 	{"emms", 0, NULL, 0x0f77, 2},
+	{"endbr32", 0, endbr32, 0},
+	{"endbr64", 0, endbr64, 0},
 	{"f2xm1", 0, NULL, 0xd9f0, 2},
 	{"fabs", 0, NULL, 0xd9e1, 2},
 	{"fadd", 0, &opfadd, 0},

--- a/test/db/asm/x86_32
+++ b/test/db/asm/x86_32
@@ -134,6 +134,7 @@ d "div byte [eax]" f630
 d "divsd xmm0, qword [eax]" f20f5e00
 d "divss xmm0, dword [eax]" f30f5e00
 d "emms" 0f77
+ad "endbr32" f30f1efb
 d "femms" 0f0e
 d "fxrstor [eax]" 0fae08
 d "fxsave [eax]" 0fae00

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -960,6 +960,7 @@ a "bswap rax" 480fc8
 a "bswap r15" 490fcf
 a "bswap eax" 0fc8
 a "bswap r15d" 410fcf
+ad "endbr64" f30f1efa
 ad "xchg eax, r8d" 4190
 a "xchg r8d, eax" 4190
 ad "xchg rax, rdx" 4892


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

endbr64 and endbr32 instructions were not supported by the assembler

**Test plan**

32 and 64bit assembly and disassembly of those instructions work as expected in the testsuite

**Closing issues**

none