### PR TITLE
Do not enforce A0 to be present as it is missing from many arch

### DIFF
--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -410,9 +410,12 @@ R_API char *r_reg_profile_to_cc(RReg *reg) {
 	const char *a2 = r_reg_get_name_by_type (reg, "A2");
 	const char *a3 = r_reg_get_name_by_type (reg, "A3");
 
-	// it is mandatory to have at least =A0 defined in the reg profile
+	// TODO: it is mandatory to have at least =A0 defined in the reg profile
 	// this will be enforced in reg/profile at parsing time
-	r_return_val_if_fail (a0, NULL);
+	// r_return_val_if_fail (a0, NULL);
+	if (!a0) {
+		return NULL;
+	}
 	if (!r0) {
 		r0 = a0;
 	}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Although it should be like that, A0 is missing from many architectures and until that is properly implemented in all architectures we cannot keep this warning (`WARNING: r_reg_profile_to_cc: assertion 'a0' failed (line 415)`) everywhere.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

asan should be green.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
