### PR TITLE
Fix forward declaration of RCore

### DIFF
--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -238,7 +238,7 @@ typedef struct r_core_tasks_t {
 	bool oneshot_running;
 } RCoreTaskScheduler;
 
-typedef struct r_core_t {
+struct r_core_t {
 	RBin *bin;
 	RConfig *config;
 	ut64 offset; // current seek
@@ -343,7 +343,7 @@ typedef struct r_core_t {
 	int (*r_main_ragg2)(int argc, const char **argv);
 	int (*r_main_rasm2)(int argc, const char **argv);
 	int (*r_main_rax2)(int argc, const char **argv);
-} RCore;
+};
 
 // maybe move into RAnal
 typedef struct r_core_item_t {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fixes the following [compilation error](https://github.com/XVilka/debian-oldies/runs/1145536590?check_suite_focus=true#step:3:18485) on Debian Wheezy, Squeeze, Etch:
```
gcc -c  -MD   -fPIC -g -Wall -D__UNIX__=1 -DR2_PLUGIN_INCORE -I/radare2-master/libr/..//shlr -I/radare2-master/libr/../shlr/sdb/src -I/radare2-master/libr/../shlr/zip/include -I/radare2-master/libr -I/radare2-master/libr/include -I/radare2-master/libr/../shlr/sdb/src -fvisibility=hidden -I../../shlr/sdb/src/ -DHAVE_FORK=1 -DUSE_R2=1 -I../../shlr -o log.o log.c
In file included from log.c:6:
/radare2-master/libr/include/r_core.h:346: error: redefinition of typedef 'RCore'
/radare2-master/libr/include/r_cmd.h:12: note: previous declaration of 'RCore' was here
make[2]: *** [log.o] Error 1
make[2]: Leaving directory `/radare2-master/libr/util'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/radare2-master/libr/util'
```

The problem was introduced in https://github.com/radareorg/radare2/commit/75a80741ee710bd8d9370e5831e1a2185c7791f5 by @ret2libc - older GCC versions think the line `typedef struct r_core_t RCore;` in `libr/include/r_cmd.h` conflicts with the lines of `typedef struct r_core_t { .... } RCore;` in `libr/include/r_core.h`. Thus I removed the typedef from `libr/include/r_core.h`. If you think the fix is ugly we probably should remove the line from `libr/include/r_cmd.h` then whatsoever.


**Test plan**

Everything green here and in Debian Oldies repository: https://github.com/XVilka/debian-oldies


