### PR TITLE
Fix multiple bugs in matching ##signatures

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -675,7 +675,7 @@ struct ctxSearchCB {
 	const char *prefix;
 };
 
-static bool apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad) {
+static void apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad) {
 	r_return_val_if_fail (core && fcn && it && it->name, false);
 	const char *name = it->realname? it->realname: it->name;
 	if (rad) {
@@ -684,24 +684,23 @@ static bool apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad)
 			r_cons_printf ("\"afn %s @ 0x%08" PFMT64x "\"\n", tmp, fcn->addr);
 			free (tmp);
 		}
-		return true;
+		return;
 	}
 	RFlagItem *flag = r_flag_get (core->flags, fcn->name);
 	if (!flag || !flag->space || strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS)) {
-		return false;
+		return;
 	}
 	r_flag_rename (core->flags, flag, name);
 	r_anal_function_rename (fcn, name);
 	if (core->anal->cb.on_fcn_rename) {
 		core->anal->cb.on_fcn_rename (core->anal, core->anal->user, fcn, name);
 	}
-	return true;
 }
 
-static bool apply_types(RCore *core, RAnalFunction *fcn,  RSignItem *it) {
+static void apply_types(RCore *core, RAnalFunction *fcn, RSignItem *it) {
 	r_return_val_if_fail (core && fcn && it && it->name, false);
 	if (!it->types) {
-		return false;
+		return;
 	}
 	const char *name = it->realname? it->realname: it->name;
 	RListIter *iter;
@@ -714,19 +713,18 @@ static bool apply_types(RCore *core, RAnalFunction *fcn,  RSignItem *it) {
 			eprintf ("Unexpected type: %s\n", type);
 			free (alltypes);
 			free (start);
-			return false;
+			return;
 		}
 		if (!(alltypes = r_str_appendf (alltypes, "%s\n", type))) {
 			free (alltypes);
 			free (start);
-			return false;
+			return;
 		}
 	}
 	r_str_remove_char (alltypes, '"');
 	r_anal_save_parsed_type (core->anal, alltypes);
 	free (start);
 	free (alltypes);
-	return true;
 }
 
 static void apply_flag(RCore *core, RSignItem *it, ut64 addr, int size, int count, const char *prefix, bool rad) {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -676,7 +676,7 @@ struct ctxSearchCB {
 };
 
 static void apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad) {
-	r_return_val_if_fail (core && fcn && it && it->name, false);
+	r_return_if_fail (core && fcn && it && it->name);
 	const char *name = it->realname? it->realname: it->name;
 	if (rad) {
 		char *tmp = r_name_filter2 (name);
@@ -698,7 +698,7 @@ static void apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad)
 }
 
 static void apply_types(RCore *core, RAnalFunction *fcn, RSignItem *it) {
-	r_return_val_if_fail (core && fcn && it && it->name, false);
+	r_return_if_fail (core && fcn && it && it->name);
 	if (!it->types) {
 		return;
 	}

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -722,7 +722,7 @@ static bool apply_types(RCore *core, RAnalFunction *fcn,  RSignItem *it) {
 			return false;
 		}
 	}
