### PR TITLE
Fix root help in newshell

### DIFF
--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -72,6 +72,7 @@ R_API RCmd *r_cmd_new(void) {
 	cmd->nullcallback = cmd->data = NULL;
 	cmd->ht_cmds = ht_pp_new0 ();
 	cmd->root_cmd_desc = create_cmd_desc (cmd, NULL, R_CMD_DESC_TYPE_ARGV, "", NULL);
+	cmd->root_cmd_desc->help = NULL;
 	r_core_plugin_init (cmd);
 	r_cmd_macro_init (&cmd->macro);
 	r_cmd_alias_init (cmd);
@@ -507,7 +508,7 @@ R_API char *r_cmd_get_help(RCmd *cmd, RCmdParsedArgs *args, bool use_color) {
 
 	RCmdDesc *cd = cmdid_p >= cmdid? r_cmd_get_desc (cmd, cmdid): r_cmd_get_root (cmd);
 	free (cmdid);
-	if (!cd) {
+	if (!cd || !cd->help) {
 		return NULL;
 	}
 

--- a/test/db/cmd/cmd_help
+++ b/test/db/cmd/cmd_help
@@ -225,3 +225,14 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME="base help"
+FILE=-
+CMDS=<<EOF
+?~print
+EOF
+EXPECT=<<EOF
+| p[?] [len]              print current block with format and length
+| x[?] [len]              alias for 'px' (print hexadecimal)
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

If root_cmddesc has `help` enabled, it will try to generate the help automatically. However, for now we don't have all the correct messages in place, so it would show wrong stuff.

By setting `help` to NULL we ensure that `?` just fallbacks to old command handler.