### PR TITLE
Add binary search alg to pvector ##util

### DIFF
--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -268,6 +268,9 @@ static inline void **r_pvector_push_front(RPVector *vec, void *x) {
 // sort vec using quick sort.
 R_API void r_pvector_sort(RPVector *vec, RPVectorComparator cmp);
 
+// binary search vector, must be sorted already
+R_API int r_pvector_bsearch(RPVector *vec, void *needle, RPVectorComparator cmp);
+
 static inline void **r_pvector_reserve(RPVector *vec, size_t capacity) {
 	return (void **)r_vector_reserve (&vec->v, capacity);
 }

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -349,3 +349,29 @@ R_API void r_pvector_sort(RPVector *vec, RPVectorComparator cmp) {
 	r_return_if_fail (vec && cmp);
 	quick_sort (vec->v.a, vec->v.len, cmp);
 }
+
+R_API int r_pvector_bsearch(RPVector *vec, void *needle, RPVectorComparator cmp) {
+	r_return_val_if_fail (vec && cmp, -1);
+	size_t top = 0;
+	size_t end = vec->v.len;
+	void **ar = vec->v.a;
+
+	size_t dif;
+	while ((dif = end - top) > 0) {
+		size_t piv = top + dif / 2;
+		int match = cmp (ar[piv], needle);
+		if (!match) {
+			while (piv > top && !cmp (ar[piv - 1], needle)) {
+				piv--;
+			}
+			return piv;
+		}
+
+		if (match < 0) {
+			top = piv + 1;
+		} else {
+			end = piv;
+		}
+	}
+	return -1;
+}

--- a/test/unit/test_vector.c
+++ b/test/unit/test_vector.c
@@ -1040,6 +1040,162 @@ static bool test_pvector_sort(void) {
 	mu_end;
 }
 
+static bool test_pvector_bsearch(void) {
+	RPVector v;
+	r_pvector_init (&v, NULL);
+	RPVectorComparator cmp = (RPVectorComparator)strcmp;
+
+	r_pvector_push (&v, "A");
+	mu_assert_eq (v.v.len, 1UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+
+	r_pvector_push (&v, "B");
+	mu_assert_eq (v.v.len, 2UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+
+	r_pvector_push (&v, "C");
+	mu_assert_eq (v.v.len, 3UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+
+	r_pvector_push (&v, "D");
+	mu_assert_eq (v.v.len, 4UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+
+	// skipping E so we have something in middle to fail to find
+	r_pvector_push (&v, "F");
+	mu_assert_eq (v.v.len, 5UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't have");
+
+	r_pvector_push (&v, "G");
+	mu_assert_eq (v.v.len, 6UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	r_pvector_push (&v, "H");
+	mu_assert_eq (v.v.len, 7UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// duplicate should return first instance
+	r_pvector_push (&v, "H");
+	mu_assert_eq (v.v.len, 8UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// duplicate again
+	r_pvector_push (&v, "H");
+	mu_assert_eq (v.v.len, 9UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// duplicate again, again
+	r_pvector_push (&v, "H");
+	mu_assert_eq (v.v.len, 10UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// duplicates in middle
+	r_pvector_push (&v, "I");
+	mu_assert_eq (v.v.len, 11UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "I", cmp), 10UL, "searching 'I'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// duplicates further in middle...
+	r_pvector_push (&v, "I");
+	mu_assert_eq (v.v.len, 12UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "I", cmp), 10UL, "searching 'I'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	// last
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	r_pvector_push (&v, "I");
+	mu_assert_eq (v.v.len, 19UL, "bsearch len");
+	mu_assert_eq (r_pvector_bsearch (&v, "A", cmp), 0UL, "searching 'A'");
+	mu_assert_eq (r_pvector_bsearch (&v, "B", cmp), 1UL, "searching 'B'");
+	mu_assert_eq (r_pvector_bsearch (&v, "C", cmp), 2UL, "searching 'C'");
+	mu_assert_eq (r_pvector_bsearch (&v, "D", cmp), 3UL, "searching 'D'");
+	mu_assert_eq (r_pvector_bsearch (&v, "F", cmp), 4UL, "searching 'F'");
+	mu_assert_eq (r_pvector_bsearch (&v, "G", cmp), 5UL, "searching 'G'");
+	mu_assert_eq (r_pvector_bsearch (&v, "H", cmp), 6UL, "searching 'H'");
+	mu_assert_eq (r_pvector_bsearch (&v, "I", cmp), 10UL, "searching 'I'");
+	mu_assert_eq (r_pvector_bsearch (&v, "z", cmp), -1, "Found 'z', shouldn't have");
+	mu_assert_eq (r_pvector_bsearch (&v, "E", cmp), -1, "Found E, shoulnd't of");
+
+	r_pvector_clear (&v);
+	mu_end;
+}
+
 static bool test_pvector_foreach(void) {
 	RPVector v;
 	init_test_pvector2 (&v, 5, 5);
@@ -1125,6 +1281,7 @@ static int all_tests(void) {
 	mu_run_test (test_pvector_push);
 	mu_run_test (test_pvector_push_front);
 	mu_run_test (test_pvector_sort);
+	mu_run_test (test_pvector_bsearch);
 	mu_run_test (test_pvector_foreach);
 	mu_run_test (test_pvector_lower_bound);
 


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Ads `r_pvector_bsearch` which will perform a binary search on a `RPVector` iff the vector is sorted by `cmp`. Otherwise, undefined results.
