### PR TITLE
Prevent leak when jumptable has size hint ##anal

### DIFF
--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -455,15 +455,6 @@ R_API bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAnal
 	// default case is the jump target of the unconditional jump
 	*default_case = prev_bb->jump == my_bb->addr ? prev_bb->fail : prev_bb->jump;
 
-	RAnalOp tmp_aop = {0};
-	ut8 *bb_buf = calloc (1, prev_bb->size);
-	if (!bb_buf) {
-		return false;
-	}
-	// search for a cmp register with a reasonable size
-	anal->iob.read_at (anal->iob.io, prev_bb->addr, (ut8 *) bb_buf, prev_bb->size);
-	isValid = false;
-
 	RAnalHint *hint = r_anal_hint_get (anal, addr);
 	if (hint) {
 		ut64 val = hint->val;
@@ -473,6 +464,15 @@ R_API bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAnal
 			return true;
 		}
 	}
+
+	RAnalOp tmp_aop = {0};
+	ut8 *bb_buf = calloc (1, prev_bb->size);
+	if (!bb_buf) {
+		return false;
+	}
+	// search for a cmp register with a reasonable size
+	anal->iob.read_at (anal->iob.io, prev_bb->addr, (ut8 *) bb_buf, prev_bb->size);
+	isValid = false;
 
 	RRegItem *cmp_reg = NULL;
 	for (i = prev_bb->ninstr - 1; i >= 0; i--) {


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

If a hint is used then the code returns without free'ing `bb_buf`. This moves the early return for a code hint to just before `bb_buf` allocation, so no extra free case needs to be done.
