### PR TITLE
Fix race condition and remove unnecessary SDB build targets ##build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 endif
 
 all: plugins.cfg libr/include/r_version.h
-	${MAKE} -C shlr targets
+	${MAKE} -C shlr sdbs
 	${MAKE} -C shlr/zip
 	${MAKE} -C libr/util
 	${MAKE} -C libr/socket

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -64,7 +64,6 @@ ifeq (${BUILD_OS},haiku)
   LDFLAGS+=-lexecinfo
 endif
 
-EXTRA_PRE+=sdb_version
 EXTRA_PRE+=spp_config
 
 include ../rules.mk

--- a/libr/util/sdb.mk
+++ b/libr/util/sdb.mk
@@ -1,6 +1,7 @@
 SDBPATH=../../shlr/sdb/src/
 SDBLIB=${SDBPATH}/libsdb.a
 EXTRA_TARGETS+=${SDBLIB}
+EXTRA_PRE+=$(SDBLIB)
 
 SDB_OBJS=
 SDB_OBJS+=buffer.o
@@ -34,6 +35,5 @@ OBJS+=$(SDBOBJS)
 
 CFLAGS+=-I$(SDBPATH)
 
-sdb_version:
-	$(MAKE) -C "$(SDBPATH)" sdb_version.h
-	${MAKE} -C ${SDBPATH}
+$(SDBLIB):
+	$(MAKE) -C ../../shlr sdbs

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -60,7 +60,7 @@ CS_REV=
 CS_PATCHES=1
 endif
 
-.PHONY: capstone-sync capstone-build all clean mrproper libgdbr libwindbg bochs tree-sitter-sync
+.PHONY: capstone-sync capstone-build all clean mrproper libgdbr libwindbg bochs tree-sitter-sync sdbs
 
 ifeq ($(shell gcc -v > /dev/null 2>&1 && echo works),works)
 HOST_CC?=gcc
@@ -113,23 +113,12 @@ else
 BUILD_EXT_EXE=
 endif
 
-SDB_TARGETS=$(SDBLIB)
-ifneq (${EXT_EXE},)
-SDB_TARGETS+=sdb/sdb${EXT_EXE}
-else
-SDB_TARGETS+=sdb/sdb
-endif
-
 PIC=
 ifneq ($(CC),cccl)
 PIC=-fPIC
-ifeq ($(filter sdb/sdb${BUILD_EXT_EXE},$(SDB_TARGETS)),)
-SDB_TARGETS+=sdb/sdb${BUILD_EXT_EXE}
-endif
 endif
 
-targets:
-	#for TARGET in ${SDB_TARGETS} ; do ${MAKE} $$TARGET ; done
+sdbs:
 	$(MAKE) sdb-native-build HOST_CC=$(HOST_CC) CC=$(HOST_CC)
 	$(MAKE) sdb-target-build
 
@@ -157,6 +146,7 @@ sdb-native-build: sdb/src/sdb_version.h
 	cp -f sdb/src/sdb${BUILD_EXT_EXE} sdb/src/.sdb${BUILD_EXT_EXE}
 	cp -f sdb/src/sdb${BUILD_EXT_EXE} sdb/sdb$(BUILD_EXT_EXE)
 	-file sdb/sdb$(BUILD_EXT_EXE)
+	cp -f sdb/src/.sdb${BUILD_EXT_EXE} $@
 
 sdb-target-build: sdb/src/sdb_version.h
 	@echo
@@ -169,14 +159,6 @@ sdb-target-build: sdb/src/sdb_version.h
 	$(MAKE) -C sdb/src ARCH=xxx RANLIB="${RANLIB}" CFLAGS_SHARED="${CFLAGS_SHARED}" \
 		CC="${CC}" AR="${AR}" ARCH=undefined CFLAGS='${CFLAGS}' LDFLAGS='${LDFLAGS}' libsdb.a
 	${RANLIB} sdb/src/libsdb.a
