### PR TITLE
Fix arm32 db/cmd/regexp

### DIFF
--- a/libr/include/r_regex.h
+++ b/libr/include/r_regex.h
@@ -13,8 +13,8 @@ typedef struct r_regex_t {
 } RRegex;
 
 typedef struct r_regmatch_t {
-	off_t rm_so;		/* start of match */
-	off_t rm_eo;		/* end of match */
+	st64 rm_so;		/* start of match */
+	st64 rm_eo;		/* end of match */
 } RRegexMatch;
 
 /* regcomp() flags */


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
It's a preprocess problem. Due to the included headers, `libr/search/regexp.c` see `RRegexMatch`'s `off_t` field as 64-bit, while `libr/util/regex/regexec.c` see the `off_t` as 32-bit. This can be noticed by comparing the output of `gcc -I../include -I../../shlr/sdb/src -E regexp.c` and `gcc -I../../include -E regexec.c`.
The macro that produces this difference is `__USE_FILE_OFFSET64`. We can run `gcc -I../include -I../../shlr/sdb/src -E -dM regexp.c` and `gcc -I../../include -E -dM regexec.c` to see the difference.
The solution is to force 64-bit.
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r -t 0 db/cmd/regexp
Running from /home/pi/github/radare2/test
Loaded 4 tests.
Skipping json tests because jq is not available.
[4/4]                       4 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```