### PR TITLE
Add 'aev' as an alias for VbE and improve esil debugger ##esil

### DIFF
--- a/libr/anal/esil.c
+++ b/libr/anal/esil.c
@@ -3669,16 +3669,11 @@ repeat:
 
 R_API bool r_anal_esil_runword(RAnalEsil *esil, const char *word) {
 	const char *str = NULL;
-	(void)runword (esil, word);
-	if (*word) {
-		if (!runword (esil, word)) {
-			return false;
-		}
-		int ew = evalWord (esil, word, &str);
-		eprintf ("ew %d\n", ew);
-		eprintf ("--> %s\n", r_str_getf (str));
+	if (runword (esil, word)) {
+		(void)evalWord (esil, word, &str);
+		return true;
 	}
-	return true;
+	return false;
 }
 
 //frees all elements from the stack, not the stack itself

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -202,6 +202,7 @@ static const char *help_msg_ae[] = {
 	"aesuo", " [optype]", "step until given opcode type",
 	"aetr", "[esil]", "Convert an ESIL Expression to REIL",
 	"aets", "[?]", "ESIL Trace session",
+	"aev", " [esil]", "visual esil debugger for the given expression or current instruction",
 	"aex", " [hex]", "evaluate opcode expression",
 	NULL
 };
@@ -6366,6 +6367,9 @@ static void cmd_anal_esil(RCore *core, const char *input) {
 	RAnalOp *op = NULL;
 
 	switch (input[0]) {
+	case 'v': // "aev"
+		r_core_visual_esil (core, r_str_trim_head_ro (input + 1));
+		break;
 	case 'p': // "aep"
 		switch (input[1]) {
 		case 'c': // "aepc"

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -2205,7 +2205,7 @@ R_API void r_core_visual_browse(RCore *core, const char *input) {
 			r_core_visual_config (core);
 			break;
 		case 'E': // "vbe"
-			r_core_visual_esil (core);
+			r_core_visual_esil (core, NULL);
 			break;
 		case 'c': // "vbc"
 			r_core_visual_classes (core);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -792,7 +792,7 @@ R_API int r_core_visual_view_zigns(RCore *core);
 R_API int r_core_visual_view_rop(RCore *core);
 R_API int r_core_visual_comments(RCore *core);
 R_API int r_core_visual_prompt(RCore *core);
-R_API bool r_core_visual_esil (RCore *core);
+R_API bool r_core_visual_esil (RCore *core, const char *input);
 R_API int r_core_search_preludes(RCore *core, bool log);
 R_API int r_core_search_prelude(RCore *core, ut64 from, ut64 to, const ut8 *buf, int blen, const ut8 *mask, int mlen);
 R_API RList* /*<RIOMap*>*/ r_core_get_boundaries_prot (RCore *core, int protection, const char *mode, const char *prefix);


### PR DESCRIPTION
* n/p keys seek one instruction forward/backward
* o key to enter new offset
* e key to enter new esil expression
* infinite loop fixed on invalid expressions
* : enter commands working again

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
