### PR TITLE
Add AMD Am29000 under architectures on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ V850, CRIS, XAP, PIC, LM32, 8051, 6502, i4004, i8080, Propeller,
 Tricore, CHIP-8, LH5801, T8200, GameBoy, SNES, SPC700, MSP430, Xtensa,
 NIOS II, Java, Dalvik, WebAssembly, MSIL, EBC, TMS320 (c54x, c55x,
 c55+, c66), Hexagon, Brainfuck, Malbolge, whitespace, DCPU16, LANAI,
-MCORE, mcs96, RSP, SuperH-4, VAX.
+MCORE, mcs96, RSP, SuperH-4, VAX, AMD Am29000.
 
 ## File Formats
 


### PR DESCRIPTION

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**
Through #14826, support for AMD Am29000 or AMD 29k was added to radare2, but was never added to the README. I've added that to the list of supported architectures on the README.


**Test plan**

None

**Closing issues**

Related to #14826 