### PR TITLE
Fix wrong check in dyldcache rebase v2 logic ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1366,7 +1366,7 @@ static void rebase_bytes_v2(RDyldRebaseInfo2 *rebase_info, ut8 *buf, ut64 offset
 				ut32 delta = 1;
 				while (delta) {
 					ut64 position = in_buf + first_rebase_off - page_offset;
-					if (position + 8 >= count) {
+					if (position + 8 > count) {
 						break;
 					}
 					ut64 raw_value = r_read_le64 (buf + position);


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix a boundary check which was too aggressive and broke parsing in some dyldcaches with v2 rebase info.