### PR TITLE
Cleanup public API for ##search

### DIFF
--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -115,13 +115,6 @@ R_API int r_search_range_reset(RSearch *s);
 
 R_API int r_search_bmh(const RSearchKeyword *kw, const ut64 from, const ut8 *buf, const int len, ut64 *out);
 
-// TODO: is this an internal API?
-R_API int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 // Returns 2 if search.maxhits is reached, 0 on error, otherwise 1
 R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr);
 R_API void r_search_set_distance(RSearch *s, int dist);

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -113,7 +113,6 @@ R_API void r_search_kw_reset(RSearch *s);
 R_API int r_search_range_add(RSearch *s, ut64 from, ut64 to);
 R_API int r_search_range_set(RSearch *s, ut64 from, ut64 to);
 R_API int r_search_range_reset(RSearch *s);
-R_API int r_search_set_blocksize(RSearch *s, ut32 bsize);
 
 R_API int r_search_bmh(const RSearchKeyword *kw, const ut64 from, const ut8 *buf, const int len, ut64 *out);
 

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -119,7 +119,6 @@ R_API int r_search_bmh(const RSearchKeyword *kw, const ut64 from, const ut8 *buf
 R_API int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_magic_update(RSearch *_s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -123,7 +123,6 @@ R_API int r_search_magic_update(RSearch *_s, ut64 from, const ut8 *buf, int len)
 R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-R_API int r_search_xrefs_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 // Returns 2 if search.maxhits is reached, 0 on error, otherwise 1
 R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr);
 R_API void r_search_set_distance(RSearch *s, int dist);

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -113,8 +113,6 @@ R_API int r_search_range_add(RSearch *s, ut64 from, ut64 to);
 R_API int r_search_range_set(RSearch *s, ut64 from, ut64 to);
 R_API int r_search_range_reset(RSearch *s);
 
-R_API int r_search_bmh(const RSearchKeyword *kw, const ut64 from, const ut8 *buf, const int len, ut64 *out);
-
 // Returns 2 if search.maxhits is reached, 0 on error, otherwise 1
 R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr);
 R_API void r_search_set_distance(RSearch *s, int dist);

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -94,7 +94,6 @@ R_API void r_search_free(RSearch *s);
 R_API RList *r_search_find(RSearch *s, ut64 addr, const ut8 *buf, int len);
 R_API RList *r_search_find_uds(RSearch *search, ut64 addr, const ut8 *data, size_t size, bool verbose);
 R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len);
-R_API int r_search_update_i(RSearch *s, ut64 from, const ut8 *buf, long len);
 
 R_API void r_search_keyword_free (RSearchKeyword *kw);
 R_API RSearchKeyword* r_search_keyword_new(const ut8 *kw, int kwlen, const ut8 *bm, int bmlen, const char *data);

--- a/libr/search/aes_find.c
+++ b/libr/search/aes_find.c
@@ -55,7 +55,7 @@ static bool aes128_key_test(const unsigned char *buf) {
 	return word1 && word2;
 }
 
-R_API int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i, t, last = len - AES128_SEARCH_LENGTH;
 	RListIter *iter;
 	RSearchKeyword *kw;

--- a/libr/search/aes_find.c
+++ b/libr/search/aes_find.c
@@ -55,7 +55,7 @@ static bool aes128_key_test(const unsigned char *buf) {
 	return word1 && word2;
 }
 
-int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i, t, last = len - AES128_SEARCH_LENGTH;
 	RListIter *iter;
 	RSearchKeyword *kw;

