### PR TITLE
Optimize alias iteration to linear time and improve alias help

### DIFF
--- a/libr/include/r_cmd.h
+++ b/libr/include/r_cmd.h
@@ -285,7 +285,7 @@ R_API int r_cmd_macro_call(RCmdMacro *mac, const char *name);
 R_API int r_cmd_macro_break(RCmdMacro *mac, const char *value);
 
 R_API bool r_cmd_alias_del(RCmd *cmd, const char *k);
-R_API RList *r_cmd_alias_keys(RCmd *cmd);
+R_API const char **r_cmd_alias_keys(RCmd *cmd);
 R_API int r_cmd_alias_set_cmd(RCmd *cmd, const char *k, const char *v);
 R_API int r_cmd_alias_set_str(RCmd *cmd, const char *k, const char *v);
 R_API int r_cmd_alias_set_raw(RCmd *cmd, const char *k, const ut8 *v, int sz);


### PR DESCRIPTION
This optimizes alias iteration for autocompletion purposes. Previously, RList was used to easily pass a user pointer into the functional style of ht_pp_foreach() as opposed to the iterative style of e.g. r_list_foreach(). Now, special structs are used to store state during iteration. Since these use single contiguous chunks of memory, they operate much faster.

Additionally, we no longer use r_cmd_alias_get() for potential matches, instead storing both keys and values for potential completions, removing another hashtable lookup and cementing linear time operation.

Alias help has also been slightly edited for accuracy and informativeness.

This also fixes a bug that caused autocompletion to not include data aliases despite them being valid for use in commands. e.g. `> $t<tab>` did not include `$test1=$string data`, but did include `$test2=pd`. They are now both correctly included.