### PR TITLE
Fix new defects and an overread

### DIFF
--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -515,6 +515,7 @@ R_API void r_cons_grepbuf(void) {
 		r_str_ansi_filter (buf, NULL, NULL, -1);
 		char *out = r_str_ss (buf);
 		free (cons->context->buffer);
+		free (buf);
 		cons->context->buffer = out;
 		cons->context->buffer_len = strlen (out);
 		cons->context->buffer_sz = cons->context->buffer_len;

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -3962,9 +3962,8 @@ repeat_arroba:
 					r_sys_setenv (k, v);
 					r_list_append (tmpenvs, k);
 				} 
-			} else {
-				free (k);
 			}
+			free (k);
 		} else if (ptr[1] == '.') { // "@."
 			if (ptr[2] == '.') { // "@.."
 				if (ptr[3] == '.') { // "@..."

--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -780,6 +780,7 @@ R_API void r_io_bank_del_map(RIO *io, const ut32 bankid, const ut32 mapid) {
 		if (mapref->id == map->id) {
 			_delete_submaps_from_bank_tree (io, bank, iter, map);
 			r_list_delete (bank->maprefs, iter);
+			break;
 		}
 	}
 	// map is not referenced by this bank; nothing to do

--- a/libr/util/sstext.c
+++ b/libr/util/sstext.c
@@ -225,7 +225,8 @@ static const SevenSegments ss[] = {
 	{ 'z', {" __ ",
 		"  / ",
 		" /_ "}
-	}
+	},
+	{ '\0', { 0 }}
 };
 
 R_API char *r_str_ss(const char* msg) {


### PR DESCRIPTION
* Fix global variable overread in r_str_ss()
* Fix memory leak in grep ASCII art ~?ea
* Fix memory leak in @%
* Fix use-after-free in r_io_bank_del_map()