### PR TITLE
Fix the wrong plugin used after failed arch.encoding ##arch

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -51,31 +51,20 @@ R_API int r_anal_opasm(RAnal *anal, ut64 addr, const char *s, ut8 *outbuf, int o
 			if (dot) {
 				char *an = r_str_ndup (arch_name, dot - arch_name);
 				if (r_arch_use (anal->arch, anal->arch->cfg, an)) {
-					tmparch = strdup (arch_name);
+					if (anal->arch->session->plugin->encode) {
+						char *an2 = r_str_newf ("%s.nz", an);
+						if (r_arch_use (anal->arch, anal->arch->cfg, an2)) {
+							tmparch = an2;
+						} else {
+							free (an2);
+						}
+					} else {
+						tmparch = strdup (arch_name);
+					}
 				}
 				free (an);
 			}
-			// workaround because r_arch_use doesnt handle encoder sessions until R2_590
 			if (!tmparch) {
-				char *an = r_str_newf ("%s.nz", arch_name);
-				if (r_arch_use (anal->arch, anal->arch->cfg, an)) {
-					tmparch = an;
-				} else {
-					free (an);
-				}
-			}
-			// workaround because r_arch_use doesnt handle encoder sessions until R2_590
-			if (!tmparch) {
-				char *an = r_str_newf ("%s.nz", arch_name);
-				if (r_arch_use (anal->arch, anal->arch->cfg, an)) {
-					tmparch = an;
-				} else {
-					free (an);
-				}
-			}
-			if (!tmparch) {
-				// cannot assemble with this plugin
-				// R_FREE (oldname);
 				r_anal_op_free (op);
 				goto beach;
 			}

--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -36,6 +36,7 @@ R_API int r_anal_opasm(RAnal *anal, ut64 addr, const char *s, ut8 *outbuf, int o
 	bool arch_set = false;
 	char *tmparch = NULL;
 	int ret = 0;
+	char *oldname = NULL;
 	if (outlen > 0 && anal->arch->session && anal->uses == 2) {
 		RArchSession *as = R_UNWRAP3 (anal, arch, session);
 		RArchPluginEncodeCallback encode = R_UNWRAP3 (as, plugin, encode);
@@ -43,7 +44,6 @@ R_API int r_anal_opasm(RAnal *anal, ut64 addr, const char *s, ut8 *outbuf, int o
 		if (!op) {
 			return -1;
 		}
-		char *oldname = NULL;
 		if (!encode) {
 			oldname = strdup (as->plugin->name);
 			const char *arch_name = as->plugin->name;
@@ -75,9 +75,9 @@ R_API int r_anal_opasm(RAnal *anal, ut64 addr, const char *s, ut8 *outbuf, int o
 			}
 			if (!tmparch) {
 				// cannot assemble with this plugin
-				free (oldname);
+				// R_FREE (oldname);
 				r_anal_op_free (op);
-				return -1;
+				goto beach;
 			}
 		}
 		r_anal_op_set_mnemonic (op, addr, s);
@@ -136,6 +136,10 @@ beach:
 			r_arch_use (anal->arch, anal->arch->cfg, tmparch);
 		}
 		free (tmparch);
+	} else {
+		if (oldname) {
+			r_arch_use (anal->arch, anal->arch->cfg, oldname);
+		}
 	}
 	return ret;
 }

--- a/test/db/cmd/archs
+++ b/test/db/cmd/archs
@@ -1,3 +1,17 @@
+NAME=wawa
+FILE=-
+CMDS=<<EOF
+-a sh
+pd 1
+wa 8d00
+pd 1
+EOF
+EXPECT=<<EOF
+            0x00000000      0000           .word 0x00000000
+            0x00000000      0000           .word 0x00000000
+EOF
+RUN
+
 NAME=endian tests: mips
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
