### PR TITLE
Use `r_file_binsh` in `r_run_start`

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -1206,7 +1206,7 @@ R_API int r_run_start(RRunProfile *p) {
 			close (0);
 			close (1);
 			char *bin_sh = r_file_binsh ();
-			if (bin_sh != NULL) {
+			if (bin_sh) {
 				exit (execl (bin_sh, bin_sh, "-c", p->_system, NULL));
 			} else {
 				exit (r_sys_cmd (p->_system));

--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -1205,12 +1205,8 @@ R_API int r_run_start(RRunProfile *p) {
 #if __UNIX__
 			close (0);
 			close (1);
-			char *shell_env = r_sys_getenv ("SHELL");
-			char *bin_sh = (R_STR_ISNOTEMPTY (shell_env) && r_file_exists (shell_env))
-				? shell_env
-				: r_file_path ("sh");
-			// Honor $SHELL ?
-			if (R_STR_ISNOTEMPTY (bin_sh)) {
+			char *bin_sh = r_file_binsh ();
+			if (bin_sh != NULL) {
 				exit (execl (bin_sh, bin_sh, "-c", p->_system, NULL));
 			} else {
 				exit (r_sys_cmd (p->_system));


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: none
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This way it'll use `SHELL_PATH` from `libr/include/r_util/r_file.h`, allowing [patching](https://github.com/termux/termux-packages/blob/master/packages/radare2/fix-bin-sh-path.patch) to be simpler.
