### PR TITLE
Use tab width 8 in editor configuration templates ##doc

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -310,17 +310,17 @@ Vim/Neovim:
 
 ```vim
 setl cindent
-setl tabstop=4
+setl tabstop=8
 setl noexpandtab
-setl cino=:0,+0,(2,J0,{1,}0,>4,)1,m2
+setl cino=:0,+0,(2,J0,{1,}0,>8,)1,m1
 ```
 
 Emacs:
 
 ```elisp
 (c-add-style "radare2"
-             '((c-basic-offset . 4)
-               (tab-width . 4)
+             '((c-basic-offset . 8)
+               (tab-width . 8)
                (indent-tabs-mode . t)
                ;;;; You would need (put 'c-auto-align-backslashes 'safe-local-variable 'booleanp) to enable this
                ;; (c-auto-align-backslashes . nil)


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: None
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Also set cino-m to 1 because `setl cino=mN` option is just a zero/non-zero flag, there is no need to set it to 2.