### PR TITLE
Unionize ESIL float conversions

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -3129,7 +3129,7 @@ static bool esil_float_add(RAnalEsil *esil) {
 			(void)(tmp); // suppress unused warning
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, R_NAN);
+				ret = esil_pushnum_float(esil, NAN);
 			} else {
 				ret = esil_pushnum_float(esil, s + d);
 			}
@@ -3159,7 +3159,7 @@ static bool esil_float_sub(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, R_NAN);
+				ret = esil_pushnum_float(esil, NAN);
 			} else {
 				ret = esil_pushnum_float(esil, d - s);
 			}
@@ -3189,7 +3189,7 @@ static bool esil_float_mul(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, R_NAN);
+				ret = esil_pushnum_float(esil, NAN);
 			} else {
 				ret = esil_pushnum_float(esil, s * d);
 			}
@@ -3219,7 +3219,7 @@ static bool esil_float_div(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, R_NAN);
+				ret = esil_pushnum_float(esil, NAN);
 			} else {
 				ret = esil_pushnum_float(esil, d / s);
 			}

--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -3125,7 +3125,7 @@ static bool esil_float_add(RAnalEsil *esil) {
 			(void)(tmp); // suppress unused warning
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+				ret = esil_pushnum_float(esil, R_NAN);
 			} else {
 				ret = esil_pushnum_float(esil, s + d);
 			}
@@ -3155,7 +3155,7 @@ static bool esil_float_sub(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+				ret = esil_pushnum_float(esil, R_NAN);
 			} else {
 				ret = esil_pushnum_float(esil, d - s);
 			}
@@ -3185,7 +3185,7 @@ static bool esil_float_mul(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+				ret = esil_pushnum_float(esil, R_NAN);
 			} else {
 				ret = esil_pushnum_float(esil, s * d);
 			}
@@ -3215,7 +3215,7 @@ static bool esil_float_div(RAnalEsil *esil) {
 			(void)(tmp);
 			int raised = fetestexcept(FE_OVERFLOW);
 			if (raised & FE_OVERFLOW) {
-				ret = esil_pushnum_float(esil, 0.0 / 0.0);
+				ret = esil_pushnum_float(esil, R_NAN);
 			} else {
 				ret = esil_pushnum_float(esil, d / s);
 			}

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -93,13 +93,6 @@ R_API double r_num_sin(double a);
 R_API size_t r_num_bit_count(ut32 val);
 R_API double r_num_get_float(RNum *num, const char *str);
 
-#define R_NAN r_num_nan()
-
-static inline double r_num_nan() {
-	union { ut64 i; double d;} r_nan = { 0x7ff8000000000000 };
-	return r_nan.d;
-}
-
 static inline st64 r_num_abs(st64 num) {
 	return num < 0 ? -num : num;
 }

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -81,6 +81,13 @@ R_API double r_num_sin(double a);
 R_API size_t r_num_bit_count(ut32 val);
 R_API double r_num_get_float(RNum *num, const char *str);
 
+#define R_NAN r_num_nan()
+
+static inline double r_num_nan() {
+	union { ut64 i; double d;} r_nan = { 0x7ff8000000000000 };
+	return r_nan.d;
+}
+
 static inline st64 r_num_abs(st64 num) {
 	return num < 0 ? -num : num;
 }

--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -12,6 +12,18 @@ typedef struct {
 	ut64 n;
 } RNumCalcValue;
 
+typedef union {
+	ut16   u16;
+	ut32   u32;
+	ut64   u64;
+	st16   s16;
+	st32   s32;
+	st64   s64;
+	float  f32;
+	double f64;
+	/* long double f80; */
+} RNumFloat;
+
 typedef enum {
 	RNCNAME, RNCNUMBER, RNCEND, RNCINC, RNCDEC,
 	RNCPLUS='+', RNCMINUS='-', RNCMUL='*', RNCDIV='/', RNCMOD='%',


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Use unions instead of type punning in order to eliminate errors, avoid endian issues, and generally clean up the code so it is not hacky af. Will be tested by CI

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
