### PR TITLE
Fix JSON encoding of unsigned search values ##search

### DIFF
--- a/libr/core/cmd_search.c
+++ b/libr/core/cmd_search.c
@@ -666,7 +666,7 @@ static int _cb_hit_sz(RSearchKeyword *kw, int klen, void *user, ut64 addr) {
 
 		if (param->outmode == R_MODE_JSON) {
 			pj_o (param->pj);
-			pj_kN (param->pj, "offset", base_addr + addr);
+			pj_kn (param->pj, "offset", base_addr + addr);
 			pj_ks (param->pj, "type", type);
 			pj_ks (param->pj, "data", s);
 			pj_end (param->pj);
@@ -680,7 +680,7 @@ static int _cb_hit_sz(RSearchKeyword *kw, int klen, void *user, ut64 addr) {
 	} else if (kw) {
 		if (param->outmode == R_MODE_JSON) {
 			pj_o (param->pj);
-			pj_kN (param->pj, "offset", base_addr + addr);
+			pj_kn (param->pj, "offset", base_addr + addr);
 			pj_ki (param->pj, "len", klen);
 			pj_end (param->pj);
 		} else {
@@ -1343,7 +1343,7 @@ static void print_rop(RCore *core, RList *hitlist, PJ *pj, int mode) {
 				r_list_append (ropList, (void *) opstr_n);
 			}
 			pj_o (pj);
-			pj_kN (pj, "offset", hit->addr);
+			pj_kn (pj, "offset", hit->addr);
 			pj_ki (pj, "size", hit->len);
 			pj_ks (pj, "opcode", r_asm_op_get_asm (&asmop));
 			pj_ks (pj, "type", r_anal_optype_tostring (analop.type));
@@ -2283,7 +2283,7 @@ static void search_hit_at(RCore *core, struct search_parameters *param, RCoreAsm
 	switch (param->outmode) {
 	case R_MODE_JSON:
 		pj_o (param->pj);
-		pj_kN (param->pj, "offset", hit->addr);
+		pj_kn (param->pj, "offset", hit->addr);
 		pj_ki (param->pj, "len", hit->len);
 		pj_ks (param->pj, "code", hit->code);
 		pj_end (param->pj);
@@ -3222,8 +3222,8 @@ void _CbInRangeSearchV(RCore *core, ut64 from, ut64 to, int vsize, void *user) {
 		r_cons_printf ("0x%"PFMT64x ": 0x%"PFMT64x"\n", from, to);
 	} else {
 		pj_o (param->pj);
-		pj_kN (param->pj, "offset", from);
-		pj_kN (param->pj, "value", to);
+		pj_kn (param->pj, "offset", from);
+		pj_kn (param->pj, "value", to);
 		pj_end (param->pj);
 	}
 	r_core_cmdf (core, "f %s.value.0x%08"PFMT64x" %d = 0x%08"PFMT64x, prefix, to, vsize, to); // flag at value of hit

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -211,6 +211,32 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=/j search (cfg.json.num=hex search.show=true)
+FILE=malloc://1024
+CMDS=<<EOF
+e cfg.json.num=hex
+e search.show=true
+wx 666f6f005c
+/j foo
+EOF
+EXPECT=<<EOF
+[{"offset":"0x0","type":"string","data":"foo\\"}]
+EOF
+RUN
+
+NAME=/j search (cfg.json.num=hex search.show=false)
+FILE=malloc://1024
+CMDS=<<EOF
+e cfg.json.num=hex
+e search.show=false
+wx 666f6f005c
+/j foo
+EOF
+EXPECT=<<EOF
+[{"offset":"0x0","len":3}]
+EOF
+RUN
+
 NAME=/! search
 FILE=malloc://1024
 CMDS=<<EOF
@@ -461,6 +487,37 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=Rop search json
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch=x86
+e anal.arch=x86
+e asm.bits=32
+"wa add esp,8;pop ebx; pop ebp; ret"
+/Rj
+q
+EOF
+EXPECT=<<EOF
+[{"opcodes":[{"offset":0,"size":3,"opcode":"add esp, 8","type":"add"},{"offset":3,"size":1,"opcode":"pop ebx","type":"pop"},{"offset":4,"size":1,"opcode":"pop ebp","type":"pop"},{"offset":5,"size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":6},{"opcodes":[{"offset":1,"size":2,"opcode":"les ecx, [eax]","type":"null"},{"offset":3,"size":1,"opcode":"pop ebx","type":"pop"},{"offset":4,"size":1,"opcode":"pop ebp","type":"pop"},{"offset":5,"size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":5},{"opcodes":[{"offset":2,"size":3,"opcode":"or byte [ebx + 0x5d], bl","type":"or"},{"offset":5,"size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":4}]
+EOF
+RUN
+
+NAME=Rop search json (cfg.json.num=hex)
+FILE=malloc://1024
+CMDS=<<EOF
+e asm.arch=x86
+e anal.arch=x86
+e asm.bits=32
+e cfg.json.num=hex
+"wa add esp,8;pop ebx; pop ebp; ret"
+/Rj
+q
+EOF
+EXPECT=<<EOF
+[{"opcodes":[{"offset":"0x0","size":3,"opcode":"add esp, 8","type":"add"},{"offset":"0x3","size":1,"opcode":"pop ebx","type":"pop"},{"offset":"0x4","size":1,"opcode":"pop ebp","type":"pop"},{"offset":"0x5","size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":6},{"opcodes":[{"offset":"0x1","size":2,"opcode":"les ecx, [eax]","type":"null"},{"offset":"0x3","size":1,"opcode":"pop ebx","type":"pop"},{"offset":"0x4","size":1,"opcode":"pop ebp","type":"pop"},{"offset":"0x5","size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":5},{"opcodes":[{"offset":"0x2","size":3,"opcode":"or byte [ebx + 0x5d], bl","type":"or"},{"offset":"0x5","size":1,"opcode":"ret","type":"ret"}],"retaddr":5,"size":4}]
+EOF
+RUN
+
 NAME=Rop search w/ regexp
 FILE=malloc://1024
 CMDS=<<EOF
@@ -656,6 +713,18 @@ wx 0x12345678aabbccddeeff12345678
 EOF
 EXPECT=<<EOF
 [{"offset":0,"value":2018915346},{"offset":10,"value":2018915346}]
+EOF
+RUN
+
+NAME=/V4j search 4 byte with json (cfg.json.num=hex)
+FILE=-
+CMDS=<<EOF
+e cfg.json.num=hex
+wx 0x12345678aabbccddeeff12345678
+/V4j 0x78563412 0x78563420
+EOF
+EXPECT=<<EOF
+[{"offset":"0x0","value":"0x78563412"},{"offset":"0xa","value":"0x78563412"}]
 EOF
 RUN
 

--- a/test/db/cmd/cmd_search_asm
+++ b/test/db/cmd/cmd_search_asm
@@ -392,3 +392,30 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=match ins1 followed by ins2 in linear disasm with json output
+FILE=bins/mach0/iGoat-Swift.arm_64.1
+CMDS=<<EOF
+e search.in=range
+e search.from=0x100007e0c
+e search.to=0x100007eec
+"/adj add;ret"
+EOF
+EXPECT=<<EOF
+[{"offset":4294999692,"len":8,"code":"add sp, sp, 0x40; ret"},{"offset":4294999780,"len":8,"code":"add sp, sp, 0x30; ret"}]
+EOF
+RUN
+
+NAME=match ins1 followed by ins2 in linear disasm with json output (cfg.json.num=hex)
+FILE=bins/mach0/iGoat-Swift.arm_64.1
+CMDS=<<EOF
+e search.in=range
+e search.from=0x100007e0c
+e search.to=0x100007eec
+e cfg.json.num=hex
+"/adj add;ret"
+EOF
+EXPECT=<<EOF
+[{"offset":"0x100007e8c","len":8,"code":"add sp, sp, 0x40; ret"},{"offset":"0x100007ee4","len":8,"code":"add sp, sp, 0x30; ret"}]
+EOF
+RUN
+


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [/] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This fix means `cfg.json.num` is taken into account, and large addresses will not be encoded as negative numbers.