### PR TITLE
Create reloc maps for elf bins (experimental) ##bin

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -291,6 +291,7 @@ typedef RIOMap *(*RIOMapGetAt)(RIO *io, ut64 addr);
 typedef RIOMap *(*RIOMapGetPaddr)(RIO *io, ut64 paddr);
 typedef bool (*RIOAddrIsMapped)(RIO *io, ut64 addr);
 typedef RIOMap *(*RIOMapAdd)(RIO *io, int fd, int flags, ut64 delta, ut64 addr, ut64 size);
+typedef RIOMap *(*RIORelocMapAdd)(RIO *io, int fd, int perm, RIORelocMap *rm, ut64 addr, ut64 size);
 #if HAVE_PTRACE
 typedef long (*RIOPtraceFn)(RIO *io, r_ptrace_request_t request, pid_t pid, void *addr, r_ptrace_data_t data);
 typedef void *(*RIOPtraceFuncFn)(RIO *io, void *(*func)(void *), void *user);
@@ -328,6 +329,7 @@ typedef struct r_io_bind_t {
 	RIOMapGetAt map_get_at;
 	RIOMapGetPaddr map_get_paddr;
 	RIOMapAdd map_add;
+	RIORelocMapAdd reloc_map_add;
 	RIOV2P v2p;
 	RIOP2V p2v;
 #if HAVE_PTRACE

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -491,6 +491,7 @@ R_API void r_io_bind(RIO *io, RIOBind *bnd) {
 	bnd->map_get_paddr = r_io_map_get_paddr;
 	bnd->addr_is_mapped = r_io_addr_is_mapped;
 	bnd->map_add = r_io_map_add;
+	bnd->reloc_map_add = r_io_reloc_map_add;
 #if HAVE_PTRACE
 	bnd->ptrace = r_io_ptrace;
 	bnd->ptrace_func = r_io_ptrace_func;


### PR DESCRIPTION
This is more of a POC than a fully functional thing. It lacks of proper map perms, a real write and remap cb. Also RelocMaps do not need to be heap located, it's done here for simplicity. I wanted to get this done befor sleep.
Ideally a RelocMap->data would contain all the necessary information to patch the bin header if this user tries to write to the RelocMap. so if the bin is opened with write permissions. the user can patch a reloc, close r2, open the bin again and the patch would persist. This could not be achieved if we abuse io-cache for setting relocs

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
