### PR TITLE
Fix UB in cannotated_code

### DIFF
--- a/libr/core/cannotated_code.c
+++ b/libr/core/cannotated_code.c
@@ -51,6 +51,7 @@ R_API void r_core_annotated_code_print_json(RAnnotatedCode *code) {
 			break;
 		case R_CODE_ANNOTATION_TYPE_SYNTAX_HIGHLIGHT:
 			pj_ks (pj, "type", "syntax_highlight");
+			type_str = NULL;
 			switch (annotation->syntax_highlight.type) {
 			case R_SYNTAX_HIGHLIGHT_TYPE_KEYWORD:
 				type_str = "keyword";
@@ -77,7 +78,9 @@ R_API void r_core_annotated_code_print_json(RAnnotatedCode *code) {
 				type_str = "global_variable";
 				break;
 			}
-			pj_ks (pj, "syntax_highlight", type_str);
+			if (type_str) {
+				pj_ks (pj, "syntax_highlight", type_str);
+			}
 			break;
 		}
 		pj_end (pj);


### PR DESCRIPTION
```
cannotated_code.c: In function 'r_core_annotated_code_print_json':
cannotated_code.c:80:4: warning: 'type_str' may be used uninitialized in this function [-Wmaybe-uninitialized]
    pj_ks (pj, "syntax_highlight", type_str);
```
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
