### PR TITLE
Fix editor failing to delete tmp files

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3777,6 +3777,7 @@ R_API char *r_core_editor(const RCore *core, const char *file, const char *str) 
 		return NULL;
 	}
 	bool readonly = false;
+	bool tempfile = false;
 	if (file && *file != '*') {
 		name = strdup (file);
 		fd = r_sandbox_open (file, O_RDWR, 0644);
@@ -3788,6 +3789,7 @@ R_API char *r_core_editor(const RCore *core, const char *file, const char *str) 
 			}
 		}
 	} else {
+		tempfile = true;
 		fd = r_file_mkstemp (file, &name);
 	}
 	if (fd == -1) {
@@ -3827,7 +3829,7 @@ R_API char *r_core_editor(const RCore *core, const char *file, const char *str) 
 		if (len && ret[len - 1] == '\n') {
 			ret[len - 1] = 0; // chop
 		}
-		if (!file) {
+		if (tempfile) {
 			r_file_rm (name);
 		}
 	}


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

A temp file is created, through `r_file_mkstemp` if the file name is `NULL` or starts with `*`. The temp file should always be deleted but the delete check did not cover the case where the filename is starts with `*`.

This would cause commands like `toe` to leave temp files around needlessly.