### PR TITLE
Initial implementation of io.fd plugin ##io

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -506,6 +506,7 @@ extern RIOPlugin r_io_plugin_ar;
 extern RIOPlugin r_io_plugin_rbuf;
 extern RIOPlugin r_io_plugin_winedbg;
 extern RIOPlugin r_io_plugin_gprobe;
+extern RIOPlugin r_io_plugin_fd;
 
 #if __cplusplus
 }

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -9,6 +9,7 @@ r_io_sources = [
   'undo.c',
   'p_cache.c',
   'p/io_ar.c',
+  'p/io_fd.c',
   'p/io_bfdbg.c',
   'p/io_bochs.c',
   'p/io_debug.c',

--- a/libr/io/p/fd.mk
+++ b/libr/io/p/fd.mk
@@ -1,0 +1,16 @@
+OBJ_FD=io_fd.o
+
+STATIC_OBJ+=${OBJ_FD}
+TARGET_FD=io_fd.${EXT_SO}
+ALL_TARGETS+=${TARGET_FD}
+
+ifeq (${WITHPIC},0)
+LINKFLAGS+=../../util/libr_util.a
+LINKFLAGS+=../../io/libr_io.a
+else
+LINKFLAGS+=-L../../util -lr_util
+LINKFLAGS+=-L.. -lr_io
+endif
+
+${TARGET_FD}: ${OBJ_FD}
+	${CC_LIB} $(call libname,io_fd) ${CFLAGS} -o ${TARGET_FD} ${OBJ_FD} ${LINKFLAGS}

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -58,23 +58,23 @@ static bool __check(RIO *io, const char *pathname, bool many) {
 }
 
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
-	if (__check (io, pathname, 0)) {
-		if (r_sandbox_enable (false)) {
-			eprintf ("Do not permit " FDURI " in sandbox mode.\n");
+	if (r_sandbox_enable (false)) {
+		eprintf ("Do not permit " FDURI " in sandbox mode.\n");
+		return NULL;
+	}
+	if (!__check (io, pathname, 0)) {
+		return NULL;
+	}
+	RIOFdata *fdd = R_NEW0 (RIOFdata);
+	if (fdd) {
+		fdd->fd = r_num_math (NULL, pathname + 5);
+		if (fdd->fd < 0) {
+			free (fdd);
+			eprintf ("Invalid filedescriptor.\n");
 			return NULL;
 		}
-		RIOFdata *fdd = R_NEW0 (RIOFdata);
-		if (fdd) {
-			fdd->fd = r_num_math (NULL, pathname + 5);
-			if (fdd->fd < 0) {
-				free (fdd);
-				eprintf ("Invalid filedescriptor.\n");
-				return NULL;
-			}
-		}
-		return r_io_desc_new (io, &r_io_plugin_fd, pathname, R_PERM_RW | rw, mode, fdd);
 	}
-	return NULL;
+	return r_io_desc_new (io, &r_io_plugin_fd, pathname, R_PERM_RW | rw, mode, fdd);
 }
 
 RIOPlugin r_io_plugin_fd = {

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -14,26 +14,26 @@ typedef struct {
 } RIOFdata;
 
 static int __write(RIO *io, RIODesc *desc, const ut8 *buf, int count) {
-	RIOFdata *mal = (RIOFdata*)desc->data;
-	if (mal) {
-		return write (mal->fd, buf, count);
+	RIOFdata *fdd = (RIOFdata*)desc->data;
+	if (fdd) {
+		return write (fdd->fd, buf, count);
 	}
 	return -1;
 }
 
 static bool __resize(RIO *io, RIODesc *desc, ut64 count) {
-	RIOFdata *mal = (RIOFdata*)desc->data;
-	if (mal) {
-		return ftruncate (mal->fd, count) == 0;
+	RIOFdata *fdd = (RIOFdata*)desc->data;
+	if (fdd) {
+		return ftruncate (fdd->fd, count) == 0;
 	}
 	return false;
 }
 
 static int __read(RIO *io, RIODesc *desc, ut8 *buf, int count) {
-	RIOFdata *mal = (RIOFdata*)desc->data;
-	if (mal) {
+	RIOFdata *fdd = (RIOFdata*)desc->data;
+	if (fdd) {
 		r_cons_break_push (NULL, NULL);
-		int res = read (mal->fd, buf, count);
+		int res = read (fdd->fd, buf, count);
 		r_cons_break_pop ();
 		return res;
 	}
@@ -46,9 +46,9 @@ static int __close(RIODesc *desc) {
 }
 
 static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
-	RIOFdata *mal = (RIOFdata*)desc->data;
-	if (mal) {
-		return lseek (mal->fd, offset, whence);
+	RIOFdata *fdd = (RIOFdata*)desc->data;
+	if (fdd) {
+		return lseek (fdd->fd, offset, whence);
 	}
 	return 0;
 }
@@ -63,16 +63,16 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			eprintf ("Do not permit " FDURI " in sandbox mode.\n");
 			return NULL;
 		}
-		RIOFdata *mal = R_NEW0 (RIOFdata);
-		if (mal) {
-			mal->fd = r_num_math (NULL, pathname + 5);
-			if (((int)mal->fd) < 0) {
-				free (mal);
+		RIOFdata *fdd = R_NEW0 (RIOFdata);
+		if (fdd) {
+			fdd->fd = r_num_math (NULL, pathname + 5);
+			if (fdd->fd) < 0) {
+				free (fdd);
 				eprintf ("Invalid filedescriptor.\n");
 				return NULL;
 			}
 		}
-		return r_io_desc_new (io, &r_io_plugin_fd, pathname, R_PERM_RW | rw, mode, mal);
+		return r_io_desc_new (io, &r_io_plugin_fd, pathname, R_PERM_RW | rw, mode, fdd);
 	}
 	return NULL;
 }

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -7,6 +7,8 @@
 #include <r_cons.h>
 #include <sys/types.h>
 
+#define FDURI "fd://"
+
 typedef struct {
 	int fd;
 } RIOFdata;
@@ -52,13 +54,13 @@ static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
 }
 
 static bool __check(RIO *io, const char *pathname, bool many) {
-	return !strncmp (pathname, "fd://", 5);
+	return !strncmp (pathname, FDURI, strlen (FDURI));
 }
 
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 	if (__check (io, pathname, 0)) {
 		if (r_sandbox_enable (false)) {
-			eprintf ("Do not permit fd:// in sandbox mode.\n");
+			eprintf ("Do not permit " FDURI " in sandbox mode.\n");
 			return NULL;
 		}
 		RIOFdata *mal = R_NEW0 (RIOFdata);
@@ -78,7 +80,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 RIOPlugin r_io_plugin_fd = {
 	.name = "fd",
 	.desc = "Local process filedescriptor IO",
-	.uris = "fd://",
+	.uris = FDURI,
 	.license = "LGPL3",
 	.open = __open,
 	.close = __close,

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -40,7 +40,7 @@ static int __read(RIO *io, RIODesc *desc, ut8 *buf, int count) {
 }
 
 static int __close(RIODesc *desc) {
-	// dont close, could be problematic in self://
+	R_FREE (desc->data);
 	return 0;
 }
 

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -66,7 +66,7 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 		RIOFdata *fdd = R_NEW0 (RIOFdata);
 		if (fdd) {
 			fdd->fd = r_num_math (NULL, pathname + 5);
-			if (fdd->fd) < 0) {
+			if (fdd->fd < 0) {
 				free (fdd);
 				eprintf ("Invalid filedescriptor.\n");
 				return NULL;

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -1,0 +1,91 @@
+/* radare - LGPL - Copyright 2020 - pancake */
+
+#include "r_io.h"
+#include "r_lib.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+typedef struct {
+	int fd;
+	ut32 size;
+} RIOMalloc;
+
+static int __write(RIO *io, RIODesc *desc, const ut8 *buf, int count) {
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	if (mal) {
+		return write (mal->fd, buf, count);
+	}
+	return -1;
+}
+
+static bool __resize(RIO *io, RIODesc *desc, ut64 count) {
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	if (mal) {
+		return ftruncate (mal->fd, count) == 0;
+	}
+	return false;
+}
+
+static int __read(RIO *io, RIODesc *desc, ut8 *buf, int count) {
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	if (mal) {
+		return read (mal->fd, buf, count);
+	}
+	return -1;
+}
+
+static int __close(RIODesc *desc) {
+	// dont close, could be problematic in self://
+	return 0;
+}
+
+static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	if (mal) {
+		return lseek (mal->fd, offset, whence);
+	}
+	return 0;
+}
+
+static bool __check(RIO *io, const char *pathname, bool many) {
+	return !strncmp (pathname, "fd://", 4);
+}
+
+static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
+	if (__check (io, pathname, 0)) {
+		RIOMalloc *mal = R_NEW0 (RIOMalloc);
+		if (mal) {
+			mal->fd = r_num_math (NULL, pathname + 4);
+			if (((int)mal->fd) < 0) {
+				free (mal);
+				eprintf ("Invalid filedescriptor.\n");
+				return NULL;
+			}
+		}
+		return r_io_desc_new (io, &r_io_plugin_fd, pathname, R_PERM_RW | rw, mode, mal);
+	}
+	return NULL;
+}
+
+RIOPlugin r_io_plugin_fd = {
+	.name = "fd",
+	.desc = "Local process filedescriptor IO",
+	.uris = "fd://",
+	.license = "LGPL3",
+	.open = __open,
+	.close = __close,
+	.read = __read,
+	.check = __check,
+	.lseek = __lseek,
+	.write = __write,
+	.resize = __resize,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_IO,
+	.data = &r_io_plugin_fd,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/io/p/io_fd.c
+++ b/libr/io/p/io_fd.c
@@ -9,11 +9,10 @@
 
 typedef struct {
 	int fd;
-	ut32 size;
-} RIOMalloc;
+} RIOFdata;
 
 static int __write(RIO *io, RIODesc *desc, const ut8 *buf, int count) {
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	RIOFdata *mal = (RIOFdata*)desc->data;
 	if (mal) {
 		return write (mal->fd, buf, count);
 	}
@@ -21,7 +20,7 @@ static int __write(RIO *io, RIODesc *desc, const ut8 *buf, int count) {
 }
 
 static bool __resize(RIO *io, RIODesc *desc, ut64 count) {
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	RIOFdata *mal = (RIOFdata*)desc->data;
 	if (mal) {
 		return ftruncate (mal->fd, count) == 0;
 	}
@@ -29,7 +28,7 @@ static bool __resize(RIO *io, RIODesc *desc, ut64 count) {
 }
 
 static int __read(RIO *io, RIODesc *desc, ut8 *buf, int count) {
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	RIOFdata *mal = (RIOFdata*)desc->data;
 	if (mal) {
 		r_cons_break_push (NULL, NULL);
 		int res = read (mal->fd, buf, count);
@@ -45,7 +44,7 @@ static int __close(RIODesc *desc) {
 }
 
 static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	RIOFdata *mal = (RIOFdata*)desc->data;
 	if (mal) {
 		return lseek (mal->fd, offset, whence);
 	}
@@ -53,7 +52,7 @@ static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
 }
 
 static bool __check(RIO *io, const char *pathname, bool many) {
-	return !strncmp (pathname, "fd://", 4);
+	return !strncmp (pathname, "fd://", 5);
 }
 
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
@@ -62,9 +61,9 @@ static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 			eprintf ("Do not permit fd:// in sandbox mode.\n");
 			return NULL;
 		}
-		RIOMalloc *mal = R_NEW0 (RIOMalloc);
+		RIOFdata *mal = R_NEW0 (RIOFdata);
 		if (mal) {
-			mal->fd = r_num_math (NULL, pathname + 4);
+			mal->fd = r_num_math (NULL, pathname + 5);
 			if (((int)mal->fd) < 0) {
 				free (mal);
 				eprintf ("Invalid filedescriptor.\n");

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -264,6 +264,7 @@ fs_plugins = [
 
 io_plugins = [
   'ar',
+  'fd',
   'bfdbg',
   'bochs',
   'debug',

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -260,6 +260,7 @@ io.winedbg
 io.zip
 io.r2k
 io.ar
+io.fd
 io.rbuf
 lang.vala
 parse.6502_pseudo


### PR DESCRIPTION
Useful for self:// and r2frida when injecting the lib inside a target process

* [x] Handle ^C
* [x] Honor sandbox
* [x] Build in meson
* [x] Support Windows

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This plugin was in the issues for a very long time, i saw it when it was pinged by the stalebot, so it was easy to implement

**Test plan**

Uhm maybe opening a file and assuming we get the right fd from the OS to manipualte it in live.. but there are no tests for libr2preload or self:// or for r2frida

**Closing issues**

Fixes https://github.com/radareorg/ideas/issues/116