### PR TITLE
Partial #19687: Create download artifacts script and other CI changes

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,73 @@
+name: android
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  android-acr-aarch64:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get --assume-yes install pax wget gperf cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
+    - name: Compile with acr
+      run: |
+        sys/android-ndk-install.sh
+        sys/android-build.sh arm64
+        ls -l
+    - uses: actions/upload-artifact@v2
+      with:
+        name: android-acr-aarch64
+        path: radare2*android*aarch64.tar.gz
+
+  android-acr-arm:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get --assume-yes install pax wget gperf cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
+    - name: Compile with acr
+      run: |
+        sys/android-ndk-install.sh 16 arm
+        sys/android-build.sh arm
+        ls -l
+    - uses: actions/upload-artifact@v2
+      with:
+        name: android-acr-arm
+        path: radare2*android*arm.tar.gz
+
+  android-meson:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+      #  name: [x86_64, arm, aarch64]
+        name: [x86_64]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get --assume-yes install pax wget cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
+    - name: Compile with meson
+      run: |
+        export PATH=${HOME}/.local/bin:${PATH}
+        CFLAGS="-static" LDFLAGS="-static" meson --buildtype release --default-library static --prefix=/tmp/android-dir -Dblob=true build --cross-file .github/meson-android-${{ matrix.name }}.ini
+        ninja -C build && ninja -C build install
+    - name: Create radare2-android-${{ matrix.name }}.tar.gz
+      run: |
+        cd /tmp
+        rm -rf android-dir/include android-dir/lib
+        tar --transform 's/android-dir/data\/data\/org.radareorg.radare2installer/g' -cvf radare2-android-${{ matrix.name }}.tar.gz android-dir/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: android-meson
+        path: /tmp/radare2-android-${{ matrix.name }}.tar.gz

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         name: android-acr-aarch64
         path: radare2*android*aarch64.tar.gz
+        retention-days: 30
 
   android-acr-arm:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
@@ -44,6 +45,7 @@ jobs:
       with:
         name: android-acr-arm
         path: radare2*android*arm.tar.gz
+        retention-days: 30
 
   android-meson:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
@@ -71,3 +73,4 @@ jobs:
       with:
         name: android-meson
         path: /tmp/radare2-android-${{ matrix.name }}.tar.gz
+        retention-days: 30

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         path: dist/macos/*.pkg
         name: macos-acr
+        retention-days: 30
 #   macos-acr-m1:
 #     runs-on: macos-latest
 #     steps:
@@ -36,6 +37,7 @@ jobs:
 #       with:
 #         path: dist/macos/*.pkg
 #         name: macos-acr-m1
+#         retention-days: 30
 
   # Mobile
   ios-cydia32:
@@ -53,6 +55,7 @@ jobs:
       with:
         name: ios-cydia32
         path: ./dist/cydia/radare2/radare2-arm32_*_iphoneos-arm.deb
+        retention-days: 30
   ios-cydia:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
     runs-on: macos-latest
@@ -75,3 +78,4 @@ jobs:
         path: |
           ./r2ios-sdk.zip
           ./dist/cydia/radare2*/*.deb
+        retention-days: 30

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -1,0 +1,77 @@
+name: apple
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  # macOS
+  macos-acr:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Packaging
+      run: dist/macos/build-pkg.sh
+#    - name: Building Radare2
+#      run: |
+#        export CFLAGS="-O2" # -Werror -Wno-unused-result -Wno-unicode -Wno-unneeded-internal-declaration"
+#        sys/install.sh && make -C dist/macos
+    - name: Pub
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist/macos/*.pkg
+        name: macos-acr
+#   macos-acr-m1:
+#     runs-on: macos-latest
+#     steps:
+#     - name: Checkout
+#       uses: actions/checkout@v2
+#     - name: Packaging
+#       run: export CC="xcrun --sdk macosx11.1 gcc -arch arm64" ; dist/macos/build-pkg.sh
+#     - name: Pub
+#       uses: actions/upload-artifact@v2
+#       with:
+#         path: dist/macos/*.pkg
+#         name: macos-acr-m1
+
+  # Mobile
+  ios-cydia32:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install pkg-config/ldid2 with Homebrew
+      run: brew install pkg-config ldid
+    - name: Create cydia32 package
+      run: ./sys/ios-cydia32.sh
+    - name: List sys/cydia
+      run: ls -lahR ./dist/cydia
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ios-cydia32
+        path: ./dist/cydia/radare2/radare2-arm32_*_iphoneos-arm.deb
+  ios-cydia:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install pkg-config/ldid2 with Homebrew
+      run: brew install pkg-config ldid
+    - name: Create cydia package
+      run: ./sys/ios-cydia.sh
+    - name: Create iOS SDK
+      run: |
+        ./sys/ios-sdk.sh
+        pushd /tmp/r2ios
+        zip -r /tmp/r2ios-sdk.zip *
+        popd
+        mv /tmp/r2ios-sdk.zip .
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ios-cydia
+        path: |
+          ./r2ios-sdk.zip
+          ./dist/cydia/radare2*/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,9 @@ jobs:
     - name: Installing with symlinks
       run: |
         sys/wasi.sh
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - uses: actions/upload-artifact@v2
       with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
