### PR TITLE
Fix r_str_ansi_len() causing unaligned 'unaligned' words ##disasm

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1932,7 +1932,7 @@ R_API size_t r_str_ansi_nlen(const char *str, size_t slen) {
 		}
 		i += chlen;
 	}
-	return len > 0 ? len: 1;
+	return len; // len > 0 ? len: 1;
 }
 
 R_API size_t r_str_ansi_len(const char *str) {

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -127,7 +127,7 @@ mov r0, r0
             0x00000000      0000           movs r0, r0
             0x00000000      0000a0e1       mov r0, r0
             0x00000000      0000           movs r0, r0
-            0x00000002                    unaligned
+            0x00000002                     unaligned
         ,=< 0x00000002      a0e1           b 0x346
 EOF
 RUN

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -243,6 +243,9 @@ bool test_r_str_rchr(void) {
 bool test_r_str_ansi_len(void) {
 	int len;
 
+	len = r_str_ansi_len ("\x1b[0m");
+	mu_assert_eq (len, 0, "len(ansi only)");
+
 	len = r_str_ansi_len ("radare2");
 	mu_assert_eq (len, 7, "len(ascii only)");
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
