### PR TITLE
Abstract r_diff_levenshtein_path ##diff

### DIFF
--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -52,9 +52,10 @@ typedef enum {
 } RLevOp;
 
 typedef struct r_lev_buf {
-	ut8 *buf, *mask;
+	void *buf;
 	ut32 len;
 } RLevBuf;
+typedef bool (*RLevMatches)(RLevBuf *a, RLevBuf *b, ut32 ia, ut32 ib);
 
 typedef int (*RDiffCallback) (RDiff *diff, void *user, RDiffOp *op);
 
@@ -90,7 +91,7 @@ R_API int r_diff_gdiff(const char *file1, const char *file2, int rad, int va);
 R_API RDiffChar *r_diffchar_new(const ut8 *a, const ut8 *b);
 R_API void r_diffchar_print(RDiffChar *diffchar);
 R_API void r_diffchar_free(RDiffChar *diffchar);
-R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevOp **chgs);
+R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff, RLevOp **chgs);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This abstracts the `r_diff_levenshtein_path` function so it can compare things other then byte buffers. The `RLevBuf` now holds a `void *` and the caller provides a function pointer to do comparisons between two buffers. So this could be used to compare ESIL strings. I ran my differential fuzzer on this using a simple `ut8 *` buffers and it seemed to work properly.

Double check that the function declaration and types make sense. Nothing relies on this code yet, so it's best to nit pick it now. Maybe it would be better to store both buffers and their lengths in a single struct like the following?

```
typedef struct r_lev_buf {
    void *bufa, *bufb;
    ut32 lena, lenb;
    void *user; // for callback, just in case
}
```

I am terrible at organizing this kind of stuff, let me know what you think. I am happy to change anything.