### PR TITLE
Fix objc rodata mask

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -6,6 +6,14 @@
 #define RO_META (1 << 0)
 #define MAX_CLASS_NAME_LEN 256
 
+#ifdef R_BIN_MACH064
+#define FAST_DATA_MASK 0x00007ffffffffff8UL
+#else
+#define FAST_DATA_MASK 0xfffffffcUL
+#endif
+
+#define RO_DATA_PTR(x) ((x) & FAST_DATA_MASK)
+
 struct MACH0_(SMethodList) {
 	ut32 entsize;
 	ut32 count;
@@ -1163,7 +1171,7 @@ void MACH0_(get_class_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, bool dupe, 
 			}
 		}
 	}
-	get_class_ro_t (c.data & ~0x3, bf, &is_meta_class, klass);
+	get_class_ro_t (RO_DATA_PTR (c.data), bf, &is_meta_class, klass);
 
 #if SWIFT_SUPPORT
 	if (q (c.data + n_value) & 7) {
@@ -1486,8 +1494,7 @@ void MACH0_(get_category_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, RSkipLis
 			R_FREE (category_name);
 			return;
 		}
-
-		mach0_ut name_field = ro_data + 3 * 4 + ptr_size;
+		mach0_ut name_field = RO_DATA_PTR (ro_data) + 3 * 4 + ptr_size;
 #ifdef R_BIN_MACH064
 		name_field += 4;
 #endif

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -53,3 +53,12 @@ EXPECT=<<EOF
 4
 EOF
 RUN
+
+NAME=objc categories (swift)
+FILE=bins/mach0/TestSwiftObjc
+CMDS=ic~ class
+EXPECT=<<EOF
+0x100003078 [0x100001ad0 - 0x100001ad0]      0 class 0 TestSwiftObjc.ThisIsASwiftClass(TEST)
+0x1000031e8 [0x100001d80 - 0x100001d80]      0 class 0 TestSwiftObjc.ThisIsASwiftClass :: NSObject
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Flags are encoded in the lower / upper bits of the pointer to objc class data. This strips those bits from the pointer before using it.

**Test plan**

- open a binary with objective-c categories on swift classes
- run `ic` and check the base class name of the category, if it's `(null)` is wrong

```diff
 [0x100001b00]> ic
-0x100003078 [0x100001ad0 - 0x100001ad0]      0 class 0 (null)(TEST)
+0x100003078 [0x100001ad0 - 0x100001ad0]      0 class 0 TestSwiftObjc.ThisIsASwiftClass(TEST)
 0x100001ad0 method 0      testObjc
 0x1000031e8 [0x100001d80 - 0x100001d80]      0 class 0 TestSwiftObjc.ThisIsASwiftClass :: NSObject
 0x100001d80 method 0      init
```

Added an r2r test which does just that, depends on this test bin: https://github.com/radareorg/radare2-testbins/pull/25

