### PR TITLE
Fix unexpected FPU exception in ESIL emulation ##esil

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1619,6 +1619,17 @@ static bool esil_div(RAnalEsil *esil) {
 	return ret;
 }
 
+static bool detect_fpu_div_exception(ut64 a, ut64 b) {
+	if (b == 0LL) {
+		// division by zero
+		return true;
+	}
+	if (a == 0x8000000000000000 && b == -1) {
+		return true;
+	}
+	return false;
+}
+
 static bool esil_signed_div(RAnalEsil *esil) {
 	bool ret = false;
 	st64 s, d;
@@ -1626,7 +1637,7 @@ static bool esil_signed_div(RAnalEsil *esil) {
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, (ut64 *)&s)) {
 		if (dst && r_anal_esil_get_parm (esil, dst, (ut64 *)&d)) {
-			if (s == 0) {
+			if (detect_fpu_div_exception (d, s)) {
 				ERR ("esil_div: Division by zero!");
 				esil->trap = R_ANAL_TRAP_DIVBYZERO;
 				esil->trap_code = 0;

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1541,10 +1541,11 @@ static bool esil_mod(RAnalEsil *esil) {
 }
 
 static bool detect_fpu_div_exception(ut64 a, ut64 b) {
+	// division by zero
 	if (b == UT64_MIN) {
-		// division by zero
 		return true;
 	}
+	// undefined result (0x80000 / -1) cant be represented
 	if (a == UT64_GT0 && b == UT64_MAX) {
 		return true;
 	}

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -1540,6 +1540,17 @@ static bool esil_mod(RAnalEsil *esil) {
 	return ret;
 }
 
+static bool detect_fpu_div_exception(ut64 a, ut64 b) {
+	if (b == UT64_MIN) {
+		// division by zero
+		return true;
+	}
+	if (a == UT64_GT0 && b == UT64_MAX) {
+		return true;
+	}
+	return false;
+}
+
 static bool esil_signed_mod(RAnalEsil *esil) {
 	bool ret = false;
 	st64 s, d;
@@ -1547,7 +1558,7 @@ static bool esil_signed_mod(RAnalEsil *esil) {
 	char *src = r_anal_esil_pop (esil);
 	if (src && r_anal_esil_get_parm (esil, src, (ut64 *)&s)) {
 		if (dst && r_anal_esil_get_parm (esil, dst, (ut64 *)&d)) {
-			if (s == 0) {
+			if (detect_fpu_div_exception (d, s)) {
 				if (esil->verbose > 0) {
 					eprintf ("0x%08"PFMT64x" esil_mod: Division by zero!\n", esil->address);
 				}
@@ -1617,17 +1628,6 @@ static bool esil_div(RAnalEsil *esil) {
 	free (src);
 	free (dst);
 	return ret;
-}
-
-static bool detect_fpu_div_exception(ut64 a, ut64 b) {
-	if (b == 0LL) {
-		// division by zero
-		return true;
-	}
-	if (a == 0x8000000000000000 && b == -1) {
-		return true;
-	}
-	return false;
 }
 
 static bool esil_signed_div(RAnalEsil *esil) {

--- a/test/db/esil/flag_tests
+++ b/test/db/esil/flag_tests
@@ -140,3 +140,21 @@ EXPECT=<<EOF
 0x0
 EOF
 RUN
+
+NAME=signed division traps
+FILE=-
+CMDS=<<EOF
+"ae 32,0,/"
+"ae 0,32,/"
+"ae -1,0x8000000000000000,~/"
+"ae -1,0x8000000000000000,~%"
+EOF
+EXPECT=<<EOF
+0x0
+EOF
+EXPECT_ERR=<<EOF
+ESIL TRAP type 3 code 0x00000000 divbyzero
+ESIL TRAP type 3 code 0x00000000 divbyzero
+ESIL TRAP type 3 code 0x00000000 divbyzero
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

![IMAGE 2020-10-21 17:57:26](https://user-images.githubusercontent.com/6431515/96745874-e1579d80-13c6-11eb-8796-59ddd6088711.jpg)

**Test plan**

We need OVF macros for signed/unsigned and zero division checks to cover all possible r2 fpu exceptions.

* i cant share the binary, but its easy to reproduce with this oneliner. But the signed instructions were not documented (ae??)



```
[0x00000000]> "ae -1,0x8000000000000000,~/"
zsh: floating point exception  r2 -
$
```

**Closing issues**


