### PR TITLE
Change Itanium VTable detection heuristic ##anal

### DIFF
--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -90,6 +90,7 @@ static bool vtable_section_can_contain_vtables(RBinSection *section) {
 	return !strcmp (section->name, ".rodata") ||
 		!strcmp (section->name, ".rdata") ||
 		!strcmp (section->name, ".data.rel.ro") ||
+		!strcmp (section->name, ".data.rel.ro.local") ||
 		r_str_endswith (section->name, "__const");
 }
 
@@ -98,6 +99,7 @@ static bool section_can_contain_rtti(RBinSection *section) {
 		return true;
 	}
 	return !strcmp (section->name, ".data.rel.ro") ||
+		!strcmp (section->name, ".data.rel.ro.local") ||
 		r_str_endswith (section->name, "__const");
 }
 

--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -95,6 +95,9 @@ static bool vtable_section_can_contain_vtables(RBinSection *section) {
 }
 
 static bool section_can_contain_rtti(RBinSection *section) {
+	if (!section) {
+		return false;
+	}
 	if (section->is_data) {
 		return true;
 	}

--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -83,7 +83,7 @@ static bool vtable_is_value_in_text_section(RVTableContext *context, ut64 curAdd
 	return ret;
 }
 
-static bool vtable_section_can_contain_vtables(RVTableContext *context, RBinSection *section) {
+static bool vtable_section_can_contain_vtables(RBinSection *section) {
 	if (section->is_segment) {
 		return false;
 	}
@@ -93,24 +93,24 @@ static bool vtable_section_can_contain_vtables(RVTableContext *context, RBinSect
 		r_str_endswith (section->name, "__const");
 }
 
-static bool vtable_is_addr_vtable_start_itanium(RVTableContext *context, ut64 curAddress, ut64 data_section_start, ut64 data_section_end) {
+static bool vtable_is_addr_vtable_start_itanium(RVTableContext *context, RBinSection *section, ut64 curAddress) {
 	ut64 value;
 	if (!curAddress || curAddress == UT64_MAX) {
 		return false;
 	}
-	if (curAddress && !vtable_is_value_in_text_section (context, curAddress, NULL)) {
+	if (curAddress && !vtable_is_value_in_text_section (context, curAddress, NULL)) { // Vtable beginning referenced from the code
 		return false;
 	}
-	if (!context->read_addr (context->anal, curAddress - context->word_size, &value)) {
+	if (!context->read_addr (context->anal, curAddress - context->word_size, &value)) { // get the RTTI pointer
 		return false;
 	}
-	if (value && (value < data_section_start || value >= data_section_end)) {
+	if (value && !section->is_data) { // RTTI ptr must point somewhere in the data section
 		return false;
 	}
-	if (!context->read_addr (context->anal, curAddress - 2 * context->word_size, &value)) {
+	if (!context->read_addr (context->anal, curAddress - 2 * context->word_size, &value)) { // Offset to top
 		return false;
 	}
-	if ((st32)value > 0) {
+	if ((st32)value > 0) { // Offset to top has to be negative
 		return false;
 	}
 	return true;
@@ -155,12 +155,12 @@ static bool vtable_is_addr_vtable_start_msvc(RVTableContext *context, ut64 curAd
 	return false;
 }
 
-static bool vtable_is_addr_vtable_start(RVTableContext *context, ut64 curAddress, ut64 data_section_start, ut64 data_section_end) {
+static bool vtable_is_addr_vtable_start(RVTableContext *context, RBinSection *section, ut64 curAddress) {
 	if (context->abi == R_ANAL_CPP_ABI_MSVC) {
 		return vtable_is_addr_vtable_start_msvc (context, curAddress);
 	}
 	if (context->abi == R_ANAL_CPP_ABI_ITANIUM) {
-		return vtable_is_addr_vtable_start_itanium (context, curAddress, data_section_start, data_section_end);
+		return vtable_is_addr_vtable_start_itanium (context, section, curAddress);
 	}
 	r_return_val_if_reached (false);
 }
@@ -226,7 +226,7 @@ R_API RList *r_anal_vtable_search(RVTableContext *context) {
 			break;
 		}
 
-		if (!vtable_section_can_contain_vtables (context, section)) {
+		if (!vtable_section_can_contain_vtables (section)) {
 			continue;
 		}
 
@@ -244,7 +244,7 @@ R_API RList *r_anal_vtable_search(RVTableContext *context) {
 				break;
 			}
 
-			if (vtable_is_addr_vtable_start (context, startAddress, section->vaddr, endAddress)) {
+			if (vtable_is_addr_vtable_start (context, section, startAddress)) {
 				RVTableInfo *vtable = r_anal_vtable_parse_at (context, startAddress);
 				if (vtable) {
 					r_list_append (vtables, vtable);

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -471,7 +471,7 @@ EOF
 RUN
 
 NAME=ppc-detect-vtables
-FILE=bins/elf/ppc_vtables
+FILE=bins/elf/ppc_classes
 CMDS=<<EOF
 av
 EOF

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -469,3 +469,60 @@ EXPECT=<<EOF
 0x1001010a
 EOF
 RUN
+
+NAME=ppc-detect-vtables
+FILE=bins/elf/ppc_vtables
+CMDS=<<EOF
+av
+EOF
+EXPECT=<<EOF
+
+Vtable Found at 0x100016d4
+0x100016d4 : No Name found
+0x100016d8 : No Name found
+0x100016dc : No Name found
+
+
+Vtable Found at 0x100016e8
+0x100016e8 : No Name found
+0x100016ec : No Name found
+0x100016f0 : No Name found
+
+
+Vtable Found at 0x100016fc
+0x100016fc : No Name found
+0x10001700 : No Name found
+0x10001704 : No Name found
+
+
+Vtable Found at 0x10001710
+0x10001710 : No Name found
+0x10001714 : No Name found
+0x10001718 : No Name found
+0x1000171c : No Name found
+0x10001720 : No Name found
+
+
+Vtable Found at 0x1000172c
+0x1000172c : No Name found
+0x10001730 : No Name found
+0x10001734 : No Name found
+0x10001738 : No Name found
+0x1000173c : No Name found
+
+
+Vtable Found at 0x10001748
+0x10001748 : No Name found
+0x1000174c : No Name found
+0x10001750 : No Name found
+0x10001754 : No Name found
+0x10001758 : No Name found
+
+
+Vtable Found at 0x10001764
+0x10001764 : No Name found
+0x10001768 : No Name found
+0x1000176c : No Name found
+
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I've been testing out the VTable, RTTI detection and parsing, I've tried some exotic Arches and found that sometimes only some Vtables are found, so far we assumed that vtable always have to be in the same section as a vtable, but in some binaries (PowerPC one, some RTTIs were in the .rodata and others were in .sdata) that wasn't the case, I've relaxed the requirement so we only check if the RTTI pointer points to an initialized data section which improved the detection. But I don't know how to properly detect such section in Radare, I got inspired by the implementation for possible Vtable section.

I've looked into Retdec way and they only seem to check if RTTI is a valid pointer somewhere in the binary and then they parse the RTTI, if any crucial step of the parsing fails, they take it as an invalid RTTI and thus invalid Vtable

We can maybe try the same approach, that would also help us to not rely on flags for knowing the TypeInfoClass, also because in some examples relying on the flags didn't work and we lost more RTTI information because of it, because it assumes that anything that doesn't have the flag is the default TypeInfo_Class