### PR TITLE
Rafind regexp fixes ##search

### DIFF
--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -464,7 +464,7 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 	if (opt.ind + 1 == argc && !r_file_is_directory (argv[opt.ind])) {
 		ro.quiet = true;
 	}
-	if (ro.json && ro.mode == R_SEARCH_KEYWORD) {
+	if (ro.json && (ro.mode == R_SEARCH_KEYWORD || ro.mode == R_SEARCH_REGEXP)) {
 		// TODO: remove mode check when all modes use api
 		ro.pj = pj_new ();
 		pj_a (ro.pj);

--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -257,7 +257,7 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 		}
 		goto done;
 	}
-	if (ro->mode == R_SEARCH_KEYWORD || ro->mode == R_SEARCH_REGEXP) {
+	if (ro->mode == R_SEARCH_KEYWORD) {
 		r_list_foreach (ro->keywords, iter, kw) {
 			if (ro->hexstr) {
 				if (ro->mask) {
@@ -270,6 +270,11 @@ static int rafind_open_file(RafindOptions *ro, const char *file, const ut8 *data
 			} else {
 				r_search_kw_add (rs, r_search_keyword_new_str (kw, ro->mask, NULL, 0));
 			}
+		}
+	}
+	if (ro->mode == R_SEARCH_REGEXP) {
+		r_list_foreach (ro->keywords, iter, kw) {
+			r_search_kw_add (rs, r_search_keyword_new_regexp (kw, NULL));
 		}
 	}
 

--- a/test/db/tools/rafind2
+++ b/test/db/tools/rafind2
@@ -212,6 +212,64 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rafind2 json
+FILE=-
+CMDS=!rafind2 -j -s README bins/arm/README
+EXPECT=<<EOF
+[{"file":"bins/arm/README","offset":0,"type":"string","data":"README"}]
+EOF
+RUN
+
+NAME=rafind2 regexp
+FILE=-
+CMDS=!rafind2 -e /R.A..E/ bins/arm/README
+EXPECT=<<EOF
+0x0
+EOF
+RUN
+
+NAME=rafind2 regexp json
+FILE=-
+CMDS=!rafind2 -j -e /R.A..E/ bins/arm/README
+EXPECT=<<EOF
+[{"file":"bins/arm/README","offset":0,"type":"string","data":"README"}]
+EOF
+RUN
+
+NAME=rafind2 multiple strings
+FILE=-
+CMDS=!rafind2 -s README -s This bins/arm/README
+EXPECT=<<EOF
+0x0
+0xf
+EOF
+RUN
+
+NAME=rafind2 multiple strings json
+FILE=-
+CMDS=!rafind2 -j -s README -s This bins/arm/README
+EXPECT=<<EOF
+[{"file":"bins/arm/README","offset":0,"type":"string","data":"README"},{"file":"bins/arm/README","offset":15,"type":"string","data":"This directory contains binaries for tests on the arm architecture. So far the"}]
+EOF
+RUN
+
+NAME=rafind2 multiple regexps
+FILE=-
+CMDS=!rafind2 -e /R....E/ -e /Th.s/ bins/arm/README
+EXPECT=<<EOF
+0x0
+0xf
+EOF
+RUN
+
+NAME=rafind2 multiple regexps json
+FILE=-
+CMDS=!rafind2 -j -e /R....E/ -e /Th.s/ bins/arm/README
+EXPECT=<<EOF
+[{"file":"bins/arm/README","offset":0,"type":"string","data":"README"},{"file":"bins/arm/README","offset":15,"type":"string","data":"This directory contains binaries for tests on the arm architecture. So far the"}]
+EOF
+RUN
+
 NAME=rafind2 ""
 FILE=-
 CMDS=!rafind2 ""


### PR DESCRIPTION
strlen does not count the trailing \0 - the r_search_keyword_new call
uses memcpy internally to copy the string based on the length provided
in the argument.

Effectively we do not copy the trailing \0 to the keyword and the search
does not always work as intended (sometimes the garbage from the memory
is 'joined' to the keyword string).

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
