### PR TITLE
Remove some of MSVC warnings

### DIFF
--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -185,7 +185,7 @@ endif
 tree_sitter_cflags = ''
 if cc.has_argument('-std=gnu99')
   tree_sitter_cflags = '-std=gnu99'
-elif cc.has_argument('std=c99')
+elif cc.has_argument('-std=c99')
   tree_sitter_cflags = '-std=c99'
 endif
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Removes annoying warning:
```
cl : command line warning D9002: ignoring unknown option '-std=c99' [C:\projects\radare2\build\shlr\cafa177@@tree_sitter@sta.vcxproj]
```