-
-${SDB_TARGETS}:
-ifneq (${EXT_AR},a)
-	-cp -f sdb/src/libsdb.a sdb/src/libsdb.${EXT_AR}
-endif
-	rm -f $@
-	cp -f sdb/src/.sdb${BUILD_EXT_EXE} $@
-	$(MAKE) targets
 
 .PHONY: sdb-sync sync-sdb sdbclean sdb-native-build sdb-target-build
 SDB_F=README.md config.mk src Makefile meson.build

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -146,7 +146,6 @@ sdb-native-build: sdb/src/sdb_version.h
 	cp -f sdb/src/sdb${BUILD_EXT_EXE} sdb/src/.sdb${BUILD_EXT_EXE}
 	cp -f sdb/src/sdb${BUILD_EXT_EXE} sdb/sdb$(BUILD_EXT_EXE)
 	-file sdb/sdb$(BUILD_EXT_EXE)
-	cp -f sdb/src/.sdb${BUILD_EXT_EXE} $@
 
 sdb-target-build: sdb/src/sdb_version.h
 	@echo

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -119,27 +119,14 @@ PIC=-fPIC
 endif
 
 sdbs:
-	$(MAKE) sdb-native-build HOST_CC=$(HOST_CC) CC=$(HOST_CC)
-	$(MAKE) sdb-target-build
+	$(MAKE) sdb-host HOST_CC=$(HOST_CC) CC=$(HOST_CC)
+	$(MAKE) sdb-target
 
-sdb/src/sdb_version.h:
+sdb-host:
 	@echo
