### PR TITLE
Implement pdu

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1669,7 +1669,7 @@ static int core_anal_graph_construct_nodes(RCore *core, RAnalFunction *fcn, int 
 			if (buf) {
 				r_io_read_at (core->io, bbi->addr, buf, bbi->size);
 				if (is_json_format_disasm) {
-					r_core_print_disasm (core, bbi->addr, buf, bbi->size, bbi->size, true, true, pj, NULL);
+					r_core_print_disasm (core, bbi->addr, buf, bbi->size, bbi->size, 0, NULL, true, true, pj, NULL);
 				} else {
 					r_core_print_disasm_json (core, bbi->addr, buf, bbi->size, 0, pj);
 				}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2021 - pancake */
+/* radare - LGPL - Copyright 2009-2022 - pancake */
 
 #include "r_asm.h"
 #include "r_core.h"

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -288,13 +288,13 @@ static const char *help_msg_pds[] = {
 };
 
 static const char *help_msg_pdu[] = {
-	"Usage:", "pdu[aceios]", "Disassemble instructions until condition",
-	"pdua", " [addr]", "disassemble until address",
-	"pduc", "", "disassemble until call",
-	"pdue", " [expr]", "disassemble until esil expression",
-	"pdui", " [inst]", "disassemble until instruction (e.g.: add esp, 0x20)",
-	"pduo", " [opcode]", "disassemble until opcode (e.g.: mul)",
-	"pdus", "", "disassemble until syscall",
+	"Usage:", "pdu[aceios][j]", "Disassemble instructions until condition",
+	"pdua", "[j] [addr]", "disassemble until address",
+	"pduc", "[j]", "disassemble until call",
+	"pdue", "[j] [expr]", "disassemble until esil expression",
+	"pdui", "[j] [inst]", "disassemble until instruction (e.g.: add esp, 0x20)",
+	"pduo", "[j] [opcode]", "disassemble until opcode (e.g.: mul)",
+	"pdus", "[j]", "disassemble until syscall",
 	NULL
 };
 
@@ -1103,7 +1103,6 @@ static void pdu_help(RCore *core, char spec) {
 	r_config_set_b (core->config, "scr.color.grep", c);
 }
 
-// TODO: json support
 static int cmd_pdu(RCore *core, const char *input) {
 	int ret = 0;
 	const char *sep = strchr (input, ' ');
@@ -1145,7 +1144,11 @@ static int cmd_pdu(RCore *core, const char *input) {
 
 		// pD <count>
 		count = to - core->offset;
-		r_core_cmdf (core, "pD %" PFMT64u, count);
+		if (input[1] == 'j') {
+			r_core_cmdf (core, "pDJ %" PFMT64u, count);
+		} else {
+			r_core_cmdf (core, "pD %" PFMT64u, count);
+		}
 		}
 		break;
 	case 'c': // "pduc"

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -291,7 +291,7 @@ static const char *help_msg_pdu[] = {
 	"Usage:", "pdu[aceios][j]", "Disassemble instructions until condition",
 	"pdua", "[j] [addr]", "disassemble until address",
 	"pduc", "[j]", "disassemble until call",
-	"pdue", "[j] [expr]", "disassemble until esil expression",
+	//"pdue", "[j] [expr]", "disassemble until esil expression",
 	"pdui", "[j] [inst]", "disassemble until instruction (e.g.: add esp, 0x20)",
 	"pduo", "[j] [opcode]", "disassemble until opcode (e.g.: mul)",
 	"pdus", "[j]", "disassemble until syscall",
@@ -1145,7 +1145,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		ret = r_core_print_disasm (core, addr, buf, len, 0, opcode, "call", false,
 				input[1] == 'j', NULL, NULL);
 		break;
-	case 'e': // "pdue"
+	/*case 'e': // "pdue"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdue", true);
 			break;
@@ -1153,7 +1153,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 
 		ret = r_core_print_disasm (core, addr, buf, len, 0, esil, arg, false,
 				input[1] == 'j', NULL, NULL);
-		break;
+		break;*/
 	case 'i': // "pdui"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdui", true);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1124,7 +1124,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		ut64 to;
 		ut64 count;
 
-		if (input[1] == '?' || !arg) {
+		if (input[1] == '?' || input[2] == '?' || !arg) {
 			pdu_help (core, 'a');
 			return 0;
 		}
@@ -1152,7 +1152,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		}
 		break;
 	case 'c': // "pduc"
-		if (input[1] == '?') {
+		if (input[1] == '?' || input[2] == '?') {
 			pdu_help (core, 'c');
 			return 0;
 		}
@@ -1161,7 +1161,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'e': // "pdue"
-		if (input[1] == '?' || !arg) {
+		if (input[1] == '?' || input[2] == '?' || !arg) {
 			pdu_help (core, 'e');
 			return 0;
 		}
@@ -1170,7 +1170,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'i': // "pdui"
-		if (input[1] == '?' || !arg) {
+		if (input[1] == '?' || input[2] == '?' || !arg) {
 			pdu_help (core, 'i');
 			return 0;
 		}
@@ -1179,7 +1179,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'o': // "pduo"
-		if (input[1] == '?' || !arg) {
+		if (input[1] == '?' || input[2] == '?' || !arg) {
 			pdu_help (core, 'o');
 			return 0;
 		}
@@ -1188,7 +1188,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 's': // "pdus"
-		if (input[1] == '?') {
+		if (input[1] == '?' || input[2] == '?') {
 			pdu_help (core, 's');
 			return 0;
 		}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -10,11 +10,6 @@
 #define R_CORE_MAX_DISASM (1024 * 1024 * 8)
 #define PF_USAGE_STR "pf[.k[.f[=v]]|[v]]|[n]|[0|cnt][fmt] [a0 a1 ...]"
 
-#define DPRINTstr(x) eprintf (#x"=%s\n", x)
-#define DPRINTd(x) eprintf (#x"=%d\n", x)
-#define DPRINTut64(x) eprintf (#x"=%" PFMT64u " (0x%" PFMT64x ")\n", x, x)
-#define DPRINTst64(x) eprintf (#x"=%" PFMT64d "\n", x)
-
 static int printzoomcallback(void *user, int mode, ut64 addr, ut8 *bufz, ut64 size);
 static const char *help_msg_pa[] = {
 	"Usage: pa[edD]", "[asm|hex]", "print (dis)assembled",

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1149,8 +1149,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 		//count = to - core->offset;
 		// pD <count> @<offset>
 		//r_core_cmdf (core, "pD %" PFMT64u " @0x%" PFMT64x, count, core->offset);
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
-				"address", &to, input[1] == 'j', NULL, NULL);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "address", &to,
+				input[1] == 'j', NULL, NULL);
 		}
 		break;
 	case 'c': // "pduc"
@@ -1159,8 +1159,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 			return 0;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
-				"opcode", "call", input[1] == 'j', NULL, NULL;);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "opcode", "call",
+				input[1] == 'j', NULL, NULL;);
 		break;
 	case 'e': // "pdue"
 		if (input[1] == '?' || !arg) {
@@ -1168,8 +1168,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 			return 0;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM, "esil",
-				arg, input[1] == 'j', NULL, NULL);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "esil", arg,
+				input[1] == 'j', NULL, NULL);
 		break;
 	case 'i': // "pdui"
 		if (input[1] == '?' || !arg) {
@@ -1177,8 +1177,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 			return 0;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
-				"instruction", arg, input[1] == 'j', NULL, NULL);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "instruction", arg,
+				input[1] == 'j', NULL, NULL);
 		break;
 	case 'o': // "pduo"
 		if (input[1] == '?' || !arg) {
@@ -1186,8 +1186,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 			return 0;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
-				"opcode", arg, input[1] == 'j', NULL, NULL);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "opcode", arg,
+				input[1] == 'j', NULL, NULL);
 		break;
 	case 's': // "pdus"
 		if (input[1] == '?') {
@@ -1195,8 +1195,8 @@ static int cmd_pdu(RCore *core, const char *input) {
 			return 0;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
-				"opcode", "syscall", input[1] == 'j', NULL, NULL);
+		ret = r_core_print_disasm_until (core, addr, buf, len, "opcode", "syscall",
+				input[1] == 'j', NULL, NULL);
 		break;
 	case '?': // "pdu?"
 	default:

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1085,24 +1085,6 @@ R_API void r_core_set_asm_configs(RCore *core, char *arch, ut32 bits, int segoff
 	r_config_set_i (core->config, "asm.segoff", segoff);
 }
 
-/* TODO replace with help_match */
-static void pdu_help(RCore *core, char spec) {
-	const bool c = r_config_get_b (core->config, "scr.color.grep");
-	r_config_set_b (core->config, "scr.color.grep", true);
-
-	/* only show relevant subcmd line if applicable */
-	char *help = r_core_cmd_strf (core, "pdu?~pdu%c", spec);
-	if (help && *help) { // strlen (help) > 0
-		r_cons_printf ("%s", help);
-	} else {
-		r_core_cmd0 (core, "pdu?");
-	}
-	free (help);
-
-	r_cons_flush ();
-	r_config_set_b (core->config, "scr.color.grep", c);
-}
-
 static int cmd_pdu(RCore *core, const char *input) {
 	int ret = 0;
 	const char *sep = strchr (input, ' ');
@@ -1125,7 +1107,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		ut64 count;
 
 		if (input[1] == '?' || input[2] == '?' || !arg) {
-			pdu_help (core, 'a');
+			r_core_cmd_help_match (core, help_msg_pdu, "pdua", true);
 			return 0;
 		}
 
@@ -1153,7 +1135,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'c': // "pduc"
 		if (input[1] == '?' || input[2] == '?') {
-			pdu_help (core, 'c');
+			r_core_cmd_help_match (core, help_msg_pdu, "pduc", true);
 			return 0;
 		}
 
@@ -1162,7 +1144,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'e': // "pdue"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
-			pdu_help (core, 'e');
+			r_core_cmd_help_match (core, help_msg_pdu, "pdue", true);
 			return 0;
 		}
 
@@ -1171,7 +1153,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'i': // "pdui"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
-			pdu_help (core, 'i');
+			r_core_cmd_help_match (core, help_msg_pdu, "pdui", true);
 			return 0;
 		}
 
@@ -1180,7 +1162,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'o': // "pduo"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
-			pdu_help (core, 'o');
+			r_core_cmd_help_match (core, help_msg_pdu, "pduo", true);
 			return 0;
 		}
 
@@ -1189,7 +1171,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 's': // "pdus"
 		if (input[1] == '?' || input[2] == '?') {
-			pdu_help (core, 's');
+			r_core_cmd_help_match (core, help_msg_pdu, "pdus", true);
 			return 0;
 		}
 

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1119,18 +1119,21 @@ static int cmd_pdu(RCore *core, const char *input) {
 	if (buf) {
 		r_io_read_at (core->io, core->offset, buf, len);
 	} else {
-		eprintf ("Cannot allocate %d byte(s)\n", bsize);
+		eprintf ("Cannot allocate %d byte(s)\n", len);
 		return 1;
 	}
 
 	switch (*input) {
 	case 'a': // "pdua"
+		{
+		ut64 to;
+
 		if (input[1] == '?' || !arg) {
 			pdu_help (core, 'a');
 			return 0;
 		}
 
-		to = r_num_math (core->num, arg);
+		to = r_num_get (core->num, arg);
 
 		if (!to) {
 			eprintf ("Couldn't parse address \"%s\"\n", arg);
@@ -1148,6 +1151,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		//r_core_cmdf (core, "pD %" PFMT64u " @0x%" PFMT64x, count, core->offset);
 		ret = r_core_print_disasm_until (core, addr, buf, len, R_CORE_MAX_DISASM,
 				"address", &to, input[1] == 'j', NULL, NULL);
+		}
 		break;
 	case 'c': // "pduc"
 		if (input[1] == '?') {

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1142,7 +1142,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 			break;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, opcode, "call",
+		ret = r_core_print_disasm (core, addr, buf, len, 0, opcode, "call", false,
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'e': // "pdue"
@@ -1151,7 +1151,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 			break;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, esil, arg,
+		ret = r_core_print_disasm (core, addr, buf, len, 0, esil, arg, false,
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'i': // "pdui"
@@ -1160,7 +1160,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 			break;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, instruction, arg,
+		ret = r_core_print_disasm (core, addr, buf, len, 0, instruction, arg, false,
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 'o': // "pduo"
@@ -1169,7 +1169,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 			break;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, opcode, arg,
+		ret = r_core_print_disasm (core, addr, buf, len, 0, opcode, arg, false,
 				input[1] == 'j', NULL, NULL);
 		break;
 	case 's': // "pdus"
@@ -1178,7 +1178,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 			break;
 		}
 
-		ret = r_core_print_disasm_until (core, addr, buf, len, instruction, "syscall",
+		ret = r_core_print_disasm (core, addr, buf, len, 0, instruction, "syscall", false,
 				input[1] == 'j', NULL, NULL);
 		break;
 	case '?': // "pdu?"
@@ -5744,7 +5744,7 @@ static int cmd_print(void *data, const char *input) {
 						} else {
 							core->num->value = r_core_print_disasm (
 								core, b->addr, block,
-								b->size, b->size, true,
+								b->size, b->size, 0, NULL, true,
 								input[2] == 'J', NULL, NULL);
 						}
 						free (block);
@@ -5838,7 +5838,7 @@ static int cmd_print(void *data, const char *input) {
 						ut8 *buf = calloc (sz, 1);
 						if (buf) {
 							(void)r_io_read_at (core->io, at, buf, sz);
-							core->num->value = r_core_print_disasm (core, at, buf, sz, sz, true, false, NULL, f);
+							core->num->value = r_core_print_disasm (core, at, buf, sz, sz, 0, NULL, true, false, NULL, f);
 							free (buf);
 							// r_core_cmdf (core, "pD %d @ 0x%08" PFMT64x, f->_size > 0 ? f->_size: r_anal_function_realsize (f), f->addr);
 						}
@@ -5953,7 +5953,7 @@ static int cmd_print(void *data, const char *input) {
 							break;
 						}
 						r_io_read_at (core->io, addr - l, block1, l); // core->blocksize);
-						core->num->value = r_core_print_disasm (core, addr - l, block1, l, l, true, formatted_json, NULL, NULL);
+						core->num->value = r_core_print_disasm (core, addr - l, block1, l, l, 0, NULL, true, formatted_json, NULL, NULL);
 					} else { // pd
 						int instr_len;
 						if (!r_core_prevop_addr (core, core->offset, l, &start)) {
@@ -5981,8 +5981,9 @@ static int cmd_print(void *data, const char *input) {
 						}
 						core->num->value = r_core_print_disasm (core,
 								core->offset, block1,
-								R_MAX (bs, bs1), l, false,
-								formatted_json, NULL, NULL);
+								R_MAX (bs, bs1), l, 0, NULL,
+								false, formatted_json, NULL,
+								NULL);
 						r_core_seek (core, prevaddr, true);
 					}
 				}
@@ -5999,7 +6000,8 @@ static int cmd_print(void *data, const char *input) {
 						r_io_read_at (core->io, addr, block1, addrbytes * l);
 						core->num->value = r_core_print_disasm (core,
 								addr, block1, addrbytes * l, l,
-								true, formatted_json, NULL, NULL);
+								0, NULL, true, formatted_json,
+								NULL, NULL);
 					} else {
 						eprintf ("Cannot allocate %" PFMT64d " byte(s)\n", addrbytes * l);
 					}
@@ -6014,8 +6016,8 @@ static int cmd_print(void *data, const char *input) {
 							}
 						}
 						core->num->value = r_core_print_disasm (core,
-								addr, buf, buf_size, l,	false,
-								formatted_json, NULL, NULL);
+								addr, buf, buf_size, l,	0, NULL,
+								false, formatted_json, NULL, NULL);
 					}
 				}
 			}

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1108,35 +1108,38 @@ static int cmd_pdu(RCore *core, const char *input) {
 
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdua", true);
-			return 0;
+			break;
 		}
 
 		to = r_num_get (core->num, arg);
 
 		if (!to) {
 			eprintf ("Couldn't parse address \"%s\"\n", arg);
-			return 1;
+			ret = 1;
+			break;
 		} else if (to < addr) {
 			eprintf ("Can't print until an earlier address\n");
-			return 2;
+			ret = 2;
+			break;
 		} else if (to == addr) {
 			eprintf ("Can't print until the start address\n");
-			return 2;
+			ret = 2;
+			break;
 		}
 
 		// pD <count>
 		count = to - core->offset;
 		if (input[1] == 'j') {
-			r_core_cmdf (core, "pDJ %" PFMT64u, count);
+			ret = r_core_cmdf (core, "pDJ %" PFMT64u, count);
 		} else {
-			r_core_cmdf (core, "pD %" PFMT64u, count);
+			ret = r_core_cmdf (core, "pD %" PFMT64u, count);
 		}
 		}
 		break;
 	case 'c': // "pduc"
 		if (input[1] == '?' || input[2] == '?') {
 			r_core_cmd_help_match (core, help_msg_pdu, "pduc", true);
-			return 0;
+			break;
 		}
 
 		ret = r_core_print_disasm_until (core, addr, buf, len, opcode, "call",
@@ -1145,7 +1148,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 	case 'e': // "pdue"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdue", true);
-			return 0;
+			break;
 		}
 
 		ret = r_core_print_disasm_until (core, addr, buf, len, esil, arg,
@@ -1154,7 +1157,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 	case 'i': // "pdui"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdui", true);
-			return 0;
+			break;
 		}
 
 		ret = r_core_print_disasm_until (core, addr, buf, len, instruction, arg,
@@ -1163,7 +1166,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 	case 'o': // "pduo"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
 			r_core_cmd_help_match (core, help_msg_pdu, "pduo", true);
-			return 0;
+			break;
 		}
 
 		ret = r_core_print_disasm_until (core, addr, buf, len, opcode, arg,
@@ -1172,7 +1175,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 	case 's': // "pdus"
 		if (input[1] == '?' || input[2] == '?') {
 			r_core_cmd_help_match (core, help_msg_pdu, "pdus", true);
-			return 0;
+			break;
 		}
 
 		ret = r_core_print_disasm_until (core, addr, buf, len, instruction, "syscall",

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -1085,8 +1085,8 @@ R_API void r_core_set_asm_configs(RCore *core, char *arch, ut32 bits, int segoff
 	r_config_set_i (core->config, "asm.segoff", segoff);
 }
 
+/* TODO replace with help_match */
 static void pdu_help(RCore *core, char spec) {
-	/* XXX better "temp color" functionality? */
 	const bool c = r_config_get_b (core->config, "scr.color.grep");
 	r_config_set_b (core->config, "scr.color.grep", true);
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5408,7 +5408,7 @@ static void ds_end_line_highlight(RDisasmState *ds) {
 /**
  * \brief Disassemble instructions until a condition is met
  */
-R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, int max_disasm, const char *condition_type_str, const void *condition, bool json, PJ *pj, RAnalFunction *pdf) {
+R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, PDU_CONDITION condition_type, const void *condition, bool json, PJ *pj, RAnalFunction *pdf) {
 	enum {
 		address,
 		esil,
@@ -5416,11 +5416,10 @@ R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, i
 		opcode
 	} pdu_condition;
 
-	pdu_condition condition_type;
-	ut8 address_condition;
-	const char *esil_condition;
-	const char *instruction_condition;
-	const char *opcode_condition;
+	ut64 address_condition = 0;
+	const char *esil_condition = NULL;
+	const char *instruction_condition = NULL;
+	const char *opcode_condition = NULL;
 
 	RPrint *p = core->print;
 	RAnalFunction *of = NULL;
@@ -5430,17 +5429,13 @@ R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, i
 	ut8 *nbuf = NULL;
 	const int max_op_size = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
 
-	if (!strcmp (condition_type_str, "address")) {
-		condition_type = address;
+	if (condition_type == address) {
 		address_condition = *(ut8 *)condition;
-	} else if (!strcmp (condition_type_str, "esil")) {
-		condition_type = esil;
-		esil_condition = (char *)condition;
-	} else if (!strcmp (condition_type_str, "instruction")) {
-		condition_type = instruction;
-		instruction_condition = (char *)condition;
-	} else if (!strcmp (condition_type_str, "opcode")) {
-		condition_type = opcode;
+	} else if (condition_type == esil) {
+		esil_condition = (const char *)condition;
+	} else if (condition_type == instruction) {
+		instruction_condition = (const char *)condition;
+	} else if (condition_type == opcode) {
 		opcode_condition = (char *)condition;
 	}
 

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5422,7 +5422,7 @@ R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int cou
 	bool pdu_condition_met = false;
 	char *opstr_nocolor = NULL;
 	int opcode_len = -1;
-	const char *pdu_condition_esil = NULL;
+	//const char *pdu_condition_esil = NULL;
 	const char *pdu_condition_instruction = NULL;
 	const char *pdu_condition_opcode = NULL;
 
@@ -5442,9 +5442,10 @@ R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int cou
 		ds->count_bytes = false;
 		ds->count = INT_MAX;
 
-		if (pdu_condition_type == esil) {
+		/*if (pdu_condition_type == esil) {
 			pdu_condition_esil = (const char *)pdu_condition;
-		} else if (pdu_condition_type == instruction) {
+		} else*/
+		if (pdu_condition_type == instruction) {
 			pdu_condition_instruction = (const char *)pdu_condition;
 		} else if (pdu_condition_type == opcode) {
 			pdu_condition_opcode = (const char *)pdu_condition;
@@ -5897,10 +5898,9 @@ toro:
 				// we can't strcmp with color codes interfering
 				r_str_ansi_filter (opstr_nocolor, &ds->opstr, NULL, -1);
 				switch (pdu_condition_type) {
-				case esil:
-					// TODO
+				/*case esil:
 					pdu_condition_met = true;
-					break;
+					break;*/
 				case instruction:
 					// match full instruction
 					if (!strcmp (pdu_condition_instruction, opstr_nocolor)) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5406,6 +5406,579 @@ static void ds_end_line_highlight(RDisasmState *ds) {
 }
 
 /**
+ * \brief Disassemble instructions until a condition is met
+ */
+R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, int max_disasm, const char *condition_type_str, const void *condition, bool json, PJ *pj, RAnalFunction *pdf) {
+	enum {
+		address,
+		esil,
+		instruction,
+		opcode
+	} pdu_condition;
+
+	pdu_condition condition_type;
+	ut8 address_condition;
+	const char *esil_condition;
+	const char *instruction_condition;
+	const char *opcode_condition;
+
+	RPrint *p = core->print;
+	RAnalFunction *of = NULL;
+	RAnalFunction *f = NULL;
+	bool calc_row_offsets = p->calc_row_offsets;
+	int skip_bytes_flag = 0, skip_bytes_bb = 0;
+	ut8 *nbuf = NULL;
+	const int max_op_size = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
+
+	if (!strcmp (condition_type_str, "address")) {
+		condition_type = address;
+		address_condition = *(ut8 *)condition;
+	} else if (!strcmp (condition_type_str, "esil")) {
+		condition_type = esil;
+		esil_condition = (char *)condition;
+	} else if (!strcmp (condition_type_str, "instruction")) {
+		condition_type = instruction;
+		instruction_condition = (char *)condition;
+	} else if (!strcmp (condition_type_str, "opcode")) {
+		condition_type = opcode;
+		opcode_condition = (char *)condition;
+	}
+
+	// TODO: All those ds must be print flags
+	RDisasmState *ds = ds_init (core);
+	ds->count_bytes = false;
+	ds->print = p;
+	ds->count = max_disasm;
+	ds->buf = buf;
+	ds->len = len;
+	ds->addr = addr;
+	ds->hint = NULL;
+	ds->buf_line_begin = 0;
+	ds->pdf = pdf;
+
+	if (json) {
+		ds->pj = pj? pj: r_core_pj_new (core);
+		if (!ds->pj) {
+			ds_free (ds);
+			return 0;
+		}
+		r_cons_push ();
+	} else {
+		ds->pj = NULL;
+	}
+
+	// disable row_offsets to prevent other commands to overwrite computed info
+	p->calc_row_offsets = false;
+
+	//r_cons_printf ("len=%d count=%d limit=%d\n", len, count, p->limit);
+	// TODO: import values from debugger is possible
+	// TODO: allow to get those register snapshots from traces
+	// TODO: per-function register state trace
+	// XXX - is there a better way to reset a the analysis counter so that
+	// when code is disassembled, it can actually find the correct offsets
+	{ /* used by asm.emu */
+		r_reg_arena_push (core->anal->reg);
+	}
+
+	ds_reflines_init (ds);
+	/* reset jmp table if not asked to keep it */
+	if (!core->keep_asmqjmps) { // hack
+		core->asmqjmps_count = 0;
+		ut64 *p = realloc (core->asmqjmps, R_CORE_ASMQJMPS_NUM * sizeof (ut64));
+		if (p) {
+			core->asmqjmps_size = R_CORE_ASMQJMPS_NUM;
+			core->asmqjmps = p;
+			for (int i = 0; i < R_CORE_ASMQJMPS_NUM; i++) {
+				core->asmqjmps[i] = UT64_MAX;
+			}
+		}
+	}
+	if (ds->pj && !pj) {
+		pj_a (ds->pj);
+	}
+toro:
+	// uhm... is this necessary? imho can be removed
+	r_asm_set_pc (core->rasm, r_core_pava (core, ds->addr));
+	core->cons->vline = r_config_get_i (core->config, "scr.utf8") ? (r_config_get_i (core->config, "scr.utf8.curvy") ? r_vline_uc : r_vline_u) : r_vline_a;
+
+	if (core->print->cur_enabled) {
+		// TODO: support in-the-middle-of-instruction too
+		r_anal_op_fini (&ds->analop);
+		if (r_anal_op (core->anal, &ds->analop, core->offset + core->print->cur,
+			buf + core->print->cur, (int)(len - core->print->cur), R_ANAL_OP_MASK_ALL)) {
+			// TODO: check for ds->analop.type and ret
+			ds->dest = ds->analop.jump;
+		}
+	} else {
+		/* highlight eip */
+		const char *pc = core->anal->reg->name[R_REG_NAME_PC];
+		if (pc) {
+			RFlagItem *item = r_flag_get (core->flags, pc);
+			if (item) {
+				ds->dest = item->offset;
+			}
+		}
+	}
+
+	ds_print_esil_anal_init (ds);
+	r_cons_break_push (NULL, NULL);
+
+	int inc = 0;
+	int ret = 0;
+	for (ds->index = 0; ds_left (ds) > 0 && ds->lines < ds->count;
+			ds->index += inc, ds->lines++) {
+		ds->at = ds->addr + ds->index;
+		ds->vat = r_core_pava (core, ds->at);
+
+		if (r_cons_is_breaked ()) {
+			R_FREE (nbuf);
+			if (ds->pj) {
+				r_cons_pop ();
+			}
+			r_cons_break_pop ();
+			ds_free (ds);
+			return 0; //break;
+		}
+
+		if (core->print->flags & R_PRINT_FLAGS_UNALLOC) {
+			if (!core->anal->iob.is_valid_offset (core->anal->iob.io, ds->at, 0)) {
+				ds_begin_line (ds);
+				ds_print_labels (ds, f);
+				ds_setup_print_pre (ds, false, false);
+				ds_print_lines_left (ds);
+				core->print->resetbg = (ds->asm_highlight == UT64_MAX);
+				ds_start_line_highlight (ds);
+				ds_print_offset (ds);
+				r_cons_printf ("  unmapped\n");
+				inc = 1;
+				continue;
+			}
+		}
+		if (!ds->show_comment_right) {
+			if (ds->show_cmtesil) {
+				const char *esil = R_STRBUF_SAFEGET (&ds->analop.esil);
+				// ds_begin_line (ds);
+				ds_pre_line (ds);
+				ds_setup_print_pre (ds, false, false);
+				r_cons_strcat ("      ");
+				ds_print_lines_left (ds);
+				ds_begin_comment (ds);
+				if (ds->show_color) {
+					ds_comment (ds, true, "; %s%s%s",
+						ds->pal_comment, esil, Color_RESET);
+				} else {
+					ds_comment (ds, true, "; %s", esil);
+				}
+			}
+		}
+		r_core_seek_arch_bits (core, ds->at); // slow but safe
+		ds->has_description = false;
+		ds->hint = r_core_hint_begin (core, ds->hint, ds->at);
+		ds->printed_str_addr = UT64_MAX;
+		ds->printed_flag_addr = UT64_MAX;
+		// XXX. this must be done in ds_update_pc()
+		// ds_update_pc (ds, ds->at);
+		r_asm_set_pc (core->rasm, ds->at);
+		ds_update_ref_lines (ds);
+		r_anal_op_fini (&ds->analop);
+		r_anal_op (core->anal, &ds->analop, ds->at, ds_bufat (ds), ds_left (ds), R_ANAL_OP_MASK_ALL);
+		if (ds_must_strip (ds)) {
+			inc = ds->analop.size;
+			// inc = ds->asmop.payload + (ds->asmop.payload % ds->core->rasm->dataalign);
+			r_anal_op_fini (&ds->analop);
+			continue;
+		}
+		// f = r_anal_get_fcn_in (core->anal, ds->at, R_ANAL_FCN_TYPE_NULL);
+		f = ds->fcn = fcnIn (ds, ds->at, R_ANAL_FCN_TYPE_NULL);
+		if (f && f->folded && r_anal_function_contains (f, ds->at)) {
+			int delta = (ds->at <= f->addr)? (ds->at - r_anal_function_max_addr (f)): 0;
+			if (of != f) {
+				char cmt[32];
+				get_bits_comment (core, f, cmt, sizeof (cmt));
+				const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, ds->at);
+				if (comment) {
+					ds_pre_xrefs (ds, true);
+					r_cons_printf ("; %s\n", comment);
+				}
+				r_cons_printf ("%s%s%s (fcn) %s%s%s\n",
+					COLOR (ds, color_fline), core->cons->vline[CORNER_TL],
+					COLOR (ds, color_fname), f->name, cmt, COLOR_RESET (ds));
+				ds_setup_print_pre (ds, true, false);
+				ds_print_lines_left (ds);
+				ds_print_offset (ds);
+				r_cons_printf ("(%" PFMT64d " byte folded function)\n", r_anal_function_linear_size (f));
+				//r_cons_printf ("%s%s%s\n", COLOR (ds, color_fline), core->cons->vline[RDWN_CORNER], COLOR_RESET (ds));
+				if (delta < 0) {
+					delta = -delta;
+				}
+				ds->addr += delta + ds->index;
+				r_io_read_at (core->io, ds->addr, buf, len);
+				inc = 0; //delta;
+				ds->index = 0;
+				of = f;
+				r_anal_op_fini (&ds->analop);
+				if (count_bytes) {
+					break;
+				}
+			} else {
+				ds->lines--;
+				ds->addr++;
+				r_io_read_at (core->io, ds->addr, buf, len);
+				inc = 0; //delta;
+				ds->index = 0;
+				r_anal_op_fini (&ds->analop);
+			}
+			continue;
+		}
+		ds_show_comments_right (ds);
+		// TRY adding here
+		char *link_key = sdb_fmt ("link.%08" PFMT64x, ds->addr + ds->index);
+		const char *link_type = sdb_const_get (core->anal->sdb_types, link_key, 0);
+		if (link_type) {
+			char *fmt = r_type_format (core->anal->sdb_types, link_type);
+			if (fmt) {
+				r_cons_printf ("(%s)\n", link_type);
+				r_core_cmdf (core, "pf %s @ 0x%08" PFMT64x "\n", fmt, ds->addr + ds->index);
+				const ut32 type_bitsize = r_type_get_bitsize (core->anal->sdb_types, link_type);
+				// always round up when calculating byte_size from bit_size of types
+				// could be struct with a bitfield entry
+				inc = (type_bitsize >> 3) + (!!(type_bitsize & 0x7));
+				free (fmt);
+				r_anal_op_fini (&ds->analop);
+				continue;
+			}
+		} else {
+			int left = ds_left (ds);
+#if DEBUG_DISASM
+			eprintf ("BEFORE ds_disassemble:\n");
+			eprintf ("ds->index=%#x len=%#x left=%#x\n", ds->index, len, left);
+			eprintf ("ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x\n", ds->addr, ds->at, ds->count, ds->lines);
+#endif
+			if (left < max_op_size && !count_bytes) {
+#if DEBUG_DISASM
+				eprintf ("Not enough bytes to disassemble, going to retry.\n");
+#endif
+				goto retry;
+			}
+
+			ret = ds_disassemble (ds, (ut8 *)ds_bufat (ds), left);
+#if DEBUG_DISASM
+			eprintf ("AFTER ds_disassemble:\n");
+			eprintf ("ret=%d len=%#x left=%#x ", ret, len, left);
+			eprintf ("ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x\n", ds->addr, ds->at, ds->count, ds->lines);
+#endif
+			eprintf ("ds->asm_str: %s\n", ds->asm_str);
+			if (ret == -31337) {
+				inc = ds->oplen; // minopsz maybe? or we should add invopsz
+				r_anal_op_fini (&ds->analop);
+				continue;
+			}
+		}
+
+		ds_atabs_option (ds);
+		if (ds->analop.addr != ds->at) {
+			r_anal_op_fini (&ds->analop);
+			r_anal_op (core->anal, &ds->analop, ds->at, ds_bufat (ds), ds_left (ds), R_ANAL_OP_MASK_ALL);
+		}
+		if (ret < 1) {
+			r_strbuf_fini (&ds->analop.esil);
+			r_strbuf_init (&ds->analop.esil);
+			ds->analop.type = R_ANAL_OP_TYPE_ILL;
+		}
+		if (ds->hint) {
+			if (ds->hint->size) {
+				ds->analop.size = ds->hint->size;
+			}
+			if (ds->hint->ptr) {
+				ds->analop.ptr = ds->hint->ptr;
+			}
+		}
+		ds_print_bbline (ds);
+		if (ds->at >= addr) {
+			r_print_set_rowoff (core->print, ds->lines, ds->at - addr, calc_row_offsets);
+		}
+		skip_bytes_flag = handleMidFlags (core, ds, true);
+		if (ds->midbb) {
+			skip_bytes_bb = handleMidBB (core, ds);
+		}
+		ds_show_flags (ds, false);
+		ds_show_xrefs (ds);
+		if (skip_bytes_flag && ds->midflags == R_MIDFLAGS_SHOW &&
+				(!ds->midbb || !skip_bytes_bb || skip_bytes_bb > skip_bytes_flag)) {
+			ds->at += skip_bytes_flag;
+			ds_show_flags(ds, true);
+			ds_show_xrefs(ds);
+			ds->at -= skip_bytes_flag;
+		}
+		if (ds->pdf) {
+			static bool sparse = false;
+			RAnalBlock *bb = r_anal_function_bbget_in (core->anal, ds->pdf, ds->at);
+			if (!bb) {
+				for (inc = 1; inc < ds->oplen; inc++) {
+					RAnalBlock *bb = r_anal_function_bbget_in (core->anal, ds->pdf, ds->at + inc);
+					if (bb) {
+						break;
+					}
+				}
+				r_anal_op_fini (&ds->analop);
+				if (!sparse) {
+					r_cons_printf ("..\n");
+					sparse = true;
+				}
+				continue;
+			}
+			sparse = false;
+		}
+		ds_control_flow_comments (ds);
+		ds_adistrick_comments (ds);
+		/* XXX: This is really cpu consuming.. need to be fixed */
+		ds_show_functions (ds);
+
+		if (ds->show_comments && !ds->show_comment_right) {
+			ds_show_refs (ds);
+			ds_build_op_str (ds, false);
+			ds_print_ptr (ds, len + 256, ds->index);
+			ds_print_sysregs (ds);
+			ds_print_fcn_name (ds);
+			ds_print_demangled (ds);
+			ds_print_color_reset (ds);
+			if (!ds->pseudo) {
+				R_FREE (ds->opstr);
+			}
+			if (ds->show_emu) {
+				ds_print_esil_anal (ds);
+			}
+			if ((ds->analop.type == R_ANAL_OP_TYPE_CALL || ds->analop.type & R_ANAL_OP_TYPE_UCALL) && ds->show_calls) {
+				ds_print_calls_hints (ds);
+			}
+			ds_show_comments_describe (ds);
+		}
+
+		f = fcnIn (ds, ds->addr, 0);
+		ds_begin_line (ds);
+		ds_print_labels (ds, f);
+		ds_setup_print_pre (ds, false, false);
+		ds_print_lines_left (ds);
+		core->print->resetbg = (ds->asm_highlight == UT64_MAX);
+		ds_start_line_highlight (ds);
+		ds_print_offset (ds);
+		////
+		RAnalFunction *fcn = f;
+		if (fcn) {
+			RAnalBlock *bb = r_anal_function_bbget_in (core->anal, fcn, ds->at);
+			if (!bb) {
+				fcn = r_anal_get_function_at (core->anal, ds->at);
+				if (fcn) {
+					bb = r_anal_function_bbget_in (core->anal, fcn, ds->at);
+				}
+			}
+			if (bb) {
+				if (bb->folded) {
+					r_cons_printf ("[+] Folded BB [..0x%08"PFMT64x"]\n", ds->at + bb->size);
+					inc = bb->size;
+					continue;
+				}
+			}
+		}
+		////
+		int mi_type;
+		bool mi_found = ds_print_meta_infos (ds, buf, len, ds->index, &mi_type);
+		if (ds->asm_hint_pos == 0) {
+			if (mi_found) {
+				r_cons_printf ("      ");
+			} else {
+				ds_print_core_vmode (ds, ds->asm_hint_pos);
+			}
+		}
+		ds_print_op_size (ds);
+		ds_print_trace (ds);
+		ds_print_cycles (ds);
+		ds_print_family (ds);
+		ds_print_stackptr (ds);
+		if (mi_found) {
+			ds_print_dwarf (ds);
+			ret = ds_print_middle (ds, ret);
+
+			ds_print_asmop_payload (ds, ds_bufat (ds));
+			if (core->rasm->syntax != R_ASM_SYNTAX_INTEL) {
+				RAsmOp ao; /* disassemble for the vm .. */
+				int os = core->rasm->syntax;
+				r_asm_set_syntax (core->rasm, R_ASM_SYNTAX_INTEL);
+				r_asm_disassemble (core->rasm, &ao, ds_bufat (ds), ds_left (ds) + 5);
+				r_asm_set_syntax (core->rasm, os);
+			}
+			if (mi_type == R_META_TYPE_FORMAT) {
+				if ((ds->show_comments || ds->show_usercomments) && ds->show_comment_right) {
+			//		haveMeta = false;
+				}
+			}
+			if (mi_type != R_META_TYPE_FORMAT) {
+				if (ds->asm_hint_pos > 0) {
+					ds_print_core_vmode (ds, ds->asm_hint_pos);
+				}
+			}
+			ds_end_line_highlight (ds);
+			if ((ds->show_comments || ds->show_usercomments) && ds->show_comment_right) {
+				ds_print_color_reset (ds);
+				ds_print_comments_right (ds);
+			}
+		} else {
+			/* show cursor */
+			ds_print_show_cursor (ds);
+			if (!ds->show_bytes_right) {
+				ds_print_show_bytes (ds);
+			}
+			ds_print_lines_right (ds);
+			ds_print_optype (ds);
+			ds_print_vliw (ds, false);
+			ds_build_op_str (ds, true);
+			ds_print_opstr (ds);
+			ds_print_vliw (ds, true);
+			ds_end_line_highlight (ds);
+			ds_print_dwarf (ds);
+			ret = ds_print_middle (ds, ret);
+
+			ds_print_asmop_payload (ds, ds_bufat (ds));
+			if (core->rasm->syntax != R_ASM_SYNTAX_INTEL) {
+				RAsmOp ao; /* disassemble for the vm .. */
+				int os = core->rasm->syntax;
+				r_asm_set_syntax (core->rasm, R_ASM_SYNTAX_INTEL);
+				r_asm_disassemble (core->rasm, &ao, ds_bufat (ds), ds_left (ds) + 5);
+				r_asm_set_syntax (core->rasm, os);
+			}
+			if (ds->show_bytes_right && ds->show_bytes) {
+				ds_comment (ds, true, "");
+				ds_print_show_bytes (ds);
+			}
+			if (ds->asm_hint_pos > 0) {
+				ds_print_core_vmode (ds, ds->asm_hint_pos);
+			}
+			// ds_print_cc_update (ds);
+
+			ds_cdiv_optimization (ds);
+			if ((ds->show_comments || ds->show_usercomments) && ds->show_comment_right) {
+				if (ds->show_cmtesil) {
+					const char *esil = R_STRBUF_SAFEGET (&ds->analop.esil);
+					if (ds->show_color) {
+						ds_comment (ds, true, "; %s%s%s",
+							ds->pal_comment, esil, Color_RESET);
+					} else {
+						ds_comment (ds, true, "; %s", esil);
+					}
+				}
+				ds_print_ptr (ds, len + 256, ds->index);
+				ds_print_sysregs (ds);
+				ds_print_fcn_name (ds);
+				ds_print_demangled (ds);
+				ds_print_color_reset (ds);
+				ds_print_comments_right (ds);
+				ds_print_esil_anal (ds);
+				ds_show_refs (ds);
+			}
+		}
+		core->print->resetbg = true;
+		ds_newline (ds);
+		if (ds->line) {
+			if (ds->show_lines_ret && ds->analop.type == R_ANAL_OP_TYPE_RET) {
+				if (strchr (ds->line, '>')) {
+					memset (ds->line, ' ', r_str_len_utf8 (ds->line));
+				}
+				ds_begin_line (ds);
+				ds_print_pre (ds, true);
+				ds_print_ref_lines (ds->line, ds->line_col, ds);
+				r_cons_printf ("; --------------------------------------");
+				ds_newline (ds);
+			}
+			R_FREE (ds->line);
+			R_FREE (ds->line_col);
+			R_FREE (ds->refline);
+			R_FREE (ds->refline2);
+			R_FREE (ds->prev_line_col);
+		}
+		R_FREE (ds->opstr);
+		inc = ds->oplen;
+
+		if (ds->midflags == R_MIDFLAGS_REALIGN && skip_bytes_flag) {
+			inc = skip_bytes_flag;
+		}
+		if (skip_bytes_bb && skip_bytes_bb < inc) {
+			inc = skip_bytes_bb;
+		}
+		inc += ds->asmop.payload + (ds->asmop.payload % ds->core->rasm->dataalign);
+
+
+		// TODO check conditions here!
+		switch (condition_type) {
+			
+		}
+	}
+	r_anal_op_fini (&ds->analop);
+
+	R_FREE (nbuf);
+	r_cons_break_pop ();
+
+#if HASRETRY
+	if (!ds->count_bytes && ds->lines < ds->count) {
+		ds->at = ds->addr = ds->at + inc;
+		ds->index = 0;
+	retry:
+#if DEBUG_DISASM
+		eprintf ("Retrying. ds->at,ds->addr=%#" PFMT64x ", ds->index=%d\n", ds->at, ds->index);
+#endif
+		if (len < max_op_size) {
+			ds->len = len = max_op_size + 32;
+		}
+		free (nbuf);
+		ds->buf = buf = nbuf = malloc (len);
+		if (!buf) {
+			eprintf ("Cannot allocate %d bytes%c", len, 10);
+		}
+
+		// enough bytes?
+		if (ds->lines < ds->count && !count_bytes) {
+			ds->addr += ds->index;
+#if DEBUG_DISASM
+			eprintf ("len=%d\n", len);
+#endif
+			r_io_read_at (core->io, ds->addr, buf, len);
+			if (count_bytes) {
+				goto toro;
+			} else {
+				inc = 0;
+			}
+		}
+
+		// always reloop if counting by instructions
+		if (!count_bytes) {
+			goto toro;
+		}
+
+		R_FREE (nbuf);
+	}
+#endif
+	if (ds->pj) {
+		r_cons_pop ();
+		if (!pj) {
+			pj_end (ds->pj);
+			r_cons_printf ("%s", pj_string (ds->pj));
+			pj_free (ds->pj);
+		}
+	}
+	r_print_set_rowoff (core->print, ds->lines, ds->at - addr, calc_row_offsets);
+	r_print_set_rowoff (core->print, ds->lines + 1, UT32_MAX, calc_row_offsets);
+	// TODO: this too (must review)
+	ds_print_esil_anal_fini (ds);
+	ds_reflines_fini (ds);
+	R_FREE (nbuf);
+	p->calc_row_offsets = calc_row_offsets;
+	/* used by asm.emu */
+	r_reg_arena_pop (core->anal->reg);
+	ut64 res = ds_offset (ds); //-ds->lastfail;
+	ds_free (ds);
+	return res;
+}
+
+/**
  * \brief Disassemble `count` instructions, or bytes if `count_bytes` is enabled
  */
 R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool json, PJ *pj, RAnalFunction *pdf) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5419,7 +5419,7 @@ R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, e
 	bool pdu_condition_met = false;
 	char *opstr_nocolor = NULL;
 
-	int opcode_len;
+	int opcode_len = -1;
 	if (condition_type == opcode) {
 		opcode_len = strlen (condition);
 	}

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -665,7 +665,7 @@ R_API ut32 r_core_asm_bwdis_len(RCore* core, int* len, ut64* start_addr, ut32 l)
 
 
 enum pdu_condition {
-	esil,
+	//esil,
 	instruction,
 	opcode
 };

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -667,6 +667,15 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, in
 R_API int r_core_print_disasm_instructions_with_buf(RCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);
 R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opcodes);
 R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mode);
+
+typedef enum {
+	address,
+	esil,
+	instruction,
+	opcode
+} PDU_CONDITION;
+R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, PDU_CONDITION condition_type, const void *condition, bool json, PJ *pj, RAnalFunction *pdf);
+
 R_API int r_core_disasm_pdi_with_buf(RCore *core, ut64 address, ut8 *buf, ut32 nb_opcodes, ut32 nb_bytes, int fmt);
 R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt);
 R_API int r_core_disasm_pde(RCore *core, int nb_opcodes, int mode);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -662,18 +662,18 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len);
 R_API RList *r_core_asm_back_disassemble_instr(RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API RList *r_core_asm_back_disassemble_byte(RCore *core, ut64 addr, int len, ut32 hit_count, ut32 extra_padding);
 R_API ut32 r_core_asm_bwdis_len(RCore* core, int* len, ut64* start_addr, ut32 l);
-R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, bool count_bytes, bool json, PJ *pj, RAnalFunction *pdf);
-R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
-R_API int r_core_print_disasm_instructions_with_buf(RCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);
-R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opcodes);
-R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mode);
+
 
 enum pdu_condition {
 	esil,
 	instruction,
 	opcode
 };
