### PR TITLE
Don't add already existing parent class ##anal

### DIFF
--- a/libr/anal/class.c
+++ b/libr/anal/class.c
@@ -727,8 +727,20 @@ R_API RAnalClassErr r_anal_class_base_set(RAnal *anal, const char *class_name, R
 		free (base_class_name_sanitized);
 		return R_ANAL_CLASS_ERR_NONEXISTENT_CLASS;
 	}
+	RVector /*<RAnalBaseClass>*/ *bases = r_anal_class_base_get_all (anal, class_name);
+	if (bases) {
+		RAnalBaseClass *existing_base;
+		r_vector_foreach (bases, existing_base) {
+			if (!strcmp (existing_base->class_name, base->class_name)) {
+				free (base_class_name_sanitized);
+				r_vector_free (bases);
+				return R_ANAL_CLASS_ERR_OTHER;
+			}
+		}
+	}
 	RAnalClassErr err = r_anal_class_base_set_raw (anal, class_name, base, base_class_name_sanitized);
 	free (base_class_name_sanitized);
+	r_vector_free (bases);
 	return err;
 }
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -123,6 +123,7 @@ static const char *help_msg_ac[] = {
 	"acm", " [class name] [method name] [offset] ([vtable offset])", "add/edit method",
 	"acm-", " [class name] [method name]", "delete method",
 	"acmn", " [class name] [method name] [new name]", "rename method",
+	"acg", "", "print inheritance ascii graph",
 	"ac?", "", "show this help",
 	NULL
 };


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
I was going through my notes of details, TODOs etc. and I added help string to print help to a new `acg` command with `ac?`, I've also noticed that since we are adding RTTI inheritance info with `aaa` or `avrr` if you do it multiple times, the same base will be added twice, so you might end up with:
```
[0x00001120]> acl
Bat: Bird, Mammal, Bird, Mammal
Bird
Cat: Mammal, Mammal
Dog: Cat, Cat
Kappa: Cat, Cat
Mammal
```
So I've added a check that confirms the base doesn't already exists for a class before adding it
