### PR TITLE
Improve handling of nindirectsyms for corrupt macho binaries ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4190,8 +4190,6 @@ static RVector /* <RBinElfSymbol> */ *Elf_(_r_bin_elf_load_symbols_and_imports)(
 	size_t import_ret_ctr = 0;
 	size_t ret_ctr = 0; // amount of symbols stored in ret
 	RVector *ret = parse_gnu_debugdata (bin, &ret_ctr);
-	// ret_size = amount of dbgsymbols in the array (not size of the array)
-	size_t ret_size = ret_ctr * sizeof (RBinElfSymbol); // size of ret allocation
 	ElfSymbolMemory memory = { .symbols = ret, .sym = NULL, .strtab = NULL };
 	int i;
 	for (i = 0; i < bin->ehdr.e_shnum; i++) {
@@ -4318,8 +4316,6 @@ static RVector /* <RBinElfSymbol> */ *Elf_(_r_bin_elf_load_symbols_and_imports)(
 			_symbol_memory_free (&memory);
 			return NULL;
 		}
-
-		ret_size += increment * sizeof (RBinElfSymbol);
 
 		int k;
 		for (k = 1; k < nsym; k++, ret_ctr++) {

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2576,7 +2576,7 @@ static bool parse_import_stub(struct MACH0_(obj_t) *bin, struct symbol_t *symbol
 			nsyms = (int)(sect_size / sect_fragment);
 			for (j = 0; j < nsyms; j++) {
 				if (bin->sects) {
-					if (bin->sects[i].reserved1 + j >= bin->nindirectsyms) {
+					if (bin->nindirectsyms < 0 || bin->sects[i].reserved1 + j >= bin->nindirectsyms) {
 						continue;
 					}
 				}

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -119,7 +119,7 @@ struct MACH0_(obj_t) {
 	int symstrlen;
 	int nsymtab;
 	ut32 *indirectsyms;
-	ut32 nindirectsyms;
+	int nindirectsyms;
 	int maxsymlen;
 
 	RBinImport **imports_by_ord;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Simply changing `nindirectsyms` from `int` -> `ut32` did not help. A value that was negative previously, would now try to allocate a very large amount of memory. The previous change was reverted, and a check was added to see if `nindirectsyms` is a positive number.