### PR TITLE
Add API for getting Atomic and Typedef Types and remove broken !size

### DIFF
--- a/libr/anal/d/types-darwin.sdb.txt
+++ b/libr/anal/d/types-darwin.sdb.txt
@@ -212,7 +212,6 @@ func.recvfrom.ret=ssize_t
 
 NSString=struct
 struct.NSString=p0,p1,str,len
-struct.NSString.!size=256
 struct.NSString.p0=void *,0,0
 struct.NSString.p0.meta=4
 struct.NSString.p1=size_t,0,0

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -280,7 +280,7 @@ error:
 }
 
 static RAnalBaseType *get_typedef_type(RAnal *anal, const char *sname) {
-	r_return_val_if_fail (anal && sname, NULL);
+	r_return_val_if_fail (anal && R_STR_ISNOTEMPTY (sname), NULL);
 
 	RAnalBaseType *base_type = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_TYPEDEF);
 	if (!base_type) {
@@ -299,7 +299,7 @@ error:
 }
 
 static RAnalBaseType *get_atomic_type(RAnal *anal, const char *sname) {
-	r_return_val_if_fail (anal && sname, NULL);
+	r_return_val_if_fail (anal && R_STR_ISNOTEMPTY (sname), NULL);
 
 	RAnalBaseType *base_type = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_ATOMIC);
 	if (!base_type) {

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -531,7 +531,7 @@ static void save_atomic_type(const RAnal *anal, const RAnalBaseType *type) {
 
 	sdb_set (anal->sdb_types,
 			r_strbuf_setf (&key, "type.%s", sname),
-			r_strbuf_setf (&val, "%s", type->type), 0);
+			type->type, 0);
 
 	free (sname);
 

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -312,9 +312,7 @@ static RAnalBaseType *get_atomic_type(RAnal *anal, const char *sname) {
 	}
 
 	RStrBuf key;
-	r_strbuf_init (&key);
-	r_strbuf_setf (&key, "type.%s.size", sname);
-	base_type->size = sdb_num_get (anal->sdb_types, r_strbuf_get (&key), 0);
+	base_type->size = sdb_num_get (anal->sdb_types, r_strbuf_initf (&key, "type.%s.size", sname), 0);
 	r_strbuf_fini (&key);
 
 	return base_type;
@@ -387,9 +385,9 @@ static void save_struct(const RAnal *anal, const RAnalBaseType *type) {
 	r_vector_foreach (&type->struct_data.members, member) {
 		// struct.name.param=type,offset,argsize
 		char *member_sname = r_str_sanitize_sdb_key (member->name);
-		r_strbuf_setf (&param_key, "%s.%s.%s", kind, sname, member_sname);
-		r_strbuf_setf (&param_val, "%s,%" PFMT64u ",%" PFMT64u "", member->type, member->offset, 0);
-		sdb_set (anal->sdb_types, r_strbuf_get (&param_key), r_strbuf_get (&param_val), 0);
+		sdb_set (anal->sdb_types,
+			r_strbuf_setf (&param_key, "%s.%s.%s", kind, sname, member_sname),
+			r_strbuf_setf (&param_val, "%s,%" PFMT64u ",%" PFMT64u "", member->type, member->offset, 0), 0);
 		free (member_sname);
 
 		r_strbuf_appendf (&arglist, (i++ == 0) ? "%s" : ",%s", member->name);
@@ -436,9 +434,9 @@ static void save_union(const RAnal *anal, const RAnalBaseType *type) {
 	r_vector_foreach (&type->union_data.members, member) {
 		// union.name.arg1=type,offset,argsize
 		char *member_sname = r_str_sanitize_sdb_key (member->name);
-		r_strbuf_setf (&param_key, "%s.%s.%s", kind, sname, member_sname);
-		r_strbuf_setf (&param_val, "%s,%" PFMT64u ",%" PFMT64u "", member->type, member->offset, 0);
-		sdb_set (anal->sdb_types, r_strbuf_get (&param_key), r_strbuf_get (&param_val), 0);
+		sdb_set (anal->sdb_types,
+				r_strbuf_setf (&param_key, "%s.%s.%s", kind, sname, member_sname),
+				r_strbuf_setf (&param_val, "%s,%" PFMT64u ",%" PFMT64u "", member->type, member->offset, 0), 0);
 		free (member_sname);
 
 		r_strbuf_appendf (&arglist, (i++ == 0) ? "%s" : ",%s", member->name);
@@ -486,12 +484,13 @@ static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	r_vector_foreach (&type->enum_data.cases, cas) {
 		// enum.name.arg1=type,offset,???
 		char *case_sname = r_str_sanitize_sdb_key (cas->name);
-		r_strbuf_setf (&param_key, "enum.%s.%s", sname, case_sname);
-		r_strbuf_setf (&param_val, "0x%" PFMT32x "", cas->val);
-		sdb_set (anal->sdb_types, r_strbuf_get (&param_key), r_strbuf_get (&param_val), 0);
+		sdb_set (anal->sdb_types,
+				r_strbuf_setf (&param_key, "enum.%s.%s", sname, case_sname),
+				r_strbuf_setf (&param_val, "0x%" PFMT32x "", cas->val), 0);
 
-		r_strbuf_setf (&param_key, "enum.%s.0x%" PFMT32x "", sname, cas->val);
-		sdb_set (anal->sdb_types, r_strbuf_get (&param_key), case_sname, 0);
+		sdb_set (anal->sdb_types,
+				r_strbuf_setf (&param_key, "enum.%s.0x%" PFMT32x "", sname, cas->val),
+				case_sname, 0);
 		free (case_sname);
 
 		r_strbuf_appendf (&arglist, (i++ == 0) ? "%s" : ",%s", cas->name);
@@ -526,13 +525,13 @@ static void save_atomic_type(const RAnal *anal, const RAnalBaseType *type) {
 	r_strbuf_init (&key);
 	r_strbuf_init (&val);
 
-	r_strbuf_setf (&key, "type.%s.size", sname);
-	r_strbuf_setf (&val, "%" PFMT64u "", type->size);
-	sdb_set (anal->sdb_types, r_strbuf_get (&key), r_strbuf_get (&val), 0);
+	sdb_set (anal->sdb_types,
+			r_strbuf_setf (&key, "type.%s.size", sname),
+			r_strbuf_setf (&val, "%" PFMT64u "", type->size), 0);
 
-	r_strbuf_setf (&key, "type.%s", sname);
-	r_strbuf_setf (&val, "%s", type->type);
-	sdb_set (anal->sdb_types, r_strbuf_get (&key), r_strbuf_get (&val), 0);
+	sdb_set (anal->sdb_types,
+			r_strbuf_setf (&key, "type.%s", sname),
+			r_strbuf_setf (&val, "%s", type->type), 0);
 
 	free (sname);
 
@@ -556,9 +555,9 @@ static void save_typedef(const RAnal *anal, const RAnalBaseType *type) {
 	r_strbuf_init (&key);
 	r_strbuf_init (&val);
 
-	r_strbuf_setf (&key, "typedef.%s", sname);
-	r_strbuf_setf (&val, "%s", type->type);
-	sdb_set (anal->sdb_types, r_strbuf_get (&key), r_strbuf_get (&val), 0);
+	sdb_set (anal->sdb_types,
+			r_strbuf_setf (&key, "typedef.%s", sname),
+			r_strbuf_setf (&val, "%s", type->type), 0);
 
 	free (sname);
 

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -441,17 +441,8 @@ static int print_struct_union_list_json(Sdb *TDB, SdbForeachCallback filter) {
 			continue;
 		}
 		pj_o (pj); // {
-		char *sizecmd = r_str_newf ("%s.%s.!size", sdbkv_value (kv), k);
-		if (!sizecmd) {
-			break;
-		}
-		char *size_s = sdb_querys (TDB, NULL, -1, sizecmd);
 		pj_ks (pj, "type", k); // key value pair of string and string
-		pj_ki (pj, "size", size_s ? atoi (size_s) : 0); // key value pair of string and int
 		pj_end (pj); // }
-
-		free (sizecmd);
-		free (size_s);
 	}
 	pj_end (pj); // ]
 

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -272,7 +272,7 @@ EXPECT=<<EOF
 |           ; arg func main @ r0
 |           ; arg int argc @ r1
 |           0x00008174      b80000eb       bl sym.__libc_start_main    ; lr=0x8178 -> 0xeb0002a4 ; pc=0x845c -> 0xe92d41f0
-|                                                                      ; int __libc_start_main(?, -1, ?, ?, ?, ?, -1)
+|                                                                      ; int __libc_start_main(?, ?, ?, ?, ?, ?, -1)
 \           0x00008178      a40200eb       bl sym.abort                ; lr=0x817c -> 0xe92d4030 ; pc=0x8c10 -> 0xe59f62a0
 \                                                                      ; void abort(void)
 
@@ -281,7 +281,7 @@ EXPECT=<<EOF
 |           ; arg int argc @ r1
 |              ; lr=0x8178 -> 0xeb0002a4
 |              ; pc=0x845c -> 0xe92d41f0 sym.__libc_start_main
-|              ; int __libc_start_main(?, -1, ?, ?, ?, ?, -1)
+|              ; int __libc_start_main(?, ?, ?, ?, ?, ?, -1)
 |           0x00008174      b80000eb       bl sym.__libc_start_main
 |              ; lr=0x817c -> 0xe92d4030
 |              ; pc=0x8c10 -> 0xe59f62a0 sym.abort
@@ -296,7 +296,7 @@ EXPECT=<<EOF
 | ; arg int argc @ r1                                |
 |    ; lr=0x8178 -> 0xeb0002a4                       |
 |    ; pc=0x845c -> 0xe92d41f0 sym.__libc_start_main |
-|    ; int __libc_start_main(?, -1, ?, ?, ?, ?, -1)  |
+|    ; int __libc_start_main(?, ?, ?, ?, ?, ?, -1)   |
 | bl sym.__libc_start_main;[oa]                      |
 |    ; lr=0x817c -> 0xe92d4030                       |
 |    ; pc=0x8c10 -> 0xe59f62a0 sym.abort             |

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -246,7 +246,7 @@ NAME=tc typedef
 FILE=-
 CMDS=<<EOF
 "td typedef char *string;"
-tc
+ttc
 EOF
 EXPECT=<<EOF
 typedef char * string;

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -241,3 +241,14 @@ struct NSString {
 };
 EOF
 RUN
+
+NAME=tc typedef
+FILE=-
+CMDS=<<EOF
+"td typedef char *string;"
+tc
+EOF
+EXPECT=<<EOF
+typedef char * string;
+EOF
+RUN

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -246,7 +246,7 @@ NAME=tc typedef
 FILE=-
 CMDS=<<EOF
 "td typedef char *string;"
-ttc
+ttc string
 EOF
 EXPECT=<<EOF
 typedef char * string;

--- a/test/db/cmd/cmd_to
+++ b/test/db/cmd/cmd_to
@@ -63,7 +63,6 @@ days=typedef
 easy_prey=typedef
 humans=typedef
 struct.dangerous=neo
-struct.dangerous.!size=64
 struct.dangerous.neo=uint64_t,0,0
 struct.dangerous.neo.meta=13
 tokyo=typedef

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -213,7 +213,6 @@ t-xoo
 EOF
 EXPECT=<<EOF
 union.xoo=x,y,z
-union.xoo.!size=32
 union.xoo.x=int32_t,0,0
 union.xoo.x.meta=0
 union.xoo.y=int32_t,0,0
@@ -1394,7 +1393,6 @@ tk~struct.s1
 EOF
 EXPECT=<<EOF
 struct.s1=a,size,b
-struct.s1.!size=96
 struct.s1.a=int32_t,0,0
 struct.s1.a.meta=0
 struct.s1.b=int32_t,8,0
@@ -1538,7 +1536,6 @@ EXPECT=<<EOF
 pf.foo dc a b
 tk foo=union
 tk union.foo=a,b
-tk union.foo.!size=32
 tk union.foo.a=int32_t,0,0
 tk union.foo.a.meta=0
 tk union.foo.b=char,0,0

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -38,6 +38,7 @@ if get_option('enable_tests')
     'json',
     'list',
     'parse_ctype',
+    'pdb',
     'pj',
     'queue',
     'r2r',

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -95,10 +95,11 @@ static bool test_anal_save_base_type_struct(void) {
 	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
 	base->name = strdup ("kappa");
 
-	RAnalStructMember member;
-	member.offset = 0;
-	member.type = strdup ("int32_t");
-	member.name = strdup ("bar");
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("bar")
+	};
 	r_vector_push (&base->struct_data.members, &member);
 
 	member.offset = 4;
@@ -154,10 +155,11 @@ static bool test_anal_save_base_type_union(void) {
 	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_UNION);
 	base->name = strdup ("kappa");
 
-	RAnalUnionMember member;
-	member.offset = 0;
-	member.type = strdup ("int32_t");
-	member.name = strdup ("bar");
+	RAnalUnionMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("bar")
+	};
 	r_vector_push (&base->union_data.members, &member);
 
 	member.offset = 0;
@@ -190,9 +192,7 @@ static bool test_anal_get_base_type_enum(void) {
 	mu_assert_eq (R_ANAL_BASE_TYPE_KIND_ENUM, base->kind, "Wrong base type");
 	mu_assert_streq (base->name, "foo", "type name");
 
-	RAnalEnumCase *cas;
-
-	cas = r_vector_index_ptr (&base->enum_data.cases, 0);
+	RAnalEnumCase *cas = r_vector_index_ptr (&base->enum_data.cases, 0);
 	mu_assert_eq (cas->val, 1, "Incorrect value for enum case");
 	mu_assert_streq (cas->name, "firstCase", "Incorrect name for enum case");
 
@@ -213,9 +213,10 @@ static bool test_anal_save_base_type_enum(void) {
 	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_ENUM);
 	base->name = strdup ("foo");
 
-	RAnalEnumCase cas;
-	cas.name = strdup ("firstCase");
-	cas.val = 1;
+	RAnalEnumCase cas = {
+		.name = strdup ("firstCase"),
+		.val = 1
+	};
 	r_vector_push (&base->enum_data.cases, &cas);
 
 	cas.name = strdup ("secondCase");

--- a/test/unit/test_dwarf_integration.c
+++ b/test/unit/test_dwarf_integration.c
@@ -41,7 +41,6 @@ static bool test_parse_dwarf_types(void) {
 	char * value = NULL;
 	Sdb *sdb = anal->sdb_types;
 	check_kv ("_cairo_status", "enum");
-	check_kv ("enum._cairo_status.!size", "32");
 	check_kv ("enum._cairo_status.0x0", "CAIRO_STATUS_SUCCESS");
 	check_kv ("enum._cairo_status.CAIRO_STATUS_SUCCESS", "0x0");
 	check_kv ("enum._cairo_status.0x9", "CAIRO_STATUS_INVALID_PATH_DATA");
@@ -63,12 +62,10 @@ static bool test_parse_dwarf_types(void) {
 	"CAIRO_STATUS_INVALID_SLANT,CAIRO_STATUS_INVALID_WEIGHT");
 
 	check_kv ("_MARGINS", "struct");
-	check_kv ("struct._MARGINS.!size", "128");
 	// TODO evaluate member_location operations in DWARF to get offset and test it
 	check_kv ("struct._MARGINS", "cxLeftWidth,cxRightWidth,cyTopHeight,cyBottomHeight");
 
 	check_kv ("unaligned", "union");
-	check_kv ("union.unaligned.!size", "64");
 	check_kv ("union.unaligned", "ptr,u2,u4,u8,s2,s4,s8");
 	check_kv ("union.unaligned.u2", "short unsigned int,0,0");
 	check_kv ("union.unaligned.s8", "long long int,0,0");

--- a/test/unit/test_dwarf_integration.c
+++ b/test/unit/test_dwarf_integration.c
@@ -253,5 +253,5 @@ int all_tests(void) {
 }
 
 int main(int argc, char **argv) {
-	return all_tests();
+	return all_tests ();
 }

--- a/test/unit/test_pdb.c
+++ b/test/unit/test_pdb.c
@@ -420,7 +420,6 @@ bool test_pdb_tpi_rust(void) {
 			mu_assert_eq (type_info->leaf_type, eLF_ARGLIST, "Incorrect data type");
 		} else if (type->tpi_idx == 0x1058) {
 			mu_assert_eq (type_info->leaf_type, eLF_STRUCTURE, "Incorrect data type");
-			SType *return_type;
 			char *name;
 			type_info->get_name (&type->type_data, &name);
 			mu_assert_streq (name, "std::thread::local::fast::Key<core::cell::Cell<core::option::Option<core::ptr::non_null::NonNull<core::task::wake::Context>>>>", "Wrong name");
@@ -475,7 +474,6 @@ bool test_pdb_type_save(void) {
 	check_kv ("union.R2_TEST_UNION", "r2_union_var_1,r2_union_var_2");
 	check_kv ("union.R2_TEST_UNION.r2_union_var_1", "int32_t,0,0");
 	check_kv ("union.R2_TEST_UNION.r2_union_var_2", "double,0,0");
-	check_kv ("union.R2_TEST_UNION.!size", "8");
 
 	check_kv ("__m64", "union");
 	check_kv ("union.__m64", "m64_u64,m64_f32,m64_i8,m64_i16,m64_i32,m64_i64,m64_u8,m64_u16,m64_u32");
@@ -488,19 +486,16 @@ bool test_pdb_type_save(void) {
 	check_kv ("union.__m64.m64_u8", "uint8_t[8],0,0");
 	check_kv ("union.__m64.m64_u16", "uint16_t[8],0,0");
 	check_kv ("union.__m64.m64_u32", "uint32_t[8],0,0");
-	check_kv ("union.__m64.!size", "8");
 
 	check_kv ("TEST_CLASS", "struct");
 	check_kv ("struct.TEST_CLASS", "class_var1,calss_var2");
 	check_kv ("struct.TEST_CLASS.class_var1", "int32_t,0,0");
 	check_kv ("struct.TEST_CLASS.calss_var2", "uint16_t,4,0");
-	check_kv ("union.__m64.!size", "8");
 
 	check_kv ("localeinfo_struct", "struct");
 	check_kv ("struct.localeinfo_struct", "locinfo,mbcinfo");
 	check_kv ("struct.localeinfo_struct.locinfo", "struct threadlocaleinfostruct*,0,0");
 	check_kv ("struct.localeinfo_struct.mbcinfo", "struct threadmbcinfostruct*,4,0");
-	check_kv ("union.__m64.!size", "8");
 	r_anal_free (anal);
 	mu_end;
 }

--- a/test/unit/test_sdb.h
+++ b/test/unit/test_sdb.h
@@ -1,0 +1,20 @@
+#ifndef TEST_SDB_H
+#define TEST_SDB_H
+
+static void diff_cb(const SdbDiff *diff, void *user) {
+	char buf[2048];
+	if (sdb_diff_format (buf, sizeof(buf), diff) < 0) {
+		return;
+	}
+	printf ("%s\n", buf);
+}
+
+static inline void print_sdb(Sdb *sdb) {
+	Sdb *e = sdb_new0 ();
+	sdb_diff (e, sdb, diff_cb, NULL);
+	sdb_free (e);
+}
+
+#define assert_sdb_eq(actual, expected, msg) mu_assert ((msg), sdb_diff (expected, actual, diff_cb, NULL));
+
+#endif //R2DB_TEST_UTILS_H

--- a/test/unit/test_sdb.h
+++ b/test/unit/test_sdb.h
@@ -3,7 +3,7 @@
 
 static void diff_cb(const SdbDiff *diff, void *user) {
 	char buf[2048];
-	if (sdb_diff_format (buf, sizeof(buf), diff) < 0) {
+	if (sdb_diff_format (buf, sizeof (buf), diff) < 0) {
 		return;
 	}
 	printf ("%s\n", buf);


### PR DESCRIPTION
Filling this template is fun.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

see commit titles

**Test plan**

run the tests