### PR TITLE
Check length before disassembling cr16 instructions ##asm

### DIFF
--- a/libr/anal/p/anal_cr16.c
+++ b/libr/anal/p/anal_cr16.c
@@ -18,7 +18,7 @@ static int cr16_op(RAnal *anal, RAnalOp *op, ut64 addr,
 
 	memset(&cmd, 0, sizeof (cmd));
 
-	ret = op->size = cr16_decode_command(buf, &cmd);
+	ret = op->size = cr16_decode_command(buf, &cmd, len);
 
 	if (ret <= 0) {
 		return ret;

--- a/libr/asm/arch/cr16/cr16_disas.h
+++ b/libr/asm/arch/cr16/cr16_disas.h
@@ -46,7 +46,7 @@ struct cr16_cmd {
 	char operands[CR16_INSTR_MAXLEN];
 };
 
-int cr16_decode_command(const ut8 *instr, struct cr16_cmd *cmd);
+int cr16_decode_command(const ut8 *instr, struct cr16_cmd *cmd, int len);
 
 enum cr16_opcodes {
 	CR16_ADD	= 0x0,

--- a/libr/asm/p/asm_cr16.c
+++ b/libr/asm/p/asm_cr16.c
@@ -9,7 +9,7 @@
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	struct cr16_cmd cmd;
-	int ret = cr16_decode_command (buf, &cmd);
+	int ret = cr16_decode_command (buf, &cmd, len);
 	r_strbuf_set (&op->buf_asm, sdb_fmt ("%s %s", cmd.instr, cmd.operands));
 	return op->size = ret;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Who is the "owner" of this assembler? I don't even know what this architecture is about... However, this whole disassembler is missing any check on the length at all. It is completely ignored

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/radareorg/radare2/issues/17285