-	r_str_remove_char (alltypes, "\"");
+	r_str_remove_char (alltypes, '"');
 	r_anal_save_parsed_type (core->anal, alltypes);
 	free (start);
 	free (alltypes);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -734,7 +734,7 @@ static void apply_flag(RCore *core, RSignItem *it, ut64 addr, int size, int coun
 	char *name = r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count);
 	if (name) {
 		if (rad) {
-			char tmp = r_name_filter2 (name);
+			char *tmp = r_name_filter2 (name);
 			if (tmp) {
 				r_cons_printf ("f %s %d @ 0x%08" PFMT64x "\n", tmp, size, addr);
 				free (tmp);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -367,7 +367,7 @@ static bool addTypesZign(RCore *core, const char *name, const char *args0, int n
 
 	RList *types = r_list_newf ((RListFree)free);
 	for (i = 0; i < nargs; i++) {
-		r_list_append (types, r_str_new (r_str_word_get0 (args0, i)));
+		r_list_append (types, strdup (r_str_word_get0 (args0, i)));
 	}
 
 	bool retval = r_sign_add_types (core->anal, name, types);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -359,20 +359,20 @@ static bool addVarsZign(RCore *core, const char *name, const char *args0, int na
 }
 
 static bool addTypesZign(RCore *core, const char *name, const char *args0, int nargs) {
-       int i = 0;
-       if (nargs < 1) {
-               eprintf ("error: invalid syntax\n");
-               return false;
-       }
+	int i = 0;
+	if (nargs < 1) {
+		eprintf ("error: invalid syntax\n");
+		return false;
+	}
 
-       RList *types = r_list_newf ((RListFree) free);
-       for (i = 0; i < nargs; i++) {
-               r_list_append (types, r_str_new (r_str_word_get0 (args0, i)));
-       }
+	RList *types = r_list_newf ((RListFree)free);
+	for (i = 0; i < nargs; i++) {
+		r_list_append (types, r_str_new (r_str_word_get0 (args0, i)));
+	}
 
-       bool retval = r_sign_add_types (core->anal, name, types);
-       r_list_free (types);
-       return retval;
+	bool retval = r_sign_add_types (core->anal, name, types);
+	r_list_free (types);
+	return retval;
 }
 
 static bool addZign(RCore *core, const char *name, int type, const char *args0, int nargs) {
@@ -406,7 +406,7 @@ static bool addZign(RCore *core, const char *name, int type, const char *args0, 
 }
 
 static int cmdAdd(void *data, const char *input) {
-	RCore *core = (RCore *) data;
+	RCore *core = (RCore *)data;
 
 	switch (*input) {
 	case ' ':
@@ -675,112 +675,69 @@ struct ctxSearchCB {
 	const char *prefix;
 };
 
-static bool __fcnstrValidField(char *field, int i) {
-	char *arg_number = r_str_newf ("%d", i);
-	int is_ret = strcmp (field, "ret");
-	int is_args = strcmp (field, "args");
-	int is_arg = strcmp (field, "arg");
-	int is_arg_number = strcmp (field, arg_number);
-
-	free (arg_number);
-
-	return !(is_ret && is_args && is_arg && is_arg_number);
+static bool apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad) {
+	r_return_val_if_fail (core && fcn && it && it->name, false);
+	const char *name = it->realname? it->realname: it->name;
+	if (rad) {
+		char *tmp = r_name_filter2 (name);
+		if (tmp) {
+			r_cons_printf ("\"afn %s @ 0x%08" PFMT64x "\"\n", tmp, fcn->addr);
+			free (tmp);
+		}
+		return true;
+	}
+	RFlagItem *flag = r_flag_get (core->flags, fcn->name);
+	if (!flag || !flag->space || strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS)) {
+		return false;
+	}
+	r_flag_rename (core->flags, flag, name);
+	r_anal_function_rename (fcn, name);
+	if (core->anal->cb.on_fcn_rename) {
+		core->anal->cb.on_fcn_rename (core->anal, core->anal->user, fcn, name);
+	}
+	return true;
 }
 
-static char *__types_list_to_fcnstr(RList *types) {
-	char *type_kv = NULL, *k = NULL, *v = NULL;
-	char *field = NULL, *name = NULL, *rettype = NULL;
-	char *arg = NULL, *ret = NULL;
-	int nargs = 0, i = 0, j = 0;
-	RList *args = r_list_new ();
+static bool apply_types(RCore *core, RAnalFunction *fcn,  RSignItem *it) {
+	r_return_val_if_fail (core && fcn && it && it->name, false);
+	if (!it->types) {
+		return false;
+	}
+	const char *name = it->realname? it->realname: it->name;
 	RListIter *iter;
-
-	r_list_foreach (types, iter, type_kv) {
-		k = strtok (type_kv, "=");
-		v = strtok (NULL, "\0");
-
-		strtok (k, ".");
-		name = strtok (NULL, ".");
-		field = strtok (NULL, ".");
-
-		while (!__fcnstrValidField (field, i) && field) {
-			name = field;
-			field = strtok (NULL, ".");
+	char *type;
+	char *start = r_str_newf ("func.%s.", name);
+	size_t startlen = strlen (start);
+	char *alltypes = NULL;
+	r_list_foreach (it->types, iter, type) {
+		if (strncmp (start, type, startlen)) {
+			eprintf ("Unexpected type: %s\n", type);
+			free (alltypes);
+			free (start);
+			return false;
 		}
-
-		if (!strcmp (field, "args")) {
-			nargs = atoi (v);
-		} else if (!strcmp (field, "ret")) {
-			rettype = strdup (v);
-		} else {
-			if (i < nargs) {
-				arg = strdup (v);
-				for (j = 0; j < strlen (arg); j++) {
-					if (arg[j] == ',') {
-						arg[j] = ' ';
-					}
-				}
-				r_list_append (args, r_str_ndup (arg + 1,
-					strlen (arg) - 2));
-				free (arg);
-			}
-			i++;
+		if (!(alltypes = r_str_appendf (alltypes, "%s\n", type))) {
+			free (alltypes);
+			free (start);
+			return false;
 		}
 	}
-
-	if (!rettype) {
-		rettype = strdup ("void"); // workaround for "afs" bug
-	}
-
-	ret = r_str_newf ("%s %s(", rettype, name);
-
-	r_list_foreach (args, iter, arg) {
-		if (iter != r_list_tail (args)) {
-			ret = r_str_newf ("%s%s, ", ret, arg);
-		}
-	}
-
-	ret = (r_list_length (args) > 0)
-		? r_str_newf ("%s%s);", ret, (char *)r_list_get_top (args))
-		: r_str_newf ("%s);", ret);
-
-	r_list_free (args);
-	free (rettype);
-	return ret;
+	r_str_remove_char (alltypes, "\"");
+	r_anal_save_parsed_type (core->anal, alltypes);
+	free (start);
+	free (alltypes);
+	return true;
 }
 
-static void addFlag(RCore *core, RSignItem *it, ut64 addr, int size, int count, const char* prefix, bool rad) {
-	RAnalFunction *fcn = NULL;
+static void apply_flag(RCore *core, RSignItem *it, ut64 addr, int size, int count, const char *prefix, bool rad) {
 	const char *zign_prefix = r_config_get (core->config, "zign.prefix");
-	char *name = NULL;
-
-	if (it->types) {
-		char *fcnstr = __types_list_to_fcnstr (it->types);
-		char *fcnstr_copy = strdup (fcnstr);
-		fcn = r_anal_get_fcn_in (core->anal, it->addr, 0);
-		if (fcn) {
-			char *arg = strtok (fcnstr_copy, "(");
-			r_str_trim_tail (arg);
-			const char *fcn_name = strrchr (arg, ' ');
-			// __setFunctionName() ; cmd_anal.c:2535 ; Expand into R_API function
-			free (fcn->name);
-			fcn->name = strdup (fcn_name + 1);
-			if (core->anal->cb.on_fcn_rename) {
-				core->anal->cb.on_fcn_rename (core->anal, core->anal->user, fcn, fcn->name);
-			}
-			r_anal_str_to_fcn (core->anal, fcn, fcnstr);
-		}
-		if (fcnstr_copy) {
-			free (fcnstr_copy);
-		}
-		free (fcnstr);
-	}
-	name = r_name_filter2 (r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count));
+	char *name = r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count);
 	if (name) {
 		if (rad) {
-			r_cons_printf ("f %s %d @ 0x%08"PFMT64x"\n", name, size, addr);
-			if (it->realname) {
-				r_cons_printf ("\"afn %s @ 0x%08"PFMT64x"\"\n", it->realname, addr); // XXX command injection
+			char tmp = r_name_filter2 (name);
+			if (tmp) {
+				r_cons_printf ("f %s %d @ 0x%08" PFMT64x "\n", tmp, size, addr);
+				free (tmp);
 			}
 		} else {
 			r_flag_set (core->flags, name, addr, size);
@@ -790,17 +747,25 @@ static void addFlag(RCore *core, RSignItem *it, ut64 addr, int size, int count, 
 }
 
 static int searchHitCB(RSignItem *it, RSearchKeyword *kw, ut64 addr, void *user) {
-	struct ctxSearchCB *ctx = (struct ctxSearchCB *) user;
-	addFlag (ctx->core, it, addr, kw->keyword_length, kw->count, ctx->prefix, ctx->rad);
+	struct ctxSearchCB *ctx = (struct ctxSearchCB *)user;
+	apply_flag (ctx->core, it, addr, kw->keyword_length, kw->count, ctx->prefix, ctx->rad);
+	RAnalFunction *fcn = r_anal_get_fcn_in (ctx->core->anal, addr, 0);
+	// TODO: create fcn if it does not exist
+	if (fcn) {
+		apply_name (ctx->core, fcn, it, ctx->rad);
+		apply_types (ctx->core, fcn, it);
+	}
 	ctx->count++;
 	return 1;
 }
 
 static int fcnMatchCB(RSignItem *it, RAnalFunction *fcn, void *user) {
-	struct ctxSearchCB *ctx = (struct ctxSearchCB *) user;
+	struct ctxSearchCB *ctx = (struct ctxSearchCB *)user;
 	// TODO(nibble): use one counter per metric zign instead of ctx->count
 	ut64 sz = r_anal_function_realsize (fcn);
-	addFlag (ctx->core, it, fcn->addr, sz, ctx->count, ctx->prefix, ctx->rad);
+	apply_flag (ctx->core, it, fcn->addr, sz, ctx->count, ctx->prefix, ctx->rad);
+	apply_name (ctx->core, fcn, it, ctx->rad);
+	apply_types (ctx->core, fcn, it);
 	ctx->count++;
 	return 1;
 }
@@ -832,7 +797,7 @@ static bool searchRange(RCore *core, ut64 from, ut64 to, bool rad, struct ctxSea
 		}
 		(void)r_io_read_at (core->io, at, buf, rlen);
 		if (r_sign_search_update (core->anal, ss, &at, buf, rlen) == -1) {
-			eprintf ("search: update read error at 0x%08"PFMT64x"\n", at);
+			eprintf ("search: update read error at 0x%08" PFMT64x "\n", at);
 			retval = false;
 			break;
 		}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This refactors out multiple bugs in the matching of signatures. When a signature is matched, either `fcnMatchCB` or `searchHitCB` is called. This previous lead to `addFlag` where there were a few bugs. These bugs prevented the function from being renamed, having types applied and resulted in some leaks.

There is still a bug where types are not applied because the `RSignItem` passed to `searchHitCB` does not have a `types` member. This is due to a bug in `r_sign_item_dup` and is addressed in #17608.

**Test plan**
```
$ r2 static 
 -- Did you know that radare2 can decompile to assembly?
[0x00401c60]> s 0x0041dec0
[0x0041dec0]> af
[0x0041dec0]> afs
void fcn.0041dec0 (int64_t arg1);
[0x0041dec0]> zo ./out.sdb 
[0x0041dec0]> z*
zs *
za sym.__strdup b f30f1efa4154554889fd4883ec08e83d69f9ff4c8d60014c89e7e8d167f9ff4885c074154883c4084c89e24889ee4889c75d415ce98769f9ff5a31c05d415cc3:ffffffffffffffffffffffffffffff00000000ffffffffffffffff00000000ffffffff00ffffffffffffffffffffffffffffffffff00000000ffffffffffffff
za sym.__strdup g cc=2 nbbs=3 edges=3 ebbs=1 bbsum=64
za sym.__strdup o 0x0008fb30
za sym.__strdup v r110
za sym.__strdup t func.sym.__strdup.args=1 func.sym.__strdup.arg.0="uint32_t,AAAA"
za sym.__strdup h d8b82299783a827712112871062c12f183da2579815bbb644bec13b71fac5618
[0x0041dec0]> z.
[+] searching 0x0041dec0 - 0x0041dfc0
[+] searching function metrics
hits: 1
[0x0041dec0]> afs
void sym.__strdup (uint32_t AAAA);
[0x0041dec0]> 
```
Note: I use `z.` here b/c it is fast and easy to show. This PR alone won't make `z.` assign types correctly because of the other bug mentioned above. 
**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
