### PR TITLE
Define PTRACE_O_* flags for old glibc

### DIFF
--- a/libr/debug/p/native/linux/linux_coredump.c
+++ b/libr/debug/p/native/linux/linux_coredump.c
@@ -9,6 +9,7 @@
 #include <sys/ptrace.h>
 #include <asm/ptrace.h>
 #include "linux_coredump.h"
+#include "linux_ptrace.h"
 
 /* For compatibility */
 #if __x86_64__ || __arm64__

--- a/libr/debug/p/native/linux/linux_coredump.h
+++ b/libr/debug/p/native/linux/linux_coredump.h
@@ -10,7 +10,7 @@
 /*Macros for XSAVE/XRESTORE*/
 /*
         From: http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developers-manual.pdf
-        Bit 00: x87 state. 
+        Bit 00: x87 state.
         Bit 01: SSE state.
         Bit 02: AVX state.
         Bits 04 - 03: MPX state. (https://software.intel.com/sites/default/files/managed/9d/f6/Intel_MPX_EnablingGuide.pdf)
@@ -24,7 +24,7 @@
 #define BNDREGS_BIT             (1ULL << 3)
 #define BNDCSR_BIT              (1ULL << 4)
 /* From Intel MPX: "The OS should set both bits to ONE to enable Intel MPX; otherwise the processor would interpret Intel MPX instructions as NOPs" */
-#define MPX_BIT			(BNDREGS_BIT | BNDCSR_BIT) 
+#define MPX_BIT			(BNDREGS_BIT | BNDCSR_BIT)
 /* https://software.intel.com/sites/default/files/managed/b4/3a/319433-024.pdf - Page 66
 "Execute XGETBV and verify that XCR0[7:5] = ‘111b’ (OPMASK state, upper 256-bit of ZMM0-ZMM15 and ZMM16-ZMM31 state are enabled by OS) and that XCR0[2:1] = ‘11b’ (XMM state and YMM state are enabled by OS)" */
 #define AVX512_k_BIT            (1ULL << 5)
@@ -60,7 +60,7 @@
 #define R_DEBUG_REG_T	struct user_regs_struct
 
 #define SIZE_NT_FILE_DESCSZ	sizeof(unsigned long) * 3   /* start_address * end_address * offset_address */
