### PR TITLE
fix segfault when bin->symbols is NULL #21503 ##bin

### DIFF
--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -505,11 +505,13 @@ static RList *patch_relocs(RBin *b) {
 
 	size_t nimports = 0;
 	int i;
-	for (i = 0; i < bin->hdr.f_nsyms; i++) {
-		if (is_imported_symbol (&bin->symbols[i])) {
-			nimports++;
+	if (bin->symbols) {
+		for (i = 0; i < bin->hdr.f_nsyms; i++) {
+			if (is_imported_symbol (&bin->symbols[i])) {
+				nimports++;
+			}
+			i += bin->symbols[i].n_numaux;
 		}
-		i += bin->symbols[i].n_numaux;
 	}
 	ut64 m_vaddr = UT64_MAX;
 	if (nimports) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge

**Description**
extra check added before for loop if bin->symbols is not NULL in patch_relocs()
