### PR TITLE
Improve autocomplete

### DIFF
--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -344,18 +344,18 @@ static int cmd_hash_bang(RCore *core, const char *input) {
 	if (r_str_endswith (input, "?")) {
 		char *ex = strchr (input, '!');
 		if (ex) {
-			char *foo = r_str_ndup (ex + 1, strlen (ex) - 2);
-			RLangPlugin *lp = r_lang_get_by_name (core->lang, foo);
+			char *name = r_str_ndup (ex + 1, strlen (ex) - 2);
+			RLangPlugin *lp = r_lang_get_by_name (core->lang, name);
 			if (lp) {
 				if (lp->example) {
 					r_cons_println (lp->example);
 				} else {
-					eprintf ("This language plugin doesnt provide any example.\n");
+					eprintf ("%s plugin does not provide an example.\n", name);
 				}
 			} else {
-				eprintf ("Unknown rlang plugin '%s'.\n", foo);
+				eprintf ("Unknown rlang plugin '%s'.\n", name);
 			}
-			free (foo);
+			free (name);
 		}
 		return false;
 	}

--- a/libr/core/cmd_hash.c
+++ b/libr/core/cmd_hash.c
@@ -2,6 +2,19 @@
 
 #include <r_core.h>
 
+const char *help_msg_hash[] = {
+	"Usage:", "#!<interpreter>", "[<args>] [<file] [<<eof]",
+	"#", "", "comment - do nothing",
+	"#!", "", "list all available interpreters",
+	"#!v?", "", "show vlang script example",
+	"#!python?", "", "show python script example",
+	"#!python", "", "run python commandline",
+	"#!python", " foo.py", "run foo.py python script (same as '. foo.py')",
+	//"#!python <<EOF        get python code until 'EOF' mark\n"
+	"#!python", " arg0 a1 <<q", "set arg0 and arg1 and read until 'q'",
+	NULL
+};
+
 typedef void (*HashHandler)(const ut8 *block, int len);
 
 typedef struct {
@@ -353,7 +366,11 @@ static int cmd_hash_bang(RCore *core, const char *input) {
 					eprintf ("%s plugin does not provide an example.\n", name);
 				}
 			} else {
-				eprintf ("Unknown rlang plugin '%s'.\n", name);
+				if (*name) {
+					eprintf ("Unknown rlang plugin '%s'.\n", name);
+				} else {
+					r_core_cmd_help_match (core, help_msg_hash, "#!", false);
+				}
 			}
 			free (name);
 		}
@@ -403,18 +420,7 @@ static int cmd_hash(void *data, const char *input) {
 		return cmd_hash_bang (core, input);
 	}
 	if (*input == '?') {
-		const char *helpmsg3[] = {
-		"Usage #!interpreter [<args>] [<file] [<<eof]","","",
-		" #", "", "comment - do nothing",
-		" #!","","list all available interpreters",
-		" #!v?","","show vlang script example",
-		" #!python?","","show python script example",
-		" #!python","","run python commandline",
-		" #!python"," foo.py","run foo.py python script (same as '. foo.py')",
-		//" #!python <<EOF        get python code until 'EOF' mark\n"
-		" #!python"," arg0 a1 <<q","set arg0 and arg1 and read until 'q'",
-		NULL};
-		r_core_cmd_help (core, helpmsg3);
+		r_core_cmd_help (core, help_msg_hash);
 		return false;
 	}
 	/* this is a comment - captain obvious

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1264,10 +1264,12 @@ static void autocomplete_process_path(RLineCompletion *completion, const char *s
 		goto out;
 	}
 
+#if 0
 	if (path[0] == '>') {
 		is_pipe = true;
 		path++;
 	}
+#endif
 
 	lpath = r_str_new (path);
 #if __WINDOWS__
@@ -1349,9 +1351,12 @@ static void autocomplete_filename(RLineCompletion *completion, RLineBuffer *buf,
 
 	if (pipe) {
 		args = r_str_new (pipe);
+#if 0
 		if (pipe[1] == ' ') {
+			// currently unreachable
 			narg++;
 		}
+#endif
 	} else {
 		args = r_str_new (buf->data);
 	}
@@ -1913,11 +1918,11 @@ R_API void r_core_autocomplete(R_NULLABLE RCore *core, RLineCompletion *completi
 			should_complete &= buf->data + buf->index < pipe_space;
 		}
 		if (should_complete) {
-			if (pipe[1] == ' '){
-				autocomplete_filename (completion, buf, core->rcmd, NULL, 0);
-			} else {
+			if (pipe[1] != ' '){
 				r_line_completion_push (completion, ">");
+				return;
 			}
+			autocomplete_filename (completion, buf, core->rcmd, NULL, 1);
 		}
 	} else if (ptr) {
 		char *ptr_space = ptr[1] == ' '
@@ -1928,11 +1933,11 @@ R_API void r_core_autocomplete(R_NULLABLE RCore *core, RLineCompletion *completi
 			should_complete &= buf->data + buf->index < ptr_space;
 		}
 		if (should_complete) {
-			if (ptr[1] == ' ') {
-				autocomplete_flags (core, completion, ptr+2);
-			} else {
+			if (ptr[1] != ' ') {
 				r_line_completion_push (completion, "@");
+				return;
 			}
+			autocomplete_flags (core, completion, ptr+2);
 		}
 	} else if (!strncmp (buf->data, "#!pipe ", 7)) {
 		if (strchr (buf->data + 7, ' ')) {


### PR DESCRIPTION
Closes #19438.

* `#!` has been removed from tabhelp, listing is preferable. Help for `#!` comes from `#?`.
  * `#` and `#!` help has also been improved. `#!?` now prints help instead of erroring out.
* `>` and `@` still require a space, but will now automatically add one if it does not exist.

Removing the space requirement for `>` and `@` is not possible without including them in the autocompletion output, which is undesirable. It's something I'd like to see in the future, but the current API can't handle it.