### PR TITLE
fix loongarch meson script miss

### DIFF
--- a/libr/meson.build
+++ b/libr/meson.build
@@ -109,6 +109,9 @@ if not no_user_plugins
     anal_plugins += [ 'riscv' ]
     parse_plugins += [ 'riscv_pseudo' ]
   endif
+  if user_plugins.contains('loongarch')
+    anal_plugins += [ 'loongarch_gnu' ]
+  endif
   if user_plugins.contains('elf')
     bin_plugins += [ 'elf', 'elf64' ]
   endif
@@ -144,6 +147,7 @@ anal_plugins += [
   'i8080',
   'java',
   'kvx',
+  'loongarch_gnu',
   'm68k_cs',
   'm680x_cs',
   'malbolge',
@@ -247,6 +251,7 @@ if no_user_plugins
       'z80',
       'arm_gnu',
       'mips_gnu',
+      'loongarch_gnu',
       'ppc_gnu',
       'sparc_gnu',
     ]


### PR DESCRIPTION


- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

I found that the meson build of radare2 does not seem to include anal_loongarch_gnu
When I use r2（build with meson） to analyze the loongarch binary I get the following message
```
anal.arch: cannot find (loongarch)
anal.arch: cannot find (loongarch)
asm.arch: cannot find (loongarch)
asm.arch: cannot find (loongarch)
```
I fixed the issue with anal in the patch, but I'm not sure how to fix the issue with asm, because the asm function is included in anal in loongarch, and there is no separate asm module


