### PR TITLE
Add Debian OLD (Debian 8 Jessie)

### DIFF
--- a/.github/workflows/debianold.yml
+++ b/.github/workflows/debianold.yml
@@ -1,0 +1,41 @@
+name: Debian OLD (Jessie) test
+
+on:
+  push:
+    branches:
+    - 'pre-release*'
+    - 'prerelease*'
+    - 'release-*'
+    - 'debian*'
+
+jobs:
+  build:
+    name: debian-8-build
+    runs-on: ubuntu-latest
+    container: debian:jessie
+
+    steps:
+    - name: Install tools
+      run: apt-get update && apt-get install --yes patch unzip git gcc make curl pkg-config
+    - name: Checkout r2
+      run: |
+        git clone https://github.com/${{ github.repository }}
+        cd radare2
+        git fetch origin ${{ github.ref }}
+        git checkout -b local_branch FETCH_HEAD
+    - name: Checkout our Testsuite Binaries
+      uses: actions/checkout@v2
+      with:
+          repository: radareorg/radare2-testbins
+          path: test/bins
+    - name: Configure with ACR and build
+      run: ./configure --prefix=/usr && make
+      working-directory: radare2
+    - name: Install with make
+      run: make install
+      working-directory: radare2
+    - name: Run tests
+      run: cd test && make
+      working-directory: radare2
+      env:
+        PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -32,7 +32,7 @@ TS_BRA=master
 TS_TIP=9a82dcc666d06617cbab3061467075019fae0b0d
 
 ifeq ($(CS_RELEASE),1)
-CS_VER=4.0.1
+CS_VER=4.0.2
 CS_TAR=https://codeload.github.com/aquynh/capstone/tar.gz/$(CS_VER)
 #CS_TAR=http://capstone-engine.org/download/$(CS_VER)/capstone-$(CS_VER).tgz
 CS_PATCHES=0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203261/84986992-0a92c380-b172-11ea-9b1f-f542488f8e8d.png)


Add Debian 8 (Jessie) Docker build to ensure radare2 works
on the older Debian-based systems too.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Along with CentOS 6 build, it makes sense to make sure radare2 works on the older Debian-based systems as well: Debian itself, old versions of Ubuntu, etc.

**Test plan**

All green.

...
