### PR TITLE
Rename `asm.var.sub` to `asm.sub.var` ##cons

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3086,7 +3086,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.lines.wide", "false", "Put a space between lines");
 	SETBPREF ("asm.fcnsig", "true", "Show function signature in disasm");
 	SETICB ("asm.lines.width", 7, &cb_asmlineswidth, "Number of columns for program flow arrows");
-	SETICB ("asm.sub.varmin", 0x100, &cb_asmsubvarmin, "Minimum value to substitute in instructions (asm.var.sub)");
+	SETICB ("asm.sub.varmin", 0x100, &cb_asmsubvarmin, "Minimum value to substitute in instructions (asm.sub.var)");
 	SETCB ("asm.sub.tail", "false", &cb_asmsubtail, "Replace addresses with prefix .. syntax");
 	SETBPREF ("asm.middle", "false", "Allow disassembling jumps in the middle of an instruction");
 	SETBPREF ("asm.noisy", "true", "Show comments considered noisy but possibly useful");
@@ -3119,7 +3119,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.capitalize", "false", "Use camelcase at disassembly");
 	SETBPREF ("asm.var", "true", "Show local function variables in disassembly");
 	SETBPREF ("asm.var.access", "false", "Show accesses of local variables");
-	SETBPREF ("asm.var.sub", "true", "Substitute variables in disassembly");
+	SETBPREF ("asm.sub.var", "true", "Substitute variables in disassembly");
 	SETI ("asm.var.summary", 0, "Show variables summary instead of full list in disasm (0, 1, 2)");
 	SETBPREF ("asm.sub.varonly", "true", "Substitute the entire variable expression with the local variable name (e.g. [local10h] instead of [ebp+local10h])");
 	SETBPREF ("asm.sub.reg", "false", "Substitute register names with their associated role name (drp~=)");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1845,7 +1845,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 		} else if (fmt == 'j') {
 			char strsub[128] = { 0 };
 			// pc+33
-			r_parse_varsub (core->parser, NULL,
+			r_parse_subvar (core->parser, NULL,
 				core->offset + idx,
 				asmop.size, r_asm_op_get_asm (&asmop),
 				strsub, sizeof (strsub));
@@ -1868,7 +1868,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			{
 				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, 0);
 				if (fcn) {
-					r_parse_varsub (core->parser, fcn, addr, asmop.size,
+					r_parse_subvar (core->parser, fcn, addr, asmop.size,
 							strsub, strsub, sizeof (strsub));
 				}
 			}
@@ -1995,7 +1995,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			}
 		} else {
 		char disasm[128] = { 0 };
-		r_parse_varsub (core->parser, NULL,
+		r_parse_subvar (core->parser, NULL,
 			core->offset + idx,
 			asmop.size, r_asm_op_get_asm (&asmop),
 			disasm, sizeof (disasm));
@@ -2025,7 +2025,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 			{
 				RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, 0);
 				if (fcn) {
-					r_parse_varsub (core->parser, fcn, addr, asmop.size,
+					r_parse_subvar (core->parser, fcn, addr, asmop.size,
 							disasm, disasm, sizeof (disasm));
 				}
 			}
@@ -7466,7 +7466,7 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	ut8 buf[12];
 	RAsmOp asmop = {0};
 	char *buf_asm = NULL;
-	bool asm_varsub = r_config_get_i (core->config, "asm.var.sub");
+	bool asm_subvar = r_config_get_i (core->config, "asm.sub.var");
 	core->parser->pseudo = r_config_get_i (core->config, "asm.pseudo");
 	core->parser->subrel = r_config_get_i (core->config, "asm.sub.rel");
 	core->parser->localvar_only = r_config_get_i (core->config, "asm.sub.varonly");
@@ -7480,11 +7480,11 @@ static char *get_buf_asm(RCore *core, ut64 from, ut64 addr, RAnalFunction *fcn, 
 	int ba_len = r_strbuf_length (&asmop.buf_asm) + 128;
 	char *ba = malloc (ba_len);
 	strcpy (ba, r_strbuf_get (&asmop.buf_asm));
-	if (asm_varsub) {
+	if (asm_subvar) {
 		core->parser->get_ptr_at = r_anal_function_get_var_stackptr_at;
 		core->parser->get_reg_at = r_anal_function_get_var_reg_at;
 		core->parser->get_op_ireg = get_op_ireg;
-		r_parse_varsub (core->parser, fcn, addr, asmop.size,
+		r_parse_subvar (core->parser, fcn, addr, asmop.size,
 				ba, ba, sizeof (asmop.buf_asm));
 	}
 	RAnalHint *hint = r_anal_hint_get (core->anal, addr);

--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -48,7 +48,7 @@ typedef struct r_parse_plugin_t {
 	int (*parse)(RParse *p, const char *data, char *str);
 	bool (*assemble)(RParse *p, char *data, char *str);
 	int (*filter)(RParse *p, ut64 addr, RFlag *f, char *data, char *str, int len, bool big_endian);
-	bool (*varsub)(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len);
+	bool (*subvar)(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len);
 	int (*replace)(int argc, const char *argv[], char *newstr);
 } RParsePlugin;
 
@@ -67,7 +67,7 @@ R_API bool r_parse_use(RParse *p, const char *name);
 R_API bool r_parse_parse(RParse *p, const char *data, char *str);
 R_API bool r_parse_assemble(RParse *p, char *data, char *str); // XXX deprecate, unused and probably useless, related to write-hack
 R_API bool r_parse_filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, char *str, int len, bool big_endian);
-R_API bool r_parse_varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len);
+R_API bool r_parse_subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len);
 R_API char *r_parse_immtrim(char *opstr);
 
 /* c */

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -325,7 +325,7 @@ static char *mount_oldstr(RParse* p, const char *reg, st64 delta, bool ucase) {
 	return oldstr;
 }
 
-static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
 	RList *spargs = NULL;
 	RList *bpargs = NULL;
 	RListIter *iter;
@@ -442,7 +442,7 @@ RParsePlugin r_parse_plugin_arm_pseudo = {
 	.name = "arm.pseudo",
 	.desc = "ARM/ARM64 pseudo syntax",
 	.parse = parse,
-	.varsub = &varsub,
+	.subvar = &subvar,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/parse/p/parse_mips_pseudo.c
+++ b/libr/parse/p/parse_mips_pseudo.c
@@ -250,7 +250,7 @@ static int parse(RParse *p, const char *data, char *str) {
 	return true;
 }
 
-static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
 	RListIter *iter;
 	char *oldstr;
 	char *tstr = strdup (data);
@@ -372,7 +372,7 @@ RParsePlugin r_parse_plugin_mips_pseudo = {
 	.init = NULL,
 	.fini = NULL,
 	.parse = parse,
-	.varsub = varsub,
+	.subvar = subvar,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/parse/p/parse_wasm_pseudo.c
+++ b/libr/parse/p/parse_wasm_pseudo.c
@@ -20,7 +20,7 @@ static char* get_fcn_name(RAnal *anal, ut32 fcn_id) {
 	return s;
 }
 
-static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
 	char *fcn_name = NULL;
 	str[0] = 0;
 	if (!strncmp (data, "call ", 5)) {
@@ -38,7 +38,7 @@ static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 RParsePlugin r_parse_plugin_wasm_pseudo = {
 	.name = "wasm.pseudo",
 	.desc = "WASM pseudo syntax",
-	.varsub = &varsub,
+	.subvar = &subvar,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/parse/p/parse_x86_pseudo.c
+++ b/libr/parse/p/parse_x86_pseudo.c
@@ -344,7 +344,7 @@ static inline void mk_reg_str(const char *regname, int delta, bool sign, bool at
 	r_strbuf_free (sb);
 }
 
-static bool varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
 	RList *bpargs, *spargs;
 	RAnal *anal = p->analb.anal;
 	RListIter *bpargiter, *spiter;
@@ -550,7 +550,7 @@ RParsePlugin r_parse_plugin_x86_pseudo = {
 	.name = "x86.pseudo",
 	.desc = "X86 pseudo syntax",
 	.parse = &parse,
-	.varsub = &varsub,
+	.subvar = &subvar,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -134,9 +134,9 @@ R_API char *r_parse_immtrim(char *opstr) {
 	return opstr;
 }
 
-R_API bool r_parse_varsub(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
-	if (p->cur && p->cur->varsub) {
-		return p->cur->varsub (p, f, addr, oplen, data, str, len);
+R_API bool r_parse_subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data, char *str, int len) {
+	if (p->cur && p->cur->subvar) {
+		return p->cur->subvar (p, f, addr, oplen, data, str, len);
 	}
 	return false;
 }

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2,9 +2,9 @@ NAME=pd varsub-issue
 FILE=bins/mach0/mac-ls2
 CMDS=<<EOF
 s 0x100001232
-e asm.var.sub=0
+e asm.sub.var=0
 pd 1
-e asm.var.sub=1
+e asm.sub.var=1
 pd 1
 f fin.dus=0x1000054d0
 pd 1
@@ -580,7 +580,7 @@ CMDS=<<EOF
 e anal.vars.stackname=true
 e asm.arch=x86
 e asm.bits=64
-e asm.var.sub=true
+e asm.sub.var=true
 e asm.lines.bb=false
 e asm.bytes=false
 e asm.comments=false
@@ -1883,7 +1883,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=arm asm.var.sub, asm.ucase and asm.pseudo (fp)
+NAME=arm asm.sub.var, asm.ucase and asm.pseudo (fp)
 FILE=bins/elf/analysis/armcall
 CMDS=<<EOF
 e asm.bytes=false
@@ -1893,16 +1893,16 @@ wv4 0xe59b0008 @ 0x00010464
 wv4 0xe59b100c @ 0x00010468
 af @ main
 e asm.pseudo=false
-e asm.var.sub=true
+e asm.sub.var=true
 e asm.ucase=true
 pd 4 @ 0x0001045c
 ?e
-e asm.var.sub=false
+e asm.sub.var=false
 e asm.ucase=false
 pd 4 @ 0x0001045c
 ?e
 e asm.pseudo=true
-e asm.var.sub=true
+e asm.sub.var=true
 e asm.sub.varonly=false
 pd 4 @ 0x0001045c
 ?e

--- a/test/db/formats/elf/mips
+++ b/test/db/formats/elf/mips
@@ -11,7 +11,7 @@ NAME=ELF: mipsbe-ubusd
 FILE=bins/elf/analysis/mipsbe-ubusd
 CMDS=<<EOF
 af
-e asm.var.sub=false
+e asm.sub.var=false
 pif
 EOF
 EXPECT=<<EOF
@@ -40,7 +40,7 @@ NAME=ELF: mipsbe-busybox
 FILE=bins/elf/analysis/mipsbe-busybox
 CMDS=<<EOF
 af
-e asm.var.sub=false
+e asm.sub.var=false
 pif
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

On #17455, it was suggested to rename `asm.var.sub` to `asm.sub.var` for better organization. That is what this PR is hoping to achieve.

Mainly, to do this, I have renamed three things : 
* `r_parse_varsub` to `r_parse_subvar`
*  the bool `asm_varsub` to `asm_subvar`
* the bool `varsub` to `subvar`

**Test plan**

I renamed the tests and tried running it. Files including this particular command were in `cmd/cmd_pd` and `/formats/elf/mips`,which seemed to be doing fine:
```
$ r2r -i test/db/cmd/cmd_pd
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 117 tests.
Skipping json tests because jq is not available.
[117/117]                 117 OK         0 BR        0 XX        0 FX
Finished in 2 seconds.
```
```
$ r2r -i test/db/formats/elf/mips 
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 3 tests.
Skipping json tests because jq is not available.
[3/3]                       3 OK         0 BR        0 XX        0 FX
Finished in 4 seconds.
```

**Closing issues**

Related to #17455 
