### PR TITLE
Add R2_DEBUG_EPRINT to disable debug var printing at compiletime or runtime

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -336,6 +336,7 @@ int main(int argc, char **argv) {
 
 	r_sys_setenv ("RABIN2_TRYLIB", "0");
 	r_sys_setenv ("R2_DEBUG_ASSERT", "1");
+	r_sys_setenv ("R2_SUPPRESS_VAR_EPRINT", "1");
 	r_sys_setenv ("TZ", "UTC");
 	ut64 time_start = r_time_now_mono ();
 	R2RState state = {{0}};

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv) {
 
 	r_sys_setenv ("RABIN2_TRYLIB", "0");
 	r_sys_setenv ("R2_DEBUG_ASSERT", "1");
-	r_sys_setenv ("R2_NO_EPRINT_MACROS", "1");
+	r_sys_setenv ("R2_DEBUG_EPRINT", "0");
 	r_sys_setenv ("TZ", "UTC");
 	ut64 time_start = r_time_now_mono ();
 	R2RState state = {{0}};

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv) {
 
 	r_sys_setenv ("RABIN2_TRYLIB", "0");
 	r_sys_setenv ("R2_DEBUG_ASSERT", "1");
-	r_sys_setenv ("R2_SUPPRESS_VAR_EPRINT", "1");
+	r_sys_setenv ("R2_NO_EPRINT_MACROS", "1");
 	r_sys_setenv ("TZ", "UTC");
 	ut64 time_start = r_time_now_mono ();
 	R2RState state = {{0}};

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -463,7 +463,10 @@ static inline void *r_new_copy(int size, void *data) {
 #define eprintf(...) fprintf (stderr, __VA_ARGS__)
 #endif
 
-#ifdef NO_EPRINT_MACROS
+#ifndef R2_DEBUG_EPRINT
+#define R2_DEBUG_EPRINT 0
+#endif
+#if !R2_DEBUG_EPRINT
 #define EPRINT_STR
 #define EPRINT_CHAR
 #define EPRINT_INT

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -461,23 +461,34 @@ static inline void *r_new_copy(int size, void *data) {
 
 #ifndef eprintf
 #define eprintf(...) fprintf (stderr, __VA_ARGS__)
-
-#define EPRINT_STR(x) eprintf (#x ": \"%s\"\n", x)
-#define EPRINT_CHAR(x) eprintf (#x ": '%c' (0x%x)\n", x, x)
-#define EPRINT_INT(x) eprintf (#x ": %d (0x%x)\n", x, x)
-#define EPRINT_BOOL(x) eprintf (#x ": %s\n", x? "true": "false")
-#define EPRINT_PTR(x) eprintf (#x ": %p\n", x)
-
-#define EPRINT_UT64(x) eprintf (#x ": %" PFMT64u " (0x%" PFMT64x ")\n", x, x)
-#define EPRINT_ST64(x) eprintf (#x ": %" PFMT64d " (0x%" PFMT64x ")\n", x, x)
-#define EPRINT_UT32(x) eprintf (#x ": %" PFMT32u " (0x%" PFMT32x ")\n", x, x)
-#define EPRINT_ST32(x) eprintf (#x ": %" PFMT32d " (0x%" PFMT32x ")\n", x, x)
-#define EPRINT_UT16(x) eprintf (#x ": %hu (0x%hx)\n", x, x)
-#define EPRINT_ST16(x) eprintf (#x ": %hd (0x%hx)\n", x, x)
-#define EPRINT_UT8(x) eprintf (#x ": %hhu (0x%hhx)\n", x, x)
-#define EPRINT_ST8(x) eprintf (#x ": %hhd (0x%hhx)\n", x, x)
 #endif
 
+#ifndef NO_EPRINT_MACROS
+/* Pass R2_SUPPRESS_VAR_EPRINT=1 as an environment variable to disable these
+ * macros at runtime. Used by r2r to prevent interference with tests. */
+#define EPRINT_VAR_WRAPPER(name, fmt, ...) {				\
+	char *eprint_env = r_sys_getenv ("R2_SUPPRESS_VAR_EPRINT");	\
+	if (!eprint_env || strcmp (eprint_env, "1")) {			\
+		eprintf (#name ": " fmt "\n", __VA_ARGS__);		\
+	}								\
+	free (eprint_env);						\
+}
+
+#define EPRINT_STR(x) EPRINT_VAR_WRAPPER (x, "\"%s\"", x)
+#define EPRINT_CHAR(x) EPRINT_VAR_WRAPPER (x, "'%c' (0x%x)", x, x)
+#define EPRINT_INT(x) EPRINT_VAR_WRAPPER (x, "%d (0x%x)", x, x)
+#define EPRINT_BOOL(x) EPRINT_VAR_WRAPPER (x, "%s", x? "true": "false")
+#define EPRINT_PTR(x) EPRINT_VAR_WRAPPER (x, "%p", x)
+
+#define EPRINT_UT64(x) EPRINT_VAR_WRAPPER (x, "%" PFMT64u " (0x%" PFMT64x ")", x, x)
+#define EPRINT_ST64(x) EPRINT_VAR_WRAPPER (x, "%" PFMT64d " (0x%" PFMT64x ")", x, x)
+#define EPRINT_UT32(x) EPRINT_VAR_WRAPPER (x, "%" PFMT32u " (0x%" PFMT32x ")", x, x)
+#define EPRINT_ST32(x) EPRINT_VAR_WRAPPER (x, "%" PFMT32d " (0x%" PFMT32x ")", x, x)
+#define EPRINT_UT16(x) EPRINT_VAR_WRAPPER (x, "%hu (0x%hx)", x, x)
+#define EPRINT_ST16(x) EPRINT_VAR_WRAPPER (x, "%hd (0x%hx)", x, x)
+#define EPRINT_UT8(x) EPRINT_VAR_WRAPPER (x, "%hhu (0x%hhx)", x, x)
+#define EPRINT_ST8(x) EPRINT_VAR_WRAPPER (x, "%hhd (0x%hhx)", x, x)
+#endif
 
 #if __APPLE__
 # if __i386__

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -463,7 +463,22 @@ static inline void *r_new_copy(int size, void *data) {
 #define eprintf(...) fprintf (stderr, __VA_ARGS__)
 #endif
 
-#ifndef NO_EPRINT_MACROS
+#ifdef NO_EPRINT_MACROS
+#define EPRINT_STR
+#define EPRINT_CHAR
+#define EPRINT_INT
+#define EPRINT_BOOL
+#define EPRINT_PTR
+
+#define EPRINT_UT64
+#define EPRINT_ST64
+#define EPRINT_UT32
+#define EPRINT_ST32
+#define EPRINT_UT16
+#define EPRINT_ST16
+#define EPRINT_UT8
+#define EPRINT_ST8
+#else
 /* Pass R2_SUPPRESS_VAR_EPRINT=1 as an environment variable to disable these
  * macros at runtime. Used by r2r to prevent interference with tests. */
 #define EPRINT_VAR_WRAPPER(name, fmt, ...) {				\

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -479,10 +479,10 @@ static inline void *r_new_copy(int size, void *data) {
 #define EPRINT_UT8
 #define EPRINT_ST8
 #else
-/* Pass R2_SUPPRESS_VAR_EPRINT=1 as an environment variable to disable these
+/* Pass R2_NO_EPRINT_MACROS=1 as an environment variable to disable these
  * macros at runtime. Used by r2r to prevent interference with tests. */
 #define EPRINT_VAR_WRAPPER(name, fmt, ...) {				\
-	char *eprint_env = r_sys_getenv ("R2_SUPPRESS_VAR_EPRINT");	\
+	char *eprint_env = r_sys_getenv ("R2_NO_EPRINT_MACROS");	\
 	if (!eprint_env || strcmp (eprint_env, "1")) {			\
 		eprintf (#name ": " fmt "\n", __VA_ARGS__);		\
 	}								\


### PR DESCRIPTION
EPRINT macros are very useful for debugging, but interfere with output for tests when running r2r. This patch adds a check for the `R2_SUPPRESS_VAR_EPRINT` environment variable to allow the user (or the test suite) to disable them at runtime (must be `"1"`).

This includes a minor refactor to the macros - now, instead of each one being a raw eprintf, they use a wrapper that passes the name, format string, and `__VA_ARGS__` along to eprintf after checking the environment variable. The format string is partially pre-constructed to make the definitions more clear about what the specific type needs to be printed properly.

Example usage:

```
$ git diff libr/core/cmd_print.c
diff --git a/libr/core/cmd_print.c b/libr/core/cmd_print.c
index 0d77c1700..43ed406db 100644
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6575,6 +6575,7 @@ static int cmd_print(void *data, const char *input) {
                 cmd_print_op(core, input);
                 break;
         case 'x': // "px"
+                EPRINT_STR (input);
                 if (input[1] == '-' && input[2] == '-') {
                         int rowsize = r_config_get_i (core->config, "hex.cols");
                         int ctxlines = r_num_math (core->num, input + 3);
$ sys/user.sh
$ r2 -
[0x00000000]> px >/dev/null
input: "x"
[0x00000000]> q
$ R2_SUPPRESS_VAR_EPRINT=1 r2 -
[0x00000000]> px >/dev/null
[0x00000000]> q
```