### PR TITLE
Optcons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -984,9 +984,13 @@ R_API void r_cons_flush(void) {
 	} else {
 		CTX (lastMode) = false;
 	}
-	// compress output (45 / 250 KB)
-	optimize ();
-	optimize ();
+	if (I.optimize) {
+		// compress output (45 / 250 KB)
+		optimize ();
+		if (I.optimize > 1) {
+			optimize ();
+		}
+	}
 	r_cons_filter ();
 	if (r_cons_is_interactive () && I.fdout == 1) {
 		/* Use a pager if the output doesn't fit on the terminal window. */

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -915,6 +915,9 @@ R_API void r_cons_eflush(void) {
 	}
 }
 
+// TODO: must be called twice to remove all unnecessary reset codes. maybe adding the last two words would be faster
+// TODO remove all the strdup
+// TODO remove the slow memmove
 static void optimize(void) {
 	char *buf = CTX (buffer);
 	int len = CTX (buffer_len);
@@ -922,22 +925,40 @@ static void optimize(void) {
 	int escape_n = 0;
 	char escape[32];
 	bool onescape = false;
+	char *oldstr = NULL;
 	for (i = 0; i < len; i++) {
 		if (onescape) {
-			if (buf[i] == ';') {
-				eprintf ("ERN %s%c", escape, 10);
+			escape[escape_n++] = buf[i];
+			escape[escape_n] = 0;
+			if (buf[i] == 'm' || buf[i] == 'K' || buf[i] == 'L') {
+				int pos = (i - escape_n);
+			// 	eprintf ("JJJ(%s) (%s)%c", escape + 1, oldstr?oldstr+1:"", 10);
+				if (oldstr && !strcmp (escape, oldstr)) {
+					// trim str
+					memmove (buf + pos + 1, buf + i + 1, len - i + 1);
+					i -= escape_n - 1;
+					len -= escape_n;
+				}
+				free (oldstr);
+				oldstr = strdup (escape);
+			//	eprintf ("ERN (%d) %s%c", pos, escape, 10);
 				onescape = false;
 			} else {
-				escape[escape_n++] = buf[i];
-				escape[escape_n] = 0;
+				if (escape_n + 1 >= sizeof(escape)) {
+					escape_n = 0;
+					onescape = false;
+				}
 			}
-		}
-		if (buf[i] == 0x1b) {
+		} else if (buf[i] == 0x1b) {
+			escape_n = 0;
 			onescape = true;
+			escape[escape_n++] = buf[i];
+			escape[escape_n] = 0;
 			codes++;
 		}
 	}
-	eprintf ("%d%c", codes, 10);
+	// eprintf ("FROM %d TO %d (%d)%c", I.context->buffer_len, len, codes, 10);
+	I.context->buffer_len = len;
 }
 
 R_API void r_cons_flush(void) {
@@ -963,7 +984,9 @@ R_API void r_cons_flush(void) {
 	} else {
 		CTX (lastMode) = false;
 	}
-optimize ();
+	// compress output (45 / 250 KB)
+	optimize ();
+	optimize ();
 	r_cons_filter ();
 	if (r_cons_is_interactive () && I.fdout == 1) {
 		/* Use a pager if the output doesn't fit on the terminal window. */

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2238,6 +2238,13 @@ static bool cb_scrbreakword(void* user, void* data) {
 	return true;
 }
 
+static bool cb_scroptimize(void* user, void* data) {
+	RConfigNode *node = (RConfigNode*) data;
+	RCore *core = (RCore*) user;
+	core->cons->optimize = node->i_value;
+	return true;
+}
+
 static bool cb_scrcolumns(void* user, void* data) {
 	RConfigNode *node = (RConfigNode*) data;
 	RCore *core = (RCore*) user;
@@ -3846,6 +3853,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("scr.gadgets", "true", &cb_scr_gadgets, "Run pg in prompt, visual and panels");
 	SETBPREF ("scr.panelborder", "false", "Specify panels border active area (0 by default)");
 	SETICB ("scr.columns", 0, &cb_scrcolumns, "Force console column count (width)");
+	SETICB ("scr.optimize", 0, &cb_scroptimize, "Optimize the amount of ansi escapes and spaces (0, 1, 2 passes)");
 	SETBPREF ("scr.dumpcols", "false", "Prefer pC commands before p ones");
 	SETCB ("scr.rows", "0", &cb_scrrows, "Force console row count (height) ");
 	SETICB ("scr.rows", 0, &cb_rows, "Force console row count (height) (duplicate?)");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -434,6 +434,7 @@ typedef struct r_cons_t {
 	int fix_columns;
 	bool break_lines;
 	int noflush;
+	int optimize;
 	bool show_autocomplete_widget;
 	FILE *fdin; // FILE? and then int ??
 	int fdout; // only used in pipe.c :?? remove?


### PR DESCRIPTION
This PR shows how 10-25% of the output is unnecessary/repeated escape ansi codes. Some test outputs is not correct because the mode is not restored after a newline which introduces some glitches in panels. Also ideally this function should not use the heap and be implemented in the actual print methods instead of having the logic as a postprocess to avoid walking the buffer twice