### PR TITLE
Dis-allow \.* in rvc commit messages

### DIFF
--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -711,8 +711,8 @@ R_API bool r_vc_commit(const char *rp, const char *message, const char *author, 
 		eprintf ("Commit message is too long\n");
 		return false;
 	}
-	for (const char *m = message; m; m++) {
-		if (*m < ' '){
+	for (const char *m = message; *m; m++) {
+		if (*m < ' ') {
 			eprintf ("commit messages must not contain unprintable charecters\n");
 			return false;
 		}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -708,10 +708,19 @@ R_API bool r_vc_commit(const char *rp, const char *message, const char *author, 
 			return false;
 		}
 	} else if (r_str_len_utf8 (message) > MAX_MESSAGE_LEN) {
+		eprintf ("Commit message is too long\n");
 		return false;
 	}
-	RList *blobs;
-	blobs = blobs_add (rp, files);
+	if (strchr (message, '\n')) {
+		return false;
+	}
+	for (const char *m = message; m; m++) {
+		if (*m < ' '){
+			eprintf ("commit messages must not contain unprintable charecters\n");
+			return false;
+		}
+	}
+	RList *blobs = blobs_add (rp, files);
 	if (!blobs) {
 		return false;
 	}

--- a/libr/core/rvc.c
+++ b/libr/core/rvc.c
@@ -711,9 +711,6 @@ R_API bool r_vc_commit(const char *rp, const char *message, const char *author, 
 		eprintf ("Commit message is too long\n");
 		return false;
 	}
-	if (strchr (message, '\n')) {
-		return false;
-	}
 	for (const char *m = message; m; m++) {
 		if (*m < ' '){
 			eprintf ("commit messages must not contain unprintable charecters\n");


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**