### PR TITLE
Resolve ${arch}.nz as fallback when finding an assembler peer ##arch

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -52,6 +52,15 @@ R_API int r_anal_opasm(RAnal *anal, ut64 addr, const char *s, ut8 *outbuf, int o
 				}
 				free (an);
 			}
+			// workaround because r_arch_use doesnt handle encoder sessions until R2_590
+			if (!tmparch) {
+				char *an = r_str_newf ("%s.nz", arch_name);
+				if (r_arch_use (anal->arch, anal->arch->cfg, an)) {
+					tmparch = an;
+				} else {
+					free (an);
+				}
+			}
 			if (!tmparch) {
 				// cannot assemble with this plugin
 				r_anal_op_free (op);

--- a/libr/debug/trace.c
+++ b/libr/debug/trace.c
@@ -27,13 +27,12 @@ R_API RDebugTrace *r_debug_trace_new(void) {
 }
 
 R_API void r_debug_trace_free(RDebugTrace *trace) {
-	if (!trace) {
-		return;
+	if (trace) {
+		r_list_purge (trace->traces);
+		free (trace->traces);
+		ht_pp_free (trace->ht);
+		R_FREE (trace);
 	}
-	r_list_purge (trace->traces);
-	free (trace->traces);
-	ht_pp_free (trace->ht);
-	R_FREE (trace);
 }
 
 // TODO: added overlap/mask support here... wtf?


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
