### PR TITLE
Fix dp command in BSD systems ##debug

### DIFF
--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -608,7 +608,7 @@ static RList *r_debug_native_pids(RDebug *dbg, int pid) {
 #elif __linux__
 	return linux_pid_list (pid, list);
 #else /* rest is BSD */
-	return bsd_pid_list (dbg, list);
+	return bsd_pid_list (dbg, pid, list);
 #endif
 	return list;
 }

--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -293,44 +293,34 @@ RList *bsd_pid_list(RDebug *dbg, int pid, RList *list) {
 # define KINFO_PROC kinfo_proc
 #endif
 	char errbuf[_POSIX2_LINE_MAX];
-	struct KINFO_PROC* kp;
+	struct KINFO_PROC *kp, *entry;
 	int cnt = 0;
+	int i;
+
 #if __FreeBSD__
 	kvm_t *kd = kvm_openfiles (NULL, "/dev/null", NULL, KVM_OPEN_FLAG, errbuf);
 #else
 	kvm_t *kd = kvm_openfiles (NULL, NULL, NULL, KVM_OPEN_FLAG, errbuf);
 #endif
 	if (!kd) {
-		eprintf ("kvm_openfiles says %s\n", errbuf);
+		eprintf ("kvm_openfiles failed: %s\n", errbuf);
 		return NULL;
 	}
-	if (pid) {
-		kp = KVM_GETPROCS (kd, KERN_PROC_PID, pid, &cnt);
-		if (cnt == 1) {
-			RDebugPid *p = r_debug_pid_new (KP_COMM (kp), pid, KP_UID (kp), 's', 0);
-			if (p) r_list_append (list, p);
-			/* we got our process, now fetch the parent process */
-			kp = KVM_GETPROCS (kd, KERN_PROC_PID, KP_PPID(kp), &cnt);
-                        if (cnt == 1) {
-				RDebugPid *p = r_debug_pid_new (KP_COMM (kp), KP_PID (kp), KP_UID (kp), 's', 0);
-				if (p) {
-					p->ppid = KP_PPID (kp);
-					r_list_append (list, p);
-				}
-			}
-		}
-	} else {
-		kp = KVM_GETPROCS (kd, KERN_PROC_UID, geteuid(), &cnt);
-		int i;
-		for (i = 0; i < cnt; i++) {
-			RDebugPid *p = r_debug_pid_new (KP_COMM (kp + i), KP_PID (kp + i), KP_UID (kp), 's', 0);
+
+	kp = KVM_GETPROCS (kd, KERN_PROC_PROC, 0, &cnt);
+	for (i = 0; i < cnt; i++) {
+		entry = kp + i;
+		// Unless pid 0 is requested, only add the requested pid and it's child processes
+		if (0 == pid || KP_PID (entry) == pid || KP_PPID (entry) == pid) {
+			RDebugPid *p = r_debug_pid_new (KP_COMM (entry), KP_PID (entry), KP_UID (entry), 's', 0);
 			if (p) {
-				p->ppid = KP_PPID (kp);
+				p->ppid = KP_PPID (entry);
 				r_list_append (list, p);
 			}
 		}
 	}
-	kvm_close(kd);
+
+	kvm_close (kd);
 #endif
 	return list;
 }

--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -296,7 +296,11 @@ RList *bsd_pid_list(RDebug *dbg, RList *list) {
 	char errbuf[_POSIX2_LINE_MAX];
 	struct KINFO_PROC* kp;
 	int cnt = 0;
-	kvm_t* kd = kvm_openfiles (NULL, NULL, NULL, KVM_OPEN_FLAG, errbuf);
+#if __FreeBSD__
+	kvm_t *kd = kvm_openfiles (NULL, "/dev/null", NULL, KVM_OPEN_FLAG, errbuf);
+#else
+	kvm_t *kd = kvm_openfiles (NULL, NULL, NULL, KVM_OPEN_FLAG, errbuf);
+#endif
 	if (!kd) {
 		eprintf ("kvm_openfiles says %s\n", errbuf);
 		return NULL;

--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -253,7 +253,7 @@ RDebugInfo *bsd_info(RDebug *dbg, const char *arg) {
 #endif
 }
 
-RList *bsd_pid_list(RDebug *dbg, RList *list) {
+RList *bsd_pid_list(RDebug *dbg, int pid, RList *list) {
 #if __KFBSD__
 #ifdef __NetBSD__
 # define KVM_OPEN_FLAG KVM_NO_FILES
@@ -292,7 +292,6 @@ RList *bsd_pid_list(RDebug *dbg, RList *list) {
 # define KP_UID(x) (x)->ki_uid
 # define KINFO_PROC kinfo_proc
 #endif
-	int pid = dbg->pid;
 	char errbuf[_POSIX2_LINE_MAX];
 	struct KINFO_PROC* kp;
 	int cnt = 0;

--- a/libr/debug/p/native/bsd/bsd_debug.h
+++ b/libr/debug/p/native/bsd/bsd_debug.h
@@ -9,7 +9,7 @@
 int bsd_handle_signals(RDebug *dbg);
 int bsd_reg_write(RDebug *dbg, int type, const ut8 *buf, int size);
 RDebugInfo *bsd_info(RDebug *dbg, const char *arg);
-RList *bsd_pid_list(RDebug *dbg, RList *list);
+RList *bsd_pid_list(RDebug *dbg, int pid, RList *list);
 RList *bsd_native_sysctl_map(RDebug *dbg);
 RList *bsd_desc_list(int pid);
 RList *bsd_thread_list(RDebug *dbg, int pid, RList *list);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

`dp` failed with permission denied on FreeBSD, didn't display the process' children and running `dp [pid]` didn't work.

**Test plan**

In *BSD without root:

* Run `dp` and see that the process and it's children are displayed
* Run `dp 0` and see that all processes shown in `ps` are printed(without threads)
* Run `dp [other pid]` and see that the process and it's children are displayed