-R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, enum pdu_condition condition_type, const char *condition, bool json, PJ *pj, RAnalFunction *pdf);
+R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int count, enum pdu_condition pdu_condition_type, const void *pdu_condition, bool count_bytes, bool json, PJ *pj, RAnalFunction *pdf);
+R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int len, int lines, PJ *pj);
+R_API int r_core_print_disasm_instructions_with_buf(RCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);
+R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opcodes);
+R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mode);
 
 R_API int r_core_disasm_pdi_with_buf(RCore *core, ut64 address, ut8 *buf, ut32 nb_opcodes, ut32 nb_bytes, int fmt);
 R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -668,13 +668,12 @@ R_API int r_core_print_disasm_instructions_with_buf(RCore *core, ut64 address, u
 R_API int r_core_print_disasm_instructions(RCore *core, int nb_bytes, int nb_opcodes);
 R_API int r_core_print_disasm_all(RCore *core, ut64 addr, int l, int len, int mode);
 
-typedef enum {
-	address,
+enum pdu_condition {
 	esil,
 	instruction,
 	opcode
-} PDU_CONDITION;
-R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, PDU_CONDITION condition_type, const void *condition, bool json, PJ *pj, RAnalFunction *pdf);
+};
+R_API int r_core_print_disasm_until(RCore *core, ut64 addr, ut8 *buf, int len, enum pdu_condition condition_type, const char *condition, bool json, PJ *pj, RAnalFunction *pdf);
 
 R_API int r_core_disasm_pdi_with_buf(RCore *core, ut64 address, ut8 *buf, ut32 nb_opcodes, ut32 nb_bytes, int fmt);
 R_API int r_core_disasm_pdi(RCore *core, int nb_opcodes, int nb_bytes, int fmt);

