### PR TITLE
Fix NULL dereference in rfs tab complete

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1143,7 +1143,7 @@ static void autocomplete_mount_point (RLineCompletion *completion, RCore *core, 
 static void autocomplete_ms_path(RLineCompletion *completion, RCore *core, const char *str, const char *path) {
 	char *lpath = NULL, *dirname = NULL , *basename = NULL;
 	char *p = NULL;
-	char *pwd = (core->rfs && *(core->rfs->cwd)) ? *(core->rfs->cwd): ".";
+	char *pwd = (core->rfs && core->rfs->cwd && *(core->rfs->cwd)) ? *(core->rfs->cwd): ".";
 	int n = 0;
 	RList *list;
 	RListIter *iter;
@@ -1617,7 +1617,7 @@ static void autocomplete_file(RLineCompletion *completion, const char *str) {
 static void autocomplete_ms_file(RCore* core, RLineCompletion *completion, const char *str) {
 	r_return_if_fail (str);
 	char *pipe = strchr (str, '>');
-	char *path = (core->rfs && *(core->rfs->cwd)) ? *(core->rfs->cwd): "/";
+	char *path = (core->rfs && core->rfs->cwd && *(core->rfs->cwd)) ? *(core->rfs->cwd): "/";
 	if (pipe) {
 		str = r_str_trim_head_ro (pipe + 1);
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Fix null dref segfault when tab completing file path in `mo` command after `ms` command as run. This might be a bug in `ms` not putting the `rfs` structure in a proper state, but I don't know enough about `rfs` to really comment. 

To cause the segfult do this:

```
# make ext2 system
$ dd if=/dev/zero of=ext2.img count=10 bs=1M
> 10+0 records in
10+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.0062472 s, 1.7 GB/s
$ mkfs.ext2 ./ext2.img
mke2fs 1.46.1 (9-Feb-2021)
Discarding device blocks: done                            
Creating filesystem with 10240 1k blocks and 2560 inodes
...
$ r2 -v 
radare2 5.1.1 26621 @ linux-x86-64 git.5.1.1
commit: 8841faf4aec261cd7488fe919a3046afeaf85c7a build: 2021-02-15__15:18:42
$ r2 ./ext2.img
Mounted ext2 on /root at 0x0
[0x00000000]> mo **TAB TAB no crash**
[0x00000000]> ms
 [/]> ^D **exit  it**
[0x00000000]> mo **TAB**
Segmentation fault
 ```