### PR TITLE
Fix #19473 - Support libc filename w/o version for heap analysis

### DIFF
--- a/libr/core/linux_heap_glibc.c
+++ b/libr/core/linux_heap_glibc.c
@@ -109,9 +109,13 @@ static bool GH(is_tcache)(RCore *core) {
 		RListIter *iter;
 		r_debug_map_sync (core->dbg);
 		r_list_foreach (core->dbg->maps, iter, map) {
-			// In case the binary is named *libc-*
+			// In case the binary is named *libc-* or *libc.*
 			if (strncmp (map->name, core->bin->file, strlen(map->name)) != 0) {
 				fp = strstr (map->name, "libc-");
+				if (fp) {
+					break;
+				}
+				fp = strstr (map->name, "libc.");
 				if (fp) {
 					break;
 				}
@@ -411,11 +415,13 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 		r_debug_map_sync (core->dbg);
 		r_list_foreach (core->dbg->maps, iter, map) {
 			/* Try to find the main arena address using the glibc's symbols. */
-			if (strstr (map->name, "/libc-") && first_libc && main_arena_sym == GHT_MAX) {
+			if ((strstr (map->name, "/libc-") || strstr (map->name, "/libc."))
+					&& first_libc && main_arena_sym == GHT_MAX) {
 				first_libc = false;
 				main_arena_sym = GH (get_main_arena_with_symbol) (core, map);
 			}
-			if (strstr (map->name, "/libc-") && map->perm == R_PERM_RW) {
+			if ((strstr (map->name, "/libc-") || strstr (map->name, "/libc."))
+					&& map->perm == R_PERM_RW) {
 				libc_addr_sta = map->addr;
 				libc_addr_end = map->addr_end;
 				break;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [x] Closing issues: #19473
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

Gentoo keeps its libc in /lib64/libc.so.6 which breaks detection of a map with libc in memory for heap analysis.
I added condition that searches not only for "/libc-" but also for "/libc." among memory map names.

Hope that looks about right, @trufae