### PR TITLE
Expand r_sign API ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -934,6 +934,22 @@ static RSignHash *r_sign_fcn_bbhash(RAnal *a, RAnalFunction *fcn) {
 	return hash;
 }
 
+R_API int r_sign_all_functions(RAnal *a) {
+	RAnalFunction *fcni = NULL;
+	RListIter *iter = NULL;
+	int count = 0;
+
+	r_list_foreach (a->fcns, iter, fcni) {
+		if (r_cons_is_breaked ()) {
+			break;
+		}
+		if (r_sign_add_func (a, fcni, NULL)) {
+			count++;
+		}
+	}
+	return count;
+}
+
 R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name) {
 	r_return_val_if_fail (a && fcn, false);
 	RSignItem *it = r_sign_item_new ();

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -40,21 +40,15 @@ int list_str_cmp (const void *a, const void *b) {
 R_API RList *r_sign_fcn_vars(RAnal *a, RAnalFunction *fcn) {
 	r_return_val_if_fail (a && fcn, NULL);
 
-	RCore *core = a->coreb.core;
-
-	if (!core) {
-		return NULL;
-	}
-
 	RListIter *iter;
 	RAnalVar *var;
 	RList *ret = r_list_newf ((RListFree) free);
 	if (!ret) {
 		return NULL;
 	}
-	RList *reg_vars = r_anal_var_list (core->anal, fcn, R_ANAL_VAR_KIND_REG);
-	RList *spv_vars = r_anal_var_list (core->anal, fcn, R_ANAL_VAR_KIND_SPV);
-	RList *bpv_vars = r_anal_var_list (core->anal, fcn, R_ANAL_VAR_KIND_BPV);
+	RList *reg_vars = r_anal_var_list (a, fcn, R_ANAL_VAR_KIND_REG);
+	RList *spv_vars = r_anal_var_list (a, fcn, R_ANAL_VAR_KIND_SPV);
+	RList *bpv_vars = r_anal_var_list (a, fcn, R_ANAL_VAR_KIND_BPV);
 	r_list_foreach (bpv_vars, iter, var) {
 		r_list_append (ret, r_str_newf ("b%d", var->delta));
 	}

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -341,22 +341,10 @@ out_case_manual:
 		r_cons_break_pop ();
 		break;
 	case 'F':
-		{
-			RAnalFunction *fcni = NULL;
-			RListIter *iter = NULL;
-			int count = 0;
-
-			r_cons_break_push (NULL, NULL);
-			r_list_foreach (core->anal->fcns, iter, fcni) {
-				if (r_cons_is_breaked ()) {
-					break;
-				}
-				r_sign_add_func (core->anal, fcni, NULL);
-				count++;
-			}
-			r_cons_break_pop ();
-			eprintf ("generated zignatures: %d\n", count);
-		}
+		r_cons_break_push (NULL, NULL);
+		int count = r_sign_all_functions (core->anal);
+		r_cons_break_pop ();
+		eprintf ("generated zignatures: %d\n", count);
 		break;
 	case '?':
 		if (input[1] == '?') {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -115,68 +115,6 @@ static char *getFcnComments(RCore *core, RAnalFunction *fcn) {
 }
 #endif
 
-static void addFcnZign(RCore *core, RAnalFunction *fcn, const char *name) {
-	char *ptr = NULL;
-	char *zignspace = NULL;
-	char *zigname = NULL;
-	const RSpace *curspace = r_spaces_current (&core->anal->zign_spaces);
-	int len = 0;
-
-	if (name) {
-		zigname = r_str_new (name);
-	} else {
-		// If the user has set funtion names containing a single ':' then we assume
-		// ZIGNSPACE:FUNCTION, and for now we only support the 'zg' command
-		if ((ptr = strchr (fcn->name, ':')) != NULL) {
-			len = ptr - fcn->name;
-			zignspace = r_str_newlen (fcn->name, len);
-			r_spaces_push (&core->anal->zign_spaces, zignspace);
-		} else if (curspace) {
-			zigname = r_str_newf ("%s:", curspace->name);
-		}
-		zigname = r_str_appendf (zigname, "%s", fcn->name);
-	}
-
-	// create empty item
-	RSignItem *it = r_sign_item_new ();
-	if (!it) {
-		free (zigname);
-		return;
-	}
-	// add sig types info to item
-	it->name = zigname; // will be free'd when item is free'd
-	it->space = r_spaces_current (&core->anal->zign_spaces);
-	// TODO: sort fcn bbs
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_GRAPH);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_BYTES);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_XREFS);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_REFS);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_VARS);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_TYPES);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_BBHASH);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_OFFSET);
-	r_sign_addto_item (core->anal, it, fcn, R_SIGN_NAME);
-
-	/* r_sign_add_addr (core->anal, zigname, fcn->addr); */
-
-	// commit the item to anal
-	r_sign_add_item (core->anal, it);
-
-	/*
-	XXX this is very slow and poorly tested
-	char *comments = getFcnComments (core, fcn);
-	if (comments) {
-		r_sign_add_comment (core->anal, zigname, comments);
-	}
-	*/
-
-	r_sign_item_free (it); // causes zigname to be free'd
-	if (zignspace) {
-		r_spaces_pop (&core->anal->zign_spaces);
-		free (zignspace);
-	}
-}
-
 static bool addCommentZign(RCore *core, const char *name, RList *args) {
 	if (r_list_length (args) != 1) {
 		eprintf ("Invalid number of arguments\n");
@@ -371,46 +309,30 @@ out_case_manual:
 		}
 		break;
 	case 'f': // "zaf"
-		{
-			RAnalFunction *fcni = NULL;
-			RListIter *iter = NULL;
-			const char *fcnname = NULL, *zigname = NULL;
-			char *args = NULL;
-			int n = 0;
-			bool retval = true;
+		char *args = r_str_trim_dup (input + 1);
+		int n = r_str_word_set0 (args);
 
-			args = r_str_trim_dup (input + 1);
-			n = r_str_word_set0 (args);
-
-			if (n > 2) {
-				eprintf ("Usage: zaf [fcnname] [zigname]\n");
-				retval = false;
-				goto out_case_fcn;
-			}
-
-			switch (n) {
-			case 2:
-				zigname = r_str_word_get0 (args, 1);
-			case 1:
-				fcnname = r_str_word_get0 (args, 0);
-			}
-
-			r_cons_break_push (NULL, NULL);
-			r_list_foreach (core->anal->fcns, iter, fcni) {
-				if (r_cons_is_breaked ()) {
-					break;
-				}
-				if ((!fcnname && core->offset == fcni->addr) ||
-					(fcnname && !strcmp (fcnname, fcni->name))) {
-					addFcnZign (core, fcni, zigname);
-					break;
-				}
-			}
-			r_cons_break_pop ();
-
-out_case_fcn:
+		if (n > 2) {
+			eprintf ("Usage: zaf [fcnname] [zigname]\n");
 			free (args);
-			return retval;
+			return false;
+		}
+
+		RAnalFunction *fcni = NULL;
+		const char *zigname = (n == 2)? r_str_word_get0 (args, 1): NULL;
+		if (n > 0) {
+			fcni = r_anal_get_function_byname (core->anal, r_str_word_get0 (args, 0));
+		} else {
+			fcni = r_anal_get_function_at (core->anal, core->offset);
+		}
+		if (fcni) {
+			r_sign_add_func (core->anal, fcni, zigname);
+		}
+
+		free (args);
+		if (!fcni) {
+			eprintf ("Could not find function");
+			return false;
 		}
 		break;
 	case 'c': // "zac"
@@ -429,7 +351,7 @@ out_case_fcn:
 				if (r_cons_is_breaked ()) {
 					break;
 				}
-				addFcnZign (core, fcni, NULL);
+				r_sign_add_func (core->anal, fcni, NULL);
 				count++;
 			}
 			r_cons_break_pop ();

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -309,30 +309,32 @@ out_case_manual:
 		}
 		break;
 	case 'f': // "zaf"
