### PR TITLE
Fix autocompletion for 'e ' and handle cfg.charset=<tab> ##shell

### DIFF
--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -488,18 +488,18 @@ beach:
 /* r_config_desc takes a RConfig and a name,
  * r_config_node_desc takes a RConfigNode
  * Both set and return node->desc */
-R_API const char* r_config_desc(RConfig *cfg, const char *name, const char *desc) {
+R_API RConfigNode * r_config_desc(RConfig *cfg, const char *name, const char *desc) {
 	RConfigNode *node = r_config_node_get (cfg, name);
 	return r_config_node_desc (node, desc);
 }
 
-R_API const char* r_config_node_desc(RConfigNode *node, const char *desc) {
+R_API RConfigNode* r_config_node_desc(RConfigNode *node, const char *desc) {
 	r_return_val_if_fail (node, NULL);
 	if (desc) {
 		free (node->desc);
 		node->desc = strdup (desc);
 	}
-	return node->desc;
+	return node;
 }
 
 R_API bool r_config_rm(RConfig *cfg, const char *name) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -970,6 +970,18 @@ static bool cb_asmos(void *user, void *data) {
 	return true;
 }
 
+static void update_cfgcharsets_options(RCore *core, RConfigNode *node) {
+	// static void autocomplete_charsets(RCore *core, RLineCompletion *completion, const char *str) {
+	char *name;
+	RListIter *iter;
+	RList *chs = r_charset_list (core->print->charset);
+	r_config_node_purge_options (node);
+	r_list_foreach (chs, iter, name) {
+		SETOPTIONS (node, name, NULL);
+	}
+	r_list_free (chs);
+}
+
 static void update_asmparser_options(RCore *core, RConfigNode *node) {
 	RListIter *iter;
 	RParsePlugin *parser;
@@ -989,7 +1001,6 @@ static bool cb_asmparser(void *user, void *data) {
 		print_node_options (node);
 		return false;
 	}
-
 	return r_parse_use (core->parser, node->value);
 }
 
@@ -3465,7 +3476,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("prj.gpg", "false", "TODO: Encrypt project with GnuPGv2");
 
 	/* cfg */
-	SETCB ("cfg.charset", "", &cb_cfgcharset, "Specify encoding to use when printing strings");
+	n = SETCB ("cfg.charset", "", &cb_cfgcharset, "Specify encoding to use when printing strings");
+	update_cfgcharsets_options (core, n);
 	SETBPREF ("cfg.r2wars", "false", "Enable some tweaks for the r2wars game");
 	SETBPREF ("cfg.plugins", "true", "Load plugins at startup");
 	SETCB ("time.fmt", "%Y-%m-%d %H:%M:%S %z", &cb_cfgdatefmt, "Date format (%Y-%m-%d %H:%M:%S %z)");

--- a/libr/include/r_config.h
+++ b/libr/include/r_config.h
@@ -81,7 +81,7 @@ R_API RConfigNode *r_config_set(RConfig *cfg, const char *name, const char *valu
 R_API bool r_config_rm(RConfig *cfg, const char *name);
 R_API ut64 r_config_get_i(RConfig *cfg, const char *name);
 R_API const char *r_config_get(RConfig *cfg, const char *name);
-R_API const char *r_config_desc(RConfig *cfg, const char *name, const char *desc);
+R_API RConfigNode *r_config_desc(RConfig *cfg, const char *name, const char *desc);
 R_API void r_config_list(RConfig *cfg, const char *str, int rad);
 
 R_API bool r_config_toggle(RConfig *cfg, const char *name);
@@ -95,7 +95,7 @@ R_API void r_config_serialize(R_NONNULL RConfig *config, R_NONNULL Sdb *db);
 R_API bool r_config_unserialize(R_NONNULL RConfig *config, R_NONNULL Sdb *db, R_NULLABLE char **err);
 
 // RConfigNode
-R_API const char *r_config_node_desc(RConfigNode *node, const char *desc);
+R_API RConfigNode *r_config_node_desc(RConfigNode *node, const char *desc);
 R_API char *r_config_node_to_string(RConfigNode *node);
 R_API void r_config_node_add_option(RConfigNode *node, const char *option);
 R_API void r_config_node_purge_options(RConfigNode *node);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -176,6 +176,7 @@ typedef enum r_core_autocomplete_types_t {
 	R_CORE_AUTOCMPLT_OPTN,
 	R_CORE_AUTOCMPLT_MS,
 	R_CORE_AUTOCMPLT_SDB,
+	R_CORE_AUTOCMPLT_CHRS,
 // --- left as last always
 	R_CORE_AUTOCMPLT_END,
 } RCoreAutocompleteType;

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -50,6 +50,7 @@ R_API size_t r_charset_encode_str(RCharset *rc, ut8 *out, size_t out_len, const 
 R_API size_t r_charset_decode_str(RCharset *rc, ut8 *out, size_t out_len, const ut8 *in, size_t in_len);
 R_API bool r_charset_open(RCharset *c, const char *cs);
 R_API bool r_charset_use(RCharset *c, const char *cf);
+R_API RList *r_charset_list(RCharset *c);
 R_API void r_charset_close(RCharset *c);
 R_API RCharsetRune * add_rune(RCharsetRune *rcsr, const ut8 *ch, const ut8 *hx);
 R_API RCharsetRune *search_from_hex(RCharsetRune *rcsr, const ut8 *hx);

--- a/libr/util/charset.c
+++ b/libr/util/charset.c
@@ -34,6 +34,32 @@ R_API SdbGperf *r_charset_get_gperf(const char *k) {
 }
 #endif
 
+R_API RList *r_charset_list(RCharset *ch) {
+	RList *list = r_list_newf (free);
+#if HAVE_GPERF
+	SdbGperf **gp = (SdbGperf**)gperfs;
+	while (*gp) {
+		SdbGperf *g = *gp;
+		r_list_append (list, strdup (g->name));
+		gp++;
+	}
+#endif
+	// iterate in disk
+	const char *cs = R2_PREFIX R_SYS_DIR R2_SDB R_SYS_DIR "charsets" R_SYS_DIR;
+	RList *files = r_sys_dir (cs);
+	RListIter *iter;
+	char *file;
+	r_list_foreach (files, iter, file) {
+		char *dot = strstr (file, ".sdb");
+		if (dot) {
+			*dot = 0;
+			r_list_append (list, strdup (file));
+		}
+	}
+	r_list_free (files);
+	return list;
+}
+
 R_API RCharset *r_charset_new(void) {
 	RCharset *ch = R_NEW0 (RCharset);
 	ch->db = sdb_new0 ();


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
