### PR TITLE
Fix long1,long4 pickle opcodes ##anal

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -566,7 +566,7 @@ static inline int l_num_to_bytes(ut64 n, bool sign) {
 		test = -test;
 		flip = true;
 	}
-	st64 last;
+	st64 last = 0;
 	while (test) {
 		last = test;
 		test = test >> 8;

--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -160,6 +160,14 @@ static const struct opmap op_name_map[] = {
 	{ "readonly_buffer", '\x98' }
 };
 
+static inline bool valid_offset(RAnal *a, ut64 addr) {
+	RIOIsValidOff validoff = a->iob.io? a->iob.is_valid_offset: NULL;
+	if (validoff && !validoff (a->iob.io, addr, 0)) {
+		return false;
+	}
+	return true;
+}
+
 static inline int handle_int(RAnalOp *op, const char *name, int sz, const ut8 *buf, int buflen) {
 	if (sz <= buflen && sz <= sizeof (op->val)) {
 		op->size += sz;
@@ -168,6 +176,45 @@ static inline int handle_int(RAnalOp *op, const char *name, int sz, const ut8 *b
 		return op->size;
 	}
 	return -1;
+}
+
+static inline int handle_long(RAnal *a, RAnalOp *op, const char *name, int sz, const ut8 *buf, int buflen) {
+	r_return_val_if_fail (sz == 1 || sz == 4, -1);
+	op->sign = true;
+
+	// process how long the numer is is
+	if (sz > buflen) {
+		return -1;
+	}
+	ut64 longlen = r_mem_get_num (buf, sz);
+	buf += sz;
+	buflen -= sz;
+	op->size += sz + longlen;
+
+	if (longlen <= sizeof (op->val) && longlen <= buflen) {
+		op->val = 0;
+		if (longlen) {
+			st64 i, out = 0;
+			bool neg = buf[longlen - 1] & 0x80? true: false;
+			for (i = 0; i < longlen; i++) {
+				ut8 v = neg? ~buf[i]: buf[i]; // force positive
+				out += (ut64)v << (8 * i);
+			}
+			if (neg) {
+				out = -out - 1;
+			}
+			op->val = out;
+		}
+		op->mnemonic = r_str_newf ("long%d %" PFMT64d, sz, op->val);
+	} else {
+		if (!valid_offset (a, op->addr + op->size - 1)) {
+			op->size = 1;
+			return -1;
+		}
+		op->mnemonic = r_str_newf ("long%d <%" PFMT64d " bytes long int too big>", sz, longlen);
+		op->val = UT8_MAX;
+	}
+	return op->size;
 }
 
 static inline int handle_float(RAnalOp *op, const char *name, int sz, const ut8 *buf, int buflen) {
@@ -287,16 +334,13 @@ static inline int cnt_str(RAnal *a, RAnalOp *op, const char *name, int sz, const
 		op->ptrsize = r_mem_get_num (buf, sz);
 		op->size = op->nopcode + sz + op->ptrsize;
 		op->ptr = op->addr + sz + op->nopcode;
-		RIOIsValidOff validoff = a->iob.io? a->iob.is_valid_offset: NULL;
-		if (validoff && !validoff (a->iob.io, op->addr + op->size - 1, 0)) {
-			// end of string is in bad area, probably this is invalid offset for op
-			op->size = 1;
-			op->type = R_ANAL_OP_TYPE_ILL;
-		} else {
-			// handle string
+		if (valid_offset (a, op->addr + op->size - 1)) {
 			buflen -= sz;
 			buf += sz;
 			set_mnemonic_str (op, name, buf, R_MIN (buflen, MAXSTRLEN));
+		} else {
+			op->size = 1;
+			op->type = R_ANAL_OP_TYPE_ILL;
 		}
 	}
 	return op->size;
@@ -425,9 +469,9 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 	case OP_NEWFALSE:
 		trivial_op ("newfalse");
 	case OP_LONG1:
-		return handle_int (op, "long1", 1, buf, len);
+		return handle_long (a, op, "long1", 1, buf, len);
 	case OP_LONG4:
-		return handle_int (op, "long4", 4, buf, len);
+		return handle_long (a, op, "long1", 4, buf, len);
 	case OP_BINBYTES:
 		return cnt_str (a, op, "binbytes", 4, buf, len);
 	case OP_SHORT_BINBYTES:
@@ -466,10 +510,12 @@ static int analop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, RAn
 }
 
 static inline bool write_num_sz(ut64 n, int byte_sz, ut8 *outbuf, int outsz) {
+	if (byte_sz > outsz) {
+		return false;
+	}
 	int bits = r_num_to_bits (NULL, n);
-	// TODO: signedness prbly wrong...
 	if (n && bits > byte_sz * 8) {
-		R_LOG_ERROR ("Arg 0x%" PFMT64x " is more than %d bits", n, bits);
+		R_LOG_ERROR ("Arg 0x%" PFMT64x " is more than %d bytes", n, byte_sz);
 		return false;
 	}
 	switch (byte_sz) {
@@ -491,19 +537,72 @@ static inline bool write_num_sz(ut64 n, int byte_sz, ut8 *outbuf, int outsz) {
 	return true;
 }
 
-static inline int assemble_int(const char *str, int byte_sz, ut8 *outbuf, int outsz) {
-	if (outsz < byte_sz) {
-		return -2;
-	}
+static inline bool get_asmembled_num(const char *str, ut64 *out) {
 	RNum *num = r_num_new (NULL, NULL, NULL);
 	if (num) {
-		ut64 n = r_num_math (num, str);
+		*out = r_num_math (num, str);
 		r_num_free (num);
-		if (write_num_sz (n, byte_sz, outbuf, outsz)) {
-			return byte_sz;
-		}
+		return true;
+	}
+	return false;
+}
+
+static inline int assemble_int(const char *str, int byte_sz, ut8 *outbuf, int outsz) {
+	ut64 n;
+	if (outsz < byte_sz || !get_asmembled_num (str, &n)) {
+		return -2;
+	}
+	if (write_num_sz (n, byte_sz, outbuf, outsz)) {
+		return byte_sz;
 	}
 	return 0;
+}
+
+static inline int l_num_to_bytes(ut64 n, bool sign) {
+	bool flip = false;
+	st64 test = n;
+	int ret = 0;
+	if (sign && test < 0) {
+		test = -test;
+		flip = true;
+	}
+	st64 last;
+	while (test) {
+		last = test;
+		test = test >> 8;
+		ret++;
+	}
+	if (!flip && last & 0x80) {
+		ret++; // extra null byte needed to indicate positive
+	}
+	return ret;
+}
+
+static inline int assemble_longint(const char *str, int byte_sz, ut8 *outbuf, int outsz) {
+	// long1 is followed by a single byte indicating size of the encoded long,
+	// so up to 255 byte numbers, long4 uses 4 bytes to encode size
+	ut64 n;
+	if (get_asmembled_num (str, &n)) {
+		if (!n && write_num_sz (n, byte_sz, outbuf, outsz)) { // special, can be smaller
+			return byte_sz;
+		}
+		int bytes = l_num_to_bytes (n, true);
+		if (bytes > sizeof (ut64)) {
+			R_LOG_ERROR ("Can't assemble longs larger then 64 bits yet");
+			return -2;
+		}
+		int writesize = bytes + byte_sz;
+		if (writesize < outsz && write_num_sz (bytes, byte_sz, outbuf, outsz)) {
+			outbuf += byte_sz;
+			outsz -= byte_sz;
+			size_t i;
+			for (i = 0; i < bytes; i++) {
+				outbuf[i] = 0xff & (n >> (i * 8));
+			}
+			return writesize;
+		}
+	}
+	return -2;
 }
 
 static inline int assemble_float(const char *str, ut8 *outbuf, int outsz) {
@@ -667,7 +766,6 @@ static int pickle_opasm(RAnal *a, ut64 addr, const char *str, ut8 *outbuf, int o
 		case OP_LONG_BINPUT:
 		case OP_LONG_BINGET:
 		case OP_EXT4:
-		case OP_LONG4:
 			wlen += assemble_int (arg, 4, outbuf, outsz);
 			break;
 		case OP_BININT2:
@@ -679,8 +777,13 @@ static int pickle_opasm(RAnal *a, ut64 addr, const char *str, ut8 *outbuf, int o
 		case OP_BINPUT:
 		case OP_PROTO:
 		case OP_EXT1:
-		case OP_LONG1:
 			wlen += assemble_int (arg, 1, outbuf, outsz);
+			break;
+		case OP_LONG4:
+			wlen += assemble_longint (arg, 4, outbuf, outsz);
+			break;
+		case OP_LONG1:
+			wlen += assemble_longint (arg, 1, outbuf, outsz);
 			break;
 		// float
 		case OP_BINFLOAT:

--- a/test/db/anal/pickle
+++ b/test/db/anal/pickle
@@ -169,7 +169,13 @@ wa LONG_BINGET 0x11223344
 pid 1
 wa EXT4 0x11223344
 pid 1
-wa LONG4 0x11223344
+wa LONG4 11223344
+pid 1
+wa LONG1 11223344
+pid 1
+wa LONG4 -11223344
+pid 1
+wa LONG1 -11223344
 pid 1
 wa BININT2 0x1122
 pid 1
@@ -185,8 +191,6 @@ wa PROTO 0x11
 pid 1
 wa EXT1 0x11
 pid 1
-wa LONG1 0x11
-pid 1
 EOF
 EXPECT=<<EOF
 0x00000000   958877885544332211  frame 0x1122334455887788
@@ -194,7 +198,10 @@ EXPECT=<<EOF
 0x00000000           7244332211  long_binput 0x11223344
 0x00000000           6a44332211  long_binget 0x11223344
 0x00000000           8444332211  ext4 0x11223344
-0x00000000           8b44332211  long4 0x11223344
+0x00000000   8b040000003041ab00  long4 11223344
+0x00000000         8a043041ab00  long1 11223344
+0x00000000     8b03000000d0be54  long4 5553872
+0x00000000           8a03d0be54  long1 5553872
 0x00000000               4d2211  binint2 0x1122
 0x00000000               832211  ext2 0x1122
 0x00000000                 4b11  binint1 0x11
@@ -202,7 +209,6 @@ EXPECT=<<EOF
 0x00000000                 7111  binput 0x11
 0x00000000                 8011  proto 0x11
 0x00000000                 8211  ext1 0x11
-0x00000000                 8a11  long1 0x11
 EOF
 RUN
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The long1 and long4 opcodes were implemented wrong. This updates the assembler/disassembler to fix them, mostly.

Previously I thought `long1` would push a 8 bit number to the stack, instead it can push a 2040 bit number to the stack. The first byte after `long1` op indicates how many bytes should be interpreted as a signed little endian number and pushed onto the VM stack. The `long4` op uses 4 bytes.

Giant numbers are not completely handled, but handled well enough to get through I think.

In light of this, I also output longs as decimal numbers. Signdness gets a little funny otherwise because 0x00ff is treated as 255 while 0xff is treated as -1.