### PR TITLE
Remove unused update variable in __print__decompiler_cb()

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -4487,8 +4487,6 @@ static void __print_decompiler_cb(void *user, void *p) {
 		}
 		return;
 	}
-#else
-	bool update = true;
 #endif
 	// RAnalFunction *func = r_anal_get_fcn_in (core->anal, core->offset, R_ANAL_FCN_TYPE_NULL);
 	if (func && core->panels_root->cur_pdc_cache) {


### PR DESCRIPTION
Unused variable warning is killing the CI