### PR TITLE
Fix memleak in test_buf & test_cmd

### DIFF
--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -460,7 +460,9 @@ static void fill_children_chars(RStrBuf *sb, RCmdDesc *cd) {
 		r_strbuf_prepend (&csb, "<");
 		r_strbuf_append (&csb, ">");
 	}
-	r_strbuf_append (sb, r_strbuf_drain_nofree (&csb));
+	char *tmp = r_strbuf_drain_nofree (&csb);
+	r_strbuf_append (sb, tmp);
+	free (tmp);
 }
 
 static bool show_children_shortcut(RCmdDesc *cd) {

--- a/test/unit/test_buf.c
+++ b/test/unit/test_buf.c
@@ -122,6 +122,7 @@ bool test_r_buf_file(void) {
 	// Cleanup
 	r_buf_free (b);
 	unlink (filename);
+	free (filename);
 	mu_end;
 }
 
@@ -165,6 +166,7 @@ bool test_r_buf_mmap(void) {
 	// Cleanup
 	r_buf_free (b);
 	unlink(filename);
+	free (filename);
 	mu_end;
 }
 

--- a/test/unit/test_cmd.c
+++ b/test/unit/test_cmd.c
@@ -166,6 +166,7 @@ bool test_cmd_descriptor_group(void) {
 	free (h);
 
 	r_cmd_free (cmd);
+	r_cmd_parsed_args_free (pa);
 	mu_end;
 }
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
#18150 