### PR TITLE
Fix #17023 - Use strrchr when 2nd argument of r_str_rchr is NULL

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -649,7 +649,7 @@ R_API const char *r_str_rstr(const char *base, const char *p) {
 R_API const char *r_str_rchr(const char *base, const char *p, int ch) {
 	r_return_val_if_fail (base, NULL);
 	if (!p) {
-		p = base + strlen (base);
+		return strrchr (base, ch);
 	}
 	for (; p >= base; p--) {
 		if (ch == *p) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

strrchr seems to be available in all the platforms we care of, for performance reasons we should only use it when we dont know the length of the string

**Test plan**

some unit tests will be added for this API

**Closing issues**
#17009 17023