### PR TITLE
Fix resize tests

### DIFF
--- a/test/db/io/resize
+++ b/test/db/io/resize
@@ -12,7 +12,7 @@ i~^size[1]
 !rm ${R2_FILE}
 EOF
 EXPECT=<<EOF
-0
+0x0
 0xa
 0x4
 0xa
@@ -33,7 +33,7 @@ psz
 !rm ${R2_FILE}
 EOF
 EXPECT=<<EOF
-0
+0x0
 0x3
 0xb
 hello world


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

Looks like `i` on an empty file returns size `0x0` instead of `0`. This was causing the test two tests to fail. So I updated the tests because I think `0x0` is more consistent.
