### PR TITLE
Fix aae logic for mem read xrefs ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5038,20 +5038,17 @@ static bool esilbreak_mem_read(REsil *esil, ut64 addr, ut8 *buf, int len) {
 			break;
 		}
 		// TODO incorrect
-		bool validRef = false;
 		if (trace && myvalid (mycore->io, refptr)) {
 			if (ntarget == UT64_MAX || ntarget == refptr) {
 				str[0] = 0;
 				if (r_io_read_at (mycore->io, refptr, str, sizeof (str)) < 1) {
 					//eprintf ("Invalid read\n");
 					str[0] = 0;
-					validRef = false;
 				} else {
 					r_anal_xrefs_set (mycore->anal, esil->address, refptr, R_ANAL_REF_TYPE_DATA | R_ANAL_REF_TYPE_READ);
 					str[sizeof (str) - 1] = 0;
 					add_string_ref (mycore, esil->address, refptr);
 					esilbreak_last_data = UT64_MAX;
-					validRef = true;
 				}
 			}
 		}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5055,10 +5055,10 @@ static bool esilbreak_mem_read(REsil *esil, ut64 addr, ut8 *buf, int len) {
 				}
 			}
 		}
-
-		/** resolve ptr */
-		if (ntarget == UT64_MAX || ntarget == addr || (ntarget == UT64_MAX && !validRef)) {
-			r_anal_xrefs_set (mycore->anal, esil->address, addr, R_ANAL_REF_TYPE_DATA | R_ANAL_REF_TYPE_READ);
+		if (myvalid (mycore->io, addr) && r_io_read_at (mycore->io, addr, (ut8*)buf, len)) {
+			if (!is_stack (mycore->io, addr)) {
+				r_anal_xrefs_set (mycore->anal, esil->address, addr, R_ANAL_REF_TYPE_DATA | R_ANAL_REF_TYPE_READ);
+			}
 		}
 	}
 	return false; // fallback

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56079,6 +56079,7 @@ EOF
 RUN
 
 NAME=axt find mem reads xrefs
+ARGS=-a arm -b 64
 FILE=bins/mach0/TestApp.ios
 CMDS=<<EOF
 aae

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56078,3 +56078,16 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=axt find mem reads xrefs
+FILE=bins/mach0/TestApp.ios
+CMDS=<<EOF
+aae
+axt 0x100009394~[1]
+EOF
+EXPECT=<<EOF
+0x100005eb4
+0x100006078
+0x1000060e0
+EOF
+RUN
+


### PR DESCRIPTION

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

In this way is consistent with mem write logic and mem read xrefs are found too.
