### PR TITLE
Close #20453 - Fix crash due to null debug file handle/uri

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -344,14 +344,14 @@ static bool setbpint(RCore *r, const char *mode, const char *sym) {
 #endif
 
 // XXX - need to handle index selection during debugging
-static int r_core_file_do_load_for_debug(RCore *r, ut64 baseaddr, const char *filenameuri) {
+static int r_core_file_do_load_for_debug(RCore *r, ut64 baseaddr, R_NULLABLE const char *filenameuri) {
 	RIODesc *desc = r->io->desc;
 	RBinFile *binfile = NULL;
 	RBinPlugin *plugin;
 	int xtr_idx = 0; // if 0, load all if xtr is used
 
 	// TODO : Honor file.path eval var too?
-	if (!strncmp ("dbg://", filenameuri, 6)) {
+	if (filenameuri && r_str_startswith (filenameuri, "dbg://")) {
 		filenameuri += 6;
 	}
 	if (!desc) {

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1113,7 +1113,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 									}
 									r_core_bin_load (r, NULL, addr);
 								}
-							} else if (fh->name && r_str_startswith (fh->name, "gdb://")) {
+							} else if (fh && fh->name && r_str_startswith (fh->name, "gdb://")) {
 								filepath = iod->name;
 								if (r_file_exists (filepath) && !r_file_is_directory (filepath)) {
 									if (addr == UT64_MAX) {


### PR DESCRIPTION
2 null checks are needed for debug file open to avoid a crash when the file doesn't exist.

No longer crashes:

```
$ r2 -e dbg.exe.path=nonexistent -AA -d gdb://localhost:1234
ERROR: Could not resolve address 'localhost' or failed to connect
gdb.io.open: Cannot connect to host.
[r] Cannot open 'gdb://localhost:1234'
```