### PR TITLE
Fix 'call start' register confusion warning ##asm

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4609,9 +4609,18 @@ static bool is_xmm_register(const char *token) {
 
 static bool is_mm_register(const char *token) {
 	if (!r_str_ncasecmp ("mm", token, 2)) {
+		const bool parn = token[2] == '(';
+		if (parn) {
+			token++;
+		}
 		if (isdigit (token[2]) && !isdigit(token[3])) {
 			int n = token[2];
 			if (n >= '0' && n <= '7') {
+				if (parn) {
+					if (token[3] != ')') {
+						return false;
+					}
+				}
 				return true;
 			}
 		}
@@ -4621,9 +4630,18 @@ static bool is_mm_register(const char *token) {
 
 static bool is_st_register(const char *token) {
 	if (!r_str_ncasecmp ("st", token, 2)) {
+		const bool parn = token[2] == '(';
+		if (parn) {
+			token++;
+		}
 		if (isdigit (token[2]) && !isdigit(token[3])) {
 			int n = token[2];
 			if (n >= '0' && n <= '7') {
+				if (parn) {
+					if (token[3] != ')') {
+						return false;
+					}
+				}
 				return true;
 			}
 		}

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4598,6 +4598,39 @@ static x86newTokenType getToken(const char *str, size_t *begin, size_t *end) {
 	}
 }
 
+static bool is_xmm_register(const char *token) {
+	// check xmm0..xmm15
+	if (!r_str_ncasecmp ("xmm", token, 3)) {
+		int n = atoi (token + 3);
+		return (n >= 0 && n <= 15);
+	}
+	return false;
+}
+
+static bool is_mm_register(const char *token) {
+	if (!r_str_ncasecmp ("mm", token, 2)) {
+		if (isdigit (token[2]) && !token[3]) {
+			int n = token[2];
+			if (n >= '0' && n <= '7') {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+static bool is_st_register(const char *token) {
+	if (!r_str_ncasecmp ("st", token, 2)) {
+		if (isdigit (token[2]) && !token[3]) {
+			int n = token[2];
+			if (n >= '0' && n <= '7') {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 /**
  * Get the register at position pos in str. Increase pos afterwards.
  */
@@ -4698,15 +4731,15 @@ static Register parseReg(RAsm *a, const char *str, size_t *pos, ut32 *type) {
 		}
 	}
 	// Extended registers
-	if (!r_str_ncasecmp ("st", token, 2)) {
+	if (is_st_register (token)) {
 		*type = (OT_FPUREG & ~OT_REGALL);
 		*pos = 2;
 	}
-	if (!r_str_ncasecmp ("mm", token, 2)) {
+	if (is_mm_register (token)) {
 		*type = (OT_MMXREG & ~OT_REGALL);
 		*pos = 2;
 	}
-	if (!r_str_ncasecmp ("xmm", token, 3)) {
+	if (is_xmm_register (token)) {
 		*type = (OT_XMMREG & ~OT_REGALL);
 		*pos = 3;
 	}

--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -4609,7 +4609,7 @@ static bool is_xmm_register(const char *token) {
 
 static bool is_mm_register(const char *token) {
 	if (!r_str_ncasecmp ("mm", token, 2)) {
-		if (isdigit (token[2]) && !token[3]) {
+		if (isdigit (token[2]) && !isdigit(token[3])) {
 			int n = token[2];
 			if (n >= '0' && n <= '7') {
 				return true;
@@ -4621,7 +4621,7 @@ static bool is_mm_register(const char *token) {
 
 static bool is_st_register(const char *token) {
 	if (!r_str_ncasecmp ("st", token, 2)) {
-		if (isdigit (token[2]) && !token[3]) {
+		if (isdigit (token[2]) && !isdigit(token[3])) {
 			int n = token[2];
 			if (n >= '0' && n <= '7') {
 				return true;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

```
$ rasm2 -f fail.asm
Expected register number 'art'
e800000000c3
$ cat fail.asm
call start
start:
ret
```

**Test plan**

Not sure if we really need a test for this, i have improved the checks for registers names, this reduces the possibility to try to encode this call as a `call reg`

**Closing issues**

Reported by skuater in chat
