### PR TITLE
Reuse code in memory-based io plugins ##refactor

### DIFF
--- a/libr/io/Makefile
+++ b/libr/io/Makefile
@@ -8,7 +8,7 @@ R2DEPS+=r_cons
 R2DEPS+=r_crypto
 STATIC_OBJS=$(subst ..,p/..,$(subst io_,p/io_,$(STATIC_OBJ)))
 OBJS=${STATIC_OBJS}
-OBJS+=io.o io_plugin.o io_map.o io_desc.o io_cache.o p_cache.o undo.o ioutils.o io_fd.o
+OBJS+=io.o io_plugin.o io_map.o io_desc.o io_cache.o p_cache.o undo.o ioutils.o io_fd.o io_memory.o
 
 CFLAGS+=-Wall -DR2_PLUGIN_INCORE
 

--- a/libr/io/io_memory.c
+++ b/libr/io/io_memory.c
@@ -1,0 +1,144 @@
+/* radare - LGPL - Copyright 2008-2020 - pancake */
+
+#include "io_memory.h"
+
+static inline ut32 _io_malloc_sz(RIODesc *desc) {
+	if (!desc) {
+		return 0;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	return mal? mal->size: 0;
+}
+
+static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
+	if (!desc) {
+		return;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	if (mal) {
+		mal->size = sz;
+	}
+}
+
+static inline ut8* _io_malloc_buf(RIODesc *desc) {
+	if (!desc) {
+		return NULL;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	return mal->buf;
+}
+
+
+static inline ut8* _io_malloc_set_buf(RIODesc *desc, ut8* buf) {
+	if (!desc) {
+		return NULL;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	return mal->buf = buf;
+}
+
+static inline ut64 _io_malloc_off(RIODesc *desc) {
+	if (!desc) {
+		return 0;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	return mal->offset;
+}
+
+static inline void _io_malloc_set_off(RIODesc *desc, ut64 off) {
+	if (!desc) {
+		return;
+	}
+	RIOMalloc *mal = (RIOMalloc*)desc->data;
+	mal->offset = off;
+}
+
+int io_memory_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
+	if (!fd || !buf || count < 0 || !fd->data) {
+		return -1;
+	}
+	if (_io_malloc_off (fd) > _io_malloc_sz (fd)) {
+		return -1;
+	}
+	if (_io_malloc_off (fd) + count > _io_malloc_sz (fd)) {
+		count -= (_io_malloc_off (fd) + count -_io_malloc_sz (fd));
+	}
+	if (count > 0) {
+		memcpy (_io_malloc_buf (fd) + _io_malloc_off (fd), buf, count);
+		_io_malloc_set_off (fd, _io_malloc_off (fd) + count);
+		return count;
+	}
+	return -1;
+}
+
+bool io_memory_resize(RIO *io, RIODesc *fd, ut64 count) {
+	ut8 * new_buf = NULL;
+	if (!fd || !fd->data || count == 0) {
+		return false;
+	}
+	ut32 mallocsz = _io_malloc_sz (fd);
+	if (_io_malloc_off (fd) > mallocsz) {
+		return false;
+	}
+	new_buf = malloc (count);
+	if (!new_buf) {
+		return false;
+	}
+	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
+	if (count > mallocsz) {
+		memset (new_buf + mallocsz, 0, count - mallocsz);
+	}
+	free (_io_malloc_buf (fd));
+	_io_malloc_set_buf (fd, new_buf);
+	_io_malloc_set_sz (fd, count);
+	return true;
+}
+
+int io_memory_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	memset (buf, 0xff, count);
+	if (!fd || !fd->data) {
+		return -1;
+	}
+	ut32 mallocsz = _io_malloc_sz (fd);
+	if (_io_malloc_off (fd) > mallocsz) {
+		return -1;
+	}
+	if (_io_malloc_off (fd) + count >= mallocsz) {
+		count = mallocsz - _io_malloc_off (fd);
+	}
+	memcpy (buf, _io_malloc_buf (fd) + _io_malloc_off (fd), count);
+	_io_malloc_set_off (fd, _io_malloc_off (fd) + count);
+	return count;
+}
+
+int io_memory_close(RIODesc *fd) {
+	RIOMalloc *riom;
+	if (!fd || !fd->data) {
+		return -1;
+	}
+	riom = fd->data;
+	R_FREE (riom->buf);
+	R_FREE (fd->data);
+	return 0;
+}
+
+ut64 io_memory_lseek(RIO* io, RIODesc *fd, ut64 offset, int whence) {
+	ut64 r_offset = offset;
+	if (!fd || !fd->data) {
+		return offset;
+	}
+	ut32 mallocsz = _io_malloc_sz (fd);
+	switch (whence) {
+	case SEEK_SET:
+		r_offset = (offset <= mallocsz) ? offset : mallocsz;
+		break;
+	case SEEK_CUR:
+		r_offset = (_io_malloc_off (fd) + offset <= mallocsz ) ? _io_malloc_off (fd) + offset : mallocsz;
+		break;
+	case SEEK_END:
+		r_offset = _io_malloc_sz (fd);
+		break;
+	}
+	_io_malloc_set_off (fd, r_offset);
+	return r_offset;
+}

--- a/libr/io/io_memory.h
+++ b/libr/io/io_memory.h
@@ -1,0 +1,18 @@
+#ifndef IO_MEMORY_H
+#define IO_MEMORY_H
+
+#include "r_io.h"
+
+typedef struct {
+	ut8 *buf;
+	ut32 size;
+	ut64 offset;
+} RIOMalloc;
+
+int io_memory_close(RIODesc *fd);
+int io_memory_read(RIO *io, RIODesc *fd, ut8 *buf, int count);
+ut64 io_memory_lseek(RIO* io, RIODesc *fd, ut64 offset, int whence);
+int io_memory_write(RIO *io, RIODesc *fd, const ut8 *buf, int count);
+bool io_memory_resize(RIO *io, RIODesc *fd, ut64 count);
+
+#endif

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -2,6 +2,7 @@ r_io_sources = [
   'io.c',
   'io_fd.c',
   'io_map.c',
+  'io_memory.c',
   'io_cache.c',
   'io_desc.c',
   'io_plugin.c',

--- a/libr/io/p/io_http.c
+++ b/libr/io/p/io_http.c
@@ -4,100 +4,27 @@
 #include "r_lib.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include "../io_memory.h"
 
-typedef struct {
-	int fd;
-	ut8 *buf;
-	ut32 size;
-} RIOMalloc;
-
-#define RIOHTTP_FD(x) (((RIOMalloc*)(x)->data)->fd)
-#define RIOHTTP_SZ(x) (((RIOMalloc*)(x)->data)->size)
-#define RIOHTTP_BUF(x) (((RIOMalloc*)(x)->data)->buf)
-
-static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	if (io->off + count > RIOHTTP_SZ (fd)) {
-		return -1;
-	}
-	memcpy (RIOHTTP_BUF (fd)+io->off, buf, count);
-	return count;
-}
-
-static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
-	unsigned int sz;
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	sz = RIOHTTP_SZ (fd);
-	if (io->off >= sz) {
-		return -1;
-	}
-	if (io->off + count >= sz) {
-		count = sz - io->off;
-	}
-	memcpy (buf, RIOHTTP_BUF (fd) + io->off, count);
-	return count;
-}
-
-static int __close(RIODesc *fd) {
-	RIOMalloc *riom;
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	riom = fd->data;
-	R_FREE (riom->buf);
-	R_FREE (fd->data);
-	return 0;
-}
-
-static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
-	switch (whence) {
-	case SEEK_SET: return offset;
-	case SEEK_CUR: return io->off + offset;
-	case SEEK_END: return RIOHTTP_SZ (fd);
-	}
-	return offset;
-}
-
-static bool __plugin_open(RIO *io, const char *pathname, bool many) {
+static bool __check(RIO *io, const char *pathname, bool many) {
 	return (!strncmp (pathname, "http://", 7));
 }
 
-static inline int getmalfd (RIOMalloc *mal) {
-	return (UT32_MAX >> 1) & (int)(size_t)mal->buf;
-}
-
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
-	char *out;
-	int rlen, code;
-	if (__plugin_open (io, pathname, 0)) {
-		out = r_socket_http_get (pathname, &code, &rlen);
-		if (out) {
-			RIOMalloc *mal = R_NEW0 (RIOMalloc);
-			if (!mal) {
-				return NULL;
-			}
-			mal->size = rlen;
-			mal->buf = malloc (mal->size+1);
-			if (!mal->buf) {
-				free (mal);
-				return NULL;
-			}
-			if (mal->buf != NULL) {
-				mal->fd = getmalfd (mal);
-				memcpy (mal->buf, out, mal->size);
-				free (out);
-				return r_io_desc_new (io, &r_io_plugin_http,
-					pathname, rw, mode, mal);
-			}
-			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname+9, mal->size);
-			free (mal);
+	if (__check (io, pathname, 0)) {
+		int rlen, code;
+		RIOMalloc *mal = R_NEW0 (RIOMalloc);
+		if (!mal) {
+			return NULL;
 		}
-		free (out);
+		mal->offset = 0;
+		mal->buf = r_socket_http_get (pathname, &code, &rlen);
+		if (mal->buf && rlen > 0) {
+			mal->size = rlen;
+			return r_io_desc_new (io, &r_io_plugin_malloc, pathname, R_PERM_RW | rw, mode, mal);
+		}
+		eprintf ("No HTTP response\n");
+		free (mal);
 	}
 	return NULL;
 }
@@ -108,11 +35,11 @@ RIOPlugin r_io_plugin_http = {
 	.uris = "http://",
 	.license = "LGPL3",
 	.open = __open,
-	.close = __close,
-	.read = __read,
-	.check = __plugin_open,
-	.lseek = __lseek,
-	.write = __write,
+	.close = io_memory_close,
+	.read = io_memory_read,
+	.check = __check,
+	.lseek = io_memory_lseek,
+	.write = io_memory_write,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -1,157 +1,9 @@
 /* radare - LGPL - Copyright 2008-2017 - pancake */
 
-#include "r_io.h"
 #include "r_lib.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
-
-typedef struct {
-	ut8 *buf;
-	ut32 size;
-	ut64 offset;
-} RIOMalloc;
-
-static inline ut32 _io_malloc_sz(RIODesc *desc) {
-	if (!desc) {
-		return 0;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	return mal? mal->size: 0;
-}
-
-static inline void _io_malloc_set_sz(RIODesc *desc, ut32 sz) {
-	if (!desc) {
-		return;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	if (mal) {
-		mal->size = sz;
-	}
-}
-
-static inline ut8* _io_malloc_buf(RIODesc *desc) {
-	if (!desc) {
-		return NULL;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	return mal->buf;
-}
-
-
-static inline ut8* _io_malloc_set_buf(RIODesc *desc, ut8* buf) {
-	if (!desc) {
-		return NULL;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	return mal->buf = buf;
-}
-
-static inline ut64 _io_malloc_off(RIODesc *desc) {
-	if (!desc) {
-		return 0;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	return mal->offset;
-}
-
-static inline void _io_malloc_set_off(RIODesc *desc, ut64 off) {
-	if (!desc) {
-		return;
-	}
-	RIOMalloc *mal = (RIOMalloc*)desc->data;
-	mal->offset = off;
-}
-
-static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
-	if (!fd || !buf || count < 0 || !fd->data) {
-		return -1;
-	}
-	if (_io_malloc_off (fd) > _io_malloc_sz (fd)) {
-		return -1;
-	}
-	if (_io_malloc_off (fd) + count > _io_malloc_sz (fd)) {
-		count -= (_io_malloc_off (fd) + count -_io_malloc_sz (fd));
-	}
-	if (count > 0) {
-		memcpy (_io_malloc_buf (fd) + _io_malloc_off (fd), buf, count);
-		_io_malloc_set_off (fd, _io_malloc_off (fd) + count);
-		return count;
-	}
-	return -1;
-}
-
-static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
-	ut8 * new_buf = NULL;
-	if (!fd || !fd->data || count == 0) {
-		return false;
-	}
-	ut32 mallocsz = _io_malloc_sz (fd);
-	if (_io_malloc_off (fd) > mallocsz) {
-		return false;
-	}
-	new_buf = malloc (count);
-	if (!new_buf) {
-		return false;
-	}
-	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
-	if (count > mallocsz) {
-		memset (new_buf + mallocsz, 0, count - mallocsz);
-	}
-	free (_io_malloc_buf (fd));
-	_io_malloc_set_buf (fd, new_buf);
-	_io_malloc_set_sz (fd, count);
-	return true;
-}
-
-static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
-	memset (buf, 0xff, count);
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	ut32 mallocsz = _io_malloc_sz (fd);
-	if (_io_malloc_off (fd) > mallocsz) {
-		return -1;
-	}
-	if (_io_malloc_off (fd) + count >= mallocsz) {
-		count = mallocsz - _io_malloc_off (fd);
-	}
-	memcpy (buf, _io_malloc_buf (fd) + _io_malloc_off (fd), count);
-	_io_malloc_set_off (fd, _io_malloc_off (fd) + count);
-	return count;
-}
-
-static int __close(RIODesc *fd) {
-	RIOMalloc *riom;
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	riom = fd->data;
-	R_FREE (riom->buf);
-	R_FREE (fd->data);
-	return 0;
-}
-
-static ut64 __lseek(RIO* io, RIODesc *fd, ut64 offset, int whence) {
-	ut64 r_offset = offset;
-	if (!fd || !fd->data) {
-		return offset;
-	}
-	ut32 mallocsz = _io_malloc_sz (fd);
-	switch (whence) {
-	case SEEK_SET:
-		r_offset = (offset <= mallocsz) ? offset : mallocsz;
-		break;
-	case SEEK_CUR:
-		r_offset = (_io_malloc_off (fd) + offset <= mallocsz ) ? _io_malloc_off (fd) + offset : mallocsz;
-		break;
-	case SEEK_END:
-		r_offset = _io_malloc_sz (fd);
-		break;
-	}
-	_io_malloc_set_off (fd, r_offset);
-	return r_offset;
-}
+#include "../io_memory.h"
 
 static bool __check(RIO *io, const char *pathname, bool many) {
 	return (!strncmp (pathname, "malloc://", 9)) || (!strncmp (pathname, "hex://", 6));
@@ -160,6 +12,9 @@ static bool __check(RIO *io, const char *pathname, bool many) {
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
 	if (__check (io, pathname, 0)) {
 		RIOMalloc *mal = R_NEW0 (RIOMalloc);
+		if (!mal) {
+			return NULL;
+		}
 		if (!strncmp (pathname, "hex://", 6)) {
 			mal->size = strlen (pathname);
 			mal->buf = calloc (1, mal->size + 1);
@@ -197,12 +52,12 @@ RIOPlugin r_io_plugin_malloc = {
 	.uris = "malloc://,hex://",
 	.license = "LGPL3",
 	.open = __open,
-	.close = __close,
-	.read = __read,
+	.close = io_memory_close,
+	.read = io_memory_read,
 	.check = __check,
-	.lseek = __lseek,
-	.write = __write,
-	.resize = __resize,
+	.lseek = io_memory_lseek,
+	.write = io_memory_write,
+	.resize = io_memory_resize,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/io/p/io_tcp.c
+++ b/libr/io/p/io_tcp.c
@@ -4,71 +4,10 @@
 #include "r_lib.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
+#include "../io_memory.h"
 
-typedef struct {
-	int fd;
-	ut8 *buf;
-	ut32 size;
-} RIOMalloc;
-
-#define RIOTCP_FD(x) (((RIOMalloc*)(x)->data)->fd)
-#define RIOTCP_SZ(x) (((RIOMalloc*)(x)->data)->size)
-#define RIOTCP_BUF(x) (((RIOMalloc*)(x)->data)->buf)
-
-static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	if (io->off + count > RIOTCP_SZ (fd)) {
-		return -1;
-	}
-	memcpy (RIOTCP_BUF (fd)+io->off, buf, count);
-	return count;
-}
-
-static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
-	unsigned int sz;
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	sz = RIOTCP_SZ (fd);
-	if (io->off >= sz) {
-		return -1;
-	}
-	if (io->off + count >= sz) {
-		count = sz - io->off;
-	}
-	memcpy (buf, RIOTCP_BUF (fd) + io->off, count);
-	return count;
-}
-
-static int __close(RIODesc *fd) {
-	RIOMalloc *riom;
-	if (!fd || !fd->data) {
-		return -1;
-	}
-	riom = fd->data;
-	R_FREE (riom->buf);
-	R_FREE (fd->data);
-	return 0;
-}
-
-static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
-	switch (whence) {
-	case SEEK_SET: return offset;
-	case SEEK_CUR: return io->off + offset;
-	case SEEK_END: return RIOTCP_SZ (fd);
-	}
-	return offset;
-}
-
-static bool __plugin_open(RIO *io, const char *pathname, bool many) {
+static bool __check(RIO *io, const char *pathname, bool many) {
 	return (!strncmp (pathname, "tcp://", 6));
-}
-
-static inline int getmalfd (RIOMalloc *mal) {
-	return (UT32_MAX >> 1) & (int)(size_t)mal->buf;
 }
 
 static ut8 *tcpme (const char *pathname, int *code, int *len) {
@@ -124,35 +63,20 @@ static ut8 *tcpme (const char *pathname, int *code, int *len) {
 }
 
 static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
-	ut8 *out;
-	int rlen, code;
-	if (__plugin_open (io, pathname, 0)) {
-		out = tcpme (pathname, &code, &rlen);
-		if (out && rlen > 0) {
-			RIOMalloc *mal = R_NEW0 (RIOMalloc);
-			if (!mal) {
-				free (out);
-				return NULL;
-			}
-			mal->size = rlen;
-			mal->buf = malloc (mal->size + 1);
-			if (!mal->buf) {
-				free (mal);
-				free (out);
-				return NULL;
-			}
-			if (mal->buf != NULL) {
-				mal->fd = getmalfd (mal);
-				memcpy (mal->buf, out, mal->size);
-				free (out);
-				rw = 7;
-				return r_io_desc_new (io, &r_io_plugin_tcp,
-					pathname, rw, mode, mal);
-			}
-			eprintf ("Cannot allocate (%s) %d byte(s)\n", pathname + 9, mal->size);
-			free (mal);
+	if (__check (io, pathname, 0)) {
+		int rlen, code;
+		RIOMalloc *mal = R_NEW0 (RIOMalloc);
+		if (!mal) {
+			return NULL;
 		}
-		free (out);
+		mal->offset = 0;
+		mal->buf = tcpme (pathname, &code, &rlen);
+		if (mal->buf && rlen > 0) {
+			mal->size = rlen;
+			return r_io_desc_new (io, &r_io_plugin_tcp, pathname, rw, mode, mal);
+		}
+		eprintf ("No TCP segment\n");
+		free (mal);
 	}
 	return NULL;
 }
@@ -163,11 +87,11 @@ RIOPlugin r_io_plugin_tcp = {
 	.uris = "tcp://",
 	.license = "LGPL3",
 	.open = __open,
-	.close = __close,
-	.read = __read,
-	.check = __plugin_open,
-	.lseek = __lseek,
-	.write = __write,
+	.close = io_memory_close,
+	.read = io_memory_read,
+	.check = __check,
+	.lseek = io_memory_lseek,
+	.write = io_memory_write,
 };
 
 #ifndef R2_PLUGIN_INCORE


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #17806
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
Replace buggy http/tcp plugins' read (and maybe others) to malloc plugin's implementation.
Before:
```sh
liumeo@liumeo-imac:~/github/radare2$ r2 tcp://localhost:8001
 -- Order pizza for $12.48? [Y/n]
[0x00001fa0]> aaa
[Cannot find function at 0x00001fa0 sym. and entry0 (aa)
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] find and analyze function preludes (aap)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for vtables
[x] Finding xrefs in noncode section with anal.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00000000 to 0x0000353c (aav)
[x] 0x00000000-0x0000353c in 0x0-0x353c (aav)
[Warning: No SN reg alias for current architecture.aaef)
Warning: No SN reg alias for current architecture.
```
After:
```sh
liumeo@liumeo-imac:~/github/radare2$ r2 tcp://localhost:8001
 -- radare2 0.9.7 is so old, my grandfarther was using it with his enigma in WWII
[0x100000bd0]> aaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for objc references
[x] Check for vtables
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Use -AA or aaaa to perform additional experimental analysis.
```
Use `nc -l 8001 <a.out` to provide the binary.