### PR TITLE
Fix broken unit test in hex

### DIFF
--- a/test/unit/test_hex.c
+++ b/test/unit/test_hex.c
@@ -173,15 +173,13 @@ bool test_str2bin_alloc () {
 	mu_assert_eq (len, 0, "r_hex_str2bin_until_new invalid str 4");
 	mu_assert_null (buf, "r_hex_str2bin_until_new invalid str 4");
 
-#if 0
 	// bad bufs
-	ut8 *buf2[3];
+	ut8 buf2[3];
 	len = r_hex_str2bin_until_new ("44", (ut8 **)&buf2);
 	mu_assert_eq (len, -1, "r_hex_str2bin_until_new accepted non-null **");
 
 	len = r_hex_str2bin_until_new ("4142", NULL);
 	mu_assert_eq (len, -1, "r_hex_str2bin_until_new NULL *");
-#endif
 
 	// valid input
 	buf = NULL;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Hopefully, this fixes the disabled tests. I think I messed up the pointer logic and so the test was using uninitialized memory before.
