### PR TITLE
Fix out-of-memory allocation on a fuzzed plan9 binary ##crash

### DIFF
--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -414,6 +414,10 @@ static RList *symbols(RBinFile *bf) {
 
 		// source file name components
 		if (sym.type == 'f') {
+			if (sym.value * 4 > r_buf_size (bf->buf)) {
+				R_LOG_ERROR ("Prevented huge memory allocation");
+				break;
+			}
 			if (r_pvector_length (names) < sym.value) {
 				if (!r_pvector_reserve (names, sym.value)) {
 					goto error;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
