### PR TITLE
Remove TCC TLS

### DIFF
--- a/libr/parse/c/libtcc.c
+++ b/libr/parse/c/libtcc.c
@@ -20,13 +20,6 @@
 #include <r_util.h>
 #include "tcc.h"
 
-/********************************************************/
-/* global variables */
-/* XXX: get rid of this ASAP */
-ST_DATA R_TH_LOCAL RPVector *tcc_typedefs;
-
-/********************************************************/
-
 #ifdef __WINDOWS__
 // GCC appears to use '/' for relative paths and '\\' for absolute paths on Windows
 static char *normalize_slashes(char *path) {
@@ -294,22 +287,22 @@ static int tcc_compile(TCCState *s1) {
 	s1->funcname = "";
 
 	/* define some often used types */
-	int8_type.t = VT_INT8;
-	int16_type.t = VT_INT16;
-	int32_type.t = VT_INT32;
-	int64_type.t = VT_INT64;
+	s1->int8_type.t = VT_INT8;
+	s1->int16_type.t = VT_INT16;
+	s1->int32_type.t = VT_INT32;
+	s1->int64_type.t = VT_INT64;
 
-	char_pointer_type.t = VT_INT8;
-	mk_pointer (s1, &char_pointer_type);
+	s1->char_pointer_type.t = VT_INT8;
+	mk_pointer (s1, &s1->char_pointer_type);
 
 	if (s1->bits != 64) {
-		size_type.t = VT_INT32;
+		s1->size_type.t = VT_INT32;
 	} else {
-		size_type.t = VT_INT64;
+		s1->size_type.t = VT_INT64;
 	}
 
-	func_old_type.t = VT_FUNC;
-	func_old_type.ref = sym_push (s1, SYM_FIELD, &int32_type, FUNC_CDECL, FUNC_OLD);
+	s1->func_old_type.t = VT_FUNC;
+	s1->func_old_type.ref = sym_push (s1, SYM_FIELD, &s1->int32_type, FUNC_CDECL, FUNC_OLD);
 
 // FIXME: Should depend on the target options too
 #ifdef TCC_TARGET_ARM
@@ -669,49 +662,47 @@ typedef struct FlagDef {
 	const char *name;
 } FlagDef;
 
-void (*tcc_cb)(const char *, char **) = NULL;
-
 PUB_FUNC void tcc_set_callback(TCCState *s, void (*cb)(const char *, char **), char **p) {
 	if (cb) {
-		tcc_cb = cb;
-		tcc_cb_ptr = p;
+		s->cb = cb;
+		s->cb_user_data = p;
 		tcc_init_defines (s);
 	}
 }
 
-PUB_FUNC void tcc_appendf(const char *fmt, ...) {
+PUB_FUNC void tcc_appendf(TCCState *s, const char *fmt, ...) {
 	char b[1024];
 	va_list ap;
 	va_start (ap, fmt);
 	vsnprintf (b, sizeof (b), fmt, ap);
-	if (tcc_cb) {
-		tcc_cb (b, tcc_cb_ptr);
+	if (s->cb) {
+		s->cb (b, s->cb_user_data);
 	} else {
 		// eprintf ("Missing callback for tcc_cb\n");
 	}
 	va_end (ap);
 }
 
-PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...) {
-	if (!tcc_typedefs) {
-		tcc_typedefs = r_pvector_new ((RPVectorFree) free);
+PUB_FUNC void tcc_typedef_appendf(TCCState *s, const char *fmt, ...) {
+	if (!s->typedefs) {
+		s->typedefs = r_pvector_new ((RPVectorFree) free);
 	}
 	char typedefs_tail[1024];
 	va_list ap;
 	va_start (ap, fmt);
 	if (vsnprintf (typedefs_tail, sizeof (typedefs_tail), fmt, ap) > 0) {
-		r_pvector_push (tcc_typedefs, strdup (typedefs_tail));
+		r_pvector_push (s->typedefs, strdup (typedefs_tail));
 	} // XXX else? how this should behave if sizeof (typedefs_tail) is not enough?
 	va_end (ap);
 }
 
-PUB_FUNC void tcc_typedef_alias_fields(const char *alias) {
-	if (tcc_typedefs) {
+PUB_FUNC void tcc_typedef_alias_fields(TCCState *s, const char *alias) {
+	if (s->typedefs) {
 		void **it;
-		r_pvector_foreach (tcc_typedefs, it) {
-			tcc_appendf (*it, alias);
+		r_pvector_foreach (s->typedefs, it) {
+			tcc_appendf (s, *it, alias);
 		}
-		r_pvector_free (tcc_typedefs);
-		tcc_typedefs = NULL;
+		r_pvector_free (s->typedefs);
+		s->typedefs = NULL;
 	}
 }

--- a/libr/parse/c/tcc.h
+++ b/libr/parse/c/tcc.h
@@ -393,6 +393,18 @@ anon_sym: anonymous symbol index
 	const char *global_type;
 	const char *global_symname;
 
+	RPVector *typedefs;
+
+	// callback for appendf
+	void (*cb)(const char *, char **);
+	char **cb_user_data;
+
+	char decl_kind[1024];
+
+	// used to store current token information in the preprocessor
+	char tok_buf[STRING_MAX_SIZE + 1];
+	CString tok_cstr_buf;
+
 	Sym *global_stack;
 	Sym *local_stack;
 	Sym *define_stack;
@@ -720,7 +732,6 @@ static inline int toup(int c) {
 #define ST_INLN
 #define ST_FUNC
 #define ST_DATA extern
-extern char **tcc_cb_ptr;
 #endif
 
 /* ------------ libtcc.c ------------ */
@@ -834,9 +845,9 @@ ST_FUNC long long expr_const(TCCState *s1);
 #define ST_DATA
 #endif
 /********************************************************/
-PUB_FUNC void tcc_appendf(const char *fmt, ...);
-PUB_FUNC void tcc_typedef_appendf(const char *fmt, ...);
-PUB_FUNC void tcc_typedef_alias_fields(const char *alias);
+PUB_FUNC void tcc_appendf(TCCState *s, const char *fmt, ...);
+PUB_FUNC void tcc_typedef_appendf(TCCState *s, const char *fmt, ...);
+PUB_FUNC void tcc_typedef_alias_fields(TCCState *s, const char *alias);
 
 extern void (*tcc_cb)(const char *, char **);
 

--- a/libr/parse/c/tccgen.c
+++ b/libr/parse/c/tccgen.c
@@ -25,12 +25,6 @@
 	return;								\
 } while (0)
 
-/* callback pointer */
-ST_DATA R_TH_LOCAL char **tcc_cb_ptr;
-// globals that must be moved into TCCState
-ST_DATA R_TH_LOCAL CType char_pointer_type, func_old_type;
-ST_DATA R_TH_LOCAL CType int8_type, int16_type, int32_type, int64_type, size_type;
-
 /* ------------------------------------------------------------------------- */
 static inline CType *pointed_type(CType *type);
 static bool is_compatible_types(CType *type1, CType *type2);
@@ -371,7 +365,7 @@ void vpush(TCCState *s1, CType *type) {
 ST_FUNC void vpushi(TCCState *s1, int v) {
 	CValue cval = {0};
 	cval.i = v;
-	vsetc (s1, &int32_type, VT_CONST, &cval);
+	vsetc (s1, &s1->int32_type, VT_CONST, &cval);
 }
 
 /* push a pointer sized constant */
@@ -382,7 +376,7 @@ static void vpushs(TCCState *s1, long long v) {
 	} else {
 		cval.ull = v;
 	}
-	vsetc (s1, &size_type, VT_CONST, &cval);
+	vsetc (s1, &s1->size_type, VT_CONST, &cval);
 }
 
 /* push arbitrary 64 bit constant */
@@ -399,7 +393,7 @@ void vpush64(TCCState *s1, int ty, unsigned long long v) {
 ST_FUNC void vpushll(TCCState *s1, long long v) {
 	CValue cval;
 	cval.ll = v;
-	vsetc (s1, &int64_type, VT_CONST, &cval);
+	vsetc (s1, &s1->int64_type, VT_CONST, &cval);
 }
 
 ST_FUNC void vset(TCCState *s1, CType *type, int r, int v) {
@@ -982,15 +976,15 @@ do_decl:
 				// TODO: use is_typedef here
 				if (strcmp (name, "{")) {
 					const char *varstr = get_tok_str (s1, v, NULL);
-					tcc_appendf ("%s=enum\n", name);
-					tcc_appendf ("[+]enum.%s=%s\n", name, varstr);
-					tcc_appendf ("enum.%s.%s=0x%"PFMT64x "\n", name, varstr, iota);
-					tcc_appendf ("enum.%s.0x%"PFMT64x "=%s\n", name, iota, varstr);
+					tcc_appendf (s1, "%s=enum\n", name);
+					tcc_appendf (s1, "[+]enum.%s=%s\n", name, varstr);
+					tcc_appendf (s1, "enum.%s.%s=0x%"PFMT64x "\n", name, varstr, iota);
+					tcc_appendf (s1, "enum.%s.0x%"PFMT64x "=%s\n", name, iota, varstr);
 					// TODO: if token already defined throw an error
 					// if (varstr isInside (arrayOfvars)) { erprintf ("ERROR: DUP VAR IN ENUM\n"); }
 				}
 				/* enum symbols have static storage */
-				ss = sym_push (s1, v, &int64_type, VT_CONST, iota);
+				ss = sym_push (s1, v, &s1->int64_type, VT_CONST, iota);
 				if (!ss) {
 					return;
 				}
@@ -1015,7 +1009,7 @@ do_decl:
 
 			const char *ctype = (a == TOK_UNION)? "union": "struct";
 			if (!is_typedef || !autonamed) {
-				tcc_appendf ("%s=%s\n", name, ctype);
+				tcc_appendf (s1, "%s=%s\n", name, ctype);
 			}
 
 			while (s1->tok != '}') {
@@ -1137,16 +1131,16 @@ do_decl:
 							int type_bt = type1.t & VT_BTYPE;
 							//eprintf("2: %s.%s = %s\n", ctype, name, varstr);
 							if (is_typedef && autonamed) {
-								tcc_typedef_appendf ("[+]typedef.%%s.fields=%s\n", varstr);
-								tcc_typedef_appendf ("typedef.%%s.%s.meta=%d\n", varstr, type_bt);
-								tcc_typedef_appendf ("typedef.%%s.%s=%s,%d,%d\n", varstr, b, offset, (int)s1->arraysize);
+								tcc_typedef_appendf (s1, "[+]typedef.%%s.fields=%s\n", varstr);
+								tcc_typedef_appendf (s1, "typedef.%%s.%s.meta=%d\n", varstr, type_bt);
+								tcc_typedef_appendf (s1, "typedef.%%s.%s=%s,%d,%d\n", varstr, b, offset, (int)s1->arraysize);
 							} else {
-								tcc_appendf ("[+]%s.%s=%s\n",
+								tcc_appendf (s1, "[+]%s.%s=%s\n",
 									ctype, name, varstr);
-								tcc_appendf ("%s.%s.%s.meta=%d\n",
+								tcc_appendf (s1, "%s.%s.%s.meta=%d\n",
 									ctype, name, varstr, type_bt);
 								/* compact form */
-								tcc_appendf ("%s.%s.%s=%s,%d,%d\n",
+								tcc_appendf (s1, "%s.%s.%s=%s,%d,%d\n",
 									ctype, name, varstr, b, offset, (int)s1->arraysize);
 							}
 #if 0
@@ -1157,9 +1151,9 @@ do_decl:
 							// (%s) field (%s) offset=%d array=%d", name, b, get_tok_str(v, NULL), offset, arraysize);
 							s1->arraysize = 0;
 							if (type1.t & VT_BITFIELD) {
-								tcc_appendf ("%s.%s.%s.bitfield.pos=%d\n",
+								tcc_appendf (s1, "%s.%s.%s.bitfield.pos=%d\n",
 									ctype, name, varstr, (type1.t >> VT_STRUCT_SHIFT) & 0x3f);
-								tcc_appendf ("%s.%s.%s.bitfield.size=%d\n",
+								tcc_appendf (s1, "%s.%s.%s.bitfield.size=%d\n",
 									ctype, name, varstr, (type1.t >> (VT_STRUCT_SHIFT + 6)) & 0x3f);
 							}
 							// printf("\n");
@@ -1496,9 +1490,9 @@ static void post_type(TCCState *s1, CType *type, AttributeDef *ad) {
 			const char *ret_type = s1->global_type;
 			free (symname);
 			symname = strdup (s1->global_symname);
-			tcc_appendf ("func.%s.ret=%s\n", symname, ret_type);
-			tcc_appendf ("func.%s.cc=%s\n", symname, "cdecl");	// TODO
-			tcc_appendf ("%s=func\n", symname);
+			tcc_appendf (s1, "func.%s.ret=%s\n", symname, ret_type);
+			tcc_appendf (s1, "func.%s.cc=%s\n", symname, "cdecl");	// TODO
+			tcc_appendf (s1, "%s=func\n", symname);
 		}
 		arg_size = 0;
 		if (s1->tok != ')') {
@@ -1538,7 +1532,7 @@ old_proto:
 				} else {
 					char kind[1024];
 					type_to_str (s1, kind, sizeof (kind), &pt, NULL);
-					tcc_appendf ("func.%s.arg.%d=%s,%s\n",
+					tcc_appendf (s1, "func.%s.arg.%d=%s,%s\n",
 						symname, narg, kind, s1->global_symname);
 					narg++;
 				}
@@ -1555,7 +1549,7 @@ old_proto:
 				}
 			}
 		}
-		tcc_appendf ("func.%s.args=%d\n", symname, narg);
+		tcc_appendf (s1, "func.%s.args=%d\n", symname, narg);
 		/* if no parameters, then old type prototype */
 		if (l == 0) {
 			l = FUNC_OLD;
@@ -1705,12 +1699,11 @@ redo:
 		post_type (s1, type, ad);
 		s1->nocode_wanted = saved_nocode_wanted;
 	} else {
-		static R_TH_LOCAL char kind[1024]; // XXX
 		char *name = get_tok_str (s1, *v, NULL);
-		type_to_str (s1, kind, sizeof(kind), type, NULL);
+		type_to_str (s1, s1->decl_kind, sizeof(s1->decl_kind), type, NULL);
 		// eprintf ("---%d %s STATIC %s\n", td, kind, name);
 		s1->global_symname = name;
-		s1->global_type = kind;
+		s1->global_type = s1->decl_kind;
 		post_type (s1, type, ad);
 	}
 	type->t |= storage;
@@ -2005,7 +1998,7 @@ str_init:
 				TCC_ERR ("__builtin_va_start expects a local variable");
 			}
 			s1->vtop->r &= ~(VT_LVAL | VT_REF);
-			s1->vtop->type = char_pointer_type;
+			s1->vtop->type = s1->char_pointer_type;
 		}
 		break;
 	case TOK_builtin_va_arg_types:
@@ -2099,7 +2092,7 @@ tok_identifier:
 				TCC_ERR ("field not found: %s", get_tok_str (s1, s1->tok & ~SYM_FIELD, NULL));
 			}
 			/* add field offset to pointer */
-			s1->vtop->type = char_pointer_type;	/* change type to 'char *' */
+			s1->vtop->type = s1->char_pointer_type;	/* change type to 'char *' */
 			vpushi (s1, s->c);
 			/* change type to field type, and set to lvalue */
 			s1->vtop->type = s->type;
@@ -3106,9 +3099,9 @@ func_error1:
 					char buf[500];
 					alias = get_tok_str (s1, v, NULL);
 					type_to_str (s1, buf, sizeof (buf), &sym->type, NULL);
-					tcc_appendf ("%s=typedef\n", alias);
-					tcc_appendf ("typedef.%s=%s\n", alias, buf);
-					tcc_typedef_alias_fields (alias);
+					tcc_appendf (s1, "%s=typedef\n", alias);
+					tcc_appendf (s1, "typedef.%s=%s\n", alias, buf);
+					tcc_typedef_alias_fields (s1, alias);
 				} else {
 					r = 0;
 					if ((type.t & VT_BTYPE) == VT_FUNC) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This removes the remaining TLS inside of TCC. As well, it fixes a bug where existing saved types would not be restored from sdb when parsing entire C files. I do not have a reproducer for this I just observed that the existing behavior is wrong.
