### PR TITLE
Sync cp-demangle fixes

### DIFF
--- a/libr/bin/mangling/cxx/cp-demangle.c
+++ b/libr/bin/mangling/cxx/cp-demangle.c
@@ -4737,12 +4737,8 @@ d_print_comp_inner (struct d_print_info *dpi, int options,
 	    typed_name = d_right (typed_name);
 	    if (typed_name->type == DEMANGLE_COMPONENT_DEFAULT_ARG)
 	      typed_name = typed_name->u.s_unary_num.sub;
-	    if (typed_name == NULL)
-	      {
-		d_print_error (dpi);
-		return;
-	      }
-	    while (is_fnqual_component_type (typed_name->type))
+	    while (typed_name != NULL
+		   && is_fnqual_component_type (typed_name->type))
 	      {
 		if (i >= sizeof adpm / sizeof adpm[0])
 		  {
@@ -4760,6 +4756,11 @@ d_print_comp_inner (struct d_print_info *dpi, int options,
 		++i;
 
 		typed_name = d_left (typed_name);
+	      }
+	    if (typed_name == NULL)
+	      {
+		d_print_error (dpi);
+		return;
 	      }
 	  }
 

--- a/libr/bin/mangling/cxx/cp-demangle.c
+++ b/libr/bin/mangling/cxx/cp-demangle.c
@@ -3333,7 +3333,7 @@ d_expression_1 (struct d_info *di)
       d_advance (di, 2);
       if (peek == 't')
 	type = cplus_demangle_type (di);
-      if (!d_peek_next_char (di))
+      if (!d_peek_char (di) || !d_peek_next_char (di))
 	return NULL;
       return d_make_comp (di, DEMANGLE_COMPONENT_INITIALIZER_LIST,
 			  type, d_exprlist (di, 'E'));

--- a/libr/bin/mangling/cxx/cp-demangle.c
+++ b/libr/bin/mangling/cxx/cp-demangle.c
@@ -1324,8 +1324,14 @@ d_encoding (struct d_info *di, int top_level)
 	     really apply here; this happens when parsing a class
 	     which is local to a function.  */
 	  if (dc->type == DEMANGLE_COMPONENT_LOCAL_NAME)
-	    while (is_fnqual_component_type (d_right (dc)->type))
-	      d_right (dc) = d_left (d_right (dc));
+	    {
+	      while (d_right (dc) != NULL
+		     && is_fnqual_component_type (d_right (dc)->type))
+		d_right (dc) = d_left (d_right (dc));
+
+	      if (d_right (dc) == NULL)
+		dc = NULL;
+	    }
 	}
       else
 	{


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Syncs fixes from GCC

- mangling/cxx: d_expression_1: Don't peek ahead unless the current char is valid. https://github.com/gcc-mirror/gcc/commit/956bea2cd6110f104f12d5861143efc71213c140 
- mangling/cxx: d_encoding: Guard against NULL return values from d_right (dc) https://github.com/gcc-mirror/gcc/commit/927e42fd52ed7dee859ac85fec9dd6830d769773
- mangling/cxx: d_print_comp_inner: Guard against a NULL 'typed_name' https://github.com/gcc-mirror/gcc/commit/80024f3180b9c4c904cd65323e1d1333cf19d1fe
