### PR TITLE
Add r_core_help_match() to get help for a specific command

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -2146,29 +2146,9 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 	}
 }
 
-/* See r_cons_cmd_help().
- * This version will only print help for a specific command.
- * Will append spec to cmd before looking for a match, if spec != 0.
- */
-R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec) {
-	const char **match = NULL;
+static void print_match(const char **match, bool use_color) {
 	const char *match_help_text[4];
-	int i;
-
-	if (spec) {
-		/* We now own cmd */
-		cmd = r_str_newf ("%s%c", cmd, spec);
-	}
-
-	for (i = 0; help[i]; i += 3) {
-		if (!strcmp (help[i], cmd)) {
-			match = &help[i];
-			break;
-		}
-	}
-
-	/* Command was not found in help text. */
-	r_return_if_fail (match);
+	size_t i;
 
 	/* Manually construct help array. No need to strdup, just borrow. */
 	match_help_text[3] = NULL;
@@ -2176,6 +2156,36 @@ R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_
 		match_help_text[i] = match[i];
 	}
 	r_cons_cmd_help (match_help_text, use_color);
+}
+
+/* See r_cons_cmd_help().
+ * This version will only print help for a specific command.
+ * Will append spec to cmd before looking for a match, if spec != 0.
+ *
+ * If exact is false, will match any command that contains the search text.
+ * For example, ("pd", 'r', false) matches both `pdr` and `pdr.`.
+ */
+R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec, bool exact) {
+	size_t i;
+
+	if (spec) {
+		/* We now own cmd */
+		cmd = r_str_newf ("%s%c", cmd, spec);
+	}
+
+	for (i = 0; help[i]; i += 3) {
+		if (exact) {
+			if (!strcmp (help[i], cmd)) {
+				print_match (&help[i], use_color);
+				break;
+			}
+		} else {
+			if (!strstr (help[i], cmd)) {
+				print_match (&help[i], use_color);
+				/* Don't break - can have multiple results */
+			}
+		}
+	}
 
 	if (spec) {
 		free (cmd);

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -2146,6 +2146,42 @@ R_API void r_cons_cmd_help(const char *help[], bool use_color) {
 	}
 }
 
+/* See r_cons_cmd_help().
+ * This version will only print help for a specific command.
+ * Will append spec to cmd before looking for a match, if spec != 0.
+ */
+R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec) {
+	const char **match = NULL;
+	const char *match_help_text[4];
+	int i;
+
+	if (spec) {
+		/* We now own cmd */
+		cmd = r_str_newf ("%s%c", cmd, spec);
+	}
+
+	for (i = 0; help[i]; i += 3) {
+		if (!strcmp (help[i], cmd)) {
+			match = &help[i];
+			break;
+		}
+	}
+
+	/* Command was not found in help text. */
+	r_return_if_fail (match);
+
+	/* Manually construct help array. No need to strdup, just borrow. */
+	match_help_text[3] = NULL;
+	for (i = 0; i < 3; i++) {
+		match_help_text[i] = match[i];
+	}
+	r_cons_cmd_help (match_help_text, use_color);
+
+	if (spec) {
+		free (cmd);
+	}
+}
+
 R_API void r_cons_clear_buffer(void) {
 	if (I.vtmode) {
 		(void)write (1, "\x1b" "c\x1b[3J", 6);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -337,12 +337,12 @@ R_API void r_core_cmd_help(const RCore *core, const char *help[]) {
 	r_cons_cmd_help (help, core->print->flags & R_PRINT_FLAGS_COLOR);
 }
 
-R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd) {
-	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0);
+R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, bool exact) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0, exact);
 }
 
-R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec) {
-	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec);
+R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec, bool exact) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec, exact);
 }
 
 struct duplicate_flag_t {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -337,6 +337,14 @@ R_API void r_core_cmd_help(const RCore *core, const char *help[]) {
 	r_cons_cmd_help (help, core->print->flags & R_PRINT_FLAGS_COLOR);
 }
 
+R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0);
+}
+
+R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec);
+}
+
 struct duplicate_flag_t {
 	RList *ret;
 	const char *word;

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -891,7 +891,7 @@ R_API void r_cons_visual_write(char *buffer);
 R_API bool r_cons_is_utf8(void);
 R_API bool r_cons_is_windows(void);
 R_API void r_cons_cmd_help(const char *help[], bool use_color);
-R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec);
+R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec, bool exact);
 R_API void r_cons_log_stub(const char *output, const char *funcname, const char *filename,
  unsigned int lineno, unsigned int level, const char *tag, const char *fmtstr, ...) R_PRINTF_CHECK(7, 8);
 

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -891,6 +891,7 @@ R_API void r_cons_visual_write(char *buffer);
 R_API bool r_cons_is_utf8(void);
 R_API bool r_cons_is_windows(void);
 R_API void r_cons_cmd_help(const char *help[], bool use_color);
+R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_NONNULL char *cmd, char spec);
 R_API void r_cons_log_stub(const char *output, const char *funcname, const char *filename,
  unsigned int lineno, unsigned int level, const char *tag, const char *fmtstr, ...) R_PRINTF_CHECK(7, 8);
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -842,8 +842,8 @@ R_API char *r_str_widget_list(void *user, RList *list, int rows, int cur, PrintI
 R_API PJ *r_core_pj_new(RCore *core);
 /* help */
 R_API void r_core_cmd_help(const RCore *core, const char *help[]);
-R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd);
-R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec);
+R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, bool exact);
+R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec, bool exact);
 
 /* anal stats */
 

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -842,6 +842,8 @@ R_API char *r_str_widget_list(void *user, RList *list, int rows, int cur, PrintI
 R_API PJ *r_core_pj_new(RCore *core);
 /* help */
 R_API void r_core_cmd_help(const RCore *core, const char *help[]);
+R_API void r_core_cmd_help_match(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd);
+R_API void r_core_cmd_help_match_spec(const RCore *core, const char *help[], R_BORROW R_NONNULL char *cmd, char spec);
 
 /* anal stats */
 


### PR DESCRIPTION
This new function makes it easier to get help text for specific commands in color. By avoiding grep and working directly on the help text array, we can pinpoint the exact line we want by using strcmp and borrowing the string pointers to craft a custom help text array. The only allocation needed is done to append spec to cmd if `spec != 0`.

```
/* Impossible to get color due to color codes interfering */
r_core_cmd0 (core, "pd?~^\| pdl");

/* These 2 are interchangable - spec makes it easier to check for ? in one place */
r_core_cmd_help_match (core, help_msg_pd, "pdl");
r_core_cmd_help_match_spec (core, help_msg_pd, "pd", 'l');

/* Get help for an appropriate subcommand */
r_core_cmd_help_match_spec (core, help_msg_pd, "pd", input[1]);
```