### PR TITLE
fcn_recurse: Fix dangling pointers if r_anal_op's setting of asm.bits is fully processed

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -501,9 +501,6 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 		variadic_reg = r_reg_get (anal->reg, "rax", R_REG_TYPE_GPR);
 	}
 	bool has_variadic_reg = !!variadic_reg;
-	const char *bp_reg = anal->reg->name[R_REG_NAME_BP];
-	const char *sp_reg = anal->reg->name[R_REG_NAME_SP];
-	bool has_stack_regs = bp_reg && sp_reg;
 
 	if (r_cons_is_breaked ()) {
 		return R_ANAL_RET_END;
@@ -645,6 +642,10 @@ repeat:
 			// RET_END causes infinite loops somehow
 			gotoBeach (R_ANAL_RET_END);
 		}
+		const char *bp_reg = anal->reg->name[R_REG_NAME_BP];
+		const char *sp_reg = anal->reg->name[R_REG_NAME_SP];
+		bool has_stack_regs = bp_reg && sp_reg;
+
 		if (anal->opt.nopskip && fcn->addr == at) {
 			RFlagItem *fi = anal->flb.get_at (anal->flb.f, addr, false);
 			if (!fi || strncmp (fi->name, "sym.", 4)) {
@@ -1289,7 +1290,9 @@ analopfinish:
 			last_is_mov_lr_pc = false;
 		}
 		if (has_variadic_reg && !fcn->is_variadic) {
-			bool dst_is_variadic = op.dst && op.dst->reg && op.dst->reg->offset == variadic_reg->offset;
+			variadic_reg = r_reg_get (anal->reg, "rax", R_REG_TYPE_GPR);
+			bool dst_is_variadic = op.dst && op.dst->reg
+					&& variadic_reg && op.dst->reg->offset == variadic_reg->offset;
 			bool op_is_cmp = (op.type == R_ANAL_OP_TYPE_CMP) || op.type == R_ANAL_OP_TYPE_ACMP;
 			if (dst_is_variadic && !op_is_cmp) {
 				has_variadic_reg = false;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following asan test (https://travis-ci.com/github/radareorg/radare2/jobs/378852160#L12178):

![fcn_recurse-dangling](https://user-images.githubusercontent.com/12002672/91639268-f14aa500-ea47-11ea-97a9-7f34c604a66b.PNG)

It appears `r_anal_op()` can set `asm.bits` and if this is fully processed, `anal->reg` gets a new register profile and pointers obtained through the old register profile, such as:
https://github.com/radareorg/radare2/blob/0b671bc3578cc52211ff340c6e69fd8b44ef3266/libr/anal/fcn.c#L500-L502 and
https://github.com/radareorg/radare2/blob/0b671bc3578cc52211ff340c6e69fd8b44ef3266/libr/anal/fcn.c#L504-L505 can dangle.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The asan test above is fixed. All non-asan builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
