### PR TITLE
Reload file when opening a project ##projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -662,9 +662,9 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") == 0 &&
-	  	strcmp (r_config_get (core->config, "asm.emu"), "false") == 0) {
-		char *reopen = r_str_newf ("\"o %s\"", r_file_abspath (core->bin->file));
+	if (!core->bin->is_debugger &&
+			  strcmp (r_config_get (core->config, "asm.emu"), "false") == 0) {
+		char *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath (core->bin->file));
 		r_str_write (fd, reopen);
 		free (reopen);
 	}

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -663,7 +663,7 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") != 0) {
+	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") == 0) {
 		char *reopen = r_str_newf ("\"o %s\"", r_file_abspath (core->bin->file));
 		r_str_write (fd, reopen);
 		free (reopen);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -662,7 +662,7 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	if (!core->bin->is_debugger && !r_config_get_i(core->config, "asm.emu")) {
+	if (!core->bin->is_debugger && !r_config_get_i (core->config, "asm.emu")) {
 		char *fpath = r_file_abspath (core->bin->file);
 		if (fpath != NULL){
 		char *reopen = r_str_newf ("\"o %s\"\n",fpath);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -658,12 +658,12 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 		ohl = strdup (hl);
 		r_cons_highlight (NULL);
 	}
-
 	fdold = r_cons_singleton ()->fdout;
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") == 0) {
+	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") == 0 &&
+	  	strcmp (r_config_get (core->config, "asm.emu"), "false") == 0) {
 		char *reopen = r_str_newf ("\"o %s\"", r_file_abspath (core->bin->file));
 		r_str_write (fd, reopen);
 		free (reopen);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -664,11 +664,13 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_str_write (fd, "# r2 rdb project file\n");
 	if (!core->bin->is_debugger && !r_config_get_i (core->config, "asm.emu")) {
 			char *fpath = r_file_abspath (core->bin->file);
-			if (fpath){
+			if (fpath) {
 				char *reopen = r_str_newf ("\"o %s\"\n",fpath);
+				if (reopen) {
 				r_str_write (fd, reopen);
 				free (reopen);
 				free (fpath);
+				}
 			}
 	}
 	// Set file.path and file.lastpath to empty string to signal

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -670,8 +670,10 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 				r_str_write (fd, reopen);
 				free (reopen);
 				free (fpath);
-				}
 			}
+			
+		}
+		
 	}
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -662,11 +662,15 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
-	if (!core->bin->is_debugger &&
-			  strcmp (r_config_get (core->config, "asm.emu"), "false") == 0) {
-		char *reopen = r_str_newf ("\"o %s\"\n", r_file_abspath (core->bin->file));
+	if (!core->bin->is_debugger && !r_config_get_i(core->config, "asm.emu")) {
+		char *fpath = r_file_abspath (core->bin->file);
+		if (fpath != NULL){
+		char *reopen = r_str_newf ("\"o %s\"\n",fpath);
 		r_str_write (fd, reopen);
 		free (reopen);
+		free (fpath);
+
+		}
 	}
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -663,10 +663,10 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
 	if (!core->bin->is_debugger && !r_config_get_i (core->config, "asm.emu")) {
-			char *fpath = r_file_abspath (core->bin->file);
-			if (fpath) {
-				char *reopen = r_str_newf ("\"o %s\"\n",fpath);
-				if (reopen) {
+		char *fpath = r_file_abspath (core->bin->file);
+		if (fpath) {
+			char *reopen = r_str_newf ("\"o %s\"\n",fpath);
+			if (reopen) {
 				r_str_write (fd, reopen);
 				free (reopen);
 				free (fpath);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -663,13 +663,12 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
 	if (!core->bin->is_debugger && !r_config_get_i (core->config, "asm.emu")) {
-		char *fpath = r_file_abspath (core->bin->file);
-		if (fpath != NULL){
-		char *reopen = r_str_newf ("\"o %s\"\n",fpath);
-		r_str_write (fd, reopen);
-		free (reopen);
-		free (fpath);
-
+			char *fpath = r_file_abspath (core->bin->file);
+			if (fpath){
+				char *reopen = r_str_newf ("\"o %s\"\n",fpath);
+				r_str_write (fd, reopen);
+				free (reopen);
+				free (fpath);
 		}
 	}
 	// Set file.path and file.lastpath to empty string to signal

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -663,6 +663,11 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 	r_cons_singleton ()->fdout = fd;
 	r_cons_singleton ()->context->is_interactive = false;
 	r_str_write (fd, "# r2 rdb project file\n");
+	if (strcmp (r_config_get (core->config, "cfg.debug"), "false") != 0) {
+		char *reopen = r_str_newf ("\"o %s\"", r_file_abspath (core->bin->file));
+		r_str_write (fd, reopen);
+		free (reopen);
+	}
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).
 	r_config_set (core->config, "file.path", "");

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -669,7 +669,7 @@ static bool project_save_script(RCore *core, const char *file, int opts) {
 				r_str_write (fd, reopen);
 				free (reopen);
 				free (fpath);
-		}
+			}
 	}
 	// Set file.path and file.lastpath to empty string to signal
 	// new behaviour to project load routine (see io maps below).

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -452,6 +452,6 @@ pd 1 ~test
 rm .tmp/
 EOF
 EXPECT=<<EOF
-0x00400506      55             push rbp                    ; test
+|           0x00400506      55             push rbp                    ; test
 EOF
 RUN

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -439,3 +439,19 @@ EXPECT=<<EOF
 5
 EOF
 RUN
+NAME=Reopening project with changes loading
+FILE=bins/elf/analysis/main
+BROKEN=1
+CMDS=<<EOF
+aaa > /dev/null
+e dir.projects = .tmp/
+s main > /dev/null
+CC test
+Ps lapa > /dev/null
+Po lapa
+pd 1 ~test
+EOF
+EXPECT=<<EOF
+│           0x00400506      55             push rbp                    ; test test
+EOF
+RUN

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -452,6 +452,6 @@ pd 1 ~test
 rm .tmp/
 EOF
 EXPECT=<<EOF
-│           0x00400506      55             push rbp                    ; test
+0x00400506      55             push rbp                    ; test
 EOF
 RUN

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -449,8 +449,9 @@ CC test
 Ps lapa > /dev/null
 Po lapa
 pd 1 ~test
+rm .tmp/
 EOF
 EXPECT=<<EOF
-│           0x00400506      55             push rbp                    ; test test
+│           0x00400506      55             push rbp                    ; test
 EOF
 RUN

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -441,7 +441,6 @@ EOF
 RUN
 NAME=Reopening project with changes loading
 FILE=bins/elf/analysis/main
-BROKEN=1
 CMDS=<<EOF
 aaa > /dev/null
 e dir.projects = .tmp/


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I made radare projects reload their binary if the project was not saved in debug mode. This patch fixes a problem that makes radare2 projects unusable because radare won't load any binary when the project is loaded.
This patch does not reload projects that are opend in debug mode.
This patch does not work if the binary is emulated.
#17270 that is also me
...

**Test plan**
I have added a new test to test/db/cmd/cmd_project the test opens a file adds a comment, saves a project and then reopens it the comment should still be there or else the test will fail.

**Closing issues**
 I have had this issue a while ago #16353 

...
