### PR TITLE
Introduce RIORegion as an alternative to r_io_is_valid_offset

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -15,16 +15,16 @@
 
 #define R_IO_UNDOS 64
 
-#define r_io_map_begin(map) r_itv_begin (map->itv)
-#define r_io_map_to(map) ( r_itv_end (map->itv) - 1 )
+#define r_io_map_begin(map) r_itv_begin ((map)->itv)
+#define r_io_map_to(map) ( r_itv_end ((map)->itv) - 1 )
 #define r_io_map_from r_io_map_begin
 #define r_io_submap_from(sm) (r_io_map_begin (sm))
 #define r_io_submap_to(sm) (r_io_map_to (sm))
-#define r_io_map_end(map) r_itv_end (map->itv)
-#define r_io_map_size(map) r_itv_size (map->itv)
-#define r_io_map_contain(map, addr) r_itv_contain (map->itv, addr)
+#define r_io_map_end(map) r_itv_end ((map)->itv)
+#define r_io_map_size(map) r_itv_size ((map)->itv)
+#define r_io_map_contain(map, addr) r_itv_contain ((map)->itv, addr)
 #define r_io_submap_contain(sm, addr) r_io_map_contain (sm, addr)
-#define r_io_submap_overlap(bd, sm) r_itv_overlap(bd->itv, sm->itv)
+#define r_io_submap_overlap(bd, sm) r_itv_overlap((bd)->itv, (sm)->itv)
 
 #define r_io_map_set_begin(map, new_addr)	\
 	do {					\

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -244,6 +244,11 @@ typedef struct r_io_bank_t {
 	bool drain_me;	// speedup r_io_nread_at
 } RIOBank;
 
+typedef struct r_io_region_t {
+	RInterval itv;
+	ut32 perm;
+} RIORegion;
+
 typedef struct io_cache_item_t {
 	RInterval *tree_itv;
 	RInterval itv;
@@ -401,6 +406,7 @@ R_API bool r_io_bank_write_at(RIO *io, const ut32 bankid, ut64 addr, const ut8 *
 R_API int r_io_bank_read_from_submap_at(RIO *io, const ut32 bankid, ut64 addr, ut8 *buf, int len);
 R_API int r_io_bank_write_to_submap_at(RIO *io, const ut32 bankid, ut64 addr, const ut8 *buf, int len);
 R_API void r_io_bank_drain(RIO *io, const ut32 bankid);
+R_API bool r_io_bank_get_region_at(RIO *io, const ut32 bankid, RIORegion *region, ut64 addr);
 
 //io.c
 R_API RIO *r_io_new(void);
@@ -431,6 +437,7 @@ R_API bool r_io_set_write_mask(RIO *io, const ut8 *mask, int len);
 R_API void r_io_bind(RIO *io, RIOBind *bnd);
 R_API bool r_io_shift(RIO *io, ut64 start, ut64 end, st64 move);
 R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence);
+R_API bool r_io_get_region_at(RIO *io, RIORegion *region, ut64 addr);
 R_API void r_io_fini(RIO *io);
 R_API void r_io_free(RIO *io);
 #define r_io_bind_init(x) memset (&(x), 0, sizeof (x))

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -553,6 +553,20 @@ R_API ut64 r_io_seek(RIO* io, ut64 offset, int whence) {
 	return io->off;
 }
 
+R_API bool r_io_get_region_at(RIO *io, RIORegion *region, ut64 addr) {
+	r_return_val_if_fail (io && region, false);
+	if (!io->va) {
+		if (io->desc) {
+			region->perm = io->desc->perm;
+			region->itv.addr = 0ULL;
+			region->itv.size = r_io_desc_size (io->desc);
+			return addr < region->itv.size;
+		}
+		return false;
+	}
+	return r_io_bank_get_region_at (io, io->bank, region, addr);
+}
+
 #if HAVE_PTRACE
 
 #if USE_PTRACE_WRAP


### PR DESCRIPTION
There are situations in which anal performs consecutive calls to r_io_is_valid_offset. each of these call causes a search on the submap tree of the active iobank. RIORegion provides a different approach to this, which can be used in anal for optimization.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
