### PR TITLE
Use `r_str_cpy` and `snprintf` in `parse_att2intel.c` ##refractor

### DIFF
--- a/libr/parse/p/parse_att2intel.c
+++ b/libr/parse/p/parse_att2intel.c
@@ -42,8 +42,8 @@ static int replace(int argc, const char *argv[], char *newstr) {
 					if (ops[i].str[j]>='0' && ops[i].str[j]<='9') {
 						const char *w = argv[ ops[i].str[j]-'0' ];
 						if (w != NULL) {
-							strcpy(newstr+k, w);
-							k += strlen(w)-1;
+							strcpy (newstr + k, w);
+							k += strlen (w) - 1;
 						}
 					} else {
 						newstr[k] = ops[i].str[j];
@@ -105,16 +105,17 @@ static int parse(RParse *p, const char *data, char *str) {
 			num = (char *)r_str_lchr (buf, ',');
 		}
 		if (num) {
-			n = atoi (num+1);
+			n = atoi (num + 1);
 			*ptr = '[';
-			memmove (num+1, ptr, strlen (ptr)+1);
+			r_str_cpy (num + 1, ptr);
 			ptr = (char*)r_str_lchr (buf, ']');
 			if (n && ptr) {
 				char *rest = strdup (ptr+1);
+				size_t dist = strlen (data) + 1 - (ptr - buf);
 				if (n > 0) {
-					sprintf (ptr, "+%d]%s", n, rest);
+					snprintf (ptr, dist, "+%d]%s", n, rest);
 				} else {
-					sprintf (ptr, "%d]%s", n, rest);
+					snprintf (ptr, dist, "%d]%s", n, rest);
 				}
 				free (rest);
 			}


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

While working on #17777, I [was suggested](https://github.com/radareorg/radare2/pull/17777#discussion_r512959073) to replace `sprintf` with `snprintf` to avoid overflow. I've applied the same on `parse_att2intel.c` on this PR.

I've also used `r_str_cpy` on an instance of `memmove` and added some missing spaces .

**Test plan**

See if any CI fails and fix anything that went unnoticed.

**Closing issues**

None
