### PR TITLE
Improve /ca speed and add JSON output for crypto functions

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -3714,11 +3714,13 @@ reread:
 		case 'd': // "/cd"
 			{
 				RSearchKeyword *kw;
+				if (input[2] == 'j') {
+					param.outmode = R_MODE_JSON;
+				}
 				kw = r_search_keyword_new_hex ("308200003082", "ffff0000ffff", NULL);
 				r_search_reset (core->search, R_SEARCH_KEYWORD);
 				if (kw) {
 					r_search_kw_add (core->search, kw);
-					// eprintf ("Searching %d byte(s)...\n", kw->keyword_length);
 					r_search_begin (core->search);
 				} else {
 					eprintf ("bad pointer\n");
@@ -3729,6 +3731,9 @@ reread:
 		case 'g': // "/cg"
 			{
 				RSearchKeyword *kw;
+				if (input[2] == 'j') {
+					param.outmode = R_MODE_JSON;
+				}
 				r_search_reset (core->search, R_SEARCH_KEYWORD);
 				// PGP ASCII Armor according to https://datatracker.ietf.org/doc/html/rfc4880
 				kw = r_search_keyword_new_str ("BEGIN PGP PRIVATE KEY", NULL, NULL, false);
@@ -3775,6 +3780,9 @@ reread:
 		case 'a': // "/ca"
 			{
 				RSearchKeyword *kw;
+				if (input[2] == 'j') {
+					param.outmode = R_MODE_JSON;
+				}
 				kw = r_search_keyword_new_hexmask ("00", NULL);
 				// AES search is done over 40 bytes
 				kw->keyword_length = AES_SEARCH_LENGTH;
@@ -3787,6 +3795,9 @@ reread:
 		case 'r': // "/cr"
 			{
 				RSearchKeyword *kw;
+				if (input[2] == 'j') {
+					param.outmode = R_MODE_JSON;
+				}
 				kw = r_search_keyword_new_hexmask ("00", NULL);
 				// Private key search is at least 11 bytes
 				kw->keyword_length = PRIVATE_KEY_SEARCH_LENGTH;

--- a/libr/search/aes_find.c
+++ b/libr/search/aes_find.c
@@ -20,39 +20,36 @@
 #define AES256_KEY_LENGTH 32
 
 static bool aes256_key_test(const unsigned char *buf) {
-	bool word1 = buf[32] == (buf[0] ^ Sbox[buf[29]] ^ 1) \
+	return( buf[32] == (buf[0] ^ Sbox[buf[29]] ^ 1) \
 		&& buf[33] == (buf[1] ^ Sbox[buf[30]]) \
 		&& buf[34] == (buf[2] ^ Sbox[buf[31]]) \
-		&& buf[35] == (buf[3] ^ Sbox[buf[28]]);
-	bool word2 = (buf[36] == (buf[4] ^ buf[32]) \
+		&& buf[35] == (buf[3] ^ Sbox[buf[28]])
+		&& buf[36] == (buf[4] ^ buf[32]) \
 		&& buf[37] == (buf[5] ^ buf[33]) \
 		&& buf[38] == (buf[6] ^ buf[34]) \
 		&& buf[39] == (buf[7] ^ buf[35]));
-	return word1 && word2;
 }
 
 static bool aes192_key_test(const unsigned char *buf) {
-	bool word1 = buf[24] == (buf[0] ^ Sbox[buf[21]] ^ 1) \
+	return( buf[24] == (buf[0] ^ Sbox[buf[21]] ^ 1) \
 		&& buf[25] == (buf[1] ^ Sbox[buf[22]]) \
 		&& buf[26] == (buf[2] ^ Sbox[buf[23]]) \
-		&& buf[27] == (buf[3] ^ Sbox[buf[20]]);
-	bool word2 = buf[28] == (buf[4] ^ buf[24]) \
+		&& buf[27] == (buf[3] ^ Sbox[buf[20]]) \
+		&& buf[28] == (buf[4] ^ buf[24]) \
 		&& buf[29] == (buf[5] ^ buf[25]) \
 		&& buf[30] == (buf[6] ^ buf[26]) \
-		&& buf[31] == (buf[7] ^ buf[27]);
-	return word1 && word2;
+		&& buf[31] == (buf[7] ^ buf[27]));
 }
 
 static bool aes128_key_test(const unsigned char *buf) {
-	bool word1 = buf[16] == (buf[0] ^ Sbox[buf[13]] ^ 1) \
+	return( buf[16] == (buf[0] ^ Sbox[buf[13]] ^ 1) \
 		&& buf[17] == (buf[1] ^ Sbox[buf[14]]) \
 		&& buf[18] == (buf[2] ^ Sbox[buf[15]]) \
-		&& buf[19] == (buf[3] ^ Sbox[buf[12]]);
-	bool word2 = buf[20] == (buf[4] ^ buf[16]) \
+		&& buf[19] == (buf[3] ^ Sbox[buf[12]]) \
+		&& buf[20] == (buf[4] ^ buf[16]) \
 		&& buf[21] == (buf[5] ^ buf[17]) \
 		&& buf[22] == (buf[6] ^ buf[18]) \
-		&& buf[23] == (buf[7] ^ buf[19]);
-	return word1 && word2;
+		&& buf[23] == (buf[7] ^ buf[19]));
 }
 
 R_IPI int search_aes_update(RSearch *s, ut64 from, const ut8 *buf, int len) {

--- a/test/db/cmd/cmd_search_crypto
+++ b/test/db/cmd/cmd_search_crypto
@@ -14,6 +14,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=cmd.hit for /caj
+FILE=bins/other/aes_192.dump
+CMDS=/caj
+EXPECT=<<EOF
+[{"offset":250,"type":"hexpair","data":"000102030405060708090a0b0c0d0e0f1011121314151617"}]
+EOF
+RUN
+
 NAME=cmd.hit for /cd
 FILE=bins/other/certificate.ber
 CMDS=/cd


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- `/ca` is about twice faster by returning false value earlier. 
- JSON output is now supported for crypto functions: `/caj`,`/cdj`, ...

Before:

```bash
[0x00000000]> ?t /ca
Searching 40 bytes in [0x0-0x3d090000]
hits: 0
19.477705
```
After:
```bash
[0x00000000]> ?t /ca
Searching 40 bytes in [0x0-0x3d090000]
hits: 0
11.955273
```

