### PR TITLE
Fix #16687 - Handle multiple colon separated paths in dir.types ##types

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3553,7 +3553,7 @@ R_API int r_core_config_init(RCore *core) {
 		free (path);
 	}
 	SETCB ("dir.source", "", &cb_dirsrc, "Path to find source files");
-	SETPREF ("dir.types", "/usr/include", "Default path to look for cparse type files");
+	SETPREF ("dir.types", "/usr/include", "Default colon-separated list of paths to find C headers to cparse types");
 	SETPREF ("dir.libs", "", "Specify path to find libraries to load when bin.libs=true");
 	p = r_sys_getenv (R_SYS_HOME);
 	SETCB ("dir.home", r_str_get_fail (p, "/"), &cb_dirhome, "Path for the home directory");

--- a/libr/parse/code.c
+++ b/libr/parse/code.c
@@ -106,10 +106,18 @@ R_API char *r_parse_c_file(RAnal *anal, const char *path, const char *dir, char 
 	tcc_set_callback (T, &__appendString, &str);
 	tcc_set_error_func (T, (void *)error_msg, __errorFunc);
 	sdb_foreach (anal->sdb_types, __typeLoad, anal);
-	if (tcc_add_file (T, path, dir) == -1) {
-		free (str);
-		str = NULL;
+	char *d = strdup (dir);
+	RList *dirs = r_str_split_list (d, ":", 0);
+	RListIter *iter;
+	char *di;
+	r_list_foreach (dirs, iter, di) {
+		if (tcc_add_file (T, path, di) == -1) {
+			free (str);
+			str = NULL;
+		}
 	}
+	r_list_free (dirs);
+	free (d);
 	tcc_delete (T);
 	return str;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
