### PR TITLE
Refactor Variable Constraints out of SDB ##anal

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1635,25 +1635,15 @@ static ut32 tmp_get_realsize (RAnalFunction *f) {
 
 static void ds_show_functions_argvar(RDisasmState *ds, RAnalFunction *fcn, RAnalVar *var, const char *base, bool is_var, char sign) {
 	int delta = var->kind == 'b' ? R_ABS (var->delta + fcn->bp_off) : R_ABS (var->delta);
-	const char *pfx = is_var ? "var" : "arg", *constr = NULL;
-	RStrBuf *constr_buf = NULL;
-	bool cond = false;
-	if (ds->core && ds->core->anal) {
-		constr_buf = var_get_constraint (ds->core->anal, fcn, var);
-		if (constr_buf) {
-			constr = r_strbuf_get (constr_buf);
-			if (constr[0]) {
-				cond = true;
-			}
-		}
-	}
+	const char *pfx = is_var ? "var" : "arg";
+	char *constr = r_anal_var_get_constraints_readable (var);
 	r_cons_printf ("%s%s %s%s%s%s %s%s%s%s@ %s%c0x%x", COLOR_ARG (ds, color_func_var), pfx,
 			COLOR_ARG (ds, color_func_var_type), var->type,
 			r_str_endswith (var->type, "*") ? "" : " ",
 			var->name, COLOR_ARG (ds, color_func_var_addr),
-			cond? " { ":"",
-			cond? constr: "",
-			cond? "} ":"",
+			constr? " { ":"",
+			constr? constr: "",
+			constr? "} ":"",
 			base, sign, delta);
 	if (ds->show_varsum == -1) {
 		char *val = r_core_cmd_strf (ds->core, ".afvd %s", var->name);
@@ -1663,7 +1653,7 @@ static void ds_show_functions_argvar(RDisasmState *ds, RAnalFunction *fcn, RAnal
 			free (val);
 		}
 	}
-	r_strbuf_free (constr_buf);
+	free (constr);
 }
 
 static void printVarSummary(RDisasmState *ds, RList *list) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -783,6 +783,11 @@ typedef struct r_anal_var_access_t {
 	ut8 type; // RAnalVarAccessType bits
 } RAnalVarAccess;
 
+typedef struct r_anal_var_constraint_t {
+	_RAnalCond cond;
+	ut64 val;
+} RAnalVarConstraint;
+
 // generic for args and locals
 typedef struct r_anal_var_t {
 	RAnalFunction *fcn;
@@ -794,6 +799,7 @@ typedef struct r_anal_var_t {
 	char *regname; // name of the register
 	RVector/*<RAnalVarAccess>*/ accesses; // ordered by offset, touch this only through API or expect uaf
 	char *comment;
+	RVector/*<RAnalVarConstraint>*/ constraints;
 
 	// below members are just for caching, TODO: remove them and do it better
 	int argnum;
@@ -1694,6 +1700,8 @@ R_API ut64 r_anal_var_addr(RAnalVar *var);
 R_API void r_anal_var_set_access(RAnalVar *var, const char *reg, ut64 access_addr, int access_type, st64 stackptr);
 R_API void r_anal_var_remove_access_at(RAnalVar *var, ut64 address);
 R_API void r_anal_var_clear_accesses(RAnalVar *var);
+R_API void r_anal_var_add_constraint(RAnalVar *var, R_BORROW RAnalVarConstraint *constraint);
+R_API char *r_anal_var_get_constraints_readable(RAnalVar *var);
 
 // Get the access to var at exactly addr if there is one
 R_API RAnalVarAccess *r_anal_var_get_access_at(RAnalVar *var, ut64 addr);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -617,7 +617,6 @@ R_API RList *r_core_anal_fcn_get_calls (RCore *core, RAnalFunction *fcn); // get
 
 /*tp.c*/
 R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn);
-R_API RStrBuf *var_get_constraint(RAnal *a, RAnalFunction *fcn, RAnalVar *var);
 
 /* asm.c */
 #define R_MIDFLAGS_SHOW 1


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

See title, having them in sdb would make the constraints leak beyond the lifetime of vars/functions and harder to use.

**Test plan**

There is a test in `test/db/cmd/types` that covers this code quite well: https://github.com/radareorg/radare2/blob/1c485e8bfc94e052ac3976dcc3251a5e76650532/test/db/cmd/types#L1342-L1362.
