### PR TITLE
Fix capstone include directory

### DIFF
--- a/libr/anal/p/anal_6502_cs.c
+++ b/libr/anal/p/anal_6502_cs.c
@@ -5,7 +5,7 @@
 #include <r_lib.h>
 #include <r_asm.h>
 #include <r_anal.h>
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #if CS_API_MAJOR >= 5 || (CS_API_MAJOR >= 4 && CS_API_MINOR >= 1)
 #define CAPSTONE_HAS_MOS65XX 1
@@ -14,7 +14,7 @@
 #endif
 
 #if CAPSTONE_HAS_MOS65XX
-#include <mos65xx.h>
+#include <capstone/mos65xx.h>
 
 static csh handle = 0;
 

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -3,9 +3,8 @@
 #include <r_anal.h>
 #include <r_lib.h>
 #include <ht_uu.h>
-#include <arm.h>
-#include <capstone.h>
-#include <arm.h>
+#include <capstone/capstone.h>
+#include <capstone/arm.h>
 #include <r_util/r_assert.h>
 #include "./anal_arm_hacks.inc"
 

--- a/libr/anal/p/anal_evm_cs.c
+++ b/libr/anal/p/anal_evm_cs.c
@@ -3,9 +3,9 @@
 #include <r_asm.h>
 #include <r_lib.h>
 
-#include <capstone.h>
+#include <capstone/capstone.h>
 #if CS_API_MAJOR >= 5
