### PR TITLE
Add r_core_cmd_tobuf() and overhaul alias system

### DIFF
--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2009-2021 - pancake */
 
 #include <r_core.h>
+#include "ht_pp.h"
 
 /*!
  * Number of sub-commands to show as options when displaying the help of a
@@ -101,9 +102,7 @@ err:
 }
 
 R_API void r_cmd_alias_init(RCmd *cmd) {
-	cmd->aliases.count = 0;
-	cmd->aliases.keys = NULL;
-	cmd->aliases.values = NULL;
+	cmd->aliases = ht_pp_new0 ();
 }
 
 R_API RCmd *r_cmd_new(void) {
@@ -185,114 +184,219 @@ out:
 	return res;
 }
 
-R_API char **r_cmd_alias_keys(RCmd *cmd, int *sz) {
-	if (sz) {
-		*sz = cmd->aliases.count;
-	}
-	return cmd->aliases.keys;
+static bool get_keys(void *keylist_in, const void *k, const void *v) {
+	RList *keylist = (RList *) keylist_in;
+	return r_list_append (keylist, (char *) k);
 }
 
-R_API void r_cmd_alias_free (RCmd *cmd) {
-	int i; // find
-	for (i = 0; i < cmd->aliases.count; i++) {
-		free (cmd->aliases.keys[i]);
-		free (cmd->aliases.values[i]);
+R_API RList *r_cmd_alias_keys(RCmd *cmd) {
+	RList *keylist = r_list_new ();
+	if (!keylist) {
+		return NULL;
 	}
-	cmd->aliases.count = 0;
-	R_FREE (cmd->aliases.keys);
-	R_FREE (cmd->aliases.values);
-	free (cmd->aliases.remote);
+
+	ht_pp_foreach (cmd->aliases, get_keys, keylist);
+
+	return keylist;
 }
 
-R_API bool r_cmd_alias_del (RCmd *cmd, const char *k) {
-	int i; // find
-	for (i = 0; i < cmd->aliases.count; i++) {
-		if (!k || !strcmp (k, cmd->aliases.keys[i])) {
-			R_FREE (cmd->aliases.values[i]);
-			cmd->aliases.count--;
-			if (cmd->aliases.count > 0) {
-				if (i > 0) {
-					free (cmd->aliases.keys[i]);
-					cmd->aliases.keys[i] = cmd->aliases.keys[0];
-					free (cmd->aliases.values[i]);
-					cmd->aliases.values[i] = cmd->aliases.values[0];
-				}
-				memmove (cmd->aliases.values,
-					cmd->aliases.values + 1,
-					cmd->aliases.count * sizeof (void*));
-				memmove (cmd->aliases.keys,
-					cmd->aliases.keys + 1,
-					cmd->aliases.count * sizeof (void*));
-			}
-			return true;
+R_API void r_cmd_alias_free(RCmd *cmd) {
+	ht_pp_free (cmd->aliases);
+	cmd->aliases = NULL;
+}
+
+R_API bool r_cmd_alias_del(RCmd *cmd, const char *k) {
+	return ht_pp_delete(cmd->aliases, k);
+}
+
+R_API int r_cmd_alias_set_cmd(RCmd *cmd, const char *k, const char *v) {
+	RCmdAliasVal *val = R_NEW (RCmdAliasVal);
+	val->data = (ut8 *) strdup (v);
+	val->sz = strlen (v) + 1;
+	val->is_str = true;
+	val->is_data = false;
+
+	return ht_pp_update (cmd->aliases, strdup (k), val);
+}
+
+R_API int r_cmd_alias_set_str(RCmd *cmd, const char *k, const char *v) {
+	RCmdAliasVal *val = R_NEW (RCmdAliasVal);
+	val->data = (ut8 *) strdup (v);
+	val->is_str = true;
+	val->is_data = true;
+
+	/* No trailing newline */
+	int len = strlen (v);
+	while (len-- > 0) {
+		if (v[len] == '\r' || v[len] == '\n') {
+			val->data[len] = '\0';
+		} else {
+			break;
 		}
 	}
