### PR TITLE
Use meson install instead of manual installation in meson.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,13 +76,13 @@ install:
 build_script:
   - appveyor AddMessage "Compiling radare2 %R2_VERSION% (%builder%)"
 
-  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && python sys\meson.py --backend vs2017 --release --xp --install="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2017_64 ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && python sys\meson.py --backend vs2017 --release --xp --install --prefix="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == vs2019_64 ( choco install mingw && refreshenv && set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && python sys\meson.py --backend vs2019 --release --install="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2019_64 ( choco install mingw && refreshenv && set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && python sys\meson.py --backend vs2019 --release --install --prefix="%DIST_FOLDER%" --webui --options static_runtime=true && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == vs2017_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && python sys\meson.py --release --shared --install="%DIST_FOLDER%" --webui && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == vs2017_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2017%" x64 && python sys\meson.py --release --shared --install --prefix="%DIST_FOLDER%" --webui && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
-  - cmd: if %builder% == clang_cl_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && set CC=clang-cl && python sys\meson.py --release --shared --install="%DIST_FOLDER%" --webui && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
+  - cmd: if %builder% == clang_cl_64_dyn ( set "PATH=C:\mingw\bin;C:\mingw\msys\1.0\bin;%PYTHON%;%PATH%" && call "%VSVARSALLPATH2019%" x64 && set CC=clang-cl && python sys\meson.py --release --shared --install --prefix="%DIST_FOLDER%" --webui && 7z a %ARTIFACT_ZIP% %DIST_FOLDER% )
 
 # Run tests only conditionally
 for:

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -16,7 +16,7 @@ You will need:
 First, call `vcvarsall.bat` with your architecture (x86, x64, arm) to setup the compilation environment.
 
 	cd radare2	
-	python3 sys\meson.py --release --backend vs2019 --shared --install="%cd%\radare2_dist" --webui
+	python3 sys\meson.py --release --backend vs2019 --shared --install --prefix="%cd%\radare2_dist" --webui
 
 You can change `--backend` to your VS version (`vs2015`, `vs2017`), `ninja` buildsystem is also supported.
 

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -259,6 +259,8 @@ def main():
         sys.exit(1)
     if not args.prefix:
         args.prefix = os.path.join(ROOT, args.dir, 'priv_install_dir')
+    else:
+        args.prefix = os.path.abspath(args.prefix)
     for option in args.options:
         if '=' not in option:
             log.error('Invalid option: %s', option)

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -64,10 +64,12 @@ def set_global_variables():
     log.debug('Meson: %s', MESON)
     log.debug('Version: %s', version)
 
-def meson(command, builddir=None, prefix=None, backend=None,
+def meson(command, rootdir=None, builddir=None, prefix=None, backend=None,
           release=False, shared=None, *, options=[]):
     """[R_API] Invoke meson"""
     cmd = MESON + [command]
+    if rootdir:
+        cmd.append(rootdir)
     if builddir:
         cmd.append(builddir)
     if prefix:

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -64,25 +64,25 @@ def set_global_variables():
     log.debug('Meson: %s', MESON)
     log.debug('Version: %s', version)
 
-def meson(root, build, prefix=None, backend=None,
-          release=False, shared=False, *, options=[]):
+def meson(command, builddir=None, prefix=None, backend=None,
+          release=False, shared=None, *, options=[]):
     """[R_API] Invoke meson"""
-    command = MESON + [root, build]
+    cmd = MESON + [command]
+    if builddir:
+        cmd.append(builddir)
     if prefix:
-        command.append('--prefix={}'.format(prefix))
+        cmd.append('--prefix={}'.format(prefix))
     if backend:
-        command.append('--backend={}'.format(backend))
+        cmd.append('--backend={}'.format(backend))
     if release:
-        command.append('--buildtype=release')
-    if shared:
-        command.append('--default-library=shared')
-    else:
-        command.append('--default-library=static')
+        cmd.append('--buildtype=release')
+    if shared != None:
+        cmd.append('--default-library={}'.format('shared' if shared else 'static'))
     if options:
-        command.extend(options)
+        cmd.extend(options)
 
-    log.debug('Invoking meson: %s', command)
-    ret = subprocess.call(command)
+    log.debug('Invoking meson: %s', cmd)
+    ret = subprocess.call(cmd)
     if ret != 0:
         log.error('Meson error. Exiting.')
         sys.exit(1)
@@ -157,69 +157,6 @@ def xp_compat(builddir):
             proj.write(c)
             log.debug("%s .. OK", f)
 
-def win_dist(args):
-    """Create r2 distribution for Windows"""
-    builddir = os.path.join(ROOT, args.dir)
-    PATH_FMT['DIST'] = args.install
-    PATH_FMT['BUILDDIR'] = builddir
-
-    makedirs(r'{DIST}')
-    makedirs(r'{DIST}\bin')
-    copy(r'{BUILDDIR}\binr\*\*.exe', r'{DIST}\bin')
-
-    r2_bat_fname = args.install + r'\bin\r2.bat'
-    log.debug('create "%s"', r2_bat_fname)
-    with open(r2_bat_fname, 'w') as r2_bat:
-        r2_bat.write('@"%~dp0\\radare2" %*\n')
-
-    r2_sh_fname = args.install + r'\bin\r2'
-    log.debug('create "%s"', r2_sh_fname)
-    with open(r2_sh_fname, 'w') as r2_sh:
-        r2_sh.write('#!/bin/sh\n$(dirname "$0")/radare2 "$@"\n')
-
-    copy(r'{BUILDDIR}\libr\*\*.dll', r'{DIST}\bin')
-    makedirs(r'{DIST}\{R2_LIBDIR}')
-    if args.shared:
-        copy(r'{BUILDDIR}\libr\*\*.lib', r'{DIST}\{R2_LIBDIR}')
-    else:
-        copy(r'{BUILDDIR}\libr\*\*.a', r'{DIST}\{R2_LIBDIR}')
-    win_dist_libr2(install_webui=args.webui)
-
-def win_dist_libr2(install_webui=False, **path_fmt):
-    """[R_API] Add libr2 data/www/include/doc to dist directory"""
-    PATH_FMT.update(path_fmt)
-
-    if install_webui:
-        copytree(r'{ROOT}\shlr\www', r'{DIST}\{R2_WWWROOT}')
-    copytree(r'{ROOT}\libr\magic\d\default', r'{DIST}\{R2_SDB}\magic')
-    makedirs(r'{DIST}\{R2_SDB}\syscall')
-    copy(r'{BUILDDIR}\libr\syscall\d\*.sdb', r'{DIST}\{R2_SDB}\syscall')
-    makedirs(r'{DIST}\{R2_SDB}\fcnsign')
-    copy(r'{BUILDDIR}\libr\anal\d\*.sdb', r'{DIST}\{R2_SDB}\fcnsign')
-    makedirs(r'{DIST}\{R2_SDB}\opcodes')
-    copy(r'{BUILDDIR}\libr\asm\d\*.sdb', r'{DIST}\{R2_SDB}\opcodes')
-    makedirs(r'{DIST}\{R2_INCDIR}\sdb')
-    makedirs(r'{DIST}\{R2_INCDIR}\r_util')
-    makedirs(r'{DIST}\{R2_INCDIR}\r_crypto')
-    copy(r'{ROOT}\libr\include\*.h', r'{DIST}\{R2_INCDIR}')
-    copy(r'{BUILDDIR}\r_version.h', r'{DIST}\{R2_INCDIR}')
-    copy(r'{BUILDDIR}\r_userconf.h', r'{DIST}\{R2_INCDIR}')
-    copy(r'{ROOT}\libr\include\sdb\*.h', r'{DIST}\{R2_INCDIR}\sdb')
-    copy(r'{ROOT}\libr\include\r_util\*.h', r'{DIST}\{R2_INCDIR}\r_util')
-    copy(r'{ROOT}\libr\include\r_crypto\*.h', r'{DIST}\{R2_INCDIR}\r_crypto')
-    makedirs(r'{DIST}\{R2_FORTUNES}')
-    copy(r'{ROOT}\doc\fortunes.*', r'{DIST}\{R2_FORTUNES}')
-    copytree(r'{ROOT}\libr\bin\d', r'{DIST}\{R2_SDB}\format',
-             exclude=('Makefile', 'meson.build', 'dll'))
-    makedirs(r'{DIST}\{R2_SDB}\format\dll')
-    copy(r'{BUILDDIR}\libr\bin\d\*.sdb', r'{DIST}\{R2_SDB}\format\dll')
-    copytree(r'{ROOT}\libr\cons\d', r'{DIST}\{R2_THEMES}',
-             exclude=('Makefile', 'meson.build'))
-    makedirs(r'{DIST}\{R2_FLAGS}')
-    copy(r'{BUILDDIR}\libr\flag\d\*.r2', r'{DIST}\{R2_FLAGS}')
-    makedirs(r'{DIST}\{R2_HUD}')
-    copy(r'{ROOT}\doc\hud', r'{DIST}\{R2_HUD}\main')
-
 def build(args):
     """ Build radare2 """
     log.info('Building radare2')
@@ -230,7 +167,7 @@ def build(args):
     if args.local:
         options.append('-Dlocal=true')
     if not os.path.exists(r2_builddir):
-        meson(ROOT, r2_builddir, prefix=args.prefix, backend=args.backend,
+        meson('setup', builddir=r2_builddir, prefix=args.prefix, backend=args.backend,
               release=args.release, shared=args.shared, options=options)
     if args.backend != 'ninja':
         # XP support was dropped in Visual Studio 2019 v142 platform
@@ -247,14 +184,7 @@ def build(args):
 
 def install(args):
     """ Install radare2 """
-    if os.name == 'nt':
-        win_dist(args)
-        return
-    log.warning('Install not implemented yet for this platform.')
-    # TODO
-    #if os.name == 'posix':
-    #    os.system('DESTDIR="{destdir}" ninja -C {build} install'
-    #            .format(destdir=destdir, build=args.dir))
+    meson('install', options=[['-C', '{}'.format(args.dir)], '--no-rebuild'])
 
 def main():
     # Create logger and get applications paths
@@ -294,10 +224,7 @@ def main():
             help='Install using symlinks')
     parser.add_argument('--webui', action='store_true',
             help='Install WebUIs')
-    if os.name == 'nt':
-        parser.add_argument('--install', help='Installation directory')
-    else:
-        parser.add_argument('--install', action='store_true',
+    parser.add_argument('--install', action='store_true',
             help='Install radare2 after building')
     parser.add_argument('--options', nargs='*', default=[])
     args = parser.parse_args()

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -184,7 +184,7 @@ def build(args):
 
 def install(args):
     """ Install radare2 """
-    meson('install', options=[['-C', '{}'.format(args.dir)], '--no-rebuild'])
+    meson('install', options=['-C', '{}'.format(args.dir), '--no-rebuild'])
 
 def main():
     # Create logger and get applications paths

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -257,10 +257,7 @@ def main():
     if args.xp and args.backend in 'vs2019':
         log.error('--xp is not compatible with --backend vs2019')
         sys.exit(1)
-    if os.name == 'nt' and args.install and os.path.exists(args.install):
-        log.error('%s already exists', args.install)
-        sys.exit(1)
-    if os.name == 'nt' and not args.prefix:
+    if not args.prefix:
         args.prefix = os.path.join(ROOT, args.dir, 'priv_install_dir')
     for option in args.options:
         if '=' not in option:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The recent SDB header PR #17249 required an update to meson.py's manual installation paths. This PR replaces the dist building functions in the script with meson's install command to avoid modifying file paths each time include dirs are added.

**Test plan**

Build r2 using sys/meson.py. This solves an issue when building r2 with Cutter so you can also run Cutter's prepare_r2.bat and then run build.bat.