### PR TITLE
Fix format-security build warning ##bin (#17730)

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -35,7 +35,7 @@ static ut64 read_uleb128(ut8 **p, ut8 *end) {
 	ut64 v;
 	*p = (ut8 *)r_uleb128 (*p, end - *p, &v, &error);
 	if (error) {
-		eprintf (error);
+		eprintf ("%s", error);
 		R_FREE (error);
 		return UT64_MAX;
 	}


### PR DESCRIPTION
**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

#17489 introduced a string format security build warning, by calling `eprintf()` with the reuslt of `r_str_newf()`, `error`. This PR is fixing this warning by calling `eprintf()` with `error` as an argument to `"%s"`, a format string, [as suggested](https://fedoraproject.org/wiki/Format-Security-FAQ#How_do_I_fix_these_errors.3F).

**Test plan**

None

**Closing issues**

Closes #17730