### PR TITLE
Fix uaf caused by RRegItem.free instead of .unref ##crash

### DIFF
--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -245,7 +245,7 @@ R_API void r_reg_free_internal(RReg *reg, bool init) {
 		}
 		if (init) {
 			r_list_free (reg->regset[i].regs);
-			reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_free);
+			reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_unref);
 		} else {
 			r_list_free (reg->regset[i].regs);
 			reg->regset[i].regs = NULL;
@@ -326,7 +326,7 @@ R_API RReg *r_reg_init(RReg *reg) {
 			return NULL;
 		}
 		reg->regset[i].pool = r_list_newf ((RListFree)r_reg_arena_free);
-		reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_free);
+		reg->regset[i].regs = r_list_newf ((RListFree)r_reg_item_unref);
 		r_list_push (reg->regset[i].pool, arena);
 		reg->regset[i].arena = arena;
 	}

--- a/test/fuzz/fuzz_cmd.c
+++ b/test/fuzz/fuzz_cmd.c
@@ -6,6 +6,9 @@ int LLVMFuzzerInitialize(int *lf_argc, char ***lf_argv) {
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+	if (Size < 1) {
+		return 0;
+	}
 	RCore *r = r_core_new();
 	if (Size < 1) {
 		return 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
