### PR TITLE
Implement save and load functions for debug session ##debug

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -472,8 +472,8 @@ static const char *help_msg_dts[] = {
 	"Usage:", "dts[*]", "",
 	"dts+", "", "Start trace session",
 	"dts-", "", "Stop trace session",
-	"dtst", " [file] ", "Save trace sessions to disk",
-	"dtsf", " [file] ", "Read trace sessions from disk",
+	"dtst", " [dir] ", "Save trace sessions to disk",
+	"dtsf", " [dir] ", "Read trace sessions from disk",
 	"dtsm", "", "List current memory map and hash",
 	NULL
 };
@@ -4888,7 +4888,7 @@ static int cmd_debug(void *data, const char *input) {
 					eprintf ("Session already started\n");
 					break;
 				}
-				core->dbg->session = r_debug_session_new (core->dbg);
+				core->dbg->session = r_debug_session_new ();
 				r_debug_add_checkpoint (core->dbg);
 				break;
 			case '-': // "dts-"
@@ -4911,7 +4911,7 @@ static int cmd_debug(void *data, const char *input) {
 					r_debug_session_free (core->dbg->session);
 					core->dbg->session = NULL;
 				}
-				core->dbg->session = r_debug_session_new (core->dbg);
+				core->dbg->session = r_debug_session_new ();
 				r_debug_session_load (core->dbg, input + 4);
 				break;
 			case 'm': // "dtsm"

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -472,6 +472,8 @@ static const char *help_msg_dts[] = {
 	"Usage:", "dts[*]", "",
 	"dts+", "", "Start trace session",
 	"dts-", "", "Stop trace session",
+	"dtst", " [file] ", "Save trace sessions to disk",
+	"dtsf", " [file] ", "Read trace sessions from disk",
 	"dtsm", "", "List current memory map and hash",
 	NULL
 };
@@ -4896,6 +4898,21 @@ static int cmd_debug(void *data, const char *input) {
 				}
 				r_debug_session_free (core->dbg->session);
 				core->dbg->session = NULL;
