### PR TITLE
Fix p=F output ##print

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -4324,7 +4324,7 @@ static void cmd_print_bars(RCore *core, const char *input) {
 						k++;
 					}
 					break;
-				case 'f':
+				case 'F':
 					if (p[j] == 0xff) {
 						k++;
 					}

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -1258,3 +1258,16 @@ offset table offset points outside of valid range
 ERROR: bplist parse error
 EOF
 RUN
+
+NAME=p=F hello-linux-x86_64
+FILE=bins/elf/analysis/hello-linux-x86_64
+CMDS=p=F
+EXPECT=<<EOF
+0x00400000 000 0000 |
+0x00400100 001 0000 |
+0x00400200 002 0000 |
+0x00400300 003 000a |##
+0x00400400 004 0013 |###
+0x00400500 005 0014 |####
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The case was never triggered. Giving only zero bars output results.
