### PR TITLE
Mark fixed tests as not broken and change incorrect x86_32 tests

### DIFF
--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -212,7 +212,6 @@ RUN
 
 NAME=ARM32 bb 0 size -- a2f
 FILE=malloc://32
-BROKEN=1
 CMDS=<<EOF
 wx ff0000e2010050e30000001affffffea70009de594008de5e4139fe500f09ee5
 e asm.arch=arm

--- a/test/db/asm/arm_32
+++ b/test/db/asm/arm_32
@@ -66,7 +66,7 @@ a "popeq {r4, r5, r6, r7, pc}" f080bd08
 a "popeq {r3, r4, r5, r6, r7, pc}" f880bd08
 a "popeq {r3, r4, r5, r6, r7, r8, sl, pc}" f885bd08
 a "popeq {r3, r4, r5, r6, r7, r8, r9, sl, fp, pc}" f88fbd08
-aB "reveq r3, r3" 333fbf06
+a "reveq r3, r3" 333fbf06
 a "rsbeq ip, r1, r7" 07c06100
 a "rsbne r6, r0, r6" 06606010
 aB "stmeq r0, {r2, r3}" 0c008008

--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -215,12 +215,9 @@ a "mov w15, 0xacdb0000" 6f9bb552
 dB "mov w15, 0xacdb0000" 6f9bb552
 a "mov w15, 0xffff0000" efffbf52
 dB "mov w15, 0xffff0000" efffbf52
-a "mov x30, 0x884800000000" 1e09d1d2
-dB "mov x30, 0x884800000000" 1e09d1d2
-a "mov x29, 0xffff00000000" fdffdfd2
-dB "mov x29, 0xffff00000000" fdffdfd2
-a "mov x27, 0x3721000000000000" 3be4e6d2
-dB "mov x27, 0x3721000000000000" 3be4e6d2
+ad "mov x30, 0x884800000000" 1e09d1d2
+ad "mov x29, 0xffff00000000" fdffdfd2
+ad "mov x27, 0x3721000000000000" 3be4e6d2
 a "mov x26, 0xffff000000000000" faffffd2
 dB "mov x26, 0xffff000000000000" faffffd2
 a "mov w25, 0xffffcfc7" 19078612

--- a/test/db/asm/x86_32
+++ b/test/db/asm/x86_32
@@ -259,6 +259,7 @@ d "pop gs" 0fa9
 d "pop ss" 17
 d "popfd" 9D
 d "por mm0, qword [eax]" 0feb00
+dB "prefetch byte [eax]" 0f0d
 d "prefetchnta byte [eax]" 0f1800
 d "prefetcht0 byte [eax]" 0f1808
 d "prefetcht1 byte [eax]" 0f1810
@@ -301,6 +302,7 @@ d "rdpmc" 0f33
 d "rdtsc" 0f31
 d "rdtscp" 0f01f9
 d "repne movsb byte es:[edi], byte ptr [esi]" f2a4
+dB "invalid" f389d8 # rep mov eax, ecb - not string instruction
 d "retf 0" CA0000
 d "rol byte [eax], 0" c00000
 d "rol byte [eax], 1" d000
@@ -438,7 +440,6 @@ dB "pextrq dword [eax], xmm0, 0" 660f3a16
 dB "pinsrq xmm0, dword [eax], 0" 660f3a22
 dB "pmovmskb eax, mm0" 0fd7
 dB "popcnt eax, qword [eax]" f30fb8
-dB "prefetch byte [eax]" 0f0d00
 d "rep movsb byte es:[edi], byte ptr [esi]" f3a4
 dB "retw" 66c3
 dB "skinit" 0f01de
@@ -501,10 +502,9 @@ d "pmulld xmm0, xmm0" 660f3840c0
 d "phminposuw xmm0, xmm0" 660f3841c0
 d "movbe dword [eax], eax" 0f38f100
 d "movbe eax, dword [eax]" 0f38f000
-d "mulsd xmm7, xmm7" 66f3f20f59ff
-dB "mulss xmm7, xmm7" 66f2f0f59ff0
+d "mulss xmm7, xmm7" f30f59ff
 d "mulpd xmm7, xmm7" 660f59ff
-dB "mulsd xmm7, xmm7" f2660f59ff
+d "mulsd xmm7, xmm7" f20f59ff
 d "mulps xmm7, xmm7" 0f59ff
 d "mpsadbw xmm0, xmm0, 0" 660f3a42c000
 d "pcmpestrm xmm0, xmm0, 0" 660f3a60c000
@@ -1484,10 +1484,9 @@ aB "mulpd xmm7, xmm7" 660f59ff
 aB "mulps xmm0, xmmword [eax]" 0f5900
 aB "mulps xmm7, xmm7" 0f59ff
 aB "mulsd xmm0, qword [eax]" f20f5900
-aB "mulsd xmm7, xmm7" 66f3f20f59ff
-aB "mulsd xmm7, xmm7" f2660f59ff
+aB "mulsd xmm7, xmm7" f20f59ff
 aB "mulss xmm0, dword [eax]" f30f5900
-aB "mulss xmm7, xmm7" 66f2f0f59ff0
+aB "mulss xmm7, xmm7" f30f59ff
 ad "mwait" 0f01c9
 aB "neg byte [eax]" f618
 ad "nop" 90
@@ -1649,7 +1648,7 @@ a "pop gs" 0fa9
 a "pop ss" 17
 aB "por mm0, qword [eax]" 0feb00
 aB "por xmm0, xmmword [eax]" 660feb00
