### PR TITLE
Fix #19452 - Highlight grep with empty search string causes infinite loop ##util

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -962,6 +962,9 @@ R_API char* r_str_replace(char *str, const char *key, const char *val, int g) {
 		r_str_replace_char (str, *key, *val);
 		return str;
 	}
+	if (klen == 0) {
+		return str;
+	}
 	if (klen == vlen && !strcmp (key, val)) {
 		return str;
 	}

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -438,3 +438,14 @@ Hello World
 4e2420
 EOF
 RUN
+
+NAME=highlight grep with empty string
+ARGS=-escr.highlight.grep=true
+TIMEOUT=2
+CMDS=<<EOF
+i~[0]:0
+EOF
+EXPECT=<<EOF
+fd
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #19452
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Add check for empty key in `r_str_replace`, fixing an infinite loop when `scr.highlight.grep=true` and the user runs a grep command with an empty string.