### PR TITLE
DWARF - fixed OOB read and memory leak

### DIFF
--- a/libr/anal/type_dwarf.c
+++ b/libr/anal/type_dwarf.c
@@ -317,22 +317,30 @@ static st32 parse_type (const RBinDwarfDie *all_dies, const ut64 count,
 		break;
 	case DW_TAG_volatile_type:
 		type_idx = find_attr_idx (die, DW_AT_type);
-		parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		if (type_idx != -1) {
+			parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		}
 		r_strbuf_append (strbuf, " volatile");
 		break;
 	case DW_TAG_restrict_type:
 		type_idx = find_attr_idx (die, DW_AT_type);
-		parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		if (type_idx != -1) {
+			parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		}
 		r_strbuf_append (strbuf, " restrict");
 		break;
 	case DW_TAG_rvalue_reference_type:
 		type_idx = find_attr_idx (die, DW_AT_type);
-		parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		if (type_idx != -1) {
+			parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		}
 		r_strbuf_append (strbuf, " &&");
 		break;
 	case DW_TAG_reference_type:
 		type_idx = find_attr_idx (die, DW_AT_type);
-		parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		if (type_idx != -1) {
+			parse_type (all_dies, count, die->attr_values[type_idx].reference, strbuf, size);
+		}
 		r_strbuf_append (strbuf, " &");
 		break;
 	default:

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -481,6 +481,7 @@ static const ut8 *parse_line_header_source(RBinFile *bf, const ut8 *buf, const u
 					hdr->file_names[count].file_len = file_len;
 				}
 				free (comp_dir);
+				free (include_dir);
 				free (pinclude_dir);
 			}
 			count++;

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -480,9 +480,11 @@ static const ut8 *parse_line_header_source(RBinFile *bf, const ut8 *buf, const u
 					hdr->file_names[count].mod_time = mod_time;
 					hdr->file_names[count].file_len = file_len;
 				}
-				free (comp_dir);
-				free (include_dir);
-				free (pinclude_dir);
+				if (comp_dir) {
+					R_FREE (include_dir);
+					R_FREE (comp_dir);
+				}
+				R_FREE (pinclude_dir);
 			}
 			count++;
 			if (mode == R_MODE_PRINT && i) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
**Detailed description**

Fixed OOB read and leak in dwarf code base based on ASAN and valgrind findings when executing 
"radare2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc 'CL 0x0000a24e
' bins/mach0/TestRTTI-armv7-dSYM" 
