### PR TITLE
Improve the xxhash system library detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,8 +237,11 @@ if sys_magic.found() and get_option('use_sys_magic')
 endif
 
 # handle xxhash library
-sys_xxhash = dependency('xxhash', required: false)
+sys_xxhash = dependency('libxxhash', required: false)
 use_sys_xxhash = false
+if not sys_xxhash.found()
+  sys_xxhash = dependency('xxhash', required: false)
+endif
 if not sys_xxhash.found()
   sys_xxhash = cc.find_library('xxhash', required: false)
 endif


### PR DESCRIPTION
The pkgconfig module is named libxxhash on Debian/Fedora/RedHat/SuSE/Arch so I added libxxhash on first place.
Keeping the xxhash checked second.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
