### PR TITLE
Use PJ in `iAj` ##json

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -978,9 +978,8 @@ static void list_xtr_archs(RBin *bin, int mode) {
 				}
 				pj_end (pj);
 				pj_end (pj);
-				char *s = pj_drain (pj);
-				r_cons_println (s);
-				free (s);
+				bin->cb_printf ("%s\n", pj_string (pj));
+				pj_free (pj);
 				break;
 			}
 			default:

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -962,19 +962,27 @@ static void list_xtr_archs(RBin *bin, int mode) {
 			machine = xtr_data->metadata->machine;
 			bits = xtr_data->metadata->bits;
 			switch (mode) {
-			case 'q':
+			case 'q': // "iAq"
 				bin->cb_printf ("%s\n", arch);
 				break;
-			case 'j':
-				bin->cb_printf (
-					"%s{\"arch\":\"%s\",\"bits\":%d,"
-					"\"offset\":%" PFMT64d
-					",\"size\":%" PFMT64d
-					",\"machine\":\"%s\"}",
-					i++ ? "," : "", arch, bits,
-					xtr_data->offset, xtr_data->size,
-					machine);
+			case 'j': { // "iAj"
+				PJ * pj = pj_new ();
+				pj_o (pj);
+				pj_a (pj);
+				pj_ks (pj, "arch", arch);
+				pj_ki (pj, "bits", bits);
+				pj_ki (pj, "offset", xtr_data->offset);
+				pj_kn (pj, "size", xtr_data->size);
+				if (machine) {
+					pj_ks (pj, "machine", machine);
+				}
+				pj_end (pj);
+				pj_end (pj);
+				char *s = pj_drain (pj);
+				r_cons_println (s);
+				free (s);
 				break;
+			}
 			default:
 				bin->cb_printf ("%03i 0x%08" PFMT64x
 						" %" PFMT64d " %s_%i %s\n",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`iAj` currently works by constructing a JSON string and printing it. Here, I've reimplemented it using the PJ API. 

**Test plan**
Currently, `iAj` on one of the test binary prints:
`{"bins":[{"arch":"x86","bits":32,"offset":0,"size":5240,"machine":"Intel 80386"}]}`

Using this, `iAj` would print:
`{"bins":[{"arch":"x86","bits":32,"offset":0,"size":5240,"machine":"Intel 80386"}]}`

**Closing issues**

None
