### PR TITLE
Fix memleak in test_r2pipe & test_esil_dfg_filter

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2044,7 +2044,7 @@ R_API int r_core_fgets(char *buf, int len) {
 		rli->completion.run = autocomplete;
 		rli->completion.run_user = rli->user;
 	} else {
-		rli->history.data = NULL;
+		r_line_hist_free ();
 		r_line_completion_set (&rli->completion, 0, NULL);
 		rli->completion.run = NULL;
 		rli->completion.run_user = NULL;

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1506,8 +1506,6 @@ beach:
 	free (envprofile);
 	free (debugbackend);
 	r_core_free (r);
-	r_cons_set_raw (0);
-	r_cons_free ();
 	LISTS_FREE ();
 	R_FREE (pfile);
 	return ret;

--- a/test/unit/test_esil_dfg_filter.c
+++ b/test/unit/test_esil_dfg_filter.c
@@ -61,6 +61,7 @@ bool test_lemon_const_folder(void) {
 	RStrBuf *filtered = r_anal_esil_dfg_filter (dfg, "eax");
 	const bool cmp_result = !strcmp(r_strbuf_get(filtered), "0x2,eax,:=");
 	r_strbuf_free (filtered);
+	r_anal_esil_dfg_free (dfg);
 	r_anal_free (anal);
 	
 	mu_assert_true (cmp_result, "esil dfg const folding is broken");


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
#18150 