### PR TITLE
Handle COND_AL and COND_NV in analysis ##anal

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -110,6 +110,17 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		if (ret < 1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 		}
+		/* special case some conditionals */
+		if (op->cond == R_ANAL_COND_AL) {
+			/* Always conditional. */
+			op->cond = 0;
+			op->type &= ~R_ANAL_OP_TYPE_COND;
+			op->fail = 0;
+		} else if (op->cond == R_ANAL_COND_NV) {
+			/* Never conditional. */
+			op->cond = 0;
+			op->type = R_ANAL_OP_TYPE_NOP;
+		}
 		op->addr = addr;
 		/* consider at least 1 byte to be part of the opcode */
 		if (op->nopcode < 1) {

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -115,7 +115,6 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 			/* Always conditional. */
 			op->cond = 0;
 			op->type &= ~R_ANAL_OP_TYPE_COND;
-			op->fail = 0;
 		} else if (op->cond == R_ANAL_COND_NV) {
 			/* Never conditional. */
 			op->cond = 0;

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -111,11 +111,11 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 			op->type = R_ANAL_OP_TYPE_ILL;
 		}
 		/* special case some conditionals */
-		if (op->cond == R_ANAL_COND_AL) {
+		if (op->type & R_ANAL_OP_TYPE_COND && op->cond == R_ANAL_COND_AL) {
 			/* Always conditional. */
 			op->cond = 0;
 			op->type &= ~R_ANAL_OP_TYPE_COND;
-		} else if (op->cond == R_ANAL_COND_NV) {
+		} else if (op->type & R_ANAL_OP_TYPE_COND && op->cond == R_ANAL_COND_NV) {
 			/* Never conditional. */
 			op->cond = 0;
 			op->type = R_ANAL_OP_TYPE_NOP;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

if a RAnalOp is properly filled out, in some archs, there can be ALWAYS or NEVER conditionals.
anal should take this into consideration and treat them as either a NOP (never) or as a non conditional (ALWAYS).

...

**Test plan**

i'm adding support for another arch that supports this and will pr this soon

...

**Closing issues**
n/a

