### PR TITLE
Remove undocumented and unlogged seek behavior when no alias match is found

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -798,12 +798,7 @@ static int cmd_alias(void *data, const char *input) {
 				r_core_cmd0 (core, (char *)v->data);
 			}
 		} else {
-			ut64 at = r_num_get (core->num, buf);
-			if (at != UT64_MAX) {
-				r_core_seek (core, at, true);
-			} else {
-				eprintf ("No such alias \"$%s\"\n", buf);
-			}
+			eprintf ("No such alias \"$%s\"\n", buf);
 		}
 	}
 	free (buf);


### PR DESCRIPTION
**Checklist**

- [X] Closing issues: #17929
- [X] Mark this if you consider it ready to merge

**Description**

This is totally undocumented and makes e.g. `$1` do `s 1` if no "1" alias is defined but without recording it for `s-` as described in the issue. Now it just fails with "No such alias" as expected.