### PR TITLE
More fixes for new IO cache implementation ##io

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7184,6 +7184,7 @@ R_API int r_core_disasm_pde(RCore *core, int nb_opcodes, int mode) {
 	REsil *esil = core->anal->esil;
 #if USE_NEW_IO_CACHE_API
 	r_io_cache_init (core->io);
+	RIOCache *cache_clone = r_io_cache_clone (core->io);
 #else
 	RPVector ocache = core->io->cache;
 	const int ocached = core->io->cached;
@@ -7296,7 +7297,7 @@ R_API int r_core_disasm_pde(RCore *core, int nb_opcodes, int mode) {
 	free (buf);
 	r_reg_arena_pop (reg);
 #if USE_NEW_IO_CACHE_API
-	R_LOG_TODO ("new-io-cache doesnt rollbacks yet");
+	r_io_cache_replace (core->io, cache_clone);
 #else
 	int len = r_pvector_length (&ocache);
 	if (r_pvector_length (&core->io->cache) > len) {

--- a/libr/io/io_cache.c
+++ b/libr/io/io_cache.c
@@ -290,6 +290,10 @@ void _io_cache_item_free(void *data) {
 
 R_API void r_io_cache_init(RIO *io) {
 	r_return_if_fail (io);
+	if (io->cache) {
+		return;
+	}
+
 	io->cache = R_NEW (RIOCache);
 	if (io->cache) {
 		io->cache->tree = r_crbtree_new (NULL);

--- a/libr/io/io_cache.c
+++ b/libr/io/io_cache.c
@@ -659,7 +659,7 @@ R_API RIOCache *r_io_cache_clone(RIO *io) {
 		RIOCacheItem *ci = _clone_ci ((RIOCacheItem *)*iter);
 		r_pvector_push (clone->vec, ci);
 		if (ci->tree_itv) {
-			r_crbtree_insert (clone->tree, clone, _ci_start_cmp_cb, NULL);
+			r_crbtree_insert (clone->tree, ci, _ci_start_cmp_cb, NULL);
 		}
 	}
 	return clone;

--- a/libr/io/io_cache.c
+++ b/libr/io/io_cache.c
@@ -655,7 +655,7 @@ R_API RIOCache *r_io_cache_clone(RIO *io) {
 	clone->tree = r_crbtree_new (NULL);
 	clone->vec = r_pvector_new ((RPVectorFree)_io_cache_item_free);
 	void **iter;
-	r_pvector_foreach_prev (io->cache->vec, iter) {
+	r_pvector_foreach (io->cache->vec, iter) {
 		RIOCacheItem *ci = _clone_ci ((RIOCacheItem *)*iter);
 		r_pvector_push (clone->vec, ci);
 		if (ci->tree_itv) {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Proper handling of IO cache in pde command. A deep copy is made, since pde command can modify the IO cache. After the command, the cached is replaced with the copy to undo effects of pde.
- Fixed a bug in case cache was initialized multiple times (memory leak).
- Fix bug in clone function that reversed order of the writes.
- Fix a nasty bug when cloning cache items due to C not checking any types on `void*`.