### PR TITLE
Fix NULL deref in rasm2 on pickles

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -263,7 +263,8 @@ static inline int cnt_str(RAnal *a, RAnalOp *op, const char *name, int sz, const
 		op->ptrsize = r_mem_get_num (buf, sz);
 		op->size = op->nopcode + sz + op->ptrsize;
 		op->ptr = op->addr + sz + op->nopcode;
-		if (!a->iob.is_valid_offset (a->iob.io, op->addr + op->size - 1, 0)) {
+		RIOIsValidOff validoff = a->iob.io? a->iob.is_valid_offset: NULL;
+		if (validoff && !validoff (a->iob.io, op->addr + op->size - 1, 0)) {
 			// end of string is in bad area, probably this is invalid offset for op
 			op->size = 1;
 			op->type = R_ANAL_OP_TYPE_ILL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Currently rasm2 does not seem to use io bind. So `a->iob.is_valid_offset` call just lands at NULL.
