### PR TITLE
Fix build warnings in rtti_itanium.c ##anal

### DIFF
--- a/libr/anal/rtti_itanium.c
+++ b/libr/anal/rtti_itanium.c
@@ -479,7 +479,8 @@ static class_type_info *rtti_itanium_type_info_new(RVTableContext *context, ut64
 	}
 }
 
-static void rtti_itanium_type_info_free(class_type_info *cti) {
+static void rtti_itanium_type_info_free(void *info) {
+	class_type_info *cti = info;
 	if (!cti) {
 		return;
 	}
@@ -614,6 +615,8 @@ static void add_class_bases(RVTableContext *context, const class_type_info *cti)
 			}
 		}
 	} break;
+	default: // other types have no parent classes
+		break;
 	}
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix left build warnings from #17365 

```
rtti_itanium.c:592:10: warning: enumeration values 'R_TYPEINFO_TYPE_UNKNOWN' and 'R_TYPEINFO_TYPE_CLASS' not handled in switch [-Wswitch]
        switch (cti->type) {
                ^
rtti_itanium.c:622:18: warning: incompatible pointer types assigning to 'RListFree' (aka 'void (*)(void *)') from 'void (class_type_info *)' (aka 'void (struct class_type_info_t *)') [-Wincompatible-pointer-types]
        rtti_list->free = rtti_itanium_type_info_free;
                        ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```
