### PR TITLE
Fix and refactor the ar:// plugin ##io

### DIFF
--- a/shlr/ar/ar.c
+++ b/shlr/ar/ar.c
@@ -3,252 +3,309 @@
 #include <r_util.h>
 #include "ar.h"
 
-#define BUF_SIZE 512
+#define AR_MAGIC_HEADER "!<arch>\n"
+#define AR_FILE_HEADER_END "`\n"
 
-const char *AR_MAGIC_HEADER = "!<arch>\n";
-const char *AR_FILE_HEADER_END = "`\n";
-const int AR_FILENAME_LEN = 16;
+typedef struct Filetable {
+	char *data;
+	ut64 size;
+	ut64 offset;
+} filetable;
 
-/* Used to lookup filename table */
-static int index_filename = -2;
+static RArFp *arfp_new(RBuffer *b, ut32 *refcount) {
+	r_return_val_if_fail (b, NULL);
+	RArFp *f = R_NEW (RArFp);
+	if (f) {
+		if (refcount) {
+			(*refcount)++;
+		}
+		f->name = NULL;
+		f->refcount = refcount;
+		f->buf = b;
+		f->start = 0;
+		f->end = 0;
+	}
+	return f;
+}
+
+bool ar_check_magic(RBuffer *b) {
+	char buf[sizeof (AR_MAGIC_HEADER) - 1];
+	if (r_buf_read (b, (ut8 *)buf, sizeof (buf)) != sizeof (buf)) {
+		return false;
+	}
+	if (strncmp (buf, AR_MAGIC_HEADER, 8)) {
+		eprintf ("Wrong file type.\n");
+		return false;
+	}
+	return true;
+}
+
+static inline void arf_clean_name(RArFp *arf) {
+	free (arf->name);
+	arf->name = NULL;
+}
+
+static char *name_from_table(ut64 off, filetable *tbl) {
+	if (off > tbl->size) {
+		eprintf ("Malformed ar: name lookup out of bounds for header at offset 0x%" PFMT64x "\n", off);
+		return NULL;
+	}
+	// files are suppose to be line feed seperated but we also stop on invalid
+	// chars, such as '/' or '\0'
+
+	char *buf = tbl->data;
+	ut64 i;
+	for (i = off; i < tbl->size; i++) {
+		char c = buf[i];
+		if (c == '\n' || c == '\0') {
+			break;
+		}
+	}
+	if (i == off) {
+		return NULL;
+	}
+	return r_str_newlen (buf + off, i - off - 1);
+}
+
+#define VERIFY_AR_NUM_FIELD(x, s)                                                                \
+	x[sizeof (x) - 1] = '\0';                                                                \
+	r_str_trim_tail (x);                                                                     \
+	if (x[0] != '\0' && (x[0] == '-' || !r_str_isnumber (x))) {                              \
+		eprintf ("Malformed AR: bad %s in header at offset 0x%" PFMT64x "\n", s, h_off); \
+		return -1;                                                                       \
+	}
+
+/* -1 error, 0 end, 1 contnue */
+static int ar_parse_header(RArFp *arf, filetable *tbl, ut64 arsize) {
+	r_return_val_if_fail (arf && arf->buf && tbl, -1);
+	RBuffer *b = arf->buf;
+
+	ut64 h_off = r_buf_tell (b);
+	if (h_off % 2 == 1) {
+		// headers start at even offset
+		ut8 tmp[1];
+		if (r_buf_read (b, tmp, 1) != 1 || tmp[0] != '\n') {
+			return -1;
+		}
+		h_off++;
+	}
+
+	struct header {
+		char name[16];
+		char timestamp[12];
+		char oid[6];
+		char gid[6];
+		char mode[8];
+		char size[10];
+		char end[2];
+	} h;
+
+	int r = r_buf_read (b, (ut8 *)&h, sizeof (h));
+	if (r != sizeof (h)) {
+		if (r == 0) {
+			return 0; // no more file
+		}
+		if (r < 0) {
+			eprintf ("io_ar: io error\n");
+		} else {
+			eprintf ("io_ar: Invalid file length\n");
+		}
+		return -1;
+	}
+
+	if (strncmp (h.end, AR_FILE_HEADER_END, sizeof (h.end))) {
+		eprintf ("Invalid header at offset 0x%" PFMT64x ": bad end field\n", h_off);
+		return -1;
+	}
+
+	// remove trailing spaces from fields and verify they are valid
+	VERIFY_AR_NUM_FIELD (h.timestamp, "timestamp")
+	VERIFY_AR_NUM_FIELD (h.oid, "oid")
+	VERIFY_AR_NUM_FIELD (h.gid, "gid")
+	VERIFY_AR_NUM_FIELD (h.mode, "mode")
+	VERIFY_AR_NUM_FIELD (h.size, "size")
+
+	if (h.size[0] == '\0') {
+		eprintf ("Malformed AR: bad size in header at offset 0x%" PFMT64x "\n", h_off);
+		return -1;
+	}
+	ut64 size = atol (h.size);
+
+	h.timestamp[0] = '\0'; // null terminate h.name
+	r_str_trim_tail (h.name);
+
+	/*
+	 * handle fake files
+	*/
+	if (!strcmp (h.name, "/")) {
+		// skip over symbol table
+		if (r_buf_seek (b, size, R_BUF_CUR) <= 0 || r_buf_tell (b) > arsize) {
+			eprintf ("Malformed ar: too short\n");
+			return -1;
+		}
+		// return next entry
+		return ar_parse_header (arf, tbl, arsize);
+	} else if (!strcmp (h.name, "//")) {
+		// table of file names
+		if (tbl->data || tbl->size != 0) {
+			eprintf ("invalid ar file: two filename lookup tables (at 0x%" PFMT64x ", and 0x%" PFMT64x ")\n", tbl->offset, h_off);
+			return -1;
+		}
+		tbl->data = (char *)malloc (size + 1);
+		if (!tbl->data || r_buf_read (b, (ut8 *)tbl->data, size) != size) {
+			return -1;
+		}
+		tbl->data[size] = '\0';
+		tbl->size = size;
+		tbl->offset = h_off;
+
+		// return next entry
+		return ar_parse_header (arf, tbl, arsize);
+	}
+
+	/*
+	 * handle real files
+	*/
+	RList *list = r_str_split_duplist (h.name, "/", false); // don't strip spaces
+	if (r_list_length (list) != 2) {
+		r_list_free (list);
+		eprintf ("invalid ar file: invalid file name in header at: 0x%" PFMT64x "\n", h_off);
+		return -1;
+	}
+
+	char *tmp = r_list_pop_head (list);
+	if (tmp[0] == '\0') {
+		free (tmp);
+		tmp = r_list_pop (list);
+		if (r_str_isnumber (tmp)) {
+			arf->name = name_from_table (atol (tmp), tbl);
+		} else {
+			eprintf ("invalid ar file: invalid file name in header at: 0x%" PFMT64x "\n", h_off);
+		}
+		free (tmp);
+	} else {
+		arf->name = tmp;
+		tmp = r_list_pop (list);
+		if (tmp[0]) {
+			arf_clean_name (arf);
+			eprintf ("invalid ar file: invalid file name in header at: 0x%" PFMT64x "\n", h_off);
+		}
+		free (tmp);
+	}
+	r_list_free (list);
+
+	if (!arf->name) {
+		return -1;
+	}
+	arf->start = r_buf_tell (b);
+	arf->end = arf->start + size;
+
+	// skip over file content and make sure it is all there
+	if (r_buf_seek (b, size, R_BUF_CUR) <= 0 || r_buf_tell (b) > arsize) {
+		eprintf ("Malformed ar: missing the end of %s (header offset: 0x%" PFMT64x ")\n", arf->name, h_off);
+		arf_clean_name (arf);
+		return -1;
+	}
+
+	return 1;
+}
+#undef VERIFY_AR_NUM_FIELD
 
 /**
- * Open an ar/lib file. If filename is NULL, list archive files
+ * \brief Open specific file withen a ar/lib file.
+ * \param arname the name of the .a file
+ * \param filename the name of file in the .a file that you wish to open
+ * \return a handle of the internal filename or NULL
+ *
+ * Open an ar/lib file by name. If filename is NULL, then archive files will be
+ * listed.
  */
