### PR TITLE
Improve cons_html_filter.

### DIFF
--- a/libr/cons/html.c
+++ b/libr/cons/html.c
@@ -2,17 +2,17 @@
 
 #include <r_cons.h>
 
-static const char *gethtmlrgb(const char *str) {
+static bool gethtmlrgb(const char *str, char *buf) {
 	ut8 r = 0, g = 0, b = 0;
 	if (r_cons_rgb_parse (str, &r, &g, &b, 0)) {
-		static char buf[32];
 		sprintf (buf, "#%02x%02x%02x", r, g, b);
-		return buf;
+		return true;
 	}
-	return "";
+	buf[0] = '\0';
+	return false;
 }
 
-static const char *gethtmlcolor(const char ptrch, const char *def) {
+static const char *gethtmlcolor(const char ptrch) {
 	switch (ptrch) {
 	case '0': return "#000"; // BLACK
 	case '1': return "#f00"; // RED
@@ -23,9 +23,9 @@ static const char *gethtmlcolor(const char ptrch, const char *def) {
 	case '6': return "#aaf"; // TURQOISE
 	case '7': return "#fff"; // WHITE
 	case '8': return "#777"; // GREY
-	case '9': break; // ???
+	case '9': break; // default
 	}
-	return def;
+	return "";
 }
 
 // TODO: move into r_util/str
@@ -33,9 +33,14 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 	const char *str = ptr;
 	int esc = 0;
 	int len = 0;
-	int inv = 0;
+	bool inv = false;
+	char text_color[16] = {};
+	char background_color[16] = {};
+	bool has_set = false;
+	bool need_to_set = false;
+	bool need_to_clear = false;
+	bool first_style;
 	int tmp;
-	bool tag_font = false;
 	if (!ptr) {
 		return NULL;
 	}
@@ -44,6 +49,33 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 		return NULL;
 	}
 	for (; ptr[0]; ptr = ptr + 1) {
+		if (esc == 0 && ptr[0] != 0x1b && need_to_set) {
+			if (has_set) {
+				r_strbuf_append (res, "</font>");
+				has_set = false;
+			}
+			if (!need_to_clear) {
+				first_style = true;
+				r_strbuf_append (res, "<font");
+				if (text_color[0]) {
+					r_strbuf_appendf (res, " color='%s'", text_color);
+				}
+				if (background_color[0]) {
+					r_strbuf_append (res, first_style? " style='": ";");
+					r_strbuf_appendf (res, "background-color:%s", background_color);
+					first_style = false;
+				}
+				if (inv) {
+					r_strbuf_append (res, first_style? " style='": ";");
+					r_strbuf_append (res, "text-decoration:underline overline");
+					first_style = false;
+				}
+				r_strbuf_append (res, first_style? ">": "'>");
+				has_set = true;
+			}
+			need_to_clear = false;
+			need_to_set = false;
+		}
 		if (ptr[0] == '\n') {
 			tmp = (int) (size_t) (ptr - str);
 			r_strbuf_append_n (res, str, tmp);
@@ -56,13 +88,13 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 			str = ptr + 1;
 			continue;
 		} else if (ptr[0] == '<') {
-			tmp = (int) (size_t) (ptr - str);
+			tmp = (int)(size_t) (ptr - str);
 			r_strbuf_append_n (res, str, tmp);
 			r_strbuf_append (res, "&lt;");
 			str = ptr + 1;
 			continue;
 		} else if (ptr[0] == '>') {
-			tmp = (int) (size_t) (ptr - str);
+			tmp = (int)(size_t) (ptr - str);
 			r_strbuf_append_n (res, str, tmp);
 			r_strbuf_append (res, "&gt;");
 			str = ptr + 1;
@@ -76,12 +108,8 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 		}
 		if (ptr[0] == 0x1b) {
 			esc = 1;
-			tmp = (int) (size_t) (ptr - str);
+			tmp = (int)(size_t) (ptr - str);
 			r_strbuf_append_n (res, str, tmp);
-			if (tag_font) {
-				r_strbuf_append (res, "</font>");
-				tag_font = false;
-			}
 			str = ptr + 1;
 			continue;
 		}
@@ -114,15 +142,15 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 				continue;
 			} else if (!strncmp (ptr, "48;5;", 5) || !strncmp (ptr, "48;2;", 5)) {
 				char *end = strchr (ptr, 'm');
-				r_strbuf_appendf (res, "<font style='background-color:%s'>", gethtmlrgb (ptr));
-				tag_font = true;
+				gethtmlrgb (ptr, background_color);
+				need_to_set = true;
 				ptr = end;
 				str = ptr + 1;
 				esc = 0;
 			} else if (!strncmp (ptr, "38;5;", 5) || !strncmp (ptr, "38;2;", 5)) {
 				char *end = strchr (ptr, 'm');
-				r_strbuf_appendf (res, "<font color='%s'>", gethtmlrgb (ptr));
-				tag_font = true;
+				gethtmlrgb (ptr, text_color);
+				need_to_set = true;
 				ptr = end;
 				str = ptr + 1;
 				esc = 0;
@@ -135,43 +163,56 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 				continue;
 			} else if (ptr[0] == '0' && ptr[1] == 'm') {
 				str = (++ptr) + 1;
-				esc = inv = 0;
+				esc = 0;
+				inv = false;
+				text_color[0] = '\0';
+				background_color[0] = '\0';
+				need_to_set = need_to_clear = true;
 				continue;
 				// reset color
-			} else if (ptr[0] == '7' && ptr[1] == 'm') {
-				str = (++ptr) + 1;
-				inv = 128;
+			} else if (!strncmp (ptr, "27m", 3)) {
+				inv = false;
+				need_to_set = true;
+				ptr = ptr + 2;
+				str = ptr + 1;
 				esc = 0;
 				continue;
-				// reset color
+				// reset invert color
+			} else if (ptr[0] == '7' && ptr[1] == 'm') {
+				str = (++ptr) + 1;
+				inv = true;
+				need_to_set = true;
+				esc = 0;
+				continue;
+				// invert color
 			} else if (ptr[0] == '3' && ptr[2] == 'm') {
-				const char *htmlColor = gethtmlcolor (ptr[1], inv? "#fff":NULL);
+				const char *htmlColor = gethtmlcolor (ptr[1]);
 				if (htmlColor) {
-					r_strbuf_appendf (res, "<font color='%s'>", htmlColor);
+					r_str_ncpy (text_color, htmlColor, sizeof (text_color));
 				}
-				tag_font = true;
-				ptr = ptr + 1;
-				str = ptr + 2;
+				need_to_set = true;
+				ptr = ptr + 2;
+				str = ptr + 1;
 				esc = 0;
 				continue;
 			} else if (ptr[0] == '4' && ptr[2] == 'm') {
-				const char *htmlColor = gethtmlcolor (ptr[1], inv? "#000":NULL);
+				const char *htmlColor = gethtmlcolor (ptr[1]);
 				if (htmlColor) {
-					r_strbuf_appendf (res, "<font style='background-color:%s'>", htmlColor);
+					r_str_ncpy (background_color, htmlColor, sizeof (background_color));
 				}
-				tag_font = true;
-				ptr = ptr + 1;
-				str = ptr + 2;
+				need_to_set = true;
+				ptr = ptr + 2;
+				str = ptr + 1;
 				esc = 0;
 				continue;
 			}
 		}
 		len++;
 	}
