### PR TITLE
Fix warning when trying to resolve GP on MIPS binaries without entrypoint

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -34,8 +34,9 @@ static bool __isMips(RAsm *a) {
 
 static void loadGP(RCore *core) {
 	if (__isMips (core->rasm)) {
+		ut64 e0 = r_num_math (core->num, "entry0");
 		ut64 gp = r_num_math (core->num, "loc._gp");
-		if (!gp || gp == UT64_MAX) {
+		if ((!gp || gp == UT64_MAX) && (e0 && e0 != UT64_MAX)) {
 			r_config_set (core->config, "anal.roregs", "zero");
 			r_core_cmd0 (core, "10aes@entry0");
 			r_config_set (core->config, "anal.roregs", "zero,gp");


### PR DESCRIPTION
…oint

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
