### PR TITLE
Fix udiff.c warnings

### DIFF
--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -530,9 +530,9 @@ R_API RDiffChar *r_diffchar_new(const ut8 *a, const ut8 *b) {
 	}
 
 	// Copy strings (note that strncpy does pad with nulls)
-	strncpy (dup_a, a, len_long);
+	strncpy ((char *)dup_a, (const char *)a, len_long);
 	a = dup_a;
-	strncpy (dup_b, b, len_long);
+	strncpy ((char *)dup_b, (const char *)b, len_long);
 	b = dup_b;
 
 	// Fill table
@@ -764,8 +764,8 @@ R_API void r_diffchar_print(RDiffChar *diffchar) {
 
 R_API void r_diffchar_free(RDiffChar *diffchar) {
 	if (diffchar) {
-		free (diffchar->align_a);
-		free (diffchar->align_b);
+		free ((ut8 *)diffchar->align_a);
+		free ((ut8 *)diffchar->align_b);
 		free (diffchar);
 	}
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fixes the following warnings:

![udiff c-clang-warnings](https://user-images.githubusercontent.com/12002672/87935236-4d262380-cac3-11ea-846f-5671e0687c69.jpg)
(e.g. https://github.com/radareorg/radare2/runs/887292162#step:9:326)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Builds are warning-free with regard to the above.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
