### PR TITLE
Rework `SOURCE_DATE_EPOCH` usage be portable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -72,11 +72,12 @@ endif
 if host_machine.system() == 'windows'
   r2birth = run_command('cmd', '/c', 'echo %date%__%time%')
 else
-  source_date_epoch = run_command('sh', '-c', 'echo $SOURCE_DATE_EPOCH').stdout().strip()
-  if source_date_epoch == ''
-     source_date_epoch = run_command('date', '+%s').stdout().strip()
-  endif
-  r2birth = run_command('date', '-u', '-d', '@' + source_date_epoch, '+%Y-%m-%d__%H:%M:%S')
+  r2birth = run_command('sh', '-c', '''
+      SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-`date +%s`}";
+      FORMAT="+%Y-%m-%d__%H:%M:%S";
+      date -u -d @"$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
+      date -u -r  "$SOURCE_DATE_EPOCH" "$FORMAT" 2>/dev/null ||
+      date -u "$FORMAT"''')
 endif
 if r2birth.returncode() != 0
   r2birth = ''


### PR DESCRIPTION
<!-- Please read the contributing guidelines:
* https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
In short:
* PR title must be capitalized, concise and use ##tags
* Follow the coding style, add tests and documentation if necessary
-->

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [radare2book](https://github.com/radareorg/radare2book)

**Description**

As a follow-up of #19699,
Rework `SOURCE_DATE_EPOCH` usage in meson to be portable
to make @rofl0r and FreeBSD users happy.

Please test.

<!-- Explain the **details** to understand the purpose of this contribution, with enough information to help us understand better the changes. -->