### PR TITLE
Fix test_idstorage mu_assert warnings

### DIFF
--- a/test/unit/test_idstorage.c
+++ b/test/unit/test_idstorage.c
@@ -8,7 +8,7 @@ bool test_r_id_storage_add0(void) {
 	bool success = r_id_storage_add (ids, str, &id);
 	void *ptr = r_id_storage_get (ids, id);
 	r_id_storage_free (ids);
-	mu_assert (success && (ptr == str), "id_storage_add 0");
+	mu_assert ("id_storage_add 0", success && (ptr == str));
 	mu_end;
 }
 
@@ -22,7 +22,7 @@ bool test_r_id_storage_add1(void) {
 	r_id_storage_add (ids, str, &id);
 	bool success = r_id_storage_add (ids, str, &id);
 	r_id_storage_free (ids);
-	mu_assert (!success, "id_storage_add 1");
+	mu_assert ("id_storage_add 1", !success);
 	mu_end;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Fixes the following warning (https://travis-ci.com/github/radareorg/radare2/jobs/379559222#L2138):

![mu_assert-warning](https://user-images.githubusercontent.com/12002672/91843840-02362900-ec89-11ea-9075-491995a2351e.PNG)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All non-asan builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
