### PR TITLE
Improve ESIL support for ARM (clz, ldrb, sbc, tbh, tbb, it, blx, asr, lsl, cmp) ##anal

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1679,7 +1679,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		r_strbuf_appendf (&op->esil, "%d,sp,+=",
 			4 * insn->detail->arm.op_count);
 		break;
-	case ARM_INS_LDM: {
+	case ARM_INS_LDM:
 		const char *comma = "";
 		for (i = 1; i < insn->detail->arm.op_count; i++) {
 			r_strbuf_appendf (&op->esil, "%s%s,%d,+,[4],%s,=",
@@ -1690,7 +1690,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 			r_strbuf_appendf (&op->esil, ",%d,%s,+=,",
 				(insn->detail->arm.op_count - 1) * 4, ARG (0));
 		}
-	} break;
+        break;
 	case ARM_INS_CMP:
 		r_strbuf_appendf (&op->esil, "%s,%s,==", ARG (1), ARG (0));
 		break;

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1680,11 +1680,9 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 			4 * insn->detail->arm.op_count);
 		break;
 	case ARM_INS_LDM:
-		const char *comma = "";
-		for (i = 1; i < insn->detail->arm.op_count; i++) {
-			r_strbuf_appendf (&op->esil, "%s%s,%d,+,[4],%s,=",
-				comma, ARG (0), (i - 1) * 4, REG (i));
-			comma = ",";
+		r_strbuf_appendf (&op->esil, "%s,%d,+,[4],%s,=", ARG (0), 0, REG (1));
+		for (i = 2; i < insn->detail->arm.op_count; i++) {
+			r_strbuf_appendf (&op->esil, ",%s,%d,+,[4],%s,=", ARG (0), (i - 1) * 4, REG (i));
 		}
 		if (insn->detail->arm.writeback == true) { //writeback, reg should be incremented
 			r_strbuf_appendf (&op->esil, ",%d,%s,+=,",

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -18,6 +18,30 @@ radare_emulation
 EOF
 RUN
 
+NAME=clz
+FILE=malloc://0x200
+CMDS=<<EOF
+e io.cache=true
+e asm.bits=16
+e asm.arch=arm
+wa clz r0, r1
+aer r1=0x80000000
+aes
+aer r0
+aer0
+aer r1=0x1
+aes
+aer r0
+aer0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x00000000
+0x0000001f
+0x00000020
+EOF
+RUN
 
 NAME=addw emulation
 FILE=malloc://0x200
@@ -140,7 +164,6 @@ RUN
 
 NAME=ldm r3!, {r1, r4, r5}
 FILE=malloc://0x200
-BROKEN=1
 CMDS=<<EOF
 e asm.arch=arm
 e asm.bits=16
@@ -162,9 +185,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=stm r1!, {r5}
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar r1=4		# address
+ar r5=0xaabbccdd
+wx 20c1
+aes
+ar r1
+p8 4 @ 4
+EOF
+EXPECT=<<EOF
+0x00000008
+ddccbbaa
+EOF
+RUN
+
 NAME=stm r2!, {r1, r4, r5}
 FILE=malloc://0x200
-BROKEN=1
 CMDS=<<EOF
 e asm.arch=arm
 e asm.bits=16
@@ -210,7 +250,7 @@ wx 08bf
 aoe
 EOF
 EXPECT=<<EOF
-0x0 zf,?{,4,pc,+=,}
+0x0 zf,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -223,7 +263,7 @@ wx 18bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 zf,!,?{,4,pc,+=,}
+0x0 zf,!,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -236,7 +276,7 @@ wx 28bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 cf,?{,4,pc,+=,}
+0x0 cf,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -249,7 +289,7 @@ wx 38bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 cf,!,?{,4,pc,+=,}
+0x0 cf,!,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -262,7 +302,7 @@ wx 48bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 nf,?{,4,pc,+=,}
+0x0 nf,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -275,7 +315,7 @@ wx 58bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 nf,!,?{,4,pc,+=,}
+0x0 nf,!,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -288,7 +328,7 @@ wx 68bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 vf,?{,4,pc,+=,}
+0x0 vf,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -301,7 +341,7 @@ wx 78bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 vf,!,?{,4,pc,+=,}
+0x0 vf,!,?{,2,$$,+,pc,=,}
 EOF
 RUN
 
@@ -314,7 +354,7 @@ wx e8bf00000000
 aoe
 EOF
 EXPECT=<<EOF
-0x0 4,pc,+=
+0x0 2,$$,+,pc,=
 EOF
 RUN
 
@@ -464,6 +504,24 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldr immediate with post increment
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+wa ldr r2, [r3], 10
+wx aabbccdd @ 10
+aer r3=10
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xddccbbaa
+0x00000014
+EOF
+RUN
+
 NAME=add wrapping around
 FILE=malloc://0x200
 CMDS=<<EOF
@@ -498,9 +556,9 @@ ar cpsr
 EOF
 EXPECT=<<EOF
 0x10000000
-0x20000000
+0x30000000
 0x90000001
-0x00000000
+0x80000000
 EOF
 RUN
 
@@ -779,7 +837,7 @@ aer lr
 aer pc
 EOF
 EXPECT=<<EOF
-0x00000004
+0x00000005
 0x00000008
 EOF
 RUN

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -594,6 +594,23 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldrb r1, [r3, r2, lsl 2]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r3=4
+ar r2=1
+wx 0211d3e7
+wx aabbccdd @ 8
+aes
+ar r1
+EOF
+EXPECT=<<EOF
+0x000000aa
+EOF
+RUN
+
 NAME=str r2, [r3, 4]
 FILE=malloc://0x200
 CMDS=<<EOF
@@ -2293,6 +2310,23 @@ ar r0
 EOF
 EXPECT=<<EOF
 0x00000028
+EOF
+RUN
+
+NAME=lsl reg same destination and source
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+aer r3=0xffffffaa
+wx 0331a0e1
+aes
+ar r3
+ar cpsr
+EOF
+EXPECT=<<EOF
+0xfffffea8
+0x00000000
 EOF
 RUN
 


### PR DESCRIPTION
- [*] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [*] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [*] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Indentation fixed by script

Added support for :
- ARM_INS_CLZ
- ARM_INS_LDRB
- ARM_INS_SBC
- ARM_INS_TBH
- ARM_INS_TBB

Fixed:
- ARM_INS_IT (partial)
- ARM_INS_BLX (consider thumb)
- ARM_INS_ASR
- ARM_INS_LSL
- Update flags for CMP

Tested against binary running on target, seems to solve lot of issues yet.

Credits also goes to @Baldanos who contributed to this pull request
