### PR TITLE
Add `ec bgprompt` for a colorful shell and visual prompts ##cons

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -936,6 +936,10 @@ static inline void delete_till_end(void) {
 	I.buffer.index = I.buffer.index > 0 ? I.buffer.index - 1 : 0;
 }
 
+static const char *promptcolor (void) {
+	return r_cons_singleton ()->context->pal.bgprompt;
+}
+
 static void __print_prompt(void) {
 	RCons *cons = r_cons_singleton ();
 	int columns = r_cons_get_size (NULL) - 2;
@@ -944,16 +948,17 @@ static void __print_prompt(void) {
 		r_cons_gotoxy (0,  cons->rows);
 		r_cons_flush ();
 	}
+	printf ("%s", promptcolor ());
 	r_cons_clear_line (0);
 	if (cons->context->color_mode > 0) {
-		printf ("\r%s%s", Color_RESET, I.prompt);
+		printf ("\r%s%s%s", Color_RESET, promptcolor (), I.prompt);
 	} else {
 		printf ("\r%s", I.prompt);
 	}
 	if (I.buffer.length > 0) {
 		fwrite (I.buffer.data, I.buffer.length, 1, stdout);
 	}
-	printf ("\r%s", I.prompt);
+	printf ("\r%s%s%s", promptcolor (), I.prompt, promptcolor ());
 	if (I.buffer.index > cols) {
 		printf ("< ");
 		i = I.buffer.index - cols;
@@ -1094,7 +1099,7 @@ static void __update_prompt_color(void) {
 		} else {
 			BEGIN = cons->context->pal.prompt;
 		}
-		END = cons->context->pal.reset;
+	//	END = cons->context->pal.reset;
 	}
 	char *prompt = r_str_escape (I.prompt);		// remote the color
 	free (I.prompt);
@@ -2058,7 +2063,7 @@ _end:
 	r_cons_set_raw (0);
 	r_cons_enable_mouse (mouse_status);
 	if (I.echo) {
-		printf ("\r%s%s\n", I.prompt, I.buffer.data);
+		printf ("\r%s%s%s%s\n", I.prompt, promptcolor (), I.buffer.data, Color_RESET);
 		fflush (stdout);
 	}
 

--- a/libr/cons/pal.c
+++ b/libr/cons/pal.c
@@ -23,6 +23,7 @@ static struct {
 	{ "flow", r_offsetof (RConsPrintablePalette, flow), r_offsetof (RConsPalette, flow) },
 	{ "flow2", r_offsetof (RConsPrintablePalette, flow2), r_offsetof (RConsPalette, flow2) },
 	{ "prompt", r_offsetof (RConsPrintablePalette, prompt), r_offsetof (RConsPalette, prompt) },
+	{ "bgprompt", r_offsetof (RConsPrintablePalette, bgprompt), r_offsetof (RConsPalette, bgprompt) },
 	{ "offset", r_offsetof (RConsPrintablePalette, offset), r_offsetof (RConsPalette, offset) },
 	{ "input", r_offsetof (RConsPrintablePalette, input), r_offsetof (RConsPalette, input) },
 	{ "invalid", r_offsetof (RConsPrintablePalette, invalid), r_offsetof (RConsPalette, invalid) },
@@ -205,6 +206,7 @@ R_API void r_cons_pal_init(RConsContext *ctx) {
 	ctx->cpal.pop                = (RColor) RColor_MAGENTA;
 	// ctx->cpal.pop.attr           = R_CONS_ATTR_BOLD;
 	ctx->cpal.prompt             = (RColor) RColor_YELLOW;
+	ctx->cpal.bgprompt           = (RColor) RColor_NULL;
 	ctx->cpal.push               = (RColor) RColor_MAGENTA;
 	ctx->cpal.crypto             = (RColor) RColor_BGBLUE;
 	ctx->cpal.reg                = (RColor) RColor_CYAN;

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3360,7 +3360,7 @@ static void set_prompt(RCore *r) {
 		remote = "=!";
 	}
 
-	if (r_config_get_i (r->config, "scr.color")) {
+	if (r_config_get_i (r->config, "scr.color") > 0) {
 		BEGIN = r->cons->context->pal.prompt;
 		END = r->cons->context->pal.reset;
 	}
@@ -3395,7 +3395,7 @@ static void set_prompt(RCore *r) {
 	}
 
 	chop_prompt (filename, tmp, 128);
-	char *prompt = r_str_newf ("%s%s[%s%s]>%s ", filename, BEGIN, remote,
+	char *prompt = r_str_newf ("%s%s[%s%s]> %s", filename, BEGIN, remote,
 		tmp, END);
 	r_line_set_prompt (r_str_get (prompt));
 

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4152,6 +4152,7 @@ static void visual_refresh(RCore *core) {
 	}
 	r_cons_flush ();
 	r_cons_print_clear ();
+	r_cons_strcat (core->cons->context->pal.bgprompt);
 	core->cons->context->noflush = true;
 
 	int hex_cols = r_config_get_i (core->config, "hex.cols");

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -166,6 +166,7 @@ typedef struct r_cons_palette_t {
 	RColor other;
 	RColor pop;
 	RColor prompt;
+	RColor bgprompt;
 	RColor push;
 	RColor crypto;
 	RColor reg;
@@ -241,6 +242,7 @@ typedef struct r_cons_printable_palette_t {
 	char *other;
 	char *pop;
 	char *prompt;
+	char *bgprompt;
 	char *push;
 	char *crypto;
 	char *reg;

--- a/test/db/cmd/cmd_ec
+++ b/test/db/cmd/cmd_ec
@@ -42,6 +42,7 @@ ec help rgb:a0b070
 ec flow rgb:c0a060
 ec flow2 rgb:f0e0c0
 ec prompt rgb:906000
+ec bgprompt rgb:000000
 ec offset rgb:906000
 ec input rgb:c0a060
 ec invalid rgb:c06040
@@ -154,6 +155,7 @@ EXPECT=<<EOF
  [36m##[0m  flow
  [34m##[0m  flow2
  [33m##[0m  prompt
+ [0m##[0m  bgprompt
  [32m##[0m  offset
  [37m##[0m  input
  [1;91m##[0m  invalid
@@ -224,6 +226,7 @@ EXPECT=<<EOF
  [96m##[0m  flow
  [94m##[0m  flow2
  [93m##[0m  prompt
+ [0m##[0m  bgprompt
  [92m##[0m  offset
  [97m##[0m  input
  [1;91m##[0m  invalid


### PR DESCRIPTION
* ec bgprompt=red blue ; ec prompt=green yellow
![IMAGE 2022-05-20 21:44:19](https://user-images.githubusercontent.com/6431515/169600452-b75e60af-f942-4903-b8da-801f2c6f533e.jpg)

