### PR TITLE
Add basic support for 32bit Mach-O fixups ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -209,7 +209,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
-	ut8 ptr_size;
+	ut64 ptr_size;
 } RFixupEventDetails;
 
 typedef struct {
@@ -217,7 +217,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
-	ut8 ptr_size;
+	ut64 ptr_size;
 	ut64 ordinal;
 	ut64 addend;
 } RFixupBindEventDetails;
@@ -227,7 +227,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
-	ut8 ptr_size;
+	ut64 ptr_size;
 	ut32 ordinal;
 	ut8 key;
 	ut8 addr_div;
@@ -239,7 +239,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
-	ut8 ptr_size;
+	ut64 ptr_size;
 	ut64 ptr_value;
 } RFixupRebaseEventDetails;
 
@@ -248,7 +248,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
-	ut8 ptr_size;
+	ut64 ptr_size;
 	ut64 ptr_value;
 	ut8 key;
 	ut8 addr_div;

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -209,6 +209,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
+	ut8 ptr_size;
 } RFixupEventDetails;
 
 typedef struct {
@@ -216,6 +217,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
+	ut8 ptr_size;
 	ut64 ordinal;
 	ut64 addend;
 } RFixupBindEventDetails;
@@ -225,6 +227,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
+	ut8 ptr_size;
 	ut32 ordinal;
 	ut8 key;
 	ut8 addr_div;
@@ -236,6 +239,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
+	ut8 ptr_size;
 	ut64 ptr_value;
 } RFixupRebaseEventDetails;
 
@@ -244,6 +248,7 @@ typedef struct {
 	struct MACH0_(obj_t) *bin;
 	ut64 offset;
 	ut64 raw_ptr;
+	ut8 ptr_size;
 	ut64 ptr_value;
 	ut8 key;
 	ut8 addr_div;

--- a/libr/bin/format/mach0/mach0_defines.h
+++ b/libr/bin/format/mach0/mach0_defines.h
@@ -1582,6 +1582,29 @@ struct dyld_chained_ptr_arm64e_auth_bind24 {
 		auth : 1; // == 1
 };
 
+struct dyld_chained_ptr_32_rebase {
+	uint32_t target : 26,
+		next : 5,
+		bind : 1; // == 0
+};
+
+struct dyld_chained_ptr_32_bind {
+	uint32_t ordinal : 20,
+		addend : 6,
+		next : 5,
+		bind : 1; // == 1
+};
+
+struct dyld_chained_ptr_32_cache_rebase {
+	uint32_t target : 30,
+		next : 2;
+};
+
+struct dyld_chained_ptr_32_firmware_rebase {
+	uint32_t target : 26,
+		next : 6;
+};
+
 enum {
 	DYLD_CHAINED_IMPORT          = 1,
 	DYLD_CHAINED_IMPORT_ADDEND   = 2,

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -782,9 +782,9 @@ static bool rebase_buffer_callback2(void *context, RFixupEventDetails * event_de
 	switch (event_details->type) {
 	case R_FIXUP_EVENT_BIND:
 	case R_FIXUP_EVENT_BIND_AUTH:
-		r_buf_write_at (ctx->obj->b, in_buf, (const ut8*)"\x00\x00\x00\x00\x00\x00\x00", 8);
+		r_buf_write_at (ctx->obj->b, in_buf, (const ut8*)"\x00\x00\x00\x00\x00\x00\x00", event_details->ptr_size);
 		ut8 data[8] = {0};
-		r_buf_read_at (ctx->obj->b, in_buf, data, 8);
+		r_buf_read_at (ctx->obj->b, in_buf, data, event_details->ptr_size);
 		add_fixup (rflist, in_buf, 0);
 		if (data[0]) {
 			eprintf ("DATA0 write has failed\n");
@@ -796,8 +796,8 @@ static bool rebase_buffer_callback2(void *context, RFixupEventDetails * event_de
 			ut8 data[8] = {0};
 			ut64 v = ((RFixupRebaseEventDetails *) event_details)->ptr_value;
 			add_fixup (rflist, in_buf, v);
-			memcpy (&data, &v, sizeof (data));
-			r_buf_write_at (ctx->obj->b, in_buf, data, 8);
+			memcpy (&data, &v, event_details->ptr_size);
+			r_buf_write_at (ctx->obj->b, in_buf, data, event_details->ptr_size);
 		}
 		break;
 	default:


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Add support for 32-bit chained fixup formats.
