### PR TITLE
[5.8.0] Fix free-before-use on r_io_reopen of a rbuf:// fd/desc ##io

### DIFF
--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -18,8 +18,6 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 }
 
 static bool __close(RIODesc *fd) {
-	RBuffer *b = fd->data;
-	r_buf_free (b);
 	return true;
 }
 


### PR DESCRIPTION
The plugin doesn't allocate the rbuf, therefor shouldn't free it on close
