### PR TITLE
Allow rasm2 -f to open files with r_io files ##io

### DIFF
--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -716,12 +716,13 @@ static inline char *io_slurp(const char *file, size_t *len) {
 		des = r_io_open_nomap (io, file, R_PERM_R, 0);
 		if (des) {
 			ut64 size = r_io_desc_size (des);
-			ret = malloc (size);
-			if (!ret || !r_io_read (io, ret, size)) {
+			ret = malloc (size + 1);
+			if (size >= ST32_MAX || !ret || !r_io_read (io, ret, size)) {
 				free (ret);
 				ret = NULL;
 			} else {
 				*len = size;
+				ret[size] = '\0';
 			}
 		}
 	}
@@ -991,7 +992,7 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		} else {
 			content = r_file_slurp (file, &length);
 			if (!content) {
-				content = io_slurp (file, &length);
+				content = (char *)io_slurp (file, &length);
 			}
 			if (content) {
 				if (length > ST32_MAX) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Updates rasm2 so that if a file fails to slurp r_io is attempted.
