### PR TITLE
Put archinfo.{minopsz,maxopsz,align} in the output of i ##bin

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5534,6 +5534,7 @@ R_API char *r_core_cmd_str(RCore *core, const char *cmd) {
 			r_cons_singleton ()->noflush = false;
 			r_cons_flush ();
 		}
+		r_cons_pop ();
 		return NULL;
 	}
 	if (--core->in_cmdstr == 0) {

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -252,6 +252,18 @@ static void r_core_file_info(RCore *core, PJ *pj, int mode) {
 				pj_ks (pj, "referer", desc->referer);
 			}
 		}
+		int v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
+		if (v > 0) {
+			pj_ki (pj, "minopsz", v);
+		}
+		v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
+		if (v > 0) {
+			pj_ki (pj, "maxopsz", v);
+		}
+		v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_ALIGN);
+		if (v > 0) {
+			pj_ki (pj, "pcalign", v);
+		}
 		pj_ki (pj, "block", core->blocksize);
 		if (binfile) {
 			if (binfile->curxtr) {
@@ -281,6 +293,18 @@ static void r_core_file_info(RCore *core, PJ *pj, int mode) {
 				r_num_units (humansz, sizeof (humansz), fsz);
 				pair ("humansz", humansz);
 			}
+		}
+		int v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
+		if (v > 0) {
+			pair ("minopsz", sdb_fmt ("%d", v));
+		}
+		v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
+		if (v > 0) {
+			pair ("maxopsz", sdb_fmt ("%d", v));
+		}
+		v = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_ALIGN);
+		if (v > 0) {
+			pair ("pcalign", sdb_fmt ("%d", v));
 		}
 		if (desc) {
 			pair ("mode", r_str_rwx_i (desc->perm & R_PERM_RWX));
@@ -467,7 +491,7 @@ static int cmd_info(void *data, const char *input) {
 		if (!strncmp (input, "zzz", 3)) {
 			is_izzzj = true;
 		}
-		if (!strncmp(input, "dpi", 3)) {
+		if (!strncmp (input, "dpi", 3)) {
 			is_idpij = true;
 		}
 	}

--- a/test/db/anal/s390
+++ b/test/db/anal/s390
@@ -8,6 +8,9 @@ fd       3
 file     bins/s390/zos/prueba/prueba
 size     0x11000
 humansz  68K
+minopsz  2
+maxopsz  6
+pcalign  2
 mode     r-x
 format   off
 iorw     false
@@ -27,14 +30,11 @@ laddr    0x0
 linenum  false
 lsyms    false
 machine  s360
-maxopsz  6
-minopsz  2
 nx       false
 os       Z/OS
-pcalign  2
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       false

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -213,6 +213,8 @@ fd       3
 file     malloc://1025
 size     0x401
 humansz  1.0K
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true
@@ -227,13 +229,10 @@ havecode false
 laddr    0x0
 linenum  false
 lsyms    false
-maxopsz  16
-minopsz  1
 nx       false
-pcalign  0
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       false
@@ -289,6 +288,8 @@ fd       3
 file     malloc://1024
 size     0x400
 humansz  1K
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true
@@ -307,13 +308,10 @@ havecode false
 laddr    0x0
 linenum  false
 lsyms    false
-maxopsz  16
-minopsz  1
 nx       false
-pcalign  0
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       false
@@ -331,6 +329,8 @@ EXPECT=<<EOF
 fd       3
 size     0x1323
 humansz  4.8K
+minopsz  1
+maxopsz  16
 mode     r-x
 format   elf
 iorw     false
@@ -352,16 +352,13 @@ lang     c
 linenum  true
 lsyms    true
 machine  Intel 80386
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    no
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -446,7 +443,7 @@ nx       false
 os       any
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   any
@@ -1238,9 +1235,6 @@ arch arm
 bits 16
 os linux
 endian little
-minopsz 2
-maxopsz 4
-pcalign 2
 EOF
 RUN
 
@@ -1252,9 +1246,6 @@ arch arm
 bits 16
 os linux
 endian little
-minopsz 2
-maxopsz 4
-pcalign 2
 __cxa_finalize
 __cxa_atexit
 malloc
@@ -1560,16 +1551,13 @@ lang     c
 linenum  true
 lsyms    true
 machine  Intel 80386
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    no
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -1602,17 +1590,14 @@ EXPECT=<<EOF
   "linenum": true,
   "lsyms": true,
   "machine": "Intel 80386",
-  "maxopsz": 16,
-  "minopsz": 1,
   "nx": true,
   "os": "linux",
   "cc": "",
-  "pcalign": 0,
   "pic": false,
   "relocs": true,
   "relro": "no",
   "rpath": "NONE",
-  "sanitiz": false,
+  "sanitize": false,
   "static": false,
   "stripped": false,
   "subsys": "linux",
@@ -3077,6 +3062,8 @@ EXPECT=<<EOF
 fd       3
 size     0x1a36
 humansz  6.6K
+minopsz  1
+maxopsz  16
 mode     r-x
 format   elf64
 iorw     false
@@ -3099,16 +3086,13 @@ lang     c
 linenum  true
 lsyms    true
 machine  AMD x86-64 architecture
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    no
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -3191,16 +3175,13 @@ lang     c
 linenum  true
 lsyms    true
 machine  AMD x86-64 architecture
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    no
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -3538,6 +3519,8 @@ EXPECT=<<EOF
 fd       3
 size     0x1a36
 humansz  6.6K
+minopsz  1
+maxopsz  16
 mode     r-x
 iorw     false
 block    0x100

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -446,6 +446,8 @@ fd       3
 file     bins/elf/true32
 size     0x560c
 humansz  21.5K
+minopsz  1
+maxopsz  16
 mode     r-x
 format   elf
 iorw     false
@@ -467,16 +469,13 @@ lang     c
 linenum  false
 lsyms    false
 machine  Intel 80386
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   false
 relro    partial
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped true
 subsys   linux
@@ -486,6 +485,8 @@ fd       3
 file     malloc://512
 size     0x200
 humansz  512
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -74,6 +74,8 @@ EXPECT=<<EOF
 fd       3
 file     malloc://1024
 humansz  1K
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true
@@ -88,6 +90,8 @@ EXPECT=<<EOF
 fd       3
 file     malloc://1024
 humansz  1K
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true
@@ -102,6 +106,8 @@ EXPECT=<<EOF
 file     malloc://1024
 size     0x400
 humansz  1K
+minopsz  1
+maxopsz  16
 mode     rwx
 format   any
 iorw     true

--- a/test/db/formats/dmp/dmp
+++ b/test/db/formats/dmp/dmp
@@ -24,14 +24,11 @@ laddr    0x0
 linenum  false
 lsyms    false
 machine  AMD64
-maxopsz  16
-minopsz  1
 nx       false
 os       Unknown
-pcalign  0
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       true

--- a/test/db/formats/elf/elf-riscv64
+++ b/test/db/formats/elf/elf-riscv64
@@ -429,7 +429,7 @@ os       linux
 pic      false
 relocs   true
 rpath    NONE
-sanitiz  false
+sanitize false
 static   true
 stripped false
 subsys   linux

--- a/test/db/formats/elf/v850
+++ b/test/db/formats/elf/v850
@@ -10,6 +10,9 @@ fd       3
 file     bins/v850/ired_v850
 size     0xedeb8
 humansz  951.7K
+minopsz  2
+maxopsz  8
+pcalign  2
 mode     r-x
 format   elf
 iorw     false
@@ -31,15 +34,12 @@ lang     c
 linenum  true
 lsyms    true
 machine  NEC V800 series
-maxopsz  8
-minopsz  2
 nx       false
 os       linux
-pcalign  2
 pic      false
 relocs   true
 rpath    NONE
-sanitiz  false
+sanitize false
 static   true
 stripped false
 subsys   linux

--- a/test/db/formats/mdmp
+++ b/test/db/formats/mdmp
@@ -26,15 +26,12 @@ laddr    0x0
 linenum  false
 lsyms    false
 machine  AMD64
-maxopsz  16
-minopsz  1
 nx       false
 os       Windows NT Workstation 6.1.7601
-pcalign  0
 pic      false
 relocs   false
 rpath    NONE
-sanitiz  false
+sanitize false
 static   true
 streams  13
 stripped false

--- a/test/db/formats/prg
+++ b/test/db/formats/prg
@@ -23,7 +23,7 @@ nx       false
 os       c64
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       true

--- a/test/db/formats/smd
+++ b/test/db/formats/smd
@@ -28,7 +28,7 @@ nx       false
 os       smd
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 va       true

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -15,6 +15,9 @@ fd       3
 file     bins/wasm/dotnet.wasm
 size     0x2ae89a
 humansz  2.7M
+minopsz  1
+maxopsz  1
+pcalign  1
 mode     r-x
 format   wasm
 iorw     false
@@ -35,14 +38,11 @@ laddr    0x0
 linenum  false
 lsyms    false
 machine  wasm
-maxopsz  1
-minopsz  1
 nx       false
 os       WebAssembly
-pcalign  1
 pic      false
 relocs   false
-sanitiz  false
+sanitize false
 static   true
 stripped false
 subsys   wasm

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -632,16 +632,13 @@ lang     c
 linenum  true
 lsyms    true
 machine  Intel 80386
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    no
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -740,16 +737,13 @@ lang     c++
 linenum  true
 lsyms    true
 machine  AMD x86-64 architecture
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      true
 relocs   true
 relro    full
 rpath    NONE
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   linux
@@ -778,16 +772,13 @@ lang     c++
 linenum  true
 lsyms    true
 machine  AMD x86-64 architecture
-maxopsz  16
-minopsz  1
 nx       true
 os       linux
-pcalign  0
 pic      false
 relocs   true
 relro    partial
 rpath    NONE
-sanitiz  true
+sanitize true
 static   false
 stripped false
 subsys   linux
@@ -815,14 +806,11 @@ lang     c++ with blocks
 linenum  false
 lsyms    false
 machine  x86 64 all
-maxopsz  16
-minopsz  1
 nx       false
 os       darwin
-pcalign  0
 pic      true
 relocs   false
-sanitiz  false
+sanitize false
 static   false
 stripped false
 subsys   darwin


### PR DESCRIPTION
* Does not requires rbin to work, its tied to RAnal which is global

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
