### PR TITLE
Refactor output of ##signatures

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1503,8 +1503,8 @@ static int cmd_zign(void *data, const char *input) {
 
 	switch (*input) {
 	case '\0':
-	case '*':
-	case 'q':
+	case '*': // "z*"
+	case 'q': // "zq"
 	case 'j': // "zj"
 		r_sign_list (core->anal, *input);
 		break;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

The code for `z`, `z*` and `zj` has been bothering me for a while. So I refactored it a little and dropped a lot of code. It should be a much easier to implement a new signature type that uses a `RList` data type.

Two things were fixed. Dumping signatures of type RList was abstracted into a single function (except for types signatures, they take special handing for json).  Then `r_sign_foreach` is being used instead of `sdb_foreach`. This means the `r_sign_foreach` will handle the de-serialiaztion, space handling and free'ing of the RSignItem.
