### PR TITLE
r2pm: Allow reuse of gitdir-cleaning code in package scripts

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -409,6 +409,21 @@ R2PM_DEPS() {
 	done
 }
 
+R2PM_CLEAN_GITDIR() {
+	[ -z "$1" ] && R2PM_FAIL "R2PM_CLEAN_GITDIR: Missing dir"
+	if [ -d "${R2PM_GITDIR}/$1" ]; then
+		echo "Cleaning up ${R2PM_GITDIR}/$1..."
+		rm -rf "${R2PM_GITDIR}/$1"
+	elif [ -d "${R2PM_GITDIR}/$1.git" ]; then
+		echo "Cleaning up ${R2PM_GITDIR}/$1.git..."
+		rm -rf "${R2PM_GITDIR}/$1.git"
+	else
+		echo "Cannot find $1 or $1.git in ${R2PM_GITDIR}"
+		return 1
+	fi
+	return 0
+}
+
 pkgFilePath() {
 	for a in "${R2PM_DBDIR}" "${R2PM_USRDIR}"/db2/*/db ; do
 		if [ -f "$a/$1" ]; then
@@ -570,7 +585,7 @@ case "$1" in
 		while [ -n "$2" ]; do
 			echo "Cleaning $2..."
 			FILE="$(pkgFilePath "$2")"
-			R2PM_CLEAN_GITDIR=1
+			R2PM_AUTOCLEAN_GITDIR=1
 			if [ -f "${FILE}" ]; then
 				NAME="$2"
 				ACTION=clean
@@ -582,17 +597,9 @@ case "$1" in
 				RC=1
 			fi
 
-			if [ "${R2PM_CLEAN_GITDIR}" = 1 ]; then
-				if [ -d "${R2PM_GITDIR}/$2" ]; then
-					echo "Cleaning up ${R2PM_GITDIR}/$2..."
-					rm -rf "${R2PM_GITDIR}/$2"
-				elif [ -d "${R2PM_GITDIR}/$2.git" ]; then
-					echo "Cleaning up ${R2PM_GITDIR}/$2.git..."
-					rm -rf "${R2PM_GITDIR}/$2.git"
-				else
-					echo "Cannot find $2 or $2.git in ${R2PM_GITDIR}"
-					RC=1
-				fi
+			if [ "${R2PM_AUTOCLEAN_GITDIR}" = 1 ]; then
+				R2PM_CLEAN_GITDIR "$2"
+				RC=$?
 			fi
 			shift
 		done


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr exposes r2pm's gitdir-cleaning code for use by package scripts. Example usage below.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Add the following to the r2dec package script before R2PM_END:

```sh
if [ "$ACTION" = clean ]; then
	R2PM_AUTOCLEAN_GITDIR=0
	R2PM_CLEAN_GITDIR "r2dec-js"
        RC=$?
fi
```

and then run `r2pm -ci r2dec`. There should be a message stating that the `r2dec-js` dir is being cleaned.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
