### PR TITLE
Fix assert in asm.pseudo by stop using the deprecated RParse.parse() API

### DIFF
--- a/libr/arch/meson.build
+++ b/libr/arch/meson.build
@@ -41,7 +41,7 @@ r_arch_sources = [
 
 if arch_plugins.contains('x86_nz')
   r_arch_sources += [
-    'p/x86_nz/plugin.c' 
+    'p/x86_nz/plugin.c'
   ]
 endif
 

--- a/libr/asm/parse.c
+++ b/libr/asm/parse.c
@@ -172,7 +172,7 @@ R_API char *r_parse_instruction(RParse *p, const char *data) {
 	return NULL;
 }
 
-R_API bool r_parse_parse(RParse *p, const char *data, char *str) { // TODO deprecate. because r_parse_instruction is better
+R_API bool r_parse_parse(RParse *p, const char *data, char *str) { // TODO deprecate. in R2_590 because r_parse_instruction is better
 	r_return_val_if_fail (p && data && str, false);
 	return (p && data && *data && p->cur && p->cur->parse)
 		? p->cur->parse (p, data, str) : false;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2806,12 +2806,22 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 	ds->oplen = ds->asmop.size;
 	if (ds->pseudo) {
 #if 1
-		r_parse_parse (core->parser, ds->opstr
-				? ds->opstr
-				: r_asm_op_get_asm (&ds->asmop),
-				ds->str);
+		char *str = ds->opstr ? ds->opstr : r_asm_op_get_asm (&ds->asmop);
+		if (!str) {
+			str = ds->str;
+		}
+		r_parse_parse (core->parser, str, ds->str);
 		free (ds->opstr);
 		ds->opstr = strdup (ds->str);
+#else
+		char *str = ds->opstr? ds->opstr: ds->str;
+		char *s = r_parse_instruction (core->parser, str);
+		if (R_STR_ISNOTEMPTY (s)) {
+			free (ds->opstr);
+			ds->opstr = s;
+		} else {
+			free (s);
+		}
 #endif
 	}
 	if (ds->acase) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
