### PR TITLE
Fix bug to not print both long chars

### DIFF
--- a/libr/util/charset.c
+++ b/libr/util/charset.c
@@ -149,7 +149,8 @@ R_API size_t r_charset_decode_str(RCharset *rc, ut8 *out, size_t out_len, const 
 					o += ll - 1;
 				}
 				found = true;
-				cur += strlen (str) - 1;
+				size_t str_len = strlen (str) - 1;
+				cur += str_len > 0 ? str_len - 1: 1;
 				free (str_hx);
 				break;
 			}

--- a/libr/util/charset.c
+++ b/libr/util/charset.c
@@ -149,6 +149,7 @@ R_API size_t r_charset_decode_str(RCharset *rc, ut8 *out, size_t out_len, const 
 					o += ll - 1;
 				}
 				found = true;
+				cur += strlen (str) - 1;
 				free (str_hx);
 				break;
 			}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Fix the bug that write 2 times multiple charsets.