### PR TITLE
Add missing op types to r_anal_optype_to_string ##anal

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -361,6 +361,8 @@ repeat:
 	case R_ANAL_OP_TYPE_IRCALL: return "ircall";
 	case R_ANAL_OP_TYPE_UCCALL: return "uccall";
 	case R_ANAL_OP_TYPE_UCJMP : return "ucjmp";
+	case R_ANAL_OP_TYPE_MCJMP : return "mcjmp";
+	case R_ANAL_OP_TYPE_RCJMP : return "rcjmp";
 	case R_ANAL_OP_TYPE_UJMP  : return "ujmp";
 	case R_ANAL_OP_TYPE_RJMP  : return "rjmp";
 	case R_ANAL_OP_TYPE_IJMP  : return "ijmp";
@@ -372,6 +374,8 @@ repeat:
 	case R_ANAL_OP_TYPE_CASE  : return "case";
 	case R_ANAL_OP_TYPE_CPL   : return "cpl";
 	case R_ANAL_OP_TYPE_CRYPTO: return "crypto";
+	case R_ANAL_OP_TYPE_LENGTH: return "lenght";
+	case R_ANAL_OP_TYPE_ABS   : return "abs";
 	}
 	if (once) {
 		once = false;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
