### PR TITLE
Use non-interactive RCore in rasign2 -S

### DIFF
--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -34,7 +34,7 @@ static RCore *opencore(const char *fname) {
 		return NULL;
 	}
 	r_core_loadlibs (c, R_CORE_LOADLIBS_ALL, NULL);
-	r_config_set_i (c->config, "scr.interactive", false);
+	r_config_set_b (c->config, "scr.interactive", false);
 	if (fname) {
 #if __WINDOWS__
 		char *winf = r_acp_to_utf8 (fname);
@@ -90,7 +90,7 @@ static int handle_sdb(const char *fname, struct rasignconf *conf) {
 	// can't use RAnal here because JSON output requires core, in a sneaky way
 	RCore *core = r_core_new ();
 	if (core && r_sign_load (core->anal, fname)) {
-		r_config_set_i (core->config, "scr.interactive", false);
+		r_config_set_b (core->config, "scr.interactive", false);
 		if (conf->collision) {
 			r_sign_resolve_collisions (core->anal);
 		}

--- a/libr/main/rasign2.c
+++ b/libr/main/rasign2.c
@@ -90,6 +90,7 @@ static int handle_sdb(const char *fname, struct rasignconf *conf) {
 	// can't use RAnal here because JSON output requires core, in a sneaky way
 	RCore *core = r_core_new ();
 	if (core && r_sign_load (core->anal, fname)) {
+		r_config_set_i (core->config, "scr.interactive", false);
 		if (conf->collision) {
 			r_sign_resolve_collisions (core->anal);
 		}
@@ -139,7 +140,7 @@ static RList *get_ar_file_uris(const char *fname) {
 		return NULL;
 	}
 	RList *uris = r_list_newf (free);
-	RList *list_fds = r_io_open_many (io, allfiles, 0, 0444);
+	RList *list_fds = r_io_open_many (io, allfiles, 0, 0);
 	free (allfiles);
 
 	bool fail = false;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Noticed on larger signature files that `rasign2 -S` would prompt and mess up the terminal. This should fix that.

I also notices rasig2 couldn't open /usr/libx32/libc.a even though it has 0644 perms. So I tried to change flags on the open command but it didn't work... I will look into it more later.
