### PR TITLE
Don't disable (enable) mouse if mouse is already disabled (enabled)

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -473,6 +473,10 @@ R_API void r_cons_enable_highlight(const bool enable) {
 }
 
 R_API bool r_cons_enable_mouse(const bool enable) {
+	if ((I.mouse && enable)
+	    || (!I.mouse && !enable)) {
+		return I.mouse;
+	}
 #if __WINDOWS__
 	if (I.vtmode == 2) {
 #endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

On Windows Terminal, the escape sequences to disable mouse tracking is emitted even though the mouse is already disabled. This at least messes up test runs when `!radare2` is used. This pr prevents that.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `r2r -i db/tools/r2` under Windows Terminal.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
