### PR TITLE
Fix Mach-O rebase on fat slices ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2258,6 +2258,7 @@ RList *MACH0_(get_segments)(RBinFile *bf) {
 			s->size = (bin->sects[i].flags == S_ZEROFILL) ? 0 : (ut64)bin->sects[i].size;
 			// XXX flags
 			s->paddr = (ut64)bin->sects[i].offset;
+			s->paddr += bf->o->boffset;
 			int segment_index = 0;
 			//s->perm =prot2perm (bin->segs[j].initprot);
 			for (j = 0; j < bin->nsegs; j++) {

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2258,7 +2258,6 @@ RList *MACH0_(get_segments)(RBinFile *bf) {
 			s->size = (bin->sects[i].flags == S_ZEROFILL) ? 0 : (ut64)bin->sects[i].size;
 			// XXX flags
 			s->paddr = (ut64)bin->sects[i].offset;
-			s->paddr += bf->o->boffset;
 			int segment_index = 0;
 			//s->perm =prot2perm (bin->segs[j].initprot);
 			for (j = 0; j < bin->nsegs; j++) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -745,7 +745,7 @@ static int rebasing_and_stripping_io_read(RIO *io, RIODesc *fd, ut8 *buf, int co
 	ut64 io_off = io->off;
 	int result = obj->original_io_read (io, fd, internal_buffer, count);
 	if (result == count) {
-		rebase_buffer (obj, io_off, fd, internal_buffer, count);
+		rebase_buffer (obj, io_off - bf->o->boffset, fd, internal_buffer, count);
 		memcpy (buf, internal_buffer, result);
 	}
 	return result;

--- a/test/db/formats/mach0/fatmach0
+++ b/test/db/formats/mach0/fatmach0
@@ -236,3 +236,27 @@ nth paddr       vaddr      bind   type size lib name
 2    0x00005f94 0x90000f94 LOCAL  FUNC 0        imp.exit
 EOF
 RUN
+
+NAME=fatmach0 objc
+FILE=bins/mach0/modernobjc-noarm64
+ARGS=-a arm
+CMDS=ic
+EXPECT=<<EOF
+0x100009298 [0x100001e90 - 0x100001e90]      0 class 0 ViewController
+0x100001e90 method 0      viewDidLoad
+0x1000092c0 [0x100001ee4 - 0x1000020a4]    448 class 0 AppDelegate
+0x100001ee4 method 0      application:didFinishLaunchingWithOptions:
+0x100001f74 method 1      application:configurationForConnectingSceneSession:options:
+0x1000020a4 method 2      application:didDiscardSceneSessions:
+0x100009310 [0x1000021d0 - 0x100002494]    708 class 0 SceneDelegate
+0x1000021d0 method 0      scene:willConnectToSession:options:
+0x100002280 method 1      sceneDidDisconnect:
+0x1000022d4 method 2      sceneDidBecomeActive:
+0x100002328 method 3      sceneWillResignActive:
+0x10000237c method 4      sceneWillEnterForeground:
+0x1000023d0 method 5      sceneDidEnterBackground:
+0x100002424 method 6      window
+0x100002450 method 7      setWindow:
+0x100002494 method 8      .cxx_destruct
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

The gist of it is: compensate for the bin file offset when running the rebasing logic.

This aims to fix the same problem as https://github.com/radareorg/radare2/pull/18222 in a less hacky way.

I still think that fat slices should be mapped alone and not relying on bin file offset, but this works in the short term.