-	return false;
+	val->sz = len+1;
+
+	return ht_pp_update (cmd->aliases, strdup (k), val);
 }
 
-// XXX: use a hashtable or any other standard data structure
-R_API int r_cmd_alias_set(RCmd *cmd, const char *k, const char *v, int remote) {
-	void *tofree = NULL;
-	if (!strncmp (v, "base64:", 7)) {
-		ut8 *s = r_base64_decode_dyn (v + 7, -1);
-		if (s) {
-			tofree = s;
-			v = (const char *)s;
-		}
-	}
+R_API int r_cmd_alias_set_raw(RCmd *cmd, const char *k, const ut8 *v, int sz) {
 	int i;
-	for (i = 0; i < cmd->aliases.count; i++) {
-		int matches = !strcmp (k, cmd->aliases.keys[i]);
-		if (matches) {
-			free (cmd->aliases.values[i]);
-			cmd->aliases.values[i] = strdup (v);
-			free (tofree);
+
+	if (sz < 1) {
+		return 1;
+	}
+
+	RCmdAliasVal *val = R_NEW (RCmdAliasVal);
+	if (!val) {
+		return 1;
+	}
+
+	val->data = malloc (sz);
+	if (!val->data) {
+		free (val);
+		return 1;
+	}
+
+	memcpy (val->data, v, sz);
+	val->sz = sz;
+
+	/* If it's a string already, we speed things up later by checking now */
+	const ut8 *firstnull = NULL;
+	for (i = 0; i < sz; i++) {
+		/* \0 before expected -> not string */
+		if (v[i] == '\0') {
+			firstnull = &v[i];
+			break;
+		}
+	}
+
+	if (firstnull && firstnull == &v[sz-1]) {
+		/* Data is already a string */
+		val->is_str = true;
+	} else if (!firstnull) {
+		/* Data is an unterminated string */
+		val->sz++;
+		val->data = realloc(val->data, val->sz);
+		if (!val->data) {
+			free (val);
 			return 1;
 		}
+		val->data[val->sz-1] = '\0';
+		val->is_str = true;
+	} else {
+		val->is_str = false;
 	}
 
-	i = cmd->aliases.count++;
-	char **K = (char **)realloc (cmd->aliases.keys,
-				     sizeof (char *) * cmd->aliases.count);
-	if (K) {
-		cmd->aliases.keys = K;
-		int *R = (int *)realloc (cmd->aliases.remote,
-				sizeof (int) * cmd->aliases.count);
-		if (R) {
-			cmd->aliases.remote = R;
-			char **V = (char **)realloc (cmd->aliases.values,
-					sizeof (char *) * cmd->aliases.count);
-			if (V) {
-				cmd->aliases.values = V;
-				cmd->aliases.keys[i] = strdup (k);
-				cmd->aliases.values[i] = strdup (v);
-				cmd->aliases.remote[i] = remote;
+	val->is_data = true;
+
+	if (val->is_str) {
+		/* No trailing newline */
+		int len = val->sz - 1;
+		while (len-- > 0) {
+			if (v[len] == '\r' || v[len] == '\n') {
+				val->data[len] = '\0';
+			} else {
+				break;
 			}
 		}
+		val->sz = len+1;
 	}
-	free (tofree);
+
+	return ht_pp_update (cmd->aliases, strdup (k), val);
+}
+
+R_API RCmdAliasVal *r_cmd_alias_get(RCmd *cmd, const char *k) {
+	r_return_val_if_fail (cmd && cmd->aliases && k, NULL);
+
+	bool found;
+	RCmdAliasVal *v = ht_pp_find(cmd->aliases, k, &found);
+	return found? v: NULL;
+}
+
+static ut8 *alias_append_internal(int *out_szp, const RCmdAliasVal *first, const ut8 *second, int second_sz) {
+	ut8* out;
+	int out_sz;
+
+	/* If appending to a string, always overwrite the trailing \0 */
+	int bytes_from_first = first->is_str
+		? first->sz - 1
+		: first->sz;
+
+	out_sz = bytes_from_first + second_sz;
+	out = malloc (out_sz);
+	if (!out) {
+		return NULL;
+	}
+
+	/* Copy full buffer if raw bytes. Stop before \0 if string. */
+	memcpy (out, first->data, bytes_from_first);
+	/* Always copy all bytes from second, including trailing \0 */
+	memcpy (out+bytes_from_first, second, second_sz);
+
+	if (out_sz) {
+		*out_szp = out_sz;
+	}
+	return out;
+}
+
+R_API int r_cmd_alias_append_str(RCmd *cmd, const char *k, const char *a) {
+	RCmdAliasVal *v_old = r_cmd_alias_get (cmd, k);
+	if (v_old) {
+		if (!v_old->is_data) {
+			return 1;
+		}
+
+		int new_len;
+		ut8* new = alias_append_internal (&new_len, v_old, (ut8 *)a, strlen (a) + 1);
+
+		if (!new) {
+			return 1;
+		}
+
+		r_cmd_alias_set_raw (cmd, k, new, new_len);
+		free (new);
+	} else {
+		r_cmd_alias_set_str (cmd, k, a);
+	}
+
 	return 0;
 }
 
-R_API const char *r_cmd_alias_get(RCmd *cmd, const char *k, int remote) {
-	r_return_val_if_fail (cmd && k, NULL);
-	int matches, i;
-	// TODO: use a hashtable
-	for (i = 0; i < cmd->aliases.count; i++) {
-		matches = 0;
-		if (remote) {
-			if (cmd->aliases.remote[i]) {
-				matches = !strncmp (k, cmd->aliases.keys[i],
-					strlen (cmd->aliases.keys[i]));
-			}
-		} else {
-			matches = !strcmp (k, cmd->aliases.keys[i]);
+R_API int r_cmd_alias_append_raw(RCmd *cmd, const char *k, const ut8 *a, int sz) {
+	RCmdAliasVal *v_old = r_cmd_alias_get (cmd, k);
+	if (v_old) {
+		if (!v_old->is_data) {
+			return 1;
 		}
-		if (matches) {
-			return cmd->aliases.values[i];
-		}
+
+		int new_len;
+		ut8 *new = alias_append_internal (&new_len, v_old, a, sz);
+
+		r_cmd_alias_set_raw (cmd, k, new, new_len);
+		free (new);
+	} else {
+		r_cmd_alias_set_raw (cmd, k, a, sz);
 	}
-	return NULL;
+
+	return 0;
+}
+
+/* Returns a new copy of v->data. If !v->is_str, hex escaped */
+R_API char *r_cmd_alias_val_strdup(RCmdAliasVal *v) {
+	if (v->is_str) {
+		return strdup ((char *)v->data);
+	}
+
+	return r_str_escape_raw (v->data, v->sz);
+}
+
+/* Returns a new copy of v->data. If !v->is_str, b64 encoded. */
+R_API char *r_cmd_alias_val_strdup_b64(RCmdAliasVal *v) {
+	if (v->is_str) {
+		return strdup ((char *)v->data);
+	}
+
+	return r_base64_encode_dyn ((char *)v->data, v->sz);
 }
 
 R_API void r_cmd_set_data(RCmd *cmd, void *data) {
@@ -328,15 +432,12 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 		}
 	} else {
 		char *nstr = NULL;
-		const char *ji = r_cmd_alias_get (cmd, input, 1);
-		if (ji) {
-			if (*ji == '$') {
-				r_cons_strcat (ji + 1);
-				return true;
-			} else {
-				nstr = r_str_newf ("=!%s", input);
-				input = nstr;
-			}
+		RCmdAliasVal *v = r_cmd_alias_get (cmd, input);
+		if (v && v->is_data) {
+			char *v_str = r_cmd_alias_val_strdup (v);
+			r_cons_strcat (v_str);
+			free (v_str);
+			return true;
 		}
 		r_list_foreach (cmd->plist, iter, cp) {
 			if (cp->call && cp->call (cmd->data, input)) {

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -560,9 +560,13 @@ static int cmd_cmp(void *data, const char *input) {
 		if (input[1] == 't') {
 			const char *path = r_str_trim_head_ro (input + 2);
 			if (*path == '$') {
-				const char *oldText = r_cmd_alias_get (core->rcmd, path, 1);
-				if (oldText) {
-					r_cons_printf ("%s\n", oldText + 1);
+				RCmdAliasVal *v = r_cmd_alias_get (core->rcmd, path+1);
+				if (v) {
+					char *v_str = r_cmd_alias_val_strdup (v);
+					r_cons_println (v_str);
+					free (v_str);
+				} else {
+					eprintf ("No such alias \"$%s\"\n", path+1);
 				}
 			} else {
 				if (r_fs_check (core->fs, path)) {

--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -4,6 +4,7 @@
 #include <r_types.h>
 #include <r_util.h>
 #include <r_bind.h>
+#include "ht_pp.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,12 +69,14 @@ typedef struct r_cmd_item_t {
 	RCmdCb callback;
 } RCmdItem;
 
-typedef struct r_cmd_alias_t {
-	int count;
-	char **keys;
-	char **values;
-	int *remote;
-} RCmdAlias;
+typedef HtPP *RCmdAlias;
+
+typedef struct r_cmd_alias_val_t {
+	ut8 *data; // The actual value buffer
+	int sz; // Buffer size
+	bool is_str; // Is the buffer string-safe? (i.e. strlen(v) == sz-1. dont strlen if this isnt set)
+	bool is_data; // Is the buffer data or a command? (if false, is_str must be true - commands can't be raw)
+} RCmdAliasVal;
 
 typedef struct r_cmd_desc_example_t {
 	const char *example;
@@ -283,9 +286,15 @@ R_API int r_cmd_macro_call(RCmdMacro *mac, const char *name);
 R_API int r_cmd_macro_break(RCmdMacro *mac, const char *value);
 
 R_API bool r_cmd_alias_del(RCmd *cmd, const char *k);
-R_API char **r_cmd_alias_keys(RCmd *cmd, int *sz);
-R_API int r_cmd_alias_set(RCmd *cmd, const char *k, const char *v, int remote);
-R_API const char *r_cmd_alias_get(RCmd *cmd, const char *k, int remote);
+R_API RList *r_cmd_alias_keys(RCmd *cmd);
+R_API int r_cmd_alias_set_cmd(RCmd *cmd, const char *k, const char *v);
+R_API int r_cmd_alias_set_str(RCmd *cmd, const char *k, const char *v);
+R_API int r_cmd_alias_set_raw(RCmd *cmd, const char *k, const ut8 *v, int sz);
+R_API RCmdAliasVal *r_cmd_alias_get(RCmd *cmd, const char *k);
+R_API int r_cmd_alias_append_str(RCmd *cmd, const char *k, const char *a);
+R_API int r_cmd_alias_append_raw(RCmd *cmd, const char *k, const ut8 *a, int sz);
+R_API char *r_cmd_alias_val_strdup(RCmdAliasVal *v);
+R_API char *r_cmd_alias_val_strdup_b64(RCmdAliasVal *v);
 R_API void r_cmd_alias_free(RCmd *cmd);
 R_API void r_cmd_macro_fini(RCmdMacro *mac);
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -433,6 +433,7 @@ R_API int r_core_cmd_pipe(RCore *core, char *radare_cmd, char *shell_cmd);
 R_API char *r_core_cmd_str(RCore *core, const char *cmd);
 R_API char *r_core_cmd_strf(RCore *core, const char *fmt, ...) R_PRINTF_CHECK(2, 3);
 R_API char *r_core_cmd_str_pipe(RCore *core, const char *cmd);
+R_API RBuffer *r_core_cmd_tobuf(RCore *core, const char *cmd);
 R_API int r_core_cmd_file(RCore *core, const char *file);
 R_API int r_core_cmd_lines(RCore *core, const char *lines);
 R_API int r_core_cmd_command(RCore *core, const char *command);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -188,6 +188,7 @@ R_API int r_str_path_unescape(char *path);
 R_API char *r_str_path_escape(const char *path);
 R_API int r_str_unescape(char *buf);
 R_API char *r_str_sanitize_r2(const char *buf);
+R_API char *r_str_escape_raw(const ut8 *buf, int sz);
 R_API char *r_str_escape(const char *buf);
 R_API char *r_str_escape_sh(const char *buf);
 R_API char *r_str_escape_sql(const char *buf);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1381,6 +1381,24 @@ out:
 	return new_buf;
 }
 
+/* hex-escape unprintable characters in a raw buffer (null-safe) */
+R_API char *r_str_escape_raw(const ut8 *buf, int sz) {
+	r_return_val_if_fail (buf, NULL);
+
+	/* Worst case scenario, we convert every byte to a \xhh escape */
+	char *new_buf = malloc (1 + sz * 4);
+	if (!new_buf) {
+		return NULL;
+	}
+	char *q = new_buf;
+	int i;
+	for (i = 0; i < sz; i++) {
+		r_str_byte_escape ((char *)&buf[i], &q, false, false, true);
+	}
+	*q = '\0';
+	return new_buf;
+}
+
 R_API char *r_str_escape(const char *buf) {
 	return r_str_escape_ (buf, false, true, true, false, true);
 }

--- a/test/db/cmd/cmd_alias
+++ b/test/db/cmd/cmd_alias
@@ -57,3 +57,88 @@ EXPECT=<<EOF
 $foo
 EOF
 RUN
+
+NAME=grep $alias
+FILE=-
+CMDS=<<EOF
+wx 9090909090
+pd 5~?
+pd 5~:..2 >$a
+$a~?
+EOF
+EXPECT=<<EOF
+5
+2
+EOF
+RUN
+
+NAME=cat $alias
+FILE=-
+CMDS=<<EOF
+echo test data >$a
+cat $a
+EOF
+EXPECT=<<EOF
+test data
+EOF
+RUN
+
+NAME=$alias types, setting, and printing
+FILE=-
+CMDS=<<EOF
+wx 4141414100
+ps >$str_redirect_alias
+$str_set_alias=$BBBB
+wx 430043004300
+pr 6 >$bytes_redirect_alias
+$bytes_set_alias=$D\\x00D\\x00D\\x00
+$bytes_decode_alias=base64:RQBFAEUA
+
+$*
+?e -----
+$**
+EOF
+EXPECT=<<EOF
+$bytes_redirect_alias=C\x00C\x00C\x00
+$str_set_alias=BBBB
+$str_redirect_alias=AAAA
+$bytes_set_alias=D\x00D\x00D\x00
+$bytes_decode_alias=E\x00E\x00E\x00
+-----
+$bytes_redirect_alias=base64:QwBDAEMA
+$str_set_alias=BBBB
+$str_redirect_alias=AAAA
+$bytes_set_alias=base64:RABEAEQA
+$bytes_decode_alias=base64:RQBFAEUA
+EOF
+RUN
+
+NAME=dont append to cmd $alias
+FILE=-
+CMDS=<<EOF
+$a=af
+$*
+pr >> $a
+$*
+EOF
+EXPECT=<<EOF
+$a=af
+$a=af
+EOF
+RUN
+
+NAME=show commands $aliases
+FILE=-
+CMDS=<<EOF
+$a=pd
+$b=pD
+$c=$text
+$a?
+$b?
+$c?
+EOF
+EXPECT=<<EOF
+pd
+pD
+EOF
+RUN

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -39,7 +39,7 @@ CMDS=<<EOF
 b 6
 w hello world
 ps
-wtf $jej
+wtf $jeje
 w xxxxx_xxxxx
 wff $jeje
 ps


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)

**Description**

The alias system up to this point has been pretty bare-bones and stored as string arrays, leading to slow lookups and incorrect behavior with commands that use raw bytes like `pr`. Aliases are now stored in a hashtable mapping a string key to a structure with a data buffer, size, string flag, and command flag. Aliases can now store both strings and raw bytes. To support this, API functions have been added for running commands and getting the raw output, and escaping unprintable characters in a buffer. The alias API is also greatly expanded, making it easier to work with in the future.