### PR TITLE
Fix #18717 - Syscall table is always loaded on startup now

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -745,6 +745,9 @@ static bool cb_asmbits(void *user, void *data) {
 	}
 
 	int bits = node->i_value;
+	if (!bits) {
+		bits = (R_SYS_BITS & 8)? 64: 32;
+	}
 #if 0
 // TODO: pretty good optimization, but breaks many tests when arch is different i think
 	if (bits == core->rasm->bits && bits == core->anal->bits && bits == core->dbg->bits) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -746,7 +746,7 @@ static bool cb_asmbits(void *user, void *data) {
 
 	int bits = node->i_value;
 	if (!bits) {
-		bits = (R_SYS_BITS & 8)? 64: 32;
+		return false;
 	}
 #if 0
 // TODO: pretty good optimization, but breaks many tests when arch is different i think

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -641,7 +641,6 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 		eprintf ("r_core_bin_load: no file specified\n");
 		return false;
 	}
-
 	r->bin->minstrlen = r_config_get_i (r->config, "bin.minstr");
 	r->bin->maxstrbuf = r_config_get_i (r->config, "bin.maxstrbuf");
 	if (is_io_load) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2009-2020 - pancake */
+/* radare2 - LGPL - Copyright 2009-2021 - pancake */
 
 #include <r_core.h>
 #include <r_socket.h>
@@ -3722,19 +3722,19 @@ R_API char *r_core_editor(const RCore *core, const char *file, const char *str) 
 }
 
 /* weak getters */
-R_API RCons *r_core_get_cons (RCore *core) {
+R_API RCons *r_core_get_cons(RCore *core) {
 	return core->cons;
 }
 
-R_API RConfig *r_core_get_config (RCore *core) {
+R_API RConfig *r_core_get_config(RCore *core) {
 	return core->config;
 }
 
-R_API RBin *r_core_get_bin (RCore *core) {
+R_API RBin *r_core_get_bin(RCore *core) {
 	return core->bin;
 }
 
-R_API RBuffer *r_core_syscallf (RCore *core, const char *name, const char *fmt, ...) {
+R_API RBuffer *r_core_syscallf(RCore *core, const char *name, const char *fmt, ...) {
 	char str[1024];
 	RBuffer *buf;
 	va_list ap;
@@ -3747,10 +3747,9 @@ R_API RBuffer *r_core_syscallf (RCore *core, const char *name, const char *fmt, 
 	return buf;
 }
 
-R_API RBuffer *r_core_syscall (RCore *core, const char *name, const char *args) {
+R_API RBuffer *r_core_syscall(RCore *core, const char *name, const char *args) {
 	RBuffer *b = NULL;
 	char code[1024];
-	int num;
 
 	//arch check
 	if (strcmp (core->anal->cur->arch, "x86")) {
@@ -3758,7 +3757,7 @@ R_API RBuffer *r_core_syscall (RCore *core, const char *name, const char *args) 
 		return 0;
 	}
 
-	num = r_syscall_get_num (core->anal->syscall, name);
+	int num = r_syscall_get_num (core->anal->syscall, name);
 
 	//bits check
 	switch (core->rasm->bits) {
@@ -3920,6 +3919,5 @@ R_API PJ *r_core_pj_new(RCore *core) {
 	} else if (!strcmp ("strip", config_string_encoding)) {
 		string_encoding = PJ_ENCODING_STR_STRIP;
 	}
-
 	return pj_new_with_encoding (string_encoding, number_encoding);
 }

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1,3 +1,18 @@
+NAME=linux syscall empty
+ARGS=-a x86 -b 64 -k linux
+FILE=-
+CMDS=<<EOF
+asl~?
+e asm.bits=32
+asl~?
+EOF
+
+EXPECT=<<EOF
+335
+365
+EOF
+RUN
+
 NAME=linux syscall
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
