### PR TITLE
extend usage info about '/*' and '*/'

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -149,6 +149,7 @@ static const char *help_msg_star[] = {
 	"*", "entry0=cc", "write trap in entrypoint",
 	"*", "entry0+10=0x804800", "write value in delta address",
 	"*", "entry0", "read byte at given address",
+	"*", "/", "end multiline comment. (use '/*' to start mulitiline comment",
 	"TODO: last command should honor asm.bits", "", "",
 	NULL
 };

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -70,6 +70,7 @@ static const char *help_msg_slash[] = {
 	"/x", " ff0033", "search for hex string",
 	"/x", " ff43:ffd0", "search for hexpair with mask",
 	"/z", " min max", "search for strings of given size",
+	"/*", " [comment string]", "add multiline comment, end it with '*/'",
 #if 0
 	"\nConfiguration:", "", " (type `e??search.` for a complete list)",
 	"e", " cmd.hit = x", "command to execute on every search hit",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [Y] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [Y] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [N] I've added tests that prove my fix is effective or that my feature works (if possible)
- [Y] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
extend the help info of '/' and '*' command.

**Test**
Fuzz Timeout 
```
r2r -LF bins/fuzzed @fuzz
Running from /home/runner/work/radare2/radare2/test
Category: fuzz
Loaded 505 tests.

[XX] TIMEOUT /home/runner/work/radare2/radare2/test/bins/fuzzed <fuzz> /home/runner/work/radare2/radare2/test/bins/fuzzed/swift_read
R2_NOPLUGINS=1 radare2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -N -Qc aaa /home/runner/work/radare2/radare2/test/bins/fuzzed/swift_read
-- stdout

-- stderr
malformed export trie
malformed export trie
[ ] Analyze all flags starting with sym. and entry0 (aa)
[
[x] Analyze all flags starting with sym. and entry0 (aa)

[ ] Analyze function calls (aac)
[
-- exit status: -1
[**] /home/runner/work/radare2/radare2/test/bins/fuzzed      504 OK         0 BR        1 XX        0 FX

Finished in 26 minutes and 47 seconds.
make: *** [Makefile:15: fuzz-tests] Error 1
Error: Process completed with exit code 2.
```

**Closing issues**

closes #17848


**Addtional Info**
Is this multiline-comment feature deprecated. It cannot be used in `cfg.newshell`. 