### PR TITLE
Fix shell portability issue

### DIFF
--- a/sys/docker_build_alpine_image.sh
+++ b/sys/docker_build_alpine_image.sh
@@ -186,7 +186,7 @@ RUN set -o pipefail && \
 			echo "alias q=\"exit\"" >>/root/.bashrc \
 		) \
 	) && ( \
-		[ "$gname" == "root" ] || \
+		[ "$gname" = "root" ] || \
 		( \
 			groupadd -f $gname && \
 			(groupmod -g $gid $gname 2>/dev/null || true) && \


### PR DESCRIPTION
Caught in pkgsrc on NetBSD.

**Checklist**

- [ ] Closing issues: #issue
- [x ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

== is an unportable shell construct.