### PR TITLE
Add esil.dfg.mapinfo and esil.dfg.maps config vars ##anal

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4160,6 +4160,8 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("esil.stats", "false", "statistics from ESIL emulation stored in sdb");
 	SETBPREF ("esil.nonull", "false", "prevent memory read, memory write at null pointer");
 	SETCB ("esil.mdev.range", "", &cb_mdevrange, "specify a range of memory to be handled by cmd.esil.mdev");
+	SETBPREF ("esil.dfg.mapinfo", "false", "use mapinfo for esil dfg");
+	SETBPREF ("esil.dfg.maps", "false", "set ro maps for esil dfg");
 
 	/* json encodings */
 	n = NODECB ("cfg.json.str", "none", &cb_jsonencoding);

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -7093,7 +7093,9 @@ static void cmd_aeg(RCore *core, int argc, char *argv[]) {
 			}
 			const char *esilstr = r_strbuf_get (&aop->esil);
 			if (R_STR_ISNOTEMPTY (esilstr)) {
-				RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilstr);
+				RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilstr,
+					r_config_get_b (core->config, "esil.dfg.mapinfo"),
+					r_config_get_b (core->config, "esil.dfg.maps"));
 				if (!dfg) {
 					r_anal_op_free (aop);
 					return;
@@ -7116,7 +7118,9 @@ static void cmd_aeg(RCore *core, int argc, char *argv[]) {
 				r_strbuf_append (sb, argv[i]);
 			}
 			char *esilexpr = r_strbuf_drain (sb);
-			RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilexpr);
+			RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilexpr,
+					r_config_get_b (core->config, "esil.dfg.mapinfo"),
+					r_config_get_b (core->config, "esil.dfg.maps"));
 			if (dfg) {
 				RAGraph *agraph = r_agraph_new_from_graph (dfg->flow, &cbs);
 				r_anal_esil_dfg_free (dfg);
@@ -7149,7 +7153,9 @@ static void cmd_aeg(RCore *core, int argc, char *argv[]) {
 			}
 			const char *esilstr = r_strbuf_get (&aop->esil);
 			if (R_STR_ISNOTEMPTY (esilstr)) {
-				RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilstr);
+				RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, esilstr,
+					r_config_get_b (core->config, "esil.dfg.mapinfo"),
+					r_config_get_b (core->config, "esil.dfg.maps"));
 				if (!dfg) {
 					r_anal_op_free (aop);
 					return;
@@ -7159,7 +7165,9 @@ static void cmd_aeg(RCore *core, int argc, char *argv[]) {
 			}
 			r_anal_op_free (aop);
 		} else {
-			RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, argv[1]);
+			RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (core->anal, NULL, argv[1],
+				r_config_get_b (core->config, "esil.dfg.mapinfo"),
+				r_config_get_b (core->config, "esil.dfg.maps"));
 			r_return_if_fail (dfg);
 			agraph = r_agraph_new_from_graph (dfg->flow, &cbs);
 			r_anal_esil_dfg_free (dfg);
@@ -7181,7 +7189,9 @@ static void cmd_aeg(RCore *core, int argc, char *argv[]) {
 		break;
 	case 'f':	// "aegf"
 	{
-		RStrBuf *filtered = r_anal_esil_dfg_filter_expr (core->anal, argv[1], argv[2]);
+		RStrBuf *filtered = r_anal_esil_dfg_filter_expr (core->anal, argv[1], argv[2],
+			r_config_get_b (core->config, "esil.dfg.mapinfo"),
+			r_config_get_b (core->config, "esil.dfg.maps"));
 		if (filtered) {
 			r_cons_printf ("%s\n", r_strbuf_get (filtered));
 			r_strbuf_free (filtered);
@@ -8109,7 +8119,9 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 			if (ret > 0) {
 				const char *arg = input + 2;
 				const char *expr = R_STRBUF_SAFEGET (&aop.esil);
-				RStrBuf *b = r_anal_esil_dfg_filter_expr (core->anal, expr, arg);
+				RStrBuf *b = r_anal_esil_dfg_filter_expr (core->anal, expr, arg,
+					r_config_get_b (core->config, "esil.dfg.mapinfo"),
+					r_config_get_b (core->config, "esil.dfg.maps"));
 				if (b) {
 					char *s = r_strbuf_drain (b);
 					r_cons_printf ("%s\n", s);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -745,6 +745,8 @@ typedef struct r_anal_esil_dfg_t {
 	RGraphNode *cur;
 	RGraphNode *old;
 	REsil *esil;
+	bool use_map_info;
+	bool use_maps;
 	bool malloc_failed;
 } RAnalEsilDFG;
 
@@ -1620,12 +1622,12 @@ R_API SdbGperf *r_anal_get_gperf_cc(const char *k);
 R_API SdbGperf *r_anal_get_gperf_types(const char *k);
 
 R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new(RAnalEsilDFG *edf, const char *c);
-R_API RAnalEsilDFG *r_anal_esil_dfg_new(RAnal *anal);
+R_API RAnalEsilDFG *r_anal_esil_dfg_new(RAnal *anal, bool use_map_info, bool use_maps);
 R_API void r_anal_esil_dfg_free(RAnalEsilDFG *dfg);
-R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *dfg, const char *expr);
+R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *dfg, const char *expr, bool use_map_info, bool use_maps);
 R_API void r_anal_esil_dfg_fold_const(RAnal *anal, RAnalEsilDFG *dfg);
 R_API RStrBuf *r_anal_esil_dfg_filter(RAnalEsilDFG *dfg, const char *reg);
-R_API RStrBuf *r_anal_esil_dfg_filter_expr(RAnal *anal, const char *expr, const char *reg);
+R_API RStrBuf *r_anal_esil_dfg_filter_expr(RAnal *anal, const char *expr, const char *reg, bool use_map_info, bool use_maps);
 R_API bool r_anal_esil_dfg_reg_is_const(RAnalEsilDFG *dfg, const char *reg);
 R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn);
 

--- a/test/unit/test_esil_dfg_filter.c
+++ b/test/unit/test_esil_dfg_filter.c
@@ -18,7 +18,7 @@ bool test_filter_regs(void) {
 	const ut64 al = r_reg_getv (anal->reg, "al");
 	r_reg_setv (anal->reg, "eax", 0);
 
-	RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (anal, NULL, "0x9090,ax,:=,0xff,ah,:=");
+	RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (anal, NULL, "0x9090,ax,:=,0xff,ah,:=", false, false);
 
 	// filter for ax register
 	RStrBuf *filtered_expr = r_anal_esil_dfg_filter (dfg, "ax");
@@ -56,7 +56,7 @@ bool test_lemon_const_folder(void) {
 	r_anal_set_bits (anal, 32);
 	r_anal_set_reg_profile (anal, NULL);
 
-	RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (anal, NULL, "4,!,3,ebx,:=,!,1,+,eax,:=");
+	RAnalEsilDFG *dfg = r_anal_esil_dfg_expr (anal, NULL, "4,!,3,ebx,:=,!,1,+,eax,:=", false, false);
 	r_anal_esil_dfg_fold_const (anal, dfg);
 	RStrBuf *filtered = r_anal_esil_dfg_filter (dfg, "eax");
 	const bool cmp_result = !strcmp (r_strbuf_get(filtered), "0x2,eax,:=");


### PR DESCRIPTION
Allows esil dfg to take into account if a specific addr is RO and read from the corresponding map instead of the treebuf fd

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
