### PR TITLE
Ragg2 user plugins ##egg

### DIFF
--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -263,7 +263,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				b = malloc (strlen (opt.arg) + 1);
 				len = r_hex_str2bin (p, b);
 				if (len > 0) {
-					r_egg_patch (es->e, off, (const ut8*)b, len);
+					r_egg_patch (es->e, off, (const ut8 *)b, len);
 				} else {
 					eprintf ("Invalid hexstr for -w\n");
 				}
@@ -278,13 +278,13 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			{
 			ut32 n = r_num_math (NULL, opt.arg);
 			append = 1;
-			r_egg_patch (es->e, -1, (const ut8*)&n, 4);
+			r_egg_patch (es->e, -1, (const ut8 *)&n, 4);
 			}
 			break;
 		case 'N':
 			{
 			ut64 n = r_num_math (NULL, opt.arg);
-			r_egg_patch (es->e, -1, (const ut8*)&n, 8);
+			r_egg_patch (es->e, -1, (const ut8 *)&n, 8);
 			append = 1;
 			}
 			break;
@@ -298,7 +298,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				n = r_num_math (NULL, p + 1);
 				*p = ':';
 				// TODO: honor endianness here
-				r_egg_patch (es->e, off, (const ut8*)&n, 4);
+				r_egg_patch (es->e, off, (const ut8 *)&n, 4);
 			} else {
 				eprintf ("Missing colon in -d\n");
 			}
@@ -311,7 +311,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				ut64 n, off = r_num_math (NULL, opt.arg);
 				n = r_num_math (NULL, p + 1);
 				// TODO: honor endianness here
-				r_egg_patch (es->e, off, (const ut8*)&n, 8);
+				r_egg_patch (es->e, off, (const ut8 *)&n, 8);
 			} else {
 				eprintf ("Missing colon in -d\n");
 			}
@@ -480,7 +480,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			size_t l;
 			char *buf = r_file_slurp (textFile, &l);
 			if (buf && l > 0) {
-				r_egg_raw (es->e, (const ut8*)buf, (int)l);
+				r_egg_raw (es->e, (const ut8 *)buf, (int)l);
 			} else {
 				eprintf ("Error loading '%s'\n", textFile);
 			}
@@ -523,7 +523,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	if (str) {
 		int l = strlen (str);
 		if (l > 0) {
-			r_egg_raw (es->e, (const ut8*)str, l);
+			r_egg_raw (es->e, (const ut8 *)str, l);
 		}
 	}
 
@@ -532,7 +532,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		size_t l;
 		char *buf = r_file_slurp (contents, &l);
 		if (buf && l > 0) {
-			r_egg_raw (es->e, (const ut8*)buf, (int)l);
+			r_egg_raw (es->e, (const ut8 *)buf, (int)l);
 		} else {
 			eprintf ("Error loading '%s'\n", contents);
 		}

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -6,6 +6,76 @@
 #include <r_util/r_print.h>
 #include <r_util.h>
 
