### PR TITLE
Warn about unpatched relocs when no bin.cache is set for macho fixups ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -984,7 +984,7 @@ static RList* patch_relocs(RBin *b) {
 		return NULL;
 	}
 	if (!io->cached) {
-		eprintf ("Warning: run r2 with -e bin.cache=true to fix relocations in disassembly\n");
+		R_LOG_WARN ("run r2 with -e bin.cache=true to fix relocations in disassembly");
 		return NULL;
 	}
 	ut64 n_vaddr = g->itv.addr + g->itv.size;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -642,16 +642,23 @@ static RList* patch_relocs(RBin *b) {
 		}
 		r_list_append (ext_relocs, reloc);
 	}
-	RBinReloc *r;
-	RListIter *iter2;
+	if (mo->reloc_fixups && r_list_length (mo->reloc_fixups) > 0) {
+		if (!io->cached) {
+			R_LOG_WARN ("run r2 with -e bin.cache=true to fix relocations in disassembly");
+			goto beach;
+		} else {
+			RBinReloc *r;
+			RListIter *iter2;
 
-	r_list_foreach (mo->reloc_fixups, iter2, r) {
-		ut64 paddr = r->paddr + mo->baddr;
-		ut8 buf[8], obuf[8];
-		r_write_ble64 (buf, r->vaddr, false);
-		r_io_read_at (io, paddr, obuf, 8);
-		if (memcmp (buf, obuf, 8)) {
-			r_io_write_at (io, paddr, buf, 8);
+			r_list_foreach (mo->reloc_fixups, iter2, r) {
+				ut64 paddr = r->paddr + mo->baddr;
+				ut8 buf[8], obuf[8];
+				r_write_ble64 (buf, r->vaddr, false);
+				r_io_read_at (io, paddr, obuf, 8);
+				if (memcmp (buf, obuf, 8)) {
+					r_io_write_at (io, paddr, buf, 8);
+				}
+			}
 		}
 	}
 	ut64 num_ext_relocs = r_list_length (ext_relocs);

--- a/libr/bin/p/bin_rel.c
+++ b/libr/bin/p/bin_rel.c
@@ -543,7 +543,7 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 
 static RList *patch_relocs(RBin *b) {
 	if (!b->iob.io->cached) {
-		eprintf ("Warning: run r2 with -e bin.cache=true to fix relocations in disassembly\n");
+		R_LOG_WARN ("run r2 with -e bin.cache=true to fix relocations in disassembly");
 		return NULL;
 	}
 

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -4387,7 +4387,7 @@ EXPECT=<<EOF
 0 entrypoints
 EOF
 EXPECT_ERR=<<EOF
-Warning: run r2 with -e bin.cache=true to fix relocations in disassembly
+WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 EOF
 RUN
 

--- a/test/db/formats/rel
+++ b/test/db/formats/rel
@@ -5,7 +5,7 @@ CMDS=
 EXPECT_ERR=<<EOF
 INFO: REL module ID 00000001
 INFO: REL version 3
-Warning: run r2 with -e bin.cache=true to fix relocations in disassembly
+WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 EOF
 RUN
 

--- a/test/db/io/write
+++ b/test/db/io/write
@@ -25,7 +25,7 @@ EXPECT=<<EOF
 1\xed^\x89\xe1\x83\xe4\xf0PTR\xe8"
 EOF
 EXPECT_ERR=<<EOF
-Warning: run r2 with -e bin.cache=true to fix relocations in disassembly
+WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 ERROR: [cmd_write.c:192] Cannot write. Check `omp` or reopen the file with `oo+`
 EOF
 RUN
@@ -45,7 +45,7 @@ EXPECT=<<EOF
 hello
 EOF
 EXPECT_ERR=<<EOF
-Warning: run r2 with -e bin.cache=true to fix relocations in disassembly
+WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 ERROR: [cmd_write_fail] Cannot write. Check `omp` or reopen the file with `oo+`
 EOF
 RUN


### PR DESCRIPTION


* Use R_LOG for elf and rel fileformats

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
