### PR TITLE
Fix wasm function offset lookup ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -243,7 +243,7 @@ typedef struct r_bin_wasm_obj_t {
 	// cache purposes
 	RList *g_sections;
 	RPVector *g_types;
-	RPVector *g_imports;
+	RPVector *g_imports_arr[4];
 	RPVector *g_funcs;
 	RPVector *g_tables;
 	RPVector *g_memories;
@@ -263,7 +263,7 @@ RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf);
 void r_bin_wasm_destroy(RBinFile *bf);
 RList *r_bin_wasm_get_sections(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_types(RBinWasmObj *bin);
-RPVector *r_bin_wasm_get_imports(RBinWasmObj *bin);
+RPVector *r_bin_wasm_get_imports_kind(RBinWasmObj *bin, ut32 kind);
 RPVector *r_bin_wasm_get_functions(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_tables(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_memories(RBinWasmObj *bin);

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -152,93 +152,113 @@ alloc_err:
 	return NULL;
 }
 
-static RList *symbols(RBinFile *bf) {
-	RBinSymbol *ptr = NULL;
+static inline ut32 first_ord_not_import(RBinWasmObj *bin, ut32 kind) {
+	RPVector *imps = r_bin_wasm_get_imports_kind (bin, kind);
+	return imps? r_pvector_len (imps): 0;
+}
 
-	if (!bf || !bf->o || !bf->o->bin_obj) {
+static const char *import_typename(ut32 kind) {
+	switch (kind) {
+	case R_BIN_WASM_EXTERNALKIND_Function:
+		return R_BIN_TYPE_FUNC_STR;
+	case R_BIN_WASM_EXTERNALKIND_Table:
+		return "TABLE";
+	case R_BIN_WASM_EXTERNALKIND_Memory:
+		return "MEMORY";
+	case R_BIN_WASM_EXTERNALKIND_Global:
+		return R_BIN_BIND_GLOBAL_STR;
+	default:
+		r_warn_if_reached ();
 		return NULL;
 	}
-	RBinWasmObj *bin = bf->o->bin_obj;
-	RList *ret = r_list_newf ((RListFree)free);
-	if (!ret) {
-		goto bad_alloc;
-	}
+}
 
-	ut32 fcn_idx = 0;
-	ut32 table_idx = 0;
-	ut32 mem_idx = 0;
-	ut32 global_idx = 0;
-
+static inline bool symbols_add_import_kind(RBinWasmObj *bin, ut32 kind, RList *list) {
 	void **p;
-	RPVector *imports = r_bin_wasm_get_imports (bin);
-	if (imports) {
+	ut32 ordinal = 0;
+	const char *type = import_typename (kind);
+	RPVector *imports = r_bin_wasm_get_imports_kind (bin, kind);
+	if (imports && type) {
 		r_pvector_foreach (imports, p) {
 			RBinWasmImportEntry *imp = *p;
-			if (!(ptr = R_NEW0 (RBinSymbol))) {
-				goto bad_alloc;
+			RBinSymbol *sym = R_NEW0 (RBinSymbol);
+			if (!sym) {
+				return false;
 			}
-			ptr->name = strdup (imp->field_str);
-			ptr->libname = strdup (imp->module_str);
-			ptr->is_imported = true;
-			ptr->forwarder = "NONE";
-			ptr->bind = "NONE";
-			switch (imp->kind) {
-			case R_BIN_WASM_EXTERNALKIND_Function:
-				ptr->type = R_BIN_TYPE_FUNC_STR;
-				ptr->ordinal = fcn_idx++;
-				break;
-			case R_BIN_WASM_EXTERNALKIND_Table:
-				ptr->type = "TABLE";
-				ptr->ordinal = table_idx++;
-				break;
-			case R_BIN_WASM_EXTERNALKIND_Memory:
-				ptr->type = "MEMORY";
-				ptr->ordinal = mem_idx++;
-				break;
-			case R_BIN_WASM_EXTERNALKIND_Global:
-				ptr->type = R_BIN_BIND_GLOBAL_STR;
-				ptr->ordinal = global_idx++;
-				break;
-			}
-			ptr->size = 0;
-			ptr->vaddr = -1;
-			ptr->paddr = -1;
-			r_list_append (ret, ptr);
+			sym->ordinal = ordinal++;
+			sym->type = type;
+			sym->name = strdup (imp->field_str);
+			sym->libname = strdup (imp->module_str);
+			sym->is_imported = true;
+			sym->forwarder = "NONE";
+			sym->bind = "NONE";
+			sym->size = 0;
+			sym->vaddr = -1;
+			sym->paddr = -1;
+			r_list_append (list, sym);
 		}
 	}
+	return true;
+}
 
+static inline bool symbols_add_code(RBinWasmObj *bin, RList *list) {
 	RPVector *codes = r_bin_wasm_get_codes (bin);
 	if (!codes) {
-		return ret;
+		return false;
 	}
 	RPVector *exports = r_bin_wasm_get_exports (bin);
 	if (exports) {
 		r_pvector_sort (exports, _export_sorter);
 	}
 
+	ut32 ordinal = first_ord_not_import (bin, R_BIN_WASM_EXTERNALKIND_Function);
 	RBinWasmExportEntry *exp;
+	void **p;
 	r_pvector_foreach (codes, p) {
 		RBinWasmCodeEntry *func = *p;
-		ptr = R_NEW0 (RBinSymbol);
-		if (!ptr) {
+		RBinSymbol *sym = R_NEW0 (RBinSymbol);
+		if (!sym) {
+			return false;
+		}
+		exp = find_export (exports, R_BIN_WASM_EXTERNALKIND_Function, ordinal);
+		if (exp) {
+			sym->name = strdup (exp->field_str);
+			sym->bind = R_BIN_BIND_GLOBAL_STR;
+		} else {
+			sym->bind = "NONE";
+			const char *name = r_bin_wasm_get_function_name (bin, ordinal);
+			sym->name = name? strdup (name): r_str_newf ("fcn.%d", ordinal);
+		}
+		sym->forwarder = "NONE";
+		sym->type = R_BIN_TYPE_FUNC_STR;
+		sym->size = func->len;
+		sym->vaddr = (ut64)func->code;
+		sym->paddr = (ut64)func->code;
+		sym->ordinal = ordinal++;
+		r_list_append (list, sym);
+	}
+	return true;
+}
+
+static RList *symbols(RBinFile *bf) {
+	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
+	RBinWasmObj *bin = bf->o->bin_obj;
+	RList *ret = r_list_newf ((RListFree)free);
+	if (!ret) {
+		goto bad_alloc;
+	}
+
+	// add all import kinds to symbols
+	int i;
+	for (i = 0; i <= R_BIN_WASM_EXTERNALKIND_Global; i++) {
+		if (!symbols_add_import_kind (bin, i, ret)) {
 			goto bad_alloc;
 		}
-		exp = find_export (exports, R_BIN_WASM_EXTERNALKIND_Function, fcn_idx);
-		if (exp) {
-			ptr->name = strdup (exp->field_str);
-			ptr->bind = R_BIN_BIND_GLOBAL_STR;
-		} else {
-			ptr->bind = "NONE";
-			const char *name = r_bin_wasm_get_function_name (bin, fcn_idx);
-			ptr->name = name? strdup (name): r_str_newf ("fcn.%d", fcn_idx);
-		}
-		ptr->forwarder = "NONE";
-		ptr->type = R_BIN_TYPE_FUNC_STR;
-		ptr->size = func->len;
-		ptr->vaddr = (ut64)func->code;
-		ptr->paddr = (ut64)func->code;
-		ptr->ordinal = fcn_idx++;
-		r_list_append (ret, ptr);
+	}
+
+	// add code to symbols
+	if (!symbols_add_code (bin, ret)) {
+		goto bad_alloc;
 	}
 
 	// TODO: globals, tables and memories
@@ -251,48 +271,35 @@ bad_alloc:
 static RList *get_imports(RBinFile *bf) {
 	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
 	RBinWasmObj *bin = bf->o->bin_obj;
-	RPVector *imports = r_bin_wasm_get_imports (bin);
 	RList *ret = r_list_newf ((RListFree)r_bin_import_free);
-
-	if (!ret || !imports) {
+	if (!ret) {
 		goto bad_alloc;
 	}
 
-	ut32 fcn_idx = 0;
-	ut32 table_idx = 0;
-	ut32 mem_idx = 0;
-	ut32 global_idx = 0;
-	void **p;
-	r_pvector_foreach (imports, p) {
-		RBinWasmImportEntry *import = *p;
-		RBinImport *ptr = R_NEW0 (RBinImport);
-		if (!ptr) {
-			goto bad_alloc;
+	ut32 kind;
+	for (kind = 0; kind <= R_BIN_WASM_EXTERNALKIND_Global; kind++) {
+		const char *type = import_typename (kind);
+		RPVector *imports = r_bin_wasm_get_imports_kind (bin, kind);
+		if (!type || !imports) {
+			continue;
 		}
-		ptr->name = strdup (import->field_str);
-		ptr->classname = strdup (import->module_str);
-		ptr->bind = "NONE";
-		switch (import->kind) {
-		case R_BIN_WASM_EXTERNALKIND_Function:
-			ptr->type = "FUNC";
-			ptr->ordinal = fcn_idx++;
-			break;
-		case R_BIN_WASM_EXTERNALKIND_Table:
-			ptr->type = "TABLE";
-			ptr->ordinal = table_idx++;
-			break;
-		case R_BIN_WASM_EXTERNALKIND_Memory:
-			ptr->type = "MEM";
-			ptr->ordinal = mem_idx++;
-			break;
-		case R_BIN_WASM_EXTERNALKIND_Global:
-			ptr->type = "GLOBAL";
-			ptr->ordinal = global_idx++;
-			break;
+		int i = 0;
+		void **p;
+		r_pvector_foreach (imports, p) {
+			RBinWasmImportEntry *import = *p;
+			RBinImport *ptr = R_NEW0 (RBinImport);
+			if (!ptr) {
+				goto bad_alloc;
+			}
+			ptr->name = strdup (import->field_str);
+			ptr->classname = strdup (import->module_str);
+			ptr->type = type;
+			ptr->bind = "NONE";
+			ptr->ordinal = i++;
+			r_list_append (ret, ptr);
 		}
-		r_list_append (ret, ptr);
 	}
-	return ret;
+
 bad_alloc:
 	r_list_free (ret);
 	return NULL;

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -347,12 +347,13 @@ static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data,
 	return buf;
 }
 
-static int get_fcn_offset_from_id(RBinFile *bf, int fcn_idx) {
-	// XXX shouldn't the number of functions in imports be considered?
+static int get_fcn_offset_from_id(RBinFile *bf, int ordinal) {
 	RBinWasmObj *bin = bf->o->bin_obj;
+	ut32 min = first_ord_not_import (bin, R_BIN_WASM_EXTERNALKIND_Function);
 	RPVector *codes = r_bin_wasm_get_codes (bin);
-	if (codes) {
-		RBinWasmCodeEntry *func = vector_at (codes, fcn_idx);
+	if (min <= ordinal && codes) {
+		ordinal -= min;
+		RBinWasmCodeEntry *func = vector_at (codes, ordinal);
 		if (func) {
 			return func->code;
 		}

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -88,26 +88,25 @@ FILE=bins/wasm/sections.wasm
 CMDS=aa;afl
 EXPECT=<<EOF
 0x00000207    1 3            entry0
-0x0000053d    1 4            sym.__errno_location
-0x0000023d    3 209          sym.main
-0x00000415    6 148          sym.__main_void
-0x000004ab    1 3            sym.__original_main
-0x000004df    1 12           sym.exit
-0x000004f5    1 3            sym.stackSave
-0x000004fa    1 5            sym.stackRestore
 0x00000516    1 19           sym.emscripten_stack_init
+0x0000023d    3 209          sym.main
 0x0000032d    1 126          sym.atoi_via_import
 0x000003b9    1 54           sym.static_int_sum
 0x000003f3    3 14           fcn.000003f3
-0x000003f1    1 2            sym._start
-0x000004ed    1 6            sym._Exit
-0x00000505    1 15           sym.stackAlloc
-0x00000403    1 7            sym.main_2e_1
+0x000004ab    1 3            sym.__original_main
+0x00000415    6 148          sym.__main_void
+0x000004df    1 12           sym.exit
 0x000004b0    1 1            sym.dummy
 0x000004b5    3 40           sym.libc_exit_fini
+0x000004ed    1 6            sym._Exit
+0x00000403    1 7            sym.main_2e_1
+0x000004f5    1 3            sym.stackSave
+0x000004fa    1 5            sym.stackRestore
+0x00000505    1 15           sym.stackAlloc
 0x0000052b    1 6            sym.emscripten_stack_get_free
 0x00000533    1 3            sym.emscripten_stack_get_base
 0x00000538    1 3            sym.emscripten_stack_get_end
+0x0000053d    1 4            sym.__errno_location
 EOF
 RUN
 

--- a/test/db/formats/web_assembly
+++ b/test/db/formats/web_assembly
@@ -188,3 +188,14 @@ nth paddr      vaddr      bind   type size lib name
 29  0x000002d3 0x000002d3 GLOBAL FUNC 11       f64_nearest_hi
 EOF
 RUN
+
+NAME=WASM get function offset
+FILE=bins/wasm/sections.wasm
+CMDS=<<EOF
+s 0x2e8
+pd 2~sym.static_int_sum[4]
+EOF
+EXPECT=<<EOF
+0x3b9
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This code addresses two things.

First the import sectoin is now split into 4 `RPVector`'s instead of 1, there is a separate vector for functions, memories, globals and tables. The import section marks the start of the index space and since there is a different index space for each type, having them separated will simplify parsing logic. This also produces a very minor speed improvement because import parsing loops don't need switches for types.

With the separate import types I then fixed an issue where the WASM `.get_offset` API was returning the wrong function. Now that API returns the offset to the correct function. This results in `aa` finding functions in a different order, so a test had to be fixed.

I did not add a test for `get_offset` yet because it is still not quite right. I have not figured out why but the offset it returns is off by a few bytes:
```
$ r2 ~/radare2/test/bins/wasm/sections.wasm 
...
[0x00000207]> s 0x2e8
[0x000002e8]> pd 2
            0x000002e8      1007           call sym.static_int_sum     ; 0x3b9 ; "#"
            0x000002ea      2116           set_local 22

 ```
```
$ wasm-objdump -d ~/radare2/test/bins/wasm/sections.wasm|grep static_int_sum
 0002e8: 10 07                      |   call 7 <static_int_sum>
0003ac func[7] <static_int_sum>:
```

Wasm-objdump puts `static_int_sum` at 0x0003ac while r2 puts it at 0x3b9. So r2 is not quite right but it's a lot less wrong. Before this patch it would point to the wrong function:

```
[0x000002e8]> pd 3
            0x000002e8      1007           call sym.static_int_sum     ; sym.__original_main
                                                                       ; 0x4ab ; sym.__original_main
            0x000002ea      2116           set_local 22
            0x000002ec      2004           get_local 4
```

I will look into correcting the address problem next.