### PR TITLE
Remove the empty definition of rvc.use()

### DIFF
--- a/libr/include/rvc.h
+++ b/libr/include/rvc.h
@@ -81,7 +81,6 @@ R_API bool r_vc_clone(const Rvc *rvc, const char *dst);
 
 R_API Rvc *rvc_git_init(const char *path);
 R_API Rvc *rvc_git_open(const char *path);
-R_API bool rvc_use(Rvc *vc, RvcType); // R2_590 DEPRECATED
 R_API bool rvc_checkout(Rvc *vc, const char *bname);
 R_API bool rvc_git_commit(Rvc *rvc, const char *message, const char *author, const RList *files);
 R_API void rvc_git_close(struct r_vc_t *vc, bool save);

--- a/libr/util/rvc.c
+++ b/libr/util/rvc.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2021-2022 - RHL120, pancake */
+/* radare - LGPL - Copyright 2021-2023 - RHL120, pancake */
 
 #define R_LOG_ORIGIN "rvc"
 
@@ -15,11 +15,6 @@ R_API void rvc_free(Rvc *vc) {
 		free (vc->path);
 		free (vc);
 	}
-}
-
-R_API bool rvc_use(Rvc *vc, RvcType type) { // R2_590
-	R_LOG_ERROR ("rvc_use is deprecated. Don't use it");
-	return false;
 }
 
 R_API RvcType rvc_repo_type(const char *path) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
