### PR TITLE
Add A0 register into MIPS register profiles

### DIFF
--- a/shlr/gdb/include/reg/mips.h
+++ b/shlr/gdb/include/reg/mips.h
@@ -1,5 +1,6 @@
 return strdup (
 "=PC    pc\n"
+"=A0    a0\n"
 "=SP    sp\n"
 "=BP    gp\n"
 "gpr	zero	.32	0	0\n"

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -313,6 +313,7 @@ static int gdbr_parse_target_xml(libgdbr_t *g, char *xml_data, ut64 len) {
 	case R_SYS_ARCH_MIPS:
 		if (!(profile = r_str_prepend (profile,
 						"=PC	pc\n"
+			    	    	    	"=A0	a0\n"
 						"=SP	r29\n"))) {
 			goto exit_err;
 		}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes comment https://github.com/radareorg/radare2/issues/8992#issuecomment-1384983689
A0 register is required to successfully apply the profile. Add this register to the default MIPS profile and to profile received be GDB client to prevent error during profile application.
