### PR TITLE
Fix invalid json output for drtj command

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -2360,7 +2360,8 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 	char *arg;
 	struct r_reg_item_t *r;
 	const char *name, *use_color;
-	int size, i, type = R_REG_TYPE_GPR;
+	size_t i;
+	int size, type = R_REG_TYPE_GPR;
 	int bits = (core->dbg->bits & R_SYS_BITS_64)? 64: 32;
 	int use_colors = r_config_get_i (core->config, "scr.color");
 	int newbits = atoi ((str&&*str)? str + 1: "");
@@ -2860,15 +2861,17 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 			rad = str[1];
 			str++;
 			if (rad == 'j' && !str[1]) {
-				// TODO use pj api here
-				r_cons_print ("[");
-				for (i = 0; (name = r_reg_get_type (i)); i++) {
-					if (i) {
-						r_cons_print (",");
-					}
-					r_cons_printf ("\"%s\"", name);
+				PJ *pj = pj_new ();
+				if (!pj) {
+					break;
 				}
-				r_cons_println ("]");
+				pj_a (pj);
+				for (i = 0; (name = r_reg_get_type (i)); i++) {
+					pj_s (pj, name);
+				}
+				pj_end (pj);
+				r_cons_println (pj_string (pj));
+				pj_free (pj);
 				break;
 			}
 			// fallthrough

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -92,6 +92,7 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 	RList *head;
 	ut64 diff;
 	char strvalue[256];
+	bool isJson = (rad == 'j' || rad == 'J');
 	if (!dbg || !dbg->reg) {
 		return false;
 	}
@@ -120,8 +121,15 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 	if (dbg->regcols) {
 		cols = dbg->regcols;
 	}
-	if (rad == 'j') {
-		dbg->cb_printf ("{");
+	PJ *pj;
+	if (isJson) {
+		pj = pj_new ();
+		if (!pj) {
+			return false;
+		}
+		if (rad == 'j') {
+			pj_o (pj);
+		}
 	}
 	// with the new field "arena" into reg items why need
 	// to get all arenas.
@@ -171,9 +179,9 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 			r_reg_arena_swap (dbg->reg, false);
 			diff = r_reg_get_value (dbg->reg, item);
 			r_reg_arena_swap (dbg->reg, false);
-			delta = value-diff;
-			if (tolower ((ut8)rad) == 'j') {
-				snprintf (strvalue, sizeof (strvalue),"%"PFMT64u, value);
+			delta = value - diff;
+			if (isJson) {
+				pj_kn (pj, item->name, value);
 			} else {
 				if (pr && pr->wide_offsets && dbg->bits & R_SYS_BITS_64) {
 					snprintf (strvalue, sizeof (strvalue),"0x%016"PFMT64x, value);
@@ -200,16 +208,17 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 				default:
 					snprintf (strvalue, sizeof (strvalue), "ERROR");
 			}
+			if (isJson) {
+				pj_ks (pj, item->name, strvalue);
+			}
 			delta = 0; // TODO: calculate delta with big values.
 		}
 		itmidx++;
 
+		if (isJson) {
+			continue;
+		}
 		switch (rad) {
-			case 'J':
-			case 'j':
-				dbg->cb_printf ("%s\"%s\":%s",
-						n?",":"", item->name, strvalue);
-				break;
 			case '-':
 				dbg->cb_printf ("f-%s\n", item->name);
 				break;
@@ -276,10 +285,12 @@ R_API int r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char 
 		n++;
 	}
 beach:
-	if (rad == 'j') {
-		dbg->cb_printf ("}\n");
-	} else if (rad == 'J') {
-		// do nothing
+	if (isJson) {
+		if (rad == 'j') {
+			pj_end (pj);
+		}
+		dbg->cb_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	} else if (n > 0 && (rad == 2 || rad == '=') && ((n%cols))) {
 		dbg->cb_printf ("\n");
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Putting double quotes between hexadecimal big numbers to make them JSON strings, because big numbers are not generally supported in JSON and string is good enough.

**Test plan**
Test that `drtj fpu` or any other register types outputs a valid json. I am thinking of including it in the json test. However, every time r2r runs, it says `Skipping json tests because jq is not available.`, although I have `jq` installed and tested. The `jq` process seems to always exit with an error code. I have found that the sourcehut ci does not run the json test as well. Is there a bug or configuration error?

**Closing issues**

closes #16635 
