### PR TITLE
Initial implementation of the 'aafs' command ##analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
       with:
         name: radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz
         path: r2-static.tar.xz
-    - name: Static static r2 with meson
+    - name: Static r2 build with meson
       run: |
         sudo apt-get --assume-yes install python3-wheel python3-setuptools cabextract gperf
         sudo pip3 install meson ninja

--- a/libr/asm/p/asm_x86_nasm.c
+++ b/libr/asm/p/asm_x86_nasm.c
@@ -23,8 +23,12 @@ static int assemble(RAsm *a, RAsmOp *op, const char *buf) {
 
 	char *asm_buf = r_str_newf ("[BITS %i]\nORG 0x%"PFMT64x"\n%s\n", a->bits, a->pc, buf);
 	if (asm_buf) {
-		(void)write (ifd, asm_buf, strlen (asm_buf));
+		int slen = strlen (asm_buf);
+		int wlen = write (ifd, asm_buf, slen);
 		free (asm_buf);
+		if (slen != wlen) {
+			return -1;
+		}
 	}
 
 	close (ifd);

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -55,7 +55,7 @@ static size_t consume_u7_r(RBuffer *b, ut64 max, ut8 *out) {
 }
 
 static size_t consume_s7_r(RBuffer *b, ut64 max, st8 *out) {
-	size_t n;
+	size_t n = 0;
 	ut32 tmp = consume_r (b, max, &n, (ConsumeFcn)read_i32_leb128);
 	if (out) {
 		*out = (st8) (((tmp & 0x10000000) << 7) | (tmp & 0x7f));
@@ -792,18 +792,14 @@ RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf) {
 }
 
 void r_bin_wasm_destroy(RBinFile *bf) {
-	RBinWasmObj *bin;
-
 	if (!bf || !bf->o || !bf->o->bin_obj) {
 		return;
 	}
-
-	bin = bf->o->bin_obj;
+	RBinWasmObj *bin = bf->o->bin_obj;
 	r_buf_free (bin->buf);
 
 	r_list_free (bin->g_sections);
 	r_list_free (bin->g_types);
-
 	r_list_free (bin->g_imports);
 	r_list_free (bin->g_exports);
 	r_list_free (bin->g_tables);

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -368,8 +368,8 @@ EXPECT=<<EOF
 0x00001337    0 0            func
 EOF
 EXPECT_ERR=<<EOF
-Cannot add function (duplicated)
-Cannot add function (duplicated)
+Cannot add function 'func' (duplicated) at 0x00001337
+Cannot add function 'func' (duplicated) at 0x00001337
 EOF
 RUN
 


### PR DESCRIPTION
* Find function entrypoints and creates a single basic block function
* Useful for fast initial analysis instead of aaa (30min vs 5s)
* Handy to get xrefs context in function boundaries

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
