### PR TITLE
Fix -Wimplicit-const-int-float-conversion spotted by latest clang

### DIFF
--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -3066,7 +3066,7 @@ static bool esil_double_to_int(REsil *esil) {
 			if (isnan (s.f64) || isinf (s.f64)) {
 				R_LOG_DEBUG ("esil_float_to_int: nan or inf detected");
 			}
-			if (s.f64 > ST64_MIN || s.f64 < ST64_MAX) {
+			if (s.f64 > (double)ST64_MIN || s.f64 < (double)ST64_MAX) {
 				ret = r_esil_pushnum (esil, (st64)(s.f64));
 			} else {
 				R_LOG_DEBUG ("double-to-int out of range");

--- a/test/fuzz/fuzz_x509_parse.c
+++ b/test/fuzz/fuzz_x509_parse.c
@@ -9,7 +9,7 @@ int LLVMFuzzerInitialize(int *lf_argc, char ***lf_argv) {
 	return 0;
 }
 
-R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length) {
+R_API RX509Certificate *wtf_r_x509_parse_certificate2(const ut8 *buffer, ut32 length) {
 	if (!buffer || !length) {
 		return NULL;
 	}
@@ -20,7 +20,7 @@ R_API RX509Certificate *r_x509_parse_certificate2(const ut8 *buffer, ut32 length
 }
 
 int LLVMFuzzerTestOneInput(const ut8 *data, size_t len) {
-	RX509Certificate *out = r_x509_parse_certificate2 (data, len);
+	RX509Certificate *out = wtf_r_x509_parse_certificate2 (data, len);
 	free (out);
 	return 0;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
