### PR TITLE
Sync capstone if not at correct commit

### DIFF
--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -252,7 +252,7 @@ capstone-sync:
 ifeq ($(WITHOUT_PULL),1)
 	@echo "Nothing to sync because of --without-pull"
 else
-	if [ ! -d capstone ]; then \
+	if [ ! -d capstone ] || [ $(shell [ -d capstone/.git ] && git --git-dir capstone/.git rev-parse HEAD) != $(CS_TIP) ]; then \
 		"$(SHELL)" capstone.sh "${CS_URL}" "${CS_BRA}" "${CS_TIP}" "${CS_REV}" "${CS_ARCHIVE_URL}" ; \
 	fi
 endif

--- a/shlr/capstone.sh
+++ b/shlr/capstone.sh
@@ -127,7 +127,7 @@ if [ -z "${CS_ARCHIVE}" ]; then
 	fi
 fi
 
-if [ -d capstone ]; then
+if [ -d capstone -a ! -d capstone/.git ] || [ "$(git --git-dir capstone/.git rev-parse --verify HEAD > /dev/null 2>&1)" = ${CS_TIP} ]; then
 	echo "[capstone] Nothing to do"
 	exit 0
 fi


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Instead of just checking that the capstone directory exists, check that we're at the correct commit. Avoids problems if new enums are added.