### PR TITLE
Update r_file_mkstemp to work with sandbox

### DIFF
--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -55,7 +55,7 @@ R_API bool r_file_fexists(const char *fmt, ...) R_PRINTF_CHECK(1, 2);
 R_API char *r_file_slurp_line(const char *file, int line, int context);
 R_API char *r_file_slurp_lines(const char *file, int line, int count);
 R_API char *r_file_slurp_lines_from_bottom(const char *file, int line);
-R_API char *r_file_temp_suf(R_NULLABLE const char *prefix, R_NULLABLE const char *suf);
+R_API char *r_file_temp_ex(R_NULLABLE const char *prefix, R_NULLABLE const char *ex);
 R_API int r_file_mkstemp(const char *prefix, char **oname);
 R_API char *r_file_tmpdir(void);
 R_API char *r_file_readlink(const char *path);

--- a/libr/include/r_util/r_file.h
+++ b/libr/include/r_util/r_file.h
@@ -55,6 +55,7 @@ R_API bool r_file_fexists(const char *fmt, ...) R_PRINTF_CHECK(1, 2);
 R_API char *r_file_slurp_line(const char *file, int line, int context);
 R_API char *r_file_slurp_lines(const char *file, int line, int count);
 R_API char *r_file_slurp_lines_from_bottom(const char *file, int line);