--- a/test/db/cmd/cmd_pdu
+++ b/test/db/cmd/cmd_pdu
@@ -22,17 +22,17 @@ pduo?
 pdus?
 EOF
 EXPECT=<<EOF
-| pdua [addr]    disassemble until address
+| pdua[j] [addr]    disassemble until address
 ---
-| pduc           disassemble until call
+| pduc[j]           disassemble until call
 ---
-| pdue [expr]    disassemble until esil expression
+| pdue[j] [expr]    disassemble until esil expression
 ---
-| pdui [inst]    disassemble until instruction (e.g.: add esp, 0x20)
+| pdui[j] [inst]    disassemble until instruction (e.g.: add esp, 0x20)
 ---
-| pduo [opcode]  disassemble until opcode (e.g.: mul)
+| pduo[j] [opcode]  disassemble until opcode (e.g.: mul)
 ---
-| pdus           disassemble until syscall
+| pdus[j]           disassemble until syscall
 EOF
 RUN
 
@@ -98,6 +98,7 @@ EOF
 RUN
 
 NAME=pdue
+BROKEN=1
 CMDS=<<EOF
 pdue
 EOF

--- a/test/db/cmd/cmd_pdu
+++ b/test/db/cmd/cmd_pdu
@@ -1,0 +1,120 @@
+NAME=pdu prints help
+CMDS=<<EOF
+pdu~[0]:0
+EOF
+EXPECT=<<EOF
+Usage:
+EOF
+RUN
+
+NAME=pduX help
+CMDS=<<EOF
+pdua?
+?e ---
+pduc?
+?e ---
+pdue?
+?e ---
+pdui?
+?e ---
+pduo?
+?e ---
+pdus?
+EOF
+EXPECT=<<EOF
+| pdua [addr]    disassemble until address
+---
+| pduc           disassemble until call
+---
+| pdue [expr]    disassemble until esil expression
+---
+| pdui [inst]    disassemble until instruction (e.g.: add esp, 0x20)
+---
+| pduo [opcode]  disassemble until opcode (e.g.: mul)
+---
+| pdus           disassemble until syscall
+EOF
+RUN
+
+NAME=pdua
+CMDS=<<EOF
+wx 5e4889e24883e4f05054
+pdua 10
+?e ----
+s 4
+pdua 10
+EOF
+EXPECT=<<EOF
+            0x00000000      5e             pop rsi
+            0x00000001      4889e2         mov rdx, rsp
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      50             push rax
+            0x00000009      54             push rsp
+----
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      50             push rax
+            0x00000009      54             push rsp
+EOF
+RUN
+
+NAME=pduc
+CMDS=<<EOF
+wx 5e4889e24883e4f0e841424344
+pduc
+EOF
+EXPECT=<<EOF
+            0x00000000      5e             pop rsi
+            0x00000001      4889e2         mov rdx, rsp
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      e841424344     call 0x4443424e
+EOF
+RUN
+
+NAME=pdui
+CMDS=<<EOF
+wx 5e4889e24883e4f05054
+pdui push rsp
+EOF
+EXPECT=<<EOF
+            0x00000000      5e             pop rsi
+            0x00000001      4889e2         mov rdx, rsp
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      50             push rax
+            0x00000009      54             push rsp
+EOF
+RUN
+
+NAME=pduo
+CMDS=<<EOF
+wx 5e4889e24883e4f05054
+pduo push
+EOF
+EXPECT=<<EOF
+            0x00000000      5e             pop rsi
+            0x00000001      4889e2         mov rdx, rsp
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      50             push rax
+EOF
+RUN
+
+NAME=pdue
+CMDS=<<EOF
+pdue
+EOF
+EXPECT=<<EOF
+unimplemented
+EOF
+RUN
+
+NAME=pdus
+CMDS=<<EOF
+wx 5e4889e24883e4f00f05
+pdus
+EOF
+EXPECT=<<EOF
+            0x00000000      5e             pop rsi
+            0x00000001      4889e2         mov rdx, rsp
+            0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
+            0x00000008      0f05           syscall
+EOF
+RUN

