### PR TITLE
Fix '\xff' strings issue in bsd-rv64/arm64 ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4227,7 +4227,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			char *str = r_str_from_ut64 (r_read_ble64 (&v, be));
 			if (R_STR_ISNOTEMPTY (str)) {
 				bool printable = true;
-				const char *ptr = str;
+				const signed char *ptr = str;
 				for (; *ptr ; ptr++) {
 					if (*ptr < 10) {
 						printable = false;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2022 - nibble, pancake, dso, lazula */
+/* radare - LGPL - Copyright 2009-2023 - nibble, pancake, dso, lazula */
 
 #define R_LOG_ORIGIN "disasm"
 
@@ -4227,7 +4227,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			char *str = r_str_from_ut64 (r_read_ble64 (&v, be));
 			if (R_STR_ISNOTEMPTY (str)) {
 				bool printable = true;
-				const signed char *ptr = str;
+				const signed char *ptr = (const signed char *)str;
 				for (; *ptr ; ptr++) {
 					if (*ptr < 10) {
 						printable = false;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
