### PR TITLE
Fix the XML parser ##util

### DIFF
--- a/libr/util/rxml.c
+++ b/libr/util/rxml.c
@@ -249,7 +249,7 @@ R_API void r_xml_free(RXml *x) {
 R_API RXmlRet r_xml_parse(RXml *x, int _ch) {
 	/* Ensure that characters are in the range of 0..255 rather than -126..125.
 	 * All character comparisons are done with positive integers. */
-	ut8 ch = (ut8 )(_ch + 256) & 0xff;
+	ut32 ch = (ut32)(_ch + 256) & 0xff;
 	if (!ch) {
 		return R_XML_ESYN;
 	}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [/] I've added tests (optional)
- [/] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `R_XML_IS_*()` macros assume that `ch` has more than 8 bits, so they can do clever subtraction and only perform a single comparison.

While we could add casts to those macros, the 0..255 clamping logic also seems to assume there being more than 8 bits.

So these things considered it seems to make the most sense to do what the original yxml code does, and use `unsigned`. It is also consistent with `r_xml_refend()`.