### PR TITLE
Fix potential uninitialized value

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -1613,7 +1613,7 @@ R_API void r_print_raw(RPrint *p, ut64 addr, const ut8 *buf, int len, int offlin
 	{
 		const ut8 *o, *q;
 		ut64 off;
-		bool mustbreak = 0;
+		bool mustbreak = false;
 		int i, linenum_abs, linenum = 1;
 		o = q = buf;
 		i = 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Fix the uninitialized value warning detected by static analyse tool infer@facebook

**Warning Type**
Uninitialized Value

**Component Name**
radare2/libr/util/print.c (line:1642)

**Additional Information**
The value read from mustbreak could be uninitialized.



