### PR TITLE
Rewrite r_list_uniq with a faster algorithm ##core

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1607,7 +1607,6 @@ R_API int r_anal_function_del(RAnal *a, ut64 addr) {
 	RAnalFunction *fcn;
 	RListIter *iter, *iter_tmp;
 	r_list_foreach_safe (a->fcns, iter, iter_tmp, fcn) {
-		D eprintf ("fcn at %"PFMT64x" %"PFMT64x"\n", fcn->addr, addr);
 		if (fcn->addr == addr) {
 			r_anal_function_delete (fcn);
 		}

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -80,8 +80,8 @@ R_API void r_anal_save_parsed_type(RAnal *anal, const char *parsed) {
 	sdb_query_lines (anal->sdb_types, parsed);
 }
 
-static int typecmp(const void *a, const void *b) {
-	return strcmp (a, b);
+static ut64 typecmp_val(const void *a) {
+	return r_str_hash64 (a);
 }
 
 R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn) {
@@ -92,9 +92,8 @@ R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn) {
 	r_list_foreach (list, iter, var) {
 		r_list_append (type_used, var->type);
 	}
-	RList *uniq = r_list_uniq (type_used, typecmp);
-	r_list_free (type_used);
-	return uniq;
+	r_list_uniq_inplace (type_used, typecmp_val);
+	return type_used;
 }
 
 R_IPI void enum_type_case_free(void *e, void *user) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1272,8 +1272,8 @@ R_API bool r_core_pdb_info(RCore *core, const char *file, PJ *pj, int mode) {
 	return true;
 }
 
-static int srclineCmp(const void *a, const void *b) {
-	return r_str_cmp (a, b, -1);
+static ut64 srclineVal(const void *a) {
+	return r_str_hash64 (a);
 }
 
 static int bin_source(RCore *r, PJ *pj, int mode) {
@@ -1306,11 +1306,10 @@ static int bin_source(RCore *r, PJ *pj, int mode) {
 		r_list_free (list);
 	}
 	r_cons_printf ("[Source file]\n");
-	RList *uniqlist = r_list_uniq (final_list, srclineCmp);
-	r_list_foreach (uniqlist, iter2, srcline) {
+	r_list_uniq_inplace (final_list, srclineVal);
+	r_list_foreach (final_list, iter2, srcline) {
 		r_cons_printf ("%s\n", srcline);
 	}
-	r_list_free (uniqlist);
 	r_list_free (final_list);
 	return true;
 }

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2249,6 +2249,12 @@ static void ds_show_comments_right(RDisasmState *ds) {
 	ds->show_comment_right = scr;
 }
 
+static ut64 flagVal(const void *a) {
+	const RFlagItem *fa = a;
+	return r_str_hash64 (fa->realname? fa->realname: fa->name);
+}
+
+#if 0
 static int flagCmp(const void *a, const void *b) {
 	const RFlagItem *fa = a;
 	const RFlagItem *fb = b;
@@ -2257,6 +2263,7 @@ static int flagCmp(const void *a, const void *b) {
 	}
 	return strcmp (fa->name, fb->name);
 }
+#endif
 
 static void __preline_flag(RDisasmState *ds, RFlagItem *flag) {
 	ds_newline (ds);
@@ -2299,13 +2306,14 @@ static bool is_first(const char *fs) {
 	}
 	return false;
 }
+
 static RList *custom_sorted_flags(const RList *flaglist) {
 	RListIter *iter;
 	RFlagItem *flag;
 	if (!flaglist) {
 		return NULL;
 	}
-	RList *list = r_list_uniq (flaglist, flagCmp);
+	RList *list = r_list_uniq (flaglist, flagVal);
 	RList *res = r_list_newf (NULL);
 	RList *rest = r_list_newf (NULL);
 	RList *tail = r_list_newf (NULL);

--- a/libr/include/r_list.h
+++ b/libr/include/r_list.h
@@ -32,6 +32,7 @@ typedef struct r_list_range_t {
 
 // RListComparator should return -1, 0, 1 to indicate "a<b", "a==b", "a>b".
 typedef int (*RListComparator)(const void *a, const void *b);
+typedef ut64 (*RListComparatorItem)(const void *a);
 
 #define ROFList_Parent RList
 typedef struct r_oflist_t {
@@ -87,7 +88,8 @@ R_API RListIter *r_list_add_sorted(RList *list, void *data, RListComparator cmp)
 R_API void r_list_sort(RList *list, RListComparator cmp);
 R_API void r_list_merge_sort(RList *list, RListComparator cmp);
 R_API void r_list_insertion_sort(RList *list, RListComparator cmp);
-R_API RList *r_list_uniq(const RList *list, RListComparator cmp);
+R_API RList *r_list_uniq(const RList *list, RListComparatorItem cmp);
+R_API int r_list_uniq_inplace(RList *list, RListComparatorItem cmp);
 R_API void r_list_init(RList *list);
 R_API void r_list_delete(RList *list, RListIter *iter);
 R_API bool r_list_delete_data(RList *list, void *ptr);

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -5,12 +5,12 @@
 #define _FILE_OFFSET_BITS 64
 
 // defines like IS_DIGIT, etc'
+#include <r_types_base.h>
 #include "r_util/r_str_util.h"
 #include <r_userconf.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <assert.h>
-
 #include <stdint.h> // required for uint64_t
 #include <inttypes.h> // required for PRIx64
 
@@ -243,8 +243,6 @@
 #else
 #define R_PRINTF_CHECK(fmt, dots)
 #endif
-
-#include <r_types_base.h>
 
 #undef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64

--- a/libr/util/list.c
+++ b/libr/util/list.c
@@ -1,10 +1,11 @@
-/* radare - LGPL - Copyright 2007-2021 - pancake, alvarofe */
+/* radare - LGPL - Copyright 2007-2022 - pancake, alvarofe */
 // TODO: RRef - reference counting
 
 #include <stdio.h>
 
 #define _R_LIST_C_
 #include "r_util.h"
+#include <set.h>
 
 #define MERGE_LIMIT 24
 
@@ -629,29 +630,45 @@ R_API void r_list_sort(RList *list, RListComparator cmp) {
 	}
 }
 
-R_API RList *r_list_uniq(const RList *list, RListComparator cmp) {
+R_API RList *r_list_uniq(const RList *list, RListComparatorItem cmp) {
 	RListIter *iter, *iter2;
-	void *item, *item2;
+	void *item;
+	int deleted = 0;
 
-	r_return_val_if_fail (list && cmp, NULL);
-
-	RList *nl = r_list_newf (NULL);
-	if (!nl) {
-		return NULL;
-	}
-	r_list_foreach (list, iter, item) {
-		bool found = false;
-		r_list_foreach (nl, iter2, item2) {
-			if (cmp (item, item2) == 0) {
-				found = true;
-				break;
-			}
-		}
-		if (!found) {
-			r_list_append (nl, item);
+	r_return_val_if_fail (list && cmp, 0);
+	RList *rlist = r_list_newf (list->free);
+	SetU *s = set_u_new ();
+	r_list_foreach_safe (list, iter, iter2, item) {
+		ut64 v = cmp (item);
+		if (set_u_contains (s, v)) {
+			deleted ++;
+		} else {
+			set_u_add (s, v);
+			r_list_append (rlist, item);
 		}
 	}
-	return nl;
+	set_u_free (s);
+	return rlist;
+}
+
+R_API int r_list_uniq_inplace(RList *list, RListComparatorItem cmp) {
+	RListIter *iter, *iter2;
+	void *item;
+	int deleted = 0;
+
+	r_return_val_if_fail (list && cmp, 0);
+	SetU *s = set_u_new ();
+	r_list_foreach_safe (list, iter, iter2, item) {
+		ut64 v = cmp (item);
+		if (set_u_contains (s, v)) {
+			r_list_delete (list, iter);
+			deleted ++;
+		} else {
+			set_u_add (s, v);
+		}
+	}
+	set_u_free (s);
+	return deleted;
 }
 R_API char *r_list_to_str(RList *list, char ch) {
 	RListIter *iter;

--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -289,6 +289,12 @@ R_API char *r_syscmd_ls(const char *input, int cons_width) {
 	return res;
 }
 
+static ut64 valstr(const void *_a) {
+	const char *a = _a;
+	return r_str_hash64 (a);
+}
+
+
 static int cmpstr(const void *_a, const void *_b) {
 	const char *a = _a, *b = _b;
 	return (int)strcmp (a, b);
@@ -390,7 +396,7 @@ R_API char *r_syscmd_uniq(const char *file) {
 			eprintf ("No such file or directory\n");
 		} else {
 			list = r_str_split_list (data, "\n", 0);
-			RList *uniq_list = r_list_uniq (list, cmpstr);
+			RList *uniq_list = r_list_uniq (list, valstr);
 			data = r_list_to_str (uniq_list, '\n');
 			r_list_free (uniq_list);
 			r_list_free (list);


### PR DESCRIPTION
* Adds _inplace() variant to avoid creating a new list
* Speedups aafs, aflm, pd, aflt and aflj

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
