### PR TITLE
Fix missing calling convention when using asm.arch=*.XXX ##anal

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -744,10 +744,14 @@ static R_TH_LOCAL int old_bits = -1;
 static R_TH_LOCAL char *old_arch = NULL;
 
 R_API void r_core_anal_cc_init(RCore *core) {
-	const char *anal_arch = r_config_get (core->config, "anal.arch");
+	char *anal_arch = strdup (r_config_get (core->config, "anal.arch"));
 	const int bits = core->anal->config->bits;
 	if (!anal_arch) {
 		return;
+	}
+	char *dot = strchr (anal_arch, '.');
+	if (dot) {
+		*dot = 0;
 	}
 	if (old_bits != -1) {
 		if (old_bits == bits) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
