### PR TITLE
Fix pcdelta for ARM esil LDR ##anal

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2817,8 +2817,8 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 			if (REGBASE(1) == ARM_REG_PC) {
 				op->refptr = 4;
 				op->ptr = addr + pcdelta + MEMDISP(1);
-				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",2,2,%s,>>,<<,+,0xffffffff,&,[4],0x%x,&,%s,=",
-					(ut64)MEMDISP(1), pc, mask, REG(0));
+				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",2,2,%s,%d,+,>>,<<,+,0xffffffff,&,[4],0x%x,&,%s,=",
+					(ut64)MEMDISP(1), pc, pcdelta, mask, REG(0));
 			} else {
 				int disp = MEMDISP(1);
 				// not refptr, because we can't grab the reg value statically op->refptr = 4;

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -2721,3 +2721,23 @@ EXPECT=<<EOF
 0xaaaaaaaaaaaaaaaa
 EOF
 RUN
+
+NAME=esil pcdelta ldr
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+e asm.emu=true
+wx 01000000
+wx 04301fe5 @0x4 # ldr r3, [pc, #-0x4]
+wx 02000000 @0x8
+wx 03000000 @0xc
+aer pc=0x4
+aes
+aes
+aer r3
+EOF
+EXPECT=<<EOF
+0x00000002
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
ARM LDR translation in ESIL was wrong when pcdelta was not zero.
We have to add it to the $$ value.
