### PR TITLE
Fix crash in PE when resolving corrupted ordinal exports ##bin

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3087,6 +3087,8 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 	data_dir_export = &bin->data_directory[PE_IMAGE_DIRECTORY_ENTRY_EXPORT];
 	export_dir_rva = data_dir_export->VirtualAddress;
 	export_dir_size = data_dir_export->Size;
+	PE_VWord *func_rvas = NULL;
+	PE_Word *ordinals = NULL;
 	if (bin->export_directory) {
 		if (bin->export_directory->NumberOfFunctions + 1 <
 		bin->export_directory->NumberOfFunctions) {
@@ -3113,8 +3115,8 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 
 		const size_t names_sz = bin->export_directory->NumberOfNames * sizeof (PE_Word);
 		const size_t funcs_sz = bin->export_directory->NumberOfFunctions * sizeof (PE_VWord);
-		PE_Word *ordinals = malloc (names_sz);
-		PE_VWord *func_rvas = malloc (funcs_sz);
+		ordinals = malloc (names_sz);
+		func_rvas = malloc (funcs_sz);
 		if (!ordinals || !func_rvas) {
 			goto beach;
 		}

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -56,13 +56,10 @@ static inline int is_arm(struct PE_(r_bin_pe_obj_t)* bin) {
 }
 
 struct r_bin_pe_addr_t *PE_(check_msvcseh) (struct PE_(r_bin_pe_obj_t) *bin) {
-	struct r_bin_pe_addr_t* entry;
+	r_return_val_if_fail (bin && bin->b, NULL);
 	ut8 b[512];
 	int n = 0;
-	if (!bin || !bin->b) {
-		return 0LL;
-	}
-	entry = PE_(r_bin_pe_get_entrypoint) (bin);
+	struct r_bin_pe_addr_t* entry = PE_(r_bin_pe_get_entrypoint) (bin);
 	ZERO_FILL (b);
 	if (r_buf_read_at (bin->b, entry->paddr, b, sizeof (b)) < 0) {
 		bprintf ("Warning: Cannot read entry at 0x%08"PFMT64x "\n", entry->paddr);
@@ -3073,6 +3070,7 @@ struct r_bin_pe_addr_t* PE_(r_bin_pe_get_entrypoint)(struct PE_(r_bin_pe_obj_t)*
 }
 
 struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* bin) {
+	r_return_val_if_fail (bin, NULL);
 	struct r_bin_pe_export_t* exp, * exports = NULL;
 	PE_Word function_ordinal;
 	PE_VWord functions_paddr, names_paddr, ordinals_paddr, function_rva, name_vaddr, name_paddr;
@@ -3083,7 +3081,7 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 	int n,i, export_dir_size;
 	st64 exports_sz = 0;
 
-	if (!bin || !bin->data_directory) {
+	if (!bin->data_directory) {
 		return NULL;
 	}
 	data_dir_export = &bin->data_directory[PE_IMAGE_DIRECTORY_ENTRY_EXPORT];
@@ -3123,19 +3121,32 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 			free (func_rvas);
 			return NULL;
 		}
-		r_buf_read_at (bin->b, ordinals_paddr, (ut8 *)ordinals, names_sz);
-		r_buf_read_at (bin->b, functions_paddr, (ut8 *)func_rvas, funcs_sz);
+		int r = r_buf_read_at (bin->b, ordinals_paddr, (ut8 *)ordinals, names_sz);
+		if (r != names_sz) {
+			free (exports);
+			free (ordinals);
+			free (func_rvas);
+			return NULL;
+		}
+		int s = r_buf_read_at (bin->b, functions_paddr, (ut8 *)func_rvas, funcs_sz);
+		if (s != names_sz) {
+			free (exports);
+			free (ordinals);
+			free (func_rvas);
+			return NULL;
+		}
 		for (i = 0; i < bin->export_directory->NumberOfFunctions; i++) {
 			// get vaddr from AddressOfFunctions array
 			function_rva = r_read_at_ble32 ((ut8 *)func_rvas, i * sizeof (PE_VWord), bin->endian);
 			// have exports by name?
-			if (bin->export_directory->NumberOfNames != 0) {
+			if (bin->export_directory->NumberOfNames > 0) {
 				// search for value of i into AddressOfOrdinals
 				name_vaddr = 0;
 				for (n = 0; n < bin->export_directory->NumberOfNames; n++) {
-					function_ordinal = r_read_at_ble16 ((ut8 *)ordinals, n * sizeof (PE_Word), bin->endian);
+					PE_Word fo = r_read_at_ble16 ((ut8 *)ordinals, n * sizeof (PE_Word), bin->endian);
 					// if exist this index into AddressOfOrdinals
-					if (i == function_ordinal) {
+					if (i == fo) {
+						function_ordinal = fo;
 						// get the VA of export name  from AddressOfNames
 						r_buf_read_at (bin->b, names_paddr + n * sizeof (PE_VWord), (ut8*) &name_vaddr, sizeof (PE_VWord));
 						break;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3116,24 +3116,15 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 		PE_Word *ordinals = malloc (names_sz);
 		PE_VWord *func_rvas = malloc (funcs_sz);
 		if (!ordinals || !func_rvas) {
-			free (exports);
-			free (ordinals);
-			free (func_rvas);
-			return NULL;
+			goto beach;
 		}
 		int r = r_buf_read_at (bin->b, ordinals_paddr, (ut8 *)ordinals, names_sz);
 		if (r != names_sz) {
-			free (exports);
-			free (ordinals);
-			free (func_rvas);
-			return NULL;
+			goto beach;
 		}
-		int s = r_buf_read_at (bin->b, functions_paddr, (ut8 *)func_rvas, funcs_sz);
-		if (s != names_sz) {
-			free (exports);
-			free (ordinals);
-			free (func_rvas);
-			return NULL;
+		r = r_buf_read_at (bin->b, functions_paddr, (ut8 *)func_rvas, funcs_sz);
+		if (r != names_sz) {
+			goto beach;
 		}
 		for (i = 0; i < bin->export_directory->NumberOfFunctions; i++) {
 			// get vaddr from AddressOfFunctions array
@@ -3200,6 +3191,11 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 		exports = exp;
 	}
 	return exports;
+beach:
+	free (exports);
+	free (ordinals);
+	free (func_rvas);
+	return NULL;
 }
 
 static void free_rsdr_hdr(SCV_RSDS_HEADER* rsds_hdr) {

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3125,7 +3125,7 @@ struct r_bin_pe_export_t* PE_(r_bin_pe_get_exports)(struct PE_(r_bin_pe_obj_t)* 
 			goto beach;
 		}
 		r = r_buf_read_at (bin->b, functions_paddr, (ut8 *)func_rvas, funcs_sz);
-		if (r != names_sz) {
+		if (r != funcs_sz) {
 			goto beach;
 		}
 		for (i = 0; i < bin->export_directory->NumberOfFunctions; i++) {


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Found by clusterfuzz

**Test plan**

merge the PR in r2bins and open the file

```
/Users/pancake/prg/radare2/libr/..//libr/bin/p/../format/pe/pe.c:3135:60: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/pancake/prg/radare2/libr/..//libr/bin/p/../format/pe/pe.c:3135:60 in
/Users/pancake/prg/radare2/libr/include/r_endian.h:150:33: runtime error: addition of unsigned offset to 0x00012041d800 overflowed to 0x00002041d800
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/pancake/prg/radare2/libr/include/r_endian.h:150:33 in
AddressSanitizer:DEADLYSIGNAL
=================================================================
==49267==ERROR: AddressSanitizer: SEGV on unknown address 0x00002041d801 (pc 0x0001107a3876 bp 0x7ffee4496e60 sp 0x7ffee4496e00 T0)
==49267==The signal is caused by a READ memory access.
    #0 0x1107a3875 in r_read_le16 r_endian.h
    #1 0x1107bd3b2 in r_read_at_le16 r_endian.h:151
    #2 0x11078637f in r_read_at_ble16 r_endian.h:326
    #3 0x110784061 in Pe32_r_bin_pe_get_exports pe.c:3136
    #4 0x110743f44 in symbols bin_pe.inc:204
    #5 0x1101bdb95 in r_bin_object_set_items bobj.c:329
    #6 0x1101b98e5 in r_bin_object_new bobj.c:174
    #7 0x11019d7e5 in r_bin_file_new_from_buffer bfile.c:524
    #8 0x1101465d4 in r_bin_open_buf bin.c:286
    #9 0x110143f63 in r_bin_open_io bin.c:346
    #10 0x111941367 in r_core_file_do_load_for_io_plugin cfile.c:432
    #11 0x11193378f in r_core_bin_load cfile.c:643
    #12 0x1166b9ecb in r_main_radare2 radare2.c:1051
    #13 0x10b7644a5 in main (r2:x86_64+0x1000014a5)
    #14 0x7fff719b1cc8 in start (libdyld.dylib:x86_64+0x1acc8)

==49267==Register values:
rax = 0x000000002041d801  rbx = 0x00007ffee4497320  rcx = 0x0000100000000000  rdx = 0x000000002041d800
rdi = 0x000000002041d801  rsi = 0x0000000000000001  rbp = 0x00007ffee4496e60  rsp = 0x00007ffee4496e00
 r8 = 0x0000000116958400   r9 = 0x00007ffee4496290  r10 = 0x0000000000000000  r11 = 0x0000000000000206
r12 = 0x0000000000000001  r13 = 0x0000000000000001  r14 = 0x0000000000000001  r15 = 0x0000000000000001
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV r_endian.h in r_read_le16
==49267==ABORTING
Abort trap: 6
```

**Closing issues**

one from clusterfuzz-land