### PR TITLE
Warn once about the missing anal.cc ##anal

### DIFF
--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2011-2020 - pancake, Oddcoder */
+/* radare - LGPL - Copyright 2011-2021 - pancake, Oddcoder */
 
 /* Universal calling convention implementation based on sdb */
 
@@ -68,6 +68,10 @@ R_API bool r_anal_cc_set(RAnal *anal, const char *expr) {
 	free (e);
 	free (args);
 	return true;
+}
+
+R_API bool r_anal_cc_once(RAnal *anal) {
+	return sdb_add (DB, "warn", "once", 0);
 }
 
 R_API void r_anal_cc_get_json(RAnal *anal, PJ *pj, const char *name) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -763,7 +763,9 @@ static int __core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dep
 	}
 	const char *cc = r_anal_cc_default (core->anal);
 	if (!cc) {
-		eprintf ("Warning: set your favourite calling convention in `e anal.cc=?`\n");
+		if (r_anal_cc_once (core->anal)) {
+			eprintf ("Warning: set your favourite calling convention in `e anal.cc=?`\n");
+		}
 		cc = "reg";
 	}
 	fcn->cc = r_str_constpool_get (&core->anal->constpool, cc);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1816,6 +1816,7 @@ R_API bool r_anal_cc_exist(RAnal *anal, const char *convention);
 R_API void r_anal_cc_del(RAnal *anal, const char *name);
 R_API bool r_anal_cc_set(RAnal *anal, const char *expr);
 R_API char *r_anal_cc_get(RAnal *anal, const char *name);
+R_API bool r_anal_cc_once(RAnal *anal);
 R_API void r_anal_cc_get_json(RAnal *anal, PJ *pj, const char *name);
 R_API const char *r_anal_cc_arg(RAnal *anal, const char *convention, int n);
 R_API const char *r_anal_cc_self(RAnal *anal, const char *convention);


### PR DESCRIPTION
* fix anoying warning on archs with dynamic or unknown regprofiles

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
