### PR TITLE
Optimize 'aao' objc analysis ##anal

### DIFF
--- a/libr/core/anal_objc.c
+++ b/libr/core/anal_objc.c
@@ -92,28 +92,27 @@ static ut64 getRefPtr(RCoreObjc *o, ut64 classMethodsVA, bool *rfound) {
 	}
 
 	size_t cnt = 0;
-	ut64 ref = 0LL;
-
-	bool found = false;
+	ut64 ref = UT64_MAX;
 	bool isMsgRef = false;
-	RVector *vec = ht_up_find (o->up, namePtr, &found);
-	if (found && vec) {
-		ut64 *addr;
-		r_vector_foreach (vec, addr) {
-			const ut64 at = *addr;
-			if (inBetween (o->_selrefs, at)) {
-				isMsgRef = false;
-				ref = at;
-			} else if (inBetween (o->_msgrefs, at)) {
-				isMsgRef = true;
-				ref = at;
-			} else if (inBetween (o->_const, at)) {
-				cnt++;
-			}
+
+	RVector *vec = ht_up_find (o->up, namePtr, rfound);
+	if (!*rfound || !vec) {
+		return false;
+	}
+	ut64 *addr;
+	r_vector_foreach (vec, addr) {
+		const ut64 at = *addr;
+		if (inBetween (o->_selrefs, at)) {
+			isMsgRef = false;
+			ref = at;
+		} else if (inBetween (o->_msgrefs, at)) {
+			isMsgRef = true;
+			ref = at;
+		} else if (inBetween (o->_const, at)) {
+			cnt++;
 		}
 	}
-	
-	*rfound = found; // (cnt > 1 && ref != 0);
+	// (cnt > 1 && ref != 0);
 	return isMsgRef? ref - 8: ref;
 }
 

--- a/libr/core/anal_objc.c
+++ b/libr/core/anal_objc.c
@@ -123,7 +123,6 @@ static ut64 getRefPtr(RCoreObjc *o, ut64 classMethodsVA, bool *rfound) {
 		*rfound = false;
 		return UT64_MAX;
 	}
-	// (cnt > 1 && ref != 0);
 	return isMsgRef? ref - 8: ref;
 }
 
@@ -169,7 +168,7 @@ static bool objc_build_refs(RCoreObjc *objc) {
 	return true;
 }
 
