### PR TITLE
Fix pickle asm rejecting empty strings ##anal

### DIFF
--- a/libr/anal/p/anal_pickle.c
+++ b/libr/anal/p/anal_pickle.c
@@ -638,7 +638,7 @@ static inline int assemble_cnt_str(char *str, int byte_sz, ut8 *outbuf, int outs
 	str++;
 	int wlen = -2;
 	len = r_str_unescape (str);
-	if (len > 0 && len + byte_sz <= outsz && write_num_sz (len, byte_sz, outbuf, outsz)) {
+	if (len >= 0 && len + byte_sz <= outsz && write_num_sz (len, byte_sz, outbuf, outsz)) {
 		wlen = len + byte_sz;
 		memcpy (outbuf + byte_sz, str, len);
 	}

--- a/test/db/anal/pickle
+++ b/test/db/anal/pickle
@@ -393,3 +393,20 @@ next_buffer
 readonly_buffer
 EOF
 RUN
+
+NAME=Empty strings assemble
+FILE=malloc://16
+CMDS=<<EOF
+e asm.arch=pickle
+wa+ string ""
+wa+ short_binstring ""
+wa global " "
+s 0
+pid 3
+EOF
+EXPECT=<<EOF
+0x00000000             5327270a  string ""
+0x00000004                 5500  short_binstring ""
+0x00000006               630a0a  global " "
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Lets you pickle some empty strings like  `rasm2 -a pickle 'short_binstring ""'`