### PR TITLE
Improve iA command for MIPS ##bin

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1093,7 +1093,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 					pj_ks (pj, "isa", h_flag);
 				}
 				if (machine) {
-						pj_ks (pj, "machine", machine);
+					pj_ks (pj, "machine", machine);
 				}
 				pj_end (pj);
 				break;

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1040,7 +1040,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 	ut64 obj_size = obj->obj_size;
 	const char *arch = info? info->arch: NULL;
 	const char *machine = info? info->machine: "unknown_machine";
-
+	const char *h_flag = info? info->head_flag:" ";
 	i++;
 	if (!arch) {
 		snprintf (unk, sizeof (unk), "unk_%d", i);
@@ -1060,13 +1060,16 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			pj_ki (pj, "bits", bits);
 			pj_kn (pj, "offset", boffset);
 			pj_kn (pj, "size", obj_size);
+			if (!strcmp(arch, "mips")) {
+				pj_ks (pj, "isa", h_flag);
+			}
 			if (machine) {
 				pj_ks (pj, "machine", machine);
 			}
 			pj_end (pj);
 			break;
 		default:
-			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, sdb_fmt ("%s_%i", arch, bits), machine);
+			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, sdb_fmt ("%s_%i %s", arch, bits, h_flag), machine);
 			bin->cb_printf ("%s\n", r_table_tostring(table));
 		}
 		snprintf (archline, sizeof (archline) - 1,
@@ -1086,13 +1089,16 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_ki (pj, "bits", bits);
 				pj_kn (pj, "offset", boffset);
 				pj_kn (pj, "size", obj_size);
+				if (!strcmp(arch, "mips")) {
+					pj_ks (pj, "isa", h_flag);
+				}
 				if (machine) {
-					pj_ks (pj, "machine", machine);
+						pj_ks (pj, "machine", machine);
 				}
 				pj_end (pj);
 				break;
 			default:
-				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, sdb_fmt("%s_%i", arch, bits), "");
+				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, sdb_fmt("%s_%i %s", arch, bits, h_flag), "");
 				bin->cb_printf ("%s\n", r_table_tostring(table));
 			}
 			snprintf (archline, sizeof (archline),

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1061,7 +1061,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			pj_ki (pj, "bits", bits);
 			pj_kn (pj, "offset", boffset);
 			pj_kn (pj, "size", obj_size);
-			if (!strcmp(arch, "mips")) {
+			if ( !strcmp(arch, "mips") ) {
 				pj_ks (pj, "isa", h_flag);
 			}
 			if (machine) {
@@ -1070,8 +1070,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			pj_end (pj);
 			break;
 		default:
-			str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag)
-					  :sdb_fmt ("%s_%i", arch, bits);
+			str_fmt = strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
+					  : sdb_fmt ("%s_%i", arch, bits);
 			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, str_fmt , machine);
 			bin->cb_printf ("%s\n", r_table_tostring(table));
 		}
@@ -1101,8 +1101,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_end (pj);
 				break;
 			default:
-				str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag)\
-						  :sdb_fmt ("%s_%i", arch, bits);
+				str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
+						  : sdb_fmt ("%s_%i", arch, bits);
 				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
 				bin->cb_printf ("%s\n", r_table_tostring(table));
 			}

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1040,7 +1040,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 	ut64 obj_size = obj->obj_size;
 	const char *arch = info? info->arch: NULL;
 	const char *machine = info? info->machine: "unknown_machine";
