### PR TITLE
Support space separated instruction types and family in /at and /af ##search

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -252,10 +252,11 @@ R_API bool r_anal_op_ismemref(int t) {
 	}
 }
 
+#define OPTYPES_COUNT 62
 static struct optype {
 	const int type;
 	const char *name;
-} optypes[] = {
+} optypes[OPTYPES_COUNT] = {
 	{ R_ANAL_OP_TYPE_IO, "io" },
 	{ R_ANAL_OP_TYPE_ACMP, "acmp" },
 	{ R_ANAL_OP_TYPE_ADD, "add" },
@@ -328,6 +329,13 @@ R_API int r_anal_optype_from_string(const char *type) {
 		}
 	}
 	return -1;
+}
+
+R_API const char *r_anal_optype_index(int idx) {
+	if (idx < 0 || idx >= OPTYPES_COUNT) {
+		return NULL;
+	}
+	return optypes[idx].name;
 }
 
 R_API const char *r_anal_optype_to_string(int t) {

--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -143,9 +143,10 @@ static const char *help_msg_slash[] = {
 };
 
 static const char *help_msg_slash_at[] = {
-	"Usage:", "/at[mjsf] [arg]", "Search for instructions matching type/family/mnemonic",
-	"/atf", " [family]", "search for given-family type of instructions",
+	"Usage:", "/at[flmj] [arg]", "Search for instructions matching type/family/mnemonic",
 	"/at", " [optype,optype2]", "list instructions matching any of the comma separated optypes",
+	"/atj", " [optype,optype2]", "same as above but using json as output",
+	"/atf", " [family]", "search for given-family type of instructions",
 	"/atl", "", "list all the instruction types (RAnalOp.Type)",
 	"/atm", "", "search matching only the instruction mnemonic",
 	NULL
@@ -2506,7 +2507,7 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 				for (i = 0; i < 64; i++) {
 					const char *str = type == 'f'
 						? r_anal_op_family_to_string (i)
-						: r_anal_optype_to_string (i);
+						: r_anal_optype_index (i);
 					if (R_STR_ISEMPTY (str)) {
 						break;
 					}
@@ -2577,10 +2578,10 @@ static bool do_anal_search(RCore *core, struct search_parameters *param, const c
 				continue;
 			}
 			bool found = false;
-			for (i = 0; i < 64; i++) {
+			for (i = 0; i < 1024; i++) {
 				const char *str = type == 'f'
 					? r_anal_op_family_to_string (i)
-					: r_anal_optype_to_string (i);
+					: r_anal_optype_index (i);
 				if (R_STR_ISEMPTY (str)) {
 					break;
 				}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1050,6 +1050,7 @@ R_API bool r_anal_op_nonlinear(int t);
 R_API const char *r_anal_op_direction_tostring(RAnalOp *op);
 R_API bool r_anal_op_ismemref(int t);
 R_API const char *r_anal_optype_to_string(int t);
+R_API const char *r_anal_optype_index(int idx);
 R_API int r_anal_optype_from_string(const char *type);
 R_API const char *r_anal_op_family_to_string(int n);
 R_API int r_anal_op_family_from_string(const char *f);


### PR DESCRIPTION

* Check all the types/families provided before searching
* Needed for: /at `/atl~^sh` for shl/shr oneliners f.ex

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
