### PR TITLE
Add serialization API for vars ##anal

### DIFF
--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -793,6 +793,15 @@ typedef struct r_anal_var_t {
 	int argnum;
 } RAnalVar;
 
+// RAnalVar "prototype", RAnalVar w/o function used for serialization
+typedef struct r_anal_var_proto_t {
+	char *name;
+	char *type;
+	RAnalVarKind kind;
+	bool isarg;
+	int delta;
+} RAnalVarProt;
+
 // Refers to a variable or a struct field inside a variable, only for varsub
 R_DEPRECATE typedef struct r_anal_var_field_t {
 	char *name;
@@ -1709,7 +1718,11 @@ R_API void r_anal_save_parsed_type(RAnal *anal, const char *parsed);
 /* var.c */
 R_API R_OWN char *r_anal_function_autoname_var(RAnalFunction *fcn, char kind, const char *pfx, int ptr);
 R_API R_BORROW RAnalVar *r_anal_function_set_var(RAnalFunction *fcn, int delta, char kind, R_NULLABLE const char *type, int size, bool isarg, R_NONNULL const char *name);
+R_API bool r_anal_function_set_var_prot(RAnalFunction *fcn, RList /*<RAnalVarProt>*/ *l);
 R_API R_BORROW RAnalVar *r_anal_function_get_var(RAnalFunction *fcn, char kind, int delta);
+R_API RList *r_anal_var_deserialize(const char *ser);
+R_API char *r_anal_var_prot_serialize(RList /*<RAnalVarProt>*/ *l, bool spaces);
+R_API RList /*<RAnalVarProt>*/ *r_anal_var_get_prots(RAnalFunction *fcn);
 R_API R_BORROW RAnalVar *r_anal_function_get_var_byname(RAnalFunction *fcn, const char *name);
 R_API void r_anal_function_delete_vars_by_kind(RAnalFunction *fcn, RAnalVarKind kind);
 R_API void r_anal_function_delete_all_vars(RAnalFunction *fcn);

--- a/test/unit/test_anal_var.c
+++ b/test/unit/test_anal_var.c
@@ -216,6 +216,47 @@ bool test_r_anal_var() {
 	mu_assert_eq (r_pvector_len (used_vars), 1, "used vars count");
 	mu_assert ("used vars", r_pvector_contains (used_vars, b));
 
+	// serialization / RAnalVarProt
+	RList *vps = r_anal_var_get_prots (fcn);
+	mu_assert ("Failed r_anal_var_get_protos", vps && r_list_length (vps) == 2);
+
+	char *serial = r_anal_var_prot_serialize (vps, true);
+	mu_assert ("serial space", !strcmp (serial, "fs-16:var_b:char *, tr48:arg42:int64_t"));
+	free (serial);
+
+	serial = r_anal_var_prot_serialize (vps, false);
+	mu_assert ("serial no space", !strcmp (serial, "fs-16:var_b:char *,tr48:arg42:int64_t"));
+	free (serial);
+	r_list_free (vps);
+
+	vps = r_anal_var_deserialize ("ts-16:var_name:char **, tr48:var_name_b:size_t");
+	mu_assert ("Failed r_anal_var_deserialize", vps && r_list_length (vps) == 2);
+
+	RAnalVarProt *vp = (RAnalVarProt *)r_list_get_bottom (vps);
+	mu_assert ("Deserialize name[0]", !strcmp (vp->name, "var_name") && !strcmp (vp->type, "char **"));
+	vp = (RAnalVarProt *)r_list_get_top (vps);
+	mu_assert ("Deserialize name[1]", !strcmp (vp->name, "var_name_b") && !strcmp (vp->type, "size_t"));
+
+	mu_assert ("r_anal_function_set_var_prot", r_anal_function_set_var_prot (fcn, vps));
+	mu_assert ("Setting first var from proto", !strcmp (b->name, "var_name") && !strcmp (b->type, "char **"));
+	mu_assert ("Setting second var from proto", !strcmp (c->name, "var_name_b") && !strcmp (c->type, "size_t"));
+
+	r_list_purge (vps);
+	vp = R_NEW0 (RAnalVarProt);
+	vp->name = strdup ("bad_name:`${}~|#@&<>,");
+	vp->type = strdup ("bad_type:`${}~|#@&<>,");
+	r_list_append (vps, vp);
+	vp->kind = 'z';
+	serial = r_anal_var_prot_serialize (vps, false);
+	mu_assert ("Serializtion succeeded despite invalide kind", !serial);
+	free (serial);
+
+	vp->kind = R_ANAL_VAR_KIND_REG;
+	serial = r_anal_var_prot_serialize (vps, false);
+	mu_assert ("Serializtion filtered bad chars", serial && !strcmp ("fr0:bad_name_____________:bad_type:____________", serial));
+	r_list_free (vps);
+	free (serial);
+
 	r_anal_var_delete (b);
 	r_anal_var_delete (c);
 

--- a/test/unit/test_anal_var.c
+++ b/test/unit/test_anal_var.c
@@ -257,6 +257,9 @@ bool test_r_anal_var() {
 	r_list_free (vps);
 	free (serial);
 
+	vps = r_anal_var_deserialize ("ts-16:v,r_name:char **");
+	mu_assert ("No ',' in serialized name", !vps);
+
 	r_anal_var_delete (b);
 	r_anal_var_delete (c);
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Ads API to r_anal to serialize and deserialize variable information. This is very similar to the serialization found in #19353 but put in RAnalVar so plugins can benefit from it. Additionally, I found it helpful to serialize the `isarg` value, so that is in there now too.

Let me know if I named things stupid, I am happy to change it.

Once this is merged I will rebase #19353 and update it to use the RAnalVar serialization API instead of inviting it's own.