### PR TITLE
Remove r_sign_item_dup ##signatures

### DIFF
--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -135,7 +135,6 @@ R_API bool r_sign_save(RAnal *a, const char *file);
 R_API bool r_sign_anal_additem(RAnal *a, RSignItem *it);
 
 R_API RSignItem *r_sign_item_new(void);
-R_API RSignItem *r_sign_item_dup(RSignItem *it);
 R_API void r_sign_item_free(RSignItem *item);
 R_API void r_sign_graph_free(RSignGraph *graph);
 R_API void r_sign_bytes_free(RSignBytes *bytes);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The `r_sign_item_dup` appears to only be used in one place. This is to set up a list of `RSignItems` for `r_search`. The items don't need to be duplicated if they are never free'd. This should result in a performance boost. 

The `r_sign_item_dup` function also has a bug where it does not properly duplicate the `items` signature. So by refactoring this function out, the `searchHitCB` should now get the necessary information to apply the type information to a function.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See the command executed in #17607 PR.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
