### PR TITLE
Use Ht instead of SDB for pcache ##io

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -118,7 +118,7 @@ typedef struct r_io_desc_t {
 	char *uri;
 	char *name;
 	char *referer;
-	Sdb *cache;
+	HtUP/*<ut64, RIODescCache *>*/ *cache;
 	void *data;
 	struct r_io_plugin_t *plugin;
 	RIO *io;
@@ -422,14 +422,14 @@ R_API bool r_io_cache_write(RIO *io, ut64 addr, const ut8 *buf, int len);
 R_API bool r_io_cache_read(RIO *io, ut64 addr, ut8 *buf, int len);
 
 /* io/p_cache.c */
-R_API bool r_io_desc_cache_init (RIODesc *desc);
-R_API int r_io_desc_cache_write (RIODesc *desc, ut64 paddr, const ut8 *buf, int len);
-R_API int r_io_desc_cache_read (RIODesc *desc, ut64 paddr, ut8 *buf, int len);
-R_API bool r_io_desc_cache_commit (RIODesc *desc);
-R_API void r_io_desc_cache_cleanup (RIODesc *desc);
-R_API void r_io_desc_cache_fini (RIODesc *desc);
-R_API void r_io_desc_cache_fini_all (RIO *io);
-R_API RList *r_io_desc_cache_list (RIODesc *desc);
+R_API bool r_io_desc_cache_init(RIODesc *desc);
+R_API int r_io_desc_cache_write(RIODesc *desc, ut64 paddr, const ut8 *buf, int len);
+R_API int r_io_desc_cache_read(RIODesc *desc, ut64 paddr, ut8 *buf, int len);
+R_API bool r_io_desc_cache_commit(RIODesc *desc);
+R_API void r_io_desc_cache_cleanup(RIODesc *desc);
+R_API void r_io_desc_cache_fini(RIODesc *desc);
+R_API void r_io_desc_cache_fini_all(RIO *io);
+R_API RList *r_io_desc_cache_list(RIODesc *desc);
 R_API int r_io_desc_extend(RIODesc *desc, ut64 size);
 
 /* io/buffer.c */


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

There is absolutely no reason why this should be an sdb when the key is ut64 and the value is a pointer.