### PR TITLE
Add JSON variants of pxd[1,2,4,8] commands ##print

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6088,24 +6088,45 @@ l = use_blocksize;
 				switch (input[2]) {
 				case '1':
 					// 1 byte signed words (byte)
-					r_print_hexdump (core->print, core->offset,
-							core->block, len, -1, 4, 1);
+					if (input[3] == 'j') {
+						r_print_jsondump (core->print, core->block,
+							len, 8);
+					} else {
+						r_print_hexdump (core->print, core->offset,
+								 core->block, len, -1, 4, 1);
+					}
 					break;
 				case '2':
 					// 2 byte signed words (short)
-					r_print_hexdump (core->print, core->offset,
-							core->block, len, -10, 2, 1);
+					if (input[3] == 'j') {
+						r_print_jsondump (core->print, core->block,
+							len, 16);
+					} else {
+						r_print_hexdump (core->print, core->offset,
+								 core->block, len, -10, 2, 1);
+					}
 					break;
 				case '8':
-					r_print_hexdump (core->print, core->offset,
-							core->block, len, -8, 4, 1);
+					if (input[3] == 'j') {
+						r_print_jsondump (core->print, core->block,
+							len, 64);
+					} else {
+						r_print_hexdump (core->print, core->offset,
+								 core->block, len, -8, 4, 1);
+					}
 					break;
 				case '4':
 				case ' ':
+				case 'j':
 				case 0:
 					// 4 byte signed words
-					r_print_hexdump (core->print, core->offset,
-						core->block, len, 10, 4, 1);
+					if (input[2] == 'j' || input[3] == 'j') {
+						r_print_jsondump (core->print, core->block,
+							len, 32);
+					} else {
+						r_print_hexdump (core->print, core->offset,
+								 core->block, len, 10, 4, 1);
+					}
 					break;
 				default:
 					r_core_cmd_help (core, help_msg_pxd);

--- a/test/db/json/json4
+++ b/test/db/json/json4
@@ -14,6 +14,11 @@ Pj
 psj
 pxhj
 pxj
+pxdj
+pxd1j
+pxd2j
+pxd4j
+pxd8j
 pxqj
 pxrj
 pxwj


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The pxd[1,2,4,8] commands had no equivalent JSON version. I've added that behavior and modeled it after pxh/pxw/pxq.

**Test plan**

The output of pxdj/pxd1j/pxd2j/pxd4j/pxd8j should contain the same numbers as pxd/pxd1/pxd2/pxd4/pxd8.
