### PR TITLE
Revert "Fix clang-cl build"

### DIFF
--- a/libr/debug/p/native/windows/windows_debug.h
+++ b/libr/debug/p/native/windows/windows_debug.h
@@ -118,28 +118,28 @@ typedef struct{
 	char *Name;
 } LIB_ITEM, *PLIB_ITEM;
 
-static DWORD (WINAPI *w32_GetModuleBaseName)(HANDLE, HMODULE, LPTSTR, DWORD);
-static BOOL (WINAPI *w32_GetModuleInformation)(HANDLE, HMODULE, LPMODULEINFO, DWORD);
-static BOOL (WINAPI *w32_DebugActiveProcessStop)(DWORD);
-static HANDLE (WINAPI *w32_OpenThread)(DWORD, BOOL, DWORD);
-static BOOL (WINAPI *w32_DebugBreakProcess)(HANDLE);
-static DWORD (WINAPI *w32_GetThreadId)(HANDLE); // Vista
-static DWORD (WINAPI *w32_GetProcessId)(HANDLE); // XP
-static HANDLE (WINAPI *w32_OpenProcess)(DWORD, BOOL, DWORD);
-static BOOL (WINAPI *w32_QueryFullProcessImageName)(HANDLE, DWORD, LPTSTR, PDWORD);
-static DWORD (WINAPI *w32_GetMappedFileName)(HANDLE, LPVOID, LPTSTR, DWORD);
-static NTSTATUS (WINAPI *w32_NtQuerySystemInformation)(ULONG, PVOID, ULONG, PULONG);
-static NTSTATUS (WINAPI *w32_NtQueryInformationThread)(HANDLE, ULONG, PVOID, ULONG, PULONG);
-static NTSTATUS (WINAPI *w32_NtDuplicateObject)(HANDLE, HANDLE, HANDLE, PHANDLE, ACCESS_MASK, ULONG, ULONG);
-static NTSTATUS (WINAPI *w32_NtQueryObject)(HANDLE, ULONG, PVOID, ULONG, PULONG);
+DWORD (WINAPI *w32_GetModuleBaseName)(HANDLE, HMODULE, LPTSTR, DWORD);
+BOOL (WINAPI *w32_GetModuleInformation)(HANDLE, HMODULE, LPMODULEINFO, DWORD);
+BOOL (WINAPI *w32_DebugActiveProcessStop)(DWORD);
+HANDLE (WINAPI *w32_OpenThread)(DWORD, BOOL, DWORD);
+BOOL (WINAPI *w32_DebugBreakProcess)(HANDLE);
+DWORD (WINAPI *w32_GetThreadId)(HANDLE); // Vista
+DWORD (WINAPI *w32_GetProcessId)(HANDLE); // XP
+HANDLE (WINAPI *w32_OpenProcess)(DWORD, BOOL, DWORD);
+BOOL (WINAPI *w32_QueryFullProcessImageName)(HANDLE, DWORD, LPTSTR, PDWORD);
+DWORD (WINAPI *w32_GetMappedFileName)(HANDLE, LPVOID, LPTSTR, DWORD);
+NTSTATUS (WINAPI *w32_NtQuerySystemInformation)(ULONG, PVOID, ULONG, PULONG);
+NTSTATUS (WINAPI *w32_NtQueryInformationThread)(HANDLE, ULONG, PVOID, ULONG, PULONG);
+NTSTATUS (WINAPI *w32_NtDuplicateObject)(HANDLE, HANDLE, HANDLE, PHANDLE, ACCESS_MASK, ULONG, ULONG);
+NTSTATUS (WINAPI *w32_NtQueryObject)(HANDLE, ULONG, PVOID, ULONG, PULONG);
 // fpu access API
-static ut64 (WINAPI *w32_GetEnabledXStateFeatures)();
-static BOOL (WINAPI *w32_InitializeContext)(PVOID, DWORD, PCONTEXT*, PDWORD);
-static BOOL (WINAPI *w32_GetXStateFeaturesMask)(PCONTEXT Context, PDWORD64);
-static PVOID (WINAPI *w32_LocateXStateFeature)(PCONTEXT Context, DWORD, PDWORD);
-static BOOL (WINAPI *w32_SetXStateFeaturesMask)(PCONTEXT Context, DWORD64);
-static DWORD (WINAPI *w32_GetModuleFileNameEx)(HANDLE, HMODULE, LPTSTR, DWORD);
-static HANDLE (WINAPI *w32_CreateToolhelp32Snapshot)(DWORD, DWORD);
+ut64 (WINAPI *w32_GetEnabledXStateFeatures)();
+BOOL (WINAPI *w32_InitializeContext)(PVOID, DWORD, PCONTEXT*, PDWORD);
+BOOL (WINAPI *w32_GetXStateFeaturesMask)(PCONTEXT Context, PDWORD64);
+PVOID (WINAPI *w32_LocateXStateFeature)(PCONTEXT Context, DWORD, PDWORD);
+BOOL (WINAPI *w32_SetXStateFeaturesMask)(PCONTEXT Context, DWORD64);
+DWORD (WINAPI *w32_GetModuleFileNameEx)(HANDLE, HMODULE, LPTSTR, DWORD);
+HANDLE (WINAPI *w32_CreateToolhelp32Snapshot)(DWORD, DWORD);
 
 // APIs
 int w32_init(RDebug *dbg);

--- a/shlr/heap/include/r_windows/windows_heap.h
+++ b/shlr/heap/include/r_windows/windows_heap.h
@@ -988,22 +988,22 @@ typedef struct _HeapInformation {
 	DEBUG_HEAP_INFORMATION heaps[/* count */];
 } HeapInformation, *PHeapInformation;
 
-static PDEBUG_BUFFER (NTAPI *RtlCreateQueryDebugBuffer)(
+PDEBUG_BUFFER (NTAPI *RtlCreateQueryDebugBuffer)(
 	IN DWORD Size,
 	IN BOOLEAN EventPair
 );
 
-static NTSTATUS (NTAPI *RtlQueryProcessDebugInformation)(
+NTSTATUS (NTAPI *RtlQueryProcessDebugInformation)(
 	IN DWORD ProcessId,
 	IN DWORD DebugInfoClassMask,
 	IN OUT PDEBUG_BUFFER DebugBuffer
 );
 
-static NTSTATUS (NTAPI *RtlDestroyQueryDebugBuffer)(
+NTSTATUS (NTAPI *RtlDestroyQueryDebugBuffer)(
 	IN PDEBUG_BUFFER DebugBuffer
 );
 
-static __kernel_entry NTSTATUS (NTAPI *w32_NtQueryInformationProcess)(
+__kernel_entry NTSTATUS (NTAPI *w32_NtQueryInformationProcess)(
   IN HANDLE           ProcessHandle,
   IN PROCESSINFOCLASS ProcessInformationClass,
   OUT PVOID           ProcessInformation,


### PR DESCRIPTION
My PR radareorg/radare2#17935 must be reverted since it causes a crash after opening binary in debug mode.