### PR TITLE
RStr.wrap() supports ansi and use it in VT ##visual

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1742,7 +1742,7 @@ static void visual_textlogs(RCore *core) {
 	int index = 1;
 	while (true) {
 		r_cons_clear00 ();
-		const char *title = "[visual-text-logs] Use [hjkl] to move, `i` to insert, `q` to quit\n";
+		const char *title = "[q] [visual-text-logs] Move with [hjkl], `i` to insert, `-` trim logs\n";
 		if (r_config_get_i (core->config, "scr.color") > 0) {
 			r_cons_printf (Color_YELLOW"%s"Color_RESET, title);
 		} else {
@@ -1751,6 +1751,8 @@ static void visual_textlogs(RCore *core) {
 		r_core_cmdf (core, "Tv %d", index);
 		r_cons_printf ("--\n");
 		char *s = r_core_cmd_strf (core, "Tm %d~{}", index);
+		int w = r_cons_get_size (NULL);
+		s = r_str_wrap (s, w);
 		r_cons_printf ("%s\n", s);
 		free (s);
 		r_cons_visual_flush ();

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3288,9 +3288,19 @@ R_API char *r_str_wrap(const char *str, int w) {
 	}
 	size_t r_size = 8 * strlen (str);
 	r = ret = malloc (r_size);
+	if (!r) {
+		return NULL;
+	}
 	char *end = r + r_size;
 	int cw = 0;
 	while (*str && r + 1 < end) {
+		size_t ansilen = __str_ansi_length (str);
+		if (ansilen > 1) {
+			memcpy (r, str, ansilen);
+			str += ansilen;
+			r += ansilen;
+			continue;
+		}
 		if (*str == '\t') {
 			// skip
 		} else if (*str == '\r') {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
