### PR TITLE
Rename MD5 symbols to prevent OpenSSL collision

### DIFF
--- a/libr/hash/md5.c
+++ b/libr/hash/md5.c
@@ -171,7 +171,7 @@ static const ut8 PADDING[64] = {
 };
 
 /* MD5 initialization. Begins an MD5 operation, writing a new context */
-void MD5_Init(R_MD5_CTX *context) {
+void r_MD5_Init(R_MD5_CTX *context) {
 	if (context) {
 		context->count[0] = context->count[1] = 0;
 		context->state[0] = 0x67452301;
@@ -183,7 +183,7 @@ void MD5_Init(R_MD5_CTX *context) {
 
 /* MD5 block update operation. Continues an MD5 message-digest operation,
  * processing another message block, and updating the context */
-void MD5_Update(R_MD5_CTX *context, const ut8 *input, ut32 inputLen) {
+void r_MD5_Update(R_MD5_CTX *context, const ut8 *input, ut32 inputLen) {
 	ut32 i;
 
 	/* Compute number of bytes mod 64 */
@@ -212,7 +212,7 @@ void MD5_Update(R_MD5_CTX *context, const ut8 *input, ut32 inputLen) {
 	memmove ((void*)&context->buffer[index], (void*)&input[i], inputLen - i);
 }
 
-void MD5_Final(ut8 digest[16], R_MD5_CTX *context) {
+void r_MD5_Final(ut8 digest[16], R_MD5_CTX *context) {
 	ut8 bits[8];
 
 	/* Save number of bits */
@@ -221,10 +221,10 @@ void MD5_Final(ut8 digest[16], R_MD5_CTX *context) {
 	/* Pad out to 56 mod 64.  */
 	ut32 index = (ut32)((context->count[0] >> 3) & 0x3f);
 	ut32 padLen = (index < 56) ? (56 - index) : (120 - index);
-	MD5_Update (context, PADDING, padLen);
+	r_MD5_Update (context, PADDING, padLen);
 
 	/* Append length (before padding) */
-	MD5_Update (context, bits, 8);
+	r_MD5_Update (context, bits, 8);
 
 	/* Store state in digest */
 	Encode (digest, context->state, 16);

--- a/libr/hash/md5.h
+++ b/libr/hash/md5.h
@@ -1,8 +1,8 @@
 #ifndef _R_MD5_H
 #define _R_MD5_H
 
-void MD5_Init(MD5_CTX *);
-void MD5_Update(MD5_CTX *, const ut8*, unsigned int);
-void MD5_Final(ut8 [16], MD5_CTX *);
+void r_MD5_Init(MD5_CTX *);
+void r_MD5_Update(MD5_CTX *, const ut8*, unsigned int);
+void r_MD5_Final(ut8 [16], MD5_CTX *);
 
 #endif

--- a/libr/hash/state.c
+++ b/libr/hash/state.c
@@ -25,6 +25,10 @@
 #  define r_SHA512_Init         SHA512_Init
 #  define r_SHA512_Update       SHA512_Update
 #  define r_SHA512_Final        SHA512_Final
+
+#  define r_MD5_Init            MD5_Init
+#  define r_MD5_Update          MD5_Update
+#  define r_MD5_Final           MD5_Final
 #else
 #include "md4.h"
 #include "md5.h"
@@ -136,22 +140,22 @@ R_API ut8 *r_hash_do_sha512(RHash *ctx, const ut8 *input, int len) {
 R_API ut8 *r_hash_do_md5(RHash *ctx, const ut8 *input, int len) {
 	if (len < 0) {
 		if (len == -1) {
-			MD5_Init (&ctx->md5);
+			r_MD5_Init (&ctx->md5);
 		} else if (len == -2) {
-			MD5_Final (ctx->digest, &ctx->md5);
+			r_MD5_Final (ctx->digest, &ctx->md5);
 		}
 		return NULL;
 	}
 	if (ctx->rst) {
-		MD5_Init (&ctx->md5);
+		r_MD5_Init (&ctx->md5);
 	}
 	if (len > 0) {
-		MD5_Update (&ctx->md5, input, len);
+		r_MD5_Update (&ctx->md5, input, len);
 	} else {
-		MD5_Update (&ctx->md5, (const ut8 *) "", 0);
+		r_MD5_Update (&ctx->md5, (const ut8 *) "", 0);
 	}
 	if (ctx->rst) {
-		MD5_Final (ctx->digest, &ctx->md5);
+		r_MD5_Final (ctx->digest, &ctx->md5);
 	}
 	return ctx->digest;
 }


### PR DESCRIPTION
The other symbols (e.g. SHA1) are renamed with a r_ prefix, but the
MD5 symbols are not.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
