### PR TITLE
Fix esil data refs in arm for misaligned data ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5093,9 +5093,6 @@ repeat:
 				ut64 dst = ESIL->cur;
 				if ((target && dst == ntarget) || !target) {
 					if (CHECKREF (dst)) {
-						if ((dst & 1) && (core->anal->bits == 16)) {
-							dst &= ~1;
-						}
 						r_anal_xrefs_set (core->anal, cur, dst, R_ANAL_REF_TYPE_DATA);
 					}
 				}

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -1056,3 +1056,16 @@ EXPECT=<<EOF
 0x0006506c CCu "switch table (13 cases) at 0x65074"
 EOF
 RUN
+
+NAME=misaligned arm string xref
+FILE=bins/mach0/misaligned_data-iOS-armv7
+CMDS=<<EOF
+aav
+aae
+af
+axt str.helloradareworld
+EOF
+EXPECT=<<EOF
+main 0xbf9c [DATA] add r0, pc
+EOF
+RUN


### PR DESCRIPTION
in armv7, if data refs are not aligned do not mask.

finds data ref in https://github.com/radareorg/radare2-testbins/pull/34

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

arm can make data misaligned, and it mustn't always be masked off, like code refs should be.

...

**Test plan**

verify that the data ref is calculated properly with esil analysis in https://github.com/radareorg/radare2-testbins/pull/34

...

**Closing issues**

none

...
