### PR TITLE
Add line information for Plan 9 ##bin

### DIFF
--- a/libr/anal/d/cc-arm-64.sdb.txt
+++ b/libr/anal/d/cc-arm-64.sdb.txt
@@ -25,3 +25,8 @@ cc.swift.argn=stack
 cc.swift.self=x20
 cc.swift.error=x21
 cc.swift.ret=x0
+
+p9=cc
+cc.p9.arg0=x0
+cc.p9.argn=stack
+cc.p9.ret=x0

--- a/libr/anal/d/cc-x86-64.sdb.txt
+++ b/libr/anal/d/cc-x86-64.sdb.txt
@@ -46,3 +46,8 @@ cc.amd64syscall.arg3=r10
 cc.amd64syscall.arg4=r8
 cc.amd64syscall.arg5=r9
 cc.amd64syscall.ret=rax
+
+p9=cc
+cc.p9.arg0=rbp
+cc.p9.argn=stack
+cc.p9.ret=rax

--- a/libr/bin/format/p9/p9bin.c
+++ b/libr/bin/format/p9/p9bin.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2011-2021 pancake<nopcode.org>, keegan */
+/* radare2 - MIT - Copyright 2021-2022 - pancake, keegan, Plan 9 Foundation */
 
 #include "p9bin.h"
 #include <r_asm.h>

--- a/libr/bin/format/p9/p9bin.h
+++ b/libr/bin/format/p9/p9bin.h
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2011-2021 - pancake, keegan */
+/* radare2 - LGPL - Copyright 2011-2022 - pancake, keegan */
 
 #ifndef P9BIN_H
 #define P9BIN_H
