### PR TITLE
Update r2r's manpage about the `-i` mode

### DIFF
--- a/man/r2r.1
+++ b/man/r2r.1
@@ -6,6 +6,7 @@
 .Sh SYNOPSIS
 .Nm r2r
 .Op Fl h
+.Op Fl i
 .Op Fl n
 .Op Fl q
 .Op Fl v
@@ -26,6 +27,8 @@ You need radare2 to be available in $PATH.
 .Bl -tag -width Fl
 .It Fl h
 Show the help/usage message
+.It Fl i
+Interactive mode
 .It Fl n
 Do not run any test, just load/parse them
 .It Fl q

--- a/man/r2r.1
+++ b/man/r2r.1
@@ -20,8 +20,6 @@
 .Sh DESCRIPTION
 Run all the radare2-regressions tests matching a specific word in the name.
 .Pp
-TODO: this manpage is work-in-progress
-.Pp
 You need radare2 to be available in $PATH.
 .Sh OPTIONS
 .Bl -tag -width Fl


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

On r2r, you can pass the `-i` option for interactive mode. The manpage for r2r has been updated with information about that now.

**Test plan**

Manpage after adding this:


![image](https://user-images.githubusercontent.com/29057155/99235202-8e350700-281b-11eb-895d-44302cb20d47.png)

- [x] There's still a line that reads `TODO: this manpage is work-in-progress`. I'm not sure whether we still need that, here.

- [ ]  See whether anything needs to be tweaked or rephrased.

**Closing issues**

None
