### PR TITLE
Support building windbg plugin under mingw

### DIFF
--- a/libr/debug/p/debug_windbg.c
+++ b/libr/debug/p/debug_windbg.c
@@ -34,13 +34,13 @@ typedef struct { // Keep in sync with io_windbg.c
 	ULONG64 server;
 	ULONG64 processBase;
 	DWORD lastExecutionStatus;
-	PDEBUG_CLIENT5 dbgClient;
-	PDEBUG_CONTROL4 dbgCtrl;
-	PDEBUG_DATA_SPACES4 dbgData;
-	PDEBUG_REGISTERS2 dbgReg;
-	PDEBUG_SYSTEM_OBJECTS4 dbgSysObj;
-	PDEBUG_SYMBOLS3 dbgSymbols;
-	PDEBUG_ADVANCED3 dbgAdvanced;
+	PDEBUG_CLIENT4 dbgClient;
+	PDEBUG_CONTROL3 dbgCtrl;
+	PDEBUG_DATA_SPACES3 dbgData;
+	PDEBUG_REGISTERS dbgReg;
+	PDEBUG_SYSTEM_OBJECTS3 dbgSysObj;
+	PDEBUG_SYMBOLS2 dbgSymbols;
+	PDEBUG_ADVANCED dbgAdvanced;
 } DbgEngContext;
 
 static bool __is_target_kernel(DbgEngContext *idbg) {

--- a/libr/debug/p/debug_windbg.c
+++ b/libr/debug/p/debug_windbg.c
@@ -24,7 +24,9 @@
 
 #define TIMEOUT 500
 #define THISCALL(dbginterface, function, ...) dbginterface->lpVtbl->function (dbginterface, __VA_ARGS__)
+#define THISCALL0(dbginterface, function) dbginterface->lpVtbl->function (dbginterface)
 #define ITHISCALL(dbginterface, function, ...) THISCALL (idbg->dbginterface, function, __VA_ARGS__)
+#define ITHISCALL0(dbginterface, function) THISCALL0 (idbg->dbginterface, function)
 #define RELEASE(I) if (I) THISCALL (I, Release);
 
 typedef struct { // Keep in sync with io_windbg.c
@@ -489,7 +491,7 @@ static bool windbg_attach(RDebug *dbg, int pid) {
 static bool windbg_detach(RDebug *dbg, int pid) {
 	DbgEngContext *idbg = dbg->user;
 	r_return_val_if_fail (idbg && idbg->initialized, 0);
-	return SUCCEEDED (ITHISCALL (dbgClient, DetachProcesses));
+	return SUCCEEDED (ITHISCALL0 (dbgClient, DetachProcesses));
 }
 
 static bool windbg_kill(RDebug *dbg, int pid, int tid, int sig) {
@@ -510,7 +512,7 @@ static bool windbg_kill(RDebug *dbg, int pid, int tid, int sig) {
 		}
 		return exit_code == STILL_ACTIVE;
 	}
-	HRESULT hr = ITHISCALL (dbgClient, TerminateProcesses);
+	HRESULT hr = ITHISCALL0 (dbgClient, TerminateProcesses);
 	return SUCCEEDED (hr);
 }
 

--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -25,13 +25,13 @@ typedef struct { // Keep in sync with debug_windbg.c
 	ULONG64 server;
 	ULONG64 processBase;
 	DWORD lastExecutionStatus;
-	PDEBUG_CLIENT5 dbgClient;
-	PDEBUG_CONTROL4 dbgCtrl;
-	PDEBUG_DATA_SPACES4 dbgData;
-	PDEBUG_REGISTERS2 dbgReg;
-	PDEBUG_SYSTEM_OBJECTS4 dbgSysObj;
-	PDEBUG_SYMBOLS3 dbgSymbols;
-	PDEBUG_ADVANCED3 dbgAdvanced;
+	PDEBUG_CLIENT4 dbgClient;
+	PDEBUG_CONTROL3 dbgCtrl;
+	PDEBUG_DATA_SPACES3 dbgData;
+	PDEBUG_REGISTERS dbgReg;
+	PDEBUG_SYSTEM_OBJECTS3 dbgSysObj;
+	PDEBUG_SYMBOLS2 dbgSymbols;
+	PDEBUG_ADVANCED dbgAdvanced;
 } DbgEngContext;
 
 #define THISCALL(dbginterface, function, ...) dbginterface->lpVtbl->function (dbginterface, __VA_ARGS__)
@@ -272,25 +272,25 @@ static DbgEngContext *create_remote_context(const char *opts) {
 	LPWSTR wopts = (LPWSTR)r_utf8_to_utf16 (opts);
 
 	// Initialize interfaces
-	if (w32_DebugConnectWide (wopts, &IID_IDebugClient5, (PVOID *)&idbg->dbgClient) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugClient4, (PVOID *)&idbg->dbgClient) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugControl4, (PVOID *)&idbg->dbgCtrl) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugControl3, (PVOID *)&idbg->dbgCtrl) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugDataSpaces4, (PVOID *)&idbg->dbgData) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugDataSpaces3, (PVOID *)&idbg->dbgData) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugRegisters2, (PVOID *)&idbg->dbgReg) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugRegisters, (PVOID *)&idbg->dbgReg) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugSystemObjects4, (PVOID *)&idbg->dbgSysObj) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugSystemObjects3, (PVOID *)&idbg->dbgSysObj) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugAdvanced3, (PVOID *)&idbg->dbgAdvanced) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugAdvanced, (PVOID *)&idbg->dbgAdvanced) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugConnectWide (wopts, &IID_IDebugSymbols3, (PVOID *)&idbg->dbgSymbols) != S_OK) {
+	if (w32_DebugConnectWide (wopts, &IID_IDebugSymbols2, (PVOID *)&idbg->dbgSymbols) != S_OK) {
 		goto fail;
 	}
 	if (!init_callbacks (idbg)) {
@@ -311,25 +311,25 @@ static DbgEngContext *create_context(void) {
 	}
 
 	// Initialize interfaces
-	if (w32_DebugCreate (&IID_IDebugClient5, (PVOID *)&idbg->dbgClient) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugClient4, (PVOID *)&idbg->dbgClient) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugControl4, (PVOID *)&idbg->dbgCtrl) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugControl3, (PVOID *)&idbg->dbgCtrl) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugDataSpaces4, (PVOID *)&idbg->dbgData) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugDataSpaces3, (PVOID *)&idbg->dbgData) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugRegisters2, (PVOID *)&idbg->dbgReg) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugRegisters, (PVOID *)&idbg->dbgReg) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugSystemObjects4, (PVOID *)&idbg->dbgSysObj) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugSystemObjects3, (PVOID *)&idbg->dbgSysObj) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugAdvanced3, (PVOID *)&idbg->dbgAdvanced) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugAdvanced, (PVOID *)&idbg->dbgAdvanced) != S_OK) {
 		goto fail;
 	}
