### PR TITLE
Kill RAnal.sdb_fcns

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -106,7 +106,6 @@ R_API RAnal *r_anal_new(void) {
 	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_UNSET, zign_unset_for, NULL);
 	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_COUNT, zign_count_for, NULL);
 	r_event_hook (anal->zign_spaces.event, R_SPACE_EVENT_RENAME, zign_rename_for, NULL);
-	anal->sdb_fcns = sdb_ns (anal->sdb, "fcns", 1);
 	r_anal_hint_storage_init (anal);
 	r_interval_tree_init (&anal->meta, r_meta_item_free);
 	anal->sdb_types = sdb_ns (anal->sdb, "types", 1);
@@ -413,7 +412,6 @@ R_API bool r_anal_op_is_eob(RAnalOp *op) {
 }
 
 R_API int r_anal_purge (RAnal *anal) {
-	sdb_reset (anal->sdb_fcns);
 	r_anal_hint_clear (anal);
 	r_interval_tree_fini (&anal->meta);
 	r_interval_tree_init (&anal->meta, r_meta_item_free);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7388,38 +7388,6 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		char *space = strchr (input, ' ');
 		char *tmp = NULL;
 		char *name = space ? strdup (space + 1): NULL;
-
-		if (name && (tmp = strchr (name, ' '))) {
-			char *varname = tmp + 1;
-			*tmp = '\0';
-			RAnalFunction *fcn = r_anal_get_function_byname (core->anal, name);
-			if (fcn) {
-				RAnalVar *var = r_anal_function_get_var_byname (fcn, varname);
-				if (var) {
-					const char *rvar = var_ref_list (fcn->addr, var->delta, 'R');
-					const char *wvar = var_ref_list (fcn->addr, var->delta, 'W');
-					char *res = sdb_get (core->anal->sdb_fcns, rvar, 0);
-					char *res1 = sdb_get (core->anal->sdb_fcns, wvar, 0);
-					const char *ref;
-					RListIter *iter;
-					RList *list = (res && *res)? r_str_split_list (res, ",", 0): NULL;
-					RList *list1 = (res1 && *res1)? r_str_split_list (res1, ",", 0): NULL;
-					r_list_join (list , list1);
-					r_list_foreach (list, iter, ref) {
-						ut64 addr = r_num_math (NULL, ref);
-						char *op = get_buf_asm (core, core->offset, addr, fcn, true);
-						r_cons_printf ("%s 0x%"PFMT64x" [DATA] %s\n", fcn?  fcn->name : "(nofunc)", addr, op);
-						free (op);
-					}
-					free (res);
-					free (res1);
-					R_FREE (name);
-					r_list_free (list);
-					r_list_free (list1);
-					break;
-				}
-			}
-		}
 		if (space) {
 			addr = r_num_math (core->num, space + 1);
 		} else {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2288,11 +2288,12 @@ static int mywrite(const ut8 *buf, int len) {
 }
 
 static bool exists_var(RPrint *print, ut64 func_addr, char *str) {
-	char *name_key = sdb_fmt ("var.0x%"PFMT64x ".%d.%s", func_addr, 1, str);
-	if (sdb_const_get_len (((RCore*)(print->user))->anal->sdb_fcns, name_key, NULL, 0)) {
-		return true;
+	RAnal *anal = ((RCore*)(print->user))->anal;
+	RAnalFunction *fcn = r_anal_get_function_at (anal, func_addr);
+	if (!fcn) {
+		return false;
 	}
-	return false;
+	return !!r_anal_function_get_var_byname (fcn, str);
 }
 
 static bool r_core_anal_log(struct r_anal_t *anal, const char *msg) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -660,7 +660,6 @@ typedef struct r_anal_t {
 	PrintfCallback cb_printf;
 	//moved from RAnalFcn
 	Sdb *sdb; // root
-	Sdb *sdb_fcns;
 	Sdb *sdb_pins;
 	HtUP/*<RVector<RAnalAddrHintRecord>>*/ *addr_hints; // all hints that correspond to a single address
 	RBTree/*<RAnalArchHintRecord>*/ arch_hints;

--- a/test/db/cmd/cmd_k
+++ b/test/db/cmd/cmd_k
@@ -34,7 +34,6 @@ EXPECT=<<EOF
 {
   "anal": {
     "cur_cmd": [
-      "fcns",
       "types",
       "*aligned_alloc=func",
       "_Exit=func",

--- a/test/db/cmd/cmd_k
+++ b/test/db/cmd/cmd_k
@@ -35,11 +35,6 @@ EXPECT=<<EOF
   "anal": {
     "cur_cmd": [
       "fcns",
-      "fcn.0x00000000.arg.0=int32_t",
-      "fcn.0x00000000.arg.4=int32_t",
-      "fcn.0x00000000.arg.8=int32_t",
-      "fcn.0x0804846e.arg.0=int32_t",
-      "fcn.0x0804846e.arg.4=int32_t",
       "types",
       "*aligned_alloc=func",
       "_Exit=func",

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1231,7 +1231,7 @@ var char * s1 @ rbp-0x1020
 var int64_t var_18h @ rbp-0x18
 arg char ** argv @ rsi
 arg int argc @ rdi
-var char ** str @ rbp-0xb0
+var char * str @ rbp-0xb0
 var signed int var_a4h @ rbp-0xa4
 var signed int64_t var_a0h @ rbp-0xa0
 var uint32_t var_9ch @ rbp-0x9c
@@ -1260,7 +1260,7 @@ var char * var_28h @ rbp-0x28
 var char * var_20h @ rbp-0x20
 var int64_t var_18h @ rbp-0x18
 var int64_t var_8h @ rbp-0x8
-arg char ** arg2 @ rsi
+arg char * arg2 @ rsi
 arg signed int arg1 @ rdi
 EOF
 RUN
@@ -1611,5 +1611,6 @@ fcn.0000e780
 fcn.0000c0f0
 =
 fcn.00011b90
+fcn.00014d50
 EOF
 RUN


### PR DESCRIPTION
**DO NOT SQUASH!!!!!!!!!!!!!!!!!!!!!!!!!!!!**

Filling this template is power, France is bacon.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

### Detailed description

I'll go through the previously remaining uses of `sdb_fcns` and how they have been killed.

#### Variables

... were saved in this sdb until #16547 which was merged months ago. Apparently the only remaining use of vars there was the `exists_var` callback for RPrint, which I rewrote for the correct variable storage.

#### Variable XRefs

`axt` queried accesses to variables from `sdb_fmt`, but there was no place that actually wrote these accesses there so it was basically a nop. The correct way to query accesses to vars is by using `afv=`.

#### Type propagation

This one is a bit more complicated. This is roughly how the relevant type matching part worked before:

```
foreach f in all functions {
    foreach call to callee in f {
        if callee is a user-defined function {
            sdb_fcns["arg i of callee has type"] = "type coming from f's vars" foreach i in len(callee args)
        } else { ... }
    }
    foreach i where "arg i of f has type" in sdb_fcns {
        f.arg[i].type = sdb_fcns["arg i of f has type"]
    }
}
```

So whenever types should be propagated from a caller into a callee's args, they weren't directly set, but rather temporarily saved by abusing `sdb_fmt` and only later actually applied to the callee. Do not confuse `f` and `callee` above! In the bottom loop, the types for `f` are applied, which are generally not the ones saved in the same loop iteration of the outermost loop.
This had the negative side-effect that some callee's just wouldn't get their args propagated, depending on their position in the list of functions.

I changed it to the more intuitive solution, just applying the types directly:
```
foreach f in all functions {
    foreach call to callee in f {
        if callee is a user-defined function {
            callee.arg[i].type = "type coming from f's vars" foreach i in len(callee args)
        } else { ... }
    }
}
```

This gets rid of the abuse of the global sdb as local temporary variables and fixes the order-dependence mentioned above.
The fixed order-dependence does slightly change the results of a few tests. I checked them in detail and some now have better results, some a bit worse with the worse results being the result of bugs in the backtracking of types and ignoring of pointer derefs and refs, but that part is not touched by this pr so it is overall more correct now.

**tl;dr**: The sdb was abused for local storage, this was fixed by fixing a bug, which affects some tests positively and some slightly negatively, but overall it's better now and definitely more correct.

### Test plan

run the tests