### PR TITLE
Fix xbe symbol name lookup

### DIFF
--- a/libr/bin/p/bin_xbe.c
+++ b/libr/bin/p/bin_xbe.c
@@ -297,9 +297,9 @@ static RList *symbols(RBinFile *bf) {
 		}
 		const ut32 thunk_index = thunk_addr[i] ^ 0x80000000;
 		// Basic sanity checks
-		if (thunk_addr[i] & 0x80000000 && thunk_index < XBE_MAX_THUNK) {
-			eprintf ("%d\n", thunk_index);
-			sym->name = r_str_newf ("kt.%s", kt_name[thunk_index]);
+		if (thunk_addr[i] & 0x80000000 && thunk_index > 0 && thunk_index <= XBE_MAX_THUNK) {
+			eprintf ("thunk_index %d\n", thunk_index);
+			sym->name = r_str_newf ("kt.%s", kt_name[thunk_index - 1]);
 			sym->vaddr = (h->kernel_thunk_addr ^ obj->kt_key) + (4 * i);
 			sym->paddr = sym->vaddr - h->base;
 			sym->size = 4;

--- a/test/db/formats/xbe
+++ b/test/db/formats/xbe
@@ -29,7 +29,7 @@ EXPECT=<<EOF
 
 nth paddr       vaddr      bind type size lib name
 --------------------------------------------------
-0    0x000016c0 0x000116c0 NONE NONE 4        kt.vsnprintf
+0    0x000016c0 0x000116c0 NONE NONE 4        kt.sprintf
 EOF
 RUN
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [X] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [X] I've added tests that prove my fix is effective or that my feature works (if possible)
- [X] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This PR is a fix to a bug I found on Cutter, where the list of symbols on an Xbox XBE file did not match what was expected.

I found the symbol name lookup was off-by-one. The issue was that the thunk indexes start from 1, not 0. Radare2 implements the name lookup using an array of strings without correcting this index.

I verified the expected symbol list on the test file `bins/xbe/default.xbe` using **XbeExplorer**: https://github.com/PatrickvL/Dxbx/releases

![image](https://user-images.githubusercontent.com/327967/97077226-cf9a1400-15d9-11eb-81b7-9aca3a5b70d8.png)

The symbol name uses a different convention, but `RtlSprintf` is the same import as `sprintf` (see https://github.com/PatrickvL/Dxbx/blob/7d86a82050be2a1b461fca0dc5e2fea952a88948/Source/Delphi/src/uKernelThunk.pas#L417)

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

1. I modified `test/Makefile` to jump straight to the XBE test

```
diff --git a/test/Makefile b/test/Makefile
index 4c782f9ae..e04ee1e66 100644
--- a/test/Makefile
+++ b/test/Makefile
@@ -17,6 +17,9 @@ fuzz-tests: bins
 keystone: bins
        ${RUNTEST} db/extras/asm/x86.ks_
 
+xbe: bins
+       ${RUNTEST} db/formats/xbe
+
 swf: bins
        ${RUNTEST} db/extras/cmd/swf
```

2. Ran `make -k xbe`

```
r2r -L db/formats/xbe
Running from /home/temp/radare2/test
Loaded 7 tests.
Skipping json tests because jq is not available.
[**]              /home/temp/radare2/test/db/formats/xbe        5 OK         2 BR        0 XX        0 FX

Finished in 0 seconds.
```

**Closing issues**

Links to https://github.com/radareorg/cutter/issues/2451, but Cutter will need to update their submodule for this to be fixed
