### PR TITLE
Fix overread in r_str_firstbut_escape() when string ends with a single backslash

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2648,6 +2648,9 @@ R_API const char *r_str_firstbut_escape(const char *s, char ch, const char *but)
 		if (*p == '\\') {
 			p++;
 			if (*p == ch || strchr(but, *p)) {
+				if (!*p) {
+					break;
+				}
 				continue;
 			} else if (!*p) {
 				break;


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

`r_str_firstbut_escape()` now no longer reads past the string terminator when the given string ends with a single backslash. In the bad code, this occurs because when `p` points to `"\\\0"`, `p` is incremented once explicitly (now pointing to "\0"), but then again implicitly in the loop increment (now pointing into uninitialized memory), before the loop condition triggers, dereferencing this bad pointer.

The function now explicitly checks if `p` points to a null terminator, and if it does, uses `break` instead of `continue`.