### PR TITLE
Use calloc in kvx arch plugin

### DIFF
--- a/libr/arch/p/kvx/plugin.c
+++ b/libr/arch/p/kvx/plugin.c
@@ -233,19 +233,18 @@ static const char *kvx_reg_profile = ""
  */
 
 static bool kvx_init(RArchSession *s) {
-	r_return_val_if_fail (!s->user, false);
-	s->user = malloc (sizeof (bundle_t));
-	return s->user? true: false;
+	r_return_val_if_fail (s && !s->data, false);
+	s->data = R_NEW0 (bundle_t);
+	return s->data? true: false;
 }
 
 static bool kvx_fini(RArchSession *s) {
-	free (s->user);
-	s->user = NULL;
+	R_FREE (s->data);
 	return true;
 }
 
 static bool kvx_op(RArchSession *a, RAnalOp *op, RArchDecodeMask mask) {
-	bundle_t *bundle = a->user;
+	bundle_t *bundle = a->data;
 	const ut64 addr = op->addr;
 	const size_t len = op->size;
 	const ut8 *data = op->bytes;


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

The plugin user struct used to be in bss, thus zero initialized... Lets use calloc here, just in case.

