### PR TITLE
Optimize and cleanup the dex_get_proto function ##bin

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -293,10 +293,11 @@ static char *dex_get_proto(RBinDexObj *bin, int proto_id) {
 		ut16 type_idx = r_read_le16 (typeidx_buf + off);
 		ut16 type_desc_id = type_desc (bin, type_idx);
 		if (type_desc_id == UT16_MAX) {
-			break;
+			r_strbuf_append (sig, "?;");
+		} else {
+			const char *buff = getstr (bin, type_desc_id);
+			r_strbuf_append (sig, buff? buff: "?;");
 		}
-		const char *buff = getstr (bin, type_desc_id);
-		r_strbuf_append (sig, buff? buff: "?");
 	}
 	r_strbuf_appendf (sig, ")%s", return_type);
 	free (typeidx_buf);

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -275,6 +275,10 @@ static char *dex_get_proto(RBinDexObj *bin, int proto_id) {
 	}
 	// size of the list, in 16 bit entries
 	ut32 list_size = r_read_le32 (params_buf);
+	if (list_size >= ST32_MAX) {
+		eprintf ("Warning: function prototype contains too many parameters (> 2 million).\n");
+		list_size = ST32_MAX;
+	}
 	size_t typeidx_bufsize = (list_size * sizeof (ut16));
 	if (params_off + typeidx_bufsize > bin->size) {
 		typeidx_bufsize = bin->size - params_off;

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -422,6 +422,15 @@ Class #1            -
 EOF
 RUN
 
+NAME=DEX radare2installer.dex classes (is getProper)
+FILE=bins/dex/org.radare.radare2installer.dex
+CMDS=is~getProper
+EXPECT=<<EOF
+1649  0x00006a20 0x00006a20 NONE   FUNC   0        imp.Ljava/lang/System.method.getProperty(Ljava/lang/String;)Ljava/lang/String;
+1650  0x00006a28 0x00006a28 NONE   FUNC   0        imp.Ljava/lang/System.method.getProperty(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+EOF
+RUN
+
 NAME=DEX radare2installer.dex classes (ic command)
 FILE=bins/dex/org.radare.radare2installer.dex
 CMDS=ic


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

reading function arguments is causing many r_io_read calls for methods with > 1 arg. this can be simplified to make the code more readable as well as use strbuf instead of manual pointer mangling.

There's almost no real speedup gain, but the code is more optimal.

**Test plan**

i added a test

**Closing issues**
noine