### PR TITLE
Fix #17590 - Fix invalid deref in print_types_format

### DIFF
--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -350,6 +350,7 @@ static int pdb_read_root(RPdb *pdb) {
 		page = (SPage *) r_list_iter_get (it);
 		if (page->stream_pages == 0) {
 			//eprintf ("Warning: no stream pages. Skipping.\n");
+			r_list_append (pList, NULL);
 			i++;
 			continue;
 		}

--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -193,7 +193,7 @@ R_API RListIter *r_list_item_new(void *data) {
 R_API RListIter *r_list_append(RList *list, void *data) {
 	RListIter *item = NULL;
 
-	r_return_val_if_fail (list && data, NULL);
+	r_return_val_if_fail (list, NULL);
 
 	item = R_NEW (RListIter);
 	if (!item) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Make sure streams are in their proper index for `r_list_get_n` by appending a NULL item when necessary


**Test plan**

Tests pass

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Closes #17590
