### PR TITLE
Improve help under `v?` ##cons

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -339,6 +339,14 @@ static const char *help_msg_vertical_bar[] = {
 	NULL
 };
 
+static const char *help_msg_v[] = {
+	"Usage:", "v[*i]", "",
+	"v", " test", "load saved layout with name test",
+	"v=", " test", "save current layout with name test",
+	"vi", " test", "open the file test in 'cfg.editor'",
+	NULL
+};
+
 R_API void r_core_cmd_help(const RCore *core, const char *help[]) {
 	r_cons_cmd_help (help, core->print->flags & R_PRINT_FLAGS_COLOR);
 }
@@ -1897,10 +1905,7 @@ static int cmd_panels(void *data, const char *input) {
 		return false;
 	}
 	if (*input == '?') {
-		eprintf ("Usage: v[*i]\n");
-		eprintf ("v.test    # save current layout with name test\n");
-		eprintf ("v test    # load saved layout with name test\n");
-		eprintf ("vi ...    # launch 'cfg.editor'\n");
+		r_core_cmd_help (core, help_msg_v);
 		return false;
 	}
 	if (!r_cons_is_interactive ()) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -341,6 +341,7 @@ static const char *help_msg_vertical_bar[] = {
 
 static const char *help_msg_v[] = {
 	"Usage:", "v[*i]", "",
+	"v", "", "open visual panels",
 	"v", " test", "load saved layout with name test",
 	"v=", " test", "save current layout with name test",
 	"vi", " test", "open the file test in 'cfg.editor'",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The help under `v?` currently doesn't look pretty as it's just `eprintinf`-ing it.
I've reimplemented it properly in this Pull Request, by using `r_core_cmd_help`.

**Test plan**

This is what the `v?`will output after this PR:

![image](https://user-images.githubusercontent.com/29057155/94895429-07191300-04a9-11eb-8ba8-ce493035f587.png)
Also, to save the layout, the current help asks us to run `v.` but it's on `v=`, `r_save_panels_layout` is actually called and the layout is saved, as you can see [here](https://github.com/radareorg/radare2/blob/master/libr/core/cmd.c#L1917). 

Currently, I've added the help as `v=`, but I'd like a maintainer to review it.

**Closing issues**

None