### PR TITLE
Auto-rename name collisions in ##signatures

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -46,10 +46,11 @@ static const char *help_msg_z_slash[] = {
 };
 
 static const char *help_msg_za[] = {
-	"Usage:", "za[fF?] [args] ", "# Add zignature",
+	"Usage:", "za[fFM?] [args] ", "# Add zignature",
 	"za ", "zigname type params", "add zignature",
 	"zaf ", "[fcnname] [zigname]", "create zignature for function",
 	"zaF ", "", "generate zignatures for all functions",
+	"zaM ", "", "Same as zaF but merge signatures of same name",
 	"za?? ", "", "show extended help",
 	NULL
 };
@@ -319,9 +320,11 @@ out_case_manual:
 		r_sign_resolve_collisions (core->anal);
 		r_cons_break_pop ();
 		break;
-	case 'F':
+	case 'F': // "zaF"
+	case 'M': // "zaM"
+		bool merge = input[0] == 'M'? true: false;
 		r_cons_break_push (NULL, NULL);
-		int count = r_sign_all_functions (core->anal);
+		int count = r_sign_all_functions (core->anal, merge);
 		r_cons_break_pop ();
 		eprintf ("generated zignatures: %d\n", count);
 		break;

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -110,7 +110,7 @@ typedef struct {
 R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
 R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph);
-R_API int r_sign_all_functions(RAnal *a);
+R_API int r_sign_all_functions(RAnal *a, bool merge);
 R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name);
 R_API bool r_sign_addto_item(RAnal *a, RSignItem *it, RAnalFunction *fcn, RSignType type);
 R_API bool r_sign_add_addr(RAnal *a, const char *name, ut64 addr);
@@ -128,7 +128,7 @@ R_API bool r_sign_add_bb_hash(RAnal *a, RAnalFunction *fcn, const char *name);
 R_API char *r_sign_calc_bbhash(RAnal *a, RAnalFunction *fcn);
 R_API bool r_sign_deserialize(RAnal *a, RSignItem *it, const char *k, const char *v);
 R_API RSignItem *r_sign_get_item(RAnal *a, const char *name);
-R_API bool r_sign_add_item(RAnal *a, RSignItem *it);
+R_API bool r_sign_add_item(RAnal *a, RSignItem *it, bool merge);
 
 R_API bool r_sign_foreach(RAnal *a, RSignForeachCallback cb, void *user);
 R_API const char *r_sign_type_to_name(int type);

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1965,3 +1965,20 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=zaF vs zaM
+FILE=bins/elf/analysis/zigs
+CMDS=<<EOF
+aa
+zg
+f test_orig_size = `z~?`
+zaM
+?v test_orig_size - `z~?`
+zaF
+?v test_orig_size - `z~?`~0xf?
+EOF
+EXPECT=<<EOF
+0x0
+1
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Previously `zg` and `zaF` would merge functions of the same name. So when function `foo` is encountered, if a `foo` already exists in the working sign space, the existing `foo` would be updated.

After this patch `zaF` and `zg` will generate a signature named `foo_2` if the a signature for `foo` already exists in the current sign space. If a signature for `foo` is updated to `foo_2` and there is no `realname` field for that signature, the `realname` is updated to `foo`.

So only `zaF`, `zg` and rasign2 functionality will be changed. If you want to merge signatures of the same name, use `zaM` instead of `zaF`. If you want to merge signatures with rasign2 use the new `-m` flag.

This currently has no effect on `rasign2 -S` behavior, so merging sdb files with `rasign2 -So allfiles.sdb added_file.sdb` will overwrite the signatures of the same name in `allfiles.sdb`. For example:
```
> rasign2 -Sr test1.sdb 
zs *
za test b 44444444
> rasign2 -Sr test2.sdb 
zs *
za test b 55555555
> rasign2 -So all.sdb test2.sdb 
> rasign2 -So all.sdb test1.sdb 
> rasign2 -Sr all.sdb 
zs *
za test b 44444444
```

This has been default, but now that `-m` exists, I consider this a bug. I intend to fix it soon.