### PR TITLE
Optimize and fix heap overflow in asm.tabs using RStrBuf ##crash

### DIFF
--- a/test/db/cmd/cmd_ah
+++ b/test/db/cmd/cmd_ah
@@ -200,8 +200,8 @@ EXPECT=<<EOF
             0x100001059      4889e5         mov rbp, rsp
             0x10000105c      4157           push r15
             0x100001058      55             hello world
-            0x100001059      4889e5         mov rbp, rsp
-            0x10000105c      4157           push r15
+            0x100001059      4889e5         mov  rbp,  rsp
+            0x10000105c      4157           push  r15
 EOF
 RUN
 

--- a/test/db/cmd/feat_astabs
+++ b/test/db/cmd/feat_astabs
@@ -10,7 +10,7 @@ wx 410fb744245883f80c
 pd 2
 EOF
 EXPECT=<<EOF
-  0x00000000      410fb7442458   movzx   eax,    word [r12 + 0x58]
-  0x00000006      83f80c         cmp     eax,    0xc
+  0x00000000      410fb7442458   movzx    eax,    word [r12 + 0x58]
+  0x00000006      83f80c         cmp      eax,    0xc
 EOF
 RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
