### PR TITLE
Revive travis s390x and fix x86.as test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,11 @@ jobs:
       name: S390X
       arch: s390x
       dist: bionic
-      env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1" R2_X86AS=x86_64-linux-gnu-as
+      env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1" R2_X86AS=x86_64-w64-mingw32-as
       addons:
         apt:
           packages:
-            - gcc-x86-64-linux-gnu
+            - binutils-mingw-w64-x86-64
     # Linux with GCC on ARMv8 (64bit)
     - if: (branch = master AND type = push) OR head_branch =~ ^arm64-*
       os: linux
@@ -100,11 +100,11 @@ jobs:
     # Linux with GCC on System Z
     - os: linux
       arch: s390x
-      env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1" R2_X86AS=x86_64-linux-gnu-as
+      env: NODOCKER=1 COMPILER_NAME=gcc CXX=g++ CC=gcc CFLAGS="-DR2_ASSERT_STDOUT=1" R2_X86AS=x86_64-w64-mingw32-as
       addons:
         apt:
           packages:
-            - gcc-x86-64-linux-gnu
+            - binutils-mingw-w64-x86-64
     # Linux with GCC on ARMv8 (64bit)
     - os: linux
       arch: arm64


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Assembler cares about arch only.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

https://travis-ci.com/github/eagleoflqj/radare2/jobs/431657391
Lots of errors come back instead of instant failure.
On my qemu `r2r db/tools/rasm2` shows 7XXs and they are all not x86.as.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
