### PR TITLE
Fix #18967 - Fix emulation for the mov-pc thumb instruction ##esil

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2671,7 +2671,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 	case ARM_INS_MOV:
 	case ARM_INS_VMOV:
 	case ARM_INS_MOVW:
-		r_strbuf_appendf (&op->esil, "%s,%s,=", ARG (1), REG (0));
+		MATH32 ("=");
 		break;
 	case ARM_INS_CBZ:
 		r_strbuf_appendf (&op->esil, "%s,!,?{,%" PFMT32u ",pc,=,}",

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2671,7 +2671,11 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 	case ARM_INS_MOV:
 	case ARM_INS_VMOV:
 	case ARM_INS_MOVW:
-		MATH32 ("=");
+		if (a->bits == 16) {
+			MATH32 ("=");
+		} else {
+			r_strbuf_appendf (&op->esil, "%s,%s,=", ARG (1), REG (0));
+		}
 		break;
 	case ARM_INS_CBZ:
 		r_strbuf_appendf (&op->esil, "%s,!,?{,%" PFMT32u ",pc,=,}",

--- a/test/db/anal/thumb
+++ b/test/db/anal/thumb
@@ -18,3 +18,24 @@ EXPECT=<<EOF
 \ 0x00000048      case.0xa.0,c  pop {r4, pc}
 EOF
 RUN
+
+NAME=thumb unaligned mov, pc
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+wx 01308fe213ff2fe178460c30c0460190491a921a0b2701df2f62696e2f736800
+s8
+af
+aeim
+aepc 8
+2ds
+dr?r0
+x 16 @r:r0
+EOF
+EXPECT=<<EOF
+0x00000018
+- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
+0x00000018  2f62 696e 2f73 6800 0000 0000 0000 0000  /bin/sh.........
+EOF
+RUN

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -963,7 +963,7 @@ aes
 aer r0
 EOF
 EXPECT=<<EOF
-0x00000002
+0x00000004
 EOF
 RUN
 
@@ -1206,5 +1206,33 @@ EXPECT=<<EOF
             0x0000000e      054b           ldr r3, [0x00000024]        ; [0x24:4]=0x4b054b05
             0x00000010      054b           ldr r3, [0x00000028]        ; [0x28:4]=0x4b054b05
             0x00000012      054b           ldr r3, [0x00000028]        ; [0x28:4]=0x4b054b05
+EOF
+RUN
+
+NAME=thumb mov PC and add
+FILE=bins/elf/thumb-movpcadd
+CMDS=<<EOF
+e emu.str=true
+e asm.bytes=false
+s main
+af
+pdf~pstr
+EOF
+EXPECT=<<EOF
+|           0x00010556      adds r0, 0x10                              ; (pstr 0x000618b4) "Hello World\n"
+EOF
+RUN
+
+NAME=thumb mov PC and add unaligned
+FILE=bins/elf/thumb-movpcadd2
+CMDS=<<EOF
+e emu.str=true
+e asm.bytes=false
+s main
+af
+pdf~pstr
+EOF
+EXPECT=<<EOF
+|           0x00010558      adds r0, 0xe                               ; (pstr 0x000618b4) "Hello World\n"
 EOF
 RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
