### PR TITLE
Check node_string length before subtracting 2 from strlen

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5129,6 +5129,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(redirect_command) {
 DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_command) {
 	// TODO: traverse command tree to print help
 	// FIXME: once we have a command tree, this special handling should be removed
+	size_t node_str_len = strlen (node_string);
 	if (!strcmp (node_string, "@?")) {
 		r_core_cmd_help (state->core, help_msg_at);
 	} else if (!strcmp (node_string, "@@?")) {
@@ -5141,16 +5142,15 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_command) {
 		r_cons_grep_help ();
 	} else if (!strcmp (node_string, ">?")) {
 		r_core_cmd_help (state->core, help_msg_greater_sign);
-	} else if (!strcmp (node_string + strlen (node_string) - 2, "?*")) {
-		size_t node_len = strlen (node_string);
+	} else if (node_str_len >= 2 && !strcmp (node_string + node_str_len - 2, "?*")) {
 		int detail = 0;
-		if (node_len > 3 && node_string[node_len - 3] == '?') {
+		if (node_str_len > 3 && node_string[node_str_len - 3] == '?') {
 			detail++;
-			if (node_len > 4 && node_string[node_len - 4] == '?') {
+			if (node_str_len > 4 && node_string[node_str_len - 4] == '?') {
 				detail++;
 			}
 		}
-		node_string[node_len - 2 - detail] = '\0';
+		node_string[node_str_len - 2 - detail] = '\0';
 		recursive_help (state->core, detail, node_string);
 		return R_CMD_STATUS_OK;
 	} else {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When running `?` I got this:
```
==659891==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200009fc0f at pc 0x7f02ecef3db5 bp 0x7ffd7c27fe20 sp 0x7ffd7c27f5c8                                                                                                                                      
READ of size 1 at 0x60200009fc0f thread T0                                                     
    #0 0x7f02ecef3db4  (/lib64/libasan.so.5+0xd6db4)                                           
    #1 0x7f02ea8f3d09 in handle_ts_help_command_internal ../libr/core/cmd.c:5144               
    #2 0x7f02ea8f3a21 in handle_ts_help_command ../libr/core/cmd.c:5129                                                                                                                       
    #3 0x7f02ea90768d in handle_ts_command ../libr/core/cmd.c:6496                             
    #4 0x7f02ea908110 in handle_ts_commands_internal ../libr/core/cmd.c:6551                   
    #5 0x7f02ea9079d7 in handle_ts_commands ../libr/core/cmd.c:6516                            
    #6 0x7f02ea908c3b in core_cmd_tsr2cmd ../libr/core/cmd.c:6642                                                                                                                                                                             
    #7 0x7f02ea9090fe in r_core_cmd ../libr/core/cmd.c:6685                                                                                                                                   
    #8 0x7f02ea92cca0 in r_core_prompt_exec ../libr/core/core.c:2995                           
    #9 0x7f02ea92b789 in r_core_prompt_loop ../libr/core/core.c:2846                           
    #10 0x7f02ecadb60d in r_main_radare2 ../libr/main/radare2.c:1365                                                                                                                          
    #11 0x401522 in main ../binr/radare2/radare2.c:96                                          
    #12 0x7f02ec90f1a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)                         
    #13 0x40115d in _start (/home/rschiron/projects/radare2/build/binr/radare2/radare2+0x40115d)                                                                                              
                                                                                               
0x60200009fc0f is located 1 bytes to the left of 2-byte region [0x60200009fc10,0x60200009fc12)                         
allocated by thread T0 here:                                                                                           
    #0 0x7f02ecf2af16 in __interceptor_calloc (/lib64/libasan.so.5+0x10df16)                                           
    #1 0x7f02ecc69f12 in r_str_newf ../libr/util/str.c:728                                                             
    #2 0x7f02ea8ee894 in ts_node_sub_string ../libr/core/cmd.c:4585                                                    
    #3 0x7f02ea8f39c0 in handle_ts_help_command ../libr/core/cmd.c:5129                                                
    #4 0x7f02ea90768d in handle_ts_command ../libr/core/cmd.c:6496                                                     
    #5 0x7f02ea908110 in handle_ts_commands_internal ../libr/core/cmd.c:6551                                           
    #6 0x7f02ea9079d7 in handle_ts_commands ../libr/core/cmd.c:6516                                                    
    #7 0x7f02ea908c3b in core_cmd_tsr2cmd ../libr/core/cmd.c:6642                                                                       
    #8 0x7f02ea9090fe in r_core_cmd ../libr/core/cmd.c:6685                                                                             
    #9 0x7f02ea92cca0 in r_core_prompt_exec ../libr/core/core.c:2995                                                                    
    #10 0x7f02ea92b789 in r_core_prompt_loop ../libr/core/core.c:2846                                                                   
    #11 0x7f02ecadb60d in r_main_radare2 ../libr/main/radare2.c:1365                                                                    
    #12 0x401522 in main ../binr/radare2/radare2.c:96                                                                                   
    #13 0x7f02ec90f1a2 in __libc_start_main (/lib64/libc.so.6+0x271a2)                                                                  
```