### PR TITLE
Add byte ##signatures to metric search

### DIFF
--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -77,6 +77,7 @@ typedef struct r_sign_search_met {
 	 */
 	RSignType types[8];
 	int mincc; // min complexity for graph search
+	int minsz;
 	RAnal *anal;
 	void *user; // user data for callback function
 	RSignMatchCallback cb;


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Moves bytes searching against functions into the `r_sign_fcn_match_metrics`.  This will allow `fcnMatchCB` to get all the found signatures for a function at once and make a better decision on if the function should be renamed, or if there are signature collisions.

If `z/` is run, with no other function metrics enabled, then this new code should have no effect. The byte search callback function `searchBytesHitCB` will be responsible for renaming functions and setting flags.

If `z/` is run with other search metrics enabled, then the usual `z/` byte search will occur but `searchBytesHitCB` will not rename anything. That function will only be responsible for finding and creating new functions. Then the metric search will also check known functions, including those previously found, against the same byte pattern. This is so the function that does the naming has the most information and will be better suited to resolving signature conflicts.

Note: `searchBytesHitCB` apparently does not create functions at all. So `z/` without `aa` before hand won't create a new function, just a flag. This is addressed in the next pull request.