### PR TITLE
Fix Windows #!pipe

### DIFF
--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -23,22 +23,10 @@ static HANDLE myCreateChildProcess(const char * szCmdline) {
 	BOOL bSuccess = FALSE;
 	siStartInfo.cb = sizeof (STARTUPINFO);
 	siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+	siStartInfo.hStdInput = GetStdHandle (STD_INPUT_HANDLE);
+	siStartInfo.hStdOutput = GetStdHandle (STD_OUTPUT_HANDLE);
+	siStartInfo.hStdError = GetStdHandle (STD_ERROR_HANDLE);
 
-	SECURITY_ATTRIBUTES saAttr;
-	saAttr.nLength = sizeof (SECURITY_ATTRIBUTES);
-	saAttr.bInheritHandle = TRUE;
-	saAttr.lpSecurityDescriptor = NULL;
-	LPTSTR pipeName = calloc (128, sizeof (TCHAR)); 
-	GetEnvironmentVariable (TEXT ("R2PIPE_PATH"), pipeName, 128);
-
-	pipe = CreateFile (pipeName,
-				GENERIC_READ | GENERIC_WRITE,
-				FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
-				&saAttr, OPEN_EXISTING, 0, NULL);
-
-	siStartInfo.hStdOutput = pipe;
-	siStartInfo.hStdInput = pipe;
-	siStartInfo.hStdError = pipe;
 	LPTSTR cmdline_ = r_sys_conv_utf8_to_win (szCmdline);
 	bSuccess = CreateProcess (NULL, cmdline_, NULL, NULL,
 		TRUE, 0, NULL, NULL, &siStartInfo, &piProcInfo);
@@ -60,7 +48,7 @@ static void lang_pipe_run_win(RLang *lang) {
 	CHAR buf[PIPE_BUF_SIZE];
 	BOOL bSuccess = TRUE;
 	int i, res = 0;
-	DWORD dwRead = 0, dwWritten = 0, dwLeft = 1;
+	DWORD dwRead = 0, dwWritten = 0;
 	r_cons_break_push (NULL, NULL);
 	do {
 		if (r_cons_is_breaked ()) {
@@ -68,13 +56,10 @@ static void lang_pipe_run_win(RLang *lang) {
 			break;
 		}
 		memset (buf, 0, PIPE_BUF_SIZE);
-		while (bSuccess && (!dwLeft || !dwRead)) {
-			bSuccess = PeekNamedPipe (hPipeInOut, buf, PIPE_BUF_SIZE, &dwRead, NULL, &dwLeft);
-			if (bStopPipeLoop && (!dwLeft || !dwRead)) {
-				break;
-			}
-		}
-		if (bSuccess && (dwRead || dwLeft)) {
+		do {
+			bSuccess = PeekNamedPipe (hPipeInOut, buf, PIPE_BUF_SIZE, &dwRead, NULL, NULL);
+		} while (bSuccess && !bStopPipeLoop && !dwRead);
+		if (bSuccess && dwRead) {
 			bSuccess = ReadFile (hPipeInOut, buf, PIPE_BUF_SIZE, &dwRead, NULL);
 		}
 		if (bSuccess && dwRead > 0) {
@@ -223,10 +208,6 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 	char *r2pipe_var = r_str_newf ("R2PIPE_IN%x", _getpid ());
 	char *r2pipe_paz = r_str_newf ("\\\\.\\pipe\\%s", r2pipe_var);
 	LPTSTR r2pipe_paz_ = r_sys_conv_utf8_to_win (r2pipe_paz);
-	SECURITY_ATTRIBUTES saAttr;
-	saAttr.nLength = sizeof (SECURITY_ATTRIBUTES);
-	saAttr.bInheritHandle = TRUE;
-	saAttr.lpSecurityDescriptor = NULL;
 
 	SetEnvironmentVariable (TEXT ("R2PIPE_PATH"), r2pipe_paz_);
 	hPipeInOut = CreateNamedPipe (r2pipe_paz_,
@@ -234,9 +215,17 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT, PIPE_UNLIMITED_INSTANCES,
 			PIPE_BUF_SIZE,
 			PIPE_BUF_SIZE,
-			0, &saAttr);
+			0, NULL);
+	if (hPipeInOut == INVALID_HANDLE_VALUE) {
+		eprintf ("CreateNamedPipe failed: %#x\n", (int)GetLastError ());
+		goto beach;
+	}
 	hproc = myCreateChildProcess (code);
+	bool connected = false;
 	if (hproc) {
+		connected = ConnectNamedPipe (hPipeInOut, NULL) ? true : (GetLastError () == ERROR_PIPE_CONNECTED);
+	}
+	if (hproc && connected) {
 		/* a separate thread is created that sets bStopPipeLoop once hproc terminates. */
 		bStopPipeLoop = FALSE;
 		CloseHandle (CreateThread (NULL, 0, WaitForProcThread, NULL, 0, NULL));
@@ -246,6 +235,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 	}
 	DeleteFile (r2pipe_paz_);
 	CloseHandle (hPipeInOut);
+beach:
 	free (r2pipe_var);
 	free (r2pipe_paz);
 	free (r2pipe_paz_);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the Windows #!pipe code so that it works.

This is the companion pr to radareorg/radare2-r2pipe#117.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tested with the following Python 3 script using the `. <script>` command:

```python
import r2pipe
r2 = r2pipe.open()
r2.cmd('aa')
print('\nFunction names:')
for func in r2.cmdj('aflj'):
    print(func['name'])
print('\nDisassembly of entry0:')
print(r2.cmd('pdf'))
```

Further tests on other scripts welcome.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

**TODO**

- [ ] Eliminate busy-waiting on PeekNamedPipe()