### PR TITLE
Implement ?== operator to compare strings ##shell

### DIFF
--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -127,7 +127,7 @@ static const char *help_msg_question[] = {
 	"?+", " [cmd]", "run cmd if $? > 0",
 	"?-", " [cmd]", "run cmd if $? < 0",
 	"?=", " eip-0x804800", "hex and dec result for this math expr",
-	"?==", "x86==`e asm.arch`", "strcmp two strings separated by ==",
+	"?==", "x86 `e asm.arch`", "strcmp two strings separated by ==",
 	"??", " [cmd]", "run cmd if $? != 0",
 	"??", "", "show value of operation",
 	"?_", " hudfile", "load hud menu with given file",
@@ -748,13 +748,12 @@ static int cmd_help(void *data, const char *input) {
 	case '=': // "?=" set num->value
 		if (input[1] == '=') { // ?==
 			char *s = strdup (input + 2);
-			char *e = strstr (s, "==");
+			char *e = strchr (s, ' ');
 			if (e) {
-				*e = 0;
-				e += 2;
+				*e++ = 0;
 				core->num->value = strcmp (s, e);
 			} else {
-				eprintf ("Missing == in expression\n");
+				eprintf ("Missing secondary word in expression to compare\n");
 			}
 			free (s);
 		} else {

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -127,6 +127,7 @@ static const char *help_msg_question[] = {
 	"?+", " [cmd]", "run cmd if $? > 0",
 	"?-", " [cmd]", "run cmd if $? < 0",
 	"?=", " eip-0x804800", "hex and dec result for this math expr",
+	"?==", "x86==`e asm.arch`", "strcmp two strings separated by ==",
 	"??", " [cmd]", "run cmd if $? != 0",
 	"??", "", "show value of operation",
 	"?_", " hudfile", "load hud menu with given file",
@@ -745,10 +746,23 @@ static int cmd_help(void *data, const char *input) {
 		core->num->value = n; // redundant
 		break;
 	case '=': // "?=" set num->value
-		if (input[1]) {
-			r_num_math (core->num, input+1);
+		if (input[1] == '=') { // ?==
+			char *s = strdup (input + 2);
+			char *e = strstr (s, "==");
+			if (e) {
+				*e = 0;
+				e += 2;
+				core->num->value = strcmp (s, e);
+			} else {
+				eprintf ("Missing == in expression\n");
+			}
+			free (s);
 		} else {
-			r_cons_printf ("0x%"PFMT64x"\n", core->num->value);
+			if (input[1]) { // ?=
+				r_num_math (core->num, input+1);
+			} else {
+				r_cons_printf ("0x%"PFMT64x"\n", core->num->value);
+			}
 		}
 		break;
 	case '+': // "?+"
@@ -777,9 +791,8 @@ static int cmd_help(void *data, const char *input) {
 				if (input[1] == '?') {
 					cmd_help_exclamation (core);
 					return 0;
-				} else {
-					return core->num->value = r_core_cmd (core, input+1, 0);
 				}
+				return core->num->value = r_core_cmd (core, input+1, 0);
 			}
 		} else {
 			r_cons_printf ("0x%"PFMT64x"\n", core->num->value);

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -127,7 +127,7 @@ static const char *help_msg_question[] = {
 	"?+", " [cmd]", "run cmd if $? > 0",
 	"?-", " [cmd]", "run cmd if $? < 0",
 	"?=", " eip-0x804800", "hex and dec result for this math expr",
-	"?==", " x86 `e asm.arch`", "strcmp two strings separated by ==",
+	"?==", " x86 `e asm.arch`", "strcmp two strings",
 	"??", " [cmd]", "run cmd if $? != 0",
 	"??", "", "show value of operation",
 	"?_", " hudfile", "load hud menu with given file",

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -127,7 +127,7 @@ static const char *help_msg_question[] = {
 	"?+", " [cmd]", "run cmd if $? > 0",
 	"?-", " [cmd]", "run cmd if $? < 0",
 	"?=", " eip-0x804800", "hex and dec result for this math expr",
-	"?==", "x86 `e asm.arch`", "strcmp two strings separated by ==",
+	"?==", " x86 `e asm.arch`", "strcmp two strings separated by ==",
 	"??", " [cmd]", "run cmd if $? != 0",
 	"??", "", "show value of operation",
 	"?_", " hudfile", "load hud menu with given file",
@@ -747,15 +747,19 @@ static int cmd_help(void *data, const char *input) {
 		break;
 	case '=': // "?=" set num->value
 		if (input[1] == '=') { // ?==
-			char *s = strdup (input + 2);
-			char *e = strchr (s, ' ');
-			if (e) {
-				*e++ = 0;
-				core->num->value = strcmp (s, e);
+			if (input[2] == ' ') {
+				char *s = strdup (input + 3);
+				char *e = strchr (s, ' ');
+				if (e) {
+					*e++ = 0;
+					core->num->value = strcmp (s, e);
+				} else {
+					eprintf ("Missing secondary word in expression to compare\n");
+				}
+				free (s);
 			} else {
-				eprintf ("Missing secondary word in expression to compare\n");
+				eprintf ("Usage: ?== str1 str2\n");
 			}
-			free (s);
 		} else {
 			if (input[1]) { // ?=
 				r_num_math (core->num, input+1);

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2370,7 +2370,7 @@ CMDS=<<EOF
 # Common parts
 #
 e asm.arch=x86
-?==x86==`e asm.arch`
+?==x86 `e asm.arch`
 ?!e asm.assembler=x86.as
 ??e asm.assembler=x86.nz
 e asm.bits=32

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2370,7 +2370,9 @@ CMDS=<<EOF
 # Common parts
 #
 e asm.arch=x86
-e asm.assembler=x86.as
+?==x86==`e asm.arch`
+?!e asm.assembler=x86.as
+??e asm.assembler=x86.nz
 e asm.bits=32
 wa bsf eax, ebx
 #

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2370,7 +2370,7 @@ CMDS=<<EOF
 # Common parts
 #
 e asm.arch=x86
-?==x86 `e asm.arch`
+?== x86 `e asm.arch`
 ?!e asm.assembler=x86.as
 ??e asm.assembler=x86.nz
 e asm.bits=32


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

needed because:

* theres no way to strcmp in r2
* x86.as tests are x86-specific

other solutions for the 2nd problem are:

- add ARCHONLY= in r2r
- do some r2 scripting magic
- make arch-specific tests in a separate directory
- install x86 toolchain on non-x86 testsuite platforms
- fallback to x86.nz inside the plugin

but also bear in mind that there are more failing x86.as tests that must be addressed, this PR is only fixing one

```
$ git grep x86.as test
test/db/esil/x86_32:e asm.assembler=x86.as
test/db/esil/x86_32:e asm.assembler=x86.as
test/db/tools/rasm2:CMDS=!rasm2 -s att -a x86.as -b 64 "test %rbx, %rax" 
test/db/tools/rasm2:CMDS=!rasm2 -s intel -a x86.as -b 64 "test rax, rbx" 
test/db/tools/rasm2:CMDS=!rasm2 -s att -a x86.as -b 64 "add \$33, %rbx"
test/db/tools/rasm2:CMDS=!rasm2 -s intel -a x86.as -b 64 "add rbx, 33" 
test/db/tools/rasm2:NAME=rasm2 -s att -a x86.as -b 64 movq %rdx, %rax
test/db/tools/rasm2:CMDS=!rasm2 -s att -a x86.as -b 64 "movq %rdx, %rax"
test/db/tools/rasm2:NAME=rasm2 x86.asm.32
```

**Test plan**

just see travis for arm64

**Closing issues**

there are some issues tracking XX on non-x86, lazy to find now, and this is just fixing some of them
