### PR TITLE
Rename `asm.filter` to `asm.sub.names` ##cons

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -219,7 +219,7 @@ R_API bool r_asm_setup(RAsm *a, const char *arch, int bits, int big_endian) {
 }
 
 // TODO: spagueti
-R_API int r_asm_filter_input(RAsm *a, const char *f) {
+R_API int r_asm_sub_names_input(RAsm *a, const char *f) {
 	r_return_val_if_fail (a && f, false);
 	if (!a->ifilter) {
 		a->ifilter = r_parse_new ();
@@ -232,7 +232,7 @@ R_API int r_asm_filter_input(RAsm *a, const char *f) {
 	return true;
 }
 
-R_API int r_asm_filter_output(RAsm *a, const char *f) {
+R_API int r_asm_sub_names_output(RAsm *a, const char *f) {
 	if (!a->ofilter) {
 		a->ofilter = r_parse_new ();
 	}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3058,7 +3058,7 @@ R_API int r_core_config_init(RCore *core) {
 	n = NODECB ("emu.skip", "ds", &cb_emuskip);
 	SETDESC (n, "Skip metadata of given types in asm.emu");
 	SETOPTIONS (n, "d", "c", "s", "f", "m", "h", "C", "r", NULL);
-	SETBPREF ("asm.filter", "true", "Replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
+	SETBPREF ("asm.sub.names", "true", "Replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
 	SETPREF ("asm.strip", "", "strip all instructions given comma separated types");
 	SETBPREF ("asm.optype", "false", "show opcode type next to the instruction bytes");
 	SETBPREF ("asm.lines.fcn", "true", "Show function boundary lines");

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2260,7 +2260,7 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 	}
 
 	maxhits = (int) r_config_get_i (core->config, "search.maxhits");
-	filter = (int) r_config_get_i (core->config, "asm.filter");
+	filter = (int) r_config_get_i (core->config, "asm.sub.names");
 	if (param->outmode == R_MODE_JSON) {
 		r_cons_print ("[");
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -88,7 +88,7 @@ typedef struct {
 	int atabsoff;
 	int decode;
 	bool pseudo;
-	int filter;
+	int subnames;
 	int interactive;
 	bool subjmp;
 	bool subvar;
@@ -630,7 +630,7 @@ static RDisasmState * ds_init(RCore *core) {
 	if (ds->pseudo) {
 		ds->atabs = 0;
 	}
-	ds->filter = r_config_get_i (core->config, "asm.filter");
+	ds->subnames = r_config_get_i (core->config, "asm.sub.names");
 	ds->interactive = r_cons_is_interactive ();
 	ds->subjmp = r_config_get_i (core->config, "asm.sub.jmp");
 	ds->subvar = r_config_get_i (core->config, "asm.sub.var");
@@ -1060,7 +1060,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		free (ds->opstr);
 		ds->opstr = strdup (ds->hint->opcode);
 	}
-	if (ds->filter) {
+	if (ds->subnames) {
 		RSpace *ofs = core->parser->flagspace;
 		RSpace *fs = ds->flagspace_ports;
 		if (ds->analop.type == R_ANAL_OP_TYPE_IO) {
@@ -3371,7 +3371,7 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		return;
 	}
 	RAnalFunction *f = fcnIn (ds, ds->analop.jump, R_ANAL_FCN_TYPE_NULL);
-	if (!f && ds->core->flags && (!ds->core->vmode || (!ds->subjmp && !ds->filter))) {
+	if (!f && ds->core->flags && (!ds->core->vmode || (!ds->subjmp && !ds->subnames))) {
 		const char *arch;
 		RFlagItem *flag = r_flag_get_by_spaces (ds->core->flags, ds->analop.jump,
 		                                        R_FLAGS_FS_CLASSES, R_FLAGS_FS_SYMBOLS, NULL);
@@ -3410,7 +3410,7 @@ static void ds_print_fcn_name(RDisasmState *ds) {
 		} else if (delta < 0) {
 			ds_begin_comment (ds);
 			ds_comment (ds, true, "; %s-0x%x", f->name, -delta);
-		} else if ((!ds->core->vmode || (!ds->subjmp && !ds->filter))
+		} else if ((!ds->core->vmode || (!ds->subjmp && !ds->subnames))
 			   && (!ds->opstr || !strstr (ds->opstr, f->name))) {
 			RFlagItem *flag_sym;
 			if (ds->core->vmode && ds->asm_demangle
@@ -5770,7 +5770,7 @@ toro:
 					free (ds->opstr);
 					ds->opstr = strdup (R_STRBUF_SAFEGET (&ds->analop.esil));
 				}
-			} else if (ds->filter) {
+			} else if (ds->subnames) {
 				char *asm_str;
 				RSpace *ofs = core->parser->flagspace;
 				RSpace *fs = ds->flagspace_ports;
@@ -6331,7 +6331,7 @@ R_API int r_core_disasm_pdi_with_buf(RCore *core, ut64 address, ut8 *buf, ut32 n
 	bool show_offset = r_config_get_i (core->config, "asm.offset");
 	bool show_bytes = r_config_get_i (core->config, "asm.bytes");
 	int decode = r_config_get_i (core->config, "asm.decode");
-	int filter = r_config_get_i (core->config, "asm.filter");
+	int subnames = r_config_get_i (core->config, "asm.sub.names");
 	int show_color = r_config_get_i (core->config, "scr.color");
 	bool asm_ucase = r_config_get_i (core->config, "asm.ucase");
 	bool asm_instr = r_config_get_i (core->config, "asm.instr");
@@ -6531,7 +6531,7 @@ toro:
 				if (asm_immtrim) {
 					r_parse_immtrim (asm_str);
 				}
-				if (filter) {
+				if (subnames) {
 					RAnalHint *hint = r_anal_hint_get (core->anal, at);
 					r_parse_filter (core->parser, at, core->flags, hint,
 						asm_str, opstr, sizeof (opstr) - 1, core->print->big_endian);

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -191,7 +191,7 @@ R_API int r_core_pseudo_code(RCore *core, const char *input) {
 	}
 	r_config_hold_i (hc, "asm.pseudo", "asm.decode", "asm.lines", "asm.bytes", "asm.stackptr", NULL);
 	r_config_hold_i (hc, "asm.offset", "asm.flags", "asm.lines.fcn", "asm.comments", NULL);
-	r_config_hold_i (hc, "asm.functions", "asm.section", "asm.cmt.col", "asm.filter", NULL);
+	r_config_hold_i (hc, "asm.functions", "asm.section", "asm.cmt.col", "asm.sub.names", NULL);
 	r_config_hold_i (hc, "scr.color", "emu.str", "asm.emu", "emu.write", NULL);
 	r_config_hold_i (hc, "io.cache", NULL);
 	if (!fcn) {
@@ -203,7 +203,7 @@ R_API int r_core_pseudo_code(RCore *core, const char *input) {
 	r_config_set_i (core->config, "asm.stackptr", 0);
 	r_config_set_i (core->config, "asm.pseudo", 1);
 	r_config_set_i (core->config, "asm.decode", 0);
-	r_config_set_i (core->config, "asm.filter", 1);
+	r_config_set_i (core->config, "asm.sub.names", 1);
 	r_config_set_i (core->config, "asm.lines", 0);
 	r_config_set_i (core->config, "asm.bytes", 0);
 	r_config_set_i (core->config, "asm.offset", 0);

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -170,8 +170,8 @@ R_API RAsmCode* r_asm_rasm_assemble(RAsm *a, const char *buf, bool use_spp);
 R_API char *r_asm_to_string(RAsm *a, ut64 addr, const ut8 *b, int l);
 /* to ease the use of the native bindings (not used in r2) */
 R_API ut8 *r_asm_from_string(RAsm *a, ut64 addr, const char *b, int *l);
-R_API int r_asm_filter_input(RAsm *a, const char *f);
-R_API int r_asm_filter_output(RAsm *a, const char *f);
+R_API int r_asm_sub_names_input(RAsm *a, const char *f);
+R_API int r_asm_sub_names_output(RAsm *a, const char *f);
 R_API char *r_asm_describe(RAsm *a, const char* str);
 R_API RList* r_asm_get_plugins(RAsm *a);
 R_API void r_asm_list_directives(void);

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -733,17 +733,17 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		if (p) {
 			*p = 0;
 			if (*filters) {
-				r_asm_filter_input (as->a, filters);
+				r_asm_sub_names_input (as->a, filters);
 			}
 			if (p[1]) {
-				r_asm_filter_output (as->a, p + 1);
+				r_asm_sub_names_output (as->a, p + 1);
 			}
 			*p = ':';
 		} else {
 			if (dis) {
-				r_asm_filter_output (as->a, filters);
+				r_asm_sub_names_output (as->a, filters);
 			} else {
-				r_asm_filter_input (as->a, filters);
+				r_asm_sub_names_input (as->a, filters);
 			}
 		}
 	}

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -152,10 +152,10 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=asm.filter issue
+NAME=asm.sub.names issue
 FILE=malloc://1024
 CMDS=<<EOF
-e asm.filter=1
+e asm.sub.names=1
 e asm.arch=arm
 e asm.bits=64
 
@@ -167,10 +167,10 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=asm.filter issue
+NAME=asm.sub.names issue
 FILE=malloc://1024
 CMDS=<<EOF
-e asm.filter=0
+e asm.sub.names=0
 e asm.arch=arm
 e asm.bits=64
 wx fa67bba9
@@ -181,7 +181,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=asm.filter issue #6752
+NAME=asm.sub.names issue #6752
 FILE=malloc://1024
 CMDS=<<EOF
 s 0x100
@@ -802,15 +802,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd asm.filter color
+NAME=pd asm.sub.names color
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
 e asm.bytes=false
 e asm.comments=false
 e scr.color=1
-e asm.filter=true
+e asm.sub.names=true
 pd 1 @ 0x0001145f
-e asm.filter=false
+e asm.sub.names=false
 pd 1 @ 0x0001145f
 EOF
 EXPECT=<<EOF
@@ -869,7 +869,7 @@ e scr.strconv=asciiesc
 pd 1 @ 0x0040169d
 e scr.strconv=asciidot
 pd 1 @ 0x0040169d
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 pd 1 @ 0x00401693
 e bin.str.enc=utf8
@@ -895,7 +895,7 @@ NAME=bin.str.enc utf8
 FILE=bins/elf/strenc
 CMDS=<<EOF
 e asm.bytes=false
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e str.escbslash=true
 e bin.str.enc=utf8
@@ -915,7 +915,7 @@ RUN
 NAME=bin.str.enc latin1
 FILE=bins/pe/testapp-msvc64.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e bin.str.enc=latin1
 pd 1 @ 0x140001058
@@ -932,12 +932,12 @@ NAME=bin.str.enc utf16le
 FILE=bins/elf/strenc
 CMDS=<<EOF
 e asm.bytes=false
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e str.escbslash=true
 e bin.str.enc=guess
 pd 1 @ 0x004016ac
-e asm.filter=true
+e asm.sub.names=true
 e asm.cmt.off=false
 e bin.str.enc=guess
 pd 1 @ 0x004016b6
@@ -971,7 +971,7 @@ e bin.str.enc=utf16le
 pd 1 @ 0x004016de
 e bin.str.enc=utf32le
 pd 1 @ 0x004016de
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e bin.str.enc=guess
 pd 1 @ 0x004016ed
@@ -993,7 +993,7 @@ RUN
 NAME=bin.str.enc guess utf16le
 FILE=bins/pe/testapp-msvc64.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e bin.str.enc=guess
 pd 1 @ 0x14000104c
@@ -1025,7 +1025,7 @@ RUN
 NAME=bin.str.enc alias
 FILE=bins/elf/strenc
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e asm.bytes=false
 e asm.cmt.off=false
@@ -1076,7 +1076,7 @@ RUN
 NAME=hide flag iff unchanged and string shown
 FILE=bins/pe/testapp-msvc64.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=false
 e str.escbslash=false
 e asm.cmt.right=true
@@ -1108,7 +1108,7 @@ RUN
 NAME=asm.noisy
 FILE=bins/pe/testapp-msvc64.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.noisy=true
 e str.escbslash=false
 e asm.cmt.right=true
@@ -1127,7 +1127,7 @@ RUN
 NAME=fcn name cmt alignment
 FILE=bins/pe/ConsoleApplication1.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 af @ main
 pd 1 @ 0x00401157
 EOF
@@ -1136,10 +1136,10 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=call asm.filter=false flag cmt
+NAME=call asm.sub.names=false flag cmt
 FILE=bins/pe/ConsoleApplication1.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 e asm.cmt.right=true
 pd 1 @ 0x004010c6
 e asm.cmt.right=false
@@ -1159,10 +1159,10 @@ FILE=bins/pe/testapp-msvc64.exe
 CMDS=<<EOF
 e asm.noisy=false
 e str.escbslash=false
-e asm.filter=true
+e asm.sub.names=true
 e asm.cmt.off=false
 pd 1 @ 0x140001010
-e asm.filter=false
+e asm.sub.names=false
 e asm.cmt.off=true
 pd 1 @ 0x140001010
 e asm.cmt.off=nodup
@@ -1661,9 +1661,9 @@ NAME=emu.str dup str/flag cmt fix
 FILE=bins/elf/analysis/ls2
 CMDS=<<EOF
 e emu.str=true
-e asm.filter=true
+e asm.sub.names=true
 pd 1 @ 0x00402a5f
-e asm.filter=false
+e asm.sub.names=false
 pd 1 @ 0x00402a5f
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -527,7 +527,7 @@ FILE=bins/elf/abcde-qt32
 CMDS=<<EOF
 e asm.demangle=true
 e asm.bytes=false
-e asm.filter=false
+e asm.sub.names=false
 e asm.sub.jmp=false
 aa
 e asm.cmt.right=true
@@ -556,7 +556,7 @@ NAME=newlined-comment-refline fix (#14627), wayward rip-relative flag fixes
 FILE=bins/elf/ls
 CMDS=<<EOF
 e asm.bytes=false
-e asm.filter=true
+e asm.sub.names=true
 (pd_tests; e asm.sub.rel=true; pd 15; ?e; e asm.sub.rel=false; pd 1 @ 0x000041ee; pd 1 @ 0x00004225)
 (insn_tests; e scr.color=0; .(pd_tests); ?e; e scr.color=1; .(pd_tests))
 s 0x000041e0

--- a/test/db/formats/elf/bomb
+++ b/test/db/formats/elf/bomb
@@ -16,7 +16,7 @@ RUN
 NAME=ELF: bomb - pi 1
 FILE=bins/elf/bomb
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/elf/simple
+++ b/test/db/formats/elf/simple
@@ -9,7 +9,7 @@ RUN
 NAME=ELF: simple.elf - code
 FILE=bins/elf/analysis/simple.elf
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pid 4 @ entry0
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/CoST
+++ b/test/db/formats/pe/CoST
@@ -39,7 +39,7 @@ RUN
 NAME=PE: corkami CoST.exe - pi 1
 FILE=bins/pe/CoST.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/bigSoRD
+++ b/test/db/formats/pe/bigSoRD
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami bigSoRD.exe - pi 1
 FILE=bins/pe/bigSoRD.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/bottomsecttbl
+++ b/test/db/formats/pe/bottomsecttbl
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami bottomsecttbl.exe - pi 1
 FILE=bins/pe/bottomsecttbl.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/cfgbogus
+++ b/test/db/formats/pe/cfgbogus
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami cfgbogus.exe - pi 1
 FILE=bins/pe/cfgbogus.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/compiled
+++ b/test/db/formats/pe/compiled
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami compiled.exe - pi 1
 FILE=bins/pe/compiled.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/copyright
+++ b/test/db/formats/pe/copyright
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami copyright.exe - pi 1
 FILE=bins/pe/copyright.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/ctxt
+++ b/test/db/formats/pe/ctxt
@@ -24,7 +24,7 @@ RUN
 NAME=PE: corkami ctxt.dll - pi 1
 FILE=bins/pe/ctxt.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/ctxt-ld
+++ b/test/db/formats/pe/ctxt-ld
@@ -24,7 +24,7 @@ RUN
 NAME=PE: corkami ctxt-ld.exe - pi 1
 FILE=bins/pe/ctxt-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/d_nonnull-ld
+++ b/test/db/formats/pe/d_nonnull-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami d_nonnull-ld - pi 1
 FILE=bins/pe/d_nonnull-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/d_resource-ld
+++ b/test/db/formats/pe/d_resource-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami d_resource-ld.exe - pi 1
 FILE=bins/pe/d_resource-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/d_tiny-ld
+++ b/test/db/formats/pe/d_tiny-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami d_tiny-ld.exe - pi 1
 FILE=bins/pe/d_tiny-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/ddsect
+++ b/test/db/formats/pe/ddsect
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami ddsect.exe - pi 1
 FILE=bins/pe/ddsect.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/debug
+++ b/test/db/formats/pe/debug
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami debug.exe - pi 1
 FILE=bins/pe/debug.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/delaycorrupt
+++ b/test/db/formats/pe/delaycorrupt
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami delaycorrupt.exe - pi 1
 FILE=bins/pe/delaycorrupt.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/delayfake
+++ b/test/db/formats/pe/delayfake
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami delayfake.exe - pi 1
 FILE=bins/pe/delayfake.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/delayimports
+++ b/test/db/formats/pe/delayimports
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami delayimports.exe - pi 1
 FILE=bins/pe/delayimports.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dep
+++ b/test/db/formats/pe/dep
@@ -26,7 +26,7 @@ RUN
 NAME=PE: corkami dep.exe - pi 1
 FILE=bins/pe/dep.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dll
+++ b/test/db/formats/pe/dll
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dll.dll - pi 1
 FILE=bins/pe/dll.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dll-dynld
+++ b/test/db/formats/pe/dll-dynld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dll-dynld.exe - pi 1
 FILE=bins/pe/dll-dynld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dll-dynunicld
+++ b/test/db/formats/pe/dll-dynunicld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dll-dynunicld.exe - pi 1
 FILE=bins/pe/dll-dynunicld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dll-ld
+++ b/test/db/formats/pe/dll-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dll-ld.exe - pi 1
 FILE=bins/pe/dll-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dll-webdavld
+++ b/test/db/formats/pe/dll-webdavld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dll-webdavld.exe - pi 1
 FILE=bins/pe/dll-webdavld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllbound
+++ b/test/db/formats/pe/dllbound
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllbound.dll - pi 1
 FILE=bins/pe/dllbound.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllbound-ld
+++ b/test/db/formats/pe/dllbound-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllbound-ld.exe - pi 1
 FILE=bins/pe/dllbound-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllbound-redirld
+++ b/test/db/formats/pe/dllbound-redirld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllbound-redirld.exe - pi 1
 FILE=bins/pe/dllbound-redirld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllbound-redirldXP
+++ b/test/db/formats/pe/dllbound-redirldXP
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllbound-redirldXP.exe - pi 1
 FILE=bins/pe/dllbound-redirldXP.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllbound2
+++ b/test/db/formats/pe/dllbound2
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllbound2.dll - pi 1
 FILE=bins/pe/dllbound2.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllcfgdup
+++ b/test/db/formats/pe/dllcfgdup
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllcfgdup.dll - pi 1
 FILE=bins/pe/dllcfgdup.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllcfgdup-dynld
+++ b/test/db/formats/pe/dllcfgdup-dynld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllcfgdup-dynld.exe - pi 1
 FILE=bins/pe/dllcfgdup-dynld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllemptyexp
+++ b/test/db/formats/pe/dllemptyexp
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllemptyexp.dll - pi 1
 FILE=bins/pe/dllemptyexp.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllemptyexp-ld
+++ b/test/db/formats/pe/dllemptyexp-ld
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllemptyexp-ld.exe - pi 1
 FILE=bins/pe/dllemptyexp-ld.exe
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF

--- a/test/db/formats/pe/dllextep
+++ b/test/db/formats/pe/dllextep
@@ -16,7 +16,7 @@ RUN
 NAME=PE: corkami dllextep.dll - pi 1
 FILE=bins/pe/dllextep.dll
 CMDS=<<EOF
-e asm.filter=false
+e asm.sub.names=false
 pi 1
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

On #17455, it was suggested to rename `asm.filter` to `asm.sub.names` for better organization. That is what this PR is hoping to achieve.

To achieve this, here I have renamed:
* `r_asm_filter_input` to `r_asm_sub_names_input` 
* `r_asm_filter_output` to `r_asm_sub_names_output`
* A variable named `filter` to `subnames`.

**Test plan**
I ran the tests after renaming the command and didn't encounter any considerably huge problems

```
$ r2r -i db/formats/pe/*
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 447 tests.
Skipping json tests because jq is not available.
[447/447]                 444 OK         3 BR        0 XX        0 FX
Finished in 33 seconds.
```

```
$ r2r -i db/cmd/cmd_pd db/cmd/cmd_pd2
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 137 tests.
Skipping json tests because jq is not available.
[137/137]                 137 OK         0 BR        0 XX        0 FX
Finished in 2 seconds.
```

**Closing issues**

Closes #17455 
