### PR TITLE
Wasm iE improvment ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -1247,7 +1247,6 @@ RList *r_bin_wasm_get_elements(RBinWasmObj *bin) {
 
 RList *r_bin_wasm_get_codes(RBinWasmObj *bin) {
 	RBinWasmSection *code = NULL;
-	;
 	RList *codes = NULL;
 
 	if (!bin || !bin->g_sections) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This will cause `iE` to output something. It's still not all the way right, but it's progress:

After pull:
```
[0x00000207]> iE
[Exports]

nth paddr      vaddr      bind   type size lib name
―――――――――――――――――――――――――――――――――――――――――――――――――――
8   ---------- ---------- GLOBAL FUNC 0        _start
23  ---------- ---------- GLOBAL FUNC 0        __errno_location
19  ---------- ---------- GLOBAL FUNC 0        emscripten_stack_init
20  ---------- ---------- GLOBAL FUNC 0        emscripten_stack_get_free
21  ---------- ---------- GLOBAL FUNC 0        emscripten_stack_get_base
22  ---------- ---------- GLOBAL FUNC 0        emscripten_stack_get_end
16  ---------- ---------- GLOBAL FUNC 0        stackSave
17  ---------- ---------- GLOBAL FUNC 0        stackRestore
18  ---------- ---------- GLOBAL FUNC 0        stackAlloc
```
Before pull:
```
[0x00000207]> iE
[Exports]

nth paddr vaddr bind type size lib name
―――――――――――――――――――――――――――――――――――――――
```

I have a C program I compiled into wasm that is good for testing this stuff and I hope to add it to bins soon. I just need to overcome some silly things.