### PR TITLE
Add r_search_upate_read API ##search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -3821,13 +3821,18 @@ reread:
 		} else if (input[param_offset - 1]) {
 			int ps = atoi (input + param_offset);
 			if (ps > 1) {
+				r_search_set_mode (core->search, R_SEARCH_PATTERN);
+				r_search_pattern_size (core->search, ps);
+
 				RListIter *iter;
 				RIOMap *map;
 				r_list_foreach (param.boundaries, iter, map) {
-					eprintf ("-- %llx %llx\n", r_io_map_begin (map), r_io_map_end (map));
+					ut64 from = r_io_map_begin (map);
+					ut64 to = r_io_map_end (map);
+					eprintf ("-- %llx %llx\n", from, to);
+
 					r_cons_break_push (NULL, NULL);
-					r_search_pattern_size (core->search, ps);
-					r_search_pattern (core->search, r_io_map_begin (map), r_io_map_end (map));
+					r_search_update_read (core->search, from, to);
 					r_cons_break_pop ();
 				}
 				break;

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -94,6 +94,7 @@ R_API void r_search_free(RSearch *s);
 R_API RList *r_search_find(RSearch *s, ut64 addr, const ut8 *buf, int len);
 R_API RList *r_search_find_uds(RSearch *search, ut64 addr, const ut8 *data, size_t size, bool verbose);
 R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len);
+R_API int r_search_update_read(RSearch *s, ut64 from, ut64 to);
 
 R_API void r_search_keyword_free (RSearchKeyword *kw);
 R_API RSearchKeyword* r_search_keyword_new(const ut8 *kw, int kwlen, const ut8 *bm, int bmlen, const char *data);
@@ -124,7 +125,6 @@ R_API int r_search_begin(RSearch *s);
 
 /* pattern search */
 R_API void r_search_pattern_size(RSearch *s, int size);
-R_API int r_search_pattern(RSearch *s, ut64 from, ut64 to);
 
 #ifdef __cplusplus
 }

--- a/libr/search/bytepat.c
+++ b/libr/search/bytepat.c
@@ -56,7 +56,7 @@ static int is_fi_present(fnditem* n, unsigned char* blk , int patlen) {
 	return false;
 }
 
-R_API int r_search_pattern(RSearch *s, ut64 from, ut64 to) {
+R_IPI int search_pattern(RSearch *s, ut64 from, ut64 to) {
 	ut8 block[BSIZE+MAX_PATLEN], sblk[BSIZE+MAX_PATLEN+1];
 	ut64 addr, bact, bytes, intaddr, rb, bproc = 0;
 	int nr,i, moar=0, pcnt, cnt = 0, k = 0;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -86,6 +86,7 @@ R_API int r_search_set_mode(RSearch *s, int mode) {
 	case R_SEARCH_STRING: s->update = search_strings_update; break;
 	case R_SEARCH_DELTAKEY: s->update = search_deltakey_update; break;
 	case R_SEARCH_MAGIC: s->update = search_magic_update; break;
+	case R_SEARCH_PATTERN: s->update = NULL; break;
 	}
 	if (s->update || mode == R_SEARCH_PATTERN) {
 		s->mode = mode;
@@ -482,6 +483,17 @@ R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len) {
 		eprintf ("r_search_update: No search method defined\n");
 	}
 	return ret;
+}
+
+// like r_search_update but uses s->iob, does not need to loop as much
+R_API int r_search_update_read(RSearch *s, ut64 from, ut64 to) {
+	switch (s->mode) {
+	case R_SEARCH_PATTERN:
+		return search_pattern (s, from, to);
+	default:
+		eprintf ("Unsupported mode\n");
+		return -1;
+	}
 }
 
 static int listcb(RSearchKeyword *k, void *user, ut64 addr) {

--- a/libr/search/search.h
+++ b/libr/search/search.h
@@ -5,3 +5,6 @@ R_IPI int search_privkey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_IPI int search_deltakey_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_IPI int search_strings_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 R_IPI int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
+
+// update read API's use RSearch.iob instead of provided buf
+R_IPI int search_pattern(RSearch *s, ut64 from, ut64 to);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Consider this a proposal, if you don't like it then don't merge.

Currently `cmd_search.c` searches using `r_search_update` with `core->blocksize` buffers. This means each mode of searching must keep state between `r_search_update` calls in order to find matches that span a `core->blocksize` boundary. This is not easy and some modes fail at it:

```
[0x00000000]> x 0x20 @0xf0
- offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
0x000000f0  4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA
0x00000100  4242 4242 4242 4242 4242 4242 4242 4242  BBBBBBBBBBBBBBBB
[0x00000000]> /e /AB/
Searching 2 bytes in [0x0-0x201]
hits: 0
[0x00000000]> / AB
Searching 2 bytes in [0x0-0x201]
hits: 1
0x000000ff hit1_0 .AAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBB.
```

So this pull implements `r_search_update_read` which will allow the search mode to read in bytes with `RIOBind`. `r_search_pattern` worked this way already. So it has been moved to `R_IPI seasrch_pattern` and hid behind `r_search_update_read`.