### PR TITLE
Remove warning about extra tokens after #endif

### DIFF
--- a/libr/anal/base_types.h
+++ b/libr/anal/base_types.h
@@ -14,4 +14,4 @@ R_IPI void union_type_member_free(void *e, void *user);
 #ifdef __cplusplus
 }
 #endif
-#endif // R_BASE_TYPES_H
+#endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Remove tokens after #endif to remove warnings as shown here #17384
