### PR TITLE
Fix malformed DWARF crash due invalid .debug_str reference ##bin

### DIFF
--- a/libr/anal/type_dwarf.c
+++ b/libr/anal/type_dwarf.c
@@ -139,7 +139,7 @@ static char *get_die_name(const RBinDwarfDie *die) {
 	char *name = NULL;
 	st32 name_attr_idx = find_attr_idx (die, DW_AT_name);
 
-	if (name_attr_idx != -1) {
+	if (name_attr_idx != -1 && die->attr_values[name_attr_idx].string.content) {
 		name = strdup (die->attr_values[name_attr_idx].string.content);
 	} else {
 		name = create_type_name_from_offset (die->offset);
@@ -367,7 +367,11 @@ static RAnalStructMember *parse_struct_member (const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			name = strdup (value->string.content);
+			if (!value->string.content) {
+				name = create_type_name_from_offset (die->offset);
+			} else {
+				name = strdup (value->string.content);
+			}
 			if (!name) {
 				goto cleanup;
 			}
@@ -447,7 +451,11 @@ static RAnalEnumCase *parse_enumerator(const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			name = strdup (value->string.content);
+			if (!value->string.content) {
+				name = create_type_name_from_offset (die->offset);
+			} else {
+				name = strdup (value->string.content);
+			}
 			if (!name) {
 				goto cleanup;
 			}
@@ -654,7 +662,11 @@ static void parse_typedef(const RAnal *anal, const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			name = strdup (value->string.content);
+			if (!value->string.content) {
+				name = create_type_name_from_offset (die->offset);
+			} else {
+				name = strdup (value->string.content);
+			}
 			if (!name) {
 				goto cleanup;
 			}
@@ -703,7 +715,11 @@ static void parse_atomic_type(const RAnal *anal, const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			name = strdup (value->string.content);
+			if (!value->string.content) {
+				name = create_type_name_from_offset (die->offset);
+			} else {
+				name = strdup (value->string.content);
+			}
 			if (!name) {
 				return;
 			}

--- a/libr/anal/type_dwarf.c
+++ b/libr/anal/type_dwarf.c
@@ -117,7 +117,7 @@ static bool strbuf_rev_append_char(RStrBuf *sb, const char *s, const char *needl
 }
 
 /**
- * @brief Create a type name from offset
+ * @brief Create a type name from it's unique offset
  * 
  * @param offset 
  * @return char* Name or NULL if error
@@ -130,10 +130,10 @@ static char *create_type_name_from_offset(ut64 offset) {
 }
 
 /**
- * @brief Get the DIE name
+ * @brief Get the DIE name or create unique one from it's offset
  * 
  * @param die 
- * @return char* DIEs name or NULL if not found
+ * @return char* DIEs name or NULL if error
  */
 static char *get_die_name(const RBinDwarfDie *die) {
 	char *name = NULL;
@@ -367,11 +367,7 @@ static RAnalStructMember *parse_struct_member (const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			if (!value->string.content) {
-				name = create_type_name_from_offset (die->offset);
-			} else {
-				name = strdup (value->string.content);
-			}
+			name = get_die_name (die);
 			if (!name) {
 				goto cleanup;
 			}
@@ -451,11 +447,7 @@ static RAnalEnumCase *parse_enumerator(const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			if (!value->string.content) {
-				name = create_type_name_from_offset (die->offset);
-			} else {
-				name = strdup (value->string.content);
-			}
+			name = get_die_name (die);
 			if (!name) {
 				goto cleanup;
 			}
@@ -662,11 +654,7 @@ static void parse_typedef(const RAnal *anal, const RBinDwarfDie *all_dies,
 		RBinDwarfAttrValue *value = &die->attr_values[i];
 		switch (die->attr_values[i].attr_name) {
 		case DW_AT_name:
-			if (!value->string.content) {
-				name = create_type_name_from_offset (die->offset);
-			} else {
-				name = strdup (value->string.content);
-			}
+			name = get_die_name (die);
 			if (!name) {
 				goto cleanup;
 			}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1651,7 +1651,7 @@ static const ut8 *parse_attr_value(const ut8 *obuf, int obuf_len,
 			value->string.content =
 				strdup ((const char *)(debug_str + value->string.offset));
 		} else {
-			value->string.content = NULL;
+			value->string.content = NULL; // Means malformed DWARF, should we print error message?
 		}
 		break;
 	// offset in .debug_info


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix for #17383 

In case the string pointer into debug_str isn't valid, the string can be NULL which wasn't accounted for in the future type parsing, I've added the handling for this situation.