### PR TITLE
It seems we don't really require such a high version of meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('radare2', 'c', license: 'LGPL3', meson_version: '>=0.50.1')
+project('radare2', 'c', license: 'LGPL3', meson_version: '>=0.49.2')
 
 py3_exe = import('python').find_installation('python3')
 git_exe = find_program('git', required: false)


### PR DESCRIPTION
Some systems still ship older meson version and since it doesn't seem we
require such a high version, let's just require an older one.