### PR TITLE
Dont show asm.describe on strings ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5185,7 +5185,17 @@ static void ds_print_comments_right(RDisasmState *ds) {
 	bool is_code = (!ds->hint) || (ds->hint && ds->hint->type != 'd');
 	RAnalMetaItem *mi = r_meta_get_at (ds->core->anal, ds->at, R_META_TYPE_ANY, NULL);
 	if (mi) {
-		is_code = mi->type != 'd';
+		switch (mi->type) {
+		case 'd':
+		case 'h':
+		case 'm':
+		case 's':
+		case 'f':
+			is_code = false;
+			break;
+		default:
+			break;
+		}
 		mi = NULL;
 	}
 	if (is_code && ds->asm_describe && !ds->has_description) {

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -1,3 +1,18 @@
+NAME=pd asmdescribe on string
+FILE=bins/mach0/mac-ls4
+ARGS=-a arm -b64
+CMDS=<<EOF
+s 0x100003ac0
+Cz
+e asm.describe=1
+pd 2
+EOF
+EXPECT=<<EOF
+            0x100003ac0     .string "\xbf\n" ; len=3
+            0x100003ac3                     unaligned
+EOF
+RUN
+
 NAME=pd call sym bug
 FILE=bins/mach0/hello-objc-arm
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
