### PR TITLE
Use ut64 for bin bind offsets ##bin #if R2_590

### DIFF
--- a/libr/anal/p/anal_dalvik.c
+++ b/libr/anal/p/anal_dalvik.c
@@ -6,7 +6,7 @@
 #define GETWIDE "32,v%u,<<,v%u,|"
 #define SETWIDE "DUP,v%u,=,32,SWAP,>>,v%u,="
 
-static inline int _anal_get_offset(RAnal *a, int type, int idx) {
+static inline ut64 _anal_get_offset(RAnal *a, int type, int idx) {
 	if (a && a->binb.bin && a->binb.get_offset) {
 		return a->binb.get_offset (a->binb.bin, type, idx);
 	}
@@ -523,7 +523,7 @@ static int dalvik_disassemble(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			vB = (buf[3] << 8) | buf[2];
 			if (buf[0] == 0x1a) {
 				offset = _anal_get_offset (a, 's', vB);
-				if (offset == -1) {
+				if (offset == UT64_MAX) {
 					snprintf (str, sizeof (str), " v%i, string+%i", vA, vB);
 				} else {
 					snprintf (str, sizeof (str), " v%i, 0x%"PFMT64x, vA, offset);
@@ -550,7 +550,7 @@ static int dalvik_disassemble(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			vB = (buf[1] & 0xf0) >> 4;
 			vC = (buf[3]<<8) | buf[2];
 			offset = _anal_get_offset (a, 'o', vC);
-			if (offset == -1) {
+			if (offset == UT64_MAX) {
 				snprintf (str, sizeof (str), " v%i, v%i, [obj+%04x]", vA, vB, vC);
 			} else {
 				snprintf (str, sizeof (str), " v%i, v%i, [0x%"PFMT64x"]", vA, vB, offset);
@@ -561,7 +561,7 @@ static int dalvik_disassemble(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			vA = (int) buf[1];
 			vB = (buf[3] << 8) | buf[2];
 			offset = _anal_get_offset (a, 't', vB);
-			if (offset == -1) {
+			if (offset == UT64_MAX) {
 				snprintf (str, sizeof (str), " v%i, thing+%i", vA, vB);
 			} else {
 				snprintf (str, sizeof (str), " v%i, 0x%"PFMT64x, vA, offset);
@@ -593,7 +593,7 @@ static int dalvik_disassemble(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			vA = (int) buf[1];
 			vB = (int) (buf[5] | (buf[4] << 8) | (buf[3] << 16) | (buf[2] << 24));
 			offset = _anal_get_offset (a, 's', vB);
-			if (offset == -1) {
+			if (offset == UT64_MAX) {
 				snprintf (str, sizeof (str), " v%i, string+%i", vA, vB);
 			} else {
 				snprintf (str, sizeof (str), " v%i, 0x%"PFMT64x, vA, offset);

--- a/libr/arch/p/wasm/plugin.c
+++ b/libr/arch/p/wasm/plugin.c
@@ -27,20 +27,14 @@ typedef struct wasm_cf_info {
 static inline ut64 get_func_offset(RArch *a, ut32 id, bool start) {
 	if (a && a->binb.get_offset && a->binb.bin) {
 		int type = start? 'F': 'e'; // find start or end
-		int ret = a->binb.get_offset (a->binb.bin, type, id);
-		if (ret >= 0) {
-			return ret;
-		}
+		return a->binb.get_offset (a->binb.bin, type, id);
 	}
 	return UT64_MAX;
 }
 
 static inline ut64 func_off_from_idx(RArch *a, ut32 id) {
 	if (a && a->binb.get_offset && a->binb.bin) {
-		int ret = a->binb.get_offset (a->binb.bin, 'f', id);
-		if (ret >= 0) {
-			return ret;
-		}
+		return a->binb.get_offset (a->binb.bin, 'f', id);
 	}
 	return UT64_MAX;
 }

--- a/libr/bin/p/bin_dex.c
+++ b/libr/bin/p/bin_dex.c
@@ -1855,7 +1855,7 @@ static RList *entries(RBinFile *bf) {
 	return ret;
 }
 
-static int getoffset(RBinFile *bf, int type, int idx) {
+static ut64 getoffset(RBinFile *bf, int type, int idx) {
 	struct r_bin_dex_obj_t *dex = bf->o->bin_obj;
 	switch (type) {
 	case 'm': // methods
@@ -1878,7 +1878,7 @@ static int getoffset(RBinFile *bf, int type, int idx) {
 	case 'c': // class
 		return dex_get_type_offset (bf, idx);
 	}
-	return -1;
+	return UT64_MAX;
 }
 
 static const char *getname(RBinFile *bf, int type, int idx, bool sd) {

--- a/libr/bin/p/bin_wasm.c
+++ b/libr/bin/p/bin_wasm.c
@@ -416,8 +416,8 @@ static RBuffer *create(RBin *bin, const ut8 *code, int codelen, const ut8 *data,
 	return buf;
 }
 
-static int get_fcn_offset_from_id(RBinFile *bf, int ordinal) {
-	RBinWasmObj *bin = R_UNWRAP3 (bf, o, bin_obj);
+static ut64 get_fcn_offset_from_id(RBinFile *bf, int ordinal) {
+	RBinWasmObj *bin = bf->o->bin_obj;
 	ut32 min = first_ord_not_import (bin, R_BIN_WASM_EXTERNALKIND_Function);
 	RPVector *codes = r_bin_wasm_get_codes (bin);
 	if (min <= ordinal && codes) {
@@ -427,7 +427,7 @@ static int get_fcn_offset_from_id(RBinFile *bf, int ordinal) {
 			return func->code;
 		}
 	}
-	return -1;
+	return UT64_MAX;
 }
 
 static int _code_frm_addr(const void *_code, const void *_needle) {
@@ -442,7 +442,7 @@ static int _code_frm_addr(const void *_code, const void *_needle) {
 	return 0;
 }
 
-static int get_fcn_offset_from_addr(RBinFile *bf, int addr, bool start) {
+static ut64 get_fcn_offset_from_addr(RBinFile *bf, int addr, bool start) {
 	RBinWasmObj *bin = R_UNWRAP3 (bf, o, bin_obj);
 	if (bin) {
 		RPVector *codes = r_bin_wasm_get_codes (bin);
@@ -457,10 +457,10 @@ static int get_fcn_offset_from_addr(RBinFile *bf, int addr, bool start) {
 			}
 		}
 	}
-	return -1;
+	return UT64_MAX;
 }
 
-static int getoffset(RBinFile *bf, int type, int idx) {
+static ut64 getoffset(RBinFile *bf, int type, int idx) {
 	switch (type) {
 	case 'f': // fcnid -> fcnaddr
 		return get_fcn_offset_from_id (bf, idx);

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -474,7 +474,7 @@ typedef struct r_bin_plugin_t {
 	int (*demangle_type)(const char *str);
 	struct r_bin_dbginfo_t *dbginfo;
 	struct r_bin_write_t *write;
-	int (*get_offset)(RBinFile *bf, int type, int idx);
+	ut64 (*get_offset) (RBinFile *bf, int type, int idx);
 	const char* (*get_name)(RBinFile *bf, int type, int idx, bool simplified);
 	ut64 (*get_vaddr)(RBinFile *bf, ut64 baddr, ut64 paddr, ut64 vaddr);
 	RBuffer* (*create)(RBin *bin, const ut8 *code, int codelen, const ut8 *data, int datalen, RBinArchOptions *opt);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `RBinBind->get_offset` returns an `int` while the code using these values cast them to `ut64`. This will update the API to ut64. 

Still not 100% confident this code is right, figured I would let the tests run while I check a few things manually.
