### PR TITLE
Disable the disassembler logic in the asm plugin for 8051

### DIFF
--- a/libr/asm/p/asm_8051.c
+++ b/libr/asm/p/asm_8051.c
@@ -9,21 +9,6 @@
 #include <r_asm.h>
 
 #include <8051_ass.h>
-#include "../arch/8051/8051_disas.c"
-
-static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
-	int dlen = 0;
-	char *s = r_8051_disas (a->pc, buf, len, &dlen);
-	if (dlen < 0) {
-		dlen = 0;
-	}
-	if (s) {
-		r_strbuf_set (&op->buf_asm, s);
-		free (s);
-	}
-	op->size = dlen;
-	return dlen;
-}
 
 RAsmPlugin r_asm_plugin_8051 = {
 	.name = "8051",
@@ -31,7 +16,7 @@ RAsmPlugin r_asm_plugin_8051 = {
 	.bits = 8,
 	.endian = R_SYS_ENDIAN_NONE,
 	.desc = "8051 Intel CPU",
-	.disassemble = &disassemble,
+	// .disassemble = &disassemble,
 	.assemble = &assemble_8051,
 	.license = "PD",
 	.cpus =


### PR DESCRIPTION
* Avoid compile+link the same code twice for asm & anal

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
