### PR TITLE
Fixes for old glibc (Debian Etch)

### DIFF
--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -319,6 +319,8 @@ static RDebugReasonType linux_handle_new_task(RDebug *dbg, int tid) {
 			if (ret == -1) {
 				continue;
 			}
+#ifdef PT_GETEVENTMSG
+			// NOTE: This API was added in Linux 2.5.46
 			if (siginfo.si_signo == SIGTRAP) {
 				// si_code = (SIGTRAP | PTRACE_EVENT_* << 8)
 				int pt_evt = siginfo.si_code >> 8;
@@ -333,6 +335,7 @@ static RDebugReasonType linux_handle_new_task(RDebug *dbg, int tid) {
 					break;
 				}
 			}
+#endif
 		}
 	}
 	return R_DEBUG_REASON_UNKNOWN;

--- a/libr/debug/p/native/linux/linux_ptrace.h
+++ b/libr/debug/p/native/linux/linux_ptrace.h
@@ -18,8 +18,8 @@
 // Sadly, there is no reliable and portable way to check the linux kernel
 // version from headers, so we assume it's supported.
 #if defined(__GLIBC__) && defined(__GLIBC_MINOR__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 3)
-#if !defined(PTRACE_GETEVENTMSG) && !defined(PTRACE_GETEVENTMSG)
-#define PTRACE_SETOPTIONS 0x4201
+#if !defined(PT_GETEVENTMSG) && !defined(PTRACE_GETEVENTMSG)
+#define PTRACE_GETEVENTMSG 0x4201
 #define PT_GETEVENTMSG PTRACE_GETEVENTMSG
 #endif
 #endif

--- a/libr/debug/p/native/linux/linux_ptrace.h
+++ b/libr/debug/p/native/linux/linux_ptrace.h
@@ -14,6 +14,16 @@
 #define PTRACE_SETSIGINFO 0x4203
 #endif
 
+// A special case of the older Glibc but the kernel newer than 2.5.46
+// Sadly, there is no reliable and portable way to check the linux kernel
+// version from headers, so we assume it's supported.
+#if defined(__GLIBC__) && defined(__GLIBC_MINOR__) && (__GLIBC__ <= 2) && (__GLIBC_MINOR__ <= 3)
+#if !defined(PTRACE_GETEVENTMSG) && !defined(PTRACE_GETEVENTMSG)
+#define PTRACE_SETOPTIONS 0x4201
+#define PT_GETEVENTMSG PTRACE_GETEVENTMSG
+#endif
+#endif
+
 #if !defined(PTRACE_EVENT_FORK) && !defined(PTRACE_EVENT_VFORK) && !defined(PTRACE_EVENT_CLONE) \
 	&& !defined(PTRACE_EVENT_EXEC) && !defined(PTRACE_EVENT_VFORK_DONE) && !defined(PTRACE_EVENT_EXIT)
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

A continuation of #17540. Continuing to bringing radare2 to the older platforms - older GCC and Glibc.
Old version of Glibc doesn't export `PTRACE_GETEVENTMSG' [ptrace() API](https://www.man7.org/linux/man-pages/man2/ptrace.2.html) types but the Linux kernel >= 2.5.46 provides it. There is no reliable and portable way to check the kernel version during the compilation, thus it's defined for sufficiently old glibc unconditionally.

**Test plan**

It should fix some build errors on Debian Etch: https://github.com/XVilka/debian-oldies/tree/master/etch