### PR TITLE
Parse relocs from Mach-O chained binds if no opcodes ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3233,6 +3233,9 @@ static bool walk_bind_chains_callback(void * context, RFixupEventDetails * event
 				addend += item->addend;
 				break;
 			}
+			default:
+				bprintf ("Unsupported imports format\n");
+				return false;
 		}
 
 		ut64 symbols_offset = bin->fixups_header.symbols_offset + fixups_offset;
@@ -4577,9 +4580,9 @@ void MACH0_(iterate_chained_fixups)(struct MACH0_(obj_t) *bin, ut64 limit_start,
 					ut64 delta, stride, addend;
 					ut16 pointer_format = bin->chained_starts[i]->pointer_format;
 					RFixupEvent event = R_FIXUP_EVENT_NONE;
-					ut8 key, addr_div;
-					ut16 diversity;
-					ut32 ordinal;
+					ut8 key = 0, addr_div = 0;
+					ut16 diversity = 0;
+					ut32 ordinal = UT32_MAX;
 					if (pointer_format == DYLD_CHAINED_PTR_ARM64E) {
 						stride = 8;
 						bool is_auth = IS_PTR_AUTH (raw_ptr);

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -10,6 +10,9 @@
 #define bprintf if (bin->verbose) eprintf
 #define Eprintf if (mo->verbose) eprintf
 
+#define IS_PTR_AUTH(x) ((x & (1ULL << 63)) != 0)
+#define IS_PTR_BIND(x) ((x & (1ULL << 62)) != 0)
+
 typedef struct {
 	struct symbol_t *symbols;
 	int j;
@@ -25,6 +28,11 @@ typedef struct {
 	int i;
 	ut8 *next_child;
 } RTrieState;
+
+typedef struct {
+	ut8 * imports;
+	RSkipList *relocs;
+} RWalkBindChainsContext;
 
 // OMG; THIS SHOULD BE KILLED; this var exposes the local native endian, which is completely unnecessary
 // USE THIS: int ws = bf->o->info->big_endian;
@@ -1510,6 +1518,9 @@ static bool parse_chained_fixups(struct MACH0_(obj_t) *bin, ut32 offset, ut32 si
 	if (!bin->chained_starts) {
 		return false;
 	}
+	bin->fixups_header = header;
+	bin->fixups_offset = offset;
+	bin->fixups_size = size;
 	size_t i;
 	ut64 cursor = starts_at + sizeof (ut32);
 	for (i = 0; i < segs_count; i++) {
@@ -3187,6 +3198,144 @@ static void parse_relocation_info(struct MACH0_(obj_t) *bin, RSkipList *relocs, 
 	free (info);
 }
 
+static bool walk_bind_chains_callback(void * context, RFixupEventDetails * event_details) {
+	r_return_val_if_fail (event_details->type == R_FIXUP_EVENT_BIND || event_details->type == R_FIXUP_EVENT_BIND_AUTH, false);
+	RWalkBindChainsContext *ctx = context;
+	ut8 *imports = ctx->imports;
+	struct MACH0_(obj_t) *bin = event_details->bin;
+	ut32 imports_count = bin->fixups_header.imports_count;
+	ut32 fixups_offset = bin->fixups_offset;
+	ut32 fixups_size = bin->fixups_size;
+	ut32 imports_format = bin->fixups_header.imports_format;
+	ut32 import_index = ((RFixupBindEventDetails *) event_details)->ordinal;
+	ut64 addend = 0;
+	if (event_details->type != R_FIXUP_EVENT_BIND_AUTH) {
+		addend = ((RFixupBindEventDetails *) event_details)->addend;
+	}
+
+	if (import_index < imports_count) {
+		ut64 name_offset;
+		switch (imports_format) {
+			case DYLD_CHAINED_IMPORT: {
+				struct dyld_chained_import * item = &((struct dyld_chained_import *) imports)[import_index];
+				name_offset = item->name_offset;
+				break;
+			}
+			case DYLD_CHAINED_IMPORT_ADDEND: {
+				struct dyld_chained_import_addend * item = &((struct dyld_chained_import_addend *) imports)[import_index];
+				name_offset = item->name_offset;
+				addend += item->addend;
+				break;
+			}
+			case DYLD_CHAINED_IMPORT_ADDEND64: {
+				struct dyld_chained_import_addend64 * item = &((struct dyld_chained_import_addend64 *) imports)[import_index];
+				name_offset = item->name_offset;
+				addend += item->addend;
+				break;
+			}
+		}
+
+		ut64 symbols_offset = bin->fixups_header.symbols_offset + fixups_offset;
+
+		if (symbols_offset + name_offset + 1 < fixups_offset + fixups_size) {
+			char *name = r_buf_get_string (bin->b, symbols_offset + name_offset);
+			if (name) {
+				struct reloc_t *reloc = R_NEW0 (struct reloc_t);
+				if (!reloc) {
+					free (name);
+					return false;
+				}
+				reloc->addr = offset_to_vaddr (bin, event_details->offset);
+				reloc->offset = event_details->offset;
+				reloc->ord = import_index;
+				reloc->type = R_BIN_RELOC_64;
+				reloc->size = 8;
+				reloc->addend = addend;
+				r_str_ncpy (reloc->name, name, sizeof (reloc->name) - 1);
+				r_skiplist_insert (ctx->relocs, reloc);
+				free (name);
+			} else if (bin->verbose) {
+				eprintf ("Malformed chained bind: failed to read name\n");
+			}
+		} else if (bin->verbose) {
+			eprintf ("Malformed chained bind: name_offset out of bounds\n");
+		}
+	} else if (bin->verbose) {
+		eprintf ("Malformed chained bind: import out of length\n");
+	}
+
+	return true;
+}
+
+static void walk_bind_chains(struct MACH0_(obj_t) *bin, RSkipList *relocs) {
+	r_return_if_fail (bin && bin->fixups_offset);
+
+	ut8 *imports = NULL;
+
+	ut32 imports_count = bin->fixups_header.imports_count;
+	ut32 fixups_offset = bin->fixups_offset;
+	ut32 imports_offset = bin->fixups_header.imports_offset;
+	if (!imports_count || !imports_offset) {
+		return;
+	}
+	if (bin->fixups_header.symbols_format != 0) {
+		eprintf ("Compressed fixups symbols not supported yet, please file a bug with a sample attached.\n");
+		return;
+	}
+
+	ut32 imports_format = bin->fixups_header.imports_format;
+	ut64 imports_size;
+	switch (imports_format) {
+		case DYLD_CHAINED_IMPORT:
+			imports_size = sizeof (struct dyld_chained_import) * imports_count;
+			break;
+		case DYLD_CHAINED_IMPORT_ADDEND:
+			imports_size = sizeof (struct dyld_chained_import_addend) * imports_count;
+			break;
+		case DYLD_CHAINED_IMPORT_ADDEND64:
+			imports_size = sizeof (struct dyld_chained_import_addend64) * imports_count;
+			break;
+		default:
+			eprintf ("Unsupported chained imports format: %d\n", imports_format);
+			goto beach;
+	}
+
+	imports = malloc (imports_size);
+	if (!imports) {
+		goto beach;
+	}
+
+	switch (imports_format) {
+		case DYLD_CHAINED_IMPORT:
+			if (r_buf_fread_at (bin->b, fixups_offset + imports_offset,
+					imports, "i", imports_count) != imports_size) {
+				goto beach;
+			}
+			break;
+		case DYLD_CHAINED_IMPORT_ADDEND:
+			if (r_buf_fread_at (bin->b, fixups_offset + imports_offset,
+					imports, "ii", imports_count) != imports_size) {
+				goto beach;
+			}
+			break;
+		case DYLD_CHAINED_IMPORT_ADDEND64:
+			if (r_buf_fread_at (bin->b, fixups_offset + imports_offset,
+					imports, "il", imports_count) != imports_size) {
+				goto beach;
+			}
+			break;
+	}
+
+	RWalkBindChainsContext ctx;
+	ctx.imports = imports;
+	ctx.relocs = relocs;
+
+	MACH0_(iterate_chained_fixups) (bin, 0, UT64_MAX, R_FIXUP_EVENT_MASK_BIND_ALL, &walk_bind_chains_callback, &ctx);
+
+beach:
+	free (imports);
+}
+
 static bool is_valid_ordinal_table_size(ut64 size) {
 	return size > 0 && size <= UT16_MAX;
 }
@@ -3536,7 +3685,7 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 		if (!relocs) {
 			relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
 			if (!relocs) {
-				return NULL;
+				goto beach;
 			}
 		}
 		for (j = 0; j < amount; j++) {
@@ -3557,10 +3706,20 @@ RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin) {
 		if (!relocs) {
 			relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
 			if (!relocs) {
-				return NULL;
+				goto beach;
 			}
 		}
 		parse_relocation_info (bin, relocs, bin->dysymtab.extreloff, bin->dysymtab.nextrel);
+	}
+
+	if (!bin->dyld_info && bin->chained_starts && bin->nsegs && bin->fixups_offset) {
+		if (!relocs) {
+			relocs = r_skiplist_new ((RListFree) &free, (RListComparator) &reloc_comparator);
+			if (!relocs) {
+				goto beach;
+			}
+		}
+		walk_bind_chains (bin, relocs);
 	}
 beach:
 	r_pvector_free (threaded_binds);
@@ -4378,4 +4537,214 @@ struct MACH0_(mach_header) *MACH0_(get_hdr)(RBuffer *buf) {
 	macho_hdr->reserved = r_read_ble (&machohdrbytes[28], big_endian, 32);
 #endif
 	return macho_hdr;
+}
+
+void MACH0_(iterate_chained_fixups)(struct MACH0_(obj_t) *bin, ut64 limit_start, ut64 limit_end, ut32 event_mask, RFixupCallback callback, void * context) {
+	int i = 0;
+	for (; i < bin->nsegs; i++) {
+		if (!bin->chained_starts[i]) {
+			continue;
+		}
+		int page_size = bin->chained_starts[i]->page_size;
+		if (page_size < 1) {
+			page_size = 4096;
+		}
+		ut64 start = bin->segs[i].fileoff;
+		ut64 end = start + bin->segs[i].filesize;
+		if (end >= limit_start && start <= limit_end) {
+			ut64 page_idx = (R_MAX (start, limit_start) - start) / page_size;
+			ut64 page_end_idx = (R_MIN (limit_end, end) - start) / page_size;
+			for (; page_idx <= page_end_idx; page_idx++) {
+				if (page_idx >= bin->chained_starts[i]->page_count) {
+					break;
+				}
+				ut16 page_start = bin->chained_starts[i]->page_start[page_idx];
+				if (page_start == DYLD_CHAINED_PTR_START_NONE) {
+					continue;
+				}
+				ut64 cursor = start + page_idx * page_size + page_start;
+				while (cursor < limit_end && cursor < end) {
+					ut8 tmp[8];
+					bool previous_rebasing = bin->rebasing_buffer;
+					bin->rebasing_buffer = true;
+					if (r_buf_read_at (bin->b, cursor, tmp, 8) != 8) {
+						bin->rebasing_buffer = previous_rebasing;
+						break;
+					}
+					bin->rebasing_buffer = previous_rebasing;
+					ut64 raw_ptr = r_read_le64 (tmp);
+					ut64 ptr_value = raw_ptr;
+					ut64 delta, stride, addend;
+					ut16 pointer_format = bin->chained_starts[i]->pointer_format;
+					RFixupEvent event = R_FIXUP_EVENT_NONE;
+					ut8 key, addr_div;
+					ut16 diversity;
+					ut32 ordinal;
+					if (pointer_format == DYLD_CHAINED_PTR_ARM64E) {
+						stride = 8;
+						bool is_auth = IS_PTR_AUTH (raw_ptr);
+						bool is_bind = IS_PTR_BIND (raw_ptr);
+						if (is_auth && is_bind) {
+							struct dyld_chained_ptr_arm64e_auth_bind *p =
+									(struct dyld_chained_ptr_arm64e_auth_bind *) &raw_ptr;
+							event = R_FIXUP_EVENT_BIND_AUTH;
+							delta = p->next;
+							ordinal = p->ordinal;
+							key = p->key;
+							addr_div = p->addrDiv;
+							diversity = p->diversity;
+						} else if (!is_auth && is_bind) {
+							struct dyld_chained_ptr_arm64e_bind *p =
+									(struct dyld_chained_ptr_arm64e_bind *) &raw_ptr;
+							event = R_FIXUP_EVENT_BIND;
+							delta = p->next;
+							ordinal = p->ordinal;
+							addend = p->addend;
+						} else if (is_auth && !is_bind) {
+							struct dyld_chained_ptr_arm64e_auth_rebase *p =
+									(struct dyld_chained_ptr_arm64e_auth_rebase *) &raw_ptr;
+							event = R_FIXUP_EVENT_REBASE_AUTH;
+							delta = p->next;
+							ptr_value = p->target + bin->baddr;
+							key = p->key;
+							addr_div = p->addrDiv;
+							diversity = p->diversity;
+						} else {
+							struct dyld_chained_ptr_arm64e_rebase *p =
+									(struct dyld_chained_ptr_arm64e_rebase *) &raw_ptr;
+							event = R_FIXUP_EVENT_REBASE;
+							delta = p->next;
+							ptr_value = ((ut64)p->high8 << 56) | p->target;
+						}
+					} else if (pointer_format == DYLD_CHAINED_PTR_ARM64E_USERLAND24) {
+						stride = 8;
+						struct dyld_chained_ptr_arm64e_bind24 *bind =
+								(struct dyld_chained_ptr_arm64e_bind24 *) &raw_ptr;
+						if (bind->bind) {
+							delta = bind->next;
+							if (bind->auth) {
+								struct dyld_chained_ptr_arm64e_auth_bind24 *p =
+										(struct dyld_chained_ptr_arm64e_auth_bind24 *) &raw_ptr;
+								event = R_FIXUP_EVENT_BIND_AUTH;
+								ordinal = p->ordinal;
+								key = p->key;
+								addr_div = p->addrDiv;
+								diversity = p->diversity;
+							} else {
+								event = R_FIXUP_EVENT_BIND;
+								ordinal = bind->ordinal;
+								addend = bind->addend;
+							}
+						} else {
+							if (bind->auth) {
+								struct dyld_chained_ptr_arm64e_auth_rebase *p =
+										(struct dyld_chained_ptr_arm64e_auth_rebase *) &raw_ptr;
+								event = R_FIXUP_EVENT_REBASE_AUTH;
+								delta = p->next;
+								ptr_value = p->target + bin->baddr;
+								key = p->key;
+								addr_div = p->addrDiv;
+								diversity = p->diversity;
+							} else {
+								struct dyld_chained_ptr_arm64e_rebase *p =
+									(struct dyld_chained_ptr_arm64e_rebase *) &raw_ptr;
+								event = R_FIXUP_EVENT_REBASE;
+								delta = p->next;
+								ptr_value = bin->baddr + (((ut64)p->high8 << 56) | p->target);
+							}
+						}
+					} else if (pointer_format == DYLD_CHAINED_PTR_64_OFFSET) {
+						stride = 4;
+						struct dyld_chained_ptr_64_bind *bind =
+								(struct dyld_chained_ptr_64_bind *) &raw_ptr;
+						if (bind->bind) {
+							event = R_FIXUP_EVENT_BIND;
+							delta = bind->next;
+							ordinal = bind->ordinal;
+							addend = bind->addend;
+						} else {
+							struct dyld_chained_ptr_64_rebase *p =
+								(struct dyld_chained_ptr_64_rebase *) &raw_ptr;
+							event = R_FIXUP_EVENT_REBASE;
+							delta = p->next;
+							ptr_value = bin->baddr + (((ut64)p->high8 << 56) | p->target);
+						}
+					} else {
+						eprintf ("Unsupported chained pointer format %d\n", pointer_format);
+						return;
+					}
+					if (cursor >= limit_start && cursor <= limit_end - 8 && (event & event_mask) != 0) {
+						bool carry_on;
+						switch (event) {
+							case R_FIXUP_EVENT_BIND: {
+								RFixupBindEventDetails event_details;
+
+								event_details.type = event;
+								event_details.bin = bin;
+								event_details.offset = cursor;
+								event_details.raw_ptr = raw_ptr;
+								event_details.ordinal = ordinal;
+								event_details.addend = addend;
+
+								carry_on = callback (context, (RFixupEventDetails *) &event_details);
+								break;
+							}
+							case R_FIXUP_EVENT_BIND_AUTH: {
+								RFixupBindAuthEventDetails event_details;
+
+								event_details.type = event;
+								event_details.bin = bin;
+								event_details.offset = cursor;
+								event_details.raw_ptr = raw_ptr;
+								event_details.ordinal = ordinal;
+								event_details.key = key;
+								event_details.addr_div = addr_div;
+								event_details.diversity = diversity;
+
+								carry_on = callback (context, (RFixupEventDetails *) &event_details);
+								break;
+							}
+							case R_FIXUP_EVENT_REBASE: {
+								RFixupRebaseEventDetails event_details;
+
+								event_details.type = event;
+								event_details.bin = bin;
+								event_details.offset = cursor;
+								event_details.raw_ptr = raw_ptr;
+								event_details.ptr_value = ptr_value;
+
+								carry_on = callback (context, (RFixupEventDetails *) &event_details);
+								break;
+							}
+							case R_FIXUP_EVENT_REBASE_AUTH: {
+								RFixupRebaseAuthEventDetails event_details;
+
+								event_details.type = event;
+								event_details.bin = bin;
+								event_details.offset = cursor;
+								event_details.raw_ptr = raw_ptr;
+								event_details.ptr_value = ptr_value;
+								event_details.key = key;
+								event_details.addr_div = addr_div;
+								event_details.diversity = diversity;
+
+								carry_on = callback (context, (RFixupEventDetails *) &event_details);
+								break;
+							}
+							default:
+								eprintf ("Unexpected event while iterating chained fixups\n");
+								carry_on = false;
+						}
+						if (!carry_on) {
+							return;
+						}
+					}
+					cursor += delta * stride;
+					if (!delta) {
+						break;
+					}
+				}
+			}
+		}
+	}
 }

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -36,6 +36,18 @@
 #define CSSLOT_ENTITLEMENTS  5
 #define CSSLOT_CMS_SIGNATURE 0x10000
 
+typedef enum {
+	R_FIXUP_EVENT_NONE = 0,
+	R_FIXUP_EVENT_REBASE = 1,
+	R_FIXUP_EVENT_REBASE_AUTH = 2,
+	R_FIXUP_EVENT_BIND = 4,
+	R_FIXUP_EVENT_BIND_AUTH = 8,
+} RFixupEvent;
+
+#define R_FIXUP_EVENT_MASK_BIND_ALL (R_FIXUP_EVENT_BIND | R_FIXUP_EVENT_BIND_AUTH)
+#define R_FIXUP_EVENT_MASK_REBASE_ALL (R_FIXUP_EVENT_REBASE | R_FIXUP_EVENT_REBASE_AUTH)
+#define R_FIXUP_EVENT_MASK_ALL (R_FIXUP_EVENT_MASK_BIND_ALL | R_FIXUP_EVENT_MASK_REBASE_ALL)
+
 struct section_t {
 	ut64 offset;
 	ut64 addr;
@@ -119,6 +131,9 @@ struct MACH0_(obj_t) {
 	char *compiler;
 	int nsegs;
 	struct r_dyld_chained_starts_in_segment **chained_starts;
+	struct dyld_chained_fixups_header fixups_header;
+	ut64 fixups_offset;
+	ut64 fixups_size;
 	struct MACH0_(section) *sects;
 	int nsects;
 	struct MACH0_(nlist) *symtab;
@@ -180,6 +195,54 @@ struct MACH0_(obj_t) {
 	bool rebasing_buffer;
 };
 
+typedef struct {
+	RFixupEvent type;
+	struct MACH0_(obj_t) *bin;
+	ut64 offset;
+	ut64 raw_ptr;
+} RFixupEventDetails;
+
+typedef struct {
+	RFixupEvent type;
+	struct MACH0_(obj_t) *bin;
+	ut64 offset;
+	ut64 raw_ptr;
+	ut64 ordinal;
+	ut64 addend;
+} RFixupBindEventDetails;
+
+typedef struct {
+	RFixupEvent type;
+	struct MACH0_(obj_t) *bin;
+	ut64 offset;
+	ut64 raw_ptr;
+	ut32 ordinal;
+	ut8 key;
+	ut8 addr_div;
+	ut16 diversity;
+} RFixupBindAuthEventDetails;
+
+typedef struct {
+	RFixupEvent type;
+	struct MACH0_(obj_t) *bin;
+	ut64 offset;
+	ut64 raw_ptr;
+	ut64 ptr_value;
+} RFixupRebaseEventDetails;
+
+typedef struct {
+	RFixupEvent type;
+	struct MACH0_(obj_t) *bin;
+	ut64 offset;
+	ut64 raw_ptr;
+	ut64 ptr_value;
+	ut8 key;
+	ut8 addr_div;
+	ut16 diversity;
+} RFixupRebaseAuthEventDetails;
+
+typedef bool (*RFixupCallback)(void * context, RFixupEventDetails * event_details);
+
 void MACH0_(opts_set_default)(struct MACH0_(opts_t) *options, RBinFile *bf);
 struct MACH0_(obj_t) *MACH0_(mach0_new)(const char *file, struct MACH0_(opts_t) *options);
 struct MACH0_(obj_t) *MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *options);
@@ -213,4 +276,5 @@ int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header) *hdr);
 struct MACH0_(mach_header) *MACH0_(get_hdr)(RBuffer *buf);
 void MACH0_(mach_headerfields)(RBinFile *bf);
 RList *MACH0_(mach_fields)(RBinFile *bf);
+void MACH0_(iterate_chained_fixups)(struct MACH0_(obj_t) *obj, ut64 limit_start, ut64 limit_end, ut32 event_mask, RFixupCallback callback, void *context);
 #endif

--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -1582,4 +1582,31 @@ struct dyld_chained_ptr_arm64e_auth_bind24 {
 		auth : 1; // == 1
 };
 
+enum {
+	DYLD_CHAINED_IMPORT          = 1,
+	DYLD_CHAINED_IMPORT_ADDEND   = 2,
+	DYLD_CHAINED_IMPORT_ADDEND64 = 3,
+};
+
+struct dyld_chained_import {
+	uint32_t lib_ordinal : 8,
+		weak_import : 1,
+		name_offset : 23;
+};
+
+struct dyld_chained_import_addend {
+	uint32_t lib_ordinal : 8,
+		weak_import : 1,
+		name_offset : 23;
+	int32_t addend;
+};
+
+struct dyld_chained_import_addend64 {
+	uint64_t lib_ordinal : 16,
+		weak_import : 1,
+		reserved : 15,
+		name_offset : 32;
+	uint64_t addend;
+};
+
 #endif

--- a/test/db/anal/classes
+++ b/test/db/anal/classes
@@ -146,7 +146,7 @@ Type Info at 0x100008370:
 type: __class_type_info
 found_at: 4295000200
 class_vtable: 4295000176
-ref_to_type_class: 13838435755002691596
+ref_to_type_class: 0
 ref_to_type_name: 4294999928
 name: A
 name_unique: true

--- a/test/db/cmd/cmd_tc
+++ b/test/db/cmd/cmd_tc
@@ -482,6 +482,7 @@ CMDS=ic*
 EXPECT=<<EOF
 fs classes
 "f class.Employee = 0x1000079a8"
+"f super.Employee.NSObject = 0"
 "f method.Employee.sayHello = 0x1000079d8"
 "f method.Employee.helloWorld = 0x100007a08"
 "f method.Employee.p0 = 0x100007a38"

--- a/test/db/formats/mach0/fatmach0
+++ b/test/db/formats/mach0/fatmach0
@@ -15,7 +15,7 @@ RUN
 
 NAME=fatmach0 string location dylib 64
 FILE=bins/mach0/libexpat.1.dylib
-ARGS=-b64
+ARGS=-ax86 -b64
 CMDS=<<EOF
 s str.parsing_finished
 x 16
@@ -272,13 +272,13 @@ FILE=bins/mach0/modernobjc-noarm64
 ARGS=-a arm
 CMDS=ic
 EXPECT=<<EOF
-0x100009298 [0x100001e90 - 0x100001e90]      0 class 0 ViewController
+0x100009298 [0x100001e90 - 0x100001e90]      0 class 0 ViewController :: UIViewController
 0x100001e90 method 0      viewDidLoad
-0x1000092c0 [0x100001ee4 - 0x1000020a4]    448 class 0 AppDelegate
+0x1000092c0 [0x100001ee4 - 0x1000020a4]    448 class 0 AppDelegate :: UIResponder
 0x100001ee4 method 0      application:didFinishLaunchingWithOptions:
 0x100001f74 method 1      application:configurationForConnectingSceneSession:options:
 0x1000020a4 method 2      application:didDiscardSceneSessions:
-0x100009310 [0x1000021d0 - 0x100002494]    708 class 0 SceneDelegate
+0x100009310 [0x1000021d0 - 0x100002494]    708 class 0 SceneDelegate :: UIResponder
 0x1000021d0 method 0      scene:willConnectToSession:options:
 0x100002280 method 1      sceneDidDisconnect:
 0x1000022d4 method 2      sceneDidBecomeActive:

--- a/test/db/formats/mach0/objc
+++ b/test/db/formats/mach0/objc
@@ -102,6 +102,7 @@ NAME=macOS arm64 with DYLD_CHAINED_PTR_64_OFFSET
 FILE=bins/mach0/hello-macos-arm64-chained
 CMDS=<<EOF
 ic Test
+ic~::
 EOF
 EXPECT=<<EOF
 class Test
@@ -111,6 +112,7 @@ class Test
 0x100003b68 method Test      methodWithTwoArgs:secondArg:
 0x100003be0 method Test      methodWithReturn
 0x100003aa0 method Test c    someStaticMethod
+0x1000080f8 [0x100003a7c - 0x100003be0]    356 class 0 Test :: NSObject
 EOF
 RUN
 
@@ -135,10 +137,13 @@ NAME=macOS arm64e with DYLD_CHAINED_PTR_ARM64E_USERLAND24
 FILE=bins/mach0/TestMacOS-arm64e
 CMDS=<<EOF
 ic AppDelegate~:1..
+ic~::
 EOF
 EXPECT=<<EOF
 0x100003238 method AppDelegate      applicationDidFinishLaunching:
 0x100003288 method AppDelegate      applicationWillTerminate:
 0x1000032d8 method AppDelegate      applicationSupportsSecureRestorableState:
+0x100008a70 [0x10000313c - 0x100003184]     72 class 0 ViewController :: NSViewController
+0x100008a98 [0x100003238 - 0x1000032d8]    160 class 0 AppDelegate :: NSObject
 EOF
 RUN


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Modern arm64 / arm64e Mach-O binaries (used in iOS since 14.x and macOS on M1) have no dyld bind opcodes. Information about bound symbols is instead stored as part of the "chained fixups" (the same used for rebasing).

This change does:
- walk the chained fixups if no dyld bind opcodes are found
- centralize the iteration of chained fixups so that the same code is used when rebasing and binding: the `iterate_chained_fixups()` function now handles the underlying quirks and exposes a more abstract interface to it

The most visible effect of this change is that now modern arm64 / arm64e Mach-O binaries have information about Objective-C parent classes even when they are imported, and that's what i changed in the relevant test cases in order to test this.

NOTE: also changed another unrelated test (`fatmach0 string location dylib 64`) so that it works also when it runs from an M1 mac.
