### PR TITLE
Windows r_sys_perror: Add error code to string

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -901,7 +901,7 @@ R_API void r_sys_perror_str(const char *fun) {
 			0, NULL )) {
 		char *err = r_sys_conv_win_to_utf8 (lpMsgBuf);
 		if (err) {
-			eprintf ("%s: %s\n", fun, err);
+			eprintf ("%s: (%#x) %s\n", fun, dw, err);
 			free (err);
 		}
 		LocalFree (lpMsgBuf);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The pr adds an error code to the Windows r_sys_perror() string, to make it easier to look up and confirm the id of the error in the [System Error Code table](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes#system-error-codes). Example output:

![r_sys_perror error code](https://user-images.githubusercontent.com/12002672/88877027-2c926200-d257-11ea-831b-6a0d8659bc2b.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
