### PR TITLE
Fix supported OS list from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also use [r2lrn](https://github.com/0ki/r2lrn) or r2golf for a hands-on 
 
 ## Operating Systems
 
-Windows>=7, GNU/Linux, GNU/Darwin, GNU/Hurd, Apple's {mac,i,iPad,watch}OS,
+Windows (since XP), GNU/Linux, GNU/Darwin, GNU/Hurd, Apple's {Mac,i,iPad,watch}OS,
 [Dragonfly|Net|Free|Open]BSD, Android, QNX, Solaris, Haiku, FirefoxOS.
 
 ## Architectures

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ You can also use [r2lrn](https://github.com/0ki/r2lrn) or r2golf for a hands-on 
 
 ## Operating Systems
 
-Windows (since XP), GNU/Linux, OS X, [Net|Free|Open]BSD,
-Android, iOS, OSX, QNX, Solaris, Haiku, Firefox OS.
+Windows>=7, GNU/Linux, GNU/Darwin, GNU/Hurd, Apple's {mac,i,iPad,watch}OS,
+[Dragonfly|Net|Free|Open]BSD, Android, QNX, Solaris, Haiku, FirefoxOS.
 
 ## Architectures
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

it's quite outdated/wrong

**Test plan**

is windows 7 the minimum windows supported?

What do you think about putting the release download links in the REAMDE?