### PR TITLE
Add size parameter to r_magic_load_buffer ##util

### DIFF
--- a/libr/include/r_magic.h
+++ b/libr/include/r_magic.h
@@ -284,7 +284,7 @@ R_API const char *r_magic_error(RMagic*);
 R_API void r_magic_setflags(RMagic*, int);
 
 R_API bool r_magic_load(RMagic*, const char *);
-R_API bool r_magic_load_buffer(RMagic*, const char *);
+R_API bool r_magic_load_buffer(RMagic*, const ut8 *, size_t);
 R_API bool r_magic_compile(RMagic*, const char *);
 R_API bool r_magic_check(RMagic*, const char *);
 R_API int r_magic_errno(RMagic*);

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -268,7 +268,7 @@ void file_delmagic(struct r_magic *p, int type, size_t entries) {
 }
 
 /* const char *fn: list of magic files and directories */
-struct mlist * file_apprentice(RMagic *ms, const char *fn, int action) {
+struct mlist * file_apprentice(RMagic *ms, const char *fn, size_t fn_size, int action) {
 	char *p, *mfn;
 	int file_err, errs = -1;
 	struct mlist *mlist;
@@ -278,8 +278,8 @@ struct mlist * file_apprentice(RMagic *ms, const char *fn, int action) {
 		return NULL;
 	}
 
-	if (!(mfn = strdup (fn))) {
-		file_oomem (ms, strlen (fn));
+	if (!(mfn = strndup (fn, fn_size))) {
+		file_oomem (ms, fn_size);
 		return NULL;
 	}
 	fn = mfn;

--- a/libr/magic/apprentice.c
+++ b/libr/magic/apprentice.c
@@ -278,7 +278,7 @@ struct mlist * file_apprentice(RMagic *ms, const char *fn, size_t fn_size, int a
 		return NULL;
 	}
 
-	if (!(mfn = strndup (fn, fn_size))) {
+	if (!(mfn = r_str_ndup (fn, fn_size))) {
 		file_oomem (ms, fn_size);
 		return NULL;
 	}

--- a/libr/magic/file.h
+++ b/libr/magic/file.h
@@ -65,7 +65,7 @@ int file_zmagic(struct r_magic_set *, int, const char *, const ut8*, size_t);
 int file_ascmagic(struct r_magic_set *, const unsigned char *, size_t);
 int file_is_tar(struct r_magic_set *, const unsigned char *, size_t);
 int file_softmagic(struct r_magic_set *, const unsigned char *, size_t, int);
-struct mlist *file_apprentice(struct r_magic_set *, const char *, int);
+struct mlist *file_apprentice(struct r_magic_set *, const char *, size_t, int);
 ut64 file_signextend(RMagic *, struct r_magic *, ut64);
 void file_delmagic(struct r_magic *, int type, size_t entries);
 void file_badread(struct r_magic_set *);

--- a/libr/magic/magic.c
+++ b/libr/magic/magic.c
@@ -228,9 +228,9 @@ R_API void r_magic_free(RMagic *ms) {
 	}
 }
 
-R_API bool r_magic_load_buffer(RMagic* ms, const char *magicdata) {
-	if (*magicdata == '#') {
-		struct mlist *ml = file_apprentice (ms, magicdata, FILE_LOAD);
+R_API bool r_magic_load_buffer(RMagic* ms, const ut8 *magicdata, size_t magicdata_size) {
+	if (magicdata_size > 0 && *magicdata == '#') {
+		struct mlist *ml = file_apprentice (ms, magicdata, magicdata_size, FILE_LOAD);
 		if (ml) {
 			free_mlist (ms->mlist);
 			ms->mlist = ml;
@@ -243,7 +243,7 @@ R_API bool r_magic_load_buffer(RMagic* ms, const char *magicdata) {
 }
 
 R_API bool r_magic_load(RMagic* ms, const char *magicfile) {
-	struct mlist *ml = file_apprentice (ms, magicfile, FILE_LOAD);
+	struct mlist *ml = file_apprentice (ms, magicfile, strlen (magicfile), FILE_LOAD);
 	if (ml) {
 		free_mlist (ms->mlist);
 		ms->mlist = ml;
@@ -253,13 +253,13 @@ R_API bool r_magic_load(RMagic* ms, const char *magicfile) {
 }
 
 R_API bool r_magic_compile(RMagic *ms, const char *magicfile) {
-	struct mlist *ml = file_apprentice (ms, magicfile, FILE_COMPILE);
+	struct mlist *ml = file_apprentice (ms, magicfile, strlen (magicfile), FILE_COMPILE);
 	free_mlist (ml);
 	return ml != NULL;
 }
 
 R_API bool r_magic_check(RMagic *ms, const char *magicfile) {
-	struct mlist *ml = file_apprentice (ms, magicfile, FILE_CHECK);
+	struct mlist *ml = file_apprentice (ms, magicfile, strlen (magicfile), FILE_CHECK);
 	free_mlist (ml);
 	return ml != NULL;
 }

--- a/libr/magic/magic.c
+++ b/libr/magic/magic.c
@@ -230,7 +230,7 @@ R_API void r_magic_free(RMagic *ms) {
 
 R_API bool r_magic_load_buffer(RMagic* ms, const ut8 *magicdata, size_t magicdata_size) {
 	if (magicdata_size > 0 && *magicdata == '#') {
-		struct mlist *ml = file_apprentice (ms, magicdata, magicdata_size, FILE_LOAD);
+		struct mlist *ml = file_apprentice (ms, (const char *)magicdata, magicdata_size, FILE_LOAD);
 		if (ml) {
 			free_mlist (ms->mlist);
 			ms->mlist = ml;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

It is still UTF-8, and thus not valid to have a NULL inside of the the
file, but sometimes inputs are not NULL-terminated
