### PR TITLE
Use r_str_get_fail() throughout codebase ##refactor

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1723,7 +1723,7 @@ R_API char *r_anal_function_get_json(RAnalFunction *function) {
 	pj_ks (pj, "name", function->name);
 	const bool no_return = r_anal_noreturn_at_addr (a, function->addr);
 	pj_kb (pj, "noreturn", no_return);
-	pj_ks (pj, "ret", ret_type?ret_type: "void");
+	pj_ks (pj, "ret", r_str_get_fail (ret_type, "void"));
 	if (function->cc) {
 		pj_ks (pj, "cc", function->cc);
 	}
@@ -1805,7 +1805,7 @@ R_API char *r_anal_function_get_signature(RAnalFunction *function) {
 		free (arg_i);
 		free (sdb_arg_i);
 	}
-	ret = r_str_newf ("%s %s (%s);", ret_type? ret_type: "void", realname, args);
+	ret = r_str_newf ("%s %s (%s);", r_str_get_fail (ret_type, "void"), realname, args);
 
 	free (sdb_args);
 	free (sdb_ret);

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -41,7 +41,7 @@ static bool _is_any(const char *str, ...) {
 }
 
 static void arg_p2(char *buf, unsigned long val, const char* const* array, size_t size) {
-	const char *s = val >= size || array[val] ? array[val] : "unknown";
+	const char *s = (val >= size || array[val]) ? array[val] : "unknown";
 	snprintf (buf, RISCVARGSIZE, "%s", s);
 }
 

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1036,7 +1036,7 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 		{
 			dst = getarg (&gop, 0, 0, NULL, DST_AR, NULL);
 			esilprintf (op, "%s,%d,%s,-,=[%d],%d,%s,-=",
-				dst ? dst : "eax", rs, sp, rs, rs, sp);
+				r_str_get_fail (dst, "eax"), rs, sp, rs, rs, sp);
 		}
 		break;
 	case X86_INS_PUSHF:

--- a/libr/asm/arch/riscv/riscv.c
+++ b/libr/asm/arch/riscv/riscv.c
@@ -38,7 +38,7 @@ static const char * const *riscv_fpr_names = riscv_fpr_names_abi;
 static int init = 0;
 
 static void arg_p (char *buf, unsigned long val, const char* const* array, size_t size) {
-	const char *s = val >= size || array[val] ? array[val] : "unknown";
+	const char *s = (val >= size || array[val]) ? array[val] : "unknown";
 	sprintf (buf+strlen (buf), "%s", s);
 }
 

--- a/libr/asm/p/asm_dalvik.c
+++ b/libr/asm/p/asm_dalvik.c
@@ -501,7 +501,7 @@ static int dalvik_disassemble (RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 			strasm = NULL;
 			size = 2;
 		}
