### PR TITLE
Fix Negative Offset in Hexdump Json Output

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6541,7 +6541,7 @@ static int cmd_print(void *data, const char *input) {
 		r_cons_break_push (NULL, NULL);
 		switch (input[1]) {
 		case 'j': // "pxj"
-			r_print_jsondump (core->print, core->block, core->num->value, 8);
+			r_print_jsondump (core->print, core->block, len, 8);
 			break;
 		case '/': // "px/"
 			r_core_print_examine (core, input + 2);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6541,7 +6541,7 @@ static int cmd_print(void *data, const char *input) {
 		r_cons_break_push (NULL, NULL);
 		switch (input[1]) {
 		case 'j': // "pxj"
-			r_print_jsondump (core->print, core->block, core->blocksize, 8);
+			r_print_jsondump (core->print, core->block, core->num->value, 8);
 			break;
 		case '/': // "px/"
 			r_core_print_examine (core, input + 2);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6541,7 +6541,7 @@ static int cmd_print(void *data, const char *input) {
 		r_cons_break_push (NULL, NULL);
 		switch (input[1]) {
 		case 'j': // "pxj"
-			r_print_jsondump (core->print, core->block, len, 8);
+			r_print_jsondump (core->print, block, len, 8);
 			break;
 		case '/': // "px/"
 			r_core_print_examine (core, input + 2);


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

When the user try to get a json output of a negative relative offset in the `px` command, it will always get a fixed `256` data block.

This fix will rely in the `core->num->value` instead the `core->blocksize` when passing it to `r_print_jsondump` making the output correct.

How to reproduce:

`xj -10`
<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
