### PR TITLE
Fix oob read bug in r_str_home on empty env vars

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -278,7 +278,7 @@ R_API char *r_str_home(const char *str) {
 		}
 	}
 	length = strlen (home) + 1;
-	if (str) {
+	if (!R_STR_ISEMPTY (str)) {
 		length += strlen (R_SYS_DIR) + strlen (str);
 	}
 	dst = (char *)malloc (length);
@@ -287,7 +287,7 @@ R_API char *r_str_home(const char *str) {
 	}
 	int home_len = strlen (home);
 	memcpy (dst, home, home_len + 1);
-	if (str) {
+	if (!R_STR_ISEMPTY (str)) {
 		dst[home_len] = R_SYS_DIR[0];
 		strcpy (dst + home_len + 1, str);
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
