### PR TITLE
Update snes_op_table.h WDM

### DIFF
--- a/libr/asm/arch/snes/snes_op_table.h
+++ b/libr/asm/arch/snes/snes_op_table.h
@@ -96,7 +96,7 @@ static snes_op_t snes_op[]={
 {"and 0x%06x,x",	SNES_OP_32BIT},
 {"rti",			SNES_OP_8BIT},
 {"eor (0x%02x,x)",	SNES_OP_16BIT},
-{"wdm",			SNES_OP_8BIT},
+{"wdm 0x%02X",		SNES_OP_16BIT},
 {"eor 0x%02x,s",	SNES_OP_16BIT},
 {"mvp 0x%02x,0x%02x",	SNES_OP_24BIT},
 {"eor 0x%02x",		SNES_OP_16BIT},


### PR DESCRIPTION
WDM is a two byte instruction incorrectly being decoded as a single byte. Modified the table to correct this and updated the format string appropriately.

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [x] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

This is a minor change. The `SNES_OP_8BIT` was replaced with `SNES_OP_16BIT`, and the format string was updated to include the operand.

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

Is it really necessary for such a small change?

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
