### PR TITLE
Fix mips.gnu,C-TYPE instruction classification error ##anal

### DIFF
--- a/libr/anal/p/anal_mips_gnu.c
+++ b/libr/anal/p/anal_mips_gnu.c
@@ -194,7 +194,7 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 			break;
 		}
 		//family = 'J';
-	} else if ((optype & 0x1c) == 0x1c) {
+	} else if ((optype & 0x3c) == 0x10) {
 /*
 	C-TYPE
 	======


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)




**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Reference ：
《MIPS® Architecture For Programmers Volume II-A: The MIPS64® Instruction Set》
A.2 Instruction Bit Encoding Tables

             000      001        010         011         100       101     110         111
 010    COP0   COP1    COP2     COP1X   BEQL   BNEL   BLEZL   BGTZL 

Therefore, the instruction mask of C-TYPE should be 0x3c (111100b)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
