### PR TITLE
Exclude files of nested rvc repos from repo_files() ##projects

### DIFF
--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -918,20 +918,13 @@ R_API bool r_vc_branch(const char *rp, const char *bname) {
 R_API bool r_vc_new(const char *path) {
 	Sdb *db;
 	char *commitp, *blobsp;
-	switch (repo_exists (path)) {
-	case 0:
-		break;
-	case 1:
-		eprintf ("Repo already exists at: %s", path);
-		return false;
-	case -1:
-		eprintf ("Can't create repo\n");
-		return false;
-	case -2:
-		eprintf ("Repository exists but is corrupt\n");
-		return false;
-	}
 	char *vcp = r_str_newf ("%s" R_SYS_DIR ".rvc", path);
+	if (r_file_is_directory (vcp)) {
+		eprintf ("A directory already exists in %s\n", path);
+		free (vcp);
+		return false;
+
+	}
 	if (!vcp) {
 		return false;
 	}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -404,13 +404,15 @@ static bool traverse_files(RList *dst, const char *dir) {
 }
 
 static RList *repo_files(const char *dir) {
-	RList *ret = r_list_new ();
-	if (!ret && !traverse_files (ret, dir)) {
-		r_list_free (ret);
-		return NULL;
-	}
-	return ret;
-}
+ 	RList *ret = r_list_newf (free);
+ 	if (ret) {
+           if (!traverse_files (ret, dir)) {
+ 		r_list_free (ret);
+ 		ret = NULL;
+           }
+ 	}
+ 	return ret;
+ }
 
 //shit function:
 static RList *get_uncommitted(const char *rp) {

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -361,18 +361,17 @@ static bool dr(RList *dst, const char *dir) {
 	RListIter *iter;
 	bool ret = true;
 	RList *files = r_sys_dir (dir);
+	if (!r_list_empty (dst)) {
+		char *vcp = r_str_newf ("%s" R_SYS_DIR ".rvc", dir);
+		if (!vcp) {
+			return false;
+		}
+		if (r_file_is_directory (vcp)) {
+			return true;
+		}
+	}
 	if (!files) {
 		return false;
-	}
-	if (!r_list_empty (dst)) {
-		RListIter *iter;
-		char *path;
-		r_list_foreach (files, iter, path) {
-			if (!strcmp (path, ".rvc")) {
-				r_list_free (files);
-				return true;
-			}
-		}
 	}
 	r_list_foreach (files, iter, name) {
 		char *path;

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -355,8 +355,7 @@ static bool rm_empty_dir(const char *rp) {
 	return true;
 }
 
-//This is why anonymous functions are cool
-static bool dr(RList *dst, const char *dir) {
+static bool traverse_files(RList *dst, const char *dir) {
 	char *name;
 	RListIter *iter;
 	bool ret = true;
@@ -387,7 +386,7 @@ static bool dr(RList *dst, const char *dir) {
 			break;
 		}
 		if (r_file_is_directory (path)) {
-			if (!dr (dst, path)) {
+			if (!traverse_files (dst, path)) {
 				ret = false;
 				break;
 			}
@@ -406,7 +405,7 @@ static bool dr(RList *dst, const char *dir) {
 
 static RList *repo_files(const char *dir) {
 	RList *ret = r_list_new ();
-	if (!ret && !dr (ret, dir)) {
+	if (!ret && !traverse_files (ret, dir)) {
 		r_list_free (ret);
 		return NULL;
 	}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -406,10 +406,7 @@ static bool dr(RList *dst, const char *dir) {
 
 static RList *repo_files(const char *dir) {
 	RList *ret = r_list_new ();
-	if (!ret) {
-		return NULL;
-	}
-	if (!dr (ret, dir)) {
+	if (!ret && !dr (ret, dir)) {
 		r_list_free (ret);
 		return NULL;
 	}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -916,7 +916,7 @@ R_API bool r_vc_new(const char *path) {
 	char *commitp, *blobsp;
 	char *vcp = r_str_newf ("%s" R_SYS_DIR ".rvc", path);
 	if (r_file_is_directory (vcp)) {
-		eprintf ("A directory already exists in %s\n", path);
+		eprintf ("A repository already exists in %s\n", path);
 		free (vcp);
 		return false;
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This PR prevents repo_files() from traversing dirs with a .rvc in them (besides the root)