--- a/test/db/cmd/cmd_pdu
+++ b/test/db/cmd/cmd_pdu
@@ -10,29 +10,57 @@ RUN
 NAME=pduX help
 CMDS=<<EOF
 pdua?
+pduaj?
+pdua
+pduaj
 ?e ---
 pduc?
+pducj?
 ?e ---
 pdue?
+pduej?
+pdue
+pduej
 ?e ---
 pdui?
+pduij?
+pdui
+pduij
 ?e ---
 pduo?
+pduoj?
+pduo
+pduoj
 ?e ---
 pdus?
+pdusj?
 EOF
 EXPECT=<<EOF
-| pdua[j] [addr]    disassemble until address
+| pdua[j] [addr]  disassemble until address
+| pdua[j] [addr]  disassemble until address
+| pdua[j] [addr]  disassemble until address
+| pdua[j] [addr]  disassemble until address
 ---
-| pduc[j]           disassemble until call
+| pduc[j]  disassemble until call
+| pduc[j]  disassemble until call
 ---
-| pdue[j] [expr]    disassemble until esil expression
+| pdue[j] [expr]  disassemble until esil expression
+| pdue[j] [expr]  disassemble until esil expression
+| pdue[j] [expr]  disassemble until esil expression
+| pdue[j] [expr]  disassemble until esil expression
 ---
