### PR TITLE
Define PYC_ROOT and WASM_ROOT

### DIFF
--- a/libr/anal/p/pyc.mk
+++ b/libr/anal/p/pyc.mk
@@ -35,6 +35,7 @@ STATIC_OBJ+=${OBJ_PYC}
 TARGET_PYC=anal_pyc.$(EXT_SO)
 
 ALL_TARGETS+=${TARGET_PYC}
+PYC_ROOT=../asm/arch/pyc
 CFLAGS+=-I$(PYC_ROOT)
 
 ${TARGET_PYC}: ${OBJ_PYC}

--- a/libr/anal/p/wasm.mk
+++ b/libr/anal/p/wasm.mk
@@ -1,4 +1,5 @@
 OBJ_WASM=anal_wasm.o
+WASM_ROOT=../asm/arch/wasm
 CFLAGS+=-I$(WASM_ROOT)
 
 STATIC_OBJ+=${OBJ_WASM}


### PR DESCRIPTION
Avoid passing -I as this is a non-portable construct.

Caught in pkgsrc on NetBSD.

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Passing "-I" without the path breaks the build.