### PR TITLE
Deprecate `obb` command and make `obo` use the file descriptor ##bin

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -70,11 +70,10 @@ static const char *help_msg_ob[] = {
 	"oba", " [addr] [baddr]", "Open file and load bin info at given address",
 	"oba", " [addr] [filename]", "Open file and load bin info at given address",
 	"oba", " [addr]", "Open bin info from the given address",
-	"obb", " [bfid]", "Switch to open binfile by fd number (Same as op)",
 	"obf", " ([file])", "Load bininfo for current file (useful for r2 -n)",
 	"obj", "", "List opened binary files and objid (JSON format)",
 	"obn", " [name]", "Select binfile by name",
-	"obo", " [iofd]", "Switch to open binary file by objid (DEPRECATED)",
+	"obo", " [fd]", "Switch to open binfile by fd number",
 	"obr", " [baddr]", "Rebase current bin object",
 	NULL
 };
@@ -283,16 +282,6 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			r_list_free (files);
 		}
 		break;
-	case 'b': // "obb"
-		if (input[2] == ' ') {
-			ut32 id = r_num_math (core->num, input + 3);
-			if (!r_core_bin_raise (core, id)) {
-				eprintf ("Invalid RBinFile.id number.\n");
-			}
-		} else {
-			eprintf ("Usage: obb [bfid]\n");
-		}
-		break;
 	case ' ': // "ob "
 	{
 		ut32 id;
@@ -334,6 +323,18 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			value = input[2] ? input + 2 : NULL;
 		}
 		break;
+#if 0
+	case 'b': // "obb" // same as "ob $fd"
+		if (input[2] == ' ') {
+			ut32 id = r_num_math (core->num, input + 3);
+			if (!r_core_bin_raise (core, id)) {
+				eprintf ("Invalid RBinFile.id number.\n");
+			}
+		} else {
+			eprintf ("Usage: obb [bfid]\n");
+		}
+		break;
+#endif
 	case 'o': // "obo"
 		if (input[2] == ' ') {
 			ut32 fd = r_num_math (core->num, input + 3);

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -323,18 +323,6 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			value = input[2] ? input + 2 : NULL;
 		}
 		break;
-#if 0
-	case 'b': // "obb" // same as "ob $fd"
-		if (input[2] == ' ') {
-			ut32 id = r_num_math (core->num, input + 3);
-			if (!r_core_bin_raise (core, id)) {
-				eprintf ("Invalid RBinFile.id number.\n");
-			}
-		} else {
-			eprintf ("Usage: obb [bfid]\n");
-		}
-		break;
-#endif
 	case 'o': // "obo"
 		if (input[2] == ' ') {
 			ut32 fd = r_num_math (core->num, input + 3);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -955,7 +955,7 @@ static const char *radare_argv[] = {
 	"L?", "L", "L-", "Ll", "LL", "La", "Lc", "Ld", "Lh", "Li", "Lo",
 	"m?", "m", "m*", "ml", "m-", "md", "mf?", "mf", "mg", "mo", "mi", "mp", "ms", "my",
 	"o?", "o", "o-", "o--", "o+", "oa", "oa-", "oq", "o*", "o.", "o=",
-	"ob?", "ob", "ob*", "obo", "obb", "oba", "obf", "obj", "obr", "ob-", "ob-*",
+	"ob?", "ob", "ob*", "obo", "oba", "obf", "obj", "obr", "ob-", "ob-*",
 	"oc", "of", "oi", "oj", "oL", "om", "on",
 	"oo?", "oo", "oo+", "oob", "ood", "oom", "oon", "oon+", "oonn", "oonn+",
 	"op",  "ox",

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -11,16 +11,16 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=obb baddrs
+NAME=obo baddrs
 FILE=bins/mach0/mac-ls2
 ARGS=-B0x50000
 CMDS=<<EOF
 s
 o bins/mach0/mac-ls
 s
-obo 0
+obo 3
 s
-obo 1
+obo 4
 s
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -18,9 +18,9 @@ CMDS=<<EOF
 s
 o bins/mach0/mac-ls
 s
-obb 0
+obo 0
 s
-obb 1
+obo 1
 s
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This command was marked as deprecated for enough time

**Test plan**

Check if its not misused internally via rcore_cmd

**Closing issues**

dunno