### PR TITLE
Fix 'left'/'h' key in Symbols tab

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -2849,7 +2849,7 @@ static void __direction_panels_cursor_cb(void *user, int direction) {
 	int sub;
 	switch ((Direction)direction) {
 	case LEFT:
-		if (!core->print->cur_enabled) {
+		if (core->print->cur_enabled) {
 			break;
 		}
 		if (cur->view->sx > 0) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
