### PR TITLE
Optimize macho parser

### DIFF
--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -89,7 +89,7 @@ static char *swiftField(const char *dn, const char *cn) {
 }
 
 // R2_590 - move into rbin as public api
-static RBinSymbol *r_bin_symbol_clone(RBinSymbol *bs) {
+RBinSymbol *r_bin_symbol_clone(RBinSymbol *bs) {
 	RBinSymbol *nbs = R_NEW (RBinSymbol);
 	memcpy (nbs, bs, sizeof (RBinSymbol));
 	nbs->name = strdup (nbs->name);

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2179,7 +2179,7 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) *mo) {
 	free (mo->compiler);
 #if FEATURE_SYMLIST
 	if (mo->symbols_loaded) {
-		r_list_purge (&mo->symbols_cache);
+		r_vector_fini (&mo->symbols_cache);
 	}
 #endif
 	r_list_free (mo->sections_cache);
@@ -2871,18 +2871,15 @@ static void _fill_exports(struct MACH0_(obj_t) *bin, const char *name, ut64 flag
 		return;
 	}
 
-	RBinSymbol *sym = R_NEW0 (RBinSymbol);
-	if (!sym) {
-		return;
-	}
-	sym->vaddr = vaddr;
-	sym->paddr = offset + context->boffset;
-	sym->type = "EXT";
-	sym->name = strdup (name);
-	sym->bind = R_BIN_BIND_GLOBAL_STR;
-	sym->ordinal = (*context->ordinal)++;
-	_enrich_symbol (context->bf, bin, context->symcache, sym);
-	r_list_append (&bin->symbols_cache, sym);
+	RBinSymbol sym = {0};
+	sym.vaddr = vaddr;
+	sym.paddr = offset + context->boffset;
+	sym.type = "EXT";
+	sym.name = strdup (name);
+	sym.bind = R_BIN_BIND_GLOBAL_STR;
+	sym.ordinal = (*context->ordinal)++;
+	_enrich_symbol (context->bf, bin, context->symcache, &sym);
+	r_vector_push (&bin->symbols_cache, &sym);
 }
 
 static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, HtPP *symcache) {
@@ -2969,26 +2966,22 @@ static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, HtPP *symcac
 				continue;
 			}
 
-			RBinSymbol *sym = R_NEW0 (RBinSymbol);
-			if (!sym) {
-				break;
-			}
-			sym->vaddr = vaddr;
-			sym->paddr = addr_to_offset (bin, sym->vaddr) + obj->boffset;
-			sym->size = 0; /* TODO: Is it anywhere? */
-			sym->bits = bin->symtab[i].n_desc & N_ARM_THUMB_DEF ? 16 : bits;
-			sym->is_imported = false;
-			sym->type = bin->symtab[i].n_type & N_EXT ? "EXT" : "LOCAL";
-			sym->name = sym_name;
-			_update_main_addr_if_needed (bin, sym);
+			RBinSymbol sym = {0};
+			sym.vaddr = vaddr;
+			sym.paddr = addr_to_offset (bin, sym.vaddr) + obj->boffset;
+			sym.size = 0; /* TODO: Is it anywhere? */
+			sym.bits = bin->symtab[i].n_desc & N_ARM_THUMB_DEF ? 16 : bits;
+			sym.is_imported = false;
+			sym.type = bin->symtab[i].n_type & N_EXT ? "EXT" : "LOCAL";
+			sym.name = sym_name;
+			_update_main_addr_if_needed (bin, &sym);
 
-			if (hash_find_or_insert (hash, sym->name, sym->vaddr)) {
-				r_bin_symbol_free (sym);
+			if (hash_find_or_insert (hash, sym.name, sym.vaddr)) {
 				j--;
 			} else {
-				_enrich_symbol (bf, bin, symcache, sym);
-				sym->ordinal = ordinal++;
-				r_list_append (&bin->symbols_cache, sym);
+				_enrich_symbol (bf, bin, symcache, &sym);
+				sym.ordinal = ordinal++;
+				r_vector_push (&bin->symbols_cache, &sym);
 			}
 		}
 	}
@@ -3002,22 +2995,19 @@ static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, HtPP *symcac
 		}
 		if (parse_import_stub (bin, &symbol, i) && symbol.addr >= 100) {
 			j++;
-			RBinSymbol *sym = R_NEW0 (RBinSymbol);
-			if (!sym) {
-				break;
+			RBinSymbol sym = {0};
+			sym.lang = R_BIN_LANG_C;
+			sym.vaddr = symbol.addr;
+			sym.paddr = symbol.offset + obj->boffset;
+			sym.name = symbol.name;
+			if (!sym.name) {
+				sym.name = r_str_newf ("entry%u", (ut32)i);
 			}
-			sym->lang = R_BIN_LANG_C;
-			sym->vaddr = symbol.addr;
-			sym->paddr = symbol.offset + obj->boffset;
-			sym->name = symbol.name;
-			if (!sym->name) {
-				sym->name = r_str_newf ("entry%u", (ut32)i);
-			}
-			sym->type = symbol.type == R_BIN_MACH0_SYMBOL_TYPE_LOCAL? "LOCAL": "EXT";
-			sym->is_imported = symbol.is_imported;
-			sym->ordinal = ordinal++;
-			_enrich_symbol (bf, bin, symcache, sym);
-			r_list_append (&bin->symbols_cache, sym);
+			sym.type = symbol.type == R_BIN_MACH0_SYMBOL_TYPE_LOCAL? "LOCAL": "EXT";
+			sym.is_imported = symbol.is_imported;
+			sym.ordinal = ordinal++;
+			_enrich_symbol (bf, bin, symcache, &sym);
+			r_vector_push (&bin->symbols_cache, &sym);
 		}
 	}
 
@@ -3036,27 +3026,23 @@ static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, HtPP *symcac
 				continue;
 			}
 
-			RBinSymbol *sym = R_NEW0 (RBinSymbol);
-			if (!sym) {
-				break;
-			}
-			sym->vaddr = vaddr;
-			sym->paddr = addr_to_offset (bin, vaddr) + obj->boffset;
-			sym->type = (st->n_type & N_EXT)? "EXT": "LOCAL";
+			RBinSymbol sym = {0};
+			sym.vaddr = vaddr;
+			sym.paddr = addr_to_offset (bin, vaddr) + obj->boffset;
+			sym.type = (st->n_type & N_EXT)? "EXT": "LOCAL";
 			char *sym_name = get_name (bin, st->n_strx, false);
 			if (sym_name) {
-				sym->name = sym_name;
+				sym.name = sym_name;
 			} else {
-				sym->name = r_str_newf ("entry%u", (ut32)i);
+				sym.name = r_str_newf ("entry%u", (ut32)i);
 			}
