### PR TITLE
Correctly align r_core_cmd_help_match output in inexact mode

### DIFF
--- a/libr/cons/help.c
+++ b/libr/cons/help.c
@@ -110,18 +110,6 @@ R_API void r_cons_cmd_help(RCoreHelpMessage help, bool use_color) {
 	}
 }
 
-static void print_match(const char * const *match, bool use_color) {
-	const char *match_help_text[4];
-	size_t i;
-
-	/* Manually construct help array. No need to strdup, just borrow. */
-	match_help_text[3] = NULL;
-	for (i = 0; i < 3; i++) {
-		match_help_text[i] = match[i];
-	}
-	r_cons_cmd_help (match_help_text, use_color);
-}
-
 /* See r_cons_cmd_help().
  * This version will only print help for a specific command.
  * Will append spec to cmd before looking for a match, if spec != 0.
@@ -130,6 +118,11 @@ static void print_match(const char * const *match, bool use_color) {
  * For example, ("pd", 'r', false) matches both `pdr` and `pdr.`.
  */
 R_API void r_cons_cmd_help_match(RCoreHelpMessage help, bool use_color, R_BORROW R_NONNULL char *cmd, char spec, bool exact) {
+	RVector/*<int>*/ *match_indices = r_vector_new (sizeof (int), NULL, NULL);
+	char **matches = NULL;
+	size_t num_matches;
+	int *current_index_ptr;
+	size_t matches_copied;
 	size_t i;
 
 	if (spec) {
@@ -137,20 +130,34 @@ R_API void r_cons_cmd_help_match(RCoreHelpMessage help, bool use_color, R_BORROW
 		cmd = r_str_newf ("%s%c", cmd, spec);
 	}
 
+	/* Collect matching indices */
 	for (i = 0; help[i]; i += 3) {
-		if (exact) {
-			if (!strcmp (help[i], cmd)) {
-				print_match (&help[i], use_color);
-				break;
-			}
-		} else {
-			if (strstr (help[i], cmd)) {
-				print_match (&help[i], use_color);
-				/* Don't break - can have multiple results */
-			}
+		if (exact? (bool)!strcmp (help[i], cmd): (bool)strstr (help[i], cmd)) {
+			r_vector_push (match_indices, &i);
 		}
 	}
 
+	/* Leave if no matches */
+	num_matches = r_vector_length (match_indices);
+	if (num_matches == 0) {
+		goto out;
+	}
+
+	matches = R_NEWS (char *, (3 * num_matches) + 1);
+
+	matches_copied = 0;
+	r_vector_foreach (match_indices, current_index_ptr) {
+		int current_index = *current_index_ptr;
+		for (i = 0; i < 3; i++) {
+			matches[matches_copied++] = (char *)help[current_index++];
+		}
+	}
+	matches[matches_copied] = NULL;
+	r_cons_cmd_help ((const char * const *)matches, use_color);
+
+out:
+	free (matches);
+	r_vector_free (match_indices);
 	if (spec) {
 		free (cmd);
 	}

--- a/test/db/cmd/cmd_pf2
+++ b/test/db/cmd/cmd_pf2
@@ -181,6 +181,9 @@ FILE=malloc://1024
 CMDS=pf 16 16
 EXPECT=<<EOF
 | pf fmt  show data using the given format-string. See 'pf??' and 'pf???'.
+| pf?    help on commands
+| pf??   help on format characters
+| pf???  show usage examples
 EOF
 RUN
 
@@ -189,6 +192,9 @@ FILE=malloc://1024
 CMDS=pf 16 16
 EXPECT=<<EOF
 | pf fmt  show data using the given format-string. See 'pf??' and 'pf???'.
+| pf?    help on commands
+| pf??   help on format characters
+| pf???  show usage examples
 EOF
 RUN
 


### PR DESCRIPTION
Fix #21449

Also allows exact mode to have multiple matches in cases where this applies such as `tej`:

```
[0x00000000]> tej?
| tej         list all loaded enums in json
| tej <enum>  show enum in json
```