### PR TITLE
RBinFile size must be ut64, not signed int to open > 2GB files ##bin

### DIFF
--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -282,7 +282,7 @@ typedef struct r_bin_object_t {
 typedef struct r_bin_file_t {
 	char *file;
 	int fd;
-	int size;
+	ut64 size;
 	int rawstr;
 	int strmode;
 	ut32 id;


### PR DESCRIPTION
* Causes `izz` to fail with invalid negative ranges
* Also affects other commands, but this breaks the ABI
