### PR TITLE
Fix arm32 db/cmd/cmd_ab

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2367,7 +2367,7 @@ static void anal_bb_list(RCore *core, const char *input) {
 				char *call = ut64join (calls);
 				char *xref = ut64join (calls);
 				char *fcns = fcnjoin (block->fcns);
-				r_table_add_rowf (table, "xdddsssss",
+				r_table_add_rowf (table, "xnddsssss",
 					block->addr,
 					block->size,
 					block->traced,


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
`ut64` should be `n`.
https://github.com/radareorg/radare2/blob/4a1a624318704778f784b9d888580f26036f4a46/libr/util/table.c#L205-L210
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r db/cmd/cmd_ab
Running from /home/pi/github/radare2/test
Loaded 2 tests.
Skipping json tests because jq is not available.
[2/2]                       2 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```