### PR TITLE
Clang format script fixes

### DIFF
--- a/sys/clang-format-diff.py
+++ b/sys/clang-format-diff.py
@@ -126,7 +126,7 @@ def main():
 
         debug('lineidx : ' + input[lineidx + i])
 
-        if input[lineidx + i].startswith('diff'):
+        if input[lineidx + i].startswith('diff') or (i != 0 and input[lineidx + i].startswith('@@')):
             break
         i += 1
 

--- a/sys/clang-format-diff.py
+++ b/sys/clang-format-diff.py
@@ -110,7 +110,6 @@ def main():
         if lineidx + i >= len(input):
           break
 
-        debug('lineidx : ' + input[lineidx + i])
         # do not count lines that are removed
         if not input[lineidx + i].startswith('-'):
           range_line += 1
@@ -124,6 +123,9 @@ def main():
             debug('set range_end: ' + str(start_line + range_line))
             lines_by_file.setdefault(filename, []).append([range_start, range_end - 1])
             range_start, range_end = None, None
+
+        debug('lineidx : ' + input[lineidx + i])
+
         if input[lineidx + i].startswith('diff'):
             break
         i += 1

--- a/sys/clang-format-diff.py
+++ b/sys/clang-format-diff.py
@@ -117,10 +117,10 @@ def main():
 
         if input[lineidx + i].startswith('+'):
           if range_start is None:
-            range_start = start_line + range_line
+            range_start = start_line + range_line - 1
             debug('set range_start: ' + str(start_line + range_line))
         elif range_start is not None and range_end is None:
-            range_end = start_line + range_line
+            range_end = start_line + range_line - 1
             debug('set range_end: ' + str(start_line + range_line))
             lines_by_file.setdefault(filename, []).append([range_start, range_end - 1])
             range_start, range_end = None, None


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
The first patch fixes an off-by-one error when detecting formatting issues.

Without this, for example such change goes unnoticed:

```
diff --git a/libr/main/radare2.c b/libr/main/radare2.c
index 7699c091a..a7a6397f9 100644
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -280,6 +280,7 @@ beach:
 }
 
 static bool mustSaveHistory(RConfig *c) {
+       test();
        if (!r_config_get_i (c, "scr.histsave")) {
                return false;
        }
```

The second patch improves the debug output by moving the printed line after printing the boundaries.
Thanks to this, using `--debug` we get:

```
lineidx :  }
lineidx :  
lineidx :  static bool mustSaveHistory(RConfig *c) {
set range_start: 284
lineidx : +     test();
set range_end: 285
lineidx :       if (!r_config_get_i (c, "scr.histsave")) {
lineidx :               return false;
lineidx :       }
```

Instead of the original, confusing:

```
lineidx :  }
lineidx :  
lineidx :  static bool mustSaveHistory(RConfig *c) {
lineidx : +     test();
set range_start: 284
lineidx :       if (!r_config_get_i (c, "scr.histsave")) {
set range_end: 285
lineidx :               return false;
lineidx :       }
```

The last patch makes the script break the patch into proper git chunks before detecting ranges.
Without this, the script tends to detect lots of unchanged lines as changed.

This makes it work much more reliably when using it the way recommended in the contributing guide ( `git diff origin/master | ./sys/clang-format-diff.py -p1`)