### PR TITLE
Drop spaces in pseudo strings

### DIFF
--- a/libr/parse/parse.c
+++ b/libr/parse/parse.c
@@ -11,7 +11,6 @@ static RParsePlugin *parse_static_plugins[] =
 	{ R_PARSE_STATIC_PLUGINS };
 
 R_API RParse *r_parse_new(void) {
-	int i;
 	RParse *p = R_NEW0 (RParse);
 	if (!p) {
 		return NULL;
@@ -28,6 +27,7 @@ R_API RParse *r_parse_new(void) {
 	p->subtail = false;
 	p->minval = 0x100;
 	p->localvar_only = false;
+	size_t i;
 	for (i = 0; parse_static_plugins[i]; i++) {
 		r_parse_add (p, parse_static_plugins[i]);
 	}

--- a/test/db/anal/s390
+++ b/test/db/anal/s390
@@ -134,7 +134,7 @@ EXPECT=<<EOF
   {
     "opcode": "la %r4, 8(%r15)",
     "disasm": "la %r4, 8(%r15)",
-    "pseudo": "la %r4,8(%r15) ",
+    "pseudo": "la %r4, 8 (%r15) ",
     "description": "Load Address",
     "mnemonic": "la",
     "mask": "ffffffff",

--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -50,7 +50,7 @@ EXPECT=<<EOF
   {
     "opcode": "pushf",
     "disasm": "pushf",
-    "pseudo": "pushf ",
+    "pseudo": "push ()",
     "description": "push flags register onto the stack",
     "mnemonic": "pushf",
     "mask": "ff",

--- a/test/db/anal/x86_32
+++ b/test/db/anal/x86_32
@@ -3124,7 +3124,7 @@ EXPECT=<<EOF
   {
     "opcode": "pushf",
     "disasm": "pushf",
-    "pseudo": "pushf ",
+    "pseudo": "push ()",
     "description": "push flags register onto the stack",
     "mnemonic": "pushf",
     "mask": "ffff",
@@ -3375,11 +3375,12 @@ ao 1
 p8 1
 EOF
 EXPECT=<<EOF
-17
+18
 address: 0x0
 opcode: nop
 esilcost: 0
 disasm: nop
+pseudo: no 
 mnemonic: nop
 description: no operation
 mask: ff

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -2461,7 +2461,7 @@ EXPECT=<<EOF
   {
     "opcode": "pushf",
     "disasm": "pushf",
-    "pseudo": "pushf ",
+    "pseudo": "push ()",
     "description": "push flags register onto the stack",
     "mnemonic": "pushf",
     "mask": "ffff",
@@ -2631,7 +2631,7 @@ aae
 pd 1 @ 0x08048432
 EOF
 EXPECT=<<EOF
-[36m|[0m           [32m0x08048432[0m      [37mlea[36m eax[0m,[36m [0m[33mstr.Hello_PIC_[0m[36m[0m[0m
+[36m|[0m           [32m0x08048432[0m      [37mlea[36m eax[0m,[36m[36m str.Hello_PIC_[0m[0m
 EOF
 RUN
 
@@ -3235,7 +3235,7 @@ address: 0x0
 opcode: push rbp
 esilcost: 24
 disasm: push rbp
-pseudo: push( rbp )
+pseudo: push (rbp)
 mnemonic: push
 description: push word, doubleword or quadword onto the stack
 mask: ff
@@ -3993,7 +3993,7 @@ EXPECT=<<EOF
 |           ; arg int64_t arg_bh @ rbp+0xb
 |           ; var int64_t var_4h @ rsp+0x4
 |           ; arg int64_t arg_ch @ rsp+0xc
-|           0x00000000      54             push( rsp )
+|           0x00000000      54             push  (rsp)
 |           0x00000001      4889e5         rbp = rsp
 |           0x00000004      b402           ah = 2
 |           0x00000006      66b83333       ax = 0x3333

--- a/test/db/cmd/cmd_ahi
+++ b/test/db/cmd/cmd_ahi
@@ -333,7 +333,7 @@ pd 1
 EOF
 EXPECT=<<EOF
             0x00000000      mov dword [esp + 0x68], 'm0[\x1b'
-            [32m[7m0x00000000[0m      [37mmov dword [0m[[36mesp [0m+[36m[36m [33m0x68[0m][36m[0m,[36m[36m [33m'm0[\x1b'[0m[0m
+            [32m[7m0x00000000[0m      [37mmov dword [0m[[36mesp [0m+[36m[36m [33m0x68[0m][36m[0m,[36m[36m 'm0[0m[[36m\x1b'[0m[0m
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -204,7 +204,7 @@ f-rip
 pd 1
 EOF
 EXPECT=<<EOF
-fcn.00000106 ()
+fcn.00000106  ()
 EOF
 RUN
 
@@ -808,7 +808,7 @@ e asm.sub.names=false
 pd 1 @ 0x0001145f
 EOF
 EXPECT=<<EOF
-            [32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [0m[36mstr.A_NULL_argv_0__was_passed_through_an_exec_system_call._n[0m[36m[0m[0m
+            [32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m str.A_NULL_argv_0__was_passed_through_an_exec_system_call._n[0m[0m
             [32m0x0001145f[0m      [37mlea[36m rdi[0m,[36m[36m [0m[[36m[36m0x0001b5d8[0m][36m[0m[0m
 EOF
 RUN
@@ -1366,7 +1366,7 @@ e asm.cmt.right=1
 pdJ 1 @ 0x080483ec
 EOF
 EXPECT=<<EOF
-[{"offset":134514169,"arrow":134514133,"text":"|       `=< 0x080485f9      72da           if (((unsigned) var) < 0) goto 0x80485d5"}]
+[{"offset":134514169,"arrow":134514133,"text":"|       `=< 0x080485f9      72da           if   (((unsigned) var) < 0) goto 0x80485d5"}]
 [{"offset":134513644,"text":"            ; sym.imp.__libc_start_main"},{"offset":134513644,"text":"            ; int __libc_start_main(func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end)"},{"offset":134513644,"text":"            0x080483ec      e873ffffff     134513508,eip,4,esp,-=,esp,=[],eip,="}]
 [{"offset":134513644,"text":"            0x080483ec      e873ffffff     134513508,eip,4,esp,-=,esp,=[],eip,= ; sym.imp.__libc_start_main ; int __libc_start_main(func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end)"}]
 EOF
@@ -1733,17 +1733,17 @@ e emu.str.inv=false
 pd 1 @ 0x161d
 EOF
 EXPECT=<<EOF
-            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m[31m                 [31m; 0x21f7[31m [31m; "abcdefghi"[0m[31m ; [7m"\n  Blue Pill"[27m str._n__Blue_Pill[0m
-            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m[31m                 [31m; 0x21f7[31m [31m; [7m"abcdefghi"[27m[0m[31m ; "\n  Blue Pill" str._n__Blue_Pill[0m
+            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m abcdefghi[0m][36m[0m[0m[31m                 [31m; 0x21f7[31m [31m; "abcdefghi"[0m[31m ; [7m"\n  Blue Pill"[27m str._n__Blue_Pill[0m
+            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m abcdefghi[0m][36m[0m[0m[31m                 [31m; 0x21f7[31m [31m; [7m"abcdefghi"[27m[0m[31m ; "\n  Blue Pill" str._n__Blue_Pill[0m
 
             [31m; 0x21f7
             [31m; "abcdefghi"
 [0m[31m[0m               [31m; [7m"\n  Blue Pill"[27m str._n__Blue_Pill
-[0m            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m
+[0m            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m abcdefghi[0m][36m[0m[0m
             [31m; 0x21f7
             [31m; [7m"abcdefghi"[27m
 [0m[31m[0m               [31m; "\n  Blue Pill" str._n__Blue_Pill
-[0m            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m [36mabcdefghi][36m[0m[0m
+[0m            [32m0x0000161d[0m      [37mlea[36m eax[0m,[36m [0m[[36mesi [0m-[36m[36m abcdefghi[0m][36m[0m[0m
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -681,7 +681,7 @@ EXPECT=<<EOF
        [36m|[0m[36m|[0m   [32m0x00004214[0m      [1;92mcall 0x13c50[0m[0m
        [36m|[0m[36m`[0m[36m-[0m[36m>[0m [32m0x0000421a[0m      [37mmov qword[36m [0m[[36m[33m0x000232b0[0m][36m[0m,[36m[36m [33m0x50[0m[0m[31m               [31m; 'P'
        [36m|[0m    [31m                                                           [31m; [0x232b0:8]=0[0m
-       [36m|[0m    [32m0x00004225[0m      [37mlea[36m rdi[0m,[36m[36m [0m[36mstr.COLUMNS[0m[36m[0m[0m[31m                       [31m; 0x18a22[31m [31m; "COLUMNS"[0m
+       [36m|[0m    [32m0x00004225[0m      [37mlea[36m rdi[0m,[36m[36m str.COLUMNS[0m[0m[31m                       [31m; 0x18a22[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [37mlea[36m rsi[0m,[36m [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m                   [31m; 0x21a40[0m
             [32m0x00004225[0m      [37mlea[36m rdi[0m,[36m [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m                   [31m; str.COLUMNS
@@ -723,7 +723,7 @@ EXPECT=<<EOF
        [36m|[0m[36m|[0m   [32m0x00004214[0m      [1;92mcall 0x13c50[0m[0m
        [36m|[0m[36m`[0m[36m-[0m[36m>[0m [32m0x0000421a[0m      [37mmov qword[36m [0m[[36m[33m0x000232b0[0m][36m[0m,[36m[36m [33m0x50[0m[0m[31m               [31m; 'P'
        [36m|[0m    [31m                                                           [31m; [0x232b0:8]=0[0m
-       [36m|[0m    [32m0x00004225[0m      [37mmov[36m rax[0m,[36m qword[36m [0m[[36m[36mstr.COLUMNS[0m][36m[0m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
+       [36m|[0m    [32m0x00004225[0m      [37mmov[36m rax[0m,[36m qword[36m [0m[[36mstr.COLUMNS[0m][36m[0m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [37mmov[36m rax[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m             [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [37mmov[36m rax[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m             [31m; str.COLUMNS
@@ -765,7 +765,7 @@ EXPECT=<<EOF
        [36m|[0m[36m|[0m   [32m0x00004214[0m      [1;92mcall 0x13c50[0m[0m
        [36m|[0m[36m`[0m[36m-[0m[36m>[0m [32m0x0000421a[0m      [37mmov qword[36m [0m[[36m[33m0x000232b0[0m][36m[0m,[36m[36m [33m0x50[0m[0m[31m               [31m; 'P'
        [36m|[0m    [31m                                                           [31m; [0x232b0:8]=0[0m
-       [36m|[0m    [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword[36m [0m[[36m[36mstr.COLUMNS[0m][36m[0m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
+       [36m|[0m    [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword[36m [0m[[36mstr.COLUMNS[0m][36m[0m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [36mcmp[36m rsi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x1d84b[0m][36m[0m[0m[31m             [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [36mcmp[36m rdi[0m,[36m qword [0m[[36mrip [0m+[36m[36m [33m0x147f6[0m][36m[0m[0m[31m             [31m; str.COLUMNS
@@ -784,7 +784,7 @@ pd 1
 EOF
 EXPECT=<<EOF
             0x00005e6e      488d3d339b01.  lea rdi, section..fini_array ; 0x1f9a8
-            [32m0x00005e6e[0m      [33m48[37m8d[33m3d[33m33[37m9b[37m01[37m.[0m  [37mlea[36m rdi[0m,[36m[36m [0m[36msection..fini_array[0m[36m[0m[0m[31m [31m; 0x1f9a8[0m
+            [32m0x00005e6e[0m      [33m48[37m8d[33m3d[33m33[37m9b[37m01[37m.[0m  [37mlea[36m rdi[0m,[36m[36m section..fini_array[0m[0m[31m [31m; 0x1f9a8[0m
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -11,6 +11,51 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=pd pseudo @ t1
+FILE=bins/pe/t1.exe
+ARGS=-e bin.str.real=true
+CMDS=<<EOF
+e asm.flags.real=true
+af
+e asm.pseudo=true
+pdf
+EOF
+EXPECT=<<EOF
+/ 109: entry0 ();
+|           0x0040200f      66be0300       si = 3
+|           0x00402013      e8e8ffffff     fcn.00402000  ()
+|       .-> 0x00402018      6a00           push  (0)
+|       :   0x0040201a      680e104000     push  ("LABEL")             ; 0x40100e
+|       :   0x0040201f      6800104000     push  ("Hello, World!")     ; section..data
+|       :                                                              ; 0x401000
+|       :   0x00402024      6a00           push  (0)
+|       :   0x00402026      ff15b8304000   dword [MessageBoxA]  ()     ; 0x4030b8 ; int MessageBoxA(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType)
+|       :   0x0040202c      680e104000     push  ("LABEL")             ; 0x40100e
+|       :   0x00402031      ff15dc304000   dword [puts]  ()            ; 0x4030dc ; int puts(const char *s)
+|       :   0x00402037      83c404         esp += 4
+|       :   0x0040203a      664e           si-
+|       :   0x0040203c      6683fe00       var = si - 0
+|       `=< 0x00402040      7fd6           if  (var > 0) goto loc_0x402018
+|           0x00402042      a1dc304000     eax = dword [puts]          ; [0x4030dc:4]=0x30e8 reloc.crtdll.dll_puts
+|           0x00402047      6800104000     push  ("Hello, World!")     ; section..data
+|                                                                      ; 0x401000
+|           0x0040204c      ffd0           eax  ()
+|           0x0040204e      ff1588304000   dword [GetProcessHeap]  ()  ; 0x403088 ; HANDLE GetProcessHeap(void)
+|           0x00402054      50             push  (eax)
+|           0x00402055      6814104000     push  (">%p\\n")            ; 0x401014
+|           0x0040205a      ff15e0304000   dword [printf]  ()          ; 0x4030e0 ; int printf(const char *format)
+|           0x00402060      6a00           push  (0)
+|           0x00402062      6800104000     push  ("Hello, World!")     ; section..data
+|                                                                      ; 0x401000
+|           0x00402067      6800104000     push  ("Hello, World!")     ; section..data
+|                                                                      ; 0x401000
+|           0x0040206c      6a00           push  (0)
+|           0x0040206e      ff15b8304000   dword [MessageBoxA]  ()     ; 0x4030b8 ; int MessageBoxA(HWND hWnd, LPCSTR lpText, LPCSTR lpCaption, UINT uType)
+|           0x00402074      6a00           push  (0)
+\           0x00402076      ff1584304000   dword [ExitProcess]  ()     ; 0x403084 ; VOID ExitProcess(UINT uExitCode)
+EOF
+RUN
+
 NAME=pdc @ t1
 FILE=bins/pe/t1.exe
 ARGS=-e bin.str.real=true
@@ -58,49 +103,50 @@ EXPECT=<<EOF
 function entry0 () {
     loc_0x40200f:
     si = 3
-    fcn.00402000 ()
+    fcn.00402000  ()
     do {
         loc_0x402018:
-        push( 0 )
-        push( "LABEL" ) //0x40100e ; (pstr 0x0040100e) "LABEL"
-        push( "Hello, World!" ) //section..data
+        push  (0)
+        push  ("LABEL") //0x40100e ; (pstr 0x0040100e) "LABEL"
+        push  ("Hello, World!") //section..data
         //0x401000 ; (pstr 0x00401000) "Hello, World!"
-        push( 0 )
-        dword [MessageBoxA] () //0x4030b8 ; reloc.user32.dll_MessageBoxA
+        push  (0)
+        dword [MessageBoxA]  () //0x4030b8 ; reloc.user32.dll_MessageBoxA
         //int MessageBoxA(NULL, 0x6c6c6548, 0x4542414c, NULL)
-        push( "LABEL" ) //0x40100e ; (pstr 0x0040100e) "LABEL"
-        dword [puts] () //0x4030dc ; reloc.crtdll.dll_puts
+        push  ("LABEL") //0x40100e ; (pstr 0x0040100e) "LABEL"
+        dword [puts]  () //0x4030dc ; reloc.crtdll.dll_puts
         //int puts("LABEL")
         esp += 4
-        si--
+        si-
         var = si - 0
-        if (var > 0) goto loc_0x402018 //unlikely
+        if  (var > 0) goto loc_0x402018 //unlikely
         } while (?);
 return;
 loc_0x402042:
 eax = dword [puts] //[0x4030dc:4]=0x30e8 reloc.crtdll.dll_puts ; reloc.crtdll.dll_puts
-push( "Hello, World!" ) //section..data
+push  ("Hello, World!") //section..data
 //0x401000 ; (pstr 0x00401000) "Hello, World!"
-eax ()        //(pstr 0x0040100e) "LABEL" ; reloc.crtdll.dll_puts
+eax  ()       //(pstr 0x0040100e) "LABEL" ; reloc.crtdll.dll_puts
 //int puts("Hello, World!")
-dword [GetProcessHeap] () //0x403088 ; reloc.kernel32.dll_GetProcessHeap
+dword [GetProcessHeap]  () //0x403088 ; reloc.kernel32.dll_GetProcessHeap
 //HANDLE GetProcessHeap(void)
-push( eax )
-push( ">%p\\n" ) //0x401014 ; (pstr 0x00401014) ">%p\n"
-dword [printf] () //0x4030e0 ; (pstr 0x0040100e) "LABEL" ; reloc.crtdll.dll_printf
+push  (eax)
+push  (">%p\\n") //0x401014 ; (pstr 0x00401014) ">%p\n"
+dword [printf]  () //0x4030e0 ; (pstr 0x0040100e) "LABEL" ; reloc.crtdll.dll_printf
 //int printf(">%p\n")
-push( 0 )
-push( "Hello, World!" ) //section..data
+push  (0)
+push  ("Hello, World!") //section..data
 //0x401000 ; (pstr 0x00401000) "Hello, World!"
-push( "Hello, World!" ) //section..data
+push  ("Hello, World!") //section..data
 //0x401000 ; (pstr 0x00401000) "Hello, World!"
-push( 0 )
-dword [MessageBoxA] () //0x4030b8 ; reloc.user32.dll_MessageBoxA
+push  (0)
+dword [MessageBoxA]  () //0x4030b8 ; reloc.user32.dll_MessageBoxA
 //int MessageBoxA(NULL, 0x6c6c6548, 0x6c6c6548, NULL)
-push( 0 )
-dword [ExitProcess] () //0x403084 ; reloc.kernel32.dll_ExitProcess
+push  (0)
+dword [ExitProcess]  () //0x403084 ; reloc.kernel32.dll_ExitProcess
 //VOID ExitProcess(NULL)
 (break)
 }
 EOF
 RUN
+

--- a/test/db/cmd/print
+++ b/test/db/cmd/print
@@ -100,7 +100,7 @@ pd 20~7f
 EOF
 EXPECT=<<EOF
         ,=< 0x100001083      7f05           jg 0x10000108a
-        `-> 0x10000108a      488d357f3a00.  lea rsi, [section.4.__TEXT.__cstring] ; 0x100004b10
+        `-> 0x10000108a      488d357f3a00.  lea rsi, [0x100004b10]     ; section.4.__TEXT.__cstring
         ,=< 0x100001083      7f05           jg jeje.lolo
         `-> 0x10000108a      488d357f3a00.  lea rsi, section.4.__TEXT.__cstring ; 0x100004b10
 EOF


### PR DESCRIPTION
This change exposes a bug in the regrssions suite, the varsub doesnt seems to work well without spaces. ( and ) chars should be used as delimiters as comma or space do.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
