### PR TITLE
Fix size returned from r_anal_op ##anal

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -87,13 +87,14 @@ R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int le
 	int ret = R_MIN (2, len);
 	if (len > 0 && anal->arch->session) {
 		r_anal_op_set_bytes (op, addr, data, len);
-		bool bret = r_arch_decode (anal->arch, op, mask);
-		if (!bret) {
+		if (!r_arch_decode (anal->arch, op, mask) || op->size <= 0) {
 			op->type = R_ANAL_OP_TYPE_ILL;
 			op->size = r_anal_archinfo (anal, R_ANAL_ARCHINFO_INV_OP_SIZE);
 			if (op->size < 0) {
 				op->size = 1;
 			}
+		} else {
+			ret = op->size;
 		}
 #if 0
 		// r_arch_op_to_analop (op, &archop);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
When `r_arch_decode` is used `r_anal_op` returns 2 even if `op->size` is larger. This fixes that. 

Not sure if this is what you want, so feel free to close if it's wrong.