### PR TITLE
Assign radare2 binr target ##build

### DIFF
--- a/binr/radare2/meson.build
+++ b/binr/radare2/meson.build
@@ -1,4 +1,4 @@
-executable('radare2', 'radare2.c',
+radare2_exe = executable('radare2', 'radare2.c',
   include_directories: [platform_inc],
   dependencies: [
     r_util_dep,


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This way, when radare2 is used as a subproject with cli=enabled, the radare2 executable can be referenced