### PR TITLE
Fix memleak in `r2` and test_big

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ don't need to reinstall every time you change something in the builddir.
 
 Alternatively you can also build with meson + ninja:
 
-	$ ./sys/meson.py --prefix=/usr --shared --install
+	$ sys/meson.py --prefix=/usr --shared --install
 
 Or install in your home with meson + ninja:
 
-	$ ./sys/meson.py --prefix=/home/$USER/r2meson --local --shared --install
+	$ sys/meson.py --prefix=$HOME/r2meson --local --shared --install
 
 ## Uninstall
 

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -351,7 +351,6 @@ R_API int r_main_radare2(int argc, const char **argv) {
 	bool do_list_io_plugins = false;
 	char *file = NULL;
 	char *pfile = NULL;
-	char *debugbackend = strdup ("native");
 	const char *asmarch = NULL;
 	const char *asmos = NULL;
 	const char *forcebin = NULL;
@@ -450,7 +449,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 
 	set_color_default (r);
 	bool load_l = true;
-
+	char *debugbackend = strdup ("native");
 	RGetopt opt;
 	r_getopt_init (&opt, argc, argv, "=02AMCwxfF:H:hm:e:nk:NdqQs:p:b:B:a:Lui:I:l:P:R:r:c:D:vVSTzuXt");
 	while ((c = r_getopt_next (&opt)) != -1) {

--- a/test/db/cmd/cmd_project
+++ b/test/db/cmd/cmd_project
@@ -275,6 +275,7 @@ NAME=Save project for a binary without saving its info
 FILE=bins/elf/analysis/main
 ARGS=-n
 CMDS=<<EOF
+e prj.git=false
 e dir.projects = .tmp/
 Ps blub > /dev/null
 Po blub > /dev/null

--- a/test/unit/test_big.c
+++ b/test/unit/test_big.c
@@ -461,6 +461,7 @@ static bool test_r_big_powm(void) {
 	r_big_free (a);
 	r_big_free (b);
 	r_big_free (c);
+	r_big_free (m);
 	mu_end;
 }
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
#18150 
```sh
liumeo@liumeo-x64:~/r2asan$ r2
Usage: r2 [-ACdfLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-i file]
          [-s addr] [-B baddr] [-m maddr] [-c cmd] [-e k=v] file|pid|-|--|=

=================================================================
==5850==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 7 byte(s) in 1 object(s) allocated from:
    #0 0x7fe452eb2257 in __interceptor_strdup (/lib/x86_64-linux-gnu/libasan.so.6+0x5a257)
    #1 0x7fe4523610eb in r_main_radare2 /home/liumeo/radare2/libr/main/radare2.c:354
    #2 0x564ad29fe85f in main /home/liumeo/radare2/binr/radare2/radare2.c:96
    #3 0x7fe451791cb1 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x28cb1)

SUMMARY: AddressSanitizer: 7 byte(s) leaked in 1 allocation(s).
```
It was awful.
Also modify README because mac has a difference directory hierarchy.