### PR TITLE
Show prev nodes in graph.few ##graph

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4556,6 +4556,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 			} else {
 				eprintf ("Cannot undo\n");
 			}
+			if (r_config_get_i (core->config, "graph.few")) {
+				g->need_reload_nodes = true;
+			}
 			break;
 		}
 		case 'U':
@@ -4568,6 +4571,9 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 				r_core_seek (core, undo->off, false);
 			} else {
 				eprintf ("Cannot redo\n");
+			}
+			if (r_config_get_i (core->config, "graph.few")) {
+				g->need_reload_nodes = true;
 			}
 			break;
 		}


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This pull does two things. It upgrades `graph.few` to display the nodes that reference the current node (see changes to `cur_points_to_bb`). 

It also fixes a minor bug in `graph.few`. Changing nodes with tab did not refresh the nodes on the screen. I refactored the code a bit so that any change to seek when `graph.few` was enabled would result in a refresh.