### PR TITLE
Fix r2r crash on Windows if test doesn't have CMDS

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -142,6 +142,10 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 		// RUN is the only cmd without value
 		if (strcmp (line, "RUN") == 0) {
 			test->run_line = linenum;
+			if (!test->cmds.value) {
+				eprintf (LINEFMT "Error: Test without CMDS key\n", file, linenum);
+				goto fail;
+			}
 			r_pvector_push (ret, test);
 			test = r2r_cmd_test_new ();
 			if (!test) {

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -942,6 +942,9 @@ R_API R2RProcessOutput *r2r_run_cmd_test(R2RRunConfig *config, R2RCmdTest *test,
 		}
 		r_list_push (files, "-");
 	}
+	if (!test->cmds.value) {
+		test->cmds.value = strdup ("");
+	}
 	R2RProcessOutput *out = run_r2_test (config, test->cmds.value, files, extra_args, test->load_plugins, runner, user);
 	r_list_free (extra_args);
 	r_list_free (files);

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -942,9 +942,6 @@ R_API R2RProcessOutput *r2r_run_cmd_test(R2RRunConfig *config, R2RCmdTest *test,
 		}
 		r_list_push (files, "-");
 	}
-	if (!test->cmds.value) {
-		test->cmds.value = strdup ("");
-	}
 	R2RProcessOutput *out = run_r2_test (config, test->cmds.value, files, extra_args, test->load_plugins, runner, user);
 	r_list_free (extra_args);
 	r_list_free (files);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

