### PR TITLE
meson: install rasign2.1 man page too ##build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -679,6 +679,7 @@ if cli_enabled
     'man/ragg2.1',
     'man/rahash2.1',
     'man/rarun2.1',
+    'man/rasign2.1',
     'man/rasm2.1',
     'man/rax2.1',
     'man/ravc2.1',


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This file is installed by the GNU autotools-based build system but not by meson.