### PR TITLE
Fix missing bounds check in dwarf_langs

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -340,6 +340,13 @@ static int abbrev_cmp(const void *a, const void *b) {
 	}
 }
 
+static bool is_printable_lang(ut64 attr_code) {
+	if (attr_code >= sizeof (dwarf_langs) / sizeof (dwarf_langs[0])) {
+		return false;
+	}
+	return dwarf_langs[attr_code] != NULL;
+}
+
 static inline bool is_printable_attr(ut64 attr_code) {
 	return (attr_code >= DW_AT_sibling && attr_code <= DW_AT_loclists_base) ||
 			attr_code == DW_AT_MIPS_linkage_name ||
@@ -1434,7 +1441,11 @@ static void print_attr_value(const RBinDwarfAttrValue *val, PrintfCallback print
 	case DW_FORM_data16:
 		print ("%"PFMT64u"", val->uconstant);
 		if (val->attr_name == DW_AT_language) {
-			print ("   (%s)", dwarf_langs[val->uconstant]);
+			if (is_printable_lang (val->uconstant)) {
+				print ("   (%s)", dwarf_langs[val->uconstant]);
+			} else {
+				print ("   (unknown language)");
+			}
 		}
 		break;
 	case DW_FORM_string:


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
This change adds a bounds check to the print used to display the DW_AT_language attribute. Currently, there is no check on the index, which can lead to memory disclosure or crashes. This print is used in `rabin2 -d`.
  I've added a bounds check on the maximum language index, as well as a check that makes sure the language is defined.
  
## Test file:
I originally found the bug with a fuzzer and used it to create the following synthetic example file:
```bash
#!/bin/bash

echo "int main(){}" | gcc -x c - -o example

echo -n "ATQAEwcTBxMHAAAA" | base64 -d > tmp_abbrev
echo -n "IgAAAAQAAAAAAAgBQUFBQUFBQUEVAAAAAAAAAAwAAAAAAAAAAAA=" | base64 -d > tmp_info

objcopy --add-section .debug_info=tmp_info example
objcopy --add-section .debug_abbrev=tmp_abbrev example

rm tmp_*
```
The test file contains three language tags:
* `0x4141414141414141` -> way out of bounds, will cause a segfault
* `0x15` -> In bounds, but not defined
* `0x0c` -> Valid tag (C99)

## Old behaviour:
```
rabin2 -d example 
dwarf.c:1441:33: runtime error: index 4702111234474983745 out of bounds for type 'char *[36]'
dwarf.c:1441:4: runtime error: load of address 0xa0a8a09f498f668 with insufficient space for an object of type 'const char *'
0xa0a8a09f498f668: note: pointer points here
<memory cannot be printed>
AddressSanitizer:DEADLYSIGNAL
=================================================================
==217608==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7fffe9fe9f52 bp 0x7ffffff9bda0 sp 0x7ffffff9bd70 T0)
==217608==The signal is caused by a READ memory access.
==217608==Hint: address points to the zero page.
    #0 0x7fffe9fe9f51 in print_attr_value /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/bin/dwarf.c:1441
    #1 0x7fffe9febab7 in print_debug_info /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/bin/dwarf.c:1549
    #2 0x7fffe9ff8b4b in r_bin_dwarf_parse_info /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/bin/dwarf.c:2238
    #3 0x7fffec62ade2 in bin_dwarf /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/core/cbin.c:1086
    #4 0x7fffec6538ca in r_core_bin_info /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/core/cbin.c:4186
    #5 0x7ffff7491d98 in r_main_rabin2 /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/main/rabin2.c:1173
    #6 0x5555555551ac in main /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/binr/rabin2/rabin2.c:6
    #7 0x7ffff68c60b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #8 0x5555555550cd in _start (/home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/binr/rabin2/rabin2+0x10cd)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/rick/courses/ru/SoftwareSecurity/RadareFuzzing/radare2/libr/bin/dwarf.c:1441 in print_attr_value
==217608==ABORTING
```
## New bahavior
```
~/git/radare2/r2-static/usr/bin/rabin2 -d example 
   1      DW_TAG_variable           [no children] (0x0)
    DW_AT_language                 DW_FORM_data8                 
    DW_AT_language                 DW_FORM_data8                 
    DW_AT_language                 DW_FORM_data8                 

  Compilation Unit @ offset 0x0:
   Length:        0x22
   Version:       4
   Abbrev Offset: 0x0
   Pointer Size:  8

<0xb>: Abbrev Number: 1    (DW_TAG_variable)
     DW_AT_language            : 4702111234474983745   (unknown language)
     DW_AT_language            : 21   (unknown language)
     DW_AT_language            : 12   (C99)
<0x24>: Abbrev Number: 0    (DW_TAG_null_entry)
<0x25>: Abbrev Number: 0    (DW_TAG_null_entry)

```

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
