### PR TITLE
Scan with FLIRT regardless of the function being unknown

### DIFF
--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -669,10 +669,6 @@ static int node_match_functions(RAnal *anal, const RFlirtNode *root_node) {
 	RListIter *it_func;
 	RAnalFunction *func;
 	r_list_foreach (anal->fcns, it_func, func) {
-		if (func->type != R_ANAL_FCN_TYPE_FCN && func->type != R_ANAL_FCN_TYPE_LOC) { // scan only for unknown functions
-			continue;
-		}
-
 		ut64 func_size = r_anal_function_linear_size (func);
 		ut8 *func_buf = malloc (func_size);
 		if (!func_buf) {


### PR DESCRIPTION

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

FLIRT does not run over functions that have debugging symbols. Even if the function has said symbols FLIRT scanning can still be useful, hence I'm uncommenting the check.
