### PR TITLE
Remove axt for vars because it is redundant with afv=

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -6,7 +6,6 @@
 #include <r_list.h>
 
 #define READ_AHEAD 1
-#define SDB_KEY_BB "bb.0x%"PFMT64x ".0x%"PFMT64x
 // XXX must be configurable by the user
 #define JMPTBLSZ 512
 #define JMPTBL_LEA_SEARCH_SZ 64
@@ -26,10 +25,6 @@
 // 64KB max size
 // 256KB max function size
 #define MAX_FCN_SIZE (1024 * 256)
-
-#define DB a->sdb_fcns
-#define EXISTS(x, ...) snprintf (key, sizeof (key) - 1, x, ## __VA_ARGS__), sdb_exists (DB, key)
-#define SETKEY(x, ...) snprintf (key, sizeof (key) - 1, x, ## __VA_ARGS__);
 
 typedef struct fcn_tree_iter_t {
 	int len;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7388,38 +7388,6 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 		char *space = strchr (input, ' ');
 		char *tmp = NULL;
 		char *name = space ? strdup (space + 1): NULL;
-
-		if (name && (tmp = strchr (name, ' '))) {
-			char *varname = tmp + 1;
-			*tmp = '\0';
-			RAnalFunction *fcn = r_anal_get_function_byname (core->anal, name);
-			if (fcn) {
-				RAnalVar *var = r_anal_function_get_var_byname (fcn, varname);
-				if (var) {
-					const char *rvar = var_ref_list (fcn->addr, var->delta, 'R');
-					const char *wvar = var_ref_list (fcn->addr, var->delta, 'W');
-					char *res = sdb_get (core->anal->sdb_fcns, rvar, 0);
-					char *res1 = sdb_get (core->anal->sdb_fcns, wvar, 0);
-					const char *ref;
-					RListIter *iter;
-					RList *list = (res && *res)? r_str_split_list (res, ",", 0): NULL;
-					RList *list1 = (res1 && *res1)? r_str_split_list (res1, ",", 0): NULL;
-					r_list_join (list , list1);
-					r_list_foreach (list, iter, ref) {
-						ut64 addr = r_num_math (NULL, ref);
-						char *op = get_buf_asm (core, core->offset, addr, fcn, true);
-						r_cons_printf ("%s 0x%"PFMT64x" [DATA] %s\n", fcn?  fcn->name : "(nofunc)", addr, op);
-						free (op);
-					}
-					free (res);
-					free (res1);
-					R_FREE (name);
-					r_list_free (list);
-					r_list_free (list1);
-					break;
-				}
-			}
-		}
 		if (space) {
 			addr = r_num_math (core->num, space + 1);
 		} else {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
