### PR TITLE
Fix NULL node warning in VV ##graph

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2315,16 +2315,11 @@ static void add_child(RCore *core, RAGraph *g, RANode *u, ut64 jump) {
 	RANode *v = r_agraph_get_node (g, title);
 	if (v) {
 		ut64 a = r_num_get (NULL, u->title);
-		int len = 64;
-		char key[len];
+		char key[64];
 		char *fmt = "agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight";
-		if (len > snprintf (key, len, fmt, a, jump)) {
-			bool hl = sdb_exists (core->sdb, key);
-			r_agraph_add_edge (g, u, v, hl);
-		} else {
-			// shouldn't overflow but implies len is wrong
-			r_warn_if_reached ();
-		}
+		snprintf (key, sizeof (key), fmt, a, jump);
+		bool hl = sdb_exists (core->sdb, key);
+		r_agraph_add_edge (g, u, v, hl);
 	} else {
 		eprintf ("[!!] Failed to add child node 0x%" PFMT64x " to %s. Child not found\n", jump, u->title);
 	}

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2315,10 +2315,16 @@ static void add_child(RCore *core, RAGraph *g, RANode *u, ut64 jump) {
 	RANode *v = r_agraph_get_node (g, title);
 	if (v) {
 		ut64 a = r_num_get (NULL, u->title);
-		ut64 b = r_num_get (NULL, title);
-		const char *k = sdb_fmt ("agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight", a, b);
-		bool hl = sdb_exists (core->sdb, k);
-		r_agraph_add_edge (g, u, v, hl);
+		int len = 64;
+		char key[len];
+		char *fmt = "agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight";
+		if (len > snprintf (key, len, fmt, a, jump)) {
+			bool hl = sdb_exists (core->sdb, key);
+			r_agraph_add_edge (g, u, v, hl);
+		} else {
+			// shouldn't overflow but implies len is wrong
+			r_warn_if_reached ();
+		}
 	} else {
 		eprintf ("[!!] Failed to add child node 0x%" PFMT64x " to %s. Child not found\n", jump, u->title);
 	}

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2319,6 +2319,8 @@ static void add_child(RCore *core, RAGraph *g, RANode *u, ut64 jump) {
 		const char *k = sdb_fmt ("agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight", a, b);
 		bool hl = sdb_exists (core->sdb, k);
 		r_agraph_add_edge (g, u, v, hl);
+	} else {
+		eprintf ("[!!] Failed to add child node 0x%" PFMT64x " to %s. Child not found\n", jump, u->title);
 	}
 	free (title);
 }

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2313,12 +2313,14 @@ static void add_child(RCore *core, RAGraph *g, RANode *u, ut64 jump) {
 	}
 	char *title = get_title (jump);
 	RANode *v = r_agraph_get_node (g, title);
-	ut64 a = r_num_get (NULL, u->title);
-	ut64 b = r_num_get (NULL, title);
+	if (v) {
+		ut64 a = r_num_get (NULL, u->title);
+		ut64 b = r_num_get (NULL, title);
+		const char *k = sdb_fmt ("agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight", a, b);
+		bool hl = sdb_exists (core->sdb, k);
+		r_agraph_add_edge (g, u, v, hl);
+	}
 	free (title);
-	const char *k = sdb_fmt ("agraph.edge.0x%"PFMT64x"_0x%"PFMT64x".highlight", a, b);
-	bool hl = sdb_exists (core->sdb, k);
-	r_agraph_add_edge (g, u, v, hl);
 }
 
 /* build the RGraph inside the RAGraph g, starting from the Basic Blocks */

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2316,7 +2316,7 @@ static void add_child(RCore *core, RAGraph *g, RANode *u, ut64 jump) {
 	if (v) {
 		ut64 a = r_num_get (NULL, u->title);
 		char key[64];
-		char *fmt = "agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight";
+		const char *fmt = "agraph.edge.0x%" PFMT64x "_0x%" PFMT64x ".highlight";
 		snprintf (key, sizeof (key), fmt, a, jump);
 		bool hl = sdb_exists (core->sdb, key);
 		r_agraph_add_edge (g, u, v, hl);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

I am not very familiar with this code, so please double check me. 

I had `r_agraph_add_edge` warning because `v` was `NULL`.  If `v` being `NULL` is an error, then an `else` should be added to the code to warn. Otherwise, i think it is good to merge.