### PR TITLE
Use null plugin when using unexistent asm plugin ##asm

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -360,7 +360,7 @@ static void load_asm_descriptions(RAsm *a, RAsmPlugin *p) {
 
 // TODO: this can be optimized using r_str_hash()
 R_API bool r_asm_use(RAsm *a, const char *name) {
-	r_return_val_if_fail (a, name, false);
+	r_return_val_if_fail (a && name, false);
 	RAsmPlugin *h;
 	RListIter *iter;
 	r_list_foreach (a->plugins, iter, h) {

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -360,7 +360,11 @@ static void load_asm_descriptions(RAsm *a, RAsmPlugin *p) {
 
 // TODO: this can be optimized using r_str_hash()
 R_API bool r_asm_use(RAsm *a, const char *name) {
-	r_return_val_if_fail (a && name, false);
+	r_return_val_if_fail (a, false);
+	if (R_STR_ISEMPTY (name)) {
+		// that shouldnt be permitted imho, keep for backward compat
+		return false;
+	}
 	RAsmPlugin *h;
 	RListIter *iter;
 	r_list_foreach (a->plugins, iter, h) {

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -360,11 +360,9 @@ static void load_asm_descriptions(RAsm *a, RAsmPlugin *p) {
 
 // TODO: this can be optimized using r_str_hash()
 R_API bool r_asm_use(RAsm *a, const char *name) {
+	r_return_val_if_fail (a, name, false);
 	RAsmPlugin *h;
 	RListIter *iter;
-	if (!a || !name) {
-		return false;
-	}
 	r_list_foreach (a->plugins, iter, h) {
 		if (h->arch) {
 			if (!strcmp (h->name, name)) {
@@ -397,6 +395,9 @@ R_API bool r_asm_use(RAsm *a, const char *name) {
 	}
 	sdb_free (a->pair);
 	a->pair = NULL;
+	if (strcmp (name, "null")) {
+		return r_asm_use (a, "null");
+	}
 	return false;
 }
 


### PR DESCRIPTION
* Fixes anal disasm warnings and related problems

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
