### PR TITLE
WIP: Initial work to support thread-safe RCons

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2021 - pancake */
+/* radare2 - LGPL - Copyright 2013-2022 - pancake */
 
 #include <r_anal.h>
 #include <r_lib.h>
@@ -62,8 +62,8 @@
 #define ISPREINDEX64() (((OPCOUNT64() == 2) && (ISMEM64(1)) && (ISWRITEBACK64())) || ((OPCOUNT64() == 3) && (ISMEM64(2)) && (ISWRITEBACK64())))
 #define ISPOSTINDEX64() (((OPCOUNT64() == 3) && (ISIMM64(2)) && (ISWRITEBACK64())) || ((OPCOUNT64() == 4) && (ISIMM64(3)) && (ISWRITEBACK64())))
 
-static HtUU *ht_itblock = NULL;
-static HtUU *ht_it = NULL;
+static R_TH_LOCAL HtUU *ht_itblock = NULL;
+static R_TH_LOCAL HtUU *ht_it = NULL;
 
 #define BITMASK_BY_WIDTH_COUNT 64
 static const ut64 bitmask_by_width[BITMASK_BY_WIDTH_COUNT] = {

--- a/libr/anal/p/anal_snes.c
+++ b/libr/anal/p/anal_snes.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2015 - condret */
+/* radare - LGPL - Copyright 2015-2022 - condret */
 
 #include <string.h>
 #include <r_types.h>
@@ -8,7 +8,7 @@
 #include "../../asm/arch/snes/snes_op_table.h"
 #include "../../asm/p/asm_snes.h"
 
-static struct snes_asm_flags* snesflags = NULL;
+static R_TH_LOCAL struct snes_asm_flags* snesflags = NULL;
 
 static int snes_anop(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	op->size = snes_op_get_size(snesflags->M, snesflags->X, &snes_op[data[0]]);

--- a/libr/anal/p/anal_tms320.c
+++ b/libr/anal/p/anal_tms320.c
@@ -10,7 +10,7 @@
 #include "anal_tms320c64x.c"
 #include "../../asm/arch/tms320/tms320_dasm.h"
 
-static tms320_dasm_t engine = { 0 };
+static R_TH_LOCAL tms320_dasm_t engine = { 0 };
 
 typedef int (* TMS_ANAL_OP_FN)(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len);
 

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -59,7 +59,7 @@ struct Getarg {
 	int bits;
 };
 
-static csh handle = 0;
+static R_TH_LOCAL csh handle = 0;
 
 static void hidden_op(cs_insn *insn, cs_x86 *x, int mode) {
 	unsigned int id = insn->id;
@@ -3328,7 +3328,7 @@ static int cs_len_prefix_opcode(uint8_t *item) {
 }
 
 static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAnalOpMask mask) {
-	static int omode = 0;
+	static __thread int omode = 0;
 	cs_insn *insn = NULL;
 	int mode = (a->bits==64)? CS_MODE_64:
 		(a->bits==32)? CS_MODE_32:

--- a/libr/asm/arch/tms320/tms320_dasm.c
+++ b/libr/asm/arch/tms320/tms320_dasm.c
@@ -94,8 +94,8 @@ int run_f_list(tms320_dasm_t * dasm) {
 			break;
 
 		case TMS320_FLAG_l1:
-			temp = get_bits(dasm->opcode64, flag->f, 1);
-			set_field_value(dasm, l1, temp);
+			temp = get_bits (dasm->opcode64, flag->f, 1);
+			set_field_value (dasm, l1, temp);
 			break;
 		case TMS320_FLAG_l3:
 			temp = get_bits(dasm->opcode64, flag->f, 3);
@@ -1026,9 +1026,8 @@ insn_item_t * decode_insn(tms320_dasm_t * dasm)
 
 }
 
-insn_item_t * decode_insn_head(tms320_dasm_t * dasm)
-{
-	run_f_list(dasm);
+insn_item_t * decode_insn_head(tms320_dasm_t * dasm) {
+	run_f_list (dasm);
 
 	if (dasm->insn->i_list) {
 		dasm->insn = dasm->insn->i_list;
@@ -1112,8 +1111,7 @@ static int full_insn_size(tms320_dasm_t *dasm)
  * TMS320 disassembly engine public interface
  */
 
-int tms320_dasm(tms320_dasm_t * dasm, const ut8 * stream, int len)
-{
+int tms320_dasm(tms320_dasm_t * dasm, const ut8 * stream, int len) {
 	init_dasm(dasm, stream, len);
 
 	if (tms320_f_get_cpu(dasm) != TMS320_F_CPU_C55X_PLUS) {
@@ -1140,25 +1138,23 @@ int tms320_dasm(tms320_dasm_t * dasm, const ut8 * stream, int len)
 // insn_head_t c55x_list[]
 #include "c55x/table.h"
 
-int tms320_dasm_init(tms320_dasm_t * dasm) {
+bool tms320_dasm_init(tms320_dasm_t * dasm) {
 	int i = 0;
 
 	if (dasm->map) {
 		/* already initialized */
-		return 0;
+		return false;
 	}
 
 	dasm->map = ht_up_new0 ();
 	if (!dasm->map) {
-		return 0;
+		return false;
 	}
 	for (i = 0; i < ARRAY_SIZE(c55x_list); i++) {
 		ht_up_insert (dasm->map, c55x_list[i].byte, &c55x_list[i]);
 	}
-
-	tms320_f_set_cpu(dasm, TMS320_F_CPU_C55X);
-
-	return 0;
+	tms320_f_set_cpu (dasm, TMS320_F_CPU_C55X);
+	return true;
 }
 
 int tms320_dasm_fini(tms320_dasm_t * dasm) {

--- a/libr/asm/arch/tms320/tms320_dasm.h
+++ b/libr/asm/arch/tms320/tms320_dasm.h
@@ -239,7 +239,7 @@ typedef struct {
 
 extern int tms320_dasm(tms320_dasm_t *, const ut8 *, int);
 
-extern int tms320_dasm_init(tms320_dasm_t *);
+extern bool tms320_dasm_init(tms320_dasm_t *);
 extern int tms320_dasm_fini(tms320_dasm_t *);
 
 #endif /* __TMS320_DASM_H__ */

--- a/libr/asm/p/asm_arm_cs.c
+++ b/libr/asm/p/asm_arm_cs.c
@@ -8,9 +8,10 @@
 #include "./asm_arm_hacks.inc"
 
 bool arm64ass(const char *str, ut64 addr, ut32 *op);
-static csh cd = 0;
-static HtUU *ht_itblock = NULL;
-static HtUU *ht_it = NULL;
+// XXX kill globals
+static R_TH_LOCAL csh cd = 0;
+static R_TH_LOCAL HtUU *ht_itblock = NULL;
+static R_TH_LOCAL HtUU *ht_it = NULL;
 
 #include "cs_mnemonics.c"
 

--- a/libr/asm/p/asm_snes.c
+++ b/libr/asm/p/asm_snes.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2012-2015 - condret, pancake */
+/* radare - LGPL - Copyright 2012-2021 - condret, pancake */
 
 #include <r_types.h>
 #include <r_util.h>
@@ -7,7 +7,7 @@
 #include "../arch/snes/snesdis.c"
 #include "asm_snes.h"
 
-static struct snes_asm_flags* snesflags = NULL;
+static _Thread_local struct snes_asm_flags* snesflags = NULL;
 
 static bool snes_asm_init(void* user) {
 	if (!snesflags) {

--- a/libr/asm/p/asm_tms320.c
+++ b/libr/asm/p/asm_tms320.c
@@ -72,7 +72,7 @@ static int tms320c64x_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) 
 
 #include "../arch/tms320/tms320_dasm.h"
 
-static tms320_dasm_t engine = { 0 };
+static R_TH_LOCAL tms320_dasm_t engine = { 0 };
 
 static int tms320_disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	if (a->cpu && r_str_casecmp (a->cpu, "c54x") == 0) {

--- a/libr/asm/p/asm_x86_cs.c
+++ b/libr/asm/p/asm_x86_cs.c
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2013-2021 - pancake */
+/* radare2 - LGPL - Copyright 2013-2022 - pancake */
 
 #include <r_asm.h>
 #include <r_lib.h>
@@ -6,8 +6,8 @@
 
 #define USE_ITER_API 1
 
-static csh cd = 0;
-static int n = 0;
+static _Thread_local csh cd = 0;
+static _Thread_local int n = 0;
 
 static bool the_end(void *p) {
 #if 0
@@ -57,7 +57,7 @@ static bool check_features(RAsm *a, cs_insn *insn) {
 }
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
-	static int omode = 0;
+	static R_TH_LOCAL int omode = 0;
 	int mode, ret;
 	ut64 off = a->pc;
 

--- a/libr/bin/p/bin_java.c
+++ b/libr/bin/p/bin_java.c
@@ -10,7 +10,8 @@
 
 #define IFDBG_BIN_JAVA if (0)
 
-static Sdb *DB = NULL;
+static R_TH_LOCAL Sdb *DB = NULL;
+
 static void add_bin_obj_to_sdb(RBinJavaObj *bin);
 static int add_sdb_bin_obj(const char *key, RBinJavaObj *bin_obj);
 

--- a/libr/cons/line.c
+++ b/libr/cons/line.c
@@ -3,7 +3,7 @@
 #include <r_util.h>
 #include <r_cons.h>
 
-static RLine r_line_instance;
+static R_TH_LOCAL RLine r_line_instance;
 #define I r_line_instance
 
 R_API RLine *r_line_singleton(void) {

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -1,6 +1,7 @@
-/* radare - LGPL - Copyright 2013-2021 - pancake, sghctoma, xarkes */
+/* radare - LGPL - Copyright 2013-2022 - pancake, sghctoma, xarkes */
 
 #include <r_cons.h>
+#include <r_th.h>
 
 #define RCOLOR_AT(i) (RColor *) (((ut8 *) &(r_cons_context ()->cpal)) + keys[i].coff)
 #define COLOR_AT(i) (char **) (((ut8 *) &(r_cons_context ()->pal)) + keys[i].off)
@@ -152,6 +153,13 @@ static void __cons_pal_update_event(RConsContext *ctx) {
 }
 
 R_API void r_cons_pal_init(RConsContext *ctx) {
+	static R_TH_LOCAL RThreadLock *lock = NULL;
+	if (lock) {
+		r_th_lock_wait (lock);
+	} else {
+		lock = r_th_lock_new (false);
+	}
+	r_th_lock_enter (lock);
 	memset (&ctx->cpal, 0, sizeof (ctx->cpal));
 
 	ctx->cpal.b0x00              = (RColor) RColor_GREEN;
@@ -238,10 +246,15 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.graph_diff_new     =  (RColor) RColor_RED;
 	ctx->cpal.graph_diff_match   =  (RColor) RColor_GRAY;
 	ctx->cpal.graph_diff_unmatch =  (RColor) RColor_YELLOW;
-
-	r_cons_pal_free (ctx);
 	ctx->pal.reset = Color_RESET; // reset is not user accessible, const char* is ok
 	__cons_pal_update_event (ctx);
+	r_cons_pal_free (ctx);
+	int i;
+	for (i = 0; keys[i].name; i++) {
+		char **color = (char **) (((ut8 *) &(ctx->pal)) + keys[i].off);
+		*color = NULL;
+	}
+	r_th_lock_leave (lock);
 }
 
 R_API void r_cons_pal_free(RConsContext *ctx) {
@@ -502,7 +515,7 @@ static void r_cons_pal_show_rgb(void) {
 }
 
 R_API void r_cons_pal_show(void) {
-	int i;
+	size_t i;
 	for (i = 0; colors[i].name; i++) {
 		r_cons_printf ("%s%s__"Color_RESET" %s\n",
 			colors[i].code,
@@ -613,7 +626,7 @@ R_API void r_cons_pal_list(int rad, const char *arg) {
  * r_cons_pal_update_event () must be called after this function
  * so the changes take effect. */
 R_API int r_cons_pal_set(const char *key, const char *val) {
-	int i;
+	size_t i;
 	RColor *rcolor;
 	for (i = 0; keys[i].name; i++) {
 		if (!strcmp (key, keys[i].name)) {
@@ -629,7 +642,7 @@ R_API int r_cons_pal_set(const char *key, const char *val) {
 
 /* Get the named RColor */
 R_API RColor r_cons_pal_get(const char *key) {
-	int i;
+	size_t i;
 	RColor *rcolor;
 	for (i = 0; keys[i].name; i++) {
 		if (!strcmp (key, keys[i].name)) {

--- a/libr/cons/rgb.c
+++ b/libr/cons/rgb.c
@@ -1,11 +1,12 @@
-/* radare - LGPL - Copyright 2013-2020 - pancake, xarkes */
+/* radare - LGPL - Copyright 2013-2022 - pancake, xarkes */
 /* ansi 256 color extension for r_cons */
 /* https://en.wikipedia.org/wiki/ANSI_color */
 
 #include <r_cons.h>
+#include <r_th.h>
 
-int color_table[256] = { 0 };
-int value_range[6] = { 0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff};
+static R_TH_LOCAL int color_table[256] = { 0 };
+static R_TH_LOCAL int value_range[6] = { 0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff};
 
 static void init_color_table(void) {
 	int i, r, g, b;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -19,8 +19,8 @@
 #define DEBUG_DISASM 0
 
 // ugly globals but meh
-static ut64 emustack_min = 0LL;
-static ut64 emustack_max = 0LL;
+static R_TH_LOCAL ut64 emustack_min = 0LL;
+static R_TH_LOCAL ut64 emustack_max = 0LL;
 
 static const char* r_vline_a[] = {
 	"|",  // LINE_VERT
@@ -881,7 +881,7 @@ static RDisasmState *ds_init(RCore *core) {
 	return ds;
 }
 
-static ut64 lastaddr = UT64_MAX;
+static __thread ut64 lastaddr = UT64_MAX;
 
 static void ds_reflines_fini(RDisasmState *ds) {
 	RAnal *anal = ds->core->anal;

--- a/libr/include/heap/r_jemalloc/internal/tsd.h
+++ b/libr/include/heap/r_jemalloc/internal/tsd.h
@@ -109,66 +109,6 @@ a_name##tsd_get(bool init);						\
 a_attr void								\
 a_name##tsd_set(a_type *val);
 
-/* malloc_tsd_externs(). */
-#ifdef JEMALLOC_MALLOC_THREAD_CLEANUP
-#define	malloc_tsd_externs(a_name, a_type)				\
-extern __thread a_type	a_name##tsd_tls;				\
-extern __thread bool	a_name##tsd_initialized;			\
-extern bool		a_name##tsd_booted;
-#elif (defined(JEMALLOC_TLS))
-#define	malloc_tsd_externs(a_name, a_type)				\
-extern __thread a_type	a_name##tsd_tls;				\
-extern pthread_key_t	a_name##tsd_tsd;				\
-extern bool		a_name##tsd_booted;
-#elif (defined(_WIN32))
-#define	malloc_tsd_externs(a_name, a_type)				\
-extern DWORD		a_name##tsd_tsd;				\
-extern a_name##tsd_wrapper_t	a_name##tsd_boot_wrapper;		\
-extern bool		a_name##tsd_booted;
-#else
-#define	malloc_tsd_externs(a_name, a_type)				\
-extern pthread_key_t	a_name##tsd_tsd;				\
-extern tsd_init_head_t	a_name##tsd_init_head;				\
-extern a_name##tsd_wrapper_t	a_name##tsd_boot_wrapper;		\
-extern bool		a_name##tsd_booted;
-#endif
-
-/* malloc_tsd_data(). */
-#ifdef JEMALLOC_MALLOC_THREAD_CLEANUP
-#define	malloc_tsd_data(a_attr, a_name, a_type, a_initializer)		\
-a_attr __thread a_type JEMALLOC_TLS_MODEL				\
-    a_name##tsd_tls = a_initializer;					\
-a_attr __thread bool JEMALLOC_TLS_MODEL					\
-    a_name##tsd_initialized = false;					\
-a_attr bool		a_name##tsd_booted = false;
-#elif (defined(JEMALLOC_TLS))
-#define	malloc_tsd_data(a_attr, a_name, a_type, a_initializer)		\
-a_attr __thread a_type JEMALLOC_TLS_MODEL				\
-    a_name##tsd_tls = a_initializer;					\
-a_attr pthread_key_t	a_name##tsd_tsd;				\
-a_attr bool		a_name##tsd_booted = false;
-#elif (defined(_WIN32))
-#define	malloc_tsd_data(a_attr, a_name, a_type, a_initializer)		\
-a_attr DWORD		a_name##tsd_tsd;				\
-a_attr a_name##tsd_wrapper_t a_name##tsd_boot_wrapper = {		\
-	false,								\
-	a_initializer							\
-};									\
-a_attr bool		a_name##tsd_booted = false;
-#else
-#define	malloc_tsd_data(a_attr, a_name, a_type, a_initializer)		\
-a_attr pthread_key_t	a_name##tsd_tsd;				\
-a_attr tsd_init_head_t	a_name##tsd_init_head = {			\
-	ql_head_initializer(blocks),					\
-	MALLOC_MUTEX_INITIALIZER					\
-};									\
-a_attr a_name##tsd_wrapper_t a_name##tsd_boot_wrapper = {		\
-	false,								\
-	a_initializer							\
-};									\
-a_attr bool		a_name##tsd_booted = false;
-#endif
-
 /* malloc_tsd_funcs(). */
 #ifdef JEMALLOC_MALLOC_THREAD_CLEANUP
 #define	malloc_tsd_funcs(a_attr, a_name, a_type, a_initializer,		\

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -904,6 +904,7 @@ R_API void r_cons_switchbuf(bool active);
 R_API int r_cons_readchar_timeout(ut32 usec);
 R_API int r_cons_any_key(const char *msg);
 R_API int r_cons_eof(void);
+R_API void r_cons_thready(void);
 
 R_API int r_cons_palette_init(const unsigned char *pal);
 R_API int r_cons_pal_set(const char *key, const char *val);

--- a/libr/lang/lang.c
+++ b/libr/lang/lang.c
@@ -20,7 +20,7 @@ R_LIB_VERSION(r_lang);
 #include "p/go.c"    // hardcoded
 #include "p/lib.c"
 
-static RLang *__lang = NULL;
+static R_TH_LOCAL RLang *__lang = NULL;
 
 R_API void r_lang_plugin_free(RLangPlugin *p) {
 	if (p && p->fini) {

--- a/libr/lang/p/spp.c
+++ b/libr/lang/p/spp.c
@@ -5,7 +5,7 @@
 #include "r_lang.h"
 #define USE_R2 1
 
-static RLang *Glang = NULL;
+static R_TH_LOCAL RLang *Glang = NULL;
 #undef S_API
 // #include "../../../shlr/spp/spp.c"
 #include "../../../shlr/spp/spp.h"

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2008-2021 - pancake */
+/* radare - LGPL - Copyright 2008-2022 - pancake */
 
 #include <r_util.h>
 #include <r_lib.h>
@@ -7,7 +7,7 @@ R_LIB_VERSION(r_lib);
 
 /* TODO: avoid globals */
 #define IFDBG if(__has_debug)
-static bool __has_debug = false;
+static R_TH_LOCAL bool __has_debug = false;
 
 /* XXX : this must be registered in runtime */
 static const char *r_lib_types[] = {

--- a/libr/util/log.c
+++ b/libr/util/log.c
@@ -1,18 +1,18 @@
-/* radare - LGPL - Copyright 2007-2018 - pancake, ret2libc */
+/* radare - LGPL - Copyright 2007-2022 - pancake, ret2libc */
 
-#define LOG_CONFIGSTR_SIZE 512
+#define LOG_CONFIGSTR_SIZE 128
 #define LOG_OUTPUTBUF_SIZE 512
 
 #include <r_core.h>
 #include <stdarg.h>
 
 // TODO: Use thread-local storage to make these variables thread-safe
-static RList *log_cbs = NULL; // Functions to call when outputting log string
-static int cfg_loglvl = R_LOGLVL_ERROR; // Log level output
-static int cfg_logtraplvl = R_LOGLVL_FATAL; // Log trap level
-static bool cfg_logsrcinfo = false; // Print out debug source info with the output
-static bool cfg_logcolors = false; // Output colored log text based on level
-static char cfg_logfile[LOG_CONFIGSTR_SIZE] = ""; // Output text to filename
+static R_TH_LOCAL RList *log_cbs = NULL; // Functions to call when outputting log string
+static R_TH_LOCAL int cfg_loglvl = R_LOGLVL_ERROR; // Log level output
+static R_TH_LOCAL int cfg_logtraplvl = R_LOGLVL_FATAL; // Log trap level
+static R_TH_LOCAL bool cfg_logsrcinfo = false; // Print out debug source info with the output
+static R_TH_LOCAL bool cfg_logcolors = false; // Output colored log text based on level
+static R_TH_LOCAL char cfg_logfile[LOG_CONFIGSTR_SIZE] = ""; // Output text to filename
 static const char *level_tags[] = { // Log level to tag string lookup array
 	[R_LOGLVL_SILLY]     = "SILLY",
 	[R_LOGLVL_VERBOSE]   = "VERBOSE",

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -5,7 +5,10 @@
 
 #define DFLT_ROWS 16
 
+// global
 static const char hex[16] = "0123456789ABCDEF";
+// global mutable
+static R_TH_LOCAL RPrintIsInterruptedCallback is_interrupted_cb = NULL;
 
 static int nullprinter(const char *a, ...) {
 	return 0;
@@ -26,8 +29,6 @@ static int libc_eprintf(const char *format, ...) {
 	va_end (ap);
 	return 0;
 }
-
-static RPrintIsInterruptedCallback is_interrupted_cb = NULL;
 
 R_API void r_print_portionbar(RPrint *p, const ut64 *portions, int n_portions) {
 	const int use_color = p->flags & R_PRINT_FLAGS_COLOR;
@@ -2059,9 +2060,9 @@ R_API const char* r_print_color_op_type(RPrint *p, ut32 anal_type) {
 	}
 }
 
-// Global buffer to speed up colorizing performance
+// XXX Global buffer to speed up colorizing performance
 #define COLORIZE_BUFSIZE 1024
-static char o[COLORIZE_BUFSIZE];
+static __thread char o[COLORIZE_BUFSIZE];
 
 static bool issymbol(char c) {
 	switch (c) {

--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -15,9 +15,9 @@
 #include <priv.h>
 #endif
 
-static bool G_enabled = false;
-static bool G_disabled = false;
-static int G_graintype = R_SANDBOX_GRAIN_NONE;
+static R_TH_LOCAL bool G_enabled = false;
+static R_TH_LOCAL bool G_disabled = false;
+static R_TH_LOCAL int G_graintype = R_SANDBOX_GRAIN_NONE;
 
 #define R_SANDBOX_GUARD(x,y) if (G_enabled && !(G_graintype & (x))) { return (y); }
 

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1248,12 +1248,17 @@ R_API char *r_sys_whoami(void) {
 #elif __wasi__
 	strcpy (buf, "user");
 #else
+	char *user = r_sys_getenv ("USER");
+	return user? user: r_str_newf ("uid%d", getuid ());
+#if 0
+	// XXX this is not thread safe and getpwuid_r is not available
 	struct passwd *pw = getpwuid (getuid ());
 	if (pw) {
 		return strdup (pw->pw_name);
 	}
 	int uid = getuid ();
 	snprintf (buf, sizeof (buf), "uid%d", uid);
+#endif
 #endif
 	return strdup (buf);
 }
@@ -1308,7 +1313,7 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 }
 
 R_API const char *r_sys_prefix(const char *pfx) {
-	static char *prefix = NULL;
+	static R_TH_LOCAL char *prefix = NULL;
 	if (!prefix) {
 #if __WINDOWS__
 		prefix = r_sys_get_src_dir_w32 ();

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2017 - pancake */
+/* radare - LGPL - Copyright 2009-2022 - pancake */
 
 #include <r_th.h>
 
@@ -18,11 +18,16 @@ R_API RThreadLock *r_th_lock_new(bool recursive) {
 #endif
 			pthread_mutex_init (&thl->lock, &attr);
 		} else {
-			pthread_mutex_init (&thl->lock, NULL);
+			pthread_mutexattr_t attr;
+			pthread_mutexattr_init (&attr);
+			pthread_mutex_init (&thl->lock, &attr);
 		}
 #elif __WINDOWS__
 		// TODO: obey `recursive` (currently it is always recursive)
 		InitializeCriticalSection (&thl->lock);
+#else
+#warning Unsupported mutex
+		R_FREE (thl);
 #endif
 	}
 	return thl;

--- a/sys/sanitize.sh
+++ b/sys/sanitize.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 # SANITIZE="address leak memory undefined"
 # SANITIZE="address signed-integer-overflow"  # Faster build
-SANITIZE=${SANITIZE:="address undefined signed-integer-overflow"}
+# default:
+# SANITIZE=${SANITIZE:="address undefined signed-integer-overflow"}
+SANITIZE=${SANITIZE:="thread undefined signed-integer-overflow"}
 
 printf "\033[32m"
 echo "========================================================================="

--- a/test/unit/races.c
+++ b/test/unit/races.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <r_core.h>
+
+static int r2stuff(RThread *th) {
+	r_cons_thready ();
+	RCore *core = r_core_new ();
+	int i;
+	for (i = 0; i < 10; i++) {
+		// printf ("%d\n", i);
+		char *a = r_core_cmd_str (core, "?e hello");
+		if (a && strcmp (a, "hello\n")) {
+			eprintf ("(%s)\n", a);
+			exit (1);
+		}
+ 		free (r_core_cmd_str (core, "af-*;af; pd 4"));
+		free (a);
+	}
+	r_core_free (core);
+	return 0;
+}
+
+int main() {
+	RThread *a = r_th_new (r2stuff, NULL, 0);
+	RThread *b = r_th_new (r2stuff, NULL, 0); // if 0 then crash happens in r_cons initialization /o\
+
+	r_th_start (a, true);
+	r_th_start (b, true);
+	r_th_wait (a);
+	r_th_wait (b);
+
+	r_th_free (a);
+	r_th_free (b);
+	return 0;
+}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This patch allows r2 to be used on multiple threads, this is, a single RCore on each thread should work independently, because the "only" global should be the RConsInstance. Turns out, there are some extra issues in the way:

* tms320 plugin is not thread safe and uses globals, disabled for testing
* r_cons_pal initialization frees global pointers
* r_cons_init uses a mutex
* RConsInstance and Context are now TLS
* The r_cons_thready() function initializes those TLS variables
* Capstone is also not thread safe because cs_init/cs_close use globals
* The _Thread_local is a C11 keyword, And this shouldnt be a hard requirement
* The thready rcons instance should be just a pointer, not the whole RCons struct