### PR TITLE
Fix r_cons_yesno. Key variable was never changed

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -663,6 +663,7 @@ R_API bool r_cons_yesno(int def, const char *fmt, ...) {
 	r_cons_set_raw (true);
 	char buf[] = " ?\n";
 	if (read (0, buf + 1, 1) == 1) {
+		key = (ut8)buf[1];
 		if (write (2, buf, 3) == 3) {
 			if (key == 'Y') {
 				key = 'y';


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Output was not printed when `r_cons_yesno` was called.
Reproducer:
```
[0x00400de0]> pd 1234
Do you want to print 1257 lines? (y/N) y
[0x00400de0]> 
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Just try the reproducer, it should print 1234 lines of output (on any binary).
