### PR TITLE
fix mul and imul for *dx operands and 64 bit widths ##esil

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1712,10 +1712,12 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 						if ( width == 1 ) {
 							esilprintf(op, "0xffffff00,eflags,&=,%s,%s,%%,eflags,|=,%s,%s,*,%s,=,0xff,eflags,&,%s,=,0xffffff00,eflags,&=,2,eflags,|=",
 								arg0, r_nume, arg0, r_nume, r_quot, r_rema);
+						} else if ( width == 8 ) { // TODO still needs to be fixed to handle correct signed 128 bit value 
+							esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
+									arg0, r_nume, r_nume, r_rema);
 						} else {
-							// this got a little bit crazy, 
-							esilprintf (op, "%d,%d,%s,~,%d,%s,~,*,>>,%s,=,%s,%s,*=,%d,%d,%s,~,>>,%s,-,?{,1,1,}{,0,0,},cf,:=,of,:=",
-									width*8, width*8, arg0, width*8, r_nume, r_rema, arg0, r_nume, width*8, width*8, r_nume, r_rema);
+							esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,%s,=,%d,SWAP,>>,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
+									width*8, arg0, width*8, r_nume, r_nume, width*8, r_rema);
 						}
 					}
 					else {
@@ -1737,9 +1739,12 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 				if ( width == 1 ) {
 					esilprintf(op, "0xffffff00,eflags,&=,%s,%s,%%,eflags,|=,%s,%s,*,%s,=,0xff,eflags,&,%s,=,0xffffff00,eflags,&=,2,eflags,|=",
 						src, r_nume, src, r_nume, r_quot, r_rema);
+				} else if ( width == 8 ) {
+					esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
+							src, r_nume, r_nume, r_rema);
 				} else {
-					esilprintf (op, "%d,%s,%s,*,>>,%s,=,%s,%s,*=,%s,?{,1,1,}{,0,0,},cf,:=,of,:=",
-							width*8, src, r_nume, r_rema, src, r_nume, r_rema);
+					esilprintf (op, "%s,%s,*,DUP,%s,=,%d,SWAP,>>,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
+							src, r_nume, r_nume, width*8, r_rema);
 				}
 			} else {
 				/* should never happen */

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1703,8 +1703,8 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 				if (arg2) {
 					multiplier = arg2;
 				}
-				esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,%s,=,%s,-,!,!,DUP,cf,:=,of,:=", 
-					width*8, multiplier, width*8, arg1, arg0, arg0);
+				esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,%s,=,%d,%s,~,-,!,!,DUP,cf,:=,of,:=", 
+					width*8, multiplier, width*8, arg1, arg0, width*8, arg0);
 			} else {
 				if (arg0) {
 					const char *r_quot = (width==1)?"al": (width==2)?"ax": (width==4)?"eax":"rax";
@@ -1712,11 +1712,11 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 					const char *r_nume = (width==1)?"ax": r_quot;
 
 					if ( width == 8 ) { // TODO still needs to be fixed to handle correct signed 128 bit value 
-						esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
+						esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=", // flags will be sometimes wrong
 								arg0, r_nume, r_nume, r_rema);
 					} else {
-						esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,%s,=,%d,SWAP,>>,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
-								width*8, arg0, width*8, r_nume, r_nume, width*8, r_rema); 
+						esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,DUP,%s,=,%d,SWAP,>>,%s,=,%d,%s,~,-,!,!,DUP,cf,:=,of,:=",
+								width*8, arg0, width*8, r_nume, r_nume, width*8, r_rema, width*8, r_nume); 
 					}
 				}
 			}

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1711,7 +1711,7 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 					const char *r_rema = (width==1)?"ah": (width==2)?"dx": (width==4)?"edx":"rdx";
 					const char *r_nume = (width==1)?"ax": r_quot;
 
-					if ( width == 8 ) { // TODO still needs to be fixed to handle correct signed 128 bit value 
+					if (width == 8) { // TODO still needs to be fixed to handle correct signed 128 bit value 
 						esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=", // flags will be sometimes wrong
 								arg0, r_nume, r_nume, r_rema);
 					} else {

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -43,6 +43,72 @@ imul r9
 EOF
 RUN
 
+NAME=imul 1 arg pos result
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wa imul edx
+aei; ar eax=4; ar edx=8; aes; ar eax,of,cf
+EOF
+EXPECT=<<EOF
+0x00000020
+0x00000000
+0x00000000
+EOF
+RUN
+
+NAME=imul 1 arg neg result
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wa imul edx
+aei; ar eax=-4; ar edx=8; aes; ar edx,eax,of,cf
+EOF
+EXPECT=<<EOF
+0xffffffff
+0xffffffe0
+0x00000000
+0x00000000
+EOF
+RUN
+
+NAME=imul 1 arg overflow result
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wa imul edx
+aei; ar eax=0xfffff; ar edx=0xfffffc; aes; ar edx,eax,of,cf
+EOF
+EXPECT=<<EOF
+0x00000fff
+0xfec00004
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=mul 64 bit
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wa mul rdx
+aei; 
+ar rax=0xdfdfdfdfdfdfdfdf; 
+ar rdx=0x0cfcfcfcfcfcfcfc; 
+aes; ar rdx,rax,of,cf
+EOF
+EXPECT=<<EOF
+0xb5bbc1c7cdd3d9d
+0x15c56504a443e384
+0x00000001
+0x00000001
+EOF
+RUN
+
 NAME=imul 2 arg
 FILE=-
 CMDS=<<EOF

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -39,7 +39,7 @@ e asm.bits=64
 EOF
 EXPECT=<<EOF
 imul r9
-0x00000000 64,64,r9,~,64,rax,~,*,>>,rdx,=,r9,rax,*=,64,64,rax,~,>>,rdx,-,?{,1,1,}{,0,0,},cf,:=,of,:=
+0x00000000 r9,rax,L*,rax,=,DUP,rdx,=,!,!,DUP,cf,:=,of,:=
 EOF
 RUN
 
@@ -53,7 +53,7 @@ e asm.bits=64
 EOF
 EXPECT=<<EOF
 imul eax, ecx
-0x00000000 32,eax,~,32,ecx,~,*,DUP,eax,=,eax,-,?{,1,1,}{,0,0,},cf,:=,of,:=
+0x00000000 32,eax,~,32,ecx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=
 EOF
 RUN
 
@@ -67,7 +67,7 @@ e asm.bits=64
 EOF
 EXPECT=<<EOF
 imul rax, r11, 0x33666667
-0x00000000 64,862348903,~,64,r11,~,*,DUP,rax,=,rax,-,?{,1,1,}{,0,0,},cf,:=,of,:=
+0x00000000 64,862348903,~,64,r11,~,*,DUP,rax,=,64,rax,~,-,!,!,DUP,cf,:=,of,:=
 EOF
 RUN
 
@@ -143,7 +143,7 @@ EOF
 EXPECT=<<EOF
 opcode: imul eax, ebx, 0x89
 esilcost: 0
-esil: 32,137,~,32,ebx,~,*,DUP,eax,=,eax,-,?{,1,1,}{,0,0,},cf,:=,of,:=
+esil: 32,137,~,32,ebx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #18860
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Fixes my bad mul / imul ESIL which did not work for *dx operands (the register is written to and then used again as if it were not) and also MUL was not valid for 64 bits. 64 bit IMUL instructions will still be wrong since theres no 128 bit sign extension. I will fix this at some point. I really hate IMUL.
