### PR TITLE
Fix undefined behaviour in RVector, RPVector, RInterval and container_of ##fix

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -722,11 +722,7 @@ static inline void r_run_call10(void *fcn, void *arg1, void *arg2, void *arg3, v
 }
 
 #ifndef container_of
-# ifdef _MSC_VER
-#  define container_of(ptr, type, member) ((type *)((char *)(ptr) - offsetof(type, member)))
-# else
-#  define container_of(ptr, type, member) ((type *)((char *)(__typeof__(((type *)0)->member) *){ptr} - offsetof(type, member)))
-# endif
+#define container_of(ptr, type, member) (ptr? ((type *)((char *)(ptr) - r_offsetof(type, member))): NULL)
 #endif
 
 // reference counter

--- a/libr/include/r_vector.h
+++ b/libr/include/r_vector.h
@@ -294,10 +294,12 @@ static inline void **r_pvector_flush(RPVector *vec) {
  * }
  */
 #define r_pvector_foreach(vec, it) \
+	if ((vec)->v.len > 0) \
 	for (it = (void **)(vec)->v.a; it != (void **)(vec)->v.a + (vec)->v.len; it++)
 
 // like r_pvector_foreach() but inverse
 #define r_pvector_foreach_prev(vec, it) \
+	if ((vec)->v.len > 0) \
 	for (it = ((vec)->v.len == 0 ? NULL : (void **)(vec)->v.a + (vec)->v.len - 1); it != NULL && it != (void **)(vec)->v.a - 1; it--)
 
 /*

--- a/libr/util/intervaltree.c
+++ b/libr/util/intervaltree.c
@@ -168,6 +168,7 @@ R_API bool r_interval_tree_resize(RIntervalTree *tree, RIntervalNode *node, ut64
 // This must always return the topmost node that matches start!
 // Otherwise r_interval_tree_first_at will break!!!
 R_API RIntervalNode *r_interval_tree_node_at(RIntervalTree *tree, ut64 start) {
+	r_return_val_if_fail (tree, NULL);
 	RIntervalNode *node = tree->root;
 	while (node) {
 		if (start < node->start) {


### PR DESCRIPTION
* All those basic primites were based on wrong assumptions
* Added more return_if preconditions on several anal functions

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
