### PR TITLE
[5.8.0] Fix free-before-use on r_io_reopen of a rbuf:// fd/desc ##io

### DIFF
--- a/libr/io/p/io_rbuf.c
+++ b/libr/io/p/io_rbuf.c
@@ -18,8 +18,6 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 }
 
 static bool __close(RIODesc *fd) {
-	RBuffer *b = fd->data;
-	r_buf_free (b);
 	return true;
 }
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
