### PR TITLE
Use r_sys_getpid() for source portability whetever getpid() is called

### DIFF
--- a/binr/preload/libr2.c
+++ b/binr/preload/libr2.c
@@ -39,8 +39,9 @@ static void _libwrap_init(void) {
 	char *web;
 	r_sys_signal (SIGUSR1, sigusr1);
 	r_sys_signal (SIGUSR2, sigusr2);
-	printf ("libr2 initialized. send SIGUSR1 to %d in order to reach the r2 prompt\n", getpid ());
-	printf ("kill -USR1 %d\n", getpid ());
+	int pid = r_sys_getpid ();
+	printf ("libr2 initialized. send SIGUSR1 to %d in order to reach the r2 prompt\n", pid);
+	printf ("kill -USR1 %d\n", pid);
 	fflush (stdout);
 	web = r_sys_getenv ("RARUN2_WEB");
 	core = r_core_new ();

--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -209,7 +209,7 @@ static void trace_me(void) {
 		r_sys_perror ("ptrace-traceme");
 	}
 #if __APPLE__
-	ptrace (PT_SIGEXC, getpid(), NULL, 0);
+	ptrace (PT_SIGEXC, r_sys_getpid (), NULL, 0);
 #endif
 #else
 	if (ptrace (PTRACE_TRACEME, 0, NULL, NULL) != 0) {

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2014-2020 - pancake */
+/* radare - LGPL - Copyright 2014-2021 - pancake */
 
 #include <r_userconf.h>
 #include <r_io.h>
@@ -153,7 +153,7 @@ static int update_self_regions(RIO *io, int pid) {
 #elif __sun && defined _LP64
 	char path[PATH_MAX];
 	int err;
-	pid_t self = getpid ();
+	pid_t self = r_sys_getpid ();
 	struct ps_prochandle *Pself = Pgrab(self, PGRAB_RDONLY, &err);
 
 	if (!Pself) {
@@ -264,7 +264,7 @@ static bool __plugin_open(RIO *io, const char *file, bool many) {
 }
 
 static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
-	int ret, pid = getpid ();
+	int ret, pid = r_sys_getpid ();
 	if (r_sandbox_enable (0)) {
 		return NULL;
 	}
@@ -321,7 +321,7 @@ static int __close(RIODesc *fd) {
 static void got_alarm(int sig) {
 #if !defined(__WINDOWS__)
 	// !!! may die if not running from r2preload !!! //
-	kill (getpid (), SIGUSR1);
+	kill (r_sys_getpid (), SIGUSR1);
 #endif
 }
 
@@ -337,7 +337,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *cmd) {
 			return NULL;
 		}
 		/* do nothing here */
-		kill (getpid (), SIGKILL);
+		kill (r_sys_getpid (), SIGKILL);
 #endif
 	} else if (!strncmp (cmd, "call ", 5)) {
 		size_t cbptr = 0;

--- a/libr/main/r2agent.c
+++ b/libr/main/r2agent.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2020 - pancake */
+/* radare2 - LGPL - Copyright 2013-2021 - pancake */
 
 #include "index.h"
 #include <r_main.h>
@@ -96,7 +96,7 @@ R_API int r_main_r2agent(int argc, const char **argv) {
 		}
 	}
 #if USE_IOS_JETSAM
-	memorystatus_control (MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT, getpid (), 256, NULL, 0);
+	memorystatus_control (MEMORYSTATUS_CMD_SET_JETSAM_TASK_LIMIT, r_sys_getpid (), 256, NULL, 0);
 #endif
 	if (dodaemon) {
 #if LIBC_HAVE_FORK

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -1073,7 +1073,7 @@ R_API int r_run_config_env(RRunProfile *p) {
 	}
 	if (p->_timeout) {
 #if __UNIX__
-		int mypid = getpid ();
+		int mypid = r_sys_getpid ();
 		if (!r_sys_fork ()) {
 			int use_signal = p->_timeout_sig;
 			if (use_signal < 1) {
@@ -1177,7 +1177,7 @@ R_API int r_run_start(RRunProfile *p) {
 			setsid ();
 			if (p->_timeout) {
 #if __UNIX__
-				int mypid = getpid ();
+				int mypid = r_sys_getpid ();
 				if (!r_sys_fork ()) {
 					int use_signal = p->_timeout_sig;
 					if (use_signal < 1) {
@@ -1236,11 +1236,11 @@ R_API int r_run_start(RRunProfile *p) {
 			}
 		}
 		if (p->_pid) {
-			eprintf ("PID: %d\n", getpid ());
+			eprintf ("PID: %d\n", r_sys_getpid ());
 		}
 		if (p->_pidfile) {
 			char pidstr[32];
-			snprintf (pidstr, sizeof (pidstr), "%d\n", getpid ());
+			snprintf (pidstr, sizeof (pidstr), "%d\n", r_sys_getpid ());
 			r_file_dump (p->_pidfile,
 				(const ut8*)pidstr,
 				strlen (pidstr), 0);

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -444,7 +444,7 @@ static void signal_handler(int signum) {
 	if (!crash_handler_cmd) {
 		return;
 	}
-	snprintf (cmd, sizeof(cmd) - 1, crash_handler_cmd, getpid ());
+	snprintf (cmd, sizeof(cmd) - 1, crash_handler_cmd, r_sys_getpid ());
 	r_sys_backtrace ();
 	exit (r_sys_cmd (cmd));
 }

--- a/libr/util/thread.c
+++ b/libr/util/thread.c
@@ -177,7 +177,7 @@ R_API bool r_th_setaffinity(RThread *th, int cpuid) {
 	pset_create (&c);
 	pset_assign (c, cpuid, NULL);
 
-	if (pset_bind (c, P_PID, getpid (), NULL)) {
+	if (pset_bind (c, P_PID, r_sys_getpid (), NULL)) {
 		pset_destroy (c);
 		eprintf ("Failed to set cpu affinity\n");
 		return false;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
