### PR TITLE
Fix asserts in r2 -a snes foo.sfc ##bin

### DIFF
--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -423,7 +423,7 @@ R_API int r_bin_object_set_items(RBinFile *bf, RBinObject *o) {
 	if (p->mem)  {
 		o->mem = p->mem (bf);
 	}
-	if (bin->filter_rules & (R_BIN_REQ_INFO | R_BIN_REQ_SYMBOLS | R_BIN_REQ_IMPORTS)) {
+	if (o->info && bin->filter_rules & (R_BIN_REQ_INFO | R_BIN_REQ_SYMBOLS | R_BIN_REQ_IMPORTS)) {
 		o->lang = isSwift? R_BIN_NM_SWIFT: r_bin_load_languages (bf);
 	}
 	return true;

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1259,7 +1259,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 				}
 			}
 		}
-		if (o && compute_hashes) {
+		if (o && o->info && compute_hashes) {
 			// TODO: recall with limit=0 ?
 			ut64 limit = r_config_get_i (r->config, "bin.hashlimit");
 			r_bin_file_set_hashes (r->bin, r_bin_file_compute_hashes (r->bin, limit));


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

```
$ r2 /tmp/speed_test_v51.sfc
Cannot determine if this is a LoROM or HiROM file
Cannot determine if this is a LoROM or HiROM file
WARNING: r_bin_load_languages: assertion 'binfile->o->info' failed (line 70)
WARNING: r_bin_file_set_hashes: assertion 'bin && bin->cur && bin->cur->o && bin->cur->o->info' failed (line 968)
[0x00000000]>
```

**Test plan**

```
$ R2_DEBUG_ASSERT=1 lldb -- r2 /tmp/speed_test_v51.sfc
```

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
