### PR TITLE
Fix r_bin_elf_get_stripped for ELF files without section header.

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2024,7 +2024,7 @@ ut64 Elf_(r_bin_elf_get_main_offset)(ELFOBJ *bin) {
 
 bool Elf_(r_bin_elf_get_stripped)(ELFOBJ *bin) {
 	if (!bin->shdr) {
-		return false;
+		return true;
 	}
 	if (bin->g_sections) {
 		size_t i;


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ELF files without sections were automatically considered as not "not stripped". Given that static symbols and MiniDebugInfo are stored in dedicated sections (.symtab, .strtab, and .gnu_debugdata, respectively) an ELF file without any section would have a difficult time providing that information.