### PR TITLE
Fix typo in ios-syscalls.txt

### DIFF
--- a/libr/include/sflib/darwin-arm-64/ios-syscalls.txt
+++ b/libr/include/sflib/darwin-arm-64/ios-syscalls.txt
@@ -420,7 +420,6 @@
 422	____sigwait_nocancel
 423	__semwait_signal_nocancel
 424	__mac_mount
-424	__mac_mount
 425	__mac_get_mount
 426	__mac_getfsstat
 427	__fsgetpath


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
``__mac_mount`` was listed twice with the same number (424), so i deleted the dupe