### PR TITLE
Use remote URL for git pull in install scripts ##build

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -67,7 +67,7 @@ if [ "$1" != "--without-pull" ]; then
 		git branch | grep "^\* master" > /dev/null
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
-			git pull
+			git pull https://github.com/radareorg/radare2 master
 		fi
 	fi
 else

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -249,7 +249,7 @@ def main():
 
     # Check arguments
     if args.pull:
-        os.system('git pull')
+        os.system('git pull https://github.com/radareorg/radare2 master')
     if args.project and args.backend == 'ninja':
         log.error('--project is not compatible with --backend ninja')
         sys.exit(1)

--- a/sys/termux.sh
+++ b/sys/termux.sh
@@ -7,7 +7,7 @@ export ANDROID=1
 # make clean > /dev/null 2>&1
 rm -f libr/include/r_version.h
 cp -f dist/plugins-cfg/plugins.termux.cfg plugins.cfg
-git pull
+git pull https://github.com/radareorg/radare2 master
 ./preconfigure
 ./configure-plugins
 bash ./configure --with-compiler=termux --prefix=${PREFIX} || exit 1

--- a/sys/user.sh
+++ b/sys/user.sh
@@ -53,7 +53,7 @@ if [ $WITHOUT_PULL -eq 0 ]; then
 		git branch | grep "^\* master" > /dev/null
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
-			git pull
+			git pull https://github.com/radareorg/radare2 master
 		fi
 	fi
 fi


### PR DESCRIPTION
**Description**

Some users' master branch does not track upstream, causing `git pull` in install scripts to fail when building on master with the error "There is no tracking information for the current branch". Adding the repository URL and specifying the master branch prevents this failure, allowing master to be updated automatically during install without tracking information.