### PR TITLE
Fix arm64 register access in xnu debugger ##debug

### DIFF
--- a/libr/debug/p/native/xnu/reg/darwin-arm64.h
+++ b/libr/debug/p/native/xnu/reg/darwin-arm64.h
@@ -86,10 +86,9 @@ return strdup (
 // special registers
 "gpr	fp	.64	232	0\n" // FP
 "gpr	lr	.64	236	0\n" // LR
-"gpr	sp	.64	240	0\n" // SP
-"gpr	pc	.64	248	0\n" // PC
-// "gpr	pstate	.64	256	0\n" // FLAGS
-"gpr	pstate	.64	256	0   _____tfiae_____________j__qvczn\n" // x0
+"gpr	sp	.64	248	0\n" // SP
+"gpr	pc	.64	256	0\n" // PC
+"gpr	pstate	.64	264	0   _____tfiae_____________j__qvczn\n" // x0
 "gpr	vf	.1	256.28	0	overflow\n" // set if overflows
 "gpr	cf	.1	256.29	0	carry\n" // set if last op carries
 "gpr	zf	.1	256.30	0	zero\n" // set if last op is 0

--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -448,8 +448,16 @@ int xnu_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {
 #if __POWERPC__
 #warning TODO powerpc support here
 #else
-		memcpy (&th->gpr.uts, buf, R_MIN (size, sizeof (th->gpr.uts)));
+		// memcpy (&th->gpr.uts, buf, R_MIN (size, sizeof (th->gpr.uts)));
+		{
+		size_t buf_size = R_MIN (size, sizeof (th->gpr));
+#if __x86_64__ || __i386__
+		memcpy (&th->gpr.uts, buf, buf_size);
+#else
+		memcpy (&th->gpr, buf, buf_size);
 #endif
+#endif
+		}
 		ret = xnu_thread_set_gpr (dbg, th);
 		break;
 	}
@@ -594,7 +602,8 @@ static void xnu_free_threads_ports(RDebugPid *p) {
 RList *xnu_thread_list(RDebug *dbg, int pid, RList *list) {
 #if __arm__ || __arm64__ || __aarch_64__
 	#define CPU_PC (dbg->bits == R_SYS_BITS_64) ? \
-		state.ts_64.__pc : state.ts_32.__pc
+		state.arm64.__pc : state.arm32.__pc
+		/* state.ts_64.__pc : state.ts_32.__pc */
 #elif __POWERPC__
 	#define CPU_PC state.srr0
 #elif __x86_64__ || __i386__

--- a/libr/debug/p/native/xnu/xnu_threads.c
+++ b/libr/debug/p/native/xnu/xnu_threads.c
@@ -138,7 +138,7 @@ static bool xnu_thread_set_gpr(RDebug *dbg, xnu_thread_t *thread) {
 	// thread->flavor is used in a switch+case but in regs->tsh.flavor we
 	// specify
 	thread->state = &regs->uts;
-	//thread->state = regs;
+	thread->state = &regs;
 	thread->flavor = x86_THREAD_STATE;
 	thread->count = x86_THREAD_STATE_COUNT;
 	if (dbg->bits == R_SYS_BITS_64) {
@@ -154,8 +154,8 @@ static bool xnu_thread_set_gpr(RDebug *dbg, xnu_thread_t *thread) {
 	thread->flavor = ARM_UNIFIED_THREAD_STATE;
 	thread->count = ARM_UNIFIED_THREAD_STATE_COUNT;
 #endif
-	//thread->state = regs;
-	thread->state = &regs->uts;
+	//thread->state = &regs->uts;
+	thread->state = &regs;
 	if (dbg->bits == R_SYS_BITS_64) {
 		thread->flavor = ARM_THREAD_STATE64;
 		thread->count = ARM_THREAD_STATE64_COUNT;
@@ -191,8 +191,8 @@ static bool xnu_thread_get_gpr(RDebug *dbg, xnu_thread_t *thread) {
 #if __POWERPC__
 	thread->state = regs;
 #elif  __arm64 || __aarch64 || __arch64__ || __arm64__
-	//thread->state = regs;
-	thread->state = &regs->uts;
+	thread->state = regs;
+	// thread->state = &regs->uts;
 	if (dbg->bits == R_SYS_BITS_64) {
 		thread->flavor = ARM_THREAD_STATE64;
 		thread->count = ARM_THREAD_STATE64_COUNT;

--- a/libr/debug/p/native/xnu/xnu_threads.h
+++ b/libr/debug/p/native/xnu/xnu_threads.h
@@ -15,7 +15,13 @@
 #	ifndef ARM_THREAD_STATE64
 #		define ARM_THREAD_STATE64 6
 #	endif
-#	define R_REG_T arm_unified_thread_state_t
+typedef union rz_xnu_arm_reg_state_t {
+	// which one is used here is determined by RzXnuDebug.cpu
+	arm_thread_state32_t arm32;
+	arm_thread_state64_t arm64;
+} RXnuArmRegState;
+// #	define R_REG_T arm_unified_thread_state_t
+#define R_REG_T        RXnuArmRegState
 #	define R_REG_STATE_T MACHINE_THREAD_STATE
 #	define R_REG_STATE_SZ MACHINE_THREAD_STATE_COUNT
 #elif __x86_64__ || __i386__


### PR DESCRIPTION
* Inspired by commit e893d2fb66916734fa71589058f7de9bb8c8fbf5
* in rizinorg/rizin by Author: Florian Märkl <info@florianmaerkl.de>
* Date:   Sat Aug 6 19:09:11 2022 +0200

    Fix arm64 register access in xnu debugger

    ARM_THREAD_STATE64 fetches arm_thread_state64_t but our struct was
    arm_unified_thread_state_t, which adds a header. The pc in the register
    profile was hacked to account for the shift, but all the x-regs were
    not, so x7 had the value of x8 for example. Now we just use the specific
    state for 32 or 64.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
