### PR TITLE
Use PJ in `bj` and add tests ##json

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1702,9 +1702,16 @@ static int cmd_bsize(void *data, const char *input) {
 			eprintf ("Usage: bf [flagname]\n");
 		}
 		break;
-	case 'j': // "bj"
-		r_cons_printf ("{\"blocksize\":%d,\"blocksize_limit\":%d}\n", core->blocksize, core->blocksize_max);
+	case 'j': { // "bj"
+		PJ * pj = pj_new ();
+		pj_o (pj);
+		pj_ki (pj, "blocksize", core->blocksize);
+		pj_ki (pj, "blocksize_limit", core->blocksize_max);
+		pj_end (pj);
+		r_cons_println (pj_string (pj));
+		pj_free (pj);
 		break;
+	}
 	case '*': // "b*"
 		r_cons_printf ("b 0x%x\n", core->blocksize);
 		break;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1704,6 +1704,9 @@ static int cmd_bsize(void *data, const char *input) {
 		break;
 	case 'j': { // "bj"
 		PJ * pj = pj_new ();
+		if (!pj) {
+			break;
+		}
 		pj_o (pj);
 		pj_ki (pj, "blocksize", core->blocksize);
 		pj_ki (pj, "blocksize_limit", core->blocksize_max);

--- a/test/db/cmd/cmd_b
+++ b/test/db/cmd/cmd_b
@@ -1,0 +1,21 @@
+NAME=b
+FILE=-
+CMDS=<<EOF
+b 100
+b
+EOF
+EXPECT=<<EOF
+0x64
+EOF
+RUN
+
+NAME=bj
+FILE=-
+CMDS=<<EOF
+b 100
+bj
+EOF
+EXPECT=<<EOF
+{"blocksize":100,"blocksize_limit":52428800}
+EOF
+RUN

--- a/test/db/json/json2
+++ b/test/db/json/json2
@@ -9,6 +9,7 @@ axgj @ str.Invalid_phase_s
 axj @ sym.main
 axtj
 axtj @ sym.main
+bj
 CCfj
 CCj
 dbj


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

In this patch, I have used the PJ API for the command `bj` and added tests for both `b` and `bj`. `bj` was previously `printf`-ing the output to STDOUT.

**Test plan**
All the written tests pass without any breaks:
```
$ r2r -Vi test/db/cmd/cmd_b
Running from /home/cjunior/Downloads/programs/radare2/test
Loaded 2 tests.
Skipping json tests because jq is not available.
[OK] /home/cjunior/Downloads/programs/radare2/test/db/cmd/cmd_b bj
[OK] /home/cjunior/Downloads/programs/radare2/test/db/cmd/cmd_b b
[2/2]                       2 OK         0 BR        0 XX        0 FX
Finished in 1 seconds.
```

- [ ]  Request changes if necessary and fix them.

**Closing issues**
Related to #13969 
