### PR TITLE
Fix crash in XNU kernel parsing (no cache) ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -1485,7 +1485,8 @@ enum {
 	DYLD_CHAINED_PTR_32          = 3,
 	DYLD_CHAINED_PTR_32_CACHE    = 4,
 	DYLD_CHAINED_PTR_32_FIRMWARE = 5,
-	DYLD_CHAINED_PTR_ARM64E_CACHE = 8, /* TODO: figure out the right name */
+	DYLD_CHAINED_PTR_ARM64E_KERNEL = 7,
+	DYLD_CHAINED_PTR_64_KERNEL_CACHE = 8,
 };
 
 struct dyld_chained_ptr_arm64e_rebase {

--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -200,7 +200,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	}
 
 	RCFValueDict *prelink_info = NULL;
-	if (main_mach0->hdr.filetype != MH_FILESET) {
+	if (main_mach0->hdr.filetype != MH_FILESET && prelink_range->range.size) {
 		prelink_info = r_cf_value_dict_parse (fbuf, prelink_range->range.offset,
 				prelink_range->range.size, R_CF_OPTION_SKIP_NSDATA);
 		if (!prelink_info) {
@@ -2139,7 +2139,8 @@ static void rebase_buffer_fixup(RKernelCacheObj *kobj, ut64 off, RIODesc *fd, ut
 							ptr_value = ((ut64)p->high8 << 56) | p->target;
 							ptr_value += obj->baddr;
 						}
-					} else if (obj->chained_starts[i]->pointer_format == DYLD_CHAINED_PTR_ARM64E_CACHE) {
+					} else if (obj->chained_starts[i]->pointer_format == DYLD_CHAINED_PTR_64_KERNEL_CACHE ||
+							obj->chained_starts[i]->pointer_format == DYLD_CHAINED_PTR_ARM64E_KERNEL) {
 						bool is_auth = IS_PTR_AUTH (raw_ptr);
 						stride = 4;
 						if (is_auth) {


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Fix a crash happening when opening XNU standalone kernels for arm64 macOS. It happened because it's not a kernel cache, though it retains empty information about kexts.

After fixing it, also noticed the pointer rebasing wasn't working correctly, because this kind of kernels has a different chained pointer format, so i added it and took the chance to rename one of them for which i didn't know the name at the time i wrote the logic to handle it.
