### PR TITLE
Add Levenshtiend path API to ##diff

### DIFF
--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -56,7 +56,7 @@ typedef struct r_lev_buf {
 	ut32 len;
 } RLevBuf;
 
-typedef int (*RDiffCallback)(RDiff *diff, void *user, RDiffOp *op);
+typedef int (*RDiffCallback) (RDiff *diff, void *user, RDiffOp *op);
 
 typedef struct r_diffchar_t {
 	const ut8 *align_a;

--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -43,6 +43,19 @@ typedef struct r_diff_t {
 	int (*callback)(struct r_diff_t *diff, void *user, RDiffOp *op);
 } RDiff;
 
+typedef enum {
+	LEVEND, // array terminator
+	LEVNOP, // no change
+	LEVSUB, // substitution
+	LEVADD, // add byte in bufb to bufa
+	LEVDEL // delete byte from bufa
+} RLevOp;
+
+typedef struct r_lev_buf {
+	ut8 *buf, *mask;
+	ut32 len;
+} RLevBuf;
+
 typedef int (*RDiffCallback)(RDiff *diff, void *user, RDiffOp *op);
 
 typedef struct r_diffchar_t {
@@ -77,6 +90,7 @@ R_API int r_diff_gdiff(const char *file1, const char *file2, int rad, int va);
 R_API RDiffChar *r_diffchar_new(const ut8 *a, const ut8 *b);
 R_API void r_diffchar_print(RDiffChar *diffchar);
 R_API void r_diffchar_free(RDiffChar *diffchar);
+R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevOp **chgs);
 #endif
 
 #ifdef __cplusplus

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -174,7 +174,7 @@ R_API char *r_diff_buffers_to_string(RDiff *d, const ut8 *a, int la, const ut8 *
 #else
 // XXX buffers_static doesnt constructs the correct string in this callback
 static int tostring(RDiff *d, void *user, RDiffOp *op) {
-	RDiffUser *u = (RDiffUser*)user;
+	RDiffUser *u = (RDiffUser *)user;
 	if (op->a_len > 0) {
 		char *a_str = r_str_ndup ((const char *)op->a_buf + op->a_off, op->a_len);
 		u->str = r_str_appendf (u->str, "+(%s)", a_str);
@@ -219,15 +219,15 @@ R_API char *r_diff_buffers_to_string(RDiff *d, const ut8 *a, int la, const ut8 *
 }
 #endif
 
-#define diffHit(void) {\
-	const size_t i_hit = i - hit;\
-	int ra = la - i_hit;\
-	int rb = lb - i_hit;\
-	struct r_diff_op_t o = {\
-		.a_off = d->off_a+i-hit, .a_buf = a+i-hit, .a_len = R_MIN (hit, ra),\
-		.b_off = d->off_b+i-hit, .b_buf = b+i-hit, .b_len = R_MIN (hit, rb)\
-	};\
-	d->callback (d, d->user, &o);\
+#define diffHit(void) { \
+	const size_t i_hit = i - hit; \
+	int ra = la - i_hit; \
+	int rb = lb - i_hit; \
+	struct r_diff_op_t o = { \
+		.a_off = d->off_a+i-hit, .a_buf = a+i-hit, .a_len = R_MIN (hit, ra), \
+		.b_off = d->off_b+i-hit, .b_buf = b+i-hit, .b_len = R_MIN (hit, rb) \
+	}; \
+	d->callback (d, d->user, &o); \
 }
 
 R_API int r_diff_buffers_static(RDiff *d, const ut8 *a, int la, const ut8 *b, int lb) {
@@ -236,8 +236,8 @@ R_API int r_diff_buffers_static(RDiff *d, const ut8 *a, int la, const ut8 *b, in
 	la = R_ABS (la);
 	lb = R_ABS (lb);
 	if (la != lb) {
-	 	len = R_MIN (la, lb);
-		eprintf ("Buffer truncated to %d byte(s) (%d not compared)\n", len, R_ABS(lb-la));
+		len = R_MIN (la, lb);
+		eprintf ("Buffer truncated to %d byte(s) (%d not compared)\n", len, R_ABS(lb - la));
 	} else {
 		len = la;
 	}
@@ -270,10 +270,10 @@ R_API char *r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b,
 		r_file_hexdump (".b", b, lb, 0);
 	}
 #endif
-	char* err = NULL;
-	char* out = NULL;
+	char *err = NULL;
+	char *out = NULL;
 	int out_len;
-	char* diff_cmdline = r_str_newf ("%s .a .b", d->diff_cmd);
+	char *diff_cmdline = r_str_newf ("%s .a .b", d->diff_cmd);
 	if (diff_cmdline) {
 		(void)r_sys_cmd_str_full (diff_cmdline, NULL, &out, &out_len, &err);
 		free (diff_cmdline);
@@ -293,10 +293,8 @@ R_API int r_diff_buffers(RDiff *d, const ut8 *a, ut32 la, const ut8 *b, ut32 lb)
 // Eugene W. Myers' O(ND) diff algorithm
 // Returns edit distance with costs: insertion=1, deletion=1, no substitution
 R_API bool r_diff_buffers_distance_myers(RDiff *diff, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity) {
-	const bool verbose = diff ? diff->verbose: false;
-	if (!a || !b) {
-		return false;
-	}
+	r_return_val_if_fail (a && b, false);
+	const bool verbose = diff? diff->verbose: false;
 	const ut32 length = la + lb;
 	const ut8 *ea = a + la, *eb = b + lb;
 	// Strip prefix
@@ -348,10 +346,7 @@ out:
 }
 
 R_API bool r_diff_buffers_distance_levenshtein(RDiff *diff, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity) {
-	if (!a || !b) {
-		return false;
-	}
-
+	r_return_if_fail (a && b, false);
 	const bool verbose = diff ? diff->verbose : false;
 	const ut32 length = R_MAX (la, lb);
 	const ut8 *ea = a + la, *eb = b + lb, *t;

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -346,7 +346,7 @@ out:
 }
 
 R_API bool r_diff_buffers_distance_levenshtein(RDiff *diff, const ut8 *a, ut32 la, const ut8 *b, ut32 lb, ut32 *distance, double *similarity) {
-	r_return_if_fail (a && b, false);
+	r_return_val_if_fail (a && b, false);
 	const bool verbose = diff ? diff->verbose : false;
 	const ut32 length = R_MAX (la, lb);
 	const ut8 *ea = a + la, *eb = b + lb, *t;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
I did not see a way to get the changes from a Levenshtien algorithm in r2, so I made it.

This pull ads a the function `r_diff_levenshtein_path`. Like `r_diff_buffers_distance_levenshtein` this function computes the Levenshtien distance. Unlike `r_diff_buffers_distance_levenshtein` it produces enough of the matrix to return a `RLEVEND` terminated array of changes that can be used to get from one buffer to the other. So this is not a replacement for `r_diff_buffers_distance_levenshtein`. This is only helpful if you want to display where difference in buffers occur, and what those differences are.

Currently nothing in r2 uses this function yet. I hope to use it for diffing signatures to help debug why a signature does not match. Thus the capability to include a mask in the buffer comparison. 

I am not sure I am putting this code in the proper place, naming things well or using proper types. So I figured I would submit it for review now.

### About the alg:
Since Levenshtien is expensive in memory, a `maxdst` parameter is accepted. When this value is small, the algorithm can allocate much smaller rows for the matrix. Also, by watching when a change must occur between rows, we can make smaller allocations on later rows. If the provided `maxdist` is not large enough, the function returns ST32_MAX as the distance and the array of changes is left pointing at `NULL`. Errors, such as memory alloc fails, will result in returning -1.

### fuzzing it
Since this alg is a bit tricky, I threw a differential fuzzing harness together and let AFL attack it. The harness aborts if distance returned by `r_diff_buffers_distance_levenshtein` differs from the returned distance of `r_diff_levenshtein_path`. This is verified both for `r_diff_levenshtein_path` with a maximum `maxdist` and a minimum `maxdist` (ie: `maxdist` set to actual distance). The harness will also abort if the array of changes from `r_diff_levenshtein_path` vary depending on `maxdist` minimum/maximum. The harness will also abort if a provided `maxdist` one less then minimum does not exit correctly. After 400M+ iterations there were no crashes or hangs. I will upload the fuzzing harness if you would like to see it.

## Debug output to show how memory is saved
With no provided max distance, `abcdefg` vs `XabcdefgX` saves only one cell of memory b/c only one change happens early:
```
       58 61 62 63 64 65 66 67 58
    00 01 02 03 04 05 06 07 08 09  buflen: 10
61  01 01 01 02 03 04 05 06 07 08  buflen: 10
62  02 02 02 01 02 03 04 05 06 07  buflen: 10
63  03 03 03 02 01 02 03 04 05 06  buflen: 10
64  04 04 04 03 02 01 02 03 04 05  buflen: 10
65  05 05 05 04 03 02 01 02 03 04  buflen: 10
66  06 06 06 05 04 03 02 01 02 03  buflen: 10
67  .. 07 07 06 05 04 03 02 01 02  buflen: 9

79 matrix cells allocated
distance: 2
     ++   X  changes: 1
  a  ==   a  changes: 1
  b  ==   b  changes: 1
  c  ==   c  changes: 1
  d  ==   d  changes: 1
  e  ==   e  changes: 1
  f  ==   f  changes: 1
  g  ==   g  changes: 1
     ++   X  changes: 2
```

Same input as above but with a `maxdist` of 2 results in rows being allocated with fewer cells. 27 total cells here, 79 above. What is computed in the matrix here agrees with the one above. Cells occupied by `..` represents cells that were never computed or allocated. Those cells are not reachable taking a path through the matrix that only uses 2 changes.
```
       58 61 62 63 64 65 66 67 58
    00 01 02 03 04 .. .. .. .. ..  buflen: 5
61  .. 01 01 02 03 04 .. .. .. ..  buflen: 5
62  .. .. .. 01 02 03 .. .. .. ..  buflen: 3
63  .. .. .. .. 01 02 03 .. .. ..  buflen: 3
64  .. .. .. .. .. 01 02 03 .. ..  buflen: 3
65  .. .. .. .. .. .. 01 02 03 ..  buflen: 3
66  .. .. .. .. .. .. .. 01 02 03  buflen: 3
67  .. .. .. .. .. .. .. .. 01 02  buflen: 2

27 matrix cells allocated
distance: 2
...
```

We can still save a modest amount of memory without knowing the distance ahead of time if many changes occur early. 
```
       41 42 43 44 45 46 47 48 49 4a 4b
    00 01 02 03 04 05 06 07 08 09 0a 0b  buflen: 12
61  01 01 02 03 04 05 06 07 08 09 0a 0b  buflen: 12
62  02 02 02 03 04 05 06 07 08 09 0a 0b  buflen: 12
63  03 03 03 03 04 05 06 07 08 09 0a 0b  buflen: 12
64  04 04 04 04 04 05 06 07 08 09 0a 0b  buflen: 12
65  05 05 05 05 05 05 06 07 08 09 0a 0b  buflen: 12
66  06 06 06 06 06 06 06 07 08 09 0a 0b  buflen: 12
67  .. .. 07 07 07 07 07 07 08 09 0a 0b  buflen: 10
68  .. .. .. .. 08 08 08 08 08 09 0a 0b  buflen: 8
69  .. .. .. .. .. .. 09 09 09 09 0a 0b  buflen: 6
6a  .. .. .. .. .. .. .. .. 0a 0a 0a 0b  buflen: 4
6b  .. .. .. .. .. .. .. .. .. .. 0b 0b  buflen: 2

114 matrix cells allocated
distance: 11
  a  ->   A  changes: 1
  b  ->   B  changes: 2
  c  ->   C  changes: 3
  d  ->   D  changes: 4
  e  ->   E  changes: 5
  f  ->   F  changes: 6
  g  ->   G  changes: 7
  h  ->   H  changes: 8
  i  ->   I  changes: 9
  j  ->   J  changes: 10
  k  ->   K  changes: 11
``` 
