### PR TITLE
Fix the infamous 160 byte memory leak in sdb

### DIFF
--- a/shlr/sdb/src/main.c
+++ b/shlr/sdb/src/main.c
@@ -788,6 +788,7 @@ static int gen_gperf(MainOptions *mo, const char *file, const char *name) {
 			eprintf ("Outdated sdb binary in PATH?\n");
 		}
 	}
+	free (out);
 	free (buf);
 	return rc;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
