### PR TITLE
Fix null deref in fuzzed xtr after 080bf49

### DIFF
--- a/libr/bin/p/bin_xtr_fatmach0.c
+++ b/libr/bin/p/bin_xtr_fatmach0.c
@@ -132,7 +132,9 @@ static RList * oneshotall_buffer(RBin *bin, RBuffer *b) {
 		int i = 0;
 		for (i = 1; data && i < narch; i++) {
 			data = oneshot_buffer (bin, b, i);
-			r_list_append (res, data);
+			if (data) {
+				r_list_append (res, data);
+			}
 		}
 		return res;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Now r_list_append accepts null data because of 080bf49
