### PR TITLE
x86-16 bit disasm print filter more tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,26 +78,10 @@ jobs:
         sudo apt install gperf
     - name: Installing with symlinks
       run: |
-        export CFLAGS="-O0 -Werror -Wno-unused-result -Wno-stringop-truncation"
+        export CFLAGS="-O2 -Werror -Wno-unused-result -Wno-stringop-truncation"
         sys/install.sh
     - name: Running tests
       run: r2r test/db/cmd
-  build-syscapstone:
-    name: linux-sys-capstone
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Installing capstone
-      run: |
-        git clone --branch next --single-branch --depth=1 https://github.com/capstone-engine/capstone
-        cd capstone && ( git log | head ) && sh make.sh && sudo make install
-    - name: Installing r2 with sys-capstone
-      run: |
-        export CFLAGS="-O0 -Werror -Wno-unused-result -Wno-stringop-truncation"
-        sys/install.sh
-    - name: Checking if capstone was cloned
-      run: if [ -d shlr/capstone ]; then echo "Capstone wasnt supposed to be cloned"; return 1; fi
   build-resymlink:
     name: linux-acr-resymlink
     runs-on: ubuntu-20.04
@@ -106,7 +90,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Installing with symlinks
       run: |
-        export CFLAGS="-O0 -Werror -Wno-unused-result -Wno-stringop-truncation"
+        export CFLAGS="-O2 -Werror -Wno-unused-result -Wno-stringop-truncation"
         sys/install.sh
     - name: Uninstalling
       run: sudo make uninstall
@@ -176,7 +160,7 @@ jobs:
         git config --global pull.rebase false
         git clone --depth 1 . "spa ces"
         cd "spa ces"
-        export CFLAGS="-O0 -Werror -Wno-unused-result -Wno-stringop-truncation"
+        export CFLAGS="-O2 -Werror -Wno-unused-result -Wno-stringop-truncation"
         meson --prefix="/tmp/r 2" build
         ninja -C build
         ninja -C build install

--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -139,7 +139,6 @@ R_API RAnal *r_anal_new(void) {
 			r_anal_add (anal, anal_static_plugins[i]);
 		}
 	}
-	R_DIRTY (anal);
 	return anal;
 }
 
@@ -381,6 +380,7 @@ R_API ut8 *r_anal_mask(RAnal *anal, int size, const ut8 *data, ut64 at) {
 	}
 
 	r_anal_op_free (op);
+
 	return ret;
 }
 
@@ -397,7 +397,6 @@ R_API void r_anal_trace_bb(RAnal *anal, ut64 addr) {
 			}
 		}
 	}
-	R_DIRTY (anal);
 }
 
 R_API RList* r_anal_get_fcns(RAnal *anal) {
@@ -554,10 +553,7 @@ R_API bool r_anal_noreturn_add(RAnal *anal, const char *name, ut64 addr) {
 		}
 		tmp_name = fcn ? fcn->name: fi->name;
 		if (fcn) {
-			if (!fcn->is_noreturn) {
-  				fcn->is_noreturn = true;
-				R_DIRTY (anal);
-			}
+			fcn->is_noreturn = true;
 		}
 	}
 	if (r_type_func_exist (TDB, tmp_name)) {
@@ -749,7 +745,6 @@ R_API void r_anal_add_import(RAnal *anal, const char *imp) {
 	if (!cimp) {
 		return;
 	}
-	R_DIRTY (anal);
 	r_list_push (anal->imports, cimp);
 }
 
@@ -758,7 +753,6 @@ R_API void r_anal_remove_import(RAnal *anal, const char *imp) {
 	const char *eimp;
 	r_list_foreach (anal->imports, it, eimp) {
 		if (!strcmp (eimp, imp)) {
-			R_DIRTY (anal);
 			r_list_delete (anal->imports, it);
 			return;
 		}
@@ -766,6 +760,5 @@ R_API void r_anal_remove_import(RAnal *anal, const char *imp) {
 }
 
 R_API void r_anal_purge_imports(RAnal *anal) {
-	R_DIRTY(anal);
 	r_list_purge (anal->imports);
 }

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -175,7 +175,6 @@ R_API RAnalVar *r_anal_function_set_var(RAnalFunction *fcn, int delta, char kind
 		free (var->regname);
 		free (var->type);
 	}
-	R_DIRTY (fcn->anal);
 	var->name = strdup (name);
 	var->regname = reg? strdup (reg->name): NULL; // TODO: no strdup here? pool? or not keep regname at all?
 	var->type = strdup (type);
@@ -194,7 +193,6 @@ R_API bool r_anal_function_set_var_prot(RAnalFunction *fcn, RList *l) {
 			return false;
 		}
 	}
-	R_DIRTY (fcn->anal);
 	return true;
 }
 
@@ -682,7 +680,6 @@ R_API void r_anal_var_remove_access_at(RAnalVar *var, ut64 address) {
 		RPVector *inst_accesses = ht_up_find (var->fcn->inst_vars, (ut64)offset, NULL);
 		r_pvector_remove_data (inst_accesses, var);
 	}
-	R_DIRTY (var->fcn->anal);
 }
 
 R_API void r_anal_var_clear_accesses(RAnalVar *var) {
@@ -700,7 +697,6 @@ R_API void r_anal_var_clear_accesses(RAnalVar *var) {
 		}
 	}
 	r_vector_clear (&var->accesses);
