### PR TITLE
Do not return a buffer when slurping a empty file

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -367,7 +367,7 @@ R_API char *r_file_slurp(const char *str, R_NULLABLE size_t *usz) {
 			} while (!feof (fd));
 			char *nbuf = realloc (buf, size + 1);
 			if (!nbuf) {
-				free(buf);
+				free (buf);
 				return NULL;
 			}
 			buf = nbuf;

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -365,6 +365,13 @@ R_API char *r_file_slurp(const char *str, R_NULLABLE size_t *usz) {
 				}
 				size += r;
 			} while (!feof (fd));
+			char *nbuf = realloc (buf, size + 1);
+			if (!nbuf) {
+				free(buf);
+				return NULL;
+			}
+			buf = nbuf;
+			buf[size] = '\0';
 			if (usz) {
 				*usz = size;
 			}

--- a/test/unit/test_util.c
+++ b/test/unit/test_util.c
@@ -113,6 +113,41 @@ bool test_autonames(void) {
 	mu_end;
 }
 
+bool test_file_slurp(void) {
+
+#ifdef __WINDOWS__
+#define S_IRWXU _S_IREAD | _S_IWRITE
+#endif
+
+	const char* test_file =  "./empty_file";
+	size_t s;
+	const char* some_words = "some words";
+
+	int f = open (test_file, O_CREAT, S_IRWXU);
+	mu_assert_neq (f, -1, "cannot create empty file");
+	close (f);
+
+	char* content = r_file_slurp (test_file, &s);
+	mu_assert_eq (s, 0, "size should be zero");
+	mu_assert_eq (strlen (content), 0, "returned buffer should be empty");
+	free (content);
+
+	f = open (test_file, O_WRONLY, S_IRWXU);
+	mu_assert_neq (f, -1, "cannot reopen empty file");
+	write (f, some_words, strlen (some_words));
+	close (f);
+
+	content = r_file_slurp (test_file, &s);
+	mu_assert_eq (s, strlen (some_words), "size should be correct");
+	mu_assert_eq (strlen (content), strlen (some_words), "size for the buffer should be correct");
+	mu_assert_streq (content, some_words, "content should match");
+	free (content);
+
+	unlink (test_file);
+
+	mu_end;
+}
+
 bool test_initial_underscore(void) {
 	Sdb *TDB = setup_sdb ();
 	char *s;
@@ -168,6 +203,7 @@ int all_tests() {
 	mu_run_test (test_dll_names);
 	mu_run_test (test_references);
 	mu_run_test (test_autonames);
+	mu_run_test (test_file_slurp);
 	mu_run_test (test_initial_underscore);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

While running r2 from git, I was greeted by:
    
    |ERROR| Invalid command ��Y�' (0x08)
    
I quickly found this came from:
    
    $ ls -l ~/.radare2rc
    -rw-r--r--. 1 misc misc 0 19 avril  2017 /home/misc/.radare2rc
    
Debugging showed that if the file is empty, we return the buffer
that was reallocate earlier with uninitialized memory.
    
Since r_core_cmd_file do not check the size (it pass NULL as a
2nd parameter for r_file_slurp), it doesn't see the file is empty,
and so try to interpret 6 bytes as a command.
    
Given that grep find 54 calls to r_file_slurp with NULL
as a 2nd parameter, this will also fix a bit more than just this
error message.

**Test plan**

* Create a empty file ~/.radare2rc
* Run r2
* See no error message about "|ERROR| Invalid command"
