### PR TITLE
Fix BPF archinfo

### DIFF
--- a/libr/anal/p/anal_bpf.c
+++ b/libr/anal/p/anal_bpf.c
@@ -1231,16 +1231,21 @@ static int esil_bpf_fini(RAnalEsil *esil) {
 */
 
 static int archinfo(RAnal *anal, int q) {
-	const int bits = anal->config->bits;
 	switch (q) {
+	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
+		return 8;
+	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
+		return 8;
+	case R_ANAL_ARCHINFO_INV_OP_SIZE:
+		return 8;
 	case R_ANAL_ARCHINFO_ALIGN:
+		return 8;
 	case R_ANAL_ARCHINFO_DATA_ALIGN:
 		return 1;
 	}
-	//case R_ANAL_ARCHINFO_MAX_OP_SIZE:
-	//case R_ANAL_ARCHINFO_MIN_OP_SIZE:
-	return (bits == 64)? 8: 4;
+	return 0;
 }
+
 RAnalPlugin r_anal_plugin_bpf = {
 	.name = "bpf.mr",
 	.desc = "Berkely packet filter analysis plugin",

--- a/libr/anal/p/anal_bpf_cs.c
+++ b/libr/anal/p/anal_bpf_cs.c
@@ -626,13 +626,18 @@ static bool set_reg_profile(RAnal *anal) {
 static int archinfo(RAnal *anal, int q) {
 	const int bits = anal->config->bits;
 	switch (q) {
+	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
+		return 8;
+	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
+		return (bits == 64)? 16: 8;
+	case R_ANAL_ARCHINFO_INV_OP_SIZE:
+		return 8;
 	case R_ANAL_ARCHINFO_ALIGN:
+		return 8;
 	case R_ANAL_ARCHINFO_DATA_ALIGN:
 		return 1;
 	}
-	//case R_ANAL_ARCHINFO_MAX_OP_SIZE:
-	//case R_ANAL_ARCHINFO_MIN_OP_SIZE:
-	return (bits == 64)? 8: 4;
+	return 0;
 }
 
 RAnalPlugin r_anal_plugin_bpf_cs = {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The archinfo for bpf and bpf.cs is a bit off.

- `R_ANAL_ARCHINFO_MIN_OP_SIZE = 8`, `R_ANAL_ARCHINFO_INV_OP_SIZE = 8`: cBPF and eBPF instructions are 8 bytes long. 
- `R_ANAL_ARCHINFO_MAX_OP_SIZE = 16`: eBPF has a special opcode (`lddw reg, imm`) that fuses two ins into one.
- `R_ANAL_ARCHINFO_ALIGN = 8`: Instructions are 8 byte aligned
- `R_ANAL_ARCHINFO_DATA_ALIGN = 1`: Alignment checks on data are not mandatory