### PR TITLE
Fix `rj` and add tests ##json

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1834,7 +1834,7 @@ static int cmd_resize(void *data, const char *input) {
 			char *s = pj_drain (pj);
 			r_cons_println (s);
 			free (s);
-			break;
+			return true;
 		}
 	case 'h':
 		if (core->file) {

--- a/test/db/cmd/cmd_r
+++ b/test/db/cmd/cmd_r
@@ -20,3 +20,11 @@ EXPECT=<<EOF
             0x00000000      90             nop
 EOF
 RUN
+
+NAME=rj-pj
+FILE=bins/elf/crackme0x05
+CMDS=rj
+EXPECT=<<EOF
+{"size":7656}
+EOF
+RUN

--- a/test/db/json/json4
+++ b/test/db/json/json4
@@ -17,6 +17,7 @@ pxj
 pxqj
 pxrj
 pxwj
+rj
 sj
 tej
 tfj


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This PR fixes [an issue](https://github.com/radareorg/radare2/pull/17443#issuecomment-695193995)(also explained below) with `rj` and add tests for it.

**Test plan**

`rj` also printed `r_io_resize: cannot resize`, along with the required output.
```
[0x08048320]> rj
r_io_resize: cannot resize
{"size":5240}
```
Which stopped, when I replaced the break statement in the case that prints `rj` with, a return statement, just like the other cases in the same switch statement.
I'm not sure whether this is the right way to fix this, which is why I'm putting this on draft.

Other than that, I've added the tests for `rj`.
```
$ r2r -i db/cmd/cmd_r
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 3 tests.
Skipping json tests because jq is not available.
[3/3]                       3 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```

**Closing issues**

None
