### PR TITLE
Do not allow WASM build to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,6 @@ jobs:
       env: COMPILER_NAME=gcc CXX=g++ CC=gcc INSTALL_SYSTEM=meson R2_SYS_CAPSTONE=true R2_TESTS_DISABLE=1
 
   allow_failures:
-    # Emscripten
-    - os: linux
-      name: WASM
-      env: EMSCRIPTEN=1
     # Linux with GCC on PowerPC
     - os: linux
       arch: ppc64le


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Since now WASM is green we make it necessary for Travis CI to be green.

In the future though, we might want to move this job to GitHub Actions too, to reduce unnecessary Travis CI usage as much as possible.

https://github.com/radareorg/radare2/issues/15688#issuecomment-730856128

Regarding enabling on pull requests - I am not sure, it was disabled on purpose to save the time. cc @eagleoflqj 

