### PR TITLE
Fix r2pipe.cmd("Z") when command fails returns no output ##r2pipe

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2417,7 +2417,7 @@ static int cmd_resize(void *data, const char *input) {
 			eprintf ("r_io_resize: cannot resize\n");
 		}
 	}
-	if (newsize < core->offset+core->blocksize || oldsize < core->offset + core->blocksize) {
+	if (newsize < (core->offset + core->blocksize) || oldsize < (core->offset + core->blocksize)) {
 		r_core_block_read (core);
 	}
 	return true;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3316,6 +3316,9 @@ R_API int r_core_prompt_exec(RCore *r) {
 		}
 		ret = r_core_cmd (r, cmd, true);
 		if (ret < 0) {
+			if (r->cons && r->cons->line && r->cons->line->zerosep) {
+				r_cons_zero ();
+			}
 			r_core_cmd_queue (r, NULL);
 			break;
 		}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
