### PR TITLE
Don't map the binary at address 0, io.va=0 is enough

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2730,7 +2730,7 @@ static void add_section(RCore *core, RBinSection *sec, ut64 addr, int fd) {
 	r_name_filter (map_name, R_FLAG_NAME_SIZE);
 	int perm = sec->perm;
 	// workaround to force exec bit in text section
-	if (sec->name &&  strstr (sec->name, "text")) {
+	if (sec->name && strstr (sec->name, "text")) {
 		perm |= R_PERM_X;
 	}
 

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -692,7 +692,8 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 			}
 		}
 	} else {
-		if (desc) {
+		ut64 bin_baddr = r_config_get_i (r->config, "bin.baddr");
+		if (desc && bin_baddr) {
 			r_io_map_add (r->io, desc->fd, desc->perm, 0, laddr, r_io_desc_size (desc));
 		}
 		if (binfile) {


### PR DESCRIPTION
* We should change this behaviour in the next big release

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
