### PR TITLE
Fix ESIL sign extension operator bug ##anal

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -576,7 +576,7 @@ static bool esil_signext(RAnalEsil *esil) {
 	}
 	
 	//Make sure the other bits are 0
-	src &= 0xffffffffffffffffLL >> (64 - dst); 
+	src &= UT64_MAX >> (64 - dst); 
 
 	ut64 m = 0;
 	if (dst < 64) {

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -574,6 +574,9 @@ static bool esil_signext(RAnalEsil *esil) {
 	} else {
 		free (p_dst);
 	}
+	
+	//Make sure the other bits are 0
+	src &= 0xffffffffffffffffLL >> (64 - dst); 
 
 	ut64 m = 0;
 	if (dst < 64) {

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -324,3 +324,11 @@ EXPECT=<<EOF
 0xffffffffffffff80
 EOF
 RUN
+
+NAME=signext ex 
+FILE=-
+CMDS="ae 32,0xffffffffffffff12,~"
+EXPECT=<<EOF
+0xffffffffffffff12
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
“~” means extends **n** bit value to 64-bit value
A bug occurs when the number of digits to be expanded is greater than **n**

For example, I execute the  "ae 32,0xffffffffffffff12,~"

output:
```
0xfffffffeffffff12
```
should be:
```
0xffffffffffffff12
```

**Test-plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
