### PR TITLE
Fix unshown warning in `zb` command when size is small

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1100,9 +1100,7 @@ static bool bestmatch_sig(RCore *core, const char *input) {
 		RSignBytes *b = item->bytes;
 		int minsz = r_config_get_i (core->config, "zign.minsz");
 		if (b && b->size < minsz) {
-			eprintf ("Warning: Function signature is too small (%d < %d) See e zign.minsz", b->size, minsz);
-			r_sign_item_free (item);
-			return false;
+			eprintf ("Warning: Function signature is too small (%d < %d) See e zign.minsz \n", b->size, minsz);
 		}
 	}
 	if (r_config_get_i (core->config, "zign.graph")) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Now `zb` command has no output when function signature is smaller than minsz, it's meant to print warning but `\n` is missing so users can just see blank.

I make small changes so the warning is shown along with the matched functions.

`make -k all` throw lots of errors on my machine saying `<r_*.h>: No such file or directory`. But I have checked the tests manually and there is no test related to small function signature size so I think it can be merged.

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
