### PR TITLE
Add initial BPF ELF relocs

### DIFF
--- a/libr/bin/format/elf/glibc_elf.h
+++ b/libr/bin/format/elf/glibc_elf.h
@@ -3964,6 +3964,10 @@ enum
 
 #define R_BPF_NONE		0	/* No reloc */
 #define R_BPF_64_64		1
+#define R_BPF_64_ABS64		2
+#define R_BPF_64_ABS32		3
+#define R_BPF_64_NODYLD32	4
+#define R_BPF_64_RELATIVE	8
 #define R_BPF_64_32		10
 
 /* Imagination Meta specific relocations. */

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -711,8 +711,19 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 		case R_PPC_GLOB_DAT:    ADD (32, 0);
 		case R_PPC_JMP_SLOT:    ADD (32, 0);
 		default:
-			eprintf ("unimplemented ELF/PPC reloc type %d\n", rel->type);
+			R_LOG_DEBUG ("unimplemented ELF/PPC reloc type %d", rel->type);
 		break;
+		}
+		break;
+	case EM_BPF: switch (rel->type) {
+		case R_BPF_NONE: break;
+		case R_BPF_64_64: r->vaddr += 4; ADD (32, 0); break;
+		case R_BPF_64_ABS64: ADD (64, 0); break;
+		case R_BPF_64_ABS32: ADD (32, 0); break;
+		case R_BPF_64_NODYLD32: ADD (32, 0); break;
+		default:
+			R_LOG_DEBUG ("unimplemented ELF/BPF reloc type %d", rel->type);
+			break;
 		}
 		break;
 	default:

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -612,114 +612,114 @@ static RBinReloc *reloc_convert(struct Elf_(r_bin_elf_obj_t) *bin, RBinElfReloc 
 	switch (bin->ehdr.e_machine) {
 	case EM_386: switch (rel->type) {
 		case R_386_NONE:     break; // malloc then free. meh. then again, there's no real world use for _NONE.
-		case R_386_32:       ADD(32, 0);
-		case R_386_PC32:     ADD(32,-(st64)P);
-		case R_386_GLOB_DAT: SET(32);
-		case R_386_JMP_SLOT: SET(32);
-		case R_386_RELATIVE: ADD(32, B);
-		case R_386_GOTOFF:   ADD(32, -(st64)got_addr);
-		case R_386_GOTPC:    ADD(32, got_addr - P);
-		case R_386_16:       ADD(16, 0);
-		case R_386_PC16:     ADD(16,-(st64)P);
-		case R_386_8:        ADD(8,  0);
-		case R_386_PC8:      ADD(8, -(st64)P);
-		case R_386_COPY:     ADD(32, 0); // XXX: copy symbol at runtime
+		case R_386_32:       ADD(32, 0); break;
+		case R_386_PC32:     ADD(32,-(st64)P); break;
+		case R_386_GLOB_DAT: SET(32); break;
+		case R_386_JMP_SLOT: SET(32); break;
+		case R_386_RELATIVE: ADD(32, B); break;
+		case R_386_GOTOFF:   ADD(32, -(st64)got_addr); break;
+		case R_386_GOTPC:    ADD(32, got_addr - P); break;
+		case R_386_16:       ADD(16, 0); break;
+		case R_386_PC16:     ADD(16,-(st64)P); break;
+		case R_386_8:        ADD(8,  0); break;
+		case R_386_PC8:      ADD(8, -(st64)P); break;
+		case R_386_COPY:     ADD(32, 0); break; // XXX: copy symbol at runtime
 		case R_386_IRELATIVE: r->is_ifunc = true; SET(32);
 		default: break;
 		}
 		break;
 	case EM_X86_64: switch (rel->type) {
-		case R_X86_64_NONE:	break; // malloc then free. meh. then again, there's no real world use for _NONE.
-		case R_X86_64_64:	ADD(64, 0);
-		case R_X86_64_PLT32:	ADD(32,-(st64)P /* +L */);
-		case R_X86_64_GOT32:	ADD(32, got_addr);
-		case R_X86_64_PC32:	ADD(32,-(st64)P);
-		case R_X86_64_GLOB_DAT: r->vaddr -= rel->sto; SET(64);
-		case R_X86_64_JUMP_SLOT: r->vaddr -= rel->sto; SET(64);
-		case R_X86_64_RELATIVE:	ADD(64, B);
-		case R_X86_64_32:	ADD(32, 0);
-		case R_X86_64_32S:	ADD(32, 0);
-		case R_X86_64_16:	ADD(16, 0);
-		case R_X86_64_PC16:	ADD(16,-(st64)P);
-		case R_X86_64_8:	ADD(8,  0);
-		case R_X86_64_PC8:	ADD(8, -(st64)P);
-		case R_X86_64_GOTPCREL:	ADD(64, got_addr - P);
-		case R_X86_64_COPY:	ADD(64, 0); // XXX: copy symbol at runtime
-		case R_X86_64_IRELATIVE: r->is_ifunc = true; SET(64);
+		case R_X86_64_NONE:      break; // malloc then free. meh. then again, there's no real world use for _NONE.
+		case R_X86_64_64:        ADD(64, 0); break;
+		case R_X86_64_PLT32:     ADD(32,-(st64)P /* +L */); break;
+		case R_X86_64_GOT32:     ADD(32, got_addr); break;
+		case R_X86_64_PC32:      ADD(32,-(st64)P); break;
+		case R_X86_64_GLOB_DAT:  r->vaddr -= rel->sto; SET(64); break;
+		case R_X86_64_JUMP_SLOT: r->vaddr -= rel->sto; SET(64); break;
+		case R_X86_64_RELATIVE:  ADD(64, B); break;
+		case R_X86_64_32:        ADD(32, 0); break;
+		case R_X86_64_32S:       ADD(32, 0); break;
+		case R_X86_64_16:        ADD(16, 0); break;
+		case R_X86_64_PC16:      ADD(16,-(st64)P); break;
+		case R_X86_64_8:         ADD(8,  0); break;
+		case R_X86_64_PC8:       ADD(8, -(st64)P); break;
+		case R_X86_64_GOTPCREL:  ADD(64, got_addr - P); break;
+		case R_X86_64_COPY:      ADD(64, 0); break; // XXX: copy symbol at runtime
+		case R_X86_64_IRELATIVE: r->is_ifunc = true; SET(64); break;
 		default: break;
 		}
 		break;
 	case EM_ARM:
 		switch (rel->type) {
-		case R_ARM_NONE:	break;
-		case R_ARM_ABS32:	ADD(32, 0);
-		case R_ARM_REL32:	ADD(32,-(st64)P);
-		case R_ARM_ABS16:	ADD(16, 0);
-		case R_ARM_ABS8:	ADD(8,  0);
-		case R_ARM_SBREL32:	ADD(32, -(st64)B);
-		case R_ARM_GLOB_DAT:	ADD(32, 0);
-		case R_ARM_JUMP_SLOT:	ADD(32, 0);
-		case R_ARM_COPY:       ADD(32, 0); // copy symbol at runtime
-		case R_ARM_RELATIVE:	ADD(32, B);
-		case R_ARM_GOTOFF:	ADD(32,-(st64)got_addr);
-		case R_ARM_GOTPC:      ADD(32, got_addr - P);
-		case R_ARM_CALL: ADD(24, -P);
-		case R_ARM_JUMP24: ADD(24, -P);
-		case R_ARM_THM_JUMP24: ADD(24, -P);
-		case R_ARM_PREL31: ADD(32, -P);
-		case R_ARM_MOVW_PREL_NC: ADD(16, -P);
-		case R_ARM_MOVT_PREL: ADD(32, -P);
-		case R_ARM_THM_MOVW_PREL_NC: ADD(16, -P);
-		case R_ARM_REL32_NOI: ADD(32, -P);
-		case R_ARM_ABS32_NOI: ADD(32, 0);
-		case R_ARM_ALU_PC_G0_NC: ADD(32, -P);
-		case R_ARM_ALU_PC_G0: ADD(32, -P);
-		case R_ARM_ALU_PC_G1_NC: ADD(32, -P);
-		case R_ARM_ALU_PC_G1: ADD(32, -P);
-		case R_ARM_ALU_PC_G2: ADD(32, -P);
-		case R_ARM_LDR_PC_G1: ADD(32, -P);
-		case R_ARM_LDR_PC_G2: ADD(32, -P);
-		case R_ARM_LDRS_PC_G0: ADD(32, -P);
-		case R_ARM_LDRS_PC_G1: ADD(32, -P);
-		case R_ARM_LDRS_PC_G2: ADD(32, -P);
-		case R_ARM_LDC_PC_G0: ADD(32, -P);
-		case R_ARM_LDC_PC_G1: ADD(32, -P);
-		case R_ARM_LDC_PC_G2: ADD(32, -P);
+		case R_ARM_NONE:             break;
+		case R_ARM_ABS32:            ADD(32, 0); break;
+		case R_ARM_REL32:            ADD(32,-(st64)P); break;
+		case R_ARM_ABS16:            ADD(16, 0); break;
+		case R_ARM_ABS8:             ADD(8,  0); break;
+		case R_ARM_SBREL32:          ADD(32, -(st64)B); break;
+		case R_ARM_GLOB_DAT:         ADD(32, 0); break;
+		case R_ARM_JUMP_SLOT:        ADD(32, 0); break;
+		case R_ARM_COPY:             ADD(32, 0); break; // copy symbol at runtime
+		case R_ARM_RELATIVE:         ADD(32, B); break;
+		case R_ARM_GOTOFF:           ADD(32,-(st64)got_addr); break;
+		case R_ARM_GOTPC:            ADD(32, got_addr - P); break;
+		case R_ARM_CALL:             ADD(24, -P); break;
+		case R_ARM_JUMP24:           ADD(24, -P); break;
+		case R_ARM_THM_JUMP24:       ADD(24, -P); break;
+		case R_ARM_PREL31:           ADD(32, -P); break;
+		case R_ARM_MOVW_PREL_NC:     ADD(16, -P); break;
+		case R_ARM_MOVT_PREL:        ADD(32, -P); break;
+		case R_ARM_THM_MOVW_PREL_NC: ADD(16, -P); break;
+		case R_ARM_REL32_NOI:        ADD(32, -P); break;
+		case R_ARM_ABS32_NOI:        ADD(32, 0); break;
+		case R_ARM_ALU_PC_G0_NC:     ADD(32, -P); break;
+		case R_ARM_ALU_PC_G0:        ADD(32, -P); break;
+		case R_ARM_ALU_PC_G1_NC:     ADD(32, -P); break;
+		case R_ARM_ALU_PC_G1:        ADD(32, -P); break;
+		case R_ARM_ALU_PC_G2:        ADD(32, -P); break;
+		case R_ARM_LDR_PC_G1:        ADD(32, -P); break;
+		case R_ARM_LDR_PC_G2:        ADD(32, -P); break;
+		case R_ARM_LDRS_PC_G0:       ADD(32, -P); break;
+		case R_ARM_LDRS_PC_G1:       ADD(32, -P); break;
+		case R_ARM_LDRS_PC_G2:       ADD(32, -P); break;
+		case R_ARM_LDC_PC_G0:        ADD(32, -P); break;
+		case R_ARM_LDC_PC_G1:        ADD(32, -P); break;
+		case R_ARM_LDC_PC_G2:        ADD(32, -P); break;
 		default: ADD(32, got_addr); break; // reg relocations
 		}
 		break;
 	case EM_RISCV:
 		switch (rel->type) {
-		case R_RISCV_NONE: break;
-		case R_RISCV_JUMP_SLOT: ADD(64, 0);
-		case R_RISCV_RELATIVE: ADD(64, B);
+		case R_RISCV_NONE:      break;
+		case R_RISCV_JUMP_SLOT: ADD(64, 0); break;
+		case R_RISCV_RELATIVE:  ADD(64, B); break;
 		default: ADD(64, got_addr); break; // reg relocations
 		}
 		break;
 	case EM_AARCH64: switch (rel->type) {
-		case R_AARCH64_NONE: break;
-		case R_AARCH64_ABS32: ADD (32, 0);
-		case R_AARCH64_ABS16: ADD (16, 0);
-		case R_AARCH64_GLOB_DAT: SET (64);
-		case R_AARCH64_JUMP_SLOT: SET (64);
-		case R_AARCH64_RELATIVE: ADD (64, B);
+		case R_AARCH64_NONE:      break;
+		case R_AARCH64_ABS32:     ADD (32, 0); break;
+		case R_AARCH64_ABS16:     ADD (16, 0); break;
+		case R_AARCH64_GLOB_DAT:  SET (64); break;
+		case R_AARCH64_JUMP_SLOT: SET (64); break;
+		case R_AARCH64_RELATIVE:  ADD (64, B); break;
 		default: break; // reg relocations
 		}
 		break;
 	case EM_PPC: switch (rel->type) {
-		case R_PPC_NONE:    	break;
-		case R_PPC_GLOB_DAT:    ADD (32, 0);
-		case R_PPC_JMP_SLOT:    ADD (32, 0);
+		case R_PPC_NONE:        break;
+		case R_PPC_GLOB_DAT:    ADD (32, 0); break;
+		case R_PPC_JMP_SLOT:    ADD (32, 0); break;
 		default:
 			R_LOG_DEBUG ("unimplemented ELF/PPC reloc type %d", rel->type);
 		break;
 		}
 		break;
 	case EM_BPF: switch (rel->type) {
-		case R_BPF_NONE: break;
-		case R_BPF_64_64: r->vaddr += 4; ADD (32, 0); break;
-		case R_BPF_64_ABS64: ADD (64, 0); break;
-		case R_BPF_64_ABS32: ADD (32, 0); break;
+		case R_BPF_NONE:        break;
+		case R_BPF_64_64:       r->vaddr += 4; ADD (32, 0); break;
+		case R_BPF_64_ABS64:    ADD (64, 0); break;
+		case R_BPF_64_ABS32:    ADD (32, 0); break;
 		case R_BPF_64_NODYLD32: ADD (32, 0); break;
 		default:
 			R_LOG_DEBUG ("unimplemented ELF/BPF reloc type %d", rel->type);

--- a/test/db/anal/bpf_64
+++ b/test/db/anal/bpf_64
@@ -119,3 +119,32 @@ esil: r9,16,r2,+,=[4]
 family: cpu
 EOF
 RUN
+
+NAME=pd 5
+FILE=bins/bpf/memo_v2.solana.so
+CMDS=pd 5
+EXPECT=<<EOF
+            ;-- entry0:
+            ;-- entrypoint:
+            0x000009b8      bf1200000000.  mov64 r2, r1
+            0x000009c0      bfa100000000.  mov64 r1, r10
+            0x000009c8      07010000d0ff.  add64 r1, 0xffffffd0
+            0x000009d0      851000000502.  call 0x205
+            0x000009d8      79a6d0ff0000.  ldxdw r6, [r10+0xffd0]
+EOF
+RUN
+
+NAME=is
+FILE=bins/bpf/memo_v2.solana.so
+CMDS=is
+EXPECT=<<EOF
+[Symbols]
+
+nth paddr      vaddr      bind   type   size lib name
+-----------------------------------------------------
+3   0x00000c48 0x00000c48 GLOBAL FUNC   328      custom_panic
+4   0x000009b8 0x000009b8 GLOBAL FUNC   328      entrypoint
+1   ---------- 0x00000000 GLOBAL NOTYPE 16       imp.abort
+2   ---------- 0x00000000 GLOBAL NOTYPE 16       imp.sol_log_
+EOF
+RUN


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [x] ~~I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)~~

**Description**

- Adds BPF relocation types
- Adds an attempt to implement said relocations

```
Enum  ELF Reloc Type     Description      BitSize  Offset        Calculation
0     R_BPF_NONE         None
1     R_BPF_64_64        ld_imm64 insn    32       r_offset + 4  S + A
2     R_BPF_64_ABS64     normal data      64       r_offset      S + A
3     R_BPF_64_ABS32     normal data      32       r_offset      S + A
4     R_BPF_64_NODYLD32  .BTF[.ext] data  32       r_offset      S + A
10    R_BPF_64_32        call insn        32       r_offset + 4  (S + A) / 8 - 1
```

Reference: https://www.kernel.org/doc/html/latest/bpf/llvm_reloc.html