### PR TITLE
Fix a fatmach0 test under aarch64 ##test

### DIFF
--- a/test/db/formats/mach0/mach0
+++ b/test/db/formats/mach0/mach0
@@ -136,10 +136,8 @@ RUN
 
 NAME=mach0 headers2
 FILE=bins/mach0/ired
-CMDS=<<EOF
-oa arm 32 bins/mach0/ired
-iH
-EOF
+ARGS=-aarm -b32
+CMDS=iH
 EXPECT=<<EOF
 pf.mach0_header @ 0x00004000
 0x00004000  Magic       0xfeedface

--- a/test/db/formats/mach0/mach0
+++ b/test/db/formats/mach0/mach0
@@ -136,7 +136,10 @@ RUN
 
 NAME=mach0 headers2
 FILE=bins/mach0/ired
-CMDS=iH
+CMDS=<<EOF
+oa arm 32 bins/mach0/ired
+iH
+EOF
 EXPECT=<<EOF
 pf.mach0_header @ 0x00004000
 0x00004000  Magic       0xfeedface


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

When the host where r2 runs is aarch64, the 64 bit part of the binary is selected by default and the test fails, so I select the arch/bits explicitly.
Since I never worked with fatmach0 stuff I am not entirely sure whether switching with `oa` is the correct approach here so please review.

**Test plan**

Run the tests on a 64 bit arm system.