### PR TITLE
Move coverage testing to  meson-gcc-newshell-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
             build_system: meson
             compiler: gcc
             run_tests: true
-            meson_options: -Db_coverage=true
-            coverage: true
-            enabled: ${{ github.event_name != 'test__pull_request' }}
+            enabled: ${{ github.event_name != 'pull_request' }}
             timeout: 45
           - name: linux-acr-clang-build
             os: ubuntu-latest
@@ -59,9 +57,7 @@ jobs:
             os: ubuntu-latest
             build_system: meson
             compiler: gcc
-            meson_options: -Db_coverage=true
-            coverage: true
-            enabled: ${{ github.event_name == 'test__fpull_request' }}
+            enabled: ${{ github.event_name == 'pull_request' }}
             timeout: 45
           - name: linux-meson-gcc-newshell-tests
             os: ubuntu-latest
@@ -72,7 +68,7 @@ jobs:
             meson_options: -Db_coverage=true
             coverage: true
             enabled: true
-            timeout: 60
+            timeout: 50
           - name: macos-clang-tests
             os: macos-latest
             build_system: acr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             meson_options: -Db_coverage=true
             coverage: true
             enabled: true
-            timeout: 45
+            timeout: 60
           - name: macos-clang-tests
             os: macos-latest
             build_system: acr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
             build_system: meson
             compiler: gcc
             run_tests: true
-            enabled: ${{ github.event_name != 'pull_request' }}
+            meson_options: -Db_coverage=true
+            coverage: true
+            enabled: ${{ github.event_name != 'test__pull_request' }}
             timeout: 45
           - name: linux-acr-clang-build
             os: ubuntu-latest
@@ -59,7 +61,7 @@ jobs:
             compiler: gcc
             meson_options: -Db_coverage=true
             coverage: true
-            enabled: ${{ github.event_name == 'pull_request' }}
+            enabled: ${{ github.event_name == 'test__fpull_request' }}
             timeout: 45
           - name: linux-meson-gcc-newshell-tests
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
             os: ubuntu-latest
             build_system: meson
             compiler: gcc
-            meson_options: -Db_coverage=true
-            coverage: true
             run_tests: true
             enabled: ${{ github.event_name != 'pull_request' }}
             timeout: 45
@@ -69,6 +67,8 @@ jobs:
             compiler: gcc
             newshell: true
             run_tests: true
+            meson_options: -Db_coverage=true
+            coverage: true
             enabled: true
             timeout: 45
           - name: macos-clang-tests

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -869,6 +869,7 @@ static void __add_vars_sdb(RCore *core, RAnalFunction *fcn) {
 	r_anal_fcn_vars_cache_fini (&cache);
 }
 
+
 static bool cmd_anal_aaft(RCore *core) {
 	RListIter *it;
 	RAnalFunction *fcn;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -869,7 +869,6 @@ static void __add_vars_sdb(RCore *core, RAnalFunction *fcn) {
 	r_anal_fcn_vars_cache_fini (&cache);
 }
 
-
 static bool cmd_anal_aaft(RCore *core) {
 	RListIter *it;
 	RAnalFunction *fcn;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Previously coverage was measured on meson-gcc-tests which isn't run on pull requests. meson-gcc-newshell-tests should do more or less the same code except part of command parsing code.

**Test plan**

Wait for pull request tests to finish. Make sure test coverage for whole project not the diff is ~40% same as when master is being tested.

**Closing issues**
