### PR TITLE
Fix move based on uninitialized value in rtti_itanium ##anal

### DIFF
--- a/libr/anal/rtti_itanium.c
+++ b/libr/anal/rtti_itanium.c
@@ -564,10 +564,7 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 		return;
 	}
 
-	RAnalVTable vtable;
-	vtable.id = NULL;
-	vtable.offset = 0;
-	vtable.addr = vtable_info->saddr;
+	RAnalVTable vtable = { .id = NULL, .offset = 0, .size = 0, .addr = vtable_info->saddr};
 	r_anal_class_vtable_set (context->anal, class_name, &vtable);
 	r_anal_class_vtable_fini (&vtable);
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

While running valgrind during `aaaa` command I've noticed that valgrind complains:
```
==65046== Conditional jump or move depends on uninitialised value(s)
==65046==    at 0x4A4082D: _itoa_word (_itoa.c:179)
==65046==    by 0x4A5C6F4: __vfprintf_internal (vfprintf-internal.c:1687)
==65046==    by 0x4A71119: __vsnprintf_internal (vsnprintf.c:114)
==65046==    by 0x494DA56: sdb_fmt (fmt.c:33)
==65046==    by 0x62D29AD: r_anal_class_vtable_set (class.c:871)
==65046==    by 0x630A93D: recovery_apply_vtable (rtti_itanium.c:571)
==65046==    by 0x630AA7A: r_anal_rtti_itanium_recover_all (rtti_itanium.c:595)
==65046==    by 0x63065FF: r_anal_rtti_recover_all (rtti.c:94)
==65046==    by 0x5ACBC20: cmd_anal_rtti (cmd_anal.c:9538)
==65046==    by 0x5ACBD0D: cmd_anal_virtual_functions (cmd_anal.c:9564)
==65046==    by 0x5ACDB0D: cmd_anal (cmd_anal.c:10205)
==65046==    by 0x5B86406: r_cmd_call (cmd_api.c:329)
```
This was due to the uninitialised Vtable size member