### PR TITLE
WIP: use sdb in rvc

### DIFF
--- a/binr/rvc2/rvc2.c
+++ b/binr/rvc2/rvc2.c
@@ -1,7 +1,6 @@
 /* radare - LGPL - Copyright 2021 - pancake */
-
 #include <r_main.h>
 
 int main (int argc, const char *argv[]) {
-	return r_main_rvc2 (argc, argv);
+	//return r_main_rvc2 (argc, argv);
 }

--- a/binr/rvc2/rvc2.c
+++ b/binr/rvc2/rvc2.c
@@ -2,5 +2,5 @@
 #include <r_main.h>
 
 int main (int argc, const char *argv[]) {
-	return r_main_rvc2 (argc, argv);
+	//return r_main_rvc2 (argc, argv);
 }

--- a/binr/rvc2/rvc2.c
+++ b/binr/rvc2/rvc2.c
@@ -2,5 +2,5 @@
 #include <r_main.h>
 
 int main (int argc, const char *argv[]) {
-	//return r_main_rvc2 (argc, argv);
+	return r_main_rvc2 (argc, argv);
 }

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -72,7 +72,7 @@ static bool bfadd(RList *dst, const char *path, const char *rp) {
 		return false;
 	}
 	blob->fhash = sha256_file (absp);
