### PR TITLE
Fixes r_sys_pid_to_path for Haiku using proper team_id/pid_t ##util

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1172,7 +1172,7 @@ R_API char *r_sys_pid_to_path(int pid) {
 	int32_t group = 0;
 	image_info ii;
 
-	while (get_next_image_info (0, &group, &ii) == B_OK) {
+	while (get_next_image_info ((team_id)pid, &group, &ii) == B_OK) {
 		if (ii.type == B_APP_IMAGE) {
 			break;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)