### PR TITLE
Add Z registers

### DIFF
--- a/libr/anal/p/anal_arm_regprofile.inc
+++ b/libr/anal/p/anal_arm_regprofile.inc
@@ -439,6 +439,42 @@ static char *get_reg_profile(RAnal *anal) {
 		"fpu	q30h	.64	776	0\n"
 		"fpu	q31h	.64	792	0\n"
 		
+		/* scalable vector registers */
+		// these can be more than 128 bit
+		// adding mostly to stop ESIL errors
+		"fpu	z0	.128	288	0\n"
+		"fpu	z1	.128	304	0\n"
+		"fpu	z2	.128	320	0\n"
+		"fpu	z3	.128	336	0\n"
+		"fpu	z4	.128	352	0\n"
+		"fpu	z5	.128	368	0\n"
+		"fpu	z6	.128	384	0\n"
+		"fpu	z7	.128	400	0\n"
+		"fpu	z8	.128	416	0\n"
+		"fpu	z9	.128	432	0\n"
+		"fpu	z10	.128	448	0\n"
+		"fpu	z11	.128	464	0\n"
+		"fpu	z12	.128	480	0\n"
+		"fpu	z13	.128	496	0\n"
+		"fpu	z14	.128	512	0\n"
+		"fpu	z15	.128	528	0\n"
+		"fpu	z16	.128	544	0\n"
+		"fpu	z17	.128	560	0\n"
+		"fpu	z18	.128	576	0\n"
+		"fpu	z19	.128	592	0\n"
+		"fpu	z20	.128	608	0\n"
+		"fpu	z21	.128	624	0\n"
+		"fpu	z22	.128	640	0\n"
+		"fpu	z23	.128	656	0\n"
+		"fpu	z24	.128	672	0\n"
+		"fpu	z25	.128	688	0\n"
+		"fpu	z26	.128	704	0\n"
+		"fpu	z27	.128	720	0\n"
+		"fpu	z28	.128	736	0\n"
+		"fpu	z29	.128	752	0\n"
+		"fpu	z30	.128	768	0\n"
+		"fpu	z31	.128	784	0\n"
+
 		/*  foo */
 		"gpr	fp	.64	232	0\n" // fp = x29
 		"gpr	lr	.64	240	0\n" // lr = x30


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds the z0-31 registers to the register profile. They are newer scalable registers but share the bottom 128 bits with the v0-31 regs so for right now I just identify the two. 

<!-- explain your changes if necessary -->
