### PR TITLE
Fix not calling r_asm_op_fini() when needed

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -605,7 +605,7 @@ static RList *r_core_asm_back_disassemble_all(RCore *core, ut64 addr, ut64 len, 
 		r_asm_op_fini (&op);
 	} while ( ((int) current_buf_pos  >= 0) && (int)(len - current_buf_pos) >= 0 && hit_count <= max_hit_count);
 
-	free(buf);
+	free (buf);
 	return hits;
 }
 

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -2132,7 +2132,6 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 	const char *esilstr;
 	const char *opexstr;
 	RAnalHint *hint;
-	RAsmOp asmop = {0};
 	RAnalOp op = {0};
 	ut64 addr;
 	PJ *pj = NULL;
@@ -2162,6 +2161,7 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 	}
 	}
 	for (i = idx = ret = 0; idx < len && (!nops || (nops && i < nops)); i++, idx += ret) {
+		RAsmOp asmop = {0};
 		addr = core->offset + idx;
 		r_asm_set_pc (core->rasm, addr);
 		hint = r_anal_hint_get (core->anal, addr);
@@ -2558,8 +2558,8 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 		free (mnem);
 		r_anal_hint_free (hint);
 		r_anal_op_fini (&op);
+		r_asm_op_fini (&asmop);
 	}
