### PR TITLE
Unused var had a meaning in the xnu kernelcache parser ##bin

### DIFF
--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -1475,6 +1475,9 @@ static RList *resolve_mig_subsystem(RKernelCacheObj *obj) {
 			incomplete--;
 		}
 	}
+	if (incomplete) {
+		return NULL;
+	}
 
 	if (!data_const_offset || !data_const_size || !data_const_vaddr ||
 		!text_exec_offset || !text_exec_size || !text_exec_vaddr) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
