### PR TITLE
[WIP] Debug log: turn on by default, split into sessions, add to issue template

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,3 @@ repository and run all the tests in order to verify that no changes break any fu
 
 We run those tests on every commit, and they are also executed with ASAN
 and valgrind on different platforms to catch other unwanted 'features'.
-

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ repository and run all the tests in order to verify that no changes break any fu
 
 We run those tests on every commit, and they are also executed with ASAN
 and valgrind on different platforms to catch other unwanted 'features'.
+


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This is a draft Pull Request. It is meant to be discussed, implemented and amended (force-pushed).

Design and implementation ideas are split into commits with descriptive messages. I'll duplicate them here in their initial form:

### Turn on debug log by default

Sh|t happens often when you least expect it. If radare crashes, we can't
prepare for it in advance -- only conduct postmortem investigation, such as
analyze logs. It won't get us anywhere if logs are not enabled by default,
therefore we have configure them to a default location.

We use platform-specific directories somewhere under user's home directory.

### Store per-session debug logs in a directory

Single file logging is not as helpful when there are many instances of an
app (i.e. many sessions) running around at the same time.

Moreover, consider this scenario:
- app crashes,
- users wants to retrieve logs,
- but he/she doesn't remember where they are stored,
- so user launches new `r2 -` instance to check the `e logs.file` value...
- only to find out that the previous (crashed) session's log has been
  overwritten by this new useless session.

Thus we need to keep track of different sessions in their own log files.

This commit:
* implements logging directory config var `e logs.dir`;
* deprecates `e log.file` (single-file) config var;
* uses platform-specific directories.

### Update GitHub issue template to ask for debug logs

To help troubleshoot problems and have more reproducible bug reports, from
now on we'll be politely requesting users to upload their latest log file
from the `e log.dir` directory.