### PR TITLE
Add missing `PTRACE_GETSIGINFO` for old glibc

### DIFF
--- a/libr/io/p/io_ptrace.c
+++ b/libr/io/p/io_ptrace.c
@@ -31,6 +31,15 @@ static void open_pidmem (RIOPtrace *iop);
 extern int errno;
 #endif
 
+// PTRACE_GETSIGINFO is defined only since glibc 2.4 but appeared much
+// earlier in linux kernel - since 2.3.99-pre6
+// So we define it manually
+#if __linux__ && defined(__GLIBC__)
+#ifndef PTRACE_GETSIGINFO
+#define PTRACE_GETSIGINFO 0x4202
+#endif
+#endif
+
 #if 0
 procpidmem is buggy.. running this sometimes results in ffff
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

[Debian Etch](https://wiki.debian.org/DebianEtch) has old glibc (2.2.3 for example) that doesn't define `PTRACE_GETSIGINFO`, but Linux kernel already supports this value - it appeared in linux-2.3.99-pre6 while Etch has linux-2.6.18.

I skimmed through history and it seems value didn't change since - it's `0x4202` for all this time. Thus, we define it manually for these older distributions.

**Test plan**

It should build with Debian Etch: https://github.com/XVilka/debian-oldies/tree/master/etch

Just run "./build" there for the Docker container to build radare2
