### PR TITLE
Fix segmentation fault when listing cache entries before init ##io

### DIFF
--- a/libr/io/io_cache.c
+++ b/libr/io/io_cache.c
@@ -578,6 +578,9 @@ R_API void r_io_cache_commit(RIO *io, ut64 from, ut64 to) {
 
 R_API bool r_io_cache_list(RIO *io, int rad) {
 	r_return_val_if_fail (io, false);
+	if (!io->cache || !io->cache->vec) {
+		return false;
+	}
 	size_t i, j = 0;
 	void **iter;
 	RIOCacheItem *ci;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Title of PR says it all.