### PR TITLE
meson install sdb faster

### DIFF
--- a/libr/anal/d/meson.build
+++ b/libr/anal/d/meson.build
@@ -81,9 +81,12 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: false
+    install: host_machine.system() == 'windows' ? false : true,
+    install_dir: join_paths(r2_sdb, 'fcnsign')
   )
 endforeach
 
-meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
-                         meson.current_build_dir(), join_paths(r2_sdb, 'fcnsign'))
+if host_machine.system() == 'windows'
+  meson.add_install_script('../../../sys/copy_sdb_files.bat',
+                           meson.current_build_dir(), join_paths(r2_sdb, 'fcnsign'))
+endif

--- a/libr/anal/d/meson.build
+++ b/libr/anal/d/meson.build
@@ -81,7 +81,9 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: true,
-    install_dir: join_paths(r2_sdb, 'fcnsign')
+    install: false
   )
 endforeach
+
+meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
+                         meson.current_build_dir(), join_paths(r2_sdb, 'fcnsign'))

--- a/libr/asm/d/meson.build
+++ b/libr/asm/d/meson.build
@@ -37,9 +37,12 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: false
+    install: host_machine.system() == 'windows' ? false : true,
+    install_dir: join_paths(r2_sdb, 'opcodes')
   )
 endforeach
 
-meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
-                         meson.current_build_dir(), join_paths(r2_sdb, 'opcodes'))
+if host_machine.system() == 'windows'
+  meson.add_install_script('../../../sys/copy_sdb_files.bat',
+                           meson.current_build_dir(), join_paths(r2_sdb, 'opcodes'))
+endif

--- a/libr/asm/d/meson.build
+++ b/libr/asm/d/meson.build
@@ -37,7 +37,9 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: true,
-    install_dir: join_paths(r2_sdb, 'opcodes')
+    install: false
   )
 endforeach
+
+meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
+                         meson.current_build_dir(), join_paths(r2_sdb, 'opcodes'))

--- a/libr/bin/d/meson.build
+++ b/libr/bin/d/meson.build
@@ -160,10 +160,12 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: true,
-    install_dir: join_paths(r2_sdb, 'format/dll')
+    install: false
   )
 endforeach
+
+meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
+                         meson.current_build_dir(), join_paths(r2_sdb, 'format/dll'))
 
 format_files = [
   'elf32',

--- a/libr/bin/d/meson.build
+++ b/libr/bin/d/meson.build
@@ -160,12 +160,15 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: false
+    install: host_machine.system() == 'windows' ? false : true,
+    install_dir: join_paths(r2_sdb, 'format/dll')
   )
 endforeach
 
-meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
-                         meson.current_build_dir(), join_paths(r2_sdb, 'format/dll'))
+if host_machine.system() == 'windows'
+  meson.add_install_script('../../../sys/copy_sdb_files.bat',
+                           meson.current_build_dir(), join_paths(r2_sdb, 'format/dll'))
+endif
 
 format_files = [
   'elf32',

--- a/libr/syscall/d/meson.build
+++ b/libr/syscall/d/meson.build
@@ -65,7 +65,9 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: true,
-    install_dir: join_paths(r2_sdb, 'syscall')
+    install: false
   )
 endforeach
+
+meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
+                         meson.current_build_dir(), join_paths(r2_sdb, 'syscall'))

--- a/libr/syscall/d/meson.build
+++ b/libr/syscall/d/meson.build
@@ -65,9 +65,12 @@ foreach file : sdb_files
     command: sdb_gen_cmd,
     depends: sdb_exe,
     build_by_default: true,
-    install: false
+    install: host_machine.system() == 'windows' ? false : true,
+    install_dir: join_paths(r2_sdb, 'syscall')
   )
 endforeach
 
-meson.add_install_script('../../../sys/copy_sdb_files' + (host_machine.system() == 'windows' ? '.bat' : '.sh'),
-                         meson.current_build_dir(), join_paths(r2_sdb, 'syscall'))
+if host_machine.system() == 'windows'
+  meson.add_install_script('../../../sys/copy_sdb_files.bat',
+                           meson.current_build_dir(), join_paths(r2_sdb, 'syscall'))
+endif

--- a/sys/copy_sdb_files.bat
+++ b/sys/copy_sdb_files.bat
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+set SRC=%1
+set SRC=%SRC:/=\%\*.sdb
+set DST=%2
+set DST=%MESON_INSTALL_PREFIX%\%DST:/=\%
+md "%DST%"
+echo copy "%SRC%" -^> "%DST%\"
+copy "%SRC%" "%DST%"

--- a/sys/copy_sdb_files.sh
+++ b/sys/copy_sdb_files.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+SRC="$1"
+DST="${DESTDIR}/${MESON_INSTALL_PREFIX}/$2"
+mkdir -p "${DST}"
+cp -fv "${SRC}"/*.sdb "${DST}"

--- a/sys/copy_sdb_files.sh
+++ b/sys/copy_sdb_files.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-SRC="$1"
-DST="${DESTDIR}/${MESON_INSTALL_PREFIX}/$2"
-mkdir -p "${DST}"
-cp -fv "${SRC}"/*.sdb "${DST}"

--- a/sys/create_r2.bat
+++ b/sys/create_r2.bat
@@ -1,1 +1,1 @@
-@echo @"%%~dp0\radare2" %%*> %MESON_INSTALL_PREFIX%\bin\r2.bat
+@echo @"%%~dp0\radare2" %%*> "%MESON_INSTALL_PREFIX%\bin\r2.bat"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

On Windows with Meson 0.52.0 and Ninja 1.10.1, Meson searches for `install_name_tool` on the PATH before _**every**_ individual sdb install, e.g.:

![Meson-install_name_tool](https://user-images.githubusercontent.com/12002672/91681081-e2670e00-eb7f-11ea-8515-5d2de04337e3.PNG)

For a long PATH, this can take a significant amount of time. Idk whether this is a bug, and whether the bug is in Meson or Ninja.

This pr short-circuits the above by using an install script. Note that as per https://github.com/mesonbuild/meson/pull/1215, arguments can be passed to install scripts.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
