### PR TITLE
Remove pid start message

### DIFF
--- a/libr/io/p/io_debug.c
+++ b/libr/io/p/io_debug.c
@@ -416,7 +416,7 @@ static int fork_and_ptraceme_for_unix(RIO *io, int bits, const char *cmd) {
 			r_cons_sleep_end (bed);
 		} while (ret != child_pid && !r_cons_is_breaked ());
 		if (WIFSTOPPED (status)) {
-			eprintf ("Process with PID %d started...\n", (int)child_pid);
+			eprintf ("Process started...\n");
 		} else if (WEXITSTATUS (status) == MAGIC_EXIT) {
 			child_pid = -1;
 		} else if (r_cons_is_breaked ()) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Remove the debugee PID at the start of the launch of radare2. It will permit to make tests easier.