### PR TITLE
Fix meson with sys_xxhash

### DIFF
--- a/libr/crypto/meson.build
+++ b/libr/crypto/meson.build
@@ -41,7 +41,7 @@ r_crypto_sources += files(
 r_crypto_deps = [r_util_dep]
 
 if use_sys_xxhash
-  r_crypto_deps += files(sys_xxhash)
+  r_crypto_deps += sys_xxhash
 else
   r_crypto_sources += files('hash/xxhash.c')
 endif


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

`libr/crypto/meson.build`used `files(sys_xxhash)` instead of just `sys_xxhash`, resulting in `libr/crypto/meson.build:44:2: ERROR: files argument 1 was of type "PkgConfigDependency" but should have been "str"`.