### PR TITLE
Fix #16254 - grep expression parse improvement ##cons

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -373,7 +373,7 @@ static char *find_next_intgrep(char *cmd, const char *quotes) {
 			return (char *)p;
 		}
 		//twiddle unescape
-		memmove (p - 1, p, strlen (p) + 1);
+		r_str_cpy (p - 1, p);
 		cmd = p + 1;
 	} while (*cmd);
 	return NULL;

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -72,9 +72,10 @@ R_API void r_cons_grep_help(void) {
 
 static void parse_grep_expression(const char *str) {
 	static char buf[R_CONS_GREP_BUFSIZE], *ptrs[R_CONS_GREP_COUNT];
-	int wlen, len, ptrs_length, is_range, num_is_parsed, fail = 0;
+	int wlen, len, is_range, num_is_parsed, fail = false;
 	char *ptr, *optr, *ptr2, *ptr3, *end_ptr = NULL, last;
 	ut64 range_begin, range_end;
+	size_t ptrs_length;
 
 	if (!str || !*str) {
 		return;
@@ -115,7 +116,8 @@ static void parse_grep_expression(const char *str) {
 	grep->str = NULL;
 	bool first = true;
 	sorted_column = 0;
-	for (int i = 0; i < ptrs_length; i++) {
+	size_t i;
+	for (i = 0; i < ptrs_length; i++) {
 		ptr = ptrs[i];
 		end_ptr = ptr2 = ptr3 = NULL;
 		while (*ptr) {
@@ -226,7 +228,7 @@ static void parse_grep_expression(const char *str) {
 		ptr3 = strchr (ptr, ']');
 		is_range = 0;
 		num_is_parsed = 0;
-		fail = 0;
+		fail = false;
 		range_begin = range_end = -1;
 
 		if (ptr2 && ptr3) {
@@ -250,7 +252,7 @@ static void parse_grep_expression(const char *str) {
 				case ',':
 					for (; range_begin <= range_end; range_begin++) {
 						if (range_begin >= R_CONS_GREP_TOKENS) {
-							fail = 1;
+							fail = true;
 							break;
 						}
 						grep->tokens[range_begin] = 1;
@@ -258,7 +260,7 @@ static void parse_grep_expression(const char *str) {
 					}
 					// case of [n-]
 					if (*ptr2 == ']' && is_range && !num_is_parsed) {
-						num_is_parsed = 1;
+						num_is_parsed = true;
 						range_end = -1;
 					} else {
 						is_range = 0;
@@ -276,7 +278,7 @@ static void parse_grep_expression(const char *str) {
 						} else {
 							range_begin = range_end = r_num_get (cons->num, ptr2);
 						}
-						num_is_parsed = 1;
+						num_is_parsed = true;
 					}
 				}
 			}

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -71,8 +71,8 @@ R_API void r_cons_grep_help(void) {
 #define R_CONS_GREP_BUFSIZE 4096
 
 static void parse_grep_expression(const char *str) {
-	static char buf[R_CONS_GREP_BUFSIZE];
-	int wlen, len, is_range, num_is_parsed, fail = 0;
+	static char buf[R_CONS_GREP_BUFSIZE], *ptrs[R_CONS_GREP_COUNT];
+	int wlen, len, ptrs_length, is_range, num_is_parsed, fail = 0;
 	char *ptr, *optr, *ptr2, *ptr3, *end_ptr = NULL, last;
 	ut64 range_begin, range_end;
 
@@ -81,112 +81,6 @@ static void parse_grep_expression(const char *str) {
 	}
 	RCons *cons = r_cons_singleton ();
 	RConsGrep *grep = &cons->context->grep;
-	sorted_column = 0;
-	bool first = true;
-	while (*str) {
-		switch (*str) {
-		case '.':
-			if (str[1] == '.') {
-				if (str[2] == '.') {
-					grep->less = 2;
-				} else {
-					grep->less = 1;
-				}
-				return;
-			}
-			str++;
-			break;
-		case '{':
-			if (str[1] == ':') {
-				grep->human = true; // human friendly indentation ij~{:
-				grep->json = 1;
-				if (!strncmp (str, "{:...", 5)) {
-					grep->hud = true;
-				} else if (!strncmp (str, "{:..", 4)) {
-					grep->less = 1;
-				}
-			} else if (str[1] == '}') {
-				// standard json indentation
-				grep->json = 1;
-				if (!strncmp (str, "{}...", 5)) {
-					grep->hud = true;
-				} else if (!strncmp (str, "{}..", 4)) {
-					grep->less = 1;
-				}
-			} else {
-				char *jsonPath = strdup (str + 1);
-				char *jsonPathEnd = strchr (jsonPath, '}');
-				if (jsonPathEnd) {
-					*jsonPathEnd = 0;
-					free (grep->json_path);
-					grep->json_path = jsonPath;
-					grep->json = 1;
-				} else {
-					free (jsonPath);
-				}
-				return;
-			}
-			str++;
-			break;
-		case '$':
-			str++;
-			if (*str == '!') {
-				grep->sort_invert = true;
-				str++;
-			} else {
-				grep->sort_invert = false;
-			}
-			grep->sort = atoi (str);
-			while (IS_DIGIT (*str)) {
-				str++;
-			}
-			if (*str == ':') {
-				grep->sort_row = atoi (++str);
-				str++;
-			}
-			break;
-		case '&':
-			str++;
-			grep->amp = 1;
-			break;
-		case '<':
-			grep->zoom = atoi (++str);
-			//grep->zoomy = atoi (arg);
-			break;
-		case '+':
-			if (first) {
-				str++;
-				grep->icase = 1;
-			} else {
-				goto while_end;
-			}
-			break;
-		case '^':
-			str++;
-			grep->begin = 1;
-			break;
-		case '!':
-			str++;
-			grep->neg = 1;
-			break;
-		case '?':
-			str++;
-			grep->counter = 1;
-			if (*str == '.') {
-				grep->charCounter = true;
-				str++;
-			} else if (*str == '?') {
-				cons->filter = true;
-				r_cons_grep_help ();
-				return;
-			}
-			break;
-		default:
-			goto while_end;
-		}
-		first = false;
-	}
-while_end:
 
 	len = strlen (str) - 1;
 	if (len > R_CONS_GREP_BUFSIZE - 1) {
@@ -203,128 +97,262 @@ while_end:
 	}
 
 	ptr = buf;
-	ptr2 = strchr (ptr, '[');
-	ptr3 = strchr (ptr, ']');
-	is_range = 0;
-	num_is_parsed = 0;
-	fail = 0;
-	range_begin = range_end = -1;
+	ptrs_length = 1;
+	ptrs[0] = ptr;
 
-	if (ptr2 && ptr3) {
-		end_ptr = ptr2;
-		last = ptr3[1];
-		ptr3[1] = '\0';
-		ptr2++;
-		for (; ptr2 <= ptr3; ptr2++) {
-			if (fail) {
-				ZERO_FILL (grep->tokens);
-				grep->tokens_used = 0;
-				break;
-			}
-			switch (*ptr2) {
-			case '-':
-				is_range = 1;
-				num_is_parsed = 0;
-				range_end = -1;
-				break;
-			case ']':  // fallthrough to handle ']' like ','
-			case ',':
-				for (; range_begin <= range_end; range_begin++) {
-					if (range_begin >= R_CONS_GREP_TOKENS) {
-						fail = 1;
-						break;
-					}
-					grep->tokens[range_begin] = 1;
-					grep->tokens_used = 1;
-				}
-				// case of [n-]
-				if (*ptr2 == ']' && is_range && !num_is_parsed) {
-					num_is_parsed = 1;
-					range_end = -1;
-				} else {
-					is_range = 0;
-					num_is_parsed = 0;
-				}
-				break;
-			default:
-				if (!num_is_parsed) {
-					if (is_range) {
-						range_end = r_num_get (cons->num, ptr2);
-						// check for bad value, if range_end == 0, we check if ptr2 == '0'
-						if (range_end == 0 && *ptr != '0') {
-							range_end = -1; // this allow [n- ]
-						}
-					} else {
-						range_begin = range_end = r_num_get (cons->num, ptr2);
-					}
-					num_is_parsed = 1;
-				}
-			}
+	while ((ptrs[ptrs_length] = (strchr (ptr, '~')))) {
+		*(ptrs[ptrs_length]) = '\0';
+		ptrs[ptrs_length]++;
+		ptr = ptrs[ptrs_length];
+		ptrs_length++;
+		if (ptrs_length >= R_CONS_GREP_COUNT) {
+			eprintf ("to many nested greps\n");
+			return;
 		}
-		ptr3[1] = last;
-	}
-
-	ptr2 = strchr_ns (ptr, ':'); // line number
-	grep->range_line = 2; // there is not :
-	if (ptr2 && ptr2[1] != ':' && ptr2[1] && (IS_DIGIT (ptr2[1]) || ptr2[1] == '-' || ptr2[1] == '.')) {
-		end_ptr = end_ptr ? R_MIN (end_ptr, ptr2) : ptr2;
-		char *p, *token = ptr2 + 1;
-		p = strstr (token, "..");
-		if (!p) {
-			grep->line = r_num_get (cons->num, ptr2 + 1);
-			grep->range_line = 0;
-		} else {
-			*p = '\0';
-			grep->range_line = 1;
-			if (*token) {
-				grep->f_line = r_num_get (cons->num, token);
-			} else {
-				grep->f_line = 0;
-			}
-			if (p[2]) {
-				grep->l_line = r_num_get (cons->num, p + 2);
-			} else {
-				grep->l_line = 0;
-			}
-		}
-	}
-	if (end_ptr) {
-		*end_ptr = '\0';
-	}
-
-	len = strlen (buf) - 1;
-	if (len > 1 && buf[len] == '$' && buf[len - 1] != '\\') {
-		grep->end = 1;
-		buf[len] = '\0';
 	}
 
 	free (grep->str);
-	if (*ptr) {
-		grep->str = (char *) strdup (ptr);
-		do {
-			optr = ptr;
-			ptr = strchr (ptr, ','); // grep keywords
-			if (ptr) {
-				*ptr++ = '\0';
-			}
-			wlen = strlen (optr);
-			if (!wlen) {
-				continue;
-			}
-			if (wlen >= R_CONS_GREP_WORD_SIZE - 1) {
-				eprintf ("grep string too long\n");
-				continue;
-			}
-			grep->nstrings++;
-			if (grep->nstrings > R_CONS_GREP_WORDS - 1) {
-				eprintf ("too many grep strings\n");
+	grep->str = NULL;
+	bool first = true;
+	sorted_column = 0;
+	for (int i = 0; i < ptrs_length; i++) {
+		ptr = ptrs[i];
+		end_ptr = ptr2 = ptr3 = NULL;
+		while (*ptr) {
+			switch (*ptr) {
+			case '.':
+				if (ptr[1] == '.') {
+					if (ptr[2] == '.') {
+						grep->less = 2;
+					} else {
+						grep->less = 1;
+					}
+					return;
+				}
+				ptr++;
 				break;
+			case '{':
+				if (ptr[1] == ':') {
+					grep->human = true; // human friendly indentation ij~{:
+					grep->json = 1;
+					if (!strncmp (ptr, "{:...", 5)) {
+						grep->hud = true;
+					} else if (!strncmp (ptr, "{:..", 4)) {
+						grep->less = 1;
+					}
+				} else if (ptr[1] == '}') {
+					// standard json indentation
+					grep->json = 1;
+					if (!strncmp (ptr, "{}...", 5)) {
+						grep->hud = true;
+					} else if (!strncmp (ptr, "{}..", 4)) {
+						grep->less = 1;
+					}
+				} else {
+					char *jsonPath = strdup (ptr + 1);
+					char *jsonPathEnd = strchr (jsonPath, '}');
+					if (jsonPathEnd) {
+						*jsonPathEnd = 0;
+						free (grep->json_path);
+						grep->json_path = jsonPath;
+						grep->json = 1;
+					} else {
+						free (jsonPath);
+					}
+					return;
+				}
+				ptr++;
+				break;
+			case '$':
+				ptr++;
+				if (*ptr == '!') {
+					grep->sort_invert = true;
+					ptr++;
+				} else {
+					grep->sort_invert = false;
+				}
+				grep->sort = atoi (ptr);
+				while (IS_DIGIT (*ptr)) {
+					ptr++;
+				}
+				if (*ptr == ':') {
+					grep->sort_row = atoi (++ptr);
+					ptr++;
+				}
+				break;
+			case '&':
+				ptr++;
+				grep->amp = 1;
+				break;
+			case '<':
+				grep->zoom = atoi (++ptr);
+				//grep->zoomy = atoi (arg);
+				break;
+			case '+':
+				if (first) {
+					ptr++;
+					grep->icase = 1;
+				} else {
+					goto while_end;
+				}
+				break;
+			case '^':
+				ptr++;
+				grep->begin = 1;
+				break;
+			case '!':
+				ptr++;
+				grep->neg = 1;
+				break;
+			case '?':
+				ptr++;
+				grep->counter = 1;
+				if (*ptr == '.') {
+					grep->charCounter = true;
+					ptr++;
+				} else if (*ptr == '?') {
+					cons->filter = true;
+					r_cons_grep_help ();
+					return;
+				}
+				break;
+			default:
+				goto while_end;
 			}
-			r_str_ncpy (grep->strings[grep->nstrings - 1],
-				optr, R_CONS_GREP_WORD_SIZE);
-		} while (ptr);
-	} else {
-		grep->str = strdup (ptr);
+			first = false;
+		}
+	while_end:
+		ptr2 = strchr (ptr, '[');
+		ptr3 = strchr (ptr, ']');
+		is_range = 0;
+		num_is_parsed = 0;
+		fail = 0;
+		range_begin = range_end = -1;
+
+		if (ptr2 && ptr3) {
+			end_ptr = ptr2;
+			last = ptr3[1];
+			ptr3[1] = '\0';
+			ptr2++;
+			for (; ptr2 <= ptr3; ptr2++) {
+				if (fail) {
+					ZERO_FILL (grep->tokens);
+					grep->tokens_used = 0;
+					break;
+				}
+				switch (*ptr2) {
+				case '-':
+					is_range = 1;
+					num_is_parsed = 0;
+					range_end = -1;
+					break;
+				case ']': // fallthrough to handle ']' like ','
+				case ',':
+					for (; range_begin <= range_end; range_begin++) {
+						if (range_begin >= R_CONS_GREP_TOKENS) {
+							fail = 1;
+							break;
+						}
+						grep->tokens[range_begin] = 1;
+						grep->tokens_used = 1;
+					}
+					// case of [n-]
+					if (*ptr2 == ']' && is_range && !num_is_parsed) {
+						num_is_parsed = 1;
+						range_end = -1;
+					} else {
+						is_range = 0;
+						num_is_parsed = 0;
+					}
+					break;
+				default:
+					if (!num_is_parsed) {
+						if (is_range) {
+							range_end = r_num_get (cons->num, ptr2);
+							// check for bad value, if range_end == 0, we check if ptr2 == '0'
+							if (range_end == 0 && *ptr != '0') {
+								range_end = -1; // this allow [n- ]
+							}
+						} else {
+							range_begin = range_end = r_num_get (cons->num, ptr2);
+						}
+						num_is_parsed = 1;
+					}
+				}
+			}
+			ptr3[1] = last;
+		}
+
+		ptr2 = strchr_ns (ptr, ':'); // line number
+		grep->range_line = 2; // there is not :
+		if (ptr2 && ptr2[1] != ':' && ptr2[1] && (IS_DIGIT (ptr2[1]) || ptr2[1] == '-' || ptr2[1] == '.')) {
+			end_ptr = end_ptr? R_MIN (end_ptr, ptr2): ptr2;
+			char *p, *token = ptr2 + 1;
+			p = strstr (token, "..");
+			if (!p) {
+				grep->line = r_num_get (cons->num, ptr2 + 1);
+				grep->range_line = 0;
+			} else {
+				*p = '\0';
+				grep->range_line = 1;
+				if (*token) {
+					grep->f_line = r_num_get (cons->num, token);
+				} else {
+					grep->f_line = 0;
+				}
+				if (p[2]) {
+					grep->l_line = r_num_get (cons->num, p + 2);
+				} else {
+					grep->l_line = 0;
+				}
+			}
+		}
+		if (end_ptr) {
+			*end_ptr = '\0';
+		}
+
+		len = strlen (ptr) - 1;
+		if (len > 1 && ptr[len] == '$' && ptr[len - 1] != '\\') {
+			grep->end = 1;
+			ptr[len] = '\0';
+		}
+
+		if (*ptr) {
+			if (!grep->str) {
+				grep->str = (char *)strdup (ptr);
+			} else {
+				char *temp = (char *)malloc (sizeof (char) * len + 1);
+				strcpy (temp, ",");
+				strcat (temp, ptr);
+				grep->str = r_str_append (grep->str, temp);
+			}
+
+			do {
+				optr = ptr;
+				ptr = strchr (ptr, ','); // grep keywords
+				if (ptr) {
+					*ptr++ = '\0';
+				}
+				wlen = strlen (optr);
+				if (!wlen) {
+					continue;
+				}
+				if (wlen >= R_CONS_GREP_WORD_SIZE - 1) {
+					eprintf ("grep string too long\n");
+					continue;
+				}
+				grep->nstrings++;
+				if (grep->nstrings > R_CONS_GREP_WORDS - 1) {
+					eprintf ("too many grep strings\n");
+					break;
+				}
+				r_str_ncpy (grep->strings[grep->nstrings - 1],
+					optr, R_CONS_GREP_WORD_SIZE);
+			} while (ptr);
+		}
+	}
+	if (!grep->str) {
+		grep->str = strdup ("");
 		grep->nstrings++;
 		grep->strings[0][0] = 0;
 	}
@@ -340,10 +368,10 @@ static char *find_next_intgrep(char *cmd, const char *quotes) {
 			break;
 		}
 		if (p == cmd || *(p - 1) != '\\') {
-			return (char*)p;
+			return (char *)p;
 		}
 		//twiddle unescape
-		memmove (p - 1, p, strlen(p) + 1);
+		memmove (p - 1, p, strlen (p) + 1);
 		cmd = p + 1;
 	} while (*cmd);
 	return NULL;
@@ -352,11 +380,7 @@ static char *find_next_intgrep(char *cmd, const char *quotes) {
 /*
  * Removes grep part from *cmd* and returns newly allocated string
  * with reshaped grep expression.
- *
- * Function converts multiple twiddle expressions into internal representation.
- * For example:
- * converts "~str1~str2~str3~?" into "?&str1,str2,str3"
- */
+*/
 static char *preprocess_filter_expr(char *cmd, const char *quotes) {
 	char *p1, *p2, *ns = NULL;
 	const char *strsep = "&";
@@ -382,12 +406,12 @@ static char *preprocess_filter_expr(char *cmd, const char *quotes) {
 		ns = r_str_append (ns, strsep);
 		ns = r_str_appendlen (ns, p1 + 1, (int)(p2 - p1 - 1));
 		p1 = p2;
-		strsep = ",";
+		strsep = "~";
 		i++;
 	}
 
 	if (i > 0) {
-		ns = r_str_append (ns, ",");
+		ns = r_str_append (ns, "~");
 	}
 
 	ns = r_str_append (ns, p1 + 1);
@@ -415,7 +439,7 @@ R_API char *r_cons_grep_strip(char *cmd, const char *quotestr) {
 	return ptr;
 }
 
-R_API void r_cons_grep_process(char * grep) {
+R_API void r_cons_grep_process(char *grep) {
 	if (grep) {
 		parse_grep_expression (grep);
 		free (grep);
@@ -428,7 +452,7 @@ static int cmp(const void *a, const void *b) {
 	const char *ca = r_str_trim_head_ro (a);
 	const char *cb = r_str_trim_head_ro (b);
 	if (!a || !b) {
-		return (int) (size_t) ((char*) a - (char*) b);
+		return (int) (size_t) ((char *) a - (char *) b);
 	}
 	if (sorted_column > 0) {
 		da = strdup (ca);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -59,6 +59,7 @@ extern "C" {
 #define R_CONS_GREP_WORDS 10
 #define R_CONS_GREP_WORD_SIZE 64
 #define R_CONS_GREP_TOKENS 64
+#define R_CONS_GREP_COUNT 10
 
 R_LIB_VERSION_HEADER(r_cons);
 

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -188,6 +188,8 @@ i~or~true
 i~&or,true
 i~or~ny[0]
 i~&or,ny[0]
+i~or[1]~any
+i~or[1]~:1
 EOF
 EXPECT=<<EOF
 1
@@ -198,6 +200,8 @@ iorw     true
 iorw     true
 format
 format
+any
+true
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Now grep expression converts from `~str1[0]~str2~str3~?` into `?&str1[0],str2,str3`, and parses in series: modifier, endmodifier, column, row and at the end words. After the parsing of column or row has occurred, it is deleting col or row part by `\0` split, so we get `~str1\00]~str2~str3~?`, lost all data after and cases like a `~[0]~:1` will not work. So better way is to convert the expression to `?&str1[0]~str2~str3` create pointer to every nested grep, split by `\0` and parse every expression apart in the loop

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->