### PR TITLE
Fix free befor use bug, if bin.libs is enabled

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -477,7 +477,6 @@ static bool try_loadlib(RCore *core, const char *lib, ut64 addr) {
 	void *p = r_core_file_open (core, lib, 0, addr);
 	if (p) {
 		r_core_bin_load (core, lib, addr);
-		R_FREE (p);
 		return true;
 	}
 	return false;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

r_core_file_open returns RIODesc, which RIO keeps track of. If you want to properly destroy a RIODesc use r_io_desc_close or in rare cases r_io_desc_del. In this scenario both seems wrong, as we want to have access to hte libs after loading them