### PR TITLE
Fix heap overread in loongarch when len < 4 ##anal

### DIFF
--- a/libr/anal/p/anal_loongarch_gnu.c
+++ b/libr/anal/p/anal_loongarch_gnu.c
@@ -1209,7 +1209,7 @@ loongarch_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOp
 	struct loongarch_anal_opcode *it;
 	ut32 opcode, optype;
 	ut32 insn_id = 0;
-	if (!op) {
+	if (!op || (len < INSNLEN)) {
 		return INSNLEN;
 	}
 	op->type = R_ANAL_OP_TYPE_UNK;


### PR DESCRIPTION
Fixes the broken test referenced [here](https://github.com/radareorg/radare2/pull/19515#issuecomment-1000566119)