### PR TITLE
Add r_sys_now_mono() and use in r2r ##util

### DIFF
--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -2,12 +2,6 @@
 
 #include "r2r.h"
 
-#define NSEC_PER_SEC  1000000000
-#define NSEC_PER_MSEC 1000000
-#define USEC_PER_SEC  1000000
-#define NSEC_PER_USEC 1000
-#define USEC_PER_MSEC 1000
-
 #if __WINDOWS__
 struct r2r_subprocess_t {
 	HANDLE stdin_write;
@@ -236,20 +230,6 @@ error:
 	goto beach;
 }
 
-static ut64 now_us(void) {
-	LARGE_INTEGER f;
-	if (!QueryPerformanceFrequency (&f)) {
-		return 0;
-	}
-	LARGE_INTEGER v;
-	if (!QueryPerformanceCounter (&v)) {
-		return 0;
-	}
-	v.QuadPart *= 1000000;
-	v.QuadPart /= f.QuadPart;
-	return v.QuadPart;
-}
-
 R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 	OVERLAPPED stdout_overlapped = { 0 };
 	stdout_overlapped.hEvent = CreateEvent (NULL, TRUE, FALSE, NULL);
@@ -265,7 +245,7 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 
 	ut64 timeout_us_abs = UT64_MAX;
 	if (timeout_ms != UT64_MAX) {
-		timeout_us_abs = now_us () + timeout_ms * USEC_PER_MSEC;
+		timeout_us_abs = r_sys_now_mono () + timeout_ms * USEC_PER_MSEC;
 	}
 
 	ut8 stdout_buf[0x500];
@@ -307,7 +287,7 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 		
 		DWORD timeout = INFINITE;
 		if (timeout_us_abs != UT64_MAX) {
-			ut64 now = now_us ();
+			ut64 now = r_sys_now_mono ();
 			if (now >= timeout_us_abs) {
 				return false;
 			}
@@ -635,12 +615,9 @@ error:
 }
 
 R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
-	struct timespec timeout_abs;
+	ut64 timeout_abs;
 	if (timeout_ms != UT64_MAX) {
-		clock_gettime (CLOCK_MONOTONIC, &timeout_abs);
-		timeout_abs.tv_nsec += timeout_ms * NSEC_PER_MSEC;
-		timeout_abs.tv_sec += timeout_abs.tv_nsec / NSEC_PER_SEC;
-		timeout_abs.tv_nsec = timeout_abs.tv_nsec % NSEC_PER_SEC;
+		timeout_abs = r_sys_now_mono () + timeout_ms * R_USEC_PER_MSEC;
 	}
 
 	int r = 0;
@@ -674,15 +651,12 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 		struct timeval timeout_s;
 		struct timeval *timeout = NULL;
 		if (timeout_ms != UT64_MAX) {
-			struct timespec now;
-			clock_gettime (CLOCK_MONOTONIC, &now);
-			st64 usec_diff = ((st64)timeout_abs.tv_sec - now.tv_sec) * USEC_PER_SEC
-					+ ((st64)timeout_abs.tv_nsec - now.tv_nsec) / NSEC_PER_USEC;
+			st64 usec_diff = timeout_abs - r_sys_now_mono ();
 			if (usec_diff <= 0) {
 				break;
 			}
-			timeout_s.tv_sec = usec_diff / USEC_PER_SEC;
-			timeout_s.tv_usec = usec_diff % USEC_PER_SEC;
+			timeout_s.tv_sec = usec_diff / R_USEC_PER_SEC;
+			timeout_s.tv_usec = usec_diff % R_USEC_PER_SEC;
 			timeout = &timeout_s;
 		}
 		r = select (nfds, &rfds, NULL, NULL, timeout);

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -245,7 +245,7 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 
 	ut64 timeout_us_abs = UT64_MAX;
 	if (timeout_ms != UT64_MAX) {
-		timeout_us_abs = r_sys_now_mono () + timeout_ms * USEC_PER_MSEC;
+		timeout_us_abs = r_sys_now_mono () + timeout_ms * R_USEC_PER_MSEC;
 	}
 
 	ut8 stdout_buf[0x500];
