### PR TITLE
Partial #19687: Add release github actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,16 @@ jobs:
           asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_name: radare2_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_content_type: application/vnd.debian.binary-package
-      - name: Upload asset for Windows (mingw64)
+      - name: Upload asset for Windows (w64)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/artifact/radare2-${{ steps.r2v.outputs.branch }}-mingw64.zip
-          asset_name: radare2-${{ steps.r2v.outputs.branch }}-mingw64.zip
+          asset_path: dist/artifacts/artifact/radare2-${{ steps.r2v.outputs.branch }}-w64.zip
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-w64.zip
           asset_content_type: application/zip
-      - name: Upload asset for Windows (mingw32)
+      - name: Upload asset for Windows (w32)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-w32.zip/radare2-${{ steps.r2v.outputs.branch }}-w32.zip
-          asset_name: radare2-${{ steps.r2v.outputs.branch }}-mingw32.zip
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-w32.zip
           asset_content_type: application/zip
       - name: Upload asset for macOS
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,185 @@
+name: release
+on:
+  push:
+    tags:
+      - '*.*.*'
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Extract r2 version
+        run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
+        id: r2v
+      - name: Prepare release notes
+        run: ./sys/release-notes.sh | tee ./RELEASE_NOTES.md
+      - name: Download artifacts
+        env:
+          REPO: ${{ github.repository }}
+          COMMIT: ${{ github.sha }}
+          DESTDIR: dist/artifacts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID=`gh run --repo "${REPO}" list --workflow "ci.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
+          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
+          RUN_ID=`gh run --repo "${REPO}" list --workflow "windows.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
+          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
+          RUN_ID=`gh run --repo "${REPO}" list --workflow "freebsd.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
+          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
+          find "${DESTDIR}" -type f
+      - name: Create GitHub release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: ./RELEASE_NOTES.md
+          draft: false
+          prerelease: false
+      - name: Upload asset for Debian (amd64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_amd64.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_name: radare2_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for Debian (i386)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_name: radare2_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for Windows (mingw64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/artifact/radare2-${{ steps.r2v.outputs.branch }}-mingw64.zip
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-mingw64.zip
+          asset_content_type: application/zip
+      - name: Upload asset for Windows (mingw32)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-w32.zip/radare2-${{ steps.r2v.outputs.branch }}-w32.zip
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-mingw32.zip
+          asset_content_type: application/zip
+      - name: Upload asset for macOS
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}_macos.pkg/radare2-${{ steps.r2v.outputs.branch }}.pkg
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}.pkg
+          asset_content_type: application/x-xar
+      - name: Upload asset for iPhoneOS (arm)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}_iphoneos-arm64.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_name: radare2_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for iPhoneOS (arm32)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_name: radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for iOS SDK
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/r2ios_sdk-${{ steps.r2v.outputs.branch }}.zip/r2ios-sdk.zip
+          asset_name: r2ios-sdk-${{ steps.r2v.outputs.branch }}.zip
+          asset_content_type: application/zip
+      - name: Upload asset for Android (arm)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz/radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload asset for Android (x86_64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-x86_64.tar.gz/radare2-android-x86_64.tar.gz
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-x86_64.tar.gz
+          asset_content_type: application/x-tar
+      - name: Upload asset for Android (aarch64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz/radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
+          asset_content_type: application/gzip
+      - name: Upload asset for Linux (static)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz/r2-static.tar.xz
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz
+          asset_content_type: application/x-xz
+      - name: Upload asset for Debian dev (amd64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_amd64.zip/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_name: radare2-dev_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for Debian dev (i386)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_name: radare2-dev_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload asset for WASI
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
+          asset_content_type: application/zip
+      - name: Upload asset for FreeBSD
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/artifacts/artifact/radare2-freebsd.tgz
+          asset_name: radare2-${{ steps.r2v.outputs.branch }}-freebsd.tgz
+          asset_content_type: application/gzip


### PR DESCRIPTION
This pull request implements "Automatically publish artifacts in releases" from #19687.

It has been implemented all in one file, alternatively "Download artifacts" can be moved as script in `sys`.
Also using [dawidd6/action-download-artifact@v2](https://github.com/dawidd6/action-download-artifact#readme) has been discarted to reduce external code execution during release creation.