### PR TITLE
Add XCOFF64 support ##bin

### DIFF
--- a/dist/plugins-cfg/plugins.android.cfg
+++ b/dist/plugins-cfg/plugins.android.cfg
@@ -38,6 +38,7 @@ bin.dyldcache
 bin.xnu_kernelcache
 bin.nin3ds
 bin.xbe
+bin.xcoff64
 bin_xtr.xtr_fatmach0
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_sep64

--- a/dist/plugins-cfg/plugins.def.cfg
+++ b/dist/plugins-cfg/plugins.def.cfg
@@ -134,6 +134,7 @@ bin.lua
 bin.wad
 bin.wasm
 bin.xbe
+bin.xcoff64
 bin.xnu_kernelcache
 bin.z64
 bin.zimg

--- a/dist/plugins-cfg/plugins.ios-store.cfg
+++ b/dist/plugins-cfg/plugins.ios-store.cfg
@@ -32,6 +32,7 @@ bin.ningba
 bin.ninds
 bin.nin3ds
 bin.xbe
+bin.xcoff64
 bin_xtr.xtr_fatmach0
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_sep64

--- a/dist/plugins-cfg/plugins.ios.cfg
+++ b/dist/plugins-cfg/plugins.ios.cfg
@@ -33,6 +33,7 @@ bin.ningba
 bin.ninds
 bin.nin3ds
 bin.xbe
+bin.xcoff64
 bin_xtr.xtr_fatmach0
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_sep64

--- a/dist/plugins-cfg/plugins.mingw.cfg
+++ b/dist/plugins-cfg/plugins.mingw.cfg
@@ -118,6 +118,7 @@ bin.sfc
 bin.te
 bin.vsf
 bin.xbe
+bin.xcoff64
 bin.z64
 bin.dyldcache
 bin.xnu_kernelcache

--- a/dist/plugins-cfg/plugins.nocs.cfg
+++ b/dist/plugins-cfg/plugins.nocs.cfg
@@ -104,6 +104,7 @@ bin.sfc
 bin.te
 bin.vsf
 bin.xbe
+bin.xcoff64
 bin.z64
 bin.dyldcache
 bin.xnu_kernelcache

--- a/dist/plugins-cfg/plugins.nogpl.cfg
+++ b/dist/plugins-cfg/plugins.nogpl.cfg
@@ -50,6 +50,7 @@ bin.pe64
 bin.pebble
 bin.te
 bin.xbe
+bin.xcoff64
 bin.z64
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_fatmach0

--- a/dist/plugins-cfg/plugins.static.cfg
+++ b/dist/plugins-cfg/plugins.static.cfg
@@ -90,6 +90,7 @@ bin.vsf
 bin.xbe
 bin.z64
 bin.dyldcache
+bin.xcoff64
 bin.xnu_kernelcache
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_fatmach0

--- a/dist/plugins-cfg/plugins.static.nogpl.cfg
+++ b/dist/plugins-cfg/plugins.static.nogpl.cfg
@@ -73,6 +73,7 @@ bin.sfc
 bin.te
 bin.vsf
 bin.xbe
+bin.xcoff64
 bin.z64
 bin.dyldcache
 bin.xnu_kernelcache

--- a/dist/plugins-cfg/plugins.termux.cfg
+++ b/dist/plugins-cfg/plugins.termux.cfg
@@ -97,6 +97,7 @@ bin.vsf
 bin.xbe
 bin.z64
 bin.dyldcache
+bin.xcoff64
 bin.xnu_kernelcache
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_fatmach0

--- a/dist/plugins-cfg/plugins.tiny.cfg
+++ b/dist/plugins-cfg/plugins.tiny.cfg
@@ -31,6 +31,7 @@ bin.ningba
 bin.ninds
 bin.nin3ds
 bin.xbe
+bin.xcoff64
 bin_xtr.xtr_fatmach0
 bin_xtr.xtr_dyldcache
 bin_xtr.xtr_sep64

--- a/libr/bin/format/coff/coff.h
+++ b/libr/bin/format/coff/coff.h
@@ -8,9 +8,6 @@
 #include <r_lib.h>
 #include <r_bin.h>
 
