### PR TITLE
Fix ELF parser hang on malformed .plt.got header ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1606,7 +1606,7 @@ static ut64 get_import_addr_x86_manual(ELFOBJ *bin, RBinElfReloc *rel) {
 	ut64 plt_addr = s->offset;
 	ut64 plt_sym_addr;
 
-	while (plt_addr + 2 + 4 < s->offset + s->size) {
+	while (plt_addr + 2 + 4 < s->offset + s->size && plt_addr + 2 + 4 < bin->size) {
 		/*we try to locate the plt entry that correspond with the relocation
 		  since got does not point back to .plt. In this case it has the following
 		  form


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

.plt.got size read from the section header is not sanity checked to lie within file, hence get_import_addr_x86_manual() may get stuck in a loop  with high CPU usage on crafted ELF, unable to find plt_addr but still increasing it. 

It may take r2 a very long time to open such ELFs if size of .plt.got as stated in its header is too big, effectively looking like a DoS.
