### PR TITLE
Fix compiler warnings

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1926,8 +1926,8 @@ R_API int r_core_anal_esil_fcn(RCore *core, ut64 at, ut64 from, int reftype, int
 	return 0;
 }
 
-static int find_sym_flag(void *a1, void *a2) {
-	RFlagItem *f = (RFlagItem *)a2;
+static int find_sym_flag(const void *a1, const void *a2) {
+	const RFlagItem *f = (const RFlagItem *)a2;
 	return f->space && !strcmp (f->space->name, R_FLAGS_FS_SYMBOLS)? 0: 1;
 }
 

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2580,7 +2580,7 @@ static char *find_ch_after_macro(char *ptr, char ch) {
 static int r_core_cmd_subst(RCore *core, char *cmd) {
 	ut64 rep = strtoull (cmd, NULL, 10);
 	int ret = 0, orep;
-	char *cmt, *colon = NULL, *icmd = NULL;
+	char *colon = NULL, *icmd = NULL;
 	bool tmpseek = false;
 	bool original_tmpseek = core->tmpseek;
 
@@ -2626,7 +2626,6 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	}
 	if (*icmd && !strchr (icmd, '"')) {
 		char *hash = icmd;
-		cmt = NULL;
 		for (hash = icmd + 1; *hash; hash++) {
 			if (*hash == '\\') {
 				hash++;
@@ -2641,7 +2640,6 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 		if (hash && *hash) {
 			*hash = 0;
 			r_str_trim_tail (icmd);
-			cmt = hash + 1;
 		}
 	}
 	if (*cmd != '"') {


### PR DESCRIPTION
It's a while I have these warnings on my system (Fedora 31):
```
[1090/1507] Compiling C object 'libr/core/f105261@@r_core@sha/canal.c.o'                                                                                                                      
../libr/core/canal.c: In function ‘is_skippable_addr’:                                                                                                                                        
../libr/core/canal.c:1943:45: warning: passing argument 3 of ‘r_list_find’ from incompatible pointer type [-Wincompatible-pointer-types]                                                      
 1943 |  return !(flags && r_list_find (flags, fcn, find_sym_flag));                                                                                                                          
      |                                             ^~~~~~~~~~~~~                                                                                                                             
      |                                             |                                                                                                                                         
      |                                             int (*)(void *, void *)                    
In file included from ../libr/core/canal.c:4:                                                  
../libr/include/r_list.h:115:18: note: expected ‘RListComparator’ {aka ‘int (*)(const void *, const void *)’} but argument is of type ‘int (*)(void *, void *)’                               
  115 | R_API RListIter *r_list_find(const RList *list, const void *p, RListComparator cmp);   
      |                  ^~~~~~~~~~~                                                           
[1169/1507] Compiling C object 'libr/core/f105261@@r_core@sha/cmd.c.o'                         
../libr/core/cmd.c: In function ‘r_core_cmd_subst’:                                            
../libr/core/cmd.c:2583:8: warning: variable ‘cmt’ set but not used [-Wunused-but-set-variable]                                                                                               
 2583 |  char *cmt, *colon = NULL, *icmd = NULL;                                               
      |        ^~~                                                                    
```