### PR TITLE
Fix signal definition error on MIPS platform

### DIFF
--- a/libr/util/signal.c
+++ b/libr/util/signal.c
@@ -16,10 +16,6 @@ static struct {
 	{ "SIGSEGV", SIGSEGV },
 	{ "SIGTERM", SIGTERM },
 #if __linux__
-#if __mips__
-#else
-	{ "SIGSTKFLT", SIGSTKFLT },
-#endif
 	{ "SIGWINCH", SIGWINCH },
 	{ "SIGIO", SIGIO },
 	{ "SIGPWR", SIGPWR },
@@ -98,10 +94,6 @@ R_API const char *r_signal_to_human(int signum) {
 	case SIGPROF: return "Profiling Timer Expired";
 #if __linux__
 	case SIGPWR: return "Power Failure";
-#if __mips__
-#else
-	case SIGSTKFLT: return "Stack fault";
-#endif
 	case SIGPOLL: return "Pollable Event (Same as SIGIO)";
 	// case SIGIO: return "IO ready";
 #endif

--- a/libr/util/signal.c
+++ b/libr/util/signal.c
@@ -16,7 +16,10 @@ static struct {
 	{ "SIGSEGV", SIGSEGV },
 	{ "SIGTERM", SIGTERM },
 #if __linux__
+#if __mips__
+#else
 	{ "SIGSTKFLT", SIGSTKFLT },
+#endif
 	{ "SIGWINCH", SIGWINCH },
 	{ "SIGIO", SIGIO },
 	{ "SIGPWR", SIGPWR },
@@ -95,7 +98,10 @@ R_API const char *r_signal_to_human(int signum) {
 	case SIGPROF: return "Profiling Timer Expired";
 #if __linux__
 	case SIGPWR: return "Power Failure";
+#if __mips__
+#else
 	case SIGSTKFLT: return "Stack fault";
+#endif
 	case SIGPOLL: return "Pollable Event (Same as SIGIO)";
 	// case SIGIO: return "IO ready";
 #endif


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

env:
Linux junchao-pc 4.19.0-13-loongson-3 #1 SMP Tue Aug 17 01:57:07 UTC 2021 mips64 GNU/Linux

When I compile with the latest master branch code on the mips（loonsong 3a4000） platform, I get the following error：

```
[util 143] CC debruijn.c
[util 144] CC log.c
[util 145] CC getopt.c
[util 146] CC table.c
[util 147] CC utf8.c
[util 148] CC utf16.c
[util 149] CC utf32.c
[util 150] CC strbuf.c
[util 151] CC lib.c
[util 152] CC name.c
[util 153] CC spaces.c
[util 154] CC signal.c
[util 155] CC syscmd.c
[util 156] CC udiff.c
[util 157] CC bdiff.c
signal.c:19:17: error SIGSTKFLT? undeclared here (not in a function); did you mean ?SIGSTKSZ??
  { "SIGSTKFLT", SIGSTKFLT },
                 ^~~~~~~~~
                 SIGSTKSZ
make[2]: *** [/home/junchao/work/plugin/radare2/libr/../global.mk:42?signal.o] ?? 1
make[1]: *** [../rules.mk:72?all] ?? 2
make: *** [Makefile:53?all] ?? 2

```
The current version of my system kernel and the latest linux kernel ,mips don't seem to have this signal defined

linux：
arch/mips/include/uapi/asm/signal.h
