### PR TITLE
Reset certificate search properly

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -3391,6 +3391,7 @@ reread:
 			{
 				RSearchKeyword *kw;
 				kw = r_search_keyword_new_hex ("308200003082", "ffff0000ffff", NULL);
+				r_search_reset (core->search, R_SEARCH_KEYWORD);
 				if (kw) {
 					r_search_kw_add (core->search, kw);
 					// eprintf ("Searching %d byte(s)...\n", kw->keyword_length);

--- a/test/db/cmd/cmd_search_hit
+++ b/test/db/cmd/cmd_search_hit
@@ -184,6 +184,19 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=cmd.hit for multiple /cd
+FILE=bins/other/certificate.ber
+CMDS=<<EOF
+/cd
+/cr
+/cd
+EOF
+EXPECT=<<EOF
+0x0000002f hit0_0 308203493082
+0x0000002f hit2_0 308203493082
+EOF
+RUN
+
 NAME=cmd.hit for /a
 FILE=malloc://1024
 CMDS=<<EOF


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Certificate search was not reset thus displaying wrong results if previous search was made.
