### PR TITLE
Debug UX improvements

### DIFF
--- a/libr/bin/dbginfo.c
+++ b/libr/bin/dbginfo.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2020 - nibble, pancake */
+/* radare - LGPL - Copyright 2009-2020 - nibble, pancake, keegan */
 
 #include <r_types.h>
 #include <r_bin.h>
@@ -17,7 +17,7 @@ R_API bool r_bin_addr2line(RBin *bin, ut64 addr, char *file, int len, int *line)
 			}
 		}
 	}
-	return false;
+	return r_bin_addr2line2 (bin, addr, file, len, line);
 }
 
 R_API bool r_bin_addr2line2(RBin *bin, ut64 addr, char *file, int len, int *line) {
@@ -45,112 +45,52 @@ R_API bool r_bin_addr2line2(RBin *bin, ut64 addr, char *file, int len, int *line
 }
 
 R_API char *r_bin_addr2text(RBin *bin, ut64 addr, int origin) {
-	r_return_val_if_fail (bin, NULL);
-	char file[4096];
-	int line;
-	char *out = NULL, *out2 = NULL;
-	char *file_nopath = NULL;
-	if (!bin->cur) {
-		return NULL;
-	}
-	char *key = r_str_newf ("0x%"PFMT64x, addr);
-	char *file_line = sdb_get (bin->cur->sdb_addrinfo, key, 0);
-	if (file_line) {
-		char *token = strchr (file_line, '|');
-		if (token) {
-			*token++ = 0;
-			line = atoi (token);
-			bool found = true;
-			const char *filename = file_line;
-			char *nf = NULL;
-			if (!r_file_exists (file_line)) {
-				const char *bn = r_file_basename (file_line);
-				// TODO: use dir.source
-				if (r_file_exists (bn)) {
-					filename = bn;
-				} else {
-					nf = r_str_newf ("%s/%s", bin->srcdir, bn);
-					if (r_file_exists (bn)) {
-						filename = nf;
-					} else {
-						found = false;
-						// R_LOG_WARN ("Cannot find %s", filename);
-						// return NULL;
-					}
-				}
-			}
-			if (found) {
-				out = r_file_slurp_line (filename, line, 0);
-				*token++ = ':';
-				free (nf);
-			}
-		} else {
-			return file_line;
-		}
-	}
-	free (key);
-	if (out) {
-		if (origin > 1) {
-			file_nopath = file_line;
-		} else {
-			file_nopath = strrchr (file_line, '/');
-			if (file_nopath) {
-				file_nopath++;
-			} else {
-				file_nopath = file_line;
-			}
-		}
-		if (origin) {
-			char *res = r_str_newf ("%s:%d%s%s",
-					r_str_get (file_nopath),
-					line, file_nopath? " ": "",
-					r_str_get (out));
-			free (out);
-			out = res;
-		}
-		free (file_line);
-		return out;
-	}
-	R_FREE (file_line);
+	r_return_val_if_fail (bin && bin->cur, NULL);
+	char path[4096] = {0};
+	int line_number;
+	char *line = NULL;
+	char *basename = NULL;
 
-	file[0] = 0;
-	if (r_bin_addr2line (bin, addr, file, sizeof (file), &line)) {
-		if (bin->srcdir && *bin->srcdir) {
-			char *slash = strrchr (file, '/');
-			char *nf = r_str_newf ("%s/%s", bin->srcdir, slash? slash + 1: file);
-			strncpy (file, nf, sizeof (file) - 1);
-			free (nf);
-		}
-		// TODO: this is slow. must use a cached pool of mapped files and line:off entries
-		out = r_file_slurp_line (file, line, 0);
-		if (!out) {
-			if (origin > 1) {
-				file_nopath = file;
-			} else {
-				file_nopath = strrchr (file, '/');
-				if (file_nopath) {
-					file_nopath++;
-				} else {
-					file_nopath = file;
-				}
-			}
-			return r_str_newf ("%s:%d", r_str_get (file_nopath), line);
-		}
-		out2 = malloc ((strlen (file) + 64 + strlen (out)) * sizeof (char));
-		if (origin > 1) {
-			file_nopath = NULL;
+	if (r_bin_addr2line (bin, addr, path, sizeof (path), &line_number)) {
+		char *source = NULL;
+		// if we have a source dir, prepend the full file name
+		if (strlen (bin->srcdir)) {
+			source = r_str_newf ("%s/%s", bin->srcdir, path);
 		} else {
-			file_nopath = strrchr (file, '/');
+			// otherwise use the original name
+			source = strdup (path);
 		}
-		if (origin) {
-			snprintf (out2, strlen (file) + 63 + strlen (out), "%s:%d%s%s",
-				file_nopath? file_nopath + 1: file, line, *out? " ": "", out);
-		} else {
-			snprintf (out2, 64, "%s", out);
+
+		if (r_file_exists (source)) {
+			// TODO: use a cached pool of files and line entries
+			line = r_file_slurp_line (source, line_number, 0);
 		}
-		free (out);
+
+		free (source);
 	}
-	return out2;
+
+	if (line) {
+		if (origin > 1) {
+			basename = path;
+		} else {
+			// if there is a / use the basename. e.g. /usr/src/example.c becomes example.c
+			basename = strrchr (path, '/');
+			if (basename) {
+				basename++;
+			} else {
+				basename = path;
+			}
+		}
+
+		if (origin) {
+			char *debug_line = r_str_newf ("%s:%d: %s", r_str_get (basename),
+				line_number, r_str_get (line));
+			free (line);
+			line = debug_line;
+		}
+		return line;
+	}
+	return NULL;
 }
 
 R_API char *r_bin_addr2fileline(RBin *bin, ut64 addr) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6580,9 +6580,6 @@ R_API int r_core_print_disasm_json(RCore *core, ut64 addr, ut8 *buf, int nb_byte
 			int line;
 			char file[1024];
 			bool ret = r_bin_addr2line (core->bin, at, file, sizeof (file) - 1, &line);
-			if (!ret) {
-				ret = r_bin_addr2line2 (core->bin, at, file, sizeof (file) - 1, &line);
-			}
 			if (ret) {
 				pj_ko (pj, "addrline");
 				pj_ks (pj, "file", file);

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -812,9 +812,9 @@ R_API RBinSection *r_bin_get_section_at(RBinObject *o, ut64 off, int va);
 
 /* dbginfo.c */
 R_API bool r_bin_addr2line(RBin *bin, ut64 addr, char *file, int len, int *line);
-R_API bool r_bin_addr2line2(RBin *bin, ut64 addr, char *file, int len, int *line);
+R_DEPRECATE R_API bool r_bin_addr2line2(RBin *bin, ut64 addr, char *file, int len, int *line);
 R_API char *r_bin_addr2text(RBin *bin, ut64 addr, int origin);
-R_API char *r_bin_addr2fileline(RBin *bin, ut64 addr);
+R_DEPRECATE R_API char *r_bin_addr2fileline(RBin *bin, ut64 addr);
 /* bin_write.c */
 R_API bool r_bin_wr_addlib(RBin *bin, const char *lib);
 R_API ut64 r_bin_wr_scn_resize(RBin *bin, const char *name, ut64 size);

--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -127,6 +127,9 @@ R_API int r_reg_type_by_name(const char *str) {
 	if (!strcmp (str, "all")) {
 		return R_REG_TYPE_ALL;
 	}
+	if (!strcmp (str, "xmm")) {
+		return R_REG_TYPE_VEC128;
+	}
 	return -1;
 }
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

    Fix loading source files with dir.source ##debug

    * Deprecate addr2line2 because addr2line should instead do this
    * Deprecate r_bin_addr2fileline because it is unused and users
      should use addr2line instead
    * Clean up the code in addr2text to use addr2line. Now it can handle
      get_line debug directives, whereas it previously only used the
      sdb_addrinfo table
    * Preprend the FULL PATH with dir.source instead of basename
    
---

    Handle aarch64 XMM register profile ##debug

    When using aarch64 QEMU I had failing assertions in my terminal.
    I inspected the output of the register profile and found that it
    was failing on:

            xmm     v0      .128    .2144   0
            xmm     v1      .128    .2272   0
            xmm     v2      .128    .2400   0
            xmm     v3      .128    .2528   0

    The previous entries, which are `gpr`, are handled. Instead of adding
    `xmm` back to the table, we can instead convert it into the `vec128`
    counterpart. I wonder which other entries are missing.
