### PR TITLE
Freed Variables After Last Use In project.c

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -230,6 +230,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 
 	char *rc_path = get_project_script_path (core, prjfile);
 	char *prj_dir = r_file_dirname (rc_path);
+	r_return_val_if_fail (prj_dir, false);
 	R_FREE (rc_path);
 	if (r_str_endswith (prjfile, R_SYS_DIR "rc.r2")) {
 		// XXX

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -230,7 +230,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 
 	char *rc_path = get_project_script_path (core, prjfile);
 	char *prj_dir = r_file_dirname (rc_path);
-
+	R_FREE (rc_path);
 	if (r_str_endswith (prjfile, R_SYS_DIR "rc.r2")) {
 		// XXX
 		eprintf ("ENDS WITH\n");
@@ -243,7 +243,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s.d", prjfile);
 			if (!db) {
 				free (prj_dir);
-				free (rc_path);
 				return false;
 			}
 			path = strdup (db);
@@ -251,7 +250,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s" R_SYS_DIR "%s.d", prj_dir, prjfile);
 			if (!db) {
 				free (prj_dir);
-				free (rc_path);
 				return false;
 			}
 			path = r_file_abspath (db);
@@ -260,7 +258,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	if (!path) {
 		free (db);
 		free (prj_dir);
-		free (rc_path);
 		return false;
 	}
 	if (rop_db) {
@@ -280,7 +277,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 		free (db);
 		free (path);
 		free (prj_dir);
-		free (rc_path);
 		return false;
 	}
 	sdb_ns_set (core->sdb, "rop", rop_db);
@@ -308,7 +304,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	free (path_ns);
 	free (db);
 	free (prj_dir);
-	free (rc_path);
 	return true;
 }
 
@@ -462,10 +457,10 @@ R_API char *r_core_project_name(RCore *core, const char *prjfile) {
 	if (R_STR_ISEMPTY (file)) {
 		free (file);
 		file = strdup (prjfile);
-		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
+		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
 		if (slash) {
 			*slash = 0;
-			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
+			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
 			if (slash) {
 				char *res = strdup (slash + 1);
 				free (file);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -257,6 +257,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	}
 	if (!path) {
 		free (db);
+		free (prj_dir);
 		return false;
 	}
 	if (rop_db) {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -243,7 +243,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s.d", prjfile);
 			if (!db) {
 				free (prj_dir);
-				free (rc_path);
 				return false;
 			}
 			path = strdup (db);
@@ -251,7 +250,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s" R_SYS_DIR "%s.d", prj_dir, prjfile);
 			if (!db) {
 				free (prj_dir);
-				free (rc_path);
 				return false;
 			}
 			path = r_file_abspath (db);
@@ -259,8 +257,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	}
 	if (!path) {
 		free (db);
-		free (prj_dir);
-		free (rc_path);
 		return false;
 	}
 	if (rop_db) {
@@ -280,7 +276,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 		free (db);
 		free (path);
 		free (prj_dir);
-		free (rc_path);
 		return false;
 	}
 	sdb_ns_set (core->sdb, "rop", rop_db);
@@ -308,7 +303,6 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	free (path_ns);
 	free (db);
 	free (prj_dir);
-	free (rc_path);
 	return true;
 }
 

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -310,10 +310,8 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 R_API void r_core_project_execute_cmds(RCore *core, const char *prjfile) {
 	char *str = r_core_project_notes_file (core, prjfile);
 	char *data = r_file_slurp (str, NULL);
-	if (!data) {
-		free (str);
-		return;
-	}
+	free (str);
+	r_return_if_fail (data);
 	Output out;
 	out.fout = NULL;
 	out.cout = r_strbuf_new (NULL);
@@ -331,7 +329,6 @@ R_API void r_core_project_execute_cmds(RCore *core, const char *prjfile) {
 		bol = strtok (NULL, "\n");
 	}
 	free (data);
-	free (str);
 }
 
 typedef struct {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -230,12 +230,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 
 	char *rc_path = get_project_script_path (core, prjfile);
 	char *prj_dir = r_file_dirname (rc_path);
-<<<<<<< HEAD
-	r_return_val_if_fail (prj_dir, false);
 	R_FREE (rc_path);
-=======
-
->>>>>>> parent of d4cdb2d1d... In load_project_rop() rc_path is not freed when not in use
 	if (r_str_endswith (prjfile, R_SYS_DIR "rc.r2")) {
 		// XXX
 		eprintf ("ENDS WITH\n");
@@ -467,10 +462,10 @@ R_API char *r_core_project_name(RCore *core, const char *prjfile) {
 	if (R_STR_ISEMPTY (file)) {
 		free (file);
 		file = strdup (prjfile);
-		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
+		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
 		if (slash) {
 			*slash = 0;
-			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
+			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
 			if (slash) {
 				char *res = strdup (slash + 1);
 				free (file);

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -230,8 +230,12 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 
 	char *rc_path = get_project_script_path (core, prjfile);
 	char *prj_dir = r_file_dirname (rc_path);
+<<<<<<< HEAD
 	r_return_val_if_fail (prj_dir, false);
 	R_FREE (rc_path);
+=======
+
+>>>>>>> parent of d4cdb2d1d... In load_project_rop() rc_path is not freed when not in use
 	if (r_str_endswith (prjfile, R_SYS_DIR "rc.r2")) {
 		// XXX
 		eprintf ("ENDS WITH\n");
@@ -244,6 +248,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s.d", prjfile);
 			if (!db) {
 				free (prj_dir);
+				free (rc_path);
 				return false;
 			}
 			path = strdup (db);
@@ -251,6 +256,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 			db = r_str_newf ("%s" R_SYS_DIR "%s.d", prj_dir, prjfile);
 			if (!db) {
 				free (prj_dir);
+				free (rc_path);
 				return false;
 			}
 			path = r_file_abspath (db);
@@ -259,6 +265,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	if (!path) {
 		free (db);
 		free (prj_dir);
+		free (rc_path);
 		return false;
 	}
 	if (rop_db) {
@@ -278,6 +285,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 		free (db);
 		free (path);
 		free (prj_dir);
+		free (rc_path);
 		return false;
 	}
 	sdb_ns_set (core->sdb, "rop", rop_db);
@@ -305,6 +313,7 @@ static bool load_project_rop(RCore *core, const char *prjfile) {
 	free (path_ns);
 	free (db);
 	free (prj_dir);
+	free (rc_path);
 	return true;
 }
 
@@ -458,10 +467,10 @@ R_API char *r_core_project_name(RCore *core, const char *prjfile) {
 	if (R_STR_ISEMPTY (file)) {
 		free (file);
 		file = strdup (prjfile);
-		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
+		char *slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
 		if (slash) {
 			*slash = 0;
-			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]);
+			slash = (char *)r_str_lchr (file, R_SYS_DIR[0]); 
 			if (slash) {
 				char *res = strdup (slash + 1);
 				free (file);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
In project.c ln 231 you can see: char *rc_path = get_project_script_path (core, prjfile);
and then in line 232 rc_path is used for the last time but it is not freed until the function returns.