### PR TITLE
Support sbfm/ubfm in arm64 ##asm

### DIFF
--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -307,3 +307,15 @@ d "bti" 1f2403d5
 d "bti c" 5f2403d5
 d "bti j" 9f2403d5
 d "bti jc" df2403d5
+a "sbfm w0, w1, 31, 5" 20141f13 # alias
+a "sbfm x3, x2, 8, 63" 43fc4893
+a "ubfm w0, w1, 2, 31" 207c0253 # alias
+a "ubfm x2, x3, 63, 7" 621c7fd3
+ad "sbfiz w4, w5, 0x1f, 1" a4000113
+ad "sbfiz x6, x7, 1, 0x3f" e6f87f93
+ad "ubfiz w8, w9, 1, 0xf" 28391f53
+ad "ubfiz x10, x11, 6, 0x13" 6a497ad3
+ad "sbfx w12, w13, 0xf, 0x10" ac790f13
+ad "sbfx x14, x15, 0x21, 0x1b" eeed6193
+ad "ubfx w16, w17, 0x1d, 2" 307a1d53
+ad "ubfx x18, x19, 2, 0x39" 72ea42d3


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #15274
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
* Define `cond_check` to reduce code. Also, positive condition is better than negative condition.
* Extract register encoding logic in common, so that fix the bug below:
```sh
liumeo@liumeo-x64:~$ rasm2 -a arm -b 64 'stur x0, [x30]'
p/../arch/arm/armass64.c:316:61: runtime error: left shift of 30 by 29 places cannot be represented in type 'int'
c00300f8
```
* Support sbfm/ubfm and their aliases sbfx, ubfx, sbfiz, ubfiz.
```sh
liumeo@liumeo-imac:~$ rasm2 -aarm -b64 "UBFX X8, X0, 8, 8"
083c48d3
```