+R_API char *r_file_temp_suf(R_NULLABLE const char *prefix, R_NULLABLE const char *suf);
 R_API int r_file_mkstemp(const char *prefix, char **oname);
 R_API char *r_file_tmpdir(void);
 R_API char *r_file_readlink(const char *path);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1164,7 +1164,7 @@ R_API char *r_file_temp_ex(R_NULLABLE const char *prefix, R_NULLABLE const char 
 
 static inline char *file_fmt_split(const char *fmt) {
 	if (R_STR_ISEMPTY (fmt)) {
-		return r_file_temp_suf (NULL, NULL);
+		return r_file_temp_ex (NULL, NULL);
 	}
 	char *name = NULL;
 	char *dup = strdup (fmt);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1149,7 +1149,7 @@ R_API char *r_file_temp(const char *prefix) {
 	return res;
 }
 
-R_API char *r_file_temp_suf(R_NULLABLE const char *prefix, R_NULLABLE const char *suf) {
+R_API char *r_file_temp_ex(R_NULLABLE const char *prefix, R_NULLABLE const char *ex) {
 	prefix = R_STR_ISEMPTY (prefix)? "r2": prefix;
 	suf = R_STR_ISEMPTY (suf)? "": suf;
 	char *path = r_file_tmpdir ();

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1150,7 +1150,7 @@ R_API char *r_file_temp(const char *prefix) {
 }
 
 R_API char *r_file_temp_suf(R_NULLABLE const char *prefix, R_NULLABLE const char *suf) {
-	prefix = R_STR_ISEMPTY (prefix)? "r2_": prefix;
+	prefix = R_STR_ISEMPTY (prefix)? "r2": prefix;
 	suf = R_STR_ISEMPTY (suf)? "": suf;
 	char *path = r_file_tmpdir ();
 	char *res = NULL;

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1172,8 +1172,8 @@ static inline char *file_fmt_split(const char *fmt) {
 		RList *splt = r_str_split_list (dup, "*", 2);
 		if (splt && r_list_length (splt)) {
 			char *pref = r_list_pop_head (splt);
-			char *suf = r_list_pop_head (splt);
-			name = r_file_temp_suf (pref, suf);
+			char *ex = r_list_pop_head (splt);
+			name = r_file_temp_ex (pref, ex);
 		}
 		r_list_free (splt);
 		free (dup);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1149,15 +1149,52 @@ R_API char *r_file_temp(const char *prefix) {
 	return res;
 }
 
+R_API char *r_file_temp_suf(R_NULLABLE const char *prefix, R_NULLABLE const char *suf) {
+	prefix = R_STR_ISEMPTY (prefix)? "r2_": prefix;
+	suf = R_STR_ISEMPTY (suf)? "": suf;
+	char *path = r_file_tmpdir ();
+	char *res = NULL;
+	if (path) {
+		ut64 t = r_time_now ();
+		res = r_str_newf ("%s/%s.%" PFMT64x "%s", path, prefix, t, suf);
+		free (path);
+	}
+	return res;
+}
+
+static inline char *file_fmt_split(const char *fmt) {
+	if (R_STR_ISEMPTY (fmt)) {
+		return r_file_temp_suf (NULL, NULL);
+	}
+	char *name = NULL;
+	char *dup = strdup (fmt);
+	int suflen = 0;
+	if (dup) {
+		RList *splt = r_str_split_list (dup, "*", 2);
+		if (splt && r_list_length (splt)) {
+			char *pref = r_list_pop_head (splt);
+			char *suf = r_list_pop_head (splt);
+			name = r_file_temp_suf (pref, suf);
+		}
+		r_list_free (splt);
+		free (dup);
+	}
+	return name;
+}
+
 R_API int r_file_mkstemp(R_NULLABLE const char *prefix, char **oname) {
 	int h = -1;
-	char *path = r_file_tmpdir ();
 	if (!prefix) {
 		prefix = "r2";
 	}
 #if __WINDOWS__
 	LPTSTR name = NULL;
+	char *path = r_file_tmpdir ();
+	if (!path) {
+		return -1;
+	}
 	LPTSTR path_ = r_sys_conv_utf8_to_win (path);
+	free (path);
 	LPTSTR prefix_ = r_sys_conv_utf8_to_win (prefix);
 
 	name = (LPTSTR)malloc (sizeof (TCHAR) * (MAX_PATH + 1));
@@ -1182,48 +1219,20 @@ err_r_file_mkstemp:
 	free (name);
 	free (path_);
 	free (prefix_);
+#elif __wasi__
+	// nothing to do for wasm, drops to return -1
 #else
-	char pfxx[1024];
-	const char *suffix = strchr (prefix, '*');
-
-	if (suffix) {
-		suffix++;
-		r_str_ncpy (pfxx, prefix, (size_t)(suffix - prefix));
-		prefix = pfxx;
-	} else {
-		suffix = "";
-	}
-
-	char *name = r_str_newf ("%s/r2.%s.XXXXXX%s", path, prefix, suffix);
-#if __wasi__
-	// nothing to do
-#else
-	mode_t mask = umask (S_IWGRP | S_IWOTH);
-	if (suffix && *suffix) {
-#if defined(__GLIBC__) && defined(__GLIBC_MINOR__) && 2 <= __GLIBC__ && 19 <= __GLIBC__MINOR__
-		h = mkstemps (name, strlen (suffix));
-#else
-		char *const xpos = strrchr (name, 'X');
-		const char c = (char)(NULL != xpos ? *(xpos + 1) : 0);
-		if (0 != c) {
-			xpos[1] = 0;
-			h = mkstemp (name);
-			xpos[1] = c;
+	char *name = file_fmt_split (prefix);
+	if (name) {
+		int perm = RDWR_FLAGS | O_CREAT | O_EXCL | O_BINARY;
+		h = r_sandbox_open (name, perm, 0644);
+		if (h != -1) {
+			*oname = name;
 		} else {
-			h = -1;
+			free (name);
 		}
-#endif
-	} else {
-		h = mkstemp (name);
 	}
-	umask (mask);
 #endif
-	if (oname) {
-		*oname = (h!=-1)? strdup (name): NULL;
-	}
-	free (name);
-#endif
-	free (path);
 	return h;
 }
 

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1168,7 +1168,6 @@ static inline char *file_fmt_split(const char *fmt) {
 	}
 	char *name = NULL;
 	char *dup = strdup (fmt);
-	int suflen = 0;
 	if (dup) {
 		RList *splt = r_str_split_list (dup, "*", 2);
 		if (splt && r_list_length (splt)) {

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1151,12 +1151,12 @@ R_API char *r_file_temp(const char *prefix) {
 
 R_API char *r_file_temp_ex(R_NULLABLE const char *prefix, R_NULLABLE const char *ex) {
 	prefix = R_STR_ISEMPTY (prefix)? "r2": prefix;
-	suf = R_STR_ISEMPTY (suf)? "": suf;
+	ex = R_STR_ISEMPTY (ex)? "": ex;
 	char *path = r_file_tmpdir ();
 	char *res = NULL;
 	if (path) {
 		ut64 t = r_time_now ();
-		res = r_str_newf ("%s/%s.%" PFMT64x "%s", path, prefix, t, suf);
+		res = r_str_newf ("%s/%s.%" PFMT64x "%s", path, prefix, t, ex);
 		free (path);
 	}
 	return res;


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This simplifies `r_file_mkstemp` and fixes a couple bugs. If this is accepted then #19598 can just be closed.

Bugs:
On my system the macro `defined(__GLIBC__) && defined(__GLIBC_MINOR__) && 2 <= __GLIBC__ && 19 <= __GLIBC__MINOR__` does not seem to correctly detect the presence of `mkstemps`. 

The fallback to `mkstemp` causes bugs when a suffix is used. Given `r2.XXXXXX.h`, the alg truncates the name to `r2.XXXXXX` to be acceptable to `mkstemp`. This then returns a file descriptor for `r2.XXXXXX`. Afterward the alg ads the suffix back in, returning a filename of `r2.XXXXXX.h`. So running `toe struct.foo` will populate `r2.XXXXXX` file with the known `foo` struct and open the new file `r2.XXXXXX.h` in the text editor.

Also, previously the sandbox was not used for file creation here. This should fix that.