### PR TITLE
Add r_search_maps to ##search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2453,45 +2453,6 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 	r_cons_break_pop ();
 }
 
-static void do_read_search(RSearch *s, struct search_parameters *param) {
-	RListIter *iter;
-	RIOMap *map;
-	ut64 prevto = UT64_MAX;
-	ut64 prevfrom = UT64_MAX;
-
-	// TODO: update pattern search to work with this
-	if (s->mode != R_SEARCH_PATTERN) {
-		r_search_set_read_cb (s, &_cb_hit_sz, param);
-	}
-
-	r_cons_break_push (NULL, NULL);
-	r_list_foreach_prev (param->boundaries, iter, map) {
-		if (r_cons_is_breaked ()) {
-			break;
-		}
-
-		ut64 from = r_io_map_begin (map);
-		ut64 to = r_io_map_end (map);
-
-		if (prevto == from) { // absorb new search area into previous
-			prevto = to;
-			continue;
-		}
-		if (prevto != UT64_MAX && prevfrom != UT64_MAX) {
-			// do last search
-			eprintf ("Searching in [0x%" PFMT64x "-0x%" PFMT64x "]\n", prevfrom, prevto);
-			r_search_update_read (s, prevfrom, prevto);
-		}
-		prevto = to;
-		prevfrom = from;
-	}
-	if (prevto != UT64_MAX && prevfrom != UT64_MAX) {
-		eprintf ("Searching in [0x%" PFMT64x "-0x%" PFMT64x "]\n", prevfrom, prevto);
-		r_search_update_read (s, prevfrom, prevto);
-	}
-	r_cons_break_pop ();
-}
-
 static void do_string_search(RCore *core, RInterval search_itv, struct search_parameters *param) {
 	ut64 at;
 	ut8 *buf;
@@ -4366,7 +4327,11 @@ again:
 	if (dosearch) {
 		do_string_search (core, search_itv, &param);
 	} else if (dosearch_read) {
-		do_read_search (search, &param);
+		// TODO: update pattern search to work with this
+		if (search->mode != R_SEARCH_PATTERN) {
+			r_search_set_read_cb (search, &_cb_hit_sz, &param);
+		}
+		r_search_maps (search, param.boundaries);
 	}
 beach:
 	core->num->value = search->nhits;

--- a/libr/include/r_search.h
+++ b/libr/include/r_search.h
@@ -103,6 +103,7 @@ R_API RList *r_search_find(RSearch *s, ut64 addr, const ut8 *buf, int len);
 R_API RList *r_search_find_uds(RSearch *search, ut64 addr, const ut8 *data, size_t size, bool verbose);
 R_API int r_search_update(RSearch *s, ut64 from, const ut8 *buf, long len);
 R_API int r_search_update_read(RSearch *s, ut64 from, ut64 to);
+R_API int r_search_maps(RSearch *s, RList /*<<RIOMap>>*/ *maps);
 
 R_API void r_search_keyword_free(RSearchKeyword *kw);
 R_API RSearchKeyword* r_search_keyword_new(const ut8 *kw, int kwlen, const ut8 *bm, int bmlen, const char *data);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

When two maps are next to each other, may as well search them in one go. This will make finding matches that live on the boarder between maps simpler.

**edit**
I went ahead and made this an API to search maps. That will ease the burden on the caller for setting up a search.