### PR TITLE
Fix leaks in esil tests

### DIFF
--- a/libr/bin/dbginfo.c
+++ b/libr/bin/dbginfo.c
@@ -40,6 +40,7 @@ R_API bool r_bin_addr2line2(RBin *bin, ut64 addr, char *file, int len, int *line
 			return true;
 		}
 	}
+	free (key);
 	return false;
 }
 

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2206,10 +2206,12 @@ char* Elf_(r_bin_elf_get_head_flag)(ELFOBJ *bin) {
 	char *str = Elf_(r_bin_elf_get_cpu) (bin);
 	if (str) {
 		head_flag = r_str_append (head_flag, str);
+		free (str);
 	}
 	str = Elf_(r_bin_elf_get_abi) (bin);
 	if (str) {
 		head_flag = r_str_appendf (head_flag, " %s", str);
+		free (str);
 	}
 	if (R_STR_ISEMPTY (head_flag)) {
 		head_flag = r_str_append (head_flag, "unknown_flag");

--- a/libr/cons/grep.c
+++ b/libr/cons/grep.c
@@ -606,15 +606,6 @@ R_API void r_cons_grepbuf(void) {
 		}
 		return;
 	}
-	if (!cons->context->buffer) {
-		cons->context->buffer_len = len + 20;
-		cons->context->buffer = malloc (cons->context->buffer_len);
-		if (!cons->context->buffer) {
-			cons->context->buffer_len = 0;
-			return;
-		}
-		cons->context->buffer[0] = 0;
-	}
 	RStrBuf *ob = r_strbuf_new ("");
 	// if we modify cons->lines we should update I.context->buffer too
 	cons->lines = 0;
@@ -720,11 +711,12 @@ R_API void r_cons_grepbuf(void) {
 	cons->context->buffer_len = r_strbuf_length (ob);
 	if (grep->counter) {
 		int cnt = grep->charCounter? strlen (cons->context->buffer): cons->lines;
-		if (cons->context->buffer_len < 10) {
-			cons->context->buffer_len = 10; // HACK
+		if (cons->context->buffer) {
+			free (cons->context->buffer);
 		}
-		snprintf (cons->context->buffer, cons->context->buffer_len, "%d\n", cnt);
+		cons->context->buffer = r_str_newf ("%d\n", cnt);
 		cons->context->buffer_len = strlen (cons->context->buffer);
+		cons->context->buffer_sz = cons->context->buffer_len+1;
 		cons->num->value = cons->lines;
 		r_strbuf_free (ob);
 		return;

--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -278,6 +278,7 @@ beach:
 	free (buf);
 	free (ptr);
 	free (code);
+	free (inp);
 	R_FREE (opst);
 	r_cons_break_pop ();
 	return hits;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -6335,7 +6335,6 @@ static void cmd_aespc(RCore *core, ut64 addr, ut64 until_addr, int off) {
 	buf = malloc (bsize);
 	if (!buf) {
 		eprintf ("Cannot allocate %d byte(s)\n", bsize);
-		free (buf);
 		return;
 	}
 	if (addr == -1) {
@@ -6384,6 +6383,7 @@ static void cmd_aespc(RCore *core, ut64 addr, ut64 until_addr, int off) {
 		addr += ret; // aop.size;
 		r_anal_op_fini (&aop);
 	}
+	free (buf);
 	r_core_seek (core, oldoff, true);
 	r_reg_setv (core->dbg->reg, "SP", cursp);
 }

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5789,6 +5789,7 @@ static void cmd_esil_mem(RCore *core, const char *input) {
 			// Close the fd associated with the aeim stack
 			ut64 fd = sdb_atoi (fi);
 			(void)r_io_fd_close (core->io, fd);
+			free (fi);
 		}
 	}
 	size = r_config_get_i (core->config, "esil.stack.size");

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -2482,6 +2482,7 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 							if (s) {
 								r_cons_printf ("%s", s);
 							}
+							free (s);
 						}
 					} else {
 						r_cons_printf ("0x%08"PFMT64x "   # %i: %s\n",
@@ -2498,8 +2499,7 @@ static void do_asm_search(RCore *core, struct search_parameters *param, const ch
 				}
 				count++;
 			}
-			r_list_purge (hits);
-			free (hits);
+			r_list_free (hits);
 		}
 	}
 	if (param->outmode == R_MODE_JSON) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6825,6 +6825,7 @@ toro:
 					}
 					r_cons_println (opstr);
 				}