-/* 
+/*
 NT_FILE layout:
 	[number of mappings]
 	[page size]
@@ -196,7 +196,7 @@ typedef struct elf_note_types {
 	int size_roundedup;
 	int size_name;
 	char name[8];
-} note_info_t;		
+} note_info_t;
 
 typedef enum {
 	ADDR,

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -18,6 +18,8 @@
 #include <unistd.h>
 #include <elf.h>
 
+#include "linux_ptrace.h"
+
 #ifdef __GLIBC__
 #define HAVE_YMM 1
 #else

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -97,7 +97,7 @@ struct powerpc_regs_t {
 
 // typedef ut64 riscv64_regs_t [65];
 // #define R_DEBUG_REG_T riscv64_regs_t
-#define R_DEBUG_REG_T struct user_regs_struct 
+#define R_DEBUG_REG_T struct user_regs_struct
 // #define R_DEBUG_REG_T mcontext_t 77 784 in size (coz the fpu regs)
 
 #elif __mips__

--- a/libr/debug/p/native/linux/linux_ptrace.h
+++ b/libr/debug/p/native/linux/linux_ptrace.h
@@ -1,0 +1,32 @@
+#ifndef LINUX_PTRACE_H
+#define LINUX_PTRACE_H
+
+// PTRACE_* constants are defined only since glibc 2.4 but appeared much
+// earlier in linux kernel - since 2.3.99-pre6
+// So we define it manually
+// Originally these constants are defined in Linux include/uapi/linux/ptrace.h
+//
+#if __linux__ && defined(__GLIBC__)
+
+#if !defined(PTRACE_SETOPTIONS) && !defined(PTRACE_GETSIGINFO) && !defined(PTRACE_SETSIGINFO)
+#define PTRACE_SETOPTIONS 0x4200
+#define PTRACE_GETSIGINFO 0x4202
+#define PTRACE_SETSIGINFO 0x4203
+#endif
+
+#if !defined(PTRACE_O_TRACEFORK) && !defined(PTRACE_O_TRACEVFORK) && !defined(PTRACE_O_TRACECLONE) \
+	&& !defined(PTRACE_O_TRACEEXEC) && !defined(PTRACE_O_TRACEVFORKDONE) && !defined(PTRACE_O_TRACEEXIT)
+
+#define PTRACE_O_TRACESYSGOOD 1
+#define PTRACE_O_TRACEFORK (1 << 1)
+#define PTRACE_O_TRACEVFORK (1 << 2)
+#define PTRACE_O_TRACECLONE (1 << 3)
+#define PTRACE_O_TRACEEXEC (1 << 4)
+#define PTRACE_O_TRACEVFORKDONE (1 << 5)
+#define PTRACE_O_TRACEEXIT (1 << 6)
+
+#endif
+
+#endif
+
+#endif


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

A continuation of https://github.com/radareorg/radare2/pull/17416. [Debian Etch](https://wiki.debian.org/DebianEtch) has old glibc (2.2.3 for example) that doesn't define `PTRACE_GETSIGINFO`, `PTRACE_SETSIGINFO`, `PTRACE_O_*` flags, but Linux kernel already supports this value - it appeared in linux-2.3.99-pre6 while Etch has linux-2.6.18.

**Test plan**

It should build with Debian Etch: https://github.com/XVilka/debian-oldies/tree/master/etch

Just run "./build" there for the Docker container to build radare2

**Original error**

See https://github.com/XVilka/debian-oldies/issues/1:
```
In file included from p/debug_native.c:65:
p/native/linux/linux_debug.h:112:1: warning: "TRAP_BRKPT" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/debug_native.c:4:
/usr/include/bits/siginfo.h:218:1: warning: this is the location of the previous definition
In file included from p/debug_native.c:65:
p/native/linux/linux_debug.h:113:1: warning: "TRAP_TRACE" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/debug_native.c:4:
/usr/include/bits/siginfo.h:220:1: warning: this is the location of the previous definition

In file included from p/native/linux/linux_debug.c:14:
p/native/linux/linux_debug.h:112:1: warning: "TRAP_BRKPT" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/native/linux/linux_debug.c:6:
/usr/include/bits/siginfo.h:218:1: warning: this is the location of the previous definition
In file included from p/native/linux/linux_debug.c:14:
p/native/linux/linux_debug.h:113:1: warning: "TRAP_TRACE" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/native/linux/linux_debug.c:6:
/usr/include/bits/siginfo.h:220:1: warning: this is the location of the previous definition
p/native/linux/linux_debug.c: In function 'linux_handle_signals':
p/native/linux/linux_debug.c:76: error: 'PTRACE_GETSIGINFO' undeclared (first use in this function)
p/native/linux/linux_debug.c:76: error: (Each undeclared identifier is reported only once
p/native/linux/linux_debug.c:76: error: for each function it appears in.)
p/native/linux/linux_debug.c: In function 'linux_set_options':
p/native/linux/linux_debug.c:291: error: 'PTRACE_O_TRACEFORK' undeclared (first use in this function)
p/native/linux/linux_debug.c:292: error: 'PTRACE_O_TRACEVFORK' undeclared (first use in this function)
p/native/linux/linux_debug.c:293: error: 'PTRACE_O_TRACECLONE' undeclared (first use in this function)
p/native/linux/linux_debug.c:295: error: 'PTRACE_O_TRACEVFORKDONE' undeclared (first use in this function)
p/native/linux/linux_debug.c:298: error: 'PTRACE_O_TRACEEXEC' undeclared (first use in this function)
p/native/linux/linux_debug.c:301: error: 'PTRACE_O_TRACEEXIT' undeclared (first use in this function)
p/native/linux/linux_debug.c:304: error: 'PTRACE_O_TRACESYSGOOD' undeclared (first use in this function)
p/native/linux/linux_debug.c:305: error: 'PTRACE_SETOPTIONS' undeclared (first use in this function)
p/native/linux/linux_debug.c: In function 'linux_attach_single_pid':
p/native/linux/linux_debug.c:557: error: 'PTRACE_GETSIGINFO' undeclared (first use in this function)
make[4]: *** [p/native/linux/linux_debug.o] Error 1
make[4]: Leaving directory `/radare2-master/libr/debug'
make[3]: *** [foo] Error 2
```

*P.S. Also related https://github.com/radareorg/radare2/issues/17417*