### PR TITLE
Fix proper hash comments & quotes mix ##cmd

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3062,24 +3062,28 @@ static int r_core_cmd_subst(RCore *core, char *cmd) {
 	if (!icmd || (cmd[0] == '#' && cmd[1] != '!' && cmd[1] != '?')) {
 		goto beach;
 	}
-	if (*icmd && !strchr (icmd, '"')) {
+	if (*cmd) {
+		int inside_quote = 0;
 		char *hash;
-		for (hash = icmd + 1; *hash; hash++) {
+		for (hash = cmd; *hash; hash++) {
 			if (*hash == '\\') {
 				hash++;
-				if (*hash == '#') {
+				if (*hash == '#' || *hash == '"') {
 					continue;
 				} else if (!*hash) {
 					break;
 				}
 			}
-			if (*hash == '#') {
+			if (*hash == '"') {
+				inside_quote ^= 1;
+			}
+			if (*hash == '#' && hash != cmd && !inside_quote) {
 				break;
 			}
 		}
-		if (hash && *hash) {
+		if (hash && *hash && !inside_quote) {
 			*hash = 0;
-			r_str_trim_tail (icmd);
+			r_str_trim_tail (cmd);
 		}
 	}
 	if (*cmd != '"') {

--- a/test/db/cmd/cmd_interpret
+++ b/test/db/cmd/cmd_interpret
@@ -32,6 +32,7 @@ EOF
 RUN
 
 NAME=$foo=#!pipe
+ARGS=-ecfg.newshell=true
 FILE=-
 CMDS=<<EOF
 #!pipe echo hello
@@ -42,7 +43,6 @@ $foo
 $foo
 ?e --
 $-*
-e cfg.newshell=true
 $foo=\#!pipe echo hello
 $foo
 ?e --

--- a/test/db/cmd/cmds
+++ b/test/db/cmd/cmds
@@ -154,3 +154,13 @@ EXPECT=<<EOF
 b821000000
 EOF
 RUN
+
+NAME=hash comment and double quote
+FILE=malloc://1024
+CMDS=<<EOF
+?? # ;o"
+EOF
+EXPECT=<<EOF
+0
+EOF
+RUN


### PR DESCRIPTION
The problem was that the quotes are not checked to be before or after
the hash comment.

Fixes: 765f2b6bd4098b8e90e46a45c174a71099bc0d56
Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@gmail.com>

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #2818
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Any command after the hash sign can be executed if double quote is after the hash.
Example:
```
[0x00000004]> ?  # ;0.wrongseek;Invalidcmd|\wrongsh;3=4@4>/@\wrongfile"";=h
Cannot seek to unknown address '0.wrongseek'
|ERROR| Invalid command 'Invalidcmd' (0x49)
sh: 1: wrongsh: not found
r_cons_pipe_open: Cannot open file '/@\wrongfile""'
Error: Unknown host
Error: Unknown host
Starting http server...
open http://localhost:9090/
r2 -C http://localhost:9090/cmd/
```
