### PR TITLE
Hardcode the version of meson/ninja to use to ensure consistency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       run: sudo apt-get --assume-yes install python3-wheel python3-setuptools
     - name: Install meson and ninja
       if: matrix.build_system == 'meson'
-      run: pip3 install --user meson ninja
+      run: pip3 install --user meson==0.52.0 ninja==1.10.0
     - name: Install test dependencies
       run: pip3 install --user 'git+https://github.com/radareorg/radare2-r2pipe#egg=r2pipe&subdirectory=python'
     - name: Install clang

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,7 +50,7 @@ jobs:
       run: sudo apt-get --assume-yes install python3-wheel python3-setuptools
     - name: Install meson and ninja
       if: matrix.build_system == 'meson'
-      run: pip3 install --user meson ninja
+      run: pip3 install --user meson==0.52.0 ninja==1.10.0
     - name: Install test dependencies
       if: matrix.run_tests
       run: pip3 install --user 'git+https://github.com/radareorg/radare2-r2pipe#egg=r2pipe&subdirectory=python'


### PR DESCRIPTION
Yesterday a new meson version was released, however it causes issues when used with coverage. See https://github.com/radareorg/radare2/runs/864707895 and https://github.com/mesonbuild/meson/issues/7437 .

This PR tries to fix the problem by ensuring we always use the same version of meson/ninja. Also, 0.52.0 should be more than enough at the moment to build the project.