### PR TITLE
Add longest field to RSearch ##search

### DIFF
--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -61,6 +61,7 @@ typedef void (RSearchDFree)(void *ptr);
 typedef struct r_search_t {
 	int n_kws; // hit${n_kws}_${count}
 	int mode;
+	int longest; // iff > 0, longest element in kws
 	ut32 pattern_size;
 	ut32 string_min; // max length of strings for R_SEARCH_STRING
 	ut32 string_max; // min length of strings for R_SEARCH_STRING

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -147,7 +147,7 @@ static inline int get_longest(RSearch *s) {
 	RListIter *iter;
 	RSearchKeyword *kw;
 	r_list_foreach (s->kws, iter, kw) {
-		s->longest = R_MAX (s->longest, kw->keyword_length);
+		s->longest = R_MAX (s->longest, (int)kw->keyword_length);
 	}
 	return s->longest;
 }
@@ -517,7 +517,7 @@ R_API int r_search_kw_add(RSearch *s, RSearchKeyword *kw) {
 	if (!kw || !kw->keyword_length) {
 		return false;
 	}
-	s->longest = R_MAX (kw->keyword_length, s->longest);
+	s->longest = R_MAX ((int)kw->keyword_length, s->longest);
 	kw->kwidx = s->n_kws++;
 	r_list_append (s->kws, kw);
 	return true;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -147,7 +147,7 @@ static inline int get_longest(RSearch *s) {
 	RListIter *iter;
 	RSearchKeyword *kw;
 	r_list_foreach (s->kws, iter, kw) {
-		s->longest = R_MAX (l, kw->keyword_length);
+		s->longest = R_MAX (s->longest, kw->keyword_length);
 	}
 	return s->longest;
 }

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -36,6 +36,7 @@ R_API RSearch *r_search_new(int mode) {
 	s->contiguous = 0;
 	s->overlap = false;
 	s->pattern_size = 0;
+	s->longest = -1;
 	s->string_max = 255;
 	s->string_min = 3;
 	s->hits = r_list_newf (free);
@@ -139,17 +140,28 @@ R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr) {
 	return s->maxhits && s->nhits >= s->maxhits? 2: 1;
 }
 
+static inline int get_longest(RSearch *s) {
+	if (s->longest > 0) {
+		return s->longest;
+	}
+	RListIter *iter;
+	RSearchKeyword *kw;
+	r_list_foreach (s->kws, iter, kw) {
+		s->longest = R_MAX (l, kw->keyword_length);
+	}
+	return s->longest;
+}
+
 // TODO support search across block boundaries
 // Supported search variants: backward, overlap
 R_IPI int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RListIter *iter;
-	int longest = 0, i, j;
+	int i, j;
 	RSearchKeyword *kw;
 	RSearchLeftover *left;
 	const int old_nhits = s->nhits;
-	r_list_foreach (s->kws, iter, kw) {
-		longest = R_MAX (longest, kw->keyword_length + 1);
-	}
+
+	int longest = get_longest (s) + 1;
 	if (!longest) {
 		return 0;
 	}
@@ -362,13 +374,11 @@ R_IPI int search_kw_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;
 	RListIter *iter;
 	RSearchLeftover *left;
-	int longest = 0, i;
+	int i;
 	const int old_nhits = s->nhits;
 
-	r_list_foreach (s->kws, iter, kw) {
-		longest = R_MAX (longest, kw->keyword_length);
-	}
-	if (!longest) {
+	int longest = get_longest (s);
+	if (longest <= 0) {
 		return 0;
 	}
 	if (s->data) {
@@ -507,6 +517,7 @@ R_API int r_search_kw_add(RSearch *s, RSearchKeyword *kw) {
 	if (!kw || !kw->keyword_length) {
 		return false;
 	}
+	s->longest = R_MAX (kw->keyword_length, s->longest);
 	kw->kwidx = s->n_kws++;
 	r_list_append (s->kws, kw);
 	return true;
@@ -542,6 +553,7 @@ R_API void r_search_reset(RSearch *s, int mode) {
 }
 
 R_API void r_search_kw_reset(RSearch *s) {
+	s->longest = -1;
 	r_list_purge (s->kws);
 	r_list_purge (s->hits);
 	if (s->datafree) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

The longest keyword was being computed every time an update was done. So for large files, with large keyword lists, a lot of computation can be saved by just remembering the longest keyword. So r_search should continue to function the same after this pull, it should just move faster.

Note: one of the longest variables used a `+1`, I am not completely sure why. Keeping state between update calls is a bit confusing. So I left the logic as is, it should work exactly the same. That is why one of the `longests` has a +1 and the other does not. I hope to pretty this code up further as I understand it better.