### PR TITLE
Add support for listing parsers, bits and add Lp command

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -709,6 +709,18 @@ static bool cb_dbgbtdepth(void *user, void *data) {
 static bool cb_asmbits(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
+
+	if (node->value[0] == '?') {
+		int bits = core->rasm->cur->bits;
+		int i;
+		for (i = 1; i <= bits; i <<= 1) {
+			if (i & bits) {
+				r_cons_printf ("%d\n", i);
+			}
+		}
+		return false;
+	}
+
 	bool ret = false;
 	if (!core) {
 		eprintf ("user can't be NULL\n");
@@ -909,6 +921,15 @@ static bool cb_asmos(void *user, void *data) {
 static bool cb_asmparser(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
+	if (node->value[0] == '?') {
+		RListIter *iter;
+		RParsePlugin *plugin;
+		r_list_foreach (core->parser->parsers, iter, plugin) {
+			r_cons_printf ("%s\n", plugin->name);
+		}
+		return false;
+	}
+
 	return r_parse_use (core->parser, node->value);
 }
 
@@ -2128,7 +2149,7 @@ static bool scr_vtmode(void *user, void *data) {
 	}
 	node->i_value = node->i_value > 2 ? 2 : node->i_value;
 	r_line_singleton ()->vtmode = r_cons_singleton ()->vtmode = node->i_value;
-	
+
 	DWORD mode;
 	HANDLE input = GetStdHandle (STD_INPUT_HANDLE);
 	GetConsoleMode (input, &mode);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -560,14 +560,12 @@ static void update_asmarch_options(RCore *core, RConfigNode *node) {
 
 static void update_asmbits_options(RCore *core, RConfigNode *node) {
 	if (core && core->rasm && core->rasm->cur && node) {
-		char buf[20];
 		int bits = core->rasm->cur->bits;
 		int i;
 		r_list_purge (node->options);
 		for (i = 1; i <= bits; i <<= 1) {
 			if (i & bits) {
-				snprintf (buf, 20, "%d", i);
-				SETOPTIONS (node, strdup (buf), NULL);
+				SETOPTIONS (node, r_str_newf ("%d", i), NULL);
 			}
 		}
 	}

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -558,6 +558,21 @@ static void update_asmarch_options(RCore *core, RConfigNode *node) {
 	}
 }
 
+static void update_asmbits_options(RCore *core, RConfigNode *node) {
+	if (core && core->rasm && core->rasm->cur && node) {
+		char buf[20];
+		int bits = core->rasm->cur->bits;
+		int i;
+		r_list_purge (node->options);
+		for (i = 1; i <= bits; i <<= 1) {
+			if (i & bits) {
+				snprintf (buf, 20, "%d", i);
+				SETOPTIONS (node, strdup (buf), NULL);
+			}
+		}
+	}
+}
+
 static bool cb_asmarch(void *user, void *data) {
 	char asmparser[32];
 	RCore *core = (RCore *) user;
@@ -618,6 +633,7 @@ static bool cb_asmarch(void *user, void *data) {
 		} else {
 			bits = 64;
 		}
+		update_asmbits_options (core, r_config_node_get (core->config, "asm.bits"));
 	}
 	snprintf (asmparser, sizeof (asmparser), "%s.pseudo", node->value);
 	r_config_set (core->config, "asm.parser", asmparser);
@@ -711,13 +727,8 @@ static bool cb_asmbits(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *) data;
 
 	if (node->value[0] == '?') {
-		int bits = core->rasm->cur->bits;
-		int i;
-		for (i = 1; i <= bits; i <<= 1) {
-			if (i & bits) {
-				r_cons_printf ("%d\n", i);
-			}
-		}
+		update_asmbits_options (core, node);
+		print_node_options (node);
 		return false;
 	}
 
@@ -918,15 +929,23 @@ static bool cb_asmos(void *user, void *data) {
 	return true;
 }
 
+static void update_asmparser_options(RCore *core, RConfigNode *node) {
+	RListIter *iter;
+	RParsePlugin *parser;
+	if (core && node && core->parser && core->parser->parsers) {
+		r_list_purge (node->options);
+		r_list_foreach (core->parser->parsers, iter, parser) {
+			SETOPTIONS (node, parser->name, NULL);
+		}
+	}
+}
+
 static bool cb_asmparser(void *user, void *data) {
 	RCore *core = (RCore*) user;
 	RConfigNode *node = (RConfigNode*) data;
 	if (node->value[0] == '?') {
-		RListIter *iter;
-		RParsePlugin *plugin;
-		r_list_foreach (core->parser->parsers, iter, plugin) {
-			r_cons_printf ("%s\n", plugin->name);
-		}
+		update_asmparser_options (core, node);
+		print_node_options (node);
 		return false;
 	}
 
@@ -3162,7 +3181,9 @@ R_API int r_core_config_init(RCore *core) {
 	n = NODECB ("asm.features", "", &cb_asmfeatures);
 	SETDESC (n, "Specify supported features by the target CPU");
 	update_asmfeatures_options (core, n);
-	SETCB ("asm.parser", "x86.pseudo", &cb_asmparser, "Set the asm parser to use");
+	n = NODECB ("asm.parser", "x86.pseudo", &cb_asmparser);
+	SETDESC (n, "Set the asm parser to use");
+	update_asmparser_options (core, n);
 	SETCB ("asm.segoff", "false", &cb_segoff, "Show segmented address in prompt (x86-16)");
 	SETCB ("asm.decoff", "false", &cb_decoff, "Show segmented address in prompt (x86-16)");
 	SETICB ("asm.seggrn", 4, &cb_seggrn, "Segment granularity in bits (x86-16)");
@@ -3176,6 +3197,8 @@ R_API int r_core_config_init(RCore *core) {
 #else
 	SETICB ("asm.bits", 32, &cb_asmbits, "Word size in bits at assembler");
 #endif
+	n = r_config_node_get(cfg, "asm.bits");
+	update_asmbits_options (core, n);
 	SETBPREF ("asm.functions", "true", "Show functions in disassembly");
 	SETBPREF ("asm.xrefs", "true", "Show xrefs in disassembly");
 	SETBPREF ("asm.demangle", "true", "Show demangled symbols in disasm");

--- a/libr/core/cmd_log.c
+++ b/libr/core/cmd_log.c
@@ -21,6 +21,7 @@ static const char *help_msg_L[] = {
 	"Lh", "", "list hash plugins (same as ph)",
 	"Li", "", "list bin plugins (same as iL)",
 	"Lo", "", "list io plugins (same as oL)",
+	"Lp", "", "list parser plugins (e asm.parser=?)",
 	NULL
 };
 
@@ -343,6 +344,9 @@ static int cmd_plugins(void *data, const char *input) {
 		break;
 	case 'a': // "La"
 		r_core_cmd0 (core, "e asm.arch=??");
+		break;
+	case 'p': // "Lp"
+		r_core_cmd0 (core, "e asm.parser=?");
 		break;
 	case 'D': // "LD"
 		if (input[1] == ' ') {

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -1,7 +1,7 @@
 NAME=List Parser Plugins Lp
 FILE=-
 CMDS=<<EOF
-Lp ~
+Lp~$
 EOF
 EXPECT=<<EOF
 6502.pseudo

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -1,0 +1,23 @@
+NAME=List Parser Plugins Lp
+FILE=-
+CMDS=<<EOF
+Lp
+EOF
+EXPECT=<<EOF
+6502.pseudo
+arm.pseudo
+att2intel
+avr.pseudo
+chip8.pseudo
+dalvik.pseudo
+m68k.pseudo
+mips.pseudo
+ppc.pseudo
+sh.pseudo
+tms320.pseudo
+v850.pseudo
+wasm.pseudo
+x86.pseudo
+z80.pseudo
+EOF
+RUN

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -1,7 +1,7 @@
 NAME=List Parser Plugins Lp
 FILE=-
 CMDS=<<EOF
-Lp | sort
+Lp ~
 EOF
 EXPECT=<<EOF
 6502.pseudo

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -1,7 +1,7 @@
 NAME=List Parser Plugins Lp
 FILE=-
 CMDS=<<EOF
-Lp
+Lp | sort
 EOF
 EXPECT=<<EOF
 6502.pseudo


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
For issue #17708 it is required to implement `e asm.parser=?` which should print all the parsers loaded currently. I've added code to update `node->options` list to have all the plugins listed.

Similarly `e asm.bits=?` is implemented by getting the value of `core->rasm->cur->bits` and populating all the `node->options` list to have all the available configurations.

Also the `Lp` command has been added to print all the parsers which will just call the `e asm.parser=?` command similar to implementation of `La`

Tab completion works for those fields now.
 
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
Test case for `Lp` has been added to list the plugins (current output from my local terminal). I've tested locally for the changes made and autocomplete along with listing works for `asm.bits` and `asm.parser`.
**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #17708 
...
