### PR TITLE
Don't skip byte when moving left/right in cursor mode

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -6988,11 +6988,10 @@ virtualmouse:
 			core->cons->cpos.x--;
 			core->print->cur--;
 		} else if (core->print->cur_enabled) {
-			core->print->cur--;
+			cur->model->directionCb (core, (int)LEFT);
 			RPanel *cp = __get_cur_panel (core->panels);
 			if (cp) {
 				core->cons->cpos.x--;
-				core->print->cur--;
 				cp->view->curpos--;
 			}
 		} else if (cur->model->directionCb) {
@@ -7006,7 +7005,6 @@ virtualmouse:
 		} else if (cur->model->directionCb) {
 			cur->model->directionCb (core, (int)RIGHT);
 			r_cons_switchbuf (false);
-			core->print->cur++;
 		} else if (core->print->cur_enabled) {
 			core->print->cur++;
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
I noticed that in the disassembly panel, when trying to move left/right in cursor mode it 'skips' a byte. This commit aims to fix that.