### PR TITLE
Move the console flushing decision to the console context

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -116,6 +116,8 @@ static void cons_context_init(RConsContext *context, R_NULLABLE RConsContext *pa
 	context->event_interrupt_data = NULL;
 	context->pageable = true;
 	context->log_callback = NULL;
+	context->cmd_str_depth = 0;
+	context->noflush = false;
 
 	if (parent) {
 		context->color_mode = parent->color_mode;
@@ -588,7 +590,6 @@ R_API RCons *r_cons_new(void) {
 	I.force_columns = 0;
 	I.event_resize = NULL;
 	I.event_data = NULL;
-	I.noflush = false;
 	I.linesleep = 0;
 	I.fdin = stdin;
 	I.fdout = 1;
@@ -975,11 +976,11 @@ static void optimize(void) {
 
 R_API void r_cons_flush(void) {
 	const char *tee = I.teefile;
-	if (I.noflush) {
-		return;
-	}
 	if (!I.context) {
 		r_cons_context_reset ();
+	}
+	if (I.context->noflush) {
+		return;
 	}
 	if (I.context->errmode == R_CONS_ERRMODE_FLUSH) {
 		r_cons_eflush ();
@@ -1095,7 +1096,7 @@ R_API void r_cons_flush(void) {
 }
 
 R_API void r_cons_visual_flush(void) {
-	if (I.noflush) {
+	if (I.context->noflush) {
 		return;
 	}
 	r_cons_highlight (I.highlight);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5487,19 +5487,19 @@ R_API char *r_core_cmd_strf(RCore *core, const char *fmt, ...) {
 /* return: pointer to a buffer with the output of the command */
 R_API char *r_core_cmd_str(RCore *core, const char *cmd) {
 	r_cons_push ();
-	r_cons_singleton ()->noflush = true;
-	core->in_cmdstr++;
+	core->cons->context->noflush = true;
+	core->cons->context->cmd_str_depth++;
 	if (r_core_cmd (core, cmd, 0) == -1) {
 		//eprintf ("Invalid command: %s\n", cmd);
-		if (--core->in_cmdstr == 0) {
-			r_cons_singleton ()->noflush = false;
+		if (--core->cons->context->cmd_str_depth == 0) {
+			core->cons->context->noflush = false;
 			r_cons_flush ();
 		}
 		r_cons_pop ();
 		return NULL;
 	}
-	if (--core->in_cmdstr == 0) {
-		r_cons_singleton ()->noflush = false;
+	if (--core->cons->context->cmd_str_depth == 0) {
+		core->cons->context->noflush = false;
 	}
 	r_cons_filter ();
 	const char *static_str = r_cons_get_buffer ();

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4103,7 +4103,7 @@ static void visual_refresh(RCore *core) {
 	}
 	r_cons_flush ();
 	r_cons_print_clear ();
-	r_cons_singleton ()->noflush = true;
+	core->cons->context->noflush = true;
 
 	int hex_cols = r_config_get_i (core->config, "hex.cols");
 	int split_w = 12 + 4 + hex_cols + (hex_cols * 3);
@@ -4201,7 +4201,7 @@ static void visual_refresh(RCore *core) {
 	}
 #endif
 	blocksize = core->num->value? core->num->value: core->blocksize;
-	r_cons_singleton ()->noflush = false;
+	core->cons->context->noflush = false;
 	/* this is why there's flickering */
 	if (core->print->vflush) {
 		r_cons_visual_flush ();

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -394,6 +394,8 @@ typedef struct r_cons_context_t {
 	RConsEvent event_interrupt;
 	void *event_interrupt_data;
 	int cmd_depth;
+	int cmd_str_depth;
+	bool noflush;
 
 	// Used for per-task logging redirection
 	RLogCallback log_callback; // TODO: RList of callbacks
@@ -436,7 +438,6 @@ typedef struct r_cons_t {
 	int fix_rows;
 	int fix_columns;
 	bool break_lines;
-	int noflush;
 	int optimize;
 	bool show_autocomplete_widget;
 	FILE *fdin; // FILE? and then int ??

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -350,7 +350,6 @@ struct r_core_t {
 	bool log_events; // core.c:cb_event_handler : log actions from events if cfg.log.events is set
 	RList *ropchain;
 	char *theme;
-	int in_cmdstr;
 	bool marks_init;
 	ut64 marks[UT8_MAX + 1];
 


### PR DESCRIPTION
When a server is started as a background task, the console will remain silent until the server stops. This is undesirable because the intent of running the server in the background is to be able to keep working in radare while the server is running.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #19118
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)
