### PR TITLE
Do not free ds->opstr after r_parse_immtrim

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1051,7 +1051,6 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 	if (ds->immtrim) {
 		char *res = r_parse_immtrim (ds->opstr);
 		if (res) {
-			free (ds->opstr);
 			ds->opstr = res;
 		}
 		return;

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2217,6 +2217,7 @@ RUN
 NAME=asm.imm.trim
 FILE=bins/elf/crackme0x05
 CMDS=<<EOF
+s 0x080483d5
 pi 1 @e:asm.imm.trim=false
 pi 1 @e:asm.imm.trim=true
 EOF

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2223,6 +2223,6 @@ pi 1 @e:asm.imm.trim=true
 EOF
 EXPECT=<<EOF
 and esp, 0xfffffff0
-and esp,
+and esp, 
 EOF
 RUN

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2213,3 +2213,15 @@ EXPECT=<<EOF
 66: parell (char *s);
 EOF
 RUN
+
+NAME=asm.imm.trim
+FILE=bins/elf/crackme0x05
+CMDS=<<EOF
+pi 1 @e:asm.imm.trim=false
+pi 1 @e:asm.imm.trim=true
+EOF
+EXPECT=<<EOF
+and esp, 0xfffffff0
+and esp,
+EOF
+RUN


### PR DESCRIPTION
There is no new allocation in r_parse_immtrim, so it is not required to
free the "previous" string.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

r_parse_immtrim just moves bytes but it does not allocate a new string, so the free is wrong.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Run `e asm.imm.trim=true; pd 10` and you will get a double free.
