### PR TITLE
Refactor zbr to honor vars ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -823,7 +823,7 @@ static int bb_sort_by_addr(const void *x, const void *y) {
 }
 
 static RSignBytes *r_sign_fcn_bytes(RAnal *a, RAnalFunction *fcn) {
-	r_return_val_if_fail (a && fcn, false);
+	r_return_val_if_fail (a && fcn && fcn->bbs && fcn->bbs->head, false);
 
 	// get size
 	RCore *core = a->coreb.core;

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -188,14 +188,6 @@ static RList *zign_types_to_list(RAnal *a, const char *types) {
 	return ret;
 }
 
-static void bytes_sig_free(RSignBytes *bytes) {
-	if (bytes) {
-		free (bytes->bytes);
-		free (bytes->mask);
-		free (bytes);
-	}
-}
-
 static RList *do_reflike_sig(const char *token) {
 	RList *list = NULL;
 	char *scratch = r_str_new (token);
@@ -557,7 +549,7 @@ static void mergeItem(RSignItem *dst, RSignItem *src) {
 	char *ref, *var, *type;
 
 	if (src->bytes) {
-		bytes_sig_free (dst->bytes);
+		r_sign_bytes_free (dst->bytes);
 		dst->bytes = R_NEW0 (RSignBytes);
 		if (!dst->bytes) {
 			return;
@@ -566,13 +558,13 @@ static void mergeItem(RSignItem *dst, RSignItem *src) {
 		dst->bytes->size = src->bytes->size;
 		dst->bytes->bytes = malloc (src->bytes->size);
 		if (!dst->bytes->bytes) {
-			bytes_sig_free (dst->bytes);
+			r_sign_bytes_free (dst->bytes);
 			return;
 		}
 		memcpy (dst->bytes->bytes, src->bytes->bytes, src->bytes->size);
 		dst->bytes->mask = malloc (src->bytes->size);
 		if (!dst->bytes->mask) {
-			bytes_sig_free (dst->bytes);
+			r_sign_bytes_free (dst->bytes);
 			return;
 		}
 		memcpy (dst->bytes->mask, src->bytes->mask, src->bytes->size);
@@ -757,7 +749,7 @@ static bool addBytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, co
 fail:
 	if (it) {
 		free (it->name);
-		bytes_sig_free (it->bytes);
+		r_sign_bytes_free (it->bytes);
 	}
 	free (it);
 	return false;
@@ -879,7 +871,7 @@ static RSignBytes *r_sign_fcn_bytes(RAnal *a, RAnalFunction *fcn) {
 
 	return sig;
 bytes_failed:
-	bytes_sig_free (sig);
+	r_sign_bytes_free (sig);
 	return NULL;
 }
 
@@ -1380,41 +1372,12 @@ R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double 
 	return output;
 }
 
-static RSignItem *item_frm_signame(RAnal *a, const char *signame) {
-	// example zign|*|sym.unlink_blk
-	char k[R_SIGN_KEY_MAXSZ];
-
-	serializeKey (a, r_spaces_current (&a->zign_spaces), signame, k);
-	char *value = sdb_querys (a->sdb_zigns, NULL, 0, k);
-	if (!value) {
-		return NULL;
-	}
-
-	RSignItem *it = r_sign_item_new ();
-	if (!it) {
-		free (value);
-		return NULL;
-	}
-
-	if (!r_sign_deserialize (a, it, k, value)) {
-		r_sign_item_free (it);
-		it = NULL;
-	}
-	free (value);
-	return it;
-}
-
-R_API RList *r_sign_find_closest_fcn(RAnal *a, char *signame, int count, double score_threshold) {
-	r_return_val_if_fail (a && signame && count > 0 && score_threshold >= 0 && score_threshold <= 1, NULL);
-	RSignItem *it = item_frm_signame (a, signame);
-	if (!it) {
-		eprintf ("Couldn't get signature for %s\n", signame);
-		return NULL;
-	}
+R_API RList *r_sign_find_closest_fcn(RAnal *a, RSignItem *it, int count, double score_threshold) {
+	r_return_val_if_fail (a && it && count > 0 && score_threshold >= 0 && score_threshold <= 1, NULL);
+	r_return_val_if_fail (it->bytes || it->graph, NULL);
 
 	RList *output = r_list_newf ((RListFree)r_sign_close_match_free);
 	if (!output) {
-		r_sign_item_free (it);
 		return NULL;
 	}
 
@@ -1436,7 +1399,6 @@ R_API RList *r_sign_find_closest_fcn(RAnal *a, char *signame, int count, double 
 		// turn function into signature item
 		RSignItem *fsig = r_sign_item_new ();
 		if (!fsig) {
-			r_sign_item_free (it);
 			r_list_free (output);
 			return NULL;
 		}
@@ -1453,7 +1415,6 @@ R_API RList *r_sign_find_closest_fcn(RAnal *a, char *signame, int count, double 
 		closest_match_update (&data, fsig);
 	}
 	free (data.bytes_combined);
-	r_sign_item_free (it);
 	return output;
 }
 
@@ -2660,7 +2621,7 @@ R_API void r_sign_item_free(RSignItem *item) {
 		return;
 	}
 	free (item->name);
-	bytes_sig_free (item->bytes);
+	r_sign_bytes_free (item->bytes);
 	if (item->hash) {
 		free (item->hash->bbhash);
 		free (item->hash);
@@ -2677,6 +2638,14 @@ R_API void r_sign_item_free(RSignItem *item) {
 
 R_API void r_sign_graph_free(RSignGraph *graph) {
 	free (graph);
+}
+
+R_API void r_sign_bytes_free(RSignBytes *bytes) {
+	if (bytes) {
+		free (bytes->bytes);
+		free (bytes->mask);
+		free (bytes);
+	}
 }
 
 static bool loadCB(void *user, const char *k, const char *v) {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1009,7 +1009,33 @@ static void print_possible_matches(RList *list) {
 	}
 }
 
-static bool bestmatch_fcn(RCore *core,  const char *input) {
+static RSignItem *item_frm_signame(RAnal *a, const char *signame) {
+	// example zign|*|sym.unlink_blk
+	const RSpace *space = r_spaces_current (&a->zign_spaces);
+	char *k = r_str_newf ("zign|%s|%s", space? space->name: "*", signame);
+	char *value = sdb_querys (a->sdb_zigns, NULL, 0, k);
+	if (!value) {
+		free (k);
+		return NULL;
+	}
+
+	RSignItem *it = r_sign_item_new ();
+	if (!it) {
+		free (k);
+		free (value);
+		return NULL;
+	}
+
+	if (!r_sign_deserialize (a, it, k, value)) {
+		r_sign_item_free (it);
+		it = NULL;
+	}
+	free (k);
+	free (value);
+	return it;
+}
+
+static bool bestmatch_fcn(RCore *core, const char *input) {
 	r_return_val_if_fail (input && core, false);
 
 	char *argv = r_str_new (input);
@@ -1019,6 +1045,11 @@ static bool bestmatch_fcn(RCore *core,  const char *input) {
 
 	int count = 5;
 	char *zigname = strtok (argv, " ");
+	if (!zigname) {
+		eprintf ("Need a signature\n");
+		free (argv);
+		return false;
+	}
 	char *cs = strtok (NULL, " ");
 	if (cs) {
 		if ((count = atoi (cs)) <= 0) {
@@ -1032,9 +1063,25 @@ static bool bestmatch_fcn(RCore *core,  const char *input) {
 			return false;
 		}
 	}
-
-	RList *list = r_sign_find_closest_fcn (core->anal, zigname, count, 0);
+	RSignItem *it = item_frm_signame (core->anal, zigname);
+	if (!it) {
+		eprintf ("Couldn't get signature for %s\n", zigname);
+		free (argv);
+		return false;
+	}
 	free (argv);
+
+	if (!r_config_get_i (core->config, "zign.bytes")) {
+		r_sign_bytes_free (it->bytes);
+		it->bytes = NULL;
+	}
+	if (!r_config_get_i (core->config, "zign.graph")) {
+		r_sign_graph_free (it->graph);
+		it->graph = NULL;
+	}
+
+	RList *list = r_sign_find_closest_fcn (core->anal, it, count, 0);
+	r_sign_item_free (it);
 
 	if (list) {
 		print_possible_matches (list);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -138,6 +138,7 @@ R_API RSignItem *r_sign_item_new(void);
 R_API RSignItem *r_sign_item_dup(RSignItem *it);
 R_API void r_sign_item_free(RSignItem *item);
 R_API void r_sign_graph_free(RSignGraph *graph);
+R_API void r_sign_bytes_free(RSignBytes *bytes);
 
 R_API RList *r_sign_fcn_refs(RAnal *a, RAnalFunction *fcn);
 R_API RList *r_sign_fcn_xrefs(RAnal *a, RAnalFunction *fcn);
@@ -149,7 +150,7 @@ R_API void r_sign_flirt_dump(const RAnal *anal, const char *flirt_file);
 R_API void r_sign_flirt_scan(RAnal *anal, const char *flirt_file);
 
 R_API RList *r_sign_find_closest_sig(RAnal *a, RSignItem *it, int count, double score_threshold);
-R_API RList *r_sign_find_closest_fcn(RAnal *a, char *signame, int count, double score_threshold);
+R_API RList *r_sign_find_closest_fcn(RAnal *a, RSignItem *it, int count, double score_threshold);
 R_API void r_sign_close_match_free(RSignCloseMatch *match);
 R_API bool r_sign_diff(RAnal *a, RSignOptions *options, const char *other_space_name);
 R_API bool r_sign_diff_by_name(RAnal *a, RSignOptions *options, const char *other_space_name, bool not_matching);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I did not like the `r_sign_find_closest_fcn` function accepting a signature name instead of a signature item. Changing it to accept a signature item allows for `cmd_zign.c:bestmatch_fcn` to add/remove signature types from the item according to user preference.  I wanted to fix this early before someone else uses the interface.

Also, the first commit ads a NULL pointer de-reference guard to `r_sign_fcn_bytes`. See #17528. I don't know that this really fixes the issue. If `RAnalFunction->bbs` can be empty, then the `r_return_if_fail` should probably not be used.

I felt like it was a minor thing to include this one line guard. I made the commits separate so you can squash or not. I can close this and submit separate PRs if you would prefer.


**Test plan**

I have pretty good tests for `zbr` already and all of them pass.

**Closing issues**


...
