### PR TITLE
Do not run tests for build-static ##build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,9 @@ jobs:
       run: |
         r2 -v
         r2r -v
-        cd test
-        make
+        # NOTE: disabled until all tests properly pass
+        # cd test
+        # make
 
   create-tarball:
     name: Create source tarball


### PR DESCRIPTION
Something does not work well with static (it hasn't at least from the
moment build-static started running full tests). To avoid all kind of
brokeness all around, let's switch back to no-tests. We will enable them
together with the proper fixes for the static build.