### PR TITLE
r_file_slurp: don't choke on an empty file ##util

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -370,9 +370,6 @@ R_API char *r_file_slurp(const char *str, R_NULLABLE size_t *usz) {
 			/* proc file */
 			fseek (fd, 0, SEEK_SET);
 			sz = r_file_proc_size (fd);
-			if (!sz) {
-				sz = -1;
-			}
 		} else {
 			sz = 65536;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

If `0` is an empty file:

```
% radiff 0 1
radiff2: Cannot open 0
```

This patch fixes it.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
