### PR TITLE
Cleanup debugger state during restart.

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -116,6 +116,8 @@ R_API int r_core_file_reopen(RCore *core, const char *args, int perm, int loadbi
 		// Reset previous pid and tid
 		core->dbg->pid = -1;
 		core->dbg->tid = -1;
+		core->dbg->recoil_mode = R_DBG_RECOIL_NONE;
+		memset (&core->dbg->reason, 0, sizeof (core->dbg->reason));
 		// Reopen and attach
 		r_core_setup_debugger (core, "native", true);
 		r_debug_select (core->dbg, newpid, newtid);

--- a/test/db/archos/linux-x64/dbg_oo
+++ b/test/db/archos/linux-x64/dbg_oo
@@ -68,3 +68,30 @@ EXPECT=<<EOF
  1 fd: 4 +0x00000000 0x00000000 - 0x7ffffffffffffffe rwx 
 EOF
 RUN
+
+NAME=breakpoints after double doo
+FILE=bins/elf/analysis/x86-helloworld-gcc
+ARGS=
+CMDS=<<EOF
+db main
+db main+3
+doo > $_
+dc # should hit the first breakpoint
+.dr*
+?v eip-main
+doo > $_
+dc # should hit the first breakpoint
+.dr*
+?v eip-main
+dc # should hit the the second breakpoint
+.dr*
+?v eip-main
+EOF
+EXPECT=<<EOF
+0x0
+0x0
+0x3
+Hello world!
+EOF
+RUN
+


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Reinitialize debugger state when reopening in debug mode.

**Test plan**

* perform the steps described in #17212 testcase added

**Closing issues**

Closes #17212
