### PR TITLE
Show PTR in Intel syntax

### DIFF
--- a/libr/asm/p/asm_x86_cs.c
+++ b/libr/asm/p/asm_x86_cs.c
@@ -104,15 +104,10 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		}
 	}
 	if (op->size == 0 && n > 0 && insn->size > 0) {
-		char *ptrstr;
 		op->size = insn->size;
 		char *buf_asm = sdb_fmt ("%s%s%s",
 				insn->mnemonic, insn->op_str[0]?" ":"",
 				insn->op_str);
-		ptrstr = strstr (buf_asm, "ptr ");
-		if (ptrstr) {
-			memmove (ptrstr, ptrstr + 4, strlen (ptrstr + 4) + 1);
-		}
 		r_asm_op_set_asm (op, buf_asm);
 	} else {
 		decompile_vm (a, op, buf, len);


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

For Intel syntax the copy-past use case is broken when the PTR dropped from view. The copied code string should first be purged from all PTRs and then pasted to be assembled by rasm2 (see issue #17752)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Open gettid.o binary
The function sym.gettid() should show 'PTR' for mov instructions
```
┌ 17: sym.gettid ();
│           0x08000040      64488b042500.  mov rax, qword ptr fs:[0]    ; [05] -r-x section size 17 named .text.gettid
│           0x08000049      488b4008       mov rax, qword ptr [rax + 8]
│           0x0800004d      8b4010         mov eax, dword ptr [rax + 0x10]
```

[gettid.zip](https://github.com/radareorg/radare2/files/5347427/gettid.zip)


**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #17752
