### PR TITLE
Fix warning in the JSON parser

### DIFF
--- a/libr/util/json_parser.c
+++ b/libr/util/json_parser.c
@@ -231,7 +231,7 @@ static char *parse_value(RJson *parent, const char *key, char *p) {
 		js = create_json (R_JSON_OBJECT, key, parent);
 		p++;
 		while (1) {
-			const char *new_key;
+			const char *new_key = NULL;
 			p = parse_key (&new_key, p);
 			if (!p) {
 				return NULL; // error


### PR DESCRIPTION
json_parser.c: In function 'parse_value':
json_parser.c:240:9: warning: 'new_key' may be used uninitialized in this function [-Wmaybe-uninitialized]
     p = parse_value (js, new_key, p);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
