### PR TITLE
Fix '.?e ?e msg' - interpret ? subcommands ##shell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1268,6 +1268,10 @@ static int cmd_interpret(void *data, const char *input) {
 	const char *host, *port, *cmd;
 	RCore *core = (RCore *)data;
 
+	if (!strcmp (input, "?")) {
+		r_core_cmd_help (core, help_msg_dot);
+		return 0;
+	}
 	switch (*input) {
 	case '\0': // "."
 		lastcmd_repeat (core, 0);
@@ -1352,9 +1356,6 @@ static int cmd_interpret(void *data, const char *input) {
 		break;
 	case '(': // ".("
 		r_cmd_macro_call (&core->rcmd->macro, input + 1);
-		break;
-	case '?': // ".?"
-		r_core_cmd_help (core, help_msg_dot);
 		break;
 	default:
 		if (*input >= 0 && *input <= 9) {

--- a/test/db/cmd/cmd_interpret
+++ b/test/db/cmd/cmd_interpret
@@ -7,3 +7,13 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=.?e ?e
+FILE=--
+CMDS=<<EOF
+.?e ?e hello world
+EOF
+EXPECT=<<EOF
+hello world
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

interpretting a line uising a subcommand of ? it was failing 

**Test plan**
i added a test

**Closing issues**

none