### PR TITLE
correct function pointers and allow fallback on libutil.so for dyn_init

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -74,11 +74,27 @@ static void dyn_init(void) {
 		dyn_openpty = r_lib_dl_sym (NULL, "openpty");
 	}
 	if (!dyn_login_tty) {
-		dyn_openpty = r_lib_dl_sym (NULL, "login_tty");
+		dyn_login_tty = r_lib_dl_sym (NULL, "login_tty");
 	}
 	if (!dyn_forkpty) {
-		dyn_openpty = r_lib_dl_sym (NULL, "forkpty");
+		dyn_forkpty = r_lib_dl_sym (NULL, "forkpty");
 	}
+
+#ifdef __linux__
+	// for linux distros which use it, attempt to fall back on libutil.so if something failed
+	if (!(dyn_openpty && dyn_login_tty && dyn_forkpty)) {
+		r_lib_dl_open("libutil.so");
+		if (!dyn_openpty) {
+			dyn_openpty = r_lib_dl_sym (NULL, "openpty");
+		}
+		if (!dyn_login_tty) {
+			dyn_login_tty = r_lib_dl_sym (NULL, "login_tty");
+		}
+		if (!dyn_forkpty) {
+			dyn_forkpty = r_lib_dl_sym (NULL, "forkpty");
+		}
+	}
+#endif
 }
 
 #endif

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -79,7 +79,7 @@ static void dyn_init(void) {
 	if (!dyn_forkpty) {
 		dyn_forkpty = r_lib_dl_sym (NULL, "forkpty");
 	}
-#ifdef R_LIB_EXT
+#if __UNIX__
 	// attempt to fall back on libutil if we failed to load anything
 	if (!(dyn_openpty && dyn_login_tty && dyn_forkpty)) {
 		void *libutil;


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #18501
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

I've corrected the function pointers in the original dyn_init logic. If we're on linux and any symbol failed to be found, dl_open libutil.so and try to resolve any fps which are still NULL.