### PR TITLE
Last of RBinWasmObj entries to RPVectors ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -598,8 +598,9 @@ static RBinWasmCodeEntry *parse_code_entry(RBinWasmObj *bin, ut64 bound, ut32 in
 	ut8 end;
 	r_buf_read (b, &end, 1);
 	if (end != R_BIN_WASM_END_OF_CODE) {
-		eprintf ("[wasm] Code entry at starting at 0x%" PFMT64x " has ending byte 0x%x at 0x" PFMT64x ", should be 0x%x\n",
-			ptr->file_offset, end, r_buf_tell (b) - 1, R_BIN_WASM_END_OF_CODE);
+		ut32 where = r_buf_tell (b) - 1;
+		eprintf ("[wasm] Code entry at starting at 0x%x has ending byte 0x%x at 0x%x, should be 0x%x\n",
+			(ut32)ptr->file_offset, end, where, R_BIN_WASM_END_OF_CODE);
 		goto beach;
 	}
 	return ptr;

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -598,7 +598,7 @@ static RBinWasmCodeEntry *parse_code_entry(RBinWasmObj *bin, ut64 bound, ut32 in
 	ut8 end;
 	r_buf_read (b, &end, 1);
 	if (end != R_BIN_WASM_END_OF_CODE) {
-		eprintf ("[wasm] Code entry at starting at 0x%" PFMT64x " has ending byte 0x%x at 0x%x, should be 0x%x\n",
+		eprintf ("[wasm] Code entry at starting at 0x%" PFMT64x " has ending byte 0x%x at 0x" PFMT64x ", should be 0x%x\n",
 			ptr->file_offset, end, r_buf_tell (b) - 1, R_BIN_WASM_END_OF_CODE);
 		goto beach;
 	}

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -168,7 +168,7 @@ typedef struct r_bin_wasm_start_t {
 
 struct r_bin_wasm_local_entry_t {
 	ut32 count;
-	r_bin_wasm_value_type_t type;
+	st8 type; // r_bin_wasm_value_type_t
 };
 
 typedef struct r_bin_wasm_element_t {
@@ -181,14 +181,13 @@ typedef struct r_bin_wasm_element_t {
 } RBinWasmElementEntry;
 
 typedef struct r_bin_wasm_code_t {
+	ut32 sec_i;
+	ut64 file_offset;
 	ut32 body_size;
 	ut32 local_count; // numer of local entries
 	struct r_bin_wasm_local_entry_t *locals;
 	ut32 code; // offset
 	ut32 len; // real bytecode length
-	ut8 byte; // 0xb, indicating end of the body
-	char *name;
-	char *signature;
 } RBinWasmCodeEntry;
 
 typedef struct r_bin_wasm_data_t {
@@ -248,7 +247,7 @@ typedef struct r_bin_wasm_obj_t {
 	RPVector *g_globals;
 	RPVector *g_exports;
 	RPVector *g_elements;
-	RList *g_codes;
+	RPVector *g_codes;
 	RList *g_datas;
 	RBinWasmStartEntry *g_start;
 
@@ -268,7 +267,7 @@ RPVector *r_bin_wasm_get_memories(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_globals(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_elements(RBinWasmObj *bin);
-RList *r_bin_wasm_get_codes(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_codes(RBinWasmObj *bin);
 RList *r_bin_wasm_get_datas(RBinWasmObj *bin);
 RList *r_bin_wasm_get_custom_names(RBinWasmObj *bin);
 ut32 r_bin_wasm_get_entrypoint(RBinWasmObj *bin);

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -249,7 +249,7 @@ typedef struct r_bin_wasm_obj_t {
 	RPVector *g_elements;
 	RPVector *g_codes;
 	RList *g_datas;
-	RBinWasmStartEntry *g_start;
+	ut32 g_start;
 
 	RList *g_names;
 	// etc...

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -191,6 +191,8 @@ typedef struct r_bin_wasm_code_t {
 } RBinWasmCodeEntry;
 
 typedef struct r_bin_wasm_data_t {
+	ut32 sec_i;
+	ut64 file_offset;
 	ut32 index; // linear memory index (0 in MVP)
 	struct r_bin_wasm_init_expr_t offset; // bytecode evaluated at runtime
 	ut32 size;
@@ -248,7 +250,7 @@ typedef struct r_bin_wasm_obj_t {
 	RPVector *g_exports;
 	RPVector *g_elements;
 	RPVector *g_codes;
-	RList *g_datas;
+	RPVector *g_datas;
 	ut32 g_start;
 
 	RList *g_names;
@@ -268,7 +270,7 @@ RPVector *r_bin_wasm_get_globals(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_elements(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_codes(RBinWasmObj *bin);
-RList *r_bin_wasm_get_datas(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_datas(RBinWasmObj *bin);
 RList *r_bin_wasm_get_custom_names(RBinWasmObj *bin);
 ut32 r_bin_wasm_get_entrypoint(RBinWasmObj *bin);
 const char *r_bin_wasm_get_function_name(RBinWasmObj *bin, ut32 idx);

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -172,6 +172,8 @@ struct r_bin_wasm_local_entry_t {
 };
 
 typedef struct r_bin_wasm_element_t {
+	ut32 sec_i;
+	ut64 file_offset;
 	ut32 index;
 	struct r_bin_wasm_init_expr_t init;
 	ut32 num_elem;
@@ -245,7 +247,7 @@ typedef struct r_bin_wasm_obj_t {
 	RPVector *g_memories;
 	RPVector *g_globals;
 	RPVector *g_exports;
-	RList *g_elements;
+	RPVector *g_elements;
 	RList *g_codes;
 	RList *g_datas;
 	RBinWasmStartEntry *g_start;
@@ -265,7 +267,7 @@ RPVector *r_bin_wasm_get_tables(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_memories(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_globals(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_exports(RBinWasmObj *bin);
-RList *r_bin_wasm_get_elements(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_elements(RBinWasmObj *bin);
 RList *r_bin_wasm_get_codes(RBinWasmObj *bin);
 RList *r_bin_wasm_get_datas(RBinWasmObj *bin);
 RList *r_bin_wasm_get_custom_names(RBinWasmObj *bin);

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -112,6 +112,8 @@ struct r_bin_wasm_memory_type_t {
 };
 
 typedef struct r_bin_wasm_import_t {
+	ut32 sec_i;
+	ut64 file_offset;
 	ut32 module_len;
 	char *module_str;
 	ut32 field_len;
@@ -123,7 +125,6 @@ typedef struct r_bin_wasm_import_t {
 		struct r_bin_wasm_table_type_t type_t;
 		struct r_bin_wasm_memory_type_t type_m;
 	};
-
 } RBinWasmImportEntry;
 
 typedef struct r_bin_wasm_function_t {
@@ -240,9 +241,9 @@ typedef struct r_bin_wasm_obj_t {
 	ut32 entrypoint;
 
 	// cache purposes
-	RPVector *g_types;
 	RList *g_sections;
-	RList *g_imports;
+	RPVector *g_types;
+	RPVector *g_imports;
 	RPVector *g_funcs;
 	RPVector *g_tables;
 	RPVector *g_memories;
@@ -262,7 +263,7 @@ RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf);
 void r_bin_wasm_destroy(RBinFile *bf);
 RList *r_bin_wasm_get_sections(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_types(RBinWasmObj *bin);
-RList *r_bin_wasm_get_imports(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_imports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_functions(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_tables(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_memories(RBinWasmObj *bin);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Mostly refactoring things to RPVectors. This does clean up a bunch of code and fix a few bugs that could cause if double free's.

This does change how ordinals are assigned to some symbols. Wasm uses separate "index spaces" to identify functions, tables, memories and globals.  So there is a `global[0]` and a `function[0]` rather then `symbols[0]` being either a function or global. This code will better this behavior in ordinals. So there may be a global symbol with the same ordinal as a function.