### PR TITLE
Fix pD reading too many bytes and remove unused argument from r_core_print_disasm()

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1666,7 +1666,7 @@ static int core_anal_graph_construct_nodes(RCore *core, RAnalFunction *fcn, int 
 			if (buf) {
 				r_io_read_at (core->io, bbi->addr, buf, bbi->size);
 				if (is_json_format_disasm) {
-					r_core_print_disasm (core, bbi->addr, buf, bbi->size, bbi->size, true, false, true, pj, NULL);
+					r_core_print_disasm (core, bbi->addr, buf, bbi->size, bbi->size, true, true, pj, NULL);
 				} else {
 					r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0, pj);
 				}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5383,12 +5383,8 @@ static void ds_end_line_highlight(RDisasmState *ds) {
 
 /**
  * \brief Disassemble `count` instructions, or bytes if `count_bytes` is enabled
- * \param read_buffer_only Do not enable in new code! Workaround for code that
- *        relied on this function incorrectly stopping at basic block
- *        boundaries. This options prevents the function from reading past the
- *        buffer with r_io like it does now.
  */
-R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool read_buffer_only, bool json, PJ *pj, RAnalFunction *pdf) {
+R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool json, PJ *pj, RAnalFunction *pdf) {
 	RPrint *p = core->print;
 	RAnalFunction *of = NULL;
 	RAnalFunction *f = NULL;
@@ -5607,7 +5603,7 @@ toro:
 			eprintf ("ds->index=%#x len=%#x left=%#x\n", ds->index, len, left);
 			eprintf ("ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x\n", ds->addr, ds->at, ds->count, ds->lines);
 #endif
-			if (left < max_op_size && !count_bytes && !read_buffer_only) {
+			if (left < max_op_size && !count_bytes) {
 #if DEBUG_DISASM
 				eprintf ("Not enough bytes to disassemble, going to retry.\n");
 #endif
@@ -5881,7 +5877,7 @@ toro:
 		}
 
 		// enough bytes?
-		if (ds->lines < ds->count && !count_bytes && !read_buffer_only) {
+		if (ds->lines < ds->count && !count_bytes) {
 			ds->addr += ds->index;
 #if DEBUG_DISASM
 			eprintf ("len=%d\n", len);
@@ -7009,7 +7005,7 @@ R_API int r_core_disasm_pde(RCore *core, int nb_opcodes, int mode) {
 					break;
 				default:
 					// ok
-					r_core_print_disasm (core, block_start, buf, block_sz, block_instr, false, false, false, NULL, NULL);
+					r_core_print_disasm (core, block_start, buf, block_sz, block_instr, false, false, NULL, NULL);
 					break;
 				}
 			}

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -662,7 +662,7 @@ R_API RList *r_core_asm_bwdisassemble (RCore *core, ut64 addr, int n, int len);
 R_API RList *r_core_asm_back_disassemble_instr (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API RList *r_core_asm_back_disassemble_byte (RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API ut32 r_core_asm_bwdis_len(RCore* core, int* len, ut64* start_addr, ut32 l);
-R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool read_buffer_only, bool json, PJ *pj, RAnalFunction *pdf);
+R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool json, PJ *pj, RAnalFunction *pdf);
 R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
 R_API int r_core_print_disasm_instructions_with_buf(RCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);
 R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opcodes);


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

#19112 fixed a problem where instructions would be cut off in some cases. This was done by reading more bytes into the buffer if it did not have enough bytes left for a full instruction. Unfortunately, the fact that instructions are intended to be cut off when using `pD` slipped by me and I misunderstood what was and wasn't intended behavior. I introduced a specific argument for this behavior, but it can actually be done only (and more correctly) by checking `count_bytes`.

The first commit fixes the problem and leaves the argument untouched, and the second commit removes the now-unused argument. I also changed the debug logging to use eprintf and made the debug flag macro more descriptive.

```
lazula@mint-desktop:~/radare2$ r2 -c 'pD 1' -qN -
            0x00000000      0000           add byte [rax], al
lazula@mint-desktop:~/radare2$ git checkout fix-pD-overread
Switched to branch 'fix-pD-overread'
lazula@mint-desktop:~/radare2$ sys/user.sh >/dev/null 2>&1
lazula@mint-desktop:~/radare2$ r2 -c 'pD 1' -qN -
            0x00000000      00             invalid
```