### PR TITLE
Improve checks parsing dyldcache headers ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1618,15 +1618,20 @@ static void populate_cache_headers(RDyldCache *cache) {
 	cache_hdr_t *h;
 	ut64 offsets[MAX_N_HDR];
 	ut64 offset = 0;
+	ut64 buf_size = r_buf_size (cache->buf);
 	do {
 		offsets[cache->n_hdr] = offset;
 		h = read_cache_header (cache->buf, offset);
 		if (!h) {
 			break;
 		}
-		r_list_append (hdrs, h);
 
 		ut64 size = h->codeSignatureOffset + h->codeSignatureSize;
+		if (!size || size > buf_size) {
+			break;
+		}
+
+		r_list_append (hdrs, h);
 
 #define SHIFT_MAYBE(x) \
 	if (x) { \


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Bail out parsing multiple headers if malformed (as opposed to keeping re-parsing the same header when size is zero until the max limit is reached).

<!-- explain your changes if necessary -->
