### PR TITLE
Add 'pxu' mode to ##visual

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -52,13 +52,13 @@ static const char *printfmtColumns[NPF] = {
 };
 
 // to print the stack in the debugger view
-#define PRINT_HEX_FORMATS 10
+#define PRINT_HEX_FORMATS 11
 #define PRINT_3_FORMATS 2
 #define PRINT_4_FORMATS 9
 #define PRINT_5_FORMATS 7
 
 static const char *printHexFormats[PRINT_HEX_FORMATS] = {
-	"px", "pxa", "pxr", "prx", "pxb", "pxh", "pxw", "pxq", "pxd", "pxr",
+	"px", "pxa", "pxr", "prx", "pxb", "pxh", "pxw", "pxq", "pxu", "pxd", "pxr",
 };
 static R_TH_LOCAL int current3format = 0;
 static const char *print3Formats[PRINT_3_FORMATS] = { //  not used at all. its handled by the pd format
@@ -80,7 +80,7 @@ R_API void r_core_visual_applyHexMode(RCore *core, int hexMode) {
 	case 0: /* px */
 	case 3: /* prx */
 	case 6: /* pxw */
-	case 9: /* pxr */
+	case 10: /* pxr */
 		r_config_set (core->config, "hex.compact", "false");
 		r_config_set (core->config, "hex.comments", "true");
 		break;
@@ -95,7 +95,8 @@ R_API void r_core_visual_applyHexMode(RCore *core, int hexMode) {
 		break;
 	case 2: /* pxr */
 	case 5: /* pxh */
-	case 8: /* pxd */
+	case 8: /* pxu */
+	case 9: /* pxd */
 		r_config_set (core->config, "hex.compact", "false");
 		r_config_set (core->config, "hex.comments", "false");
 		break;


### PR DESCRIPTION
* Unsigned integers in print format list

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Issue #20671

```
[nik@viki radare2]$ binr/radare2/radare2 -v
radare2 5.7.7 28754 @ linux-x86-64 git.5.7.7
commit: e241f89b362b36d74d3491a47306eaab94652d69 build: 2022-09-09__12:54:16
```
```
[0x00000000 *0x00000000 [Xadvc]8 ($$+0x0)]> pxu                                                        
- offset - |  0  1   2  3   4  5   6  7   8  9   A  B   C  D   E  F   0  1   2  3| 0123456789ABCDEF0123
0x00000000 |           22            86             6             0             0  ....V...............
0x00000014 |            0          2785          2729          1428             9  ....................
0x00000028 |            0          3450    3221225471          1428             9  ....z...............
```