### PR TITLE
Fix #21823 - tag static elfs as non libinjectables ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1089,6 +1089,9 @@ static RBinInfo* info(RBinFile *bf) {
 	}
 	if (Elf_(is_static) (obj)) {
 		ret->dbg_info |= R_BIN_DBG_STATIC;
+#if R2_590
+		ret->has_libinjprot = true;
+#endif
 	}
 	lookup_sections (bf, ret);
 	lookup_symbols (bf, ret);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
