### PR TITLE
Add help under `axt?` ##cons

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -720,12 +720,22 @@ static const char *help_msg_ax[] = {
 	"axj", "", "list refs in json format",
 	"axF", " [flg-glob]", "find data/code references of flags",
 	"axm", " addr [at]", "copy data/code references pointing to addr to also point to curseek (or at)",
-	"axt", " [addr]", "find data/code references to this address",
+	"axt", " [?] [addr]", "find data/code references to this address",
 	"axf", " [addr]", "find data/code references from this address",
 	"axv", " [addr]", "list local variables read-write-exec references",
 	"ax.", " [addr]", "find data/code references from and to this address",
 	"axff[j]", " [addr]", "find data/code references from this function",
 	"axs", " addr [at]", "add string ref",
+	NULL
+};
+
+static const char *help_msg_axt[]= {
+	"Usage:", "ax[?gq*]", "find data/code references",
+	"axtj", " [addr]", "find data/code references to this address and print in json format",
+	"axtg", " [addr]", "display commands to generate graphs according to the xrefs",
+	"axtq", " [addr]", "find and list the data/code references in quiet mode",
+	"axt*", " [addr]", "set flags on the corresponding xrefs",
+	"axt?", " ","Show this help",
 	NULL
 };
 
@@ -7448,6 +7458,9 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 				pj_end (pj);
 				r_cons_println (pj_string (pj));
 				pj_free (pj);
+			}
+			else if (input[1] == '?') { // axt?
+				r_core_cmd_help (core, help_msg_axt);
 			}
 		}
 		r_list_free (list);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -735,7 +735,6 @@ static const char *help_msg_axt[]= {
 	"axtg", " [addr]", "display commands to generate graphs according to the xrefs",
 	"axtq", " [addr]", "find and list the data/code references in quiet mode",
 	"axt*", " [addr]", "same as axt, but prints as r2 commands",
-	"axt?", " ","Show this help",
 	NULL
 };
 
@@ -7300,6 +7299,10 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		cmd_afvx (core, NULL, input[1] == 'j');
 		break;
 	case 't': { // "axt"
+		if (input[1] == '?') { // axt?
+			r_core_cmd_help (core, help_msg_axt);
+			break;
+		}
 		RList *list = NULL;
 		RAnalFunction *fcn;
 		RAnalRef *ref;
@@ -7458,9 +7461,6 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 				pj_end (pj);
 				r_cons_println (pj_string (pj));
 				pj_free (pj);
-			}
-			else if (input[1] == '?') { // axt?
-				r_core_cmd_help (core, help_msg_axt);
 			}
 		}
 		r_list_free (list);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -730,7 +730,7 @@ static const char *help_msg_ax[] = {
 };
 
 static const char *help_msg_axt[]= {
-	"Usage:", "axt[?gq*]", "find data/code references",
+	"Usage:", "axt[?gq*]", "find data/code references to this address",
 	"axtj", " [addr]", "find data/code references to this address and print in json format",
 	"axtg", " [addr]", "display commands to generate graphs according to the xrefs",
 	"axtq", " [addr]", "find and list the data/code references in quiet mode",

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -720,7 +720,7 @@ static const char *help_msg_ax[] = {
 	"axj", "", "list refs in json format",
 	"axF", " [flg-glob]", "find data/code references of flags",
 	"axm", " addr [at]", "copy data/code references pointing to addr to also point to curseek (or at)",
-	"axt", " [?] [addr]", "find data/code references to this address",
+	"axt", "[?] [addr]", "find data/code references to this address",
 	"axf", " [addr]", "find data/code references from this address",
 	"axv", " [addr]", "list local variables read-write-exec references",
 	"ax.", " [addr]", "find data/code references from and to this address",
@@ -730,11 +730,11 @@ static const char *help_msg_ax[] = {
 };
 
 static const char *help_msg_axt[]= {
-	"Usage:", "ax[?gq*]", "find data/code references",
+	"Usage:", "axt[?gq*]", "find data/code references",
 	"axtj", " [addr]", "find data/code references to this address and print in json format",
 	"axtg", " [addr]", "display commands to generate graphs according to the xrefs",
 	"axtq", " [addr]", "find and list the data/code references in quiet mode",
-	"axt*", " [addr]", "set flags on the corresponding xrefs",
+	"axt*", " [addr]", "same as axt, but prints as r2 commands",
 	"axt?", " ","Show this help",
 	NULL
 };


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Add help for `axtj`, `axt*`, `axtq` and `axtg`

**Test plan**
Right now, `axt?` returns nothing. With this, `axt?` returns:
```
[0x00000100]> axt?
Usage: ax[?gq*]  find data/code references
| axtj [addr]  find data/code references to this address and print in json format
| axtg [addr]  display commands to generate graphs according to the xrefs
| axtq [addr]  find and list the data/code references in quiet mode
| axt* [addr]  set flags on the corresponding xrefs
| axt?         Show this help
```
For the radare2book, I had put a PR regarding this on [#263](https://github.com/radareorg/radare2book/pull/263)
- [ ] See whether the implementation is right and check what more is to be done.

**Closing issues**

None
