### PR TITLE
Avoid c99 feature

### DIFF
--- a/libr/crypto/p/crypto_cps2.c
+++ b/libr/crypto/p/crypto_cps2.c
@@ -726,7 +726,8 @@ static bool set_key(RCrypto *cry, const ut8 *key, int keylen, int mode, int dire
 	} else if (keylen == 20) {
 		const ut8* key8 = (const ut8*)key;
 		unsigned short decoded[10] = {0};
-		for (int b = 0; b < 10 * 16; b++) {
+		int b;
+		for (b = 0; b < 10 * 16; b++) {
 			int bit = (317 - b) % 160;
 			if ((key8[bit / 8] >> ((bit ^ 7) % 8)) & 1)	{
 				decoded[b / 16] |= (0x8000 >> (b % 16));


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
Hello,
this patch avoids c99 feature of declaring variable withing the for stanza. 
In rest of the radare2 the same pattern of NOT declaring the variables in for cycle is already followed.
This was the only exception.


Sample build log output
FAILED: libr/crypto/libr_crypto.so.5.2.0.p/p_crypto_cps2.c.o 
cc -Ilibr/crypto/libr_crypto.so.5.2.0.p -I. -I.. -I../libr/include -I../shlr/spp -I../shlr/sdb/src -pipe -D_FILE_OFFSET_BITS=64 -fvisibility=hidden -O2 -g -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -fPIC -pthread -DR2_PLUGIN_INCORE=1 -MD -MQ libr/crypto/libr_crypto.so.5.2.0.p/p_crypto_cps2.c.o -MF libr/crypto/libr_crypto.so.5.2.0.p/p_crypto_cps2.c.o.d -o libr/crypto/libr_crypto.so.5.2.0.p/p_crypto_cps2.c.o -c ../libr/crypto/p/crypto_cps2.c
../libr/crypto/p/crypto_cps2.c: In function 'set_key':
../libr/crypto/p/crypto_cps2.c:729:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (int b = 0; b < 10 * 16; b++) {
   ^
../libr/crypto/p/crypto_cps2.c:729:3: note: use option -std=c99 or -std=gnu99 to compile your code
ninja: build stopped: subcommand failed.