-		r_strbuf_set (&op->buf_asm, strasm? strasm: "invalid");
+		r_strbuf_set (&op->buf_asm, r_str_get_fail (strasm, "invalid"));
 	} else if (len > 0) {
 		r_strbuf_set (&op->buf_asm, "invalid");
 		op->size = len;

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -491,7 +491,7 @@ static bool r_bin_print_plugin_details(RBin *bin, RBinPlugin *bp, int json) {
 		pj_o (pj);
 		pj_ks (pj, "name", bp->name);
 		pj_ks (pj, "description", bp->desc);
-		pj_ks (pj, "license", bp->license ? bp->license : "???");
+		pj_ks (pj, "license", r_str_get_fail (bp->license, "???"));
 		pj_end (pj);
 		bin->cb_printf ("%s\n", pj_string (pj));
 		pj_free (pj);
@@ -522,7 +522,7 @@ static void __printXtrPluginDetails(RBin *bin, RBinXtrPlugin *bx, int json) {
 		pj_o (pj);
 		pj_ks (pj, "name", bx->name);
 		pj_ks (pj, "description", bx->desc);
-		pj_ks (pj, "license", bx->license ? bx->license : "???");
+		pj_ks (pj, "license", r_str_get_fail (bx->license, "???"));
 		pj_end (pj);
 		bin->cb_printf ("%s\n", pj_string (pj));
 		pj_free (pj);
@@ -584,7 +584,7 @@ R_API void r_bin_list(RBin *bin, int format) {
 			pj_o (pj);
 			pj_ks (pj, "name", bp->name);
 			pj_ks (pj, "description", bp->desc);
-			pj_ks (pj, "license", bp->license ? bp->license : "???");
+			pj_ks (pj, "license", r_str_get_fail (bp->license, "???"));
 			pj_end (pj);
 		}
 		pj_end (pj);
@@ -593,7 +593,7 @@ R_API void r_bin_list(RBin *bin, int format) {
 			pj_o (pj);
 			pj_ks (pj, "name", bx->name);
 			pj_ks (pj, "description", bx->desc);
-			pj_ks (pj, "license", bx->license ? bx->license : "???");
+			pj_ks (pj, "license", r_str_get_fail (bx->license, "???"));
 			pj_end (pj);
 		}
 		pj_end (pj);
@@ -602,7 +602,7 @@ R_API void r_bin_list(RBin *bin, int format) {
 			pj_o (pj);
 			pj_ks (pj, "name", ld->name);
 			pj_ks (pj, "description", ld->desc);
-			pj_ks (pj, "license", ld->license ? ld->license : "???");
+			pj_ks (pj, "license", r_str_get_fail (ld->license, "???"));
 			pj_end (pj);
 		}
 		pj_end (pj);
@@ -612,19 +612,19 @@ R_API void r_bin_list(RBin *bin, int format) {
 	} else {
 		r_list_foreach (bin->plugins, it, bp) {
 			bin->cb_printf ("bin  %-11s %s (%s) %s %s\n",
-				bp->name, bp->desc, bp->license? bp->license: "???",
+				bp->name, bp->desc, r_str_get_fail (bp->license, "???"),
 				r_str_get (bp->version),
 				r_str_get (bp->author));
 		}
 		r_list_foreach (bin->binxtrs, it, bx) {
 			const char *name = strncmp (bx->name, "xtr.", 4)? bx->name : bx->name + 3;
 			bin->cb_printf ("xtr  %-11s %s (%s)\n", name,
-				bx->desc, bx->license? bx->license: "???");
+				bx->desc, r_str_get_fail (bx->license, "???"));
 		}
 		r_list_foreach (bin->binldrs, it, ld) {
 			const char *name = strncmp (ld->name, "ldr.", 4)? ld->name : ld->name + 3;
 			bin->cb_printf ("ldr  %-11s %s (%s)\n", name,
-				ld->desc, ld->license? ld->license: "???");
+				ld->desc, r_str_get_fail (ld->license, "???"));
 		}
 	}
 }

--- a/libr/bin/format/mach0/dyldcache.c
+++ b/libr/bin/format/mach0/dyldcache.c
@@ -55,7 +55,7 @@ struct r_bin_dyldcache_lib_t *r_bin_dyldcache_extract(struct r_bin_dyldcache_obj
 		return NULL;
 	}
 	if (bin->size < 1) {
-		eprintf ("Empty file? (%s)\n", bin->file? bin->file: "(null)");
+		eprintf ("Empty file? (%s)\n", r_str_getf (bin->file));
 		return NULL;
 	}
 	if (bin->nlibs < 0 || idx < 0 || idx >= bin->nlibs) {

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1522,7 +1522,7 @@ void MACH0_(get_category_t)(mach0_ut p, RBinFile *bf, RBinClass *klass, RSkipLis
 		if (target_class_name) {
 			demangled = demangle_classname (target_class_name);
 		}
-		klass->name = r_str_newf ("%s(%s)", demangled ? demangled : "(null)", category_name);
+		klass->name = r_str_newf ("%s(%s)", r_str_getf (demangled), category_name);
 		R_FREE (target_class_name);
 		R_FREE (demangled);
 	}

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -300,7 +300,7 @@ static char *dex_get_proto(RBinDexObj *bin, int proto_id) {
 				r_strbuf_append (sig, "?;");
 			} else {
 				const char *buff = getstr (bin, type_desc_id);
-				r_strbuf_append (sig, buff? buff: "?;");
+				r_strbuf_append (sig, r_str_get_fail (buff, "?;"));
 			}
 		}
 		free (typeidx_buf);
@@ -787,7 +787,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->bclass = r_bin_dex_get_version (bf->o->bin_obj);
 	ret->rclass = strdup ("class");
 	ret->os = strdup ("linux");
