### PR TITLE
Stop trace sessions in the doc command ##debug

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5304,6 +5304,8 @@ static int cmd_debug(void *data, const char *input) {
 				eprintf ("No open debug session\n");
 				break;
 			}
+			// Stop trace session
+			r_core_cmd0 (core, "dts-");
 			// Kill debugee and all child processes
 			if (core->dbg && core->dbg->h && core->dbg->h->pids && core->dbg->pid != -1) {
 				list = core->dbg->h->pids (core->dbg, core->dbg->pid);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5305,7 +5305,10 @@ static int cmd_debug(void *data, const char *input) {
 				break;
 			}
 			// Stop trace session
-			r_core_cmd0 (core, "dts-");
+			if (core->dbg->session) {
+				r_debug_session_free (core->dbg->session);
+				core->dbg->session = NULL;
+			}
 			// Kill debugee and all child processes
 			if (core->dbg && core->dbg->h && core->dbg->h->pids && core->dbg->pid != -1) {
 				list = core->dbg->h->pids (core->dbg, core->dbg->pid);


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Close any existing trace session when stopping debug with `doc` to avoid accidentally starting a new debug session with an existing trace. 

**Test plan**

Run `ood` -> `dts+` -> `doc` and see that `dts-` reports that there's no session