### PR TITLE
Make grep begin, end, and negate properties per-word

### DIFF
--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -105,9 +105,9 @@ typedef struct r_cons_grep_t {
 	int amp;
 	int zoom;
 	int zoomy; // if set then its scaled unproportionally
-	int neg;
-	int begin;
-	int end;
+	int neg[R_CONS_GREP_WORDS];
+	int begin[R_CONS_GREP_WORDS];
+	int end[R_CONS_GREP_WORDS];
 	bool icase;
 	bool ascart;
 } RConsGrep;

--- a/test/db/cmd/feat_grep
+++ b/test/db/cmd/feat_grep
@@ -169,7 +169,6 @@ EOF
 RUN
 
 NAME=double grep neg
-BROKEN=1
 FILE=malloc://1024
 CMDS=i~f~!file
 EXPECT=<<EOF
@@ -308,7 +307,6 @@ EOF
 RUN
 
 NAME=multigrep2
-BROKEN=1
 FILE=malloc://1024
 CMDS=<<EOF
 ?e hello world~hello~!boing

--- a/test/db/tools/ravc2
+++ b/test/db/tools/ravc2
@@ -26,7 +26,7 @@ cd ravc2_commit_test
 !!ravc2 init
 echo hello > hello
 !!ravc2 commit "hello world!" hello
-!!ravc2 log~!author,time,hash
+!!ravc2 log~!author~!time~!hash
 cd ../
 rmrf ravc2_commit_test
 EOF
@@ -67,7 +67,7 @@ cd ravc2_log_test
 !!ravc2 init
 echo hello > hello
 !!ravc2 commit "hello world!" hello
-!!ravc2 log ~!hash,author,time
+!!ravc2 log~!hash~!author~!time
 cd ../
 rmrf ravc2_log_test
 EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)

**Description**

Fixes #18690.

Grep `!`, `^`, and `$` - negation, begin, and end are now tracked per-term. Logic has been modified to cope with these changes, allowing the user to string multiple simple grep expressions together as described in the issue. 2 grep tests have been fixed.

This patch contains a breaking change - `~!a,b,c` must now be `~!a~!b~!c`, since b and c have their own negation flag now instead of a single negation applying to all terms. See ravc2 tests.