### PR TITLE
Fix C99 construct without -c99

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -424,7 +424,8 @@ static const ut8 *parse_line_header (
 		if (f) {
 			fprintf (f, " Opcodes:\n");
 		}
-		for (int i = 1; i <= hdr->opcode_base - 1; i++) {
+		int i;
+		for (i = 1; i <= hdr->opcode_base - 1; i++) {
 			if (buf + 2 > buf_end) {
 				break;
 			}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -424,7 +424,7 @@ static const ut8 *parse_line_header (
 		if (f) {
 			fprintf (f, " Opcodes:\n");
 		}
-		int i;
+		size_t i;
 		for (i = 1; i < hdr->opcode_base; i++) {
 			if (buf + 2 > buf_end) {
 				break;

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -425,7 +425,7 @@ static const ut8 *parse_line_header (
 			fprintf (f, " Opcodes:\n");
 		}
 		int i;
-		for (i = 1; i <= hdr->opcode_base - 1; i++) {
+		for (i = 1; i < hdr->opcode_base; i++) {
 			if (buf + 2 > buf_end) {
 				break;
 			}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -431,7 +431,7 @@ static const ut8 *parse_line_header (
 			}
 			hdr->std_opcode_lengths[i] = READ (buf, ut8);
 			if (f) {
-				fprintf (f, "  Opcode %d has %d arg\n", i, hdr->std_opcode_lengths[i]);
+				fprintf (f, "  Opcode %zu has %d arg\n", i, hdr->std_opcode_lengths[i]);
 			}
 		}
 		if (f) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

See previous PR (#16850 #14593), this doesn't build unless -c99 is used for gcc.
