### PR TITLE
Fix arm32 db/cmd/cmd_open

### DIFF
--- a/libr/bin/p/bin_any.c
+++ b/libr/bin/p/bin_any.c
@@ -36,11 +36,6 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->has_pi = 0;
 	ret->has_canary = 0;
 	ret->has_retguard = -1;
-	if (R_SYS_BITS & R_SYS_BITS_64) {
-		ret->bits = 64;
-	} else {
-		ret->bits = 32;
-	}
 	ret->big_endian = 0;
 	ret->has_va = 0;
 	ret->has_nx = 0;

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -397,7 +397,7 @@ static int r_core_file_do_load_for_debug(RCore *r, ut64 baseaddr, const char *fi
 	binfile = r_bin_cur (r->bin);
 	r_core_bin_set_env (r, binfile);
 	plugin = r_bin_file_cur_plugin (binfile);
-	if (plugin && !strncmp (plugin->name, "any", 5)) {
+	if (plugin && !strcmp (plugin->name, "any")) {
 		// set use of raw strings
 		// r_config_set_i (r->config, "io.va", false);
 		//\\ r_config_set (r->config, "bin.rawstr", "true");
@@ -407,7 +407,7 @@ static int r_core_file_do_load_for_debug(RCore *r, ut64 baseaddr, const char *fi
 	} else if (binfile) {
 		RBinObject *obj = r_bin_cur_object (r->bin);
 		RBinInfo *info = obj? obj->info: NULL;
-		if (plugin && strcmp (plugin->name, "any") && info) {
+		if (plugin && info) {
 			r_core_bin_set_arch_bits (r, binfile->file, info->arch, info->bits);
 		}
 	}
@@ -450,6 +450,7 @@ static int r_core_file_do_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loada
 		if (!info) {
 			return false;
 		}
+		info->bits = r->rasm->bits;
 		// set use of raw strings
 		r_core_bin_set_arch_bits (r, binfile->file, info->arch, info->bits);
 		// r_config_set_i (r->config, "io.va", false);
@@ -463,7 +464,7 @@ static int r_core_file_do_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loada
 		if (!info) {
 			return false;
 		}
-		if (plugin && strcmp (plugin->name, "any") && info) {
+		if (plugin) {
 			r_core_bin_set_arch_bits (r, binfile->file,
 				info->arch, info->bits);
 		}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
No need to assign system bits to unknown file. Instead, this should be done by `info->bits = r->rasm->bits;`.
Also remove some comparisons which are already guaranteed by previous conditions.
Test:
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r db/cmd/cmd_open 
Running from /home/pi/github/radare2/test
Loaded 30 tests.
Skipping json tests because jq is not available.
[30/30]                    29 OK         1 BR        0 XX        0 FX
Finished in 2 seconds.
```