### PR TITLE
r_reg_get_name_idx: Don't treat empty reg name differently from other invalid reg names

### DIFF
--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -88,8 +88,8 @@ R_API void r_reg_item_free(RRegItem *item) {
 }
 
 R_API int r_reg_get_name_idx(const char *type) {
-	r_return_val_if_fail (R_STR_ISNOTEMPTY (type), -1);
-	if (type[1] && !type[2])
+	r_return_val_if_fail (type, -1);
+	if (type[0] && type[1] && !type[2])
 	switch (*type | (type[1] << 8)) {
 	/* flags */
 	case 'Z' + ('F' << 8): return R_REG_NAME_ZF;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following asan test and others like it (https://travis-ci.com/github/radareorg/radare2/jobs/378789409#L2801):

![r_reg_get_name_idx-XX](https://user-images.githubusercontent.com/12002672/91566286-00f9b900-e976-11ea-9756-f7b41aa0774b.PNG)

by not treating empty reg names differently from other invalid reg names.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All asan tests that are XX only because of the above assertion are fixed. All non-asan builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
