### PR TITLE
Fix #ideas-294 - Remove RIO.debug

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -3502,7 +3502,7 @@ static int agraph_refresh(struct agraph_refresh_data *grd) {
 	}
 
 	// allow to change the current function during debugging
-	if (g->is_instep && core->io->debug) {
+	if (g->is_instep && core->bin->is_debugger) {
 		// seek only when the graph node changes
 		const char *pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
 		RRegItem *r = r_reg_get (core->dbg->reg, pc, -1);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -253,7 +253,7 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 		types |= R_ANAL_ADDR_TYPE_FUNC;
 	}
 	// check registers
-	if (core->io && core->io->debug && core->dbg) { // TODO: if cfg.debug here
+	if (core->bin && core->bin->is_debugger && core->dbg) { // TODO: if cfg.debug here
 		RDebugMap *map;
 		RListIter *iter;
 		// use 'dm'
@@ -2290,7 +2290,7 @@ R_API void r_core_anal_importxrefs(RCore *core) {
 	RBinInfo *info = r_bin_get_info (core->bin);
 	RBinObject *obj = r_bin_cur_object (core->bin);
 	bool lit = info ? info->has_lit: false;
-	int va = core->io->va || core->io->debug;
+	bool va = core->io->va || core->bin->is_debugger;
 
 	RListIter *iter;
 	RBinImport *imp;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1124,7 +1124,6 @@ static bool cb_cfgdebug(void *user, void *data) {
 	}
 	if (core->io) {
 		core->io->va = !node->i_value;
-		core->io->debug = node->i_value;
 	}
 	if (core->dbg && node->i_value) {
 		const char *dbgbackend = r_config_get (core->config, "dbg.backend");
@@ -1368,7 +1367,7 @@ static bool cb_dbg_forks(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	core->dbg->trace_forks = node->i_value;
-	if (core->io->debug) {
+	if (core->bin->is_debugger) {
 		r_debug_attach (core->dbg, core->dbg->pid);
 	}
 	return true;
@@ -1407,7 +1406,7 @@ static bool cb_dbg_execs(void *user, void *data) {
 #if __linux__
 	RCore *core = (RCore*) user;
 	core->dbg->trace_execs = node->i_value;
-	if (core->io->debug) {
+	if (core->bin->is_debugger) {
 		r_debug_attach (core->dbg, core->dbg->pid);
 	}
 #else
@@ -1422,7 +1421,7 @@ static bool cb_dbg_clone(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	core->dbg->trace_clone = node->i_value;
-	if (core->io->debug) {
+	if (core->bin->is_debugger) {
 		r_debug_attach (core->dbg, core->dbg->pid);
 	}
 	return true;
@@ -1439,7 +1438,7 @@ static bool cb_dbg_aftersc(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	core->dbg->trace_aftersyscall = node->i_value;
-	if (core->io->debug) {
+	if (core->bin->is_debugger) {
 		r_debug_attach (core->dbg, core->dbg->pid);
 	}
 	return true;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5177,7 +5177,7 @@ static int cmd_debug(void *data, const char *input) {
 		cmd_debug_map (core, input + 1);
 		break;
 	case 'r': // "dr"
-		if (core->io->debug || input[1] == '?') {
+		if (core->bin->is_debugger || input[1] == '?') {
 			cmd_debug_reg (core, input + 1);
 		} else {
 			cmd_anal_reg (core, input + 1);

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -454,7 +454,7 @@ static int cmd_info(void *data, const char *input) {
 	bool newline = r_cons_is_interactive ();
 	int fd = r_io_fd_get_current (core->io);
 	RIODesc *desc = r_io_desc_get (core->io, fd);
-	int i, va = core->io->va || core->io->debug;
+	int i, va = core->io->va || core->bin->is_debugger;
 	int mode = 0; //R_MODE_SIMPLE;
 	bool rdump = false;
 	int is_array = 0;

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -870,7 +870,7 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, int perm, const char *mode,
 			append_bound (list, core->io, search_itv, core->offset, 1, 5);
 		}
 	} else if (!strncmp (mode, "dbg.", 4)) {
-		if (core->io->debug) {
+		if (core->bin->is_debugger) {
 			int mask = 0;
 			int add = 0;
 			bool heap = false;
@@ -3688,7 +3688,7 @@ reread:
 		}
 		break;
 	case 'E': // "/E"
-		if (core->io && core->io->debug) {
+		if (core->bin && core->bin->is_debugger) {
 			r_debug_map_sync (core->dbg);
 		}
 		do_esil_search (core, &param, input);

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -201,7 +201,7 @@ beach:
 
 static void seek_to_register(RCore *core, const char *input, bool is_silent) {
 	ut64 off;
-	if (core->io->debug) {
+	if (core->bin->is_debugger) {
 		off = r_debug_reg_get (core->dbg, input);
 		if (!is_silent) {
 			r_io_sundo_push (core->io, core->offset, r_print_get_cursor (core->print));

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -87,8 +87,6 @@ typedef struct r_io_t {
 	int cached;
 	bool cachemode; // write in cache all the read operations (EXPERIMENTAL)
 	int p_cache;
-	int debug;
-//#warning remove debug from RIO
 	RIDPool *map_ids;
 	RPVector maps; //from tail backwards maps with higher priority are found
 	RPVector map_skyline; // map parts that are not covered by others


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

ive removed io.debug, but there's still bin.is_debugger, which should be addressed in a separate PR (and discussed) because imho rbin should autodetect if its loading a memory dump of the process state without having any special flag.

ill wait to address the bin.is_debugger thing after this PR gets merged.

**Test plan**

wait for the green

**Closing issues**

fixes this one:

https://github.com/radareorg/ideas/issues/294