### PR TITLE
Fix wrong function signature in io.gdb

### DIFF
--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -203,7 +203,7 @@ static int __gettid(RIODesc *fd) {
 }
 
 extern int send_msg(libgdbr_t *g, const char *command);
-extern int read_packet(libgdbr_t *instance);
+extern int read_packet(libgdbr_t *instance, bool vcont);
 
 static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	if (!desc) {
@@ -263,7 +263,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 	if (r_str_startswith (cmd, "pkt ")) {
 		gdbr_lock_enter (desc);
 		if (send_msg (desc, cmd + 4) >= 0) {
-			(void)read_packet (desc);
+			(void)read_packet (desc, false);
 			desc->data[desc->data_len] = '\0';
 			io->cb_printf ("reply:\n%s\n", desc->data);
 			if (!desc->no_ack) {
@@ -290,7 +290,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		}
 		gdbr_lock_enter (desc);
 		if (send_msg (desc, "bs") >= 0) {
-			(void)read_packet (desc);
+			(void)read_packet (desc, false);
 			desc->data[desc->data_len] = '\0';
 			if (!desc->no_ack) {
 				eprintf ("[waiting for ack]\n");
@@ -313,7 +313,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 		}
 		gdbr_lock_enter (desc);
 		if (send_msg (desc, "bc") >= 0) {
-			(void)read_packet (desc);
+			(void)read_packet (desc, false);
 			desc->data[desc->data_len] = '\0';
 			if (!desc->no_ack) {
 				eprintf ("[waiting for ack]\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

see shlr/gdb/src/packet.c

**Test plan**

justt see compiler output. its a warning

**Closing issues**

none, but it may behave wrong because of UB
...