-	r_asm_op_fini (&asmop);
 	r_anal_op_fini (&op);
 	if (fmt == 's') {
 		r_cons_printf ("%d\n", totalsize);

--- a/libr/core/cmd_debug.c
+++ b/libr/core/cmd_debug.c
@@ -798,7 +798,6 @@ static bool is_repeatable_inst(RCore *core, ut64 addr) {
 }
 
 static int step_until_inst(RCore *core, const char *instr, bool regex) {
-	RAsmOp asmop;
 	ut8 buf[32];
 	ut64 pc;
 	int ret;
@@ -811,6 +810,7 @@ static int step_until_inst(RCore *core, const char *instr, bool regex) {
 	}
 	r_cons_break_push (NULL, NULL);
 	for (;;) {
+		RAsmOp asmop;
 		if (r_cons_is_breaked ()) {
 			break;
 		}
@@ -836,15 +836,18 @@ static int step_until_inst(RCore *core, const char *instr, bool regex) {
 			if (regex) {
 				if (r_regex_match (instr, "e", buf_asm)) {
 					eprintf ("Stop.\n");
+					r_asm_op_fini (&asmop);
 					break;
 				}
 			} else {
 				if (strstr (buf_asm, instr)) {
 					eprintf ("Stop.\n");
+					r_asm_op_fini (&asmop);
 					break;
 				}
 			}
 		}
+		r_asm_op_fini (&asmop);
 	}
 	r_cons_break_pop ();
 	return true;

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -6916,6 +6916,7 @@ static int cmd_print(void *data, const char *input) {
 					}
 					r_cons_printf ("  // %s\n", r_strbuf_get (&asmop.buf_asm));
 					i--;
+					r_asm_op_fini (&asmop);
 				}
 				r_cons_printf (".equ shellcode_len, %d\n", len);
 			} else {

--- a/libr/core/cmd_seek.c
+++ b/libr/core/cmd_seek.c
@@ -304,6 +304,7 @@ static int cmd_seek_opcode_backward(RCore *core, int numinstr) {
 			}
 			val += op.size;
 			addr = prev_addr;
+			r_asm_op_fini (&op);
 		}
 	}
 	r_core_seek (core, addr, true);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2494,6 +2494,7 @@ R_API char *r_core_anal_hasrefs_to_depth(RCore *core, ut64 value, PJ *pj, int de
 				r_asm_set_pc (core->rasm, value);
 				r_asm_disassemble (core->rasm, &op, buf, sizeof (buf));
 				r_strbuf_appendf (s, "'%s' ", r_asm_op_get_asm (&op));
+				r_asm_op_fini (&op);
 				/* get library name */
 				{ // NOTE: dup for mapname?
 					RDebugMap *map;

--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -1591,6 +1591,7 @@ static void __fix_cursor_down(RCore *core) {
 			if (sz < 1) {
 				sz = 1;
 			}
+			r_asm_op_fini (&op);
 			r_core_seek_delta (core, sz);
 			print->cur = R_MAX (print->cur - sz, 0);
 			if (print->ocur != -1) {
@@ -2778,6 +2779,7 @@ static void __direction_disassembly_cb(void *user, int direction) {
 			r_core_visual_disasm_down (core, &op, &cols);
 			r_core_seek (core, core->offset + cols, true);
 			__set_panel_addr (core, cur, core->offset);
+			r_asm_op_fini (&op);
 		}
 		break;
 	}

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1979,6 +1979,7 @@ static void cursor_prevrow(RCore *core, bool use_ocur) {
 				r_core_seek (core, prev_addr, true);
 				prev_sz = r_asm_disassemble (core->rasm, &op,
 					core->block, 32);
+				r_asm_op_fini (&op);
 			}
 		} else {
 			prev_sz = roff - prev_roff;
@@ -2050,6 +2051,7 @@ static bool fix_cursor(RCore *core) {
 				p->ocur = R_MAX (p->ocur - sz, 0);
 			}
 			res |= off_is_visible;
+			r_asm_op_fini (&op);
 		}
 	} else if (core->print->cur >= offscreen) {
 		r_core_seek (core, core->offset + p->cols, true);
@@ -2446,7 +2448,6 @@ static int process_get_click(RCore *core, int ch) {
 
 R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 	ut8 och = arg[0];
-	RAsmOp op;
 	ut64 offset = core->offset;
 	char buf[4096];
 	const char *key_s;
@@ -3102,8 +3103,10 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 							times = distance;
 						}
 						while (times--) {
+							RAsmOp op;
 							if (isDisasmPrint (core->printidx)) {
 								r_core_visual_disasm_down (core, &op, &cols);
+								r_asm_op_fini (&op);
 							} else if (!strcmp (__core_visual_print_command (core),
 									"prc")) {
 								cols = r_config_get_i (core->config, "hex.cols");
@@ -3130,10 +3133,12 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 				}
 			} else {
 				if (core->print->screen_bounds > 1 && core->print->screen_bounds >= core->offset) {
+					RAsmOp op;
 					ut64 addr = UT64_MAX;
 					if (isDisasmPrint (core->printidx)) {
 						if (core->print->screen_bounds == core->offset) {
 							r_asm_disassemble (core->rasm, &op, core->block, 32);
+							r_asm_op_fini (&op);
 						}
 						if (addr == core->offset || addr == UT64_MAX) {
 							addr = core->offset + 48;

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -133,7 +133,6 @@ R_API bool r_core_visual_esil(RCore *core, const char *input) {
 	char *word = NULL;
 	int x = 0;
 	char *ginput = NULL;
-	RAsmOp asmop;
 	RAnalOp analop;
 	ut8 buf[sizeof (ut64)];
 	unsigned int addrsize = r_config_get_i (core->config, "esil.addr.size");
@@ -168,6 +167,7 @@ R_API bool r_core_visual_esil(RCore *core, const char *input) {
 		if (input) {
 			expr = strdup (input);
 		} else {
+			RAsmOp asmop;
 			memcpy (buf, core->block, sizeof (ut64));
 			// bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 			(void) r_asm_disassemble (core->rasm, &asmop, buf, sizeof (ut64));
@@ -192,6 +192,7 @@ R_API bool r_core_visual_esil(RCore *core, const char *input) {
 			r_cons_printf (Color_RESET"asm: %s\n"Color_RESET, op);
 			free (op);
 			expr = strdup (r_strbuf_get (&analop.esil));
+			r_asm_op_fini (&asmop);
 		}
 		{
 			r_cons_printf (Color_RESET"esil: %s\n"Color_RESET, expr);
@@ -362,7 +363,6 @@ R_API bool r_core_visual_bit_editor(RCore *core) {
 	bool colorBits = false;
 	int analopType;
 	int i, j, x = 0;
-	RAsmOp asmop;
 	RAnalOp analop;
 	ut8 buf[sizeof (ut64)];
 	bool bitsInLine = false;
@@ -376,6 +376,7 @@ R_API bool r_core_visual_bit_editor(RCore *core) {
 	}
 	memcpy (buf, core->block + cur, sizeof (ut64));
 	for (;;) {
+		RAsmOp asmop;
 		r_cons_clear00 ();
 		bool use_color = core->print->flags & R_PRINT_FLAGS_COLOR;
 		(void) r_asm_disassemble (core->rasm, &asmop, buf, sizeof (ut64));
@@ -642,6 +643,7 @@ R_API bool r_core_visual_bit_editor(RCore *core) {
 			}
 			break;
 		}
+		r_asm_op_fini (&asmop);
 	}
 	return true;
 }

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -528,9 +528,9 @@ static int rasm_disasm(RAsmState *as, ut64 addr, const char *buf, int len, int b
 			r_anal_op_fini (&aop);
 		}
 	} else if (hex) {
-		RAsmOp op;
 		r_asm_set_pc (as->a, addr);
 		while ((len - ret) > 0) {
+			RAsmOp op;
 			int dr = r_asm_disassemble (as->a, &op, data + ret, len - ret);
 			if (dr == -1 || op.size < 1) {
 				op.size = 1;
@@ -543,6 +543,7 @@ static int rasm_disasm(RAsmState *as, ut64 addr, const char *buf, int len, int b
 			free (op_hex);
 			ret += op.size;
 			r_asm_set_pc (as->a, addr+ ret);
+			r_asm_op_fini (&op);
 		}
 	} else {
 		r_asm_set_pc (as->a, addr);


### PR DESCRIPTION
Fixes some leaks.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The RAsmOp is used on stack when disassembling and after its content is not need it needs to call its _fini to free possible heap memory previously allocated.
