### PR TITLE
Bugfix: Zignatures corrupt JSON output in types

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -1493,6 +1493,10 @@ static void print_function_args_json(RAnal *a, PJ *pj, char *arg_type) {
 }
 
 static void print_type_json(RAnal *a, char *type, PJ *pj, size_t pos) {
+	if (pos == 0) {
+		return;
+	}
+
 	char *str_type = strchr (type, '=');
 
 	if (str_type == NULL) {
@@ -1502,28 +1506,17 @@ static void print_type_json(RAnal *a, char *type, PJ *pj, size_t pos) {
 	*str_type = '\0';
 	++str_type;
 
-	if (pos == 0) { // ret value
-		pj_o (pj);
-		pj_ks (pj, "name", type);
-		pj_ks (pj, "type", str_type);
-		pj_end (pj);
-	} else if (pos >= 2) {
-		print_function_args_json (a, pj, str_type);
-	}
+	print_function_args_json (a, pj, str_type);
 }
 
 static void print_list_separator(RAnal *a, RSignItem *it, PJ *pj, int format, int pos) {
-	if (pos > 0) {
-		if (format == '*') {
-			a->cb_printf (" ");
-		} else if (format == 'j') {
-			if (pos == 2) {
-				pj_o (pj);
-				pj_ka (pj, "args");
-			}
-		} else {
-			a->cb_printf (", ");
-		}
+	if (pos == 0 || format == 'j') {
+		return;
+	}
+	if (format == '*') {
+		a->cb_printf (" ");
+	} else {
+		a->cb_printf (", ");
 	}
 }
 
@@ -1543,11 +1536,6 @@ static void print_list_type_body(RAnal *a, RSignItem *it, PJ *pj, int format) {
 			a->cb_printf ("%s", type);
 		}
 		i++;
-	}
-
-	if (format == 'j') {
-		pj_end (pj);
-		pj_end (pj);
 	}
 }
 

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1106,3 +1106,15 @@ EXPECT=<<EOF
 4
 EOF
 RUN
+
+NAME=zj producing valid types
+FILE=bins/elf/static-glibc-2.27
+CMDS=<<EOF
+aaa
+zaf fcn.00484d40 fcn.00484d40
+zj
+EOF
+EXPECT=<<EOF
+[{"name":"fcn.00484d40","bytes":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c40848","mask":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c40848","graph":{"cc":4,"nbbs":5,"edges":5,"ebbs":2,"bbsum":72},"addr":4738368,"refs":[],"xrefs":[],"vars":["r110"],"types":[{"name":"arg1","type":"int64_t"}],"hash":{"bbhash":"8ff8a5c7f84179483b764fbb18dc4c44f39da6527a0a16485c7ae519f00e687f"}}]
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In the function `print_list_type_body` two new JSON contexts are created if there are 2 or more items to print (see function `print_list_separator`). However, before return these two contexts are closed anyways, without respecting whether they were actually created, resulting in corrupt JSON under some circumstances.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
`rasign2 -aj /bin/ls | jq .`

*Before patch*
```
Error: Parse error on line 1:
...args","type":"1"}]}],"hash":{"bbhash":"f
-----------------------^
Expecting 'EOF', got ','
```
*After patch*
```
rasign2 -aj ls | jq . ; echo $?`
...
0
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
