### PR TITLE
Fix r2r build when doing static linking ##build

### DIFF
--- a/binr/r2r/Makefile
+++ b/binr/r2r/Makefile
@@ -1,6 +1,7 @@
 BIN=r2r
 BINDEPS=r_util r_cons
-OBJ=load.o run.o
+# OBJ=load.o run.o
+CFLAGS+=-DALLINC=1
 
 include ../rules.mk
 include ../../libr/util/deps.mk

--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -1,5 +1,6 @@
-/* radare - LGPL - Copyright 2020-2022 - pancake, thestr4ng3r */
+/* radare - LGPL - Copyright 2020-2023 - pancake, thestr4ng3r */
 
+#undef R_LOG_ORIGIN
 #define R_LOG_ORIGIN "r2r.load"
 
 #include "r2r.h"

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -1,6 +1,10 @@
 /* radare - LGPL - Copyright 2020-2023 - pancake, thestr4ng3r */
 
 #include "r2r.h"
+#if ALLINC
+#include "load.c"
+#include "run.c"
+#endif
 
 #define WORKERS_DEFAULT        8
 #define JSON_TEST_FILE_DEFAULT "bins/elf/crackme0x00b"


### PR DESCRIPTION
* That looks like a gcc bug, because clang is not affected
* Anyway, lets just workaround it this way

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
