### PR TITLE
Fix disasm alignment of data words in s390x disassembler plugins ##anal

### DIFF
--- a/libr/anal/p/anal_s390_cs.c
+++ b/libr/anal/p/anal_s390_cs.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2014-2019 - pancake */
+/* radare2 - LGPL - Copyright 2014-2021 - pancake */
 
 #include <r_anal.h>
 #include <r_lib.h>
@@ -59,12 +59,14 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 	cs_insn *insn;
 	int mode = CS_MODE_BIG_ENDIAN;
 	int ret = cs_open (CS_ARCH_SYSZ, mode, &handle);
+	op->size = 4;
 	if (ret == CS_ERR_OK) {
 		cs_option (handle, CS_OPT_DETAIL, CS_OPT_ON);
 		// capstone-next
 		int n = cs_disasm (handle, (const ut8*)buf, len, addr, 1, &insn);
 		if (n < 1) {
 			op->type = R_ANAL_OP_TYPE_ILL;
+			return -1;
 		} else {
 			if (mask & R_ANAL_OP_MASK_OPEX) {
 				opex (&op->opex, handle, insn);
@@ -186,6 +188,7 @@ static bool set_reg_profile(RAnal *anal) {
 
 static int archinfo(RAnal *anal, int q) {
 	switch (q) {
+	case R_ANAL_ARCHINFO_DATA_ALIGN:
 	case R_ANAL_ARCHINFO_ALIGN:
 		return 2;
 	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
@@ -202,7 +205,7 @@ RAnalPlugin r_anal_plugin_s390_cs = {
 	.esil = false,
 	.license = "BSD",
 	.arch = "s390",
-	.bits = 32|64,
+	.bits = 32 | 64, // it's actually 31
 	.op = &analop,
 	.archinfo = archinfo,
 	.set_reg_profile = &set_reg_profile,

--- a/libr/asm/p/asm_s390_cs.c
+++ b/libr/asm/p/asm_s390_cs.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2015 - pancake */
+/* radare2 - LGPL - Copyright 2013-2021 - pancake */
 
 // instruction set : http://www.tachyonsoft.com/inst390m.htm
 
@@ -26,18 +26,19 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		cs_close (&cd);
 		cd = 0;
 	}
-	op->size = 0;
+	op->size = 4;
 	omode = mode;
 	if (cd == 0) {
 		ret = cs_open (CS_ARCH_SYSZ, mode, &cd);
 		if (ret) {
-			return 0;
+			return -1;
 		}
 		cs_option (cd, CS_OPT_DETAIL, CS_OPT_OFF);
 	}
+	r_asm_op_set_asm (op, "invalid");
 	n = cs_disasm (cd, (const ut8*)buf, len, off, 1, &insn);
-	if (n>0) {
-		if (insn->size>0) {
+	if (n > 0) {
+		if (insn->size > 0) {
 			op->size = insn->size;
 			char *buf_asm = sdb_fmt ("%s%s%s",
 					insn->mnemonic, insn->op_str[0]?" ": "",

--- a/libr/asm/p/asm_s390_gnu.c
+++ b/libr/asm/p/asm_s390_gnu.c
@@ -43,7 +43,8 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	char options[64];
 	struct disassemble_info disasm_obj;
 	if (len < 6) {
-		return -1;
+		r_asm_op_set_asm (op, "truncated");
+		return 4;
 	}
 	buf_global = &op->buf_asm;
 	Offset = a->pc;
@@ -56,6 +57,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	} else {
 		*options = 0;
 	}
+	r_asm_op_set_asm (op, "");
 	disasm_obj.disassembler_options = options;
 	disasm_obj.buffer = bytes;
 	disasm_obj.read_memory_func = &s390_buffer_read_memory;
@@ -67,8 +69,9 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	disasm_obj.stream = stdout;
 	disassemble_init_s390 (&disasm_obj);
 	op->size = print_insn_s390 ((bfd_vma)Offset, &disasm_obj);
-	if (op->size == -1) {
-		r_asm_op_set_asm (op, "(data)");
+	if (op->size < 1) {
+		r_asm_op_set_asm (op, "invalid");
+		op->size = 4;
 	}
 	return op->size;
 }

--- a/test/db/anal/s390
+++ b/test/db/anal/s390
@@ -1,3 +1,40 @@
+NAME=pd 10 align
+FILE=bins/s390/zos/prueba/prueba
+CMDS=<<EOF
+/x 47F0F024
+s hit0_0
+e asm.arch=s390
+pd 10
+e asm.arch=s390.gnu
+pd 10
+EOF
+EXPECT=<<EOF
+0x00001928 hit0_0 47f0f024
+            ;-- hit0_0:
+            0x00001928      47f0f024       b 0x24(%r15)
+            0x0000192c      01c3c5c5       invalid
+            0x00001930      000000a0       invalid
+            0x00001934      00000090       invalid
+            0x00001938      47f0f001       b 1(%r15)
+            0x0000193c      58f0c31c       l %r15, 0x31c(%r12)
+            0x00001940      184e           lr %r4, %r14
+            0x00001942      05ef           balr %r14, %r15
+            0x00001944      00000000       invalid
+            0x00001948      a7f4000c       j 0x1960
+            ;-- hit0_0:
+            0x00001928      47f0f024       b 36(%r15)
+            0x0000192c      01c3c5c5       invalid
+            0x00001930      000000a0       invalid
+            0x00001934      00000090       invalid
+            0x00001938      47f0f001       b 1(%r15)
+            0x0000193c      58f0c31c       l %r15,796(%r12)
+            0x00001940      184e           lr %r4,%r14
+            0x00001942      05ef           balr %r14,%r15
+            0x00001944      00000000       invalid
+            0x00001948      a7f4000c       j 0x00001960
+EOF
+RUN
+
 NAME=aoj 4140f008
 FILE=bins/s390/linux/prueba
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
