### PR TITLE
Fix color changing for same block and prc=f ##print

### DIFF
--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -776,14 +776,6 @@ static void cmd_prc_zoom(RCore *core, const char *input) {
 	core->print->zoom->mode = (input && *input)? input[1]: 'e';
 	r_print_zoom_buf (core->print, core, printzoomcallback, from, to, len, len);
 	block = core->print->zoom->buf;
-	switch (core->print->zoom->mode) {
-	case 'f':
-		// scale buffer for proper visualization of small numbers as colors
-		for (i = 0; i < core->print->zoom->size; i++) {
-			block[i] *= 8;
-		}
-		break;
-	}
 
 	for (i = 0; i < len; i += cols) {
 		ut64 ea = core->offset + i;


### PR DESCRIPTION
The color issue of small numbers have been fixed in another commit.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The prc=f would switch colors, if used on same block again, because it accumulates changes.
Better fix would be to round away from zero in such cases, would fix scr.colors=0 in all other print cases.
Cant scr.colors=0 case have more entries? One could just count number of white pixels in default font per each character ....
and sort that from lowest to highest, and get more entries than current 9.

