### PR TITLE
Fix ldr pre post esil ##emu ##test

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2922,9 +2922,9 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 						pcdelta, pc, LSHIFT2(1), MEMINDEX(1), mask, REG(0));
 				} else {
 					if (ISREG(1)) {
-					    const char op_index = ISMEMINDEXSUB (1)? '-': '+';
+						const char op_index = ISMEMINDEXSUB (1)? '-': '+';
 						r_strbuf_appendf (&op->esil, "%s,2,2,%d,%s,+,>>,<<,%c,0xffffffff,&,[4],0x%x,&,%s,=",
-							MEMINDEX(1), pcdelta, pc, op_index, mask, REG(0));
+							MEMINDEX (1), pcdelta, pc, op_index, mask, REG (0));
 					} else {
 						r_strbuf_appendf (&op->esil, "2,2,%d,%s,+,>>,<<,%d,+,0xffffffff,&,[4],0x%x,&,%s,=",
 							pcdelta, pc, MEMDISP(1), mask, REG(0));
@@ -2935,7 +2935,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 					r_strbuf_appendf (&op->esil, "%s,%d,%s,<<,+,0xffffffff,&,[4],0x%x,&,%s,=",
 						MEMBASE (1), LSHIFT2 (1), MEMINDEX (1), mask, REG (0));
 				} else if (HASMEMINDEX(1)) {	// e.g. `ldr r2, [r3, r1]`
-				    const char op_index = ISMEMINDEXSUB (1)? '-': '+';
+					const char op_index = ISMEMINDEXSUB (1)? '-': '+';
 					r_strbuf_appendf (&op->esil, "%s,%s,%c,0xffffffff,&,[4],0x%x,&,%s,=",
 						MEMINDEX (1), MEMBASE (1), op_index, mask, REG (0));
 				} else {
@@ -2943,12 +2943,24 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 						MEMDISP (1), MEMBASE (1), mask, REG (0));
 				}
 				if (insn->detail->arm.writeback) {
-					if (ISIMM (2)) {
-						r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
-							MEMBASE (1), IMM (2), MEMBASE (1));
-					} else {
-						r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
-							MEMBASE (1), MEMDISP (1), MEMBASE (1));
+					if (ISPOSTINDEX32 ()) {
+						if (ISIMM (2)) {
+							r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
+								MEMBASE (1), IMM (2), MEMBASE (1));
+						} else {
+							const char op_index = ISMEMINDEXSUB (2)? '-': '+';
+							r_strbuf_appendf (&op->esil, ",%d,%s,<<,%s,%c,%s,=",
+								LSHIFT2 (2), REG (2), MEMBASE (1), op_index, MEMBASE (1));
+						}
+					} else if (ISPREINDEX32 ()) {
+						if (HASMEMINDEX (1)) {
+							const char op_index = ISMEMINDEXSUB (1)? '-': '+';
+							r_strbuf_appendf (&op->esil, ",%d,%s,<<,%s,%c,%s,=",
+								LSHIFT2 (1), MEMINDEX (1), MEMBASE (1), op_index, MEMBASE (1));
+						} else {
+							r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
+								MEMBASE (1), MEMDISP (1), MEMBASE (1));
+						}
 					}
 				}
 			}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2922,8 +2922,9 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 						pcdelta, pc, LSHIFT2(1), MEMINDEX(1), mask, REG(0));
 				} else {
 					if (ISREG(1)) {
-						r_strbuf_appendf (&op->esil, "2,2,%d,%s,+,>>,<<,%s,+,0xffffffff,&,[4],0x%x,&,%s,=",
-							pcdelta, pc, MEMINDEX(1), mask, REG(0));
+					    const char op_index = ISMEMINDEXSUB (1)? '-': '+';
+						r_strbuf_appendf (&op->esil, "%s,2,2,%d,%s,+,>>,<<,%c,0xffffffff,&,[4],0x%x,&,%s,=",
+							MEMINDEX(1), pcdelta, pc, op_index, mask, REG(0));
 					} else {
 						r_strbuf_appendf (&op->esil, "2,2,%d,%s,+,>>,<<,%d,+,0xffffffff,&,[4],0x%x,&,%s,=",
 							pcdelta, pc, MEMDISP(1), mask, REG(0));
@@ -2934,8 +2935,9 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 					r_strbuf_appendf (&op->esil, "%s,%d,%s,<<,+,0xffffffff,&,[4],0x%x,&,%s,=",
 						MEMBASE (1), LSHIFT2 (1), MEMINDEX (1), mask, REG (0));
 				} else if (HASMEMINDEX(1)) {	// e.g. `ldr r2, [r3, r1]`
-					r_strbuf_appendf (&op->esil, "%s,%s,+,0xffffffff,&,[4],0x%x,&,%s,=",
-						MEMINDEX (1), MEMBASE (1), mask, REG (0));
+				    const char op_index = ISMEMINDEXSUB (1)? '-': '+';
+					r_strbuf_appendf (&op->esil, "%s,%s,%c,0xffffffff,&,[4],0x%x,&,%s,=",
+						MEMINDEX (1), MEMBASE (1), op_index, mask, REG (0));
 				} else {
 					r_strbuf_appendf (&op->esil, "%d,%s,+,0xffffffff,&,[4],0x%x,&,%s,=",
 						MEMDISP (1), MEMBASE (1), mask, REG (0));

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -162,6 +162,44 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldr r0, [r1, 6]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar > /dev/null
+ar r1=2
+wx 51f8060f
+wx aaaaaaaabbbbbbbb44332211@4
+aes
+ar r0
+ar r1
+EOF
+EXPECT=<<EOF
+0xbbbbbbbb
+0x00000008
+EOF
+RUN
+
+NAME=ldr r0, [r1], -4
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar > /dev/null
+ar r1=8
+wx 51f80409
+wx aaaaaaaabbbbbbbb44332211@4
+aes
+ar r0
+ar r1
+EOF
+EXPECT=<<EOF
+0xbbbbbbbb
+0x00000004
+EOF
+RUN
+
 NAME=ldrd r2, r3, [r1]
 FILE=malloc://0x200
 CMDS=<<EOF

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -567,6 +567,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ldr r0, [r1, 7]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar > /dev/null
+ar r0=0
+ar r1=1
+wx 0700b1e5
+wx aaaaaaaabbbbbbbb44332211@4
+aes
+ar r0
+ar r1
+EOF
+EXPECT=<<EOF
+0xbbbbbbbb
+0x00000008
+EOF
+RUN
+
 NAME=ldr r0, [r0, 7]
 FILE=malloc://0x200
 CMDS=<<EOF
@@ -581,6 +601,26 @@ ar r0
 EOF
 EXPECT=<<EOF
 0xbbbbbbaa
+EOF
+RUN
+
+NAME=ldr r0, [r1], 7
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar > /dev/null
+ar r0=0
+ar r1=8
+wx 070091e4
+wx aaaaaaaabbbbbbbb44332211@4
+aes
+ar r0
+ar r1
+EOF
+EXPECT=<<EOF
+0xbbbbbbbb
+0x0000000f
 EOF
 RUN
 
@@ -615,6 +655,61 @@ ar r2
 EOF
 EXPECT=<<EOF
 0xffeeddcc
+EOF
+RUN
+
+NAME=ldr r2, [r3, -r1]
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r3=8
+ar r1=2
+wx 012013e7
+wx aabbccddeeff @ 4
+aes
+ar r2
+EOF
+EXPECT=<<EOF
+0xffeeddcc
+EOF
+RUN
+
+NAME=ldr r2, [r3, r1, lsl 1]!
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r3=4
+ar r1=1
+wx 8120b3e7
+wx aabbccddeeff @ 4
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xffeeddcc
+0x00000006
+EOF
+RUN
+
+NAME=ldr r2, [r3], -r1, lsl #1
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+ar r3=6
+ar r1=1
+wx 812013e6
+wx aabbccddeeff @ 4
+aes
+ar r2
+ar r3
+EOF
+EXPECT=<<EOF
+0xffeeddcc
+0x00000004
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

ESIL translation of ldr instructions lacked support for pre/post-indexed register offset, along with negative register offset.

Instructions like `ldr r0, [r1], -r2` and `ldr r0, [r1, -r2]` where thus handled like `ldr r0, [r1, r2]`.

Strictly speaking, the problem with negative register offset (the `-r2`) is not related to the pre/post-indexed problem. But as I resolved both problems at the same time I only do one PR. Let me know if you want me to make two separate PR for this.

Anyway, this PR includes tests for ARM32 and ARM16 in order to ensure no future regression.