### PR TITLE
Add `acll (class_name)` to print class information ##anal

### DIFF
--- a/libr/anal/class.c
+++ b/libr/anal/class.c
@@ -1019,7 +1019,7 @@ static void r_anal_class_print_cmd(RAnal *anal, const char *class_name) {
 	}
 }
 
-static void r_anal_class_json(RAnal *anal, PJ *j, const char *class_name) {
+R_API void r_anal_class_json(RAnal *anal, PJ *j, const char *class_name) {
 	pj_o (j);
 	pj_ks (j, "name", class_name);
 

--- a/libr/anal/class.c
+++ b/libr/anal/class.c
@@ -937,7 +937,7 @@ R_API RAnalClassErr r_anal_class_vtable_delete(RAnal *anal, const char *class_na
 // ---- PRINT ----
 
 
-static void r_anal_class_print(RAnal *anal, const char *class_name, bool lng) {
+R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool lng) {
 	r_cons_print (class_name);
 
 	RVector *bases = r_anal_class_base_get_all (anal, class_name);

--- a/libr/anal/class.c
+++ b/libr/anal/class.c
@@ -937,7 +937,7 @@ R_API RAnalClassErr r_anal_class_vtable_delete(RAnal *anal, const char *class_na
 // ---- PRINT ----
 
 
-R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool lng) {
+R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool detailed) {
 	r_cons_print (class_name);
 
 	RVector *bases = r_anal_class_base_get_all (anal, class_name);
@@ -959,7 +959,7 @@ R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool lng) {
 	r_cons_print ("\n");
 
 
-	if (lng) {
+	if (detailed) {
 		RVector *vtables = r_anal_class_vtable_get_all (anal, class_name);
 		if (vtables) {
 			RAnalVTable *vtable;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9835,6 +9835,7 @@ static void cmd_anal_classes(RCore *core, const char *input) {
 				char *name_end = (char *)r_str_trim_head_wp (class_name);
 				*name_end = 0; // trim the whitespace around the name
 				r_anal_class_print (core->anal, class_name, true);
+				free (class_name);
 				break;
 			}
 		}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9826,7 +9826,13 @@ static void cmd_anal_classes(RCore *core, const char *input) {
 	switch (input[0]) {
 	case 'l': // "acl"
 		if (input[1] == 'l') { // "acll" (name)
-			const char *arg = r_str_trim_head_ro (input + 2);
+			char mode = 0;
+			int arg_offset = 2;
+			if (input[2] == 'j') {
+				arg_offset++;
+				mode = 'j';
+			}
+			const char *arg = r_str_trim_head_ro (input + arg_offset);
 			if (*arg) { // if there is an argument
 				char *class_name = strdup (arg);
 				if (!class_name) {
@@ -9834,7 +9840,14 @@ static void cmd_anal_classes(RCore *core, const char *input) {
 				}
 				char *name_end = (char *)r_str_trim_head_wp (class_name);
 				*name_end = 0; // trim the whitespace around the name
-				r_anal_class_print (core->anal, class_name, true);
+				if (mode == 'j') {
+					PJ *pj = pj_new ();
+					r_anal_class_json (core->anal, pj, class_name);
+					r_cons_printf ("%s\n", pj_string (pj));
+					pj_free (pj);
+				} else {
+					r_anal_class_print (core->anal, class_name, true);
+				}
 				free (class_name);
 				break;
 			}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -109,7 +109,8 @@ static const char *help_msg_abt[] = {
 
 static const char *help_msg_ac[] = {
 	"Usage:", "ac", "anal classes commands",
-	"acl[lj*]", "", "list all classes",
+	"acl[j*]", "", "list all classes",
+	"acll", " (class_name)", "list all or single class detailed",
 	"ac", " [class name]", "add class",
 	"ac-", " [class name]", "delete class",
 	"acn", " [class name] [new class name]", "rename class",
@@ -9824,6 +9825,19 @@ static void cmd_anal_class_vtable(RCore *core, const char *input) {
 static void cmd_anal_classes(RCore *core, const char *input) {
 	switch (input[0]) {
 	case 'l': // "acl"
+		if (input[1] == 'l') { // "acll" (name)
+			const char *arg = r_str_trim_head_ro (input + 2);
+			if (*arg) { // if there is an argument
+				char *class_name = strdup (arg);
+				if (!class_name) {
+					break;
+				}
+				char *name_end = (char *)r_str_trim_head_wp (class_name);
+				*name_end = 0; // trim the whitespace around the name
+				r_anal_class_print (core->anal, class_name, true);
+				break;
+			}
+		}
 		r_anal_class_list (core->anal, input[1]);
 		break;
 	case ' ': // "ac"

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -110,7 +110,7 @@ static const char *help_msg_abt[] = {
 static const char *help_msg_ac[] = {
 	"Usage:", "ac", "anal classes commands",
 	"acl[j*]", "", "list all classes",
-	"acll", " (class_name)", "list all or single class detailed",
+	"acll[j]", " (class_name)", "list all or single class detailed",
 	"ac", " [class name]", "add class",
 	"ac-", " [class name]", "delete class",
 	"acn", " [class name] [new class name]", "rename class",

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -2045,7 +2045,7 @@ R_API RVector/*<RAnalVTable>*/ *r_anal_class_vtable_get_all(RAnal *anal, const c
 R_API RAnalClassErr r_anal_class_vtable_set(RAnal *anal, const char *class_name, RAnalVTable *vtable);
 R_API RAnalClassErr r_anal_class_vtable_delete(RAnal *anal, const char *class_name, const char *vtable_id);
 
-R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool lng);
+R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool detailed);
 R_API void r_anal_class_list(RAnal *anal, int mode);
 R_API void r_anal_class_list_bases(RAnal *anal, const char *class_name);
 R_API void r_anal_class_list_vtables(RAnal *anal, const char *class_name);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -2045,6 +2045,7 @@ R_API RVector/*<RAnalVTable>*/ *r_anal_class_vtable_get_all(RAnal *anal, const c
 R_API RAnalClassErr r_anal_class_vtable_set(RAnal *anal, const char *class_name, RAnalVTable *vtable);
 R_API RAnalClassErr r_anal_class_vtable_delete(RAnal *anal, const char *class_name, const char *vtable_id);
 
+R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool lng);
 R_API void r_anal_class_list(RAnal *anal, int mode);
 R_API void r_anal_class_list_bases(RAnal *anal, const char *class_name);
 R_API void r_anal_class_list_vtables(RAnal *anal, const char *class_name);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -2046,6 +2046,7 @@ R_API RAnalClassErr r_anal_class_vtable_set(RAnal *anal, const char *class_name,
 R_API RAnalClassErr r_anal_class_vtable_delete(RAnal *anal, const char *class_name, const char *vtable_id);
 
 R_API void r_anal_class_print(RAnal *anal, const char *class_name, bool detailed);
+R_API void r_anal_class_json(RAnal *anal, PJ *j, const char *class_name);
 R_API void r_anal_class_list(RAnal *anal, int mode);
 R_API void r_anal_class_list_bases(RAnal *anal, const char *class_name);
 R_API void r_anal_class_list_vtables(RAnal *anal, const char *class_name);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

I've added option to print "acll" information about single class

```
[0x00001120]> acl
Bat
Bird
Cat
Dog
Kappa
Mammal
[0x00001120]> acll Bat
Bat
  (vtable at 0x3b98)
  (vtable at 0x3bc0)
  virtual_0 @ 0x192e (vtable + 0x0)
  virtual_8 @ 0x1967 (vtable + 0x8)
  virtual_16 @ 0x146c (vtable + 0x10)
[0x00001120]> ac?
Usage: ac  anal classes commands
| acl[j*]                                                    list all classes
| acll (class_name)                                        list all or single class detailed
```