### PR TITLE
Implement 'afs*' command to export function signature info in r2 commands ##anal

### DIFF
--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -578,6 +578,39 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=afsafv
+FILE=bins/mach0/ls-osx-x86_64
+CMDS=<<EOF
+aa
+s main
+afs
+afs*
+?e original
+afv~arg
+?e deleted
+afv-*
+afv~arg
+?e recovered from signature
+.afs*
+afv~arg
+EOF
+EXPECT=<<EOF
+int main (int argc, char **argv);
+tn main
+afc amd64
+afvr rdi argc int
+afvr rsi argv char **
+
+original
+arg char ** argv @ rsi
+arg int argc @ rdi
+deleted
+recovered from signature
+arg char ** argv @ rsi
+arg int argc @ rdi
+EOF
+RUN
+
 NAME=tp with varname
 FILE=bins/elf/struct_sample
 CMDS=<<EOF


### PR DESCRIPTION

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
