### PR TITLE
Set prj.vc to false if git is not in PATH

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4014,11 +4014,12 @@ R_API int r_core_config_init(RCore *core) {
 	/* RVC */
 	{
 		char *p = r_file_path ("git");
-		bool found = (p && *p == 'g');
-		if (!found) {
+		if (strcmp (p, "git")) {
 			SETCB ("prj.vc.type", "git", &cb_prjvctype, "What should projects use as a vc");
 		} else {
-			//SETCB ("prj.vc.type", "rvc", &cb_prjvctype, "What should projects use as a vc"); //l8er
+			SETBPREF ("prj.vc", "false", "Use your version control system of choice (rvc, git) to manage projects");
+			/*The follwing is just a place holder*/
+			SETCB ("prj.vc.type", "rvc", &cb_prjvctype, "What should projects use as a vc");
 		}
 		free (p);
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Ps used to fail on windows due to a missuse of r_file_path, prj.vc was always set to true and prj.vc.type was sometime undeclared. This PR attempts to fix these problems
