### PR TITLE
Add path to vcvarsall.bat from VS 2019 Professional

### DIFF
--- a/preconfigure.bat
+++ b/preconfigure.bat
@@ -45,19 +45,28 @@ cl --help > NUL 2> NUL
 if %ERRORLEVEL% == 0 (
   echo FOUND
 ) else (
-
-if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community" (
-  echo "Found community edition"
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
-) else (
-  if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" (
-    echo "Found Enterprise edition"
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" "x86_64"
+  if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community" (
+    echo "Found community edition"
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
   ) else (
-    echo "Not Found"
-    exit /b 1
+    if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" (
+      echo "Found Enterprise edition"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+    ) else (
+      if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat" (
+        echo "Found Professional edition"
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+      ) else (
+        if EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
+          echo "Found BuildTools"
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+        ) else (
+          echo "Not Found"
+          exit /b 1
+        )
+      )
+    )
   )
-)
 )
 
 if EXIST "libr\asm\arch\arm\v35arm64\arch-arm64" (


### PR DESCRIPTION
Currently the `preconfigure.bat` file only looks at the community edition
and the Enterprise edition of VS 2019. This change adds Professional and BuildTools 
edition to the search.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

The `preconfigure.bat` scripts is looking for a heap of tools needed in order to build radare2 on Windows. One of such tools is the [Microsoft C++ Compiler](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_file_locations) which can be included in the environment of your current console executing the `vcvarsall.bat` file. The `vcvarsall.bat` file can be located in a few different places depending on your edition of Visual Studio. This change looks at the other two default locations in addition to the two locations `preconfigure.bat` already looked.
