### PR TITLE
Honor escaping semicolons in macro definitions ##shell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2021 - nibble, pancake */
+/* radare - LGPL - Copyright 2009-2022 - nibble, pancake */
 
 #define INTERACTIVE_MAX_REP 1024
 
@@ -750,7 +750,7 @@ static int cmd_alias(void *data, const char *input) {
 					r_cmd_alias_set_raw (core->rcmd, buf, (ut8 *)s, l);
 					free (s);
 				} else if (!strncmp (def, "base64:", 7)) {
-					int b64_len = strlen (def+7);
+					int b64_len = strlen (def + 7);
 					if (b64_len > 0 && b64_len % 4 == 0) {
 						/* b64 decode result is always shorter
 						 * than strlen() of input */

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -498,6 +498,10 @@ R_API void r_cmd_del(RCmd *cmd, const char *command) {
 
 static char *r_cmd_filter_special(const char *input) {
 	char *s = strdup (input);
+	// XXX workaround to call macros with quotes
+	if (*s == '(') {
+		return s;
+	}
 	r_str_trim_args (s);
 	return s;
 }

--- a/libr/core/cmd_api.c
+++ b/libr/core/cmd_api.c
@@ -496,6 +496,7 @@ R_API void r_cmd_del(RCmd *cmd, const char *command) {
 	R_FREE (cmd->cmds[idx]);
 }
 
+#if SHELLFILTER
 static char *r_cmd_filter_special(const char *input) {
 	char *s = strdup (input);
 	// XXX workaround to call macros with quotes
@@ -505,6 +506,7 @@ static char *r_cmd_filter_special(const char *input) {
 	r_str_trim_args (s);
 	return s;
 }
+#endif
 
 R_API int r_cmd_call(RCmd *cmd, const char *input) {
 	struct r_cmd_item_t *c;
@@ -538,9 +540,13 @@ R_API int r_cmd_call(RCmd *cmd, const char *input) {
 		c = cmd->cmds[((ut8)input[0]) & 0xff];
 		if (c && c->callback) {
 			if (*input) {
+#if SHELLFILTER
 				char *s = r_cmd_filter_special (input + 1);
 				ret = c->callback (cmd->data, s);
 				free (s);
+#else
+				ret = c->callback (cmd->data, input + 1);
+#endif
 			} else {
 				ret = c->callback (cmd->data, "");
 			}

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -1088,6 +1088,9 @@ static int cmd_help(void *data, const char *input) {
 		r_core_clippy (core, r_str_trim_head_ro (input + 1));
 		break;
 	case 'e': // "?e" echo
+#if !SHELLFILTER
+		r_str_trim_args ((char *)input);
+#endif
 		switch (input[1]) {
 		case 'a': // "?ea hello world
 			{

--- a/libr/core/cmd_help.c
+++ b/libr/core/cmd_help.c
@@ -1088,8 +1088,6 @@ static int cmd_help(void *data, const char *input) {
 		r_core_clippy (core, r_str_trim_head_ro (input + 1));
 		break;
 	case 'e': // "?e" echo
-		r_str_trim_args ((char *)input);
-
 		switch (input[1]) {
 		case 'a': // "?ea hello world
 			{

--- a/libr/core/cmd_macro.c
+++ b/libr/core/cmd_macro.c
@@ -1,4 +1,5 @@
-/* radare - LGPL - Copyright 2009-2014 - pancake */
+/* radare - LGPL - Copyright 2009-2022 - pancake */
+
 #include "r_cmd.h"
 #include "r_core.h"
 
@@ -51,14 +52,14 @@ static int cmd_macro(void *data, const char *input) {
 				break;
 			case ')':
 				j--;
-				if (buf[i+1] =='(') {
+				if (buf[i + 1] == '(') {
 					buf[i + 1] = 0;
 					mustcall = i + 2;
 				}
 				break;
 			}
 		}
-		buf[strlen (buf) - 1]=0;
+		buf[strlen (buf) - 1] = 0;
 		r_cmd_macro_add (&core->rcmd->macro, buf);
 		if (mustcall) {
 			char *comma = strchr (buf, ' ');
@@ -71,10 +72,12 @@ static int cmd_macro(void *data, const char *input) {
 				r_cmd_macro_call (&core->rcmd->macro, buf);
 			} else {
 				eprintf ("Invalid syntax for macro\n");
+				r_core_return_code (core, R_CMD_RC_FAILURE);
 			}
 		}
 		free (buf);
 		} break;
 	}
-	return 0;
+	r_core_return_code (core, R_CMD_RC_SUCCESS);
+	return R_CMD_RC_SUCCESS;
 }

--- a/libr/core/cmd_macro.c
+++ b/libr/core/cmd_macro.c
@@ -17,9 +17,13 @@ static const char *help_msg_lparen[] = {
 	NULL
 };
 
-static int cmd_macro(void *data, const char *input) {
+static int cmd_macro(void *data, const char *_input) {
 	char *buf = NULL;
 	RCore *core = (RCore*)data;
+	char *input = strdup (_input);
+#if !SHELLFILTER
+	r_str_trim_args (input);
+#endif
 
 	switch (*input) {
 	case ')':
@@ -79,5 +83,6 @@ static int cmd_macro(void *data, const char *input) {
 		} break;
 	}
 	r_core_return_code (core, R_CMD_RC_SUCCESS);
+	free (input);
 	return R_CMD_RC_SUCCESS;
 }

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -7665,7 +7665,10 @@ beach:
 }
 
 static int cmd_hexdump(void *data, const char *input) {
-	return cmd_print (data, input - 1);
+	char *pcmd = r_str_newf ("x%s", input);
+	int rc = cmd_print (data, pcmd);
+	free (pcmd);
+	return rc;
 }
 
 static int lenof(ut64 off, int two) {

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -2136,7 +2136,9 @@ static int cmd_write(void *data, const char *input) {
 		const char *curcs = r_config_get (core->config, "cfg.charset");
 		char *str = strdup (input);
 
-		// r_str_trim_args (str);
+#if !SHELLFILTER
+		r_str_trim_args (str);
+#endif
 		r_str_trim_tail (str);
 
 		ut64 addr = core->offset;

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -2136,7 +2136,7 @@ static int cmd_write(void *data, const char *input) {
 		const char *curcs = r_config_get (core->config, "cfg.charset");
 		char *str = strdup (input);
 
-		r_str_trim_args (str);
+		// r_str_trim_args (str);
 		r_str_trim_tail (str);
 
 		ut64 addr = core->offset;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -31,6 +31,9 @@
 #include "r_bind.h"
 #include "r_codemeta.h"
 
+// TODO: thois var should be 1 at some point :D
+#define SHELLFILTER 0
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2021 - pancake */
+/* radare - LGPL - Copyright 2007-2022 - pancake */
 
 #include "r_types.h"
 #include "r_util.h"
@@ -982,7 +982,6 @@ R_API char* r_str_replace(char *str, const char *key, const char *val, int g) {
 			if (vlen > klen) {
 				newstr = realloc (str, slen + 1);
 				if (!newstr) {
-					eprintf ("realloc fail\n");
 					R_FREE (str);
 					break;
 				}

--- a/libr/util/str_trim.c
+++ b/libr/util/str_trim.c
@@ -106,6 +106,19 @@ R_API void r_str_trim_head(char *str) {
 	}
 }
 
+static bool is_escapable(char ch) {
+	switch (ch) {
+	case '@':
+	case '"':
+	case '\'':
+	case '|':
+	case ';':
+	case '`':
+		return true;
+	}
+	return false;
+}
+
 R_API void r_str_trim_args(char *str) {
 	r_return_if_fail (str);
 	char q = 0;
@@ -139,14 +152,7 @@ R_API void r_str_trim_args(char *str) {
 			if (e) {
 				e = false;
 			} else {
-				switch (s[1]) {
-				case 'e':
-				case 'r':
-				case 'n':
-				case 't':
-				case 'x':
-					break;
-				default:
+				if (is_escapable (s[1])) {
 					e = true;
 					s++;
 					continue;

--- a/libr/util/str_trim.c
+++ b/libr/util/str_trim.c
@@ -139,9 +139,18 @@ R_API void r_str_trim_args(char *str) {
 			if (e) {
 				e = false;
 			} else {
-				e = true;
-				s++;
-				continue;
+				switch (s[1]) {
+				case 'e':
+				case 'r':
+				case 'n':
+				case 't':
+				case 'x':
+					break;
+				default:
+					e = true;
+					s++;
+					continue;
+				}
 			}
 			break;
 		default:

--- a/test/db/cmd/cmd_afn
+++ b/test/db/cmd/cmd_afn
@@ -35,7 +35,7 @@ f@F:functions~483f4,48540
 f@F:*~483f4,48540
 afn mymain @ 0x08048540
 afn @ 0x08048540
-"?e The main flag shouldn't be renamed, it comes from bin:"
+"?e The main flag shouldnt be renamed, it comes from bin:"
 f@F:functions~483f4,48540
 ?e --
 f@F:*~483f4,48540
@@ -59,7 +59,7 @@ EXPECT=<<EOF
 0x08048540 92 main
 0x08048540 92 sym.main
 mymain
-The main flag shouldn't be renamed, it comes from bin:
+The main flag shouldnt be renamed, it comes from bin:
 0x080483f4 33 fcn.080483f4
 0x08048540 92 mymain
 --

--- a/test/db/cmd/cmd_macros
+++ b/test/db/cmd/cmd_macros
@@ -1,3 +1,32 @@
+NAME=escaping colons
+FILE=-
+CMDS=<<EOF
+"(msg;?e hello;?e world)"
+(msg2\;?e hello\;?e world)
+.(msg)
+.(msg2)
+EOF
+EXPECT=<<EOF
+hello
+world
+hello
+world
+EOF
+RUN
+
+NAME=escaping echoes
+FILE=-
+CMDS=<<EOF
+?e hello\@world\|pipe
+?e one\ntwo
+EOF
+EXPECT=<<EOF
+hello@world|pipe
+one
+two
+EOF
+RUN
+
 NAME=(msg x;?e $0)
 FILE=-
 CMDS=<<EOF

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -1305,7 +1305,7 @@ RUN
 
 NAME=pdJ string
 CMDS=<<EOF
-w Snoo"ping as" usual,
+w 'Snoo\"ping as\" usual',
 Cs 30
 pdJ 1
 EOF

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -163,7 +163,7 @@ RUN
 NAME=wp
 FILE=-
 CMDS=<<EOF
-echo 0x10 "hello" > .r2-wp.test
+echo "0x10 \"hello\"" > .r2-wp.test
 echo 0x20 01020304 >> .r2-wp.test
 cat .r2-wp.test
 wp .r2-wp.test

--- a/test/db/cmd/cmd_w
+++ b/test/db/cmd/cmd_w
@@ -163,7 +163,7 @@ RUN
 NAME=wp
 FILE=-
 CMDS=<<EOF
-echo "0x10 \"hello\"" > .r2-wp.test
+echo 0x10 "hello" > .r2-wp.test
 echo 0x20 01020304 >> .r2-wp.test
 cat .r2-wp.test
 wp .r2-wp.test

--- a/test/db/cmd/feat_quote
+++ b/test/db/cmd/feat_quote
@@ -6,6 +6,15 @@ w0 15
 w "\"Hello World\""
 ps
 w0 15
+w "\'Hello World\'"
+ps
+w0 15
+w "'Hello World'"
+ps
+w0 15
+w '"Hello World"'
+ps
+w0 15
 w "Hello;World"
 ps
 w0 15
@@ -14,6 +23,9 @@ ps
 EOF
 EXPECT=<<EOF
 Hello World
+"Hello World"
+'Hello World'
+'Hello World'
 "Hello World"
 Hello;World
 Hello@World
@@ -31,6 +43,9 @@ w0 15
 w '\'Hello World\''
 ps
 w0 15
+w '\'Hello World''
+ps
+w0 15
 w 'Hello;World'
 ps
 w0 15
@@ -41,6 +56,7 @@ EXPECT=<<EOF
 Hello World
 "Hello World"
 'Hello World'
+'Hello World
 Hello;World
 Hello@World
 EOF


### PR DESCRIPTION
```
[0x00000000]> (x\;?e hello\;?e world)
[0x00000000]> .(x)
No macro named 'x'
[0x00000000]> (
0 (x\ ; ?e hello\; ?e world)
[0x00000000]>
```