### PR TITLE
rasign2 refactoring ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -177,6 +177,14 @@ static RList *zign_types_to_list(RAnal *a, char *types) {
 	return ret;
 }
 
+static void bytes_sig_free(RSignBytes *bytes) {
+	if (bytes) {
+		free (bytes->bytes);
+		free (bytes->mask);
+		free (bytes);
+	}
+}
+
 R_API bool r_sign_deserialize(RAnal *a, RSignItem *it, const char *k, const char *v) {
 	char *refs = NULL;
 	char *vars = NULL;
@@ -325,7 +333,7 @@ R_API bool r_sign_deserialize(RAnal *a, RSignItem *it, const char *k, const char
 			// allocate
 			size = atoi (token);
 			if (size > 0) {
-				free (it->bytes);
+				bytes_sig_free (it->bytes);
 				it->bytes = R_NEW0 (RSignBytes);
 				if (!it->bytes) {
 					goto out;
@@ -517,11 +525,7 @@ static void mergeItem(RSignItem *dst, RSignItem *src) {
 	char *ref, *var, *type;
 
 	if (src->bytes) {
-		if (dst->bytes) {
-			free (dst->bytes->bytes);
-			free (dst->bytes->mask);
-			free (dst->bytes);
-		}
+		bytes_sig_free (dst->bytes);
 		dst->bytes = R_NEW0 (RSignBytes);
 		if (!dst->bytes) {
 			return;
@@ -530,14 +534,13 @@ static void mergeItem(RSignItem *dst, RSignItem *src) {
 		dst->bytes->size = src->bytes->size;
 		dst->bytes->bytes = malloc (src->bytes->size);
 		if (!dst->bytes->bytes) {
-			free (dst->bytes);
+			bytes_sig_free (dst->bytes);
 			return;
 		}
 		memcpy (dst->bytes->bytes, src->bytes->bytes, src->bytes->size);
 		dst->bytes->mask = malloc (src->bytes->size);
 		if (!dst->bytes->mask) {
-			free (dst->bytes->bytes);
-			free (dst->bytes);
+			bytes_sig_free (dst->bytes);
 			return;
 		}
 		memcpy (dst->bytes->mask, src->bytes->mask, src->bytes->size);
@@ -604,7 +607,7 @@ static void mergeItem(RSignItem *dst, RSignItem *src) {
 	}
 }
 
-static bool addItem(RAnal *a, RSignItem *it) {
+R_API bool r_sign_anal_additem(RAnal *a, RSignItem *it) {
 	char key[R_SIGN_KEY_MAXSZ], val[R_SIGN_VAL_MAXSZ];
 	const char *curval = NULL;
 	bool retval = true;
@@ -654,7 +657,7 @@ static bool addHash(RAnal *a, const char *name, int type, const char *val) {
 	switch (type) {
 	case R_SIGN_BBHASH:
 		it->hash->bbhash = strdup (val);
-		retval = addItem (a, it);
+		retval = r_sign_anal_additem (a, it);
 		r_sign_item_free (it);
 		break;
 	}
@@ -672,19 +675,11 @@ static bool addBBHash(RAnal *a, RAnalFunction *fcn, const char *name) {
 	if (!it->name) {
 		goto beach;
 	}
-	it->hash = R_NEW0 (RSignHash);
 	it->space = r_spaces_current (&a->zign_spaces);
-	if (!it->hash) {
-		goto beach;
-	}
 
-	char *digest_hex = r_sign_calc_bbhash (a, fcn);
-	if (!digest_hex) {
-		free (digest_hex);
-		goto beach;
+	if (r_sign_addto_item (a, it, fcn, R_SIGN_BBHASH)) {
+		retval = r_sign_anal_additem (a, it);
 	}
-	it->hash->bbhash = digest_hex;
-	retval = addItem (a, it);
 beach:
 	r_sign_item_free (it);
 	return retval;
@@ -724,16 +719,13 @@ static bool addBytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, co
 		goto fail;
 	}
 	memcpy (it->bytes->mask, mask, size);
-	retval = addItem (a, it);
+	retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 	return retval;
 fail:
 	if (it) {
 		free (it->name);
-		if (it->bytes) {
-			free (it->bytes->bytes);
-			free (it->bytes);
-		}
+		bytes_sig_free (it->bytes);
 	}
 	free (it);
 	return false;
@@ -774,6 +766,109 @@ R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *byt
 	return retval;
 }
 
+static RSignGraph *r_sign_fcn_graph(RAnalFunction *fcn) {
+	r_return_val_if_fail (fcn, false);
+	RSignGraph *graph = R_NEW0 (RSignGraph);
+	if (graph) {
+		graph->cc = r_anal_function_complexity (fcn),
+		graph->nbbs = r_list_length (fcn->bbs);
+		graph->edges = r_anal_function_count_edges (fcn, &graph->ebbs);
+		graph->bbsum = r_anal_function_realsize (fcn);
+	}
+	return graph;
+}
+
+static RSignBytes *r_sign_fcn_bytes(RAnal *a, RAnalFunction *fcn) {
+	r_return_val_if_fail (a && fcn, false);
+	RCore *core = a->coreb.core;
+	int maxsz = a->coreb.cfggeti (core, "zign.maxsz");
+	int fcnlen = r_anal_function_realsize (fcn);
+	int size = R_MIN (core->io->addrbytes * fcnlen, maxsz);
+
+	RSignBytes *sig = R_NEW0 (RSignBytes);
+	if (!sig) {
+		goto bytes_failed;
+	}
+	sig->size = size;
+
+	// hopefully not necissary, but just in case
+	if (size <= 0) {
+		eprintf ("error: Negative size for bytes signature\n");
+		goto bytes_failed;
+	}
+
+	// get bytes part of signature
+	if (!(sig->bytes = malloc (size))) {
+		goto bytes_failed;
+	}
+
+	if (!a->iob.read_at (a->iob.io, fcn->addr, sig->bytes, size)) {
+		eprintf ("error: failed to read at 0x%08" PFMT64x "\n", fcn->addr);
+		goto bytes_failed;
+	}
+
+	// get mask part of signature
+	if (!(sig->mask = r_anal_mask (a, size, sig->bytes, fcn->addr))) {
+		goto bytes_failed;
+	}
+
+	return sig;
+bytes_failed:
+	bytes_sig_free (sig);
+	return NULL;
+}
+
+static RSignHash *r_sign_fcn_bbhash(RAnal *a, RAnalFunction *fcn) {
+	r_return_val_if_fail (a && fcn, NULL);
+	RSignHash *hash = R_NEW0 (RSignHash);
+	if (!hash) {
+		return NULL;
+	}
+
+	char *digest_hex = r_sign_calc_bbhash (a, fcn);
+	if (!digest_hex) {
+		free (hash);
+		return NULL;
+	}
+	hash->bbhash = digest_hex;
+	return hash;
+}
+
+R_API bool r_sign_addto_item(RAnal *a, RSignItem *it, RAnalFunction *fcn, RSignType type) {
+	r_return_val_if_fail (a && it && fcn, false);
+	switch (type) {
+	case R_SIGN_GRAPH:
+		return !it->graph && (it->graph = r_sign_fcn_graph (fcn));
+	case R_SIGN_BYTES:
+		return !it->bytes && (it->bytes = r_sign_fcn_bytes (a, fcn));
+	case R_SIGN_XREFS:
+		return !it->xrefs && (it->xrefs = r_sign_fcn_xrefs (a, fcn));
+	case R_SIGN_REFS:
+		return !it->refs && (it->refs = r_sign_fcn_refs (a, fcn));
+	case R_SIGN_VARS:
+		return !it->vars && (it->vars = r_sign_fcn_vars (a, fcn));
+	case R_SIGN_TYPES:
+		return !it->types && (it->types = r_sign_fcn_types (a, fcn));
+	case R_SIGN_BBHASH:
+		return !it->hash && (it->hash = r_sign_fcn_bbhash (a, fcn));
+	case R_SIGN_OFFSET:
+		it->addr = fcn->addr;
+		return true;
+	case R_SIGN_NAME:
+		if (!it->realname && it->name) {
+			if (strcmp (it->name, fcn->name)) {
+				it->realname = strdup (fcn->name);
+			}
+			return true;
+		}
+		break;
+	default:
+		eprintf ("Error: %s Can not handle type %c\n", __FUNCTION__, type);
+	}
+
+	return false;
+}
+
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph) {
 	r_return_val_if_fail (a && !R_STR_ISEMPTY (name), false);
 	bool retval = true;
@@ -794,7 +889,7 @@ R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph) {
 		return false;
 	}
 	*it->graph = graph;
-	retval = addItem (a, it);
+	retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 
 	return retval;
@@ -810,7 +905,7 @@ R_API bool r_sign_add_comment(RAnal *a, const char *name, const char *comment) {
 	it->name = r_str_new (name);
 	it->space = r_spaces_current (&a->zign_spaces);
 	it->comment = strdup (comment);
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 	return retval;
 }
@@ -822,7 +917,7 @@ R_API bool r_sign_add_name(RAnal *a, const char *name, const char *realname) {
 		it->name = r_str_new (name);
 		it->realname = strdup (realname);
 		it->space = r_spaces_current (&a->zign_spaces);
-		bool retval = addItem (a, it);
+		bool retval = r_sign_anal_additem (a, it);
 		r_sign_item_free (it);
 		return retval;
 	}
@@ -840,7 +935,7 @@ R_API bool r_sign_add_addr(RAnal *a, const char *name, ut64 addr) {
 	it->space = r_spaces_current (&a->zign_spaces);
 	it->addr = addr;
 
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 
 	r_sign_item_free (it);
 
@@ -863,11 +958,11 @@ R_API bool r_sign_add_vars(RAnal *a, const char *name, RList *vars) {
 		return false;
 	}
 	it->space = r_spaces_current (&a->zign_spaces);
-	it->vars = r_list_newf ((RListFree) free);
+	it->vars = r_list_newf ((RListFree)free);
 	r_list_foreach (vars, iter, var) {
 		r_list_append (it->vars, strdup (var));
 	}
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 
 	return retval;
@@ -893,7 +988,7 @@ R_API bool r_sign_add_types(RAnal *a, const char *name, RList *types) {
 	r_list_foreach (types, iter, type) {
 		r_list_append (it->types, strdup (type));
 	}
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 
 	return retval;
@@ -918,7 +1013,7 @@ R_API bool r_sign_add_refs(RAnal *a, const char *name, RList *refs) {
 	r_list_foreach (refs, iter, ref) {
 		r_list_append (it->refs, strdup (ref));
 	}
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 
 	return retval;
@@ -943,7 +1038,7 @@ R_API bool r_sign_add_xrefs(RAnal *a, const char *name, RList *xrefs) {
 	r_list_foreach (xrefs, iter, ref) {
 		r_list_append (it->xrefs, strdup (ref));
 	}
-	bool retval = addItem (a, it);
+	bool retval = r_sign_anal_additem (a, it);
 	r_sign_item_free (it);
 
 	return retval;
@@ -1041,32 +1136,6 @@ static double matchGraph(RSignItem *a, RSignItem *b) {
 	return total / 5.0;
 }
 
-static RSignItem *create_graph_sign_from_fcn(RAnal *a, RAnalFunction *fcn) {
-	r_return_val_if_fail (a && fcn, false);
-
-	RSignGraph *graph = R_NEW0 (RSignGraph);
-	if (!graph) {
-		return NULL;
-	}
-	graph->cc = r_anal_function_complexity (fcn),
-	graph->nbbs = r_list_length (fcn->bbs);
-	graph->edges = r_anal_function_count_edges (fcn, &graph->ebbs);
-	graph->bbsum = r_anal_function_realsize (fcn);
-
-
-	RSignItem *item = r_sign_item_new ();
-	if (!item) {
-		r_sign_graph_free (graph);
-		return NULL;
-	}
-
-	item->name = r_str_new (fcn->name);
-	item->space = r_spaces_current (&a->zign_spaces);
-	item->graph = graph;
-
-	return item;
-}
-
 static int score_cmpr(const void *a, const void *b) {
 	double sa = ((RSignCloseMatch *)a)->score;
 	double sb = ((RSignCloseMatch *)b)->score;
@@ -1152,28 +1221,19 @@ R_API void r_sign_close_match_free(RSignCloseMatch *match) {
 	free (match);
 }
 
-R_API RList *r_sign_find_closest_sig(RAnal *a, RAnalFunction *fcn, int count, double score_threshold) {
-	r_return_val_if_fail (a && fcn && count > 0 && score_threshold <= 1 && score_threshold >= 0, false);
+R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double score_threshold) {
+	r_return_val_if_fail (a && it && count > 0 && score_threshold <= 1 && score_threshold >= 0, false);
 
 	ClosestMatchData data;
-	data.count = count;
-	data.score_threshold = score_threshold;
-	data.infimum = 0.0;
-
-	// create a graph for the current function to be compared against
-	RSignItem *test = create_graph_sign_from_fcn (a, fcn);
-	if (!test) {
-		return NULL;
-	}
-	data.test = test;
-
-	// sorted list will contian the closest matches
 	RList *output = r_list_newf ((RListFree)r_sign_close_match_free);
 	if (!output) {
-		r_sign_item_free (test);
 		return NULL;
 	}
 	data.output = output;
+	data.count = count;
+	data.score_threshold = score_threshold;
+	data.infimum = 0.0;
+	data.test = it;
 
 	// TODO: handle sign spaces
 	if (!sdb_foreach (a->sdb_zigns, &closest_match_callback, (void *)&data)) {
@@ -1181,7 +1241,6 @@ R_API RList *r_sign_find_closest_sig(RAnal *a, RAnalFunction *fcn, int count, do
 		output = NULL;
 	}
 
-	r_sign_item_free (test);
 	return output;
 }
 
@@ -2388,11 +2447,7 @@ R_API void r_sign_item_free(RSignItem *item) {
 		return;
 	}
 	free (item->name);
-	if (item->bytes) {
-		free (item->bytes->bytes);
-		free (item->bytes->mask);
-		free (item->bytes);
-	}
+	bytes_sig_free(item->bytes);
 	if (item->hash) {
 		free (item->hash->bbhash);
 		free (item->hash);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -93,84 +93,6 @@ static void cmd_zign_init(RCore *core, RCmdDesc *parent) {
 	DEFINE_CMD_DESCRIPTOR (core, zc);
 }
 
-static bool addFcnHash(RCore *core, RAnalFunction *fcn, const char *name) {
-	r_return_val_if_fail (core && fcn && name, false);
-	return r_sign_add_bb_hash (core->anal, fcn, name);
-}
-
-static bool addFcnBytes(RCore *core, RAnalFunction *fcn, const char *name) {
-	r_return_val_if_fail (core && fcn && name, false);
-	int maxsz = r_config_get_i (core->config, "zign.maxsz");
-	int fcnlen = r_anal_function_realsize (fcn);
-	int len = R_MIN (core->io->addrbytes * fcnlen, maxsz);
-
-	ut8 *buf = malloc (len);
-	if (!buf) {
-		return false;
-	}
-
-	bool retval = false;
-	if (r_io_is_valid_offset (core->io, fcn->addr, 0)) {
-		(void)r_io_read_at (core->io, fcn->addr, buf, len);
-		retval = r_sign_add_anal (core->anal, name, len, buf, fcn->addr);
-	} else {
-		eprintf ("error: cannot read at 0x%08"PFMT64x"\n", fcn->addr);
-	}
-	free (buf);
-	return retval;
-}
-
-static bool addFcnGraph(RCore *core, RAnalFunction *fcn, const char *name) {
-	RSignGraph graph = {
-		.cc = r_anal_function_complexity (fcn),
-		.nbbs = r_list_length (fcn->bbs)
-	};
-	// XXX ebbs doesnt gets initialized if calling this from inside the struct
-	graph.edges = r_anal_function_count_edges (fcn, &graph.ebbs);
-	graph.bbsum = r_anal_function_realsize (fcn);
-	return r_sign_add_graph (core->anal, name, graph);
-}
-
-static bool addFcnXRefs(RCore *core, RAnalFunction *fcn, const char *name) {
-	bool retval = false;
-	RList *xrefs = r_sign_fcn_xrefs (core->anal, fcn);
-	if (xrefs) {
-		retval = r_sign_add_xrefs (core->anal, name, xrefs);
-		r_list_free (xrefs);
-	}
-	return retval;
-}
-
-static bool addFcnRefs(RCore *core, RAnalFunction *fcn, const char *name) {
-	RList *refs = r_sign_fcn_refs (core->anal, fcn);
-	if (!refs) {
-		return false;
-	}
-	bool retval = r_sign_add_refs (core->anal, name, refs);
-	r_list_free (refs);
-	return retval;
-}
-
-static bool addFcnVars(RCore *core, RAnalFunction *fcn, const char *name) {
-	RList *vars = r_sign_fcn_vars (core->anal, fcn);
-	if (!vars) {
-		return false;
-	}
-	bool retval = r_sign_add_vars (core->anal, name, vars);
-	r_list_free (vars);
-	return retval;
-}
-
-static bool addFcnTypes(RCore *core, RAnalFunction *fcn, const char *name) {
-	RList *types = r_sign_fcn_types (core->anal, fcn);
-	if (!types) {
-		return false;
-	}
-	bool retval = r_sign_add_types (core->anal, name, types);
-	r_list_free (types);
-	return retval;
-}
-
 #if 0
 static char *getFcnComments(RCore *core, RAnalFunction *fcn) {
 	// XXX this is slow as hell on big binaries
@@ -205,26 +127,39 @@ static void addFcnZign(RCore *core, RAnalFunction *fcn, const char *name) {
 		zigname = r_str_appendf (zigname, "%s", fcn->name);
 	}
 
-	addFcnGraph (core, fcn, zigname);
-	addFcnBytes (core, fcn, zigname);
-	addFcnXRefs (core, fcn, zigname);
-	addFcnRefs (core, fcn, zigname);
-	addFcnVars (core, fcn, zigname);
-	addFcnTypes (core, fcn, zigname);
-	addFcnHash (core, fcn, zigname);
-	if (strcmp (zigname, fcn->name)) {
-		r_sign_add_name (core->anal, zigname, fcn->name);
+	// create empty item
+	RSignItem *it = r_sign_item_new ();
+	if (!it) {
+		free (zigname);
+		return;
 	}
-/*
+	// add sig types info to item
+	it->name = zigname; // will be free'd when item is free'd
+	it->space = r_spaces_current (&core->anal->zign_spaces);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_GRAPH);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_BYTES);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_XREFS);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_REFS);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_VARS);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_TYPES);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_BBHASH);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_OFFSET);
+	r_sign_addto_item (core->anal, it, fcn, R_SIGN_NAME);
+
+	/* r_sign_add_addr (core->anal, zigname, fcn->addr); */
+
+	// commit the item to anal
+	r_sign_anal_additem (core->anal, it);
+
+	/*
 	XXX this is very slow and poorly tested
 	char *comments = getFcnComments (core, fcn);
 	if (comments) {
 		r_sign_add_comment (core->anal, zigname, comments);
 	}
-*/
-	r_sign_add_addr (core->anal, zigname, fcn->addr);
+	*/
 
-	free (zigname);
+	r_sign_item_free (it); // causes zigname to be free'd
 	if (zignspace) {
 		r_spaces_pop (&core->anal->zign_spaces);
 		free (zignspace);
@@ -1061,10 +996,20 @@ static bool bestmatch(void *data, const char *input) {
 		}
 	}
 
-	r_cons_break_push (NULL, NULL);
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
-	if (fcn) {
-		RList *list = r_sign_find_closest_sig (core->anal, fcn, count, 0);
+	RSignItem *item = r_sign_item_new ();
+	if (!item) {
+		return NULL;
+	}
+
+	if (!r_sign_addto_item (core->anal, item, fcn, R_SIGN_GRAPH)) {
+		r_sign_item_free (item);
+		return NULL;
+	}
+
+	if (item->graph) {
+		r_cons_break_push (NULL, NULL);
+		RList *list = r_sign_find_closest_sig (core->anal, item, count, 0);
 		if (list) {
 			found = true;
 			RListIter *itr;
@@ -1074,9 +1019,10 @@ static bool bestmatch(void *data, const char *input) {
 			}
 			r_list_free (list);
 		}
+		r_cons_break_pop ();
 	}
 
-	r_cons_break_pop ();
+	r_sign_item_free (item);
 	return found;
 }
 

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -97,6 +97,7 @@ typedef struct {
 R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
 R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph);
+R_API bool r_sign_addto_item(RAnal *a, RSignItem *it, RAnalFunction *fcn, RSignType type);
 R_API bool r_sign_add_addr(RAnal *a, const char *name, ut64 addr);
 R_API bool r_sign_add_name(RAnal *a, const char *name, const char *realname);
 R_API bool r_sign_add_comment(RAnal *a, const char *name, const char *comment);
@@ -129,6 +130,7 @@ R_API bool r_sign_load(RAnal *a, const char *file);
 R_API bool r_sign_load_gz(RAnal *a, const char *filename);
 R_API char *r_sign_path(RAnal *a, const char *file);
 R_API bool r_sign_save(RAnal *a, const char *file);
+R_API bool r_sign_anal_additem(RAnal *a, RSignItem *it);
 
 R_API RSignItem *r_sign_item_new(void);
 R_API RSignItem *r_sign_item_dup(RSignItem *it);
@@ -144,7 +146,7 @@ R_API int r_sign_is_flirt(RBuffer *buf);
 R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file);
 R_API void r_sign_flirt_scan(RAnal *anal, const char *flirt_file);
 
-R_API RList *r_sign_find_closest_sig(RAnal *a, RAnalFunction *fcn, int count, double score_threshold);
+R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double score_threshold);
 R_API void r_sign_close_match_free(RSignCloseMatch *match);
 R_API bool r_sign_diff(RAnal *a, RSignOptions *options, const char *other_space_name);
 R_API bool r_sign_diff_by_name(RAnal *a, RSignOptions *options, const char *other_space_name, bool not_matching);

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1115,6 +1115,6 @@ zaf fcn.00484d40 fcn.00484d40
 zj
 EOF
 EXPECT=<<EOF
-[{"name":"fcn.00484d40","bytes":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c40848","mask":"ffffffffffffffffffffffffff00ffffffffffffff00000000ffffffffffffff00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","graph":{"cc":4,"nbbs":5,"edges":5,"ebbs":2,"bbsum":72},"addr":4738368,"refs":[],"xrefs":[],"vars":["r110"],"types":[{"name":"arg1","type":"int64_t"}],"hash":{"bbhash":"8ff8a5c7f84179483b764fbb18dc4c44f39da6527a0a16485c7ae519f00e687f"}}]
+[{"name":"fcn.00484d40","bytes":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c4084889d85b5dc3","mask":"ffffffffffffffffffffffffff00ffffffffffffff00000000ffffffffffffff00ffffffffffffffffffffffffffffffffffff0000000000ffffffffffffffffffffffffffffffffffffffffff","graph":{"cc":4,"nbbs":5,"edges":5,"ebbs":2,"bbsum":72},"addr":4738368,"refs":[],"xrefs":[],"vars":["r110"],"types":[{"name":"arg1","type":"int64_t"}],"hash":{"bbhash":"8ff8a5c7f84179483b764fbb18dc4c44f39da6527a0a16485c7ae519f00e687f"}}]
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This is a refactor of some sign code. It will result in a speed increase on signature creation. It will also help me to expand the `zb` command soon.

Currently, `zaf` on a single function will result in around 8 `RSignItem`'s being create, saved and then freed. Saving each individually causes a name collision which requires reallocating old items and merging.

The `r_sign_addto_item` function was created so a single `RSignitem` can easily have signature types added to it. The `addItem` function was renamed and added to the `r_sign` API. Now the `zaf` command will only allocate a single `RSignitem`, signatures are added to the item with `r_sign_addto_item`. Since only one item is saved there are no collisions under normal circumstances. 

I also updated the code for `zb` to use `r_sign_addto_item` which saves some lines of code. The interface for `r_sign_find_closest_sig` was updated to be more friendly.

As a result of this update `rasign2 libc.so` completes 1 second faster on my computer.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The commands `zaf`, `zaF` and `zb` are running on new code but should function identical to before. All current `r2r` tests for zignatures pass. 

Feel free to suggest better variable and function names. I am bad at naming things :( 
Also, I am not completely sure how `r_cons_break` works, so it maybe should be moved around in the `cmd_zign.c:bestmatch` function.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

None...
