### PR TITLE
Fix bug in zaf creating zignspace ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -953,30 +953,14 @@ R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name) {
 	if (!it) {
 		return false;
 	}
-
-	// TODO: why set it->name = "spacename:name" when there is a it-space?
-	char *ptr;
-	char *zignspace = NULL;
-	if (name) {
-		it->name = strdup (name);
-	} else {
-		const RSpace *curspace = r_spaces_current (&a->zign_spaces);
-		if ((ptr = strchr (fcn->name, ':')) != NULL) {
-			int len = ptr - fcn->name;
-			zignspace = r_str_newlen (fcn->name, len);
-			r_spaces_push (&a->zign_spaces, zignspace);
-		} else if (curspace) {
-			it->name = r_str_newf ("%s:", curspace->name);
-		}
-		it->name = r_str_appendf (it->name, "%s", fcn->name);
-	}
+	it->space = r_spaces_current (&a->zign_spaces);
+	it->name = strdup (name? name: fcn->name);
 
 	if (!it->name) {
 		r_sign_item_free (it);
 		return false;
 	}
 
-	it->space = r_spaces_current (&a->zign_spaces);
 	r_sign_addto_item (a, it, fcn, R_SIGN_GRAPH);
 	r_sign_addto_item (a, it, fcn, R_SIGN_BYTES);
 	r_sign_addto_item (a, it, fcn, R_SIGN_XREFS);
@@ -989,12 +973,7 @@ R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name) {
 
 	// commit the item to anal
 	r_sign_add_item (a, it);
-
-	r_sign_item_free (it); // causes zigname to be free'd
-	if (zignspace) {
-		r_spaces_pop (&a->zign_spaces);
-		free (zignspace);
-	}
+	r_sign_item_free (it);
 	return true;
 }
 

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -263,9 +263,6 @@ R_API bool r_sign_deserialize(RAnal *a, RSignItem *it, const char *k, const char
 		}
 		RSignType st = (RSignType)*word;
 		switch (st) {
-		case R_SIGN_ANAL:
-			eprintf ("Unsupported\n");
-			break;
 		case R_SIGN_NAME:
 			DBL_VAL_FAIL (it->realname, R_SIGN_NAME);
 			it->realname = strdup (token);
@@ -375,7 +372,7 @@ R_API bool r_sign_deserialize(RAnal *a, RSignItem *it, const char *k, const char
 			}
 			break;
 		default:
-			eprintf ("Unsupported (%s)\n", word);
+			eprintf ("Unsupported (%c)\n", st);
 			break;
 		}
 	}

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -435,7 +435,11 @@ static int cmdSpace(void *data, const char *input) {
 			eprintf ("Usage: zs+zignspace\n");
 			return false;
 		}
-		r_spaces_push (zs, input + 1);
+		char *sp = r_str_trim_dup (input + 1);
+		if (sp) {
+			r_spaces_push (zs, sp);
+			free (sp);
+		}
 		break;
 	case 'r':
 		if (input[1] != ' ' || !input[2]) {

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -353,7 +353,7 @@ out_case_manual:
 			// TODO #7967 help refactor: move to detail
 			r_cons_printf ("Adding Zignatures (examples and documentation)\n\n"
 				"Zignature types:\n"
-				"  a: bytes pattern (anal mask)\n"
+				"  a: bytes pattern, r2 creates mask from analysis\n"
 				"  b: bytes pattern\n"
 				"  c: base64 comment\n"
 				"  n: real function name\n"

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -19,7 +19,7 @@ typedef enum {
 	R_SIGN_BYTES = 'b', // bytes pattern
 	R_SIGN_BYTES_MASK = 'm', // bytes pattern
 	R_SIGN_BYTES_SIZE = 's', // bytes pattern
-	R_SIGN_ANAL = 'a', // bytes pattern (anal mask) // wtf ?
+	R_SIGN_ANAL = 'a', // bytes pattern, input only, creates mask from byte analysis
 	R_SIGN_COMMENT = 'c', // comment
 	R_SIGN_GRAPH = 'g', // graph metrics
 	R_SIGN_OFFSET = 'o', // addr

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -421,14 +421,24 @@ e zign.mincc = 0
 zs zigs
 zaf main
 z
+zs *
+z
 EOF
 EXPECT=<<EOF
-zigs:main:
+main:
   bytes: 554889e54883ec10897dfc488975f0bf13064000e8c2ffffffb800000000c9c3
   mask: ffffffffffffffffffffffffffffffff00000000ff00000000ffffffffffffff
   graph: cc=1 nbbs=1 edges=0 ebbs=1 bbsum=32
   addr: 0x0040055b
-  realname: main
+  refs: sym.print
+  vars: b-12, b-24, r82, r78
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
+  bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
+(zigs) main:
+  bytes: 554889e54883ec10897dfc488975f0bf13064000e8c2ffffffb800000000c9c3
+  mask: ffffffffffffffffffffffffffffffff00000000ff00000000ffffffffffffff
+  graph: cc=1 nbbs=1 edges=0 ebbs=1 bbsum=32
+  addr: 0x0040055b
   refs: sym.print
   vars: b-12, b-24, r82, r78
   types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
@@ -444,14 +454,24 @@ e zign.mincc = 0
 zs zigs
 zaf @ main
 z
+zs *
+z
 EOF
 EXPECT=<<EOF
-zigs:main:
+main:
   bytes: 554889e54883ec10897dfc488975f0bf13064000e8c2ffffffb800000000c9c3
   mask: ffffffffffffffffffffffffffffffff00000000ff00000000ffffffffffffff
   graph: cc=1 nbbs=1 edges=0 ebbs=1 bbsum=32
   addr: 0x0040055b
-  realname: main
+  refs: sym.print
+  vars: b-12, b-24, r82, r78
+  types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
+  bbhash: 9890426532f35eb3a80fe773d887714fe27d13ea125ad7e90beab16a51b74496
+(zigs) main:
+  bytes: 554889e54883ec10897dfc488975f0bf13064000e8c2ffffffb800000000c9c3
+  mask: ffffffffffffffffffffffffffffffff00000000ff00000000ffffffffffffff
+  graph: cc=1 nbbs=1 edges=0 ebbs=1 bbsum=32
+  addr: 0x0040055b
   refs: sym.print
   vars: b-12, b-24, r82, r78
   types: func.main.ret=int, func.main.args=2, func.main.arg.0="int,argc", func.main.arg.1="char **,argv"
@@ -532,7 +552,7 @@ aa
 zs zigs
 zaf main
 z/
-?v sign.bytes.zigs:main_0
+?v sign.bytes.main_0
 EOF
 EXPECT=<<EOF
 0x40055b


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Before this commit, r2 will create a new zignspace if a function name contains a `:`. See below:
```
[0x00005b20]> s main
[0x000040a0]> afn newspace:name
[0x000040a0]> zs
[0x000040a0]> zaf
[0x000040a0]> zs
    1 * newspace
[0x000040a0]> z
(newspace) newspace:name:
...
```