-	const char *h_flag = info? info->head_flag:" ";
+	const char *h_flag = info? info->head_flag: NULL;
+	char * str_fmt;
 	i++;
 	if (!arch) {
 		snprintf (unk, sizeof (unk), "unk_%d", i);
@@ -1069,7 +1070,9 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			pj_end (pj);
 			break;
 		default:
-			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, sdb_fmt ("%s_%i %s", arch, bits, h_flag), machine);
+			str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag)
+					  :sdb_fmt ("%s_%i", arch, bits);
+			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, str_fmt , machine);
 			bin->cb_printf ("%s\n", r_table_tostring(table));
 		}
 		snprintf (archline, sizeof (archline) - 1,
@@ -1098,7 +1101,9 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_end (pj);
 				break;
 			default:
-				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, sdb_fmt("%s_%i %s", arch, bits, h_flag), "");
+				str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag)\
+						  :sdb_fmt ("%s_%i", arch, bits);
+				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
 				bin->cb_printf ("%s\n", r_table_tostring(table));
 			}
 			snprintf (archline, sizeof (archline),

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1061,7 +1061,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			pj_ki (pj, "bits", bits);
 			pj_kn (pj, "offset", boffset);
 			pj_kn (pj, "size", obj_size);
-			if ( !strcmp(arch, "mips") ) {
+			if (!strcmp (arch, "mips")) {
 				pj_ks (pj, "isa", h_flag);
 			}
 			if (machine) {
@@ -1092,7 +1092,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_ki (pj, "bits", bits);
 				pj_kn (pj, "offset", boffset);
 				pj_kn (pj, "size", obj_size);
-				if (!strcmp(arch, "mips")) {
+				if (!strcmp (arch, "mips")) {
 					pj_ks (pj, "isa", h_flag);
 				}
 				if (machine) {
@@ -1101,7 +1101,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_end (pj);
 				break;
 			default:
-				str_fmt = strcmp(h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
+				str_fmt = strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 						  : sdb_fmt ("%s_%i", arch, bits);
 				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
 				bin->cb_printf ("%s\n", r_table_tostring(table));

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2102,21 +2102,21 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	}
 }
 
-char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin){
+char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
 		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
-         switch (mipsType) {
-         case EF_MIPS_ARCH_1:    return strdup ("mips1");
-         case EF_MIPS_ARCH_2:    return strdup ("mips2");
-         case EF_MIPS_ARCH_3:    return strdup ("mips3");
-         case EF_MIPS_ARCH_4:    return strdup ("mips4");
-         case EF_MIPS_ARCH_5:    return strdup ("mips5");
-         case EF_MIPS_ARCH_32:   return strdup ("mips32");
-         case EF_MIPS_ARCH_64:   return strdup ("mips64");
-         case EF_MIPS_ARCH_32R2: return strdup("mips32r2");
-         case EF_MIPS_ARCH_64R2: return strdup("mips64r2");
-         default :               return strdup (" Unknown mips ISA");
-         }
+		switch (mipsType) {
+	    case EF_MIPS_ARCH_1:		return strdup ("mips1");
+	    case EF_MIPS_ARCH_2:		return strdup ("mips2");
+        case EF_MIPS_ARCH_3:		return strdup ("mips3");
+        case EF_MIPS_ARCH_4:		return strdup ("mips4");
+        case EF_MIPS_ARCH_5:		return strdup ("mips5");
+        case EF_MIPS_ARCH_32:		return strdup ("mips32");
+        case EF_MIPS_ARCH_64:		return strdup ("mips64");
+        case EF_MIPS_ARCH_32R2:		return strdup ("mips32r2");
+        case EF_MIPS_ARCH_64R2:		return strdup ("mips64r2");
+        default :					return strdup (" Unknown mips ISA");
+        }
      }
 	//TODO: Fill other arch 
 	return strdup("unknown_flag");

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2102,6 +2102,28 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	}
 }
 
+char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin){
+          if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
+              const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
+                  switch (mipsType) {
+                  case EF_MIPS_ARCH_1:    return strdup ("MIPS-I");
+                  case EF_MIPS_ARCH_2:    return strdup ("MIPS-II");
+                  case EF_MIPS_ARCH_3:    return strdup ("MIPS-III");
+                  case EF_MIPS_ARCH_4:    return strdup ("MIPS-IV");
+                  case EF_MIPS_ARCH_5:    return strdup ("MIPS-V");
+                  case EF_MIPS_ARCH_32:   return strdup ("MIPS-32");
+                  case EF_MIPS_ARCH_64:   return strdup ("MIPS-64");
+                  case EF_MIPS_ARCH_32R2: return strdup("MIPS-32r2");
+                  case EF_MIPS_ARCH_64R2: return strdup("MIPS-64r2");
+                  default :               return strdup (" Unknown mips arch");
+                  }
+          }
+  
+	return strdup(" ");
+}
+
+
+
 // http://www.sco.com/developers/gabi/latest/ch4.eheader.html
 
 char* Elf_(r_bin_elf_get_machine_name)(ELFOBJ *bin) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2108,16 +2108,16 @@ char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	switch (mipsType) {
 	case EF_MIPS_ARCH_1:        return strdup ("mips1");
 	case EF_MIPS_ARCH_2:        return strdup ("mips2");
-        case EF_MIPS_ARCH_3:        return strdup ("mips3");
-        case EF_MIPS_ARCH_4:        return strdup ("mips4");
-        case EF_MIPS_ARCH_5:        return strdup ("mips5");
-        case EF_MIPS_ARCH_32:       return strdup ("mips32");
-        case EF_MIPS_ARCH_64:       return strdup ("mips64");
-        case EF_MIPS_ARCH_32R2:     return strdup ("mips32r2");
-        case EF_MIPS_ARCH_64R2:     return strdup ("mips64r2");
-        default :                   return strdup (" Unknown mips ISA");
-        }
-     }
+	case EF_MIPS_ARCH_3:        return strdup ("mips3");
+	case EF_MIPS_ARCH_4:        return strdup ("mips4");
+	case EF_MIPS_ARCH_5:        return strdup ("mips5");
+	case EF_MIPS_ARCH_32:       return strdup ("mips32");
+	case EF_MIPS_ARCH_64:       return strdup ("mips64");
+	case EF_MIPS_ARCH_32R2:     return strdup ("mips32r2");
+	case EF_MIPS_ARCH_64R2:     return strdup ("mips64r2");
+	default :                   return strdup (" Unknown mips ISA");
+	}
+	}
 	//TODO: Fill other arch 
 	return strdup("unknown_flag");
 }

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2104,19 +2104,19 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 
 char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
