### PR TITLE
Use floating point for coverage percent calculation.

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -8785,7 +8785,7 @@ static void r_core_anal_info (RCore *core, const char *input) {
 	int covr = compute_coverage (core);
 	int call = compute_calls (core);
 	int xrfs = r_anal_xrefs_count (core->anal);
-	int cvpc = (code > 0)? (covr * 100 / code): 0;
+	int cvpc = (code > 0)? (covr * 100.0 / code): 0;
 	if (*input == 'j') {
 		PJ *pj = pj_new ();
 		if (!pj) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Use floating point during coverage percentage calculation to avoid overflow. 
Triggering the problem requires analyzing quite large executable so I don't it's practical to have automated test for it.

**Test plan**

Tested using blender executable (82MB) from ArchLinux repository.

* `aa`
* `aaij`


Before
```
[0x00d00560]> aaij
{"fcns":89083,"xrefs":1053522,"calls":588786,"strings":1348,"symbols":84802,"imports":1842,"covrage":35230923,"codesz":69489608,"percent":-11}
```
After
```
[0x00d00560]> aaij
{"fcns":89083,"xrefs":1053522,"calls":588786,"strings":1348,"symbols":84802,"imports":1842,"covrage":35230923,"codesz":69489608,"percent":50}
```

**Closing issues**
Closes #17385 