-	R_DIRTY (var->fcn->anal);
 }
 
 R_API RAnalVarAccess *r_anal_var_get_access_at(RAnalVar *var, ut64 addr) {

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -111,7 +111,6 @@ R_API bool r_anal_xrefs_set(RAnal *anal, ut64 from, ut64 to, const RAnalRefType 
 	}
 	setxref (anal->dict_xrefs, to, from, type);
 	setxref (anal->dict_refs, from, to, type);
-	R_DIRTY (anal);
 	return true;
 }
 
@@ -130,7 +129,6 @@ R_API bool r_anal_xrefs_deln(RAnal *anal, ut64 from, ut64 to, const RAnalRefType
 		ht_up_delete (d, from);
 	}
 #endif
-	R_DIRTY (anal);
 	return true;
 }
 
@@ -142,7 +140,6 @@ R_API bool r_anal_xref_del(RAnal *anal, ut64 from, ut64 to) {
 	res |= r_anal_xrefs_deln (anal, from, to, R_ANAL_REF_TYPE_CALL);
 	res |= r_anal_xrefs_deln (anal, from, to, R_ANAL_REF_TYPE_DATA);
 	res |= r_anal_xrefs_deln (anal, from, to, R_ANAL_REF_TYPE_STRING);
-	R_DIRTY (anal);
 	return res;
 }
 

--- a/libr/asm/p/asm_arm_cs.c
+++ b/libr/asm/p/asm_arm_cs.c
@@ -115,11 +115,11 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	static int obits = 32;
 	bool disp_hash = a->immdisp;
 	cs_insn* insn = NULL;
+	cs_mode mode = 0;
 	int ret, n = 0;
 	bool found = false;
 	ut64 itcond;
 
