### PR TITLE
Kill HAVE_EPRINTF, replace with ifndef eprintf

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -400,9 +400,8 @@ static inline void *r_new_copy(int size, void *data) {
 #endif
 #endif
 
-#ifndef HAVE_EPRINTF
+#ifndef eprintf
 #define eprintf(...) fprintf (stderr, __VA_ARGS__)
-#define HAVE_EPRINTF 1
 
 #define EPRINT_STR(x) eprintf (#x ": \"%s\"\n", x)
 #define EPRINT_CHAR(x) eprintf (#x ": %c\n", x)

--- a/shlr/sdb/src/types.h
+++ b/shlr/sdb/src/types.h
@@ -9,8 +9,9 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-#undef eprintf
-#define eprintf(...) fprintf(stderr,__VA_ARGS__)
+#ifndef eprintf
+#define eprintf(...) fprintf (stderr, __VA_ARGS__)
+#endif
 
 // Copied from https://gcc.gnu.org/wiki/Visibility
 #ifndef SDB_API

--- a/shlr/winkd/transport.h
+++ b/shlr/winkd/transport.h
@@ -4,10 +4,9 @@
 #include <r_types.h>
 #include <stdint.h>
 
-#ifndef HAVE_EPRINTF
+#ifndef eprintf
 #include <stdio.h>
 #define eprintf(...) { fprintf(stderr,##__VA_ARGS__); }
-#define HAVE_EPRINTF 1
 #endif
 
 #define KD_IO_PIPE 0


### PR DESCRIPTION
Macro redefinition is messing with CI, this should fix it. Not sure why the CI on my eprintf changes didnt show these errors when I changed the eprintf definition in `r_types.h` to have spaces, but checking for eprintf already being defined should prevent it.