### PR TITLE
Implement `lj` ##json

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1188,6 +1188,22 @@ static int cmd_ls(void *data, const char *input) { // "ls"
 			eprintf ("Usage: less [file]\n");
 		}
 		break;
+	case 'j': { // "lj"
+		PJ * pj = pj_new();
+		pj_a (pj);
+		pj_o (pj);
+		char * res = r_syscmd_ls (arg);
+		pj_s (pj, res);
+		pj_end (pj);
+		pj_end (pj);
+		char * j = pj_drain (pj);
+		if (j) {
+			r_cons_printf ("%s \n", j);
+			free (j);
+		}
+		free (res);
+		break;
+		}
 	default: // "ls"
 		if (!arg) {
 			arg = "";

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1189,18 +1189,24 @@ static int cmd_ls(void *data, const char *input) { // "ls"
 		}
 		break;
 	case 'j': { // "lj"
-		PJ * pj = pj_new();
-		pj_a (pj);
-		pj_o (pj);
-		char * res = r_syscmd_ls (arg);
-		pj_s (pj, res);
-		pj_end (pj);
-		pj_end (pj);
-		char * j = pj_drain (pj);
-		if (j) {
-			r_cons_printf ("%s \n", j);
-			free (j);
+		if (!arg) {
+			arg = "";
 		}
+		if (r_fs_check (core->fs, arg)) {
+			r_core_cmdf (core, "md %s", arg);
+		} else {
+			PJ * pj = pj_new ();
+			pj_a (pj);
+			pj_o (pj);
+			RList *res = r_sys_dir (arg);
+			pj_s (pj, res);
+			pj_end (pj);
+			pj_end (pj);
+			char * j = pj_drain (pj);
+			if (j) {
+				r_cons_println (j);
+				free (j);
+			}
 		free (res);
 		break;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Issue #13969 suggests to implement `lj` for consistency and standardization.

**Test plan**

Right now, there's extra spaces and a `\n` at the end, I would need guidance on how to fix that, if needed.
```
[{"             file1                 ../                  ./               file2\n"}] 
```

**Closing issues**

As discussed in #13969
