### PR TITLE
Ignore trailing backslash in unescape_special_chars()

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2896,6 +2896,11 @@ static char *unescape_special_chars(const char *s, const char *special_chars) {
 			dst[j++] = s[i];
 			continue;
 		}
+
+		if (!s[i + 1]) {
+			break;
+		}
+
 		dst[j++] = s[i + 1];
 		i++;
 	}


### PR DESCRIPTION
Fix a buffer overread when the input ends with a backslash