### PR TITLE
Add pickle assembler ##anal

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -634,7 +634,7 @@ static int pickle_opasm(RAnal *a, ut64 addr, const char *str, ut8 *outbuf, int o
 		case OP_UNICODE:
 		case OP_GET:
 		case OP_PUT:
-			R_LOG_ERROR ("This assembler can't handle %s (op: 0x%02x) yet\n", opstr, op);
+			R_LOG_ERROR ("This assembler can't handle %s (op: 0x%02x) yet", opstr, op);
 			wlen = -1;
 			break;
 		default:

--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -368,7 +368,7 @@ static inline bool write_num_sz(ut64 n, int byte_sz, ut8 *outbuf, int outsz) {
 	int bits = r_num_to_bits (NULL, n);
 	// TODO: signedness prbly wrong...
 	if (bits > byte_sz * 8) {
-		R_LOG_ERROR ("Arg 0x" PFMT64x " more then %d bits\n", n, bits);
+		R_LOG_ERROR ("Arg 0x" PFMT64x " more then %d bits", n, bits);
 		false;
 	}
 	switch (byte_sz) {

--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -5,6 +5,11 @@
 
 #define MAXSTRLEN 128
 
+struct opmap {
+	const char *name;
+	char op;
+};
+
 enum opcode {
 	OP_MARK = '(',
 	OP_STOP = '.',
@@ -82,6 +87,77 @@ enum opcode {
 	OP_BYTEARRAY8 = '\x96',
 	OP_NEXT_BUFFER = '\x97',
 	OP_READONLY_BUFFER = '\x98'
+};
+
+static const struct opmap op_name_map[] = {
+	{ "MARK", '(' },
+	{ "STOP", '.' },
+	{ "POP", '0' },
+	{ "POP_MARK", '1' },
+	{ "DUP", '2' },
+	{ "FLOAT", 'F' },
+	{ "INT", 'I' },
+	{ "BININT", 'J' },
+	{ "BININT1", 'K' },
+	{ "LONG", 'L' },
+	{ "BININT2", 'M' },
+	{ "NONE", 'N' },
+	{ "PERSID", 'P' },
+	{ "BINPERSID", 'Q' },
+	{ "REDUCE", 'R' },
+	{ "STRING", 'S' },
+	{ "BINSTRING", 'T' },
+	{ "SHORT_BINSTRING", 'U' },
+	{ "UNICODE", 'V' },
+	{ "BINUNICODE", 'X' },
+	{ "APPEND", 'a' },
+	{ "BUILD", 'b' },
+	{ "GLOBAL", 'c' },
+	{ "DICT", 'd' },
+	{ "EMPTY_DICT", '}' },
+	{ "APPENDS", 'e' },
+	{ "GET", 'g' },
+	{ "BINGET", 'h' },
+	{ "INST", 'i' },
+	{ "LONG_BINGET", 'j' },
+	{ "LIST", 'l' },
+	{ "EMPTY_LIST", ']' },
+	{ "OBJ", 'o' },
+	{ "PUT", 'p' },
+	{ "BINPUT", 'q' },
+	{ "LONG_BINPUT", 'r' },
+	{ "SETITEM", 's' },
+	{ "TUPLE", 't' },
+	{ "EMPTY_TUPLE", ')' },
+	{ "SETITEMS", 'u' },
+	{ "BINFLOAT", 'G' },
+	{ "PROTO", '\x80' },
+	{ "NEWOBJ", '\x81' },
+	{ "EXT1", '\x82' },
+	{ "EXT2", '\x83' },
+	{ "EXT4", '\x84' },
+	{ "TUPLE1", '\x85' },
+	{ "TUPLE2", '\x86' },
+	{ "TUPLE3", '\x87' },
+	{ "NEWTRUE", '\x88' },
+	{ "NEWFALSE", '\x89' },
+	{ "LONG1", '\x8a' },
+	{ "LONG4", '\x8b' },
+	{ "BINBYTES", 'B' },
+	{ "SHORT_BINBYTES", 'C' },
+	{ "SHORT_BINUNICODE", '\x8c' },
+	{ "BINUNICODE8", '\x8d' },
+	{ "BINBYTES8", '\x8e' },
+	{ "EMPTY_SET", '\x8f' },
+	{ "ADDITEMS", '\x90' },
+	{ "FROZENSET", '\x91' },
+	{ "NEWOBJ_EX", '\x92' },
+	{ "STACK_GLOBAL", '\x93' },
+	{ "MEMOIZE", '\x94' },
+	{ "FRAME", '\x95' },
+	{ "BYTEARRAY8", '\x96' },
+	{ "NEXT_BUFFER", '\x97' },
+	{ "READONLY_BUFFER", '\x98' }
 };
 
 static inline int handle_int(RAnalOp *op, const char *name, int sz, const ut8 *buf, int buflen) {
@@ -434,83 +510,11 @@ static inline int assemble_cnt_str(const char *str, int byte_sz, ut8 *outbuf, in
 }
 
 static inline int write_op(char *opstr, ut8 *outbuf) {
-	struct opmap {const char *name; char op;};
-	struct opmap map[] = {
-		{ "MARK", '(' },
-		{ "STOP", '.' },
-		{ "POP", '0' },
-		{ "POP_MARK", '1' },
-		{ "DUP", '2' },
-		{ "FLOAT", 'F' },
-		{ "INT", 'I' },
-		{ "BININT", 'J' },
-		{ "BININT1", 'K' },
-		{ "LONG", 'L' },
-		{ "BININT2", 'M' },
-		{ "NONE", 'N' },
-		{ "PERSID", 'P' },
-		{ "BINPERSID", 'Q' },
-		{ "REDUCE", 'R' },
-		{ "STRING", 'S' },
-		{ "BINSTRING", 'T' },
-		{ "SHORT_BINSTRING", 'U' },
-		{ "UNICODE", 'V' },
-		{ "BINUNICODE", 'X' },
-		{ "APPEND", 'a' },
-		{ "BUILD", 'b' },
-		{ "GLOBAL", 'c' },
-		{ "DICT", 'd' },
-		{ "EMPTY_DICT", '}' },
-		{ "APPENDS", 'e' },
-		{ "GET", 'g' },
-		{ "BINGET", 'h' },
-		{ "INST", 'i' },
-		{ "LONG_BINGET", 'j' },
-		{ "LIST", 'l' },
-		{ "EMPTY_LIST", ']' },
-		{ "OBJ", 'o' },
-		{ "PUT", 'p' },
-		{ "BINPUT", 'q' },
-		{ "LONG_BINPUT", 'r' },
-		{ "SETITEM", 's' },
-		{ "TUPLE", 't' },
-		{ "EMPTY_TUPLE", ')' },
-		{ "SETITEMS", 'u' },
-		{ "BINFLOAT", 'G' },
-		{ "PROTO", '\x80' },
-		{ "NEWOBJ", '\x81' },
-		{ "EXT1", '\x82' },
-		{ "EXT2", '\x83' },
-		{ "EXT4", '\x84' },
-		{ "TUPLE1", '\x85' },
-		{ "TUPLE2", '\x86' },
-		{ "TUPLE3", '\x87' },
-		{ "NEWTRUE", '\x88' },
-		{ "NEWFALSE", '\x89' },
-		{ "LONG1", '\x8a' },
-		{ "LONG4", '\x8b' },
-		{ "BINBYTES", 'B' },
-		{ "SHORT_BINBYTES", 'C' },
-		{ "SHORT_BINUNICODE", '\x8c' },
-		{ "BINUNICODE8", '\x8d' },
-		{ "BINBYTES8", '\x8e' },
-		{ "EMPTY_SET", '\x8f' },
-		{ "ADDITEMS", '\x90' },
-		{ "FROZENSET", '\x91' },
-		{ "NEWOBJ_EX", '\x92' },
-		{ "STACK_GLOBAL", '\x93' },
-		{ "MEMOIZE", '\x94' },
-		{ "FRAME", '\x95' },
-		{ "BYTEARRAY8", '\x96' },
-		{ "NEXT_BUFFER", '\x97' },
-		{ "READONLY_BUFFER", '\x98' }
-	};
-
 	bool ret = false;
 	size_t i;
-	for (i = 0; i < R_ARRAY_SIZE (map); i++) {
-		if (!r_str_casecmp (opstr, map[i].name)) {
-			*outbuf = (ut8)map[i].op;
+	for (i = 0; i < R_ARRAY_SIZE (op_name_map); i++) {
+		if (!r_str_casecmp (opstr, op_name_map[i].name)) {
+			*outbuf = (ut8)op_name_map[i].op;
 			ret = true;
 			break;
 		}

--- a/test/db/anal/pickle
+++ b/test/db/anal/pickle
@@ -43,3 +43,215 @@ EXPECT=<<EOF
 0x0000000f                   44  
 EOF
 RUN
+
+NAME=Assemble and dissassemble single byte funcs
+FILE=malloc://8
+CMDS=<<EOF
+e asm.arch=pickle
+wa MARK
+pid 1
+wa STOP
+pid 1
+wa POP
+pid 1
+wa POP_MARK
+pid 1
+wa DUP
+pid 1
+wa NONE
+pid 1
+wa BINPERSID
+pid 1
+wa REDUCE
+pid 1
+wa APPEND
+pid 1
+wa BUILD
+pid 1
+wa DICT
+pid 1
+wa EMPTY_DICT
+pid 1
+wa APPENDS
+pid 1
+wa LIST
+pid 1
+wa EMPTY_LIST
+pid 1
+wa OBJ
+pid 1
+wa SETITEM
+pid 1
+wa TUPLE
+pid 1
+wa EMPTY_TUPLE
+pid 1
+wa SETITEMS
+pid 1
+wa NEWOBJ
+pid 1
+wa TUPLE1
+pid 1
+wa TUPLE2
+pid 1
+wa TUPLE3
+pid 1
+wa NEWTRUE
+pid 1
+wa NEWFALSE
+pid 1
+wa EMPTY_SET
+pid 1
+wa ADDITEMS
+pid 1
+wa FROZENSET
+pid 1
+wa NEWOBJ_EX
+pid 1
+wa STACK_GLOBAL
+pid 1
+wa MEMOIZE
+pid 1
+wa NEXT_BUFFER
+pid 1
+wa READONLY_BUFFER
+pid 1
+EOF
+EXPECT=<<EOF
+0x00000000                   28  MARK
+0x00000000                   2e  STOP
+0x00000000                   30  POP
+0x00000000                   31  POP_MARK
+0x00000000                   32  DUP
+0x00000000                   4e  NONE
+0x00000000                   51  BINPERSID
+0x00000000                   52  REDUCE
+0x00000000                   61  APPEND
+0x00000000                   62  BUILD
+0x00000000                   64  DICT
+0x00000000                   7d  EMPTY_DICT
+0x00000000                   65  APPENDS
+0x00000000                   6c  LIST
+0x00000000                   5d  EMPTY_LIST
+0x00000000                   6f  OBJ
+0x00000000                   73  SETITEM
+0x00000000                   74  TUPLE
+0x00000000                   29  EMPTY_TUPLE
+0x00000000                   75  SETITEMS
+0x00000000                   81  NEWOBJ
+0x00000000                   85  TUPLE1
+0x00000000                   86  TUPLE2
+0x00000000                   87  TUPLE3
+0x00000000                   88  NEWTRUE
+0x00000000                   89  NEWFALSE
+0x00000000                   8f  EMPTY_SET
+0x00000000                   90  ADDITEMS
+0x00000000                   91  FROZENSET
+0x00000000                   92  NEWOBJ_EX
+0x00000000                   93  STACK_GLOBAL
+0x00000000                   94  MEMOIZE
+0x00000000                   97  NEXT_BUFFER
+0x00000000                   98  READONLY_BUFFER
+EOF
+RUN
+
+NAME=Assemble and dissassemble all ints
+FILE=malloc://16
+CMDS=<<EOF
+e asm.arch=pickle
+wa FRAME 0x1122334455887788
+pid 1
+wa BININT 0x11223344
+pid 1
+wa LONG_BINPUT 0x11223344
+pid 1
+wa LONG_BINGET 0x11223344
+pid 1
+wa EXT4 0x11223344
+pid 1
+wa LONG4 0x11223344
+pid 1
+wa BININT2 0x1122
+pid 1
+wa EXT2 0x1122
+pid 1
+wa BININT1 0x11
+pid 1
+wa BINGET 0x11
+pid 1
+wa BINPUT 0x11
+pid 1
+wa PROTO 0x11
+pid 1
+wa EXT1 0x11
+pid 1
+wa LONG1 0x11
+pid 1
+EOF
+EXPECT=<<EOF
+0x00000000   958877885544332211  FRAME 0x1122334455887788
+0x00000000           4a44332211  BININT 0x11223344
+0x00000000           7244332211  LONG_BINPUT 0x11223344
+0x00000000           6a44332211  LONG_BINGET 0x11223344
+0x00000000           8444332211  EXT4 0x11223344
+0x00000000           8b44332211  LONG4 0x11223344
+0x00000000               4d2211  BININT2 0x1122
+0x00000000               832211  EXT2 0x1122
+0x00000000                 4b11  BININT1 0x11
+0x00000000                 6811  BINGET 0x11
+0x00000000                 7111  BINPUT 0x11
+0x00000000                 8011  PROTO 0x11
+0x00000000                 8211  EXT1 0x11
+0x00000000                 8a11  LONG1 0x11
+EOF
+RUN
+
+NAME=Assemble and dissassemble counted strings
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=pickle
+wa BINUNICODE8 AABBCCDD
+pid 1
+wa BINBYTES8 AABBCCDD
+pid 1
+wa BYTEARRAY8 AABBCCDD
+pid 1
+wa BINSTRING AABBCCDD
+pid 1
+wa BINUNICODE AABBCCDD
+pid 1
+wa BINBYTES AABBCCDD
+pid 1
+wa SHORT_BINBYTES AABBCCDD
+pid 1
+wa SHORT_BINSTRING AABBCCDD
+pid 1
+wa SHORT_BINUNICODE AABBCCDD
+pid 1
+EOF
+EXPECT=<<EOF
+0x00000000 8d08000000000000006161626263636464  BINUNICODE8 "aabbccdd"
+0x00000000 8e08000000000000006161626263636464  BINBYTES8 "aabbccdd"
+0x00000000 9608000000000000006161626263636464  BYTEARRAY8 "aabbccdd"
+0x00000000 54080000006161626263636464  BINSTRING "aabbccdd"
+0x00000000 58080000006161626263636464  BINUNICODE "aabbccdd"
+0x00000000 42080000006161626263636464  BINBYTES "aabbccdd"
+0x00000000 43086161626263636464  SHORT_BINBYTES "aabbccdd"
+0x00000000 55086161626263636464  SHORT_BINSTRING "aabbccdd"
+0x00000000 8c086161626263636464  SHORT_BINUNICODE "aabbccdd"
+EOF
+RUN
+
+
+NAME=Assemble and dissassemble float
+FILE=malloc://16
+CMDS=<<EOF
+e asm.arch=pickle
+wa BINFLOAT 4.328
+pid 1
+e asm.arch=pickle
+EOF
+EXPECT=<<EOF
+0x00000000   4740114fdf3b645a1d  BINFLOAT 4.328000
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This pull adds an assembler for the python pickle machine architecture. 

At this time, the assembler handles all ops except `INST`, `GLOBAL`, `FLOAT`, `INT`, `LONG`, `PERSID`, `STRING`, `UNICODE`, `GET` and `PUT`. I hope to add assemblers for those soon. Assuming this looks ok, you can merge now or wait.

Also, I did this in rather a lazy way. If you want me to use a hash table for opcode names I can refactor a bit.