@@ -24,6 +24,8 @@ typedef struct r_bin_plan9_obj_t {
 	// use this instead of the one in the header
 	ut64 entry;
 	bool is_kernel;
+	// pc quantization per arch
+	ut64 pcq;
 } RBinPlan9Obj;
 
 /* Flag for extended header. This means that an additional 64-bit integer follows

--- a/libr/bin/format/p9/p9bin.h
+++ b/libr/bin/format/p9/p9bin.h
@@ -1,4 +1,4 @@
-/* radare2 - LGPL - Copyright 2011-2022 - pancake, keegan */
+/* radare2 - MIT - Copyright 2021-2022 - pancake, keegan, Plan 9 Foundation */
 
 #ifndef P9BIN_H
 #define P9BIN_H

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -24,6 +24,7 @@ r_bin_sources = [
   'p/bin_dbginfo_dex.c',
   'p/bin_dbginfo_elf.c',
   'p/bin_dbginfo_elf64.c',
+  'p/bin_dbginfo_p9.c',
   'p/bin_dex.c',
   'p/bin_dmp64.c',
   'p/bin_dol.c',

--- a/libr/bin/p/bin_dbginfo_p9.c
+++ b/libr/bin/p/bin_dbginfo_p9.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2022 - nibble, montekki, pancake, keegan */
+/* radare - LGPL - Copyright 2009-2022 - nibble, montekki, pancake */
 
 #include <r_bin.h>
 

--- a/libr/bin/p/bin_dbginfo_p9.c
+++ b/libr/bin/p/bin_dbginfo_p9.c
@@ -1,0 +1,25 @@
+/* radare - LGPL - Copyright 2009-2022 - nibble, montekki, pancake, keegan */
+
+#include <r_bin.h>
+
+static bool get_line(RBinFile *bf, ut64 addr, char *file, int len, int *line) {
+	if (bf->sdb_addrinfo) {
+		char offset[SDB_NUM_BUFSZ];
+		char *offset_ptr = sdb_itoa (addr, 16, offset, sizeof (offset));
+		char *ret = sdb_get (bf->sdb_addrinfo, offset_ptr, 0);
+		if (ret) {
+			char *p = strchr (ret, '|');
+			if (p) {
+				*p = '\0';
+				strncpy (file, ret, len);
+				*line = atoi (p + 1);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+RBinDbgInfo r_bin_dbginfo_p9 = {
+	.get_line = &get_line,
+};

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -371,6 +371,7 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->bclass = strdup ("program");
 	ret->rclass = strdup ("p9");
 	ret->os = strdup ("Plan9");
+	ret->default_cc = strdup ("p9");
 	ret->arch = strdup (r_sys_arch_str (arch));
 	ret->machine = strdup (ret->arch);
 	ret->subsystem = strdup ("plan9");

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -9,6 +9,8 @@
 #undef P9_ALIGN
 #define P9_ALIGN(address, align) (((address) + (align - 1)) & ~(align - 1))
 
+extern struct r_bin_dbginfo_t r_bin_dbginfo_p9;
+
 static bool check_buffer(RBinFile *bf, RBuffer *buf) {
 	RSysArch arch;
 	int bits, big_endian;
@@ -41,6 +43,29 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 
 	// kernels require different maps (see uses for details)
 	o->is_kernel = o->entry & KERNEL_MASK;
+
+	// each arch has a pc quantization used for line-number calculation
+	switch (o->header.magic) {
+	case MAGIC_AMD64:
+	case MAGIC_INTEL_386:
+		o->pcq = 1;
+		break;
+	case MAGIC_68020:
+		o->pcq = 2;
+		break;
+	case MAGIC_ARM64:
+	case MAGIC_PPC64:
+	case MAGIC_SPARC:
+	case MAGIC_SPARC64:
+	case MAGIC_MIPS_3000BE:
+	case MAGIC_MIPS_4000BE:
+	case MAGIC_MIPS_4000LE:
+	case MAGIC_MIPS_3000LE:
+	case MAGIC_ARM:
+	case MAGIC_PPC:
+		o->pcq = 4;
+		break;
+	}
 
 	if (bin_obj) {
 		*bin_obj = o;
@@ -216,11 +241,11 @@ static RList *sections(RBinFile *bf) {
 	phys += ptr->size;
 	vsize += ptr->vsize;
 
-	// add spsz segment
+	// add pc/sp offsets segment
 	if (!(ptr = R_NEW0 (RBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup ("spsz");
+	ptr->name = strdup ("pcsp");
 	ptr->size = o->header.spsz;
 	ptr->vsize = P9_ALIGN (o->header.spsz, align);
 	ptr->paddr = phys;
@@ -231,11 +256,11 @@ static RList *sections(RBinFile *bf) {
 	phys += ptr->size;
 	vsize += ptr->vsize;
 
-	// add pcsz segment
+	// add pc/line numbers segment
 	if (!(ptr = R_NEW0 (RBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup ("pcsz");
+	ptr->name = strdup ("pcline");
 	ptr->size = o->header.pcsz;
 	ptr->vsize = P9_ALIGN (o->header.pcsz, align);
 	ptr->paddr = phys;
@@ -247,66 +272,217 @@ static RList *sections(RBinFile *bf) {
 	return ret;
 }
 
-static RList *symbols(RBinFile *bf) {
-	RList *ret = NULL;
-	RBinPlan9Obj *o = (RBinPlan9Obj *)bf->o->bin_obj;
+typedef struct {
+	ut64 value;
+	char type;
+	char *name;
+} Sym;
 
-	if (!(ret = r_list_newf (free))) {
-		return NULL;
+static st64 sym_read(RBinFile *bf, Sym *sym, const ut64 offset) {
+	st64 size = 0;
+	const RBinPlan9Obj *o = (RBinPlan9Obj *)bf->o->bin_obj;
+	const ut64 syms = o->header_size + o->header.text + o->header.data;
+
+	ut64 value;
+	if (o->header.magic & HDR_MAGIC) {
+		// for 64-bit binaries the value type is 8 bytes
+		value = r_buf_read_be64_at (bf->buf, syms + offset);
+		if (value == UT64_MAX) {
+			return -1;
+		}
+		size += sizeof (ut64);
+	} else {
+		value = (ut64)r_buf_read_be32_at (bf->buf, syms + offset);
+		if (value == UT32_MAX) {
+			return -1;
+		}
+		size += sizeof (ut32);
 	}
 
-	ut64 syms = o->header_size + o->header.text + o->header.data;
+	const ut8 typ = r_buf_read8_at (bf->buf, syms + offset + size);
+	if (typ == UT8_MAX) {
+		return -1;
+	}
+	size += sizeof (typ);
+	const char type = typ & 0x7f;
+
+	char *name = r_buf_get_string (bf->buf, syms + offset + size);
+	if (!name) {
+		return -1;
+	}
+	size += strlen (name) + 1;
+
+	sym->value = value;
+	sym->type = type;
+	sym->name = name;
+	return size;
+}
+
+static void sym_fini(void *sym, void *user) {
+	(void)user;
+	Sym *s = (Sym *)sym;
+	if (s && s->name) {
+		free (s->name);
+		s->name = NULL;
+	}
+}
+
+static int apply_history(RBinFile *bf, ut64 pc, ut64 line, Sym *base, Sym **ret) {
+	// start of current level
+	Sym *start;
+	// current entry
+	Sym *h;
+	// sum of size of files this level
+	st64 delta;
+	int k;
+
+	// see fline in libmach
+	start = base;
+	h = base;
+	delta = h->value;
+	while (h && h->name && line > h->value) {
+		if (strlen (h->name)) {
+			if (start == base)
+				start = h++;
+			else {
+				k = apply_history (bf, pc, line, start, &h);
+				if (k <= 0) {
+					return k;
+				}
+			}
+		} else {
+			if (start == base) {
+				// end of recursion level
+				if (ret) {
+					*ret = h;
+				}
+				return 1;
+			} else {
+				// end of included file
+				delta += h->value - start->value;
+				h++;
+				start = base;
+			}
+		}
+	}
+
+	if (!h) {
+		return -1;
+	}
+
+	char *name = h->name? start->name: "<unknown>";
+	if (start != base) {
+		line = line - start->value + 1;
+	} else {
+		line = line - delta + 1;
+	}
+
+	char buffer[SDB_NUM_BUFSZ] = {0};
+	char *line_info = r_str_newf ("%s|%"PFMT64d, name, line);
+	char *address = sdb_itoa (pc, 16, buffer, sizeof (buffer));
+	sdb_set (bf->sdb_addrinfo, address, line_info, 0);
+	sdb_set (bf->sdb_addrinfo, line_info, address, 0);
+	free (line_info);
+	return 0;
+}
+
+static RList *symbols(RBinFile *bf) {
+	RList *ret = NULL;
+	RVector *history = NULL; // <Sym>
+	HtUP *histories = NULL; // <ut64, RVector<Sym> *>
+	RPVector *names = NULL; // <char *>
+	const RBinPlan9Obj *o = (RBinPlan9Obj *)bf->o->bin_obj;
+	ut64 i;
+	Sym sym = {0};
+
+	if (!(ret = r_list_newf (free))) {
+		goto error;
+	}
+
+	if (!(histories = ht_up_new0 ())) {
+		goto error;
+	}
+
+	if (!(names = r_pvector_new (NULL))) {
+		goto error;
+	}
+
+	const ut64 syms = o->header_size + o->header.text + o->header.data;
+
+	if (!bf->sdb_addrinfo && o->header.syms && o->header.pcsz) {
+		bf->sdb_addrinfo = sdb_new0 ();
+	}
 
 	ut64 offset = 0;
 	while (offset < o->header.syms) {
-		ut64 value;
-		if (o->header.magic & HDR_MAGIC) {
-			// for 64-bit binaries the value type is 8 bytes
-			value = r_buf_read_be64_at (bf->buf, syms + offset);
-			if (value == UT64_MAX) {
-				goto error;
-			}
-			offset += sizeof (ut64);
-		} else {
-			value = (ut64)r_buf_read_be32_at (bf->buf, syms + offset);
-			if (value == UT32_MAX) {
-				goto error;
-			}
-			offset += sizeof (ut32);
-		}
-
-		const ut8 typ = r_buf_read8_at (bf->buf, syms + offset);
-		if (typ == UT8_MAX) {
+		const st64 size = sym_read (bf, &sym, offset);
+		if (size == -1) {
 			goto error;
 		}
-		offset += sizeof (typ);
-		const char type = typ & 0x7f;
+		offset += size;
 
-		char *name = r_buf_get_string (bf->buf, syms + offset);
-		if (!name) {
-			goto error;
+		// source file name components
+		if (sym.type == 'f') {
+			if (r_pvector_length (names) < sym.value) {
+				r_pvector_reserve (names, sym.value);
+				// reserve zeros so this is safe
+				names->v.len = sym.value;
+			}
+
+			r_pvector_set (names, sym.value - 1, sym.name);
+			continue;
 		}
-		offset += strlen (name) + 1;
 
-		// source file names or source file line offsets contain additional details
-		if (type == 'Z' || type == 'z') {
-			// look for two adjacent zeros to terminate the sequence
-			ut64 j, fin = (o->header.syms > offset)? o->header.syms - offset: 0;
-			for (j = 0; j < fin; j++) {
-				ut16 data = r_buf_read_be16_at (bf->buf, syms + offset + j);
-				if (data == UT16_MAX) {
+		// source file name
+		if (sym.type == 'z') {
+			// make a /-delim name
+			RStrBuf *sb = r_strbuf_new (NULL);
+
+			ut64 fin = (o->header.syms > offset)? o->header.syms - offset: 0;
+			for (i = 0; i < fin; i += sizeof (ut16)) {
+				ut16 index = r_buf_read_be16_at (bf->buf, syms + offset + i);
+				if (index == UT16_MAX) {
+					r_strbuf_free (sb);
 					goto error;
 				}
 
-				if (data == 0) {
-					offset += j + sizeof (ut16);
+				// read indices until a zero index
+				if (index == 0) {
+					offset += i + sizeof (ut16);
 					break;
 				}
+
+				char *name = r_pvector_at (names, index - 1);
+				r_strbuf_appendf (sb, "%s", name);
+				// lead / is NOT assumed
+				if (i != 0) {
+					r_strbuf_append (sb, "/");
+				}
 			}
+
+			char *name = r_strbuf_drain (sb);
+			size_t name_size = strlen (name);
+			// pop final /
+			if (name_size) {
+				name[name_size - 1] = '\0';
+			}
+
+			// a new history
+			if (sym.value == 1 && history) {
+				history = NULL;
+			}
+
+			if (!history) {
+				history = r_vector_new (sizeof (Sym), sym_fini, NULL);
+			}
+
+			Sym history_sym = {sym.value, 'z', name};
+			r_vector_push (history, &history_sym);
+			continue;
 		}
 
 		// skip non symbol information
-		switch (type) {
+		switch (sym.type) {
 		case 'T':
 		case 't':
 		case 'L':
@@ -316,31 +492,90 @@ static RList *symbols(RBinFile *bf) {
 		case 'B':
 		case 'b':
 			break;
+		// TODO: source file line offset
+		case 'Z':
+			// fallthrough
 		default:
+			sym_fini (&sym, NULL);
 			continue;
 		}
 
-		RBinSymbol *ptr = R_NEW0 (RBinSymbol);
-		if (!ptr) {
-			free (name);
+		RBinSymbol *bin_sym = R_NEW0 (RBinSymbol);
+		if (!bin_sym) {
 			goto error;
 		}
 
-		ptr->name = name;
-		ptr->paddr = value - baddr (bf);
+		bin_sym->name = sym.name;
+		bin_sym->paddr = sym.value - baddr (bf);
 		// for kernels the header is not mapped
 		if (o->is_kernel) {
-			ptr->paddr += o->header_size;
+			bin_sym->paddr += o->header_size;
 		}
-		ptr->vaddr = value;
-		ptr->size = 0;
-		ptr->ordinal = 0;
-		r_list_append (ret, ptr);
+		bin_sym->vaddr = sym.value;
+		bin_sym->size = 0;
+		bin_sym->ordinal = 0;
+		r_list_append (ret, bin_sym);
+
+		if (history) {
+			ht_up_insert (histories, bin_sym->vaddr, history);
+		}
 	}
 
+	history = NULL;
+
+	const ut64 pcs = syms + o->header.syms + o->header.spsz;
+
+	ut64 line = 0;
+	// base address (for kernels the header is NOT mapped)
+	ut64 pc = baddr (bf) + (o->is_kernel? 0: o->header_size) - o->pcq;
+
+	offset = 0;
+	while (offset < o->header.pcsz) {
+		RVector *h = ht_up_find (histories, pc + o->pcq, NULL);
+		if (h) {
+			history = h;
+		}
+
+		ut64 prev = line;
+
+		const ut8 b = r_buf_read8_at (bf->buf, pcs + offset);
+		if (b == UT8_MAX) {
+			goto error;
+		}
+		offset += sizeof (ut8);
+
+		// see pc2line in libmach
+		if (b == 0) {
+			ut32 d = r_buf_read_be32_at (bf->buf, pcs + offset);
+			if (d == UT32_MAX) {
+				goto error;
+			}
+			line += (st32)d;
+			offset += sizeof (ut32);
+		} else if (b < 65) {
+			line += b;
+		} else if (b < 129) {
+			line -= b - 64;
+		} else {
+			pc += o->pcq * (b - 129);
+		}
+
+		pc += o->pcq;
+
+		if (prev != line && r_vector_length (history) > 1) {
+			apply_history (bf, pc, line, r_vector_at (history, 0), NULL);
+		}
+	}
+
+	sym_fini (&sym, NULL);
+	ht_up_free (histories);
+	r_pvector_free (names);
 	return ret;
 error:
+	sym_fini (&sym, NULL);
 	r_list_free (ret);
+	r_pvector_free (names);
+	ht_up_free (histories);
 	return NULL;
 }
 
@@ -358,8 +593,13 @@ static RBinInfo *info(RBinFile *bf) {
 	RBinInfo *ret = NULL;
 	RSysArch arch;
 	int bits, big_endian;
+	struct plan9_exec header;
 
 	if (!r_bin_p9_get_arch (bf->buf, &arch, &bits, &big_endian)) {
+		return NULL;
+	}
+
+	if (r_buf_fread_at (bf->buf, 0, (ut8 *)&header, "IIIIIIII", 1) != sizeof (header)) {
 		return NULL;
 	}
 
@@ -380,6 +620,15 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->has_va = true;
 	ret->big_endian = big_endian;
 	ret->dbg_info = 0;
+	if (header.syms) {
+		ret->dbg_info |= R_BIN_DBG_SYMS;
+	}
+	if (header.pcsz) {
+		ret->dbg_info |= R_BIN_DBG_LINENUMS;
+	}
+	if (!ret->dbg_info) {
+		ret->dbg_info |= R_BIN_DBG_STRIPPED;
+	}
 	return ret;
 }
 
@@ -453,6 +702,7 @@ RBinPlugin r_bin_plugin_p9 = {
 	.imports = &imports,
 	.info = &info,
 	.libs = &libs,
+	.dbginfo = &r_bin_dbginfo_p9,
 	.create = &create,
 };
 

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -61,7 +61,7 @@ static ut64 baddr(RBinFile *bf) {
 		// if this is an arm64 kernel: check mask and return known
 		// base address. see libmach for definitions.
 		if (o->is_kernel) {
-			return 0xffffffff80000000ULL;
+			return 0xffffffffc0080000ULL;
 		}
 		return 0x10000ULL;
 	case MAGIC_AMD64:

--- a/libr/bin/p/p9.mk
+++ b/libr/bin/p/p9.mk
@@ -1,4 +1,4 @@
-OBJ_P9=bin_p9.o ../format/p9/p9bin.o
+OBJ_P9=bin_p9.o bin_dbginfo_p9.o ../format/p9/p9bin.o
 
 STATIC_OBJ+=${OBJ_P9}
 TARGET_P9=bin_p9.${EXT_SO}

--- a/test/db/cmd/cmd_afcl
+++ b/test/db/cmd/cmd_afcl
@@ -10,6 +10,7 @@ EXPECT=<<EOF
 amd64
 amd64syscall
 ms
+p9
 reg
 swift
 EOF
@@ -73,6 +74,7 @@ afcl
 EOF
 EXPECT=<<EOF
 arm64
+p9
 reg
 swift
 EOF

--- a/test/db/cmd/cmd_ara
+++ b/test/db/cmd/cmd_ara
@@ -93,6 +93,7 @@ EXPECT=<<EOF
 amd64
 amd64syscall
 ms
+p9
 reg
 swift
 r0 reg(r0, r1, r2, r3)
@@ -100,6 +101,7 @@ rax reg(rdi, rsi, rdx, rcx)
 amd64
 amd64syscall
 ms
+p9
 reg
 swift
 EOF

--- a/test/db/cmd/cmd_tcc
+++ b/test/db/cmd/cmd_tcc
@@ -9,6 +9,7 @@ EXPECT=<<EOF
 amd64
 amd64syscall
 ms
+p9
 reg
 swift
 EOF
@@ -21,6 +22,7 @@ EXPECT=<<EOF
 amd64
 amd64syscall
 ms
+p9
 reg
 swift
 EOF
@@ -34,15 +36,17 @@ tccl
 tcc*
 EOF
 EXPECT=<<EOF
-{"amd64":{"ret":"rax","signature":"rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","args":["rdi","rsi","rdx","rcx","r8","r9","xmm0","xmm1","xmm2","xmm3","xmm4"]},"amd64syscall":{"ret":"rax","signature":"rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);","args":["rdi","rsi","rdx","r10","r8","r9"]},"ms":{"ret":"rax","signature":"rax ms (rcx, rdx, r8, r9, stack);","args":["rcx","rdx","r8","r9"],"argn":"stack"},"reg":{"ret":"rax","signature":"rax reg (rdi, rsi, rdx, rcx);","args":["rdi","rsi","rdx","rcx"]},"swift":{"ret":"rax","signature":"rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;","args":["rdi","rsi","rdx","rcx","r8","r9","xmm0","xmm1","xmm2","xmm3","xmm4"],"error":"r12"}}
+{"amd64":{"ret":"rax","signature":"rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);","args":["rdi","rsi","rdx","rcx","r8","r9","xmm0","xmm1","xmm2","xmm3","xmm4"]},"amd64syscall":{"ret":"rax","signature":"rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);","args":["rdi","rsi","rdx","r10","r8","r9"]},"ms":{"ret":"rax","signature":"rax ms (rcx, rdx, r8, r9, stack);","args":["rcx","rdx","r8","r9"],"argn":"stack"},"p9":{"ret":"rax","signature":"rax p9 (rbp, stack);","args":["rbp"],"argn":"stack"},"reg":{"ret":"rax","signature":"rax reg (rdi, rsi, rdx, rcx);","args":["rdi","rsi","rdx","rcx"]},"swift":{"ret":"rax","signature":"rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;","args":["rdi","rsi","rdx","rcx","r8","r9","xmm0","xmm1","xmm2","xmm3","xmm4"],"error":"r12"}}
 rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
 rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
 rax ms (rcx, rdx, r8, r9, stack);
+rax p9 (rbp, stack);
 rax reg (rdi, rsi, rdx, rcx);
 rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
 tcc rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
 tcc rax amd64syscall (rdi, rsi, rdx, r10, r8, r9);
 tcc rax ms (rcx, rdx, r8, r9, stack);
+tcc rax p9 (rbp, stack);
 tcc rax reg (rdi, rsi, rdx, rcx);
 tcc rax r13.swift (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4) r12;
 EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

* Fix load address of Plan 9 arm64 kernels
* Add Plan 9 calling convention for arm64 and x86-64
* Add Plan 9 line number information

Additionally, since I have rewritten the Plan 9 bin plugin entirely from its original state, with your blessing pancake I'd like to relicense it to be an MIT plugin like the Plan 9 source itself (we now borrow the line recovery algorithms from the source, specifically `hline` and `pc2line` from `sym.c` in `libmach` so I've added the foundation to the copyright header).


<!-- explain your changes if necessary -->
