### PR TITLE
Refactor `ar` set command to static func ##anal

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -5489,7 +5489,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 			char *ostr = r_str_trim_dup (str + 1);
 			char *regname = r_str_trim_nc (ostr);
 			if (!reg_name_roll_set (core, regname, n)) {
-				R_LOG_ERROR ("ar: Unknown register '%s'\n", regname);
+				R_LOG_ERROR ("ar: Unknown register '%s'", regname);
 			}
 			free (ostr);
 			return;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This breaks out some of the `ar` handler code into it's own static functions. Then 3 instances of `r_core_cmd*` calls can be replaced with a call to the new function.

I hope to remove more `r_core_cmd*` functions from this file in the future.