### PR TITLE
ARM disassembler: don't compute [pc, reg] memory location

### DIFF
--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -4083,7 +4083,7 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->stackop = R_ANAL_STACK_GET;
 			op->stackptr = 0;
 			op->ptr = -MEMDISP (1);
-		} else if (REGBASE(1) == ARM_REG_PC && !HASMEMINDEX(1)) {
+		} else if (REGBASE (1) == ARM_REG_PC && !HASMEMINDEX (1)) {
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP (1);
 			op->refptr = 4;
 			if (REGID(0) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -3004,7 +3004,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		addr &= ~3LL;
 		if (MEMDISP(1) < 0) {
 			const char *pc = "$$";
-			if (REGBASE(1) == ARM_REG_PC) {
+			if (REGBASE(1) == ARM_REG_PC && !HASMEMINDEX(1)) {
 				op->refptr = 4;
 				op->ptr = addr + pcdelta + MEMDISP(1);
 				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",2,2,%s,%d,+,>>,<<,+,0xffffffff,&,[4],0x%x,&,%s,=",
@@ -3021,7 +3021,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 				}
 			}
 		} else {
-			if (REGBASE(1) == ARM_REG_PC) {
+			if (REGBASE(1) == ARM_REG_PC && !HASMEMINDEX(1)) {
 				const char *pc = "$$";
 				op->refptr = 4;
 				op->ptr = addr + pcdelta + MEMDISP(1);
@@ -4083,7 +4083,7 @@ jmp $$ + 4 + ( [delta] * 2 )
 			op->stackop = R_ANAL_STACK_GET;
 			op->stackptr = 0;
 			op->ptr = -MEMDISP (1);
-		} else if (REGBASE(1) == ARM_REG_PC) {
+		} else if (REGBASE(1) == ARM_REG_PC && !HASMEMINDEX(1)) {
 			op->ptr = (addr & ~3LL) + (thumb? 4: 8) + MEMDISP (1);
 			op->refptr = 4;
 			if (REGID(0) == ARM_REG_PC && insn->detail->arm.cc != ARM_CC_AL) {

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -361,11 +361,11 @@ static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 				ripend = "]";
 			}
 			char * maybe_num = neg? neg+1 : rip;
-			if( r_is_valid_input_num_value(NULL, maybe_num)){
+			if (r_is_valid_input_num_value (NULL, maybe_num)) {
 				if (neg) {
-					repl_num -= r_num_get(NULL, maybe_num);
+					repl_num -= r_num_get (NULL, maybe_num);
 				} else {
-					repl_num += r_num_get(NULL, maybe_num);
+					repl_num += r_num_get (NULL, maybe_num);
 				}
 				rip -= 3;
 				*rip = 0;

--- a/libr/parse/p/parse_arm_pseudo.c
+++ b/libr/parse/p/parse_arm_pseudo.c
@@ -360,16 +360,19 @@ static bool subvar(RParse *p, RAnalFunction *f, ut64 addr, int oplen, char *data
 			if (!ripend) {
 				ripend = "]";
 			}
-			if (neg) {
-				repl_num -= r_num_get (NULL, neg + 1);
-			} else {
-				repl_num += r_num_get (NULL, rip);
+			char * maybe_num = neg? neg+1 : rip;
+			if( r_is_valid_input_num_value(NULL, maybe_num)){
+				if (neg) {
+					repl_num -= r_num_get(NULL, maybe_num);
+				} else {
+					repl_num += r_num_get(NULL, maybe_num);
+				}
+				rip -= 3;
+				*rip = 0;
+				tstr_new = r_str_newf ("%s0x%08"PFMT64x"%s", tstr, repl_num, ripend);
+				free (tstr);
+				tstr = tstr_new;
 			}
-			rip -= 3;
-			*rip = 0;
-			tstr_new = r_str_newf ("%s0x%08"PFMT64x"%s", tstr, repl_num, ripend);
-			free (tstr);
-			tstr = tstr_new;
 		}
 	}
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ARM disassembler: for [pc, #imm ] , is ok to compute the address to display out. but not for [pc, reg].