-	const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
-	switch (mipsType) {
-	case EF_MIPS_ARCH_1:        return strdup ("mips1");
-	case EF_MIPS_ARCH_2:        return strdup ("mips2");
-	case EF_MIPS_ARCH_3:        return strdup ("mips3");
-	case EF_MIPS_ARCH_4:        return strdup ("mips4");
-	case EF_MIPS_ARCH_5:        return strdup ("mips5");
-	case EF_MIPS_ARCH_32:       return strdup ("mips32");
-	case EF_MIPS_ARCH_64:       return strdup ("mips64");
-	case EF_MIPS_ARCH_32R2:     return strdup ("mips32r2");
-	case EF_MIPS_ARCH_64R2:     return strdup ("mips64r2");
-	default :                   return strdup (" Unknown mips ISA");
-	}
+		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
+		switch (mipsType) {
+		case EF_MIPS_ARCH_1:        return strdup ("mips1");
+		case EF_MIPS_ARCH_2:        return strdup ("mips2");
+		case EF_MIPS_ARCH_3:        return strdup ("mips3");
+		case EF_MIPS_ARCH_4:        return strdup ("mips4");
+		case EF_MIPS_ARCH_5:        return strdup ("mips5");
+		case EF_MIPS_ARCH_32:       return strdup ("mips32");
+		case EF_MIPS_ARCH_64:       return strdup ("mips64");
+		case EF_MIPS_ARCH_32R2:     return strdup ("mips32r2");
+		case EF_MIPS_ARCH_64R2:     return strdup ("mips64r2");
+		default :                   return strdup (" Unknown mips ISA");
+		}
 	}
 	//TODO: Fill other arch 
 	return strdup("unknown_flag");

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2106,23 +2106,21 @@ char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
 		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
 		switch (mipsType) {
-	    case EF_MIPS_ARCH_1:		return strdup ("mips1");
-	    case EF_MIPS_ARCH_2:		return strdup ("mips2");
-        case EF_MIPS_ARCH_3:		return strdup ("mips3");
-        case EF_MIPS_ARCH_4:		return strdup ("mips4");
-        case EF_MIPS_ARCH_5:		return strdup ("mips5");
-        case EF_MIPS_ARCH_32:		return strdup ("mips32");
-        case EF_MIPS_ARCH_64:		return strdup ("mips64");
-        case EF_MIPS_ARCH_32R2:		return strdup ("mips32r2");
-        case EF_MIPS_ARCH_64R2:		return strdup ("mips64r2");
-        default :					return strdup (" Unknown mips ISA");
+	    case EF_MIPS_ARCH_1:        return strdup ("mips1");
+	    case EF_MIPS_ARCH_2:        return strdup ("mips2");
+        case EF_MIPS_ARCH_3:        return strdup ("mips3");
+        case EF_MIPS_ARCH_4:        return strdup ("mips4");
+        case EF_MIPS_ARCH_5:        return strdup ("mips5");
+        case EF_MIPS_ARCH_32:       return strdup ("mips32");
+        case EF_MIPS_ARCH_64:       return strdup ("mips64");
+        case EF_MIPS_ARCH_32R2:     return strdup ("mips32r2");
+        case EF_MIPS_ARCH_64R2:     return strdup ("mips64r2");
+        default :                   return strdup (" Unknown mips ISA");
         }
      }
 	//TODO: Fill other arch 
 	return strdup("unknown_flag");
 }
