### PR TITLE
Esil float

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -5,6 +5,11 @@
 #include <r_util.h>
 #include <r_bind.h>
 
+// should these be here?
+#include <math.h>
+#include <float.h>
+#include <fenv.h>
+
 #define IFDBG if (esil && esil->verbose > 1)
 #define IFVBS if (esil && esil->verbose > 0)
 #define FLG(x) R_ANAL_ESIL_FLAG_##x
@@ -2907,6 +2912,506 @@ static bool esil_set_delay_slot(RAnalEsil *esil) {
 	return ret;
 }
 
+/*
+	OP ("NAN", esil_is_nan, 1, 1, OT_MATH);
+	OP ("I2D", esil_int_to_double, 1, 1, OT_MATH);
+	OP ("D2I", esil_double_to_int, 1, 1, OT_MATH);
+	OP ("D2F", esil_double_to_float, 1, 2, OT_MATH);
+	OP ("F2D", esil_float_to_double, 1, 2, OT_MATH);
+	OP ("F==", esil_float_cmp, 1, 2, OT_MATH);
+	OP ("F!=", esil_float_negcmp, 1, 2, OT_MATH);
+	OP ("F<", esil_float_less, 1, 2, OT_MATH);
+	OP ("F<=", esil_float_lesseq, 1, 2, OT_MATH);
+	OP ("F+", esil_float_add, 1, 2, OT_MATH);
+	OP ("F-", esil_float_sub, 1, 2, OT_MATH);
+	OP ("F*", esil_float_mul, 1, 2, OT_MATH);
+	OP ("F/", esil_float_div, 1, 2, OT_MATH);
+	OP ("-F", esil_float_neg, 1, 1, OT_MATH);
+	OP ("CEIL", esil_float_ceil, 1, 1, OT_MATH);
+	OP ("FLOOR", esil_float_floor, 1, 1, OT_MATH);
+	OP ("ROUND", esil_float_round, 1, 1, OT_MATH);
+	OP ("SQRT", esil_float_sqrt, 1, 1, OT_MATH);
+*/
+
+static int esil_get_parm_float(RAnalEsil *esil, const char *str, double *num)
+{
+	return r_anal_esil_get_parm(esil, str, (ut64 *)num);
+}
+
+static bool esil_pushnum_float(RAnalEsil *esil, double num)
+{
+	return r_anal_esil_pushnum(esil, *(ut64 *)&num);
+}
+
+static bool esil_is_nan(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			ret = r_anal_esil_pushnum(esil, isnan(s));
+		}
+		else {
+			ERR("esil_is_nan: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_is_nan: fail to get argument from stack.");
+	}
+	return ret;
+}
+
+static bool esil_int_to_double(RAnalEsil *esil) {
+	bool ret = false;
+	st64 s;
+	char *src = r_anal_esil_pop(esil);
+	if (src) {
+		if (r_anal_esil_get_parm(esil, src, (ut64 *)&s)) {
+			ret = esil_pushnum_float(esil, (double)s * 1.0);
+		}
+		else {
+			ERR("esil_int_to_float: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_int_to_float: fail to get argument from stack.");
+	}
+	return ret;
+}
+
+static bool esil_double_to_int(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			if (isnan(s) || isinf(s)) {
+				ERR("esil_float_to_int: nan or inf detected.");
+			}
+			ret = r_anal_esil_pushnum(esil, (st64)(s));
+		}
+		else {
+			ERR("esil_float_to_int: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_to_int: fail to get argument from stack.");
+	}
+	return ret;
+}
+
+static bool esil_double_to_float(RAnalEsil *esil) {
+	bool ret = false;
+	double d;
+	ut64 s = 0;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (r_anal_esil_get_parm(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(d) || isinf(d)) {
+			ret = r_anal_esil_pushnum(esil, *(ut64 *)&d);
+		}
+		else if (s == 4) {
+			float f = (float)d;
+			ret = r_anal_esil_pushnum(esil, *(ut64 *)&f);
+		}
+		else if (s == 8) {
+			double f = (double)d;
+			ret = r_anal_esil_pushnum(esil, *(ut64 *)&f);
+		}
+		/* TODO: support long double
+		else if(s == 10) {
+			long double f = (long double)d;
+			ret = r_anal_esil_pushnum(esil, *(ut64 *)&f);
+		}*/
+		else {
+			ret = r_anal_esil_pushnum(esil, *(ut64 *)&d);
+		}
+	}
+	else {
+		ERR("esil_float_to_float: invalid parameters.");
+	}
+
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_to_double(RAnalEsil *esil) {
+	bool ret = false;
+	double d;
+	ut64 s = 0;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (r_anal_esil_get_parm(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(d) || isinf(d)) {
+			ret = esil_pushnum_float(esil, d);
+		}
+		else if (s == 4) {
+			ret = esil_pushnum_float(esil, (double)(*(float  *)&d));
+		}
+		else if (s == 8) {
+			ret = esil_pushnum_float(esil, (double)(*(double *)&d));
+		}
+		/*else if(s == 10)
+			ret = esil_pushnum_float(esil, (double)(*(long double *)&d));
+		*/
+		else {
+			ret = esil_pushnum_float(esil, d);
+		}
+	}
+	else {
+		ERR("esil_float_to_float: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_cmp(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (src && dst && esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s) || isnan(d)) {
+			ret = r_anal_esil_pushnum(esil, 0);
+		}
+		else {
+			ret = r_anal_esil_pushnum(esil, fabs(s - d) <= DBL_EPSILON);
+		}
+	}
+	else {
+		ERR("esil_float_cmp: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_negcmp(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (src && dst && esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s) || isnan(d)) {
+			ret = r_anal_esil_pushnum(esil, 0);
+		}
+		else {
+			ret = r_anal_esil_pushnum(esil, fabs(s - d) >= DBL_EPSILON);
+		}
+	}
+	else {
+		ERR("esil_float_negcmp: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_less(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s) || isnan(d)) {
+			ret = r_anal_esil_pushnum(esil, 0);
+		}
+		else {
+			ret = r_anal_esil_pushnum(esil, s < d);
+		}
+	}
+	else {
+		ERR("esil_float_less: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_lesseq(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s) || isnan(d)) {
+			ret = r_anal_esil_pushnum(esil, 0);
+		}
+		else {
+			ret = r_anal_esil_pushnum(esil, s <= d);
+		}
+	}
+	else {
+		ERR("esil_float_lesseq: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_add(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d))
+	{
+		if (isnan(s)) {
+			ret = esil_pushnum_float(esil, s);
+		}
+		else if (isnan(d)) {
+			ret = esil_pushnum_float(esil, d);
+		}
+		else {
+			feclearexcept(FE_OVERFLOW);
+			double tmp = s + d;
+			(void)(tmp); // suppress unused warning
+			int raised = fetestexcept(FE_OVERFLOW);
+			if (raised & FE_OVERFLOW)
+				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+			else
+				ret = esil_pushnum_float(esil, s + d);
+		}
+	}
+	else {
+		ERR("esil_float_add: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_sub(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s)) {
+			ret = esil_pushnum_float(esil, s);
+		}
+		else if (isnan(d)) {
+			ret = esil_pushnum_float(esil, d);
+		}
+		else {
+			feclearexcept(FE_OVERFLOW);
+			double tmp = d - s;
+			(void)(tmp);
+			int raised = fetestexcept(FE_OVERFLOW);
+			if (raised & FE_OVERFLOW) {
+				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+			}
+			else {
+				ret = esil_pushnum_float(esil, d - s);
+			}
+		}
+	}
+	else {
+		ERR("esil_float_sub: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_mul(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s)) {
+			ret = esil_pushnum_float(esil, s);
+		}
+		else if (isnan(d)) {
+			ret = esil_pushnum_float(esil, d);
+		}
+		else {
+			feclearexcept(FE_OVERFLOW);
+			double tmp = s * d;
+			(void)(tmp);
+			int raised = fetestexcept(FE_OVERFLOW);
+			if (raised & FE_OVERFLOW)
+				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+			else
+				ret = esil_pushnum_float(esil, s * d);
+		}
+	}
+	else {
+		ERR("esil_float_mul: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_div(RAnalEsil *esil) {
+	bool ret = false;
+	double s, d;
+	char *dst = r_anal_esil_pop(esil);
+	char *src = r_anal_esil_pop(esil);
+
+	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
+		if (isnan(s)) {
+			ret = esil_pushnum_float(esil, s);
+		}
+		else if (isnan(d)) {
+			ret = esil_pushnum_float(esil, d);
+		}
+		else {
+			feclearexcept(FE_OVERFLOW);
+			double tmp = d / s;
+			(void)(tmp);
+			int raised = fetestexcept(FE_OVERFLOW);
+			if (raised & FE_OVERFLOW)
+				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+			else
+				ret = esil_pushnum_float(esil, d / s);
+		}
+	}
+	else {
+		ERR("esil_float_div: invalid parameters.");
+	}
+	free(dst);
+	free(src);
+	return ret;
+}
+
+static bool esil_float_neg(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+
+	if (src)	{
+		if (esil_get_parm_float(esil, src, &s)) {
+			ret = esil_pushnum_float(esil, -s);
+		}
+		else {
+			ERR("esil_float_neg: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_neg: fail to get element from stack.");
+	}
+	return ret;
+}
+
+static bool esil_float_ceil(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			if (isnan(s)) {
+				ret = esil_pushnum_float(esil, s);
+			}
+			else {
+				ret = esil_pushnum_float(esil, ceil(s));
+			}
+		}
+		else {
+			ERR("esil_float_ceil: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_ceil: fail to get element from stack.");
+	}
+	return ret;
+}
+
+static bool esil_float_floor(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			if (isnan(s)) {
+				ret = esil_pushnum_float(esil, s);
+			}
+			else {
+				ret = esil_pushnum_float(esil, floor(s));
+			}
+		}
+		else {
+			ERR("esil_float_floor: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_floor: fail to get element from stack.");
+	}
+
+	return ret;
+}
+
+static bool esil_float_round(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			if (isnan(s)) {
+				ret = esil_pushnum_float(esil, s);
+			}
+			else {
+				ret = esil_pushnum_float(esil, round(s));
+			}
+		}
+		else {
+			ERR("esil_float_round: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_round: fail to get element from stack.");
+	}
+	return ret;
+}
+
+static bool esil_float_sqrt(RAnalEsil *esil) {
+	bool ret = false;
+	double s;
+	char *src = r_anal_esil_pop(esil);
+
+	if (src) {
+		if (esil_get_parm_float(esil, src, &s)) {
+			if (isnan(s)) {
+				ret = esil_pushnum_float(esil, s);
+			}
+			else {
+				ret = esil_pushnum_float(esil, sqrt(s));
+			}
+		}
+		else {
+			ERR("esil_float_sqrt: invalid parameters.");
+		}
+		free(src);
+	}
+	else {
+		ERR("esil_float_sqrt: fail to get element from stack.");
+	}
+	return ret;
+}
+
 static bool iscommand(RAnalEsil *esil, const char *word, RAnalEsilOp **op) {
 	RAnalEsilOp *eop = ht_pp_find (esil->ops, word, NULL);
 	if (eop) {
@@ -3379,6 +3884,27 @@ static void r_anal_esil_setup_ops(RAnalEsil *esil) {
 	OP ("SETJT", esil_set_jump_target, 0, 1, OT_UNK);
 	OP ("SETJTS", esil_set_jump_target_set, 0, 1, OT_UNK);
 	OP ("SETD", esil_set_delay_slot, 0, 1, OT_UNK);
+
+	/* we all float down here */
+	OP ("NAN", esil_is_nan, 1, 1, OT_MATH);
+	OP ("I2D", esil_int_to_double, 1, 1, OT_MATH);
+	OP ("D2I", esil_double_to_int, 1, 1, OT_MATH);
+	OP ("D2F", esil_double_to_float, 1, 2, OT_MATH);
+	OP ("F2D", esil_float_to_double, 1, 2, OT_MATH);
+	OP ("F==", esil_float_cmp, 1, 2, OT_MATH);
+	OP ("F!=", esil_float_negcmp, 1, 2, OT_MATH);
+	OP ("F<", esil_float_less, 1, 2, OT_MATH);
+	OP ("F<=", esil_float_lesseq, 1, 2, OT_MATH);
+	OP ("F+", esil_float_add, 1, 2, OT_MATH);
+	OP ("F-", esil_float_sub, 1, 2, OT_MATH);
+	OP ("F*", esil_float_mul, 1, 2, OT_MATH);
+	OP ("F/", esil_float_div, 1, 2, OT_MATH);
+	OP ("-F", esil_float_neg, 1, 1, OT_MATH);
+	OP ("CEIL", esil_float_ceil, 1, 1, OT_MATH);
+	OP ("FLOOR", esil_float_floor, 1, 1, OT_MATH);
+	OP ("ROUND", esil_float_round, 1, 1, OT_MATH);
+	OP ("SQRT", esil_float_sqrt, 1, 1, OT_MATH);
+
 }
 
 /* register callbacks using this anal module. */

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -2942,13 +2942,11 @@ static bool esil_is_nan(RAnalEsil *esil) {
 	if (src) {
 		if (esil_get_parm_float(esil, src, &s)) {
 			ret = r_anal_esil_pushnum(esil, isnan(s));
-		}
-		else {
+		} else {
 			ERR("esil_is_nan: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_is_nan: fail to get argument from stack.");
 	}
 	return ret;
@@ -2961,13 +2959,11 @@ static bool esil_int_to_double(RAnalEsil *esil) {
 	if (src) {
 		if (r_anal_esil_get_parm(esil, src, (ut64 *)&s)) {
 			ret = esil_pushnum_float(esil, (double)s * 1.0);
-		}
-		else {
+		} else {
 			ERR("esil_int_to_float: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_int_to_float: fail to get argument from stack.");
 	}
 	return ret;
@@ -2983,13 +2979,11 @@ static bool esil_double_to_int(RAnalEsil *esil) {
 				ERR("esil_float_to_int: nan or inf detected.");
 			}
 			ret = r_anal_esil_pushnum(esil, (st64)(s));
-		}
-		else {
+		} else {
 			ERR("esil_float_to_int: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_to_int: fail to get argument from stack.");
 	}
 	return ret;
@@ -3005,12 +2999,10 @@ static bool esil_double_to_float(RAnalEsil *esil) {
 	if (r_anal_esil_get_parm(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(d) || isinf(d)) {
 			ret = r_anal_esil_pushnum(esil, *(ut64 *)&d);
-		}
-		else if (s == 4) {
+		} else if (s == 32) {
 			float f = (float)d;
 			ret = r_anal_esil_pushnum(esil, *(ut64 *)&f);
-		}
-		else if (s == 8) {
+		} else if (s == 64) {
 			double f = (double)d;
 			ret = r_anal_esil_pushnum(esil, *(ut64 *)&f);
 		}
@@ -3022,8 +3014,7 @@ static bool esil_double_to_float(RAnalEsil *esil) {
 		else {
 			ret = r_anal_esil_pushnum(esil, *(ut64 *)&d);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_to_float: invalid parameters.");
 	}
 
@@ -3043,19 +3034,18 @@ static bool esil_float_to_double(RAnalEsil *esil) {
 		if (isnan(d) || isinf(d)) {
 			ret = esil_pushnum_float(esil, d);
 		}
-		else if (s == 4) {
+		else if (s == 32) {
 			ret = esil_pushnum_float(esil, (double)(*(float  *)&d));
 		}
-		else if (s == 8) {
+		else if (s == 64) {
 			ret = esil_pushnum_float(esil, (double)(*(double *)&d));
 		}
-		/*else if(s == 10)
+		/*else if(s == 80)
 			ret = esil_pushnum_float(esil, (double)(*(long double *)&d));*/
 		else {
 			ret = esil_pushnum_float(esil, d);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_to_float: invalid parameters.");
 	}
 	free(dst);
@@ -3072,12 +3062,10 @@ static bool esil_float_cmp(RAnalEsil *esil) {
 	if (src && dst && esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s) || isnan(d)) {
 			ret = r_anal_esil_pushnum(esil, 0);
-		}
-		else {
+		} else {
 			ret = r_anal_esil_pushnum(esil, fabs(s - d) <= DBL_EPSILON);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_cmp: invalid parameters.");
 	}
 	free(dst);
@@ -3094,12 +3082,10 @@ static bool esil_float_negcmp(RAnalEsil *esil) {
 	if (src && dst && esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s) || isnan(d)) {
 			ret = r_anal_esil_pushnum(esil, 0);
-		}
-		else {
+		} else {
 			ret = r_anal_esil_pushnum(esil, fabs(s - d) >= DBL_EPSILON);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_negcmp: invalid parameters.");
 	}
 	free(dst);
@@ -3116,12 +3102,10 @@ static bool esil_float_less(RAnalEsil *esil) {
 	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s) || isnan(d)) {
 			ret = r_anal_esil_pushnum(esil, 0);
-		}
-		else {
+		} else {
 			ret = r_anal_esil_pushnum(esil, s < d);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_less: invalid parameters.");
 	}
 	free(dst);
@@ -3138,12 +3122,10 @@ static bool esil_float_lesseq(RAnalEsil *esil) {
 	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s) || isnan(d)) {
 			ret = r_anal_esil_pushnum(esil, 0);
-		}
-		else {
+		} else {
 			ret = r_anal_esil_pushnum(esil, s <= d);
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_lesseq: invalid parameters.");
 	}
 	free(dst);
@@ -3161,24 +3143,20 @@ static bool esil_float_add(RAnalEsil *esil) {
 	{
 		if (isnan(s)) {
 			ret = esil_pushnum_float(esil, s);
-		}
-		else if (isnan(d)) {
+		} else if (isnan(d)) {
 			ret = esil_pushnum_float(esil, d);
-		}
-		else {
+		} else {
 			feclearexcept(FE_OVERFLOW);
 			double tmp = s + d;
 			(void)(tmp); // suppress unused warning
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
 				ret = esil_pushnum_float(esil, 0.0 / 0.0);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, s + d);
 			}
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_add: invalid parameters.");
 	}
 	free(dst);
@@ -3195,24 +3173,20 @@ static bool esil_float_sub(RAnalEsil *esil) {
 	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s)) {
 			ret = esil_pushnum_float(esil, s);
-		}
-		else if (isnan(d)) {
+		} else if (isnan(d)) {
 			ret = esil_pushnum_float(esil, d);
-		}
-		else {
+		} else {
 			feclearexcept(FE_OVERFLOW);
 			double tmp = d - s;
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
 				ret = esil_pushnum_float(esil, 0.0 / 0.0);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, d - s);
 			}
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_sub: invalid parameters.");
 	}
 	free(dst);
@@ -3229,24 +3203,20 @@ static bool esil_float_mul(RAnalEsil *esil) {
 	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s)) {
 			ret = esil_pushnum_float(esil, s);
-		}
-		else if (isnan(d)) {
+		} else if (isnan(d)) {
 			ret = esil_pushnum_float(esil, d);
-		}
-		else {
+		} else {
 			feclearexcept(FE_OVERFLOW);
 			double tmp = s * d;
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
 				ret = esil_pushnum_float(esil, 0.0 / 0.0);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, s * d);
 			}
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_mul: invalid parameters.");
 	}
 	free(dst);
@@ -3263,22 +3233,20 @@ static bool esil_float_div(RAnalEsil *esil) {
 	if (esil_get_parm_float(esil, src, &s) && esil_get_parm_float(esil, dst, &d)) {
 		if (isnan(s)) {
 			ret = esil_pushnum_float(esil, s);
-		}
-		else if (isnan(d)) {
+		} else if (isnan(d)) {
 			ret = esil_pushnum_float(esil, d);
-		}
-		else {
+		} else {
 			feclearexcept(FE_OVERFLOW);
 			double tmp = d / s;
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
-			if (raised & FE_OVERFLOW)
+			if (raised & FE_OVERFLOW) {
 				ret = esil_pushnum_float(esil, 0.0 / 0.0);
-			else
+			} else {
 				ret = esil_pushnum_float(esil, d / s);
+			}
 		}
-	}
-	else {
+	} else {
 		ERR("esil_float_div: invalid parameters.");
 	}
 	free(dst);
@@ -3294,13 +3262,11 @@ static bool esil_float_neg(RAnalEsil *esil) {
 	if (src)	{
 		if (esil_get_parm_float(esil, src, &s)) {
 			ret = esil_pushnum_float(esil, -s);
-		}
-		else {
+		} else {
 			ERR("esil_float_neg: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_neg: fail to get element from stack.");
 	}
 	return ret;
@@ -3315,17 +3281,14 @@ static bool esil_float_ceil(RAnalEsil *esil) {
 		if (esil_get_parm_float(esil, src, &s)) {
 			if (isnan(s)) {
 				ret = esil_pushnum_float(esil, s);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, ceil(s));
 			}
-		}
-		else {
+		} else {
 			ERR("esil_float_ceil: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_ceil: fail to get element from stack.");
 	}
 	return ret;
@@ -3340,17 +3303,14 @@ static bool esil_float_floor(RAnalEsil *esil) {
 		if (esil_get_parm_float(esil, src, &s)) {
 			if (isnan(s)) {
 				ret = esil_pushnum_float(esil, s);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, floor(s));
 			}
-		}
-		else {
+		} else {
 			ERR("esil_float_floor: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_floor: fail to get element from stack.");
 	}
 
@@ -3366,17 +3326,14 @@ static bool esil_float_round(RAnalEsil *esil) {
 		if (esil_get_parm_float(esil, src, &s)) {
 			if (isnan(s)) {
 				ret = esil_pushnum_float(esil, s);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, round(s));
 			}
-		}
-		else {
+		} else {
 			ERR("esil_float_round: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_round: fail to get element from stack.");
 	}
 	return ret;
@@ -3391,17 +3348,14 @@ static bool esil_float_sqrt(RAnalEsil *esil) {
 		if (esil_get_parm_float(esil, src, &s)) {
 			if (isnan(s)) {
 				ret = esil_pushnum_float(esil, s);
-			}
-			else {
+			} else {
 				ret = esil_pushnum_float(esil, sqrt(s));
 			}
-		}
-		else {
+		} else {
 			ERR("esil_float_sqrt: invalid parameters.");
 		}
 		free(src);
-	}
-	else {
+	} else {
 		ERR("esil_float_sqrt: fail to get element from stack.");
 	}
 	return ret;

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -347,3 +347,35 @@ EXPECT=<<EOF
 0x00000005
 EOF
 RUN
+
+NAME=float int to double
+FILE=-
+CMDS="ae 9,I2D"
+EXPECT=<<EOF
+0x4022000000000000
+EOF
+RUN
+
+NAME=float double to int
+FILE=-
+CMDS="ae 9,I2D,D2I"
+EXPECT=<<EOF
+0x9
+EOF
+RUN
+
+NAME=float double to float (32)
+FILE=-
+CMDS="ae 32,9,I2D,D2F"
+EXPECT=<<EOF
+0x41100000
+EOF
+RUN
+
+NAME=float math
+FILE=-
+CMDS="ae 9,I2D,SQRT,4,I2D,F+,3,I2D,F/,6,I2D,F*"
+EXPECT=<<EOF
+0x4004924924924924
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #17541
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Add floating point operations. This is based on code by @FXTi in r2ghidra, slightly adapted to push the doubles to the stack as normal hex strings. This results in a lot less friction with the current working of ESIL