-#include <evm.h>
+#include <capstone/evm.h>
 
 static void set_opdir(RAnalOp *op) {
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {

--- a/libr/anal/p/anal_m680x_cs.c
+++ b/libr/anal/p/anal_m680x_cs.c
@@ -2,7 +2,7 @@
 
 #include <r_asm.h>
 #include <r_lib.h>
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #if CS_API_MAJOR >= 4 && CS_API_MINOR >= 0
 #define CAPSTONE_HAS_M680X 1
@@ -19,7 +19,7 @@
 #endif
 
 #if CAPSTONE_HAS_M680X
-#include <m680x.h>
+#include <capstone/m680x.h>
 
 static int m680xmode(const char *str) {
 	if (R_STR_ISEMPTY (str)) {

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -2,7 +2,7 @@
 
 #include <r_asm.h>
 #include <r_lib.h>
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #ifdef CAPSTONE_M68K_H
 #define CAPSTONE_HAS_M68K 1
@@ -16,7 +16,7 @@
 #endif
 
 #if CAPSTONE_HAS_M68K
-#include <m68k.h>
+#include <capstone/m68k.h>
 // http://www.mrc.uidaho.edu/mrc/people/jff/digital/M68Kir.html
 
 #define OPERAND(x) insn->detail->m68k.operands[x]

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_asm.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <mips.h>
+#include <capstone/capstone.h>
+#include <capstone/mips.h>
 
 static ut64 t9_pre = UT64_MAX;
 // http://www.mrc.uidaho.edu/mrc/people/jff/digital/MIPSir.html

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_anal.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <ppc.h>
+#include <capstone/capstone.h>
+#include <capstone/ppc.h>
 #include "../../asm/arch/ppc/libvle/vle.h"
 
 #define SPR_HID0 0x3f0 /* Hardware Implementation Register 0 */

--- a/libr/anal/p/anal_riscv_cs.c
+++ b/libr/anal/p/anal_riscv_cs.c
@@ -3,9 +3,9 @@
 #include <r_asm.h>
 #include <r_lib.h>
 
-#include <capstone.h>
+#include <capstone/capstone.h>
 #if CS_API_MAJOR >= 5
-#include <riscv.h>
+#include <capstone/riscv.h>
 
 // http://www.mrc.uidaho.edu/mrc/people/jff/digital/RISCVir.html
 

--- a/libr/anal/p/anal_s390_cs.c
+++ b/libr/anal/p/anal_s390_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_anal.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <systemz.h>
+#include <capstone/capstone.h>
+#include <capstone/systemz.h>
 // instruction set: http://www.tachyonsoft.com/inst390m.htm
 
 #if CS_API_MAJOR < 2

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_anal.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <sparc.h>
+#include <capstone/capstone.h>
+#include <capstone/sparc.h>
 
 #if CS_API_MAJOR < 2
 #error Old Capstone not supported

--- a/libr/anal/p/anal_tms320.c
+++ b/libr/anal/p/anal_tms320.c
@@ -82,7 +82,7 @@ int tms320_c55x_plus_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int
 }
 
 // c64x
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #ifdef CAPSTONE_TMS320C64X_H
 #define CAPSTONE_HAS_TMS320C64X 1

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_anal.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <x86.h>
+#include <capstone/capstone.h>
+#include <capstone/x86.h>
 
 #if 0
 CYCLES:

--- a/libr/anal/p/anal_xcore_cs.c
+++ b/libr/anal/p/anal_xcore_cs.c
@@ -2,8 +2,8 @@
 
 #include <r_anal.h>
 #include <r_lib.h>
-#include <capstone.h>
-#include <xcore.h>
+#include <capstone/capstone.h>
+#include <capstone/xcore.h>
 
 #if CS_API_MAJOR < 2
 #error Old Capstone not supported

--- a/libr/anal/p/capstone.mk
+++ b/libr/anal/p/capstone.mk
@@ -7,7 +7,6 @@ CS_LDFLAGS=${CAPSTONE_LDFLAGS}
 else
 # use capstone from shlr/capstone
 CS_CFLAGS=-I${SHLR}/capstone/include
-CS_CFLAGS=-I${SHLR}/capstone/include/capstone
 CS_LDFLAGS=$(SHLR)/capstone/libcapstone.a
 #SHARED_OBJ+=${CS_LDFLAGS}
 endif

--- a/libr/asm/p/asm_tms320.c
+++ b/libr/asm/p/asm_tms320.c
@@ -11,7 +11,7 @@
 #include <r_lib.h>
 #include <r_asm.h>
 #if WANT_CAPSTONE
-#include <capstone.h>
+#include <capstone/capstone.h>
 #endif
 
 #ifdef CAPSTONE_TMS320C64X_H

--- a/libr/asm/p/asm_tms320c64x.c
+++ b/libr/asm/p/asm_tms320c64x.c
@@ -2,7 +2,7 @@
 
 #include <r_asm.h>
 #include <r_lib.h>
-#include <capstone.h>
+#include <capstone/capstone.h>
 static csh cd = 0;
 #include "cs_mnemonics.c"
 

--- a/libr/asm/p/cs_version.h
+++ b/libr/asm/p/cs_version.h
@@ -1,7 +1,7 @@
 #ifndef CS_VERSION_H
 #define CS_VERSION_H
 
-#include <capstone.h>
+#include <capstone/capstone.h>
 
 #if CS_API_MAJOR == 5
 #define CAPSTONE_VERSION_STRING "v5"

--- a/shlr/capstone-patches/v3/capstone-include.patch
+++ b/shlr/capstone-patches/v3/capstone-include.patch
@@ -1,0 +1,70 @@
+diff --git a/include/capstone/arm.h b/include/capstone/arm.h
+new file mode 100644
+index 00000000..5445c96e
+--- /dev/null
++++ b/include/capstone/arm.h
+@@ -0,0 +1 @@
++#include "../arm.h"
+diff --git a/include/capstone/arm64.h b/include/capstone/arm64.h
+new file mode 100644
+index 00000000..30b49da7
+--- /dev/null
++++ b/include/capstone/arm64.h
+@@ -0,0 +1 @@
++#include "../arm64.h"
+diff --git a/include/capstone/capstone.h b/include/capstone/capstone.h
+new file mode 100644
+index 00000000..761a67b8
+--- /dev/null
++++ b/include/capstone/capstone.h
+@@ -0,0 +1 @@
++#include "../capstone.h"
+diff --git a/include/capstone/mips.h b/include/capstone/mips.h
+new file mode 100644
+index 00000000..b91dbabb
+--- /dev/null
++++ b/include/capstone/mips.h
+@@ -0,0 +1 @@
++#include "../mips.h"
+diff --git a/include/capstone/platform.h b/include/capstone/platform.h
+new file mode 100644
+index 00000000..40f1b399
+--- /dev/null
++++ b/include/capstone/platform.h
+@@ -0,0 +1 @@
++#include "../platform.h"
+diff --git a/include/capstone/ppc.h b/include/capstone/ppc.h
+new file mode 100644
+index 00000000..d18092c9
+--- /dev/null
++++ b/include/capstone/ppc.h
+@@ -0,0 +1 @@
++#include "../ppc.h"
+diff --git a/include/capstone/sparc.h b/include/capstone/sparc.h
+new file mode 100644
+index 00000000..e6b9d11b
+--- /dev/null
++++ b/include/capstone/sparc.h
+@@ -0,0 +1 @@
++#include "../sparc.h"
+diff --git a/include/capstone/systemz.h b/include/capstone/systemz.h
+new file mode 100644
+index 00000000..96160def
+--- /dev/null
++++ b/include/capstone/systemz.h
+@@ -0,0 +1 @@
++#include "../systemz.h"
+diff --git a/include/capstone/x86.h b/include/capstone/x86.h
+new file mode 100644
+index 00000000..1f504270
+--- /dev/null
++++ b/include/capstone/x86.h
+@@ -0,0 +1 @@
++#include "../x86.h"
+diff --git a/include/capstone/xcore.h b/include/capstone/xcore.h
+new file mode 100644
+index 00000000..1482ce50
+--- /dev/null
++++ b/include/capstone/xcore.h
+@@ -0,0 +1 @@
++#include "../xcore.h"

--- a/shlr/meson.build
+++ b/shlr/meson.build
@@ -29,6 +29,9 @@ if not capstone_dep.found() or not get_option('use_sys_capstone')
     elif capstone_version == 'v3'
       CS_TIP = '61bf71c771680033651f16cff832446e421847b1'
       CS_BRA = 'v3'
+      patches_files = [
+        'capstone-include.patch'
+      ]
     elif capstone_version == 'v4'
       CS_TIP = 'a7cac8352f7397aa73bb2e2dcc1b6cdb2e1b8461'
       CS_BRA = 'v4'
@@ -191,9 +194,6 @@ if not capstone_dep.found() or not get_option('use_sys_capstone')
   endif
 
   capstone_includes = [platform_inc, include_directories(join_paths('capstone','include'))]
-  if capstone_version == 'v4' or capstone_version == 'v5'
-    capstone_includes += [include_directories(join_paths('capstone','include','capstone'))]
-  endif
 
   libr2capstone = static_library('r2capstone', cs_files,
     c_args: cs_c_args,


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Capstone requires to explicitly state the include path like `#include <capstone/capstone.h>` (see https://www.capstone-engine.org/lang_c.html). Until version 4 `#include <capstone.h>` worked as well. But from version 5 on, the former method is required (see https://github.com/capstone-engine/capstone/issues/1807).

This PR fixes the include paths such that Radare2 can be built against newer versions of capstone.