### PR TITLE
Fix oobread and unaligned casts in the NE entrypoint logic ##crash

### DIFF
--- a/libr/bin/format/ne/ne.c
+++ b/libr/bin/format/ne/ne.c
@@ -408,14 +408,21 @@ RList *r_bin_ne_get_entrypoints(r_bin_ne_obj_t *bin) {
 				off += 2;
 				ut8 segnum = *(bin->entry_table + off);
 				off++;
-				ut16 segoff = *(ut16 *)(bin->entry_table + off);
-				if (segnum > 0) {
+				if (off > bin->ne_header->EntryTableLength) {
+					break;
+				}
+				ut16 segoff = r_read_le16 (bin->entry_table + off);
+				if (segnum > 0 && segnum < bin->ne_header->SegCount) {
 					entry->paddr = (ut64)bin->segment_entries[segnum - 1].offset * bin->alignment + segoff;
 				}
 			} else { // Fixed
+				if (off + 2 >= bin->ne_header->EntryTableLength) {
+					break;
+				}
+				ut16 delta = r_read_le16 (bin->entry_table + off);
 				if (bundle_type < bin->ne_header->SegCount) {
 					entry->paddr = (ut64)bin->segment_entries[bundle_type - 1].offset
-						* bin->alignment + *(ut16 *)(bin->entry_table + off);
+						* bin->alignment + delta;
 				}
 			}
 			off += 2;


### PR DESCRIPTION
* Reported by @hmsec via huntr.dev
* Reproducer: nepocaligns
* BountyID: ec538fa4-06c6-4050-a141-f60153ddeaac

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
