### PR TITLE
Use r_str_ndup in another bound check in dwarf ##bin

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1447,7 +1447,8 @@ static void parse_function(Context *ctx, ut64 idx) {
 		r_strbuf_append (&ret_type, "void");
 	}
 	r_warn_if_fail (ctx->lang);
-	char *new_name = ctx->anal->binb.demangle (NULL, ctx->lang, fcn.name, fcn.addr, false);
+	char *new_name = ctx->anal->binb.demangle
+		? ctx->anal->binb.demangle (NULL, ctx->lang, fcn.name, fcn.addr, false): NULL;
 	fcn.name = new_name ? new_name : strdup (fcn.name);
 	fcn.signature = r_str_newf ("%s %s(%s);", r_strbuf_get (&ret_type), fcn.name, r_strbuf_get (&args));
 	sdb_save_dwarf_function (&fcn, variables, ctx->sdb);

--- a/test/db/cmd/cmd_flags
+++ b/test/db/cmd/cmd_flags
@@ -501,7 +501,7 @@ aaa
 e asm.arch=x86
 e asm.bits=32
 s entry0
-e asm.reflines=false
+e asm.lines=false
 e asm.offset=false
 e asm.functions=false
 e asm.comments=false
@@ -510,8 +510,8 @@ f.blah
 pd 1
 EOF
 EXPECT=<<EOF
-           .blah:
-               31ed           xor ebp, ebp           ; start.S:67
+ .blah:
+     31ed           xor ebp, ebp                               ; start.S:67
 EOF
 RUN
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
