### PR TITLE
Fix version string from git formerly known as GIT_TAP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ all: plugins.cfg libr/include/r_version.h
 	${MAKE} -C libr
 	${MAKE} -C binr
 
-GIT_TAP=$(shell git tag -l --sort=refname | grep -e '^\d.\d.\d$$' | tail -n1 || echo $(VERSION))
+GIT_TAP=$(shell git tag -l --sort=refname | grep '^[0-9]\.[0-9]' | tail -n1 || echo $(VERSION))
 GIT_TIP=$(shell git rev-parse HEAD 2>/dev/null || echo HEAD)
 R2_VER=$(shell ./configure -qV)
 ifdef SOURCE_DATE_EPOCH


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
