### PR TITLE
Use pj in rtti_msvc ##refactor

### DIFF
--- a/libr/anal/rtti_msvc.c
+++ b/libr/anal/rtti_msvc.c
@@ -298,12 +298,15 @@ static void rtti_msvc_print_complete_object_locator(rtti_complete_object_locator
 				   prefix, col->object_base);
 }
 
-//TODO PJ
-static void rtti_msvc_print_complete_object_locator_json(rtti_complete_object_locator *col) {
-	r_cons_printf ("{\"signature\":%"PFMT32u",\"vftable_offset\":%"PFMT32u",\"cd_offset\":%"PFMT32u","
-				   "\"type_desc_addr\":%"PFMT32u",\"class_desc_addr\":%"PFMT32u",\"object_base\":%"PFMT32u"}",
-				   col->signature, col->vtable_offset, col->cd_offset, col->type_descriptor_addr,
-				   col->class_descriptor_addr, col->object_base);
+static void rtti_msvc_print_complete_object_locator_json(PJ *pj, rtti_complete_object_locator *col) {
+	pj_o (pj);
+	pj_kn (pj, "signature", col->signature);
+	pj_kn (pj, "vftable_offset", col->vtable_offset);
+	pj_kn (pj, "cd_offset", col->cd_offset);
+	pj_kn (pj, "type_desc_addr", col->type_descriptor_addr);
+	pj_kn (pj, "class_desc_addr", col->class_descriptor_addr);
+	pj_kn (pj, "object_base", col->object_base);
+	pj_end (pj);
 }
 
 static void rtti_msvc_print_type_descriptor(rtti_type_descriptor *td, ut64 addr, const char *prefix) {
@@ -317,10 +320,12 @@ static void rtti_msvc_print_type_descriptor(rtti_type_descriptor *td, ut64 addr,
 				   prefix, td->name);
 }
 
-//TODO PJ
-static void rtti_msvc_print_type_descriptor_json(rtti_type_descriptor *td) {
-	r_cons_printf ("{\"vtable_addr\":%"PFMT64u",\"spare\":%"PFMT64u",\"name\":\"%s\"}",
-				   td->vtable_addr, td->spare, td->name);
+static void rtti_msvc_print_type_descriptor_json(PJ *pj, rtti_type_descriptor *td) {
+	pj_o (pj);
+	pj_kn (pj, "vtable_addr", td->vtable_addr);
+	pj_kn (pj, "spare", td->spare);
+	pj_ks (pj, "name", td->name);
+	pj_end (pj);
 }
 
 static void rtti_msvc_print_class_hierarchy_descriptor(rtti_class_hierarchy_descriptor *chd, ut64 addr, const char *prefix) {
@@ -336,11 +341,13 @@ static void rtti_msvc_print_class_hierarchy_descriptor(rtti_class_hierarchy_desc
 				   prefix, chd->base_class_array_addr);
 }
 
-//TODO
-static void rtti_msvc_print_class_hierarchy_descriptor_json(rtti_class_hierarchy_descriptor *chd) {
-	r_cons_printf ("{\"signature\":%"PFMT32u",\"attributes\":%"PFMT32u",\"num_base_classes\":%"PFMT32u","
-				   "\"base_class_array_addr\":%"PFMT32u"}",
-				   chd->signature, chd->attributes, chd->num_base_classes, chd->base_class_array_addr);
+static void rtti_msvc_print_class_hierarchy_descriptor_json(PJ *pj, rtti_class_hierarchy_descriptor *chd) {
+	pj_o (pj);
+	pj_kn (pj, "signature", chd->signature);
+	pj_kn (pj, "attributes", chd->attributes);
+	pj_kn (pj, "num_base_classes", chd->num_base_classes);
+	pj_kn (pj, "base_class_array_addr", chd->base_class_array_addr);
+	pj_end (pj);
 }
 
 static void rtti_msvc_print_base_class_descriptor(rtti_base_class_descriptor *bcd, const char *prefix) {
@@ -362,13 +369,17 @@ static void rtti_msvc_print_base_class_descriptor(rtti_base_class_descriptor *bc
 				   prefix, bcd->attributes);
 }
 
-//TODO PJ
-static void rtti_msvc_print_base_class_descriptor_json(rtti_base_class_descriptor *bcd) {
-	r_cons_printf ("{\"type_desc_addr\":%"PFMT32u",\"num_contained_bases\":%"PFMT32u","
-				   "\"where\":{\"mdisp\":%"PFMT32d",\"pdisp\":%"PFMT32d",\"vdisp\":%"PFMT32d"},"
-				   "\"attributes\":%"PFMT32u"}",
-				   bcd->type_descriptor_addr, bcd->num_contained_bases,
-				   bcd->where.mdisp, bcd->where.pdisp, bcd->where.vdisp, bcd->attributes);
+static void rtti_msvc_print_base_class_descriptor_json(PJ *pj, rtti_base_class_descriptor *bcd) {
+	pj_o (pj);
+	pj_kn (pj, "type_desc_addr", bcd->type_descriptor_addr);
+	pj_kn (pj, "num_contained_bases", bcd->num_contained_bases);
+	pj_ko (pj, "where");
+	pj_ki (pj, "mdisp", bcd->where.mdisp);
+	pj_ki (pj, "pdisp", bcd->where.pdisp);
+	pj_ki (pj, "vdisp", bcd->where.vdisp);
+	pj_end (pj);
+	pj_kn (pj, "attributes", bcd->attributes);
+	pj_end (pj);
 }
 
 
@@ -415,7 +426,13 @@ R_API void r_anal_rtti_msvc_print_complete_object_locator(RVTableContext *contex
 	}
 
 	if (mode == 'j') {
-		rtti_msvc_print_complete_object_locator_json (&col);
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		rtti_msvc_print_complete_object_locator_json (pj, &col);
+		r_cons_print (pj_string (pj));
+		pj_free (pj);
 	} else {
 		rtti_msvc_print_complete_object_locator (&col, addr, "");
 	}
@@ -429,7 +446,13 @@ R_API void r_anal_rtti_msvc_print_type_descriptor(RVTableContext *context, ut64 
 	}
 
 	if (mode == 'j') {
-		rtti_msvc_print_type_descriptor_json (&td);
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		rtti_msvc_print_type_descriptor_json (pj, &td);
+		r_cons_print (pj_string (pj));
+		pj_free (pj);
 	} else {
 		rtti_msvc_print_type_descriptor (&td, addr, "");
 	}
@@ -445,7 +468,13 @@ R_API void r_anal_rtti_msvc_print_class_hierarchy_descriptor(RVTableContext *con
 	}
 
 	if (mode == 'j') {
-		rtti_msvc_print_class_hierarchy_descriptor_json (&chd);
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		rtti_msvc_print_class_hierarchy_descriptor_json (pj, &chd);
+		r_cons_print (pj_string (pj));
+		pj_free (pj);
 	} else {
 		rtti_msvc_print_class_hierarchy_descriptor (&chd, addr, "");
 	}
@@ -459,7 +488,13 @@ R_API void r_anal_rtti_msvc_print_base_class_descriptor(RVTableContext *context,
 	}
 
 	if (mode == 'j') {
-		rtti_msvc_print_base_class_descriptor_json (&bcd);
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		rtti_msvc_print_base_class_descriptor_json (pj, &bcd);
+		r_cons_print (pj_string (pj));
+		pj_free (pj);
 	} else {
 		rtti_msvc_print_base_class_descriptor (&bcd, "");
 	}
@@ -467,6 +502,7 @@ R_API void r_anal_rtti_msvc_print_base_class_descriptor(RVTableContext *context,
 
 static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *context, ut64 atAddress, int mode, bool strict) {
 	bool use_json = mode == 'j';
+	PJ *pj;
 
 	ut64 colRefAddr = atAddress - context->word_size;
 	ut64 colAddr;
@@ -521,16 +557,20 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 	}
 
 
-	//TODO PJ
 	// print
 	if (use_json) {
-		r_cons_print ("{\"complete_object_locator\":");
-		rtti_msvc_print_complete_object_locator_json (&col);
-		r_cons_print (",\"type_desc\":");
-		rtti_msvc_print_type_descriptor_json (&td);
-		r_cons_print (",\"class_hierarchy_desc\":");
-		rtti_msvc_print_class_hierarchy_descriptor_json (&chd);
-		r_cons_print (",\"base_classes\":[");
+		pj = pj_new ();
+		if (!pj) {
+			return false;
+		}
+		pj_o (pj);
+		pj_k (pj, "complete_object_locator");
+		rtti_msvc_print_complete_object_locator_json (pj, &col);
+		pj_k (pj, "type_desc");
+		rtti_msvc_print_type_descriptor_json (pj, &td);
+		pj_k (pj, "class_hierarchy_desc");
+		rtti_msvc_print_class_hierarchy_descriptor_json (pj, &chd);
+		pj_ka (pj, "base_classes");
 	} else {
 		rtti_msvc_print_complete_object_locator (&col, colAddr, "");
 		rtti_msvc_print_type_descriptor (&td, typeDescriptorAddr, "\t");
@@ -539,21 +579,16 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 
 
 	// base classes
-	bool json_first = true;
 	RListIter *bcdIter;
 	rtti_base_class_descriptor *bcd;
 	r_list_foreach (baseClassArray, bcdIter, bcd) {
 		if (use_json) {
-			if (json_first) {
-				r_cons_print ("{\"desc\":");
-				json_first = false;
-			} else {
-				r_cons_print (",{\"desc\":");
-			}
+			pj_o (pj);
+			pj_k (pj, "desc");
 		}
 
 		if (use_json) {
-			rtti_msvc_print_base_class_descriptor_json (bcd);
+			rtti_msvc_print_base_class_descriptor_json (pj, bcd);
 		} else {
 			rtti_msvc_print_base_class_descriptor (bcd, "\t\t");
 		}
@@ -562,8 +597,8 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 		rtti_type_descriptor btd = { 0 };
 		if (rtti_msvc_read_type_descriptor (context, baseTypeDescriptorAddr, &btd)) {
 			if (use_json) {
-				r_cons_print (",\"type_desc\":");
-				rtti_msvc_print_type_descriptor_json (&btd);
+				pj_k (pj, "type_desc");
+				rtti_msvc_print_type_descriptor_json (pj, &btd);
 			} else {
 				rtti_msvc_print_type_descriptor (&btd, baseTypeDescriptorAddr, "\t\t\t");
 			}
@@ -575,15 +610,14 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 		}
 
 		if(use_json) {
-			r_cons_print ("}");
+			pj_end (pj);
 		}
 	}
 	if (use_json) {
-		r_cons_print ("]");
-	}
-
-	if (use_json) {
-		r_cons_print ("}");
+		pj_end (pj);
+		pj_end (pj);
+		r_cons_print (pj_string (pj));
+		pj_free (pj);
 	}
 
 	rtti_type_descriptor_fini (&td);

--- a/test/db/cmd/cmd_avr
+++ b/test/db/cmd/cmd_avr
@@ -161,3 +161,14 @@ type_info
   virtual_0 @ 0x401136 (vtable + 0x0)
 EOF
 RUN
+
+NAME=avraj msvc x86
+FILE=bins/pe/cpp-msvc-x86.exe
+CMDS=<<EOF
+aar
+avraj
+EOF
+EXPECT=<<EOF
+[{"complete_object_locator":{"signature":0,"vftable_offset":0,"cd_offset":0,"type_desc_addr":4298928,"class_desc_addr":4290676,"object_base":0},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVAlbum@@"},"class_hierarchy_desc":{"signature":0,"attributes":0,"num_base_classes":1,"base_class_array_addr":4290692},"base_classes":[{"desc":{"type_desc_addr":4298928,"num_contained_bases":0,"where":{"mdisp":0,"pdisp":-1,"vdisp":0},"attributes":64},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVAlbum@@"}}]},{"complete_object_locator":{"signature":0,"vftable_offset":0,"cd_offset":0,"type_desc_addr":4298948,"class_desc_addr":4290748,"object_base":0},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVInAbsentia@@"},"class_hierarchy_desc":{"signature":0,"attributes":0,"num_base_classes":2,"base_class_array_addr":4290764},"base_classes":[{"desc":{"type_desc_addr":4298948,"num_contained_bases":1,"where":{"mdisp":0,"pdisp":-1,"vdisp":0},"attributes":64},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVInAbsentia@@"}},{"desc":{"type_desc_addr":4298928,"num_contained_bases":0,"where":{"mdisp":0,"pdisp":-1,"vdisp":0},"attributes":64},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVAlbum@@"}}]},{"complete_object_locator":{"signature":0,"vftable_offset":0,"cd_offset":0,"type_desc_addr":4298976,"class_desc_addr":4290824,"object_base":0},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVtype_info@@"},"class_hierarchy_desc":{"signature":0,"attributes":0,"num_base_classes":1,"base_class_array_addr":4290840},"base_classes":[{"desc":{"type_desc_addr":4298976,"num_contained_bases":0,"where":{"mdisp":0,"pdisp":-1,"vdisp":0},"attributes":64},"type_desc":{"vtable_addr":4268540,"spare":0,"name":".?AVtype_info@@"}}]}]
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

https://github.com/rizinorg/rizin/issues/200
Note: these 4 functions are not tested, as they are R_API and not used in radare2. This can be easily checked by `git grep`.
r_anal_rtti_msvc_print_complete_object_locator
r_anal_rtti_msvc_print_type_descriptor
r_anal_rtti_msvc_print_class_hierarchy_descriptor
r_anal_rtti_msvc_print_base_class_descriptor