### PR TITLE
 fix mips.gnu failed to disassemble privileged instructions by default

### DIFF
--- a/libr/asm/arch/mips/gnu/mips-dis.c
+++ b/libr/asm/arch/mips/gnu/mips-dis.c
@@ -533,8 +533,8 @@ set_default_mips_dis_options (struct disassemble_info *info)
 
   /* Defaults: mipsIII/r3000 (?!), (o)32-style ("oldabi") GPR names,
      and numeric FPR, CP0 register, and HWR names.  */
-  mips_isa = ISA_MIPS3;
-  mips_processor = CPU_LOONGSON_2F; // R3000
+  mips_isa = ISA_MIPS32;
+  mips_processor = CPU_MIPS32; 
   mips_gpr_names = mips_gpr_names_oldabi;
   mips_fpr_names = mips_fpr_names_numeric;
   mips_cp0_names = mips_cp0_names_numeric;

--- a/libr/asm/p/asm_mips_gnu.c
+++ b/libr/asm/p/asm_mips_gnu.c
@@ -46,7 +46,7 @@ static int disassemble(struct r_asm_t *a, struct r_asm_op_t *op, const ut8 *buf,
 	/* prepare disassembler */
 	memset (&disasm_obj,'\0', sizeof (struct disassemble_info));
 	mips_mode = a->bits;
-	disasm_obj.arch = CPU_LOONGSON_2F;
+	disasm_obj.arch = CPU_MIPS32;
 	disasm_obj.buffer = bytes;
 	disasm_obj.read_memory_func = &mips_buffer_read_memory;
 	disasm_obj.symbol_at_address_func = &symbol_at_address;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

ISA_MIPS3 is too old to fail the disassembly of common I32 instructions

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
