### PR TITLE
pxi: alias for pDi, hexII's pxi is now pxI ##print

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -521,7 +521,8 @@ static const char *help_msg_px[] = {
 	"pxf", "", "show hexdump of current function",
 	"pxh", "", "show hexadecimal half-words dump (16bit)",
 	"pxH", "", "same as above, but one per line",
-	"pxi", "", "HexII compact binary representation",
+	"pxi", "", "examine instructions (same as pDi)",
+	"pxI", "", "HexII compact binary representation",
 	"pxl", "", "display N lines (rows) of hexdump",
 	"pxo", "", "show octal dump",
 	"pxq", "", "show hexadecimal quad-words dump (64bit)",
@@ -6974,6 +6975,9 @@ static int cmd_print(void *data, const char *input) {
 			}
 			break;
 		case 'i': // "pxi"
+			r_core_cmdf (core, "pDi %s", input + 2);
+			break;
+		case 'I': // "pxI"
 			if (l != 0) {
 				core->print->show_offset = r_config_get_i (core->config, "hex.offset");
 				r_print_hexii (core->print, core->offset, core->block,


### PR DESCRIPTION
* cmd compatibility break
* Useful to disasm with `xi` as in `examine instructions` (as in x/i)
* Takes bytes as argument, because `x` works with bytes not instruction counts

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
