### PR TITLE
Fix uninitialized pj instance in dreg.c

### DIFF
--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -123,15 +123,13 @@ R_API bool r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char
 	if (dbg->regcols) {
 		cols = dbg->regcols;
 	}
-	PJ *pj;
+	PJ *pj = NULL;
 	if (isJson) {
 		pj = pj_new ();
 		if (!pj) {
 			return false;
 		}
-		if (rad == 'j') {
-			pj_o (pj);
-		}
+		pj_o (pj);
 	}
 	// with the new field "arena" into reg items why need
 	// to get all arenas.
@@ -288,9 +286,7 @@ R_API bool r_debug_reg_list(RDebug *dbg, int type, int size, int rad, const char
 	}
 beach:
 	if (isJson) {
-		if (rad == 'j') {
-			pj_end (pj);
-		}
+		pj_end (pj);
 		dbg->cb_printf ("%s\n", pj_string (pj));
 		pj_free (pj);
 	} else if (n > 0 && (rad == 2 || rad == '=') && ((n%cols))) {


### PR DESCRIPTION
dreg.c:294:3: warning: 'pj' may be used uninitialized in this function [-Wmaybe-uninitialized]

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
