### PR TITLE
Increase project name max length ##projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -13,7 +13,7 @@
 // project apis to be used from cmd_project.c
 
 static bool is_valid_project_name(const char *name) {
-	if (r_str_len_utf8 (name) >= 16) {
+	if (r_str_len_utf8 (name) >= 64) {
 		return false;
 	}
 	const char *extention = r_str_endswith (name, ".zip") ? r_str_last (name, ".zip") : NULL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
If there is no reason not to I'd like to increase the maximum length of a project name. It's particularly annoying as of know when working with files which must respect a certain naming convention. I have some scripts where I automate the analysis and creation of the project and I'd like for the project to have the same name as the file.
