### PR TITLE
Fix abort in r_lib_open

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -291,7 +291,9 @@ R_API int r_lib_open(RLib *lib, const char *file) {
 	}
 
 	int res = r_lib_open_ptr (lib, file, handler, stru);
-	free (stru);
+	if (strf) {
+		free (stru);
+	}
 	return res;
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

I get an abort in `free` when running esilsolve plugin because `stru` contains an offset inside the .so file found from:
`stru = (RLibStruct *) r_lib_dl_sym (handler, lib->symname);` and not from `stru = strf ();`. This will fix it.
