### PR TITLE
Escape environment vars in the default rarun profile

### DIFF
--- a/libr/include/r_socket.h
+++ b/libr/include/r_socket.h
@@ -256,6 +256,7 @@ R_API int r_run_config_env(RRunProfile *p);
 R_API int r_run_start(RRunProfile *p);
 R_API void r_run_reset(RRunProfile *p);
 R_API bool r_run_parsefile(RRunProfile *p, const char *b);
+R_API char *r_run_get_environ_profile(char **environ);
 
 /* rapipe */
 R_API R2Pipe *rap_open(const char *cmd);

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -386,26 +386,8 @@ R_API int r_main_radare2(int argc, const char **argv) {
 
 	r_sys_env_init ();
 	// Create rarun2 profile with startup environ
-	char *envprofile = NULL;
-	char **e = r_sys_get_environ ();
-	if (e) {
-		RStrBuf *sb = r_strbuf_new (NULL);
-		while (e && *e) {
-			char *k = strdup (*e);
-			char *v = strchr (k, '=');
-			if (v) {
-				*v++ = 0;
-				v = r_str_escape (v);
-				if (v) {
-					r_strbuf_appendf (sb, "setenv=%s=\"%s\"\n", k, v);
-					free (v);
-				}
-			}
-			free (k);
-			e++;
-		}
-		envprofile = r_strbuf_drain (sb);
-	}
+	char **env = r_sys_get_environ ();
+	char *envprofile = r_run_get_environ_profile (env);
 
 	if (r_sys_getenv_asbool ("R2_DEBUG")) {
 		char *sysdbg = r_sys_getenv ("R2_DEBUG_TOOL");

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -395,7 +395,11 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			char *v = strchr (k, '=');
 			if (v) {
 				*v++ = 0;
-				r_strbuf_appendf (sb, "setenv=%s='%s'\n", k, v);
+				v = r_str_escape (v);
+				if (v) {
+					r_strbuf_appendf (sb, "setenv=%s=\"%s\"\n", k, v);
+					free (v);
+				}
 			}
 			free (k);
 			e++;

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -391,7 +391,13 @@ R_API int r_main_radare2(int argc, const char **argv) {
 	if (e) {
 		RStrBuf *sb = r_strbuf_new (NULL);
 		while (e && *e) {
-			r_strbuf_appendf (sb, "setenv=%s\n", *e);
+			char *k = strdup (*e);
+			char *v = strchr (k, '=');
+			if (v) {
+				*v++ = 0;
+				r_strbuf_appendf (sb, "setenv=%s='%s'\n", k, v);
+			}
+			free (k);
 			e++;
 		}
 		envprofile = r_strbuf_drain (sb);

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -1228,3 +1228,25 @@ R_API int r_run_start(RRunProfile *p) {
 	}
 	return 0;
 }
+
+R_API char *r_run_get_environ_profile(char **env) {
+	if (!env) {
+		return NULL;
+	}
+	RStrBuf *sb = r_strbuf_new (NULL);
+	while (*env) {
+		char *k = strdup (*env);
+		char *v = strchr (k, '=');
+		if (v) {
+			*v++ = 0;
+			v = r_str_escape_latin1 (v, false, true, true);
+			if (v) {
+				r_strbuf_appendf (sb, "setenv=%s=\"%s\"\n", k, v);
+				free (v);
+			}
+		}
+		free (k);
+		env++;
+	}
+	return r_strbuf_drain (sb);
+}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Escape the environment variable values with `'` in the startup rarun profile to prevent misinterpreting special characters as rarun prefixes.

For example, an env var with special characters like `DISPLAY=:0` should not be parsed as a hexpair string by `run.c:getstr`

**Test plan**

...

**Closing issues**
