### PR TITLE
Support Mach-O DYLD_CHAINED_PTR_64_OFFSET format ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -1485,6 +1485,7 @@ enum {
 	DYLD_CHAINED_PTR_32          = 3,
 	DYLD_CHAINED_PTR_32_CACHE    = 4,
 	DYLD_CHAINED_PTR_32_FIRMWARE = 5,
+	DYLD_CHAINED_PTR_64_OFFSET = 6,
 	DYLD_CHAINED_PTR_ARM64E_KERNEL = 7,
 	DYLD_CHAINED_PTR_64_KERNEL_CACHE = 8,
 };
@@ -1542,6 +1543,22 @@ struct dyld_chained_ptr_arm64e_cache_auth_rebase {
 		key : 2,
 		next : 12,
 		auth : 1; // == 1
+};
+
+struct dyld_chained_ptr_64_rebase {
+	uint64_t target : 36,
+		high8 : 8,
+		reserved : 7,
+		next : 12,
+		bind : 1; // == 0
+};
+
+struct dyld_chained_ptr_64_bind {
+	uint64_t ordinal : 24,
+		addend : 8,
+		reserved : 19,
+		next : 12,
+		bind : 1; // == 1
 };
 
 #endif

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -97,3 +97,20 @@ EXPECT=<<EOF
                                 main+116 0x100000ec4 ->      CODE -> 0x100000e20 method.Person.setName:
 EOF
 RUN
+
+NAME=macOS arm64 with DYLD_CHAINED_PTR_64_OFFSET
+FILE=bins/mach0/hello-macos-arm64-chained
+CMDS=<<EOF
+ic Test
+EOF
+EXPECT=<<EOF
+class Test
+0x100003a7c method Test      init
+0x100003acc method Test      methodWithoutArgs
+0x100003b18 method Test      methodWithOneArg:
+0x100003b68 method Test      methodWithTwoArgs:secondArg:
+0x100003be0 method Test      methodWithReturn
+0x100003aa0 method Test c    someStaticMethod
+EOF
+RUN
+


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Support the `DYLD_CHAINED_PTR_64_OFFSET` chained pointer format for the purpose of rebasing Mach-O binaries. This is the default when compiling `arm64` binaries on macOS Monterey on M1 architecture.

Depends on new test bin: https://github.com/radareorg/radare2-testbins/pull/69

(credit: https://github.com/rizinorg/rizin/pull/1996)
