### PR TITLE
Add arall:// and liball:// #IO plugin

### DIFF
--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -205,6 +205,8 @@ R_API RList* r_io_open_many(RIO* io, const char* uri, int perm, int mode) {
 			}
 		}
 	}
+	// ensure no double free with r_list_close and r_io_free
+	desc_list->free = NULL;
 	return desc_list;
 }
 

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -90,7 +90,7 @@ static RList *r_io_ar_open_many(RIO *io, const char *file, int rw, int mode) {
 	data.rw = rw;
 	data.mode = mode;
 	data.arname = strstr (file, "://") + 3;
-	data.list = r_list_newf ((RListFree *)r_io_ar_close);
+	data.list = r_list_newf ((RListFree)r_io_ar_close);
 	if (data.list && ar_open_all_cb (data.arname, (RArOpenManyCB)__io_ar_list, (void *)&data) < 0) {
 		r_list_free (data.list);
 		return NULL;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -55,7 +55,7 @@ typedef struct ar_many_data {
 	const char *schema;
 	const char *arname;
 	RIO *io;
-	int rw;
+	bool rw;
 	int mode;
 	RList *list;
 } ar_many_data;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -9,7 +9,8 @@
 static const char *r_io_get_individual_schema(const char *file) {
 	if (!strncmp ("arall://", file, 8)) {
 		return "ar://";
-	} else if (!strncmp ("liball://", file, 9)) {
+	}
+	if (!strncmp ("liball://", file, 9)) {
 		return "lib://";
 	}
 	return NULL;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -33,7 +33,7 @@ static int r_io_ar_close(RIODesc *fd) {
 
 static RIODesc *r_io_ar_open(RIO *io, const char *file, int rw, int mode) {
 	r_return_val_if_fail (r_io_ar_plugin_open (io, file, false), NULL);
-	char *arname = strstr (file, "://") + 3;
+	const char *arname = strstr (file, "://") + 3;
 	char *filename = strstr (arname, "//");
 	if (filename) {
 		*filename = 0;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -10,7 +10,7 @@ static const char *r_io_get_individual_schema(const char *file) {
 	if (!strncmp ("arall://", file, 8)) {
 		return "ar://";
 	}
-	if (!strncmp ("liball://", file, 9)) {
+	if (r_str_startswith (file, "liball://")) {
 		return "lib://";
 	}
 	return NULL;

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -71,7 +71,7 @@ static int __io_ar_list(RArFp *arf, void *user) {
 		return -1; // stop error
 	}
 
-	des->name = strdup(arf->name);
+	des->name = strdup (arf->name);
 	if (!r_list_append (data->list, des)) {
 		r_io_ar_close (des);
 		return -1; // stop error

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -7,7 +7,7 @@
 
 
 static const char *r_io_get_individual_schema(const char *file) {
-	if (!strncmp ("arall://", file, 8)) {
+	if (r_str_startswith (file, "arall://")) {
 		return "ar://";
 	}
 	if (r_str_startswith (file, "liball://")) {

--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -6,14 +6,33 @@
 #include "ar.h"
 
 
+static const char *r_io_get_individual_schema(const char *file) {
+	if (!strncmp ("arall://", file, 8)) {
+		return "ar://";
+	} else if (!strncmp ("liball://", file, 9)) {
+		return "lib://";
+	}
+	return NULL;
+}
+
 static bool r_io_ar_plugin_open(RIO *io, const char *file, bool many) {
+	r_return_val_if_fail (io && file, NULL);
+	if (many) {
+		return (r_io_get_individual_schema (file) != NULL);
+	}
 	return !strncmp ("ar://", file, 5) || !strncmp ("lib://", file, 6);
 }
 
+static int r_io_ar_close(RIODesc *fd) {
+	if (!fd || !fd->data) {
+		return -1;
+	}
+	return ar_close ((RArFp *)fd->data);
+}
+
 static RIODesc *r_io_ar_open(RIO *io, const char *file, int rw, int mode) {
-	RIODesc *res = NULL;
-	char *url = strdup (file);
-	char *arname = strstr (url, "://") + 3;
+	r_return_val_if_fail (r_io_ar_plugin_open (io, file, false), NULL);
+	char *arname = strstr (file, "://") + 3;
 	char *filename = strstr (arname, "//");
 	if (filename) {
 		*filename = 0;
@@ -21,16 +40,61 @@ static RIODesc *r_io_ar_open(RIO *io, const char *file, int rw, int mode) {
 	}
 
 	RArFp *arf = ar_open_file (arname, filename);
+	RIODesc *res = NULL;
 	if (arf) {
-		res = r_io_desc_new (io, &r_io_plugin_ar, filename, rw, mode, arf);
+		res = r_io_desc_new (io, &r_io_plugin_ar, file, rw, mode, arf);
+		if (res) {
+			res->name = strdup (filename);
+		}
 	}
-	free (url);
 	return res;
 }
 
+typedef struct ar_many_data {
+	const char *schema;
+	const char *arname;
+	RIO *io;
+	int rw;
+	int mode;
+	RList *list;
+} ar_many_data;
+
+static int __io_ar_list(RArFp *arf, void *user) {
+	ar_many_data *data = (ar_many_data *)user;
+	char *uri = r_str_newf ("%s%s//%s", data->schema, data->arname, arf->name);
+	RIODesc *des = r_io_desc_new (data->io, &r_io_plugin_ar, uri, data->rw, data->mode, arf);
+	free (uri);
+
+	if (!des) {
+		ar_close (arf);
+		return -1; // stop error
+	}
+
+	des->name = strdup(arf->name);
+	if (!r_list_append (data->list, des)) {
+		r_io_ar_close (des);
+		return -1; // stop error
+	}
+	return 0; // continue
+}
+
 static RList *r_io_ar_open_many(RIO *io, const char *file, int rw, int mode) {
-	eprintf ("Not implemented\n");
-	return NULL;
+	r_return_val_if_fail (io && file, NULL);
+	ar_many_data data;
+	if ((data.schema = r_io_get_individual_schema (file)) == NULL) {
+		r_warn_if_reached ();
+		return NULL;
+	}
+	data.io = io;
+	data.rw = rw;
+	data.mode = mode;
+	data.arname = strstr (file, "://") + 3;
+	data.list = r_list_newf ((RListFree *)r_io_ar_close);
+	if (data.list && ar_open_all_cb (data.arname, (RArOpenManyCB)__io_ar_list, (void *)&data) < 0) {
+		r_list_free (data.list);
+		return NULL;
+	}
+	return data.list;
 }
 
 static ut64 r_io_ar_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
@@ -69,18 +133,11 @@ static int r_io_ar_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 	return ar_write_at ((RArFp *) fd->data, io->off, (void *) buf, count);
 }
 
-static int r_io_ar_close(RIODesc *fd) {
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	return ar_close ((RArFp *) fd->data);
-}
-
 RIOPlugin r_io_plugin_ar = {
 	.name = "ar",
 	.desc = "Open ar/lib files",
 	.license = "LGPL3",
-	.uris = "ar://,lib://",
+	.uris = "ar://,lib://,arall://,liball://",
 	.open = r_io_ar_open,
 	.open_many = r_io_ar_open_many,
 	.write = r_io_ar_write,

--- a/shlr/ar/ar.h
+++ b/shlr/ar/ar.h
@@ -10,9 +10,13 @@ typedef struct RARFP {
 	ut32 *refcount;
 } RArFp;
 
+typedef int (*RArOpenManyCB) (RArFp *arf, void *user);
+
 /* Offset passed is always the real io->off of the inspected file,
  * the functions automatically translate it to relative offset within the archive */
 R_API RArFp *ar_open_file(const char *arname, const char *filename);
+R_API RList *ar_open_all(const char *arname);
+R_API int ar_open_all_cb(const char *arname, RArOpenManyCB cb, void *user);
 R_API int ar_close(RArFp *f);
 R_API int ar_read_at(RArFp *f, ut64 off, void *buf, int count);
 R_API int ar_write_at(RArFp *f, ut64 off, void *buf, int count);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This ads open_many support to the ar IO plugin. Not much to see or test yet because opening multiple files does not seem to work right now (see #18194). 

I did step through this in gdb to ensure there are no leaks. Even when the AR parser passes the magic bytes test but fails to parse the first ar file. The trickery with the reference counter works well.

I also added a line is added to `r_io_open_many` to ensure it's returned `RList` is will not have it's `RIODesc` members closed (free'd) when the list is free'd. The `r_io_open_many` function stores each `RIODesc` element of the list in io storage (via `r_io_desc_add`). So if the list keeps it's free method, a double free will occur when IO is free'd. The zipall plugin deals with this by returning a list that already has a NULL free method. I think it would be better to return a list with a valid free method so that another caller can trust the list is properly free'd with `r_list_free`.

I did not touch zipall, but if you like I can update it to return a list with a proper free method.