### PR TITLE
Fix runtime warning after leaving an rlang session ##shell

### DIFF
--- a/libr/cons/line.c
+++ b/libr/cons/line.c
@@ -86,7 +86,9 @@ R_API void r_line_completion_set(RLineCompletion *completion, int argc, const ch
 	r_return_if_fail (completion && (argc >= 0));
 	r_line_completion_clear (completion);
 	if (argc > completion->args_limit) {
-		R_LOG_WARN ("Maximum completion capacity reached, increase scr.maxtab");
+		argc = completion->args_limit;
+		R_LOG_DEBUG ("Maximum completion capacity reached, increase scr.maxtab (%d %d)",
+				argc, completion->args_limit);
 	}
 	size_t count = R_MIN (argc, completion->args_limit);
 	r_pvector_reserve (&completion->args, count);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
