### PR TITLE
Better handling of Wasm Names ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -129,7 +129,8 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 	}
 
 	// room for even every character getting encoded
-	char *sout = malloc (len * 4 + 2);
+	ut32 maxsize = len * 4 + 2;
+	char *sout = malloc (maxsize);
 	if (!sout) {
 		free (orig);
 		return false;
@@ -140,7 +141,7 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 		if (WASM_IS_OK (orig, i, len)) {
 			sout[oi++] = orig[i];
 		} else {
-			oi += snprintf (sout + oi, len - oi, "_%02x_", orig[i]);
+			oi += snprintf (sout + oi, maxsize - oi, "_%02x_", orig[i]);
 		}
 	}
 	sout[oi++] = '\0';

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -140,7 +140,7 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 		if (WASM_IS_OK (orig, i, len)) {
 			sout[oi++] = orig[i];
 		} else {
-			oi += sprintf (sout + oi, "_%02x_", orig[i]);
+			oi += snprintf (sout + oi, len - oi, "_%02x_", orig[i]);
 		}
 	}
 	sout[oi++] = '\0';

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -129,7 +129,7 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 	}
 
 	// room for even every character getting encoded
-	ut32 maxsize = len * 4 + 2;
+	size_t maxsize = (len * 4) + 2;
 	char *sout = malloc (maxsize);
 	if (!sout) {
 		free (orig);

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -154,7 +154,7 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 	}
 	*str_out = tmp;
 	if (len_out) {
-		len_out = len;
+		*len_out = len;
 	}
 	return true;
 }

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -521,18 +521,13 @@ static bool parse_namemap(RBuffer *b, ut64 bound, RIDStorage *map, ut32 *count) 
 	}
 
 	for (i = 0; i < *count; i++) {
-		RBinWasmName *name = R_NEW0 (RBinWasmName);
-		if (!name) {
-			return false;
-		}
-
 		ut32 idx;
 		if (!consume_u32_r (b, bound, &idx)) {
-			R_FREE (name);
 			return false;
 		}
 
-		if (!consume_str_new (b, bound, &name->len, (char **)&name->name)) {
+		char *name;
+		if (!consume_str_new (b, bound, NULL, &name)) {
 			R_FREE (name);
 			return false;
 		}
@@ -613,11 +608,7 @@ static RBinWasmCustomNameEntry *parse_custom_name_entry(RBuffer *b, ut64 bound) 
 
 	switch (cust->type) {
 	case R_BIN_WASM_NAMETYPE_Module:
-		cust->mod_name = R_NEW0 (struct r_bin_wasm_name_t);
-		if (!cust->mod_name) {
-			goto beach;
-		}
-		if (!consume_str_new (b, bound, &cust->mod_name->len, (char **)&cust->mod_name->name)) {
+		if (!consume_str_new (b, bound, NULL, &cust->mod_name)) {
 			goto beach;
 		}
 		break;
@@ -1281,10 +1272,9 @@ const char *r_bin_wasm_get_function_name(RBinWasmObj *bin, ut32 idx) {
 	RBinWasmCustomNameEntry *nam;
 	r_list_foreach (bin->g_names, iter, nam) {
 		if (nam->type == R_BIN_WASM_NAMETYPE_Function) {
-			struct r_bin_wasm_name_t *n = NULL;
-
-			if ((n = r_id_storage_get (nam->func->names, idx))) {
-				return (const char *)n->name;
+			const char *n = r_id_storage_get (nam->func->names, idx);
+			if (n) {
+				return n;
 			}
 		}
 	}

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -137,7 +137,7 @@ static bool consume_encoded_name_new(RBuffer *b, ut64 bound, ut32 *len_out, char
 	}
 
 	size_t i, oi = 0;
-	for (i = 0; i < len; i++) {
+	for (i = 0; i < len && oi + 4 < maxsize; i++) {
 		if (WASM_IS_OK (orig, i, len)) {
 			sout[oi++] = orig[i];
 		} else {

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -66,11 +66,6 @@ struct r_bin_wasm_resizable_limits_t {
 	ut32 maximum;
 };
 
-typedef struct r_bin_wasm_name_t {
-	ut32 len;
-	ut8 *name;
-} RBinWasmName;
-
 typedef struct r_bin_wasm_section_t {
 	ut8 id;
 	ut32 size;
@@ -208,7 +203,7 @@ typedef struct r_bin_wasm_custom_name_entry_t {
 
 	ut8 payload_data;
 	union {
-		RBinWasmName *mod_name;
+		char *mod_name;
 		RBinWasmCustomNameFunctionNames *func;
 		RBinWasmCustomNameLocalNames *local;
 	};


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A Wasm "Name" is valid if it's utf-8, which can include NULL bytes and all kind of other crazy things. So to prevent r2 from choking on this later in tcc or something, I encode the names on entry. This means we don't have to keep the string length and we can decode them later on output if we want.

Encoder might be a bit overkill atm, I pretty much encode every WASM name into something that can be treated as a C var. I probably don't need to encode section names so strongly, for example I could let a section name start with a number or `.`. So maybe this is just a stop gap.

Feel free to ask for better encoding or accept for now.