### PR TITLE
Fix #19783: Improve scr.prompt.flag to include offset and hex delta

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3196,14 +3196,16 @@ R_API bool r_core_prompt_loop(RCore *r) {
 
 static int prompt_flag(RCore *r, char *s, size_t maxlen) {
 	const char DOTS[] = "...";
-	const RFlagItem *f = r_flag_get_at (r->flags, r->offset, false);
+	const RFlagItem *f = r_flag_get_at (r->flags, r->offset, true);
 	if (!f) {
 		return false;
 	}
 	if (f->offset < r->offset) {
-		snprintf (s, maxlen, "%s + %" PFMT64u, f->name, r->offset - f->offset);
+		snprintf (s, maxlen, "0x%08" PFMT64x " | %s+0x%" PFMT64x,
+				r->offset, f->name, r->offset - f->offset);
 	} else {
-		snprintf (s, maxlen, "%s", f->name);
+		snprintf (s, maxlen, "0x%08" PFMT64x " | %s",
+				r->offset, f->name);
 	}
 	if (strlen (s) > maxlen - sizeof (DOTS)) {
 		s[maxlen - sizeof (DOTS) - 1] = '\0';


### PR DESCRIPTION
## Comparison

### Before:

```
$ r2 test/bins/elf/ls
[0x00005ae0]> e scr.prompt.flag
false
[0x00005ae0]> e scr.prompt.flag=1
[entry0]> s +1
[0x00005ae0]> s -1
[entry0]>
```

### After:

```
$ r2 test/bins/elf/ls
[0x00005ae0]> e scr.prompt.flag
false
[0x00005ae0]> e scr.prompt.flag=1
[0x00005ae0 | entry0]> s +1
[0x00005ae1 | entry0+0x1]> s -1
[0x00005ae0 | entry0]>
```