### PR TITLE
Fix #18852 wrong tables in graphviz dot ##print

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1561,19 +1561,20 @@ static int core_anal_graph_construct_edges(RCore *core, RAnalFunction *fcn, int 
 							"bb.0x%08"PFMT64x".switch", bbi->addr);
 							sdb_array_add_num (DB, key, caseop->value, 0);
 				} else if (is_html) {
-					r_cons_printf ("<div class=\"connector _0x%08"PFMT64x" _0x%08"PFMT64x"\">\n"
+					r_cons_printf ("<div class=\"connector _0x%08" PFMT64x " _0x%08" PFMT64x "\">\n"
 							"  <img class=\"connector-end\" src=\"img/arrow.gif\"/></div>\n",
-							caseop->addr, caseop->jump);
+							bbi->addr, caseop->addr);
 				} else if (!is_json && !is_keva) {
 					if (is_star) {
-						char *from = get_title (caseop->addr);
-						char *to = get_title (caseop->jump);
+						char *from = get_title (bbi->addr);
+						char *to = get_title (caseop->addr);
 						r_cons_printf ("age %s %s\n", from ,to);
-						free(from);
-						free(to);
+						free (from);
+						free (to);
 					} else {
-						r_cons_printf ("        \"0x%08"PFMT64x"\" -> \"0x%08"PFMT64x"\" " \
-						"[color2=\"%s\"];\n", caseop->addr, caseop->jump, pal_fail);
+						r_cons_printf ("        \"0x%08" PFMT64x "\" -> \"0x%08" PFMT64x "\" "
+								"[color=\"%s\"];\n",
+								bbi->addr, caseop->addr, pal_trfa);
 						core_anal_color_curr_node (core, bbi);
 					}
 				}

--- a/test/db/cmd/cmd_agf
+++ b/test/db/cmd/cmd_agf
@@ -25,3 +25,39 @@ EXPECT=<<EOF
 [{"name":"fcn.00000042","offset":66,"ninstr":8,"nargs":0,"nlocals":0,"size":17,"stack":0,"type":"fcn","blocks":[{"offset":66,"size":8,"jump":80,"fail":74,"ops":[{"offset":66,"text":"17: fcn.00000042 ();"},{"offset":66,"text":"     0000           add byte [rax], al"},{"offset":68,"text":"     4883f800       cmp rax, 0"},{"offset":72,"arrow":80,"text":"     7406           je 0x50"}]},{"offset":74,"size":6,"jump":80,"ops":[{"offset":74,"text":"     0000           add byte [rax], al"},{"offset":76,"text":"     0000           add byte [rax], al"},{"offset":78,"text":"     0000           add byte [rax], al"}]},{"offset":80,"size":3,"ops":[{"offset":80,"text":"     0000           add byte [rax], al"},{"offset":82,"text":"     c3             ret"}]}]}]
 EOF
 RUN
+
+NAME=agfdm correct jump tables
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+s 0x100
+wx 42000000000000004e000000000000005a00000000000000660000000000000072000000000000007e00000000000000
+s 0x10
+wx 554889e5897dfcc745f8000000008b45fc89c14889ca4883ea0548894df00f8756000000488b45f0488b0cc500010000ffe1c745f800000000e943000000c745f801000000e937000000c745f802000000e92b000000c745f803000000e91f000000c745f804000000e913000000c745f805000000e907000000c745f8ffffffff8b45f85dc3
+af
+agfdm
+EOF
+EXPECT=<<EOF
+digraph code {
+	graph [bgcolor=azure fontsize=8 fontname="Courier" splines="ortho"];
+	node [fillcolor=gray style=filled shape=box];
+	edge [arrowhead="normal"];
+        "0x00000010" -> "0x0000008a" [color="#13a10e"];
+        "0x00000010" -> "0x00000034" [color="#c50f1f"];
+        "0x0000008a" -> "0x00000091" [color="#3a96dd"];
+        "0x00000034" -> "0x00000042" [color="#3a96dd"];
+        "0x00000034" -> "0x0000004e" [color="#3a96dd"];
+        "0x00000034" -> "0x0000005a" [color="#3a96dd"];
+        "0x00000034" -> "0x00000066" [color="#3a96dd"];
+        "0x00000034" -> "0x00000072" [color="#3a96dd"];
+        "0x00000034" -> "0x0000007e" [color="#3a96dd"];
+        "0x00000042" -> "0x00000091" [color="#3a96dd"];
+        "0x0000004e" -> "0x00000091" [color="#3a96dd"];
+        "0x0000005a" -> "0x00000091" [color="#3a96dd"];
+        "0x00000066" -> "0x00000091" [color="#3a96dd"];
+        "0x00000072" -> "0x00000091" [color="#3a96dd"];
+        "0x0000007e" -> "0x00000091" [color="#3a96dd"];
+}
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #18852
- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Details on the bug can be found in Issue #18852.
Turns out that when processing a graph for export in several formats (including graphviz), when processing a jump table, an edge `caseop->addr` -> `caseop->jump` is added for each case of the jump table. However debugging the `caseop` struct shows that these fields contain the same value, hence the reason of the self-looping edge. 
Given that the GML implementation was only slightly different and did not present the bug, I replaced `caseop->addr` and `caseop->jump` with the values used in that implementation.

Additionally:
- replaced `color2` with `color`. color2 is not a valid graphviz keyword and is ignored (tested with dot 2.47.3).
- changed the color to be consistent with all the other representations.

Formatting looks a bit weird to me, but this is the output of clang-format.py
