### PR TITLE
Fix 18619 - Wrong assembly generated for: "add x0, x0, 1, lsl #12" (ARM64)

### DIFF
--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -921,6 +921,8 @@ static ut32 arithmetic(ArmOp *op, int k) {
 				data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
 			case ARM_ASR:
 				data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
+			default: 
+				return data;
 		}
 	}
 	if (op->operands[2].type & ARM_CONSTANT  && op->operands[3].type & ARM_SHIFT) {

--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -914,15 +914,13 @@ static ut32 arithmetic(ArmOp *op, int k) {
 	}
 
 	if (op->operands[2].type & ARM_GPR  && op->operands[3].type & ARM_SHIFT) {
-		if (op->operands[3].shift == ARM_LSL) {
-			data |= (0x00040000 * op->operands[3].shift_amount);
-		} 
-		if (op->operands[3].shift == ARM_LSR) {
-			data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
-		}
-
-		if (op->operands[3].shift == ARM_ASR) {
-			data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
+		switch (op->operands[3].shift) {
+			case ARM_LSL:
+				data |= (0x00040000 * op->operands[3].shift_amount);
+			case ARM_LSR:
+				data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
+			case ARM_ASR:
+				data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
 		}
 	}
 	if (op->operands[2].type & ARM_CONSTANT  && op->operands[3].type & ARM_SHIFT) {

--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -912,6 +912,25 @@ static ut32 arithmetic(ArmOp *op, int k) {
 		data += (op->operands[2].reg & 0x3f) << 18;
 		data += (op->operands[2].reg >> 6) << 8;
 	}
+
+	if (op->operands[2].type & ARM_GPR  && op->operands[3].type & ARM_SHIFT) {
+		if (op->operands[3].shift == ARM_LSL) {
+			data |= (0x00040000 * op->operands[3].shift_amount);
+		} 
+		if (op->operands[3].shift == ARM_LSR) {
+			data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
+		}
+
+		if (op->operands[3].shift == ARM_ASR) {
+			data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
+		}
+	}
+	if (op->operands[2].type & ARM_CONSTANT  && op->operands[3].type & ARM_SHIFT) {
+		if ((op->operands[3].shift == ARM_LSL) && (op->operands[3].shift_amount == 12)) {
+			data |= (0x4000);
+		}
+	}
+
 	return data;
 }
 

--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -901,7 +901,6 @@ static ut32 arithmetic(ArmOp *op, int k) {
 	if (op->operands[2].type & ARM_GPR) {
 		k -= 6;
 	}
-
 	data = k;
 	data += encode1reg (op);
 	data += (op->operands[1].reg & 7) << (24 + 5);
@@ -913,24 +912,27 @@ static ut32 arithmetic(ArmOp *op, int k) {
 		data += (op->operands[2].reg >> 6) << 8;
 	}
 
-	if (op->operands[2].type & ARM_GPR  && op->operands[3].type & ARM_SHIFT) {
-		switch (op->operands[3].shift) {
-			case ARM_LSL:
-				data |= (0x00040000 * op->operands[3].shift_amount);
-			case ARM_LSR:
-				data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
-			case ARM_ASR:
-				data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
-			default: 
-				return data;
-		}
-	}
 	if (op->operands[2].type & ARM_CONSTANT  && op->operands[3].type & ARM_SHIFT) {
 		if ((op->operands[3].shift == ARM_LSL) && (op->operands[3].shift_amount == 12)) {
 			data |= (0x4000);
 		}
 	}
 
+	if (op->operands[2].type & ARM_GPR  && op->operands[3].type & ARM_SHIFT) {
+		switch (op->operands[3].shift) {
+			case ARM_LSL:
+				data |= (0x00040000 * op->operands[3].shift_amount);
+				break;
+			case ARM_LSR:
+				data |= (0x00040000 * op->operands[3].shift_amount) | (0x4000);
+				break;
+			case ARM_ASR:
+				data |= (0x00040000 * op->operands[3].shift_amount) | (0x8000);
+				break;
+			default:
+				return data;
+		}
+	}
 	return data;
 }
 

--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -363,3 +363,12 @@ ad "sbfx w12, w13, 0xf, 0x10" ac790f13
 ad "sbfx x14, x15, 0x21, 0x1b" eeed6193
 ad "ubfx w16, w17, 0x1d, 2" 307a1d53
 ad "ubfx x18, x19, 2, 0x39" 72ea42d3
+a "add x0, x0, 1" 00040091
+a "add x0, x0, 1, lsl 12" 00044091
+a "add x0, x0, 2, lsl 12" 00084091
+a "add x0, x0, x1, lsl 1" 0004018b
+a "add x0, x0, x1, lsl 2" 0008018b
+a "add x0, x0, x1, lsr 1" 0004418b
+a "add x0, x0, x1, lsr 2" 0008418b
+a "add x0, x0, x1, asr 1" 0004818b
+a "add x0, x0, x1, asr 2" 0008818b

--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -368,7 +368,10 @@ a "add x0, x0, 1, lsl 12" 00044091
 a "add x0, x0, 2, lsl 12" 00084091
 a "add x0, x0, x1, lsl 1" 0004018b
 a "add x0, x0, x1, lsl 2" 0008018b
+a "add x0, x0, x1, lsl 12" 0030018b
 a "add x0, x0, x1, lsr 1" 0004418b
 a "add x0, x0, x1, lsr 2" 0008418b
+a "add x0, x0, x1, lsr 12" 0030418b
 a "add x0, x0, x1, asr 1" 0004818b
 a "add x0, x0, x1, asr 2" 0008818b
+a "add x0, x0, x1, asr 12" 0030818b


### PR DESCRIPTION
**Checklist**

- [ X] Closing issues: #18619
- [ ] Mark this if you consider it ready to merge
- [X ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
