### PR TITLE
Add libr/asm/arch/arm/v35arm64/arch-arm64 to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ libr/config.h
 libr/include/r_userconf.h
 libr/include/r_version.h
 libr/include/r_version.h.tmp
+libr/asm/arch/arm/v35arm64/arch-arm64
 shlr/capstone/
 shlr/java/out
 shlr/java/out.exe


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

d1d9f7f774162e62a0c2512cd43cda8fec1793ba introduced an additional directory download during the build process which was not added to .gitignore, causing the cloned repository to show up as untracked in `git status` after building.

```
$ git checkout master
$ git status
On branch master
nothing to commit, working tree clean
$ sys/user.sh
$ git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        libr/asm/arch/arm/v35arm64/arch-arm64/

nothing added to commit but untracked files present (use "git add" to track)
```

```
$ rm -rf libr/asm/arch/arm/v35arm64/arch-arm64/
$ git checkout add-arch-arm64-dir-to-gitignore
$ git status
On branch add-arch-arm64-dir-to-gitignore
nothing to commit, working tree clean
$ sys/user.sh
$ git status
On branch add-arch-arm64-dir-to-gitignore
nothing to commit, working tree clean
```