### PR TITLE
Add R2PM_GITSKIP env var to skip git checkout master && git pull  ##r2pm

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -92,6 +92,9 @@ else
 	export DYLD_LIBRARY_PATH="${R2PM_HOMEPREFIX}/lib"
 fi
 
+# Anything defined here will cause master not to be checked out or pulled
+export R2PM_GITSKIP="${R2PM_GITSKIP}"
+
 # Global Vars
 TRAVIS_TYPE=XX
 TRAVIS_JOB=86948888
@@ -330,15 +333,19 @@ R2PM_GIT() {
 	cd "${R2PM_GITDIR}"
 	if [ -d "${DIR}" ]; then
 		cd "${DIR}"
-		git checkout master
-		git pull
+		if [ -z "${R2PM_GITSKIP}" ]; then
+			git checkout master
+			git pull
+		fi
 	else
 		git clone --depth 1 --recursive "${URL}" "${DIR}" || R2PM_FAIL "Oops"
 		cd "${DIR}" || R2PM_FAIL "Oops"
 	fi
 	r2 -qv | grep -q git || { # r2 >= 4.5
-		git checkout "r2-${R2_VERSION}"
-		git pull
+		if [ -z "${R2PM_GITSKIP}" ]; then
+			git checkout "r2-${R2_VERSION}"
+			git pull
+		fi
 	}
 }
 
@@ -737,6 +744,7 @@ Environment:
  R2PM_BINDIR=${R2PM_BINDIR}
  R2PM_DBDIR=${R2PM_DBDIR}
  R2PM_GITDIR=${R2PM_GITDIR}
+ R2PM_GITSKIP=${R2PM_GITSKIP}
 HELP
 	;;
 esac

--- a/man/r2pm.1
+++ b/man/r2pm.1
@@ -50,6 +50,10 @@ Install a package
 .Pp
   $ r2pm install yara3
 .Pp
+Install a test package (don't git pull on $R2PM_GITDIR/yara3)
+.Pp
+  $ R2PM_GITSKIP=1 r2pm install yara3
+.Pp
 Uninstall a package
 .Pp
   $ r2pm uninstall yara3


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
This change is needed for example for radare2-extras
to successfully install packages on a particular testing branch for CI.

Relates to https://github.com/radareorg/radare2-extras/pull/265 (please drop the WIP commit)