### PR TITLE
macho libraries don't have an entrypoint and 0 is not a valid address ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3558,7 +3558,7 @@ struct addr_t *MACH0_(get_entrypoint)(struct MACH0_(obj_t) *bin) {
 	r_return_val_if_fail (bin, NULL);
 
 	ut64 ea = entry_to_vaddr (bin);
-	if (ea == 0 || ea == UT64_MAX) {
+	if (ea == 0 || ea == UT64_MAX) {
 		return NULL;
 	}
 	struct addr_t *entry = R_NEW0 (struct addr_t);

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3557,11 +3557,15 @@ beach:
 struct addr_t *MACH0_(get_entrypoint)(struct MACH0_(obj_t) *bin) {
 	r_return_val_if_fail (bin, NULL);
 
+	ut64 ea = entry_to_vaddr (bin);
+	if (ea == 0 || ea == UT64_MAX) {
+		return NULL;
+	}
 	struct addr_t *entry = R_NEW0 (struct addr_t);
 	if (!entry) {
 		return NULL;
 	}
-	entry->addr = entry_to_vaddr (bin);
+	entry->addr = ea;
 	entry->offset = addr_to_offset (bin, entry->addr);
 	entry->haddr = sdb_num_get (bin->kv, "mach0.entry.offset", 0);
 	sdb_num_set (bin->kv, "mach0.entry.vaddr", entry->addr, 0);


### PR DESCRIPTION
* in this case the lib is mapped at 0 so the first executable section

	> iS paddr/sort,perm/str/-r-x,vaddr/cols~:3
	0x00000c30

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

see https://github.com/radareorg/radare2/pull/17195, macho libs show 1 entrypoint at adderss 0 when typing ie:

```
$ r2 /usr/local/lib/libr_util.dylib
 -- License server overloaded (ETOOMUCHCASH)
[0x00000000]> ie
[Entrypoints]
vaddr=0x00000000 paddr=0x00000000 haddr=-1 type=program

1 entrypoints

[0x00000000]>
```

**Test plan**

need to add a test opening a lib and chking the entry0 if it exists and whcih is the initial seek address. we can add another flag for this instead of entry0 which is tied to the bin headers.

**Closing issues**

kind of related to https://github.com/radareorg/radare2/pull/17195