### PR TITLE
Fix oobread bug in r_str_(ndup|nlen) APIs spotted by ASAN in SMD pars…

### DIFF
--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -1,4 +1,4 @@
-/* radare - LGPL3 - 2015-2018 - pancake */
+/* radare - LGPL3 - 2015-2021 - pancake */
 
 #include <r_bin.h>
 
@@ -139,7 +139,7 @@ static void addsym(RList *ret, const char *name, ut64 addr) {
 	r_list_append (ret, ptr);
 }
 
-static void showstr(const char *str, const ut8 *s, int len) {
+static void showstr(const char *str, const ut8 *s, size_t len) {
 	char *msg = r_str_ndup ((const char *) s, len);
 	eprintf ("%s: %s\n", str, msg);
 	free (msg);
@@ -153,7 +153,7 @@ static RList *symbols(RBinFile *bf) {
 	if (!(ret = r_list_newf (free))) {
 		return NULL;
 	}
-	SMD_Header hdr;
+	SMD_Header hdr = {0};
 	int left = r_buf_read_at (bf->buf, 0x100, (ut8*)&hdr, sizeof (hdr));
 	if (left < sizeof (SMD_Header)) {
 		return NULL;
@@ -163,15 +163,15 @@ static RList *symbols(RBinFile *bf) {
 	addsym (ret, "rom_end", r_read_be32 (&hdr.RomEnd));
 	addsym (ret, "ram_start", r_read_be32 (&hdr.RamStart));
 	addsym (ret, "ram_end", r_read_be32 (&hdr.RamEnd));
-	showstr ("Copyright", hdr.CopyRights, 32);
-	showstr ("DomesticName", hdr.DomesticName, 48);
-	showstr ("OverseasName", hdr.OverseasName, 48);
-	showstr ("ProductCode", hdr.ProductCode, 14);
+	showstr ("Copyright", hdr.CopyRights, sizeof (hdr.CopyRights));
+	showstr ("DomesticName", hdr.DomesticName, sizeof (hdr.DomesticName));
+	showstr ("OverseasName", hdr.OverseasName, sizeof (hdr.OverseasName));
+	showstr ("ProductCode", hdr.ProductCode, sizeof (hdr.ProductCode));
 	eprintf ("Checksum: 0x%04x\n", (ut32) hdr.CheckSum);
-	showstr ("Peripherials", hdr.Peripherials, 16);
-	showstr ("SramCode", hdr.SramCode, 12);
-	showstr ("ModemCode", hdr.ModemCode, 12);
-	showstr ("CountryCode", hdr.CountryCode, 16);
+	showstr ("Peripherials", hdr.Peripherials, sizeof (hdr.Peripherials));
+	showstr ("SramCode", hdr.SramCode, sizeof (hdr.SramCode));
+	showstr ("ModemCode", hdr.ModemCode, sizeof (hdr.ModemCode));
+	showstr ("CountryCode", hdr.CountryCode, sizeof (hdr.CountryCode));
 	ut32 vtable[64];
 	r_buf_read_at (bf->buf, 0, (ut8*)&vtable, sizeof (ut32) * 64);
 	/* parse vtable */

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -836,7 +836,7 @@ R_API char *r_str_ndup(const char *ptr, int len) {
 	if (!ptr || len < 0) {
 		return NULL;
 	}
-	size_t plen = strlen (ptr);
+	size_t plen = r_str_nlen (ptr, len);
 	size_t olen = R_MIN (len, plen);
 	char *out = malloc (olen + 1);
 	if (!out) {
@@ -1921,7 +1921,7 @@ R_API size_t r_str_ansi_len(const char *str) {
 R_API size_t r_str_nlen(const char *str, int n) {
 	size_t len = 0;
 	if (str) {
-		while (*str && n > 0) {
+		while (n > 0 && *str) {
 			len++;
 			str++;
 			n--;


### PR DESCRIPTION
…er ##bin

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
