### PR TITLE
Id next

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -458,6 +458,8 @@ R_API bool r_io_fd_get_base (RIO *io, int fd, ut64 *base);
 R_API const char *r_io_fd_get_name (RIO *io, int fd);
 R_API int r_io_fd_get_current(RIO *io);
 R_API bool r_io_use_fd (RIO *io, int fd);
+R_API int r_io_fd_get_next (RIO *io, int fd);
+R_API int r_io_fd_get_prev (RIO *io, int fd);
 
 
 #define r_io_range_new()	R_NEW0(RIORange)

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -395,6 +395,8 @@ R_API void r_io_desc_free (RIODesc *desc);
 R_API bool r_io_desc_add (RIO *io, RIODesc *desc);
 R_API bool r_io_desc_del (RIO *io, int fd);
 R_API RIODesc *r_io_desc_get (RIO *io, int fd);
+R_API RIODesc *r_io_desc_get_next (RIO *io, RIODesc *desc);
+R_API RIODesc *r_io_desc_get_prev (RIO *io, RIODesc *desc);
 R_API ut64 r_io_desc_seek (RIODesc *desc, ut64 offset, int whence);
 R_API bool r_io_desc_resize (RIODesc *desc, ut64 newsize);
 R_API ut64 r_io_desc_size (RIODesc *desc);

--- a/libr/include/r_util/r_idpool.h
+++ b/libr/include/r_util/r_idpool.h
@@ -37,6 +37,8 @@ R_API RIDStorage *r_id_storage_new(ut32 start_id, ut32 last_id);
 R_API bool r_id_storage_set(RIDStorage *storage, void *data, ut32 id);
 R_API bool r_id_storage_add(RIDStorage *storage, void *data, ut32 *id);
 R_API void *r_id_storage_get(RIDStorage *storage, ut32 id);
+R_API bool r_id_storage_get_next(RIDStorage *storage, ut32 *id);
+R_API bool r_id_storage_get_prev(RIDStorage *storage, ut32 *id);
 R_API void r_id_storage_delete(RIDStorage *storage, ut32 id);
 R_API void *r_id_storage_take(RIDStorage *storage, ut32 id);
 R_API bool r_id_storage_foreach(RIDStorage *storage, RIDStorageForeachCb cb, void *user);

--- a/libr/io/io_desc.c
+++ b/libr/io/io_desc.c
@@ -73,6 +73,24 @@ R_API RIODesc* r_io_desc_get(RIO* io, int fd) {
 	return (RIODesc*) r_id_storage_get (io->files, fd);
 }
 
+R_API RIODesc *r_io_desc_get_next(RIO *io, RIODesc *desc) {
+	r_return_val_if_fail (desc && io && io->files, NULL);
+	const int next_fd = r_io_fd_get_next (io, desc->fd)
+	if (next_fd == -1) {
+		return NULL;
+	}
+	return (RIODesc*) r_id_storage_get (io->files, next_fd);
+}
+
+R_API RIODesc *r_io_desc_get_prev(RIO *io, RIODesc *desc) {
+	r_return_val_if_fail (desc && io && io->files, NULL);
+	const int prev_fd = r_io_fd_get_prev (io, desc->fd)
+	if (prev_fd == -1) {
+		return NULL;
+	}
+	return (RIODesc*) r_id_storage_get (io->files, prev_fd);
+}
+
 R_API RIODesc *r_io_desc_open(RIO *io, const char *uri, int perm, int mode) {
 	r_return_val_if_fail (io && uri, NULL);
 	RIOPlugin *plugin = r_io_plugin_resolve (io, uri, 0);

--- a/libr/io/io_fd.c
+++ b/libr/io/io_fd.c
@@ -126,3 +126,21 @@ R_API int r_io_fd_get_current(RIO *io) {
 	}
 	return -1;
 }
+
+R_API int r_io_fd_get_next(RIO *io, int fd) {
+	r_return_val_if_fail (io, -1);
+	int ret = fd;
+	if (!r_id_storage_get_next (io->files, &ret)) {
+		return -1;
+	}
+	return ret;
+}
+
+R_API int r_io_fd_get_prev(RIO *io, int fd) {
+	r_return_val_if_fail (io, -1);
+	int ret = fd;
+	if (!r_id_storage_get_prev (io->files, &ret)) {
+		return -1;
+	}
+	return ret;
+}

--- a/libr/util/idpool.c
+++ b/libr/util/idpool.c
@@ -163,6 +163,35 @@ R_API void* r_id_storage_get(RIDStorage* storage, ut32 id) {
 	return storage->data[id];
 }
 
+// usually these shall not be used
+// id-storage doesn't provide sorting things in specific order
+// there are only a very few reasonable usecases, such as cycling through RIODescs
+R_API bool r_id_storage_get_next(RIDStorage *storage, ut32 *id) {
+	r_return_val_if_fail (id && storage && storage->data, false);
+	// it does not indicate a bug, if the passed id goes beyond the boundaries of the storage
+	// therefor no r_return_val_if_fail for this case
+	if (storage->id <= *id) {
+		return false;
+	}
+
+	do {
+		*id = (*id + 1) % storage->size;
+	} while (!storage->data[*id]);
+	return true;
+}
+
+R_API bool r_id_storage_get_prev(RIDStorage *storage, ut32 *id) {
+	r_return_val_if_fail (id && storage && storage->data, false);
+	if (storage->id <= *id) {
+		return false;
+	}
+
+	do {
+		*id = (*id + (storage->size - 1)) % storage->size;
+	} while (!storage->data[*id]);
+	return true;
+}
+
 R_API void r_id_storage_delete(RIDStorage* storage, ut32 id) {
 	if (!storage || !storage->data || (storage->size <= id)) {
 		return;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Let me be honest with you: From my perspective this code is mostly useless, except for the use case of #17162 . RIDStorage does not provide any specific ordering of the stored values, so if you look at a specific value, that is stored in an id_storage, there is no such thing as next or previous value. However this code pr is useful for cycling through values in an unspecific order, just as in #17156.

So why is there r_io_fd_get_next and r_io_desc_get_next? Wouldn't it be enough to have only one of them?
The reason for that is, that I want the io api to be used as painless as possible. Imo that means, that projects that only use the map and fd api shouldn't be forced to switch between desc and fd to use this.

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
