### PR TITLE
Fix bug in graph matching ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -2193,9 +2193,11 @@ R_API int r_sign_search_update(RAnal *a, RSignSearch *ss, ut64 *at, const ut8 *b
 
 // allow ~10% of margin error
 static int matchCount(int a, int b) {
-	int c = a - b;
-	int m = a / 10;
-	return R_ABS (c) < m;
+	int m = R_MAX (a, b);
+	if (m > 100) {
+		return R_ABS (a - b) < m / 10;
+	}
+	return a == b;
 }
 
 static int sig_graph_diff(RSignItem *ia, RSignItem *ib) {
@@ -2216,7 +2218,7 @@ static int sig_graph_diff(RSignItem *ia, RSignItem *ib) {
 	if (a->ebbs != -1 && a->ebbs != b->ebbs) {
 		return 1;
 	}
-	if (a->bbsum > 0 && matchCount (a->bbsum, b->bbsum)) {
+	if (a->bbsum > 0 && !matchCount (a->bbsum, b->bbsum)) {
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Previous graph match logic was inverted for `bbsum` logic. This is because small `bbsum` would mess up the math in `matchCount`. For example, `matchCount( 5, 5)` returns `0` because `R_ABS(5 - 5) == 0 !< 0 == 5 /10`. So it was thought that `matchCount` returning `0` was a match. This means, normal sized functions would fail to match because `matchCount(>10, >10)` returned 1:

```
> r2 /bin/ls
[0x00006160]> s main
[0x00004760]> af
[0x00004760]> zaf
[0x00004760]> z/
[+] searching 0x000245c8 - 0x000258b8
[+] searching 0x00023350 - 0x000245c8
[+] searching 0x00019000 - 0x00021f08
[+] searching 0x00004000 - 0x000181a9
[+] searching 0x00000000 - 0x00003538
[+] searching function metrics
bytes:  1
refs:   1
types:  1
bbhash: 1
total:  4
[0x00004760]> zi~graph?
0
```

This patch also requires that the max size be at least 100 before the fuzziness kicks in. I just made this number up.