+typedef struct {
+	RLib *l;
+	REgg *e;
+	// TODO flags
+	// bool oneliner;
+	// bool coutput;
+	// bool json;
+	// bool quiet;
+} REggState;
+
+static void __load_plugins(REggState *es);
+
+static REggState *__es_new(void) {
+	REggState *es = R_NEW0 (REggState);
+	if (es) {
+		es->l = r_lib_new (NULL, NULL);
+		es->e = r_egg_new ();
+		__load_plugins (es);
+	}
+	return es;
+}
+
+static void __es_free(REggState *es) {
+	r_egg_free (es->e);
+	r_lib_free (es->l);
+	free (es);
+}
+
+/* egg callback */
+static int __lib_egg_cb(RLibPlugin *pl, void *user, void *data) {
+	REggPlugin *hand = (REggPlugin *)data;
+	REggState *es = (REggState *)user;
+	r_egg_add (es->e, hand);
+	return true;
+}
+
+static void __load_plugins(REggState *es) {
+	char *tmp = r_sys_getenv ("RAGG2_NOPLUGINS");
+	if (tmp) {
+		free (tmp);
+		return;
+	}
+
+	r_lib_add_handler (es->l, R_LIB_TYPE_EGG, "egg plugins", &__lib_egg_cb, NULL, es);
+
+	char *path = r_sys_getenv (R_LIB_ENV);
+	if (path && *path) {
+		r_lib_opendir (es->l, path);
+	}
+
+	// load plugins from the home directory
+	char *homeplugindir = r_str_home (R2_HOME_PLUGINS);
+	r_lib_opendir (es->l, homeplugindir);
+	free (homeplugindir);
+
+	// load plugins from the system directory
+	char *plugindir = r_str_r2_prefix (R2_PLUGINS);
+	char *extrasdir = r_str_r2_prefix (R2_EXTRAS);
+	char *bindingsdir = r_str_r2_prefix (R2_BINDINGS);
+	r_lib_opendir (es->l, plugindir);
+	r_lib_opendir (es->l, extrasdir);
+	r_lib_opendir (es->l, bindingsdir);
+	free (plugindir);
+	free (extrasdir);
+	free (bindingsdir);
+
+	free (tmp);
+	free (path);
+}
+
 static int usage(int v) {
 	printf ("Usage: ragg2 [-FOLsrxhvz] [-a arch] [-b bits] [-k os] [-o file] [-I path]\n"
 		"             [-i sc] [-E enc] [-B hex] [-c k=v] [-C file] [-p pad] [-q off]\n"
@@ -142,7 +212,12 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	int ofileauto = 0;
 	RBuffer *b;
 	int c, i, fd = -1;
-	REgg *egg = r_egg_new ();
+
+	if (argc < 2) {
+		return usage (1);
+	}
+
+	REggState *es = __es_new ();
 
 	RGetopt opt;
 	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxXrk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:");
@@ -171,7 +246,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			if (R_STR_ISEMPTY (opt.arg)) {
 				eprintf ("Cannot open empty contents path\n");
 				free (sequence);
-				r_egg_free (egg);
+				__es_free (es);
 				return 1;
 			}
 			contents = opt.arg;
@@ -188,7 +263,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				b = malloc (strlen (opt.arg) + 1);
 				len = r_hex_str2bin (p, b);
 				if (len > 0) {
-					r_egg_patch (egg, off, (const ut8*)b, len);
+					r_egg_patch (es->e, off, (const ut8*)b, len);
 				} else {
 					eprintf ("Invalid hexstr for -w\n");
 				}
@@ -203,13 +278,13 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			{
 			ut32 n = r_num_math (NULL, opt.arg);
 			append = 1;
-			r_egg_patch (egg, -1, (const ut8*)&n, 4);
+			r_egg_patch (es->e, -1, (const ut8*)&n, 4);
 			}
 			break;
 		case 'N':
 			{
 			ut64 n = r_num_math (NULL, opt.arg);
-			r_egg_patch (egg, -1, (const ut8*)&n, 8);
+			r_egg_patch (es->e, -1, (const ut8*)&n, 8);
 			append = 1;
 			}
 			break;
@@ -223,7 +298,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				n = r_num_math (NULL, p + 1);
 				*p = ':';
 				// TODO: honor endianness here
-				r_egg_patch (egg, off, (const ut8*)&n, 4);
+				r_egg_patch (es->e, off, (const ut8*)&n, 4);
 			} else {
 				eprintf ("Missing colon in -d\n");
 			}
@@ -236,7 +311,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				ut64 n, off = r_num_math (NULL, opt.arg);
 				n = r_num_math (NULL, p + 1);
 				// TODO: honor endianness here
-				r_egg_patch (egg, off, (const ut8*)&n, 8);
+				r_egg_patch (es->e, off, (const ut8*)&n, 8);
 			} else {
 				eprintf ("Missing colon in -d\n");
 			}
@@ -255,10 +330,10 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			if (R_STR_ISEMPTY (opt.arg)) {
 				eprintf ("Cannot open empty include path\n");
 				free (sequence);
-				r_egg_free (egg);
+				__es_free (es);
 				return 1;
 			}
-			r_egg_lang_include_path (egg, opt.arg);
+			r_egg_lang_include_path (es->e, opt.arg);
 			break;
 		case 'i':
 			shellcode = opt.arg;
@@ -274,9 +349,9 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			char *p = strchr (opt.arg, '=');
 			if (p) {
 				*p++ = 0;
-				r_egg_option_set (egg, opt.arg, p);
+				r_egg_option_set (es->e, opt.arg, p);
 			} else {
-				r_egg_option_set (egg, opt.arg, "true");
+				r_egg_option_set (es->e, opt.arg, "true");
 			}
 			}
 			break;
@@ -314,17 +389,17 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			show_execute_rop = 1;
 			break;
 		case 'L':
-			list (egg);
-			r_egg_free (egg);
+			list (es->e);
+			__es_free (es);
 			free (sequence);
 			return 0;
 		case 'h':
