### PR TITLE
Fix Windows console mouse disable escape sequence ##windows

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -562,8 +562,8 @@ R_API bool r_cons_enable_mouse(const bool enable) {
 #endif
 		const char *click = enable
 			? "\x1b[?1000;1006;1015h"
-			: "\x1b[?1001r"
-			  "\x1b[?1000l";
+			: "\x1b[?1000;1006;1015l";
+			// : "\x1b[?1001r\x1b[?1000l";
 		// : "\x1b[?1000;1006;1015l";
 		// const char *old = enable ? "\x1b[?1001s" "\x1b[?1000h" : "\x1b[?1001r" "\x1b[?1000l";
 		bool enabled = I->mouse;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
