### PR TITLE
Avoid pesky warning

### DIFF
--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -1,6 +1,9 @@
 #ifndef R2_TH_H
 #define R2_TH_H
 
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE
+#endif
 #define _GNU_SOURCE
 #include "r_types.h"
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fixing the following warning during the compilation of `lang-python`:
```
cc python.c python/*.c -I/home/akochkov/.local/share/radare2/prefix/include -I/home/akochkov/bin/prefix/radare2/include/libr  -DPREFIX=\"\" -I/home/akochkov/bin/prefix/radare2/include/libr  -DPREFIX=\"\" -I/usr/include/python3.8 -I/usr/include/python3.8 -DPYVER=3 -lpython3.8 -lcrypt -lpthread -ldl -lutil -lm -lm -L/usr/lib -L/home/akochkov/bin/prefix/radare2/lib  -lr_core -lr_io -lr_util -shared -lr_asm \
-I/home/akochkov/bin/prefix/radare2/include/libr -L/home/akochkov/bin/prefix/radare2/lib -lr_core -lssl -lcrypto -lr_config -lr_debug -lr_bin -lr_anal -lr_bp -lr_egg -lr_asm -lr_lang -lr_parse -lr_flag -lr_reg -lr_search -lr_syscall -lr_fs -lr_io -lr_socket -lr_magic -lr_crypto -lr_hash -lr_cons -lr_util -ldl  \
-L/home/akochkov/.local/share/radare2/prefix/lib -L/home/akochkov/bin/prefix/radare2/lib  -lr_core -lr_io -lr_util -shared -lr_asm -fPIC -o lang_python.so
In file included from /home/akochkov/bin/prefix/radare2/include/libr/r_util.h:13,
                 from /home/akochkov/bin/prefix/radare2/include/libr/r_getopt.h:4,
                 from /home/akochkov/bin/prefix/radare2/include/libr/r_main.h:7,
                 from /home/akochkov/bin/prefix/radare2/include/libr/r_core.h:6,
                 from python/core.h:6,
                 from python.c:5:
/home/akochkov/bin/prefix/radare2/include/libr/r_th.h:4: warning: "_GNU_SOURCE" redefined
    4 | #define _GNU_SOURCE
      | 
In file included from /usr/include/python3.8/pyconfig.h:6,
                 from /usr/include/python3.8/Python.h:8,
                 from python/common.h:13,
                 from python.c:4:
/usr/include/python3.8/pyconfig-64.h:1575: note: this is the location of the previous definition
 1575 | #define _GNU_SOURCE 1
      | 
python/anal.c: In function ‘Radare_plugin_anal’:
python/anal.c:260:23: warning: assignment to ‘RAnalRegProfCallback’ {aka ‘_Bool (*)(struct r_anal_t *)’} from incompatible pointer type ‘int (*)(RAnal *)’ {aka ‘int (*)(struct r_anal_t *)’} [-Wincompatible-pointer-types]
  260 |   ap->set_reg_profile = py_set_reg_profile;
      |                       ^

```

**Test plan**

Compile `lang-python`

