### PR TITLE
Check for .git extension in upstream remote in install scripts

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -68,7 +68,7 @@ if [ "$1" != "--without-pull" ]; then
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
 			# Attempt to update from an existing remote
-			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2\(\.git\)\? (fetch)' | cut -f1 | head -n1)
 			if [ -n "$UPSTREAM_REMOTE" ]; then
 				git pull "$UPSTREAM_REMOTE" master
 			else

--- a/sys/termux.sh
+++ b/sys/termux.sh
@@ -8,7 +8,7 @@ export ANDROID=1
 rm -f libr/include/r_version.h
 cp -f dist/plugins-cfg/plugins.termux.cfg plugins.cfg
 # Attempt to update from an existing remote
-UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2\(\.git\)\? (fetch)' | cut -f1 | head -n1)
 if [ -n "$UPSTREAM_REMOTE" ]; then
 	git pull "$UPSTREAM_REMOTE" master
 else

--- a/sys/user.sh
+++ b/sys/user.sh
@@ -54,7 +54,7 @@ if [ $WITHOUT_PULL -eq 0 ]; then
 		if [ $? = 0 ]; then
 			echo "WARNING: Updating from remote repository"
 			# Attempt to update from an existing remote
-			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2 (fetch)' | cut -f1 | head -n1)
+			UPSTREAM_REMOTE=$(git remote -v | grep 'radareorg/radare2\(\.git\)\? (fetch)' | cut -f1 | head -n1)
 			if [ -n "$UPSTREAM_REMOTE" ]; then
 				git pull "$UPSTREAM_REMOTE" master
 			else


### PR DESCRIPTION
Improvement to #19500. Now, if you used ".git" in the remote name it will still work.