### PR TITLE
Fix wrong json key string (refs to name) in anal_axg

### DIFF
--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -9032,7 +9032,7 @@ static void anal_axg(RCore *core, const char *input, int level, Sdb *db, int opt
 					pj_o (pj);
 					pj_ks (pj, "type", "fcn");
 					pj_kn (pj, "fcn_addr", fcn->addr);
-					pj_ks (pj, "refs", fcn->name);
+					pj_ks (pj, "name", fcn->name);
 					pj_k (pj, "refs");
 					pj_a (pj);
 				}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
