### PR TITLE
Fix problems in `l` command

### DIFF
--- a/libr/fs/fs.c
+++ b/libr/fs/fs.c
@@ -689,7 +689,7 @@ R_API bool r_fs_check(RFS *fs, const char *p) {
 	r_return_val_if_fail (fs && p, false);
 	RFSRoot *root;
 	RListIter *iter;
-	char* path = strdup (p);
+	char *path = strdup (p);
 	if (path) {
 		r_str_trim_path (path);
 		r_list_foreach (fs->roots, iter, root) {

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1327,7 +1327,7 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 }
 
 static bool dir_recursive(RList *dst, const char *dir) {
-	char *name;
+	char *name, *path = NULL;
 	RListIter *iter;
 	bool ret = true;
 	RList *files = r_sys_dir (dir);
@@ -1335,7 +1335,6 @@ static bool dir_recursive(RList *dst, const char *dir) {
 		return false;
 	}
 	r_list_foreach (files, iter, name) {
-		char *path;
 		if (!strcmp (name, "..") || !strcmp (name, ".")) {
 			continue;
 		}
@@ -1344,9 +1343,8 @@ static bool dir_recursive(RList *dst, const char *dir) {
 			ret = false;
 			break;
 		}
-		if (!r_list_append (dst, path)) {
+		if (!r_list_append (dst, strdup (path))) {
 			ret = false;
-			free (path);
 			break;
 		}
 		if (r_file_is_directory (path)) {
@@ -1355,13 +1353,15 @@ static bool dir_recursive(RList *dst, const char *dir) {
 				break;
 			}
 		}
+		R_FREE (path);
 	}
+	free (path);
 	r_list_free (files);
 	return ret;
 }
 
 R_API RList *r_file_lsrf(const char *dir) {
-	RList *ret = r_list_new ();
+	RList *ret = r_list_newf (free);
 	if (!ret) {
 		return NULL;
 	}

--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -170,7 +170,7 @@ R_API char *r_syscmd_ls(const char *input, int cons_width) {
 	}
 	if (*input) {
 		if (!strncmp (input, "-h", 2) || *input == '?') {
-			eprintf ("Usage: ls ([-e,-l,-j,-q]) ([path]) # long, json, quiet\n");
+			eprintf ("Usage: ls [-e,-l,-j,-q] [path] # long, json, quiet\n");
 			return NULL;
 		}
 		if ((!strncmp (input, "-e", 2))) {
@@ -236,6 +236,9 @@ R_API char *r_syscmd_ls(const char *input, int cons_width) {
 		return res;
 	}
 	RList *files = r_sys_dir (path);
+	if (!files) {
+		return NULL;
+	}
 	r_list_sort (files, (RListComparator)strcmp);
 
 	if (path[strlen (path) - 1] == '/') {

--- a/test/db/cmd/cmd_ownshell
+++ b/test/db/cmd/cmd_ownshell
@@ -25,7 +25,6 @@ RUN
 
 NAME=mkdir -p
 FILE=-
-BROKEN=1
 CMDS=<<EOF
 rm /tmp/foo/bar/foo/fooz
 rm /tmp/foo/bar/foo


### PR DESCRIPTION
Input for `cmd_ls()` changed without being accounted for. The command string changed from `"ls"` to `"l"`, moving the input pointer back.