### PR TITLE
Fix ESIL movi.n immediate value parsing ##emu

### DIFF
--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -634,6 +634,12 @@ static inline void sign_extend(st32 *value, ut8 bit) {
 	}
 }
 
+static inline void sign_extend2(st32 *value, ut8 bit1, ut8 bit2, ut8 shift) {
+	ut8 bit = ((*value >> bit1) & 1) & ((*value >> bit2) & 1);
+	if(bit)
+		*value |= 0xFFFFFFFF << (31 - shift);
+}
+
 static void xtensa_check_stack_op(xtensa_isa isa, xtensa_opcode opcode, xtensa_format format,
 		size_t i, xtensa_insnbuf slot_buffer, RAnalOp *op) {
 	st32 imm;
@@ -911,7 +917,7 @@ static void esil_move_imm(xtensa_isa isa, xtensa_opcode opcode, xtensa_format fo
 
 	// 33: movi.n
 	if (opcode == 33) {
-		sign_extend (&imm, 6);
+		sign_extend2 (&imm, 6, 5, 25);
 	}
 
 	esil_push_signed_imm (&op->esil, imm);

--- a/libr/anal/p/anal_xtensa.c
+++ b/libr/anal/p/anal_xtensa.c
@@ -635,9 +635,9 @@ static inline void sign_extend(st32 *value, ut8 bit) {
 }
 
 static inline void sign_extend2(st32 *value, ut8 bit1, ut8 bit2, ut8 shift) {
-	ut8 bit = ((*value >> bit1) & 1) & ((*value >> bit2) & 1);
-	if(bit)
-		*value |= 0xFFFFFFFF << (31 - shift);
+	if (((*value >> bit1) & 1) && ((*value >> bit2) & 1)) {
+		*value |= UT32_MAX << (32 - shift);
+	}
 }
 
 static void xtensa_check_stack_op(xtensa_isa isa, xtensa_opcode opcode, xtensa_format format,

--- a/test/db/esil/xtensa_32
+++ b/test/db/esil/xtensa_32
@@ -214,3 +214,38 @@ EXPECT=<<EOF
 a3 = 0x0000bbcc
 EOF
 RUN
+
+NAME=movi.n: extract unsigned imm
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=xtensa
+e asm.bits=32
+e asm.esil=1
+wx 4ce87cdb
+s 0x0
+aeip
+aes
+ar~a8
+EOF
+EXPECT=<<EOF
+a8 = 0x0000004e
+EOF
+RUN
+
+NAME=movi.n: extract signed imm
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=xtensa
+e asm.bits=32
+e asm.esil=1
+wx 4ce87cdb
+s 0x0
+aeip
+aes
+aes
+ar~a11
+EOF
+EXPECT=<<EOF
+a11 = 0xfffffffd
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

ESIL, xtensa

```
e asm.arch=xtensa
e asm.bits=32
e asm.emu=1
```

Input code:
`0x00000000      4ce8           movi.n a8, 78`

### Expected behavior
`0x00000000      4ce8           movi.n a8, 78               ; a8=0x4e`

### Actual behavior
`0x00000000      4ce8           movi.n a8, 78               ; a8=0xffffffffffffffce`

According to the [xtensa Instructions manual](https://0x04.net/~mwk/doc/xtensa.pdf )(page 422, movi.n) immediate argument's sign should be extracted as logical AND on bits 6 and 5 not only bit 6

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Corresponding test created for signed and unsigned values
...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
