### PR TITLE
Fix #20049 - '.' in stack panel seeks to SP or BP if unset ##visual

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -6602,7 +6602,16 @@ virtualmouse:
 		__rotate_panels (core, true);
 		break;
 	case '.':
-		if (__check_panel_type (cur, PANEL_CMD_DISASSEMBLY)) {
+		if (__check_panel_type (cur, PANEL_CMD_STACK)) {
+			ut64 addr = r_debug_reg_get (core->dbg, "SP");
+			if (!addr || addr == UT64_MAX) {
+				addr = r_debug_reg_get (core->dbg, "BP");
+			}
+			if (addr && addr != UT64_MAX) {
+				r_core_seek (core, addr, true);
+				__set_panel_addr (core, cur, addr);
+			}
+		} else if (__check_panel_type (cur, PANEL_CMD_DISASSEMBLY)) {
 			ut64 addr = r_debug_reg_get (core->dbg, "PC");
 			if (addr && addr != UT64_MAX) {
 				r_core_seek (core, addr, true);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
