### PR TITLE
r2pm: Don't clone while cleaning

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -317,9 +317,7 @@ R2PM_DOC() {
 }
 
 R2PM_GIT() {
-	if [ -z "${NAME}" ] || [ "$ACTION" = clean ]; then
-		return
-	fi
+	[ -z "${NAME}" -o "$ACTION" = clean ] && return
 	URL="$1"
 	if [ -z "$2" ]; then
 		DIR="`basename $1`"

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -317,7 +317,9 @@ R2PM_DOC() {
 }
 
 R2PM_GIT() {
-	[ -z "${NAME}" ] && return
+	if [ -z "${NAME}" ] || [ "$ACTION" = clean ]; then
+		return
+	fi
 	URL="$1"
 	if [ -z "$2" ]; then
 		DIR="`basename $1`"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr prevents a `git clone` due to R2PM_GIT while cleaning. This is especially bad when doing `r2pm -ci` on a fresh install (and a cleanable package) because the package repo is cloned twice.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Eyeball `r2pm -ci`.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
