### PR TITLE
Use r_core_flag_get_by_spaces() in getFunctionName() ##rizin

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -89,8 +89,7 @@ static int cmpaddr (const void *_a, const void *_b) {
 	return (a->addr > b->addr)? 1: (a->addr < b->addr)? -1: 0;
 }
 
-
-static char *getFunctionName(RCore *core, ut64 addr) {
+static char *get_function_name(RCore *core, ut64 addr) {
 	RBinFile *bf = r_bin_cur (core->bin);
 	if (bf && bf->o) {
 		Sdb *kv = bf->o->addr2klassmethod;
@@ -100,17 +99,8 @@ static char *getFunctionName(RCore *core, ut64 addr) {
 			return res;
 		}
 	}
-	RListIter *iter;
-	RFlagItem *flag;
-	const RList* flags = r_flag_get_list (core->flags, addr);
-	const char *name = NULL;
-	r_list_foreach (flags, iter, flag) {
-		name = flag->name;
-		if (r_str_startswith (name, "sym.")) {
-			break;
-		}
-	}
-	return name ? strdup (name) : NULL;
+	RFlagItem *flag = r_core_flag_get_by_spaces (core->flags, addr);
+	return (flag && flag->name) ? strdup (flag->name) : NULL;
 }
 
 static RCore *mycore = NULL;
@@ -778,7 +768,7 @@ static int __core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dep
 		fcn->bits = core->anal->bits;
 	}
 	fcn->addr = at;
-	fcn->name = getFunctionName (core, at);
+	fcn->name = get_function_name (core, at);
 
 	if (!fcn->name) {
 		fcn->name = r_str_newf ("%s.%08"PFMT64x, fcnpfx, at);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
