### PR TITLE
io/p/io_zip: fix NULL deref when opening unknown zip

### DIFF
--- a/libr/io/p/io_zip.c
+++ b/libr/io/p/io_zip.c
@@ -136,11 +136,15 @@ static int r_io_zip_slurp_file(RIOZipFileObj *zfo) {
 
 	if (zipArch && zfo && zfo->entry != -1) {
 		zFile = zip_fopen_index (zipArch, zfo->entry, 0);
+		if (!zFile) {
+			zip_close (zipArch);
+			return false;
+		}
 		if (!zfo->b) {
 			zfo->b = r_buf_new ();
 		}
 		zip_stat_init (&sb);
-		if (zFile && zfo->b && !zip_stat_index (zipArch, zfo->entry, 0, &sb)) {
+		if (zfo->b && !zip_stat_index (zipArch, zfo->entry, 0, &sb)) {
 			ut8 *buf = calloc (1, sb.size);
 			if (buf) {
 				zip_fread (zFile, buf, sb.size);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
