### PR TITLE
Initial support for git tags in r2pm ##r2pm

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -336,7 +336,7 @@ R2PM_GIT() {
 	# r2>=4.5 : R2_VERSION=$(r2 -H R2_VERSION)
 	R2_VERSION=$(r2 -qv)
 	if [ -z "`echo $R2_VERSION | grep git`" ]; then
-		git checkout v"${R2_VERSION}"
+		git checkout "r2-${R2_VERSION}"
 		git pull
 	fi
 }

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -327,10 +327,17 @@ R2PM_GIT() {
 	cd "${R2PM_GITDIR}"
 	if [ -d "${DIR}" ]; then
 		cd "${DIR}"
+		git checkout master
 		git pull
 	else
 		git clone --depth 1 --recursive "${URL}" "${DIR}" || R2PM_FAIL "Oops"
 		cd "${DIR}" || R2PM_FAIL "Oops"
+	fi
+	# r2>=4.5 : R2_VERSION=$(r2 -H R2_VERSION)
+	R2_VERSION=$(r2 -qv)
+	if [ -z "`echo $R2_VERSION | grep git`" ]; then
+		git checkout v"${R2_VERSION}"
+		git pull
 	fi
 }
 

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -160,6 +160,7 @@ static int main_help(int line) {
 		" R2_NOPLUGINS do not load r2 shared plugins\n"
 		" R2_RCFILE    ~/.radare2rc (user preferences, batch script)\n" // TOO GENERIC
 		" R2_RDATAHOME %s\n" // TODO: rename to RHOME R2HOME?
+		" R2_VERSION   contains the current versaion of r2\n" 
 		"Paths:\n"
 		" R2_PREFIX    "R2_PREFIX"\n"
 		" R2_INCDIR    "R2_INCDIR"\n"
@@ -191,9 +192,9 @@ static int main_print_var(const char *var_name) {
 		const char *name;
 		const char *value;
 	} r2_vars[] = {
+		{ "R2_VERSION", R2_VERSION },
 		{ "R2_PREFIX", R2_PREFIX },
 		{ "R2_MAGICPATH", magicpath },
-		{ "R2_PREFIX", R2_PREFIX },
 		{ "R2_INCDIR", incdir },
 		{ "R2_LIBDIR", libdir },
 		{ "R2_LIBEXT", R_LIB_EXT },

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -160,7 +160,7 @@ static int main_help(int line) {
 		" R2_NOPLUGINS do not load r2 shared plugins\n"
 		" R2_RCFILE    ~/.radare2rc (user preferences, batch script)\n" // TOO GENERIC
 		" R2_RDATAHOME %s\n" // TODO: rename to RHOME R2HOME?
-		" R2_VERSION   contains the current versaion of r2\n" 
+		" R2_VERSION   contains the current version of r2\n" 
 		"Paths:\n"
 		" R2_PREFIX    "R2_PREFIX"\n"
 		" R2_INCDIR    "R2_INCDIR"\n"


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

When using r2 from non-git (release builds), installing packages can result in build problems. This PR aims to enable r2pm with the ability to pick the right commit from the tagged version from 3rd party repos if available.

Afaik this is done by r2ghidra-dec and r2dec-js, it may be good to define a different tag name than just the r2 version string, otherwise it will confuse users with the version of the decompiler and the veresion of the r2 required to build. so my suggestion is to use `r2-` as prefix in the 3rd party repos

**Test plan**

Get r2-4.4, replace the r2pm shellscript with the one in this PR, and type the following command:

```
$ r2pm -ci r2ghidra-dec
```

As you can see the PR also introduces r2 -H R2_VERSION, but r2 -qv is used for now, so backward compat may be handled in here.

**Closing issues**

none, but this thing has been requested for years, and i dont think those few lines will hurt anyone