### PR TITLE
Fix #18256 - Double free in RBin.DEX.libs

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2011-2020 - pancake, h4ng3r */
+/* radare - LGPL - Copyright 2011-2021 - pancake, h4ng3r */
 
 #include <r_cons.h>
 #include <r_types.h>
@@ -2145,8 +2145,9 @@ static RList* libs(RBinFile *bf) {
 			char *n = r_str_newf ("%s%s%s", path, R_SYS_DIR, file);
 			if (strcmp (n, bf->file)) {
 				r_list_append (ret, n);
+			} else {
+				free (n);
 			}
-			free (n);
 		}
 	}
 	r_list_free (files);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
