### PR TITLE
sdb: Strip UTF8 BOM when creating db

### DIFF
--- a/shlr/sdb/src/main.c
+++ b/shlr/sdb/src/main.c
@@ -265,9 +265,13 @@ static int createdb(const char *f, const char **args, int nargs) {
 	insertkeys (s, args, nargs, '=');
 	sdb_config (s, options);
 	for (; (line = stdin_slurp (NULL));) {
-		if ((eq = strchr (line, '='))) {
+		size_t off = 0;
+		if (line[0] == '\xef' && line[1] == '\xbb' && line[2] == '\xbf') {
+			off = 3;
+		}
+		if ((eq = strchr (line + off, '='))) {
 			*eq++ = 0;
-			sdb_disk_insert (s, line, eq);
+			sdb_disk_insert (s, line + off, eq);
 		}
 		free (line);
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr prevents the following:

![BOM_in_sdb_with_oval](https://user-images.githubusercontent.com/12002672/86362958-ad862a00-bca8-11ea-969a-92db20084309.png)

i.e. a UTF8 BOM in the sdb.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
