### PR TITLE
Fix iAj and use pj in bin.c ##refactor

### DIFF
--- a/libr/bin/bfile.c
+++ b/libr/bin/bfile.c
@@ -625,26 +625,6 @@ R_API RBinFile *r_bin_file_find_by_name(RBin *bin, const char *name) {
 	return NULL;
 }
 
-R_IPI RBinFile *r_bin_file_find_by_name_n(RBin *bin, const char *name, int idx) {
-	RListIter *iter;
-	RBinFile *bf = NULL;
-	int i = 0;
-	if (!bin) {
-		return bf;
-	}
-
-	r_list_foreach (bin->binfiles, iter, bf) {
-		if (bf && bf->file && !strcmp (bf->file, name)) {
-			if (i == idx) {
-				break;
-			}
-			i++;
-		}
-		bf = NULL;
-	}
-	return bf;
-}
-
 R_API bool r_bin_file_set_cur_by_id(RBin *bin, ut32 bin_id) {
 	RBinFile *bf = r_bin_file_find_by_id (bin, bin_id);
 	return bf? r_bin_file_set_cur_binfile (bin, bf): false;

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -484,11 +484,17 @@ static bool r_bin_print_plugin_details(RBin *bin, RBinPlugin *bp, int json) {
 	if (json == 'q') {
 		bin->cb_printf ("%s\n", bp->name);
 	} else if (json) {
-		//TODO PJ
-		bin->cb_printf (
-			"{\"name\":\"%s\",\"description\":\"%s\","
-			"\"license\":\"%s\"}\n",
-			bp->name, bp->desc, bp->license? bp->license: "???");
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return false;
+		}
+		pj_o (pj);
+		pj_ks (pj, "name", bp->name);
+		pj_ks (pj, "description", bp->desc);
+		pj_ks (pj, "license", bp->license ? bp->license : "???");
+		pj_end (pj);
+		bin->cb_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	} else {
 		bin->cb_printf ("Name: %s\n", bp->name);
 		bin->cb_printf ("Description: %s\n", bp->desc);
@@ -509,11 +515,17 @@ static void __printXtrPluginDetails(RBin *bin, RBinXtrPlugin *bx, int json) {
 	if (json == 'q') {
 		bin->cb_printf ("%s\n", bx->name);
 	} else if (json) {
-		//TODO PJ
-		bin->cb_printf (
-			"{\"name\":\"%s\",\"description\":\"%s\","
-			"\"license\":\"%s\"}\n",
-			bx->name, bx->desc, bx->license? bx->license: "???");
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		pj_o (pj);
+		pj_ks (pj, "name", bx->name);
+		pj_ks (pj, "description", bx->desc);
+		pj_ks (pj, "license", bx->license ? bx->license : "???");
+		pj_end (pj);
+		bin->cb_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	} else {
 		bin->cb_printf ("Name: %s\n", bx->name);
 		bin->cb_printf ("Description: %s\n", bx->desc);
@@ -562,39 +574,41 @@ R_API void r_bin_list(RBin *bin, int format) {
 			bin->cb_printf ("%s\n", bx->name);
 		}
 	} else if (format) {
-		//TODO PJ
-		int i;
-
-		i = 0;
-		bin->cb_printf ("{\"bin\":[");
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		pj_o (pj);
+		pj_ka (pj, "bin");
 		r_list_foreach (bin->plugins, it, bp) {
-			bin->cb_printf (
-				"%s{\"name\":\"%s\",\"description\":\"%s\","
-				"\"license\":\"%s\"}",
-				i? ",": "", bp->name, bp->desc, bp->license? bp->license: "???");
-			i++;
+			pj_o (pj);
+			pj_ks (pj, "name", bp->name);
+			pj_ks (pj, "description", bp->desc);
+			pj_ks (pj, "license", bp->license ? bp->license : "???");
+			pj_end (pj);
 		}
-
-		i = 0;
-		bin->cb_printf ("],\"xtr\":[");
+		pj_end (pj);
+		pj_ka (pj, "xtr");
 		r_list_foreach (bin->binxtrs, it, bx) {
-			bin->cb_printf (
-				"%s{\"name\":\"%s\",\"description\":\"%s\","
-				"\"license\":\"%s\"}",
-				i? ",": "", bx->name, bx->desc, bx->license? bx->license: "???");
-			i++;
+			pj_o (pj);
+			pj_ks (pj, "name", bx->name);
+			pj_ks (pj, "description", bx->desc);
+			pj_ks (pj, "license", bx->license ? bx->license : "???");
+			pj_end (pj);
 		}
-
-		i = 0;
-		bin->cb_printf ("],\"ldr\":[");
+		pj_end (pj);
+		pj_ka (pj, "ldr");
 		r_list_foreach (bin->binxtrs, it, ld) {
-			bin->cb_printf (
-				"%s{\"name\":\"%s\",\"description\":\"%s\","
-				"\"license\":\"%s\"}",
-				i? ",": "", ld->name, ld->desc, ld->license? ld->license: "???");
-			i++;
+			pj_o (pj);
+			pj_ks (pj, "name", ld->name);
+			pj_ks (pj, "description", ld->desc);
+			pj_ks (pj, "license", ld->license ? ld->license : "???");
+			pj_end (pj);
 		}
-		bin->cb_printf ("]}\n");
+		pj_end (pj);
+		pj_end (pj);
+		bin->cb_printf ("%s\n", pj_string (pj));
+		pj_free (pj);
 	} else {
 		r_list_foreach (bin->plugins, it, bp) {
 			bin->cb_printf ("bin  %-11s %s (%s) %s %s\n",
@@ -952,9 +966,14 @@ static void list_xtr_archs(RBin *bin, int mode) {
 		RBinXtrData *xtr_data;
 		int bits, i = 0;
 		char *arch, *machine;
+		PJ *pj;
 
 		if (mode == 'j') {
-			bin->cb_printf ("\"bins\":[");
+			pj = pj_new ();
+			if (!pj) {
+				return;
+			}
+			pj_ka (pj, "bins");
 		}
 
 		r_list_foreach (binfile->xtr_data, iter_xtr, xtr_data) {
@@ -970,20 +989,13 @@ static void list_xtr_archs(RBin *bin, int mode) {
 				bin->cb_printf ("%s\n", arch);
 				break;
 			case 'j': { // "iAj"
-				PJ * pj = pj_new ();
 				pj_o (pj);
-				pj_a (pj);
 				pj_ks (pj, "arch", arch);
 				pj_ki (pj, "bits", bits);
-				pj_ki (pj, "offset", xtr_data->offset);
-				pj_kn (pj, "size", xtr_data->size);
-				if (machine) {
-					pj_ks (pj, "machine", machine);
-				}
+				pj_kN (pj, "offset", xtr_data->offset);
+				pj_kN (pj, "size", xtr_data->size);
+				pj_ks (pj, "machine", machine);
 				pj_end (pj);
-				pj_end (pj);
-				bin->cb_printf ("%s\n", pj_string (pj));
-				pj_free (pj);
 				break;
 			}
 			default:
@@ -997,7 +1009,9 @@ static void list_xtr_archs(RBin *bin, int mode) {
 		}
 
 		if (mode == 'j') {
-			bin->cb_printf ("]");
+			pj_end (pj);
+			bin->cb_printf ("%s", pj_string (pj));
+			pj_free (pj);
 		}
 	}
 }
@@ -1005,45 +1019,41 @@ static void list_xtr_archs(RBin *bin, int mode) {
 R_API void r_bin_list_archs(RBin *bin, int mode) {
 	r_return_if_fail (bin);
 
-	int i = 0;
 	char unk[128];
 	char archline[256];
 	RBinFile *binfile = r_bin_cur (bin);
-	RTable *table = r_table_new ();
 	const char *name = binfile? binfile->file: NULL;
 	int narch = binfile? binfile->narch: 0;
 
 	//are we with xtr format?
 	if (binfile && binfile->curxtr) {
 		list_xtr_archs (bin, mode);
-		r_table_free (table);
 		return;
 	}
 	Sdb *binfile_sdb = binfile? binfile->sdb: NULL;
 	if (!binfile_sdb) {
 	//	eprintf ("Cannot find SDB!\n");
-		r_table_free (table);
 		return;
 	}
 	if (!binfile) {
 	//	eprintf ("Binary format not currently loaded!\n");
-		r_table_free (table);
 		return;
 	}
 	sdb_unset (binfile_sdb, ARCHS_KEY, 0);
-	PJ *pj = pj_new ();
-	pj_o (pj);
-	if (mode == 'j') {
-		pj_k (pj, "bins");
-		pj_a (pj);
-	}
-	RBinFile *nbinfile = r_bin_file_find_by_name_n (bin, name, i);
+	RBinFile *nbinfile = r_bin_file_find_by_name (bin, name);
 	if (!nbinfile) {
-		pj_free (pj);
-		r_table_free (table);
 		return;
 	}
-	i = -1;
+	RTable *table = r_table_new ();
+	const char *fmt = "dXnss";
+	PJ *pj;
+	if (mode == 'j') {
+		pj = pj_new ();
+		if (!pj) {
+			return;
+		}
+		pj_ka (pj, "bins");
+	}
 	RBinObject *obj = nbinfile->o;
 	RBinInfo *info = obj->info;
 	char bits = info? info->bits: 0;
@@ -1053,13 +1063,12 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 	const char *machine = info? info->machine: "unknown_machine";
 	const char *h_flag = info? info->head_flag: NULL;
 	char * str_fmt;
-	i++;
 	if (!arch) {
-		snprintf (unk, sizeof (unk), "unk_%d", i);
+		snprintf (unk, sizeof (unk), "unk_0");
 		arch = unk;
 	}
 	r_table_hide_header (table);
-	r_table_set_columnsf (table, "nXnss", "num", "offset", "size", "arch", "machine", NULL);
+	r_table_set_columnsf (table, fmt, "num", "offset", "size", "arch", "machine", NULL);
 
 	if (info && narch > 1) {
 		switch (mode) {
@@ -1084,8 +1093,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 		default:
 			str_fmt = h_flag && strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 				: sdb_fmt ("%s_%i", arch, bits);
-			r_table_add_rowf (table, "nXnss", i, boffset, obj_size, str_fmt , machine);
-			bin->cb_printf ("%s\n", r_table_tostring(table));
+			r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, machine);
+			bin->cb_printf ("%s", r_table_tostring(table));
 		}
 		snprintf (archline, sizeof (archline) - 1,
 			"0x%08" PFMT64x ":%" PFMT64u ":%s:%d:%s",
@@ -1116,8 +1125,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			default:
 				str_fmt = h_flag && strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 					: sdb_fmt ("%s_%i", arch, bits);
-				r_table_add_rowf (table, "dsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, str_fmt, "");
-				bin->cb_printf ("%s\n", r_table_tostring(table));
+				r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, "");
+				bin->cb_printf ("%s", r_table_tostring(table));
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",
@@ -1139,8 +1148,8 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				pj_end (pj);
 				break;
 			default:
-				r_table_add_rowf (table, "nsnss", i, sdb_fmt ("0x%08" PFMT64x , boffset), obj_size, "", "");
-				bin->cb_printf ("%s\n", r_table_tostring(table));
+				r_table_add_rowf (table, fmt, 0, boffset, obj_size, "", "");
+				bin->cb_printf ("%s", r_table_tostring(table));
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",
@@ -1152,13 +1161,12 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 	}
 	if (mode == 'j') {
 		pj_end (pj);
-		pj_end (pj);
 		const char *s = pj_string (pj);
 		if (s) {
-			bin->cb_printf ("%s\n", s);
+			bin->cb_printf ("%s", s);
 		}
+		pj_free (pj);
 	}
-	pj_free (pj);
 	r_table_free (table);
 }
 

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -906,7 +906,7 @@ trashbin_binxtrs:
 	r_id_storage_free (bin->ids);
 	r_str_constpool_fini (&bin->constpool);
 trashbin:
-	free(bin);
+	free (bin);
 	return NULL;
 }
 
@@ -1094,7 +1094,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 			str_fmt = h_flag && strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 				: sdb_fmt ("%s_%i", arch, bits);
 			r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, machine);
-			bin->cb_printf ("%s", r_table_tostring(table));
+			bin->cb_printf ("%s", r_table_tostring (table));
 		}
 		snprintf (archline, sizeof (archline) - 1,
 			"0x%08" PFMT64x ":%" PFMT64u ":%s:%d:%s",
@@ -1126,7 +1126,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				str_fmt = h_flag && strcmp (h_flag, "unknown_flag")? sdb_fmt ("%s_%i %s", arch, bits, h_flag) \
 					: sdb_fmt ("%s_%i", arch, bits);
 				r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, "");
-				bin->cb_printf ("%s", r_table_tostring(table));
+				bin->cb_printf ("%s", r_table_tostring (table));
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",
@@ -1149,7 +1149,7 @@ R_API void r_bin_list_archs(RBin *bin, int mode) {
 				break;
 			default:
 				r_table_add_rowf (table, fmt, 0, boffset, obj_size, "", "");
-				bin->cb_printf ("%s", r_table_tostring(table));
+				bin->cb_printf ("%s", r_table_tostring (table));
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",

--- a/libr/bin/i/private.h
+++ b/libr/bin/i/private.h
@@ -10,7 +10,6 @@ R_IPI RBinObject *r_bin_file_object_find_by_id(RBinFile *binfile, ut32 binobj_id
 R_IPI RList *r_bin_file_get_strings(RBinFile *a, int min, int dump, int raw);
 R_IPI RBinFile *r_bin_file_find_by_object_id(RBin *bin, ut32 binobj_id);
 R_IPI RBinFile *r_bin_file_find_by_id(RBin *bin, ut32 binfile_id);
-R_IPI RBinFile *r_bin_file_find_by_name_n(RBin *bin, const char *name, int idx);
 R_IPI bool r_bin_file_set_obj(RBin *bin, RBinFile *bf, RBinObject *obj);
 R_IPI RBinFile *r_bin_file_xtr_load_bytes(RBin *bin, RBinXtrPlugin *xtr, const char *filename, const ut8 *bytes, ut64 sz, ut64 file_sz, ut64 baseaddr, ut64 loadaddr, int idx, int fd, int rawstr);
 R_IPI bool r_bin_file_set_bytes(RBinFile *binfile, const ut8 *bytes, ut64 sz, bool steal_ptr);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2093,7 +2093,7 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 
 	if (pj) {
 		pj_end (pj);
-		r_cons_printf ("%s\n", pj_string (pj));
+		r_cons_print (pj_string (pj));
 		pj_free (pj);
 	}
 

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -595,10 +595,14 @@ static int cmd_info(void *data, const char *input) {
 				if (z) { playMsg (core, n, z);}\
 				r_core_bin_info (core, x, mode, va, NULL, y);
 		case 'A': // "iA"
-			newline = false;
-			{
-				int mode = (input[1] == 'j')? 'j': 1;
-				r_bin_list_archs (core->bin, mode);
+			if (input[1] == 'j') {
+				r_cons_print ("{");
+				r_bin_list_archs (core->bin, 'j');
+				r_cons_print ("}");
+				newline = true;
+			} else {
+				r_bin_list_archs (core->bin, 1);
+				newline = false;
 			}
 			break;
 		case 'E': // "iE"
@@ -917,6 +921,9 @@ static int cmd_info(void *data, const char *input) {
 			}
 			break;
 		case 'i': { // "ii"
+			if (input[1] == 'j') {
+				newline = true;
+			}
 			RBinObject *obj = r_bin_cur_object (core->bin);
 			RBININFO ("imports", R_CORE_BIN_ACC_IMPORTS, NULL,
 				(obj && obj->imports)? r_list_length (obj->imports): 0);

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -342,7 +342,6 @@ iAj
 EOF
 EXPECT=<<EOF
 0   0x00000000 266108 mips_32 mips1 o32 
-
 {"bins":[{"arch":"mips","bits":32,"offset":0,"size":266108,"isa":"mips1","features":"o32","machine":"MIPS R3000"}]}
 EOF
 RUN
@@ -355,7 +354,6 @@ iAj
 EOF
 EXPECT=<<EOF
 0   0x00000000 1039368 mips_64 mips64r2 n64 
-
 {"bins":[{"arch":"mips","bits":64,"offset":0,"size":1039368,"isa":"mips64r2","features":"n64","machine":"MIPS R3000"}]}
 EOF
 RUN
@@ -365,7 +363,6 @@ FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=iA
 EXPECT=<<EOF
 0   0x00000000 4899 x86_32 
-
 EOF
 RUN
 
@@ -3028,7 +3025,6 @@ FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=iA
 EXPECT=<<EOF
 0   0x00000000 6710 x86_64 
-
 EOF
 RUN
 

--- a/test/db/formats/mach0/fatmach0
+++ b/test/db/formats/mach0/fatmach0
@@ -174,33 +174,31 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=fatmach0 archs 3true
+NAME=fatmach0 archs iA iAj
 FILE=bins/mach0/fatmach0-3true
-CMDS=iA
-EXPECT=<<EOF
-000 0x00001000 13792 x86_64 x86 64 all
-001 0x00005000 13760 x86_32 386
-002 0x00009000 13616 ppc_32 7400
+CMDS=<<EOF
+iA
+iAj
 EOF
-RUN
-
-NAME=fatmach0 rabin2 archs iA
-FILE=bins/mach0/fatmach0-3true
-CMDS=iA
 EXPECT=<<EOF
 000 0x00001000 13792 x86_64 x86 64 all
 001 0x00005000 13760 x86_32 386
 002 0x00009000 13616 ppc_32 7400
+{"bins":[{"arch":"x86","bits":64,"offset":4096,"size":13792,"machine":"x86 64 all"},{"arch":"x86","bits":32,"offset":20480,"size":13760,"machine":"386"},{"arch":"ppc","bits":32,"offset":36864,"size":13616,"machine":"7400"}]}
 EOF
 RUN
 
 NAME=fatmach0 rabin2 archs
 FILE=bins/mach0/fatmach0-3true
-CMDS=!rabin2 -A bins/mach0/fatmach0-3true
+CMDS=<<EOF
+!rabin2 -A bins/mach0/fatmach0-3true
+!rabin2 -Aj bins/mach0/fatmach0-3true
+EOF
 EXPECT=<<EOF
 000 0x00001000 13792 x86_64 x86 64 all
 001 0x00005000 13760 x86_32 386
 002 0x00009000 13616 ppc_32 7400
+{"bins":[{"arch":"x86","bits":64,"offset":4096,"size":13792,"machine":"x86 64 all"},{"arch":"x86","bits":32,"offset":20480,"size":13760,"machine":"386"},{"arch":"ppc","bits":32,"offset":36864,"size":13616,"machine":"7400"}]}
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

https://github.com/rizinorg/rizin/issues/200
Before:
```sh
liumeo@liumeo-x64:~/radare2/test$ r2 -Qc iAj bins/mach0/fatmach0-3true
"bins":[{["arch":"x86","bits":64,"offset":4096,"size":13792,"machine":"x86 64 all"]}
{["arch":"x86","bits":32,"offset":20480,"size":13760,"machine":"386"]}
{["arch":"ppc","bits":32,"offset":36864,"size":13616,"machine":"7400"]}
]liumeo@liumeo-x64:~/radare2/test$
```
Now:
```sh
liumeo@liumeo-imac:~/github/radare2/test$ r2 -Qc iAj bins/mach0/fatmach0-3true
{"bins":[{"arch":"x86","bits":64,"offset":4096,"size":13792,"machine":"x86 64 all"},{"arch":"x86","bits":32,"offset":20480,"size":13760,"machine":"386"},{"arch":"ppc","bits":32,"offset":36864,"size":13616,"machine":"7400"}]}
```
Both `rabin2 -Aj` and `r2 -Qc iAj` are fixed. See tests.
Moreover:
* Remove `r_bin_file_find_by_name_n` because it's useless after 1fbc7f21683e481a4c6ca6ba6b30a80117418b57
* Fix wrong pj imported #17636 
* Fix wrong r_table format
* Remove some useless newlines