### PR TITLE
Remove (again) wrong forward declarations

### DIFF
--- a/libr/include/r_bin_dwarf.h
+++ b/libr/include/r_bin_dwarf.h
@@ -803,9 +803,6 @@ typedef struct {
 
 #define r_bin_dwarf_line_new(o,a,f,l) o->address=a, o->file = strdup (f?f:""), o->line = l, o->column =0,o
 
-typedef struct r_bin_t RBin; // forward declaration so I can keep the functions in this interface
-typedef struct r_anal_t RAnal; // forward declaration so I can keep the functions in this interface
-
 R_API RList *r_bin_dwarf_parse_aranges(RBin *a, int mode);
 R_API RList *r_bin_dwarf_parse_line(RBin *a, int mode);
 R_API RBinDwarfDebugAbbrev *r_bin_dwarf_parse_abbrev(RBin *a, int mode);


### PR DESCRIPTION
Fix compilation on CentOS 6. RBin is already forward declared at the
beginning of r_bin.h. RAnal is not used.

See https://github.com/radareorg/radare2/runs/899717533?check_suite_focus=true