### PR TITLE
Fix potential NULL deref in r_cons_flush

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -978,6 +978,9 @@ R_API void r_cons_flush(void) {
 	if (I.noflush) {
 		return;
 	}
+	if (!I.context) {
+		r_cons_context_reset ();
+	}
 	if (I.context->errmode == R_CONS_ERRMODE_FLUSH) {
 		r_cons_eflush ();
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Got a segfault in `r_cons_flush` while working on a rasign2 feature. The new feature never uses `RCore` and was segfaulting when `r_cons_flush` was being executed but there was nothing to be printed. I think this is the correct fix, but I don't know r_cons well, so feel free to correct me.