### PR TITLE
Fix arm32 db/cmd/cmd_pc

### DIFF
--- a/libr/util/print_code.c
+++ b/libr/util/print_code.c
@@ -6,13 +6,13 @@
 static const char* bits_to_c_code_fmtstr(int bits) {
 	switch (bits) {
 	case 16:
-		return "0x%04x";
+		return "0x%04" PFMT64x;
 	case 32:
-		return "0x%08xU";
+		return "0x%08" PFMT64x "U";
 	case 64:
 		return "0x%016" PFMT64x "ULL";
 	}
-	return "0x%02x";
+	return "0x%02" PFMT64x;
 }
 
 static int get_instruction_size(RPrint *p, ut64 at) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
The returned string are all used to format the return value of `r_read_ble`, which is ut64.
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r db/cmd/cmd_pc
Running from /home/pi/github/radare2/test
Loaded 15 tests.
Skipping json tests because jq is not available.
[15/15]                    15 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```