### PR TITLE
Fix non-debug projects by reopening the file ##projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -630,7 +630,10 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 
 static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	char *filename, *hl, *ohl = NULL;
+	char *binpath = r_file_abspath(core->bin->file);
+	char  *reopen = (char *) r_malloc(strlen(binpath) + 32);
 	int fd, fdold;
+	sprintf(reopen, "\"o %s\"\n", binpath);
 
 	if (!file || *file == '\0') {
 		return false;
@@ -653,6 +656,9 @@ static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
+        r_str_write(fd, reopen);
+	free(reopen);
+	free(binpath);
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).
 	r_config_set (core->config, "file.path", "");
@@ -779,6 +785,7 @@ R_API bool r_core_project_save(RCore *core, const char *prjName) {
 #if TRANSITION
 			r_file_rm (scriptPath);
 			r_sys_mkdirp (prjDir);
+
 			eprintf ("Please remove: rm -rf %s %s.d\n", prjName, prjName);
 			char *rc = r_str_newf ("%s" R_SYS_DIR "rc", prjDir);
 			if (!rc) {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -630,7 +630,7 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 
 static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	char *filename, *hl, *ohl = NULL;
-	char  *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath(core->bin->file);
+	char  *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath(core->bin->file));
 	int fd, fdold;
 
 	if (!file || *file == '\0') {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -656,7 +656,7 @@ static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-        r_str_write(fd, reopen);
+	r_str_write(fd, reopen);
 	free(reopen);
 	free(binpath);
 	// Set file.path and file.lastpath to empty string to signal

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -630,7 +630,7 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 
 static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	char *filename, *hl, *ohl = NULL;
-	char  *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath(core->bin->file));
+	char  *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath (core->bin->file));
 	int fd, fdold;
 
 	if (!file || *file == '\0') {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -630,10 +630,8 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 
 static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	char *filename, *hl, *ohl = NULL;
-	char *binpath = r_file_abspath(core->bin->file);
-	char  *reopen = (char *) r_malloc(strlen(binpath) + 33);
+	char  *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath(core->bin->file);
 	int fd, fdold;
-	sprintf(reopen, "\"o %s\"\n", binpath);
 
 	if (!file || *file == '\0') {
 		return false;
@@ -656,9 +654,8 @@ static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	r_str_write(fd, reopen);
-	free(reopen);
-	free(binpath);
+	r_str_write (fd, reopen);
+	free (reopen);
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).
 	r_config_set (core->config, "file.path", "");

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -631,7 +631,7 @@ static bool simpleProjectSaveScript(RCore *core, const char *file, int opts) {
 static bool projectSaveScript(RCore *core, const char *file, int opts) {
 	char *filename, *hl, *ohl = NULL;
 	char *binpath = r_file_abspath(core->bin->file);
-	char  *reopen = (char *) r_malloc(strlen(binpath) + 32);
+	char  *reopen = (char *) r_malloc(strlen(binpath) + 33);
 	int fd, fdold;
 	sprintf(reopen, "\"o %s\"\n", binpath);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [*] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [*] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [*] I've added tests that prove my fix is effective or that my feature works (if possible)
- [*] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
normally when you save a project it and reaload it r2 doesn't reopen the file so I added a o [binary file path] into the r2 project's rc file. the projects loads successfully if not saved in debug mode. because of PIE 
...

**Test plan**
I have recompiled r2 on archlinux with /sys/install.sh and everything works prefectly fine including the Ps (project save) command
...
...
# #16353 