### PR TITLE
WIP: Add safe static lock initialization ##util

### DIFF
--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -32,12 +32,9 @@
 # define R_TH_LOCAL
 #endif
 
-#if HAVE_TH_LOCAL
-// #warning HAVE TLS
-// #include <threads.h>
-// #include <stdatomic.h>
-#else
-// #warning LACK TLS
+#if __STDC_VERSION__ >= 201112L && !defined (_MSC_VER)
+# define HAVE_STDATOMIC_H 1
+# include <stdatomic.h>
 #endif
 
 #if WANT_THREADS
@@ -104,9 +101,23 @@ typedef struct r_th_sem_t {
 	R_TH_SEM_T sem;
 } RThreadSemaphore;
 
+typedef enum r_th_lock_type_t {
+	R_TH_LOCK_TYPE_STATIC = 0,
+	R_TH_LOCK_TYPE_HEAP,
+} RThreadLockType;
+
 typedef struct r_th_lock_t {
+#ifdef HAVE_STDATOMIC_H
+	atomic_bool activating;
+#endif
+	struct {
+		ut8 active : 1;
+		RThreadLockType type : 7;
+	};
 	R_TH_LOCK_T lock;
 } RThreadLock;
+
+#define R_THREAD_LOCK_INIT {0}
 
 typedef struct r_th_cond_t {
 	R_TH_COND_T cond;

--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -19,22 +19,30 @@
 # define HAVE_TH_LOCAL 1
 # define R_TH_LOCAL __thread
 
+# define HAVE_STDATOMIC_H 0
+# define R_ATOMIC_BOOL int
+
 #elif _MSC_VER
 # define HAVE_TH_LOCAL 1
 # define R_TH_LOCAL __declspec( thread )
+
+# define HAVE_STDATOMIC_H 0
+# define R_ATOMIC_BOOL int
 
 #elif __STDC_VERSION__ >= 201112L
 # define HAVE_TH_LOCAL 1
 # define R_TH_LOCAL _Thread_local
 
+# define HAVE_STDATOMIC_H 1
+# include <stdatomic.h>
+# define R_ATOMIC_BOOL atomic_bool
+
 #else
 # define HAVE_TH_LOCAL 0
 # define R_TH_LOCAL
-#endif
 
-#if __STDC_VERSION__ >= 201112L && !defined (_MSC_VER)
-# define HAVE_STDATOMIC_H 1
-# include <stdatomic.h>
+# define HAVE_STDATOMIC_H 0
+# define R_ATOMIC_BOOL int
 #endif
 
 #if WANT_THREADS
@@ -107,9 +115,7 @@ typedef enum r_th_lock_type_t {
 } RThreadLockType;
 
 typedef struct r_th_lock_t {
-#ifdef HAVE_STDATOMIC_H
-	atomic_bool activating;
-#endif
+	R_ATOMIC_BOOL activating;
 	struct {
 		ut8 active : 1;
 		RThreadLockType type : 7;

--- a/libr/parse/code.c
+++ b/libr/parse/code.c
@@ -9,6 +9,7 @@
 #include "c/tccpp.c"
 #include "c/libtcc.c"
 
+static R_TH_LOCAL RThreadLock r_tcc_lock = R_THREAD_LOCK_INIT;
 static R_TH_LOCAL TCCState *s1 = NULL;
 extern int tcc_sym_push(TCCState *s1, char *typename, int typesize, int meta);
 
@@ -35,6 +36,7 @@ static bool __typeLoad(void *p, const char *k, const char *v) {
 	if (!p) {
 		return false;
 	}
+	r_th_lock_enter (&r_tcc_lock);
 	int btype = 0;
 	RAnal *anal = (RAnal*)p;
 	// TCCState *s1 = NULL; // XXX THIS WILL MAKE IT CRASH
@@ -80,6 +82,7 @@ static bool __typeLoad(void *p, const char *k, const char *v) {
 		}
 		tcc_sym_push (s1, (char *)typename, typesize, btype);
 	}
+	r_th_lock_leave (&r_tcc_lock);
 	return true;
 }
 
@@ -102,8 +105,10 @@ static void __errorFunc(void *opaque, const char *msg) {
 
 R_API char *r_parse_c_file(RAnal *anal, const char *path, const char *dir, char **error_msg) {
 	char *str = NULL;
+	r_th_lock_enter (&r_tcc_lock);
 	TCCState *T = tcc_new (anal->cpu, anal->bits, anal->os);
 	if (!T) {
+		r_th_lock_leave (&r_tcc_lock);
 		return NULL;
 	}
 	s1 = T; // XXX delete global
@@ -127,13 +132,16 @@ R_API char *r_parse_c_file(RAnal *anal, const char *path, const char *dir, char 
 	r_list_free (dirs);
 	free (d);
 	tcc_delete (T);
+	r_th_lock_leave (&r_tcc_lock);
 	return str;
 }
 
 R_API char *r_parse_c_string(RAnal *anal, const char *code, char **error_msg) {
 	char *str = NULL;
+	r_th_lock_enter (&r_tcc_lock);
 	TCCState *T = tcc_new (anal->cpu, anal->bits, anal->os);
 	if (!T) {
+		r_th_lock_leave (&r_tcc_lock);
 		return NULL;
 	}
 	s1 = T; // XXX delete global
@@ -144,5 +152,6 @@ R_API char *r_parse_c_string(RAnal *anal, const char *code, char **error_msg) {
 		R_FREE (str);
 	}
 	tcc_delete (T);
+	r_th_lock_leave (&r_tcc_lock);
 	return str;
 }

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2022 - pancake */
+/* radare - LGPL - Copyright 2009-2022 - pancake, keegan */
 
 #include <r_th.h>
 
@@ -30,6 +30,39 @@ static bool lock_init(RThreadLock *thl, bool recursive) {
 	return true;
 }
 
+static bool r_atomic_exchange(volatile R_ATOMIC_BOOL *data, bool v) {
+#if HAVE_STDATOMIC_H
+	return atomic_exchange_explicit (data, v, memory_order_acquire);
+#elif __GNUC__
+	int orig;
+	int conv = (int)v;
+	__atomic_exchange (data, &conv, &orig, __ATOMIC_ACQUIRE);
+	return orig;
+#elif _MSC_VER
+	int conv = (int)v;
+	return InterlockedExchange (data, conv);
+#else
+	bool orig = v;
+	*data = v;
+	return orig;
+#endif
+}
+
+static void r_atomic_store(volatile R_ATOMIC_BOOL *data, bool v) {
+#if HAVE_STDATOMIC_H
+	atomic_store_explicit (data, v, memory_order_release);
+#elif __GNUC__
+	int conv = (int)v;
+	__atomic_store (data, &conv, __ATOMIC_RELEASE);
+#elif _MSC_VER
+	int conv = (int)v;
+	while (InterlockedExchange (data, conv) != conv)
+		;
+#else
+	*data = v;
+#endif
+}
+
 R_API RThreadLock *r_th_lock_new(bool recursive) {
 	RThreadLock *thl = R_NEW0 (RThreadLock);
 	if (!thl) {
@@ -42,9 +75,7 @@ R_API RThreadLock *r_th_lock_new(bool recursive) {
 
 	thl->type = R_TH_LOCK_TYPE_HEAP;
 	thl->active = 1;
-#ifdef HAVE_STDATOMIC_H
 	thl->activating = 0;
-#endif
 	return thl;
 }
 
@@ -62,19 +93,17 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 
 	// initialize static locks on acquisition
 	if (thl->type == R_TH_LOCK_TYPE_STATIC) {
-#ifdef HAVE_STDATOMIC_H
-		while (atomic_exchange_explicit (&thl->activating, true, memory_order_acquire))
+		// start spinning
+		while (r_atomic_exchange (&thl->activating, true))
 			;
-#endif /* HAVE_STDATOMIC_H */
 
 		if (!thl->active) {
 			lock_init (thl, false);
 			thl->active = 1;
 		}
 
-#ifdef HAVE_STDATOMIC_H
-		atomic_store_explicit (&thl->activating, false, memory_order_release);
-#endif /* HAVE_STDATOMIC_H */
+		// finish spinning
+		r_atomic_store (&thl->activating, false);
 	}
 #if HAVE_PTHREAD
 	return pthread_mutex_lock (&thl->lock);

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -4,32 +4,47 @@
 
 /* locks/mutex/sems */
 
-R_API RThreadLock *r_th_lock_new(bool recursive) {
-	RThreadLock *thl = R_NEW0 (RThreadLock);
-	if (thl) {
+static bool lock_init(RThreadLock *thl, bool recursive) {
 #if HAVE_PTHREAD
-		if (recursive) {
-			pthread_mutexattr_t attr;
-			pthread_mutexattr_init (&attr);
+	if (recursive) {
+		pthread_mutexattr_t attr;
+		pthread_mutexattr_init (&attr);
 #if !defined(__GLIBC__) || __USE_UNIX98__
-			pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
 #else
-			pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE_NP);
-#endif
-			pthread_mutex_init (&thl->lock, &attr);
-		} else {
-			pthread_mutexattr_t attr;
-			pthread_mutexattr_init (&attr);
-			pthread_mutex_init (&thl->lock, &attr);
-		}
+		pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE_NP);
+#endif /* !defined(__GLIBC__) || __USE_UNIX98__ */
+		pthread_mutex_init (&thl->lock, &attr);
+	} else {
+		pthread_mutexattr_t attr;
+		pthread_mutexattr_init (&attr);
+		pthread_mutex_init (&thl->lock, &attr);
+	}
 #elif __WINDOWS__
-		// TODO: obey `recursive` (currently it is always recursive)
-		InitializeCriticalSection (&thl->lock);
+	// TODO: obey `recursive` (currently it is always recursive)
+	InitializeCriticalSection (&thl->lock);
 #else
 #warning Unsupported mutex
-		R_FREE (thl);
-#endif
+	return false;
+#endif /* HAVE_PTHREAD */
+	return true;
+}
+
+R_API RThreadLock *r_th_lock_new(bool recursive) {
+	RThreadLock *thl = R_NEW0 (RThreadLock);
+	if (!thl) {
+		return NULL;
 	}
+
+	if (!lock_init (thl, recursive)) {
+		return NULL;
+	}
+
+	thl->type = R_TH_LOCK_TYPE_HEAP;
+	thl->active = 1;
+#ifdef HAVE_STDATOMIC_H
+	thl->activating = 0;
+#endif
 	return thl;
 }
 
@@ -44,6 +59,23 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 	if (!thl) {
 		return -1;
 	}
+
+	// initialize static locks on acquisition
+	if (thl->type == R_TH_LOCK_TYPE_STATIC) {
+#ifdef HAVE_STDATOMIC_H
+		while (atomic_exchange_explicit (&thl->activating, true, memory_order_acquire))
+			;
+#endif /* HAVE_STDATOMIC_H */
+
+		if (!thl->active) {
+			lock_init (thl, false);
+			thl->active = 1;
+		}
+
+#ifdef HAVE_STDATOMIC_H
+		atomic_store_explicit (&thl->activating, false, memory_order_release);
+#endif /* HAVE_STDATOMIC_H */
+	}
 #if HAVE_PTHREAD
 	return pthread_mutex_lock (&thl->lock);
 #elif __WINDOWS__
@@ -55,6 +87,9 @@ R_API int r_th_lock_enter(RThreadLock *thl) {
 }
 
 R_API int r_th_lock_tryenter(RThreadLock *thl) {
+	if (!thl) {
+		return -1;
+	}
 #if HAVE_PTHREAD
 	return !pthread_mutex_trylock (&thl->lock);
 #elif __WINDOWS__
@@ -85,7 +120,9 @@ R_API void *r_th_lock_free(RThreadLock *thl) {
 #elif __WINDOWS__
 		DeleteCriticalSection (&thl->lock);
 #endif
-		free (thl);
+		if (thl->type == R_TH_LOCK_TYPE_HEAP) {
+			free (thl);
+		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

* Allows RThreadLock to be initialized on acquisition, which means global locks do not need to be heap allocated

Note: MSVC does not support C11 atomics so those users should make sure they are wearing their seatbelts. I think we could use Windows APIs instead for interlocked exchange/store.

