### PR TITLE
Fix PPC ESIL of addis instruction ##esil

### DIFF
--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -929,8 +929,11 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 			op->type = R_ANAL_OP_TYPE_ADD;
 			esilprintf (op, "%s,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
-		case PPC_INS_ADDE:
 		case PPC_INS_ADDIS:
+			op->type = R_ANAL_OP_TYPE_ADD;
+			esilprintf (op, "16,%s,<<,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_ADDE:
 		case PPC_INS_ADDME:
 		case PPC_INS_ADDZE:
 			op->type = R_ANAL_OP_TYPE_ADD;

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -42,3 +42,33 @@ bdnz 0xfffffffffffffff0
 0x00000000 1,ctr,-=,$z,!,?{,0xfffffffffffffff0,pc,=,}
 EOF
 RUN
+
+NAME=addis with positive number ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 3c4c0002)
+EOF
+EXPECT=<<EOF
+addis r2, r12, 2
+0x00000000 16,0x2,<<,r12,+,r2,=
+EOF
+RUN
+
+NAME=addis with negative number ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 3c4cfffd)
+EOF
+EXPECT=<<EOF
+addis r2, r12, -3
+0x00000000 16,0xfffffffffffffffd,<<,r12,+,r2,=
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ESIL of `addis r2, r12, 3` is `3,r12,+,r2,=`, but should be: `16,3,<<,r12,+,r2,=`

`addis` is "add immediate shifted", but its ESIL output is for "add immediate".

<!-- explain your changes if necessary -->
