### PR TITLE
Fix a memleak in wt command

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1526,7 +1526,7 @@ static int wt_handler_old(void *data, const char *input) {
 					prefix = "dump";
 				}
 				str++;
-				filename = r_str_newf ("%s-0x%08"PFMT64x, prefix, core->offset);
+				filename = r_str_newf ("%s-0x%08"PFMT64x, prefix, core->offset);	//XXX: memleak
 			} else {
 				if (*str) {
 					if (str[1] == '?') {
@@ -1632,6 +1632,7 @@ static int wt_handler_old(void *data, const char *input) {
 					sz, poff, filename);
 		}
 	}
+	free (ostr);
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Holy shit, that function is a mess!
