### PR TITLE
Correct magic hit numbering and move base64 into magic

### DIFF
--- a/libr/core/cmd_magic.c
+++ b/libr/core/cmd_magic.c
@@ -131,6 +131,7 @@ static int r_core_magic_at(RCore *core, RSearchKeyword *kw, const char *file, ut
 		// We do not flag for pm command.
 		if (kw) {
 			flag = r_str_newf ("%s%d_%d", searchprefix, kw->kwidx, kw->count);
+			kw->count++;
 			r_flag_set (core->flags, flag, addr + adelta, 1);
 		}
 		// TODO: This must be a callback .. move this into RSearch?

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -3859,10 +3859,6 @@ reread:
 				kw = r_search_keyword_new_hexmask ("01020408102040801b366cc0ab4d9a2f5ebf63c697356ad4b37dfaefc591", NULL); // AES
 				r_search_kw_add (search, kw);
 
-				// base64
-				kw = r_search_keyword_new_str ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", NULL, NULL, false);
-				r_search_kw_add (search, kw);
-
 				// blowfish
 				if (le) {
 					// LE blowfish

--- a/libr/magic/d/default/encoding
+++ b/libr/magic/d/default/encoding
@@ -1,0 +1,8 @@
+#Base64 index tables
+0   string ABCDEFGHIJKLMNOPQRSTUVWXYZabcde
+> 31 string fghijklmnopqrstuvwxyz0123456789
+> 62 string +/                              Base64 standard index table
+
+0   string ACEGIKMOQSUWYBDFHJLNPRTVXZacegi
+> 31 string kmoqsuwybdfhjlnprtvxz0246813579
+> 62 string \=+                             Base64 SerComm index table

--- a/test/db/cmd/cmd_search_magic
+++ b/test/db/cmd/cmd_search_magic
@@ -73,3 +73,14 @@ EXPECT=<<EOF
 0x00000000 1 magic0_0 Binary PLIST data stream
 EOF
 RUN
+
+NAME=/m on Zip
+FILE=bins/zip/CDinFN.zip
+CMDS=<<EOF
+/m
+EOF
+EXPECT=<<EOF
+0x00000000 1 hit0_0 ZIP Zip archive data, at least v1.0 to extract
+0x00000062 1 hit0_1 End of Zip archive
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

base64 is removed from `/ck`, it was not really crypto and the final goal is to have all ck into magic. The numbering of hit is corrected. Magic file for encoding is from https://github.com/ReFirmLabs/binwalk/blob/master/src/binwalk/magic/encoding
