### PR TITLE
Add missing RUN to last x86_16 test and mark broken

### DIFF
--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -142,6 +142,7 @@ EOF
 RUN
 
 NAME=x86-16 seg:off call addr replace with analysed func name
+BROKEN=1
 FILE=-
 CMDS=<<EOF
 e asm.arch=x86
@@ -153,10 +154,10 @@ pdf @ 0x2
 EOF
 EXPECT=<<EOF
 / 10: funcB ();
-|           0000:0002      55             push bp
-|           0000:0003      8bec           mov bp, sp
-|           0000:0005      9a0d000000     lcall funcA
-|           0000:000a      5d             pop bp
-\           0000:000b      c3             ret
+|           0000:0002     55             push bp
+|           0000:0003     8bec           mov bp, sp
+|           0000:0005     9a0d000000     lcall funcA
+|           0000:000a     5d             pop bp
+\           0000:000b     c3             ret
 EOF
-
+RUN


### PR DESCRIPTION
The last test in #19593 was missing RUN. I added this, fixed the spacing in the EXPECT, and marked it as broken since it is.

Relevant incorrect line:
```
-|           0000:0005     9a0d000000     lcall funcA
+|           0000:0005     9a0d000000     lcall 0, funcA
```