### PR TITLE
Fix null deref in arm32 calling conventions via 'aaef' ##analysis

### DIFF
--- a/libr/anal/d/cc-arm-32.sdb.txt
+++ b/libr/anal/d/cc-arm-32.sdb.txt
@@ -3,6 +3,9 @@ default.cc=arm32
 arm32=cc
 cc.arm32.arg0=r0
 cc.arm32.arg1=r1
+cc.arm32.arg2=r2
+cc.arm32.arg3=r3
+cc.arm32.arg4=r4
 cc.arm32.ret=r0
 
 arm16=cc
@@ -10,6 +13,7 @@ cc.arm16.arg0=r0
 cc.arm16.arg1=r1
 cc.arm16.arg2=r2
 cc.arm16.arg3=r3
+cc.arm16.arg4=r4
 cc.arm16.argn=stack
 cc.arm16.ret=r0
 
@@ -18,6 +22,7 @@ cc.swift.arg0=r0
 cc.swift.arg1=r1
 cc.swift.arg2=r2
 cc.swift.arg3=r3
+cc.swift.arg4=r4
 cc.swift.argn=stack
 cc.swift.self=r10
 cc.swift.self=r8

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1242,10 +1242,12 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			char *name = NULL;
 			int delta = 0;
 			const char *regname = r_anal_cc_arg (anal, fcn->cc, i);
-			RRegItem *ri = r_reg_get (anal->reg, regname, -1);
-			if (ri) {
-				delta = ri->index;
-				r_unref (ri);
+			if (regname) {
+				RRegItem *ri = r_reg_get (anal->reg, regname, -1);
+				if (ri) {
+					delta = ri->index;
+					r_unref (ri);
+				}
 			}
 			if (fname) {
 				type = r_type_func_args_type (TDB, fname, i);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
