### PR TITLE
Fix null deref in `is` command ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2366,7 +2366,7 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 					}
 				} else {
 					fi = r_flag_set (r->flags, sn.methflag, addr, symbol->size);
-					char *comment = fi->comment ? strdup (fi->comment) : NULL;
+					char *comment = (fi && fi->comment) ? strdup (fi->comment) : NULL;
 					if (comment) {
 						r_flag_item_set_comment (fi, comment);
 						R_FREE (comment);

--- a/libr/debug/dsession.c
+++ b/libr/debug/dsession.c
@@ -64,8 +64,10 @@ R_API bool r_debug_add_checkpoint(RDebug *dbg) {
 	for (i = 0; i < R_REG_TYPE_LAST; i++) {
 		RRegArena *a = dbg->reg->regset[i].arena;
 		RRegArena *b = r_reg_arena_new (a->size);
-		memcpy (b->bytes, a->bytes, b->size);
-		checkpoint.arena[i] = b;
+		if (a && a->bytes) {
+			memcpy (b->bytes, a->bytes, b->size);
+			checkpoint.arena[i] = b;
+		}
 	}
 
 	// Save current memory maps


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

<!-- 

**Description**

Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes.

-->
