### PR TITLE
Fix rasm2 -L bits field for 4 and 0-bit plugins ##asm

### DIFF
--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -204,25 +204,23 @@ static void rasm2_list(RAsmState *as, const char *arch) {
 			bits[0] = 0;
 			if (h->bits == 27) {
 				strcat (bits, "27");
+			} else if (h->bits == 0) {
+				strcat (bits, "any");
 			} else {
-				if (h->bits == 0) {
-					strcat (bits, "any");
-				} else {
-					if (h->bits & 4) {
-						strcat (bits, "4 ");
-					}
-					if (h->bits & 8) {
-						strcat (bits, "8 ");
-					}
-					if (h->bits & 16) {
-						strcat (bits, "16 ");
-					}
-					if (h->bits & 32) {
-						strcat (bits, "32 ");
-					}
-					if (h->bits & 64) {
-						strcat (bits, "64 ");
-					}
+				if (h->bits & 4) {
+					strcat (bits, "4 ");
+				}
+				if (h->bits & 8) {
+					strcat (bits, "8 ");
+				}
+				if (h->bits & 16) {
+					strcat (bits, "16 ");
+				}
+				if (h->bits & 32) {
+					strcat (bits, "32 ");
+				}
+				if (h->bits & 64) {
+					strcat (bits, "64 ");
 				}
 			}
 			feat = "__";

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -205,17 +205,24 @@ static void rasm2_list(RAsmState *as, const char *arch) {
 			if (h->bits == 27) {
 				strcat (bits, "27");
 			} else {
-				if (h->bits & 8) {
-					strcat (bits, "8 ");
-				}
-				if (h->bits & 16) {
-					strcat (bits, "16 ");
-				}
-				if (h->bits & 32) {
-					strcat (bits, "32 ");
-				}
-				if (h->bits & 64) {
-					strcat (bits, "64 ");
+				if (h->bits == 0) {
+					strcat (bits, "any");
+				} else {
+					if (h->bits & 4) {
+						strcat (bits, "4 ");
+					}
+					if (h->bits & 8) {
+						strcat (bits, "8 ");
+					}
+					if (h->bits & 16) {
+						strcat (bits, "16 ");
+					}
+					if (h->bits & 32) {
+						strcat (bits, "32 ");
+					}
+					if (h->bits & 64) {
+						strcat (bits, "64 ");
+					}
 				}
 			}
 			feat = "__";

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -1,3 +1,13 @@
+NAME=rasm2 i4004
+FILE=-
+CMDS=<<EOF
+!!rasm2 -L~4004
+EOF
+EXPECT=<<EOF
+_dAe  4          i4004       LGPL3   Intel 4004 microprocessor
+EOF
+RUN
+
 NAME=rasm2 arm asm/dis endian
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
