### PR TITLE
Fix some GCC 10.1 warnings

### DIFF
--- a/libr/anal/p/anal_arm_gnu.c
+++ b/libr/anal/p/anal_arm_gnu.c
@@ -43,8 +43,6 @@ static int op_thumb(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	arm_set_thumb (arminsn, true);
 	arm_set_input_buffer (arminsn, data);
 	arm_set_pc (arminsn, addr);
-	op->jump = op->fail = -1;
-	op->ptr = op->val = -1;
 	op->delay = 0;
 	op->size = arm_disasm_one_insn (arminsn);
 	op->jump = arminsn->jmp;

--- a/libr/anal/p/anal_pyc.c
+++ b/libr/anal/p/anal_pyc.c
@@ -59,9 +59,6 @@ static int pyc_op(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *data, int len, RA
 	ut64 func_base = func->start_offset;
 	ut32 extended_arg = 0, oparg = 0;
 	ut8 op_code = data[0];
-	op->jump = UT64_MAX;
-	op->fail = UT64_MAX;
-	op->ptr = op->val = UT64_MAX;
 	op->addr = addr;
 	op->sign = true;
 	op->type = R_ANAL_OP_TYPE_ILL;

--- a/libr/anal/p/anal_tms320_c55x_plus.c
+++ b/libr/anal/p/anal_tms320_c55x_plus.c
@@ -21,12 +21,8 @@ int tms320_c55x_plus_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int
 		return 0;
 	}
 
-	memset (op, 0, sizeof (RAnalOp));
-	op->type = R_ANAL_OP_TYPE_UNK;
 	op->addr = addr;
-	op->jump = op->fail = -1;
-	op->ptr = op->val = -1;
-        op->size = ins_len;
+	op->size = ins_len;
 
 	if (ins_len == 1) {
 		if (*ins == 0x20) {

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1774,7 +1774,6 @@ static int cmd_debug_map(RCore *core, const char *input) {
 					baddr = map->addr;
 
 					if (libname) {
-						char *cmd, *res;
 						const char *file = map->file? map->file: map->name;
 						char *newfile = NULL;
 						if (!r_file_exists (file)) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix GCC 10.1 warnings on Fedora 32.

Closes #17054 