### PR TITLE
Fix null derefs on RCons when no context is provided ##cons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -283,7 +283,7 @@ R_API void r_cons_break_clear() {
 }
 
 R_API void r_cons_context_break_push(RConsContext *context, RConsBreak cb, void *user, bool sig) {
-	if (!context->break_stack) {
+	if (!context || !context->break_stack) {
 		return;
 	}
 
@@ -310,7 +310,7 @@ R_API void r_cons_context_break_push(RConsContext *context, RConsBreak cb, void 
 }
 
 R_API void r_cons_context_break_pop(RConsContext *context, bool sig) {
-	if (!context->break_stack) {
+	if (!context || !context->break_stack) {
 		return;
 	}
 	//restore old state
@@ -358,7 +358,7 @@ R_API bool r_cons_is_breaked() {
 			I.timeout = 0;
 		}
 	}
-	return I.context->breaked;
+	return I.context && I.context->breaked;
 }
 
 R_API int r_cons_get_cur_line() {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
