### PR TITLE
Fix #20248 - DoubleFree in RCons.pop() triggered via RCore.cmdStr() #…

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3511,7 +3511,7 @@ R_API int r_core_prompt_exec(RCore *r) {
 		if (!cmd) {
 			break;
 		}
-		ret = r_core_cmd (r, cmd, true);
+		ret = r_core_cmd (r, cmd, true); // initial free
 		free (cmd);
 		if (ret < 0) {
 			if (r->cons && r->cons->line && r->cons->line->zerosep) {
@@ -3528,7 +3528,7 @@ R_API int r_core_prompt_exec(RCore *r) {
 			r->cons->context->use_tts = false;
 		}
 		r_cons_echo (NULL);
-		r_cons_flush ();
+		r_cons_flush (); // double free
 		if (r->cons && r->cons->line && r->cons->line->zerosep) {
 			r_cons_zero ();
 		}


### PR DESCRIPTION
…#crash

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
