### PR TITLE
Fix OOB disasm in anal.i8080

### DIFF
--- a/libr/anal/p/anal_i8080.c
+++ b/libr/anal/p/anal_i8080.c
@@ -14,7 +14,7 @@
 static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	char out[32];
 	ut8 code[3] = {0};
-	memcpy (code, data, R_MIN (sizeof(code), len));
+	memcpy (code, data, R_MIN (sizeof (code), len));
 	int ilen = i8080_disasm (code, out, len);
 	if (mask & R_ANAL_OP_MASK_DISASM) {
 		op->mnemonic = r_str_ndup (out, sizeof(out));

--- a/libr/anal/p/anal_i8080.c
+++ b/libr/anal/p/anal_i8080.c
@@ -13,7 +13,7 @@
 
 static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	char out[32];
-	unsigned char code[3] = {0};
+	ut8 code[3] = {0};
 	memcpy (code, data, R_MIN (sizeof(code), len));
 	int ilen = i8080_disasm (code, out, len);
 	if (mask & R_ANAL_OP_MASK_DISASM) {

--- a/libr/anal/p/anal_i8080.c
+++ b/libr/anal/p/anal_i8080.c
@@ -13,13 +13,15 @@
 
 static int i8080_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
 	char out[32];
-	int ilen = i8080_disasm (data, out, len);
+	unsigned char code[3] = {0};
+	memcpy (code, data, R_MIN (sizeof(code), len));
+	int ilen = i8080_disasm (code, out, len);
 	if (mask & R_ANAL_OP_MASK_DISASM) {
 		op->mnemonic = r_str_ndup (out, sizeof(out));
 	}
 	op->addr = addr;
 	op->type = R_ANAL_OP_TYPE_UNK;
-	switch (data[0]) {
+	switch (code[0]) {
 	case 0x00:
 		op->type = R_ANAL_OP_TYPE_NOP;
 		break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes regression in https://github.com/radareorg/radare2/pull/20303 where anal.i8080 would read up to 2 bytes past the buffer end.