### PR TITLE
Fix swift metadata string allocation and filtering bug

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1735,8 +1735,8 @@ static bool read_ptr_va(RBinFile *bf, ut64 vaddr, mach0_ut *out) {
 static char *readstr(RBinFile *bf, ut64 addr) {
 	r_return_val_if_fail (bf, NULL);
 
-	int name_len = 128;
-	char *name = calloc (1, name_len);
+	int name_len = 256;
+	char *name = calloc (1, name_len + 1);
 	int len = r_buf_read_at (bf->buf, addr, (ut8 *)name, name_len);
 	if (len < 2) {
 		R_FREE (name);

--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -136,6 +136,9 @@ R_API bool r_name_filter_print(char *s) {
 }
 
 R_API bool r_name_filter(char *s, int maxlen) {
+	if (R_STR_ISEMPTY (s)) {
+		return false;
+	}
 	// if maxlen == -1 : R_FLAG_NAME_SIZE
 	// maxlen is ignored, the function signature must change
 	// char *os = s;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
