### PR TITLE
Fix arm ldrd esil ##emu ##test

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1785,7 +1785,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX64()) {
+				if (ISPREINDEX64 ()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1913,7 +1913,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX64()) {
+				if (ISPREINDEX64 ()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1919,7 +1919,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				r_strbuf_appendf (&op->esil, ",=[%d]", size);
 
-				if (ISPOSTINDEX64()) {
+				if (ISPOSTINDEX64 ()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -57,7 +57,7 @@
 
 #define ISWRITEBACK32() insn->detail->arm.writeback
 #define ISPREINDEX32() (((OPCOUNT () == 2) && (ISMEM (1)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 3) && (ISMEM (2)) && (ISWRITEBACK32 ())))
-#define ISPOSTINDEX32() ((OPCOUNT () == 3) && (ISIMM (2) || ISREG (2)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 4) && (ISIMM (3) || ISREG (3)) && (ISWRITEBACK32 ()))
+#define ISPOSTINDEX32() (((OPCOUNT () == 3) && (ISIMM (2) || ISREG (2)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 4) && (ISIMM (3) || ISREG (3)) && (ISWRITEBACK32 ())))
 #define ISWRITEBACK64() (insn->detail->arm64.writeback == true)
 #define ISPREINDEX64() ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64()))
 #define ISPOSTINDEX64() ((OPCOUNT64() == 4) && (ISIMM64(3)) && (ISWRITEBACK64()))

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -56,8 +56,8 @@
 #define SHIFTVALUE(x) insn->detail->arm.operands[x].shift.value
 
 #define ISWRITEBACK32() insn->detail->arm.writeback
-#define ISPREINDEX32() ((OPCOUNT() == 2) && (ISMEM(1)) && (ISWRITEBACK32())) || ((OPCOUNT() == 3) && (ISMEM(2)) && (ISWRITEBACK32()))
-#define ISPOSTINDEX32() ((OPCOUNT() == 3) && (ISIMM(2) || ISREG(2)) && (ISWRITEBACK32())) || ((OPCOUNT() == 4) && (ISIMM(3) || ISREG(3)) && (ISWRITEBACK32()))
+#define ISPREINDEX32() ((OPCOUNT () == 2) && (ISMEM (1)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 3) && (ISMEM (2)) && (ISWRITEBACK32 ()))
+#define ISPOSTINDEX32() ((OPCOUNT () == 3) && (ISIMM (2) || ISREG (2)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 4) && (ISIMM (3) || ISREG (3)) && (ISWRITEBACK32 ()))
 #define ISWRITEBACK64() (insn->detail->arm64.writeback == true)
 #define ISPREINDEX64() ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64()))
 #define ISPOSTINDEX64() ((OPCOUNT64() == 4) && (ISIMM64(3)) && (ISWRITEBACK64()))
@@ -2772,40 +2772,40 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		break;
 	case ARM_INS_LDRD:
 		addr &= ~3LL;
-		if (MEMDISP(2) < 0) {
+		if (MEMDISP (2) < 0) {
 			const char *pc = "$$";
-			if (REGBASE(2) == ARM_REG_PC) {
+			if (REGBASE (2) == ARM_REG_PC) {
 				op->refptr = 4;
-				op->ptr = addr + pcdelta + MEMDISP(2);
-				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",2,2,%s,%d,+,>>,<<,+,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
-					(ut64)MEMDISP(2), pc, pcdelta, REG(0), REG(1));
+				op->ptr = addr + pcdelta + MEMDISP (2);
+				r_strbuf_appendf (&op->esil, "0x%" PFMT64x ",2,2,%s,%d,+,>>,<<,+,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
+					(ut64)MEMDISP (2), pc, pcdelta, REG (0), REG (1));
 			} else {
-				int disp = MEMDISP(2);
+				int disp = MEMDISP (2);
 				// not refptr, because we can't grab the reg value statically op->refptr = 4;
 				if (disp < 0) {
-					r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%s,-,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
-							(ut64)-disp, MEMBASE(2), REG(0), REG(1));
+					r_strbuf_appendf (&op->esil, "0x%" PFMT64x ",%s,-,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
+						(ut64)-disp, MEMBASE (2), REG (0), REG (1));
 				} else {
-					r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%s,+,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
-							(ut64)disp, MEMBASE(2), REG(0), REG(1));
+					r_strbuf_appendf (&op->esil, "0x%" PFMT64x ",%s,+,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
+						(ut64)disp, MEMBASE (2), REG (0), REG (1));
 				}
 			}
 		} else {
-			if (REGBASE(2) == ARM_REG_PC) {
+			if (REGBASE (2) == ARM_REG_PC) {
 				const char *pc = "$$";
 				op->refptr = 4;
-				op->ptr = addr + pcdelta + MEMDISP(2);
-				if (HASMEMINDEX(2) || ISREG(2)) {
-				    const char op_index = ISMEMINDEXSUB(2) ? '-' : '+';
-				    r_strbuf_appendf (&op->esil, "%s,2,2,%d,%s,+,>>,<<,%c,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
-						MEMINDEX(2), pcdelta, pc, op_index, REG(0), REG(1));
+				op->ptr = addr + pcdelta + MEMDISP (2);
+				if (HASMEMINDEX (2) || ISREG (2)) {
+					const char op_index = ISMEMINDEXSUB (2)? '-': '+';
+					r_strbuf_appendf (&op->esil, "%s,2,2,%d,%s,+,>>,<<,%c,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
+						MEMINDEX (2), pcdelta, pc, op_index, REG (0), REG (1));
 				} else {
 					r_strbuf_appendf (&op->esil, "2,2,%d,%s,+,>>,<<,%d,+,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
-						pcdelta, pc, MEMDISP(2), REG(0), REG(1));
+						pcdelta, pc, MEMDISP (2), REG (0), REG (1));
 				}
 			} else {
-				if (HASMEMINDEX(2)) {	// e.g. `ldrd r2, r3 [r4, r1]`
-				    const char op_index = ISMEMINDEXSUB(2) ? '-' : '+';
+				if (HASMEMINDEX (2)) { // e.g. `ldrd r2, r3 [r4, r1]`
+					const char op_index = ISMEMINDEXSUB (2)? '-': '+';
 					r_strbuf_appendf (&op->esil, "%s,%s,%c,0xffffffff,&,DUP,[4],%s,=,4,+,[4],%s,=",
 						MEMINDEX (2), MEMBASE (2), op_index, REG (0), REG (1));
 				} else {
@@ -2813,25 +2813,25 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 						MEMDISP (2), MEMBASE (2), REG (0), REG (1));
 				}
 				if (insn->detail->arm.writeback) {
-				    if(ISPOSTINDEX32()) {
-				        if (ISIMM (3)) {
-						    r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
-							    MEMBASE (2), IMM (3), MEMBASE (2));
-					    } else {
-					        const char op_index = ISMEMINDEXSUB(3) ? '-' : '+';
-					        r_strbuf_appendf (&op->esil, ",%s,%s,%c,%s,=",
-							    REG (3), MEMBASE (2), op_index, MEMBASE (2));
-					    }
-				    } else if (ISPREINDEX32()) {
-				        if (HASMEMINDEX(2)) {
-					        const char op_index = ISMEMINDEXSUB(2) ? '-' : '+';
-					        r_strbuf_appendf (&op->esil, ",%s,%s,%c,%s,=",
-							    MEMINDEX (2), MEMBASE (2), op_index, MEMBASE (2));
-					    } else {
-					        r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
-							    MEMBASE (2), MEMDISP (2), MEMBASE (2));
-					    }
-				    }				
+					if (ISPOSTINDEX32 ()) {
+						if (ISIMM (3)) {
+							r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
+								MEMBASE (2), IMM (3), MEMBASE (2));
+						} else {
+							const char op_index = ISMEMINDEXSUB (3)? '-': '+';
+							r_strbuf_appendf (&op->esil, ",%s,%s,%c,%s,=",
+								REG (3), MEMBASE (2), op_index, MEMBASE (2));
+						}
+					} else if (ISPREINDEX32 ()) {
+						if (HASMEMINDEX (2)) {
+							const char op_index = ISMEMINDEXSUB (2)? '-': '+';
+							r_strbuf_appendf (&op->esil, ",%s,%s,%c,%s,=",
+								MEMINDEX (2), MEMBASE (2), op_index, MEMBASE (2));
+						} else {
+							r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
+								MEMBASE (2), MEMDISP (2), MEMBASE (2));
+						}
+					}
 				}
 			}
 		}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1692,7 +1692,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX64()) {
+				if (ISPREINDEX64 ()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -59,8 +59,8 @@
 #define ISPREINDEX32() (((OPCOUNT () == 2) && (ISMEM (1)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 3) && (ISMEM (2)) && (ISWRITEBACK32 ())))
 #define ISPOSTINDEX32() (((OPCOUNT () == 3) && (ISIMM (2) || ISREG (2)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 4) && (ISIMM (3) || ISREG (3)) && (ISWRITEBACK32 ())))
 #define ISWRITEBACK64() (insn->detail->arm64.writeback == true)
-#define ISPREINDEX64() ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64()))
-#define ISPOSTINDEX64() ((OPCOUNT64() == 4) && (ISIMM64(3)) && (ISWRITEBACK64()))
+#define ISPREINDEX64() (((OPCOUNT64() == 2) && (ISMEM64(1)) && (ISWRITEBACK64())) || ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64())))
+#define ISPOSTINDEX64() (((OPCOUNT64() == 3) && (ISIMM64(2)) && (ISWRITEBACK64())) || ((OPCOUNT64() == 4) && (ISIMM64(3)) && (ISWRITEBACK64())))
 
 static HtUU *ht_itblock = NULL;
 static HtUU *ht_it = NULL;
@@ -1692,13 +1692,13 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX32()) {
+				if (ISPREINDEX64()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 
 				r_strbuf_appendf (&op->esil, ",[%d],%s,=", size, REG64 (0));
 
-				if (ISPOSTINDEX32()) {
+				if (ISPOSTINDEX64()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {
@@ -1785,13 +1785,13 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX32()) {
+				if (ISPREINDEX64()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 
 				r_strbuf_appendf (&op->esil, ",[%d],~,%s,=", size, REG64 (0));
 				
-				if (ISPOSTINDEX32()) {
+				if (ISPOSTINDEX64()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {
@@ -1913,13 +1913,13 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
-				if (ISPREINDEX32()) {
+				if (ISPREINDEX64()) {
 					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 
 				r_strbuf_appendf (&op->esil, ",=[%d]", size);
 
-				if (ISPOSTINDEX32()) {
+				if (ISPOSTINDEX64()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {
@@ -3441,10 +3441,10 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		} else if (ISPOSTINDEX64 () && REGID64 (2) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -IMM64 (3);
-		} else if (ISPREINDEX32 () && REGBASE64 (1) == ARM64_REG_SP) {
+		} else if (ISPREINDEX64 () && REGBASE64 (1) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -MEMDISP64 (1);
-		} else if (ISPOSTINDEX32 () && REGID64 (1) == ARM64_REG_SP) {
+		} else if (ISPOSTINDEX64 () && REGID64 (1) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -IMM64 (2);
 		}
@@ -3467,10 +3467,10 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		} else if (ISPOSTINDEX64 () && REGID64 (2) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -IMM64 (3);
-		} else if (ISPREINDEX32 () && REGBASE64 (1) == ARM64_REG_SP) {
+		} else if (ISPREINDEX64 () && REGBASE64 (1) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -MEMDISP64 (1);
-		} else if (ISPOSTINDEX32 () && REGID64 (1) == ARM64_REG_SP) {
+		} else if (ISPOSTINDEX64 () && REGID64 (1) == ARM64_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -IMM64 (2);
 		}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1791,7 +1791,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				r_strbuf_appendf (&op->esil, ",[%d],~,%s,=", size, REG64 (0));
 				
-				if (ISPOSTINDEX64()) {
+				if (ISPOSTINDEX64 ()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -56,7 +56,7 @@
 #define SHIFTVALUE(x) insn->detail->arm.operands[x].shift.value
 
 #define ISWRITEBACK32() insn->detail->arm.writeback
-#define ISPREINDEX32() ((OPCOUNT () == 2) && (ISMEM (1)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 3) && (ISMEM (2)) && (ISWRITEBACK32 ()))
+#define ISPREINDEX32() (((OPCOUNT () == 2) && (ISMEM (1)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 3) && (ISMEM (2)) && (ISWRITEBACK32 ())))
 #define ISPOSTINDEX32() ((OPCOUNT () == 3) && (ISIMM (2) || ISREG (2)) && (ISWRITEBACK32 ())) || ((OPCOUNT () == 4) && (ISIMM (3) || ISREG (3)) && (ISWRITEBACK32 ()))
 #define ISWRITEBACK64() (insn->detail->arm64.writeback == true)
 #define ISPREINDEX64() ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64()))

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1698,7 +1698,7 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 
 				r_strbuf_appendf (&op->esil, ",[%d],%s,=", size, REG64 (0));
 
-				if (ISPOSTINDEX64()) {
+				if (ISPOSTINDEX64 ()) {
 					if (ISREG64 (2)) { // not sure if register valued post indexing exists?
 						r_strbuf_appendf (&op->esil, ",tmp,%s,+,%s,=", REG64 (2), REG64 (1));
 					} else {

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -162,6 +162,109 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldrd r2, r3, [r1]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar r1=8
+# put value at r1 into r2 and at r1+4 into r3
+wx d1e90023 # ldrd r2,r3,[r1]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, #4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar r1=4
+# put value at r1+4 into r2 and at r1+4+4 into r3
+wx d1e90123 # ldrd r2,r3,[r1, 4]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [pc, #8]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+# put value at pc+4 into r2 and at pc+4+4 into r3
+wx dfe90223 # ldrd r2, r3, [pc, #8]
+wx ddccbbaa @ 12
+wx efbeadde @ 16
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, #4]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar r1=4
+# put value at r1+4 into r2 and at r1+4+4 into r3 then put r1+4 into r1
+wx f1e90123 # ldrd r2, r3, [r1, #4]!
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000008
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1], #4
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar r1=8
+# put value at r1 into r2 and at r1+4 into r3 then put r1+4 into r1
+wx f1e80123 # ldrd r2,r3,[r1], 4
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x0000000c
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
 NAME=ldm r3!, {r1, r4, r5}
 FILE=malloc://0x200
 CMDS=<<EOF

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -635,6 +635,263 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldrd r2, r3, [r1]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=8
+# put value at r1 into r2 and at r1+4 into r3
+wx d020c1e1 # ldrd r2,r3,[r1]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, #4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=4
+# put value at r1+4 into r2 and at r1+4+4 into r3
+wx d420c1e1 # ldrd r2,r3,[r1, 4]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [pc, #4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+# put value at pc+4 into r2 and at pc+4+4 into r3
+wx d420CFe1 # ldrd r2, r3, [pc, #4]
+wx ddccbbaa @ 12
+wx efbeadde @ 16
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, #4]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=4
+# put value at r1+4 into r2 and at r1+4+4 into r3 then put r1+4 into r1
+wx d420e1e1 # ldrd r2, r3, [r1, #4]!
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000008
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1], #4
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=8
+# put value at r1 into r2 and at r1+4 into r3 then put r1+4 into r1
+wx d420c1e0 # ldrd r2,r3,[r1], 4
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x0000000c
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, r4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=4
+ar r4=4
+# put value at r1+r4 into r2 and at r1+r4+4 into r3
+wx d42081e1 # ldrd r2,r3,[r1, r4]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, -r4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=12
+ar r4=4
+# put value at r1-r4 into r2 and at r1-r4+4 into r3
+wx d42001e1 # ldrd r2,r3,[r1, -r4]
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [pc, r4]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r4=4
+# put value at pc+r4 into r2 and at pc+r4+4 into r3
+wx d4208fe1 # ldrd r2, r3, [pc, r4]
+wx ddccbbaa @ 12
+wx efbeadde @ 16
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, r4]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=4
+ar r4=4
+# put value at r1+r4 into r2 and at r1+r4+4 into r3 then put r1+r4 into r1
+wx d420a1e1 # ldrd r2,r3,[r1, r4]!
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000008
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1, -r4]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=12
+ar r4=4
+# put value at r1-r4 into r2 and at r1-r4+4 into r3 then put r1-r4 into r1
+wx d42021e1 # ldrd r2,r3,[r1, -r4]!
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000008
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1], r4
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=8
+ar r4=4
+# put value at r1 into r2 and at r1+4 into r3 then put r1+r4 into r1
+wx d42081e0 # ldrd r2,r3,[r1], r4
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x0000000c
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
+NAME=ldrd r2, r3, [r1], -r4
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r1=8
+ar r4=4
+# put value at r1 into r2 and at r1+4 into r3 then put r1-r4 into r1
+wx d42001e0 # ldrd r2,r3,[r1], -r4
+wx ddccbbaa @ 8
+wx efbeadde @ 12
+aes
+ar r1
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000004
+0xaabbccdd
+0xdeadbeef
+EOF
+RUN
+
 NAME=str r2, [r3, 4]
 FILE=malloc://0x200
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

In ARM architecture, the ldrd instruction was handled as ldrb by ESIL. 
A ldrb instruction loads an unsigned byte into a register. A ldrd instruction loads a word into a register, and the following word (first word address + 4) into a second register.

The ESIL representation of ldrd was thus wrong. This PR fixes the ESIL and adds a few tests to ensure future non-regression.

`LDRB` is `LDR` with `B` type:
`LDR{type}{cond} Rt, [Rn {, #offset}] ; immediate offset`
-> Loads the byte [Rn + offset] into Rt

`LDRD` is a separate instruction:
`LDRD{cond} Rt, Rt2, [Rn {, #offset}] ; immediate offset, doubleword`
-> Loads the word [Rn + offset] into Rt and the word [Rn + offset + 4] int Rt2