### PR TITLE
Fix rvector assert when indexing empty ones ##r2r

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -237,6 +237,7 @@ R_API RPVector *r2r_load_cmd_test_file(const char *file) {
 #undef DO_KEY_NUM
 
 		R_LOG_ERROR (LINEFMT ": Unknown key \"%s\"", file, linenum, line);
+		break;
 	} while ((line = nextline));
 beach:
 	free (contents);

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -158,6 +158,9 @@ R_API void *r_vector_insert(RVector *vec, size_t index, void *x) {
 
 R_API void *r_vector_insert_range(RVector *vec, size_t index, void *first, size_t count) {
 	r_return_val_if_fail (vec && index <= vec->len, NULL);
+	if (count < 1) {
+		return NULL;
+	}
 	if (vec->len + count > vec->capacity) {
 		RESIZE_OR_RETURN_NULL (R_MAX (NEXT_VECTOR_CAPACITY, vec->len + count));
 	}


### PR DESCRIPTION
* Crashing when passing corrupted tests to r2r

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
