### PR TITLE
Sanitize function names for prototypes ##anal

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1847,6 +1847,29 @@ R_API char *r_anal_function_get_json(RAnalFunction *function) {
 	return pj_drain (pj);
 }
 
+#define ALPH(x) \
+	(x >= 'a' && x <= 'z') || (x >= 'A' && x <= 'Z')
+#define ISNUM(x) \
+	(x >= '0' && x <= '9')
+#define VALID_TOKEN_CHR(x) \
+	(ALPH (x) || ISNUM (x) || x == '_' || x == '.')
+static inline char *sanitize_fname(const char *name) {
+	char *sane = strdup (name);
+	if (sane) {
+		char *ptr = sane;
+		while (*ptr) {
+			if (!VALID_TOKEN_CHR (*ptr)) {
+				*ptr = '_';
+			}
+			ptr++;
+		}
+	}
+	return sane;
+}
+#undef ALPH
+#undef ISNUM
+#undef VALID_TOKEN_CHR
+
 R_API char *r_anal_function_get_signature(RAnalFunction *function) {
 	RAnal *a = function->anal;
 	const char *realname = NULL, *import_substring = NULL;
@@ -1900,7 +1923,10 @@ R_API char *r_anal_function_get_signature(RAnalFunction *function) {
 		free (arg_i);
 		free (sdb_arg_i);
 	}
+	char *sane = sanitize_fname (realname);
+	realname = sane? sane: realname;
 	ret = r_str_newf ("%s %s (%s);", r_str_get_fail (ret_type, "void"), realname, args);
+	free (sane);
 
 	free (sdb_args);
 	free (sdb_ret);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Potential/partial fix for #19805

This will ensure function prototypes created by `r_anal_function_get_signature` have a function name that tcc will accept. When a function has an invalid name, the invalid chars will be replaced with `_`. So in the case of #19805 the function name `method.OnePasswordNativeMessageHost.OPNMXPCConnection.setXpcConnection:` will become `method.OnePasswordNativeMessageHost.OPNMXPCConnection.setXpcConnection_` in the prototype.

For signatures this won't affect the renaming of the function on match. The matched function should still become `method.OnePasswordNativeMessageHost.OPNMXPCConnection.setXpcConnection:`. I don't know if it will have another ill affect somewhere else.

The core of the issue might be that a functions can have names with `:` in them. So feel free to deny this pull and tell me to fix it another way :)

## example with this patch

```
> r2 /bin/ls
Warning: run r2 with -e bin.cache=true to fix relocations in disassembly
 ╭──╮    ╭─────────────────────────────────────╮
 │ ╶│╶   │                                     │
 │ O o  <  r2 is meant to be read by machines. │
 │  │  ╱ │                                     │
 │ ╭┘ ╱  ╰─────────────────────────────────────╯
 │ ╰ ╱
 ╰──'
[0x00006180]> aa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze all functions arguments/locals
[0x00006180]> s main
[0x00004760]> afn method.OnePasswordNativeMessageHost.OPNMXPCConnection.setXpcConnection:
[0x00004760]> zaf
[0x00004760]> z.
[+] searching function metrics
bytes:  1
graph:  1
refs:   1
types:  1
bbhash: 1
total:  5
[0x00004760]> z~type
  types: int method.OnePasswordNativeMessageHost.OPNMXPCConnection.setXpcConnection_ (int argc, char **argv)
[0x00004760]> 
```