### PR TITLE
Partial #19687: Fix CI release notes on creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -444,6 +444,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Download all git history and tags
       - name: Extract r2 version
         run: echo "##[set-output name=branch;]$( cd sys;python version.py )"
         id: r2v


### PR DESCRIPTION
This pull request responses to #19687.

Add git history before generate release notes.