### PR TITLE
Avoid printing DELTA

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -1983,7 +1983,6 @@ static int var_cmd(RCore *core, const char *str) {
 			r_str_trim (vartype);
 		}
 		if (type == 'b') {
-			eprintf ("DELTA\n");
 			delta -= fcn->bp_off;
 		}
 		if ((type == 'b') && delta > 0) {


### PR DESCRIPTION
This deletes a `printf` that was maybe left here by mistake? Mostly this is an issue when loading large project files, as it can print DELTA infinitely :)