-aB "prefetch byte [eax]" 0f0d00
+a "prefetch byte [eax]" 0f0d
 aB "prefetchnta byte [eax]" 0f1800
 aB "prefetcht0 byte [eax]" 0f1808
 aB "prefetcht1 byte [eax]" 0f1810

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -45,7 +45,7 @@ a "and dword[rax], 0x1234" 812034120000
 a "and dword[rax], 0x123490" 812090341200
 a "and dword[rax], 0x12349012" 812012903412
 a "and qword[rax], 0x12349012" 48812012903412
-aB "and r15b, 0x2a" ff2a
+a "and r15b, 0x2a" ff2a
 a "and ebx, 0x1234" 81e334120000
 a "and byte[rax-0x2a], 12" 8060d60c
 a "and byte[rbx], 99" 802363
@@ -65,7 +65,7 @@ a "call qword[rax - 0x123456]" ff90aacbedff
 a "call qword[rax + 0x0eadbeef]" ff90efbead0e
 a "call qword[rax - 0x0eadbeef]" ff90114152f1
 a "call qword[rsi]" ff16
-aB "call qword[r14]" ff1f
+a "call qword[r14]" ff1f
 aB "call qword[r14 - 0x0eadbeef]" 41ff96114152f1
 a "cdqe" 4898
 a "cmp al, 1" 3c01
@@ -83,7 +83,7 @@ a "cmp qword[rax-0x1234], 0x8765" 4881b8ccedffff65870000
 a "cmp qword[rsp-0x1111], rsi" 4839b424efeeffff
 a "cmp byte[rsp-0x1111], al" 388424efeeffff
 aB "cmp word[rsp-0x1111], dx" 66399424efeeffff
-aB "cmp dword[rdi-0x9888], ecx" 67398f7867ffff
+a "cmp dword[rdi-0x9888], ecx" 67398f7867ffff
 a "cmp qword[rsp-0x9888], rax" 483984247867ffff
 a "cmp rax, 33" 4883f821
 a "cmp rax, rbx" 4839d8
@@ -98,8 +98,8 @@ a "imul ecx" f7e9
 a "imul rax" 48f7e8
 a "imul word[rax]" 66f728
 aB "imul word[rax+0x345]" 66f7a845030000
-aB "imul dword[rax+0x345]" f728
-aB "imul dword[rax+0x1234]" f728
+a "imul dword[rax+0x345]" f728
+a "imul dword[rax+0x1234]" f728
 aB "imul qword[rax+0x1234]" 48f7a834120000
 aB "imul ax, bx" 660fafc3
 aB "imul ax, si" 660fafc6

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -280,7 +280,6 @@ EOF
 RUN
 
 NAME=float args afli
-BROKEN=1
 FILE=bins/elf/float_point
 CMDS=<<EOF
 aa

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -1493,7 +1493,6 @@ RUN
 
 NAME=iD
 FILE=bins/elf/libmagic.so
-BROKEN=1
 CMDS=iD swift _TFSSCfT21_builtinStringLiteralBp8byteSizeBw7isASCIIBi1__SS
 EXPECT=<<EOF
 Swift.String.init (_builtinStringLiteral(Builtin.RawPointer byteSize__Builtin.Word isASCII__Builtin.Int1 _) -> String

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -16,7 +16,6 @@ EOF
 RUN
 
 NAME=null raw wff
-BROKEN=1
 FILE=-
 CMDS=<<EOF
 b 6

--- a/test/db/cmd/cmd_table
+++ b/test/db/cmd/cmd_table
@@ -17,7 +17,6 @@ RUN
 
 NAME=comma table2
 FILE=bins/mach0/mac-ls
-BROKEN=1
 CMDS=<<EOF
 afr
 e scr.utf8=false

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -422,7 +422,6 @@ EOF
 RUN
 
 NAME=escaped chars 2
-BROKEN=1
 CMDS=?e Hello\n\x3bWorld~\;
 EXPECT=<<EOF
 ;World

--- a/test/db/formats/mangling/swift
+++ b/test/db/formats/mangling/swift
@@ -8,7 +8,6 @@ RUN
 
 NAME=elf swift demangle (requires swift-demangle program)
 FILE=bins/elf/analysis/hello-swift
-BROKEN=1
 CMDS=isq~0x004009e0
 EXPECT=<<EOF
 0x004009e0 16 Swift.String.init (_builtinStringLiteral(Builtin.RawPointer byteSize__Builtin.Word isASCII__Builtin.Int1 _) -> String

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -877,7 +877,6 @@ RUN
 
 NAME=rabin2 -D swift
 FILE=bins/elf/libc.so.0
-BROKEN=1
 CMDS=!rabin2 -D swift  _TFSSCfT21_builtinStringLiteralBp8byteSizeBw7isASCIIBi1__SS
 EXPECT=<<EOF
 Swift.String.init (_builtinStringLiteral(Builtin.RawPointer byteSize__Builtin.Word isASCII__Builtin.Int1 _) -> String

--- a/test/db/tools/radiff2
+++ b/test/db/tools/radiff2
@@ -57,7 +57,6 @@ RUN
 
 NAME=radiff2 gnu unified string comparison
 FILE=-
-BROKEN=1
 CMDS=!!radiff2 -Uz bins/elf/elf_one_symbol_shdr bins/elf/elf_one_symbol_shdr1 | tail -n 2
 EXPECT=<<EOF
 -Hello world!

--- a/test/db/tools/ravc2
+++ b/test/db/tools/ravc2
@@ -39,7 +39,6 @@ EOF
 RUN
 
 NAME=ravc2 branch
-BROKEN=1
 CMDS=<<EOF
 mkdir ravc2_branch_test
 cd ravc2_branch_test


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)

**Description**

We have some tests that got fixed but are still marked as broken. A few are still left that are only broken on specific platforms, so they still show up as fixed in r2r outside those platforms.

Additionally, some bad x86_32 tests have been changed to correctly track problems like failing to reject `rep` prefixes with non-string instructions.