### PR TITLE
Fix memleak in db/esil/apple

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3525,10 +3525,7 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 			}
 			if (parse_import_ptr (bin, reloc, bin->dysymtab.iundefsym + j)) {
 				reloc->ord = j;
-				RSkipListNode *node = r_skiplist_insert (relocs, reloc);
-				if (node && reloc != node->data) {
-					free (reloc);
-				}
+				r_skiplist_insert_autofree (relocs, reloc);
 			} else {
 				R_FREE (reloc);
 			}

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2432,6 +2432,7 @@ static int inSymtab(HtPP *hash, const char *name, ut64 addr) {
 		return true;
 	}
 	ht_pp_insert (hash, key, "1");
+	free (key);
 	return false;
 }
 
@@ -2505,13 +2506,13 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 		}
 		if (len) {
 			ut64 flags = read_uleb128 (&p, end);
-		if (flags == UT64_MAX) {
-			break;
-		}
+			if (flags == UT64_MAX) {
+				break;
+			}
 			ut64 offset = read_uleb128 (&p, end);
-		if (offset == UT64_MAX) {
-			break;
-		}
+			if (offset == UT64_MAX) {
+				break;
+			}
 			ut64 resolver = 0;
 			bool isReexport = flags & EXPORT_SYMBOL_FLAGS_REEXPORT;
 			bool hasResolver = flags & EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER;
@@ -2564,7 +2565,7 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 			goto beach;
 		}
 		if (state->i == child_count) {
-			r_list_pop (states);
+			free (r_list_pop (states));
 			continue;
 		}
 		if (!state->next_child) {
@@ -3147,6 +3148,7 @@ static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList * relocs,
 
 		struct reloc_t *reloc = R_NEW0 (struct reloc_t);
 		if (!reloc) {
+			free (sym_name);
 			return;
 		}
 
@@ -3159,7 +3161,9 @@ static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList * relocs,
 		reloc->size = a_info.r_length;
 		r_str_ncpy (reloc->name, sym_name, sizeof (reloc->name) - 1);
 		r_skiplist_insert (relocs, reloc);
+		free (sym_name);
 	}
+	free (info);
 }
 
 static bool is_valid_ordinal_table_size(ut64 size) {
@@ -3521,7 +3525,10 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 			}
 			if (parse_import_ptr (bin, reloc, bin->dysymtab.iundefsym + j)) {
 				reloc->ord = j;
-				r_skiplist_insert (relocs, reloc);
+				RSkipListNode *node = r_skiplist_insert (relocs, reloc);
+				if (node && reloc != node->data) {
+					free (reloc);
+				}
 			} else {
 				R_FREE (reloc);
 			}

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1338,11 +1338,13 @@ RList *MACH0_(parse_classes)(RBinFile *bf) {
 		}
 		r_list_append (ret, klass);
 	}
+	r_skiplist_free (relocs);
 	return ret;
 
 get_classes_error:
 	r_list_free (sctns);
 	r_list_free (ret);
+	r_skiplist_free (relocs);
 	// XXX DOUBLE FREE r_bin_class_free (klass);
 	return NULL;
 }

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -223,7 +223,6 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 		return NULL;
 	}
 	Sdb *TDB = core->anal->sdb_types;
-	RList *list = r_list_newf ((RListFree)r_anal_fcn_arg_free);
 	char *key = resolve_fcn_name (core->anal, fcn_name);
 	if (!key) {
 		return NULL;
@@ -240,6 +239,7 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 		free (key);
 		return NULL;
 	}
+	RList *list = r_list_newf ((RListFree)r_anal_fcn_arg_free);
 	int i;
 	ut64 spv = r_reg_getv (core->anal->reg, sp);
 	ut64 s_width = (core->anal->bits == 64)? 8: 4;
@@ -255,6 +255,7 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 		for (i = 0; i < nargs; i++) {
 			RAnalFuncArg *arg = R_NEW0 (RAnalFuncArg);
 			if (!arg) {
+				r_list_free (list);
 				return NULL;
 			}
 			set_fcn_args_info (arg, core->anal, key, cc, i);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -2555,7 +2555,7 @@ static void _handle_call(RCore *core, char *line, char **str) {
 static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	const char *linecolor = NULL;
 	char *ox, *qo, *string = NULL;
-	char *line, *s, *str, *string2 = NULL;
+	char *line, *s, *string2 = NULL;
 	char *switchcmp = NULL;
 	int i, count, use_color = r_config_get_i (core->config, "scr.color");
 	bool show_comments = r_config_get_i (core->config, "asm.comments");
@@ -2612,6 +2612,7 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 	}
 	for (i = 0; i < count; i++) {
 		ut64 addr = UT64_MAX;
+		char *str;
 		ox = strstr (line, "0x");
 		qo = strchr (line, '\"');
 		R_FREE (string);
@@ -2705,7 +2706,6 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 		}
 #endif
 		if (str) {
-			str = strdup (str);
 			char *qoe = NULL;
 			if (!qoe) {
 				qoe = strchr (str + 1, '\x1b');
@@ -2738,12 +2738,11 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 			}
 		}
 		if (str) {
-			str = strdup (str);
 			char *qoe = strchr (str, ';');
 			if (qoe) {
-				char* t = str;
 				str = r_str_ndup (str, qoe - str);
-				free (t);
+			} else {
+				str = strdup (str);
 			}
 		}
 		if (str) {
@@ -2865,13 +2864,13 @@ static void disasm_strings(RCore *core, const char *input, RAnalFunction *fcn) {
 				}
 			}
 		}
