### PR TITLE
Attach to target pid/tid on remote lldb connect ##debug

### DIFF
--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -233,8 +233,9 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 		}
 	}
 	if (g->remote_type == GDB_REMOTE_TYPE_LLDB) {
-		ret = gdbr_connect_lldb (g);
-		goto end;
+		if ((ret = gdbr_connect_lldb (g)) < 0) {
+			goto end;
+		}
 	}
 	// Query the thread / process id
 	g->stub_features.qC = true;
@@ -249,7 +250,7 @@ int gdbr_connect(libgdbr_t *g, const char *host, int port) {
 	// Check if vCont is supported
 	gdbr_check_vcont (g);
 	// Set pid/thread for operations other than "step" and "continue"
-	if (gdbr_select (g, g->pid, 0) < 0) {
+	if (gdbr_select (g, g->pid, g->tid) < 0) {
 		// return -1;
 	}
 	// Set thread for "step" and "continue" operations


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

LLDB's connect implementation didn't properly handle attaching to the current pid/tid and setting them for step/continue operations. gdbr's implementation is shared with lldb now.

**Test plan**

* Run lldb-server with:

```
lldb-server-10 g localhost:1234 -- test_binary
```

* Run the following command in r2 to connect to the server:

```
oodf gdb://127.0.0.1:1234
```

* Check that the registers are synchronized, step/continue/breakpoints work and that `dp` and `dpt` show the correct thread+process.