### PR TITLE
Add log error when pj depth limit reached ##util

### DIFF
--- a/libr/util/pj.c
+++ b/libr/util/pj.c
@@ -76,6 +76,7 @@ R_API const char *pj_string(PJ *j) {
 static PJ *pj_begin(PJ *j, char type) {
 	if (j) {
 		if (!j || j->level >= R_PRINT_JSON_DEPTH_LIMIT) {
+			R_LOG_ERROR ("JSON depth limit reached");
 			return NULL;
 		}
 		char msg[2] = { type, 0 };


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I hit the JSON depth limit and it took a bit to figure out why JSON failed. This may save someone in the future some debugging. Assuming `R_LOG` is allowed here.
