### PR TITLE
Fix order of operations in the ESIL code of pop with memory operand

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1160,9 +1160,19 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 			case X86_OP_MEM:
 				{
 					dst = getarg (&gop, 0, 1, NULL, DST_AR, NULL);
+					// It is important that we calculate the address
+					// of the destination operand AFTER we increased
+					// the stack pointer.
+					//
+					// Qouting the Intel manual:
+					//
+					// If the ESP register is used as a base register
+					// for addressing a destination operand in memory,
+					// the POP instruction computes the effective address
+					// of the operand after it increments the ESP register.
 					esilprintf (op,
-						"%s,[%d],%s,%d,%s,+=",
-						sp, rs, dst, rs, sp);
+						"%s,[%d],%d,%s,+=,%s",
+						sp, rs, rs, sp, dst);
 					break;
 				}
 			case X86_OP_REG:

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -556,3 +556,16 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=pop mem rsp
+FILE=-
+CMDS=<<EOF
+aei; aeim
+"wa push 0x41414141; push 0x42424242; pop [rsp]"
+3.aes
+pv4 @ rsp
+EOF
+EXPECT=<<EOF
+0x42424242
+EOF
+RUN


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->

The ESIL code of the x86 instruction `pop [rsp]` was wrong, because the calculated memory destination was the value of `rsp` **before** the `pop` instruction; this is wrong behaviour according to the Intel manual:

If the ESP register is used as a base register for addressing a destination operand in memory, the POP instruction computes the effective address of the operand after it increments the ESP register.