### PR TITLE
Rename anal.in=raw to anal.in=range

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2891,7 +2891,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("anal.to", -1, (RConfigCallback)&cb_anal_from, "Upper limit on the address range for analysis");
 	n = NODECB ("anal.in", "io.maps.x", &cb_searchin);
 	SETDESC (n, "Specify search boundaries for analysis");
-	SETOPTIONS (n, "raw", "block",
+	SETOPTIONS (n, "range", "block",
 		"bin.segment", "bin.segments", "bin.segments.x", "bin.segments.r", "bin.section", "bin.sections", "bin.sections.rwx", "bin.sections.r", "bin.sections.rw", "bin.sections.rx", "bin.sections.wx", "bin.sections.x",
 		"io.map", "io.maps", "io.maps.rwx", "io.maps.r", "io.maps.rw", "io.maps.rx", "io.maps.wx", "io.maps.x",
 		"dbg.stack", "dbg.heap",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

On #14927, it was suggested to rename `anal.in`=raw to `anal.in=range` to honour `anal.in` and `anal.from`. I plan to solve the issue with this Pull Request.

**Test plan**
* The right direction in solving this, if I missed anything.
*  Guidance on `e.search.in` and `e.zoom.in` as it has the same options.

**Closing issues**

Closes #14927 