### PR TITLE
FIx #18171 - Support RNum for syscall-name in `asl` command ##anal

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7315,17 +7315,17 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 		break;
 	case 'l': // "asl"
 		if (input[1] == ' ') {
-			if (!isalpha ((ut8)input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
-				si = r_syscall_get (core->anal->syscall, n, -1);
-				if (si)
-					r_cons_println (si->name);
-				else eprintf ("Unknown syscall number\n");
+			const char *sc_name = r_str_trim_head_ro (input + 2);
+			int sc_number = r_syscall_get_num (core->anal->syscall, sc_name);
+			if (sc_number != 0) {
+				r_cons_printf ("%s\n", syscallNumber (sc_number));
 			} else {
-				n = r_syscall_get_num (core->anal->syscall, input + 2);
-				if (n != -1) {
-					r_cons_printf ("%s\n", syscallNumber (n));
+				int sc_number = r_num_math (num, sc_name);
+				si = r_syscall_get (core->anal->syscall, sc_number, -1);
+				if (si) {
+					r_cons_println (si->name);
 				} else {
-					eprintf ("Unknown syscall name\n");
+					eprintf ("Unknown syscall number\n");
 				}
 			}
 		} else {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2020 - pancake, maijin */
+/* radare - LGPL - Copyright 2009-2021 - pancake, maijin */
 
 #include <r_core.h>
 #include <r_util/r_graph_drawable.h>
@@ -7255,14 +7255,13 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 	RSyscallItem *si;
 	RListIter *iter;
 	RList *list;
-	RNum *num = NULL;
 	int n;
 
 	switch (input[0]) {
 	case 'c': // "asc"
 		if (input[1] == 'a') {
 			if (input[2] == ' ') {
-				if (!isalpha ((ut8)input[3]) && (n = r_num_math (num, input + 3)) >= 0 ) {
+				if (!isalpha ((ut8)input[3]) && (n = r_num_math (core->num, input + 3)) >= 0 ) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf (".equ SYS_%s %s\n", si->name, syscallNumber (n));
@@ -7286,7 +7285,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 			}
 		} else {
 			if (input[1] == ' ') {
-				if (!isalpha ((ut8)input[2]) && (n = r_num_math (num, input + 2)) >= 0 ) {
+				if (!isalpha ((ut8)input[2]) && (n = r_num_math (core->num, input + 2)) >= 0) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf ("#define SYS_%s %s\n", si->name, syscallNumber (n));
@@ -7320,8 +7319,11 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 			if (sc_number != 0) {
 				r_cons_printf ("%s\n", syscallNumber (sc_number));
 			} else {
-				int sc_number = r_num_math (num, sc_name);
+				sc_number = r_num_math (core->num, sc_name);
 				si = r_syscall_get (core->anal->syscall, sc_number, -1);
+				if (!si) {
+					si = r_syscall_get (core->anal->syscall, -1, sc_number);
+				}
 				if (si) {
 					r_cons_println (si->name);
 				} else {

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1,3 +1,19 @@
+NAME=linux syscall
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+e asm.os=linux
+asl $$ @@= 1 2 3 4
+EOF
+EXPECT=<<EOF
+write
+open
+close
+stat
+EOF
+RUN
+
 NAME=imul 1 arg
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
