### PR TITLE
Implement print disasm until optype ##print

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -453,7 +453,7 @@ static const char *help_msg_pi[] = {
 	"pif", "[?]", "print instructions of function",
 	"pij", "", "print N instructions in JSON",
 	"pir", "", "like 'pdr' but with 'pI' output",
-	"piu", "[q] [instruction]", "disassemble until instruction is found",
+	"piu", "[q] [instruction]", "disassemble until instruction of given optype is found",
 	"pix", "  [hexpairs]", "alias for pdx and pad",
 	NULL
 };

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4191,7 +4191,6 @@ dsmap {
 #define P(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 
 static void disasm_until_optype(RCore *core, ut64 addr, char type_print, int optype, int limit) {
-
 	int p = 0;
 	const bool show_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 	int i;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -453,7 +453,7 @@ static const char *help_msg_pi[] = {
 	"pif", "[?]", "print instructions of function",
 	"pij", "", "print N instructions in JSON",
 	"pir", "", "like 'pdr' but with 'pI' output",
-	"piu", "[q] [limit]", "disasm until ujmp or ret is found (see pdp)",
+	"piu", "[q] [instruction]", "disassemble until instruction is found",
 	"pix", "  [hexpairs]", "alias for pdx and pad",
 	NULL
 };
@@ -4190,13 +4190,10 @@ dsmap {
 
 #define P(x) (core->cons && core->cons->context->pal.x)? core->cons->context->pal.x
 
-static void disasm_until_ret(RCore *core, ut64 addr, char type_print, const char *arg) {
+static void disasm_until_optype(RCore *core, ut64 addr, char type_print, int optype, int limit) {
 	int p = 0;
 	const bool show_color = core->print->flags & R_PRINT_FLAGS_COLOR;
-	int i, limit = 1024;
-	if (arg && *arg && arg[1]) {
-		limit = r_num_math (core->num, arg + 1);
-	}
+	int i;
 	for (i = 0; i < limit; i++) {
 		RAnalOp *op = r_core_anal_op (core, addr, R_ANAL_OP_MASK_BASIC | R_ANAL_OP_MASK_DISASM);
 		if (op) {
@@ -4215,12 +4212,8 @@ static void disasm_until_ret(RCore *core, ut64 addr, char type_print, const char
 					r_cons_printf ("0x%08"PFMT64x"  %10s %s\n", addr + p, "", m);
 				}
 			}
-			switch (op->type & 0xfffff) {
-			case R_ANAL_OP_TYPE_RET:
-			case R_ANAL_OP_TYPE_UJMP:
+			if ((op->type & 0xfffff) == optype) {
 				goto beach;
-				break;
-
 			}
 			if (op->type == R_ANAL_OP_TYPE_JMP) {
 				addr = op->jump;
@@ -4252,7 +4245,7 @@ static void disasm_ropchain(RCore *core, ut64 addr, char type_print) {
 			n = r_read_ble32 (buf + p, be);
 		}
 		r_cons_printf ("[0x%08"PFMT64x"] 0x%08"PFMT64x"\n", addr + p, n);
-		disasm_until_ret (core, n, type_print, NULL);
+		disasm_until_optype (core, n, type_print, R_ANAL_OP_TYPE_RET, 1024);
 		if (core->rasm->bits == 64) {
 			p += 8;
 		} else {
@@ -5012,9 +5005,27 @@ static int cmd_print(void *data, const char *input) {
 			// r_cons_printf ("|Usage: pi[defj] [num]\n");
 			r_core_cmd_help (core, help_msg_pi);
 			break;
-		case 'u': // "piu" disasm until ret/jmp . todo: accept arg to specify type
-			disasm_until_ret (core, core->offset, input[2], input + 2);
-			break;
+		case 'u': // "piu" disasm until given optype
+		{
+			int optype = -1;
+			char print_type = 0;
+			const char *_input = input;
+			if (_input[2] && _input[2] != ' ') {
+				print_type = _input[2];
+				_input++;
+			}
+			if (_input[2] && _input[3]) {
+				// TODO: add limit as arg
+				const char *instruction = r_str_word_get_first (_input + 3);
+				optype = r_anal_optype_from_string (instruction);
+				if (optype == -1) {
+					optype = R_ANAL_OP_TYPE_RET;
+				}
+			} else {
+				optype = R_ANAL_OP_TYPE_RET;
+			}
+			disasm_until_optype (core, core->offset, print_type, optype, 1024);
+		} break;
 		case 'x': // "pix"
 			__cmd_pad (core, r_str_trim_head_ro (input + 2));
 			break;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -453,7 +453,7 @@ static const char *help_msg_pi[] = {
 	"pif", "[?]", "print instructions of function",
 	"pij", "", "print N instructions in JSON",
 	"pir", "", "like 'pdr' but with 'pI' output",
-	"piu", "[q] [instruction]", "disassemble until instruction of given optype is found",
+	"piu", "[q] [optype]", "disassemble until instruction of given optype is found (See /atl)",
 	"pix", "  [hexpairs]", "alias for pdx and pad",
 	NULL
 };


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

- Replaces the old `disasm_until_ret` to allow specific optype from `R_ANAL_OP_TYPE_*` members.
- Replaces command `piu` to allow specifying a instruction, like `piu add` to disasm until first `add` opcode.

Example
```
[0x08000040]> pi 11
push rbp
mov rbp, rsp
mov dword [var_ch], 5
mov dword [var_8h], 7
mov edx, dword [var_ch]
mov eax, dword [var_8h]
add eax, edx
mov dword [var_4h], eax
mov eax, dword [var_4h]
pop rbp
ret
[0x08000040]> piuq add
push rbp
mov rbp, rsp
mov dword ptr [rbp - 0xc], 5
mov dword ptr [rbp - 8], 7
mov edx, dword ptr [rbp - 0xc]
mov eax, dword ptr [rbp - 8]
add eax, edx
[0x08000040]> piu pop
0x08000040             push rbp
0x08000041             mov rbp, rsp
0x08000044             mov dword ptr [rbp - 0xc], 5
0x0800004b             mov dword ptr [rbp - 8], 7
0x08000052             mov edx, dword ptr [rbp - 0xc]
0x08000055             mov eax, dword ptr [rbp - 8]
0x08000058             add eax, edx
0x0800005a             mov dword ptr [rbp - 4], eax
0x0800005d             mov eax, dword ptr [rbp - 4]
0x08000060             pop rbp
[0x08000040]> pi?
Usage: pi[bdefrj] [num]
| pia                   print all possible opcodes (byte per byte)
| pib                   print instructions of basic block
| pid                   alias for pdi
| pie                   print offset + esil expression
| pif[?]                print instructions of function
| pij                   print N instructions in JSON
| pir                   like 'pdr' but with 'pI' output
| piu[q] [instruction]  disassemble until instruction is found
| pix  [hexpairs]       alias for pdx and pad
```

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
