### PR TITLE
Add collision ##signatures feature to rasign2

### DIFF
--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -12,6 +12,7 @@ static void rasign_show_help(void) {
 		" -q               quiet mode\n"
 		" -r               show output in radare commands\n"
 		" -s signspace     save all signatures under this signspace\n"
+		" -c               add collision signatures before writing file\n"
 		" -v               show version information\n"
 		"Examples:\n"
 		"  rasign2 -o libc.sdb libc.so.6\n");
@@ -66,9 +67,10 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 	bool quiet = false;
 	bool json = false;
 	bool flirt = false;
+	bool collision = false;
 	RGetopt opt;
 
-	r_getopt_init (&opt, argc, argv, "afhjo:qrs:v");
+	r_getopt_init (&opt, argc, argv, "afhjo:qrs:cv");
 	while ((c = r_getopt_next (&opt)) != -1) {
 		switch (c) {
 		case 'a':
@@ -76,6 +78,9 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 			break;
 		case 'o':
 			ofile = opt.arg;
+			break;
+		case 'c':
+			collision = true;
 			break;
 		case 's':
 			space = opt.arg;
@@ -153,6 +158,10 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 
 	// create zignatures
 	r_sign_all_functions (core->anal);
+
+	if (collision) {
+		r_sign_resolve_collisions (core->anal);
+	}
 
 	// write sigs to file
 	if (ofile && !r_sign_save (core->anal, ofile)) {

--- a/test/db/tools/rasign2
+++ b/test/db/tools/rasign2
@@ -104,6 +104,14 @@ spacename
 EOF
 RUN
 
+NAME=rasign2 collision check
+FILE=-
+CMDS=!!rasign2 -cr bins/elf/hello_world~sym.imp.free~ C ?
+EXPECT=<<EOF
+7
+EOF
+RUN
+
 NAME=rasign2 -f libc-v7.sig
 FILE=
 CMDS=!rasign2 -f bins/other/sigs/libc-v7.sig


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This adds the `-c` flag to rasign2 which will cause rasign2 to compute collision signatures before output.
