### PR TITLE
Rename asm.jmpsub to asm.sub.jmp

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3944,7 +3944,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 	}
 	r_cons_break_push (NULL, NULL);
 	at = from;
-	st64 asm_var_submin = r_config_get_i (core->config, "asm.var.submin");
+	st64 asm_sub_varmin = r_config_get_i (core->config, "asm.sub.varmin");
 	while (at < to && !r_cons_is_breaked ()) {
 		int i = 0, ret = bsz;
 		if (!r_io_is_valid_offset (core->io, at, R_PERM_X)) {
@@ -3971,7 +3971,7 @@ R_API int r_core_anal_search_xrefs(RCore *core, ut64 from, ut64 to, int rad) {
 				break;
 			}
 			// find references
-			if ((st64)op.val > asm_var_submin && op.val != UT64_MAX && op.val != UT32_MAX) {
+			if ((st64)op.val > asm_sub_varmin && op.val != UT64_MAX && op.val != UT32_MAX) {
 				if (found_xref (core, op.addr, op.val, R_ANAL_REF_TYPE_DATA, count, rad, cfg_debug, cfg_anal_strings)) {
 					count++;
 				}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -406,10 +406,10 @@ static bool cb_asmvarsubmin(void *user, void *data) {
 	return true;
 }
 
-static bool cb_asmtailsub(void *user, void *data) {
+static bool cb_asmsubtail (void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
-	core->parser->tailsub = node->i_value;
+	core->parser->subtail = node->i_value;
 	return true;
 }
 
@@ -3074,7 +3074,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.fcnsig", "true", "Show function signature in disasm");
 	SETICB ("asm.lines.width", 7, &cb_asmlineswidth, "Number of columns for program flow arrows");
 	SETICB ("asm.var.submin", 0x100, &cb_asmvarsubmin, "Minimum value to substitute in instructions (asm.var.sub)");
-	SETCB ("asm.tailsub", "false", &cb_asmtailsub, "Replace addresses with prefix .. syntax");
+	SETCB ("asm.sub.tail", "false", &cb_asmsubtail, "Replace addresses with prefix .. syntax");
 	SETBPREF ("asm.middle", "false", "Allow disassembling jumps in the middle of an instruction");
 	SETBPREF ("asm.noisy", "true", "Show comments considered noisy but possibly useful");
 	SETBPREF ("asm.offset", "true", "Show offsets in disassembly");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3010,7 +3010,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.calls", "true", "Show callee function related info as comments in disasm");
 	SETBPREF ("asm.comments", "true", "Show comments in disassembly view");
 	SETBPREF ("asm.usercomments", "false", "Show user comments even if asm.comments is false");
-	SETBPREF ("asm.jmpsub", "true", "Always substitute jump, call and branch targets in disassembly");
+	SETBPREF ("asm.sub.jmp", "true", "Always substitute jump, call and branch targets in disassembly");
 	SETBPREF ("asm.hints", "true", "Disable all asm.hint* if false");
 	SETBPREF ("asm.hint.jmp", "false", "Show jump hints [numbers] in disasm");
 	SETBPREF ("asm.hint.call", "true", "Show call hints [numbers] in disarm");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3109,8 +3109,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.var.sub", "true", "Substitute variables in disassembly");
 	SETI ("asm.var.summary", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
 	SETBPREF ("asm.var.subonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
-	SETBPREF ("asm.regsub", "false", "Substitute register names with their associated role name (drp~=)");
-	SETBPREF ("asm.relsub", "true", "Substitute pc relative expressions in disasm");
+	SETBPREF ("asm.sub.reg", "false", "Substitute register names with their associated role name (drp~=)");
+	SETBPREF ("asm.sub.rel", "true", "Substitute pc relative expressions in disasm");
 	SETBPREF ("asm.cmt.fold", "false", "Fold comments, toggle with Vz");
 	SETBPREF ("asm.family", "false", "Show family name in disasm");
 	SETBPREF ("asm.symbol", "false", "Show symbol+delta instead of absolute offset");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -406,7 +406,7 @@ static bool cb_asmvarsubmin(void *user, void *data) {
 	return true;
 }
 
-static bool cb_asmsubtail (void *user, void *data) {
+static bool cb_asmsubtail(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
 	core->parser->subtail = node->i_value;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -461,7 +461,7 @@ static bool cb_asmpseudo (void *user, void *data) {
 	return true;
 }
 
-static bool cb_asmsecsub(void *user, void *data) {
+static bool cb_asmsubsec(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
 	if (node->i_value) {
@@ -3091,7 +3091,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.section.perm", "false", "Show section permissions in the disasm");
 	SETBPREF ("asm.section.name", "true", "Show section name in the disasm");
 	SETI ("asm.section.col", 20, "Columns width to show asm.section");
-	SETCB ("asm.section.sub", "false", &cb_asmsecsub, "Show offsets in disasm prefixed with section/map name");
+	SETCB ("asm.sub.section", "false", &cb_asmsubsec, "Show offsets in disasm prefixed with section/map name");
 	SETCB ("asm.pseudo", "false", &cb_asmpseudo, "Enable pseudo syntax");
 	SETBPREF ("asm.size", "false", "Show size of opcodes in disassembly (pd)");
 	SETBPREF ("asm.stackptr", "false", "Show stack pointer at disassembly");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -399,7 +399,7 @@ static bool cb_analijmp(void *user, void *data) {
 	return true;
 }
 
-static bool cb_asmvarsubmin(void *user, void *data) {
+static bool cb_asmsubvarmin(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
 	core->parser->minval = node->i_value;
@@ -3073,7 +3073,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.lines.wide", "false", "Put a space between lines");
 	SETBPREF ("asm.fcnsig", "true", "Show function signature in disasm");
 	SETICB ("asm.lines.width", 7, &cb_asmlineswidth, "Number of columns for program flow arrows");
-	SETICB ("asm.var.submin", 0x100, &cb_asmvarsubmin, "Minimum value to substitute in instructions (asm.var.sub)");
+	SETICB ("asm.sub.varmin", 0x100, &cb_asmsubvarmin, "Minimum value to substitute in instructions (asm.var.sub)");
 	SETCB ("asm.sub.tail", "false", &cb_asmsubtail, "Replace addresses with prefix .. syntax");
 	SETBPREF ("asm.middle", "false", "Allow disassembling jumps in the middle of an instruction");
 	SETBPREF ("asm.noisy", "true", "Show comments considered noisy but possibly useful");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3108,7 +3108,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.var.access", "false", "Show accesses of local variables");
 	SETBPREF ("asm.var.sub", "true", "Substitute variables in disassembly");
 	SETI ("asm.var.summary", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
-	SETBPREF ("asm.var.subonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
+	SETBPREF ("asm.sub.varonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
 	SETBPREF ("asm.sub.reg", "false", "Substitute register names with their associated role name (drp~=)");
 	SETBPREF ("asm.sub.rel", "true", "Substitute pc relative expressions in disasm");
 	SETBPREF ("asm.cmt.fold", "false", "Fold comments, toggle with Vz");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7080,7 +7080,7 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	bool asm_varsub = r_config_get_i (core->config, "asm.var.sub");
 	core->parser->pseudo = r_config_get_i (core->config, "asm.pseudo");
 	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
-	core->parser->localvar_only = r_config_get_i (core->config, "asm.var.subonly");
+	core->parser->localvar_only = r_config_get_i (core->config, "asm.sub.varonly");
 
 	if (core->parser->subrel) {
 		core->parser->subrel_addr = from;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1739,7 +1739,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 				strsub, sizeof (strsub));
 				ut64 killme = UT64_MAX;
 				if (r_io_read_i (core->io, op.ptr, &killme, op.refptr, be)) {
-					core->parser->relsub_addr = killme;
+					core->parser->subrel_addr = killme;
 				}
 			// 0x33->sym.xx
 			char *p = strdup (strsub);
@@ -1885,7 +1885,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			disasm, sizeof (disasm));
 		ut64 killme = UT64_MAX;
 		if (r_io_read_i (core->io, op.ptr, &killme, op.refptr, be)) {
-			core->parser->relsub_addr = killme;
+			core->parser->subrel_addr = killme;
 		}
 		char *p = strdup (disasm);
 		if (p) {
@@ -7083,7 +7083,7 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	core->parser->localvar_only = r_config_get_i (core->config, "asm.var.subonly");
 
 	if (core->parser->subrel) {
-		core->parser->relsub_addr = from;
+		core->parser->subrel_addr = from;
 	}
 	r_io_read_at (core->io, addr, buf, size);
 	r_asm_set_pc (core->rasm, addr);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1638,7 +1638,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 	bool stats = r_config_get_i (core->config, "esil.stats");
 	bool be = core->print->big_endian;
 	bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
-	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
+	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
 	int ret, i, j, idx, size;
 	const char *color = "";
 	const char *esilstr;
@@ -7079,10 +7079,10 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	char *buf_asm = NULL;
 	bool asm_varsub = r_config_get_i (core->config, "asm.var.sub");
 	core->parser->pseudo = r_config_get_i (core->config, "asm.pseudo");
-	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
+	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
 	core->parser->localvar_only = r_config_get_i (core->config, "asm.var.subonly");
 
-	if (core->parser->relsub) {
+	if (core->parser->subrel) {
 		core->parser->relsub_addr = from;
 	}
 	r_io_read_at (core->io, addr, buf, size);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -783,7 +783,7 @@ static RDisasmState * ds_init(RCore *core) {
 
 	ds->showpayloads = r_config_get_i (ds->core->config, "asm.payloads");
 	ds->showrelocs = r_config_get_i (core->config, "bin.relocs");
-	ds->min_ref_addr = r_config_get_i (core->config, "asm.var.submin");
+	ds->min_ref_addr = r_config_get_i (core->config, "asm.sub.varmin");
 
 	if (ds->show_flag_in_bytes) {
 		ds->show_flags = false;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1005,12 +1005,12 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 	/* initialize */
 	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
 	core->parser->subreg = r_config_get_i (core->config, "asm.sub.reg");
-	core->parser->relsub_addr = 0;
+	core->parser->subrel_addr = 0;
 	if (core->parser->subrel
 	    && (ds->analop.type == R_ANAL_OP_TYPE_LEA || ds->analop.type == R_ANAL_OP_TYPE_MOV
 	        || ds->analop.type == R_ANAL_OP_TYPE_CMP)
 	    && ds->analop.ptr != UT64_MAX) {
-		core->parser->relsub_addr = ds->analop.ptr;
+		core->parser->subrel_addr = ds->analop.ptr;
 	}
 	if (ds->varsub && ds->opstr) {
 		ut64 at = ds->vat;
@@ -1032,7 +1032,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 				if ((ref->type == R_ANAL_REF_TYPE_DATA
 					|| ref->type == R_ANAL_REF_TYPE_STRING)
 					&& ds->analop.type == R_ANAL_OP_TYPE_LEA) {
-					core->parser->relsub_addr = ref->addr;
+					core->parser->subrel_addr = ref->addr;
 					break;
 				}
 			}
@@ -1075,11 +1075,11 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 			}
 		}
 		if (core->parser->subrel && ds->analop.refptr) {
-			if (core->parser->relsub_addr == 0) {
+			if (core->parser->subrel_addr == 0) {
 				ut64 killme = UT64_MAX;
 				const int be = core->rasm->big_endian;
 				r_io_read_i (core->io, ds->analop.ptr, &killme, ds->analop.refptr, be);
-				core->parser->relsub_addr = killme;
+				core->parser->subrel_addr = killme;
 			}
 		}
 		char *asm_str = colorize_asm_string (core, ds, print_color);
@@ -3931,9 +3931,9 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		if (((st64)p) > 0) {
 			f = r_flag_get_i (core->flags, p);
 			if (f) {
-				ut64 relsub_addr = core->parser->relsub_addr;
-				if (relsub_addr && relsub_addr != p) {
-					f2 = r_core_flag_get_by_spaces (core->flags, relsub_addr);
+				ut64 subrel_addr = core->parser->subrel_addr;
+				if (subrel_addr && subrel_addr != p) {
+					f2 = r_core_flag_get_by_spaces (core->flags, subrel_addr);
 					f2_in_opstr = f2 && ds->opstr && (strstr (ds->opstr, f2->name) || strstr (ds->opstr, f2->realname)) ;
 				}
 				refaddr = p;
@@ -6021,7 +6021,7 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			ut64 killme = UT64_MAX;
 			bool be = core->print->big_endian;
 			if (r_io_read_i (core->io, ds->analop.ptr, &killme, ds->analop.refptr, be)) {
-				core->parser->relsub_addr = killme;
+				core->parser->subrel_addr = killme;
 			}
 		}
 		{

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -633,8 +633,8 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->interactive = r_cons_is_interactive ();
 	ds->subjmp = r_config_get_i (core->config, "asm.sub.jmp");
 	ds->varsub = r_config_get_i (core->config, "asm.var.sub");
-	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
-	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
+	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
+	core->parser->subreg = r_config_get_i (core->config, "asm.sub.reg");
 	core->parser->localvar_only = r_config_get_i (core->config, "asm.var.subonly");
 	core->parser->retleave_asm = NULL;
 	ds->show_fcnsig = r_config_get_i (core->config, "asm.fcnsig");
@@ -1003,10 +1003,10 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		ds->opstr = strdup (r_asm_op_get_asm (&ds->asmop));
 	}
 	/* initialize */
-	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
-	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
+	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
+	core->parser->subreg = r_config_get_i (core->config, "asm.sub.reg");
 	core->parser->relsub_addr = 0;
-	if (core->parser->relsub
+	if (core->parser->subrel
 	    && (ds->analop.type == R_ANAL_OP_TYPE_LEA || ds->analop.type == R_ANAL_OP_TYPE_MOV
 	        || ds->analop.type == R_ANAL_OP_TYPE_CMP)
 	    && ds->analop.ptr != UT64_MAX) {
@@ -1024,7 +1024,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 			free (ds->opstr);
 			ds->opstr = strdup (ds->strsub);
 		}
-		if (core->parser->relsub) {
+		if (core->parser->subrel) {
 			RList *list = r_anal_refs_get (core->anal, at);
 			RListIter *iter;
 			RAnalRef *ref;
@@ -1074,7 +1074,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 				core->parser->flagspace = NULL;
 			}
 		}
-		if (core->parser->relsub && ds->analop.refptr) {
+		if (core->parser->subrel && ds->analop.refptr) {
 			if (core->parser->relsub_addr == 0) {
 				ut64 killme = UT64_MAX;
 				const int be = core->rasm->big_endian;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -90,7 +90,7 @@ typedef struct {
 	bool pseudo;
 	int filter;
 	int interactive;
-	bool jmpsub;
+	bool subjmp;
 	bool varsub;
 	bool show_lines;
 	bool show_lines_bb;
@@ -631,7 +631,7 @@ static RDisasmState * ds_init(RCore *core) {
 	}
 	ds->filter = r_config_get_i (core->config, "asm.filter");
 	ds->interactive = r_cons_is_interactive ();
-	ds->jmpsub = r_config_get_i (core->config, "asm.jmpsub");
+	ds->subjmp = r_config_get_i (core->config, "asm.sub.jmp");
 	ds->varsub = r_config_get_i (core->config, "asm.var.sub");
 	core->parser->relsub = r_config_get_i (core->config, "asm.relsub");
 	core->parser->regsub = r_config_get_i (core->config, "asm.regsub");
@@ -3378,7 +3378,7 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		return;
 	}
 	RAnalFunction *f = fcnIn (ds, ds->analop.jump, R_ANAL_FCN_TYPE_NULL);
-	if (!f && ds->core->flags && (!ds->core->vmode || (!ds->jmpsub && !ds->filter))) {
+	if (!f && ds->core->flags && (!ds->core->vmode || (!ds->subjmp && !ds->filter))) {
 		const char *arch;
 		RFlagItem *flag = r_flag_get_by_spaces (ds->core->flags, ds->analop.jump,
 		                                        R_FLAGS_FS_CLASSES, R_FLAGS_FS_SYMBOLS, NULL);
@@ -3417,7 +3417,7 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		} else if (delta < 0) {
 			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s-0x%x", f->name, -delta);
-		} else if ((!ds->core->vmode || (!ds->jmpsub && !ds->filter))
+		} else if ((!ds->core->vmode || (!ds->subjmp && !ds->filter))
 			   && (!ds->opstr || !strstr (ds->opstr, f->name))) {
 			RFlagItem *flag_sym;
 			if (ds->core->vmode && ds->asm_demangle
@@ -5023,8 +5023,7 @@ static char *ds_sub_jumps(RDisasmState *ds, char *str) {
 	RFlag *f = ds->core->flags;
 	const char *name = NULL;
 	const char *kw = "";
-
-	if (!ds->jmpsub || !anal) {
+	if (!ds->subjmp || !anal) {
 		return str;
 	}
 	int optype = ds->analop.type & 0xFFFF;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -635,7 +635,7 @@ static RDisasmState * ds_init(RCore *core) {
 	ds->varsub = r_config_get_i (core->config, "asm.var.sub");
 	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
 	core->parser->subreg = r_config_get_i (core->config, "asm.sub.reg");
-	core->parser->localvar_only = r_config_get_i (core->config, "asm.var.subonly");
+	core->parser->localvar_only = r_config_get_i (core->config, "asm.sub.varonly");
 	core->parser->retleave_asm = NULL;
 	ds->show_fcnsig = r_config_get_i (core->config, "asm.fcnsig");
 	ds->show_vars = r_config_get_i (core->config, "asm.var");

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -24,7 +24,7 @@ typedef struct r_parse_t {
 	bool subrel; // replace rip relative expressions in instruction
 	bool subtail; // replace any immediate relative to current address with .. prefix syntax
 	bool localvar_only; // if true use only the local variable name (e.g. [local_10h] instead of [ebp + local10h])
-	ut64 relsub_addr;
+	ut64 subrel_addr;
 	int maxflagnamelen;
 	int minval;
 	char *retleave_asm;

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -22,7 +22,7 @@ typedef struct r_parse_t {
 	bool pseudo;
 	bool subreg; // replace registers with their respective alias/role name (rdi=A0, ...)
 	bool subrel; // replace rip relative expressions in instruction
-	bool tailsub; // replace any immediate relative to current address with .. prefix syntax
+	bool subtail; // replace any immediate relative to current address with .. prefix syntax
 	bool localvar_only; // if true use only the local variable name (e.g. [local_10h] instead of [ebp + local10h])
 	ut64 relsub_addr;
 	int maxflagnamelen;

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -20,8 +20,8 @@ typedef struct r_parse_t {
 	RSpace *flagspace;
 	RSpace *notin_flagspace;
 	bool pseudo;
-	bool regsub; // replace registers with their respective alias/role name (rdi=A0, ...)
-	bool relsub; // replace rip relative expressions in instruction
+	bool subreg; // replace registers with their respective alias/role name (rdi=A0, ...)
+	bool subrel; // replace rip relative expressions in instruction
 	bool tailsub; // replace any immediate relative to current address with .. prefix syntax
 	bool localvar_only; // if true use only the local variable name (e.g. [local_10h] instead of [ebp + local10h])
 	ut64 relsub_addr;

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -158,7 +158,7 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 	replaceWords (ptr, "dword ", src);
 	replaceWords (ptr, "qword ", src);
 #endif
-	if (p->regsub) {
+	if (p->subreg) {
 		__replaceRegisters (p->analb.anal->reg, ptr, false);
 		if (x86) {
 			__replaceRegisters (p->analb.anal->reg, ptr, true);

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -348,7 +348,7 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 					}
 					return true;
 				}
-				if (p->tailsub) { //  && off > UT32_MAX && addr > UT32_MAX)
+				if (p->subtail) { //  && off > UT32_MAX && addr > UT32_MAX)
 					if (off != UT64_MAX) {
 						if (off == addr) {
 							insert (ptr, "$$");

--- a/libr/parse/filter.c
+++ b/libr/parse/filter.c
@@ -207,9 +207,9 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 				         && (data[3] == ' ' || data[3] == 0x1b);
 				bool remove_brackets = false;
 				flag = p->flag_get (f, off);
-				if ((!flag || arm) && p->relsub_addr) {
-					remove_brackets = lea || (arm && p->relsub_addr);
-					flag2 = p->flag_get (f, p->relsub_addr);
+				if ((!flag || arm) && p->subrel_addr) {
+					remove_brackets = lea || (arm && p->subrel_addr);
+					flag2 = p->flag_get (f, p->subrel_addr);
 					if (!flag || arm) {
 						flag = flag2;
 					}
@@ -289,7 +289,7 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 							banned = true;
 						}
 					}
-					if (p->relsub_addr && !banned && lea) {  // TODO: use remove_brackets
+					if (p->subrel_addr && !banned && lea) {  // TODO: use remove_brackets
 						int flag_len = strlen (flag->name);
 						char *ptr_end = str + strlen (data) + flag_len - 1;
 						char *ptr_right = ptr_end + 1, *ptr_left, *ptr_esc;

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -292,7 +292,7 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 		free (tstr);
 		return false;
 	}
-	if (p->relsub) {
+	if (p->subrel) {
 		char *rip = (char *)r_str_casestr (tstr, "[pc, ");
 		if (!rip) {
 			rip = (char *)r_str_casestr (tstr, "[PC, ");

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -352,7 +352,7 @@ static bool varsub (RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *dat
 
 	bool att = strchr (data, '%');
 
-	if (p->relsub) {
+	if (p->subrel) {
 		if (att) {
 			char *rip = (char *) r_str_casestr (tstr, "(%rip)");
 			if (rip) {

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -26,7 +26,7 @@ R_API RParse *r_parse_new(void) {
 	p->flagspace = NULL;
 	p->pseudo = false;
 	p->subrel = false;
-	p->tailsub = false;
+	p->subtail = false;
 	p->minval = 0x100;
 	p->localvar_only = false;
 	for (i = 0; parse_static_plugins[i]; i++) {

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -25,7 +25,7 @@ R_API RParse *r_parse_new(void) {
 	p->notin_flagspace = NULL;
 	p->flagspace = NULL;
 	p->pseudo = false;
-	p->relsub = false;
+	p->subrel = false;
 	p->tailsub = false;
 	p->minval = 0x100;
 	p->localvar_only = false;

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -458,7 +458,7 @@ jump: 0x00000020
 EOF
 RUN
 
-NAME=arm relsub >256
+NAME=arm subrel >256
 FILE=malloc://800
 CMDS=<<EOF
 wx 0d039fe5
@@ -475,7 +475,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=arm relsub <256
+NAME=arm subrel <256
 FILE=-
 CMDS=<<EOF
 wx 0c009fe5
@@ -495,7 +495,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=arm relsub
+NAME=arm subrel
 FILE=bins/elf/arm1.bin
 CMDS=<<EOF
 e asm.arch=arm
@@ -516,7 +516,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=arm relsub
+NAME=arm subrel
 FILE=bins/elf/analysis/arm-ls
 BROKEN=1
 CMDS=<<EOF

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -486,7 +486,7 @@ e asm.bytes=false
 e asm.offset=false
 f sym.callback=0x14
 pd 1
-e asm.var.submin=0
+e asm.sub.varmin=0
 pd 1
 EOF
 EXPECT=<<EOF

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1062,7 +1062,7 @@ RUN
 NAME=reflines offset 2 (ascii)
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.bytes=false
 e asm.leahints=false
 e scr.utf8=false
@@ -1111,7 +1111,7 @@ RUN
 NAME=reflines offset 3 (ascii)
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.bytes=false
 e asm.leahints=false
 e scr.utf8=false
@@ -1153,7 +1153,7 @@ RUN
 NAME=reflines offset 3 (ascii + wide)
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.bytes=false
 e asm.leahints=false
 e scr.utf8=false
@@ -1196,7 +1196,7 @@ RUN
 NAME=reflines offset 4 (ascii + wide)
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.bytes=false
 e asm.leahints=false
 e scr.utf8=false
@@ -1238,7 +1238,7 @@ RUN
 NAME=reflines in noreturn
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.bytes=false
 e asm.leahints=false
 e scr.utf8=false
@@ -1328,7 +1328,7 @@ RUN
 NAME=auto string memory reference (iopa)
 FILE=malloc://8096
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.arch = x86
 e asm.bits=64
 e scr.color = false
@@ -1350,7 +1350,7 @@ RUN
 NAME=auto string memory reference (io.va)
 FILE=malloc://8096
 CMDS=<<EOF
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.arch = x86
 e asm.bits=64
 e scr.color = false
@@ -2053,13 +2053,13 @@ fcn.08048542 0x80485ab [CALL] call sym.imp.exit
 EOF
 RUN
 
-NAME=axt respect relsub
+NAME=axt respect subrel
 FILE=bins/pe/ibknoreloc64.exe
 CMDS=<<EOF
 aaa
-e asm.relsub=false
+e asm.sub.rel=false
 axt @ sym.imp.msvcrt.dll_printf
-e asm.relsub=true
+e asm.sub.rel=true
 axt @ sym.imp.msvcrt.dll_printf
 EOF
 EXPECT=<<EOF
@@ -2272,11 +2272,11 @@ main 0x8048432 [STRING] lea eax, str.Hello_PIC
 EOF
 RUN
 
-NAME=strings xref issue without relsub
+NAME=strings xref issue without subrel
 FILE=bins/elf/redpill
 CMDS=<<EOF
 e anal.strings=true
-e asm.relsub=false
+e asm.sub.rel=false
 aa
 aae
 axt 0x00001d89
@@ -2298,11 +2298,11 @@ main 0x161d [STRING] lea eax, [esi - 0x21f7]
 EOF
 RUN
 
-NAME=reference PIC binary without relsub
+NAME=reference PIC binary without subrel
 FILE=bins/elf/analysis/xrefpic
 CMDS=<<EOF
 e anal.strings=true
-e asm.relsub=false
+e asm.sub.rel=false
 aa
 aae
 axt@0x80484e0

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -269,14 +269,14 @@ FILE=-
 ARGS=-m 0x100001000
 CMDS=<<EOF
 e io.va
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.leahints=false
 e asm.arch=x86
 e asm.bits=64
 e io.va=true
 wx c7055f44000000000000
 pd 1
-e asm.relsub=true; pd 1
+e asm.sub.rel=true; pd 1
 ahi 10; pd 1
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_att
+++ b/test/db/cmd/cmd_att
@@ -1,4 +1,4 @@
-NAME=att relsub
+NAME=att subrel
 FILE=bins/mach0/mac-ls
 CMDS=<<EOF
 e asm.syntax=att

--- a/test/db/cmd/cmd_att
+++ b/test/db/cmd/cmd_att
@@ -100,7 +100,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=att varsub 2 with asm.var.subonly disabled
+NAME=att varsub 2 with asm.sub.varonly disabled
 FILE=bins/elf/varsub
 CMDS=<<EOF
 aa; s main
@@ -109,7 +109,7 @@ e asm.var=0
 e asm.lines.bb=0
 e asm.bytes=0
 e asm.comments=false
-e asm.var.subonly=false
+e asm.sub.varonly=false
 pdf
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -8,7 +8,7 @@ e asm.var.sub=1
 pd 1
 f fin.dus=0x1000054d0
 pd 1
-e asm.relsub=0
+e asm.sub.rel=0
 pd 1
 EOF
 EXPECT=<<EOF
@@ -553,19 +553,19 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd asm.relsub
+NAME=pd asm.sub.rel
 FILE=malloc://1024
 ARGS=-m 0x400000
 CMDS=<<EOF
 e io.va=true
-e asm.relsub=false
+e asm.sub.rel=false
 e asm.arch=x86
 e asm.bits=64
 wx 488d0502000000
 e asm.lines.bb=false
 e asm.comments=false
 pd 1
-e asm.relsub=true
+e asm.sub.rel=true
 pd 1
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -574,7 +574,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd asm.var.subonly
+NAME=pd asm.sub.varonly
 FILE=malloc://1024
 CMDS=<<EOF
 e anal.vars.stackname=true
@@ -590,10 +590,10 @@ e scr.color=false
 wx 554889e583ec60488b44244089ec5dc3
 af
 afva
-e asm.var.subonly=true
+e asm.sub.varonly=true
 pd 1 @ 0~var
 pd 1 @ 7
-e asm.var.subonly=false
+e asm.sub.varonly=false
 pd 1 @ 0~var
 pd 1 @ 7
 EOF
@@ -1903,10 +1903,10 @@ pd 4 @ 0x0001045c
 ?e
 e asm.pseudo=true
 e asm.var.sub=true
-e asm.var.subonly=false
+e asm.sub.varonly=false
 pd 4 @ 0x0001045c
 ?e
-e asm.var.subonly=true
+e asm.sub.varonly=true
 s main
 afvn local2 var_ch
 afvn arg1 arg_8h

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -35,7 +35,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=arm indirect relsub fix (#11780)
+NAME=arm indirect subrel fix (#11780)
 FILE=bins/elf/analysis/arm_32_flags0
 CMDS=<<EOF
 e asm.bytes=false
@@ -528,7 +528,7 @@ CMDS=<<EOF
 e asm.demangle=true
 e asm.bytes=false
 e asm.filter=false
-e asm.jmpsub=false
+e asm.sub.jmp=false
 aa
 e asm.cmt.right=true
 pd 1 @ 0x080493b4
@@ -557,7 +557,7 @@ FILE=bins/elf/ls
 CMDS=<<EOF
 e asm.bytes=false
 e asm.filter=true
-(pd_tests; e asm.relsub=true; pd 15; ?e; e asm.relsub=false; pd 1 @ 0x000041ee; pd 1 @ 0x00004225)
+(pd_tests; e asm.sub.rel=true; pd 15; ?e; e asm.sub.rel=false; pd 1 @ 0x000041ee; pd 1 @ 0x00004225)
 (insn_tests; e scr.color=0; .(pd_tests); ?e; e scr.color=1; .(pd_tests))
 s 0x000041e0
 .(insn_tests)

--- a/test/db/cmd/lea_intel
+++ b/test/db/cmd/lea_intel
@@ -1,4 +1,4 @@
-NAME=lea_intel att relsub
+NAME=lea_intel att subrel
 FILE=bins/elf/ezpz
 CMDS=<<EOF
 e asm.lines.bb=0

--- a/test/db/formats/elf/serial
+++ b/test/db/formats/elf/serial
@@ -1,11 +1,11 @@
-NAME=serial relsub
+NAME=serial subrel
 FILE=bins/elf/analysis/serial
 CMDS=<<EOF
 s 0x00400b35
 e asm.leahints=false
 e asm.bytes=false
 e asm.lines.bb=false
-e asm.relsub=true
+e asm.sub.rel=true
 e asm.comments=false
 pd 1
 af @ 0x0040073d


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

On #16801, it was proposed to organize `asm~sub` to `asm.sub.*`. 
Here, I've renamed `asm.jmpsub` to `asm.sub.jmp` and renamed the node `jmpsub` to `subjmp`.

**Test plan**
A simple build from source will update the changes.

**Closing issues**

Related to #16801 

(Being a beginner, I was going through the 'good first issues'. Any forms of advices and opinions are welcome on this, as I'd like to work on the whole issue and remaining commands under this.)