### PR TITLE
Fix possible use of dangling pointer due to calling r_anal_pin_fini() followed by r_anal_pin_init()

### DIFF
--- a/libr/anal/pin.c
+++ b/libr/anal/pin.c
@@ -36,7 +36,9 @@ R_API void r_anal_pin_init(RAnal *a) {
 }
 
 R_API void r_anal_pin_fini(RAnal *a) {
-	sdb_free (DB);
+	if (sdb_free (DB)) {
+		DB = NULL;
+	}
 }
 
 R_API void r_anal_pin(RAnal *a, ut64 addr, const char *name) {


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This pr fixes possible use of a dangling pointer in r_anal_pin, when calling r_anal_pin_fini() followed by r_anal_pin_init(), due to sdb_free() being called twice.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

All builds are green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

Probably fixes #17718.
