### PR TITLE
WIP: 8051: handle any mov case

### DIFF
--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -351,7 +351,6 @@ static bool is_direct(char const *str) {
 static bool is_reg(char const *str) {
 	r_return_val_if_fail (str, false);
 	return tolower (str[0]) == 'r' && R_BETWEEN ('0', str[1], '7') && !str[2];
-		&& !str[2];
 }
 
 /**

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -442,9 +442,9 @@ static bool parse_register(char const* register_input, ut8* hex_out) {
 	return true;
 }
 
-/**
- * attempts to parse the given string as an 8bit-wide address
- */
+  /*
+  * attempts to parse the given string as an 8bit-wide address
+  */
 static bool address_direct(char const* addr_str, ut8* addr_out) {
 	ut16 addr_big;
 	ut8 addr_short;
@@ -458,13 +458,15 @@ static bool address_direct(char const* addr_str, ut8* addr_out) {
 		found = true;
 	}
 
-	if (!found) {
+	/* need opinion in order to remove this comment
+	 *
+	  if (!found) {
 		if ( !parse_register (addr_str, &addr_short)) {
 			return false;
 		}
 		*addr_out = addr_short;
 		return true;
-	}
+	}*/
 
 	*addr_out = addr_big;
 	return found;
@@ -589,6 +591,36 @@ static bool singlearg_direct(ut8 const firstbyte, char const* arg
 	(*out)[1] = address;
 	*out += 2;
 	return ret;
+}
+
+static bool singlearg_direct_or_register(ut8 const first_byte, char const* arg, ut8**out) {
+	ut16 addr_big;
+	ut8 addr_short;
+
+	bool found;
+	if ( !parse_hexadecimal (arg, &addr_big)
+		|| (0xFF < addr_big)) {
+		found = false;
+	} else {
+		found = true;
+	}
+
+	if (!found) {
+		if ( !parse_register (arg, &addr_short)) {
+			return false;
+		}
+
+		(*out)[0] = first_byte;
+		(*out)[1] = addr_short;
+		*out += 2;
+
+		return true;
+	}
+
+	(*out)[0] = first_byte;
+	(*out)[1] = addr_big;
+	*out += 2;
+	return found;
 }
 
 static bool singlearg_immediate(ut8 firstbyte, char const* imm_str, ut8**out) {
@@ -1166,11 +1198,11 @@ static bool mnem_orl(char const*const*arg, ut16 pc, ut8**out) {
 }
 
 static bool mnem_pop(char const*const*arg, ut16 pc, ut8**out) {
-	return singlearg_direct (0xd0, arg[0], out);
+	return singlearg_direct_or_register (0xd0, arg[0], out);
 }
 
 static bool mnem_push(char const*const*arg, ut16 pc, ut8**out) {
-	return singlearg_direct (0xc0, arg[0], out);
+	return singlearg_direct_or_register (0xc0, arg[0], out);
 }
 
 static bool mnem_ret(char const*const*arg, ut16 pc, ut8**out) {

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1257,7 +1257,8 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 		offset = register_offset (arg[1]);
 		if (offset < 2) {
 			return singlearg_register (0x66 + offset, arg[1], out);
-		} else if (offset < 10) {
+		}
+		if (offset < 10) {
 			return single_byte_instr (0x66 + offset, out);
 		}
 	}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -351,7 +351,6 @@ static bool is_direct(char const *str) {
 static bool is_reg(char const *str) {
 	r_return_val_if_fail (str, false);
 	return tolower (str[0]) == 'r' && R_BETWEEN ('0', str[1], '7') && !str[2];
-		&& R_BETWEEN ('0', str[1], '7')
 		&& !str[2];
 }
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -447,9 +447,18 @@ static bool parse_register(char const* register_input, ut8* hex_out) {
   */
 static bool address_direct(char const* addr_str, ut8* addr_out) {
 	ut16 addr_big;
+	ut8 addr_short;
 	// rasm2 resolves symbols, so does this really only need to parse hex?
 	// maybe TODO: check address bounds?
 	bool found = parse_hexadecimal (addr_str, &addr_big);// && (addr_big < 0xFF);
+
+	if (!found) {
+		if (!parse_register (addr_str, &addr_short)) {
+			return false;
+		}
+		*addr_out = addr_short;
+		return true;
+	}
 
 	*addr_out = addr_big;
 	return found;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -877,7 +877,7 @@ static bool mnem_jbc(char const*const*arg, ut16 pc, ut8**out) {
 	to_address (arg[1], &jmp_addr);
 
 	if (!relative_address (pc + 1, jmp_addr, (*out) + 2)) {
-		eprintf ("error during the assembly: address not found\n");
+		eprintf ("error during the assembly: address %x not found\n", jmp_addr);
 		return false;
 	}
 
@@ -999,11 +999,11 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	if (arg[0][0] == 'r') {
 		if (R_BETWEEN ('0', arg[0][1], '7')) {
 			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x78 + arg[1][1]-'0', arg[1], out);
+				return singlearg_immediate (0x78 + arg[0][1]-'0', arg[1], out);
 			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xa8 + arg[1][1]-'0', arg[1], out);
+				return singlearg_direct (0xa8 + arg[0][1]-'0', arg[1], out);
 			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xf8 + arg[1][1]-'0', out);
+				return single_byte_instr (0xf8 + arg[0][1]-'0', out);
 			}
 		}
 	}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1014,8 +1014,8 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (address_direct (arg[0], &dst_addr)) {
-		if (address_direct (arg[1], &src_addr)) {
+	if (parse_hexadecimal (arg[0], &dst_addr)) {
+		if (parse_hexadecimal (arg[1], &src_addr)) {
 			(*out)[0] = 0x85;
 			(*out)[1] = src_addr;
 			(*out)[2] = dst_addr;
@@ -1411,7 +1411,7 @@ static bool mnem_swap(char const*const*arg, ut16 pc, ut8**out) {
 static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 	ut8 dest_addr;
 	ut16 dest_hexadecimal;
-	if (address_direct (arg[0], &dest_addr)) {
+	if (parse_hexadecimal (arg[0], &dest_hexadecimal)) {
 		if (!r_str_casecmp (arg[1], "a")) {
 			return singlearg_direct (0x62, arg[0], out);
 		}
@@ -1429,7 +1429,7 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 		if (arg[1][0] == '#') {
 			return singlearg_immediate (0x64, arg[1], out);
 		}
-		if (address_direct (arg[1], &dest_addr)) {
+		if (parse_hexadecimal (arg[1], &dest_hexadecimal)) {
 			return singlearg_direct (0x65, arg[1], out);
 		}
 		if (!r_str_casecmp (arg[1], "@r0") || !r_str_casecmp (arg[1], "[r0]")) {

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -955,10 +955,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	    (*out)[2] = src_imm & 0x00ff;
 	    *out += 3;
 	    return true;
-	} else if (!r_str_casecmp (arg[0], "@r0") && resolve_immediate (arg[1] + 1, &src_imm)) {
+	} else if ((!r_str_casecmp (arg[0], "@r0") && resolve_immediate (arg[1] + 1, &src_imm)) || (!r_str_casecmp (arg[0], "[r0]") && resolve_immediate (arg[1] + 1, &src_imm))) {
 		singlearg_immediate (0x76, arg[1], out);
 		return true;
-	} else if (!r_str_casecmp (arg[0], "@r1") && resolve_immediate (arg[1] + 1, &src_imm)) {
+	} else if ((!r_str_casecmp (arg[0], "@r1") && resolve_immediate (arg[1] + 1, &src_imm))  || (!r_str_casecmp (arg[0], "[r1]") && resolve_immediate (arg[1] + 1, &src_imm))) {
 		singlearg_immediate (0x77, arg[1], out);
 		return true;
 	} else if (!r_str_casecmp (arg[0], "r0") && resolve_immediate (arg[1] + 1, &src_imm)) {
@@ -996,10 +996,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		(*out)[1] = src_addr;
 		(*out)[2] = dst_addr;
 		*out += 3;
-	} else if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r0")) {
+	} else if ((is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r0")) || (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "[r0]"))) {
 		singlearg_direct (0x86, arg[0], out);
 		return true;
-	} else if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r1")) {
+	} else if ((is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r1"))  || (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "[r1]"))) {
 		singlearg_direct (0x87, arg[0], out);
 		return true;
 	} else if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r0")) {
@@ -1324,13 +1324,18 @@ static bool mnem_swap(char const*const*arg, ut16 pc, ut8**out) {
 
 static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 	ut8 dest_addr;
+	ut16 dest_hexadecimal;
 	if (address_direct (arg[0], &dest_addr)) {
 		if (!r_str_casecmp (arg[1], "a")) {
 			return singlearg_direct (0x62, arg[0], out);
 		} else if (arg[1][0] == '#') {
 			(*out)[0] = 0x63;
-			(*out)[1] = arg[1][1];
-		    (*out)[2] = arg[2][1] & 0x00ff;
+			parse_hexadecimal (arg[0], &dest_hexadecimal);
+			(*out)[1] = dest_hexadecimal;
+			parse_hexadecimal (arg[1] + 1, &dest_hexadecimal);
+		    (*out)[2] = dest_hexadecimal;
+		    *out += 3;
+		    return true;
 		}
 	} else if (!r_str_casecmp (arg[0], "a")) {
 		if (arg[1][0] == '#') {
@@ -1345,7 +1350,7 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
 			return singlearg_register (0x67, arg[1], out);
 		}
-		if (is_reg (arg[1])) {
+		if (is_reg (arg[1])) { // todo specify each case
 			return singlearg_register (0x68, arg[1], out);
 		}
 	}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -869,7 +869,6 @@ static bool mnem_jb(char const*const*arg, ut16 pc, ut8**out) {
 }
 
 static bool mnem_jbc(char const*const*arg, ut16 pc, ut8**out) {
-
 	ut8 cmp_addr;
 	if (!address_bit (arg[0], &cmp_addr)) {
 		eprintf ("error during the assembly: address bit not found\n");
@@ -877,9 +876,11 @@ static bool mnem_jbc(char const*const*arg, ut16 pc, ut8**out) {
 	}
 
 	ut16 jmp_addr;
-	if (!to_address (arg[1], &jmp_addr) && !relative_address (pc + 1, jmp_addr, (*out) + 2)) {
-		eprintf ("error during the assembly: address not found\n");
-		return false;
+	to_address (arg[1], &jmp_addr);
+
+	if (!relative_address (pc + 1, jmp_addr, (*out) + 2)) {
+	    eprintf ("error during the assembly: address not found\n");
+    	return false;
 	}
 
 	(*out)[0] = 0x10;
@@ -1023,8 +1024,8 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	if (parse_hexadecimal (arg[0], &dst_imm)) {
 		if (parse_hexadecimal (arg[1], &src_imm)) {
 			(*out)[0] = 0x85;
-			(*out)[1] = src_addr;
-			(*out)[2] = dst_addr;
+			(*out)[1] = src_imm;
+			(*out)[2] = dst_imm;
 			*out += 3;
 			return true;
 		}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -743,7 +743,7 @@ static bool mnem_cjne(char const*const*arg, ut16 pc, ut8**out) {
 		if (!resolve_immediate (arg[1] + 1, &imm)) {
 			return false;
 		}
-		(*out)[0] = 0xbf | register_number (arg[0]) ;
+		(*out)[0] = 0xb8 | register_number (arg[0]) ;
 		(*out)[1] = imm & 0x00FF;
 		// out[2] set earlier
 		*out += 3;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -554,7 +554,6 @@ static ut8 register_offset(const char *reg) {
 		return 1;
 	}
 	return register_number (reg) + 2;
-	}
 }
 
 /******************************************************************************

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -970,36 +970,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			return single_byte_instr (0xe7, out);
 		}
 
-		if (!r_str_casecmp (arg[1], "r0")) {
-			return single_byte_instr (0xe8, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r1")) {
-			return single_byte_instr (0xe9, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r2")) {
-			return single_byte_instr (0xea, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r3")) {
-			return single_byte_instr (0xeb, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r4")) {
-			return single_byte_instr (0xec, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r5")) {
-			return single_byte_instr (0xed, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r6")) {
-			return single_byte_instr (0xee, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r7")) {
-			return single_byte_instr (0xef, out);
+		if (arg[1][0] == 'r') {
+			if (R_BETWEEN ('0', arg[1][1], '7')) {
+				return single_byte_instr (0xe8 + arg[1][1]-'0', out);
+			}
 		}
 	}
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -997,79 +997,14 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	}
 
 	if (arg[0][0] == 'r') {
-		switch (arg[0][1]) {
-		case '0':
-			if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xf8, out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xa8, arg[1], out);
-			} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x78, arg[1], out);
-			}
-			break;
-		case '1':
+		if (R_BETWEEN ('0', arg[0][1], '7')) {
 			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x79, arg[1], out);
+				return singlearg_immediate (0x78 + arg[1][1]-'0', arg[1], out);
 			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xa9, arg[1], out);
+				return singlearg_direct (0xa8 + arg[1][1]-'0', arg[1], out);
 			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xf9, out);
+				return single_byte_instr (0xf8 + arg[1][1]-'0', out);
 			}
-			break;
-		case '2':
-			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x7a, arg[1], out);
-			} else if (is_direct(arg[1])) {
-				return singlearg_direct (0xaa, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xfa, out);
-			}
-			break;
-		case '3':
-			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x7b, arg[1], out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xab, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xfb, out);
-			}
-			break;
-		case '4':
-			if (resolve_immediate (arg[1]+1, &dst_imm)) {
-				return singlearg_direct (0x7c, arg[1]+1, out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xac, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xfc, out);
-			}
-			break;
-		case '5':
-			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x7d, arg[1], out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xad, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xfd, out);
-			}
-			break;
-		case '6':
-			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x7e, arg[1], out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xae, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xfe, out);
-			}
-			break;
-		case '7':
-			if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x7f, arg[1], out);
-			} else if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xff, out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xaf, arg[1], out);
-			}
-			break;
 		}
 	}
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1413,15 +1413,15 @@ int assemble_8051(RAsm *a, RAsmOp *op, char const *user_asm) {
 	ut8 instr[4] = {0};
 	ut8 *binp = instr;
 	if (!mnem (carg, a->pc, &binp)) {
-		free (arg[0]); arg[0] = 0; carg[2] = 0;
-		free (arg[1]); arg[1] = 0; carg[1] = 0;
-		free (arg[2]); arg[2] = 0; carg[0] = 0;
+		R_FREE (arg[0]);
+		R_FREE (arg[1]);
+		R_FREE (arg[2]);
 		return 0;
 	}
 
-	free (arg[0]); arg[0] = 0; carg[2] = 0;
-	free (arg[1]); arg[1] = 0; carg[1] = 0;
-	free (arg[2]); arg[2] = 0; carg[0] = 0;
+	R_FREE (arg[0]);
+	R_FREE (arg[1]);
+	R_FREE (arg[2]);
 	size_t len = binp - instr;
 	r_strbuf_setbin (&op->buf, instr, len);
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -499,7 +499,7 @@ static bool address_bit(char const* addr_str, ut8* addr_out) {
 	}
 
 	ut8 addr_bytepart = 0x00;
-    if (!parse_register(bytepart, &addr_bytepart)) {
+	if (!parse_register(bytepart, &addr_bytepart)) {
 		if (!parse_address_direct (bytepart, &byte)) {
 			ret = false;
 			goto end;
@@ -1014,7 +1014,7 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	}
 	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]"))) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x77, arg[1], out);
+			return singlearg_immediate (0x77, arg[1], out);
 		} else if (!r_str_casecmp (arg[1], "a")) {
 			return single_byte_instr (0xf7, out);
 		} else if (is_direct (arg[1])) {
@@ -1022,14 +1022,14 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 	if (!r_str_casecmp (arg[0], "r0")) {
-			if (!r_str_casecmp (arg[1], "a")) {
-				return single_byte_instr (0xf8, out);
-			} else if (is_direct (arg[1])) {
-				return singlearg_direct (0xa8, arg[1], out);
-			} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
-				return singlearg_immediate (0x78, arg[1], out);
-		    }
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf8, out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xa8, arg[1], out);
+		} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x78, arg[1], out);
 		}
+	}
 	if (!r_str_casecmp (arg[0], "r1")) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
 			return singlearg_immediate (0x79, arg[1], out);
@@ -1041,8 +1041,8 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	}
 	if (!r_str_casecmp (arg[0], "r2")) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x7a, arg[1], out);
-	    } else if (is_direct(arg[1])) {
+			return singlearg_immediate (0x7a, arg[1], out);
+		} else if (is_direct(arg[1])) {
 			return singlearg_direct (0xaa, arg[1], out);
 		} else if (!r_str_casecmp (arg[1], "a")) {
 			return single_byte_instr (0xfa, out);
@@ -1051,10 +1051,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 
 	if (!r_str_casecmp (arg[0], "r3")) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x7b, arg[1], out);
-	    } else if (is_direct (arg[1])) {
-    		return singlearg_direct (0xab, arg[1], out);
-	    } else if (!r_str_casecmp (arg[1], "a")) {
+			return singlearg_immediate (0x7b, arg[1], out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xab, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
 			return single_byte_instr (0xfb, out);
 		}
 	}
@@ -1164,7 +1164,7 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			(*out)[2] = src_imm & 0xff;
 			*out += 3;
 			return true;
-        }
+		}
 	}
 	if (address_bit (arg[0], &src_addr)) {
 		if (!r_str_casecmp (arg[1], "c")) {
@@ -1376,9 +1376,9 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 			parse_hexadecimal (arg[0], &dest_hexadecimal);
 			(*out)[1] = dest_hexadecimal;
 			parse_hexadecimal (arg[1] + 1, &dest_hexadecimal);
-		    (*out)[2] = dest_hexadecimal;
-		    *out += 3;
-		    return true;
+			(*out)[2] = dest_hexadecimal;
+			*out += 3;
+			return true;
 		}
 	}
 	if (!r_str_casecmp (arg[0], "a")) {

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -350,7 +350,7 @@ static bool is_direct(char const *str) {
  */
 static bool is_reg(char const *str) {
 	r_return_val_if_fail (str, false);
-	return tolower (str[0]) == 'r'
+	return tolower (str[0]) == 'r' && R_BETWEEN ('0', str[1], '7') && !str[2];
 		&& R_BETWEEN ('0', str[1], '7')
 		&& !str[2];
 }

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1021,11 +1021,11 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (address_direct (arg[0], &dst_imm)) {
-		if (parse_hexadecimal (arg[1], &src_imm)) {
+	if (address_direct (arg[0], &dst_addr)) {
+		if (parse_hexadecimal (arg[1], &src_addr)) {
 			(*out)[0] = 0x85;
-			(*out)[1] = src_imm;
-			(*out)[2] = dst_imm;
+			(*out)[1] = src_addr;
+			(*out)[2] = dst_addr;
 			*out += 3;
 			return true;
 		}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -944,127 +944,146 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 	ut16 src_imm, dst_imm;
 	ut8 src_addr, dst_addr;
 
-	if (!r_str_casecmp (arg[0], "a") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		return singlearg_immediate (0x74, arg[1], out);
-	}
-	if (parse_hexadecimal (arg[0], &dst_imm) && resolve_immediate (arg[1] + 1, &src_imm)) { //TODO: write doublearg_direct_register for 3 bytes instructions
-		//use : "arg[1][0] == '#'" ?
-		(*out)[0] = 0x75;
-	    (*out)[1] = dst_imm;
-	    (*out)[2] = src_imm & 0x00ff;
-	    *out += 3;
-	    return true;
-	}
-	if ((!r_str_casecmp (arg[0], "@r0") && resolve_immediate (arg[1] + 1, &src_imm)) || (!r_str_casecmp (arg[0], "[r0]") && resolve_immediate (arg[1] + 1, &src_imm))) {
-		return singlearg_immediate (0x76, arg[1], out);
-	}
-	if ((!r_str_casecmp (arg[0], "@r1") && resolve_immediate (arg[1] + 1, &src_imm))  || (!r_str_casecmp (arg[0], "[r1]") && resolve_immediate (arg[1] + 1, &src_imm))) {
-		return singlearg_immediate (0x77, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r0") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		return singlearg_immediate (0x78, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r1") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x79, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r2") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7a, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r3") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7b, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r4") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7c, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r5") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7d, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r6") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7e, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r7") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		singlearg_immediate (0x7f, arg[1], out);
-		return true;
-	}
-	if (is_indirect_reg (arg[0]) && is_indirect_reg (arg[1])) { //TODO: write doublearg_direct_register for 3 bytes instructions
-		if (!address_direct (arg[0], &dst_addr)) {
-			return false;
+	if (!r_str_casecmp (arg[0], "a")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x74, arg[1], out);
 		}
-		if (!address_direct (arg[1], &src_addr)) {
-			return false;
+	}
+	if (parse_hexadecimal (arg[0], &dst_imm)) { //TODO: write doublearg_direct_register for 3 bytes instructions
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			//use : "arg[1][0] == '#'" ?
+			(*out)[0] = 0x75;
+			(*out)[1] = dst_imm;
+			(*out)[2] = src_imm & 0x00ff;
+			*out += 3;
+			return true;
 		}
-		(*out)[0] = 0x85;
-		(*out)[1] = src_addr;
-		(*out)[2] = dst_addr;
-		*out += 3;
 	}
-	if ((is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r0")) || (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "[r0]"))) {
-		singlearg_direct (0x86, arg[0], out);
-		return true;
+	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]"))) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x76, arg[1], out);
+		}
 	}
-	if ((is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "@r1"))  || (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "[r1]"))) {
-		singlearg_direct (0x87, arg[0], out);
-		return true;
+	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]"))) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x77, arg[1], out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r0")) {
-		singlearg_direct (0x88, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r0")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x78, arg[1], out);
+	    }
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r1")) {
-		singlearg_direct (0x89, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r1")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x79, arg[1], out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r2")) {
-		singlearg_direct (0x8a, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r2")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x7a, arg[1], out);
+	    }
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r3")) {
-		singlearg_direct (0x8b, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r3")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x7b, arg[1], out);
+	    }
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r4")) {
-		singlearg_direct (0x8c, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r4")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7c, arg[1], out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r5")) {
-		singlearg_direct (0x8d, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r5")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7d, arg[1], out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r6")) {
-		singlearg_direct (0x8e, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r6")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7e, arg[1], out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "r7")) {
-		singlearg_direct (0x8f, arg[0], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r7")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7f, arg[1], out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "dptr") && resolve_immediate (arg[1] + 1, &src_imm)) {
-		parse_register ("dptr", &dst_addr);
-		(*out)[0] = 0x90;
-		(*out)[1] = src_imm >> 8;
-		(*out)[2] = src_imm & 0xff;
-		*out += 3;
-		return true;
+
+	if (address_direct (arg[0], &dst_addr)) {
+		if (address_direct (arg[1], &src_addr)) {
+			(*out)[0] = 0x85;
+			(*out)[1] = src_addr;
+			(*out)[2] = dst_addr;
+			*out += 3;
+			return true;
+		}
+
+		if (!r_str_casecmp (arg[1], "@r0") || !r_str_casecmp (arg[1], "[r0]")) {
+			return singlearg_direct (0x86, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
+			return singlearg_direct (0x87, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r0")) {
+			return singlearg_direct (0x88, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r1")) {
+			return singlearg_direct (0x89, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r2")) {
+			return singlearg_direct (0x8a, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r3")) {
+			return singlearg_direct (0x8b, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r4")) {
+			return singlearg_direct (0x8c, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r5")) {
+			return singlearg_direct (0x8d, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r6")) {
+			return singlearg_direct (0x8e, arg[0], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r7")) {
+			return singlearg_direct (0x8f, arg[0], out);
+		}
 	}
-	if (address_bit (arg[0], &src_addr) && !r_str_casecmp (arg[1], "c")) {
-		singlearg_bit (0x92, arg[0], out);
-		return true;
+
+	if (!r_str_casecmp (arg[0], "dptr")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			parse_register ("dptr", &dst_addr);
+			(*out)[0] = 0x90;
+			(*out)[1] = src_imm >> 8;
+			(*out)[2] = src_imm & 0xff;
+			*out += 3;
+			return true;
+        }
 	}
-	if (!r_str_casecmp (arg[0], "c") && address_bit (arg[1], &src_addr)) {
-		singlearg_bit (0xa2, arg[1], out);
-		return true;
+	if (address_bit (arg[0], &src_addr)) {
+		if (!r_str_casecmp (arg[1], "c")) {
+			return singlearg_bit (0x92, arg[0], out);
+		}
+
+		if (address_bit (arg[1], &src_addr)) {
+			return singlearg_bit (0xa2, arg[1], out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "@r0") && address_direct (arg[1], &src_addr)) {
+	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) && address_direct (arg[1], &src_addr)) {
 		singlearg_direct (0xa6, arg[1], out);
 		return true;
 	}
-	if (!r_str_casecmp (arg[0], "@r1") && address_direct (arg[1], &src_addr)) {
+	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) && address_direct (arg[1], &src_addr)) {
 		singlearg_direct (0xa7, arg[1], out);
 		return true;
 	}
@@ -1100,93 +1119,106 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		singlearg_direct (0xaf, arg[1], out);
 		return true;
 	}
-	if (!r_str_casecmp (arg[0], "a") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xe5, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "a")) {
+		if (address_direct (arg[1], &src_addr)) {
+			return singlearg_direct (0xe5, arg[1], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "@r0") || !r_str_casecmp (arg[1], "[r0]")) {
+			return single_byte_instr (0xe6, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
+			return single_byte_instr (0xe7, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r0")) {
+			return single_byte_instr (0xe8, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r1")) {
+			return single_byte_instr (0xe9, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r2")) {
+			return single_byte_instr (0xea, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r3")) {
+			return single_byte_instr (0xeb, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r4")) {
+			return single_byte_instr (0xec, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r5")) {
+			return single_byte_instr (0xed, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r6")) {
+			return single_byte_instr (0xee, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r7")) {
+			return single_byte_instr (0xef, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "@r0")) {
-		single_byte_instr (0xe6, out);
-		return true;
+
+	if (address_direct (arg[0], &src_addr)) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return singlearg_direct (0xf5, arg[0], out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "@r1")) {
-		single_byte_instr (0xe7, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf6, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r0")) {
-		single_byte_instr (0xe8, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf7, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r1")) {
-		single_byte_instr (0xe9, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r0")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf8, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r2")) {
-		single_byte_instr (0xea, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r1")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf9, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r3")) {
-		single_byte_instr (0xeb, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r2")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfa, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r4")) {
-		single_byte_instr (0xec, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r3")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfb, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r5")) {
-		single_byte_instr (0xed, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r4")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			single_byte_instr (0xfc, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r6")) {
-		single_byte_instr (0xee, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r5")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfd, out);
+		}
 	}
-	if (!r_str_casecmp (arg[0], "a") && !r_str_casecmp (arg[1], "r7")) {
-		single_byte_instr (0xef, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r6")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfe, out);
+		}
 	}
-	if (is_indirect_reg (arg[0]) && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xf5, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "@r0") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xf6, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "@r1") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xf7, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r0") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xf8, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r1") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xf9, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r2") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xfa, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r3") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xfb, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r4") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xfc, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r5") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xfd, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r6") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xfe, out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r7") && !r_str_casecmp (arg[1], "a")) {
-		single_byte_instr (0xff, out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r7")) {
+		if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xff, out);
+		}
 	}
 
 	return false;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1309,6 +1309,10 @@ static bool mnem_xchd(char const*const*arg, ut16 pc, ut8**out) {
 	return singlearg_register (0xd6, arg[1], out);
 }
 
+static bool mnem_reserved(char const*const*arg, ut16 pc, ut8**out) {
+	return single_byte_instr (0xa5, out);
+}
+
 /******************************************************************************
  * ## Section 6: mnemonic token dispatcher
                  -------------------------*/
@@ -1339,6 +1343,7 @@ static parse_mnem_args mnemonic(char const *user_asm, int*nargs) {
 		mnem (1, jnz)
 		mnem (1, lcall)
 		mnem (1, ljmp)
+		mnem (0, reserved)
 /* so uh, the whitespace-independent matching sees movc and mov c as the same
  * thing...
  * My first thought was to add an exception for mov c, but later I saw that it'd

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1350,8 +1350,29 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
 			return singlearg_register (0x67, arg[1], out);
 		}
-		if (is_reg (arg[1])) { // todo specify each case
-			return singlearg_register (0x68, arg[1], out);
+		if (!r_str_casecmp (arg[1], "r0")) {
+			return single_byte_instr (0x68, out);
+		}
+		if (!r_str_casecmp (arg[1], "r1")) {
+			return single_byte_instr (0x69, out);
+		}
+		if (!r_str_casecmp (arg[1], "r2")) {
+			return single_byte_instr (0x6a, out);
+		}
+		if (!r_str_casecmp (arg[1], "r3")) {
+			return single_byte_instr (0x6b, out);
+		}
+		if (!r_str_casecmp (arg[1], "r4")) {
+			return single_byte_instr (0x6c, out);
+		}
+		if (!r_str_casecmp (arg[1], "r5")) {
+			return single_byte_instr (0x6d, out);
+		}
+		if (!r_str_casecmp (arg[1], "r6")) {
+			return single_byte_instr (0x6e, out);
+		}
+		if (!r_str_casecmp (arg[1], "r7")) {
+			return single_byte_instr (0x6f, out);
 		}
 	}
 	return true;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -553,7 +553,7 @@ static ut8 register_offset(const char *reg) {
 	if (!r_str_casecmp (reg, "@r1") || !r_str_casecmp (reg, "[r1]")) {
 		return 1;
 	}
-		return register_number (reg) + 2;
+	return register_number (reg) + 2;
 	}
 }
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -340,6 +340,12 @@ static bool is_indirect_reg(char const*str)
 	return false;
 }
 
+static bool is_direct(char const*str)
+{
+	ut16 useless;
+	return parse_hexadecimal (str, &useless);
+}
+
 /**
  * returns true if the given string denotes an 'r'-register
  */
@@ -1014,8 +1020,8 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (parse_hexadecimal (arg[0], &dst_addr)) {
-		if (parse_hexadecimal (arg[1], &src_addr)) {
+	if (parse_hexadecimal (arg[0], &dst_imm)) {
+		if (parse_hexadecimal (arg[1], &src_imm)) {
 			(*out)[0] = 0x85;
 			(*out)[1] = src_addr;
 			(*out)[2] = dst_addr;
@@ -1083,48 +1089,43 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			return singlearg_bit (0xa2, arg[1], out);
 		}
 	}
-	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) && address_direct (arg[1], &src_addr)) {
+	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) && is_direct (arg[1])) {
 		singlearg_direct (0xa6, arg[1], out);
 		return true;
 	}
-	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) && address_direct (arg[1], &src_addr)) {
+	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) && is_direct (arg[1])) {
 		singlearg_direct (0xa7, arg[1], out);
 		return true;
 	}
-	if (!r_str_casecmp (arg[0], "r0") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xa8, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r0") && is_direct (arg[1])) {
+		return singlearg_direct (0xa8, arg[1], out);
 	}
-	if (!r_str_casecmp (arg[0], "r1") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xa9, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r1") && is_direct (arg[1])) {
+		return singlearg_direct (0xa9, arg[1], out);
 	}
-	if (!r_str_casecmp (arg[0], "r2") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xaa, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r2") && is_direct(arg[1])) {
+		return singlearg_direct (0xaa, arg[1], out);
 	}
-	if (!r_str_casecmp (arg[0], "r3") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xab, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r3") && is_direct (arg[1])) {
+		return singlearg_direct (0xab, arg[1], out);
 	}
-	if (!r_str_casecmp (arg[0], "r4") && address_direct (arg[1], &src_addr)) {
-		singlearg_direct (0xac, arg[1], out);
-		return true;
+	if (!r_str_casecmp (arg[0], "r4") && is_direct (arg[1])) {
+		return singlearg_direct (0xac, arg[1], out);
 	}
-	if (!r_str_casecmp (arg[0], "r5") && address_direct (arg[1], &src_addr)) {
+	if (!r_str_casecmp (arg[0], "r5") && is_direct (arg[1])) {
 		singlearg_direct (0xad, arg[1], out);
 		return true;
 	}
-	if (!r_str_casecmp (arg[0], "r6") && address_direct (arg[1], &src_addr)) {
+	if (!r_str_casecmp (arg[0], "r6") && is_direct (arg[1])) {
 		singlearg_direct (0xae, arg[1], out);
 		return true;
 	}
-	if (!r_str_casecmp (arg[0], "r7") && address_direct (arg[1], &src_addr)) {
+	if (!r_str_casecmp (arg[0], "r7") && is_direct (arg[1])) {
 		singlearg_direct (0xaf, arg[1], out);
 		return true;
 	}
 	if (!r_str_casecmp (arg[0], "a")) {
-		if (address_direct (arg[1], &src_addr)) {
+		if (is_direct (arg[1])) {
 			return singlearg_direct (0xe5, arg[1], out);
 		}
 
@@ -1169,7 +1170,7 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (address_direct (arg[0], &src_addr)) {
+	if (is_direct (arg[0])) {
 		if (!r_str_casecmp (arg[1], "a")) {
 			return singlearg_direct (0xf5, arg[0], out);
 		}
@@ -1409,7 +1410,6 @@ static bool mnem_swap(char const*const*arg, ut16 pc, ut8**out) {
 }
 
 static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
-	ut8 dest_addr;
 	ut16 dest_hexadecimal;
 	if (parse_hexadecimal (arg[0], &dest_hexadecimal)) {
 		if (!r_str_casecmp (arg[1], "a")) {

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1019,11 +1019,11 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (address_direct (arg[0], &dst_addr)) {
-		if (parse_hexadecimal (arg[1], &src_addr)) {
+	if (parse_hexadecimal (arg[0], &dst_imm)) {
+		if (parse_hexadecimal (arg[1], &src_imm)) {
 			(*out)[0] = 0x85;
-			(*out)[1] = src_addr;
-			(*out)[2] = dst_addr;
+			(*out)[1] = src_imm;
+			(*out)[2] = dst_imm;
 			*out += 3;
 			return true;
 		}

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -995,79 +995,81 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			return singlearg_direct (0xa7, arg[1], out);
 		}
 	}
-	if (!r_str_casecmp (arg[0], "r0")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf8, out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xa8, arg[1], out);
-		} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x78, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r1")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x79, arg[1], out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xa9, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf9, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r2")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7a, arg[1], out);
-		} else if (is_direct(arg[1])) {
-			return singlearg_direct (0xaa, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfa, out);
-		}
-	}
 
-	if (!r_str_casecmp (arg[0], "r3")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7b, arg[1], out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xab, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfb, out);
-		}
-	}
-
-	if (!r_str_casecmp (arg[0], "r4")) {
-		if (resolve_immediate (arg[1]+1, &dst_imm)) {
-			return singlearg_direct (0x7c, arg[1]+1, out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xac, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfc, out);
-		}
-	}
-
-	if (!r_str_casecmp (arg[0], "r5")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7d, arg[1], out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xad, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfd, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r6")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7e, arg[1], out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xae, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfe, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r7")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7f, arg[1], out);
-		} else if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xff, out);
-		} else if (is_direct (arg[1])) {
-			return singlearg_direct (0xaf, arg[1], out);
+	if (arg[0][0] == 'r') {
+		switch (arg[0][1]) {
+		case '0':
+			if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xf8, out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xa8, arg[1], out);
+			} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x78, arg[1], out);
+			}
+			break;
+		case '1':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x79, arg[1], out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xa9, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xf9, out);
+			}
+			break;
+		case '2':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x7a, arg[1], out);
+			} else if (is_direct(arg[1])) {
+				return singlearg_direct (0xaa, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xfa, out);
+			}
+			break;
+		case '3':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x7b, arg[1], out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xab, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xfb, out);
+			}
+			break;
+		case '4':
+			if (resolve_immediate (arg[1]+1, &dst_imm)) {
+				return singlearg_direct (0x7c, arg[1]+1, out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xac, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xfc, out);
+			}
+			break;
+		case '5':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x7d, arg[1], out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xad, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xfd, out);
+			}
+			break;
+		case '6':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x7e, arg[1], out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xae, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xfe, out);
+			}
+			break;
+		case '7':
+			if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x7f, arg[1], out);
+			} else if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xff, out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xaf, arg[1], out);
+			}
+			break;
 		}
 	}
 
@@ -1097,36 +1099,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			return singlearg_direct (0x87, arg[0], out);
 		}
 
-		if (!r_str_casecmp (arg[1], "r0")) {
-			return singlearg_direct (0x88, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r1")) {
-			return singlearg_direct (0x89, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r2")) {
-			return singlearg_direct (0x8a, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r3")) {
-			return singlearg_direct (0x8b, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r4")) {
-			return singlearg_direct (0x8c, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r5")) {
-			return singlearg_direct (0x8d, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r6")) {
-			return singlearg_direct (0x8e, arg[0], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r7")) {
-			return singlearg_direct (0x8f, arg[0], out);
+		if (arg[1][0] == 'r') {
+			if (R_BETWEEN ('0', arg[1][1], '7')) {
+				return singlearg_direct (0x88 + arg[1][1]-'0', arg[0], out);
+			}
 		}
 	}
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -958,6 +958,7 @@ static bool mnem_mov_c(char const*const*arg, ut16 pc, ut8**out) {
 }
 
 static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
+	//TODO handle r1!!!
 	if (!r_str_casecmp (arg[0], "dptr")) {
 		ut16 imm;
 		if (!resolve_immediate (arg[1] + 1, &imm)) {
@@ -1040,6 +1041,31 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		*out += 3;
 		return true;
 	}
+
+	if (!r_str_casecmp (arg[0], "@r0")) {
+		ut16 imm;
+		if (!resolve_immediate (arg[1] + 1, &imm)) {
+			return false;
+		}
+		(*out)[0] = 0x76;
+		(*out)[1] = imm >> 8;
+		(*out)[2] = imm;
+		*out += 3;
+		return true;
+	}
+
+	if (!r_str_casecmp (arg[0], "@r1")) {
+		ut16 imm;
+		if (!resolve_immediate (arg[1] + 1, &imm)) {
+			return false;
+		}
+		(*out)[0] = 0x77;
+		(*out)[1] = imm >> 8;
+		(*out)[2] = imm;
+		*out += 3;
+		return true;
+	}
+
 	ut8 src_addr;
 	if (!address_direct (arg[1], &src_addr)) {
 		return false;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -449,7 +449,7 @@ static bool parse_register(char const* register_input, ut8* hex_out) {
   /*
   * attempts to parse the given string as an 8bit-wide address
   */
-static bool address_direct(char const* addr_str, ut8* addr_out) {
+static bool parse_address_direct(char const* addr_str, ut8* addr_out) {
 	ut16 addr_big;
 	ut8 addr_short;
 	// rasm2 resolves symbols, so does this really only need to parse hex?
@@ -500,7 +500,7 @@ static bool address_bit(char const* addr_str, ut8* addr_out) {
 
 	ut8 addr_bytepart = 0x00;
     if (!parse_register(bytepart, &addr_bytepart)) {
-		if (!address_direct (bytepart, &byte)) {
+		if (!parse_address_direct (bytepart, &byte)) {
 			ret = false;
 			goto end;
 		}
@@ -577,7 +577,7 @@ static bool singlearg_reladdr(ut8 const firstbyte, char const* arg
 static bool singlearg_direct(ut8 const firstbyte, char const* arg, ut8 **out) {
 	bool ret = true;
 	ut8 address = 0x00;
-	if (!address_direct (arg, &address)) {
+	if (!parse_address_direct (arg, &address)) {
 		return false;
 	}
 
@@ -693,7 +693,7 @@ static bool mnem_anl(char const*const*arg, ut16 pc, ut8**out) {
 	}
 
 	ut8 address;
-	if (!address_direct (arg[0], &address)) {
+	if (!parse_address_direct (arg[0], &address)) {
 		return false;
 	}
 	if (!r_str_casecmp (arg[1], "a")) {
@@ -729,7 +729,7 @@ static bool mnem_cjne(char const*const*arg, ut16 pc, ut8**out) {
 			return true;
 		}
 		ut8 address;
-		if (!address_direct (arg[1], &address)) {
+		if (!parse_address_direct (arg[1], &address)) {
 			return false;
 		}
 		(*out)[0] = 0xb5;
@@ -823,7 +823,7 @@ static bool mnem_djnz(char const*const*arg, ut16 pc, ut8**out) {
 		return true;
 	}
 	ut8 dec_address;
-	if (!address_direct (arg[0], &dec_address))  {
+	if (!parse_address_direct (arg[0], &dec_address))  {
 		return false;
 	}
 	(*out)[0] = 0xd5;
@@ -1302,7 +1302,7 @@ static bool mnem_orl(char const*const*arg, ut16 pc, ut8**out) {
 	}
 
 	ut8 dest_addr;
-	if (!address_direct (arg[0], &dest_addr)) {
+	if (!parse_address_direct (arg[0], &dest_addr)) {
 		return false;
 	}
 	ut16 imm;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -957,9 +957,148 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
 			return singlearg_immediate (0x74, arg[1], out);
 		}
+
+		if (is_direct (arg[1])) {
+			return singlearg_direct (0xe5, arg[1], out);
+		}
+
+		if (!r_str_casecmp (arg[1], "@r0") || !r_str_casecmp (arg[1], "[r0]")) {
+			return single_byte_instr (0xe6, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
+			return single_byte_instr (0xe7, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r0")) {
+			return single_byte_instr (0xe8, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r1")) {
+			return single_byte_instr (0xe9, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r2")) {
+			return single_byte_instr (0xea, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r3")) {
+			return single_byte_instr (0xeb, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r4")) {
+			return single_byte_instr (0xec, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r5")) {
+			return single_byte_instr (0xed, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r6")) {
+			return single_byte_instr (0xee, out);
+		}
+
+		if (!r_str_casecmp (arg[1], "r7")) {
+			return single_byte_instr (0xef, out);
+		}
 	}
-	if (parse_hexadecimal (arg[0], &dst_imm)) { //TODO: write doublearg_direct_register for 3 bytes instructions
+
+	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]"))) {
 		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x76, arg[1], out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xa6, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf6, out);
+		}
+	}
+	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]"))) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x77, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf7, out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xa7, arg[1], out);
+		}
+	}
+	if (!r_str_casecmp (arg[0], "r0")) {
+			if (!r_str_casecmp (arg[1], "a")) {
+				return single_byte_instr (0xf8, out);
+			} else if (is_direct (arg[1])) {
+				return singlearg_direct (0xa8, arg[1], out);
+			} else if (resolve_immediate (arg[1] + 1, &src_imm)) {
+				return singlearg_immediate (0x78, arg[1], out);
+		    }
+		}
+	if (!r_str_casecmp (arg[0], "r1")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x79, arg[1], out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xa9, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xf9, out);
+		}
+	}
+	if (!r_str_casecmp (arg[0], "r2")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x7a, arg[1], out);
+	    } else if (is_direct(arg[1])) {
+			return singlearg_direct (0xaa, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfa, out);
+		}
+	}
+
+	if (!r_str_casecmp (arg[0], "r3")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+		    return singlearg_immediate (0x7b, arg[1], out);
+	    } else if (is_direct (arg[1])) {
+    		return singlearg_direct (0xab, arg[1], out);
+	    } else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfb, out);
+		}
+	}
+
+	if (!r_str_casecmp (arg[0], "r4")) {
+		if (resolve_immediate (arg[1]+1, &dst_imm)) {
+			return singlearg_direct (0x7c, arg[1]+1, out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xac, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfc, out);
+		}
+	}
+
+	if (!r_str_casecmp (arg[0], "r5")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7d, arg[1], out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xad, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfd, out);
+		}
+	}
+	if (!r_str_casecmp (arg[0], "r6")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7e, arg[1], out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xae, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xfe, out);
+		}
+	}
+	if (!r_str_casecmp (arg[0], "r7")) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {
+			return singlearg_immediate (0x7f, arg[1], out);
+		} else if (!r_str_casecmp (arg[1], "a")) {
+			return single_byte_instr (0xff, out);
+		} else if (is_direct (arg[1])) {
+			return singlearg_direct (0xaf, arg[1], out);
+		}
+	}
+
+	if (parse_hexadecimal (arg[0], &dst_imm)) {
+		if (resolve_immediate (arg[1] + 1, &src_imm)) {//TODO: write doublearg_direct_register for 3 bytes instructions
 			//use : "arg[1][0] == '#'" ?
 			(*out)[0] = 0x75;
 			(*out)[1] = dst_imm;
@@ -967,59 +1106,7 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			*out += 3;
 			return true;
 		}
-	}
-	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]"))) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x76, arg[1], out);
-		}
-	}
-	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]"))) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x77, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r0")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x78, arg[1], out);
-	    }
-	}
-	if (!r_str_casecmp (arg[0], "r1")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x79, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r2")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x7a, arg[1], out);
-	    }
-	}
-	if (!r_str_casecmp (arg[0], "r3")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-		    return singlearg_immediate (0x7b, arg[1], out);
-	    }
-	}
-	if (!r_str_casecmp (arg[0], "r4")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7c, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r5")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7d, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r6")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7e, arg[1], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r7")) {
-		if (resolve_immediate (arg[1] + 1, &src_imm)) {
-			return singlearg_immediate (0x7f, arg[1], out);
-		}
-	}
 
-	if (parse_hexadecimal (arg[0], &dst_imm)) {
 		if (parse_hexadecimal (arg[1], &src_imm)) {
 			(*out)[0] = 0x85;
 			(*out)[1] = src_imm;
@@ -1088,140 +1175,10 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 			return singlearg_bit (0xa2, arg[1], out);
 		}
 	}
-	if ((!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) && is_direct (arg[1])) {
-		singlearg_direct (0xa6, arg[1], out);
-		return true;
-	}
-	if ((!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) && is_direct (arg[1])) {
-		singlearg_direct (0xa7, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r0") && is_direct (arg[1])) {
-		return singlearg_direct (0xa8, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r1") && is_direct (arg[1])) {
-		return singlearg_direct (0xa9, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r2") && is_direct(arg[1])) {
-		return singlearg_direct (0xaa, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r3") && is_direct (arg[1])) {
-		return singlearg_direct (0xab, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r4") && is_direct (arg[1])) {
-		return singlearg_direct (0xac, arg[1], out);
-	}
-	if (!r_str_casecmp (arg[0], "r5") && is_direct (arg[1])) {
-		singlearg_direct (0xad, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r6") && is_direct (arg[1])) {
-		singlearg_direct (0xae, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "r7") && is_direct (arg[1])) {
-		singlearg_direct (0xaf, arg[1], out);
-		return true;
-	}
-	if (!r_str_casecmp (arg[0], "a")) {
-		if (is_direct (arg[1])) {
-			return singlearg_direct (0xe5, arg[1], out);
-		}
-
-		if (!r_str_casecmp (arg[1], "@r0") || !r_str_casecmp (arg[1], "[r0]")) {
-			return single_byte_instr (0xe6, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
-			return single_byte_instr (0xe7, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r0")) {
-			return single_byte_instr (0xe8, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r1")) {
-			return single_byte_instr (0xe9, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r2")) {
-			return single_byte_instr (0xea, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r3")) {
-			return single_byte_instr (0xeb, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r4")) {
-			return single_byte_instr (0xec, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r5")) {
-			return single_byte_instr (0xed, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r6")) {
-			return single_byte_instr (0xee, out);
-		}
-
-		if (!r_str_casecmp (arg[1], "r7")) {
-			return single_byte_instr (0xef, out);
-		}
-	}
 
 	if (is_direct (arg[0])) {
 		if (!r_str_casecmp (arg[1], "a")) {
 			return singlearg_direct (0xf5, arg[0], out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "@r0") || !r_str_casecmp (arg[0], "[r0]")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf6, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "@r1") || !r_str_casecmp (arg[0], "[r1]")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf7, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r0")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf8, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r1")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xf9, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r2")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfa, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r3")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfb, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r4")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			single_byte_instr (0xfc, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r5")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfd, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r6")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xfe, out);
-		}
-	}
-	if (!r_str_casecmp (arg[0], "r7")) {
-		if (!r_str_casecmp (arg[1], "a")) {
-			return single_byte_instr (0xff, out);
 		}
 	}
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -552,7 +552,7 @@ static ut8 register_offset(const char *reg) {
 	}
 	if (!r_str_casecmp (reg, "@r1") || !r_str_casecmp (reg, "[r1]")) {
 		return 1;
-	} else {
+	}
 		return register_number (reg) + 2;
 	}
 }

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1279,29 +1279,8 @@ static bool mnem_xrl(char const*const*arg, ut16 pc, ut8**out) {
 		if (!r_str_casecmp (arg[1], "@r1") || !r_str_casecmp (arg[1], "[r1]")) {
 			return singlearg_register (0x67, arg[1], out);
 		}
-		if (!r_str_casecmp (arg[1], "r0")) {
-			return single_byte_instr (0x68, out);
-		}
-		if (!r_str_casecmp (arg[1], "r1")) {
-			return single_byte_instr (0x69, out);
-		}
-		if (!r_str_casecmp (arg[1], "r2")) {
-			return single_byte_instr (0x6a, out);
-		}
-		if (!r_str_casecmp (arg[1], "r3")) {
-			return single_byte_instr (0x6b, out);
-		}
-		if (!r_str_casecmp (arg[1], "r4")) {
-			return single_byte_instr (0x6c, out);
-		}
-		if (!r_str_casecmp (arg[1], "r5")) {
-			return single_byte_instr (0x6d, out);
-		}
-		if (!r_str_casecmp (arg[1], "r6")) {
-			return single_byte_instr (0x6e, out);
-		}
-		if (!r_str_casecmp (arg[1], "r7")) {
-			return single_byte_instr (0x6f, out);
+		if (R_BETWEEN ('0', arg[1][1], '7')) {
+			return single_byte_instr (0x68 + arg[1][1] - '0', out);
 		}
 	}
 	return true;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -340,8 +340,7 @@ static bool is_indirect_reg(char const*str)
 	return false;
 }
 
-static bool is_direct(char const*str)
-{
+static bool is_direct(char const*str) {
 	ut16 useless;
 	return parse_hexadecimal (str, &useless);
 }
@@ -349,8 +348,7 @@ static bool is_direct(char const*str)
 /**
  * returns true if the given string denotes an 'r'-register
  */
-static bool is_reg(char const*str)
-{
+static bool is_reg(char const *str) {
 	return str && tolower ((unsigned char)str[0]) == 'r' && r_str_ansi_nlen (str, 3) == 2
 		&& '0' <= str[1] && str[1] <= '7';
 }
@@ -879,8 +877,8 @@ static bool mnem_jbc(char const*const*arg, ut16 pc, ut8**out) {
 	to_address (arg[1], &jmp_addr);
 
 	if (!relative_address (pc + 1, jmp_addr, (*out) + 2)) {
-	    eprintf ("error during the assembly: address not found\n");
-    	return false;
+		eprintf ("error during the assembly: address not found\n");
+		return false;
 	}
 
 	(*out)[0] = 0x10;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -862,13 +862,8 @@ static bool mnem_jbc(char const*const*arg, ut16 pc, ut8**out) {
 	}
 
 	ut16 jmp_addr;
-	if (!to_address (arg[1], &jmp_addr)) {
+	if (!to_address (arg[1], &jmp_addr) && !relative_address (pc + 1, jmp_addr, (*out) + 2)) {
 		eprintf ("error during the assembly: address not found\n");
-		return false;
-	}
-
-	if (!relative_address (pc + 1, jmp_addr, (*out) + 2)) {
-		eprintf ("error during the assembly: not a relative address. It is not possible to assemble a single instruction with no context. Did you provide full code?\n");
 		return false;
 	}
 

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -1021,7 +1021,7 @@ static bool mnem_mov(char const*const*arg, ut16 pc, ut8**out) {
 		}
 	}
 
-	if (parse_hexadecimal (arg[0], &dst_imm)) {
+	if (address_direct (arg[0], &dst_imm)) {
 		if (parse_hexadecimal (arg[1], &src_imm)) {
 			(*out)[0] = 0x85;
 			(*out)[1] = src_imm;

--- a/libr/asm/arch/8051/8051_ass.c
+++ b/libr/asm/arch/8051/8051_ass.c
@@ -549,7 +549,8 @@ static int register_number(char const*reg) {
 static ut8 register_offset(const char *reg) {
 	if (!r_str_casecmp (reg, "@r0") || !r_str_casecmp (reg, "[r0]")) {
 		return 0;
-	} else if (!r_str_casecmp (reg, "@r1") || !r_str_casecmp (reg, "[r1]")) {
+	}
+	if (!r_str_casecmp (reg, "@r1") || !r_str_casecmp (reg, "[r1]")) {
 		return 1;
 	} else {
 		return register_number (reg) + 2;

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -164,11 +164,12 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 
 		// substitute direct addresses with register name
 		*olen = oplen;
-		if (disasm) {
+		/*if (disasm) {
 			disasm = _replace_register (disasm, arg1, val1);
 			disasm = _replace_register (disasm, arg2, val2);
 			return disasm;
-		}
+		}*/
+		return disasm;
 		return NULL;
 	}
 

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -6,60 +6,7 @@
 
 #include "8051_ops.h"
 
-static const char *_8051_regs[] = {
-	"r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", // 0x00
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x08
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x10
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x18
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x20
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x28
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x30
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x38
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x40
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x48
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x50
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x58
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x60
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x68
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x70
-	0, 0, 0, 0, 0, 0, 0, 0, // 0x78
-	"p0", "sp", "dpl", "dph", 0, 0, 0, "pcon", // 0x80
-	"tcon", "tmod", "tl0", "tl1", "th0", "th1", 0, 0, // 0x88
-	"p1", 0, 0, 0, 0, 0, 0, 0, // 0x90
-	"scon", "sbuf", 0, 0, 0, 0, 0, 0, // 0x98
-	"p2", 0, 0, 0, 0, 0, 0, 0, // 0xa0
-	"ie", 0, 0, 0, 0, 0, 0, 0, // 0xa8
-	"p3", 0, 0, 0, 0, 0, 0, 0, // 0xb0
-	"ip", 0, 0, 0, 0, 0, 0, 0, // 0xb8
-	0, 0, 0, 0, 0, 0, 0, 0, // 0xc0
-	0, 0, 0, 0, 0, 0, 0, 0, // 0xc8
-	"psw", 0, 0, 0, 0, 0, 0, 0, // 0xd0
-	0, 0, 0, 0, 0, 0, 0, 0, // 0xd8
-	"acc", 0, 0, 0, 0, 0, 0, 0, // 0xe0
-	0, 0, 0, 0, 0, 0, 0, 0, // 0xe8
-	"b", 0, 0, 0, 0, 0, 0, 0, // 0xf0
-	0, 0, 0, 0, 0, 0, 0, 0  // 0xf8
-};
 
-/*static char* _replace_register(char* disasm, ut8 arg, ut8 val) {//TODO point to bank address when necessary
-	char key[10];
-	char subst[10];
-	if (arg == A_DIRECT) {
-		if (_8051_regs[val]) {
-			sprintf (key, " 0x%02x", val);
-			sprintf (subst, " %s", _8051_regs[val]);
-			disasm = r_str_replace (disasm, key, subst, 0);
-		}
-	} else if (arg == A_BIT) {
-		val = arg_bit (val);
-		if (_8051_regs[val]) {
-			sprintf (key, "0x%02x.", val);
-			sprintf (subst, "%s.", _8051_regs[val]);
-			disasm = r_str_replace (disasm, key, subst, 0);
-		}
-	}
-	return disasm;
-}*/
 
 static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 	int i = 0;
@@ -75,7 +22,7 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 		ut8 arg2 = _8051_ops[i].arg2;
 		ut8 arg3 = _8051_ops[i].arg3;
 		ut8 oplen = _8051_ops[i].len;
-		ut8 val1 = 0, val2 = 0;
+
 		char* disasm = 0;
 
 		switch (oplen) {
@@ -100,19 +47,15 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 					} else {
 						disasm = r_str_newf (name, buf[0] & mask, buf[1]);
 					}
-					val2 = buf[1];
 				} else if ((arg2 == A_RI) || (arg2 == A_RN)) {
 					// op arg, @Ri; op arg, Rn
 					disasm = r_str_newf (name, buf[1], buf[0] & mask);
-					val1 = buf[1];
 				} else if (arg1 == A_BIT) {
 					// bit addressing mode
 					disasm = r_str_newf (name, arg_bit (buf[1]), buf[1] & 0x07);
-					val1 = buf[1];
 				} else {
 					// direct, immediate, bit
 					disasm = r_str_newf (name, buf[1]);
-					val1 = buf[1];
 				}
 			} else {
 				*olen = -1;
@@ -132,25 +75,19 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 					} else if (arg1 == A_BIT) {
 						// bit, offset
 						disasm = r_str_newf (name, arg_bit (buf[1]), buf[1] & 0x07, arg_offset (pc + 3, buf[2]));
-						val1 = buf[1];
 					} else {
 						// direct, offset; a, immediate, offset
 						disasm = r_str_newf (name, buf[1], arg_offset (pc + 3, buf[2]));
-						val1 = buf[1];
 					}
 				} else if (arg3 == A_OFFSET) {
 					// @Ri/Rn, direct, offset
 					disasm = r_str_newf (name, buf[0] & mask, buf[1], arg_offset (pc + 3, buf[2]));
-					val2 = buf[1];
 				} else if (arg1 == A_DIRECT && arg2 == A_DIRECT) {
 					// op direct, direct has src and dest swapped
 					disasm = r_str_newf (name, buf[2], buf[1]);
-					val1 = buf[2];
-					val2 = buf[1];
 				} else {
 					// direct, immediate
 					disasm = r_str_newf (name, buf[1], buf[2]);
-					val1 = buf[1];
 				}
 			} else {
 				*olen = -1;
@@ -164,11 +101,6 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 
 		// substitute direct addresses with register name
 		*olen = oplen;
-		/*if (disasm) {
-			disasm = _replace_register (disasm, arg1, val1);
-			disasm = _replace_register (disasm, arg2, val2);
-			return disasm;
-		}*/
 		return disasm;
 	}
 

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -41,7 +41,7 @@ static const char *_8051_regs[] = {
 	0, 0, 0, 0, 0, 0, 0, 0  // 0xf8
 };
 
-static char* _replace_register(char* disasm, ut8 arg, ut8 val) {
+static char* _replace_register(char* disasm, ut8 arg, ut8 val) {//TODO point to bank address when necessary
 	char key[10];
 	char subst[10];
 	if (arg == A_DIRECT) {
@@ -164,11 +164,11 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 
 		// substitute direct addresses with register name
 		*olen = oplen;
-		/*if (disasm) {
+		if (disasm) {
 			disasm = _replace_register (disasm, arg1, val1);
 			disasm = _replace_register (disasm, arg2, val2);
 			return disasm;
-		}*/
+		}
 		return disasm;
 		return NULL;
 	}

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -23,7 +23,7 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 		ut8 arg3 = _8051_ops[i].arg3;
 		ut8 oplen = _8051_ops[i].len;
 
-		char* disasm = 0;
+		char* disasm = NULL;
 
 		switch (oplen) {
 		case 1:

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -41,7 +41,7 @@ static const char *_8051_regs[] = {
 	0, 0, 0, 0, 0, 0, 0, 0  // 0xf8
 };
 
-static char* _replace_register(char* disasm, ut8 arg, ut8 val) {//TODO point to bank address when necessary
+/*static char* _replace_register(char* disasm, ut8 arg, ut8 val) {//TODO point to bank address when necessary
 	char key[10];
 	char subst[10];
 	if (arg == A_DIRECT) {
@@ -59,7 +59,7 @@ static char* _replace_register(char* disasm, ut8 arg, ut8 val) {//TODO point to 
 		}
 	}
 	return disasm;
-}
+}*/
 
 static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 	int i = 0;
@@ -164,11 +164,11 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 
 		// substitute direct addresses with register name
 		*olen = oplen;
-		if (disasm) {
+		/*if (disasm) {
 			disasm = _replace_register (disasm, arg1, val1);
 			disasm = _replace_register (disasm, arg2, val2);
 			return disasm;
-		}
+		}*/
 		return disasm;
 	}
 

--- a/libr/asm/arch/8051/8051_disas.c
+++ b/libr/asm/arch/8051/8051_disas.c
@@ -170,7 +170,6 @@ static char *r_8051_disas(ut64 pc, const ut8 *buf, int len, int *olen) {
 			return disasm;
 		}
 		return disasm;
-		return NULL;
 	}
 
 	// invalid op-code

--- a/libr/asm/arch/8051/8051_ops.h
+++ b/libr/asm/arch/8051/8051_ops.h
@@ -178,6 +178,7 @@ static _8051_op_t _8051_ops[] = {
 	{0xa2, 1, OP_MOV, T (MOV), "mov c, 0x%02x.%d", 2, M_NONE, A_BIT, 0, 0},
 	{0xa3, 2, OP_INC, T (ADD), "inc dptr", 1, M_NONE, 0, 0, 0},
 	{0xa4, 4, OP_MUL, T (MUL), "mul ab", 1, M_NONE, 0, 0, 0},
+	{0xa5, 1, OP_INVALID, T (UNK), "reserved", 1, M_NONE, 0, 0, 0},
 	{0xa6, 2, OP_MOV, T (MOV), "mov @r%d, 0x%02x", 2, M_RI, A_RI, A_DIRECT, 0},
 	{0xa8, 2, OP_MOV, T (MOV), "mov r%d, 0x%02x", 2, M_RN, A_RN, A_DIRECT, 0},
 	{0xb0, 2, OP_ANL, T (AND), "anl c, /0x%02x.%d", 2, M_NONE, A_BIT, 0, 0},


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This is a great refactoring and a great improvement. Not ready yet. I need to check any possible case. For example, it does not work for 'mov 0x0f, a' yet.

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
