### PR TITLE
Add r_rbtree_cont_node_{first/last} (siol_eternal) ##util

### DIFF
--- a/libr/include/r_util/r_rbtree.h
+++ b/libr/include/r_util/r_rbtree.h
@@ -113,6 +113,8 @@ R_API bool r_rbtree_cont_delete(RContRBTree *tree, void *data, RContRBCmp cmp, v
 R_API RContRBNode *r_rbtree_cont_find_node(RContRBTree *tree, void *data, RContRBCmp cmp, void *user);
 R_API RContRBNode *r_rbtree_cont_node_next(RContRBNode *node);
 R_API RContRBNode *r_rbtree_cont_node_prev(RContRBNode *node);
+R_API RContRBNode *r_rbtree_cont_node_first(RContRBTree *tree);
+R_API RContRBNode *r_rbtree_cont_node_last(RContRBTree *tree);
 R_API void *r_rbtree_cont_find(RContRBTree *tree, void *data, RContRBCmp cmp, void *user);
 R_API void *r_rbtree_cont_first(RContRBTree *tree);
 R_API void *r_rbtree_cont_last(RContRBTree *tree);

--- a/libr/util/rbtree.c
+++ b/libr/util/rbtree.c
@@ -576,9 +576,8 @@ R_API RContRBNode *r_rbtree_cont_node_prev(RContRBNode *node) {
 	return (container_of (parent, RContRBNode, node));
 }
 
-// not a direct pendant to r_rbtree_first, but similar
-// returns first element in the tree, not an iter or a node
-R_API void *r_rbtree_cont_first(RContRBTree *tree) {
+// pendant to r_rbtree_first
+R_API RContRBNode *r_rbtree_cont_node_first(RContRBTree *tree) {
 	r_return_val_if_fail (tree, NULL);
 	if (!tree->root) {
 		// empty tree
@@ -588,10 +587,11 @@ R_API void *r_rbtree_cont_first(RContRBTree *tree) {
 	while (node->child[0]) {
 		node = node->child[0];
 	}
-	return (container_of (node, RContRBNode, node))->data;
+	return container_of (node, RContRBNode, node);
 }
 
-R_API void *r_rbtree_cont_last(RContRBTree *tree) {
+// pendant to r_rbtree_last
+R_API RContRBNode *r_rbtree_cont_node_last(RContRBTree *tree) {
 	r_return_val_if_fail (tree, NULL);
 	if (!tree->root) {
 		// empty tree
@@ -601,7 +601,29 @@ R_API void *r_rbtree_cont_last(RContRBTree *tree) {
 	while (node->child[1]) {
 		node = node->child[1];
 	}
-	return (container_of (node, RContRBNode, node))->data;
+	return container_of (node, RContRBNode, node);
+}
+
+// not a direct pendant to r_rbtree_first, but similar
+// returns first element in the tree, not an iter or a node
+R_API void *r_rbtree_cont_first(RContRBTree *tree) {
+	r_return_val_if_fail (tree, NULL);
+	RContRBNode *first = r_rbtree_cont_node_first (tree);
+	if (!first) {
+		// empty tree
+		return NULL;
+	}
+	return first->data;
+}
+
+R_API void *r_rbtree_cont_last(RContRBTree *tree) {
+	r_return_val_if_fail (tree, NULL);
+	RContRBNode *last = r_rbtree_cont_node_last (tree);
+	if (!last) {
+		// empty tree
+		return NULL;
+	}
+	return last->data;
 }
 
 R_API void r_rbtree_cont_free(RContRBTree *tree) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Sometimes you need to get the first node instead of the item so that you can iterate forwards/backwards on the tree. I need this for iobanks
