### PR TITLE
Fix wrong demangling of tiff swab16 bit data ##bin

### DIFF
--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -261,7 +261,7 @@ R_API char *r_bin_demangle_swift(const char *s, bool syscmd) {
 			break;
 		case 'I': // interfaces
 			/* TODO */
-			break;
+			return NULL; // Fix __TIFF demangling
 		}
 	}
 	if (tail) {

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -26,10 +26,10 @@ nth vaddr      bind type lib name
 15  ---------- NONE FUNC     __TIFFSetupFields
 16  ---------- NONE FUNC     __TIFFFillStriles
 17  ---------- NONE FUNC     __TIFFNoPostDecode
-18  ---------- NONE FUNC     sym.imp.BitData
-19  ---------- NONE FUNC     sym.imp.BitData
-20  ---------- NONE FUNC     sym.imp.BitData
-21  ---------- NONE FUNC     sym.imp.BitData
+18  ---------- NONE FUNC     __TIFFSwab16BitData
+19  ---------- NONE FUNC     __TIFFSwab24BitData
+20  ---------- NONE FUNC     __TIFFSwab32BitData
+21  ---------- NONE FUNC     __TIFFSwab64BitData
 22  ---------- NONE FUNC     _TIFFSetCompressionScheme
 23  ---------- NONE FUNC     __TIFFDataSize
 24  ---------- NONE FUNC     __TIFFCheckMalloc


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
