### PR TITLE
add basic support for LoongArch

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3669,7 +3669,7 @@ R_API int r_core_config_init(RCore *core) {
 	r_config_set_getter (cfg, "dbg.swstep", (RConfigCallback)__dbg_swstep_getter);
 
 // TODO: This should be specified at first by the debug backend when attaching
-#if __arm__ || __mips__
+#if __arm__ || __mips__ || __loongarch__
 	SETICB ("dbg.bpsize", 4, &cb_dbgbpsize, "Size of software breakpoints");
 #else
 	SETICB ("dbg.bpsize", 1, &cb_dbgbpsize, "Size of software breakpoints");

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -1622,6 +1622,10 @@ RDebugPlugin r_debug_plugin_native = {
 	.bits = R_SYS_BITS_32 | R_SYS_BITS_64,
 	.arch = "mips",
 	.canstep = false,
+#elif __loongarch
+	.bits = R_SYS_BITS_32 | R_SYS_BITS_64,
+	.arch = "loongarch",
+	.canstep = false,
 #elif __powerpc__
 # if __powerpc64__
 	.bits = R_SYS_BITS_32 | R_SYS_BITS_64,

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -39,6 +39,8 @@ char *linux_reg_profile (RDebug *dbg) {
 	} else {
 #		include "reg/linux-mips64.h"
 	}
+#elif __loongarch__
+#		include "reg/linux-loongarch64.h"
 #elif (__i386__ || __x86_64__)
 	if (dbg->bits & R_SYS_BITS_32) {
 #if __x86_64__

--- a/libr/debug/p/native/linux/linux_debug.h
+++ b/libr/debug/p/native/linux/linux_debug.h
@@ -105,6 +105,12 @@ struct powerpc_regs_t {
 #include <sys/ucontext.h>
 typedef ut64 mips64_regs_t [274];
 #define R_DEBUG_REG_T mips64_regs_t
+
+#elif __loongarch__
+
+#include <sys/ucontext.h>
+typedef ut64 la_regs_t [274];
+#define R_DEBUG_REG_T la_regs_t
 #endif
 #endif
 

--- a/libr/debug/p/native/linux/reg/linux-loongarch64.h
+++ b/libr/debug/p/native/linux/reg/linux-loongarch64.h
@@ -1,0 +1,66 @@
+#if 0
+	reg      name    usage
+	---+-----------+-------------
+	0        zero   always zero
+	1         ra    return address
+	2         tp	TLS
+	3		  sp	stack pointer
+	4-11	  a0-a7 argument
+	4-5		  v0-v1 return value
+	12-20	  t0-t8 temp
+	21		  x		reserved
+	22		  fp	frame point
+	23-31	  s0-s8 subroutine registe variables
+#endif
+
+	return strdup (
+	"=PC	pc\n"
+	"=SP	sp\n"
+	"=BP	fp\n"
+	"=A0	a0\n"
+	"=A1	a1\n"
+	"=A2	a2\n"
+	"=A3	a3\n"
+	"=A4	a0\n"
+	"=A5	a1\n"
+	"=A6	a2\n"
+	"=A7	a3\n"
+	"gpr	zero	.64	0	0\n"
+	"gpr	ra	.64	8	0\n"
+	"gpr	tp	.64	16	0\n"
+	"gpr	sp	.64	24	0\n"
+	/* args */
+	"gpr	a0	.64	32	0\n"
+	"gpr	a1	.64	40	0\n"
+	/*FIXME v0 v1 and a0 a1 are overlapping*/
+	"gpr	a2	.64	48	0\n"
+	"gpr	a3	.64	56	0\n"
+	"gpr	a4	.64	64	0\n"
+	"gpr	a5	.64	72	0\n"
+	"gpr	a6	.64	80	0\n"
+	"gpr	a7	.64	88	0\n"
+	/* tmp */
+	"gpr	t0	.64	96	0\n"
+	"gpr	t1	.64	104	0\n"
+	"gpr	t2	.64	112	0\n"
+	"gpr	t3	.64	120	0\n"
+	"gpr	t4	.64	128	0\n"
+	"gpr	t5	.64	136	0\n"
+	"gpr	t6	.64	144	0\n"
+	"gpr	t7	.64	152	0\n"
+	"gpr	t8	.64	160	0\n"
+	"gpr	x	.64	168	0\n"
+	"gpr	fp	.64	176	0\n"
+	/* saved */
+	"gpr	s0	.64	184	0\n"
+	"gpr	s1	.64	192	0\n"
+	"gpr	s2	.64	200	0\n"
+	"gpr	s3	.64	208	0\n"
+	"gpr	s4	.64	216	0\n"
+	"gpr	s5	.64	224	0\n"
+	"gpr	s6	.64	232	0\n"
+	"gpr	s7	.64	240	0\n"
+	"gpr	s8	.64	248	0\n"
+	/* extra */
+	"gpr	pc	.64	272	0\n"
+	);

--- a/libr/include/heap/r_jemalloc/internal/jemalloc_internal.h
+++ b/libr/include/heap/r_jemalloc/internal/jemalloc_internal.h
@@ -263,6 +263,9 @@ typedef unsigned szind_t;
 #  ifdef __mips__
 #    define LG_QUANTUM		3
 #  endif
+#  ifdef __loongarch__
+#    define LG_QUANTUM		4	//TODO check me
+#  endif
 #  ifdef __or1k__
 #    define LG_QUANTUM		3
 #  endif

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -530,6 +530,10 @@ static inline void *r_new_copy(int size, void *data) {
 #define R_SYS_ARCH "mips"
 #define R_SYS_BITS R_SYS_BITS_32
 #define R_SYS_ENDIAN 1
+#elif __loongarch__
+#define R_SYS_ARCH "loongarch"
+#define R_SYS_BITS (R_SYS_BITS_32 | R_SYS_BITS_64)
+#define R_SYS_ENDIAN 1
 #elif __EMSCRIPTEN__
 /* we should default to wasm when ready */
 #define R_SYS_ARCH "x86"

--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -121,6 +121,8 @@ R_API bool r_sys_tts(const char *txt, bool bg);
 #  endif
 #elif __mips__
 #  define r_sys_breakpoint() __asm__ volatile ("break");
+#elif __loongarch__
+#  define r_sys_breakpoint() __asm__ volatile ("break");
 // #  define r_sys_breakpoint() __asm__ volatile ("teq $0, $0");
 #elif __EMSCRIPTEN__
 // TODO: cannot find a better way to breakpoint in wasm/asm.js


### PR DESCRIPTION

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Hello friends, recently Loongson released the LoongArch architecture processor, this patch is used to support radare2 can be compiled properly on loongarch.、
I'll be submitting a patch to support binary file analysis for the loongarch platform later.

You can view detailed information about LoongArch at the link below
[LoongArch-Documentation](https://github.com/loongson/LoongArch-Documentation)