-			r_egg_free (egg);
+			__es_free (es);
 			free (sequence);
 			return usage (1);
 		case 'v':
 			free (sequence);
-			r_egg_free (egg);
+			__es_free (es);
 			return r_main_version_print ("ragg2");
 		case 'z':
 			show_str = 1;
@@ -335,14 +410,14 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			break;
 		default:
 			free (sequence);
-			r_egg_free (egg);
+			__es_free (es);
 			return 1;
 		}
 	}
 
 	if (opt.ind == argc && !eggprg && !shellcode && !bytes && !contents && !encoder && !padding && !pattern && !append && !get_offset && !str) {
 		free (sequence);
-		r_egg_free (egg);
+		__es_free (es);
 		return usage (0);
 	}
 	if (opt.ind != argc) {
@@ -362,7 +437,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		if (strncmp (sequence, "0x", 2)) {
 			eprintf ("Need hex value with `0x' prefix e.g. 0x41414142\n");
 			free (sequence);
-			r_egg_free (egg);
+			__es_free (es);
 			return 1;
 		}
 
@@ -370,12 +445,12 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		printf ("Little endian: %d\n", r_debruijn_offset (get_offset, false));
 		printf ("Big endian: %d\n", r_debruijn_offset (get_offset, true));
 		free (sequence);
-		r_egg_free (egg);
+		__es_free (es);
 		return 0;
 	}
 
 	// initialize egg
-	r_egg_setup (egg, arch, bits, 0, os);
+	r_egg_setup (es->e, arch, bits, 0, os);
 	if (file) {
 		if (R_STR_ISEMPTY (file)) {
 			eprintf ("Cannot open empty path\n");
@@ -390,7 +465,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 				if (feof (stdin)) {
 					break;
 				}
-				r_egg_load (egg, buf, 0);
+				r_egg_load (es->e, buf, 0);
 			}
 		} else if (strstr (file, ".c")) {
 			char *fileSanitized = strdup (file);
@@ -405,7 +480,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			size_t l;
 			char *buf = r_file_slurp (textFile, &l);
 			if (buf && l > 0) {
-				r_egg_raw (egg, (const ut8*)buf, (int)l);
+				r_egg_raw (es->e, (const ut8*)buf, (int)l);
 			} else {
 				eprintf ("Error loading '%s'\n", textFile);
 			}
@@ -422,24 +497,24 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 			} else {
 				fmt = 0;
 			}
