### PR TITLE
Fix fast jump with ahc on register calls ##visual

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3814,7 +3814,6 @@ static bool ds_print_core_vmode(RDisasmState *ds, int pos) {
 	case R_ANAL_OP_TYPE_RJMP:
 	case R_ANAL_OP_TYPE_RCALL:
 		if (ds->analop.jump != UT64_MAX && ds->analop.jump != UT32_MAX) {
-			ds->analop.jump = get_ptr_ble (ds, ds->analop.jump);
 			slen = ds_print_shortcut (ds, ds->analop.jump, pos);
 			gotShortcut = true;
 		}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This fixes what I think is a bug, but maybe I am not thinking about it properly?

For a `call sym.somewhere` you can use `ahc sym.other` to set the suggested location where the call actually lands. Then in visual modes you can get promps that will fast jump to the `sym.other` location.

When you have a `call rax` and you know `rax` is always holds `sym.other` you can *not* do `ahc sym.other` because `ds_print_core_vmode` will de-reference `sym.other`. So for `ahc` to work in this case, you must find a location that points to `sym.other`. In static analysis, such a location may not exist.

I feel like `ahc` means "use this jump location". I see the merit of de-referencing in some situations but I feel like a different command should be used.

So this pull "fixes" things but maybe something else should be done. Let me know if I can do something better and I will.