### PR TITLE
Fix macOS warning: overrides prior initialization

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -85,7 +85,6 @@ static const char *dwarf_tag_name_encodings[] = {
 	[DW_TAG_subprogram] = "DW_TAG_subprogram",
 	[DW_TAG_template_type_param] = "DW_TAG_template_type_param",
 	[DW_TAG_template_value_param] = "DW_TAG_template_value_param",
-	[DW_TAG_template_alias] = "DW_TAG_template_alias",
 	[DW_TAG_thrown_type] = "DW_TAG_thrown_type",
 	[DW_TAG_try_block] = "DW_TAG_try_block",
 	[DW_TAG_variant_part] = "DW_TAG_variant_part",


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

```
$ gcc -c -MD -fno-common   -fPIC -g -Wall -D__UNIX__=1 -DR2_PLUGIN_INCORE -Iformat -Imangling -I/Users/liumeo/github/radare2/libr/../shlr/zip/include -I../format/pyc/ -I/Users/liumeo/github/radare2/libr/..//shlr/yxml/ -I/Users/liumeo/github/radare2/libr -I/Users/liumeo/github/radare2/libr/include -I/Users/liumeo/github/radare2/libr/../shlr/sdb/src -fvisibility=hidden -o dwarf.o dwarf.c
dwarf.c:107:28: warning: initializer overrides prior initialization of this
      subobject [-Winitializer-overrides]
        [DW_TAG_template_alias] = "DW_TAG_template_alias",
                                  ^~~~~~~~~~~~~~~~~~~~~~~
dwarf.c:88:28: note: previous initialization is here
        [DW_TAG_template_alias] = "DW_TAG_template_alias",
                                  ^~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
