### PR TITLE
Initialize variable that could result in wild free

### DIFF
--- a/libr/bin/mangling/microsoft_demangle.c
+++ b/libr/bin/mangling/microsoft_demangle.c
@@ -231,7 +231,7 @@ static int get_template_params(const char *sym, size_t *amount_of_read_chars, ch
 				free (data_type.left);
 				free (data_type.right);
 			} else {
-				char *tmp;
+				char *tmp = NULL;
 				err = parse_function (sym, &str, &tmp, &ret);
 				*str_type_code = r_str_newf ("&%s", tmp);
 				free (tmp);


### PR DESCRIPTION
tmp must be initialized to null
in the case a function isn't parsed properly, tmp doesn't get touched in parse_function, so then a wild pointer is free'd


**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
before
```c
			} else {
				char *tmp; // uninitialized
				err = parse_function (sym, &str, &tmp, &ret);  // tmp doesn't always get touched
				*str_type_code = r_str_newf ("&%s", tmp); // empty string
				free (tmp); // free uninit var!!!!
			}
```