### PR TITLE
Fix incorrect style guide for switch statements in DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -48,7 +48,7 @@ You may find some additional notes on this topic in doc/vim.
   cases are indented at the switch level.
 
 ```c
-switch(n) {
+switch (n) {
 case 1:
 	break;
 case 2:


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

Added a missing space in the expected style for switch statements in DEVELOPERS.md.