-static RCoreObjc *core_objc_new (RCore *core) {
+static RCoreObjc *core_objc_new(RCore *core) {
 	RCoreObjc *o = R_NEW0 (RCoreObjc);
 	o->core = core;
 	o->word_size = (core->rasm->bits == 64)? 8: 4;

--- a/libr/core/anal_objc.c
+++ b/libr/core/anal_objc.c
@@ -19,6 +19,13 @@ typedef struct {
 	RBinSection *_data;
 } RCoreObjc;
 
+
+const size_t objc2ClassSize = 0x28;
+const size_t objc2ClassInfoOffs = 0x20;
+const size_t objc2ClassMethSize = 0x18;
+const size_t objc2ClassBaseMethsOffs = 0x20;
+const size_t objc2ClassMethImpOffs = 0x10;
+
 static void array_add(RCoreObjc *o, ut64 va, ut64 xrefs_to) {
 	bool found = false;
 	RVector *vec = ht_up_find (o->up, va, &found);
@@ -97,6 +104,7 @@ static ut64 getRefPtr(RCoreObjc *o, ut64 classMethodsVA, bool *rfound) {
 
 	RVector *vec = ht_up_find (o->up, namePtr, rfound);
 	if (!*rfound || !vec) {
+		*rfound = false;
 		return false;
 	}
 	ut64 *addr;
@@ -112,43 +120,46 @@ static ut64 getRefPtr(RCoreObjc *o, ut64 classMethodsVA, bool *rfound) {
 			cnt++;
 		}
 	}
+	if (cnt > 1 || ref == 0 || ref == UT64_MAX) {
+		*rfound = false;
+		return UT64_MAX;
+	}
 	// (cnt > 1 && ref != 0);
 	return isMsgRef? ref - 8: ref;
 }
 
 static bool objc_build_refs(RCoreObjc *objc) {
 	ut64 off;
-	if (!objc->_const || !objc->_selrefs) {
-		return false;
-	}
+	r_return_val_if_fail (objc->_const && objc->_selrefs, false);
 
+	const ut64 va_const = objc->_const->vaddr;
 	size_t ss_const = objc->_const->vsize;
+	const ut64 va_selrefs = objc->_selrefs->vaddr;
 	size_t ss_selrefs = objc->_selrefs->vsize;
+
 	// TODO: check if ss_const or ss_selrefs are too big before going further
 	size_t maxsize = R_MAX (ss_const, ss_selrefs);
 	ut8 *buf = calloc (1, maxsize);
 	if (!buf) {
 		return false;
 	}
-	const size_t word_size = objc->word_size;
+	const size_t word_size = objc->word_size; // assuming 8 because of the read_le64
 	if (!r_io_read_at (objc->core->io, objc->_const->vaddr, buf, ss_const)) {
 		eprintf ("aao: Cannot read the whole const section %zu\n", ss_const);
 		return false;
 	}
-	const ut64 va_const = objc->_const->vaddr;
-	for (off = 0; off + 8 < objc->_const->vsize; off += word_size) {
+	for (off = 0; off + word_size < ss_const; off += word_size) {
 		ut64 va = va_const + off;
 		ut64 xrefs_to = r_read_le64 (buf + off);
 		if (isValid (xrefs_to)) {
 			array_add (objc, va, xrefs_to);
 		}
 	}
-	if (!r_io_read_at (objc->core->io, objc->_selrefs->vaddr, buf, ss_selrefs)) {
+	if (!r_io_read_at (objc->core->io, va_selrefs, buf, ss_selrefs)) {
 		eprintf ("aao: Cannot read the whole selrefs section\n");
 		return false;
 	}
-	const ut64 va_selrefs = objc->_selrefs->vaddr;
-	for (off = 0; off + 8 < objc->_selrefs->vsize; off += word_size) {
+	for (off = 0; off + word_size < ss_selrefs; off += word_size) {
 		ut64 va = va_selrefs + off;
 		ut64 xrefs_to = r_read_le64 (buf + off);
 		if (isValid (xrefs_to)) {
@@ -159,18 +170,13 @@ static bool objc_build_refs(RCoreObjc *objc) {
 	return true;
 }
 
-static bool objc_find_refs(RCore *core) {
-	RCoreObjc objc = {0};
-
-	const size_t objc2ClassSize = 0x28;
-	const size_t objc2ClassInfoOffs = 0x20;
-	const size_t objc2ClassMethSize = 0x18;
-	const size_t objc2ClassBaseMethsOffs = 0x20;
-	const size_t objc2ClassMethImpOffs = 0x10;
-
-	objc.core = core;
-	objc.word_size = (core->rasm->bits == 64)? 8: 4;
-
+static RCoreObjc *core_objc_new (RCore *core) {
+	RCoreObjc *o = R_NEW0 (RCoreObjc);
+	o->core = core;
+	o->word_size = (core->rasm->bits == 64)? 8: 4;
+	if (o->word_size != 8) {
+		eprintf ("Warning: aao experimental on 32bit binaries\n");
+	}
 	RList *sections = r_bin_get_sections (core->bin);
 	if (!sections) {
 		return false;
@@ -181,30 +187,40 @@ static bool objc_find_refs(RCore *core) {
 	r_list_foreach (sections, iter, s) {
 		const char *name = s->name;
 		if (strstr (name, "__objc_data")) {
-			objc._data = s;
+			o->_data = s;
 		} else if (strstr (name, "__objc_selrefs")) {
-			objc._selrefs = s;
+			o->_selrefs = s;
 		} else if (strstr (name, "__objc_msgrefs")) {
-			objc._msgrefs = s;
+			o->_msgrefs = s;
 		} else if (strstr (name, "__objc_const")) {
-			objc._const = s;
+			o->_const = s;
 		}
 	}
-	if (!objc._const) {
-		if (core->anal->verbose) {
-			eprintf ("Could not find necessary objc_const section\n");
-		}
-		return false;
+	r_list_free (sections); // XXX
+	if (!o->_const || ((o->_selrefs || o->_msgrefs) && !(o->_data && o->_const))) {
+		free (o);
+		return NULL;
 	}
-	if ((objc._selrefs || objc._msgrefs) && !(objc._data && objc._const)) {
+	o->up = ht_up_new (NULL, kv_array_free, NULL);
+
+	return o;
+}
+
+static void core_objc_free(RCoreObjc *o) {
+	ht_up_free (o->up);
+	free (o);
+}
+
+static bool objc_find_refs(RCore *core) {
+	RCoreObjc *objc = core_objc_new (core);
+	if (!objc) {
 		if (core->anal->verbose) {
 			eprintf ("Could not find necessary Objective-C sections...\n");
 		}
 		return false;
 	}
 
-	objc.up = ht_up_new (NULL, kv_array_free, NULL);
-	if (!objc_build_refs (&objc)) {
+	if (!objc_build_refs (objc)) {
 		return false;
 	}
 	const char *oldstr = r_print_rowlog (core->print, "Parsing metadata in ObjC to find hidden xrefs");
@@ -213,22 +229,22 @@ static bool objc_find_refs(RCore *core) {
 	ut64 off;
 	size_t total_xrefs = 0;
 	bool readSuccess = true;
-	for (off = 0; off < objc._data->vsize && readSuccess; off += objc2ClassSize) {
+	for (off = 0; off < objc->_data->vsize && readSuccess; off += objc2ClassSize) {
 		if (!readSuccess || r_cons_is_breaked ()) {
 			break;
 		}
 
-		ut64 va = objc._data->vaddr + off;
-		ut64 classRoVA = readQword (&objc, va + objc2ClassInfoOffs, &readSuccess);
+		ut64 va = objc->_data->vaddr + off;
+		ut64 classRoVA = readQword (objc, va + objc2ClassInfoOffs, &readSuccess);
 		if (!readSuccess || isInvalid (classRoVA)) {
 			continue;
 		}
-		ut64 classMethodsVA = readQword (&objc, classRoVA + objc2ClassBaseMethsOffs, &readSuccess);
+		ut64 classMethodsVA = readQword (objc, classRoVA + objc2ClassBaseMethsOffs, &readSuccess);
 		if (!readSuccess || isInvalid (classMethodsVA)) {
 			continue;
 		}
 
-		ut32 count = readDword (&objc, classMethodsVA + 4, &readSuccess);
+		ut32 count = readDword (objc, classMethodsVA + 4, &readSuccess);
 		if (!readSuccess || ((ut32)count == UT32_MAX)) {
 			continue;
 		}
@@ -239,13 +255,12 @@ static bool objc_find_refs(RCore *core) {
 			if (r_cons_is_breaked ()) {
 				break;
 			}
-
 			bool found = false;
-			ut64 selRefVA = getRefPtr (&objc, va, &found);
+			ut64 selRefVA = getRefPtr (objc, va, &found);
 			if (!found) {
 				continue;
 			}
-			ut64 funcVA = readQword (&objc, va + objc2ClassMethImpOffs, &readSuccess);
+			ut64 funcVA = readQword (objc, va + objc2ClassMethImpOffs, &readSuccess);
 			if (!readSuccess) {
 				break;
 			}
@@ -261,23 +276,23 @@ static bool objc_find_refs(RCore *core) {
 			}
 		}
 	}
-	ht_up_free (objc.up);
 
-	const ut64 from = objc._selrefs->vaddr;
-	const ut64 to = from + objc._selrefs->vsize;
+	const ut64 va_selrefs = objc->_selrefs->vaddr;
+	const ut64 ss_selrefs = va_selrefs + objc->_selrefs->vsize;
 
 	char rs[128];
 	snprintf (rs, sizeof (rs), "Found %zu objc xrefs...", total_xrefs);
 	r_print_rowlog (core->print, rs);
 	size_t total_words = 0;
 	ut64 a;
-	const size_t word_size = objc.word_size;
-	for (a = from; a < to; a += word_size) {
+	const size_t word_size = objc->word_size;
+	for (a = va_selrefs; a < ss_selrefs; a += word_size) {
 		r_meta_set (core->anal, R_META_TYPE_DATA, a, word_size, NULL);
 		total_words++;
 	}
 	snprintf (rs, sizeof (rs), "Found %zu objc xrefs in %zu dwords.", total_xrefs, total_words);
 	r_print_rowlog_done (core->print, rs);
+	core_objc_free (objc);
 	return true;
 }
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -467,7 +467,7 @@ R_API char* r_core_add_asmqjmp(RCore *core, ut64 addr);
 R_API void r_core_anal_type_init(RCore *core);
 R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn);
 R_API void r_core_anal_inflags (RCore *core, const char *glob);
-R_API int cmd_anal_objc (RCore *core, const char *input, bool auto_anal);
+R_API bool cmd_anal_objc (RCore *core, const char *input, bool auto_anal);
 R_API void r_core_anal_cc_init(RCore *core);
 R_API void r_core_anal_paths(RCore *core, ut64 from, ut64 to, bool followCalls, int followDepth, bool is_json);
 R_API void r_core_anal_esil_graph(RCore *core, const char *expr);

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -68,3 +68,17 @@ EXPECT=<<EOF
 0x1000031e8 [0x100001d80 - 0x100001d80]      0 class 0 TestSwiftObjc.ThisIsASwiftClass :: NSObject
 EOF
 RUN
+
+NAME=aao hello-objc selrefs
+FILE=bins/mach0/hello-objc
+CMDS=aao;ax~sel
+EXPECT=<<EOF
+              section.0.__TEXT.__text+20 0x100000db4 ->      DATA -> 0x100001150 section.14.__DATA.__objc_selrefs
+                                 main+15 0x100000e5f ->      DATA -> 0x100001158 section.14.__DATA.__objc_selrefs+8
+                                 main+45 0x100000e7d ->      DATA -> 0x100001160 section.14.__DATA.__objc_selrefs+16
+                                 main+64 0x100000e90 ->      DATA -> 0x100001168 section.14.__DATA.__objc_selrefs+24
+                                 main+86 0x100000ea6 ->      DATA -> 0x100001158 section.14.__DATA.__objc_selrefs+8
+                                main+116 0x100000ec4 ->      DATA -> 0x100001160 section.14.__DATA.__objc_selrefs+16
+                                main+135 0x100000ed7 ->      DATA -> 0x100001168 section.14.__DATA.__objc_selrefs+24
+EOF
+RUN

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -71,8 +71,9 @@ RUN
 
 NAME=aao hello-objc selrefs
 FILE=bins/mach0/hello-objc
-CMDS=aao;ax~sel
+CMDS=aao;ax~?;ax~selref
 EXPECT=<<EOF
+92
               section.0.__TEXT.__text+20 0x100000db4 ->      DATA -> 0x100001150 section.14.__DATA.__objc_selrefs
                                  main+15 0x100000e5f ->      DATA -> 0x100001158 section.14.__DATA.__objc_selrefs+8
                                  main+45 0x100000e7d ->      DATA -> 0x100001160 section.14.__DATA.__objc_selrefs+16
@@ -80,5 +81,13 @@ EXPECT=<<EOF
                                  main+86 0x100000ea6 ->      DATA -> 0x100001158 section.14.__DATA.__objc_selrefs+8
                                 main+116 0x100000ec4 ->      DATA -> 0x100001160 section.14.__DATA.__objc_selrefs+16
                                 main+135 0x100000ed7 ->      DATA -> 0x100001168 section.14.__DATA.__objc_selrefs+24
+EOF
+RUN
+
+NAME=aao hello-objc selrefs
+FILE=bins/mach0/hello-objc
+CMDS=aao;ax~method
+EXPECT=<<EOF
+method.Person.name
 EOF
 RUN

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -71,7 +71,11 @@ RUN
 
 NAME=aao hello-objc selrefs
 FILE=bins/mach0/hello-objc
-CMDS=aao;ax~?;ax~selref
+CMDS=<<EOF
+aao
+ax~?
+ax~selref
+EOF
 EXPECT=<<EOF
 92
               section.0.__TEXT.__text+20 0x100000db4 ->      DATA -> 0x100001150 section.14.__DATA.__objc_selrefs
@@ -84,10 +88,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=aao hello-objc selrefs
+NAME=aao hello-objc methods references
 FILE=bins/mach0/hello-objc
 CMDS=aao;ax~method
 EXPECT=<<EOF
-method.Person.name
+              section.0.__TEXT.__text+20 0x100000db4 ->      CODE -> 0x100000df0 method.Person.name
+                                 main+45 0x100000e7d ->      CODE -> 0x100000e20 method.Person.setName:
+                                main+116 0x100000ec4 ->      CODE -> 0x100000e20 method.Person.setName:
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The aao command has been optimized a couple of times, based on the origin which was a Python script, the boost compared to the original script is more than 10 times faster. With this refactoring and cleanup I plan to make it even faster.

* [x] Reuse heap allocation between 
* [x] Use size_t instead of int for loops
* [x] Use bool ref to indicate success instead of UT64_MAX
* [x] Reduce unnecessary dereferences on non modified variables
* [x] Use more const and inline
* [x] Improve rowlog messages
* [x] Remove the use of sdb_fmt
* [x] Replace SDB+sprintf into plain HtUP+Vector
* [.] Use a single allocation instead of all the readQword calls (future optimization)

**Test plan**

There are objc tests for this already, but i may add another one and do proper benchmarking.

**Closing issues**

None