### PR TITLE
Fix `r2 /directory` behaviour ##shell

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1109,7 +1109,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			free (debugbackend);
 			return 1;
 		}
-		if (r_sys_chdir (argv[opt.ind])) {
+		if (!r_sys_chdir (argv[opt.ind])) {
 			R_LOG_ERROR ("Cannot open directory");
 			LISTS_FREE ();
 			free (pfile);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
