### PR TITLE
Check some OS 3 times a week

### DIFF
--- a/.github/workflows/centos6.yml
+++ b/.github/workflows/centos6.yml
@@ -7,6 +7,8 @@ on:
     - 'prerelease*'
     - 'release-*'
     - 'centos*'
+  schedule:
+    - cron: '0 18 * * 1,3,5' # Three-weekly at 18:00 UTC on Monday, Wednesday, and Friday
 
 jobs:
   build:

--- a/.github/workflows/debianold.yml
+++ b/.github/workflows/debianold.yml
@@ -7,6 +7,8 @@ on:
     - 'prerelease*'
     - 'release-*'
     - 'debian*'
+  schedule:
+    - cron: '0 18 * * 1,3,5' # Three-weekly at 18:00 UTC on Monday, Wednesday, and Friday
 
 jobs:
   build:


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

It allows to run the following builds and tests 3 time a week - at Monday, Wednesday, Friday. Like Coverity, it will allow to spot bugs early rather than before the release:
- Debian Jessie
- CentOS 6

