### PR TITLE
r2r: Check whether test has EXPECT or EXPECT_ERR

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -146,6 +146,11 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 				eprintf (LINEFMT "Error: Test without CMDS key\n", file, linenum);
 				goto fail;
 			}
+			if (!(test->expect.value || test->expect_err.value)) {
+				eprintf (LINEFMT "Error: Test without EXPECT or EXPECT_ERR key"
+				         " (did you forget an EOF?)\n", file, linenum);
+				goto fail;
+			}
 			r_pvector_push (ret, test);
 			test = r2r_cmd_test_new ();
 			if (!test) {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -181,9 +181,12 @@ NAME=t-enum
 FILE=-
 CMDS=<<EOF
 td enum pe_machine { IMAGE_FILE_MACHINE_IA64=0x200, IMAGE_FILE_MACHINE_I386=0x14c };
+te~?pe_machine
 t-pe_machine
-t~?pe_machine'
+te~?pe_machine
+EOF
 EXPECT=<<EOF
+1
 0
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Currently, tests missing both EXPECT and EXPECT_ERR (maybe via a missing EOF) are silently ignored. This pr makes r2r check whether a test has either EXPECT or EXPECT_ERR (or both) and aborts if not so.

Sample output using `r2r -i db/tools/r2`:

![test_no_expect_expect_err](https://user-images.githubusercontent.com/12002672/90968122-4dc73500-e51b-11ea-903b-afe6cd0a3609.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Remove line 118 from
https://github.com/radareorg/radare2/blob/b67d1bf7c22be6e5e31a9fa37347bab10fe00f28/test/db/tools/r2#L111-L122
and run `r2r -i db/tools/r2`. Output should be like the above.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
