### PR TITLE
Add scr.theme and Lt commands as alias for 'eco' ##cons

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2382,6 +2382,19 @@ static bool cb_fps(void *user, void *data) {
 	return true;
 }
 
+static bool cb_scrtheme(void* user, void* data) {
+	RCore *core = (RCore*) user;
+	RConfigNode *node = (RConfigNode*) data;
+	if (*node->value) {
+		if (*node->value == '?') {
+			r_core_cmd0 (core, "eco");
+		} else {
+			r_core_cmdf (core, "eco %s", node->value);
+		}
+	}
+	return true;
+}
+
 static bool cb_scrbreakword(void* user, void* data) {
 	RConfigNode *node = (RConfigNode*) data;
 	if (*node->value) {
@@ -4023,6 +4036,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("scr.breaklines", "false", &cb_breaklines, "Break lines in Visual instead of truncating them");
 	SETCB ("scr.gadgets", "true", &cb_scr_gadgets, "Run pg in prompt, visual and panels");
 	SETBPREF ("scr.panelborder", "false", "Specify panels border active area (0 by default)");
+	SETCB ("scr.theme", "default", &cb_scrtheme, "Specify the theme name to load on startup (See 'ec?')");
 	SETICB ("scr.columns", 0, &cb_scrcolumns, "Force console column count (width)");
 	SETICB ("scr.optimize", 0, &cb_scroptimize, "Optimize the amount of ansi escapes and spaces (0, 1, 2 passes)");
 	SETBPREF ("scr.dumpcols", "false", "Prefer pC commands before p ones");

--- a/libr/core/cmd_log.c
+++ b/libr/core/cmd_log.c
@@ -13,16 +13,17 @@ static const char *help_msg_L[] = {
 	"L-", "duk", "unload core plugin by name",
 	"La", "", "list asm/anal plugins (aL, e asm.arch=" "??" ")",
 	"Lc", "", "list core plugins",
-	"Ld", "", "list debug plugins (same as dL)",
+	"Ld", "", "list debug plugins (dL)",
 	"LD", "", "list supported decompilers (e cmd.pdc=?)",
 	"Le", "", "list esil plugins",
 	"Lg", "", "list egg plugins",
-	"Lh", "", "list hash plugins (same as ph)",
-	"Li", "", "list bin plugins (same as iL)",
-	"Ll", "", "list lang plugins (same as #!)",
+	"Lh", "", "list hash plugins (ph)",
+	"Li", "", "list bin plugins (iL)",
+	"Lt", "", "list color themes (eco)",
+	"Ll", "", "list lang plugins (#!)",
 	"LL", "", "lock screen",
-	"Lm", "", "list fs plugins (same as mL)",
-	"Lo", "", "list io plugins (same as oL)",
+	"Lm", "", "list fs plugins (mL)",
+	"Lo", "", "list io plugins (oL)",
 	"Lp", "", "list parser plugins (e asm.parser=?)",
 	NULL
 };
@@ -328,6 +329,9 @@ static int cmd_plugins(void *data, const char *input) {
 		break;
 	case '?':
 		r_core_cmd_help (core, help_msg_L);
+		break;
+	case 't': // "Lt"
+		r_core_cmd0 (core, "eco");
 		break;
 	case 'm': // "Lm"
 		r_core_cmdf (core, "mL%s", input + 1);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
