### PR TITLE
Fix #17137 - Support multiple symbol servers with ';'

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2868,9 +2868,9 @@ R_API int r_core_config_init(RCore *core) {
         SETCB ("cmd.times", "", &cb_cmdtimes, "Run when a command is repeated (number prefix)");
 	/* pdb */
 	SETPREF ("pdb.useragent", "Microsoft-Symbol-Server/6.11.0001.402", "User agent for Microsoft symbol server");
-	SETPREF ("pdb.server", "https://msdl.microsoft.com/download/symbols", "Base URL for Microsoft symbol server");
+	SETPREF ("pdb.server", "https://msdl.microsoft.com/download/symbols", "Semi-colon separated list of base URLs for Microsoft symbol servers");
 	{
-		char *pdb_path = r_str_home(R2_HOME_PDB);
+		char *pdb_path = r_str_home (R2_HOME_PDB);
 		SETPREF ("pdb.symstore", pdb_path, "Path to downstream symbol store");
 		R_FREE(pdb_path);
 	}

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -822,13 +822,25 @@ static int cmd_info(void *data, const char *input) {
 					break;
 				case 'd':
 					pdbopts.user_agent = (char*) r_config_get (core->config, "pdb.useragent");
-					pdbopts.symbol_server = (char*) r_config_get (core->config, "pdb.server");
 					pdbopts.extract = r_config_get_i (core->config, "pdb.extract");
 					pdbopts.symbol_store_path = (char*) r_config_get (core->config, "pdb.symstore");
-					int r = r_bin_pdb_download (core, 0, NULL, &pdbopts);
+					char *str = strdup (r_config_get (core->config, "pdb.server"));
+					RList *server_l = r_str_split_list (str, ";", 0);
+					RListIter *it;
+					char *server;
+					int r = 1;
+					r_list_foreach (server_l, it, server) {
+						pdbopts.symbol_server = server;
+						r = r_bin_pdb_download (core, 0, NULL, &pdbopts);
+						if (!r) {
+							break;
+						}
+					}
 					if (r > 0) {
 						eprintf ("Error while downloading pdb file\n");
 					}
+					free (str);
+					r_list_free (server_l);
 					input++;
 					break;
 				case 'i':


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* Add support for UNC paths as symbol servers on Windows

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #17137
