### PR TITLE
Small optimzation to r_strbuf_vappendf

### DIFF
--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -295,10 +295,10 @@ R_API bool r_strbuf_vappendf(RStrBuf *sb, const char *fmt, va_list ap) {
 		}
 		*p = 0;
 		vsnprintf (p, ret + 1, fmt, ap2);
-		ret = r_strbuf_append (sb, p);
+		ret = r_strbuf_append_n (sb, p, ret);
 		free (p);
 	} else if (ret >= 0) {
-		ret = r_strbuf_append (sb, string);
+		ret = r_strbuf_append_n (sb, string, ret);
 	} else {
 		ret = false;
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Very minor optimization to `r_strbuf_vappendf` (and thus `r_strbuf_appendf`). The `r_strbuf_vappendf` function already computes the length of the appended string and stores it in `ret`. So instead of doing `r_strbuf_append_n (sb, p, strlen (p))` via `r_strbuf_append` you can just do `r_strbuf_append_n (sb, p, ret)` and save a `strlen` loop.
