### PR TITLE
Add tests for creating #signatures

### DIFF
--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1118,3 +1118,318 @@ EXPECT=<<EOF
 [{"name":"fcn.00484d40","bytes":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c4084889d85b5dc3","mask":"ffffffffffffffffffffffffff00ffffffffffffff00000000ffffffffffffff00ffffffffffffffffffffffffffffffffffff0000000000ffffffffffffffffffffffffffffffffffffffffff","graph":{"cc":4,"nbbs":5,"edges":5,"ebbs":2,"bbsum":72},"addr":4738368,"refs":[],"xrefs":[],"vars":["r110"],"types":[{"name":"arg1","type":"int64_t"}],"hash":{"bbhash":"8ff8a5c7f84179483b764fbb18dc4c44f39da6527a0a16485c7ae519f00e687f"}}]
 EOF
 RUN
+
+NAME=x86-64 function with hole
+FILE=bins/elf/libc.so.6
+CMDS=<<EOF
+s 0xec800
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.__write b f30f1efa488d05256d0d008b0085c07517b8010000000f05483d00f0ffff7758c30f1f800000000041544989d4554889f55389fb4883ec10e823c901004c89e24889ee89df4189c0b8010000000f05483d00f0ffff77354489c74889442408e85cc90100488b4424084883c4105b5d415cc3660f1f440000488b15c1150d00f7d864890248c7c0ffffffffc3488b15ad150d00f7d864890248c7c0ffffffffebb6:ffffffffff000000000000ffffffffff00ffffffffffffffff0000000000ff00ff00000000000000ffffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffffffffffffffffff0000000000ff00ffffffffffffffffff00000000ffffffffffffffffffffffffffff000000000000ff000000000000ffffffffffffffffffffffffffff000000000000ffffffffffffffffffffffffff00
+za sym.__write g cc=6 nbbs=7 edges=7 ebbs=3 bbsum=148
+za sym.__write o 0x000ec800
+za sym.__write r sym.__libc_enable_asynccancel sym.__libc_disable_asynccancel
+za sym.__write v s-32 r119 r114 r110
+za sym.__write t func.sym.__write.args=3 func.sym.__write.arg.0="int64_t,arg1" func.sym.__write.arg.1="int64_t,arg2" func.sym.__write.arg.2="int64_t,arg3"
+za sym.__write h 4f2d194bae72345352b26e0a36531e7d6ff6cb5d6b50b92487246507b8dafdc5
+EOF
+RUN
+
+NAME=x86-64 function with jumpback
+FILE=bins/elf/libc.so.6
+CMDS=<<EOF
+s 0x8a900
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.bcopy b f30f1efa4887fee92479f9ff:ffffffffffffffff00000000
+za sym.bcopy g cc=1 nbbs=2 edges=1 ebbs=1 bbsum=23
+za sym.bcopy o 0x0008a900
+za sym.bcopy r sym..plt.sec
+za sym.bcopy v r110
+za sym.bcopy t func.sym.bcopy.args=1 func.sym.bcopy.arg.0="int64_t,arg1"
+za sym.bcopy h 7549556f94a4c26907f0304da9892c797a73e6c44907dc2030389392a9df8f69
+EOF
+RUN
+
+NAME=x86-64 r_sign_fcn_bytes bounds check
+FILE=bins/elf/libc.so.6
+CMDS=<<EOF
+s 0x0593a0
+e zign.maxsz = 41
+af
+zaf
+z* ~za sym._IO_printf b
+EOF
+EXPECT=<<EOF
+za sym._IO_printf b f30f1efa4881ecd80000004889742428488954243048894c24384c894424404c894c244884c074370f:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff
+EOF
+RUN
+
+NAME=80386 function with hole
+FILE=bins/elf/fcn_in_test.elf
+CMDS=<<EOF
+s 0x1090
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.deregister_tm_clones b e8e400000081c26b2f00008d8a180000008d821800000039c8741d8b82ecffffff85c074135589e583ec1451ffd083c410c9c38d74260090c3:ff00000000ff0000000000ffffffffffffffffffffffffffffff00ffffffffffffffffff00ffffffffffffffffffffffffffff0000000000ff
+za sym.deregister_tm_clones g cc=4 nbbs=4 edges=4 ebbs=2 bbsum=52
+za sym.deregister_tm_clones o 0x00001090
+za sym.deregister_tm_clones r sym.__x86.get_pc_thunk.dx
+za sym.deregister_tm_clones h 903d0936e77ecc1f2e91f7b2eb2476fdc06d7f2ba9501b1436468dbda5d7caaa
+EOF
+RUN
+
+NAME=80386 function with jumpback
+FILE=bins/elf/fcn_in_test.elf
+CMDS=<<EOF
+s 0x1184
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za main b 31c075f8ebf689c05090909090c3:ffffff00ff00ffffffffffffffff
+za main g cc=2 nbbs=4 edges=4 ebbs=1 bbsum=18
+za main o 0x00001184
+za main t func.main.ret=int func.main.args=3 func.main.arg.0="int,argc" func.main.arg.1="char **,argv" func.main.arg.2="char **,envp"
+za main h a9f218a725149b64061b9064406b46abe5653b97eb0f88a3e3e0086d1532c898
+EOF
+RUN
+
+NAME=80386 r_sign_fcn_bytes bounds check
+FILE=bins/elf/fcn_in_test.elf
+CMDS=<<EOF
+s 0x00001120
+e zign.maxsz = 32
+af
+zaf
+z* ~za sym.__do_global_dtors_aux b
+EOF
+EXPECT=<<EOF
+za sym.__do_global_dtors_aux b f30f1efb5589e553e853ffffff81c3d32e000083ec0480bb180000000075288b:ffffffffffffffffff00000000ff0000000000ffffffffffffffffffffff00ff
+EOF
+RUN
+
+NAME=MIPS R3000 function with hole
+FILE=bins/elf/libc.so.0
+CMDS=<<EOF
+s 0x00051490
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.fpathconf b 3c1c0005279c11200399e02127bdfef8afbf0100afb100fcafb000f8afbc001004810008008088218f9980180320f809000000008fbc00102404ffff100000142403000910a000412404007f24a5ffff2ca20013104000088f83805c0005108024638d00004310218c420000005c102100400008000000008f9980180320f809000000008fbc00102404ffff240300161000002eac4300001000002c240400ff8f9980180320f809000000008fbc00100220202127a500188f998224004080210320f8098c510000044100088fbc00108e030000240200591462001c2404ffff240400ff10000019ae110000100000178fa40040100000152404100010000013000020218f9980f0022020210320f80927a500600440000c8fbc00108fa200743043f0003402800010620003240260001462000500000000100000042404000110000002240400202404ffff8fbf01008fb100fc8fb000f80080102103e0000827bd0108:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffff000000ffffffffffffffffffffffffffffffffff000000ffffffffff000000ffffffffffffffffffffffffff000000ff000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffff000000ffffffff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffff
+za sym.fpathconf g cc=5 nbbs=8 edges=9 ebbs=2 bbsum=176
+za sym.fpathconf o 0x00051490
+za sym.fpathconf v s-8 s-12 s-16 s-248 r4 r5
+za sym.fpathconf t func.sym.fpathconf.args=2 func.sym.fpathconf.arg.0="int32_t,arg1" func.sym.fpathconf.arg.1="int32_t,arg2"
+za sym.fpathconf h 52f232c2d8158ce806cadf84ed77273fb11711dfa6cb5feb997ce03c1459be43
+EOF
+RUN
+
+NAME=MIPS R3000 function with jumpback
+FILE=bins/elf/ld-uClibc-0.9.33.2.so
+CMDS=<<EOF
+s 0x2a1c
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym._dl_malloc b 3c1c0002279cc5e40399e0218f82807427bdfff88c590000afbe00041320000503a0f02103c0e8218fbe00040320000827bd000803c0e8218f99801c8fbe0004273928dc1000ff9e27bd0008:ffffffffffffffffffffffffff000000ffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffff000000ffffffff
+za sym._dl_malloc g cc=8 nbbs=12 edges=16 ebbs=2 bbsum=396
+za sym._dl_malloc o 0x00002a1c
+za sym._dl_malloc r sym._dl_dprintf sym._dl_dprintf
+za sym._dl_malloc v b16 s-4 s-12 s-16 s-20 s-8 s-24 s-32 s-80 s-76 s-28 s-36 s-40 r4 r6 r7 r5
+za sym._dl_malloc t func.sym._dl_malloc.args=5 func.sym._dl_malloc.arg.0="int32_t,arg1" func.sym._dl_malloc.arg.1="int32_t,arg2" func.sym._dl_malloc.arg.2="int32_t,arg3" func.sym._dl_malloc.arg.3="int32_t,arg4" func.sym._dl_malloc.arg.4="int32_t,arg_10h"
+za sym._dl_malloc h ec986971438cf486e01f14e9bc442d9f4c457854207d30fe4aa9f1ffdf892911
+EOF
+RUN
+
+NAME=MIPS R3000  r_sign_fcn_bytes bounds check
+FILE=bins/elf/libc.so.0
+CMDS=<<EOF
+s 0x00051490
+af
+e zign.maxsz = 41
+zaf
+z* ~za sym.fpathconf b
+EOF
+EXPECT=<<EOF
+za sym.fpathconf b 3c1c0005279c11200399e02127bdfef8afbf0100afb100fcafb000f8afbc001004810008008088218f:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffff
+EOF
+RUN
+
+NAME=PowerPC function with hole
+FILE=bins/elf/busybox-powerpc
+CMDS=<<EOF
+s 0x100e2b0c
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za fcn.100e2b0c b 38c000014800000c38c00000480000049421ffd07c0802a63d401013bf2100147c9923787cbe2b787cda33787c7f1b7890010034480000083bff0001897f0000812aa39c5560083c7c09022e700900204082ffe82f8b002b419e00182f8b002d3b80000040be00143b800001480000083b8000003bff000157c007357c6a1b7840820044881f00003bde000a2f80003040be00288c1f00013bdefffe600000207feafb785400063e2f80007840be000c57de083c3bff00012f9e0010409d00083bc00010381efffe390000002b800022419d00943800ffff7fa0f3967c1df1d67c0000f8541b063e480000087feafb78893f00007c08e8407c88e8003bff00013809ffd061290020540b063e2b0900602b8b0009409d00143929ffa93960002840990008552b063e7f8bf000409c00384181001040a600247f8bd840409d001c4bfe70057f9cd038380000223900ffff900300004bffff987c08f1d67d0b02144bffff8c2f990000419e0008915900002f9a00007d3c00d03c007fff55290ffe6000ffff7fe90214419e001c7f88f84040bd00144bfe6fb138000022900300007fe8fb782f9c0000419e00087d0800d0800100347d034378bb210014382100307c0803a64e800020:ffffffffff0000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffff000000ffffffffffffffffff000000ffffffffff000000ffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffffffffffff000000ffffffffffffffffff000000ff000000ff000000ffffffffff000000ff000000ffffffffffffffffffffffffffffffffff000000ffffffffffffffffff000000ffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000ffffffffff000000ff000000ffffffffffffffffffffffffffffffffff000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+za fcn.100e2b0c g cc=19 nbbs=35 edges=52 ebbs=1 bbsum=448
+za fcn.100e2b0c o 0x100e2b0c
+za fcn.100e2b0c v b0 b1 s52 s48 r74 r81
+za fcn.100e2b0c t func.fcn.100e2b0c.args=6 func.fcn.100e2b0c.arg.0="int32_t,arg1" func.fcn.100e2b0c.arg.1="int32_t,arg8" func.fcn.100e2b0c.arg.2="int32_t,arg_0h" func.fcn.100e2b0c.arg.3="int32_t,arg_1h" func.fcn.100e2b0c.arg.4="int32_t,arg_30h" func.fcn.100e2b0c.arg.5="int32_t,arg_34h"
+za fcn.100e2b0c h 3b28d8f368cb414615bda7313fc4cdc24096498e7183cc05165607770be26928
+EOF
+RUN
+
+NAME=PowerPC function with jumpback
+FILE=bins/elf/busybox-powerpc
+CMDS=<<EOF
+s 0x10002d70
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za fcn.10002d70 b 38a0000038c000004bfffed4:ffffffffffffffffff000000
+za fcn.10002d70 g cc=12 nbbs=19 edges=29 ebbs=1 bbsum=304
+za fcn.10002d70 o 0x10002d70
+za fcn.10002d70 v b-4096 s4148 s4108 s4144 s8
+za fcn.10002d70 t func.fcn.10002d70.args=4 func.fcn.10002d70.arg.0="int32_t,arg_8h" func.fcn.10002d70.arg.1="int32_t,arg_100ch" func.fcn.10002d70.arg.2="int32_t,arg_1030h" func.fcn.10002d70.arg.3="int32_t,arg_1034h"
+za fcn.10002d70 h b73e65dc846183808d8e385076f9bbcd0b1dcdaa5652254fb55b3b159462a507
+EOF
+RUN
+
+NAME=PowerPC r_sign_fcn_bytes bounds check
+FILE=bins/elf/busybox-powerpc
+CMDS=<<EOF
+s 0x1000016c
+af
+e zign.maxsz = 30
+zaf
+z* ~za fcn.1000016c b
+EOF
+EXPECT=<<EOF
+za fcn.1000016c b 3d2000007c0802a6392900009421fff02f89000090010014419e001c3c80:ffffffffffffffffffffffffffffffffffffffffffffffffff000000ffff
+EOF
+RUN
+
+NAME=ARM function with hole
+FILE=bins/elf/libmagic.so
+CMDS=<<EOF
+s 0x78ea
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym._Unwind_VRS_Get b 10b5041c042913d8081c00f072fd05031103030001200ce00220002b09d10f2a07d88240a418029a61681160181c00e0022010bd:ffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000ffffffff
+za sym._Unwind_VRS_Get g cc=2 nbbs=4 edges=4 ebbs=1 bbsum=28
+za sym._Unwind_VRS_Get o 0x000078ea
+za sym._Unwind_VRS_Get r sym.__gnu_thumb1_case_uqi
+za sym._Unwind_VRS_Get v r0 r1
+za sym._Unwind_VRS_Get t func.sym._Unwind_VRS_Get.args=2 func.sym._Unwind_VRS_Get.arg.0="int16_t,arg1" func.sym._Unwind_VRS_Get.arg.1="int16_t,arg2"
+za sym._Unwind_VRS_Get h 3132d0ebfa3b792867a4ffc36455e088bf3fcffc7627bd48c64bf901308463db
+EOF
+RUN
+
+NAME=ARM function with jumpback
+FILE=bins/elf/libverifyPass.so
+CMDS=<<EOF
+s 0x0000183c
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.__aeabi_unwind_cpp_pr0 b 0030a0e3d4feffea
+za sym.__aeabi_unwind_cpp_pr0 g cc=27 nbbs=50 edges=75 ebbs=1 bbsum=1176
+za sym.__aeabi_unwind_cpp_pr0 o 0x0000183c
+za sym.__aeabi_unwind_cpp_pr0 r sym._Unwind_VRS_Get sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym._Unwind_VRS_Get sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym.__gnu_unwind_execute sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym._Unwind_VRS_Set
+za sym.__aeabi_unwind_cpp_pr0 v s-48 s-20 s-36 s-24 s-16 s-15 s-12 s-68 s-8 s-44 s-40 s-52 s-56 s-4 s-32 r1 r0
+za sym.__aeabi_unwind_cpp_pr0 t func.sym.__aeabi_unwind_cpp_pr0.args=2 func.sym.__aeabi_unwind_cpp_pr0.arg.0="int32_t,arg1" func.sym.__aeabi_unwind_cpp_pr0.arg.1="int32_t,arg2"
+za sym.__aeabi_unwind_cpp_pr0 h 1d6b2ca1aa1e08761e43859262a1d8f989251159b6fbd2baed6056b1f122d768
+EOF
+RUN
+
+NAME=ARM r_sign_fcn_bytes bounds check
+FILE=bins/elf/libverifyPass.so
+CMDS=<<EOF
+s 0x00001844
+af
+e zign.maxsz = 42
+zaf
+z* ~za fcn.00001844 b
+EOF
+EXPECT=<<EOF
+za fcn.00001844 b f04f2de9a8519fe5a8319fe505508fe0033095e714d04de2000053e30040a0e1026041e20800000a0600:ffffffff0000f0ff0000f0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+EOF
+RUN
+
+NAME=ARM aarch64 function with hole
+FILE=bins/elf/switch-hello-world.elf
+CMDS=<<EOF
+s 0x12180
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.memset b 200c014e0400028b5f8001f1c80300545f4000f102020054013c084ea2001836010000f981801ff8c0035fd61f2003d582001036010000b981c01fb8c0035fd6820000b4010000394200083681e01f78c0035fd60000803dc200303780009f3c620028360004803d80009e3cc0035fd60004803d000001ad80003fadc0035fd61f2003d5211c001203ec7c920000803d5f0004f12028407a80010054820003cb634000d1424001d1600001ad600082ad420001f1a8ffff5480003ead80003fadc0035fd61f2003d5e5003bd585fe2737a50c0012bf100071810200546004803d600001ad63e47a92600002ad600003ad820003cb420004d1630002911f2003d523740bd563000191420001f1a8ffff54600000ad600001ad80003ead80003fadc0035fd61f2003d5bf140071410200546004803d600001ad600002ad600003ad63e07992820003cb420004d16300029123740bd563000291420002f1a8ffff5480003cad80003dad80003ead80003fadc0035fd686008052c720c51ae50001915f0005ebc3f8ff54e60400d16500078b63400091a20003eba500268aa0000054600082ac60003fad420001f1a8ffff54e30305aa820005cb420007eba300005423740bd56300078b420007eba2ffff544200078b638000d1b6ffff17:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+za sym.memset g cc=28 nbbs=35 edges=47 ebbs=8 bbsum=460
+za sym.memset o 0x00012180
+za sym.memset v r73 r74 r72 r71 r69 r67
+za sym.memset t func.sym.memset.args=6 func.sym.memset.arg.0="void *,s" func.sym.memset.arg.1="int,c" func.sym.memset.arg.2="size_t,n" func.sym.memset.arg.3="int64_t,arg4" func.sym.memset.arg.4="int64_t,arg6" func.sym.memset.arg.5="int64_t,arg8"
+za sym.memset h 82e8b18bbf263f9ed0e31d6b68099efe6eb8805a429444f8aa119af00c47369c
+EOF
+RUN
+
+NAME=ARM aarch64 function with jmpback
+FILE=bins/elf/switch-hello-world.elf
+CMDS=<<EOF
+s 0x131a4
+af
+zaf
+z*
+EOF
+EXPECT=<<EOF
+zs *
+za sym.strnlen b c1ffffb4ecc300b202ec7c92080c40f2610300542e0400d1cefd44d34310c1a868000ccb69d800b28a000ccb8bd800b20601298a47012b8ace0500f1c80007aa005940fac0feff54c80007aa68fdffb4400000cb660000b4002000d1e70306aa002000d1e70cc0daed10c0da000c4d8b1f0001eb0090819ac0035fd62e0400d1eb0308cb1f2100f1ca0d4092cefd44d3090080924310c1a86bf17dd34a01088b2925cb9ace114a8b630009aa850009aa63d09fda84d0859adaffff17:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000f0ff0000f0ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+za sym.strnlen g cc=7 nbbs=11 edges=14 ebbs=2 bbsum=196
+za sym.strnlen o 0x000131a4
+za sym.strnlen v r73 r72 r70 r69
+za sym.strnlen t func.sym.strnlen.args=4 func.sym.strnlen.arg.0="int64_t,arg2" func.sym.strnlen.arg.1="int64_t,arg3" func.sym.strnlen.arg.2="int64_t,arg5" func.sym.strnlen.arg.3="int64_t,arg6"
+za sym.strnlen h c573e9053dfa735f51cca8aea51eda71ca46fd402d11feb4d7f8ccf1b3b46d72
+EOF
+RUN
+
+NAME=ARM aarch64 r_sign_fcn_bytes bounds check
+FILE=bins/elf/switch-hello-world.elf
+CMDS=<<EOF
+s 0x00016e9c
+e zign.maxsz = 94
+af
+zaf
+z* ~za sym._vfprintf_r b
+EOF
+EXPECT=<<EOF
+za sym._vfprintf_r b ff0314d1fd7b00a9fd030091f35301a9f30302aaf55b02a9f76303a9f70300aaf80303aaf96b04a9fa0301aafb7305a9e827066d6a170094000040f9e06700f989efff97e05700f9020180d2e0a3059101008052a4ecff97b70000b4e052:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000fcffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I added the following tests to cmd_zignature:
x86-64 function with hole
x86-64 function with jumpback
x86-64 r_sign_fcn_bytes bounds check
80386 function with hole
80386 function with jumpback
80386 r_sign_fcn_bytes bounds check
MIPS R3000 function with hole
MIPS R3000 function with jumpback
MIPS R3000  r_sign_fcn_bytes bounds check
PowerPC function with hole
PowerPC function with jumpback
PowerPC r_sign_fcn_bytes bounds check
ARM function with hole
ARM function with jumpback
ARM r_sign_fcn_bytes bounds check
ARM aarch64 function with hole
ARM aarch64 function with jmpback
ARM aarch64 r_sign_fcn_bytes bounds check

Mostly this checks edge cases when creating byte signatures. I manually double checked that the output was expected. I did not include any tests for sparc yet.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Ensure the tests are relevant and useful and well named. Make sure I am not attempting to match too much information. 
I might of gotten carried away, feel free to tell me to reduce things.

All tests pass on my machine:
```
r2r db/cmd/cmd_zignature 
Running from ....test
Loaded 66 tests.
Skipping json tests because jq is not available.
[66/66]                    66 OK         0 BR        0 XX        0 FX
Finished in 12 seconds.
```

**Closing issues**
Does not close anything.

...
