### PR TITLE
Fix rasm2 x86.nz for "xchg eax,eax"

### DIFF
--- a/libr/asm/p/asm_x86_nz.c
+++ b/libr/asm/p/asm_x86_nz.c
@@ -2746,7 +2746,17 @@ static int opxchg(RAsm *a, ut8 *data, const Opcode *op) {
 			& (op->operands[1].type & ALL_SIZE))) { // unmatched operand sizes
 			return -1;
 		}
-		if (op->operands[0].reg == X86R_EAX
+		if (a->config->bits == 64
+				&& op->operands[0].reg == X86R_EAX
+				&& !op->operands[0].extended
+				&& op->operands[0].type & OT_DWORD
+				&& op->operands[1].reg == X86R_EAX
+				&& !op->operands[1].extended
+				&& op->operands[1].type & OT_DWORD) {
+			data[l++] = 0x87;
+			data[l++] = 0xc0;
+			return l;
+		} else if (op->operands[0].reg == X86R_EAX
 				&& !op->operands[0].extended
 				&& !(op->operands[0].type & OT_BYTE)
 				&& op->operands[1].type & OT_GPREG) {

--- a/test/db/asm/x86_32
+++ b/test/db/asm/x86_32
@@ -406,6 +406,10 @@ d "xchg edi, eax" 97
 d "xchg edx, eax" 92
 d "xchg esi, eax" 96
 d "xchg esp, eax" 94
+a "xchg ax, ax" 6690
+a "xchg eax, eax" 90
+ad "xchg bx, ax" 6693
+ad "xchg ebx, eax" 93
 d "xgetbv" 0f01d0
 d "xlatb" D7
 d "xor al, 0" 3400

--- a/test/db/asm/x86_64
+++ b/test/db/asm/x86_64
@@ -1178,6 +1178,12 @@ ad "xchg r8d, r15d" 4587f8
 ad "xchg r15d, r8d" 4587c7
 ad "xchg rdx, r8" 4c87c2
 ad "xchg r15, rdx" 4987d7
+a "xchg ax, ax" 6690
+ad "xchg eax, eax" 87c0
+a "xchg rax, rax" 4890
+ad "xchg bx, ax" 6693
+ad "xchg ebx, eax" 93
+ad "xchg rbx, rax" 4893
 d "call qword [rip + 0x3a8f3e]" 48ff153e8f3a00
 d "call qword [rip + 0x1d638f]" 48ff158f631d00
 a "fmul st2, st0" dcca


### PR DESCRIPTION
- [X ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`xchg eax,eax` is not the same as `nop` in 64-bit, must not translate as 0x90

Expected output:
    rasm2 -a x86.nz -b 64 "xchg eax,eax" -> 87c0
    rasm2 -a x86.nz -b 32 "xchg eax,eax" -> 90
    
Also add some more test cases for xchg