-| pdui[j] [inst]    disassemble until instruction (e.g.: add esp, 0x20)
+| pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
+| pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
+| pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
+| pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
 ---
 | pduo[j] [opcode]  disassemble until opcode (e.g.: mul)
+| pduo[j] [opcode]  disassemble until opcode (e.g.: mul)
+| pduo[j] [opcode]  disassemble until opcode (e.g.: mul)
+| pduo[j] [opcode]  disassemble until opcode (e.g.: mul)
 ---
-| pdus[j]           disassemble until syscall
+| pdus[j]  disassemble until syscall
+| pdus[j]  disassemble until syscall
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pdu
+++ b/test/db/cmd/cmd_pdu
@@ -7,7 +7,7 @@ Usage:
 EOF
 RUN
 
-NAME=pduX help
+NAME=pdu subcommand help
 CMDS=<<EOF
 pdua?
 pduaj?
@@ -16,11 +16,6 @@ pduaj
 ?e ---
 pduc?
 pducj?
-?e ---
-pdue?
-pduej?
-pdue
-pduej
 ?e ---
 pdui?
 pduij?
@@ -43,11 +38,6 @@ EXPECT=<<EOF
 ---
 | pduc[j]  disassemble until call
 | pduc[j]  disassemble until call
----
-| pdue[j] [expr]  disassemble until esil expression
-| pdue[j] [expr]  disassemble until esil expression
-| pdue[j] [expr]  disassemble until esil expression
-| pdue[j] [expr]  disassemble until esil expression
 ---
 | pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
 | pdui[j] [inst]  disassemble until instruction (e.g.: add esp, 0x20)
@@ -122,16 +112,6 @@ EXPECT=<<EOF
             0x00000001      4889e2         mov rdx, rsp
             0x00000004      4883e4f0       and rsp, 0xfffffffffffffff0
             0x00000008      50             push rax
-EOF
-RUN
-
-NAME=pdue
-BROKEN=1
-CMDS=<<EOF
-pdue
-EOF
-EXPECT=<<EOF
-unimplemented
 EOF
 RUN
 


### PR DESCRIPTION
**Checklist**

- [X] Closing issues: #18739
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)

**Description**

Initial implementation of `pdu` commands. All of the proposed commands have been implemented except for `pdue` and they all have tests.

`r_core_print_disasm()` has been modified to add condition type and pointer arguments. Internally, each condition type can be cast from void* and placed in their own special variable. To add a new condition type, add a new entry to the condition type enumeration in r_core.h and handle it in both cmd_pdu() and r_core_print_disasm()