### PR TITLE
Improve RISC-V analysis for compressed instructions

### DIFF
--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -342,7 +342,7 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	if (o->args) {
 		const char *name = o->name;
 		// Test for compressed instruction
-		if (!strncmp ("c.",o->name,2)) {
+		if (!strncmp ("c.", o->name, 2)) {
 			name += 2;
 			op->size = 2;
 		}

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -342,7 +342,7 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	if (o->args) {
 		const char *name = o->name;
 		// Test for compressed instruction
-		if (o->name[0] == 'c' && o->name[1] == '.') {
+		if (!strncmp ("c.",o->name,2)) {
 			name += 2;
 			op->size = 2;
 		}

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -297,7 +297,6 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	riscv_args_t args = {0};
 	ut64 word = 0;
 	int xlen = anal->bits;
-
 	op->size = 4;
 	op->addr = addr;
 	op->type = R_ANAL_OP_TYPE_UNK;
@@ -341,9 +340,11 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	}
 
 	if (o->args) {
-		const char* name = o->name;
+		const char *name = o->name;
+		// Test for compressed instruction
 		if (o->name[0] == 'c' && o->name[1] == '.') {
 			name += 2;
+			op->size = 2;
 		}
 #define ARG(x) (arg_n (&args, (x)))
 		get_insn_args (&args, o->args, word, addr);
@@ -476,7 +477,11 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 			}
 		} else if (!strcmp (name, "jal")) {
 			if (strcmp (ARG (0), "0")) {
-				esilprintf (op, "%d,$$,+,%s,=,%s,pc,=", op->size, ARG (0), ARG (1));
+				if (args.num == 1) {
+					esilprintf (op, "%d,$$,+,ra,=,%s,pc,=", op->size, ARG (0));
+				} else {
+					esilprintf (op, "%d,$$,+,%s,=,%s,pc,=", op->size, ARG (0), ARG (1));
+				}
 			} else {
 				esilprintf (op, "%s,pc,=", ARG (1));
 			}
@@ -537,49 +542,60 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 
 // branch/jumps/calls/rets
 	if (is_any ("jal")) {
-		// decide whether it's ret or call
+		// decide whether it's jump or call
 		int rd = (word >> OP_SH_RD) & OP_MASK_RD;
-		op->type = (rd == 0) ? R_ANAL_OP_TYPE_RET: R_ANAL_OP_TYPE_CALL;
+		op->type = (rd == 0) ? R_ANAL_OP_TYPE_JMP: R_ANAL_OP_TYPE_CALL;
 		op->jump = EXTRACT_UJTYPE_IMM (word) + addr;
-		op->fail = addr + 4;
+		op->fail = addr + op->size;
+	} else if (is_any ("c.jal")) {
+		op->type = R_ANAL_OP_TYPE_CALL;
+		op->jump = EXTRACT_RVC_IMM (word) + addr;
+		op->fail = addr + op->size;
 	} else if (is_any ("jr")) {
 		op->type = R_ANAL_OP_TYPE_JMP;
-	} else if (is_any ("j", "jump")) {
+	} else if (is_any ("c.j", "jump")) {
 		op->type = R_ANAL_OP_TYPE_JMP;
+		op->jump = EXTRACT_RVC_J_IMM (word) + addr;
 	} else if (is_any ("jalr")) {
 		// decide whether it's ret or call
 		int rd = (word >> OP_SH_RD) & OP_MASK_RD;
 		op->type = (rd == 0) ? R_ANAL_OP_TYPE_RET: R_ANAL_OP_TYPE_UCALL;
-	} else if (is_any ("ret")) {
+	} else if (is_any ("c.jr")) {
 		op->type = R_ANAL_OP_TYPE_RET;
 	} else if (is_any ("beqz", "beq", "blez", "bgez", "ble",
-			"bleu", "bge", "bgeu", "bltz", "bgtz", "blt", "bltu",
-			"bgt", "bgtu", "bnez", "bne")) {
+			   "bleu", "bge", "bgeu", "bltz", "bgtz", "blt", "bltu",
+			   "bgt", "bgtu", "bnez", "bne")) {
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->jump = EXTRACT_SBTYPE_IMM (word) + addr;
 		op->fail = addr + 4;
 // math
-	} else if (is_any ("addi", "addw", "addiw", "add", "auipc")) {
+	} else if (is_any ("addi", "addw", "addiw", "add", "auipc", "c.addi",
+			   "c.addw", "c.add")) {
 		op->type = R_ANAL_OP_TYPE_ADD;
-	} else if (is_any ("subi", "subw", "sub")) {
+	} else if (is_any ("c.mv")) {
+		op->type = R_ANAL_OP_TYPE_MOV;
+	} else if (is_any ("subi", "subw", "sub", "c.sub")) {
 		op->type = R_ANAL_OP_TYPE_SUB;
-	} else if (is_any ("xori", "xor")) {
+	} else if (is_any ("xori", "xor", "c.xor")) {
 		op->type = R_ANAL_OP_TYPE_XOR;
-	} else if (is_any ("andi", "and")) {
+	} else if (is_any ("andi", "and", "c.andi")) {
 		op->type = R_ANAL_OP_TYPE_AND;
-	} else if (is_any ("ori", "or")) {
+	} else if (is_any ("ori", "or", "c.or")) {
 		op->type = R_ANAL_OP_TYPE_OR;
 	} else if (is_any ("not")) {
 		op->type = R_ANAL_OP_TYPE_NOT;
+	} else if (is_any ("c.nop")) {
+		op->type = R_ANAL_OP_TYPE_NOP;
 	} else if (is_any ("mul", "mulh", "mulhu", "mulhsu", "mulw")) {
 		op->type = R_ANAL_OP_TYPE_MUL;
 	} else if (is_any ("div", "divu", "divw", "divuw")) {
 		op->type = R_ANAL_OP_TYPE_DIV;
 // memory
-	} else if (is_any ("sd", "sb", "sh", "sw")) {
+	} else if (is_any ("sd", "sb", "sh", "sw", "c.sd", "c.sw")) {
 		op->type = R_ANAL_OP_TYPE_STORE;
 	} else if (is_any ("ld", "lw", "lwu", "lui", "li",
-			"lb", "lbu", "lh", "lhu", "la", "lla")) {
+			   "lb", "lbu", "lh", "lhu", "la", "lla", "c.ld",
+			   "c.lw", "c.li")) {
 		op->type = R_ANAL_OP_TYPE_LOAD;
 	}
 	if (mask & R_ANAL_OP_MASK_VAL && args.num) {

--- a/test/db/anal/riscv
+++ b/test/db/anal/riscv
@@ -8,3 +8,20 @@ EXPECT=<<EOF
 0x00010330    1 68           sym._printf_r
 EOF
 RUN
+
+NAME=jump with compress instruction
+FILE=-
+CMDS=<<EOF
+e asm.arch=riscv
+e asm.bits=32
+wx 21a001009d06aa858146
+pd 5
+EOF
+EXPECT=<<EOF
+        ,=< 0x00000000      21a0           j 0x8
+        |   0x00000002      0100           nop
+        |   0x00000004      9d06           addi a3, a3, 7
+        |   0x00000006      aa85           mv a1, a0
+        `-> 0x00000008      8146           li a3, 0
+EOF
+RUN

--- a/test/db/formats/elf/elf-riscv64
+++ b/test/db/formats/elf/elf-riscv64
@@ -448,7 +448,7 @@ af
 pdf
 EOF
 EXPECT=<<EOF
-/ (fcn) main 140
+/ (fcn) main 160
 // int main (int argc, char **argv, char **envp);
 |           ; var int64_t var_18h @ s0-0x18
 |           ; var int64_t var_14h @ s0-0x14
@@ -462,33 +462,38 @@ EXPECT=<<EOF
 |           0x00010164      2326f4fe       sw a5, -20(s0)
 |           0x00010168      9307f0ff       li a5, -1
 |           0x0001016c      2324f4fe       sw a5, -24(s0)
-|           0x00010170      b7170200       lui a5, 0x21
-|           0x00010174      1385874f       addi a0, a5, 1272
-|           0x00010178      ef00c01f       jal ra, sym.printf
-|           0x0001017c      930784fe       addi a5, s0, -24
-|           0x00010180      93850700       mv a1, a5
-|           0x00010184      b7170200       lui a5, 0x21
-|           0x00010188      13850751       addi a0, a5, 1296
-|           0x0001018c      ef00402f       jal ra, sym.scanf
-|           0x00010190      032784fe       lw a4, -24(s0)
-|           0x00010194      8327c4fe       lw a5, -20(s0)
-|       ,=< 0x00010198      631cf700       bne a4, a5, 0x101b0
-|       |   0x0001019c      b7170200       lui a5, 0x21
-|       |   0x000101a0      13858751       addi a0, a5, 1304
-|       |   0x000101a4      ef00002d       jal ra, sym.puts
-|       |   0x000101a8      93070000       li a5, 0
-|       |   0x000101ac      6f000003       j 0x101dc
-|       `-> 0x000101b0      032784fe       lw a4, -24(s0)
-|           0x000101b4      8327c4fe       lw a5, -20(s0)
-|       ,=< 0x000101b8      635af700       ble a5, a4, 0x101cc
-|       |   0x000101bc      b7170200       lui a5, 0x21
-|       |   0x000101c0      13858752       addi a0, a5, 1320
-|       |   0x000101c4      ef00002b       jal ra, sym.puts
-|       |   0x000101c8      6ff09ffa       j 0x10170
-|       `-> 0x000101cc      b7170200       lui a5, 0x21
-|           0x000101d0      13858753       addi a0, a5, 1336
-|           0x000101d4      ef00002a       jal ra, sym.puts
-\           0x000101d8      6ff09ff9       j 0x10170
+|      ..-> 0x00010170      b7170200       lui a5, 0x21
+|      ::   0x00010174      1385874f       addi a0, a5, 1272
+|      ::   0x00010178      ef00c01f       jal ra, sym.printf
+|      ::   0x0001017c      930784fe       addi a5, s0, -24
+|      ::   0x00010180      93850700       mv a1, a5
+|      ::   0x00010184      b7170200       lui a5, 0x21
+|      ::   0x00010188      13850751       addi a0, a5, 1296
+|      ::   0x0001018c      ef00402f       jal ra, sym.scanf
+|      ::   0x00010190      032784fe       lw a4, -24(s0)
+|      ::   0x00010194      8327c4fe       lw a5, -20(s0)
+|     ,===< 0x00010198      631cf700       bne a4, a5, 0x101b0
+|     |::   0x0001019c      b7170200       lui a5, 0x21
+|     |::   0x000101a0      13858751       addi a0, a5, 1304
+|     |::   0x000101a4      ef00002d       jal ra, sym.puts
+|     |::   0x000101a8      93070000       li a5, 0
+|    ,====< 0x000101ac      6f000003       j 0x101dc
+|    |`---> 0x000101b0      032784fe       lw a4, -24(s0)
+|    | ::   0x000101b4      8327c4fe       lw a5, -20(s0)
+|    |,===< 0x000101b8      635af700       ble a5, a4, 0x101cc
+|    ||::   0x000101bc      b7170200       lui a5, 0x21
+|    ||::   0x000101c0      13858752       addi a0, a5, 1320
+|    ||::   0x000101c4      ef00002b       jal ra, sym.puts
+|    ||`==< 0x000101c8      6ff09ffa       j 0x10170
+|    |`---> 0x000101cc      b7170200       lui a5, 0x21
+|    |  :   0x000101d0      13858753       addi a0, a5, 1336
+|    |  :   0x000101d4      ef00002a       jal ra, sym.puts
+|    |  `=< 0x000101d8      6ff09ff9       j 0x10170
+|    `----> 0x000101dc      13850700       mv a0, a5
+|           0x000101e0      83308101       ld ra, 24(sp)
+|           0x000101e4      03340101       ld s0, 16(sp)
+|           0x000101e8      13010102       addi sp, sp, 32
+\           0x000101ec      67800000       ret
 EOF
 RUN
 
@@ -502,7 +507,7 @@ pdf
 EOF
 EXPECT=<<EOF
             ; CALL XREF from entry0 @ 0x10040
-/ (fcn) main 140
+/ (fcn) main 160
 // int main (int argc, char **argv, char **envp);
 |           ; var int64_t var_bp_18h @ s0-0x18
 |           ; var int64_t var_14h @ s0-0x14
@@ -516,34 +521,41 @@ EXPECT=<<EOF
 |           0x00010164      2326f4fe       sw a5, -20(s0)
 |           0x00010168      9307f0ff       li a5, -1
 |           0x0001016c      2324f4fe       sw a5, -24(s0)
-|           0x00010170      b7170200       lui a5, 0x21
-|           0x00010174      1385874f       addi a0, a5, 1272           ; const char *format
-|           0x00010178      ef00c01f       jal ra, sym.printf
-|           0x0001017c      930784fe       addi a5, s0, -24
-|           0x00010180      93850700       mv a1, a5
-|           0x00010184      b7170200       lui a5, 0x21
-|           0x00010188      13850751       addi a0, a5, 1296           ; const char *format
-|           0x0001018c      ef00402f       jal ra, sym.scanf
-|           0x00010190      032784fe       lw a4, -24(s0)
-|           0x00010194      8327c4fe       lw a5, -20(s0)
-|       ,=< 0x00010198      631cf700       bne a4, a5, 0x101b0
-|       |   0x0001019c      b7170200       lui a5, 0x21
-|       |   0x000101a0      13858751       addi a0, a5, 1304           ; const char *s
-|       |   0x000101a4      ef00002d       jal ra, sym.puts
-|       |   0x000101a8      93070000       li a5, 0
-|       |   0x000101ac      6f000003       j 0x101dc
-|       |   ; CODE XREF from main @ 0x10198
-|       `-> 0x000101b0      032784fe       lw a4, -24(s0)
-|           0x000101b4      8327c4fe       lw a5, -20(s0)
-|       ,=< 0x000101b8      635af700       ble a5, a4, 0x101cc
-|       |   0x000101bc      b7170200       lui a5, 0x21
-|       |   0x000101c0      13858752       addi a0, a5, 1320           ; const char *s
-|       |   0x000101c4      ef00002b       jal ra, sym.puts
-|       |   0x000101c8      6ff09ffa       j 0x10170
-|       |   ; CODE XREF from main @ 0x101b8
-|       `-> 0x000101cc      b7170200       lui a5, 0x21
-|           0x000101d0      13858753       addi a0, a5, 1336           ; const char *s
-|           0x000101d4      ef00002a       jal ra, sym.puts
-\           0x000101d8      6ff09ff9       j 0x10170
+|           ; CODE XREFS from main @ 0x101c8, 0x101d8
+|      ..-> 0x00010170      b7170200       lui a5, 0x21
+|      ::   0x00010174      1385874f       addi a0, a5, 1272           ; const char *format
+|      ::   0x00010178      ef00c01f       jal ra, sym.printf
+|      ::   0x0001017c      930784fe       addi a5, s0, -24
+|      ::   0x00010180      93850700       mv a1, a5
+|      ::   0x00010184      b7170200       lui a5, 0x21
+|      ::   0x00010188      13850751       addi a0, a5, 1296           ; const char *format
+|      ::   0x0001018c      ef00402f       jal ra, sym.scanf
+|      ::   0x00010190      032784fe       lw a4, -24(s0)
+|      ::   0x00010194      8327c4fe       lw a5, -20(s0)
+|     ,===< 0x00010198      631cf700       bne a4, a5, 0x101b0
+|     |::   0x0001019c      b7170200       lui a5, 0x21
+|     |::   0x000101a0      13858751       addi a0, a5, 1304           ; const char *s
+|     |::   0x000101a4      ef00002d       jal ra, sym.puts
+|     |::   0x000101a8      93070000       li a5, 0
+|    ,====< 0x000101ac      6f000003       j 0x101dc
+|    ||::   ; CODE XREF from main @ 0x10198
+|    |`---> 0x000101b0      032784fe       lw a4, -24(s0)
+|    | ::   0x000101b4      8327c4fe       lw a5, -20(s0)
+|    |,===< 0x000101b8      635af700       ble a5, a4, 0x101cc
+|    ||::   0x000101bc      b7170200       lui a5, 0x21
+|    ||::   0x000101c0      13858752       addi a0, a5, 1320           ; const char *s
+|    ||::   0x000101c4      ef00002b       jal ra, sym.puts
+|    ||`==< 0x000101c8      6ff09ffa       j 0x10170
+|    || :   ; CODE XREF from main @ 0x101b8
+|    |`---> 0x000101cc      b7170200       lui a5, 0x21
+|    |  :   0x000101d0      13858753       addi a0, a5, 1336           ; const char *s
+|    |  :   0x000101d4      ef00002a       jal ra, sym.puts
+|    |  `=< 0x000101d8      6ff09ff9       j 0x10170
+|    |      ; CODE XREF from main @ 0x101ac
+|    `----> 0x000101dc      13850700       mv a0, a5
+|           0x000101e0      83308101       ld ra, 24(sp)
+|           0x000101e4      03340101       ld s0, 16(sp)
+|           0x000101e8      13010102       addi sp, sp, 32
+\           0x000101ec      67800000       ret
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Previous compressed instructions were not analysed.

**Test plan**
One test added.
