### PR TITLE
Fix Ordering Of Fontname And Label For Dot Graphs

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1738,7 +1738,7 @@ static int core_anal_graph_construct_nodes(RCore *core, RAnalFunction *fcn, int 
 							r_cons_printf(" \"0x%08"PFMT64x"\" [fillcolor=\"%s\","
 							"color=\"black\", fontname=\"%s\","
 							" label=\"%s\", URL=\"%s/0x%08"PFMT64x"\"]\n",
-							bbi->addr, difftype, diffstr, font, fcn->name,
+							bbi->addr, difftype, font, diffstr, fcn->name,
 							bbi->addr);
 						}
 						free (diffstr);
@@ -1762,7 +1762,7 @@ static int core_anal_graph_construct_nodes(RCore *core, RAnalFunction *fcn, int 
 							r_cons_printf(" \"0x%08"PFMT64x"\" [fillcolor=\"%s\","
 									"color=\"black\", fontname=\"%s\","
 									" label=\"%s\", URL=\"%s/0x%08"PFMT64x"\"]\n",
-									bbi->addr, difftype, str, font, fcn->name, bbi->addr);
+									bbi->addr, difftype, font, str, fcn->name, bbi->addr);
 						}
 					}
 					r_diff_free (d);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Previously the `label` and `fontname` values were swapped.
Because of this the generated dot graphs only displayed
"Courier" as their label and not the asm code.

This bug was found by generating dot graphs with the radiff2 tool (`radiff2 -m d -g ...`).