### PR TITLE
Use r_core_cmd_str_pipe when using `.` in a panel

### DIFF
--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -337,13 +337,13 @@ static int cmd_hash_bang (RCore *core, const char *input) {
 					eprintf ("Error: scr.interactive required to run the rlang prompt\n");
 				}
 			}
-		} else if (av[0][0]=='?' || av[0][0]=='*') {
+		} else if (av[0][0] == '?' || av[0][0] == '*') {
 			r_lang_list (core->lang);
 		}
 	} else {
 		r_lang_list (core->lang);
 	}
-	r_str_argv_free(av);
+	r_str_argv_free (av);
 	return true;
 }
 

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -872,8 +872,9 @@ static char *__handle_cmd_str_cache(RCore *core, RPanel *panel, bool force_cache
 	if (b) {
 		core->print->cur_enabled = false;
 	}
-	char *out = r_core_cmd_str (core, cmd);
-	r_cons_echo (NULL);
+	char *out = (*cmd == '.' || *cmd == '#')
+		? r_core_cmd_str_pipe (core, cmd)
+		: r_core_cmd_str (core, cmd);
 	if (force_cache) {
 		panel->model->cache = true;
 	}

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -872,7 +872,7 @@ static char *__handle_cmd_str_cache(RCore *core, RPanel *panel, bool force_cache
 	if (b) {
 		core->print->cur_enabled = false;
 	}
-	char *out = (*cmd == '.' || *cmd == '#')
+	char *out = (*cmd == '.')
 		? r_core_cmd_str_pipe (core, cmd)
 		: r_core_cmd_str (core, cmd);
 	if (force_cache) {

--- a/libr/include/r_lang.h
+++ b/libr/include/r_lang.h
@@ -30,12 +30,12 @@ typedef struct r_lang_plugin_t {
 	const char *license;
 	const char **help;
 	const char *ext;
-	int (*init)(RLang *user);
+	bool (*init)(RLang *user);
 	bool (*setup)(RLang *user);
-	int (*fini)(RLang *user);
-	int (*prompt)(RLang *user);
-	int (*run)(RLang *user, const char *code, int len);
-	int (*run_file)(RLang *user, const char *file);
+	bool (*fini)(RLang *user);
+	bool (*prompt)(RLang *user);
+	bool (*run)(RLang *user, const char *code, int len);
+	bool (*run_file)(RLang *user, const char *file);
 	int (*set_argv)(RLang *user, int argc, char **argv);
 } RLangPlugin;
 
@@ -52,14 +52,13 @@ R_API bool r_lang_setup(RLang *lang);
 R_API bool r_lang_add(RLang *lang, RLangPlugin *foo);
 R_API bool r_lang_list(RLang *lang);
 R_API bool r_lang_use(RLang *lang, const char *name);
-R_API int r_lang_run(RLang *lang, const char *code, int len);
-R_API int r_lang_run_string(RLang *lang, const char *code);
+R_API bool r_lang_run(RLang *lang, const char *code, int len);
+R_API bool r_lang_run_string(RLang *lang, const char *code);
 /* TODO: user_ptr must be deprecated */
 R_API void r_lang_set_user_ptr(RLang *lang, void *user);
 R_API bool r_lang_set_argv(RLang *lang, int argc, char **argv);
-R_API int r_lang_run(RLang *lang, const char *code, int len);
-R_API int r_lang_run_file(RLang *lang, const char *file);
-R_API int r_lang_prompt(RLang *lang);
+R_API bool r_lang_run_file(RLang *lang, const char *file);
+R_API bool r_lang_prompt(RLang *lang);
 R_API void r_lang_plugin_free(RLangPlugin *p); // XXX
 R_API RLangPlugin *r_lang_get_by_name(RLang *lang, const char *name);
 R_API RLangPlugin *r_lang_get_by_extension(RLang *lang, const char *ext);

--- a/libr/lang/lang.c
+++ b/libr/lang/lang.c
@@ -199,19 +199,19 @@ R_API bool r_lang_set_argv(RLang *lang, int argc, char **argv) {
 	return false;
 }
 
-R_API int r_lang_run(RLang *lang, const char *code, int len) {
+R_API bool r_lang_run(RLang *lang, const char *code, int len) {
 	if (lang->cur && lang->cur->run) {
 		return lang->cur->run (lang, code, len);
 	}
 	return false;
 }
 
-R_API int r_lang_run_string(RLang *lang, const char *code) {
+R_API bool r_lang_run_string(RLang *lang, const char *code) {
 	return r_lang_run (lang, code, strlen (code));
 }
 
-R_API int r_lang_run_file(RLang *lang, const char *file) {
-	int ret = false;
+R_API bool r_lang_run_file(RLang *lang, const char *file) {
+	bool ret = false;
 	if (lang->cur) {
 		if (!lang->cur->run_file) {
 			if (lang->cur->run) {
@@ -232,7 +232,7 @@ R_API int r_lang_run_file(RLang *lang, const char *file) {
 }
 
 /* TODO: deprecate or make it more modular .. reading from stdin in a lib?!? wtf */
-R_API int r_lang_prompt(RLang *lang) {
+R_API bool r_lang_prompt(RLang *lang) {
 	char buf[1024];
 	const char *p;
 

--- a/libr/lang/p/c.c
+++ b/libr/lang/p/c.c
@@ -92,16 +92,18 @@ static int lang_c_init(void *user) {
 	return true;
 }
 
-static int lang_c_run(RLang *lang, const char *code, int len) {
+static bool lang_c_run(RLang *lang, const char *code, int len) {
 	FILE *fd = r_sandbox_fopen (".tmp.c", "w");
-	if (fd) {
-		fputs ("#include <r_core.h>\n\nvoid entry(RCore *core, int argc, const char **argv) {\n", fd);
-		fputs (code, fd);
-		fputs ("\n}\n", fd);
-		fclose (fd);
-		lang_c_file (lang, ".tmp.c");
-		r_file_rm (".tmp.c");
-	} else eprintf ("Cannot open .tmp.c\n");
+	if (!fd) {
+		eprintf ("Cannot open .tmp.c\n");
+		return false;
+	}
+	fputs ("#include <r_core.h>\n\nvoid entry(RCore *core, int argc, const char **argv) {\n", fd);
+	fputs (code, fd);
+	fputs ("\n}\n", fd);
+	fclose (fd);
+	lang_c_file (lang, ".tmp.c");
+	r_file_rm (".tmp.c");
 	return true;
 }
 

--- a/libr/lang/p/cpipe.c
+++ b/libr/lang/p/cpipe.c
@@ -71,7 +71,7 @@ static int lang_cpipe_init(void *user) {
 	return true;
 }
 
-static int lang_cpipe_run(RLang *lang, const char *code, int len) {
+static bool lang_cpipe_run(RLang *lang, const char *code, int len) {
 	FILE *fd = r_sandbox_fopen (".tmp.c", "w");
 	if (!fd) {
 		eprintf ("Cannot open .tmp.c\n");

--- a/libr/lang/p/lib.c
+++ b/libr/lang/p/lib.c
@@ -1,18 +1,18 @@
-/* radare - LPGL - Copyright 2017 condret */
+/* radare - LPGL - Copyright 2017-2020 condret */
 
 #include <r_lib.h>
 #include <r_core.h>
 #include <r_lang.h>
 
-static int lang_lib_init (RLang *user) {
+static bool lang_lib_init(RLang *user) {
 	return true;
 }
 
-static int lang_lib_file_run (RLang *user, const char *file) {
+static bool lang_lib_file_run(RLang *user, const char *file) {
 	char *libpath;
 	void *lib;
 	if (!(libpath = r_str_new (file))) {
-		return -1;
+		return false;
 	}
 	if (!r_str_startswith (libpath, "/") && !r_str_startswith (libpath, "./")) {
 		libpath = r_str_prepend (libpath, "./");
@@ -24,7 +24,7 @@ static int lang_lib_file_run (RLang *user, const char *file) {
 	}
 	if (!r_file_exists (libpath)) {
 		free (libpath);
-		return -1;
+		return false;
 	}	
 	
 	lib = r_lib_dl_open (libpath);
@@ -39,7 +39,7 @@ static int lang_lib_file_run (RLang *user, const char *file) {
 		r_lib_dl_close (lib);
 	}
 	free (libpath);
-	return 0;
+	return true;
 }
 
 static RLangPlugin r_lang_plugin_lib = {

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -193,7 +193,7 @@ static bool lang_pipe_run(RLang *lang, const char *code, int len) {
 			buf[sizeof (buf) - 1] = 0;
 			res = lang->cmd_str ((RCore*)lang->user, buf);
 			if (res) {
-				r_cons_print (res);
+				// r_cons_print (res);
 				(void) write (input[1], res, strlen (res) + 1);
 				free (res);
 			} else {

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2015-2019 pancake */
+/* radare2 - LGPL - Copyright 2015-2020 pancake */
 
 #include "r_lib.h"
 #include "r_core.h"
@@ -9,11 +9,6 @@
 #ifdef _MSC_VER
 #include <process.h>
 #endif
-
-static int lang_pipe_run(RLang *lang, const char *code, int len);
-static int lang_pipe_file(RLang *lang, const char *file) {
-	return lang_pipe_run (lang, file, -1);
-}
 
 #if __WINDOWS__
 static HANDLE myCreateChildProcess(const char * szCmdline) {
@@ -133,7 +128,7 @@ static void env(const char *s, int f) {
 }
 #endif
 
-static int lang_pipe_run(RLang *lang, const char *code, int len) {
+static bool lang_pipe_run(RLang *lang, const char *code, int len) {
 #if __UNIX__
 	int safe_in = dup (0);
 	int child, ret;
@@ -295,6 +290,10 @@ beach:
 	return hproc != NULL;
 #endif
 #endif
+}
+
+static bool lang_pipe_file(RLang *lang, const char *file) {
+	return lang_pipe_run (lang, file, -1);
 }
 
 static RLangPlugin r_lang_plugin_pipe = {

--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -192,8 +192,8 @@ static bool lang_pipe_run(RLang *lang, const char *code, int len) {
 			}
 			buf[sizeof (buf) - 1] = 0;
 			res = lang->cmd_str ((RCore*)lang->user, buf);
-			//eprintf ("%d %s\n", ret, buf);
 			if (res) {
+				r_cons_print (res);
 				(void) write (input[1], res, strlen (res) + 1);
 				free (res);
 			} else {

--- a/libr/lang/p/rust.c
+++ b/libr/lang/p/rust.c
@@ -70,10 +70,13 @@ static int lang_rust_init(void *user) {
 	return true;
 }
 
-static int lang_rust_run(RLang *lang, const char *code, int len) {
+static bool lang_rust_run(RLang *lang, const char *code, int len) {
 	FILE *fd = r_sandbox_fopen ("_tmp.rs", "w");
-	if (fd) {
-		const char *rust_header = \
+	if (!fd) {
+		eprintf ("Cannot open _tmp.rs\n");
+		return false;
+	}
+	const char *rust_header = \
 "use std::ffi::CStr;\n" \
 "extern {\n" \
 "        pub fn r_core_cmd_str(core: *const u8, s: *const u8) -> *const u8;\n" \
@@ -103,13 +106,12 @@ static int lang_rust_run(RLang *lang, const char *code, int len) {
 		const char *rust_footer = \
 "        }\n" \
 "}\n";
-		fputs (rust_header, fd);
-		fputs (code, fd);
-		fputs (rust_footer, fd);
-		fclose (fd);
-		lang_rust_file (lang, "_tmp.rs");
-		r_file_rm ("_tmp.rs");
-	} else eprintf ("Cannot open _tmp.rs\n");
+	fputs (rust_header, fd);
+	fputs (code, fd);
+	fputs (rust_footer, fd);
+	fclose (fd);
+	lang_rust_file (lang, "_tmp.rs");
+	r_file_rm ("_tmp.rs");
 	return true;
 }
 

--- a/libr/lang/p/spp.c
+++ b/libr/lang/p/spp.c
@@ -9,12 +9,12 @@ static RLang *Glang = NULL;
 #include <spp.h>
 #include "spp_r2.inc"
 
-static int lang_spp_init(RLang *l) {
+static bool lang_spp_init(RLang *l) {
 	Glang = l;
 	return true;
 }
 
-static int lang_spp_run(RLang *lang, const char *code, int len) {
+static bool lang_spp_run(RLang *lang, const char *code, int len) {
 	Output out;
 	out.fout = NULL;
 	out.cout = r_strbuf_new (NULL);
@@ -29,7 +29,7 @@ static int lang_spp_run(RLang *lang, const char *code, int len) {
 	return true;
 }
 
-static int lang_spp_file(RLang *lang, const char *file) {
+static bool lang_spp_file(RLang *lang, const char *file) {
 	size_t len;
 	char *code = r_file_slurp (file, &len);
 	if (code) {

--- a/libr/lang/p/vala.c
+++ b/libr/lang/p/vala.c
@@ -6,7 +6,7 @@
 #include "r_core.h"
 #include "r_lang.h"
 
-static int lang_vala_file(RLang *lang, const char *file, bool silent) {
+static bool lang_vala_file(RLang *lang, const char *file, bool silent) {
 	void *lib;
 	char *p, name[512], buf[512];
 	char *vapidir, *srcdir, *libname;
@@ -121,16 +121,16 @@ static int lang_vala_file(RLang *lang, const char *file, bool silent) {
 	return 0;
 }
 
-static int vala_run_file(RLang *lang, const char *file) {
+static bool vala_run_file(RLang *lang, const char *file) {
 	return lang_vala_file(lang, file, false);
 }
 
-static int lang_vala_init(void *user) {
+static bool lang_vala_init(void *user) {
 	// TODO: check if "valac" is found in path
 	return true;
 }
 
-static int lang_vala_run(RLang *lang, const char *code, int len) {
+static bool lang_vala_run(RLang *lang, const char *code, int len) {
 	bool silent = !strncmp (code, "-s", 2);
 	FILE *fd = r_sandbox_fopen (".tmp.vala", "w");
 	if (fd) {

--- a/libr/lang/p/zig.c
+++ b/libr/lang/p/zig.c
@@ -4,7 +4,7 @@
 #include <r_core.h>
 #include <r_lang.h>
 
-static int lang_zig_file(RLang *lang, const char *file) {
+static bool lang_zig_file(RLang *lang, const char *file) {
 	void *lib;
 	char *a, *cc, *p;
 	const char *libpath, *libname;
@@ -67,12 +67,12 @@ static int lang_zig_file(RLang *lang, const char *file) {
 	return true;
 }
 
-static int lang_zig_init(void *user) {
+static bool lang_zig_init(void *user) {
 	// TODO: check if "valac" is found in path
 	return true;
 }
 
-static int lang_zig_run(RLang *lang, const char *code, int len) {
+static bool lang_zig_run(RLang *lang, const char *code, int len) {
 	const char *file = "_tmp.zig";
 	FILE *fd = r_sandbox_fopen (file, "w");
 	if (fd) {

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -242,28 +242,29 @@ static bool run_commands(RCore *r, RList *cmds, RList *files, bool quiet, int do
 	const char *file;
 	int ret;
 	/* -i */
+	bool has_failed = false;
 	r_list_foreach (files, iter, file) {
 		if (!r_file_exists (file)) {
 			eprintf ("Script '%s' not found.\n", file);
 			goto beach;
 		}
 		ret = r_core_run_script (r, file);
+		r_cons_flush ();
 		if (ret == -2) {
 			eprintf ("[c] Cannot open '%s'\n", file);
 		}
-		if (ret < 0 || (ret == 0 && quiet)) {
-			r_cons_flush ();
-			return false;
+		if (ret < 0) {
+			has_failed = true;
+			break;
 		}
 	}
 	/* -c */
 	r_list_foreach (cmds, iter, cmdn) {
-		//r_core_cmd0 (r, cmdn);
 		r_core_cmd_lines (r, cmdn);
 		r_cons_flush ();
 	}
 beach:
-	if (quiet) {
+	if (quiet && !has_failed) {
 		if (do_analysis) {
 			return true;
 		}


### PR DESCRIPTION
* Captures the output of the r2pipe interpreter's `print`

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

Running r2pipe scripts in visual panels results in no output captured because the `print` statements of the language are printed directly to fd=2, in order to capture them this patch checks if the command is starting with a dot and uses the cmdstr_pipe() function instead.

Known issues:

* I tried to handle #! but it doesnt works. 

```
$ cat test.py
import r2pipe

r2 = r2pipe.open()
print(r2.cmd("?e hehehehe"))
$
```

**Test plan**

run r2 panels mode like this: `r2 -cv /bin/ls`

press `e` to edit the command to run in the current panel and type `. test.py`

without this patch there's no output captured.

![IMAGE 2020-11-28 01:30:46](https://user-images.githubusercontent.com/6431515/100490138-57af9400-3119-11eb-82aa-d48cab0f2a97.jpg)

**Closing issues**

None but reported in the chat by dreg