### PR TITLE
Support R2_PREFIX env var to override compile-time PREFIX ##core

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -158,7 +158,7 @@ static int main_help(int line) {
 	}
 	if (line == 2) {
 		char *datahome = r_xdg_datadir (NULL);
-		const char *dirPrefix = R2_PREFIX;
+		const char *dirPrefix = r_sys_prefix (NULL);
 		RStrBuf *sb = r_strbuf_new ("");
 
 		r_strbuf_append (sb, "Scripts:\n");
@@ -219,12 +219,13 @@ static int main_print_var(const char *var_name) {
 	char *plugins = r_str_r2_prefix (R2_PLUGINS);
 	char *magicpath = r_str_r2_prefix (R2_SDB_MAGIC);
 	char *historyhome = r_xdg_cachedir ("history");
+	const char *r2prefix = r_sys_prefix (NULL);
 	struct {
 		const char *name;
 		const char *value;
 	} r2_vars[] = {
 		{ "R2_VERSION", R2_VERSION },
-		{ "R2_PREFIX", R2_PREFIX },
+		{ "R2_PREFIX", r2prefix },
 		{ "R2_MAGICPATH", magicpath },
 		{ "R2_INCDIR", incdir },
 		{ "R2_LIBDIR", libdir },

--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -1353,15 +1353,25 @@ R_API bool r_sys_tts(const char *txt, bool bg) {
 	return false;
 }
 
+// leaks and globs
+static R_TH_LOCAL char *r2_prefix = NULL;
+
 R_API const char *r_sys_prefix(const char *pfx) {
+	if (!r2_prefix) {
+		r2_prefix = r_sys_getenv ("R2_PREFIX");
+		if (R_STR_ISEMPTY (r2_prefix)) {
+			free (r2_prefix);
+			r2_prefix = strdup (R2_PREFIX);
+		}
+	}
 	if (!prefix) {
 #if R2__WINDOWS__
 		prefix = r_sys_get_src_dir_w32 ();
 		if (!prefix) {
-			prefix = strdup (R2_PREFIX);
+			prefix = strdup (r2_prefix);
 		}
 #else
-		prefix = strdup (R2_PREFIX);
+		prefix = strdup (r2_prefix);
 #endif
 	}
 	if (pfx) {


### PR DESCRIPTION
* Supports overriding system paths at startup time
* Makes happy snaps and other sandboxed or randomized execution environments

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
