### PR TITLE
Remove read watchpoints, and fix checking of type watchpoints in debug_gdb ##debug

### DIFF
--- a/libr/bp/bp.c
+++ b/libr/bp/bp.c
@@ -298,7 +298,7 @@ R_API int r_bp_list(RBreakpoint *bp, int rad) {
 			pj_o (pj);
 			pj_kN (pj, "addr", b->addr);
 			pj_ki (pj, "size", b->size);
-			pj_ks (pj, "perm", r_str_rwx_i (b->perm & 7)); /* filter out R_BP_PROT_ACCESS */
+			pj_ks (pj, "perm", r_str_rwx_i (b->perm & 7));
 			pj_kb (pj, "hw", b->hw);
 			pj_kb (pj, "trace", b->trace);
 			pj_kb (pj, "enabled", b->enabled);
@@ -317,7 +317,7 @@ R_API int r_bp_list(RBreakpoint *bp, int rad) {
 				" %d %c%c%c %s %s %s %s cmd=\"%s\" cond=\"%s\" " \
 				"name=\"%s\" module=\"%s\"\n",
 				b->addr, b->addr + b->size, b->size,
-				((b->perm & R_BP_PROT_READ) | (b->perm & R_BP_PROT_ACCESS)) ? 'r' : '-',
+				(b->perm & R_BP_PROT_ACCESS) ? 'r' : '-', /*| (b->perm & R_BP_PROT_READ) - readonly hardware breakpoints don't work*/
 				((b->perm & R_BP_PROT_WRITE)| (b->perm & R_BP_PROT_ACCESS)) ? 'w' : '-',
 				(b->perm & R_BP_PROT_EXEC) ? 'x' : '-',
 				b->hw ? "hw": "sw",

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -89,7 +89,7 @@ static const char *help_msg_db[] = {
 	"dbh-", " <name>", "Remove breakpoint plugin handler",
 	"dbt", "[?]", "Show backtrace. See dbt? for more details",
 	"dbx", " [expr]", "Set expression for bp in current offset",
-	"dbw", " <addr> <r/w/rw>", "Add watchpoint",
+	"dbw", " <addr> <w/rw>", "Add watchpoint", /*readonly hardware breakpoints don't work, so without r*/
 #if __WINDOWS__
 	"dbW", " <WM_DEFINE> [?|handle|name]", "Set cond. breakpoint on a window message handler",
 #endif
@@ -113,7 +113,7 @@ static const char *help_msg_dbt[] = {
 };
 
 static const char *help_msg_dbw[] = {
-	"Usage: dbw", "<addr> <r/w/rw>"," # Add watchpoint",
+	"Usage: dbw", "<addr> <w/rw>"," # Add watchpoint", /*readonly hardware breakpoints don't work, so without r*/
 	NULL
 };
 
@@ -3359,9 +3359,11 @@ static void add_breakpoint(RCore *core, const char *input, bool hwbp, bool watch
 			int rw = 0;
 			if (watch) {
 				if (sl % 2 == 0) {
-					if (!strcmp (DB_ARG (i + 1), "r")) {
+					//readonly hardware breakpoints don't work
+					/*if (!strcmp (DB_ARG (i + 1), "r")) {
 						rw = R_BP_PROT_READ;
-					} else if (!strcmp (DB_ARG (i + 1), "w")) {
+					} else */
+					if (!strcmp (DB_ARG (i + 1), "w")) {
 						rw = R_BP_PROT_WRITE;
 					} else if (!strcmp (DB_ARG (i + 1), "rw")) {
 						rw = R_BP_PROT_ACCESS;

--- a/libr/debug/p/debug_gdb.c
+++ b/libr/debug/p/debug_gdb.c
@@ -445,7 +445,7 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 		break;
 	}
 	// TODO handle size (area of watch in upper layer and then bpsize. For the moment watches are set on exact on byte
-	case R_PERM_W: {
+	case R_BP_PROT_WRITE: {
 		if (set) {
 			gdbr_set_hww (desc, b->addr, "", 1);
 		} else {
@@ -453,15 +453,16 @@ static int r_debug_gdb_breakpoint (RBreakpoint *bp, RBreakpointItem *b, bool set
 		}
 		break;
 	}
-	case R_PERM_R: {
+	//readonly hardware breakpoints don't work
+	/*case R_BP_PROT_READ: {
 		if (set) {
 			gdbr_set_hwr (desc, b->addr, "", 1);
 		} else {
 			gdbr_remove_hwr (desc, b->addr, 1);
 		}
 		break;
-	}
-	case R_PERM_ACCESS: {
+	}*/
+	case R_BP_PROT_ACCESS: {
 		if (set) {
 			gdbr_set_hwa (desc, b->addr, "", 1);
 		} else {

--- a/libr/debug/p/debug_windbg.c
+++ b/libr/debug/p/debug_windbg.c
@@ -232,9 +232,10 @@ static int windbg_breakpoint(RBreakpoint *bp, RBreakpointItem *b, bool set) {
 		if (b->perm & R_BP_PROT_EXEC) {
 			access_type |= DEBUG_BREAK_EXECUTE;
 		}
-		if (b->perm & R_BP_PROT_READ) {
+		//readonly hardware breakpoints don't work
+		/*if (b->perm & R_BP_PROT_READ) {
 			access_type |= DEBUG_BREAK_READ;
-		}
+		}*/
 		if (b->perm & R_BP_PROT_WRITE) {
 			access_type |= DEBUG_BREAK_WRITE;
 		}

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -92,8 +92,8 @@ typedef struct r_bp_t {
 enum {
 	R_BP_PROT_EXEC = 1,
 	R_BP_PROT_WRITE = 2,
-	R_BP_PROT_READ = 4,
-	R_BP_PROT_ACCESS = 8,
+	//R_BP_PROT_READ = 4, - readonly hardware breakpoints don't work
+	R_BP_PROT_ACCESS = 4,
 };
 
 typedef struct r_bp_trace_t {


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

1) Remove read only watchpoints, because all watchpoints are hardware breakpoints and hw breakpoints don't support read only.
2) Fix checking of type (read/write/execute) watchpoint/breakpoint in debug_gdb. Previously it use own consts, their were replaced to consts from r_bp.h.