### PR TITLE
Add DESTDIR to sys/create_r2.sh

### DIFF
--- a/sys/create_r2.bat
+++ b/sys/create_r2.bat
@@ -1,1 +1,1 @@
-@echo @"%%~dp0\radare2" %%*> %MESON_INSTALL_PREFIX%\bin\r2.bat
+@echo @"%%~dp0\radare2" %%*> %DESTDIR%\%MESON_INSTALL_PREFIX%\bin\r2.bat

--- a/sys/create_r2.bat
+++ b/sys/create_r2.bat
@@ -1,1 +1,1 @@
-@echo @"%%~dp0\radare2" %%*> %DESTDIR%\%MESON_INSTALL_PREFIX%\bin\r2.bat
+@echo @"%%~dp0\radare2" %%*> %MESON_INSTALL_PREFIX%\bin\r2.bat

--- a/sys/create_r2.sh
+++ b/sys/create_r2.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cd "${MESON_INSTALL_PREFIX}/bin" && ln -fs radare2 r2
+cd "${DESTDIR}/${MESON_INSTALL_PREFIX}/bin" && ln -fs radare2 r2


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Commit fb1190d248 adds custom meson install scripts which do not inherit `DESTDIR`, preventing installation to a custom directory.

This pull request adds `DESTDIR` following the example at https://mesonbuild.com/Installing.html#custom-install-behavior to achieve expected behavior, which is particularly useful for packaging purposes.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Specify a custom `DESTDIR` while installing. For example:

```
$ ./sys/meson.py --prefix="/usr"
$ DESTDIR="${pkgdir}" ninja -C build install
```

Note: I updated the Windows batch script as well, but do not have the capability to test it.