### PR TITLE
Fix double free when shrinking vectors ##crash

### DIFF
--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -19,6 +19,11 @@
 
 #define RESIZE_OR_RETURN_NULL(next_capacity) do { \
 		size_t new_capacity = next_capacity; \
+		if (new_capacity == 0) { \
+			R_FREE (vec->a); \
+			vec->capacity = 0; \
+			break; \
+		} \
 		void **new_a = realloc (vec->a, vec->elem_size * new_capacity); \
 		if (!new_a) { \
 			return NULL; \


### PR DESCRIPTION
realloc() call can return NULL for size of 0 and still free()
that memory, there was no check for this so code ends prematurely
and double free can happen later.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
