### PR TITLE
Add zb score threshold variable ##signatures

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3261,7 +3261,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("zign.autoload", "false", "Autoload all zignatures located in " R_JOIN_2_PATHS ("~", R2_HOME_ZIGNS));
 	SETPREF ("zign.diff.bthresh", "1.0", "Threshold for diffing zign bytes [0, 1] (see zc?)");
 	SETPREF ("zign.diff.gthresh", "1.0", "Threshold for diffing zign graphs [0, 1] (see zc?)");
-	SETPREF ("zign.bestthresh", "0.0", "Threshold for zb commands");
+	SETPREF ("zign.threshold", "0.0", "Minimum similarity required for inclusion in zb output");
 
 	/* diff */
 	SETCB ("diff.sort", "addr", &cb_diff_sort, "Specify function diff sorting column see (e diff.sort=?)");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3261,6 +3261,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("zign.autoload", "false", "Autoload all zignatures located in " R_JOIN_2_PATHS ("~", R2_HOME_ZIGNS));
 	SETPREF ("zign.diff.bthresh", "1.0", "Threshold for diffing zign bytes [0, 1] (see zc?)");
 	SETPREF ("zign.diff.gthresh", "1.0", "Threshold for diffing zign graphs [0, 1] (see zc?)");
+	SETPREF ("zign.bestthresh", "0.0", "Threshold for zb commands");
 
 	/* diff */
 	SETCB ("diff.sort", "addr", &cb_diff_sort, "Specify function diff sorting column see (e diff.sort=?)");

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1035,6 +1035,16 @@ static RSignItem *item_frm_signame(RAnal *a, const char *signame) {
 	return it;
 }
 
