### PR TITLE
Correct output value for AES and private key search

### DIFF
--- a/libr/search/aes-find.c
+++ b/libr/search/aes-find.c
@@ -75,5 +75,5 @@ R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 			}
 		}
 	}
-	return 0;
+	return -1;
 }

--- a/libr/search/privkey-find.c
+++ b/libr/search/privkey-find.c
@@ -102,5 +102,5 @@ R_API int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len
 			}
 		}
 	}
-	return 0;
+	return -1;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
If the function **r_search_privkey_update** return 0 when nothing is found, the search will stop after one block because the return value match with **r_search_hit_new** return value.

**Test plan**
I will update test binary in the repository to test that properly.
