### PR TITLE
Add missing switch-case in RAnal.wasm to fix a warning

### DIFF
--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2017-2019 - xvilka, deroad */
+/* radare2 - LGPL - Copyright 2017-2020 - xvilka, deroad */
 
 #include <string.h>
 #include <r_types.h>
@@ -81,12 +81,15 @@ static int wasm_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len
 	op->sign = true;
 	op->type = R_ANAL_OP_TYPE_UNK;
 	switch (wop.type) {
-		case WASM_TYPE_OP_CORE:
-			op->id = wop.op.core;
-			break;
-		case WASM_TYPE_OP_ATOMIC:
-			op->id = (0xfe << 8) | wop.op.atomic;
-			break;
+	case WASM_TYPE_OP_CORE:
+		op->id = wop.op.core;
+		break;
+	case WASM_TYPE_OP_ATOMIC:
+		op->id = (0xfe << 8) | wop.op.atomic;
+		break;
+	case WASM_TYPE_OP_SIMD:
+		op->id = 0xfd;
+		break;
 	}
 
 	if (!wop.txt || !strncmp (wop.txt, "invalid", 7)) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fixes the following compilation warning:

```
/Users/pancake/prg/radare2/libr/..//libr/anal/p/anal_wasm.c:83:10: warning: enumeration value 'WASM_TYPE_OP_SIMD' not handled in switch [-Wswitch]
        switch (wop.type) {
                ^
/Users/pancake/prg/radare2/libr/..//libr/anal/p/anal_wasm.c:83:10: note: add missing switch cases
        switch (wop.type) {
                ^
```

**Test plan**

run make

**Closing issues**

nobody noticed
