### PR TITLE
Fix unused argument warning spotted in r2cutter

### DIFF
--- a/libr/include/r_types_overflow.h
+++ b/libr/include/r_types_overflow.h
@@ -53,6 +53,7 @@ static inline bool overflow_name(type_base a, type_base b) { \
 }
 #define UNSIGNED_DIV_OVERFLOW_CHECK(overflow_name, type_base, type_min, type_max) \
 static inline bool overflow_name(type_base a, type_base b) { \
+	(void)(a); \
 	return !b; \
 }
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
