### PR TITLE
Fix mg when file exists and cannot be created

### DIFF
--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -331,8 +331,9 @@ static int cmd_mount(void *data, const char *_input) {
 			int total_bytes_read = 0;
 			int blocksize = file->size < core->blocksize ? file->size : core->blocksize;
 			size = size > 0 ? size : file->size;
-			if (!r_sys_truncate (localFile, 0)) {
+			if (r_file_exists(localFile) && !r_sys_truncate (localFile, 0)) {
 				eprintf ("Cannot create file %s\n", localFile);
+				break;
 			}
 			while (total_bytes_read < size && ptr < file->size) {
 				int bytes_read = 0;

--- a/libr/core/cmd_mount.c
+++ b/libr/core/cmd_mount.c
@@ -331,7 +331,7 @@ static int cmd_mount(void *data, const char *_input) {
 			int total_bytes_read = 0;
 			int blocksize = file->size < core->blocksize ? file->size : core->blocksize;
 			size = size > 0 ? size : file->size;
-			if (r_file_exists(localFile) && !r_sys_truncate (localFile, 0)) {
+			if (r_file_exists (localFile) && !r_sys_truncate (localFile, 0)) {
 				eprintf ("Cannot create file %s\n", localFile);
 				break;
 			}


### PR DESCRIPTION
- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

When executing 'mg', the message is printed when file does not previously exist.  With this fix, error message is only printed when the file exists and cannot be truncated. 