### PR TITLE
asm_*_gnu.c: *_buffer_read_memory: honour memaddr as offset into code buffer

### DIFF
--- a/libr/asm/p/asm_cris_gnu.c
+++ b/libr/asm/p/asm_cris_gnu.c
@@ -26,7 +26,14 @@ static RStrBuf *buf_global = NULL;
 static unsigned char bytes[8];
 
 static int cris_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 8) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/libr/asm/p/asm_hppa_gnu.c
+++ b/libr/asm/p/asm_hppa_gnu.c
@@ -27,7 +27,14 @@ static int hppa_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 leng
 		return 0;
 	}
 #endif
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 4) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/libr/asm/p/asm_lanai_gnu.c
+++ b/libr/asm/p/asm_lanai_gnu.c
@@ -14,7 +14,14 @@ static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int lanai_buffer_read_memory(bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 4) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/libr/asm/p/asm_mips_gnu.c
+++ b/libr/asm/p/asm_mips_gnu.c
@@ -21,7 +21,14 @@ static char *pre_cpu = NULL;
 static char *pre_features = NULL;
 
 static int mips_buffer_read_memory(bfd_vma memaddr, bfd_byte *myaddr, unsigned int length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 4) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/libr/asm/p/asm_ppc_gnu.c
+++ b/libr/asm/p/asm_ppc_gnu.c
@@ -17,7 +17,14 @@ static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int ppc_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 4) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/libr/asm/p/asm_sparc_gnu.c
+++ b/libr/asm/p/asm_sparc_gnu.c
@@ -15,6 +15,13 @@ static RStrBuf *buf_global = NULL;
 static unsigned char bytes[4];
 
 static int sparc_buffer_read_memory (bfd_vma memaddr, bfd_byte *myaddr, unsigned int length, struct disassemble_info *info) {
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 4) {
+		return -1;
+	}
 	memcpy (myaddr, bytes, length);
 	return 0;
 }

--- a/libr/asm/p/asm_v850_gnu.c
+++ b/libr/asm/p/asm_v850_gnu.c
@@ -16,7 +16,14 @@ static RStrBuf *buf_global = NULL;
 static ut8 bytes[8];
 
 static int v850_buffer_read_memory(bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
-	memcpy (myaddr, bytes, length);
+	int delta = (memaddr - Offset);
+	if (delta < 0) {
+		return -1;      // disable backward reads
+	}
+	if ((delta + length) > 8) {
+		return -1;
+	}
+	memcpy (myaddr, bytes + delta, length);
 	return 0;
 }
 

--- a/test/db/anal/v850.gnu
+++ b/test/db/anal/v850.gnu
@@ -1,0 +1,12 @@
+NAME=v850.gnu proper imm32 handling
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch = v850.gnu
+wx 210674060000210674061234
+pi 2 @0
+EOF
+EXPECT=<<EOF
+mov 0x674, r1
+mov 0x34120674, r1
+EOF
+RUN


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [x] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

The V850.gnu disassembler target didn't honour memory offset in reading code memory, mis-disassembling e.g. mov instructions with an IMM32 operand. This fixes that.

**Test plan**

    echo -ne '\x21\x06\x74\x06\x00\x00' > test.bin; r2 -A -a v850.gnu -c 'pd 1 @0' test.bin

Good output: 0x00000000      210674060000   mov 0x674, r1
