### PR TITLE
Create new GitHub workflow for continuous build ##build

### DIFF
--- a/.github/upload.sh
+++ b/.github/upload.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set +x # Do not leak information
+
+# Exit immediately if one of the files given as arguments is not there
+# because we don't want to delete the existing release if we don't have
+# the new files that should be uploaded 
+for file in "$@"
+do
+    if [ ! -e "$file" ]
+    then echo "$file is missing, giving up." >&2; exit 1
+    fi
+done
+
+if [ $# -eq 0 ]; then
+    echo "No artifacts to use for release, giving up."
+    exit 0
+fi
+
+if command -v sha256sum >/dev/null 2>&1 ; then
+  shatool="sha256sum"
+elif command -v shasum >/dev/null 2>&1 ; then
+  shatool="shasum -a 256" # macOS fallback
+else
+  echo "Neither sha256sum nor shasum is available, cannot check hashes"
+fi
+
+# Do not use "latest" as it is reserved by GitHub
+RELEASE_NAME="continuous"
+RELEASE_TITLE="Continuous build"
+is_prerelease="true"
+
+REPO_SLUG="$GITHUB_REPOSITORY"
+if [ -z "$REPO_SLUG" ] ; then
+read -r -p "Repo Slug (GitHub and Travis CI username/reponame): " REPO_SLUG
+fi
+if [ -z "$GITHUB_TOKEN" ] ; then
+read -r -s -p "Token (https://github.com/settings/tokens): " GITHUB_TOKEN
+fi
+
+tag_url="https://api.github.com/repos/$REPO_SLUG/git/refs/tags/$RELEASE_NAME"
+tag_infos=$(curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" "${tag_url}")
+echo "tag_infos: $tag_infos"
+tag_sha=$(echo "$tag_infos" | grep '"sha":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+echo "tag_sha: $tag_sha"
+
+release_url="https://api.github.com/repos/$REPO_SLUG/releases/tags/$RELEASE_NAME"
+echo "Getting the release ID..."
+echo "release_url: $release_url"
+release_infos=$(curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" "${release_url}")
+echo "release_infos: $release_infos"
+release_id=$(echo "$release_infos" | grep "\"id\":" | head -n 1 | tr -s " " | cut -f 3 -d" " | cut -f 1 -d ",")
+echo "release ID: $release_id"
+upload_url=$(echo "$release_infos" | grep '"upload_url":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+echo "upload_url: $upload_url"
+release_url=$(echo "$release_infos" | grep '"url":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+echo "release_url: $release_url"
+target_commit_sha=$(echo "$release_infos" | grep '"target_commitish":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+echo "target_commit_sha: $target_commit_sha"
+
+if [ "$GITHUB_SHA" != "$target_commit_sha" ] ; then
+  echo "GITHUB_SHA != target_commit_sha, hence deleting $RELEASE_NAME..."
+
+  if [ ! -z "$release_id" ]; then
+    delete_url="https://api.github.com/repos/$REPO_SLUG/releases/$release_id"
+    echo "Delete the release..."
+    echo "delete_url: $delete_url"
+    curl -XDELETE \
+        --header "Authorization: token ${GITHUB_TOKEN}" \
+        "${delete_url}"
+  fi
+
+  # echo "Checking if release with the same name is still there..."
+  # echo "release_url: $release_url"
+  # curl -XGET --header "Authorization: token ${GITHUB_TOKEN}" \
+  #     "$release_url"
+
+  if [ "$RELEASE_NAME" == "continuous" ] ; then
+    # if this is a continuous build tag, then delete the old tag
+    # in preparation for the new release
+    echo "Delete the tag..."
+    delete_url="https://api.github.com/repos/$REPO_SLUG/git/refs/tags/$RELEASE_NAME"
+    echo "delete_url: $delete_url"
+    curl -XDELETE \
+        --header "Authorization: token ${GITHUB_TOKEN}" \
+        "${delete_url}"
+  fi
+
+  echo "Create release..."
+
+  if [ -z "$TRAVIS_BRANCH" ] ; then
+    TRAVIS_BRANCH="master"
+  fi
+
+  BODY="$UPLOADTOOL_BODY"
+
+  release_infos=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+       --data '{"tag_name": "'"$RELEASE_NAME"'","target_commitish": "'"$GITHUB_SHA"'","name": "'"$RELEASE_TITLE"'","body": "'"$BODY"'","draft": false,"prerelease": '$is_prerelease'}' "https://api.github.com/repos/$REPO_SLUG/releases")
+
+  echo "$release_infos"
+
+  unset upload_url
+  upload_url=$(echo "$release_infos" | grep '"upload_url":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+  echo "upload_url: $upload_url"
+
+  unset release_url
+  release_url=$(echo "$release_infos" | grep '"url":' | head -n 1 | cut -d '"' -f 4 | cut -d '{' -f 1)
+  echo "release_url: $release_url"
+
+fi
+
+if [ -z "$release_url" ] ; then
+	echo "Cannot figure out the release URL for $RELEASE_NAME"
+	exit 1
+fi
+
+echo "Upload binaries to the release..."
+
+for FILE in "$@" ; do
+  FULLNAME="${FILE}"
+  BASENAME="$(basename "${FILE}")"
+  curl -H "Authorization: token ${GITHUB_TOKEN}" \
+       -H "Accept: application/vnd.github.manifold-preview" \
+       -H "Content-Type: application/octet-stream" \
+       --data-binary @$FULLNAME \
+       "$upload_url?name=$BASENAME"
+  echo ""
+done
+
+$shatool "$@"
+
+echo "Publish the release..."
+release_infos=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+    --data '{"draft": false}' "$release_url")
+echo "$release_infos"

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,59 @@
+name: Continuous build
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-continuous-deb:
+    name: Continuous deb build
+    runs-on: ubuntu-latest
+    container: debian:buster
+    steps:
+    - name: Install tools
+      run: apt-get update && apt-get install --yes patch unzip git gcc make curl pkg-config xz-utils wget file python
+    - name: Checkout r2
+      run: |
+        git clone https://github.com/${{ github.repository }}
+        cd radare2
+        git fetch origin ${{ github.ref }}
+        git checkout -b local_branch FETCH_HEAD
+    - name: Extract r2 version
+      shell: bash
+      run: echo "##[set-output name=branch;]$(python sys/version.py)"
+      id: extract_version
+      working-directory: radare2
+    - name: Preparing the deb package
+      run: |
+        sys/debian.sh
+      working-directory: radare2
+    - name: Upload deb file
+      uses: actions/upload-artifact@v2
+      with:
+        name: radare2_${{ steps.extract_version.outputs.branch }}_amd64.deb
+        path: radare2/radare2_${{ steps.extract_version.outputs.branch }}_amd64.deb
+    - name: Upload -dev deb file
+      uses: actions/upload-artifact@v2
+      with:
+        name: radare2-dev_${{ steps.extract_version.outputs.branch }}_amd64.deb
+        path: radare2/radare2-dev_${{ steps.extract_version.outputs.branch }}_amd64.deb
+
+  create-release:
+    name: Create/Update pre-release Continuous build
+    runs-on: ubuntu-latest
+    needs: [build-continuous-deb]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Extract r2 version
+      shell: bash
+      run: echo "##[set-output name=branch;]$(python sys/version.py)"
+      id: extract_version
+    - uses: actions/download-artifact@v2
+    - name: Display structure of downloaded files
+      run: ls -R
+    - name: Upload files
+      shell: bash
+      run: .github/upload.sh ./radare2_${{ steps.extract_version.outputs.branch }}_amd64.deb/radare2_${{ steps.extract_version.outputs.branch }}_amd64.deb ./radare2-dev_${{ steps.extract_version.outputs.branch }}_amd64.deb/radare2-dev_${{ steps.extract_version.outputs.branch }}_amd64.deb
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPLOADTOOL_BODY: Continuous build ${{ github.sha }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,6 @@ jobs:
       arch: arm64
       dist: bionic
       env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1"
-    # Building *.deb package
-    - if: (branch = master AND type = push) OR head_branch =~ ^debian-*
-      os: linux
-      name: Debian
-      dist: stretch
-      env: COMPILER_NAME=gcc DEBPKG=1 CC=gcc CFLAGS="-O2 -DR2_ASSERT_STDOUT=1"
     # Run Fuzzing Sanity Test on every push
     # XXX its broken it complains about invalid key
     #- os: linux
@@ -122,12 +116,6 @@ before_install:
     elif [ "$TRAVIS_OS_NAME" != "osx" ] && [ "$NODOCKER" != "1" ]; then
       docker pull radareorg/r2-travis:latest || docker build -t radareorg/r2-travis:latest -f Dockerfile.travis .
     fi
-
-after_success:
-  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-  - compgen -G "r2js.zip" > /dev/null && bash upload.sh r2js.zip
-  - compgen -G "*.deb" > /dev/null && bash upload.sh *.deb
-  - compgen -G "/tmp/*.pkg" > /dev/null && bash upload.sh /tmp/*.pkg
 
 script:
   - export PR_NAME=$(echo $TRAVIS_PULL_REQUEST_SLUG | cut -d'/' -f1)


### PR DESCRIPTION
Avoid polluting the Releases page with a lot of "continuous build"
releases, which also break the "Latest release" shown by API/UI. This
job will upload as artifacts the .deb packages created on each
commit and create a pre-release "Continuous build" instead of an actual one.


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Closes #17598 