### PR TITLE
Fix sys/sdk.sh after the sdb refactoring

### DIFF
--- a/sys/sdk.sh
+++ b/sys/sdk.sh
@@ -25,6 +25,8 @@ rm -rf "${SDKDIR}"
 mkdir -p "${SDKDIR}"/lib
 rm -f libr/libr.a
 cp -rf libr/include "${SDKDIR}"
+mkdir -p "${SDKDIR}/include/sdb"
+cp -rf shlr/sdb/src/*.h "${SDKDIR}/include/sdb/"
 FILES=`find libr shlr -iname '*.a'`
 cp -f ${FILES} "${SDKDIR}"/lib
 OS=`uname`


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

SDB headers are not included in the sdk, so all the projects using the sdk are broken. this patches solves the problem


**Test plan**

sys/sdk.sh ; find r2sdk | grep sdb.h

**Closing issues**

none registered