### PR TITLE
Fix #15473 - Align meta dwords in the middle of instructions ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3061,7 +3061,7 @@ static bool ds_print_data_type(RDisasmState *ds, const ut8 *obuf, int ib, int si
 	if (ds->asm_hint_imm) { // thats not really an imm.. but well dont add more hints for now
 		(void) ds_print_shortcut (ds, n, ds->asm_hint_pos);
 	}
-	if (r_config_get_i (core->config, "asm.marks")) {
+	if (r_config_get_b (core->config, "asm.marks")) {
 		r_cons_printf ("  ");
 		int q = core->print->cur_enabled &&
 			ds->cursor >= ds->index &&
@@ -3243,6 +3243,11 @@ static bool ds_print_meta_infos(RDisasmState *ds, ut8* buf, int len, int idx, in
 			int size = mi_size;
 			ut8 *b = malloc (mi_size);
 			if (b) {
+				int delta = ds->at - node->start;
+				if (delta > 0) {
+					ds->at -= delta;
+					r_cons_printf ("-%d ", delta);
+				}
 				r_io_read_at (core->io, ds->at, b, mi_size);
 				if (size > 0 && !ds_print_data_type (ds, b, ds->hint? ds->hint->immbase: 0, mi_size)) {
 					if (size > delta) {

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -1,3 +1,18 @@
+NAME=Cd4middle
+FILE=-
+CMDS=<<EOF
+wx 01002143547601020304
+Cd 4 4 @ 4
+pd 4
+EOF
+EXPECT=<<EOF
+            0x00000000      0100           add dword [rax], eax
+            0x00000002      214354         and dword [rbx + 0x54], eax
+        ,=< 0x00000005 -1      .dword 0x02017654
+        `-> 0x00000008      .dword 0x00000403
+EOF
+RUN
+
 NAME=Cd999
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
