### PR TITLE
Fix memory leak when parsing DW_FORM_line_strp ##bin

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1529,6 +1529,7 @@ static void free_attr_value(RBinDwarfAttrValue *val) {
 	switch (val->attr_form) {
 	case DW_FORM_strp:
 	case DW_FORM_string:
+	case DW_FORM_line_strp:
 		R_FREE (val->string.content);
 		break;
 	case DW_FORM_exprloc:

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -1881,7 +1881,7 @@ static const ut8 *parse_attr_value(const ut8 *obuf, int obuf_len, RBinDwarfAttrD
 		ut8 *section = NULL;
 		section = get_section_bytes (bin, section_name, &section_len);
 		if (section && value->string.offset < section_len) {
-			char *ds = r_str_ndup ((const char *)(section + value->string.offset), section_len);
+			char *ds = r_str_ndup ((const char *)(section + value->string.offset), section_len - 1);
 			if (ds) {
 				r_str_ansi_strip (ds);
 				r_str_replace_ch (ds, '\n', 0, true);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Sorry missed this from my previous PR #21297. Since we support DW_FORM_line_strp now we need to free those strings as well.