### PR TITLE
Fixing r_sys_pid_to_path for DragonFlyBSD ##util

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1175,7 +1175,7 @@ R_API char *r_sys_pid_to_path(int pid) {
 #endif
 #else
 	int ret;
-#if __FreeBSD__
+#if __FreeBSD__ || __DragonFly__
 	char pathbuf[PATH_MAX];
 	size_t pathbufl = sizeof (pathbuf);
 	int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, pid};


### PR DESCRIPTION
Same API and approach as FreeBSD.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)