### PR TITLE
Fix unref issue when calling RCore.free from multiple threads

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3299,9 +3299,10 @@ R_API void r_core_fini(RCore *c) {
 	r_core_task_scheduler_fini (&c->tasks);
 	c->rcmd = r_cmd_free (c->rcmd);
 	r_list_free (c->cmd_descriptors);
-	r_unref (c->print->config);
+	/*
 	r_unref (c->anal->reg->config);
 	r_unref (c->anal->config);
+	*/
 	r_anal_free (c->anal);
 	r_asm_free (c->rasm);
 	c->rasm = NULL;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -361,6 +361,7 @@ R_API RPrint* r_print_free(RPrint *p) {
 	R_FREE (p->lines_cache);
 	R_FREE (p->row_offsets);
 	r_charset_free (p->charset);
+	r_unref (p->config);
 	free (p);
 	return NULL;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
