### PR TITLE
Fix taking over variable use on the last instruction of block

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -416,7 +416,7 @@ static bool fcn_takeover_block_recursive_followthrough_cb(RAnalBlock *block, voi
 		}
 		// Steal vars from this block
 		size_t i;
-		for (i = 0; i + 1 < block->ninstr; i++) {
+		for (i = 0; i < block->ninstr; i++) {
 			const ut64 addr = r_anal_bb_opaddr_i (block, i);
 			RPVector *vars_used = r_anal_function_get_vars_used_at (other_fcn, addr);
 			if (!vars_used) {

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -295,3 +295,34 @@ afvW
 \           0x00000030      7047           bx lr
 EOF
 RUN
+
+NAME=Takeover variables
+FILE=-
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+wx e805000000e80600000039d1742577145589e583ec048b5d088b4d0c895dfc83f90174098b45fc8945fc49ebf28b45fc89ec5dc3
+aac
+afv  @ 10
+afvx @ 10
+afv  @ 16
+afvx @ 16
+EOF
+EXPECT=<<EOF
+afvR
+afvW
+var int32_t var_4h_2 @ ebp-0x4
+var int32_t var_4h @ ebp+0x0
+arg int32_t arg_8h @ ebp+0x8
+arg int32_t arg_ch @ ebp+0xc
+afvR
+    arg_8h  0x16
+    arg_ch  0x19
+  var_4h_2
+    var_4h  0x24,0x2d
+afvW
+    arg_8h
+    arg_ch
+  var_4h_2  0x1c
+    var_4h  0x27
+EOF
+RUN


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [x] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

Off by 1 error
