### PR TITLE
Fix regexp search in rafind2 ##search

### DIFF
--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -257,7 +257,7 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 		}
 		goto done;
 	}
-	if (ro->mode == R_SEARCH_KEYWORD) {
+	if (ro->mode == R_SEARCH_KEYWORD || ro->mode == R_SEARCH_REGEXP) {
 		r_list_foreach (ro->keywords, iter, kw) {
 			if (ro->hexstr) {
 				if (ro->mask) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

The `-e` switch (regexp) didn't work in rafind2 - the keywords were never set.
It seems that the code can be shared with regular keyword search. The only issue, which I don't think can be solved without some proper refactoring is that some of the modes that can specify the keywords multiple times share the same variables (e.g. the keywords) and overwrite the mode. So I guess it won't work as expected (?)