### PR TITLE
Allow disabling non-ascii char truncation from mostly ascii strings (str.truncnonascii) ##strings

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -260,39 +260,41 @@ static int string_scan_range(RList *list, RBinFile *bf, int min,
 					}
 				}
 			}
-			switch (str_type) {
-			case R_STRING_TYPE_UTF8:
-			case R_STRING_TYPE_WIDE:
-			case R_STRING_TYPE_WIDE32:
-				num_blocks = 0;
-				block_list = r_utf_block_list ((const ut8*)tmp, i - 1,
-				                               str_type == R_STRING_TYPE_WIDE ? &freq_list : NULL);
-				if (block_list) {
-					for (j = 0; block_list[j] != -1; j++) {
-						num_blocks++;
-					}
-				}
-				if (freq_list) {
-					num_chars = 0;
-					actual_ascii = 0;
-					for (j = 0; freq_list[j] != -1; j++) {
-						num_chars += freq_list[j];
-						if (!block_list[j]) { // ASCII
-							actual_ascii = freq_list[j];
+			if (bin->trunc_nonascii) {
+				switch (str_type) {
+				case R_STRING_TYPE_UTF8:
+				case R_STRING_TYPE_WIDE:
+				case R_STRING_TYPE_WIDE32:
+					num_blocks = 0;
+					block_list = r_utf_block_list (
+					    (const ut8*)tmp, i - 1, str_type == R_STRING_TYPE_WIDE ? &freq_list : NULL);
+					if (block_list) {
+						for (j = 0; block_list[j] != -1; j++) {
+							num_blocks++;
 						}
 					}
-					free (freq_list);
-					expected_ascii = num_blocks ? num_chars / num_blocks : 0;
-					if (actual_ascii > expected_ascii) {
-						ascii_only = true;
-						needle = str_start;
-						free (block_list);
+					if (freq_list) {
+						num_chars = 0;
+						actual_ascii = 0;
+						for (j = 0; freq_list[j] != -1; j++) {
+							num_chars += freq_list[j];
+							if (!block_list[j]) { // ASCII
+								actual_ascii = freq_list[j];
+							}
+						}
+						free (freq_list);
+						expected_ascii = num_blocks ? num_chars / num_blocks : 0;
+						if (actual_ascii > expected_ascii) {
+							ascii_only = true;
+							needle = str_start;
+							free (block_list);
+							continue;
+						}
+					}
+					free (block_list);
+					if (num_blocks > R_STRING_MAX_UNI_BLOCKS) {
 						continue;
 					}
-				}
-				free (block_list);
-				if (num_blocks > R_STRING_MAX_UNI_BLOCKS) {
-					continue;
 				}
 			}
 			RBinString *bs = R_NEW0 (RBinString);

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -764,9 +764,6 @@ R_API RList *r_bin_reset_strings(RBin *bin) {
 		bf->o->strings = NULL;
 	}
 
-	if (bin->minstrlen <= 0) {
-		return NULL;
-	}
 	bf->rawstr = bin->rawstr;
 	RBinPlugin *plugin = r_bin_file_cur_plugin (bf);
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -940,6 +940,16 @@ static bool cb_binstrenc (void *user, void *data) {
 	return false;
 }
 
+static bool cb_truncnonascii(void *user, void *data) {
+	RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (core->bin) {
+		core->bin->trunc_nonascii = node->i_value;
+		r_bin_reset_strings (core->bin);
+	}
+	return true;
+}
+
 static bool cb_binfilter(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
@@ -3602,6 +3612,7 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* str */
 	SETCB ("str.escbslash", "false", &cb_str_escbslash, "Escape the backslash");
+	SETCB ("str.truncnonascii", "true", &cb_truncnonascii, "Truncate non-ascii chars from ascii strings");
 
 	/* search */
 	SETCB ("search.contiguous", "true", &cb_contiguous, "Accept contiguous/adjacent search hits");

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -332,6 +332,7 @@ typedef struct r_bin_t {
 	char *srcdir; // dir.source
 	char *prefix; // bin.prefix
 	char *strenc;
+	bool trunc_nonascii;
 	ut64 filter_rules;
 	bool demanglercmd;
 	bool verbose;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3443,17 +3443,22 @@ f main @ 0x0000142e
 EOF
 RUN
 
-NAME=iz utf16le
-BROKEN=1
+NAME=iz utf16le; str.truncnonascii
 FILE=bins/elf/strenc
 CMDS=<<EOF
 e str.escbslash=true
+e str.truncnonascii=true
 iz~green
 iz~wall
+?e
+e str.truncnonascii=false
+iz~green
 EOF
 EXPECT=<<EOF
-005 0x00002248 0x00402248  57 118 (.rodata) utf16le \nutf16le> \\u00a2\\u20ac\\U00010348 in green:\e[32m ¢€𐍈 \e[0m\n blocks=Basic Latin,Latin-1 Supplement,Currency Symbols,Gothic
-007 0x000022c8 0x004022c8  33  68 (.rodata) utf16le is a wall with no embedded zeros\n
+5   0x00002248 0x00402248 48  97   .rodata utf16le \nutf16le> \\u00a2\\u20ac\\U00010348 in green:\e[32m 
+8   0x000022c8 0x004022c8 33  68   .rodata utf16le is a wall with no embedded zeros\n
+
+5   0x00002248 0x00402248 57  118  .rodata utf16le \nutf16le> \\u00a2\\u20ac\\U00010348 in green:\e[32m ¢€𐍈 \e[0m\n blocks=Basic Latin,Latin-1 Supplement,Currency Symbols,Gothic
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr allows the disabling of the truncation of non-ascii chars from ascii strings using str.truncnonascii.

Also, this pr removes the minstrlen check from r_bin_reset_strings() since it has no business checking it.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

GitHubCI and AppVeyor are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
