### PR TITLE
codecov: Add yaml config for ignoring failures in coverage for PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        branches:
+          - master
+          - 'release-*'
+        if_not_found: failure
+        if_ci_failed: error
+        informational: false
+    patch:
+      default:
+        if_not_found: success
+        if_ci_failed: success
+        informational: true


### PR DESCRIPTION
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Ignore failures in coverage for PRs.
Also, only test "project" coverage on master or release branches.

**Test plan**
Check the coverage stats on this PR, it should pass (even though it may or may not have bad coverage).
