### PR TITLE
fix afj command and afj command extension

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -352,7 +352,7 @@ static const char *help_msg_af[] = {
 	"afd", "[addr]","show function + delta for given offset",
 	"afF", "[1|0|]", "fold/unfold/toggle",
 	"afi", " [addr|fcn.name]", "show function(s) information (verbose afl)",
-	"afj", " [tableaddr] [count]", "analyze function jumptable",
+	"afj", " [tableaddr] [elem_sz] [count] [seg]", "analyze function jumptable (adding seg to each elem)",
 	"afl", "[?] [ls*] [fcn name]", "list functions (addr, size, bbs, name) (see afll)",
 	"afm", " name", "merge two functions",
 	"afM", " name", "print functions map",
@@ -3673,9 +3673,13 @@ static int cmd_anal_fcn(RCore *core, const char *input) {
 			if (block && !r_list_empty (block->fcns)) {
 				char *args = strdup (input + 2);
 				RList *argv = r_str_split_list (args, " ", 0);
-				ut64 table = r_num_math (core->num, r_list_get_n (argv, 0));
-				ut64 elements = r_num_math (core->num, r_list_get_n (argv, 1));
-				r_anal_jmptbl (core->anal, r_list_first (block->fcns), block, core->offset, table, elements, UT64_MAX);
+				ut64 table = r_num_math (core->num, r_list_get_n (argv, 1));
+				ut64 sz = r_num_math (core->num, r_list_get_n (argv, 2));
+				ut64 elements = r_num_math (core->num, r_list_get_n (argv, 3));
+				ut64 seg = r_num_math (core->num, r_list_get_n (argv, 4));
+				int depth = 50;
+				try_walkthrough_jmptbl (core->anal, r_list_first (block->fcns), block, depth, core->offset, 0, table, seg, sz, elements, 0, false);
+				free (args);
 			} else {
 				eprintf ("No function defined here\n");
 			}


### PR DESCRIPTION
fix invalid argv read for table param and others,
fix memory leak by missing free for strdup,
fix invalid elem size and elem count for jmtbl which previously was set to same value, now it can be set properly
extend afj command by adding 2 new parameters elem_sz and seg for precise jmp tbl reading.

According to our IRC conversation about afj naming it is not changed yet. Great subject for discussion about analyzing function jumptable command name.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
