### PR TITLE
Refactor serialization of ##signatures

### DIFF
--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -11,10 +11,6 @@ extern "C" {
 
 R_LIB_VERSION_HEADER(r_sign);
 
-// XXX those limits should go away
-#define R_SIGN_KEY_MAXSZ 1024
-#define R_SIGN_VAL_MAXSZ 10240
-
 #define ZIGN_HASH "sha256"
 #define R_ZIGN_HASH R_HASH_SHA256
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Refactors the serialization of signatures. I am going to be adding a new signature type soon but saw the current serialization code was difficult to add to, so I refactored it.

I replaced the old sdb key seriliaztion code with code that allocates the key in the heap. This removes the need use of `R_SIGN_KEY_MAXSZ` and `R_SIGN_VAL_MAXSZ`. 

I reworked completely rewrote the value serialization function. Now there should be a lot fewer allocations and re-allocations. Additionally, adding a new `RList` style signature will only require a single line be added to the serialization function.

While replacing the old key serialization function, I saw a lot of repeated code. Mainly sdb_foreach callbacks that all did a serialization. So I made a slightly more `local_foreach_item` function that replaces several `sdb_foreach`. 

The space renaming callback is a bit finicky. I don't think sdb was made so that you can delete and set items mid `sdb_foreach`. If I set the new item, then deleted, it would result in bugs. Also after a `sdb_remove` the key and value pair provided by sdb_foreach are free'd. Is there another way to do this? A `sdb_rename_key` or something?
