### PR TITLE
Fix oobread and null deref in symbols file parser ##crash

### DIFF
--- a/libr/bin/format/mach0/coresymbolication.c
+++ b/libr/bin/format/mach0/coresymbolication.c
@@ -269,6 +269,9 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 		for (i = 0; i < hdr->n_sections && cursor < end; i++) {
 			ut8 *sect_start = cursor;
 			RCoreSymCacheElementSection *sect = &result->sections[i];
+			if (cursor + (word_size * 4) > end) {
+				goto beach;
+			}
 			sect->vaddr = sect->paddr = r_read_ble (cursor, false, bits);
 			if (sect->vaddr < page_zero_size) {
 				sect->vaddr += page_zero_size;
@@ -359,6 +362,10 @@ RCoreSymCacheElement *r_coresym_cache_element_new(RBinFile *bf, RBuffer *buf, ut
 				continue;
 			}
 			string_origin = relative_to_strings? b + start_of_strings : cursor;
+			if (!string_origin) {
+				cursor += R_CS_EL_SIZE_LSYM;
+				continue;
+			}
 			lsym->flc.file = str_dup_safe (b, string_origin + file_name_off, end);
 			if (!lsym->flc.file) {
 				cursor += R_CS_EL_SIZE_LSYM;

--- a/libr/bin/p/bin_symbols.c
+++ b/libr/bin/p/bin_symbols.c
@@ -353,28 +353,30 @@ static bool check_buffer(RBinFile *bf, RBuffer *b) {
 }
 
 static RList *symbols(RBinFile *bf) {
-	RList *res = r_list_newf ((RListFree)r_bin_symbol_free);
-	r_return_val_if_fail (res && bf->o && bf->o->bin_obj, res);
+	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
 	RCoreSymCacheElement *element = bf->o->bin_obj;
 	size_t i;
 	HtUU *hash = ht_uu_new0 ();
 	if (!hash) {
-		return res;
+		return NULL;
 	}
+	RList *res = r_list_newf ((RListFree)r_bin_symbol_free);
 	bool found = false;
-	for (i = 0; i < element->hdr->n_lined_symbols; i++) {
-		RCoreSymCacheElementSymbol *sym = (RCoreSymCacheElementSymbol *)&element->lined_symbols[i];
-		if (!sym) {
-			break;
-		}
-		ht_uu_find (hash, sym->paddr, &found);
-		if (found) {
-			continue;
-		}
-		RBinSymbol *s = bin_symbol_from_symbol (element, sym);
-		if (s) {
-			r_list_append (res, s);
-			ht_uu_insert (hash, sym->paddr, 1);
+	if (element->lined_symbols) {
+		for (i = 0; i < element->hdr->n_lined_symbols; i++) {
+			RCoreSymCacheElementSymbol *sym = (RCoreSymCacheElementSymbol *)&element->lined_symbols[i];
+			if (!sym) {
+				break;
+			}
+			ht_uu_find (hash, sym->paddr, &found);
+			if (found) {
+				continue;
+			}
+			RBinSymbol *s = bin_symbol_from_symbol (element, sym);
+			if (s) {
+				r_list_append (res, s);
+				ht_uu_insert (hash, sym->paddr, 1);
+			}
 		}
 	}
 	if (element->symbols) {


### PR DESCRIPTION
* Reported by @cnitlrt
* BountyID: af6c3e9e-b7df-4d80-b48f-77fdd17b4038/
* Reproducer: symoob

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
