### PR TITLE
Move CAN table search to /ru command

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -126,7 +126,6 @@ static const char *help_msg_slash_c[] = {
 	"/cd", "", "Search for ASN1/DER certificates",
 	"/cr", "", "Search for ASN1/DER private keys (RSA and ECC)",
 	"/cg", "", "Search for GPG/PGP keys and signatures (Plaintext and binary form)",
-	"/cu", "[*qj]", "Search for UDS CAN database tables (binbloom)",
 	NULL
 };
 
@@ -137,6 +136,7 @@ static const char *help_msg_slash_r[] = {
 	"/rc", "", "search for call references",
 	"/re", " [addr]", "search references using esil",
 	"/rr", "", "Find read references",
+	"/ru", "[*qj]", "Search for UDS CAN database tables (binbloom)",
 	"/rw", "", "Find write references",
 	"/rx", "", "Find exec references",
 	NULL
@@ -3422,6 +3422,17 @@ reread:
 				}
 			}
 			break;
+		case 'u': // "/ru"
+			{
+				bool v = r_config_get_i (core->config, "search.verbose");
+				int mode = input[2];
+				if (!mode && !v) {
+					mode = 'q';
+				}
+				(void)r_core_search_uds (core, mode);
+				dosearch = false;
+				break;
+			}
 		case 'w': // "/rw" - write refs
 			{
 				RListIter *iter;
@@ -3580,7 +3591,7 @@ reread:
 				goto beach;
 			}
 			break;
-		case 'd': // "cd"
+		case 'd': // "/cd"
 			{
 				RSearchKeyword *kw;
 				kw = r_search_keyword_new_hex ("308200003082", "ffff0000ffff", NULL);
@@ -3595,18 +3606,7 @@ reread:
 				}
 			}
 			break;
-		case 'u': // "cu"
-			{
-				bool v = r_config_get_i (core->config, "search.verbose");
-				int mode = input[2];
-				if (!mode && !v) {
-					mode = 'q';
-				}
-				(void)r_core_search_uds (core, mode);
-				dosearch = false;
-				break;
-			}
-		case 'g': // "cg"
+		case 'g': // "/cg"
 			{
 				RSearchKeyword *kw;
 				r_search_reset (core->search, R_SEARCH_KEYWORD);
@@ -3652,7 +3652,7 @@ reread:
 
 				break;
 			}
-		case 'a': // "ca"
+		case 'a': // "/ca"
 			{
 				RSearchKeyword *kw;
 				kw = r_search_keyword_new_hexmask ("00", NULL);
@@ -3664,7 +3664,7 @@ reread:
 				param.aes_search = true;
 				break;
 			}
