### PR TITLE
Fix #21332 - Add missing use_sys_openssl option for meson ##build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -281,6 +281,7 @@ else
 endif
 
 # handle openssl library
+use_ssl_crypto = get_option('use_ssl_crypto')
 if get_option('use_ssl')
   static_sys_openssl = get_option('static_sys_openssl')
   sys_openssl = dependency('openssl', required: false, static: static_sys_openssl)


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
