### PR TITLE
Fix use after free in RStr.replaceAll() ##crash

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2022 - pancake */
+/* radare - LGPL - Copyright 2007-2023 - pancake */
 
 #include <r_bin.h>
 
@@ -952,7 +952,7 @@ R_API R_MUSTUSE char* r_str_replace_all(char *str, const char *key, const char *
 	while (strstr (str, key)) {
 		res = r_str_replace (str, key, val, true);
 		if (!res) {
-			return str;
+			return NULL;
 		}
 		str = res;
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
