### PR TITLE
Set RPATH/RUNPATH on r2 libs too if local

### DIFF
--- a/binr/blob/meson.build
+++ b/binr/blob/meson.build
@@ -5,7 +5,7 @@ executable('radare2', 'main.c',
     r_util_dep,
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )
 

--- a/binr/r2agent/meson.build
+++ b/binr/r2agent/meson.build
@@ -7,6 +7,6 @@ executable('r2agent', 'r2agent.c',
     r_cons_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/r2r/meson.build
+++ b/binr/r2r/meson.build
@@ -7,7 +7,7 @@ if get_option('enable_r2r')
       lrt,
     ],
     install: true,
-    install_rpath: rpath,
+    install_rpath: rpath_exe,
     implicit_include_directories: false
   )
 endif

--- a/binr/rabin2/meson.build
+++ b/binr/rabin2/meson.build
@@ -13,6 +13,6 @@ executable('rabin2', 'rabin2.c',
     r_bin_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/radare2/meson.build
+++ b/binr/radare2/meson.build
@@ -25,6 +25,6 @@ executable('radare2', 'radare2.c',
     r_magic_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/radiff2/meson.build
+++ b/binr/radiff2/meson.build
@@ -14,6 +14,6 @@ executable('radiff2', 'radiff2.c',
     r_config_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rafind2/meson.build
+++ b/binr/rafind2/meson.build
@@ -10,6 +10,6 @@ executable('rafind2', 'rafind2.c',
     r_cons_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/ragg2/meson.build
+++ b/binr/ragg2/meson.build
@@ -14,6 +14,6 @@ executable('ragg2', 'ragg2.c',
     r_crypto_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rahash2/meson.build
+++ b/binr/rahash2/meson.build
@@ -9,6 +9,6 @@ executable('rahash2', 'rahash2.c',
     r_socket_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rarun2/meson.build
+++ b/binr/rarun2/meson.build
@@ -6,6 +6,6 @@ executable('rarun2', 'rarun2.c',
     r_socket_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rasign2/meson.build
+++ b/binr/rasign2/meson.build
@@ -8,6 +8,6 @@ executable('rasign2', 'rasign2.c',
     r_bin_dep,
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rasm2/meson.build
+++ b/binr/rasm2/meson.build
@@ -10,6 +10,6 @@ executable('rasm2', 'rasm2.c',
     r_hash_dep
   ],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/binr/rax2/meson.build
+++ b/binr/rax2/meson.build
@@ -2,6 +2,6 @@ executable('rax2', 'rax2.c',
   include_directories: [platform_inc],
   dependencies: [r_util_dep, r_main_dep],
   install: true,
-  install_rpath: rpath,
+  install_rpath: rpath_exe,
   implicit_include_directories: false
 )

--- a/libr/anal/meson.build
+++ b/libr/anal/meson.build
@@ -184,6 +184,7 @@ r_anal = library('r_anal', r_anal_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/asm/meson.build
+++ b/libr/asm/meson.build
@@ -228,6 +228,7 @@ r_asm = library('r_asm', r_asm_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -154,6 +154,7 @@ r_bin = library('r_bin', r_bin_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/bp/meson.build
+++ b/libr/bp/meson.build
@@ -18,6 +18,7 @@ r_bp = library('r_bp', r_bp_sources,
   dependencies: [r_util_dep],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/config/meson.build
+++ b/libr/config/meson.build
@@ -11,6 +11,7 @@ r_config = library('r_config', r_config_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/cons/meson.build
+++ b/libr/cons/meson.build
@@ -27,6 +27,7 @@ r_cons = library('r_cons', r_cons_sources,
   dependencies: [r_util_dep],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/core/meson.build
+++ b/libr/core/meson.build
@@ -116,6 +116,7 @@ r_core = library('r_core', r_core_sources,
   dependencies: r_core_deps,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/crypto/meson.build
+++ b/libr/crypto/meson.build
@@ -27,6 +27,7 @@ r_crypto = library('r_crypto', r_crypto_sources,
   c_args: library_cflags,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/debug/meson.build
+++ b/libr/debug/meson.build
@@ -105,6 +105,7 @@ r_debug = library('r_debug', r_debug_sources,
   dependencies: r_debug_deps,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/egg/meson.build
+++ b/libr/egg/meson.build
@@ -25,6 +25,7 @@ r_egg = library('r_egg', r_egg_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/flag/meson.build
+++ b/libr/flag/meson.build
@@ -12,6 +12,7 @@ r_flag = library('r_flag', r_flag_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/fs/meson.build
+++ b/libr/fs/meson.build
@@ -35,6 +35,7 @@ r_fs = library('r_fs', r_fs_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/hash/meson.build
+++ b/libr/hash/meson.build
@@ -30,6 +30,7 @@ r_hash = library('r_hash', r_hash_sources,
   dependencies: dependencies,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -84,6 +84,7 @@ r_io = library('r_io', r_io_sources,
   c_args: library_cflags,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/lang/meson.build
+++ b/libr/lang/meson.build
@@ -19,6 +19,7 @@ r_lang = library('r_lang', r_lang_sources,
   dependencies: [r_util_dep, r_cons_dep],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/magic/meson.build
+++ b/libr/magic/meson.build
@@ -23,6 +23,7 @@ r_magic = library('r_magic', r_magic_sources,
   dependencies: r_magic_deps,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/main/meson.build
+++ b/libr/main/meson.build
@@ -45,6 +45,7 @@ r_main = library('r_main', r_main_sources,
   dependencies: r_main_deps,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -32,6 +32,7 @@ r_parse = library('r_parse', r_parse_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/reg/meson.build
+++ b/libr/reg/meson.build
@@ -13,6 +13,7 @@ r_reg = library('r_reg', r_reg_sources,
   dependencies: [r_util_dep],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/search/meson.build
+++ b/libr/search/meson.build
@@ -14,6 +14,7 @@ r_search = library('r_search', r_search_sources,
   dependencies: [r_util_dep],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/socket/meson.build
+++ b/libr/socket/meson.build
@@ -22,6 +22,7 @@ r_socket = library('r_socket', r_socket_sources,
   c_args: library_cflags,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/syscall/meson.build
+++ b/libr/syscall/meson.build
@@ -11,6 +11,7 @@ r_syscall = library('r_syscall', r_syscall_sources,
   ],
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -103,6 +103,7 @@ r_util = library('r_util', r_util_sources,
   dependencies: r_util_deps,
   install: true,
   implicit_include_directories: false,
+  install_rpath: rpath_lib,
   soversion: r2_libversion
 )
 

--- a/meson.build
+++ b/meson.build
@@ -404,13 +404,6 @@ libr_pc = configure_file(
   install_dir: join_paths(get_option('libdir'), 'pkgconfig')
 )
 
-# handle rpath
-rpath = ''
-if get_option('local') and get_option('default_library') == 'shared'
-  rpath = '$ORIGIN/../' + get_option('libdir')
-  add_project_link_arguments('-Wl,--disable-new-dtags', language: 'c')
-endif
-
 # handle zlib dependency
 zlib_dep = dependency('zlib', required: false)
 if not zlib_dep.found() or not get_option('use_sys_zlib')
@@ -613,6 +606,8 @@ subdir('libr/cons/d')
 subdir('libr/magic/d')
 subdir('libr/flag/d')
 subdir('libr/main')
+
+rpath = get_option('local') and get_option('default_library') == 'shared' ? '$ORIGIN/../' + get_option('libdir') : ''
 
 cli_option = get_option('cli')
 if cli_option.auto()

--- a/meson.build
+++ b/meson.build
@@ -607,7 +607,8 @@ subdir('libr/magic/d')
 subdir('libr/flag/d')
 subdir('libr/main')
 
-rpath = get_option('local') and get_option('default_library') == 'shared' ? '$ORIGIN/../' + get_option('libdir') : ''
+rpath_exe = \
+  get_option('local') and get_option('default_library') == 'shared' ? '$ORIGIN/../' + get_option('libdir') : ''
 
 cli_option = get_option('cli')
 if cli_option.auto()

--- a/meson.build
+++ b/meson.build
@@ -572,6 +572,13 @@ if get_option('b_sanitize').contains('undefined')
   pkgcfg_sanitize_libs += ' -lubsan'
 endif
 
+rpath_exe = ''
+rpath_lib = ''
+if get_option('local') and get_option('default_library') == 'shared'
+  rpath_exe = '$ORIGIN/../' + get_option('libdir')
+  rpath_lib = '$ORIGIN'
+endif
+
 subdir('libr/util')
 subdir('libr/socket')
 subdir('libr/hash')
@@ -606,9 +613,6 @@ subdir('libr/cons/d')
 subdir('libr/magic/d')
 subdir('libr/flag/d')
 subdir('libr/main')
-
-rpath_exe = \
-  get_option('local') and get_option('default_library') == 'shared' ? '$ORIGIN/../' + get_option('libdir') : ''
 
 cli_option = get_option('cli')
 if cli_option.auto()

--- a/meson.build
+++ b/meson.build
@@ -404,6 +404,13 @@ libr_pc = configure_file(
   install_dir: join_paths(get_option('libdir'), 'pkgconfig')
 )
 
+# handle rpath
+rpath = ''
+if get_option('local') and get_option('default_library') == 'shared'
+  rpath = '$ORIGIN/../' + get_option('libdir')
+  add_project_link_arguments('-Wl,--disable-new-dtags', language: 'c')
+endif
+
 # handle zlib dependency
 zlib_dep = dependency('zlib', required: false)
 if not zlib_dep.found() or not get_option('use_sys_zlib')
@@ -606,8 +613,6 @@ subdir('libr/cons/d')
 subdir('libr/magic/d')
 subdir('libr/flag/d')
 subdir('libr/main')
-
-rpath = get_option('local') and get_option('default_library') == 'shared' ? '$ORIGIN/../' + get_option('libdir') : ''
 
 cli_option = get_option('cli')
 if cli_option.auto()

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -246,6 +246,11 @@ def main():
           if not ldflags:
               ldflags = ''
           os.environ['LDFLAGS'] = ldflags + ' -fsanitize=' + args.sanitize
+    if args.local and args.shared:
+        ldflags = os.environ.get('LDFLAGS')
+        if not ldflags:
+            ldflags = ''
+        os.environ['LDFLAGS'] = ldflags + ' -Wl,--disable-new-dtags'
 
     # Check arguments
     if args.pull:

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -246,11 +246,6 @@ def main():
           if not ldflags:
               ldflags = ''
           os.environ['LDFLAGS'] = ldflags + ' -fsanitize=' + args.sanitize
-    if args.local and args.shared:
-        ldflags = os.environ.get('LDFLAGS')
-        if not ldflags:
-            ldflags = ''
-        os.environ['LDFLAGS'] = ldflags + ' -Wl,--disable-new-dtags'
 
     # Check arguments
     if args.pull:

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -88,8 +88,9 @@ if get_option('enable_tests')
         lrt,
       ],
       install: false,
-      install_rpath: rpath,
-      implicit_include_directories: false)
+      install_rpath: rpath_exe,
+      implicit_include_directories: false
+    )
     test(test, exe, workdir: join_paths(meson.current_source_dir(), '..'))
   endforeach
 endif


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

The linker of Ubuntu 20.04 (WSL2) by default sets RUNPATH instead of RPATH if requested, but its dynamic linker treats RUNPATH and RPATH differently resulting in the following error when running r2 with a meson local installation:

```
r2: error while loading shared libraries: libr_config.so.4.6.0-git: cannot open shared object file: No such file or directory
```

This pr fixes that by setting RPATH/RUNPATH on r2 libs too.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Under Ubuntu 20.04 (WSL2) in r2's git root dir:

```sh
rm -rf build
sys/meson.py --release --shared --local --prefix ~/bin/radare2-git --install
~/bin/radare2-git/bin/r2 -
```

The above error should not occur.

This pr was only tested under Ubuntu 20.04 (WSL2), but should be harmless for distribution linkers that set RPATH by default (e.g. Fedora).

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...

----

The renaming of `rpath` to `rpath_exe` was done using:

```sh
REGEX="install_rpath: rpath" bash -c 'git grep -l "$REGEX" | xargs -n 1 sed -i "s/$REGEX/&_exe/"'
```

The setting of `r2_lib` was done using:

```sh
REGEX="^\([[:blank:]]*\)\(soversion: r2_libversion\)" bash -c 'git grep -l "$REGEX" | xargs -n 1 sed -i "s/$REGEX/\1install_rpath: rpath_lib,\n\1\2/"'
```