+				free (tmpopstr);
 				r_anal_op_fini (&analop);
 			} else {
 				char opstr[128] = {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1183,6 +1183,7 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		ds->opstr = strdup (ds->str);
 		char *asm_str = colorize_asm_string (core, ds, print_color);
 		if (asm_str) {
+			free (ds->opstr);
 			ds->opstr = asm_str;
 			r_str_ncpy (ds->str, asm_str, sizeof (ds->str));
 // strcpy (ds->str, asm_str);

--- a/libr/core/esil2c.c
+++ b/libr/core/esil2c.c
@@ -32,6 +32,8 @@ static bool esil2c_eq(RAnalEsil *esil) {
 	} else {
 		r_strbuf_appendf (user->sb, "  %s = %s;\n", dst, src);
 	}
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -40,11 +42,11 @@ static bool esil2c_peek8(RAnalEsil *esil) {
 	char *src = r_anal_esil_pop (esil);
 
 	if (!src) {
-		free (src);
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  tmp = mem_qword[%s];\n", src);
 	r_anal_esil_push (esil, "tmp");
+	free (src);
 	return true;
 }
 
@@ -59,6 +61,8 @@ static bool esil2c_poke8(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  mem_qword[%s] = %s;\n", dst, src);
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -73,6 +77,8 @@ static bool esil2c_addeq(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  %s += %s;\n", dst, src);
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -87,6 +93,8 @@ static bool esil2c_add(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  tmp = %s + %s;\n", dst, src);
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -101,6 +109,8 @@ static bool esil2c_subeq(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  %s -= %s;\n", dst, src);
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -117,6 +127,8 @@ static bool esil2c_xor(RAnalEsil *esil) {
 	char *var = r_str_newf ("tmp%d", esil->stackptr);
 	r_strbuf_appendf (user->sb, "  %s = %s ^ %s;\n", var, dst, src);
 	r_anal_esil_push (esil, var);
+	free (dst);
+	free (src);
 	free (var);
 	return true;
 }
@@ -133,6 +145,8 @@ static bool esil2c_sub(RAnalEsil *esil) {
 	}
 	r_strbuf_appendf (user->sb, "  tmp = %s - %s;\n", dst, src);
 	r_anal_esil_push (esil, "tmp");
+	free (dst);
+	free (src);
 	return true;
 }
 
@@ -143,6 +157,7 @@ static bool esil2c_dec(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  %s--;\n", src);
+	free (src);
 	return true;
 }
 
@@ -153,6 +168,7 @@ static bool esil2c_inc(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  %s++;\n", src);
+	free (src);
 	return true;
 }
 
@@ -165,6 +181,7 @@ static bool esil2c_neg(RAnalEsil *esil) {
 	char *var = r_str_newf ("tmp%d", esil->stackptr);
 	r_strbuf_appendf (user->sb, "  %s = !%s;\n", var, src);
 	r_anal_esil_push (esil, var);
+	free (src);
 	free (var);
 	return true;
 }
@@ -176,6 +193,7 @@ static bool esil2c_goto(RAnalEsil *esil) {
 		return false;
 	}
 	r_strbuf_appendf (user->sb, "  goto addr_%08"PFMT64x"_%s;\n", esil->address, src);
+	free (src);
 	return true;
 }
 

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1618,6 +1618,7 @@ R_API int r_print_format_struct_size(RPrint *p, const char *f, int mode, int n) 
 	char *end, *args, *fmt;
 	int size = 0, tabsize = 0, i, idx = 0, biggest = 0, fmt_len = 0, times = 1;
 	bool tabsize_set = false;
+	bool free_fmt2 = true;
 	if (!f) {
 		return -1;
 	}
@@ -1627,8 +1628,12 @@ R_API int r_print_format_struct_size(RPrint *p, const char *f, int mode, int n) 
 	const char *fmt2 = p? sdb_get (p->formats, f, NULL): NULL;
 	if (!fmt2) {
 		fmt2 = f;
+		free_fmt2 = false;
 	}
 	char *o = strdup (fmt2);
+	if (free_fmt2) {
+		R_FREE (fmt2);
+	}
 	if (!o) {
 		return -1;
 	}


### PR DESCRIPTION
All leaks from `sys/sanitize.sh && r2r test/db/esil`.

The grepbuf change fixes a poorly-designed bandage fix. The removed block, when hit, caused a 20-byte memory leak when `buffer_len == 0 && buffer == NULL`.