### PR TITLE
Set correct CPU in DOL bin loader

### DIFF
--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -160,6 +160,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->arch = strdup ("ppc");
 	ret->has_va = true;
 	ret->bits = 32;
+	ret->cpu = "ps";
 
 	return ret;
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] ~~I've added tests (optional)~~
- [x] ~~I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)~~

**Description**

The DOL file format is exclusively used with GameCube / Wii machines.
Both of those use the PowerPC 750CL instruction set, which ships the paired-singles CPU extension.
Radare2 incorrectly defaults to the altivec CPU type when loading a DOL binary with `r2 -F dol ./main.dol`, which garbles assembly.

This fix was tested with RMCP01 ROM at `0x80199fc8` (PSMTXInverse).