### PR TITLE
Fix 1byte oobread bug in the java decoder spotted by arch

### DIFF
--- a/shlr/java/code.c
+++ b/shlr/java/code.c
@@ -139,10 +139,15 @@ R_API int java_print_opcode(RBinJavaObj *obj, ut64 addr, int idx, const ut8 *byt
 	case 0x3a: // "astore"
 	case 0xbc: // "newarray"
 	case 0xa9: // ret <var-num>
-		snprintf (output, outlen, "%s %d", JAVA_OPS[idx].name, bytes[1]);
-		output[outlen-1] = 0;
-		return update_bytes_consumed (JAVA_OPS[idx].size);
-
+		if (len > 1) {
+			snprintf (output, outlen, "%s %d", JAVA_OPS[idx].name, bytes[1]);
+			output[outlen-1] = 0;
+			return update_bytes_consumed (JAVA_OPS[idx].size);
+		} else {
+			// ERROR
+			return 0;
+		}
+		break;
 	case 0x12: // ldc
 		arg = r_bin_java_resolve_without_space (obj, (ut16)bytes[1]);
 		if (arg) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
