### PR TITLE
Function `prefer_linkage_name` fails if `ctx->lang` is NULL

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -748,7 +748,9 @@ static void get_spec_die_type(Context *ctx, RBinDwarfDie *die, RStrBuf *ret_type
 /* For some languages linkage name is more informative like C++,
    but for Rust it's rubbish and the normal name is fine */
 static bool prefer_linkage_name(char *lang) {
-	if (!strcmp (lang, "rust")) {
+	if (lang == NULL) {
+		return false;
+	} else if (!strcmp (lang, "rust")) {
 		return false;
 	} else if (!strcmp (lang, "ada")) {
 		return false;


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

I have a binary that triggers a SEGFAULT in R2 because of a null dereference in `prefer_linkage_name`.