### PR TITLE
Fix the failure in finding the executing user's ID during install ##build

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$UID" = 0 ]; then
+if [ "$(id -u)" = 0 ]; then
 	echo "[XX] Do not run this script as root!"
 	if [ -n "${SUDO_USER}" ]; then
 		echo "[--] Downgrading credentials to ${SUDO_USER}"


### PR DESCRIPTION
The `UID` variable used previously is a Bash extension that isn't present on all
POSIX shells.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This PR relates to a [comment I made earlier](https://github.com/radareorg/radare2/commit/815c4322171398d3807869e8cd3fdc77efcf724f#commitcomment-48786111).
<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
