### PR TITLE
Fix rabin2 -Pj and idpij (json PDB output format) ##bin

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -353,7 +353,7 @@ static int string_scan_range(RList *list, RBinFile *bf, int min,
 		pj_end (pj);
 		RIO *io = bin->iob.io;
 		if (io) {
-			io->cb_printf ("%s\n", pj_string (pj));
+			io->cb_printf ("%s", pj_string (pj));
 		}
 		pj_free (pj);
 	}

--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -1108,7 +1108,6 @@ static void print_types_json(const RPdb *pdb, PJ *pj, const RList *types) {
 
 	RListIter *it = r_list_iterator (types);
 
-	pj_o (pj);
 	pj_ka (pj, "types");
 
 	while (r_list_iter_next (it)) {
@@ -1214,7 +1213,6 @@ static void print_types_json(const RPdb *pdb, PJ *pj, const RList *types) {
 			break;
 		}
 	}
-	pj_end (pj);
 	pj_end (pj);
 }
 
@@ -1366,7 +1364,6 @@ static void print_gvars(RPdb *pdb, ut64 img_base, PJ *pj, int format) {
 	}
 
 	if (format == 'j') {
-		pj_o (pj);
 		pj_ka (pj, "gvars");
 	}
 	gsym_data_stream = (SGDATAStream *)gsym->stream;
@@ -1423,7 +1420,6 @@ static void print_gvars(RPdb *pdb, ut64 img_base, PJ *pj, int format) {
 		}
 	}
 	if (format == 'j') {
-		pj_end (pj);
 		pj_end (pj);
 	}
 }

--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -1107,6 +1107,8 @@ static void print_types_json(const RPdb *pdb, PJ *pj, const RList *types) {
 	r_return_if_fail (pdb && types && pj);
 
 	RListIter *it = r_list_iterator (types);
+
+	pj_o (pj);
 	pj_ka (pj, "types");
 
 	while (r_list_iter_next (it)) {
@@ -1212,6 +1214,7 @@ static void print_types_json(const RPdb *pdb, PJ *pj, const RList *types) {
 			break;
 		}
 	}
+	pj_end (pj);
 	pj_end (pj);
 }
 
@@ -1363,6 +1366,7 @@ static void print_gvars(RPdb *pdb, ut64 img_base, PJ *pj, int format) {
 	}
 
 	if (format == 'j') {
+		pj_o (pj);
 		pj_ka (pj, "gvars");
 	}
 	gsym_data_stream = (SGDATAStream *)gsym->stream;
@@ -1419,6 +1423,7 @@ static void print_gvars(RPdb *pdb, ut64 img_base, PJ *pj, int format) {
 		}
 	}
 	if (format == 'j') {
+		pj_end (pj);
 		pj_end (pj);
 	}
 }

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1270,12 +1270,15 @@ R_API bool r_core_pdb_info(RCore *core, const char *file, int mode) {
 		break;
 	}
 	PJ *pj = r_core_pj_new (core);
+	pj_a (pj);
 
 	pdb.print_types (&pdb, pj, mode);
 	pdb.print_gvars (&pdb, baddr, pj, mode);
 	// Save compound types into SDB
 	r_parse_pdb_types (core->anal, &pdb);
 	pdb.finish_pdb_parse (&pdb);