+				break;
+			case 't': // "dtst"
+				if (!core->dbg->session) {
+					eprintf ("No session started\n");
+					break;
+				}
+				r_debug_session_save (core->dbg->session, input + 4);
+				break;
+			case 'f': // "dtsf"
+				if (core->dbg->session) {
+					r_debug_session_free (core->dbg->session);
+					core->dbg->session = NULL;
+				}
+				core->dbg->session = r_debug_session_new (core->dbg);
+				r_debug_session_load (core->dbg, input + 4);
 				break;
 			case 'm': // "dtsm"
 				if (core->dbg->session) {

--- a/libr/debug/dsession.c
+++ b/libr/debug/dsession.c
@@ -2,6 +2,10 @@
 
 #include <r_debug.h>
 
+#define CMP_CNUM_REG(x, y) ((x) >= ((RDebugChangeReg *)y)->cnum ? 1 : -1)
+#define CMP_CNUM_MEM(x, y) ((x) >= ((RDebugChangeMem *)y)->cnum ? 1 : -1)
+#define CMP_CNUM_CHKPT(x, y) ((x) >= ((RDebugCheckpoint *)y)->cnum ? 1 : -1)
+
 R_API void r_debug_session_free(RDebugSession *session) {
 	if (session) {
 		r_vector_free (session->checkpoints);
@@ -230,4 +234,376 @@ R_API bool r_debug_session_add_mem_change(RDebugSession *session, ut64 addr, ut8
 	RDebugChangeMem mem = { session->cnum, data };
 	r_vector_push (vmem, &mem);
 	return true;
+}
+
+// {"<addr>": {"size":<size_t>, "a":[<RDebugChangeReg>]}},
+static bool save_register_cb(void *j, const ut64 k, const void *v) {
+	RVector *vreg = (RVector *)v;
+	RDebugChangeReg *reg;
+	pj_ko (j, sdb_fmt ("0x%"PFMT64x, k));
+	pj_kn (j, "size", vreg->len);
+	pj_ka (j, "a");
+	r_vector_foreach (vreg, reg) {
+		pj_o (j);
+		pj_kN (j, "cnum", reg->cnum);
+		pj_kn (j, "data", reg->data);
+		pj_end (j);
+	}
+	pj_end (j);
+	pj_end (j);
+	return true;
+}
+
+// reglist=<addr>,<addr>,...
+static bool save_reglist(void *db, const ut64 k, const void *v) {
+	sdb_array_add (db, "reglist", sdb_fmt ("0x%"PFMT64x, k), 0);
+	return true;
+}
+
+static bool save_registers(Sdb *db, HtUP *registers) {
+	PJ *j = pj_new ();
+	if (!j) {
+		return false;
+	}
+	pj_o (j);
+	ht_up_foreach (registers, save_register_cb, j);
+	pj_end (j);
+	sdb_set (db, "registers", pj_string (j), 0);
+	pj_free (j);
+
+	ht_up_foreach (registers, save_reglist, db);
+	return true;
+}
+
+// {"<addr>": {"size":<size_t>, "a":[<RDebugChangeMem>]}},
+static bool save_memory_cb(void *j, const ut64 k, const void *v) {
+	RVector *vmem = (RVector *)v;
+	RDebugChangeMem *mem;
+	pj_ko (j, sdb_fmt ("0x%"PFMT64x, k));
+	pj_kn (j, "size", vmem->len);
+	pj_ka (j, "a");
+	r_vector_foreach (vmem, mem) {
+		pj_o (j);
+		pj_kN (j, "cnum", mem->cnum);
+		pj_kn (j, "data", mem->data);
+		pj_end (j);
+	}
+	pj_end (j);
+	pj_end (j);
+	return true;
+}
+
+// memorylist=<addr>,<addr>,...
+static bool save_memorylist(void *db, const ut64 k, const void *v) {
+	sdb_array_add (db, "memorylist", sdb_fmt ("0x%"PFMT64x, k), 0);
+	return true;
+}
+
+static bool save_memory(Sdb *db, HtUP *memory) {
+	PJ *j = pj_new ();
+	if (!j) {
+		return false;
+	}
+	pj_o (j);
+	ht_up_foreach (memory, save_memory_cb, j);
+	pj_end (j);
+	sdb_set (db, "memory", pj_string (j), 0);
+	pj_free (j);
+
+	ht_up_foreach (memory, save_memorylist, db);
+	return true;
+}
+
+static bool save_checkpoints(Sdb *db, RVector *checkpoints) {
+	size_t i;
+	RDebugCheckpoint *chkpt;
+	RDebugSnap *snap;
+	RListIter *iter;
+	PJ *j = pj_new ();
+	if (!j) {
+		return false;
+	}
+
+	pj_o (j);
+	r_vector_foreach (checkpoints, chkpt) {
+		// Append cnum to chkptlist sdb_array
+		// chkptlist=<cnum>,<cnum>,...
+		sdb_array_add (db, "chkptlist", sdb_fmt ("0x%"PFMT64x, chkpt->cnum), 0);
+
+		pj_ko (j, sdb_fmt ("0x%"PFMT64x, chkpt->cnum));
+
+		// Serialize RRegArena to json
+		// registers: {"<RRegisterType>": <RRegArena>, ...}
+		pj_ko (j, "registers");
+		for (i = 0; i < R_REG_TYPE_LAST; i++) {
+			iter = chkpt->reg[i];
+			RRegArena *arena = iter->data;
+			pj_ko (j, sdb_fmt ("%d", i));
+			if (arena->bytes) {
+				char *ebytes = sdb_encode ((const void *)arena->bytes, arena->size);
+				pj_ks (j, "bytes", ebytes);
+				free (ebytes);
+				pj_kn (j, "size", arena->size);
+			} else {
+				pj_kn (j, "size", 0);
+			}
+			pj_end (j);
+		}
+		pj_end (j);
+
+		// Serialize RDebugSnap to json
+		// snaps: {"size":<size_t>, "a":[<RDebugSnap>]},
+		pj_ko (j, "snaps");
+		pj_kn (j, "size", r_list_length (chkpt->snaps));
+		pj_ka (j, "a");
+		r_list_foreach (chkpt->snaps, iter, snap) {
+			pj_o (j);
+			pj_ks (j, "name", snap->name);
+			pj_kn (j, "addr", snap->addr);
+			pj_kn (j, "addr_end", snap->addr_end);
+			pj_kn (j, "size", snap->size);
+			char *edata = sdb_encode ((const void *)snap->data, snap->size);
+			pj_ks (j, "data", edata);
+			free (edata);
+			pj_kn (j, "perm", snap->perm);
+			pj_kn (j, "user", snap->user);
+			pj_kb (j, "shared", snap->shared);
+			pj_end (j);
+		}
+		pj_end (j);
+		pj_end (j);
+		pj_end (j);
+	}
+	pj_end (j);
+	sdb_set (db, "checkpoints", pj_string (j), 0);
+	pj_free (j);
+	return true;
+}
+
+/*
+ * SDB Format:
+ *
+ * /
+ *   maxcnum=<maxcnum>
+ *
+ *   reglist=<addr>,<addr>,...
+ *   registers={"<addr>": {"size":<size_t>, "a":[<RDebugChangeReg>]}, ...}
+ *
+ *   memorylist=<addr>,<addr>,...
+ *   memory={"<addr>": {"size":<size_t>, "a":[<RDebugChangeMem>]}, ...}
+ *
+ *   chkptlist=<cnum>,<cnum>,...
+ *   checkpoints={
+ *     "<cnum>": {
+ *       registers: {"<RRegisterType>": <RRegArena>, ...},
+ *       snaps: {"size":<size_t>, "a":[<RDebugSnap>]},
+ *     },
+ *     ...
+ *   }
+ *
+ * RDebugChangeReg JSON:
+ * {"cnum":<int>, "data":<ut64>}
+ *
+ * RDebugChangeMem JSON:
+ * {"cnum":<int>, "data":<ut8>}
+ *
+ * RRegArena JSON:
+ * {"size":<int>, "bytes":"<base64>"}
+ *
+ * RDebugSnap JSON:
+ * {"name":<str>, "addr":<ut64>, "addr_end":<ut64>, "size":<ut64>,
+ *  "data":"<base64>", "perm":<int>, "user":<int>, "shared":<bool>}
+ *
+ * Notes:
+ * - This mostly follows r2db-style serialization and uses sdb_json as the parser.
+ * - Use keys in reglist, memorylist, chkptlist to iterate over their corresponding dicts.
+ */
+R_API bool r_debug_session_save(RDebugSession *session, const char *file) {
+	bool ret = false;
+	Sdb *db = sdb_new0 ();
+	if (!db) {
+		return false;
+	}
+
+	sdb_num_set (db, "maxcnum", session->maxcnum, 0);
+	if (!save_registers (db, session->registers)) {
+		eprintf ("Error: failed to save registers to sdb\n");
+		goto end;
+	}
+	if (!save_memory (db, session->memory)) {
+		eprintf ("Error: failed to save memory to sdb\n");
+		goto end;
+	}
+	if (!save_checkpoints (db, session->checkpoints)) {
+		eprintf ("Error: failed to save checkpoints to sdb\n");
+		goto end;
+	}
+
+	sdb_file (db, file);
+	if (!sdb_sync (db)) {
+		eprintf ("Failed to sync session to %s\n", file);
+		goto end;
+	}
+	ret = true;
+end:
+	sdb_close (db);
+	sdb_free (db);
+	return ret;
+}
+
+#define CNUM(x) sdb_fmt ("%s.a[%u].cnum", addr, x)
+#define DATA(x) sdb_fmt ("%s.a[%u].data", addr, x)
+
+// Extract ut64 value from sdb_json str
+static ut64 _json_num_get(Sdb *db, const char *k, const char *p, ut32 *cas) {
+	char *vstr = sdb_json_get (db, k, p, cas);
+	if (vstr) {
+		ut64 v = sdb_atoi (vstr);
+		free (vstr);
+		return v;
+	}
+	return 0;
+}
+
+static bool load_memory(Sdb *db, HtUP *memory) {
+	size_t i, size;
+	char *addr;
+	// Iterate over "memory" items
+	char *a = sdb_get (db, "memorylist", 0);
+	sdb_aforeach (addr, a) {
+		// Insert a new vector into `memory` HtUP at `addr`
+		RVector *vmem = r_vector_new (sizeof (RDebugChangeMem), NULL, NULL);
+		if (!vmem) {
+			eprintf ("Error: failed to allocate RVector vmem.\n");
+			return false;
+		}
+		ht_up_insert (memory, sdb_atoi (addr), vmem);
+
+		// Extract <RDebugChangeMem>'s into the new vector
+		size = _json_num_get (db, "memory", sdb_fmt ("%s.size", addr, i), 0);
+		for (i = 0; i < size; i++) {
+			int cnum = _json_num_get (db, "memory", CNUM (i), 0);
+			ut8 data = _json_num_get (db, "memory", DATA (i), 0);
+			RDebugChangeMem mem = { cnum, data };
+			r_vector_push (vmem, &mem);
+		}
+		sdb_aforeach_next (addr);
+	}
+	return true;
+}
+
+static bool load_registers(Sdb *db, HtUP *registers) {
+	size_t i, size;
+	char *addr;
+	// Iterate over "registers" items
+	char *a = sdb_get (db, "reglist", 0);
+	sdb_aforeach (addr, a) {
+		// Insert a new vector into `registers` HtUP at `addr`
+		RVector *vreg = r_vector_new (sizeof (RDebugChangeReg), NULL, NULL);
+		if (!vreg) {
+			eprintf ("Error: failed to allocate RVector vreg.\n");
+			return false;
+		}
+		ht_up_insert (registers, sdb_atoi (addr), vreg);
+
+		// Extract <RDebugChangeReg>'s into the new vector
+		size = _json_num_get (db, "registers", sdb_fmt ("%s.size", addr, i), 0);
+		for (i = 0; i < size; i++) {
+			int cnum = _json_num_get (db, "registers", CNUM (i), 0);
+			ut64 data = _json_num_get (db, "registers", DATA (i), 0);
+			RDebugChangeReg reg = { cnum, data };
+			r_vector_push (vreg, &reg);
+		}
+		sdb_aforeach_next (addr);
+	}
+	return true;
+}
+
+#define SNAPATTR(ATTR) sdb_fmt ("%s.snaps.a[%u]." #ATTR, cnum, i)
+#define REGATTR(ATTR) sdb_fmt ("%s.registers.%d." #ATTR, cnum, i)
+
+static bool load_checkpoints(Sdb *db, RDebug *dbg, RVector *checkpoints) {
+	size_t i, size;
+	char *cnum;
+	// Iterate over "checkpoints" items
+	char *a = sdb_get (db, "chkptlist", 0);
+	sdb_aforeach (cnum, a) {
+		RDebugCheckpoint checkpoint = { 0 };
+		checkpoint.cnum = (int)sdb_atoi (cnum);
+
+		// Extract RRegArena's from "registers"
+		for (i = 0; i < R_REG_TYPE_LAST; i++) {
+			int size = _json_num_get (db, "checkpoints", REGATTR (size), 0);
+			if (size == 0) {
+				continue;
+			}
+			char *edata = sdb_json_get (db, "checkpoints", REGATTR (bytes), 0);
+			ut8 *bytes = sdb_decode (edata, NULL);
+			r_reg_set_bytes (dbg->reg, i, bytes, size);
+			free (bytes);
+			free (edata);
+			checkpoint.reg[i] = r_list_tail (dbg->reg->regset[i].pool);
+		}
+		r_reg_arena_push (dbg->reg);
+
+		// Extract RDebugSnap's from "snaps"
+		checkpoint.snaps = r_list_newf ((RListFree)r_debug_snap_free);
+		size = sdb_json_num_get (db, "checkpoints", sdb_fmt ("%s.snaps.size", cnum, i), 0);
+		for (i = 0; i < size; i++) {
+			RDebugSnap *snap = R_NEW0 (RDebugSnap);
+			if (!snap) {
+				eprintf ("Error: failed to allocate RDebugSnap snap");
+				return false;
+			}
+
+			snap->name = sdb_json_get (db, "checkpoints", SNAPATTR (name), 0);
+			snap->size = _json_num_get (db, "checkpoints", SNAPATTR (size), 0);
+			snap->addr = _json_num_get (db, "checkpoints", SNAPATTR (addr), 0);
+			snap->addr_end = _json_num_get (db, "checkpoints", SNAPATTR (addr_end), 0);
+			snap->perm = _json_num_get (db, "checkpoints", SNAPATTR (perm), 0);
+			snap->user = _json_num_get (db, "checkpoints", SNAPATTR (user), 0);
+			char *sharedstr = sdb_json_get (db, "checkpoints", SNAPATTR (shared), 0);
+			snap->shared = (strlen (sharedstr) == 4 && !strncmp (sharedstr, "true", 4));
+			free (sharedstr);
+
+			char *edata = sdb_json_get (db, "checkpoints", SNAPATTR (data), 0);
+			snap->data = sdb_decode (edata, NULL);
+			free (edata);
+			r_list_append (checkpoint.snaps, snap);
+		}
+
+		r_vector_push (checkpoints, &checkpoint);
+		sdb_aforeach_next (cnum);
+	}
+	return true;
+}
+
+R_API bool r_debug_session_load(RDebug *dbg, const char *file) {
+	bool ret = false;
+	Sdb *db = sdb_new (NULL, file, 0);
+	if (!db) {
+		return false;
+	}
+
+	dbg->session->maxcnum = sdb_num_get (db, "maxcnum", 0);
+	if (!load_memory (db, dbg->session->memory)) {
+		eprintf ("Error: failed to load memory from %s sdb\n", file);
+		goto end;
+	}
+	if (!load_registers (db, dbg->session->registers)) {
+		eprintf ("Error: failed to load registers from %s sdb\n", file);
+		goto end;
+	}
+	if (!load_checkpoints (db, dbg, dbg->session->checkpoints)) {
+		eprintf ("Error: failed to load checkpoints from %s sdb\n", file);
+		goto end;
+	}
+
+	// Restore debugger to cnum 0
+	r_debug_session_restore_reg_mem (dbg, 0);
+	ret = true;
+end:
+	sdb_close (db);
+	sdb_free (db);
+	return ret;
 }

--- a/libr/debug/dsession.c
+++ b/libr/debug/dsession.c
@@ -28,7 +28,7 @@ static void htup_vector_free(HtUPKv *kv) {
 	r_vector_free (kv->value);
 }
 
-R_API RDebugSession *r_debug_session_new() {
+R_API RDebugSession *r_debug_session_new(void) {
 	RDebugSession *session = R_NEW0 (RDebugSession);
 	if (!session) {
 		return NULL;
@@ -269,7 +269,7 @@ static bool serialize_register_cb(void *db, const ut64 k, const void *v) {
 	return true;
 }
 
-static bool serialize_registers(Sdb *db, HtUP *registers) {
+static void serialize_registers(Sdb *db, HtUP *registers) {
 	ht_up_foreach (registers, serialize_register_cb, db);
 }
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -172,10 +172,6 @@ typedef struct r_debug_snap_t {
 	bool shared;
 } RDebugSnap;
 
-#define CMP_CNUM_REG(x, y) ((x) >= ((RDebugChangeReg *)y)->cnum ? 1 : -1)
-#define CMP_CNUM_MEM(x, y) ((x) >= ((RDebugChangeMem *)y)->cnum ? 1 : -1)
-#define CMP_CNUM_CHKPT(x, y) ((x) >= ((RDebugCheckpoint *)y)->cnum ? 1 : -1)
-
 typedef struct {
 	int cnum;
 	ut64 data;
@@ -188,7 +184,7 @@ typedef struct {
 
 typedef struct r_debug_checkpoint_t {
 	int cnum;
-	RListIter *reg[R_REG_TYPE_LAST];
+	RListIter *reg[R_REG_TYPE_LAST]; // <RRegArena>//
 	RList *snaps; // <RDebugSnap>
 } RDebugCheckpoint;
 
@@ -199,7 +195,7 @@ typedef struct r_debug_session_t {
 	RVector *checkpoints; /* RVector<RDebugCheckpoint> */
 	HtUP *memory; /* RVector<RDebugChangeMem> */
 	HtUP *registers; /* RVector<RDebugChangeReg> */
-	int /*RDebugReasonType*/ reasontype;
+	int reasontype /*RDebugReasonType*/;
 	RBreakpointItem *bp;
 } RDebugSession;
 
@@ -586,6 +582,8 @@ R_API bool r_debug_session_add_reg_change(RDebugSession *session, int arena, ut6
 R_API bool r_debug_session_add_mem_change(RDebugSession *session, ut64 addr, ut8 data);
 R_API void r_debug_session_restore_reg_mem(RDebug *dbg, ut32 cnum);
 R_API void r_debug_session_list_memory(RDebug *dbg);
+R_API bool r_debug_session_save(RDebugSession *session, const char *file);
+R_API bool r_debug_session_load(RDebug *dbg, const char *file);
 R_API bool r_debug_trace_ins_before(RDebug *dbg);
 R_API bool r_debug_trace_ins_after(RDebug *dbg);
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -589,7 +589,7 @@ R_API bool r_debug_session_load(RDebug *dbg, const char *file);
 R_API bool r_debug_trace_ins_before(RDebug *dbg);
 R_API bool r_debug_trace_ins_after(RDebug *dbg);
 
-R_API RDebugSession *r_debug_session_new();
+R_API RDebugSession *r_debug_session_new(void);
 R_API void r_debug_session_free(RDebugSession *session);
 
 R_API RDebugSnap *r_debug_snap_map(RDebug *dbg, RDebugMap *map);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -184,7 +184,7 @@ typedef struct {
 
 typedef struct r_debug_checkpoint_t {
 	int cnum;
-	RListIter *reg[R_REG_TYPE_LAST]; // <RRegArena>//
+	RRegArena *arena[R_REG_TYPE_LAST];
 	RList *snaps; // <RDebugSnap>
 } RDebugCheckpoint;
 
@@ -582,12 +582,14 @@ R_API bool r_debug_session_add_reg_change(RDebugSession *session, int arena, ut6
 R_API bool r_debug_session_add_mem_change(RDebugSession *session, ut64 addr, ut8 data);
 R_API void r_debug_session_restore_reg_mem(RDebug *dbg, ut32 cnum);
 R_API void r_debug_session_list_memory(RDebug *dbg);
+R_API void r_debug_session_serialize(RDebugSession *session, Sdb *db);
+R_API void r_debug_session_deserialize(RDebugSession *session, Sdb *db);
 R_API bool r_debug_session_save(RDebugSession *session, const char *file);
 R_API bool r_debug_session_load(RDebug *dbg, const char *file);
 R_API bool r_debug_trace_ins_before(RDebug *dbg);
 R_API bool r_debug_trace_ins_after(RDebug *dbg);
 
-R_API RDebugSession *r_debug_session_new(RDebug *dbg);
+R_API RDebugSession *r_debug_session_new();
 R_API void r_debug_session_free(RDebugSession *session);
 
 R_API RDebugSnap *r_debug_snap_map(RDebug *dbg, RDebugMap *map);

--- a/shlr/sdb/src/json/rangstr.h
+++ b/shlr/sdb/src/json/rangstr.h
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 #include "../types.h"
 
-#define RangstrType unsigned short
+#define RangstrType unsigned int
 
 typedef struct {
 	int type;

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -5,21 +5,17 @@ CMDS=<<EOF
 dcu main
 dts+
 ds 200
-dm~?
-ara~?
-dtst dump
-dtsf dump
-dm~?
-ara~?
+dtst ./
+dtsf ./
 dr rip
 ds 10
 dr rip
+rm ./session.sdb
+rm ./registers.sdb
+rm ./memory.sdb
+rm ./checkpoints.sdb
 EOF
 EXPECT=<<EOF
-16
-24
-16
-32
 0x00400574
 0x00400565
 EOF

--- a/test/db/archos/linux-x64/dbg_dts
+++ b/test/db/archos/linux-x64/dbg_dts
@@ -1,0 +1,26 @@
+NAME=save and load debug session (dtst, dtsf)
+FILE=bins/elf/analysis/calls_x64
+ARGS=-d
+CMDS=<<EOF
+dcu main
+dts+
+ds 200
+dm~?
+ara~?
+dtst dump
+dtsf dump
+dm~?
+ara~?
+dr rip
+ds 10
+dr rip
+EOF
+EXPECT=<<EOF
+16
+24
+16
+32
+0x00400574
+0x00400565
+EOF
+RUN

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -22,6 +22,7 @@ if get_option('enable_tests')
     'cons',
     'contrbtree',
     'debruijn',
+    'debug_session',
     'diff',
     'dwarf',
     'dwarf_info',

--- a/test/unit/test_debug_session.c
+++ b/test/unit/test_debug_session.c
@@ -1,0 +1,201 @@
+#include <r_debug.h>
+#include <r_util.h>
+#include <r_reg.h>
+#include "minunit.h"
+
+Sdb *ref_db() {
+	Sdb *db = sdb_new0 ();
+
+	sdb_num_set (db, "maxcnum", 1, 0);
+
+	Sdb *registers_db = sdb_ns (db, "registers", true);
+	sdb_set (registers_db, "0x100", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":1094861636},{\"cnum\":1,\"data\":3735928559}]}", 0);
+
+	Sdb *memory_sdb = sdb_ns (db, "memory", true);
+	sdb_set (memory_sdb, "0x7ffffffff000", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":170},{\"cnum\":1,\"data\":187}]}", 0);
+	sdb_set (memory_sdb, "0x7ffffffff001", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":0},{\"cnum\":1,\"data\":1}]}", 0);
+
+	Sdb *checkpoints_sdb = sdb_ns (db, "checkpoints", true);
+	sdb_set (checkpoints_sdb, "0x0", "{"
+		"\"registers\":{"
+			"\"0\":{\"bytes\":\"AAAAAAAAAAAAAAAAAAAAAA==\",\"size\":16},"
+			"\"1\":{\"bytes\":\"AQEBAQEBAQEBAQEBAQEBAQ==\",\"size\":16},"
+			"\"2\":{\"bytes\":\"AgICAgICAgICAgICAgICAg==\",\"size\":16},"
+			"\"3\":{\"bytes\":\"AwMDAwMDAwMDAwMDAwMDAw==\",\"size\":16},"
+			"\"4\":{\"bytes\":\"BAQEBAQEBAQEBAQEBAQEBA==\",\"size\":16},"
+			"\"5\":{\"bytes\":\"BQUFBQUFBQUFBQUFBQUFBQ==\",\"size\":16},"
+			"\"6\":{\"bytes\":\"BgYGBgYGBgYGBgYGBgYGBg==\",\"size\":16},"
+			"\"7\":{\"bytes\":\"BwcHBwcHBwcHBwcHBwcHBw==\",\"size\":16}},"
+		"\"snaps\":{"
+			"\"size\":1,\"a\":["
+			"{\"name\":\"[stack]\",\"addr\":8796092882944,\"addr_end\":8796092883200,\"size\":256,\"data\":\"8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8A==\",\"perm\":7,\"user\":0,\"shared\":true}"
+		"]}"
+	"}", 0);
+
+	return db;
+}
+
+RDebugSession *ref_session() {
+	size_t i;
+	RDebugSession *s = r_debug_session_new ();
+
+	// Registers & Memory
+	r_debug_session_add_reg_change (s, 0, 0x100, 0x41424344);
+	r_debug_session_add_mem_change (s, 0x7ffffffff000, 0xaa);
+	r_debug_session_add_mem_change (s, 0x7ffffffff001, 0x00);
+	s->maxcnum++;
+	s->cnum++;
+
+	r_debug_session_add_reg_change (s, 0, 0x100, 0xdeadbeef);
+	r_debug_session_add_mem_change (s, 0x7ffffffff000, 0xbb);
+	r_debug_session_add_mem_change (s, 0x7ffffffff001, 0x01);
+
+	// Checkpoints
+	RDebugCheckpoint checkpoint = { 0 };
+	for (i = 0; i < R_REG_TYPE_LAST; i++) {
+		RRegArena *a = r_reg_arena_new (0x10);
+		memset (a->bytes, i, a->size);
+		checkpoint.arena[i] = a;
+	}
+	checkpoint.snaps = r_list_newf ((RListFree)r_debug_snap_free);
+	RDebugSnap *snap = R_NEW0 (RDebugSnap);
+	snap->name = strdup ("[stack]");
+	snap->addr = 0x7fffffde000;
+	snap->addr_end = 0x7fffffde100;
+	snap->size = 0x100;
+	snap->perm = 7;
+	snap->user = 0;
+	snap->shared = true;
+	snap->data = malloc (snap->size);
+	memset (snap->data, 0xf0, snap->size);
+	r_list_append (checkpoint.snaps, snap);
+	r_vector_push (s->checkpoints, &checkpoint);
+
+	return s;
+}
+
+static void diff_cb(const SdbDiff *diff, void *user) {
+	char buf[2048];
+	if (sdb_diff_format (buf, sizeof(buf), diff) < 0) {
+		return;
+	}
+	printf ("%s\n", buf);
+}
+
+static bool test_session_save(void) {
+	Sdb *expected = ref_db ();
+	Sdb *actual = sdb_new0 ();
+	RDebugSession *s = ref_session ();
+	r_debug_session_serialize (s, actual);
+
+	mu_assert ("save", sdb_diff (expected, actual, diff_cb, NULL));
+
+	sdb_free (actual);
+	sdb_free (expected);
+	r_debug_session_free (s);
+	mu_end;
+}
+
+static bool compare_registers_cb(void *user, const ut64 key, const void *value) {
+	RDebugChangeReg *actual_reg, *expected_reg;
+	HtUP *ref = user;
+	RVector *actual_vreg = (RVector *)value;
+
+	RVector *expected_vreg = ht_up_find (ref, key, NULL);
+	mu_assert ("vreg not found", expected_vreg);
+	mu_assert_eq (actual_vreg->len, expected_vreg->len, "vreg length");
+
+	size_t i;
+	r_vector_enumerate (actual_vreg, actual_reg, i) {
+		expected_reg = r_vector_index_ptr (expected_vreg, i);
+		mu_assert_eq (actual_reg->cnum, expected_reg->cnum, "cnum");
+		mu_assert_eq (actual_reg->data, expected_reg->data, "data");
+	}
+	return true;
+}
+
+static bool compare_memory_cb(void *user, const ut64 key, const void *value) {
+	RDebugChangeMem *actual_mem, *expected_mem;
+	HtUP *ref = user;
+	RVector *actual_vmem = (RVector *)value;
+
+	RVector *expected_vmem = ht_up_find (ref, key, NULL);
+	mu_assert ("vmem not found", expected_vmem);
+	mu_assert_eq (actual_vmem->len, expected_vmem->len, "vmem length");
+
+	size_t i;
+	r_vector_enumerate (actual_vmem, actual_mem, i) {
+		expected_mem = r_vector_index_ptr (expected_vmem, i);
+		mu_assert_eq (actual_mem->cnum, expected_mem->cnum, "cnum");
+		mu_assert_eq (actual_mem->data, expected_mem->data, "data");
+	}
+	return true;
+}
+
+static bool arena_eq(RRegArena *actual, RRegArena *expected) {
+	mu_assert ("arena null", actual && expected);
+	mu_assert_eq (actual->size, expected->size, "arena size");
+	mu_assert_memeq (actual->bytes, expected->bytes, expected->size, "arena bytes");
+	return true;
+}
+
+static bool snap_eq(RDebugSnap *actual, RDebugSnap *expected) {
+	mu_assert ("snap null", actual && expected);
+	mu_assert_streq (actual->name, expected->name, "snap name");
+	mu_assert_eq (actual->addr, expected->addr, "snap addr");
+	mu_assert_eq (actual->addr_end, expected->addr_end, "snap addr_end");
+	mu_assert_eq (actual->size, expected->size, "snap size");
+	mu_assert_eq (actual->perm, expected->perm, "snap perm");
+	mu_assert_eq (actual->user, expected->user, "snap user");
+	mu_assert_eq (actual->shared, expected->shared, "snap shared");
+	mu_assert_memeq (actual->data, expected->data, expected->size, "snap data");
+	return true;
+}
+
+static bool test_session_load(void) {
+	RDebugSession *ref = ref_session ();
+	RDebugSession *s = r_debug_session_new ();
+	Sdb *db = ref_db ();
+	r_debug_session_deserialize (s, db);
+
+	mu_assert_eq (s->maxcnum, ref->maxcnum, "maxcnum");
+	// Registers
+	ht_up_foreach (s->registers, compare_registers_cb, ref->registers);
+	// Memory
+	ht_up_foreach (s->memory, compare_memory_cb, ref->memory);
+	// Checkpoints
+	size_t i, chkpt_idx;
+	RDebugCheckpoint *chkpt, *ref_chkpt;
+	mu_assert_eq (s->checkpoints->len, ref->checkpoints->len, "checkpoints length");
+	r_vector_enumerate (s->checkpoints, chkpt, chkpt_idx) {
+		ref_chkpt = r_vector_index_ptr (ref->checkpoints, chkpt_idx);
+		// Registers
+		for (i = 0; i < R_REG_TYPE_LAST; i++) {
+			arena_eq (chkpt->arena[i], ref_chkpt->arena[i]);
+		}	
+		// Snaps
+		RListIter *actual_snaps_iter = r_list_iterator (chkpt->snaps);
+		RListIter *expected_snaps_iter = r_list_iterator (ref_chkpt->snaps);
+		while (actual_snaps_iter && expected_snaps_iter) {
+			RDebugSnap *actual_snap = r_list_iter_get (actual_snaps_iter);
+			RDebugSnap *expected_snap = r_list_iter_get (expected_snaps_iter);
+			snap_eq (actual_snap, expected_snap);
+		}
+
+	}
+
+	sdb_free (db);
+	r_debug_session_free (s);
+	r_debug_session_free (ref);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_session_save);
+	mu_run_test (test_session_load);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}

--- a/test/unit/test_debug_session.c
+++ b/test/unit/test_debug_session.c
@@ -9,27 +9,27 @@ Sdb *ref_db() {
 	sdb_num_set (db, "maxcnum", 1, 0);
 
 	Sdb *registers_db = sdb_ns (db, "registers", true);
-	sdb_set (registers_db, "0x100", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":1094861636},{\"cnum\":1,\"data\":3735928559}]}", 0);
+	sdb_set (registers_db, "0x100", "[{\"cnum\":0,\"data\":1094861636},{\"cnum\":1,\"data\":3735928559}]", 0);
 
 	Sdb *memory_sdb = sdb_ns (db, "memory", true);
-	sdb_set (memory_sdb, "0x7ffffffff000", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":170},{\"cnum\":1,\"data\":187}]}", 0);
-	sdb_set (memory_sdb, "0x7ffffffff001", "{\"size\":2,\"a\":[{\"cnum\":0,\"data\":0},{\"cnum\":1,\"data\":1}]}", 0);
+	sdb_set (memory_sdb, "0x7ffffffff000", "[{\"cnum\":0,\"data\":170},{\"cnum\":1,\"data\":187}]", 0);
+	sdb_set (memory_sdb, "0x7ffffffff001", "[{\"cnum\":0,\"data\":0},{\"cnum\":1,\"data\":1}]", 0);
 
 	Sdb *checkpoints_sdb = sdb_ns (db, "checkpoints", true);
 	sdb_set (checkpoints_sdb, "0x0", "{"
-		"\"registers\":{"
-			"\"0\":{\"bytes\":\"AAAAAAAAAAAAAAAAAAAAAA==\",\"size\":16},"
-			"\"1\":{\"bytes\":\"AQEBAQEBAQEBAQEBAQEBAQ==\",\"size\":16},"
-			"\"2\":{\"bytes\":\"AgICAgICAgICAgICAgICAg==\",\"size\":16},"
-			"\"3\":{\"bytes\":\"AwMDAwMDAwMDAwMDAwMDAw==\",\"size\":16},"
-			"\"4\":{\"bytes\":\"BAQEBAQEBAQEBAQEBAQEBA==\",\"size\":16},"
-			"\"5\":{\"bytes\":\"BQUFBQUFBQUFBQUFBQUFBQ==\",\"size\":16},"
-			"\"6\":{\"bytes\":\"BgYGBgYGBgYGBgYGBgYGBg==\",\"size\":16},"
-			"\"7\":{\"bytes\":\"BwcHBwcHBwcHBwcHBwcHBw==\",\"size\":16}},"
-		"\"snaps\":{"
-			"\"size\":1,\"a\":["
+		"\"registers\":["
+			"{\"arena\":0,\"bytes\":\"AAAAAAAAAAAAAAAAAAAAAA==\",\"size\":16},"
+			"{\"arena\":1,\"bytes\":\"AQEBAQEBAQEBAQEBAQEBAQ==\",\"size\":16},"
+			"{\"arena\":2,\"bytes\":\"AgICAgICAgICAgICAgICAg==\",\"size\":16},"
+			"{\"arena\":3,\"bytes\":\"AwMDAwMDAwMDAwMDAwMDAw==\",\"size\":16},"
+			"{\"arena\":4,\"bytes\":\"BAQEBAQEBAQEBAQEBAQEBA==\",\"size\":16},"
+			"{\"arena\":5,\"bytes\":\"BQUFBQUFBQUFBQUFBQUFBQ==\",\"size\":16},"
+			"{\"arena\":6,\"bytes\":\"BgYGBgYGBgYGBgYGBgYGBg==\",\"size\":16},"
+			"{\"arena\":7,\"bytes\":\"BwcHBwcHBwcHBwcHBwcHBw==\",\"size\":16}"
+		"],"
+		"\"snaps\":["
 			"{\"name\":\"[stack]\",\"addr\":8796092882944,\"addr_end\":8796092883200,\"size\":256,\"data\":\"8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8A==\",\"perm\":7,\"user\":0,\"shared\":true}"
-		"]}"
+		"]"
 	"}", 0);
 
 	return db;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

* Add dtst and dtsf commands
* Change Rangstr to unsigned int to increase json length limit

Store `RDebugSession` in sdb and save it to disk in the following format:
```
maxcnum=<maxcnum>

reglist=<addr>,<addr>,...
registers={"<addr>": {"size":<size_t>, "a":[<RDebugChangeReg>]}, ...}

memorylist=<addr>,<addr>,...
memory={"<addr>": {"size":<size_t>, "a":[<RDebugChangeMem>]}, ...}

chkptlist=<cnum>,<cnum>,...
checkpoints={
  "<cnum>": {
        registers: {"<RRegisterType>": <RRegArena>, ...},
        snaps: {"size":<size_t>, "a":[<RDebugSnap>]},
  },
  ...
}

RDebugChangeReg JSON:
{"cnum":<int>, "data":<ut64>}

RDebugChangeMem JSON:
{"cnum":<int>, "data":<ut8>}

RRegArena JSON:
{"size":<int>, "bytes":"<base64>"}

RDebugSnap JSON:
{"name":<str>, "addr":<ut64>, "addr_end":<ut64>, "size":<ut64>,
 "data":"<base64>", "perm":<int>, "user":<int>, "shared":<bool>}
```
The serialization style mostly follows the WIP `r2db` for r2 project. This PR uses the `sdb_json` json parser and a list of keys (`reglist`, `memorylist`, `chkptlist`) to ease iteration over dictionary (`registers`, `memory`, `checkpoints`).

**Test plan**

I have added the test case `dbg_dts` to test saving, loading and debugging after loading in one session.