### PR TITLE
Remove the `file.offset` unused config variable

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4223,7 +4223,6 @@ R_API int r_core_config_init(RCore *core) {
 
 	/* file */
 	SETBPREF ("file.info", "true", "RBin info loaded");
-	SETPREF ("file.offset", "", "offset where the file will be mapped at");
 	SETPREF ("file.type", "", "type of current file");
 	SETI ("file.loadalign", 1024, "alignment of load addresses");
 	/* magic */

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -658,7 +658,6 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			r_config_set_i (r->config, "io.va", 1);
 			mapaddr = r_num_math (r->num, opt.arg);
 			s_seek = opt.arg;
-			r_config_set_i (r->config, "file.offset", mapaddr);
 			break;
 		case 'M':
 			r_config_set (r->config, "bin.demangle", "false");


### PR DESCRIPTION
* It was set for a while, RBinFile holds this info in loadaddr
* file.offset was conceptually wrong because its 'global'

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
