### PR TITLE
Support compilation with meson on old systems like CentOS6/DebianWheezy ##build

### DIFF
--- a/binr/r2r/meson.build
+++ b/binr/r2r/meson.build
@@ -3,7 +3,8 @@ if get_option('enable_r2r')
   executable('r2r', ['r2r.c', 'load.c', 'run.c'],
     include_directories: [platform_inc],
     dependencies: [
-      r_util_dep
+      r_util_dep,
+      lrt,
     ],
     install: true,
     install_rpath: rpath,

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -102,6 +102,7 @@ r_core_deps = [
   platform_deps,
   gdb_dep,
   java_dep,
+  lrt,
   shell_parser_dep
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -347,15 +347,21 @@ userconf.set10('WITH_GPL', true)
 ok = cc.has_header_symbol('sys/personality.h', 'ADDR_NO_RANDOMIZE')
 userconf.set10('HAVE_DECL_ADDR_NO_RANDOMIZE', ok)
 
+lrt = []
+if not cc.has_function('clock_gettime', prefix: '#include <time.h>') and cc.has_header_symbol('features.h', '__GLIBC__')
+  lrt = cc.find_library('rt', required: true)
+endif
+
 foreach item : [
-    ['arc4random_uniform', '#include <stdlib.h>'],
-    ['explicit_bzero', '#include <string.h>'],
-    ['explicit_memset', '#include <string.h>'],
-    ['clock_nanosleep', '#include <time.h>'],
-    ['sigaction', '#include <signal.h>']
+    ['arc4random_uniform', '#include <stdlib.h>', []],
+    ['explicit_bzero', '#include <string.h>', []],
+    ['explicit_memset', '#include <string.h>', []],
+    ['clock_nanosleep', '#include <time.h>', []],
+    ['clock_gettime', '#include <time.h>', [lrt]],
+    ['sigaction', '#include <signal.h>', []]
   ]
   func = item[0]
-  ok = cc.has_function(func, prefix: item[1])
+  ok = cc.has_function(func, prefix: item[1], dependencies: item[2])
   userconf.set10('HAVE_@0@'.format(func.to_upper()), ok)
 endforeach
 

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -155,6 +155,13 @@ endif
 
 
 # handle tree-sitter
+tree_sitter_cflags = ''
+if cc.has_argument('-std=gnu99')
+  tree_sitter_cflags = '-std=gnu99'
+elif cc.has_argument('std=c99')
+  tree_sitter_cflags = '-std=c99'
+endif
+
 tree_sitter_dep = dependency('tree-sitter', required: false)
 if not tree_sitter_dep.found() or not get_option('use_sys_tree_sitter')
   message('Use bundled tree-sitter')
@@ -201,10 +208,11 @@ if not tree_sitter_dep.found() or not get_option('use_sys_tree_sitter')
   libtree_sitter = static_library('tree_sitter', tree_sitter_files,
     include_directories: tree_sitter_inc,
     implicit_include_directories: false,
-    c_args: ['-std=c99']
+    c_args: tree_sitter_cflags,
   )
 
   tree_sitter_dep = declare_dependency(
+    compile_args: tree_sitter_cflags,
     link_with: libtree_sitter,
     include_directories: tree_sitter_inc
   )

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -75,7 +75,8 @@ if get_option('enable_tests')
         r_search_dep,
         r_hash_dep,
         r_crypto_dep,
-        r_magic_dep
+        r_magic_dep,
+        lrt,
       ],
       install: false,
       install_rpath: rpath,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Compiling radare2 on older systems like CentOS 6 or Debian:Wheezy resulted in errors due to missing reference to clock_gettime. This was fixed for acr/make in a29f0ccce5b0281a89ab3aff174fcbf07a477054 . This PR fixes it for meson as well.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try to compile radare2 on centos:6 container with meson.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

This partially fix https://github.com/radareorg/cutter/issues/2316 (only the r2 part of the problem).