### PR TITLE
Add abstract Levenshtein dist ##diff

### DIFF
--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -91,7 +91,6 @@ R_API int r_diff_gdiff(const char *file1, const char *file2, int rad, int va);
 R_API RDiffChar *r_diffchar_new(const ut8 *a, const ut8 *b);
 R_API void r_diffchar_print(RDiffChar *diffchar);
 R_API void r_diffchar_free(RDiffChar *diffchar);
-R_API st32 r_diff_levenshtein_dist(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff);
 R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff, RLevOp **chgs);
 #endif
 

--- a/libr/include/r_diff.h
+++ b/libr/include/r_diff.h
@@ -91,6 +91,7 @@ R_API int r_diff_gdiff(const char *file1, const char *file2, int rad, int va);
 R_API RDiffChar *r_diffchar_new(const ut8 *a, const ut8 *b);
 R_API void r_diffchar_print(RDiffChar *diffchar);
 R_API void r_diffchar_free(RDiffChar *diffchar);
+R_API st32 r_diff_levenshtein_dist(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff);
 R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff, RLevOp **chgs);
 #endif
 

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -685,20 +685,7 @@ R_API void r_diffchar_free(RDiffChar *diffchar) {
 	}
 }
 
-/**
- * \brief Return Levenshtein distance between to RLevBuf *
- * \param bufa Structure to represent starting buffer
- * \param bufb Structure to represent the buffer to reach
- * \param maxdst Max Levenshtein distance need, send UT32_MAX if unkown.
- * \param levdiff Function pointer returning true when there is a difference.
- *
- * Find Levenshtein distance between two buffers. This algorythm does not
- * return the path through the matrix, so it is dramaticly more memmory
- * effecent then r_diff_levenshtein_path. A good maxdst can help speed the
- * algorythm by reducing the number of cells iterated over. If maxdst is
- * exceeded, ST32_MAX is retured.
- */
-R_API st32 r_diff_levenshtein_dist_abs(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff) {
+static st32 r_diff_levenshtein_nopath(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff) {
 	r_return_val_if_fail (bufa && bufb && bufa->buf && bufb->buf, -1);
 
 	// force buffer b to be longer, this will invert add/del resulsts
@@ -831,7 +818,11 @@ R_API st32 r_diff_levenshtein_dist_abs(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst
  * caller must free *chgs.
  */
 R_API st32 r_diff_levenshtein_path(RLevBuf *bufa, RLevBuf *bufb, ut32 maxdst, RLevMatches levdiff, RLevOp **chgs) {
-	r_return_val_if_fail (bufa && bufb && bufa->buf && bufb->buf && chgs && !*chgs, -1);
+	r_return_val_if_fail (bufa && bufb && bufa->buf && bufb->buf, -1);
+	if (chgs == NULL) {
+		return r_diff_levenshtein_nopath (bufa, bufb, maxdst, levdiff);
+	}
+	r_return_val_if_fail (!*chgs, -1);
 
 	// force buffer b to be longer, this will invert add/del resulsts
 	bool invert = false;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Add `r_diff_levenshtein_dist` which acts like `r_diff_levenshtein_path` but does not allocate the matrix or return the path through the matrix. 

This is pretty much identical to `r_diff_buffers_distance_levenshtein` except `r_diff_levenshtein_dist` is abstract. It can work on any data type since comparisons are done via a function pointer. The `r_diff_levenshtein_dist` function also has the same `maxdist` logic from `r_diff_levenshtein_path` which can improve speed. In particular, `zb` and `zbr` should see a speed increase in using the new function because of an early exit when two signatures show differences early but are of similar size.

The new function will also attempt to calculate fewer cells as the number of changes seen increases. This could have a speedup but also comes at the expense of code complexity. I would not get rid of `r_diff_buffers_distance_levenshtein`, it would be good to compare the results of both to each other to find bugs. I did do differential fuzzing on this again and got through 9M executions of AFL without finding a difference.

If this is accepted I will go about switching `zb` and `zbr` to this function so we can have some regression testing for it.