### PR TITLE
Fix Mach-O symbol parsing in dyldcache ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1123,7 +1123,6 @@ static ut64 resolve_symbols_off(RDyldCache *cache, ut64 pa) {
 				ut32 i,j;
 				for (i = 0; i < cache->n_hdr; i++) {
 					cache_hdr_t *hdr = &cache->hdr[i];
-					ut64 hdr_offset = cache->hdr_offset[i];
 					ut32 maps_index = cache->maps_index[i];
 					for (j = 0; j < hdr->mappingCount; j++) {
 						ut64 map_start = cache->maps[maps_index + j].address;


### PR DESCRIPTION

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This change correctly computes the offset to reach the symbol info from each actual binary in the multiple sub-caches scenario.
