### PR TITLE
Remove example.syscall-file ##build

### DIFF
--- a/libr/syscall/example.syscall-file
+++ b/libr/syscall/example.syscall-file
@@ -1,4 +1,0 @@
-; Linux syscalls
-; name int sysnum args
-write 0x80 4 3 ; write(fd, ptr, len)
-read 0x80 3 3 ; read(fd, ptr, len)


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
There is an example file named `example.syscall-file` inside `libr/syscall` which houses an outdated example which is not needed. This PR removes that file.

This was mentioned twice in [#140](https://github.com/radareorg/radare2book/issues/140#issuecomment-703081995) of the radare2book.

**Test plan**
None.

**Closing issues**

As discussed in [#140](https://github.com/radareorg/radare2book/issues/140)