### PR TITLE
Fix debug tests on Debian Jessie ##test

### DIFF
--- a/.github/workflows/debianold.yml
+++ b/.github/workflows/debianold.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Install tools
-      run: apt-get update && apt-get install --yes patch unzip git gcc make curl pkg-config python3
+      run: apt-get update && apt-get install --yes patch unzip git gcc make curl pkg-config python3 libc6-i386
     - name: Checkout r2
       run: |
         git clone https://github.com/${{ github.repository }}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Those binaries require the i386 libc6 to run. I included the package in the `apt install` command.

**Test Plans**

I tested it by setting up a `debian:jessie` docker container similar to the one specified in `debianold.yml`

**Closing issues**

closes #17227 
