### PR TITLE
FIX #19149: Prevent NULL pointer dereference in line_header_fini()

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -612,6 +612,7 @@ static const ut8 *parse_line_header (
 	hdr->line_range = READ8 (buf);
 	hdr->opcode_base = READ8 (buf);
 
+	hdr->file_names_count = 0;
 	hdr->file_names = NULL;
 
 	if (mode == R_MODE_PRINT) {


### PR DESCRIPTION
hdr->file_names is set to NULL.
However, the corresponding count variable is not set to zero.
It might stay on a non-zero value and
cause the code in line_header_fini() to dereference the NULL pointer.

Setting hdr->file_names_count to zero solves that issue.

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #19149
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
