### PR TITLE
Show instruction and bytes when failing asm tests ##tests

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -82,8 +82,8 @@ static int help(bool verbose) {
 		"\n"
 		"R2R_SKIP_ARCHOS=1  # do not run the arch-os-specific tests\n"
 		"R2R_SKIP_JSON=1    # do not run the JSON tests\n"
-		"R2R_SKIP_FUZZ=1     # do not run the rasm2 tests\n"
-		"R2R_SKIP_UNIT=1     # do not run the rasm2 tests\n"
+		"R2R_SKIP_FUZZ=1    # do not run the rasm2 tests\n"
+		"R2R_SKIP_UNIT=1    # do not run the rasm2 tests\n"
 		"R2R_SKIP_CMD=1     # do not run the rasm2 tests\n"
 		"R2R_SKIP_ASM=1     # do not run the rasm2 tests\n"
 		"\n"
@@ -230,8 +230,10 @@ int main(int argc, char **argv) {
 				printf (R2_VERSION "\n");
 			} else {
 				char *s = r_str_version ("r2r");
-				printf ("%s\n", s);
-				free (s);
+				if (s) {
+					printf ("%s\n", s);
+					free (s);
+				}
 			}
 			return 0;
 		case 'V':

--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -1110,7 +1110,7 @@ R_API bool r2r_check_asm_test(R2RAsmTestOutput *out, R2RAsmTest *test) {
 		if (!out->bytes || !test->bytes || out->bytes_size != test->bytes_size || out->as_timeout) {
 			return false;
 		}
-		if (memcmp (out->bytes, test->bytes, test->bytes_size) != 0) {
+		if (memcmp (out->bytes, test->bytes, test->bytes_size)) {
 			return false;
 		}
 	}
@@ -1118,7 +1118,7 @@ R_API bool r2r_check_asm_test(R2RAsmTestOutput *out, R2RAsmTest *test) {
 		if (!out->disasm || !test->disasm || out->as_timeout) {
 			return false;
 		}
-		if (strcmp (out->disasm, test->disasm) != 0) {
+		if (strcmp (out->disasm, test->disasm)) {
 			return false;
 		}
 	}
@@ -1210,9 +1210,19 @@ R_API R2RTestResultInfo *r2r_run_test(R2RRunConfig *config, R2RTest *test) {
 			success = true;
 			ret->run_failed = false;
 		} else {
-			R2RAsmTest *asm_test = test->asm_test;
-			R2RAsmTestOutput *out = r2r_run_asm_test (config, asm_test);
-			success = r2r_check_asm_test (out, asm_test);
+			R2RAsmTest *at = test->asm_test;
+			R2RAsmTestOutput *out = r2r_run_asm_test (config, at);
+			success = r2r_check_asm_test (out, at);
+			if (!success) {
+				eprintf ("\n");
+				eprintf ("[rasm2:error] code: %s vs %s\n", at->disasm, out->disasm);
+				char *b0 = r_hex_bin2strdup (at->bytes, at->bytes_size);
+				char *b1 = r_hex_bin2strdup (out->bytes, out->bytes_size);
+				eprintf ("[rasm2:error] data: %s vs %s\n", b0, b1);
+				free (b0);
+				free (b1);
+			}
+			// TODO: show more details of the failed assembled instruction
 			ret->asm_out = out;
 			ret->timeout = out->as_timeout || out->disas_timeout;
 			ret->run_failed = !out;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
