### PR TITLE
Reading proc fields may be racy

### DIFF
--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -564,6 +564,10 @@ R_API R2RSubprocess *r2r_subprocess_start(
 		close (stderr_pipe[1]);
 		close (stderr_pipe[0]);
 
+		int fd;
+		for (fd = 3; fd < 2048; fd++) {
+			close (fd);
+		}
 		size_t i;
 		for (i = 0; i < env_size; i++) {
 			setenv (envvars[i], envvals[i], 1);


### PR DESCRIPTION
This tries to fix the several hangs we see in CI when running r2r json
tests. By running valgrind helgrind tool, you see:

```
==228548==  Lock at 0x4CE1080 was first observed
==228548==    at 0x484299B: pthread_mutex_init (hg_intercepts.c:785)
==228548==    by 0x48E1101: r_th_lock_new (thread_lock.c:21)
==228548==    by 0x40BAC1: r2r_subprocess_init (run.c:450)
==228548==    by 0x407265: main (r2r.c:279)
==228548==  Address 0x4ce1080 is 0 bytes inside a block of size 40
alloc'd
==228548==    at 0x483DB89: calloc (vg_replace_malloc.c:760)
==228548==    by 0x48E10AD: r_th_lock_new (thread_lock.c:8)
==228548==    by 0x40BAC1: r2r_subprocess_init (run.c:450)
==228548==    by 0x407265: main (r2r.c:279)
==228548==  Block was alloc'd by thread #1
==228548==
==228548== Possible data race during read of size 4 at 0x4CE0C38 by
thread #5
==228548== Locks held: none
==228548==    at 0x40CFE8: r2r_check_json_test (run.c:982)
==228548==    by 0x40D9EA: r2r_run_test (run.c:1190)
==228548==    by 0x407D45: worker_th (r2r.c:496)
==228548==    by 0x48E0B64: _r_th_launcher (thread.c:37)
==228548==    by 0x4841737: mythread_wrapper (hg_intercepts.c:387)
==228548==    by 0x49AC431: start_thread (in
/usr/lib64/libpthread-2.31.so)
==228548==    by 0x4AC6912: clone (in /usr/lib64/libc-2.31.so)
==228548==
==228548== This conflicts with a previous write of size 4 by thread #2
==228548== Locks held: 1, at address 0x4CE1080
==228548==    at 0x40BA50: sigchld_th (run.c:436)
==228548==    by 0x48E0B64: _r_th_launcher (thread.c:37)
==228548==    by 0x4841737: mythread_wrapper (hg_intercepts.c:387)
==228548==    by 0x49AC431: start_thread (in
/usr/lib64/libpthread-2.31.so)
==228548==    by 0x4AC6912: clone (in /usr/lib64/libc-2.31.so)
==228548==  Address 0x4ce0c38 is 24 bytes inside a block of size 160
alloc'd
==228548==    at 0x483DB89: calloc (vg_replace_malloc.c:760)
==228548==    by 0x40BCC7: r2r_subprocess_start (run.c:499)
==228548==    by 0x40CFA4: r2r_check_json_test (run.c:979)
==228548==    by 0x40D9EA: r2r_run_test (run.c:1190)
==228548==    by 0x407D45: worker_th (r2r.c:496)
==228548==    by 0x48E0B64: _r_th_launcher (thread.c:37)
==228548==    by 0x4841737: mythread_wrapper (hg_intercepts.c:387)
==228548==    by 0x49AC431: start_thread (in
/usr/lib64/libpthread-2.31.so)
==228548==    by 0x4AC6912: clone (in /usr/lib64/libc-2.31.so)
==228548==  Block was alloc'd by thread #5
```

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Let's see if it's green, I'm also running locally the tests... Helgrind does not report anything now btw.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
