### PR TITLE
Add EPRINT macros for debug printing with variable name

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -401,8 +401,21 @@ static inline void *r_new_copy(int size, void *data) {
 #endif
 
 #ifndef HAVE_EPRINTF
-#define eprintf(...) fprintf(stderr,__VA_ARGS__)
+#define eprintf(...) fprintf (stderr, __VA_ARGS__)
 #define HAVE_EPRINTF 1
+
+#define EPRINT_STR(x) eprintf (#x ": %s", x)
+#define EPRINT_CHAR(x) eprintf (#x ": %c", x)
+#define EPRINT_INT(x) eprintf (#x ": %d (%x)", x, x)
+#define EPRINT_BOOL(x) eprintf (#x ": %s", x? "true": "false")
+#define EPRINT_UT64(x) eprintf (#x ": %" PFMT64u " (%" PFMT64x ")", x, x)
+#define EPRINT_ST64(x) eprintf (#x ": %" PFMT64d " (%" PFMT64x ")", x, x)
+#define EPRINT_UT32(x) eprintf (#x ": %" PFMT32u " (%" PFMT32x ")", x, x)
+#define EPRINT_ST32(x) eprintf (#x ": %" PFMT32d " (%" PFMT32x ")", x, x)
+#define EPRINT_UT16(x) eprintf (#x ": %hu (%hx)", x, x)
+#define EPRINT_ST16(x) eprintf (#x ": %hd (%hx)", x, x)
+#define EPRINT_UT8(x) eprintf (#x ": %hhu (%hhx)", x, x)
+#define EPRINT_ST8(x) eprintf (#x ": %hhd (%hhx)", x, x)
 #endif
 
 #ifndef typeof


### PR DESCRIPTION
**Checklist**

- [X] Mark this if you consider it ready to merge

**Description**

Add a few macros that eprintf the variable name and value. Very useful for speeding up debugging without worrying about format specifiers.