### PR TITLE
Fix arm32 db/cmd/cmd_i

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1116,7 +1116,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			default:
 				str_fmt = h_flag && strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 					: sdb_fmt ("%s_%i", arch, bits);
-				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
+				r_table_add_rowf (table, "dsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
 				bin->cb_printf ("%s\n", r_table_tostring(table));
 			}
 			snprintf (archline, sizeof (archline),

--- a/libr/include/r_types_base.h
+++ b/libr/include/r_types_base.h
@@ -3,6 +3,7 @@
 
 #include <ctype.h>
 #include <sys/types.h>
+#include <limits.h>
 
 #define cut8 const unsigned char
 #define ut64 unsigned long long

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1566,7 +1566,7 @@ R_API char *r_str_encoded_json(const char *buf, int buf_size, int encoding) {
 
 		const char *format = encoding == PJ_ENCODING_STR_ARRAY ? "%03u," : "%02X";
 		while (buf[loop] != '\0' && i < (new_sz - 1)) {
-			sprintf (encoded_str + i, format, (ut8) buf[loop]);
+			snprintf (encoded_str + i, new_sz - i, format, (ut8) buf[loop]);
 			loop++;
 			i += increment;
 		}

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1566,7 +1566,7 @@ R_API char *r_str_encoded_json(const char *buf, int buf_size, int encoding) {
 
 		const char *format = encoding == PJ_ENCODING_STR_ARRAY ? "%03u," : "%02X";
 		while (buf[loop] != '\0' && i < (new_sz - 1)) {
-			snprintf (encoded_str + i, sizeof (encoded_str), format, (ut8) buf[loop]);
+			sprintf (encoded_str + i, format, (ut8) buf[loop]);
 			loop++;
 			i += increment;
 		}

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -157,7 +157,7 @@ RUN
 
 NAME=i (all) (malloc)
 FILE=malloc://1025
-ARGS=-a x86
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 i
 ia
@@ -242,7 +242,7 @@ RUN
 
 NAME=i (all) (malloc) iI*
 FILE=malloc://1024
-ARGS=-a x86
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 i
 i*


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
Fix all tests of db/cmd/cmd_i, for various reasons:
* `r_table_add_rowf` wrong format
* `SSIZE_MAX` not defined, so that `#else` branch is applied: https://github.com/radareorg/radare2/blob/56cdc7c112e5a51ce71715dcf84252d016155076/libr/include/r_types_base.h#L104-L114
* wrong limit `sizeof (encoded_str)` which is the size of a pointer passed to `snprintf`. Use `sprintf` is safe since the buffer is big enough and the arg `(ut8) buf[loop]` is 0 to 255.
* assign bit in test
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r db/cmd/cmd_i
Running from /home/pi/github/radare2/test
Loaded 142 tests.
Skipping json tests because jq is not available.
[142/142]                 134 OK         7 BR        0 XX        1 FX
Finished in 6 seconds.
```