### PR TITLE
Use type instead of Get-Content to prevent BOM insertion on sdb generation in Windows

### DIFF
--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -217,8 +217,9 @@ sdb_exe = r'@0@'
 outfile = sys.argv[1]
 infiles = sys.argv[2:]
 if os.name == 'nt':
-    infiles = ','.join(infiles)
-    os.system('powershell -c "Get-Content {} | {} {} ="'.format(infiles, sdb_exe, outfile))
+    # DO NOT replace chr(92) with a backslash
+    infiles, sdb_exe, outfile = map(lambda x: x.replace('/', chr(92)), [' '.join(infiles), sdb_exe, outfile])
+    os.system('type {} | {} {} ='.format(infiles, sdb_exe, outfile))
 else:
     infiles = ' '.join(infiles)
     os.system('cat {} | {} {} ='.format(infiles, sdb_exe, outfile))

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -217,7 +217,7 @@ sdb_exe = r'@0@'
 outfile = sys.argv[1]
 infiles = sys.argv[2:]
 if os.name == 'nt':
-    # DO NOT replace chr(92) with a backslash
+    # DO NOT replace chr(92) below with a backslash
     infiles, sdb_exe, outfile = map(lambda x: x.replace('/', chr(92)), [' '.join(infiles), sdb_exe, outfile])
     os.system('type {} | {} {} ='.format(infiles, sdb_exe, outfile))
 else:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the problem seen in #17197 and radareorg/sdb#209, i.e.

![BOM_in_sdb_with_oval](https://user-images.githubusercontent.com/12002672/86473796-2a320a80-bd74-11ea-9895-ccbecfe54837.png)

aka there is a BOM in my Windows sdb.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
