### PR TITLE
Append missing loongson 2e/2f entries in mips-dis.c and mybfd.h

### DIFF
--- a/libr/asm/arch/include/mybfd.h
+++ b/libr/asm/arch/include/mybfd.h
@@ -1791,6 +1791,8 @@ enum bfd_architecture
 #define bfd_mach_mips12000             12000
 #define bfd_mach_mips16                16
 #define bfd_mach_mips5                 5
+#define bfd_mach_mips_loongson_2e      3001
+#define bfd_mach_mips_loongson_2f      3002
 #define bfd_mach_mips_sb1              12310201 /* octal 'SB', 01 */
 #define bfd_mach_mipsisa32             32
 #define bfd_mach_mipsisa32r2           33

--- a/libr/asm/arch/mips/gnu/mips-dis.c
+++ b/libr/asm/arch/mips/gnu/mips-dis.c
@@ -430,6 +430,16 @@ const struct mips_arch_choice mips_arch_choices[] =
     mips_cp0sel_names_sb1, ARRAY_SIZE (mips_cp0sel_names_sb1),
     mips_hwr_names_numeric },
 
+  { "loongson2e", 1, bfd_mach_mips_loongson_2e, CPU_LOONGSON_2E,
+    ISA_MIPS3 | INSN_LOONGSON_2E, 
+    mips_cp0_names_numeric, 
+    NULL, 0, mips_hwr_names_numeric },
+
+  { "loongson2f", 1, bfd_mach_mips_loongson_2f, CPU_LOONGSON_2F,
+    ISA_MIPS64 | INSN_LOONGSON_2F, 
+    mips_cp0_names_numeric,
+    NULL, 0, mips_hwr_names_numeric },
+
   /* This entry, mips16, is here only for ISA/processor selection; do
      not print its name.  */
   { "",		1, bfd_mach_mips16, CPU_MIPS16, ISA_MIPS3 | INSN_MIPS16,


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Just add some missing entries inside mybfd.h and mips-dis.c from latest source code of binutils, for loongson MIPS processor support. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
