### PR TITLE
Fix for internal less and hud mode available while in non-interactive

### DIFF
--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -19,6 +19,10 @@ R_API char *r_cons_hud_file(const char *f) {
 // Display a buffer in the hud (splitting it line-by-line and ignoring
 // the lines starting with # )
 R_API char *r_cons_hud_string(const char *s) {
+	if (!r_cons_is_interactive ()) {
+		eprintf ("Hud mode requires scr.interactive=true.\n");
+		return NULL;
+	}
 	char *os, *track, *ret, *o = strdup (s);
 	if (!o) {
 		return NULL;

--- a/libr/cons/less.c
+++ b/libr/cons/less.c
@@ -7,6 +7,10 @@
 
 R_API int r_cons_less_str(const char *str, const char *exitkeys) {
 	r_return_val_if_fail (str && *str, 0);
+	if (!r_cons_is_interactive ()) {
+		eprintf ("Internal less requires scr.interactive=true.\n");
+		return 0;
+	}
 
 	static int in_help = false;
 	static const char *r_cons_less_help = \

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -9,4 +9,4 @@ EXPECT_ERR=<<EOF
 Internal less requires scr.interactive=true
 Hud mode requires scr.interactive=true
 EOF
-
+RUN

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -1,0 +1,12 @@
+NAME=Internal less
+FILE=-
+CMDS=<<EOF
+e scr.interactive=false
+pd 10~..
+pd 10~...
+EOF
+EXPECT_ERR=<<EOF
+Internal less requires scr.interactive=true
+Hud mode requires scr.interactive=true
+EOF
+

--- a/test/db/cmd/cmd_interactive_modes
+++ b/test/db/cmd/cmd_interactive_modes
@@ -2,11 +2,20 @@ NAME=Internal less
 FILE=-
 CMDS=<<EOF
 e scr.interactive=false
-pd 10~..
-pd 10~...
+pd 1~..
 EOF
 EXPECT_ERR=<<EOF
-Internal less requires scr.interactive=true
-Hud mode requires scr.interactive=true
+Internal less requires scr.interactive=true.
+EOF
+RUN
+
+NAME=Hud mode
+FILE=-
+CMDS=<<EOF
+e scr.interactive=false
+pd 1~...
+EOF
+EXPECT_ERR=<<EOF
+Hud mode requires scr.interactive=true.
 EOF
 RUN


### PR DESCRIPTION
mode

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)


**Detailed description**

Interactive output modes - Internal less and hud - were available while `e scr.interactive=false`, which caused certain Cutter's console panel - And maybe other UIs - to hang.

**Test plan**

Test available at `test/db/cmd/cmd_interactive_modes`

**Closing issues**

Closes #17677 "

...
