### PR TITLE
Fix #17494 - Pass the whole input string to r_core_cmd_str_pipe ##newshell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4768,7 +4768,7 @@ static char *do_handle_substitution_cmd(struct tsr2cmd_state *state, TSNode inn_
 
 	// execute the sub command
 	char *o_out = inn_str[0] == '!'?
-		r_core_cmd_str_pipe (core, inn_str + 1):
+		r_core_cmd_str_pipe (core, inn_str):
 		r_core_cmd_str (core, inn_str);
 
 	// restore color and cmd_in_backticks

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4758,13 +4758,13 @@ void free_tsr2cmd_edit(struct tsr2cmd_edit *edit) {
 
 static char *do_handle_substitution_cmd(struct tsr2cmd_state *state, TSNode inn_cmd) {
 	RCore *core = state->core;
+	int value = core->num->value;
 	char *inn_str = ts_node_sub_parent_string (state->substitute_cmd, inn_cmd, state->input);
 
 	// save current color and disable it
 	int ocolor = r_config_get_i (core->config, "scr.color");
 	r_config_set_i (core->config, "scr.color", 0);
 	core->cmd_in_backticks = true;
-	int value = core->num->value;
 
 	// execute the sub command
 	char *o_out = inn_str[0] == '!'?

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -6955,31 +6955,6 @@ R_API char *r_core_cmd_str_pipe(RCore *core, const char *cmd) {
 	if (!p && *cmd != '!' && *cmd != '.') {
 		return r_core_cmd_str (core, cmd);
 	}
-#if 0
-	char *p = (*cmd != '"')? strchr (cmd, '|'): NULL;
-	if (p) {
-		// This code works but its pretty ugly as its a workaround to
-		// make the webserver work as expected, this was broken some
-		// weeks. let's use this hackaround for now
-		char *c = strdup (cmd);
-		c[p - cmd] = 0;
-		if (!strcmp (p + 1, "H")) {
-			char *res = r_core_cmd_str (core, c);
-			free (c);
-			char *hres = r_cons_html_filter (res, NULL);
-			free (res);
-			return hres;
-		} else {
-			int sh = r_config_get_i (core->config, "scr.color");
-			r_config_set_i (core->config, "scr.color", 0);
-			char *ret = r_core_cmd_str (core, c);
-			r_config_set_i (core->config, "scr.color", sh);
-			free (c);
-			return ret;
-		}
-	}
-	return r_core_cmd_str (core, cmd);
-#else
 	r_cons_reset ();
 	r_sandbox_disable (true);
 	if (r_file_mkstemp ("cmd", &tmp) != -1) {
@@ -6991,7 +6966,11 @@ R_API char *r_core_cmd_str_pipe(RCore *core, const char *cmd) {
 			return r_core_cmd_str (core, cmd);
 		}
 		char *_cmd = strdup (cmd);
-		r_core_cmd_subst (core, _cmd);
+		if (core->use_tree_sitter_r2cmd) {
+			r_core_cmd (core, _cmd, 0);
+		} else {
+			r_core_cmd_subst (core, _cmd);
+		}
 		r_cons_flush ();
 		r_cons_pipe_close (pipefd);
 		if (r_file_exists (tmp)) {
@@ -7011,7 +6990,6 @@ R_API char *r_core_cmd_str_pipe(RCore *core, const char *cmd) {
 	}
 	r_sandbox_disable (0);
 	return NULL;
-#endif
 }
 
 R_API char *r_core_cmd_strf(RCore *core, const char *fmt, ...) {

--- a/test/db/tools/r2
+++ b/test/db/tools/r2
@@ -110,7 +110,6 @@ RUN
 
 NAME=r2 shortcut
 FILE=-
-ARGS=-e cfg.newshell=false
 CMDS=<<EOF
 ?q `!!r2 -h~Usage?`
 ?+ ?vi $?


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When executing a command like:
```
> ?e `!!r2 -h~Usage?`
```

One of the `!` was ignored, leading to the execution of different commands (`!r2 -h`was executed instead of `!!r2 -h`).

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The test should pass for both newshell and old.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes https://github.com/radareorg/radare2/issues/17494