### PR TITLE
Cleanup dbg.trace config vars and better error messages ##debug

### DIFF
--- a/libr/anal/esil_trace.c
+++ b/libr/anal/esil_trace.c
@@ -17,7 +17,11 @@ static void htup_vector_free(HtUPKv *kv) {
 }
 
 R_API RAnalEsilTrace *r_anal_esil_trace_new(RAnalEsil *esil) {
-	r_return_val_if_fail (esil && esil->stack_addr && esil->stack_size, NULL);
+	r_return_val_if_fail (esil, NULL);
+	if (!esil->stack_addr || !esil->stack_size) {
+		eprintf ("Run `aeim` to initialize a stack for the ESIL vm\n");
+		return NULL;
+	}
 	size_t i;
 	RAnalEsilTrace *trace = R_NEW0 (RAnalEsilTrace);
 	if (!trace) {

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3573,7 +3573,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.tabs.once", "false", "only tabulate the opcode, not the arguments");
 	SETI ("asm.tabs.off", 0, "tabulate spaces after the offset");
 	SETBPREF ("asm.trace", "false", "show execution traces for each opcode");
-	SETBPREF ("asm.tracespace", "false", "indent disassembly with trace.count information");
+	SETBPREF ("asm.trace.space", "false", "indent disassembly with trace.count information");
 	SETBPREF ("asm.ucase", "false", "use uppercase syntax at disassembly");
 	SETBPREF ("asm.capitalize", "false", "use camelcase at disassembly");
 	SETBPREF ("asm.var", "true", "show local function variables in disassembly");
@@ -3826,7 +3826,11 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("dbg.profile", "", &cb_runprofile, "path to RRunProfile file");
 	SETCB ("dbg.args", "", &cb_dbg_args, "set the args of the program to debug");
 	SETCB ("dbg.follow.child", "false", &cb_dbg_follow_child, "continue tracing the child process on fork. By default the parent process is traced");
-	SETCB ("dbg.trace_continue", "true", &cb_dbg_trace_continue, "trace every instruction between the initial PC position and the PC position at the end of continue's execution");
+	SETCB ("dbg.trace.continue", "true", &cb_dbg_trace_continue, "trace every instruction between the initial PC position and the PC position at the end of continue's execution");
+	SETBPREF ("dbg.trace.inrange", "false", "while tracing, avoid following calls outside specified range");
+	SETBPREF ("dbg.trace.libs", "true", "trace library code too");
+	SETCB ("dbg.trace", "false", &cb_trace, "trace program execution (see asm.trace)");
+	SETICB ("dbg.trace.tag", 0, &cb_tracetag, "trace tag");
 	/* debug */
 	SETCB ("dbg.status", "false", &cb_dbgstatus, "set cmd.prompt to '.dr*' or '.dr*;drd;sr PC;pi 1;s-'");
 #if DEBUGGER
@@ -3845,8 +3849,6 @@ R_API int r_core_config_init(RCore *core) {
 	r_config_desc (cfg, "dbg.follow", "follow program counter when pc > core->offset + dbg.follow");
 	SETBPREF ("dbg.rebase", "true", "rebase anal/meta/comments/flags when reopening file in debugger");
 	SETCB ("dbg.swstep", "false", &cb_swstep, "force use of software steps (code analysis+breakpoint)");
-	SETBPREF ("dbg.trace.inrange", "false", "while tracing, avoid following calls outside specified range");
-	SETBPREF ("dbg.trace.libs", "true", "trace library code too");
 	SETBPREF ("dbg.exitkills", "true", "kill process on exit");
 	SETPREF ("dbg.exe.path", "", "path to binary being debugged");
 	SETCB ("dbg.execs", "false", &cb_dbg_execs, "stop execution if new thread is created");
@@ -3864,8 +3866,6 @@ R_API int r_core_config_init(RCore *core) {
 #endif
 	SETBPREF ("dbg.bpsysign", "false", "ignore system breakpoints");
 	SETICB ("dbg.btdepth", 128, &cb_dbgbtdepth, "depth of backtrace");
-	SETCB ("dbg.trace", "false", &cb_trace, "trace program execution (see asm.trace)");
-	SETICB ("dbg.trace.tag", 0, &cb_tracetag, "trace tag");
 
 
 	/* cmd */

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5837,14 +5837,18 @@ tail_return:
 	return tail_return_value;
 }
 
-R_API int r_core_esil_step_back(RCore *core) {
-	r_return_val_if_fail (core->anal->esil && core->anal->esil->trace, -1);
+R_API bool r_core_esil_step_back(RCore *core) {
+	r_return_val_if_fail (core && core->anal, false);
+	if (!core->anal->esil || !core->anal->esil->trace) {
+		eprintf ("Run `aeim` to initialize the esil VM and enable e dbg.trace=true\n");
+		return false;
+	}
 	RAnalEsil *esil = core->anal->esil;
 	if (esil->trace->idx > 0) {
 		r_anal_esil_trace_restore (esil, esil->trace->idx - 1);
-		return 1;
+		return true;
 	}
-	return -1;
+	return false;
 }
 
 static void cmd_address_info(RCore *core, const char *addrstr, int fmt) {
@@ -7150,7 +7154,7 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 		} break;
 		case 'b': // "aesb"
 			if (!r_core_esil_step_back (core)) {
-				eprintf ("cannnot step back\n");
+				eprintf ("Cannot step back\n");
 			}
 			r_core_cmd0 (core, ".ar*");
 			break;

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -4618,7 +4618,7 @@ static int cmd_debug_step(RCore *core, const char *input) {
 	switch (input[1]) {
 	case 0: // "ds"
 	case ' ':
-		if (r_config_get_i (core->config, "cfg.debug")) {
+		if (r_config_get_b (core->config, "cfg.debug")) {
 			r_reg_arena_swap (core->dbg->reg, true);
 			// sync registers for BSD PT_STEP/PT_CONT
 			// XXX(jjd): is this necessary?

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -694,7 +694,7 @@ static RDisasmState *ds_init(RCore *core) {
 	ds->linesright = r_config_get_i (core->config, "asm.lines.right");
 	ds->show_indent = r_config_get_i (core->config, "asm.indent");
 	ds->indent_space = r_config_get_i (core->config, "asm.indentspace");
-	ds->tracespace = r_config_get_i (core->config, "asm.tracespace");
+	ds->tracespace = r_config_get_i (core->config, "asm.trace.space");
 	ds->cyclespace = r_config_get_i (core->config, "asm.cyclespace");
 	ds->show_dwarf = r_config_get_i (core->config, "asm.dwarf");
 	ds->dwarfFile = r_config_get_i (ds->core->config, "asm.dwarf.file");

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -3274,6 +3274,7 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 			if (key_s && *key_s) {
 				r_core_cmd0 (core, key_s);
 			} else {
+				// r_core_cmd0 (core, "dsb");
 				__core_visual_step_over (core);
 			}
 			break;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -636,7 +636,7 @@ R_API int r_core_anal_refs(RCore *core, const char *input);
 R_API void r_core_agraph_print(RCore *core, int use_utf, const char *input);
 R_API bool r_core_esil_cmd(RAnalEsil *esil, const char *cmd, ut64 a1, ut64 a2);
 R_API int r_core_esil_step(RCore *core, ut64 until_addr, const char *until_expr, ut64 *prev_addr, bool stepOver);
-R_API int r_core_esil_step_back(RCore *core);
+R_API bool r_core_esil_step_back(RCore *core);
 R_API ut64 r_core_anal_get_bbaddr(RCore *core, ut64 addr);
 R_API bool r_core_anal_bb_seek(RCore *core, ut64 addr);
 R_API bool r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth);


### PR DESCRIPTION
* aeim;e key.S=dsb;e dbg.trace=true;ds;dsb
* aes was causing assert when no aeim was executed

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
