### PR TITLE
Fix ESIL for RISC-V 64-bit load instruction

### DIFF
--- a/test/db/esil/riscv_64
+++ b/test/db/esil/riscv_64
@@ -29,3 +29,25 @@ EXPECT=<<EOF
 0xffffffffce00007f
 EOF
 RUN
+
+NAME=RISC-V ESIL for load instructions
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch=riscv
+e asm.bits=64
+wx 37f65aff32e09246036701008317210003081100
+aei
+aeim
+6aes
+ar a3
+ar a4
+ar a5
+ar a6
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0xff5af000
+0xffffffffffffff5a
+0xfffffffffffffff0
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: None
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

- Fix sign extension for load instruction.
- Correction of shift immediate instruction.
