### PR TITLE
Fix leak in wasm opcode disassembly ##anal

### DIFF
--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -27,6 +27,10 @@ static ut64 get_cf_offset(RAnal *anal, const ut8 *data, int len) {
 	return anal->binb.get_offset (anal->binb.bin, 'f', fcn_id);
 }
 
+static inline clean_op(WasmOp *wop) {
+	free (wop->txt);
+}
+
 static bool advance_till_scope_end(RAnal* anal, RAnalOp *op, ut64 address, ut32 expected_type, ut32 depth, bool use_else) {
 	ut8 buffer[16];
 	ut8 *ptr = buffer;
@@ -38,7 +42,11 @@ static bool advance_till_scope_end(RAnal* anal, RAnalOp *op, ut64 address, ut32 
 	}
 	while (anal->iob.read_at (anal->iob.io, address, buffer, sizeof (buffer))) {
 		size = wasm_dis (&wop, ptr, end - ptr);
-		if (!wop.txt || (wop.type == WASM_TYPE_OP_CORE && wop.op.core == WASM_OP_TRAP)) {
+		if (!wop.txt) {
+			break;
+		}
+		free (wop.txt);
+		if (wop.type == WASM_TYPE_OP_CORE && wop.op.core == WASM_OP_TRAP) {
 			// if invalid stop here.
 			break;
 		}

--- a/libr/anal/p/anal_wasm.c
+++ b/libr/anal/p/anal_wasm.c
@@ -27,10 +27,6 @@ static ut64 get_cf_offset(RAnal *anal, const ut8 *data, int len) {
 	return anal->binb.get_offset (anal->binb.bin, 'f', fcn_id);
 }
 
-static inline clean_op(WasmOp *wop) {
-	free (wop->txt);
-}
-
 static bool advance_till_scope_end(RAnal* anal, RAnalOp *op, ut64 address, ut32 expected_type, ut32 depth, bool use_else) {
 	ut8 buffer[16];
 	ut8 *ptr = buffer;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `wasm_dis` function populates `wop->txt` with a `char *` that was never free'd. This pull ensures it gets free'd.