@@ -291,7 +291,7 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 			if (now >= timeout_us_abs) {
 				return false;
 			}
-			timeout = (DWORD)((timeout_us_abs - now) / USEC_PER_MSEC);
+			timeout = (DWORD)((timeout_us_abs - now) / R_USEC_PER_MSEC);
 		}
 		DWORD signaled = WaitForMultipleObjects (handles.len, handles.a, FALSE, timeout);
 		if (!stdout_eof && signaled == stdout_index) {

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -651,10 +651,11 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms) {
 		struct timeval timeout_s;
 		struct timeval *timeout = NULL;
 		if (timeout_ms != UT64_MAX) {
-			st64 usec_diff = timeout_abs - r_sys_now_mono ();
-			if (usec_diff <= 0) {
+			ut64 now = r_sys_now_mono ();
+			if (now >= timeout_abs) {
 				break;
 			}
+			ut64 usec_diff = timeout_abs - r_sys_now_mono ();
 			timeout_s.tv_sec = usec_diff / R_USEC_PER_SEC;
 			timeout_s.tv_usec = usec_diff % R_USEC_PER_SEC;
 			timeout = &timeout_s;

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -37,7 +37,19 @@ R_API int r_sys_signal(int sig, void (*handler) (int));
 R_API void r_sys_env_init(void);
 R_API char **r_sys_get_environ(void);
 R_API void r_sys_set_environ(char **e);
+
+#define R_NSEC_PER_SEC  1000000000
+#define R_NSEC_PER_MSEC 1000000
+#define R_USEC_PER_SEC  1000000
+#define R_NSEC_PER_USEC 1000
+#define R_USEC_PER_MSEC 1000
+
+// wall clock time in microseconds
 R_API ut64 r_sys_now(void);
+
+// monotonic time in microseconds
+R_API ut64 r_sys_now_mono(void);
+
 R_API const char *r_time_to_string (ut64 ts);
 R_API int r_sys_fork(void);
 // nocleanup = false => exit(); true => _exit()

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -2,6 +2,8 @@
 
 #if __linux__
 #include <time.h>
+#elif __APPLE__ && !defined(MAC_OS_X_VERSION_10_12)
+#include <mach/mach_time.h>
 #endif
 
 #include <r_userconf.h>
@@ -231,6 +233,11 @@ R_API ut64 r_sys_now_mono(void) {
 	v.QuadPart *= 1000000;
 	v.QuadPart /= f.QuadPart;
 	return v.QuadPart;
+#elif __APPLE__ && !defined(MAC_OS_X_VERSION_10_12)
+	ut64 ticks = mach_absolute_time ();
+	static mach_timebase_info_data_t tb;
+	mach_timebase_info (&tb);
+	return ((ticks * tb.numer) / tb.denom) / R_NSEC_PER_USEC;
 #else
 	struct timespec now;
 	clock_gettime (CLOCK_MONOTONIC, &now);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -218,6 +218,27 @@ R_API ut64 r_sys_now(void) {
 	return ret;
 }
 
+R_API ut64 r_sys_now_mono(void) {
+#if __WINDOWS__
+	LARGE_INTEGER f;
+	if (!QueryPerformanceFrequency (&f)) {
+		return 0;
+	}
+	LARGE_INTEGER v;
+	if (!QueryPerformanceCounter (&v)) {
+		return 0;
+	}
+	v.QuadPart *= 1000000;
+	v.QuadPart /= f.QuadPart;
+	return v.QuadPart;
+#else
+	struct timespec now;
+	clock_gettime (CLOCK_MONOTONIC, &now);
+	return now.tv_sec * R_USEC_PER_SEC
+		+ now.tv_nsec / R_NSEC_PER_USEC;
+#endif
+}
+
 R_API int r_sys_truncate(const char *file, int sz) {
 #if __WINDOWS__
 	int fd = r_sandbox_open (file, O_RDWR, 0644);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Wall clock time is conceptually wrong for measuring time deltas. This adds a portable function for monotonic time.

**Test plan**

r2r should still show the elapsed time correctly on exit.

**Closing issues**

Fix #17264
