### PR TITLE
Add recursive list functionality to libr/util/file.c

### DIFF
--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -54,7 +54,7 @@ R_API bool r_file_copy(const char *src, const char *dst);
 R_API bool r_file_move(const char *src, const char *dst);
 R_API RList* r_file_globsearch (const char *globbed_path, int maxdepth);
 R_API RMmap *r_file_mmap_arch (RMmap *map, const char *filename, int fd);
-
+R_API bool r_file_find(RList *dst, char *dir);
 #ifdef __cplusplus
 }
 #endif

--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -54,7 +54,7 @@ R_API bool r_file_copy(const char *src, const char *dst);
 R_API bool r_file_move(const char *src, const char *dst);
 R_API RList* r_file_globsearch (const char *globbed_path, int maxdepth);
 R_API RMmap *r_file_mmap_arch (RMmap *map, const char *filename, int fd);
-R_API bool r_file_find(RList *dst, char *dir);
+R_API bool r_file_dir_recursive(RList *dst, char *dir);
 #ifdef __cplusplus
 }
 #endif

--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -54,7 +54,7 @@ R_API bool r_file_copy(const char *src, const char *dst);
 R_API bool r_file_move(const char *src, const char *dst);
 R_API RList* r_file_globsearch (const char *globbed_path, int maxdepth);
 R_API RMmap *r_file_mmap_arch (RMmap *map, const char *filename, int fd);
-R_API bool r_file_dir_recursive(RList *dst, char *dir);
+R_API bool r_file_dir_recursive(RList *dst, const char *dir);
 #ifdef __cplusplus
 }
 #endif

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,24 +1275,6 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
-R_API bool r_file_copy_recursive(char *dst, char *src) {
-	char *path;
-	RListIter *iter;
-	RList *files = r_list_new ();
-	r_return_val_if_fail (files, false);
-	char *newp = r_file_dirname (src);
-	if (!newp) {
-		r_list_free (files);
-		return false;
-	}
-	dst = r_str_newf ("%s" R_SYS_DIR "%s", newp);
-	free (newp);
-	if (!dst) {
-		r_list_free (files);
-		return false;
-	}
-}
-
 R_API bool r_file_dir_recursive(RList *dst, char *dir) {
 	char *cwd = r_sys_getdir ();
 	r_return_val_if_fail (cwd, NULL);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,6 +1275,31 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
+R_API bool r_file_find (RList *dst, char *dir) {
+	char *cwd = r_sys_getdir ();
+	r_return_val_if_fail (cwd, NULL);
+	if (r_sys_chdir (dir) == false) {
+		free (cwd);
+		return false;
+	}
+	bool ret = true;
+	RList *files = r_sys_dir (".");
+	RListIter *iter;
+	char *name;
+	r_return_val_if_fail (files, false);
+	r_list_foreach (files, iter, name) {
+		if (strcmp (name, ".") == 0 || strcmp (name, "..") == 0) {
+			continue;
+		}
+		r_list_append (dst, r_file_abspath (name));
+		if (r_file_is_directory (name)) {
+			ret = lsrf (dst, name);
+		}
+	}
+	r_sys_chdir (cwd);
+	return ret;
+}
+
 static void recursive_search_glob(const char *path, const char *glob, RList* list, int depth) {
 	if (depth < 1) {
 		return;

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,6 +1275,24 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
+R_API bool r_file_copy_recursive(char *dst, char *src) {
+	char *path;
+	RListIter *iter;
+	RList *files = r_list_new ();
+	r_return_val_if_fail (files, false);
+	char *newp = r_file_dirname (src);
+	if (!newp) {
+		r_list_free (files);
+		return false;
+	}
+	dst = r_str_newf ("%s" R_SYS_DIR "%s", newp);
+	free (newp);
+	if (!dst) {
+		r_list_free (files);
+		return false;
+	}
+}
+
 R_API bool r_file_dir_recursive(RList *dst, char *dir) {
 	char *cwd = r_sys_getdir ();
 	r_return_val_if_fail (cwd, NULL);
@@ -1288,14 +1306,10 @@ R_API bool r_file_dir_recursive(RList *dst, char *dir) {
 	char *name;
 	r_return_val_if_fail (files, false);
 	r_list_foreach (files, iter, name) {
-		char buff[3];
 		if (strcmp (name, ".") == 0 || strcmp (name, "..") == 0) {
 			continue;
 		}
 		r_list_append (dst, r_file_abspath (name));
-		if (readlink (name, buff, 3) != -1) {
-			continue;
-		}
 		if (r_file_is_directory (name)) {
 			ret = r_file_dir_recursive (dst, name);
 		}

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,7 +1275,7 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
-R_API bool r_file_find(RList *dst, char *dir) {
+R_API bool r_file_dir_recursive(RList *dst, char *dir) {
 	char *cwd = r_sys_getdir ();
 	r_return_val_if_fail (cwd, NULL);
 	if (r_sys_chdir (dir) == false) {
@@ -1297,7 +1297,7 @@ R_API bool r_file_find(RList *dst, char *dir) {
 			continue;
 		}
 		if (r_file_is_directory (name)) {
-			ret = r_file_find (dst, name);
+			ret = r_file_dir_recursive (dst, name);
 		}
 	}
 	r_sys_chdir (cwd);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1276,13 +1276,13 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 }
 
 R_API bool r_file_dir_recursive(RList *dst, char *dir) {
+	bool ret = false;
 	char *cwd = r_sys_getdir ();
 	r_return_val_if_fail (cwd, NULL);
 	if (r_sys_chdir (dir) == false) {
 		free (cwd);
-		return false;
+		return ret;
 	}
-	bool ret = true;
 	RList *files = r_sys_dir (".");
 	RListIter *iter;
 	char *name;

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,10 +1275,12 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
-R_API bool r_file_dir_recursive(RList *dst, char *dir) {
+R_API bool r_file_dir_recursive(RList *dst, const char *dir) {
 	bool ret = false;
 	char *cwd = r_sys_getdir ();
-	r_return_val_if_fail (cwd, NULL);
+	if (!cwd) {
+		return false;
+	}
 	if (r_sys_chdir (dir) == false) {
 		free (cwd);
 		return ret;

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1293,7 +1293,7 @@ R_API bool r_file_find (RList *dst, char *dir) {
 		}
 		r_list_append (dst, r_file_abspath (name));
 		if (r_file_is_directory (name)) {
-			ret = lsrf (dst, name);
+			ret = r_file_find (dst, name);
 		}
 	}
 	r_sys_chdir (cwd);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1275,7 +1275,7 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #endif
 }
 
-R_API bool r_file_find (RList *dst, char *dir) {
+R_API bool r_file_find(RList *dst, char *dir) {
 	char *cwd = r_sys_getdir ();
 	r_return_val_if_fail (cwd, NULL);
 	if (r_sys_chdir (dir) == false) {
@@ -1288,10 +1288,14 @@ R_API bool r_file_find (RList *dst, char *dir) {
 	char *name;
 	r_return_val_if_fail (files, false);
 	r_list_foreach (files, iter, name) {
+		char buff[3];
 		if (strcmp (name, ".") == 0 || strcmp (name, "..") == 0) {
 			continue;
 		}
 		r_list_append (dst, r_file_abspath (name));
+		if (readlink (name, buff, 3) != -1) {
+			continue;
+		}
 		if (r_file_is_directory (name)) {
 			ret = r_file_find (dst, name);
 		}


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This patch is supposed to add the functionality given by the unix command find <dir>. In the future this functionality might enable fetures like recursive copy and remove 
