### PR TITLE
Fix operands that have an extension plus a shift

### DIFF
--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -248,6 +248,16 @@ static const char *decode_shift_64(ShiftType shift) {
 	case ShiftType_LSR:
 		return E_OP_SR;
 
+	// need to include these "shifts"
+	case ShiftType_SXTB:
+	case ShiftType_SXTW:
+	case ShiftType_SXTH:
+	case ShiftType_SXTX:
+	case ShiftType_UXTB:
+	case ShiftType_UXTW:
+	case ShiftType_UXTH:
+	case ShiftType_UXTX:
+
 	case ShiftType_LSL:
 	case ShiftType_MSL:
 		return E_OP_SL;
@@ -621,6 +631,12 @@ static void arg64_append(RStrBuf *sb, Instruction *insn, int n, int i, int sign)
 
 	int shift = LSHIFT2_64 (n);
 	int signext = EXT64 (n);
+	if (!signext) {
+		// this is weird but signext+shift is all in shiftType?
+		// not extend. why even have an extend field?
+		// why not just shiftType = sx* with a shiftValue of 0? 
+		signext = decode_sign_ext64(op.shiftType);
+	}
 	if (sign && !signext) {
 		signext = size;
 	}

--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -635,7 +635,7 @@ static void arg64_append(RStrBuf *sb, Instruction *insn, int n, int i, int sign)
 		// this is weird but signext+shift is all in shiftType?
 		// not extend. why even have an extend field?
 		// why not just shiftType = sx* with a shiftValue of 0? 
-		signext = decode_sign_ext64(op.shiftType);
+		signext = decode_sign_ext64 (op.shiftType);
 	}
 	if (sign && !signext) {
 		signext = size;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `arm.v35` plugin has two types of "shifts" in `InstructionOperand`, `shiftType` and `extend` 

```c
struct InstructionOperand {
    ...
    ShiftType shiftType;
    bool shiftValueUsed;
    uint32_t shiftValue;
    ShiftType extend;
    ...
}
```

However AArch64 can have operands that have both a shift AND an extension. For these operands instead of having the shift in `shiftType` and the extension type in `extend`, `shiftType` contains the extend type and the left shift is implied and has its value in shiftValue. Previously the shift type would be missed as in the ESIL expression

```
str w16, [x12, w15, sxtw  0x2]    ->    w16,x12,2,w15,,+,=[4]
```

instead of 

```
str w16, [x12, w15, sxtw  0x2]    ->    w16,x12,32,2,w15,<<,~,+,=[4]
```

This is really confusing and I may make a PR to the v35 plugin. The `extend` field should probably just be eliminated as it is not necessary. For now we check both for sign extension shifts. 

<!-- explain your changes if necessary -->
