### PR TITLE
Implement `asm.pseudo` for RISC-V

### DIFF
--- a/libr/include/r_parse.h
+++ b/libr/include/r_parse.h
@@ -132,6 +132,7 @@ extern RParsePlugin r_parse_plugin_mips_pseudo;
 extern RParsePlugin r_parse_plugin_ppc_pseudo;
 extern RParsePlugin r_parse_plugin_sh_pseudo;
 extern RParsePlugin r_parse_plugin_wasm_pseudo;
+extern RParsePlugin r_parse_plugin_riscv_pseudo;
 extern RParsePlugin r_parse_plugin_x86_pseudo;
 extern RParsePlugin r_parse_plugin_z80_pseudo;
 extern RParsePlugin r_parse_plugin_tms320_pseudo;

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -328,6 +328,7 @@ parse_plugins = [
   'mips_pseudo',
   'ppc_pseudo',
   'sh_pseudo',
+  'riscv_pseudo',
   'v850_pseudo',
   'wasm_pseudo',
   'x86_pseudo',

--- a/libr/parse/meson.build
+++ b/libr/parse/meson.build
@@ -17,6 +17,7 @@ r_parse_sources = [
   'p/parse_v850_pseudo.c',
   'p/parse_wasm_pseudo.c',
   'p/parse_x86_pseudo.c',
+  'p/parse_riscv_pseudo.c',
   'p/parse_z80_pseudo.c'
 ]
 

--- a/libr/parse/p/parse_riscv_pseudo.c
+++ b/libr/parse/p/parse_riscv_pseudo.c
@@ -181,10 +181,11 @@ static int parse(RParse *p, const char *data, char *str) {
 					ptr = (char*)r_str_lchr (buf, ']');
 					if (n && ptr) {
 						char *rest = strdup (ptr + 1);
+						int dist = ptr - buf;
 						if (n > 0) {
-							snprintf (ptr, sizeof (ptr), "+%d]%s", n, rest);
+							snprintf (ptr, len + 1 - dist, "+%d]%s", n, rest);
 						} else {
-							snprintf (ptr, sizeof (ptr), "%d]%s", n, rest);
+							snprintf (ptr, len + 1 - dist, "%d]%s", n, rest);
 						}
 						free (rest);
 					}

--- a/libr/parse/p/parse_riscv_pseudo.c
+++ b/libr/parse/p/parse_riscv_pseudo.c
@@ -175,16 +175,16 @@ static int parse(RParse *p, const char *data, char *str) {
 					num = (char *)r_str_lchr (buf, ',');
 				}
 				if (num) {
-					n = atoi (num+1);
+					n = atoi (num + 1);
 					*ptr = '[';
-					memmove (num+1, ptr, strlen (ptr)+1);
+					r_str_cpy (num + 1, ptr);
 					ptr = (char*)r_str_lchr (buf, ']');
 					if (n && ptr) {
-						char *rest = strdup (ptr+1);
+						char *rest = strdup (ptr + 1);
 						if (n > 0) {
-							sprintf (ptr, "+%d]%s", n, rest);
+							snprintf (ptr, sizeof (ptr), "+%d]%s", n, rest);
 						} else {
-							sprintf (ptr, "%d]%s", n, rest);
+							snprintf (ptr, sizeof (ptr), "%d]%s", n, rest);
 						}
 						free (rest);
 					}

--- a/libr/parse/p/parse_riscv_pseudo.c
+++ b/libr/parse/p/parse_riscv_pseudo.c
@@ -1,0 +1,229 @@
+/* radare - LGPL - Copyright 2020 - Aswin C (officialcjunior) */
+
+#include <r_lib.h>
+#include <r_flag.h>
+#include <r_anal.h>
+#include <r_parse.h>
+
+static int replace(int argc, const char *argv[], char *newstr) {
+#define MAXPSEUDOOPS 10
+	int i, j, k, d;
+	char ch;
+	struct {
+		int narg;
+		char *op;
+		char *str;
+		int args[MAXPSEUDOOPS];
+	} ops[] = {
+		{ 0, "add", "# = # + #", { 1, 2, 3 } },
+		{ 0, "addi", "# = # + #", { 1, 2, 3 } },
+		{ 0, "and", "# = # & #", { 1, 2, 3 } },
+		{ 0, "andi", "# = # & #", { 1, 2, 3 } },
+		{ 0, "beq", "if (# == #) goto #", { 1, 2, 3 } },
+		{ 0, "bleu", "if (unsigned)# <= # goto #", { 1, 2, 3 } },
+		{ 0, "bltu", "if (unsigned)# < # goto #", { 1, 2, 3 } },
+		{ 0, "blt", "if (# < #) goto #", { 1, 2, 3 } },
+		{ 0, "beqz", "if (# == 0) goto #", { 1, 2 } },
+		{ 0, "bne", "if (# != #) goto #", { 1, 2, 3 } },
+		{ 0, "bnez", "if (# != 0) goto #", { 1, 2 } },
+		{ 0, "bgez", "if (# >= 0) goto #", { 1, 2 } },
+		{ 0, "bgtz", "if (# > 0) goto #", { 1, 2 } },
+		{ 0, "fld", "# = #", { 1, 2 } },
+		{ 0, "j", "jmp #", { 1 } },
+		{ 0, "jr", "jmp #", { 1 } },
+		{ 0, "jalr", "jmp #", { 1 } },
+		{ 0, "jal", "jmp #", { 1 } },
+		{ 0, "ld", "# = (double)[#]", { 1, 2 } },
+		{ 0, "li", "# = #", { 1, 2 } },
+		{ 0, "lh", "# = [#]", { 1, 2 } },
+		{ 0, "lui", "# = #", { 1, 2 } },
+		{ 0, "lbu", "# = (unsigned)[#]", { 1, 2 } },
+		{ 0, "lhu", "# = (unsigned)[#]", { 1, 2 } },
+		{ 0, "lw", "# = [#]", { 1, 2 } },
+		{ 0, "mv", "# = #", { 1, 2 } },
+		{ 0, "or", "# = # | #", { 1, 2, 3 } },
+		{ 0, "sd", "[#] = (double)#", { 2, 1 } },
+		{ 0, "sw", "[#] = #", { 2, 1 } },
+		{ 0, "sb", "[#] = #", { 2, 1 } },
+		{ 0, "sh", "[#] = #", { 2, 1 } },
+		{ 0, "sub", "# = # - #", { 1, 2, 3 } },
+		{ 0, NULL }
+	};
+	if (!newstr) {
+		return false;
+	}
+
+	for (i = 0; ops[i].op; i++) {
+		if (ops[i].narg) {
+			if (argc - 1 != ops[i].narg) {
+				continue;
+			}
+		}
+		if (!strcmp (ops[i].op, argv[0])) {
+			if (newstr) {
+				d = 0;
+				j = 0;
+				ch = ops[i].str[j];
+				for (j = 0, k = 0; ch != '\0'; j++, k++) {
+					ch = ops[i].str[j];
+					if (ch == '#') {
+						if (d >= MAXPSEUDOOPS) {
+							// XXX Shouldn't ever happen...
+							continue;
+						}
+						int idx = ops[i].args[d];
+						d++;
+						if (idx <= 0) {
+							// XXX Shouldn't ever happen...
+							continue;
+						}
+						const char *w = argv[idx];
+						if (w) {
+							strcpy (newstr + k, w);
+							k += strlen (w) - 1;
+						}
+					} else {
+						newstr[k] = ch;
+					}
+				}
+				newstr[k] = '\0';
+			}
+			r_str_replace_char (newstr, '{', '(');
+			r_str_replace_char (newstr, '}', ')');
+			return true;
+		}
+	}
+
+	/* TODO: this is slow */
+	newstr[0] = '\0';
+	for (i = 0; i < argc; i++) {
+		strcat (newstr, argv[i]);
+		strcat (newstr, (!i || i == argc - 1)? " " : ",");
+	}
+
+	r_str_replace_char (newstr, '{', '(');
+	r_str_replace_char (newstr, '}', ')');
+	return false;
+}
+
+static int parse(RParse *p, const char *data, char *str) {
+	char w0[256], w1[256], w2[256], w3[256];
+	int i, len = strlen (data), n;
+	char *buf, *ptr, *optr, *num;
+
+	if (len >= sizeof (w0)) {
+		return false;
+	}
+	// malloc can be slow here :?
+	if (!(buf = malloc (len + 1))) {
+		return false;
+	}
+	memcpy (buf, data, len + 1);
+	if (*buf) {
+		*w0 = *w1 = *w2 = *w3 = '\0';
+		ptr = strchr (buf, ' ');
+		if (!ptr) {
+			ptr = strchr (buf, '\t');
+		}
+		if (ptr) {
+			*ptr = '\0';
+			for (++ptr; *ptr == ' '; ptr++) {
+				;
+			}
+			strncpy (w0, buf, sizeof (w0) - 1);
+			strncpy (w1, ptr, sizeof (w1) - 1);
+
+			optr = ptr;
+			if (*ptr == '(') {
+				ptr = strchr (ptr+1, ')');
+			}
+			if (ptr && *ptr == '[') {
+				ptr = strchr (ptr+1, ']');
+			}
+			if (ptr && *ptr == '{') {
+				ptr = strchr (ptr+1, '}');
+			}
+			if (!ptr) {
+				eprintf ("Unbalanced bracket\n");
+				free(buf);
+				return false;
+			}
+			ptr = strchr (ptr, ',');
+			if (ptr) {
+				*ptr = '\0';
+				for (++ptr; *ptr == ' '; ptr++) {
+					;
+				}
+				strncpy (w1, optr, sizeof (w1) - 1);
+				strncpy (w2, ptr, sizeof (w2) - 1);
+				optr = ptr;
+				ptr = strchr (ptr, ',');
+				if (ptr) {
+					*ptr = '\0';
+					for (++ptr; *ptr == ' '; ptr++) {
+						;
+					}
+					strncpy (w2, optr, sizeof (w2) - 1);
+					strncpy (w3, ptr, sizeof (w3) - 1);
+				}
+			}
+			ptr = strchr (buf, '(');
+			if (ptr) {
+				*ptr = 0;
+				num = (char*)r_str_lchr (buf, ' ');
+				if (!num) {
+					num = (char *)r_str_lchr (buf, ',');
+				}
+				if (num) {
+					n = atoi (num+1);
+					*ptr = '[';
+					memmove (num+1, ptr, strlen (ptr)+1);
+					ptr = (char*)r_str_lchr (buf, ']');
+					if (n && ptr) {
+						char *rest = strdup (ptr+1);
+						if (n > 0) {
+							sprintf (ptr, "+%d]%s", n, rest);
+						} else {
+							sprintf (ptr, "%d]%s", n, rest);
+						}
+						free (rest);
+					}
+				} else {
+					*ptr = '[';
+				}
+			}
+		}
+		{
+			const char *wa[] = { w0, w1, w2, w3 };
+			int nw = 0;
+			for (i = 0; i < 4; i++) {
+				if (wa[i][0]) {
+					nw++;
+				}
+			}
+			replace (nw, wa, str);
+		}
+	}
+	{
+		char *s = strdup (str);
+		s = r_str_replace (s, "+ -", "- ", 1);
+		s = r_str_replace (s, "- -", "+ ", 1);
+		strcpy (str, s);
+		free (s);
+	}
+	free (buf);
+	return true;
+}
+
+RParsePlugin r_parse_plugin_riscv_pseudo = {
+	.name = "riscv.pseudo",
+	.desc = "riscv pseudo syntax",
+	.parse = parse,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_PARSE,
+	.data = &r_parse_plugin_riscv_pseudo,
+	.version = R2_VERSION};
+#endif

--- a/libr/parse/p/parse_riscv_pseudo.c
+++ b/libr/parse/p/parse_riscv_pseudo.c
@@ -181,11 +181,11 @@ static int parse(RParse *p, const char *data, char *str) {
 					ptr = (char*)r_str_lchr (buf, ']');
 					if (n && ptr) {
 						char *rest = strdup (ptr + 1);
-						int dist = ptr - buf;
+						size_t dist = len + 1 - (ptr - buf);
 						if (n > 0) {
-							snprintf (ptr, len + 1 - dist, "+%d]%s", n, rest);
+							snprintf (ptr, dist, "+%d]%s", n, rest);
 						} else {
-							snprintf (ptr, len + 1 - dist, "%d]%s", n, rest);
+							snprintf (ptr, dist, "%d]%s", n, rest);
 						}
 						free (rest);
 					}

--- a/libr/parse/p/riscv_pseudo.mk
+++ b/libr/parse/p/riscv_pseudo.mk
@@ -11,6 +11,6 @@ ifeq ($(CC),cccl)
 	endif
 
 ${TARGET_RISCVPSEUDO}: ${OBJ_RISCVPSEUDO}
-	${CC} $(call libname,parse_riscv_pseudo) -L../../util -llibr_util \
+	${CC} $(call libname,parse_riscv_pseudo) -L../../util -lr_util \
 		$(LDFLAGS_SHARED) ${RISCV_CFLAGS} -o ${TARGET_RISCVPSEUDO} ${OBJ_RISCVPSEUDO}
 

--- a/libr/parse/p/riscv_pseudo.mk
+++ b/libr/parse/p/riscv_pseudo.mk
@@ -1,0 +1,16 @@
+OBJ_RISCVPSEUDO+=parse_riscv_pseudo.o
+
+TARGET_RISCVPSEUDO=parse_riscv_pseudo.${EXT_SO}
+ALL_TARGETS+=${TARGET_RISCVPSEUDO}
+STATIC_OBJ+=${OBJ_RISCVPSEUDO}
+
+ifeq ($(CC),cccl)
+	RISCV_CFLAGS:=${CFLAGS}
+	else
+	RISCV_CFLAGS:=${CFLAGS} ${LINK}
+	endif
+
+${TARGET_RISCVPSEUDO}: ${OBJ_RISCVPSEUDO}
+	${CC} $(call libname,parse_riscv_pseudo) -L../../util -llibr_util \
+		$(LDFLAGS_SHARED) ${RISCV_CFLAGS} -o ${TARGET_RISCVPSEUDO} ${OBJ_RISCVPSEUDO}
+

--- a/plugins.def.cfg
+++ b/plugins.def.cfg
@@ -270,6 +270,7 @@ parse.att2intel
 parse.chip8_pseudo
 parse.dalvik_pseudo
 parse.m68k_pseudo
+parse.riscv_pseudo
 parse.mips_pseudo
 parse.ppc_pseudo
 parse.sh_pseudo

--- a/plugins.static.cfg
+++ b/plugins.static.cfg
@@ -224,6 +224,7 @@ parse.mips_pseudo
 parse.ppc_pseudo
 parse.sh_pseudo
 parse.wasm_pseudo
+parse.riscv_pseudo
 parse.x86_pseudo
 parse.z80_pseudo"
 SHARED="io.shm

--- a/test/db/anal/riscv
+++ b/test/db/anal/riscv
@@ -42,3 +42,19 @@ EXPECT=<<EOF
             0x00000008      0000           illegal
 EOF
 RUN
+
+NAME=asm pseudo for riscv
+FILE=bins/elf/analysis/guess-number-riscv64
+CMDS=<<EOF
+s 0x00010178
+e asm.pseudo = 1
+pd 5
+EOF
+EXPECT=<<EOF
+            0x00010178      ef00c01f       jmp ra                      ; sym.printf
+            0x0001017c      930784fe       a5 = s0 - 24
+            0x00010180      93850700       a1 = a5
+            0x00010184      b7170200       a5 = 0x21
+            0x00010188      13850751       a0 = a5 + 1296
+EOF
+RUN

--- a/test/db/cmd/cmd_list
+++ b/test/db/cmd/cmd_list
@@ -13,6 +13,7 @@ dalvik.pseudo
 m68k.pseudo
 mips.pseudo
 ppc.pseudo
+riscv.pseudo
 sh.pseudo
 tms320.pseudo
 v850.pseudo

--- a/test/db/formats/elf/elf-riscv64
+++ b/test/db/formats/elf/elf-riscv64
@@ -525,7 +525,7 @@ EXPECT=<<EOF
 |      ::   0x00010174      1385874f       addi a0, a5, 1272           ; const char *format
 |      ::   0x00010178      ef00c01f       jal ra, dbg.printf
 |      ::   0x0001017c      930784fe       addi a5, s0, -24
-|      ::   0x00010180      93850700       mv a1, var_bp_18h
+|      ::   0x00010180      93850700       mv a1, a5
 |      ::   0x00010184      b7170200       lui a5, 0x21
 |      ::   0x00010188      13850751       addi a0, a5, 1296           ; const char *format
 |      ::   0x0001018c      ef00402f       jal ra, dbg.scanf


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

What I'm hoping to add here, is support for `asm.pseudo` for the RISC-V architecture. I referred to [The RISC-V Instruction Set Manual](http://content.riscv.org/wp-content/uploads/2017/05/riscv-spec-v2.2.pdf), notably page 110, for the instructions.
As I am not an expert in this, I was mostly looking at the commit [e28ce](https://github.com/radareorg/radare2/commit/e28ce2990d90660a35053263555d796f034f74e3) and `parse_arm_pseudo.c` to make this possible.

**Test plan**
It seems to work, at least on layman's terms:

![image](https://user-images.githubusercontent.com/29057155/95674273-aab2a380-0bcc-11eb-8cc9-ca786b9b6883.png)

I've added a small test which succeeds, but I think its probably not enough, as it's not very big and I believe that there's lot more to fix and add in this PR.
```
$ r2r -i test/db/anal/riscv 
Loaded 4 tests.
Skipping json tests because jq is not available.
[4/4]                       4 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```

I'm still learning how the parsing works, so here, I've basically just used the function `parse()` from `parse_arm_pseudo`, so it probably have many useless things, that I didn't understand or thought wasn't important. So, I'm hoping to fix them all, one by one, through your requests.

**Closing issues**
None