-			if (hash_find_or_insert (hash, sym->name, sym->vaddr)) {
-				r_bin_symbol_free (sym);
+			if (hash_find_or_insert (hash, sym.name, sym.vaddr)) {
 				continue;
 			}
-			_update_main_addr_if_needed (bin, sym);
-			sym->ordinal = ordinal++;
-			_enrich_symbol (bf, bin, symcache, sym);
-			r_list_append (&bin->symbols_cache, sym);
+			_update_main_addr_if_needed (bin, &sym);
+			sym.ordinal = ordinal++;
+			_enrich_symbol (bf, bin, symcache, &sym);
+			r_vector_push (&bin->symbols_cache, &sym);
 			j++;
 		}
 	}
@@ -3072,7 +3058,7 @@ static void _parse_function_start_symbols(RBinFile *bf, struct MACH0_(obj_t) *bi
 
 	int wordsize = MACH0_(get_bits) (bin);
 	bool is_stripped = false;
-	ut32 i = r_list_length (&bin->symbols_cache);
+	ut32 i = r_vector_length (&bin->symbols_cache);
 
 	// functions from LC_FUNCTION_STARTS
 	if (bin->func_start) {
@@ -3084,25 +3070,22 @@ static void _parse_function_start_symbols(RBinFile *bf, struct MACH0_(obj_t) *bi
 		while (temp + 3 < temp_end && *temp) {
 			temp = r_uleb128_decode (temp, NULL, &value);
 			address += value;
-			RBinSymbol *sym = R_NEW0 (RBinSymbol);
-			if (!sym) {
-				break;
-			}
-			sym->vaddr = bin->baddr + address;
-			sym->paddr = address + obj->boffset;
-			sym->size = 0;
-			sym->name = r_str_newf ("func.%08"PFMT64x, sym->vaddr);
-			sym->type = R_BIN_TYPE_FUNC_STR;
-			sym->forwarder = "NONE";
-			sym->bind = R_BIN_BIND_LOCAL_STR;
-			sym->ordinal = i++;
+			RBinSymbol sym = {0};
+			sym.vaddr = bin->baddr + address;
+			sym.paddr = address + obj->boffset;
+			sym.size = 0;
+			sym.name = r_str_newf ("func.%08"PFMT64x, sym.vaddr);
+			sym.type = R_BIN_TYPE_FUNC_STR;
+			sym.forwarder = "NONE";
+			sym.bind = R_BIN_BIND_LOCAL_STR;
+			sym.ordinal = i++;
 			if (bin->hdr.cputype == CPU_TYPE_ARM && wordsize < 64) {
-				_handle_arm_thumb (sym);
+				_handle_arm_thumb (&sym);
 			}
-			r_list_append (&bin->symbols_cache, sym);
+			r_vector_push (&bin->symbols_cache, &sym);
 			// if any func is not found in syms then we consider it to be stripped
 			if (!is_stripped) {
-				snprintf (symstr + 5, sizeof (symstr) - 5 , "%" PFMT64x, sym->vaddr);
+				snprintf (symstr + 5, sizeof (symstr) - 5 , "%" PFMT64x, sym.vaddr);
 				bool found = false;
 				ht_pp_find (symcache, symstr, &found);
 				if (!found) {
@@ -3135,8 +3118,17 @@ static bool _check_if_debug_build(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 	return false;
 }
 
+static void _r_bin_symbol_fini(void *_sym, void *user) {
+	RBinSymbol *sym = _sym;
+	if (sym) {
+		free (sym->name);
+		free (sym->libname);
+		free (sym->classname);
+		// TODO remove free (sym);
+	}
+}
 
-const RList *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
+const RVector *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 	r_return_val_if_fail (bin, NULL);
 	if (bin->symbols_loaded) {
 		return &bin->symbols_cache;
@@ -3144,8 +3136,7 @@ const RList *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 
 	bin->symbols_loaded = true;
 
-	r_list_init (&bin->symbols_cache);
-	bin->symbols_cache.free = (RListFree) r_bin_symbol_free;
+	r_vector_init (&bin->symbols_cache, sizeof (RBinSymbol), (RVectorFree) _r_bin_symbol_fini, NULL);
 
 	HtPP *symcache = ht_pp_new0 ();
 	if (!symcache) {

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2177,7 +2177,11 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) *mo) {
 	free (mo->signature);
 	free (mo->intrp);
 	free (mo->compiler);
-	r_list_free (mo->symbols_cache);
+#if FEATURE_SYMLIST
+	if (mo->symbols_loaded) {
+		r_pvector_fini (&mo->symbols_cache);
+	}
+#endif
 	r_list_free (mo->sections_cache);
 	if (mo->imports_loaded) {
 		r_pvector_fini (&mo->imports_cache);
@@ -2793,77 +2797,84 @@ beach:
 	return count;
 }
 
-static void fill_exports_list(struct MACH0_(obj_t) *bin, const char *name, ut64 flags, ut64 offset, void *ctx) {
-	RList *list = (RList*) ctx;
+static void update_main_addr_if_needed (struct MACH0_(obj_t) *bin, const RBinSymbol *sym) {
+	if (!bin->main_addr || bin->main_addr == UT64_MAX) {
+		const char *name = sym->name;
+		if (!strcmp (name, "__Dmain")) {
+			bin->main_addr = sym->vaddr;
+		} else if (strstr (name, "4main") && !strstr (name, "STATIC")) {
+			bin->main_addr = sym->vaddr;
+		} else if (!strcmp (name, "_main")) {
+			bin->main_addr = sym->vaddr;
+		} else if (!strcmp (name, "main")) {
+			bin->main_addr = sym->vaddr;
+		}
+	}
+}
+
+typedef struct fill_context_t {
+	HtPP *hash;
+	ut64 boffset;
+} FillCtx;
+
+static void _fill_exports_pvector(struct MACH0_(obj_t) *bin, const char *name, ut64 flags, ut64 offset, void *ctx) {
+	FillCtx *context = ctx;
+	ut64 vaddr = offset_to_vaddr (bin, offset);
+	if (hash_find_or_insert (context->hash, name, vaddr)) {
+		return;
+	}
+
 	RBinSymbol *sym = R_NEW0 (RBinSymbol);
 	if (!sym) {
 		return;
 	}
-	sym->vaddr = offset_to_vaddr (bin, offset);
-	sym->paddr = offset;
+	sym->vaddr = vaddr;
+	sym->paddr = offset + context->boffset;
 	sym->type = "EXT";
 	sym->name = strdup (name);
 	sym->bind = R_BIN_BIND_GLOBAL_STR;
-	r_list_append (list, sym);
+	r_pvector_push (&bin->symbols_cache, sym);
 }
 
-const RList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) *bin) {
-	struct symbol_t *symbols;
+static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 	size_t i, j, s, symbols_size, symbols_count;
 	ut32 to = UT32_MAX;
 	ut32 from = UT32_MAX;
 
-	r_return_val_if_fail (bin, NULL);
-	if (bin->symbols_cache) {
-		return bin->symbols_cache;
+	RBinObject *obj = bf? bf->o: NULL;
+	if (!obj) {
+		return;
 	}
-	RList *list = r_list_newf ((RListFree)r_bin_symbol_free);
-	bin->symbols_cache = list;
 
 	HtPP *hash = ht_pp_new0 ();
 	if (!hash) {
-		return NULL;
+		return;
 	}
 
-	walk_exports (bin, fill_exports_list, list);
-	if (r_list_length (list)) {
-		RListIter *it;
-		RBinSymbol *s;
-		r_list_foreach (list, it, s) {
-			hash_find_or_insert (hash, s->name, s->vaddr);
-		}
-	}
+	FillCtx fill_context = { .hash = hash, .boffset = obj->boffset };
+	walk_exports (bin, _fill_exports_pvector, &fill_context);
 
 	if (!bin->symtab || !bin->symstr) {
 		ht_pp_free (hash);
-		return list;
+		return;
 	}
 	/* parse dynamic symbol table */
-	symbols_count = (bin->dysymtab.nextdefsym + \
-			bin->dysymtab.nlocalsym + \
-			bin->dysymtab.nundefsym);
-	symbols_count += bin->nsymtab;
-	ut64 tmp = symbols_count + 1;
-	if (SZT_MUL_OVFCHK (symbols_count + 1, 2)) {
-		// overflow may happen here
+	symbols_count = bin->dysymtab.nextdefsym + bin->dysymtab.nlocalsym + bin->dysymtab.nundefsym;
+	if (symbols_count == 0) {
 		ht_pp_free (hash);
-		return NULL;
+		return;
 	}
-	tmp *= 2;
-	if (SZT_MUL_OVFCHK (tmp, sizeof (struct symbol_t))) {
-		// overflow may happen here
-		ht_pp_free (hash);
-		return NULL;
-	}
-	tmp *= sizeof (struct symbol_t);
-	symbols_size = tmp;
 
-	if (symbols_size < 1 || !(symbols = calloc (1, symbols_size))) {
+	symbols_count += bin->nsymtab;
+	if (SZT_MUL_OVFCHK (symbols_count, 2 * sizeof (RBinSymbol))) {
+		// overflow may happen here
 		ht_pp_free (hash);
-		return NULL;
+		return;
 	}
+
+	symbols_size = symbols_count * 2 * sizeof (RBinSymbol);
 	j = 0; // symbol_idx
-	bin->main_addr = 0;
+	bin->main_addr = UT64_MAX;
 	int bits = MACH0_(get_bits_from_hdr) (&bin->hdr);
 	for (s = 0; s < 2; s++) {
 		switch (s) {
@@ -2886,55 +2897,50 @@ const RList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) *bin) {
 			continue;
 		}
 
-		from = R_MIN (from, symbols_size / sizeof (struct symbol_t));
-		to = R_MIN (R_MIN (to, bin->nsymtab), symbols_size / sizeof (struct symbol_t));
-
-		ut32 maxsymbols = symbols_size / sizeof (struct symbol_t);
+		from = R_MIN (from, symbols_size / sizeof (RBinSymbol));
+		to = R_MIN (R_MIN (to, bin->nsymtab), symbols_size / sizeof (RBinSymbol));
+		ut32 maxsymbols = symbols_size / sizeof (RBinSymbol);
 		if (symbols_count >= maxsymbols) {
 			symbols_count = maxsymbols - 1;
 			R_LOG_WARN ("Truncated symbol table");
 		}
+
 		for (i = from; i < to && j < symbols_count; i++, j++) {
+			ut64 vaddr = bin->symtab[i].n_value;
+			if (vaddr < 100) {
+				j--;
+				continue;
+			}
+
+			int stridx = bin->symtab[i].n_strx;
+			char *sym_name = get_name (bin, stridx, false);
+			if (!sym_name) {
+				j--;
+				continue;
+			}
+
 			RBinSymbol *sym = R_NEW0 (RBinSymbol);
 			if (!sym) {
 				break;
 			}
-			sym->vaddr = bin->symtab[i].n_value;
-			sym->paddr = addr_to_offset (bin, sym->vaddr);
-			symbols[j].size = 0; /* TODO: Is it anywhere? */
+			sym->vaddr = vaddr;
+			sym->paddr = addr_to_offset (bin, sym->vaddr) + obj->boffset;
+			sym->size = 0; /* TODO: Is it anywhere? */
 			sym->bits = bin->symtab[i].n_desc & N_ARM_THUMB_DEF ? 16 : bits;
+			sym->is_imported = false;
+			sym->type = bin->symtab[i].n_type & N_EXT ? "EXT" : "LOCAL";
+			sym->name = sym_name;
+			update_main_addr_if_needed (bin, sym);
 
-			if (bin->symtab[i].n_type & N_EXT) {
-				sym->type = "EXT";
-			} else {
-				sym->type = "LOCAL";
-			}
-			int stridx = bin->symtab[i].n_strx;
-			char *sym_name = get_name (bin, stridx, false);
-			if (sym_name) {
-				sym->name = sym_name;
-				if (!bin->main_addr || bin->main_addr == UT64_MAX) {
-					const char *name = sym->name;
-					if (!strcmp (name, "__Dmain")) {
-						bin->main_addr = symbols[j].addr;
-					} else if (strstr (name, "4main") && !strstr (name, "STATIC")) {
-						bin->main_addr = symbols[j].addr;
-					} else if (!strcmp (name, "_main")) {
-						bin->main_addr = symbols[j].addr;
-					} else if (!strcmp (name, "main")) {
-						bin->main_addr = symbols[j].addr;
-					}
-				}
-			} else {
-				sym->name = r_str_newf ("unk%u", (ut32)i);
-			}
-			if (!hash_find_or_insert (hash, sym->name, sym->vaddr)) {
-				r_list_append (list, sym);
-			} else {
+			if (hash_find_or_insert (hash, sym->name, sym->vaddr)) {
 				r_bin_symbol_free (sym);
+				j--;
+			} else {
+				r_pvector_push (&bin->symbols_cache, sym);
 			}
 		}
 	}
+
 	to = R_MIN ((ut32)bin->nsymtab, bin->dysymtab.iundefsym + bin->dysymtab.nundefsym);
 	for (i = bin->dysymtab.iundefsym; i < to; i++) {
 		struct symbol_t symbol;
@@ -2942,7 +2948,7 @@ const RList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) *bin) {
 			R_LOG_WARN ("mach0-get-symbols: error");
 			break;
 		}
-		if (parse_import_stub (bin, &symbol, i)) {
+		if (parse_import_stub (bin, &symbol, i) && symbol.addr >= 100) {
 			j++;
 			RBinSymbol *sym = R_NEW0 (RBinSymbol);
 			if (!sym) {
@@ -2950,60 +2956,202 @@ const RList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) *bin) {
 			}
 			sym->lang = R_BIN_LANG_C;
 			sym->vaddr = symbol.addr;
-			sym->paddr = symbol.offset;
+			sym->paddr = symbol.offset + obj->boffset;
 			sym->name = symbol.name;
 			if (!sym->name) {
-				sym->name = r_str_newf ("unk%u", (ut32)i);
+				sym->name = r_str_newf ("entry%u", (ut32)i);
 			}
+			sym->type = symbol.type == R_BIN_MACH0_SYMBOL_TYPE_LOCAL? "LOCAL": "EXT";
 			sym->is_imported = symbol.is_imported;
-			r_list_append (list, sym);
+			r_pvector_push (&bin->symbols_cache, sym);
 		}
 	}
 
 	for (i = 0; i < bin->nsymtab && i < symbols_count; i++) {
 		struct MACH0_(nlist) *st = &bin->symtab[i];
+		if (st->n_type & N_STAB) {
+			continue;
+		}
 		// 0 is for imports
 		// 1 is for symbols
 		// 2 is for func.eh (exception handlers?)
 		int section = st->n_sect;
 		if (section == 1 && j < symbols_count) { // text ??st->n_type == 1) maybe wrong
+			ut64 vaddr = st->n_value;
+			if (vaddr < 100) {
+				continue;
+			}
+
 			RBinSymbol *sym = R_NEW0 (RBinSymbol);
 			if (!sym) {
 				break;
 			}
-			/* is symbol */
-			sym->vaddr = st->n_value;
-			sym->paddr = addr_to_offset (bin, symbols[j].addr);
-			sym->is_imported = symbols[j].is_imported;
+			sym->vaddr = vaddr;
+			sym->paddr = addr_to_offset (bin, vaddr) + obj->boffset;
 			sym->type = (st->n_type & N_EXT)? "EXT": "LOCAL";
 			char *sym_name = get_name (bin, st->n_strx, false);
 			if (sym_name) {
 				sym->name = sym_name;
-				if (hash_find_or_insert (hash, sym->name, sym->vaddr)) {
-					r_bin_symbol_free (sym);
-					continue;
-				}
-				if (!bin->main_addr || bin->main_addr == UT64_MAX) {
-					const char *name = sym->name;
-					if (name && !strcmp (name, "__Dmain")) {
-						bin->main_addr = symbols[i].addr;
-					} else if (strstr (name, "4main") && !strstr (name, "STATIC")) {
-						bin->main_addr = symbols[i].addr;
-					} else if (symbols[i].name && !strcmp (symbols[i].name, "_main")) {
-						bin->main_addr = symbols[i].addr;
-					}
-				}
 			} else {
-				sym->name = r_str_newf ("unk%u", (ut32)i);
+				sym->name = r_str_newf ("entry%u", (ut32)i);
 			}
-			r_list_append (list, sym);
+			if (hash_find_or_insert (hash, sym->name, sym->vaddr)) {
+				r_bin_symbol_free (sym);
+				continue;
+			}
+			update_main_addr_if_needed (bin, sym);
+			r_pvector_push (&bin->symbols_cache, sym);
 			j++;
 		}
 	}
+
 	ht_pp_free (hash);
-	// bin->symbols = symbols;
-	free (symbols);
-	return list;
+}
+
+static void _handle_arm_thumb(RBinSymbol *sym) {
+	if (sym->paddr & 1) {
+		sym->paddr--;
+		sym->vaddr--;
+		sym->bits = 16;
+	}
+}
+
+// TODO integrate directly into _parse_symbols
+static void _enrich_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, Sdb *symcache) {
+	int wordsize = MACH0_(get_bits) (bin);
+
+	ut32 i = 0;
+	void **iter;
+	r_pvector_foreach (&bin->symbols_cache, iter) {
+		RBinSymbol *sym = *iter;
+		if (sym->name[0] == '_' && !sym->is_imported) {
+			char *demangled = r_bin_demangle (bf, sym->name, sym->name, sym->vaddr, false);
+			if (demangled) {
+				sym->dname = demangled;
+				char *p = strchr (demangled, '.');
+				if (p) {
+					if (IS_UPPER (sym->name[0])) {
+						sym->classname = strdup (sym->name);
+						sym->classname[p - sym->name] = 0;
+					} else if (IS_UPPER (p[1])) {
+						sym->classname = strdup (p + 1);
+						p = strchr (sym->classname, '.');
+						if (p) {
+							*p = 0;
+						}
+					}
+				}
+			}
+		}
+
+		sym->forwarder = "NONE";
+		sym->bind = sym->type && !strncmp (sym->type, "LOCAL", 5)? R_BIN_BIND_LOCAL_STR: R_BIN_BIND_GLOBAL_STR;
+		sym->type = R_BIN_TYPE_FUNC_STR;
+		sym->ordinal = i;
+
+		if (bin->hdr.cputype == CPU_TYPE_ARM && wordsize < 64) {
+			_handle_arm_thumb (sym);
+		}
+
+		bin->dbg_info = strncmp (sym->name, "radr://", 7)? 0: 1;
+		r_strf_var (k, 32, "sym0x%"PFMT64x, sym->vaddr);
+		sdb_set (symcache, k, "found", 0);
+
+		i++;
+	}
+}
+
+static void _parse_function_start_symbols(RBinFile *bf, struct MACH0_(obj_t) *bin, Sdb *symcache) {
+	RBinObject *obj = bf? bf->o: NULL;
+	if (!obj) {
+		return;
+	}
+
+	int wordsize = MACH0_(get_bits) (bin);
+	bool is_stripped = false;
+	ut32 i = r_pvector_length (&bin->symbols_cache);
+
+	// functions from LC_FUNCTION_STARTS
+	if (bin->func_start) {
+		char symstr[128];
+		ut64 value = 0, address = 0;
+		const ut8 *temp = bin->func_start;
+		const ut8 *temp_end = bin->func_start + bin->func_size;
+		strcpy (symstr, "sym0x");
+		while (temp + 3 < temp_end && *temp) {
+			temp = r_uleb128_decode (temp, NULL, &value);
+			address += value;
+			RBinSymbol *sym = R_NEW0 (RBinSymbol);
+			if (!sym) {
+				break;
+			}
+			sym->vaddr = bin->baddr + address;
+			sym->paddr = address + obj->boffset;
+			sym->size = 0;
+			sym->name = r_str_newf ("func.%08"PFMT64x, sym->vaddr);
+			sym->type = R_BIN_TYPE_FUNC_STR;
+			sym->forwarder = "NONE";
+			sym->bind = R_BIN_BIND_LOCAL_STR;
+			sym->ordinal = i++;
+			if (bin->hdr.cputype == CPU_TYPE_ARM && wordsize < 64) {
+				_handle_arm_thumb (sym);
+			}
+			r_pvector_push (&bin->symbols_cache, sym);
+			// if any func is not found in syms then we can consider it is stripped
+			if (!is_stripped) {
+				snprintf (symstr + 5, sizeof (symstr) - 5 , "%" PFMT64x, sym->vaddr);
+				if (!sdb_const_get (symcache, symstr, 0)) {
+					is_stripped = true;
+				}
+			}
+		}
+	}
+
+	if (is_stripped) {
+		bin->dbg_info |= R_BIN_DBG_STRIPPED;
+	}
+}
+
+static bool _check_if_debug_build(RBinFile *bf, struct MACH0_(obj_t) *bin) {
+	RList *sections = MACH0_(get_segments) (bf);
+	if (!sections) {
+		return false;
+	}
+
+	RListIter *iter;
+	RBinSection *section;
+	r_list_foreach (sections, iter, section) {
+		if (strstr (section->name, "DWARF.__debug_line")) {
+			return true;
+		}
+	}
+
+	r_list_free (sections);
+	return false;
+}
+
+
+const RPVector *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
+	r_return_val_if_fail (bin, NULL);
+	if (bin->symbols_loaded) {
+		return &bin->symbols_cache;
+	}
+
+	r_pvector_init (&bin->symbols_cache, (RPVectorFree) r_bin_symbol_free);
+	Sdb *symcache = sdb_new0 ();
+	bool is_debug = _check_if_debug_build (bf, bin);
+	_parse_symbols (bf, bin);
+	_enrich_symbols (bf, bin, symcache);
+	_parse_function_start_symbols (bf, bin, symcache);
+	r_pvector_shrink (&bin->symbols_cache);
+	sdb_free (symcache);
+
+	if (is_debug) {
+		bin->dbg_info |= R_BIN_DBG_LINENUMS;
+	}
+
+	bin->symbols_loaded = true;
+	return &bin->symbols_cache;
 }
 
 static void assign_export_symbol_t(struct MACH0_(obj_t) *bin, const char *name, ut64 flags, ut64 offset, void *ctx) {
@@ -3346,7 +3494,7 @@ const RPVector *MACH0_(load_imports)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 		RBinImport *import = import_from_name (bf->rbin, imp_name);
 		if (!import) {
 			free (imp_name);
-			break;  // TODO change into continue?
+			break;
 		}
 
 		import->ordinal = i;
@@ -4366,7 +4514,7 @@ char *MACH0_(get_filetype)(struct MACH0_(obj_t) *bin) {
 	return bin? MACH0_(get_filetype_from_hdr) (&bin->hdr): strdup ("Unknown");
 }
 
-ut64 MACH0_(get_main)(struct MACH0_(obj_t) *bin) {
+ut64 MACH0_(get_main)(RBinFile *bf, struct MACH0_(obj_t) *bin) {
 	ut64 addr = UT64_MAX;
 	int i;
 
@@ -4375,7 +4523,7 @@ ut64 MACH0_(get_main)(struct MACH0_(obj_t) *bin) {
 	// other = valid main addr
 	if (bin->main_addr == UT64_MAX) {
 #if FEATURE_SYMLIST
-		 (void)MACH0_(get_symbols_list) (bin);
+		 (void)MACH0_(load_symbols) (bf, bin);
 #else
 		 (void)MACH0_(get_symbols) (bin);
 #endif

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -91,11 +91,6 @@ struct addr_t {
 	int last;
 };
 
-struct lib_t {
-	char name[R_BIN_MACH0_STRING_LENGTH];
-	int last;
-};
-
 struct blob_index_t {
 	ut32 type;
 	ut32 offset;
@@ -196,6 +191,8 @@ struct MACH0_(obj_t) {
 	RList *sections_cache;
 	bool imports_loaded;
 	RPVector imports_cache;
+	bool libs_loaded;
+	RPVector libs_cache;
 	RList *reloc_fixups;
 	ut8 *internal_buffer;
 	int internal_buffer_size;
@@ -266,7 +263,7 @@ void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void 
 const RPVector *MACH0_(load_imports)(RBinFile* bf, struct MACH0_(obj_t) *bin);
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin);
 struct addr_t *MACH0_(get_entrypoint)(struct MACH0_(obj_t) *bin);
-struct lib_t *MACH0_(get_libs)(struct MACH0_(obj_t) *bin);
+const RPVector *MACH0_(load_libs)(struct MACH0_(obj_t) *bin);
 ut64 MACH0_(get_baddr)(struct MACH0_(obj_t) *bin);
 char *MACH0_(get_class)(struct MACH0_(obj_t) *bin);
 int MACH0_(get_bits)(struct MACH0_(obj_t) *bin);

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -159,7 +159,8 @@ struct MACH0_(obj_t) {
 		struct arm_thread_state32 arm_32;
 		struct arm_thread_state64 arm_64;
 	} thread_state;
-	char (*libs)[R_BIN_MACH0_STRING_LENGTH];
+	bool libs_loaded;
+	RPVector libs_cache;
 	int nlibs;
 	int size;
 	ut64 baddr;
@@ -191,8 +192,6 @@ struct MACH0_(obj_t) {
 	RList *sections_cache;
 	bool imports_loaded;
 	RPVector imports_cache;
-	bool libs_loaded;
-	RPVector libs_cache;
 	RList *reloc_fixups;
 	ut8 *internal_buffer;
 	int internal_buffer_size;

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -6,7 +6,7 @@
 #define _INCLUDE_R_BIN_MACH0_H_
 
 // 20% faster loading times for macho if enabled
-#define FEATURE_SYMLIST 0
+#define FEATURE_SYMLIST 1
 
 #define R_BIN_MACH0_STRING_LENGTH 256
 
@@ -181,14 +181,15 @@ struct MACH0_(obj_t) {
 	int func_size;
 	bool verbose;
 	ut64 header_at;
+	struct symbol_t *symbols; // TODO remove
+	bool symbols_loaded;
+	RPVector symbols_cache;
 	ut64 symbols_off;
 	void *user;
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
-	struct symbol_t *symbols;
 	ut64 main_addr;
 	int (*original_io_read)(RIO *io, RIODesc *fd, ut8 *buf, int count);
 	bool rebasing_buffer;
-	RList *symbols_cache;
 	RList *sections_cache;
 	bool imports_loaded;
 	RPVector imports_cache;
@@ -257,7 +258,7 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) *bin);
 struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) *bin);
 RList *MACH0_(get_segments)(RBinFile *bf);
 const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin);
-const RList *MACH0_(get_symbols_list)(struct MACH0_(obj_t) *bin);
+const RPVector *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin);
 void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void *user);
 const RPVector *MACH0_(load_imports)(RBinFile* bf, struct MACH0_(obj_t) *bin);
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin);
@@ -276,7 +277,7 @@ char *MACH0_(get_cpusubtype)(struct MACH0_(obj_t) *bin);
 char *MACH0_(get_cpusubtype_from_hdr)(struct MACH0_(mach_header) *hdr);
 char *MACH0_(get_filetype)(struct MACH0_(obj_t) *bin);
 char *MACH0_(get_filetype_from_hdr)(struct MACH0_(mach_header) *hdr);
-ut64 MACH0_(get_main)(struct MACH0_(obj_t) *bin);
+ut64 MACH0_(get_main)(RBinFile *bf, struct MACH0_(obj_t) *bin);
 const char *MACH0_(get_cputype_from_hdr)(struct MACH0_(mach_header) *hdr);
 int MACH0_(get_bits_from_hdr)(struct MACH0_(mach_header) *hdr);
 struct MACH0_(mach_header) *MACH0_(get_hdr)(RBuffer *buf);

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -183,7 +183,7 @@ struct MACH0_(obj_t) {
 	ut64 header_at;
 	struct symbol_t *symbols; // TODO remove
 	bool symbols_loaded;
-	RList symbols_cache;
+	RVector symbols_cache;
 	ut64 symbols_off;
 	void *user;
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
@@ -258,7 +258,7 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) *bin);
 struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) *bin);
 RList *MACH0_(get_segments)(RBinFile *bf);
 const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin);
-const RList *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin);
+const RVector *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin);
 void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void *user);
 const RPVector *MACH0_(load_imports)(RBinFile* bf, struct MACH0_(obj_t) *bin);
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin);

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -183,7 +183,7 @@ struct MACH0_(obj_t) {
 	ut64 header_at;
 	struct symbol_t *symbols; // TODO remove
 	bool symbols_loaded;
-	RPVector symbols_cache;
+	RList symbols_cache;
 	ut64 symbols_off;
 	void *user;
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);
@@ -258,7 +258,7 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) *bin);
 struct section_t *MACH0_(get_sections)(struct MACH0_(obj_t) *bin);
 RList *MACH0_(get_segments)(RBinFile *bf);
 const struct symbol_t *MACH0_(get_symbols)(struct MACH0_(obj_t) *bin);
