### PR TITLE
Wasm allow partial custom name parsing ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -653,6 +653,7 @@ static RBinWasmCustomNameEntry *parse_custom_name_entry(RBuffer *b, ut64 bound) 
 	}
 	cust->type = R_BIN_WASM_NAMETYPE_None;
 
+	size_t start = r_buf_tell (b);
 	if (!consume_u7_r (b, bound, &cust->type)) {
 		goto beach;
 	};
@@ -687,6 +688,10 @@ static RBinWasmCustomNameEntry *parse_custom_name_entry(RBuffer *b, ut64 bound) 
 			goto beach;
 		}
 		break;
+	default:
+		eprintf ("[wasm] Halting custom name section parsing at unknown type 0x%x offset 0x%" PFMT64x "\n", cust->type, start);
+		cust->type = R_BIN_WASM_NAMETYPE_None;
+		goto beach;
 	}
 
 	return cust;
@@ -847,7 +852,7 @@ static RList *r_bin_wasm_get_custom_name_entries(RBinWasmObj *bin, RBinWasmSecti
 		RBinWasmCustomNameEntry *nam = parse_custom_name_entry (buf, bound);
 
 		if (!nam) {
-			goto beach;
+			break; // allow partial parsing of section
 		}
 
 		if (!r_list_append (ret, nam)) {

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -82,3 +82,31 @@ nth paddr        size vaddr       vsize perm name
 
 EOF
 RUN
+
+NAME=WASM: Functions are renamed from custom name section
+FILE=bins/wasm/sections.wasm
+CMDS=aa;afl
+EXPECT=<<EOF
+0x00000207    1 3            entry0
+0x0000053d    1 4            sym.__errno_location_1
+0x0000023d    3 209          sym.main
+0x00000415    6 148          sym.__main_void
+0x000004ab    1 3            sym.__original_main
+0x000004df    1 12           sym.exit
+0x000004f5    1 3            sym.stackSave_1
+0x000004fa    1 5            sym.stackRestore_1
+0x00000516    1 19           sym.emscripten_stack_init_1
+0x0000032d    1 126          sym.atoi_via_import
+0x000003b9    1 54           sym.static_int_sum
+0x000003f3    3 14           fcn.000003f3
+0x000003f1    1 2            sym._start_1
+0x000004ed    1 6            sym._Exit
+0x00000505    1 15           sym.stackAlloc_1
+0x00000403    1 7            sym.main_2e_1
+0x000004b0    1 1            sym.dummy
+0x000004b5    3 40           sym.libc_exit_fini
+0x0000052b    1 6            sym.emscripten_stack_get_free_1
+0x00000533    1 3            sym.emscripten_stack_get_base_1
+0x00000538    1 3            sym.emscripten_stack_get_end_1
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Wasm *Custom Sections* can include a *Name* section which will store debugging information, such as plain text names of functions. I only see 3 sub-section types ([found here](https://webassembly.github.io/spec/core/appendix/custom.html#subsections)). But it seems `sections.wasm` in test bins has more subsection types. When the r2 parser hits these sections, it does not give up, instead it goes off the rails and eventually finds a error in the file and drops all the properly parsed section information.

This pull updates r2 to quickly give up when hitting an unknown sub-section type, but keep the information that was properly parsed. This means most the function names in `section.wasm` can be discovered and named.