### PR TITLE
Add pcg to print array in Golang format

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -67,6 +67,7 @@ static const char *help_msg_pc[] = {
 	"pco", "", "Objective-C",
 	"pcp", "", "python",
 	"pcr", "", "rust",
+	"pcg", "", "Golang",
 	"pcS", "", "shellscript that reconstructs the bin",
 	"pcs", "", "string",
 	"pcv", "", "JaVa",

--- a/libr/util/print_code.c
+++ b/libr/util/print_code.c
@@ -169,6 +169,15 @@ R_API void r_print_code(RPrint *p, ut64 addr, const ut8 *buf, int len, char lang
 		}
 		p->cb_printf ("\n.equ shellcode_len, %d\n", len);
 		break;
+	case 'g': // "pcg"
+		p->cb_printf ("var BUFF = [%d]byte{", len);
+		for (i = 0; !r_print_is_interrupted () && i < len; i++) {
+			r_print_cursor (p, i, 1, 1);
+			p->cb_printf ("0x%x%s", buf[i], (i + 1 < len)? ",": "");
+			r_print_cursor (p, i, 1, 0);
+		}
+		p->cb_printf ("}\n");
+		break;
 	case 's': // "pcs"
 		p->cb_printf ("\"");
 		for (i = 0; !r_print_is_interrupted () && i < len; i++) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

Add a new print support for Golang variable slices, that's very useful when embedding files/shellcodes inside the source.

- [X ] Mark this if you consider it ready to merge


```go
[0x00005bc0]> pcg 10
var BUFF = [10]byte{0xf3,0xf,0x1e,0xfa,0x31,0xed,0x49,0x89,0xd1,0x5e}
```