### PR TITLE
remove the uppercase in the U of resoUrces in the help of rabin2

### DIFF
--- a/doc/zsh/_rabin2
+++ b/doc/zsh/_rabin2
@@ -49,7 +49,7 @@ _rabin2() {
   '-s[symbols]'
   '-S[sections]'
   '-u[unfiltered (no rename duplicated symbols/sections)]'
-  '-U[resoUrces]'
+  '-U[resources]'
   '-v[display version and quit]'
   '-V[Show binary version information]'
   '-x[extract bins contained in file]'

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -61,7 +61,7 @@ static int rabin_show_help(int v) {
 		" -t              display file hashes\n"
 		" -T              display file signature\n"
 		" -u              unfiltered (no rename duplicated symbols/sections)\n"
-		" -U              resoUrces\n"
+		" -U              resources\n"
 		" -v              display version and quit\n"
 		" -V              Show binary version information\n"
 		" -w              display try/catch blocks\n"


### PR DESCRIPTION
**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Fix the bug of the uppercase of U in the help of rabin2 on resoUrces.

...

**Test plan**

    do rabin2 -h
    see -U resoUrces in the help between a long long help.

...

**Closing issues**

closes #17869

...
