### PR TITLE
Fix wasm iE duplicates ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -497,7 +497,7 @@ static RBinWasmTypeEntry *parse_type_entry(RBuffer *b, ut64 bound, ut32 index) {
 	if (!type) {
 		return NULL;
 	}
-	type->index = index;
+	type->sec_i = index;
 	type->file_offset = r_buf_tell (b);
 	if (!consume_u7_r (b, bound, &type->form)) {
 		goto beach;
@@ -582,7 +582,7 @@ beach:
 static RBinWasmFunctionEntry *parse_function_entry(RBuffer *b, ut64 bound, ut32 index) {
 	RBinWasmFunctionEntry *func = R_NEW0 (RBinWasmFunctionEntry);
 	if (func && consume_u32_r (b, bound, &func->typeindex)) {
-		func->index = index;
+		func->sec_i = index;
 		func->file_offset = r_buf_tell (b);
 		return func;
 	}
@@ -799,7 +799,7 @@ beach:
 static RBinWasmMemoryEntry *parse_memory_entry(RBuffer *b, ut64 bound, ut32 index) {
 	RBinWasmMemoryEntry *ptr = R_NEW0 (RBinWasmMemoryEntry);
 	if (ptr) {
-		ptr->index = index;
+		ptr->sec_i = index;
 		ptr->file_offset = r_buf_tell (b);
 		if (!consume_limits_r (b, bound, &ptr->limits)) {
 			free (ptr);
@@ -812,8 +812,8 @@ static RBinWasmMemoryEntry *parse_memory_entry(RBuffer *b, ut64 bound, ut32 inde
 static RBinWasmTableEntry *parse_table_entry(RBuffer *b, ut64 bound, ut32 index) {
 	RBinWasmTableEntry *table = R_NEW0 (RBinWasmTableEntry);
 	if (table) {
+		table->sec_i = index;
 		table->file_offset = r_buf_tell (b);
-		table->index = index;
 		if (!consume_s7_r (b, bound, (st8 *)&table->element_type)) {
 			goto beach;
 		}
@@ -831,7 +831,7 @@ beach:
 static RBinWasmGlobalEntry *parse_global_entry(RBuffer *b, ut64 bound, ut32 index) {
 	RBinWasmGlobalEntry *ptr = R_NEW0 (RBinWasmGlobalEntry);
 	if (!ptr) {
-		ptr->index = index;
+		ptr->sec_i = index;
 		ptr->file_offset = r_buf_tell (b);
 		if (!consume_u7_r (b, bound, (ut8 *)&ptr->content_type)) {
 			goto beach;

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -88,8 +88,8 @@ typedef struct r_bin_wasm_type_vector_t {
 } RBinWasmTypeVec;
 
 typedef struct r_bin_wasm_type_t {
+	ut32 sec_i;
 	ut64 file_offset;
-	ut32 index;
 	ut8 form;
 	RBinWasmTypeVec *args;
 	RBinWasmTypeVec *rets;
@@ -127,26 +127,26 @@ typedef struct r_bin_wasm_import_t {
 } RBinWasmImportEntry;
 
 typedef struct r_bin_wasm_function_t {
+	ut32 sec_i;
 	ut64 file_offset;
-	ut32 index;
 	ut32 typeindex;
 } RBinWasmFunctionEntry;
 
 typedef struct r_bin_wasm_table_t {
-	ut32 index;
+	ut32 sec_i;
 	ut64 file_offset;
 	ut8 element_type; // only anyfunc
 	struct r_bin_wasm_resizable_limits_t limits;
 } RBinWasmTableEntry;
 
 typedef struct r_bin_wasm_memory_t {
-	ut32 index;
+	ut32 sec_i;
 	ut64 file_offset;
 	struct r_bin_wasm_resizable_limits_t limits;
 } RBinWasmMemoryEntry;
 
 typedef struct r_bin_wasm_global_t {
-	ut32 index;
+	ut32 sec_i;
 	ut64 file_offset;
 	r_bin_wasm_value_type_t content_type;
 	ut8 mutability; // 0 if immutable, 1 if mutable

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -154,6 +154,8 @@ typedef struct r_bin_wasm_global_t {
 } RBinWasmGlobalEntry;
 
 typedef struct r_bin_wasm_export_t {
+	ut32 sec_i;
+	ut64 file_offset;
 	ut32 field_len;
 	char *field_str;
 	ut8 kind;
@@ -239,10 +241,10 @@ typedef struct r_bin_wasm_obj_t {
 	RList *g_sections;
 	RList *g_imports;
 	RPVector *g_funcs;
-	RList *g_exports;
 	RPVector *g_tables;
 	RPVector *g_memories;
 	RPVector *g_globals;
+	RPVector *g_exports;
 	RList *g_elements;
 	RList *g_codes;
 	RList *g_datas;
@@ -259,10 +261,10 @@ RList *r_bin_wasm_get_sections(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_types(RBinWasmObj *bin);
 RList *r_bin_wasm_get_imports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_functions(RBinWasmObj *bin);
-RList *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_tables(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_memories(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_globals(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RList *r_bin_wasm_get_elements(RBinWasmObj *bin);
 RList *r_bin_wasm_get_codes(RBinWasmObj *bin);
 RList *r_bin_wasm_get_datas(RBinWasmObj *bin);

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -88,25 +88,104 @@ FILE=bins/wasm/sections.wasm
 CMDS=aa;afl
 EXPECT=<<EOF
 0x00000207    1 3            entry0
-0x0000053d    1 4            sym.__errno_location_1
+0x0000053d    1 4            sym.__errno_location
 0x0000023d    3 209          sym.main
 0x00000415    6 148          sym.__main_void
 0x000004ab    1 3            sym.__original_main
 0x000004df    1 12           sym.exit
-0x000004f5    1 3            sym.stackSave_1
-0x000004fa    1 5            sym.stackRestore_1
-0x00000516    1 19           sym.emscripten_stack_init_1
+0x000004f5    1 3            sym.stackSave
+0x000004fa    1 5            sym.stackRestore
+0x00000516    1 19           sym.emscripten_stack_init
 0x0000032d    1 126          sym.atoi_via_import
 0x000003b9    1 54           sym.static_int_sum
 0x000003f3    3 14           fcn.000003f3
-0x000003f1    1 2            sym._start_1
+0x000003f1    1 2            sym._start
 0x000004ed    1 6            sym._Exit
-0x00000505    1 15           sym.stackAlloc_1
+0x00000505    1 15           sym.stackAlloc
 0x00000403    1 7            sym.main_2e_1
 0x000004b0    1 1            sym.dummy
 0x000004b5    3 40           sym.libc_exit_fini
-0x0000052b    1 6            sym.emscripten_stack_get_free_1
-0x00000533    1 3            sym.emscripten_stack_get_base_1
-0x00000538    1 3            sym.emscripten_stack_get_end_1
+0x0000052b    1 6            sym.emscripten_stack_get_free
+0x00000533    1 3            sym.emscripten_stack_get_base
+0x00000538    1 3            sym.emscripten_stack_get_end
+EOF
+RUN
+
+NAME=WASM Export functions with custom section
+FILE=bins/wasm/sections.wasm
+CMDS=iE
+EXPECT=<<EOF
+[Exports]
+
+nth paddr      vaddr      bind   type size lib name
+---------------------------------------------------
+8   0x000003f1 0x000003f1 GLOBAL FUNC 16       _start
+16  0x000004f5 0x000004f5 GLOBAL FUNC 3        stackSave
+17  0x000004fa 0x000004fa GLOBAL FUNC 5        stackRestore
+18  0x00000505 0x00000505 GLOBAL FUNC 15       stackAlloc
+19  0x00000516 0x00000516 GLOBAL FUNC 19       emscripten_stack_init
+20  0x0000052b 0x0000052b GLOBAL FUNC 6        emscripten_stack_get_free
+21  0x00000533 0x00000533 GLOBAL FUNC 3        emscripten_stack_get_base
+22  0x00000538 0x00000538 GLOBAL FUNC 3        emscripten_stack_get_end
+23  0x0000053d 0x0000053d GLOBAL FUNC 4        __errno_location
+EOF
+RUN
+
+NAME=WASM Export functions with custom section
+FILE=bins/wasm/sections.wasm
+CMDS=iE
+EXPECT=<<EOF
+[Exports]
+
+nth paddr      vaddr      bind   type size lib name
+---------------------------------------------------
+8   0x000003f1 0x000003f1 GLOBAL FUNC 16       _start
+16  0x000004f5 0x000004f5 GLOBAL FUNC 3        stackSave
+17  0x000004fa 0x000004fa GLOBAL FUNC 5        stackRestore
+18  0x00000505 0x00000505 GLOBAL FUNC 15       stackAlloc
+19  0x00000516 0x00000516 GLOBAL FUNC 19       emscripten_stack_init
+20  0x0000052b 0x0000052b GLOBAL FUNC 6        emscripten_stack_get_free
+21  0x00000533 0x00000533 GLOBAL FUNC 3        emscripten_stack_get_base
+22  0x00000538 0x00000538 GLOBAL FUNC 3        emscripten_stack_get_end
+23  0x0000053d 0x0000053d GLOBAL FUNC 4        __errno_location
+EOF
+RUN
+
+NAME=WASM Export functions w/o custom section
+FILE=bins/wasm/unary.wasm
+CMDS=iE
+EXPECT=<<EOF
+[Exports]
+
+nth paddr      vaddr      bind   type size lib name
+---------------------------------------------------
+2   0x000001d2 0x000001d2 GLOBAL FUNC 5        i32_eqz_100
+3   0x000001d9 0x000001d9 GLOBAL FUNC 4        i32_eqz_0
+4   0x000001df 0x000001df GLOBAL FUNC 5        i32_clz
+5   0x000001e6 0x000001e6 GLOBAL FUNC 5        i32_ctz
+6   0x000001ed 0x000001ed GLOBAL FUNC 5        i32_popcnt
+7   0x000001f4 0x000001f4 GLOBAL FUNC 5        i64_eqz_100
+8   0x000001fb 0x000001fb GLOBAL FUNC 4        i64_eqz_0
+9   0x00000201 0x00000201 GLOBAL FUNC 5        i64_clz
+10  0x00000208 0x00000208 GLOBAL FUNC 5        i64_ctz
+11  0x0000020f 0x0000020f GLOBAL FUNC 5        i64_popcnt
+12  0x00000216 0x00000216 GLOBAL FUNC 7        f32_neg
+13  0x0000021f 0x0000021f GLOBAL FUNC 7        f32_abs
+14  0x00000228 0x00000228 GLOBAL FUNC 9        f32_sqrt_neg_is_nan
+15  0x00000233 0x00000233 GLOBAL FUNC 7        f32_sqrt_100
+16  0x0000023c 0x0000023c GLOBAL FUNC 7        f32_ceil
+17  0x00000245 0x00000245 GLOBAL FUNC 7        f32_floor
+18  0x0000024e 0x0000024e GLOBAL FUNC 7        f32_trunc
+19  0x00000257 0x00000257 GLOBAL FUNC 7        f32_nearest_lo
+20  0x00000260 0x00000260 GLOBAL FUNC 7        f32_nearest_hi
+21  0x00000269 0x00000269 GLOBAL FUNC 11       f64_neg
+22  0x00000276 0x00000276 GLOBAL FUNC 11       f64_abs
+23  0x00000283 0x00000283 GLOBAL FUNC 13       f64_sqrt_neg_is_nan
+24  0x00000292 0x00000292 GLOBAL FUNC 11       f64_sqrt_100
+25  0x0000029f 0x0000029f GLOBAL FUNC 11       f64_ceil
+26  0x000002ac 0x000002ac GLOBAL FUNC 11       f64_floor
+27  0x000002b9 0x000002b9 GLOBAL FUNC 11       f64_trunc
+28  0x000002c6 0x000002c6 GLOBAL FUNC 11       f64_nearest_lo
+29  0x000002d3 0x000002d3 GLOBAL FUNC 11       f64_nearest_hi
 EOF
 RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Wasm function names can appear in the custom name section or in the export section. An earlier attempted fix for bad `iE` mistakenly caused duplicate export entries in `iE` output if the wasm file had a custom name section.

This update will properly fix this problem, I think. The only uncertainty I have is in the case that custom names section and export sections disagree on a function name. I suspect the export section should be trusted in this case. That is how the current code will work. You can see this happen in the tests I updated.

This new code updates exports from a `RList` to a `RPVector`. This means it can be quick sorted and binary searched. So finding exports should be much faster.