### PR TITLE
Fix compilation warnings ##dwarf

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1148,17 +1148,13 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 		bool get_linkage_name = prefer_linkage_name (ctx->lang);
 		bool has_linkage_name = false;
 		int argNumber = 1;
-		/* TODO deal with lexical block ?? */
-		/* TODO merge the formal_parameter and variable parts */
 		size_t j;
 		for (j = idx; child_depth > 0 && j < ctx->count; j++) {
 			child_die = &ctx->all_dies[j];
 			RStrBuf type;
 			r_strbuf_init (&type);
 			const char *name = NULL;
-			// right now we skip non direct descendants of the structure
-			// TODO maybe add parsing of possible thrown exception DW_TAG_thrown_type
-			if (child_depth == 1 && child_die->tag == DW_TAG_formal_parameter) {
+			if (child_depth == 1 && (child_die->tag == DW_TAG_formal_parameter || child_die->tag == DW_TAG_variable)) {
 				Variable *var = R_NEW0 (Variable);
 				size_t i;
 				for (i = 0; i < child_die->count; i++) {
@@ -1190,78 +1186,47 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 						break;
 					}
 				}
-				/* arguments sometimes have only type, create generic argX */
-				if (type.len) {
-					bool free_name = false;
-					if (!name) {
-						name = r_str_newf ("arg%d", argNumber);
-						free_name = true;
-					}
-					r_strbuf_appendf (args, "%s %s,", r_strbuf_get (&type), name);
-					if (free_name) {
-						var->name = name;
+				if (child_die->tag == DW_TAG_formal_parameter) {
+					/* arguments sometimes have only type, create generic argX */
+					if (type.len) {
+						bool free_name = false;
+						if (!name) {
+							name = r_str_newf ("arg%d", argNumber);
+							free_name = true;
+						}
+						r_strbuf_appendf (args, "%s %s,", r_strbuf_get (&type), name);
+						if (free_name) {
+							var->name = name;
+						} else {
+							var->name = strdup (name);
+						}
+						var->type = strdup (r_strbuf_get (&type));
+						r_list_append (variables, var);
 					} else {
-						var->name = strdup (name);
+						variable_free (var);
 					}
-					var->type = strdup (r_strbuf_get (&type));
-					r_list_append (variables, var);
-				} else {
-					variable_free (var);
+					argNumber++;
+				} else { /* DW_TAG_variable */
+					if (name && type.len) {
+						var->name = strdup (name);
+						var->type = strdup (r_strbuf_get (&type));
+						r_list_append (variables, var);
+					} else {
+						variable_free (var);
+					}
+					r_strbuf_fini (&type);
 				}
-				argNumber++;
 			} else if (child_depth == 1 && child_die->tag == DW_TAG_unspecified_parameters) {
 				r_strbuf_appendf (args, "va_args ...,");
-			} else if (child_die->tag == DW_TAG_variable) { /* child_depth == 1 &&  */
-				Variable *var = R_NEW0 (Variable);
-				RStrBuf var_type;
-				r_strbuf_init (&var_type);
-				size_t i;
-				for (i = 0; i < child_die->count; i++) {
-					const RBinDwarfAttrValue *val = &child_die->attr_values[i];
-					switch (val->attr_name) {
-					case DW_AT_name:
-						if (!get_linkage_name || !has_linkage_name) {
-							var->name = val->string.content;
-						}
-						break;
-					case DW_AT_linkage_name:
-					case DW_AT_MIPS_linkage_name:
-						var->name = val->string.content;
-						has_linkage_name = true;
-						break;
-					case DW_AT_type:
-						parse_type (ctx, val->reference, &var_type, NULL);
-						break;
-					// abstract origin is supposed to have omitted information
-					case DW_AT_abstract_origin:
-						parse_abstract_origin (ctx, val->reference, &var_type, &name);
-						break;
-					case DW_AT_location:
-						var->location = parse_dwarf_location (ctx, val, find_attr (die, DW_AT_frame_base));
-						break;
-					default:
-						break;
-					}
-				}
-				if (var->name && var_type.len) {
-					var->name = strdup (var->name);
-					var->type = strdup (r_strbuf_get (&var_type));
-					r_list_append (variables, var);
-				} else {
-					variable_free (var);
-				}
-				r_strbuf_fini  (&var_type);
 			}
 			if (child_die->has_children) {
 				child_depth++;
 			}
-			// sibling list is terminated by null entry
-			if (child_die->abbrev_code == 0) {
+			if (child_die->abbrev_code == 0) { /* sibling list is terminated by null entry */
 				child_depth--;
 			}
 			r_strbuf_fini (&type);
 		}
-		// if no params
 		if (args->len > 0) {
 			r_strbuf_slice (args, 0, args->len - 1);
 		}

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1184,7 +1184,7 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 						break;
 					}
 				}
-				if (child_die->tag == DW_TAG_formal_parameter) {
+				if (child_die->tag == DW_TAG_formal_parameter && child_depth == 1) {
 					/* arguments sometimes have only type, create generic argX */
 					if (type.len) {
 						if (!name) {

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -46,12 +46,12 @@ typedef struct dwarf_var_location_t {
 
 typedef struct dwarf_variable_t {
 	VariableLocation *location;
-	const char *name;
+	char *name;
 	char *type;
 } Variable;
 
 static void variable_free(Variable *var) {
-	free ((char *) var->name);
+	free (var->name);
 	free (var->location);
 	free (var->type);
 	free (var);
@@ -1189,17 +1189,12 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 				if (child_die->tag == DW_TAG_formal_parameter) {
 					/* arguments sometimes have only type, create generic argX */
 					if (type.len) {
-						bool free_name = false;
 						if (!name) {
-							name = r_str_newf ("arg%d", argNumber);
-							free_name = true;
-						}
-						r_strbuf_appendf (args, "%s %s,", r_strbuf_get (&type), name);
-						if (free_name) {
-							var->name = name;
+							var->name = r_str_newf ("arg%d", argNumber);
 						} else {
 							var->name = strdup (name);
 						}
+						r_strbuf_appendf (args, "%s %s,", r_strbuf_get (&type), var->name);
 						var->type = strdup (r_strbuf_get (&type));
 						r_list_append (variables, var);
 					} else {

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -51,7 +51,7 @@ typedef struct dwarf_variable_t {
 } Variable;
 
 static void variable_free(Variable *var) {
-	free (var->name);
+	free ((char *) var->name);
 	free (var->location);
 	free (var->type);
 	free (var);

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1154,7 +1154,7 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 			RStrBuf type;
 			r_strbuf_init (&type);
 			const char *name = NULL;
-			if (child_depth == 1 && (child_die->tag == DW_TAG_formal_parameter || child_die->tag == DW_TAG_variable)) {
+			if (child_die->tag == DW_TAG_formal_parameter || child_die->tag == DW_TAG_variable) {
 				Variable *var = R_NEW0 (Variable);
 				size_t i;
 				for (i = 0; i < child_die->count; i++) {
@@ -1178,9 +1178,7 @@ static st32 parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 						parse_abstract_origin (ctx, val->reference, &type, &name);
 						break;
 					case DW_AT_location:
-						if (val->kind == DW_AT_KIND_BLOCK) {
-							var->location = parse_dwarf_location (ctx, val, find_attr (die, DW_AT_frame_base));
-						}
+						var->location = parse_dwarf_location (ctx, val, find_attr (die, DW_AT_frame_base));
 						break;
 					default:
 						break;

--- a/test/unit/test_dwarf_integration.c
+++ b/test/unit/test_dwarf_integration.c
@@ -39,7 +39,6 @@ static bool test_parse_dwarf_types(void) {
 	r_anal_dwarf_process_info (anal, &ctx);
 
 	char * value = NULL;
-	char *object_name = "_cairo_status";
 	Sdb *sdb = anal->sdb_types;
 	check_kv ("_cairo_status", "enum");
 	check_kv ("enum._cairo_status.!size", "32");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
```
./libr/anal/dwarf_process.c:54:8: warning: passing argument 1 of 'free' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  free (var->name);

../test/unit/test_dwarf_integration.c:42:8: warning: unused variable 'object_name' [-Wunused-variable]
  char *object_name = "_cairo_status";
```