### PR TITLE
Always use b64 encoded filepaths on the fs.io calls ##fs

### DIFF
--- a/libr/fs/p/fs_io.c
+++ b/libr/fs/p/fs_io.c
@@ -36,7 +36,11 @@ static int fs_io_read(RFSFile *file, ut64 addr, int len) {
 		return -1;
 	}
 	
-	char *cmd = r_str_newf ("mg %s 0x%08"PFMT64x" %d", abs_path, addr, len);
+	char *enc_path = r_base64_encode_dyn (abs_path, -1);
+	char *enc_uri = r_str_newf ("base64:%s", enc_path);
+	char *cmd = r_str_newf ("mg %s 0x%08"PFMT64x" %d", enc_uri, addr, len);
+	free (enc_uri);
+	free (enc_path);
 	R_FREE (abs_path);
 	if (!cmd) {
 		return -1;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
