### PR TITLE
Clean-up ASN.1 parser and update x509 fuzzing

### DIFF
--- a/libr/include/r_util/r_x509.h
+++ b/libr/include/r_util/r_x509.h
@@ -107,7 +107,6 @@ R_API char *r_x509_crl_tostring(RX509CertificateRevocationList *crl, const char*
 R_API void r_x509_crl_json(PJ* pj, RX509CertificateRevocationList *crl);
 
 R_API RX509Certificate *r_x509_parse_certificate(RASN1Object *object);
-R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length);
 R_API void r_x509_free_certificate(RX509Certificate* certificate);
 R_API char *r_x509_certificate_tostring(RX509Certificate* certificate, const char* pad);
 R_API void r_x509_certificate_json(PJ* pj, RX509Certificate *certificate);

--- a/libr/util/x509.c
+++ b/libr/util/x509.c
@@ -237,16 +237,6 @@ fail:
 	return cert;
 }
 
-R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length) {
-	if (!buffer || !length) {
-		return NULL;
-	}
-	RASN1Object *object = r_asn1_object_parse (buffer, buffer, length, 0);
-	RX509Certificate *certificate = r_x509_parse_certificate (object);
-	// object freed by r_x509_parse_certificate
-	return certificate;
-}
-
 R_API RX509CRLEntry *r_x509_parse_crlentry(RASN1Object *object) {
 	if (!object || object->list.length != 2) {
 		return NULL;

--- a/test/fuzz/fuzz_x509_parse.c
+++ b/test/fuzz/fuzz_x509_parse.c
@@ -9,6 +9,16 @@ int LLVMFuzzerInitialize(int *lf_argc, char ***lf_argv) {
 	return 0;
 }
 
+R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length) {
+	if (!buffer || !length) {
+		return NULL;
+	}
+	RASN1Object *object = r_asn1_object_parse (buffer, buffer, length, 0);
+	RX509Certificate *certificate = r_x509_parse_certificate (object);
+	// object freed by r_x509_parse_certificate
+	return certificate;
+}
+
 int LLVMFuzzerTestOneInput(const ut8 *data, size_t len) {
 	RX509Certificate *out = r_x509_parse_certificate2 (data, len);
 	free (out);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Move function used only by x509 fuzzer and update checks in ASN.1 lengths to reject length over 48 bits.
