### PR TITLE
Fix #19964 - show relro:no even if no dyn section is found ##bin

### DIFF
--- a/doc/fortunes.fun
+++ b/doc/fortunes.fun
@@ -326,3 +326,4 @@ Are you still watching?
 Starting application, this might take some time...
 Do you want to restart to install these updates now or try tonight?
 Updates available
+This binary has not been analyzed. Would you like to analyze it now?

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1035,9 +1035,11 @@ static int bin_info(RCore *r, PJ *pj, int mode, ut64 laddr) {
 		pair_bool (pj, "pic", info->has_pi);
 		pair_bool (pj, "relocs", R_BIN_DBG_RELOCS & info->dbg_info);
 		Sdb *sdb_info = sdb_ns (obj->kv, "info", false);
-		tmp_buf = sdb_get (sdb_info, "elf.relro", 0);
-		if (tmp_buf) {
-			pair_str (pj, "relro", tmp_buf);
+		if (sdb_info) {
+			tmp_buf = sdb_get (sdb_info, "elf.relro", 0);
+			if (R_STR_ISNOTEMPTY (tmp_buf)) {
+				pair_str (pj, "relro", tmp_buf);
+			}
 			free (tmp_buf);
 		}
 		pair_str (pj, "rpath", info->rpath);

--- a/libr/core/cmd_meta.c
+++ b/libr/core/cmd_meta.c
@@ -98,10 +98,8 @@ static RCoreHelpMessage help_msg_CS = {
 };
 
 static RCoreHelpMessage help_msg_Cs = {
-	"Usage:", "Cs[ga-*.] [size] [@addr]", "",
-	"NOTE:", " size", "1 unit in bytes == width in bytes of smallest possible char in encoding,",
-	"", "", "  so ascii/latin1/utf8 = 1, utf16le = 2",
-	" Cz", " [size] [@addr]", "ditto",
+	"Usage:", "Cs[ga-*.] ([size]) [@addr]", "",
+	"Cz", " [size] [@addr]", "ditto",
 	"Cs", " [size] @addr", "add string (guess latin1/utf16le)",
 	"Cs", "", "list all strings in human friendly form",
 	"Cs*", "", "list all strings in r2 commands",

--- a/test/db/formats/elf/relro
+++ b/test/db/formats/elf/relro
@@ -1,0 +1,23 @@
+NAME=relro partial
+FILE=bins/elf/relro/true32
+CMDS=ij~{bin.relro}
+EXPECT=<<EOF
+partial
+EOF
+RUN
+
+NAME=relro no
+FILE=bins/elf/relro/top
+CMDS=ij~{bin.relro}
+EXPECT=<<EOF
+no
+EOF
+RUN
+
+NAME=relro full
+FILE=bins/elf/relro/netifd
+CMDS=ij~{bin.relro}
+EXPECT=<<EOF
+full
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
