### PR TITLE
Fix ~300 warnings in the pyc disasembler

### DIFF
--- a/libr/asm/arch/pyc/opcode.c
+++ b/libr/asm/arch/pyc/opcode.c
@@ -203,7 +203,7 @@ void add_arg_fmt(pyc_opcodes *ret, char *op_name, const char *(*formatter) (ut32
 	r_list_append (ret->opcode_arg_fmt, fmt);
 }
 
-void (def_op)(struct op_parameter par) {
+void (def_opN)(struct op_parameter par) {
 	free (par.op_obj[par.op_code].op_name);
 	par.op_obj[par.op_code].op_name = strdup (par.op_name);
 	par.op_obj[par.op_code].op_code = par.op_code;
@@ -214,22 +214,22 @@ void (def_op)(struct op_parameter par) {
 	}
 }
 
-void (name_op)(struct op_parameter par) {
+void (name_opN)(struct op_parameter par) {
 	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
 	par.op_obj[par.op_code].type |= HASNAME;
 }
 
-void (local_op)(struct op_parameter par) {
+void (local_opN)(struct op_parameter par) {
 	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
 	par.op_obj[par.op_code].type |= HASLOCAL;
 }
 
-void (free_op)(struct op_parameter par) {
+void (free_opN)(struct op_parameter par) {
 	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
 	par.op_obj[par.op_code].type |= HASFREE;
 }
 
-void (store_op)(struct op_parameter par) {
+void (store_opN)(struct op_parameter par) {
 	switch (par.func) {
 	case NAME_OP:
 		name_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
@@ -255,7 +255,7 @@ void (varargs_op)(struct op_parameter par) {
 	par.op_obj[par.op_code].type |= HASVARGS;
 }
 
-void (const_op)(struct op_parameter par) {
+void (const_opN)(struct op_parameter par) {
 	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push);
 	par.op_obj[par.op_code].type |= HASCONST;
 }
@@ -265,16 +265,16 @@ void (compare_op)(struct op_parameter par) {
 	par.op_obj[par.op_code].type |= HASCOMPARE;
 }
 
-void (jabs_op)(struct op_parameter par) {
-	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push, .fallthrough = par.fallthrough);
+void (jabs_opN)(struct op_parameter par) {
+	def_op00 (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push, .fallthrough = par.fallthrough);
 	par.op_obj[par.op_code].type |= HASJABS;
 	if (par.conditional) {
 		par.op_obj[par.op_code].type |= HASCONDITION;
 	}
 }
 
-void (jrel_op)(struct op_parameter par) {
-	def_op (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push, .fallthrough = par.fallthrough);
+void (jrel_opN)(struct op_parameter par) {
+	def_op00 (.op_obj = par.op_obj, .op_name = par.op_name, .op_code = par.op_code, .pop = par.pop, .push = par.push, .fallthrough = par.fallthrough);
 	par.op_obj[par.op_code].type |= HASJREL;
 	if (par.conditional) {
 		par.op_obj[par.op_code].type |= HASCONDITION;

--- a/libr/asm/arch/pyc/opcode.h
+++ b/libr/asm/arch/pyc/opcode.h
@@ -122,37 +122,52 @@ struct op_parameter {
 	bool fallthrough;
 };
 
-#define def_op(...) def_op((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
-void (def_op)(struct op_parameter par);
+#define def_op(...) def_opN((struct op_parameter){ .fallthrough = true, __VA_ARGS__ })
+#define def_op0(...) def_opN((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
+#define def_op00(...) def_opN((struct op_parameter){ __VA_ARGS__ })
+void (def_opN)(struct op_parameter par);
 
-#define name_op(...) name_op((struct op_parameter){ .pop = -2, .push = -2, __VA_ARGS__ })
-void (name_op)(struct op_parameter par);
+#define name_op0(...) name_opN((struct op_parameter){ .pop = -2, .push = -2, __VA_ARGS__ })
+#define name_op(...) name_opN((struct op_parameter){ __VA_ARGS__ })
+void (name_opN)(struct op_parameter par);
 
-#define local_op(...) local_op((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
-void (local_op)(struct op_parameter par);
+#define local_op0(...) local_opN((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
+#define local_op(...) local_opN((struct op_parameter){  __VA_ARGS__ })
+void (local_opN)(struct op_parameter par);
 
-#define free_op(...) free_op((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
-void (free_op)(struct op_parameter par);
+#define free_op0(...) free_opN((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
+#define free_op(...) free_opN((struct op_parameter){ __VA_ARGS__ })
+void (free_opN)(struct op_parameter par);
 
-#define store_op(...) store_op((struct op_parameter){ .pop = 0, .push = 1, .func = DEF_OP, __VA_ARGS__ })
-void (store_op)(struct op_parameter par);
+#define store_op00(...) store_opN((struct op_parameter){ __VA_ARGS__ })
+#define store_op(...) store_opN((struct op_parameter){ .func = DEF_OP, __VA_ARGS__ })
+#define store_op0(...) store_opN((struct op_parameter){ .pop = 0, .push = 1, .func = DEF_OP, __VA_ARGS__ })
+void (store_opN)(struct op_parameter par);
 
-#define varargs_op(...) varargs_op((struct op_parameter){ .pop = -1, .push = 1, __VA_ARGS__ })
+#define varargs_op(...) varargs_op((struct op_parameter){ __VA_ARGS__ })
+#define varargs_op0(...) varargs_op((struct op_parameter){ .pop = -1, .push = 1, __VA_ARGS__ })
 void (varargs_op)(struct op_parameter par);
 
-#define const_op(...) const_op((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
-void (const_op)(struct op_parameter par);
+#define const_op(...) const_opN((struct op_parameter){ .pop = 0, .push = 1, __VA_ARGS__ })
+#define const_op00(...) const_opN((struct op_parameter){ __VA_ARGS__ })
+void (const_opN)(struct op_parameter par);
 
-#define compare_op(...) compare_op((struct op_parameter){ .pop = 2, .push = 1, __VA_ARGS__ })
+#define compare_op0(...) compare_op((struct op_parameter){ .pop = 2, .push = 1, __VA_ARGS__ })
+#define compare_op(...) compare_op((struct op_parameter){ __VA_ARGS__ })
 void (compare_op)(struct op_parameter par);
 
-#define jabs_op(...) jabs_op((struct op_parameter){ .pop = 0, .push = 0, .conditional = false, .fallthrough = true, __VA_ARGS__ })
-void (jabs_op)(struct op_parameter par);
+#define jabs_op00(...) jabs_opN((struct op_parameter){ __VA_ARGS__ })
+#define jabs_op0(...) jabs_opN((struct op_parameter){ .pop = 0, .push = 0, .conditional = false, .fallthrough = true, __VA_ARGS__ })
+#define jabs_op(...) jabs_opN((struct op_parameter){ .fallthrough = true, __VA_ARGS__ })
+void (jabs_opN)(struct op_parameter par);
 
-#define jrel_op(...) jrel_op((struct op_parameter){ .pop = 0, .push = 0, .conditional = false, .fallthrough = true, __VA_ARGS__ })
-void (jrel_op)(struct op_parameter par);
+#define jrel_op00(...) jrel_opN((struct op_parameter){ __VA_ARGS__ })
+#define jrel_op0(...) jrel_opN((struct op_parameter){ .pop = 0, .push = 0, .conditional = false, .fallthrough = true, __VA_ARGS__ })
+#define jrel_op(...) jrel_opN((struct op_parameter){ .fallthrough = true, __VA_ARGS__ })
+void (jrel_opN)(struct op_parameter par);
 
-#define nargs_op(...) nargs_op((struct op_parameter){ .pop = -2, .push = -2, __VA_ARGS__ })
+#define nargs_op(...) nargs_op((struct op_parameter){ __VA_ARGS__ })
+#define nargs_op0(...) nargs_op((struct op_parameter){ .pop = -2, .push = -2, __VA_ARGS__ })
 void (nargs_op)(struct op_parameter par);
 
 #define rm_op(...) rm_op((struct op_parameter){ __VA_ARGS__ })

--- a/libr/asm/arch/pyc/opcode_15.c
+++ b/libr/asm/arch/pyc/opcode_15.c
@@ -8,7 +8,7 @@ pyc_opcodes *opcode_15(void) {
 
 	ret->version_sig = (void *(*)())opcode_15;
 
-	def_op (.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false);
+	def_opN ((struct op_parameter) {.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false});
 	def_op (.op_obj = ret->opcodes, .op_name = "POP_TOP", .op_code = 1);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_TWO", .op_code = 2);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_THREE", .op_code = 3);
@@ -60,7 +60,7 @@ pyc_opcodes *opcode_15(void) {
 	def_op (.op_obj = ret->opcodes, .op_name = "BREAK_LOOP", .op_code = 80, .pop = 0, .push = 0);
 
 	def_op (.op_obj = ret->opcodes, .op_name = "LOAD_LOCALS", .op_code = 82, .pop = 0, .push = 1);
-	def_op (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
 
 	def_op (.op_obj = ret->opcodes, .op_name = "EXEC_STMT", .op_code = 85, .pop = 3, .push = 0);
 
@@ -70,16 +70,16 @@ pyc_opcodes *opcode_15(void) {
 
 	ret->have_argument = 90; // Opcodes from here have an argument:
 
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_NAME", .op_code = 91, .pop = 0, .push = 0); // ""
 	varargs_op (.op_obj = ret->opcodes, .op_name = "UNPACK_TUPLE", .op_code = 92); // Number of tuple items
 	def_op (.op_obj = ret->opcodes, .op_name = "UNPACK_LIST", .op_code = 93); // Number of list items
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_ATTR", .op_code = 96, .pop = 1, .push = 0); // ""
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_GLOBAL", .op_code = 98, .pop = 0, .push = 0); // ""
 
-	const_op (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
+	const_op00 (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
 	name_op (.op_obj = ret->opcodes, .op_name = "LOAD_NAME", .op_code = 101, .pop = 0, .push = 1); // Operand is in name list
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_TUPLE", .op_code = 102, .pop = -1, .push = 1); // Number of tuple items
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_LIST", .op_code = 103, .pop = -1, .push = 1); // Number of list items
@@ -103,12 +103,12 @@ pyc_opcodes *opcode_15(void) {
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_FINALLY", .op_code = 122, .pop = 0, .push = 0, .conditional = true); // ""
 
 	local_op (.op_obj = ret->opcodes, .op_name = "LOAD_FAST", .op_code = 124, .pop = 0, .push = 1); // Local variable number
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
-	local_op (.op_obj = ret->opcodes, .op_name = "DELETE_FAST", .op_code = 126); // Local variable number
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
+	local_op0 (.op_obj = ret->opcodes, .op_name = "DELETE_FAST", .op_code = 126); // Local variable number
 
 	def_op (.op_obj = ret->opcodes, .op_name = "SET_LINENO", .op_code = 127); // Current line number
 
-	def_op (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = -1, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = -1, .push = 0, .fallthrough = false);
 	// Number of raise arguments (1, 2, or 3)
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION", .op_code = 131, .pop = -1, .push = 1); // //args + (//kwargs << 8)
 

--- a/libr/asm/arch/pyc/opcode_2x.c
+++ b/libr/asm/arch/pyc/opcode_2x.c
@@ -8,7 +8,7 @@ pyc_opcodes *opcode_2x(void) {
 
 	ret->version_sig = (void *(*)())opcode_2x;
 
-	def_op (.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false);
 	def_op (.op_obj = ret->opcodes, .op_name = "POP_TOP", .op_code = 1, .pop = 1, .push = 0);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_TWO", .op_code = 2, .pop = 2, .push = 2);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_THREE", .op_code = 3, .pop = 3, .push = 3);
@@ -79,7 +79,7 @@ pyc_opcodes *opcode_2x(void) {
 	def_op (.op_obj = ret->opcodes, .op_name = "BREAK_LOOP", .op_code = 80, .pop = 0, .push = 0);
 
 	def_op (.op_obj = ret->opcodes, .op_name = "LOAD_LOCALS", .op_code = 82, .pop = 0, .push = 1);
-	def_op (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
 	def_op (.op_obj = ret->opcodes, .op_name = "IMPORT_STAR", .op_code = 84, .pop = 1, .push = 0);
 	def_op (.op_obj = ret->opcodes, .op_name = "EXEC_STMT", .op_code = 85, .pop = 3, .push = 0);
 	def_op (.op_obj = ret->opcodes, .op_name = "YIELD_VALUE", .op_code = 86, .pop = 1, .push = 1);
@@ -90,17 +90,17 @@ pyc_opcodes *opcode_2x(void) {
 
 	ret->have_argument = 90; // Opcodes from here have an argument:
 
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_NAME", .op_code = 91, .pop = 0, .push = 0); // ""
 	varargs_op (.op_obj = ret->opcodes, .op_name = "UNPACK_SEQUENCE", .op_code = 92, .pop = 9, .push = 1); // TOS is number of tuple items
 	jrel_op (.op_obj = ret->opcodes, .op_name = "FOR_ITER", .op_code = 93, .pop = 9, .push = 1); // TOS is read
 
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_ATTR", .op_code = 96, .pop = 1, .push = 0); // ""
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_GLOBAL", .op_code = 98, .pop = 0, .push = 0); // ""
 	def_op (.op_obj = ret->opcodes, .op_name = "DUP_TOPX", .op_code = 99, .pop = 1, .push = -1); // number of items to duplicate
-	const_op (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
+	const_op00 (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
 	name_op (.op_obj = ret->opcodes, .op_name = "LOAD_NAME", .op_code = 101, .pop = 0, .push = 1); // Operand is in name list
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_TUPLE", .op_code = 102, .pop = 9, .push = 1); // TOS is number of tuple items
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_LIST", .op_code = 103, .pop = 9, .push = 1); // TOS is number of list items
@@ -111,24 +111,24 @@ pyc_opcodes *opcode_2x(void) {
 	name_op (.op_obj = ret->opcodes, .op_name = "IMPORT_NAME", .op_code = 107, .pop = 2, .push = 1); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "IMPORT_FROM", .op_code = 108, .pop = 0, .push = 1); // Operand is in name list
 
-	jrel_op (.op_obj = ret->opcodes, .op_name = "JUMP_FORWARD", .op_code = 110, .pop = 0, .push = 0, .fallthrough = false); // Number of bytes to skip
+	jrel_op00 (.op_obj = ret->opcodes, .op_name = "JUMP_FORWARD", .op_code = 110, .pop = 0, .push = 0, .fallthrough = false); // Number of bytes to skip
 	jrel_op (.op_obj = ret->opcodes, .op_name = "JUMP_IF_FALSE", .op_code = 111, .pop = 1, .push = 1, .conditional = true); // ""
 
 	jrel_op (.op_obj = ret->opcodes, .op_name = "JUMP_IF_TRUE", .op_code = 112, .pop = 1, .push = 1, .conditional = true); // ""
-	jabs_op (.op_obj = ret->opcodes, .op_name = "JUMP_ABSOLUTE", .op_code = 113, .pop = 0, .push = 0, .fallthrough = false); // Target byte offset from beginning of code
+	jabs_op00 (.op_obj = ret->opcodes, .op_name = "JUMP_ABSOLUTE", .op_code = 113, .pop = 0, .push = 0, .fallthrough = false); // Target byte offset from beginning of code
 
 	name_op (.op_obj = ret->opcodes, .op_name = "LOAD_GLOBAL", .op_code = 116, .pop = 0, .push = 1); // Operand is in name list
 
-	jabs_op (.op_obj = ret->opcodes, .op_name = "CONTINUE_LOOP", .op_code = 119, .pop = 0, .push = 0, .fallthrough = false); // Target address
+	jabs_op00 (.op_obj = ret->opcodes, .op_name = "CONTINUE_LOOP", .op_code = 119, .pop = 0, .push = 0, .fallthrough = false); // Target address
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_LOOP", .op_code = 120, .pop = 0, .push = 0, .conditional = true); // Distance to target address
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_EXCEPT", .op_code = 121, .pop = 0, .push = 6, .conditional = true); // ""
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_FINALLY", .op_code = 122, .pop = 0, .push = 7, .conditional = true); // ""
 
 	local_op (.op_obj = ret->opcodes, .op_name = "LOAD_FAST", .op_code = 124, .pop = 0, .push = 1); // Local variable number
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
 	local_op (.op_obj = ret->opcodes, .op_name = "DELETE_FAST", .op_code = 126); // Local variable number
 
-	def_op (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = 1, .push = 0, .fallthrough = false); // Number of raise arguments (1, 2, or 3)
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = 1, .push = 0, .fallthrough = false); // Number of raise arguments (1, 2, or 3)
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION", .op_code = 131, .pop = 9, .push = 1); // TOS is //args + (//kwargs << 8)
 
 	def_op (.op_obj = ret->opcodes, .op_name = "MAKE_FUNCTION", .op_code = 132, .pop = 9, .push = 1); // TOS is number of args with default values
@@ -137,7 +137,7 @@ pyc_opcodes *opcode_2x(void) {
 	def_op (.op_obj = ret->opcodes, .op_name = "MAKE_CLOSURE", .op_code = 134, .pop = 9, .push = 1);
 	free_op (.op_obj = ret->opcodes, .op_name = "LOAD_CLOSURE", .op_code = 135, .pop = 0, .push = 1);
 	free_op (.op_obj = ret->opcodes, .op_name = "LOAD_DEREF", .op_code = 136, .pop = 0, .push = 1);
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_DEREF", .op_code = 137, .pop = 1, .push = 0, .func = FREE_OP);
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_DEREF", .op_code = 137, .pop = 1, .push = 0, .func = FREE_OP);
 
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION_VAR", .op_code = 140, .pop = -1, .push = 1); // #args + (#kwargs << 8)
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION_KW", .op_code = 141, .pop = -1, .push = 1); // #args + (#kwargs << 8)

--- a/libr/asm/arch/pyc/opcode_36.c
+++ b/libr/asm/arch/pyc/opcode_36.c
@@ -14,7 +14,7 @@ pyc_opcodes *opcode_36(void) {
 	rm_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION_VAR_KW", .op_code = 142);
 
 	// These are new since Python 3.6
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_ANNOTATION", .op_code = 127, .func = NAME_OP); // Index in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_ANNOTATION", .op_code = 127, .func = NAME_OP); // Index in name list
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_ASYNC_WITH", .op_code = 154);
 	def_op (.op_obj = ret->opcodes, .op_name = "FORMAT_VALUE", .op_code = 155);
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_CONST_KEY_MAP", .op_code = 156, .pop = -1, .push = 1); // TOS is count of kwargs

--- a/libr/asm/arch/pyc/opcode_3x.c
+++ b/libr/asm/arch/pyc/opcode_3x.c
@@ -8,7 +8,7 @@ pyc_opcodes *opcode_3x(void) {
 
 	ret->version_sig = (void *(*)())opcode_3x;
 
-	def_op (.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "STOP_CODE", .op_code = 0, .pop = 0, .push = 0, .fallthrough = false);
 	def_op (.op_obj = ret->opcodes, .op_name = "POP_TOP", .op_code = 1, .pop = 1, .push = 0);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_TWO", .op_code = 2, .pop = 2, .push = 2);
 	def_op (.op_obj = ret->opcodes, .op_name = "ROT_THREE", .op_code = 3, .pop = 3, .push = 3);
@@ -76,7 +76,7 @@ pyc_opcodes *opcode_3x(void) {
 	def_op (.op_obj = ret->opcodes, .op_name = "WITH_CLEANUP", .op_code = 81, .pop = 1, .push = 0); // Cleans up the stack when a with statement
 		// block exits.  Handle stack special
 
-	def_op (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RETURN_VALUE", .op_code = 83, .pop = 1, .push = 0, .fallthrough = false);
 	def_op (.op_obj = ret->opcodes, .op_name = "IMPORT_STAR", .op_code = 84, .pop = 1, .push = 0);
 
 	def_op (.op_obj = ret->opcodes, .op_name = "YIELD_VALUE", .op_code = 86, .pop = 1, .push = 1);
@@ -86,21 +86,21 @@ pyc_opcodes *opcode_3x(void) {
 
 	ret->have_argument = 90; // Opcodes from here have an argument:
 
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_NAME", .op_code = 90, .pop = 1, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_NAME", .op_code = 91, .pop = 0, .push = 0); // ""
 	varargs_op (.op_obj = ret->opcodes, .op_name = "UNPACK_SEQUENCE", .op_code = 92, .pop = 9, .push = 1); // TOS is number of tuple items
 	jrel_op (.op_obj = ret->opcodes, .op_name = "FOR_ITER", .op_code = 93, .pop = 9, .push = 1);
 
 	def_op (.op_obj = ret->opcodes, .op_name = "UNPACK_EX", .op_code = 94, .pop = 9, .push = 1); // assignment with a starred target; TOS is #entries
 		// argument has a count
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_ATTR", .op_code = 95, .pop = 2, .push = 0, .func = NAME_OP); // Operand is in name list
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_ATTR", .op_code = 96, .pop = 1, .push = 0); // ""
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_GLOBAL", .op_code = 97, .pop = 1, .push = 0, .func = NAME_OP); // ""
 	name_op (.op_obj = ret->opcodes, .op_name = "DELETE_GLOBAL", .op_code = 98, .pop = 0, .push = 0); // ""
 
 	// Python 2's DUP_TOPX is gone starting in Python 3.2
 
-	const_op (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
+	const_op00 (.op_obj = ret->opcodes, .op_name = "LOAD_CONST", .op_code = 100, .pop = 0, .push = 1); // Operand is in const list
 	name_op (.op_obj = ret->opcodes, .op_name = "LOAD_NAME", .op_code = 101, .pop = 0, .push = 1); // Operand is in name list
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_TUPLE", .op_code = 102, .pop = 9, .push = 1); // TOS is count of tuple items
 	varargs_op (.op_obj = ret->opcodes, .op_name = "BUILD_LIST", .op_code = 103, .pop = 9, .push = 1); // TOS is count of list items
@@ -126,10 +126,10 @@ pyc_opcodes *opcode_3x(void) {
 	jrel_op (.op_obj = ret->opcodes, .op_name = "SETUP_FINALLY", .op_code = 122, .pop = 0, .push = 6, .conditional = true); // ""
 
 	local_op (.op_obj = ret->opcodes, .op_name = "LOAD_FAST", .op_code = 124, .pop = 0, .push = 1); // Local variable number
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_FAST", .op_code = 125, .pop = 1, .push = 0, .func = LOCAL_OP); // Local variable number
 	local_op (.op_obj = ret->opcodes, .op_name = "DELETE_FAST", .op_code = 126, .pop = 0, .push = 0); // Local variable number
 
-	def_op (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = 9, .push = 1, .fallthrough = false);
+	def_op00 (.op_obj = ret->opcodes, .op_name = "RAISE_VARARGS", .op_code = 130, .pop = 9, .push = 1, .fallthrough = false);
 	// Number of raise arguments (1, 2, or 3)
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION", .op_code = 131, .pop = 9, .push = 1); // #args + (#kwargs << 8)
 
@@ -139,7 +139,7 @@ pyc_opcodes *opcode_3x(void) {
 	def_op (.op_obj = ret->opcodes, .op_name = "MAKE_CLOSURE", .op_code = 134, .pop = 9, .push = 1); // TOS is number of items to pop
 	free_op (.op_obj = ret->opcodes, .op_name = "LOAD_CLOSURE", .op_code = 135, .pop = 0, .push = 1);
 	free_op (.op_obj = ret->opcodes, .op_name = "LOAD_DEREF", .op_code = 136, .pop = 0, .push = 1);
-	store_op (.op_obj = ret->opcodes, .op_name = "STORE_DEREF", .op_code = 137, .pop = 1, .push = 0, .func = FREE_OP);
+	store_op00 (.op_obj = ret->opcodes, .op_name = "STORE_DEREF", .op_code = 137, .pop = 1, .push = 0, .func = FREE_OP);
 	free_op (.op_obj = ret->opcodes, .op_name = "DELETE_DEREF", .op_code = 138, .pop = 0, .push = 0);
 
 	nargs_op (.op_obj = ret->opcodes, .op_name = "CALL_FUNCTION_VAR", .op_code = 140, .pop = 9, .push = 1); // #args + (#kwargs << 8)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

running make in mac resulst in about 300 warnings from the pyc disassembler
```
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode_3x.c:155:79: warning: initializer overrides prior initialization of this subobject [-Winitializer-overrides]
        def_op (.op_obj = ret->opcodes, .op_name = "MAP_ADD", .op_code = 147, .pop = 2, .push = 1); // Calls dict.setitem(TOS1[-i], TOS, TOS1)
                                                                                     ^
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode.h:125:95: note: expanded from macro 'def_op'
#define def_op(...) def_op((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
                                                                                              ^~~~~~~~~~~
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode_3x.c:155:2: note: previous initialization is here
        def_op (.op_obj = ret->opcodes, .op_name = "MAP_ADD", .op_code = 147, .pop = 2, .push = 1); // Calls dict.setitem(TOS1[-i], TOS, TOS1)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode.h:125:58: note: expanded from macro 'def_op'
#define def_op(...) def_op((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
                                                         ^~
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode_3x.c:155:90: warning: initializer overrides prior initialization of this subobject [-Winitializer-overrides]
        def_op (.op_obj = ret->opcodes, .op_name = "MAP_ADD", .op_code = 147, .pop = 2, .push = 1); // Calls dict.setitem(TOS1[-i], TOS, TOS1)
                                                                                                ^
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode.h:125:95: note: expanded from macro 'def_op'
#define def_op(...) def_op((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
                                                                                              ^~~~~~~~~~~
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode_3x.c:155:2: note: previous initialization is here
        def_op (.op_obj = ret->opcodes, .op_name = "MAP_ADD", .op_code = 147, .pop = 2, .push = 1); // Calls dict.setitem(TOS1[-i], TOS, TOS1)
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/pancake/prg/radare2/libr/asm/arch/pyc/opcode.h:125:70: note: expanded from macro 'def_op'
#define def_op(...) def_op((struct op_parameter){ .pop = -2, .push = -2, .fallthrough = true, __VA_ARGS__ })
                                                                     ^~
209 warnings generated.
```
```
**Test plan**

check the output of the compiler and see no warnings

**Closing issues**
none