### PR TITLE
Add sign extension assignment operator

### DIFF
--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -332,3 +332,18 @@ EXPECT=<<EOF
 0xffffffffffffff12
 EOF
 RUN
+
+NAME=sign extension assignement
+FILE=-
+CMDS=<<EOF
+e asm.arch=riscv
+e asm.bits=32
+"ae 0x8007,a0,=,0x5,a1,=,16,a0,~=,8,a1,~="
+ar a0
+ar a1
+EOF
+EXPECT=<<EOF
+0xffff8007
+0x00000005
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Introduce new **~=** operator doing sign extension assignment of a register. For example:
```
> "ae 0x81,a0,="
> "ae 8,a0,~="
> ar a0
0xffffff81
```
This would simplify a lot of ESIL expressions for architecture using sign extension.
