### PR TITLE
Fix duplicated entry symbols in macho ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2948,7 +2948,9 @@ const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin) {
 
 		for (i = 0; i < bin->nsymtab; i++) {
 			struct MACH0_(nlist) *st = &bin->symtab[i];
-			stridx = st->n_strx;
+			if (st->n_type & N_STAB) {
+				continue;
+			}
 			// 0 is for imports
 			// 1 is for symbols
 			// 2 is for func.eh (exception handlers?)
@@ -2964,11 +2966,12 @@ const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin) {
 				} else {
 					symbols[j].type = R_BIN_MACH0_SYMBOL_TYPE_LOCAL;
 				}
+				stridx = st->n_strx;
 				char *sym_name = get_name (bin, stridx, false);
 				if (sym_name) {
 					symbols[j].name = sym_name;
 				} else {
-					symbols[j].name = r_str_newf ("entry%d\n", i);
+					symbols[j].name = r_str_newf ("entry%d", i);
 					//symbols[j].name[0] = 0;
 				}
 				symbols[j].last = 0;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4483,3 +4483,15 @@ EXPECT_ERR=<<EOF
 Warning: run r2 with -e io.cache=true to fix relocations in disassembly
 EOF
 RUN
+
+NAME=macho-ghost-symbols
+FILE=bins/mach0/libr_flag.dylib
+CMDS=<<EOF
+is~?
+is~entry?
+EOF
+EXPECT=<<EOF
+247
+0
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Solves https://github.com/radareorg/radare2/pull/17233

**Test plan**

theres a test

**Closing issues**

https://github.com/radareorg/radare2/pull/17233