### PR TITLE
Fix incorrect type, that breaks liball:// and arall://

### DIFF
--- a/libr/io/p/io_ar.c
+++ b/libr/io/p/io_ar.c
@@ -64,7 +64,7 @@ typedef struct ar_many_data {
 	const char *schema;
 	const char *arname;
 	RIO *io;
-	bool rw;
+	int rwx;
 	int mode;
 	RList *list;
 } ar_many_data;
@@ -72,7 +72,7 @@ typedef struct ar_many_data {
 static int __io_ar_list(RArFp *arf, void *user) {
 	ar_many_data *data = (ar_many_data *)user;
 	char *uri = r_str_newf ("%s%s//%s", data->schema, data->arname, arf->name);
-	RIODesc *des = r_io_desc_new (data->io, &r_io_plugin_ar, uri, data->rw, data->mode, arf);
+	RIODesc *des = r_io_desc_new (data->io, &r_io_plugin_ar, uri, data->rwx, data->mode, arf);
 	free (uri);
 
 	if (!des) {
@@ -96,7 +96,7 @@ static RList *r_io_ar_open_many(RIO *io, const char *file, int rw, int mode) {
 		return NULL;
 	}
 	data.io = io;
-	data.rw = rw;
+	data.rwx = rw;
 	data.mode = mode;
 	data.arname = strstr (file, "://") + 3;
 	data.list = r_list_newf ((RListFree)r_io_ar_close);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
