### PR TITLE
Fix FreeBSD step error ##debug

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -96,7 +96,8 @@ static int r_debug_handle_signals(RDebug *dbg) {
 #if __KFBSD__
 	return bsd_handle_signals (dbg);
 #else
-	return -1;
+	eprinf ("Warning: signal handling is not supported on this platform\n");
+	return 0;
 #endif
 }
 #endif
@@ -533,7 +534,7 @@ static RDebugReasonType r_debug_native_wait(RDebug *dbg, int pid) {
 #if __OpenBSD__ || __NetBSD__
 			reason = R_DEBUG_REASON_BREAKPOINT;
 #else
-			if (!r_debug_handle_signals (dbg)) {
+			if (r_debug_handle_signals (dbg) != 0) {
 				return R_DEBUG_REASON_ERROR;
 			}
 			reason = dbg->reason.type;


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

As described in #17500, an error was printed after each step because `r_debug_native_wait` failed due to an incorrect handling of `r_debug_handle_signals`'s return value.
I have also added a warning for platforms that don't support signal handling after stepping without causing a failure.

**Test plan**

Open a program in FreeBSD and step/continue.

**Closing issues**

closes #17500