+double get_zb_threshold(RCore *core) {
+	const char *th = r_config_get (core->config, "zign.bestthresh");
+	double thresh = r_num_get_float (NULL, th);
+	if (thresh < 0.0 || thresh > 1.0) {
+		eprintf ("Invalid zign.bestthresh %s, using 0.0\n", th);
+		thresh = 0.0;
+	}
+	return thresh;
+}
+
 static bool bestmatch_fcn(RCore *core, const char *input) {
 	r_return_val_if_fail (input && core, false);
 
@@ -1080,7 +1090,8 @@ static bool bestmatch_fcn(RCore *core, const char *input) {
 		it->graph = NULL;
 	}
 
-	RList *list = r_sign_find_closest_fcn (core->anal, it, count, 0);
+	double thresh = get_zb_threshold (core);
+	RList *list = r_sign_find_closest_fcn (core->anal, it, count, thresh);
 	r_sign_item_free (it);
 
 	if (list) {
@@ -1127,10 +1138,11 @@ static bool bestmatch_sig(RCore *core, const char *input) {
 		r_sign_addto_item (core->anal, item, fcn, R_SIGN_GRAPH);
 	}
 
+	double th = get_zb_threshold (core);
 	bool found = false;
 	if (item->graph || item->bytes) {
 		r_cons_break_push (NULL, NULL);
-		RList *list = r_sign_find_closest_sig (core->anal, item, count, 0);
+		RList *list = r_sign_find_closest_sig (core->anal, item, count, th);
 		if (list) {
 			found = true;
 			print_possible_matches (list);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1036,10 +1036,10 @@ static RSignItem *item_frm_signame(RAnal *a, const char *signame) {
 }
 
 static double get_zb_threshold(RCore *core) {
-	const char *th = r_config_get (core->config, "zign.bestthresh");
+	const char *th = r_config_get (core->config, "zign.threshold");
 	double thresh = r_num_get_float (NULL, th);
 	if (thresh < 0.0 || thresh > 1.0) {
-		eprintf ("Invalid zign.bestthresh %s, using 0.0\n", th);
+		eprintf ("Invalid zign.threshold %s, using 0.0\n", th);
 		thresh = 0.0;
 	}
 	return thresh;

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1035,7 +1035,7 @@ static RSignItem *item_frm_signame(RAnal *a, const char *signame) {
 	return it;
 }
 
-double get_zb_threshold(RCore *core) {
+static double get_zb_threshold(RCore *core) {
 	const char *th = r_config_get (core->config, "zign.bestthresh");
 	double thresh = r_num_get_float (NULL, th);
 	if (thresh < 0.0 || thresh > 1.0) {

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1627,7 +1627,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=zb zign.bestthresh
+NAME=zb zign.threshold
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
@@ -1643,13 +1643,13 @@ za sym.4 g cc=12 nbbs=17 edges=30 ebbs=1 bbsum=307
 za sym.4 b 4883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffff00000000ff000000000000ffffffffffffff
 za sym.5 g cc=10 nbbs=14 edges=22 ebbs=1 bbsum=284
 za sym.5 b 08e89e02ffff488b2d77952a004889c38b450048:ffff00000000ff000000000000ffffffffffffff
-e zign.bestthresh = .99
+e zign.threshold = .99
 zb ~[5]
-e zign.bestthresh = .9
+e zign.threshold = .9
 zb ~[5]
-e zign.bestthresh = .8
+e zign.threshold = .8
 zb ~[5]
-e zign.bestthresh = .7
+e zign.threshold = .7
 zb ~[5]
 EOF
 EXPECT=<<EOF
@@ -1666,20 +1666,20 @@ sym.4
 EOF
 RUN
 
-NAME=zbr zign.bestthresh
+NAME=zbr zign.threshold
 FILE=bins/elf/ls
 CMDS=<<EOF
 aa
 e zign.maxsz = 32
 za main b 41574156415541545589fd534889f34883ec58488b3e64488b04252800000048
 za main g cc=429 nbbs=300 edges=437 ebbs=8 bbsum=6739
-e zign.bestthresh = 1.0
+e zign.threshold = 1.0
 zbr main~[5]
-e zign.bestthresh = 0.5
+e zign.threshold = 0.5
 zbr main~[5]
-e zign.bestthresh = 0.3
+e zign.threshold = 0.3
 zbr main~[5]
-e zign.bestthresh = 0.12
+e zign.threshold = 0.12
 zbr main 30~[5]
 EOF
 EXPECT=<<EOF
@@ -1691,12 +1691,12 @@ sym._obstack_newchunk
 EOF
 RUN
 
-NAME=zbr invalid bestthresh
+NAME=zbr invalid threshold
 FILE=bins/elf/ls
 CMDS=<<EOF
 aa
 e zign.maxsz = 32
-e zign.bestthresh = 99.0
+e zign.threshold = 99.0
 za main b 41574156415541545589fd534889f34883ec58488b3e64488b04252800000048
 za main g cc=429 nbbs=300 edges=437 ebbs=8 bbsum=6739
 zbr main ~[5]
@@ -1710,11 +1710,11 @@ sym._obstack_begin_1
 EOF
 RUN
 
-NAME=zb invalid bestthresh
+NAME=zb invalid threshold
 FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 s 0x00410210
-e zign.bestthresh = 99.0
+e zign.threshold = 99.0
 e zign.maxsz = 32
 af
 za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1434,22 +1434,14 @@ RUN
 
 NAME=ARM function with jumpback
 FILE=bins/elf/libverifyPass.so
-BROKEN=1
 CMDS=<<EOF
 s 0x0000183c
 af
 zaf
-z*
+z* ~sym.__aeabi_unwind_cpp_pr0 b
 EOF
 EXPECT=<<EOF
-zs *
 za sym.__aeabi_unwind_cpp_pr0 b 0030a0e3d4feffea
-za sym.__aeabi_unwind_cpp_pr0 g cc=27 nbbs=50 edges=75 ebbs=1 bbsum=1176
-za sym.__aeabi_unwind_cpp_pr0 o 0x0000183c
-za sym.__aeabi_unwind_cpp_pr0 r sym._Unwind_VRS_Get sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym._Unwind_VRS_Get sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym.__gnu_unwind_execute sym._Unwind_VRS_Get sym._Unwind_VRS_Set sym._Unwind_VRS_Set
-za sym.__aeabi_unwind_cpp_pr0 v s-48 s-20 s-36 s-24 s-16 s-15 s-12 s-68 s-8 s-44 s-40 s-52 s-56 s-4 s-32 r1 r0
-za sym.__aeabi_unwind_cpp_pr0 t func.sym.__aeabi_unwind_cpp_pr0.args=2 func.sym.__aeabi_unwind_cpp_pr0.arg.0="int32_t,arg1" func.sym.__aeabi_unwind_cpp_pr0.arg.1="int32_t,arg2"
-za sym.__aeabi_unwind_cpp_pr0 h 1d6b2ca1aa1e08761e43859262a1d8f989251159b6fbd2baed6056b1f122d768
 EOF
 RUN
 
@@ -1632,5 +1624,118 @@ zbr sym.exact 1
 EOF
 EXPECT=<<EOF
 1.00000  1.00000 B  1.00000 G   fcn.00410210
+EOF
+RUN
+
+NAME=zb zign.bestthresh
+FILE=bins/elf/static-glibc-2.27
+CMDS=<<EOF
+s 0x00410210
+e zign.maxsz = 32
+af
+za sym.1 g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.1 b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.2 g cc=16 nbbs=25 edges=40 ebbs=1 bbsum=377
+za sym.2 b 41544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.3 g cc=14 nbbs=21 edges=35 ebbs=1 bbsum=347
+za sym.3 b fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.4 g cc=12 nbbs=17 edges=30 ebbs=1 bbsum=307
+za sym.4 b 4883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffff00000000ff000000000000ffffffffffffff
+za sym.5 g cc=10 nbbs=14 edges=22 ebbs=1 bbsum=284
+za sym.5 b 08e89e02ffff488b2d77952a004889c38b450048:ffff00000000ff000000000000ffffffffffffff
+e zign.bestthresh = .99
+zb ~[5]
+e zign.bestthresh = .9
+zb ~[5]
+e zign.bestthresh = .8
+zb ~[5]
+e zign.bestthresh = .7
+zb ~[5]
+EOF
+EXPECT=<<EOF
+sym.1
+sym.1
+sym.2
+sym.1
+sym.2
+sym.3
+sym.1
+sym.2
+sym.3
+sym.4
+EOF
+RUN
+
+NAME=zbr zign.bestthresh
+FILE=bins/elf/ls
+CMDS=<<EOF
+aa
+e zign.maxsz = 32
+za main b 41574156415541545589fd534889f34883ec58488b3e64488b04252800000048
+za main g cc=429 nbbs=300 edges=437 ebbs=8 bbsum=6739
+e zign.bestthresh = 1.0
+zbr main~[5]
+e zign.bestthresh = 0.5
+zbr main~[5]
+e zign.bestthresh = 0.3
+zbr main~[5]
+e zign.bestthresh = 0.12
+zbr main 30~[5]
+EOF
+EXPECT=<<EOF
+main
+main
+main
+main
+sym._obstack_newchunk
+EOF
+RUN
+
+NAME=zbr invalid bestthresh
+FILE=bins/elf/ls
+CMDS=<<EOF
+aa
+e zign.maxsz = 32
+e zign.bestthresh = 99.0
+za main b 41574156415541545589fd534889f34883ec58488b3e64488b04252800000048
+za main g cc=429 nbbs=300 edges=437 ebbs=8 bbsum=6739
+zbr main ~[5]
+EOF
+EXPECT=<<EOF
+main
+sym._obstack_newchunk
+sym._obstack_free
+sym._obstack_begin
+sym._obstack_begin_1
+EOF
+RUN
+
+NAME=zb invalid bestthresh
+FILE=bins/elf/static-glibc-2.27
+CMDS=<<EOF
+s 0x00410210
+e zign.bestthresh = 99.0
+e zign.maxsz = 32
+af
+za sym.exact g cc=17 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.exact b 415541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.second g cc=16 nbbs=29 edges=44 ebbs=1 bbsum=407
+za sym.second b ff5541544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.third g cc=16 nbbs=28 edges=44 ebbs=1 bbsum=407
+za sym.third b ffff41544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.fourth g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=407
+za sym.fourth b ffffff544989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.fith g cc=16 nbbs=28 edges=43 ebbs=1 bbsum=401
+za sym.fith b ffffffff4989fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+za sym.not_shown g cc=15 nbbs=28 edges=43 ebbs=1 bbsum=395
+za sym.not_shown b ffffffffff89fc55534883ec08e89e02ffff488b2d77952a004889c38b450048:ffffffffffffffffffffffffffff00000000ff000000000000ffffffffffffff
+zb ~[5]
+EOF
+EXPECT=<<EOF
+sym.exact
+sym.second
+sym.third
+sym.fourth
+sym.fith
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed) 
Book update [pending here](https://github.com/radareorg/radare2book/pull/271/commits)

**Detailed description**

Small change to finally make use of the score threshold variable in zb commands. Setting `e zign.bestthresh = 0.5` will limit requires results to have a similarity score above `0.5`.  Setting a good threshold value should increase the speed of the algorithm by reducing the number of times the Levenshtein Distance is executed.

I am not a big fan of `bestthresh`, so if you have a better name I am happy to change it.  

**Test plan**

Tests were submitted to take care of common edge cases. The bulk of this feature was previously implemented, I just added the variable.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
