### PR TITLE
Fix #16730 - Add bounds check to r_vector_insert ##util

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -77,7 +77,10 @@ static inline bool r_vector_empty(const RVector *vec) {
 R_API void r_vector_clear(RVector *vec);
 
 // returns a pointer to the offset inside the array where the element of the index lies.
-R_API void *r_vector_index_ptr(RVector *vec, size_t index);
+static inline void *r_vector_index_ptr(RVector *vec, size_t index) {
+	r_return_val_if_fail (vec && index < vec->capacity, NULL);
+	return (char *)vec->a + vec->elem_size * index;
+}
 
 // helper function to assign an element of size vec->elem_size from elem to p.
 // elem is a pointer to the actual data to assign!
@@ -169,14 +172,17 @@ R_API void r_pvector_clear(RPVector *vec);
 R_API void r_pvector_free(RPVector *vec);
 
 static inline size_t r_pvector_len(const RPVector *vec) {
+	r_return_val_if_fail (vec, 0);
 	return vec->v.len;
 }
 
 static inline void *r_pvector_at(const RPVector *vec, size_t index) {
+	r_return_val_if_fail (vec && index < vec->v.len, NULL);
 	return ((void **)vec->v.a)[index];
 }
 
 static inline void r_pvector_set(RPVector *vec, size_t index, void *e) {
+	r_return_if_fail (vec && index < vec->v.len);
 	((void **)vec->v.a)[index] = e;
 }
 
@@ -186,11 +192,13 @@ static inline bool r_pvector_empty(RPVector *vec) {
 
 // returns a pointer to the offset inside the array where the element of the index lies.
 static inline void **r_pvector_index_ptr(RPVector *vec, size_t index) {
+	r_return_val_if_fail (vec && index < vec->v.capacity, NULL);
 	return ((void **)vec->v.a) + index;
 }
 
 // same as r_pvector_index_ptr(<vec>, 0)
 static inline void **r_pvector_data(RPVector *vec) {
+	r_return_val_if_fail (vec, NULL);
 	return (void **)vec->v.a;
 }
 

--- a/libr/util/binheap.c
+++ b/libr/util/binheap.c
@@ -13,7 +13,9 @@ static inline void _heap_down(RBinHeap *h, size_t i, void *x) {
 		}
 		r_pvector_set (&h->a, i, r_pvector_at (&h->a, j));
 	}
-	r_pvector_set (&h->a, i, x);
+	if (i < h->a.v.len) {
+		r_pvector_set (&h->a, i, x);
+	}
 }
 
 static inline void _heap_up(RBinHeap *h, size_t i, void *x) {

--- a/libr/util/binheap.c
+++ b/libr/util/binheap.c
@@ -45,8 +45,7 @@ R_API RBinHeap *r_binheap_new(RPVectorComparator cmp) {
 
 R_API void *r_binheap_pop(RBinHeap *h) {
 	void *ret = r_pvector_at (&h->a, 0);
-	h->a.v.len--;
-	_heap_down (h, 0, r_pvector_at (&h->a, h->a.v.len));
+	_heap_down (h, 0, r_pvector_pop (&h->a));
 	return ret;
 }
 

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -142,7 +142,7 @@ R_API void r_vector_remove_at(RVector *vec, size_t index, void *into) {
 }
 
 R_API void *r_vector_insert(RVector *vec, size_t index, void *x) {
-	r_return_val_if_fail (vec, NULL);
+	r_return_val_if_fail (vec && index <= vec->len, NULL);
 	if (vec->len >= vec->capacity) {
 		RESIZE_OR_RETURN_NULL (NEXT_VECTOR_CAPACITY);
 	}

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -108,14 +108,6 @@ R_API RVector *r_vector_clone(RVector *vec) {
 	return ret;
 }
 
-R_API void *r_vector_index_ptr(RVector *vec, size_t index) {
-	r_return_val_if_fail (vec, NULL);
-	if (index >= vec->capacity) {
-		return NULL;
-	}
-	return (char *)vec->a + vec->elem_size * index;
-}
-
 R_API void r_vector_assign(RVector *vec, void *p, void *elem) {
 	r_return_if_fail (vec && p && elem);
 	memcpy (p, elem, vec->elem_size);
@@ -158,7 +150,7 @@ R_API void *r_vector_insert(RVector *vec, size_t index, void *x) {
 }
 
 R_API void *r_vector_insert_range(RVector *vec, size_t index, void *first, size_t count) {
-	r_return_val_if_fail (vec, NULL);
+	r_return_val_if_fail (vec && index <= vec->len, NULL);
 	if (vec->len + count > vec->capacity) {
 		RESIZE_OR_RETURN_NULL (R_MAX (NEXT_VECTOR_CAPACITY, vec->len + count));
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Insert is only valid when the index lies inside the vector or exactly one after it.

**Closing issues**

Fix #16730