### PR TITLE
Refactor r_sign metrics match ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -2374,11 +2374,11 @@ static bool hash_match(RSignItem *it, char **digest_hex, RSignSearchMetrics *sm)
 
 static bool str_list_equals(RList *la, RList *lb) {
 	r_return_val_if_fail (la && lb, false);
-	int len = r_list_length (la);
+	size_t len = r_list_length (la);
 	if (len != r_list_length (lb)) {
 		return false;
 	}
-	int i;
+	size_t i;
 	for (i = 0; i < len; i++) {
 		const char *a = r_list_get_n (la, i);
 		const char *b = r_list_get_n (lb, i);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -70,11 +70,19 @@ typedef struct r_sign_item_t {
 
 typedef int (*RSignForeachCallback)(RSignItem *it, void *user);
 typedef int (*RSignSearchCallback)(RSignItem *it, RSearchKeyword *kw, ut64 addr, void *user);
-typedef int (*RSignGraphMatchCallback)(RSignItem *it, RAnalFunction *fcn, void *user);
-typedef int (*RSignOffsetMatchCallback)(RSignItem *it, RAnalFunction *fcn, void *user);
-typedef int (*RSignHashMatchCallback)(RSignItem *it, RAnalFunction *fcn, void *user);
-typedef int (*RSignRefsMatchCallback)(RSignItem *it, RAnalFunction *fcn, void *user);
-typedef int (*RSignVarsMatchCallback)(RSignItem *it, RAnalFunction *fcn, void *user);
+typedef int (*RSignMatchCallback)(RSignItem *it, RAnalFunction *fcn, RSignType type, bool seen, void *user);
+
+typedef struct r_sign_search_met {
+	/* types is an 0 terminated array of RSignTypes that are going to be
+	 * searched for. Valid types are: graph, offset, refs, bbhash, types, vars
+	 */
+	RSignType types[7];
+	int mincc; // min complexity for graph search
+	RAnal *anal;
+	void *user; // user data for callback function
+	RSignMatchCallback cb;
+	RAnalFunction *fcn;
+} RSignSearchMetrics;
 
 typedef struct r_sign_search_t {
 	RSearch *search;
@@ -123,12 +131,7 @@ R_API RSignSearch *r_sign_search_new(void);
 R_API void r_sign_search_free(RSignSearch *ss);
 R_API void r_sign_search_init(RAnal *a, RSignSearch *ss, int minsz, RSignSearchCallback cb, void *user);
 R_API int r_sign_search_update(RAnal *a, RSignSearch *ss, ut64 *at, const ut8 *buf, int len);
-R_API bool r_sign_match_graph(RAnal *a, RAnalFunction *fcn, int mincc, RSignGraphMatchCallback cb, void *user);
-R_API bool r_sign_match_addr(RAnal *a, RAnalFunction *fcn, RSignOffsetMatchCallback cb, void *user);
-R_API bool r_sign_match_hash(RAnal *a, RAnalFunction *fcn, RSignHashMatchCallback cb, void *user);
-R_API bool r_sign_match_refs(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
-R_API bool r_sign_match_vars(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
-R_API bool r_sign_match_types(RAnal *a, RAnalFunction *fcn, RSignRefsMatchCallback cb, void *user);
+R_API int r_sign_fcn_match_metrics(RSignSearchMetrics *sm);
 
 R_API bool r_sign_load(RAnal *a, const char *file);
 R_API bool r_sign_load_gz(RAnal *a, const char *filename);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

This refactors r_sign function metrics matching. Now instead of a function to match each metric type, there is a single function. This allows RSignItems to created only once, instead of once per type. Additionally, a cache was added to some of the expensive function information. This results in a significant speed increase.
 
```
$ ./r2test.sh 
Warning: run r2 with -e io.cache=true to fix relocations in disassembly
[x] Analyze all flags starting with sym. and entry0 (aa)
generated zignatures: 3182
[+] searching function metrics
hits: 15919
774.342817
15919
$ ./r2test.sh 
Warning: run r2 with -e io.cache=true to fix relocations in disassembly
[x] Analyze all flags starting with sym. and entry0 (aa)
generated zignatures: 3182
[+] searching function metrics
hits: 286318
134.880014
286318
$ cat r2test.sh 
#!/bin/bash

r2 -Qc 'aa
zg
e zign.bytes = false
?t z/
f ~sign.?' /usr/lib/libc.so.6
```

I am not sure why there is a discrepancy in hits between versions. All current tests pass.

**Test plan**

Current r2 zign tests pass. More could be added but I will have to look into where things are weak.

**Closing issues**

None
