### PR TITLE
Use sdb == for generating dbs in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -522,26 +522,10 @@ sdb_exe = executable('sdb', ['shlr/sdb/src/main.c'] + sdb_files,
   native: true,
 )
 
-sdb_gen_cmd_script = '''#script
-import os
-import sys
-sdb_exe = r'@0@'
-outfile = sys.argv[1]
-infiles = sys.argv[2:]
-if os.name == 'nt':
-    # DO NOT replace chr(92) below with a backslash
-    infiles, sdb_exe, outfile = map(lambda x: x.replace('/', chr(92)), [' '.join(infiles), sdb_exe, outfile])
-    os.system('type {} | {} {} ='.format(infiles, sdb_exe, outfile))
-else:
-    infiles = ' '.join(infiles)
-    os.system('cat {} | {} {} ='.format(infiles, sdb_exe, outfile))
-'''.format(sdb_exe.full_path())
-
 sdb_gen_cmd = [
-  py3_exe,
-  '-c',
-  sdb_gen_cmd_script,
+  sdb_exe,
   '@OUTPUT@',
+  '==',
   '@INPUT@'
 ]
 

--- a/shlr/sdb/src/query.c
+++ b/shlr/sdb/src/query.c
@@ -259,13 +259,10 @@ repeat:
 next_quote:
 		quot = strchr (quot, '"');
 		if (quot) {
-			quot--;
-			if (*quot=='\\') {
-				memmove (quot, quot + 1, strlen (quot));
-				quot++;
+			if (*(quot - 1) == '\\') {
+				memmove (quot - 1, quot, strlen (quot) + 1);
 				goto next_quote;
 			}
-			quot++;
 			*quot++ = 0; // crash on read only mem!!
 		} else {
 			eprintf ("Missing quote\n");

--- a/shlr/sdb/src/sdb.1
+++ b/shlr/sdb/src/sdb.1
@@ -8,7 +8,7 @@
 .Nm sdb
 .Op Fl 0dehjJv
 .Ar -|db
-.Ar -=
+.Ar [-|=|==]
 .Ar [.file|expr ..]
 .Sh DESCRIPTION
 SDB is a simple disk and memory string-based key-value database. It is based on CDB and uses
@@ -36,6 +36,8 @@ Some useful ways to run it:
 $ sdb -                           ; in memory database
 .Pp
 $ sdb test.db = < test.txt        ; create database from text file
+.Pp
+$ sdb test.db == a.txt b.txt      ; create database from text files in a single command
 .Pp
 $ sdb test.db                     ; dump contents of database
 .Pp


### PR DESCRIPTION
Filling this template is filling this template.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Build on Pinebook Pro (`time ninja`):

Before:
```
real    4m8.053s
user    20m34.937s
sys     2m58.248s
```

After:
```
real    3m9.292s
user    15m23.409s
sys     2m21.460s
```

linux-meson-gcc-build:
Before: 2m 38s
After: 2m 6s

**Test plan**

Build r2 with meson.

