### PR TITLE
Fix linking of libr/syscall/libr_syscall.so

### DIFF
--- a/libr/syscall/d/Makefile
+++ b/libr/syscall/d/Makefile
@@ -21,6 +21,7 @@ F+= openbsd-x86-32
 F+= openbsd-x86-64
 F+= windows-x86-32
 F+= windows-x86-64
+CFLAGS+=-fPIC
 
 include $(TOP)/config-user.mk
 HOST_CC?=gcc


### PR DESCRIPTION
Relates to 842b89a

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixed r2 linking in Slackware 15.0 and GCC 11.2.0. r2 didn't compile/link with the following error:

```
LD libr_syscall.so
/usr/bin/ld: d/darwin-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/dos-x86-16.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/freebsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-mips-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-sparc-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/netbsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/openbsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/openbsd-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/s110-arm-16.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/windows-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/windows-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
collect2: error: ld returned 1 exit status
gmake[3]: *** [../rules.mk:91: libr_syscall.so] Error 1
gmake[2]: *** [Makefile:163: syscall] Error 2
gmake[1]: *** [Makefile:24: all] Error 2
gmake: *** [Makefile:56: all] Error 2
Oops
```

When running `make` in `libr/syscall`:

```
make[1]: Leaving directory '/home/pyllyukko/work/radare2/libr/syscall'
"ccache gcc -Wl,--as-needed -fvisibility=hidden -shared -o libr_syscall.so -Wl,-soname=libr_syscall.so syscall.o ioports.o splugs.o d/darwin-arm-32.o d/darwin-arm-64.o d/darwin-x86-32.o d/darwin-x86-64.o d/dos-x86-16.o d/freebsd-x86-32.o d/ios-arm-32.o d/ios-arm-64.o d/ios-x86-32.o d/linux-arm-32.o d/linux-arm-64.o d/linux-mips-32.o d/linux-sparc-32.o d/linux-x86-32.o d/linux-x86-64.o d/netbsd-x86-32.o d/openbsd-x86-32.o d/openbsd-x86-64.o d/s110-arm-16.o d/windows-x86-32.o d/windows-x86-64.o  -L/home/pyllyukko/work/radare2/libr/util -lr_util   -fPIC -fvisibility=hidden   -Wl,-rpath,/home/pyllyukko/bin/prefix/radare2/lib -Wl,--as-needed -fvisibility=hidden"
/usr/bin/ld: d/darwin-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/dos-x86-16.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/freebsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/ios-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-mips-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-sparc-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/linux-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/netbsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/openbsd-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/openbsd-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/s110-arm-16.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/windows-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/windows-x86-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
collect2: error: ld returned 1 exit status
make: *** [../rules.mk:91: libr_syscall.so] Error 1
```