### PR TITLE
Older GCC/Glibc warning fixes

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3432,7 +3432,7 @@ static bool anal_block_cb(RAnalBlock *bb, BlockRecurseCtx *ctx) {
 		int opsize = op->size;
 		int optype = op->type;
 		r_anal_op_free (op);
-		if (opsize < 1) { 
+		if (opsize < 1) {
 			break;
 		}
 		if (optype == R_ANAL_OP_TYPE_CALL) {
@@ -3453,7 +3453,7 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly) {
 	if (core->anal->opt.bb_max_size < 1) {
 		return;
 	}
-	BlockRecurseCtx ctx = { 0, { 0 }, argonly, fcn, core };
+	BlockRecurseCtx ctx = { 0, {{ 0 }}, argonly, fcn, core };
 	r_pvector_init (&ctx.reg_set, free);
 	int *reg_set = R_NEWS0 (int, REG_SET_SIZE);
 	r_pvector_push (&ctx.reg_set, reg_set);

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -109,11 +109,13 @@ typedef ut64 mips64_regs_t [274];
 #endif
 
 // SIGTRAP si_codes from <asm/siginfo.h>
+#if !defined(TRAP_BRKPT) && !defined(TRAP_TRACE)
 #define TRAP_BRKPT		1
 #define TRAP_TRACE		2
 #define TRAP_BRANCH		3
 #define TRAP_HWBKPT		4
 #define TRAP_UNK		5
+#endif
 
 //API
 bool linux_set_options(RDebug *dbg, int pid);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

A continuation of https://github.com/radareorg/radare2/pull/17459. Continuing to bringing radare2 to the older platforms - older GCC and Glibc.


**Test plan**

It should build with Debian Etch: https://github.com/XVilka/debian-oldies/tree/master/etch

Just run "./build" there for the Docker container to build radare2

**Original error**

```
In file included from p/native/linux/linux_debug.c:14:
p/native/linux/linux_debug.h:112:1: warning: "TRAP_BRKPT" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/native/linux/linux_debug.c:6:
/usr/include/bits/siginfo.h:218:1: warning: this is the location of the previous definition
In file included from p/native/linux/linux_debug.c:14:
p/native/linux/linux_debug.h:113:1: warning: "TRAP_TRACE" redefined
In file included from /usr/include/signal.h:212,
                 from /radare2-master/libr/include/r_util/r_signal.h:5,
                 from /radare2-master/libr/include/r_cons.h:16,
                 from /radare2-master/libr/include/r_diff.h:6,
                 from /radare2-master/libr/include/r_util.h:7,
                 from /radare2-master/libr/include/r_io.h:7,
                 from /radare2-master/libr/include/r_anal.h:11,
                 from /radare2-master/libr/include/r_debug.h:5,
                 from p/native/linux/linux_debug.c:6:

 gcc -c  -MD   -fPIC -g -Wall -D__UNIX__=1 -I../../shlr/heap/include -I../../shlr/tree-sitter/lib/include -I../../shlr/radare2-shell-parser/src/tree_parser -DR2_PLUGIN_INCORE -I../../shlr -I/radare2-master/libr -I/radare2-master/libr/include -I/radare2-master/libr/../shlr/sdb/src -fvisibility=hidden -o canal.o canal.c
canal.c: In function 'r_core_recover_vars':
canal.c:3456: warning: missing braces around initializer
canal.c:3456: warning: (near initialization for 'ctx.reg_set.v')
```
