### PR TITLE
Remove globals in radiff2 ##build

### DIFF
--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -34,28 +34,30 @@ enum {
         GRAPH_GML_MODE
 };
 
-static bool zignatures = false;
-static const char *file = NULL;
-static const char *file2 = NULL;
-static ut32 count = 0;
-static int showcount = 0;
-static int useva = true;
-static int delta = 0;
-static int showbare = false;
-static int json_started = 0;
-static int diffmode = 0;
-static bool disasm = false;
-static bool pdc = false;
-static bool quiet = false;
-static RCore *core = NULL;
-static const char *arch = NULL;
-const char *runcmd = NULL;
-static int bits = 0;
-static int anal_all = 0;
-static bool verbose = false;
-static RList *evals = NULL;
+typedef struct {
+	bool zignatures;
+	const char *file;
+	const char *file2;
+	ut32 count;
+	int showcount;
+	int useva;
+	int delta;
+	int showbare;
+	bool json_started;
+	int diffmode;
+	bool disasm;
+	bool pdc;
+	bool quiet;
+	RCore *core;
+	const char *arch;
+	const char *runcmd;
+	int bits;
+	int anal_all;
+	bool verbose;
+	RList *evals;
+} RadiffOptions;
 
-static RCore *opencore(const char *f) {
+static RCore *opencore(RadiffOptions *ro, const char *f) {
 	RListIter *iter;
 	const ut64 baddr = UT64_MAX;
 	const char *e;
@@ -64,9 +66,9 @@ static RCore *opencore(const char *f) {
 		return NULL;
 	}
 	r_core_loadlibs (c, R_CORE_LOADLIBS_ALL, NULL);
-	r_config_set_i (c->config, "io.va", useva);
+	r_config_set_i (c->config, "io.va", ro->useva);
 	r_config_set_i (c->config, "scr.interactive", false);
-	r_list_foreach (evals, iter, e) {
+	r_list_foreach (ro->evals, iter, e) {
 		r_config_eval (c->config, e, false);
 	}
 	if (f) {
@@ -90,20 +92,19 @@ static RCore *opencore(const char *f) {
 		if (r_list_empty (r_bin_get_sections (c->bin))) {
 			r_config_set_i (c->config, "io.va", false);
 		}
-
-		if (anal_all) {
+		if (ro->anal_all) {
 			const char *cmd = "aac";
-			switch (anal_all) {
+			switch (ro->anal_all) {
 			case 1: cmd = "aaa"; break;
 			case 2: cmd = "aaaa"; break;
 			}
 			r_core_cmd0 (c, cmd);
 		}
-		if (runcmd) {
-			r_core_cmd0 (c, runcmd);
+		if (ro->runcmd) {
+			r_core_cmd0 (c, ro->runcmd);
 		}
 		// generate zignaturez?
-		if (zignatures) {
+		if (ro->zignatures) {
 			r_core_cmd0 (c, "zg");
 		}
 		r_cons_flush ();
@@ -126,19 +127,20 @@ static void readstr(char *s, int sz, const ut8 *buf, int len) {
 }
 
 static int cb(RDiff *d, void *user, RDiffOp *op) {
-	int i; // , diffmode = (int)(size_t)user;
+	int i;
+	RadiffOptions *ro = user;
 	char s[256] = {0};
-	if (showcount) {
-		count++;
+	if (ro->showcount) {
+		ro->count++;
 		return 1;
 	}
-	switch (diffmode) {
+	switch (ro->diffmode) {
 	case 'U': // 'U' in theory never handled here
 	case 'u':
 		if (op->a_len > 0) {
 			readstr (s, sizeof (s), op->a_buf, op->a_len);
 			if (*s) {
-				if (!quiet) {
+				if (!ro->quiet) {
 					printf (Color_RED);
 				}
 				printf ("-0x%08"PFMT64x":", op->a_off);
@@ -146,7 +148,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 				for (i = 0; i < len; i++) {
 					printf ("%02x ", op->a_buf[i]);
 				}
-				if (!quiet) {
+				if (!ro->quiet) {
 					char *p = r_str_escape ((const char*)op->a_buf);
 					printf (" \"%s\"", p);
 					free (p);
@@ -158,14 +160,14 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		if (op->b_len > 0) {
 			readstr (s, sizeof (s), op->b_buf, op->b_len);
 			if (*s) {
-				if (!quiet) {
+				if (!ro->quiet) {
 					printf (Color_GREEN);
 				}
 				printf ("+0x%08"PFMT64x":", op->b_off);
 				for (i = 0; i < op->b_len; i++) {
 					printf ("%02x ", op->b_buf[i]);
 				}
-				if (!quiet) {
+				if (!ro->quiet) {
 					char *p = r_str_escape((const char*)op->b_buf);
 					printf (" \"%s\"", p);
 					free (p);
@@ -176,7 +178,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		}
 		break;
 	case 'r':
-		if (disasm) {
+		if (ro->disasm) {
 			eprintf ("r2cmds (-r) + disasm (-D) not yet implemented\n");
 		}
 		if (op->a_len == op->b_len) {
@@ -188,28 +190,28 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		} else {
 			if (op->a_len > 0) {
 				printf ("r-%d @ 0x%08"PFMT64x "\n",
-					op->a_len, op->a_off + delta);
+					op->a_len, op->a_off + ro->delta);
 			}
 			if (op->b_len > 0) {
 				printf ("r+%d @ 0x%08"PFMT64x "\n",
-					op->b_len, op->b_off + delta);
+					op->b_len, op->b_off + ro->delta);
 				printf ("wx ");
 				for (i = 0; i < op->b_len; i++) {
 					printf ("%02x", op->b_buf[i]);
 				}
-				printf (" @ 0x%08"PFMT64x "\n", op->b_off + delta);
+				printf (" @ 0x%08"PFMT64x "\n", op->b_off + ro->delta);
 			}
-			delta += (op->b_off - op->a_off);
+			ro->delta += (op->b_off - op->a_off);
 		}
 		return 1;
 	case 'j':
-		if (disasm) {
+		if (ro->disasm) {
 			eprintf ("JSON (-j) + disasm (-D) not yet implemented\n");
 		}
-		if (json_started) {
+		if (ro->json_started) {
 			printf (",\n");
 		}
-		json_started = 1;
+		ro->json_started = true;
 		printf ("{\"offset\":%"PFMT64d ",", op->a_off);
 		printf ("\"from\":\"");
 		for (i = 0; i < op->a_len; i++) {
@@ -223,27 +225,27 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 		return 1;
 	case 0:
 	default:
-		if (disasm) {
+		if (ro->disasm) {
 			int i;
 			printf ("--- 0x%08"PFMT64x "  ", op->a_off);
-			if (!core) {
-				core = opencore (file);
-				if (arch) {
-					r_config_set (core->config, "asm.arch", arch);
+			if (!ro->core) {
+				ro->core = opencore (ro, ro->file);
+				if (ro->arch) {
+					r_config_set (ro->core->config, "asm.arch", ro->arch);
 				}
-				if (bits) {
-					r_config_set_i (core->config, "asm.bits", bits);
+				if (ro->bits) {
+					r_config_set_i (ro->core->config, "asm.bits", ro->bits);
 				}
 			}
 			for (i = 0; i < op->a_len; i++) {
 				printf ("%02x", op->a_buf[i]);
 			}
 			printf ("\n");
-			if (core) {
+			if (ro->core) {
 				int len = R_MAX (4, op->a_len);
-				RAsmCode *ac = r_asm_mdisassemble (core->rasm, op->a_buf, len);
+				RAsmCode *ac = r_asm_mdisassemble (ro->core->rasm, op->a_buf, len);
 				char *acbufasm = strdup (ac->assembly);
-				if (quiet) {
+				if (ro->quiet) {
 					char *bufasm = r_str_prefix_all (acbufasm, "- ");
 					printf ("%s\n", bufasm);
 					free (bufasm);
@@ -261,21 +263,21 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 				printf ("%02x", op->a_buf[i]);
 			}
 		}
-		if (disasm) {
+		if (ro->disasm) {
 			int i;
 			printf ("+++ 0x%08"PFMT64x "  ", op->b_off);
-			if (!core) {
-				core = opencore (NULL);
+			if (!ro->core) {
+				ro->core = opencore (ro, NULL);
 			}
 			for (i = 0; i < op->b_len; i++) {
 				printf ("%02x", op->b_buf[i]);
 			}
 			printf ("\n");
-			if (core) {
+			if (ro->core) {
 				int len = R_MAX (4, op->b_len);
-				RAsmCode *ac = r_asm_mdisassemble (core->rasm, op->b_buf, len);
+				RAsmCode *ac = r_asm_mdisassemble (ro->core->rasm, op->b_buf, len);
 				char *acbufasm = strdup (ac->assembly);
-				if (quiet) {
+				if (ro->quiet) {
 					char *bufasm = r_str_prefix_all (acbufasm, "+ ");
 					printf ("%s\n", bufasm);
 					free (bufasm);
@@ -700,14 +702,14 @@ static void handle_sha256(const ut8 *block, int len) {
 	r_hash_free (ctx);
 }
 
-static ut8 *slurp(RCore **c, const char *file, size_t *sz) {
+static ut8 *slurp(RadiffOptions *ro, RCore **c, const char *file, size_t *sz) {
 	RIODesc *d;
 	RIO *io;
 	if (c && file && strstr (file, "://")) {
 		ut8 *data = NULL;
 		ut64 size;
 		if (!*c) {
-			*c = opencore (NULL);
+			*c = opencore (ro, NULL);
 		}
 		if (!*c) {
 			eprintf ("opencore failed\n");
@@ -919,6 +921,7 @@ static void __print_diff_graph(RCore *c, ut64 off, int gmode) {
 }
 
 R_API int r_main_radiff2(int argc, const char **argv) {
+	RadiffOptions ro = {0};
 	const char *columnSort = NULL;
 	const char *addr = NULL;
 	RCore *c = NULL, *c2 = NULL;
@@ -931,32 +934,32 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 	int diffops = 0;
 	int threshold = -1;
 	double sim = 0.0;
-	evals = r_list_newf (NULL);
+	ro.evals = r_list_newf (NULL);
 
 	RGetopt opt;
 	r_getopt_init (&opt, argc, argv, "Aa:b:BCDe:npg:m:G:OijrhcdsS:uUvVxXt:zqZ");
 	while ((o = r_getopt_next (&opt)) != -1) {
 		switch (o) {
 		case 'a':
-			arch = opt.arg;
+			ro.arch = opt.arg;
 			break;
 		case 'A':
-			anal_all++;
+			ro.anal_all++;
 			break;
 		case 'b':
-			bits = atoi (opt.arg);
+			ro.bits = atoi (opt.arg);
 			break;
 		case 'B':
-			diffmode = 'B';
+			ro.diffmode = 'B';
 			break;
 		case 'e':
-			r_list_append (evals, (void*)opt.arg);
+			r_list_append (ro.evals, (void*)opt.arg);
 			break;
 		case 'p':
-			useva = false;
+			ro.useva = false;
 			break;
 		case 'r':
-			diffmode = 'r';
+			ro.diffmode = 'r';
 			break;
 		case 'g':
 			mode = MODE_GRAPH;
@@ -978,10 +981,10 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 		        }
 		}       break;
 		case 'G':
-			runcmd = opt.arg;
+			ro.runcmd = opt.arg;
 			break;
 		case 'c':
-			showcount = 1;
+			ro.showcount = 1;
 			break;
 		case 'C':
 			mode = MODE_CODE;
@@ -990,7 +993,7 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			mode = MODE_DIFF_IMPORTS;
 			break;
 		case 'n':
-			showbare = true;
+			ro.showbare = true;
 			break;
 		case 'O':
 			diffops = 1;
@@ -1003,12 +1006,12 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			delta = 1;
 			break;
 		case 'D':
-			if (disasm) {
-				pdc = true;
-				disasm = false;
+			if (ro.disasm) {
+				ro.pdc = true;
+				ro.disasm = false;
 				mode = MODE_CODE;
 			} else {
-				disasm = true;
+				ro.disasm = true;
 			}
 			break;
 		case 'h':
@@ -1032,27 +1035,27 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			mode = MODE_COLSII;
 			break;
 		case 'u':
-			diffmode = 'u';
+			ro.diffmode = 'u';
 			break;
 		case 'U':
-			diffmode = 'U';
+			ro.diffmode = 'U';
 			break;
 		case 'v':
 			return r_main_version_print ("radiff2");
 		case 'q':
-			quiet = true;
+			ro.quiet = true;
 			break;
 		case 'V':
-			verbose = true;
+			ro.verbose = true;
 			break;
 		case 'j':
-			diffmode = 'j';
+			ro.diffmode = 'j';
 			break;
 		case 'z':
 			mode = MODE_DIFF_STRS;
 			break;
 		case 'Z':
-			zignatures = true;
+			ro.zignatures = true;
 			break;
 		default:
 			return show_help (0);
@@ -1062,10 +1065,10 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 	if (argc < 3 || opt.ind + 2 > argc) {
 		return show_help (0);
 	}
-	file = (opt.ind < argc)? argv[opt.ind]: NULL;
-	file2 = (opt.ind + 1 < argc)? argv[opt.ind + 1]: NULL;
+	ro.file = (opt.ind < argc)? argv[opt.ind]: NULL;
+	ro.file2 = (opt.ind + 1 < argc)? argv[opt.ind + 1]: NULL;
 
-	if (R_STR_ISEMPTY (file) || R_STR_ISEMPTY(file2)) {
+	if (R_STR_ISEMPTY (ro.file) || R_STR_ISEMPTY (ro.file2)) {
 		eprintf ("Cannot open empty path\n");
 		return 1;
 	}
@@ -1075,35 +1078,35 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 	case MODE_CODE:
 	case MODE_DIFF_STRS:
 	case MODE_DIFF_IMPORTS:
-		c = opencore (file);
+		c = opencore (&ro, ro.file);
 		if (!c) {
-			eprintf ("Cannot open '%s'\n", r_str_get (file));
+			eprintf ("Cannot open '%s'\n", r_str_get (ro.file));
 		}
-		c2 = opencore (file2);
+		c2 = opencore (&ro, ro.file2);
 		if (!c || !c2) {
-			eprintf ("Cannot open '%s'\n", r_str_get (file2));
+			eprintf ("Cannot open '%s'\n", r_str_get (ro.file2));
 			return 1;
 		}
 		c->c2 = c2;
 		c2->c2 = c;
 		r_core_parse_radare2rc (c);
-		if (arch) {
-			r_config_set (c->config, "asm.arch", arch);
-			r_config_set (c2->config, "asm.arch", arch);
+		if (ro.arch) {
+			r_config_set (c->config, "asm.arch", ro.arch);
+			r_config_set (c2->config, "asm.arch", ro.arch);
 		}
-		if (bits) {
-			r_config_set_i (c->config, "asm.bits", bits);
-			r_config_set_i (c2->config, "asm.bits", bits);
+		if (ro.bits) {
+			r_config_set_i (c->config, "asm.bits", ro.bits);
+			r_config_set_i (c2->config, "asm.bits", ro.bits);
 		}
 		if (columnSort) {
 			r_config_set (c->config, "diff.sort", columnSort);
 			r_config_set (c2->config, "diff.sort", columnSort);
 		}
-		r_config_set_i (c->config, "diff.bare", showbare);
-		r_config_set_i (c2->config, "diff.bare", showbare);
+		r_config_set_i (c->config, "diff.bare", ro.showbare);
+		r_config_set_i (c2->config, "diff.bare", ro.showbare);
 		r_anal_diff_setup_i (c->anal, diffops, threshold, threshold);
 		r_anal_diff_setup_i (c2->anal, diffops, threshold, threshold);
-		if (pdc) {
+		if (ro.pdc) {
 			if (!addr) {
 				//addr = "entry0";
 				addr = "main";
@@ -1146,7 +1149,7 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			}
 			free (words);
 		} else if (mode == MODE_CODE) {
-			if (zignatures) {
+			if (ro.zignatures) {
 				r_core_cmd0 (c, "z~?");
 				r_core_cmd0 (c2, "z~?");
 				r_core_zdiff (c, c2);
@@ -1179,16 +1182,16 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 		break;
 	default: {
 		size_t fsz;
-		bufa = slurp (&c, file, &fsz);
+		bufa = slurp (&ro, &c, ro.file, &fsz);
 		sza = fsz;
 		if (!bufa) {
-			eprintf ("radiff2: Cannot open %s\n", r_str_get (file));
+			eprintf ("radiff2: Cannot open %s\n", r_str_get (ro.file));
 			return 1;
 		}
-		bufb = slurp (&c, file2, &fsz);
+		bufb = slurp (&ro, &c, ro.file2, &fsz);
 		szb = fsz;
 		if (!bufb) {
-			eprintf ("radiff2: Cannot open: %s\n", r_str_get (file2));
+			eprintf ("radiff2: Cannot open: %s\n", r_str_get (ro.file2));
 			free (bufa);
 			return 1;
 		}
@@ -1204,14 +1207,14 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 
 	switch (mode) {
 	case MODE_COLSII:
-		if (!c && !r_list_empty (evals)) {
-			c = opencore (NULL);
+		if (!c && !r_list_empty (ro.evals)) {
+			c = opencore (&ro, NULL);
 		}
 		dump_cols_hexii (bufa, (int)sza, bufb, (int)szb, (r_cons_get_size (NULL) > 112)? 16: 8);
 		break;
 	case MODE_COLS:
-		if (!c && !r_list_empty (evals)) {
-			c = opencore (NULL);
+		if (!c && !r_list_empty (ro.evals)) {
+			c = opencore (&ro, NULL);
 		}
 		dump_cols (bufa, (int)sza, bufb, (int)szb, (r_cons_get_size (NULL) > 112)? 16: 8);
 		break;
@@ -1220,32 +1223,32 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 	case MODE_DIFF_IMPORTS:
 		d = r_diff_new ();
 		r_diff_set_delta (d, delta);
-		if (diffmode == 'j') {
-			printf ("{\"files\":[{\"filename\":\"%s\", \"size\":%"PFMT64u", \"sha256\":\"", file, sza);
+		if (ro.diffmode == 'j') {
+			printf ("{\"files\":[{\"filename\":\"%s\", \"size\":%"PFMT64u", \"sha256\":\"", ro.file, sza);
 			handle_sha256 (bufa, (int)sza);
-			printf ("\"},\n{\"filename\":\"%s\", \"size\":%"PFMT64u", \"sha256\":\"", file2, szb);
+			printf ("\"},\n{\"filename\":\"%s\", \"size\":%"PFMT64u", \"sha256\":\"", ro.file2, szb);
 			handle_sha256 (bufb, (int)szb);
 			printf ("\"}],\n");
 			printf ("\"changes\":[");
 		}
-		if (diffmode == 'B') {
+		if (ro.diffmode == 'B') {
 			(void) write (1, "\xd1\xff\xd1\xff\x04", 5);
 		}
-		if (diffmode == 'U') {
+		if (ro.diffmode == 'U') {
 			char *res = r_diff_buffers_unified (d, bufa, (int)sza, bufb, (int)szb);
 			if (res) {
 				printf ("%s", res);
 				free (res);
 			}
-		} else if (diffmode == 'B') {
+		} else if (ro.diffmode == 'B') {
 			r_diff_set_callback (d, &bcb, 0);
 			r_diff_buffers (d, bufa, (ut32)sza, bufb, (ut32)szb);
 			(void) write (1, "\x00", 1);
 		} else {
-			r_diff_set_callback (d, &cb, 0); // (void *)(size_t)diffmode);
+			r_diff_set_callback (d, &cb, &ro);
 			r_diff_buffers (d, bufa, (ut32)sza, bufb, (ut32)szb);
 		}
-		if (diffmode == 'j') {
+		if (ro.diffmode == 'j') {
 			printf ("]\n");
 		}
 		r_diff_free (d);
@@ -1256,7 +1259,7 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 		{
 			RDiff *d = r_diff_new ();
 			if (d) {
-				d->verbose = verbose;
+				d->verbose = ro.verbose;
 				if (mode == MODE_DIST_LEVENSTEIN) {
 					d->type = 'l';
 				} else if (mode == MODE_DIST_MYERS) {
@@ -1264,21 +1267,21 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 				} else {
 					d->type = 0;
 				}
-				r_diff_buffers_distance (d, bufa, (ut32)sza, bufb, (ut32)szb, &count, &sim);
+				r_diff_buffers_distance (d, bufa, (ut32)sza, bufb, (ut32)szb, &ro.count, &sim);
 				r_diff_free (d);
 			}
 		}
 		printf ("similarity: %.3f\n", sim);
-		printf ("distance: %d\n", count);
+		printf ("distance: %d\n", ro.count);
 		break;
 	}
 	r_cons_free ();
 
-	if (diffmode == 'j' && showcount) {
-		printf (",\"count\":%d}\n", count);
-	} else if (showcount && diffmode != 'j') {
-		printf ("%d\n", count);
-	} else if (!showcount && diffmode == 'j') {
+	if (ro.diffmode == 'j' && ro.showcount) {
+		printf (",\"count\":%d}\n", ro.count);
+	} else if (ro.showcount && ro.diffmode != 'j') {
+		printf ("%d\n", ro.count);
+	} else if (!ro.showcount && ro.diffmode == 'j') {
 		printf ("}\n");
 	}
 	free (bufa);

--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -169,7 +169,7 @@ static int cb(RDiff *d, void *user, RDiffOp *op) {
 					printf ("%02x ", op->b_buf[i]);
 				}
 				if (!ro->quiet) {
-					char *p = r_str_escape((const char*)op->b_buf);
+					char *p = r_str_escape ((const char*)op->b_buf);
 					printf (" \"%s\"", p);
 					free (p);
 					printf (Color_RESET);
@@ -921,11 +921,10 @@ static void __print_diff_graph(RCore *c, ut64 off, int gmode) {
 }
 
 R_API int r_main_radiff2(int argc, const char **argv) {
-	RadiffOptions ro = {0};
+	RadiffOptions ro = (RadiffOptions){0};
 	const char *columnSort = NULL;
 	const char *addr = NULL;
 	RCore *c = NULL, *c2 = NULL;
-	RDiff *d;
 	ut8 *bufa = NULL, *bufb = NULL;
 	int o, /*diffmode = 0,*/ delta = 0;
 	ut64 sza = 0, szb = 0;
@@ -934,6 +933,9 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 	int diffops = 0;
 	int threshold = -1;
 	double sim = 0.0;
+	RDiff *d;
+
+	ro.useva = true;
 	ro.evals = r_list_newf (NULL);
 
 	RGetopt opt;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

There's no open issue for that what there was at some point. the thing is that globals are bad and we want to use radiff2 from inside r2 on multiple threads.