+
+	pj_end (pj);
 
 	if (mode == 'j') {
 		r_cons_printf ("%s\n", pj_string (pj));

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -456,6 +456,7 @@ static int cmd_info(void *data, const char *input) {
 	bool rdump = false;
 	int is_array = 0;
 	bool is_izzzj = false;
+	bool is_idpij = false;
 	Sdb *db;
 
 	for (i = 0; input[i] && input[i] != ' '; i++)
@@ -479,8 +480,11 @@ static int cmd_info(void *data, const char *input) {
 		if (!strncmp (input, "zzz", 3)) {
 			is_izzzj = true;
 		}
+		if (!strncmp(input, "dpi", 3)) {
+			is_idpij = true;
+		}
 	}
-	if (is_array && !is_izzzj) {
+	if (is_array && !is_izzzj && !is_idpij) {
 		r_cons_printf ("{");
 	}
 	if (!*input) {
@@ -1244,7 +1248,7 @@ static int cmd_info(void *data, const char *input) {
 		}
 	}
 done:
-	if (is_array && !is_izzzj) {
+	if (is_array && !is_izzzj && !is_idpij) {
 		r_cons_printf ("}\n");
 	} else if (newline) {
 		r_cons_newline ();

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -366,7 +366,7 @@ static void cmd_info_bin(RCore *core, int va, int mode) {
 			r_core_bin_info (core, R_CORE_BIN_ACC_INFO, mode, va, NULL, NULL);
 		}
 		if ((mode & R_MODE_JSON) && array == 0) {
-			r_cons_strcat ("}\n");
+			r_cons_print ("}");
 		}
 	} else {
 		eprintf ("No file selected\n");
@@ -603,7 +603,6 @@ static int cmd_info(void *data, const char *input) {
 				r_cons_print ("{");
 				r_bin_list_archs (core->bin, 'j');
 				r_cons_print ("}");
-				newline = true;
 			} else {
 				r_bin_list_archs (core->bin, 1);
 				newline = false;
@@ -663,7 +662,7 @@ static int cmd_info(void *data, const char *input) {
 						}
 					}
 					pj_end (pj);
-					r_cons_printf ("%s\n", pj_string (pj));
+					r_cons_print (pj_string (pj));
 					pj_free (pj);
 				} else { // "it"
 					if (!equal) {
@@ -925,9 +924,6 @@ static int cmd_info(void *data, const char *input) {
 			}
 			break;
 		case 'i': { // "ii"
-			if (input[1] == 'j') {
-				newline = true;
-			}
 			RBinObject *obj = r_bin_cur_object (core->bin);
 			RBININFO ("imports", R_CORE_BIN_ACC_IMPORTS, NULL,
 				(obj && obj->imports)? r_list_length (obj->imports): 0);
@@ -955,9 +951,6 @@ static int cmd_info(void *data, const char *input) {
 			break;
 		case 'V': // "iV"
 			RBININFO ("versioninfo", R_CORE_BIN_ACC_VERSIONINFO, NULL, 0);
-			if (input[1] == 'j') {
-				newline = true;
-			}
 			break;
 		case 'T': // "iT"
 		case 'C': // "iC" // rabin2 -C create // should be deprecated and just use iT (or find a better name)
@@ -1249,8 +1242,9 @@ static int cmd_info(void *data, const char *input) {
 	}
 done:
 	if (is_array && !is_izzzj && !is_idpij) {
-		r_cons_printf ("}\n");
-	} else if (newline) {
+		r_cons_printf ("}");
+	}
+	if (newline || mode == R_MODE_JSON) {
 		r_cons_newline ();
 	}
 redone:

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -197,6 +197,9 @@ static void cmd_open_bin(RCore *core, const char *input) {
 	case 'j': // "obj"
 	case '*': // "ob*"
 		r_core_bin_list (core, input[1]);
+		if (input[1] == 'j') {
+			r_cons_newline ();
+		}
 		break;
 	case '.': // "ob."
 		{

--- a/test/db/cmd/cmd_idp
+++ b/test/db/cmd/cmd_idp
@@ -25,3 +25,12 @@ EXPECT=<<EOF
 32
 EOF
 RUN
+
+NAME=idpij
+FILE=
+CMDS=idpij bins/pdb/minimal.pdb
+EXPECT=<<EOF
+[{"types":[{"type":"structure","name":"struct_typedef","size":7,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":1},{"member_type":"int32_t","member_name":"c","offset":3}]},{"type":"structure","name":"<unnamed-tag>","size":4,"members":[{"member_type":"char[4]","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":0}]},{"type":"structure","name":"unnamed_member_types_typedef","size":8,"members":[{"member_type":"union <unnamed-tag>","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":4}]},{"type":"structure","name":"bitfield_typedef","size":1,"members":[{"member_type":"bitfield uint8_t : 1","member_name":"a","offset":0},{"member_type":"bitfield uint8_t : 2","member_name":"b","offset":0},{"member_type":"bitfield uint8_t : 3","member_name":"c","offset":0}]},{"type":"structure","name":"union_typedef","size":4,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":0},{"member_type":"int32_t","member_name":"c","offset":0}]}]},{"gvars":[{"address":12292,"symtype":0,"section_name":".data","gdata_name":"_uninitialized_global"},{"address":12288,"symtype":0,"section_name":".data","gdata_name":"_initialized_global"},{"address":4096,"symtype":2,"section_name":".text","gdata_name":"_function"},{"address":4182,"symtype":2,"section_name":".text","gdata_name":"_mainCRTStartup"},{"address":4120,"symtype":2,"section_name":".text","gdata_name":"_main"}]}]
+EOF
+RUN
+

--- a/test/db/cmd/cmd_idp
+++ b/test/db/cmd/cmd_idp
@@ -28,9 +28,144 @@ RUN
 
 NAME=idpij
 FILE=
-CMDS=idpij bins/pdb/minimal.pdb
+CMDS=idpij bins/pdb/minimal.pdb~{}
 EXPECT=<<EOF
-[{"types":[{"type":"structure","name":"struct_typedef","size":7,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":1},{"member_type":"int32_t","member_name":"c","offset":3}]},{"type":"structure","name":"<unnamed-tag>","size":4,"members":[{"member_type":"char[4]","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":0}]},{"type":"structure","name":"unnamed_member_types_typedef","size":8,"members":[{"member_type":"union <unnamed-tag>","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":4}]},{"type":"structure","name":"bitfield_typedef","size":1,"members":[{"member_type":"bitfield uint8_t : 1","member_name":"a","offset":0},{"member_type":"bitfield uint8_t : 2","member_name":"b","offset":0},{"member_type":"bitfield uint8_t : 3","member_name":"c","offset":0}]},{"type":"structure","name":"union_typedef","size":4,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":0},{"member_type":"int32_t","member_name":"c","offset":0}]}]},{"gvars":[{"address":12292,"symtype":0,"section_name":".data","gdata_name":"_uninitialized_global"},{"address":12288,"symtype":0,"section_name":".data","gdata_name":"_initialized_global"},{"address":4096,"symtype":2,"section_name":".text","gdata_name":"_function"},{"address":4182,"symtype":2,"section_name":".text","gdata_name":"_mainCRTStartup"},{"address":4120,"symtype":2,"section_name":".text","gdata_name":"_main"}]}]
+{
+  "types": [
+    {
+      "type": "structure",
+      "name": "struct_typedef",
+      "size": 7,
+      "members": [
+        {
+          "member_type": "char",
+          "member_name": "a",
+          "offset": 0
+        },
+        {
+          "member_type": "uint16_t",
+          "member_name": "b",
+          "offset": 1
+        },
+        {
+          "member_type": "int32_t",
+          "member_name": "c",
+          "offset": 3
+        }
+      ]
+    },
+    {
+      "type": "structure",
+      "name": "<unnamed-tag>",
+      "size": 4,
+      "members": [
+        {
+          "member_type": "char[4]",
+          "member_name": "a",
+          "offset": 0
+        },
+        {
+          "member_type": "int32_t",
+          "member_name": "b",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "type": "structure",
+      "name": "unnamed_member_types_typedef",
+      "size": 8,
+      "members": [
+        {
+          "member_type": "union <unnamed-tag>",
+          "member_name": "a",
+          "offset": 0
+        },
+        {
+          "member_type": "int32_t",
+          "member_name": "b",
+          "offset": 4
+        }
+      ]
+    },
+    {
+      "type": "structure",
+      "name": "bitfield_typedef",
+      "size": 1,
+      "members": [
+        {
+          "member_type": "bitfield uint8_t : 1",
+          "member_name": "a",
+          "offset": 0
+        },
+        {
+          "member_type": "bitfield uint8_t : 2",
+          "member_name": "b",
+          "offset": 0
+        },
+        {
+          "member_type": "bitfield uint8_t : 3",
+          "member_name": "c",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "type": "structure",
+      "name": "union_typedef",
+      "size": 4,
+      "members": [
+        {
+          "member_type": "char",
+          "member_name": "a",
+          "offset": 0
+        },
+        {
+          "member_type": "uint16_t",
+          "member_name": "b",
+          "offset": 0
+        },
+        {
+          "member_type": "int32_t",
+          "member_name": "c",
+          "offset": 0
+        }
+      ]
+    }
+  ],
+  "gvars": [
+    {
+      "address": 12292,
+      "symtype": 0,
+      "section_name": ".data",
+      "gdata_name": "_uninitialized_global"
+    },
+    {
+      "address": 12288,
+      "symtype": 0,
+      "section_name": ".data",
+      "gdata_name": "_initialized_global"
+    },
+    {
+      "address": 4096,
+      "symtype": 2,
+      "section_name": ".text",
+      "gdata_name": "_function"
+    },
+    {
+      "address": 4182,
+      "symtype": 2,
+      "section_name": ".text",
+      "gdata_name": "_mainCRTStartup"
+    },
+    {
+      "address": 4120,
+      "symtype": 2,
+      "section_name": ".text",
+      "gdata_name": "_main"
+    }
+  ]
+}
 EOF
 RUN
 

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -1061,6 +1061,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rabin2 -Pj
+FILE=bins/pdb/minimal.pdb
+CMDS=!rabin2 -Pj ${R2_FILE}
+EXPECT=<<EOF
+{"pdb":[{"types":[{"type":"structure","name":"struct_typedef","size":7,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":1},{"member_type":"int32_t","member_name":"c","offset":3}]},{"type":"structure","name":"<unnamed-tag>","size":4,"members":[{"member_type":"char[4]","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":0}]},{"type":"structure","name":"unnamed_member_types_typedef","size":8,"members":[{"member_type":"union <unnamed-tag>","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":4}]},{"type":"structure","name":"bitfield_typedef","size":1,"members":[{"member_type":"bitfield uint8_t : 1","member_name":"a","offset":0},{"member_type":"bitfield uint8_t : 2","member_name":"b","offset":0},{"member_type":"bitfield uint8_t : 3","member_name":"c","offset":0}]},{"type":"structure","name":"union_typedef","size":4,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":0},{"member_type":"int32_t","member_name":"c","offset":0}]}]},{"gvars":[{"address":12292,"symtype":0,"section_name":".data","gdata_name":"_uninitialized_global"},{"address":12288,"symtype":0,"section_name":".data","gdata_name":"_initialized_global"},{"address":4096,"symtype":2,"section_name":".text","gdata_name":"_function"},{"address":4182,"symtype":2,"section_name":".text","gdata_name":"_mainCRTStartup"},{"address":4120,"symtype":2,"section_name":".text","gdata_name":"_main"}]}]
+}
+EOF
+RUN
+
 NAME=rabin2 -S ""
 FILE=-
 CMDS=!rabin2 -S ""

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -1063,9 +1063,145 @@ RUN
 
 NAME=rabin2 -Pj
 FILE=bins/pdb/minimal.pdb
-CMDS=!rabin2 -Pj ${R2_FILE}
+CMDS=!!rabin2 -Pj ${R2_FILE}~{}
 EXPECT=<<EOF
-{"pdb":[{"types":[{"type":"structure","name":"struct_typedef","size":7,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":1},{"member_type":"int32_t","member_name":"c","offset":3}]},{"type":"structure","name":"<unnamed-tag>","size":4,"members":[{"member_type":"char[4]","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":0}]},{"type":"structure","name":"unnamed_member_types_typedef","size":8,"members":[{"member_type":"union <unnamed-tag>","member_name":"a","offset":0},{"member_type":"int32_t","member_name":"b","offset":4}]},{"type":"structure","name":"bitfield_typedef","size":1,"members":[{"member_type":"bitfield uint8_t : 1","member_name":"a","offset":0},{"member_type":"bitfield uint8_t : 2","member_name":"b","offset":0},{"member_type":"bitfield uint8_t : 3","member_name":"c","offset":0}]},{"type":"structure","name":"union_typedef","size":4,"members":[{"member_type":"char","member_name":"a","offset":0},{"member_type":"uint16_t","member_name":"b","offset":0},{"member_type":"int32_t","member_name":"c","offset":0}]}]},{"gvars":[{"address":12292,"symtype":0,"section_name":".data","gdata_name":"_uninitialized_global"},{"address":12288,"symtype":0,"section_name":".data","gdata_name":"_initialized_global"},{"address":4096,"symtype":2,"section_name":".text","gdata_name":"_function"},{"address":4182,"symtype":2,"section_name":".text","gdata_name":"_mainCRTStartup"},{"address":4120,"symtype":2,"section_name":".text","gdata_name":"_main"}]}]
+{
+  "pdb": {
+    "types": [
+      {
+        "type": "structure",
+        "name": "struct_typedef",
+        "size": 7,
+        "members": [
+          {
+            "member_type": "char",
+            "member_name": "a",
+            "offset": 0
+          },
+          {
+            "member_type": "uint16_t",
+            "member_name": "b",
+            "offset": 1
+          },
+          {
+            "member_type": "int32_t",
+            "member_name": "c",
+            "offset": 3
+          }
+        ]
+      },
+      {
+        "type": "structure",
+        "name": "<unnamed-tag>",
+        "size": 4,
+        "members": [
+          {
+            "member_type": "char[4]",
+            "member_name": "a",
+            "offset": 0
+          },
+          {
+            "member_type": "int32_t",
+            "member_name": "b",
+            "offset": 0
+          }
+        ]
+      },
+      {
+        "type": "structure",
+        "name": "unnamed_member_types_typedef",
+        "size": 8,
+        "members": [
+          {
+            "member_type": "union <unnamed-tag>",
+            "member_name": "a",
+            "offset": 0
+          },
+          {
+            "member_type": "int32_t",
+            "member_name": "b",
+            "offset": 4
+          }
+        ]
+      },
+      {
+        "type": "structure",
+        "name": "bitfield_typedef",
+        "size": 1,
+        "members": [
+          {
+            "member_type": "bitfield uint8_t : 1",
+            "member_name": "a",
+            "offset": 0
+          },
+          {
+            "member_type": "bitfield uint8_t : 2",
+            "member_name": "b",
+            "offset": 0
+          },
+          {
+            "member_type": "bitfield uint8_t : 3",
+            "member_name": "c",
+            "offset": 0
+          }
+        ]
+      },
+      {
+        "type": "structure",
+        "name": "union_typedef",
+        "size": 4,
+        "members": [
+          {
+            "member_type": "char",
+            "member_name": "a",
+            "offset": 0
+          },
+          {
+            "member_type": "uint16_t",
+            "member_name": "b",
+            "offset": 0
+          },
+          {
+            "member_type": "int32_t",
+            "member_name": "c",
+            "offset": 0
+          }
+        ]
+      }
+    ],
+    "gvars": [
+      {
+        "address": 12292,
+        "symtype": 0,
+        "section_name": ".data",
+        "gdata_name": "_uninitialized_global"
+      },
+      {
+        "address": 12288,
+        "symtype": 0,
+        "section_name": ".data",
+        "gdata_name": "_initialized_global"
+      },
+      {
+        "address": 4096,
+        "symtype": 2,
+        "section_name": ".text",
+        "gdata_name": "_function"
+      },
+      {
+        "address": 4182,
+        "symtype": 2,
+        "section_name": ".text",
+        "gdata_name": "_mainCRTStartup"
+      },
+      {
+        "address": 4120,
+        "symtype": 2,
+        "section_name": ".text",
+        "gdata_name": "_main"
+      }
+    ]
+  }
 }
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The information packed in the `pdb` field of the json, such as the `types` and `gvars` should be objects inside an array but, with recent changes in the json/pdb area, those were ommited.
The result was an invalid json when calling, for example `rabin2 -Pj some.pdb > some.pdb.json` or `idpij` in the radare shell.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

On the master branch, the issue can be reproduced as follows:
```
$ rabin2 -Pj ntdll.pdb | jq . 1>/dev/null
parse error: ':' not as part of an object at line 1, column 15
```
Also, the issue can easily be seen by inspecting the first items in the resulting json ( the missing `[{` before the `"types"` array):
```
{"pdb":"types":[{"type":"structure","name"
```

With the following fix, the resulting json is valid:
```
$ rabin2 -Pj ntdll.pdb | jq . 1>/dev/null ; echo $?
0
```
Also, it can be seen in the json as well:
```
{"pdb":[{"types":[{"type":"structure",
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

