### PR TITLE
Fix #20206 - pthread_create: Resource temporarily unavailable

### DIFF
--- a/libr/lang/p/pipe.c
+++ b/libr/lang/p/pipe.c
@@ -234,7 +234,7 @@ static bool lang_pipe_run(RLang *lang, const char *code, int len) {
 		close (safe_in);
 	}
 #ifndef __wasi__
-	waitpid (child, NULL, WNOHANG);
+	waitpid (child, NULL, WUNTRACED);
 #endif
 	return true;
 #else


### PR DESCRIPTION
Fix error that appears when running a long session with esil.
https://github.com/radareorg/radare2/issues/20206

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
