### PR TITLE
Fix underflow in r_list_pop

### DIFF
--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -282,8 +282,8 @@ R_API void *r_list_pop(RList *list) {
 		}
 		data = iter->data;
 		free (iter);
+		list->length--;
 	}
-	list->length--;
 	return data;
 }
 
@@ -302,8 +302,8 @@ R_API void *r_list_pop_head(RList *list) {
 		}
 		data = iter->data;
 		free (iter);
+		list->length--;
 	}
-	list->length--;
 	return data;
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

If you pop from an empty list the `RList->length` value will go negative. I think this is an unexpected state that could cause unexpected behavior.

I don't know if there is any code in r2 that uses this in an unsafe way. I only found this because I did a `while (r_list_pop (list))` and ended up with a list of length -1.
