### PR TITLE
Optimize RCore.analOp() lowers aa from 1m23 to 1m19 ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -975,6 +975,10 @@ R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr, int mask) {
 	if (!op) {
 		return NULL;
 	}
+	int maxopsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MAX_OP_SIZE);
+	if (sizeof (buf) < maxopsz) {
+		maxopsz = sizeof (buf);
+	}
 	int delta = (addr - core->offset);
 	int minopsz = 8;
 	if (delta > 0 && delta + minopsz < core->blocksize && addr >= core->offset && addr + 16 < core->offset + core->blocksize) {
@@ -984,11 +988,11 @@ R_API RAnalOp* r_core_anal_op(RCore *core, ut64 addr, int mask) {
 			goto err_op;
 		}
 	} else {
-		if (!r_io_read_at (core->io, addr, buf, sizeof (buf))) {
+		if (!r_io_read_at (core->io, addr, buf, maxopsz)) {
 			goto err_op;
 		}
 		ptr = buf;
-		len = sizeof (buf);
+		len = maxopsz;
 	}
 	if (r_anal_op (core->anal, op, addr, ptr, len, mask) < 1) {
 		goto err_op;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
