### PR TITLE
Support .a files in rasign2 ##signatures

### DIFF
--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -71,40 +71,31 @@ static int signs_from_file(const char *fname, struct rasignconf *conf) {
 		eprintf ("Could not get core\n");
 		return -1;
 	}
-
 	// quiet mode
 	if (conf->quiet) {
 		r_config_set (core->config, "scr.prompt", "false");
 		r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
 	}
-
 	if (conf->space) {
 		r_spaces_set (&core->anal->zign_spaces, conf->space);
 	}
-
 	// run analysis to find functions
 	find_functions (core, conf->a_cnt);
-
 	// create zignatures
 	r_sign_all_functions (core->anal);
-
 	if (conf->collision) {
 		r_sign_resolve_collisions (core->anal);
 	}
-
 	if (conf->rad) {
 		r_sign_list (core->anal, '*');
 	}
-
 	if (conf->json) {
 		r_sign_list (core->anal, 'j');
 	}
-
 	// write sigs to file
 	if (conf->ofile && !r_sign_save (core->anal, conf->ofile)) {
 		eprintf ("Failed to write file\n");
 	}
-
 	r_cons_flush ();
 	r_core_free (core);
 	return 0;
@@ -207,8 +198,7 @@ static int handle_archive_files(const char *fname, struct rasignconf *conf) {
 R_API int r_main_rasign2(int argc, const char **argv) {
 	int c;
 	RGetopt opt;
-	struct rasignconf conf;
-	memset (&conf, 0, sizeof (struct rasignconf));
+	struct rasignconf conf = {0};
 
 	r_getopt_init (&opt, argc, argv, "Aafhjo:qrs:cv");
 	while ((c = r_getopt_next (&opt)) != -1) {
@@ -274,12 +264,12 @@ R_API int r_main_rasign2(int argc, const char **argv) {
 		if (conf.json) {
 			eprintf ("JSON does not work with .a files currently\n");
 			return -1;
-		} else if (conf.collision && conf.rad) {
+		}
+		if (conf.collision && conf.rad) {
 			eprintf ("Rasign2 can not currently handle .a files with -c and -r\n");
 			return -1;
-		} else {
-			return handle_archive_files (ifile, &conf);
 		}
+		return handle_archive_files (ifile, &conf);
 	} else {
 		return signs_from_file (ifile, &conf);
 	}

--- a/man/rasign2.1
+++ b/man/rasign2.1
@@ -15,6 +15,11 @@ radiff2 implements many binary diffing algorithms for data and code.
 .Bl -tag -width Fl
 .It Fl a
 Analyze binary after loading it with RCore and use -AA to run aaaa instead of aaa.
+.It Fl A
+Treat the provided input file as an ar archive of .o files, and create
+signatures for all functions in the .o files.
+.It Fl c
+After finding all signatures, find all signature collisions.
 .It Fl f
 Interpret the input file as a flirt database and dump the signatures.
 .It Fl h

--- a/test/db/tools/rasign2
+++ b/test/db/tools/rasign2
@@ -129,3 +129,11 @@ EXPECT=<<EOF
  0. 16 D2A2 0298 0000:__libc_start_main
 EOF
 RUN
+
+NAME=rasign2 -Ar libc-v10.sig
+FILE=
+CMDS=!!rasign2 -Ar bins/ar/libgdbr.a~ g ?
+EXPECT=<<EOF
+94
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This is a work in progress. I need to update the man page and add tests.

This is a hack to add initial support for .a (ar archive files of .o object files) to rasign2 without having openmany support in core. An even bigger hack is using a new `RCore` for each object file. But the following basic algorithm in pseudocode did not work.

```
core = r_core_new ()
for (objectfile in archive) {
    r_core_file_open (core, objectfile, 0, 0)
    r_core_bin_load (core, NULL, UT64_MAX)
   file_functions (core)
   create_signatures (core)
   r_core_file_close_all_but (core) # closes the objectfile?
}
output_signatures (core)   
```

So let me know if there is a better way. This is a stop gap until `r_core_file_open_many` is fixed anyways.