### PR TITLE
Unwrap quoted strings when passing args to newer handlers ##newshell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4830,28 +4830,42 @@ static void handle_substitution_args(struct tsr2cmd_state *state, TSNode args, R
 	}
 }
 
-static char *unescape_arg(struct tsr2cmd_state *state, TSNode arg, const char *special_chars) {
-	char *arg_str = ts_node_sub_string (arg, state->input);
+static char *unescape_arg_str(struct tsr2cmd_state *state, const char *arg_str, const char *special_chars) {
 	char *unescaped_arg = unescape_special_chars (arg_str, special_chars);
 	R_LOG_DEBUG ("original arg = '%s', unescaped arg = '%s'\n", arg_str, unescaped_arg);
+	return unescaped_arg;
+}
+
+static char *unescape_arg(struct tsr2cmd_state *state, TSNode arg, const char *special_chars) {
+	char *arg_str = ts_node_sub_string (arg, state->input);
+	char *unescaped_arg = unescape_arg_str (state, arg_str, special_chars);
 	free (arg_str);
 	return unescaped_arg;
 }
 
-static char *do_handle_ts_unescape_arg(struct tsr2cmd_state *state, TSNode arg) {
+static char *do_handle_ts_unescape_arg(struct tsr2cmd_state *state, TSNode arg, bool do_unwrap) {
 	if (is_ts_arg (arg)) {
-		return do_handle_ts_unescape_arg (state, ts_node_named_child (arg, 0));
+		return do_handle_ts_unescape_arg (state, ts_node_named_child (arg, 0), do_unwrap);
 	} else if (is_ts_arg_identifier (arg)) {
 		return unescape_arg (state, arg, SPECIAL_CHARS_REGULAR);
 	} else if (is_ts_single_quoted_arg (arg) || is_ts_double_quoted_arg (arg)) {
 		const char *special = is_ts_single_quoted_arg (arg)? SPECIAL_CHARS_SINGLE_QUOTED: SPECIAL_CHARS_DOUBLE_QUOTED;
-		return unescape_arg (state, arg, special);
+		char *o_arg_str = ts_node_sub_string (arg, state->input);
+		char *arg_str = o_arg_str;
+		if (do_unwrap) {
+			// remove quotes
+			arg_str[strlen (arg_str) - 1] = '\0';
+			arg_str++;
+		}
+		char *res = unescape_arg_str (state, arg_str, special);
+		free (o_arg_str);
+		return res;
 	} else if (is_ts_concatenation (arg)) {
 		uint32_t i, n_children = ts_node_named_child_count (arg);
 		RStrBuf *sb = r_strbuf_new (NULL);
 		for (i = 0; i < n_children; i++) {
 			TSNode sub_arg = ts_node_named_child (arg, i);
-			char *s = do_handle_ts_unescape_arg (state, sub_arg);
+			char *s = do_handle_ts_unescape_arg (state, sub_arg, do_unwrap);
 			r_strbuf_append (sb, s);
 		}
 		return r_strbuf_drain (sb);
@@ -4860,7 +4874,7 @@ static char *do_handle_ts_unescape_arg(struct tsr2cmd_state *state, TSNode arg) 
 	}
 }
 
-static RCmdParsedArgs *parse_args(struct tsr2cmd_state *state, TSNode args) {
+static RCmdParsedArgs *parse_args(struct tsr2cmd_state *state, TSNode args, bool do_unwrap) {
 	if (ts_node_is_null (args)) {
 		return r_cmd_parsed_args_newargs (0, NULL);
 	} else if (is_ts_args (args)) {
@@ -4869,7 +4883,7 @@ static RCmdParsedArgs *parse_args(struct tsr2cmd_state *state, TSNode args) {
 		char **unescaped_args = R_NEWS0 (char *, n_children);
 		for (i = 0; i < n_children; i++) {
 			TSNode arg = ts_node_named_child (args, i);
-			unescaped_args[i] = do_handle_ts_unescape_arg (state, arg);
+			unescaped_args[i] = do_handle_ts_unescape_arg (state, arg, do_unwrap);
 		}
 		RCmdParsedArgs *res = r_cmd_parsed_args_newargs (n_children, unescaped_args);
 		for (i = 0; i < n_children; i++) {
@@ -4878,7 +4892,7 @@ static RCmdParsedArgs *parse_args(struct tsr2cmd_state *state, TSNode args) {
 		free (unescaped_args);
 		return res;
 	} else {
-		char *unescaped_args[] = { do_handle_ts_unescape_arg (state, args) };
+		char *unescaped_args[] = { do_handle_ts_unescape_arg (state, args, do_unwrap) };
 		RCmdParsedArgs *res = r_cmd_parsed_args_newargs (1, unescaped_args);
 		free (unescaped_args[0]);
 		return res;
@@ -4947,7 +4961,7 @@ static bool substitute_args(struct tsr2cmd_state *state, TSNode args, TSNode *ne
 	return res;
 }
 
-static RCmdParsedArgs *ts_node_handle_arg_prargs(struct tsr2cmd_state *state, TSNode command, TSNode arg, uint32_t child_idx) {
+static RCmdParsedArgs *ts_node_handle_arg_prargs(struct tsr2cmd_state *state, TSNode command, TSNode arg, uint32_t child_idx, bool do_unwrap) {
 	RCmdParsedArgs *res = NULL;
 	TSNode new_command;
 	substitute_args_init (state, command);
@@ -4958,7 +4972,7 @@ static RCmdParsedArgs *ts_node_handle_arg_prargs(struct tsr2cmd_state *state, TS
 	}
 
 	arg = ts_node_named_child (new_command, child_idx);
-	res = parse_args (state, arg);
+	res = parse_args (state, arg, do_unwrap);
 	if (res == NULL) {
 		R_LOG_ERROR ("Cannot parse arg\n");
 		goto err;
@@ -4969,7 +4983,7 @@ err:
 }
 
 static char *ts_node_handle_arg(struct tsr2cmd_state *state, TSNode command, TSNode arg, uint32_t child_idx) {
-	RCmdParsedArgs *a = ts_node_handle_arg_prargs (state, command, arg, child_idx);
+	RCmdParsedArgs *a = ts_node_handle_arg_prargs (state, command, arg, child_idx, true);
 	char *str = r_cmd_parsed_args_argstr (a);
 	r_cmd_parsed_args_free (a);
 	return str;
@@ -4997,7 +5011,9 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(arged_command) {
 
 	RCmdParsedArgs *pr_args = NULL;
 	if (!ts_node_is_null (args)) {
-		pr_args = ts_node_handle_arg_prargs (state, node, args, 1);
+		RCmdDesc *cd = r_cmd_get_desc (state->core->rcmd, command_str);
+		bool do_unwrap = cd && cd->type != R_CMD_DESC_TYPE_OLDINPUT;
+		pr_args = ts_node_handle_arg_prargs (state, node, args, 1, do_unwrap);
 		if (!pr_args) {
 			goto err;
 		}
@@ -5186,7 +5202,9 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(help_command) {
 		RCmdParsedArgs *pr_args = NULL;
 		RCmdStatus res = R_CMD_STATUS_INVALID;
 		if (!ts_node_is_null (args)) {
-			pr_args = ts_node_handle_arg_prargs (state, node, args, 1);
+			RCmdDesc *cd = r_cmd_get_desc (state->core->rcmd, command_str);
+			bool do_unwrap = cd && cd->type != R_CMD_DESC_TYPE_OLDINPUT;
+			pr_args = ts_node_handle_arg_prargs (state, node, args, 1, do_unwrap);
 			if (!pr_args) {
 				goto err_else;
 			}
@@ -5722,7 +5740,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_offsets_command) {
 	TSNode args = ts_node_named_child (node, 1);
 	ut64 orig_offset = core->offset;
 
-	RCmdParsedArgs *a = ts_node_handle_arg_prargs (state, node, args, 1);
+	RCmdParsedArgs *a = ts_node_handle_arg_prargs (state, node, args, 1, true);
 	if (!a) {
 		R_LOG_ERROR ("Cannot parse args\n");
 		return R_CMD_STATUS_INVALID;
@@ -5983,7 +6001,7 @@ DEFINE_HANDLE_TS_FCN_AND_SYMBOL(iter_interpret_command) {
 	}
 	TSNode args = ts_node_named_child (new_command, 1);
 
-	RCmdParsedArgs *a = parse_args (state, args);
+	RCmdParsedArgs *a = parse_args (state, args, true);
 	if (!a) {
 		r_list_free (edits);
 		substitute_args_fini (state);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1168,6 +1168,9 @@ R_API int r_str_unescape(char *buf) {
 			buf[i] = (ch << 4) + ch2;
 			esc_seq_len = 4;
 			break;
+		case '$':
+			buf[i] = '$';
+			break;
 		default:
 			if (IS_OCTAL (buf[i + 1])) {
 				int num_digits = 1;

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -1310,10 +1310,24 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pdJ string
+NAME=pdJ string - oldshell
+ARGS=-ecfg.newshell=false
 FILE=malloc://128
 CMDS=<<EOF
 w Snoo"ping as" usual,
+Cs 30
+pdJ 1
+EOF
+EXPECT=<<EOF
+[{"offset":0,"text":"            0x00000000     .string \"Snoo\\\"ping as\\\" usual,\" ; len=30"}]
+EOF
+RUN
+
+NAME=pdJ string - newshell
+ARGS=-ecfg.newshell=true
+FILE=malloc://128
+CMDS=<<EOF
+w "Snoo\"ping as\" usual,"
 Cs 30
 pdJ 1
 EOF

--- a/test/db/cmd/feat_quote
+++ b/test/db/cmd/feat_quote
@@ -1,0 +1,72 @@
+NAME=Double quotes - newshell
+ARGS=-e cfg.newshell=true
+FILE=-
+CMDS=<<EOF
+w "Hello World"
+ps
+w0 15
+w "\"Hello World\""
+ps
+w0 15
+w "Hello;World"
+ps
+w0 15
+w "Hello@World"
+ps
+EOF
+EXPECT=<<EOF
+Hello World
+"Hello World"
+Hello;World
+Hello@World
+EOF
+RUN
+
+NAME=Single quotes - newshell
+ARGS=-e cfg.newshell=true
+FILE=-
+CMDS=<<EOF
+w 'Hello World'
+ps
+w0 15
+w '"Hello World"'
+ps
+w0 15
+w '\'Hello World\''
+ps
+w0 15
+w 'Hello;World'
+ps
+w0 15
+w 'Hello@World'
+ps
+EOF
+EXPECT=<<EOF
+Hello World
+"Hello World"
+'Hello World'
+Hello;World
+Hello@World
+EOF
+RUN
+
+NAME=Quotes and substitution - newshell
+ARGS=-e cfg.newshell=true
+FILE=-
+CMDS=<<EOF
+w "Hello $(?e World)"
+ps
+w0 15
+w 'Hello $(?e World)'
+ps
+w0 15
+w "Hello \$(?e World)"
+ps
+w0 15
+EOF
+EXPECT=<<EOF
+Hello World
+Hello $(?e World)
+Hello $(?e World)
+EOF
+RUN

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -29,11 +29,30 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME="/e /t\wst\d\d\d\s\w\w/i"
+NAME="/e /t\wst\d\d\d\s\w\w/i" - oldshell
+ARGS=-ecfg.newshell=false
 FILE=malloc://1024
 CMDS=<<EOF
 w "test123 ab"
 w "Test123 ab" @444
+?e
+e search.in=block
+b 777
+"/e /t\wst\d\d\d\s\w\w/i"
+EOF
+EXPECT=<<EOF
+
+0x00000001 hit0_0 ""test123 ab""
+0x000001bd hit0_1 ""Test123 ab""
+EOF
+RUN
+
+NAME="/e /t\wst\d\d\d\s\w\w/i" - newshell
+ARGS=-ecfg.newshell=true
+FILE=malloc://1024
+CMDS=<<EOF
+w '"test123 ab"'
+w '"Test123 ab"' @444
 ?e
 e search.in=block
 b 777

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -42,11 +42,6 @@ b 777
 EOF
 EXPECT=<<EOF
 
-0x00000001 hit0_0 ""test123 ab""
-0x000001bd hit0_1 ""Test123 ab""
-EOF
-RUN
-
 NAME="/e /t\wst\d\d\d\s\w\w/i" - newshell
 ARGS=-ecfg.newshell=true
 FILE=malloc://1024

--- a/test/db/cmd/regexp
+++ b/test/db/cmd/regexp
@@ -42,6 +42,11 @@ b 777
 EOF
 EXPECT=<<EOF
 
+0x00000001 hit0_0 ""test123 ab""
+0x000001bd hit0_1 ""Test123 ab""
+EOF
+RUN
+
 NAME="/e /t\wst\d\d\d\s\w\w/i" - newshell
 ARGS=-ecfg.newshell=true
 FILE=malloc://1024


### PR DESCRIPTION
When a user wraps an argument, it means like in SH that he wants the
command to consider the argument as one single arg, even if composed by
multiple words. The same applies for r2newshell. So far we did not
unwrap quoted strings to maintain compatibility with old shell, but
doing this unwrapping is one of the nice feature of newshell.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

When using old shell,
```
w Hello   World
```
would write to file the string 
```
Hello   World
```
because it simply takes as argument whatever is found after `w `. However, with `cfg.newshell=true`, arguments are parsed and split by the parser itself, which is not aware of how each command handlers wants to parse its arguments. To be generic, it splits arguments by space, but if a user wants to pass multiple words as a single argument, he can do that in the same way he is used to do that in bash/sh, by wrapping things in `"..."` or `'...'`.

When wrapping strings in quotes, the command should just get the quoted string without the quotes, because those quotes were just a mean to tell the parser the string had to be considered as a single argument. So far however we also passed the quotes to the command handlers, because this way we were compatible with existing handlers, which do the parsing themselves. So if you did:
```
e cfg.newshell=true
w "Hello   World"
```
the `w` handler would get the string
```
"Hello   World"
```
which is not what we wanted. This PR removes the quotes when the command handler is not an old one, which does the parsing by itself.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Try writing things like `Hello;World` with the `w` command.
With oldshell, you had to quote the entire command, which was counter-intuitive and different from anything the user is usually used to.
With newshell you should be able to just do `w "Hello;World"`.