### PR TITLE
Use an authorized API call for the abi job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,7 +539,10 @@ jobs:
         path: /tmp
     - name: Download latest release
       run: |
-        DOWNLOAD_URL=$(curl -s https://api.github.com/repos/radareorg/radare2/releases/latest | jq -r '.assets[] | select(.name | startswith("radare2")) | select(.name | endswith("static.tar.xz")) | .browser_download_url')
+        DOWNLOAD_URL=$(curl -s \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        https://api.github.com/repos/radareorg/radare2/releases/latest \
+        | jq -r '.assets[] | select(.name | startswith("radare2")) | select(.name | endswith("static.tar.xz")) | .browser_download_url')
         wget -O r2-static-latest.tar.xz $DOWNLOAD_URL
     - name: Untar
       run: |


### PR DESCRIPTION


<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

This should increase the number of allowed api requests from 60 to 1000. So hopefully, we don't get any failed api calls anymore.
[Link to the doc](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)