### PR TITLE
Fix #17322 - Honor bin.baddr from idp to load rebased PDB files ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1189,8 +1189,17 @@ static int bin_dwarf(RCore *core, int mode) {
 	return true;
 }
 
-R_API int r_core_pdb_info(RCore *core, const char *file, ut64 baddr, int mode) {
-	RPdb pdb = R_EMPTY;
+R_API bool r_core_pdb_info(RCore *core, const char *file, int mode) {
+	r_return_val_if_fail (core && file, false);
+
+	ut64 baddr = r_config_get_i (core->config, "bin.baddr");
+	if (core->bin->cur && core->bin->cur->o && core->bin->cur->o->baddr) {
+		baddr = core->bin->cur->o->baddr;
+	} else {
+		eprintf ("Warning: Cannot find base address, flags will probably be misplaced\n");
+	}
+
+	R_PDB pdb = R_EMPTY;
 
 	pdb.cb_printf = r_cons_printf;
 	if (!init_pdb_parser (&pdb, file)) {
@@ -1231,11 +1240,6 @@ R_API int r_core_pdb_info(RCore *core, const char *file, ut64 baddr, int mode) {
 	}
 	pj_free (pj);
 	return true;
-}
-
-static int bin_pdb(RCore *core, int mode) {
-	ut64 baddr = r_bin_get_baddr (core->bin);
-	return r_core_pdb_info (core, core->bin->file, baddr, mode);
 }
 
 static int srclineCmp(const void *a, const void *b) {
@@ -4150,7 +4154,7 @@ R_API int r_core_bin_info(RCore *core, int action, int mode, int va, RCoreBinFil
 		ret &= bin_dwarf (core, mode);
 	}
 	if ((action & R_CORE_BIN_ACC_PDB)) {
-		ret &= bin_pdb (core, mode);
+		ret &= r_core_pdb_info (core, core->bin->file, mode);
 	}
 	if ((action & R_CORE_BIN_ACC_SOURCE)) {
 		ret &= bin_source (core, mode);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1199,7 +1199,7 @@ R_API bool r_core_pdb_info(RCore *core, const char *file, int mode) {
 		eprintf ("Warning: Cannot find base address, flags will probably be misplaced\n");
 	}
 
-	R_PDB pdb = R_EMPTY;
+	RPdb pdb = R_EMPTY;
 
 	pdb.cb_printf = r_cons_printf;
 	if (!init_pdb_parser (&pdb, file)) {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -742,7 +742,7 @@ R_API int r_core_bin_info (RCore *core, int action, int mode, int va, RCoreBinFi
 R_API int r_core_bin_set_arch_bits (RCore *r, const char *name, const char * arch, ut16 bits);
 R_API int r_core_bin_update_arch_bits (RCore *r);
 R_API char *r_core_bin_method_flags_str(ut64 flags, int mode);
-R_API int r_core_pdb_info(RCore *core, const char *file, ut64 baddr, int mode);
+R_API bool r_core_pdb_info(RCore *core, const char *file, int mode);
 
 /* rtr */
 R_API int r_core_rtr_cmds (RCore *core, const char *port);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -42,7 +42,7 @@ static int file_stat (const char *file, struct stat* const pStat) {
 #endif // __WINDOWS__
 }
 
-R_API bool r_file_truncate (const char *filename, ut64 newsize) {
+R_API bool r_file_truncate(const char *filename, ut64 newsize) {
 	r_return_val_if_fail (filename, false);
 	int fd;
 	if (r_file_is_directory (filename)) {
@@ -78,7 +78,7 @@ Example:
 	str = r_file_basename ("home/inisider/Downloads/user32.dll");
 	// str == user32.dll
 */
-R_API const char *r_file_basename (const char *path) {
+R_API const char *r_file_basename(const char *path) {
 	r_return_val_if_fail (path, NULL);
 	const char *ptr = r_str_rchr (path, NULL, '/');
 	if (ptr) {
@@ -97,7 +97,7 @@ Example:
 	// str == "home/inisider/Downloads"
 	free (str);
 */
-R_API char *r_file_dirname (const char *path) {
+R_API char *r_file_dirname(const char *path) {
 	r_return_val_if_fail (path, NULL);
 	char *newpath = strdup (path);
 	char *ptr = (char*)r_str_rchr (newpath, NULL, '/');

--- a/test/db/formats/pdb
+++ b/test/db/formats/pdb
@@ -9,6 +9,33 @@ PDB "user32.pdb" download success
 EOF
 RUN
 
+NAME=idp 404
+FILE=-
+CMDS=<<EOF
+idp 404.pdb
+EOF
+EXPECT=
+EXPECT_ERR=<<EOF
+Cannot open file
+EOF
+RUN
+
+NAME=idp and baddr
+FILE=-
+CMDS=<<EOF
+e bin.baddr=0
+idp bins/pdb/Project1.pdb
+f~pdb:1
+e bin.baddr=0x800000
+idp bins/pdb/Project1.pdb
+f~pdb:1
+EOF
+EXPECT=<<EOF
+0x00011000 0 pdb.__enc_textbss_end
+0x00811000 0 pdb.__enc_textbss_end
+EOF
+RUN
+
 NAME=find structure R2_TEST_STRUCT
 FILE=bins/pdb/Project1.pdb
 CMDS=!rabin2 -P ${R2_FILE} | grep -ao R2_TEST_STRUCT


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

From telegram:
```
a> Hi guys.
a> I have a question.
a> When using radare2 with -B to set the correct base address the function names are not presented when I load the pdb
a> Without the -B everything works perfectly
a> 
```
**Test plan**

see tests

**Closing issues**

#17322
