### PR TITLE
Fix unreleased locks

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -464,6 +464,7 @@ int main(int argc, char **argv) {
 		RThread *th = r_th_new (worker_th, &state, 0);
 		if (!th) {
 			eprintf ("Failed to start thread.\n");
+			r_th_lock_leave (state.lock);
 			exit (-1);
 		}
 		r_pvector_push (&workers, th);

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -448,6 +448,7 @@ static RThreadFunctionRet sigchld_th(RThread *th) {
 			}
 			ut8 r = 0;
 			if (write (proc->killpipe[1], &r, 1) != 1) {
+				r_th_lock_leave (subprocs_mutex);
 				break;
 			}
 		}


### PR DESCRIPTION
The lock subprocs_mutex is not released correctly when write (proc->killpipe[1], &r, 1) != 1 (the second break) in the function static RThreadFunctionRet sigchld_th(RThread *th). Also, the lock could be released before exit (-1); for better resource management and code symmetry.

This PR is to fix them. Thank you for your checking.
