### PR TITLE
Prevent overriding of register profile set by GDB client

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -234,6 +234,9 @@ R_API bool r_anal_use(RAnal *anal, const char *name) {
 	r_return_val_if_fail (anal, false);
 	RListIter *it;
 	RAnalPlugin *h;
+	if (anal->uses) {
+		return true;
+	}
 	// r_anal plugins
 	r_list_foreach (anal->plugins, it, h) {
 		if (!h->name || strcmp (h->name, name)) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

See https://github.com/radareorg/radare2/issues/8992#issuecomment-1384298988. `r_anal_use` function is called after GDB client set register profile and overrides the profile by default one. This quickfix prevents it.

