### PR TITLE
Move /e to new search API ##search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -568,6 +568,7 @@ static char *getstring(char *b, int l) {
 }
 
 static int _cb_hit_sz(RSearchKeyword *kw, int klen, void *user, ut64 addr) {
+	r_return_val_if_fail (kw && user, -1);
 	struct search_parameters *param = user;
 	RCore *core = param->core;
 	ut64 base_addr = 0;
@@ -682,11 +683,16 @@ static int _cb_hit_sz(RSearchKeyword *kw, int klen, void *user, ut64 addr) {
 	return true;
 }
 
-static int _cb_hit(RSearchKeyword *kw, void *user, ut64 addr) {
-	struct search_parameters *param = user;
-	const RSearch *search = param->core->search;
-	int klen = kw? kw->keyword_length + (search->mode == R_SEARCH_DELTAKEY): 0;
-	return _cb_hit_sz (kw, klen, user, addr);
+static int _cb_hit(R_NULLABLE RSearchKeyword *kw, void *user, ut64 addr) {
+	RSearchKeyword kw_fake = { 0 };
+	RSearchKeyword *kw_used = &kw_fake;
+	int klen = 0;
+	if (kw) {
+		struct search_parameters *param = user;
+		const RSearch *search = param->core->search;
+		klen = kw? kw->keyword_length + (search->mode == R_SEARCH_DELTAKEY): 0;
+	}
+	return _cb_hit_sz (kw_used, klen, user, addr);
 }
 
 static inline void print_search_progress(ut64 at, ut64 to, int n, struct search_parameters *param) {

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -231,6 +231,7 @@ struct search_parameters {
 	bool inverse;
 	bool aes_search;
 	bool privkey_search;
+	int c; // used for progress
 };
 
 struct endlist_pair {
@@ -688,18 +689,16 @@ static int _cb_hit(RSearchKeyword *kw, void *user, ut64 addr) {
 	return _cb_hit_sz (kw, klen, user, addr);
 }
 
-static int c = 0;
-
 static inline void print_search_progress(ut64 at, ut64 to, int n, struct search_parameters *param) {
-	if ((++c % 64) || (param->outmode == R_MODE_JSON)) {
+	if ((++param->c % 64) || (param->outmode == R_MODE_JSON)) {
 		return;
 	}
 	if (r_cons_singleton ()->columns < 50) {
-		eprintf ("\r[  ]  0x%08"PFMT64x "  hits = %d   \r%s",
-			at, n, (c % 2)? "[ #]": "[# ]");
+		eprintf ("\r[  ]  0x%08" PFMT64x "  hits = %d   \r%s",
+			at, n, (param->c % 2)? "[ #]": "[# ]");
 	} else {
-		eprintf ("\r[  ]  0x%08"PFMT64x " < 0x%08"PFMT64x "  hits = %d   \r%s",
-			at, to, n, (c % 2)? "[ #]": "[# ]");
+		eprintf ("\r[  ]  0x%08" PFMT64x " < 0x%08" PFMT64x "  hits = %d   \r%s",
+			at, to, n, (param->c % 2)? "[ #]": "[# ]");
 	}
 }
 
@@ -3193,6 +3192,7 @@ static int cmd_search(void *data, const char *input) {
 		.inverse = false,
 		.aes_search = false,
 		.privkey_search = false,
+		.c = 0,
 	};
 	if (!param.cmd_hit) {
 		param.cmd_hit = "";
@@ -3243,8 +3243,6 @@ static int cmd_search(void *data, const char *input) {
 		search_itv.addr = 0;
 		search_itv.size = UT64_MAX;
 	}
-
-	c = 0;
 
 	searchshow = r_config_get_i (core->config, "search.show");
 	param.mode = r_config_get (core->config, "search.in");

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -691,6 +691,7 @@ static int _cb_hit(R_NULLABLE RSearchKeyword *kw, void *user, ut64 addr) {
 		struct search_parameters *param = user;
 		const RSearch *search = param->core->search;
 		klen = kw? kw->keyword_length + (search->mode == R_SEARCH_DELTAKEY): 0;
+		kw_used = kw;
 	}
 	return _cb_hit_sz (kw_used, klen, user, addr);
 }

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2964,6 +2964,7 @@ R_API bool r_core_init(RCore *core) {
 	r_io_bind (core->io, &(core->anal->iob));
 	r_io_bind (core->io, &(core->fs->iob));
 	r_cons_bind (&(core->fs->csb));
+	r_cons_bind (&(core->search->consb));
 	r_core_bind (core, &(core->fs->cob));
 	r_io_bind (core->io, &(core->bin->iob));
 	r_flag_bind (core->flags, &(core->anal->flb));

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -55,8 +55,9 @@ typedef struct r_search_hit_t {
 	ut64 addr;
 } RSearchHit;
 
-typedef int (*RSearchCallback)(RSearchKeyword *kw, void *user, ut64 where);
-typedef void (RSearchDFree)(void *ptr);
+typedef int (*RSearchCallback) (RSearchKeyword *kw, void *user, ut64 where); // TODO: depricate, b/c lacks match len
+typedef int (*RSearchRCb) (RSearchKeyword *kw, int mlen, void *user, ut64 where);
+typedef void (RSearchDFree) (void *ptr);
 
 typedef struct r_search_t {
 	int n_kws; // hit${n_kws}_${count}
@@ -68,7 +69,8 @@ typedef struct r_search_t {
 	void *data; // data used by search algorithm
 	RSearchDFree *datafree;
 	void *user; // user data passed to callback
-	RSearchCallback callback;
+	RSearchCallback callback; // TODO: depricate
+	RSearchRCb r_callback;
 	ut64 nhits;
 	ut64 maxhits; // search.maxhits
 	RList *hits;
@@ -120,8 +122,8 @@ R_API int r_search_hit_new(RSearch *s, RSearchKeyword *kw, ut64 addr);
 R_API void r_search_set_distance(RSearch *s, int dist);
 R_API int r_search_strings(RSearch *s, ut32 min, ut32 max);
 R_API int r_search_set_string_limits(RSearch *s, ut32 min, ut32 max); // WTF dupped?
-//R_API int r_search_set_callback(RSearch *s, int (*callback)(struct r_search_kw_t *, void *, ut64), void *user);
-R_API void r_search_set_callback(RSearch *s, RSearchCallback(callback), void *user);
+R_API void r_search_set_callback(RSearch *s, RSearchCallback(callback), void *user); // TODO: depricate
+R_API void r_search_set_read_cb(RSearch *s, RSearchRCb cb, void *user);
 R_API int r_search_begin(RSearch *s);
 
 /* pattern search */

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -55,7 +55,10 @@ typedef struct r_search_hit_t {
 	ut64 addr;
 } RSearchHit;
 
-typedef int (*RSearchCallback) (RSearchKeyword *kw, void *user, ut64 where); // TODO: depricate, b/c lacks match len
+typedef int (*RSearchCallback) (R_NULLABLE RSearchKeyword *kw, void *user, ut64 where); // TODO: depricate, b/c lacks match len
+
+// kw should never be NULL, send a fake kw from stack if backend search
+// function does not use kw's
 typedef int (*RSearchRCb) (RSearchKeyword *kw, int mlen, void *user, ut64 where);
 typedef void (RSearchDFree) (void *ptr);
 

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -5,6 +5,7 @@
 #include <r_util.h>
 #include <r_list.h>
 #include <r_io.h>
+#include "r_cons.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,6 +86,7 @@ typedef struct r_search_t {
 	int (*update)(struct r_search_t *s, ut64 from, const ut8 *buf, int len);
 	RList *kws; // TODO: Use r_search_kw_new ()
 	RIOBind iob;
+	RConsBind consb;
 	char bckwrds;
 } RSearch;
 

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -29,7 +29,8 @@ R_IPI int search_regex_read(RSearch *s, ut64 from, ut64 to) {
 			ut8 buf[512];
 			int len = R_MIN (to - addr, sizeof (buf));
 			if (!s->iob.read_at (s->iob.io, addr, buf, len)) {
-				return -1; // failed to read
+				ret = -1; // failed to read
+				goto beach;
 			}
 			match.rm_so = 0;
 			match.rm_eo = len;

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -34,20 +34,19 @@ R_IPI int search_regex_read(RSearch *s, ut64 from, ut64 to) {
 
 		// TODO: allow user to configure according to the maximum expected
 		// match length to prevent FN on matches that span boundaries.
-
 		while (addr < to) { // get buffer
+			if (s->consb.is_breaked ()) {
+				goto beach;
+			}
+
 			int len = R_MIN (to - addr, buflen);
 			if (!s->iob.read_at (s->iob.io, addr, buf, len)) {
 				ret = -1; // failed to read
 				goto beach;
 			}
+
 			match.rm_so = 0;
 			match.rm_eo = len;
-
-			if (r_cons_is_breaked ()) {
-				break;
-			}
-
 			int m = r_regex_exec (&rx, (char *)buf, 1, &match, R_REGEX_STARTEND);
 			if (!m) { // match
 				ut32 mtch_len = match.rm_eo - match.rm_so;

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -1,7 +1,86 @@
 /* radare - LGPL - Copyright 2008-2020 - pancake, TheLemonMan */
 
 #include "r_search.h"
+#include "search.h"
 #include <r_regex.h>
+
+R_IPI int search_regex_read(RSearch *s, ut64 from, ut64 to) {
+	RSearchKeyword *kw;
+	RListIter *iter;
+	RRegexMatch match;
+	RRegex rx = {0};
+	const int old_nhits = s->nhits;
+	int ret = 0;
+
+	r_list_foreach (s->kws, iter, kw) {
+		ut64 addr = from;
+		int reflags = R_REGEX_EXTENDED;
+
+		if (kw->icase) {
+			reflags |= R_REGEX_ICASE;
+		}
+
+		if (r_regex_init (&rx, (char *)kw->bin_keyword, reflags)) {
+			eprintf ("Cannot compile '%s' regexp\n", kw->bin_keyword);
+			return -1;
+		}
+
+		while (addr < to) { // get buffer
+			ut8 buf[512];
+			int len = R_MIN (to - addr, sizeof (buf));
+			if (!s->iob.read_at (s->iob.io, addr, buf, len)) {
+				return -1; // failed to read
+			}
+			match.rm_so = 0;
+			match.rm_eo = len;
+
+			int m = r_regex_exec (&rx, (char *)buf, 1, &match, R_REGEX_STARTEND);
+			if (!m) { // match
+				ut32 mtch_len = match.rm_eo - match.rm_so;
+				if (match.rm_eo < match.rm_so || !mtch_len) {
+					// <= zero length match (ie /a*/ matches everything)
+					ret = -1;
+					goto beach;
+				}
+
+				// match extends to end of this buffer, but maybe even further?, so try again at match start
+				if (match.rm_eo == len && !match.rm_so && mtch_len < len) {
+					addr += match.rm_so;
+					continue;
+				}
+				int t = r_search_hit_sz (s, kw, addr + match.rm_so, mtch_len);
+				if (!t) {
+					ret = -1;
+					goto beach;
+				}
+				if (t > 1) { // max matches reached
+					goto beach;
+				}
+				// adjust where buffer starts next loop
+				if (s->overlap) {
+					addr += match.rm_so + 1;
+				} else {
+					addr += match.rm_eo;
+				}
+			} else if (m == R_REGEX_NOMATCH) {
+				// if a match exists accross buffer boundary, this will still
+				// find it, unless start of match is withen first 7/8th of buffer
+				// TODO: use some RSearch member to allow user to tune this distance
+				addr += len - (len / 8);
+			} else { // regex error
+				ret = -1;
+				goto beach;
+			}
+		}
+	}
+
+beach:
+	r_regex_fini (&rx);
+	if (!ret) {
+		ret = s->nhits - old_nhits;
+	}
+	return ret;
+}
 
 R_IPI int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	RSearchKeyword *kw;

--- a/libr/search/regexp.c
+++ b/libr/search/regexp.c
@@ -34,6 +34,10 @@ R_IPI int search_regex_read(RSearch *s, ut64 from, ut64 to) {
 			match.rm_so = 0;
 			match.rm_eo = len;
 
+			if (r_cons_is_breaked ()) {
+				break;
+			}
+
 			int m = r_regex_exec (&rx, (char *)buf, 1, &match, R_REGEX_STARTEND);
 			if (!m) { // match
 				ut32 mtch_len = match.rm_eo - match.rm_so;

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -483,19 +483,13 @@ R_API void r_search_pattern_size(RSearch *s, int size) {
 }
 
 R_API void r_search_set_callback(RSearch *s, RSearchCallback(callback), void *user) {
-	if (s->r_callback) {
-		// prevent user from being passed to wrong function
-		s->r_callback = NULL;
-	}
+	s->r_callback = NULL; // prevent user from being passed to wrong function
 	s->callback = callback;
 	s->user = user;
 }
 
 R_API void r_search_set_read_cb(RSearch *s, RSearchRCb cb, void *user) {
-	if (s->callback) {
-		// prevent user from being passed to wrong function
-		s->callback = NULL;
-	}
+	s->callback = NULL; // prevent user from being passed to wrong function
 	s->r_callback = cb;
 	s->user = user;
 }

--- a/libr/search/search.c
+++ b/libr/search/search.c
@@ -3,6 +3,7 @@
 #include <r_search.h>
 #include <r_list.h>
 #include <ctype.h>
+#include <r_util/r_assert.h>
 #include "search.h"
 
 // Experimental search engine (fails, because stops at first hit of every block read
@@ -516,6 +517,7 @@ R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len) {
 
 // like r_search_update but uses s->iob, does not need to loop as much
 R_API int r_search_update_read(RSearch *s, ut64 from, ut64 to) {
+	r_return_val_if_fail (s && s->iob.read_at && s->consb.is_breaked, -1);
 	switch (s->mode) {
 	case R_SEARCH_PATTERN:
 		return search_pattern (s, from, to);

--- a/libr/search/search.h
+++ b/libr/search/search.h
@@ -8,3 +8,6 @@ R_IPI int search_regexp_update(RSearch *s, ut64 from, const ut8 *buf, int len);
 
 // update read API's use RSearch.iob instead of provided buf
 R_IPI int search_pattern(RSearch *s, ut64 from, ut64 to);
+R_IPI int search_regex_read(RSearch *s, ut64 from, ut64 to);
+
+R_IPI int r_search_hit_sz(RSearch *s, RSearchKeyword *kw, ut64 addr, ut32 sz);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This moves `/e` command over to `r_search_update_read` and fixes a few bugs in `/e`. 

This fixes some bugs in `/e`.
* Less false negatives due to matches crossing buffer boundaries. This can still happen if a match is larger then 64 characters and it falls across a buffer boundary. This should be updated in the future so users can configure an expected largest match length.
* Prevent infinite loop when searching for a zero length match `/e /A*/`.
* Matches have a proper length.

This pull implements  a second callback system that should replace the first. When a match was found previously, the callback assumed the match length was equal to the keyword length. So a match of `/A{30}/` would be treated as a length of 5. The new callback accepts a size of match to fix this. The old callback system should probably be fazed out.