### PR TITLE
Fix OOB access in z80 disasm for "OP [ixy+nn]" instructions.

### DIFF
--- a/libr/asm/arch/z80/z80.c
+++ b/libr/asm/arch/z80/z80.c
@@ -112,7 +112,7 @@ FUNC_ATTR_USED static int z80Disass (RAsmOp *op, const ut8 *buf, int len) {
 			buf_asm = sdb_fmt (z_op[res].name, buf[2]+(buf[3]<<8));
 		}
 		if (z_op[res].type == (Z80_OP16^Z80_ARG8)) {
-			buf_asm = sdb_fmt (z_op[res].name, buf[2], buf[3]);
+			buf_asm = sdb_fmt (z_op[res].name, buf[2]);
 		}
 		if (z_op[res].type == (Z80_OP24 ^ Z80_ARG8)) {
 			cb_tab = (char **) z_op[res].op_moar;

--- a/test/db/asm/z80
+++ b/test/db/asm/z80
@@ -1123,6 +1123,7 @@ d "xor 0x00" ee00
 d "xor [hl]" ae
 d "xor [ix+0x00]" ddae00
 d "xor [iy+0x00]" fdae00
+d "xor [iy+0x1f]" fdae1f
 d "xor a" af
 d "xor b" a8
 d "xor c" a9


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

There is only one 8bit constant to read. Doesn't fix leak in z80 assembler that's a separate problem and requires more refactoring.

**Test plan**

Run `r2r db/asm/z80` with sanitizer and `ASAN_OPTIONS=detect_odr_violation=0:detect_leaks=0`

**Closing issues**
closes #17265
