### PR TITLE
Fix typo in doc/intro.md

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -508,7 +508,7 @@ PEDA like details: `drr;pd 10@-10;pxr 40@esp`
 Debug in visual mode
 
 ```
-toggl breakpoints with F2
+toggle breakpoints with F2
 single-step with F7 (s)
 step-over with F8 (S)
 continue with F9


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
"toggle breakpoints with F2" was misspelled as "toggl breakpoints with F2"