### PR TITLE
Esil dfg lemon const folder

### DIFF
--- a/libr/anal/esil_dfg.c
+++ b/libr/anal/esil_dfg.c
@@ -17,6 +17,11 @@ typedef struct r_anal_esil_dfg_filter_t {
 	Sdb *results;
 } RAnalEsilDFGFilter;
 
+typedef struct r_anal_esil_dfg_const_reducer_t {
+	RAnalEsilDFGFilter filter;
+	RContRBTree *const_result_gnodes;
+} RAnalEsilDFGConstReducer;
+
 // TODO: simple const propagation - use node->type of srcs to propagate consts of pushed vars
 
 R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new(RAnalEsilDFG *edf, const char *c) {
@@ -26,14 +31,14 @@ R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new(RAnalEsilDFG *edf, const char *
 	return ret;
 }
 
-static void _dfg_node_free (RAnalEsilDFGNode *free_me) {
+static void _dfg_node_free(RAnalEsilDFGNode *free_me) {
 	if (free_me) {
 		r_strbuf_free (free_me->content);
 		free (free_me);
 	}
 }
 
-static int _rv_del_alloc_cmp (void *incoming, void *in, void *user) {
+static int _rv_del_alloc_cmp(void *incoming, void *in, void *user) {
 	EsilDFGRegVar *rv_incoming = (EsilDFGRegVar *)incoming;
 	EsilDFGRegVar *rv_in = (EsilDFGRegVar *)in;
 	RAnalEsilDFG *dfg = (RAnalEsilDFG *)user;
@@ -173,13 +178,13 @@ static int _rv_del_alloc_cmp (void *incoming, void *in, void *user) {
 	return -1;
 }
 
-static int _rv_ins_cmp (void *incoming, void *in, void *user) {
+static int _rv_ins_cmp(void *incoming, void *in, void *user) {
 	EsilDFGRegVar *rv_incoming = (EsilDFGRegVar *)incoming;
 	EsilDFGRegVar *rv_in = (EsilDFGRegVar *)in;
 	return rv_incoming->from - rv_in->from;
 }
 
-static bool _edf_reg_set (RAnalEsilDFG *dfg, const char *reg, RGraphNode *node) {
+static bool _edf_reg_set(RAnalEsilDFG *dfg, const char *reg, RGraphNode *node) {
 	r_return_val_if_fail (dfg && !dfg->malloc_failed && reg, false);
 	const ut32 _reg_strlen = 4 + strlen (reg);
 	char *_reg = R_NEWS0 (char, _reg_strlen + 1);
@@ -229,7 +234,7 @@ static bool _edf_reg_set (RAnalEsilDFG *dfg, const char *reg, RGraphNode *node) 
 	return true;
 }
 
-static int _rv_find_cmp (void *incoming, void *in, void *user) {
+static int _rv_find_cmp(void *incoming, void *in, void *user) {
 	EsilDFGRegVar *rv_incoming = (EsilDFGRegVar *)incoming;
 	EsilDFGRegVar *rv_in = (EsilDFGRegVar *)in;
 
@@ -352,7 +357,6 @@ static RGraphNode *_edf_origin_reg_get(RAnalEsilDFG *dfg, const char *reg) {
 	return origin_reg_node;
 }
 
-
 static RGraphNode *_edf_reg_get(RAnalEsilDFG *dfg, const char *reg) {
 	r_return_val_if_fail (dfg && reg, NULL);
 	const ut32 _reg_strlen = 4 + strlen (reg);
@@ -420,9 +424,9 @@ static RGraphNode *_edf_reg_get(RAnalEsilDFG *dfg, const char *reg) {
 		}
 		free (rv);
 	}
-	reg_node = NULL;	// is this needed?
+	reg_node = NULL; // is this needed?
 	if (dfg->malloc_failed) {
-		while (!r_queue_is_empty(dfg->todo)) {
+		while (!r_queue_is_empty (dfg->todo)) {
 			free (r_queue_dequeue (dfg->todo));
 			goto beach;
 		}
@@ -433,30 +437,29 @@ static RGraphNode *_edf_reg_get(RAnalEsilDFG *dfg, const char *reg) {
 	case 1:
 		reg_node = r_queue_dequeue (parts);
 		break;
-	default:
-		{
-			RAnalEsilDFGNode *_reg_node = r_anal_esil_dfg_node_new (dfg, "merge to ");
-			if (!_reg_node) {
-				while (!r_queue_is_empty (dfg->todo)) {
-					free (r_queue_dequeue (dfg->todo));
-				}
-				dfg->malloc_failed = true;
-				goto beach;
+	default: {
+		RAnalEsilDFGNode *_reg_node = r_anal_esil_dfg_node_new (dfg, "merge to ");
+		if (!_reg_node) {
+			while (!r_queue_is_empty (dfg->todo)) {
+				free (r_queue_dequeue (dfg->todo));
 			}
-
-			r_strbuf_appendf (_reg_node->content, "%s:var_%d", reg, dfg->idx++);
-			reg_node = r_graph_add_node (dfg->flow, _reg_node);
-			if (!reg_node) {
-				_dfg_node_free (_reg_node);
-				while (!r_queue_is_empty (dfg->todo)) {
-					free (r_queue_dequeue (dfg->todo));
-				}
-				dfg->malloc_failed = true;
-				goto beach;
-			}
+			dfg->malloc_failed = true;
+			goto beach;
 		}
+
+		r_strbuf_appendf (_reg_node->content, "%s:var_%d", reg, dfg->idx++);
+		reg_node = r_graph_add_node (dfg->flow, _reg_node);
+		if (!reg_node) {
+			_dfg_node_free (_reg_node);
+			while (!r_queue_is_empty (dfg->todo)) {
+				free (r_queue_dequeue (dfg->todo));
+			}
+			dfg->malloc_failed = true;
+			goto beach;
+		}
+	}
 		do {
-			r_graph_add_edge (dfg->flow, r_queue_dequeue(parts), reg_node);
+			r_graph_add_edge (dfg->flow, r_queue_dequeue (parts), reg_node);
 		} while (!r_queue_is_empty (parts));
 		break;
 	}
@@ -465,8 +468,7 @@ beach:
 	return reg_node;
 }
 
-
-static bool _edf_var_set (RAnalEsilDFG *dfg, const char *var, RGraphNode *node) {
+static bool _edf_var_set(RAnalEsilDFG *dfg, const char *var, RGraphNode *node) {
 	r_return_val_if_fail (dfg && var, false);
 	const ut32 _var_strlen = 4 + strlen (var);
 	char *_var = R_NEWS0 (char, _var_strlen + 1);
@@ -480,8 +482,7 @@ static bool _edf_var_set (RAnalEsilDFG *dfg, const char *var, RGraphNode *node) 
 	return ret;
 }
 
-
-static RGraphNode *_edf_var_get (RAnalEsilDFG *dfg, const char *var) {
+static RGraphNode *_edf_var_get(RAnalEsilDFG *dfg, const char *var) {
 	r_return_val_if_fail (dfg && var, NULL);
 	const ut32 _var_strlen = 4 + strlen (var);
 	char *_var = R_NEWS0 (char, _var_strlen + 1);
@@ -712,7 +713,7 @@ static bool edf_consume_1_push_1(RAnalEsil *esil) {
 		src_node = _edf_var_get (edf, src);
 		// cannot fail, bc src cannot be NULL
 		RAnalEsilDFGNode *ec_node = (RAnalEsilDFGNode *)src_node->data;
-		const_result = (eop->type == R_ANAL_ESIL_OP_TYPE_MATH) & !!(ec_node->type & R_ANAL_ESIL_DFG_BLOCK_CONST);
+		const_result = (eop_type == R_ANAL_ESIL_OP_TYPE_MATH) & !!(ec_node->type & R_ANAL_ESIL_DFG_BLOCK_CONST);
 	}
 
 	free (src);
@@ -765,7 +766,7 @@ static bool edf_consume_2_set_mem(RAnalEsil *esil) {
 	if (!dst_node) {
 		dst_node = _edf_var_get (edf, dst);
 	}
-//probably dead code
+	//probably dead code
 	if (!dst_node) {
 		if (dst_type == R_ANAL_ESIL_PARM_REG) {
 			RGraphNode *n_reg = r_graph_add_node (edf->flow, r_anal_esil_dfg_node_new (edf, dst));
@@ -911,14 +912,14 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_new(RReg *regs) {
 		return NULL;
 	}
 
-// this is not exactly necessary
-// could use RReg-API directly in the dfg gen,
-// but sdb as transition table is probably faster
+	// this is not exactly necessary
+	// could use RReg-API directly in the dfg gen,
+	// but sdb as transition table is probably faster
 	RRegItem *ri;
 	RListIter *ator;
 	r_list_foreach (regs->allregs, ator, ri) {
 		const ut32 from = ri->offset;
-		const ut32 to = from + ri->size - 1;	// closed intervals because of FUCK YOU
+		const ut32 to = from + ri->size - 1; // closed intervals because of FUCK YOU
 		const ut64 v = to | (((ut64)from) << 32);
 		const ut32 reg_strlen = 4 + strlen (ri->name) + 1;
 		char *reg = R_NEWS0 (char, reg_strlen);
@@ -1013,9 +1014,16 @@ static int _dfg_node_filter_insert_cmp(void *incoming, void *in, void *user) {
 	return incoming_node->idx - in_node->idx;
 }
 
-static void _dfg_rev_dfs_cb(RGraphNode *n, RGraphVisitor *vi) {
+static int _dfg_gnode_reducer_insert_cmp(void *incoming, void *in, void *user) {
+	RGraphNode *incoming_gnode = (RGraphNode *)incoming;
+	RGraphNode *in_gnode = (RGraphNode *)in;
+	RAnalEsilDFGNode *incoming_node = (RAnalEsilDFGNode *)incoming_gnode->data;
+	RAnalEsilDFGNode *in_node = (RAnalEsilDFGNode *)in_gnode->data;
+	return in_node->idx - incoming_node->idx;
+}
+
+static void _dfg_filter_rev_dfs(RGraphNode *n, RAnalEsilDFGFilter *filter) {
 	RAnalEsilDFGNode *node = (RAnalEsilDFGNode *)n->data;
-	RAnalEsilDFGFilter *filter = (RAnalEsilDFGFilter *)vi->data;
 	switch (node->type) {
 	case R_ANAL_ESIL_DFG_BLOCK_CONST:
 	case R_ANAL_ESIL_DFG_BLOCK_VAR:
@@ -1025,12 +1033,27 @@ static void _dfg_rev_dfs_cb(RGraphNode *n, RGraphVisitor *vi) {
 		r_rbtree_cont_insert (filter->tree, node, _dfg_node_filter_insert_cmp, NULL);
 		break;
 	case R_ANAL_ESIL_DFG_BLOCK_RESULT: // outnode must be result generator here
-	{
+	case R_ANAL_ESIL_DFG_BLOCK_RESULT | R_ANAL_ESIL_DFG_BLOCK_CONST: {
 		RGraphNode *previous = (RGraphNode *)r_list_get_top (n->in_nodes);
 		if (previous) {
 			sdb_ptr_set (filter->results, r_strbuf_get (node->content), previous, 0);
 		}
 	} break;
+	}
+}
+
+static void _dfg_filter_rev_dfs_cb(RGraphNode *n, RGraphVisitor *vi) {
+	_dfg_filter_rev_dfs (n, (RAnalEsilDFGFilter *)vi->data);
+}
+
+static void _dfg_const_reducer_rev_dfs_cb(RGraphNode *n, RGraphVisitor *vi) {
+	RAnalEsilDFGConstReducer *reducer = (RAnalEsilDFGConstReducer *)vi->data;
+	RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)n->data;
+	_dfg_filter_rev_dfs (n, &reducer->filter);
+	r_queue_enqueue (reducer->filter.dfg->todo, n);
+	if (enode->type == (R_ANAL_ESIL_DFG_BLOCK_CONST | R_ANAL_ESIL_DFG_BLOCK_RESULT)) {
+		// n can only exist in the tree, if it is a const-result
+		r_rbtree_cont_delete (reducer->const_result_gnodes, n, _dfg_gnode_reducer_insert_cmp, NULL);
 	}
 }
 
@@ -1075,6 +1098,98 @@ static RStrBuf *get_resolved_expr(RAnalEsilDFGFilter *filter, RAnalEsilDFGNode *
 	return res;
 }
 
+R_API void r_anal_esil_dfg_fold_const(RAnal *anal, RAnalEsilDFG *dfg) {
+	// sorted RContRBTree for graph-nodes that contain edf-nodes with const-result as type
+	RAnalEsilDFGConstReducer reducer = { { dfg, NULL, NULL }, r_rbtree_cont_new () };
+	RListIter *iter;
+	RGraphNode *gnode;
+	r_list_foreach (dfg->flow->nodes, iter, gnode) {
+		RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)gnode->data;
+		// insert const-result-nodes into the tree
+		// sort key is enode->idx
+		if (enode->type == (R_ANAL_ESIL_DFG_BLOCK_CONST | R_ANAL_ESIL_DFG_BLOCK_RESULT)) {
+			r_rbtree_cont_insert (reducer.const_result_gnodes, gnode, _dfg_gnode_reducer_insert_cmp, NULL);
+		}
+	}
+
+	RAnalEsil *esil = r_anal_esil_new (4096, 0, 1);
+	r_anal_esil_setup (esil, anal, 1, 0, 0);
+	RGraphVisitor vi = { _dfg_const_reducer_rev_dfs_cb, NULL, NULL, NULL, NULL, &reducer };
+	while ((gnode = (RGraphNode *)r_rbtree_cont_first (reducer.const_result_gnodes))) {
+		// filter, remove gnodes from const-result-tree
+		// during rdfs, run in esil, replace subtree with
+		// const-nodes and fix str-reference if outnode exists
+
+		// filter
+		reducer.filter.tree = r_rbtree_cont_new ();
+		reducer.filter.results = sdb_new0 (); // I guess this can be done better
+
+		r_graph_dfs_node_reverse (dfg->flow, gnode, &vi);
+
+		// ok, so gnode here cannot contain a generative node, only const-results
+		// get_resolved_expr expects a generative node
+		// the predecessor of a const-result node is always a generative node
+		RGraphNode *previous_gnode = (RGraphNode *)r_list_get_top (gnode->in_nodes);
+		// it can never be NULL
+
+		RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)previous_gnode->data;
+
+		RStrBuf *filtered = get_resolved_expr (&reducer.filter, enode);
+		{
+			char *sanitized = r_str_replace (r_str_replace (strdup (r_strbuf_get (filtered)), ",,", ",", 1), ",,", ",", 1);
+			r_strbuf_set (filtered, (sanitized[0] == ',') ? &sanitized[1] : sanitized);
+			free (sanitized);
+		}
+		r_rbtree_cont_free (reducer.filter.tree);
+		sdb_free (reducer.filter.results);
+
+		// running filtered const-expression in esil
+		r_anal_esil_parse (esil, r_strbuf_get (filtered));
+		char *reduced_const = r_anal_esil_pop (esil);
+		r_strbuf_free (filtered);
+
+		// this part needs some explanation:
+		// in _dfg_const_reducer_rev_dfs_cb all nodes that are traversed during
+		// reverse dfs are enqueued in dfg->todo. reverse dfs in this context
+		// ALWAYS starts with a const-result-node. Result-nodes ALWAYS have a
+		// generative node as predecessor, which represent to operation.
+		// An operation in esil, with the exception of $z and some custom operations,
+		// have at least one operand, which is represented by at least one node in the dfg.
+		// As a consequence of this, we can safely dequeue 2 nodes from the dfg->todo
+		// without any checks and reuse them
+
+		gnode = (RGraphNode *)r_queue_dequeue (dfg->todo);
+		enode = (RAnalEsilDFGNode *)gnode->data;
+		RGraphNode *next_gnode = (RGraphNode *)r_list_get_top (gnode->out_nodes);
+		if (next_gnode) {
+			// Cannot assume that there is another operation
+			// Fix string reference
+			RAnalEsilDFGNode *next_enode = (RAnalEsilDFGNode *)next_gnode->data;
+			char *fixed = r_str_replace (strdup (r_strbuf_get (next_enode->content)),
+				r_strbuf_get (enode->content), reduced_const, 0);
+			r_strbuf_set (next_enode->content, fixed);
+			free (fixed);
+		}
+
+		// replace subtree with const-nodes
+		r_strbuf_setf (enode->content, "%s:const_%d", reduced_const, enode->idx);
+		gnode = (RGraphNode *)r_queue_dequeue (dfg->todo);
+		enode = (RAnalEsilDFGNode *)gnode->data;
+		r_strbuf_set (enode->content, reduced_const);
+		free (reduced_const);
+
+		while (!r_queue_is_empty (dfg->todo)) {
+			gnode = (RGraphNode *)r_queue_dequeue (dfg->todo);
+			enode = (RAnalEsilDFGNode *)gnode->data;
+			_dfg_node_free (enode);
+			r_graph_del_node (dfg->flow, gnode);
+		}
+	}
+
+	r_anal_esil_free (esil);
+	r_rbtree_cont_free (reducer.const_result_gnodes);
+}
+
 R_API RStrBuf *r_anal_esil_dfg_filter(RAnalEsilDFG *dfg, const char *reg) {
 	if (!dfg || !reg) {
 		return NULL;
@@ -1087,7 +1202,7 @@ R_API RStrBuf *r_anal_esil_dfg_filter(RAnalEsilDFG *dfg, const char *reg) {
 	// allocate stuff
 	RAnalEsilDFGFilter filter = { dfg, r_rbtree_cont_new (), sdb_new0 () };
 	RStrBuf *filtered = r_strbuf_new ("");
-	RGraphVisitor vi = { _dfg_rev_dfs_cb, NULL, NULL, NULL, NULL, &filter };
+	RGraphVisitor vi = { _dfg_filter_rev_dfs_cb, NULL, NULL, NULL, NULL, &filter };
 
 	// dfs the graph starting at node of esp-register
 	r_graph_dfs_node_reverse (dfg->flow, resolve_me, &vi);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5952,34 +5952,3 @@ kontinue:
 	r_list_free (todo);
 	ht_uu_free (done);
 }
-
-R_API void r_core_anal_esil_graph(RCore *core, const char *expr) {
-	RAnalEsilDFG * edf = r_anal_esil_dfg_expr(core->anal, NULL, expr);
-	RListIter *iter, *ator;
-	RGraphNode *node, *edon;
-	RStrBuf *buf = r_strbuf_new ("");
-	r_cons_printf ("ag-\n");
-	r_list_foreach (r_graph_get_nodes (edf->flow), iter, node) {
-		const RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)node->data;
-		char *esc_str = r_str_escape (r_strbuf_get (enode->content));
-		r_strbuf_set (buf, esc_str);
-		if (enode->type == R_ANAL_ESIL_DFG_BLOCK_GENERATIVE) {
-			r_strbuf_prepend (buf, "generative:");
-		}
-		char *b64_buf = r_base64_encode_dyn (r_strbuf_get (buf), buf->len);
-		r_cons_printf ("agn %d base64:%s\n", enode->idx, b64_buf);
-		free (b64_buf);
-		free (esc_str);
-	}
-	r_strbuf_free (buf);
-
-	r_list_foreach (r_graph_get_nodes (edf->flow), iter, node) {
-		const RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)node->data;
-		r_list_foreach (r_graph_get_neighbours (edf->flow, node), ator, edon) {
-			const RAnalEsilDFGNode *edone = (RAnalEsilDFGNode *)edon->data;
-			r_cons_printf ("age %d %d\n", enode->idx, edone->idx);
-		}
-	}
-
-	r_anal_esil_dfg_free (edf);
-}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -167,7 +167,8 @@ static const char *help_msg_ae[] = {
 	"aecue", " [esil]", "continue until esil expression match",
 	"aef", " [addr]", "emulate function",
 	"aefa", " [addr]", "emulate function to find out args in given or current offset",
-	"aeg", " [expr]", "esil graph",
+	"aeg", " [expr]", "esil data flow graph",
+	"aegf", " [expr] [register]", "esil data flow graph filter",
 	"aei", "", "initialize ESIL VM state (aei- to deinitialize)",
 	"aeim", " [addr] [size] [name]", "initialize ESIL VM stack (aeim- remove)",
 	"aeip", "", "initialize ESIL program counter to curseek",
@@ -296,6 +297,15 @@ static const char *help_msg_aec[] = {
 static const char *help_msg_aeC[] = {
 	"Examples:", "aeC", " arg0 arg1 ... @ calladdr",
 	"aeC", " 1 2 @ sym._add", "Call sym._add(1,2)",
+	NULL
+};
+
+static const char *help_msg_aeg[] = {
+	"Usage:", "aeg[cfiv*]", " [...]",
+	"aeg", "", "analyze current instruction as an esil graph",
+	"aegf", "", "analyze given expression and filter for register",
+	"aeg*", "", "analyze current instruction as an esil graph",
+	"aegv" "", "analyse and launch the visual interactive mode (.aeg*;aggv == aegv)",
 	NULL
 };
 
@@ -6072,6 +6082,123 @@ static void __anal_esil_function(RCore *core, ut64 addr) {
 	r_anal_esil_free (core->anal->esil);
 }
 
+static void print_esil_dfg_as_commands(RCore *core, RAnalEsilDFG *dfg) {
+	RListIter *iter, *ator;
+	RGraphNode *node, *edon;
+	RStrBuf *sb = r_strbuf_new ("");
+	if (!sb) {
+		return;
+	}
+	r_cons_println ("ag-");
+	r_list_foreach (r_graph_get_nodes (dfg->flow), iter, node) {
+		const RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)node->data;
+		char *esc_str = r_str_escape (r_strbuf_get (enode->content));
+		if (!esc_str) {
+			r_strbuf_free (sb);
+			return;
+		}
+		r_strbuf_set (sb, esc_str);
+		if (enode->type == R_ANAL_ESIL_DFG_BLOCK_GENERATIVE) {
+			r_strbuf_prepend (sb, "generative:");
+		}
+		char *b64_buf = r_base64_encode_dyn (r_strbuf_get (sb), sb->len);
+		if (!b64_buf) {
+			r_strbuf_free (sb);
+			free (esc_str);
+			return;
+		}
+
+		r_cons_printf ("agn %d base64:%s\n", enode->idx, b64_buf);
+		free (b64_buf);
+		free (esc_str);
+	}
+	r_strbuf_free (sb);
+
+	r_list_foreach (r_graph_get_nodes (dfg->flow), iter, node) {
+		const RAnalEsilDFGNode *enode = (RAnalEsilDFGNode *)node->data;
+		r_list_foreach (r_graph_get_neighbours (dfg->flow, node), ator, edon) {
+			const RAnalEsilDFGNode *edone = (RAnalEsilDFGNode *)edon->data;
+			r_cons_printf ("age %d %d\n", enode->idx, edone->idx);
+		}
+	}
+}
+
+static void cmd_aeg(RCore *core, int argc, char *argv[]) {
+	if (argc == 0) {
+		r_core_cmd0 (core, ".aeg*;agg");
+		return;
+	}
+	if (argc == 1) {	// "aeg"
+		RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, argv[0]);
+		r_return_if_fail (dfg);
+		print_esil_dfg_as_commands (core, dfg);
+		r_anal_esil_dfg_free (dfg);
+		return;
+	}
+	switch (argv[0][0]) {
+	case '*':	// "aeg*"
+	{
+		RAnalOp *aop = r_core_anal_op (core, core->offset, R_ANAL_OP_MASK_ESIL);
+		if (!aop) {
+			return;
+		}
+		const char *esilstr = r_strbuf_get (&aop->esil);
+		if (R_STR_ISNOTEMPTY (esilstr)) {
+			RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilstr);
+			if (!dfg) {
+				r_anal_op_free (aop);
+				return;
+			}
+			print_esil_dfg_as_commands (core, dfg);
+			r_anal_esil_dfg_free (dfg);
+		}
+	}
+	break;
+	case 'i':	// "aegi"
+	case 'v':	// "aegv"
+	{
+		RConfigHold *hc = r_config_hold_new (core->config);
+		if (!hc) {
+			return;
+		}
+		r_config_hold_s (hc, "cmd.gprompt",  NULL);
+		r_config_set (core->config, "cmd.gprompt", "pi 1");
+		r_core_cmd0 (core, ".aeg*;aggv");
+		r_config_hold_free (hc);
+	}
+	break;
+	case 'f':	// "aegf"
+	{
+		RStrBuf *filtered = r_anal_esil_dfg_filter_expr (core->anal, argv[1], argv[2]);
+		if (filtered) {
+			r_cons_printf ("%s\n", r_strbuf_get (filtered));
+			r_strbuf_free (filtered);
+		}
+	}
+	case 'c':	// "aegc"
+	{
+		RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, argv[1]);
+		if (!dfg) {
+			return;
+		}
+		r_anal_esil_dfg_fold_const (core->anal, dfg);
+		if (argv[0][1] == 'f') {	// "aegcf"
+			RStrBuf *filtered = r_anal_esil_dfg_filter (dfg, argv[2]);
+			if (filtered) {
+				r_cons_printf ("%s\n", r_strbuf_get (filtered));
+				r_strbuf_free (filtered);
+			}
+		} else {
+			print_esil_dfg_as_commands (core, dfg);
+		}
+		r_anal_esil_dfg_free (dfg);
+	}
+	case '?':	// "aeg?"
+	default:
+		r_core_cmd_help (core, help_msg_aeg);
+	}
+}
+
 static void cmd_anal_esil(RCore *core, const char *input) {
 	RAnalEsil *esil = core->anal->esil;
 	ut64 addr = core->offset;
@@ -6452,29 +6579,16 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 		}
 		break;
 	case 'g': // "aeg"
-		if (input[1] == 'i' || input[1] == 'v') {
-			char *oprompt = strdup (r_config_get (core->config, "cmd.gprompt"));
-			r_config_set (core->config, "cmd.gprompt", "pi 1");
-			r_core_cmd0 (core, ".aeg*;aggv");
-			r_config_set (core->config, "cmd.gprompt", oprompt);
-			free (oprompt);
-		} else if (!input[1]) {
-			r_core_cmd0 (core, ".aeg*;agg");
-		} else if (input[1] == ' ') {
-			r_core_anal_esil_graph (core, input + 2);
-		} else if (input[1] == '*') {
-			RAnalOp *aop = r_core_anal_op (core, core->offset, R_ANAL_OP_MASK_ESIL);
-			if (aop) {
-				const char *esilstr = r_strbuf_get (&aop->esil);
-				if (R_STR_ISNOTEMPTY (esilstr)) {
-					r_core_anal_esil_graph (core, esilstr);
-				}
+		{
+			int argc;
+			char **argv = r_str_argv (&input[1], &argc);
+			r_return_if_fail (argv);
+			cmd_aeg (core, argc, argv);
+			int i;
+			for (i = 0; i < argc; i++) {
+				free (argv[i]);
 			}
-		} else {
-			r_cons_printf ("Usage: aeg[iv*]\n");
-			r_cons_printf (" aeg  analyze current instruction as an esil graph\n");
-			r_cons_printf (" aeg* analyze current instruction as an esil graph\n");
-			r_cons_printf (" aegv and launch the visual interactive mode (.aeg*;aggv == aegv)\n");
+			free (argv);
 		}
 		break;
 	case 'b': // "aeb"

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1260,13 +1260,13 @@ typedef struct r_anal_esil_cfg_t {
 	RGraph *g;
 } RAnalEsilCFG;
 
-typedef enum {
+enum {
 	R_ANAL_ESIL_DFG_BLOCK_CONST = 1,
 	R_ANAL_ESIL_DFG_BLOCK_VAR = 2,
 	R_ANAL_ESIL_DFG_BLOCK_PTR = 4,
 	R_ANAL_ESIL_DFG_BLOCK_RESULT = 8,
 	R_ANAL_ESIL_DFG_BLOCK_GENERATIVE = 16,
-} RAnalEsilDFGBlockType;
+};	//RAnalEsilDFGBlockType
 
 typedef struct r_anal_esil_dfg_t {
 	ut32 idx;
@@ -1284,7 +1284,7 @@ typedef struct r_anal_esil_dfg_node_t {
 	// add more info here
 	ut32 idx;
 	RStrBuf *content;
-	RAnalEsilDFGBlockType type;
+	ut32 /*RAnalEsilDFGBlockType*/ type;
 } RAnalEsilDFGNode;
 
 typedef int (*RAnalCmdExt)(/* Rcore */RAnal *anal, const char* input);
@@ -2120,10 +2120,11 @@ R_API RAnalEsilCFG *r_anal_esil_cfg_op(RAnalEsilCFG *cfg, RAnal *anal, RAnalOp *
 R_API void r_anal_esil_cfg_merge_blocks(RAnalEsilCFG *cfg);
 R_API void r_anal_esil_cfg_free(RAnalEsilCFG *cfg);
 
-R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new (RAnalEsilDFG *edf, const char *c);
+R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new(RAnalEsilDFG *edf, const char *c);
 R_API RAnalEsilDFG *r_anal_esil_dfg_new(RReg *regs);
 R_API void r_anal_esil_dfg_free(RAnalEsilDFG *dfg);
 R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *dfg, const char *expr);
+R_API void r_anal_esil_dfg_fold_const(RAnal *anal, RAnalEsilDFG *dfg);
 R_API RStrBuf *r_anal_esil_dfg_filter(RAnalEsilDFG *dfg, const char *reg);
 R_API RStrBuf *r_anal_esil_dfg_filter_expr(RAnal *anal, const char *expr, const char *reg);
 R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -479,7 +479,6 @@ R_API void r_core_anal_inflags (RCore *core, const char *glob);
 R_API bool cmd_anal_objc (RCore *core, const char *input, bool auto_anal);
 R_API void r_core_anal_cc_init(RCore *core);
 R_API void r_core_anal_paths(RCore *core, ut64 from, ut64 to, bool followCalls, int followDepth, bool is_json);
-R_API void r_core_anal_esil_graph(RCore *core, const char *expr);
 
 R_API void r_core_list_io(RCore *core);
 R_API RListInfo *r_listinfo_new (const char *name, RInterval pitv, RInterval vitv, int perm, const char *extra);

--- a/libr/include/r_util/r_rbtree.h
+++ b/libr/include/r_util/r_rbtree.h
@@ -110,6 +110,7 @@ R_API RContRBTree *r_rbtree_cont_newf(RContRBFree f);
 R_API bool r_rbtree_cont_insert(RContRBTree *tree, void *data, RContRBCmp cmp, void *user);
 R_API bool r_rbtree_cont_delete(RContRBTree *tree, void *data, RContRBCmp cmp, void *user);
 R_API void *r_rbtree_cont_find(RContRBTree *tree, void *data, RContRBCmp cmp, void *user);
+R_API void *r_rbtree_cont_first(RContRBTree *tree);
 
 #define r_rbtree_cont_foreach(tree, it, dat) \
 	for ((it) = r_rbtree_first (&tree->root->node); r_rbtree_iter_has(&it) && (dat = r_rbtree_iter_get (&it, RContRBNode, node)->data); r_rbtree_iter_next (&(it)))

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -488,6 +488,23 @@ R_API void *r_rbtree_cont_find(RContRBTree *tree, void *data, RContRBCmp cmp, vo
 	return NULL;
 }
 
+// not a direct pendant to r_rbtree_first, but similar
+// returns first element in the tree, not an iter or a node
+R_API void *r_rbtree_cont_first(RContRBTree *tree) {
+	r_return_val_if_fail (tree, NULL);
+	if (!tree->root) {
+		// empty tree
+		return NULL;
+	}
+	RBIter iter = r_rbtree_first (&tree->root->node);
+	if (iter.len == 0) {
+		// also empty tree
+		return NULL;
+	}
+	RBNode *first_rbnode = iter.path[iter.len-1];
+	return (container_of (first_rbnode, RContRBNode, node))->data;
+}
+
 R_API void r_rbtree_cont_free(RContRBTree *tree) {
 	if (tree && tree->root) {
 		r_rbtree_free (&tree->root->node, cont_node_free, tree->free);

--- a/test/unit/test_esil_dfg_filter.c
+++ b/test/unit/test_esil_dfg_filter.c
@@ -50,7 +50,25 @@ bool test_filter_regs(void) {
 	mu_end;
 }
 
+bool test_lemon_const_folder(void) {
+	RAnal *anal = r_anal_new ();
+	r_anal_use (anal, "x86");
+	r_anal_set_bits (anal, 32);
+	r_anal_set_reg_profile (anal);
+
+	RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (anal, NULL, "4,!,3,ebx,:=,!,1,+,eax,:=");
+	r_anal_esil_dfg_fold_const (anal, dfg);
+	RStrBuf *filtered = r_anal_esil_dfg_filter (dfg, "eax");
+	const bool cmp_result = !strcmp(r_strbuf_get(filtered), "0x2,eax,:=");
+	r_strbuf_free (filtered);
+	r_anal_free (anal);
+	
+	mu_assert_true (cmp_result, "esil dfg const folding is broken");
+	mu_end;
+}
+
 int main(int argc, char **argv) {
 	mu_run_test (test_filter_regs);
+	mu_run_test (test_lemon_const_folder);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
The esil dfg filter already allows filtering for subexpressions, which would compute a specified register. This PR adds const folding to that. The following example shows filtering for eax, w/o const folding:
`4,!,3,ebx,:=,!,1,+,eax,:=  ===> 0x4,!,!,0x1,+,eax,:=`
Now the same with const folding:
`4,!,3,ebx,:=,!,1,+,eax,:=  ===> 0x2,eax,:=`

Const folding is done on the dfg graph, it is a function to tune up the dfg.