+        name: build-wasi
         path: radare2-*-wasi.zip
   build-acr-gperf:
     name: linux-acr-gperf
@@ -200,13 +197,10 @@ jobs:
         # NOLTO=1 sys/static.sh
         make -C binr/blob
         tar cJvf r2-static.tar.xz r2-static
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - name: Pub
       uses: actions/upload-artifact@v2
       with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz
+        name: linux-static
         path: r2-static.tar.xz
     - name: Static r2 build with meson
       run: |
@@ -222,13 +216,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Packaging for Debian
       run: sys/debian.sh
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys; python version.py )"
-      id: r2v
     - name: Pub
       uses: actions/upload-artifact@v2
       with:
-        name: radare2_${{ steps.r2v.outputs.branch }}-debian_amd64.zip
+        name: linux-acr-deb-64
         path: dist/debian/*/*.deb
   linux-acr-deb-32:
     runs-on: ubuntu-18.04
@@ -242,13 +233,10 @@ jobs:
         export LDFLAGS=-m32
         export ARCH=i386
         sys/debian.sh
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - name: Pub
       uses: actions/upload-artifact@v2
       with:
-        name: radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip
+        name: linux-acr-deb-32
         path: dist/debian/*/*.deb
 ## RPM PACKAGES DISABLED
 #  linux-meson-rpm:
@@ -267,6 +255,7 @@ jobs:
 #    - name: Pub
 #      uses: actions/upload-artifact@v2
 #      with:
+#        name: linux-meson-rpm
 #        path: RPMS/*/*.rpm *.rpm dist/rpm/*.rpm
 #  centos-meson-rpm:
 #    runs-on: ubuntu:18.04
@@ -295,6 +284,7 @@ jobs:
 #    - name: Pub
 #      uses: actions/upload-artifact@v2
 #      with:
+#        name: centos-meson-rpm
 #        path: rpmbuild/RPMS/*/*.rpm
   linux-asan-fuzz:
     runs-on: ubuntu-20.04
@@ -346,9 +336,6 @@ jobs:
       uses: actions/checkout@v2
     - name: Packaging
       run: dist/macos/build-pkg.sh
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( python sys/version.py )"
-      id: r2v
 #    - name: Building Radare2
 #      run: |
 #        export CFLAGS="-O2" # -Werror -Wno-unused-result -Wno-unicode -Wno-unneeded-internal-declaration"