-	@echo BUILD SUMARY
-	@echo ============
-	@echo COMPILER ${COMPILER}
-	@echo CC ${CC}
-	@echo HOST_CC ${HOST_CC}
-	@echo HOST_OS ${HOST_OS}
-	@echo BUILD_OS ${BUILD_OS}
-	@echo ============
-	$(MAKE) -C sdb clean
-	$(MAKE) -C sdb src/sdb_version.h
-
-sdb-native-build: sdb/src/sdb_version.h
-	@echo
-	@echo ">>>>>>>>>>>>>>>>"
-	@echo "NATIVE BUILD SDB"
-	@echo ">>>>>>>>>>>>>>>>"
+	@echo ">>>>>>>>"
+	@echo "HOST SDB"
+	@echo ">>>>>>>>"
 	@echo
 	$(MAKE) -C sdb clean ; rm -f sdb/src/*.o sdb/src/sdb_version.h
 	$(MAKE) -C sdb/src "CC=${HOST_CC}" LDFLAGS='${HOST_LDFLAGS}' CPPFLAGS='' CFLAGS='${HOST_CFLAGS} ${PIC}' bin
@@ -147,11 +134,11 @@ sdb-native-build: sdb/src/sdb_version.h
 	cp -f sdb/src/sdb${BUILD_EXT_EXE} sdb/sdb$(BUILD_EXT_EXE)
 	-file sdb/sdb$(BUILD_EXT_EXE)
 
-sdb-target-build: sdb/src/sdb_version.h
+sdb-target:
 	@echo
-	@echo ">>>>>>>>>>>>>>>>"
-	@echo "TARGET BUILD SDB"
-	@echo ">>>>>>>>>>>>>>>>"
+	@echo ">>>>>>>>>>"
+	@echo "TARGET SDB"
+	@echo ">>>>>>>>>>"
 	@echo
 	$(MAKE) -C sdb clean ; rm -f sdb/src/*.o sdb/src/sdb_version.h
 	$(MAKE) -C sdb/src sdb_version.h
@@ -159,7 +146,7 @@ sdb-target-build: sdb/src/sdb_version.h
 		CC="${CC}" AR="${AR}" ARCH=undefined CFLAGS='${CFLAGS}' LDFLAGS='${LDFLAGS}' libsdb.a
 	${RANLIB} sdb/src/libsdb.a
 
-.PHONY: sdb-sync sync-sdb sdbclean sdb-native-build sdb-target-build
+.PHONY: sdb-sync sync-sdb sdbclean sdb-native sdb-target
 SDB_F=README.md config.mk src Makefile meson.build
 SDB_SYNCFILES=$(addprefix sdb.vc/,${SDB_F})
 I=../libr/include
@@ -185,7 +172,7 @@ sdb-sync sync-sdb:
 	cp -rf ${SDB_SYNCFILES} sdb
 	rm -rf sdb.vc
 	rm -f src/sdb_version.h
-	cd sdb ; $(MAKE) src/sdb_version.h
+	$(MAKE) -C sdb src/sdb_version.h
 	mkdir -p sdb/test sdb/memcache
 	sed -e 's,HAVE_VALA=,HAVE_VALA=#,' sdb/config.mk > .t
 	mv .t sdb/config.mk

--- a/shlr/sdb/Makefile
+++ b/shlr/sdb/Makefile
@@ -14,13 +14,14 @@ endif
 
 vala:
 ifneq (${HAVE_VALA},)
-	cd ${VALADIR} && ${MAKE}
-	cd ${VALADIR}/types && ${MAKE}
+	$(MAKE) -C $(VALADIR)
+	$(MAKE) -C $(VALADIR)/types
 else
 	@echo Nothing to do.
 endif
 
-.PHONY: test sdb.js pkgconfig
+.PHONY: test sdb.js pkgconfig dist w32dista asan
+
 test:
 	${MAKE} -C test
 
@@ -38,16 +39,17 @@ CFILES=cdb.c buffer.c cdb_make.c ls.c ht.c sdb.c num.c base64.c
 CFILES+=json.c ns.c lock.c util.c disk.c query.c array.c fmt.c main.c
 EMCCFLAGS=-O2 -s EXPORTED_FUNCTIONS="['_sdb_querys','_sdb_new0']"
 #EMCCFLAGS+=--embed-file sdb.data
+
 sdb.js: src/sdb_version.h
 	cd src ; emcc ${EMCCFLAGS} -I. -o ../sdb.js ${CFILES}
 
 clean:
 	rm -f src/sdb_version.h
-	cd src && ${MAKE} clean
-	cd memcache && ${MAKE} clean
-	cd test && ${MAKE} clean
+	$(MAKE) -C src clean
+	$(MAKE) -C memcache clean
+	$(MAKE) -C test clean
 ifneq (${HAVE_VALA},)
-	cd ${VALADIR} && ${MAKE} clean
+	${MAKE} -C $(VALADIR) clean
 endif
 
 dist:

--- a/shlr/sdb/config.mk
+++ b/shlr/sdb/config.mk
@@ -6,7 +6,7 @@ INCDIR=${PREFIX}/include
 VAPIDIR=${DATADIR}/vala/vapi/
 MANDIR=${DATADIR}/man/man1
 
-SDBVER=1.4.1
+SDBVER=1.5.1-git
 
 BUILD_MEMCACHE=0
 

--- a/shlr/sdb/src/Makefile
+++ b/shlr/sdb/src/Makefile
@@ -53,7 +53,10 @@ ifneq ($(SILENT),)
 endif
 	$(CC) ${CFLAGS} ${LDFLAGS} $(LDFLAGS_SHARED) -o $@ ${SOBJ}
 
-bin $(BIN): sdb_version.h libsdb.a main.o
+bin_deps: sdb_version.h
+	$(MAKE) libsdb.a main.o
+
+bin $(BIN): bin_deps
 ifneq ($(SILENT),)
 	@echo BIN ${BIN}
 endif

--- a/shlr/sdb/src/Makefile
+++ b/shlr/sdb/src/Makefile
@@ -8,15 +8,13 @@ SOBJ=$(subst .o,.o.o,${OBJ})
 WITHPIC?=1
 BIN=sdb${EXT_EXE}
 
-.PHONY: all static shared clean
+.PHONY: all static shared clean mrproper install
 
-all: ${BIN} sdb_version.h
-	${MAKE} static
+all: $(BIN)
+	$(MAKE) static
 ifeq ($(WITHPIC),1)
-	${MAKE} shared
+	$(MAKE) shared
 endif
-
-bin: $(BIN)
 
 json.o: json/api.c json/js0n.c json/path.c json/rangstr.c json/indent.c
 
@@ -24,15 +22,21 @@ install:
 	$(MAKE) -C .. install
 
 sdb_version.h:
-	cd .. ; ${MAKE} src/sdb_version.h
+	$(MAKE) -C .. src/sdb_version.h
 
 shared: sdb_version.h
-	${MAKE} libsdb.${SOVER}
+	$(MAKE) libsdb.${SOVER}
 
 static: sdb_version.h
-	${MAKE} libsdb.a
+	$(MAKE) libsdb.a
 
-libsdb.a: ${OBJ}
+sdb_objs: sdb_version.h
+	$(MAKE) ${OBJ}
+
+sdb_objs2: sdb_version.h
+	$(MAKE) ${SOBJ}
+
+libsdb.a: sdb_objs
 ifneq ($(SILENT),)
 	@echo AR libsdb.a
 endif
@@ -40,20 +44,20 @@ endif
 	${AR} q libsdb.a ${OBJ}
 	${RANLIB} libsdb.a
 
-libsdb.${SOVER}: ${SOBJ}
+libsdb.${SOVER}: sdb_objs2
 ifneq ($(EXT_SO),${SOVER})
 	ln -fs libsdb.${SOVER} libsdb.${EXT_SO}
 endif
 ifneq ($(SILENT),)
 	@echo LIB libsdb.${SOVER}
 endif
-	${CC} ${CFLAGS} ${LDFLAGS} $(LDFLAGS_SHARED) -o $@ ${SOBJ}
+	$(CC) ${CFLAGS} ${LDFLAGS} $(LDFLAGS_SHARED) -o $@ ${SOBJ}
 
-${BIN}: sdb_version.h libsdb.a main.o
+bin $(BIN): sdb_version.h libsdb.a main.o
 ifneq ($(SILENT),)
 	@echo BIN ${BIN}
 endif
-	${CC} ${CFLAGS} ${LDFLAGS} -o ${BIN} main.o ${OBJ}
+	$(CC) ${CFLAGS} ${LDFLAGS} -o ${BIN} main.o ${OBJ}
 
 mrproper clean:
 	rm -rf ${OBJ} ${SOBJ} main.o libsdb.a a.out ${BIN} sdb.dSYM
@@ -72,14 +76,14 @@ S=$
 ifneq ($(SILENT),)
 	@echo CC $<
 endif
-	${CC} -c ${CPPFLAGS} ${CFLAGS} ${CFLAGS_SHARED} -o $@ $<
+	$(CC) -c ${CPPFLAGS} ${CFLAGS} ${CFLAGS_SHARED} -o $@ $<
 
 %.o.o: %.c
 ifneq ($(SILENT),)
 	@echo CC PIC $<
 endif
 	@mv `echo $<|sed -e 's,\.c$S,\.d,g'` $<.tmp 2>/dev/null || true
-	${CC} -c ${CPPFLAGS} ${CFLAGS} ${CFLAGS_SHARED} -o $@ $<
+	$(CC) -c ${CPPFLAGS} ${CFLAGS} ${CFLAGS_SHARED} -o $@ $<
 	@mv `echo $<|sed -e 's,\.c$S,\.d,g'` `echo $<|sed -e 's,\.c$S,\._d,g'` 2>/dev/null || true
 	@mv $<.tmp `echo $<|sed -e 's,\.c$S,\.d,g'` 2>/dev/null ||true
 

--- a/shlr/sdb/src/cdb.c
+++ b/shlr/sdb/src/cdb.c
@@ -59,6 +59,9 @@ bool cdb_init(struct cdb *c, int fd) {
 			eprintf ("Cannot mmap %d\n", (int)st.st_size);
 			return false;
 		}
+		if (c->map) {
+			munmap (c->map, c->size);
+		}
 #else
 		char *x = calloc (1, st.st_size);
 		if (!x) {
@@ -69,12 +72,6 @@ bool cdb_init(struct cdb *c, int fd) {
 		if (read (fd, x, st.st_size) != st.st_size) {
 			/* handle read error */
 		}
