### PR TITLE
Add test to arm.winedbg

### DIFF
--- a/libr/anal/rtti_msvc.c
+++ b/libr/anal/rtti_msvc.c
@@ -585,9 +585,6 @@ static bool rtti_msvc_print_complete_object_locator_recurse(RVTableContext *cont
 		if (use_json) {
 			pj_o (pj);
 			pj_k (pj, "desc");
-		}
-
-		if (use_json) {
 			rtti_msvc_print_base_class_descriptor_json (pj, bcd);
 		} else {
 			rtti_msvc_print_base_class_descriptor (bcd, "\t\t");

--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -309,7 +309,7 @@ R_API void r_anal_list_vtables(RAnal *anal, int rad) {
 				const char *const name = fcn ? fcn->name : NULL;
 				pj_o (pj);
 				pj_kN (pj, "offset", curMethod->addr);
-				pj_ks (pj, "name", name ? name : noMethodName);
+				pj_ks (pj, "name", r_str_get_fail (name, noMethodName));
 				pj_end (pj);
 			}
 			pj_end (pj);
@@ -342,7 +342,7 @@ R_API void r_anal_list_vtables(RAnal *anal, int rad) {
 			r_vector_foreach (&table->methods, curMethod) {
 				RAnalFunction *fcn = r_anal_get_fcn_in (anal, curMethod->addr, 0);
 				const char *const name = fcn ? fcn->name : NULL;
-				r_cons_printf ("0x%08"PFMT64x" : %s\n", vtableStartAddress, name ? name : noMethodName);
+				r_cons_printf ("0x%08"PFMT64x" : %s\n", vtableStartAddress, r_str_get_fail (name, noMethodName));
 				vtableStartAddress += context.word_size;
 			}
 			r_cons_newline ();

--- a/libr/asm/arch/arm/winedbg/be_arm.c
+++ b/libr/asm/arch/arm/winedbg/be_arm.c
@@ -442,7 +442,6 @@ static ut16 thumb_disasm_pushpop(struct winedbg_arm_insn *arminsn, ut16 inst) {
 static ut16 thumb_disasm_blocktrans(struct winedbg_arm_insn *arminsn, ut16 inst) {
 	short load = (inst >> 11) & 0x01;
 	short i;
-	short last;
 	bool first = true;
 
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s %s!, {", load ? "ldmia" : "stmia", tbl_regs[(inst >> 8) & 0x07]);

--- a/libr/asm/arch/arm/winedbg/be_arm.c
+++ b/libr/asm/arch/arm/winedbg/be_arm.c
@@ -142,9 +142,8 @@ static ut32 arm_disasm_mrstrans(struct winedbg_arm_insn *arminsn, ut32 inst) {
 static ut32 arm_disasm_msrtrans(struct winedbg_arm_insn *arminsn, ut32 inst) {
 	short immediate = (inst >> 25) & 0x01;
 	short dst = (inst >> 22) & 0x01;
-	short simple = (inst >> 16) & 0x01;
 
-	if (simple || !immediate) {
+	if (!immediate) {
 		arminsn->str_asm = r_str_appendf (arminsn->str_asm, "msr%s %s, %s", get_cond (inst), dst ? "spsr" : "cpsr",
 				tbl_regs[get_nibble (inst, 0)]);
 		return 0;
@@ -310,25 +309,14 @@ static ut32 arm_disasm_blocktrans(struct winedbg_arm_insn *arminsn, ut32 inst) {
 	short psr       = (inst >> 22) & 0x01;
 	short addrmode  = (inst >> 23) & 0x03;
 	short i;
-	short last=15;
+	bool first = true;
 
-	for (i=15;i>=0;i--) {
-		if ((inst>>i) & 1) {
-			last = i;
-			break;
-		}
-	}
-
-	//TODO PJ
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s%s %s%s, {", load ? "ldm" : "stm", tbl_addrmode[addrmode],
 			get_cond (inst), tbl_regs[get_nibble (inst, 4)], writeback ? "!" : "");
-	for (i=0;i<=15;i++) {
-		if ((inst>>i) & 1) {
-			if (i == last) {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s", tbl_regs[i]);
-			} else {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s, ", tbl_regs[i]);
-			}
+	for (i = 0; i <= 15; i++, inst >>= 1) {
+		if (inst & 1) {
+			arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s", first ? "" : ", ", tbl_regs[i]);
+			first = false;
 		}
 	}
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "}%s", psr ? "^" : "");
@@ -342,28 +330,28 @@ static ut32 arm_disasm_swi(struct winedbg_arm_insn *arminsn, ut32 inst) {
 }
 
 static ut32 arm_disasm_coproctrans(struct winedbg_arm_insn *arminsn, ut32 inst) {
-	ut16 CRm    = inst & 0x0f;
-	ut16 CP     = (inst >> 5)  & 0x07;
-	ut16 CPnum  = (inst >> 8)  & 0x0f;
-	ut16 CRn    = (inst >> 16) & 0x0f;
-	ut16 load   = (inst >> 20) & 0x01;
-	ut16 CP_Opc = (inst >> 21) & 0x07;
+	ut16 CRm     = inst & 0x0f;
+	ut16 CP_Opc2 = (inst >> 5)  & 0x07;
+	ut16 CPnum   = (inst >> 8)  & 0x0f;
+	ut16 CRn     = (inst >> 16) & 0x0f;
+	ut16 load    = (inst >> 20) & 0x01;
+	ut16 CP_Opc1 = (inst >> 21) & 0x07;
 
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s %u, %u, %s, cr%u, cr%u, {%u}", load ? "mrc" : "mcr",
-			get_cond (inst), CPnum, CP, tbl_regs[get_nibble (inst, 3)], CRn, CRm, CP_Opc);
+			get_cond (inst), CPnum, CP_Opc1, tbl_regs[get_nibble (inst, 3)], CRn, CRm, CP_Opc2);
 	return 0;
 }
 
 static ut32 arm_disasm_coprocdataop(struct winedbg_arm_insn *arminsn, ut32 inst) {
-	ut16 CRm    = inst & 0x0f;
-	ut16 CP     = (inst >> 5)  & 0x07;
-	ut16 CPnum  = (inst >> 8)  & 0x0f;
-	ut16 CRd    = (inst >> 12) & 0x0f;
-	ut16 CRn    = (inst >> 16) & 0x0f;
-	ut16 CP_Opc = (inst >> 20) & 0x0f;
+	ut16 CRm     = inst & 0x0f;
+	ut16 CP_Opc2 = (inst >> 5)  & 0x07;
+	ut16 CPnum   = (inst >> 8)  & 0x0f;
+	ut16 CRd     = (inst >> 12) & 0x0f;
+	ut16 CRn     = (inst >> 16) & 0x0f;
+	ut16 CP_Opc1 = (inst >> 20) & 0x0f;
 
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "cdp%s %u, %u, cr%u, cr%u, cr%u, {%u}", get_cond (inst),
-			CPnum, CP, CRd, CRn, CRm, CP_Opc);
+			CPnum, CP_Opc1, CRd, CRn, CRm, CP_Opc2);
 	return 0;
 }
 
@@ -433,30 +421,18 @@ static ut16 thumb_disasm_pushpop(struct winedbg_arm_insn *arminsn, ut16 inst) {
 	short lrpc = (inst >> 8)  & 0x01;
 	short load = (inst >> 11) & 0x01;
 	short i;
-	short last;
+	bool first = true;
 
-	for (i=7;i>=0;i--) {
-		if ((inst>>i) & 1) {
-			break;
-		}
-	}
-	last = i;
-
-	//TODO PJ
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s {", load ? "pop" : "push");
 
-	for (i=0;i<=7;i++) {
-		if ((inst>>i) & 1) {
-			if (i == last) {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s", tbl_regs[i]);
-			}
-			else {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s, ", tbl_regs[i]);
-			}
+	for (i = 0; i <= 7; i++, inst >>= 1) {
+		if (inst & 1) {
+			arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s", first ? "" : ", ", tbl_regs[i]);
+			first = false;
 		}
 	}
 	if (lrpc) {
-		arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s", last ? ", " : "", load ? "pc" : "lr");
+		arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s", first ? "" : ", ", load ? "pc" : "lr");
 	}
 
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "}");
@@ -467,25 +443,14 @@ static ut16 thumb_disasm_blocktrans(struct winedbg_arm_insn *arminsn, ut16 inst)
 	short load = (inst >> 11) & 0x01;
 	short i;
 	short last;
+	bool first = true;
 
-	for (i=7;i>=0;i--) {
-		if ((inst>>i) & 1) {
-			break;
-		}
-	}
-	last = i;
-
-	//TODO PJ
 	arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s %s!, {", load ? "ldmia" : "stmia", tbl_regs[(inst >> 8) & 0x07]);
 
-	for (i=0;i<=7;i++) {
-		if ((inst>>i) & 1) {
-			if (i == last) {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s", tbl_regs[i]);
-			}
-			else {
-				arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s, ", tbl_regs[i]);
-			}
+	for (i = 0; i <= 7; i++, inst >>= 1) {
+		if (inst & 1) {
+			arminsn->str_asm = r_str_appendf (arminsn->str_asm, "%s%s", first ? "" : ", ", tbl_regs[i]);
+			first = false;
 		}
 	}
 

--- a/test/db/asm/arm.winedbg_32
+++ b/test/db/asm/arm.winedbg_32
@@ -1,0 +1,33 @@
+d "bl 0x1900" 3e0600eb
+d "b 0x1900" 3e0600ea
+d "mlaeq r7, r5, r7, r0" 95072700
+d "mlane r3, r1, r3, r2" 91232310
+d "mulne r3, r3, r0" 93000310
+d "smlal r4, r1, r2, r3" 9243e1e0
+d "smull r4, r1, r2, r3" 9243c1e0
+d "umlalne r4, r5, r3, r7" 9347a510
+d "umull r4, r5, r3, r7" 934785e0
+d "swp r1, r2, [r0]" 921000e1
+d "swpb r1, r2, [r0]" 921040e1
+d "beq 0x8" 0000000a
+d "bxeq lr" 1eff2f01
+d "bxne lr" 1eff2f11
+d "mrs r1, cpsr" 00100fe1
+d "msr cpsr, r1" 01f029e1
+d "msr cpsr, #13" 0df029e3
+d "moveq r0, r10" 0a00a001
+d "nopeq" 00f02003
+d "addeq r1, r1, r0" 00108100
+d "andeq r3, r5, #2147483648" 02310502
+d "addeq r1, r1, r2, lsl #2" 02118100
+d "orrne r0, r0, r1, lsl ip" 110c8011
+d "ldr r1, [r2, r3]" 031092e7
+d "ldr r1, [r2, r3, lsl #2]" 031192e7
+d "ldmdbeq r2, {r0, r1}" 03001209
+d "stmiaeq r0, {r2, r3}" 0c008008
+d "swi #3" 030000ef
+d "mrc 5, 1, r4, cr2, cr4, {6}" d44532ee
+d "mcr 1, 2, r3, cr4, cr5, {6}" d53144ee
+d "cdp 1, 2, cr3, cr4, cr5, {6}" c53124ee
+d "ldc 0, cr1, [r3, #4]!" 0110b3ed
+d "stc 1, cr2, [r4, #-4]!" 012124ed

--- a/test/db/asm/arm_32
+++ b/test/db/asm/arm_32
@@ -192,7 +192,6 @@ d "uxtbeq r1, r0" 7010ef06
 d "uxtheq r0, r0" 7000ff06
 d "vstreq d0, [r0]" 000b800d
 d "blne 0x1900" 8374211b 0xff7a46ec
-a "addeq r1, r1, r0" 00108100
 aB "addeq r1, r1, r2, lsl 2" 02118100
 a "addne r1, r1, ip" 0c108110
 aB "addne r1, r1, r0, lsl 2" 00118110
@@ -202,7 +201,6 @@ a "andne r3, r3, r2" 02300310
 a "andne ip, ip, r7" 07c00c10
 aB "asreq r0, ip, 0x1f" cc0fa001
 aB "asrne r0, r4, 0x1f" c40fa011
-a "beq 8" 0000000a
 aB "biceq r3, r3, 7" 0730c303
 a "blne 0x1900" 3E06001B
 a "bl 0x1900" 3e0600eb
@@ -228,7 +226,6 @@ aB "lsreq r0, r0, 0x10" 2008a001
 aB "lsrne r0, r0, 9" a004a011
 aB "mlaeq r7, r5, r7, r0" 95072700
 aB "mlane r3, r1, r3, r2" 91232310
-a "moveq r0, sl" 0a00a001
 aB "movne r0, sb" 0900a011
 aB "mulne r3, r3, r0" 93000310
 a "mvneq r0, 0x15" 1500e003


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Some problems noticed when applying @Lazula 's pj patches.
* The return value of `pj_drain` should be manually freed, so better use `pj_string` instead.
* be_arm.c produces something like `ldmdbeq r2, {r0, r1}`, which is not json so pj cannot be applied.
* arm.winedbg lacks tests. I added some from db/asm/arm_32 and find bugs on `msr`, `mrc/mcr` and `cdp`. I fixed them according to [ARM datasheet](https://developer.arm.com/documentation/ddi0406/latest/) B9.3.10, B9.3.11, A8.8.112, A8.8.108 and A8.8.30.
* Removed 3 duplicate tests in db/asm/arm_32