### PR TITLE
Fix quotes in pickle assembly ##anal

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -248,7 +248,7 @@ static inline int handle_opstring(RAnalOp *op, const ut8 *buf, int buflen) {
 		return -1;
 	}
 	buf++;
-	buflen -= 1; // remove starting quote
+	buflen --; // remove starting quote
 	char *str = get_line (buf, buflen);
 	if (str) {
 		size_t len = strlen (str);

--- a/test/db/anal/pickle
+++ b/test/db/anal/pickle
@@ -210,23 +210,23 @@ NAME=Assemble and dissassemble counted strings
 FILE=malloc://32
 CMDS=<<EOF
 e asm.arch=pickle
-wa BINUNICODE8 AABBCCDD
+wa BINUNICODE8 "AABBCCDD"
 pid 1
-wa BINBYTES8 AABBCCDD
+wa BINBYTES8 "AABBCCDD"
 pid 1
-wa BYTEARRAY8 AABBCCDD
+wa BYTEARRAY8 "AABBCCDD"
 pid 1
-wa BINSTRING AABBCCDD
+wa BINSTRING "AABBCCDD"
 pid 1
-wa BINUNICODE AABBCCDD
+wa BINUNICODE "AABBCCDD"
 pid 1
-wa BINBYTES AABBCCDD
+wa BINBYTES "AABBCCDD"
 pid 1
-wa SHORT_BINBYTES AABBCCDD
+wa SHORT_BINBYTES "AABBCCDD"
 pid 1
-wa SHORT_BINSTRING AABBCCDD
+wa SHORT_BINSTRING "AABBCCDD"
 pid 1
-wa SHORT_BINUNICODE AABBCCDD
+wa SHORT_BINUNICODE "AABBCCDD"
 pid 1
 EOF
 EXPECT=<<EOF
@@ -260,25 +260,25 @@ NAME=Assemble and dissassemble newline strs
 FILE=malloc://32
 CMDS=<<EOF
 e asm.arch=pickle
-wa INST string1 string2
+wa INST "string1 string2"
 pid 1
-wa GLOBAL string1 string2
+wa GLOBAL "string1 string2"
 pid 1
-wa FLOAT string_arg
+wa FLOAT "string_arg"
 pid 1
-wa INT string_arg
+wa INT "string_arg"
 pid 1
-wa LONG string_arg
+wa LONG "string_arg"
 pid 1
-wa PERSID string_arg
+wa PERSID "string_arg"
 pid 1
-wa STRING string_arg
+wa STRING "string_arg"
 pid 1
-wa UNICODE string_arg
+wa UNICODE "string_arg"
 pid 1
-wa GET string_arg
+wa GET "string_arg"
 pid 1
-wa PUT string_arg
+wa PUT "string_arg"
 pid 1
 EOF
 EXPECT=<<EOF
@@ -288,7 +288,7 @@ EXPECT=<<EOF
 0x00000000 49737472696e675f6172670a  int "string_arg"
 0x00000000 4c737472696e675f6172670a  long "string_arg"
 0x00000000 50737472696e675f6172670a  persid "string_arg"
-0x00000000 53737472696e675f6172670a  string "string_arg"
+0x00000000 5327737472696e675f617267270a  string "string_arg"
 0x00000000 56737472696e675f6172670a  unicode "string_arg"
 0x00000000 67737472696e675f6172670a  get "string_arg"
 0x00000000 70737472696e675f6172670a  put "string_arg"


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Assembler and disassembler should now agree on quotes. After the pull you can do:

```
x='string "test test"'; for i in {1..10}; do x=$(rasm2 -da pickle $(rasm2 -a pickle "$x" )); echo $x; done
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
string "test test"
```
