### PR TITLE
Improve alias string detection

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3723,6 +3723,7 @@ escape_pipe:
 			// pipe to alias variable
 			// register output of command as an alias
 
+			r_config_set_i (core->config, "scr.color", COLOR_MODE_DISABLED);
 			RBuffer *cmd_out = r_core_cmd_tobuf (core, cmd);
 			int alias_len;
 			ut8 *alias_data = r_buf_read_all (cmd_out, &alias_len);

--- a/test/db/cmd/cmd_alias
+++ b/test/db/cmd/cmd_alias
@@ -93,6 +93,8 @@ wx 430043004300
 pr 6 >$bytes_redirect_alias
 $bytes_set_alias=$D\\x00D\\x00D\\x00
 $bytes_decode_alias=base64:RQBFAEUA
+wx 909090
+pr 3 >$bytes_unterminated_alias
 
 $*
 ?e -----
@@ -101,12 +103,14 @@ EOF
 EXPECT=<<EOF
 $bytes_redirect_alias=C\x00C\x00C\x00
 $str_set_alias=BBBB
+$bytes_unterminated_alias=\x90\x90\x90
 $str_redirect_alias=AAAA
 $bytes_set_alias=D\x00D\x00D\x00
 $bytes_decode_alias=E\x00E\x00E\x00
 -----
 $bytes_redirect_alias=base64:QwBDAEMA
 $str_set_alias=BBBB
+$bytes_unterminated_alias=base64:kJCQ
 $str_redirect_alias=AAAA
 $bytes_set_alias=base64:RABEAEQA
 $bytes_decode_alias=base64:RQBFAEUA


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)

**Description**

Alias string detection now considers presence of non-ASCII characters in addition to null byte locations when determining if data is an unterminated string. e.g. `\x90\x90\x90` is no longer incorrectly considered an unterminated string. Didn't get picked up by other tests because they contained nulls, which caused the string detection to recognize that they were bytes.