### PR TITLE
Add commands to parse mangling pointers glibc heap

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2968,7 +2968,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI ("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
 	SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
 #endif
-	SETBPREF ("dbg.glibc.demangle", "false", "Demangle linked-lists pointers");
+	SETBPREF ("dbg.glibc.demangle", "false", "Demangle linked-lists pointers introduced in glibc 2.32");
 	SETPREF ("dbg.libc.dbglib", "", "Set libc debug library file");
 
 	SETBPREF ("esil.prestep", "true", "Step before esil evaluation in `de` commands");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2968,6 +2968,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI ("dbg.glibc.ma_offset", 0x1bb000, "Main_arena offset from his symbol");
 	SETI ("dbg.glibc.fc_offset", 0x148, "First chunk offset from brk_start");
 #endif
+	SETBPREF ("dbg.glibc.demangle", "false", "Demangle linked-lists pointers");
 	SETPREF ("dbg.libc.dbglib", "", "Set libc debug library file");
 
 	SETBPREF ("esil.prestep", "true", "Step before esil evaluation in `de` commands");

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -1044,9 +1044,11 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
 		if (tcache) {
-			//tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
-			GHT fc_offset = GH(tcache_chunk_size) (core, brk_start);
-			initial_brk = ((brk_start >> 12) << 12) + fc_offset;
+			tcache_initial_brk = ((brk_start >> 12) << 12) + GH(HDR_SZ);
+			initial_brk = tcache_initial_brk;
+			initial_brk += (glibc_version < 230)
+				? sizeof (GH (RHeapTcachePre230))
+				: sizeof (GH (RHeapTcache));
 		} else {
 			initial_brk = (brk_start >> 12) << 12;
 		}
@@ -1255,9 +1257,6 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 						}
 					}
 				}
-			}
-			if (is_main_arena) {
-				tcache_initial_brk = brk_start + 0x10;
 			}
 			GH (tcache_free) (tcache_heap);
 		}

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -1599,9 +1599,8 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 		break;
 	case 'f': // "dmhf"
 		if (GH(r_resolve_main_arena) (core, &m_arena)) {
-			bool demangle = (input[1] == 'm') ? true : false;
-			char *m_state_str, *dup = strdup (input + (demangle ? 2 : 1));
-			demangle = (!demangle) ? r_config_get_i (core->config, "dbg.glibc.demangle") : demangle;
+			bool demangle = r_config_get_i (core->config, "dbg.glibc.demangle");
+			char *m_state_str, *dup = strdup (input + 1);
 			if (*dup) {
 				strtok (dup, ":");
 				m_state_str = strtok (NULL, ":");
@@ -1673,7 +1672,6 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 				break;
 			}
 			bool demangle = r_config_get_i (core->config, "dbg.glibc.demangle");
-			demangle = (input[1] == 'm') ? true : demangle;
 			GH(print_tcache_instance) (core, m_arena, main_arena, demangle);
 		}
 		break;

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -67,6 +67,14 @@ static inline GHT GH(align_address_to_size)(ut64 addr, ut64 align) {
 	return addr + ((align - (addr % align)) % align);
 }
 
