### PR TITLE
Fix ##ragg2 options 

### DIFF
--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -217,7 +217,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	REggState *es = __es_new ();
 
 	RGetopt opt;
-	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxXrk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:");
+	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxXrk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:E:");
 	while ((c = r_getopt_next (&opt)) != -1) {
 		switch (c) {
 		case 'a':

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -217,7 +217,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	REggState *es = __es_new ();
 
 	RGetopt opt;
-	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxX:rk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:E:");
+	r_getopt_init (&opt, argc, argv, "a:b:B:c:C:d:D:e:E:f:Fhi:I:k:Ln:N:o:Op:P:q:rsS:vw:xX:z");
 	while ((c = r_getopt_next (&opt)) != -1) {
 		switch (c) {
 		case 'a':

--- a/libr/main/ragg2.c
+++ b/libr/main/ragg2.c
@@ -217,7 +217,7 @@ R_API int r_main_ragg2(int argc, const char **argv) {
 	REggState *es = __es_new ();
 
 	RGetopt opt;
-	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxXrk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:E:");
+	r_getopt_init (&opt, argc, argv, "n:N:he:a:b:f:o:sxX:rk:FOI:Li:c:p:P:B:C:vd:D:w:zq:S:E:");
 	while ((c = r_getopt_next (&opt)) != -1) {
 		switch (c) {
 		case 'a':


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)


**Description**

Fixes the following option parsing issues
- The X flag should require an argument
- The E flag throws an illegal option error
  ```sh
  $ ragg2 -i exec -E xor -c key=0xa
  ragg2: illegal option -- E
  ```
  Expected behavior
  ```sh
  $ ragg2 -i exec -E xor -c key=0xa
  6a1b596a0a5be8ffffffffc15e4883c60d301e48ffc6e2f93bca42b1db979c9bda869df542fdd1595e5593585d5e54ba31050f
  ```

