### PR TITLE
Mark libgdbr_t.server_debug field as deprecated

### DIFF
--- a/shlr/gdb/include/libgdbr.h
+++ b/shlr/gdb/include/libgdbr.h
@@ -184,7 +184,7 @@ typedef struct libgdbr_t {
 	int remote_type;
 	bool no_ack;
 	bool is_server;
-	bool server_debug; // deprecated
+	R_DEPRECATE bool server_debug; // R2_590 no usages, to be removed
 	bool get_baddr;
 	libgdbr_stop_reason_t stop_reason;
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge

**Description**

After merging #21237 mark `libgdbr_t.server_debug` field as deprecated to be removed during next ABI change.
