### PR TITLE
 Bring back tcc support ##build

### DIFF
--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # “At 00:00 on every Tuesday, Thursday, and Saturday”
     - cron:  '0 13 * * 2,4,6'
+  # FIXME: To remove before merge!!!
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:

--- a/shlr/heap/include/r_jemalloc/internal/util.h
+++ b/shlr/heap/include/r_jemalloc/internal/util.h
@@ -287,7 +287,7 @@ lg_floor(size_t x)
 	assert(ret < UINT_MAX);
 	return ((unsigned)ret);
 }
-#elif (defined(JEMALLOC_HAVE_BUILTIN_CLZ))
+#elif (defined(JEMALLOC_HAVE_BUILTIN_CLZ)) && !defined(__TINYC__)
 JEMALLOC_INLINE unsigned
 lg_floor(size_t x)
 {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Building r2 with TCC is somewhat desirable. This PR aims to fix https://github.com/radareorg/radare2/issues/4328

**Test plan**

Maybe add a github action with the following lines:

```
r2pm -ci tcc
export CC="tcc"
r2pm -r ./configure --with-compiler=tcc
r2pm -r make
```

**Closing issues**

Closes https://github.com/radareorg/radare2/issues/4328