### PR TITLE
r2pm: Allow package script to declare cleaning is done

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -573,25 +573,26 @@ case "$1" in
 			if [ -f "${FILE}" ]; then
 				NAME="$2"
 				ACTION=clean
-				DONE=0
 				export PATH="${R2PM_HOMEBINDIR}:${PATH}"
 				. "${FILE}"
+				SKIP_GITCLEAN=$?
 				echo $FILE TGZ=$R2PM_TGZ
-				[ "${DONE}" = 1 ] && exit 0
 			else
 				echo "Cannot find $FILE"
 				RC=1
 			fi
 
-			if [ -d "${R2PM_GITDIR}/$2" ]; then
-				echo "Cleaning up ${R2PM_GITDIR}/$2..."
-				rm -rf "${R2PM_GITDIR}/$2"
-			elif [ -d "${R2PM_GITDIR}/$2.git" ]; then
-				echo "Cleaning up ${R2PM_GITDIR}/$2.git..."
-				rm -rf "${R2PM_GITDIR}/$2.git"
-			else
-				echo "Cannot find $2 or $2.git in ${R2PM_GITDIR}"
-				RC=1
+			if [ "${SKIP_GITCLEAN}" = 0 ]; then
+				if [ -d "${R2PM_GITDIR}/$2" ]; then
+					echo "Cleaning up ${R2PM_GITDIR}/$2..."
+					rm -rf "${R2PM_GITDIR}/$2"
+				elif [ -d "${R2PM_GITDIR}/$2.git" ]; then
+					echo "Cleaning up ${R2PM_GITDIR}/$2.git..."
+					rm -rf "${R2PM_GITDIR}/$2.git"
+				else
+					echo "Cannot find $2 or $2.git in ${R2PM_GITDIR}"
+					RC=1
+				fi
 			fi
 			shift
 		done

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -573,9 +573,11 @@ case "$1" in
 			if [ -f "${FILE}" ]; then
 				NAME="$2"
 				ACTION=clean
+				DONE=0
 				export PATH="${R2PM_HOMEBINDIR}:${PATH}"
 				. "${FILE}"
 				echo $FILE TGZ=$R2PM_TGZ
+				[ "${DONE}" = 1 ] && exit 0
 			else
 				echo "Cannot find $FILE"
 				RC=1

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -570,19 +570,19 @@ case "$1" in
 		while [ -n "$2" ]; do
 			echo "Cleaning $2..."
 			FILE="$(pkgFilePath "$2")"
+			R2PM_CLEAN_GITDIR=1
 			if [ -f "${FILE}" ]; then
 				NAME="$2"
 				ACTION=clean
 				export PATH="${R2PM_HOMEBINDIR}:${PATH}"
 				. "${FILE}"
-				SKIP_GITCLEAN=$?
 				echo $FILE TGZ=$R2PM_TGZ
 			else
 				echo "Cannot find $FILE"
 				RC=1
 			fi
 
-			if [ "${SKIP_GITCLEAN}" = 0 ]; then
+			if [ "${R2PM_CLEAN_GITDIR}" = 1 ]; then
 				if [ -d "${R2PM_GITDIR}/$2" ]; then
 					echo "Cleaning up ${R2PM_GITDIR}/$2..."
 					rm -rf "${R2PM_GITDIR}/$2"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr allows r2pm package scripts to do their own cleaning of their git dir.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add the following to the r2dec package script before R2PM_END:

```sh
if [ "$ACTION" = clean ]; then
	rm -rf "${R2PM_GITDIR}/r2dec-js"
	DONE=1
fi
```

and then run `r2pm -ci r2dec`. There should be no error message stating that the r2dec git dir cannot be found.

This is currently necessary for cleaning because the git dirname (`r2dec-js`) is hardcoded in the r2dec source.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
