### PR TITLE
Emit json when radiff2 is run with -Cj ##diff

### DIFF
--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -159,3 +159,79 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
 		}
 	}
 }
+
+/* Iterate available diffs and print json output */
+R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
+	RList *fcns = r_anal_get_fcns (c->anal);
+	const char *match;
+	RListIter *iter;
+	RAnalFunction *f;
+	PJ *pj = pj_new ();
+
+	if (!pj) {
+		return;
+	}
+
+	fcns = r_anal_get_fcns (c->anal);
+	if (r_list_empty (fcns)) {
+		eprintf ("No functions found, try running with -A or load a project\n");
+		return;
+	}
+
+	pj_a (pj);
+
+	r_list_foreach (fcns, iter, f) {
+		switch (f->type) {
+		case R_ANAL_FCN_TYPE_FCN:
+		case R_ANAL_FCN_TYPE_SYM:
+			switch (f->diff->type) {
+			case R_ANAL_DIFF_TYPE_MATCH:
+				match = "MATCH";
+				break;
+			case R_ANAL_DIFF_TYPE_UNMATCH:
+				match = "UNMATCH";
+				break;
+			default:
+				match = "NEW";
+				f->diff->dist = 0;
+			}
+
+			pj_o (pj);
+			pj_kn (pj, "addr", f->addr);
+			pj_ks (pj, "name", f->name? f->name: "");
+			pj_kn (pj, "size", r_anal_function_linear_size (f));
+			pj_kn (pj, "diff_addr", f->diff->addr);
+			pj_ks (pj, "diff_name", f->diff->name? f->diff->name: "");
+			pj_kn (pj, "diff_size", f->diff->size);
+			pj_ks (pj, "match", match);
+			pj_kd (pj, "dist", f->diff->dist);
+			pj_end (pj);
+
+			break;
+		}
+	}
+
+	fcns = r_anal_get_fcns (c2->anal);
+	r_list_foreach (fcns, iter, f) {
+		switch (f->type) {
+		case R_ANAL_FCN_TYPE_FCN:
+		case R_ANAL_FCN_TYPE_SYM:
+			if (f->diff->type == R_ANAL_DIFF_TYPE_NULL) {
+				pj_o (pj);
+				pj_kn (pj, "addr", f->addr);
+				pj_ks (pj, "name", f->name? f->name: "");
+				pj_kn (pj, "size", r_anal_function_linear_size (f));
+				pj_ks (pj, "match", "NEW");
+				pj_kd (pj, "dist", 0);
+				pj_end (pj);
+			}
+			break;
+		}
+	}
+
+	pj_end (pj);
+
+	char *s = pj_drain (pj);
+	printf ("%s\n", s);
+	free (s);
+}

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -166,7 +166,7 @@ R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
 	const char *match;
 	RListIter *iter;
 	RAnalFunction *f;
-	PJ *pj = pj_new ();
+	PJ *pj = core_pj_new ();
 
 	if (!pj) {
 		return;

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -162,7 +162,7 @@ R_API void r_core_diff_show(RCore *c, RCore *c2) {
 
 /* Iterate available diffs and print json output */
 R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
-	RList *fcns = r_anal_get_fcns (c->anal);
+	RList *fcns;
 	const char *match;
 	RListIter *iter;
 	RAnalFunction *f;

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -174,7 +174,7 @@ R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
 
 	fcns = r_anal_get_fcns (c->anal);
 	if (r_list_empty (fcns)) {
-		eprintf ("No functions found, try running with -A or load a project\n");
+		R_LOG_INFO ("No functions found, try running with -A or load a project\n");
 		return;
 	}
 

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -174,7 +174,7 @@ R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
 
 	fcns = r_anal_get_fcns (c->anal);
 	if (r_list_empty (fcns)) {
-		R_LOG_INFO ("No functions found, try running with -A or load a project\n");
+		R_LOG_INFO ("No functions found, try running with -A or load a project");
 		return;
 	}
 

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -174,7 +174,7 @@ R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
 
 	fcns = r_anal_get_fcns (c->anal);
 	if (r_list_empty (fcns)) {
-		R_LOG_INFO ("No functions found, try running with -A or load a project");
+		R_LOG_ERROR ("No functions found, try running with -A or load a project");
 		return;
 	}
 

--- a/libr/core/gdiff.c
+++ b/libr/core/gdiff.c
@@ -166,7 +166,7 @@ R_API void r_core_diff_show_json(RCore *c, RCore *c2) {
 	const char *match;
 	RListIter *iter;
 	RAnalFunction *f;
-	PJ *pj = core_pj_new ();
+	PJ *pj = r_core_pj_new (c);
 
 	if (!pj) {
 		return;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -842,6 +842,7 @@ R_API void r_core_hack_help(const RCore *core);
 R_API int r_core_hack(RCore *core, const char *op);
 R_API bool r_core_dump(RCore *core, const char *file, ut64 addr, ut64 size, int append);
 R_API void r_core_diff_show(RCore *core, RCore *core2);
+R_API void r_core_diff_show_json(RCore *core, RCore *core2);
 R_API void r_core_clippy(RCore *core, const char *msg);
 
 /* watchers */

--- a/libr/main/radiff2.c
+++ b/libr/main/radiff2.c
@@ -1054,7 +1054,7 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 			break;
 		case 't':
 			ro.threshold = atoi (opt.arg);
-			printf ("%s\n", opt.arg);
+			// printf ("%s\n", opt.arg);
 			break;
 		case 'd':
 			delta = 1;
@@ -1211,7 +1211,11 @@ R_API int r_main_radiff2(int argc, const char **argv) {
 				r_core_zdiff (c, c2);
 			} else {
 				r_core_gdiff (c, c2);
-				r_core_diff_show (c, c2);
+				if (ro.diffmode == 'j') {
+					r_core_diff_show_json (c, c2);
+				} else {
+					r_core_diff_show (c, c2);
+				}
 			}
 		} else if (ro.mode == MODE_DIFF_SYMBOLS) {
 			int sz;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Radiff2 when run with `-AAC` creates a table of similar functions based on their similarity scores. This information is not available as json, so I added a new function `r_core_diff_show_json`. The output of this function consists of an array of objects that have the following template:

```
    {
        "addr": 4203120,
        "name": "entry0",
        "size": 88,
        "diff_addr": 4203248,
        "diff_name": "entry0",
        "diff_size": 88,
        "match": "MATCH",
        "dist": 0.965909
    },
    {
        "addr": 4213228,
        "name": "fcn.004049ec",
        "size": 664,
        "match": "NEW",
        "dist": 0.000000
    },
```

<!-- explain your changes if necessary -->
