### PR TITLE
COFF: add ARMNT and ARM64 support ##bin

### DIFF
--- a/libr/bin/format/coff/coff.h
+++ b/libr/bin/format/coff/coff.h
@@ -29,6 +29,7 @@ struct r_bin_coff_obj {
 	bool verbose;
 	HtUP *sym_ht;
 	HtUP *imp_ht;
+	ut64 *scn_va;
 };
 
 bool r_coff_supported_arch(const ut8 *buf); /* Reads two bytes from buf. */

--- a/libr/bin/format/coff/coff_specs.h
+++ b/libr/bin/format/coff/coff_specs.h
@@ -153,6 +153,14 @@
 #define COFF_REL_AMD64_REL32_4		8
 #define COFF_REL_AMD64_REL32_5		9
 
+#define COFF_REL_ARM_BRANCH24T		20
+#define COFF_REL_ARM_BLX23T		21
+
+#define COFF_REL_ARM64_ABSOLUTE		0
+#define COFF_REL_ARM64_ADDR32		1
+#define COFF_REL_ARM64_ADDR32NB		2
+#define COFF_REL_ARM64_BRANCH26		3
+
 R_PACKED(
 struct coff_hdr {
 	ut16 f_magic;	/* Magic number */

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -67,6 +67,7 @@ static bool _fill_bin_symbol(RBin *rbin, struct r_bin_coff_obj *bin, int idx, RB
 		//first index is 0 that is why -1
 		sc_hdr = &bin->scn_hdrs[s->n_scnum - 1];
 		ptr->paddr = sc_hdr->s_scnptr + s->n_value;
+		ptr->vaddr = bin->scn_va[s->n_scnum - 1] + s->n_value;
 	}
 
 	switch (s->n_sclass) {
@@ -82,7 +83,7 @@ static bool _fill_bin_symbol(RBin *rbin, struct r_bin_coff_obj *bin, int idx, RB
 	case COFF_SYM_CLASS_EXTERNAL:
 		if (s->n_scnum == COFF_SYM_SCNUM_UNDEF) {
 			ptr->is_imported = true;
-			ptr->paddr = UT64_MAX;
+			ptr->paddr = ptr->vaddr = UT64_MAX;
 			ptr->bind = "NONE";
 		} else {
 			ptr->bind = R_BIN_BIND_GLOBAL_STR;
@@ -94,7 +95,7 @@ static bool _fill_bin_symbol(RBin *rbin, struct r_bin_coff_obj *bin, int idx, RB
 	case COFF_SYM_CLASS_STATIC:
 		if (s->n_scnum == COFF_SYM_SCNUM_ABS) {
 			ptr->type = "ABS";
-			ptr->paddr = UT64_MAX;
+			ptr->paddr = ptr->vaddr = UT64_MAX;
 			ptr->name = r_str_newf ("%s-0x%08x", coffname, s->n_value);
 			if (ptr->name) {
 				R_FREE (coffname);
@@ -113,7 +114,6 @@ static bool _fill_bin_symbol(RBin *rbin, struct r_bin_coff_obj *bin, int idx, RB
 		ptr->type = r_str_constpool_get (&rbin->constpool, sdb_fmt ("%i", s->n_sclass));
 		break;
 	}
-	ptr->vaddr = ptr->paddr;
 	ptr->size = 4;
 	ptr->ordinal = 0;
 	return true;
@@ -192,6 +192,7 @@ static RList *sections(RBinFile *bf) {
 			ptr->size = obj->scn_hdrs[i].s_size;
 			ptr->vsize = obj->scn_hdrs[i].s_size;
 			ptr->paddr = obj->scn_hdrs[i].s_scnptr;
+			ptr->vaddr = obj->scn_va[i];
 			ptr->add = true;
 			ptr->perm = 0;
 			if (obj->scn_hdrs[i].s_flags & COFF_SCN_MEM_READ) {
@@ -269,6 +270,14 @@ static ut32 _read_le32(RBin *rbin, ut64 addr) {
 	return r_read_le32 (data);
 }
 
+static ut16 _read_le16(RBin *rbin, ut64 addr) {
+	ut8 data[2] = { 0 };
+	if (!rbin->iob.read_at (rbin->iob.io, addr, data, sizeof (data))) {
+		return UT16_MAX;
+	}
+	return r_read_le16 (data);
+}
+
 #define BYTES_PER_IMP_RELOC		8
 
 static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *bin, bool patch, ut64 imp_map) {
@@ -321,12 +330,12 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *bin, bool patch, u
 
 			reloc->symbol = symbol;
 			reloc->paddr = bin->scn_hdrs[i].s_scnptr + rel[j].r_vaddr;
-			reloc->vaddr = reloc->paddr;
+			reloc->vaddr = bin->scn_va[i] + rel[j].r_vaddr;
 			reloc->type = rel[j].r_type;
 
 			ut64 sym_vaddr = symbol->vaddr;
 			if (symbol->is_imported) {
-				reloc->import = (RBinImport *)ht_up_find (bin->sym_ht, (ut64)rel[j].r_symndx, NULL);
+				reloc->import = (RBinImport *)ht_up_find (bin->imp_ht, (ut64)rel[j].r_symndx, NULL);
 				if (patch_imports) {
 					bool found;
 					sym_vaddr = ht_uu_find (imp_vaddr_ht, (ut64)rel[j].r_symndx, &found);
@@ -334,6 +343,7 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *bin, bool patch, u
 						sym_vaddr = imp_map;
 						imp_map += BYTES_PER_IMP_RELOC;
 						ht_uu_insert (imp_vaddr_ht, (ut64)rel[j].r_symndx, sym_vaddr);
+						symbol->vaddr = sym_vaddr;
 					}
 				}
 			}
@@ -379,11 +389,50 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *bin, bool patch, u
 						break;
 					}
 					break;
+				case COFF_FILE_MACHINE_ARMNT:
+					switch (rel[j].r_type) {
+					case COFF_REL_ARM_BRANCH24T:
+					case COFF_REL_ARM_BLX23T:
+						reloc->type = R_BIN_RELOC_32;
+						ut16 hiword = _read_le16 (rbin, reloc->vaddr);
+						if (hiword == UT16_MAX) {
+							break;
+						}
+						ut16 loword = _read_le16 (rbin, reloc->vaddr + 2);
+						if (loword == UT16_MAX) {
+							break;
+						}
+						ut64 dst = sym_vaddr - reloc->vaddr - 4;
+						if (dst & 1) {
+							break;
+						}
+						loword |= (ut16)(dst >> 1) & 0x7ff;
+						hiword |= (ut16)(dst >> 12) & 0x7ff;
+						r_write_le16 (patch_buf, hiword);
+						r_write_le16 (patch_buf + 2, loword);
+						plen = 4;
+						break;
+					}
+					break;
+				case COFF_FILE_MACHINE_ARM64:
+					switch (rel[j].r_type) {
+					case COFF_REL_ARM64_BRANCH26:
+						reloc->type = R_BIN_RELOC_32;
+						ut32 data = _read_le32 (rbin, reloc->vaddr);
+						if (data == UT32_MAX) {
+							break;
+						}
+						ut64 dst = sym_vaddr - reloc->vaddr;
+						data |= (ut32)((dst >> 2) & 0x3ffffffULL);
+						r_write_le32 (patch_buf, data);
+						plen = 4;
+						break;
+					}
+					break;
 				}
 				if (patch && plen) {
 					rbin->iob.write_at (rbin->iob.io, reloc->vaddr, patch_buf, plen);
 					if (symbol->is_imported) {
-						reloc->paddr = sym_vaddr;
 						reloc->vaddr = sym_vaddr;
 					}
 				}
@@ -429,7 +478,15 @@ static RList *patch_relocs(RBin *b) {
 	}
 	ut64 m_vaddr = UT64_MAX;
 	if (nimports) {
-		m_vaddr = bin->size;
+		void **it;
+		ut64 offset = 0;
+		r_pvector_foreach (&io->maps, it) {
+			RIOMap *map = *it;
+			if ((map->itv.addr + map->itv.size) > offset) {
+				offset = map->itv.addr + map->itv.size;
+			}
+		}
+		m_vaddr = R_ROUND (offset, 16);
 		ut64 size = nimports * BYTES_PER_IMP_RELOC;
 		char *muri = r_str_newf ("malloc://%" PFMT64u, size);
 		RIODesc *desc = b->iob.open_at (io, muri, R_PERM_R, 0664, m_vaddr);
@@ -459,7 +516,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->os = strdup ("any");
 	ret->subsystem = strdup ("any");
 	ret->big_endian = obj->endian;
-	ret->has_va = false;
+	ret->has_va = true;
 	ret->dbg_info = 0;
 	ret->has_lit = true;
 
@@ -499,6 +556,16 @@ static RBinInfo *info(RBinFile *bf) {
 		ret->machine = strdup ("amd29k");
 		ret->arch = strdup ("amd29k");
 		ret->bits = 32;
+		break;
+	case COFF_FILE_MACHINE_ARMNT:
+		ret->machine = strdup ("arm");
+		ret->arch = strdup ("arm");
+		ret->bits = 32;
+		break;
+	case COFF_FILE_MACHINE_ARM64:
+		ret->machine = strdup ("arm");
+		ret->arch = strdup ("arm");
+		ret->bits = 64;
 		break;
 	case COFF_FILE_TI_COFF:
 		switch (obj->target_id) {

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -39,17 +39,17 @@ nth vaddr bind type lib name
 
 nth paddr         size vaddr        vsize perm name
 ---------------------------------------------------
-0   0x000001cc    0x2f 0x000001cc    0x2f ---- .drectve_0
-1   0x000001fb  0x8670 0x000001fb  0x8670 -r-- .debug_S_1
-2   0x0000ad73    0x70 0x0000ad73    0x70 -r-- .debug_T_2
-3   0x0000ade3   0x625 0x0000ade3   0x625 -rw- .data_3
-4   0x0000b408    0x54 0x0000b408    0x54 -r-- .rdata_4
-5   0x00000000     0x8 0x00000000     0x8 -rw- .bss_5
-6   0x0000b45c  0x2895 0x0000b45c  0x2895 -r-x .text_mn_6
-7   0x0000e967     0x8 0x0000e967     0x8 -r-- .rdata_7
-8   0x0000e96f     0x4 0x0000e96f     0x4 -r-- .rdata_8
-9   0x0000e973     0x8 0x0000e973     0x8 -r-- .rdata_9
-10  0x0000e97b     0x4 0x0000e97b     0x4 -r-- .rdata_10
+0   0x000001cc    0x2f 0x00000000    0x2f ---- .drectve_0
+1   0x000001fb  0x8670 0x00000030  0x8670 -r-- .debug_S_1
+2   0x0000ad73    0x70 0x000086a0    0x70 -r-- .debug_T_2
+3   0x0000ade3   0x625 0x00008710   0x625 -rw- .data_3
+4   0x0000b408    0x54 0x00008d40    0x54 -r-- .rdata_4
+5   0x00000000     0x8 0x00008da0     0x8 -rw- .bss_5
+6   0x0000b45c  0x2895 0x00008db0  0x2895 -r-x .text_mn_6
+7   0x0000e967     0x8 0x0000b650     0x8 -r-- .rdata_7
+8   0x0000e96f     0x4 0x0000b660     0x4 -r-- .rdata_8
+9   0x0000e973     0x8 0x0000b670     0x8 -r-- .rdata_9
+10  0x0000e97b     0x4 0x0000b680     0x4 -r-- .rdata_10
 
 EOF
 RUN
@@ -58,26 +58,25 @@ NAME=tiny coff
 FILE=bins/coff/coff.obj
 CMDS=om;is;ir
 EXPECT=<<EOF
- 3 fd: 3 +0x00000000 0x00000000 - 0x00000144 r-x 
- 2 fd: 3 +0x00000064 0x00000064 - 0x0000008a r-x fmap..text_0
- 1 fd: 3 +0x0000008b 0x0000008b - 0x000000a6 r-- fmap..data_1
+ 2 fd: 3 +0x00000064 0x00000000 - 0x00000026 r-x fmap..text_0
+ 1 fd: 3 +0x0000008b 0x00000030 - 0x0000004b r-- fmap..data_1
 [Symbols]
 
 nth paddr       vaddr              bind   type size lib name
 ------------------------------------------------------------
 0    ---------- 0xffffffffffffffff NONE   UNK  4        imp.MessageBoxA
 0    ---------- 0xffffffffffffffff NONE   UNK  4        imp.ExitProcess
-0    0x00000064 0x00000064         LOCAL  SECT 4        .text
-0    0x00000064 0x00000064         GLOBAL FUNC 4        main
-0    0x0000008b 0x0000008b         LOCAL  SECT 4        .data
+0    0x00000064 0x00000000         LOCAL  SECT 4        .text
+0    0x00000064 0x00000000         GLOBAL FUNC 4        main
+0    0x0000008b 0x00000030         LOCAL  SECT 4        .data
 [Relocations]
 
 vaddr      paddr      type   name
 ---------------------------------
-0x0000006d 0x0000006d ADD_32 .data
-0x00000074 0x00000074 ADD_32 .data
-0x00000080 0x00000080 ADD_32 MessageBoxA
-0x00000087 0x00000087 ADD_32 ExitProcess
+0x00000009 0x0000006d ADD_32 .data
+0x00000010 0x00000074 ADD_32 .data
+0x0000001c 0x00000080 ADD_32 MessageBoxA
+0x00000023 0x00000087 ADD_32 ExitProcess
 
 
 4 relocations
@@ -93,23 +92,22 @@ s sym.__1FooBar__QAE_XZ
 pd 2
 EOF
 EXPECT=<<EOF
-10 fd: 3 +0x00000000 0x00000000 - 0x000012f7 r-x 
- 9 fd: 3 +0x0000017c 0x0000017c - 0x0000026a --- fmap..drectve_0
- 8 fd: 3 +0x0000026b 0x0000026b - 0x00000d1a r-- fmap..debug_S_1
- 7 fd: 3 +0x00000d1b 0x00000d1b - 0x00000d8e r-- fmap..debug_T_2
- 6 fd: 3 +0x00000d8f 0x00000d8f - 0x00000dbb r-x fmap..text_mn_3
- 5 fd: 3 +0x00000dbc 0x00000dbc - 0x00000e8f r-- fmap..debug_S_4
- 4 fd: 3 +0x00000ec2 0x00000ec2 - 0x00000eeb r-x fmap..text_mn_5
- 3 fd: 3 +0x00000eec 0x00000eec - 0x00000fbf r-- fmap..debug_S_6
- 2 fd: 3 +0x00000ff2 0x00000ff2 - 0x00000ff5 r-- fmap..rtc_IMZ_7
- 1 fd: 3 +0x00001000 0x00001000 - 0x00001003 r-- fmap..rtc_TMZ_8
-0    0x00000d8f 0x00000d8f         LOCAL  SECT 4        .text$mn
-0    0x00000ec2 0x00000ec2         LOCAL  SECT 4        .text$mn
+ 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- fmap..drectve_0
+ 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- fmap..debug_S_1
+ 7 fd: 3 +0x00000d1b 0x00000ba0 - 0x00000c13 r-- fmap..debug_T_2
+ 6 fd: 3 +0x00000d8f 0x00000c20 - 0x00000c4c r-x fmap..text_mn_3
+ 5 fd: 3 +0x00000dbc 0x00000c50 - 0x00000d23 r-- fmap..debug_S_4
+ 4 fd: 3 +0x00000ec2 0x00000d30 - 0x00000d59 r-x fmap..text_mn_5
+ 3 fd: 3 +0x00000eec 0x00000d60 - 0x00000e33 r-- fmap..debug_S_6
+ 2 fd: 3 +0x00000ff2 0x00000e40 - 0x00000e43 r-- fmap..rtc_IMZ_7
+ 1 fd: 3 +0x00001000 0x00000e50 - 0x00000e53 r-- fmap..rtc_TMZ_8
+0    0x00000d8f 0x00000c20         LOCAL  SECT 4        .text$mn
+0    0x00000ec2 0x00000d30         LOCAL  SECT 4        .text$mn
             ;-- section..text_mn_5:
             ;-- .text$mn:
             ;-- ??1FooBar@@QAE@XZ:
-            0x00000ec2      55             push ebp                    ; [05] -r-x section size 42 named .text_mn_5
-            0x00000ec3      8bec           mov ebp, esp
+            0x00000d30      55             push ebp                    ; [05] -r-x section size 42 named .text_mn_5
+            0x00000d31      8bec           mov ebp, esp
 EOF
 RUN
 
@@ -120,16 +118,17 @@ CMDS=<<EOF
 af @ sym._TIFFGetField
 pd 1 @ reloc._TIFFVGetField-1
 axt @ sym._TIFFVGetField
-pd 1 @ 0x0000b48a
-pd 1 @ 0x0001000d
+pd 1 @ sym._TIFFVGetField+0xe
+pd 1 @ sym.imp._TIFFFindField
 EOF
 EXPECT=<<EOF
-|           0x0000b469      e80e000000     call sym._TIFFVGetField     ; RELOC 32 _TIFFVGetField @ 0x0000b47c
-sym._TIFFGetField 0xb469 [CALL] call sym._TIFFVGetField
-|           0x0000b48a      e87e4b0000     call _TIFFFindField
-            ; CALL XREF from sym._TIFFVGetField @ 0xb48a
+|           0x00008dbd      e80e000000     call sym._TIFFVGetField     ; RELOC 32 _TIFFVGetField @ 0x00008dd0
+sym._TIFFGetField 0x8dbd [CALL] call sym._TIFFVGetField
+|           0x00008dde      e8ad280000     call _TIFFFindField
+            ; CALL XREF from sym._TIFFVGetField @ 0x8dde
             ;-- reloc._TIFFFindField:
-            0x0001000d      .dword 0x00000000                          ; RELOC 32 _TIFFFindField
+            ;-- _TIFFFindField:
+            0x0000b690      .dword 0x00000000                          ; RELOC 32 _TIFFFindField
 EOF
 RUN
 
@@ -140,7 +139,7 @@ CMDS=<<EOF
 pd 2 @ sym.main+6
 EOF
 EXPECT=<<EOF
-            0x0000006a      4c8d051a0000.  lea r8, [0x0000008b]        ; sym..data ; "Win64 assembly"; RELOC 32 .data @ 0x0000008b
-            0x00000071      488d15220000.  lea rdx, [0x0000009a]       ; str.Coffee_time ; "Coffee time!"; RELOC 32 .data @ 0x0000008b + 0xf
+            0x00000006      4c8d05230000.  lea r8, [0x00000030]        ; sym..data ; "Win64 assembly"; RELOC 32 .data @ 0x00000030
+            0x0000000d      488d152b0000.  lea rdx, [0x0000003f]       ; str.Coffee_time ; "Coffee time!"; RELOC 32 .data @ 0x00000030 + 0xf
 EOF
 RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Dummy loader for COFF objects was added to avoid issues with alignment in ARM binaries.

Related issue: #7310.

Simple example: `pdf` output of function `buffer_putflush()` https://github.com/radareorg/sdb/blob/master/src/buffer.c#L53-L58  
```asm
[0x000000d0]> pdf @ sym.buffer_putflush
/ 68: sym.buffer_putflush ();
|           ; var int16_t var_0h @ sp+0x0
|           ; var int16_t var_4h @ sp+0x4
|           ; var int16_t var_8h @ sp+0x8
|           ; var int16_t var_18h @ sp+0x18
|           ; var int16_t var_1ch @ sp+0x1c
|           ; var int16_t var_20h @ sp+0x20
|           0x00000218      0fb4           push {r0, r1, r2, r3}
|           0x0000021a      2de90048       push.w {fp, lr}
|           0x0000021e      eb46           mov fp, sp
|           0x00000220      84b0           sub sp, 0x10
|           0x00000222      0698           ldr r0, [var_18h]
|           0x00000224      fff772ff       bl sym.buffer_flush         ; RELOC 32 buffer_flush @ 0x0000010c
|           0x00000228      0190           str r0, [var_4h]
|           0x0000022a      019b           ldr r3, [var_4h]
|           0x0000022c      002b           cmp r3, 0
|       ,=< 0x0000022e      02d1           bne sym._LN2_2
|       |   0x00000230      0023           movs r3, 0
|       |   0x00000232      0093           str r3, [sp]
|      ,==< 0x00000234      0ce0           b sym._LN1_2
|      ||   ;-- $LN2:
|      |`-> 0x00000236      089b           ldr r3, [var_20h]
|      |    0x00000238      079a           ldr r2, [var_1ch]
|      |    0x0000023a      0699           ldr r1, [var_18h]
|      |    0x0000023c      0c31           adds r1, 0xc
|      |    0x0000023e      0968           ldr r1, [r1]
|      |    0x00000240      0698           ldr r0, [var_18h]
|      |    0x00000242      1030           adds r0, 0x10
|      |    0x00000244      0068           ldr r0, [r0]
|      |    0x00000246      00f009f8       bl sym.allwrite             ; RELOC 32 allwrite @ 0x0000025c
|      |    0x0000024a      0290           str r0, [var_8h]
|      |    0x0000024c      029b           ldr r3, [var_8h]
|      |    0x0000024e      0093           str r3, [sp]
|      |    ; CODE XREF from sym.buffer_putflush @ 0x234
|      |    ;-- $LN1:
|      `--> 0x00000250      0098           ldr r0, [sp]
|           0x00000252      04b0           add sp, 0x10
|           0x00000254      5df804bb       ldr fp, [sp], 4
\           0x00000258      5df814fb       ldr pc, [sp], 0x14
```
COFF object itself [buffer.zip](https://github.com/radareorg/radare2/files/5398022/buffer.zip)
