### PR TITLE
Fix travis db/anal/arm noreturn errno

### DIFF
--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -1,6 +1,8 @@
 NAME=noreturn errno
 FILE=malloc://32
 CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
 s main
 af
 afi~^size


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

By default on arm64 this case fails because 0x00000000 is invalid.
```sh
rasm2 -a arm -b 64 -d 00000000
```
As the test is about arm, its success on x86 is by chance (0x0000 is valid in x86).
Moreover, since there's a separate file db/anal/arm64, why does db/anal/arm contain cases where `e asm.bits=64`? Should they be moved to db/anal/arm64?
**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

My travis https://travis-ci.com/github/eagleoflqj/radare2/jobs/403288481#L802 at least this case passed.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
