### PR TITLE
Fix issue #18799 - r2pipe commd output leaks to stdout

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5529,9 +5529,18 @@ R_API char *r_core_cmd_strf(RCore *core, const char *fmt, ...) {
 /* return: pointer to a buffer with the output of the command */
 R_API char *r_core_cmd_str(RCore *core, const char *cmd) {
 	r_cons_push ();
+	r_cons_singleton ()->noflush = true;
+	core->in_cmdstr++;
 	if (r_core_cmd (core, cmd, 0) == -1) {
 		//eprintf ("Invalid command: %s\n", cmd);
+		if (--core->in_cmdstr == 0) {
+			r_cons_singleton ()->noflush = false;
+			r_cons_flush ();
+		}
 		return NULL;
+	}
+	if (--core->in_cmdstr == 0) {
+		r_cons_singleton ()->noflush = false;
 	}
 	r_cons_filter ();
 	const char *static_str = r_cons_get_buffer ();

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -350,6 +350,7 @@ struct r_core_t {
 	bool log_events; // core.c:cb_event_handler : log actions from events if cfg.log.events is set
 	RList *ropchain;
 	char *theme;
+	int in_cmdstr;
 	bool marks_init;
 	ut64 marks[UT8_MAX + 1];
 

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -20,6 +20,7 @@ if get_option('enable_tests')
     'bitmap',
     'buf',
     'cmd',
+    'cmd_str',
     'cons',
     'contrbtree',
     'debruijn',

--- a/test/unit/test_cmd_str.c
+++ b/test/unit/test_cmd_str.c
@@ -4,7 +4,7 @@
 bool test_cmd_str_issue_18799() {
 	RCore *core = r_core_new ();
 	char *output = r_core_cmd_str (core, "pd 1 @e:asm.hints=false");
-	mu_assert ("command output leaked to stdout", strlen(output) > 0);
+	mu_assert ("command output leaked to stdout", strlen (output) > 0);
 	r_core_free (core);
 	mu_end;
 }
@@ -17,4 +17,3 @@ int all_tests() {
 int main(int argc, char **argv) {
 	return all_tests ();
 }
-

--- a/test/unit/test_cmd_str.c
+++ b/test/unit/test_cmd_str.c
@@ -1,0 +1,20 @@
+#include <r_core.h>
+#include "minunit.h"
+
+bool test_cmd_str_issue_18799() {
+	RCore *core = r_core_new ();
+	char *output = r_core_cmd_str (core, "pd 1 @e:asm.hints=false");
+	mu_assert ("command output leaked to stdout", strlen(output) > 0);
+	r_core_free (core);
+	mu_end;
+}
+
+int all_tests() {
+	mu_run_test (test_cmd_str_issue_18799);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}
+


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #18799
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

When r2pipe commands are executed the result is not supposed to be printed to the console but instead it should be returned as a string to r2pipe, while this works in general but there are some command combination that cause some leakage. This patch ensures the console isn't flushed until r_core_cmd_str is finished including the case when r_core_cmd_str is reentrant.