### PR TITLE
Fix meson infinite loop ##build

### DIFF
--- a/libr/crypto/meson.build
+++ b/libr/crypto/meson.build
@@ -52,8 +52,6 @@ else
   r_crypto_sources += files('hash/md4.c', 'hash/md5.c', 'hash/sha1.c', 'hash/sha2.c')
 endif
 
-r_crypto_sources += r_crypto_sources
-
 r_crypto = library('r_crypto', r_crypto_sources,
   include_directories: [platform_inc],
   dependencies: r_crypto_deps,


### PR DESCRIPTION
If you do a = files('example.c') and then a += a, meson rewrite will loop infinitely

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
