### PR TITLE
Windows r_sys_perror: Don't add end newline if an end newline already exists

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -901,7 +901,8 @@ R_API void r_sys_perror_str(const char *fun) {
 			0, NULL )) {
 		char *err = r_sys_conv_win_to_utf8 (lpMsgBuf);
 		if (err) {
-			eprintf ("%s: (%#x) %s\n", fun, dw, err);
+			eprintf ("%s: (%#x) %s%s", fun, dw, err,
+			         r_str_endswith (err, "\n") ? "" : "\n");
 			free (err);
 		}
 		LocalFree (lpMsgBuf);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr prevents blank lines after r_sys_perror() error messages on Windows.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Replace the following line: https://github.com/radareorg/radare2/blob/fca4fa618064eec5f10d436bc425d4d62b4cbf88/binr/r2r/run.c#L202

with

```c
r_sys_perror ("CreateProcess failed");
```

and run r2r on Windows with no jq in PATH. There should be no blank lines after the "CreateProcess failed" messages.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