-	if (blob->fhash) {
+	if (!blob->fhash) {
 		free (absp);
 		free (blob->fname);
 		free (blob);
@@ -294,8 +294,8 @@ R_API bool r_vc_new(const char *path) {
 	if (!vcp) {
 		return false;
 	}
-	commitp = r_str_newf ("%s" R_SYS_DIR "commits", path);
-	blobsp = r_str_newf ("%s" R_SYS_DIR "blobs", path);
+	commitp = r_str_newf ("%s" R_SYS_DIR "commits", vcp);
+	blobsp = r_str_newf ("%s" R_SYS_DIR "blobs", vcp);
 	if (!commitp || !blobsp) {
 		free (commitp);
 		free (blobsp);

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -1,55 +1,21 @@
 /* radare - LGPL - Copyright 2021 - RHL120, pancake */
 
+#include <sdb.h>
+#include <r_core.h>
 #include <rvc.h>
-
-static inline bool is_branch_name(const char *name) {
-	for (; *name; name++) {
-		if (!IS_DIGIT (*name) && !isalpha (*name)) {
-			return false;
-		}
-	}
-	return true;
-}
-
-static bool copy_commits(const Rvc *repo, const char *dpath, const char *spath) {
-	char *name, *commit_path;
-	RListIter *iter;
-	RList *files;
-	files = r_sys_dir (spath);
-	bool ret = true;
-	if (!files) {
-		eprintf ("Can't Open Files\n");
+static bool is_valid_branch_name(const char *name) {
+	if (r_str_len_utf8 (name) >= 16) {
 		return false;
 	}
-	r_list_foreach (files, iter, name) {
-		if (r_str_cmp (name, "..", 2) == 0 ||
-				r_str_cmp (name, ".", 1) == 0) {
-			printf ("%s", name);
+	const char  *extention = r_str_endswith (name, ".zip") ?
+		r_str_last (name, ".zip") : NULL;
+	for (; *name && name != extention; name++) {
+		if (IS_DIGIT (*name) || IS_LOWER (*name) || *name == '_') {
 			continue;
 		}
-		commit_path = r_str_newf ("%s" R_SYS_DIR "%s", spath, name);
-		if (!commit_path) {
-			ret = false;
-			break;
-		}
-		ret = r_file_copy (commit_path, dpath);
-		free (commit_path);
-		if (!ret) {
-			break;
-		}
+		return false;
 	}
-	r_list_free (files);
-	return ret;
-}
-
-static char *branch_mkdir(Rvc *repo, RvcBranch *b) {
-	char *path = r_str_newf ("%s" R_SYS_DIR "branches" R_SYS_DIR "%s"
-			R_SYS_DIR "commits" R_SYS_DIR, repo->path, b->name);
-	r_return_val_if_fail (path, NULL);
-	if (!r_sys_mkdirp (path)) {
-		R_FREE (path);
-	}
-	return path;
+	return true;
 }
 
 static char *find_sha256(const ut8 *block, int len) {
@@ -66,491 +32,323 @@ static inline char *sha256_file(const char *fname) {
 	return find_sha256 ((ut8 *)content, r_str_len_utf8 (content) * sizeof (ut8));
 }
 
-static char *read_until(const char *str, const char *find) {
-	char *ret;
-	char *f = strstr (str, find);
-	if (!f) {
-		return NULL;
-	}
-	ret = malloc (f - str + 1);
-	if (!ret) {
-		return NULL;
-	}
-	r_str_ncpy(ret, str, f - str + 1);
-	return ret;
-}
-
-static char *p2rvcp(const Rvc *repo, const char *path) {
-	char *ret;
-	char *p;
-	char *rp = read_until (repo->path, R_SYS_DIR ".rvc");
-	if (!rp) {
-		return NULL;
-	}
-	if (!r_file_is_abspath (path)) {
-		p = r_file_abspath (path);
-	} else {
-		p = r_str_new (path);
-	}
-	if (!p) {
-		free (rp);
-		return NULL;
-	}
-	ret = r_str_new (p + r_str_len_utf8 (rp) + 1);
-	free (p);
-	free (rp);
-	return ret;
-}
-
-static RvcBranch *branch_by_name(Rvc *repo, const char *name) {
-	RListIter *iter;
-	RvcBranch *b;
-	r_list_foreach (repo->branches, iter, b) {
-		if  (!r_str_cmp (name, b->name, r_str_len_utf8 (b->name) * sizeof (ut8))) {
-			return b;
-		}
-	}
-
-	return NULL;
-}
-
-static bool write_commit(Rvc *repo, RvcBranch *b, RvcCommit *commit) {
-	char *commit_path, *commit_string;
-	char *prev_path;
-	FILE *prev_file, *commit_file;
+static void free_blobs (RList *blobs) {
 	RListIter *iter;
 	RvcBlob *blob;
-	commit_string = r_str_newf ("author:%s\nmessage:%s\nntimestamp:%" PRId64"\n----",
-			commit->author, commit->message, commit->timestamp);
-	r_return_val_if_fail (commit_string, false);
-	r_list_foreach (commit->blobs, iter, blob) {
-		char *tmp = r_str_appendf (commit_string, "\nblob:%s:%s",
-				blob->fname, blob->hash);
-		if (!tmp) {
-			return false;
-		}
-		commit_string = tmp;
-	}
-	commit->hash = find_sha256 ((ut8 *) commit_string,
-			r_str_len_utf8 (commit_string) * sizeof (ut8));
-	if (!commit->hash) {
-		free (commit_string);
-		return false;
-	}
-	commit_path = r_str_newf ("%s" R_SYS_DIR "branches" R_SYS_DIR
-			"%s" R_SYS_DIR "commits" R_SYS_DIR "%s",
-			repo->path, b->name, commit->hash);
-	if (!commit_path) {
-		free (commit_string);
-		return false;
-	}
-	commit_file = fopen (commit_path, "w+");
-	free (commit_path);
-	if (!commit_file) {
-		free (commit_string);
-		return false;
-	}
-	fprintf (commit_file, "%s", commit_string);
-	free (commit_string);
-	if (!commit->prev) {
-		fclose (commit_file);
-		return true;
-	}
-	prev_path = r_str_newf ("%s" R_SYS_DIR "branches" R_SYS_DIR
-			"%s" R_SYS_DIR "commits" R_SYS_DIR "%s",
-			repo->path, b->name, commit->prev->hash);
-	if (!prev_path) {
-		fclose (commit_file);
-		return false;
-	}
-	prev_file = fopen (prev_path, "r+");
-	free (prev_path);
-	if (!prev_file) {
-		fclose (commit_file);
-		return false;
-	}
-	fprintf (commit_file, "\nprev:%s", commit->prev->hash);
-	fclose (commit_file);
-	fseek (prev_file, 0, SEEK_END);
-	fprintf (prev_file, "\nnext:%s", commit->hash);
-	fclose (prev_file);
-	return true;
-}
-
-static void free_blobs(RList *blobs) {
-	RvcBlob *blob;
-	RListIter *iter;
 	r_list_foreach (blobs, iter, blob) {
+		free (blob->fhash);
 		free (blob->fname);
-		free (blob->hash);
 	}
 	r_list_free (blobs);
 }
 
-static void free_commits(RvcCommit *head) {
-	if (!head) {
-		return;
+static char *absp2rp(const char *absp, const char *rp) {
+	char *arp = r_file_abspath (rp);
+	if (!arp) {
+		return NULL;
 	}
-	free (head->author);
-	free (head->hash);
-	free (head->message);
-	free_blobs (head->blobs);
-	free_commits (head->prev);
-	free (head);
+	if (r_str_len_utf8 (arp) < r_str_len_utf8 (rp)) {
+		free (arp);
+		return NULL;
+	}
+	return r_str_new (absp + r_str_len_utf8 (arp));
 }
 
-static void free_branches(RList *branches) {
-	RvcBranch *branch;
-	RListIter *iter;
-	r_list_foreach (branches, iter, branch) {
-		free (branch->name);
-		free_commits (branch->head);
-	}
-	free (branches);
-	return;
-}
-
-R_API bool r_vc_commit(Rvc *repo, RList *blobs, const char *auth, const char *message) {
-	RvcCommit *nc = R_NEW (RvcCommit);
-	if (!nc) {
-		eprintf ("Failed To Allocate New Commit\n");
-		return false;
-	}
-	nc->author = r_str_new (auth);
-	if (!nc->author) {
-		free (nc);
-		eprintf ("Failed To Allocate New Commit\n");
-		return false;
-	}
-	nc->message = r_str_new (message);
-	if (!nc->message) {
-		free (nc->author);
-		free (nc);
-		return false;
-	}
-	nc->timestamp = time (NULL);
-	nc->prev = repo->current_branch->head;
-	nc->blobs = blobs;
-	if (nc->prev) {
-		nc->prev->next = nc;
-	}
-	if (!write_commit (repo, repo->current_branch, nc)) {
-		free (nc->author);
-		free (nc->message);
-		free (nc);
-		eprintf ("Failed To Create Commit File\n");
-		return false;
-	}
-	repo->current_branch->head = nc;
-	return true;
-}
-
-R_API bool r_vc_branch(Rvc *repo, const char *name) {
-	char *bpath, *ppath;
-	RvcBranch *nb;
-	if (!is_branch_name (name)) {
-		eprintf ("%s Is Not A Vaild Branch Name\n", name);
-		return false;
-	}
-	nb = R_NEW0 (RvcBranch);
-	if (!nb) {
-		eprintf ("Failed To Allocate Branch Struct\n");
-		return false;
-	}
-	nb->head = NULL;
-	nb->name = r_str_new (name);
-	if (!nb->name) {
-		eprintf ("Failed To Allocate Branch Name\n");
-		free (nb);
-		return false;
-	}
-	r_list_append (repo->branches, nb);
-	bpath = branch_mkdir (repo, nb);
-	if (!bpath) {
-		eprintf ("Failed To Create Branch Directory\n");
-		free (nb->name);
-		free (nb);
-		r_list_pop (repo->branches);
-		return false;
-	}
-	if (repo->current_branch) {
-		nb->head = repo->current_branch->head;
-		ppath = r_str_newf ("%s" R_SYS_DIR "branches" R_SYS_DIR "%s"
-				R_SYS_DIR "commits" R_SYS_DIR,
-				repo->path, repo->current_branch->name);
-		if (!copy_commits (repo, bpath, ppath)) {
-			eprintf ("Failed To Copy Commits From Parent\n");
-			free (nb->name);
-			free (nb);
-			free (bpath);
-			free (ppath);
-			return false;
-		}
-		free (ppath);
-	}
-	repo->current_branch = nb;
-	free (bpath);
-	return true;
-}
-
-R_API void r_vc_free(Rvc *vc) {
-	free (vc->path);
-	free_branches (vc->branches);
-}
-
-R_API Rvc *r_vc_new(const char *path) {
-	Rvc *repo = R_NEW (Rvc);
+static bool bfadd(RList *dst, const char *path, const char *rp) {
+	RvcBlob *blob;
+	char *absp;
 	char *blob_path;
-	char *rabsp;
-	if (!repo) {
-		eprintf ("Failed To Allocate Repoistory Path\n");
-		return NULL;
+	blob = R_NEW (RvcBlob);
+	if (!blob) {
+		return false;
 	}
-	repo->current_branch = NULL;
-	rabsp = r_file_abspath (path);
-	if (r_str_endswith (rabsp, "/")) {
-		r_str_ncpy (rabsp, rabsp, r_str_len_utf8 (rabsp) - 1);
+	absp = r_file_abspath (path);
+	if (!absp) {
+		free (blob);
+		return false;
 	}
-	repo->path = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR, rabsp);
-	if (!repo->path) {
-		eprintf ("Failed To Allocate Repoistory Path\n");
-		free (repo);
-		free (rabsp);
-		return NULL;
+	blob->fname = absp2rp (path, rp);
+	if (!blob->fname) {
+		free (absp);
+		free (blob);
+		return false;
 	}
-	if (r_file_exists (repo->path) || r_file_is_directory (repo->path)) {
-		eprintf ("RVC Repoistory Already exists in %s\n", repo->path);
-		free (repo->path);
-		free (repo);
-		return NULL;
+	blob->fhash = sha256_file (absp);
+	if (blob->fhash) {
+		free (absp);
+		free (blob->fname);
+		free (blob);
+		return false;
 	}
-	if (!r_sys_mkdir (repo->path)) {
-		eprintf ("Failed To Create Repo Directory\n");
-		free (repo->path);
-		free (repo);
-		return NULL;
-	}
-	repo->branches = r_list_new ();
-	if (!repo->branches) {
-		eprintf ("Failed To Allocate Branches List\n");
-		free (repo);
-		free (repo->path);
-		return NULL;
-	}
-	if (!r_vc_branch (repo, "master")) {
-		eprintf ("Failed To Create The master Branch\n");
-		free (repo->path);
-		r_list_free (repo->branches);
-		free (repo);
-		return NULL;
-	}
-	blob_path = r_str_newf ("%s" R_SYS_DIR "blobs", repo->path);
+	blob_path = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR "blobs"
+			R_SYS_DIR "%s", rp, blob->fhash);
 	if (!blob_path) {
-		r_list_free  (repo->branches);
-		free (repo->path);
-		return NULL;
+		free (absp);
+		free (blob->fname);
+		free (blob->fhash);
+		free (blob);
+		return false;
 	}
-	if (!r_sys_mkdir (blob_path)) {
-		r_list_free (repo->branches);
+	if (!r_list_append (dst, blob)) {
+		free (absp);
+		free (blob->fname);
+		free (blob->fhash);
+		free (blob);
 		free (blob_path);
-		free (repo->path);
-		free (repo);
-		return NULL;
-	};
+		return false;
+	}
+	if (!r_file_copy (absp, blob_path)) {
+		free (absp);
+		free (blob->fname);
+		free (blob->fhash);
+		free (blob);
+		free (blob_path);
+		r_list_pop (dst);
+		return false;
+	}
+	free (absp);
 	free (blob_path);
-	return repo;
+	return true;
 }
 
-R_API RList *r_vc_add(Rvc *repo, RList *files) {
+static bool is_committed(const char *rp, const char *path) {
+	Sdb *db = sdb_new0 ();
+	if (!db) {
+		return false;
+	}
+	char *dbp = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR
+			"branches.sdb", rp);
+	if (!dbp) {
+		sdb_free (db);
+		return false;
+	}
+	if (!sdb_open (db, dbp)) {
+		free (dbp);
+		sdb_free (db);
+		return false;
+	}
+	free (dbp);
+}
+
+static RList *blobs_add(const RList *paths, const char *rp) {
+	RList *ret;
 	RListIter *iter;
-	char *fname;
-	RList *blobs = r_list_new ();
-	if (!blobs) {
-		eprintf ("r_vc_add: memory failieur\n");
-		return NULL;
-	}
-	r_list_foreach (files, iter, fname) {
-		char *bpath;
-		if (!r_file_exists (fname)) {
-			r_list_free (blobs);
-			eprintf ("r_vc_add: file: %s doesn't exist", fname);
-			return NULL;
-		}
-		RvcBlob *blob = R_NEW (RvcBlob);
-		if (!blob) {
-			eprintf ("r_vc_add: Memory Faileur\n");
-			r_list_free (blobs);
-			return NULL;
-		}
-		blob->fname = p2rvcp (repo, fname);
-		if (!blob->fname) {
-			eprintf ("r_vc_add: Memory Faileur\n");
-			r_list_free (blobs);
-			free (blob);
-			return NULL;
-		}
-		if (r_file_is_directory (fname)) {
-			r_list_free (blobs);
-			free (blob);
-			free (blob->fname);
-			eprintf ("r_vc_add: Can't Add Directories (Yet)");
-			return NULL;
-		}
-		blob->hash = sha256_file (fname);
-		if (!blob->hash) {
-			eprintf ("r_vc_add: Memory Faileur\n");
-			r_list_free (blobs);
-			free (blob->fname);
-			free (blob);
-			return NULL;
-		}
-		bpath = r_str_newf ("%s" R_SYS_DIR "blobs" R_SYS_DIR "%s",
-				repo->path, blob->hash);
-		if (!bpath) {
-			eprintf ("r_vc_add Memory Faileur\n");
-			r_list_free (blobs);
-			free (blob->fname);
-			free (blob->hash);
-			free (blob);
-			return NULL;
-		}
-		if (r_sys_cmdf ("cp -f %s %s", fname, bpath)) {
-			eprintf ("r_vc_add: can't copy blob\n");
-			r_list_free (blobs);
-			free (blob->fname);
-			free (blob->hash);
-			free (blob);
-			return NULL;
-		}
-		free (bpath);
-		if (!r_list_append (blobs, blob)) {
-			eprintf ("r_vc_add: can't copy blob\n");
-			r_list_free (blobs);
-			free (blob->fname);
-			free (blob->hash);
-			free (blob);
-			return NULL;
-		}
-	}
-	return blobs;
-}
-
-R_API RvcBlob *r_vc_path_to_commit(Rvc *repo, const char *path) {
-	RvcCommit *i;
-	i = repo->current_branch->head;
-	do {
-		RListIter *iter;
-		RvcBlob *blob;
-		r_list_foreach(i->blobs, iter, blob) {
-			char *hash;
-			if (strcmp (blob->fname, path)) {
-				continue;
-			}
-			hash = sha256_file (path);
-
-			if (!hash) {
-				return NULL;
-			}
-			if (!strcmp (hash, blob->hash)) {
-				free (hash);
-				return blob;
-			}
-			free (hash);
-		}
-	} while (i->prev);
-	return NULL;
-}
-
-R_API RvcBlob *r_vc_last_blob(Rvc *repo, const char *path) {
-	RvcCommit *i;
-	i = repo->current_branch->head;
-	do {
-		RListIter *iter;
-		RvcBlob *blob;
-		r_list_foreach(i->blobs, iter, blob) {
-			if (!strcmp (blob->fname, path)) {
-				return blob;
-			}
-		}
-	} while (i->prev);
-	return NULL;
-}
-
-R_API RList *r_vc_uncomitted(Rvc *repo) {
-	RListIter *iter, *tmp;
 	char *path;
-	char *rp = read_until (repo->path, R_SYS_DIR ".rvc/");
-	printf ("%s\n", rp);
-	if (!rp) {
+	ret = r_list_new ();
+	if (!ret) {
 		return NULL;
 	}
-	RList *files = r_file_lsrf (rp);
-	if (!files) {
-		free (rp);
-		return NULL;
-	}
-
-	r_list_foreach_safe (files, iter, tmp, path) {
-		path = p2rvcp (repo, path);
-		if (!path) {
-			r_list_free (files);
-			files = NULL;
+	r_list_foreach (ret, iter, path) {
+		bool is_dir = r_file_is_directory (path);
+		if (!is_dir && !r_file_exists (path)) {
+			free_blobs (ret);
+			ret = NULL;
 			break;
 		}
-		iter->data = path;
-		if (!r_str_cmp (".rvc", path, 4)) {
-			r_list_delete (files, iter);
+		if (is_dir) {
 			continue;
 		}
-		if (r_vc_path_to_commit (repo, path)) {
-			r_list_delete (files, iter);
+		if (!bfadd (ret, path, rp)) {
+			free_blobs (ret);
+			ret = NULL;
+			break;
 		}
 	}
-	free (rp);
-	return files;
+	return ret;
 }
 
-R_API bool r_vc_checkout(Rvc *repo, const char *name) {
+/*This Function Is Probably Somehow Broken*/
+static char *write_commit(const char *rp, const char *message, const char *auth,
+		RList *blobs) {
+	RvcBlob *blob;
 	RListIter *iter;
-	char *fpath;
-	RvcBranch *branch = branch_by_name (repo, name);
-	if (!branch) {
+	char *commit_path, *commit_hash;
+	char *content = r_str_newf ("message=%s\nauthor=%s\n----", message,
+			auth);
+	FILE *commitf;
+	if (!content) {
 		return false;
 	}
-	RvcBranch *tmpb;
-	RList *uncomitted = r_vc_uncomitted (repo);
-	if (!uncomitted) {
-		eprintf ("Memory failieur\n");
-		return false;
-	}
-	if (!r_list_empty (uncomitted)) {
-		eprintf ("Can Not Checkout Before You Commit The Following:\n");
-		r_list_foreach (uncomitted, iter, fpath) {
-			eprintf ("%s\n", fpath);
-		}
-		r_list_free (uncomitted);
-		return false;
-	}
-	r_list_free (uncomitted);
-	tmpb = repo->current_branch;
-	repo->current_branch = branch;
-	uncomitted = r_vc_uncomitted (repo);
-	r_list_foreach (uncomitted, iter, fpath) {
-		RvcBlob *blob;
-		char *bpath;
-		blob = r_vc_last_blob (repo, fpath);
-		bpath = r_str_newf ("%s" R_SYS_DIR "blobs" R_SYS_DIR "%s",
-				repo->path, blob->hash);
-		if (!bpath) {
-			r_file_rm (fpath);
-			continue;
-		}
-		if (!r_file_copy (bpath, fpath)) {
-			free (bpath);
-			repo->current_branch = tmpb;
+	r_list_foreach (blobs, iter, blob) {
+		content = r_str_appendf (content, "\n%s=%s", blob->fname,
+				blob->fhash);
+		if (!content) {
 			return false;
 		}
 	}
+	commit_hash = find_sha256 ((unsigned char *)
+			content, r_str_len_utf8 (commit_hash));
+	if (!commit_hash) {
+		free (content);
+		return false;
+	}
+	commit_path = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR "commits"
+			R_SYS_DIR "%s", rp, commit_hash);
+	if (!commit_path) {
+		free (content);
+		free (commit_hash);
+		return false;
+	}
+	commitf = fopen (commit_path, "w+");
+	free (commit_path);
+	if (!commitf) {
+		free (content);
+		free (commit_hash);
+		return false;
+	}
+	if (fprintf (commitf, "%s", content) != r_str_len_utf8 (content) * sizeof (char)) {
+		free (content);
+		free (commit_hash);
+		fclose (commitf);
+		return false;
+	}
+	fclose (commitf);
+	free (content);
+	return commit_hash;
+
+
+}
+
+R_API bool r_vc_commit(const char *rp, const char *message, const char *auth,
+		RList *files) {
+	char *commit_hash;
+	RList *blobs = blobs_add (files, rp);
+	if (!blobs) {
+		return false;
+	}
+	commit_hash = write_commit (rp, message, auth, blobs);
+	if (!commit_hash) {
+		free_blobs (blobs);
+		return false;
+	}
+	{
+		Sdb *db = sdb_new0 ();
+		char *dbf;
+		char *current_branch;
+		if (!db) {
+			free_blobs (blobs);
+			free (commit_hash);
+			return false;
+		}
+		dbf = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR "branches.sdb",
+				rp);
+		if (!dbf) {
+			free_blobs (blobs);
+			free (commit_hash);
+			return false;
+		}
+		sdb_open (db, dbf);
+		free (dbf);
+		current_branch = sdb_get (db, "current_branch", 0);
+		if (!current_branch) {
+			free_blobs (blobs);
+			free (commit_hash);
+			sdb_free (db);
+			return false;
+		}
+		if (!sdb_array_push (db, current_branch, commit_hash, 0)) {
+			free_blobs (blobs);
+			free (commit_hash);
+			sdb_close (db);
+			sdb_free (db);
+			free (current_branch);
+			return false;
+		}
+		free (current_branch);
+		sdb_sync (db);
+		sdb_unlink (db);
+		sdb_free (db);
+	}
+	free (commit_hash);
+	free_blobs (blobs);
+	return true;
+}
+
+
+R_API bool r_vc_branch(const char *rp, const char *bname) {
+	char *current_branch;
+	char *commits;
+	char *dbp;
+	Sdb *db;
+	if (!is_valid_branch_name (bname)) {
+		return false;
+	}
+	dbp = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR "branches.sdb", rp);
+	if (!dbp) {
+		return false;
+	}
+	db = sdb_new0 ();
+	if (!db) {
+		free (dbp);
+		return false;
+	}
+	if (!sdb_open (db, dbp)) {
+		sdb_free (db);
+		free (dbp);
+		return false;
+	}
+	free (dbp);
+	current_branch = sdb_get (db, "current_branch", 0);
+	if (!current_branch) {
+		sdb_free (db);
+		return false;
+	}
+	commits = sdb_get (db, current_branch, 0);
+	if (!commits) {
+		sdb_free (db);
+		free (current_branch);
+		return false;
+	}
+	free (current_branch);
+	sdb_set (db, bname, commits, 0);
+	free (commits);
+	sdb_sync (db);
+	sdb_unlink (db);
+	sdb_free (db);
+	return true;
+}
+
+R_API bool r_vc_new(const char *path) {
+	Sdb *db;
+	char *commitp, *blobsp;
+	char *vcp = r_str_newf ("%s" R_SYS_DIR ".rvc", path);
+	if (!vcp) {
+		return false;
+	}
+	commitp = r_str_newf ("%s" R_SYS_DIR "commits", path);
+	blobsp = r_str_newf ("%s" R_SYS_DIR "blobs", path);
+	if (!commitp || !blobsp) {
+		free (commitp);
+		free (blobsp);
+		return false;
+	}
+	if (!r_sys_mkdirp (commitp) || !r_sys_mkdir (blobsp)) {
+		eprintf ("Can't create The RVC repo directory");
+		free (commitp);
+		free (blobsp);
+		return false;
+	}
+	free (commitp);
+	free (blobsp);
+	db = sdb_new (vcp, "branches.db", 0);
+	free (vcp);
+	if (!db) {
+		eprintf ("Can't create The RVC branches database");
+		return false;
+	}
+	if (!sdb_set (db, "master", ",", 0)) { //Is this how you create an empty list?
+		sdb_unlink (db);
+		sdb_free (db);
+		return false;
+	}
+	if (!sdb_set (db, "current_branch", "master", 0)) {
+		sdb_unlink (db);
+		sdb_free (db);
+		return false;
+	}
+	sdb_sync (db);
+	sdb_unlink (db);
+	sdb_free (db);
 	return true;
 }
 

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -8,9 +8,7 @@ static bool is_valid_branch_name(const char *name) {
 	if (r_str_len_utf8 (name) >= 16) {
 		return false;
 	}
-	const char  *extention = r_str_endswith (name, ".zip") ?
-		r_str_last (name, ".zip") : NULL;
-	for (; *name && name != extention; name++) {
+	for (; *name; name++) {
 		if (IS_DIGIT (*name) || IS_LOWER (*name) || *name == '_') {
 			continue;
 		}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -43,6 +43,7 @@ static void free_blobs (RList *blobs) {
 }
 
 static char *absp2rp(const char *rp, const char *absp) {
+	char *ret;
 	char *arp = r_file_abspath (rp);
 	if (!arp) {
 		return NULL;
@@ -51,7 +52,18 @@ static char *absp2rp(const char *rp, const char *absp) {
 		free (arp);
 		return NULL;
 	}
-	return r_str_new (absp + r_str_len_utf8 (arp));
+ 	ret = r_str_new (absp + r_str_len_utf8 (arp));
+	free (arp);
+	return ret;
+}
+
+static char *rp2absp(const char *rp, const char *path) {
+	char *ret;
+	char *arp = r_file_abspath (rp);
+	if (!arp) {
+		return NULL;
+	}
+	return r_str_appendf (arp, R_SYS_DIR "%s", path);
 }
 
 static bool bfadd(const char *rp, RList *dst, const char *path) {

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -42,7 +42,7 @@ static void free_blobs (RList *blobs) {
 	r_list_free (blobs);
 }
 
-static char *absp2rp(const char *absp, const char *rp) {
+static char *absp2rp(const char *rp, const char *absp) {
 	char *arp = r_file_abspath (rp);
 	if (!arp) {
 		return NULL;
@@ -54,7 +54,7 @@ static char *absp2rp(const char *absp, const char *rp) {
 	return r_str_new (absp + r_str_len_utf8 (arp));
 }
 
-static bool bfadd(RList *dst, const char *path, const char *rp) {
+static bool bfadd(const char *rp, RList *dst, const char *path) {
 	RvcBlob *blob;
 	char *absp;
 	char *blob_path;
@@ -122,7 +122,7 @@ static bool bdadd(const char *rp, const char *dir, RList *dst) {
 		if (r_file_is_directory (path)) {
 			continue;
 		}
-		if (!bfadd (dst, path, rp)) {
+		if (!bfadd (rp, dst, path)) {
 			break;
 		}
 	}
@@ -130,7 +130,7 @@ static bool bdadd(const char *rp, const char *dir, RList *dst) {
 	return false;
 }
 
-static RList *blobs_add(const RList *paths, const char *rp) {
+static RList *blobs_add(const char *rp, const RList *paths) {
 	RList *ret;
 	RListIter *iter;
 	char *path;
@@ -153,7 +153,7 @@ static RList *blobs_add(const RList *paths, const char *rp) {
 			}
 			continue;
 		}
-		if (!bfadd (ret, path, rp)) {
+		if (!bfadd (rp, ret, path)) {
 			free_blobs (ret);
 			ret = NULL;
 			break;
@@ -215,7 +215,7 @@ static char *write_commit(const char *rp, const char *message, const char *auth,
 
 R_API bool r_vc_commit(const char *rp, const char *message, const char *auth, RList *files) {
 	char *commit_hash;
-	RList *blobs = blobs_add (files, rp);
+	RList *blobs = blobs_add (rp, files);
 	if (!blobs) {
 		return false;
 	}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -137,8 +137,7 @@ static RList *blobs_add(const RList *paths, const char *rp) {
 }
 
 /*This Function Is Probably Somehow Broken*/
-static char *write_commit(const char *rp, const char *message, const char *auth,
-		RList *blobs) {
+static char *write_commit(const char *rp, const char *message, const char *auth, RList *blobs) {
 	RvcBlob *blob;
 	RListIter *iter;
 	char *commit_path, *commit_hash;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -3,6 +3,7 @@
 #include <sdb.h>
 #include <r_core.h>
 #include <rvc.h>
+
 static bool is_valid_branch_name(const char *name) {
 	if (r_str_len_utf8 (name) >= 16) {
 		return false;
@@ -111,25 +112,6 @@ static bool bfadd(RList *dst, const char *path, const char *rp) {
 	return true;
 }
 
-static bool is_committed(const char *rp, const char *path) {
-	Sdb *db = sdb_new0 ();
-	if (!db) {
-		return false;
-	}
-	char *dbp = r_str_newf ("%s" R_SYS_DIR ".rvc" R_SYS_DIR
-			"branches.sdb", rp);
-	if (!dbp) {
-		sdb_free (db);
-		return false;
-	}
-	if (!sdb_open (db, dbp)) {
-		free (dbp);
-		sdb_free (db);
-		return false;
-	}
-	free (dbp);
-}
-
 static RList *blobs_add(const RList *paths, const char *rp) {
 	RList *ret;
 	RListIter *iter;
@@ -177,7 +159,7 @@ static char *write_commit(const char *rp, const char *message, const char *auth,
 		}
 	}
 	commit_hash = find_sha256 ((unsigned char *)
-			content, r_str_len_utf8 (commit_hash));
+			content, r_str_len_utf8 (content));
 	if (!commit_hash) {
 		free (content);
 		return false;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -111,6 +111,25 @@ static bool bfadd(RList *dst, const char *path, const char *rp) {
 	return true;
 }
 
+static bool bdadd(const char *rp, const char *dir, RList *dst) {
+	char *path;
+	RListIter *iter;
+	RList *files = r_file_lsrf (dir);
+	if (!files) {
+		return false;
+	}
+	r_list_foreach (files, iter, path) {
+		if (r_file_is_directory (path)) {
+			continue;
+		}
+		if (!bfadd (dst, path, rp)) {
+			break;
+		}
+	}
+	r_list_free (files);
+	return false;
+}
+
 static RList *blobs_add(const RList *paths, const char *rp) {
 	RList *ret;
 	RListIter *iter;
@@ -127,6 +146,11 @@ static RList *blobs_add(const RList *paths, const char *rp) {
 			break;
 		}
 		if (is_dir) {
+			if (!bdadd (rp, path, ret)) {
+				free_blobs (ret);
+				ret = NULL;
+				break;
+			}
 			continue;
 		}
 		if (!bfadd (ret, path, rp)) {

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -43,7 +43,6 @@ static void free_blobs (RList *blobs) {
 }
 
 static char *absp2rp(const char *rp, const char *absp) {
-	char *ret;
 	char *arp = r_file_abspath (rp);
 	if (!arp) {
 		return NULL;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -1,9 +1,6 @@
 /* radare - LGPL - Copyright 2021 - RHL120, pancake */
 
-#include <sdb.h>
-#include <r_core.h>
 #include <rvc.h>
-
 static bool is_valid_branch_name(const char *name) {
 	if (r_str_len_utf8 (name) >= 16) {
 		return false;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -2,6 +2,7 @@
 
 #include <rvc.h>
 #define FIRST_BRANCH "master"
+//TODO:Move most str literals into preprocesor directives
 
 static bool is_valid_branch_name(const char *name) {
 	if (r_str_len_utf8 (name) >= 16) {
@@ -57,14 +58,15 @@ static char *absp2rp(const char *rp, const char *absp) {
 	return ret;
 }
 
-static char *rp2absp(const char *rp, const char *path) {
-	char *ret;
+char *rp2absp(const char *rp, const char *path) {
 	char *arp = r_file_abspath (rp);
 	if (!arp) {
 		return NULL;
 	}
 	return r_str_appendf (arp, R_SYS_DIR "%s", path);
 }
+
+//TODO:Make the tree related functions abit cleaner & more efficient
 
 static RList *get_commits(Sdb *db, const size_t max_num) {
 	char *i;
@@ -120,7 +122,7 @@ static bool update_blob(RList *blobs, RvcBlob *blob) {
 	return found ? true : !!(r_list_append (blobs, blob)); //!! is the only way I found that doesnt trigger a warnning;
 }
 
-static RList *get_current_tree (const char *rp) {
+RList *get_current_tree (const char *rp) {
 	Sdb *db = sdb_new0 ();
 	if (!db) {
 		return NULL;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -162,7 +162,6 @@ static RList *blobs_add(const char *rp, const RList *paths) {
 	return ret;
 }
 
-/*This Function Is Probably Somehow Broken*/
 static char *write_commit(const char *rp, const char *message, const char *author, RList *blobs) {
 	RvcBlob *blob;
 	RListIter *iter;
@@ -344,7 +343,7 @@ R_API bool r_vc_new(const char *path) {
 		eprintf ("Can't create The RVC branches database");
 		return false;
 	}
-	if (!sdb_set (db, FIRST_BRANCH, "", 0)) { //Is this how you create an empty list?
+	if (!sdb_set (db, FIRST_BRANCH, "", 0)) {
 		sdb_unlink (db);
 		sdb_free (db);
 		return false;

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -19,8 +19,7 @@ R_API bool r_vc_git_checkout(const char *path, const char *name);
 R_API int r_vc_git_add(const char *path, const char *fname);
 R_API int r_vc_git_commit(const char *path, const char *message);
 
-R_API bool r_vc_commit(const char *rp, const char *message, const char *auth,
-		RList *files);
+R_API bool r_vc_commit(const char *rp, const char *message, const char *auth, RList *files);
 R_API bool r_vc_branch(const char *rp, const char *bname);
 R_API bool r_vc_new(const char *path);
 

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -19,7 +19,7 @@ R_API bool r_vc_git_checkout(const char *path, const char *name);
 R_API int r_vc_git_add(const char *path, const char *fname);
 R_API int r_vc_git_commit(const char *path, const char *message);
 
-R_API bool r_vc_commit(const char *rp, const char *message, const char *auth, RList *files);
+R_API bool r_vc_commit(const char *rp, const char *message, const char *author, RList *files);
 R_API bool r_vc_branch(const char *rp, const char *bname);
 R_API bool r_vc_new(const char *path);
 

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -23,6 +23,7 @@ R_API int r_vc_git_commit(const char *path, const char *message);
 R_API bool r_vc_commit(const char *rp, const char *message, const char *author, RList *files);
 R_API bool r_vc_branch(const char *rp, const char *bname);
 R_API bool r_vc_new(const char *path);
+R_API bool r_vc_checkout(const char *rp, const char *bname);
 
 #ifdef __cplusplus
 }

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -1,7 +1,5 @@
 /* radare - LGPL - Copyright 2021 - RHL120, pancake */
 
-#include <sdb.h>
-#include <r_core.h>
 #ifndef R_RVC_H
 #define R_RVC_H 1
 

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -11,7 +11,8 @@ extern "C" {
 #include <r_core.h>
 #include <sdb.h>
 typedef struct RvcBlob_t {
-	char *fname, *fhash;
+	char *fname;
+	char *fhash;
 } RvcBlob;
 R_API int r_vc_git_init(const char *path);
 R_API bool r_vc_git_branch(const char *path, const char *name);

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -1,5 +1,7 @@
 /* radare - LGPL - Copyright 2021 - RHL120, pancake */
 
+#include <sdb.h>
+#include <r_core.h>
 #ifndef R_RVC_H
 #define R_RVC_H 1
 
@@ -18,6 +20,7 @@ R_API int r_vc_git_add(const char *path, const char *fname);
 R_API int r_vc_git_commit(const char *path, const char *message);
 
 R_API bool r_vc_commit(const char *rp, const char *message, const char *auth,
+		RList *files);
 R_API bool r_vc_branch(const char *rp, const char *bname);
 R_API bool r_vc_new(const char *path);
 

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -3,54 +3,23 @@
 #ifndef R_RVC_H
 #define R_RVC_H 1
 
-#include <r_core.h>
-#include <r_util.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct blob {
-	char *fname;
-	char *hash;
+typedef struct RvcBlob_t {
+	char *fname, *fhash;
 } RvcBlob;
-
-typedef struct commit {
-	struct commit *prev;
-	RList *blobs;
-	char *author;
-	int64_t timestamp;
-	char *hash;
-	size_t next_num;
-	bool ishead;
-	char *message;
-	struct commit *next;
-} RvcCommit;
-
-typedef struct branch {
-	char *name;
-	RvcCommit *head;
-} RvcBranch;
-
-typedef struct RVc {
-	char *path;
-	RList *branches;
-	RvcBranch *current_branch;
-} Rvc;
-
-R_API RvcBlob *r_vc_path_to_commit(Rvc *repo, const char *path);
-R_API RList *r_vc_uncomitted(Rvc *repo);
-R_API bool r_vc_checkout(Rvc *repo, const char *name);
-R_API bool r_vc_commit(Rvc *repo, RList *blobs, const char *auth, const char *message);
-R_API bool r_vc_branch(Rvc *repo, const char *name);
-R_API RList *r_vc_add(Rvc *repo, RList *files);
-R_API Rvc *r_vc_new(const char *path);
-R_API void r_vc_free(Rvc *vc);
 R_API int r_vc_git_init(const char *path);
 R_API bool r_vc_git_branch(const char *path, const char *name);
 R_API bool r_vc_git_checkout(const char *path, const char *name);
 R_API int r_vc_git_add(const char *path, const char *fname);
 R_API int r_vc_git_commit(const char *path, const char *message);
+
+R_API bool r_vc_commit(const char *rp, const char *message, const char *auth,
+R_API bool r_vc_branch(const char *rp, const char *bname);
+R_API bool r_vc_new(const char *path);
 
 #ifdef __cplusplus
 }

--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+#include <r_core.h>
+#include <sdb.h>
 typedef struct RvcBlob_t {
 	char *fname, *fhash;
 } RvcBlob;

--- a/libr/main/rvc2.c
+++ b/libr/main/rvc2.c
@@ -66,7 +66,7 @@ R_API int r_main_rvc2(int argc, const char **argv) {
 	}
 	if (!strcmp (action, "commit")) {
 		char *auth, *message;
-		uint i;
+		int i;
 		RList *files;
 		if (opt.argc < 5) {
 			free (rp);

--- a/libr/main/rvc2.c
+++ b/libr/main/rvc2.c
@@ -90,7 +90,7 @@ R_API int r_main_rvc2(int argc, const char **argv) {
 			free (message);
 			return -9;
 		}
-		for (i = 3; i < argc - 1; ++i) {
+		for (i = 3; i < argc - 1; i++) {
 			char *cf = r_str_new (argv[opt.ind + i]);
 			if (!cf) {
 				free (auth);

--- a/libr/main/rvc2.c
+++ b/libr/main/rvc2.c
@@ -1,6 +1,6 @@
 /* radare - LGPL - Copyright 2021 - pancake */
 #include <rvc.h>
-
+/*
 static void rvc2_show_help(void) {
 	printf ("Usage: rvc2 [action] [file ...]\n"
 		" init            initialize repository in current directory\n"
@@ -92,3 +92,4 @@ R_API int r_main_rvc2(int argc, const char **argv) {
 	}
 	return 0;
 }
+*/

--- a/libr/main/rvc2.c
+++ b/libr/main/rvc2.c
@@ -40,11 +40,11 @@ R_API int r_main_rvc2(int argc, const char **argv) {
 		eprintf ("TODO: r_vc_git APIs should be called from r_vc\n");
 		eprintf ("TODO: r_vc_new should accept options argument\n");
 	}
-	const char *action = (opt.ind < argc)? opt.arg: NULL;
+	const char *action = (argc >= 2)? opt.argv[opt.ind] : NULL;
 	if (!action) {
 		return -1;
 	}
-	//TODO: Accept dirs that aren' PWD
+	//TODO: Accept dirs that aren't PWD
 	char *rp = r_sys_getdir ();
 	if (!rp) {
 		return -2;
@@ -90,9 +90,16 @@ R_API int r_main_rvc2(int argc, const char **argv) {
 			free (message);
 			return -9;
 		}
-		for (i = opt.ind + 3; i < argc; ++i) {
-			if (!r_list_append (files, r_str_new (argv[opt.ind + i])) ||
-					!files->tail->data) {
+		for (i = 3; i < argc - 1; ++i) {
+			char *cf = r_str_new (argv[opt.ind + i]);
+			if (!cf) {
+				free (auth);
+				free (message);
+				r_list_free (files);
+				free (rp);
+				return -10;
+			}
+			if (!r_list_append (files, cf)) {
 				free (auth);
 				free (message);
 				r_list_free (files);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)
**Description**

In https://github.com/radareorg/radare2/pull/18499 I helped introduce the abomination known as rvc. This pr tries to make rvc use sdb for branches instead of having them as dirs. This has many advantages most notably:
* Rvc does no longer copy & dup commits when branching since commit don't hold info about their position
* Rvc no longer has to have the "loading_functionality" since needed data is loaded on command
a disadvantage would be that now Rvc would have to load important data every time an R_API function is called
I would recommend the revs to focuse on the sdb usage because it is probably not valid.
TODOs:
* Add some proper error messages
* Add r_vc_checkout functionality
* Add some checks to know whether or not an rvc_repo exists before executing a command
Far TODOs:
* Unify The git APIS and RVC apis based on prj.vc
* Add reverting functionality
