### PR TITLE
V850 jmptable fix, cmpval is almost always -1 and slows anal to a crawl

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1200,7 +1200,7 @@ repeat:
 				break;
 			} else if (is_v850 && anal->opt.jmptbl) {
 				int ptsz = cmpval? cmpval + 1: 4;
-				if (cmpval!= -1){
+				if (cmpval > 0) {
 					ret = try_walkthrough_jmptbl (anal, fcn, bb, depth, op->addr,
 						0, op->addr + 2, op->addr + 2, 2, ptsz, 0, ret);
 				}

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1200,8 +1200,10 @@ repeat:
 				break;
 			} else if (is_v850 && anal->opt.jmptbl) {
 				int ptsz = cmpval? cmpval + 1: 4;
-				ret = try_walkthrough_jmptbl (anal, fcn, bb, depth, op->addr,
-					0, op->addr + 2, op->addr + 2, 2, ptsz, 0, ret);
+				if (cmpval!= -1){
+					ret = try_walkthrough_jmptbl (anal, fcn, bb, depth, op->addr,
+						0, op->addr + 2, op->addr + 2, 2, ptsz, 0, ret);
+				}
 				gotoBeach (R_ANAL_RET_END);
 				break;
 			}


### PR DESCRIPTION
- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

@trufae's jmptable PR https://github.com/radareorg/radare2/pull/18447 examines the whole memory and sprinkles the asm listing with many false `case`s:

<img width="387" alt="Screen Shot 2021-03-20 at 11 07 22 am" src="https://user-images.githubusercontent.com/175587/111852792-74900180-896c-11eb-8e32-b27587dfd085.png">

This PR mitigates this bad side effect but needs further work to fix.