### PR TITLE
Add support for additional cmd_identifiers ##newshell

### DIFF
--- a/shlr/radare2-shell-parser/corpus/special_commands.txt
+++ b/shlr/radare2-shell-parser/corpus/special_commands.txt
@@ -264,3 +264,25 @@ Pointer type commands with substitution
         (arg (cmd_substitution_arg
 	        (arged_command (cmd_identifier)
 		  (args (arg (arg_identifier))))))))))
+
+========
+editor -
+========
+
+-
+
+---
+
+(commands
+  (arged_command (cmd_identifier)))
+
+=========
+\ command
+=========
+
+\
+
+---
+
+(commands
+  (arged_command (cmd_identifier)))

--- a/shlr/radare2-shell-parser/src/scanner.c
+++ b/shlr/radare2-shell-parser/src/scanner.c
@@ -46,9 +46,8 @@ static bool is_comment(const char *s) {
 }
 
 static bool is_special_start(const int32_t ch) {
-	return ch == '*' || ch == '(' || ch == '*' || ch == '@' || ch == '|' ||
-		ch == '.' || ch == '|' || ch == '%' || ch == '~' || ch == '&' ||
-		ch == '>';
+	return ch == '*' || ch == '(' || ch == '@' || ch == '|' || ch == '>' ||
+		ch == '.' || ch == '|' || ch == '%' || ch == '~' || ch == '&';
 }
 
 static bool is_start_of_command(const int32_t ch) {

--- a/shlr/radare2-shell-parser/src/scanner.c
+++ b/shlr/radare2-shell-parser/src/scanner.c
@@ -53,7 +53,8 @@ static bool is_special_start(const int32_t ch) {
 
 static bool is_start_of_command(const int32_t ch) {
 	return isalpha (ch) || ch == '$' || ch == '?' || ch == ':' || ch == '+' ||
-		ch == '=' || ch == '/' || ch == '_' || ch == '#' || is_special_start (ch);
+		ch == '=' || ch == '/' || ch == '_' || ch == '#' || ch == '\\' ||
+		ch == '-' || is_special_start (ch);
 }
 
 static bool is_mid_command(const char *res, int len, const int32_t ch) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Commands like `-` or `\` were not working.
`-` is supposed to open the editor, `\` is for rap commands.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try `-` with `e cfg.newshell=true`, it should open your editor and execute whatever you put there