--- a/libr/search/privkey_find.c
+++ b/libr/search/privkey_find.c
@@ -64,7 +64,7 @@ static int check_fields(const ut8 *start) {
 // Finds and return index of a private key:
 // As defined in RFC 3447 for RSA, as defined in RFC 5915 for
 // elliptic curves and as defined in 7 of RFC 8410 for SafeCurves
-R_API int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i, k, max, index, t;
 	RListIter *iter;
 	RSearchKeyword *kw;

--- a/libr/search/privkey_find.c
+++ b/libr/search/privkey_find.c
@@ -64,7 +64,7 @@ static int check_fields(const ut8 *start) {
 // Finds and return index of a private key:
 // As defined in RFC 3447 for RSA, as defined in RFC 5915 for
 // elliptic curves and as defined in 7 of RFC 8410 for SafeCurves
-int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i, k, max, index, t;
 	RListIter *iter;
 	RSearchKeyword *kw;

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -3,7 +3,7 @@
 #include "r_search.h"
 #include <r_regex.h>
 
-int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RRegexMatch match;

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -3,7 +3,7 @@
 #include "r_search.h"
 #include <r_regex.h>
 
-R_API int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RRegexMatch match;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -70,7 +70,7 @@ R_API int r_search_set_string_limits(RSearch *s, ut32 min, ut32 max) {
 	return true;
 }
 
-R_API int r_search_magic_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+static int search_magic_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	eprintf ("TODO: import libr/core/cmd_search.c /m implementation into rsearch\n");
 	return false;
 }
@@ -84,7 +84,7 @@ R_API int r_search_set_mode(RSearch *s, int mode) {
 	case R_SEARCH_PRIV_KEY: s->update = r_search_privkey_update; break;
 	case R_SEARCH_STRING: s->update = r_search_strings_update; break;
 	case R_SEARCH_DELTAKEY: s->update = r_search_deltakey_update; break;
-	case R_SEARCH_MAGIC: s->update = r_search_magic_update; break;
+	case R_SEARCH_MAGIC: s->update = search_magic_update; break;
 	}
 	if (s->update || mode == R_SEARCH_PATTERN) {
 		s->mode = mode;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -483,10 +483,6 @@ R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len) {
 	return ret;
 }
 
-R_API int r_search_update_i(RSearch *s, ut64 from, const ut8 *buf, long len) {
-	return r_search_update (s, from, buf, len);
-}
-
 static int listcb(RSearchKeyword *k, void *user, ut64 addr) {
 	RSearchHit *hit = R_NEW0 (RSearchHit);
 	if (!hit) {

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -136,12 +136,12 @@ R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr) {
 		hit->addr = addr;
 		r_list_append (s->hits, hit);
 	}
-	return s->maxhits && s->nhits >= s->maxhits ? 2 : 1;
+	return s->maxhits && s->nhits >= s->maxhits? 2: 1;
 }
 
 // TODO support search across block boundaries
 // Supported search variants: backward, overlap
-int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RListIter *iter;
 	int longest = 0, i, j;
 	RSearchKeyword *kw;
@@ -358,7 +358,7 @@ static bool brute_force_match(RSearch *s, RSearchKeyword *kw, const ut8 *buf, in
 }
 
 // Supported search variants: backward, binmask, icase, inverse, overlap
-int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RSearchLeftover *left;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -3,6 +3,7 @@
 #include <r_search.h>
 #include <r_list.h>
 #include <ctype.h>
+#include "search.h"
 
 // Experimental search engine (fails, because stops at first hit of every block read
 #define USE_BMH 0

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -79,12 +79,12 @@ static int search_magic_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 R_API int r_search_set_mode(RSearch *s, int mode) {
 	s->update = NULL;
 	switch (mode) {
-	case R_SEARCH_KEYWORD: s->update = r_search_mybinparse_update; break;
-	case R_SEARCH_REGEXP: s->update = r_search_regexp_update; break;
-	case R_SEARCH_AES: s->update = r_search_aes_update; break;
-	case R_SEARCH_PRIV_KEY: s->update = r_search_privkey_update; break;
-	case R_SEARCH_STRING: s->update = r_search_strings_update; break;
-	case R_SEARCH_DELTAKEY: s->update = r_search_deltakey_update; break;
+	case R_SEARCH_KEYWORD: s->update = search_kw_update; break;
+	case R_SEARCH_REGEXP: s->update = search_regexp_update; break;
+	case R_SEARCH_AES: s->update = search_aes_update; break;
+	case R_SEARCH_PRIV_KEY: s->update = search_privkey_update; break;
+	case R_SEARCH_STRING: s->update = search_strings_update; break;
+	case R_SEARCH_DELTAKEY: s->update = search_deltakey_update; break;
 	case R_SEARCH_MAGIC: s->update = search_magic_update; break;
 	}
 	if (s->update || mode == R_SEARCH_PATTERN) {
@@ -141,7 +141,7 @@ R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr) {
 
 // TODO support search across block boundaries
 // Supported search variants: backward, overlap
-R_API int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RListIter *iter;
 	int longest = 0, i, j;
 	RSearchKeyword *kw;
@@ -358,7 +358,7 @@ static bool brute_force_match(RSearch *s, RSearchKeyword *kw, const ut8 *buf, in
 }
 
 // Supported search variants: backward, binmask, icase, inverse, overlap
-R_API int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RSearchLeftover *left;

--- a/libr/search/search.h
+++ b/libr/search/search.h
@@ -1,7 +1,7 @@
 // To keep update function out of public r_search API
-int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+R_IPI int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);

--- a/libr/search/search.h
+++ b/libr/search/search.h
@@ -1,0 +1,7 @@
+// To keep update function out of public r_search API
+int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);

--- a/libr/search/search.h
+++ b/libr/search/search.h
@@ -1,7 +1,7 @@
 // To keep update function out of public r_search API
-int r_search_mybinparse_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int r_search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int r_search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int r_search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
-int r_search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);

