### PR TITLE
Fixed breakpoint placement when no bp arch is available and added a warning for invalid bps ##debug

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -173,6 +173,10 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 	if (bp->baddr > addr) {
 		eprintf ("base addr should not be larger than the breakpoint address.\n");
 	}
+	if (bp->bpinmaps && !r_bp_is_valid (bp, b)) {
+		eprintf ("WARNING: Breakpoint won't be placed since it's not in a valid map.\n"
+			 "You can bypass this check by setting dbg.bpinmaps to false.\n");
+	}
 	b->delta = addr - bp->baddr;
 	b->size = size;
 	b->enabled = true;

--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -194,14 +194,10 @@ static RBreakpointItem *r_bp_add(RBreakpoint *bp, const ut8 *obytes, ut64 addr, 
 		} else {
 			b->obytes = NULL;
 		}
-		/* XXX: endian .. use bp->endian */
 		ret = r_bp_get_bytes (bp, b->bbytes, size, bp->endian, 0);
 		if (ret != size) {
 			eprintf ("Cannot get breakpoint bytes. No architecture selected?\n");
-			unlinkBreakpoint (bp, b);
-			return NULL;
 		}
-		b->recoil = ret;
 	}
 	bp->nbps++;
 	r_list_append (bp->bps, b);

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -46,7 +46,6 @@ typedef struct r_bp_item_t {
 	ut64 addr;
 	ut64 delta;
 	int size; /* size of breakpoint area */
-	int recoil; /* recoil */
 	bool swstep; 	/* is this breakpoint from a swstep? */
 	int perm;
 	int hw;


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

* Placing breakpoints without a selected bp plugin(the selection can be seen in `dbh`) caused breakpoint creation to fail even though the debug backend might have supported setting a breakpoint.
* It seems that issues with section mapping in avr arch/using qemu gdb information caused confusion in #17931 when breakpoints were marked as invalid and weren't placed. The second change simply adds a warning for users to be aware that their breakpoints aren't going to work without `dbg.bpinmaps` set to false in case they placed them in an invalid addresses.

**Test plan**

* See that you are able to place breakpoints without a selected bp plugin when connecting to gdbserver(you can change the x86 plugin's name in `libr/bp/p/bp_x86.c` to something else if you are testing on a x86 machine).
* See the invalid breakpoint warning using the binary given at #17931 or by setting a very high address