### PR TITLE
Use offset info in r_type_get_struct_memb()

### DIFF
--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1633,17 +1633,25 @@ RUN
 NAME=aht aligned
 FILE=-
 CMDS=<<EOF
-"td struct foo {char gap;int bar __attribute__((__aligned__(8)));};"
-ahts 8 ~foo
+"td struct foo {char gap;int bar __attribute__((__aligned__(4)));};"
+"td struct foo2 {char gap[1];int bar __attribute__((__aligned__(4)));};"
+"td struct foo3 {char gap[3];int bar __attribute__((__aligned__(4)));};"
+"td struct foo4 {char gap[4];int bar;};"
+"td struct foo5 {int gap;int bar;};"
+ahts 4 ~foo
 ?e =
-wx c7400800000000
+wx c7400400000000
 aht foo.bar
 pd 1
 EOF
 EXPECT=<<EOF
 foo.bar
+foo2.bar
+foo3.bar
+foo4.bar
+foo5.bar
 =
-            0x00000000      c74008000000.  mov dword [rax + foo.bar], 0
+            0x00000000      c74004000000.  mov dword [rax + foo.bar], 0
 EOF
 RUN
 

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1629,3 +1629,32 @@ fcn.00011b90
 fcn.00014d50
 EOF
 RUN
+
+NAME=aht aligned
+FILE=-
+CMDS=<<EOF
+"td struct foo {char gap;int bar __attribute__((__aligned__(8)));};"
+ahts 8 ~foo
+?e =
+wx c7400800000000
+aht foo.bar
+pd 1
+EOF
+EXPECT=<<EOF
+foo.bar
+=
+            0x00000000      c74008000000.  mov dword [rax + foo.bar], 0
+EOF
+RUN
+
+NAME=ahts nested
+FILE=-
+CMDS=<<EOF
+"td struct foo {int bar;int cow;};"
+"td struct spam {int ham;struct foo _foo;int eggs;};"
+ahts 8 ~spam
+EOF
+EXPECT=<<EOF
+spam._foo.cow
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
Current implementation of `r_type_get_struct_memb()` wrongly assumes that struct fields are packed.

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
Closes #17884 
...
