### PR TITLE
Fix uninitialized variable use in ostackptr

### DIFF
--- a/libr/core/disasm_stackptr.inc
+++ b/libr/core/disasm_stackptr.inc
@@ -115,7 +115,8 @@ static int ds_ostackptr_at(RDisasmState *ds, int *ostackptr) {
 }
 
 static void ds_print_stackptr(RDisasmState *ds) {
-	int ostackptr, stackptr = ds_ostackptr_at (ds, &ostackptr);
+	int ostackptr = 0;
+	int stackptr = ds_ostackptr_at (ds, &ostackptr);
 	if (ds->show_stackptr) {
 		r_cons_printf ("%5d%s", stackptr,
 			ds->analop.type == R_ANAL_OP_TYPE_CALL?">":


### PR DESCRIPTION
disasm_stackptr.inc:124:29: warning: 'ostackptr' may be used uninitialized in this function [-Wmaybe-uninitialized]

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
