### PR TITLE
r_cons_print fix for very large output ##cons

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1486,7 +1486,7 @@ static void print_debug_info(const RBinDwarfDebugInfo *inf, PrintfCallback print
 		dies = inf->comp_units[i].dies;
 
 		for (j = 0; j < inf->comp_units[i].count; j++) {
-			print ("<%"PFMT64x">: Abbrev Number: %-4" PFMT64u " ", dies[j].offset,dies[j].abbrev_code);
+			print ("<0x%"PFMT64x">: Abbrev Number: %-4" PFMT64u " ", dies[j].offset,dies[j].abbrev_code);
 
 			if (is_printable_tag (dies[j].tag)) {
 				print ("(%s)\n", dwarf_tag_name_encodings[dies[j].tag]);

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1167,7 +1167,7 @@ R_API int r_cons_get_column(void) {
 
 /* final entrypoint for adding stuff in the buffer screen */
 R_API int r_cons_memcat(const char *str, int len) {
-	if (len < 0 || (I.context->buffer_len + len) < 0) {
+	if (len < 0) {
 		return -1;
 	}
 	if (I.echo) {

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -447,8 +447,8 @@ typedef struct r_cons_context_t {
 	RConsGrep grep;
 	RStack *cons_stack;
 	char *buffer;
-	ut64 buffer_len;
-	ut64 buffer_sz;
+	size_t buffer_len;
+	size_t buffer_sz;
 
 	bool breaked;
 	RStack *break_stack;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -447,8 +447,8 @@ typedef struct r_cons_context_t {
 	RConsGrep grep;
 	RStack *cons_stack;
 	char *buffer;
-	int buffer_len;
-	int buffer_sz;
+	ut64 buffer_len;
+	ut64 buffer_sz;
 
 	bool breaked;
 	RStack *break_stack;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)

**Detailed description**

There was a segfault linked to a very large binary with DWARF information (http://xvilka.me/vmlinux_ida_dwarf_fail.zip) when using `id`. It was caused by the information being over several GiB of text and r_cons_context using `int` for it's size and length, changing it to ut64 fixed the segfaulting behaviour.
