### PR TITLE
r_cons_printf_list: fix potential busy loop

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1232,17 +1232,16 @@ R_API void r_cons_printf_list(const char *format, va_list ap) {
 	if (strchr (format, '%')) {
 		if (palloc (MOAR + strlen (format) * 20)) {
 club:
-			size = I.context->buffer_sz - I.context->buffer_len - 1; /* remaining space in I.context->buffer */
+			size = I.context->buffer_sz - I.context->buffer_len; /* remaining space in I.context->buffer */
 			written = vsnprintf (I.context->buffer + I.context->buffer_len, size, format, ap3);
 			if (written >= size) { /* not all bytes were written */
-				if (palloc (written)) {
+				if (palloc (written + 1)) {  /* + 1 byte for \0 termination */
 					va_end (ap3);
 					va_copy (ap3, ap2);
 					goto club;
 				}
 			}
 			I.context->buffer_len += written;
-			I.context->buffer[I.context->buffer_len] = 0;
 		}
 	} else {
 		r_cons_strcat (format);


### PR DESCRIPTION
Hello, the below PR is the result of a long investigation why radare2
gets stuck in some rare cases. I am not an experienced C coder so
take this analysis with a grain of salt, but it matches with what we
have seen in gdb during debugging.

In case the string to be written by `vsnprintf` including `\0`
termination equals to the length of the buffer, the code enters in a
busy loop. The original code seems to assume, that `vsnprintf` won't
terminate the string with `\0` character which it does.

The [documentation of `vsnprintf` states](https://en.cppreference.com/w/c/io/vfprintf):

> `int vsnprintf( char *restrict buffer, size_t bufsz, const
> char *restrict format, va_list vlist );`
>
> Writes the results to a character string buffer. At most bufsz - 1
> characters are written. The resulting character string will be
> terminated with a null character, unless bufsz is zero. If bufsz is
> zero, nothing is written and buffer may be a null pointer, [...]

This means that the `size` variable should be set to the total
available length of the buffer, not `length - 1`. Furthermore on the
return value the manual writes:

> however the return value (number of bytes that would be written not
> including the null terminator) is still calculated and returned.

This means that the `written` size returned doesn't contain count the
terminating `\0` in the length, so the value of `written` can be at
most `size - 1` before truncating the output. In other words a string
having`size = written + 1` would fit exactly in the buffer. (`palloc`
will make sure to allocate a properly aligned buffer).

Also as `vsnprintf` will write the terminating `\0` there is no need
to explicitly do that.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
