### PR TITLE
Remove usage of wc and awk from tests

### DIFF
--- a/test/db/archos/linux-x64/dbg_maps
+++ b/test/db/archos/linux-x64/dbg_maps
@@ -68,7 +68,7 @@ dm~?
 db sym.imp.puts
 dc~?
 dmi libc~?
-dmi libc~libc|wc -l
+dmi libc~libc~?
 EOF
 EXPECT=<<EOF
 7
@@ -88,9 +88,9 @@ dm~?
 db sym.imp.puts
 dc~?
 dmS libc~?
-dmS libc~libc|wc -l
+dmS libc~libc~?
 dmS* libc~?
-dmS* libc~libc|wc -l
+dmS* libc~libc~?
 EOF
 EXPECT=<<EOF
 7
@@ -113,13 +113,13 @@ dm~?
 db sym.imp.puts
 dc~?
 dmS libc~?
-dmS libc~libc|wc -l
+dmS libc~libc~?
 dmS* libc~?
-dmS* libc~libc|wc -l
+dmS* libc~libc~?
 dmS~?
 dmS*~?
-dmS~libc|wc -l
-dmS*~libc|wc -l
+dmS~libc~?
+dmS*~libc~?
 EOF
 EXPECT=<<EOF
 7
@@ -145,11 +145,11 @@ dmm~?
 db sym.imp.puts
 dc~?
 dmm~?
-S~.text|wc -l
-dmS hello~.text|wc -l
-dmS~x86-helloworld-gcc..text|wc -l
-dmS~libc-2.19.so..text|wc -l
-dmS~ld-2.19.so..text|wc -l
+S~.text~?
+dmS hello~.text~?
+dmS~x86-helloworld-gcc..text~?
+dmS~libc-2.19.so..text~?
+dmS~ld-2.19.so..text~?
 EOF
 EXPECT=<<EOF
 2
@@ -176,7 +176,7 @@ dmm~?
 s map._lib_i386_linux_gnu_ld_2.19.so._r_x
 S.~?
 .dmS*~?
-S.~libc-2.19.so..text|wc -l
+S.~libc-2.19.so..text~?
 EOF
 EXPECT=<<EOF
 2

--- a/test/db/cmd/feat_redirect
+++ b/test/db/cmd/feat_redirect
@@ -2,9 +2,9 @@ NAME="pb>x;!wc -c x"
 FILE=malloc://1024
 CMDS=<<EOF
 p8 10 > dump
-!wc -c dump|awk "{print \$1}"
+cat dump~?.
 p8 12800 > dump
-!wc -c dump|awk "{print \$1}"
+cat dump~?.
 !rm -f dump
 EOF
 EXPECT=<<EOF

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -102,31 +102,31 @@ RUN
 
 NAME=rabin2 -s file pe
 FILE=bins/pe/a.exe
-CMDS=!rabin2 -s ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -s ${R2_FILE}~?
 EXPECT=<<EOF
-24
+23
 EOF
 RUN
 
 NAME=rabin2 -s file elf
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=!rabin2 -s ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -s ${R2_FILE}~?
 EXPECT=<<EOF
-69
+68
 EOF
 RUN
 
 NAME=rabin2 -S, -SS, -rS and -rSS file elf
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
-!rabin2 -S ${R2_FILE}|wc -l|awk "{print \$1}"
-!rabin2 -SS ${R2_FILE}|wc -l|awk "{print \$1}"
+!!rabin2 -S ${R2_FILE}~?
+!!rabin2 -SS ${R2_FILE}~?
 !env RABIN2_PREFIX=prixfixe rabin2 -S ${R2_FILE}
 !env RABIN2_PREFIX=prixfixe rabin2 -SS ${R2_FILE}
 EOF
 EXPECT=<<EOF
-35
-14
+33
+12
 [Sections]
 
 nth paddr        size vaddr       vsize perm name
@@ -181,15 +181,15 @@ RUN
 
 NAME=rabin2 -SSS
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=!rabin2 -SSS ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -SSS ${R2_FILE}~?
 EXPECT=<<EOF
-13
+12
 EOF
 RUN
 
 NAME=rabin2 -z pe
 FILE=bins/pe/a.exe
-CMDS=!rabin2 -z ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -z ${R2_FILE}~?
 EXPECT=<<EOF
 7
 EOF
@@ -245,7 +245,7 @@ RUN
 
 NAME=rabin2 -z elf
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=!rabin2 -z ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -z ${R2_FILE}~?
 EXPECT=<<EOF
 4
 EOF
@@ -253,7 +253,7 @@ RUN
 
 NAME=rabin2 -G 0x1000 -rs fatmach0
 FILE=bins/mach0/fatmach0-3true
-CMDS=!rabin2 -G 0x1000 -rs ${R2_FILE}|grep "f " | wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -G 0x1000 -rs ${R2_FILE}~f ~?
 EXPECT=<<EOF
 3
 EOF
@@ -261,7 +261,7 @@ RUN
 
 NAME=rabin2 -G 0x1300 -rs fatmach0
 FILE=bins/mach0/fatmach0-3true
-CMDS=!rabin2 -G 0x1300 -rs ${R2_FILE}|wc -l|awk "{print \$1}"
+CMDS=!!rabin2 -G 0x1300 -rs ${R2_FILE}~?
 EXPECT=<<EOF
 1
 EOF


### PR DESCRIPTION
Fix #19775.

Line counts had to be changed since the internal `~?` seems not to count empty lines, while the external `wc -l` does.

The modified linux-64 tests are all broken anyway, but now whenever they are fixed the line count can simply be accurate to `~?` rather than `wc -l`.