### PR TITLE
Fix UB in clz(0) spotted by asan

### DIFF
--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -38,7 +38,7 @@ R_API size_t r_num_bit_count(ut32 val) {
 	count = (((val + (val >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
 	return count;
 #else
-	return __builtin_clz (val);
+	return val? __builtin_clz (val): 0;
 #endif
 }
 


### PR DESCRIPTION
* unum.c:41: runtime error: passing zero to clz(), which is not a valid argumentruet

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