+static inline GHT GH(get_next_pointer)(RCore *core, GHT pos, GH(RHeapChunk) *cnk_next) {
+	if (core->dbg->glibc_version < 232) {
+		return cnk_next->fd;
+	} else {
+		return PROTECT_PTR (pos, cnk_next->fd);
+	}
+}
+
 static GHT GH(get_main_arena_with_symbol)(RCore *core, RDebugMap *map) {
 	r_return_val_if_fail (core && map, GHT_MAX);
 	GHT base_addr = map->addr;
@@ -1175,13 +1183,13 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 
 		bool fastbin = size_tmp >= SZ * 4 && size_tmp <= global_max_fast;
 		bool is_free = false, double_free = false;
+		int glibc_version = core->dbg->glibc_version;
 
 		if (fastbin) {
 			int i = (size_tmp / (SZ * 2)) - 2;
 			GHT idx = (GHT)main_arena->GH(fastbinsY)[i];
 			(void)r_io_read_at (core->io, idx, (ut8 *)cnk, sizeof (GH(RHeapChunk)));
-			// TODO: Fix pointer mangling
-			GHT next = cnk->fd;
+			GHT next = GH (get_next_pointer) (core, idx, cnk);
 			if (prev_chunk == idx && idx && !next) {
 				is_free = true;
 			}
@@ -1193,7 +1201,7 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 						break;
 					}
 					(void)r_io_read_at (core->io, next, (ut8 *)cnk_next, sizeof (GH(RHeapChunk)));
-					GHT next_node = cnk_next->fd;
+					GHT next_node = GH (get_next_pointer) (core, next, cnk_next);
 					// avoid triple while?
 					while (next_node && next_node >= brk_start && next_node < main_arena->GH(top)) {
 						if (prev_chunk == next_node) {
@@ -1201,15 +1209,14 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 							break;
 						}
 						(void)r_io_read_at (core->io, next_node, (ut8 *)cnk_next, sizeof (GH(RHeapChunk)));
-						next_node = cnk_next->fd;
+						next_node = GH (get_next_pointer) (core, next_node, cnk_next);
 					}
 					if (double_free) {
 						break;
 					}
 				}
 				(void)r_io_read_at (core->io, next, (ut8 *)cnk, sizeof (GH(RHeapChunk)));