-#endif
-#if USE_MMAN
-		if (c->map) {
-			munmap (c->map, c->size);
-		}
-#else
 		free (c->map);
 #endif
 		c->map = x;

--- a/shlr/sdb/src/disk.c
+++ b/shlr/sdb/src/disk.c
@@ -64,7 +64,7 @@ static inline int r_sys_mkdirp(char *dir) {
 #if __SDB_WINDOWS__
 	char *p = strstr (ptr, ":\\");
 	if (p) {
-		ptr = p + 3;
+		ptr = p + 2;
 	}
 #endif
 	while ((ptr = strchr (ptr, slash))) {

--- a/shlr/sdb/src/ls.c
+++ b/shlr/sdb/src/ls.c
@@ -11,7 +11,7 @@ SDB_API SdbList *ls_newf(SdbListFree freefn) {
 	return list;
 }
 
-SDB_API SdbList *ls_new() {
+SDB_API SdbList *ls_new(void) {
 	SdbList *list = R_NEW0 (SdbList);
 	if (!list) {
 		return NULL;

--- a/shlr/sdb/src/sdbht.c
+++ b/shlr/sdb/src/sdbht.c
@@ -1,4 +1,4 @@
-/* sdb - MIT - Copyright 2011-2018 - pancake */
+/* sdb - MIT - Copyright 2011-2020 - pancake */
 
 #include "sdbht.h"
 
@@ -7,7 +7,7 @@ void sdbkv_fini(SdbKv *kv) {
 	free (kv->base.value);
 }
 
-SDB_API HtPP* sdb_ht_new() {
+SDB_API HtPP* sdb_ht_new(void) {
 	HtPP *ht = ht_pp_new ((HtPPDupValue)strdup, (HtPPKvFreeFunc)sdbkv_fini, (HtPPCalcSizeV)strlen);
 	if (ht) {
 		ht->opt.elem_size = sizeof (SdbKv);
@@ -15,8 +15,7 @@ SDB_API HtPP* sdb_ht_new() {
 	return ht;
 }
 
-static bool sdb_ht_internal_insert(HtPP* ht, const char* key,
-				    const char* value, bool update) {
+static bool sdb_ht_internal_insert(HtPP* ht, const char* key, const char* value, bool update) {
 	if (!ht || !key || !value) {
 		return false;
 	}

--- a/shlr/sdb/src/util.c
+++ b/shlr/sdb/src/util.c
@@ -273,7 +273,7 @@ SDB_API const char *sdb_const_anext(const char *str) {
 	return p ? p + 1 : NULL;
 }
 
-SDB_API ut64 sdb_now () {
+SDB_API ut64 sdb_now (void) {
 #if USE_MONOTONIC_CLOCK
 	struct timespec ts;
 	if (!clock_gettime (CLOCK_MONOTONIC, &ts)) {
@@ -288,7 +288,7 @@ SDB_API ut64 sdb_now () {
 	return 0LL;
 }
 
-SDB_API ut64 sdb_unow () {
+SDB_API ut64 sdb_unow (void) {
 	ut64 x = 0LL;
 #if USE_MONOTONIC_CLOCK
 	struct timespec ts;

--- a/sys/sdk.sh
+++ b/sys/sdk.sh
@@ -20,7 +20,7 @@ cp -f "${R2_PLUGINS_CFG}" plugins.cfg
 #./configure-plugins
 ./configure --prefix="$PREFIX" --with-libr --without-libuv --without-gpl || exit 1
 #--disable-loadlibs || exit 1
-make -j8 || exit 1
+make -j1 || exit 1
 rm -rf "${SDKDIR}"
 mkdir -p "${SDKDIR}"/lib
 rm -f libr/libr.a

--- a/sys/sdk.sh
+++ b/sys/sdk.sh
@@ -20,7 +20,7 @@ cp -f "${R2_PLUGINS_CFG}" plugins.cfg
 #./configure-plugins
 ./configure --prefix="$PREFIX" --with-libr --without-libuv --without-gpl || exit 1
 #--disable-loadlibs || exit 1
-make -j1 || exit 1
+make -j8 || exit 1
 rm -rf "${SDKDIR}"
 mkdir -p "${SDKDIR}"/lib
 rm -f libr/libr.a


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

sdb_version.h is removed in make clean step which happens when runnig those two targets in parallel.

**Test plan**

make -j

**Closing issues**

none
