### PR TITLE
Use I64x instead of llx format strings for mingw builds too ##windows

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -428,7 +428,7 @@ static inline void *r_new_copy(int size, void *data) {
 #define HAVE_REGEXP 1
 #endif
 
-#if __WINDOWS__ && !__MINGW32__
+#if __WINDOWS__
 #define PFMT64x "I64x"
 #define PFMT64d "I64d"
 #define PFMT64u "I64u"


### PR DESCRIPTION
should fix this:

````
/home/runner/work/radare2/radare2/libr/..//libr/anal/p/anal_gb.c:484:29: warning: unknown conversion type character ‘l’ in format [-Wformat=]

```