### PR TITLE
Force tests to run in UTC timezone ##test

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -331,6 +331,7 @@ int main(int argc, char **argv) {
 	}
 	atexit (r2r_subprocess_fini);
 
+	r_sys_setenv ("TZ", "UTC");
 	ut64 time_start = r_time_now_mono ();
 	R2RState state = {{0}};
 	state.run_config.r2_cmd = radare2_cmd ? radare2_cmd : RADARE2_CMD_DEFAULT;

--- a/test/README.md
+++ b/test/README.md
@@ -124,6 +124,7 @@ Advices
 
 * For portability reasons Do not use shell pipes, use `~`
 * dont use `pd` if not necessary, use `pi`
+* All tests use the UTC timezone for consistency.
 
 License
 -------


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

A test in `test/db/cmd/cmd_i` uses an incorrect timestamp, causing test failure.

```
$ grep timestamp test/db/cmd/cmd_i | uniq
    "timestamp": "Thu Jan  1 00:00:00 1970"
$ objdump -x test/bins/pe/standard.exe | grep 'Time/Date' | head -n1
Time/Date               Wed Dec 31 18:00:00 1969
```

Test no longer fails:

```
$ git checkout master && r2r test/db/cmd/cmd_i
...
[144/144]                 135 OK         7 BR        1 XX        1 FX
```

```
$ git checkout fix-broken-cmd_i-test && r2r test/db/cmd/cmd_i
...
[144/144]                 136 OK         7 BR        0 XX        1 FX
```