-#define COFF_IS_BIG_ENDIAN 1
-#define COFF_IS_LITTLE_ENDIAN 0
-
 #include "coff_specs.h"
 
 typedef struct r_bin_coff_obj {

--- a/libr/bin/format/coff/coff_specs.h
+++ b/libr/bin/format/coff/coff_specs.h
@@ -1,15 +1,16 @@
-/* radare - LGPL - Copyright 2014 - Fedor Sakharov */
+/* radare - LGPL - Copyright 2014-2023 - Fedor Sakharov, terorie */
 #ifndef COFF_SPECS_H
 #define COFF_SPECS_H
 
 #include <r_types_base.h>
 
+/* COFF magic numbers */
 #define COFF_FILE_MACHINE_UNKNOWN	0x0
 #define COFF_FILE_MACHINE_AM33		0x1d3
-#define COFF_FILE_MACHINE_AMD64	0x8664
+#define COFF_FILE_MACHINE_AMD64		0x8664
 #define COFF_FILE_MACHINE_ARM		0x1c0
-#define COFF_FILE_MACHINE_ARMNT	0x1c4
-#define COFF_FILE_MACHINE_ARM64	0xaa64
+#define COFF_FILE_MACHINE_ARMNT		0x1c4
+#define COFF_FILE_MACHINE_ARM64		0xaa64
 #define COFF_FILE_MACHINE_EBC		0xebc
 #define COFF_FILE_MACHINE_I386		0x14c
 #define COFF_FILE_MACHINE_IA64		0x200
@@ -21,15 +22,15 @@
 #define COFF_FILE_MACHINE_AMD29KLE	0x17a
 #define COFF_FILE_MACHINE_POWERPC	0x1f0
 #define COFF_FILE_MACHINE_POWERPCFP	0x1f1
-#define COFF_FILE_MACHINE_R4000	0x166
+#define COFF_FILE_MACHINE_R4000		0x166
 #define COFF_FILE_MACHINE_SH3		0x1a2
 #define COFF_FILE_MACHINE_SH3DSP	0x1a3
 #define COFF_FILE_MACHINE_SH4		0x1a6
 #define COFF_FILE_MACHINE_SH5		0x1a8
-#define COFF_FILE_MACHINE_THUMB	0x1c2
+#define COFF_FILE_MACHINE_THUMB		0x1c2
 #define COFF_FILE_MACHINE_WCEMIPSV2	0x169
-#define COFF_FILE_MACHINE_H8300	0x0083
-
+#define COFF_FILE_MACHINE_H8300		0x0083
+/* COFF magic numbers */
 #define COFF_FILE_TI_COFF		0xc1
 #define COFF_FILE_MACHINE_TMS470	0x0097
 #define COFF_FILE_MACHINE_TMS320C54	0x0098
@@ -38,6 +39,17 @@
 #define COFF_FILE_MACHINE_TMS320C28	0x009D
 #define COFF_FILE_MACHINE_MSP430	0x00A0
 #define COFF_FILE_MACHINE_TMS320C55PLUS	0x00A1
+/* XCOFF32 magic numbers */
+#define XCOFF32_FILE_MACHINE_U800WR	0x198 /* IBM RT, RW text      */
+#define XCOFF32_FILE_MACHINE_U800RO	0x19d /* IBM RT, RO text      */
+#define XCOFF32_FILE_MACHINE_U800TOC	0x19f /* IBM RT, RO text, TOC */
+#define XCOFF32_FILE_MACHINE_U802WR	0x1d8 /* IBM ??, RW text      */
+#define XCOFF32_FILE_MACHINE_U802RO	0x1dd /* IBM ??, RO text      */
+#define XCOFF32_FILE_MACHINE_U802TOC	0x1df /* IBM ??, RO text, TOC */
+/* XCOFF64 magic numbers */
+#define XCOFF64_FILE_MACHINE_U803TOC	0x1e7
+#define XCOFF64_FILE_MACHINE_U803XTOC	0x1ef
+#define XCOFF64_FILE_MACHINE_U64	0x1f7 /* IBM AIX */
 
 #define COFF_FLAGS_TI_F_RELFLG		0x0001
 #define COFF_FLAGS_TI_F_EXEC		0x0002
@@ -69,21 +81,50 @@
 #define COFF_SCN_ALIGN_16BYTES		0x00500000
 #define COFF_SCN_ALIGN_32BYTES		0x00600000
 #define COFF_SCN_ALIGN_64BYTES		0x00700000
-#define COFF_SCN_ALIGN_128BYTES	0x00800000
-#define COFF_SCN_ALIGN_256BYTES	0x00900000
-#define COFF_SCN_ALIGN_512BYTES	0x00A00000
+#define COFF_SCN_ALIGN_128BYTES		0x00800000
+#define COFF_SCN_ALIGN_256BYTES		0x00900000
+#define COFF_SCN_ALIGN_512BYTES		0x00A00000
 #define COFF_SCN_ALIGN_1024BYTES	0x00B00000
 #define COFF_SCN_ALIGN_2048BYTES	0x00C00000
 #define COFF_SCN_ALIGN_4096BYTES	0x00D00000
 #define COFF_SCN_ALIGN_8192BYTES	0x00E00000
 #define COFF_SCN_LNK_NRELOC_OVFL	0x01000000
 #define COFF_SCN_MEM_DISCARDABLE	0x02000000
-#define COFF_SCN_MEM_NOT_CACHED	0x04000000
+#define COFF_SCN_MEM_NOT_CACHED		0x04000000
 #define COFF_SCN_MEM_NOT_PAGED		0x08000000
 #define COFF_SCN_MEM_SHARED		0x10000000
 #define COFF_SCN_MEM_EXECUTE		0x20000000
 #define COFF_SCN_MEM_READ		0x40000000
 #define COFF_SCN_MEM_WRITE		0x80000000
+
+/* XCOFF section header flags (type) */
+#define XCOFF_SCN_TYPE_REG	0x0000
+#define XCOFF_SCN_TYPE_PAD	0x0008
+#define XCOFF_SCN_TYPE_DWARF	0x0010
+#define XCOFF_SCN_TYPE_TEXT	0x0020
+#define XCOFF_SCN_TYPE_DATA	0x0040
+#define XCOFF_SCN_TYPE_BSS	0x0080
+#define XCOFF_SCN_TYPE_EXCEPT	0x0100
+#define XCOFF_SCN_TYPE_INFO	0x0200
+#define XCOFF_SCN_TYPE_TDATA	0x0400
+#define XCOFF_SCN_TYPE_TBSS	0x0800
+#define XCOFF_SCN_TYPE_LOADER	0x1000
+#define XCOFF_SCN_TYPE_DEBUG	0x2000
+#define XCOFF_SCN_TYPE_TYPCHK	0x4000
+#define XCOFF_SCN_TYPE_OVRFLO	0x8000
+
+/* XCOFF section header flags (DWARF subtype) */
+#define XCOFF_SCN_SUBTYPE_DWINFO	0x10000
+#define XCOFF_SCN_SUBTYPE_DWLINE	0x20000
+#define XCOFF_SCN_SUBTYPE_DWPBNMS	0x30000
+#define XCOFF_SCN_SUBTYPE_DWPBTYP	0x40000
+#define XCOFF_SCN_SUBTYPE_DWARNGE	0x50000
+#define XCOFF_SCN_SUBTYPE_DWABREV	0x60000
+#define XCOFF_SCN_SUBTYPE_DWSTR		0x70000
+#define XCOFF_SCN_SUBTYPE_DWRNGES	0x80000
+#define XCOFF_SCN_SUBTYPE_DWLOC		0x90000
+#define XCOFF_SCN_SUBTYPE_DWFRAME	0xA0000
+#define XCOFF_SCN_SUBTYPE_DWMAC		0xB0000
 
 #define COFF_SYM_SCNUM_UNDEF 		0
 #define COFF_SYM_SCNUM_ABS		0xffff
@@ -111,33 +152,41 @@
 #define COFF_SYM_DTYPE_FUNCTION	2
 #define COFF_SYM_DTYPE_ARRAY		3
 
-#define COFF_SYM_CLASS_END_OF_FUNCTION	0xFF
-#define COFF_SYM_CLASS_NULL		0
-#define COFF_SYM_CLASS_AUTOMATIC	1
-#define COFF_SYM_CLASS_EXTERNAL	2
-#define COFF_SYM_CLASS_STATIC		3
-#define COFF_SYM_CLASS_REGISTER	4
-#define COFF_SYM_CLASS_EXTERNAL_DEF	5
-#define COFF_SYM_CLASS_LABEL		6
-#define COFF_SYM_CLASS_UNDEFINED_LABEL	7
-#define COFF_SYM_CLASS_MEMBER_OF_STRUCT 8
-#define COFF_SYM_CLASS_ARGUMENT	9
-#define COFF_SYM_CLASS_STRUCT_TAG	10
-#define COFF_SYM_CLASS_MEMBER_OF_UNION	11
-#define COFF_SYM_CLASS_UNION_TAG	12
-#define COFF_SYM_CLASS_TYPE_DEFINITION	13
-#define COFF_SYM_CLASS_UNDEFINED_STATIC 14
-#define COFF_SYM_CLASS_ENUM_TAG	15
-#define COFF_SYM_CLASS_MEMBER_OF_ENUM	16
-#define COFF_SYM_CLASS_REGISTER_PARAM	17
-#define COFF_SYM_CLASS_BIT_FIELD	18
+/* Storage class (valid for COFF, XCOFF32, XCOFF64) */
+#define COFF_SYM_CLASS_END_OF_FUNCTION	255
+#define COFF_SYM_CLASS_NULL		  0
+#define COFF_SYM_CLASS_AUTOMATIC	  1
+#define COFF_SYM_CLASS_EXTERNAL		  2
+#define COFF_SYM_CLASS_STATIC		  3
+#define COFF_SYM_CLASS_REGISTER		  4
+#define COFF_SYM_CLASS_EXTERNAL_DEF	  5
+#define COFF_SYM_CLASS_LABEL		  6
+#define COFF_SYM_CLASS_UNDEFINED_LABEL	  7
+#define COFF_SYM_CLASS_MEMBER_OF_STRUCT   8
+#define COFF_SYM_CLASS_ARGUMENT		  9
+#define COFF_SYM_CLASS_STRUCT_TAG	 10
+#define COFF_SYM_CLASS_MEMBER_OF_UNION	 11
+#define COFF_SYM_CLASS_UNION_TAG	 12
+#define COFF_SYM_CLASS_TYPE_DEFINITION	 13
+#define COFF_SYM_CLASS_UNDEFINED_STATIC  14
+#define COFF_SYM_CLASS_ENUM_TAG		 15
+#define COFF_SYM_CLASS_MEMBER_OF_ENUM	 16
+#define COFF_SYM_CLASS_REGISTER_PARAM	 17
+#define COFF_SYM_CLASS_BIT_FIELD	 18
 #define COFF_SYM_CLASS_BLOCK		100
-#define COFF_SYM_CLASS_FUNCTION	101
+#define COFF_SYM_CLASS_FUNCTION		101
 #define COFF_SYM_CLASS_END_OF_STRUCT	102
 #define COFF_SYM_CLASS_FILE		103
 #define COFF_SYM_CLASS_SECTION		104
 #define COFF_SYM_CLASS_WEAK_EXTERNAL	105
 #define COFF_SYM_CLASS_CLR_TOKEN	107
+
+/* XCOFF64 auxiliary entry type */
+#define XCOFF_AUX_EXCEPT	255
+#define XCOFF_AUX_FCN		254
+#define XCOFF_AUX_SYM		253
+#define XCOFF_AUX_FILE		252
+#define XCOFF_AUX_CSECT		251
 
 #define COFF_REL_I386_ABS		0
 #define COFF_REL_I386_DIR16		1
@@ -165,6 +214,11 @@
 #define COFF_REL_ARM64_ADDR32NB		2
 #define COFF_REL_ARM64_BRANCH26		3
 
+/* Used internally only */
+#define COFF_IS_BIG_ENDIAN 1
+#define COFF_IS_LITTLE_ENDIAN 0
+
+/* COFF/XCOFF32 file header */
 R_PACKED(
 struct coff_hdr {
 	ut16 f_magic;	/* Magic number */
@@ -176,18 +230,95 @@ struct coff_hdr {
 	ut16 f_flags;	/* Flags */
 });// __attribute__ ((packed));
 
+/* XCOFF64 file header */
+R_PACKED (
+struct xcoff64_hdr {
+	ut16 f_magic;	/* Magic number */
+	ut16 f_nscns;	/* Number of Sections */
+	ut32 f_timdat;	/* Time & date stamp */
+	ut64 f_symptr;	/* File pointer to Symbol Table */
+	ut16 f_opthdr;	/* sizeof (Optional Header) */
+	ut16 f_flags;	/* Flags */
+	ut32 f_nsyms;	/* Number of Symbols */
+});
+
+/* COFF auxiliary header */
 R_PACKED (
 struct coff_opt_hdr {
-	ut16 magic;			/* Magic Number                    */
+	ut16 magic;		/* Magic Number                    */
 	ut16 vstamp;		/* Version stamp                   */
-	ut32 tsize;			/* Text size in bytes              */
-	ut32 dsize;			/* Initialised data size           */
-	ut32 bsize;			/* Uninitialised data size         */
-	ut32 entry;			/* Entry point                     */
+	ut32 tsize;		/* Text size in bytes              */
+	ut32 dsize;		/* Initialised data size           */
+	ut32 bsize;		/* Uninitialised data size         */
+	ut32 entry;		/* Entry point                     */
 	ut32 text_start;	/* Base of Text used for this file */
 	ut32 data_start;	/* Base of Data used for this file */
 });
 
+/* XCOFF32 extended auxiliary header */
+R_PACKED (
+struct coff_opt_hdr_ext {
+	ut32 o_toc;
+	ut16 o_snentry;		/* Section number of entry point    */
+	ut16 o_sntext;		/* Section number of text section   */
+	ut16 o_sndata;		/* Section number of data section   */
+	ut16 o_sntoc;		/* Section number of TOC            */
+	ut16 o_snloader;	/* Section number of loader section */
+	ut16 o_snbss;		/* Section number of bss section    */
+	ut16 o_algntext;	/* Section alignment (2^n) of text section */
+	ut16 o_algndata;	/* Section alignment (2^n) of data section */
+	ut8  o_modtype[2];	/* Module type */
+	ut8  o_cpuflag;
+	ut8  o_cputype;
+	ut32 o_maxstack;	/* Maximum stack size */
+	ut32 o_maxdata;		/* Maximum data size */
+	ut32 o_debugger;	/* Reserved for debugger */
+	ut8  o_textpsize;	/* Text page size */
+	ut8  o_datapsize;	/* Data page size */
+	ut8  o_stackpsize;	/* Stack page size */
+	ut8  o_flags;
+	ut16 o_sntdata;		/* Section number of tdata section */
+	ut16 o_sntbss;		/* Section number of tbss section */
+});
+
+/* XCOFF64 auxiliary header */
+R_PACKED (
+struct xcoff64_opt_hdr {
+	ut16 magic;
+	ut16 vstamp;
+	ut32 o_debugger;	/* Reserved for debugger */
+	ut64 text_start;	/* Virtual address of text section */
+	ut64 data_start;	/* Virtual address of data section */
+	ut64 o_toc;
+	ut16 o_snentry;		/* Section number of entry point    */
+	ut16 o_sntext;		/* Section number of text section   */
+	ut16 o_sndata;		/* Section number of data section   */
+	ut16 o_sntoc;		/* Section number of TOC            */
+	ut16 o_snloader;	/* Section number of loader section */
+	ut16 o_snbss;		/* Section number of bss section    */
+	ut16 o_algntext;	/* Section alignment (2^n) of text section */
+	ut16 o_algndata;	/* Section alignment (2^n) of data section */
+	ut8  o_modtype[2];	/* Module type */
+	ut8  o_cpuflag;
+	ut8  o_cputype;
+	ut8  o_textpsize;	/* Text page size */
+	ut8  o_datapsize;	/* Data page size */
+	ut8  o_stackpsize;	/* Stack page size */
+	ut8  o_flags;
+	ut64 tsize;		/* Size of text section */
+	ut64 dsize;		/* Size of data section */
+	ut64 bsize;		/* Size of bss section  */
+	ut64 entry;		/* Entry point */
+	ut64 o_maxstack;	/* Maximum stack size */
+	ut64 o_maxdata;		/* Maximum data size */
+	ut16 o_sntdata;		/* Section number of tdata section */
+	ut16 o_sntbss;		/* Section number of tbss section */
+	ut16 o_x64flags;	/* 64-bit object flags */
+	ut16 o_resv3a;		/* Reserved */
+	ut32 o_resv3[2];	/* Reserved */
+});
+
+/* COFF section header */
 R_PACKED (
 struct coff_scn_hdr {
 	char s_name[8];	/* Section Name */
@@ -202,6 +333,23 @@ struct coff_scn_hdr {
 	ut32 s_flags;	/* Flags for this section */
 });
 
+/* XCOFF64 section header */
+R_PACKED (
+struct xcoff64_scn_hdr {
+	char s_name[8];	/* Section name */
+	ut64 s_paddr;	/* Physical address */
+	ut64 s_vaddr;	/* Virtual address */
+	ut64 s_size;	/* Section Size in Bytes */
+	ut64 s_scnptr;	/* File offset to the Section data */
+	ut64 s_relptr;	/* File offset to the Relocation table for this Section */
+	ut64 s_lnnoptr;	/* File offset to the Line Number table for this Section */
+	ut32 s_nreloc;	/* Number of relocation entries */
+	ut32 s_nlnno;	/* Number of line number entries */
+	ut32 s_flags;	/* Flags for this section */
+	char pad44[4];
+});
+
+/* COFF/XCOFF32 symbol */
 R_PACKED (
 struct coff_symbol {
 	char n_name[8];	/* Symbol Name */
@@ -212,6 +360,60 @@ struct coff_symbol {
 	ut8 n_numaux;	/* Auxiliary Count */
 });
 
+#define COFF_SYM_GET_DTYPE(type) (((type) >> 4) & 3)
+
+/* XCOFF64 symbol */
+R_PACKED (
+struct xcoff64_symbol {
+	ut64 n_value;	/* Value of Symbol */
+	ut32 n_offset;	/* Offset of Symbol Name */
+	ut16 n_scnum;	/* Section Number */
+	ut16 n_type;	/* Symbol Type */
+	ut8  n_sclass;	/* Storage Class */
+	ut8  n_numaux;	/* Auxiliary Count */
+});
+
+/* XCOFF64 symbol auxiliary entry */
+R_PACKED (
+union xcoff64_auxent {
+	struct {
+		ut8 x_pad[17];
+		ut8 x_auxtype;
+	} x_auxtype;
+
+	struct {
+		ut32 x_lnno;
+	} x_sym;
+
+	struct {
+		ut32 x_scnlen_lo;
+		ut32 x_parmhash;
+		ut16 x_snhash;
+		ut8  x_smtyp;
+		ut8  x_smclas;
+		ut32 x_scnlen_hi;
+	} x_csect;
+
+	struct {
+		ut64 x_exptr;
+		ut32 x_fsize;
+		ut32 x_endndx;
+	} x_except;
+
+	struct {
+		ut64 x_lnnoptr;
+		ut32 x_fsize;
+		ut32 x_endndx;
+	} x_fcn;
+});
+
+R_PACKED (
+union xcoff64_syment {
+	struct xcoff64_symbol sym;
+	union xcoff64_auxent aux;
+});
+
+/* COFF/XCOFF32 relocation */
 R_PACKED (
 struct coff_reloc {
 	ut32 r_vaddr;	/* Reference Address */
@@ -219,5 +421,102 @@ struct coff_reloc {
 	ut16 r_type;	/* Type of relocation */
 });
 
-#define COFF_SYM_GET_DTYPE(type)	(((type) >> 4) & 3)
+/* XCOFF64 relocation */
+R_PACKED (
+struct xcoff64_reloc {
+	ut64 r_vaddr;
+	ut32 r_symndx;
+	ut16 r_type;
+});
+
+/* XCOFF32 loader header */
+R_PACKED (
+struct xcoff32_ldhdr {
+	ut32 l_version;
+	ut32 l_nsyms;
+	ut32 l_nreloc;
+	ut32 l_istlen;
+	ut32 l_nimpid;
+	ut32 l_impoff;
+	ut32 l_stlen;
+	ut32 l_stoff;
+});
+
+/* XCOFF64 loader header */
+R_PACKED (
+struct xcoff64_ldhdr {
+	ut32 l_version;
+	ut32 l_nsyms;
+	ut32 l_nreloc;
+	ut32 l_istlen;
+	ut32 l_nimpid;
+	ut32 l_stlen;
+	ut64 l_impoff;
+	ut64 l_stoff;
+	ut64 l_symoff;
+	ut64 l_rldoff;
+});
+
+/* XCOFF32 loader symbol */
+R_PACKED (
+struct xcoff32_ldsym {
+	ut8  l_name[8];
+	ut32 l_value;
+	ut16 l_scnum;
+	ut8  l_smtype;
+	ut8  l_smclas;
+	ut32 l_ifile;
+	ut32 l_parm;
+});
+
+/* XCOFF64 loader symbol */
+R_PACKED (
+struct xcoff64_ldsym {
+	ut64 l_value;
+	ut32 l_offset;
+	ut16 l_scnum;
+	ut8  l_smtype;
+	ut8  l_smclas;
+	ut32 l_ifile;
+	ut32 l_parm;
+});
+
+/* XCOFF32 loader relocation */
+R_PACKED (
+struct xcoff32_ldrel {
+	ut32 l_vaddr;
+	ut32 l_symndx;
+	ut16 l_rtype;
+	ut16 l_rsecnm;
+});
+
+/* XCOFF64 loader relocation */
+R_PACKED (
+struct xcoff64_ldrel {
+	ut64 l_vaddr;
+	ut16 l_rtype;
+	ut16 l_rsecnm;
+	ut32 l_symndx;
+});
+
+/* XCOFF32 line number info */
+R_PACKED (
+struct xcoff32_lineno {
+	union {
+		ut32 l_symndx;
+		ut32 l_paddr;
+	};
+	ut16 l_lnno;
+});
+
+/* XCOFF64 line number info */
+R_PACKED (
+struct xcoff64_lineno {
+	union {
+		ut32 l_symndx;
+		ut64 l_paddr; /* TODO not portable */
+	};
+	ut32 l_lnno;
+});
+
 #endif /* COFF_SPECS_H */

--- a/libr/bin/format/coff/xcoff64.c
+++ b/libr/bin/format/coff/xcoff64.c
@@ -1,0 +1,213 @@
+/* radare - LGPL - Copyright 2023 terorie */
+
+#include <r_util.h>
+#include "xcoff64.h"
+
+R_IPI bool r_xcoff64_supported_arch(const ut8 *buf) {
+	ut16 arch = r_read_be16 (buf);
+	switch (arch) {
+	case XCOFF64_FILE_MACHINE_U803TOC:
+	case XCOFF64_FILE_MACHINE_U803XTOC:
+	case XCOFF64_FILE_MACHINE_U64:
+		return true;
+	default:
+		return false;
+	}
+}
+
+R_IPI char *r_xcoff64_symbol_name(RBinXCoff64Obj *obj, ut32 offset) {
+	char n[1024] = {0};
+	int len = 0;
+	ut64 paddr = obj->nametbl_off + offset;
+	if (paddr > obj->size) {
+		return NULL;
+	}
+	len = r_buf_read_at (obj->b, paddr, (ut8*)n, sizeof (n));
+	if (len < 1) {
+		return NULL;
+	}
+	/* ensure null terminated string */
+	n[sizeof (n) - 1] = 0;
+	return strdup (n);
+}
+
+R_IPI RBinAddr *r_xcoff64_get_entry(RBinXCoff64Obj *obj) {
+	RBinAddr *addr = R_NEW0 (RBinAddr);
+	if (!addr) {
+		return NULL;
+	}
+	/* XXX Are XCOFF64 without auxiliary header valid? */
+	if (!obj->hdr.f_opthdr) {
+		return NULL;
+	}
+	addr->hpaddr = sizeof (struct xcoff64_hdr) + r_offsetof (struct xcoff64_opt_hdr, entry);
+	addr->vaddr = obj->opt_hdr.entry;
+	if (addr->vaddr >= obj->opt_hdr.text_start) {
+		addr->paddr = addr->vaddr - obj->opt_hdr.text_start;
+	}
+	return addr;
+}
+
+static bool r_bin_xcoff64_init_hdr(RBinXCoff64Obj *obj) {
+	ut16 magic = r_buf_read_be16_at (obj->b, 0);
+	switch (magic) {
+	case XCOFF64_FILE_MACHINE_U803TOC:
+	case XCOFF64_FILE_MACHINE_U803XTOC:
+	case XCOFF64_FILE_MACHINE_U64:
+		obj->endian = COFF_IS_BIG_ENDIAN;
+		break;
+	default:
+		R_LOG_ERROR ("unsupported xcoff64 magic: %#x", magic);
+		return false;
+	}
+	int ret = 0;
+	ret = r_buf_fread_at (obj->b, 0, (ut8 *)&obj->hdr, obj->endian? "2S1I1L2S1I": "2s1i1l2s1i", 1);
+	if (ret != sizeof (struct xcoff64_hdr)) {
+		return false;
+	}
+	obj->nametbl_off = obj->hdr.f_symptr + (obj->hdr.f_nsyms * sizeof (struct xcoff64_symbol));
+	return true;
+}
+
+static bool r_bin_xcoff64_init_opt_hdr(RBinXCoff64Obj *obj) {
+	int ret;
+	if (obj->hdr.f_opthdr != 0x78) {
+		R_LOG_ERROR ("unexpected auxiliary header size in xcoff64: %#x", obj->hdr.f_opthdr);
+		return false;
+	}
+	ret = r_buf_fread_at (obj->b, sizeof (struct xcoff64_hdr),
+						 (ut8 *)&obj->opt_hdr, obj->endian? "2S1I3L8S8c6L4S3I": "2s1i3l8s8c6l4s3i", 1);
+	if (ret != sizeof (struct coff_opt_hdr)) {
+		return false;
+	}
+	return true;
+}
+
+static bool r_bin_xcoff64_init_scn_hdr(RBinXCoff64Obj *obj) {
+	int ret, size;
+	ut64 offset = sizeof (struct xcoff64_hdr) + obj->hdr.f_opthdr;
+	size = obj->hdr.f_nscns * sizeof (struct xcoff64_scn_hdr);
+	if (offset > obj->size || offset + size > obj->size || size < 0) {
+		return false;
+	}
+	obj->scn_hdrs = calloc (1, size + sizeof (struct xcoff64_scn_hdr));
+	if (!obj->scn_hdrs) {
+		return false;
+	}
+	ret = r_buf_fread_at (obj->b, offset, (ut8 *)obj->scn_hdrs, obj->endian? "8c6L3I4c": "8c6l3i4c", obj->hdr.f_nscns);
+	if (ret != size) {
+		R_FREE (obj->scn_hdrs);
+		return false;
+	}
+	return true;
+}
+
+static bool r_bin_coff_init_symtable(RBinXCoff64Obj *obj) {
+	int ret, size;
+	ut64 offset = obj->hdr.f_symptr;
+	if (obj->hdr.f_nsyms >= 0xffffff || !obj->hdr.f_nsyms) { // too much symbols, probably not allocatable
+		return false;
+	}
+	size = obj->hdr.f_nsyms * sizeof (struct xcoff64_symbol);
+	if (size < 0 ||
+		size > obj->size ||
+		offset > obj->size ||
+		offset + size > obj->size) {
+		return false;
+	}
+	obj->symbols = calloc (1, size + sizeof (struct xcoff64_symbol));
+	if (!obj->symbols) {
+		return false;
+	}
+	ret = r_buf_fread_at (obj->b, offset, (ut8 *)obj->symbols, obj->endian? "1L1I2S2c": "1l1i2s2c", obj->hdr.f_nsyms);
+	if (ret != size) {
+		R_FREE (obj->symbols);
+		return false;
+	}
+	return true;
+}
+
+static bool r_bin_xcoff64_init_scn_va(RBinXCoff64Obj *obj) {
+	int i;
+	ut64 va = 0;
+
+	obj->scn_va = R_NEWS0 (ut64, obj->hdr.f_nscns);
+	if (!obj->scn_va) {
+		return false;
+	}
+
+	/* Use predefined virtual addresses */
+	if (obj->hdr.f_opthdr) {
+		if (obj->opt_hdr.o_sntext < obj->hdr.f_nscns) {
+			obj->scn_va[obj->opt_hdr.o_sntext] = obj->opt_hdr.text_start;
+			va = R_MAX (va, obj->opt_hdr.text_start + obj->opt_hdr.tsize);
+		}
+		if (obj->opt_hdr.o_sndata < obj->hdr.f_nscns) {
+			obj->scn_va[obj->opt_hdr.o_sndata] = obj->opt_hdr.data_start;
+			va = R_MAX (va, obj->opt_hdr.data_start + obj->opt_hdr.dsize);
+		}
+	}
+	va = R_ROUND (va, 0x100ULL);
+
+	/* Place other sections after predefined */
+	for (i = 0; i < obj->hdr.f_nscns; i++) {
+		if (obj->scn_va[i]) {
+			continue;
+		}
+		ut64 sz = obj->scn_hdrs[i].s_size;
+		if (sz < 16) {
+			sz = 16;
+		}
+		obj->scn_va[i] = va;
+		va += sz;
+		va = R_ROUND (va, 16ULL);
+	}
+	return true;
+}
+
+static bool r_bin_xcoff64_init(RBinXCoff64Obj *obj, RBuffer *buf, bool verbose) {
+	if (!obj || !buf) {
+		return false;
+	}
+	obj->b = r_buf_ref (buf);
+	obj->size = r_buf_size (buf);
+	obj->verbose = verbose;
+	obj->sym_ht = ht_up_new0 ();
+	obj->imp_ht = ht_up_new0 ();
+	if (!r_bin_xcoff64_init_hdr (obj)) {
+		R_LOG_ERROR ("failed to init xcoff64 header");
+		return false;
+	}
+	r_bin_xcoff64_init_opt_hdr (obj);
+	if (!r_bin_xcoff64_init_scn_hdr (obj)) {
+	    R_LOG_WARN ("failed to init section header");
+	    return false;
+	}
+	if (!r_bin_xcoff64_init_scn_va (obj)) {
+		R_LOG_WARN ("failed to init section VA table");
+		return false;
+	}
+	if (!r_bin_coff_init_symtable (obj)) {
+		R_LOG_WARN ("failed to init symtable");
+		return false;
+	}
+	return true;
+}
+
+R_IPI void r_bin_xcoff64_free(RBinXCoff64Obj *obj) {
+	if (obj) {
+		ht_up_free (obj->sym_ht);
+		ht_up_free (obj->imp_ht);
+		free (obj->scn_va);
+		free (obj->scn_hdrs);
+		free (obj->symbols);
+		r_buf_free (obj->b);
+		free (obj);
+	}
+}
+
+R_IPI RBinXCoff64Obj *r_bin_xcoff64_new_buf(RBuffer *buf, bool verbose) {
+	RBinXCoff64Obj* bin = R_NEW0 (RBinXCoff64Obj);
+	r_bin_xcoff64_init (bin, buf, verbose);
+	return bin;
+}

--- a/libr/bin/format/coff/xcoff64.h
+++ b/libr/bin/format/coff/xcoff64.h
@@ -1,0 +1,42 @@
+/* radare - LGPL - Copyright 2023 terorie */
+
+#ifndef XCOFF_H
+#define XCOFF_H
+
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+
+#include "coff_specs.h"
+
+typedef struct r_bin_xcoff64_obj {
+	/* File headers */
+	struct xcoff64_hdr hdr;
+	struct xcoff64_opt_hdr opt_hdr;
+	struct xcoff64_scn_hdr *scn_hdrs;
+
+	/* Symbol table contains a mix of symbols and auxiliary entries.
+	 * The actual type only becomes apparent when walking the table. */
+	union xcoff64_syment *symbols;
+
+	/* File offset of symbol name table */
+	ut64 nametbl_off;
+
+	RBuffer *b;
+	size_t size;
+	ut8 endian;
+	Sdb *kv;
+	bool verbose;
+	HtUP *sym_ht;
+	HtUP *imp_ht;
+	ut64 *scn_va;
+} RBinXCoff64Obj;
+
+R_IPI bool r_xcoff64_supported_arch(const ut8 *arch);
+R_IPI RBinXCoff64Obj *r_bin_xcoff64_new_buf(RBuffer *buf, bool verbose);
+R_IPI void r_bin_xcoff64_free(RBinXCoff64Obj *obj);
+R_IPI RBinAddr *r_xcoff64_get_entry(RBinXCoff64Obj *obj);
+R_IPI char *r_xcoff64_symbol_name(RBinXCoff64Obj *obj, ut32 offset);
+
+#endif /* XCOFF_H */

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -76,6 +76,7 @@ r_bin_sources = [
   'p/bin_write_pe.c',
   'p/bin_write_pe64.c',
   'p/bin_xbe.c',
+  'p/bin_xcoff64.c',
   'p/bin_xnu_kernelcache.c',
   'p/bin_xtr_dyldcache.c',
   'p/bin_xtr_fatmach0.c',
@@ -87,6 +88,7 @@ r_bin_sources = [
 # implementation
   'format/bflt/bflt.c',
   'format/coff/coff.c',
+  'format/coff/xcoff64.c',
   'format/dex/dex.c',
   'format/dmp/dmp64.c',
   'format/elf/elf.c',

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -19,7 +19,7 @@ all: ${ALL_TARGETS}
 ALL_TARGETS=
 FORMATS=any.mk elf.mk elf64.mk pe.mk pe64.mk te.mk mach0.mk
 FORMATS+=bios.mk mach064.mk dyldcache.mk xnu_kernelcache.mk java.mk
-FORMATS+=dex.mk fs.mk ningb.mk coff.mk ningba.mk xbe.mk zimg.mk
+FORMATS+=dex.mk fs.mk ningb.mk coff.mk xcoff64.mk ningba.mk xbe.mk zimg.mk
 FORMATS+=omf.mk cgc.mk dol.mk rel.mk nes.mk mbn.mk psxexe.mk
 FORMATS+=vsf.mk nin3ds.mk bflt.mk wasm.mk sfc.mk
 FORMATS+=mdmp.mk z64.mk qnx.mk prg.mk dmp64.mk

--- a/libr/bin/p/bin_xcoff64.c
+++ b/libr/bin/p/bin_xcoff64.c
@@ -1,0 +1,257 @@
+/* radare - LGPL - Copyright 2023 - terorie */
+
+#include <r_types.h>
+#include <r_util.h>
+#include <r_lib.h>
+#include <r_bin.h>
+
+#include "coff/xcoff64.h"
+
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	*bin_obj = r_bin_xcoff64_new_buf (buf, bf->rbin->verbose);
+	return *bin_obj;
+}
+
+static void destroy(RBinFile *bf) {
+	r_bin_xcoff64_free ((struct r_bin_xcoff64_obj*)bf->o->bin_obj);
+}
+
+static ut64 baddr(RBinFile *bf) {
+	return 0;
+}
+
+static RBinAddr *binsym(RBinFile *bf, int sym) {
+	return NULL;
+}
+
+static bool _fill_bin_symbol(RBin *rbin, struct r_bin_xcoff64_obj *bin, int idx, RBinSymbol **sym) {
+	RBinSymbol *ptr = *sym;
+	struct xcoff64_symbol *s = NULL;
+	if (idx < 0 || idx > bin->hdr.f_nsyms) {
+		return false;
+	}
+	if (!bin->symbols) {
+		return false;
+	}
+	s = &bin->symbols[idx].sym;
+	char *coffname = r_xcoff64_symbol_name (bin, s->n_offset);
+	if (!coffname) {
+		return false;
+	}
+	ptr->name = coffname;
+	ptr->forwarder = "NONE";
+	ptr->bind = R_BIN_BIND_LOCAL_STR;
+	ptr->is_imported = false;
+
+	switch (s->n_sclass) {
+	case COFF_SYM_CLASS_FUNCTION:
+		ptr->type = R_BIN_TYPE_FUNC_STR;
+		break;
+	case COFF_SYM_CLASS_FILE:
+		ptr->type = R_BIN_TYPE_FILE_STR;
+		break;
+	case COFF_SYM_CLASS_SECTION:
+		ptr->type = R_BIN_TYPE_SECTION_STR;
+		break;
+	}
+
+	ptr->size = 4;
+	ptr->ordinal = 0;
+	return true;
+}
+
+static RList *entries(RBinFile *bf) {
+	struct r_bin_xcoff64_obj *obj = (struct r_bin_xcoff64_obj*)bf->o->bin_obj;
+	RList *ret;
+	if (!(ret = r_list_newf (free))) {
+		return NULL;
+	}
+	RBinAddr *ptr = r_xcoff64_get_entry (obj);
+	if (ptr) {
+		r_list_append (ret, ptr);
+	}
+	return ret;
+}
+
+/* parse_section_flags: parses the scn_hdr flags field and returns a "type" string (rodata).
+ * Also writes permission bits out to perm. Permission depends on the file magic. */
+static inline const char *parse_section_flags(ut32 i, ut32 *perm, ut16 magic) {
+	switch (i & 0xFFFF) {
+	case XCOFF_SCN_TYPE_TEXT:
+		switch (magic) {
+		case XCOFF32_FILE_MACHINE_U800WR:
+		case XCOFF32_FILE_MACHINE_U802WR:
+			*perm |= R_PERM_R|R_PERM_W|R_PERM_X;
+			break;
+		default:
+			*perm |= R_PERM_R|R_PERM_X;
+			break;
+		}
+		return "TEXT";
+	case XCOFF_SCN_TYPE_DATA:
+	case XCOFF_SCN_TYPE_TDATA:
+		*perm |= R_PERM_R|R_PERM_W;
+		return "DATA";
+	case XCOFF_SCN_TYPE_BSS:
+	case XCOFF_SCN_TYPE_TBSS:
+		*perm |= R_PERM_R|R_PERM_W;
+		return "BSS";
+	case XCOFF_SCN_TYPE_LOADER:
+		return "LOADER";
+	case XCOFF_SCN_TYPE_DEBUG:
+		return "DEBUG";
+	case XCOFF_SCN_TYPE_DWARF:
+		return "DWARF";
+	case XCOFF_SCN_TYPE_EXCEPT:
+		return "EXCEPT";
+	case XCOFF_SCN_TYPE_INFO:
+		return "INFO";
+	case XCOFF_SCN_TYPE_TYPCHK:
+		return "TYPCHK";
+	case XCOFF_SCN_TYPE_OVRFLO:
+		return "OVRFLO";
+	case XCOFF_SCN_TYPE_REG:
+		return "REG";
+	case XCOFF_SCN_TYPE_PAD:
+		return "PAD";
+	default:
+		return "";
+	}
+}
+
+static RList *sections(RBinFile *bf) {
+	char *tmp = NULL;
+	size_t i;
+	RBinSection *ptr = NULL;
+	struct r_bin_xcoff64_obj *obj = (struct r_bin_xcoff64_obj*)bf->o->bin_obj;
+
+	RList *ret = r_list_newf ((RListFree)r_bin_section_free);
+	if (!ret) {
+		return NULL;
+	}
+	if (obj && obj->scn_hdrs) {
+		for (i = 0; i < obj->hdr.f_nscns; i++) {
+			tmp = r_str_ndup (obj->scn_hdrs[i].s_name, 8);
+			if (!tmp) {
+				r_list_free (ret);
+				return NULL;
+			}
+			ptr = R_NEW0 (RBinSection);
+			if (!ptr) {
+				free (tmp);
+				return ret;
+			}
+			ptr->name = tmp;
+			if (strstr (ptr->name, "data")) {
+				ptr->is_data = true;
+			}
+			ptr->size = obj->scn_hdrs[i].s_size;
+			ptr->vsize = obj->scn_hdrs[i].s_size;
+			ptr->paddr = obj->scn_hdrs[i].s_scnptr;
+			ptr->perm = 0;
+			ptr->type = parse_section_flags (obj->scn_hdrs[i].s_flags, &ptr->perm, obj->hdr.f_magic);
+			if (obj->scn_va) {
+				ptr->vaddr = obj->scn_va[i];
+			}
+			ptr->add = true;
+			r_list_append (ret, ptr);
+		}
+	}
+	return ret;
+}
+
+static RList *symbols(RBinFile *bf) {
+	int i;
+	RBinSymbol *ptr = NULL;
+	struct r_bin_xcoff64_obj *obj = (struct r_bin_xcoff64_obj*)bf->o->bin_obj;
+	RList *ret = r_list_newf ((RListFree)r_bin_symbol_free);
+	if (!ret) {
+		return NULL;
+	}
+	ret->free = free;
+	if (obj->symbols) {
+		for (i = 0; i < obj->hdr.f_nsyms; i++) {
+			if (!(ptr = R_NEW0 (RBinSymbol))) {
+				break;
+			}
+			if (_fill_bin_symbol (bf->rbin, obj, i, &ptr)) {
+				r_list_append (ret, ptr);
+				ht_up_insert (obj->sym_ht, (ut64)i, ptr);
+			} else {
+				free (ptr);
+			}
+			i += obj->symbols[i].sym.n_numaux;
+		}
+	}
+	return ret;
+}
+
+static RBinInfo *info(RBinFile *bf) {
+	RBinInfo *ret = R_NEW0(RBinInfo);
+	struct r_bin_xcoff64_obj *obj = (struct r_bin_xcoff64_obj*)bf->o->bin_obj;
+
+	ret->file = bf->file? strdup (bf->file): NULL;
+	ret->rclass = strdup ("xcoff64");
+	ret->bclass = strdup ("xcoff64");
+	ret->type = strdup ("XCOFF64 (Executable file)");
+	ret->os = strdup ("aix");
+	ret->subsystem = strdup ("unknown");
+	ret->big_endian = obj->endian;
+	ret->has_va = true;
+	ret->dbg_info = 0;
+	ret->has_lit = true;
+
+	switch (obj->hdr.f_magic) {
+	case XCOFF64_FILE_MACHINE_U803TOC:
+	case XCOFF64_FILE_MACHINE_U803XTOC:
+	case XCOFF64_FILE_MACHINE_U64:
+		ret->machine = strdup ("ppc");
+		ret->arch = strdup ("ppc");
+		ret->big_endian = true;
+		ret->bits = 64;
+		break;
+	default:
+		ret->machine = strdup ("unknown");
+	}
+
+	return ret;
+}
+
+static RList *fields(RBinFile *bf) {
+	return NULL;
+}
+
+static ut64 size(RBinFile *bf) {
+	return 0;
+}
+
+static bool check_buffer(RBinFile *bf, RBuffer *b) {
+	ut8 tmp[24];
+	int r = r_buf_read_at (b, 0, tmp, sizeof (tmp));
+	return r >= 24 && r_xcoff64_supported_arch (tmp);
+}
+
+RBinPlugin r_bin_plugin_xcoff64 = {
+	.name = "xcoff64",
+	.desc = "xcoff64 r_bin plugin",
+	.license = "LGPL3",
+	.load_buffer = &load_buffer,
+	.destroy = &destroy,
+	.check_buffer = &check_buffer,
+	.baddr = &baddr,
+	.binsym = &binsym,
+	.entries = &entries,
+	.sections = &sections,
+	.symbols = &symbols,
+	.info = &info,
+	.fields = &fields,
+	.size = &size
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_xcoff64,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/bin/p/xcoff64.mk
+++ b/libr/bin/p/xcoff64.mk
@@ -1,0 +1,11 @@
+OBJ_XCOFF64=bin_xcoff64.o
+OBJ_XCOFF64+=../format/coff/xcoff64.o
+
+STATIC_OBJ+=${OBJ_XCOFF64}
+TARGET_XCOFF64=bin_xcoff64.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_XCOFF64}
+
+${TARGET_XCOFF64}: ${OBJ_XCOFF64}
+	${CC} $(call libname,bin_xcoff64) ${CFLAGS} \
+		$(OBJ_XCOFF64) $(LINK) $(LDFLAGS)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -859,6 +859,7 @@ extern RBinPlugin r_bin_plugin_mdmp;
 extern RBinPlugin r_bin_plugin_java;
 extern RBinPlugin r_bin_plugin_dex;
 extern RBinPlugin r_bin_plugin_coff;
+extern RBinPlugin r_bin_plugin_xcoff64;
 extern RBinPlugin r_bin_plugin_ningb;
 extern RBinPlugin r_bin_plugin_ningba;
 extern RBinPlugin r_bin_plugin_ninds;

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -122,7 +122,7 @@ if not no_user_plugins
     bin_plugins += [ 'elf', 'elf64' ]
   endif
   if user_plugins.contains('pe')
-    bin_plugins += [ 'pe', 'pe64', 'coff', 'mz', 'ne' ]
+    bin_plugins += [ 'pe', 'pe64', 'coff', 'xcoff64', 'mz', 'ne' ]
     bin_xtr_plugins += [ 'xtr_pemixed' ]
   endif
   if not user_plugins.contains('nogrub')
@@ -252,6 +252,7 @@ bin_plugins += [
   'vsf',
   'wasm',
   'xbe',
+  'xcoff64',
   'xnu_kernelcache',
   'z64',
   'zimg'

--- a/test/db/formats/xcoff64
+++ b/test/db/formats/xcoff64
@@ -1,0 +1,35 @@
+NAME=ppc xcoff64
+FILE=bins/xcoff/gcc-ppc64-aix-dwarf2-exec
+CMDS=<<EOF
+i~^format
+e asm.arch
+e asm.bits
+EOF
+EXPECT=<<EOF
+format   xcoff64
+ppc
+64
+EOF
+RUN
+
+NAME=xcoff64 sections
+FILE=bins/xcoff/gcc-ppc64-aix-dwarf2-exec
+CMDS=iS
+EXPECT=<<EOF
+[Sections]
+
+nth paddr         size vaddr        vsize perm type   name
+----------------------------------------------------------
+0   0x00000480   0xafd 0x20001300   0xafd -r-x TEXT   .text
+1   0x00000f7d   0x2f3 0x10000480   0x2f3 -rw- DATA   .data
+2   0x00000000   0x428 0x20000f7d   0x428 -rw- BSS    .bss
+3   0x00001270   0x535 0x20001e00   0x535 ---- LOADER .loader
+4   0x000017a6    0xb4 0x20002340    0xb4 ---- DWARF  .dwline
+5   0x0000185a   0x36a 0x20002400   0x36a ---- DWARF  .dwinfo
+6   0x00001bc4    0xb5 0x20002770    0xb5 ---- DWARF  .dwabrev
+7   0x00001c7a    0x40 0x20002830    0x40 ---- DWARF  .dwarnge
+8   0x00001cba    0x62 0x20002870    0x62 ---- DWARF  .dwloc
+9   0x00001d1c  0x6605 0x200028e0  0x6605 ---- DEBUG  .debug
+
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Basic XCOFF64 support. Unfortunately, some duplicated code. 
XCOFF32 not implemented yet.