### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,7 +72,11 @@ endif
 if host_machine.system() == 'windows'
   r2birth = run_command('cmd', '/c', 'echo %date%__%time%')
 else
-  r2birth = run_command('date', '+%Y-%m-%d__%H:%M:%S')
+  source_date_epoch = run_command('sh', '-c', 'echo $SOURCE_DATE_EPOCH').stdout().strip()
+  if source_date_epoch == ''
+     source_date_epoch = run_command('date', '+%s').stdout().strip()
+  endif
+  r2birth = run_command('date', '-u', '-d', '@' + source_date_epoch, '+%Y-%m-%d__%H:%M:%S')
 endif
 if r2birth.returncode() != 0
   r2birth = ''


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)


**Description**

Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call only works with GNU date. *Is MacOS-support required?*

Also use UTC to be independent of timezone.

This is the equivalent of 6b260b87c3345568ebeddf57fbe95c864ee8baf2 for meson.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).


<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->