### PR TITLE
Avoid overwriting LDFLAGS

### DIFF
--- a/libr/debug/Makefile
+++ b/libr/debug/Makefile
@@ -6,7 +6,7 @@ R2DEPS+=r_socket
 CFLAGS+=-DR2_PLUGIN_INCORE
 
 ifeq ($(OSTYPE),bsd)
-LDFLAGS=-lkvm
+LDFLAGS+=-lkvm
 endif
 
 foo:


### PR DESCRIPTION
Append, instead of setting -lkvm for BSD platforms.

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Overwriting LDFLAGS causes spurious fallout in the build system, as detected on NetBSD.
