### PR TITLE
Support function arguments without a name ##anal

### DIFF
--- a/libr/anal/d/types.sdb.txt
+++ b/libr/anal/d/types.sdb.txt
@@ -97,7 +97,7 @@ func.srandomdev.ret=void
 
 initstate=func
 func.initstate.args=3
-func.initstate.arg.0=uint32_t,state
+func.initstate.arg.0=uint32_t,seed
 func.initstate.arg.1=char *,state
 func.initstate.arg.2=size_t,size
 func.initstate.ret=char *

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2019-2022 - pancake, oddcoder, Anton Kochkov */
+/* radare - LGPL - Copyright 2019-2023 - pancake, oddcoder, Anton Kochkov */
 
 #include <r_anal.h>
 #include <string.h>

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1761,14 +1761,13 @@ R_API char *r_anal_function_format_sig(R_NONNULL RAnal *anal, R_NONNULL RAnalFun
 		for (i = 0; i < argc; i++) {
 			char *type = r_type_func_args_type (TDB, type_fcn_name, i);
 			const char *name = r_type_func_args_name (TDB, type_fcn_name, i);
-			r_str_trim (type);
 			if (R_STR_ISEMPTY (type) && !strcmp (name, "...")) {
 				R_LOG_DEBUG ("Detected, but unhandled vararg type"); // TODO implement vararg support
 				// this is vararg type!
 				free (type);
 				type = strdup ("vararg");
 			}
-			if (R_STR_ISEMPTY (type) || R_STR_ISEMPTY (name)) {
+			if (R_STR_ISEMPTY (type)) {
 				R_LOG_WARN ("Missing type for arg %d of function '%s'", i, type_fcn_name);
 				goto beach;
 			}

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -12,7 +12,7 @@ static void set_fcn_args_info(RAnalFuncArg *arg, RAnal *anal, const char *fcn_na
 	arg->name = r_type_func_args_name (TDB, fcn_name, arg_num);
 	arg->orig_c_type = r_type_func_args_type (TDB, fcn_name, arg_num);
 	if (!arg->name || !arg->orig_c_type) {
-		R_LOG_WARN ("Missing type for function argument to set (%s)\n", fcn_name);
+		R_LOG_WARN ("Missing type for function argument to set (%s)", fcn_name);
 		return;
 	}
 	if (r_str_startswith (arg->orig_c_type, "const ")) {

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -12,10 +12,10 @@ static void set_fcn_args_info(RAnalFuncArg *arg, RAnal *anal, const char *fcn_na
 	arg->name = r_type_func_args_name (TDB, fcn_name, arg_num);
 	arg->orig_c_type = r_type_func_args_type (TDB, fcn_name, arg_num);
 	if (!arg->name || !arg->orig_c_type) {
-		eprintf ("Missing type for function argument (%s)\n", fcn_name);
+		R_LOG_WARN ("Missing type for function argument to set (%s)\n", fcn_name);
 		return;
 	}
-	if (!strncmp ("const ", arg->orig_c_type, 6)) {
+	if (r_str_startswith (arg->orig_c_type, "const ")) {
 		arg->c_type = arg->orig_c_type + 6;
 	} else {
 		arg->c_type = arg->orig_c_type;

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -580,18 +580,37 @@ R_API R_OWN char *r_type_func_args_type(Sdb *TDB, R_NONNULL const char *func_nam
 			*comma = 0;
 			return ret;
 		}
-		free (ret);
+		return ret;
 	}
 	return NULL;
 }
 
+const char *const argnames[10] = {
+	"arg0",
+	"arg1",
+	"arg2",
+	"arg3",
+	"arg4",
+	"arg5",
+	"arg6",
+	"arg7",
+	"arg8",
+	"arg9",
+};
+
 R_API const char *r_type_func_args_name(Sdb *TDB, R_NONNULL const char *func_name, int i) {
 	char *query = r_str_newf ("func.%s.arg.%d", func_name, i);
-	const char *get = sdb_const_get (TDB, query, 0);
+	const char *row = sdb_const_get (TDB, query, 0);
 	free (query);
-	if (get) {
-		char *ret = strchr (get, ',');
-		return ret == 0 ? ret : ret + 1;
+	if (row) {
+		const char *ret = strchr (row, ',');
+		if (ret) {
+			return ret + 1;
+		}
+		if (i >= 0 && i < 10) {
+			R_LOG_DEBUG ("Missing arg %d name for %s", i, func_name);
+			return argnames[i];
+		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
* Default name is 'arg%d'
* Warnings moved to the right place
* Fix null assert related to this

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
