### PR TITLE
Fix #19464 - incorrect assembly for adrp on arm64 ##asm

### DIFF
--- a/libr/asm/arch/arm/armass64.c
+++ b/libr/asm/arch/arm/armass64.c
@@ -830,23 +830,26 @@ static ut32 adrp(ArmOp *op, ut64 addr, ut32 k) { //, int reg, ut64 dst) {
 	}
 	if (op->operands[1].type == ARM_CONSTANT) {
 		// XXX what about negative values?
-		at = op->operands[1].immediate - addr;
-		at /= 4;
+		ut64 imm = op->operands[1].immediate;
+		if (imm > addr) {
+			imm -= addr;
+		}
+		at = imm / 4096;
 	} else {
 		eprintf ("Usage: adrp, x0, addr\n");
 		return UT32_MAX;
 	}
-	ut8 b0 = at;
-	ut8 b1 = (at >> 3) & 0xff;
-
 #if 0
-	ut8 b2 = (at >> (8 + 7)) & 0xff;
-	data += b0 << 29;
-	data += b1 << 16;
-	data += b2 << 24;
+        31   30 29   28 ... 24   23..5  4..0
+        ---+-------+-----------+-------+----
+	op | immlo | 1 0 0 0 0 | immhi | Rd
+
+	op = 0 (adr) || 1 (adrp) 
 #endif
-	data += b0 << 16;
-	data += b1 << 8;
+	ut32 immlo = at & 3;
+	ut32 immhi = at >> 2;
+	data += (immlo << 5);
+	data += (immhi << 29);
 	return data;
 }
 

--- a/test/db/asm/arm_64
+++ b/test/db/asm/arm_64
@@ -42,6 +42,7 @@ a "eon w0, w13, w20" a001344a
 a "eon x0, x13, x20" a00134ca
 a "eon x0, x13, x20, ror 15" a03df4ca
 a "adrp x5, 0x0" 05000090
+ad "adrp x16, 0x1000" 100000b0
 a "add x0, x1, x2" 2000028b
 a "add x0, xzr, x30" e0031e8b
 a "b 0x0" 00000014


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
