### PR TITLE
Add Support for new CoreSymbolication element format ##bin

### DIFF
--- a/libr/bin/format/mach0/coresymbolication.c
+++ b/libr/bin/format/mach0/coresymbolication.c
@@ -247,6 +247,7 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 		}
 	}
 	bool relative_to_strings = false;
+	ut8* string_origin;
 	if (hdr->n_sections > 0) {
 		result->sections = R_NEWS0 (RCoreSymCacheElementSection, hdr->n_sections);
 		if (!result->sections) {
@@ -278,11 +279,8 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			if (bits == 32) {
 				cursor += word_size;
 			}
-			if (relative_to_strings) {
-				sect->name = str_dup_safe (b, b + start_of_strings + (size_t)sect_name_off, end);
-			} else {
-				sect->name = str_dup_safe (b, sect_start + (size_t)sect_name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : sect_start;
+			sect->name = str_dup_safe (b, string_origin + (size_t)sect_name_off, end);
 		}
 	}
 	if (hdr->n_symbols) {
@@ -300,20 +298,14 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t name_off = r_read_le32 (cursor + 0xc);
 			size_t mangled_name_off = r_read_le32 (cursor + 0x10);
 			sym->unk2 = (st32)r_read_le32 (cursor + 0x14);
-			if (relative_to_strings) {
-				sym->name = str_dup_safe (b, b + start_of_strings + name_off, end);
-			} else {
-				sym->name = str_dup_safe (b, cursor + name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			sym->name = str_dup_safe (b, string_origin + name_off, end);
 			if (!sym->name) {
 				cursor += R_CS_EL_SIZE_SYM;
 				continue;
 			}
-			if (relative_to_strings) {
-				sym->mangled_name = str_dup_safe (b, b + start_of_strings + mangled_name_off, end);
-			} else {
-				sym->mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			sym->mangled_name = str_dup_safe (b, string_origin + mangled_name_off, end);
 			if (!sym->mangled_name) {
 				cursor += R_CS_EL_SIZE_SYM;
 				continue;
@@ -339,29 +331,20 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t file_name_off = r_read_le32 (cursor + 0x18);
 			lsym->flc.line = r_read_le32 (cursor + 0x1c);
 			lsym->flc.col = r_read_le32 (cursor + 0x20);
-			if (relative_to_strings) {
-				lsym->sym.name = str_dup_safe (b, b + start_of_strings + name_off, end);
-			} else {
-				lsym->sym.name = str_dup_safe (b, cursor + name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			lsym->sym.name = str_dup_safe (b, string_origin + name_off, end);
 			if (!lsym->sym.name) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
 			}
-			if (relative_to_strings) {
-				lsym->sym.mangled_name = str_dup_safe (b, b + start_of_strings + mangled_name_off, end);
-			} else {
-				lsym->sym.mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			lsym->sym.mangled_name = str_dup_safe (b, string_origin + mangled_name_off, end);
 			if (!lsym->sym.mangled_name) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
 			}
-			if (relative_to_strings) {
-				lsym->flc.file = str_dup_safe (b, b + start_of_strings + file_name_off, end);
-			} else {
-				lsym->flc.file = str_dup_safe (b, cursor + file_name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			lsym->flc.file = str_dup_safe (b, string_origin + file_name_off, end);
 			if (!lsym->flc.file) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
@@ -384,11 +367,8 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t file_name_off = r_read_le32 (cursor + 8);
 			info->flc.line = r_read_le32 (cursor + 0xc);
 			info->flc.col = r_read_le32 (cursor + 0x10);
-			if (relative_to_strings) {
-				info->flc.file = str_dup_safe (b, b + start_of_strings + file_name_off, end);
-			} else {
-				info->flc.file = str_dup_safe (b, cursor + file_name_off, end);
-			}
+			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			info->flc.file = str_dup_safe (b, string_origin + file_name_off, end);
 			if (!info->flc.file) {
 				break;
 			}

--- a/libr/bin/format/mach0/coresymbolication.c
+++ b/libr/bin/format/mach0/coresymbolication.c
@@ -157,7 +157,7 @@ static char *str_dup_safe_fixed(const ut8 *b, const ut8 *str, ut64 len, const ut
 	return NULL;
 }
 
-RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits) {
+RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits, char * file_name) {
 	RCoreSymCacheElement *result = NULL;
 	ut8 *b = NULL;
 	RCoreSymCacheElementHdr *hdr = r_coresym_cache_element_header_new (buf, off, bits);
@@ -185,13 +185,23 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 		goto beach;
 	}
 	ut8 *end = b + hdr->size;
-	if (hdr->file_name_off) {
+	if (file_name) {
+		result->file_name = file_name;
+	} else if (hdr->file_name_off) {
 		result->file_name = str_dup_safe (b, b + (size_t)hdr->file_name_off, end);
 	}
 	if (hdr->version_off) {
 		result->binary_version = str_dup_safe (b, b + (size_t)hdr->version_off, end);
 	}
 	const size_t word_size = bits / 8;
+	const ut64 start_of_sections = (ut64)hdr->n_segments * R_CS_EL_SIZE_SEG + R_CS_EL_OFF_SEGS;
+	const ut64 sect_size = (bits == 32) ? R_CS_EL_SIZE_SECT_32 : R_CS_EL_SIZE_SECT_64;
+	const ut64 start_of_symbols = start_of_sections + (ut64)hdr->n_sections * sect_size;
+	const ut64 start_of_lined_symbols = start_of_symbols + (ut64)hdr->n_symbols * R_CS_EL_SIZE_SYM;
+	const ut64 start_of_line_info = start_of_lined_symbols + (ut64)hdr->n_lined_symbols * R_CS_EL_SIZE_LSYM;
+	const ut64 start_of_unknown_pairs = start_of_line_info + (ut64)hdr->n_line_info * R_CS_EL_SIZE_LINFO;
+	const ut64 start_of_strings = start_of_unknown_pairs + (ut64)hdr->n_symbols * 8;
+
 	ut64 page_zero_size = 0;
 	size_t page_zero_idx = 0;
 	if (hdr->n_segments > 0) {
@@ -236,7 +246,7 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			}
 		}
 	}
-	const ut64 start_of_sections = (ut64)hdr->n_segments * R_CS_EL_SIZE_SEG + R_CS_EL_OFF_SEGS;
+	bool relative_to_strings = false;
 	if (hdr->n_sections > 0) {
 		result->sections = R_NEWS0 (RCoreSymCacheElementSection, hdr->n_sections);
 		if (!result->sections) {
@@ -261,15 +271,20 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 				break;
 			}
 			ut64 sect_name_off = r_read_ble (cursor, false, bits);
+			if (!i && !sect_name_off) {
+				relative_to_strings = true;
+			}
 			cursor += word_size;
 			if (bits == 32) {
 				cursor += word_size;
 			}
-			sect->name = str_dup_safe (b, sect_start + (size_t)sect_name_off, end);
+			if (relative_to_strings) {
+				sect->name = str_dup_safe (b, b + start_of_strings + (size_t)sect_name_off, end);
+			} else {
+				sect->name = str_dup_safe (b, sect_start + (size_t)sect_name_off, end);
+			}
 		}
 	}
-	const ut64 sect_size = (bits == 32) ? R_CS_EL_SIZE_SECT_32 : R_CS_EL_SIZE_SECT_64;
-	const ut64 start_of_symbols = start_of_sections + (ut64)hdr->n_sections * sect_size;
 	if (hdr->n_symbols) {
 		result->symbols = R_NEWS0 (RCoreSymCacheElementSymbol, hdr->n_symbols);
 		if (!result->symbols) {
@@ -285,12 +300,20 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t name_off = r_read_le32 (cursor + 0xc);
 			size_t mangled_name_off = r_read_le32 (cursor + 0x10);
 			sym->unk2 = (st32)r_read_le32 (cursor + 0x14);
-			sym->name = str_dup_safe (b, cursor + name_off, end);
+			if (relative_to_strings) {
+				sym->name = str_dup_safe (b, b + start_of_strings + name_off, end);
+			} else {
+				sym->name = str_dup_safe (b, cursor + name_off, end);
+			}
 			if (!sym->name) {
 				cursor += R_CS_EL_SIZE_SYM;
 				continue;
 			}
-			sym->mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
+			if (relative_to_strings) {
+				sym->mangled_name = str_dup_safe (b, b + start_of_strings + mangled_name_off, end);
+			} else {
+				sym->mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
+			}
 			if (!sym->mangled_name) {
 				cursor += R_CS_EL_SIZE_SYM;
 				continue;
@@ -298,7 +321,6 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			cursor += R_CS_EL_SIZE_SYM;
 		}
 	}
-	const ut64 start_of_lined_symbols = start_of_symbols + (ut64)hdr->n_symbols * R_CS_EL_SIZE_SYM;
 	if (hdr->n_lined_symbols) {
 		result->lined_symbols = R_NEWS0 (RCoreSymCacheElementLinedSymbol, hdr->n_lined_symbols);
 		if (!result->lined_symbols) {
@@ -317,17 +339,29 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t file_name_off = r_read_le32 (cursor + 0x18);
 			lsym->flc.line = r_read_le32 (cursor + 0x1c);
 			lsym->flc.col = r_read_le32 (cursor + 0x20);
-			lsym->sym.name = str_dup_safe (b, cursor + name_off, end);
+			if (relative_to_strings) {
+				lsym->sym.name = str_dup_safe (b, b + start_of_strings + name_off, end);
+			} else {
+				lsym->sym.name = str_dup_safe (b, cursor + name_off, end);
+			}
 			if (!lsym->sym.name) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
 			}
-			lsym->sym.mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
+			if (relative_to_strings) {
+				lsym->sym.mangled_name = str_dup_safe (b, b + start_of_strings + mangled_name_off, end);
+			} else {
+				lsym->sym.mangled_name = str_dup_safe (b, cursor + mangled_name_off, end);
+			}
 			if (!lsym->sym.mangled_name) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
 			}
-			lsym->flc.file = str_dup_safe (b, cursor + file_name_off, end);
+			if (relative_to_strings) {
+				lsym->flc.file = str_dup_safe (b, b + start_of_strings + file_name_off, end);
+			} else {
+				lsym->flc.file = str_dup_safe (b, cursor + file_name_off, end);
+			}
 			if (!lsym->flc.file) {
 				cursor += R_CS_EL_SIZE_LSYM;
 				continue;
@@ -336,7 +370,6 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			meta_add_fileline (bf, r_coresym_cache_element_pa2va (result, lsym->sym.paddr), lsym->sym.size, &lsym->flc);
 		}
 	}
-	const ut64 start_of_line_info = start_of_lined_symbols + (ut64)hdr->n_lined_symbols * R_CS_EL_SIZE_LSYM;
 	if (hdr->n_line_info) {
 		result->line_info = R_NEWS0 (RCoreSymCacheElementLineInfo, hdr->n_line_info);
 		if (!result->line_info) {
@@ -351,7 +384,11 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 			size_t file_name_off = r_read_le32 (cursor + 8);
 			info->flc.line = r_read_le32 (cursor + 0xc);
 			info->flc.col = r_read_le32 (cursor + 0x10);
-			info->flc.file = str_dup_safe (b, cursor + file_name_off, end);
+			if (relative_to_strings) {
+				info->flc.file = str_dup_safe (b, b + start_of_strings + file_name_off, end);
+			} else {
+				info->flc.file = str_dup_safe (b, cursor + file_name_off, end);
+			}
 			if (!info->flc.file) {
 				break;
 			}

--- a/libr/bin/format/mach0/coresymbolication.h
+++ b/libr/bin/format/mach0/coresymbolication.h
@@ -78,7 +78,7 @@ typedef struct r_coresym_cache_element_t {
 	RCoreSymCacheElementLineInfo *line_info;
 } RCoreSymCacheElement;
 
-R_API RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits, char * file_name);
+R_API RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits, R_OWN char * file_name);
 R_API void r_coresym_cache_element_free(RCoreSymCacheElement *element);
 R_API ut64 r_coresym_cache_element_pa2va(RCoreSymCacheElement *element, ut64 pa);
 

--- a/libr/bin/format/mach0/coresymbolication.h
+++ b/libr/bin/format/mach0/coresymbolication.h
@@ -78,7 +78,7 @@ typedef struct r_coresym_cache_element_t {
 	RCoreSymCacheElementLineInfo *line_info;
 } RCoreSymCacheElement;
 
-R_API RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits);
+R_API RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut64 off, int bits, char * file_name);
 R_API void r_coresym_cache_element_free(RCoreSymCacheElement *element);
 R_API ut64 r_coresym_cache_element_pa2va(RCoreSymCacheElement *element, ut64 pa);
 

--- a/libr/bin/p/bin_symbols.c
+++ b/libr/bin/p/bin_symbols.c
@@ -118,20 +118,6 @@ static SymbolsMetadata parseMetadata(RBuffer *buf, int off) {
 	return sm;
 }
 
-/*static void printSymbolsHeader(SymbolsHeader sh) {
-	// eprintf ("0x%08x  version  0x%x\n", 4, sh.version);
-	eprintf ("0x%08x  uuid     ", 24);
-	int i;
-	for (i = 0; i < 16; i++) {
-		eprintf ("%02x", sh.uuid[i]);
-	}
-	eprintf ("\n");
-	// parse header
-	// eprintf ("0x%08x  unknown  0x%x\n", 0x28, sh.unk0); //r_read_le32 (b+ 0x28));
-	// eprintf ("0x%08x  unknown  0x%x\n", 0x2c, sh.unk1); //r_read_le16 (b+ 0x2c));
-	// eprintf ("0x%08x  slotsize %d\n", 0x2e, sh.slotsize); // r_read_le16 (b+ 0x2e));
-}*/
-
 static RBinSection *bin_section_from_section(RCoreSymCacheElementSection *sect) {
 	if (!sect->name) {
 		return NULL;
@@ -193,7 +179,7 @@ static RBinSymbol *bin_symbol_from_symbol(RCoreSymCacheElement *element, RCoreSy
 	return sym;
 }
 
-static RCoreSymCacheElement *parseDragons(RBinFile *bf, RBuffer *buf, int off, int bits, char * file_name) {
+static RCoreSymCacheElement *parseDragons(RBinFile *bf, RBuffer *buf, int off, int bits, char *file_name) {
 	D eprintf ("Dragons at 0x%x\n", off);
 	ut64 size = r_buf_size (buf);
 	if (off >= size) {
@@ -289,11 +275,10 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 		eprintf ("Invalid headers\n");
 		return false;
 	}
-	//printSymbolsHeader (sh);
 	SymbolsMetadata sm = parseMetadata (buf, 0x40);
 	char * file_name = NULL;
 	if (sm.namelen) {
-		file_name = malloc (sm.namelen);
+		file_name = calloc (sm.namelen + 1, 1);
 		if (!file_name) {
 			return false;
 		}

--- a/libr/bin/p/bin_symbols.c
+++ b/libr/bin/p/bin_symbols.c
@@ -179,7 +179,7 @@ static RBinSymbol *bin_symbol_from_symbol(RCoreSymCacheElement *element, RCoreSy
 	return sym;
 }
 
-static RCoreSymCacheElement *parseDragons(RBinFile *bf, RBuffer *buf, int off, int bits, char *file_name) {
+static RCoreSymCacheElement *parseDragons(RBinFile *bf, RBuffer *buf, int off, int bits, R_OWN char *file_name) {
 	D eprintf ("Dragons at 0x%x\n", off);
 	ut64 size = r_buf_size (buf);
 	if (off >= size) {

--- a/libr/bin/p/bin_symbols.c
+++ b/libr/bin/p/bin_symbols.c
@@ -118,7 +118,7 @@ static SymbolsMetadata parseMetadata(RBuffer *buf, int off) {
 	return sm;
 }
 
-static void printSymbolsHeader(SymbolsHeader sh) {
+/*static void printSymbolsHeader(SymbolsHeader sh) {
 	// eprintf ("0x%08x  version  0x%x\n", 4, sh.version);
 	eprintf ("0x%08x  uuid     ", 24);
 	int i;
@@ -130,7 +130,7 @@ static void printSymbolsHeader(SymbolsHeader sh) {
 	// eprintf ("0x%08x  unknown  0x%x\n", 0x28, sh.unk0); //r_read_le32 (b+ 0x28));
 	// eprintf ("0x%08x  unknown  0x%x\n", 0x2c, sh.unk1); //r_read_le16 (b+ 0x2c));
 	// eprintf ("0x%08x  slotsize %d\n", 0x2e, sh.slotsize); // r_read_le16 (b+ 0x2e));
-}
+}*/
 
 static RBinSection *bin_section_from_section(RCoreSymCacheElementSection *sect) {
 	if (!sect->name) {

--- a/test/db/formats/mach0/coresymbolication
+++ b/test/db/formats/mach0/coresymbolication
@@ -4,18 +4,101 @@ CMDS=q
 EXPECT=
 RUN
 
+NAME=Xcode symbols cache new (just open)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
+CMDS=q
+EXPECT=
+RUN
+
 NAME=Xcode symbols cache (header)
 FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE.symbols
 CMDS=<<EOF
-ih
+ih~{:
 EOF
 EXPECT=<<EOF
-{"cs_version":1,"size":7406,"name":"/System/Volumes/Data/Users/ftamagni/Library/Developer/Xcode/Archives/2020-05-12/TestRTTI 12-05-2020, 12.15.xcarchive/dSYMs/TestRTTI.app.dSYM/Contents/Resources/DWARF/TestRTTI","uuid":"d9a37b67f10a35aaa852abfbbecc03ae","segments":6,"sections":35,"symbols":67,"lined_symbols":0,"line_info":32}
+cs_version: 1
+size: 7406
+name: /Users/ftamagni/Library/Developer/Xcode/Archives/2020-05-12/TestRTTI 12-05-2020, 12.15.xcarchive/dSYMs/TestRTTI.app.dSYM/Contents/Resources/DWARF/TestRTTI
+uuid: d9a37b67f10a35aaa852abfbbecc03ae
+segments: 6
+sections: 35
+symbols: 67
+lined_symbols: 0
+line_info: 32
+EOF
+RUN
+
+NAME=Xcode symbols cache new (header)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
+CMDS=<<EOF
+ih~{:
+EOF
+EXPECT=<<EOF
+cs_version: 1
+size: 7231
+name: /Users/ftamagni/Library/Developer/Xcode/Archives/2020-05-12/TestRTTI 12-05-2020, 12.15.xcarchive/dSYMs/TestRTTI.app.dSYM/Contents/Resources/DWARF/TestRTTI
+uuid: d9a37b67f10a35aaa852abfbbecc03ae
+segments: 6
+sections: 35
+symbols: 67
+lined_symbols: 0
+line_info: 32
 EOF
 RUN
 
 NAME=Xcode symbols cache (segment and sections)
 FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE.symbols
+CMDS=<<EOF
+f~segment
+f~section
+EOF
+EXPECT=<<EOF
+0x00000000 0 segment.__PAGEZERO
+0x100000000 32768 segment.__TEXT
+0x100008000 16384 segment.__DATA
+0x10000c000 81920 segment.__LLVM
+0x100020000 4096 segment.__LINKEDIT
+0x100021000 942080 segment.__DWARF
+0x100000000 25544 section.MACH_HEADER
+0x1000063c8 412 section.__TEXT___text
+0x100006564 144 section.__TEXT___stubs
+0x1000065f4 168 section.__TEXT___stub_helper
+0x10000669c 3366 section.__TEXT___objc_methname
+0x1000073c2 112 section.__TEXT___objc_classname
+0x100007432 2778 section.__TEXT___objc_methtype
+0x100007f0c 144 section.__TEXT___cstring
+0x100007f9c 100 section.__TEXT___unwind_info
+0x100008000 8 section.__DATA___got
+0x100008008 96 section.__DATA___la_symbol_ptr
+0x100008068 32 section.__DATA___cfstring
+0x100008088 24 section.__DATA___objc_classlist
+0x1000080a0 32 section.__DATA___objc_protolist
+0x1000080c0 8 section.__DATA___objc_imageinfo
+0x1000080c8 4872 section.__DATA___objc_const
+0x1000093d0 32 section.__DATA___objc_selrefs
+0x1000093f0 16 section.__DATA___objc_classrefs
+0x100009400 8 section.__DATA___objc_superrefs
+0x100009408 4 section.__DATA___objc_ivar
+0x100009410 240 section.__DATA___objc_data
+0x100009500 392 section.__DATA___data
+0x10000c000 77261 section.__LLVM___bundle
+0x100021000 42034 section.__DWARF___debug_line
+0x10002b432 125245 section.__DWARF___debug_pubtypes
+0x100049d6f 288036 section.__DWARF___debug_info
+0x100090293 685 section.__DWARF___debug_pubnames
+0x100090540 729 section.__DWARF___debug_loc
+0x100090819 192 section.__DWARF___debug_aranges
+0x1000908d9 1925 section.__DWARF___debug_abbrev
+0x10009105e 342172 section.__DWARF___debug_str
+0x1000e48fa 732 section.__DWARF___apple_names
+0x1000e4bd6 36 section.__DWARF___apple_namespac
+0x1000e4bfa 139417 section.__DWARF___apple_types
+0x100106c93 156 section.__DWARF___apple_objc
+EOF
+RUN
+
+NAME=Xcode symbols cache new (segment and sections)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
 CMDS=<<EOF
 f~segment
 f~section
@@ -103,6 +186,44 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=Xcode symbols cache new (symbols)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
+CMDS=<<EOF
+is*~SceneDelegate
+EOF
+EXPECT=<<EOF
+"f sym.__SceneDelegate_scene:willConnectToSession:options:_ 4 0x100006514"
+"f sym.__SceneDelegate_sceneDidDisconnect:_ 4 0x100006518"
+"f sym.__SceneDelegate_sceneDidBecomeActive:_ 4 0x10000651c"
+"f sym.__SceneDelegate_sceneWillResignActive:_ 4 0x100006520"
+"f sym.__SceneDelegate_sceneWillEnterForeground:_ 4 0x100006524"
+"f sym.__SceneDelegate_sceneDidEnterBackground:_ 4 0x100006528"
+"f sym.__SceneDelegate_window_ 16 0x10000652c"
+"f sym.__SceneDelegate_setWindow:_ 20 0x10000653c"
+"f sym.__SceneDelegate_.cxx_destruct_ 20 0x100006550"
+"f sym.__OBJC_LABEL_PROTOCOL___UISceneDelegate 8 0x1000080b0"
+"f sym.__OBJC_LABEL_PROTOCOL___UIWindowSceneDelegate 8 0x1000080b8"
+"f sym.__OBJC___PROTOCOL_REFS_UISceneDelegate 24 0x100008f50"
+"f sym.__OBJC___PROTOCOL_INSTANCE_METHODS_OPT_UISceneDelegate 296 0x100008f68"
+"f sym.__OBJC___PROTOCOL_METHOD_TYPES_UISceneDelegate 96 0x100009090"
+"f sym.__OBJC___PROTOCOL_REFS_UIWindowSceneDelegate 24 0x1000090f0"
+"f sym.__OBJC___PROTOCOL_INSTANCE_METHODS_OPT_UIWindowSceneDelegate 128 0x100009108"
+"f sym.__OBJC___PROP_LIST_UIWindowSceneDelegate 24 0x100009188"
+"f sym.__OBJC___PROTOCOL_METHOD_TYPES_UIWindowSceneDelegate 40 0x1000091a0"
+"f sym.__OBJC_CLASS_PROTOCOLS___SceneDelegate 24 0x1000091c8"
+"f sym.__OBJC_METACLASS_RO___SceneDelegate 72 0x1000091e0"
+"f sym.__OBJC___INSTANCE_METHODS_SceneDelegate 224 0x100009228"
+"f sym.__OBJC___INSTANCE_VARIABLES_SceneDelegate 40 0x100009308"
+"f sym.__OBJC___PROP_LIST_SceneDelegate 88 0x100009330"
+"f sym.__OBJC_CLASS_RO___SceneDelegate 72 0x100009388"
+"f sym._OBJC_IVAR___SceneDelegate._window 4 0x100009408"
+"f sym._OBJC_METACLASS___SceneDelegate 40 0x1000094b0"
+"f sym._OBJC_CLASS___SceneDelegate 40 0x1000094d8"
+"f sym.__OBJC_PROTOCOL___UISceneDelegate 96 0x1000095c8"
+"f sym.__OBJC_PROTOCOL___UIWindowSceneDelegate 96 0x100009628"
+EOF
+RUN
+
 NAME=Xcode symbols cache (line numbers)
 FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE.symbols
 CMDS=<<EOF
@@ -117,8 +238,34 @@ line: 30
 EOF
 RUN
 
+NAME=Xcode symbols cache new (line numbers)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
+CMDS=<<EOF
+CL `is~viewDidLoad[2]`
+CL 0x100006430
+EOF
+EXPECT=<<EOF
+file: /Users/ftamagni/src/TestRTTI/TestRTTI/ViewController.m
+line: 17
+file: /Users/ftamagni/src/TestRTTI/TestRTTI/AppDelegate.m
+line: 30
+EOF
+RUN
+
 NAME=Xcode symbols cache (flags)
 FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE.symbols
+CMDS=<<EOF
+fdj@0x100006430~{:
+EOF
+EXPECT=<<EOF
+offset: 4294992900
+name: sym.__AppDelegate_application:configurationForConnectingSceneSession:options:_
+realname: -[AppDelegate application:configurationForConnectingSceneSession:options:]
+EOF
+RUN
+
+NAME=Xcode symbols cache new (flags)
+FILE=bins/mach0/D9A37B67-F10A-35AA-A852-ABFBBECC03AE-new.symbols
 CMDS=<<EOF
 fdj@0x100006430~{:
 EOF


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

The new format is similar to the older one, but all string references are offsets from the start of the string table instead of relative to where the reference lives.

This change detects and reacts to this condition.

Depends on new test bin:  https://github.com/radareorg/radare2-testbins/pull/60
