### PR TITLE
Fix wasm custom name leak ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -76,7 +76,7 @@ static bool consume_str_r(RBuffer *b, ut64 bound, size_t len, char *out) {
 	r_return_val_if_fail (b && bound > 0 && bound < r_buf_size (b), 0);
 	*out = 0;
 
-	if (r_buf_tell (b) + len <= bound) {
+	if (r_buf_tell (b) + len <= bound + 1) {
 		if (r_buf_read (b, (ut8 *)out, len) == len) {
 			out[len] = 0;
 			return true;

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -52,6 +52,7 @@ typedef enum {
 	R_BIN_WASM_NAMETYPE_Module = 0x0,
 	R_BIN_WASM_NAMETYPE_Function = 0x1,
 	R_BIN_WASM_NAMETYPE_Local = 0x2,
+	R_BIN_WASM_NAMETYPE_None = 0xff,
 } r_bin_wasm_custom_name_type_t;
 
 struct r_bin_wasm_init_expr_t {
@@ -207,7 +208,7 @@ typedef struct r_bin_wasm_custom_name_entry_t {
 
 	ut8 payload_data;
 	union {
-		struct r_bin_wasm_name_t* mod_name;
+		RBinWasmName *mod_name;
 		RBinWasmCustomNameFunctionNames *func;
 		RBinWasmCustomNameLocalNames *local;
 	};


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixing a leak and improving code some. You might want to wait for a couple tests to be added before merging.

Looks like the `parse_custom_names_local` code is untested, I don't think there is any wasm files in the test files to even hit that code. I will fix add tests soon. If someone has a wasm file that hits that code, let me know. Otherwise I will find or build something.