### PR TITLE
Handle DADDU instruction MIPS, used for GP calculation ##anal

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -408,6 +408,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case MIPS_INS_DADD:
 	case MIPS_INS_DADDI:
 	/** unsigned */
+	case MIPS_INS_DADDU:
 	case MIPS_INS_ADDU:
 	case MIPS_INS_ADDIU:
 	case MIPS_INS_DADDIU:

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -51,6 +51,23 @@ EOF
 RUN
 
 NAME=mips ld(load doubleword) instruction 
+FILE=bins/elf/analysis/mips64r2-ld-2.28.so
+CMDS=<<EOF
+s 0x000023f0
+pd 1
+s 0x00002494
+pd 1
+EOF
+EXPECT=<<EOF
+            0x000023f0      208084df       ld a0, -0x7fe0(gp)          ; [0x37020:8]=0x10a0 segment.DYNAMIC
+            0x00002494      488099df       ld t9, -0x7fb8(gp)          ; [0x37048:8]=0x134f0
+
+EOF
+RUN
+
+
+
+NAME=mips ld(load doubleword) instruction 
 FILE=bins/elf/analysis/mips64r2-busybox
 CMDS=<<EOF
 s 0x120004460

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -50,7 +50,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=mips ld(load doubleword) instruction 
+NAME=Calculate GP 
 FILE=bins/elf/analysis/mips64r2-ld-2.28.so
 CMDS=<<EOF
 s 0x000023f0
@@ -61,7 +61,6 @@ EOF
 EXPECT=<<EOF
             0x000023f0      208084df       ld a0, -0x7fe0(gp)          ; [0x37020:8]=0x10a0 segment.DYNAMIC
             0x00002494      488099df       ld t9, -0x7fb8(gp)          ; [0x37048:8]=0x134f0
-
 EOF
 RUN
 

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -64,8 +64,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-
-
 NAME=mips ld(load doubleword) instruction 
 FILE=bins/elf/analysis/mips64r2-busybox
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When the target file does not have loc._gp and the daddu instruction appears when calculating gp, a GP value calculation error will occur.

Such as the following instruction sequence:
```
0x000023d0      25c8e003       move t9, ra                 ; [11] -r-x section size 127280 named .text
            0x000023d4      01001104       bal 0x23dc
            0x000023d8      00000000       nop
            0x000023dc      25908003       move s2, gp
            0x000023e0      04001c3c       lui gp, 4
            0x000023e4      24cc9c27       addiu gp, gp, -0x33dc
            0x000023e8      2de09f03       daddu gp, gp, ra

```

[my test file](https://github.com/junchao-loongson/test-bin/raw/master/ld-nogp)

s 0x000023ec
pd 10
```
            0x000023ec      25f82003       move ra, t9
            0x000023f0      208084df       ld a0, -0x7fe0(gp)          ; [0x34c44:8]=**-1**
            0x000023f4      108084ff       sd a0, -0x7ff0(gp)
            0x000023f8      2520a003       move a0, sp
            0x000023fc      f0ffbd67       daddiu sp, sp, -0x10
            0x00002400      288088df       ld t0, -0x7fd8(gp)          ; [0x34c4c:8]=**-1**
            0x00002404      01001005       bltzal t0, 0x240c
            0x00002408      00000000       nop
            0x0000240c      2f40e803       dsubu t0, ra, t0
            0x00002410      308099df       ld t9, -0x7fd0(gp)          ; [0x34c54:8]=**-1**

```

The reason is that daddu instruction is not described in ESIL
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->



**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
