### PR TITLE
Fix not being able to return from debug when using WinDbg(DbgEng) ##debug

### DIFF
--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -575,6 +575,7 @@ remote_client:
 
 static int windbg_close(RIODesc *fd) {
 	DbgEngContext *idbg = fd->data;
+	RCore *core = fd->io->corebind.core;
 	if (idbg->server) {
 		ITHISCALL (dbgClient, EndSession, DEBUG_END_DISCONNECT);
 		ITHISCALL (dbgClient, DisconnectProcessServer, idbg->server);
@@ -583,6 +584,7 @@ static int windbg_close(RIODesc *fd) {
 		ITHISCALL (dbgClient, EndSession, DEBUG_END_PASSIVE);
 	}
 	__free_context (idbg);
+	core->dbg->user = NULL;
 	return 1;
 }
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Closing windbg io with `oo` caused r2 to crash since debug_windbg's DbgEngContext pointed to a null pointer after it was freed in the io plugin.

**Test plan**

`radare2.exe -A ./file.exe`
`oodf windbg://file`
`doc`

See that r2 doesn't crash and the file is rebased back to normal.