### PR TITLE
Add ESIL support for ARM-16 ROR instruction

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -2532,6 +2532,16 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		}
 		MATH32 ("<<");
 		break;
+	case ARM_INS_ROR:
+		if (insn->detail->arm.update_flags) {
+			if (OPCOUNT () == 2) {
+				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<<,&,!,!,cf,:=,},", ARG (1), ARG (0), ARG (1));
+			} else {
+				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<<,&,!,!,cf,:=,},", ARG (2), ARG (1), ARG (2));
+			}
+		}
+		MATH32 (">>>");
+		break;
 	case ARM_INS_SVC:
 		r_strbuf_setf (&op->esil, "%s,$", ARG (0));
 		break;

--- a/test/db/esil/arm_16
+++ b/test/db/esil/arm_16
@@ -563,6 +563,30 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rors r1, r2
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=16
+ar > /dev/null
+ar r1=0x80000001
+ar r2=0x1
+"wa rors r1, r2;rors r1, r2"
+aes
+ar r1
+ar cpsr
+aes
+ar r1
+ar cpsr
+EOF
+EXPECT=<<EOF
+0xc0000000
+0xa0000000
+0x60000000
+0x00000000
+EOF
+RUN
+
 NAME=asrs r4, r4, 2
 FILE=malloc://0x200
 CMDS=<<EOF


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ESIL support for ARM ´ror´ instruction was missing. This PR adds support and a test.
