### PR TITLE
Remove unneeded line in meson build after plugin migration ##arch

### DIFF
--- a/libr/asm/meson.build
+++ b/libr/asm/meson.build
@@ -33,7 +33,6 @@ r_asm_inc = [
     join_paths('../../shlr'),
     join_paths('arch','include'),
     join_paths('arch'),
-    join_paths('../arch/p','h8300'),
   )
 ]
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Removes a redundant line from the meson build file for asm.