### PR TITLE
Run 'aap' before 'aae' on arm64 binaries in 'aaa' ##analysis

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -11207,6 +11207,15 @@ static int cmd_anal_all(RCore *core, const char *input) {
 				if (r_cons_is_breaked ()) {
 					goto jacuzzi;
 				}
+				bool isPreludableArch = core->rasm->bits == 64 && r_str_startswith (r_config_get (core->config, "asm.arch"), "arm");
+				
+				if (!didAap && isPreludableArch) {
+					didAap = true;
+					oldstr = r_print_rowlog (core->print, "Finding function preludes");
+					(void)r_core_search_preludes (core, false); // "aap"
+					r_print_rowlog_done (core->print, oldstr);
+					r_core_task_yield (&core->tasks);
+				}
 				if (!r_str_startswith (r_config_get (core->config, "asm.arch"), "x86")) {
 					r_core_cmd0 (core, "aav");
 					r_core_task_yield (&core->tasks);
@@ -11285,12 +11294,12 @@ static int cmd_anal_all(RCore *core, const char *input) {
 
 				if (input[1] == 'a') { // "aaaa"
 					if (!didAap) {
+						didAap = true;
 						oldstr = r_print_rowlog (core->print, "Finding function preludes");
 						(void)r_core_search_preludes (core, false); // "aap"
 						r_print_rowlog_done (core->print, oldstr);
 						r_core_task_yield (&core->tasks);
 					}
-
 					oldstr = r_print_rowlog (core->print, "Enable constraint types analysis for variables");
 					r_config_set (core->config, "anal.types.constraint", "true");
 					r_print_rowlog_done (core->print, oldstr);


### PR DESCRIPTION
* No need for `aaaa` to get more functions and xrefs!
* aaef is executed instead of `aae`. so it will miss refs

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
