### PR TITLE
fix esil for bnd jmp x86 instrs and cmn arm instrs ##esil

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -1895,10 +1895,8 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 		break;
 	}
 	case ARM64_INS_CCMP:
-	case ARM64_INS_CCMN:
 	case ARM64_INS_TST: // cmp w8, 0xd
 	case ARM64_INS_CMP: // cmp w8, 0xd
-	case ARM64_INS_CMN: // cmp w8, 0xd
 		ARG64_APPEND(&op->esil, 1);
 		COMMA(&op->esil);
 		ARG64_APPEND(&op->esil, 0);
@@ -1906,6 +1904,20 @@ static int analop64_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int l
 			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) -1);
 	
 		if (insn->id == ARM64_INS_CCMP || insn->id == ARM64_INS_CCMN) {
+			r_strbuf_appendf (&op->esil, ",");
+			arm_prefix_cond(op, insn->detail->arm64.cc);
+			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));
+		}
+		break;
+	case ARM64_INS_CMN: 
+	case ARM64_INS_CCMN:
+		ARG64_APPEND(&op->esil, 1);
+		COMMA(&op->esil);
+		ARG64_APPEND(&op->esil, 0);
+		r_strbuf_appendf (&op->esil, ",-1,*,==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,$o,vf,:=",
+			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) -1);
+	
+		if (insn->id == ARM64_INS_CCMN) {
 			r_strbuf_appendf (&op->esil, ",");
 			arm_prefix_cond(op, insn->detail->arm64.cc);
 			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));

--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -1928,10 +1928,8 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	}
 	case ARM64_CCMP:
-	case ARM64_CCMN:
 	case ARM64_TST: // cmp w8, 0xd
 	case ARM64_CMP: // cmp w8, 0xd
-	case ARM64_CMN: // cmp w8, 0xd
 		ARG64_APPEND(&op->esil, 1);
 		COMMA(&op->esil);
 		ARG64_APPEND(&op->esil, 0);
@@ -1939,6 +1937,20 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) -1);
 	
 		if (insn->operation == ARM64_CCMP || insn->operation == ARM64_CCMN) {
+			r_strbuf_appendf (&op->esil, ",");
+			v35arm_prefix_cond(op, insn->operands[3].cond);
+			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64u",<<,|,pstate,:=", GETIMM64 (2));
+		}
+		break;
+	case ARM64_CCMN:
+	case ARM64_CMN:
+		ARG64_APPEND(&op->esil, 1);
+		COMMA(&op->esil);
+		ARG64_APPEND(&op->esil, 0);
+		r_strbuf_appendf (&op->esil, ",-1,*,==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,$o,vf,:=",
+			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) -1);
+	
+		if (insn->operation == ARM64_CCMN) {
 			r_strbuf_appendf (&op->esil, ",");
 			v35arm_prefix_cond(op, insn->operands[3].cond);
 			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64u",<<,|,pstate,:=", GETIMM64 (2));

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -2043,7 +2043,11 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			r_strbuf_appendf (&op->esil, ",%s,--=,0,GOTO", counter);
 		}
 	}
-	if (op->prefix & R_ANAL_OP_PREFIX_REPNE) {
+	// Intel MPX changes the REPNE prefix to mean BND for jmps, etc
+	// its barely used anymore so the best thing to do is ignore
+	if (op->prefix & R_ANAL_OP_PREFIX_REPNE && !(op->type & 
+		(R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET))) {
+
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		r_strbuf_appendf (&op->esil, ",%s,--=,zf,?{,BREAK,},0,GOTO", counter);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

This PR fixes the an issue where `bnd jmp` instructions had ESIL corresponding to `repne jmp` because Intel MPX changed the `repne` prefix to mean `bnd` on control flow instructions. it was a security thing that no longer does anything so we too will ignore it 

It also fixes the `cmn` instruction ESIL which is supposed to compare the negative of the register value to the second operand, but instead was being treated as a normal cmp. 