### PR TITLE
Fix #18202 - Large Cd truncates and crashes in pd ##disasm

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -587,7 +587,7 @@ static bool filecb(void *user, void *data, ut32 id) {
 
 static bool file_is_loaded(RCore *core, const char *lib) {
 	MyFileData filedata = {lib, false};
-	r_id_storage_foreach (r->io->files, filecb, &filedata);
+	r_id_storage_foreach (core->io->files, filecb, &filedata);
 	return filedata.found;
 }
 
@@ -733,7 +733,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		RListIter *iter;
 		RList *libs = r_bin_get_libs (r->bin);
 		r_list_foreach (libs, iter, lib) {
-			if (file_is_loaded (core, lib)) {
+			if (file_is_loaded (r, lib)) {
 				continue;
 			}
 			eprintf ("[bin.libs] Opening %s\n", lib);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2471,20 +2471,19 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 			int sz = R_MIN (16, meta_size);
 			ds->asmop.size = sz;
 			r_asm_op_set_hexbuf (&ds->asmop, buf, sz);
+			const char *tail = (meta_size > 16)? "...": "";
 			switch (meta->type) {
 			case R_META_TYPE_STRING:
-				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".string \"%s\"", meta->str));
+				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".string \"%s%s\"", meta->str, tail));
 				break;
-			// case R_META_TYPE_DATA:
-			//	break;
 			default: {
 				char *op_hex = r_asm_op_get_hex (&ds->asmop);
-				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".hex %s", op_hex));
+				r_asm_op_set_asm (&ds->asmop, sdb_fmt (".hex %s%s", op_hex, tail));
 				free (op_hex);
 				break;
 			}
 			}
-			ds->oplen = sz; //ds->asmop.size;
+			ds->oplen = meta_size;
 			return i;
 		}
 	}

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -9,6 +9,27 @@ s+2048
 pd 1~?
 EOF
 EXPECT=<<EOF
+258
+129
+1
+EOF
+RUN
+
+NAME=Cd999nometa
+FILE=-
+CMDS=<<EOF
+e asm.meta=false
+Cd 4096
+pd 2~?
+so
+pd 1~?
+so -1
+pd 1~?
+EOF
+EXPECT=<<EOF
+3
+1
+2
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -1,3 +1,17 @@
+NAME=Cd999
+FILE=-
+CMDS=<<EOF
+Cd 4096
+pd 2~?
+s 2048
+pd 1~?
+s+2048
+pd 1~?
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
 NAME=Cd4+pdi2
 FILE=bins/mach0/ls-osx-x86_64
 CMDS=<<EOF

--- a/test/db/cmd/metadata
+++ b/test/db/cmd/metadata
@@ -79,7 +79,7 @@ Cd 3
 pd 2
 EOF
 EXPECT=<<EOF
-            0x00000000      hex length=3 delta=0
+            0x00000000      hex size=3 delta=0
 0x00000000  3930 39                                  909
 
             0x00000003      3039           xor byte [ecx], bh


### PR DESCRIPTION
* The Cd size is now honored even if its HUGE
* so still not honoring this
* asm.meta=false still not supporting this well

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