-			if (!r_egg_include (egg, file, fmt)) {
+			if (!r_egg_include (es->e, file, fmt)) {
 				eprintf ("Cannot open '%s'\n", file);
 				goto fail;
 			}
 		}
 	} else {
-		if (eggprg && !r_egg_include_str (egg, eggprg)) {
+		if (eggprg && !r_egg_include_str (es->e, eggprg)) {
 			eprintf ("Cannot parse egg program.\n");
 			goto fail;
 		}
 	}
 
 	// compile source code to assembly
-	if (!r_egg_compile (egg)) {
+	if (!r_egg_compile (es->e)) {
 		if (!fmt) {
 			eprintf ("r_egg_compile: fail\n");
 			free (sequence);
-			r_egg_free (egg);
+			__es_free (es);
 			return 1;
 		}
 	}
@@ -448,7 +523,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	if (str) {
 		int l = strlen (str);
 		if (l > 0) {
-			r_egg_raw (egg, (const ut8*)str, l);
+			r_egg_raw (es->e, (const ut8*)str, l);
 		}
 	}
 
@@ -457,7 +532,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		size_t l;
 		char *buf = r_file_slurp (contents, &l);
 		if (buf && l > 0) {
-			r_egg_raw (egg, (const ut8*)buf, (int)l);
+			r_egg_raw (es->e, (const ut8*)buf, (int)l);
 		} else {
 			eprintf ("Error loading '%s'\n", contents);
 		}
@@ -466,7 +541,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 
 	// add shellcode
 	if (shellcode) {
-		if (!r_egg_shellcode (egg, shellcode)) {
+		if (!r_egg_shellcode (es->e, shellcode)) {
 			eprintf ("Unknown shellcode '%s'\n", shellcode);
 			goto fail;
 		}
@@ -477,7 +552,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		ut8 *b = malloc (strlen (bytes) + 1);
 		int len = r_hex_str2bin (bytes, b);
 		if (len > 0) {
-			if (!r_egg_raw (egg, b, len)) {
+			if (!r_egg_raw (es->e, b, len)) {
 				eprintf ("Unknown '%s'\n", shellcode);
 				free (b);
 				goto fail;
@@ -523,13 +598,13 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 
 	// assemble to binary
 	if (!show_asm) {
-		if (!r_egg_assemble (egg)) {
+		if (!r_egg_assemble (es->e)) {
 			eprintf ("r_egg_assemble: invalid assembly\n");
 			goto fail;
 		}
 	}
 	if (encoder) {
-		if (!r_egg_encode (egg, encoder)) {
+		if (!r_egg_encode (es->e, encoder)) {
 			eprintf ("Invalid encoder '%s'\n", encoder);
 			goto fail;
 		}
@@ -537,44 +612,44 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 
 	// add padding
 	if (padding) {
-		r_egg_padding (egg, padding);
+		r_egg_padding (es->e, padding);
 	}
 
 	// add pattern
 	if (pattern) {
-		r_egg_pattern (egg, r_num_math (NULL, pattern));
+		r_egg_pattern (es->e, r_num_math (NULL, pattern));
 	}
 
 	// apply patches
-	if (!egg->bin) {
-		egg->bin = r_buf_new ();
+	if (!es->e->bin) {
+		es->e->bin = r_buf_new ();
 	}
-	if (!(b = r_egg_get_bin (egg))) {
+	if (!(b = r_egg_get_bin (es->e))) {
 		eprintf ("r_egg_get_bin: invalid egg :(\n");
 		goto fail;
 	}
-	r_egg_finalize (egg);
+	r_egg_finalize (es->e);
 
 	if (show_asm) {
-		printf ("%s\n", r_egg_get_assembly (egg));
+		printf ("%s\n", r_egg_get_assembly (es->e));
 	}
 
 	if (show_raw || show_hex || show_execute) {
 		if (show_execute) {
 			int r;
 			if (show_execute_rop) {
-				r = r_egg_run_rop (egg);
+				r = r_egg_run_rop (es->e);
 			} else {
-				r = r_egg_run (egg);
+				r = r_egg_run (es->e);
 			}
-			r_egg_free (egg);
+			r_egg_free (es->e);
 			if (fd != -1) {
 				close (fd);
 			}
 			free (sequence);
 			return r;
 		}
-		b = r_egg_get_bin (egg);
+		b = r_egg_get_bin (es->e);
 		if (show_raw) {
 			ut64 blen;
 			const ut8 *tmp = r_buf_data (b, &blen);
@@ -632,13 +707,13 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 		close (fd);
 	}
 	free (sequence);
-	r_egg_free (egg);
+	__es_free (es);
 	return 0;
 fail:
 	if (fd != -1) {
 		close (fd);
 	}
 	free (sequence);
-	r_egg_free (egg);
+	__es_free (es);
 	return 1;
 }

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -43,16 +43,14 @@ static int __lib_egg_cb(RLibPlugin *pl, void *user, void *data) {
 }
 
 static void __load_plugins(REggState *es) {
-	char *tmp = r_sys_getenv ("RAGG2_NOPLUGINS");
-	if (tmp) {
-		free (tmp);
+	if (r_sys_getenv_asbool ("RAGG2_NOPLUGINS")) {
 		return;
 	}
 
 	r_lib_add_handler (es->l, R_LIB_TYPE_EGG, "egg plugins", &__lib_egg_cb, NULL, es);
 
 	char *path = r_sys_getenv (R_LIB_ENV);
-	if (path && *path) {
+	if (!R_STR_ISEMPTY (path)) {
 		r_lib_opendir (es->l, path);
 	}
 
@@ -72,7 +70,6 @@ static void __load_plugins(REggState *es) {
 	free (extrasdir);
 	free (bindingsdir);
 
-	free (tmp);
 	free (path);
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Support loading user plugins (from R2_USER_PLUGINS) in ragg2. Based on rasm2 code.

```sh
$ ragg2 -L
shellcodes:
      exec : execute cmd=/bin/sh suid=false
     myshc : egg shellcode plugin template
encoders:
       xor : xor encoder for shellcode
     myenc : egg encoder plugin template
```
```
[0x00000000]> gl
shc    exec : execute cmd=/bin/sh suid=false
enc     xor : xor encoder for shellcode
enc   myenc : egg encoder plugin template
shc   myshc : egg shellcode plugin template

```
[egg-plugin-templates.zip](https://github.com/radareorg/radare2/files/6593513/egg-plugin-templates.zip)