-	ret->subsystem = strdup (dexSubsystem? dexSubsystem: "java");
+	ret->subsystem = strdup (r_str_get_fail (dexSubsystem, "java"));
 	ret->machine = strdup ("Dalvik VM");
 	h = &ret->sum[0];
 	h->type = "sha1";

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1422,7 +1422,7 @@ R_API int r_cons_get_size(int *rows) {
 	if (isatty (0) && !ioctl (0, TIOCGWINSZ, &win)) {
 		if ((!win.ws_col) || (!win.ws_row)) {
 			const char *tty = isatty (1)? ttyname (1): NULL;
-			int fd = open (tty? tty: "/dev/tty", O_RDONLY);
+			int fd = open (r_str_get_fail (tty, "/dev/tty"), O_RDONLY);
 			if (fd != -1) {
 				int ret = ioctl (fd, TIOCGWINSZ, &win);
 				if (ret || !win.ws_col || !win.ws_row) {

--- a/libr/cons/hud.c
+++ b/libr/cons/hud.c
@@ -288,7 +288,7 @@ R_API char *r_cons_hud_path(const char *path, int dir) {
 	RList *files;
 	if (path) {
 		path = r_str_trim_head_ro (path);
-		tmp = strdup (*path? path: "./");
+		tmp = strdup (*path ? path : "./");
 	} else {
 		tmp = strdup ("./");
 	}

--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -431,7 +431,7 @@ static void type_match(RCore *core, char *fcn_name, ut64 addr, ut64 baddr, const
 				get_src_regname (core, instr_addr, tmp, sizeof (tmp));
 				ut64 ptr = get_addr (trace, tmp, j);
 				if (ptr == xaddr) {
-					__var_retype (anal, var, name, type? type: "int", memref, false);
+					__var_retype (anal, var, name, r_str_get_fail (type, "int"), memref, false);
 				}
 			}
 			r_anal_op_free (op);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1177,7 +1177,7 @@ static void hint_node_print(HintNode *node, int mode, PJ *pj) {
 			break;
 		}
 		case HINT_NODE_ARCH:
-			HINTCMD_ADDR (node, "aha %s", node->arch ? node->arch : "0");
+			HINTCMD_ADDR (node, "aha %s", r_str_get_fail (node->arch, "0"));
 			break;
 		case HINT_NODE_BITS:
 			HINTCMD_ADDR (node, "ahb %d", node->bits);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1760,7 +1760,7 @@ static int bin_relocs(RCore *r, int mode, int va) {
 				int reloc_size = 4;
 				char *n = __filterQuotedShell (name);
 				r_cons_printf ("\"f %s%s%s %d 0x%08"PFMT64x"\"\n",
-					r->bin->prefix ? r->bin->prefix : "reloc.",
+					r_str_get_fail (r->bin->prefix, "reloc."),
 					r->bin->prefix ? "." : "", n, reloc_size, addr);
 				add_metadata (r, reloc, addr, mode);
 				free (n);
@@ -2057,8 +2057,8 @@ static int bin_imports(RCore *r, int mode, int va, const char *name) {
 		} else if (IS_MODE_RAD (mode)) {
 			// TODO(eddyb) symbols that are imports.
 		} else {
-			const char *bind = import->bind? import->bind: "NONE";
-			const char *type = import->type? import->type: "NONE";
+			const char *bind = r_str_get_fail (import->bind, "NONE");
+			const char *type = r_str_get_fail (import->type, "NONE");
 			if (import->classname && import->classname[0]) {
 				r_table_add_rowf (table, "nXssss", (ut64)import->ordinal, addr, bind, type, r_str_get (libname),
 					sdb_fmt ("%s.%s", import->classname, symname));
@@ -2483,8 +2483,8 @@ static int bin_symbols(RCore *r, int mode, ut64 laddr, int va, ut64 at, const ch
 				}
 			}
 		} else {
-			const char *bind = symbol->bind? symbol->bind: "NONE";
-			const char *type = symbol->type? symbol->type: "NONE";
+			const char *bind = r_str_get_fail (symbol->bind, "NONE");
+			const char *type = r_str_get_fail (symbol->type, "NONE");
 			const char *name = r_str_getf (sn.demname? sn.demname: sn.name);
 			// const char *fwd = r_str_getf (symbol->forwarder);
 			r_table_add_rowf (table, "dssssdss",

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -204,7 +204,7 @@ static void rasm2_list(RCore *core, const char *arch, int fmt) {
 			} else {
 				r_cons_printf ("%s%s  %-9s  %-11s %-7s %s\n",
 						feat, feat2, bits, h->name,
-						h->license?h->license:"unknown", h->desc);
+						r_str_get_fail (h->license, "unknown"), h->desc);
 			}
 		}
 	}
@@ -3376,9 +3376,9 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("cfg.debug", "false", &cb_cfgdebug, "Debugger mode");
 	p = r_sys_getenv ("EDITOR");
 #if __WINDOWS__
-	r_config_set (cfg, "cfg.editor", p? p: "notepad");
+	r_config_set (cfg, "cfg.editor", r_str_get_fail (p, "notepad"));
 #else
-	r_config_set (cfg, "cfg.editor", p? p: "vi");
+	r_config_set (cfg, "cfg.editor", r_str_get_fail (p, "vi"));
 #endif
 	free (p);
 	r_config_desc (cfg, "cfg.editor", "Select default editor program");
@@ -3415,11 +3415,11 @@ R_API int r_core_config_init(RCore *core) {
 	free (p);
 	// R2_LOGSRCINFO / log.srcinfo
 	p = r_sys_getenv ("R2_LOGSRCINFO");
-	SETCB ("log.srcinfo", p ? p : "false", cb_log_config_srcinfo, "Should the log output contain src info (filename:lineno)");
+	SETCB ("log.srcinfo", r_str_get_fail (p, "false"), cb_log_config_srcinfo, "Should the log output contain src info (filename:lineno)");
 	free (p);
 	// R2_LOGCOLORS / log.colors
 	p = r_sys_getenv ("R2_LOGCOLORS");
-	SETCB ("log.colors", p ? p : "false", cb_log_config_colors, "Should the log output use colors (TODO)");
+	SETCB ("log.colors", r_str_get_fail (p, "false"), cb_log_config_colors, "Should the log output use colors (TODO)");
 	free (p);
 
 	SETCB ("log.events", "false", &cb_log_events, "Remote HTTP server to sync events with");
@@ -3461,7 +3461,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETPREF ("dir.types", "/usr/include", "Default path to look for cparse type files");
 	SETPREF ("dir.libs", "", "Specify path to find libraries to load when bin.libs=true");
 	p = r_sys_getenv (R_SYS_HOME);
-	SETCB ("dir.home", p? p: "/", &cb_dirhome, "Path for the home directory");
+	SETCB ("dir.home", r_str_get_fail (p, "/"), &cb_dirhome, "Path for the home directory");
 	free (p);
 	p = r_sys_getenv (R_SYS_TMP);
 	SETCB ("dir.tmp", r_str_get (p), &cb_dirtmp, "Path of the tmp directory");

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -820,7 +820,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			r_list_foreach (maps, iter, mapcore) {
 				RIOMap *iomap = r_io_map_get (r->io, mapcore->addr);
 				if (iomap && (mapcore->file || stack_map == iomap)) {
-					r_io_map_set_name (iomap, mapcore->file ? mapcore->file : "[stack]");
+					r_io_map_set_name (iomap, r_str_get_fail (mapcore->file, "[stack]"));
 				}
 				map++;
 			}

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5103,7 +5103,7 @@ static int cmd_debug(void *data, const char *input) {
 				if (rdi) {
 					const char *s = r_signal_to_string (core->dbg->reason.signum);
 					P ("type=%s\n", r_debug_reason_to_string (core->dbg->reason.type));
-					P ("signal=%s\n", s? s: "none");
+					P ("signal=%s\n", r_str_get_fail (s, "none"));
 					P ("signum=%d\n", core->dbg->reason.signum);
 					P ("sigpid=%d\n", core->dbg->reason.tid);
 					P ("addr=0x%"PFMT64x"\n", core->dbg->reason.addr);
@@ -5187,7 +5187,7 @@ static int cmd_debug(void *data, const char *input) {
 				if (rdi) {
 					const char *s = r_signal_to_string (core->dbg->reason.signum);
 					P ("\"type\":\"%s\",", r_debug_reason_to_string (core->dbg->reason.type));
-					P ("\"signal\":\"%s\",", s? s: "none");
+					P ("\"signal\":\"%s\",", r_str_get_fail (s, "none"));
 					P ("\"signum\":%d,", core->dbg->reason.signum);
 					P ("\"sigpid\":%d,", core->dbg->reason.tid);
 					P ("\"addr\":%"PFMT64d",", core->dbg->reason.addr);

--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -253,7 +253,7 @@ static void __printRecursive (RCore *core, RList *flags, const char *prefix, int
 		}
 		if (mode == '*') {
 			r_cons_printf ("agn %s %s\n", fn, fn + prefix_len);
-			r_cons_printf ("age %s %s\n", *prefix? prefix: "root", fn);
+			r_cons_printf ("age %s %s\n", *prefix ? prefix : "root", fn);
 		} else {
 			r_cons_printf ("%s %s\n", r_str_pad (' ', prefix_len), fn + prefix_len);
 		}
@@ -315,7 +315,7 @@ static void cmd_fz(RCore *core, const char *input) {
 		{
 			const char *a = NULL, *b = NULL;
 			r_flag_zone_around (core->flags, core->offset, &a, &b);
-			r_cons_printf ("%s %s\n", a?a:"~", b?b:"~");
+			r_cons_printf ("%s %s\n", r_str_get_fail (a, "~"), r_str_get_fail (b, "~"));
 		}
 		break;
 	case ':': // "fz:"

--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -78,7 +78,7 @@ static void cmd_mount_ls (RCore *core, const char *input) {
 		}
 		r_list_free (list);
 	}
-	const char *path = *input? input: "/";
+	const char *path = *input ? input : "/";
 	r_list_foreach (core->fs->roots, iter, root) {
 		// TODO: adjust contents between //
 		if (!strncmp (path, root->path, strlen (path))) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -617,7 +617,7 @@ static void printFunctionType(RCore *core, const char *input) {
 	int i, args = sdb_num_get (TDB, sdb_fmt ("func.%s.args", name), 0);
 	pj_ks (pj, "name", name);
 	const char *ret_type = sdb_const_get (TDB, sdb_fmt ("func.%s.ret", name), 0);
-	pj_ks (pj, "ret", ret_type? ret_type: "void");
+	pj_ks (pj, "ret", r_str_get_fail (ret_type, "void"));
 	pj_k (pj, "args");
 	pj_a (pj);
 	for (i = 0; i < args; i++) {

--- a/libr/core/visual_tabs.inc
+++ b/libr/core/visual_tabs.inc
@@ -25,7 +25,7 @@ static char *__core_visual_tab_string(RCore *core, const char *kolor) {
 			RCoreVisualTab *tab = r_list_get_n (core->visual.tabs, i);
 			const char *name = (tab && *tab->name)? tab->name: NULL;
 			if (i == core->visual.tab) {
-				str = r_str_appendf (str, Color_WHITE"_/ %s \\_%s", name ? name: "t=", kolor);
+				str = r_str_appendf (str, Color_WHITE"_/ %s \\_%s", r_str_get_fail (name, "t="), kolor);
 			} else {
 				str = r_str_appendf (str, "_%s(%d)_", r_str_get (name), i + 1);
 			}
@@ -41,7 +41,7 @@ static char *__core_visual_tab_string(RCore *core, const char *kolor) {
 				name = tab->name;
 			}
 			if (i==core->visual.tab) {
-				str = r_str_appendf (str, "_/ %d:%s \\_", i + 1, name ? name : "'=");
+				str = r_str_appendf (str, "_/ %d:%s \\_", i + 1, r_str_get_fail (name, "'="));
 			} else {
 				str = r_str_appendf (str, "_(t%d%s%s)__", i + 1, name ? ":" : "", r_str_get (name));
 			}

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -4295,7 +4295,7 @@ R_API void r_core_visual_colors(RCore *core) {
 			"' to change foreground/background color\n");
 		r_cons_printf ("# Export colorscheme with command 'ec* > filename'\n");
 		r_cons_printf ("# Preview command: '%s' - Press 'c' to change it\n", preview_cmd);
-		r_cons_printf ("# Selected colorscheme : %s  - Use 'hl' or left/right arrow keys to change colorscheme\n", curtheme ? curtheme : "default");
+		r_cons_printf ("# Selected colorscheme : %s  - Use 'hl' or left/right arrow keys to change colorscheme\n", r_str_get_fail (curtheme, "default"));
 		r_cons_printf ("# Selected element: %s  - Use 'jk' or up/down arrow keys to change element\n", k);
 		r_cons_printf ("# ec %s %s # %d (\\x1b%.*s)",
 			k, color, atoi (cstr+7), esc ? (int)(esc - cstr - 1) : (int)strlen (cstr + 1), cstr+1);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1467,7 +1467,7 @@ static int show_syscall(RDebug *dbg, const char *sysreg) {
 	reg = (int)r_debug_reg_get (dbg, sysreg);
 	si = r_syscall_get (dbg->anal->syscall, reg, -1);
 	if (si) {
-		sysname = si->name? si->name: "unknown";
+		sysname = r_str_get_fail (si->name, "unknown");
 		args = si->args;
 	} else {
 		sysname = "unknown";

--- a/libr/debug/dmap.c
+++ b/libr/debug/dmap.c
@@ -72,8 +72,8 @@ static void print_debug_map_line(RDebug *dbg, RDebugMap *map, ut64 addr, const c
 			humansz,
 			map->user ? 'u' : 's',
 			r_str_rwx_i (map->perm),
-			map->name ? map->name : "?",
-			map->file ? map->file : "?",
+			r_str_get_fail (map->name, "?"),
+			r_str_get_fail (map->file, "?"),
 			*flagname ? " ; " : "",
 			flagname
 		);

--- a/libr/debug/p/native/w32.c
+++ b/libr/debug/p/native/w32.c
@@ -454,7 +454,7 @@ int w32_dbg_wait(RDebug *dbg, int pid) {
 			break;
 		case LOAD_DLL_DEBUG_EVENT:
 			dllname = get_file_name_from_handle (de.u.LoadDll.hFile);
-			//eprintf ("(%d) Loading library at %p (%s)\n",pid, de.u.LoadDll.lpBaseOfDll, dllname ? dllname : "no name");
+			//eprintf ("(%d) Loading library at %p (%s)\n",pid, de.u.LoadDll.lpBaseOfDll, r_str_get_fail (dllname, "no name"));
 			r_debug_lstLibAdd (pid,de.u.LoadDll.lpBaseOfDll, de.u.LoadDll.hFile, dllname);
 			if (dllname) {
 				free (dllname);

--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -1138,7 +1138,7 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			if (depth < 1) {
 				depth = 64;
 			}
-			char *words = strdup (addr? addr: "0");
+			char *words = strdup (r_str_get_fail (addr, "0"));
 			char *second = strchr (words, ',');
 			if (second) {
 				*second++ = 0;

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -244,14 +244,14 @@ static void rasm2_list(RAsmState *as, const char *arch) {
 				pj_i (pj, 32);
 				pj_i (pj, 64);
 				pj_end (pj);
-				pj_ks (pj, "license", h->license? h->license: "unknown");
+				pj_ks (pj, "license", r_str_get_fail (h->license, "unknown"));
 				pj_ks (pj, "description", h->desc);
 				pj_ks (pj, "features", feat);
 				pj_end (pj);
 			} else {
 				printf ("%s%s  %-9s  %-11s %-7s %s",
 					feat, feat2, bits, h->name,
-					h->license? h->license: "unknown", h->desc);
+					r_str_get_fail (h->license, "unknown"), h->desc);
 				if (h->author) {
 					printf (" (by %s)", h->author);
 				}

--- a/libr/util/charset.c
+++ b/libr/util/charset.c
@@ -84,7 +84,7 @@ R_API size_t r_charset_encode_str(RCharset *rc, ut8 *out, size_t out_len, const 
 		ut8 ch_in = in[i];
 		snprintf (k, sizeof (k), "0x%02x", ch_in);
 		const char *v = sdb_const_get (rc->db, k, 0);
-		strcpy (o, v?v:"?");
+		strcpy (o, r_str_get_fail (v, "?"));
 		o += strlen (o);
 	}
 	return o - (char*)out;

--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -100,7 +100,7 @@ static char *showfile(char *res, const int nth, const char *fpath, const char *n
 	} else if (printfmt == FMT_RAW) {
 		res = r_str_appendf (res, "%c%s%s%s  1 %4d:%-4d  %-10d  %s\n",
 			isdir?'d': fch,
-			u_rwx? u_rwx: "-",
+			r_str_get_fail (u_rwx, "-"),
 			r_str_rwx_i ((perm >> 3) & 7),
 			r_str_rwx_i (perm & 7),
 			uid, gid, sz, nn);
@@ -415,8 +415,8 @@ R_API char *r_syscmd_join(const char *file1, const char *file2) {
 						char *out = r_str_new (field);
 						char *first = strchr (str1, ' ');
 						char *second = strchr (str2, ' ');
-						r_str_append (out, first ? first : " ");
-						r_str_append (out, second ? second : " ");
+						r_str_append (out, r_str_get_fail (first, " "));
+						r_str_append (out, r_str_get_fail (second, " "));
 						r_list_append (list, out);
 					}
 				}


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

r_str_get_fail() has been added in appropriate locations throughout the code base after being noticed during the process of adding the PJ API in various files. Additionally, two missing r_str_getf() instances have been added.

The name of r_str_get_fail() is still subject to change. I welcome any suggestions for a new, more descriptive/concise name.