### PR TITLE
Fix string literal free in bin.dol

### DIFF
--- a/libr/bin/p/bin_dol.c
+++ b/libr/bin/p/bin_dol.c
@@ -160,7 +160,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->arch = strdup ("ppc");
 	ret->has_va = true;
 	ret->bits = 32;
-	ret->cpu = "ps";
+	ret->cpu = strdup ("ps");
 
 	return ret;
 }


### PR DESCRIPTION
**Description**

I'm not sure how this ever worked. `RBinInfo::cpu` is a heap string, not a rodata constant
Fixes a minor skill issue 