### PR TITLE
Fix spelling of R_ANAL_OP_TYPE_LENGTH ##API ##capstone

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -337,7 +337,7 @@ static struct optype {
 	{ R_ANAL_OP_TYPE_CASE, "case" },
 	{ R_ANAL_OP_TYPE_CPL, "cpl" },
 	{ R_ANAL_OP_TYPE_CRYPTO, "crypto" },
-	{ R_ANAL_OP_TYPE_LENGTH, "lenght" },
+	{ R_ANAL_OP_TYPE_LENGTH, "length" },
 	{ R_ANAL_OP_TYPE_ABS, "abs" },
 };
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
