### PR TITLE
Make z/ search sigs seen in z* ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -2211,12 +2211,13 @@ struct ctxForeachCB {
 
 static bool foreachCB(void *user, const char *k, const char *v) {
 	struct ctxForeachCB *ctx = (struct ctxForeachCB *) user;
+	r_return_val_if_fail (ctx && ctx->cb, false);
 	RSignItem *it = r_sign_item_new ();
 	RAnal *a = ctx->anal;
 
 	if (r_sign_deserialize (a, it, k, v)) {
 		RSpace *cur = r_spaces_current (&a->zign_spaces);
-		if (ctx->cb && cur == it->space) {
+		if (!cur || cur == it->space) {
 			ctx->cb (it, ctx->user);
 		}
 	} else {

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -552,6 +552,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=zs * searches all zignspaces
+FILE=bins/elf/analysis/zigs
+CMDS=<<EOF
+aaa
+zs test
+zaf main foobar
+zs *
+z/
+?v sign.bytes.foobar_0
+EOF
+EXPECT=<<EOF
+0x40055b
+EOF
+RUN
+
 NAME=zc
 FILE=bins/elf/analysis/zigs_stripped
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Before this commit, when in the NULL zignspace (`zs *`), the `z`, `z*` and `zj` commands will display all signatures in all zignspaces. However, the `z/` command will only search signatures in the current NULL space. See below:

```
[0x00006160]> zs *
[0x00006160]> z ~entry
(testspace) testspace:entry0:
  realname: entry0
  types: func.entry0.args=1, func.entry0.arg.0="int64_t,arg3"
[0x00006160]> z/
[+] searching 0x000245c8 - 0x000258b8
[+] searching 0x00023350 - 0x000245c8
[+] searching 0x00019000 - 0x00021f08
[+] searching 0x00004000 - 0x000181a9
[+] searching 0x00000000 - 0x00003538
[+] searching function metrics
[0x00006160]> zs testspace 
[0x00006160]> z/
[+] searching 0x000245c8 - 0x000258b8
[+] searching 0x00023350 - 0x000245c8
[+] searching 0x00019000 - 0x00021f08
[+] searching 0x00004000 - 0x000181a9
[+] searching 0x00000000 - 0x00003538
[+] searching function metrics
bytes:  1
types:  1
bbhash: 1
total:  3
[0x00006160]> zs
    1 * testspace

```

I feel like this is confusing behavior. After this commit the NULL zignspace will cause `z/` to search for all signatures in all zignspaces. See the added test for an example.