### PR TITLE
Prevent corruption of ##types  __var_retype

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -255,13 +255,13 @@ static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stac
 		if (!rvar) {
 			return;
 		}
+		char *t = strdup (type);
 		__var_retype (anal, rvar, NULL, type, false, false);
 		RAnalVar *lvar = r_anal_var_get_dst_var (rvar);
 		if (lvar) {
-			char *t = strdup (type);
 			__var_retype (anal, lvar, NULL, t, false, false);
-			free (t);
 		}
+		free (t);
 	}
 }
 

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -258,7 +258,9 @@ static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stac
 		__var_retype (anal, rvar, NULL, type, false, false);
 		RAnalVar *lvar = r_anal_var_get_dst_var (rvar);
 		if (lvar) {
-			__var_retype (anal, lvar, NULL, type, false, false);
+			char *t = strdup (type);
+			__var_retype (anal, lvar, NULL, t, false, false);
+			free (t);
 		}
 	}
 }


### PR DESCRIPTION

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
The `__var_retype` function is used to change the type of a variable. The provided type is a `const` so it's contents are expected to stay constant.  The current `var->type` will get free'd when it is replaced. So if `var->type == type` then the content of `type` will be corrupted by heap metadata on the free.

I have seen this happen due to `retype_callee_arg` being called with the `type` of some variable, then `retype_callee_arg` obtaining that same variable through the call to `r_anal_var_get_dst_var`. At least, I think that is what is happening. 

I don't know the code here well enough to correct the logic properly, so I added the guard. This should cause some warnings until the logic is fixed but I don't think it should cause too many analysis mistakes. Naively, failing to change the type of a var, to itself, should not result in bad analysis.