### PR TITLE
Fix #19966 - Reset seek in r_debug_execute() to real PC

### DIFF
--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -5748,7 +5748,9 @@ static int cmd_debug(void *data, const char *input) {
 			if (strlen (hexpairs) < 8192) {
 				int bytes_len = r_hex_str2bin (hexpairs, bytes);
 				if (bytes_len > 0) {
-					r_debug_execute (core->dbg, bytes, bytes_len, is_dxr, is_dxrs);
+					if (!r_debug_execute (core->dbg, bytes, bytes_len, NULL, is_dxr, is_dxrs)) {
+						eprintf ("Failed to execute code.\n");
+					}
 				} else {
 					eprintf ("Failed to parse hex pairs.\n");
 				}
@@ -5767,7 +5769,9 @@ static int cmd_debug(void *data, const char *input) {
 			acode = r_asm_massemble (core->rasm, input + 2);
 			if (acode) {
 				r_reg_arena_push (core->dbg->reg);
-				r_debug_execute (core->dbg, acode->bytes, acode->len, false, false);
+				if (!r_debug_execute (core->dbg, acode->bytes, acode->len, NULL, false, false)) {
+					eprintf ("Failed to inject code.\n");
+				}
 				r_reg_arena_pop (core->dbg->reg);
 			}
 			r_asm_code_free (acode);
@@ -5794,7 +5798,9 @@ static int cmd_debug(void *data, const char *input) {
 				ut64 tmpsz;
 				const ut8 *tmp = r_buf_data (b, &tmpsz);
 				if (tmpsz > 0) {
-					r_debug_execute (core->dbg, tmp, tmpsz, false, false);
+					if (!r_debug_execute (core->dbg, tmp, tmpsz, NULL, false, false)) {
+						eprintf ("Failed to inject code.\n");
+					}
 				} else {
 					eprintf ("No egg program compiled to execute.\n");
 				}

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -515,9 +515,10 @@ R_API bool r_debug_set_arch(RDebug *dbg, const char *arch, int bits) {
  * The bytes overwritten at the program counter are always restored.
  *
  * TODO: Add support for reverse stack architectures
+ *
+ * XXX: This function will advance your seek to the end of the injected code.
  */
 R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret, bool restore, bool ignore_stack) {
-	RCore *core;
 	ut8 stack_backup[4096];
 	ut8 *pc_backup = NULL, *reg_backup = NULL;
 	int reg_backup_sz;
@@ -525,7 +526,6 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 	ut64 reg_sp, reg_pc, bp_addr;
 
 	r_return_val_if_fail (dbg && buf && len > 0, false);
-	core = dbg->corebind.core;
 
 	if (r_debug_is_dead (dbg)) {
 		return false;
@@ -602,11 +602,6 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 
 	free (pc_backup);
 	free (reg_backup);
-
-	/* Rewind seek from breakpoint address to real PC */
-	if (core) {
-		core->offset = reg_pc;
-	}
 
 	return true;
 }

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -553,9 +553,7 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 	}
 
 	reg_pc = r_reg_get_value (dbg->reg, ri_pc);
-	if (restore && !ignore_stack) {
-		reg_sp = r_reg_get_value (dbg->reg, ri_sp);
-	}
+	reg_sp = r_reg_get_value (dbg->reg, ri_sp);
 
 	pc_backup = malloc (len);
 	if (!pc_backup) {

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -567,7 +567,7 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 	dbg->iob.read_at (dbg->iob.io, reg_pc, pc_backup, len);
 	if (restore && !ignore_stack) {
 		/* Store bytes at stack */
-		dbg->iob.read_at (dbg->iob.io, reg_sp, stack_backup, len);
+		dbg->iob.read_at (dbg->iob.io, reg_sp, stack_backup, 4096);
 	}
 
 	bp_addr = reg_pc + len;
@@ -592,7 +592,7 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 	if (restore) {
 		if (!ignore_stack) {
 			/* Restore stack */
-			dbg->iob.write_at (dbg->iob.io, reg_sp, stack_backup, len);
+			dbg->iob.write_at (dbg->iob.io, reg_sp, stack_backup, 4096);
 		}
 		/* Restore registers */
 		r_reg_read_regs (dbg->reg, reg_backup, reg_backup_sz);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -605,7 +605,7 @@ R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret
 
 	/* Rewind seek from breakpoint address to real PC */
 	if (core) {
-		r_core_seek (core, reg_pc, true);
+		core->offset = reg_pc;
 	}
 
 	return true;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -526,7 +526,7 @@ R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num);
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name);
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, int *err, utX *value);
 
-R_API ut64 r_debug_execute(RDebug *dbg, const ut8 *buf, int len, bool restore, bool ignore_stack);
+R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, bool restore, bool ignore_stack);
 R_API bool r_debug_map_sync(RDebug *dbg);
 
 R_API int r_debug_stop(RDebug *dbg);

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -526,7 +526,7 @@ R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num);
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name);
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, int *err, utX *value);
 
-R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, bool restore, bool ignore_stack);
+R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret, bool restore, bool ignore_stack);
 R_API bool r_debug_map_sync(RDebug *dbg);
 
 R_API int r_debug_stop(RDebug *dbg);

--- a/test/db/archos/linux-x64/cmd_dx
+++ b/test/db/archos/linux-x64/cmd_dx
@@ -148,20 +148,18 @@ orax = 0x0000003b
 EOF
 RUN
 
-NAME=dxr should not advance seek
-BROKEN=1
+NAME=dx should not advance seek
 FILE=bins/elf/ls-focal
 ARGS=-d
 CMDS=<<EOF
 s > $seek1
-dxr 90909090
+dx 9090909090
 s > $seek2
-cmp $seek1 $seek2
-?! seek did not move
+dif $seek1 $seek2
 doc
 EOF
 EXPECT=<<EOF
-seek did not move
+
 EOF
 RUN
 


### PR DESCRIPTION
Fix #19966

Other bugfixes and API changes:

* `r_debug_execute()` returns bool instead of ut64 to report if code was successfully run
  * Return value is now an output arg
* Fix return value coming from register A0 (arg) instead of R0 (ret)
* Fix stack restoration - always restore the full 4k