### PR TITLE
Make PageUp/Down keys less laggy ##visual

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4519,8 +4519,11 @@ dodo:
 					if (chrs[0] == '[') {
 						chrs[1] = r_cons_readchar ();
 						chrs_read++;
-						if (chrs[1] >= 'A' && chrs[1] <= 'D') { // arrow keys
-							flush_stdin ();
+						int ch56 = chrs[1] == '5' || chrs[1] == '6';
+						if ((chrs[1] >= 'A' && chrs[1] <= 'D') || ch56) { // arrow keys
+							if (!ch56 || r_cons_readchar () == '~') {
+								chrs_read += ch56;
+								flush_stdin ();
 #ifndef __WINDOWS__
 							// Following seems to fix an issue where scrolling slows
 							// down to a crawl for some terminals after some time
@@ -4528,6 +4531,7 @@ dodo:
 							r_cons_set_raw (false);
 							r_cons_set_raw (true);
 #endif
+							}
 						}
 					}
 					(void)r_cons_readpush (chrs, chrs_read);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I get irritated by increasing input buffer when keeping page up/down keys pressed down.
On slower machines it will not stop scrolling when keys are no more pressed down, instead
r2 will in visual mode continue to scroll several seconds more, much more obvious in disassembly output with colors then in hex one.
