### PR TITLE
Fix #18284 (json command returning empty string) ##anal ##json

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2990,6 +2990,7 @@ static int fcn_list_json(RCore *core, RList *fcns, bool quiet) {
 	RAnalFunction *fcn;
 	PJ *pj = r_core_pj_new (core);
 	if (!pj) {
+		r_cons_println ("[]");
 		return -1;
 	}
 	pj_a (pj);
@@ -3252,6 +3253,9 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad) 
 	char temp[64];
 	r_return_val_if_fail (core && core->anal, 0);
 	if (r_list_empty (core->anal->fcns)) {
+		if (*rad == 'j') {
+			r_cons_println ("[]");
+		}
 		return 0;
 	}
 	if (*rad == '.') {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2527,6 +2527,7 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 	if (mode == 'j') {
 		pj = r_core_pj_new (core);
 		if (!pj) {
+			r_cons_println ("[]");
 			return false;
 		}
 		pj_a (pj);
@@ -2537,6 +2538,9 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 			pj_end (pj);
 			r_cons_println (pj_string (pj));
 			pj_free (pj);
+		}
+		if (mode == 'i' && input && *input == 'j') {
+			r_cons_println ("{}");
 		}
 		eprintf ("Cannot find function in 0x%08"PFMT64x"\n", addr);
 		return false;


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #18284 
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
json commands are supposed to return valid json. This PR is supposed to fix this for aflj (mentioned in the original issue) and abj (aka afbij). There might be more commands where this happens.
