### PR TITLE
Fix type check and mem leak in w32_desc_list()

### DIFF
--- a/libr/debug/p/native/windows/windows_debug.c
+++ b/libr/debug/p/native/windows/windows_debug.c
@@ -1486,7 +1486,8 @@ RList *w32_desc_list(int pid) {
 			CloseHandle (dupHandle);
 			continue;
 		}
-		if (memcmp (L"File", objectTypeInfo->Name.Buffer, sizeof ("File"))) {
+		if (wcscmp (objectTypeInfo->Name.Buffer, L"File")) {
+			CloseHandle (dupHandle);
 			continue;
 		}
 		GENERIC_MAPPING *gm = &objectTypeInfo->GenericMapping;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This check works almostly as expexted but it compares only first 2.5 (ok, first 3) chars since `sizeof("File")` is 5.

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