-
-
 
 // http://www.sco.com/developers/gabi/latest/ch4.eheader.html
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2103,23 +2103,23 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 }
 
 char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin){
-          if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
-              const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
-                  switch (mipsType) {
-                  case EF_MIPS_ARCH_1:    return strdup ("MIPS-I");
-                  case EF_MIPS_ARCH_2:    return strdup ("MIPS-II");
-                  case EF_MIPS_ARCH_3:    return strdup ("MIPS-III");
-                  case EF_MIPS_ARCH_4:    return strdup ("MIPS-IV");
-                  case EF_MIPS_ARCH_5:    return strdup ("MIPS-V");
-                  case EF_MIPS_ARCH_32:   return strdup ("MIPS-32");
-                  case EF_MIPS_ARCH_64:   return strdup ("MIPS-64");
-                  case EF_MIPS_ARCH_32R2: return strdup("MIPS-32r2");
-                  case EF_MIPS_ARCH_64R2: return strdup("MIPS-64r2");
-                  default :               return strdup (" Unknown mips ISA");
-                  }
-          }
-  
-	return strdup(" ");
+	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
+		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
+         switch (mipsType) {
+         case EF_MIPS_ARCH_1:    return strdup ("MIPS-I");
+         case EF_MIPS_ARCH_2:    return strdup ("MIPS-II");
+         case EF_MIPS_ARCH_3:    return strdup ("MIPS-III");
+         case EF_MIPS_ARCH_4:    return strdup ("MIPS-IV");
+         case EF_MIPS_ARCH_5:    return strdup ("MIPS-V");
+         case EF_MIPS_ARCH_32:   return strdup ("MIPS-32");
+         case EF_MIPS_ARCH_64:   return strdup ("MIPS-64");
+         case EF_MIPS_ARCH_32R2: return strdup("MIPS-32r2");
+         case EF_MIPS_ARCH_64R2: return strdup("MIPS-64r2");
+         default :               return strdup (" Unknown mips ISA");
+         }
+     }
+	//TODO: Fill other arch 
+	return strdup("unknown_flag");
 }
 
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2106,15 +2106,15 @@ char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin){
 	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
 		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
          switch (mipsType) {
-         case EF_MIPS_ARCH_1:    return strdup ("MIPS-I");
-         case EF_MIPS_ARCH_2:    return strdup ("MIPS-II");
-         case EF_MIPS_ARCH_3:    return strdup ("MIPS-III");
-         case EF_MIPS_ARCH_4:    return strdup ("MIPS-IV");
-         case EF_MIPS_ARCH_5:    return strdup ("MIPS-V");
-         case EF_MIPS_ARCH_32:   return strdup ("MIPS-32");
-         case EF_MIPS_ARCH_64:   return strdup ("MIPS-64");
-         case EF_MIPS_ARCH_32R2: return strdup("MIPS-32r2");
-         case EF_MIPS_ARCH_64R2: return strdup("MIPS-64r2");
+         case EF_MIPS_ARCH_1:    return strdup ("mips1");
+         case EF_MIPS_ARCH_2:    return strdup ("mips2");
+         case EF_MIPS_ARCH_3:    return strdup ("mips3");
+         case EF_MIPS_ARCH_4:    return strdup ("mips4");
+         case EF_MIPS_ARCH_5:    return strdup ("mips5");
+         case EF_MIPS_ARCH_32:   return strdup ("mips32");
+         case EF_MIPS_ARCH_64:   return strdup ("mips64");
+         case EF_MIPS_ARCH_32R2: return strdup("mips32r2");
+         case EF_MIPS_ARCH_64R2: return strdup("mips64r2");
          default :               return strdup (" Unknown mips ISA");
          }
      }

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2115,7 +2115,7 @@ char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin){
                   case EF_MIPS_ARCH_64:   return strdup ("MIPS-64");
                   case EF_MIPS_ARCH_32R2: return strdup("MIPS-32r2");
                   case EF_MIPS_ARCH_64R2: return strdup("MIPS-64r2");
-                  default :               return strdup (" Unknown mips arch");
+                  default :               return strdup (" Unknown mips ISA");
                   }
           }
   

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2104,10 +2104,10 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 
 char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	if (bin->phdr && bin->ehdr.e_machine == EM_MIPS) {
-		const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
-		switch (mipsType) {
-	    case EF_MIPS_ARCH_1:        return strdup ("mips1");
-	    case EF_MIPS_ARCH_2:        return strdup ("mips2");
+	const ut32 mipsType = bin->ehdr.e_flags & EF_MIPS_ARCH;
+	switch (mipsType) {
+	case EF_MIPS_ARCH_1:        return strdup ("mips1");
+	case EF_MIPS_ARCH_2:        return strdup ("mips2");
         case EF_MIPS_ARCH_3:        return strdup ("mips3");
         case EF_MIPS_ARCH_4:        return strdup ("mips4");
         case EF_MIPS_ARCH_5:        return strdup ("mips5");

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -168,6 +168,7 @@ bool Elf_(r_bin_elf_is_static)(struct Elf_(r_bin_elf_obj_t) *bin);
 char* Elf_(r_bin_elf_get_data_encoding)(struct Elf_(r_bin_elf_obj_t) *bin);
 char* Elf_(r_bin_elf_get_arch)(struct Elf_(r_bin_elf_obj_t) *bin);
 char* Elf_(r_bin_elf_get_machine_name)(struct Elf_(r_bin_elf_obj_t) *bin);
+char* Elf_(r_bin_elf_get_head_flag)(struct Elf_(r_bin_elf_obj_t) *bin); //yin
 char* Elf_(r_bin_elf_get_file_type)(struct Elf_(r_bin_elf_obj_t) *bin);
 char* Elf_(r_bin_elf_get_elf_class)(struct Elf_(r_bin_elf_obj_t) *bin);
 int Elf_(r_bin_elf_get_bits)(struct Elf_(r_bin_elf_obj_t) *bin);

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -1088,6 +1088,11 @@ static RBinInfo* info(RBinFile *bf) {
 		return NULL;
 	}
 	ret->machine = str;
+	if (!(str = Elf_(r_bin_elf_get_head_flag) (obj))) {
+		free (ret);
+		return NULL;
+	}    
+	ret->head_flag = str;
 	if (!(str = Elf_(r_bin_elf_get_arch) (obj))) {
 		free (ret);
 		return NULL;

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -208,6 +208,7 @@ typedef struct r_bin_info_t {
 	char *arch;
 	char *cpu;
 	char *machine;
+	char *head_flag;
 	char *os;
 	char *subsystem;
 	char *rpath;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -339,19 +339,27 @@ RUN
 
 NAME=iA (file mips I)
 FILE=bins/elf/mips-mozi
-CMDS=iA
+CMDS=<<EOF
+iA
+iAj
+EOF
 EXPECT=<<EOF
 0   0x00000000 266108 mips_32 MIPS-I
 
+{"bins":[{"arch":"mips","bits":32,"offset":0,"size":266108,"isa":"MIPS-I","machine":"MIPS R3000"}]}
 EOF
 RUN
 
 NAME=iA (file mips 64r2)
 FILE=bins/elf/analysis/mips64r2-busybox-loongson
-CMDS=iA
+CMDS=<<EOF
+iA
+iAj
+EOF
 EXPECT=<<EOF
 0   0x00000000 1039368 mips_64 MIPS-64r2
 
+{"bins":[{"arch":"mips","bits":64,"offset":0,"size":1039368,"isa":"MIPS-64r2","machine":"MIPS R3000"}]}
 EOF
 RUN
 

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -337,6 +337,26 @@ va       true
 EOF
 RUN
 
+NAME=iA (file mips I)
+FILE=bins/elf/mips-mozi
+CMDS=iA
+EXPECT=<<EOF
+0   0x00000000 266108 mips_32 MIPS-I
+
+EOF
+RUN
+
+NAME=iA (file mips 64r2)
+FILE=bins/elf/analysis/mips64r2-busybox-loongson
+CMDS=iA
+EXPECT=<<EOF
+0   0x00000000 1039368 mips_64 MIPS-64r2
+
+EOF
+RUN
+
+
+
 NAME=iA (file x86)
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=iA

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -344,7 +344,7 @@ iA
 iAj
 EOF
 EXPECT=<<EOF
-0   0x00000000 266108 mips_32 MIPS-I
+0   0x00000000 266108 mips_32 MIPS-I 
 
 {"bins":[{"arch":"mips","bits":32,"offset":0,"size":266108,"isa":"MIPS-I","machine":"MIPS R3000"}]}
 EOF
@@ -357,7 +357,7 @@ iA
 iAj
 EOF
 EXPECT=<<EOF
-0   0x00000000 1039368 mips_64 MIPS-64r2
+0   0x00000000 1039368 mips_64 MIPS-64r2 
 
 {"bins":[{"arch":"mips","bits":64,"offset":0,"size":1039368,"isa":"MIPS-64r2","machine":"MIPS R3000"}]}
 EOF

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -344,9 +344,9 @@ iA
 iAj
 EOF
 EXPECT=<<EOF
-0   0x00000000 266108 mips_32 MIPS-I 
+0   0x00000000 266108 mips_32 mips1 
 
-{"bins":[{"arch":"mips","bits":32,"offset":0,"size":266108,"isa":"MIPS-I","machine":"MIPS R3000"}]}
+{"bins":[{"arch":"mips","bits":32,"offset":0,"size":266108,"isa":"mips1","machine":"MIPS R3000"}]}
 EOF
 RUN
 
@@ -357,9 +357,9 @@ iA
 iAj
 EOF
 EXPECT=<<EOF
-0   0x00000000 1039368 mips_64 MIPS-64r2 
+0   0x00000000 1039368 mips_64 mips64r2 
 
-{"bins":[{"arch":"mips","bits":64,"offset":0,"size":1039368,"isa":"MIPS-64r2","machine":"MIPS R3000"}]}
+{"bins":[{"arch":"mips","bits":64,"offset":0,"size":1039368,"isa":"mips64r2","machine":"MIPS R3000"}]}
 EOF
 RUN
 

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -363,8 +363,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-
-
 NAME=iA (file x86)
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=iA


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

Before MIPS32/64, a number of versions of the MIPS architecture were written down.
I added the  function that the iA command can output target ISA

I want to pass the ISA information to the gnu disassembler, do you have any suggestions?

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
