### PR TITLE
Improve python disassembler and binary parser ##bin

### DIFF
--- a/libr/anal/p/anal_pyc.c
+++ b/libr/anal/p/anal_pyc.c
@@ -36,6 +36,13 @@ static char *get_reg_profile(RAnal *anal) {
 	);
 }
 
+static bool set_reg_profile(RAnal *anal) {
+	char *rp = get_reg_profile (anal);
+	bool b = r_reg_set_profile_string (anal->reg, rp);
+	free (rp);
+	return b;
+}
+
 static RList *get_pyc_code_obj(RAnal *anal) {
 	RBin *b = anal->binb.bin;
 	RBinPlugin *plugin = b->cur && b->cur->o? b->cur->o->plugin: NULL;
@@ -138,6 +145,7 @@ RAnalPlugin r_anal_plugin_pyc = {
 	.bits = 16 | 8, // Partially agree with this
 	.archinfo = archinfo,
 	.get_reg_profile = get_reg_profile,
+	.set_reg_profile = &set_reg_profile,
 	.op = &pyc_op,
 	.esil = false,
 	.fini = &finish,

--- a/libr/asm/arch/pyc/opcode.c
+++ b/libr/asm/arch/pyc/opcode.c
@@ -120,6 +120,7 @@ static version_opcode version_op[] = {
 	{ "v3.9.0a1", opcode_39 },
 	{ "v3.9.0a2", opcode_39 },
 	{ "v3.9.0a3", opcode_39 },
+	{ "v3.9.0", opcode_39 },
 	{ NULL, NULL },
 };
 

--- a/libr/asm/arch/pyc/pyc_dis.c
+++ b/libr/asm/arch/pyc/pyc_dis.c
@@ -31,11 +31,13 @@ int r_pyc_disasm(RAsmOp *opstruct, const ut8 *code, RList *cobjs, RList *interne
 
 		ut8 op = code[i];
 		i++;
-		char *name = ops->opcodes[op].op_name;
+		char *name = strdup (ops->opcodes[op].op_name);
+		r_str_case (name, 0);
 		r_strbuf_set (&opstruct->buf_asm, name);
 		if (!name) {
 			return 0;
 		}
+		free (name);
 		if (op >= ops->have_argument) {
 			if (ops->bits == 16) {
 				oparg = code[i] + code[i + 1] * 256 + extended_arg;
@@ -54,7 +56,7 @@ int r_pyc_disasm(RAsmOp *opstruct, const ut8 *code, RList *cobjs, RList *interne
 			}
 			const char *arg = parse_arg (&ops->opcodes[op], oparg, names, consts, varnames, interned_table, freevars, cellvars, ops->opcode_arg_fmt);
 			if (arg != NULL) {
-				r_strbuf_appendf (&opstruct->buf_asm, "%20s", arg);
+				r_strbuf_appendf (&opstruct->buf_asm, " %s", arg);
 				free ((char *)arg);
 			}
 		} else if (ops->bits == 8) {

--- a/libr/asm/p/asm_pyc.c
+++ b/libr/asm/p/asm_pyc.c
@@ -26,7 +26,9 @@ static int disassemble(RAsm *a, RAsmOp *opstruct, const ut8 *buf, int len) {
 	RList *interned_table = r_list_get_n (shared, 1);
 	if (!opcodes_cache || !pyc_opcodes_equal (opcodes_cache, a->cpu)) {
 		opcodes_cache = get_opcode_by_version (a->cpu);
-		opcodes_cache->bits = a->bits;
+		if (opcodes_cache) {
+			opcodes_cache->bits = a->bits;
+		}
 	}
 	int r = r_pyc_disasm (opstruct, buf, cobjs, interned_table, pc, opcodes_cache);
 	opstruct->size = r;

--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -603,9 +603,9 @@ static pyc_object *get_dict_object(RBuffer *buffer) {
 			break;
 		}
 		if (!r_list_append (ret->data, val)) {
+			free_object (val);
 			r_list_free (ret->data);
 			R_FREE (ret);
-			free_object (val);
 			return NULL;
 		}
 	}
@@ -771,6 +771,9 @@ static void free_object(pyc_object *object) {
 	case TYPE_UNKNOWN:
 		eprintf ("Free not implemented for type %x\n", object->type);
 		break;
+	case 0:
+		// nop
+		break;
 	default:
 		eprintf ("Undefined type in free_object (%x)\n", object->type);
 		break;
@@ -843,6 +846,9 @@ static pyc_object *copy_object(pyc_object *object) {
 	case TYPE_UNICODE:
 	case TYPE_UNKNOWN:
 		eprintf ("Copy not implemented for type %x\n", object->type);
+		break;
+	case 0:
+		// nop
 		break;
 	default:
 		eprintf ("Undefined type in copy_object (%x)\n", object->type);
@@ -1121,6 +1127,9 @@ static pyc_object *get_object(RBuffer *buffer) {
 		eprintf ("Get not implemented for type 0x%x\n", type);
 		free_object (ret);
 		return NULL;
+	case 0:
+		// nop
+		break;
 	default:
 		eprintf ("Undefined type in get_object (0x%x)\n", type);
 		free_object (ret);
@@ -1186,8 +1195,9 @@ static bool extract_sections_symbols(pyc_object *obj, RList *sections, RList *sy
 	if (!r_list_append (symbols, symbol)) {
 		goto fail;
 	}
-	r_list_foreach (((RList *)(cobj->consts->data)), i, obj)
+	r_list_foreach (((RList *)(cobj->consts->data)), i, obj) {
 		extract_sections_symbols (obj, sections, symbols, cobjs, prefix);
+	}
 	free (prefix);
 	return true;
 fail:
@@ -1201,11 +1211,12 @@ fail:
 bool get_sections_symbols_from_code_objects(RBuffer *buffer, RList *sections, RList *symbols, RList *cobjs, ut32 magic) {
 	bool ret;
 	magic_int = magic;
-	refs = r_list_newf ((RListFree)free_object);
+	refs = r_list_newf (NULL); // (RListFree)free_object);
 	if (!refs) {
 		return false;
 	}
 	ret = extract_sections_symbols (get_object (buffer), sections, symbols, cobjs, NULL);
 	r_list_free (refs);
+	refs = NULL;
 	return ret;
 }

--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -718,6 +718,9 @@ static void free_object(pyc_object *object) {
 	if (!object) {
 		return;
 	}
+	if ((int)object->type == 0) {
+		return;
+	}
 	switch (object->type) {
 	case TYPE_SMALL_TUPLE:
 	case TYPE_TUPLE:
@@ -771,9 +774,6 @@ static void free_object(pyc_object *object) {
 	case TYPE_UNKNOWN:
 		eprintf ("Free not implemented for type %x\n", object->type);
 		break;
-	case 0:
-		// nop
-		break;
 	default:
 		eprintf ("Undefined type in free_object (%x)\n", object->type);
 		break;
@@ -788,6 +788,9 @@ static pyc_object *copy_object(pyc_object *object) {
 		return NULL;
 	}
 	copy->type = object->type;
+	if ((int)object->type == 0) {
+		// do nothing
+	} else 
 	switch (object->type) {
 	case TYPE_NULL:
 		break;
@@ -846,9 +849,6 @@ static pyc_object *copy_object(pyc_object *object) {
 	case TYPE_UNICODE:
 	case TYPE_UNKNOWN:
 		eprintf ("Copy not implemented for type %x\n", object->type);
-		break;
-	case 0:
-		// nop
 		break;
 	default:
 		eprintf ("Undefined type in copy_object (%x)\n", object->type);

--- a/libr/bin/format/pyc/pyc_magic.c
+++ b/libr/bin/format/pyc/pyc_magic.c
@@ -222,7 +222,6 @@ struct pyc_version get_pyc_version(ut32 magic) {
 			return versions[i];
 		}
 	}
-	eprintf ("invalid version%c", 10);
 	return fail;
 }
 

--- a/libr/bin/format/pyc/pyc_magic.c
+++ b/libr/bin/format/pyc/pyc_magic.c
@@ -211,15 +211,18 @@ static struct pyc_version versions[] = {
 	{ 0x0a0d0d5c, "v3.9.0a1", "fd757083df79c21eee862e8d89aeefefe45f64a0" },
 	{ 0x0a0d0d5e, "v3.9.0a2", "bf0a31c8fb782e03e9530c2488ab2d0e29fc0495" },
 	{ 0x0a0d0d60, "v3.9.0a3", "a36ea266c6470f6c65416f24de4497637e59af23" },
+	{ 0x0a0d0d61, "v3.9.0", "123" },
 };
 
 struct pyc_version get_pyc_version(ut32 magic) {
 	struct pyc_version fail = { -1, 0, 0 };
-	ut32 i;
-	for (i = 0; i < sizeof (versions) / sizeof (*versions); i++)
+	size_t i;
+	for (i = 0; i < sizeof (versions) / sizeof (*versions); i++) {
 		if (versions[i].magic == magic) {
 			return versions[i];
 		}
+	}
+	eprintf ("invalid version%c", 10);
 	return fail;
 }
 
@@ -230,6 +233,7 @@ bool magic_int_within(ut32 target_magic, ut32 lower, ut32 upper, bool *error) {
 	ut64 ti = 0, li = 0, ui = 0;
 	ut64 size = sizeof (versions) / sizeof (struct pyc_version);
 	for (; ti < size && versions[ti].magic != target_magic; ti++) {
+		// just loop
 	}
 	if (ti == size) {
 		*error = true;
@@ -238,6 +242,7 @@ bool magic_int_within(ut32 target_magic, ut32 lower, ut32 upper, bool *error) {
 	}
 
 	for (; li < size && (versions[li].magic & 0xffff) != lower; li++) {
+		// just loop
 	}
 	if (li == size) {
 		*error = true;
@@ -246,6 +251,7 @@ bool magic_int_within(ut32 target_magic, ut32 lower, ut32 upper, bool *error) {
 	}
 
 	for (; ui < size && (versions[ui].magic & 0xffff) != upper; ui++) {
+		// just loop
 	}
 	if (ui == size) {
 		*error = true;
@@ -259,15 +265,18 @@ bool magic_int_within(ut32 target_magic, ut32 lower, ut32 upper, bool *error) {
 double version2double(const char *version) {
 	unsigned idx = 0, buf_idx = 0;
 	char buf[20];
-	double result;
+	double result = 0;
 
-	while (!('0' <= version[idx] && version[idx] <= '9'))
+	while (!('0' <= version[idx] && version[idx] <= '9')) {
 		idx++;
-	for (; version[idx] != '.'; idx++)
+	}
+	for (; version[idx] != '.'; idx++) {
 		buf[buf_idx++] = version[idx];
+	}
 	buf[buf_idx++] = version[idx++];
-	for (; '0' <= version[idx] && version[idx] <= '9'; idx++)
+	for (; '0' <= version[idx] && version[idx] <= '9'; idx++) {
 		buf[buf_idx++] = version[idx];
+	}
 	buf[buf_idx] = '\x00';
 	sscanf (buf, "%lf", &result);
 	return result;

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -1,0 +1,199 @@
+NAME=pyc load version39
+FILE=bins/pyc/py39.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python v3.9.0 VM (rev 123)
+EOF
+RUN
+
+NAME=pyc load version38
+FILE=bins/pyc/py38.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python v3.8.0 VM (rev 5d714034866ce1e9f89dc141fe4cc0b50cf20a8e)
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc load version37
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python v3.7.0 VM (rev ae1f6af15f3e4110616801e235873e47fd7d1977)
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc load version36
+FILE=bins/pyc/py36.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python v3.6.0 VM (rev 5c4568a05a0a62b5947c55f68f9f2ecfb90a4f12)
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc load version27
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+iI~machine
+EOF
+EXPECT=<<EOF
+machine  Python 2.7a2+ VM (rev edfed0e32cedf3b84c6e999052486a750a3f5bee)
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc symbols
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+is~?Human
+EOF
+EXPECT=<<EOF
+9
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc sections
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+iS~Bat
+EOF
+EXPECT=<<EOF
+30  0x00001f0d   0x2a 0x00001f0d   0x2a ---- <module>.Bat
+31  0x00001f5f    0xa 0x00001f5f    0xa ---- <module>.Bat.__init__
+32  0x00001fca    0x8 0x00001fca    0x8 ---- <module>.Bat.say
+33  0x00002037    0x4 0x00002037    0x4 ---- <module>.Bat.sonar
+34  0x00002103   0x1c 0x00002103   0x1c ---- <module>.Batman
+35  0x00002143   0x44 0x00002143   0x44 ---- <module>.Batman.__init__
+36  0x00002235    0x4 0x00002235    0x4 ---- <module>.Batman.sing
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc entry
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+ie~program
+EOF
+EXPECT=<<EOF
+vaddr=0x0000002a paddr=0x0000002a haddr=-1 type=program
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc disasm
+FILE=bins/pyc/py37.pyc
+CMDS=<<EOF
+pd 10
+EOF
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- section._module_:
+            ;-- <module>:
+            0x0000002a      6400           load_const  Multiline strings can be written
+    using three "s, and are often used
+    as documentation. ; [00] ---- section size 3218 named <module>
+            0x0000002c      5a00           store_name __doc__
+            0x0000002e      6401           load_const True
+        ,=< 0x00000030      6f0a           jump_if_false_or_pop 10
+        |   0x00000032      6402           load_const False
+        `-> 0x00000034      0100           pop_top
+            0x00000036      6402           load_const False
+        ,=< 0x00000038      7012           jump_if_true_or_pop 18
+        |   0x0000003a      6401           load_const True
+        `-> 0x0000003c      0100           pop_top
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc symbols for pyc2.7
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+is~hello_world
+EOF
+EXPECT=<<EOF
+1   0x00000052 0x00000052 NONE FUNC 9        <module>.hello_world
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc disasm for 2.7
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+pd 10
+EOF
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- section._module_:
+            ;-- <module>:
+            0x0000001e      640000         load_const CodeObject(hello_world) from hello.py ; [00] ---- section size 25 named <module>
+            0x00000021      840000         make_function
+            0x00000024      5a0000         store_name hello_world
+            0x00000027      640100         load_const 'world'
+            0x0000002a      47             print_item
+            0x0000002b      48             print_newline
+            0x0000002c      650000         load_name hello_world
+            0x0000002f      830000         call_function 0 positional, 0 named
+            0x00000032      01             pop_top
+            0x00000033      640200         load_const None
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+EOF
+RUN
+
+NAME=pyc function
+FILE=bins/pyc/py27.pyc
+CMDS=<<EOF
+af
+pdf
+EOF
+EXPECT=<<EOF
+            ;-- section._module_:
+            ;-- <module>:
+/ 25: entry0 ();
+|           0x0000001e      640000         load_const CodeObject(hello_world) from hello.py ; [00] ---- section size 25 named <module>
+|           0x00000021      840000         make_function
+|           0x00000024      5a0000         store_name hello_world
+|           0x00000027      640100         load_const 'world'
+|           0x0000002a      47             print_item
+|           0x0000002b      48             print_newline
+|           0x0000002c      650000         load_name hello_world
+|           0x0000002f      830000         call_function 0 positional, 0 named
+|           0x00000032      01             pop_top
+|           0x00000033      640200         load_const None
+\           0x00000036      53             return_value
+EOF
+EXPECT_ERR=<<EOF
+WARNING: No calling convention defined for this file, analysis may be inaccurate.
+Warning: set your favourite calling convention in `e anal.cc=?`
+EOF
+RUN


### PR DESCRIPTION
* Fix segfault when loading pyc9 file
* Lowercase all instructions (user can later decide asm.ucase)
* Use 1 space, not 20, between instruction and arg
* Detect pyc3.9 bins, not loading properly yet

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
