### PR TITLE
Add recognition to (U)COMISS instruction set ##API ##capstone

### DIFF
--- a/libr/anal/op.c
+++ b/libr/anal/op.c
@@ -599,6 +599,7 @@ R_API const char *r_anal_op_family_tostring(int n) {
 	case R_ANAL_OP_FAMILY_CRYPTO: return "crpt";
 	case R_ANAL_OP_FAMILY_IO: return "io";
 	case R_ANAL_OP_FAMILY_VIRT: return "virt";
+	case R_ANAL_OP_FAMILY_SIMD: return "simd";
 	}
 	return NULL;
 }
@@ -618,6 +619,7 @@ static const struct op_family of[] = {
 	{ "io", R_ANAL_OP_FAMILY_IO },
 	{ "sec", R_ANAL_OP_FAMILY_SECURITY },
 	{ "thread", R_ANAL_OP_FAMILY_THREAD },
+	{ "simd", R_ANAL_OP_FAMILY_SIMD },
 };
 
 R_API int r_anal_op_family_from_string(const char *f) {

--- a/libr/anal/p/anal_x86_cs.c
+++ b/libr/anal/p/anal_x86_cs.c
@@ -3139,6 +3139,13 @@ static void anop(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh 
 		op1_memimmhandle (op, insn, addr, regsz);
 		}
 		break;
+	// comiss
+	case X86_INS_COMISS:
+	case X86_INS_UCOMISS:
+	case X86_INS_VCOMISS:
+	case X86_INS_VUCOMISS:
+		op->family = R_ANAL_OP_FAMILY_SIMD;
+		break;
 	case X86_INS_ROL:
 	case X86_INS_RCL:
 		// TODO: RCL Still does not work as intended

--- a/libr/include/r_anal/op.h
+++ b/libr/include/r_anal/op.h
@@ -47,6 +47,7 @@ typedef enum {
 	R_ANAL_OP_FAMILY_VIRT,   	/* virtualization instructions */
 	R_ANAL_OP_FAMILY_SECURITY,	/* security instructions */
 	R_ANAL_OP_FAMILY_IO,     	/* IO instructions (i.e. IN/OUT) */
+	R_ANAL_OP_FAMILY_SIMD,   	/* SIMD instructions */
 	R_ANAL_OP_FAMILY_LAST
 } RAnalOpFamily;
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
COMISS and UCOMiSS instructions are prevalent when using GCC under Linux x64. Example:
```c
// compile with gcc -S -O3 test.c
#include <stdio.h>

int main(int argc, char **argv)
{
    float f1;
    float f2;

    scanf("%f", &f1);
    scanf("%f", &f2);

    if(f1 > f2)
    {
        puts("bigger");
    }
    else if(f1 < f2)
    {
        puts("smaller");
    }

    return 0;
}
```