### PR TITLE
Add x86-16 tests for the operand-size prefix

### DIFF
--- a/test/db/asm/x86_16
+++ b/test/db/asm/x86_16
@@ -10,10 +10,10 @@ dB "jmp 0xfec50" e95bec f000:fff2
 d "jmp 0x1fec50" e95bec 0x001ffff2
 a "mov al, [0xbeef]" a0efbe
 a "mov ax, [0xbeef]" a1efbe
-a "mov bx, ax" 89c3
-a "mov ebx, eax" 6689c3
-a "sub sp, 2" 83ec02
-a "sub esp, 4" 6683ec04
+aB "mov bx, ax" 89c3
+aB "mov ebx, eax" 6689c3
+aB "sub sp, 2" 83ec02
+aB "sub esp, 4" 6683ec04
 a "test bl, 0x12" f6c312
 a "test bx, 0x1234" f7c33412
 aB "test byte [bx], 0x12" f60712

--- a/test/db/asm/x86_16
+++ b/test/db/asm/x86_16
@@ -10,6 +10,10 @@ dB "jmp 0xfec50" e95bec f000:fff2
 d "jmp 0x1fec50" e95bec 0x001ffff2
 a "mov al, [0xbeef]" a0efbe
 a "mov ax, [0xbeef]" a1efbe
+a "mov bx, ax" 89c3
+a "mov ebx, eax" 6689c3
+a "sub sp, 2" 83ec02
+a "sub esp, 4" 6683ec04
 a "test bl, 0x12" f6c312
 a "test bx, 0x1234" f7c33412
 aB "test byte [bx], 0x12" f60712


### PR DESCRIPTION
In real mode – make sure the operand-size override prefix (0x66) is added when, and only when, necessary.

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

In x86 real mode, it is possible to access 32-bit registers by prefixing the instruction with 66h. This is exemplified in this PR's commit.
I've added tests that make sure that the operand-size prefix is added when needed, and not added otherwise.