### PR TITLE
r2pm: Add new command that installs package without updating git

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -327,16 +327,20 @@ R2PM_GIT() {
 	cd "${R2PM_GITDIR}"
 	if [ -d "${DIR}" ]; then
 		cd "${DIR}"
-		git checkout master
-		git pull
+		if [ "$ACTION" = Install ]; then
+			git checkout master
+			git pull
+		fi
 	else
 		git clone --depth 1 --recursive "${URL}" "${DIR}" || R2PM_FAIL "Oops"
 		cd "${DIR}" || R2PM_FAIL "Oops"
 	fi
-	r2 -qv | grep -q git || { # r2 >= 4.5
-		git checkout "r2-${R2_VERSION}"
-		git pull
-	}
+	if [ "$ACTION" = Install ]; then
+		r2 -qv | grep -q git || { # r2 >= 4.5
+			git checkout "r2-${R2_VERSION}"
+			git pull
+		}
+	fi
 }
 
 R2PM_SVN() {
@@ -446,6 +450,21 @@ r2pm_install() {
 	fi
 }
 
+r2pm_install_noupd() {
+	FILE="$(pkgFilePath "$2")"
+	if [ -f "${FILE}" ]; then
+		NAME="$2"
+		ACTION=InstallNoUpdate
+		export PATH="${R2PM_HOMEBINDIR}:${PATH}"
+		. "${FILE}"
+		R2PM_INSTALL
+		R2PM_REGISTER
+	else
+		echo "Cannot find $2"
+		exit 1
+	fi
+}
+
 r2pm_uninstall() {
 	if [ -z "$2" ]; then
 		echo "Usage: r2pm -u [package]  # uninstall [package]"
@@ -474,6 +493,25 @@ export PYTHON_PATH="${R2PM_PYPATH}:${PYTHON_PATH}"
 case "$1" in
 -I|info)
 	R2PM_Info
+	;;
+-ti|test-install)
+	if [ -z "$2" ]; then
+		echo "Usage: r2pm -ti [package]  # install [package] (no update)"
+		exit 1
+	elif [ "$2" = "all" ]; then
+		for a in `cd ${R2PM_DBDIR} && ls` ; do
+			r2pm_install_noupd "$a"
+			if [ "$?" != 0 ]; then
+				printf "\033[31mERROR: Installation failed for $a\033[0m\n"
+			fi
+		done
+	else
+		A1="$1"
+		while [ -n "$2" ] ; do
+			r2pm_install_noupd $A1 "$2"
+			shift
+		done
+	fi
 	;;
 -i|install)
 	if [ -z "$2" ]; then
@@ -708,6 +746,7 @@ Usage: r2pm [init|update|cmd] [...]
 Commands:
  -I,info                     information about repository and installed packages
  -i,install <pkgname>        install or update package in your home (pkgname=all)
+ -ti,test-install <pkgname>  install package without updating git repo
  -gi,global-install <pkg>    install or update package system-wide
  -gu,global-uninstall <pkg>  uninstall pkg from systemdir
  -u,uninstall <pkgname>      r2pm -u baleful (-uu to force)


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)

Previously, r2pm seems to switch branches to master and git pull, causing havoc for CI trying to test changes.
With this change in radare2, the following pull request in radare2-extras enables a working GitHub CI:
https://github.com/radareorg/radare2-extras/pull/265
(However the WIP change needs to be dropped so it does not use my own radare2 repo for each clone, once the r2 PR is merged).

The proof can be seen here:
https://github.com/zamaudio/radare2-extras/runs/1106054548