### PR TITLE
drr show all flags and pxrj is now structured ##print

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1978,7 +1978,7 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 		free (rrstr);
 	}
 
-	char *s = (mode == 'j')? r_table_tojson(t): r_table_tostring(t);
+	char *s = (mode == 'j')? r_table_tojson (t): r_table_tostring (t);
 	r_cons_print (s);
 	free (s);
 	r_table_free (t);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -1931,7 +1931,7 @@ R_API void r_core_debug_rr(RCore *core, RReg *reg, int mode) {
 		colorend = Color_RESET;
 	}
 
-	r_table_set_columnsf (t, "ssss", "role", "reg", "value", "ref");
+	r_table_set_columnsf (t, "ssss", "role", "reg", "value", "refstr");
 	r_list_foreach (list, iter, r) {
 		if (r->size != bits) {
 			continue;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4545,7 +4545,10 @@ static void cmd_pxr(RCore *core, int len, int mode, int wordsize, const char *ar
 					r_str_trim (rstr);
 					if (pj) {
 						char *ns = r_str_escape (rstr);
-						pj_ks (pj, "ref", r_str_trim_head_ro (ns));
+						pj_ks (pj, "refstr", r_str_trim_head_ro (ns));
+						pj_k (pj, "ref");
+						const int hex_depth = r_config_get_i (core->config, "hex.depth");
+						free (r_core_anal_hasrefs_to_depth (core, val, pj, hex_depth));
 						pj_end (pj);
 						free (ns);
 					}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3147,9 +3147,9 @@ static void ds_print_show_bytes(RDisasmState *ds) {
 		flagstr = r_flag_get_liststr (core->flags, ds->at);
 	}
 	if (flagstr) {
-		str = flagstr;
+		str = r_str_newf ("%s:", flagstr);
 		if (ds->nb > 0) {
-			k = ds->nb - strlen (flagstr) - 1;
+			k = ds->nb - strlen (str) - 1;
 			if (k < 0) {
 				str[ds->nb - 1] = '\0';
 			}
@@ -3163,6 +3163,7 @@ static void ds_print_show_bytes(RDisasmState *ds) {
 		} else {
 			pad[0] = 0;
 		}
+		R_FREE (flagstr);
 	} else {
 		if (ds->show_flag_in_bytes) {
 			k = ds->nb - 1;

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2019 - pancake, ret2libc */
+/* radare - LGPL - Copyright 2007-2020 - pancake, ret2libc */
 
 #include <r_flag.h>
 #include <r_util.h>
@@ -680,7 +680,7 @@ R_API char *r_flag_get_liststr(RFlag *f, ut64 off) {
 	char *p = NULL;
 	r_list_foreach (list, iter, fi) {
 		p = r_str_appendf (p, "%s%s",
-			fi->realname, iter->n? ",": ":");
+			fi->realname, iter->n? ",": "");
 	}
 	return p;
 }

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -468,6 +468,7 @@ R_API void r_core_set_asmqjmps(RCore *core, char *str, size_t len, int i);
 R_API char* r_core_add_asmqjmp(RCore *core, ut64 addr);
 
 R_API void r_core_anal_type_init(RCore *core);
+R_API char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, PJ *pj, int depth);
 R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn);
 R_API void r_core_anal_inflags (RCore *core, const char *glob);
 R_API bool cmd_anal_objc (RCore *core, const char *input, bool auto_anal);
@@ -840,7 +841,7 @@ typedef struct {
 
 R_API bool core_anal_bbs(RCore *core, const char* input);
 R_API bool core_anal_bbs_range (RCore *core, const char* input);
-R_API char *r_core_anal_hasrefs(RCore *core, ut64 value, bool verbose);
+R_API char *r_core_anal_hasrefs(RCore *core, ut64 value, int mode);
 R_API char *r_core_anal_get_comments(RCore *core, ut64 addr);
 R_API RCoreAnalStats* r_core_anal_get_stats (RCore *a, ut64 from, ut64 to, ut64 step);
 R_API void r_core_anal_stats_free (RCoreAnalStats *s);

--- a/libr/include/r_util/r_print.h
+++ b/libr/include/r_util/r_print.h
@@ -40,7 +40,7 @@ typedef int (*RPrintSizeCallback)(void *user, ut64 addr);
 typedef char *(*RPrintCommentCallback)(void *user, ut64 addr);
 typedef const char *(*RPrintSectionGet)(void *user, ut64 addr);
 typedef const char *(*RPrintColorFor)(void *user, ut64 addr, bool verbose);
-typedef char *(*RPrintHasRefs)(void *user, ut64 addr, bool verbose);
+typedef char *(*RPrintHasRefs)(void *user, ut64 addr, int mode);
 
 typedef struct r_print_zoom_t {
 	ut8 *buf;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -823,8 +823,8 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 	bool use_pair = true;
 	bool use_offset = true;
 	bool compact = false;
-	int use_segoff = 0;
-	int pairs = 0;
+	bool use_segoff = false;
+	bool pairs = false;
 	const char *bytefmt = "%02x";
 	const char *pre = "";
 	int last_sparse = 0;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1290,12 +1290,12 @@ R_API void r_print_hexdump(RPrint *p, ut64 addr, const ut8 *buf, int len, int ba
 				if (p->hasrefs && off != UT64_MAX) {
 					char *rstr = p->hasrefs (p->user, addr + i, false);
 					if (rstr && *rstr) {
-						printfmt (" @%s", rstr);
+						printfmt (" @ %s", rstr);
 					}
 					free (rstr);
 					rstr = p->hasrefs (p->user, off, true);
 					if (rstr && *rstr) {
-						printfmt ("%s", rstr);
+						printfmt (" %s", rstr);
 					}
 					free (rstr);
 				}

--- a/test/db/anal/x86_32
+++ b/test/db/anal/x86_32
@@ -1209,7 +1209,7 @@ afx
 EOF
 EXPECT=<<EOF
 d 0x00401006 -> 0x0040d004 mov eax, dword [0x40d004]
-s 0x00401010 -> 0x0040b9a0 0x6c6c6568  hell @str.hello ascii ('h')
+s 0x00401010 -> 0x0040b9a0 0x6c6c6568  hell @ str.hello ascii ('h')
 C 0x00401015 -> 0x004010e4 call fcn.004010e4
 d 0x0040101e -> 0x0040b9a8 push 0x40b9a8
 C 0x00401023 -> 0x004010c7 call fcn.004010c7

--- a/test/db/cmd/cmd_dr
+++ b/test/db/cmd/cmd_dr
@@ -7,6 +7,6 @@ dr ebx=0x10
 drrj~{2}
 EOF
 EXPECT=<<EOF
-{"role":"A1","reg":"ebx","value":"10","ref":" 16"}
+{"role":"A1","reg":"ebx","value":"10","refstr":"16 ebx"}
 EOF
 RUN

--- a/test/db/cmd/cmd_px
+++ b/test/db/cmd/cmd_px
@@ -185,15 +185,15 @@ pxr 48 @ 0x00600ae0
 pxr 24 @ 0x00600ae0+32
 EOF
 EXPECT=<<EOF
-0x00600ae0 0x000000000040055e   ^.@..... @reloc.printf 4195678 (.plt) R X 'push 0'
-0x00600ae8 0x000000000040056e   n.@..... @reloc.puts 4195694 (.plt) R X 'push 1'
-0x00600af0 0x000000000040057e   ~.@..... @reloc.__libc_start_main 4195710 (.plt) R X 'push 2'
-0x00600af8 0x000000000040058e   ..@..... @reloc.fgets 4195726 (.plt) R X 'push 3'
-0x00600b00 0x000000000040059e   ..@..... @reloc.strcmp 4195742 (.plt) R X 'push 4'
-0x00600b08 0x00000000004005ae   ..@..... @reloc.fflush 4195758 (.plt) R X 'push 5'
+0x00600ae0 0x000000000040055e   ^.@..... @ reloc.printf 4195678 .plt R X 'push 0'
+0x00600ae8 0x000000000040056e   n.@..... @ reloc.puts 4195694 .plt R X 'push 1'
+0x00600af0 0x000000000040057e   ~.@..... @ reloc.__libc_start_main 4195710 .plt R X 'push 2'
+0x00600af8 0x000000000040058e   ..@..... @ reloc.fgets 4195726 .plt R X 'push 3'
+0x00600b00 0x000000000040059e   ..@..... @ reloc.strcmp 4195742 .plt R X 'push 4'
+0x00600b08 0x00000000004005ae   ..@..... @ reloc.fflush 4195758 .plt R X 'push 5'
 ===
-0x00600b00 0x000000000040059e   ..@..... @reloc.strcmp 4195742 (.plt) R X 'push 4'
-0x00600b08 0x00000000004005ae   ..@..... @reloc.fflush 4195758 (.plt) R X 'push 5'
+0x00600b00 0x000000000040059e   ..@..... @ reloc.strcmp 4195742 .plt R X 'push 4'
+0x00600b08 0x00000000004005ae   ..@..... @ reloc.fflush 4195758 .plt R X 'push 5'
 0x00600b10 ..[ null bytes ]..   00000000 loc.__data_start
 EOF
 RUN
@@ -209,76 +209,124 @@ pxr 32@0x00600ae0
 pxr2j 16@0x00600ae0~{}
 EOF
 EXPECT=<<EOF
-0x00600ae0 0x0040055e  ^.@. @reloc.printf 4195678 (.plt) R X 'push 0'
+0x00600ae0 0x0040055e  ^.@. @ reloc.printf 4195678 .plt R X 'push 0'
 0x00600ae4 ..[ null bytes ]..   00000000 
-0x00600ae8 0x0040056e  n.@. @reloc.puts 4195694 (.plt) R X 'push 1'
+0x00600ae8 0x0040056e  n.@. @ reloc.puts 4195694 .plt R X 'push 1'
 0x00600aec ..[ null bytes ]..   00000000 
-0x00600af0 0x0040057e  ~.@. @reloc.__libc_start_main 4195710 (.plt) R X 'push 2'
+0x00600af0 0x0040057e  ~.@. @ reloc.__libc_start_main 4195710 .plt R X 'push 2'
 0x00600af4 ..[ null bytes ]..   00000000 
-0x00600af8 0x0040058e  ..@. @reloc.fgets 4195726 (.plt) R X 'push 3'
+0x00600af8 0x0040058e  ..@. @ reloc.fgets 4195726 .plt R X 'push 3'
 0x00600afc ..[ null bytes ]..   00000000 
-0x00600ae0 0x000000000040055e   ^.@..... @reloc.printf 4195678 (.plt) R X 'push 0'
-0x00600ae8 0x000000000040056e   n.@..... @reloc.puts 4195694 (.plt) R X 'push 1'
-0x00600af0 0x000000000040057e   ~.@..... @reloc.__libc_start_main 4195710 (.plt) R X 'push 2'
-0x00600af8 0x000000000040058e   ..@..... @reloc.fgets 4195726 (.plt) R X 'push 3'
-0x00600ae0 5e05  ^. @reloc.printf 1374 (.symtab)
-0x00600ae2 4000  @. 64 (.shstrtab) ascii ('@')
+0x00600ae0 0x000000000040055e   ^.@..... @ reloc.printf 4195678 .plt R X 'push 0'
+0x00600ae8 0x000000000040056e   n.@..... @ reloc.puts 4195694 .plt R X 'push 1'
+0x00600af0 0x000000000040057e   ~.@..... @ reloc.__libc_start_main 4195710 .plt R X 'push 2'
+0x00600af8 0x000000000040058e   ..@..... @ reloc.fgets 4195726 .plt R X 'push 3'
+0x00600ae0 5e05  ^. @ reloc.printf 1374 .symtab
+0x00600ae2 4000  @. 64 .shstrtab ascii ('@')
 0x00600ae4 0000  ..
 0x00600ae6 0000  ..
-0x00600ae8 6e05  n. @reloc.puts 1390 (.symtab)
-0x00600aea 4000  @. 64 (.shstrtab) ascii ('@')
+0x00600ae8 6e05  n. @ reloc.puts 1390 .symtab
+0x00600aea 4000  @. 64 .shstrtab ascii ('@')
 0x00600aec 0000  ..
 0x00600aee 0000  ..
-0x00600af0 7e05  ~. @reloc.__libc_start_main 1406 (.symtab)
-0x00600af2 4000  @. 64 (.shstrtab) ascii ('@')
+0x00600af0 7e05  ~. @ reloc.__libc_start_main 1406 .symtab
+0x00600af2 4000  @. 64 .shstrtab ascii ('@')
 0x00600af4 0000  ..
 0x00600af6 0000  ..
-0x00600af8 8e05  .. @reloc.fgets 1422 (.symtab)
-0x00600afa 4000  @. 64 (.shstrtab) ascii ('@')
+0x00600af8 8e05  .. @ reloc.fgets 1422 .symtab
+0x00600afa 4000  @. 64 .shstrtab ascii ('@')
 0x00600afc 0000  ..
 0x00600afe 0000  ..
-0x00600ae0 0x0040055e  ^.@. @reloc.printf (.plt) R X 'push 0'
+0x00600ae0 0x0040055e  ^.@. @ reloc.printf .plt R X 'push 0'
 0x00600ae4 ..[ null bytes ]..   00000000 
-0x00600ae8 0x0040056e  n.@. @reloc.puts (.plt) R X 'push 1'
+0x00600ae8 0x0040056e  n.@. @ reloc.puts .plt R X 'push 1'
 0x00600aec ..[ null bytes ]..   00000000 
-0x00600af0 0x0040057e  ~.@. @reloc.__libc_start_main (.plt) R X 'push 2'
+0x00600af0 0x0040057e  ~.@. @ reloc.__libc_start_main .plt R X 'push 2'
 0x00600af4 ..[ null bytes ]..   00000000 
-0x00600af8 0x0040058e  ..@. @reloc.fgets (.plt) R X 'push 3'
+0x00600af8 0x0040058e  ..@. @ reloc.fgets .plt R X 'push 3'
 0x00600afc ..[ null bytes ]..   00000000 
 [
   {
     "addr": 6294240,
-    "value": 4195678,
-    "ref": "(.plt) R X 'push 0'"
+    "value": 1374,
+    "refstr": "1374 .symtab",
+    "ref": {
+      "addr": 1374,
+      "value": "1374",
+      "section": ".symtab"
+    }
   },
   {
     "addr": 6294242,
     "value": 64,
-    "ref": "64 (.shstrtab) ascii ('@')"
+    "refstr": "64 .shstrtab ascii ('@')",
+    "ref": {
+      "addr": 64,
+      "value": "64",
+      "section": ".shstrtab",
+      "attr": [
+        "ascii"
+      ]
+    }
   },
   {
     "addr": 6294244,
     "value": 0,
-    "ref": "0 loc.imp.__gmon_start"
+    "refstr": "0",
+    "ref": {
+      "addr": 0,
+      "value": "0",
+      "attr": [
+        
+      ]
+    }
   },
   {
     "addr": 6294246,
-    "value": 91095040
+    "value": 0,
+    "refstr": "0",
+    "ref": {
+      "addr": 0,
+      "value": "0",
+      "attr": [
+        
+      ]
+    }
   },
   {
     "addr": 6294248,
-    "value": 4195694,
-    "ref": "(.plt) R X 'push 1'"
+    "value": 1390,
+    "refstr": "1390 .symtab",
+    "ref": {
+      "addr": 1390,
+      "value": "1390",
+      "section": ".symtab"
+    }
   },
   {
     "addr": 6294250,
     "value": 64,
-    "ref": "64 (.shstrtab) ascii ('@')"
+    "refstr": "64 .shstrtab ascii ('@')",
+    "ref": {
+      "addr": 64,
+      "value": "64",
+      "section": ".shstrtab",
+      "attr": [
+        "ascii"
+      ]
+    }
   },
   {
     "addr": 6294252,
     "value": 0,
-    "ref": "0 loc.imp.__gmon_start"
+    "refstr": "0",
+    "ref": {
+      "addr": 0,
+      "value": "0",
+      "attr": [
+        
+      ]
+    }
   }
 ]
 EOF


### PR DESCRIPTION
before:

![Screenshot 2020-10-08 at 12 41 23](https://user-images.githubusercontent.com/6431515/95448401-96b83900-0963-11eb-8150-90a708d302c7.png)


after:

![Screenshot 2020-10-08 at 12 39 49](https://user-images.githubusercontent.com/6431515/95448338-7ee0b500-0963-11eb-924c-49e3c42f2d0b.png)
![Screenshot 2020-10-08 at 12 40 02](https://user-images.githubusercontent.com/6431515/95448347-82743c00-0963-11eb-99c4-429325911e71.png)


 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

before:

```
$ r2 /tmp/Notes
[0x100002e10]> af
[0x100002e10]> aeim
[0x100002e10]> e io.cache=1
[0x100002e10]> wv reloc.objc_msgSend @ reloc.objc_msgSend
[0x100002e10]> aepc main ; aesu 0x100002e4b;drr~A0,A1,r15
A1   rsi    10025bfba         4297441210 (3.__TEXT.__objc_methname) R X 'jae 0x10025c030' (standardUserDefaults)
A0   rdi    0                 0
     r15    1002fcf98         4298100632 (12.__DATA_CONST.__got) R 0x1002fcf98
PC   rip    100002e4b         4294979147 (0.__TEXT.__text) main R X 'call r15'
[0x100002e10]>
```

after:

```
$ r2 /tmp/Notes
[0x100002e10]> af
[0x100002e10]> aeim
[0x100002e10]> e io.cache=1
[0x100002e10]> wv reloc.objc_msgSend @ reloc.objc_msgSend
[0x100002e10]> aepc main ; aesu 0x100002e4b;drr~A0,A1,r15
A1   rsi    10025bfba         4297441210 (3.__TEXT.__objc_methname) str.standardUserDefaults,rsi: R X 'jae 0x10025c030' (standardUserDefaults)
A0   rdi    0                 0
     r15    1002fcf98         4298100632 (12.__DATA_CONST.__got) reloc.objc_msgSend,r15: R 0x1002fcf98
PC   rip    100002e4b         4294979147 (0.__TEXT.__text) rip: main R X 'call r15'
[0x100002e10]>
```

**Test plan**

I expect some tests to fail

**Closing issues**

none tracked