-				// TODO: Fix pointer mangling
-				next = cnk->fd;
+				next = GH (get_next_pointer) (core, next, cnk);
 			}
 			if (double_free) {
 				PRINT_RA (" Double free in simple-linked list detected ");

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -1603,8 +1603,9 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 		break;
 	case 'f': // "dmhf"
 		if (GH(r_resolve_main_arena) (core, &m_arena)) {
-			bool mangling = (input[1] == 'm');
-			char *m_state_str, *dup = strdup (input + (mangling ? 2 : 1));
+			bool demangle = (input[1] == 'm') ? true : false;
+			char *m_state_str, *dup = strdup (input + (demangle ? 2 : 1));
+			demangle = (!demangle) ? r_config_get_i (core->config, "dbg.glibc.demangle") : demangle;
 			if (*dup) {
 				strtok (dup, ":");
 				m_state_str = strtok (NULL, ":");
@@ -1624,7 +1625,7 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 					free (dup);
 					break;
 				}
-				GH(print_heap_fastbin) (core, m_state, main_arena, global_max_fast, dup, mangling);
+				GH(print_heap_fastbin) (core, m_state, main_arena, global_max_fast, dup, demangle);
 			} else {
 				PRINT_RA ("This address is not part of the arenas\n");
 				free (dup);
@@ -1675,11 +1676,9 @@ static int GH(cmd_dbg_map_heap_glibc)(RCore *core, const char *input) {
 			if (!GH(update_main_arena) (core, m_arena, main_arena)) {
 				break;
 			}
-			if (input[1] == 'm') {
-				GH(print_tcache_instance) (core, m_arena, main_arena, true);
-			} else {
-				GH(print_tcache_instance) (core, m_arena, main_arena, false);
-			}
+			bool demangle = r_config_get_i (core->config, "dbg.glibc.demangle");
+			demangle = (input[1] == 'm') ? true : demangle;
+			GH(print_tcache_instance) (core, m_arena, main_arena, demangle);
 		}
 		break;
 	case '?':

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -108,9 +108,12 @@ static bool GH(is_tcache)(RCore *core) {
 		RListIter *iter;
 		r_debug_map_sync (core->dbg);
 		r_list_foreach (core->dbg->maps, iter, map) {
-			fp = strstr (map->name, "libc-");
-			if (fp) {
-				break;
+			// In case the binary is named *libc-*
+			if (strncmp (map->name, core->bin->file, strlen(map->name)) != 0) {
+				fp = strstr (map->name, "libc-");
+				if (fp) {
+					break;
+				}
 			}
 		}
 	} else {

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -1043,7 +1043,6 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 	const int offset = r_config_get_i (core->config, "dbg.glibc.fc_offset");
 	RConsPrintablePalette *pal = &r_cons_singleton ()->context->pal;
 	int glibc_version = core->dbg->glibc_version;
-	bool is_main_arena = true;
 
 	if (m_arena == m_state) {
 		GH(get_brks) (core, &brk_start, &brk_end);
@@ -1059,7 +1058,6 @@ static void GH(print_heap_segment)(RCore *core, MallocState *main_arena,
 			initial_brk = (brk_start >> 12) << 12;
 		}
 	} else {
-		is_main_arena = false;
 		brk_start = ((m_state >> 16) << 16) ;
 		brk_end = brk_start + main_arena->GH(system_mem);
 		if (tcache) {

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -873,7 +873,7 @@ void GH(print_heap_fastbin)(RCore *core, GHT m_arena, MallocState *main_arena, G
 			eprintf ("Error: 0 < bin <= %d\n", NFASTBINS);
 			break;
 		}
-		if (GH(print_single_linked_list_bin)(core, main_arena, m_arena, offset, num_bin, true)) {
+		if (GH(print_single_linked_list_bin)(core, main_arena, m_arena, offset, num_bin, mangling)) {
 			PRINT_GA (" Empty bin");
 			PRINT_BA (" 0x0\n");
 		}

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -802,7 +802,7 @@ static int GH(print_single_linked_list_bin)(RCore *core, MallocState *main_arena
 		if (!mangling) {
 			next = cnk->fd;
 		} else {
-			next = PROTECT_PTR(next, cnk->fd);
+			next = PROTECT_PTR (next, cnk->fd);
 		}
 		PRINTF_BA ("%s", next ? "->fd = " : "");
 		if (cnk->prev_size > size || ((cnk->size >> 3) << 3) > size) {
@@ -950,7 +950,7 @@ static void GH (tcache_print) (RCore *core, GH (RTcache)* tcache, bool mangling)
 					if (!mangling) {
 						tcache_tmp = read_le (&tcache_tmp);
 					} else {
-						tcache_tmp = PROTECT_PTR(tcache_fd, read_le (&tcache_tmp));
+						tcache_tmp = PROTECT_PTR (tcache_fd, read_le (&tcache_tmp));
 					}
 					PRINTF_BA ("->0x%"PFMT64x, tcache_tmp - TC_HDR_SZ);
 					tcache_fd = tcache_tmp;

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -47,6 +47,10 @@ R_LIB_VERSION_HEADER(r_heap_glibc);
 #define TC_SZ_32 0x0
 #define TC_SZ_64 0x10
 
+// Introduced with glibc 2.32
+#define PROTECT_PTR(pos, ptr) \
+	((__typeof (ptr)) ((((size_t) pos) >> 12) ^ ((size_t) ptr)))
+
 #define largebin_index_32(size)				       \
 (((((ut32)(size)) >>  6) <= 38)?  56 + (((ut32)(size)) >>  6): \
  ((((ut32)(size)) >>  9) <= 20)?  91 + (((ut32)(size)) >>  9): \

--- a/test/db/archos/linux-x64/dbg_dmht
+++ b/test/db/archos/linux-x64/dbg_dmht
@@ -7,10 +7,18 @@ dc
 dmht~?0xffffffffffff
 e dbg.glibc.demangle = true
 dmht~?0xffffffffffff
+dmht~?items : 7
+dc
+dmht~?items : 6
+dc
+dmht~?items : 5
 EOF
 EXPECT=<<EOF
 1
 0
+1
+1
+1
 EOF
 RUN
 
@@ -21,8 +29,14 @@ CMDS=<<EOF
 db 0x004011fa
 dc
 dmht~?items : 7
+dc
+dmht~?items : 6
+dc
+dmht~?items : 5
 EOF
 EXPECT=<<EOF
+1
+1
 1
 EOF
 RUN
@@ -34,8 +48,14 @@ CMDS=<<EOF
 db 0x004011fa
 dc
 dmht~?items : 7
+dc
+dmht~?items : 6
+dc
+dmht~?items : 5
 EOF
 EXPECT=<<EOF
+1
+1
 1
 EOF
 RUN

--- a/test/db/archos/linux-x64/dbg_dmht
+++ b/test/db/archos/linux-x64/dbg_dmht
@@ -1,24 +1,39 @@
-NAME=check tcache list
-FILE=bins/elf/tcache
-ARGS=-d
+NAME=check tcache mangling pointers on glibc 2.32
+FILE=bins/elf/glibc-heap-2.32
+ARGS=-Rsetenv=LD_PRELOAD=bins/elf/libc-2.32.so -d
 CMDS=<<EOF
-db 0x004011d0
+db 0x004011fa
 dc
-dmht~?items : 6
+dmht~?0xffffffffffff
+e dbg.glibc.demangle = true
+dmht~?0xffffffffffff
+EOF
+EXPECT=<<EOF
+1
+0
+EOF
+RUN
+
+NAME=check tcache list on glibc 2.31
+FILE=bins/elf/glibc-heap-2.31
+ARGS=-Rsetenv=LD_PRELOAD=bins/elf/libc-2.31.so -d
+CMDS=<<EOF
+db 0x004011fa
+dc
+dmht~?items : 7
 EOF
 EXPECT=<<EOF
 1
 EOF
 RUN
 
-
-NAME=check tcache list older versions
-FILE=bins/elf/tcache-2.27
+NAME=check tcache list on glibc 2.27
+FILE=bins/elf/glibc-heap-2.27
 ARGS=-Rsetenv=LD_PRELOAD=bins/elf/libc-2.27.so -d
 CMDS=<<EOF
-db 0x004011d0
+db 0x004011fa
 dc
-dmht~?items : 6
+dmht~?items : 7
 EOF
 EXPECT=<<EOF
 1


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed) TODO

**Detailed description**

In glibc 2.32 malloc introduces a new security safeguards to single-linked lists: chunk alignment enforcement and pointer mangling. This is a diff between malloc from glibc 2.31 and glibc 2.32:

```diff
> /* Safe-Linking:
>    Use randomness from ASLR (mmap_base) to protect single-linked lists
>    of Fast-Bins and TCache.  That is, mask the "next" pointers of the
>    lists' chunks, and also perform allocation alignment checks on them.
>    This mechanism reduces the risk of pointer hijacking, as was done with
>    Safe-Unlinking in the double-linked lists of Small-Bins.
>    It assumes a minimum page size of 4096 bytes (12 bits).  Systems with
>    larger pages provide less entropy, although the pointer mangling
>    still works.  */
> #define PROTECT_PTR(pos, ptr) \
>   ((__typeof (ptr)) ((((size_t) pos) >> 12) ^ ((size_t) ptr)))
> #define REVEAL_PTR(ptr)  PROTECT_PTR (&ptr, ptr)
1623c1635
<   global_max_fast = (((s) == 0)						     \
---
>   global_max_fast = (((size_t) (s) <= MALLOC_ALIGN_MASK - SIZE_SZ)	\
2159a2172,2174
> 	 if (__glibc_unlikely (misaligned_chunk (p)))
> 	   malloc_printerr ("do_check_malloc_state(): "
> 			    "unaligned fastbin chunk detected");
2165c2180
<           p = p->fd;
---
> 	 p = REVEAL_PTR (p->fd);
2926c2941
<   e->next = tcache->entries[tc_idx];
---
>   e->next = PROTECT_PTR (&e->next, tcache->entries[tc_idx]);
2937c2952,2954
<   tcache->entries[tc_idx] = e->next;
---
>   if (__glibc_unlikely (!aligned_OK (e)))
>     malloc_printerr ("malloc(): unaligned tcache chunk detected");
>   tcache->entries[tc_idx] = REVEAL_PTR (e->next);
2963c2980,2983
< 	 tcache_tmp->entries[i] = e->next;
---
> 	 if (__glibc_unlikely (!aligned_OK (e)))
> 	   malloc_printerr ("tcache_thread_shutdown(): "
> 			    "unaligned tcache chunk detected");
> 	 tcache_tmp->entries[i] = REVEAL_PTR (e->next);
3572a3593,3595
>       pp = REVEAL_PTR (victim->fd);                                     \
>       if (__glibc_unlikely (pp != NULL && misaligned_chunk (pp)))       \
> 	malloc_printerr ("malloc(): unaligned fastbin chunk detected"); \
3574c3597
<   while ((pp = catomic_compare_and_exchange_val_acq (fb, victim->fd, victim)) \
---
>   while ((pp = catomic_compare_and_exchange_val_acq (fb, pp, victim)) \
3585a3609,3611
> 	 if (__glibc_unlikely (misaligned_chunk (victim)))
> 	   malloc_printerr ("malloc(): unaligned fastbin chunk detected 2");
> 
3587c3613
< 	   *fb = victim->fd;
---
> 	   *fb = REVEAL_PTR (victim->fd);
3607a3634,3635
> 		     if (__glibc_unlikely (misaligned_chunk (tc_victim)))
> 			malloc_printerr ("malloc(): unaligned fastbin chunk detected 3");
3609c3637
< 			*fb = tc_victim->fd;
---
> 			*fb = REVEAL_PTR (tc_victim->fd);
4199,4203c4227,4235
< 		tmp = tmp->next)
< 	     if (tmp == e)
< 		malloc_printerr ("free(): double free detected in tcache 2");
< 	   /* If we get here, it was a coincidence.  We've wasted a
< 	      few cycles, but don't abort.  */
---
> 		tmp = REVEAL_PTR (tmp->next))
> 	     {
> 		if (__glibc_unlikely (!aligned_OK (tmp)))
> 		 malloc_printerr ("free(): unaligned chunk detected in tcache 2");
> 		if (tmp == e)
> 		 malloc_printerr ("free(): double free detected in tcache 2");
> 		/* If we get here, it was a coincidence.  We've wasted a
> 		  few cycles, but don't abort.  */
> 	     }
4267c4299
< 	p->fd = old;
---
> 	p->fd = PROTECT_PTR (&p->fd, old);
4277c4309,4310
< 	 p->fd = old2 = old;
---
> 	 old2 = old;
> 	 p->fd = PROTECT_PTR (&p->fd, old);
4474a4508,4511
> 	 if (__glibc_unlikely (misaligned_chunk (p)))
> 	   malloc_printerr ("malloc_consolidate(): "
> 			    "unaligned fastbin chunk detected");
> 
4481c4518
< 	nextp = p->fd;
---
> 	nextp = REVEAL_PTR (p->fd);
4899c4936,4938
<       for (p = fastbin (av, i); p != 0; p = p->fd)
---
>       for (p = fastbin (av, i);
> 	  p != 0;
> 	  p = REVEAL_PTR (p->fd))
4900a4940,4942
> 	 if (__glibc_unlikely (misaligned_chunk (p)))
> 	   malloc_printerr ("int_mallinfo(): "
> 			    "unaligned fastbin chunk detected");
5439a5482,5484
> 		 if (__glibc_unlikely (misaligned_chunk (p)))
> 		   malloc_printerr ("__malloc_info(): "
> 				    "unaligned fastbin chunk detected");
5441c5486
< 		 p = p->fd;
---
> 		 p = REVEAL_PTR (p->fd);
```

With this PR I would like to add a new command to print the single linked lists of tcache and fastbins (`dmhtm` and `dmhfm` respectively, the m is for mangling) with the mangling pointer resolved.

Example on a binary which uses tcache with glibc 2.32:

```
[0x00401238]> dmht
Tcache main arena @ 0x7f8f6989da00
bin : 0, items : 7, fd :0x132c760->0x132d46c->0xfffffffffffffff0->0xffffffffffffffef
[0x00401238]> dmhtm
Tcache main arena @ 0x7f8f6989da00
bin : 0, items : 7, fd :0x132c760->0x132c740->0x132c720->0x132c700->0x132c6e0->0x132c6c0->0x132c6a0
```

Do you think it's better to use/implement a command (`dmh[ft]m`) or a variable like `e dbg.mangling = true` ?

**Test plan**

TODO: add to radare2-testbins the files glibc2.32 and ld-2.32.so and a binary to check that these changes works


