### PR TITLE
Fix `aeabj` output which returned different information than `aeab` ##json

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7572,7 +7572,7 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 			if (bb) {
 				switch (input[2]) {
 				case 'j': // "aeabj"
-					cmd_aea (core, 1 + (1<<4), bb->addr, bb->size);
+					cmd_aea (core, 1 | (1<<4), bb->addr, bb->size);
 					break;
 				default:
 					cmd_aea (core, 1, bb->addr, bb->size);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7572,7 +7572,7 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 			if (bb) {
 				switch (input[2]) {
 				case 'j': // "aeabj"
-					cmd_aea (core, 1<<4, bb->addr, bb->size);
+					cmd_aea (core, 1 + (1<<4), bb->addr, bb->size);
 					break;
 				default:
 					cmd_aea (core, 1, bb->addr, bb->size);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
