### PR TITLE
Fix use of NULL obj in graph

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2227,12 +2227,12 @@ static void get_bbupdate(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 		if (node) {
 			free (node->body);
 			node->body = body;
+			R_FREE (node->color);
+			if (bb->color.r || bb->color.g || bb->color.b) {
+				node->color = r_cons_rgb_str (NULL, -1, &bb->color);
+			}
 		} else {
 			free (body);
-		}
-		R_FREE (node->color);
-		if (bb->color.r || bb->color.g || bb->color.b) {
-			node->color = r_cons_rgb_str (NULL, -1, &bb->color);
 		}
 		free (title);
 		core->keep_asmqjmps = true;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Fixes crash in `VV`. In `VV` hit `,` to toggle `grpah.few`. Then hit `q` to get to `V` mode, then hit `V` to go back to `VV`. You will segfault.

Crash happens because `node->color` is used even if it's `node == NULL`.

I don't think there is any security impact to this finding. It would only be a DOS when you try to `free (0x18)`. I don't see how a DOS in `VV` with `graph.few` would break any automated r2 things (like auto-triage with r2).
