### PR TITLE
ob to oi and omb to ob

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -4602,7 +4602,7 @@ static bool r_core_bin_file_print(RCore *core, RBinFile *bf, PJ *pj, int mode) {
 	switch (mode) {
 	case '*': {
 		char *n = __filterShell (name);
-		r_cons_printf ("oba 0x%08"PFMT64x" %s # %d\n", bf->o->boffset, n, bf->id);
+		r_cons_printf ("oia 0x%08" PFMT64x " %s # %d\n", bf->o->boffset, n, bf->id);
 		free (n);
 		break;
 	}

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -738,7 +738,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 				r_core_file_loadlib (r, lib, baddr);
 			}
 		}
-		r_core_cmd0 (r, "obb 0;s entry0");
+		r_core_cmd0 (r, "oio 0;s entry0");
 		r_config_set_i (r->config, "bin.at", true);
 		R_LOG_INFO ("[bin.libs] Linking imports");
 		RBinImport *imp;
@@ -831,7 +831,7 @@ beach:
 			// RBinObject *obj = r_bin_cur_object (r->bin);
 			// ut64 nbaddr = obj? obj->baddr: baddr;
 			r_core_cmd_callf (r, "o %s", macdwarf);
-			r_core_cmd_call (r, "obm-");
+			r_core_cmd_call (r, "oim-");
 			// r_core_cmd_callf (r, "o-."); // causes uaf
 		}
 		free (macdwarf);

