### PR TITLE
dbg.verbose is now set to false by default

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3598,7 +3598,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("dbg.hwbp", "false", "Use hardware breakpoints instead of software ones when enabled");
 	SETCB ("dbg.", "true", &cb_dbg_verbose, "Verbose debug output");
 	SETCB ("dbg.unlibs", "", &cb_dbg_unlibs, "If set stop when unloading matching libname");
-	SETCB ("dbg.verbose", "true", &cb_dbg_verbose, "Verbose debug output");
+	SETCB ("dbg.verbose", "false", &cb_dbg_verbose, "Verbose debug output");
 	SETBPREF ("dbg.slow", "false", "Show stack and regs in visual mode in a slow but verbose mode");
 	SETBPREF ("dbg.funcarg", "false", "Display arguments to function call in visual mode");
 

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -1206,7 +1206,10 @@ int linux_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 			// ignore ENODEV, it just means this CPU or kernel doesn't support XSTATE
 			ret = 0;
 		} else if (ret != 0) {
-			r_sys_perror ("PTRACE_GETREGSET");
+			if (dbg->verbose) {
+				// WSL1 doesnt support retrieving YMM registers, so this call just fails, no need to be noisy
+				r_sys_perror ("PTRACE_GETREGSET");
+			}
 			return false;
 		}
 		// stitch together xstate.fpstate._xmm and xstate.ymmh assuming LE


### PR DESCRIPTION
* Hide GETREG error shown on WSL1

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
