### PR TITLE
Fix null dereference in Pe64_bin_pe_compute_authentihash

### DIFF
--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -670,9 +670,12 @@ static bool r_pkcs7_parse_spcmessagedigest(SpcDigestInfo *messageDigest, RASN1Ob
 }
 
 R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
-	r_return_val_if_fail (cms && !strcmp (
-		cms->signedData.contentInfo.contentType->string,
-		"spcIndirectDataContext"), NULL);
+	r_return_val_if_fail (cms, NULL);
+
+	if (strcmp (cms->signedData.contentInfo.contentType->string,
+		"spcIndirectDataContext")) {
+		return NULL;
+	}
 
 	SpcIndirectDataContent *spcinfo = R_NEW0 (SpcIndirectDataContent);
 	if (!spcinfo) {

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -670,10 +670,9 @@ static bool r_pkcs7_parse_spcmessagedigest(SpcDigestInfo *messageDigest, RASN1Ob
 }
 
 R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
-	if (!cms || r_str_cmp (cms->signedData.contentInfo.contentType->string,
-				   		   "spcIndirectDataContext", -1)) {
-		return NULL;
-	}
+	r_return_val_if_fail (cms && !strcmp (
+		cms->signedData.contentInfo.contentType->string,
+		"spcIndirectDataContext"), NULL);
 
 	SpcIndirectDataContent *spcinfo = R_NEW0 (SpcIndirectDataContent);
 	if (!spcinfo) {

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -324,6 +324,10 @@ R_API RCMS *r_pkcs7_parse_cms(const ut8 *buffer, ut32 length) {
 	}
 	if (object->list.objects[0]) {
 		container->contentType = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
+		if (!container->contentType) {
+			r_asn1_free_object (object);
+			return NULL;
+		}
 	}
 	if (object->list.objects[1]) {
 		r_pkcs7_parse_signeddata (&container->signedData, object->list.objects[1]->list.objects[0]);

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -687,9 +687,8 @@ R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
 	RASN1Object *object = r_asn1_create_object (content->binary, content->length, content->binary);
 	if (!object || object->list.length < 2 || !object->list.objects ||
 		!object->list.objects[0] || !object->list.objects[1]) {
-		r_asn1_free_object (object);
-		free (spcinfo);
-		return NULL;
+		R_FREE (spcinfo);
+		goto beach;
 	}
 	if (object->list.objects[0]) {
 		if (!r_pkcs7_parse_spcdata (&spcinfo->data, object->list.objects[0])) {

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -654,7 +654,9 @@ static bool r_pkcs7_parse_spcmessagedigest(SpcDigestInfo *messageDigest, RASN1Ob
 		!object->list.objects[0] || !object->list.objects[1]) {
 		return false;
 	}
-	r_x509_parse_algorithmidentifier (&messageDigest->digestAlgorithm, object->list.objects[0]);
+	if (!r_x509_parse_algorithmidentifier (&messageDigest->digestAlgorithm, object->list.objects[0])) {
+		return false;
+	}
 	RASN1Object *obj1 = object->list.objects[1];
 	messageDigest->digest = r_asn1_create_binary (obj1->sector, obj1->length);
 	return true;
@@ -686,8 +688,12 @@ R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
 		r_pkcs7_parse_spcdata (&spcinfo->data, object->list.objects[0]);
 	}
 	if (object->list.objects[1]) {
-		r_pkcs7_parse_spcmessagedigest (&spcinfo->messageDigest, object->list.objects[1]);
+		if (!r_pkcs7_parse_spcmessagedigest (&spcinfo->messageDigest, object->list.objects[1])) {
+			R_FREE (spcinfo);
+			goto beach;
+		}
 	}
+beach:
 	r_asn1_free_object (object);
 	return spcinfo;
 }

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -670,7 +670,8 @@ static bool r_pkcs7_parse_spcmessagedigest(SpcDigestInfo *messageDigest, RASN1Ob
 }
 
 R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
-	if (!cms) {
+	if (!cms || r_str_cmp (cms->signedData.contentInfo.contentType->string,
+				   		   "spcIndirectDataContext", -1)) {
 		return NULL;
 	}
 

--- a/libr/util/pkcs7.c
+++ b/libr/util/pkcs7.c
@@ -644,6 +644,9 @@ static bool r_pkcs7_parse_spcdata(SpcAttributeTypeAndOptionalValue *data, RASN1O
 		return false;
 	}
 	data->type = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
+	if (!data->type) {
+		return false;
+	}
 	RASN1Object *obj1 = object->list.objects[1];
 	if (object->list.length > 1) {
 		if (obj1) {
@@ -689,7 +692,10 @@ R_API SpcIndirectDataContent *r_pkcs7_parse_spcinfo(RCMS *cms) {
 		return NULL;
 	}
 	if (object->list.objects[0]) {
-		r_pkcs7_parse_spcdata (&spcinfo->data, object->list.objects[0]);
+		if (!r_pkcs7_parse_spcdata (&spcinfo->data, object->list.objects[0])) {
+			R_FREE (spcinfo);
+			goto beach;
+		}
 	}
 	if (object->list.objects[1]) {
 		if (!r_pkcs7_parse_spcmessagedigest (&spcinfo->messageDigest, object->list.objects[1])) {

--- a/libr/util/x509.c
+++ b/libr/util/x509.c
@@ -41,8 +41,12 @@ static inline bool is_oid_object (RASN1Object *object) {
 }
 
 bool r_x509_parse_algorithmidentifier (RX509AlgorithmIdentifier *ai, RASN1Object *object) {
-	r_return_val_if_fail (ai && object && object->list.length >= 1 &&
-		object->list.objects && is_oid_object (object), false);
+	r_return_val_if_fail (ai && object, false);
+
+	if (object->list.length < 1 || !object->list.objects || !is_oid_object (object)) {
+			return false;
+	}
+
 	ai->algorithm = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
 	ai->parameters = NULL; // TODO
 	//ai->parameters = asn1_stringify_sector (object->list.objects[1]);

--- a/libr/util/x509.c
+++ b/libr/util/x509.c
@@ -34,13 +34,18 @@ static bool r_x509_parse_validity(RX509Validity *validity, RASN1Object *object) 
 	return true;
 }
 
+static inline bool is_oid_object (RASN1Object *object) {
+	return object->list.objects[0] &&
+		object->list.objects[0]->klass == CLASS_UNIVERSAL &&
+		object->list.objects[0]->tag == TAG_OID;
+}
+
 bool r_x509_parse_algorithmidentifier (RX509AlgorithmIdentifier *ai, RASN1Object *object) {
-	if (!ai || !object || object->list.length < 1 || !object->list.objects) {
+	if (!ai || !object || object->list.length < 1 || !object->list.objects ||
+		!is_oid_object (object)) {
 		return false;
 	}
-	if (object->list.objects[0] && object->list.objects[0]->klass == CLASS_UNIVERSAL && object->list.objects[0]->tag == TAG_OID) {
-		ai->algorithm = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
-	}
+	ai->algorithm = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
 	ai->parameters = NULL; // TODO
 	//ai->parameters = asn1_stringify_sector (object->list.objects[1]);
 	return true;

--- a/libr/util/x509.c
+++ b/libr/util/x509.c
@@ -41,10 +41,8 @@ static inline bool is_oid_object (RASN1Object *object) {
 }
 
 bool r_x509_parse_algorithmidentifier (RX509AlgorithmIdentifier *ai, RASN1Object *object) {
-	if (!ai || !object || object->list.length < 1 || !object->list.objects ||
-		!is_oid_object (object)) {
-		return false;
-	}
+	r_return_val_if_fail (ai && object && object->list.length >= 1 &&
+		object->list.objects && is_oid_object (object), false);
 	ai->algorithm = r_asn1_stringify_oid (object->list.objects[0]->sector, object->list.objects[0]->length);
 	ai->parameters = NULL; // TODO
 	//ai->parameters = asn1_stringify_sector (object->list.objects[1]);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I was following [Windows Authenticode Portable Executable Signature Format](https://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/authenticode_pe.docx) to verify which fields are mandatory and which are optional, and added further verifications to make sure  that objects that were not initialized correctly, will be dropped.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**


Closes #17431
