### PR TITLE
Fix returning imports table ##bin

### DIFF
--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -302,7 +302,7 @@ static RList *get_imports(RBinFile *bf) {
 			r_list_append (ret, ptr);
 		}
 	}
-
+	return ret;
 bad_alloc:
 	r_list_free (ret);
 	return NULL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Was wondering why 'ii' shows nothing for wasm files.
