### PR TITLE
Fix -Warray-parameter & -Wmisleading-indentation warnings

### DIFF
--- a/libr/asm/arch/arc/gnu/arcompact-dis.c
+++ b/libr/asm/arch/arc/gnu/arcompact-dis.c
@@ -89,7 +89,7 @@ static bfd_vma bfd_getm32_ac(unsigned int) ATTRIBUTE_UNUSED;
 /*
  * FIELDS is the 12-bit signed immediate value
  */
-#define FIELDS(word)      ((BITS(((signed int)(word)),0,5) << 6) | (BITS((word),6,11)))					\
+#define FIELDS(word)      ((BITS(((signed int)(word)),0,5) << 6) | (BITS((word),6,11)))
 
 /*
  * FIELD S9 is the 9-bit signed immediate value used for
@@ -99,15 +99,15 @@ static bfd_vma bfd_getm32_ac(unsigned int) ATTRIBUTE_UNUSED;
 #define FIELDS9_FLAG(word)     (((BITS(((signed int)(word)),0,5) << 6) | (BITS((word),6,11))) )
 
 #define PUT_NEXT_WORD_IN(a) {		\
-	if (is_limm==1 && !NEXT_WORD(1))       	\
+	if (is_limm == 1 && !NEXT_WORD(1))       	\
 	  mwerror(state, "Illegal limm reference in last instruction!\n"); \
-          if (info->endian == BFD_ENDIAN_LITTLE) { \
-            (a) = ((state->words[1] & 0xff00) | (state->words[1] & 0xff)) << 16; \
-            (a) |= ((state->words[1] & 0xff0000) | (state->words[1] & 0xff000000)) >> 16;	\
-          } \
-          else { \
-            (a) = state->words[1]; \
-          } \
+	if (info->endian == BFD_ENDIAN_LITTLE) { \
+		(a) = ((state->words[1] & 0xff00) | (state->words[1] & 0xff)) << 16; \
+		(a) |= ((state->words[1] & 0xff0000) | (state->words[1] & 0xff000000)) >> 16;	\
+	} \
+	else { \
+		(a) = state->words[1]; \
+	} \
 	}
 
 #define CHECK_NULLIFY() do{		\

--- a/libr/hash/sha2.c
+++ b/libr/hash/sha2.c
@@ -510,7 +510,7 @@ void r_SHA256_Update(R_SHA256_CTX *context, const ut8 *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-void r_SHA256_Final(ut8 *digest, R_SHA256_CTX *context) {
+void r_SHA256_Final(ut8 digest[r_SHA256_DIGEST_LENGTH], R_SHA256_CTX *context) {
 	ut32 *d = (ut32 *) digest;
 	unsigned int usedspace;
 
@@ -582,7 +582,7 @@ void r_SHA256_Final(ut8 *digest, R_SHA256_CTX *context) {
 	usedspace = 0;
 }
 
-char *r_SHA256_End(R_SHA256_CTX *context, char buffer[]) {
+char *r_SHA256_End(R_SHA256_CTX *context, char buffer[r_SHA256_DIGEST_STRING_LENGTH]) {
 	ut8 digest[r_SHA256_DIGEST_LENGTH], *d = digest;
 	int i;
 
@@ -893,7 +893,7 @@ static void SHA512_Last(R_SHA512_CTX *context) {
 	SHA512_Transform (context, (ut64 *) context->buffer);
 }
 
-void r_SHA512_Final(ut8 digest[], R_SHA512_CTX *context) {
+void r_SHA512_Final(ut8 digest[r_SHA512_DIGEST_LENGTH], R_SHA512_CTX *context) {
 	ut64 *d = (ut64 *) digest;
 
 	/* Sanity check: */
@@ -924,7 +924,7 @@ void r_SHA512_Final(ut8 digest[], R_SHA512_CTX *context) {
 	r_mem_memzero (context, sizeof(*context));
 }
 
-char *r_SHA512_End(R_SHA512_CTX *context, char buffer[]) {
+char *r_SHA512_End(R_SHA512_CTX *context, char buffer[r_SHA512_DIGEST_STRING_LENGTH]) {
 	ut8 digest[r_SHA512_DIGEST_LENGTH], *d = digest;
 	int i;
 
@@ -971,7 +971,7 @@ void r_SHA384_Update(R_SHA384_CTX *context, const ut8 *data, size_t len) {
 	r_SHA512_Update ((R_SHA512_CTX *) context, data, len);
 }
 
-void r_SHA384_Final(ut8 digest[], R_SHA384_CTX *context) {
+void r_SHA384_Final(ut8 digest[r_SHA384_DIGEST_LENGTH], R_SHA384_CTX *context) {
 	ut64 *d = (ut64 *) digest;
 
 	/* Sanity check: */
@@ -1002,7 +1002,7 @@ void r_SHA384_Final(ut8 digest[], R_SHA384_CTX *context) {
 	memset (context, 0, sizeof(*context));
 }
 
-char *r_SHA384_End(R_SHA384_CTX *context, char buffer[]) {
+char *r_SHA384_End(R_SHA384_CTX *context, char buffer[r_SHA384_DIGEST_STRING_LENGTH]) {
 	ut8 digest[r_SHA384_DIGEST_LENGTH], *d = digest;
 	int i;
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Fix several compilation warnings
```
sha2.c:513:26: warning: argument 1 of type 'uint8_t *' {aka 'unsigned char *'} declared as a pointer [-Warray-parameter=]
sha2.c:585:48: warning: argument 2 of type 'char[]' with mismatched bound [-Warray-parameter=]
sha2.c:896:25: warning: argument 1 of type 'uint8_t *' {aka 'unsigned char *'} with mismatched bound [-Warray-parameter=]
sha2.c:927:48: warning: argument 2 of type 'char[]' with mismatched bound [-Warray-parameter=]
sha2.c:974:25: warning: argument 1 of type 'uint8_t *' {aka 'unsigned char *'} with mismatched bound [-Warray-parameter=]
sha2.c:1005:48: warning: argument 2 of type 'char[]' with mismatched bound [-Warray-parameter=]
...
p/../arch/arc/gnu/arcompact-dis.c:102:9: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
...
```