### PR TITLE
Fix overreads in r_str_utf8_codepoint()

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -2229,11 +2229,11 @@ R_API size_t r_str_utf8_codepoint(const char* s, size_t left) {
 	}
 	if ((*s & 0x80) != 0x80) {
 		return 0;
-	} else if ((*s & 0xe0) == 0xc0 && left >= 1) {
+	} else if ((*s & 0xe0) == 0xc0 && left > 1) {
 		return ((*s & 0x1f) << 6) + (*(s + 1) & 0x3f);
-	} else if ((*s & 0xf0) == 0xe0 && left >= 3) {
+	} else if ((*s & 0xf0) == 0xe0 && left > 2) {
 		return ((*s & 0xf) << 12) + ((*(s + 1) & 0x3f) << 6) + (*(s + 2) & 0x3f);
-	} else if ((*s & 0xf8) == 0xf0 && left >= 3) {
+	} else if ((*s & 0xf8) == 0xf0 && left > 3) {
 		return ((*s & 0x7) << 18) + ((*(s + 1) & 0x3f) << 12) + ((*(s + 2) & 0x3f) << 6) + (*(s + 3) & 0x3f);
 	}
 	return 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixed crash in 'v' panel mode under address sanitizer, when showing entropy bars.
