### PR TITLE
Fix for the disappearing cursor issue in panels mode when at the bottom of the screen

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1690,10 +1690,11 @@ static void ds_print_show_cursor(RDisasmState *ds) {
 	if (!ds->show_marks) {
 		return;
 	}
+	int cursor_addr = core->offset + ds->cursor;
 	int q = core->print->cur_enabled &&
-		ds->cursor >= ds->index &&
-		ds->cursor < (ds->index + ds->asmop.size) &&
-		(core->offset + core->print->cur) == (ds->addr + core->print->cur);
+		cursor_addr >= ds->at &&
+		ds->cursor < (ds->at - core->offset + ds->asmop.buf.len);
+
 	RBreakpointItem *p = r_bp_get_at (core->dbg->bp, ds->at);
 	(void)handleMidFlags (core, ds, false);
 	if (ds->midbb) {
@@ -1706,10 +1707,10 @@ static void ds_print_show_cursor(RDisasmState *ds) {
 		res[1] = '~';
 	}
 	if (q) {
-		if (ds->cursor == ds->index) {
+		if (cursor_addr == ds->at) {
 			res[2] = '*';
 		} else {
-			int i = 2, diff = ds->cursor - ds->index;
+			int i = 2, diff = cursor_addr - ds->at;
 			if (diff > 9) {
 				res[i++] = '0' + (diff / 10);
 			}
@@ -3417,7 +3418,7 @@ static void ds_print_show_bytes(RDisasmState *ds) {
 	int oldFlags = core->print->flags;
 	char extra[128];
 	int j, k;
-	int n = (core->offset + core->print->cur) == (ds->addr + core->print->cur)? ds->index: INT_MAX;
+	int n = ds->at - core->offset;
 
 	if (!ds->show_color_bytes) {
 		core->print->flags &= ~R_PRINT_FLAGS_COLOR;


### PR DESCRIPTION


<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Follow up to #21095. That PR revealed a new problem, the cursor stops getting drawn in panels mode towards the bottom  of the screen. This PR aims to fix that. Basically, I changed some the conditions to stop relying on `ds->index` because it gets reset (back to 0) when printing if there are too many bytes.