-		case 'r': // "cr"
+		case 'r': // "/cr"
 			{
 				RSearchKeyword *kw;
 				kw = r_search_keyword_new_hexmask ("00", NULL);

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -1018,23 +1018,3 @@ EXPECT=<<EOF
 0x00000005 hit0_0 a5a5bf
 EOF
 RUN
-
-NAME=crypto search
-FILE=bins/other/jeje.gpg
-CMDS=/cg
-EOF
-EXPECT=<<EOF
-0x00000007 hit0_0 "jkasdfBEGIN PGP PRIVATE KEYsadjfjasf"
-EOF
-je
-RUN
-
-NAME=crypto search
-FILE=bins/other/v4_secret_encrypted.gpg
-CMDS=/cg
-EOF
-EXPECT=<<EOF
-0x000007e0 hit13_0 0011010001fe030302
-EOF
-je
-RUN

--- a/test/db/cmd/cmd_search_crypto
+++ b/test/db/cmd/cmd_search_crypto
@@ -1,11 +1,72 @@
-NAME=/cu search for possible UDS tables
-FILE=bins/elf/analysis/ls-linux64
-ARGS=-n
-CMDS=<<EOF
-/cuj
-EOF
+NAME=cmd.hit for /ca
+FILE=bins/other/aes.dump
+CMDS=/ca
 EXPECT=<<EOF
-[{"addr":102769,"score":7,"stride":20},{"addr":11772,"score":6,"stride":24},{"addr":14055,"score":6,"stride":32},{"addr":14151,"score":6,"stride":16},{"addr":87675,"score":6,"stride":32},{"addr":87751,"score":6,"stride":18},{"addr":87771,"score":6,"stride":16},{"addr":87787,"score":6,"stride":10},{"addr":87797,"score":6,"stride":8},{"addr":87813,"score":6,"stride":14},{"addr":87848,"score":6,"stride":12},{"addr":87916,"score":6,"stride":24},{"addr":102745,"score":6,"stride":32},{"addr":102749,"score":6,"stride":28},{"addr":102757,"score":6,"stride":28},{"addr":102789,"score":6,"stride":20},{"addr":11316,"score":5,"stride":24},{"addr":11796,"score":5,"stride":24},{"addr":13847,"score":5,"stride":16},{"addr":14087,"score":5,"stride":32}]
+0x0000001e hit0_0 0000000000000000000000000000000000000000000000000000000000000000
 EOF
 RUN
 
+NAME=cmd.hit for /ca
+FILE=bins/other/aes_192.dump
+CMDS=/ca
+EXPECT=<<EOF
+0x000000fa hit0_0 000102030405060708090a0b0c0d0e0f1011121314151617
+EOF
+RUN
+
+NAME=cmd.hit for /cd
+FILE=bins/other/certificate.ber
+CMDS=/cd
+EXPECT=<<EOF
+0x0000002f hit0_0 308203493082
+EOF
+RUN
+
+NAME=cmd.hit for multiple /cd
+FILE=bins/other/certificate.ber
+CMDS=<<EOF
+/cd
+/cr
+/cd
+EOF
+EXPECT=<<EOF
+0x0000002f hit0_0 308203493082
+0x0000002f hit2_0 308203493082
+EOF
+RUN
+
+NAME=/cg PGP search ASCII armor
+FILE=bins/other/jeje.gpg
+CMDS=/cg
+EOF
+EXPECT=<<EOF
+0x00000007 hit0_0 "jkasdfBEGIN PGP PRIVATE KEYsadjfjasf"
+EOF
+je
+RUN
+
+NAME=/cg PGP search binary
+FILE=bins/other/v4_secret_encrypted.gpg
+CMDS=/cg
+EOF
+EXPECT=<<EOF
+0x000007e0 hit13_0 0011010001fe030302
+EOF
+je
+RUN
+
+NAME=cmd.hit for /cr
+FILE=bins/other/rsa-private-4096.key
+CMDS=/cr
+EXPECT=<<EOF
+0x0000000d hit0_0 308209280201000282020100c079f24b042787e4896db411fa7647e3bb62c88796fa979f126c575f...
+EOF
+RUN
+
+NAME=cmd.hit for /cr on edd448
+FILE=bins/other/ed448-private.key
+CMDS=/cr
+EXPECT=<<EOF
+0x000000f5 hit0_0 3047020100300506032b6571043b0439176449168ec8fc66d9e67d375d1ea310b1427e8c178b2f83...
+EOF
+RUN

--- a/test/db/cmd/cmd_search_hit
+++ b/test/db/cmd/cmd_search_hit
@@ -144,59 +144,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=cmd.hit for /ca
-FILE=bins/other/aes.dump
-CMDS=/ca
-EXPECT=<<EOF
-0x0000001e hit0_0 0000000000000000000000000000000000000000000000000000000000000000
-EOF
-RUN
-
-NAME=cmd.hit for /ca
-FILE=bins/other/aes_192.dump
-CMDS=/ca
-EXPECT=<<EOF
-0x000000fa hit0_0 000102030405060708090a0b0c0d0e0f1011121314151617
-EOF
-RUN
-
-NAME=cmd.hit for /cr
-FILE=bins/other/rsa-private-4096.key
-CMDS=/cr
-EXPECT=<<EOF
-0x0000000d hit0_0 308209280201000282020100c079f24b042787e4896db411fa7647e3bb62c88796fa979f126c575f...
-EOF
-RUN
-
-NAME=cmd.hit for /cr on edd448
-FILE=bins/other/ed448-private.key
-CMDS=/cr
-EXPECT=<<EOF
-0x000000f5 hit0_0 3047020100300506032b6571043b0439176449168ec8fc66d9e67d375d1ea310b1427e8c178b2f83...
-EOF
-RUN
-
-NAME=cmd.hit for /cd
-FILE=bins/other/certificate.ber
-CMDS=/cd
-EXPECT=<<EOF
-0x0000002f hit0_0 308203493082
-EOF
-RUN
-
-NAME=cmd.hit for multiple /cd
-FILE=bins/other/certificate.ber
-CMDS=<<EOF
-/cd
-/cr
-/cd
-EOF
-EXPECT=<<EOF
-0x0000002f hit0_0 308203493082
-0x0000002f hit2_0 308203493082
-EOF
-RUN
-
 NAME=cmd.hit for /d multiple
 FILE=malloc://1024
 CMDS=<<EOF
@@ -317,6 +264,17 @@ e search.to = 0x00005c44
 /r sym.imp.__cxa_finalize
 EOF
 EXPECT=<<EOF
+EOF
+RUN
+
+NAME=/ru search for possible UDS tables
+FILE=bins/elf/analysis/ls-linux64
+ARGS=-n
+CMDS=<<EOF
+/ruj
+EOF
+EXPECT=<<EOF
+[{"addr":102769,"score":7,"stride":20},{"addr":11772,"score":6,"stride":24},{"addr":14055,"score":6,"stride":32},{"addr":14151,"score":6,"stride":16},{"addr":87675,"score":6,"stride":32},{"addr":87751,"score":6,"stride":18},{"addr":87771,"score":6,"stride":16},{"addr":87787,"score":6,"stride":10},{"addr":87797,"score":6,"stride":8},{"addr":87813,"score":6,"stride":14},{"addr":87848,"score":6,"stride":12},{"addr":87916,"score":6,"stride":24},{"addr":102745,"score":6,"stride":32},{"addr":102749,"score":6,"stride":28},{"addr":102757,"score":6,"stride":28},{"addr":102789,"score":6,"stride":20},{"addr":11316,"score":5,"stride":24},{"addr":11796,"score":5,"stride":24},{"addr":13847,"score":5,"stride":16},{"addr":14087,"score":5,"stride":32}]
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Can table search was previously in `/cu` but since it is not related to Cryptography I moved it to `/ru`. Crypto tests have been moved to search_crypto.
