### PR TITLE
Fix `system()` on arm64 macOS targets 

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -88,7 +88,7 @@
 #define TARGET_OS_IPHONE 0
 #endif
 
-#if __IPHONE_8_0 && TARGET_OS_IPHONE
+#if __IPHONE_8_0 && TARGET_OS_IPHONE && !defined(MAC_OS_VERSION_11_0)
 #define LIBC_HAVE_SYSTEM 0
 #define HAVE_SYSTEM 0
 #elif __wasi__


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

r2 assumes that arm64 Darwin targets don't have `system()`, which applies only to iOS/tvOS/watchOS, so this adds a check to exclude macOS targets.