### PR TITLE
Fix MSVC template demangling with ref to mangled symbol

### DIFF
--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -444,7 +444,7 @@ static size_t get_template(const char *buf, SStrInfo *str_info, bool memorize) {
 	}
 
 	if (*buf == '?') {
-		RList *names_l = r_list_newf (sstrinfo_free);
+		RList *names_l = r_list_newf ((RListFree)sstrinfo_free);
 		if (!names_l) {
 			return 0;
 		}
@@ -537,7 +537,7 @@ static size_t get_namespace_and_name(const char *buf, STypeCodeStr *type_code_st
 
 	size_t len = 0, read_len = 0, tmp_len = 0;
 
-	names_l = r_list_newf (sstrinfo_free);
+	names_l = r_list_newf ((RListFree)sstrinfo_free);
 
 	if (*buf == '?') {
 		size_t res = get_operator_code (buf, names_l, memorize);

--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -41,8 +41,8 @@ typedef enum ETCState { // TC - type code
 
 typedef struct STypeCodeStr {
 	char *type_str;
-	int type_str_len;
-	int curr_pos;
+	size_t type_str_len;
+	size_t curr_pos;
 } STypeCodeStr;
 
 struct SStateInfo;
@@ -50,15 +50,20 @@ typedef void (*state_func)(struct SStateInfo *, STypeCodeStr *type_code_str);
 
 typedef struct SStateInfo {
 	ETCState state;
-	char *buff_for_parsing;
-	int amount_of_read_chars;
+	const char *buff_for_parsing;
+	size_t amount_of_read_chars;
 	ETCStateMachineErr err;
 } SStateInfo;
 
 typedef struct SStrInfo {
 	char *str_ptr;
-	int len;
+	size_t len;
 } SStrInfo;
+
+static void sstrinfo_free(SStrInfo *sstrinfo) {
+	free (sstrinfo->str_ptr);
+	free (sstrinfo);
+}
 
 #define DECL_STATE_ACTION(action) static void tc_state_##action(SStateInfo *state, STypeCodeStr *type_code_str);
 DECL_STATE_ACTION(start)
@@ -105,23 +110,23 @@ static state_func const state_table[eTCStateMax] = {
 // State machine for parsing type codes functions
 ///////////////////////////////////////////////////////////////////////////////
 
-static void init_state_struct(SStateInfo *state, char *buff_for_parsing);
-static EDemanglerErr get_type_code_string(char *sym, unsigned int *amount_of_read_chars, char **str_type_code);
+static void init_state_struct(SStateInfo *state, const char *buff_for_parsing);
+static EDemanglerErr get_type_code_string(const char *sym, size_t *amount_of_read_chars, char **str_type_code);
 static int init_type_code_str_struct(STypeCodeStr *type_coder_str);
 static void free_type_code_str_struct(STypeCodeStr *type_code_str);
-static int get_template(char *buf, SStrInfo *str_info, bool memorize);
+static size_t get_template(const char *buf, SStrInfo *str_info, bool memorize);
 static char *get_num(SStateInfo *state);
-static EDemanglerErr parse_data_type(char *sym, char **demangled_type, char **access_modifier, int *len, bool *is_static, bool *is_implicit_this_pointer);
-int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str, unsigned int *amount_of_names, bool memorize);
+static EDemanglerErr parse_data_type(const char *sym, char **demangled_type, char **access_modifier, size_t *len, bool *is_static, bool *is_implicit_this_pointer);
+static size_t get_namespace_and_name(const char *buf, STypeCodeStr *type_code_str, size_t *amount_of_names, bool memorize);
 
 static void run_state(SStateInfo *state_info, STypeCodeStr *type_code_str) {
 	state_table[state_info->state](state_info, type_code_str);
 }
 
-int copy_string(STypeCodeStr *type_code_str, char *str_for_copy, unsigned int copy_len) {
+static int copy_string(STypeCodeStr *type_code_str, const char *str_for_copy, size_t copy_len) {
 	int res = 1; // all is OK
-	int str_for_copy_len = (copy_len == 0 && str_for_copy) ? strlen (str_for_copy) : copy_len;
-	int free_space = type_code_str->type_str_len - type_code_str->curr_pos - 1;
+	size_t str_for_copy_len = (copy_len == 0 && str_for_copy) ? strlen (str_for_copy) : copy_len;
+	size_t free_space = type_code_str->type_str_len - type_code_str->curr_pos - 1;
 
 	if (str_for_copy_len > free_space) {
 		return 0;
@@ -164,7 +169,7 @@ copy_string_err:
 	return res;
 }
 
-int get_template_params(char *sym, unsigned int *amount_of_read_chars, char **str_type_code) {
+static int get_template_params(const char *sym, size_t *amount_of_read_chars, char **str_type_code) {
 	SStateInfo state;
 	init_state_struct (&state, sym);
 	const char template_param[] = "template-parameter-";
@@ -204,7 +209,7 @@ int get_template_params(char *sym, unsigned int *amount_of_read_chars, char **st
 			}
 			const char *const start_sym = sym;
 			sym += 2;
-			int ret = get_namespace_and_name (sym, &str, NULL, true);
+			size_t ret = get_namespace_and_name (sym, &str, NULL, true);
 			if (!ret) {
 				return eDemanglerErrUncorrectMangledSymbol;
 			}
@@ -316,17 +321,17 @@ int get_template_params(char *sym, unsigned int *amount_of_read_chars, char **st
 	return eDemanglerErrOK;
 }
 
-static int get_operator_code(char *buf, RList *names_l, bool memorize) {
+static size_t get_operator_code(const char *buf, RList *names_l, bool memorize) {
 	// C++ operator code (one character, or two if the first is '_')
 #define SET_OPERATOR_CODE(str) { \
 	str_info = (SStrInfo *) malloc (sizeof(SStrInfo)); \
 	if (!str_info) break; \
 	str_info->len = strlen (str); \
-	str_info->str_ptr = str; \
+	str_info->str_ptr = strdup (str); \
 	r_list_append (names_l, str_info); \
 }	
 	SStrInfo *str_info;
-	int read_len = 1;
+	size_t read_len = 1;
 	switch (*++buf) {
 	case '0': SET_OPERATOR_CODE("constructor"); break;
 	case '1': SET_OPERATOR_CODE("~destructor"); break;
@@ -366,12 +371,11 @@ static int get_operator_code(char *buf, RList *names_l, bool memorize) {
 	case 'Z': SET_OPERATOR_CODE("operator-="); break;
 	case '$':
 	{
-		int i = 0;
 		str_info = (SStrInfo *)malloc (sizeof(SStrInfo));
 		if (!str_info) {
 			break;
 		}
-		i = get_template (buf + 1, str_info, memorize);
+		size_t i = get_template (buf + 1, str_info, memorize);
 		if (!i) {
 			R_FREE (str_info);
 			return 0;
@@ -428,9 +432,8 @@ static int get_operator_code(char *buf, RList *names_l, bool memorize) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-static int get_template(char *buf, SStrInfo *str_info, bool memorize) {
-	int len = 0;
-	unsigned int i = 0;
+static size_t get_template(const char *buf, SStrInfo *str_info, bool memorize) {
+	size_t len = 0;
 	char *str_type_code = NULL;
 	STypeCodeStr type_code_str;
 	// RListIter *it = NULL;
@@ -441,11 +444,11 @@ static int get_template(char *buf, SStrInfo *str_info, bool memorize) {
 	}
 
 	if (*buf == '?') {
-		RList *names_l = r_list_new ();
+		RList *names_l = r_list_newf (sstrinfo_free);
 		if (!names_l) {
 			return 0;
 		}
-		int i = get_operator_code (buf, names_l, memorize);
+		size_t i = get_operator_code (buf, names_l, memorize);
 		if (!i) {
 			return 0;
 		}
@@ -474,6 +477,7 @@ static int get_template(char *buf, SStrInfo *str_info, bool memorize) {
 	}
 
 	// get identifier
+	size_t i = 0;
 	while (*buf != '@') {
 		if (i) {
 			copy_string (&type_code_str, ", ", 0);
@@ -524,21 +528,19 @@ get_template_err:
 /// \param amount_of_names Amount of names that was in list
 /// \return Return amount of processed chars
 ///
-int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
-							unsigned int *amount_of_names, bool memorize)
-{
-	char *curr_pos = NULL, *prev_pos = NULL;
-	char *tmp = NULL;
+static size_t get_namespace_and_name(const char *buf, STypeCodeStr *type_code_str,
+	size_t *amount_of_names, bool memorize) {
+	const char *curr_pos = NULL, *prev_pos = NULL, *tmp = NULL;
 	RList /* <SStrInfo *> */ *names_l = NULL;
 	RListIter *it = NULL;
 	SStrInfo *str_info = NULL;
 
-	int len = 0, read_len = 0, tmp_len = 0;
+	size_t len = 0, read_len = 0, tmp_len = 0;
 
-	names_l = r_list_new ();
+	names_l = r_list_newf (sstrinfo_free);
 
 	if (*buf == '?') {
-		int res = get_operator_code (buf, names_l, memorize);
+		size_t res = get_operator_code (buf, names_l, memorize);
 		if (!res) {
 			return 0;
 		}
@@ -572,8 +574,8 @@ int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
 
 		// check is it teamplate???
 		if ((*tmp == '?') && (*(tmp + 1) == '$')) {
-			int i = 0;
-			str_info = (SStrInfo *) malloc (sizeof(SStrInfo));
+			size_t i = 0;
+			str_info = (SStrInfo *)malloc (sizeof (SStrInfo));
 			i = get_template (tmp + 2, str_info, memorize);
 			if (!i) {
 				R_FREE (str_info);
@@ -582,8 +584,8 @@ int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
 			r_list_append (names_l, str_info);
 
 			prev_pos = tmp + i + 2;
-			curr_pos = strchr(prev_pos, '@');
-			read_len += (i + 2);
+			curr_pos = strchr (prev_pos, '@');
+			read_len += i + 2;
 //			if (curr_pos)
 //				read_len++;
 			continue;
@@ -596,14 +598,15 @@ int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
 			}
 			len = 1;
 		} else {
-			tmp = (char *) malloc (len + 1);
-			memset (tmp, 0, len + 1);
-			memcpy (tmp, prev_pos, len);
-			r_list_append (abbr_names, tmp);
+			char *tmpname = (char *)malloc (len + 1);
+			memset (tmpname, 0, len + 1);
+			memcpy (tmpname, prev_pos, len);
+			r_list_append (abbr_names, tmpname);
+			tmp = tmpname;
 		}
 
-		str_info = (SStrInfo *) malloc (sizeof (SStrInfo));
-		str_info->str_ptr = tmp;
+		str_info = (SStrInfo *)malloc (sizeof (SStrInfo));
+		str_info->str_ptr = strdup (tmp);
 		str_info->len = strlen (tmp);
 
 		r_list_append (names_l, str_info);
@@ -617,7 +620,7 @@ int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
 			}
 		} else {
 			prev_pos = curr_pos + 1;
-			curr_pos = strchr(curr_pos + 1, '@');
+			curr_pos = strchr (curr_pos + 1, '@');
 			if (curr_pos) {
 				read_len++;
 			}
@@ -625,18 +628,17 @@ int get_namespace_and_name(char *buf, STypeCodeStr *type_code_str,
 	}
 
 get_namespace_and_name_err:
-	tmp_len = r_list_length(names_l);
+	tmp_len = r_list_length (names_l);
 	if (amount_of_names) {
 		*amount_of_names = tmp_len;
 	}
 	it = r_list_iterator (names_l);
 	r_list_foreach_prev (names_l, it, str_info) {
-		copy_string(type_code_str, str_info->str_ptr, str_info->len);
+		copy_string (type_code_str, str_info->str_ptr, str_info->len);
 
 		if (--tmp_len) {
-			copy_string(type_code_str, "::", 0);
+			copy_string (type_code_str, "::", 0);
 		}
-		free(str_info);
 	}
 	r_list_free (names_l);
 
@@ -755,8 +757,8 @@ DEF_STATE_ACTION(T)
 	} \
 }
 
-	int buff_len = strlen (state->buff_for_parsing);
-	int check_len = 0;
+	size_t buff_len = strlen (state->buff_for_parsing);
+	size_t check_len = 0;
 
 	state->state = eTCStateEnd;
 
@@ -786,8 +788,8 @@ DEF_STATE_ACTION(U)
 	} \
 }
 
-	int buff_len = strlen (state->buff_for_parsing);
-	int check_len = 0;
+	size_t buff_len = strlen (state->buff_for_parsing);
+	size_t check_len = 0;
 
 	state->state = eTCStateEnd;
 
@@ -803,7 +805,7 @@ DEF_STATE_ACTION(U)
 DEF_STATE_ACTION(W)
 {
 	//W4X@@ -> enum X, W4X@Y@@ -> enum Y::X
-	int check_len = 0;
+	size_t check_len = 0;
 	state->state = eTCStateEnd;
 
 	if (*state->buff_for_parsing != '4') {
@@ -820,24 +822,29 @@ DEF_STATE_ACTION(W)
 DEF_STATE_ACTION(V)
 {
 	// VX@@ -> class X
-	int check_len = 0;
+	size_t check_len = 0;
 	state->state = eTCStateEnd;
 
 	GET_USER_DEF_TYPE_NAME("class ");
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-static char *get_num(SStateInfo *state)
-{
+static char *get_num(SStateInfo *state) {
 	char *ptr = NULL;
 	if (*state->buff_for_parsing >= '0' && *state->buff_for_parsing <= '8') {
 		ptr = (char *) malloc (2);
+		if (!ptr) {
+			return NULL;
+		}
 		ptr[0] = *state->buff_for_parsing + 1;
 		ptr[1] = '\0';
 		state->buff_for_parsing++;
 		state->amount_of_read_chars++;
 	} else if (*state->buff_for_parsing == '9') {
 		ptr = (char *) malloc (3);
+		if (!ptr) {
+			return NULL;
+		}
 		ptr[0] = '1';
 		ptr[1] = '0';
 		ptr[2] = '\0';
@@ -858,6 +865,9 @@ static char *get_num(SStateInfo *state)
 		}
 
 		ptr = (char *)malloc (16);
+		if (!ptr) {
+			return NULL;
+		}
 		sprintf (ptr, "%u", ret);
 		state->buff_for_parsing++;
 		state->amount_of_read_chars++;
@@ -867,7 +877,7 @@ static char *get_num(SStateInfo *state)
 }
 
 #define MODIFIER(modifier_str) { \
-	unsigned int i = 0; \
+	size_t i = 0; \
 	EDemanglerErr err = eDemanglerErrOK; \
 	char *tmp = NULL; \
 	STypeCodeStr tmp_str; \
@@ -979,8 +989,8 @@ DEF_STATE_ACTION(P)
 			char *call_conv = NULL;
 			char *ret_type = NULL;
 			char *arg = NULL;
-			unsigned int i = 0;
-			unsigned int is_abbr_type = 0;
+			size_t i = 0;
+			size_t is_abbr_type = 0;
 			EDemanglerErr err;
 
 			state->state = eTCStateEnd;
@@ -1164,7 +1174,7 @@ static void tc_state_end(SStateInfo *state, STypeCodeStr *type_code_str) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-static void init_state_struct(SStateInfo *state, char *buff_for_parsing) {
+static void init_state_struct(SStateInfo *state, const char *buff_for_parsing) {
 	state->state = eTCStateStart;
 	state->buff_for_parsing = buff_for_parsing;
 	state->amount_of_read_chars = 0;
@@ -1203,13 +1213,13 @@ static void free_type_code_str_struct(STypeCodeStr *type_code_str) {
 ///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
-static EDemanglerErr get_type_code_string(char *sym, unsigned int *amount_of_read_chars, char **str_type_code) {
+static EDemanglerErr get_type_code_string(const char *sym, size_t *amount_of_read_chars, char **str_type_code) {
 	EDemanglerErr err = eDemanglerErrOK;
-	char *tmp_sym = strdup(sym);
+	char *tmp_sym = strdup (sym);
 	STypeCodeStr type_code_str;
 	SStateInfo state;
 
-	if (!init_type_code_str_struct(&type_code_str)) {
+	if (!init_type_code_str_struct (&type_code_str)) {
 		err = eDemanglerErrMemoryAllocation;
 		goto get_type_code_string_err;
 	}
@@ -1243,11 +1253,11 @@ get_type_code_string_err:
 	return err;
 }
 
-static EDemanglerErr parse_data_type(char *sym, char **data_type, char **access_modifier,
-	int *len, bool *is_static, bool *is_implicit_this_pointer) {
+static EDemanglerErr parse_data_type(const char *sym, char **data_type, char **access_modifier,
+	size_t *len, bool *is_static, bool *is_implicit_this_pointer) {
 	EDemanglerErr err = eDemanglerErrOK;
-	int i;
-	char *curr_pos = sym;
+	size_t i;
+	const char *curr_pos = sym;
 	char *ptr64 = NULL;
 	char *storage_class = NULL;
 	char *tmp;
@@ -1288,9 +1298,9 @@ static EDemanglerErr parse_data_type(char *sym, char **data_type, char **access_
 		}
 
 #define SET_STORAGE_CLASS(letter, storage_class_str) \
-	case letter: {                                   \
-		storage_class = storage_class_str;           \
-		break;                                       \
+	case letter: { \
+		storage_class = storage_class_str; \
+		break; \
 	}
 		switch (*curr_pos++) {
 		SET_STORAGE_CLASS ('A', 0);
@@ -1324,12 +1334,15 @@ static EDemanglerErr parse_data_type(char *sym, char **data_type, char **access_
 	case '7': // compiler generated static
 		return eDemanglerErrUnsupportedMangling;
 
-#define SET_ACCESS_MODIFIER(letter, flag_set, modifier_str)   \
-	case letter: {                                            \
-		if (access_modifier) *access_modifier = modifier_str; \
-		if (flag_set) *flag_set = true;                       \
-		break;                                                \
-	}
+#define SET_ACCESS_MODIFIER(letter, flag_set, modifier_str) \
+	case letter: \
+		if (access_modifier) { \
+			*access_modifier = modifier_str; \
+		}\
+		if (flag_set) { \
+			*flag_set = true; \
+		} \
+		break; \
 	/* Functions */
 	SET_ACCESS_MODIFIER ('E', is_implicit_this_pointer, "private virtual");
 	SET_ACCESS_MODIFIER ('F', is_implicit_this_pointer, "private virtual");
@@ -1368,13 +1381,12 @@ static EDemanglerErr parse_data_type(char *sym, char **data_type, char **access_
 /// mangled name of a static class member object:
 /// <public name> ::= ?<name>@[<classname>@](1->inf)@2<type><storage class>
 ///////////////////////////////////////////////////////////////////////////////
-static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_name) {
+static EDemanglerErr parse_microsoft_mangled_name(const char *sym, char **demangled_name) {
 	STypeCodeStr type_code_str;
 	STypeCodeStr func_str;
 	EDemanglerErr err = eDemanglerErrOK;
 
-	unsigned int is_abbr_type = 0;
-
+	bool is_abbr_type = false;
 	bool is_implicit_this_pointer;
 	bool is_static;
 	char *memb_func_access_code = NULL;
@@ -1387,11 +1399,9 @@ static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_na
 	SStrInfo *str_arg = NULL;
 	char *access_modifier = NULL;
 	char *data_type = NULL;
+	size_t i = 0;
 
-	unsigned int i = 0;
-	unsigned int len = 0;
-
-	char *curr_pos = sym;
+	const char *curr_pos = sym;
 	char *tmp = NULL;
 
 	memset(&type_code_str, 0, sizeof(type_code_str));
@@ -1406,7 +1416,7 @@ static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_na
 		goto parse_microsoft_mangled_name_err;
 	}
 
-	len = get_namespace_and_name (curr_pos, &type_code_str, &i, false);
+	size_t len = get_namespace_and_name (curr_pos, &type_code_str, &i, false);
 	if (!len) {
 		err = eDemanglerErrUncorrectMangledSymbol;
 		goto parse_microsoft_mangled_name_err;
@@ -1526,7 +1536,7 @@ static EDemanglerErr parse_microsoft_mangled_name(char *sym, char **demangled_na
 						goto parse_microsoft_mangled_name_err;
 					}
 					i = 1;
-					is_abbr_type = 1;
+					is_abbr_type = true;
 				} else {
 					err = eDemanglerErrUncorrectMangledSymbol;
 					goto parse_microsoft_mangled_name_err;
@@ -1640,7 +1650,7 @@ parse_microsoft_mangled_name_err:
 	return err;
 }
 
-static EDemanglerErr parse_microsoft_rtti_mangled_name(char *sym, char **demangled_name) {
+static EDemanglerErr parse_microsoft_rtti_mangled_name(const char *sym, char **demangled_name) {
 	EDemanglerErr err = eDemanglerErrOK;
 	char *type = NULL;
 	if (!strncmp (sym, "AT", 2)) {
@@ -1660,7 +1670,7 @@ static EDemanglerErr parse_microsoft_rtti_mangled_name(char *sym, char **demangl
 		err = eDemanglerErrMemoryAllocation;
 		goto parse_microsoft_rtti_mangled_name_err;
 	}
-	int len = get_namespace_and_name (sym + 2, &type_code_str, NULL, true);
+	size_t len = get_namespace_and_name (sym + 2, &type_code_str, NULL, true);
 	if (!len) {
 		err = eDemanglerErrUncorrectMangledSymbol;
 		free (type_code_str.type_str);

--- a/test/db/formats/mangling/mangling
+++ b/test/db/formats/mangling/mangling
@@ -569,3 +569,11 @@ EXPECT=<<EOF
 public: bool __cdecl ABC<char, struct DEF>::operator bool(void)const __ptr64
 EOF
 RUN
+
+NAME=Template with ref to mangled symbol
+FILE=-
+CMDS="!rabin2 -D msvc .?AV?\$Template@UUnnamedStruct@@\$1?StructName1@@3UStructType1@@B\$1?StructName2@@3U3@B\$00\$0A@VChildClass@Class@@@Class@@"
+EXPECT=<<EOF
+class Class::Template<struct UnnamedStruct, &struct StructType1 const StructName1, &struct StructType1 const StructName2, 1, 0, class Class::ChildClass>
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

* Also fix not adding the template name as an abbreviation
* Add test


**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Tests pass

