### PR TITLE
Make codecov/project informational on master as well

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
           - 'release-*'
         if_not_found: failure
         if_ci_failed: error
-        informational: false
+        informational: true
     patch:
       default:
         if_not_found: success


### PR DESCRIPTION
I don't think we want to see master red because we coverage is not good. It is definitely something we want to look at from time to time, but seeing master red just because of codecov does not seem right. Hopefully this will make it green.