+		free (str);
 		line += strlen (line) + 1;
 	}
 	// r_cons_printf ("%s", s);
 	free (string2);
 	free (string);
 	free (s);
-	free (str);
 	free (switchcmp);
 restore_conf:
 	r_config_set_i (core->config, "asm.offset", show_offset);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4690,6 +4690,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 			}
 			if (key) {
 				if (ds->asm_types < 1) {
+					free (key);
 					break;
 				}
 				const char *fcn_type = r_type_func_ret (core->anal->sdb_types, key);
@@ -4704,6 +4705,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 							r_str_getf (key));
 					if (!nargs) {
 						ds_comment_end (ds, "void)");
+						free (key);
 						break;
 					}
 				}
@@ -4746,11 +4748,13 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 				}
 				ds_comment_end (ds, "");
 				r_list_free (list);
+				free (key);
 				break;
 			} else {
 				r_list_free (list);
 				// function name not resolved
 				r_warn_if_fail (!key);
+				free (key);
 				nargs = DEFAULT_NARGS;
 				if (fcn) {
 					// @TODO: fcn->nargs should be updated somewhere and used here instead

--- a/libr/include/r_skiplist.h
+++ b/libr/include/r_skiplist.h
@@ -29,6 +29,7 @@ R_API RSkipList* r_skiplist_new(RListFree freefn, RListComparator comparefn);
 R_API void r_skiplist_free(RSkipList *list);
 R_API void r_skiplist_purge(RSkipList *list);
 R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data);
+R_API bool r_skiplist_insert_autofree(RSkipList* list, void* data);
 R_API bool r_skiplist_delete(RSkipList* list, void* data);
 R_API bool r_skiplist_delete_node(RSkipList *list, RSkipListNode *node);
 R_API RSkipListNode* r_skiplist_find(RSkipList* list, void* data);

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -198,6 +198,15 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 	return x;
 }
 
+R_API bool r_skiplist_insert_autofree(RSkipList* list, void* data) {
+	RSkipListNode* node = r_skiplist_insert (list, data);
+	if (node && data != node->data) { // duplicate
+		free (data);
+		return false;
+	}
+	return true;
+}
+
 // Delete node with data as it's payload.
 R_API bool r_skiplist_delete(RSkipList* list, void* data) {
 	return delete_element (list, data, true);

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -201,7 +201,9 @@ R_API RSkipListNode* r_skiplist_insert(RSkipList* list, void* data) {
 R_API bool r_skiplist_insert_autofree(RSkipList* list, void* data) {
 	RSkipListNode* node = r_skiplist_insert (list, data);
 	if (node && data != node->data) { // duplicate
-		free (data);
+		if (list->freefn) {
+			list->freefn (data);
+		}
 		return false;
 	}
 	return true;

--- a/libr/util/skiplist.c
+++ b/libr/util/skiplist.c
@@ -11,7 +11,7 @@
 
 #define SKIPLIST_MAX_DEPTH 31
 
-static RSkipListNode *r_skiplist_node_new (void *data, int level) {
+static RSkipListNode *r_skiplist_node_new(void *data, int level) {
 	RSkipListNode *res = R_NEW0 (RSkipListNode);
 	if (!res) {
 		return NULL;
@@ -25,7 +25,7 @@ static RSkipListNode *r_skiplist_node_new (void *data, int level) {
 	return res;
 }
 
-static void r_skiplist_node_free (RSkipList *list, RSkipListNode *node) {
+static void r_skiplist_node_free(RSkipList *list, RSkipListNode *node) {
 	if (node) {
 		if (list->freefn && node->data) {
 			list->freefn (node->data);
@@ -35,7 +35,7 @@ static void r_skiplist_node_free (RSkipList *list, RSkipListNode *node) {
 	}
 }
 
-static void init_head (RSkipListNode *head) {
+static void init_head(RSkipListNode *head) {
 	int i;
 	for (i = 0; i <= SKIPLIST_MAX_DEPTH; i++) {
 		head->forward[i] = head;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
#18150 
As I said in discord, there's a problem of `r_skiplist_insert`. When it meets duplicate key, it simply returns the original node. but this result is always ignored, thus a call `r_skiplist_insert (list, data)` may cause memory leak.
Should we check the result every time, or use a new function to insert and free if duplicate?
the leak can be reproduced by `r2 -Qc 'pd 2~?push' bins/mach0/arm16-ofp.lzh`