### PR TITLE
Fix ESIL MIPS64 NOR instruction.

### DIFF
--- a/libr/anal/p/anal_mips_cs.c
+++ b/libr/anal/p/anal_mips_cs.c
@@ -597,7 +597,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 				const char *arg1 = ARG(1);
 				const char *arg2 = ARG(2);
 				PROTECT_ZERO () {
-					r_strbuf_appendf (&op->esil, "%s,%s,|,0xffffffff,^,%s,=",
+					r_strbuf_appendf (&op->esil, "%s,%s,|,0xffffffffffffffff,^,%s,=",
 						arg2, arg1, arg0);
 				}
 			}

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -674,6 +674,23 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=nor a1, 0xfffffffe, 0xfffffffe
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=mips
+e asm.bits=32
+e cfg.bigendian=True
+ar > /dev/null
+ar v0=-2
+wx 00422827
+aes
+ar a1
+EOF
+EXPECT=<<EOF
+0x00000001
+EOF
+RUN
+
 NAME=lh v1, (v0)
 FILE=malloc://0x200
 CMDS=<<EOF

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -1,0 +1,16 @@
+NAME=nor a1, 0xfffffffffffffffe, 0xfffffffffffffffe
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=mips
+e asm.bits=64
+e cfg.bigendian=True
+ar > /dev/null
+ar v0=-2
+wx 00422827
+aes
+ar a1
+EOF
+EXPECT=<<EOF
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X ] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Simple fix, with tests, for the MIPS64 NOR instruction under ESIL.