### PR TITLE
r2pm: Add offline option for installation

### DIFF
--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -225,6 +225,7 @@ upgradeOutdated() {
 }
 
 r2pm_update() {
+	[ "${R2PM_OFFLINE}" != 0 ] && return
 	[ -z "$R2PM_DBDIR" ] && R2PM_DBDIR="${R2PM_USRDIR}/db"
 	mkdir -p "${R2PM_GITDIR}"
 	mkdir -p "${HOME}/.config"
@@ -524,9 +525,7 @@ r2pm_doc() {
 }
 
 r2pm_install() {
-	if [ "${R2PM_OFFLINE}" = 0 ]; then
-		r2pm_update
-	fi
+	r2pm_update
 	FILE="$(pkgFilePath "$2")"
 	if [ -f "${FILE}" ]; then
 		NAME="$2"

--- a/binr/r2pm/r2pm
+++ b/binr/r2pm/r2pm
@@ -524,7 +524,9 @@ r2pm_doc() {
 }
 
 r2pm_install() {
-	r2pm_update
+	if [ "${R2PM_OFFLINE}" = 0 ]; then
+		r2pm_update
+	fi
 	FILE="$(pkgFilePath "$2")"
 	if [ -f "${FILE}" ]; then
 		NAME="$2"

--- a/man/r2pm.1
+++ b/man/r2pm.1
@@ -54,6 +54,10 @@ Install a test package (don't git pull on $R2PM_GITDIR/yara3)
 .Pp
   $ R2PM_GITSKIP=1 r2pm install yara3
 .Pp
+Avoid init/update calls (don't git pull on $R2PM_DBDIR)
+.Pp
+ $ R2PM_OFFLINE=1 r2pm -i yara
+.Pp
 Uninstall a package
 .Pp
   $ r2pm uninstall yara3


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
R2PM_OFFLINE variable allows to install a package offline without pull to $R2PM_DBDIR.
