### PR TITLE
Fix #20040 - invalid char bug in afl* when function names contain ';' ##projects

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1950,7 +1950,7 @@ R_API char *r_anal_function_get_signature(RAnalFunction *function) {
 		free (sdb_arg_i);
 	}
 
-	char *sane = r_name_filter2 (realname);
+	char *sane = r_name_filter_dup (realname);
 	if (sane) {
 		r_str_replace_ch (sane, ':', '_', true);
 		realname = sane;

--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -601,7 +601,7 @@ static int module_match_buffer(RAnal *anal, const RFlirtModule *module, ut8 *b, 
 			if (!flirt_func->name[name_offs]) {
 				continue;
 			}
-			name = r_name_filter2 (flirt_func->name + name_offs);
+			name = r_name_filter_dup (flirt_func->name + name_offs);
 			free (next_module_function->name);
 			next_module_function->name = r_str_newf ("flirt.%s", name);
 			anal->flb.set (anal->flb.f, next_module_function->name,

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1281,7 +1281,7 @@ ut32 fields_offset;
 	eprintf ("  members: 0x%08"PFMT64x"\n", NCD (NCD_MEMBERS));
 	eprintf ("  fields:  0x%08"PFMT64x"\n", NCD (NCD_NFIELDS));
 	eprintf ("  fieldsat:0x%08"PFMT64x"\n", NCD (NCD_OFIELDS));
-	char * tn = r_name_filter2 (typename);
+	char * tn = r_name_filter_dup (typename);
 	r_cons_printf ("f sym.swift.%s.init = 0x%08"PFMT64x"\n",
 		tn, bf->o->baddr + NCD (NCD_ACCESSFCNPTR));
 	free (tn);
@@ -1295,7 +1295,7 @@ ut32 fields_offset;
 
 static void parse_type(RBinFile *bf, SwiftType st) {
 	char *otypename = readstr (bf, st.name_addr);
-	char *typename = r_name_filter2 (otypename);
+	char *typename = r_name_filter_dup (otypename);
 	// eprintf ("methods:\n");
 	if (st.members != UT64_MAX) {
 		ut8 buf[512];
@@ -1317,7 +1317,7 @@ static void parse_type(RBinFile *bf, SwiftType st) {
 			r_list_foreach (symbols, iter, sym) {
 				if (sym->vaddr == method_addr) {
 					free (method_name);
-					method_name = r_name_filter2 (sym->name);
+					method_name = r_name_filter_dup (sym->name);
 					break;
 				}
 			}
@@ -1342,7 +1342,7 @@ static void parse_type(RBinFile *bf, SwiftType st) {
 			if (!field_name) {
 				break;
 			}
-			char *fn = r_name_filter2 (field_name);
+			char *fn = r_name_filter_dup (field_name);
 			r_cons_printf ("f sym.swift.%s.field.%s = 0x%08"PFMT64x"\n",
 				typename, fn, bf->o->baddr + field_method_addr);
 			free (fn);

--- a/libr/bin/pdb/pdb.c
+++ b/libr/bin/pdb/pdb.c
@@ -1398,7 +1398,7 @@ static void print_gvars(RPdb *pdb, ut64 img_base, PJ *pj, int format) {
 			case 1:
 			case '*':
 			case 'r':
-				filtered_name = r_name_filter2 (r_str_trim_head_ro (name));
+				filtered_name = r_name_filter_dup (r_str_trim_head_ro (name));
 				pdb->cb_printf ("f pdb.%s = 0x%" PFMT64x " # %d %.*s\n",
 					filtered_name,
 					(ut64) (img_base + omap_remap ((omap) ? (omap->stream) : 0, gdata->offset + sctn_header->virtual_address)),

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3025,7 +3025,9 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	if (paren) {
 		*paren = '\0';
 	}
-	r_cons_printf ("\"f %s %"PFMT64u" 0x%08"PFMT64x"\"\n", name, r_anal_function_linear_size (fcn), fcn->addr);
+	char *fname = r_name_filter_dup (name);
+	r_cons_printf ("\"f %s %"PFMT64u" 0x%08"PFMT64x"\"\n", fname, r_anal_function_linear_size (fcn), fcn->addr);
+	free (fname);
 	r_cons_printf ("\"af+ 0x%08"PFMT64x" %s %c %c\"\n",
 			fcn->addr, name, //r_anal_function_size (fcn), name,
 			fcn->type == R_ANAL_FCN_TYPE_LOC?'l':

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3374,14 +3374,16 @@ static bool __setFunctionName(RCore *core, ut64 addr, const char *_name, bool pr
 	r_return_val_if_fail (core && _name, false);
 	_name = r_str_trim_head_ro (_name);
 	char *name = getFunctionName (core, addr, _name, prefix);
+	char *fname = r_name_filter_dup (name);
 	// RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_ANY);
+eprintf ("FUNCNAME (%s) f(%s)\n", name, fname);
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, addr);
 	if (fcn) {
 		char *oname = strdup (fcn->name);
 		RFlagItem *flag = r_flag_get (core->flags, fcn->name);
 		if (flag && flag->space && strcmp (flag->space->name, R_FLAGS_FS_FUNCTIONS) == 0) {
 			// Only flags in the functions fs should be renamed, e.g. we don't want to rename symbol flags.
-			r_flag_rename (core->flags, flag, name);
+			r_flag_rename (core->flags, flag, fname);
 		} else {
 			// No flag or not specific to the function, create a new one.
 			r_flag_space_push (core->flags, R_FLAGS_FS_FUNCTIONS);
@@ -3395,9 +3397,11 @@ static bool __setFunctionName(RCore *core, ut64 addr, const char *_name, bool pr
 		}
 		free (oname);
 		free (name);
+		free (fname);
 		return true;
 	}
 	free (name);
+	free (fname);
 	return false;
 }
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3376,7 +3376,6 @@ static bool __setFunctionName(RCore *core, ut64 addr, const char *_name, bool pr
 	char *name = getFunctionName (core, addr, _name, prefix);
 	char *fname = r_name_filter_dup (name);
 	// RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, addr, R_ANAL_FCN_TYPE_ANY);
-eprintf ("FUNCNAME (%s) f(%s)\n", name, fname);
 	RAnalFunction *fcn = r_anal_get_function_at (core->anal, addr);
 	if (fcn) {
 		char *oname = strdup (fcn->name);

--- a/libr/core/cmd_zign.c
+++ b/libr/core/cmd_zign.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2021 - pancake, nibble */
+/* radare - LGPL - Copyright 2009-2022 - pancake, nibble */
 
 #include <r_core.h>
 #include <r_anal.h>
@@ -428,7 +428,7 @@ static void apply_name(RCore *core, RAnalFunction *fcn, RSignItem *it, bool rad)
 	r_return_if_fail (core && fcn && it && it->name);
 	const char *name = it->realname? it->realname: it->name;
 	if (rad) {
-		char *tmp = r_name_filter2 (name);
+		char *tmp = r_name_filter_dup (name);
 		if (tmp) {
 			r_cons_printf ("\"afn %s @ 0x%08" PFMT64x "\"\n", tmp, fcn->addr);
 			free (tmp);
@@ -450,7 +450,7 @@ static void apply_flag(RCore *core, RSignItem *it, ut64 addr, int size, int coun
 	char *name = r_str_newf ("%s.%s.%s_%d", zign_prefix, prefix, it->name, count);
 	if (name) {
 		if (rad) {
-			char *tmp = r_name_filter2 (name);
+			char *tmp = r_name_filter_dup (name);
 			if (tmp) {
 				r_cons_printf ("f %s %d @ 0x%08" PFMT64x "\n", tmp, size, addr);
 				free (tmp);

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2021 - pancake, ret2libc */
+/* radare - LGPL - Copyright 2007-2022 - pancake, ret2libc */
 
 #include <r_flag.h>
 #include <r_util.h>
@@ -399,11 +399,9 @@ R_API void r_flag_list(RFlag *f, int rad, const char *pfx) {
 		rad = pfx[0];
 		pfx = NULL;
 	}
-
 	if (pfx && !*pfx) {
 		pfx = NULL;
 	}
-
 	switch (rad) {
 	case 'q':
 		r_flag_foreach_space (f, r_flag_space_cur (f), print_flag_name, f);

--- a/libr/include/r_util/r_name.h
+++ b/libr/include/r_util/r_name.h
@@ -6,21 +6,14 @@ extern "C" {
 #endif
 
 R_API bool r_name_validate_print(const char ch);
-// R_API bool r_name_validate_char(const char ch);
+R_API bool r_name_validate_char(const char ch);
 R_API bool r_name_validate_first(const char ch);
 R_API bool r_name_check(const char *s);
 R_API const char *r_name_filter_ro(const char *a);
 R_API bool r_name_filter_flag(char *s);
 R_API bool r_name_filter_print(char *s);
 R_API bool r_name_filter(char *name, int maxlen);
-R_API char *r_name_filter2(const char *name);
-
-static inline bool r_name_validate_char(const char ch) {
-	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || IS_DIGIT (ch)) {
-		return true;
-	}
-	return (ch == '.' || ch == ':' || ch == '_');
-}
+R_API char *r_name_filter_dup(const char *name);
 
 #ifdef __cplusplus
 }

--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -70,7 +70,8 @@ R_API bool r_name_validate_char(const char ch) {
 	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || IS_DIGIT (ch)) {
 		return true;
 	}
-	return (ch == ';' || ch == '.' || ch == ':' || ch == '_');
+	return (ch == '.' || ch == ':' || ch == '_');
+	// return (ch == ';' || ch == '.' || ch == ':' || ch == '_');
 }
 
 R_API bool r_name_validate_first(const char ch) {

--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -66,20 +66,12 @@ R_API bool r_name_validate_dash(const char ch) {
 	return false;
 }
 
-#if 0
 R_API bool r_name_validate_char(const char ch) {
 	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || IS_DIGIT (ch)) {
 		return true;
 	}
-	switch (ch) {
-	case '.':
-	case ':':
-	case '_':
-		return true;
-	}
-	return false;
+	return (ch == ';' || ch == '.' || ch == ':' || ch == '_');
 }
-#endif
 
 R_API bool r_name_validate_first(const char ch) {
 	if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
@@ -106,7 +98,7 @@ R_API bool r_name_check(const char *s) {
 }
 
 static inline bool is_special_char(char n) {
-	return (n == 'b' || n == 'f' || n == 'n' || n == 'r' || n == 't' || n == 'v' || n == 'a');
+	return (n == 's' || n == 'b' || n == 'f' || n == 'n' || n == 'r' || n == 't' || n == 'v' || n == 'a');
 }
 
 R_API const char *r_name_filter_ro(const char *a) {
@@ -197,7 +189,7 @@ R_API bool r_name_filter(char *s, int maxlen) {
 #endif
 }
 
-R_API char *r_name_filter2(const char *name) {
+R_API char *r_name_filter_dup(const char *name) {
 	char *s = strdup (name);
 	r_name_filter (s, -1);
 	return s;

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1154,6 +1154,10 @@ R_API int r_str_unescape(char *buf) {
 		case 'e':
 			buf[i] = 0x1b;
 			break;
+		case ' ':
+		case 's':
+			buf[i] = ' ';
+			break;
 		case '\\':
 			buf[i] = '\\';
 			break;


### PR DESCRIPTION
* Rename r_name_filter2() to r_name_filter_dup()
* Fixes some project save/load inconsistencies

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
