### PR TITLE
[5.8.0] Fix memory leak in r_str_list_join()

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3753,13 +3753,13 @@ R_API void r_str_stripLine(char *str, const char *key) {
 
 R_API char *r_str_list_join(RList *str, const char *sep) {
 	r_return_val_if_fail (str && sep, NULL);
+	RListIter *iter;
 	RStrBuf *sb = r_strbuf_new ("");
-	const char *p;
-	while ((p = r_list_pop_head (str))) {
+	r_list_foreach_iter (str, iter) {
 		if (r_strbuf_length (sb) != 0) {
 			r_strbuf_append (sb, sep);
 		}
-		r_strbuf_append (sb, p);
+		r_strbuf_append (sb, iter->data);
 	}
 	return r_strbuf_drain (sb);
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
