### PR TITLE
Fix new defects in various files

### DIFF
--- a/libr/anal/p/anal_dalvik.c
+++ b/libr/anal/p/anal_dalvik.c
@@ -851,6 +851,7 @@ static int dalvik_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int l
 	case 0x8b: // double-to-long
 	case 0x8c: // double-to-float
 		op->family = R_ANAL_OP_FAMILY_FPU;
+		/* fall through */
 	case 0x8d: // int-to-byte
 	case 0x8e: // int-to-char
 	case 0x8f: // int-to-short

--- a/libr/asm/arch/riscv/riscvasm.c
+++ b/libr/asm/arch/riscv/riscvasm.c
@@ -205,7 +205,7 @@ R_IPI int riscv_assemble(const char *str, ut64 pc, ut8 *out) {
 						invalid = true;
 						break;
 					}
-					if (!invalid) {
+					if (invalid) {
 						free (s);
 						op = ops[i].op;
 						return riscv_ri (out, op, rs, imm);

--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -94,7 +94,7 @@ R_API char *r_bin_demangle(RBinFile *bf, const char *def, const char *str, ut64 
 				break;
 			}
 		}
-		if (found) {
+		if (found && bin && bin->file) {
 			size_t len = strlen (bin->file);
 			if (!r_str_ncasecmp (str, bin->file, len)) {
 				lib = bin->file;

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -558,6 +558,7 @@ static RBinInfo *info(RBinFile *bf) {
 		ret->machine = strdup ("ARM");
 		ret->arch = strdup ("arm");
 		ret->bits = 32;
+		break;
 	case COFF_FILE_MACHINE_AMD64:
 		ret->machine = strdup ("AMD64");
 		ret->arch = strdup ("x86");

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -1608,6 +1608,7 @@ static int cmd_open(void *data, const char *input) {
 			break;
 		case '?': // "oa?"
 			r_core_cmd_help (core, help_msg_oa);
+			return 1;
 			break;
 		case ' ': // "oa "
 			{
@@ -1655,7 +1656,8 @@ static int cmd_open(void *data, const char *input) {
 		default:
 			r_core_cmd_help (core, help_msg_oa);
 			return 0;
-	}
+		}
+		break;
 	case 'n': // "on"
 		if (input[1] == '?') {
 			r_core_cmd_help (core, help_msg_on);

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -768,24 +768,26 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, R_UNUSED int perm, const ch
 			RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
 			RListIter *iter;
 			RIOMapRef *mapref;
-			r_list_foreach (bank->maprefs, iter, mapref) {
-				RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
-				const ut64 from = r_io_map_begin (map);
-				const ut64 to = r_io_map_end (map);
-				const int rwx = map->perm;
-				if (begin == UT64_MAX) {
-					begin = from;
-				}
-				if (end == UT64_MAX) {
-					end = to;
-				} else {
-					if (end == from) {
+			if (bank) {
+				r_list_foreach (bank->maprefs, iter, mapref) {
+					RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
+					const ut64 from = r_io_map_begin (map);
+					const ut64 to = r_io_map_end (map);
+					const int rwx = map->perm;
+					if (begin == UT64_MAX) {
+						begin = from;
+					}
+					if (end == UT64_MAX) {
 						end = to;
 					} else {
-						append_bound (list, NULL, search_itv,
-							begin, end - begin, rwx);
-						begin = from;
-						end = to;
+						if (end == from) {
+							end = to;
+						} else {
+							append_bound (list, NULL, search_itv,
+								begin, end - begin, rwx);
+							begin = from;
+							end = to;
+						}
 					}
 				}
 			}
@@ -813,14 +815,16 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, R_UNUSED int perm, const ch
 			RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
 			RListIter *iter;
 			RIOMapRef *mapref;
-			r_list_foreach (bank->maprefs, iter, mapref) {
-				RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
-				const ut64 from = r_io_map_begin (map);
-				const int rwx = map->perm;
-				if ((rwx & mask) != mask) {
-					continue;
+			if (bank) {
+				r_list_foreach (bank->maprefs, iter, mapref) {
+					RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
+					const ut64 from = r_io_map_begin (map);
+					const int rwx = map->perm;
+					if ((rwx & mask) != mask) {
+						continue;
+					}
+					append_bound (list, core->io, search_itv, from, r_io_map_size (map), rwx);
 				}
-				append_bound (list, core->io, search_itv, from, r_io_map_size (map), rwx);
 			}
 		}
 	} else if (r_str_startswith (mode, "bin.segments")) {
@@ -879,15 +883,17 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, R_UNUSED int perm, const ch
 				} else {
 					RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
 					RIOMapRef *mapref;
-					r_list_foreach (bank->maprefs, iter, mapref) {
-						RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
-						const ut64 from = r_io_map_begin (map);
-						const ut64 size = r_io_map_size (map);
-						const int rwx = map->perm;
-						if ((rwx & mask) != mask) {
-							continue;
+					if (bank) {
+						r_list_foreach (bank->maprefs, iter, mapref) {
+							RIOMap *map = r_io_map_get_by_ref (core->io, mapref);
+							const ut64 from = r_io_map_begin (map);
+							const ut64 size = r_io_map_size (map);
+							const int rwx = map->perm;
+							if ((rwx & mask) != mask) {
+								continue;
+							}
+							append_bound (list, core->io, search_itv, from, size, rwx);
 						}
-						append_bound (list, core->io, search_itv, from, size, rwx);
 					}
 				}
 			}

--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -426,6 +426,9 @@ static void _delete_submaps_from_bank_tree(RIO *io, RIOBank *bank, RListIter *pr
 			RIOMapRef *mapref = _mapref_from_map (map);
 			bd = r_io_submap_new (io, mapref);
 			free (mapref);
+			if (!bd) {
+				continue;
+			}
 			if (r_io_submap_from (sm) >= r_io_map_from (map)) {
 				// case 4 and 2
 				r_io_submap_set_from (bd, r_io_submap_from (sm));

--- a/libr/io/io_fd.c
+++ b/libr/io/io_fd.c
@@ -39,7 +39,7 @@ R_API int r_io_fd_write(RIO *io, int fd, const ut8 *buf, int len) {
 
 R_API ut64 r_io_fd_seek(RIO *io, int fd, ut64 addr, int whence) {
 	r_return_val_if_fail (io, UT64_MAX);
-	return io? r_io_desc_seek (r_io_desc_get (io, fd), addr, whence): UT64_MAX;
+	return r_io_desc_seek (r_io_desc_get (io, fd), addr, whence);
 }
 
 R_API ut64 r_io_fd_size(RIO *io, int fd) {

--- a/libr/main/rabin2.c
+++ b/libr/main/rabin2.c
@@ -526,7 +526,7 @@ static void setup_trylib_from_environment(RBin *bin, int type) {
 }
 
 static char *__demangleAs(RBin *bin, int type, const char *file) {
-	bool syscmd = bin? bin->demangle_usecmd: false;
+	bool syscmd = bin->demangle_usecmd;
 	char *res = NULL;
 	switch (type) {
 	case R_BIN_NM_CXX: res = r_bin_demangle_cxx (NULL, file, 0); break;

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -7,8 +7,8 @@ e asm.bits
 EOF
 EXPECT=<<EOF
 format   coff
-x86
-64
+arm
+32
 EOF
 RUN
 


### PR DESCRIPTION
Fix all the defects introduced in August or later, excluding a minor one on new experimental code for the pdr command.

* Remove unnecessary NULL check in __demangleAs()
* Remove unnecessary NULL check in r_io_fd_seek()
* Add missing break in ARM32 COFF case and fix test
* Add missing NULL checks for r_io_bank_get() result
* Add missing NULL checks in r_bin_demangle()
* Add missing NULL check for r_io_submap_new() result
* Fix improper failure check in riscv_assemble()
* Add missing break in open command
* Document fall-through case in dalvik anal