### PR TITLE
Fixed confusion between *input and *arg in cmd_ls()

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1285,7 +1285,7 @@ static int cmd_ls(void *data, const char *input) { // "ls"
 	}
 	switch (*input) {
 	case 'r':
-		cmd_lsr (core, input);
+		cmd_lsr (core, arg);
 		break;
 	case '?': // "l?"
 		eprintf ("Usage: l[es] # ls to list files, le[ss] to less a file\n");


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues:
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
In #18526 I added the r_file_lsrf function to the cmd.c file and it caused a problem as I passed *input to a function instead of *arg. I would like to express my apology towards trufae and everyone who uses r2. I clearly didn't write my code responsibly and I can only hope to one day improve so I can give back to this truly wonderful project.
