### PR TITLE
Refactor wasm function types ##bin

### DIFF
--- a/libr/anal/arch/wasm/wasm.c
+++ b/libr/anal/arch/wasm/wasm.c
@@ -629,8 +629,8 @@ R_IPI int wasm_dis(WasmOp *op, const unsigned char *buf, int buf_len) {
 				if (!(n > 0 && n < buf_len)) {
 					goto err;
 				}
-				switch (0x80 - val) {
-				case R_BIN_WASM_VALUETYPE_EMPTY:
+				switch (val) {
+				case R_BIN_WASM_VALUETYPE_VOID:
 					r_strbuf_set (sb, opdef->txt);
 					break;
 				case R_BIN_WASM_VALUETYPE_i32:

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -253,7 +253,7 @@ const char *r_bin_wasm_valuetype_to_string (r_bin_wasm_value_type_t type) {
 		return "f32";
 	case R_BIN_WASM_VALUETYPE_f64:
 		return "f64";
-	case R_BIN_WASM_VALUETYPE_ANYFUNC:
+	case R_BIN_WASM_VALUETYPE_REFTYPE:
 		return "ANYFUNC";
 	case R_BIN_WASM_VALUETYPE_FUNC:
 		return "FUNC";

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -14,7 +14,6 @@
 #define R_BIN_WASM_MAGIC_BYTES "\x00" \
 			       "asm"
 #define R_BIN_WASM_VERSION 0x1
-#define R_BIN_WASM_STRING_LENGTH 256
 #define R_BIN_WASM_END_OF_CODE 0xb
 
 #define R_BIN_WASM_SECTION_CUSTOM 0x0
@@ -84,13 +83,18 @@ typedef struct r_bin_wasm_section_t {
 	ut32 count;
 } RBinWasmSection;
 
+typedef struct r_bin_wasm_type_vector_t {
+	ut32 count;
+	ut8 *types;
+} RBinWasmTypeVec;
+
 typedef struct r_bin_wasm_type_t {
+	size_t file_offset;
+	ut32 index;
 	ut8 form;
-	ut32 param_count;
-	r_bin_wasm_value_type_t *param_types;
-	st8 return_count; // MVP = 1
-	r_bin_wasm_value_type_t return_type;
-	char to_str[R_BIN_WASM_STRING_LENGTH];
+	RBinWasmTypeVec *args;
+	RBinWasmTypeVec *rets;
+	char *to_str;
 } RBinWasmTypeEntry;
 
 // Other Types
@@ -224,8 +228,8 @@ typedef struct r_bin_wasm_obj_t {
 	ut32 entrypoint;
 
 	// cache purposes
+	RPVector *g_types;
 	RList *g_sections;
-	RList *g_types;
 	RList *g_imports;
 	RList *g_exports;
 	RList *g_tables;
@@ -244,7 +248,7 @@ typedef struct r_bin_wasm_obj_t {
 RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf);
 void r_bin_wasm_destroy(RBinFile *bf);
 RList *r_bin_wasm_get_sections(RBinWasmObj *bin);
-RList *r_bin_wasm_get_types(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_types(RBinWasmObj *bin);
 RList *r_bin_wasm_get_imports(RBinWasmObj *bin);
 RList *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RList *r_bin_wasm_get_tables(RBinWasmObj *bin);

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -30,15 +30,22 @@
 #define R_BIN_WASM_SECTION_CODE 0xa
 #define R_BIN_WASM_SECTION_DATA 0xb
 
+/*
+ * Value types From:
+ * https://webassembly.github.io/spec/core/binary/types.html#value-types,
+ * https://webassembly.github.io/spec/core/binary/types.html#binary-numtype
+ * https://github.com/sunfishcode/wasm-reference-manual/blob/master/WebAssembly.md#type-encoding-type
+ */
 typedef enum {
-	R_BIN_WASM_VALUETYPE_i32 = 0x1,
-	R_BIN_WASM_VALUETYPE_i64 = 0x2,
-	R_BIN_WASM_VALUETYPE_f32 = 0x3,
-	R_BIN_WASM_VALUETYPE_f64 = 0x4,
-	R_BIN_WASM_VALUETYPE_v128 = 0x5,
-	R_BIN_WASM_VALUETYPE_ANYFUNC = 0x10,
-	R_BIN_WASM_VALUETYPE_FUNC = 0x20,
-	R_BIN_WASM_VALUETYPE_EMPTY = 0x40,
+	R_BIN_WASM_VALUETYPE_i32 = 0x7f,
+	R_BIN_WASM_VALUETYPE_i64 = 0x7e,
+	R_BIN_WASM_VALUETYPE_f32 = 0x7d,
+	R_BIN_WASM_VALUETYPE_f64 = 0x7c,
+	R_BIN_WASM_VALUETYPE_v128 = 0x7b,
+	R_BIN_WASM_VALUETYPE_REFTYPE = 0x70,
+	R_BIN_WASM_VALUETYPE_EXTERNREF = 0x6f,
+	R_BIN_WASM_VALUETYPE_FUNC = 0x60,
+	R_BIN_WASM_VALUETYPE_VOID = 0x40,
 } r_bin_wasm_value_type_t;
 
 typedef enum {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Every wasm function should have a function type associated to it, by an index number, in the types section.

This pull updates the types to be stored in a RPVector so they can be referenced by index without traversing a double linked list. Additionally, this updates the code to accept types that contain multiple returns (see [this](https://hacks.mozilla.org/2019/11/multi-value-all-the-wasm/) for info).

Types are parsed but not used by anything yet, so I could not add any tests yet. I had a debug function in the code to loop over the types and print them, the printing did match output of `wasm-objdump`.

I would like to get type info associated to functions soon, but I am unsure of how to do that. Especially for functions that return multiple items.