### PR TITLE
DWARF - OOB read and multiple incorrect parsing fixes

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1049,7 +1049,7 @@ static int parse_line_raw(const RBin *a, const ut8 *obuf,
 			tmp_read = parse_opcodes (a, buf, buf_end - buf, &hdr, &regs, mode);
 			bytes_read += tmp_read;
 			buf += tmp_read; // Move in the buffer forward
-		} while (bytes_read < buf_size || tmp_read != 0); // if nothing is read -> error, exit
+		} while (bytes_read < buf_size && tmp_read != 0); // if nothing is read -> error, exit
 
 		line_header_fini (&hdr);
 	}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -890,8 +890,8 @@ static const ut8 *parse_std_opcode(
 		break;
 	case DW_LNS_const_add_pc:
 		adj_opcode = 255 - hdr->opcode_base;
-		if (hdr->line_range > 0) {
-			op_advance = adj_opcode / hdr->line_range;
+		if (hdr->line_range > 0) { // to dodge division by zero
+			op_advance = (adj_opcode / hdr->line_range) * hdr->min_inst_len;
 		} else {
 			op_advance = 0;
 		}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -786,7 +786,7 @@ static const ut8 *parse_spec_opcode(
 		// line line-range information. move away
 		return NULL;
 	}
-	advance_adr = adj_opcode / hdr->line_range;
+	advance_adr = (adj_opcode / hdr->line_range) * hdr->min_inst_len;
 	regs->address += advance_adr;
 	int line_increment =  hdr->line_base + (adj_opcode % hdr->line_range);
 	regs->line += line_increment;
@@ -1042,13 +1042,14 @@ static int parse_line_raw(const RBin *a, const ut8 *obuf,
 			line_header_fini (&hdr);
 			return false;
 		}
+		size_t tmp_read = 0;
 		// we read the whole compilation unit (that might be composed of more sequences)
 		do {
 			// reads one whole sequence
-			size_t tmp_read = parse_opcodes (a, buf, buf_size, &hdr, &regs, mode);
+			tmp_read = parse_opcodes (a, buf, buf_end - buf, &hdr, &regs, mode);
 			bytes_read += tmp_read;
 			buf += tmp_read; // Move in the buffer forward
-		} while (bytes_read < buf_size);
+		} while (bytes_read < buf_size || tmp_read != 0); // if nothing is read -> error, exit
 
 		line_header_fini (&hdr);
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fixes #17304 and incorrect line information parsing of special opcode and standard const add pc opcode.
