### PR TITLE
r2pm: R2PM_CLEAN_GITDIR states (sub)dir to clean

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -98,7 +98,7 @@ R2PM_ETCD="${R2CONFIGHOME}/radare2rc.d"
 
 # TODO. support system plugin installs R2PM_PLUGDIR="${R2PM_SYSLIBDIR}/radare2/last"
 if [ -z "${R2PM_GITDIR}" ]; then
-	R2PM_GITDIR="${R2PM_USRDIR}/git/"
+	R2PM_GITDIR="${R2PM_USRDIR}/git"
 fi
 if [ -z "${R2PM_DBDIR}" ]; then
 	if [ -d "${R2DATAHOME}/r2pm/db" ]; then
@@ -570,7 +570,6 @@ case "$1" in
 		while [ -n "$2" ]; do
 			echo "Cleaning $2..."
 			FILE="$(pkgFilePath "$2")"
-			R2PM_CLEAN_GITDIR=1
 			if [ -f "${FILE}" ]; then
 				NAME="$2"
 				ACTION=clean
@@ -582,17 +581,13 @@ case "$1" in
 				RC=1
 			fi
 
-			if [ "${R2PM_CLEAN_GITDIR}" = 1 ]; then
-				if [ -d "${R2PM_GITDIR}/$2" ]; then
-					echo "Cleaning up ${R2PM_GITDIR}/$2..."
-					rm -rf "${R2PM_GITDIR}/$2"
-				elif [ -d "${R2PM_GITDIR}/$2.git" ]; then
-					echo "Cleaning up ${R2PM_GITDIR}/$2.git..."
-					rm -rf "${R2PM_GITDIR}/$2.git"
-				else
-					echo "Cannot find $2 or $2.git in ${R2PM_GITDIR}"
-					RC=1
-				fi
+			[ -z "${R2PM_CLEAN_GITDIR}" ] && R2PM_CLEAN_GITDIR="$2"
+			if [ -d "${R2PM_GITDIR}/${R2PM_CLEAN_GITDIR}" ]; then
+				echo "Cleaning up ${R2PM_GITDIR}/${R2PM_CLEAN_GITDIR}..."
+				rm -rf "${R2PM_GITDIR}/${R2PM_CLEAN_GITDIR}"
+			else
+				echo "Cannot find ${R2PM_CLEAN_GITDIR} in ${R2PM_GITDIR}"
+				RC=1
 			fi
 			shift
 		done


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr changes `R2PM_CLEAN_GITDIR` so that it states the git (sub)dir to clean. I think this is better than #17411 because more r2pm code can be reused.

Supersedes #17411. Reverts #17357. Also removes the trailing `/` in `R2PM_GITDIR`.

This git (sub)dir can't be derived directly from `R2PM_GIT` because many plugins use:

```sh
R2PM_GIT "https://github.com/radareorg/radare2-extras"
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add the following anywhere in the `r2dec` package script:

```sh
R2PM_CLEAN_GITDIR=r2dec-js
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
