### PR TITLE
Add amd64syscall calling convention definition ##anal

### DIFF
--- a/libr/anal/d/cc-x86-64.sdb.txt
+++ b/libr/anal/d/cc-x86-64.sdb.txt
@@ -39,10 +39,10 @@ cc.swift.error=r12
 cc.swift.ret=rax
 
 amd64syscall=cc
-cc.amd64.arg0=rdi
-cc.amd64.arg1=rsi
-cc.amd64.arg2=rdx
-cc.amd64.arg3=r10
-cc.amd64.arg4=r8
-cc.amd64.arg5=r9
-cc.amd64.ret=rax
+cc.amd64syscall.arg0=rdi
+cc.amd64syscall.arg1=rsi
+cc.amd64syscall.arg2=rdx
+cc.amd64syscall.arg3=r10
+cc.amd64syscall.arg4=r8
+cc.amd64syscall.arg5=r9
+cc.amd64syscall.ret=rax

--- a/libr/anal/d/cc-x86-64.sdb.txt
+++ b/libr/anal/d/cc-x86-64.sdb.txt
@@ -37,3 +37,12 @@ cc.swift.arg10=xmm4
 cc.swift.self=r13
 cc.swift.error=r12
 cc.swift.ret=rax
+
+amd64syscall=cc
+cc.amd64.arg0=rdi
+cc.amd64.arg1=rsi
+cc.amd64.arg2=rdx
+cc.amd64.arg3=r10
+cc.amd64.arg4=r8
+cc.amd64.arg5=r9
+cc.amd64.ret=rax

--- a/test/db/cmd/cmd_afcl
+++ b/test/db/cmd/cmd_afcl
@@ -7,9 +7,10 @@ e asm.bits = 64
 afcl
 EOF
 EXPECT=<<EOF
-ms
-amd64
 swift
+amd64
+amd64syscall
+ms
 reg
 EOF
 RUN

--- a/test/db/cmd/cmd_ara
+++ b/test/db/cmd/cmd_ara
@@ -90,15 +90,17 @@ tcc `arcc`
 afcl
 EOF
 EXPECT=<<EOF
-ms
-amd64
 swift
+amd64
+amd64syscall
+ms
 reg
 r0 reg(r0, r1, r2, r3)
 rdi reg(rdi, rsi, rdx, rcx)
-ms
-amd64
 swift
+amd64
+amd64syscall
+ms
 reg
 EOF
 RUN

--- a/test/db/cmd/cmd_tcc
+++ b/test/db/cmd/cmd_tcc
@@ -6,9 +6,10 @@ tcc-*
 tcc
 EOF
 EXPECT=<<EOF
-ms
-amd64
 swift
+amd64
+amd64syscall
+ms
 reg
 EOF
 RUN
@@ -17,9 +18,10 @@ NAME=tcc
 FILE=bins/elf/ls
 CMDS=tcc
 EXPECT=<<EOF
-ms
-amd64
 swift
+amd64
+amd64syscall
+ms
 reg
 EOF
 RUN
@@ -32,14 +34,16 @@ tccl
 tcc*
 EOF
 EXPECT=<<EOF
-["rax ms (rcx, rdx, r8, r9, stack);","rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;","rdi reg (rdi, rsi, rdx, rcx);"]
-rax ms (rcx, rdx, r8, r9, stack);
-rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+["rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;","rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);","rax ms (rcx, rdx, r8, r9, stack);","rdi reg (rdi, rsi, rdx, rcx);"]
 rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
+rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
+rax ms (rcx, rdx, r8, r9, stack);
 rdi reg (rdi, rsi, rdx, rcx);
-tfc rax ms (rcx, rdx, r8, r9, stack);
-tfc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
 tfc rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
+tfc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+tfc rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
+tfc rax ms (rcx, rdx, r8, r9, stack);
 tfc rdi reg (rdi, rsi, rdx, rcx);
 EOF
 RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
