### PR TITLE
Correction returned code, set zero if ret isn't -1

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1636,5 +1636,5 @@ beach:
 	r_core_free (r);
 	LISTS_FREE ();
 	R_FREE (pfile);
-	return ret;
+	return (ret < 0 ? 0 : ret);
 }


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

If return code from r2 isn't -1 then it's non error and set return code in 0
