### PR TITLE
Handle 'int 0x20' as eob on x86-16 (assume DOS) ##analysis

### DIFF
--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -3317,6 +3317,12 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 	case X86_INS_INT:
 		op->type = R_ANAL_OP_TYPE_SWI;
 		op->val = (int)INSOP(0).imm;
+		if (a->config->bits == 16 && op->val == 0x20) {
+			// TODO: Ccheck for >-config->os == "DOS"
+			// "int 0x20" -> terminate program on DOS
+			op->eob = true; // looks like eob is ignored if optype is not trap :?
+			op->type = R_ANAL_OP_TYPE_TRAP;
+		}
 		break;
 	case X86_INS_SYSCALL:
 	case X86_INS_SYSENTER:

--- a/test/db/anal/x86_16
+++ b/test/db/anal/x86_16
@@ -261,4 +261,39 @@ EXPECT=<<EOF
 EOF
 RUN
 
-
+NAME=int 0x20
+FILE=bins/mz/INSTALL.EXE
+CMDS=<<EOF
+af
+pdf
+EOF
+EXPECT=<<EOF
+            ;-- section.seg_000:
+            ;-- mz.dos_header:
+/ 50: entry0 ();
+|           0000:0000     b8800b         mov ax, 0xb80                 ; [00] -rwx section size 16818 named seg_000
+|           0000:0003     ba1c04         mov dx, 0x41c
+|           0000:0006     050000         add ax, 0                     ; RELOC 16 
+|           0000:0009     3b060200       cmp ax, word [2]              ; [0x2:2]=0xba0b
+|       ,=< 0000:000d     731a           jae 0x29
+|       |   0000:000f     2d2000         sub ax, 0x20
+|       |   0000:0012     fa             cli
+|       |   0000:0013     8ed0           mov ss, ax
+|       |   0000:0015     fb             sti
+|       |   0000:0016     2d1900         sub ax, 0x19
+|       |   ; DATA XREF from entry0 @ 0x16(r)
+|       |   0000:0019     8ec0           mov es, ax
+|       |   0000:001b     50             push ax
+|       |   0000:001c     b9c700         mov cx, 0xc7
+|       |   0000:001f     33ff           xor di, di
+|       |   0000:0021     57             push di
+|       |   0000:0022     be4401         mov si, 0x144
+|       |   0000:0025     fc             cld
+|       |   0000:0026     f3a5           rep movsw word es:[di], word [si]
+|       |   0000:0028     cb             retf
+|       `-> 0000:0029     b409           mov ah, 9
+|           0000:002b     ba3201         mov dx, 0x132
+|           0000:002e     cd21           int 0x21
+\           0000:0030     cd20           int 0x20
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
