### PR TITLE
use RVector for RAnalOp src and dst instead of fix-sized array

### DIFF
--- a/libr/anal/cond.c
+++ b/libr/anal/cond.c
@@ -130,10 +130,10 @@ R_API RAnalCond *r_anal_cond_new_from_op(RAnalOp *op) {
 	}
 	//v->reg[0] = op->src[0];
 	//v->reg[1] = op->src[1];
-	cond->arg[0] = r_pvector_at(op->srcs, 0);
-	r_pvector_set(op->srcs, 0, NULL);
-	cond->arg[1] = r_pvector_at(op->srcs, 1);
-	r_pvector_set(op->srcs, 1, NULL);
+	cond->arg[0] = r_anal_value_copy (r_vector_index_ptr (op->srcs, 0));
+	cond->arg[1] = r_anal_value_copy (r_vector_index_ptr (op->srcs, 1));
+	r_vector_free (op->srcs);
+	op->srcs = NULL;
 	// TODO: moar!
 	//cond->arg[1] = op->src[1];
 	return cond;

--- a/libr/anal/cond.c
+++ b/libr/anal/cond.c
@@ -130,10 +130,10 @@ R_API RAnalCond *r_anal_cond_new_from_op(RAnalOp *op) {
 	}
 	//v->reg[0] = op->src[0];
 	//v->reg[1] = op->src[1];
-	cond->arg[0] = op->src[0];
-	op->src[0] = NULL;
-	cond->arg[1] = op->src[1];
-	op->src[1] = NULL;
+	cond->arg[0] = r_pvector_at(op->srcs, 0);
+	r_pvector_set(op->srcs, 0, NULL);
+	cond->arg[1] = r_pvector_at(op->srcs, 1);
+	r_pvector_set(op->srcs, 1, NULL);
 	// TODO: moar!
 	//cond->arg[1] = op->src[1];
 	return cond;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1142,6 +1142,9 @@ repeat:
 				bb->cmpreg = op->reg;
 				r_anal_cond_free (bb->cond);
 				bb->cond = r_anal_cond_new_from_op (op);
+				if (bb->cond) {
+					src0 = src1 = NULL;
+				}
 			}
 		}
 			break;

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -203,10 +203,11 @@ static bool is_delta_pointer_table(RAnal *anal, RAnalFunction *fcn, ut64 addr, u
 			mov_aop = *aop;
 			o_reg_dst = cur_dst.reg;
 			RAnalValue *rval = NULL;
-			rval = r_pvector_at(mov_aop.dsts, 0);
-			if (rval)
+			rval = r_vector_index_ptr (mov_aop.dsts, 0);
+			if (rval) {
 				cur_dst = *rval;
-			rval = r_pvector_at(mov_aop.srcs, 0);
+			}
+			rval = r_vector_index_ptr (mov_aop.srcs, 0);
 			if (rval) {
 				cur_scr = *rval;
 				reg_src = cur_scr.regdelta;
@@ -547,7 +548,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 	}
 	// TODO Store all this stuff in the heap so we save memory in the stack
 	RAnalOp *op = NULL;
-	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
+	RAnalValue *dst = NULL, *src0 = NULL, *src1 = NULL;
 	char *movbasereg = NULL;
 	const int addrbytes = anal->iob.io ? anal->iob.io->addrbytes : 1;
 	char *last_reg_mov_lea_name = NULL;
@@ -715,13 +716,13 @@ repeat:
 			// RET_END causes infinite loops somehow
 			gotoBeach (R_ANAL_RET_END);
 		}
-		dst = r_pvector_at(op->dsts, 0);
+		dst = r_vector_index_ptr (op->dsts, 0);
 		free (op_dst);
 		op_dst = (dst && dst->reg && dst->reg->name)? strdup (dst->reg->name): NULL;
-		src0 = r_pvector_at(op->srcs, 0);
+		src0 = r_vector_index_ptr (op->srcs, 0);
 		free (op_src);
 		op_src = (src0 && src0->reg && src0->reg->name) ? strdup (src0->reg->name): NULL;
