### PR TITLE
Fix allocation crash in bin.symbols ##bin

### DIFF
--- a/libr/bin/p/bin_symbols.c
+++ b/libr/bin/p/bin_symbols.c
@@ -280,7 +280,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadadd
 	}
 	SymbolsMetadata sm = parseMetadata (buf, 0x40);
 	char * file_name = NULL;
-	if (sm.namelen) {
+	if (sm.namelen > 0 && sm.namelen < 1024) {
 		file_name = calloc (sm.namelen + 1, 1);
 		if (!file_name) {
 			return false;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