@@ -357,7 +344,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: dist/macos/*.pkg
-        name: radare2-${{ steps.r2v.outputs.branch }}_macos.pkg
+        name: macos-acr
 #   macos-acr-m1:
 #     runs-on: macos-latest
 #     steps:
@@ -365,14 +352,11 @@ jobs:
 #       uses: actions/checkout@v2
 #     - name: Packaging
 #       run: export CC="xcrun --sdk macosx11.1 gcc -arch arm64" ; dist/macos/build-pkg.sh
-#     - name: Extract r2 version
-#       run: echo "##[set-output name=branch;]$( python sys/version.py )"
-#       id: r2v
 #     - name: Pub
 #       uses: actions/upload-artifact@v2
 #       with:
 #         path: dist/macos/*.pkg
-#         name: radare2-${{ steps.r2v.outputs.branch }}_macos_m1.pkg
+#         name: macos-acr-m1
   macos-test:
     runs-on: macos-latest
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
@@ -398,15 +382,12 @@ jobs:
       run: brew install pkg-config ldid
     - name: Create cydia32 package
       run: ./sys/ios-cydia32.sh
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( python sys/version.py )"
-      id: r2v
     - name: List sys/cydia
       run: ls -lahR ./dist/cydia
     - uses: actions/upload-artifact@v2
       with:
-        name: radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm
-        path: ./dist/cydia/radare2/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+        name: ios-cydia32
+        path: ./dist/cydia/radare2/radare2-arm32_*_iphoneos-arm.deb
   ios-cydia:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
     runs-on: macos-latest
@@ -423,17 +404,12 @@ jobs:
         zip -r /tmp/r2ios-sdk.zip *
         popd
         mv /tmp/r2ios-sdk.zip .
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( python sys/version.py )"
-      id: r2v
     - uses: actions/upload-artifact@v2
       with:
-        name: r2ios_sdk-${{ steps.r2v.outputs.branch }}.zip
-        path: ./r2ios-sdk.zip
-    - uses: actions/upload-artifact@v2
-      with:
-        name: radare2-${{ steps.r2v.outputs.branch }}_iphoneos-arm64.zip
-        path: ./dist/cydia/radare2*/*.deb
+        name: ios-cydia
+        path: |
+          ./r2ios-sdk.zip
+          ./dist/cydia/radare2*/*.deb
 
   android-acr-aarch64:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
@@ -449,12 +425,9 @@ jobs:
         sys/android-ndk-install.sh
         sys/android-build.sh arm64
         ls -l
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - uses: actions/upload-artifact@v2
       with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
+        name: android-acr-aarch64
         path: radare2*android*aarch64.tar.gz
 
   android-acr-arm:
@@ -471,12 +444,9 @@ jobs:
         sys/android-ndk-install.sh 16 arm
         sys/android-build.sh arm
         ls -l
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - uses: actions/upload-artifact@v2
       with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
+        name: android-acr-arm
         path: radare2*android*arm.tar.gz
 
   android-meson:
@@ -501,10 +471,7 @@ jobs:
         cd /tmp
         rm -rf android-dir/include android-dir/lib
         tar --transform 's/android-dir/data\/data\/org.radareorg.radare2installer/g' -cvf radare2-android-${{ matrix.name }}.tar.gz android-dir/
-    - name: Extract r2 version
-      run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
-      id: r2v
     - uses: actions/upload-artifact@v2
       with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-android-${{ matrix.name }}.tar.gz
+        name: android-meson
         path: /tmp/radare2-android-${{ matrix.name }}.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 #  schedule:
 #    - cron: '0 0 * * 1'
 
-
 jobs:
   build-offline:
     name: linux-offline
@@ -49,19 +48,6 @@ jobs:
       run: |
         cp -f dist/plugins-cfg/plugins.nocs.cfg plugins.cfg
         ./configure --without-capstone && make -j
-  build-wasi:
-    name: linux-wasi
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Installing with symlinks
-      run: |
-        sys/wasi.sh
-    - uses: actions/upload-artifact@v2
-      with:
-        name: build-wasi
-        path: radare2-*-wasi.zip
   build-acr-gperf:
     name: linux-acr-gperf
     runs-on: ubuntu-20.04
@@ -181,111 +167,6 @@ jobs:
         cd ..
         find "/tmp/r 2"
         LD_LIBRARY_PATH="/tmp/r 2/lib/x86_64-linux-gnu/" "/tmp/r 2/bin/r2" -v
-  linux-static:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Installing the musl runtime
-      run: |
-        sudo apt install musl-tools
-    - name: Building static r2 with acr
-      run: |
-        cp -f dist/plugins-cfg/plugins.static.nogpl.cfg plugins.cfg
-        NOLTO=1 sys/static.sh
-        # NOLTO=1 sys/static.sh
-        make -C binr/blob
-        tar cJvf r2-static.tar.xz r2-static
-    - name: Pub
-      uses: actions/upload-artifact@v2
-      with:
-        name: linux-static
-        path: r2-static.tar.xz
-    - name: Static r2 build with meson
-      run: |
-        sudo apt-get --assume-yes install python3-wheel python3-setuptools cabextract gperf
-        sudo pip3 install meson ninja
-        CFLAGS="-static" LDFLAGS="-static" meson --prefix=${HOME}/.local --buildtype release --default-library static build
-        ninja -C build && ninja -C build install
-  linux-acr-deb-64:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Packaging for Debian
-      run: sys/debian.sh
-    - name: Pub
-      uses: actions/upload-artifact@v2
-      with:
-        name: linux-acr-deb-64
-        path: dist/debian/*/*.deb
-  linux-acr-deb-32:
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Packaging for 32bit Debian
-      run: |
-        sudo apt install gcc-multilib gperf
-        export CFLAGS=-m32
-        export LDFLAGS=-m32
-        export ARCH=i386
-        sys/debian.sh
-    - name: Pub
-      uses: actions/upload-artifact@v2
-      with:
-        name: linux-acr-deb-32
-        path: dist/debian/*/*.deb
-## RPM PACKAGES DISABLED
-#  linux-meson-rpm:
-#    runs-on: ubuntu:18.04
-#    container: centos:8
-#    steps:
-#    - name: Checkout
-#      uses: actions/checkout@v2
-#    - name: Prepare Skeleton
-#      run: |
-#        mkdir -p SOURCES SPECS
-#        cp -f dist/rpm/*spec SPECS
-#        wget -O https://github.com/radareorg/radare2/archive/master/radare2-5.1.0-git.tar.gz
-#    - name: rpmbuild
-#      uses: robertdebock/rpmbuild-action@1.1.1
-#    - name: Pub
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: linux-meson-rpm
-#        path: RPMS/*/*.rpm *.rpm dist/rpm/*.rpm
-#  centos-meson-rpm:
-#    runs-on: ubuntu:18.04
-#    container: centos:8
-#    steps:
-#    - name: Checkout
-#      uses: actions/checkout@v2
-#    - name: Install tools for CentOS:8
-#      run: |
-#        yum install -y patch unzip git gcc make python38 python38-pip rpm-build rpmdevtools wget
-#        pip3.8 install meson ninja r2pipe
-#    - name: Building with Meson
-#      run: |
-#        meson build
-#        ninja -C build
-#        ninja -C build install
-#    - name: RPM Packaging
-#      run: |
-#        cp -f dist/rpm/radare2.spec .
-#        rpmdev-setuptree
-#        mkdir -p rpmbuild/SOURCES
-#        cd rpmbuild/SOURCES
-#        wget https://github.com/radareorg/radare2/archive/5860c3efc12d4b75e72bdce4b1d3834599620913/radare2-5.1.0-git.tar.gz
-#        cd -
-#        rpmbuild -ba radare2.spec
-#    - name: Pub
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: centos-meson-rpm
-#        path: rpmbuild/RPMS/*/*.rpm
   linux-asan-fuzz:
     runs-on: ubuntu-20.04
     continue-on-error: true
