### PR TITLE
Update `u?` and improve `uc?` ##cons

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -285,9 +285,18 @@ static const char *help_msg_u[] = {
 	"u", "", "show system uname",
 	"uw", "", "alias for wc (requires: e io.cache=true)",
 	"us", "", "alias for s- (seek history)",
-	"uc", "", "undo core commands (uc?, ucl, uc*, ..)",
+	"uc", "[?]", "undo core commands (uc?, ucl, uc*, ..)",
 	"uniq", "", "filter rows to avoid duplicates",
 	"uname", "", "uname - show system information",
+	NULL
+};
+
+static const char *help_msg_uc[] = {
+	"Usage:", "uc [cmd] [revert-cmd]", "undo core commands",
+	"uc", "", "list all core undos",
+	"uc*", "", "list all core undos as r2 commands",
+	"uc-", "", "undo last action",
+	"uc.", "", "list all reverts in current",
 	NULL
 };
 
@@ -561,14 +570,10 @@ static int cmd_undo(void *data, const char *input) {
 			free (cmd);
 			}
 			break;
-		case '?':
-			eprintf ("Usage: uc [cmd],[revert-cmd]\n");
-			eprintf (" uc. - list all reverts in current\n");
-			eprintf (" uc* - list all core undos\n");
-			eprintf (" uc  - list all core undos\n");
-			eprintf (" uc- - undo last action\n");
+		case '?': // "uc?"
+			r_core_cmd_help (core, help_msg_uc);
 			break;
-		case '.': {
+		case '.': { // "uc."
 			RCoreUndoCondition cond = {
 				.addr = core->offset,
 				.minstamp = 0,
@@ -576,7 +581,7 @@ static int cmd_undo(void *data, const char *input) {
 			};
 			r_core_undo_print (core, 1, &cond);
 			} break;
-		case '*':
+		case '*': // "uc*"
 			r_core_undo_print (core, 1, NULL);
 			break;
 		case '-': // "uc-"


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

I noticed that inside the help under `u?`, there was no indication that some sub commands exists under `uc?`, so I've added the `[?]`. 
I also improved the help under `uc?`, which was just `eprintf`-ing the help, with `r_core_cmd_help()`.

**Test plan**

So, this is what `uc?` will look like with this commit:
```
[0x00000000]> uc?
Usage: uc [cmd] [revert-cmd]  undo core commands
| uc   list all core undos
| uc*  list all core undos as r2 commands
| uc-  undo last action
| uc.  list all reverts in current
```
Please request changes, if necessary.

**Closing issues**

None
