### PR TITLE
Fix UAF crash when a read causes a resize of the map ##io

### DIFF
--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -792,6 +792,8 @@ R_API bool r_io_bank_read_at(RIO *io, const ut32 bankid, ut64 addr, ut8 *buf, in
 			const ut64 paddr = addr + buf_off - r_io_map_from (map) + map->delta;
 			ret &= (r_io_fd_read_at (io, map->fd, paddr, &buf[buf_off], read_len) == read_len);
 		}
+		// this should be only done when the underlying maps has changed (read call can cause resize!
+		node = _find_entry_submap_node (bank, &fake_sm);
 		// check return value here?
 		node = r_rbnode_next (node);
 		sm = node ? (RIOSubMap *)node->data : NULL;


### PR DESCRIPTION
* This may slow down r2 io, and needs to be addressed properly

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
