### PR TITLE
Fix travis arm64 test_r2pipe_404

### DIFF
--- a/libr/socket/r2pipe.c
+++ b/libr/socket/r2pipe.c
@@ -271,7 +271,7 @@ R_API R2Pipe *r2pipe_open(const char *cmd) {
 	env ("R2PIPE_OUT", r2p->output[1]);
 
 	if (r2p->child) {
-		char ch = -1;
+		signed char ch = -1;
 		// eprintf ("[+] r2pipeipe child is %d\n", r2pipe->child);
 		if (read (r2p->output[0], &ch, 1) != 1) {
 			eprintf ("Failed to read 1 byte\n");


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Current the travis-ci reports
```
sh: 1: rodoro2: not found
return code 32512 for rodoro2 -q0 -
test_r2pipe OK
test_r2pipe_404 ERR
[XX] Fail at line 17: r2pipe can spawn
```
Using gdb on both ubuntu 20.04 amd64 and arm64(WSL), I noticed that when line 276 fails, on amd64 it jumps to line 281, but on arm64 it jumps to line 287. That's because `char` is treated as `unsigned char` on arm, making `ch == -1` false forever.
https://github.com/radareorg/radare2/blob/2ccd0c0cd21086d5aa7ed88939b5f5bf70b80184/libr/socket/r2pipe.c#L274-L287
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

See travis-ci report whether test_r2pipe_404 succeeds. But it seems travis-ci isn't enabled here. Could you enable it manually?

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
