### PR TITLE
Fix #6467 - Add opn/opp/opr commands to priorize next/previous/rotate file ##io

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -835,17 +835,17 @@ rep:
 		}
 		break;
 	case 'V': // visual marks
-		switch(input[1]) {
+		switch (input[1]) {
 		case '-':
 			r_core_visual_mark_reset (core);
 			break;
 		case ' ':
 			{
-				const int n = atoi (input + 1);
-				if (n + ST8_MAX + 1 < UT8_MAX) {
+				int n = atoi (input + 1);
+				if (n + ASCII_MAX + 1 < UT8_MAX) {
 					const char *arg = strchr (input + 2, ' ');
 					ut64 addr = arg? r_num_math (core->num, arg): core->offset;
-					r_core_visual_mark_set (core, n + ST8_MAX + 1, addr);
+					r_core_visual_mark_set (core, n + ASCII_MAX + 1, addr);
 				}
 			}
 			break;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -957,7 +957,7 @@ static const char *radare_argv[] = {
 	"ob?", "ob", "ob*", "obo", "oba", "obf", "obj", "obr", "ob-", "ob-*",
 	"oc", "of", "oi", "oj", "oL", "om", "on",
 	"oo?", "oo", "oo+", "oob", "ood", "oom", "oon", "oon+", "oonn", "oonn+",
-	"op",  "ox",
+	"op",  "opn", "opp", "opr", "ox",
 	"p?", "p-", "p=", "p2", "p3", "p6?", "p6", "p6d", "p6e", "p8?", "p8", "p8f", "p8j",
 	"pa?", "paD", "pad", "pade", "pae", "pA",
 	"pb?", "pb", "pB", "pxb", "pB?",

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -199,38 +199,38 @@ typedef struct r_io_desc_cache_t {
 
 struct r_io_bind_t;
 
-typedef bool (*RIODescUse) (RIO *io, int fd);
-typedef RIODesc *(*RIODescGet) (RIO *io, int fd);
-typedef ut64 (*RIODescSize) (RIODesc *desc);
-typedef RIODesc *(*RIOOpen) (RIO *io, const char *uri, int flags, int mode);
-typedef RIODesc *(*RIOOpenAt) (RIO *io, const  char *uri, int flags, int mode, ut64 at);
-typedef bool (*RIOClose) (RIO *io, int fd);
-typedef bool (*RIOReadAt) (RIO *io, ut64 addr, ut8 *buf, int len);
-typedef bool (*RIOWriteAt) (RIO *io, ut64 addr, const ut8 *buf, int len);
-typedef char *(*RIOSystem) (RIO *io, const char* cmd);
-typedef int (*RIOFdOpen) (RIO *io, const char *uri, int flags, int mode);
-typedef bool (*RIOFdClose) (RIO *io, int fd);
-typedef ut64 (*RIOFdSeek) (RIO *io, int fd, ut64 addr, int whence);
-typedef ut64 (*RIOFdSize) (RIO *io, int fd);
-typedef bool (*RIOFdResize) (RIO *io, int fd, ut64 newsize);
-typedef ut64 (*RIOP2V) (RIO *io, ut64 pa);
-typedef ut64 (*RIOV2P) (RIO *io, ut64 va);
-typedef int (*RIOFdRead) (RIO *io, int fd, ut8 *buf, int len);
-typedef int (*RIOFdWrite) (RIO *io, int fd, const ut8 *buf, int len);
-typedef int (*RIOFdReadAt) (RIO *io, int fd, ut64 addr, ut8 *buf, int len);
-typedef int (*RIOFdWriteAt) (RIO *io, int fd, ut64 addr, const ut8 *buf, int len);
-typedef bool (*RIOFdIsDbg) (RIO *io, int fd);
-typedef const char *(*RIOFdGetName) (RIO *io, int fd);
-typedef RList *(*RIOFdGetMap) (RIO *io, int fd);
-typedef bool (*RIOFdRemap) (RIO *io, int fd, ut64 addr);
-typedef bool (*RIOIsValidOff) (RIO *io, ut64 addr, int hasperm);
-typedef RIOMap *(*RIOMapGet) (RIO *io, ut64 addr);
-typedef RIOMap *(*RIOMapGetPaddr) (RIO *io, ut64 paddr);
-typedef bool (*RIOAddrIsMapped) (RIO *io, ut64 addr);
-typedef RIOMap *(*RIOMapAdd) (RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
+typedef bool (*RIODescUse)(RIO *io, int fd);
+typedef RIODesc *(*RIODescGet)(RIO *io, int fd);
+typedef ut64(*RIODescSize)(RIODesc *desc);
+typedef RIODesc *(*RIOOpen)(RIO *io, const char *uri, int flags, int mode);
+typedef RIODesc *(*RIOOpenAt)(RIO *io, const  char *uri, int flags, int mode, ut64 at);
+typedef bool (*RIOClose)(RIO *io, int fd);
+typedef bool (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, int len);
+typedef bool (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int len);
+typedef char *(*RIOSystem)(RIO *io, const char* cmd);
+typedef int (*RIOFdOpen)(RIO *io, const char *uri, int flags, int mode);
+typedef bool (*RIOFdClose)(RIO *io, int fd);
+typedef ut64 (*RIOFdSeek)(RIO *io, int fd, ut64 addr, int whence);
+typedef ut64 (*RIOFdSize)(RIO *io, int fd);
+typedef bool (*RIOFdResize)(RIO *io, int fd, ut64 newsize);
+typedef ut64 (*RIOP2V)(RIO *io, ut64 pa);
+typedef ut64 (*RIOV2P)(RIO *io, ut64 va);
+typedef int (*RIOFdRead)(RIO *io, int fd, ut8 *buf, int len);
+typedef int (*RIOFdWrite)(RIO *io, int fd, const ut8 *buf, int len);
+typedef int (*RIOFdReadAt)(RIO *io, int fd, ut64 addr, ut8 *buf, int len);
+typedef int (*RIOFdWriteAt)(RIO *io, int fd, ut64 addr, const ut8 *buf, int len);
+typedef bool (*RIOFdIsDbg)(RIO *io, int fd);
+typedef const char *(*RIOFdGetName)(RIO *io, int fd);
+typedef RList *(*RIOFdGetMap)(RIO *io, int fd);
+typedef bool (*RIOFdRemap)(RIO *io, int fd, ut64 addr);
+typedef bool (*RIOIsValidOff)(RIO *io, ut64 addr, int hasperm);
+typedef RIOMap *(*RIOMapGet)(RIO *io, ut64 addr);
+typedef RIOMap *(*RIOMapGetPaddr)(RIO *io, ut64 paddr);
+typedef bool (*RIOAddrIsMapped)(RIO *io, ut64 addr);
+typedef RIOMap *(*RIOMapAdd)(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 #if HAVE_PTRACE
-typedef long (*RIOPtraceFn) (RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);
-typedef void *(*RIOPtraceFuncFn) (RIO *io, void *(*func)(void *), void *user);
+typedef long (*RIOPtraceFn)(RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);
+typedef void *(*RIOPtraceFuncFn)(RIO *io, void *(*func)(void *), void *user);
 #endif
 
 typedef struct r_io_bind_t {
@@ -273,13 +273,13 @@ typedef struct r_io_bind_t {
 
 //map.c
 R_API RIOMap *r_io_map_new(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
-R_API void r_io_map_init (RIO *io);
-R_API bool r_io_map_remap (RIO *io, ut32 id, ut64 addr);
-R_API bool r_io_map_remap_fd (RIO *io, int fd, ut64 addr);
+R_API void r_io_map_init(RIO *io);
+R_API bool r_io_map_remap(RIO *io, ut32 id, ut64 addr);
+R_API bool r_io_map_remap_fd(RIO *io, int fd, ut64 addr);
 R_API ut64 r_io_map_location(RIO *io, ut64 size);
-R_API bool r_io_map_exists (RIO *io, RIOMap *map);
-R_API bool r_io_map_exists_for_id (RIO *io, ut32 id);
-R_API RIOMap *r_io_map_resolve (RIO *io, ut32 id);
+R_API bool r_io_map_exists(RIO *io, RIOMap *map);
+R_API bool r_io_map_exists_for_id(RIO *io, ut32 id);
+R_API RIOMap *r_io_map_resolve(RIO *io, ut32 id);
 R_API RIOMap *r_io_map_add(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
 // same as r_io_map_add but used when many maps need to be added. Call r_io_update when all maps have been added.
 R_API RIOMap *r_io_map_add_batch(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
@@ -292,13 +292,13 @@ R_API void r_io_map_reset(RIO* io);
 R_API bool r_io_map_del(RIO *io, ut32 id);
 R_API bool r_io_map_del_for_fd(RIO *io, int fd);
 R_API bool r_io_map_depriorize(RIO* io, ut32 id);
-R_API bool r_io_map_priorize (RIO *io, ut32 id);
-R_API bool r_io_map_priorize_for_fd (RIO *io, int fd);
-R_API void r_io_map_cleanup (RIO *io);
-R_API void r_io_map_fini (RIO *io);
-R_API bool r_io_map_is_in_range (RIOMap *map, ut64 from, ut64 to);
-R_API void r_io_map_set_name (RIOMap *map, const char *name);
-R_API void r_io_map_del_name (RIOMap *map);
+R_API bool r_io_map_priorize(RIO *io, ut32 id);
+R_API bool r_io_map_priorize_for_fd(RIO *io, int fd);
+R_API void r_io_map_cleanup(RIO *io);
+R_API void r_io_map_fini(RIO *io);
+R_API bool r_io_map_is_in_range(RIOMap *map, ut64 from, ut64 to);
+R_API void r_io_map_set_name(RIOMap *map, const char *name);
+R_API void r_io_map_del_name(RIOMap *map);
 R_API RList* r_io_map_get_for_fd(RIO *io, int fd);
 R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize);
 
@@ -312,37 +312,37 @@ R_API ut64 r_io_p2v(RIO *io, ut64 pa);
 R_API ut64 r_io_v2p(RIO *io, ut64 va);
 
 //io.c
-R_API RIO *r_io_new (void);
-R_API RIO *r_io_init (RIO *io);
-R_API RIODesc *r_io_open_nomap (RIO *io, const char *uri, int flags, int mode);		//should return int
-R_API RIODesc *r_io_open (RIO *io, const char *uri, int flags, int mode);
-R_API RIODesc *r_io_open_at (RIO *io, const char *uri, int flags, int mode, ut64 at);
-R_API RList *r_io_open_many (RIO *io, const char *uri, int flags, int mode);
-R_API RIODesc* r_io_open_buffer (RIO *io, RBuffer *b, int flags, int mode);
-R_API bool r_io_close (RIO *io);
-R_API bool r_io_reopen (RIO *io, int fd, int flags, int mode);
-R_API int r_io_close_all (RIO *io);
-R_API int r_io_pread_at (RIO *io, ut64 paddr, ut8 *buf, int len);
-R_API int r_io_pwrite_at (RIO *io, ut64 paddr, const ut8 *buf, int len);
+R_API RIO *r_io_new(void);
+R_API RIO *r_io_init(RIO *io);
+R_API RIODesc *r_io_open_nomap(RIO *io, const char *uri, int flags, int mode);		//should return int
+R_API RIODesc *r_io_open(RIO *io, const char *uri, int flags, int mode);
+R_API RIODesc *r_io_open_at(RIO *io, const char *uri, int flags, int mode, ut64 at);
+R_API RList *r_io_open_many(RIO *io, const char *uri, int flags, int mode);
+R_API RIODesc* r_io_open_buffer(RIO *io, RBuffer *b, int flags, int mode);
+R_API bool r_io_close(RIO *io);
+R_API bool r_io_reopen(RIO *io, int fd, int flags, int mode);
+R_API int r_io_close_all(RIO *io);
+R_API int r_io_pread_at(RIO *io, ut64 paddr, ut8 *buf, int len);
+R_API int r_io_pwrite_at(RIO *io, ut64 paddr, const ut8 *buf, int len);
 R_API bool r_io_vread_at_mapped(RIO* io, ut64 vaddr, ut8* buf, int len);
-R_API bool r_io_read_at (RIO *io, ut64 addr, ut8 *buf, int len);
+R_API bool r_io_read_at(RIO *io, ut64 addr, ut8 *buf, int len);
 R_API bool r_io_read_at_mapped(RIO *io, ut64 addr, ut8 *buf, int len);
-R_API int r_io_nread_at (RIO *io, ut64 addr, ut8 *buf, int len);
+R_API int r_io_nread_at(RIO *io, ut64 addr, ut8 *buf, int len);
 R_API void r_io_alprint(RList *ls);
-R_API bool r_io_write_at (RIO *io, ut64 addr, const ut8 *buf, int len);
-R_API bool r_io_read (RIO *io, ut8 *buf, int len);
-R_API bool r_io_write (RIO *io, ut8 *buf, int len);
-R_API ut64 r_io_size (RIO *io);
-R_API bool r_io_is_listener (RIO *io);
-R_API char *r_io_system (RIO *io, const char* cmd);
-R_API bool r_io_resize (RIO *io, ut64 newsize);
-R_API int r_io_extend_at (RIO *io, ut64 addr, ut64 size);
-R_API bool r_io_set_write_mask (RIO *io, const ut8 *mask, int len);
+R_API bool r_io_write_at(RIO *io, ut64 addr, const ut8 *buf, int len);
+R_API bool r_io_read(RIO *io, ut8 *buf, int len);
+R_API bool r_io_write(RIO *io, ut8 *buf, int len);
+R_API ut64 r_io_size(RIO *io);
+R_API bool r_io_is_listener(RIO *io);
+R_API char *r_io_system(RIO *io, const char* cmd);
+R_API bool r_io_resize(RIO *io, ut64 newsize);
+R_API int r_io_extend_at(RIO *io, ut64 addr, ut64 size);
+R_API bool r_io_set_write_mask(RIO *io, const ut8 *mask, int len);
 R_API void r_io_bind(RIO *io, RIOBind *bnd);
-R_API bool r_io_shift (RIO *io, ut64 start, ut64 end, st64 move);
-R_API ut64 r_io_seek (RIO *io, ut64 offset, int whence);
-R_API int r_io_fini (RIO *io);
-R_API void r_io_free (RIO *io);
+R_API bool r_io_shift(RIO *io, ut64 start, ut64 end, st64 move);
+R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence);
+R_API int r_io_fini(RIO *io);
+R_API void r_io_free(RIO *io);
 #define r_io_bind_init(x) memset(&x,0,sizeof(x))
 
 R_API bool r_io_plugin_init(RIO *io);
@@ -383,39 +383,43 @@ R_API void r_io_wundo_set_all(RIO *io, int set);
 R_API int r_io_wundo_set(RIO *io, int n, int set);
 
 //desc.c
-R_API RIODesc *r_io_desc_new (RIO *io, RIOPlugin *plugin, const char *uri, int flags, int mode, void *data);
-R_API RIODesc *r_io_desc_open (RIO *io, const char *uri, int flags, int mode);
-R_API RIODesc *r_io_desc_open_plugin (RIO *io, RIOPlugin *plugin, const char *uri, int flags, int mode);
-R_API bool r_io_desc_close (RIODesc *desc);
-R_API int r_io_desc_read (RIODesc *desc, ut8 *buf, int count);
-R_API int r_io_desc_write (RIODesc *desc, const ut8 *buf, int count);
-R_API void r_io_desc_free (RIODesc *desc);
-R_API bool r_io_desc_add (RIO *io, RIODesc *desc);
-R_API bool r_io_desc_del (RIO *io, int fd);
-R_API RIODesc *r_io_desc_get (RIO *io, int fd);
-R_API ut64 r_io_desc_seek (RIODesc *desc, ut64 offset, int whence);
-R_API bool r_io_desc_resize (RIODesc *desc, ut64 newsize);
-R_API ut64 r_io_desc_size (RIODesc *desc);
-R_API bool r_io_desc_is_blockdevice (RIODesc *desc);
-R_API bool r_io_desc_is_chardevice (RIODesc *desc);
-R_API bool r_io_desc_exchange (RIO *io, int fd, int fdx);	//this should get 2 descs
-R_API bool r_io_desc_is_dbg (RIODesc *desc);
-R_API int r_io_desc_get_pid (RIODesc *desc);
-R_API int r_io_desc_get_tid (RIODesc *desc);
-R_API bool r_io_desc_get_base (RIODesc *desc, ut64 *base);
-R_API int r_io_desc_read_at (RIODesc *desc, ut64 addr, ut8 *buf, int len);
-R_API int r_io_desc_write_at (RIODesc *desc, ut64 addr, const ut8 *buf, int len);
+R_API RIODesc *r_io_desc_new(RIO *io, RIOPlugin *plugin, const char *uri, int flags, int mode, void *data);
+R_API RIODesc *r_io_desc_open(RIO *io, const char *uri, int flags, int mode);
+R_API RIODesc *r_io_desc_open_plugin(RIO *io, RIOPlugin *plugin, const char *uri, int flags, int mode);
+R_API bool r_io_desc_close(RIODesc *desc);
+R_API int r_io_desc_read(RIODesc *desc, ut8 *buf, int count);
+R_API int r_io_desc_write(RIODesc *desc, const ut8 *buf, int count);
+R_API void r_io_desc_free(RIODesc *desc);
+R_API bool r_io_desc_add(RIO *io, RIODesc *desc);
+R_API bool r_io_desc_del(RIO *io, int fd);
+R_API RIODesc *r_io_desc_get(RIO *io, int fd);
+R_API RIODesc *r_io_desc_get_next(RIO *io, RIODesc *desc);
+R_API RIODesc *r_io_desc_get_prev(RIO *io, RIODesc *desc);
+R_API RIODesc *r_io_desc_get_highest(RIO *io);
+R_API RIODesc *r_io_desc_get_lowest(RIO *io);
+R_API ut64 r_io_desc_seek(RIODesc *desc, ut64 offset, int whence);
+R_API bool r_io_desc_resize(RIODesc *desc, ut64 newsize);
+R_API ut64 r_io_desc_size(RIODesc *desc);
+R_API bool r_io_desc_is_blockdevice(RIODesc *desc);
+R_API bool r_io_desc_is_chardevice(RIODesc *desc);
+R_API bool r_io_desc_exchange(RIO *io, int fd, int fdx);	//this should get 2 descs
+R_API bool r_io_desc_is_dbg(RIODesc *desc);
+R_API int r_io_desc_get_pid(RIODesc *desc);
+R_API int r_io_desc_get_tid(RIODesc *desc);
+R_API bool r_io_desc_get_base(RIODesc *desc, ut64 *base);
+R_API int r_io_desc_read_at(RIODesc *desc, ut64 addr, ut8 *buf, int len);
+R_API int r_io_desc_write_at(RIODesc *desc, ut64 addr, const ut8 *buf, int len);
 
 /* lifecycle */
-R_IPI bool r_io_desc_init (RIO *io);
-R_IPI bool r_io_desc_fini (RIO *io);
+R_IPI bool r_io_desc_init(RIO *io);
+R_IPI bool r_io_desc_fini(RIO *io);
 
 /* io/cache.c */
 R_API int r_io_cache_invalidate(RIO *io, ut64 from, ut64 to);
 R_API bool r_io_cache_at(RIO *io, ut64 addr);
 R_API void r_io_cache_commit(RIO *io, ut64 from, ut64 to);
 R_API void r_io_cache_init(RIO *io);
-R_API void r_io_cache_fini (RIO *io);
+R_API void r_io_cache_fini(RIO *io);
 R_API int r_io_cache_list(RIO *io, int rad);
 R_API void r_io_cache_reset(RIO *io, int set);
 R_API bool r_io_cache_write(RIO *io, ut64 addr, const ut8 *buf, int len);
@@ -433,39 +437,43 @@ R_API RList *r_io_desc_cache_list(RIODesc *desc);
 R_API int r_io_desc_extend(RIODesc *desc, ut64 size);
 
 /* io/buffer.c */
-R_API int r_io_buffer_read (RIO* io, ut64 addr, ut8* buf, int len);
-R_API int r_io_buffer_load (RIO* io, ut64 addr, int len);
-R_API void r_io_buffer_close (RIO* io);
+R_API int r_io_buffer_read(RIO* io, ut64 addr, ut8* buf, int len);
+R_API int r_io_buffer_load(RIO* io, ut64 addr, int len);
+R_API void r_io_buffer_close(RIO* io);
 
 /* io/fd.c */
-R_API int r_io_fd_open (RIO *io, const char *uri, int flags, int mode);
-R_API bool r_io_fd_close (RIO *io, int fd);
-R_API int r_io_fd_read (RIO *io, int fd, ut8 *buf, int len);
-R_API int r_io_fd_write (RIO *io, int fd, const ut8 *buf, int len);
-R_API ut64 r_io_fd_seek (RIO *io, int fd, ut64 addr, int whence);
-R_API ut64 r_io_fd_size (RIO *io, int fd);
-R_API bool r_io_fd_resize (RIO *io, int fd, ut64 newsize);
-R_API bool r_io_fd_is_blockdevice (RIO *io, int fd);
-R_API bool r_io_fd_is_chardevice (RIO *io, int fd);
-R_API int r_io_fd_read_at (RIO *io, int fd, ut64 addr, ut8 *buf, int len);
-R_API int r_io_fd_write_at (RIO *io, int fd, ut64 addr, const ut8 *buf, int len);
-R_API bool r_io_fd_is_dbg (RIO *io, int fd);
-R_API int r_io_fd_get_pid (RIO *io, int fd);
-R_API int r_io_fd_get_tid (RIO *io, int fd);
-R_API bool r_io_fd_get_base (RIO *io, int fd, ut64 *base);
-R_API const char *r_io_fd_get_name (RIO *io, int fd);
+R_API int r_io_fd_open(RIO *io, const char *uri, int flags, int mode);
+R_API bool r_io_fd_close(RIO *io, int fd);
+R_API int r_io_fd_read(RIO *io, int fd, ut8 *buf, int len);
+R_API int r_io_fd_write(RIO *io, int fd, const ut8 *buf, int len);
+R_API ut64 r_io_fd_seek(RIO *io, int fd, ut64 addr, int whence);
+R_API ut64 r_io_fd_size(RIO *io, int fd);
+R_API bool r_io_fd_resize(RIO *io, int fd, ut64 newsize);
+R_API bool r_io_fd_is_blockdevice(RIO *io, int fd);
+R_API bool r_io_fd_is_chardevice(RIO *io, int fd);
+R_API int r_io_fd_read_at(RIO *io, int fd, ut64 addr, ut8 *buf, int len);
+R_API int r_io_fd_write_at(RIO *io, int fd, ut64 addr, const ut8 *buf, int len);
+R_API bool r_io_fd_is_dbg(RIO *io, int fd);
+R_API int r_io_fd_get_pid(RIO *io, int fd);
+R_API int r_io_fd_get_tid(RIO *io, int fd);
+R_API bool r_io_fd_get_base(RIO *io, int fd, ut64 *base);
+R_API const char *r_io_fd_get_name(RIO *io, int fd);
 R_API int r_io_fd_get_current(RIO *io);
-R_API bool r_io_use_fd (RIO *io, int fd);
+R_API bool r_io_use_fd(RIO *io, int fd);
+R_API int r_io_fd_get_next(RIO *io, int fd);
+R_API int r_io_fd_get_prev(RIO *io, int fd);
+R_API int r_io_fd_get_highest(RIO *io);
+R_API int r_io_fd_get_lowest(RIO *io);
 
 
 #define r_io_range_new()	R_NEW0(RIORange)
 #define r_io_range_free(x)	free(x)
 
 /* io/ioutils.c */
-R_API bool r_io_is_valid_offset (RIO *io, ut64 offset, int hasperm);
+R_API bool r_io_is_valid_offset(RIO *io, ut64 offset, int hasperm);
 R_API bool r_io_addr_is_mapped(RIO *io, ut64 vaddr);
-R_API bool r_io_read_i (RIO* io, ut64 addr, ut64 *val, int size, bool endian);
-R_API bool r_io_write_i (RIO* io, ut64 addr, ut64 *val, int size, bool endian);
+R_API bool r_io_read_i(RIO* io, ut64 addr, ut64 *val, int size, bool endian);
+R_API bool r_io_write_i(RIO* io, ut64 addr, ut64 *val, int size, bool endian);
 
 #if HAVE_PTRACE
 R_API long r_io_ptrace(RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);

--- a/libr/include/r_util/r_idpool.h
+++ b/libr/include/r_util/r_idpool.h
@@ -37,11 +37,15 @@ R_API RIDStorage *r_id_storage_new(ut32 start_id, ut32 last_id);
 R_API bool r_id_storage_set(RIDStorage *storage, void *data, ut32 id);
 R_API bool r_id_storage_add(RIDStorage *storage, void *data, ut32 *id);
 R_API void *r_id_storage_get(RIDStorage *storage, ut32 id);
+R_API bool r_id_storage_get_next(RIDStorage *storage, ut32 *id);
+R_API bool r_id_storage_get_prev(RIDStorage *storage, ut32 *id);
 R_API void r_id_storage_delete(RIDStorage *storage, ut32 id);
 R_API void *r_id_storage_take(RIDStorage *storage, ut32 id);
 R_API bool r_id_storage_foreach(RIDStorage *storage, RIDStorageForeachCb cb, void *user);
 R_API void r_id_storage_free(RIDStorage *storage);
 R_API RList *r_id_storage_list(RIDStorage *s);
+R_API bool r_id_storage_get_lowest(RIDStorage *storage, ut32 *id);
+R_API bool r_id_storage_get_highest(RIDStorage *storage, ut32 *id);
 
 typedef struct r_ordered_id_storage_t {
 	ut32 *permutation;

--- a/libr/io/io_desc.c
+++ b/libr/io/io_desc.c
@@ -72,6 +72,40 @@ R_API RIODesc* r_io_desc_get(RIO* io, int fd) {
 	return (RIODesc*) r_id_storage_get (io->files, fd);
 }
 
+R_API RIODesc *r_io_desc_get_next(RIO *io, RIODesc *desc) {
+	r_return_val_if_fail (desc && io && io->files, NULL);
+	const int next_fd = r_io_fd_get_next (io, desc->fd);
+	if (next_fd == -1) {
+		return NULL;
+	}
+	return (RIODesc*) r_id_storage_get (io->files, next_fd);
+}
+
+R_API RIODesc *r_io_desc_get_prev(RIO *io, RIODesc *desc) {
+	r_return_val_if_fail (desc && io && io->files, NULL);
+	const int prev_fd = r_io_fd_get_prev (io, desc->fd);
+	if (prev_fd == -1) {
+		return NULL;
+	}
+	return (RIODesc*) r_id_storage_get (io->files, prev_fd);
+}
+
+R_API RIODesc *r_io_desc_get_highest(RIO *io) {
+	int fd = r_io_fd_get_highest (io);
+	if (fd == -1) {
+		return NULL;
+	}
+	return r_io_desc_get (io, fd);
+}
+
+R_API RIODesc *r_io_desc_get_lowest(RIO *io) {
+	int fd = r_io_fd_get_lowest (io);
+	if (fd == -1) {
+		return NULL;
+	}
+	return r_io_desc_get (io, fd);
+}
+
 R_API RIODesc *r_io_desc_open(RIO *io, const char *uri, int perm, int mode) {
 	r_return_val_if_fail (io && uri, NULL);
 	RIOPlugin *plugin = r_io_plugin_resolve (io, uri, 0);

--- a/libr/io/io_desc.c
+++ b/libr/io/io_desc.c
@@ -1,11 +1,10 @@
-/* radare2 - LGPL - Copyright 2017-2019 - condret, pancake, alvaro */
+/* radare2 - LGPL - Copyright 2017-2020 - condret, pancake, alvaro */
 
 #include <r_io.h>
 #include <sdb.h>
 #include <string.h>
 
-//shall be used by plugins for creating descs
-//XXX kill mode
+// shall be used by plugins for creating descs
 R_API RIODesc* r_io_desc_new(RIO* io, RIOPlugin* plugin, const char* uri, int perm, int mode, void* data) {
 	ut32 fd32 = 0;
 	// this is required for emscripten builds to work, but should assert

--- a/libr/io/io_fd.c
+++ b/libr/io/io_fd.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2017 - condret */
+/* radare2 - LGPL - Copyright 2017-2020 - condret */
 
 #include <r_io.h>
 
@@ -125,4 +125,40 @@ R_API int r_io_fd_get_current(RIO *io) {
 		return io->desc->fd;
 	}
 	return -1;
+}
+
+R_API int r_io_fd_get_next(RIO *io, int fd) {
+	r_return_val_if_fail (io, -1);
+	int ret = fd;
+	if (!r_id_storage_get_next (io->files, (ut32 *)&ret)) {
+		return -1;
+	}
+	return ret;
+}
+
+R_API int r_io_fd_get_prev(RIO *io, int fd) {
+	r_return_val_if_fail (io, -1);
+	int ret = fd;
+	if (!r_id_storage_get_prev (io->files, (ut32 *)&ret)) {
+		return -1;
+	}
+	return ret;
+}
+
+R_API int r_io_fd_get_highest(RIO *io) {
+	r_return_val_if_fail (io, -1);
+	int fd = -1;
+	if (!r_id_storage_get_highest (io->files, (ut32 *)&fd)) {
+		return -1;
+	}
+	return fd;
+}
+
+R_API int r_io_fd_get_lowest(RIO *io) {
+	r_return_val_if_fail (io, -1);
+	int fd = -1;
+	if (!r_id_storage_get_lowest (io->files, (ut32 *)&fd)) {
+		return -1;
+	}
+	return fd;
 }

--- a/test/db/io/dupfd
+++ b/test/db/io/dupfd
@@ -27,3 +27,37 @@ EXPECT=<<EOF
 1001
 EOF
 RUN
+
+NAME=dupfd hard
+FILE=-
+CMDS=<<EOF
+op
+o -
+op
+opn
+op
+opn
+op
+opr
+op
+opr
+op
+opp
+op
+opp
+EOF
+EXPECT_ERR=<<EOF
+Cannot find file
+Cannot find file
+Cannot find file
+EOF
+EXPECT=<<EOF
+3
+4
+4
+4
+3
+4
+3
+EOF
+RUN

--- a/test/unit/test_id_storage.c
+++ b/test/unit/test_id_storage.c
@@ -1,0 +1,187 @@
+#include <r_util.h>
+#include "minunit.h"
+
+static bool test_r_id_storage_toomany(void) {
+	bool r;
+	ut32 id0, id1, id2;
+	RIDStorage *ids = r_id_storage_new (20, 22);
+	r = r_id_storage_add (ids, "aaa", &id0);
+	mu_assert_true (r, "id0");
+	r = r_id_storage_add (ids, "bbb", &id1);
+	mu_assert_true (r, "id1");
+	r = r_id_storage_add (ids, "ccc", &id2);
+	mu_assert_false (r, "id2");
+	mu_end;
+}
+
+static bool test_r_id_storage_wrong(void) {
+	bool r;
+	ut32 id0, id1;
+	RIDStorage *ids = r_id_storage_new (20, 10);
+	r = r_id_storage_add (ids, "aaa", &id0);
+	mu_assert_false (r, "id0");
+	mu_end;
+}
+
+static bool test_r_id_storage_prev_next_eq_0(void) {
+	// test if next reverts prev
+	bool r;
+	ut32 id0, id1, id2;
+	RIDStorage *ids = r_id_storage_new (1, 15);
+	r = r_id_storage_add (ids, "aaa", &id0);
+	mu_assert_true (r, "id0");
+	mu_assert_eq (id0, 1, "id0");
+	r = r_id_storage_add (ids, "bbb", &id1);
+	mu_assert_true (r, "id1");
+	mu_assert_eq (id1, 2, "id1");
+	r = r_id_storage_add (ids, "ccc", &id2);
+	mu_assert_true (r, "id2");
+	mu_assert_eq (id2, 3, "id2");
+	ut32 id = id1;
+	r_id_storage_get_prev (ids, &id);
+	r_id_storage_get_next (ids, &id);
+	r_id_storage_free (ids);
+	
+	mu_assert_eq (id, id1, "r_id_storage_{next/prev} reversal 0");
+	mu_end;
+}
+
+static bool test_r_id_storage_prev_next_eq_1(void) {
+	// test if next reverts prev (modulo wrap 1)
+	bool r;
+	ut32 id, id0, id1, id2;
+	RIDStorage *ids = r_id_storage_new (0, 15);
+	r_id_storage_add (ids, "bbb", &id0);
+	r_id_storage_add (ids, "aaa", &id1);
+	r_id_storage_add (ids, "ccc", &id2);
+	id = id0;
+	r = r_id_storage_get_prev (ids, &id);
+	mu_assert_false (r, "get_prev(0) doesnt exist");
+	ut32 n = id;
+	id = id1;
+	r = r_id_storage_get_prev (ids, &id);
+	mu_assert_true (r, "get_prev(1) must exist");
+	r = r_id_storage_get_next (ids, &id);
+	mu_assert_true (r, "get_prev(1) must exist");
+	r_id_storage_free (ids);
+	
+	mu_assert_eq (id, id1, "r_id_storage_{next/prev} reversal 1");
+	mu_end;
+}
+
+static bool test_r_id_storage_prev_next_min(void) {
+	// test if next reverts prev (modulo wrap 1)
+	bool r;
+	ut32 id, id0, id1, id2;
+	RIDStorage *ids = r_id_storage_new (3, 15);
+	r_id_storage_add (ids, "bbb", &id0);
+	r_id_storage_add (ids, "aaa", &id1);
+	r_id_storage_add (ids, "ccc", &id2);
+	id = id0;
+	r = r_id_storage_get_prev (ids, &id);
+	mu_assert_false (r, "get_prev(0) doesnt exist");
+	ut32 n = id;
+	id = id1;
+	r = r_id_storage_get_prev (ids, &id);
+	mu_assert_true (r, "get_prev(1) must exist");
+	r = r_id_storage_get_next (ids, &id);
+	mu_assert_true (r, "get_prev(1) must exist");
+	r_id_storage_free (ids);
+	mu_assert_eq (id, id1, "r_id_storage_{next/prev} reversal 1");
+	mu_end;
+}
+
+static bool test_r_id_storage_empty(void) {
+	// test if next reverts prev (modulo wrap 2)
+	ut32 id, _id = 0;
+	RIDStorage *ids = r_id_storage_new (0, 15);
+	bool r = r_id_storage_get_prev (ids, &_id);
+	mu_assert_false (r, "get prev from none");
+	r = r_id_storage_get_next (ids, &_id);
+	mu_assert_false (r, "get next from none");
+	r = r_id_storage_get_highest (ids, &_id);
+	mu_assert_false (r, "get high from none");
+	r = r_id_storage_get_lowest (ids, &_id);
+	mu_assert_false (r, "get low from none");
+	r_id_storage_free (ids);
+	
+	mu_end;
+}
+
+static bool test_r_id_storage_prev_next_eq_2(void) {
+	// test if next reverts prev (modulo wrap 2)
+	ut32 id, _id;
+	RIDStorage *ids = r_id_storage_new (0, 15);
+	r_id_storage_add (ids, "aaa", &_id);
+	r_id_storage_add (ids, "ccc", &_id);
+	r_id_storage_add (ids, "bbb", &id);
+	_id = id;
+	r_id_storage_get_prev (ids, &_id);
+	r_id_storage_get_next (ids, &_id);
+	r_id_storage_free (ids);
+	
+	mu_assert_eq (id, _id, "r_id_storage_{next/prev} reversal 2");
+	mu_end;
+}
+
+static bool test_prevnext(void) {
+	RIDStorage *ids = r_id_storage_new (5, 10);
+	ut32 id[3];
+	r_id_storage_add (ids, "a", &id[0]);
+	r_id_storage_add (ids, "b", &id[1]);
+	r_id_storage_add (ids, "c", &id[2]);
+
+	RList *ids_list = r_id_storage_list (ids);
+	const char *val0list = r_list_get_n (ids_list, 0);
+	ut32 id0list = id[*val0list - 'a'];
+	const char *val1list = r_list_get_n (ids_list, 1);
+	ut32 id1list = id[*val1list - 'a'];
+	const char *val2list = r_list_get_n (ids_list, 2);
+	ut32 id2list = id[*val2list - 'a'];
+
+	bool idw;
+	ut32 idi = id0list;
+	idw = r_id_storage_get_next (ids, &idi);
+	mu_assert_eq (idi, id1list, "next of id0 should be id1");
+	idw = r_id_storage_get_next (ids, &idi);
+	mu_assert_eq (idi, id2list, "next of id1 should be id2");
+	idw = r_id_storage_get_next (ids, &idi);
+	mu_assert_eq (idw, false, "next of id2 (last) should not exist (-1)");
+
+	idw = r_id_storage_get_prev (ids, &idi);
+	mu_assert_eq (idi, id1list, "prev of id2 should be id1");
+	idw = r_id_storage_get_prev (ids, &idi);
+	mu_assert_eq (idi, id0list, "prev of id1 should be id0");
+	idw = r_id_storage_get_prev (ids, &id0list);
+	mu_assert_eq (idw, false, "prev of id0 (first) should not exist (-1)");
+
+	ut32 lowid;
+	bool l = r_id_storage_get_lowest (ids, &lowid);
+	mu_assert_true (l, "get-lowest must return true");
+	mu_assert_eq (lowid, id0list, "lowest should be id0");
+
+	bool h = r_id_storage_get_highest (ids, &lowid);
+	mu_assert_true (h, "get-highest must return true");
+	mu_assert_eq (lowid, id2list, "highest should be id2");
+
+	r_list_free (ids_list);
+	r_id_storage_free (ids);
+
+	mu_end;
+}
+
+static int all_tests(void) {
+	mu_run_test (test_r_id_storage_prev_next_eq_0);
+	mu_run_test (test_r_id_storage_prev_next_eq_1);
+	mu_run_test (test_r_id_storage_prev_next_eq_2);
+	mu_run_test (test_r_id_storage_prev_next_min);
+	mu_run_test (test_r_id_storage_toomany);
+	mu_run_test (test_prevnext);
+	mu_run_test (test_r_id_storage_empty);
+	mu_run_test (test_r_id_storage_wrong);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
**DO NOT SQUASH**
================

Based on https://github.com/radareorg/radare2/pull/17271 

* I fixed the review comments i wrote there
* fixed next/prev/lowest/highest apis
* confirm behaviour with r2 tests
* this is ready to review, but ill squash and rebase all the commits properly when the review is done

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

See https://github.com/radareorg/radare2/pull/17162 and https://github.com/radareorg/radare2/pull/17161

**Test plan**

There are unit and r2 tests

**Closing issues**

None. thats a feature