### PR TITLE
Fix #2818 - Fix proper chopping of trailing spaces after comments

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2623,10 +2623,25 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}
-	cmt = *icmd ? (char *)r_str_firstbut (icmd, '#', "\""): NULL;
-	if (cmt && cmt != icmd) {
-		*cmt = 0;
-		r_str_trim_tail (icmd);
+	{
+		char *hash = icmd;
+		cmt = NULL;
+		for (hash = icmd; *hash; hash++) {
+			if (*hash == '\\') {
+				hash++;
+				if (*hash == '#') {
+					hash++;
+				}
+			}
+			if (*hash == '#') {
+				break;
+			}
+		}
+		if (hash && *hash) {
+			*hash = 0;
+			r_str_trim_tail (icmd);
+			cmt = hash + 1;
+		}
 	}
 	if (*cmd != '"') {
 		if (!strchr (cmd, '\'')) { // allow | awk '{foo;bar}' // ignore ; if there's a single quote

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2623,10 +2623,10 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}
-	{
+	if (*icmd) {
 		char *hash = icmd;
 		cmt = NULL;
-		for (hash = icmd; *hash; hash++) {
+		for (hash = icmd + 1; *hash; hash++) {
 			if (*hash == '\\') {
 				hash++;
 				if (*hash == '#') {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2624,8 +2624,9 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 		goto beach;
 	}
 	cmt = *icmd ? (char *)r_str_firstbut (icmd, '#', "\""): NULL;
-	if (cmt && (cmt[1] == ' ' || cmt[1] == '\t')) {
+	if (cmt && cmt != icmd) {
 		*cmt = 0;
+		r_str_trim_tail (icmd);
 	}
 	if (*cmd != '"') {
 		if (!strchr (cmd, '\'')) { // allow | awk '{foo;bar}' // ignore ; if there's a single quote

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2623,7 +2623,7 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}
-	if (*icmd) {
+	if (*icmd && !strchr (icmd, '"')) {
 		char *hash = icmd;
 		cmt = NULL;
 		for (hash = icmd + 1; *hash; hash++) {

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -1,3 +1,12 @@
+NAME=trailing comment
+FILE=-
+ARGS=-n
+CMDS=<<EOF
+/ #
+EOF
+EXPECT=
+RUN
+
 NAME=pm olf
 FILE=bins/elf/ioli/crackme0x00
 ARGS=-n


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This works fine in the newshell but not in the oldshell. this commit fixes it and adds a test

**Test plan**

Wait for travis

**Closing issues**

see pr title