### PR TITLE
Windows #!pipe: Remove busy-wait on PeekNamedPipe()

### DIFF
--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -47,10 +47,14 @@ static DWORD WINAPI WaitForProcThread(LPVOID lParam) {
 		// Just in case the #!pipe target didn't actually connect to the pipe,
 		// we connect to the pipe here to satisfy the ConnectNamedPipe().
 		LPTSTR pipeName = calloc (128, sizeof (TCHAR));
-		GetEnvironmentVariable (TEXT ("R2PIPE_PATH"), pipeName, 128);
-		HANDLE pipe = CreateFile (pipeName, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
-		if (pipe != INVALID_HANDLE_VALUE) {
-			CloseHandle (pipe);
+		if (pipeName) {
+			GetEnvironmentVariable (TEXT ("R2PIPE_PATH"), pipeName, 128);
+			HANDLE pipe = CreateFile (pipeName, GENERIC_READ | GENERIC_WRITE, 0,
+			                          NULL, OPEN_EXISTING, 0, NULL);
+			if (pipe != INVALID_HANDLE_VALUE) {
+				CloseHandle (pipe);
+			}
+			free (pipeName);
 		}
 
 		bStopPipeLoop = TRUE;

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -68,6 +68,9 @@ static void lang_pipe_run_win(RLang *lang) {
 		                                  FALSE, INFINITE);
 		if (dwEvent == WAIT_OBJECT_0 + 1) { // hproc
 			break;
+		} else if (dwEvent == WAIT_FAILED) {
+			r_sys_perror ("lang_pipe_run_win/WaitForMultipleObjects read");
+			break;
 		}
 		bSuccess = GetOverlappedResult (hPipeInOut, &oRead, &dwRead, TRUE);
 		if (!bSuccess) {
@@ -92,6 +95,8 @@ static void lang_pipe_run_win(RLang *lang) {
 					                                  FALSE, INFINITE);
 					if (dwEvent == WAIT_OBJECT_0 + 1) { // hproc
 						break;
+					} else if (dwEvent == WAIT_FAILED) {
+						r_sys_perror ("lang_pipe_run_win/WaitForMultipleObjects write");
 					}
 					BOOL rc = GetOverlappedResult (hPipeInOut, &oWrite, &dwWritten, TRUE);
 					if (!rc) {
@@ -255,6 +260,9 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 				DWORD dwEvent = WaitForMultipleObjects (R_ARRAY_SIZE (hEvents), hEvents,
 				                                        FALSE, INFINITE);
 				if (dwEvent == WAIT_OBJECT_0 + 1) { // hproc
+					goto cleanup;
+				} else if (dwEvent == WAIT_FAILED) {
+					r_sys_perror ("lang_pipe_run/WaitForMultipleObjects connect");
 					goto cleanup;
 				}
 				DWORD dummy;

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -232,14 +232,14 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 		eprintf ("CreateNamedPipe failed: %#x\n", (int)GetLastError ());
 		goto beach;
 	}
+	hConnected = CreateEvent (NULL, FALSE, FALSE, NULL);
+	if (!hConnected) {
+		eprintf ("CreateEvent failed: %#x\n", (int)GetLastError ());
+		goto pipe_cleanup;
+	}
 	hproc = myCreateChildProcess (code);
 	bool connected = false;
 	if (hproc) {
-		hConnected = CreateEvent (NULL, FALSE, FALSE, NULL);
-		if (!hConnected) {
-			eprintf ("CreateEvent failed: %#x\n", (int)GetLastError ());
-			goto pipe_cleanup;
-		}
 		/* a separate thread is created that sets bStopPipeLoop once hproc terminates. */
 		bStopPipeLoop = FALSE;
 		HANDLE hConnectThread = CreateThread (NULL, 0, WaitForProcThread, NULL, 0, NULL);
@@ -255,8 +255,8 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 			}
 		}
 		CloseHandle (hConnectThread);
-		CloseHandle (hConnected);
 	}
+	CloseHandle (hConnected);
 pipe_cleanup:
 	DeleteFile (r2pipe_paz_);
 	CloseHandle (hPipeInOut);

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -100,7 +100,7 @@ static void lang_pipe_run_win(RLang *lang) {
 					}
 					BOOL rc = GetOverlappedResult (hPipeInOut, &oWrite, &dwWritten, TRUE);
 					if (!rc) {
-						r_sys_perror ("lang_pipe_run_win/WriteFile");
+						r_sys_perror ("lang_pipe_run_win/WriteFile res");
 					}
 					if (dwWritten > 0) {
 						i += dwWritten - 1;
@@ -114,6 +114,9 @@ static void lang_pipe_run_win(RLang *lang) {
 				free (res);
 			} else {
 				WriteFile (hPipeInOut, "", 1, NULL, &oWrite);
+				if (!GetOverlappedResult (hPipeInOut, &oWrite, &dwWritten, TRUE)) {
+					r_sys_perror ("lang_pipe_run_win/WriteFile nul");
+				}
 			}
 		}
 	} while (true);

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -44,12 +44,12 @@ static void lang_pipe_run_win(RLang *lang) {
 	DWORD dwRead = 0, dwWritten = 0, dwEvent;
 	HANDLE hRead = CreateEvent (NULL, TRUE, FALSE, NULL);
 	if (!hRead) {
-		eprintf ("hRead CreateEvent failed: %#x\n", (int)GetLastError ());
+		r_sys_perror ("lang_pipe_run_win/CreateEvent hRead");
 		return;
 	}
 	HANDLE hWritten = CreateEvent (NULL, TRUE, FALSE, NULL);
 	if (!hWritten) {
-		eprintf ("hWritten CreateEvent failed: %#x\n", (int)GetLastError ());
+		r_sys_perror ("lang_pipe_run_win/CreateEvent hWritten");
 		CloseHandle (hRead);
 		return;
 	}
@@ -234,12 +234,12 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 			PIPE_BUF_SIZE,
 			0, NULL);
 	if (hPipeInOut == INVALID_HANDLE_VALUE) {
-		eprintf ("CreateNamedPipe failed: %#x\n", (int)GetLastError ());
+		r_sys_perror ("lang_pipe_run/CreateNamedPipe");
 		goto beach;
 	}
 	HANDLE hConnected = CreateEvent (NULL, TRUE, FALSE, NULL);
 	if (!hConnected) {
-		eprintf ("hConnected CreateEvent failed: %#x\n", (int)GetLastError ());
+		r_sys_perror ("lang_pipe_run/CreateEvent hConnected");
 		goto pipe_cleanup;
 	}
 	OVERLAPPED oConnect = { 0 };
@@ -262,7 +262,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 				err = GetLastError ();
 			}
 			if (!connected && err != ERROR_PIPE_CONNECTED) {
-				eprintf ("ConnectNamedPipe failed: %#x\n", (int)err);
+				r_sys_perror ("lang_pipe_run/ConnectNamedPipe");
 				goto cleanup;
 			}
 		}

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -36,31 +36,8 @@ static HANDLE myCreateChildProcess(const char * szCmdline) {
 static volatile BOOL bStopPipeLoop = FALSE;
 static HANDLE hPipeInOut = NULL;
 static HANDLE hproc = NULL;
-static HANDLE hConnected = NULL;
 #define PIPE_BUF_SIZE 8192
 
-static DWORD WINAPI WaitForProcThread(LPVOID lParam) {
-	HANDLE hEvents[] = { hConnected, hproc };
-	DWORD dwEvent = WaitForMultipleObjects (R_ARRAY_SIZE (hEvents), hEvents, FALSE, INFINITE);
-
-	if (dwEvent == WAIT_OBJECT_0 + 1) {
-		// Just in case the #!pipe target didn't actually connect to the pipe,
-		// we connect to the pipe here to satisfy the ConnectNamedPipe().
-		LPTSTR pipeName = calloc (128, sizeof (TCHAR));
-		if (pipeName) {
-			GetEnvironmentVariable (TEXT ("R2PIPE_PATH"), pipeName, 128);
-			HANDLE pipe = CreateFile (pipeName, GENERIC_READ | GENERIC_WRITE, 0,
-			                          NULL, OPEN_EXISTING, 0, NULL);
-			if (pipe != INVALID_HANDLE_VALUE) {
-				CloseHandle (pipe);
-			}
-			free (pipeName);
-		}
-
-		bStopPipeLoop = TRUE;
-	}
-	return 0;
-}
 static void lang_pipe_run_win(RLang *lang) {
 	CHAR buf[PIPE_BUF_SIZE];
 	BOOL bSuccess = TRUE;
@@ -227,7 +204,7 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 
 	SetEnvironmentVariable (TEXT ("R2PIPE_PATH"), r2pipe_paz_);
 	hPipeInOut = CreateNamedPipe (r2pipe_paz_,
-			PIPE_ACCESS_DUPLEX,
+			PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
 			PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT, PIPE_UNLIMITED_INSTANCES,
 			PIPE_BUF_SIZE,
 			PIPE_BUF_SIZE,
@@ -236,30 +213,39 @@ static int lang_pipe_run(RLang *lang, const char *code, int len) {
 		eprintf ("CreateNamedPipe failed: %#x\n", (int)GetLastError ());
 		goto beach;
 	}
-	hConnected = CreateEvent (NULL, FALSE, FALSE, NULL);
+	HANDLE hConnected = CreateEvent (NULL, TRUE, FALSE, NULL);
 	if (!hConnected) {
 		eprintf ("CreateEvent failed: %#x\n", (int)GetLastError ());
 		goto pipe_cleanup;
 	}
+	OVERLAPPED oConnect = { 0 };
+	oConnect.hEvent = hConnected;
 	hproc = myCreateChildProcess (code);
-	bool connected = false;
+	BOOL connected = FALSE;
 	if (hproc) {
-		/* a separate thread is created that sets bStopPipeLoop once hproc terminates. */
 		bStopPipeLoop = FALSE;
-		HANDLE hConnectThread = CreateThread (NULL, 0, WaitForProcThread, NULL, 0, NULL);
-		connected = ConnectNamedPipe (hPipeInOut, NULL) ? true : (GetLastError () == ERROR_PIPE_CONNECTED);
-		if (connected) {
-			if (SetEvent (hConnected)) {
-				WaitForSingleObject (hConnectThread, INFINITE);
-				CloseHandle (CreateThread (NULL, 0, WaitForProcThread, NULL, 0, NULL));
-				/* lang_pipe_run_win has to run in the command thread to prevent deadlock. */
-				lang_pipe_run_win (lang);
-			} else {
-				eprintf ("SetEvent failed: %#x\n", (int)GetLastError ());
+		connected = ConnectNamedPipe (hPipeInOut, &oConnect);
+		DWORD err = GetLastError ();
+		if (!connected && err != ERROR_PIPE_CONNECTED) {
+			if (err == ERROR_IO_PENDING) {
+				HANDLE hEvents[] = { hConnected, hproc };
+				DWORD dwEvent = WaitForMultipleObjects (R_ARRAY_SIZE (hEvents), hEvents,
+				                                        FALSE, INFINITE);
+				if (dwEvent == WAIT_OBJECT_0 + 1) { // hproc
+					goto cleanup;
+				}
+				DWORD dummy;
+				connected = GetOverlappedResult (hPipeInOut, &oConnect, &dummy, TRUE);
+				err = GetLastError ();
+			}
+			if (!connected && err != ERROR_PIPE_CONNECTED) {
+				eprintf ("ConnectNamedPipe failed: %#x\n", (int)err);
+				goto cleanup;
 			}
 		}
-		CloseHandle (hConnectThread);
+		lang_pipe_run_win (lang);
 	}
+cleanup:
 	CloseHandle (hConnected);
 pipe_cleanup:
 	DeleteFile (r2pipe_paz_);

--- a/test/db/cmd/cmd_pipe
+++ b/test/db/cmd/cmd_pipe
@@ -28,4 +28,4 @@ Disassembly of entry0:
 \           0x0804902b      e8e0ffffff     call sym.imp._Exit          ; void _Exit(int status)
 
 EOF
-RUN
+#RUN

--- a/test/db/cmd/cmd_pipe
+++ b/test/db/cmd/cmd_pipe
@@ -28,4 +28,4 @@ Disassembly of entry0:
 \           0x0804902b      e8e0ffffff     call sym.imp._Exit          ; void _Exit(int status)
 
 EOF
-#RUN
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr replaces the busy-wait on PeekNamedPipe() in the Windows #!pipe code that was noted in https://github.com/radareorg/radare2/pull/17139#issue-438658733, i.e. https://github.com/radareorg/radare2/blob/b25c3275dee4543e2464de60f58e8f279d9eed87/libr/lang/p/pipe.c#L68-L70 with overlapped I/O.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
