### PR TITLE
Fix counted string bug in pickle ##arch

### DIFF
--- a/libr/include/r_arch.h
+++ b/libr/include/r_arch.h
@@ -114,7 +114,7 @@ typedef enum {
 
 typedef struct r_arch_t {
 	RList *plugins;	       // all plugins
-	RBinBind binb; // required for java, dalvik, wasm and pyc plugin... pending refactor
+	RBinBind binb; // required for java, dalvik, wasm, pickle and pyc plugin... pending refactor
 	RNum *num; // XXX maybe not required
 	struct r_arch_session_t *session;
 	RArchConfig *cfg;      // global / default config


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Pickle opcodes can have inline data. Inline data can is often preceded by a size value which can be huge.

Since the disassembler may get off track or encounter corrupted data, it needs a means of checking if an op is of reasonable size. 
Previously `RIOBind` was used to check if a op containing inline data would end in an invalid location. The refactor to RArch messed this up a bit this patch aims to fix it again.

After this patch `is_valid_offset` from RIOBind will again be used to check if opcodes fit in the file.
