### PR TITLE
rax2: corrects base64 encoding for null bytes

### DIFF
--- a/libr/main/rax2.c
+++ b/libr/main/rax2.c
@@ -185,7 +185,8 @@ static bool rax(RNum *num, char *str, int len, int last, ut64 *_flags, int *fm) 
 	ut8 *buf;
 	char *p, out_mode = (flags & 128)? 'I': '0';
 	int i;
-	if (!(flags & 4) || !len) {
+	// For -S and -E we do not compute the length again since it may contain null byte.
+	if ((!(flags & 4) && !(flags & 4096)) || !len) {
 		len = strlen (str);
 	}
 	if ((flags & 4)) {
@@ -472,11 +473,10 @@ dotherax:
 		r_list_free (split);
 		return true;
 	} else if (flags & (1 << 12)) { // -E
-		const int n = strlen (str);
 		/* http://stackoverflow.com/questions/4715415/base64-what-is-the-worst-possible-increase-in-space-usage */
-		char *out = calloc (1, (n + 2) / 3 * 4 + 1); // ceil(n/3)*4 plus 1 for NUL
+		char *out = calloc (1, (len + 2) / 3 * 4 + 1); // ceil(n/3)*4 plus 1 for NUL
 		if (out) {
-			r_base64_encode (out, (const ut8 *) str, n);
+			r_base64_encode (out, (const ut8 *)str, len);
 			printf ("%s%s", out, nl);
 			fflush (stdout);
 			free (out);
@@ -707,6 +707,8 @@ dotherax:
 R_API int r_main_rax2(int argc, const char **argv) {
 	int i, fm = 0;
 	int rc = 0;
+	int len = 0;
+
 	if (argc < 2) {
 		help_usage ();
 		// use_stdin (num, NULL, &fm);
@@ -716,8 +718,8 @@ R_API int r_main_rax2(int argc, const char **argv) {
 		for (i = 1; i < argc; i++) {
 			char *argv_i = strdup (argv[i]);
 			if (argv_i) {
-				r_str_unescape (argv_i);
-				if (!rax (num, argv_i, 0, i == argc - 1, &flags, &fm)) {
+				len = r_str_unescape (argv_i);
+				if (!rax (num, argv_i, len, i == argc - 1, &flags, &fm)) {
 					rc = 1;
 				}
 				free (argv_i);

--- a/test/db/tools/rax2
+++ b/test/db/tools/rax2
@@ -76,6 +76,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=r rax2 -E null byte
+FILE=-
+CMDS=rax2 -E "\x60\x00\x66\x00\x67"
+EXPECT=YABmAGc=
+RUN
+
 NAME=rax2 -S hello | rax2 -s
 FILE=-
 CMDS=!rax2 -S hello | rax2 -s


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Finish to correct #20978. Null bytes are included.
