### PR TITLE
Fix #19687 - Correct types definitions for ptrace(2) on FreeBSD ##io

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -58,7 +58,7 @@ typedef void * r_ptrace_data_t;
 #elif __APPLE__
 typedef int r_ptrace_request_t;
 typedef int r_ptrace_data_t;
-#elif __OpenBSD__
+#elif __OpenBSD__ || __FreeBSD__
 typedef int r_ptrace_request_t;
 typedef int r_ptrace_data_t;
 #define R_PTRACE_NODATA 0


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

### libr/include/r_io.h
- Argument  **r_ptrace_data_t** needs to be **int** instead of **void**  on FreeBSD ptrace(2)
- Then **R_PTRACE_NODATA** should be initialized as **0** instead of **NULL**

<!-- explain your changes if necessary -->
