### PR TITLE
Show ESIL execution cost information in `ao` and `aoj` ##anal

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -3363,9 +3363,7 @@ static void r_anal_esil_setup_ops(RAnalEsil *esil) {
 
 /* register callbacks using this anal module. */
 R_API bool r_anal_esil_setup(RAnalEsil *esil, RAnal *anal, int romem, int stats, int nonull) {
-	if (!esil) {
-		return false;
-	}
+	r_return_val_if_fail (esil, false);
 	//esil->debug = 0;
 	esil->anal = anal;
 	esil->parse_goto_count = anal->esil_goto_limit;
@@ -3383,7 +3381,6 @@ R_API bool r_anal_esil_setup(RAnalEsil *esil, RAnal *anal, int romem, int stats,
 		esil->cb.reg_write = internal_esil_reg_write_no_null;
 		esil->cb.mem_read = internal_esil_mem_read_no_null;
 		esil->cb.mem_write = internal_esil_mem_write_no_null;
-
 	} else {
 		esil->cb.reg_write = internal_esil_reg_write;
 		esil->cb.mem_read = internal_esil_mem_read;
@@ -3393,8 +3390,6 @@ R_API bool r_anal_esil_setup(RAnalEsil *esil, RAnal *anal, int romem, int stats,
 	r_anal_esil_stats (esil, stats);
 	r_anal_esil_setup_ops (esil);
 
-	if (anal->cur && anal->cur->esil_init && anal->cur->esil_fini) {
-		return anal->cur->esil_init (esil);
-	}
-	return true;
+	return (anal->cur && anal->cur->esil_init)
+		? anal->cur->esil_init (esil): true;
 }

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -906,6 +906,7 @@ EOF
 EXPECT=<<EOF
 address: 0x568
 opcode: push {r3, lr}
+esilcost: 16
 disasm: push {r3, lr}
 pseudo: push (r3, lr) 
 mnemonic: push
@@ -925,6 +926,7 @@ stackptr: 8
 --
 address: 0x50e
 opcode: add r7, sp, 0
+esilcost: 0
 disasm: add r7, sp, 0
 pseudo: r7 = sp + 0
 mnemonic: add

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -65,6 +65,7 @@ EOF
 EXPECT=<<EOF
 address: 0x100007f10
 opcode: irg x8, sp, x8
+esilcost: 0
 disasm: irg x8, sp, x8
 pseudo: irg x8,sp,x8 
 mnemonic: irg
@@ -81,6 +82,7 @@ family: sec
 --
 address: 0x100007f14
 opcode: addg x9, x8, 0x20, 0x0
+esilcost: 0
 disasm: addg x9, x8, 0x20, 0x0
 pseudo: addg x9,x8,0x20, 0x0 
 mnemonic: addg

--- a/test/db/anal/tms320.c64x_32
+++ b/test/db/anal/tms320.c64x_32
@@ -30,6 +30,7 @@ EXPECT=<<EOF
     "bytes": "0041bd10",
     "size": 4,
     "type": "jmp",
+    "esilcost": 0,
     "scale": 0,
     "refptr": 0,
     "cycles": 0,

--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -72,6 +72,7 @@ EXPECT=<<EOF
     "bytes": "9c",
     "size": 1,
     "type": "upush",
+    "esilcost": 0,
     "scale": 0,
     "refptr": 0,
     "cycles": 2,

--- a/test/db/anal/x86_32
+++ b/test/db/anal/x86_32
@@ -3152,6 +3152,7 @@ EXPECT=<<EOF
     "bytes": "31c0",
     "size": 2,
     "type": "xor",
+    "esilcost": 0,
     "scale": 0,
     "refptr": 0,
     "cycles": 1,
@@ -3199,6 +3200,7 @@ EXPECT=<<EOF
     "bytes": "669c",
     "size": 2,
     "type": "upush",
+    "esilcost": 12,
     "scale": 0,
     "refptr": 0,
     "cycles": 2,
@@ -3427,9 +3429,10 @@ ao 1
 p8 1
 EOF
 EXPECT=<<EOF
-16
+17
 address: 0x0
 opcode: nop
+esilcost: 0
 disasm: nop
 mnemonic: nop
 description: no operation

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1026,7 +1026,8 @@ ahe test
 ao~esil
 EOF
 EXPECT=<<EOF
-17
+18
+esilcost: 0
 esil: test
 EOF
 RUN
@@ -1038,6 +1039,7 @@ ahe test
 ao~^esil
 EOF
 EXPECT=<<EOF
+esilcost: 0
 esil: test
 EOF
 RUN
@@ -2217,6 +2219,7 @@ EXPECT=<<EOF
     "bytes": "669c",
     "size": 2,
     "type": "upush",
+    "esilcost": 24,
     "scale": 0,
     "refptr": 0,
     "cycles": 2,
@@ -2976,6 +2979,7 @@ EOF
 EXPECT=<<EOF
 address: 0x0
 opcode: push rbp
+esilcost: 24
 disasm: push rbp
 pseudo: push rbp
 mnemonic: push

--- a/test/db/cmd/cmd_ao
+++ b/test/db/cmd/cmd_ao
@@ -24,3 +24,88 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=ao_aoj
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx c745f400000000
+ao
+aoj~{}
+EOF
+EXPECT=<<EOF
+address: 0x0
+opcode: mov dword [rbp - 0xc], 0
+esilcost: 12
+disasm: mov dword [rbp - 0xc], 0
+pseudo: dword [rbp - 0xc] = 0
+mnemonic: mov
+description: moves data from src to dst
+mask: ffffffffffffff
+prefix: 0
+id: 449
+bytes: c745f400000000
+val: 0x00000000
+disp: 0xfffffffffffffff4
+refptr: 4
+size: 7
+sign: false
+type: mov
+cycles: 1
+esil: 0,0xc,rbp,-,=[4]
+direction: write
+family: cpu
+stackop: set
+stackptr: 8
+[
+  {
+    "opcode": "mov dword [rbp - 0xc], 0",
+    "disasm": "mov dword [rbp - 0xc], 0",
+    "pseudo": "dword [rbp - 0xc] = 0",
+    "description": "moves data from src to dst",
+    "mnemonic": "mov",
+    "mask": "ffffffffffffff",
+    "esil": "0,0xc,rbp,-,=[4]",
+    "sign": false,
+    "prefix": 0,
+    "id": 449,
+    "opex": {
+      "operands": [
+        {
+          "size": 4,
+          "rw": 2,
+          "type": "mem",
+          "base": "rbp",
+          "scale": 1,
+          "disp": 18446744073709551604
+        },
+        {
+          "size": 4,
+          "rw": 0,
+          "type": "imm",
+          "value": 0
+        }
+      ],
+      "modrm": true,
+      "disp": -12
+    },
+    "addr": 0,
+    "bytes": "c745f400000000",
+    "val": 0,
+    "disp": 18446744073709551604,
+    "size": 7,
+    "type": "mov",
+    "esilcost": 12,
+    "scale": 0,
+    "refptr": 4,
+    "cycles": 1,
+    "failcycles": 0,
+    "delay": 0,
+    "stack": "set",
+    "stackptr": 8,
+    "family": "cpu"
+  }
+]
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -111,6 +111,7 @@ ao~opcode,esil
 EOF
 EXPECT=<<EOF
 opcode: imul eax, ebx, 0x89
+esilcost: 0
 esil: 32,137,~,32,ebx,~,*,DUP,eax,=,eax,-,?{,1,1,}{,0,0,},cf,:=,of,:=
 EOF
 RUN
@@ -204,6 +205,7 @@ EOF
 EXPECT=<<EOF
 
 opcode: lea rsi, [rdi + 0x68]
+esilcost: 0
 esil: 0x68,rdi,+,rsi,=
 EOF
 RUN
@@ -220,6 +222,7 @@ EOF
 EXPECT=<<EOF
 
 opcode: lea rdi, [rbp - 0x440]
+esilcost: 0
 esil: 0x440,rbp,-,rdi,=
 EOF
 RUN
@@ -236,6 +239,7 @@ EOF
 EXPECT=<<EOF
 
 opcode: mov dword [rip + 0x40dd], 1
+esilcost: 12
 esil: 1,0x40dd,rip,+,=[4]
 EOF
 RUN
@@ -310,6 +314,7 @@ e asm.bits=64
 ao~esil
 EOF
 EXPECT=<<EOF
+esilcost: 4
 esil: 32,rax,4,*,rdx,+,[4],~,rax,=
 EOF
 RUN
@@ -324,6 +329,7 @@ ao~esil,opcode
 EOF
 EXPECT=<<EOF
 opcode: lea rax, [rdi + r13*8]
+esilcost: 0
 esil: r13,8,*,rdi,+,rax,=
 EOF
 RUN
@@ -338,6 +344,7 @@ ao~opcode,esil
 EOF
 EXPECT=<<EOF
 opcode: lea rbx, [rax + rdx]
+esilcost: 0
 esil: rdx,rax,+,rbx,=
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

cc @sanguinawer 

**Detailed description**

Right now we get execution cost information statically. this patch adds support for computing the cost of executing the esil expression. this way we can properly cmopute the costs for `rep` instructions and other tricky instructions

**Test plan**

![IMAGE 2020-09-04 03:23:09](https://user-images.githubusercontent.com/6431515/92188842-f8195380-ee5d-11ea-88c9-63560616ee38.jpg)
**Closing issues**

Needed to fix a bug in r2wars