### PR TITLE
Add `dxrs` command and test `dx` commands

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -499,21 +499,16 @@ static const char *help_msg_dts[] = {
 
 static const char *help_msg_dx[] = {
 	"Usage: dx", "[aers]", " Debug execution commands",
-	"dx", " <hexpairs>", "Execute opcodes",
-	"dxa", " <asm>", "Assemble code and execute",
-	"dxe", "[?] <egg-expr>", "Compile egg expression and execute it",
-	"dxr", " <hexpairs>", "Execute opcodes and restore state",
-	"dxrs", " <hexpairs>", "Execute opcodes and restore state, excluding the stack",
-	"dxs", " <name> [args]", "Syscall injection (see gs)",
+	"dx", " <hexpairs>", "execute opcodes",
+	"dxa", " <asm>", "assemble code and execute",
+	"dxe", "[?] <egg-expr>", "compile egg expression and execute it",
+	"dxr", " <hexpairs>", "execute opcodes and restore state",
+	"dxrs", " <hexpairs>", "execute opcodes and restore state, excluding the stack",
+	"dxs", " <name> [args]", "syscall injection (see gs)",
 	"\nExamples:", "", "",
-<<<<<<< HEAD
-	"dx", " 9090", "inject two x86 nop",
-	"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "inject and restore state",
-=======
-	"dx", " 9090", "Execute two x86 nops",
-	"\"dxa mov eax,6;mov ebx,0;\"", "", "Assemble and execute",
-	"dxs", " write 1, 0x8048, 12", "Write 12 bytes from 0x8048 into stdout",
->>>>>>> Improve dx help and add dxa test
+	"dx", " 9090", "execute two x86 nops",
+	"\"dxa mov eax,6;mov ebx,0;\"", "", "assemble and execute",
+	"dxs", " write 1, 0x8048, 12", "write 12 bytes from 0x8048 into stdout",
 	NULL
 };
 

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -46,7 +46,7 @@ static const char *help_msg_d[] = {
 	"dW", "", "list process windows",
 	"dWi", "", "identify window under cursor",
 #endif
-	"dx", "[?]", "inject and run code on target process (See gs)",
+	"dx", "[?][aers]", "execute code in the child process",
 	NULL
 };
 
@@ -498,17 +498,22 @@ static const char *help_msg_dts[] = {
 };
 
 static const char *help_msg_dx[] = {
-	"Usage: dx", "", " # Code injection commands",
-	"dx", " <opcode>...", "Inject opcodes",
-	"dxa", " nop", "Assemble code and inject",
-	"dxc", " addr arg1 arg2 arg3", "Compile egg expression and inject it",
-	"dxe", " egg-expr", "Compile egg expression and inject it",
-	"dxr", " <opcode>...", "Inject opcodes and restore state",
-	"dxrs", " <opcode>...", "Inject opcodes and restore state, excluding the stack",
-	"dxs", " write 1, 0x8048, 12", "Syscall injection (see gs)",
+	"Usage: dx", "[aers]", " Debug execution commands",
+	"dx", " <hexpairs>", "Execute opcodes",
+	"dxa", " <asm>", "Assemble code and execute",
+	"dxe", "[?] <egg-expr>", "Compile egg expression and execute it",
+	"dxr", " <hexpairs>", "Execute opcodes and restore state",
+	"dxrs", " <hexpairs>", "Execute opcodes and restore state, excluding the stack",
+	"dxs", " <name> [args]", "Syscall injection (see gs)",
 	"\nExamples:", "", "",
+<<<<<<< HEAD
 	"dx", " 9090", "inject two x86 nop",
 	"\"dxa mov eax,6;mov ebx,0;int 0x80\"", "", "inject and restore state",
+=======
+	"dx", " 9090", "Execute two x86 nops",
+	"\"dxa mov eax,6;mov ebx,0;\"", "", "Assemble and execute",
+	"dxs", " write 1, 0x8048, 12", "Write 12 bytes from 0x8048 into stdout",
+>>>>>>> Improve dx help and add dxa test
 	NULL
 };
 
@@ -5590,6 +5595,10 @@ static int cmd_debug(void *data, const char *input) {
 		}
 		case 'a': { // "dxa"
 			RAsmCode *acode;
+			if (input[2] == '?' || input[2] != ' ') {
+				r_core_cmd_help_match (core, help_msg_dx, "dxa", true);
+				break;
+			}
 			r_asm_set_pc (core->rasm, core->offset);
 			acode = r_asm_massemble (core->rasm, input + 2);
 			if (acode) {
@@ -5600,8 +5609,8 @@ static int cmd_debug(void *data, const char *input) {
 			r_asm_code_free (acode);
 			break;
 		}
-		case 'e':
-			if (input[2] == '?') {
+		case 'e': // "dxe"
+			if (input[2] == '?' || input[2] != ' ') {
 				r_core_cmd_help (core, help_msg_dxe);
 			} else { // "dxe"
 				const char *program = r_str_trim_head_ro (input + 2);

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -835,7 +835,7 @@ static int linux_map_thp(RDebug *dbg, ut64 addr, int size) {
 		r_reg_arena_push (dbg->reg);
 		ut64 tmpsz;
 		const ut8 *tmp = r_buf_data (buf, &tmpsz);
-		ret = r_debug_execute (dbg, tmp, tmpsz, 1) == 0;
+		ret = r_debug_execute (dbg, tmp, tmpsz, true, false) == 0;
 		r_reg_arena_pop (dbg->reg);
 	}
 err_linux_map_thp:
@@ -891,7 +891,7 @@ static RDebugMap* linux_map_alloc(RDebug *dbg, ut64 addr, int size, bool thp) {
 		r_reg_arena_push (dbg->reg);
 		ut64 tmpsz;
 		const ut8 *tmp = r_buf_data (buf, &tmpsz);
-		map_addr = r_debug_execute (dbg, tmp, tmpsz, 1);
+		map_addr = r_debug_execute (dbg, tmp, tmpsz, true, false);
 		r_reg_arena_pop (dbg->reg);
 		if (map_addr != (ut64)-1) {
 			if (thp) {
@@ -940,7 +940,7 @@ static int linux_map_dealloc(RDebug *dbg, ut64 addr, int size) {
 		r_reg_arena_push (dbg->reg);
 		ut64 tmpsz;
 		const ut8 *tmp = r_buf_data (buf, &tmpsz);
-		ret = r_debug_execute (dbg, tmp, tmpsz, 1) == 0;
+		ret = r_debug_execute (dbg, tmp, tmpsz, true, false) == 0;
 		r_reg_arena_pop (dbg->reg);
 	}
 err_linux_map_dealloc:
@@ -1556,7 +1556,7 @@ static int r_debug_native_map_protect(RDebug *dbg, ut64 addr, int size, int perm
 		r_reg_arena_push (dbg->reg);
 		ut64 tmpsz;
 		const ut8 *tmp = r_buf_data (buf, &tmpsz);
-		r_debug_execute (dbg, tmp, tmpsz, 1);
+		r_debug_execute (dbg, tmp, tmpsz, true, false);
 		r_reg_arena_pop (dbg->reg);
 		return true;
 	}

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -526,7 +526,7 @@ R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num);
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name);
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, int *err, utX *value);
 
-R_API ut64 r_debug_execute(RDebug *dbg, const ut8 *buf, int len, int restore);
+R_API ut64 r_debug_execute(RDebug *dbg, const ut8 *buf, int len, bool restore, bool ignore_stack);
 R_API bool r_debug_map_sync(RDebug *dbg);
 
 R_API int r_debug_stop(RDebug *dbg);

--- a/test/db/archos/linux-x64/cmd_dx
+++ b/test/db/archos/linux-x64/cmd_dx
@@ -1,0 +1,206 @@
+NAME=dx always restores bytes at pc
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+p8 8 @rip
+dx 9090909090909090
+?e ---
+p8 8 @rip
+doc
+EOF
+EXPECT=<<EOF
+4889e7e8e80c0000
+---
+4889e7e8e80c0000
+EOF
+RUN
+
+NAME=dx rflags is broken
+BROKEN=1
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~rflags
+dx 48c7c000010000 # mov rax, 0x100
+?e ---
+dr~rflags
+doc
+EOF
+EXPECT=<<EOF
+rflags = 0x00000200
+---
+rflags = 0x00000200
+EOF
+RUN
+
+# FIXME: remove the rflags exclusion once it is fixed
+NAME=dx may clobber registers and stack
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~!rip~!rsp~!rflags
+dx 48c7c000010000 # mov rax, 0x100
+?e ---
+dr~!rip~!rsp~!rflags
+?e ---
+wv4 0 @rsp
+pv4 @rsp
+?e ---
+dx 48c7042444332211 # mov [rsp], 0x11223344
+pv4 @rsp
+doc
+EOF
+EXPECT=<<EOF
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+rax = 0x00000100
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0xffffffffffffffff
+---
+0x00000000
+---
+0x11223344
+EOF
+RUN
+
+NAME=dxr restores registers and stack
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~!rip~!rsp~!rflags
+?e ---
+dxr 48c7c000010000 # mov rax, 0x100
+dr~!rip~!rsp~!rflags
+?e ---
+wv4 0 @rsp
+pv4 @rsp
+?e ---
+dxr 48c7042444332211 # mov [rsp], 0x11223344
+pv4 @rsp
+doc
+EOF
+EXPECT=<<EOF
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+0x00000000
+---
+0x00000000
+EOF
+RUN
+
+NAME=dxrs restores only registers
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~!rip~!rsp~!rflags
+?e ---
+dxrs 48c7c000010000 # mov rax, 0x100
+dr~!rip~!rsp~!rflags
+?e ---
+wv4 0 @rsp
+pv4 @rsp
+?e ---
+dxrs 48c7042444332211 # mov [rsp], 0x11223344
+pv4 @rsp
+doc
+EOF
+EXPECT=<<EOF
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+0x00000000
+---
+0x11223344
+EOF
+RUN

--- a/test/db/archos/linux-x64/cmd_dx
+++ b/test/db/archos/linux-x64/cmd_dx
@@ -15,6 +15,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
+# FIXME: remove ~!rflags from other tests
 NAME=dx rflags is broken
 BROKEN=1
 FILE=bins/elf/ls-focal
@@ -202,5 +203,72 @@ orax = 0x0000003b
 0x00000000
 ---
 0x11223344
+EOF
+RUN
+
+NAME=dxa
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~!rip~!rsp~!rflags
+?e ---
+dxa mov rax, 0x100
+dr~!rip~!rsp~!rflags
+?e ---
+"dxa mov rbx, 0x200; mov rcx, 0x300"
+dr~!rip~!rsp~!rflags
+doc
+EOF
+EXPECT=<<EOF
+rax = 0x00000000
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0x0000003b
+---
+rax = 0x00000100
+rbx = 0x00000000
+rcx = 0x00000000
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0xffffffffffffffff
+---
+rax = 0x00000100
+rbx = 0x00000200
+rcx = 0x00000300
+rdx = 0x00000000
+r8 = 0x00000000
+r9 = 0x00000000
+r10 = 0x00000000
+r11 = 0x00000000
+r12 = 0x00000000
+r13 = 0x00000000
+r14 = 0x00000000
+r15 = 0x00000000
+rsi = 0x00000000
+rdi = 0x00000000
+rbp = 0x00000000
+orax = 0xffffffffffffffff
 EOF
 RUN

--- a/test/db/archos/linux-x64/cmd_dx
+++ b/test/db/archos/linux-x64/cmd_dx
@@ -1,3 +1,22 @@
+# FIXME: remove ~!rflags from other tests and remove this
+NAME=dxr should restore rflags
+BROKEN=1
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+dr~rflags
+dxr 48c7c000010000 # mov rax, 0x100
+?e ---
+dr~rflags
+doc
+EOF
+EXPECT=<<EOF
+rflags = 0x00000200
+---
+rflags = 0x00000200
+EOF
+RUN
+
 NAME=dx always restores bytes at pc
 FILE=bins/elf/ls-focal
 ARGS=-d
@@ -15,26 +34,6 @@ EXPECT=<<EOF
 EOF
 RUN
 
-# FIXME: remove ~!rflags from other tests
-NAME=dx rflags is broken
-BROKEN=1
-FILE=bins/elf/ls-focal
-ARGS=-d
-CMDS=<<EOF
-dr~rflags
-dx 48c7c000010000 # mov rax, 0x100
-?e ---
-dr~rflags
-doc
-EOF
-EXPECT=<<EOF
-rflags = 0x00000200
----
-rflags = 0x00000200
-EOF
-RUN
-
-# FIXME: remove the rflags exclusion once it is fixed
 NAME=dx may clobber registers and stack
 FILE=bins/elf/ls-focal
 ARGS=-d
@@ -146,6 +145,23 @@ orax = 0x0000003b
 0x00000000
 ---
 0x00000000
+EOF
+RUN
+
+NAME=dxr should not advance seek
+BROKEN=1
+FILE=bins/elf/ls-focal
+ARGS=-d
+CMDS=<<EOF
+s > $seek1
+dxr 90909090
+s > $seek2
+cmp $seek1 $seek2
+?! seek did not move
+doc
+EOF
+EXPECT=<<EOF
+seek did not move
 EOF
 RUN
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)

**Description**

* Break API compat for `r_debug_execute()` by adding an additional argument to ignore stack restoration.
* Add `dxrs` command to restore program state excluding the stack (only registers and overwritten instructions at PC)
* Test `dx` commands and document existing bugs. `dxe` is still untested because I could not get it to compile anything.

These changes are required for the dd refactor.