-R_API RBuffer *ar_open_file(const char *arname, const char *filename) {
-	int r;
-	RList *files = NULL;
+R_API RArFp *ar_open_file(const char *arname, const char *filename) {
 	RBuffer *b = r_buf_new_file (arname, O_RDWR, 0);
 	if (!b) {
 		r_sys_perror (__FUNCTION__);
 		return NULL;
 	}
 
-	/* Read magic header */
-	char *buffer = calloc (1, BUF_SIZE + 1);
-	if (!buffer) {
+	r_buf_seek (b, 0, R_BUF_END);
+	ut64 arsize = r_buf_tell (b);
+	r_buf_seek (b, 0, R_BUF_SET);
+
+	if (!ar_check_magic (b)) {
+		r_buf_free (b);
 		return NULL;
 	}
-	r = ar_read_header (b, buffer);
-	if (!r) {
-		goto fail;
-	}
-	files = r_list_new ();
-	/* Parse archive */
-	ar_read_file (b, buffer, true, NULL, NULL);
-	ar_read_filename_table (b, buffer, files, filename);
 
-	/* If b->base is set, then we found the file root in the archive */
-	while (r) {
-		r = ar_read_file (b, buffer, false, files, filename);
+	RArFp *arf = arfp_new (b, NULL);
+	if (!arf) {
+		r_buf_free (b);
+		return NULL;
 	}
 
-	if (!filename) {
-		RListIter *iter;
-		char *name;
-		r_list_foreach (files, iter, name) {
-			printf ("%s\n", name);
-		}
-		goto fail;
-	}
-
-	if (!r) {
-		goto fail;
-	}
-
-	free (buffer);
-	r_list_free (files);
-	return b;
-fail:
-	r_list_free (files);
-	free (buffer);
-	ar_close (b);
-	return NULL;
-}
-
-R_API int ar_close(RBuffer *b) {
-	r_buf_free (b);
-	return 0;
-}
-
-R_API int ar_read_at(RBuffer *b, ut64 off, void *buf, int count) {
-	return r_buf_read_at (b, off, buf, count);
-}
-
-R_API int ar_write_at(RBuffer *b, ut64 off, void *buf, int count) {
-	return r_buf_write_at (b, off, buf, count);
-}
-
-int ar_read(RBuffer *b, void *dest, int len) {
-	int r = r_buf_read (b, dest, len);
-	if (!r) {
-		return 0;
-	}
-	r_buf_seek (b, r, R_BUF_CUR);
-	return r;
-}
-
-int ar_read_until_slash(RBuffer *b, char *buffer, int limit) {
-	ut32 i = 0;
-	ut32 lim = (limit && limit < BUF_SIZE)? limit: BUF_SIZE;
-	while (i < lim) {
-		ar_read (b, buffer + i, 1);
-		if (buffer[i] == '/') {
-			break;
-		}
-		i++;
-	}
-	buffer[i] = '\0';
-	return i;
-}
-
-int ar_read_header(RBuffer *b, char *buffer) {
-	int r = ar_read (b, buffer, 8);
-	if (!r) {
-		return 0;
-	}
-	if (strncmp (buffer, AR_MAGIC_HEADER, 8)) {
-		eprintf ("Wrong file type.\n");
-		return 0;
-	}
-	return r;
-}
-
-int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char *filename) {
-	ut64 filesize = 0;
-	char *tmp = NULL;
-	char *curfile = NULL;
-	ut32 index = -1;
+	filetable tbl = {NULL, 0, 0};
 	int r;
+	while ((r = ar_parse_header (arf, &tbl, arsize)) > 0) {
+		if (filename) {
+			if (!strcmp (filename, arf->name)) {
+				// found the right file
+				break;
+			}
+		} else {
+			printf ("%s\n", arf->name);
+		}
 
-	/* File identifier */
-	if (lookup) {
-		ar_read (b, buffer, AR_FILENAME_LEN);
-	} else {
-		ar_read (b, buffer, 2);
-		/* Fix padding issues */
-		if (*buffer == '\n') {
-			buffer[0] = buffer[1];
-			r_buf_seek (b, -1, R_BUF_CUR);
-			ar_read (b, buffer, 2);
-		}
-		ar_read (b, buffer + 2, AR_FILENAME_LEN - 2);
-	}
-	buffer[AR_FILENAME_LEN] = '\0';
-	/* Fix some padding issues */
-	if (buffer[AR_FILENAME_LEN - 1] != '/' && buffer[AR_FILENAME_LEN - 1] != ' ') {
-		// Find padding offset
-		tmp = (char *)r_str_lchr (buffer, ' ');
-		if (!tmp) {
-			goto fail;
-		}
-		int dif = (int) (tmp - buffer);
-		dif = 31 - dif;
-		// Re-read the whole filename
-		r_buf_seek (b, -dif, R_BUF_CUR);
-		r = ar_read (b, buffer, AR_FILENAME_LEN);
-		if (r != AR_FILENAME_LEN) {
-			goto fail;
-		}
-	}
-	free (curfile);
-	curfile = strdup (buffer);
-	if (!curfile) {
-		goto fail;
-	}
-	/* If /XX then refer to filename table later */
-	if (curfile[0] == '/' && curfile[1] >= '0' && curfile[1] <= '9') {
-		index = strtoul (buffer + 1, NULL, 10);
-	} else if (curfile[0] != '/') {
-		/* Read filename */
-		tmp = strchr (curfile, '/');
-		if (!tmp) {
-			goto fail;
-		}
-		*tmp = '\0';
-		if (files) {
-			r_list_append (files, strdup (curfile));
-		}
-	}
-	/* Timestamp 12
-	 * Owner ID   6
-	 * Group ID   6
-	 * File Mode  8
-	 * File Size 10
-	 * Header end 2 */
-	r = ar_read (b, buffer, 44);
-	if (r != 44) {
-		goto fail;
+		// clean RArFp for next loop
+		arf_clean_name (arf);
 	}
 
-	filesize = strtoull (buffer + 32, &tmp, 10);
+	free (tbl.data);
 
-	/* Header end */
-	if (strncmp (buffer + 42, AR_FILE_HEADER_END, 2)) {
-		goto fail;
-	}
-
-	/* File content */
-	if (!lookup && filename) {
-		/* Check filename */
-		if (index == index_filename || !strcmp (curfile, filename)) {
-			r_buf_resize(b, filesize);
-			free (curfile);
-			return r_buf_size (b);
+	if (r <= 0) {
+		if (r == 0 && filename) {
+			eprintf ("Cound not find file '%s' in archive '%s'\n", filename, arname);
 		}
+		ar_close (arf); // results in buf being free'd
+		return NULL;
 	}
-	(void)ar_read (b, buffer, 1);
 
-	r_buf_seek (b, filesize - 1, R_BUF_CUR);
-	free (curfile);
-	return filesize;
-fail:
-	free (curfile);
+	return arf;
+}
+
+R_API int ar_close(RArFp *f) {
+	if (f) {
+		free (f->name);
+		if (f->refcount) {
+			(*f->refcount)--;
+		}
+
+		// no more files open, clean underlying buffer
+		if (!f->refcount || f->refcount == 0) {
+			free (f->refcount);
+			r_buf_free (f->buf);
+		}
+		free (f);
+	}
 	return 0;
 }
 
-int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *filename) {
-	int r = ar_read (b, buffer, AR_FILENAME_LEN);
-	if (r != AR_FILENAME_LEN) {
-		return 0;
+R_API int ar_read_at(RArFp *f, ut64 off, void *buf, int count) {
+	off += f->start;
+	if (off > f->end) {
+		return -1;
 	}
-	if (strncmp (buffer, "//", 2)) {
-		// What we read was not a filename table, just go back
-		r_buf_seek (b, -AR_FILENAME_LEN, R_BUF_CUR);
-		return 0;
+	if (count + off > f->end) {
+		count = f->end - off;
 	}
+	return r_buf_read_at (f->buf, off, buf, count);
+}
 
-	/* Read table size */
-	r_buf_seek (b, 32, R_BUF_CUR);
-	r = ar_read (b, buffer, 10);
-	if (r != 10) {
-		return 0;
+R_API int ar_write_at(RArFp *f, ut64 off, void *buf, int count) {
+	off += f->start;
+	if (off > f->end) {
+		return -1;
 	}
-	ut64 tablesize = strtoull (buffer, NULL, 10);
-
-	/* Header end */
-	r = ar_read (b, buffer, 2);
-	if (strncmp (buffer, AR_FILE_HEADER_END, 2)) {
-		return 0;
+	if (count + off > f->end) {
+		count = f->end - off;
 	}
-
-	/* Read table */
-	ut64 len = 0;
-	ut32 index = 0;
-	while (r && len < tablesize) {
-		r = ar_read_until_slash (b, buffer, tablesize - len);
-		if (filename && !strcmp (filename, (char *) buffer)) {
-			index_filename = index;
-		}
-		if (*(char *) buffer == '\n') {
-			break;
-		}
-		r_list_append (files, strdup ((char *) buffer));
-		/* End slash plus separation character ("/\n") */
-		len += r + 2;
-		/* Separation character (not always '\n') */
-		r_buf_seek (b, 1, R_BUF_CUR);
-		index++;
-	}
-	return len;
+	return r_buf_write_at (f->buf, off + f->start, buf, count);
 }

--- a/shlr/ar/ar.h
+++ b/shlr/ar/ar.h
@@ -2,16 +2,18 @@
 #ifndef _AR_H
 #define _AR_H
 
+typedef struct RARFP {
+	char *name;
+	ut64 start;
+	ut64 end;
+	RBuffer *buf;
+	ut32 *refcount;
+} RArFp;
+
 /* Offset passed is always the real io->off of the inspected file,
  * the functions automatically translate it to relative offset within the archive */
-R_API RBuffer *ar_open_file(const char *arname, const char *filename);
-R_API int ar_close(RBuffer *b);
-R_API int ar_read_at(RBuffer *b, ut64 off, void *buf, int count);
-R_API int ar_write_at(RBuffer *b, ut64 off, void *buf, int count);
-
-int ar_read(RBuffer *b, void *dest, int len);
-int ar_read_until_slash(RBuffer *b, char *buffer, int limit);
-int ar_read_header(RBuffer *b, char *buffer);
-int ar_read_file(RBuffer *b, char *buffer, bool lookup, RList *files, const char *filename);
-int ar_read_filename_table(RBuffer *b, char *buffer, RList *files, const char *filename);
-#endif	// _AR_H
+R_API RArFp *ar_open_file(const char *arname, const char *filename);
+R_API int ar_close(RArFp *f);
+R_API int ar_read_at(RArFp *f, ut64 off, void *buf, int count);
+R_API int ar_write_at(RArFp *f, ut64 off, void *buf, int count);
+#endif // _AR_H

--- a/test/db/formats/ar
+++ b/test/db/formats/ar
@@ -39,3 +39,21 @@ EXPECT=<<EOF
 0x08000070  8d50 ff48 8b45 f889 d148 8d15 0000 0000  .P.H.E...H......
 EOF
 RUN
+
+NAME=ar short with space
+FILE=ar://bins/ar/filetable_spaces.a// s_spaces
+CMDS=x 16
+EXPECT=<<EOF
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000000  7368 6f72 7473 7061 6365 0aff ffff ffff  shortspace......
+EOF
+RUN
+
+NAME=ar long with space
+FILE=ar://bins/ar/filetable_spaces.a// longgggggggggggggggggspaces
+CMDS=x 16
+EXPECT=<<EOF
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000000  6c6f 6e67 7370 6163 650a ffff ffff ffff  longspace.......
+EOF
+RUN

--- a/test/db/formats/ar
+++ b/test/db/formats/ar
@@ -1,45 +1,41 @@
 NAME=ar file sections
-BROKEN=1
 FILE=ar://bins/ar/libgdbr.a//responses.o
-CMDS=iS~:2
+CMDS=iS~:5
 EXPECT=<<EOF
-01 0x00000040  5246 0x08000040  5246 -r-x .text
+1   0x00000040  0x147e 0x08000040  0x147e -r-x .text
 EOF
 RUN
 
 NAME=ar file symbols
 FILE=ar://bins/ar/libgdbr.a//xml.o
-BROKEN=1
 CMDS=is~xml
 EXPECT=<<EOF
-001 0x00000000 0x08000000  LOCAL   FILE    0 xml.c
-007 0x000009b3 0x080009b3  LOCAL   FUNC 5373 gdbr_parse_target_xml
-017 0x00000040 0x08000040 GLOBAL   FUNC  152 gdbr_read_target_xml
+1    0x00000000 0x08000000 LOCAL  FILE   0        xml.c
+7    0x000009b3 0x080009b3 LOCAL  FUNC   5373     gdbr_parse_target_xml
+17   0x00000040 0x08000040 GLOBAL FUNC   152      gdbr_read_target_xml
 EOF
 RUN
 
 NAME=ar file content
-BROKEN=1
 FILE=ar://bins/ar/libgdbr.a//xml.o
 CMDS=px 64
 EXPECT=<<EOF
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
-0x08000040  7f45 4c46 0201 0100 0000 0000 0000 0000  .ELF............
-0x08000050  0100 3e00 0100 0000 0000 0000 0000 0000  ..>.............
-0x08000060  0000 0000 0000 0000 f068 0000 0000 0000  .........h......
-0x08000070  0000 0000 4000 0000 0000 4000 1500 1400  ....@.....@.....
+0x08000040  5548 89e5 4883 ec30 4889 7dd8 6448 8b04  UH..H..0H.}.dH..
+0x08000050  2528 0000 0048 8945 f831 c048 8b45 d80f  %(...H.E.1.H.E..
+0x08000060  b640 7e83 f001 84c0 7407 b8ff ffff ffeb  .@~.....t.......
+0x08000070  5148 8d55 e848 8b45 d848 8d35 0000 0000  QH.U.H.E.H.5....
 EOF
 RUN
 
 NAME=ar file content
-BROKEN=1
 FILE=ar://bins/ar/libgdbr.a//core.o
 CMDS=px 64
 EXPECT=<<EOF
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
-0x08000040  7f45 4c46 0201 0100 0000 0000 0000 0000  .ELF............
-0x08000050  0100 3e00 0100 0000 0000 0000 0000 0000  ..>.............
-0x08000060  0000 0000 0000 0000 d085 0000 0000 0000  ................
-0x08000070  0000 0000 4000 0000 0000 4000 1500 1400  ....@.....@.....
+0x08000040  5548 89e5 4883 ec20 4889 7de8 bf80 0000  UH..H.. H.}.....
+0x08000050  00e8 0000 0000 4889 45f8 4883 7df8 0075  ......H.E.H.}..u
+0x08000060  07b8 ffff ffff eb77 488b 45e8 488b 4020  .......wH.E.H.@ 
+0x08000070  8d50 ff48 8b45 f889 d148 8d15 0000 0000  .P.H.E...H......
 EOF
 RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This PR fixes the archive io plugin. This will let you open `ar://file.a//obj.o` files again. Tests already existed for this, but were marked broken. This PR updates the tests because formatting has changed since the tests worked. Additionally, a couple of the test appear broken from the start (ELF header should not be at entry0).

The code was refactored a lot. While I hope this makes the code more readable, the primary reason for the refactor is to add in open_many support later. Archive files have no compression. So many files could be supported by the single buffer. The `refcount` member of the `RArFp` structure is mostly unused now. When many file support is added it will ensure the underlying `RBuffer` will be cleaned up when the last reference to it is removed.

I intend on adding at least one more test to this. I don't think any of the current ar tests use a .a file that contains a filename table. I will add the next test in the morning, or on another PR. 