### PR TITLE
Add support for parsing swift metadata from macho binaries ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2229,7 +2229,7 @@ static int prot2perm(int x) {
 	return r;
 }
 
-static bool __isDataSection(RBinSection *sect) {
+static bool is_data_section(RBinSection *sect) {
 	if (strstr (sect->name, "_cstring")) {
 		return true;
 	}
@@ -2302,7 +2302,10 @@ RList *MACH0_(get_segments)(RBinFile *bf) {
 			char *section_name = r_str_ndup (bin->sects[i].sectname, 16);
 			char *segment_name = r_str_newf ("%u.%s", (ut32)i, bin->segs[segment_index].segname);
 			s->name = r_str_newf ("%s.%s", segment_name, section_name);
-			s->is_data = __isDataSection (s);
+			if (strstr (s->name, "__const")) {
+				s->format = r_str_newf ("Cd 4[%"PFMT64d"]", s->size / 4);
+			}
+			s->is_data = is_data_section (s);
 			if (strstr (section_name, "interpos") || strstr (section_name, "__mod_")) {
 #if R_BIN_MACH064
 				const int ws = 8;

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -287,10 +287,10 @@ typedef struct r_bin_file_t {
 	int strmode;
 	ut32 id;
 	RBuffer *buf;
-	ut64 offset;
+	ut64 offset; // XXX
 	RBinObject *o;
 	void *xtr_obj;
-	ut64 loadaddr;
+	ut64 loadaddr; // XXX
 	/* values used when searching the strings */
 	int minstrlen;
 	int maxstrlen;

--- a/test/db/formats/mach0/swift
+++ b/test/db/formats/mach0/swift
@@ -62,6 +62,7 @@ EOF
 RUN
 
 NAME=mach0 swift-x86-64 aav
+ARGS=-e bin.demangle=false
 FILE=bins/mach0/swift-main
 CMDS=<<EOF
 C*~?^Cd
@@ -70,13 +71,14 @@ C*~?^Cd
 Cd~?
 EOF
 EXPECT=<<EOF
-114
-134
-134
+304
+324
+324
 EOF
 RUN
 
 NAME=swift-x86-64 calling convention
+ARGS=-e bin.demangle=false
 FILE=bins/mach0/swift5.1-throwError
 CMDS=<<EOF
 s sym.__s10throwError7ThrowerC0a2MyB0yyKF
@@ -111,6 +113,7 @@ EOF
 RUN
 
 NAME=swift-x86-64 calling convention json
+ARGS=-e bin.demangle=false
 FILE=bins/mach0/swift5.1-throwError
 CMDS=<<EOF
 s sym.__s10throwError7ThrowerC0a2MyB0yyKF

--- a/test/db/formats/mach0/swift
+++ b/test/db/formats/mach0/swift
@@ -1,4 +1,56 @@
 NAME=mach0 swift demangle methods
+FILE=bins/mach0/swift/klass.orig
+ARGS=-e bin.verbose=true
+CMDS=q
+EXPECT=<<EOF
+f sym.swift.SomeClass.init = 0x100002a80
+f sym.swift.SomeClass.method.0 = 0x100003cff
+f sym.swift.SomeClass.method.1 = 0x100003d08
+f sym.swift.SomeClass.method.2 = 0x100003d0e
+f sym.swift.SomeClass.method.3 = 0x100003d17
+f sym.swift.SomeClass.method.4 = 0x100003d20
+f sym.swift.SomeClass.method.5 = 0x100003d24
+f sym.swift.SomeClass.method.6 = 0x100003d1d
+f sym.swift.SomeClass.method.__s5klass10SuperKlassCACycfCTq = 0x100003d90
+f sym.swift.SomeClass.method.8 = 0x100003d2c
+f sym.swift.SomeClass.method.9 = 0x100003d34
+f sym.swift.SomeClass.field.meh = 0x100003e8d
+f sym.swift.SomeClass.field.cow = 0x100003e91
+f sym.swift.SuperKlass.init = 0x100002440
+f sym.swift.SuperKlass.method.__s5klass10SuperKlassC10superfieldSivg = 0x1000028f0
+f sym.swift.SuperKlass.method.__s5klass10SuperKlassC10superfieldSivs = 0x100002950
+f sym.swift.SuperKlass.method.__s5klass10SuperKlassC10superfieldSivM = 0x1000029b0
+f sym.swift.SuperKlass.method.__s5klass10SuperKlassCACycfC = 0x100002a10
+f sym.swift.SuperKlass.method.4 = 0x100003d9c
+f sym.swift.SuperKlass.field.superfield = 0x100003e95
+EOF
+EXPECT_ERR=<<EOF
+data-in-code at 0xc360 size 8
+Cd 4 4 @ 0x1000031d8
+0x00003cb0 swift_type_entry:
+  flags:   0xc0000050
+  parent:  0x00003c98
+  name:    0x00003ca4 (SomeClass)
+  access:  0x100002a80
+  fields:  0x00003ea0
+  super:   0x00003e7e
+  members: 0x00003cd9
+  fields:  0x00003cd6
+  fieldsat:0x00003ce7
+0x00003d44 swift_type_entry:
+  flags:   0x80000050
+  parent:  0x00003c98
+  name:    0x00003d38 (SuperKlass)
+  access:  0x100002440
+  fields:  0x00003ec8
+  super:   0x00003d58
+  members: 0x00003d69
+  fields:  0x00003d69
+  fieldsat:0x00003d76
+EOF
+RUN
+
+NAME=mach0 swift demangle methods
 FILE=bins/mach0/swift-main
 CMDS=isq~&FooClass,method
 EXPECT=<<EOF


### PR DESCRIPTION
* __const section is formatted as dwords
* Fix swift5 symbol demangling on iOS / macOS

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
