### PR TITLE
Fix Levenstein distance on empty buffers ##radiff2

### DIFF
--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -239,8 +239,8 @@ R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, c
 	stop = bLen;
 	// Preliminary tests
 
-	//Do we have both files a & b, with positives sizes?
-	if (!aBufPtr || !bBufPtr || aLen < 0 || bLen < 0) {
+	//Do we have both files a & b
+	if (!aBufPtr || !bBufPtr) {
 		return false;
 	}
 

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -168,6 +168,7 @@ R_API int r_diff_buffers(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb)
 }
 
 R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity) {
+	r_return_val_if_fail (a && b, false);
 	const bool verbose = d? d->verbose: false;
 	/*
 	More memory efficient version on Levenshtein Distance from:
@@ -238,11 +239,6 @@ R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, c
 	}
 	stop = bLen;
 	// Preliminary tests
-
-	//Do we have both files a & b
-	if (!aBufPtr || !bBufPtr) {
-		return false;
-	}
 
 	// one or both buffers empty?
 	if (aLen == 0 || bLen == 0) {

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -239,9 +239,20 @@ R_API bool r_diff_buffers_distance_levenstein(RDiff *d, const ut8 *a, ut32 la, c
 	stop = bLen;
 	// Preliminary tests
 
-	//Do we have both files a & b, and are they at least one byte?
-	if (!aBufPtr || !bBufPtr || aLen < 1 || bLen < 1) {
+	//Do we have both files a & b, with positives sizes?
+	if (!aBufPtr || !bBufPtr || aLen < 0 || bLen < 0) {
 		return false;
+	}
+
+	// one or both buffers empty?
+	if (aLen == 0 || bLen == 0) {
+		if (distance) {
+			*distance = R_MAX (aLen, bLen);
+		}
+		if (similarity) {
+			*similarity = aLen == bLen? 1.0: 0.0;
+		}
+		return true;
 	}
 
 	//IF the files are the same size and are identical, then we have matching files


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I saw issue #17237 and took a look. I could not get the unit test to run but I spotted an unhanded edge case which the test uses. This PR will fix the case when one or both provided buffers are of length 0.

**Test plan**

I couldn't get the unit tests to run, but this works now:
```
radiff2 -ss /tmp/tests/1/*
File size differs 5 vs 0
similarity: 0.000
distance: 5
```

Previously distance was reported as 0.

**Closing issues**

Maybe #17237 ?
