### PR TITLE
Fix null derefs and memleaks in {esil,debug}traces ##esil

### DIFF
--- a/libr/core/anal_tp.c
+++ b/libr/core/anal_tp.c
@@ -517,7 +517,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	r_return_if_fail (core && core->anal && fcn);
 
 	if (!core->anal->esil) {
-		eprintf ("Please run aeim\n");
+		R_LOG_WARN ("Please run aeim");
 		return;
 	}
 
@@ -561,6 +561,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	char *ret_reg = NULL;
 	const char *_pc = r_reg_get_name (core->dbg->reg, R_REG_NAME_PC);
 	if (!_pc) {
+		anal_emul_restore (core, hc, dt, et);
 		return;
 	}
 	int retries = 2;
@@ -568,6 +569,7 @@ R_API void r_core_anal_type_match(RCore *core, RAnalFunction *fcn) {
 	r_cons_break_push (NULL, NULL);
 repeat:
 	if (retries < 0) {
+		anal_emul_restore (core, hc, dt, et);
 		free (pc);
 		return;
 	}

--- a/libr/esil/esil_trace.c
+++ b/libr/esil/esil_trace.c
@@ -21,7 +21,7 @@ static void htup_vector_free(HtUPKv *kv) {
 R_API REsilTrace *r_esil_trace_new(REsil *esil) {
 	r_return_val_if_fail (esil, NULL);
 	if (!esil->stack_addr || !esil->stack_size) {
-		R_LOG_ERROR ("Run `aeim` to initialize a stack for the ESIL vm");
+		// R_LOG_ERROR ("Run `aeim` to initialize a stack for the ESIL vm");
 		return NULL;
 	}
 	size_t i;
@@ -119,7 +119,7 @@ static bool trace_hook_reg_read(REsil *esil, const char *name, ut64 *res, int *s
 	r_strf_buffer (128);
 	bool ret = false;
 	if (*name == '0') {
-		//eprintf ("Register not found in profile\n");
+		// eprintf ("Register not found in profile\n");
 		return false;
 	}
 	if (ocbs.hook_reg_read) {
@@ -143,7 +143,7 @@ static bool trace_hook_reg_read(REsil *esil, const char *name, ut64 *res, int *s
 static bool trace_hook_reg_write(REsil *esil, const char *name, ut64 *val) {
 	r_strf_buffer (128);
 	bool ret = false;
-	//eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, *val);
+	// eprintf ("[ESIL] REG WRITE %s 0x%08"PFMT64x"\n", name, *val);
 	RRegItem *ri = r_reg_get (esil->anal->reg, name, -1);
 	if (ri) {
 		sdb_array_add (DB, KEY ("reg.write"), name, 0);
@@ -212,25 +212,25 @@ R_API void r_esil_trace_op(REsil *esil, RAnalOp *op) {
 	r_return_if_fail (esil && op);
 	r_strf_buffer (128);
 	const char *expr = r_strbuf_get (&op->esil);
-	if (R_STR_ISEMPTY (expr)) {
-		// do nothing
-		return;
-	}
 	if (!esil->trace) {
 		esil->trace = r_esil_trace_new (esil);
 		if (!esil->trace) {
 			return;
 		}
 	}
+	if (R_STR_ISEMPTY (expr)) {
+		// do nothing
+		return;
+	}
 	/* restore from trace when `idx` is not at the end */
 	if (esil->trace->idx != esil->trace->end_idx) {
+		eprintf ("j %d\n", esil->trace->idx);
 		r_esil_trace_restore (esil, esil->trace->idx + 1);
 		return;
 	}
 	/* save old callbacks */
-	int esil_verbose = esil->verbose;
 	if (ocbs_set) {
-		eprintf ("r_esil_trace_op: Cannot call recursively\n");
+		R_LOG_WARN ("r_esil_trace_op: Cannot call recursively");
 	}
 	ocbs = esil->cb;
 	ocbs_set = true;
@@ -244,18 +244,19 @@ R_API void r_esil_trace_op(REsil *esil, RAnalOp *op) {
 	//eprintf ("[ESIL] OPCODE %s\n", op->mnemonic);
 	//eprintf ("[ESIL] EXPR = %s\n", expr);
 	/* set hooks */
-	esil->verbose = 0;
 	esil->cb.hook_reg_read = trace_hook_reg_read;
 	esil->cb.hook_reg_write = trace_hook_reg_write;
 	esil->cb.hook_mem_read = trace_hook_mem_read;
 	esil->cb.hook_mem_write = trace_hook_mem_write;
 	/* evaluate esil expression */
+	const int esil_verbose = esil->verbose;
+	esil->verbose = 0; // disable verbose logs when tracing
 	r_esil_parse (esil, expr);
 	r_esil_stack_free (esil);
+	esil->verbose = esil_verbose;
 	/* restore hooks */
 	esil->cb = ocbs;
 	ocbs_set = false;
-	esil->verbose = esil_verbose;
 	/* increment idx */
 	esil->trace->idx++;
 	esil->trace->end_idx++;
@@ -320,10 +321,10 @@ static int cmp_strings_by_leading_number(void *data1, void *data2) {
 	int i = 0;
 	int j = 0;
 	int k = 0;
-	while (a[i] >= '0' && a[i] <= '9') {
+	while (isdigit (a[i])) {
 		i++;
 	}
-	while (b[j] >= '0' && b[j] <= '9') {
+	while (isdigit (b[j])) {
 		j++;
 	}
 	if (!i || !j) {
@@ -381,62 +382,55 @@ R_API void r_esil_trace_list(REsil *esil) {
 R_API void r_esil_trace_show(REsil *esil, int idx) {
 	r_strf_buffer (128);
 	PrintfCallback p = esil->anal->cb_printf;
-	const char *str2;
-	const char *str;
 	if (!esil->trace) {
 		return;
 	}
 	int trace_idx = esil->trace->idx;
 	esil->trace->idx = idx;
 
-	str2 = sdb_const_get (DB, KEY ("addr"), 0);
+	const char *str2 = sdb_const_get (DB, KEY ("addr"), 0);
 	if (!str2) {
 		return;
 	}
 	p ("ar PC = %s\n", str2);
 	/* registers */
-	str = sdb_const_get (DB, KEY ("reg.read"), 0);
-	if (str) {
+	const char *str = sdb_const_get (DB, KEY ("reg.read"), 0);
+	if (R_STR_ISNOTEMPTY (str)) {
 		char regname[32];
 		const char *next, *ptr = str;
-		if (ptr && *ptr) {
-			do {
-				next = sdb_const_anext (ptr);
-				int len = next? (int)(size_t)(next - ptr) - 1 : strlen (ptr);
-				if (len < sizeof (regname)) {
-					memcpy (regname, ptr, len);
-					regname[len] = 0;
-					str2 = sdb_const_get (DB, KEYREG ("reg.read", regname), 0);
-					p ("ar %s = %s\n", regname, str2);
-				} else {
-					R_LOG_ERROR ("Invalid entry in reg.read");
-				}
-				ptr = next;
-			} while (next);
-		}
+		do {
+			next = sdb_const_anext (ptr);
+			int len = next? (int)(size_t)(next - ptr) - 1 : strlen (ptr);
+			if (len < sizeof (regname)) {
+				memcpy (regname, ptr, len);
+				regname[len] = 0;
+				str2 = sdb_const_get (DB, KEYREG ("reg.read", regname), 0);
+				p ("ar %s = %s\n", regname, str2);
+			} else {
+				R_LOG_ERROR ("Invalid entry in reg.read");
+			}
+			ptr = next;
+		} while (next);
 	}
 	/* memory */
 	str = sdb_const_get (DB, KEY ("mem.read"), 0);
-	if (str) {
+	if (R_STR_ISNOTEMPTY (str)) {
 		char addr[64];
 		const char *next, *ptr = str;
-		if (ptr && *ptr) {
-			do {
-				next = sdb_const_anext (ptr);
-				int len = next? (int)(size_t)(next-ptr)-1 : strlen (ptr);
-				if (len < sizeof (addr)) {
-					memcpy (addr, ptr, len);
-					addr[len] = 0;
-					str2 = sdb_const_get (DB, KEYAT ("mem.read.data",
-						r_num_get (NULL, addr)), 0);
-					p ("wx %s @ %s\n", str2, addr);
-				} else {
-					R_LOG_ERROR ("Invalid entry in reg.read");
-				}
-				ptr = next;
-			} while (next);
-		}
+		do {
+			next = sdb_const_anext (ptr);
+			int len = next? (int)(size_t)(next - ptr) - 1 : strlen (ptr);
+			if (len < sizeof (addr)) {
+				memcpy (addr, ptr, len);
+				addr[len] = 0;
+				str2 = sdb_const_get (DB, KEYAT ("mem.read.data",
+					r_num_get (NULL, addr)), 0);
+				p ("wx %s @ %s\n", str2, addr);
+			} else {
+				R_LOG_ERROR ("Invalid entry in reg.read");
+			}
+			ptr = next;
+		} while (next);
 	}
-
 	esil->trace->idx = trace_idx;
 }

--- a/sys/counters.sh
+++ b/sys/counters.sh
@@ -19,6 +19,9 @@ git grep 'eprintf (' libr | grep Usage | wc -l
 printf -- "f(char)\t"
 git grep 'free ((char' libr | wc -l
 
+printf -- "IS_DIGIT\t"
+git grep 'IS_DIGIT' libr | wc -l
+
 printf -- "f(void)\t"
 git grep 'free ((void' libr | wc -l
 


### PR DESCRIPTION
* Requires `e dbg.trace=1; aeim` before testing

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
