### PR TITLE
Fix 'anal && op && len > 0' assertion in asan build

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4994,7 +4994,7 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 			r_list_delete (ctx->bbl, bbit);
 			*next_i = ctx->cur_bb->addr - ctx->start_addr;
 		}
-	} else if (cur_addr > ctx->end_addr) {
+	} else if (cur_addr >= ctx->end_addr) {
 		return false;
 	}
 	return true;
@@ -5404,7 +5404,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 		}
 		r_anal_esil_stack_free (ESIL);
 repeat:;
-	} while (get_next_i (&ictx, &i) && i < iend);
+	} while (get_next_i (&ictx, &i));
 	free (buf);
 	ESIL->cb.hook_mem_read = NULL;
 	ESIL->cb.hook_mem_write = NULL;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5404,7 +5404,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 		}
 		r_anal_esil_stack_free (ESIL);
 repeat:;
-	} while (get_next_i (&ictx, &i));
+	} while (get_next_i (&ictx, &i) && i < iend);
 	free (buf);
 	ESIL->cb.hook_mem_read = NULL;
 	ESIL->cb.hook_mem_write = NULL;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes the following (https://travis-ci.com/github/radareorg/radare2/jobs/380644746#L3173):

![aae assertion](https://user-images.githubusercontent.com/12002672/92119606-a0152980-ee2a-11ea-93fb-7f35e92f042a.PNG)


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

The asan test above is fixed. All non-asan builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
