### PR TITLE
Add support for rebasing ARM64E_USERLAND24 chained format ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -1488,6 +1488,7 @@ enum {
 	DYLD_CHAINED_PTR_64_OFFSET = 6,
 	DYLD_CHAINED_PTR_ARM64E_KERNEL = 7,
 	DYLD_CHAINED_PTR_64_KERNEL_CACHE = 8,
+	DYLD_CHAINED_PTR_ARM64E_USERLAND24 = 12,
 };
 
 struct dyld_chained_ptr_arm64e_rebase {
@@ -1559,6 +1560,26 @@ struct dyld_chained_ptr_64_bind {
 		reserved : 19,
 		next : 12,
 		bind : 1; // == 1
+};
+
+struct dyld_chained_ptr_arm64e_bind24 {
+	uint64_t ordinal : 24,
+		zero : 8,
+		addend : 19,
+		next : 11,
+		bind : 1, // == 1
+		auth : 1; // == 0
+};
+
+struct dyld_chained_ptr_arm64e_auth_bind24 {
+	uint64_t ordinal : 24,
+		zero : 8,
+		diversity : 16,
+		addrDiv : 1,
+		key : 2,
+		next : 11,
+		bind : 1, // == 1
+		auth : 1; // == 1
 };
 
 #endif

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -130,3 +130,15 @@ EXPECT=<<EOF
 0x100000c47 method 5 c    callMeNot
 EOF
 RUN
+
+NAME=macOS arm64e with DYLD_CHAINED_PTR_ARM64E_USERLAND24
+FILE=bins/mach0/TestMacOS-arm64e
+CMDS=<<EOF
+ic AppDelegate~:1..
+EOF
+EXPECT=<<EOF
+0x100003238 method AppDelegate      applicationDidFinishLaunching:
+0x100003288 method AppDelegate      applicationWillTerminate:
+0x1000032d8 method AppDelegate      applicationSupportsSecureRestorableState:
+EOF
+RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Add support for Mach-O DYLD_CHAINED_PTR_ARM64E_USERLAND24 pointer format for the purpose of rebasing only (for now).

This is the default format when compiling arm64e binaries on macOS on M1.

The added test depends on https://github.com/radareorg/radare2-testbins/pull/70
