### PR TITLE
Fix subkey removal ##bin

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -40,20 +40,22 @@ R_API void r_anal_remove_parsed_type(RAnal *anal, const char *name) {
 	if (!type) {
 		return;
 	}
-	int tmp_len = strlen (name) + strlen (type);
-	char *tmp = malloc (tmp_len + 1);
+
+	// Create a subkey before the call to r_type_del (which leaves the type string invalid)
+	char *subkey = r_str_newf ("%s.%s.", type, name);
 	r_type_del (TDB, name);
-	if (tmp) {
-		snprintf (tmp, tmp_len + 1, "%s.%s.", type, name);
-		SdbList *l = sdb_foreach_list (TDB, true);
-		ls_foreach (l, iter, kv) {
-			if (!strncmp (sdbkv_key (kv), tmp, tmp_len)) {
-				r_type_del (TDB, sdbkv_key (kv));
-			}
+
+	// TODO: This loop should be optimized
+	SdbList *l = sdb_foreach_list (TDB, true);
+	size_t subkey_len = strlen (subkey);
+	ls_foreach (l, iter, kv) {
+		const char *key = sdbkv_key (kv);
+		if (!strncmp (key, subkey, subkey_len)) {
+			r_type_del (TDB, key);
 		}
-		ls_free (l);
-		free (tmp);
 	}
+	ls_free (l);
+	free (subkey);
 }
 
 // RENAME TO r_anal_types_save(); // parses the string and imports the types


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
This PR fixes an issue in the type removal code that was using an invalid `char *` in an `snprintf` operation to create the name of an SDB subkey to be searched for. Consequently, we ended up iterating over all SDB keys to search for a key with the incorrect format: `.<name>.`, where the correct format should have been `<type>.<name>`.

<!-- explain your changes if necessary -->
