### PR TITLE
Fix r_anal_get_bbaddr to include internal addrs ##anal

### DIFF
--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -112,24 +112,9 @@ R_API ut64 r_anal_bb_size_i(RAnalBlock *bb, int i) {
 	return idx_next != UT16_MAX? idx_next - idx_cur: bb->size - idx_cur;
 }
 
-static int __bb_cmp_contains(const void *in, const RBNode *tree_node, void *user) {
-	ut64 *ret = (ut64 *)user;
-	ut64 addr = *(ut64 *)in;
-	const RAnalBlock *bb = container_of (tree_node, const RAnalBlock, _rb);
-	if (addr < bb->addr) {
-		return -1;
-	}
-	if (addr >= bb->addr + bb->size) {
-		return 1;
-	}
-	*ret = bb->addr;
-	return 0;
-}
-
 /* returns the address of the basic block that contains addr or UT64_MAX if
  * there is no such basic block */
 R_API ut64 r_anal_get_bbaddr(RAnal *anal, ut64 addr) {
-	ut64 ret = UT64_MAX;
-	r_rbtree_find (anal->bb_tree, &addr, __bb_cmp_contains, &ret);
-	return ret;
+	RAnalBlock *bb = r_anal_bb_from_offset (anal, addr);
+	return bb? bb->addr: UT64_MAX
 }

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -116,5 +116,5 @@ R_API ut64 r_anal_bb_size_i(RAnalBlock *bb, int i) {
  * there is no such basic block */
 R_API ut64 r_anal_get_bbaddr(RAnal *anal, ut64 addr) {
 	RAnalBlock *bb = r_anal_bb_from_offset (anal, addr);
-	return bb? bb->addr: UT64_MAX
+	return bb? bb->addr: UT64_MAX;
 }

--- a/libr/anal/bb.c
+++ b/libr/anal/bb.c
@@ -112,9 +112,24 @@ R_API ut64 r_anal_bb_size_i(RAnalBlock *bb, int i) {
 	return idx_next != UT16_MAX? idx_next - idx_cur: bb->size - idx_cur;
 }
 
+static int __bb_cmp_contains(const void *in, const RBNode *tree_node, void *user) {
+	ut64 *ret = (ut64 *)user;
+	ut64 addr = *(ut64 *)in;
+	const RAnalBlock *bb = container_of (tree_node, const RAnalBlock, _rb);
+	if (addr < bb->addr) {
+		return -1;
+	}
+	if (addr >= bb->addr + bb->size) {
+		return 1;
+	}
+	*ret = bb->addr;
+	return 0;
+}
+
 /* returns the address of the basic block that contains addr or UT64_MAX if
  * there is no such basic block */
 R_API ut64 r_anal_get_bbaddr(RAnal *anal, ut64 addr) {
-	RAnalBlock *bb = r_anal_get_block_at (anal, addr);
-	return bb? bb->addr: UT64_MAX;
+	ut64 ret = UT64_MAX;
+	r_rbtree_find (anal->bb_tree, &addr, __bb_cmp_contains, &ret);
+	return ret;
 }

--- a/test/db/cmd/cmd_seek
+++ b/test/db/cmd/cmd_seek
@@ -355,3 +355,17 @@ EXPECT=<<EOF
 0x20
 EOF
 RUN
+
+NAME=seek to bb start (sb)
+FILE=bins/elf/vim
+CMDS=<<EOF
+s 0x543a0
+af
+s+3
+sb
+?v $$
+EOF
+EXPECT=<<EOF
+0x543a0
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The `r_anal_get_bbaddr` function was just a wrapper for `r_anal_get_block_at` . This is incorrect since `r_anal_get_block_at` wont return a block if the provided address is not the block entry point. This mistake causes `VV` to get lost if you current seek is in the middle of a block. 

This PR fixes the problem and ads a regression test using the `sb` command.


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The `sb` command relies on  `r_anal_get_bbaddr`, so you can test for off by one errors by seeking to tricky addresses. Below shows an example of `sb` performing correctly when at main-1, main, main+1, main+blocksize-1 and when you seek to the second block.

```
$ r2 test/bins/elf/vim 
 -- ---8<--------------------8<------------------8<-----------------8<------
[0x00055a40]> s main
[0x000543a0]> af
[0x000543a0]> sb
[0x000543a0]> s-1
[0x0005439f]> sb
[0x0005439f]> s main+1
[0x000543a1]> sb
[0x000543a0]> s +`afbi ~size[1]`-1 # last addr before next block
[0x0005441d]> sb
[0x000543a0]> s +`afbi ~size[1]`# start of next block
[0x0005441e]> sb
[0x0005441e]> 
```

**Closing issues**

None that I could find.
