### PR TITLE
Fix glob matching in several cases

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1409,13 +1409,7 @@ static void recursive_glob(const char *path, const char *glob, RList* list, int 
 		if (!strcmp (file, ".") || !strcmp (file, "..")) {
 			continue;
 		}
-		char *filename;
-		if (!r_str_endswith(path, "/") && !r_str_startswith(file, "/")) {
-			filename = r_file_new (path, file, NULL);
-		} else {
-			filename = r_str_newf ("%s%s", path, file);
-		}
-
+		char *filename = r_file_new (path, file, NULL);
 		if (r_file_is_directory (filename)) {
 			recursive_glob (filename, glob, list, depth - 1);
 			free (filename);

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1409,7 +1409,13 @@ static void recursive_glob(const char *path, const char *glob, RList* list, int 
 		if (!strcmp (file, ".") || !strcmp (file, "..")) {
 			continue;
 		}
-		char *filename = r_str_newf ("%s%s", path, file);
+		char *filename;
+		if (!r_str_endswith(path, "/") && !r_str_startswith(file, "/")) {
+			filename = r_file_new (path, file, NULL);
+		} else {
+			filename = r_str_newf ("%s%s", path, file);
+		}
+
 		if (r_file_is_directory (filename)) {
 			recursive_glob (filename, glob, list, depth - 1);
 			free (filename);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2366,19 +2366,16 @@ R_API bool r_str_glob(const char* str, const char *glob) {
 			// Check if there are additional wildcards
 			// if so, we need to search for the substring in between the wildcards
 			const char *needle_end = glob;
-			while (true) {
-				if (*needle_end == '*' ||
-					*needle_end == '?' ||
-					*needle_end == '$' ||
-					*needle_end == '^' ||
-					*needle_end == '\0') {
-					break;
-				}
+			while (*needle_end != '*' &&
+					*needle_end != '?' &&
+					*needle_end != '$' &&
+					*needle_end != '^' &&
+					*needle_end != '\0') {
 				needle_end++;
 			}
-			char *needle = strndup (glob, needle_end - glob);
 			// Find the pattern in between wildcards
-			char *advance_to = strstr (str, needle);
+			char* needle = r_str_ndup(glob, needle_end - glob);
+			const char *advance_to = strstr (str, needle);
 			free (needle);
 			if (!advance_to) {
 				return false;

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2350,22 +2350,47 @@ R_API bool r_str_glob(const char* str, const char *glob) {
 	}
 	while (*str) {
 		if (!*glob) {
-			return true;
+			return false;
 		}
 		switch (*glob) {
 		case '*':
 			if (!*++glob) {
 				return true;
 			}
+			// Advance glob an additional time if it is a '**'
+			if (*glob == '*') {
+				if (!*++glob) {
+					return true;
+				}
+			}
+			// Check if there are additional wildcards
+			// if so, we need to search for the substring in between the wildcards
+			const char *needle_end = glob;
+			while (true) {
+				if (*needle_end == '*' ||
+					*needle_end == '?' ||
+					*needle_end == '$' ||
+					*needle_end == '^' ||
+					*needle_end == '\0') {
+					break;
+				}
+				needle_end++;
+			}
+			char *needle = strndup (glob, needle_end - glob);
+			// Find the pattern in between wildcards
+			char *advance_to = strstr (str, needle);
+			free (needle);
+			if (!advance_to) {
+				return false;
+			}
+			// Advance str to found pattern
 			while (*str) {
-				if (*glob == *str) {
+				if (str == advance_to) {
 					break;
 				}
 				str++;
 			}
 			break;
-		case '$':
-			return (*++glob == '\x00');
 		case '?':
 			str++;
 			glob++;

--- a/test/db/formats/cgc
+++ b/test/db/formats/cgc
@@ -9,9 +9,9 @@ RUN
 NAME=CGC: Create
 FILE=-
 CMDS=<<EOF
-rm ./cgc.cgc__
+rm ./cgc.cgc____
 !rabin2 -C elf64:cc -a x86 -b 64 ./cgc.cgc____
-ls -l ./cgc.cgc__~[3]
+ls -l ./cgc.cgc____~[3]
 rm ./cgc.cgc____
 EOF
 EXPECT=<<EOF

--- a/test/unit/test_glob.c
+++ b/test/unit/test_glob.c
@@ -12,9 +12,15 @@ bool test_r_glob(void) {
 	mu_assert_eq (r_str_glob ("foo.c", "f*d"), 0, "foo.c -> f*d -> 0");
 	mu_assert_eq (r_str_glob ("foo.c", "*"), 1, "foo.c -> * -> 1");
 	mu_assert_eq (r_str_glob ("foo.c", "fo?.c"), 1, "foo.c -> fo?.c -> 1");
-	mu_assert_eq (r_str_glob ("foo.c", "^f"), 1, "foo.c -> ^f -> 1");
+	mu_assert_eq (r_str_glob ("foo.c", "^f"), 0, "foo.c -> ^f -> 0");
+	mu_assert_eq (r_str_glob ("foo.c", "^f*"), 1, "foo.c -> ^f* -> 1");
 	mu_assert_eq (r_str_glob ("foo.c", "foo.c$"), 1, "foo.c -> foo.c$ -> 1");
 	mu_assert_eq (r_str_glob ("foo.c", "fooooooo"), 0, "foo.c -> fooooooo -> 0");
+	mu_assert_eq (r_str_glob ("foo.bar.baz", "*.baz"), 1, "foo.bar.baz -> *.baz -> 1");
+	mu_assert_eq (r_str_glob ("foo.bar.baz", "*.bar"), 0, "foo.bar.baz -> *.bar -> 0");
+	mu_assert_eq (r_str_glob ("foo.bar.baz", "*.bar.*"), 1, "foo.bar.baz -> *.bar.* -> 1");
+	mu_assert_eq (r_str_glob ("foo.bar.baz", "*.baz$"), 1, "foo.bar.baz -> *.baz$ -> 1");
+	mu_assert_eq (r_str_glob ("foo.bar.baz", "$"), 0, "foo.bar.baz -> $ -> 0");
 	mu_end;
 }
 


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR aims to fix several bugs in the glob pattern matching. These are:

1. When using a recursive glob (e.g: `/path/**.ext`) in the recursive calls to `recursive_glob` when a directory is found the path is not properly formed, as `path` does not end with `"/"` nor `file` starts with the mentioned character. i.e: a path like `/path/tofile` would be formed instead of the correct `/path/to/file`. This is fixed by the changes in `file.c`.

2. The function `r_str_glob` does not behave properly when using a recursive glob (e.g: `/path/**.ext`) as the `glob` variable will point to the second `*` character after the pre-increment in line 2357. Next, `str` is incremented until `*str == *glob`. This is not the intended behaviour as the `*` character is not meant to be found in the filename. An additional check is needed to assert that the character after the first `*` is not another `*` character and, if so, increment the `glob` pointer an additional time.

3. Similarly to the previous bug, globs containing wildcards (`*`) will not match if the target string has multiple occurrences of the character after the wildcard. e.g: for the glob `/path/*.ext` a file with the path `/path/a.b.ext` will not match as in the function `r_str_glob` `str` is incremented until `*str == '.'`. This condition is met with the first occurrence of `.`. Then the remainder of both strings are compared in a per-character basis. They won't match as with this algorithm the remainders would be `b.ext` and `ext`. Advancing to the *last* occurrence of the character after the glob fixes this issue.

4. Given a `str = "foo.bar.baz"` and a `glob = "*.bar"` the code will correctly advance the `str` pointer to the first `.` character. After that, `.bar` will be compared in both strings character by character. After this action, `str` points to the second `.` character and `glob` to a `\0` as the glob string has been exhausted. As `str` evaluates to TRUE the while loop at line 2351 will continue iterating . The first statement in said loop is `if (!glob) return true;`, so the file would match when it shouldn't

5. The case implementation for the `$` glob character is
```
return (*++glob == '\x00');
```
This is checking that there are not any characters after the `$` in the *glob* string, not in the filename. This condition is not usually met as the `str` string is usually exhausted first and the while loop is aborted. However, it can lead to situations like the `$` glob matching with every file in a directory. The last line in the function (`return ((*glob == '$' && !*glob++)  || !*glob);`) already performs the needed checks for the `$` character, so there is no need to include a `case '$'` in the loop.

I have added tests for all the observed bugs.