### PR TITLE
Fix #17379 - Avoid buffer overflow while identifying imports

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3623,6 +3623,12 @@ static RBinElfSymbol* Elf_(_r_bin_elf_get_symbols_imports)(ELFOBJ *bin, int type
 	if (nsym == -1) {
 		goto beach;
 	}
+
+	// Elf_(fix_symbols) may find additional symbols, some of which could be
+	// imported symbols. Let's reserve additional space for them.
+	r_warn_if_fail (nsym >= ret_ctr);
+	import_ret_ctr += nsym - ret_ctr;
+
 	aux = ret;
 	while (!aux->last) {
 		if ((int)aux->ordinal > max) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
  Not sure where the file comes from, can we add it to our tests? @SjRNMzU 
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

So, let's start by saying that I think the whole ELF symbols/imports retrieval is really really hacky and probably wrong in some cases, always because of the same issue that things are taken from the sections first and then "adjusted" with the info of phdr (it should be the opposite).

This problem was quite hard to debug, because ASAN/valgrind for some reason could not detect the issue at all, but there was buffer overflow. Function `_r_bin_elf_get_symbols_imports` has an initial loop where it computes `import_ret_ctr`, then it calls `fix_symbols` and then it allocates an array `import_ret` of size `import_ret_ctr`, copying elements from `ret`. However in some cases `fix_symbols` may add additional elements to `ret`, some of which apparently could be treated as imported symbols as well. This means that the original calculation done to compute `import_ret_ctr` may actually miss some symbols. When the loop at https://github.com/radareorg/radare2/blob/master/libr/bin/format/elf/elf.c#L3654 copies elements, it may actually copy more element than what originally allocated and overwrite data around in the heap.

The patch simply tries to consider this case, by incrementing `import_ret_ctr` as needed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/radareorg/radare2/issues/17379
