### PR TITLE
Add base class information from RTTI into anal classes ##anal

### DIFF
--- a/libr/anal/rtti_itanium.c
+++ b/libr/anal/rtti_itanium.c
@@ -582,8 +582,12 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 	}
 }
 
-static char *read_rtti_name();
-
+/**
+ * @brief Add any base class information about the type into anal/classes
+ * 
+ * @param context 
+ * @param cti 
+ */
 static void add_class_bases(RVTableContext *context, const class_type_info *cti) {
 	class_type_info base_info;
 

--- a/libr/anal/rtti_itanium.c
+++ b/libr/anal/rtti_itanium.c
@@ -582,18 +582,71 @@ static void recovery_apply_vtable(RVTableContext *context, const char *class_nam
 	}
 }
 
+static char *read_rtti_name();
+
+static void add_class_bases(RVTableContext *context, const class_type_info *cti) {
+	class_type_info base_info;
+
+	switch (cti->type) {
+	case R_TYPEINFO_TYPE_SI_CLASS: {
+		si_class_type_info *si_class = (void *)cti;
+		ut64 base_addr = si_class->base_class_addr;
+		base_addr += VT_WORD_SIZE (context); // offset to name
+		if (rtti_itanium_read_type_name (context, base_addr, &base_info)) {
+			// TODO in future, store the RTTI offset from vtable and use it
+			RAnalBaseClass base = { .class_name = base_info.name, .offset = 0 };
+			r_anal_class_base_set (context->anal, cti->name, &base);
+			r_anal_class_base_fini (&base);
+		}
+	} break;
+	case R_TYPEINFO_TYPE_VMI_CLASS: {
+		vmi_class_type_info *vmi_class = (void *)cti;
+		for (int i = 0; i < vmi_class->vmi_base_count; i++) {
+			base_class_type_info *base_class_info = vmi_class->vmi_bases + i;
+			ut64 base_addr = base_class_info->base_class_addr + VT_WORD_SIZE (context); // offset to name
+			if (rtti_itanium_read_type_name (context, base_addr, &base_info)) {
+				// TODO in future, store the RTTI offset from vtable and use it
+				RAnalBaseClass base = { .class_name = base_info.name, .offset = 0 };
+				r_anal_class_base_set (context->anal, cti->name, &base);
+				r_anal_class_base_fini (&base);
+			}
+		}
+	} break;
+	}
+}
+
 R_API void r_anal_rtti_itanium_recover_all(RVTableContext *context, RList *vtables) {
-	RListIter *vtableIter;
+	RList /*<class_type_info>*/ *rtti_list = r_list_new ();
+	rtti_list->free = rtti_itanium_type_info_free;
+	// to escape multiple same infos from multiple inheritance
+	SetU *unique_rttis = set_u_new ();
+
+	RListIter *iter;
 	RVTableInfo *vtable;
-	r_list_foreach (vtables, vtableIter, vtable) {
+	r_list_foreach (vtables, iter, vtable) {
 		class_type_info *cti = rtti_itanium_type_info_new (context, vtable->saddr);
 		if (!cti) {
 			continue;
 		}
 
 		r_anal_class_create (context->anal, cti->name);
+		// can't we name virtual functions virtual even without RTTI?
 		recovery_apply_vtable (context, cti->name, vtable);
 
-		rtti_itanium_type_info_free (cti);
+		// we only need one of a kind
+		if (set_u_contains (unique_rttis, cti->typeinfo_addr)) {
+			rtti_itanium_type_info_free (cti);
+		} else {
+			set_u_add (unique_rttis, cti->typeinfo_addr);
+			r_list_append (rtti_list, cti);
+		}
 	}
+
+	class_type_info *cti;
+	r_list_foreach (rtti_list, iter, cti) {
+		add_class_bases (context, cti);
+	}
+
+	set_u_free (unique_rttis);
+	r_list_free (rtti_list);
 }

--- a/test/db/anal/classes
+++ b/test/db/anal/classes
@@ -34,7 +34,7 @@ EXPECT=<<EOF
 A
 B
 C
-D
+D: B, C
   virtual_0 @ 0xa235 (vtable + 0x0)
   virtual_4 @ 0xa24f (vtable + 0x4)
   virtual_8 @ 0xa269 (vtable + 0x8)
@@ -73,7 +73,7 @@ EXPECT=<<EOF
 A
 B
 C
-D
+D: B, C
   virtual_0 @ 0x100005f1c (vtable + 0x0)
   virtual_8 @ 0x100005f44 (vtable + 0x8)
   virtual_16 @ 0x100005f6c (vtable + 0x10)
@@ -112,7 +112,7 @@ EXPECT=<<EOF
 A
 B
 C
-D
+D: B, C
   virtual_0 @ 0x100005f50 (vtable + 0x0)
   virtual_8 @ 0x100005f7c (vtable + 0x8)
   virtual_16 @ 0x100005fa8 (vtable + 0x10)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
We have RTTI parsed, but we are not using any information about base classes, this PR adds information about the bases from the RTTIs

example:
```
// before
[0x00400a20]> avrr
[0x00400a20]> acl
Bat
Bird
Cat
Dog
Kappa
Mammal

// after
[0x00400a20]> avrr
[0x00400a20]> acl
Bat: Bird, Mammal
Bird
Cat: Mammal
Dog: Cat
Kappa: Cat
Mammal
```