### PR TITLE
Fix UnnamedClass issue on fatmacho.objc parsing on arm64 ##bin

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -129,9 +129,8 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) {
 	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, 0);
 
 	mach0_ut r;
-	mach0_ut addr;
+	ut64 addr;
 
-	static RList *sctns = NULL;
 	RListIter *iter = NULL;
 	RBinSection *s = NULL;
 	RBinObject *obj = bf->o;
@@ -141,16 +140,14 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) {
 		return bin->va2pa (p, offset, left, bf);
 	}
 
+	RList *sctns = r_bin_plugin_mach.sections (bf);
 	if (!sctns) {
-		sctns = r_bin_plugin_mach.sections (bf);
-		if (!sctns) {
-			// retain just for debug
-			// eprintf ("there is no sections\n");
-			return 0;
-		}
+		// retain just for debug
+		// eprintf ("there is no sections\n");
+		return 0;
 	}
 
-	addr = p;
+	addr = (ut64)p & 0xFFFFFFFFF;
 	r_list_foreach (sctns, iter, s) {
 		if (addr >= s->vaddr && addr < s->vaddr + s->vsize) {
 			if (offset) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Reproducer:

* This issue happens ONLY on arm64 hardware (tested on iOS-arm64, linux-arm64 and macos-arm64)
* This bug happens only when listing objc classes on FAT MACHO binaries

```
$ r2 fatrepro
> ic
UnnamedClass ...
```

This PR is not yet ready to merge. i need to add a reproducer and think a better fix.