### PR TITLE
Fix #19940 - infinite loop in x/i on invalid instructions ##crash

### DIFF
--- a/test/db/cmd/cmd_disassembly
+++ b/test/db/cmd/cmd_disassembly
@@ -1,3 +1,16 @@
+NAME=infinite x/i disasm bug
+FILE=-
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+x/i 32
+?e works
+EOF
+EXPECT=<<EOF
+works
+EOF
+RUN
+
 NAME=flags subst bug
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
* Also affects pdi and pde

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
