### PR TITLE
Add doclean target into libr/util/d/Makefile ##build

### DIFF
--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -73,6 +73,7 @@ endif
 
 EXTRA_PRE+=spp_config
 EXTRA_PRE+=charsets
+EXTRA_CLEAN=doclean
 
 include ../rules.mk
 include sdb.mk
@@ -81,6 +82,10 @@ include spp.mk
 charsets:
 	$(MAKE) -C d
 .PHONY: charsets
+
+doclean:
+	$(MAKE) -C d clean
+.PHONY: doclean
 
 sync-regex regex-sync:
 	-rm -rf src/

--- a/libr/util/d/Makefile
+++ b/libr/util/d/Makefile
@@ -15,6 +15,9 @@ alle: $(F_SDB)
 	$(SDB) -t -C $@
 	test -f $@
 
+clean:
+	rm -f *.sdb *.c *.gperf
+
 install:
 	mkdir -p "$(R2_CHARSETS_PATH)"
 	for FILE in *.sdb ; do \
@@ -30,4 +33,4 @@ symstall install-symlink:
 		ln -fs "${CWD}/$$FILE" "${R2_CHARSETS_PATH}/$$FILE" ; \
 	done
 
-.PHONY: all install symstall
+.PHONY: alle clean uninstall install symstall install-symlink


### PR DESCRIPTION
**Checklist**
- [x] Not closing issues
- [x] Mark this if you consider it ready to merge
- [x] Not adding tests (optional)
- [x] Not adding documentation

**Description**

radare2 failed to build without using `--without-gperf` option,
with the following message: No rule to make target 'd/ascii.o',
needed by 'libr_util.so'.

I took a look into anal/d/Makefile which seems to be doing the same
thing. I noticed that it was using `all` as default target instead
of `alle` as done in util/d/Makefile. Moreover the .PHONY only mention
`all` an not `alle`, thus I believe this is a typo, and it was meant
to be `all`, fix this.

This could also be fixed by changing the `all` to `alle` target in `.PHONY`. not sure if it is a better fix.
---
edit: Maybe the issue I was having is only related to a dirty build directory.
The issue I was having can no longer be reproduced after cleaning the `libr/util/d/` directory

This commit now add a clean target to  `libr/util/d/Makefile`
