### PR TITLE
Add PIC_CFLAGS to the libr_syscall `%.sdb` rule ##build

### DIFF
--- a/libr/syscall/d/Makefile
+++ b/libr/syscall/d/Makefile
@@ -51,7 +51,7 @@ else
 endif
 	test -f $@
 	${SDB} -t -C $@
-	$(CC) $(CFLAGS) -c `echo $@ | sed -e s,sdb,c,`
+	$(CC) $(CFLAGS) $(PIC_CFLAGS) -c `echo $@ | sed -e s,sdb,c,`
 
 clean:
 	rm -f *.sdb


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

To fix linking on recent GNU toolchains, e.g. on Fedora 36:

```
/usr/bin/ld: d/darwin-arm-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-arm-64.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: d/darwin-x86-32.o: relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
…
```