### PR TITLE
Fix pickle arch thinking 0 is 64 bit ##anal

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -468,9 +468,9 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 static inline bool write_num_sz(ut64 n, int byte_sz, ut8 *outbuf, int outsz) {
 	int bits = r_num_to_bits (NULL, n);
 	// TODO: signedness prbly wrong...
-	if (bits > byte_sz * 8) {
+	if (n && bits > byte_sz * 8) {
 		R_LOG_ERROR ("Arg 0x%" PFMT64x " is more than %d bits", n, bits);
-		false;
+		return false;
 	}
 	switch (byte_sz) {
 	case 1:


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix bug where 0 is treated as a 64 bit number. The pickler would assemble it anyways due to another bug that this fixes.

