### PR TITLE
Fix om-command map priority if iobanks are active

### DIFF
--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -451,7 +451,7 @@ static void map_list(RIO *io, int mode, RPrint *print, int fd) {
 		}
 		RIOMapRef *mapref;
 		RListIter *iter;
-		r_list_foreach (bank->maprefs, iter, mapref) {
+		r_list_foreach_prev (bank->maprefs, iter, mapref) {
 			RIOMap *map = r_io_map_get (io, mapref->id);
 			if (fd >= 0 && map->fd != fd) {
 				continue;
@@ -1131,7 +1131,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 			}
 			RListIter *iter;
 			RIOMapRef *mapref;
-			r_list_foreach (bank->maprefs, iter, mapref) {
+			r_list_foreach_prev (bank->maprefs, iter, mapref) {
 				RIOMap *map = r_io_map_get (core->io, mapref->id);
 				char temp[32];
 				snprintf (temp, sizeof (temp), "%d", map->fd);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This is so anoying
