### PR TITLE
Set data alignment of m68k CPUs

### DIFF
--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -797,6 +797,13 @@ static int archinfo(RAnal *anal, int q) {
 		return 2;
 	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
 		return 2;
+	case R_ANAL_ARCHINFO_DATA_ALIGN:
+		const char *cpu = anal->config->cpu;
+		if (strstr (cpu, "68030") || strstr (cpu, "68040") || strstr (cpu, "68060")) {
+			return 1;
+		} else {
+			return 2;
+		}
 	}
 	return 2;
 }

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -798,11 +798,12 @@ static int archinfo(RAnal *anal, int q) {
 	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
 		return 2;
 	case R_ANAL_ARCHINFO_DATA_ALIGN:
+		{
 		const char *cpu = anal->config->cpu;
 		if (strstr (cpu, "68030") || strstr (cpu, "68040") || strstr (cpu, "68060")) {
 			return 1;
-		} else {
-			return 2;
+		}
+		return 2;
 		}
 	}
 	return 2;


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Closes #20102

Correctly report `R_ANAL_ARCHINFO_DATA_ALIGN` for CPU types 68030, 68040, 68060.
The bug report mentions additional CPUs but these are not in the list of radare's supported m68k CPUs.