-		char *args = r_str_trim_dup (input + 1);
-		int n = r_str_word_set0 (args);
+		{
+			char *args = r_str_trim_dup (input + 1);
+			int n = r_str_word_set0 (args);
 
-		if (n > 2) {
-			eprintf ("Usage: zaf [fcnname] [zigname]\n");
+			if (n > 2) {
+				eprintf ("Usage: zaf [fcnname] [zigname]\n");
+				free (args);
+				return false;
+			}
+
+			RAnalFunction *fcni = NULL;
+			const char *zigname = (n == 2)? r_str_word_get0 (args, 1): NULL;
+			if (n > 0) {
+				fcni = r_anal_get_function_byname (core->anal, r_str_word_get0 (args, 0));
+			} else {
+				fcni = r_anal_get_function_at (core->anal, core->offset);
+			}
+			if (fcni) {
+				r_sign_add_func (core->anal, fcni, zigname);
+			}
+
 			free (args);
-			return false;
-		}
-
-		RAnalFunction *fcni = NULL;
-		const char *zigname = (n == 2)? r_str_word_get0 (args, 1): NULL;
-		if (n > 0) {
-			fcni = r_anal_get_function_byname (core->anal, r_str_word_get0 (args, 0));
-		} else {
-			fcni = r_anal_get_function_at (core->anal, core->offset);
-		}
-		if (fcni) {
-			r_sign_add_func (core->anal, fcni, zigname);
-		}
-
-		free (args);
-		if (!fcni) {
-			eprintf ("Could not find function");
-			return false;
+			if (!fcni) {
+				eprintf ("Could not find function");
+				return false;
+			}
 		}
 		break;
 	case 'c': // "zac"

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -108,6 +108,7 @@ typedef struct {
 R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
 R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph);
+R_API int r_sign_all_functions(RAnal *a);
 R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name);
 R_API bool r_sign_addto_item(RAnal *a, RSignItem *it, RAnalFunction *fcn, RSignType type);
 R_API bool r_sign_add_addr(RAnal *a, const char *name, ut64 addr);

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -108,6 +108,7 @@ typedef struct {
 R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
 R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph);
+R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name);
 R_API bool r_sign_addto_item(RAnal *a, RSignItem *it, RAnalFunction *fcn, RSignType type);
 R_API bool r_sign_add_addr(RAnal *a, const char *name, ut64 addr);
 R_API bool r_sign_add_name(RAnal *a, const char *name, const char *realname);

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -152,19 +152,19 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	find_functions (core, a_cnt);
 
 	// create zignatures
-	r_core_cmd0 (core, "zg");
+	r_sign_all_functions (core->anal);
 
 	// write sigs to file
-	if (ofile) {
-		r_core_cmdf (core, "\"zos %s\"", ofile);
+	if (ofile && !r_sign_save (core->anal, ofile)) {
+		eprintf ("Failed to write file\n");
 	}
 
 	if (rad) {
-		r_core_cmd0 (core, "z*");
+		r_sign_list (core->anal, '*');
 	}
 
 	if (json) {
-		r_core_cmd0 (core, "zj");
+		r_sign_list (core->anal, 'j');
 	}
 	r_cons_flush ();
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Refactors r_sign to export `r_sign_add_func` and `r_sign_all_functions` which will turn a single function, or all known functions, into signatures. This allows `rasign2` to easily create signatures without relying on `r_core_cmd` family of functions. 
