### PR TITLE
Prefer memleak over UAF in io.bank's rbtree bug ##crash

### DIFF
--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -226,12 +226,18 @@ R_API bool r_io_bank_map_add_top(RIO *io, const ut32 bankid, const ut32 mapid) {
 		r_io_submap_set_to (bd, r_io_submap_from (sm) - 1);
 		entry = r_rbnode_next (entry);
 	}
-	while (entry && r_io_submap_to (((RIOSubMap *)entry->data)) <= r_io_submap_to (sm)) {
+	ut64 smto = r_io_submap_to (sm);
+	while (entry && r_io_submap_to (((RIOSubMap *)entry->data)) <= smto) {
 		//delete all submaps that are completly included in sm
 		RRBNode *next = r_rbnode_next (entry);
 		// this can be optimized, there is no need to do search here
+		// XXX this is a workaround to avoid an UAF in Reproducer: iobank-crash
+		void *smfree = bank->submaps->free;
+		bank->submaps->free = NULL;
 		bool a = r_crbtree_delete (bank->submaps, entry->data, _find_sm_by_from_vaddr_cb, NULL);
+		bank->submaps->free = smfree;
 		if (!a) {
+			entry = NULL;
 			break;
 		}
 		entry = next;

--- a/libr/util/new_rbtree.c
+++ b/libr/util/new_rbtree.c
@@ -138,9 +138,9 @@ R_API bool r_crbtree_insert(RRBTree *tree, void *data, RRBComparator cmp, void *
 	r_return_val_if_fail (tree && data && cmp, false);
 	bool inserted = false;
 
-	if (tree->root == NULL) {
+	if (!tree->root) {
 		tree->root = _node_new (data, NULL);
-		if (tree->root == NULL) {
+		if (!tree->root) {
 			return false;
 		}
 		inserted = true;


### PR DESCRIPTION
* That's a workaround, proper fix will come later
* Reproducer: bins/fuzzed/iobank-crash
* Reported by Akyne Choi via huntr.dev

<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->
