### PR TITLE
Remove afc=

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -839,7 +839,7 @@ static int bin_info(RCore *r, int mode, ut64 laddr) {
 		r_core_anal_type_init (r);
 		r_core_anal_cc_init (r);
 		if (info->default_cc && r_anal_cc_exist (r->anal, info->default_cc)) {
-			r_core_cmdf (r, "k anal/cc/default.cc=%s", info->default_cc);
+			r_core_cmdf (r, "e anal.cc=%s", info->default_cc);
 		}
 	} else if (IS_MODE_SIMPLE (mode)) {
 		r_cons_printf ("arch %s\n", info->arch);
@@ -889,7 +889,7 @@ static int bin_info(RCore *r, int mode, ut64 laddr) {
 				r_cons_printf ("e asm.cpu=%s\n", info->cpu);
 			}
 			if (info->default_cc) {
-				r_cons_printf ("k anal/cc/default.cc=%s", info->default_cc);
+				r_cons_printf ("e anal.cc=%s", info->default_cc);
 			}
 			v = r_anal_archinfo (r->anal, R_ANAL_ARCHINFO_ALIGN);
 			if (v != -1) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -380,7 +380,6 @@ static const char *help_msg_afc[] = {
 	"Usage:", "afc[agl?]", "",
 	"afc", " convention", "Manually set calling convention for current function",
 	"afc", "", "Show Calling convention for the Current function",
-	"afc=", "([cctype])", "Select or show default calling convention",
 	"afcr", "[j]", "Show register usage for the current function",
 	"afca", "", "Analyse function for finding the current calling convention",
 	"afcf", "[j] [name]", "Prints return type function(arg1, arg2...), see afij",
@@ -3849,18 +3848,6 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			free (argument);
 			break;
 		}
-		case '=': // "afc="
-			if (input[3]) {
-				char *argument = strdup (input + 3);
-				char *cc = argument;
-				r_str_trim (cc);
-				r_core_cmdf (core, "k anal/cc/default.cc=%s", cc);
-				r_anal_set_reg_profile (core->anal);
-				free (argument);
-			} else {
-				r_core_cmd0 (core, "k anal/cc/default.cc");
-			}
-			break;
 		case 'a': // "afca"
 			eprintf ("Todo\n");
 			break;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -871,7 +871,7 @@ static const char *radare_argv[] = {
 	"af?", "af", "afr", "af+", "af-",
 	"afa", "afan",
 	"afb?", "afb", "afb.", "afb+", "afbb", "afbr", "afbi", "afbj", "afbe", "afB", "afbc", "afb=",
-	"afB", "afC", "afCl", "afCc", "afc?", "afc", "afc=", "afcr", "afcrj", "afca", "afcf", "afcfj",
+	"afB", "afC", "afCl", "afCc", "afc?", "afc", "afcr", "afcrj", "afca", "afcf", "afcfj",
 	"afck", "afcl", "afco", "afcR",
 	"afd", "aff", "afF", "afi",
 	"afl?", "afl", "afl+", "aflc", "aflj", "afll", "afllj", "aflm", "aflq", "aflqj", "afls",

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -110,7 +110,7 @@ FILE=-
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
-afc=ms
+e anal.cc=ms
 wx 40534883ec20418bd8e80a00000003c34883c4205bc3cccc2bca8bc1c3
 aa
 pd 13
@@ -177,7 +177,7 @@ ARGS=-a x86 -b 64
 CMDS=<<EOF
 e asm.flags=false
 e anal.vars.stackname = true
-afc=ms
+e anal.cc=ms
 wx 488bc448895808488970104889781841574881ecb00000008364242000488d48884c8d9c24b0000000498b5b10498b7318498b7b20498be3415fc3
 af
 aaef

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1496,7 +1496,7 @@ RUN
 NAME=Settings global calling convention
 FILE=bins/pe/msvcfindmain.exe
 CMDS=<<EOF
-afc=pascal
+e anal.cc=pascal
 aaa
 afi @@@F~?pascal
 EOF
@@ -3523,7 +3523,7 @@ CMDS=<<EOF
 e asm.comments=0
 e anal.vars.stackname=true
 s 0x140001080
-afc=ms
+e anal.cc=ms
 af
 pdf
 EOF

--- a/test/db/formats/pe/pe64
+++ b/test/db/formats/pe/pe64
@@ -16,7 +16,7 @@ RUN
 
 NAME=pe64 cc
 FILE=bins/pe/tls64.exe
-CMDS=afc=
+CMDS=e anal.cc
 EXPECT=<<EOF
 ms
 EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
`afc=` was superseded by `e anal.cc`
