### PR TITLE
Fix `aod` (opcode description) when using the `r2ghidra` asm plugin

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -328,16 +328,26 @@ R_API bool r_asm_use_assembler(RAsm *a, const char *name) {
 	return false;
 }
 
-static void load_plugin(RAsm *a, RAsmPlugin *p) {
-	SdbGperf *gp = r_asm_get_gperf (p->name);
+static void load_asm_descriptions(RAsm *a, RAsmPlugin *p) {
+	const char *arch = p->arch;
+	if (!arch || !strcmp (p->name, "r2ghidra")) {
+		if (a->cpu) {
+			arch = a->cpu;
+		} else {
+			arch = p->name;
+		}
+	}
+#if HAVE_GPERF
+	SdbGperf *gp = r_asm_get_gperf (arch); // p->name);
 	if (gp) {
 		sdb_free (a->pair);
 		a->pair = sdb_new0 ();
 		sdb_open_gperf (a->pair, gp);
 		return;
 	}
+#endif
 	char *r2prefix = r_str_r2_prefix (R2_SDB_OPCODES);
-	char *file = r_str_newf ("%s/%s.sdb", r_str_getf (r2prefix), p->arch);
+	char *file = r_str_newf ("%s/%s.sdb", r_str_getf (r2prefix), arch);
 	if (file) {
 		sdb_free (a->pair);
 		a->pair = sdb_new (NULL, file, 0);
@@ -356,9 +366,8 @@ R_API bool r_asm_use(RAsm *a, const char *name) {
 	r_list_foreach (a->plugins, iter, h) {
 		if (!strcmp (h->name, name) && h->arch) {
 			if (!a->cur || (a->cur && strcmp (a->cur->arch, h->arch))) {
+				load_asm_descriptions (a, h);
 				r_asm_set_cpu (a, NULL);
-				load_plugin (a, h);
-
 			}
 			a->cur = h;
 			return true;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
