### PR TITLE
Improve Plan 9 support ##bin

### DIFF
--- a/libr/bin/format/p9/p9bin.c
+++ b/libr/bin/format/p9/p9bin.c
@@ -1,46 +1,68 @@
-/* radare - LGPL - Copyright 2011 pancake<nopcode.org> */
+/* radare - LGPL - Copyright 2011-2021 pancake<nopcode.org>, keegan */
 
 #include "p9bin.h"
 #include <r_asm.h>
 
-int r_bin_p9_get_arch(RBuffer *b, int *bits, int *big_endian) {
-	st32 a = (st32) r_buf_read_be32_at (b, 0);
-	if (bits) {
-		*bits = 32;
+bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
+	ut32 header = r_buf_read_be32_at (b, 0);
+	if (header == UT32_MAX) {
+		return false;
 	}
-	if (big_endian) {
-		*big_endian = 0;
+
+	*bits = 32;
+	*big_endian = 0;
+
+	switch (header) {
+	case MAGIC_68020:
+		*big_endian = 1;
+		*arch = R_SYS_ARCH_M68K;
+		return true;
+
+	case MAGIC_AMD64:
+		*bits = 64;
+		/* fallthrough */
+	case MAGIC_INTEL_386:
+		*arch = R_SYS_ARCH_X86;
+		return true;
+
+	case MAGIC_SPARC64:
+		*bits = 64;
+		/* fallthrough */
+	case MAGIC_SPARC:
+		*big_endian = 1;
+		*arch = R_SYS_ARCH_SPARC;
+		return true;
+
+	case MAGIC_MIPS_4000BE:
+		*big_endian = 1;
+		/* fallthrough */
+	case MAGIC_MIPS_4000LE:
+		*bits = 64;
+		*arch = R_SYS_ARCH_MIPS;
+		return true;
+
+	case MAGIC_MIPS_3000BE:
+		*big_endian = 1;
+		/* fallthrough */
+	case MAGIC_MIPS_3000LE:
+		*arch = R_SYS_ARCH_MIPS;
+		return true;
+
+	case MAGIC_ARM64:
+		*bits = 64;
+		/* fallthrough */
+	case MAGIC_ARM:
+		*arch = R_SYS_ARCH_ARM;
+		return true;
+
+	case MAGIC_PPC64:
+		*bits = 64;
+		/* fallthrough */
+	case MAGIC_PPC:
+		*big_endian = 1;
+		*arch = R_SYS_ARCH_PPC;
+		return true;
 	}
-	switch (a) {
-	case I_MAGIC:
-		return R_ASM_ARCH_X86;
-	case T_MAGIC:
-		if (bits) {
-			*bits = 64;
-		}
-		return R_ASM_ARCH_PPC;
-	case S_MAGIC:
-		if (bits) {
-			*bits = 64;
-		}
-		return R_ASM_ARCH_X86;
-	case K_MAGIC:
-		return R_ASM_ARCH_SPARC;
-	case U_MAGIC:
-		if (bits) {
-			*bits = 64;
-		}
-		return R_ASM_ARCH_SPARC;
-	case V_MAGIC:
-	case M_MAGIC:
-	case N_MAGIC:
-	case P_MAGIC:
-		return R_ASM_ARCH_MIPS;
-	case E_MAGIC:
-		return R_ASM_ARCH_ARM;
-	case Q_MAGIC:
-		return R_ASM_ARCH_PPC;
-	//case A_MAGIC: // 68020
-	}
-	return 0;
+
+	return false;
 }

--- a/libr/bin/format/p9/p9bin.h
+++ b/libr/bin/format/p9/p9bin.h
@@ -1,56 +1,54 @@
+/* radare2 - LGPL - Copyright 2011-2021 - pancake, keegan */
+
 #ifndef P9BIN_H
 #define P9BIN_H
 
 #include <r_util.h>
 
-/*
- * Binary loader for Plan 9's a.out executable format
- * 
- * Copyright (C) 2008 Anant Narayanan
- */
+R_PACKED(
 struct plan9_exec {
-	unsigned long magic;	/* magic number */
-	unsigned long text;	/* size of text segment */
-	unsigned long data;	/* size of initialized data */
-	unsigned long bss;	/* size of uninitialized data */
-	unsigned long syms;	/* size of symbol table */
-	unsigned long entry;	/* entry point */
-	unsigned long spsz;	/* size of pc/sp offset table */
-	unsigned long pcsz;	/* size of pc/line number table */
-};
+	ut32 magic;
+	ut32 text;
+	ut32 data;
+	ut32 bss;
+	ut32 syms;
+	ut32 entry;
+	ut32 spsz;
+	ut32 pcsz;
+});
 
-#define HDR_MAGIC	0x00008000	/* header expansion */
+/* Flag for extended header. This means that an additional 64-bit integer follows
+ * the standard header which specifies the 64-bit entrypoint. */
+#define HDR_MAGIC 0x00008000
 
-#define	_MAGIC(f, b)	((f)|((((4*(b))+0)*(b))+7))
-#define	A_MAGIC		_MAGIC(0, 8)	/* 68020 */
-#define	I_MAGIC		_MAGIC(0, 11)	/* intel 386 */
-#define	J_MAGIC		_MAGIC(0, 12)	/* intel 960 (retired) */
-#define	K_MAGIC		_MAGIC(0, 13)	/* sparc */
-#define	V_MAGIC		_MAGIC(0, 16)	/* mips 3000 BE */
-#define	X_MAGIC		_MAGIC(0, 17)	/* att dsp 3210 (retired) */
-#define	M_MAGIC		_MAGIC(0, 18)	/* mips 4000 BE */
-#define	D_MAGIC		_MAGIC(0, 19)	/* amd 29000 (retired) */
-#define	E_MAGIC		_MAGIC(0, 20)	/* arm */
-#define	Q_MAGIC		_MAGIC(0, 21)	/* powerpc */
-#define	N_MAGIC		_MAGIC(0, 22)	/* mips 4000 LE */
-#define	L_MAGIC		_MAGIC(0, 23)	/* dec alpha */
-#define	P_MAGIC		_MAGIC(0, 24)	/* mips 3000 LE */
-#define	U_MAGIC		_MAGIC(0, 25)	/* sparc64 */
-#define	S_MAGIC		_MAGIC(HDR_MAGIC, 26)	/* amd64 */
-#define	T_MAGIC		_MAGIC(HDR_MAGIC, 27)	/* powerpc64 */
+#define	_MAGIC(flags, b) ((flags) | ((((4 * (b)) + 0) * (b)) + 7))
 
-#define TOS_SIZE	14	/* Size of Top of Stack: 56 / 4 */
-#define HDR_SIZE	0x20
-#define STR_ADDR	0x1000	/* Start Address */
-#define TXT_ADDR	HDR_SIZE + ex.text	/* TEXT Address */
-#define DAT_ADDR	STR_ADDR + PAGE_ALIGN(TXT_ADDR)	/* DATA&BSS Address */
+#define	MAGIC_68020 _MAGIC(0, 8)
 
-/*---*/
+#define	MAGIC_INTEL_386 _MAGIC(0, 11)
+#define	MAGIC_AMD64 _MAGIC(HDR_MAGIC, 26)
 
-#define p9bin_open(x) fopen(x,"r")
-#define p9bin_close(x) fclose(x)
+#define	MAGIC_SPARC _MAGIC(0, 13)
+#define	MAGIC_SPARC64 _MAGIC(0, 25)
+
+#define	MAGIC_MIPS_3000BE _MAGIC(0, 16)
+#define	MAGIC_MIPS_4000BE _MAGIC(0, 18)
+#define	MAGIC_MIPS_4000LE _MAGIC(0, 22)
+#define	MAGIC_MIPS_3000LE _MAGIC(0, 24)
+
+#define	MAGIC_ARM _MAGIC(0, 20)
+#define	MAGIC_ARM64 _MAGIC(HDR_MAGIC, 28)
+
+#define	MAGIC_PPC _MAGIC(0, 21)
+#define	MAGIC_PPC64 _MAGIC(HDR_MAGIC, 27)
+
+/* Retired, and subsequently unsupported, architectures. */
+#define	MAGIC_INTEL_960 _MAGIC(0, 12)
+#define	MAGIC_ATT_DSP_3210 _MAGIC(0, 17)
+#define	MAGIC_AMD_29000 _MAGIC(0, 19)
+#define	MAGIC_DEC_ALPHA _MAGIC(0, 23)
 
 /* Reads four bytes from b. */
-int r_bin_p9_get_arch(RBuffer *b, int *bits, int *big_endian);
+bool r_bin_p9_get_arch(R_NONNULL RBuffer *b, R_NONNULL RSysArch *arch, R_NONNULL int *bits, R_NONNULL int *big_endian);
 
 #endif

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2009-2019 - nibble, pancake */
+/* radare2 - LGPL - Copyright 2009-2021 - nibble, pancake, keegan */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -6,12 +6,29 @@
 #include <r_bin.h>
 #include "../format/p9/p9bin.h"
 
+#define ALIGN(address, align) (((address) + (align - 1)) & ~(align - 1))
+
 static bool check_buffer(RBinFile *bf, RBuffer *buf) {
-	return r_bin_p9_get_arch (buf, NULL, NULL);
+	RSysArch arch;
+	int bits, big_endian;
+	return r_bin_p9_get_arch (buf, &arch, &bits, &big_endian);
 }
 
-static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr, Sdb *sdb){
-	return check_buffer (bf, b);
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr, Sdb *sdb) {
+	if (!check_buffer (bf, b)) {
+		return false;
+	}
+
+	struct plan9_exec *header = R_NEW0 (struct plan9_exec);
+	if (r_buf_fread_at (bf->buf, 0, (ut8 *)header, "IIIIIIII", 1) != sizeof (*header)) {
+		return false;
+	}
+
+	if (bin_obj) {
+		*bin_obj = header;
+	}
+
+	return true;
 }
 
 static void destroy(RBinFile *bf) {
@@ -19,33 +36,67 @@ static void destroy(RBinFile *bf) {
 }
 
 static ut64 baddr(RBinFile *bf) {
-	return 0x1000000; // XXX
+	struct plan9_exec *header = (struct plan9_exec *)bf->o->bin_obj;
+
+	switch (header->magic) {
+	case MAGIC_ARM64:
+		return 0x10000ULL;
+	case MAGIC_PPC64:
+	case MAGIC_AMD64:
+		return 0x200000ULL;
+	case MAGIC_68020:
+	case MAGIC_INTEL_386:
+	case MAGIC_SPARC:
+	case MAGIC_SPARC64:
+	case MAGIC_MIPS_3000BE:
+	case MAGIC_MIPS_4000BE:
+	case MAGIC_MIPS_4000LE:
+	case MAGIC_MIPS_3000LE:
+	case MAGIC_ARM:
+	case MAGIC_PPC:
+		return 0x1000ULL;
+	}
+
+	// unreachable because check_buffer only supports the above architectures
+	assert(0);
 }
 
 static RBinAddr *binsym(RBinFile *bf, int type) {
-	return NULL; // TODO
+	return NULL;
 }
 
 static RList *entries(RBinFile *bf) {
 	RList *ret;
 	RBinAddr *ptr = NULL;
+	struct plan9_exec *header = (struct plan9_exec *)bf->o->bin_obj;
 
 	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
+
 	ret->free = free;
+
 	if ((ptr = R_NEW0 (RBinAddr))) {
-		ptr->paddr = 8 * 4;
-		ptr->vaddr = 8 * 4;// + baddr (bf);
+		// if there is an extended header (64-bit), read the additional entry
+		if (header->magic & HDR_MAGIC) {
+			ut64 entry = r_buf_read_be64_at (bf->buf, sizeof (struct plan9_exec));
+			ptr->paddr = entry - baddr (bf);
+			ptr->vaddr = entry;
+		} else {
+			ptr->paddr = header->entry - baddr (bf);
+			ptr->vaddr = header->entry;
+		}
+
 		r_list_append (ret, ptr);
 	}
+
 	return ret;
 }
 
 static RList *sections(RBinFile *bf) {
 	RList *ret = NULL;
 	RBinSection *ptr = NULL;
-	ut64 textsize, datasize, symssize, spszsize, pcszsize;
+	struct plan9_exec *header = (struct plan9_exec *)bf->o->bin_obj;
 	if (!bf->o->info) {
 		return NULL;
 	}
@@ -53,116 +104,138 @@ static RList *sections(RBinFile *bf) {
 	if (!(ret = r_list_newf ((RListFree)free))) {
 		return NULL;
 	}
-	if (r_buf_size (bf->buf) < 28) {
-		r_list_free (ret);
-		return NULL;
+
+	ut32 align = 0x1000;
+	// on some platfroms the text segment has a separate alignment from the rest
+	switch (header->magic) {
+	case MAGIC_AMD64:
+		align = 0x200000;
+		break;
+	case MAGIC_MIPS_3000BE:
+		align = 0x4000;
+		break;
+	case MAGIC_ARM64:
+		align = 0x10000;
+		break;
 	}
+
+	ut64 phys = 0;
+	ut64 vsize = 0;
+
 	// add text segment
-	textsize = r_buf_read_le32_at (bf->buf, 4);
 	if (!(ptr = R_NEW0 (RBinSection))) {
-		r_list_free (ret);
-		return NULL;
+		return ret;
 	}
 	ptr->name = strdup ("text");
-	ptr->size = textsize;
-	ptr->vsize = textsize + (textsize % 4096);
-	ptr->paddr = 8 * 4;
-	ptr->vaddr = ptr->paddr;
+	ptr->size = header->text;
+	ptr->vsize = ALIGN(header->text, align);
+	ptr->paddr = phys;
+	ptr->vaddr = baddr (bf);
 	ptr->perm = R_PERM_RX; // r-x
 	ptr->add = true;
 	r_list_append (ret, ptr);
+	phys += ptr->size;
+	vsize += ptr->vsize;
+
+	// switch back to 4k page size
+	align = 0x1000;
+
 	// add data segment
-	datasize = r_buf_read_le32_at (bf->buf, 8);
-	if (datasize > 0) {
-		if (!(ptr = R_NEW0 (RBinSection))) {
-			return ret;
-		}
-		ptr->name = strdup ("data");
-		ptr->size = datasize;
-		ptr->vsize = datasize + (datasize % 4096);
-		ptr->paddr = textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
-		ptr->perm = R_PERM_RW;
-		ptr->add = true;
-		r_list_append (ret, ptr);
+	if (!(ptr = R_NEW0 (RBinSection))) {
+		return ret;
 	}
-	// ignore bss or what
+	ptr->name = strdup ("data");
+	ptr->size = header->data;
+	ptr->vsize = ALIGN(header->data, align);
+	ptr->paddr = phys;
+	ptr->vaddr = baddr (bf) + vsize;
+	ptr->perm = R_PERM_RW;
+	ptr->add = true;
+	r_list_append (ret, ptr);
+	phys += ptr->size;
+	vsize += ptr->vsize;
+
+	// add bss segment
+	vsize += header->bss;
+
 	// add syms segment
-	symssize = r_buf_read_le32_at (bf->buf, 16);
-	if (symssize) {
-		if (!(ptr = R_NEW0 (RBinSection))) {
-			return ret;
-		}
-		ptr->name = strdup ("syms");
-		ptr->size = symssize;
-		ptr->vsize = symssize + (symssize % 4096);
-		ptr->paddr = datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
-		ptr->perm = R_PERM_R; // r--
-		ptr->add = true;
-		r_list_append (ret, ptr);
+	if (!(ptr = R_NEW0 (RBinSection))) {
+		return ret;
 	}
+	ptr->name = strdup ("syms");
+	ptr->size = header->syms;
+	ptr->vsize = ALIGN(header->syms, align);
+	ptr->paddr = phys;
+	ptr->vaddr = baddr (bf) + vsize;
+	ptr->perm = R_PERM_R; // r--
+	ptr->add = true;
+	r_list_append (ret, ptr);
+	phys += ptr->size;
+	vsize += ptr->vsize;
+
 	// add spsz segment
-	spszsize = r_buf_read_le32_at (bf->buf, 24);
-	if (spszsize) {
-		if (!(ptr = R_NEW0 (RBinSection))) {
-			return ret;
-		}
-		ptr->name = strdup ("spsz");
-		ptr->size = spszsize;
-		ptr->vsize = spszsize + (spszsize % 4096);
-		ptr->paddr = symssize + datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
-		ptr->perm = R_PERM_R; // r--
-		ptr->add = true;
-		r_list_append (ret, ptr);
+	if (!(ptr = R_NEW0 (RBinSection))) {
+		return ret;
 	}
+	ptr->name = strdup ("spsz");
+	ptr->size = header->spsz;
+	ptr->vsize = ALIGN(header->spsz, align);
+	ptr->paddr = phys;
+	ptr->vaddr = baddr (bf) + vsize;
+	ptr->perm = R_PERM_R; // r--
+	ptr->add = true;
+	r_list_append (ret, ptr);
+	phys += ptr->size;
+	vsize += ptr->vsize;
+
 	// add pcsz segment
-	pcszsize = r_buf_read_le32_at (bf->buf, 24);
-	if (pcszsize) {
-		if (!(ptr = R_NEW0 (RBinSection))) {
-			return ret;
-		}
-		ptr->name = strdup ("pcsz");
-		ptr->size = pcszsize;
-		ptr->vsize = pcszsize + (pcszsize % 4096);
-		ptr->paddr = spszsize + symssize + datasize + textsize + (8 * 4);
-		ptr->vaddr = ptr->paddr;
-		ptr->perm = R_PERM_R; // r--
-		ptr->add = true;
-		r_list_append (ret, ptr);
+	if (!(ptr = R_NEW0 (RBinSection))) {
+		return ret;
 	}
+	ptr->name = strdup ("pcsz");
+	ptr->size = header->pcsz;
+	ptr->vsize = ALIGN(header->pcsz, align);
+	ptr->paddr = phys;
+	ptr->vaddr = baddr (bf) + vsize;
+	ptr->perm = R_PERM_R; // r--
+	ptr->add = true;
+	r_list_append (ret, ptr);
+
 	return ret;
 }
 
 static RList *symbols(RBinFile *bf) {
-	// TODO: parse symbol table
 	return NULL;
 }
 
 static RList *imports(RBinFile *bf) {
+	// all executables are statically linked
 	return NULL;
 }
 
 static RList *libs(RBinFile *bf) {
+	// all executables are statically linked
 	return NULL;
 }
 
 static RBinInfo *info(RBinFile *bf) {
 	RBinInfo *ret = NULL;
-	int bits = 32, bina, big_endian = 0;
+	RSysArch arch;
+	int bits, big_endian;
 
-	if (!(bina = r_bin_p9_get_arch (bf->buf, &bits, &big_endian))) {
+	if (!r_bin_p9_get_arch (bf->buf, &arch, &bits, &big_endian)) {
 		return NULL;
 	}
+
 	if (!(ret = R_NEW0 (RBinInfo))) {
 		return NULL;
 	}
+
 	ret->file = strdup (bf->file);
 	ret->bclass = strdup ("program");
 	ret->rclass = strdup ("p9");
 	ret->os = strdup ("Plan9");
-	ret->arch = strdup (r_sys_arch_str (bina));
+	ret->arch = strdup (r_sys_arch_str (arch));
 	ret->machine = strdup (ret->arch);
 	ret->subsystem = strdup ("plan9");
 	ret->type = strdup ("EXEC (executable file)");
@@ -174,7 +247,6 @@ static RBinInfo *info(RBinFile *bf) {
 }
 
 static ut64 size(RBinFile *bf) {
-	ut64 text, data, syms, spsz;
 	if (!bf) {
 		return 0;
 	}
@@ -184,15 +256,26 @@ static ut64 size(RBinFile *bf) {
 	if (!bf->o->info) {
 		return 0;
 	}
-	// TODO: reuse section list
-	if (r_buf_size (bf->buf) < 28) {
+
+	struct plan9_exec header;
+	if (r_buf_fread_at (bf->buf, 0, (ut8 *)&header, "IIIIIIII", 1) != sizeof (header)) {
 		return 0;
 	}
-	text = r_buf_read_le32_at (bf->buf, 4);
-	data = r_buf_read_le32_at (bf->buf, 8);
-	syms = r_buf_read_le32_at (bf->buf, 16);
-	spsz = r_buf_read_le32_at (bf->buf, 24);
-	return text + data + syms + spsz + (6 * 4);
+
+	ut64 size = sizeof (header);
+
+	// there may be an additional 64-bit entry after the header
+	if (header.magic & HDR_MAGIC) {
+		size += 8;
+	}
+
+	size += header.text;
+	size += header.data;
+	size += header.syms;
+	size += header.spsz;
+	size += header.pcsz;
+
+	return size;
 }
 
 #if !R_BIN_P9
@@ -202,7 +285,7 @@ static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data,
 	RBuffer *buf = r_buf_new ();
 #define B(x, y) r_buf_append_bytes (buf, (const ut8 *) (x), y)
 #define D(x) r_buf_append_ut32 (buf, x)
-	D (I_MAGIC); // i386 only atm
+	D (MAGIC_INTEL_386); // i386 only atm
 	D (codelen);
 	D (datalen);
 	D (4096); // bss


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**
Currently support for Plan 9 binaries is limited to i386 and even then
it doesn't work properly (certain sections won't load, the base address
is wrong, etc.)

With these changes, all architectures including ones from 9front are
supported.
