### PR TITLE
Fix leak in dwarf processing.

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1016,9 +1016,9 @@ static int bin_info(RCore *r, int mode, ut64 laddr) {
 }
 
 typedef struct {
-	int *line_starts;
+	size_t *line_starts;
 	char *content;
-	int line_count;
+	size_t line_count;
 } FileLines;
 
 static void file_lines_free(FileLines *file) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4943,8 +4943,8 @@ static void ds_print_comments_right(RDisasmState *ds) {
 					if (comment) {
 						ds_newline (ds);
 						ds_begin_line (ds);
-						int lines_count;
-						int *line_indexes = r_str_split_lines (comment, &lines_count);
+						size_t lines_count;
+						size_t *line_indexes = r_str_split_lines (comment, &lines_count);
 						if (line_indexes) {
 							int i;
 							for (i = 0; i < lines_count; i++) {

--- a/libr/fs/p/fs_io.c
+++ b/libr/fs/p/fs_io.c
@@ -87,8 +87,8 @@ static RList *fs_io_dir(RFSRoot *root, const char *path, int view /*ignored*/) {
 	char *cmd = r_str_newf ("md %s", path);
 	char *res = root->iob.system (root->iob.io, cmd);
 	if (res) {
-		int i, count = 0;
-		int *lines = r_str_split_lines (res, &count);
+		size_t i, count = 0;
+		size_t *lines = r_str_split_lines (res, &count);
 		if (lines) {
 			for (i = 0; i < count; i++) {
 				const char *line = res + lines[i];

--- a/libr/fs/p/fs_r2.c
+++ b/libr/fs/p/fs_r2.c
@@ -60,8 +60,8 @@ static RList *fscmd(RFSRoot *root, const char *cmd, int type) {
 			free (res);
 			return NULL;
 		}
-		int i, count = 0;
-		int *lines = r_str_split_lines (res, &count);
+		size_t i, count = 0;
+		size_t *lines = r_str_split_lines (res, &count);
 		if (lines) {
 			for (i = 0; i < count; i++) {
 				append_file (list, res + lines[i], type, 0, 0);
@@ -252,8 +252,8 @@ static RList *__cfg(RFSRoot *root, const char *path) {
 			free (res);
 			return NULL;
 		}
-		int i, count = 0;
-		int *lines = r_str_split_lines (res, &count);
+		size_t i, count = 0;
+		size_t *lines = r_str_split_lines (res, &count);
 		if (lines) {
 			for (i = 0; i < count; i++) {
 				char *line = res + lines[i];

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -54,7 +54,7 @@ R_API const char *r_str_lastbut(const char *s, char ch, const char *but);
 R_API int r_str_split(char *str, char ch);
 R_API RList *r_str_split_list(char *str, const char *c, int n);
 R_API RList *r_str_split_duplist(const char *str, const char *c, bool trim);
-R_API int *r_str_split_lines(char *str, int *count);
+R_API size_t *r_str_split_lines(char *str, size_t *count);
 R_API char* r_str_replace(char *str, const char *key, const char *val, int g);
 R_API char *r_str_replace_icase(char *str, const char *key, const char *val, int g, int keep_case);
 R_API char *r_str_replace_in(char *str, ut32 sz, const char *key, const char *val, int g);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3108,13 +3108,13 @@ R_API RList *r_str_split_duplist(const char *_str, const char *c, bool trim) {
 	return lst;
 }
 
-R_API int *r_str_split_lines(char *str, int *count) {
+R_API size_t *r_str_split_lines(char *str, size_t *count) {
 	int i;
-	int lines = 0;
+	size_t lines = 0;
 	if (!str) {
 		return NULL;
 	}
-	int *indexes = NULL;
+	size_t *indexes = NULL;
 	// count lines
 	for (i = 0; str[i]; i++) {
 		if (str[i] == '\n') {
@@ -3122,11 +3122,11 @@ R_API int *r_str_split_lines(char *str, int *count) {
 		}
 	}
 	// allocate and set indexes
-	indexes = calloc (sizeof (int), lines + 1);
+	indexes = calloc (sizeof (count[0]), lines + 1);
 	if (!indexes) {
 		return NULL;
 	}
-	int line = 0;
+	size_t line = 0;
 	indexes[line++] = 0;
 	for (i = 0; str[i]; i++) {
 		if (str[i] == '\n') {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Store read files with line information in in a dictionary. Simplifies the logic within `bin_dwarf` and prevents memory leak. This also reduces execution time by not having to process the same file multiple times. Previous version only stored last 1-2 files. 

As usual there is room for further optimizations but it isn't the worst part anymore. There is little value for doing it right now before improve other parts first.

When testing on Cutter debug executable
* prevent 6.7 GB memory leak
* reduce peak memory usage from 6.7GB to 1.9GB
* reduce execution time 49s -> 20s
![memory consumption screenshot](https://user-images.githubusercontent.com/7101031/93561623-369a2c80-f98d-11ea-817d-3dace2fb90b6.png)


**Test plan**

* comparisons performed by running `r2 -ci -qq executable`

Wait for coverage report to check if modifed code is executed during tests, based on that decide need for more tests.

**Closing issues**

