### PR TITLE
Fix arm32 db/asm/snes_16

### DIFF
--- a/libr/asm/arch/snes/snesdis.c
+++ b/libr/asm/arch/snes/snesdis.c
@@ -20,7 +20,7 @@ static int snesDisass(int M_flag, int X_flag, ut64 pc, RAsmOp *op, const ut8 *bu
 		break;
 	case SNES_OP_16BIT:
 		if (*buf % 0x20 == 0x10 || *buf == 0x80) { // relative branch
-			buf_asm = sdb_fmt (s_op->name, pc + 2 + (st8)buf[1]);
+			buf_asm = sdb_fmt (s_op->name, (ut32)(pc + 2 + (st8)buf[1]));
 		} else {
 			buf_asm = sdb_fmt (s_op->name, buf[1]);
 		}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
 #17898 
See https://github.com/radareorg/radare2/blob/master/libr/asm/arch/snes/snes_op_table.h, there's no 64-bit operator. But `pc` is ut64, so the result have to be converted to 32-bit.
```sh
pi@liumeo-rpi4:~/github/radare2/test $ r2r -t 0 db/asm/snes_16
Running from /home/pi/github/radare2/test
Loaded 8 tests.
Skipping json tests because jq is not available.
[8/8]                       8 OK         0 BR        0 XX        0 FX
Finished in 0 seconds.
```