### PR TITLE
Added missing null check in ht_*_find in ht_inc.c 

### DIFF
--- a/shlr/sdb/src/ht_inc.c
+++ b/shlr/sdb/src/ht_inc.c
@@ -302,7 +302,9 @@ SDB_API HT_(Kv)* Ht_(find_kv)(HtName_(Ht)* ht, const KEY_TYPE key, bool* found) 
 		*found = false;
 	}
 	if (!ht) {
-		*found = false;
+		if(found) {
+			*found = false;
+		}
 		return NULL;
 	}
 


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: None
- [x] Mark this if you consider it ready to merge

**Description**

This is a small contribution adding a null check in ht_inc.c. I came across the null pointer dereference while fuzzing with afl.
