### PR TITLE
Fix oob read in getFunctionName()

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -109,13 +109,7 @@ static char *getFunctionName(RCore *core, ut64 addr) {
 			break;
 		}
 	}
-	if (name) {
-		if (r_config_get_i (core->config, "asm.flags.real")) {
-			name += 4;
-		}
-		return strdup (name);
-	}
-	return NULL;
+	return name ? strdup (name) : NULL;
 }
 
 static RCore *mycore = NULL;

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -406,14 +406,14 @@ f sym @ 6
 f sym. @ 7
 f sym.b @ 8
 e asm.flags.real=0
-af@@*
+af @@ *
 afl
 ?e --
-af-@@*
+af- @@ *
 afl
 ?e --
 e asm.flags.real=1
-af@@*
+af @@ *
 afl
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -389,3 +389,53 @@ EXPECT=<<EOF
 0x0001f7cc    1 48           sym.__syscall_error
 EOF
 RUN
+
+NAME=function naming
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx c3c3c3c3c3c3c3c3c3
+f sym.some_func @ 0
+f sym.some_other_func @ 1
+f a @ 2
+f aa @ 3
+f aaa @ 4
+f aaaa @ 5
+f sym @ 6
+f sym. @ 7
+f sym.b @ 8
+e asm.flags.real=0
+af@@*
+afl
+?e --
+af-@@*
+afl
+?e --
+e asm.flags.real=1
+af@@*
+afl
+EOF
+EXPECT=<<EOF
+0x00000000    1 1            sym.some_func
+0x00000001    1 1            sym.some_other_func
+0x00000002    1 1            a
+0x00000003    1 1            aa
+0x00000004    1 1            aaa
+0x00000005    1 1            aaaa
+0x00000006    1 1            sym
+0x00000007    1 1            sym.
+0x00000008    1 1            sym.b
+--
+--
+0x00000000    1 1            sym.some_func
+0x00000001    1 1            sym.some_other_func
+0x00000002    1 1            a
+0x00000003    1 1            aa
+0x00000004    1 1            aaa
+0x00000005    1 1            aaaa
+0x00000006    1 1            sym
+0x00000007    1 1            sym.
+0x00000008    1 1            sym.b
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

If the function name is less than 4 chars, this will strdup out of bounds. `asm.flags.real` is only for changing the display of things, not how analysis names things, so I think this can be removed completely. Moreover, it is almost always directly overwritten later in `set_fcn_name_from_flag()`.

**Test plan**

Run `r2 -Qc "f a; af" -` with valgrind or asan. The added test triggers the bug too but doesn't crash directly for me because it's just a read in "usually" valid memory. The tests purpose is primarily to ensure this change doesn't alter the functionality.