--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -406,7 +406,7 @@ R_API bool r_core_seek(RCore *core, ut64 addr, bool rb) {
 		if (bf) {
 			core->bin->cur = bf;
 			r_bin_select_bfid (core->bin, bf->id);
-			// XXX r_core_cmdf (core, "obb %d", bf->id);
+			// XXX r_core_cmdf (core, "oib %d", bf->id);
 		} else {
 			core->bin->cur = NULL;
 		}

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -106,14 +106,14 @@ static const char *help_msg_oia[] = {
 
 static const char *help_msg_oi[] = {
 	"Usage:", "oi", " # List open binary files backed by fd",
-	"oi", " [name|bfid]", "switch to open given objid (or name)",
-	"oi", "", "list opened binary files and objid",
-	"oi*", "", "list opened binary files and objid (r2 commands)",
+	"oi", " [name|bfid]", "switch to open given binfd (or name)",
+	"oi", "", "list opened binary files and binfd",
+	"oi*", "", "list opened binary files and binfd (r2 commands)",
 	"oi", " *", "select all bins (use 'oi bfid' to pick one)",
 	"oim", "([id])", "merge current selected binfile into previous binfile (id-1)",
 	"oim-", "([id])", "same as oim, but deletes the current binfile",
 	"oi-", "*", "delete all binfiles",
-	"oi-", "[objid]", "delete binfile by objid",
+	"oi-", "[binfd]", "delete binfile by binfd",
 	"oi--", "", "delete the last binfile",
 	"oi.", " ([addr])", "show bfid at current address",
 	"oi=", "", "show ascii art table having the list of open files",
@@ -122,7 +122,7 @@ static const char *help_msg_oi[] = {
 	"oia", " [addr] [filename]", "open file and load bin info at given address",
 	"oia", " [addr]", "open bin info from the given address",
 	"oif", " ([file])", "load bininfo for current file (useful for r2 -n)",
-	"oij", "", "list opened binary files and objid (JSON format)",
+	"oij", "", "list opened binary files and binfd (JSON format)",
 	"oio", " [fd]", "switch to open binfile by fd number",
 	"oir", " [baddr]", "rebase current bin object",
 	NULL

--- a/libr/core/cmd_open.c
+++ b/libr/core/cmd_open.c
@@ -19,7 +19,7 @@ static const char *help_msg_o[] = {
 	"o=","","list opened files (ascii-art bars)",
 	"oL","","list all IO plugins registered",
 	"oa","[?][-] [A] [B] [filename]","specify arch and bits for given file",
-	"ob","[?] [lbdos] [...]","list opened binary files backed by fd",
+	"oi","[?] [lbdos] [...]","list opened binary files backed by fd",
 	"oc"," [file]","open core file, like relaunching r2",
 	"of","[?] [file]","open file without creating any map",
 	"oe"," [filename]","open cfg.editor with given file",
@@ -27,7 +27,7 @@ static const char *help_msg_o[] = {
 	"om","[?]","create, list, remove IO maps",
 	"on","[?][n] [file] 0x4000","map raw file at 0x4000 (no r_bin involved)",
 	"oo","[?][+bcdnm]","reopen current file (see oo?) (reload in rw or debugger)",
-	"op","[r|n|p|fd]", "select priorized file by fd (see ob), opn/opp/opr = next/previous/rotate",
+	"op","[r|n|p|fd]", "select priorized file by fd (see oi), opn/opp/opr = next/previous/rotate",
 	"ot"," [file]", "same as `touch [file]`",
 	"oq","","list all open files",
 	"ox", " fd fdx", "exchange the descs of fd and fdx and keep the mapping",
@@ -96,35 +96,35 @@ static const char *help_msg_o_star[] = {
 	"o*", "", "list opened files in r2 commands", NULL
 };
 
-static const char *help_msg_oba[] = {
-	"Usage:", "oba [addr] ([filename])", " # load bininfo and update flags",
-	"oba", " [addr]", "open bin info from the given address",
-	"oba", " [addr] [baddr]", "open file and load bin info at given address",
-	"oba", " [addr] [/abs/filename]", "open file and load bin info at given address",
+static const char *help_msg_oia[] = {
+	"Usage:", "oia [addr] ([filename])", " # load bininfo and update flags",
+	"oia", " [addr]", "open bin info from the given address",
+	"oia", " [addr] [baddr]", "open file and load bin info at given address",
+	"oia", " [addr] [/abs/filename]", "open file and load bin info at given address",
 	NULL
 };
 
-static const char *help_msg_ob[] = {
-	"Usage:", "ob", " # List open binary files backed by fd",
-	"ob", " [name|bfid]", "switch to open given objid (or name)",
-	"ob", "", "list opened binary files and objid",
-	"ob*", "", "list opened binary files and objid (r2 commands)",
-	"ob", " *", "select all bins (use 'ob bfid' to pick one)",
-	"obm", "([id])", "merge current selected binfile into previous binfile (id-1)",
-	"obm-", "([id])", "same as obm, but deletes the current binfile",
-	"ob-", "*", "delete all binfiles",
-	"ob-", "[objid]", "delete binfile by binobjid",
-	"ob--", "", "delete the last binfile",
-	"ob.", " ([addr])", "show bfid at current address",
-	"ob=", "", "show ascii art table having the list of open files",
-	"obL", "", "same as iL or Li",
-	"oba", " [addr] [baddr]", "open file and load bin info at given address",
-	"oba", " [addr] [filename]", "open file and load bin info at given address",
-	"oba", " [addr]", "open bin info from the given address",
-	"obf", " ([file])", "load bininfo for current file (useful for r2 -n)",
-	"obj", "", "list opened binary files and objid (JSON format)",
-	"obo", " [fd]", "switch to open binfile by fd number",
-	"obr", " [baddr]", "rebase current bin object",
+static const char *help_msg_oi[] = {
+	"Usage:", "oi", " # List open binary files backed by fd",
+	"oi", " [name|bfid]", "switch to open given objid (or name)",
+	"oi", "", "list opened binary files and objid",
+	"oi*", "", "list opened binary files and objid (r2 commands)",
+	"oi", " *", "select all bins (use 'oi bfid' to pick one)",
+	"oim", "([id])", "merge current selected binfile into previous binfile (id-1)",
+	"oim-", "([id])", "same as oim, but deletes the current binfile",
+	"oi-", "*", "delete all binfiles",
+	"oi-", "[objid]", "delete binfile by objid",
+	"oi--", "", "delete the last binfile",
+	"oi.", " ([addr])", "show bfid at current address",
+	"oi=", "", "show ascii art table having the list of open files",
+	"oiL", "", "same as iL or Li",
+	"oia", " [addr] [baddr]", "open file and load bin info at given address",
+	"oia", " [addr] [filename]", "open file and load bin info at given address",
+	"oia", " [addr]", "open bin info from the given address",
+	"oif", " ([file])", "load bininfo for current file (useful for r2 -n)",
+	"oij", "", "list opened binary files and objid (JSON format)",
+	"oio", " [fd]", "switch to open binfile by fd number",
+	"oir", " [baddr]", "rebase current bin object",
 	NULL
 };
 
@@ -234,24 +234,24 @@ static bool isfile(const char *filename) {
 }
 
 // HONOR bin.at
-static void cmd_open_bin(RCore *core, const char *input) {
+static void cmd_open_id(RCore *core, const char *input) {
 	const char *value = NULL;
 	ut32 binfile_num = -1;
 
 	switch (input[1]) {
-	case 'L': // "obL"
+	case 'L': // "oiL"
 		r_core_cmd0 (core, "iL");
 		break;
-	case '\0': // "ob"
-	case 'q': // "obj"
-	case 'j': // "obj"
-	case '*': // "ob*"
+	case '\0': // "oi"
+	case 'q': // "oiq"
+	case 'j': // "oij"
+	case '*': // "oi*"
 		r_core_bin_list (core, input[1]);
 		if (input[1] == 'j') {
 			r_cons_newline ();
 		}
 		break;
-	case '.': // "ob."
+	case '.': // "oi."
 		{
 			const char *arg = r_str_trim_head_ro (input + 2);
 			ut64 at = core->offset;
@@ -267,9 +267,9 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			}
 		}
 		break;
-	case 'a': // "oba"
+	case 'a': // "oia"
 		if ('?' == input[2]) {
-			r_core_cmd_help (core, help_msg_oba);
+			r_core_cmd_help (core, help_msg_oia);
 			break;
 		}
 		if (input[2] && input[3]) {
@@ -345,7 +345,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			r_list_free (files);
 		}
 		break;
-	case ' ': // "ob " // select bf by id or name
+	case ' ': // "oi " // select bf by id or name
 	{
 		ut32 id;
 		const char *tmp;
@@ -362,7 +362,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 		}
 		int n = r_str_word_set0 (v);
 		if (n < 1 || n > 2) {
-			eprintf ("Usage: ob [file|objid]\n");
+			r_core_cmd_help_match (core, help_msg_oi, "oi", true);
 			free (v);
 			break;
 		}
@@ -378,19 +378,19 @@ static void cmd_open_bin(RCore *core, const char *input) {
 		free (v);
 		break;
 	}
-	case 'r': // "obr"
+	case 'r': // "oir"
 		r_core_bin_rebase (core, r_num_math (core->num, input + 3));
 		r_core_cmd0 (core, ".is*");
 		break;
-	case 'f': // "obf"
+	case 'f': // "oif"
 		if (input[2] == ' ') {
-			r_core_cmdf (core, "oba 0 %s", input + 3);
+			r_core_cmdf (core, "oia 0 %s", input + 3);
 		} else {
 			r_core_bin_load (core, NULL, UT64_MAX);
 			value = input[2] ? input + 2 : NULL;
 		}
 		break;
-	case 'm': // "obm"
+	case 'm': // "oim"
 		{
 			int dstid = atoi (input + 2);
 			// TODO take argument with given id to merge to
@@ -404,7 +404,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 				if (dst) {
 					r_bin_file_merge (dst, src);
 					R_LOG_DEBUG ("merge %d into %d", current, dstid);
-					if (strchr (input + 2, '-')) { // "obm-"
+					if (strchr (input + 2, '-')) { // "oim-"
 						int curfd = -1;
 						if (core->io->desc) {
 							curfd = core->io->desc->fd;
@@ -425,7 +425,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			R_LOG_INFO ("Nothing to merge");
 		}
 		break;
-	case 'o': // "obo"
+	case 'o': // "oio"
 		if (input[2] == ' ') {
 			ut32 fd = r_num_math (core->num, input + 3);
 			RBinFile *bf = r_bin_file_find_by_fd (core->bin, fd);
@@ -433,18 +433,18 @@ static void cmd_open_bin(RCore *core, const char *input) {
 				R_LOG_ERROR ("Invalid RBinFile.id number");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_ob, "obo", true);
+			r_core_cmd_help_match (core, help_msg_oi, "oio", true);
 		}
 		break;
-	case '-': // "ob-"
+	case '-': // "oi-"
 		if (input[2] == '*') {
 			r_bin_file_delete_all (core->bin);
 		} else if (input[2] == '-') {
 			RBinFile *bf = r_bin_cur (core->bin);
 			int current = bf? bf->id: 0;
 			if (current >= 0) {
-				r_core_cmd_callf (core, "ob-%d", current);
-				r_core_cmd_callf (core, "ob %d", current -1);
+				r_core_cmd_callf (core, "oi-%d", current);
+				r_core_cmd_callf (core, "oi %d", current -1);
 			}
 		} else {
 			ut32 id;
@@ -466,7 +466,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			}
 		}
 		break;
-	case '=': // "ob="
+	case '=': // "oi="
 		{
 			char temp[SDB_NUM_BUFSZ];
 			RListIter *iter;
@@ -495,8 +495,8 @@ static void cmd_open_bin(RCore *core, const char *input) {
 			r_table_free (table);
 			r_list_free (list);
 		} break;
-	case '?': // "ob?"
-		r_core_cmd_help (core, help_msg_ob);
+	case '?': // "oi?"
+		r_core_cmd_help (core, help_msg_oi);
 		break;
 	}
 }
@@ -2107,8 +2107,8 @@ static int cmd_open(void *data, const char *input) {
 		}
 		break;
 	}
-	case 'b': // "ob"
-		cmd_open_bin (core, input);
+	case 'i': // "oi"
+		cmd_open_id (core, input);
 		break;
 	case '-': // "o-"
 		switch (input[1]) {
@@ -2317,7 +2317,7 @@ static int cmd_open(void *data, const char *input) {
 						ut64 orig_baddr = core->bin->cur->o->baddr_shift;
 						RList *orig_sections = __save_old_sections (core);
 
-						r_core_cmd0 (core, "ob-*");
+						r_core_cmd0 (core, "oi-*");
 						r_io_close_all (core->io);
 						r_config_set_b (core->config, "cfg.debug", false);
 						r_core_cmdf (core, "o %s", file);

--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -1421,9 +1421,9 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			}
 			if (mapaddr) {
 				if (r_config_get_i (r->config, "file.info")) {
-					R_LOG_WARN ("using oba to load the syminfo from different mapaddress");
+					R_LOG_WARN ("using oia to load the syminfo from different mapaddress");
 					// load symbols when using r2 -m 0x1000 /bin/ls
-					r_core_cmdf (r, "oba 0 0x%"PFMT64x, mapaddr);
+					r_core_cmdf (r, "oia 0 0x%"PFMT64x, mapaddr);
 					r_core_cmd0 (r, ".ies*");
 				}
 			}

--- a/test/db/cmd/cmd_cmp
+++ b/test/db/cmd/cmd_cmp
@@ -22,16 +22,16 @@ NAME=cmp obj
 FILE=bins/elf/ls
 CMDS=<<EOF
 o bins/elf/crackme
-ob
+oi
 cil
 ?e --
 cis
 ?e --
 cii
 ?e --
-ob 0
+oi 0
 cii 0
-ob 1
+oi 1
 cii 1
 EOF
 EXPECT=<<EOF

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -118,16 +118,16 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=obo baddrs
+NAME=oio baddrs
 FILE=bins/mach0/mac-ls2
 ARGS=-B0x50000
 CMDS=<<EOF
 s
 o bins/mach0/mac-ls
 s
-obo 3
+oio 3
 s
-obo 4
+oio 4
 s
 EOF
 EXPECT=<<EOF
@@ -294,7 +294,7 @@ NAME=oob from malloc
 FILE=malloc://1024
 CMDS=<<EOF
 wx 7f454c4601010100b32ae9310000000002000300010000000800200020000000010000000000000000002000010000001b0300001b0300000700000000100000e901000000b0e8a502000049e7551ff1c2a03ff17995d4f3f241adf35954d7a87b543f48e7551ff1c3a03ff179bc17f3795487eb79543fc0b0ddf14b78543ff1b4d41632fc944be0c0563ed179e60b197f563ff190273df179bf3e412aeda9f3595485f579543f1987553ff1914c3df1796722677b743f856aeddaf159548dec91813ef179bd7df379544dc722d1e48491ed09f05954859979543f19c3553ff190733df1795e1fa60b3b519659245e820a2350831d781f8216264d88577a11fb73546c9e0b2646d11b214bd10d3c5ad1092650921c274cd10a315a9c0a744b9e59365ad10d265e921c3011df57747d881c7a11df735412cf59074a921a314c8259751ed13a3b51960b354b8415354b98163a4cdf577a35d1597901d1203b4ad11a3551d10a31519559395ad1003b4a835927509d0c20569e177b5c9e14395a9f0d271f900d744b991c745e9316225ad11435569d59355b950b7a11df7354c511b6cac511c2838b48c9899750f5818854b6c7c55fff99915eb199c552e48b865afb8fc512a4e0c511b6cac511bbc7c81cbbc7c81cbbc7c81cbbc7c81cbbc7c81cbbc7c81cbbc7c81cbbc7c81cbbe0ef65fe839611f9848011fe8b9611f7ca9550e49e8c52e3868443fa93c542fb8b895db6998c4bf3c4cb1f9ca28a41f3ca9016fa86c556f39ec542f9878011f09f8b11e1839159b683911f9ce0bc5ee3ca8650f8ca8f5eff84c55cf3ca8445b693845fff99915ed6849049f38ecb5ee48dc55ee4ca8a5fb6c99654f58e8047d68c9754f3848a55f3c48b54e2e0ef74f89e8043b69e8d54b6ba8442e59d8a43f2cadf11b6cae53196ea3ff17954d6f079543f414894b632c950f271bae4d6f079543fd24894b63287978ff2b4d4fc41f092b606f08d92c0a9ffdd0bbabd3cf179548f393a65ff78baede0f37954fe187bea37f1595492f0bab6c4708a3f3bf92c972d2390b84b00200089c689f7b9a5020000c1e902ad35f179543fabe2f7c3e9010000003231c089c3fec0cd80c3
-oba
+oia
 i~bintype[1]
 .ie*
 p8 10 @ entry0
@@ -305,18 +305,18 @@ b32ae931000000000200
 EOF
 RUN
 
-NAME=ob select files
+NAME=oi select files
 FILE=malloc://1024
 CMDS=<<EOF
 e scr.null=true
 o malloc://512
 e scr.null=false
 i~file[1]
-obo 3
+oio 3
 i~file[1]
-obo 4
+oio 4
 i~file[1]
-obo 3
+oio 3
 i~file[1]
 EOF
 EXPECT=<<EOF
@@ -327,7 +327,7 @@ malloc://1024
 EOF
 RUN
 
-NAME=ob select files binobj
+NAME=oi select files binobj
 FILE=bins/elf/libmagic.so
 CMDS=<<EOF
 iiq~?
@@ -342,7 +342,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=ob select files binobj2
+NAME=oi select files binobj2
 FILE=bins/elf/libmagic.so
 CMDS=<<EOF
 isq~?
@@ -361,18 +361,18 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=ob 0 fix
+NAME=oi 0 fix
 FILE=<<EOF
 bins/elf/_Exit (42)
 bins/elf/libverifyPass.so
 bins/elf/libc.so.6
 EOF
 CMDS=<<EOF
-ob~[1-2]
+oi~[1-2]
 ?e
-ob 1; i~^fd
-ob 2; i~^fd
-ob 0; i~^fd
+oi 1; i~^fd
+oi 2; i~^fd
+oi 0; i~^fd
 EOF
 EXPECT=<<EOF
 0 3
@@ -412,25 +412,25 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=o: ob fix
+NAME=o: oi fix
 FILE=--
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
 o: 1024
-ob
+oi
 EOF
 EXPECT=<<EOF
 * 0 3 x86-64 ba:0x00000000 sz:1024 malloc://1024
 EOF
 RUN
 
-NAME=o: obj
+NAME=o: oij
 FILE=-
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
-obj~{}
+oij~{}
 EOF
 EXPECT=<<EOF
 [
@@ -577,19 +577,19 @@ EOF
 BROKEN=1
 RUN
 
-NAME=ob *
+NAME=oi *
 FILE=bins/elf/ls
 CMDS=<<EOF
 is~?
 o bins/elf/ezpz
 is~?
 ?e --
-ob *
+oi *
 is~?
 ?e --
-ob 0
+oi 0
 is~?
-ob 1
+oi 1
 is~?
 EOF
 EXPECT=<<EOF
@@ -603,21 +603,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=obf
+NAME=oif
 FILE=--
 CMDS=<<EOF
 # pwd
-obf ./bins/mach0/test-arm32
+oif ./bins/mach0/test-arm32
 is~?
-obf ./bins/mach0/ls-m1
+oif ./bins/mach0/ls-m1
 is~?
-ob 1
+oi 1
 is~?
 i
 ?e -- o
 o
-?e -- ob
-ob
+?e -- oi
+oi
 EOF
 EXPECT=<<EOF
 8
@@ -650,7 +650,7 @@ stripped false
 subsys   darwin
 va       true
 -- o
--- ob
+-- oi
 - 0 3 arm-32 ba:0x00000000 sz:65536 ./bins/mach0/test-arm32
 * 1 3 arm-32 ba:0x00004000 sz:65536 ./bins/mach0/test-arm32
 - 2 3 x86-64 ba:0x100000000 sz:72800 ./bins/mach0/ls-m1

--- a/test/db/io/banks
+++ b/test/db/io/banks
@@ -1,39 +1,39 @@
-NAME=omb banks
+NAME=ob banks
 FILE=malloc://1024
 CMDS=<<EOF
 om
-omb+ map 1
-omb+ nomap
-omb nomap
+ob+ map 1
+ob+ nomap
+ob nomap
 om
-omb map
+ob map
 om
-omb-*
-omb -1
+ob-*
+ob -1
 EOF
 EXPECT=<<EOF
 * 1 fd: 3 +0x00000000 0x00000000 - 0x000003ff rwx
 * 1 fd: 3 +0x00000000 0x00000000 - 0x000003ff rwx
 * 1 fd: 3 +0x00000000 0x00000000 - 0x000003ff rwx
-Usage: omb[jq,+] [fd]  Operate on memory banks
-| omb          list all memory banks
-| omb [id]     switch to use a different bank
-| omb+[name]   create a new bank with given name
-| omba [id]    adds a map to the bank
-| ombd [id]    deletes a map from the bank
-| omb-*        delete all banks
-| omb-[mapid]  delete the bank with given id
-| ombg         associate all maps to the current bank
-| ombq         show current bankid
+Usage: ob[jq,+] [fd]  Operate on memory banks
+| ob          list all memory banks
+| ob [id]     switch to use a different bank
+| ob+[name]   create a new bank with given name
+| oba [id]    adds a map to the bank
+| obd [id]    deletes a map from the bank
+| ob-*        delete all banks
+| ob-[mapid]  delete the bank with given id
+| obg         associate all maps to the current bank
+| obq         show current bankid
 EOF
 RUN
 
-NAME=omb+
+NAME=ob+
 FILE=malloc://1024
 CMDS=<<EOF
-omb+ one
-omb+ two
-omb
+ob+ one
+ob+ two
+ob
 EOF
 EXPECT=<<EOF
 * 0 default [ 1 ]
@@ -42,14 +42,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=omb name deletes them all (BUG)
+NAME=ob name deletes them all (BUG)
 BROKEN=1
 FILE=malloc://1024
 CMDS=<<EOF
-omb+ one
-omb
-omb one
-omb
+ob+ one
+ob
+ob one
+ob
 EOF
 EXPECT=<<EOF
 1: one 

--- a/test/db/io/zip
+++ b/test/db/io/zip
@@ -2,10 +2,10 @@ NAME=apkall://
 FILE=apkall://bins/dex/mobipwn-nores.apk
 CMDS=<<EOF
 o
-ob
+oi
 ic~?
-ob *
-ob
+oi *
+oi
 ic~?
 EOF
 EXPECT=<<EOF
@@ -33,10 +33,10 @@ NAME=multidex apk://
 FILE=apk://bins/dex/mobipwn-nores.apk
 CMDS=<<EOF
 o
-ob
+oi
 ic~?
-ob *
-ob
+oi *
+oi
 ic~?
 EOF
 EXPECT=<<EOF

--- a/test/db/json/json3
+++ b/test/db/json/json3
@@ -25,7 +25,7 @@ izzj
 iZj
 Lcj
 Lsj
-obj
+oij
 oj
 oLj
 omj

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -5,7 +5,7 @@ EXPECT=<<EOF
 Reassembling 8051... OK
 EOF
 EXPECT_ERR=<<EOF
-WARN: using oba to load the syminfo from different mapaddress
+WARN: using oia to load the syminfo from different mapaddress
 EOF
 RUN
 

--- a/test/fuzz/fuzz_ia.c
+++ b/test/fuzz/fuzz_ia.c
@@ -12,7 +12,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 	r_core_cmdf(r, "o malloc://%zu", Size);
 	r_io_write_at(r->io, 0, Data, Size);
 
-	r_core_cmd0(r, "oba 0");
+	r_core_cmd0(r, "oia 0");
 	r_core_cmd0(r, "ia");
 
 	r_core_free(r);


### PR DESCRIPTION
Partial #11988

Resolves:

* Rename `ob` to `oi`
* Rename `omb` to `ob`
* Rename `objid` to `binfd` in `ob?` (now `oi?`)