### PR TITLE
Fix travis ppc64le db/esil/arm_16

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -756,8 +756,7 @@ static bool cb_asmbits(void *user, void *data) {
 		}
 		if (!r_anal_set_bits (core->anal, bits)) {
 			eprintf ("asm.arch: Cannot setup '%d' bits analysis engine\n", bits);
-		} else {
-			ret = true;
+			ret = false;
 		}
 		core->print->bits = bits;
 	}

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -2,8 +2,8 @@ NAME=adr emulation
 FILE=malloc://0x200
 CMDS=<<EOF
 e io.cache=true
-e asm.bits=16
 e asm.arch=arm
+e asm.bits=16
 s 0x0008735c
 wx 30a1
 w radare_emulation\x00 @ 0x87420
@@ -22,8 +22,8 @@ NAME=clz
 FILE=malloc://0x200
 CMDS=<<EOF
 e io.cache=true
-e asm.bits=16
 e asm.arch=arm
+e asm.bits=16
 wa clz r0, r1
 aer r1=0x80000000
 aes
@@ -47,8 +47,8 @@ NAME=addw emulation
 FILE=malloc://0x200
 CMDS=<<EOF
 e io.cache=true
-e asm.bits=16
 e asm.arch=arm
+e asm.bits=16
 s 0x00088a1c 
 wx 0ff26c71
 w addw_emulation\x00 @ 0x8918c


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Can't set asm.bits=16 on ppc. Must set asm.arch first.
Also revert #17679 as https://github.com/radareorg/r2ghidra/pull/164 already fix the problem. This has to be reverted because otherwise `e asm.bits` could outputs 16 while the actual bits is still 64 on ppc (here `node->i_value` and `rasm->bits` mismatch). 

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

My travis https://travis-ci.com/github/eagleoflqj/radare2/jobs/440088471#L1041 db/esil/arm_16 passed.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
