### PR TITLE
Partial #19887 - Refactor, document, and test `cw` command

### DIFF
--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -510,7 +510,7 @@ out_free_argv:
 	case '\0': { // "cw"
 		int mode;
 		if (*input) {
-			mode = input[1];
+			mode = *input;
 			if (input[1]) {
 				addr = r_num_get (core->num, input + 2);
 			}

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -59,7 +59,11 @@ R_API R_BORROW RCoreCmpWatcher *r_core_cmpwatch_get(RCore *core, ut64 addr) {
 	return NULL;
 }
 
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd) {
+#else
+R_API int r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd) {
+#endif
 	RCoreCmpWatcher *cmpw;
 	bool found = false;
 	r_return_val_if_fail (core && cmd && size > 0, false);
@@ -104,7 +108,11 @@ R_API bool r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd
 	return true;
 }
 
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_del(RCore *core, ut64 addr) {
+#else
+R_API int r_core_cmpwatch_del(RCore *core, ut64 addr) {
+#endif
 	bool ret = false;
 	RCoreCmpWatcher *w;
 	RListIter *iter, *iter2;
@@ -129,7 +137,11 @@ R_API bool r_core_cmpwatch_del(RCore *core, ut64 addr) {
 	return ret;
 }
 
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_show(RCore *core, ut64 addr, int mode) {
+#else
+R_API int r_core_cmpwatch_show(RCore *core, ut64 addr, int mode) {
+#endif
 	RListIter *iter;
 	RCoreCmpWatcher *w;
 	PJ *pj = NULL;
@@ -206,7 +218,11 @@ static bool update_watcher(RIO *io, RCoreCmpWatcher *w) {
 }
 
 /* Replace old data with current new data, then read IO into new data */
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_update(RCore *core, ut64 addr) {
+#else
+R_API int r_core_cmpwatch_update(RCore *core, ut64 addr) {
+#endif
 	RCoreCmpWatcher *w;
 	RListIter *iter;
 	bool ret = false;
@@ -240,7 +256,11 @@ static bool revert_watcher(RCoreCmpWatcher *w) {
 }
 
 /* Mark the current old state as new, discarding the original new state */
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_revert(RCore *core, ut64 addr) {
+#else
+R_API int r_core_cmpwatch_revert(RCore *core, ut64 addr) {
+#endif
 	RCoreCmpWatcher *w;
 	RListIter *iter;
 	bool ret = false;

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -410,7 +410,6 @@ static int radare_compare(RCore *core, const ut8 *f, const ut8 *d, int len, int 
 	return len - eq;
 }
 
-// TODO: this command needs tests!
 static void cmd_cmp_watcher(RCore *core, const char *input) {
 	ut64 addr = UT64_MAX;
 	switch (*input) {

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -418,8 +418,9 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 
 	switch (*input) {
 	case ' ': { // "cw "
-		int argc, size;
 		char **argv;
+		int argc;
+		ut64 size;
 
 		argv = r_str_argv (input + 1, &argc);
 		if (!argv) {
@@ -431,10 +432,15 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 			r_core_cmpwatch_show (core, addr, 0);
 		} else if (argc == 3) { // "cw addr sz cmd"
 			addr = r_num_get (core->num, argv[0]);
-			size = atoi (argv[1]);
+			size = r_num_get (core->num, argv[1]);
+
 			if (size < 1) {
 				ret = 1;
 				eprintf ("Can't create a watcher with size less than 1.\n");
+				goto out_free_argv;
+			} else if (size > INT_MAX) {
+				ret = 1;
+				eprintf ("Can't create a watcher with size larger than an int.\n");
 				goto out_free_argv;
 			}
 
@@ -447,7 +453,7 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 				goto out_free_argv;
 			}
 
-			if (!r_core_cmpwatch_add (core, addr, size, argv[2])) {
+			if (!r_core_cmpwatch_add (core, addr, (int)size, argv[2])) {
 				ret = 1;
 				eprintf ("Failed to add watcher.\n");
 			}

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -34,7 +34,7 @@ static const char *help_msg_c[] = {
 	"cud", " [addr] @at", "Unified diff disasm from $$ and given address",
 	"cv", "[1248] [hexpairs] @at", "Compare 1,2,4,8-byte (silent return in $?)",
 	"cV", "[1248] [addr] @at", "Compare 1,2,4,8-byte address contents (silent, return in $?)",
-	"cw", "[*dqjru?] [addr]", "Compare memory watchers",
+	"cw", "[?][*dqjru] [addr]", "Compare memory watchers",
 	"cx", " [hexpair]", "Compare hexpair string (use '.' as nibble wildcard)",
 	"cx*", " [hexpair]", "Compare hexpair string (output r2 commands)",
 	"cX", " [addr]", "Like 'cc' but using hexdiff output",

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -41,38 +41,6 @@ static const char *help_msg_c[] = {
 	NULL
 };
 
-static const char *help_msg_cw[] = {
-	"Usage: cw", "[args]", "Manage compare watchers; See if and how memory changes",
-	"cw??", "", "Show more info about watchers",
-	"cw ", "addr sz cmd", "Add a compare watcher",
-	"cw", "[*q] [addr]", "Show compare watchers (*=r2 commands, q=quiet)",
-	"cwd", " [addr]", "Delete watcher",
-	"cwr", " [addr]", "Revert watcher",
-	"cwu", " [addr]", "Update watcher",
-	NULL
-};
-
-static const char *verbose_help_cw =
-	"Watchers are used to record memory at 2 different points in time, then\n"
-	"report if and how it changed. First, create one with `cw addr sz cmd`. This\n"
-	"will record sz bytes at addr. To record the second state, use `cwu`. Now, when\n"
-	"you run `cw`, the watcher will report if the bytes changed and run the command given\n"
-	"at creation with the size and address. You may overwrite any watcher by creating\n"
-	"another at the same address. This will discard the existing watcher completely.\n"
-	"\n"
-	"When you create a watcher, the data read from memory is marked as \"new\". Updating\n"
-	"the watcher with `cwu` will mark this data as \"old\", and then read the \"new\" data.\n"
-	"`cwr` will mark the current \"old\" state as being \"new\", letting you reuse it as\n"
-	"your new base state when updating with `cwu`. Any existing \"new\" state from running\n"
-	"`cwu` previously is lost in this process. Watched memory areas may overlap with no ill\n"
-	"effects, but may have unexpected results if you update some but not others.\n"
-	"\n"
-	"Showing a watcher without updating will still run the command, but it will not report\n"
-	"changes.\n"
-	"\n"
-	"When an address is an optional argument, the command will apply to all watchers if\n"
-	"you don't pass one.\n";
-
 R_API void r_core_cmpwatch_free(RCoreCmpWatcher *w) {
 	free (w->ndata);
 	free (w->odata);
@@ -412,8 +380,40 @@ static int radare_compare(RCore *core, const ut8 *f, const ut8 *d, int len, int 
 
 /* Returns 0 if operation succeeded, 1 otherwise */
 static int cmd_cmp_watcher(RCore *core, const char *input) {
+	static const char *help_msg_cw[] = {
+		"Usage: cw", "[args]", "Manage compare watchers; See if and how memory changes",
+		"cw??", "", "Show more info about watchers",
+		"cw ", "addr sz cmd", "Add a compare watcher",
+		"cw", "[*q] [addr]", "Show compare watchers (*=r2 commands, q=quiet)",
+		"cwd", " [addr]", "Delete watcher",
+		"cwr", " [addr]", "Revert watcher",
+		"cwu", " [addr]", "Update watcher",
+		NULL
+	};
+	static const char *verbose_help_cw =
+		"Watchers are used to record memory at 2 different points in time, then\n"
+		"report if and how it changed. First, create one with `cw addr sz cmd`. This\n"
+		"will record sz bytes at addr. To record the second state, use `cwu`. Now, when\n"
+		"you run `cw`, the watcher will report if the bytes changed and run the command given\n"
+		"at creation with the size and address. You may overwrite any watcher by creating\n"
+		"another at the same address. This will discard the existing watcher completely.\n"
+		"\n"
+		"When you create a watcher, the data read from memory is marked as \"new\". Updating\n"
+		"the watcher with `cwu` will mark this data as \"old\", and then read the \"new\" data.\n"
+		"`cwr` will mark the current \"old\" state as being \"new\", letting you reuse it as\n"
+		"your new base state when updating with `cwu`. Any existing \"new\" state from running\n"
+		"`cwu` previously is lost in this process. Watched memory areas may overlap with no ill\n"
+		"effects, but may have unexpected results if you update some but not others.\n"
+		"\n"
+		"Showing a watcher without updating will still run the command, but it will not report\n"
+		"changes.\n"
+		"\n"
+		"When an address is an optional argument, the command will apply to all watchers if\n"
+		"you don't pass one.\n";
+
 	ut64 addr = UT64_MAX;
 	int ret = 0;
+
 	switch (*input) {
 	case ' ': { // "cw "
 		int argc, size;

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -234,10 +234,9 @@ static bool revert_watcher(RCoreCmpWatcher *w) {
 		free (w->ndata);
 		w->ndata = w->odata;
 		w->odata = NULL;
-		return true;
 	}
 
-	return false;
+	return true;
 }
 
 /* Mark the current old state as new, discarding the original new state */
@@ -481,7 +480,7 @@ out_free_argv:
 		if (input[1]) {
 			addr = r_num_get (core->num, input + 2);
 		}
-		if (r_core_cmpwatch_revert (core, addr)) {
+		if (!r_core_cmpwatch_revert (core, addr)) {
 			if (addr == UT64_MAX) {
 				eprintf ("No watchers exist.\n");
 			} else {

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -409,7 +409,9 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 		"changes.\n"
 		"\n"
 		"When an address is an optional argument, the command will apply to all watchers if\n"
-		"you don't pass one.\n";
+		"you don't pass one.\n"
+		"\n"
+		"For more details, see section 4.10 of the radare2 book.\n";
 
 	ut64 addr = UT64_MAX;
 	int ret = 0;

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -469,6 +469,11 @@ out_free_argv:
 			addr = r_num_get (core->num, input + 2);
 		}
 
+		if (addr == UT64_MAX &&
+				!r_cons_yesno ('n', "Delete all watchers? (y/N)")) {
+			return 1;
+		}
+
 		if (!r_core_cmpwatch_del (core, addr) && addr) {
 			ret = 1;
 			if (addr == UT64_MAX) {
@@ -486,6 +491,11 @@ out_free_argv:
 
 		if (input[1]) {
 			addr = r_num_get (core->num, input + 2);
+		}
+
+		if (addr == UT64_MAX &&
+				!r_cons_yesno ('n', "Revert all watchers? (y/N)")) {
+			return 1;
 		}
 
 		if (!r_core_cmpwatch_revert (core, addr)) {

--- a/libr/core/cmd_cmp.c
+++ b/libr/core/cmd_cmp.c
@@ -411,7 +411,7 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 		"When an address is an optional argument, the command will apply to all watchers if\n"
 		"you don't pass one.\n"
 		"\n"
-		"For more details, see section 4.10 of the radare2 book.\n";
+		"For more details and examples, see section 4.10 of the radare2 book.\n";
 
 	ut64 addr = UT64_MAX;
 	int ret = 0;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -387,7 +387,7 @@ R_API int r_core_bind(RCore *core, RCoreBind *bnd);
 typedef struct r_core_cmpwatch_t {
 	ut64 addr;
 	int size;
-	char cmd[32];
+	char *cmd;
 	ut8 *odata;
 	ut8 *ndata;
 } RCoreCmpWatcher;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -817,11 +817,11 @@ R_API void r_core_clippy(RCore *core, const char *msg);
 /* watchers */
 R_API void r_core_cmpwatch_free(RCoreCmpWatcher *w);
 R_API RCoreCmpWatcher *r_core_cmpwatch_get(RCore *core, ut64 addr);
-R_API int r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd);
-R_API int r_core_cmpwatch_del(RCore *core, ut64 addr);
-R_API int r_core_cmpwatch_update(RCore *core, ut64 addr);
-R_API int r_core_cmpwatch_show(RCore *core, ut64 addr, int mode);
-R_API int r_core_cmpwatch_revert(RCore *core, ut64 addr);
+R_API bool r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd);
+R_API bool r_core_cmpwatch_del(RCore *core, ut64 addr);
+R_API bool r_core_cmpwatch_update(RCore *core, ut64 addr);
+R_API bool r_core_cmpwatch_show(RCore *core, ut64 addr, int mode);
+R_API bool r_core_cmpwatch_revert(RCore *core, ut64 addr);
 
 /* undo */
 R_API RCoreUndo *r_core_undo_new(ut64 offset, const char *action, const char *revert);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -816,12 +816,20 @@ R_API void r_core_clippy(RCore *core, const char *msg);
 
 /* watchers */
 R_API void r_core_cmpwatch_free(RCoreCmpWatcher *w);
-R_API RCoreCmpWatcher *r_core_cmpwatch_get(RCore *core, ut64 addr);
+R_API R_BORROW RCoreCmpWatcher *r_core_cmpwatch_get(RCore *core, ut64 addr);
+#if R2_VERSION_MAJOR >= 5 && R2_VERSION_MINOR >= 7
 R_API bool r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd);
 R_API bool r_core_cmpwatch_del(RCore *core, ut64 addr);
 R_API bool r_core_cmpwatch_update(RCore *core, ut64 addr);
 R_API bool r_core_cmpwatch_show(RCore *core, ut64 addr, int mode);
 R_API bool r_core_cmpwatch_revert(RCore *core, ut64 addr);
+#else
+R_API int r_core_cmpwatch_add(RCore *core, ut64 addr, int size, const char *cmd);
+R_API int r_core_cmpwatch_del(RCore *core, ut64 addr);
+R_API int r_core_cmpwatch_update(RCore *core, ut64 addr);
+R_API int r_core_cmpwatch_show(RCore *core, ut64 addr, int mode);
+R_API int r_core_cmpwatch_revert(RCore *core, ut64 addr);
+#endif
 
 /* undo */
 R_API RCoreUndo *r_core_undo_new(ut64 offset, const char *action, const char *revert);

--- a/test/db/cmd/cmd_cw
+++ b/test/db/cmd/cmd_cw
@@ -1,0 +1,83 @@
+NAME=basic cw usage
+CMDS=<<EOF
+cw 0 4 p8
+cw 100 4 p8
+cw # show all
+?e ---
+cw 100 # show at addr
+?e ---
+cwq # show quiet - no output yet
+?e ---
+cw* # show commands
+?e ---
+cw 0 8 px # overwrite
+cw*
+?e ---
+cwd 0 # delete
+cw*
+EOF
+EXPECT=<<EOF
+0x00000000
+00000000
+0x00000064
+00000000
+---
+0x00000064
+00000000
+---
+---
+cw 0x00000000 4 p8
+cw 0x00000064 4 p8
+---
+cw 0x00000000 8 px
+cw 0x00000064 4 p8
+---
+cw 0x00000064 4 p8
+EOF
+RUN
+
+NAME=cw with cwu update
+CMDS=<<EOF
+cw 0 4 p8
+cw*
+?e ---
+wx 11223344
+cwu # update
+cw
+?e ---
+cw*
+?e ---
+cwq
+EOF
+EXPECT=<<EOF
+cw 0x00000000 4 p8
+---
+0x00000000 modified
+11223344
+---
+cw 0x00000000 4 p8 # differs
+---
+0x00000000 has changed
+EOF
+RUN
+
+NAME=cw with update and cwr revert
+CMDS=<<EOF
+cw 0 4 p8
+cw*
+?e ---
+wx 11223344
+cwu # update
+cw*
+?e ---
+cwr # revert
+cw* # no longer updated internally
+EOF
+EXPECT=<<EOF
+cw 0x00000000 4 p8
+---
+cw 0x00000000 4 p8 # differs
+---
+cw 0x00000000 4 p8
+EOF
+RUN

--- a/test/db/cmd/cmd_cw
+++ b/test/db/cmd/cmd_cw
@@ -73,7 +73,7 @@ wx 11223344
 cwu # update
 cw*
 ?e ---
-cwr # revert
+cwr 0 # revert
 cw* # no longer updated internally
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_cw
+++ b/test/db/cmd/cmd_cw
@@ -6,6 +6,8 @@ cw # show all
 ?e ---
 cw 100 # show at addr
 ?e ---
+cw 200 # doesn't exist
+?e ---
 cwq # show quiet - no output yet
 ?e ---
 cw* # show commands
@@ -24,6 +26,7 @@ EXPECT=<<EOF
 ---
 0x00000064
 00000000
+---
 ---
 ---
 cw 0x00000000 4 p8

--- a/test/db/cmd/cmd_cw
+++ b/test/db/cmd/cmd_cw
@@ -6,9 +6,11 @@ cw # show all
 ?e ---
 cw 100 # show at addr
 ?e ---
-cw 200 # doesn't exist
+cw 200 # doesn't exist - no output
 ?e ---
 cwq # show quiet - no output yet
+?e ---
+cwj~{} # show json
 ?e ---
 cw* # show commands
 ?e ---
@@ -28,6 +30,21 @@ EXPECT=<<EOF
 00000000
 ---
 ---
+---
+[
+  {
+    "addr": 0,
+    "changed": false,
+    "cmd": "p8",
+    "cmd_out": "00000000\n"
+  },
+  {
+    "addr": 100,
+    "changed": false,
+    "cmd": "p8",
+    "cmd_out": "00000000\n"
+  }
+]
 ---
 cw 0x00000000 4 p8
 cw 0x00000064 4 p8
@@ -51,6 +68,8 @@ cw
 cw*
 ?e ---
 cwq
+?e ---
+cwj~{}
 EOF
 EXPECT=<<EOF
 cw 0x00000000 4 p8
@@ -61,6 +80,15 @@ cw 0x00000000 4 p8
 cw 0x00000000 4 p8 # differs
 ---
 0x00000000 has changed
+---
+[
+  {
+    "addr": 0,
+    "changed": true,
+    "cmd": "p8",
+    "cmd_out": "11223344\n"
+  }
+]
 EOF
 RUN
 


### PR DESCRIPTION
This command was originally implemented in 2012 but never documented or tested and the help text was sparse with information about what it actually did.

## Changelog

* Change the `R_API r_core_cmpwatch_*` functions to return bool for reporting success and failure.
  * The internal `cmd_cmp_watcher()` function now returns an int, so it can propagated through `cmd_cmp()`.
* Fix a bug that caused watchers to be partially overwritten and then duplicated in `core->watchers` when creating a new watcher at an address that already has one.
  * Watchers are now totally overwritten when this happens.
* Provide more verbose help text about watchers with `cw??`, including a reference to the book page.
* Add tests for `cw` and its subcommands.
* Ask user for confirmation before deleting/reverting all watchers - it's a potentially very destructive action that's very easy to do by accident.

### Book

I have created a page for comparison watchers in the book. See radareorg/radare2-book#334