### PR TITLE
Avoid assert on avr's null cmpreg test ##anal

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -266,8 +266,14 @@ static bool is_delta_pointer_table(RAnal *anal, RAnalFunction *fcn, ut64 addr, u
 	return true;
 }
 
-static ut64 try_get_cmpval_from_parents(RAnal * anal, RAnalFunction *fcn, RAnalBlock *my_bb, const char * cmp_reg) {
-	r_return_val_if_fail (fcn && fcn->bbs && cmp_reg, UT64_MAX);
+static ut64 try_get_cmpval_from_parents(RAnal *anal, RAnalFunction *fcn, RAnalBlock *my_bb, const char *cmp_reg) {
+	if (!cmp_reg) {
+		if (anal->verbose) {
+			eprintf ("try_get_cmpval_from_parents: cmp_reg not defined.\n");
+		}
+		return UT64_MAX;
+	}
+	r_return_val_if_fail (fcn && fcn->bbs, UT64_MAX);
 	RListIter *iter;
 	RAnalBlock *tmp_bb;
 	r_list_foreach (fcn->bbs, iter, tmp_bb) {

--- a/libr/anal/p/anal_avr.c
+++ b/libr/anal/p/anal_avr.c
@@ -1727,7 +1727,7 @@ static int avr_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, 
 	return size;
 }
 
-static bool avr_custom_des (RAnalEsil *esil) {
+static bool avr_custom_des(RAnalEsil *esil) {
 	ut64 key, encrypt, text,des_round;
 	ut32 key_lo, key_hi, buf_lo, buf_hi;
 	if (!esil || !esil->anal || !esil->anal->reg) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2006,7 +2006,6 @@ R_API bool r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dep
 			if (reftype == R_ANAL_REF_TYPE_CALL && fcn->type == R_ANAL_FCN_TYPE_LOC) {
 				function_rename (core->flags, fcn);
 			}
-
 			return 0;  // already analyzed function
 		}
 		if (r_anal_function_contains (fcn, from)) { // inner function
@@ -4985,6 +4984,9 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 			ctx->switch_path = r_list_new ();
 			ctx->bbl = r_list_clone (ctx->fcn->bbs);
 			ctx->cur_bb = r_anal_get_block_at (ctx->fcn->anal, ctx->fcn->addr);
+			if (!ctx->cur_bb) {
+				return false;
+			}
 			r_list_push (ctx->path, ctx->cur_bb);
 		}
 		RAnalBlock *bb = ctx->cur_bb;
@@ -5038,6 +5040,9 @@ static inline bool get_next_i(IterCtx *ctx, size_t *next_i) {
 				r_list_free (ctx->bbl);
 				return false;
 			}
+			if (!bbit->data) {
+				return false;
+			}
 			ctx->cur_bb = bbit->data;
 			r_list_push (ctx->path, ctx->cur_bb);
 			r_list_delete (ctx->bbl, bbit);
@@ -5066,6 +5071,10 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 	ut64 start = addr;
 	ut64 end = 0LL;
 	ut64 cur;
+	if (esil_anal_stop || r_cons_is_breaked ()) {
+		// faster ^C
+		return;
+	}
 
 	mycore = core;
 	if (!strcmp (str, "?")) {


### PR DESCRIPTION
* Early emulation interruption for faster ^C

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
