### PR TITLE
Add s390x and armv7 in the CI ##builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,44 @@ on:
   pull_request:
 
 jobs:
+  linux-s390x:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: uraimo/run-on-arch-action@v2
+        name: Run commands
+        id: runcmd
+        with:
+          arch: s390x
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          run: |
+            apt update
+            apt install -y make git patch wget curl build-essential
+            sys/install.sh
+      - name: Get the output
+        # Echo the `uname` output parameter from the `runcmd` step
+        run: |
+          echo "The uname output was ${{ steps.runcmd.outputs.uname }}"
+  linux-armv7:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: uraimo/run-on-arch-action@v2
+        name: Run commands
+        id: runcmd
+        with:
+          arch: armv7
+          distro: ubuntu22.04
+          githubToken: ${{ github.token }}
+          run: |
+            apt update
+            apt install -y make git patch wget curl build-essential
+            sys/install.sh
+      - name: Get the output
+        # Echo the `uname` output parameter from the `runcmd` step
+        run: |
+          echo "The uname output was ${{ steps.runcmd.outputs.uname }}"
   # WASI
   linux-wasi:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
     - name: Build on a directory with spaces (meson only)
       run: |
         export PATH=${HOME}/.local/bin:${HOME}/Library/Python/3.9/bin:${PATH}
-        sudo apt-get --assume-yes install python3-wheel gperf python3-setuptools cabextract gperf
+        sudo apt-get --assume-yes install python3-wheel gperf python3-setuptools cabextract
         sudo pip3 install meson ninja
         git config --global pull.rebase false
         git clone --depth 1 . "spa ces"


### PR DESCRIPTION

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

```
At top level:
[2936](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2936)
p/debug_native.c:1664:2: warning: #warning Unsupported architecture [-Wcpp]
[2937](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2937)
 1664 | #warning Unsupported architecture
[2938](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2938)
      |  ^~~~~~~
[2939](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2939)
[debug 848] CC p/debug_qnx.c
[2940](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2940)
[debug 849] CC p/debug_rap.c
[2941](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2941)
[debug 850] CC p/debug_winkd.c
[2942](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2942)
[debug 851] CC p/native/linux/linux_debug.c
[2943](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2943)
p/native/linux/linux_debug.c: In function 'print_fpu':
[2944](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2944)
p/native/linux/linux_debug.c:1061:2: warning: #warning print_fpu not implemented for this platform [-Wcpp]
[2945](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2945)
 1061 | #warning print_fpu not implemented for this platform
[2946](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2946)
      |  ^~~~~~~
[2947](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2947)
p/native/linux/linux_debug.c: In function 'linux_reg_read':
[2948](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2948)
p/native/linux/linux_debug.c:1172:10: warning: #warning getfpregs not implemented for this platform [-Wcpp]
[2949](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2949)
 1172 |         #warning getfpregs not implemented for this platform
[2950](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2950)
      |          ^~~~~~~
[2951](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2951)
p/native/linux/linux_debug.c:1187:75: warning: passing argument 4 of 'r_debug_ptrace' makes pointer from integer without a cast [-Wint-conversion]
[2952](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2952)
 1187 |                         ret = r_debug_ptrace (dbg, PTRACE_GETREGSET, pid, (size_t)1, &io);
[2953](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2953)
      |                                                                           ^~~~~~~~~
[2954](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2954)
      |                                                                           |
[2955](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2955)
      |                                                                           long unsigned int
[2956](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2956)
In file included from p/native/linux/linux_debug.c:6:
[2957](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2957)
/home/runner/work/radare2/radare2/libr/include/r_debug.h:617:93: note: expected 'void *' but argument is of type 'long unsigned int'
[2958](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2958)
  617 | static inline long r_debug_ptrace(RDebug *dbg, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data) {
[2959](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2959)
      |                                                                                       ~~~~~~^~~~
[2960](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2960)
p/native/linux/linux_debug.c:1066:14: warning: variable 'showfpu' set but not used [-Wunused-but-set-variable]
[2961](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2961)
 1066 |         bool showfpu = false;
[2962](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2962)
      |              ^~~~~~~
[2963](https://github.com/radareorg/radare2/runs/6662782610?check_suite_focus=true#step:3:2963)
At top level:
```