### PR TITLE
Fix ELF default arch of x86 ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2183,7 +2183,7 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 		return strdup ("loongarch");
 	case EM_386:
 	case EM_X86_64:
-		return strdup("x86");
+		return strdup ("x86");
 	case EM_NONE:
 		return strdup ("null");
 	default: return strdup ("Unknown or unsupported arch");

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2185,7 +2185,7 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 	case EM_X86_64:
 		return strdup("x86");
 	case EM_NONE:
-		return strdup("No machine");
+		return strdup ("null");
 	default: return strdup ("Unknown or unsupported arch");
 	}
 }

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2181,7 +2181,12 @@ char* Elf_(r_bin_elf_get_arch)(ELFOBJ *bin) {
 		return strdup("kvx");
 	case EM_LOONGARCH:
 		return strdup ("loongarch");
-	default: return strdup ("x86");
+	case EM_386:
+	case EM_X86_64:
+		return strdup("x86");
+	case EM_NONE:
+		return strdup("No machine");
+	default: return strdup ("Unknown or unsupported arch");
 	}
 }
 char* Elf_(r_bin_elf_get_abi)(ELFOBJ *bin) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The ELF plugin currently defaults to returning an arch of x86 as a default, which is undesirable when `e_machine` is set to `EM_NONE` or the architecture is one that isn't explicitly supported. This change removes the current x86 default in favor of reporting "No machine" for `EM_NONE`, and "Unknown or unsupported arch" when `e_machine` is specified but isn't a known value. 

I tested this by running `rabin2 -I` with 32 and 64-bit x86 ELF files, an ARM ELF, a BPF ELF, and a firmware ELF that has`e_machine` set to `EM_NONE`. This change appears to have the intended effect based on those tests.
