### PR TITLE
Fix wrong type warning

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -870,7 +870,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			}
 			r_io_map_new (r->io, fh->fd, 7, 0LL, mapaddr,
 					r_io_fd_size (r->io, fh->fd));
-			r_io_write_at (r->io, mapaddr, buf, sz);
+			r_io_write_at (r->io, mapaddr, (const ut8 *)buf, sz);
 			r_core_block_read (r);
 			free (buf);
 			free (path);


### PR DESCRIPTION
Fixes
```
../libr/main/radare2.c: In function ‘r_main_radare2’:
../libr/main/radare2.c:873:35: warning: pointer targets in passing argument 3 of ‘r_io_write_at’ differ in signedness [-Wpointer-sign]
  873 |    r_io_write_at (r->io, mapaddr, buf, sz);             
      |                                   ^~~                                                  
      |                                   |                                                    
      |                                   char *                                               
In file included from ../libr/include/r_core.h:11,
                 from ../libr/main/radare2.c:12:                                               
../libr/include/r_io.h:334:58: note: expected ‘const unsigned char *’ but argument is of type ‘char *’
  334 | R_API bool r_io_write_at (RIO *io, ut64 addr, const ut8 *buf, int len);                
      |                                               ~~~~~~~~~~~^~~                           

```