-		src1 = r_pvector_at(op->srcs, 1);
+		src1 = r_vector_index_ptr (op->srcs, 1);
 
 		if (anal->opt.nopskip && fcn->addr == at) {
 			RFlagItem *fi = anal->flb.get_at (anal->flb.f, addr, false);
@@ -1259,7 +1260,7 @@ repeat:
 						RAnalOp *prev_op = r_anal_op_new ();
 						anal->iob.read_at (anal->iob.io, op->addr - op->size, buf, sizeof (buf));
 						if (r_anal_op (anal, prev_op, op->addr - op->size, buf, sizeof (buf), R_ANAL_OP_MASK_VAL) > 0) {
-							RAnalValue *prev_dst = r_pvector_at(prev_op->dsts, 0);
+							RAnalValue *prev_dst = r_vector_index_ptr (prev_op->dsts, 0);
 							bool prev_op_has_dst_name = prev_dst && prev_dst->reg && prev_dst->reg->name;
 							bool op_has_src_name = src0 && src0->reg && src0->reg->name;
 							bool same_reg = (op->ireg && prev_op_has_dst_name && !strcmp (op->ireg, prev_dst->reg->name))
@@ -2077,8 +2078,8 @@ R_API bool r_anal_function_purity(RAnalFunction *fcn) {
 }
 
 static bool can_affect_bp(RAnal *anal, RAnalOp* op) {
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
-	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
+	RAnalValue *src = r_vector_index_ptr (op->srcs, 0);
 	const char *opdreg = (dst && dst->reg) ? dst->reg->name : NULL;
 	const char *opsreg = (src && src->reg) ? src->reg->name : NULL;
 	const char *bp_name = anal->reg->name[R_REG_NAME_BP];
@@ -2106,7 +2107,7 @@ static void __anal_fcn_check_bp_use(RAnal *anal, RAnalFunction *fcn) {
 	}
 	r_list_foreach (fcn->bbs, iter, bb) {
 		RAnalOp op;
-		RAnalValue *src=NULL;
+		RAnalValue *src = NULL;
 		ut64 at, end = bb->addr + bb->size;
 		ut8 *buf = malloc (bb->size);
 		if (!buf) {
@@ -2119,7 +2120,7 @@ static void __anal_fcn_check_bp_use(RAnal *anal, RAnalFunction *fcn) {
 			if (op.size < 1) {
 				op.size = 1;
 			}
-			src = r_pvector_at(op.srcs, 0);
+			src = r_vector_index_ptr (op.srcs, 0);
 			switch (op.type) {
 			case R_ANAL_OP_TYPE_MOV:
 			case R_ANAL_OP_TYPE_LEA:

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -202,11 +202,13 @@ static bool is_delta_pointer_table(RAnal *anal, RAnalFunction *fcn, ut64 addr, u
 			omov_aop = mov_aop;
 			mov_aop = *aop;
 			o_reg_dst = cur_dst.reg;
-			if (mov_aop.dst) {
-				cur_dst = *mov_aop.dst;
-			}
-			if (mov_aop.src[0]) {
-				cur_scr = *mov_aop.src[0];
+			RAnalValue *rval = NULL;
+			rval = r_pvector_at(mov_aop.dsts, 0);
+			if (rval)
+				cur_dst = *rval;
+			rval = r_pvector_at(mov_aop.srcs, 0);
+			if (rval) {
+				cur_scr = *rval;
 				reg_src = cur_scr.regdelta;
 			}
 		}
@@ -545,6 +547,7 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 	}
 	// TODO Store all this stuff in the heap so we save memory in the stack
 	RAnalOp *op = NULL;
+	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
 	char *movbasereg = NULL;
 	const int addrbytes = anal->iob.io ? anal->iob.io->addrbytes : 1;
 	char *last_reg_mov_lea_name = NULL;
@@ -712,10 +715,13 @@ repeat:
 			// RET_END causes infinite loops somehow
 			gotoBeach (R_ANAL_RET_END);
 		}
+		dst = r_pvector_at(op->dsts, 0);
 		free (op_dst);
-		op_dst = (op->dst && op->dst->reg && op->dst->reg->name)? strdup (op->dst->reg->name): NULL;
+		op_dst = (dst && dst->reg && dst->reg->name)? strdup (dst->reg->name): NULL;
+		src0 = r_pvector_at(op->srcs, 0);
 		free (op_src);
-		op_src = (op->src[0] && op->src[0]->reg && op->src[0]->reg->name) ? strdup (op->src[0]->reg->name): NULL;
+		op_src = (src0 && src0->reg && src0->reg->name) ? strdup (src0->reg->name): NULL;
+		src1 = r_pvector_at(op->srcs, 1);
 
 		if (anal->opt.nopskip && fcn->addr == at) {
 			RFlagItem *fi = anal->flb.get_at (anal->flb.f, addr, false);
@@ -907,9 +913,9 @@ repeat:
 				fcn->bp_off = fcn->stack;
 			}
 			// Is this a mov of immediate value into a register?
-			if (op->dst && op->dst->reg && op->dst->reg->name && op->val > 0 && op->val != UT64_MAX) {
+			if (dst && dst->reg && dst->reg->name && op->val > 0 && op->val != UT64_MAX) {
 				free (last_reg_mov_lea_name);
-				if ((last_reg_mov_lea_name = strdup (op->dst->reg->name))) {
+				if ((last_reg_mov_lea_name = strdup (dst->reg->name))) {
 					last_reg_mov_lea_val = op->val;
 					last_is_reg_mov_lea = true;
 				}
@@ -918,14 +924,14 @@ repeat:
 			if (anal->opt.jmptbl && op->scale && op->ireg) {
 				movdisp = op->disp;
 				movscale = op->scale;
-				if (op->src[0] && op->src[0]->reg) {
+				if (src0 && src0->reg) {
 					free (movbasereg);
-					movbasereg = strdup (op->src[0]->reg->name);
+					movbasereg = strdup (src0->reg->name);
 				} else {
 					R_FREE (movbasereg);
 				}
 			}
-			if (anal->opt.hpskip && regs_exist (op->src[0], op->dst) && !strcmp (op->src[0]->reg->name, op->dst->reg->name)) {
+			if (anal->opt.hpskip && regs_exist (src0, dst) && !strcmp (src0->reg->name, dst->reg->name)) {
 				skip_ret = skip_hp (anal, fcn, op, bb, addr, oplen, delay.un_idx, &idx);
 				if (skip_ret == 1) {
 					goto repeat;
@@ -973,26 +979,26 @@ repeat:
 				pair->leaddr = op->ptr; // XXX movdisp is dupped but seems to be trashed sometimes(?), better track leaddr separately
 				pair->reg = op->reg
 					? strdup (op->reg)
-					: op->dst && op->dst->reg
-					? strdup (op->dst->reg->name)
+					: dst && dst->reg
+					? strdup (dst->reg->name)
 					: NULL;
 				lea_cnt++;
 				r_list_append (anal->leaddrs, pair);
 			}
 			if (has_stack_regs && op_is_set_bp (op_dst, op_src, bp_reg, sp_reg)     ) {
-				fcn->bp_off = fcn->stack - op->src[0]->delta;
+				fcn->bp_off = fcn->stack - src0->delta;
 			}
-			if (op->dst && op->dst->reg && op->dst->reg->name && op->ptr > 0 && op->ptr != UT64_MAX) {
+			if (dst && dst->reg && dst->reg->name && op->ptr > 0 && op->ptr != UT64_MAX) {
 				free (last_reg_mov_lea_name);
-				if ((last_reg_mov_lea_name = strdup(op->dst->reg->name))) {
+				if ((last_reg_mov_lea_name = strdup(dst->reg->name))) {
 					last_reg_mov_lea_val = op->ptr;
 					last_is_reg_mov_lea = true;
 				}
 			}
 #endif
 			// skip lea reg,[reg]
-			if (anal->opt.hpskip && regs_exist (op->src[0], op->dst)
-			&& !strcmp (op->src[0]->reg->name, op->dst->reg->name)) {
+			if (anal->opt.hpskip && regs_exist (src0, dst)
+			&& !strcmp (src0->reg->name, dst->reg->name)) {
 				skip_ret = skip_hp (anal, fcn, op, bb, at, oplen, delay.un_idx, &idx);
 				if (skip_ret == 1) {
 					goto repeat;
@@ -1253,10 +1259,11 @@ repeat:
 						RAnalOp *prev_op = r_anal_op_new ();
 						anal->iob.read_at (anal->iob.io, op->addr - op->size, buf, sizeof (buf));
 						if (r_anal_op (anal, prev_op, op->addr - op->size, buf, sizeof (buf), R_ANAL_OP_MASK_VAL) > 0) {
-							bool prev_op_has_dst_name = prev_op->dst && prev_op->dst->reg && prev_op->dst->reg->name;
-							bool op_has_src_name = op->src[0] && op->src[0]->reg && op->src[0]->reg->name;
-							bool same_reg = (op->ireg && prev_op_has_dst_name && !strcmp (op->ireg, prev_op->dst->reg->name))
-								|| (op_has_src_name && prev_op_has_dst_name && !strcmp (op->src[0]->reg->name, prev_op->dst->reg->name));
+							RAnalValue *prev_dst = r_pvector_at(prev_op->dsts, 0);
+							bool prev_op_has_dst_name = prev_dst && prev_dst->reg && prev_dst->reg->name;
+							bool op_has_src_name = src0 && src0->reg && src0->reg->name;
+							bool same_reg = (op->ireg && prev_op_has_dst_name && !strcmp (op->ireg, prev_dst->reg->name))
+								|| (op_has_src_name && prev_op_has_dst_name && !strcmp (src0->reg->name, prev_dst->reg->name));
 							if (prev_op->type == R_ANAL_OP_TYPE_MOV && prev_op->disp && prev_op->disp != UT64_MAX && same_reg) {
 								//	movzx reg, byte [reg + case_table]
 								//	jmp dword [reg*4 + jump_table]
@@ -1370,8 +1377,8 @@ analopfinish:
 			}
 			break;
 		case R_ANAL_OP_TYPE_UPUSH:
-			if ((op->type & R_ANAL_OP_TYPE_REG) && last_is_reg_mov_lea && op->src[0] && op->src[0]->reg
-				&& op->src[0]->reg->name && !strcmp (op->src[0]->reg->name, last_reg_mov_lea_name)) {
+			if ((op->type & R_ANAL_OP_TYPE_REG) && last_is_reg_mov_lea && src0 && src0->reg
+				&& src0->reg->name && !strcmp (src0->reg->name, last_reg_mov_lea_name)) {
 				last_is_push = true;
 				last_push_addr = last_reg_mov_lea_val;
 				if (anal->iob.is_valid_offset (anal->iob.io, last_push_addr, 1)) {
@@ -1402,13 +1409,13 @@ analopfinish:
 		}
 		if (has_stack_regs && arch_destroys_dst) {
 			// op->dst->reg->name is invalid pointer
-			if (op_is_set_bp (op_dst, op_src, bp_reg, sp_reg) && op->src[1]) {
+			if (op_is_set_bp (op_dst, op_src, bp_reg, sp_reg) && src1) {
 				switch (op->type & R_ANAL_OP_TYPE_MASK) {
 				case R_ANAL_OP_TYPE_ADD:
-					fcn->bp_off = fcn->stack - op->src[1]->imm;
+					fcn->bp_off = fcn->stack - src1->imm;
 					break;
 				case R_ANAL_OP_TYPE_SUB:
-					fcn->bp_off = fcn->stack + op->src[1]->imm;
+					fcn->bp_off = fcn->stack + src1->imm;
 					break;
 				}
 			}
@@ -1431,13 +1438,13 @@ analopfinish:
 		}
 		if (has_variadic_reg && !fcn->is_variadic) {
 			variadic_reg = r_reg_get (anal->reg, "rax", R_REG_TYPE_GPR);
-			bool dst_is_variadic = op->dst && op->dst->reg
-					&& variadic_reg && op->dst->reg->offset == variadic_reg->offset;
+			bool dst_is_variadic = dst && dst->reg
+					&& variadic_reg && dst->reg->offset == variadic_reg->offset;
 			bool op_is_cmp = (op->type == R_ANAL_OP_TYPE_CMP) || op->type == R_ANAL_OP_TYPE_ACMP;
 			if (dst_is_variadic && !op_is_cmp) {
 				has_variadic_reg = false;
 			} else if (op_is_cmp) {
-				if (op->src[0] && op->src[0]->reg && (op->dst->reg == op->src[0]->reg) && dst_is_variadic) {
+				if (src0 && src0->reg && (dst->reg == src0->reg) && dst_is_variadic) {
 					fcn->is_variadic = true;
 				}
 			}
@@ -2070,8 +2077,8 @@ R_API bool r_anal_function_purity(RAnalFunction *fcn) {
 }
 
 static bool can_affect_bp(RAnal *anal, RAnalOp* op) {
-	RAnalValue *dst = op->dst;
-	RAnalValue *src = op->src[0];
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src = r_pvector_at(op->srcs, 0);
 	const char *opdreg = (dst && dst->reg) ? dst->reg->name : NULL;
 	const char *opsreg = (src && src->reg) ? src->reg->name : NULL;
 	const char *bp_name = anal->reg->name[R_REG_NAME_BP];
@@ -2099,6 +2106,7 @@ static void __anal_fcn_check_bp_use(RAnal *anal, RAnalFunction *fcn) {
 	}
 	r_list_foreach (fcn->bbs, iter, bb) {
 		RAnalOp op;
+		RAnalValue *src=NULL;
 		ut64 at, end = bb->addr + bb->size;
 		ut8 *buf = malloc (bb->size);
 		if (!buf) {
@@ -2111,11 +2119,12 @@ static void __anal_fcn_check_bp_use(RAnal *anal, RAnalFunction *fcn) {
 			if (op.size < 1) {
 				op.size = 1;
 			}
+			src = r_pvector_at(op.srcs, 0);
 			switch (op.type) {
 			case R_ANAL_OP_TYPE_MOV:
 			case R_ANAL_OP_TYPE_LEA:
-				if (can_affect_bp (anal, &op) && op.src[0] && op.src[0]->reg && op.src[0]->reg->name
-				&& strcmp (op.src[0]->reg->name, anal->reg->name[R_REG_NAME_SP])) {
+				if (can_affect_bp (anal, &op) && src && src->reg && src->reg->name
+				&& strcmp (src->reg->name, anal->reg->name[R_REG_NAME_SP])) {
 					fcn->bp_frame = false;
 					r_anal_op_fini (&op);
 					free (buf);

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -268,7 +268,9 @@ static bool detect_casenum_shift(RAnalOp *op, RRegItem **cmp_reg, st64 *start_ca
 	if (!*cmp_reg) {
 		return true;
 	}
-	if (op->dst && op->dst->reg && op->dst->reg->offset == (*cmp_reg)->offset) {
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	if (dst && dst->reg && dst->reg->offset == (*cmp_reg)->offset) {
 		if (op->type == R_ANAL_OP_TYPE_LEA && op->ptr == UT64_MAX) {
 			*start_casenum_shift = -(st64)op->disp;
 		} else if (op->val != UT64_MAX) {
@@ -278,7 +280,7 @@ static bool detect_casenum_shift(RAnalOp *op, RRegItem **cmp_reg, st64 *start_ca
 				*start_casenum_shift = op->val;
 			}
 		} else if (op->type == R_ANAL_OP_TYPE_MOV) {
-			*cmp_reg = op->src[0]->reg;
+			*cmp_reg = src->reg;
 			return false;
 		}
 		return true;
@@ -344,12 +346,14 @@ R_API bool try_get_delta_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 jmp_a
 		}
 		r_vector_push (&v, &i);
 		r_anal_op (anal, &tmp_aop, lea_addr + i, buf + i, search_sz - i, R_ANAL_OP_MASK_VAL);
-		if (tmp_aop.dst && tmp_aop.dst->reg) {
-			cmp_reg = tmp_aop.dst->reg;
+		RAnalValue *tmp_src = r_pvector_at(tmp_aop.srcs, 0);
+		RAnalValue *tmp_dst = r_pvector_at(tmp_aop.dsts, 0);
+		if (tmp_dst && tmp_dst->reg) {
+			cmp_reg = tmp_dst->reg;
 		} else if (tmp_aop.reg) {
 			cmp_reg = r_reg_get (anal->reg, tmp_aop.reg, R_REG_TYPE_ALL);
-		} else if (tmp_aop.src[0] && tmp_aop.src[0]->reg) {
-			cmp_reg = tmp_aop.src[0]->reg;
+		} else if (tmp_src && tmp_src->reg) {
+			cmp_reg = tmp_src->reg;
 		}
 		r_anal_op_fini (&tmp_aop);
 		// TODO: check the jmp for whether val is included in valid range or not (ja vs jae)
@@ -514,12 +518,14 @@ R_API bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAnal
 			r_anal_op (anal, &tmp_aop, op_addr,
 					bb_buf + prev_pos, buflen,
 					R_ANAL_OP_MASK_VAL);
-			if (tmp_aop.dst && tmp_aop.dst->reg) {
-				cmp_reg = tmp_aop.dst->reg;
+			RAnalValue *tmp_dst = r_pvector_at(tmp_aop.dsts, 0);
+			RAnalValue *tmp_src = r_pvector_at(tmp_aop.srcs, 0);
+			if (tmp_dst && tmp_dst->reg) {
+				cmp_reg = tmp_dst->reg;
 			} else if (tmp_aop.reg) {
 				cmp_reg = r_reg_get (anal->reg, tmp_aop.reg, R_REG_TYPE_ALL);
-			} else if (tmp_aop.src[0] && tmp_aop.src[0]->reg) {
-				cmp_reg = tmp_aop.src[0]->reg;
+			} else if (tmp_src && tmp_src->reg) {
+				cmp_reg = tmp_src->reg;
 			}
 		}
 		r_anal_op_fini (&tmp_aop);

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -268,8 +268,8 @@ static bool detect_casenum_shift(RAnalOp *op, RRegItem **cmp_reg, st64 *start_ca
 	if (!*cmp_reg) {
 		return true;
 	}
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
-	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
+	RAnalValue *src = r_vector_index_ptr (op->srcs, 0);
 	if (dst && dst->reg && dst->reg->offset == (*cmp_reg)->offset) {
 		if (op->type == R_ANAL_OP_TYPE_LEA && op->ptr == UT64_MAX) {
 			*start_casenum_shift = -(st64)op->disp;
@@ -346,8 +346,8 @@ R_API bool try_get_delta_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 jmp_a
 		}
 		r_vector_push (&v, &i);
 		r_anal_op (anal, &tmp_aop, lea_addr + i, buf + i, search_sz - i, R_ANAL_OP_MASK_VAL);
-		RAnalValue *tmp_src = r_pvector_at(tmp_aop.srcs, 0);
-		RAnalValue *tmp_dst = r_pvector_at(tmp_aop.dsts, 0);
+		RAnalValue *tmp_src = r_vector_index_ptr (tmp_aop.srcs, 0);
+		RAnalValue *tmp_dst = r_vector_index_ptr (tmp_aop.dsts, 0);
 		if (tmp_dst && tmp_dst->reg) {
 			cmp_reg = tmp_dst->reg;
 		} else if (tmp_aop.reg) {
@@ -518,8 +518,8 @@ R_API bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAnal
 			r_anal_op (anal, &tmp_aop, op_addr,
 					bb_buf + prev_pos, buflen,
 					R_ANAL_OP_MASK_VAL);
-			RAnalValue *tmp_dst = r_pvector_at(tmp_aop.dsts, 0);
-			RAnalValue *tmp_src = r_pvector_at(tmp_aop.srcs, 0);
+			RAnalValue *tmp_dst = r_vector_index_ptr (tmp_aop.dsts, 0);
+			RAnalValue *tmp_src = r_vector_index_ptr (tmp_aop.srcs, 0);
 			if (tmp_dst && tmp_dst->reg) {
 				cmp_reg = tmp_dst->reg;
 			} else if (tmp_aop.reg) {

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -29,8 +29,8 @@ R_API void r_anal_op_init(RAnalOp *op) {
 		op->val = UT64_MAX;
 		op->disp = UT64_MAX;
 
-		op->srcs = r_vector_new (sizeof(RAnalValue), NULL, NULL);
-		op->dsts = r_vector_new (sizeof(RAnalValue), NULL, NULL);
+		op->srcs = r_vector_new (sizeof (RAnalValue), NULL, NULL);
+		op->dsts = r_vector_new (sizeof (RAnalValue), NULL, NULL);
 		r_vector_reserve (op->srcs, 3);
 		r_vector_reserve (op->dsts, 1);
 	}

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -4313,7 +4313,6 @@ static void set_opdir(RAnalOp *op) {
 static void set_src_dst(RAnalValue *val, RReg *reg, csh *handle, cs_insn *insn, int x, int bits) {
 	cs_arm_op armop = INSOP (x);
 	cs_arm64_op arm64op = INSOP64 (x);
-	if (!val)	return;
 	if (bits == 64) {
 		parse_reg64_name (reg, &val->reg, &val->regdelta, *handle, insn, x);
 	} else {
@@ -4350,10 +4349,10 @@ static void set_src_dst(RAnalValue *val, RReg *reg, csh *handle, cs_insn *insn, 
 }
 
 static void create_src_dst(RAnalOp *op) {
-	r_pvector_push(op->srcs, r_anal_value_new());
-	r_pvector_push(op->srcs, r_anal_value_new());
-	r_pvector_push(op->srcs, r_anal_value_new());
-	r_pvector_push(op->dsts, r_anal_value_new());
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->dsts, NULL);
 }
 
 static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int bits) {
@@ -4399,9 +4398,9 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int 
 			break;
 		}
 		for (j = 0; j < 3; j++, i++) {
-			set_src_dst (r_pvector_at(op->srcs, j), anal->reg, &handle, insn, i, bits);
+			set_src_dst (r_vector_index_ptr (op->srcs, j), anal->reg, &handle, insn, i, bits);
 		}
-		set_src_dst (r_pvector_at(op->dsts, 0), anal->reg, &handle, insn, 0, bits);
+		set_src_dst (r_vector_index_ptr (op->dsts, 0), anal->reg, &handle, insn, 0, bits);
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (count > 2) {
@@ -4417,9 +4416,9 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int 
 				}
 			}
 		}
-		set_src_dst (r_pvector_at(op->dsts, 0), anal->reg, &handle, insn, --count, bits);
+		set_src_dst (r_vector_index_ptr (op->dsts, 0), anal->reg, &handle, insn, --count, bits);
 		for (j = 0; j < 3 && j < count; j++) {
-			set_src_dst (r_pvector_at(op->srcs, j), anal->reg, &handle, insn, j, bits);
+			set_src_dst (r_vector_index_ptr (op->srcs, j), anal->reg, &handle, insn, j, bits);
 		}
 		break;
 	default:

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -4349,10 +4349,10 @@ static void set_src_dst(RAnalValue *val, RReg *reg, csh *handle, cs_insn *insn, 
 }
 
 static void create_src_dst(RAnalOp *op) {
-	op->src[0] = r_anal_value_new ();
-	op->src[1] = r_anal_value_new ();
-	op->src[2] = r_anal_value_new ();
-	op->dst = r_anal_value_new ();
+	r_pvector_push(op->srcs, r_anal_value_new());
+	r_pvector_push(op->srcs, r_anal_value_new());
+	r_pvector_push(op->srcs, r_anal_value_new());
+	r_pvector_push(op->dsts, r_anal_value_new());
 }
 
 static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int bits) {
@@ -4398,9 +4398,9 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int 
 			break;
 		}
 		for (j = 0; j < 3; j++, i++) {
-			set_src_dst (op->src[j], anal->reg, &handle, insn, i, bits);
+			set_src_dst (r_pvector_at(op->srcs, j), anal->reg, &handle, insn, i, bits);
 		}
-		set_src_dst (op->dst, anal->reg, &handle, insn, 0, bits);
+		set_src_dst (r_pvector_at(op->dsts, 0), anal->reg, &handle, insn, 0, bits);
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (count > 2) {
@@ -4416,9 +4416,9 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh handle, cs_insn *insn, int 
 				}
 			}
 		}
-		set_src_dst (op->dst, anal->reg, &handle, insn, --count, bits);
+		set_src_dst (r_pvector_at(op->dsts, 0), anal->reg, &handle, insn, --count, bits);
 		for (j = 0; j < 3 && j < count; j++) {
-			set_src_dst (op->src[j], anal->reg, &handle, insn, j, bits);
+			set_src_dst (r_pvector_at(op->srcs, j), anal->reg, &handle, insn, j, bits);
 		}
 		break;
 	default:

--- a/libr/anal/p/anal_arm_cs.c
+++ b/libr/anal/p/anal_arm_cs.c
@@ -4313,6 +4313,7 @@ static void set_opdir(RAnalOp *op) {
 static void set_src_dst(RAnalValue *val, RReg *reg, csh *handle, cs_insn *insn, int x, int bits) {
 	cs_arm_op armop = INSOP (x);
 	cs_arm64_op arm64op = INSOP64 (x);
+	if (!val)	return;
 	if (bits == 64) {
 		parse_reg64_name (reg, &val->reg, &val->regdelta, *handle, insn, x);
 	} else {

--- a/libr/anal/p/anal_bpf.c
+++ b/libr/anal/p/anal_bpf.c
@@ -711,10 +711,8 @@ static int bpf_opasm (RAnal *a, ut64 pc, const char *str, ut8 *outbuf, int outsi
 	(op)->ptrsize = (size);
 
 #define NEW_SRC_DST(op) \
-	src = r_anal_value_new (); \
-	dst = r_anal_value_new (); \
-	r_pvector_push((op)->dsts, dst); \
-	r_pvector_push((op)->srcs, src);
+	src = r_vector_push ((op)->srcs, NULL); \
+	dst = r_vector_push ((op)->dsts, NULL);
 
 #define SET_REG_SRC_DST(op, _src, _dst) \
 	NEW_SRC_DST ((op)); \
@@ -727,14 +725,12 @@ static int bpf_opasm (RAnal *a, ut64 pc, const char *str, ut8 *outbuf, int outsi
 	src->imm = (_imm);
 
 #define SET_A_SRC(op) \
-	src = r_anal_value_new (); \
-	src->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR); \
-	r_pvector_push((op)->srcs, src);
+	src = r_vector_push ((op)->srcs, NULL); \
+	src->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR);
 
 #define SET_A_DST(op) \
-	dst = r_anal_value_new (); \
-	dst->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR); \
-	r_pvector_push((op)->dsts, dst);
+	dst = r_vector_push ((op)->dsts, NULL); \
+	dst->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR);
 
 // (k) >= 0 must also be true, but the value is already unsigned
 #define INSIDE_M(k) ((k) < 16)

--- a/libr/anal/p/anal_bpf.c
+++ b/libr/anal/p/anal_bpf.c
@@ -711,26 +711,30 @@ static int bpf_opasm (RAnal *a, ut64 pc, const char *str, ut8 *outbuf, int outsi
 	(op)->ptrsize = (size);
 
 #define NEW_SRC_DST(op) \
-	(op)->src[0] = r_anal_value_new (); \
-	(op)->dst = r_anal_value_new ();
+	src = r_anal_value_new (); \
+	dst = r_anal_value_new (); \
+	r_pvector_push((op)->dsts, dst); \
+	r_pvector_push((op)->srcs, src);
 
 #define SET_REG_SRC_DST(op, _src, _dst) \
 	NEW_SRC_DST ((op)); \
-	(op)->src[0]->reg = r_reg_get (anal->reg, (_src), R_REG_TYPE_GPR); \
-	(op)->dst->reg = r_reg_get (anal->reg, (_dst), R_REG_TYPE_GPR);
+	src->reg = r_reg_get (anal->reg, (_src), R_REG_TYPE_GPR); \
+	dst->reg = r_reg_get (anal->reg, (_dst), R_REG_TYPE_GPR);
 
 #define SET_REG_DST_IMM(op, _dst, _imm) \
 	NEW_SRC_DST ((op)); \
-	(op)->dst->reg = r_reg_get (anal->reg, (_dst), R_REG_TYPE_GPR); \
-	(op)->src[0]->imm = (_imm);
+	dst->reg = r_reg_get (anal->reg, (_dst), R_REG_TYPE_GPR); \
+	src->imm = (_imm);
 
 #define SET_A_SRC(op) \
-	(op)->src[0] = r_anal_value_new (); \
-	(op)->src[0]->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR);
+	src = r_anal_value_new (); \
+	src->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR); \
+	r_pvector_push((op)->srcs, src);
 
 #define SET_A_DST(op) \
-	(op)->dst = r_anal_value_new (); \
-	(op)->dst->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR);
+	dst = r_anal_value_new (); \
+	dst->reg = r_reg_get (anal->reg, "A", R_REG_TYPE_GPR); \
+	r_pvector_push((op)->dsts, dst);
 
 // (k) >= 0 must also be true, but the value is already unsigned
 #define INSIDE_M(k) ((k) < 16)
@@ -760,6 +764,7 @@ static const char *M[] = {
 };
 
 static int bpf_anal (RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask) {
+	RAnalValue *dst, *src;
 	RBpfSockFilter *f = (RBpfSockFilter *)data;
 	op->jump = UT64_MAX;
 	op->fail = UT64_MAX;

--- a/libr/anal/p/anal_gb.c
+++ b/libr/anal/p/anal_gb.c
@@ -115,21 +115,25 @@ static inline void gb_anal_esil_jmp(RAnalOp *op) {
 }
 
 static inline void gb_anal_jmp_hl(RReg *reg, RAnalOp *op) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "pc", R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "pc", R_REG_TYPE_GPR);
+	src->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_set (&op->esil, "hl,pc,:=");
 }
 
 static inline void gb_anal_id(RAnal *anal, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->src[0]->absolute = true;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	src->absolute = true;
 	if (data == 0x34 || data == 0x35) {
-		op->dst->memref = 1;
-		op->dst->reg = r_reg_get (anal->reg, "hl", R_REG_TYPE_GPR);
+		dst->memref = 1;
+		dst->reg = r_reg_get (anal->reg, "hl", R_REG_TYPE_GPR);
 		if (op->type == R_ANAL_OP_TYPE_ADD) {
 			r_strbuf_set (&op->esil, "1,hl,[1],+,hl,=[1],3,$c,H,:=,$z,Z,:=,0,N,:=");
 		} else {
@@ -137,14 +141,14 @@ static inline void gb_anal_id(RAnal *anal, RAnalOp *op, const ut8 data) {
 		}
 	} else {
 		if (!(data & (1<<2))) {
-			op->dst->reg = r_reg_get (anal->reg, regs_16[data>>4], R_REG_TYPE_GPR);
+			dst->reg = r_reg_get (anal->reg, regs_16[data>>4], R_REG_TYPE_GPR);
 			if (op->type == R_ANAL_OP_TYPE_ADD) {
 				r_strbuf_setf (&op->esil, "1,%s,+=", regs_16[data>>4]);
 			} else {
 				r_strbuf_setf (&op->esil, "1,%s,-=", regs_16[data >> 4]);
 			}
 		} else {
-			op->dst->reg = r_reg_get (anal->reg, regs_8[data>>3], R_REG_TYPE_GPR);
+			dst->reg = r_reg_get (anal->reg, regs_8[data>>3], R_REG_TYPE_GPR);
 			if (op->type == R_ANAL_OP_TYPE_ADD) {
 				r_strbuf_setf (&op->esil, "1,%s,+=,3,$c,H,:=,$z,Z,:=,0,N,:=", regs_8[data>>3]);
 			} else {
@@ -152,21 +156,29 @@ static inline void gb_anal_id(RAnal *anal, RAnalOp *op, const ut8 data) {
 			}
 		}
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_add_hl(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, regs_16[((data & 0xf0)>>4)], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	src->reg = r_reg_get (reg, regs_16[((data & 0xf0)>>4)], R_REG_TYPE_GPR);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_setf (&op->esil, "%s,hl,+=,0,N,:=", regs_16[((data & 0xf0)>>4)]);	//hl+=<reg>,N=0
 }
 
 static inline void gb_anal_add_sp(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
-	op->src[0]->imm = (st8)data;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
+	src->imm = (st8)data;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	if (data < 128) {
 		r_strbuf_setf (&op->esil, "0x%02x,sp,+=", data);
 	} else {
@@ -176,36 +188,46 @@ static inline void gb_anal_add_sp(RReg *reg, RAnalOp *op, const ut8 data) {
 }
 
 static void gb_anal_mov_imm(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
 	if (data[0] & 1) {
-		op->dst->reg = r_reg_get (reg, regs_16[data[0]>>4], R_REG_TYPE_GPR);
-		op->src[0]->imm = GB_SOFTCAST (data[1], data[2]);
-		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",%s,=", op->src[0]->imm, regs_16[data[0]>>4]);
+		dst->reg = r_reg_get (reg, regs_16[data[0]>>4], R_REG_TYPE_GPR);
+		src->imm = GB_SOFTCAST (data[1], data[2]);
+		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",%s,=", src->imm, regs_16[data[0]>>4]);
 	} else {
-		op->dst->reg = r_reg_get (reg, regs_8[data[0]>>3], R_REG_TYPE_GPR);
-		op->src[0]->imm = data[1];
-		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,=", op->src[0]->imm, regs_8[data[0]>>3]);
+		dst->reg = r_reg_get (reg, regs_8[data[0]>>3], R_REG_TYPE_GPR);
+		src->imm = data[1];
+		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,=", src->imm, regs_8[data[0]>>3]);
 	}
-	op->src[0]->absolute = true;
-	op->val = op->src[0]->imm;
+	src->absolute = true;
+	op->val = src->imm;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_mov_sp_hl(RReg *reg, RAnalOp *op) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
+	src->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_set (&op->esil, "hl,sp,=");
 }
 
 static inline void gb_anal_mov_hl_sp(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[1] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, regs_16[2], R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, regs_16[3], R_REG_TYPE_GPR);
-	op->src[1]->imm = (st8)data;
+	RAnalValue *dst, *src0, *src1;
+	dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();
+	src1 = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, regs_16[2], R_REG_TYPE_GPR);
+	src0->reg = r_reg_get (reg, regs_16[3], R_REG_TYPE_GPR);
+	src1->imm = (st8)data;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src0);
+	r_pvector_push(op->srcs, src1);
 	if (data < 128) {
 		r_strbuf_setf (&op->esil, "0x%02x,sp,+,hl,=", data);
 	} else {
@@ -215,53 +237,69 @@ static inline void gb_anal_mov_hl_sp(RReg *reg, RAnalOp *op, const ut8 data) {
 }
 
 static void gb_anal_mov_reg(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, regs_8[(data/8) - 8], R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, regs_8[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, regs_8[(data/8) - 8], R_REG_TYPE_GPR);
+	src->reg = r_reg_get (reg, regs_8[data & 7], R_REG_TYPE_GPR);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_setf (&op->esil, "%s,%s,=", regs_8[data & 7], regs_8[(data/8) - 8]);
 }
 
 static inline void gb_anal_mov_ime(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "ime", R_REG_TYPE_GPR);
-	op->src[0]->absolute = true;
-	op->src[0]->imm = (data != 0xf3);
-	r_strbuf_setf (&op->esil, "%d,ime,=", (int)op->src[0]->imm);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "ime", R_REG_TYPE_GPR);
+	src->absolute = true;
+	src->imm = (data != 0xf3);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
+	r_strbuf_setf (&op->esil, "%d,ime,=", (int)src->imm);
 	if (data == 0xd9) {
 		r_strbuf_append (&op->esil, ",");
 	}
 }
 
 static inline void gb_anal_mov_scf(RReg *reg, RAnalOp *op) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
-	op->src[0]->imm = 1;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
+	src->imm = 1;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_set (&op->esil, "1,C,:=");
 }
 
 static inline void gb_anal_xor_cpl(RReg *reg, RAnalOp *op) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, regs_8[7], R_REG_TYPE_GPR);
-	op->src[0]->imm = 0xff;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, regs_8[7], R_REG_TYPE_GPR);
+	src->imm = 0xff;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_set (&op->esil, "0xff,a,^=,1,N,:=,1,H,:=");
 }
 
 static inline void gb_anal_xor_ccf(RReg *reg, RAnalOp *op) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
-	op->src[0]->imm = 1;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
+	src->imm = 1;
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_set (&op->esil, "C,!=");
 }
 
 static inline void gb_anal_cond(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
 	if (data & 0x8) {
 		op->cond = R_ANAL_COND_EQ;
 	} else {
@@ -276,105 +314,117 @@ static inline void gb_anal_cond(RReg *reg, RAnalOp *op, const ut8 data) {
 	case 0xc8:
 	case 0xca:
 	case 0xcc:
-		op->dst->reg = r_reg_get (reg, regs_1[0], R_REG_TYPE_GPR);
+		dst->reg = r_reg_get (reg, regs_1[0], R_REG_TYPE_GPR);
 		break;
 	default:
-		op->dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
+		dst->reg = r_reg_get (reg, regs_1[3], R_REG_TYPE_GPR);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_pp(RReg *reg, RAnalOp *op, const ut8 data) {//push , pop
 	RAnalValue *val = r_anal_value_new ();
 	val->reg = r_reg_get (reg, regs_16_alt[(data>>4) - 12], R_REG_TYPE_GPR);
 	if ((data & 0xf) == 1) {
-		op->dst = val;
+		r_pvector_push(op->dsts, val);
 		r_strbuf_setf (&op->esil, "sp,[2],%s,=,2,sp,+=", regs_16_alt[(data>>4) - 12]);		//pop
 	} else {
-		op->src[0] = val;
+		r_pvector_push(op->srcs, val);
 		r_strbuf_setf (&op->esil, "2,sp,-=,%s,sp,=[2]", regs_16_alt[(data>>4) - 12]);		//push
 	}
 }
 
 static inline void gb_anal_and_res(RAnal *anal, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = ((~(0x1 << ((data >> 3) & 7))) & 0xff);
-	op->dst->memref = ((data & 7) == 6);
-	op->dst->reg = r_reg_get (anal->reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	if (op->dst->memref) {
-		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,[1],&,%s,=[1]", op->src[0]->imm, regs_x[data & 7], regs_x[data & 7]);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = ((~(0x1 << ((data >> 3) & 7))) & 0xff);
+	dst->memref = ((data & 7) == 6);
+	dst->reg = r_reg_get (anal->reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	if (dst->memref) {
+		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,[1],&,%s,=[1]", src->imm, regs_x[data & 7], regs_x[data & 7]);
 	} else {
-		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,&=", op->src[0]->imm, regs_x[data & 7]);
+		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,&=", src->imm, regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_and_bit(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1<<((data>>3) & 7);
-	op->dst->memref = ((data & 7) == 6);
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	if (op->dst->memref) {
-		r_strbuf_setf (&op->esil, "%" PFMT64d ",%s,[1],&,0,==,$z,Z,:=,0,N,:=,1,H,:=", op->src[0]->imm, regs_x[data & 7]);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1<<((data>>3) & 7);
+	dst->memref = ((data & 7) == 6);
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	if (dst->memref) {
+		r_strbuf_setf (&op->esil, "%" PFMT64d ",%s,[1],&,0,==,$z,Z,:=,0,N,:=,1,H,:=", src->imm, regs_x[data & 7]);
 	} else {
-		r_strbuf_setf (&op->esil, "%" PFMT64d ",%s,&,0,==,$z,Z,:=,0,N,:=,1,H,:=", op->src[0]->imm, regs_x[data & 7]);
+		r_strbuf_setf (&op->esil, "%" PFMT64d ",%s,&,0,==,$z,Z,:=,0,N,:=,1,H,:=", src->imm, regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_or_set(RAnal *anal, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = (data>>3) & 7;
-	op->dst->memref = ((data & 7) == 6);
-	op->dst->reg = r_reg_get (anal->reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	if (op->dst->memref) {
-		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,[1],|,%s,=[1]", op->src[0]->imm, regs_x[data & 7], regs_x[data & 7]);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = (data>>3) & 7;
+	dst->memref = ((data & 7) == 6);
+	dst->reg = r_reg_get (anal->reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	if (dst->memref) {
+		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,[1],|,%s,=[1]", src->imm, regs_x[data & 7], regs_x[data & 7]);
 	} else {
-		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,|=", op->src[0]->imm, regs_x[data & 7]);
+		r_strbuf_setf (&op->esil, "0x%02" PFMT64x ",%s,|=", src->imm, regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static void gb_anal_xoaasc(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
-	op->src[0]->reg = r_reg_get (reg, regs_x[data[0] & 7], R_REG_TYPE_GPR);
-	op->src[0]->memref = ((data[0] & 7) == 6);
+	RAnalValue *dst, *src0, *src1=NULL;
+	dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
+	src0->reg = r_reg_get (reg, regs_x[data[0] & 7], R_REG_TYPE_GPR);
+	src0->memref = ((data[0] & 7) == 6);
 	switch (op->type) {
 	case R_ANAL_OP_TYPE_XOR:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			r_strbuf_setf (&op->esil, "%s,[1],a,^=,$z,Z,:=,0,N,:=,0,H,:=,0,C,:=", regs_x[data[0] & 7]);
 		} else {
 			r_strbuf_setf (&op->esil, "%s,a,^=,$z,Z,:=,0,N,:=,0,H,:=,0,C,:=", regs_x[data[0] & 7]);
 		}
 		break;
 	case R_ANAL_OP_TYPE_OR:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			r_strbuf_setf (&op->esil, "%s,[1],a,|=,$z,Z,:=,0,N,:=,0,H,:=,0,C,:=", regs_x[data[0] &7]);
 		} else {
 			r_strbuf_setf (&op->esil, "%s,a,|=,$z,Z,:=,0,N,:=,0,H,:=,0,C,:=", regs_x[data[0] & 7]);
 		}
 		break;
 	case R_ANAL_OP_TYPE_AND:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			r_strbuf_setf (&op->esil, "%s,[1],a,&=,$z,Z,:=,0,N,:=,1,H,:=,0,C,:=", regs_x[data[0] & 7]);
 		} else {
 			r_strbuf_setf (&op->esil, "%s,a,&=,$z,Z,:=,0,N,:=,1,H,:=,0,C,:=", regs_x[data[0] & 7]);
 		}
 		break;
 	case R_ANAL_OP_TYPE_ADD:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			if (data[0] > 0x87) {
-				op->src[1] = r_anal_value_new ();
-				op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+				src1 = r_anal_value_new ();
+				src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 				r_strbuf_setf ( &op->esil, "C,%s,[1],+,a,+=,$z,Z,:=,3,$c,H,:=,7,$c,C,:=,0,N,:=", regs_x[data[0] & 7]);
 			} else {
 				r_strbuf_setf (&op->esil, "%s,[1],a,+=,$z,Z,:=,3,$c,H,:=,7,$c,C,:=,0,N,:=", regs_x[data[0] & 7]);
 			}
 		} else {
 			if (data[0] > 0x87) {
-				op->src[1] = r_anal_value_new ();
-				op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+				src1 = r_anal_value_new ();
+				src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 				r_strbuf_setf (&op->esil, "C,%s,+,a,+=,$z,Z,:=,3,$c,H,:=,7,$c,C,:=,0,N,:=", regs_x[data[0] & 7]);
 			} else {
 				r_strbuf_setf (&op->esil, "%s,a,+=,$z,Z,:=,3,$c,H,:=,7,$c,C,:=,0,N,:=", regs_x[data[0] & 7]);
@@ -382,18 +432,18 @@ static void gb_anal_xoaasc(RReg *reg, RAnalOp *op, const ut8 *data) {
 		}
 		break;
 	case R_ANAL_OP_TYPE_SUB:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			if (data[0] > 0x97) {
-				op->src[1] = r_anal_value_new ();
-				op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+				src1 = r_anal_value_new ();
+				src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 				r_strbuf_setf (&op->esil, "C,%s,[1],+,a,-=,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
 			} else {
 				r_strbuf_setf (&op->esil, "%s,[1],a,-=,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
 			}
 		} else {
 			if (data[0] > 0x97) {
-				op->src[1] = r_anal_value_new ();
-				op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+				src1 = r_anal_value_new ();
+				src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 				r_strbuf_setf (&op->esil, "C,%s,+,a,-=,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
 			} else {
 				r_strbuf_setf (&op->esil, "%s,a,-=,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
@@ -401,7 +451,7 @@ static void gb_anal_xoaasc(RReg *reg, RAnalOp *op, const ut8 *data) {
 		}
 		break;
 	case R_ANAL_OP_TYPE_CMP:
-		if (op->src[0]->memref) {
+		if (src0->memref) {
 			r_strbuf_setf (&op->esil, "%s,[1],a,==,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
 		} else {
 			r_strbuf_setf (&op->esil, "%s,a,==,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", regs_x[data[0] & 7]);
@@ -411,15 +461,20 @@ static void gb_anal_xoaasc(RReg *reg, RAnalOp *op, const ut8 *data) {
 		// not handled yet
 		break;
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src0);
+	if (src1)
+	   	r_pvector_push(op->srcs, src1);
 }
 
 // xor , or, and, add, adc, sub, sbc, cp
 static void gb_anal_xoaasc_imm(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
-	op->src[0]->absolute = true;
-	op->src[0]->imm = data[1];
+	RAnalValue *dst, *src0, *src1=NULL;
+	dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
+	src0->absolute = true;
+	src0->imm = data[1];
 	switch (op->type) {
 	case R_ANAL_OP_TYPE_XOR:
 		r_strbuf_setf (&op->esil, "0x%02x,a,^=,$z,Z,:=,0,N,:=,0,H,:=,0,C,:=", data[1]);
@@ -433,8 +488,8 @@ static void gb_anal_xoaasc_imm(RReg *reg, RAnalOp *op, const ut8 *data) {
 	case R_ANAL_OP_TYPE_ADD:
 		r_strbuf_setf (&op->esil, "0x%02x,", data[1]);
 		if (data[0] == 0xce) {					//adc
-			op->src[1] = r_anal_value_new ();
-			op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+			src1 = r_anal_value_new ();
+			src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 			r_strbuf_append (&op->esil, "a,+=,C,NUM,7,$c,C,:=,3,$c,H,:=,a,+=,7,$c,C,|,C,:=,3,$c,H,|=,a,a,=,$z,Z,:=,0,N,:=");
 		} else {
 			r_strbuf_append (&op->esil, "a,+=,3,$c,H,:=,7,$c,C,:=,0,N,:=,a,a,=,$z,Z,:=");
@@ -443,8 +498,8 @@ static void gb_anal_xoaasc_imm(RReg *reg, RAnalOp *op, const ut8 *data) {
 	case R_ANAL_OP_TYPE_SUB:
 		r_strbuf_setf (&op->esil, "0x%02x,", data[1]);
 		if (data[0] == 0xde) {					//sbc
-			op->src[1] = r_anal_value_new ();
-			op->src[1]->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
+			src1 = r_anal_value_new ();
+			src1->reg = r_reg_get (reg, "C", R_REG_TYPE_GPR);
 			r_strbuf_append (&op->esil, "a,-=,C,NUM,8,$b,C,:=,4,$b,H,:=,a,-=,8,$b,C,|,C,=,4,$b,H,|,H,=,a,a,=,$z,Z,:=,1,N,:=");
 		} else {
 			r_strbuf_append (&op->esil, "a,-=,4,$b,H,:=,8,$b,C,:=,1,N,:=,a,a,=,$z,Z,:=");
@@ -454,16 +509,23 @@ static void gb_anal_xoaasc_imm(RReg *reg, RAnalOp *op, const ut8 *data) {
 		r_strbuf_setf (&op->esil, "%d,a,==,$z,Z,:=,4,$b,H,:=,8,$b,C,:=,1,N,:=", data[1]);
 		break;
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src0);
+	if (src1)
+	   	r_pvector_push(op->srcs, src1);
 }
 
 	//load with [hl] as memref
 static inline void gb_anal_load_hl(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
-	op->src[0]->memref = 1;
-	op->src[0]->absolute = true;
-	op->dst->reg = r_reg_get (reg, regs_8[((data & 0x38)>>3)], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	src->memref = 1;
+	src->absolute = true;
+	dst->reg = r_reg_get (reg, regs_8[((data & 0x38)>>3)], R_REG_TYPE_GPR);
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 	r_strbuf_setf (&op->esil, "hl,[1],%s,=", regs_8[((data & 0x38)>>3)]);
 	if (data == 0x3a) {
 		r_strbuf_append (&op->esil, ",1,hl,-=");
@@ -474,49 +536,53 @@ static inline void gb_anal_load_hl(RReg *reg, RAnalOp *op, const ut8 data) {
 }
 
 static inline void gb_anal_load(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
-	op->src[0]->memref = 1;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
+	src->memref = 1;
 	switch (data[0]) {
 	case 0xf0:
-		op->src[0]->base = 0xff00 + data[1];
-		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",[1],a,=", op->src[0]->base);
+		src->base = 0xff00 + data[1];
+		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",[1],a,=", src->base);
 		break;
 	case 0xf2:
-		op->src[0]->base = 0xff00;
-		op->src[0]->regdelta = r_reg_get (reg, "c", R_REG_TYPE_GPR);
+		src->base = 0xff00;
+		src->regdelta = r_reg_get (reg, "c", R_REG_TYPE_GPR);
 		r_strbuf_set (&op->esil, "0xff00,c,+,[1],a,=");
 		break;
 	case 0xfa:
-		op->src[0]->base = GB_SOFTCAST (data[1], data[2]);
-		if (op->src[0]->base < 0x4000) {
-			op->ptr = op->src[0]->base;
+		src->base = GB_SOFTCAST (data[1], data[2]);
+		if (src->base < 0x4000) {
+			op->ptr = src->base;
 		} else {
-			if (op->addr > 0x3fff && op->src[0]->base < 0x8000) { /* hack */
-				op->ptr = op->src[0]->base + (op->addr & 0xffffffffffff0000LL);
+			if (op->addr > 0x3fff && src->base < 0x8000) { /* hack */
+				op->ptr = src->base + (op->addr & 0xffffffffffff0000LL);
 			}
 		}
-		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",[1],a,=", op->src[0]->base);
+		r_strbuf_setf (&op->esil, "0x%04" PFMT64x ",[1],a,=", src->base);
 		break;
 	default:
-		op->src[0]->reg = r_reg_get (reg, regs_16[(data[0] & 0xf0) >> 4], R_REG_TYPE_GPR);
+		src->reg = r_reg_get (reg, regs_16[(data[0] & 0xf0) >> 4], R_REG_TYPE_GPR);
 		r_strbuf_setf (&op->esil, "%s,[1],a,=", regs_16[(data[0] & 0xf0) >> 4]);
 		break;
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_store_hl(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
-	op->dst->memref = 1;
-	op->src[0]->absolute = true;
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->reg = r_reg_get (reg, "hl", R_REG_TYPE_GPR);
+	dst->memref = 1;
+	src->absolute = true;
 	if (data[0] == 0x36) {
-		op->src[0]->imm = data[1];
+		src->imm = data[1];
 		r_strbuf_setf (&op->esil, "0x%02x,hl,=[1]", data[1]);
 	} else {
-		op->src[0]->reg = r_reg_get (reg, regs_8[data[0] & 0x07], R_REG_TYPE_GPR);
+		src->reg = r_reg_get (reg, regs_8[data[0] & 0x07], R_REG_TYPE_GPR);
 		r_strbuf_setf (&op->esil, "%s,hl,=[1]", regs_8[data[0] & 0x07]);
 	}
 	if (data[0] == 0x32) {
@@ -525,142 +591,171 @@ static inline void gb_anal_store_hl(RReg *reg, RAnalOp *op, const ut8 *data) {
 	if (data[0] == 0x22) {
 		r_strbuf_set (&op->esil, "a,hl,=[1],1,hl,+=");
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static void gb_anal_store(RReg *reg, RAnalOp *op, const ut8 *data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->dst->memref = 1;
-	op->src[0]->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	dst->memref = 1;
+	src->reg = r_reg_get (reg, "a", R_REG_TYPE_GPR);
 	switch (data[0]) {
 		case 0x08:
-			op->dst->memref = 2;
-			op->dst->base = GB_SOFTCAST (data[1], data[2]);
-			op->src[0]->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
-			r_strbuf_setf (&op->esil, "sp,0x%04" PFMT64x ",=[2]", op->dst->base);
+			dst->memref = 2;
+			dst->base = GB_SOFTCAST (data[1], data[2]);
+			src->reg = r_reg_get (reg, "sp", R_REG_TYPE_GPR);
+			r_strbuf_setf (&op->esil, "sp,0x%04" PFMT64x ",=[2]", dst->base);
 			break;
 		case 0xe0:
-			op->dst->base = 0xff00 + data[1];
-			r_strbuf_setf (&op->esil, "a,0x%04" PFMT64x ",=[1]", op->dst->base);
+			dst->base = 0xff00 + data[1];
+			r_strbuf_setf (&op->esil, "a,0x%04" PFMT64x ",=[1]", dst->base);
 			break;
 		case 0xe2:
-			op->dst->base = 0xff00;
-			op->dst->regdelta = r_reg_get (reg, "c", R_REG_TYPE_GPR);
+			dst->base = 0xff00;
+			dst->regdelta = r_reg_get (reg, "c", R_REG_TYPE_GPR);
 			r_strbuf_set (&op->esil, "a,0xff00,c,+,=[1]");
 			break;
 		case 0xea:
-			op->dst->base = GB_SOFTCAST (data[1], data[2]);
-			r_strbuf_setf (&op->esil, "a,0x%04" PFMT64x ",=[1]", op->dst->base);
+			dst->base = GB_SOFTCAST (data[1], data[2]);
+			r_strbuf_setf (&op->esil, "a,0x%04" PFMT64x ",=[1]", dst->base);
 			break;
 		default:
-			op->dst->reg = r_reg_get (reg, regs_16[(data[0] & 0xf0)>>4], R_REG_TYPE_GPR);
+			dst->reg = r_reg_get (reg, regs_16[(data[0] & 0xf0)>>4], R_REG_TYPE_GPR);
 			r_strbuf_setf (&op->esil , "a,%s,=[1]", regs_16[(data[0] & 0xf0)>>4]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_swap(RReg *reg, RAnalOp* op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 4;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 4;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
 	if ((data & 7) == 6) {
-		op->dst->memref = 1;
+		dst->memref = 1;
 		r_strbuf_setf (&op->esil, "4,%s,[1],>>,4,%s,[1],<<,|,%s,=[1],$z,Z,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "4,%s,>>,4,%s,<<,|,%s,=,$z,Z,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_rlc(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
 	if ((data & 7) == 6) {
-		op->dst->memref = 1;
+		dst->memref = 1;
 		r_strbuf_setf (&op->esil, "7,%s,[1],>>,1,&,C,:=,1,%s,[1],<<,C,|,%s,=[1],$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,<<=,7,$c,C,:=,C,%s,|=,$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_rl(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
 	if ((data & 7) == 6) {
-		op->dst->memref = 1;
+		dst->memref = 1;
 		r_strbuf_setf (&op->esil, "1,%s,<<,C,|,%s,=[1],7,$c,C,:=,$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,<<,C,|,%s,=,7,$c,C,:=,$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_rrc(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get(reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get(reg, regs_x[data & 7], R_REG_TYPE_GPR);
 	if ((data &7) == 6) {
-		op->dst->memref = 1;
+		dst->memref = 1;
 		r_strbuf_setf (&op->esil, "1,%s,[1],&,C,:=,1,%s,[1],>>,7,C,<<,|,%s,=[1],$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,&,C,:=,1,%s,>>,7,C,<<,|,%s,=,$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_rr(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
 	if ((data & 7) == 6) {
-		op->dst->memref = 1;
+		dst->memref = 1;
 		r_strbuf_setf (&op->esil, "1,%s,[1],&,H,:=,1,%s,[1],>>,7,C,<<,|,%s,=[1],H,C,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,&,H,:=,1,%s,>>,7,C,<<,|,%s,=,H,C,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]); //HACK
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_sla(RReg *reg, RAnalOp *op, const ut8 data) {
+	RAnalValue *dst, *src;
 	//sra+sla+srl in one function, like xoaasc
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	op->dst->memref = ((data & 7) == 6);
-	if (op->dst->memref) {
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	dst->memref = ((data & 7) == 6);
+	if (dst->memref) {
 		r_strbuf_setf (&op->esil, "1,%s,[1],<<,%s,=[1],7,$c,C,:=,%s,[1],%s,=[1],$z,Z,:=,0,H,:=,0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,<<=,7,$c,C,:=,%s,%s,=,$z,Z,:=,0,H,:=0,N,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]); // %s,%s,= is a HACK for $z
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_sra(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	op->dst->memref = ((data & 7) == 6);
-	if (op->dst->memref) {
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	dst->memref = ((data & 7) == 6);
+	if (dst->memref) {
 		r_strbuf_setf (&op->esil, "1,%s,[1],&,C,:=,0x80,%s,[1],&,1,%s,[1],>>,|,%s,=[1],$z,Z,:=,0,N,:=,0,H,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);	//spaguesil
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,&,C,:=,0x80,%s,&,1,%s,>>,|,%s,=,$z,Z,:=,0,N,:=,0,H,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static inline void gb_anal_cb_srl(RReg *reg, RAnalOp *op, const ut8 data) {
-	op->dst = r_anal_value_new ();
-	op->src[0] = r_anal_value_new ();
-	op->src[0]->imm = 1;
-	op->dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
-	op->dst->memref = ((data & 7) == 6);
-	if (op->dst->memref) {
+	RAnalValue *dst, *src;
+	dst = r_anal_value_new ();
+	src = r_anal_value_new ();
+	src->imm = 1;
+	dst->reg = r_reg_get (reg, regs_x[data & 7], R_REG_TYPE_GPR);
+	dst->memref = ((data & 7) == 6);
+	if (dst->memref) {
 		r_strbuf_setf (&op->esil, "1,%s,[1],&,C,:=,1,%s,[1],>>,%s,=[1],$z,Z,:=,0,N,:=,0,H,:=", regs_x[data & 7], regs_x[data & 7], regs_x[data & 7]);
 	} else {
 		r_strbuf_setf (&op->esil, "1,%s,&,C,:=,1,%s,>>=,$z,Z,:=,0,N,:=,0,H,:=", regs_x[data & 7], regs_x[data & 7]);
 	}
+	r_pvector_push(op->dsts, dst);
+	r_pvector_push(op->srcs, src);
 }
 
 static bool gb_custom_daa(RAnalEsil *esil) {

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -221,28 +221,32 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	static R_TH_LOCAL RRegItem reg;
+	RAnalValue *src, *dst;
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 		ZERO_FILL (reg);
 		if (OPERAND(1).type == M68K_OP_MEM) {
-			op->src[0] = r_anal_value_new ();
-			op->src[0]->reg = &reg;
-			parse_reg_name (op->src[0]->reg, handle, insn, 1);
-			op->src[0]->delta = OPERAND(0).mem.disp;
+			src = r_anal_value_new ();
+			src->reg = &reg;
+			parse_reg_name (src->reg, handle, insn, 1);
+			src->delta = OPERAND(0).mem.disp;
+			r_pvector_push(op->srcs, src);
 		} else if (OPERAND(0).type == M68K_OP_MEM) {
-			op->dst = r_anal_value_new ();
-			op->dst->reg = &reg;
-			parse_reg_name (op->dst->reg, handle, insn, 0);
-			op->dst->delta = OPERAND(1).mem.disp;
+			dst = r_anal_value_new ();
+			dst->reg = &reg;
+			parse_reg_name (dst->reg, handle, insn, 0);
+			dst->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_LEA:
 		ZERO_FILL (reg);
 		if (OPERAND(1).type == M68K_OP_MEM) {
-			op->dst = r_anal_value_new ();
-			op->dst->reg = &reg;
-			parse_reg_name (op->dst->reg, handle, insn, 1);
-			op->dst->delta = OPERAND(1).mem.disp;
+			dst = r_anal_value_new ();
+			dst->reg = &reg;
+			parse_reg_name (dst->reg, handle, insn, 1);
+			dst->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	}

--- a/libr/anal/p/anal_m68k_cs.c
+++ b/libr/anal/p/anal_m68k_cs.c
@@ -226,27 +226,24 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_MOV:
 		ZERO_FILL (reg);
 		if (OPERAND(1).type == M68K_OP_MEM) {
-			src = r_anal_value_new ();
+			src = r_vector_push (op->srcs, NULL);
 			src->reg = &reg;
 			parse_reg_name (src->reg, handle, insn, 1);
 			src->delta = OPERAND(0).mem.disp;
-			r_pvector_push(op->srcs, src);
 		} else if (OPERAND(0).type == M68K_OP_MEM) {
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = &reg;
 			parse_reg_name (dst->reg, handle, insn, 0);
 			dst->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_LEA:
 		ZERO_FILL (reg);
 		if (OPERAND(1).type == M68K_OP_MEM) {
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = &reg;
 			parse_reg_name (dst->reg, handle, insn, 1);
 			dst->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	}

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -26,18 +26,13 @@ static R_TH_LOCAL ut64 t9_pre = UT64_MAX;
 	}
 
 #define CREATE_SRC_DST_3(op) \
-	src0 = r_anal_value_new ();\
-	src1 = r_anal_value_new ();\
-	dst = r_anal_value_new ();\
-	r_pvector_push((op)->srcs, src0);\
-	r_pvector_push((op)->srcs, src1);\
-	r_pvector_push((op)->dsts, dst);
+	src0 = r_vector_push ((op)->srcs, NULL);\
+	src1 = r_vector_push ((op)->srcs, NULL);\
+	dst = r_vector_push ((op)->dsts, NULL);
 
 #define CREATE_SRC_DST_2(op) \
-	src0 = r_anal_value_new ();\
-	dst = r_anal_value_new ();\
-	r_pvector_push((op)->srcs, src0);\
-	r_pvector_push((op)->dsts, dst);
+	src0 = r_vector_push ((op)->srcs, NULL);\
+	dst = r_vector_push ((op)->dsts, NULL);
 
 #define SET_SRC_DST_3_REGS(op) \
 	CREATE_SRC_DST_3 (op);\
@@ -700,21 +695,19 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (OPERAND(1).type == MIPS_OP_MEM) {
 			ZERO_FILL (reg);
-			src0 = r_anal_value_new ();
+			src0 = r_vector_push (op->srcs, NULL);
 			src0->reg = &reg;
 			parse_reg_name (src0->reg, *handle, insn, 1);
 			src0->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->srcs, src0);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (OPERAND(1).type == MIPS_OP_MEM) {
 			ZERO_FILL (reg);
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = &reg;
 			parse_reg_name (dst->reg, *handle, insn, 1);
 			dst->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_SHL:

--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -26,30 +26,35 @@ static R_TH_LOCAL ut64 t9_pre = UT64_MAX;
 	}
 
 #define CREATE_SRC_DST_3(op) \
-	(op)->src[0] = r_anal_value_new ();\
-	(op)->src[1] = r_anal_value_new ();\
-	(op)->dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();\
+	src1 = r_anal_value_new ();\
+	dst = r_anal_value_new ();\
+	r_pvector_push((op)->srcs, src0);\
+	r_pvector_push((op)->srcs, src1);\
+	r_pvector_push((op)->dsts, dst);
 
 #define CREATE_SRC_DST_2(op) \
-	(op)->src[0] = r_anal_value_new ();\
-	(op)->dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();\
+	dst = r_anal_value_new ();\
+	r_pvector_push((op)->srcs, src0);\
+	r_pvector_push((op)->dsts, dst);
 
 #define SET_SRC_DST_3_REGS(op) \
 	CREATE_SRC_DST_3 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
-	(op)->src[1]->reg = r_reg_get (anal->reg, REG (2), R_REG_TYPE_GPR);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
+	src1->reg = r_reg_get (anal->reg, REG (2), R_REG_TYPE_GPR);
 
 #define SET_SRC_DST_3_IMM(op) \
 	CREATE_SRC_DST_3 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
-	(op)->src[1]->imm = IMM (2);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
+	src1->imm = IMM (2);
 
 #define SET_SRC_DST_2_REGS(op) \
 	CREATE_SRC_DST_2 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);
 
 #define SET_SRC_DST_3_REG_OR_IMM(op) \
 	if (OPERAND(2).type == MIPS_OP_IMM) {\
@@ -690,23 +695,26 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	static R_TH_LOCAL RRegItem reg = {0};
+	RAnalValue *dst, *src0, *src1;
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (OPERAND(1).type == MIPS_OP_MEM) {
 			ZERO_FILL (reg);
-			op->src[0] = r_anal_value_new ();
-			op->src[0]->reg = &reg;
-			parse_reg_name (op->src[0]->reg, *handle, insn, 1);
-			op->src[0]->delta = OPERAND(1).mem.disp;
+			src0 = r_anal_value_new ();
+			src0->reg = &reg;
+			parse_reg_name (src0->reg, *handle, insn, 1);
+			src0->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->srcs, src0);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (OPERAND(1).type == MIPS_OP_MEM) {
 			ZERO_FILL (reg);
-			op->dst = r_anal_value_new ();
-			op->dst->reg = &reg;
-			parse_reg_name (op->dst->reg, *handle, insn, 1);
-			op->dst->delta = OPERAND(1).mem.disp;
+			dst = r_anal_value_new ();
+			dst->reg = &reg;
+			parse_reg_name (dst->reg, *handle, insn, 1);
+			dst->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_SHL:

--- a/libr/anal/p/anal_mips_gnu.c
+++ b/libr/anal/p/anal_mips_gnu.c
@@ -1525,6 +1525,8 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 		insn.i_reg.rt = mips_reg_decode (rt);
 		snprintf ((char *)insn.i_reg.imm, REG_BUF_MAX, "%" PFMT32d, imm);
 
+		RAnalValue *src = r_pvector_at(op->srcs, 0);
+		RAnalValue *dst = r_pvector_at(op->dsts, 0);
 		switch (optype) {
 		case 1:
 			switch (rt) {
@@ -1601,19 +1603,19 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 		case 15: // lui
 			insn.id = MIPS_INS_LUI;
 			snprintf ((char *)insn.i_reg.imm, REG_BUF_MAX, "0x%" PFMT32x, imm);
-			op->dst = r_anal_value_new ();
-			op->dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
+			dst = r_anal_value_new ();
+			dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
 			// TODO: currently there is no way for the macro to get access to this register
 			op->val = imm;
 			break;
 		case 9: // addiu
 			insn.id = MIPS_INS_ADDIU;
 			op->type = R_ANAL_OP_TYPE_ADD;
-			op->dst = r_anal_value_new ();
-			op->dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
+			dst = r_anal_value_new ();
+			dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
 			// TODO: currently there is no way for the macro to get access to this register
-			op->src[0] = r_anal_value_new ();
-			op->src[0]->reg = r_reg_get (anal->reg, mips_reg_decode (rs), R_REG_TYPE_GPR);
+			src = r_anal_value_new ();
+			src->reg = r_reg_get (anal->reg, mips_reg_decode (rs), R_REG_TYPE_GPR);
 			op->val = imm; // Beware: this one is signed... use `?vi $v`
 			if (rs == 0) {
 				insn.id = MIPS_INS_LI;

--- a/libr/anal/p/anal_mips_gnu.c
+++ b/libr/anal/p/anal_mips_gnu.c
@@ -1525,8 +1525,7 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 		insn.i_reg.rt = mips_reg_decode (rt);
 		snprintf ((char *)insn.i_reg.imm, REG_BUF_MAX, "%" PFMT32d, imm);
 
-		RAnalValue *src = r_pvector_at(op->srcs, 0);
-		RAnalValue *dst = r_pvector_at(op->dsts, 0);
+		RAnalValue *src, *dst;
 		switch (optype) {
 		case 1:
 			switch (rt) {
@@ -1603,7 +1602,7 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 		case 15: // lui
 			insn.id = MIPS_INS_LUI;
 			snprintf ((char *)insn.i_reg.imm, REG_BUF_MAX, "0x%" PFMT32x, imm);
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
 			// TODO: currently there is no way for the macro to get access to this register
 			op->val = imm;
@@ -1611,10 +1610,10 @@ static int mips_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, R
 		case 9: // addiu
 			insn.id = MIPS_INS_ADDIU;
 			op->type = R_ANAL_OP_TYPE_ADD;
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = r_reg_get (anal->reg, mips_reg_decode (rt), R_REG_TYPE_GPR);
 			// TODO: currently there is no way for the macro to get access to this register
-			src = r_anal_value_new ();
+			src = r_vector_push (op->srcs, NULL);
 			src->reg = r_reg_get (anal->reg, mips_reg_decode (rs), R_REG_TYPE_GPR);
 			op->val = imm; // Beware: this one is signed... use `?vi $v`
 			if (rs == 0) {

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -521,10 +521,10 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 static RRegItem base_regs[4];
 
 static void create_src_dst(RAnalOp *op) {
-	r_pvector_push(op->srcs, r_anal_value_new ());
-	r_pvector_push(op->srcs, r_anal_value_new ());
-	r_pvector_push(op->srcs, r_anal_value_new ());
-	r_pvector_push(op->dsts, r_anal_value_new ());
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->srcs, NULL);
+	r_vector_push (op->dsts, NULL);
 	ZERO_FILL (base_regs[0]);
 	ZERO_FILL (base_regs[1]);
 	ZERO_FILL (base_regs[2]);
@@ -551,10 +551,10 @@ static void set_src_dst(RAnalValue *val, csh *handle, cs_insn *insn, int x) {
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	create_src_dst (op);
-	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
-	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
-	RAnalValue *src2 = r_pvector_at(op->srcs, 2);
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src0 = r_vector_index_ptr (op->srcs, 0);
+	RAnalValue *src1 = r_vector_index_ptr (op->srcs, 1);
+	RAnalValue *src2 = r_vector_index_ptr (op->srcs, 2);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 	case R_ANAL_OP_TYPE_CMP:

--- a/libr/anal/p/anal_ppc_cs.c
+++ b/libr/anal/p/anal_ppc_cs.c
@@ -521,10 +521,10 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 static RRegItem base_regs[4];
 
 static void create_src_dst(RAnalOp *op) {
-	op->src[0] = r_anal_value_new ();
-	op->src[1] = r_anal_value_new ();
-	op->src[2] = r_anal_value_new ();
-	op->dst = r_anal_value_new ();
+	r_pvector_push(op->srcs, r_anal_value_new ());
+	r_pvector_push(op->srcs, r_anal_value_new ());
+	r_pvector_push(op->srcs, r_anal_value_new ());
+	r_pvector_push(op->dsts, r_anal_value_new ());
 	ZERO_FILL (base_regs[0]);
 	ZERO_FILL (base_regs[1]);
 	ZERO_FILL (base_regs[2]);
@@ -551,6 +551,10 @@ static void set_src_dst(RAnalValue *val, csh *handle, cs_insn *insn, int x) {
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	create_src_dst (op);
+	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
+	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
+	RAnalValue *src2 = r_pvector_at(op->srcs, 2);
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
 	case R_ANAL_OP_TYPE_CMP:
@@ -572,14 +576,14 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_ROR:
 	case R_ANAL_OP_TYPE_ROL:
 	case R_ANAL_OP_TYPE_CAST:
-		set_src_dst (op->src[2], &handle, insn, 3);
-		set_src_dst (op->src[1], &handle, insn, 2);
-		set_src_dst (op->src[0], &handle, insn, 1);
-		set_src_dst (op->dst, &handle, insn, 0);
+		set_src_dst (src2, &handle, insn, 3);
+		set_src_dst (src1, &handle, insn, 2);
+		set_src_dst (src0, &handle, insn, 1);
+		set_src_dst (dst, &handle, insn, 0);
 		break;
 	case R_ANAL_OP_TYPE_STORE:
-		set_src_dst (op->dst, &handle, insn, 1);
-		set_src_dst (op->src[0], &handle, insn, 0);
+		set_src_dst (dst, &handle, insn, 1);
+		set_src_dst (src0, &handle, insn, 0);
 		break;
 	}
 }

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -706,7 +706,7 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	if (mask & R_ANAL_OP_MASK_VAL && args.num) {
 		int i, j = 1;
 		RAnalValue *dst, *src;
-		dst = R_NEW0 (RAnalValue);
+		dst = r_vector_push (op->dsts, NULL);
 		char *argf = strdup (o->args);
 		char *comma = strtok (argf, ",");
 		if (comma && strchr (comma, '(')) {
@@ -718,9 +718,8 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 		} else {
 			dst->reg = r_reg_get (anal->reg, args.arg[0], -1);
 		}
-		r_pvector_push(op->dsts, dst);
 		for (i = 0; j < args.num; i++, j++) {
-			src = R_NEW0 (RAnalValue);
+			src = r_vector_push (op->srcs, NULL);
 			comma = strtok (NULL, ",");
 			if (comma && strchr (comma, '(')) {
 				src->delta = (st64)r_num_get (NULL, args.arg[j]);
@@ -731,7 +730,6 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 			} else {
 				src->imm = r_num_get (NULL, args.arg[j]);
 			}
-			r_pvector_push(op->srcs, src);
 		}
 		free (argf);
 	}

--- a/libr/anal/p/anal_riscv.c
+++ b/libr/anal/p/anal_riscv.c
@@ -705,30 +705,33 @@ static int riscv_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	}
 	if (mask & R_ANAL_OP_MASK_VAL && args.num) {
 		int i, j = 1;
-		op->dst = R_NEW0 (RAnalValue);
+		RAnalValue *dst, *src;
+		dst = R_NEW0 (RAnalValue);
 		char *argf = strdup (o->args);
 		char *comma = strtok (argf, ",");
 		if (comma && strchr (comma, '(')) {
-			op->dst->delta = (st64)r_num_get (NULL, args.arg[0]);
-			op->dst->reg = r_reg_get (anal->reg, args.arg[1], -1);
+			dst->delta = (st64)r_num_get (NULL, args.arg[0]);
+			dst->reg = r_reg_get (anal->reg, args.arg[1], -1);
 			j = 2;
 		} else if (isdigit ((unsigned char)args.arg[j][0])) {
-			op->dst->imm = r_num_get (NULL, args.arg[0]);
+			dst->imm = r_num_get (NULL, args.arg[0]);
 		} else {
-			op->dst->reg = r_reg_get (anal->reg, args.arg[0], -1);
+			dst->reg = r_reg_get (anal->reg, args.arg[0], -1);
 		}
+		r_pvector_push(op->dsts, dst);
 		for (i = 0; j < args.num; i++, j++) {
-			op->src[i] = R_NEW0 (RAnalValue);
+			src = R_NEW0 (RAnalValue);
 			comma = strtok (NULL, ",");
 			if (comma && strchr (comma, '(')) {
-				op->src[i]->delta = (st64)r_num_get (NULL, args.arg[j]);
-				op->src[i]->reg = r_reg_get (anal->reg, args.arg[j + 1], -1);
+				src->delta = (st64)r_num_get (NULL, args.arg[j]);
+				src->reg = r_reg_get (anal->reg, args.arg[j + 1], -1);
 				j++;
 			} else if (isalpha ((unsigned char)args.arg[j][0])) {
-				op->src[i]->reg = r_reg_get (anal->reg, args.arg[j], -1);
+				src->reg = r_reg_get (anal->reg, args.arg[j], -1);
 			} else {
-				op->src[i]->imm = r_num_get (NULL, args.arg[j]);
+				src->imm = r_num_get (NULL, args.arg[j]);
 			}
+			r_pvector_push(op->srcs, src);
 		}
 		free (argf);
 	}

--- a/libr/anal/p/anal_riscv_cs.c
+++ b/libr/anal/p/anal_riscv_cs.c
@@ -25,30 +25,35 @@
 	}
 
 #define CREATE_SRC_DST_3(op) \
-	(op)->src[0] = r_anal_value_new ();\
-	(op)->src[1] = r_anal_value_new ();\
-	(op)->dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();\
+	src1 = r_anal_value_new ();\
+	dst = r_anal_value_new ();\
+	r_pvector_push((op)->dsts, dst);\
+	r_pvector_push((op)->srcs, src0);\
+	r_pvector_push((op)->srcs, src1);
 
 #define CREATE_SRC_DST_2(op) \
-	(op)->src[0] = r_anal_value_new ();\
-	(op)->dst = r_anal_value_new ();
+	src0 = r_anal_value_new ();\
+	dst = r_anal_value_new ();\
+	r_pvector_push((op)->dsts, dst);\
+	r_pvector_push((op)->srcs, src0);
 
 #define SET_SRC_DST_3_REGS(op) \
 	CREATE_SRC_DST_3 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
-	(op)->src[1]->reg = r_reg_get (anal->reg, REG (2), R_REG_TYPE_GPR);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
+	src1->reg = r_reg_get (anal->reg, REG (2), R_REG_TYPE_GPR);
 
 #define SET_SRC_DST_3_IMM(op) \
 	CREATE_SRC_DST_3 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
-	(op)->src[1]->imm = IMM (2);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);\
+	src1->imm = IMM (2);
 
 #define SET_SRC_DST_2_REGS(op) \
 	CREATE_SRC_DST_2 (op);\
-	(op)->dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
-	(op)->src[0]->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);
+	dst->reg = r_reg_get (anal->reg, REG (0), R_REG_TYPE_GPR);\
+	src0->reg = r_reg_get (anal->reg, REG (1), R_REG_TYPE_GPR);
 
 #define SET_SRC_DST_3_REG_OR_IMM(op) \
 	if (OPERAND(2).type == RISCV_OP_IMM) {\
@@ -180,23 +185,26 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	static R_TH_LOCAL RRegItem reg;
+	RAnalValue *dst, *src0, *src1;
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (OPERAND(1).type == RISCV_OP_MEM) {
 			ZERO_FILL (reg);
-			op->src[0] = r_anal_value_new ();
-			op->src[0]->reg = &reg;
-			parse_reg_name (op->src[0]->reg, *handle, insn, 1);
-			op->src[0]->delta = OPERAND(1).mem.disp;
+			src0 = r_anal_value_new ();
+			src0->reg = &reg;
+			parse_reg_name (src0->reg, *handle, insn, 1);
+			src0->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->srcs, src0);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (OPERAND(1).type == RISCV_OP_MEM) {
 			ZERO_FILL (reg);
-			op->dst = r_anal_value_new ();
-			op->dst->reg = &reg;
-			parse_reg_name (op->dst->reg, *handle, insn, 1);
-			op->dst->delta = OPERAND(1).mem.disp;
+			dst = r_anal_value_new ();
+			dst->reg = &reg;
+			parse_reg_name (dst->reg, *handle, insn, 1);
+			dst->delta = OPERAND(1).mem.disp;
+			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_SHL:

--- a/libr/anal/p/anal_riscv_cs.c
+++ b/libr/anal/p/anal_riscv_cs.c
@@ -25,18 +25,13 @@
 	}
 
 #define CREATE_SRC_DST_3(op) \
-	src0 = r_anal_value_new ();\
-	src1 = r_anal_value_new ();\
-	dst = r_anal_value_new ();\
-	r_pvector_push((op)->dsts, dst);\
-	r_pvector_push((op)->srcs, src0);\
-	r_pvector_push((op)->srcs, src1);
+	src0 = r_vector_push ((op)->srcs, NULL);\
+	src1 = r_vector_push ((op)->srcs, NULL);\
+	dst = r_vector_push ((op)->dsts, NULL);
 
 #define CREATE_SRC_DST_2(op) \
-	src0 = r_anal_value_new ();\
-	dst = r_anal_value_new ();\
-	r_pvector_push((op)->dsts, dst);\
-	r_pvector_push((op)->srcs, src0);
+	src0 = r_vector_push ((op)->srcs, NULL);\
+	dst = r_vector_push ((op)->dsts, NULL);
 
 #define SET_SRC_DST_3_REGS(op) \
 	CREATE_SRC_DST_3 (op);\
@@ -190,21 +185,19 @@ static void op_fillval(RAnal *anal, RAnalOp *op, csh *handle, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (OPERAND(1).type == RISCV_OP_MEM) {
 			ZERO_FILL (reg);
-			src0 = r_anal_value_new ();
+			src0 = r_vector_push (op->srcs, NULL);
 			src0->reg = &reg;
 			parse_reg_name (src0->reg, *handle, insn, 1);
 			src0->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->srcs, src0);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (OPERAND(1).type == RISCV_OP_MEM) {
 			ZERO_FILL (reg);
-			dst = r_anal_value_new ();
+			dst = r_vector_push (op->dsts, NULL);
 			dst->reg = &reg;
 			parse_reg_name (dst->reg, *handle, insn, 1);
 			dst->delta = OPERAND(1).mem.disp;
-			r_pvector_push(op->dsts, dst);
 		}
 		break;
 	case R_ANAL_OP_TYPE_SHL:

--- a/libr/anal/p/anal_rsp.c
+++ b/libr/anal/p/anal_rsp.c
@@ -174,8 +174,8 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		break;
 	case RSP_OP_LUI:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_ADD:
@@ -183,72 +183,72 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 	case RSP_OP_ADDI:
 	case RSP_OP_ADDIU:
 		op->type = R_ANAL_OP_TYPE_ADD;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,+,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SUB:
 	case RSP_OP_SUBU:
 		op->type = R_ANAL_OP_TYPE_SUB;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,-,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_AND:
 	case RSP_OP_ANDI:
 		op->type = R_ANAL_OP_TYPE_AND;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,&,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_OR:
 	case RSP_OP_ORI:
 		op->type = R_ANAL_OP_TYPE_OR;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,|,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_XOR:
 	case RSP_OP_XORI:
 		op->type = R_ANAL_OP_TYPE_XOR;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,^,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_NOR:
 		op->type = R_ANAL_OP_TYPE_NOR;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		// TODO
 		break;
 	case RSP_OP_SLL:
 	case RSP_OP_SLLV:
 		op->type = R_ANAL_OP_TYPE_SHL;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,<<,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SRL:
 	case RSP_OP_SRLV:
 		op->type = R_ANAL_OP_TYPE_SHR;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,>>,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SRA:
 	case RSP_OP_SRAV:
 		op->type = R_ANAL_OP_TYPE_SAR;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		// TODO
 		break;
 	case RSP_OP_SLT:
@@ -257,25 +257,23 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 	case RSP_OP_SLTIU:
 		op->type = R_ANAL_OP_TYPE_CMOV;
 		op->cond = R_ANAL_COND_LT;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
-		r_pvector_push(op->srcs, parsed_operands[2].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,<,$z,?{,1,%s,=,}{,0,%s,=,}", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_J:
 		op->type = R_ANAL_OP_TYPE_JMP;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=", parsed_operands[0].esil);
 		break;
 	case RSP_OP_JAL:
 		op->type = R_ANAL_OP_TYPE_CALL;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=,0x%08" PFMT64x ",RA,=", parsed_operands[0].esil, op->fail);
 		break;
 	case RSP_OP_JR:
@@ -286,102 +284,93 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		op->delay = 1;
 		op->eob = 1;
 		op->fail = rsp_mem_addr (addr + 8, RSP_IMEM_OFFSET);
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=", parsed_operands[0].esil);
 		break;
 	case RSP_OP_BEQ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_EQ;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,==,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil, parsed_operands[2].esil);
 		break;
 	case RSP_OP_BNE:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_NE;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,==,$z,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil, parsed_operands[2].esil);
 		break;
 	case RSP_OP_BLEZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_LE;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,!,%s,0x80000000,&,!,!,|,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,<=,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BGTZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_GT;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,%s,!,!,&,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,>,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BLTZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_LT;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,<,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BGEZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_GE;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,>=,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BLTZAL:
 		op->type = R_ANAL_OP_TYPE_CCALL;
 		op->cond = R_ANAL_COND_LT;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		// TODO
 		break;
 	case RSP_OP_BGEZAL:
 		op->type = R_ANAL_OP_TYPE_CCALL;
 		op->cond = R_ANAL_COND_GE;
-		tmpval = r_anal_value_new ();
+		tmpval = r_vector_push (op->dsts, NULL);
 		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		r_pvector_push(op->dsts, tmpval);
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		// TODO
 		break;
 	case RSP_OP_LB:
 		op->type = R_ANAL_OP_TYPE_LOAD;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 1;
-		r_pvector_push(op->srcs, tmpval);
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, tmpval);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		// FIXME: sign extend
 		r_strbuf_setf (&op->esil, "%s,[1],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
@@ -389,8 +378,8 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		op->type = R_ANAL_OP_TYPE_LOAD;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 2;
-		r_pvector_push(op->srcs, tmpval);
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, tmpval);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		// FIXME: sign extend
 		r_strbuf_setf (&op->esil, "%s,[2],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
@@ -398,70 +387,70 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		op->type = R_ANAL_OP_TYPE_LOAD;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 4;
-		r_pvector_push(op->srcs, tmpval);
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, tmpval);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[4],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LBU:
 		op->type = R_ANAL_OP_TYPE_LOAD;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 1;
-		r_pvector_push(op->srcs, tmpval);
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, tmpval);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[1],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LHU:
 		op->type = R_ANAL_OP_TYPE_LOAD;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 2;
-		r_pvector_push(op->srcs, tmpval);
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, tmpval);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[2],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SB:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 1;
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->dsts, tmpval);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[1]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_SH:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 2;
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->dsts, tmpval);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[2]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_SW:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		tmpval = parsed_operands[1].value;
 		tmpval->memref = op->refptr = 4;
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->dsts, tmpval);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[4]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_MFC0:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
-		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_MTC0:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		r_pvector_push(op->srcs, parsed_operands[0].value);
-		r_pvector_push(op->dsts, parsed_operands[1].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
+		r_vector_push (op->dsts, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_MFC2:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_vector_push (op->dsts, parsed_operands[0].value);
 		//op->src[0] = parsed_operands[1].value;
 		break;
 	case RSP_OP_MTC2:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_vector_push (op->srcs, parsed_operands[0].value);
 		//op->dst = parsed_operands[1].value;
 		break;
 	case RSP_OP_CFC2:

--- a/libr/anal/p/anal_rsp.c
+++ b/libr/anal/p/anal_rsp.c
@@ -93,6 +93,7 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 	ParsedOperands parsed_operands[RSP_MAX_OPNDS];
 	memset (parsed_operands, 0, sizeof (ParsedOperands) * RSP_MAX_OPNDS);
 	rsp_instruction r_instr;
+	RAnalValue *tmpval;
 
 	op->type = R_ANAL_OP_TYPE_UNK;
 	op->size = 4;
@@ -173,8 +174,8 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		break;
 	case RSP_OP_LUI:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_ADD:
@@ -182,72 +183,72 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 	case RSP_OP_ADDI:
 	case RSP_OP_ADDIU:
 		op->type = R_ANAL_OP_TYPE_ADD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,+,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SUB:
 	case RSP_OP_SUBU:
 		op->type = R_ANAL_OP_TYPE_SUB;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,-,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_AND:
 	case RSP_OP_ANDI:
 		op->type = R_ANAL_OP_TYPE_AND;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,&,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_OR:
 	case RSP_OP_ORI:
 		op->type = R_ANAL_OP_TYPE_OR;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,|,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_XOR:
 	case RSP_OP_XORI:
 		op->type = R_ANAL_OP_TYPE_XOR;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,^,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_NOR:
 		op->type = R_ANAL_OP_TYPE_NOR;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		// TODO
 		break;
 	case RSP_OP_SLL:
 	case RSP_OP_SLLV:
 		op->type = R_ANAL_OP_TYPE_SHL;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,<<,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SRL:
 	case RSP_OP_SRLV:
 		op->type = R_ANAL_OP_TYPE_SHR;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,>>,%s,=", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SRA:
 	case RSP_OP_SRAV:
 		op->type = R_ANAL_OP_TYPE_SAR;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		// TODO
 		break;
 	case RSP_OP_SLT:
@@ -256,23 +257,25 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 	case RSP_OP_SLTIU:
 		op->type = R_ANAL_OP_TYPE_CMOV;
 		op->cond = R_ANAL_COND_LT;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[1] = parsed_operands[2].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
+		r_pvector_push(op->srcs, parsed_operands[2].value);
 		r_strbuf_setf (&op->esil, "%s,%s,<,$z,?{,1,%s,=,}{,0,%s,=,}", parsed_operands[2].esil, parsed_operands[1].esil, parsed_operands[0].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_J:
 		op->type = R_ANAL_OP_TYPE_JMP;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=", parsed_operands[0].esil);
 		break;
 	case RSP_OP_JAL:
 		op->type = R_ANAL_OP_TYPE_CALL;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=,0x%08" PFMT64x ",RA,=", parsed_operands[0].esil, op->fail);
 		break;
 	case RSP_OP_JR:
@@ -283,165 +286,182 @@ static int rsp_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RA
 		op->delay = 1;
 		op->eob = 1;
 		op->fail = rsp_mem_addr (addr + 8, RSP_IMEM_OFFSET);
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,PC,=", parsed_operands[0].esil);
 		break;
 	case RSP_OP_BEQ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_EQ;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,==,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil, parsed_operands[2].esil);
 		break;
 	case RSP_OP_BNE:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_NE;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,==,$z,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil, parsed_operands[2].esil);
 		break;
 	case RSP_OP_BLEZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_LE;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,!,%s,0x80000000,&,!,!,|,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,<=,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BGTZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_GT;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,%s,!,!,&,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,>,$z,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BLTZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_LT;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,<,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BGEZ:
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		op->cond = R_ANAL_COND_GE;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,0x80000000,&,!,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 //		r_strbuf_setf (&op->esil, "0,%s,>=,?{,%s,PC,=,}", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_BLTZAL:
 		op->type = R_ANAL_OP_TYPE_CCALL;
 		op->cond = R_ANAL_COND_LT;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		// TODO
 		break;
 	case RSP_OP_BGEZAL:
 		op->type = R_ANAL_OP_TYPE_CCALL;
 		op->cond = R_ANAL_COND_GE;
-		op->dst = r_anal_value_new ();
-		op->dst->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
-		op->src[0] = parsed_operands[0].value;
-		op->src[1] = parsed_operands[1].value;
+		tmpval = r_anal_value_new ();
+		tmpval->reg = r_reg_get (anal->reg, "PC", R_REG_TYPE_GPR);
+		r_pvector_push(op->dsts, tmpval);
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		// TODO
 		break;
 	case RSP_OP_LB:
 		op->type = R_ANAL_OP_TYPE_LOAD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[0]->memref = op->refptr = 1;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 1;
+		r_pvector_push(op->srcs, tmpval);
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		// FIXME: sign extend
 		r_strbuf_setf (&op->esil, "%s,[1],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LH:
 		op->type = R_ANAL_OP_TYPE_LOAD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[0]->memref = op->refptr = 2;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 2;
+		r_pvector_push(op->srcs, tmpval);
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		// FIXME: sign extend
 		r_strbuf_setf (&op->esil, "%s,[2],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LW:
 		op->type = R_ANAL_OP_TYPE_LOAD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[0]->memref = op->refptr = 4;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 4;
+		r_pvector_push(op->srcs, tmpval);
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[4],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LBU:
 		op->type = R_ANAL_OP_TYPE_LOAD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[0]->memref = op->refptr = 1;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 1;
+		r_pvector_push(op->srcs, tmpval);
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[1],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_LHU:
 		op->type = R_ANAL_OP_TYPE_LOAD;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
-		op->src[0]->memref = op->refptr = 2;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 2;
+		r_pvector_push(op->srcs, tmpval);
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		r_strbuf_setf (&op->esil, "%s,[2],%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_SB:
 		op->type = R_ANAL_OP_TYPE_STORE;
-		op->src[0] = parsed_operands[0].value;
-		op->dst = parsed_operands[1].value;
-		op->dst->memref = op->refptr = 1;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 1;
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[1]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_SH:
 		op->type = R_ANAL_OP_TYPE_STORE;
-		op->src[0] = parsed_operands[0].value;
-		op->dst = parsed_operands[1].value;
-		op->dst->memref = op->refptr = 2;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 2;
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[2]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_SW:
 		op->type = R_ANAL_OP_TYPE_STORE;
-		op->src[0] = parsed_operands[0].value;
-		op->dst = parsed_operands[1].value;
-		op->dst->memref = op->refptr = 4;
+		tmpval = parsed_operands[1].value;
+		tmpval->memref = op->refptr = 4;
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->dsts, tmpval);
 		r_strbuf_setf (&op->esil, "%s,%s,=[4]", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_MFC0:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		op->dst = parsed_operands[0].value;
-		op->src[0] = parsed_operands[1].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
+		r_pvector_push(op->srcs, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[1].esil, parsed_operands[0].esil);
 		break;
 	case RSP_OP_MTC0:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		op->src[0] = parsed_operands[0].value;
-		op->dst = parsed_operands[1].value;
+		r_pvector_push(op->srcs, parsed_operands[0].value);
+		r_pvector_push(op->dsts, parsed_operands[1].value);
 		r_strbuf_setf (&op->esil, "%s,%s,=", parsed_operands[0].esil, parsed_operands[1].esil);
 		break;
 	case RSP_OP_MFC2:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		op->dst = parsed_operands[0].value;
+		r_pvector_push(op->dsts, parsed_operands[0].value);
 		//op->src[0] = parsed_operands[1].value;
 		break;
 	case RSP_OP_MTC2:
 		op->type = R_ANAL_OP_TYPE_MOV;
-		op->src[0] = parsed_operands[0].value;
+		r_pvector_push(op->srcs, parsed_operands[0].value);
 		//op->dst = parsed_operands[1].value;
 		break;
 	case RSP_OP_CFC2:

--- a/libr/anal/p/anal_sh.c
+++ b/libr/anal/p/anal_sh.c
@@ -265,7 +265,7 @@ static RAnalValue *anal_regrel_jump(RAnal* anal, RAnalOp* op, ut8 reg) {
 
 /* 16 decoder routines, based on 1st nibble value */
 static int first_nibble_is_0(RAnal* anal, RAnalOp* op, ut16 code) { //STOP
-	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
+	RAnalValue *dst = NULL, *src0 = NULL, *src1 = NULL;
 	if (IS_BSRF (code)) {
 		/* Call 'far' subroutine Rn+PC+4 */
 		op->type = R_ANAL_OP_TYPE_UCALL;
@@ -409,9 +409,18 @@ static int first_nibble_is_0(RAnal* anal, RAnalOp* op, ut16 code) { //STOP
 			GET_TARGET_REG (code), GET_SOURCE_REG (code));
 		op->type = R_ANAL_OP_TYPE_MUL;
 	}
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src0)	r_pvector_push(op->srcs, src0);
-	if (src1)	r_pvector_push(op->srcs, src1);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src0) {
+		r_vector_push (op->srcs, src0);
+		r_anal_value_free (src0);
+	}
+	if (src1) {
+		r_vector_push (op->srcs, src1);
+		r_anal_value_free (src1);
+	}
 	return op->size;
 }
 
@@ -422,13 +431,15 @@ static int movl_reg_rdisp(RAnal* anal, RAnalOp* op, ut16 code) {
 	src = anal_fill_ai_rg (anal, GET_SOURCE_REG (code));
 	dst = anal_fill_reg_disp_mem (anal, GET_TARGET_REG (code), code & 0x0F, LONG_SIZE);
 	r_strbuf_setf (&op->esil, "r%d,r%d,0x%x,+,=[4]", GET_SOURCE_REG (code), GET_TARGET_REG (code), (code & 0xF) << 2);
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 
 static int first_nibble_is_2(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
+	RAnalValue *dst = NULL, *src0 = NULL, *src1 = NULL;
 	if (IS_MOVB_REG_TO_REGREF (code)) {	// 0010nnnnmmmm0000 mov.b <REG_M>,@<REG_N>
 		op->type = R_ANAL_OP_TYPE_STORE;
 		src0 = anal_fill_ai_rg (anal, GET_SOURCE_REG (code));
@@ -497,15 +508,24 @@ static int first_nibble_is_2(RAnal* anal, RAnalOp* op, ut16 code) {
 		r_strbuf_setf (&op->esil, S16_EXT("r%d") "," S16_EXT("r%d") ",*,macl,=", GET_SOURCE_REG (code), GET_TARGET_REG (code));
 	}
 
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src0)	r_pvector_push(op->srcs, src0);
-	if (src1)	r_pvector_push(op->srcs, src1);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src0) {
+		r_vector_push (op->srcs, src0);
+		r_anal_value_free (src0);
+	}
+	if (src1) {
+		r_vector_push (op->srcs, src1);
+		r_anal_value_free (src1);
+	}
 	return op->size;
 }
 
 
 static int first_nibble_is_3(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
+	RAnalValue *dst = NULL, *src0 = NULL, *src1 = NULL;
 	//TODO Handle carry/overflow , CMP/xx?
 	if (IS_ADD (code)) {
 		op->type = R_ANAL_OP_TYPE_ADD;
@@ -601,16 +621,25 @@ static int first_nibble_is_3(RAnal* anal, RAnalOp* op, ut16 code) {
 		src1 = anal_fill_ai_rg (anal, GET_TARGET_REG (code));
 		r_strbuf_setf (&op->esil, "32,r%d,r%d,0x80000000,&,?{,0xFFFFFFFF00000000,+,},r%d,r%d,0x80000000,&,?{,0xFFFFFFFF00000000,+,},*,DUP,0xFFFFFFFF,&,macl,=,>>,mach,=", GET_SOURCE_REG (code), GET_SOURCE_REG (code), GET_TARGET_REG (code), GET_TARGET_REG (code));
 	}
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src0)	r_pvector_push(op->srcs, src0);
-	if (src1)	r_pvector_push(op->srcs, src1);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src0) {
+		r_vector_push (op->srcs, src0);
+		r_anal_value_free (src0);
+	}
+	if (src1) {
+		r_vector_push (op->srcs, src1);
+		r_anal_value_free (src1);
+	}
 	return op->size;
 }
 
 
 
 static int first_nibble_is_4(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL;
+	RAnalValue *dst = NULL;
 	switch(code & 0xF0FF) { //TODO: change to common } else if construction
 	case 0x4020:	//shal
 		op->type = R_ANAL_OP_TYPE_SAL;
@@ -782,7 +811,10 @@ static int first_nibble_is_4(RAnal* anal, RAnalOp* op, ut16 code) {
 			GET_TARGET_REG (code), GET_SOURCE_REG (code));
 		op->type = R_ANAL_OP_TYPE_MUL;
 	}
-	if (dst)	r_pvector_push(op->dsts, dst);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
 	return op->size;
 }
 
@@ -793,13 +825,15 @@ static int movl_rdisp_reg(RAnal* anal, RAnalOp* op, ut16 code) {
 	dst = anal_fill_ai_rg (anal, GET_TARGET_REG (code));
 	src = anal_fill_reg_disp_mem (anal, GET_SOURCE_REG (code), code & 0x0F, LONG_SIZE);
 	r_strbuf_setf (&op->esil, "r%d,0x%x,+,[4],r%d,=", GET_SOURCE_REG (code), (code&0xF) * 4, GET_TARGET_REG (code));
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 
 static int first_nibble_is_6(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL, *src=NULL;
+	RAnalValue *dst = NULL, *src = NULL;
 	if (IS_MOV_REGS (code)) {
 		op->type = R_ANAL_OP_TYPE_MOV;
 		src = anal_fill_ai_rg (anal, GET_SOURCE_REG (code));
@@ -879,8 +913,14 @@ static int first_nibble_is_6(RAnal* anal, RAnalOp* op, ut16 code) {
 		r_strbuf_setf (&op->esil, "16,r%d,0xFFFF,&,<<,16,r%d,0xFFFF0000,&,>>,|,r%d,=", GET_SOURCE_REG (code), GET_SOURCE_REG (code), GET_TARGET_REG (code));
 		op->type = R_ANAL_OP_TYPE_MOV;
 	}
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src)	r_pvector_push(op->srcs, src);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src) {
+		r_vector_push (op->srcs, src);
+		r_anal_value_free (src);
+	}
 	return op->size;
 }
 
@@ -892,13 +932,15 @@ static int add_imm(RAnal* anal, RAnalOp* op, ut16 code) {
 	src = anal_fill_im (anal, (st8)(code & 0xFF)); //Casting to (st8) forces sign-extension.
 	dst = anal_fill_ai_rg (anal, GET_TARGET_REG (code));
 	r_strbuf_setf (&op->esil, "0x%x,DUP,0x80,&,?{,0xFFFFFF00,|,},r%d,+=", code & 0xFF, GET_TARGET_REG (code));
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 
 static int first_nibble_is_8(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL, *src=NULL;
+	RAnalValue *dst = NULL, *src = NULL;
 	if (IS_BT_OR_BF (code)) {
 		op->type = R_ANAL_OP_TYPE_CJMP; //Jump if true or jump if false insns
 		op->jump = disarm_8bit_offset (op->addr, GET_BTF_OFFSET (code));
@@ -943,8 +985,14 @@ static int first_nibble_is_8(RAnal* anal, RAnalOp* op, ut16 code) {
 		dst = anal_fill_reg_disp_mem (anal, GET_SOURCE_REG (code), code & 0x0F, WORD_SIZE);
 		r_strbuf_setf (&op->esil, "r0,0xFFFF,&,0x%x,r%d,+,=[2]", (code & 0xF) * 2, GET_SOURCE_REG (code));
 	}
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src)	r_pvector_push(op->srcs, src);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src) {
+		r_vector_push (op->srcs, src);
+		r_anal_value_free (src);
+	}
 	return op->size;
 }
 
@@ -957,8 +1005,10 @@ static int movw_pcdisp_reg(RAnal* anal, RAnalOp* op, ut16 code) {
 	src->base = (code & 0xFF) * 2+op->addr + 4;
 	src->memref = 1;
 	r_strbuf_setf (&op->esil, "0x%" PFMT64x ",[2],r%d,=,r%d,0x8000,&,?{,0xFFFF0000,r%d,|=,}", src->base, GET_TARGET_REG (code), GET_TARGET_REG (code), GET_TARGET_REG (code));
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 
@@ -984,7 +1034,7 @@ static int bsr(RAnal* anal, RAnalOp* op, ut16 code) {
 }
 
 static int first_nibble_is_c(RAnal* anal, RAnalOp* op, ut16 code) {
-	RAnalValue *dst=NULL, *src0=NULL, *src1=NULL;
+	RAnalValue *dst = NULL, *src0 = NULL, *src1 = NULL;
 	if (IS_TRAP (code)) {
 		op->type = R_ANAL_OP_TYPE_SWI;
 		op->val = (ut8)(code & 0xFF);
@@ -1066,9 +1116,18 @@ static int first_nibble_is_c(RAnal* anal, RAnalOp* op, ut16 code) {
 		r_strbuf_setf (&op->esil, "gbr,0x%x,+,[4],r0,=", (code & 0xFF) * 4);
 	}
 
-	if (dst)	r_pvector_push(op->dsts, dst);
-	if (src0)	r_pvector_push(op->srcs, src0);
-	if (src1)	r_pvector_push(op->srcs, src1);
+	if (dst) {
+		r_vector_push (op->dsts, dst);
+		r_anal_value_free (dst);
+	}
+	if (src0) {
+		r_vector_push (op->srcs, src0);
+		r_anal_value_free (src0);
+	}
+	if (src1) {
+		r_vector_push (op->srcs, src1);
+		r_anal_value_free (src1);
+	}
 	return op->size;
 }
 
@@ -1081,8 +1140,10 @@ static int movl_pcdisp_reg(RAnal* anal, RAnalOp* op, ut16 code) {
 	dst = anal_fill_ai_rg (anal, GET_TARGET_REG (code));
 	//r_strbuf_setf (&op->esil, "0x%x,[4],r%d,=", (code & 0xFF) * 4 + (op->addr & 0xfffffff3) + 4, GET_TARGET_REG (code));
 	r_strbuf_setf (&op->esil, "0x%" PFMT64x ",[4],r%d,=", (code & 0xFF) * 4 + ((op->addr >> 2)<<2) + 4, GET_TARGET_REG (code));
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 
@@ -1093,8 +1154,10 @@ static int mov_imm_reg(RAnal* anal, RAnalOp* op, ut16 code) {
 	dst = anal_fill_ai_rg (anal, GET_TARGET_REG (code));
 	src = anal_fill_im (anal, (st8)(code & 0xFF));
 	r_strbuf_setf (&op->esil, "0x%x,r%d,=,r%d,0x80,&,?{,0xFFFFFF00,r%d,|=,}", code & 0xFF, GET_TARGET_REG (code), GET_TARGET_REG (code), GET_TARGET_REG (code));
-	r_pvector_push(op->dsts, dst);
-	r_pvector_push(op->srcs, src);
+	r_vector_push (op->dsts, dst);
+	r_vector_push (op->srcs, src);
+	r_anal_value_free (dst);
+	r_anal_value_free (src);
 	return op->size;
 }
 

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -80,21 +80,19 @@ static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (INSOP (0).type == SPARC_OP_MEM) {
 			ZERO_FILL (reg);
-			val = r_anal_value_new ();
+			val = r_vector_push (op->srcs, NULL);
 			val->reg = &reg;
 			parse_reg_name (val->reg, handle, insn, 0);
 			val->delta = INSOP(0).mem.disp;
-			r_pvector_push(op->srcs, val);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (INSOP (1).type == SPARC_OP_MEM) {
 			ZERO_FILL (reg);
-			val = r_anal_value_new ();
+			val = r_vector_push (op->dsts, NULL);
 			val->reg = &reg;
 			parse_reg_name (val->reg, handle, insn, 1);
 			val->delta = INSOP(1).mem.disp;
-			r_pvector_push(op->dsts, val);
 		}
 		break;
 	}

--- a/libr/anal/p/anal_sparc_cs.c
+++ b/libr/anal/p/anal_sparc_cs.c
@@ -75,23 +75,26 @@ static int parse_reg_name(RRegItem *reg, csh handle, cs_insn *insn, int reg_num)
 
 static void op_fillval(RAnalOp *op, csh handle, cs_insn *insn) {
 	static R_TH_LOCAL RRegItem reg;
+	RAnalValue *val;
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_LOAD:
 		if (INSOP (0).type == SPARC_OP_MEM) {
 			ZERO_FILL (reg);
-			op->src[0] = r_anal_value_new ();
-			op->src[0]->reg = &reg;
-			parse_reg_name (op->src[0]->reg, handle, insn, 0);
-			op->src[0]->delta = INSOP(0).mem.disp;
+			val = r_anal_value_new ();
+			val->reg = &reg;
+			parse_reg_name (val->reg, handle, insn, 0);
+			val->delta = INSOP(0).mem.disp;
+			r_pvector_push(op->srcs, val);
 		}
 		break;
 	case R_ANAL_OP_TYPE_STORE:
 		if (INSOP (1).type == SPARC_OP_MEM) {
 			ZERO_FILL (reg);
-			op->dst = r_anal_value_new ();
-			op->dst->reg = &reg;
-			parse_reg_name (op->dst->reg, handle, insn, 1);
-			op->dst->delta = INSOP(1).mem.disp;
+			val = r_anal_value_new ();
+			val->reg = &reg;
+			parse_reg_name (val->reg, handle, insn, 1);
+			val->delta = INSOP(1).mem.disp;
+			r_pvector_push(op->dsts, val);
 		}
 		break;
 	}

--- a/libr/anal/p/anal_sparc_gnu.c
+++ b/libr/anal/p/anal_sparc_gnu.c
@@ -364,7 +364,7 @@ static RAnalValue * value_fill_addr_reg_disp(RAnal const *const anal, const int 
 static void anal_call(RAnalOp *op, const ut32 insn, const ut64 addr) {
 	const st64 disp = (get_immed_sgnext(insn, 29) * 4);
 	op->type = R_ANAL_OP_TYPE_CALL;
-	op->dst = value_fill_addr_pc_disp(addr, disp);
+	r_pvector_push(op->dsts, value_fill_addr_pc_disp(addr, disp));
 	op->jump = addr + disp;
 	op->fail = addr + 4;
 }
@@ -386,9 +386,9 @@ static void anal_jmpl(RAnal const *const anal, RAnalOp *op, const ut32 insn, con
 	op->eob = true;
 
 	if (X_LDST_I(insn)) {
-		op->dst = value_fill_addr_reg_disp (anal, X_RS1 (insn), disp);
+		r_pvector_push(op->dsts, value_fill_addr_reg_disp (anal, X_RS1 (insn), disp));
 	} else {
-		op->dst = value_fill_addr_reg_regdelta (anal, X_RS1 (insn), X_RS2 (insn));
+		r_pvector_push(op->dsts, value_fill_addr_reg_regdelta (anal, X_RS1 (insn), X_RS2 (insn)));
 	}
 }
 
@@ -423,7 +423,7 @@ static void anal_branch(RAnalOp *op, const ut32 insn, const ut64 addr) {
 	} else if (X_OP2(insn) == OP2_BPr) {
 		disp = get_immed_sgnext (X_DISP16 (insn), 15) * 4;
 	}
-	op->dst = value_fill_addr_pc_disp (addr, disp);
+	r_pvector_push(op->dsts, value_fill_addr_pc_disp (addr, disp));
 	op->jump = addr + disp;
 }
 

--- a/libr/anal/p/anal_sparc_gnu.c
+++ b/libr/anal/p/anal_sparc_gnu.c
@@ -364,7 +364,9 @@ static RAnalValue * value_fill_addr_reg_disp(RAnal const *const anal, const int 
 static void anal_call(RAnalOp *op, const ut32 insn, const ut64 addr) {
 	const st64 disp = (get_immed_sgnext(insn, 29) * 4);
 	op->type = R_ANAL_OP_TYPE_CALL;
-	r_pvector_push(op->dsts, value_fill_addr_pc_disp(addr, disp));
+	RAnalValue *val = value_fill_addr_pc_disp (addr, disp);
+	r_vector_push (op->dsts, val);
+	r_anal_value_free (val);
 	op->jump = addr + disp;
 	op->fail = addr + 4;
 }
@@ -385,11 +387,14 @@ static void anal_jmpl(RAnal const *const anal, RAnalOp *op, const ut32 insn, con
 	op->type = R_ANAL_OP_TYPE_UJMP;
 	op->eob = true;
 
+	RAnalValue *val;
 	if (X_LDST_I(insn)) {
-		r_pvector_push(op->dsts, value_fill_addr_reg_disp (anal, X_RS1 (insn), disp));
+		val = value_fill_addr_reg_disp (anal, X_RS1 (insn), disp);
 	} else {
-		r_pvector_push(op->dsts, value_fill_addr_reg_regdelta (anal, X_RS1 (insn), X_RS2 (insn)));
+		val = value_fill_addr_reg_regdelta (anal, X_RS1 (insn), X_RS2 (insn));
 	}
+	r_vector_push (op->dsts, val);
+	r_anal_value_free (val);
 }
 
 static void anal_branch(RAnalOp *op, const ut32 insn, const ut64 addr) {
@@ -423,7 +428,9 @@ static void anal_branch(RAnalOp *op, const ut32 insn, const ut64 addr) {
 	} else if (X_OP2(insn) == OP2_BPr) {
 		disp = get_immed_sgnext (X_DISP16 (insn), 15) * 4;
 	}
-	r_pvector_push(op->dsts, value_fill_addr_pc_disp (addr, disp));
+	RAnalValue *val = value_fill_addr_pc_disp (addr, disp);
+	r_vector_push (op->dsts, val);
+	r_anal_value_free (val);
 	op->jump = addr + disp;
 }
 

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -1486,11 +1486,8 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 		case X86_OP_REG:
 			{
 			src = getarg (&gop, 0, 0, NULL, SRC_AR, NULL);
-			val = r_anal_value_new ();
-			if (val) {
-				val->reg = r_reg_get (a->reg, src, R_REG_TYPE_GPR);
-			}
-			r_pvector_push(op->srcs, val);
+			val = r_vector_push (op->srcs, NULL);
+			val->reg = r_reg_get (a->reg, src, R_REG_TYPE_GPR);
 			//XXX fallthrough
 			}
 		//case X86_OP_FP:
@@ -2465,14 +2462,10 @@ static void set_access_info(RReg *reg, RAnalOp *op, csh *handle, cs_insn *insn, 
 }
 
 #define CREATE_SRC_DST(op) \
-	src0 = r_anal_value_new (); \
-	src1 = r_anal_value_new (); \
-	src2 = r_anal_value_new (); \
-	dst = r_anal_value_new (); \
-	r_pvector_push((op)->srcs, src0); \
-	r_pvector_push((op)->srcs, src1); \
-	r_pvector_push((op)->srcs, src2); \
-	r_pvector_push((op)->dsts, dst);
+	src0 = r_vector_push ((op)->srcs, NULL); \
+	src1 = r_vector_push ((op)->srcs, NULL); \
+	src2 = r_vector_push ((op)->srcs, NULL); \
+	dst = r_vector_push ((op)->dsts, NULL);
 
 static void set_src_dst(RReg *reg, RAnalValue *val, csh *handle, cs_insn *insn, int x) {
 	if (!val) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -388,6 +388,7 @@ static const char *reg32_to_name(ut8 reg) {
 }
 
 static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
+	RAnalValue *val = NULL;
 	const int bits = a->config->bits;
 	int rs = bits / 8;
 	const char *pc, *sp, *bp, *si;
@@ -1485,10 +1486,11 @@ static void anop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 		case X86_OP_REG:
 			{
 			src = getarg (&gop, 0, 0, NULL, SRC_AR, NULL);
-			op->src[0] = r_anal_value_new ();
-			if (op->src[0]) {
-				op->src[0]->reg = r_reg_get (a->reg, src, R_REG_TYPE_GPR);
+			val = r_anal_value_new ();
+			if (val) {
+				val->reg = r_reg_get (a->reg, src, R_REG_TYPE_GPR);
 			}
+			r_pvector_push(op->srcs, val);
 			//XXX fallthrough
 			}
 		//case X86_OP_FP:
@@ -2463,10 +2465,14 @@ static void set_access_info(RReg *reg, RAnalOp *op, csh *handle, cs_insn *insn, 
 }
 
 #define CREATE_SRC_DST(op) \
-	(op)->src[0] = r_anal_value_new (); \
-	(op)->src[1] = r_anal_value_new (); \
-	(op)->src[2] = r_anal_value_new (); \
-	(op)->dst = r_anal_value_new ();
+	src0 = r_anal_value_new (); \
+	src1 = r_anal_value_new (); \
+	src2 = r_anal_value_new (); \
+	dst = r_anal_value_new (); \
+	r_pvector_push((op)->srcs, src0); \
+	r_pvector_push((op)->srcs, src1); \
+	r_pvector_push((op)->srcs, src2); \
+	r_pvector_push((op)->dsts, dst);
 
 static void set_src_dst(RReg *reg, RAnalValue *val, csh *handle, cs_insn *insn, int x) {
 	if (!val) {
@@ -2493,6 +2499,7 @@ static void set_src_dst(RReg *reg, RAnalValue *val, csh *handle, cs_insn *insn, 
 }
 
 static void op_fillval(RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn, int mode) {
+	RAnalValue *dst, *src0, *src1, *src2;
 	set_access_info (a->reg, op, handle, insn, mode);
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
@@ -2515,15 +2522,15 @@ static void op_fillval(RAnal *a, RAnalOp *op, csh *handle, cs_insn *insn, int mo
 	case R_ANAL_OP_TYPE_NOT:
 	case R_ANAL_OP_TYPE_ACMP:
 		CREATE_SRC_DST (op);
-		set_src_dst (a->reg, op->dst, handle, insn, 0);
-		set_src_dst (a->reg, op->src[0], handle, insn, 1);
-		set_src_dst (a->reg, op->src[1], handle, insn, 2);
-		set_src_dst (a->reg, op->src[2], handle, insn, 3);
+		set_src_dst (a->reg, dst, handle, insn, 0);
+		set_src_dst (a->reg, src0, handle, insn, 1);
+		set_src_dst (a->reg, src1, handle, insn, 2);
+		set_src_dst (a->reg, src2, handle, insn, 3);
 		break;
 	case R_ANAL_OP_TYPE_UPUSH:
 		if ((op->type & R_ANAL_OP_TYPE_REG)) {
 			CREATE_SRC_DST (op);
-			set_src_dst (a->reg, op->src[0], handle, insn, 0);
+			set_src_dst (a->reg, src0, handle, insn, 0);
 		}
 		break;
 	default:

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -897,16 +897,18 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 	st64 ptr = 0;
 	char *addr, *esil_buf = NULL;
 	const st64 maxstackframe = 1024 * 8;
+	RAnalValue *val = NULL;
 
 	r_return_if_fail (anal && fcn && op && reg);
 
-	size_t i;
-	for (i = 0; i < R_ARRAY_SIZE (op->src); i++) {
-		if (op->src[i] && op->src[i]->reg && op->src[i]->reg->name) {
-			if (!strcmp (reg, op->src[i]->reg->name)) {
-				st64 delta = op->src[i]->delta;
+	void **it = NULL;
+	r_pvector_foreach(op->srcs, it) {
+		val = *it;
+		if (val && val->reg && val->reg->name) {
+			if (!strcmp (reg, val->reg->name)) {
+				st64 delta = val->delta;
 				if ((delta > 0 && *sign == '+') || (delta < 0 && *sign == '-')) {
-					ptr = R_ABS (op->src[i]->delta);
+					ptr = R_ABS (val->delta);
 					break;
 				}
 			}
@@ -935,10 +937,11 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 		if (strncmp (addr, "0x", 2)) {
 			//XXX: This is a workaround for inconsistent esil
-			if (!op->stackop && op->dst) {
+			val = r_pvector_at(op->dsts, 0);
+			if (!op->stackop && val) {
 				const char *sp = r_reg_get_name (anal->reg, R_REG_NAME_SP);
 				const char *bp = r_reg_get_name (anal->reg, R_REG_NAME_BP);
-				const char *rn = op->dst->reg ? op->dst->reg->name : NULL;
+				const char *rn = (val && val->reg) ? val->reg->name : NULL;
 				if (rn && ((bp && !strcmp (bp, rn)) || (sp && !strcmp (sp, rn)))) {
 					if (anal->verbose) {
 						R_LOG_WARN ("Analysis didn't fill op->stackop for instruction that alters stack at 0x%" PFMT64x, op->addr);
@@ -952,7 +955,8 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 			if (!op->stackop && op->type != R_ANAL_OP_TYPE_PUSH && op->type != R_ANAL_OP_TYPE_POP
 				&& op->type != R_ANAL_OP_TYPE_RET && r_str_isnumber (addr)) {
 				ptr = (st64)r_num_get (NULL, addr);
-				if (ptr && op->src[0] && ptr == op->src[0]->imm) {
+				val = r_pvector_at(op->srcs, 0);
+				if (ptr && val && ptr == val->imm) {
 					goto beach;
 				}
 			} else if ((op->stackop == R_ANAL_STACK_SET) || (op->stackop == R_ANAL_STACK_GET)) {
@@ -968,7 +972,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 	}
 
-	if (anal->verbose && (!op->src[0] || !op->dst)) {
+	if (anal->verbose && (!r_pvector_at(op->srcs, 0) || !r_pvector_at(op->dsts, 0))) {
 		R_LOG_WARN ("Analysis didn't fill op->src/dst at 0x%" PFMT64x, op->addr);
 	}
 
@@ -1098,8 +1102,8 @@ static inline bool arch_destroys_dst(const char *arch) {
 }
 
 static bool is_used_like_arg(const char *regname, const char *opsreg, const char *opdreg, RAnalOp *op, RAnal *anal) {
-	RAnalValue *dst = op->dst;
-	RAnalValue *src = op->src[0];
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src = r_pvector_at(op->srcs, 0);
 	switch (op->type) {
 	case R_ANAL_OP_TYPE_POP:
 		return false;
@@ -1139,17 +1143,22 @@ static bool is_used_like_arg(const char *regname, const char *opsreg, const char
 }
 
 static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
-	const char* opsreg0 = op->src[0] ? get_regname (anal, op->src[0]) : NULL;
-	const char* opsreg1 = op->src[1] ? get_regname (anal, op->src[1]) : NULL;
-	const char* opsreg2 = op->src[2] ? get_regname (anal, op->src[2]) : NULL;
+	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
+	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
+	RAnalValue *src2 = r_pvector_at(op->srcs, 2);
+	const char* opsreg0 = src0 ? get_regname (anal, src0) : NULL;
+	const char* opsreg1 = src1 ? get_regname (anal, src1) : NULL;
+	const char* opsreg2 = src2 ? get_regname (anal, src2) : NULL;
 	return (STR_EQUAL (regname, opsreg0)) || (STR_EQUAL (regname, opsreg1)) || (STR_EQUAL (regname, opsreg2));
 }
 
 R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
 	int i, argc = 0;
 	r_return_if_fail (anal && op && fcn);
-	const char *opsreg = op->src[0] ? get_regname (anal, op->src[0]) : NULL;
-	const char *opdreg = op->dst ? get_regname (anal, op->dst) : NULL;
+	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	const char *opsreg = src ? get_regname (anal, src) : NULL;
+	const char *opdreg = dst ? get_regname (anal, dst) : NULL;
 	const int size = (fcn->bits ? fcn->bits : anal->config->bits) / 8;
 	if (!fcn->cc) {
 		R_LOG_DEBUG ("No calling convention for function '%s' to extract register arguments", fcn->name);

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -901,9 +901,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 
 	r_return_if_fail (anal && fcn && op && reg);
 
-	void **it = NULL;
-	r_pvector_foreach(op->srcs, it) {
-		val = *it;
+	r_vector_foreach (op->srcs, val) {
 		if (val && val->reg && val->reg->name) {
 			if (!strcmp (reg, val->reg->name)) {
 				st64 delta = val->delta;
@@ -937,7 +935,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 		if (strncmp (addr, "0x", 2)) {
 			//XXX: This is a workaround for inconsistent esil
-			val = r_pvector_at(op->dsts, 0);
+			val = r_vector_index_ptr (op->dsts, 0);
 			if (!op->stackop && val) {
 				const char *sp = r_reg_get_name (anal->reg, R_REG_NAME_SP);
 				const char *bp = r_reg_get_name (anal->reg, R_REG_NAME_BP);
@@ -955,7 +953,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 			if (!op->stackop && op->type != R_ANAL_OP_TYPE_PUSH && op->type != R_ANAL_OP_TYPE_POP
 				&& op->type != R_ANAL_OP_TYPE_RET && r_str_isnumber (addr)) {
 				ptr = (st64)r_num_get (NULL, addr);
-				val = r_pvector_at(op->srcs, 0);
+				val = r_vector_index_ptr (op->srcs, 0);
 				if (ptr && val && ptr == val->imm) {
 					goto beach;
 				}
@@ -972,7 +970,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 	}
 
-	if (anal->verbose && (!r_pvector_at(op->srcs, 0) || !r_pvector_at(op->dsts, 0))) {
+	if (anal->verbose && (!r_vector_index_ptr (op->srcs, 0) || !r_vector_index_ptr (op->dsts, 0))) {
 		R_LOG_WARN ("Analysis didn't fill op->src/dst at 0x%" PFMT64x, op->addr);
 	}
 
@@ -1102,8 +1100,8 @@ static inline bool arch_destroys_dst(const char *arch) {
 }
 
 static bool is_used_like_arg(const char *regname, const char *opsreg, const char *opdreg, RAnalOp *op, RAnal *anal) {
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
-	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
+	RAnalValue *src = r_vector_index_ptr (op->srcs, 0);
 	switch (op->type) {
 	case R_ANAL_OP_TYPE_POP:
 		return false;
@@ -1143,9 +1141,9 @@ static bool is_used_like_arg(const char *regname, const char *opsreg, const char
 }
 
 static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
-	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
-	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
-	RAnalValue *src2 = r_pvector_at(op->srcs, 2);
+	RAnalValue *src0 = r_vector_index_ptr (op->srcs, 0);
+	RAnalValue *src1 = r_vector_index_ptr (op->srcs, 1);
+	RAnalValue *src2 = r_vector_index_ptr (op->srcs, 2);
 	const char* opsreg0 = src0 ? get_regname (anal, src0) : NULL;
 	const char* opsreg1 = src1 ? get_regname (anal, src1) : NULL;
 	const char* opsreg2 = src2 ? get_regname (anal, src2) : NULL;
@@ -1155,8 +1153,8 @@ static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
 R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
 	int i, argc = 0;
 	r_return_if_fail (anal && op && fcn);
-	RAnalValue *src = r_pvector_at(op->srcs, 0);
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src = r_vector_index_ptr (op->srcs, 0);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
 	const char *opsreg = src ? get_regname (anal, src) : NULL;
 	const char *opdreg = dst ? get_regname (anal, dst) : NULL;
 	const int size = (fcn->bits ? fcn->bits : anal->config->bits) / 8;

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4813,29 +4813,34 @@ typedef struct {
 } EsilBreakCtx;
 
 static const char *reg_name_for_access(RAnalOp* op, RAnalVarAccessType type) {
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src = r_pvector_at(op->srcs, 0);
 	if (type == R_ANAL_VAR_ACCESS_TYPE_WRITE) {
-		if (op->dst && op->dst->reg) {
-			return op->dst->reg->name;
+		if (dst && dst->reg) {
+			return dst->reg->name;
 		}
 	} else {
-		if (op->src[0] && op->src[0]->reg) {
-			return op->src[0]->reg->name;
+		if (src && src->reg) {
+			return src->reg->name;
 		}
 	}
 	return NULL;
 }
 
 static ut64 delta_for_access(RAnalOp *op, RAnalVarAccessType type) {
+	RAnalValue *dst = r_pvector_at(op->dsts, 0);
+	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
+	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
 	if (type == R_ANAL_VAR_ACCESS_TYPE_WRITE) {
-		if (op->dst) {
-			return op->dst->imm + op->dst->delta;
+		if (dst) {
+			return dst->imm + dst->delta;
 		}
 	} else {
-		if (op->src[1] && (op->src[1]->imm || op->src[1]->delta)) {
-			return op->src[1]->imm + op->src[1]->delta;
+		if (src1 && (src1->imm || src1->delta)) {
+			return src1->imm + src1->delta;
 		}
-		if (op->src[0]) {
-			return op->src[0]->imm + op->src[0]->delta;
+		if (src0) {
+			return src0->imm + src0->delta;
 		}
 	}
 	return 0;
@@ -5533,17 +5538,19 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 				}
 			} else if ((core->anal->config->bits == 32 && core->anal->cur && arch == R2_ARCH_MIPS)) {
 				ut64 dst = ESIL->cur;
-				if (!op.src[0] || !op.src[0]->reg || !op.src[0]->reg->name) {
+				RAnalValue *opsrc0 = r_pvector_at(op.srcs, 0);
+				RAnalValue *opsrc1 = r_pvector_at(op.srcs, 1);
+				if (!opsrc0 || !opsrc0->reg || !opsrc0->reg->name) {
 					break;
 				}
-				if (!strcmp (op.src[0]->reg->name, "sp")) {
+				if (!strcmp (opsrc0->reg->name, "sp")) {
 					break;
 				}
-				if (!strcmp (op.src[0]->reg->name, "zero")) {
+				if (!strcmp (opsrc0->reg->name, "zero")) {
 					break;
 				}
 				if ((target && dst == ntarget) || !target) {
-					if (dst > 0xffff && op.src[1] && (dst & 0xffff) == (op.src[1]->imm & 0xffff) && myvalid (mycore->io, dst)) {
+					if (dst > 0xffff && opsrc1 && (dst & 0xffff) == (opsrc1->imm & 0xffff) && myvalid (mycore->io, dst)) {
 						RFlagItem *f;
 						char *str;
 						if (CHECKREF (dst) || CHECKREF (cur)) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4813,8 +4813,8 @@ typedef struct {
 } EsilBreakCtx;
 
 static const char *reg_name_for_access(RAnalOp* op, RAnalVarAccessType type) {
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
-	RAnalValue *src = r_pvector_at(op->srcs, 0);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
+	RAnalValue *src = r_vector_index_ptr (op->srcs, 0);
 	if (type == R_ANAL_VAR_ACCESS_TYPE_WRITE) {
 		if (dst && dst->reg) {
 			return dst->reg->name;
@@ -4828,9 +4828,9 @@ static const char *reg_name_for_access(RAnalOp* op, RAnalVarAccessType type) {
 }
 
 static ut64 delta_for_access(RAnalOp *op, RAnalVarAccessType type) {
-	RAnalValue *dst = r_pvector_at(op->dsts, 0);
-	RAnalValue *src0 = r_pvector_at(op->srcs, 0);
-	RAnalValue *src1 = r_pvector_at(op->srcs, 1);
+	RAnalValue *dst = r_vector_index_ptr (op->dsts, 0);
+	RAnalValue *src0 = r_vector_index_ptr (op->srcs, 0);
+	RAnalValue *src1 = r_vector_index_ptr (op->srcs, 1);
 	if (type == R_ANAL_VAR_ACCESS_TYPE_WRITE) {
 		if (dst) {
 			return dst->imm + dst->delta;
@@ -5538,8 +5538,8 @@ R_API void r_core_anal_esil(RCore *core, const char *str, const char *target) {
 				}
 			} else if ((core->anal->config->bits == 32 && core->anal->cur && arch == R2_ARCH_MIPS)) {
 				ut64 dst = ESIL->cur;
-				RAnalValue *opsrc0 = r_pvector_at(op.srcs, 0);
-				RAnalValue *opsrc1 = r_pvector_at(op.srcs, 1);
+				RAnalValue *opsrc0 = r_vector_index_ptr (op.srcs, 0);
+				RAnalValue *opsrc1 = r_vector_index_ptr (op.srcs, 1);
 				if (!opsrc0 || !opsrc0->reg || !opsrc0->reg->name) {
 					break;
 				}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9472,20 +9472,27 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 			int ret = r_anal_op (core->anal, &op, core->offset, code, core->blocksize, R_ANAL_OP_MASK_VAL);
 			if (ret >= 0) {
 				// HACK: Just convert only the first imm seen
-				for (i = 0; i < 3; i++) {
-					if (op.src[i]) {
-						if (op.src[i]->imm) {
-							offimm = op.src[i]->imm;
-						} else if (op.src[i]->delta) {
-							offimm = op.src[i]->delta;
+				void **it = NULL;
+				r_pvector_foreach(op.srcs, it) {
+					RAnalValue *src = *it;
+					if (src) {
+						if (src->imm) {
+							offimm = src->imm;
+						} else if (src->delta) {
+							offimm = src->delta;
 						}
 					}
 				}
-				if (!offimm && op.dst) {
-					if (op.dst->imm) {
-						offimm = op.dst->imm;
-					} else if (op.dst->delta) {
-						offimm = op.dst->delta;
+				if (!offimm) {
+					r_pvector_foreach(op.dsts, it) {
+						RAnalValue *dst = *it;
+						if (dst) {
+							if (dst->imm) {
+								offimm = dst->imm;
+							} else if (dst->delta) {
+								offimm = dst->delta;
+							}
+						}
 					}
 				}
 				if (offimm != 0) {

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9472,9 +9472,8 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 			int ret = r_anal_op (core->anal, &op, core->offset, code, core->blocksize, R_ANAL_OP_MASK_VAL);
 			if (ret >= 0) {
 				// HACK: Just convert only the first imm seen
-				void **it = NULL;
-				r_pvector_foreach(op.srcs, it) {
-					RAnalValue *src = *it;
+				RAnalValue *src = NULL;
+				r_vector_foreach (op.srcs, src) {
 					if (src) {
 						if (src->imm) {
 							offimm = src->imm;
@@ -9484,14 +9483,12 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 					}
 				}
 				if (!offimm) {
-					r_pvector_foreach(op.dsts, it) {
-						RAnalValue *dst = *it;
-						if (dst) {
-							if (dst->imm) {
-								offimm = dst->imm;
-							} else if (dst->delta) {
-								offimm = dst->delta;
-							}
+					RAnalValue *dst = r_vector_index_ptr (op.dsts, 0);
+					if (dst) {
+						if (dst->imm) {
+							offimm = dst->imm;
+						} else if (dst->delta) {
+							offimm = dst->delta;
 						}
 					}
 				}

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9446,7 +9446,6 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 			}
 			char *ptr = strchr (type, '=');
 			ut64 offimm = 0;
-			int i = 0;
 			ut64 addr;
 
 			if (ptr) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -997,15 +997,20 @@ R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn) {
 			int j, src_imm = -1, dst_imm = -1;
 			ut64 src_addr = UT64_MAX;
 			ut64 dst_addr = UT64_MAX;
-			for (j = 0; j < 3; j++) {
-				if (aop.src[j] && aop.src[j]->reg && aop.src[j]->reg->name) {
-					src_addr = r_reg_getv (esil->anal->reg, aop.src[j]->reg->name) + index;
-					src_imm = aop.src[j]->delta;
+			void **it = NULL;
+			r_pvector_foreach (aop.srcs, it) {
+				RAnalValue *src = *it;
+				if (src && src->reg && src->reg->name) {
+					src_addr = r_reg_getv (esil->anal->reg, src->reg->name) + index;
+					src_imm = src->delta;
 				}
 			}
-			if (aop.dst && aop.dst->reg && aop.dst->reg->name) {
-				dst_addr = r_reg_getv (esil->anal->reg, aop.dst->reg->name) + index;
-				dst_imm = aop.dst->delta;
+			r_pvector_foreach (aop.dsts, it) {
+				RAnalValue *dst = *it;
+				if (dst && dst->reg && dst->reg->name) {
+					dst_addr = r_reg_getv (esil->anal->reg, dst->reg->name) + index;
+					dst_imm = dst->delta;
+				}
 			}
 			RAnalVar *var = r_anal_get_used_function_var (core->anal, aop.addr);
 			if (false) { // src_addr != UT64_MAX || dst_addr != UT64_MAX) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -997,20 +997,17 @@ R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn) {
 			int j, src_imm = -1, dst_imm = -1;
 			ut64 src_addr = UT64_MAX;
 			ut64 dst_addr = UT64_MAX;
-			void **it = NULL;
-			r_pvector_foreach (aop.srcs, it) {
-				RAnalValue *src = *it;
+			RAnalValue *src = NULL;
+			r_vector_foreach (aop.srcs, src) {
 				if (src && src->reg && src->reg->name) {
 					src_addr = r_reg_getv (esil->anal->reg, src->reg->name) + index;
 					src_imm = src->delta;
 				}
 			}
-			r_pvector_foreach (aop.dsts, it) {
-				RAnalValue *dst = *it;
-				if (dst && dst->reg && dst->reg->name) {
-					dst_addr = r_reg_getv (esil->anal->reg, dst->reg->name) + index;
-					dst_imm = dst->delta;
-				}
+			RAnalValue *dst = r_vector_index_ptr (aop.dsts, 0);
+			if (dst && dst->reg && dst->reg->name) {
+				dst_addr = r_reg_getv (esil->anal->reg, dst->reg->name) + index;
+				dst_imm = dst->delta;
 			}
 			RAnalVar *var = r_anal_get_used_function_var (core->anal, aop.addr);
 			if (false) { // src_addr != UT64_MAX || dst_addr != UT64_MAX) {

--- a/libr/core/cmd_type.c
+++ b/libr/core/cmd_type.c
@@ -994,7 +994,7 @@ R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn) {
 			if (aop.ireg) {
 				index = r_reg_getv (esil->anal->reg, aop.ireg) * aop.scale;
 			}
-			int j, src_imm = -1, dst_imm = -1;
+			int src_imm = -1, dst_imm = -1;
 			ut64 src_addr = UT64_MAX;
 			ut64 dst_addr = UT64_MAX;
 			RAnalValue *src = NULL;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -878,8 +878,10 @@ typedef struct r_anal_op_t {
 	int ptrsize;    /* f.ex: zero extends for 8, 16 or 32 bits only */
 	st64 stackptr;  /* stack pointer */
 	int refptr;     /* if (0) ptr = "reference" else ptr = "load memory of refptr bytes" */
-	RAnalValue *src[3];
-	RAnalValue *dst;
+	RPVector/*RAnalValue*/	*srcs;
+	//RAnalValue *src[3];
+	RPVector/*RAnalValue*/	*dsts;
+	//RAnalValue *dst;
 	RList *access; /* RAnalValue access information */
 	RStrBuf esil;
 	RStrBuf opex;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -878,9 +878,9 @@ typedef struct r_anal_op_t {
 	int ptrsize;    /* f.ex: zero extends for 8, 16 or 32 bits only */
 	st64 stackptr;  /* stack pointer */
 	int refptr;     /* if (0) ptr = "reference" else ptr = "load memory of refptr bytes" */
-	RPVector/*RAnalValue*/	*srcs;
+	RVector/*RAnalValue*/	*srcs;
 	//RAnalValue *src[3];
-	RPVector/*RAnalValue*/	*dsts;
+	RVector/*RAnalValue*/	*dsts;
 	//RAnalValue *dst;
 	RList *access; /* RAnalValue access information */
 	RStrBuf esil;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Hi, I spent some time changing RAnalOp.src and RAnalOp.dst to use RPVector type, they are now RAnalOp.srcs and RAnalOp.dsts. The thing was that instructions like ARM ldm/stm might have multiple src or dst, and they won't be able to fit in the limited 3 src slots or 1 dst slot in the old RAnalOp.  Currently, I've changed all the places that use them so at least it compiles, and (hopefully) functions. Please double-check if I've broken anything... Thank you!