### PR TITLE
Simplify deserialization of byte ##signatures

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -617,7 +617,7 @@ static bool validate_item(RSignItem *it) {
 			eprintf ("Signature '%s' has empty byte field\n", it->name);
 			return false;
 		}
-		if (b->mask[0] == '\0') {
+		if (!b->mask[0]) {
 			eprintf ("Signature '%s' mask starts empty\n", it->name);
 			return false;
 		}

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -135,7 +135,7 @@ static RSignBytes *deserialize_anal(RAnal *a, const char *in) {
 	RSignBytes *b = R_NEW0 (RSignBytes);
 	if (b && (b->size = r_hex_str2bin_until_new (in, &b->bytes)) > 0) {
 		in += 2 * b->size;
-		if (*in == '\0' && (b->mask = r_anal_mask (a, b->size, b->bytes, 0))) {
+		if (!*in && (b->mask = r_anal_mask (a, b->size, b->bytes, 0))) {
 			return b;
 		}
 	}

--- a/libr/include/r_sign.h
+++ b/libr/include/r_sign.h
@@ -17,8 +17,6 @@ R_LIB_VERSION_HEADER(r_sign);
 
 typedef enum {
 	R_SIGN_BYTES = 'b', // bytes pattern
-	R_SIGN_BYTES_MASK = 'm', // bytes pattern
-	R_SIGN_BYTES_SIZE = 's', // bytes pattern
 	R_SIGN_ANAL = 'a', // bytes pattern, input only, creates mask from byte analysis
 	R_SIGN_COMMENT = 'c', // comment
 	R_SIGN_GRAPH = 'g', // graph metrics
@@ -108,8 +106,8 @@ typedef struct {
 } RSignCloseMatch;
 
 #ifdef R_API
-R_API bool r_sign_add_bytes(RAnal *a, const char *name, ut64 size, const ut8 *bytes, const ut8 *mask);
-R_API bool r_sign_add_anal(RAnal *a, const char *name, ut64 size, const ut8 *bytes, ut64 at);
+R_API bool r_sign_add_bytes(RAnal *a, const char *name, const char *val);
+R_API bool r_sign_add_anal(RAnal *a, const char *name, const char *val);
 R_API bool r_sign_add_graph(RAnal *a, const char *name, RSignGraph graph);
 R_API int r_sign_all_functions(RAnal *a, bool merge);
 R_API bool r_sign_add_func(RAnal *a, RAnalFunction *fcn, const char *name);

--- a/libr/include/r_util/r_hex.h
+++ b/libr/include/r_util/r_hex.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 R_API int r_hex_pair2bin(const char *arg);
+R_API int r_hex_str2bin_until_new(const char *in, ut8 **out);
 R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask);
 R_API int r_hex_str2bin(const char *in, ut8 *out);
 R_API int r_hex_bin2str(const ut8 *in, int len, char *out);

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -450,6 +450,31 @@ R_API int r_hex_str2bin(const char *in, ut8 *out) {
 	return nibbles / 2;
 }
 
+// get the hex chars from start of string, until first non-hex char, as a heap
+// allocated ut8* buffer
+R_API int r_hex_str2bin_until_new(const char *in, ut8 **out) {
+	r_return_val_if_fail (in && out && !*out, -1);
+	size_t len = strlen (in);
+	if (len <= 1) {
+		return 0;
+	}
+	len = (len + 1) / 2;
+
+	ut8 *buf = NULL;
+	size_t nibbles = 0;
+	if ((buf = malloc (len)) != NULL) {
+		while (!r_hex_to_byte (&buf[nibbles / 2], *in)) {
+			nibbles++;
+			in++;
+		}
+	}
+	if (!nibbles || nibbles % 2 || !(*out = realloc (buf, nibbles / 2))) {
+		free (buf);
+		return !nibbles? 0: -1;
+	}
+	return nibbles / 2;
+}
+
 R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask) {
 	ut8 *ptr;
 	int len, ilen = strlen (in)+1;

--- a/libr/util/hex.c
+++ b/libr/util/hex.c
@@ -460,19 +460,30 @@ R_API int r_hex_str2bin_until_new(const char *in, ut8 **out) {
 	}
 	len = (len + 1) / 2;
 
-	ut8 *buf = NULL;
+	int ret = -1;
 	size_t nibbles = 0;
-	if ((buf = malloc (len)) != NULL) {
-		while (!r_hex_to_byte (&buf[nibbles / 2], *in)) {
+	ut8 *buf = malloc (len);
+	if (buf) {
+		while (!r_hex_to_byte (buf + nibbles / 2, *in)) {
 			nibbles++;
 			in++;
 		}
+
+		if (!nibbles || nibbles % 2) {
+			ret = 0;
+		} else {
+			ret = nibbles / 2;
+			*out = realloc (buf, ret);
+			if (!*out) {
+				ret = -1;
+			}
+		}
+
+		if (ret <= 0) {
+			free (buf);
+		}
 	}
-	if (!nibbles || nibbles % 2 || !(*out = realloc (buf, nibbles / 2))) {
-		free (buf);
-		return !nibbles? 0: -1;
-	}
-	return nibbles / 2;
+	return ret;
 }
 
 R_API int r_hex_str2binmask(const char *in, ut8 *out, ut8 *mask) {

--- a/test/unit/test_hex.c
+++ b/test/unit/test_hex.c
@@ -158,42 +158,42 @@ bool test_str2bin_alloc () {
 	int len;
 	// bad strings
 	len = r_hex_str2bin_until_new ("4", &buf);
-	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 1");
+	mu_assert_eq (len, 0, "r_hex_str2bin_until_new invalid str 1");
 	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 1");
 
 	len = r_hex_str2bin_until_new ("444:", &buf);
-	mu_assert_eq (-1, len, "r_hex_str2bin_until_new invalid str 2");
+	mu_assert_eq (len, 0, "r_hex_str2bin_until_new invalid str 2");
 	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 2");
 
 	len = r_hex_str2bin_until_new (" 4444", &buf);
-	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 3");
+	mu_assert_eq (len, 0, "r_hex_str2bin_until_new invalid str 3");
 	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 3");
 
 	len = r_hex_str2bin_until_new ("", &buf);
-	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 4");
+	mu_assert_eq (len, 0, "r_hex_str2bin_until_new invalid str 4");
 	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 4");
 
 	// bad bufs
 	ut8 *buf2[3];
 	len = r_hex_str2bin_until_new ("44", (ut8 **)&buf2);
-	mu_assert_eq (-1, len, "r_hex_str2bin_until_new accepted non-null **");
+	mu_assert_eq (len, -1, "r_hex_str2bin_until_new accepted non-null **");
 
 	len = r_hex_str2bin_until_new ("4142", NULL);
-	mu_assert_eq (-1, len, "r_hex_str2bin_until_new NULL *");
+	mu_assert_eq (len, -1, "r_hex_str2bin_until_new NULL *");
 
 	// valid input
 	buf = NULL;
 	len = r_hex_str2bin_until_new ("4142", &buf);
-	mu_assert_eq (2, len, "r_hex_str2bin_until_new simple example");
+	mu_assert_eq (len, 2, "r_hex_str2bin_until_new simple example");
 	mu_assert_notnull (buf, "r_hex_str2bin_until_new simple example");
-	mu_assert_memeq (buf, "\x41\x42", len, "r_hex_str2bin_until_new simple example");
+	mu_assert_memeq (buf, (ut8 *)"\x41\x42", len, "r_hex_str2bin_until_new simple example");
 	free (buf);
 
 	buf = NULL;
 	len = r_hex_str2bin_until_new ("414243:NOT_HEX", &buf);
-	mu_assert_eq (3, len, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
+	mu_assert_eq (len, 3, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
 	mu_assert_notnull (buf, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
-	mu_assert_memeq (buf, "\x41\x42\x43", len, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
+	mu_assert_memeq (buf, (ut8 *)"\x41\x42\x43", len, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
 	free (buf);
 
 	mu_end;

--- a/test/unit/test_hex.c
+++ b/test/unit/test_hex.c
@@ -153,11 +153,58 @@ bool test_r_hex_no_code() {
 	mu_end;
 }
 
+bool test_str2bin_alloc () {
+	ut8 *buf = NULL;
+	int len;
+	// bad strings
+	len = r_hex_str2bin_until_new ("4", &buf);
+	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 1");
+	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 1");
+
+	len = r_hex_str2bin_until_new ("444:", &buf);
+	mu_assert_eq (-1, len, "r_hex_str2bin_until_new invalid str 2");
+	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 2");
+
+	len = r_hex_str2bin_until_new (" 4444", &buf);
+	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 3");
+	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 3");
+
+	len = r_hex_str2bin_until_new ("", &buf);
+	mu_assert_eq (0, len, "r_hex_str2bin_until_new invalid str 4");
+	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 4");
+
+	// bad bufs
+	ut8 *buf2[3];
+	len = r_hex_str2bin_until_new ("44", (ut8 **)&buf2);
+	mu_assert_eq (-1, len, "r_hex_str2bin_until_new accepted non-null **");
+
+	len = r_hex_str2bin_until_new ("4142", NULL);
+	mu_assert_eq (-1, len, "r_hex_str2bin_until_new NULL *");
+
+	// valid input
+	buf = NULL;
+	len = r_hex_str2bin_until_new ("4142", &buf);
+	mu_assert_eq (2, len, "r_hex_str2bin_until_new simple example");
+	mu_assert_notnull (buf, "r_hex_str2bin_until_new simple example");
+	mu_assert_memeq (buf, "\x41\x42", len, "r_hex_str2bin_until_new simple example");
+	free (buf);
+
+	buf = NULL;
+	len = r_hex_str2bin_until_new ("414243:NOT_HEX", &buf);
+	mu_assert_eq (3, len, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
+	mu_assert_notnull (buf, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
+	mu_assert_memeq (buf, "\x41\x42\x43", len, "r_hex_str2bin_until_new \"414243:NOT_HEX\" returns 3 bytes");
+	free (buf);
+
+	mu_end;
+}
+
 bool all_tests() {
 	mu_run_test (test_r_hex_from_c);
 	mu_run_test (test_r_hex_from_py);
 	mu_run_test (test_r_hex_from_code);
 	mu_run_test (test_r_hex_no_code);
+	mu_run_test (test_str2bin_alloc);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This is two commits. One creates `r_hex_str2bin_until_new` see the unit tests for examples. Works like so:

```
ut8 *out;
char *str = "010203_NOTHEX";
int len = r_hex_str2bin_until_new (str, &out);
// len == 3
// *out == "\x010203"
// str + len * 2 == "_NOTHEX"
free (out);
```

The second commit uses the first. It simplifies the byte signature (de)serialization/parsing. It bothered me that `za` commands and sdb value deserialization used different parsing functions. Now they are put in the same place.

This also means bytes are stored in sdb files as `|b:0102030405:ffffffffff` now. Previously, serialized signatures looked like `|s:5|b:0102030405|m:ffffffffff` and required the `R_SIGN_SIZE` ('s') and `R_SIGN_MASK` ('m') enums. Those values are now free to be used for a new signature type, if desired.

This simplification should help later too. I hope to allow `z/` to deserialize just byte signatures for byte matching. This should have a modest speed increase to `z/` depending on the size of the signature database. It will large memory savings.

If you want any changes, or would rather this be split or anything else, let me know.