### PR TITLE
Fix two shift overflow causing undefined behaviour

### DIFF
--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -652,8 +652,12 @@ R_API st64 r_buf_uleb128(RBuffer *b, ut64 *v) {
 			return -1;
 		}
 		c = data & 0xff;
-		sum |= ((ut64) (c & 0x7f) << s);
-		s += 7;
+		if (s < 64) {
+			sum |= ((ut64) (c & 0x7f) << s);
+			s += 7;
+		} else {
+			sum = 0;
+		}
 		l++;
 	} while (c & 0x80);
 	if (v) {
@@ -672,8 +676,12 @@ R_API st64 r_buf_sleb128(RBuffer *b, st64 *v) {
 			return -1;
 		}
 		chunk = value & 0x7f;
-		result |= (chunk << offset);
-		offset += 7;
+		if (offset < 64) {
+			result |= (chunk << offset);
+			offset += 7;
+		} else {
+			result = 0;
+		}
 	} while (value & 0x80);
 
 	if ((value & 0x40) != 0) {


### PR DESCRIPTION
Spotted in clusterfuzz-testcase-minimized-ia_fuzz-6301506113634304

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**



**Test plan**
```c
$ cat shift.c



main() {
	unsigned long long a=0x12389;
	int i = 0;
	while (1) {
		a <<= i;
		i++;
	}
}

$ gcc -fsanitize=undefined shift.c
$ ./a.out
shift.c:8:5: runtime error: shift exponent 64 is too large for 64-bit type 'unsigned long long'
^C

```

**Closing issues**

two from coverity