### PR TITLE
Fix #17264 - use r_types.h in r2r

### DIFF
--- a/binr/r2r/r2r.h
+++ b/binr/r2r/r2r.h
@@ -3,6 +3,7 @@
 #ifndef RADARE2_R2R_H
 #define RADARE2_R2R_H
 
+#include <r_types.h>
 #include <r_util.h>
 
 #if defined (__FreeBSD__) || defined (__FreeBSD_kernel__)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

A blind fix by adding `<r_types.h>` into the `binr/r2r/r2r.h` to define `CLOCK_MONOTONIC` if undefined for the current platform.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
