### PR TITLE
write multi-byte input represented by less bytes as output

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -33,6 +33,8 @@ typedef struct r_charset_t {
 	Sdb *db_char_to_hex;
 	RCharsetRune *custom_charset;
 	size_t remaining;
+    size_t encode_maxkeylen;
+    size_t decode_maxkeylen;
 } RCharset;
 
 #define R_STR_ISEMPTY(x) (!(x) || !*(x))

--- a/libr/util/charset.c
+++ b/libr/util/charset.c
@@ -113,24 +113,35 @@ R_API size_t r_charset_encode_str(RCharset *rc, ut8 *out, size_t out_len, const 
 
 // assumes out is as big as in_len
 R_API size_t r_charset_decode_str(RCharset *rc, ut8 *out, size_t out_len, const ut8 *in, size_t in_len) {
-	char k[32];
 	char *o = (char*)out;
-	int i;
-	for (i = 0; i < in_len; i++) {
-		ut8 ch_in = in[i];
+	size_t last_char_size;
+	size_t maxkeylen = 8;
 
-		//zero terminate the string
-		snprintf (k, sizeof (k), "%c", ch_in);//snprintf (k, sizeof (k), "0x%02x", ch_in);
-		char *v = sdb_get (rc->db_char_to_hex, k, 0);
-		memmove(v, v+2, strlen (v));
+	size_t cur, j;
+	for (cur = 0; cur < in_len; ) {
+		char *str = r_str_ndup((char *)in, maxkeylen);
+		for (j = in_len ; j > 0; j--) {
+			//zero terminate the string
+			str[j] = '\0';
 
-		//convert to ascii
-		char str_hx[32];
-		snprintf (str_hx, sizeof (str_hx), "%c", (char) strtol( v, 0, 16));
-		const char *ret = r_str_get_fail (str_hx, "?");
-		strcpy (o, ret);
+			const char *v = sdb_const_get (rc->db_char_to_hex, (char *) str+cur, 0);
+			if (v) {
+				//convert to ascii
+				char *str_hx = malloc(maxkeylen);
+				snprintf (str_hx, maxkeylen, "%c", (char) strtol(v, 0, 16));//in the future handle multiple chars output
+				const char *ret = r_str_get_fail (str_hx, "?");
 
-		o += strlen (o);
+				//concatenate
+				strcpy (o, ret);
+				o += strlen (o);
+
+				//pass for multiple chars
+				last_char_size = strlen ( (char *)str+cur);
+				cur += last_char_size;
+				free (str_hx);
+			}
+		}
+		free (str);
 	}
 	return o - (char*)out;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

tha commands: `e cfg.charset=pokered; w abcd` used to work with only one char for one char translation. It can now select less values in the output.

Tested with
`e cfg.charset=pokered; "w <RIVAL>abcdefg<RIVAL>"`

