### PR TITLE
Check for an existing upstream remote in install scripts ##build

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -67,7 +67,13 @@ if [ "$1" != "--without-pull" ]; then
 		git branch | grep "^\* master" > /dev/null
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
-			git pull https://github.com/radareorg/radare2 master
+			# Attempt to update from an existing remote
+			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+			if [ -n "$UPSTREAM_REMOTE" ]; then
+				git pull "$UPSTREAM_REMOTE" master
+			else
+				git pull https://github.com/radareorg/radare2 master
+			fi
 		fi
 	fi
 else

--- a/sys/meson.py
+++ b/sys/meson.py
@@ -249,7 +249,13 @@ def main():
 
     # Check arguments
     if args.pull:
-        os.system('git pull https://github.com/radareorg/radare2 master')
+        # Attempt to update from an existing remote
+        upstream_remote = subprocess.check_output(["git", "remote", "-v"]).decode()
+        try:
+            remote = re.search(r'(.*?)\t.*radareorg/radare2 \(fetch\)', upstream_remote).group(1)
+        except AttributeError: # If search misses, None.group() throws this
+            remote = 'https://github.com/radareorg/radare2'
+        os.system(f'git pull {remote} master')
     if args.project and args.backend == 'ninja':
         log.error('--project is not compatible with --backend ninja')
         sys.exit(1)

--- a/sys/termux.sh
+++ b/sys/termux.sh
@@ -7,7 +7,13 @@ export ANDROID=1
 # make clean > /dev/null 2>&1
 rm -f libr/include/r_version.h
 cp -f dist/plugins-cfg/plugins.termux.cfg plugins.cfg
-git pull https://github.com/radareorg/radare2 master
+# Attempt to update from an existing remote
+UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+if [ -n "$UPSTREAM_REMOTE" ]; then
+	git pull "$UPSTREAM_REMOTE" master
+else
+	git pull https://github.com/radareorg/radare2 master
+fi
 ./preconfigure
 ./configure-plugins
 bash ./configure --with-compiler=termux --prefix=${PREFIX} || exit 1

--- a/sys/user.sh
+++ b/sys/user.sh
@@ -53,7 +53,13 @@ if [ $WITHOUT_PULL -eq 0 ]; then
 		git branch | grep "^\* master" > /dev/null
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
-			git pull https://github.com/radareorg/radare2 master
+			# Attempt to update from an existing remote
+			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+			if [ -n "$UPSTREAM_REMOTE" ]; then
+				git pull "$UPSTREAM_REMOTE" master
+			else
+				git pull https://github.com/radareorg/radare2 master
+			fi
 		fi
 	fi
 fi


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

Follow-up to #19423. If there is an existing remote the user has tracking upstream, using the direct URL leaves the remote lagging behind and requires manual updating. Install scripts now check for an existing named remote before pulling from the direct URL, keeping the remote tracking aligned with the current `master` when updated by these scripts.