### PR TITLE
Add return type to zj ##signatures

### DIFF
--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1231,10 +1231,10 @@ FILE=bins/elf/static-glibc-2.27
 CMDS=<<EOF
 af @0x00484d40
 zaf fcn.00484d40 fcn.00484d40
-zj
+zj~{[0][types]}
 EOF
 EXPECT=<<EOF
-[{"name":"fcn.00484d40","bytes":"55534883ec08488b1f4885db741b4889fd4889dfe857b7f7ff4801d8803800751748c74500000000004883c4084889d85b5dc30f1f440000c600004883c001488945004883c4084889d85b5dc3","mask":"ffffffffffffffffffffffffff00ffffffffffffff00000000ffffffffffffff00ffffffffffffffffffffffffffffffffffff0000000000ffffffffffffffffffffffffffffffffffffffffff","graph":{"cc":4,"nbbs":5,"edges":5,"ebbs":2,"bbsum":72},"addr":4738368,"refs":[],"xrefs":[],"vars":["r82"],"types":[{"name":"arg1","type":"int64_t"}],"collisions":[],"hash":{"bbhash":"8ff8a5c7f84179483b764fbb18dc4c44f39da6527a0a16485c7ae519f00e687f"}}]
+{"return":"void","args":[{"name":"arg1","type":"int64_t"}]}
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Previously `zj` would neglect the return type of a function:
```
 [0x00006160]> zj~{[0][types]}
[{"name":"argc","type":"int"},{"name":"argv","type":"char **"}]
```

After this update, the return type should be included. This does change the types json schema a bit.
```
[0x000040a0]> zj~{[0][types]}
{"return":"int","args":[{"name":"argc","type":"int"},{"name":"argv","type":"char **"}]}
```
