### PR TITLE
Use pj in core ##refactor

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -5498,7 +5498,6 @@ static int cmd_print(void *data, const char *input) {
 			} else {
 				cmd_pdj (core, input + 2, block);
 			}
-			r_cons_newline ();
 			pd_result = 0;
 			break;
 		case 'J': // pdJ

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1143,7 +1143,7 @@ static void cmd_pDj(RCore *core, const char *arg) {
 		eprintf ("cannot allocate %d byte(s)\n", bsize);
 	}
 	pj_end (pj);
-	r_cons_printf ("%s", pj_string (pj));
+	r_cons_println (pj_string (pj));
 	pj_free (pj);
 }
 
@@ -1156,7 +1156,7 @@ static void cmd_pdj(RCore *core, const char *arg, ut8* block) {
 	pj_a (pj);
 	r_core_print_disasm_json (core, core->offset, block, core->blocksize, nblines, pj);
 	pj_end (pj);
-	r_cons_printf ("%s\n", pj_string (pj));
+	r_cons_println (pj_string (pj));
 	pj_free (pj);
 }
 

--- a/libr/core/task.c
+++ b/libr/core/task.c
@@ -56,34 +56,31 @@ typedef struct oneshot_t {
 	void *user;
 } OneShot;
 
-R_API void r_core_task_print (RCore *core, RCoreTask *task, int mode) {
+R_API void r_core_task_print (RCore *core, RCoreTask *task, PJ *pj, int mode) {
 	switch (mode) {
-	case 'j':
-		//TODO PJ
-		{
-		r_cons_printf ("{\"id\":%d,\"state\":\"", task->id);
+	case 'j': {
+		pj_o (pj);
+		pj_ki (pj, "id", task->id);
+		pj_k (pj, "state");
 		switch (task->state) {
 		case R_CORE_TASK_STATE_BEFORE_START:
-			r_cons_print ("before_start");
+			pj_s (pj, "before_start");
 			break;
 		case R_CORE_TASK_STATE_RUNNING:
-			r_cons_print ("running");
+			pj_s (pj, "running");
 			break;
 		case R_CORE_TASK_STATE_SLEEPING:
-			r_cons_print ("sleeping");
+			pj_s (pj, "sleeping");
 			break;
 		case R_CORE_TASK_STATE_DONE:
-			r_cons_print ("done");
+			pj_s (pj, "done");
 			break;
 		}
-		r_cons_printf ("\",\"transient\":%s,\"cmd\":", task->transient ? "true" : "false");
-		if (task->cmd) {
-			r_cons_printf ("\"%s\"}", task->cmd);
-		} else {
-			r_cons_printf ("null}");
-		}
-		}
+		pj_kb (pj, "transient", task->transient);
+		pj_ks (pj, "cmd", r_str_get_fail (task->cmd, "null"));
+		pj_end (pj);
 		break;
+	}
 	default: {
 		const char *info = task->cmd;
 		if (task == core->tasks.main_task) {
@@ -102,19 +99,23 @@ R_API void r_core_task_print (RCore *core, RCoreTask *task, int mode) {
 R_API void r_core_task_list(RCore *core, int mode) {
 	RListIter *iter;
 	RCoreTask *task;
+	PJ *pj = NULL;
 	if (mode == 'j') {
-		r_cons_printf ("[");
+		pj = r_core_pj_new (core);
+		if (!pj) {
+			return;
+		}
+		pj_a (pj);
 	}
 	TASK_SIGSET_T old_sigset;
 	tasks_lock_enter (&core->tasks, &old_sigset);
 	r_list_foreach (core->tasks.tasks, iter, task) {
-		r_core_task_print (core, task, mode);
-		if (mode == 'j' && iter->n) {
-			r_cons_printf (",");
-		}
+		r_core_task_print (core, task, pj, mode);
 	}
 	if (mode == 'j') {
-		r_cons_printf ("]\n");
+		pj_end (pj);
+		r_cons_println (pj_string (pj));
+		pj_free (pj);
 	} else {
 		r_cons_printf ("--\ntotal running: %d\n", core->tasks.tasks_running);
 	}

--- a/libr/core/yank.c
+++ b/libr/core/yank.c
@@ -248,16 +248,24 @@ R_API bool r_core_yank_dump(RCore *core, ut64 pos, int format) {
 				}
 				r_cons_newline ();
 				break;
-			case 'j':
-				//TODO PJ
-				{
-					r_cons_printf ("{\"addr\":%"PFMT64u",\"bytes\":\"", core->yank_addr);
-					for (i = pos; i < r_buf_size (core->yank_buf); i++) {
-						r_cons_printf ("%02x", r_buf_read8_at (core->yank_buf, i));
-					}
-					r_cons_printf ("\"}\n");
+			case 'j': {
+				PJ *pj = r_core_pj_new (core);
+				if (!pj) {
+					break;
 				}
+				pj_o (pj);
+				pj_kn (pj, "addr", core->yank_addr);
+				RStrBuf *buf = r_strbuf_new ("");
+				for (i = pos; i < r_buf_size (core->yank_buf); i++) {
+					r_strbuf_appendf (buf, "%02x", r_buf_read8_at (core->yank_buf, i));
+				}
+				pj_ks (pj, "bytes", r_strbuf_get (buf));
+				r_strbuf_free (buf);
+				pj_end (pj);
+				r_cons_println (pj_string (pj));
+				pj_free (pj);
 				break;
+			}
 			case '*':
 				//r_cons_printf ("yfx ");
 				r_cons_printf ("wx ");

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -895,7 +895,7 @@ R_API void r_core_task_scheduler_init (RCoreTaskScheduler *tasks, RCore *core);
 R_API void r_core_task_scheduler_fini (RCoreTaskScheduler *tasks);
 R_API RCoreTask *r_core_task_get(RCoreTaskScheduler *scheduler, int id);
 R_API RCoreTask *r_core_task_get_incref(RCoreTaskScheduler *scheduler, int id);
-R_API void r_core_task_print(RCore *core, RCoreTask *task, int mode);
+R_API void r_core_task_print(RCore *core, RCoreTask *task, PJ *pj, int mode);
 R_API void r_core_task_list(RCore *core, int mode);
 R_API int r_core_task_running_tasks_count(RCoreTaskScheduler *scheduler);
 R_API const char *r_core_task_status(RCoreTask *task);

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -435,7 +435,6 @@ pdj -1
 EOF
 EXPECT=<<EOF
 [{"offset":1,"ptr":4248444,"val":4248444,"esil":"4248444,4,esp,-,=[4],4,esp,-=","refptr":false,"fcn_addr":0,"fcn_last":1020,"size":5,"opcode":"push 0x40d37c","disasm":"push 0x40d37c","bytes":"687cd34000","family":"cpu","type":"push","reloc":false,"type_num":13,"type2_num":0}]
-
 EOF
 RUN
 
@@ -448,7 +447,6 @@ pdj 3 @ main
 EOF
 EXPECT=<<EOF
 [{"offset":4195590,"esil":"rbp,8,rsp,-,=[8],8,rsp,-=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":1,"opcode":"push rbp","disasm":"push rbp","bytes":"55","family":"cpu","type":"rpush","reloc":false,"type_num":268435468,"type2_num":0,"flags":["main","sym.main"]},{"offset":4195591,"esil":"rsp,rbp,=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":3,"opcode":"mov rbp, rsp","disasm":"mov rbp, rsp","bytes":"4889e5","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":4195594,"ptr":4195780,"val":4195780,"esil":"4195780,rdi,=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":5,"opcode":"mov edi, 0x4005c4","disasm":"mov edi, str.Hello_World","bytes":"bfc4054000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0}]
-
 EOF
 RUN
 
@@ -461,7 +459,6 @@ pdj -3 @ 0x0040050f
 EOF
 EXPECT=<<EOF
 [{"offset":4195590,"esil":"rbp,8,rsp,-,=[8],8,rsp,-=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":1,"opcode":"push rbp","disasm":"push rbp","bytes":"55","family":"cpu","type":"rpush","reloc":false,"type_num":268435468,"type2_num":0,"flags":["main","sym.main"]},{"offset":4195591,"esil":"rsp,rbp,=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":3,"opcode":"mov rbp, rsp","disasm":"mov rbp, rsp","bytes":"4889e5","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0},{"offset":4195594,"ptr":4195780,"val":4195780,"esil":"4195780,rdi,=","refptr":false,"fcn_addr":0,"fcn_last":0,"size":5,"opcode":"mov edi, 0x4005c4","disasm":"mov edi, str.Hello_World","bytes":"bfc4054000","family":"cpu","type":"mov","reloc":false,"type_num":9,"type2_num":0}]
-
 EOF
 RUN
 
@@ -470,7 +467,6 @@ FILE=bins/java/Hello.class
 CMDS=pdj 1 @ 0x000002ae
 EXPECT=<<EOF
 [{"offset":686,"esil":"","refptr":false,"fcn_addr":0,"fcn_last":0,"size":2,"opcode":"ldc \"World\"","disasm":"ldc \"World\"","bytes":"120b","family":"cpu","type":"push","reloc":false,"type_num":13,"type2_num":2138640}]
-
 EOF
 RUN
 

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2360,7 +2360,6 @@ EXPECT=<<EOF
     "type2_num": 0
   }
 ]
-
 EOF
 RUN
 

--- a/test/db/formats/elf/crash
+++ b/test/db/formats/elf/crash
@@ -10,7 +10,6 @@ FILE=-
 CMDS=e asm.pseudo=1; e asm.arch=x86; e asm.bits=64; wx 7299; pdj 1
 EXPECT=<<EOF
 [{"offset":0,"esil":"cf,?{,18446744073709551515,rip,=,}","refptr":false,"fcn_addr":0,"fcn_last":0,"size":2,"opcode":"if (((unsigned) var) < 0) goto 0xffffffffffffff9b","disasm":"jb 0xffffffffffffff9b","bytes":"7299","family":"cpu","type":"cjmp","reloc":false,"type_num":2147483649,"type2_num":0,"jump":-101,"fail":2}]
-
 EOF
 RUN
 

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -614,6 +614,5 @@ EXPECT=<<EOF
   }
 ]
 
-
 EOF
 RUN

--- a/test/db/json/json1
+++ b/test/db/json/json1
@@ -1,3 +1,4 @@
+&j
 /ad/j push rbp
 /adj push rbp
 /j l

--- a/test/db/json/json4
+++ b/test/db/json/json4
@@ -2,6 +2,7 @@ pcj
 pdbj
 pdfj
 pDj
+pdaj
 pdj
 pDJ
 pdJ
@@ -32,4 +33,5 @@ tsj
 ttj
 tuj
 wcj
+yj
 zj


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
https://github.com/rizinorg/rizin/issues/200
After this, the only handmade json in core is in cmd_type.c, which is hard to replace because
1. it calls `r_core_cmdf`
2. it's in a callback function