### PR TITLE
Fix #17414 heap overflow hackyArmAnal

### DIFF
--- a/libr/anal/p/anal_arm_hacks.inc
+++ b/libr/anal/p/anal_arm_hacks.inc
@@ -145,6 +145,11 @@ static int hack_handle_br_exc_sys(ut32 insn, RAnalOp *op) {
 
 static inline int hackyArmAnal(RAnal *a, RAnalOp *op, const ut8 *buf, int len) {
 	int ret = -1;
+
+	// TODO: Handle this case properly
+	if (len < sizeof (ut32)) {
+		return -1;
+	}
 	ut32 *insn = (ut32 *)buf;
 	int insn_class = (*insn >> 25) & 0xf;
 	// Hacky support for ARMv8.3 and ARMv8.5

--- a/libr/anal/p/anal_arm_hacks.inc
+++ b/libr/anal/p/anal_arm_hacks.inc
@@ -145,15 +145,10 @@ static int hack_handle_br_exc_sys(ut32 insn, RAnalOp *op) {
 
 static inline int hackyArmAnal(RAnal *a, RAnalOp *op, const ut8 *buf, int len) {
 	int ret = -1;
-
-	// TODO: Handle this case properly
-	if (len < sizeof (ut32)) {
-		return -1;
-	}
-	ut32 *insn = (ut32 *)buf;
-	int insn_class = (*insn >> 25) & 0xf;
 	// Hacky support for ARMv8.3 and ARMv8.5
 	if (a->bits == 64 && len >= 4) {
+		ut32 *insn = (ut32 *)buf;
+		int insn_class = (*insn >> 25) & 0xf;
 		// xpaci // e#43c1da
 		if (!memcmp (buf + 1, "\x43\xc1\xda", 3)) {
 			op->type = R_ANAL_OP_TYPE_MOV;

--- a/libr/asm/p/asm_arm_hacks.inc
+++ b/libr/asm/p/asm_arm_hacks.inc
@@ -219,10 +219,10 @@ static char *hack_handle_ldst(ut32 insn) {
 
 static int hackyArmAsm(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	char *buf_asm = NULL;
-	ut32 *insn = (ut32 *)buf;
-	int insn_class = (*insn >> 25) & 0xf;
     // Hacky support for ARMv8.5
 	if (a->bits == 64 && len >= 4) {
+		ut32 *insn = (ut32 *)buf;
+		int insn_class = (*insn >> 25) & 0xf;
 		switch (insn_class) {
 		// Data Processing -- Register
 		case 5:


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The line `ut32 *insn = (ut32 *)buf;` assumes a buffer length `>=4`. This leads to an overflow on the following line according to Asan. This PR will bail out of the function early. There is probably a better way to handle this, but this will fix the overflow.

**Test plan**

Ensure it is ok to return -1 here.

**Closing issues**

closes #17414
