### PR TITLE
Don't try to parse the function if null ##dwarf

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1651,15 +1651,15 @@ R_API void r_anal_dwarf_integrate_functions(RAnal *anal, RFlag *flags, Sdb *dwar
 				r_flag_unset_off (flags, offset);
 				r_flag_set_next (flags, global_name, offset, 4);
 				free (global_name);
-			} else if (*kind == 's') {
+			} else if (*kind == 's' && fcn) {
 				r_anal_function_set_var (fcn, offset - fcn->maxstack, *kind, type, 4, false, var_name);
-			} else if (*kind == 'r') {
+			} else if (*kind == 'r' && fcn) {
 				RRegItem *i = r_reg_get (anal->reg, extra, -1);
 				if (!i) {
 					goto loop_end;
 				}
 				r_anal_function_set_var (fcn, i->index, *kind, type, 4, false, var_name);
-			} else { /* kind == 'b' */
+			} else if (fcn) { /* kind == 'b' */
 				r_anal_function_set_var (fcn, offset - fcn->bp_off, *kind, type, 4, false, var_name);
 			}
 			free (var_key);


### PR DESCRIPTION
fixes crashes on gcc 4.9.4 and ld 2.35 with score7 target "aaa"

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**


...

**Test plan**


...

**Closing issues**



...
