### PR TITLE
Improve alias hashtable usage and remedy memory leaks

### DIFF
--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -559,7 +559,9 @@ static int cmd_cmp(void *data, const char *input) {
 	case 'a': // "cat"
 		if (input[1] == 't') {
 			const char *path = r_str_trim_head_ro (input + 2);
-			if (*path == '$') {
+			if (*path == '$' && !path[1]) {
+				eprintf ("No alias name given.\n");
+			} else if (*path == '$') {
 				RCmdAliasVal *v = r_cmd_alias_get (core->rcmd, path+1);
 				if (v) {
 					char *v_str = r_cmd_alias_val_strdup (v);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4728,7 +4728,9 @@ static int cmd_debug_step (RCore *core, const char *input) {
 static ut8 *getFileData(RCore *core, const char *arg, int *sz) {
 	ut8 *out = NULL;
 	int size = 0;
-	if (*arg == '$') {
+	if (*arg == '$' && !arg[1]) {
+		eprintf ("No alias name given\n");
+	} else if (*arg == '$') {
 		RCmdAliasVal *v  = r_cmd_alias_get (core->rcmd, arg+1);
 		if (v) {
 			out = malloc (v->sz);

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -586,8 +586,10 @@ static bool cmd_wff(RCore *core, const char *input) {
 			free (out);
 		}
 	}
-	
-	if (*a == '$') {
+
+	if (*a == '$' && !a[1]) {
+		eprintf ("No alias name given.\n");
+	} else if (*a == '$') {
 		RCmdAliasVal *v = r_cmd_alias_get (core->rcmd, a+1);
 		if (v) {
 			buf = malloc (v->sz);

--- a/test/db/cmd/cmd_alias
+++ b/test/db/cmd/cmd_alias
@@ -101,19 +101,19 @@ $*
 $**
 EOF
 EXPECT=<<EOF
-$bytes_redirect_alias=C\x00C\x00C\x00
-$str_set_alias=BBBB
-$bytes_unterminated_alias=\x90\x90\x90
 $str_redirect_alias=AAAA
-$bytes_set_alias=D\x00D\x00D\x00
 $bytes_decode_alias=E\x00E\x00E\x00
------
-$bytes_redirect_alias=base64:QwBDAEMA
+$bytes_unterminated_alias=\x90\x90\x90
+$bytes_redirect_alias=C\x00C\x00C\x00
+$bytes_set_alias=D\x00D\x00D\x00
 $str_set_alias=BBBB
-$bytes_unterminated_alias=base64:kJCQ
+-----
 $str_redirect_alias=AAAA
-$bytes_set_alias=base64:RABEAEQA
 $bytes_decode_alias=base64:RQBFAEUA
+$bytes_unterminated_alias=base64:kJCQ
+$bytes_redirect_alias=base64:QwBDAEMA
+$bytes_set_alias=base64:RABEAEQA
+$str_set_alias=BBBB
 EOF
 RUN
 
@@ -144,5 +144,15 @@ EOF
 EXPECT=<<EOF
 pd
 pD
+EOF
+RUN
+
+NAME=fail for alias len 0
+FILE=-
+CMDS=<<EOF
+$=$A
+$*
+EOF
+EXPECT=<<EOF
 EOF
 RUN


### PR DESCRIPTION
* Add proper hashtable functions in RCmdAlias to prevent memory leaks
* Fix off-by-one error in alias name processing
* Don't allow 0-length aliases
* Fix memory leak in r_cmd_alias_set_raw() when malloc fails and add null checks to other alias set functions
* Document intended use of strlen() result for buffer size