### PR TITLE
backtrace support for haiku ##port

### DIFF
--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -60,6 +60,10 @@ ifeq (${BUILD_OS},dragonfly)
   LDFLAGS+=-lexecinfo
 endif
 
+ifeq (${BUILD_OS},haiku)
+  LDFLAGS+=-lexecinfo
+endif
+
 EXTRA_PRE+=sdb_version
 EXTRA_PRE+=spp_config
 

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -84,7 +84,7 @@ r_util_sources = [
 ]
 
 r_util_deps = [ldl, mth, spp_dep, pth, utl, sdb_dep, zlib_dep, platform_deps]
-if host_machine.system().startswith('freebsd') or host_machine.system().startswith('netbsd')
+if host_machine.system().startswith('freebsd') or host_machine.system().startswith('netbsd') or host_machine.system().startswith('haiku')
   # backtrace_symbols_fd requires -lexecinfo
   r_util_deps += [cc.find_library('execinfo')]
 endif

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -32,7 +32,7 @@
 static char** env = NULL;
 
 #if (__linux__ && __GNU_LIBRARY__) || defined(NETBSD_WITH_BACKTRACE) || \
-  defined(FREEBSD_WITH_BACKTRACE) || __DragonFly__ || __sun
+  defined(FREEBSD_WITH_BACKTRACE) || __DragonFly__ || __sun || __HAIKU__
 # include <execinfo.h>
 #endif
 #if __APPLE__
@@ -300,7 +300,7 @@ R_API char *r_sys_cmd_strf(const char *fmt, ...) {
 
 #if (__linux__ && __GNU_LIBRARY__) || (__APPLE__ && APPLE_WITH_BACKTRACE) || \
   defined(NETBSD_WITH_BACKTRACE) || defined(FREEBSD_WITH_BACKTRACE) || \
-  __DragonFly__ || __sun
+  __DragonFly__ || __sun || __HAIKU__
 #define HAVE_BACKTRACE 1
 #endif
 


### PR DESCRIPTION
backtrace is available but not as system library but third party package.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)