### PR TITLE
Fix meson build with use_sys_openssl ##build

### DIFF
--- a/libr/socket/meson.build
+++ b/libr/socket/meson.build
@@ -20,7 +20,6 @@ endif
 
 if use_sys_openssl
   r_util_deps += [sys_openssl]
-  r_util_static_deps += [sys_openssl]
 endif
 
 r_socket = library('r_socket', r_socket_sources,


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

r_util_static_deps already handled in the block above, currently errors trying to append to an undefined var if use_sys_openssl is set.