### PR TITLE
Fix a credentials downgrade problem in Install.sh

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
-MAKE=make
-gmake --help >/dev/null 2>&1
-[ $? = 0 ] && MAKE=gmake
+if [ "$(id -u)" = 0 ]; then
+	echo "[XX] Do not run this script as root!"
+	if [ -n "${SUDO_USER}" ]; then
+		echo "[--] Downgrading credentials to ${SUDO_USER}"
+		exec sudo -u "${SUDO_USER}" sys/install.sh $*
+	fi
+	exit 1
+fi
 
 # if owner of sys/install.sh != uid && uid == 0 { exec sudo -u id -A $SUDO_UID sys/install.sh $* }
 ARGS=""
@@ -39,15 +44,9 @@ while : ; do
 	shift
 done
 
-if [ "$(id -u)" = 0 ]; then
-	echo "[XX] Do not run this script as root!"
-	if [ -n "${SUDO_USER}" ]; then
-		echo "[--] Downgrading credentials to ${SUDO_USER}"
-		exec sudo -u "${SUDO_USER}" sys/install.sh $*
-	fi
-	exit 1
-fi
-
+MAKE=make
+gmake --help >/dev/null 2>&1
+[ $? = 0 ] && MAKE=gmake
 ${MAKE} --help 2>&1 | grep -q gnu
 if [ $? != 0 ]; then
 	echo "You need GNU Make to build me"

--- a/sys/install.sh
+++ b/sys/install.sh
@@ -39,7 +39,7 @@ while : ; do
 	shift
 done
 
-if [ "${UID}" = 0 ]; then
+if [ "$(id -u)" = 0 ]; then
 	echo "[XX] Do not run this script as root!"
 	if [ -n "${SUDO_USER}" ]; then
 		echo "[--] Downgrading credentials to ${SUDO_USER}"


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
The [sys/install.sh](https://github.com/radareorg/radare2/blob/95af8dd05e2f7d918454cd403bec0a3793ee1a38/sys/install.sh) script tries to downgrade credentials if run as root but the logic was broken and it couldn't really do that. Also this was being done a little late while it must be the first thing to do. This PR fixes both these problems.