### PR TITLE
Create function when z/ finds byte ##signatures 

### DIFF
--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -337,7 +337,7 @@ z/
 f~?
 e search.align=1
 z/
-f~?
+f~sign?
 EOF
 EXPECT=<<EOF
 0
@@ -387,7 +387,7 @@ za foo b 11223344
 e zign.minsz = 0
 fs *
 z/
-f~?
+f~sign?
 f-*
 e zign.minsz = 5
 z/


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Followup to #18703, this makes `z/` create new functions when a byte signature is found outside of a function. If bytes are the only signature in use, the function will get named. Otherwise the new function will be named by the combination of matched signatures that occurs later.