@@ -327,36 +208,6 @@ jobs:
       run: |
         export LD_LIBRARY_PATH=/usr/local/lib
         make tests
-
-  # Apple
-  macos-acr:
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Packaging
-      run: dist/macos/build-pkg.sh
-#    - name: Building Radare2
-#      run: |
-#        export CFLAGS="-O2" # -Werror -Wno-unused-result -Wno-unicode -Wno-unneeded-internal-declaration"
-#        sys/install.sh && make -C dist/macos
-    - name: Pub
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist/macos/*.pkg
-        name: macos-acr
-#   macos-acr-m1:
-#     runs-on: macos-latest
-#     steps:
-#     - name: Checkout
-#       uses: actions/checkout@v2
-#     - name: Packaging
-#       run: export CC="xcrun --sdk macosx11.1 gcc -arch arm64" ; dist/macos/build-pkg.sh
-#     - name: Pub
-#       uses: actions/upload-artifact@v2
-#       with:
-#         path: dist/macos/*.pkg
-#         name: macos-acr-m1
   macos-test:
     runs-on: macos-latest
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
@@ -371,107 +222,3 @@ jobs:
       run: export CFLAGS="-O2"; sys/install.sh
     - name: Running tests
       run: pip3 install r2pipe; make tests
-
-  # Mobile
-  ios-cydia32:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install pkg-config/ldid2 with Homebrew
-      run: brew install pkg-config ldid
-    - name: Create cydia32 package
-      run: ./sys/ios-cydia32.sh
-    - name: List sys/cydia
-      run: ls -lahR ./dist/cydia
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ios-cydia32
-        path: ./dist/cydia/radare2/radare2-arm32_*_iphoneos-arm.deb
-  ios-cydia:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install pkg-config/ldid2 with Homebrew
-      run: brew install pkg-config ldid
-    - name: Create cydia package
-      run: ./sys/ios-cydia.sh
-    - name: Create iOS SDK
-      run: |
-        ./sys/ios-sdk.sh
-        pushd /tmp/r2ios
-        zip -r /tmp/r2ios-sdk.zip *
-        popd
-        mv /tmp/r2ios-sdk.zip .
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ios-cydia
-        path: |
-          ./r2ios-sdk.zip
-          ./dist/cydia/radare2*/*.deb
-
-  android-acr-aarch64:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt-get --assume-yes install pax wget gperf cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
-    - name: Compile with acr
-      run: |
-        sys/android-ndk-install.sh
-        sys/android-build.sh arm64
-        ls -l
-    - uses: actions/upload-artifact@v2
-      with:
-        name: android-acr-aarch64
-        path: radare2*android*aarch64.tar.gz
-
-  android-acr-arm:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt-get --assume-yes install pax wget gperf cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
-    - name: Compile with acr
-      run: |
-        sys/android-ndk-install.sh 16 arm
-        sys/android-build.sh arm
-        ls -l
-    - uses: actions/upload-artifact@v2
-      with:
-        name: android-acr-arm
-        path: radare2*android*arm.tar.gz
-
-  android-meson:
-    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-      #  name: [x86_64, arm, aarch64]
-        name: [x86_64]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: sudo apt-get --assume-yes install pax wget cabextract unzip python3-wheel python3-setuptools python3-pip && pip3 install --user meson ninja
-    - name: Compile with meson
-      run: |
-        export PATH=${HOME}/.local/bin:${PATH}
-        CFLAGS="-static" LDFLAGS="-static" meson --buildtype release --default-library static --prefix=/tmp/android-dir -Dblob=true build --cross-file .github/meson-android-${{ matrix.name }}.ini
-        ninja -C build && ninja -C build install
-    - name: Create radare2-android-${{ matrix.name }}.tar.gz
-      run: |
-        cd /tmp
-        rm -rf android-dir/include android-dir/lib
-        tar --transform 's/android-dir/data\/data\/org.radareorg.radare2installer/g' -cvf radare2-android-${{ matrix.name }}.tar.gz android-dir/
-    - uses: actions/upload-artifact@v2
-      with:
-        name: android-meson
-        path: /tmp/radare2-android-${{ matrix.name }}.tar.gz

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -37,3 +37,4 @@ jobs:
       with:
         name: freebsd
         path: radare2-freebsd.tgz
