### PR TITLE
Fix coverity vulnerabilities

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -8912,7 +8912,7 @@ R_API void cmd_agfb3(RCore *core, const char *s, int x, int y) {
 	RConsPixel *p = r_cons_pixel_new (w, h);
 	r_cons_pixel_sets (p, 0, 0, s);
 	r_cons_pixel_flush (p, x, y);
-	R_FREE(p);
+	R_FREE (p);
 }
 
 R_API void cmd_agfb2(RCore *core, const char *s) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -8912,6 +8912,7 @@ R_API void cmd_agfb3(RCore *core, const char *s, int x, int y) {
 	RConsPixel *p = r_cons_pixel_new (w, h);
 	r_cons_pixel_sets (p, 0, 0, s);
 	r_cons_pixel_flush (p, x, y);
+	R_FREE(p);
 }
 
 R_API void cmd_agfb2(RCore *core, const char *s) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3580,7 +3580,7 @@ reaccept:
 					// silly http emulation over rap://
 					char line[256] = {0};
 					r_socket_read_block (c, (ut8*)line, sizeof (line));
-					if (!strncmp (line, "ET /cmd/", 8)) {
+					if (!r_str_ncpy (line, "ET /cmd/", 8)) {
 						char *cmd = line + 8;
 						char *http = strstr (cmd, "HTTP");
 						if (http) {

--- a/libr/hash/state.c
+++ b/libr/hash/state.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2017 pancake */
 
 #include <r_hash.h>
+#include <r_util.h>
 
 #if HAVE_LIB_SSL
 #include <openssl/md4.h>
@@ -52,7 +53,7 @@ R_API ut8 *r_hash_do_ssdeep(RHash *ctx, const ut8 *input, int len) {
 	}
 	char *res = r_hash_ssdeep (input, len);
 	if (res) {
-		strncpy ((char *)ctx->digest, res, R_HASH_SIZE_SSDEEP);
+		r_str_ncpy ((char *)ctx->digest, res, R_HASH_SIZE_SSDEEP);
 		free (res);
 	}
 	return ctx->digest;

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -96,6 +96,7 @@ static void dyn_init(void) {
 		if (!dyn_forkpty) {
 			dyn_forkpty = r_lib_dl_sym (libutil, "forkpty");
 		}
+		free(libutil);
 	}
 #endif
 }

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -96,7 +96,7 @@ static void dyn_init(void) {
 		if (!dyn_forkpty) {
 			dyn_forkpty = r_lib_dl_sym (libutil, "forkpty");
 		}
-		R_FREE(libutil);
+		R_FREE (libutil);
 	}
 #endif
 }

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -96,7 +96,7 @@ static void dyn_init(void) {
 		if (!dyn_forkpty) {
 			dyn_forkpty = r_lib_dl_sym (libutil, "forkpty");
 		}
-		free(libutil);
+		R_FREE(libutil);
 	}
 #endif
 }


### PR DESCRIPTION
Fixes the following vulnerabilities from Coverity scan:

- Fix 1409066 String not null terminated
- Fix 1451074 Buffer not null terminated
- Fix 1451532 Resource leak
- Fix 1451533 Resource leak