### PR TITLE
Add bin_xtr.xtr_pemixed for PE user plugin ##build

### DIFF
--- a/libr/meson.build
+++ b/libr/meson.build
@@ -115,6 +115,7 @@ if not no_user_plugins
   endif
   if user_plugins.contains('pe')
     bin_plugins += [ 'pe', 'pe64', 'coff', 'mz', 'ne' ]
+    bin_xtr_plugins += [ 'xtr_pemixed' ]
   endif
   if not user_plugins.contains('nogrub')
     fs_plugins += [ 'cpio', 'ext2', 'fat', 'fb', 'hfs',


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Currently when using the `pe` plugin pemixed is not enabled, however in the non-Meson build it will be enabled as part of the default configuration.
