### PR TITLE
Fix resource leak and logic bug in r_io_reopen ##io

### DIFF
--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -231,7 +231,7 @@ R_API bool r_io_reopen(RIO* io, int fd, int perm, int mode) {
 	}
 	//does this really work, or do we have to handler debuggers ugly
 	uri = old->referer? old->referer: old->uri;
-	if (old->plugin->close && old->plugin->close (old)) {
+	if (old->plugin->close && !old->plugin->close (old)) {
 		return false; // TODO: this is an unrecoverable scenario
 	}
 	if (!(new = r_io_open_nomap (io, uri, perm, mode))) {
@@ -251,8 +251,7 @@ R_API bool r_io_reopen(RIO* io, int fd, int perm, int mode) {
 	RIODesc *nd = r_io_open_nomap (io, uri, perm, mode);
 	if (nd) {
 		r_io_desc_exchange (io, od->fd, nd->fd);
-		r_io_desc_del (io, od->fd);
-		// bool res = r_io_desc_close (od);
+		r_io_desc_close (od);
 		if (nd->perm & R_PERM_W) {
 			io->corebind.cmdf (io->corebind.core, "omfg");
 		}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