--- a/libr/search/strings.c
+++ b/libr/search/strings.c
@@ -58,7 +58,7 @@ static bool is_encoded(int encoding, unsigned char c) {
 	return false;
 }
 
-R_API int r_search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i = 0;
 	int widechar = 0;
 	int matches = 0;

--- a/libr/search/strings.c
+++ b/libr/search/strings.c
@@ -58,7 +58,7 @@ static bool is_encoded(int encoding, unsigned char c) {
 	return false;
 }
 
-int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
+R_IPI int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	int i = 0;
 	int widechar = 0;
 	int matches = 0;

--- a/test/unit/legacy_unit/search/test-regexp.c
+++ b/test/unit/legacy_unit/search/test-regexp.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
 		r_search_keyword_new_str ("E.F", "i", NULL, 0));
 	r_search_begin (rs);
 	printf ("Searching strings in '%s'\n", buffer);
-	r_search_update_i (rs, 0LL, buffer, strlen ((const char*)buffer));
+	r_search_update (rs, 0LL, buffer, strlen ((const char *)buffer));
 	rs = r_search_free (rs);
 	return 0;
 }

--- a/test/unit/legacy_unit/search/test-str.c
+++ b/test/unit/legacy_unit/search/test-str.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
 	r_search_set_callback (rs, &hit, (void *)buffer);
 	r_search_begin (rs);
 	printf ("Searching strings in '%s'\n", buffer);
-	r_search_update_i (rs, 0LL, buffer, strlen ((const char*)buffer));
+	r_search_update (rs, 0LL, buffer, strlen ((const char *)buffer));
 	rs = r_search_free(rs);
 
 	return 0;

--- a/test/unit/legacy_unit/search/test.c
+++ b/test/unit/legacy_unit/search/test.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
 	printf ("Distance: %d\n", rs->distance);
 	r_search_begin (rs);
 	printf ("Searching for '%s' in '%s'\n", "lib", buffer);
-	r_search_update_i (rs, 0LL, (ut8*)buffer, strlen(buffer));
+	r_search_update (rs, 0LL, (ut8 *)buffer, strlen (buffer));
 
 	printf("--\n");
 
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 	printf ("Distance: %d\n", rs->distance);
 	r_search_begin (rs);
 	printf ("Searching for '%s' in '%s'\n", "lib", buffer);
-	r_search_update_i (rs, 0LL, (ut8*)buffer, strlen(buffer));
+	r_search_update (rs, 0LL, (ut8 *)buffer, strlen (buffer));
 	rs = r_search_free (rs);
 
 	printf("--\n");
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 	r_search_set_callback (rs, &hit, buffer);
 	r_search_begin (rs);
 	printf ("Searching for '%s' with binmask 'ff00ff' in '%s'\n", "lib", buffer);
-	r_search_update_i (rs, 0LL, (ut8*)buffer, strlen(buffer));
+	r_search_update (rs, 0LL, (ut8 *)buffer, strlen (buffer));
 	rs = r_search_free (rs);
 	return 0;
 }


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Trying to clean up the r_search API a bit.

A couple functions in r_earch.h were not used or were duplicates.

I moved the update functions into their own .h file to hide them from public use. They should only be used internally. I have not made this type of change in r2 before, so I probably am not doing it just right.