### PR TITLE
Minor refactors in disasm.c, primarily r_core_print_disasm() ##refactor ##asm

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4150,7 +4150,12 @@ static void pr_bb(RCore *core, RAnalFunction *fcn, RAnalBlock *b, bool emu, ut64
 		r_cons_printf ("Failed to allocate %"PFMT64u" bytes", b->size);
 		return;
 	}
-	r_io_nread_at (core->io, b->addr, buf, b->size);
+
+	if (r_io_nread_at (core->io, b->addr, buf, b->size) < 0) {
+		r_cons_printf ("Failed to read %" PFMT64u " bytes at 0x%" PFMT64x "\n",
+				b->size, b->addr);
+		return;
+	}
 
 	// currently need to use a hack argument because this code relied on
 	// pD/pI incorrectly stopping at the block boundary


### PR DESCRIPTION
* Rename locals and struct members to be consistent with new function signature
* Remove some duplicate locals and replace with struct members
* Move loop counters to loop scope and remove unused counters
* Move variable declarations and assignments to more relevant locations
* Collapse several nested, confusing, or redundant logic branches
* Add ds_offset(), ds_bufat(), and ds_left() macros to consistently track buffer information
* Add error handling to r_io_nread_at() call in cmd_print.c
* Change formatting

**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

Follow-up to https://github.com/radareorg/radare2/pull/19112, which was slightly rushed to make the 5.4.2 release. All functionality changes were made there, but there was not enough time to do some desired refactoring. Many of the most confusing points and sharp edges have been amended, though there is still some degree of data duplication which I just papered over by ensuring it's always tracked in the disasm state.

These changes will ease a future rewrite to improve this API.