### PR TITLE
Adding NULL Check to __func_name_from_ord to prevent segfault 

### DIFF
--- a/libr/bin/format/ne/ne.c
+++ b/libr/bin/format/ne/ne.c
@@ -49,6 +49,9 @@ static char *__read_nonnull_str_at(RBuffer *buf, ut64 offset) {
 }
 
 static char *__func_name_from_ord(const char *module, ut16 ordinal) {
+	if (!module) {
+		return NULL;
+	}
 	char *lower_module = strdup (module);
 	r_str_case (lower_module, false);
 	char *path = r_str_newf (R_JOIN_4_PATHS ("%s", R2_SDB_FORMAT, "dll", "%s.sdb"), r_sys_prefix (NULL), lower_module);


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
Function [__func_name_from_ord](https://github.com/radareorg/radare2/blob/master/libr/bin/format/ne/ne.c#L51) does not perform a NULL check on module which can result in a segfault with a specially crafted binary.

A specially crafted binary will result in crashing radare2 as shown in the image below.

![PUBLIC_radare2-crash](https://user-images.githubusercontent.com/1250113/155033448-16c09184-5337-4cc4-8635-d2bf27907b96.png)