+        retention-days: 30

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -35,4 +35,5 @@ jobs:
           echo DATE: ; date
     - uses: actions/upload-artifact@v2
       with:
+        name: freebsd
         path: radare2-freebsd.tgz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         name: linux-wasi
         path: radare2-*-wasi.zip
+        retention-days: 30
   linux-static:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
     runs-on: ubuntu-20.04
@@ -40,6 +41,7 @@ jobs:
       with:
         name: linux-static
         path: r2-static.tar.xz
+        retention-days: 30
     - name: Static r2 build with meson
       run: |
         sudo apt-get --assume-yes install python3-wheel python3-setuptools cabextract gperf
@@ -59,6 +61,7 @@ jobs:
       with:
         name: linux-acr-deb-64
         path: dist/debian/*/*.deb
+        retention-days: 30
   linux-acr-deb-32:
     runs-on: ubuntu-18.04
     steps:
@@ -76,6 +79,7 @@ jobs:
       with:
         name: linux-acr-deb-32
         path: dist/debian/*/*.deb
+        retention-days: 30
 ## RPM PACKAGES DISABLED
 #  linux-meson-rpm:
 #    runs-on: ubuntu:18.04
@@ -95,6 +99,7 @@ jobs:
 #      with:
 #        name: linux-meson-rpm
 #        path: RPMS/*/*.rpm *.rpm dist/rpm/*.rpm
+#        retention-days: 30
 #  centos-meson-rpm:
 #    runs-on: ubuntu:18.04
 #    container: centos:8
@@ -124,3 +129,4 @@ jobs:
 #      with:
 #        name: centos-meson-rpm
 #        path: rpmbuild/RPMS/*/*.rpm
