### PR TITLE
Adds afva in all fcns flags (if any) when performing deeper analysis

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10780,8 +10780,8 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_core_anal_all (core);
 			r_print_rowlog_done (core->print, oldstr);
 			r_core_task_yield (&core->tasks);
-			
-			// Run afvn in all fcns 
+
+			// Run afvn in all fcns
 			if (r_config_get_b (core->config, "anal.vars")) {
 				oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
 				r_core_cmd0 (core, "afva @@f");

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10784,7 +10784,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			// Run afvn in all fcns 
 			if (r_config_get_b (core->config, "anal.vars")) {
 				oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
-				r_core_cmd0 (core, "afva @@ f");
+				r_core_cmd0 (core, "afva @@f");
 				r_print_rowlog_done (core->print, oldstr);
 			}
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10780,6 +10780,13 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_core_anal_all (core);
 			r_print_rowlog_done (core->print, oldstr);
 			r_core_task_yield (&core->tasks);
+			
+			// Run afvn in all fcns 
+			oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
+			r_cons_break_push(NULL, NULL);
+			r_core_cmd0(core, "afva @@ fcn.*");
+			r_print_rowlog_done(core->print, oldstr);
+			
 			// Run pending analysis immediately after analysis
 			// Usefull when running commands with ";" or via r2 -c,-i
 			dh_orig = core->dbg->h

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10782,11 +10782,12 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_core_task_yield (&core->tasks);
 			
 			// Run afvn in all fcns 
-			oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
-			r_cons_break_push(NULL, NULL);
-			r_core_cmd0(core, "afva @@ fcn.*");
-			r_print_rowlog_done(core->print, oldstr);
-			
+			if (r_config_get_i (core->config, "anal.vars")) {
+				oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
+				r_core_cmd0 (core, "afva @@ fcn.*");
+				r_print_rowlog_done (core->print, oldstr);
+			}
+
 			// Run pending analysis immediately after analysis
 			// Usefull when running commands with ";" or via r2 -c,-i
 			dh_orig = core->dbg->h

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -10782,9 +10782,9 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_core_task_yield (&core->tasks);
 			
 			// Run afvn in all fcns 
-			if (r_config_get_i (core->config, "anal.vars")) {
+			if (r_config_get_b (core->config, "anal.vars")) {
 				oldstr = r_print_rowlog (core->print, "Analyze all functions arguments/locals");
-				r_core_cmd0 (core, "afva @@ fcn.*");
+				r_core_cmd0 (core, "afva @@ f");
 				r_print_rowlog_done (core->print, oldstr);
 			}
 

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -492,6 +492,8 @@ EXPECT=<<EOF
 0x8060b570      000080a0   sb zero, (a0)
 0x8060b574      00000000   nop
 (fcn) fcn.8060b578 20
+; arg int32_t arg1 @ a0
+; arg int32_t arg2 @ a1
 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 0x8060b57c      542d180c   jal fcn.8060b550
 0x8060b580      00000000   nop
@@ -627,6 +629,8 @@ EXPECT=<<EOF
 0x8060b570      000080a0   sb zero, (a0)
 0x8060b574      00000000   nop
 (fcn) fcn.8060b578 20
+; arg int32_t arg1 @ a0
+; arg int32_t arg2 @ a1
 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 0x8060b57c      542d180c   jal fcn.8060b550
 0x8060b580      00000000   nop
@@ -697,6 +701,8 @@ EXPECT=<<EOF
 \ 0x8060b570      000080a0   sb zero, (a0)
   0x8060b574      00000000   nop
 / (fcn) fcn.8060b578 20
+| ; arg int32_t arg1 @ a0
+| ; arg int32_t arg2 @ a1
 | 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 | 0x8060b57c      542d180c   jal fcn.8060b550
 | 0x8060b580      00000000   nop

--- a/test/db/formats/elf/crackme7
+++ b/test/db/formats/elf/crackme7
@@ -14,3 +14,20 @@ EXPECT=<<EOF
 size: 99
 EOF
 RUN
+
+
+NAME=ELF: IOLI - crackme7 - Local variables analysis
+FILE=bins/elf/ioli/crackme0x07
+ARGS=-A
+CMDS=afv @ fcn.080485b9
+EXPECT=<<EOF
+var char * format @ esp+0x4
+var int32_t var_sp_8h @ esp+0x8
+var char * var_dh @ ebp-0xd
+var signed int var_ch @ ebp-0xc
+var uint32_t var_8h @ ebp-0x8
+var int32_t var_bp_4h @ ebp-0x4
+arg char * s @ ebp+0x8
+arg int32_t arg_ch @ ebp+0xc
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)

When running `aaa` analysis in binaries, not all functions have their arguments analyzed which leaves an incomplete analysis.  This PR insures that if any `fcns` were found, it will have their arguments analyzed either. 

<!-- explain your changes if necessary -->
