### PR TITLE
Disable coverage from the newshell runs (takes 1h to finish) ##ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,12 @@ jobs:
             compiler: gcc
             newshell: true
             run_tests: true
-            meson_options: -Db_coverage=true -Duse_webui=true
-            coverage: true
-            enabled: true
-            timeout: 60
-            cflags: '-Werror -Wno-cpp'
+            # meson_options: -Db_coverage=true -Duse_webui=true
+            meson_options: -Duse_webui=true
+            ## coverage: true
+            # enabled: true
+            # timeout: 60
+            # cflags: '-Werror -Wno-cpp'
           - name: macos-acr-clang-tests
             os: macos-latest
             build_system: acr
@@ -198,9 +199,9 @@ jobs:
         NEWSHELL: ${{ matrix.newshell }}
         ASAN: ${{ matrix.asan }}
         ASAN_OPTIONS: ${{ matrix.asan_options }}
-    - name: Upload coverage info
-      uses: codecov/codecov-action@v1
-      if: matrix.coverage == '1' && matrix.enabled
+    # - name: Upload coverage info
+    #   uses: codecov/codecov-action@v1
+    #   if: matrix.coverage == '1' && matrix.enabled
     - name: Run fuzz tests
       if: matrix.run_tests && matrix.enabled && (github.event_name != 'pull_request' || contains(github.event.pull_request.head.ref, 'fuzz'))
       run: |


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

opinion on disabling coverage?
it makes newtests-meson builds to take 1h to run the testsuite, otherwise it takes about 20min
i dont think waiting 1h makes sense to determine if newshell is not passing a test
can be done on a separate task only for some commits
maybe in master only, not in PRs