### PR TITLE
Fix non-working json tests in r2r ##test

### DIFF
--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -966,8 +966,9 @@ R_API bool r2r_check_cmd_test(R2RProcessOutput *out, R2RCmdTest *test) {
 #define JQ_CMD "jq"
 
 R_API bool r2r_check_jq_available(void) {
+	const char *args[] = {"."};
 	const char *invalid_json = "this is not json lol";
-	R2RSubprocess *proc = r2r_subprocess_start (JQ_CMD, NULL, 0, NULL, NULL, 0);
+	R2RSubprocess *proc = r2r_subprocess_start (JQ_CMD, args, 1, NULL, NULL, 0);
 	if (proc) {
 		r2r_subprocess_stdin_write (proc, (const ut8 *)invalid_json, strlen (invalid_json));
 		r2r_subprocess_wait (proc, UT64_MAX);
@@ -976,7 +977,7 @@ R_API bool r2r_check_jq_available(void) {
 	r2r_subprocess_free (proc);
 
 	const char *valid_json = "{\"this is\":\"valid json\",\"lol\":true}";
-	proc = r2r_subprocess_start (JQ_CMD, NULL, 0, NULL, NULL, 0);
+	proc = r2r_subprocess_start (JQ_CMD, args, 1, NULL, NULL, 0);
 	if (proc) {
 		r2r_subprocess_stdin_write (proc, (const ut8 *)valid_json, strlen (valid_json));
 		r2r_subprocess_wait (proc, UT64_MAX);
@@ -999,7 +1000,8 @@ R_API bool r2r_check_json_test(R2RProcessOutput *out, R2RJsonTest *test) {
 	if (!out || out->ret != 0 || !out->out || !out->err || out->timeout) {
 		return false;
 	}
-	R2RSubprocess *proc = r2r_subprocess_start (JQ_CMD, NULL, 0, NULL, NULL, 0);
+	const char *args[] = {"."};
+	R2RSubprocess *proc = r2r_subprocess_start (JQ_CMD, args, 1, NULL, NULL, 0);
 	r2r_subprocess_stdin_write (proc, (const ut8 *)out->out, strlen (out->out));
 	r2r_subprocess_wait (proc, UT64_MAX);
 	bool ret = proc->ret == 0;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I found out that `jq` always exits with code 2 (usage error) and outputs its help message to `stderr`. This is because `r2r` writes the json to the `stdin` after `jq` ran. To fix this, we run `jq .` instead with the extra argument `.`, so `jq` will wait for inputs from `stdin` and parse them before exiting.

This was also explained in #17073 PR and also https://github.com/stedolan/jq/issues/1110.

**Test plan**
Instead of saying `Skipping json tests because jq is not available.`, `r2r` runs json tests when jq is available.

**Closing issues**
I could not find any issues related to this yet.