### PR TITLE
Fix for #16209 - ragg2 not working on MAC OS

### DIFF
--- a/libr/egg/egg_cfile.c
+++ b/libr/egg/egg_cfile.c
@@ -104,10 +104,10 @@ static struct cEnv_t* r_egg_cfile_set_cEnv(const char *arch, const char *os, int
 		if (!strcmp (arch, "x86")) {
 			if (bits == 32) {
 				cEnv->CFLAGS = strdup ("-arch i386 -fPIC -fPIE");
-				cEnv->LDFLAGS = strdup ("-arch i386 -shared -c -fPIC -fPIE -pie");
+				cEnv->LDFLAGS = strdup ("-arch i386 -fPIC -fPIE -pie");
 			} else {
 				cEnv->CFLAGS = strdup ("-arch x86_64 -fPIC -fPIE");
-				cEnv->LDFLAGS = strdup ("-arch x86_64 -shared -c -fPIC -fPIE -pie");
+				cEnv->LDFLAGS = strdup ("-arch x86_64 -fPIC -fPIE -pie");
 			}
 		} else {
 			cEnv->CFLAGS = strdup ("-shared -c -fPIC -pie -fPIE");
@@ -139,8 +139,8 @@ static struct cEnv_t* r_egg_cfile_set_cEnv(const char *arch, const char *os, int
 		cEnv->TEXT = ".text";
 		cEnv->FMT = "pe";
 	} else if (isXNU(os)) {
-		//cEnv->TEXT = "0.__TEXT.__text";
-		cEnv->TEXT = "0..__text";
+		cEnv->TEXT = "0.__TEXT.__text";
+		// cEnv->TEXT = "__text";
 	} else {
 		cEnv->TEXT = ".text";
 	}
@@ -185,15 +185,19 @@ static struct cEnv_t* r_egg_cfile_set_cEnv(const char *arch, const char *os, int
 		free (cEnv->CFLAGS);
 		cEnv->CFLAGS = strdup (buffer);
 	}
-	free (buffer);
-	buffer = r_str_newf ("%s -nostdlib", cEnv->LDFLAGS);
-	if (!buffer) {
-		goto fail;
-	}
-	free (cEnv->LDFLAGS);
-	cEnv->LDFLAGS = strdup (buffer);
-
-	if (r_egg_cfile_check_cEnv (cEnv)) {
+    if (!isXNU (os)) {
+        /* Every executable must link with libSystem.dylib,
+         * so '-nostdlib' is not needed for XNU/MAC */
+	    free (buffer);
+        buffer = r_str_newf ("%s -nostdlib", cEnv->LDFLAGS);
+	    if (!buffer) {
+		    goto fail;
+	    }
+	    free (cEnv->LDFLAGS);
+	    cEnv->LDFLAGS = strdup (buffer);
+    }
+    
+    if (r_egg_cfile_check_cEnv (cEnv)) {
 		R_LOG_ERROR ("invalid cEnv allocation");
 		goto fail;
 	}
@@ -307,10 +311,15 @@ R_API char* r_egg_cfile_parser(const char *file, const char *arch, const char *o
 		goto fail;
 	}
 	if (r_file_size (fileExt) == 0) {
-		eprintf ("FALLBACK: Using objcopy instead of rabin2");
+		eprintf ("FALLBACK: Using objcopy instead of rabin2\n");
 		free (output);
-		output = r_sys_cmd_strf ("'%s' -j .text -O binary '%s.o' '%s.text'",
-		  		cEnv->OBJCOPY, file, file);
+        if (isXNU(os)) {
+            output = r_sys_cmd_strf ("'%s' -j 0.__TEXT.__text -O binary '%s.o' '%s.text'",
+		  	    	cEnv->OBJCOPY, file, file);
+        } else {
+		    output = r_sys_cmd_strf ("'%s' -j .text -O binary '%s.o' '%s.text'",
+		  	    	cEnv->OBJCOPY, file, file);
+        }
 		if (!output) {
 			eprintf ("objcopy failed!\n");
 			goto fail;


### PR DESCRIPTION
Please refer to Issue https://github.com/radareorg/radare2/issues/16209 for all details.

A basic test:

```c
$ cat ./hi.c
int main() {
  write (1,"Hello!\n",7);
  exit(0);
}
```

Compile it,

```
$ ragg2 -O -F hi.c
'llvm-gcc' -arch x86_64 -fPIC -fPIE -fno-stack-protector -nostdinc -include '/usr/local/include/libr/sflib'/'darwin-x86-64'/sflib.h -z execstack -fomit-frame-pointer -finline-functions -fno-zero-initialized-in-bss -o 'hi.c.tmp' -S 'hi.c'

clang: warning: -z execstack: 'linker' input unused [-Wunused-command-line-argument]
In file included from <built-in>:1:
/usr/local/include/libr/sflib/darwin-x86-64/sflib.h:38:89: warning: declaration of 'struct rusage' will not be visible outside of this function [-Wvisibility]
static inline _sfsyscall4(pid_t, wait4, pid_t, pid, int *, status, int, options, struct rusage *, rusage)
                                                                                        ^
/usr/local/include/libr/sflib/darwin-x86-64/sflib.h:168:58: warning: declaration of 'struct sembuf' will not be visible outside of this function [-Wvisibility]
static inline _sfsyscall3(int, semop, int, semid, struct sembuf *, sops, unsigned, nsops)
                                                         ^
2 warnings generated.
'llvm-gcc' -arch x86_64 -fPIC -fPIE -pie -o 'hi.c.o' 'hi.c.s'
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
rabin2 -o 'hi.c.text' -O d/S/'0.__TEXT.__text' 'hi.c.o'
```

And run it,

```
AGAUTHAM-M-F86S:hi agautham$ ls -l hi
-rwxr-xr-x  1 agautham  staff  4264 Jul 31 21:26 hi
AGAUTHAM-M-F86S:hi agautham$ ./hi
Hello!
```