### PR TITLE
filename printing improvements in rafind2 ##search

### DIFF
--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -271,8 +271,6 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 				r_search_kw_add (rs, r_search_keyword_new_str (kw, ro->mask, NULL, 0));
 			}
 		}
-	} else if (ro->mode == R_SEARCH_STRING) {
-		r_search_kw_add (rs, r_search_keyword_new_hexmask ("00", NULL)); //XXX
 	}
 
 	ro->curfile = file;

--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -126,6 +126,9 @@ static int hit(RSearchKeyword *kw, void *user, ut64 addr) {
 	} else if (ro->rad) {
 		printf ("f hit%d_%d 0x%08"PFMT64x" ; %s\n", 0, kw->count, addr, ro->curfile);
 	} else {
+		if (!ro->quiet) {
+			printf ("%s: ", ro->curfile);
+		}
 		if (ro->showstr) {
 			printf ("0x%"PFMT64x" %s\n", addr, str);
 		} else {
@@ -178,10 +181,6 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 	int ret, result = 0;
 
 	ro->buf = NULL;
-	if (!ro->quiet) {
-		printf ("File: %s\n", file);
-	}
-
 	char *efile = r_str_escape_sh (file);
 
 	if (ro->identify) {

--- a/test/db/tools/rafind2
+++ b/test/db/tools/rafind2
@@ -199,10 +199,8 @@ NAME=rafind2 multiple files
 FILE=-
 CMDS=!rafind2 -s README bins/arm/README bins/arm/README
 EXPECT=<<EOF
-File: bins/arm/README
-0x0
-File: bins/arm/README
-0x0
+bins/arm/README: 0x0
+bins/arm/README: 0x0
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

The current implementation of the filename header wasn't very useful when there are many files without any match, for example:
```
$ rafind2 -s R2AGENT man
File: man/rax2.1
File: man/rarun2.1
File: man/radare2.1
File: man/r2agent.1
0x15
0x2c
File: man/r2pm.1
File: man/r2-docker.1
File: man/rahash2.1
File: man/radiff2.1
File: man/r2r.1
File: man/rafind2.1
File: man/rasm2.1
File: man/esil.7
File: man/rasign2.1
File: man/ragg2.1
File: man/rabin2.1
```
This gets worse if there are more files.

And even worse when it is combined with other printing modes (like json, where the header literally breaks the json by printing filenames in between).

The first patch changes the way the header is printed o more grep-like approach - the name is printed before each match:
```
$ rafind2 -s R2AGENT man
man/r2agent.1: 0x15
man/r2agent.1: 0x2c
```
(it can still be disabled with the `-q` swtich)

The second patch adds `file` entry to the json output, it now looks like this:
```
[(null){"file":"README.md","offset":185,"type":"string","data":"radare.org"},{"file":"README.md","offset":2765,"type":"string","data":"radare.org/](https://www.radare.org/)"},{"file":"README.md","offset":2790,"type":"string","data":"radare.org/)"}]
```

Note the `(null)` at the beginning of each json. The third patch solves that by initializing `comma` to an empty string, I think it was accidentally removed in 66bd6ed8706857cd7e17e94abedc53925bffee67

Note that the search types that use `r_sys_cmdf` do not now have the header printing feature, possible approaches here:
* Restore the original filename printing here (despite the flood for large directories) - should be fairly easy to add.
* Revisit this after their TODOs (_implenet using api_) are done (I might want to look at this later although I cannot promise anything).