### PR TITLE
Add - to tar xzvf ##r2pm

### DIFF
--- a/libr/main/r2pm.c
+++ b/libr/main/r2pm.c
@@ -583,7 +583,7 @@ static bool download(const char *url, const char *outfile) {
 
 static bool unzip(const char *file, const char *dir) {
 	if (r_str_endswith (file, ".tgz") || r_str_endswith (file, ".tar.gz")) {
-		return 0 == r_sys_cmdf ("tar xzvf '%s' -C '%s'", file, dir);
+		return 0 == r_sys_cmdf ("tar -xzvf '%s' -C '%s'", file, dir);
 	}
 	if (r_str_endswith (file, ".zip")) {
 		return 0 == r_sys_cmdf ("unzip '%s' -d '%s'", file, dir);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
This breaks the tar I use, seems this "dashless" syntax is GNU-specific. This change should result in no breakage, and just improve support for various tar implementations.