### PR TITLE
Fix crash due to int overflow loading mach0 ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -119,7 +119,7 @@ struct MACH0_(obj_t) {
 	int symstrlen;
 	int nsymtab;
 	ut32 *indirectsyms;
-	int nindirectsyms;
+	ut32 nindirectsyms;
 	int maxsymlen;
 
 	RBinImport **imports_by_ord;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
For some corrupt binaries, the `nindirectsyms` field would be negative, breaking the array length check. This resulted in an out-of-bounds array access.