### PR TITLE
Cleanup in libr/anal/op.c ##analysis

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -570,7 +570,7 @@ static const struct op_family of[] = {
 
 R_API int r_anal_op_family_from_string(const char *f) {
 	size_t i;
-	for (i = 0; i < sizeof (of) / sizeof (of[0]); i ++) {
+	for (i = 0; i < R_ARRAY_SIZE (of); i ++) {
 		if (!strcmp (f, of[i].name)) {
 			return of[i].id;
 		}

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -641,9 +641,17 @@ R_API const char *r_anal_op_direction_tostring(RAnalOp *op) {
 	if (!op) {
 		return "none";
 	}
-	int d = op->direction;
-	return d == 1 ? "read"
-		: d == 2 ? "write"
-		: d == 4 ? "exec"
-		: d == 8 ? "ref": "none";
+	switch (op->direction) {
+	case R_ANAL_OP_DIR_READ:
+		return "read";
+	case R_ANAL_OP_DIR_WRITE:
+		return "write";
+	case R_ANAL_OP_DIR_EXEC:
+		return "exec";
+	case R_ANAL_OP_DIR_REF:
+		return "ref";
+	default:
+		break;
+	}
+	return "none";
 }

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -557,15 +557,15 @@ struct op_family {
 };
 
 static const struct op_family of[] = {
-	{ "cpu", R_ANAL_OP_FAMILY_CPU},
-	{ "fpu", R_ANAL_OP_FAMILY_FPU},
-	{ "vec", R_ANAL_OP_FAMILY_VEC},
-	{ "priv", R_ANAL_OP_FAMILY_PRIV},
-	{ "virt", R_ANAL_OP_FAMILY_VIRT},
-	{ "crypto", R_ANAL_OP_FAMILY_CRYPTO},
-	{ "io", R_ANAL_OP_FAMILY_IO},
-	{ "sec", R_ANAL_OP_FAMILY_SECURITY},
-	{ "thread", R_ANAL_OP_FAMILY_THREAD},
+	{ "cpu", R_ANAL_OP_FAMILY_CPU },
+	{ "fpu", R_ANAL_OP_FAMILY_FPU },
+	{ "vec", R_ANAL_OP_FAMILY_VEC },
+	{ "priv", R_ANAL_OP_FAMILY_PRIV },
+	{ "virt", R_ANAL_OP_FAMILY_VIRT },
+	{ "crypto", R_ANAL_OP_FAMILY_CRYPTO },
+	{ "io", R_ANAL_OP_FAMILY_IO },
+	{ "sec", R_ANAL_OP_FAMILY_SECURITY },
+	{ "thread", R_ANAL_OP_FAMILY_THREAD },
 };
 
 R_API int r_anal_op_family_from_string(const char *f) {


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

---

 - Make r_anal_optype_{to,from}_string use the same optypes array ##analysis
 - Balance spacings in braces ##indent
 - Use R_ARRAY_SIZE in r_anal_op_family_from_string
 -  Use R_ANAL_OP_DIR* enum value instead of hardcoded values
