### PR TITLE
Improve `wz` help and error handling

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1424,8 +1424,7 @@ static int w_handler(RCore *core, const char *input) {
 	return 0;
 }
 
-static int wz_handler_old(void *data, const char *input) {
-	RCore *core = (RCore *)data;
+static int wz_handler(RCore *core, const char *input) {
 	int wseek = r_config_get_i (core->config, "cfg.wseek");
 	char *str = r_str_trim_dup (input);
 	int len = r_str_unescape (str) + 1;
@@ -1440,11 +1439,7 @@ static int wz_handler_old(void *data, const char *input) {
 	if (!r_core_write_at (core, core->offset, (const ut8 *)str, len)) {
 		cmd_write_fail (core);
 	}
-	if (len > 0) {
-		r_core_return_code (core, len);
-	} else {
-		r_core_return_code (core, 0);
-	}
+	r_core_return_code (core, len);
 	WSEEK (core, len + 1);
 	r_core_block_read (core);
 	free (str);
@@ -2176,7 +2171,7 @@ static int cmd_write(void *data, const char *input) {
 		break;
 	}
 	case 'z': // "wz"
-		wz_handler_old (core, input + 1);
+		wz_handler (core, input + 1);
 		break;
 	case 't': // "wt"
 		wt_handler_old (core, input + 1);

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1426,7 +1426,7 @@ static int w_handler(RCore *core, const char *input) {
 
 static int wz_handler(RCore *core, const char *input) {
 	int wseek = r_config_get_i (core->config, "cfg.wseek");
-	char *str = r_str_trim_dup (input);
+	char *str = strdup (input + 1);
 	int len = r_str_unescape (str) + 1;
 
 	/* write zero-terminated string */

--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1427,10 +1427,17 @@ static int w_handler(RCore *core, const char *input) {
 static int wz_handler_old(void *data, const char *input) {
 	RCore *core = (RCore *)data;
 	int wseek = r_config_get_i (core->config, "cfg.wseek");
-	char *str = strdup (input);
+	char *str = r_str_trim_dup (input);
+	int len = r_str_unescape (str) + 1;
+
 	/* write zero-terminated string */
-	int len = r_str_unescape (str);
-	if (!r_core_write_at (core, core->offset, (const ut8 *)str + 1, len)) {
+	if (*input == '?' || *input != ' ' || len < 1) {
+		free (str);
+		r_core_cmd_help_match (core, help_msg_w, "wz", true);
+		r_core_return_code (core, 0);
+		return 0;
+	}
+	if (!r_core_write_at (core, core->offset, (const ut8 *)str, len)) {
 		cmd_write_fail (core);
 	}
 	if (len > 0) {


### PR DESCRIPTION
Fixes #19891.

```
$ r2 -
[0x00000000]> o
 3 * rwx 0x00000200 malloc://512
[0x00000000]> wz
| wz string  write zero terminated string (like w + \x00)
[0x00000000]> wz1A
| wz string  write zero terminated string (like w + \x00)
[0x00000000]> wz?
| wz string  write zero terminated string (like w + \x00)
```