### PR TITLE
Only run aao in aaa on apple targets ##bin

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9059,6 +9059,16 @@ static bool is_unknown_file(RCore *core) {
 	return true;
 }
 
+static bool is_apple_target(RCore *core) {
+	const char *arch = r_config_get (core->config, "asm.arch");
+	if (!strstr (arch, "ppc") && !strstr (arch, "arm") && !strstr (arch, "x86")) {
+		return false;
+	}
+	RBinObject *bo = r_bin_cur_object (core->bin);
+	r_return_val_if_fail (!bo || (bo->plugin && bo->plugin->name), false);
+	return bo? strstr (bo->plugin->name, "mach"): false;
+}
+
 static int cmd_anal_all(RCore *core, const char *input) {
 	switch (*input) {
 	case '?':
@@ -9260,9 +9270,11 @@ static int cmd_anal_all(RCore *core, const char *input) {
 				if (r_cons_is_breaked ()) {
 					goto jacuzzi;
 				}
-				oldstr = r_print_rowlog (core->print, "Check for objc references");
-				r_print_rowlog_done (core->print, oldstr);
-				cmd_anal_objc (core, input + 1, true);
+				if (is_apple_target (core)) {
+					oldstr = r_print_rowlog (core->print, "Check for objc references");
+					r_print_rowlog_done (core->print, oldstr);
+					cmd_anal_objc (core, input + 1, true);
+				}
 				r_core_task_yield (&core->tasks);
 				oldstr = r_print_rowlog (core->print, "Check for vtables");
 				r_core_cmd0 (core, "avrr");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

aaa runs aao on any binary, aao is smart enough to not do anything if there are missing sections and such, but aaa is not that smart. this piece of code makes that work only on macho-arm,ppc-x86 bins. any other target or objc programs? (i know there's opensource objc, but this is probably using a different format for that objc section.

**Test plan**

<img width="708" alt="Screenshot 2020-07-19 at 04 17 20" src="https://user-images.githubusercontent.com/6431515/87865521-d845d300-c976-11ea-8b51-2b441610bcbe.png">

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
