### PR TITLE
Fix RReg.setValue on 128bit registers ##reg

### DIFF
--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -673,11 +673,9 @@ static bool esil_zf(REsil *esil) {
 // checks if there was a carry from bit x (x,$c)
 static bool esil_cf(REsil *esil) {
 	char *src = r_esil_pop (esil);
-
 	if (!src) {
 		return false;
 	}
-
 	if (r_esil_get_parm_type (esil, src) != R_ESIL_PARM_NUM) {
 		//I'd wish we could enforce consts here
 		//I can't say why, but I feel like "al,$c" would be cancer af
@@ -700,11 +698,9 @@ static bool esil_cf(REsil *esil) {
 static bool esil_bf(REsil *esil) {
 	r_return_val_if_fail (esil, false);
 	char *src = r_esil_pop (esil);
-
 	if (!src) {
 		return false;
 	}
-
 	if (r_esil_get_parm_type (esil, src) != R_ESIL_PARM_NUM) {
 		free (src);
 		return false;
@@ -856,10 +852,7 @@ static bool esil_eq(REsil *esil) {
 		}
 		free (newreg);
 		free (src2);
-		goto beach;
-	}
-
-	if (src && dst && r_esil_reg_read_nocallback (esil, dst, &num, NULL)) {
+	} else if (src && dst && r_esil_reg_read_nocallback (esil, dst, &num, NULL)) {
 		if (r_esil_get_parm (esil, src, &num2)) {
 			ret = r_esil_reg_write (esil, dst, num2);
 			esil->cur = num2;
@@ -871,7 +864,6 @@ static bool esil_eq(REsil *esil) {
 	} else {
 		R_LOG_DEBUG ("esil_eq: invalid parameters");
 	}
-beach:
 	free (src);
 	free (dst);
 	return ret;
@@ -2439,12 +2431,15 @@ static bool esil_mem_andeq_n(REsil *esil, int bits) {
 static bool esil_mem_andeq1(REsil *esil) {
 	return esil_mem_andeq_n (esil, 8);
 }
+
 static bool esil_mem_andeq2(REsil *esil) {
 	return esil_mem_andeq_n (esil, 16);
 }
+
 static bool esil_mem_andeq4(REsil *esil) {
 	return esil_mem_andeq_n (esil, 32);
 }
+
 static bool esil_mem_andeq8(REsil *esil) {
 	return esil_mem_andeq_n (esil, 64);
 }

--- a/libr/reg/rvalue.c
+++ b/libr/reg/rvalue.c
@@ -156,10 +156,8 @@ R_API ut64 r_reg_get_value_by_role(RReg *reg, RRegisterId role) {
 
 R_API bool r_reg_set_value(RReg *reg, RRegItem *item, ut64 value) {
 	r_return_val_if_fail (reg && item, false);
-
-	ut8 bytes[12] = {0};
+	ut8 bytes[32] = {0};
 	ut8 *src = bytes;
-
 	if (r_reg_is_readonly (reg, item)) {
 		return true;
 	}
@@ -170,7 +168,7 @@ R_API bool r_reg_set_value(RReg *reg, RRegItem *item, ut64 value) {
 	if (!arena) {
 		return false;
 	}
-	bool be = reg->config? R_ARCH_CONFIG_IS_BIG_ENDIAN (reg->config): false;
+	const bool be = reg->config? R_ARCH_CONFIG_IS_BIG_ENDIAN (reg->config): false;
 	switch (item->size) {
 	case 80:
 	case 96: // long floating value
@@ -207,7 +205,11 @@ R_API bool r_reg_set_value(RReg *reg, RRegItem *item, ut64 value) {
 		}
 		return true;
 	case 128:
+		// function takes an ut64 as argument, which doesnt allow us to reach 128
+		r_write_ble64 (src, value, be);
+		break;
 	case 256:
+		R_LOG_DEBUG ("TODO: 256 bit register handling not implemented");
 		// XXX 128 & 256 bit
 		return false; // (ut64)r_reg_get_longdouble (reg, item);
 	default:


### PR DESCRIPTION
* Still limited to 64bit values

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
