### PR TITLE
Fix oobread bug in NE parser ##crash

### DIFF
--- a/libr/bin/format/mach0/coresymbolication.c
+++ b/libr/bin/format/mach0/coresymbolication.c
@@ -274,12 +274,12 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 				sect->vaddr += page_zero_size;
 			}
 			cursor += word_size;
-			if (cursor >= end) {
+			if (cursor + word_size >= end) {
 				break;
 			}
 			sect->size = r_read_ble (cursor, false, bits);
 			cursor += word_size;
-			if (cursor >= end) {
+			if (cursor + word_size >= end) {
 				break;
 			}
 			ut64 sect_name_off = r_read_ble (cursor, false, bits);
@@ -291,7 +291,11 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 				cursor += word_size;
 			}
 			string_origin = relative_to_strings? b + start_of_strings : sect_start;
-			sect->name = str_dup_safe (b, string_origin + (size_t)sect_name_off, end);
+			if (sect_name_off < end) {
+				sect->name = str_dup_safe (b, string_origin + sect_name_off, end);
+			} else {
+				sect->name = strdup ("");
+			}
 		}
 	}
 	if (hdr->n_symbols) {

--- a/libr/bin/format/mach0/coresymbolication.c
+++ b/libr/bin/format/mach0/coresymbolication.c
@@ -291,7 +291,7 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 				cursor += word_size;
 			}
 			string_origin = relative_to_strings? b + start_of_strings : sect_start;
-			if (sect_name_off < end) {
+			if (sect_name_off < (ut64)(size_t)(end - string_origin)) {
 				sect->name = str_dup_safe (b, string_origin + sect_name_off, end);
 			} else {
 				sect->name = strdup ("");


### PR DESCRIPTION
* Reported by @cnitlrt via huntrdev
* BountyID: 02b4b563-b946-4343-9092-38d1c5cd60c9
* Reproducer: neoobread

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
