### PR TITLE
Early support modern i/macOS ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -76,7 +76,8 @@ enum HeaderFileType {
 	MH_BUNDLE      = 0x8u,
 	MH_DYLIB_STUB  = 0x9u,
 	MH_DSYM        = 0xAu,
-	MH_KEXT_BUNDLE = 0xBu
+	MH_KEXT_BUNDLE = 0xBu,
+	MH_FILESET     = 0xCu
 };
 
 enum {
@@ -170,6 +171,7 @@ enum LoadCommandType {
 	LC_BUILD_VERSION        = 0x00000032u,
 	LC_DYLD_EXPORTS_TRIE    = 0x80000033u,
 	LC_DYLD_CHAINED_FIXUPS  = 0x80000034u,
+	LC_KEXT  = 0x80000035u, /* TODO: get the right name */
 /*
 Load command 9
        cmd LC_BUILD_VERSION
@@ -1437,6 +1439,17 @@ sizeof(struct x86_exception_state_t) / sizeof(uint32_t);
 #define EXPORT_SYMBOL_FLAGS_REEXPORT 0x08
 #define EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER 0x10
 
+struct dyld_chained_fixups_header
+{
+	uint32_t fixups_version;
+	uint32_t starts_offset;
+	uint32_t imports_offset;
+	uint32_t symbols_offset;
+	uint32_t imports_count;
+	uint32_t imports_format;
+	uint32_t symbols_format;
+};
+
 struct dyld_chained_starts_in_image {
 	uint32_t seg_count;
 };
@@ -1472,6 +1485,7 @@ enum {
 	DYLD_CHAINED_PTR_32          = 3,
 	DYLD_CHAINED_PTR_32_CACHE    = 4,
 	DYLD_CHAINED_PTR_32_FIRMWARE = 5,
+	DYLD_CHAINED_PTR_ARM64E_CACHE = 8, /* TODO: figure out the right name */
 };
 
 struct dyld_chained_ptr_arm64e_rebase {
@@ -1509,6 +1523,23 @@ struct dyld_chained_ptr_arm64e_auth_bind {
 		key : 2,
 		next : 11,
 		bind : 1, // == 1
+		auth : 1; // == 1
+};
+
+/* WARNING: this is guesswork based on trial and error */
+struct dyld_chained_ptr_arm64e_cache_rebase {
+	uint64_t target : 43,
+		high8 : 8,
+		next : 12,
+		auth : 1; // == 0
+};
+
+struct dyld_chained_ptr_arm64e_cache_auth_rebase {
+	uint64_t target : 32,
+		diversity : 16,
+		addrDiv : 1,
+		key : 2,
+		next : 12,
 		auth : 1; // == 1
 };
 

--- a/libr/bin/format/mach0/mach0_specs.h
+++ b/libr/bin/format/mach0/mach0_specs.h
@@ -322,6 +322,17 @@ typedef struct {
 	uint32_t nlistCount;
 } cache_locsym_entry_t;
 
+typedef struct {
+	uint64_t address;
+	uint64_t size;
+	uint64_t fileOffset;
+	uint64_t slideInfoOffset;
+	uint64_t slideInfoSize;
+	uint64_t unknown;
+	uint32_t maxProt;
+	uint32_t initProt;
+} cache_mapping_slide;
+
 #define DYLD_CACHE_SLIDE_PAGE_ATTRS 0xC000
 #define DYLD_CACHE_SLIDE_PAGE_ATTR_EXTRA 0x8000
 #define DYLD_CACHE_SLIDE_PAGE_ATTR_NO_REBASE 0x4000

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -12,6 +12,9 @@
 #define FAST_DATA_MASK 0xfffffffcUL
 #endif
 
+#define METHOD_LIST_FLAG_IS_SMALL 0x80000000
+#define METHOD_LIST_FLAG_IS_PREOPT 0x3
+
 #define RO_DATA_PTR(x) ((x) & FAST_DATA_MASK)
 
 struct MACH0_(SMethodList) {
@@ -532,7 +535,6 @@ error:
 ///////////////////////////////////////////////////////////////////////////////
 static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinClass *klass, bool is_static) {
 	struct MACH0_(SMethodList) ml;
-	struct MACH0_(SMethod) m;
 	mach0_ut r;
 	ut32 offset, left, i;
 	char *name = NULL;
@@ -576,8 +578,15 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 	ml.entsize = r_read_ble (&sml[0], bigendian, 32);
 	ml.count = r_read_ble (&sml[4], bigendian, 32);
 
+	bool is_small = (ml.entsize & METHOD_LIST_FLAG_IS_SMALL) != 0;
+	ut8 mlflags = ml.entsize & 0x3;
+
 	p += sizeof (struct MACH0_(SMethodList));
 	offset += sizeof (struct MACH0_(SMethodList));
+
+	size_t read_size = is_small ? 3 * sizeof (ut32) :
+			sizeof (struct MACH0_(SMethod));
+
 	for (i = 0; i < ml.count; i++) {
 		r = va2pa (p, &offset, &left, bf);
 		if (!r) {
@@ -589,29 +598,52 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 			// eprintf ("RBinClass allocation error\n");
 			return;
 		}
+		struct MACH0_(SMethod) m;
 		memset (&m, '\0', sizeof (struct MACH0_(SMethod)));
-		if (r + left < r || r + sizeof (struct MACH0_(SMethod)) < r) {
+		if (r + left < r || r + read_size < r) {
 			goto error;
 		}
 		if (r > bf->size) {
 			goto error;
 		}
-		if (r + sizeof (struct MACH0_(SMethod)) > bf->size) {
+		if (r + read_size > bf->size) {
 			goto error;
 		}
-		if (left < sizeof (struct MACH0_(SMethod))) {
+		if (left < read_size) {
 			if (r_buf_read_at (bf->buf, r, sm, left) != left) {
 				goto error;
 			}
 		} else {
-			len = r_buf_read_at (bf->buf, r, sm, sizeof (struct MACH0_(SMethod)));
-			if (len != sizeof (struct MACH0_(SMethod))) {
+			len = r_buf_read_at (bf->buf, r, sm, read_size);
+			if (len != read_size) {
 				goto error;
 			}
 		}
-		m.name = r_read_ble (&sm[0], bigendian, 8 * sizeof (mach0_ut));
-		m.types = r_read_ble (&sm[sizeof (mach0_ut)], bigendian, 8 * sizeof (mach0_ut));
-		m.imp = r_read_ble (&sm[2 * sizeof (mach0_ut)], bigendian, 8 * sizeof (mach0_ut));
+		if (!is_small) {
+			m.name = r_read_ble (&sm[0], bigendian, 8 * sizeof (mach0_ut));
+			m.types = r_read_ble (&sm[sizeof (mach0_ut)], bigendian, 8 * sizeof (mach0_ut));
+			m.imp = r_read_ble (&sm[2 * sizeof (mach0_ut)], bigendian, 8 * sizeof (mach0_ut));
+		} else {
+			st64 name_offset = (st32) r_read_ble (&sm[0], bigendian, 8 * sizeof (ut32));
+			mach0_ut name = p + name_offset;
+			if (mlflags != METHOD_LIST_FLAG_IS_PREOPT) {
+				r = va2pa (name, &offset, &left, bf);
+				if (!r) {
+					goto error;
+				}
+				ut8 tmp[8];
+				if (r_buf_read_at (bf->buf, r, tmp, sizeof (mach0_ut)) != sizeof (mach0_ut)) {
+					goto error;
+				}
+				m.name = r_read_ble (tmp, bigendian, 8 * sizeof (mach0_ut));
+			} else {
+				m.name = name;
+			}
+			st64 types_offset = (st32) r_read_ble (&sm[sizeof (ut32)], bigendian, 8 * sizeof (ut32));
+			m.types = p + types_offset + 4;
+			st64 imp_offset = (st32) r_read_ble (&sm[2 * sizeof (ut32)], bigendian, 8 * sizeof (ut32));
+			m.imp = p + imp_offset + 8;
+		}
 
 		r = va2pa (m.name, NULL, &left, bf);
 		if (r) {
@@ -684,8 +716,8 @@ static void get_method_list_t(mach0_ut p, RBinFile *bf, char *class_name, RBinCl
 		}
 		r_list_append (klass->methods, method);
 next:
-		p += sizeof (struct MACH0_(SMethod));
-		offset += sizeof (struct MACH0_(SMethod));
+		p += read_size;
+		offset += read_size;
 	}
 	return;
 error:

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -12,11 +12,11 @@ FILE=bins/mach0/objc-employee
 CMDS=icc*
 EXPECT=<<EOF
 typedef struct class_Employee {
-    uint64_t _padding; // 0
-    struct NSString* _username; // 8
-    struct NSString* _firstName; // 16
-    uint64_t _wideWord; // 24
-    short _shortWord; // 32
+    struct objc_class * isa; // 0
+    short _shortWord; // 8
+    struct NSString* _username; // 16
+    struct NSString* _firstName; // 24
+    uint64_t _wideWord; // 32
 } Employee;
 EOF
 RUN
@@ -42,16 +42,16 @@ fs classes
 "f method.Employee.shortWord = 0x100001cf0"
 "f method.Employee.wideWord = 0x100001d10"
 "f method.class.Employee.sayHello = 0x100001be0"
-"f field.Employee._padding = 0x100003328"
-"f field.Employee.Employee::(ivar)_username = 0x00003330"
-"f field.Employee.Employee::(ivar)_firstName = 0x00003338"
-"f field.Employee.Employee::(ivar)_wideWord = 0x00003340"
-"f field.Employee.Employee::(ivar)_shortWord = 0x00003328"
+"f field.Employee.isa = 0x00000000"
+"f field.Employee.Employee::(ivar)_shortWord = 0x100003328"
+"f field.Employee.Employee::(ivar)_username = 0x100003330"
+"f field.Employee.Employee::(ivar)_firstName = 0x100003338"
+"f field.Employee.Employee::(ivar)_wideWord = 0x100003340"
 "f field.Employee.Employee::(property)username = 0x00000000"
 "f field.Employee.Employee::(property)firstName = 0x00000000"
 "f field.Employee.Employee::(property)shortWord = 0x00000000"
 "f field.Employee.Employee::(property)wideWord = 0x00000000"
-"td struct Employee { uint64_t _padding; struct NSString* _username; struct NSString* _firstName; uint64_t _wideWord; short _shortWord; void* username; void* firstName; void* shortWord; void* wideWord;};"
+"td struct Employee { struct objc_class * isa; short _shortWord; struct NSString* _username; struct NSString* _firstName; uint64_t _wideWord; void* username; void* firstName; void* shortWord; void* wideWord;};"
 EOF
 RUN
 
@@ -60,11 +60,174 @@ FILE=bins/mach0/objc-employee
 CMDS=.ic*;tc
 EXPECT=<<EOF
 struct Employee {
-	uint64_t _padding;
+	struct objc_class *isa;
+	int16_t _shortWord;
 	struct NSString *_username;
 	struct NSString *_firstName;
 	uint64_t _wideWord;
+	void *username;
+	void *firstName;
+	void *shortWord;
+	void *wideWord;
+};
+struct NSString {
+	void *p0;
+	size_t p1;
+	char *str;
+	int len;
+};
+EOF
+RUN
+
+NAME=tc iOS14 arm64
+FILE=bins/mach0/objc-employee-ios14-arm64
+CMDS=.ic*;ts
+EXPECT=<<EOF
+Employee
+NSString
+EOF
+RUN
+
+NAME=tc2 iOS14 arm64
+FILE=bins/mach0/objc-employee-ios14-arm64
+CMDS=icc*
+EXPECT=<<EOF
+typedef struct class_Employee {
+    struct objc_class * isa; // 0
+    short _shortWord; // 8
+    struct NSString* _username; // 16
+    struct NSString* _firstName; // 24
+    uint64_t _wideWord; // 32
+} Employee;
+EOF
+RUN
+
+NAME=tc3 iOS14 arm64
+FILE=bins/mach0/objc-employee-ios14-arm64
+CMDS=ic*
+EXPECT=<<EOF
+fs classes
+"f class.Employee = 0x100007958"
+"f super.Employee.NSObject = 0"
+"f method.Employee.sayHello = 0x100007984"
+"f method.Employee.helloWorld = 0x1000079b0"
+"f method.Employee.p0 = 0x1000079dc"
+"f method.Employee.p1 = 0x1000079f8"
+"f method.Employee.p2 = 0x100007a14"
+"f method.Employee.p3 = 0x100007a30"
+"f method.Employee.base = 0x100007a4c"
+"f method.Employee.username = 0x100007a64"
+"f method.Employee.setUsername: = 0x100007a8c"
+"f method.Employee.firstName = 0x100007ac4"
+"f method.Employee.setFirstName: = 0x100007aec"
+"f method.Employee.shortWord = 0x100007b24"
+"f method.Employee.wideWord = 0x100007b44"
+"f method.Employee..cxx_destruct = 0x100007b60"
+"f method.class.Employee.sayHello = 0x100007958"
+"f field.Employee.isa = 0x00000000"
+"f field.Employee.Employee::(ivar)_shortWord = 0x10000c228"
+"f field.Employee.Employee::(ivar)_username = 0x10000c22c"
+"f field.Employee.Employee::(ivar)_firstName = 0x10000c230"
+"f field.Employee.Employee::(ivar)_wideWord = 0x10000c234"
+"f field.Employee.Employee::(property)username = 0x00000000"
+"f field.Employee.Employee::(property)firstName = 0x00000000"
+"f field.Employee.Employee::(property)shortWord = 0x00000000"
+"f field.Employee.Employee::(property)wideWord = 0x00000000"
+"td struct Employee { struct objc_class * isa; short _shortWord; struct NSString* _username; struct NSString* _firstName; uint64_t _wideWord; void* username; void* firstName; void* shortWord; void* wideWord;};"
+EOF
+RUN
+
+NAME=tc4 iOS14 arm64
+FILE=bins/mach0/objc-employee-ios14-arm64
+CMDS=.ic*;tc
+EXPECT=<<EOF
+struct Employee {
+	struct objc_class *isa;
 	int16_t _shortWord;
+	struct NSString *_username;
+	struct NSString *_firstName;
+	uint64_t _wideWord;
+	void *username;
+	void *firstName;
+	void *shortWord;
+	void *wideWord;
+};
+struct NSString {
+	void *p0;
+	size_t p1;
+	char *str;
+	int len;
+};
+EOF
+RUN
+
+NAME=tc iOS14 arm64e
+FILE=bins/mach0/objc-employee-ios14-arm64e
+CMDS=.ic*;ts
+EXPECT=<<EOF
+Employee
+NSString
+EOF
+RUN
+
+NAME=tc2 iOS14 arm64e
+FILE=bins/mach0/objc-employee-ios14-arm64e
+CMDS=icc*
+EXPECT=<<EOF
+typedef struct class_Employee {
+    struct objc_class * isa; // 0
+    short _shortWord; // 8
+    struct NSString* _username; // 16
+    struct NSString* _firstName; // 24
+    uint64_t _wideWord; // 32
+} Employee;
+EOF
+RUN
+
+NAME=tc3 iOS14 arm64e
+FILE=bins/mach0/objc-employee-ios14-arm64e
+CMDS=ic*
+EXPECT=<<EOF
+fs classes
+"f class.Employee = 0x1000079a8"
+"f method.Employee.sayHello = 0x1000079d8"
+"f method.Employee.helloWorld = 0x100007a08"
+"f method.Employee.p0 = 0x100007a38"
+"f method.Employee.p1 = 0x100007a54"
+"f method.Employee.p2 = 0x100007a70"
+"f method.Employee.p3 = 0x100007a8c"
+"f method.Employee.base = 0x100007aa8"
+"f method.Employee.username = 0x100007ac0"
+"f method.Employee.setUsername: = 0x100007ae8"
+"f method.Employee.firstName = 0x100007b24"
+"f method.Employee.setFirstName: = 0x100007b4c"
+"f method.Employee.shortWord = 0x100007b88"
+"f method.Employee.wideWord = 0x100007ba8"
+"f method.Employee..cxx_destruct = 0x100007bc4"
+"f method.class.Employee.sayHello = 0x1000079a8"
+"f field.Employee.isa = 0x00000000"
+"f field.Employee.Employee::(ivar)_shortWord = 0x10000c1d8"
+"f field.Employee.Employee::(ivar)_username = 0x10000c1dc"
+"f field.Employee.Employee::(ivar)_firstName = 0x10000c1e0"
+"f field.Employee.Employee::(ivar)_wideWord = 0x10000c1e4"
+"f field.Employee.Employee::(property)username = 0x00000000"
+"f field.Employee.Employee::(property)firstName = 0x00000000"
+"f field.Employee.Employee::(property)shortWord = 0x00000000"
+"f field.Employee.Employee::(property)wideWord = 0x00000000"
+"td struct Employee { struct objc_class * isa; short _shortWord; struct NSString* _username; struct NSString* _firstName; uint64_t _wideWord; void* username; void* firstName; void* shortWord; void* wideWord;};"
+EOF
+RUN
+
+NAME=tc4 iOS14 arm64e
+FILE=bins/mach0/objc-employee-ios14-arm64e
+CMDS=.ic*;tc
+EXPECT=<<EOF
+struct Employee {
+	struct objc_class *isa;
+	int16_t _shortWord;
+	struct NSString *_username;
+	struct NSString *_firstName;
+	uint64_t _wideWord;
 	void *username;
 	void *firstName;
 	void *shortWord;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This change adds early support for "modern" i/macOS, in particular:

- add support for macOS arm64 xnu kernel caches, the ones with the `MH_FILESET` format; this also adds preliminary support for parsing chained fixups, used in arm64e mach-O binaries
- add support for iOS 14.x dyld shared caches, with support for multiple rebase info and extra RW mappings
- add support for recent changes to Objective-C, in particular the "small" method lists, in which pointers to method's name, implementation and types are expressed as 32-bit relative offsets instead of absolute 64-bit pointers

I decided to do all the changes in a single PR because they're all inter-dependent.
