### PR TITLE
Fix RAnalFunction leaking imports

### DIFF
--- a/libr/anal/function.c
+++ b/libr/anal/function.c
@@ -122,6 +122,7 @@ R_API void r_anal_function_free(void *_fcn) {
 	fcn->bbs = NULL;
 	free (fcn->fingerprint);
 	r_anal_diff_free (fcn->diff);
+	r_list_free (fcn->imports);
 	free (fcn);
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`RAnalFunction.imports` wasn't freed when deleting the function.

**Test plan**

I wanted to add a unit test here but there is no API at all for imports yet so it would have to hack the stuff into the struct manually into the test. Instead here is a test from r2db that shows the leak with asan/valgrind: https://github.com/thestr4ng3r/r2db/blob/master/test/unit/test_anal.c#L305
