### PR TITLE
Use PJ in `oij` ##json

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1075,7 +1075,6 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		case 'j': {  // "oj"
 			PJ * pj = pj_new ();
 			pj_o (pj);
-			pj_a (pj);
 			pj_ks (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
 			pj_ki (pj, "fd", (int) f->fd);
 			pj_ks (pj, "uri", desc->uri);
@@ -1084,7 +1083,7 @@ R_API int r_core_file_list(RCore *core, int mode) {
 			pj_ki (pj, "size", (int) r_io_desc_size (desc));
 			pj_end (pj);
 			pj_end (pj);
-			r_cons_printf ("%s\n", pj_string (pj));
+			r_cons_println (pj_string (pj));
 			pj_free (pj);
 			break;
 		}

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1072,15 +1072,22 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		}
 		from = 0LL;
 		switch (mode) {
-		case 'j':
-			r_cons_printf ("{\"raised\":%s,\"fd\":%d,\"uri\":\"%s\",\"from\":%"
-				PFMT64d ",\"writable\":%s,\"size\":%d}%s",
-				r_str_bool (core->io->desc->fd == f->fd),
-				(int) f->fd, desc->uri, (ut64) from,
-				r_str_bool (desc->perm & R_PERM_W),
-				(int) r_io_desc_size (desc),
-				iter->n? ",": "");
+		case 'j': {  // "oj"
+			PJ * pj = pj_new ();
+			pj_o (pj);
+			pj_a (pj);
+			pj_ks (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
+			pj_ki (pj, "fd", (int) f->fd);
+			pj_ks (pj, "uri", desc->uri);
+			pj_kn (pj, "from", (ut64) from);
+			pj_ks (pj, "writable", r_str_bool (desc->perm & R_PERM_W));
+			pj_ki (pj, "size", (int) r_io_desc_size (desc));
+			pj_end (pj);
+			pj_end (pj);
+			r_cons_printf ("%s\n", pj_string (pj));
+			pj_free (pj);
 			break;
+		}
 		case '*':
 		case 'r':
 			// TODO: use a getter

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1061,9 +1061,6 @@ R_API int r_core_file_list(RCore *core, int mode) {
 	RListIter *it;
 	RBinFile *bf;
 	RListIter *iter;
-	if (mode == 'j') {
-		r_cons_printf ("[");
-	}
 	r_list_foreach (core->files, iter, f) {
 		desc = r_io_desc_get (core->io, f->fd);
 		if (!desc) {
@@ -1072,8 +1069,9 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		}
 		from = 0LL;
 		switch (mode) {
-		case 'j': {  // "oj"
+		case 'j': {  // "oij"
 			PJ * pj = pj_new ();
+			pj_a (pj);
 			pj_o (pj);
 			pj_ks (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
 			pj_ki (pj, "fd", (int) f->fd);
@@ -1149,9 +1147,6 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		break;
 		}
 		count++;
-	}
-	if (mode == 'j') {
-		r_cons_printf ("]\n");
 	}
 	return count;
 }

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1071,7 +1071,6 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		switch (mode) {
 		case 'j': {  // "oij"
 			PJ * pj = pj_new ();
-			pj_a (pj);
 			pj_o (pj);
 			pj_ks (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
 			pj_ki (pj, "fd", (int) f->fd);

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1061,6 +1061,8 @@ R_API int r_core_file_list(RCore *core, int mode) {
 	RListIter *it;
 	RBinFile *bf;
 	RListIter *iter;
+	PJ * pj = pj_new ();
+	pj_a (pj);
 	r_list_foreach (core->files, iter, f) {
 		desc = r_io_desc_get (core->io, f->fd);
 		if (!desc) {
@@ -1070,7 +1072,6 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		from = 0LL;
 		switch (mode) {
 		case 'j': {  // "oij"
-			PJ * pj = pj_new ();
 			if (!pj) {
 				free (desc);
 				break;

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1071,12 +1071,16 @@ R_API int r_core_file_list(RCore *core, int mode) {
 		switch (mode) {
 		case 'j': {  // "oij"
 			PJ * pj = pj_new ();
+			if (!pj) {
+				free (desc);
+				break;
+			}
 			pj_o (pj);
-			pj_ks (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
+			pj_kb (pj, "raised", r_str_bool (core->io->desc->fd == f->fd));
 			pj_ki (pj, "fd", (int) f->fd);
 			pj_ks (pj, "uri", desc->uri);
 			pj_kn (pj, "from", (ut64) from);
-			pj_ks (pj, "writable", r_str_bool (desc->perm & R_PERM_W));
+			pj_kb (pj, "writable", r_str_bool (desc->perm & R_PERM_W));
 			pj_ki (pj, "size", (int) r_io_desc_size (desc));
 			pj_end (pj);
 			pj_end (pj);

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -105,8 +105,7 @@ bins/elf/crackme0x00b
 EOF
 CMDS=oij
 EXPECT=<<EOF
-{"raised":true,"fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":true,"size":7656}
-{"raised":true,"fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":true,"size":7375}
+[{"raised":false,"fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":false,"size":7656},{"raised":true,"fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":false,"size":7375}]
 EOF
 RUN
 

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -105,8 +105,8 @@ bins/elf/crackme0x00b
 EOF
 CMDS=oij
 EXPECT=<<EOF
-[{"raised":"false","fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":"false","size":7656}]
-[{"raised":"true","fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":"false","size":7375}]
+{"raised":"false","fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":"false","size":7656}
+{"raised":"true","fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":"false","size":7375}
 EOF
 RUN
 

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -98,6 +98,18 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=oij-pj
+FILE=<<EOF
+bins/elf/crackme0x05
+bins/elf/crackme0x00b
+EOF
+CMDS=oij
+EXPECT=<<EOF
+[{"raised":"false","fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":"false","size":7656}]
+[{"raised":"true","fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":"false","size":7375}]
+EOF
+RUN
+
 NAME=o -
 FILE=malloc://1024
 CMDS=<<EOF

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -105,8 +105,8 @@ bins/elf/crackme0x00b
 EOF
 CMDS=oij
 EXPECT=<<EOF
-{"raised":"false","fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":"false","size":7656}
-{"raised":"true","fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":"false","size":7375}
+{"raised":true,"fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":true,"size":7656}
+{"raised":true,"fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":true,"size":7375}
 EOF
 RUN
 

--- a/test/db/json/json3
+++ b/test/db/json/json3
@@ -23,6 +23,7 @@ izj
 izzj
 Lsj
 oj
+oij
 oLj
 omj
 p-j


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`oij` currently works by constructing a JSON string and printing it. Here, I've reimplemented it using the PJ API.

**Test plan**
Using this, `oij` on one of the test binary prints:
`[{"raised":false,"fd":3,"uri":"bins/elf/crackme0x05","from":0,"writable":false,"size":7656},{"raised":true,"fd":5,"uri":"bins/elf/crackme0x00b","from":0,"writable":false,"size":7375}]`

**Closing issues**

None
