### PR TITLE
Fixes for <=glibc-2.2 versions

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -340,7 +340,13 @@ R_API int r_sys_usleep(int usecs) {
 	rqtp.tv_nsec = (usecs - (rqtp.tv_sec * 1000000)) * 1000;
 	return clock_nanosleep (CLOCK_MONOTONIC, 0, &rqtp, NULL);
 #elif __UNIX__
+#if defined(__GLIBC__) && defined(__GLIBC_MINOR__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 2)
+	// Old versions of GNU libc return void for usleep
+	usleep (usecs);
+	return 0;
+#else
 	return usleep (usecs);
+#endif
 #else
 	// w32 api uses milliseconds
 	usecs /= 1000;

--- a/libr/util/thread.c
+++ b/libr/util/thread.c
@@ -132,6 +132,10 @@ R_API bool r_th_getname(RThread *th, char *name, size_t len) {
 
 R_API bool r_th_setaffinity(RThread *th, int cpuid) {
 #if __linux__
+#if defined(__GLIBC__) && defined (__GLIBC_MINOR__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 2)
+	// Old versions of GNU libc don't have this feature
+#pragma message("warning r_th_setaffinity not implemented")
+#else
 	cpu_set_t c;
 	CPU_ZERO(&c);
 	CPU_SET(cpuid, &c);
@@ -140,6 +144,7 @@ R_API bool r_th_setaffinity(RThread *th, int cpuid) {
 		eprintf ("Failed to set cpu affinity\n");
 		return false;
 	}
+#endif
 #elif __FreeBSD__ || __DragonFly__
 	cpuset_t c;
 	CPU_ZERO(&c);

--- a/libr/util/time.c
+++ b/libr/util/time.c
@@ -72,16 +72,16 @@ R_API char *r_time_stamp_to_str(ut32 timeStamp) {
 }
 
 R_API ut32 r_time_dos_time_stamp_to_posix(ut32 timeStamp) {
-	ut16 date = timeStamp >> 16; 
+	ut16 date = timeStamp >> 16;
 	ut16 time = timeStamp & 0xFFFF;
-	
+
 	/* Date */
 	ut32 year = ((date & 0xfe00) >> 9) + 1980;
 	ut32 month = (date & 0x01e0) >> 5;
 	ut32 day = date & 0x001f;
-	
+
 	/* Time */
-	ut32 hour = (time & 0xf800) >> 11; 
+	ut32 hour = (time & 0xf800) >> 11;
 	ut32 minutes = (time & 0x07e0) >> 5;
 	ut32 seconds = (time & 0x001f) << 1;
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

A continuation of #17468. Continuing to bringing radare2 to the older platforms - older GCC and Glibc.
Old version of Glibc don't have support for `cpu_set_t` types and `CPU_SET` macro. Moreover, the type of `usleep()` is different - it returns void in older versions.

**Test plan**

It should fix some build errors on Debian Potato: https://github.com/XVilka/debian-oldies/tree/master/potato

See more errors at: https://github.com/XVilka/debian-oldies/runs/1040090876?check_suite_focus=true