### PR TITLE
Remove redundant RPVector maps from RIO

### DIFF
--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -487,10 +487,12 @@ static RList *patch_relocs(RBin *b) {
 	}
 	ut64 m_vaddr = UT64_MAX;
 	if (nimports) {
-		void **it;
 		ut64 offset = 0;
-		r_pvector_foreach (&io->maps, it) {
-			RIOMap *map = *it;
+		RIOBank *bank = b->iob.bank_get (io, io->bank);
+		RListIter *iter;
+		RIOMapRef *mapref;
+		r_list_foreach (bank->maprefs, iter, mapref) {
+			RIOMap *map = b->iob.map_get (io, mapref->id);
 			if (r_io_map_end (map) > offset) {
 				offset = r_io_map_end (map);
 			}

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -915,11 +915,13 @@ static RList* patch_relocs(RBin *b) {
 	if (size == 0) {
 		return NULL;
 	}
-	void **it;
-	r_pvector_foreach (&io->maps, it) {
-		RIOMap *map = *it;
-		if (r_io_map_begin (map) > offset) {
-			offset = r_io_map_begin (map);
+	RIOBank *bank = b->iob.bank_get (io, io->bank);
+	RListIter *iter;
+	RIOMapRef *mapref;
+	r_list_foreach (bank->maprefs, iter, mapref) {
+		RIOMap *map = b->iob.map_get (io, mapref->id);
+		if (r_io_map_from (map) > offset) {
+			offset = r_io_map_from (map);
 			g = map;
 		}
 	}

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -621,11 +621,13 @@ static RList* patch_relocs(RBin *b) {
 	int cdsz = obj->info ? obj->info->bits / 8 : 8;
 
 	ut64 offset = 0;
-	void **vit;
-	r_pvector_foreach (&io->maps, vit) {
-		RIOMap *map = *vit;
-		if (r_io_map_begin (map) > offset) {
-			offset = r_io_map_begin (map);
+	RIOBank *bank = b->iob.bank_get (io, io->bank);
+	RListIter *iter;
+	RIOMapRef *mapref;
+	r_list_foreach (bank->maprefs, iter, mapref) {
+		RIOMap *map = b->iob.map_get (io, mapref->id);
+		if (r_io_map_from (map) > offset) {
+			offset = r_io_map_from (map);
 			g = map;
 		}
 	}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -277,20 +277,24 @@ R_API ut64 r_core_anal_address(RCore *core, ut64 addr) {
 		int _perm = -1;
 		if (core->io) {
 			// sections
-			void **it;
-			r_pvector_foreach (&core->io->maps, it) {
-				RIOMap *s = *it;
-				if (addr >= s->itv.addr && addr < (s->itv.addr + s->itv.size)) {
-					// sections overlap, so we want to get the one with lower perms
-					_perm = (_perm != -1) ? R_MIN (_perm, s->perm) : s->perm;
-					// TODO: we should identify which maps come from the program or other
-					//types |= R_ANAL_ADDR_TYPE_PROGRAM;
-					// find function those sections should be created by hand or esil init
-					if (s->name && strstr (s->name, "heap")) {
-						types |= R_ANAL_ADDR_TYPE_HEAP;
-					}
-					if (s->name && strstr (s->name, "stack")) {
-						types |= R_ANAL_ADDR_TYPE_STACK;
+			RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+			if (bank) {
+				RIOMapRef *mapref;
+				RListIter *iter;
+				r_list_foreach (bank->maprefs, iter, mapref) {
+					RIOMap *s = r_io_map_get (core->io, mapref->id);
+					if (addr >= s->itv.addr && addr < (s->itv.addr + s->itv.size)) {
+						// sections overlap, so we want to get the one with lower perms
+						_perm = (_perm != -1) ? R_MIN (_perm, s->perm) : s->perm;
+						// TODO: we should identify which maps come from the program or other
+						//types |= R_ANAL_ADDR_TYPE_PROGRAM;
+						// find function those sections should be created by hand or esil init
+						if (s->name && strstr (s->name, "heap")) {
+							types |= R_ANAL_ADDR_TYPE_HEAP;
+						}
+						if (s->name && strstr (s->name, "stack")) {
+							types |= R_ANAL_ADDR_TYPE_STACK;
+						}
 					}
 				}
 			}

--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -221,33 +221,19 @@ static void GH(get_brks)(RCore *core, GHT *brk_start, GHT *brk_end) {
 			}
 		}
 	} else {
-		if (core->io->use_banks) {
-			RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
-			if (!bank) {
-				return;
-			}
-			RIOMapRef *mapref;
-			RListIter *iter;
-			r_list_foreach (bank->maprefs, iter, mapref) {
-				RIOMap *map = r_io_map_get (core->io, mapref->id);
-				if (map->name) {
-					if (strstr (map->name, "[heap]")) {
-						*brk_start = r_io_map_begin (map);
-						*brk_end = r_io_map_end (map);
-						break;
-					}
-				}
-			}
-		} else {
-			void **it;
-			r_pvector_foreach (&core->io->maps, it) {
-				RIOMap *map = *it;
-				if (map->name) {
-					if (strstr (map->name, "[heap]")) {
-						*brk_start = r_io_map_begin (map);
-						*brk_end = r_io_map_end (map);
-						break;
-					}
+		RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+		if (!bank) {
+			return;
+		}
+		RIOMapRef *mapref;
+		RListIter *iter;
+		r_list_foreach (bank->maprefs, iter, mapref) {
+			RIOMap *map = r_io_map_get (core->io, mapref->id);
+			if (map->name) {
+				if (strstr (map->name, "[heap]")) {
+					*brk_start = r_io_map_begin (map);
+					*brk_end = r_io_map_end (map);
+					break;
 				}
 			}
 		}
@@ -436,9 +422,14 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 			}
 		}
 	} else {
-		void **it;
-		r_pvector_foreach (&core->io->maps, it) {
-			RIOMap *map = *it;
+		RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+		if (!bank) {
+			return false;
+		}
+		RIOMapRef *mapref;
+		RListIter *iter;
+		r_list_foreach (bank->maprefs, iter, mapref) {
+			RIOMap *map = r_io_map_get (core->io, mapref->id);
 			if (map->name && strstr (map->name, "arena")) {
 				libc_addr_sta = r_io_map_begin (map);
 				libc_addr_end = r_io_map_end (map);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -234,17 +234,11 @@ static bool __core_visual_gogo(RCore *core, int ch) {
 	case 'g':
 		if (core->io->va) {
 			map = r_io_map_get_at (core->io, core->offset);
-			if (core->io->use_banks) {
-				if (!map) {
-					RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
-					if (bank && r_list_length (bank->maprefs)) {
-						map = r_io_map_get (core->io,
-							((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
-					}
-				}
-			} else {
-				if (!map && !r_pvector_empty (&core->io->maps)) {
-					map = r_pvector_at (&core->io->maps, r_pvector_len (&core->io->maps) - 1);
+			if (!map) {
+				RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+				if (bank && r_list_length (bank->maprefs)) {
+					map = r_io_map_get (core->io,
+						((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
 				}
 			}
 			if (map) {
@@ -257,17 +251,11 @@ static bool __core_visual_gogo(RCore *core, int ch) {
 		return true;
 	case 'G':
 		map = r_io_map_get_at (core->io, core->offset);
-		if (core->io->use_banks) {
-			if (!map) {
-				RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
-				if (bank && r_list_length (bank->maprefs)) {
-					map = r_io_map_get (core->io,
-						((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
-				}
-			}
-		} else {
-			if (!map && !r_pvector_empty (&core->io->maps)) {
-				map = r_pvector_at (&core->io->maps, r_pvector_len (&core->io->maps) - 1);
+		if (!map) {
+			RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+			if (bank && r_list_length (bank->maprefs)) {
+				map = r_io_map_get (core->io,
+					((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
 			}
 		}
 		if (map) {
@@ -3550,17 +3538,10 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 							entry = s->vaddr;
 						} else {
 							RIOMap *map = NULL;
-							if (core->io->use_banks) {
-								RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
-								if (bank && r_list_length (bank->maprefs)) {
-									map = r_io_map_get (core->io,
-										((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
-								}
-							} else {
-								if (!r_pvector_empty (&core->io->maps)) {
-								map = r_pvector_at (&core->io->maps,
-									r_pvector_len (&core->io->maps) - 1);
-								}
+							RIOBank *bank = r_io_bank_get (core->io, core->io->bank);
+							if (bank && r_list_length (bank->maprefs)) {
+								map = r_io_map_get (core->io,
+									((RIOMapRef *)r_list_get_top (bank->maprefs))->id);
 							}
 							if (map) {
 								entry = r_io_map_from (map);

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -120,9 +120,8 @@ typedef struct r_io_t {
 	ut32 p_cache; // uses 1, 2, 4.. probably R_PERM_RWX :D
 	ut64 mts;	// map "timestamps", this sucks somehow
 	ut32 curbank;	// id of current bank
-	RIDStorage *maps_by_id;
-	RPVector maps; //from tail backwards maps with higher priority are found
 	RIDStorage *files;
+	RIDStorage *maps_by_id;
 	RIDStorage *banks;
 	RCache *buffer;
 	RPVector cache;
@@ -270,7 +269,9 @@ typedef const char *(*RIOFdGetName)(RIO *io, int fd);
 typedef RList *(*RIOFdGetMap)(RIO *io, int fd);
 typedef bool (*RIOFdRemap)(RIO *io, int fd, ut64 addr);
 typedef bool (*RIOIsValidOff)(RIO *io, ut64 addr, int hasperm);
-typedef RIOMap *(*RIOMapGet)(RIO *io, ut64 addr);
+typedef RIOBank *(*RIOBankGet)(RIO *io, ut32 bankid);
+typedef RIOMap *(*RIOMapGet)(RIO *io, ut32 id);
+typedef RIOMap *(*RIOMapGetAt)(RIO *io, ut64 addr);
 typedef RIOMap *(*RIOMapGetPaddr)(RIO *io, ut64 paddr);
 typedef bool (*RIOAddrIsMapped)(RIO *io, ut64 addr);
 typedef RIOMap *(*RIOMapAdd)(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
@@ -306,7 +307,9 @@ typedef struct r_io_bind_t {
 	RIOFdRemap fd_remap;
 	RIOIsValidOff is_valid_offset;
 	RIOAddrIsMapped addr_is_mapped;
-	RIOMapGet map_get_at;
+	RIOBankGet bank_get;
+	RIOMapGet map_get;
+	RIOMapGetAt map_get_at;
 	RIOMapGetPaddr map_get_paddr;
 	RIOMapAdd map_add;
 	RIOV2P v2p;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -27,11 +27,6 @@ R_API RIO* r_io_init(RIO* io) {
 	if (bank) {
 		io->bank = bank->id;
 		r_io_bank_add (io, bank);
-		void **p;
-		r_pvector_foreach (&io->maps, p) {
-			RIOMap *map = (RIOMap*) p;
-			r_io_bank_map_add_top (io, bank->id, map->id);
-		}
 	}
 	return io;
 }
@@ -507,6 +502,8 @@ R_API void r_io_bind(RIO *io, RIOBind *bnd) {
 	bnd->fd_get_map = r_io_map_get_by_fd;
 	bnd->fd_remap = r_io_map_remap_fd;
 	bnd->is_valid_offset = r_io_is_valid_offset;
+	bnd->bank_get = r_io_bank_get;
+	bnd->map_get = r_io_map_get;
 	bnd->map_get_at = r_io_map_get_at;
 	bnd->map_get_paddr = r_io_map_get_paddr;
 	bnd->addr_is_mapped = r_io_addr_is_mapped;

--- a/libr/io/io_desc.c
+++ b/libr/io/io_desc.c
@@ -277,14 +277,16 @@ R_API bool r_io_desc_exchange(RIO* io, int fd, int fdx) {
 		r_io_desc_cache_cleanup (desc);
 		r_io_desc_cache_cleanup (descx);
 	}
-	void **it;
-	r_pvector_foreach (&io->maps, it) {
-		RIOMap *map = *it;
-		if (map->fd == fdx) {
-			map->perm &= (desc->perm | R_PERM_X);
-		} else if (map->fd == fd) {
-			map->perm &= (descx->perm | R_PERM_X);
-		}
+	ut32 map_id;
+	if (r_id_storage_get_lowest (io->maps_by_id, &map_id)) {
+		do {
+			RIOMap *map = r_id_storage_get (io->maps_by_id, map_id);
+			if (map->fd == fdx) {
+				map->perm &= (desc->perm | R_PERM_X);
+			} else if (map->fd == fd) {
+				map->perm &= (descx->perm | R_PERM_X);
+			}
+		} while (r_id_storage_get_next (io->maps_by_id, &map_id));
 	}
 	return true;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
It's no longer needed and doesn't represent map priority in banks.

Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! Please be green! 
