### PR TITLE
mkstemps() is available only since glibc 2.19

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1093,7 +1093,19 @@ err_r_file_mkstemp:
 	char *name = r_str_newf ("%s/r2.%s.XXXXXX%s", path, prefix, suffix);
 	mode_t mask = umask (S_IWGRP | S_IWOTH);
 	if (suffix && *suffix) {
+#if defined(__GLIBC__) && defined(__GLIBC_MINOR__) && 2 <= __GLIBC__ && 19 <= __GLIBC__MINOR__
 		h = mkstemps (name, strlen (suffix));
+#else
+		char *const xpos = strrchr (name, 'X');
+		const char c = (char)(NULL != xpos ? *(xpos + 1) : 0);
+		if (0 != c) {
+			xpos[1] = 0;
+			h = mkstemp (name);
+			xpos[1] = c;
+		} else {
+			h = -1;
+		}
+#endif
 	} else {
 		h = mkstemp (name);
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`mkstemps()` was added only in GLIBC > 2.19, see https://man7.org/linux/man-pages/man3/mkstemp.3.html
To support earlier version it should be emulated manually

**Test plan**

It should build with Debian Lenny: https://github.com/XVilka/debian-oldies/tree/master/lenny

Just run "./build" there for the Docker container to build radare2


