### PR TITLE
Fix #18783 - Support ELFs with phnum > 0xFFFF ##bin

### DIFF
--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -210,6 +210,7 @@ bool Elf_(r_bin_elf_section_perms)(RBinFile *bf, const char *name, int perms);
 bool Elf_(r_bin_elf_entry_write)(RBinFile *bf, ut64 addr);
 bool Elf_(r_bin_elf_del_rpath)(RBinFile *bf);
 
+ut64 Elf_(r_bin_elf_get_phnum)(ELFOBJ *bin);
 bool Elf_(r_bin_elf_is_executable)(ELFOBJ *bin);
 int Elf_(r_bin_elf_has_relro)(struct Elf_(r_bin_elf_obj_t) *bin);
 int Elf_(r_bin_elf_has_nx)(struct Elf_(r_bin_elf_obj_t) *bin);

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -174,8 +174,7 @@ static bool is_wordable_section(const char *name) {
 static RList* sections(RBinFile *bf) {
 	struct Elf_(r_bin_elf_obj_t)* obj = (bf && bf->o)? bf->o->bin_obj : NULL;
 	struct r_bin_elf_section_t *section = NULL;
-	int i, num, found_load = 0;
-	Elf_(Phdr)* phdr = NULL;
+	int i, found_load = 0;
 	RBinSection *ptr = NULL;
 	RList *ret = NULL;
 
@@ -221,9 +220,11 @@ static RList* sections(RBinFile *bf) {
 
 	// program headers is another section
 	ut16 mach = obj->ehdr.e_machine;
-	num = obj->ehdr.e_phnum;
-	phdr = obj->phdr;
+	Elf_(Phdr)* phdr = obj->phdr;
+
+
 	if (phdr) {
+		ut64 num = Elf_(r_bin_elf_get_phnum) (obj);
 		int n = 0;
 		for (i = 0; i < num; i++) {
 			if (!(ptr = R_NEW0 (RBinSection))) {

--- a/test/db/formats/elf/bigph
+++ b/test/db/formats/elf/bigph
@@ -1,0 +1,11 @@
+NAME=coredumps with zillions of program headers
+FILE=gzip://bins/elf/core65k.gz
+CMDS=iSS~?
+EXPECT=<<EOF
+131074
+EOF
+EXPECT_ERR=<<EOF
+Setting up coredump arch-bits to: x86-64
+Setting up coredump: 65535 maps have been found and created
+EOF
+RUN


### PR DESCRIPTION
* Useful for loading qemu coredumps

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