+#        retention-days: 30

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,126 @@
+name: linux
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  linux-wasi:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Installing with symlinks
+      run: |
+        sys/wasi.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: linux-wasi
+        path: radare2-*-wasi.zip
+  linux-static:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Installing the musl runtime
+      run: |
+        sudo apt install musl-tools
+    - name: Building static r2 with acr
+      run: |
+        cp -f dist/plugins-cfg/plugins.static.nogpl.cfg plugins.cfg
+        NOLTO=1 sys/static.sh
+        # NOLTO=1 sys/static.sh
+        make -C binr/blob
+        tar cJvf r2-static.tar.xz r2-static
+    - name: Pub
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-static
+        path: r2-static.tar.xz
+    - name: Static r2 build with meson
+      run: |
+        sudo apt-get --assume-yes install python3-wheel python3-setuptools cabextract gperf
+        sudo pip3 install meson ninja
+        CFLAGS="-static" LDFLAGS="-static" meson --prefix=${HOME}/.local --buildtype release --default-library static build
+        ninja -C build && ninja -C build install
+  linux-acr-deb-64:
+    if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Packaging for Debian
+      run: sys/debian.sh
+    - name: Pub
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-acr-deb-64
+        path: dist/debian/*/*.deb
+  linux-acr-deb-32:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Packaging for 32bit Debian
+      run: |
+        sudo apt install gcc-multilib gperf
+        export CFLAGS=-m32
+        export LDFLAGS=-m32
+        export ARCH=i386
+        sys/debian.sh
+    - name: Pub
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-acr-deb-32
+        path: dist/debian/*/*.deb
+## RPM PACKAGES DISABLED
+#  linux-meson-rpm:
+#    runs-on: ubuntu:18.04
+#    container: centos:8
+#    steps:
+#    - name: Checkout
+#      uses: actions/checkout@v2
+#    - name: Prepare Skeleton
+#      run: |
+#        mkdir -p SOURCES SPECS
+#        cp -f dist/rpm/*spec SPECS
+#        wget -O https://github.com/radareorg/radare2/archive/master/radare2-5.1.0-git.tar.gz
+#    - name: rpmbuild
+#      uses: robertdebock/rpmbuild-action@1.1.1
+#    - name: Pub
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: linux-meson-rpm
+#        path: RPMS/*/*.rpm *.rpm dist/rpm/*.rpm
+#  centos-meson-rpm:
+#    runs-on: ubuntu:18.04
+#    container: centos:8
+#    steps:
+#    - name: Checkout
+#      uses: actions/checkout@v2
+#    - name: Install tools for CentOS:8
+#      run: |
+#        yum install -y patch unzip git gcc make python38 python38-pip rpm-build rpmdevtools wget
+#        pip3.8 install meson ninja r2pipe
+#    - name: Building with Meson
+#      run: |
+#        meson build
+#        ninja -C build
+#        ninja -C build install
+#    - name: RPM Packaging
+#      run: |
+#        cp -f dist/rpm/radare2.spec .
+#        rpmdev-setuptree
+#        mkdir -p rpmbuild/SOURCES
+#        cd rpmbuild/SOURCES
+#        wget https://github.com/radareorg/radare2/archive/5860c3efc12d4b75e72bdce4b1d3834599620913/radare2-5.1.0-git.tar.gz
+#        cd -
+#        rpmbuild -ba radare2.spec
+#    - name: Pub
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: centos-meson-rpm
+#        path: rpmbuild/RPMS/*/*.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,9 @@ jobs:
         run: ./sys/release-notes.sh | tee ./RELEASE_NOTES.md
       - name: Download artifacts
         env:
