### PR TITLE
Deprecate the asm.minicols config variable ##disasm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3674,7 +3674,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.anal", "false", "analyze code and refs while disassembling (see anal.strings)");
 	SETI ("asm.symbol.col", 40, "columns width to show asm.section");
 	SETCB ("asm.assembler", "", &cb_asmassembler, "set the plugin name to use when assembling");
-	SETBPREF ("asm.minicols", "false", "only show the instruction in the column disasm");
 	RConfigNode *asmcpu = NODECB ("asm.cpu", R_SYS_ARCH, &cb_asmcpu);
 	SETDESC (asmcpu, "set the kind of asm.arch cpu");
 	RConfigNode *asmarch = NODECB ("asm.arch", R_SYS_ARCH, &cb_asmarch);

--- a/libr/core/cmd_print.c
+++ b/libr/core/cmd_print.c
@@ -884,12 +884,8 @@ static void cmd_pCd(RCore *core, const char *input) {
 	int rows = h - 2;
 	int obsz = core->blocksize;
 	int user_rows = r_num_math (core->num, input);
-	bool asm_minicols = r_config_get_i (core->config, "asm.minicols");
 	char *o_ao = strdup (r_config_get (core->config, "asm.offset"));
 	char *o_ab = strdup (r_config_get (core->config, "asm.bytes"));
-	if (asm_minicols) {
-		r_config_set_b (core->config, "asm.offset", false);
-	}
 	r_config_set_b (core->config, "asm.bytes", false);
 	if (user_rows > 0) {
 		rows = user_rows + 1;
@@ -913,10 +909,6 @@ static void cmd_pCd(RCore *core, const char *input) {
 	r_cons_pop ();
 	r_cons_canvas_print (c);
 	r_cons_canvas_free (c);
-	if (asm_minicols) {
-		r_config_set (core->config, "asm.offset", o_ao);
-		r_config_set (core->config, "asm.bytes", o_ab);
-	}
 	r_config_set (core->config, "asm.bytes", o_ab);
 	free (o_ao);
 	free (o_ab);
@@ -966,13 +958,8 @@ static void cmd_pCD(RCore *core, const char *input) {
 	int rows = h - 2;
 	int obsz = core->blocksize;
 	int user_rows = r_num_math (core->num, input);
-	bool asm_minicols = r_config_get_i (core->config, "asm.minicols");
 	char *o_ao = strdup (r_config_get (core->config, "asm.offset"));
 	char *o_ab = strdup (r_config_get (core->config, "asm.bytes"));
-	if (asm_minicols) {
-		r_config_set_b (core->config, "asm.offset", false);
-		r_config_set_b (core->config, "asm.bytes", false);
-	}
 	r_config_set_b (core->config, "asm.bytes", false);
 	if (user_rows > 0) {
 		rows = user_rows + 1;
@@ -1011,10 +998,6 @@ static void cmd_pCD(RCore *core, const char *input) {
 	r_cons_pop ();
 	r_cons_canvas_print (c);
 	r_cons_canvas_free (c);
-	if (asm_minicols) {
-		r_config_set (core->config, "asm.offset", o_ao);
-		r_config_set (core->config, "asm.bytes", o_ab);
-	}
 	r_config_set (core->config, "asm.bytes", o_ab);
 	free (o_ao);
 	free (o_ab);


### PR DESCRIPTION
* Just set asm.offset=0 and asm.bytes=0 if needed on multicolumn disasm

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
