### PR TITLE
Fix out-of-bounds read when running "wtf"

### DIFF
--- a/libr/core/cmd_write.c
+++ b/libr/core/cmd_write.c
@@ -1568,6 +1568,7 @@ static int cmd_wt(RCore *core, const char *input) {
 		}
 		case 'f': // "wtf"
 			switch (input[1]) {
+			case '\0':
 			case '?': // "wtf?"
 				r_core_cmd_help_match (core, help_msg_wt, "wtf", true);
 				ret = 1;


### PR DESCRIPTION
Print help and leave if `input[1]` is `'\0'`. Better behavior and avoids attempting to read `input[2]`.