### PR TITLE
Fix potential fault in ar ##io plugin

### DIFF
--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -35,19 +35,25 @@ static int r_io_ar_close(RIODesc *fd) {
 static RIODesc *r_io_ar_open(RIO *io, const char *file, int rw, int mode) {
 	r_return_val_if_fail (r_io_ar_plugin_open (io, file, false), NULL);
 	char *uri = strdup (file);
-	const char *arname = strstr (uri, "://") + 3;
-	char *filename = strstr (arname, "//");
-	if (filename) {
-		*filename = 0;
-		filename += 2;
+	if (!uri) {
+		return NULL;
 	}
-
-	RArFp *arf = ar_open_file (arname, filename);
 	RIODesc *res = NULL;
-	if (arf) {
-		res = r_io_desc_new (io, &r_io_plugin_ar, file, rw, mode, arf);
-		if (res) {
-			res->name = strdup (filename);
+	const char *arname = strstr (uri, "://");
+	if (arname) {
+		arname += 3;
+		char *filename = strstr (arname, "//");
+		if (filename) {
+			*filename = 0;
+			filename += 2;
+		}
+
+		RArFp *arf = ar_open_file (arname, filename);
+		if (arf) {
+			res = r_io_desc_new (io, &r_io_plugin_ar, file, rw, mode, arf);
+			if (res) {
+				res->name = strdup (filename);
+			}
 		}
 	}
 	free (uri);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Fix potential problems in ar io plugin. This handles the case where `strdup` returns `NULL` separately, just in case `strstr` can't handle `NULL` input. I did not see anything about that in the man pages.
