### PR TITLE
Fix #17049 - oa whithout filename specify, add oa test ##shell ##test

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1416,9 +1416,18 @@ static int cmd_open(void *data, const char *input) {
 				bits = r_num_math (core->num, r_str_word_get0 (ptr, 1));
 				arch = r_str_word_get0 (ptr, 0);
 				r_core_bin_set_arch_bits (core, filename, arch, bits);
-				RBinFile *file = r_bin_file_find_by_name (core->bin, filename);
-				if (!file) {
-					eprintf ("Cannot find file %s\n", filename);
+				RBinFile *file;
+				if (filename != NULL) {
+					file = r_bin_file_find_by_name (core->bin, filename);
+					if (!file) {
+						eprintf ("Cannot find file %s\n", filename);
+						free (ptr);
+						return 0;
+					}
+				} else if (core->bin->binfiles->length == 1) {
+					file = (RBinFile *)core->bin->binfiles->head->data;
+				} else {
+					eprintf ("More than one file is opened, specify the filename\n");
 					free (ptr);
 					return 0;
 				}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1416,18 +1416,18 @@ static int cmd_open(void *data, const char *input) {
 				bits = r_num_math (core->num, r_str_word_get0 (ptr, 1));
 				arch = r_str_word_get0 (ptr, 0);
 				r_core_bin_set_arch_bits (core, filename, arch, bits);
-				RBinFile *file;
-				if (filename != NULL) {
+				RBinFile *file = NULL;
+				if (filename) {
 					file = r_bin_file_find_by_name (core->bin, filename);
 					if (!file) {
 						eprintf ("Cannot find file %s\n", filename);
-						free (ptr);
-						return 0;
 					}
-				} else if (core->bin->binfiles->length == 1) {
-					file = (RBinFile *)core->bin->binfiles->head->data;
+				} else if (r_list_length(core->bin->binfiles) == 1) {
+					file = (RBinFile *)r_list_first(core->bin->binfiles);
 				} else {
 					eprintf ("More than one file is opened, specify the filename\n");
+				}
+				if (!file) {
 					free (ptr);
 					return 0;
 				}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1423,7 +1423,7 @@ static int cmd_open(void *data, const char *input) {
 						eprintf ("Cannot find file %s\n", filename);
 					}
 				} else if (r_list_length (core->bin->binfiles) == 1) {
-					file = (RBinFile *)r_list_first(core->bin->binfiles);
+					file = (RBinFile *)r_list_first (core->bin->binfiles);
 				} else {
 					eprintf ("More than one file is opened, specify the filename\n");
 				}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1422,7 +1422,7 @@ static int cmd_open(void *data, const char *input) {
 					if (!file) {
 						eprintf ("Cannot find file %s\n", filename);
 					}
-				} else if (r_list_length(core->bin->binfiles) == 1) {
+				} else if (r_list_length (core->bin->binfiles) == 1) {
 					file = (RBinFile *)r_list_first(core->bin->binfiles);
 				} else {
 					eprintf ("More than one file is opened, specify the filename\n");

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -477,3 +477,22 @@ block    0x100
 
 EOF
 RUN
+
+NAME=oa 
+FILE=bins/elf/ls
+ARGS=-e io.cache=true
+CMDS=<<EOF
+oa x86 64
+o bins/elf/true
+oa x86 64
+oa x86 64 bins/elf/ls
+oa x86 64 nonfile
+oa x86 
+EOF
+EXPECT=<<EOF
+More than one file is opened, specify the filename
+Cannot find file nonfile
+Missing argument
+EOF
+BROKEN=1
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Fix bug with oa command, add a case usage without filename if opened only one file. Add tests for oa.
Probably need to change command description in the book because the new use case not obvious, but not sure how 
<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
