### PR TITLE
Fix autoloading of ##signatures

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -285,11 +285,8 @@ static bool mustSaveHistory(RConfig *c) {
 }
 
 static inline void autoload_zigns(RCore *r) {
-	if (r_config_get_i (r->config, "zign.autoload")) {
-		char *path = r_file_abspath (r_config_get (r->config, "dir.zigns"));
-		if (!path) {
-			return;
-		}
+	char *path = r_file_abspath (r_config_get (r->config, "dir.zigns"));
+	if (R_STR_ISNOTEMPTY (path)) {
 		RList *list = r_sys_dir (path);
 		RListIter *iter;
 		char *file;
@@ -305,8 +302,8 @@ static inline void autoload_zigns(RCore *r) {
 			}
 		}
 		r_list_free (list);
-		free (path);
 	}
+	free (path);
 }
 
 // Try to set the correct scr.color for the current terminal.
@@ -926,7 +923,9 @@ R_API int r_main_radare2(int argc, const char **argv) {
 		r_config_set (r->config, "scr.utf8", "false");
 	}
 
-	autoload_zigns (r);
+	if (r_config_get_b (r->config, "zign.autoload")) {
+		autoload_zigns (r);
+	}
 
 	if (pfile && r_file_is_directory (pfile)) {
 		if (debug) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes `dir->zigns` typo and avoids a warning from `r_sys_dir` if `!path`. I also pulled it as out as a static inline function to simplify `r_main_radare2`.
