### PR TITLE
Implements r_sys_aslr for NetBSD ##port

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -278,7 +278,7 @@ static void setASLR(RRunProfile *r, int enabled) {
 	// for osxver>=10.7
 	// "unset the MH_PIE bit in an already linked executable" with --no-pie flag of the script
 	// the right way is to disable the aslr bit in the spawn call
-#elif __FreeBSD__
+#elif __FreeBSD__ || __NetBSD__
 	r_sys_aslr (enabled);
 #else
 	// not supported for this platform

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #if defined(__NetBSD__)
 # include <sys/param.h>
+# include <sys/sysctl.h>
 # if __NetBSD_Prereq__(7,0,0)
 #  define NETBSD_WITH_BACKTRACE
 # endif
@@ -553,6 +554,12 @@ R_API bool r_sys_aslr(int val) {
 		ret = false;
 	}
 #endif
+#elif __NetBSD__
+	size_t vlen = sizeof (val);
+	if (sysctlbyname ("security.pax.aslr.enabled", NULL, 0, &val, vlen) == -1) {
+		eprintf ("Failed to set RVA\n");
+		ret = false;
+	}
 #endif
 	return ret;
 }


### PR DESCRIPTION
ASLR on NetBSD is also settable via sysctl call.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)