### PR TITLE
Add support for TIMEOUT key for cmd tests ##r2r

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -15,7 +15,7 @@ R_API void r2r_cmd_test_free(R2RCmdTest *test) {
 		return;
 	}
 #define DO_KEY_STR(key, field) free (test->field.value);
-	R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, R2R_CMD_TEST_FOREACH_RECORD_NOP)
+	R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, R2R_CMD_TEST_FOREACH_RECORD_NOP, R2R_CMD_TEST_FOREACH_RECORD_NOP)
 #undef DO_KEY_STR
 	free (test);
 }
@@ -198,17 +198,43 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 			if (!strcmp (val, "1")) { \
 				test->field.value = true; \
 			} else if (!strcmp (val, "0")) { \
-                test->field.value = false; \
+				test->field.value = false; \
 			} else { \
 				eprintf (LINEFMT "Error: Invalid value \"%s\" for boolean key \"%s\", only \"1\" or \"0\" allowed.\n", file, linenum, val, key); \
 				goto fail; \
-            } \
+			} \
 			continue; \
 		}
 
-		R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, DO_KEY_BOOL)
+#define DO_KEY_NUM(key, field) \
+		if (strcmp (line, key) == 0) { \
+			if (test->field.value) { \
+				eprintf (LINEFMT "Warning: Duplicate key \"%s\"\n", file, linenum, key); \
+			} \
+			test->field.set = true; \
+			/* Strip comment */ \
+			char *cmt = strchr (val, '#'); \
+			if (cmt) { \
+				*cmt = '\0'; \
+				cmt--; \
+				while (cmt > val && *cmt == ' ') { \
+					*cmt = '\0'; \
+					cmt--; \
+				} \
+			} \
+			char *endval; \
+			test->field.value = strtol (val, &endval, 0); \
+			if (!endval || *endval) { \
+				eprintf (LINEFMT "Error: Invalid value \"%s\" for numeric key \"%s\", only numbers allowed.\n", file, linenum, val, key); \
+				goto fail; \
+			} \
+			continue; \
+		}
+
+		R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, DO_KEY_BOOL, DO_KEY_NUM)
 #undef DO_KEY_STR
 #undef DO_KEY_BOOL
+#undef DO_KEY_NUM
 
 		eprintf (LINEFMT "Unknown key \"%s\".\n", file, linenum, line);
 	} while ((line = nextline));

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -50,7 +50,7 @@ static int help(bool verbose) {
 		" -V           verbose\n"
 		" -i           interactive mode\n"
 		" -n           do nothing (don't run any test, just load/parse them)\n"
-		" -L           log mode (better printing for CI, logfiles, etc.)"
+		" -L           log mode (better printing for CI, logfiles, etc.)\n"
 		" -F [dir]     run fuzz tests (open and default analysis) on all files in the given dir\n"
 		" -j [threads] how many threads to use for running tests concurrently (default is "WORKERS_DEFAULT_STR")\n"
 		" -r [radare2] path to radare2 executable (default is "RADARE2_CMD_DEFAULT")\n"
@@ -590,7 +590,7 @@ static void print_diff(const char *actual, const char *expected, bool diffchar) 
 }
 
 static R2RProcessOutput *print_runner(const char *file, const char *args[], size_t args_size,
-		const char *envvars[], const char *envvals[], size_t env_size, void *user) {
+	const char *envvars[], const char *envvals[], size_t env_size, ut64 timeout_ms, void *user) {
 	size_t i;
 	for (i = 0; i < env_size; i++) {
 		printf ("%s=%s ", envvars[i], envvals[i]);
@@ -877,9 +877,15 @@ static void fixup_tests(RPVector *results, const char *edited_file, ut64 start_l
 			test->field.line += delta; \
 		}
 
-		R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, DO_KEY_BOOL)
+#define DO_KEY_NUM(key, field) \
+		if (test->field.set && test->field.line >= start_line) { \
+			test->field.line += delta; \
+		}
+
+		R2R_CMD_TEST_FOREACH_RECORD(DO_KEY_STR, DO_KEY_BOOL, DO_KEY_NUM)
 #undef DO_KEY_STR
 #undef DO_KEY_BOOL
+#undef DO_KEY_NUM
 	}
 }
 

--- a/binr/r2r/r2r.h
+++ b/binr/r2r/r2r.h
@@ -37,6 +37,12 @@ typedef struct r2r_cmd_test_bool_record {
 	bool set;
 } R2RCmdTestBoolRecord;
 
+typedef struct r2r_cmd_test_num_record {
+	ut64 value;
+	ut64 line; // bools are always oneliners (e.g. TIMEOUT=10)
+	bool set;
+} R2RCmdTestNumRecord;
+
 typedef struct r2r_cmd_test_t {
 	R2RCmdTestStringRecord name;
 	R2RCmdTestStringRecord file;
@@ -46,15 +52,17 @@ typedef struct r2r_cmd_test_t {
 	R2RCmdTestStringRecord expect;
 	R2RCmdTestStringRecord expect_err;
 	R2RCmdTestBoolRecord broken;
+	R2RCmdTestNumRecord timeout;
 	ut64 run_line;
 	bool load_plugins;
 } R2RCmdTest;
 
 #define R2R_CMD_TEST_FOREACH_RECORD_NOP(name, field)
-#define R2R_CMD_TEST_FOREACH_RECORD(macro_str, macro_bool) \
+#define R2R_CMD_TEST_FOREACH_RECORD(macro_str, macro_bool, macro_int) \
 	macro_str ("NAME", name) \
 	macro_str ("FILE", file) \
 	macro_str ("ARGS", args) \
+	macro_int ("TIMEOUT", timeout) \
 	macro_str ("SOURCE", source) \
 	macro_str ("CMDS", cmds) \
 	macro_str ("EXPECT", expect) \
@@ -182,7 +190,7 @@ R_API bool r2r_subprocess_wait(R2RSubprocess *proc, ut64 timeout_ms);
 R_API void r2r_subprocess_free(R2RSubprocess *proc);
 
 typedef R2RProcessOutput *(*R2RCmdRunner)(const char *file, const char *args[], size_t args_size,
-		const char *envvars[], const char *envvals[], size_t env_size, void *user);
+	const char *envvars[], const char *envvals[], size_t env_size, ut64 timeout_ms, void *user);
 
 R_API void r2r_process_output_free(R2RProcessOutput *out);
 R_API R2RProcessOutput *r2r_run_cmd_test(R2RRunConfig *config, R2RCmdTest *test, R2RCmdRunner runner, void *user);

--- a/test/README.md
+++ b/test/README.md
@@ -113,6 +113,8 @@ Example commands tests for the other `db/` folders:
 * **ARGS** (optional) are the command line argument passed to r2 (e.g -b 16)
 * **CMDS** are the commands to be executed by the test
 * **EXPECT** is the expected output of the test
+* **BROKEN** (optional) is 1 if the tests is expected to be fail, 0 otherwise
+* **TIMEOUT** (optional) is the number of seconds to wait before considering the test timeout
 
 You must end the test by adding RUN keyword
 

--- a/test/db/formats/pe/65535sects
+++ b/test/db/formats/pe/65535sects
@@ -1,5 +1,6 @@
 NAME=PE: corkami 65535sects.exe - section list, entrypoint, open and analyze
 FILE=bins/pe/65535sects.exe
+TIMEOUT=1320
 CMDS=<<EOF
 aa
 om~?


### PR DESCRIPTION
 **Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Right now the timeout was a global defined in Config. This PR adds support for per-test timeout, in case some tests are expected to take a bit more time.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

`db/formats/pe/65535sects` should pass in ASAN build in travis.