-const RPVector *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin);
+const RList *MACH0_(load_symbols)(RBinFile *bf, struct MACH0_(obj_t) *bin);
 void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void *user);
 const RPVector *MACH0_(load_imports)(RBinFile* bf, struct MACH0_(obj_t) *bin);
 RSkipList *MACH0_(get_relocs)(struct MACH0_(obj_t) *bin);

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1324,11 +1324,12 @@ static void parse_type(RList *list, RBinFile *bf, SwiftType st) {
 				break;
 			}
 			method_addr += bf->o->baddr;
-			RList * symbols = (RList *)MACH0_(get_symbols_list) (bf->o->bin_obj);
-			RListIter *iter;
+			const RPVector *symbols = MACH0_(load_symbols) (bf, bf->o->bin_obj);
 			RBinSymbol *sym;
+			void **iter;
 			char *method_name = r_str_newf ("%d", i);
-			r_list_foreach (symbols, iter, sym) {
+			r_pvector_foreach (symbols, iter) {
+				sym = *iter;
 				if (sym->vaddr == method_addr) {
 					free (method_name);
 					method_name = r_name_filter_dup (sym->name);

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1324,11 +1324,12 @@ static void parse_type(RList *list, RBinFile *bf, SwiftType st) {
 				break;
 			}
 			method_addr += bf->o->baddr;
-			const RList *symbols = MACH0_(load_symbols) (bf, bf->o->bin_obj);
+			const RVector *symbols = MACH0_(load_symbols) (bf, bf->o->bin_obj);
 			RBinSymbol *sym;
-			RListIter *iter;
+			void **iter;
 			char *method_name = r_str_newf ("%d", i);
-			r_list_foreach (symbols, iter, sym) {
+			r_vector_foreach (symbols, iter) {
+				sym = *iter;
 				if (sym->vaddr == method_addr) {
 					free (method_name);
 					method_name = r_name_filter_dup (sym->name);

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1324,12 +1324,11 @@ static void parse_type(RList *list, RBinFile *bf, SwiftType st) {
 				break;
 			}
 			method_addr += bf->o->baddr;
-			const RPVector *symbols = MACH0_(load_symbols) (bf, bf->o->bin_obj);
+			const RList *symbols = MACH0_(load_symbols) (bf, bf->o->bin_obj);
 			RBinSymbol *sym;
-			void **iter;
+			RListIter *iter;
 			char *method_name = r_str_newf ("%d", i);
-			r_pvector_foreach (symbols, iter) {
-				sym = *iter;
+			r_list_foreach (symbols, iter, sym) {
 				if (sym->vaddr == method_addr) {
 					free (method_name);
 					method_name = r_name_filter_dup (sym->name);

--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -2015,7 +2015,7 @@ void symbols_from_bin(RDyldCache *cache, RList *ret, RBinFile *bf, RDyldBinImage
 		return;
 	}
 
-	// const RList*symbols = MACH0_(get_symbols_list) (mach0);
+	// const RList *symbols = MACH0_(load_symbols) (mach0);
 	const struct symbol_t *symbols = MACH0_(get_symbols) (mach0);
 	if (!symbols) {
 		return;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -359,7 +359,7 @@ static RBinImport *import_from_name(RBin *rbin, const char *orig_name, HtPP *imp
 	char *name = (char*) orig_name;
 	const char *const _objc_class = "_OBJC_CLASS_$";
 	const char *const _objc_metaclass = "_OBJC_METACLASS_$";
-	const char * type = "FUNC";
+	const char *type = "FUNC";
 
 	if (r_str_startswith (name, _objc_class)) {
 		name += strlen (_objc_class);

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -189,9 +189,39 @@ static void _handle_arm_thumb(struct MACH0_(obj_t) *bin, RBinSymbol **p) {
 }
 
 #if FEATURE_SYMLIST
+// R2_590 remove this duplicate function once it is exposed in public API
+static RBinSymbol *r_bin_symbol_clone(RBinSymbol *bs) {
+	RBinSymbol *nbs = R_NEW (RBinSymbol);
+	memcpy (nbs, bs, sizeof (RBinSymbol));
+	nbs->name = strdup (nbs->name);
+	if (nbs->dname) {
+		nbs->dname = strdup (nbs->dname);
+	}
+	if (nbs->libname) {
+		nbs->libname = strdup (nbs->libname);
+	}
+	if (nbs->classname) {
+		nbs->classname = strdup (nbs->classname);
+	}
+	return nbs;
+}
+
 static RList *symbols(RBinFile *bf) {
 	RBinObject *obj = bf? bf->o: NULL;
-	return (RList *)MACH0_(get_symbols_list) (obj->bin_obj);
+	const RPVector *symbols = MACH0_(load_symbols) (bf, obj->bin_obj);
+	if (!symbols) {
+		return NULL;
+	}
+
+	RList *list = r_list_newf ((RListFree) r_bin_symbol_free);
+	void **it;
+	r_pvector_foreach (symbols, it) {
+		// need to clone here, in bobj.c the list free function is forced to `r_bin_symbol_free`
+		// otherwise, a list with no free function could be returned here..
+		RBinSymbol *symbol = r_bin_symbol_clone (*it);
+		r_list_append (list, symbol);
+	}
+	return list;
 }
 #else
 static RList *symbols(RBinFile *bf) {
@@ -1096,7 +1126,7 @@ static RBinAddr *binsym(RBinFile *bf, int sym) {
 	RBinAddr *ret = NULL;
 	switch (sym) {
 	case R_BIN_SYM_MAIN:
-		addr = MACH0_(get_main) (bf->o->bin_obj);
+		addr = MACH0_(get_main) (bf, bf->o->bin_obj);
 		if (addr == UT64_MAX || !(ret = R_NEW0 (RBinAddr))) {
 			return NULL;
 		}

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -451,23 +451,22 @@ static RList *relocs(RBinFile *bf) {
 }
 
 static RList *libs(RBinFile *bf) {
-	int i;
-	char *ptr = NULL;
-	struct lib_t *libs;
-	RList *ret = NULL;
 	RBinObject *obj = bf ? bf->o : NULL;
-
-	if (!obj || !obj->bin_obj || !(ret = r_list_newf (free))) {
+	if (!obj) {
 		return NULL;
 	}
-	if ((libs = MACH0_(get_libs) (obj->bin_obj))) {
-		for (i = 0; !libs[i].last; i++) {
-			ptr = strdup (libs[i].name);
-			r_list_append (ret, ptr);
-		}
-		free (libs);
+
+	const RPVector *libs = MACH0_(load_libs) (obj->bin_obj);
+	if (!libs) {
+		return NULL;
 	}
-	return ret;
+
+	RList *result = r_list_new ();
+	void **it;
+	r_pvector_foreach (libs, it) {
+		r_list_append (result, *it);
+	}
+	return result;
 }
 
 static RBinInfo *info(RBinFile *bf) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -215,9 +215,12 @@ static RList *symbols(RBinFile *bf) {
 
 	RList *list = r_list_newf ((RListFree) r_bin_symbol_free);
 	void **it;
+	int i = 0;
 	r_vector_foreach (symbols, it) {
 		// need to clone here, in bobj.c the list free function is forced to `r_bin_symbol_free`
 		// otherwise, a shallow copy of a list with no free function could be returned here..
+		eprintf ("length = %d, i = %d\n", symbols->len, i);
+		i++;
 		r_list_append (list, r_bin_symbol_clone ((RBinSymbol*) *it));
 	}
 	return list;

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -208,18 +208,18 @@ static RBinSymbol *r_bin_symbol_clone(RBinSymbol *bs) {
 
 static RList *symbols(RBinFile *bf) {
 	RBinObject *obj = bf? bf->o: NULL;
-	const RPVector *symbols = MACH0_(load_symbols) (bf, obj->bin_obj);
+	const RList *symbols = MACH0_(load_symbols) (bf, obj->bin_obj);
 	if (!symbols) {
 		return NULL;
 	}
 
 	RList *list = r_list_newf ((RListFree) r_bin_symbol_free);
-	void **it;
-	r_pvector_foreach (symbols, it) {
+	RListIter *it;
+	RBinSymbol *symbol;
+	r_list_foreach (symbols, it, symbol) {
 		// need to clone here, in bobj.c the list free function is forced to `r_bin_symbol_free`
-		// otherwise, a list with no free function could be returned here..
-		RBinSymbol *symbol = r_bin_symbol_clone (*it);
-		r_list_append (list, symbol);
+		// otherwise, a shallow copy of a list with no free function could be returned here..
+		r_list_append (list, r_bin_symbol_clone (symbol));
 	}
 	return list;
 }

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -208,18 +208,17 @@ static RBinSymbol *r_bin_symbol_clone(RBinSymbol *bs) {
 
 static RList *symbols(RBinFile *bf) {
 	RBinObject *obj = bf? bf->o: NULL;
-	const RList *symbols = MACH0_(load_symbols) (bf, obj->bin_obj);
+	const RVector *symbols = MACH0_(load_symbols) (bf, obj->bin_obj);
 	if (!symbols) {
 		return NULL;
 	}
 
 	RList *list = r_list_newf ((RListFree) r_bin_symbol_free);
-	RListIter *it;
-	RBinSymbol *symbol;
-	r_list_foreach (symbols, it, symbol) {
+	void **it;
+	r_vector_foreach (symbols, it) {
 		// need to clone here, in bobj.c the list free function is forced to `r_bin_symbol_free`
 		// otherwise, a shallow copy of a list with no free function could be returned here..
-		r_list_append (list, r_bin_symbol_clone (symbol));
+		r_list_append (list, r_bin_symbol_clone ((RBinSymbol*) *it));
 	}
 	return list;
 }

--- a/libr/bin/p/bin_mach064.c
+++ b/libr/bin/p/bin_mach064.c
@@ -269,7 +269,7 @@ static RBinAddr* binsym(RBinFile *bf, int sym) {
 	RBinAddr *ret = NULL;
 	switch (sym) {
 	case R_BIN_SYM_MAIN:
-		addr = MACH0_(get_main) (bf->o->bin_obj);
+		addr = MACH0_(get_main) (bf, bf->o->bin_obj);
 		if (!addr || !(ret = R_NEW0 (RBinAddr))) {
 			return NULL;
 		}

--- a/libr/util/vector.c
+++ b/libr/util/vector.c
@@ -12,11 +12,6 @@
 #define INITIAL_VECTOR_LEN 4
 #endif
 
-#define NEXT_VECTOR_CAPACITY (vec->capacity < INITIAL_VECTOR_LEN \
-	? INITIAL_VECTOR_LEN \
-	: vec->capacity <= 12 ? vec->capacity * 2 \
-	: vec->capacity + (vec->capacity >> 1))
-
 #define RESIZE_OR_RETURN_NULL(next_capacity) do { \
 		size_t new_capacity = next_capacity; \
 		if (new_capacity == 0) { \

--- a/test/db/cmd/display_flag
+++ b/test/db/cmd/display_flag
@@ -49,8 +49,8 @@ EXPECT=<<EOF
 ;-- func.100000f50:
 0x100000f50      55             push rbp
 0x100000000 0 __mh_execute_header
-0x100000f60 0 _main
 0x100000f50 0 _r\x1b#8qt
+0x100000f60 0 _main
 0x100000f8a 0 imp.printf
 0x100000f50 0 func.100000f50
 0x100000f60 0 func.100000f60

--- a/test/db/formats/mach0/leb128
+++ b/test/db/formats/mach0/leb128
@@ -12,6 +12,5 @@ id.compat=0.0.1
 EOF
 EXPECT_ERR=<<EOF
 ERROR: malformed uleb128
-ERROR: malformed uleb128
 EOF
 RUN

--- a/test/db/formats/mach0/mach0
+++ b/test/db/formats/mach0/mach0
@@ -267,8 +267,8 @@ CMDS=ik ***~uuid
 EXPECT=<<EOF
 info/mach0_uuid_command.format=[4]Ed[16]b (mach0_load_command_type)cmd cmdsize uuid
 info/mach0_cmd_8.format=mach0_uuid_command
-info/uuid.0=ff4d6c2e1dc0369d98d0d3040a8049e8
 info/mach0_cmd_8.cmd=uuid
+info/uuid.0=ff4d6c2e1dc0369d98d0d3040a8049e8
 EOF
 RUN
 

--- a/test/db/formats/mangling/bin
+++ b/test/db/formats/mangling/bin
@@ -2,13 +2,13 @@ NAME=binsym demangling
 FILE=bins/mach0/hellocxx-osx-i386
 CMDS=!rabin2 -qsD cxx all bins/mach0/hellocxx-osx-i386
 EXPECT=<<EOF
-0x00002054 0 _NXArgc
-0x00002058 0 _NXArgv
+0x00001000 0 __mh_execute_header
 0x00001d9a 0 unsigned long const& std::min<unsigned long>(unsigned long const&, unsigned long const&)
 0x00002060 0 ___progname
-0x00001000 0 __mh_execute_header
-0x0000205c 0 _environ
 0x00001d52 0 _main
+0x00002054 0 _NXArgc
+0x00002058 0 _NXArgv
+0x0000205c 0 _environ
 0x00001c10 0 start
 0x00001ba0 0 __static_initialization_and_destruction_0(int, int)
 0x00001bf2 0 global constructors keyed to main
@@ -33,13 +33,13 @@ FILE=bins/mach0/hellocxx-osx-i386
 ARGS=-M
 CMDS=isq
 EXPECT=<<EOF
-0x00002054 0 _NXArgc
-0x00002058 0 _NXArgv
+0x00001000 0 __mh_execute_header
 0x00001d9a 0 __ZSt3minImERKT_S2_S2_
 0x00002060 0 ___progname
-0x00001000 0 __mh_execute_header
-0x0000205c 0 _environ
 0x00001d52 0 _main
+0x00002054 0 _NXArgc
+0x00002058 0 _NXArgv
+0x0000205c 0 _environ
 0x00001c10 0 start
 0x00001ba0 0 __Z41__static_initialization_and_destruction_0ii
 0x00001bf2 0 __GLOBAL__I_main


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I refactored some parts of the mach0 parser:
- Some results are now cached after first time they are needed, subsequent function calls return the cached result. Further optimizations can be made here if e.g. in `bobj.c` the free function of a `RList` is not hardcoded to `r_bin_import_free` (😱)
- Reduced memory usage by making clever usage of data-structures
- Removed the ".last hack" for the refactored parts.

**PR is still WIP**, I still want to refactor symbols and relocations list.
