### PR TITLE
Update debian.sh

### DIFF
--- a/sys/debian.sh
+++ b/sys/debian.sh
@@ -20,7 +20,7 @@ rm -rf "${PKGDIR}" "${DEVDIR}"
 
 export CFLAGS="-O2 -Werror -Wno-cpp"
 export CFLAGS="${CFLAGS} -Wno-unused-result"
-export CFLAGS="${CFLAGS} -Wno-stringpop-truncation"
+export CFLAGS="${CFLAGS} -Wno-stringop-truncation"
 # build
 ./configure --prefix=/usr > /dev/null
 [ $? != 0 ] && exit 1


### PR DESCRIPTION
The flag as given is a typo by the looks of it, as there is no such flag for GCC. As given, the build by doing

`./sys/debian.sh`

to build debian packages is broken.

This small edit corrects things.

Of course the whole thing is just a ruse to hide warnings from the compiler, it does not actually fix any underlying badness.