### PR TITLE
Fix rafind2 issues when used with multiple files ##search

### DIFF
--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -38,7 +38,6 @@ typedef struct {
 
 static void rafind_options_fini(RafindOptions *ro) {
 	free (ro->buf);
-	r_list_free (ro->keywords);
 }
 
 static void rafind_options_init(RafindOptions *ro) {
@@ -476,6 +475,7 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 		}
 		rafind_open (&ro, file);
 	}
+	r_list_free (ro.keywords);
 	if (ro.json) {
 		printf ("]\n");
 	}

--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -241,10 +241,10 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 		/* TODO: implement using api */
 		char *tostr = (to && to != UT64_MAX)?  r_str_newf ("-e search.to=%"PFMT64d, to): strdup ("");
 		r_sys_cmdf ("r2"
-			" -e search.in=range"
-			" -e search.align=%d"
-			" -e search.from=%"PFMT64d
-			" %s -qnc/m%s \"%s\"",
+			    " -e search.in=range"
+			    " -e search.align=%d"
+			    " -e search.from=%" PFMT64d
+			    " %s -qnc/m%s \"%s\"",
 			ro->align, ro->from, tostr, ro->json? "j": "", efile);
 		free (tostr);
 		goto done;

--- a/test/db/tools/rafind2
+++ b/test/db/tools/rafind2
@@ -195,6 +195,25 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rafind2 multiple files
+FILE=-
+CMDS=!rafind2 -s README bins/arm/README bins/arm/README
+EXPECT=<<EOF
+File: bins/arm/README
+0x0
+File: bins/arm/README
+0x0
+EOF
+RUN
+
+NAME=rafind2 recursive
+FILE=-
+CMDS=!rafind2 -q -s README bins/arm
+EXPECT=<<EOF
+0x0
+EOF
+RUN
+
 NAME=rafind2 ""
 FILE=-
 CMDS=!rafind2 ""


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->



Hi, I have discovered some issues in ``rafind2`` when it is used with multiple files.

The first issue is that ``rafind2`` segfaults when multiple files are provided.

For example (invoked in the top of the repo):
```
$ rafind2 -s radare.org Makefile README.md
File: Makefile
0x36d5
File: README.md
Segmentation fault (core dumped)
```

The issue seems to be that after some refactoring the list of keywords to search for is freed prematurely.
Note that this issue also affects the recursive search when providing a dir instead of files.

The first patch in this PR should fix this, see:

```
$ rafind2 -s radare.org Makefile README.md
File: Makefile
0x36d5
File: README.md
0xb9
0xacd
0xae6
```

The second issue is that the context for each file is not re-initialized and can contain garbage from the previous run.

For example:
```
$ rafind2 -s radare.org Makefile README.md
```

Produces a different output than:
```
$ rafind2 -s radare.org README.md Makefile
```

In addition running ``rafind2`` recursively in the root git directory produces lots of ``Invalid delta`` errors.

The second patch in this PR fixes that - the fix is to use a local copy of the variables from the context instead of operating on the shared context.

The third patch adds two tests which should make sure similar things do not happen in the future.

The last patch fixes some formatting issues in the code reported by ``./sys/clang-format-diff.py``.
The changes are in a separate patch as I did not really change those lines and I am not sure I should be fixing their formatting - the extra commit is easier to drop if it should stay as it is now. I can also amend this patch to the one with the changes if you'd prefer me to.
