### PR TITLE
Fix heap oob read in bbget()

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -370,11 +370,11 @@ static RAnalBlock *bbget(RAnal *anal, ut64 addr, bool jumpmid) {
 					for (i = last_instr_idx; i >= 0; i--) {
 						const ut64 off = r_anal_bb_offset_inst (bb, i);
 						const ut64 at = bb->addr + off;
-						if (addr <= at) {
+						if (addr <= at || off >= bb->size) {
 							continue;
 						}
 						RAnalOp op;
-						int size = r_anal_op (anal, &op, at, buf + off, bb->size, R_ANAL_OP_MASK_BASIC);
+						int size = r_anal_op (anal, &op, at, buf + off, bb->size - off, R_ANAL_OP_MASK_BASIC);
 						if (size > 0 && op.delay) {
 							if (op.delay >= last_instr_idx - i) {
 								in_delay_slot = true;


### PR DESCRIPTION
Filling this template is moisten.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`buf` has size `bb->size` so `buf + off` has size `bb->size - off`.

**Test plan**

Run with asan:
`r2 -Aq test/bins/fuzzed/9255cead7e2cb22611359fec200090da`
The error can be seen here: https://github.com/radareorg/radare2/runs/1101358657