### PR TITLE
Fix oob in load_table_asciiart ##asan

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1392,7 +1392,10 @@ static void load_table_asciiart(RCore *core, RTable *t, RList *lines) {
 			expect_header = false;
 		} else if (expect_rows) {
 			char *arg;
-			RList *args = r_str_split_list (line + strlen (separator), separator, 0);
+			size_t line_len = strlen (line);
+			size_t separator_len = strlen (separator);
+			size_t pos = (line_len < separator_len)? line_len: separator_len;
+			RList *args = r_str_split_list (line + pos, separator, 0);
 			RList *items = r_list_newf (free);
 			RListIter *iter2;
 			if (r_list_length (args) < ncols) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

```
sys/sanitize.sh
r2r -i test/db/cmd/cmd_table
```