### PR TITLE
Fix uninitialized usage of a variable, fix crash in r_str_append

### DIFF
--- a/libr/core/rtr_http.c
+++ b/libr/core/rtr_http.c
@@ -374,7 +374,7 @@ static int r_core_rtr_http_run(RCore *core, int launch, int browse, const char *
 			} else {
 				const char *root = r_config_get (core->config, "http.root");
 				const char *homeroot = r_config_get (core->config, "http.homeroot");
-				char *path;
+				char *path = NULL;
 				if (!strcmp (rs->path, "/")) {
 					free (rs->path);
 					if (*index == '/') {


### PR DESCRIPTION
```
In file included from rtr.c:234:0:
rtr_http.c: In function 'r_core_rtr_http_run.isra.1':
rtr_http.c:403:44: warning: 'path' may be used uninitialized in this function [-Wmaybe-uninitialized]
      path = (*index == '/')? strdup (index): r_str_append (path, index);
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
