### PR TITLE
Add bytes to zb command ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -1261,8 +1261,7 @@ static bool closest_match_callback(void *a, const char *name, const char *value)
 			// bytes distance is slow. To avoid it, we can do quick maths to
 			// see if the highest possible score would be good enough to change
 			// results
-			double maxscore = maxscore = R_MIN (sizea, sizeb) /
-				R_MAX (sizea, sizeb);
+			double maxscore = R_MIN (sizea, sizeb) / R_MAX (sizea, sizeb);
 			if (div > 0) {
 				maxscore = (maxscore + score) / div;
 			}

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -1114,10 +1114,8 @@ R_API bool r_sign_delete(RAnal *a, const char *name) {
 }
 
 static ut8 * build_combined_bytes(RSignBytes *bsig) {
-	if (!bsig || !bsig->bytes || !bsig->mask) {
-		return NULL;
-	}
-	ut8 *buf = (ut8 *)malloc(bsig->size);
+	r_return_val_if_fail (bsig && bsig->bytes && bsig->mask, NULL);
+	ut8 *buf = (ut8 *)malloc (bsig->size);
 	if (!buf) {
 		return NULL;
 	}
@@ -1129,9 +1127,7 @@ static ut8 * build_combined_bytes(RSignBytes *bsig) {
 }
 
 static double cmp_bytesig_to_buff(RSignBytes *sig, ut8 *buf, int len) {
-	if (!sig || !buf || len < 0) {
-		return -1.0;
-	}
+	r_return_val_if_fail (sig && buf && len >= 0, (double)-1.0);
 	ut8 *sigbuf = build_combined_bytes (sig);
 	if (!sigbuf) {
 		return -1.0;
@@ -1320,22 +1316,15 @@ R_API void r_sign_close_match_free(RSignCloseMatch *match) {
 }
 
 R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double score_threshold) {
-	r_return_val_if_fail (a && it && count > 0, NULL);
+	r_return_val_if_fail (a && it && count > 0 && score_threshold >= 0 && score_threshold <= 1, NULL);
 
 	// need at least one acceptable signature type
-	if (!it->bytes && !it->graph) {
-		return NULL;
-	}
+	r_return_val_if_fail (it->bytes || it->graph, NULL);
 
 	ClosestMatchData data;
 	RList *output = r_list_newf ((RListFree)r_sign_close_match_free);
 	if (!output) {
 		return NULL;
-	}
-
-	// impossible standard, return empty list
-	if (score_threshold > 1.0) {
-		return output;
 	}
 
 	data.output = output;

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -1113,6 +1113,36 @@ R_API bool r_sign_delete(RAnal *a, const char *name) {
 	return sdb_remove (a->sdb_zigns, k, 0);
 }
 
+static ut8 * build_combined_bytes(RSignBytes *bsig) {
+	if (!bsig || !bsig->bytes || !bsig->mask) {
+		return NULL;
+	}
+	ut8 *buf = (ut8 *)malloc(bsig->size);
+	if (!buf) {
+		return NULL;
+	}
+	int i;
+	for (i = 0; i < bsig->size; i++) {
+		buf[i] = bsig->bytes[i] & bsig->mask[i];
+	}
+	return buf;
+}
+
+static double cmp_bytesig_to_buff(RSignBytes *sig, ut8 *buf, int len) {
+	if (!sig || !buf || len < 0) {
+		return -1.0;
+	}
+	ut8 *sigbuf = build_combined_bytes (sig);
+	if (!sigbuf) {
+		return -1.0;
+	}
+
+	double sim = -1.0;
+	r_diff_buffers_distance (NULL, sigbuf, sig->size, buf, len, NULL, &sim);
+	free (sigbuf);
+	return sim;
+}
+
 static double matchBytes(RSignItem *a, RSignItem *b) {
 	double result = 0.0;
 
@@ -1120,14 +1150,14 @@ static double matchBytes(RSignItem *a, RSignItem *b) {
 		return result;
 	}
 
-	size_t min_size = R_MIN ((size_t) a->bytes->size, (size_t) b->bytes->size);
+	size_t min_size = R_MIN ((size_t)a->bytes->size, (size_t)b->bytes->size);
 	if (!min_size) {
 		return result;
 	}
 
 	ut8 *combined_mask = NULL;
 	if (a->bytes->mask || b->bytes->mask) {
-		combined_mask = (ut8*) malloc (min_size);
+		combined_mask = (ut8*)malloc (min_size);
 		if (!combined_mask) {
 			return result;
 		}
@@ -1142,7 +1172,7 @@ static double matchBytes(RSignItem *a, RSignItem *b) {
 
 	if ((combined_mask && !r_mem_cmp_mask (a->bytes->bytes, b->bytes->bytes, combined_mask, min_size)) ||
 		(!combined_mask && !memcmp (a->bytes->bytes, b->bytes->bytes, min_size))) {
-		result = (double) min_size / (double) R_MAX (a->bytes->size, b->bytes->size);
+		result = (double)min_size / (double)R_MAX (a->bytes->size, b->bytes->size);
 	}
 
 	free (combined_mask);
@@ -1150,8 +1180,8 @@ static double matchBytes(RSignItem *a, RSignItem *b) {
 	return result;
 }
 
-#define SIMILARITY(a,b) \
-	((a) == (b) ? 1.0 : (R_MAX ((a),(b)) == 0.0 ? 0.0 : (double) R_MIN ((a), (b)) / (double) R_MAX ((a), (b))))
+#define SIMILARITY(a, b) \
+	((a) == (b)? 1.0: (R_MAX ((a), (b)) == 0.0? 0.0: (double)R_MIN ((a), (b)) / (double)R_MAX ((a), (b))))
 
 static double matchGraph(RSignItem *a, RSignItem *b) {
 	if (!a->graph || !b->graph) {
@@ -1187,6 +1217,7 @@ typedef struct {
 	RList *output;
 	size_t count;
 	double score_threshold;
+	ut8 *bytes_combined;
 
 	// greatest lower bound. Thanks lattice theory for helping name variables
 	double infimum;
@@ -1205,25 +1236,57 @@ static bool closest_match_callback(void *a, const char *name, const char *value)
 		return false;
 	}
 
-	double score = matchGraph (it, data->test);
+	// quantify how close the signature matches
+	int div = 0;
+	double score = 0.0;
+	double gscore = -1.0;
+	if (it->graph && data->test->graph) {
+		gscore = matchGraph (it, data->test);
+		score += gscore;
+		div++;
+	}
+	double bscore = -1.0;
+	bool list_full = (r_list_length (data->output) == data->count);
+
+	// value to beat to enter the list
+	double pivot = data->score_threshold;
+	if (list_full) {
+		pivot = R_MAX (pivot, data->infimum);
+	}
+
+	if (it->bytes && data->bytes_combined) {
+		int sizea = it->bytes->size;
+		int sizeb = data->test->bytes->size;
+		if (pivot > 0.0) {
+			// bytes distance is slow. To avoid it, we can do quick maths to
+			// see if the highest possible score would be good enough to change
+			// results
+			double maxscore = maxscore = R_MIN (sizea, sizeb) /
+				R_MAX (sizea, sizeb);
+			if (div > 0) {
+				maxscore = (maxscore + score) / div;
+			}
+			if (maxscore < pivot) {
+				r_sign_item_free (it);
+				return true;
+			}
+		}
+
+		// get true byte score
+		bscore = cmp_bytesig_to_buff (it->bytes, data->bytes_combined, sizeb);
+		score += bscore;
+		div++;
+	}
+	if (div == 0) {
+		r_sign_item_free (it);
+		return true;
+	}
+	score /= div;
 
 	// score is too low, don't bother doing any more work
-	if (score < data->score_threshold) {
+	if (score < pivot) {
 		r_sign_item_free (it);
 		return true;
-	}
-
-	RList *output = data->output;
-
-	// return early if the list does not need to be changed
-	if (score < data->infimum && r_list_length (output) >= data->count) {
-		r_sign_item_free (it);
-		return true;
-	}
-
-	// remove an element if list is full
-	if (r_list_length (output) >= data->count) {
-		r_sign_close_match_free (r_list_pop (output));
 	}
 
 	// add new element
@@ -1232,41 +1295,60 @@ static bool closest_match_callback(void *a, const char *name, const char *value)
 		r_sign_item_free (it);
 		return false;
 	}
-	row->name = strdup (it->name);
-	if (!row->name) {
-		r_sign_item_free (it);
-		free (row);
-		return false;
-	}
 	row->score = score;
-	r_list_add_sorted (output, (void *)row, &score_cmpr);
+	row->gscore = gscore;
+	row->bscore = bscore;
+	row->item = it;
+	r_list_add_sorted (data->output, (void *)row, &score_cmpr);
 
-	// get new infimum
-	row = r_list_get_top (output);
-	data->infimum = row->score;
+	if (list_full) {
+		// remove smallest element
+		r_sign_close_match_free (r_list_pop (data->output));
 
-	r_sign_item_free (it);
+		// get new infimum
+		row = r_list_get_top (data->output);
+		data->infimum = row->score;
+	}
+
 	return true;
 }
 
 R_API void r_sign_close_match_free(RSignCloseMatch *match) {
-	free (match->name);
-	free (match);
+	if (match) {
+		r_sign_item_free (match->item);
+		free (match);
+	}
 }
 
 R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double score_threshold) {
-	r_return_val_if_fail (a && it && count > 0 && score_threshold <= 1 && score_threshold >= 0, false);
+	r_return_val_if_fail (a && it && count > 0, NULL);
+
+	// need at least one acceptable signature type
+	if (!it->bytes && !it->graph) {
+		return NULL;
+	}
 
 	ClosestMatchData data;
 	RList *output = r_list_newf ((RListFree)r_sign_close_match_free);
 	if (!output) {
 		return NULL;
 	}
+
+	// impossible standard, return empty list
+	if (score_threshold > 1.0) {
+		return output;
+	}
+
 	data.output = output;
 	data.count = count;
 	data.score_threshold = score_threshold;
 	data.infimum = 0.0;
 	data.test = it;
+	if (it->bytes) {
+		data.bytes_combined = build_combined_bytes (it->bytes);
+	} else {
+		data.bytes_combined = NULL;
+	}
 
 	// TODO: handle sign spaces
 	if (!sdb_foreach (a->sdb_zigns, &closest_match_callback, (void *)&data)) {
@@ -1274,6 +1356,7 @@ R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double 
 		output = NULL;
 	}
 
+	free (data.bytes_combined);
 	return output;
 }
 
@@ -2480,7 +2563,7 @@ R_API void r_sign_item_free(RSignItem *item) {
 		return;
 	}
 	free (item->name);
-	bytes_sig_free(item->bytes);
+	bytes_sig_free (item->bytes);
 	if (item->hash) {
 		free (item->hash->bbhash);
 		free (item->hash);

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -1116,12 +1116,11 @@ R_API bool r_sign_delete(RAnal *a, const char *name) {
 static ut8 * build_combined_bytes(RSignBytes *bsig) {
 	r_return_val_if_fail (bsig && bsig->bytes && bsig->mask, NULL);
 	ut8 *buf = (ut8 *)malloc (bsig->size);
-	if (!buf) {
-		return NULL;
-	}
-	int i;
-	for (i = 0; i < bsig->size; i++) {
-		buf[i] = bsig->bytes[i] & bsig->mask[i];
+	if (buf) {
+		size_t i;
+		for (i = 0; i < bsig->size; i++) {
+			buf[i] = bsig->bytes[i] & bsig->mask[i];
+		}
 	}
 	return buf;
 }
@@ -1129,13 +1128,11 @@ static ut8 * build_combined_bytes(RSignBytes *bsig) {
 static double cmp_bytesig_to_buff(RSignBytes *sig, ut8 *buf, int len) {
 	r_return_val_if_fail (sig && buf && len >= 0, (double)-1.0);
 	ut8 *sigbuf = build_combined_bytes (sig);
-	if (!sigbuf) {
-		return -1.0;
-	}
-
 	double sim = -1.0;
-	r_diff_buffers_distance (NULL, sigbuf, sig->size, buf, len, NULL, &sim);
-	free (sigbuf);
+	if (sigbuf) {
+		r_diff_buffers_distance (NULL, sigbuf, sig->size, buf, len, NULL, &sim);
+		free (sigbuf);
+	}
 	return sim;
 }
 

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1028,9 +1028,7 @@ static bool bestmatch(void *data, const char *input) {
 		RSignBytes *b = item->bytes;
 		int minsz = r_config_get_i (core->config, "zign.minsz");
 		if (b && b->size < minsz) {
-			eprintf (
-				"[!!] Function signature to small (%d < %d (zign.minsz))\n",
-				b->size, minsz);
+			eprintf ("Warning: Function signature is too small (%d < %d) See e zign.minsz", b->size, minsz);
 			r_sign_item_free (item);
 			return false;
 		}
@@ -1050,7 +1048,7 @@ static bool bestmatch(void *data, const char *input) {
 		}
 		r_cons_break_pop ();
 	} else {
-		eprintf ("[!!] no signatures types available for testing\n");
+		eprintf ("Warning: no signatures types available for testing\n");
 	}
 
 	r_sign_item_free (item);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -983,43 +983,74 @@ TODO: add useXRefs, useName
 	return retval;
 }
 
+static void print_possible_matches(RList *list) {
+	RListIter *itr;
+	RSignCloseMatch *row;
+	r_list_foreach (list, itr, row) {
+		// total score
+		if (row->bscore > 0.0 && row->gscore > 0.0) {
+			r_cons_printf ("%02.5lf  ", row->score);
+		}
+		if (row->bscore > 0.0) {
+			r_cons_printf ("%02.5lf B  ", row->bscore);
+		}
+		if (row->gscore > 0.0) {
+			r_cons_printf ("%02.5lf G  ", row->gscore);
+		}
+		r_cons_printf (" %s\n", row->item->name);
+	}
+}
+
 static bool bestmatch(void *data, const char *input) {
 	RCore *core = (RCore *)data;
-	bool found = false;
 	int count = 5;
 
 	if (!R_STR_ISEMPTY (input)) {
 		count = atoi (input);
 		if (count <= 0) {
 			eprintf ("[!!] invalid number %s\n", input);
-			return found;
+			return false;
 		}
 	}
 
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->offset, 0);
+	if (!fcn) {
+		eprintf ("No function at 0x%08" PFMT64x "\n", core->offset);
+		return false;
+	}
 	RSignItem *item = r_sign_item_new ();
 	if (!item) {
-		return NULL;
+		return false;
 	}
 
-	if (!r_sign_addto_item (core->anal, item, fcn, R_SIGN_GRAPH)) {
-		r_sign_item_free (item);
-		return NULL;
+	if (r_config_get_i (core->config, "zign.bytes")) {
+		r_sign_addto_item (core->anal, item, fcn, R_SIGN_BYTES);
+		RSignBytes *b = item->bytes;
+		int minsz = r_config_get_i (core->config, "zign.minsz");
+		if (b && b->size < minsz) {
+			eprintf (
+				"[!!] Function signature to small (%d < %d (zign.minsz))\n",
+				b->size, minsz);
+			r_sign_item_free (item);
+			return false;
+		}
+	}
+	if (r_config_get_i (core->config, "zign.graph")) {
+		r_sign_addto_item (core->anal, item, fcn, R_SIGN_GRAPH);
 	}
 
-	if (item->graph) {
+	bool found = false;
+	if (item->graph || item->bytes) {
 		r_cons_break_push (NULL, NULL);
 		RList *list = r_sign_find_closest_sig (core->anal, item, count, 0);
 		if (list) {
 			found = true;
-			RListIter *itr;
-			RSignCloseMatch *row;
-			r_list_foreach (list, itr, row) {
-				r_cons_printf ("%02.5lf %s\n", row->score, row->name);
-			}
+			print_possible_matches (list);
 			r_list_free (list);
 		}
 		r_cons_break_pop ();
+	} else {
+		eprintf ("[!!] no signatures types available for testing\n");
 	}
 
 	r_sign_item_free (item);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -11,7 +11,7 @@ static const char *help_msg_z[] = {
 	"Usage:", "z[*j-aof/cs] [args] ", "# Manage zignatures",
 	"z", "", "show zignatures",
 	"z.", "", "find matching zignatures in current offset",
-	"zb", "[n=5]", "find n closest matching graph zignature at current offset",
+	"zb", "[n=5]", "find n closest matching zignatures to function at current offset",
 	"z*", "", "show zignatures in radare format",
 	"zq", "", "show zignatures in quiet mode",
 	"zj", "", "show zignatures in json format",

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -89,8 +89,10 @@ typedef struct r_sign_options_t {
 } RSignOptions;
 
 typedef struct {
-	char *name;
 	double score;
+	double bscore;
+	double gscore;
+	RSignItem *item;
 } RSignCloseMatch;
 
 #ifdef R_API

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -994,8 +994,10 @@ NAME=zb bad count
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 zb NOTANUMBER
 EOF
 EXPECT=<<EOF
@@ -1006,8 +1008,10 @@ NAME=zb negative count
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 zb -1
 EOF
 EXPECT=<<EOF
@@ -1018,12 +1022,14 @@ NAME=zb single exact match
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 zb
 EOF
 EXPECT=<<EOF
-1.00000 sym.exact
+1.00000  1.00000 B  1.00000 G   sym.exact
 EOF
 RUN
 
@@ -1031,21 +1037,28 @@ NAME=zb match 5 by default
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.second g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.second b ff5541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.third g cc=16 nbbs=28 edges=44 ebbs=1 bbsum=407
+za sym.third b ffff41544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.fourth g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=407
+za sym.fourth b ffffff544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.fith g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=401
+za sym.fith b ffffffff4989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.not_shown g cc=15 nbbs=28 edges=43 ebbs=1 bbsum=395
-zb
+za sym.not_shown b ffffffffff89fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb ~[5]
 EOF
 EXPECT=<<EOF
-1.00000 sym.exact
-0.98824 sym.second
-0.98134 sym.third
-0.97679 sym.fourth
-0.97384 sym.fith
+sym.exact
+sym.second
+sym.third
+sym.fourth
+sym.fith
 EOF
 RUN
 
@@ -1053,22 +1066,45 @@ NAME=zb match 6 of 6 with 100 count
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.second g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.second b ff5541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.third g cc=16 nbbs=28 edges=44 ebbs=1 bbsum=407
+za sym.third b ffff41544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.fourth g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=407
+za sym.fourth b ffffff544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.fith g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=401
+za sym.fith b ffffffff4989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.sixth g cc=15 nbbs=28 edges=43 ebbs=1 bbsum=395
-zb 100
+za sym.sixth b ffffffffff89fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb 100~[5]
 EOF
 EXPECT=<<EOF
-1.00000 sym.exact
-0.98824 sym.second
-0.98134 sym.third
-0.97679 sym.fourth
-0.97384 sym.fith
-0.95913 sym.sixth
+sym.exact
+sym.second
+sym.third
+sym.fourth
+sym.fith
+sym.sixth
+EOF
+RUN
+
+NAME=zb ignore masked bytes
+FILE=bins/elf/static-glibc-2.27
+CMDS=<<EOF
+s 0x00410210
+e zign.maxsz = 32
+af
+za sym.perf1 b 415541544989fc55534883ec08e800000000488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.perf2 b 415541544989fc55534883ec08e8ffffffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb ~[0]
+EOF
+EXPECT=<<EOF
+1.00000
+1.00000
 EOF
 RUN
 
@@ -1076,15 +1112,20 @@ NAME=zb count 1
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
+e zign.maxsz = 32
 af
 za sym.right g cc=16 nbbs=28 edges=44 ebbs=1 bbsum=407
+za sym.right b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.wrong g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=407
+za sym.wrong b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.nope g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=401
+za sym.nope b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.bad g cc=15 nbbs=28 edges=43 ebbs=1 bbsum=395
-zb 1
+za sym.bad b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb 1 ~?
 EOF
 EXPECT=<<EOF
-0.98134 sym.right
+1
 EOF
 RUN
 
@@ -1094,13 +1135,20 @@ CMDS=<<EOF
 s 0x00410210
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate1 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.duplicate1 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate2 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.duplicate2 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate3 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.duplicate3 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate4 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.duplicate4 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate5 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.duplicate5 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
 za sym.duplicate6 g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
-zb~dup?
+za sym.duplicate6 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb ~sym.duplicate?
 EOF
 EXPECT=<<EOF
 4


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This adds the bytes signature into the the `zb` command to find the top `n` closest matching signatures. The bytes comparison is done by the Levenshtien distance. The Levenshtien algorithm is slow, so the difference in signature lengths is considered first to see if the Levenshtien algorythm is even necessary.

Example on known `strdup` and `fclose` functions in a statically compiled binary against signatures from the known libc version.
```
[0x0041e390]> z* ~ g cc=?
3149
[0x0041e390]> s sym.strdup 
[0x0041e390]> zb
1.00000  1.00000 B  1.00000 G   sym.__strdup
0.95000  0.91176 B  0.98824 G   sym.wcsdup
0.92754  0.86957 B  0.98551 G   sym.strndup
0.77465  0.55556 B  0.99375 G   sym.envz_remove
0.73906  0.51562 B  0.96250 G   sym.getlogin_r
[0x0041e390]> s sym.fclose 
[0x0040fc10]> zb
0.96032  0.92400 B  0.99664 G   sym.fclose
0.65971  0.35600 B  0.96342 G   sym._nl_expand_alias
0.65770  0.37800 B  0.93740 G   sym.fdopen
0.65112  0.35000 B  0.95225 G   sym.__run_exit_handlers
0.62532  0.34800 B  0.90264 G   sym.__cxa_finalize
```

The `zb` command on `strdup` completes near instantly. The same command on `fclose` takes about a second to complete. Notice that the byte score improves upon the graph score, increasing the distance between the correct answer and the second best answer.

You can see [this](https://github.com/swoops/r2_zb_stats/) repo for some quick and dirty statistics on how this can help when a perfect match fails. 

**Test plan**

See the update to the regression tests.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