-	if (tag_font) {
+	r_strbuf_append_n (res, str, ptr - str);
+	if (has_set) {
 		r_strbuf_append (res, "</font>");
 	}
-	r_strbuf_append_n (res, str, ptr - str);
 	if (newlen) {
 		*newlen = res->len;
 	}

--- a/libr/cons/html.c
+++ b/libr/cons/html.c
@@ -34,8 +34,8 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 	int esc = 0;
 	int len = 0;
 	bool inv = false;
-	char text_color[16] = {};
-	char background_color[16] = {};
+	char text_color[16] = {0};
+	char background_color[16] = {0};
 	bool has_set = false;
 	bool need_to_set = false;
 	bool need_to_clear = false;

--- a/test/unit/test_cons.c
+++ b/test/unit/test_cons.c
@@ -118,8 +118,55 @@ bool test_r_cons() {
 	mu_end;
 }
 
+bool test_cons_to_html() {
+	char *html;
+
+	html = r_cons_html_filter ("\x1b[32mhello\x1b[0m", NULL);
+	mu_assert_streq_free (html, "<font color='#0f0'>hello</font>", "Simple font color");
+
+	html = r_cons_html_filter ("\x1b[31mhello\x1b[0mabc", NULL);
+	mu_assert_streq_free (html, "<font color='#f00'>hello</font>abc", "Simple font color2");
+
+	html = r_cons_html_filter ("\x1b[31mhe\x1b[44mllo\x1b[0mabc", NULL);
+	mu_assert_streq_free (html, "<font color='#f00'>he</font><font color='#f00' style='background-color:#00f'>llo</font>abc", "Color and background");
+
+	html = r_cons_html_filter ("\x1b[44mhe\x1b[31mllo\x1b[0mabc", NULL);
+	mu_assert_streq_free (html, "<font style='background-color:#00f'>he</font><font color='#f00' style='background-color:#00f'>llo</font>abc", "Background and color");
+
+	html = r_cons_html_filter ("AA\x1b[31mBB\x1b[32mCC\x1b[0mDD", NULL);
+	mu_assert_streq_free (html, "AA<font color='#f00'>BB</font><font color='#0f0'>CC</font>DD", "Switch color");
+
+	html = r_cons_html_filter ("AA\x1b[31mBB\x1b[32m\x1b[41mCC\x1b[0mDD", NULL);
+	mu_assert_streq_free (html, "AA<font color='#f00'>BB</font><font color='#0f0' style='background-color:#f00'>CC</font>DD", "Multiple changes");
+
+	html = r_cons_html_filter ("\x1b[33m0x0005d01\x1b[0m \x1b[36mand\x1b[36m foo", NULL);
+	mu_assert_streq_free (html, "<font color='#ff0'>0x0005d01</font>&nbsp;<font color='#aaf'>and</font><font color='#aaf'>&nbsp;foo</font>", "Space and reset");
+
+	html = r_cons_html_filter ("\x1b[33mAAAA\x1b[7mBBBB\x1b[33mBBB\x1b[0mCCC", NULL);
+	mu_assert_streq_free (html, "<font color='#ff0'>AAAA</font>"
+				    "<font color='#ff0' style='text-decoration:underline overline'>BBBB</font>"
+				    "<font color='#ff0' style='text-decoration:underline overline'>BBB</font>CCC",
+		"Invert");
+
+	html = r_cons_html_filter ("\x1b[33mAAAA\x1b[7mBBBB\x1b[33mBBB\x1b[27mCCC", NULL);
+	mu_assert_streq_free (html, "<font color='#ff0'>AAAA</font>"
+				    "<font color='#ff0' style='text-decoration:underline overline'>BBBB</font>"
+				    "<font color='#ff0' style='text-decoration:underline overline'>BBB</font><font color='#ff0'>CCC</font>",
+		"Invert rest");
+
+	html = r_cons_html_filter ("\x1b[41m\x1b[31mBB\x1b[39mCC", NULL);
+	mu_assert_streq_free (html, "<font color='#f00' style='background-color:#f00'>BB</font>"
+		"<font style='background-color:#f00'>CC</font>", "Default font color color");
+
+	html = r_cons_html_filter ("\x1b[41m\x1b[31mBB\x1b[49mCC", NULL);
+	mu_assert_streq_free (html, "<font color='#f00' style='background-color:#f00'>BB</font><font color='#f00'>CC</font>", "Default background color");
+
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test (test_r_cons);
+	mu_run_test (test_cons_to_html);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Old implementation didn't handle well mix of text and background color changes.

**Test plan**

* Unit tests work
* disassembly output in Cutter which uses cons_html_filter isn't broken
![Screenshot from 2020-08-14 22-48-19](https://user-images.githubusercontent.com/7101031/90287357-59ae5980-de80-11ea-8de0-899a35a5ad04.png)


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
