### PR TITLE
Fix leak in r_anal_get_gperf_cc ##anal

### DIFF
--- a/libr/anal/anplugs.c
+++ b/libr/anal/anplugs.c
@@ -84,6 +84,7 @@ R_API SdbGperf *r_anal_get_gperf_cc(const char *k) {
 	while (*gp) {
 		SdbGperf *g = *gp;
 		if (!strcmp (kk, g->name)) {
+			free (kk);
 			return *gp;
 		}
 		gp++;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix for a memory leak in `r_anal_get_gperf_cc`