### PR TITLE
Liberate RSpaces from old rbtree api

### DIFF
--- a/libr/core/cmd_flag.c
+++ b/libr/core/cmd_flag.c
@@ -298,7 +298,7 @@ static void __flag_graph (RCore *core, const char *input, int mode) {
 }
 
 static void spaces_list(RSpaces *sp, int mode) {
-	RSpaceIter it;
+	RSpaceIter *it;
 	RSpace *s;
 	const RSpace *cur = r_spaces_current (sp);
 	PJ *pj = NULL;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1544,7 +1544,7 @@ static void autocomplete_zignatures(RCore *core, RLineCompletion *completion, co
 	int length = strlen (msg);
 	RSpaces *zs = &core->anal->zign_spaces;
 	RSpace *s;
-	RSpaceIter it;
+	RSpaceIter *it;
 
 	r_spaces_foreach (zs, it, s) {
 		if (!strncmp (msg, s->name, length)) {
@@ -1561,7 +1561,7 @@ static void autocomplete_flagspaces(RCore *core, RLineCompletion *completion, co
 	r_return_if_fail (msg);
 	int length = strlen (msg);
 	RFlag *flag = core->flags;
-	RSpaceIter it;
+	RSpaceIter *it;
 	RSpace *s;
 	r_flag_space_foreach (flag, it, s) {
 		if (!strncmp (msg, s->name, length)) {

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -1993,7 +1993,7 @@ R_API int r_core_visual_trackflags(RCore *core) {
 		} else {
 			r_cons_printf ("Flag spaces:\n\n");
 			hit = 0;
-			RSpaceIter it;
+			RSpaceIter *it;
 			const RSpace *s, *cur = r_flag_space_cur (core->flags);
 			int i = 0;
 			r_flag_space_foreach (core->flags, it, s) {

--- a/libr/include/r_util/r_new_rbtree.h
+++ b/libr/include/r_util/r_new_rbtree.h
@@ -60,6 +60,7 @@ R_API void r_crbtree_free(RRBTree *tree);
 R_API RRBNode *r_crbtree_find_node(RRBTree *tree, void *data, RRBComparator cmp, void *user);
 R_API void *r_crbtree_find(RRBTree *tree, void *data, RRBComparator cmp, void *user);
 R_API bool r_crbtree_insert(RRBTree *tree, void *data, RRBComparator cmp, void *user);
+R_API void *r_crbtree_take(RRBTree *tree, void *data, RRBComparator cmp, void *user);
 R_API bool r_crbtree_delete(RRBTree *tree, void *data, RRBComparator cmp, void *user);
 R_API RRBNode *r_crbtree_first_node(RRBTree *tree);
 R_API RRBNode *r_crbtree_last_node(RRBTree *tree);

--- a/libr/include/r_util/r_spaces.h
+++ b/libr/include/r_util/r_spaces.h
@@ -23,9 +23,9 @@ extern "C" {
  * R_SPACE_EVENT_UNSET: called when deleting a RSpace with a given name
  */
 
+// XXX: kill this
 typedef struct r_space_t {
 	char *name;
-	RBNode rb;
 } RSpace;
 
 typedef enum {
@@ -54,7 +54,7 @@ typedef struct r_space_event_t {
 typedef struct r_spaces_t {
 	const char *name;
 	RSpace *current;
-	RBTree spaces;
+	RRBTree *spaces;
 	RList *spacestack;
 	REvent *event;
 } RSpaces;
@@ -95,13 +95,12 @@ static inline const char *r_spaces_current_name(RSpaces *sp) {
 }
 
 static inline bool r_spaces_is_empty(RSpaces *sp) {
-	RBIter it = r_rbtree_first (sp->spaces);
-	return it.len == 0;
+	return !!r_crbtree_first_node (sp->spaces);
 }
 
-typedef RBIter RSpaceIter;
+typedef RRBNode RSpaceIter;
 #define r_spaces_foreach(sp, it, s) \
-	r_rbtree_foreach ((sp)->spaces, (it), (s), RSpace, rb)
+	r_crbtree_foreach ((sp)->spaces, (it), (s))
 
 #ifdef __cplusplus
 }

--- a/libr/util/spaces.c
+++ b/libr/util/spaces.c
@@ -11,6 +11,14 @@ R_API RSpaces *r_spaces_new(const char *name) {
 	return sp;
 }
 
+static void space_free(void *data) {
+	RSpace *s = (RSpace *)data;
+	if (s) {
+		free (s->name);
+		free (s);
+	}
+}
+
 R_API bool r_spaces_init(RSpaces *sp, const char *name) {
 	r_return_val_if_fail (sp && name, false);
 	sp->name = strdup (name);
@@ -18,7 +26,10 @@ R_API bool r_spaces_init(RSpaces *sp, const char *name) {
 		goto fail;
 	}
 
-	sp->spaces = NULL;
+	sp->spaces = r_crbtree_new (space_free);
+	if (!sp->spaces) {
+		goto fail;
+	}
 	sp->current = NULL;
 	sp->spacestack = r_list_new ();
 	if (!sp->spacestack) {
@@ -42,24 +53,11 @@ R_API void r_spaces_free(RSpaces *sp) {
 	free (sp);
 }
 
-static inline void space_free(RSpace *s) {
-	if (s) {
-		free (s->name);
-		free (s);
-	}
-}
-
-static void space_node_free(RBNode *n, void *user) {
-	RSpace *s = container_of (n, RSpace, rb);
-	space_free (s);
-}
-
 R_API void r_spaces_fini(RSpaces *sp) {
 	r_list_free (sp->spacestack);
 	sp->spacestack = NULL;
-	r_rbtree_free (sp->spaces, space_node_free, NULL);
+	r_crbtree_free (sp->spaces);
 	sp->spaces = NULL;
-	r_event_free (sp->event);
 	sp->event = NULL;
 	sp->current = NULL;
 	R_FREE (sp->name);
@@ -68,12 +66,12 @@ R_API void r_spaces_fini(RSpaces *sp) {
 R_API void r_spaces_purge(RSpaces *sp) {
 	sp->current = NULL;
 	r_list_purge (sp->spacestack);
-	r_rbtree_free (sp->spaces, space_node_free, NULL);
+	r_crbtree_free (sp->spaces);
 	sp->spaces = NULL;
 }
 
-static int name_space_cmp(const void *incoming, const RBNode *rb, void *user) {
-	const RSpace *s = container_of (rb, const RSpace, rb);
+static int name_space_cmp(void *incoming, void *in, void *user) {
+	RSpace *s = (RSpace *)in;
 	return strcmp (incoming, s->name);
 }
 
@@ -81,13 +79,12 @@ R_API RSpace *r_spaces_get(RSpaces *sp, const char *name) {
 	if (!name) {
 		return NULL;
 	}
-	RBNode *n = r_rbtree_find (sp->spaces, (void *)name, name_space_cmp, NULL);
-	return n? container_of (n, RSpace, rb): NULL;
+	return r_crbtree_find (sp->spaces, (void *)name, name_space_cmp, NULL);
 }
 
-static int space_cmp(const void *incoming, const RBNode *rb, void *user) {
-	const RSpace *a = (const RSpace *)incoming;
-	const RSpace *b = container_of (rb, const RSpace, rb);
+static int space_cmp(void *incoming, void *in, void *user) {
+	RSpace *a = (RSpace *)incoming;
+	RSpace *b = (RSpace *)in;
 	return strcmp (a->name, b->name);
 }
 
@@ -113,7 +110,7 @@ R_API RSpace *r_spaces_add(RSpaces *sp, const char *name) {
 		return NULL;
 	}
 
-	r_rbtree_insert (&sp->spaces, s, &s->rb, space_cmp, NULL);
+	r_crbtree_insert (sp->spaces, s, space_cmp, NULL);
 	return s;
 }
 
@@ -133,7 +130,7 @@ static inline bool spaces_unset_single(RSpaces *sp, const char *name) {
 	if (sp->current == space) {
 		sp->current = NULL;
 	}
-	return r_rbtree_delete (&sp->spaces, (void *)name, name_space_cmp, NULL, space_node_free, NULL);
+	return r_crbtree_delete (sp->spaces, (void *)name, name_space_cmp, NULL);
 }
 
 R_API bool r_spaces_unset(RSpaces *sp, const char *name) {
@@ -146,16 +143,16 @@ R_API bool r_spaces_unset(RSpaces *sp, const char *name) {
 		return false;
 	}
 
-	RBIter it;
+	RRBNode *iter;
 	RSpace *s;
-	r_spaces_foreach (sp, it, s) {
+	r_spaces_foreach (sp, iter, s) {
 		r_list_append (names, strdup (s->name));
 	}
 
-	RListIter *lit;
+	RListIter *ator;
 	const char *n;
 	bool res = false;
-	r_list_foreach (names, lit, n) {
+	r_list_foreach (names, ator, n) {
 		res |= spaces_unset_single (sp, n);
 	}
 	r_list_free (names);
@@ -218,10 +215,10 @@ R_API bool r_spaces_rename(RSpaces *sp, const char *oname, const char *nname) {
 	};
 	r_event_send (sp->event, R_SPACE_EVENT_RENAME, &ev);
 
-	r_rbtree_delete (&sp->spaces, (void *)s->name, name_space_cmp, NULL, NULL, NULL);
+	r_crbtree_take (sp->spaces, s->name, name_space_cmp, NULL);
 	free (s->name);
 	s->name = strdup (nname);
-	r_rbtree_insert (&sp->spaces, s, &s->rb, space_cmp, NULL);
+	r_crbtree_insert (sp->spaces, s, space_cmp, NULL);
 
 	return true;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
![harold](https://user-images.githubusercontent.com/5904302/142704121-b20ab165-d372-4d06-881e-291619fe03c8.jpg)
