### PR TITLE
r2r: Don't trim whitespace from diff lines

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -231,7 +231,7 @@ R_API void r2r_asm_test_free(R2RAsmTest *test) {
 }
 
 static bool parse_asm_path(const char *path, RStrConstPool *strpool, const char **arch_out, const char **cpuout, int *bitsout) {
-	RList *file_tokens = r_str_split_duplist (path, R_SYS_DIR);
+	RList *file_tokens = r_str_split_duplist (path, R_SYS_DIR, true);
 	if (!file_tokens || r_list_empty (file_tokens)) {
 		r_list_free (file_tokens);
 		return false;

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -526,7 +526,7 @@ static void print_diff(const char *actual, const char *expected) {
 	char *uni = r_diff_buffers_to_string (d, (const ut8 *)expected, (int)strlen (expected), (const ut8 *)actual, (int)strlen (actual));
 	r_diff_free (d);
 
-	RList *lines = r_str_split_duplist (uni, "\n");
+	RList *lines = r_str_split_duplist (uni, "\n", false);
 	RListIter *it;
 	char *line;
 	bool header_found = false;

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -919,8 +919,8 @@ static R2RProcessOutput *run_r2_test(R2RRunConfig *config, const char *cmds, RLi
 }
 
 R_API R2RProcessOutput *r2r_run_cmd_test(R2RRunConfig *config, R2RCmdTest *test, R2RCmdRunner runner, void *user) {
-	RList *extra_args = test->args.value ? r_str_split_duplist (test->args.value, " ") : NULL;
-	RList *files = r_str_split_duplist (test->file.value, "\n");
+	RList *extra_args = test->args.value ? r_str_split_duplist (test->args.value, " ", true) : NULL;
+	RList *files = r_str_split_duplist (test->file.value, "\n", true);
 	RListIter *it;
 	RListIter *tmpit;
 	char *token;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2352,7 +2352,7 @@ next:
 
 static char *build_hash_string(int mode, const char *chksum, ut8 *data, ut32 datalen) {
 	char *chkstr = NULL, *aux, *ret = NULL;
-	RList *hashlist = r_str_split_duplist (chksum, ",");
+	RList *hashlist = r_str_split_duplist (chksum, ",", true);
 	RListIter *iter;
 	char *hashname;
 	r_list_foreach (hashlist, iter, hashname) {
@@ -2382,7 +2382,7 @@ static char *filter_hash_string(const char *chksum) {
 
 	char *aux, *ret = NULL;
 	bool isFirst = true;
-	RList *hashlist = r_str_split_duplist (chksum, ",");
+	RList *hashlist = r_str_split_duplist (chksum, ",", true);
 	RListIter *iter;
 	char *hashname;
 	r_list_foreach (hashlist, iter, hashname) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2554,7 +2554,7 @@ static bool cb_dirpfx(RCore *core, RConfigNode *node) {
 static bool cb_anal_roregs(RCore *core, RConfigNode *node) {
 	if (core && core->anal && core->anal->reg) {
 		r_list_free (core->anal->reg->roregs);
-		core->anal->reg->roregs = r_str_split_duplist (node->value, ",");
+		core->anal->reg->roregs = r_str_split_duplist (node->value, ",", true);
 	}
 	return true;
 }

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -53,7 +53,7 @@ R_API const char *r_str_firstbut(const char *s, char ch, const char *but);
 R_API const char *r_str_lastbut(const char *s, char ch, const char *but);
 R_API int r_str_split(char *str, char ch);
 R_API RList *r_str_split_list(char *str, const char *c, int n);
-R_API RList *r_str_split_duplist(const char *str, const char *c);
+R_API RList *r_str_split_duplist(const char *str, const char *c, bool trim);
 R_API int *r_str_split_lines(char *str, int *count);
 R_API char* r_str_replace(char *str, const char *key, const char *val, int g);
 R_API char *r_str_replace_icase(char *str, const char *key, const char *val, int g, int keep_case);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3086,7 +3086,7 @@ R_API RList *r_str_split_list(char *str, const char *c, int n)  {
 	return lst;
 }
 
-R_API RList *r_str_split_duplist(const char *_str, const char *c) {
+R_API RList *r_str_split_duplist(const char *_str, const char *c, bool trim) {
 	r_return_val_if_fail (_str && c, NULL);
 	RList *lst = r_list_newf (free);
 	char *str = strdup (_str);
@@ -3098,7 +3098,9 @@ R_API RList *r_str_split_duplist(const char *_str, const char *c) {
 			*next = '\0';
 			next += clen;
 		}
-		r_str_trim (aux);
+		if (trim) {
+			r_str_trim (aux);
+		}
 		r_list_append (lst, strdup (aux));
 		aux = next;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Before:

![no_trim_before](https://user-images.githubusercontent.com/12002672/84517039-4278b180-ad01-11ea-90dd-f1b39bc62ade.PNG)

After:

![no_trim_after](https://user-images.githubusercontent.com/12002672/84517068-515f6400-ad01-11ea-9db5-db4d5c81ebd4.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Eyeball diff output for tests that have leading space.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
