### PR TITLE
Fix the type used for the fini callback in r_arch_plugin_t ##arch

### DIFF
--- a/libr/include/r_arch.h
+++ b/libr/include/r_arch.h
@@ -163,7 +163,7 @@ typedef struct r_arch_plugin_t {
 	RSysBits bits;
 	RSysBits addr_bits;
 	RArchPluginInitCallback init;
-	RArchPluginInitCallback fini;
+	RArchPluginFiniCallback fini;
 	RArchPluginInfoCallback info;
 	RArchPluginRegistersCallback regs;
 	RArchPluginEncodeCallback encode;


### PR DESCRIPTION
The fini callback has a type (RArchPluginFiniCallback) use that.
