### PR TITLE
Fix plugin type name array issue in Lc command

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2008-2020 - pancake */
+/* radare - LGPL - Copyright 2008-2021 - pancake */
 
 #include <r_util.h>
 #include <r_lib.h>
@@ -11,7 +11,7 @@ static bool __has_debug = false;
 
 /* XXX : this must be registered in runtime */
 static const char *r_lib_types[] = {
-	"io", "dbg", "lang", "asm", "anal", "parse", "bin", "bin_xtr",
+	"io", "dbg", "lang", "asm", "anal", "parse", "bin", "bin_xtr", "bin_ldr",
 	"bp", "syscall", "fastcall", "crypto", "core", "egg", "fs", NULL
 };
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
