### PR TITLE
Split GROUP RCmdDesc and regular ones ##newshell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7161,8 +7161,8 @@ R_API void r_core_cmd_init(RCore *core) {
 		case R_CMD_DESC_TYPE_ARGV:
 			cd = r_cmd_desc_argv_new (core->rcmd, root, cmds[i].cmd, cmds[i].argv_cb, cmds[i].help);
 			break;
-		case R_CMD_DESC_TYPE_GROUP:
-			cd = r_cmd_desc_group_new (core->rcmd, root, cmds[i].cmd, cmds[i].help);
+		case R_CMD_DESC_TYPE_INNER:
+			cd = r_cmd_desc_inner_new (core->rcmd, root, cmds[i].cmd, cmds[i].help);
 			break;
 		}
 		if (cmds[i].descriptor_init) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -7085,6 +7085,7 @@ R_API void r_core_cmd_init(RCore *core) {
 		RCmdCb cb;
 		void (*descriptor_init)(RCore *core, RCmdDesc *parent);
 		const RCmdDescHelp *help;
+		const RCmdDescHelp *group_help;
 		RCmdDescType type;
 		RCmdArgvCb argv_cb;
 	} cmds[] = {
@@ -7133,7 +7134,7 @@ R_API void r_core_cmd_init(RCore *core) {
 		{"<",        "pipe into RCons.readChar", cmd_pipein, NULL, &pipein_help},
 		{"V",   "enter visual mode", cmd_visual, NULL, &V_help},
 		{"v",   "enter visual mode", cmd_panels, NULL, &v_help},
-		{"w",    "write bytes", cmd_write, cmd_write_init, &w_help, R_CMD_DESC_TYPE_ARGV, w_handler},
+		{"w",    "write bytes", cmd_write, cmd_write_init, &w_help, &w_group_help, R_CMD_DESC_TYPE_GROUP, w_handler},
 		{"x",        "alias for px", cmd_hexdump, NULL, &x_help},
 		{"y",     "yank bytes", cmd_yank, NULL, &y_help},
 		{"z",     "zignatures", cmd_zign, cmd_zign_init, &z_help},
@@ -7163,6 +7164,9 @@ R_API void r_core_cmd_init(RCore *core) {
 			break;
 		case R_CMD_DESC_TYPE_INNER:
 			cd = r_cmd_desc_inner_new (core->rcmd, root, cmds[i].cmd, cmds[i].help);
+			break;
+		case R_CMD_DESC_TYPE_GROUP:
+			cd = r_cmd_desc_group_new (core->rcmd, root, cmds[i].cmd, cmds[i].argv_cb, cmds[i].help, cmds[i].group_help);
 			break;
 		}
 		if (cmds[i].descriptor_init) {

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -94,7 +94,7 @@ static RCmdDesc *create_cmd_desc(RCmd *cmd, RCmdDesc *parent, RCmdDescType type,
 	res->n_children = 0;
 	res->help = help? help: &not_defined_help;
 	r_pvector_init (&res->children, (RPVectorFree)cmd_desc_free);
-	if (type != R_CMD_DESC_TYPE_GROUP && !ht_pp_insert (cmd->ht_cmds, name, res)) {
+	if (type != R_CMD_DESC_TYPE_INNER && !ht_pp_insert (cmd->ht_cmds, name, res)) {
 		goto err;
 	}
 	cmd_desc_set_parent (res, parent);
@@ -1240,9 +1240,9 @@ R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *nam
 	return res;
 }
 
-R_API RCmdDesc *r_cmd_desc_group_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help) {
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help) {
 	r_return_val_if_fail (cmd && parent && name, NULL);
-	return create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_GROUP, name, help);
+	return create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_INNER, name, help);
 }
 
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb, const RCmdDescHelp *help) {
@@ -1267,7 +1267,7 @@ R_API bool r_cmd_desc_has_handler(RCmdDesc *cd) {
 		return cd->d.argv_data.cb;
 	case R_CMD_DESC_TYPE_OLDINPUT:
 		return cd->d.oldinput_data.cb;
-	case R_CMD_DESC_TYPE_GROUP:
+	case R_CMD_DESC_TYPE_INNER:
 		return false;
 	}
 	return false;

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -405,6 +405,12 @@ R_API RCmdStatus r_cmd_call_parsed_args(RCmd *cmd, RCmdParsedArgs *args) {
 
 	res = R_CMD_STATUS_INVALID;
 	switch (cd->type) {
+	case R_CMD_DESC_TYPE_GROUP:
+		if (!cd->d.group_data.exec_cd) {
+			break;
+		}
+		cd = cd->d.group_data.exec_cd;
+		// fallthrough
 	case R_CMD_DESC_TYPE_ARGV:
 		if (cd->d.argv_data.cb) {
 			res = cd->d.argv_data.cb (cmd->data, args->argc, (const char **)args->argv);

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -81,7 +81,7 @@ static void cmd_desc_free(RCmdDesc *cd) {
 	free (cd);
 }
 
-static RCmdDesc *create_cmd_desc(RCmd *cmd, RCmdDesc *parent, RCmdDescType type, const char *name, const RCmdDescHelp *help) {
+static RCmdDesc *create_cmd_desc(RCmd *cmd, RCmdDesc *parent, RCmdDescType type, const char *name, const RCmdDescHelp *help, bool ht_insert) {
 	RCmdDesc *res = R_NEW0 (RCmdDesc);
 	if (!res) {
 		return NULL;
@@ -94,7 +94,7 @@ static RCmdDesc *create_cmd_desc(RCmd *cmd, RCmdDesc *parent, RCmdDescType type,
 	res->n_children = 0;
 	res->help = help? help: &not_defined_help;
 	r_pvector_init (&res->children, (RPVectorFree)cmd_desc_free);
-	if (type != R_CMD_DESC_TYPE_INNER && !ht_pp_insert (cmd->ht_cmds, name, res)) {
+	if (ht_insert && !ht_pp_insert (cmd->ht_cmds, name, res)) {
 		goto err;
 	}
 	cmd_desc_set_parent (res, parent);
@@ -122,7 +122,7 @@ R_API RCmd *r_cmd_new(void) {
 	}
 	cmd->nullcallback = cmd->data = NULL;
 	cmd->ht_cmds = ht_pp_new0 ();
-	cmd->root_cmd_desc = create_cmd_desc (cmd, NULL, R_CMD_DESC_TYPE_ARGV, "", &root_help);
+	cmd->root_cmd_desc = create_cmd_desc (cmd, NULL, R_CMD_DESC_TYPE_ARGV, "", &root_help, true);
 	r_core_plugin_init (cmd);
 	r_cmd_macro_init (&cmd->macro);
 	r_cmd_alias_init (cmd);
@@ -165,10 +165,21 @@ R_API RCmdDesc *r_cmd_get_desc(RCmd *cmd, const char *cmd_identifier) {
 	// match longer commands first
 	while (*cmdid) {
 		RCmdDesc *cd = ht_pp_find (cmd->ht_cmds, cmdid, NULL);
-		if (cd && (cd->type == R_CMD_DESC_TYPE_OLDINPUT ||
-			(cd->type == R_CMD_DESC_TYPE_ARGV && is_exact_match))) {
-			res = cd;
-			goto out;
+		if (cd) {
+			switch (cd->type) {
+			case R_CMD_DESC_TYPE_ARGV:
+				if (!is_exact_match) {
+					break;
+				}
+				// fallthrough
+			case R_CMD_DESC_TYPE_GROUP:
+				// fallthrough
+			case R_CMD_DESC_TYPE_OLDINPUT:
+				res = cd;
+				goto out;
+			case R_CMD_DESC_TYPE_INNER:
+				break;
+			}
 		}
 		is_exact_match = false;
 		*(--end_cmdid) = '\0';
@@ -452,14 +463,6 @@ static bool show_children_shortcut(RCmdDesc *cd, RCmdDesc *parent) {
 	return (cd != parent && (cd->n_children || cd->help->options)) || cd->type == R_CMD_DESC_TYPE_OLDINPUT;
 }
 
-static bool show_args(RCmdDesc *cd, RCmdDesc *parent) {
-	return (cd->n_children == 0 || cd == parent) && cd->help->args_str;
-}
-
-static bool show_group_args(RCmdDesc *cd, RCmdDesc *parent) {
-	return !show_args (cd, parent) && cd->help->group_args_str;
-}
-
 static void fill_usage_strbuf(RStrBuf *sb, RCmdDesc *cd, bool use_color, RCmdDesc *parent) {
 	RCons *cons = r_cons_singleton ();
 	const char *pal_label_color = use_color? cons->context->pal.label: "",
@@ -477,16 +480,11 @@ static void fill_usage_strbuf(RStrBuf *sb, RCmdDesc *cd, bool use_color, RCmdDes
 			r_strbuf_append (sb, pal_reset);
 			fill_children_chars (sb, cd);
 		}
-		if (show_args (cd, parent)) {
-			const char *cd_args_str = cd->help->args_str? cd->help->args_str: "";
-			r_strbuf_appendf (sb, "%s%s%s", pal_args_color, cd_args_str, pal_reset);
-		} else if (show_group_args (cd, parent)) {
-			r_strbuf_appendf (sb, "%s%s%s", pal_args_color, cd->help->group_args_str, pal_reset);
+		if (R_STR_ISNOTEMPTY (cd->help->args_str)) {
+			r_strbuf_appendf (sb, "%s%s%s", pal_args_color, cd->help->args_str, pal_reset);
 		}
 	}
-	if (cd->help->group_summary) {
-		r_strbuf_appendf (sb, "   %s# %s%s", pal_help_color, cd->help->group_summary, pal_reset);
-	} else if (cd->help->summary) {
+	if (cd->help->summary) {
 		r_strbuf_appendf (sb, "   %s# %s%s", pal_help_color, cd->help->summary, pal_reset);
 	}
 	r_strbuf_append (sb, "\n");
@@ -503,10 +501,8 @@ static size_t calc_padding_len(RCmdDesc *cd, RCmdDesc *parent) {
 		children_length += r_strbuf_length (&sb);
 		r_strbuf_fini (&sb);
 	}
-	if (show_args (cd, parent)) {
+	if (R_STR_ISNOTEMPTY (cd->help->args_str)) {
 		args_len = strlen0 (cd->help->args_str);
-	} else if (show_group_args (cd, parent)) {
-		args_len = strlen0 (cd->help->group_args_str);
 	}
 	return name_len + args_len + children_length;
 }
@@ -533,32 +529,24 @@ static void print_child_help(RStrBuf *sb, RCmdDesc *cd, size_t max_len, bool use
 		r_strbuf_append (sb, pal_opt_color);
 		fill_children_chars (sb, cd);
 	}
-	if (show_args (cd, parent)) {
+	if (R_STR_ISNOTEMPTY (cd->help->args_str)) {
 		r_strbuf_appendf (sb, "%s%s", pal_args_color, cd->help->args_str);
-	} else if (show_group_args (cd, parent)) {
-		r_strbuf_appendf (sb, "%s%s", pal_args_color, cd->help->group_args_str);
 	}
 	r_strbuf_appendf (sb, " %*s%s# %s%s\n", padding, "", pal_help_color, cd_summary, pal_reset);
 }
 
-static char *inner_get_help(RCmd *cmd, RCmdDesc *cd, bool use_color) {
+static char *argv_group_get_help(RCmd *cmd, RCmdDesc *cd, bool use_color) {
 	RStrBuf *sb = r_strbuf_new (NULL);
 	fill_usage_strbuf (sb, cd, use_color, cd->parent);
 
 	void **it_cd;
 	size_t max_len = 0;
 
-	if (cd->d.argv_data.cb) {
-		max_len = update_max_len (cd, max_len, cd);
-	}
 	r_cmd_desc_children_foreach (cd, it_cd) {
 		RCmdDesc *child = *(RCmdDesc **)it_cd;
 		max_len = update_max_len (child, max_len, cd);
 	}
 
-	if (cd->d.argv_data.cb) {
-		print_child_help (sb, cd, max_len, use_color, cd);
-	}
 	r_cmd_desc_children_foreach (cd, it_cd) {
 		RCmdDesc *child = *(RCmdDesc **)it_cd;
 		print_child_help (sb, child, max_len, use_color, cd);
@@ -636,20 +624,26 @@ R_API char *r_cmd_get_help(RCmd *cmd, RCmdParsedArgs *args, bool use_color) {
 	}
 
 	switch (cd->type) {
+	case R_CMD_DESC_TYPE_GROUP:
+		if (detail > 1 && cd->d.group_data.exec_cd) {
+			cd = cd->d.group_data.exec_cd;
+		}
+		// fallthrough
 	case R_CMD_DESC_TYPE_ARGV:
 		if (detail == 1 && !r_pvector_empty (&cd->children)) {
 			if (args->argc > 1) {
 				return NULL;
 			}
-			return inner_get_help (cmd, cd, use_color);
+			return argv_group_get_help (cmd, cd, use_color);
 		}
 		return argv_get_help (cmd, cd, args, detail, use_color);
 	case R_CMD_DESC_TYPE_OLDINPUT:
 		return oldinput_get_help (cmd, cd, args);
-	default:
+	case R_CMD_DESC_TYPE_INNER:
 		r_warn_if_reached ();
 		return NULL;
 	}
+	return NULL;
 }
 
 /** macro.c **/
@@ -1229,9 +1223,8 @@ R_API const char *r_cmd_parsed_args_cmd(RCmdParsedArgs *a) {
 
 /* RCmdDescriptor */
 
-R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help) {
-	r_return_val_if_fail (cmd && parent && name, NULL);
-	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_ARGV, name, help);
+static RCmdDesc *argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help, bool ht_insert) {
+	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_ARGV, name, help, ht_insert);
 	if (!res) {
 		return NULL;
 	}
@@ -1240,14 +1233,39 @@ R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *nam
 	return res;
 }
 
+R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help) {
+	r_return_val_if_fail (cmd && parent && name, NULL);
+	return argv_new (cmd, parent, name, cb, help, true);
+}
+
 R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help) {
 	r_return_val_if_fail (cmd && parent && name, NULL);
-	return create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_INNER, name, help);
+	return create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_INNER, name, help, false);
+}
+
+R_API RCmdDesc *r_cmd_desc_group_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help, const RCmdDescHelp *group_help) {
+	r_return_val_if_fail (cmd && parent && name, NULL);
+	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_GROUP, name, group_help, true);
+	if (!res) {
+		return NULL;
+	}
+
+	RCmdDesc *exec_cd = NULL;
+	if (cb && help) {
+		exec_cd = argv_new (cmd, res, name, cb, help, false);
+		if (!exec_cd) {
+			r_cmd_desc_remove (cmd, res);
+			return NULL;
+		}
+	}
+
+	res->d.group_data.exec_cd = exec_cd;
+	return res;
 }
 
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb, const RCmdDescHelp *help) {
 	r_return_val_if_fail (cmd && parent && name && cb, NULL);
-	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_OLDINPUT, name, help);
+	RCmdDesc *res = create_cmd_desc (cmd, parent, R_CMD_DESC_TYPE_OLDINPUT, name, help, true);
 	if (!res) {
 		return NULL;
 	}
@@ -1269,6 +1287,8 @@ R_API bool r_cmd_desc_has_handler(RCmdDesc *cd) {
 		return cd->d.oldinput_data.cb;
 	case R_CMD_DESC_TYPE_INNER:
 		return false;
+	case R_CMD_DESC_TYPE_GROUP:
+		return cd->d.group_data.exec_cd && r_cmd_desc_has_handler (cd->d.group_data.exec_cd);
 	}
 	return false;
 }

--- a/libr/core/cmd_helps.c
+++ b/libr/core/cmd_helps.c
@@ -177,10 +177,13 @@ const RCmdDescHelp v_help = {
 	.summary = "enter visual panels mode",
 };
 
+const RCmdDescHelp w_group_help = {
+	.summary = "write commands",
+};
+
 const RCmdDescHelp w_help = {
 	.args_str = " <string>",
 	.summary = "write string",
-	.group_summary = "write commands",
 };
 
 const RCmdDescHelp x_help = {
@@ -215,7 +218,7 @@ const RCmdDescExample w_incdec_help_examples[] = {
 
 const RCmdDescHelp w_incdec_help = {
 	.summary = "increment/decrement byte,word..",
-	.group_args_str = " [n]",
+	.args_str = " [n]",
 	.options = "<1248><+->",
 };
 
@@ -314,11 +317,14 @@ const RCmdDescExample wB_help_examples[] = {
 	{ 0 },
 };
 
+const RCmdDescHelp wB_group_help = {
+	.args_str = " [value]",
+	.summary = "Set or unset bits with given value",
+};
+
 const RCmdDescHelp wB_help = {
 	.summary = "Set bits with given value",
 	.args_str = " [value]",
-	.group_args_str = " [value]",
-	.group_summary = "Set or unset bits with given value",
 	.description = "Set the bits that are set in the value passed as arguments. 0 bits in the value argument are ignored, while the others are set at the current offset",
 	.examples = wB_help_examples,
 };
@@ -336,13 +342,15 @@ const RCmdDescExample wv_help_examples[] = {
 	{ 0 },
 };
 
+const RCmdDescHelp wv_group_help = {
+	.args_str = " [value]",
+	.summary = "Write value of given size",
+};
+
 const RCmdDescHelp wv_help = {
 	.summary = "Write value as 4 - bytes / 8 - bytes based on value",
-	.options = "[size]",
 	.args_str = " [value]",
-	.group_args_str = " [value]",
 	.description = "Write the number passed as argument at the current offset as a 4 - bytes value or 8 - bytes value if the input is bigger than UT32_MAX, respecting the cfg.bigendian variable",
-	.group_summary = "Write value of given size",
 	.examples = wv_help_examples,
 };
 

--- a/libr/core/cmd_helps.h
+++ b/libr/core/cmd_helps.h
@@ -48,6 +48,7 @@ extern const RCmdDescHelp pipein_help;
 extern const RCmdDescHelp V_help;
 extern const RCmdDescHelp v_help;
 extern const RCmdDescHelp w_help;
+extern const RCmdDescHelp w_group_help;
 extern const RCmdDescHelp x_help;
 extern const RCmdDescHelp y_help;
 extern const RCmdDescHelp z_help;
@@ -74,11 +75,13 @@ extern const RCmdDescHelp w8_dec_help;
 
 // wB helps
 
+extern const RCmdDescHelp wB_group_help;
 extern const RCmdDescHelp wB_help;
 extern const RCmdDescHelp wB_minus_help;
 
 // wv helps
 
+extern const RCmdDescHelp wv_group_help;
 extern const RCmdDescHelp wv_help;
 extern const RCmdDescHelp wv1_help;
 extern const RCmdDescHelp wv2_help;

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -2086,7 +2086,7 @@ static void cmd_write_init(RCore *core, RCmdDesc *parent) {
 
 	DEFINE_CMD_ARGV_DESC (core, w0, parent);
 
-	DEFINE_CMD_ARGV_DESC_GROUP (core, w, w_incdec, parent);
+	DEFINE_CMD_ARGV_DESC_INNER (core, w, w_incdec, parent);
 	DEFINE_CMD_ARGV_DESC_DETAIL (core, w1, w1, w_incdec_cd, NULL, &w1_incdec_help);
 	DEFINE_CMD_ARGV_DESC_DETAIL (core, w1+, w1_inc, w1_cd, w1_incdec_handler, &w1_inc_help);
 	DEFINE_CMD_ARGV_DESC_DETAIL (core, w1-, w1_dec, w1_cd, w1_incdec_handler, &w1_dec_help);

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -2075,10 +2075,10 @@ static void cmd_write_init(RCore *core, RCmdDesc *parent) {
 	DEFINE_CMD_DESCRIPTOR (core, wv);
 	DEFINE_CMD_DESCRIPTOR (core, wx);
 
-	DEFINE_CMD_ARGV_DESC (core, wB, parent);
+	DEFINE_CMD_ARGV_GROUP_WITH_CHILD (core, wB, parent);
 	DEFINE_CMD_ARGV_DESC_SPECIAL (core, wB-, wB_minus, wB_cd);
 
-	DEFINE_CMD_ARGV_DESC (core, wv, parent);
+	DEFINE_CMD_ARGV_GROUP_WITH_CHILD (core, wv, parent);
 	DEFINE_CMD_ARGV_DESC (core, wv1, wv_cd);
 	DEFINE_CMD_ARGV_DESC (core, wv2, wv_cd);
 	DEFINE_CMD_ARGV_DESC (core, wv4, wv_cd);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -124,25 +124,6 @@ typedef struct r_cmd_desc_help_t {
 	 */
 	const char *options;
 	/**
-	 * When a command is used both as a parent command and as a subcommand
-	 * (e.g. `w` is both the parent of `wv`, `ws`, etc. and it's also the
-	 * command `w`), this is the summary used for the parent level, while
-	 * summary becomes the text used for the subcommand.
-	 *
-	 * Optional.
-	 */
-	const char *group_summary;
-	/**
-	 * When a command is used both as a parent command and as a subcommand
-	 * (e.g. `w` is both the parent of `wv`, `ws`, etc. and it's also the
-	 * command `w`), this is the argument string used for the parent level,
-	 * while args_str becomes the text used for the subcommand.
-	 *
-	 * Optional.
-	 * TODO: explain how to differentiate between required and optional arguments
-	 */
-	const char *group_args_str;
-	/**
 	 * List of examples used to better explain how to use the command. This
 	 * is shown together with the long description.
 	 *
@@ -162,6 +143,11 @@ typedef enum {
 	// stored in the hashtable and cannot be retrieved except by listing the
 	// children of its parent.
 	R_CMD_DESC_TYPE_INNER,
+	// for cmd descriptors that are parent of other sub-commands but that
+	// may also have a sub-command with the same name. For example, `wc` is
+	// both the parent of `wci`, `wc*`, etc. but there is also `wc` as a
+	// sub-command.
+	R_CMD_DESC_TYPE_GROUP,
 } RCmdDescType;
 
 typedef struct r_cmd_desc_t {
@@ -179,6 +165,9 @@ typedef struct r_cmd_desc_t {
 		struct {
 			RCmdArgvCb cb;
 		} argv_data;
+		struct {
+			struct r_cmd_desc_t *exec_cd;
+		} group_data;
 	} d;
 } RCmdDesc;
 
@@ -225,6 +214,9 @@ typedef struct r_core_plugin_t {
 #define DEFINE_CMD_ARGV_DESC_INNER(core, name, c_name, parent) \
 	RCmdDesc *c_name##_cd = r_cmd_desc_inner_new (core->rcmd, parent, #name, &c_name##_help); \
 	r_warn_if_fail (c_name##_cd)
+#define DEFINE_CMD_ARGV_GROUP_WITH_CHILD(core, name, parent)                                    \
+	RCmdDesc *name##_cd = r_cmd_desc_group_new (core->rcmd, parent, #name, name##_handler, &name##_help, &name##_group_help); \
+	r_warn_if_fail (name##_cd)
 #define DEFINE_CMD_ARGV_DESC(core, name, parent) \
 	DEFINE_CMD_ARGV_DESC_SPECIAL (core, name, name, parent)
 #define DEFINE_CMD_OLDINPUT_DESC(core, name, parent) \
@@ -275,6 +267,7 @@ static inline int r_cmd_status2int(RCmdStatus s) {
 /* RCmdDescriptor */
 R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help);
 R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help);
+R_API RCmdDesc *r_cmd_desc_group_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help, const RCmdDescHelp *group_help);
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb, const RCmdDescHelp *help);
 R_API RCmdDesc *r_cmd_desc_parent(RCmdDesc *cd);
 R_API bool r_cmd_desc_has_handler(RCmdDesc *cd);

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -158,8 +158,10 @@ typedef enum {
 	R_CMD_DESC_TYPE_ARGV,
 	// for cmd descriptors that are just used to group together related
 	// sub-commands. Do not use this if the command can be used by itself or
-	// if it's necessary to show its help.
-	R_CMD_DESC_TYPE_GROUP,
+	// if it's necessary to show its help, because this descriptor is not
+	// stored in the hashtable and cannot be retrieved except by listing the
+	// children of its parent.
+	R_CMD_DESC_TYPE_INNER,
 } RCmdDescType;
 
 typedef struct r_cmd_desc_t {
@@ -220,8 +222,8 @@ typedef struct r_core_plugin_t {
 	r_warn_if_fail (c_name##_cd)
 #define DEFINE_CMD_ARGV_DESC_SPECIAL(core, name, c_name, parent) \
 	DEFINE_CMD_ARGV_DESC_DETAIL (core, name, c_name, parent, c_name##_handler, &c_name##_help)
-#define DEFINE_CMD_ARGV_DESC_GROUP(core, name, c_name, parent) \
-	RCmdDesc *c_name##_cd = r_cmd_desc_group_new (core->rcmd, parent, #name, &c_name##_help); \
+#define DEFINE_CMD_ARGV_DESC_INNER(core, name, c_name, parent) \
+	RCmdDesc *c_name##_cd = r_cmd_desc_inner_new (core->rcmd, parent, #name, &c_name##_help); \
 	r_warn_if_fail (c_name##_cd)
 #define DEFINE_CMD_ARGV_DESC(core, name, parent) \
 	DEFINE_CMD_ARGV_DESC_SPECIAL (core, name, name, parent)
@@ -272,7 +274,7 @@ static inline int r_cmd_status2int(RCmdStatus s) {
 
 /* RCmdDescriptor */
 R_API RCmdDesc *r_cmd_desc_argv_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdArgvCb cb, const RCmdDescHelp *help);
-R_API RCmdDesc *r_cmd_desc_group_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help);
+R_API RCmdDesc *r_cmd_desc_inner_new(RCmd *cmd, RCmdDesc *parent, const char *name, const RCmdDescHelp *help);
 R_API RCmdDesc *r_cmd_desc_oldinput_new(RCmd *cmd, RCmdDesc *parent, const char *name, RCmdCb cb, const RCmdDescHelp *help);
 R_API RCmdDesc *r_cmd_desc_parent(RCmdDesc *cd);
 R_API bool r_cmd_desc_has_handler(RCmdDesc *cd);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Some background:
when you do `a` as a command can mean 2 things: 1) `alias for aai - analysis information` 2) the group which includes all analysis information. In the help, you see them in 2 places: when you do `?` you will see `| a[?]                    analysis commands`, when you do `a?`, you will see `Usage: a     analysis commands` and then one line below `| a                  alias for aai - analysis information`.

As you can see, the same string can reference two different "concepts" in the help. Before this PR, we had merged the help strings in one single structure, however most of the other commands did not use those additional fields (group_summary, group_args_str) and they required special handling in the cmd_api code.

This PR splits the two concepts, instead of keeping everything in one single RCmdDesc. The R_CMD_DESC_TYPE_GROUP will hold the information about the "group" (e.g. "analysis commands" group), while the `d.group_data.exec_cd` will hold the info about the actual command that execute something (e.g. `alias for aai - analysis information`). This makes the code easier and the RCmdDescHelp structure easier to explain, I think. 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Play with the help and `e cfg.newshell=true`.
