### PR TITLE
Add bin.cache evar to use io.cache when bins need to patch relocs ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1712,7 +1712,7 @@ static int bin_relocs(RCore *r, PJ *pj, int mode, int va) {
 		if (r_pvector_len (&r->io->cache) == 0) {
 			r_config_set (r->config, "io.cache", "false");
 		} else {
-			r_config_set (r->config, "io.cache.read", "false");
+			r_config_set (r->config, "io.cache.read", "true");
 		}
 	}
 

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1700,9 +1700,20 @@ static int bin_relocs(RCore *r, PJ *pj, int mode, int va) {
 
 	va = VA_TRUE; // XXX relocs always vaddr?
 	//this has been created for reloc object files
+	const bool bin_cache = r_config_get_i (r->config, "bin.cache");
+	if (bin_cache) {
+		r_config_set (r->config, "io.cache", "true");
+	}
 	RBNode *relocs = r_bin_patch_relocs (r->bin);
 	if (!relocs) {
 		relocs = r_bin_get_relocs (r->bin);
+	}
+	if (bin_cache) {
+		if (r_pvector_len (&r->io->cache) == 0) {
+			r_config_set (r->config, "io.cache", "false");
+		} else {
+			r_config_set (r->config, "io.cache.read", "false");
+		}
 	}
 
 	if (IS_MODE_RAD (mode)) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3387,6 +3387,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETOPTIONS (n, "a", "8", "p", "e", "u", "i", "U", "f", NULL);
 	SETCB ("bin.filter", "true", &cb_binfilter, "Filter symbol names to fix dupped names");
 	SETCB ("bin.force", "", &cb_binforce, "Force that rbin plugin");
+	SETPREF ("bin.cache", "true", "Enable io.cache and fall to io.cache.read if bin needs to patch relocs");
 	SETPREF ("bin.lang", "", "Language for bin.demangle");
 	SETBPREF ("bin.demangle", "true", "Import demangled symbols from RBin");
 	SETBPREF ("bin.demangle.libs", "false", "Show library name on demangled symbols names");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3387,7 +3387,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETOPTIONS (n, "a", "8", "p", "e", "u", "i", "U", "f", NULL);
 	SETCB ("bin.filter", "true", &cb_binfilter, "Filter symbol names to fix dupped names");
 	SETCB ("bin.force", "", &cb_binforce, "Force that rbin plugin");
-	SETPREF ("bin.cache", "true", "Enable io.cache and fall to io.cache.read if bin needs to patch relocs");
+	SETPREF ("bin.cache", "false", "Enable io.cache and fall to io.cache.read if bin needs to patch relocs");
 	SETPREF ("bin.lang", "", "Language for bin.demangle");
 	SETBPREF ("bin.demangle", "true", "Import demangled symbols from RBin");
 	SETBPREF ("bin.demangle.libs", "false", "Show library name on demangled symbols names");

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -109,17 +109,22 @@ FILE=bins/elf/libverifyPass.so
 CMDS=<<EOF
 e anal.vars.stackname=true
 e asm.lines.bb = false
+e io.cache=false
+e io.cache.read=false
+wc-*
 aa
 s sym.Java_com_app_ndh_NDHActivity_print
 to bins/headers/jni.h
+td struct NULL { }
 tl JNINativeInterface = 0x464c457f
+tl NULL = 0
 pdf~JNINativeInterface
 pdr~JNI?
 EOF
 EXPECT=<<EOF
 | ; var struct JNINativeInterface @ sp+0x12c
 | 0x00000f74      4b93           str r3, [JNINativeInterface]
-| 0x00000f76      039b           ldr r3, [var_134h]                    ; JNINativeInterface.reserved0
+| 0x00000f76      039b           ldr r3, [NULL]                        ; JNINativeInterface.reserved0
 | 0x00000f7e      d358           ldr r3, [r2, r3]                      ; JNINativeInterface.GetStringUTFChars
 | 0x00000f82      019a           ldr r2, [var_13ch]                    ; JNINativeInterface.reserved0
 | 0x0000100e      d358           ldr r3, [r2, r3]                      ; JNINativeInterface.GetStringLength


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