-	cs_mode mode = 0;
 	mode |= (a->bits == 16)? CS_MODE_THUMB: CS_MODE_ARM;
 	mode |= (a->big_endian)? CS_MODE_BIG_ENDIAN: CS_MODE_LITTLE_ENDIAN;
 	if (mode != omode || a->bits != obits) {
@@ -133,8 +133,10 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 		if (strstr (a->cpu, "cortex")) {
 			mode |= CS_MODE_MCLASS;
 		}
-		if (a->bits != 64 && strstr (a->cpu, "v8")) {
-			mode |= CS_MODE_V8;
+		if (a->bits != 64) {
+			if (strstr (a->cpu, "v8")) {
+				mode |= CS_MODE_V8;
+			}
 		}
 	}
 	if (a->features && a->bits != 64) {
@@ -225,7 +227,7 @@ static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 static int assemble(RAsm *a, RAsmOp *op, const char *buf) {
 	const bool is_thumb = (a->bits == 16);
 	int opsize;
-	ut32 opcode = UT32_MAX;
+	ut32 opcode;
 	if (a->bits == 64) {
 		if (!arm64ass (buf, a->pc, &opcode)) {
 			return -1;

--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -397,6 +397,7 @@ R_API RConfigNode* r_config_set(RConfig *cfg, const char *name, const char *valu
 	RConfigNode *node = NULL;
 	char *ov = NULL;
 	ut64 oi;
+
 	r_return_val_if_fail (cfg && cfg->ht, NULL);
 	r_return_val_if_fail (!IS_NULLSTR (name), NULL);
 
@@ -415,7 +416,6 @@ R_API RConfigNode* r_config_set(RConfig *cfg, const char *name, const char *valu
 		} else {
 			node->value = strdup ("");
 		}
-		R_DIRTY (cfg);
 		if (r_config_node_is_bool (node)) {
 			bool b = r_str_is_true (value);
 			node->i_value = b;
@@ -504,7 +504,6 @@ R_API RConfigNode* r_config_node_desc(RConfigNode *node, const char *desc) {
 R_API bool r_config_rm(RConfig *cfg, const char *name) {
 	RConfigNode *node = r_config_node_get (cfg, name);
 	if (node) {
-		R_DIRTY (cfg);
 		ht_pp_delete (cfg->ht, node->name);
 		r_list_delete_data (cfg->nodes, node);
 		return true;
@@ -536,7 +535,6 @@ R_API RConfigNode* r_config_set_i(RConfig *cfg, const char *name, const ut64 i) 
 	char buf[128], *ov = NULL;
 	r_return_val_if_fail (cfg && name, NULL);
 	RConfigNode *node = r_config_node_get (cfg, name);
-	R_DIRTY (cfg);
 	if (node) {
 		if (r_config_node_is_ro (node)) {
 			node = NULL;
@@ -676,7 +674,6 @@ R_API RConfig* r_config_new(void *user) {
 	cfg->num = NULL;
 	cfg->lock = false;
 	cfg->cb_printf = (void *) printf;
-	R_DIRTY (cfg);
 	return cfg;
 }
 
@@ -694,7 +691,6 @@ R_API RConfig* r_config_clone(RConfig *cfg) {
 	}
 	c->lock = cfg->lock;
 	c->cb_printf = cfg->cb_printf;
-	R_DIRTY (c);
 	return c;
 }
 

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3658,8 +3658,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("prj.zip", "false", "Use ZIP format for project files");
 	SETBPREF ("prj.gpg", "false", "TODO: Encrypt project with GnuPGv2");
 	SETBPREF ("prj.sandbox", "false", "Sandbox r2 while loading project files");
-	SETBPREF ("prj.alwasyprompt", "false", "Even when the project is already\
-			saved, ask the user to save the project when qutting");
 
 	/* cfg */
 	n = SETCB ("cfg.charset", "", &cb_cfgcharset, "Specify encoding to use when printing strings");

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -139,12 +139,6 @@ R_API int r_core_project_list(RCore *core, int mode) {
 	return 0;
 }
 
-R_API void r_core_project_undirty(RCore *core) {
-	core->config->is_dirty = false;
-	core->anal->is_dirty = false;
-	core->flags->is_dirty = false;
-}
-
 R_API int r_core_project_delete(RCore *core, const char *prjfile) {
 	if (r_sandbox_enable (0)) {
 		eprintf ("Cannot delete project in sandbox mode\n");
@@ -383,9 +377,6 @@ R_API bool r_core_project_open(RCore *core, const char *prj_path) {
 	ret = r_core_project_load (core, prj_name, prj_script);
 	free (prj_name);
 	free (prj_script);
-	if (ret)  {
-		r_core_project_undirty(core);
-	}
 	return ret;
 }
 
@@ -706,7 +697,6 @@ R_API bool r_core_project_save(RCore *core, const char *prj_name) {
 	}
 	free (script_path);
 	r_config_set (core->config, "prj.name", prj_name);
-	r_core_project_undirty(core);
 	return ret;
 }
 
@@ -719,7 +709,42 @@ R_API char *r_core_project_notes_file(RCore *core, const char *prj_name) {
 }
 
 R_API bool r_core_project_is_saved(RCore *core) {
-	return !R_IS_DIRTY (core->config)
-		&& !R_IS_DIRTY (core->anal)
-		&& !R_IS_DIRTY (core->flags);
+	bool ret;
+	char *saved_dat, *tmp_dat;
+	char *pd = r_str_newf ("%s" R_SYS_DIR "%s",
+		r_config_get (core->config, "dir.projects"),
+		r_config_get (core->config, "prj.name"));
+	if (!pd) {
+		return false;
+	}
+	char *sp = r_str_newf ("%s" R_SYS_DIR "%s", pd, "rc.r2");
+	if (!sp) {
+		free (pd);
+		return false;
+	}
+	char *tsp = r_str_newf ("%s" R_SYS_DIR "tmp", pd);
+	//horrible code follows:
+	free (pd);
+	if (!tsp) {
+		free (sp);
+		return false;
+	}
+	r_core_project_save_script (core, tsp, R_CORE_PRJ_ALL);
+	saved_dat = r_file_slurp (sp, 0);
+	free (sp);
+	if (!saved_dat) {
+		free (tsp);
+		return false;
+	}
+	//Would be better if I knew how to map files in mem in windows
+	tmp_dat = r_file_slurp (tsp, 0);
+	r_file_rm (tsp);
+	free (tsp);
+	if (!tmp_dat) {
+		return false;
+	}
+	ret = !strcmp (tmp_dat, saved_dat);
+	free (tmp_dat);
+	free (saved_dat);
+	return ret;
 }

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -94,7 +94,6 @@ static void remove_offsetmap(RFlag *f, RFlagItem *item) {
 		if (r_list_empty (flags->flags)) {
 			r_skiplist_delete (f->by_off, flags);
 		}
-		R_DIRTY (f);
 	}
 }
 
@@ -155,7 +154,6 @@ static bool update_flag_item_offset(RFlag *f, RFlagItem *item, ut64 newoff, bool
 		}
 
 		r_list_append (flagsAtOffset->flags, item);
-		R_DIRTY (f);
 		return true;
 	}
 
@@ -178,7 +176,6 @@ static bool update_flag_item_name(RFlag *f, RFlagItem *item, const char *newname
 		: ht_pp_insert (f->ht_name, fname, item);
 	if (res) {
 		set_name (item, fname);
-		R_DIRTY (f);
 		return true;
 	}
 	free (fname);
@@ -238,7 +235,6 @@ R_API RFlag *r_flag_new(void) {
 	f->ht_name = ht_pp_new (NULL, ht_free_flag, NULL);
 	f->by_off = r_skiplist_new (flag_skiplist_free, flag_skiplist_cmp);
 	new_spaces (f);
-	R_DIRTY (f);
 	return f;
 }
 
@@ -723,7 +719,6 @@ R_API RFlagItem *r_flag_set_next(RFlag *f, const char *name, ut64 off, ut32 size
 			RFlagItem *fi = r_flag_set (f, newName, off, size);
 			if (fi) {
 				free (newName);
-				R_DIRTY (f);
 				return fi;
 			}
 		}
@@ -739,7 +734,6 @@ R_API RFlagItem *r_flag_set_inspace(RFlag *f, const char *space, const char *nam
 	if (space) {
 		r_flag_space_pop (f);
 	}
-	R_DIRTY (f);
 	return fi;
 }
 
@@ -839,7 +833,6 @@ R_API bool r_flag_unset(RFlag *f, RFlagItem *item) {
 	r_return_val_if_fail (f && item, false);
 	remove_offsetmap (f, item);
 	ht_pp_delete (f->ht_name, item->name);
-	R_DIRTY (f);
 	return true;
 }
 
@@ -877,7 +870,6 @@ R_API int r_flag_unset_glob(RFlag *f, const char *glob) {
 
 	struct unset_foreach_t u = { .f = f, .n = 0 };
 	r_flag_foreach_glob (f, glob, unset_foreach, &u);
-	R_DIRTY (f);
 	return u.n;
 }
 
@@ -886,7 +878,6 @@ R_API int r_flag_unset_glob(RFlag *f, const char *glob) {
 R_API bool r_flag_unset_name(RFlag *f, const char *name) {
 	r_return_val_if_fail (f, false);
 	RFlagItem *item = ht_pp_find (f->ht_name, name, NULL);
-	R_DIRTY (f);
 	return item && r_flag_unset (f, item);
 }
 
@@ -898,7 +889,6 @@ R_API void r_flag_unset_all(RFlag *f) {
 	r_skiplist_purge (f->by_off);
 	r_spaces_fini (&f->spaces);
 	new_spaces (f);
-	R_DIRTY (f);
 }
 
 struct flag_relocate_t {
@@ -933,6 +923,7 @@ R_API int r_flag_relocate(RFlag *f, ut64 off, ut64 off_mask, ut64 to) {
 		.to = to,
 		.n = 0
 	};
+
 	r_flag_foreach (f, flag_relocate_foreach, &u);
 	return u.n;
 }

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -684,7 +684,6 @@ typedef struct r_anal_t {
 	RStrConstPool constpool;
 	RList *leaddrs;
 	char *pincmd;
-	R_DIRTY_VAR;
 } RAnal;
 
 typedef enum r_anal_addr_hint_type_t {
@@ -2188,8 +2187,7 @@ R_API bool r_anal_global_del(RAnal *anal, ut64 addr);
 R_API bool r_anal_global_retype(RAnal *anal, ut64 addr, const char *new_type);
 R_API bool r_anal_global_rename(RAnal *anal, ut64 addr, const char *new_name);
 R_API const char *r_anal_global_get_type(RAnal *anal, ut64 addr);
-/*return anal->is_dirty and sets it to false*/
-R_API bool r_anal_is_dirty(RAnal *anal);
+
 /* plugin pointers */
 extern RAnalPlugin r_anal_plugin_null;
 extern RAnalPlugin r_anal_plugin_6502;

--- a/libr/include/r_config.h
+++ b/libr/include/r_config.h
@@ -50,8 +50,6 @@ typedef struct r_config_t {
 	RList *nodes;
 	HtPP *ht;
 	bool lock;
-	/*was the struct modified after the last project save*/
-	R_DIRTY_VAR;
 } RConfig;
 
 typedef struct r_config_hold_t {

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -714,7 +714,7 @@ R_API bool r_core_project_save_script(RCore *core, const char *file, int opts);
 R_API bool r_core_project_save(RCore *core, const char *file);
 R_API char *r_core_project_name(RCore *core, const char *file);
 R_API char *r_core_project_notes_file(RCore *core, const char *file);
-R_API void r_core_project_undirty(RCore *core);
+
 R_API char *r_core_sysenv_begin(RCore *core, const char *cmd);
 R_API void r_core_sysenv_end(RCore *core, const char *cmd);
 

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -59,7 +59,6 @@ typedef struct r_flag_t {
 	PrintfCallback cb_printf;
 	RList *zones;
 	ut64 mask;
-	R_DIRTY_VAR;
 } RFlag;
 
 /* compile time dependency */

--- a/libr/include/r_util.h
+++ b/libr/include/r_util.h
@@ -86,10 +86,9 @@ extern "C" {
 #endif
 
 R_LIB_VERSION_HEADER(r_util);
+
 #ifdef __cplusplus
 }
 #endif
-#define R_DIRTY(x) (x)->is_dirty = true
-#define R_IS_DIRTY(x) (x)->is_dirty
-#define R_DIRTY_VAR bool is_dirty
+
 #endif

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1458,7 +1458,6 @@ R_API int r_main_radare2(int argc, const char **argv) {
 				r_core_cmd0 (r, "aeip");
 			}
 		}
-		r_core_project_undirty (r);
 		for (;;) {
 			if (!r_core_prompt_loop (r)) {
 				quietLeak = true;
@@ -1502,7 +1501,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 
 				const char *prj = r_config_get (r->config, "prj.name");
 				if (R_STR_ISNOTEMPTY (prj)) {
-					if (r_core_project_is_saved (r) && !r_config_get_b (r->config, "prj.alwaysprompt")) {
+					if (r_core_project_is_saved (r)) {
 						break;
 					}
 					if (no_question_save) {

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -39,7 +39,7 @@ ifeq ($(USE_CS4),1)
 CS_TIP=a7cac8352f7397aa73bb2e2dcc1b6cdb2e1b8461
 CS_BRA=v4
 else
-CS_TIP=6656bcb63ab4e87dc6079bd6b6b12cc8dd9b2ad8
+CS_TIP=f049e65f596bf8b1cbf5f2371067e34715ef1764
 CS_BRA=next
 endif
 ifeq ($(CS_COMMIT_ARCHIVE),1)

--- a/shlr/capstone-patches/v5/fix-x86-16-segoff.patch
+++ b/shlr/capstone-patches/v5/fix-x86-16-segoff.patch
@@ -1,0 +1,36 @@
+diff --git a/suite/synctools/tablegen/X86/X86InstrControl.td b/suite/synctools/tablegen/X86/X86InstrControl.td
+index 7121b0c..3271b43 100644
+--- a/suite/synctools/tablegen/X86/X86InstrControl.td
++++ b/suite/synctools/tablegen/X86/X86InstrControl.td
+@@ -250,11 +250,11 @@ let isCall = 1 in
+     let Predicates = [Not64BitMode], AsmVariantName = "att" in {
+       def FARCALL16i  : Iseg16<0x9A, RawFrmImm16, (outs),
+                                (ins i16imm:$off, i16imm:$seg),
+-                               "lcall{w}\t$seg, $off", []>,
++                               "lcall{w}\t$seg : $off", []>,
+                                OpSize16, Sched<[WriteJump]>;
+       def FARCALL32i  : Iseg32<0x9A, RawFrmImm16, (outs),
+                                (ins i32imm:$off, i16imm:$seg),
+-                               "lcall{l}\t$seg, $off", []>,
++                               "lcall{l}\t$seg : $off", []>,
+                                OpSize32, Sched<[WriteJump]>;
+     }
+ 
+diff --git a/suite/synctools/tablegen/X86/back/X86InstrControl.td b/suite/synctools/tablegen/X86/back/X86InstrControl.td
+index 7121b0c..3271b43 100644
+--- a/suite/synctools/tablegen/X86/back/X86InstrControl.td
++++ b/suite/synctools/tablegen/X86/back/X86InstrControl.td
+@@ -250,11 +250,11 @@ let isCall = 1 in
+     let Predicates = [Not64BitMode], AsmVariantName = "att" in {
+       def FARCALL16i  : Iseg16<0x9A, RawFrmImm16, (outs),
+                                (ins i16imm:$off, i16imm:$seg),
+-                               "lcall{w}\t$seg, $off", []>,
++                               "lcall{w}\t$seg : $off", []>,
+                                OpSize16, Sched<[WriteJump]>;
+       def FARCALL32i  : Iseg32<0x9A, RawFrmImm16, (outs),
+                                (ins i32imm:$off, i16imm:$seg),
+-                               "lcall{l}\t$seg, $off", []>,
++                               "lcall{l}\t$seg : $off", []>,
+                                OpSize32, Sched<[WriteJump]>;
+     }
+ 

--- a/shlr/capstone.sh
+++ b/shlr/capstone.sh
@@ -70,9 +70,6 @@ get_capstone() {
 	if [ -d capstone ]; then
 		return
 	fi
-	if [ -f capstone ]; then
-		rm -f capstone
-	fi
 	git_clone || fatal_msg 'Clone failed'
 	cd capstone || fatal_msg 'Failed to chdir'
 	parse_capstone_tip

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -20,7 +20,7 @@ if not capstone_dep.found() or not get_option('use_sys_capstone')
     patches_files = []
     # NOTE: when you update CS_TIP or CS_BRA, also update them in shlr/Makefile
     if capstone_version == 'v5'
-      CS_TIP = '6656bcb63ab4e87dc6079bd6b6b12cc8dd9b2ad8'
+      CS_TIP = 'f049e65f596bf8b1cbf5f2371067e34715ef1764'
       CS_BRA = 'next'
       patches_files = [
         'fix-x86-16.patch',

--- a/sys/install.sh
+++ b/sys/install.sh
@@ -118,30 +118,13 @@ else
 	fi
 fi
 
-NEED_CAPSTONE=1
 pkg-config --cflags capstone 2>&1 > /dev/null
 if [ $? = 0 ]; then
-	pkg-config --atleast-version=5.0.0 capstone 2>/dev/null
-	if [ $? = 0 ]; then
-		pkg-config --variable=archs capstone 2> /dev/null | grep -q riscv
-		if [ $? = 0 ]; then
-			export CFGARG="--with-syscapstone"
-			NEED_CAPSTONE=0
-			echo "Note: Using system-wide-capstone"
-		else
-			echo "Warning: Your system-wide capstone dont have enough archs"
-		fi
-	else
-		echo "Warning: Your system-wide capstone is too old for me"
-	fi
-else
-	echo "Warning: Cannot find system wide capstone"
+	export CFGARG="--with-syscapstone"
 fi
 
-if [ "$NEED_CAPSTONE" = 1 ]; then
-	if [ ! -d shlr/capstone ]; then
-		./preconfigure
-	fi
+if [ ! -d shlr/capstone ]; then
+	./preconfigure
 fi
 
 if [ "${M32}" = 1 ]; then

--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -150,112 +150,14 @@ e asm.bits=16
 wx 9090558bec9a0d0000005dc390558bec5dc3
 af funcA @ 0xd
 af funcB @ 0x2
-pd 1 @ 0x5
+pdf @ 0x2
 EOF
 EXPECT=<<EOF
+/ 10: funcB ();
+|           0000:0002     55             push bp
+|           0000:0003     8bec           mov bp, sp
 |           0000:0005     9a0d000000     lcall funcA
+|           0000:000a     5d             pop bp
+\           0000:000b     c3             ret
 EOF
 RUN
-
-NAME=x86-16 seg:off lcall addr replace with non-analysed func
-FILE=-
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-wx 9090558bec9a0d0000005dc390558bec5dc3
-pd 1 @ 0x5
-EOF
-EXPECT=<<EOF
-            0000:0005     9a0d000000     lcall 0:0xd
-EOF
-RUN
-
-NAME=x86-16 seg:off ljmp addr replace with non-analysed func
-FILE=-
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-wx 9090558becea0d0000005dc390558bec5dc3
-pd 1 @ 0x5
-EOF
-EXPECT=<<EOF
-        ,=< 0000:0005     ea0d000000     ljmp 0:0xd
-EOF
-RUN
-
-NAME=r86-16 seg:off ljmp addr replace with analysed func
-FILE=-
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-wx 9090558becea0d0000005dc390558bec5dc3
-af funcA @ 0xd
-pd 1 @ 0x5
-EOF
-EXPECT=<<EOF
-        ,=< 0000:0005     ea0d000000     ljmp funcA
-EOF
-RUN
-
-NAME=x86-16 seg:off ljmp addr replace with non-analysed func higher segment
-FILE=malloc://2048
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-e asm.seggrn=8
-s 0x400
-wx 9090558becea000004005dc3
-pd 1 @ 0x405
-EOF
-EXPECT=<<EOF
-        `=< 0000:0405     ea00000400     ljmp 4:0
-EOF
-RUN
-
-NAME=x86-16 seg:off ljmp addr replace with analysed func higher segment
-FILE=malloc://2048
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-e asm.seggrn=8
-s 0x400
-wx 558becea000004005dc3
-af funcA @ 0x400
-pd 1 @ 0x403
-EOF
-EXPECT=<<EOF
-\       `=< 0000:0403     ea00000400     ljmp funcA
-EOF
-RUN
-
-NAME=x86-16 seg:off lcall addr replace with non-analysed func higher segment
-FILE=malloc://2048
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-e asm.seggrn=8
-s 0x400
-wx 9090558bec9a000004005dc3
-pd 1 @ 0x405
-EOF
-EXPECT=<<EOF
-            0000:0405     9a00000400     lcall 4:0
-EOF
-RUN
-
-NAME=x86-16 seg:off lcall addr replace with analysed func higher segment
-FILE=malloc://2048
-CMDS=<<EOF
-e asm.arch=x86
-e asm.bits=16
-e asm.seggrn=8
-s 0x400
-wx 558bec9a000004005dc3
-af funcA @ 0x400
-pd 1 @ 0x403
-EOF
-EXPECT=<<EOF
-|           0000:0403     9a00000400     lcall funcA
-EOF
-RUN
-

--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -150,14 +150,112 @@ e asm.bits=16
 wx 9090558bec9a0d0000005dc390558bec5dc3
 af funcA @ 0xd
 af funcB @ 0x2
-pdf @ 0x2
+pd 1 @ 0x5
 EOF
 EXPECT=<<EOF
-/ 10: funcB ();
-|           0000:0002     55             push bp
-|           0000:0003     8bec           mov bp, sp
 |           0000:0005     9a0d000000     lcall funcA
-|           0000:000a     5d             pop bp
-\           0000:000b     c3             ret
 EOF
 RUN
+
+NAME=x86-16 seg:off lcall addr replace with non-analysed func
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+wx 9090558bec9a0d0000005dc390558bec5dc3
+pd 1 @ 0x5
+EOF
+EXPECT=<<EOF
+            0000:0005     9a0d000000     lcall 0:0xd
+EOF
+RUN
+
+NAME=x86-16 seg:off ljmp addr replace with non-analysed func
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+wx 9090558becea0d0000005dc390558bec5dc3
+pd 1 @ 0x5
+EOF
+EXPECT=<<EOF
+        ,=< 0000:0005     ea0d000000     ljmp 0:0xd
+EOF
+RUN
+
+NAME=r86-16 seg:off ljmp addr replace with analysed func
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+wx 9090558becea0d0000005dc390558bec5dc3
+af funcA @ 0xd
+pd 1 @ 0x5
+EOF
+EXPECT=<<EOF
+        ,=< 0000:0005     ea0d000000     ljmp funcA
+EOF
+RUN
+
+NAME=x86-16 seg:off ljmp addr replace with non-analysed func higher segment
+FILE=malloc://2048
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+e asm.seggrn=8
+s 0x400
+wx 9090558becea000004005dc3
+pd 1 @ 0x405
+EOF
+EXPECT=<<EOF
+        `=< 0000:0405     ea00000400     ljmp 4:0
+EOF
+RUN
+
+NAME=x86-16 seg:off ljmp addr replace with analysed func higher segment
+FILE=malloc://2048
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+e asm.seggrn=8
+s 0x400
+wx 558becea000004005dc3
+af funcA @ 0x400
+pd 1 @ 0x403
+EOF
+EXPECT=<<EOF
+\       `=< 0000:0403     ea00000400     ljmp funcA
+EOF
+RUN
+
+NAME=x86-16 seg:off lcall addr replace with non-analysed func higher segment
+FILE=malloc://2048
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+e asm.seggrn=8
+s 0x400
+wx 9090558bec9a000004005dc3
+pd 1 @ 0x405
+EOF
+EXPECT=<<EOF
+            0000:0405     9a00000400     lcall 4:0
+EOF
+RUN
+
+NAME=x86-16 seg:off lcall addr replace with analysed func higher segment
+FILE=malloc://2048
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=16
+e asm.seggrn=8
+s 0x400
+wx 558bec9a000004005dc3
+af funcA @ 0x400
+pd 1 @ 0x403
+EOF
+EXPECT=<<EOF
+|           0000:0403     9a00000400     lcall funcA
+EOF
+RUN
+


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

added more tests for x86-16 bit disasm filter. unfortunatelly not all pass so I think that there is still something wrong with parsing.
in general when seg:off format is used in disasm and seg is = 0 then disassembly is wrong.

seg = 0 (wrong)
```
-        ,=< 0000:0005     ea0d000000     ljmp funcA
+        ,=< 0000:0005     ea0d000000     ljmp 0:funcA
```
```
-|           0000:0005     9a0d000000     lcall funcA
+|           0000:0005     9a0d000000     lcall 0:                      ; funcA
```

seg > 0 (good)
```
\       `=< 0000:0403      ea00000400     ljmp funcA
```
```
\           0000:0403      9a00000400     lcall funcA
```

this is probably because some previous replacement (before filter function) see that part of assembly mnemonic is a valid address and replace it ignoring seg:off format.

in general the filter function is now not a problem because the input (data argument) to filter function (libr/parse/filter.c) is like that (in case of 0 seg) `ljmp 0:funcA` or `lcall 0:funcA`

I will try fix that and will send a PR (this time in correct way I guess :smile:)