### PR TITLE
Fix inexact r_core_cmd_help_match()

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -2224,7 +2224,7 @@ R_API void r_cons_cmd_help_match(const char *help[], bool use_color, R_BORROW R_
 				break;
 			}
 		} else {
-			if (!strstr (help[i], cmd)) {
+			if (strstr (help[i], cmd)) {
 				print_match (&help[i], use_color);
 				/* Don't break - can have multiple results */
 			}


### PR DESCRIPTION
`strstr` return value does not act like `strcmp`. Went unnoticed until it was needed for an upcoming PR.