### PR TITLE
Refactor wasm custom name parsing ##bin

### DIFF
--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -233,7 +233,7 @@ static inline RBinWasmSection *sections_first_custom_name(RBinWasmObj *bin) {
 	RBinWasmSection *sec;
 	r_list_foreach (bin->g_sections, iter, sec) {
 		if (sec->id == R_BIN_WASM_SECTION_CUSTOM && sec->size > 6) {
-			ut8 _tmp[CUST_NAME_START_LEN];
+			ut8 _tmp[CUST_NAME_START_LEN] = {0};
 			r_buf_read_at (buf, sec->offset, _tmp, CUST_NAME_START_LEN);
 			if (!memcmp (CUST_NAME_START, _tmp, CUST_NAME_START_LEN)) {
 				return sec;

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -225,23 +225,25 @@ static size_t consume_limits_r(RBuffer *b, ut64 bound, struct r_bin_wasm_resizab
 }
 
 // Utils
+#define CUST_NAME_START "\x04name"
+#define CUST_NAME_START_LEN sizeof CUST_NAME_START - 1
 static inline RBinWasmSection *sections_first_custom_name(RBinWasmObj *bin) {
 	RBuffer *buf = bin->buf;
 	RListIter *iter;
 	RBinWasmSection *sec;
 	r_list_foreach (bin->g_sections, iter, sec) {
 		if (sec->id == R_BIN_WASM_SECTION_CUSTOM && sec->size > 6) {
-			const ut8 start[] = "\x04name";
-			ut64 size = R_ARRAY_SIZE (start);
-			ut8 _tmp[size--]; // storage, remove null byte for comparison
-			r_buf_read_at (buf, sec->offset, _tmp, size);
-			if (!memcmp (start, _tmp, size)) {
+			ut8 _tmp[CUST_NAME_START_LEN];
+			r_buf_read_at (buf, sec->offset, _tmp, CUST_NAME_START_LEN);
+			if (!memcmp (CUST_NAME_START, _tmp, CUST_NAME_START_LEN)) {
 				return sec;
 			}
 		}
 	}
 	return NULL;
 }
+#undef CUST_NAME_START
+#undef CUST_NAME_START_LEN
 
 static inline RBinWasmSection *section_first_with_id(RList *sections, ut8 id) {
 	RBinWasmSection *sec;

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -225,34 +225,33 @@ static size_t consume_limits_r(RBuffer *b, ut64 bound, struct r_bin_wasm_resizab
 }
 
 // Utils
-static RList *r_bin_wasm_get_sections_by_id(RList *sections, ut8 id) {
-	RList *ret = r_list_newf (NULL);
-	if (ret) {
-		RBinWasmSection *sec;
-		RListIter *iter;
-		r_list_foreach (sections, iter, sec) {
-			if (sec->id == id) {
-				r_list_append (ret, sec);
+static inline RBinWasmSection *sections_first_custom_name(RBinWasmObj *bin) {
+	RBuffer *buf = bin->buf;
+	RListIter *iter;
+	RBinWasmSection *sec;
+	r_list_foreach (bin->g_sections, iter, sec) {
+		if (sec->id == R_BIN_WASM_SECTION_CUSTOM && sec->size > 6) {
+			const ut8 start[] = "\x04name";
+			ut64 size = R_ARRAY_SIZE (start);
+			ut8 _tmp[size--]; // storage, remove null byte for comparison
+			r_buf_read_at (buf, sec->offset, _tmp, size);
+			if (!memcmp (start, _tmp, size)) {
+				return sec;
 			}
 		}
 	}
-	return ret;
+	return NULL;
 }
 
-static RBinWasmSection *section_by_id_unique(RList *sections, ut8 id) {
-	RList *l = r_bin_wasm_get_sections_by_id (sections, id);
-	RBinWasmSection *sec = NULL;
-	if (l) {
-		int len = r_list_length (l);
-		if (len) {
-			sec = r_list_first (l);
-			if (sec && len > 1) {
-				eprintf ("[wasm] Using first %s section of %d\n", sec->name, len);
-			}
+static inline RBinWasmSection *section_first_with_id(RList *sections, ut8 id) {
+	RBinWasmSection *sec;
+	RListIter *iter;
+	r_list_foreach (sections, iter, sec) {
+		if (sec->id == id) {
+			return sec;
 		}
 	}
-	r_list_free (l);
-	return sec;
+	return NULL;
 }
 
 const char *r_bin_wasm_valuetype_to_string (r_bin_wasm_value_type_t type) {
@@ -384,42 +383,30 @@ static void wasm_sec_free(RBinWasmSection *sec) {
 	}
 }
 
-static void wasm_custom_name_local_free(RBinWasmCustomNameLocalName *name) {
-	if (name) {
-		r_id_storage_free (name->names);
-		R_FREE (name);
+bool _store_free_cb(void *user, void *data, ut32 id) {
+	free (data);
+	return true;
+}
+
+static inline void storage_deep_free(RIDStorage *store) {
+	if (store) {
+		r_id_storage_foreach (store, (RIDStorageForeachCb)_store_free_cb, NULL);
+		r_id_storage_free (store);
 	}
 }
 
-static inline void wasm_custom_local_names_free(RBinWasmCustomNameLocalNames *local) {
-	if (local) {
-		r_list_free (local->locals);
-		R_FREE (local);
-	}
+static bool _2d_store_free_cb(void *user, void *data, ut32 id) {
+	RIDStorage *store = (RIDStorage *)data;
+	storage_deep_free (store);
+	return true;
 }
 
-static void wasm_custom_name_free(RBinWasmCustomNameEntry *cust) {
-	if (cust) {
-		switch (cust->type) {
-		case R_BIN_WASM_NAMETYPE_Module:
-			R_FREE (cust->mod_name);
-			break;
-		case R_BIN_WASM_NAMETYPE_Function:
-			if (cust->func) {
-				r_id_storage_free (cust->func->names);
-				R_FREE (cust->func);
-			}
-			break;
-		case R_BIN_WASM_NAMETYPE_Local:
-			wasm_custom_local_names_free (cust->local);
-			break;
-		case R_BIN_WASM_NAMETYPE_None:
-			break;
-		default:
-			eprintf ("Unkown type: 0x%x\n", cust->type);
-			r_warn_if_reached ();
-		}
-		R_FREE (cust);
+static inline void free_custom_names(RBinWasmCustomNames *names) {
+	if (names) {
+		free (names->mod.name);
+		storage_deep_free (names->funcs.store);
+		r_id_storage_foreach (names->locals.store, (RIDStorageForeachCb)_2d_store_free_cb, NULL);
+		free (names);
 	}
 }
 
@@ -649,136 +636,104 @@ beach:
 	return NULL;
 }
 
-static bool parse_namemap(RBuffer *b, ut64 bound, RIDStorage *map, ut32 *count) {
-	size_t i;
-	if (!consume_u32_r (b, bound, count)) {
+static RIDStorage *parse_namemap(RBuffer *b, ut64 bound) {
+	RIDStorage *store = r_id_storage_new (0, UT32_MAX);
+	ut32 i, count;
+	if (store && consume_u32_r (b, bound, &count)) {
+		for (i = 0; i < count; i++) {
+			ut32 idx;
+			if (!consume_u32_r (b, bound, &idx)) {
+				break;
+			}
+
+			char *name = NULL;
+			if (!consume_encoded_name_new (b, bound, NULL, &name)) {
+				R_FREE (name);
+				break;
+			}
+
+			if (!r_id_storage_add (store, name, &idx)) {
+				R_FREE (name);
+				break;
+			};
+		}
+	}
+	return store;
+}
+
+static inline RIDStorage *parse_custom_names_local(RBuffer *b, ut64 bound) {
+	RIDStorage *store = r_id_storage_new (0, UT32_MAX);
+	ut32 i, count;
+	if (store && consume_u32_r (b, bound, &count)) {
+		for (i = 0; i < count; i++) {
+			ut32 idx;
+			if (!consume_u32_r (b, bound, &idx)) {
+				break;
+			}
+			RIDStorage *funcstore = parse_namemap (b, bound);
+			if (!funcstore || !r_id_storage_add (store, funcstore, &idx)) {
+				storage_deep_free (funcstore);
+				break;
+			}
+		}
+	}
+	return store;
+}
+
+static inline bool parse_custom_name_section(RBinWasmObj *bin, ut64 bound) {
+	RBinWasmCustomNames *names = bin->names;
+	RBuffer *b = bin->buf;
+	ut64 start = r_buf_tell (b);
+	ut8 type;
+	if (!consume_u7_r (b, bound, &type)) {
+		return false;
+	};
+
+	ut32 size;
+	if (!consume_u32_r (b, bound, &size)) {
 		return false;
 	}
 
-	for (i = 0; i < *count; i++) {
-		ut32 idx;
-		if (!consume_u32_r (b, bound, &idx)) {
-			return false;
-		}
-
-		char *name = NULL;
-		if (!consume_encoded_name_new (b, bound, NULL, &name)) {
-			R_FREE (name);
-			return false;
-		}
-
-		if (!r_id_storage_add (map, name, &idx)) {
-			R_FREE (name);
-			return false;
-		};
+	ut64 new_bound = start + size - 1;
+	if (new_bound > bound) {
+		eprintf ("[wasm] custom name subection at 0x%" PFMT64x " extends beyond the custom section\n", start);
+		new_bound = bound;
 	}
 
-	return true;
-}
-
-static inline RBinWasmCustomNameLocalName *parse_local_name(RBuffer *b, ut64 bound) {
-	RBinWasmCustomNameLocalName *local_name = R_NEW0 (RBinWasmCustomNameLocalName);
-	if (local_name) {
-		if (!consume_u32_r (b, bound, &local_name->index)) {
-			goto beach;
-		}
-
-		local_name->names = r_id_storage_new (0, UT32_MAX);
-		if (!local_name->names) {
-			goto beach;
-		}
-
-		if (!parse_namemap (b, bound, local_name->names, &local_name->names_count)) {
-			goto beach;
-		}
-
-		return local_name;
-	}
-beach:
-	wasm_custom_name_local_free (local_name);
-	return NULL;
-}
-
-static inline RBinWasmCustomNameLocalNames *parse_custom_names_local(RBuffer *b, ut64 bound) {
-	RBinWasmCustomNameLocalNames *local = R_NEW0 (RBinWasmCustomNameLocalNames);
-	if (!local) {
-		return NULL;
-	}
-	if (!consume_u32_r (b, bound, &local->count)) {
-		goto beach;
-	}
-
-	local->locals = r_list_newf ((RListFree)wasm_custom_name_local_free);
-	if (local->locals) {
-		size_t i;
-		for (i = 0; i < local->count; i++) {
-			RBinWasmCustomNameLocalName *local_name = parse_local_name (b, bound);
-			if (!local_name || !r_list_append (local->locals, local_name)) {
-				wasm_custom_name_local_free (local_name);
-				goto beach;
-			}
-		}
-		return local;
-	}
-
-beach:
-	wasm_custom_local_names_free (local);
-	return NULL;
-}
-
-static RBinWasmCustomNameEntry *parse_custom_name_entry(RBinWasmObj *bin, ut64 bound) {
-	RBuffer *b = bin->buf;
-	RBinWasmCustomNameEntry *cust = R_NEW0 (RBinWasmCustomNameEntry);
-	if (!cust) {
-		return NULL;
-	}
-	cust->type = R_BIN_WASM_NAMETYPE_None;
-
-	size_t start = r_buf_tell (b);
-	if (!consume_u7_r (b, bound, &cust->type)) {
-		goto beach;
-	};
-
-	if (!consume_u32_r (b, bound, &cust->size)) {
-		goto beach;
-	};
-
-	switch (cust->type) {
+	switch (type) {
 	case R_BIN_WASM_NAMETYPE_Module:
-		if (!consume_encoded_name_new (b, bound, NULL, &cust->mod_name)) {
-			goto beach;
+		if (names->mod.name) {
+			eprintf ("[wasm] Multiple module names in custom name section! first: 0x%" PFMT64x ", this: 0x%" PFMT64x "\n", names->mod.file_offset, start);
+		} else if (!consume_encoded_name_new (b, bound, NULL, &names->mod.name)) {
+			eprintf ("[wasm] Custom Name section corrupt module name at 0x%" PFMT64x "\n", start);
+		} else {
+			names->mod.file_offset = start;
 		}
 		break;
 	case R_BIN_WASM_NAMETYPE_Function:
-		cust->func = R_NEW0 (RBinWasmCustomNameFunctionNames);
-		if (!cust->func) {
-			goto beach;
-		}
-		cust->func->names = r_id_storage_new (0, UT32_MAX);
-		if (!cust->func->names) {
-			goto beach;
-		}
-
-		if (!parse_namemap (b, bound, cust->func->names, &cust->func->count)) {
-			goto beach;
+		if (names->funcs.store) {
+			eprintf ("[wasm] Multiple function susbections in custom name section! first: 0x%" PFMT64x ", this: 0x%" PFMT64x "\n", names->funcs.file_offset, start);
+		} else {
+			names->funcs.file_offset = start;
+			names->funcs.store = parse_namemap (b, bound);
 		}
 		break;
 	case R_BIN_WASM_NAMETYPE_Local:
-		cust->local = parse_custom_names_local (b, bound);
-		if (!cust->local) {
-			goto beach;
+		if (names->locals.store) {
+			eprintf ("[wasm] Multiple locals susbections in custom name section! first: 0x%" PFMT64x ", this: 0x%" PFMT64x "\n", names->locals.file_offset, start);
+		} else {
+			names->funcs.file_offset = start;
+			names->locals.store = parse_custom_names_local (b, bound);
 		}
 		break;
 	default:
-		R_LOG_WARN ("[wasm] Halting custom name section parsing at unknown type 0x%x offset 0x%" PFMTSZx, cust->type, start);
-		cust->type = R_BIN_WASM_NAMETYPE_None;
-		goto beach;
+		eprintf ("[wasm] Unkown custom name subsection with id: %d\n", type);
+		break;
 	}
 
-	return cust;
-beach:
-	wasm_custom_name_free (cust);
-	return NULL;
+	// even if a custom section fails to parse, as long as we have length we can try to parse the next one
+	r_buf_seek (b, bound + 1, R_BUF_SET);
+	return true;
 }
 
 static RBinWasmMemoryEntry *parse_memory_entry(RBinWasmObj *bin, ut64 bound, ut32 index) {
@@ -870,7 +825,7 @@ beach:
 
 static ut32 r_bin_wasm_get_start(RBinWasmObj *bin) {
 	if (bin->g_start == UT32_MAX) {
-		RBinWasmSection *sec = section_by_id_unique (bin->g_sections, R_BIN_WASM_SECTION_START);
+		RBinWasmSection *sec = section_first_with_id (bin->g_sections, R_BIN_WASM_SECTION_START);
 		if (sec) {
 			RBuffer *b = bin->buf;
 			r_buf_seek (b, sec->payload_data, R_BUF_SET);
@@ -883,34 +838,26 @@ static ut32 r_bin_wasm_get_start(RBinWasmObj *bin) {
 	return bin->g_start;
 }
 
-static RList *r_bin_wasm_get_custom_name_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
-	RList *ret = r_list_newf ((RListFree)wasm_custom_name_free);
-
+static inline bool r_bin_wasm_get_custom_name_entries(RBinWasmObj *bin, RBinWasmSection *sec) {
 	RBuffer *buf = bin->buf;
-
 	r_buf_seek (buf, sec->payload_data, R_BUF_SET);
 	ut64 bound = sec->payload_data + sec->payload_len - 1;
 
-	if (bound > r_buf_size (buf)) {
-		goto beach;
+	r_return_val_if_fail (bound <= r_buf_size (buf), false); // should be checked in section parsing
+	if (!bin->names) {
+		bin->names = R_NEW0 (RBinWasmCustomNames);
+		if (!bin->names) {
+			return NULL;
+		}
 	}
 
 	while (r_buf_tell (buf) < bound) {
-		RBinWasmCustomNameEntry *nam = parse_custom_name_entry (bin, bound);
-
-		if (!nam) {
-			break; // allow partial parsing of section
-		}
-
-		if (!r_list_append (ret, nam)) {
-			goto beach;
+		if (!parse_custom_name_section (bin, bound)) {
+			break;
 		}
 	}
 
-	return ret;
-beach:
-	r_list_free (ret);
-	return NULL;
+	return bin->names;
 }
 
 static bool parse_import_sec(RBinWasmObj *bin) {
@@ -926,7 +873,7 @@ static bool parse_import_sec(RBinWasmObj *bin) {
 		}
 	}
 
-	RBinWasmSection *sec = section_by_id_unique (bin->g_sections, R_BIN_WASM_SECTION_IMPORT);
+	RBinWasmSection *sec = section_first_with_id (bin->g_sections, R_BIN_WASM_SECTION_IMPORT);
 	if (!sec) {
 		return true; // not an error, empty import section
 	}
@@ -991,7 +938,7 @@ RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf) {
 		bin->g_codes = r_bin_wasm_get_codes (bin);
 		bin->g_datas = r_bin_wasm_get_datas (bin);
 
-		bin->g_names = r_bin_wasm_get_custom_names (bin);
+		r_bin_wasm_get_custom_names (bin);
 
 		// entrypoint from Start section
 		bin->entrypoint = r_bin_wasm_get_entrypoint (bin);
@@ -1013,7 +960,7 @@ void wasm_obj_free(RBinWasmObj *bin) {
 		r_pvector_free (bin->g_elements);
 		r_pvector_free (bin->g_codes);
 		r_pvector_free (bin->g_datas);
-		r_list_free (bin->g_names);
+		free_custom_names (bin->names);
 		free (bin);
 	}
 }
@@ -1235,7 +1182,7 @@ static RPVector *parse_sub_section_vec(RBinWasmObj *bin, RBinWasmSection *sec) {
 
 // warns if there are two sections of this type
 static inline RPVector *parse_unique_subsec_vec_by_id(RBinWasmObj *bin, ut8 id) {
-	RBinWasmSection *sec = section_by_id_unique (bin->g_sections, id);
+	RBinWasmSection *sec = section_first_with_id (bin->g_sections, id);
 	if (sec) {
 		return parse_sub_section_vec (bin, sec);
 	}
@@ -1296,47 +1243,25 @@ RPVector *r_bin_wasm_get_datas(RBinWasmObj *bin) {
 	return bin->g_datas? bin->g_datas: parse_unique_subsec_vec_by_id (bin, R_BIN_WASM_SECTION_DATA);
 }
 
-RList *r_bin_wasm_get_custom_names(RBinWasmObj *bin) {
-	RList *customs = NULL;
-
+RBinWasmCustomNames *r_bin_wasm_get_custom_names(RBinWasmObj *bin) {
 	r_return_val_if_fail (bin && bin->g_sections, NULL);
+	if (bin->names) {
+		return bin->names;
+	}
 
-	if (bin->g_names) {
-		return bin->g_names;
-	}
-	if (!(customs = r_bin_wasm_get_sections_by_id (bin->g_sections, R_BIN_WASM_SECTION_CUSTOM))) {
-		return r_list_new ();
-	}
 	// support for multiple "name" sections against spec
-	RBinWasmSection *cust = (RBinWasmSection *)r_list_first (customs);
-	if (!cust || !cust->name) {
-		r_list_free (customs);
-		return r_list_new ();
+	RBinWasmSection *sec = sections_first_custom_name (bin);
+	if (sec) {
+		r_bin_wasm_get_custom_name_entries (bin, sec);
 	}
-	if (strcmp (cust->name, "name")) {
-		r_list_free (customs);
-		return r_list_new ();
-	}
-	bin->g_names = r_bin_wasm_get_custom_name_entries (bin, cust);
-	r_list_free (customs);
-	return bin->g_names;
+	return bin->names;
 }
 
 const char *r_bin_wasm_get_function_name(RBinWasmObj *bin, ut32 idx) {
-	if (!(bin && bin->g_names)) {
-		return NULL;
-	};
+	r_return_val_if_fail (bin, NULL);
 
-	RListIter *iter;
-	RBinWasmCustomNameEntry *nam;
-	r_list_foreach (bin->g_names, iter, nam) {
-		if (nam->type == R_BIN_WASM_NAMETYPE_Function) {
-			const char *n = r_id_storage_get (nam->func->names, idx);
-			if (n) {
-				return n;
-			}
-		}
+	if (bin->names && bin->names->funcs.store) {
+		return r_id_storage_get (bin->names->funcs.store, idx);
 	}
-
 	return NULL;
 }

--- a/libr/bin/format/wasm/wasm.c
+++ b/libr/bin/format/wasm/wasm.c
@@ -234,9 +234,10 @@ static inline RBinWasmSection *sections_first_custom_name(RBinWasmObj *bin) {
 	r_list_foreach (bin->g_sections, iter, sec) {
 		if (sec->id == R_BIN_WASM_SECTION_CUSTOM && sec->size > 6) {
 			ut8 _tmp[CUST_NAME_START_LEN] = {0};
-			r_buf_read_at (buf, sec->offset, _tmp, CUST_NAME_START_LEN);
-			if (!memcmp (CUST_NAME_START, _tmp, CUST_NAME_START_LEN)) {
-				return sec;
+			if (r_buf_read_at (buf, sec->offset, _tmp, CUST_NAME_START_LEN) > 0) {
+				if (!memcmp (CUST_NAME_START, _tmp, CUST_NAME_START_LEN)) {
+					return sec;
+				}
 			}
 		}
 	}

--- a/libr/bin/format/wasm/wasm.h
+++ b/libr/bin/format/wasm/wasm.h
@@ -200,41 +200,28 @@ typedef struct r_bin_wasm_data_t {
 	ut32 data; // offset
 } RBinWasmDataEntry;
 
-// TODO: custom sections
+typedef struct r_bin_wasm_custom_module {
+	ut64 file_offset;
+	char *name;
+} RBinWasmCustomModule;
 
+typedef struct r_bin_wasm_custom_function {
+	ut64 file_offset;
+	RIDStorage *store; // RIDStorage of char *
+} RBinWasmCustomFunction;
 
-typedef struct r_bin_wasm_custom_name_function_names_t {
-	ut32 count;
-	RIDStorage *names;
-} RBinWasmCustomNameFunctionNames;
+typedef struct r_bin_wasm_custom_locals {
+	ut64 file_offset;
+	RIDStorage *store; // 2d idstore, RIDStorage of RIDStorage of char *
+} RBinWasmCustomLocals;
 
-typedef struct r_bin_wasm_custom_name_local_name_t {
-	ut32 index; // function index
-
-	ut32 names_count;
-	RIDStorage *names; // local names
-} RBinWasmCustomNameLocalName;
-
-typedef struct r_bin_wasm_custom_name_local_names_t {
-	ut32 count;
-	RList *locals; // RBinWasmCustomNameLocalName
-} RBinWasmCustomNameLocalNames;
-
-// "name" section entry
-typedef struct r_bin_wasm_custom_name_entry_t {
-	ut8 type;
-	ut32 size;
-
-	ut8 payload_data;
-	union {
-		char *mod_name;
-		RBinWasmCustomNameFunctionNames *func;
-		RBinWasmCustomNameLocalNames *local;
-	};
-} RBinWasmCustomNameEntry;
+typedef struct r_bin_wasm_custom_names {
+	RBinWasmCustomModule mod;
+	RBinWasmCustomFunction funcs;
+	RBinWasmCustomLocals locals;
+} RBinWasmCustomNames;
 
 typedef struct r_bin_wasm_obj_t {
-
 	RBuffer *buf;
 	size_t size;
 
@@ -254,9 +241,8 @@ typedef struct r_bin_wasm_obj_t {
 	RPVector *g_datas;
 	ut32 g_start;
 
-	RList *g_names;
-	// etc...
-
+	// custom sections
+	RBinWasmCustomNames *names;
 } RBinWasmObj;
 
 RBinWasmObj *r_bin_wasm_init(RBinFile *bf, RBuffer *buf);
@@ -272,7 +258,7 @@ RPVector *r_bin_wasm_get_exports(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_elements(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_codes(RBinWasmObj *bin);
 RPVector *r_bin_wasm_get_datas(RBinWasmObj *bin);
-RList *r_bin_wasm_get_custom_names(RBinWasmObj *bin);
+RBinWasmCustomNames *r_bin_wasm_get_custom_names(RBinWasmObj *bin);
 ut32 r_bin_wasm_get_entrypoint(RBinWasmObj *bin);
 const char *r_bin_wasm_get_function_name(RBinWasmObj *bin, ut32 idx);
 const char *r_bin_wasm_valuetype_to_string(r_bin_wasm_value_type_t type);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes a leak and should speed up parsing modestly.

This also sets up the code to be able to use the custom name locals section. I will work on this next I think, to get local variable names for functions.
