### PR TITLE
Restore libr/asm/d/malbolge

### DIFF
--- a/libr/asm/Makefile
+++ b/libr/asm/Makefile
@@ -60,6 +60,7 @@ OBJS+=d/i8080.o
 OBJS+=d/java.o
 OBJS+=d/lm32.o
 OBJS+=d/m68k.o
+OBJS+=d/malbolge.o
 OBJS+=d/mips.o
 OBJS+=d/tricore.o
 OBJS+=d/s390.o

--- a/libr/asm/aplugs.c
+++ b/libr/asm/aplugs.c
@@ -14,6 +14,7 @@ extern SdbGperf gperf_i8080;
 extern SdbGperf gperf_java;
 extern SdbGperf gperf_lm32;
 extern SdbGperf gperf_m68k;
+extern SdbGperf gperf_malbolge;
 extern SdbGperf gperf_mips;
 extern SdbGperf gperf_ppc;
 extern SdbGperf gperf_riscv;
@@ -42,6 +43,7 @@ static const SdbGperf *gperfs[] = {
 	&gperf_s390,
 	&gperf_lm32,
 	&gperf_m68k,
+	&gperf_malbolge,
 	&gperf_mips,
 	&gperf_tricore,
 	&gperf_ppc,

--- a/libr/asm/d/Makefile
+++ b/libr/asm/d/Makefile
@@ -1,4 +1,4 @@
-FILES=6502 8051 m68k x86 arc arm avr bpf LH5801 ppc z80 mips sparc sh xtensa
+FILES=6502 8051 m68k x86 arc arm avr bpf LH5801 ppc z80 mips sparc sh malbolge xtensa
 FILES+=i8080 java i4004 dalvik msp430 lm32 s390 tms320 riscv propeller v810 v850
 FILES+=pic18c chip8 tricore bf
 F_SDB=$(addsuffix .sdb,${FILES})

--- a/libr/asm/d/meson.build
+++ b/libr/asm/d/meson.build
@@ -13,6 +13,7 @@ sdb_files = [
   'LH5801',
   'lm32',
   'm68k',
+  'malbolge',
   'mips',
   'msp430',
   'pic18c',


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`extern SdbGperf gperf_malbolge` was incorrectly removed in #20308.
This patch restores it.