### PR TITLE
Allow to change entropy bars width with '[]' keys ##print

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1852,7 +1852,8 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 	for (i = 0; i < size; i++) {
 		cols = arr[i] > cols ? arr[i] : cols;
 	}
-	cols /= 5;
+	int div = R_MAX(255 / (p->cols * 3), 1);
+	cols /= div;
 	for (i = 0; i < size; i++) {
 		if (addr != UT64_MAX && step > 0) {
 			ut64 at = addr + (i * step);
@@ -1874,7 +1875,7 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 		} else {
 			p->cb_printf ("%s", v_line);
 		}
-		for (j = 0; j < arr[i] / 5; j++) {
+		for (j = 0; j < arr[i] / div; j++) {
 			printHistBlock (p, j, cols);
 		}
 		if (show_colors) {

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1852,7 +1852,7 @@ R_API void r_print_fill(RPrint *p, const ut8 *arr, int size, ut64 addr, int step
 	for (i = 0; i < size; i++) {
 		cols = arr[i] > cols ? arr[i] : cols;
 	}
-	int div = R_MAX(255 / (p->cols * 3), 1);
+	int div = R_MAX (255 / (p->cols * 3), 1);
 	cols /= div;
 	for (i = 0; i < size; i++) {
 		if (addr != UT64_MAX && step > 0) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

For bigger terminals no more hardcoded value for bar width.
I tried to keep old look default.
