### PR TITLE
Fix incorrect ragg2 empty string check

### DIFF
--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -343,13 +343,6 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		file = argv[opt.ind];
 	}
 
-	if (R_STR_ISEMPTY (opt.arg)) {
-		eprintf ("Cannot open empty path\n");
-		free (sequence);
-		r_egg_free (egg);
-		return 1;
-	}
-
 	if (bits == 64) {
 		if (!strcmp (format, "mach0")) {
 			format = "mach064";
@@ -378,6 +371,10 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	// initialize egg
 	r_egg_setup (egg, arch, bits, 0, os);
 	if (file) {
+		if (R_STR_ISEMPTY (file)) {
+			eprintf ("Cannot open empty path\n");
+			goto fail;
+		}
 		if (!strcmp (file, "-")) {
 			char buf[1024];
 			for (;;) {

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -147,7 +147,7 @@ EOF
 RUN
 
 NAME=ragg2 empty include
-FILE=-
+FILE=bins/other/ragg2/hi.c
 CMDS=!ragg2 -I "" bins/other/ragg2/hi.c
 EXPECT_ERR=<<EOF
 Cannot open empty include path
@@ -155,7 +155,7 @@ EOF
 RUN
 
 NAME=ragg2 empty contents
-FILE=-
+FILE=bins/other/ragg2/hi.c
 CMDS=!ragg2 -C "" bins/other/ragg2/hi.c
 EXPECT_ERR=<<EOF
 Cannot open empty contents path

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -161,3 +161,19 @@ EXPECT_ERR=<<EOF
 Cannot open empty contents path
 EOF
 RUN
+
+NAME=ragg2 debruijn sequence 1
+FILE=-
+CMDS=!ragg2 -r -P 2; ?e
+EXPECT=<<EOF
+AA
+EOF
+RUN
+
+NAME=ragg2 debruijn sequence 2
+FILE=-
+CMDS=!ragg2 -P 2 -r; ?e
+EXPECT=<<EOF
+AA
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Change the behavior of ragg2 to check for an empty string only after we know `file` is not NULL, making it closer to the purpose of the original commit without changing other behaviors of ragg2.

**Test plan**
Added tests for the scenario that was described by the user alex on IRC.

**Closing issues**

Closes #17201


