### PR TITLE
Fix debugee to inherit original environment variables ##debug

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -296,6 +296,8 @@ static const char *help_msg_do[] = {
 	"Usage:", "do", " # Debug (re)open commands",
 	"do", "", "Open process (reload, alias for 'oo')",
 	"dor", " [rarun2]", "Comma separated list of k=v rarun2 profile options (e dbg.profile)",
+	"doe", "", "Show rarun2 startup profile",
+	"doe!", "", "Edit rarun2 startup profile with $EDITOR",
 	"doo", " [args]", "Reopen in debug mode with args (alias for 'ood')",
 	"doof", " [args]", "Reopen in debug mode from file (alias for 'oodf')",
 	"doc", "", "Close debug session",
@@ -5382,6 +5384,26 @@ static int cmd_debug(void *data, const char *input) {
 		switch (input[1]) {
 		case '\0': // "do"
 			r_core_file_reopen (core, input[1] ? input + 2: NULL, 0, 1);
+			break;
+		case 'e': // "doe"
+			switch (input[2]) {
+			case '\0': // "doe"
+				if (core->io->envprofile) {
+					r_cons_println (core->io->envprofile);
+				}
+				break;
+			case '!': // "doe!"
+			{
+				char *out = r_core_editor (core, NULL, core->io->envprofile);
+				if (out) {
+					free (core->io->envprofile);
+					core->io->envprofile = out;
+					eprintf ("%s\n", core->io->envprofile);
+				}
+			} break;
+			default:
+				break;
+			}
 			break;
 		case 'r': // "dor" : rarun profile
 			if (input[2] == ' ') {

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -100,6 +100,7 @@ typedef struct r_io_t {
 	RIOUndo undo;
 	SdbList *plugins;
 	char *runprofile;
+	char *envprofile;
 #if USE_PTRACE_WRAP
 	struct ptrace_wrap_instance_t *ptrace_wrap;
 #endif

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -34,6 +34,7 @@ R_API void r_sys_info_free(RSysInfo *si);
 
 R_API int r_sys_sigaction(int *sig, void (*handler) (int));
 R_API int r_sys_signal(int sig, void (*handler) (int));
+R_API void r_sys_env_init(void);
 R_API char **r_sys_get_environ(void);
 R_API void r_sys_set_environ(char **e);
 R_API ut64 r_sys_now(void);

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -106,9 +106,13 @@ R_API bool r_run_parse(RRunProfile *pf, const char *profile) {
 		return false;
 	}
 	r_str_replace_char (str, '\r',0);
-	for (p = str; (o = strchr (p, '\n')); p = o) {
-		*o++ = 0;
+	p = str;
+	while (p) {
+		if ((o = strchr (p, '\n'))) {
+			*o++ = 0;
+		}
 		r_run_parseline (pf, p);
+		p = o;
 	}
 	free (str);
 	return true;
@@ -379,13 +383,12 @@ static int handle_redirection_proc(const char *cmd, bool in, bool out, bool err)
 }
 
 static int handle_redirection(const char *cmd, bool in, bool out, bool err) {
-	r_return_val_if_fail (cmd, 0);
 #if __APPLE__ && !__POWERPC__
 	//XXX handle this in other layer since things changes a little bit
 	//this seems like a really good place to refactor stuff
 	return 0;
 #else
-	if (!*cmd) {
+	if (!cmd || !*cmd) {
 		return 0;
 	}
 	if (cmd[0] == '"') {
@@ -1125,7 +1128,7 @@ R_API int r_run_start(RRunProfile *p) {
 #if __UNIX__
 		// XXX HACK close all non-tty fds
 		{ int i;
-			for (i = 3; i < 10; i++) {
+			for (i = 3; i < 1024; i++) {
 				close (i);
 			}
 		}

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -371,14 +371,12 @@ R_API int r_sys_clearenv(void) {
 #if __APPLE__ && !HAVE_ENVIRON
 	/* do nothing */
 	if (!env) {
-		env = r_sys_get_environ ();
+		r_sys_env_init ();
 		return 0;
 	}
-	if (env) {
-		char **e = env;
-		while (*e) {
-			*e++ = NULL;
-		}
+	char **e = env;
+	while (*e) {
+		*e++ = NULL;
 	}
 #else
 	if (!environ) {
@@ -1208,8 +1206,14 @@ R_API char *r_sys_pid_to_path(int pid) {
 #endif
 }
 
-// TODO: rename to r_sys_env_init()
-R_API char **r_sys_get_environ (void) {
+R_API void r_sys_env_init(void) {
+	char **envp = r_sys_get_environ ();
+	if (envp) {
+		r_sys_set_environ (envp);
+	}
+}
+
+R_API char **r_sys_get_environ(void) {
 #if __APPLE__ && !HAVE_ENVIRON
 	env = *_NSGetEnviron();
 #else
@@ -1222,7 +1226,7 @@ R_API char **r_sys_get_environ (void) {
 	return env;
 }
 
-R_API void r_sys_set_environ (char **e) {
+R_API void r_sys_set_environ(char **e) {
 	env = e;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Duplicate and save the original `environ` and use it for `execvpe` later in `io_debug` so the child process will not inherit the `environ` of `r2`. 

**Test plan**
Run `env -i /usr/local/bin/r2 -c dc -d /usr/bin/env` and check for empty outputs. However, afaik there is no way to run command like that in the test suite. This test should be done in debug mode, so a custom binary is required to check for environment variables set by `r2` and one of which is in `PATH`. But, this way will make the test depends on the binary and any changes in future will require the binary to be replaced to make the test valid which is too troublesome. I would be glad to receive any suggestion on this.

**Closing issues**

closes #16359 