### PR TITLE
Update byte signature flag name ##signatures

### DIFF
--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -506,7 +506,7 @@ static int fcnMatchCB(RSignItem *it, RAnalFunction *fcn, RSignType *types, void 
 		switch (t) {
 		case R_SIGN_BYTES:
 			ctx->bytes_count++;
-			prefix = "bytes";
+			prefix = "bytes_func";
 			break;
 		case R_SIGN_GRAPH:
 			prefix = "graph";

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -593,7 +593,7 @@ CMDS=<<EOF
 aa
 za sym.print b 5548....48......48......48......48....bf........b8........e8........90c9c3
 z. @@ fcn*
-?v sign.bytes.sym.print_0
+?v sign.bytes_func.sym.print_0
 EOF
 EXPECT=<<EOF
 0x400536
@@ -706,7 +706,7 @@ fs sign
 e zign.bytes = true
 e zign.graph = false
 z. @ 0x400536
-f~sign.bytes.sym.print?
+f~sign.bytes_func.sym.print?
 f~sign.graph.sym.print?
 f-*
 e zign.bytes = false
@@ -1963,9 +1963,9 @@ af- $$
 zac
 z/
 afl~main?
-zi~sign.bytes_collision.badname_1?
+zi~sign.bytes_func_collision.badname_1?
 zi~sign.graph_collision.badname_1?
-zi~sign.bytes_collision.badname2_1?
+zi~sign.bytes_func_collision.badname2_1?
 zi~sign.graph_collision.badname2_1?
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Byte signatures can match in one of two ways. First by searching with r_search, or by matching against a function. There are different implications and desires for each.

This update will cause function matches to get `bytes_func` flags and the r_search version will stay as `bytes`.