### PR TITLE
Minor bugfixes to radiff2

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -186,7 +186,7 @@ R_API int r_anal_diff_fcn(RAnal *anal, RList *fcns, RList *fcns2) {
 	if (fcns) {
 		r_list_foreach (fcns, iter, fcn) {
 			r_list_foreach (fcns2, iter2, fcn2) {
-				if (fcn->name && fcn2->name && strcmp (fcn->name, fcn2->name)) {
+				if (!fcn->name || !fcn2->name || strcmp (fcn->name, fcn2->name)) {
 					continue;
 				}
 				r_diff_buffers_distance (NULL, fcn->fingerprint, fcn->fingerprint_size,

--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -1107,8 +1107,10 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			eprintf ("Cannot open '%s'\n", r_str_getf (ro.file));
 		}
 		c2 = opencore (&ro, ro.file2);
-		if (!c || !c2) {
+		if (!c2) {
 			eprintf ("Cannot open '%s'\n", r_str_getf (ro.file2));
+		}
+		if (!c || !c2) {
 			return 1;
 		}
 		c->c2 = c2;

--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -424,7 +424,7 @@ static int bcb(RDiff *d, void *user, RDiffOp *op) {
 }
 
 static int show_help(int v) {
-	printf ("Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-m graph_mode][-t %%] [file] [file]\n");
+	printf ("Usage: radiff2 [-abBcCdeGhijnrOpqsSxuUvVzZ] [-A[A]] [-g sym] [-m graph_mode][-t %%] [file] [file]\n");
 	if (v) {
 		printf (
 			"  -a [arch]  specify architecture plugin to use (x86, arm, ..)\n"

--- a/man/radiff2.1
+++ b/man/radiff2.1
@@ -42,7 +42,7 @@ Compare the list of imports
 .It Fl n
 Suppress address names (show only addresses) when code diffing.
 .It Fl O
-Do code diffing with all bytes instead of just the fixed opcode bytes
+Do code diffing with opcode bytes only.
 .It Fl p
 Use physical addressing (io.va=0)
 .It Fl q


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [X ] Closing issues: 18235, 18236 and 18244.
- [ X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
**Issue 18236**
This fix makes changes to `libr/main/radiff2.c`  around line 1118.  I included a description of how to build a test case when I submitted this issue.
**Issue 18235**
This fix changes line 189 in  `libr/anal/diff.c.`  This is "it can't happen here" code, so it's not clear how to build a test case.  The original code is incorrect on inspection.  If either `fcn->name`  or `fcn2->name` is `NULL`, control falls into the code that will compare one function with a `NULL` name to one function with a name that may not be `NULL`.
**Issue 18244**
Fixes some minor documentation inconsistencies that I spotted.  I believe I understand the current semantics for -O, but someone else please check!
