### PR TITLE
Fix #21715 - Using wrong baddr in apk:// when multiopening ##io

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -852,7 +852,7 @@ R_API RIODesc *r_core_file_open_many(RCore *r, const char *file, int perm, ut64 
 	}
 	RListIter *iter;
 	RIODesc *first = NULL;
-	bool incloadaddr = loadaddr == 0;
+	bool incloadaddr = loadaddr == UT64_MAX;
 	// r_config_set_b (r->config, "io.va", false);
 	r_list_foreach (list_fds, iter, fd) {
 		if (fd->uri) {
@@ -866,6 +866,9 @@ R_API RIODesc *r_core_file_open_many(RCore *r, const char *file, int perm, ut64 
 			if (incloadaddr && sz != UT64_MAX) {
 				const int rest = (sz % 4096);
 				const int pillow = 0x4000;
+				if (loadaddr == UT64_MAX) {
+					loadaddr = 0;
+				}
 				loadaddr += sz + rest + pillow;
 			}
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
