### PR TITLE
Implement `rj` ##json

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -266,6 +266,7 @@ static const char *help_msg_k[] = {
 static const char *help_msg_r[] = {
 	"Usage:", "r[+-][ size]", "Resize file",
 	"r", "", "display file size",
+	"rj", "", "display the file size in JSON format",
 	"r", " size", "expand or truncate file to given size",
 	"r-", "num", "remove num bytes, move following data down",
 	"r+", "num", "insert num bytes, move following data up",
@@ -1821,15 +1822,17 @@ static int cmd_resize(void *data, const char *input) {
 			}
 		}
 		return true;
-	case 'j': // "rj"
-		if (core->file) {
+	case 'j': { // "rj"
 			PJ * pj = pj_new ();
 			pj_o (pj);
 			if (oldsize != -1) {
-				pj_n(pj, oldsize);
+				pj_n (pj, oldsize);
 			}
 			pj_end (pj);
-			pj_free (pj);
+			char *s = pj_drain (pj);
+			r_cons_printf ("%s\n", s);
+			free (s);
+			break;
 		}
 	case 'h':
 		if (core->file) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1826,7 +1826,7 @@ static int cmd_resize(void *data, const char *input) {
 			PJ * pj = pj_new ();
 			pj_o (pj);
 			if (oldsize != -1) {
-				pj_n (pj, oldsize);
+				pj_kn (pj, "size", oldsize);
 			}
 			pj_end (pj);
 			char *s = pj_drain (pj);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1830,7 +1830,7 @@ static int cmd_resize(void *data, const char *input) {
 			}
 			pj_end (pj);
 			char *s = pj_drain (pj);
-			r_cons_printf ("%s\n", s);
+			r_cons_println (s);
 			free (s);
 			break;
 		}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1821,6 +1821,16 @@ static int cmd_resize(void *data, const char *input) {
 			}
 		}
 		return true;
+	case 'j': // "rj"
+		if (core->file) {
+			PJ * pj = pj_new ();
+			pj_o (pj);
+			if (oldsize != -1) {
+				pj_n(pj, oldsize);
+			}
+			pj_end (pj);
+			pj_free (pj);
+		}
 	case 'h':
 		if (core->file) {
 			if (oldsize != -1) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Issue #13969 suggests to implement `rj`for consistency and standardization.

**Test plan**

Currently, through this commit, I'm not sure that `rj` has been implemented perfectly, as on a test binary, it there's a difference in the outputs, as shown:
```
[0x08048360]> r
7580
[0x08048360]> rj
7.4K
```
Any other high level or specific guidance is hereby requested and appreciated.

- [ ] Add the tests for `rj`, after everything is implemented correctly and ready for review

**Closing issues**

As discussed in #13969