-          REPO: ${{ github.repository }}
-          COMMIT: ${{ github.sha }}
-          DESTDIR: dist/artifacts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RUN_ID=`gh run --repo "${REPO}" list --workflow "ci.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
-          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
-          RUN_ID=`gh run --repo "${REPO}" list --workflow "windows.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
-          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
-          RUN_ID=`gh run --repo "${REPO}" list --workflow "freebsd.yml" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
-          gh run --repo "${REPO}" download "${RUN_ID}" --dir "${DESTDIR}"
-          find "${DESTDIR}" -type f
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./sys/download-artifacts.sh ${{ github.sha }}
       - name: Create GitHub release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/build-wasi/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
+          asset_path: dist/artifacts/linux-wasi/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
           asset_content_type: application/zip
       - name: Upload asset for FreeBSD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_amd64.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_path: dist/artifacts/linux-acr-deb-64/radare2/radare2_${{ steps.r2v.outputs.branch }}_amd64.deb
           asset_name: radare2_${{ steps.r2v.outputs.branch }}_amd64.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for Debian (i386)
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_path: dist/artifacts/linux-acr-deb-32/radare2/radare2_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_name: radare2_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for Windows (w64)
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/artifact/radare2-${{ steps.r2v.outputs.branch }}-w64.zip
+          asset_path: dist/artifacts/w64-meson/radare2-${{ steps.r2v.outputs.branch }}-w64.zip
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-w64.zip
           asset_content_type: application/zip
       - name: Upload asset for Windows (w32)
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-w32.zip/radare2-${{ steps.r2v.outputs.branch }}-w32.zip
+          asset_path: dist/artifacts/w32-meson/radare2-${{ steps.r2v.outputs.branch }}-w32.zip
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-w32.zip
           asset_content_type: application/zip
       - name: Upload asset for macOS
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}_macos.pkg/radare2-${{ steps.r2v.outputs.branch }}.pkg
+          asset_path: dist/artifacts/macos-acr/radare2-${{ steps.r2v.outputs.branch }}.pkg
           asset_name: radare2-${{ steps.r2v.outputs.branch }}.pkg
           asset_content_type: application/x-xar
       - name: Upload asset for iPhoneOS (arm)
@@ -81,7 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}_iphoneos-arm64.zip/radare2/radare2_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_path: dist/artifacts/ios-cydia/dist/cydia/radare2/radare2_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
           asset_name: radare2_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for iPhoneOS (arm32)
@@ -90,7 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
+          asset_path: dist/artifacts/ios-cydia32/radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
           asset_name: radare2-arm32_${{ steps.r2v.outputs.branch }}_iphoneos-arm.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for iOS SDK
@@ -99,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/r2ios_sdk-${{ steps.r2v.outputs.branch }}.zip/r2ios-sdk.zip
+          asset_path: dist/artifacts/ios-cydia/r2ios-sdk.zip
           asset_name: r2ios-sdk-${{ steps.r2v.outputs.branch }}.zip
           asset_content_type: application/zip
       - name: Upload asset for Android (arm)
@@ -108,7 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz/radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
+          asset_path: dist/artifacts/android-acr-arm/radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-arm.tar.gz
           asset_content_type: application/gzip
       - name: Upload asset for Android (x86_64)
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-x86_64.tar.gz/radare2-android-x86_64.tar.gz
+          asset_path: dist/artifacts/android-meson/radare2-android-x86_64.tar.gz
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-x86_64.tar.gz
           asset_content_type: application/x-tar
       - name: Upload asset for Android (aarch64)
@@ -126,7 +126,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz/radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
+          asset_path: dist/artifacts/android-acr-aarch64/radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-android-aarch64.tar.gz
           asset_content_type: application/gzip
       - name: Upload asset for Linux (static)
@@ -135,7 +135,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz/r2-static.tar.xz
+          asset_path: dist/artifacts/linux-static/r2-static.tar.xz
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-static.tar.xz
           asset_content_type: application/x-xz
       - name: Upload asset for Debian dev (amd64)
@@ -144,7 +144,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_amd64.zip/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_amd64.deb
+          asset_path: dist/artifacts/linux-acr-deb-64/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_amd64.deb
           asset_name: radare2-dev_${{ steps.r2v.outputs.branch }}_amd64.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for Debian dev (i386)
@@ -153,7 +153,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2_${{ steps.r2v.outputs.branch }}-debian_i386.zip/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_i386.deb
+          asset_path: dist/artifacts/linux-acr-deb-32/radare2-dev/radare2-dev_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_name: radare2-dev_${{ steps.r2v.outputs.branch }}_i386.deb
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload asset for WASI
@@ -162,7 +162,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
+          asset_path: dist/artifacts/build-wasi/radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-wasi.zip
           asset_content_type: application/zip
       - name: Upload asset for FreeBSD
@@ -171,6 +171,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/artifact/radare2-freebsd.tgz
+          asset_path: dist/artifacts/freebsd/radare2-freebsd.tgz
           asset_name: radare2-${{ steps.r2v.outputs.branch }}-freebsd.tgz
           asset_content_type: application/gzip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         name: w32-mingw
         path: radare2*.zip
+        retention-days: 30
   w64-mingw:
     name: w64-mingw
     runs-on: ubuntu-20.04
@@ -38,6 +39,7 @@ jobs:
       with:
         name: w64-mingw
         path: radare2*.zip
+        retention-days: 30
   w64-make:
     runs-on: windows-2019
     steps:
@@ -123,6 +125,7 @@ jobs:
         path: |
           radare2-${{ steps.r2v.outputs.branch }}-w32.zip
 #          radare2-win-installer\Output\radare2.exe
+        retention-days: 30
   w64-meson:
     runs-on: windows-2019
     steps:
@@ -173,4 +176,4 @@ jobs:
         path: |
           radare2-${{ steps.r2v.outputs.branch }}-w64.zip
 #          radare2-win-installer\Output\radare2.exe
-# LINUX
+        retention-days: 30

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,7 @@ jobs:
         sys/mingw32.sh
     - uses: actions/upload-artifact@v2
       with:
+        name: w32-mingw
         path: radare2*.zip
   w64-mingw:
     name: w64-mingw
@@ -35,6 +36,7 @@ jobs:
         sys/mingw64.sh
     - uses: actions/upload-artifact@v2
       with:
+        name: w64-mingw
         path: radare2*.zip
   w64-make:
     runs-on: windows-2019
@@ -105,10 +107,6 @@ jobs:
         ninja -C build -j1 install
     - name: Create zip artifact
       run: 7z a radare2-${{ steps.r2v.outputs.branch }}-w32.zip $PWD\radare2-${{ steps.r2v.outputs.branch }}-w32
-    - uses: actions/upload-artifact@v2
-      with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-w32.zip
-        path: radare2-${{ steps.r2v.outputs.branch }}-w32.zip
 #    - uses: actions/checkout@v2
 #      with:
 #        repository: radareorg/radare2-win-installer
@@ -119,10 +117,12 @@ jobs:
 #    - name: Create installer
 #      shell: pwsh
 #      run: iscc radare2-win-installer\radare2.iss /DRadare2Location=..\radare2-install\* /DLicenseLocation=..\COPYING.LESSER /DIcoLocation=radare2.ico /DMyAppVersion=${{ steps.extract_version.outputs.branch }}
-#    - uses: actions/upload-artifact@v2
-#      with:
-#        name: radare2-w32-installer-git.exe
-#        path: radare2-win-installer\Output\radare2.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: w32-meson
+        path: |
+          radare2-${{ steps.r2v.outputs.branch }}-w32.zip
+#          radare2-win-installer\Output\radare2.exe
   w64-meson:
     runs-on: windows-2019
     steps:
@@ -160,10 +160,6 @@ jobs:
         ninja -C build install
     - name: Create zip artifact
       run: 7z a radare2-${{ steps.r2v.outputs.branch }}-w64.zip $PWD\radare2-${{ steps.r2v.outputs.branch }}-w64
-    - uses: actions/upload-artifact@v2
-      with:
-        name: radare2-${{ steps.r2v.outputs.branch }}-w64.zip
-        path: radare2-${{ steps.r2v.outputs.branch }}-w64.zip
 #    - uses: actions/checkout@v2
 #      with:
 #        repository: radareorg/radare2-win-installer
@@ -171,8 +167,10 @@ jobs:
 #    - name: Create installer
 #      shell: pwsh
 #      run: iscc radare2-win-installer\radare2.iss /DRadare2Location=..\radare2-install\* /DLicenseLocation=..\COPYING.LESSER /DIcoLocation=radare2.ico /DMyAppVersion=${{ steps.extract_version.outputs.branch }}
-#    - uses: actions/upload-artifact@v2
-#      with:
-#        name: radare2-w64-installer-git.zip
-#        path: radare2-win-installer\Output\radare2.exe
+    - uses: actions/upload-artifact@v2
+      with:
+        name: w64-meson
+        path: |
+          radare2-${{ steps.r2v.outputs.branch }}-w64.zip
+#          radare2-win-installer\Output\radare2.exe
 # LINUX

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ libr/include/sdb
 **/d/*.gperf
 **/d/*.out
 **/d/*.inc
+# Artifacts
+/dist/artifacts

--- a/sys/download-artifacts.sh
+++ b/sys/download-artifacts.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+WORKFLOWS="ci.yml windows.yml freebsd.yml"
+DESTDIR="dist/artifacts"
+LIMIT=100
+
+if ! command -v gh &> /dev/null; then
+    echo "GitHub CLI (gh command) could not be found"
+    exit 1
+fi
+
+cd `dirname $PWD/$0`/..
+
+COMMIT="$1" # Optional
+if [ -z "${COMMIT}" ]; then
+  COMMIT=`git rev-parse HEAD`
+  echo "Detected commit: ${COMMIT}"
+fi
+
+echo "Removing old dist artifacts..."
+rm -Rf "${DESTDIR}"
+
+for WORKFLOW in $WORKFLOWS; do
+  echo "Looking for ${COMMIT} in ${WORKFLOW} last ${LIMIT} executions..."
+  RUN_ID=`gh run list --workflow "${WORKFLOW}" --limit "${LIMIT}" --json "databaseId,status,headSha" --jq '.[] | select(.status=="completed" and .headSha=="'"${COMMIT}"'") | .databaseId'`
+  if [ -n "${RUN_ID}" ]; then
+    echo "Found run id ${RUN_ID} for ${WORKFLOW} workflow."
+    echo "Downloading all artifacts..."
+    gh run download "${RUN_ID}" --dir "${DESTDIR}"
+  else
+    echo "No execution found for ${COMMIT} in the last ${LIMIT} executions of ${WORKFLOW} workflow."
+    exit 1
+  fi
+done
+
+echo "Artifacts downloaded:"
+find "${DESTDIR}" -type f

--- a/sys/download-artifacts.sh
+++ b/sys/download-artifacts.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-WORKFLOWS="ci.yml windows.yml freebsd.yml"
+WORKFLOWS="linux apple android windows freebsd"
 DESTDIR="dist/artifacts"
 LIMIT=100
 


### PR DESCRIPTION
This pull request responses to #19687 and improves CI changes performed in #19695.

Features:
1. Adds a new script in `sys/download-artifacts.sh` to download all artifacts into `dist/artifacts` using the [gh cli tool ](https://github.com/cli/cli#readme).
2. Renames all CI artifacts names to match the job name that publishes it.
3. Move jobs from CI workflow to external workflows (like it was with freebsd and windows)
4. Add 30 days retention policy to all generated artifacts (not to the release assets)

Any comment or feedback will be welcome if any folder or change don't match with the philosophy of the project.