### PR TITLE
Fix arm32 db/formats/dmp/dmp

### DIFF
--- a/libr/bin/format/dmp/dmp64.c
+++ b/libr/bin/format/dmp/dmp64.c
@@ -78,7 +78,7 @@ static int r_bin_dmp64_init_bmp_pages(struct r_bin_dmp64_obj_t *obj) {
 	}
 	ut64 paddr_base = obj->bmp_header->FirstPage;
 	ut64 num_pages = obj->bmp_header->Pages;
-	RBitmap *bitmap = r_bitmap_new(num_pages);
+	RBitmap *bitmap = r_bitmap_new (num_pages);
 	r_bitmap_set_bytes (bitmap, obj->bitmap, num_pages / 8);
 
 	ut64 num_bitset = 0;
@@ -109,7 +109,7 @@ static int r_bin_dmp64_init_bmp_header(struct r_bin_dmp64_obj_t *obj) {
 		r_sys_perror ("R_NEW0 (dmp_bmp_header)");
 		return false;
 	}
-	if (r_buf_read_at (obj->b, sizeof (dmp64_header), (ut8*)obj->bmp_header, sizeof (dmp_bmp_header) - sizeof (ut8*)) < 0) {
+	if (r_buf_read_at (obj->b, sizeof (dmp64_header), (ut8*)obj->bmp_header, offsetof (dmp_bmp_header, Bitmap)) < 0) {
 		eprintf ("Warning: read bmp_header\n");
 		return false;
 	}
@@ -119,10 +119,10 @@ static int r_bin_dmp64_init_bmp_header(struct r_bin_dmp64_obj_t *obj) {
 	}
 	ut64 bitmapsize = obj->bmp_header->Pages / 8;
 	obj->bitmap = calloc (1, bitmapsize);
-	if (r_buf_read_at (obj->b, sizeof (dmp64_header) + sizeof (dmp_bmp_header) - sizeof (ut8*), obj->bitmap, bitmapsize) < 0) {
+	if (r_buf_read_at (obj->b, sizeof (dmp64_header) + offsetof (dmp_bmp_header, Bitmap), obj->bitmap, bitmapsize) < 0) {
 		eprintf ("Warning: read bitmap\n");
 		return false;
-	};
+	}
 
 	return true;
 }

--- a/libr/bin/format/mdmp/mdmp_windefs.h
+++ b/libr/bin/format/mdmp/mdmp_windefs.h
@@ -489,7 +489,7 @@ R_PACKED (
 struct windows_exception_record64 {
 	ut32 exception_code;
 	ut32 exception_flags;
-	struct windows_exception_record64 *exception_record;
+	ut64 exception_record;
 	ut64 exception_address;
 	ut32 number_parameters;
 	ut32 __unusedAlignment;

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -14,12 +14,10 @@
 extern "C" {
 #endif
 
-enum {
-	R_SYS_BITS_8 = 1,
-	R_SYS_BITS_16 = 2,
-	R_SYS_BITS_32 = 4,
-	R_SYS_BITS_64 = 8,
-};
+#define R_SYS_BITS_8 1
+#define R_SYS_BITS_16 2
+#define R_SYS_BITS_32 4
+#define R_SYS_BITS_64 8
 
 typedef struct {
 	char *sysname;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

#17898 
* Use `offsetof` instead of wrongly subtracting.
* Eliminate pointer field of `struct windows_exception_record64` in mdmp_windefs.h. `struct windows_exception_record32` also needs modifying, but I can't find a reference of mdmp data structure. There's no test for that either.
* `R_SYS_BITS_32` must be defined as macro, as there are https://github.com/radareorg/radare2/blob/38e33288fb39a5a373885a516d9a2a3a7094f9b5/libr/include/r_types.h#L487 and https://github.com/radareorg/radare2/blob/38e33288fb39a5a373885a516d9a2a3a7094f9b5/libr/include/r_util/r_bitmap.h#L4-L10 Because preprocessor doesn't recognise enum, `#if R_SYS_BITS == 4` always fails since `R_SYS_BITS_32` is treated as 0.