### PR TITLE
Blindfix for a glitch in the v850 disassembler ##arch

### DIFF
--- a/libr/arch/p/v850/v850dis.c
+++ b/libr/arch/p/v850/v850dis.c
@@ -450,7 +450,20 @@ static bool v850np_disassemble(v850np_inst *inst, int cpumodel, ut64 memaddr, co
 #if ABS_R0REF
 				if (opnum == 2 && value == 0) { // "-X[r0]"
 					ut32 addr = UT32_MAX + 1 + prevalue;
-					r_strbuf_appendf (sb, "0x%08"PFMT32x, addr);
+					// uncommenting this breaks `rasm2 -a v850 -d 01fb`
+					// trim last char and append this
+					char *s = r_strbuf_drain (sb);
+					if (*s) {
+						s[strlen (s) - 1] = 0;
+						r_str_trim (s);
+					}
+					if (addr < 256) {
+						sb = r_strbuf_newf ("%s %"PFMT32d, s, addr);
+					} else {
+						sb = r_strbuf_newf ("%s 0x%08"PFMT32x, s, addr);
+					}
+					free (s);
+					// r_strbuf_appendf (sb, "0x%08"PFMT32x, addr);
 					inst->value = addr;
 					done = true;
 				} else {

--- a/test/db/anal/v850
+++ b/test/db/anal/v850
@@ -491,3 +491,14 @@ mov 0x674, r1
 mov 0x34120674, r1
 EOF
 RUN
+
+
+NAME=v850 10x bug
+FILE=malloc://1024
+CMDS=<<EOF
+!rasm2 -a v850 -d 01fb
+EOF
+EXPECT=<<EOF
+sld.b 1, lp
+EOF
+RUN


### PR DESCRIPTION
* rasm2 -a v850 -d 01fb

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
