### PR TITLE
Fix 2 last critic error lgtm

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3154,6 +3154,10 @@ reaccept:
 				}
 				goto out_of_function;
 			}
+			// prevent overflow in uncontrolled allocation size
+			if (cmd > 255) {
+				cmd = 255;
+			}
 			switch (cmd) {
 			case RAP_PACKET_OPEN:
 				r_socket_read_block (c, &flg, 1); // flags
@@ -3161,7 +3165,6 @@ reaccept:
 				r_socket_read_block (c, &cmd, 1); // len
 				pipefd = -1;
 				ptr = malloc (cmd + 1);
-				//XXX cmd is ut8..so <256 if (cmd<RAP_PACKET_MAX)
 				if (!ptr) {
 					eprintf ("Cannot malloc in rmt-open len = %d\n", cmd);
 				} else {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3154,7 +3154,7 @@ reaccept:
 				}
 				goto out_of_function;
 			}
-			switch ((ut8)cmd) {
+			switch (cmd) {
 			case RAP_PACKET_OPEN:
 				r_socket_read_block (c, &flg, 1); // flags
 				eprintf ("open (%d): ", cmd);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3154,17 +3154,13 @@ reaccept:
 				}
 				goto out_of_function;
 			}
-			// prevent overflow in uncontrolled allocation size
-			if (cmd > 255) {
-				cmd = 255;
-			}
 			switch (cmd) {
 			case RAP_PACKET_OPEN:
 				r_socket_read_block (c, &flg, 1); // flags
 				eprintf ("open (%d): ", cmd);
 				r_socket_read_block (c, &cmd, 1); // len
 				pipefd = -1;
-				ptr = malloc (cmd + 1);
+				ptr = malloc ((int)cmd + 1);
 				if (!ptr) {
 					eprintf ("Cannot malloc in rmt-open len = %d\n", cmd);
 				} else {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3160,7 +3160,10 @@ reaccept:
 				eprintf ("open (%d): ", cmd);
 				r_socket_read_block (c, &cmd, 1); // len
 				pipefd = -1;
-				ptr = malloc ((int)cmd + 1);
+				if (UT8_ADD_OVFCHK (cmd, 1)) {
+					goto out_of_function;
+				}
+				ptr = malloc (cmd + 1);
 				if (!ptr) {
 					eprintf ("Cannot malloc in rmt-open len = %d\n", cmd);
 				} else {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3163,7 +3163,7 @@ reaccept:
 				if (UT8_ADD_OVFCHK (cmd, 1)) {
 					goto out_of_function;
 				}
-				ptr = malloc (cmd + 1);
+				ptr = malloc ((size_t)cmd + 1);
 				if (!ptr) {
 					eprintf ("Cannot malloc in rmt-open len = %d\n", cmd);
 				} else {

--- a/libr/socket/socket_http_server.c
+++ b/libr/socket/socket_http_server.c
@@ -105,7 +105,7 @@ R_API RSocketHTTPRequest *r_socket_http_accept (RSocket *s, RSocketHTTPOptions *
 	}
 	if (content_length>0) {
 		r_socket_read_block (hr->s, (ut8*)buf, 1); // one missing byte wtf
-		if (content_length > INT_MAX - 1) {
+		if (ST32_ADD_OVFCHK (content_length, 1)) {
 			r_socket_http_close (hr);
 			eprintf ("Could not allocate hr data\n");
 			return NULL;

--- a/libr/socket/socket_http_server.c
+++ b/libr/socket/socket_http_server.c
@@ -73,6 +73,9 @@ R_API RSocketHTTPRequest *r_socket_http_accept (RSocket *s, RSocketHTTPOptions *
 				hr->host = strdup (buf + 6);
 			} else if (!strncmp (buf, "Content-Length: ", 16)) {
 				content_length = atoi (buf + 16);
+				if (content_length > 5000) {
+					content_length = 5000;
+				}
 			} else if (so->httpauth && !strncmp (buf, "Authorization: Basic ", 21)) {
 				char *authtoken = buf + 21;
 				size_t authlen = strlen (authtoken);

--- a/libr/socket/socket_http_server.c
+++ b/libr/socket/socket_http_server.c
@@ -73,9 +73,6 @@ R_API RSocketHTTPRequest *r_socket_http_accept (RSocket *s, RSocketHTTPOptions *
 				hr->host = strdup (buf + 6);
 			} else if (!strncmp (buf, "Content-Length: ", 16)) {
 				content_length = atoi (buf + 16);
-				if (content_length > 5000) {
-					content_length = 5000;
-				}
 			} else if (so->httpauth && !strncmp (buf, "Authorization: Basic ", 21)) {
 				char *authtoken = buf + 21;
 				size_t authlen = strlen (authtoken);
@@ -108,6 +105,11 @@ R_API RSocketHTTPRequest *r_socket_http_accept (RSocket *s, RSocketHTTPOptions *
 	}
 	if (content_length>0) {
 		r_socket_read_block (hr->s, (ut8*)buf, 1); // one missing byte wtf
+		if (content_length > INT_MAX - 1) {
+			r_socket_http_close (hr);
+			eprintf ("Could not allocate hr data\n");
+			return NULL;
+		}
 		hr->data = malloc (content_length+1);
 		hr->data_length = content_length;
 		r_socket_read_block (hr->s, hr->data, hr->data_length);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I fixed the 2 last critic error discover by lgtm.

1. Is a false positif, cmd is type ut8 and can't overflow because the standart defined his value between 0 and 255. But i add a condition to prevent regression.
2. Add a threshold of 5000 -> https://en.wikipedia.org/wiki/Maximum_transmission_unit

**Test plan**
Run the test suite

**Closing issues**
work on https://github.com/radareorg/radare2/issues/16493
