### PR TITLE
Fix search of multiple consecutive instructions

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -76,7 +76,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 	int tokcount, matchcount, count = 0;
 	int matches = 0;
 	const int addrbytes = core->io->addrbytes;
-    ut64 first_match_addr = 0;
+	 ut64 first_match_addr = 0;
 
 	if (!input || !*input) {
 		return NULL;

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -76,6 +76,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 	int tokcount, matchcount, count = 0;
 	int matches = 0;
 	const int addrbytes = core->io->addrbytes;
+    ut64 first_match_addr = 0;
 
 	if (!input || !*input) {
 		return NULL;
@@ -221,6 +222,9 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 			}
 			if (matches) {
 				code = r_str_appendf (code, "%s; ", opst);
+                if (matchcount == 0) {
+                    first_match_addr = addr;
+                }
 				if (matchcount == tokcount - 1) {
 					if (tokcount == 1) {
 						tidx = idx;
@@ -230,7 +234,7 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 						R_FREE (hits);
 						goto beach;
 					}
-					hit->addr = addr;
+					hit->addr = first_match_addr;
 					hit->len = idx + len - tidx;
 					if (hit->len == -1) {
 						r_core_asm_hit_free (hit);

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -222,9 +222,9 @@ R_API RList *r_core_asm_strsearch(RCore *core, const char *input, ut64 from, ut6
 			}
 			if (matches) {
 				code = r_str_appendf (code, "%s; ", opst);
-                if (matchcount == 0) {
-                    first_match_addr = addr;
-                }
+				if (matchcount == 0) {
+					first_match_addr = addr;
+				}
 				if (matchcount == tokcount - 1) {
 					if (tokcount == 1) {
 						tidx = idx;

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -477,6 +477,20 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=/c/ search multiple instructions
+FILE=bins/pe/standard.exe
+CMDS=<<EOF
+e asm.arch = x86
+e anal.arch = x86
+e asm.bits=32
+"/ad/ ror bh, 1; shr ebp, cl; clc"
+q
+EOF
+EXPECT=<<EOF
+0x004019d5   # 5: ror bh, 1; shr ebp, cl; clc
+EOF
+RUN
+
 NAME=/m search from/to (seek 0)
 FILE=bins/pe/standard.exe
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Fix for bug in `/ad` command where a search of multiple consecutive instructions returns offset of last instruction instead of first.

Demo:
```
e asm.arch = avr
e asm.bits = 8
wa ldi r30, 0xac @ 0
wa ldi r31, 0x06 @ 2
"/ad/ ldi r30, 0xac; ldi r31, 0x06" 
```

Expected output:
```
0x00000000   # 4: ldi r30, 0xac; ldi r31, 0x06
```

Actual output:
```
0x00000002   # 4: ldi r30, 0xac; ldi r31, 0x06
```