### PR TITLE
Consider collision ##signatures before renaming

### DIFF
--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -13,6 +13,7 @@ R_LIB_VERSION_HEADER(r_sign);
 
 #define ZIGN_HASH "sha256"
 #define R_ZIGN_HASH R_HASH_SHA256
+#define R_SIGN_COL_DELEM ':'
 
 typedef enum {
 	R_SIGN_BYTES = 'b', // bytes pattern
@@ -69,7 +70,7 @@ typedef struct r_sign_item_t {
 
 typedef int (*RSignForeachCallback) (RSignItem *it, void *user);
 typedef int (*RSignSearchCallback) (RSignItem *it, RSearchKeyword *kw, ut64 addr, void *user);
-typedef int (*RSignMatchCallback) (RSignItem *it, RAnalFunction *fcn, RSignType *types, void *user);
+typedef int (*RSignMatchCallback) (RSignItem *it, RAnalFunction *fcn, RSignType *types, void *user, RList *col);
 
 typedef struct r_sign_search_met {
 	/* types is an R_SIGN_END terminated array of RSignTypes that are going to be

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1888,3 +1888,60 @@ za sym.collide1 C b:sym.collide2 g:sym.collide2 g:sym.collide3 g:sym.collide4 g:
 za sym.collide2 C b:sym.collide1 g:sym.collide1 g:sym.collide3 g:sym.collide4 g:sym.collide5
 EOF
 RUN
+
+NAME=collisions detected and prevents renaming function
+FILE=bins/elf/ls
+CMDS=<<EOF
+s main
+af
+afn badname
+zaf
+afn badname2
+f-badname
+zaf
+afn main
+f-badname2
+af- $$
+zac
+z/
+afl~main?
+zi~sign.bytes_collision.badname_1?
+zi~sign.graph_collision.badname_1?
+zi~sign.bytes_collision.badname2_1?
+zi~sign.graph_collision.badname2_1?
+EOF
+EXPECT=<<EOF
+1
+1
+1
+1
+1
+EOF
+RUN
+
+NAME=Rename when collision intersection unique
+FILE=bins/elf/ls
+CMDS=<<EOF
+s main
+af
+afn newname
+zaf
+f- newname
+afn badbytes
+zaf
+za badbytes b 444444
+f- badbytes
+afn badgraph
+zaf
+za badgraph g cc=100 nbbs=2 edges=3 ebbs=8 bbsum=100
+afn main
+f- badgraph
+af- main
+zac
+z/
+afl~newname?
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This makes the collision signature useful. Now the function matching callback will revive a `RList` of `const char *` signature names that should collide. If this list is empty, it means there are no collisions. 

If the list is non-empty, the callback function won't rename the function anymore. It will apply flags for each matched signature and mention that a collision exists in the flag.

Collisions are resolved with a set intersection operation on `RList`'s. So if a signature has the following collisions `g:badbytes, g:other, b:badgraph, b:other` and both the byte and graph signature match, it implies the only collision is with the signature `other`. If `other` was not in the list, then there would be no collision because there would be no other signature in the list that matches on both bytes and graph signatures.

This means future, weak, signatures types can be created specifically to resolve resolve collisions. Collisions are actually not that uncommon for functions like:

```
int x(char *str) { 
    return x_n (str, strlen (str)); 
}
```