-	if (w32_DebugCreate (&IID_IDebugSymbols3, (PVOID *)&idbg->dbgSymbols) != S_OK) {
+	if (w32_DebugCreate (&IID_IDebugSymbols2, (PVOID *)&idbg->dbgSymbols) != S_OK) {
 		goto fail;
 	}
 	if (!init_callbacks (idbg)) {

--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -477,8 +477,6 @@ static RIODesc *windbg_open(RIO *io, const char *uri, int perm, int mode) {
 		case 'k':
 			if (!strcmp (opt.arg, "l")) {
 				target = TARGET_LOCAL_KERNEL;
-			} else if (!strcmp (opt.arg, "qm")) {
-				ITHISCALL (dbgCtrl, AddEngineOptions, DEBUG_ENGOPT_KD_QUIET_MODE);
 			} else {
 				target = TARGET_KERNEL;
 				args = opt.arg;

--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -466,7 +466,7 @@ static RIODesc *windbg_open(RIO *io, const char *uri, int perm, int mode) {
 			ITHISCALL (dbgCtrl, RemoveEngineOptions, DEBUG_ENGOPT_FINAL_BREAK);
 			break;
 		case 'h':
-			if (strcmp (opt.arg, "d")) {
+			if (!strcmp (opt.arg, "d")) {
 				spawn_options |= DEBUG_CREATE_PROCESS_NO_DEBUG_HEAP;
 			}
 			break;
@@ -475,9 +475,9 @@ static RIODesc *windbg_open(RIO *io, const char *uri, int perm, int mode) {
 			image_path_set = true;
 			break;
 		case 'k':
-			if (strcmp (opt.arg, "l")) {
+			if (!strcmp (opt.arg, "l")) {
 				target = TARGET_LOCAL_KERNEL;
-			} else if (strcmp (opt.arg, "qm")) {
+			} else if (!strcmp (opt.arg, "qm")) {
 				ITHISCALL (dbgCtrl, AddEngineOptions, DEBUG_ENGOPT_KD_QUIET_MODE);
 			} else {
 				target = TARGET_KERNEL;
@@ -493,11 +493,11 @@ static RIODesc *windbg_open(RIO *io, const char *uri, int perm, int mode) {
 				target = TARGET_LOCAL_ATTACH;
 				pid = atoi (opt.arg);
 			} else {
-				if (strcmp (opt.arg, "b")) {
+				if (!strcmp (opt.arg, "b")) {
 					attach_options |= DEBUG_ATTACH_INVASIVE_NO_INITIAL_BREAK;
-				} else if (strcmp (opt.arg, "e")) {
+				} else if (!strcmp (opt.arg, "e")) {
 					attach_options |= DEBUG_ATTACH_EXISTING;
-				} else if (strcmp (opt.arg, "v")) {
+				} else if (!strcmp (opt.arg, "v")) {
 					attach_options |= DEBUG_ATTACH_NONINVASIVE;
 				}
 			}


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

```
../libr/io/p/io_windbg.c:481:43: error: use of undeclared identifier 'DEBUG_ENGOPT_KD_QUIET_MODE'
                                ITHISCALL (dbgCtrl, AddEngineOptions, DEBUG_ENGOPT_KD_QUIET_MODE);

../libr/io/p/io_windbg.c:613:38: error: no member named 'GetValidRegionVirtual' in 'struct IDebugDataSpaces3Vtbl'
                if (SUCCEEDED (ITHISCALL (dbgData, GetValidRegionVirtual, io->off, count, &ValidBase, &ValidSize))) {
```

first is ~~probably fine to remove~~ gone now because it didn't work to begin with, second is more useful though