### PR TITLE
Simpler var counting API

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -769,6 +769,7 @@ R_API char *r_anal_var_get_constraints_readable(RAnalVar *var) {
 }
 
 R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type) {
+	r_return_val_if_fail (fcn && a && type >= 0 && type <= 1, -1);
 	// type { local: 0, arg: 1 };
 	RList *list = r_anal_var_list (a, fcn, kind);
 	RAnalVar *var;
@@ -785,6 +786,30 @@ R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type) {
 	}
 	r_list_free (list);
 	return count[type];
+}
+
+R_API int r_anal_var_count_all(RAnalFunction *fcn) {
+	r_return_val_if_fail (fcn, 0);
+	return r_pvector_len (&fcn->vars);
+}
+
+R_API int r_anal_var_count_args(RAnalFunction *fcn) {
+	r_return_val_if_fail (fcn, 0); // No function implies no variables, but probably mistake
+	int args = 0;
+	void **it;
+	r_pvector_foreach (&fcn->vars, it) {
+		RAnalVar *var = *it;
+		if (var->isarg) {
+			args++;
+		}
+	}
+	return args;
+}
+
+R_API int r_anal_var_count_locals(RAnalFunction *fcn) {
+	// if it's not an arg then it's local
+	int args = r_anal_var_count_args (fcn);
+	return r_anal_var_count_all (fcn) - args;
 }
 
 static bool var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, RList *list) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1879,14 +1879,8 @@ static int core_anal_graph_nodes(RCore *core, RAnalFunction *fcn, int opts, PJ *
 		free (fcn_name_escaped);
 		pj_kn (pj, "offset", fcn->addr);
 		pj_ki (pj, "ninstr", fcn->ninstr);
-		pj_ki (pj, "nargs",
-			r_anal_var_count (core->anal, fcn, 'r', 1) +
-			r_anal_var_count (core->anal, fcn, 's', 1) +
-			r_anal_var_count (core->anal, fcn, 'b', 1));
-		pj_ki (pj, "nlocals",
-			r_anal_var_count (core->anal, fcn, 'r', 0) +
-			r_anal_var_count (core->anal, fcn, 's', 0) +
-			r_anal_var_count (core->anal, fcn, 'b', 0));
+		pj_ki (pj, "nargs", r_anal_var_count_args (fcn));
+		pj_ki (pj, "nlocals", r_anal_var_count_locals (fcn));
 		pj_kn (pj, "size", r_anal_function_linear_size (fcn));
 		pj_ki (pj, "stack", fcn->maxstack);
 		pj_ks (pj, "type", r_anal_functiontype_tostring (fcn->type));
@@ -2693,12 +2687,8 @@ static int fcn_print_verbose(RCore *core, RAnalFunction *fcn, bool use_color) {
 			r_anal_function_linear_size (fcn),
 			addrwidth, r_anal_function_max_addr (fcn),
 			fcn->meta.numcallrefs,
-			r_anal_var_count (core->anal, fcn, 's', 0) +
-			r_anal_var_count (core->anal, fcn, 'b', 0) +
-			r_anal_var_count (core->anal, fcn, 'r', 0),
-			r_anal_var_count (core->anal, fcn, 's', 1) +
-			r_anal_var_count (core->anal, fcn, 'b', 1) +
-			r_anal_var_count (core->anal, fcn, 'r', 1),
+			r_anal_var_count_locals (fcn),
+			r_anal_var_count_args (fcn),
 			fcn->meta.numrefs,
 			fcn->maxstack,
 			name,
@@ -2982,13 +2972,8 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn, PJ *pj) {
 	pj_ki (pj, "outdegree", outdegree);
 
 	if (fcn->type == R_ANAL_FCN_TYPE_FCN || fcn->type == R_ANAL_FCN_TYPE_SYM) {
-		pj_ki (pj, "nlocals", r_anal_var_count (core->anal, fcn, 'b', 0) +
-				r_anal_var_count (core->anal, fcn, 'r', 0) +
-				r_anal_var_count (core->anal, fcn, 's', 0));
-		pj_ki (pj, "nargs", r_anal_var_count (core->anal, fcn, 'b', 1) +
-				r_anal_var_count (core->anal, fcn, 'r', 1) +
-				r_anal_var_count (core->anal, fcn, 's', 1));
-
+		pj_ki (pj, "nlocals", r_anal_var_count_locals (fcn));
+		pj_ki (pj, "nargs", r_anal_var_count_args (fcn));
 		pj_k (pj, "bpvars");
 		r_anal_var_list_show (core->anal, fcn, 'b', 'j', pj);
 		pj_k (pj, "spvars");
@@ -3188,12 +3173,8 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn) {
 	r_list_free (xrefs);
 
 	if (fcn->type == R_ANAL_FCN_TYPE_FCN || fcn->type == R_ANAL_FCN_TYPE_SYM) {
-		int args_count = r_anal_var_count (core->anal, fcn, 'b', 1);
-		args_count += r_anal_var_count (core->anal, fcn, 's', 1);
-		args_count += r_anal_var_count (core->anal, fcn, 'r', 1);
-		int var_count = r_anal_var_count (core->anal, fcn, 'b', 0);
-		var_count += r_anal_var_count (core->anal, fcn, 's', 0);
-		var_count += r_anal_var_count (core->anal, fcn, 'r', 0);
+		int args_count = r_anal_var_count_args (fcn);
+		int var_count = r_anal_var_count_locals (fcn);
 
 		r_cons_printf ("\nlocals: %d\nargs: %d\n", var_count, args_count);
 		r_anal_var_list_show (core->anal, fcn, 'b', 0, NULL);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -11574,9 +11574,7 @@ static void cmd_anal_aC(RCore *core, const char *input) {
 			int i, nargs = 4; // DEFAULT_NARGS;
 			if (fcn) {
 				// @TODO: fcn->nargs should be updated somewhere and used here instead
-				nargs = r_anal_var_count (core->anal, fcn, 's', 1) +
-					r_anal_var_count (core->anal, fcn, 'b', 1) +
-					r_anal_var_count (core->anal, fcn, 'r', 1);
+				nargs = r_anal_var_count_args (fcn);
 			}
 			if (nargs > 0) {
 				if (fcn_name) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5040,9 +5040,7 @@ static void ds_print_esil_anal(RDisasmState *ds) {
 				nargs = DEFAULT_NARGS;
 				if (fcn) {
 					// @TODO: fcn->nargs should be updated somewhere and used here instead
-					nargs = r_anal_var_count (core->anal, fcn, 's', 1) +
-							r_anal_var_count (core->anal, fcn, 'b', 1) +
-							r_anal_var_count (core->anal, fcn, 'r', 1);
+					nargs = r_anal_var_count_args (fcn);
 				}
 				if (nargs > 0) {
 					ds_comment_esil (ds, true, false, "%s", ds->show_color? ds->pal_comment : "");

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1686,6 +1686,9 @@ R_API void r_anal_function_update_analysis(RAnalFunction *fcn);
 R_API int r_anal_function_var_del_byindex(RAnal *a, ut64 fna, const char kind, int scope, ut32 idx);
 /* args */
 R_API int r_anal_var_count(RAnal *a, RAnalFunction *fcn, int kind, int type);
+R_API int r_anal_var_count_all(RAnalFunction *fcn);
+R_API int r_anal_var_count_args(RAnalFunction *fcn);
+R_API int r_anal_var_count_locals(RAnalFunction *fcn);
 
 /* vars // globals. not here  */
 R_API bool r_anal_var_display(RAnal *anal, RAnalVar *var);


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

I noticed `r_anal_var_count` is almost always called multiple times to get a count of all local or argument variables. Additionally, the function unnecessarily allocates/de-allocates a list. So I created a simpler API to get that information. It should run slightly faster and clean up some code.