### PR TITLE
Early break when parsing corrupted DEXs to avoid DoS ##crash

### DIFF
--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -267,8 +267,12 @@ static char *dex_get_proto(RBinDexObj *bin, int proto_id) {
 	}
 	size_t typeidx_bufsize = (list_size * sizeof (ut16));
 	if (params_off + typeidx_bufsize > bin->size) {
+		eprintf ("Warning: truncated typeidx buffer from %d to %d\n",
+			params_off + typeidx_bufsize, bin->size - params_off);
 		typeidx_bufsize = bin->size - params_off;
-		eprintf ("Warning: truncated typeidx buffer\n");
+		// early return as this may result on so many trashy symbols that take too much time to load
+		// this is only happening when there's a corrupted dex.
+		return NULL;
 	}
 	RStrBuf *sig = r_strbuf_new ("(");
 	if (typeidx_bufsize > 0) {

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -268,7 +268,7 @@ static char *dex_get_proto(RBinDexObj *bin, int proto_id) {
 	size_t typeidx_bufsize = (list_size * sizeof (ut16));
 	if (params_off + typeidx_bufsize > bin->size) {
 		eprintf ("Warning: truncated typeidx buffer from %d to %d\n",
-			params_off + typeidx_bufsize, bin->size - params_off);
+			(int)(params_off + typeidx_bufsize), (int)(bin->size - params_off));
 		typeidx_bufsize = bin->size - params_off;
 		// early return as this may result on so many trashy symbols that take too much time to load
 		// this is only happening when there's a corrupted dex.


### PR DESCRIPTION
* Reported by Google clusterfuzz
* Reproducer: clusterfuzz-testcase-minimized-ia_fuzz-5227091270959104

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
