### PR TITLE
Release 5.0.0

### DIFF
--- a/configure
+++ b/configure
@@ -129,12 +129,12 @@ done
 : ${INSTALL_PROGRAM_STRIP:=${INSTALL} -m 755 -s}
 : ${INSTALL_MAN:=${INSTALL} -m 444}
 : ${INSTALL_LIB:=${INSTALL} -m 755 -c}
- PKGNAME='radare2' ; VERSION='4.6.0-git' ; VERSION_MAJOR=4; VERSION_MINOR=6; VERSION_PATCH=0; VERSION_NUMBER=40600; CONTACT_MAIL="pancake@nopcode.org" ; CONTACT_NAME="pancake" ; CONTACT="pancake <pancake@nopcode.org>" ;
+ PKGNAME='radare2' ; VERSION='5.0.0' ; VERSION_MAJOR=5; VERSION_MINOR=0; VERSION_PATCH=0; VERSION_NUMBER=50000; CONTACT_MAIL="pancake@nopcode.org" ; CONTACT_NAME="pancake" ; CONTACT="pancake <pancake@nopcode.org>" ;
 }
 
 show_usage() {
 cat <<EOF2
-'configure' configures radare2-4.6.0-git to adapt to many kinds of systems.
+'configure' configures radare2-5.0.0 to adapt to many kinds of systems.
 
 Usage: ./configure [OPTION]... [VAR=VALUE]...
 
@@ -234,10 +234,10 @@ ocho() {
 
 show_version() {
 if [ "$QUIET" = 1 ]; then
-	echo "4.6.0-git"
+	echo "5.0.0"
 	exit 0
 fi
-echo "radare2-4.6.0-git configuration script done with acr v1.9.5.
+echo "radare2-5.0.0 configuration script done with acr v1.9.5.
 The 'Free Software Foundation' message is only for autodetection.
 Originally written by pancake <nopcode.org>."
 exit 0
@@ -266,7 +266,7 @@ case $flag in
 	show_version ; ;;
 -r|--r|--report)
 echo "PKGNAME:   radare2"
-echo "VERSION:   4.6.0-git"
+echo "VERSION:   5.0.0"
 echo "LANGS:     c"
 echo "REQUIRED:  libdl"
 echo "OPTIONAL:  libmagic libz libzip libxxhash libssl liblibuv>=1.0.0"
@@ -779,7 +779,7 @@ if [ -f "${VPATH}/${A}.acr" ]; then
   fi
  fi
  ocho "creating ${SD_TARGET}"
-mkdir -p $(echo ${A} | sed -e "s,/`basename ${A}`$,,g")
+[ "${VPATH}" != '.' ] &&  mkdir -p $(echo ${A} | sed -e "s,/`basename ${A}`$,,g")
  cat ${VPATH}/${SD_TARGET}.acr | \
 eval sed -e "s,@VPATH@,${VPATH}/${A},g" ${SEDFLAGS} > ${SD_TARGET}.tmp
 

--- a/configure.acr
+++ b/configure.acr
@@ -1,5 +1,5 @@
 PKGNAME radare2
-VERSION 4.6.0-git
+VERSION 5.0.0
 CONTACT pancake ; pancake@nopcode.org
 
 LANG_C!


### PR DESCRIPTION
# r2-5.0

## Interface

* Added the Comma API
* Added r_str_wrap() and r_cons_printat() APIs
* Fix adding comments in panels
* Improved help messages
* Removed problematic fortunes
* Add ?et command to change terminal title
* Fix double-click issue in vte terminals
* Formalize the flag names and its filtering APIs
* Fix return code when using q!. Fixes r2pipe.go
* Add experimental asm.flags.real to get strings from bin.str.real
* Removed unmaintained enyo and panels webuis (-2MB)
* Set realname on all bin strings for better asm.flags.real when bin.str.real is set
* Fix ansi colors embedded inside json output formatting
* Improve socket and http server APIs
* Add opn/opr/opp commands to rotate between opened files
* Initial implementation of scr.cursor for keyboard accessibility in visual and panels
* Add asm.hint.call.indirect to make indirect calls follow the target address (#17968)


## Performance

* Use sdb_set instead of sdb_querys (aaaa is 7x faster)
* Optimize IO.cache (makes bins with relocs much faster)

## Signatures


## Debugger

* Sync anal and debug tracing information
* Fix a crash in dts+ command with empty register arenas
* Attach to target pid/tid on remote lldb connect
* Add a warning when a breakpoint is placed in an invalid map
* Add commands to parse mangling pointers glibc heap

## Analysis

* Improve signature matching, threshold, refactor and optimize related code
* Directly apply Callee Args in Type Matching
* Takeover variables when splitting functions
* Always register the derived CC from the reg profile
* Add bbhash to detect modifications in functions (and reanalize if patched)
* Implement basic block listing commands (abl*)
* Implement tcc-* commmand to unload all calling conventions

* X86
  * Add amd64syscall and anal.cc evar
  * Fix esil for cmp/sub instructions
  * Add amd64syscall calling convention
  * Fix ELF R_X86_64_PLT32 relocation entries patching (#17587)
  * Fix x86 CMC instruction
* MIPS
  * Improves mips.gnu esil
  * Add JALR JR when the address can be computed
  * Fix GP calculation when there are multiple entries
  * Fix MIPS C-TYPE instruction check
  * Set asm.cpu for mips.gnu derived from the ISA defined in the ELF
* ARM
  * arm mte addg/subg decoding
  * fix arm it block analysis
  * BLR arm64 is type=RCALL (before it was UCALL)
  * ARM64 assembler can now assemble AND and BIC instructions (Thanks @mrmacete!)
  * Add initial support for arm and arm64 ELF relocs
  * Handle RELATIVE (todo) and IRELATIVE relocs in ARM64 ELFs
  * COFF: add ARMNT and ARM64 support
  * All testsuite run on arm32 and arm64
* v850 
  * Improve invalid instruction detection
  * Implement the pseudo disassembler plugin
  * Fallback to anal=v850 when using asm=v850.gnu
  * Add ep, sp, gp lp register aliases for v850
  * Added function preludes (aap finds much more functions)
  * Fix calling convention argument register usage for v850
  * Add all instruction descriptions
  * Set v850 disassembler when opening v800 ELF files
* TMS320
  * Implement pseudo disassembler plugin
* PowerPC
  * Initial assembler support
  * Improve reg profile to support calling conventions
* RISC-V
  * Add all instruction descriptions
  * Add Fix shift instruction analysis
  * Fix ESIL for JALR and AUIPC instruction
* SPC700 plugins moved to extras

## ESIL

* Add sign-extension operations
* Implement aof to filter expressions using the dfg api
* Fix unexpected FPU exception in ESIL emulation bug
* Enlarge ESIL VM stack from 32 to 256

## BSD

* Support pkgconf (BSD alternative to pkg-config)
* Fix build with tinycc, unfortunely the final binary segfaults
* Fix debugger support in FreeBSD
* Implements r_sys_aslr for NetBSD
* Fixing r_sys_pid_to_path for DragonFlyBSD
* Setting ASLR support for DragonFlyBSD

## Windows

* Fix r_core_editor() on Windows (#17887)
* Fix MSVC template demangling symbols
* Expose TEB address as a flag on Windows
* Add network support to WinDbg/KD (KDNET)

## Apple

* Support ObjC small method lists
* Support iOS 14.x dyld shared cache
* Add support for new macOS kernelcache


## Changes

* Rename `asm.filter` to `asm.sub.names`
* Rename `asm.var.sub` to `asm.sub.var`
* Deprecate the `afc=` command.
* Removed all globals from main functions
* afc= -> e anal.cc
* Fix big endian DWARF parsing
* labels no longer stored in sdb
* Refactor Variable Constraints out of SDB
* Fix r_anal_block_automerge incorrectly merging blocks
