### PR TITLE
Map overlay ##io

### DIFF
--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -466,7 +466,7 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *bin, bool patch, u
 					break;
 				}
 				if (patch && plen) {
-					rbin->iob.write_at (rbin->iob.io, reloc->vaddr, patch_buf, plen);
+					rbin->iob.overlay_write_at (rbin->iob.io, reloc->vaddr, patch_buf, plen);
 					if (symbol->is_imported) {
 						reloc->vaddr = sym_vaddr;
 					}
@@ -494,10 +494,6 @@ static RList *patch_relocs(RBin *b) {
 	}
 	struct r_bin_coff_obj *bin = (struct r_bin_coff_obj*)bo->bin_obj;
 	if (bin->hdr.f_flags & COFF_FLAGS_TI_F_EXEC) {
-		return NULL;
-	}
-	if (!r_io_cache_writable (io)) {
-		R_LOG_WARN ("please run r2 with -e io.cache=true to patch relocations");
 		return NULL;
 	}
 

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -769,7 +769,7 @@ static void _patch_reloc(RBinObject *binobj, struct Elf_(obj_t) *bo, ut16 e_mach
  				v -= P;
  			}
  			r_write_le32 (buf, v);
- 			r_io_write_at (iob->io, rel->rva, buf, 4);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 			}
  		default:
  			break;

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -685,20 +685,20 @@ static void _patch_reloc(RBinObject *binobj, struct Elf_(obj_t) *bo, ut16 e_mach
 			V = S + A;
 		}
 		r_write_le32 (buf, V);
-		iob->write_at (iob->io, rel->rva, buf, 4);
+		iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 		break;
 	case EM_AARCH64:
 		V = S + A;
 #if 0
 		r_write_le64 (buf, V);
-		iob->write_at (iob->io, rel->rva, buf, 8);
+		iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 #else
 		iob->read_at (iob->io, rel->rva, buf, 8);
 		// only patch the relocs that are initialized with zeroes
 		// if the destination contains a different value it's a constant useful for static analysis
 		ut64 addr = r_read_le64 (buf);
 		r_write_le64 (buf, addr? A: S);
-		iob->write_at (iob->io, rel->rva, buf, 8);
+		iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 #endif
 		break;
 	case EM_PPC64: {
@@ -734,13 +734,13 @@ static void _patch_reloc(RBinObject *binobj, struct Elf_(obj_t) *bo, ut16 e_mach
 				V &= (1 << 14) - 1;
 				iob->read_at (iob->io, rel->rva, buf, 2);
 				r_write_le32 (buf, (r_read_le32 (buf) & ~((1<<16) - (1<<2))) | V << 2);
-				iob->write_at (iob->io, rel->rva, buf, 2);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 2);
 				break;
 			case 24:
 				V &= (1 << 24) - 1;
 				iob->read_at (iob->io, rel->rva, buf, 4);
 				r_write_le32 (buf, (r_read_le32 (buf) & ~((1<<26) - (1<<2))) | V << 2);
-				iob->write_at (iob->io, rel->rva, buf, 4);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 				break;
 			}
 		} else if (word) {
@@ -748,11 +748,11 @@ static void _patch_reloc(RBinObject *binobj, struct Elf_(obj_t) *bo, ut16 e_mach
 			switch (word) {
 			case 2:
 				r_write_le16 (buf, V);
-				iob->write_at (iob->io, rel->rva, buf, 2);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 2);
 				break;
 			case 4:
 				r_write_le32 (buf, V);
-				iob->write_at (iob->io, rel->rva, buf, 4);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 				break;
 			}
 		}
@@ -833,19 +833,19 @@ static void _patch_reloc(RBinObject *binobj, struct Elf_(obj_t) *bo, ut16 e_mach
 			break;
 		case 1:
 			buf[0] = V;
-			iob->write_at (iob->io, rel->rva, buf, 1);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 1);
 			break;
 		case 2:
 			r_write_le16 (buf, V);
-			iob->write_at (iob->io, rel->rva, buf, 2);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 2);
 			break;
 		case 4:
 			r_write_le32 (buf, V);
-			iob->write_at (iob->io, rel->rva, buf, 4);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 			break;
 		case 8:
 			r_write_le64 (buf, V);
-			iob->write_at (iob->io, rel->rva, buf, 8);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 			break;
 		}
 		break;
@@ -889,10 +889,6 @@ static RList* patch_relocs(RBin *b) {
 		}
 	}
 	if (!g) {
-		return NULL;
-	}
-	if (!r_io_cache_writable (io)) {
-		R_LOG_WARN ("run r2 with -e bin.cache=true to fix relocations in disassembly");
 		return NULL;
 	}
 	ut64 n_vaddr = g->itv.addr + g->itv.size;

--- a/libr/bin/p/bin_rel.c
+++ b/libr/bin/p/bin_rel.c
@@ -176,7 +176,7 @@ static bool vwriten_at_be32(RBin *b, ut32 vaddr, ut32 val, ut32 size) {
 	ut8 buf[4];
 	r_write_be32 (&buf, val);
 	assert (size <= sizeof (buf));
-	return b->iob.write_at (b->iob.io, vaddr, (void *)&buf, size);
+	return b->iob.overlay_write_at (b->iob.io, vaddr, (void *)&buf, size);
 }
 
 static bool file_has_rel_ext(RBinFile *bf) {
@@ -542,11 +542,6 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 }
 
 static RList *patch_relocs(RBin *b) {
-	if (!r_io_cache_writable (b->iob.io)) {
-		R_LOG_WARN ("run r2 with -e bin.cache=true to fix relocations in disassembly");
-		return NULL;
-	}
-
 	int i, j;
 	const LoadedRel *rel = b->cur->o->bin_obj;
 

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1850,8 +1850,8 @@ static int bin_relocs(RCore *r, PJ *pj, int mode, int va) {
 	//this has been created for reloc object files
 	RRBTree *relocs = r_bin_get_relocs (r->bin);
 	bool apply_relocs = r_config_get_b (r->config, "bin.relocs.apply");
-	if (apply_relocs && relocs) {
-		r_bin_patch_relocs (r->bin);
+	if (apply_relocs) {
+		relocs = r_bin_patch_relocs (r->bin);
 		r_io_drain_overlay (r->io);
 	}
 	if (!relocs) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1877,6 +1877,7 @@ static int bin_relocs(RCore *r, PJ *pj, int mode, int va) {
 		}
 		// r_core_cmd_call (r, "wcs"); // write cache squash
 	}
+	r_io_drain_overlay (r->io);
 
 	if (IS_MODE_RAD (mode)) {
 		r_cons_println ("fs relocs");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3767,6 +3767,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETI ("bin.laddr", 0, "base address for loading library ('*.so')");
 	SETCB ("bin.dbginfo", "true", &cb_bindbginfo, "load debug information at startup if available");
 	SETBPREF ("bin.relocs", "true", "load relocs information at startup if available");
+	SETBPREF ("bin.relocs.apply", "false", "apply reloc information");
 	SETICB ("bin.str.min", 0, &cb_binminstr, "minimum string length for r_bin");
 	SETICB ("bin.maxsymlen", 0, &cb_binmaxsymlen, "maximum length for symbol names");
 	SETICB ("bin.str.max", 0, &cb_binmaxstr, "maximum string length for r_bin");

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -367,7 +367,8 @@ R_API RList* r_io_map_get_by_fd(RIO *io, int fd);
 R_API bool r_io_map_resize(RIO *io, ut32 id, ut64 newsize);
 R_API void r_io_map_read_from_overlay(RIOMap *map, ut64 addr, ut8 *buf, int len);
 R_API bool r_io_map_write_to_overlay(RIOMap *map, ut64 addr, const ut8 *buf, int len);
-R_IPI bool _io_map_get_overlay_intersects(RIOMap *map, RQueue *q, ut64 addr, int len);
+R_IPI bool io_map_get_overlay_intersects(RIOMap *map, RQueue *q, ut64 addr, int len);
+R_API void r_io_map_drain_overlay(RIOMap *map);
 
 // next free address to place a map.. maybe just unify
 R_API bool r_io_map_locate(RIO *io, ut64 *addr, const ut64 size, ut64 load_align);
@@ -438,6 +439,7 @@ R_API bool r_io_set_write_mask(RIO *io, const ut8 *mask, int len);
 R_API void r_io_bind(RIO *io, RIOBind *bnd);
 R_API bool r_io_shift(RIO *io, ut64 start, ut64 end, st64 move);
 R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence);
+R_API void r_io_drain_overlay(RIO *io);
 R_API void r_io_fini(RIO *io);
 R_API void r_io_free(RIO *io);
 #define r_io_bind_init(x) memset (&(x), 0, sizeof (x))

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -269,6 +269,7 @@ typedef RIODesc *(*RIOOpenAt)(RIO *io, const  char *uri, int flags, int mode, ut
 typedef bool (*RIOClose)(RIO *io, int fd);
 typedef bool (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, int len);
 typedef bool (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int len);
+typedef bool (*RIOOverlayWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int len);
 typedef char *(*RIOSystem)(RIO *io, const char* cmd);
 typedef int (*RIOFdOpen)(RIO *io, const char *uri, int flags, int mode);
 typedef bool (*RIOFdClose)(RIO *io, int fd);
@@ -308,6 +309,7 @@ typedef struct r_io_bind_t {
 	RIOClose close;
 	RIOReadAt read_at;
 	RIOWriteAt write_at;
+	RIOOverlayWriteAt overlay_write_at;
 	RIOSystem system;
 	RIOFdOpen fd_open;
 	RIOFdClose fd_close;

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -87,7 +87,6 @@
 #define R_PERM_PRIV	16
 #define R_PERM_ACCESS	32
 #define R_PERM_CREAT	64
-#define R_PERM_RELOC	128
 
 
 // HACK to fix capstone-android-mips build

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -226,7 +226,7 @@ R_API bool r_io_vwrite_at(RIO *io, ut64 vaddr, const ut8 *buf, int len) {
 	return r_io_bank_write_at (io, io->bank, vaddr, buf, len);
 }
 
-R_API bool r_io_vwrite_to_overlay_at(RIO *io, ut64 caddr, const ut8 *buf, int len) {
+R_API bool r_io_vwrite_to_overlay_at(RIO *io, ut64 vaddr, const ut8 *buf, int len) {
 	r_return_val_if_fail (io && buf && len > 0, false);
 	if ((UT64_MAX - (len - 1)) < vaddr) {
 		int _len = UT64_MAX - vaddr + 1;
@@ -491,6 +491,7 @@ R_API void r_io_bind(RIO *io, RIOBind *bnd) {
 	bnd->close = r_io_fd_close;
 	bnd->read_at = r_io_read_at;
 	bnd->write_at = r_io_write_at;
+	bnd->overlay_write_at = r_io_vwrite_to_overlay_at;
 	bnd->system = r_io_system;
 	bnd->fd_open = r_io_fd_open;
 	bnd->fd_close = r_io_fd_close;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -556,7 +556,7 @@ R_API bool r_io_shift(RIO* io, ut64 start, ut64 end, st64 move) {
 	return true;
 }
 
-R_API ut64 r_io_seek(RIO* io, ut64 offset, int whence) {
+R_API ut64 r_io_seek(RIO *io, ut64 offset, int whence) {
 	if (!io) {
 		return 0LL;
 	}
@@ -573,6 +573,15 @@ R_API ut64 r_io_seek(RIO* io, ut64 offset, int whence) {
 		break;
 	}
 	return io->off;
+}
+
+static bool drain_cb (void *user, void *data, ut32 id) {
+	r_io_map_drain_overlay ((RIOMap *)data);
+	return true;
+}
+
+R_API void r_io_drain_overlay(RIO *io) {
+	r_id_storage_foreach (io->maps, drain_cb, NULL);
 }
 
 #if HAVE_PTRACE

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -213,7 +213,7 @@ R_API bool r_io_vread_at(RIO *io, ut64 vaddr, ut8* buf, int len) {
 	return r_io_bank_read_at (io, io->bank, vaddr, buf, len);
 }
 
-R_API bool r_io_vwrite_at(RIO *io, ut64 vaddr, const ut8* buf, int len) {
+R_API bool r_io_vwrite_at(RIO *io, ut64 vaddr, const ut8 *buf, int len) {
 	r_return_val_if_fail (io && buf && len > 0, false);
 	if ((UT64_MAX - (len - 1)) < vaddr) {
 		int _len = UT64_MAX - vaddr + 1;
@@ -224,6 +224,19 @@ R_API bool r_io_vwrite_at(RIO *io, ut64 vaddr, const ut8* buf, int len) {
 		len = _len;
 	}
 	return r_io_bank_write_at (io, io->bank, vaddr, buf, len);
+}
+
+R_API bool r_io_vwrite_to_overlay_at(RIO *io, ut64 caddr, const ut8 *buf, int len) {
+	r_return_val_if_fail (io && buf && len > 0, false);
+	if ((UT64_MAX - (len - 1)) < vaddr) {
+		int _len = UT64_MAX - vaddr + 1;
+		len -= _len;
+		if (!r_io_vwrite_to_overlay_at (io, 0ULL, &buf[_len], len)) {
+			return false;
+		}
+		len = _len;
+	}
+	return r_io_bank_write_to_overlay_at (io, io->bank, vaddr, buf, len);
 }
 
 static bool internal_r_io_read_at(RIO *io, ut64 addr, ut8 *buf, int len) {

--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -869,6 +869,7 @@ R_API bool r_io_bank_write_to_overlay_at(RIO *io, const ut32 bankid, ut64 addr, 
 	r_return_val_if_fail (io, false);
 	RIOBank *bank = r_io_bank_get (io, bankid);
 	if (!bank) {
+		R_LOG_WARN ("Tfw no bank(id: %u) in io", bankid);
 		return false;
 	}
 	RIOSubMap fake_sm = {{0}};

--- a/libr/io/io_bank.c
+++ b/libr/io/io_bank.c
@@ -799,6 +799,7 @@ R_API bool r_io_bank_write_at(RIO *io, const ut32 bankid, ut64 addr, const ut8 *
 	r_return_val_if_fail (io, false);
 	RIOBank *bank = r_io_bank_get (io, bankid);
 	if (!bank) {
+		R_LOG_WARN ("Tfw no bank(id %u) in the io", bankid);
 		return false;
 	}
 	RIOSubMap fake_sm = {{0}};
@@ -825,11 +826,10 @@ R_API bool r_io_bank_write_at(RIO *io, const ut32 bankid, ut64 addr, const ut8 *
 			ret = false;
 			continue;
 		}
-		// check for overlay here
 		const ut64 buf_off = R_MAX (addr, r_io_submap_from (sm)) - addr;
 		const int write_len = R_MIN (r_io_submap_to ((&fake_sm)),
 					     r_io_submap_to (sm)) - (addr + buf_off) + 1;
-		if (_io_map_get_overlay_intersects (map, bank->todo, addr + buf_off, write_len) &&
+		if (io_map_get_overlay_intersects (map, bank->todo, addr + buf_off, write_len) &&
 			!r_queue_is_empty (bank->todo)) {
 			ut64 _buf_off = buf_off;
 			int _write_len = write_len;

--- a/libr/io/io_map.c
+++ b/libr/io/io_map.c
@@ -458,7 +458,7 @@ typedef struct map_overlay_chunk_t {
 	ut8 *buf;
 } MapOverlayChunk;
 
-static int _overlay_chunk_find (void *incoming, void *in, void *user) {
+static int _overlay_chunk_find(void *incoming, void *in, void *user) {
 	RInterval *itv = (RInterval *)incoming;
 	MapOverlayChunk *chunk = (MapOverlayChunk *)in;
 	if (r_itv_overlap (itv[0], chunk->itv)) {
@@ -605,6 +605,7 @@ R_API bool r_io_map_write_to_overlay(RIOMap *map, ut64 addr, const ut8 *buf, int
 	}
 	chunk->buf = R_NEWS (ut8, r_itv_size (search_itv));
 	if (!chunk->buf) {
+		free (chunk);
 		return false;
 	}
 	chunk->itv = search_itv;

--- a/test/db/anal/classes
+++ b/test/db/anal/classes
@@ -116,7 +116,7 @@ RUN
 
 NAME=anal classes arm64e
 FILE=bins/mach0/TestRTTI-arm64e
-ARGS=-e bin.cache=true
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 avrr
 acl

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1282,6 +1282,7 @@ RUN
 
 NAME=reflines offset 2 (ascii)
 FILE=bins/elf/analysis/ls-alxchk
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 e asm.sub.rel=false
 e asm.bytes=false
@@ -1320,8 +1321,7 @@ EXPECT=<<EOF
 |    ||||   0x00011411      cmp sil, cl
 |   ,=====< 0x00011414      jne 0x11424
 |   |||||   0x00011416      lea rbx, [rax + 4]
-|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; reloc.program_invocation_short_name
-|   |||||                                                              ; [0x1f2d0:8]=0
+|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; [0x1f2d0:8]=0x221f0 reloc.program_invocation_short_name
 |   |||||   0x00011421      mov qword [rax], rbx
 |   |||||   ; CODE XREFS from fcn.00011390 @ 0x113d0(x), 0x113e0(x), 0x113f4(x), 0x11414(x)
 |   ````--> 0x00011424      mov rax, qword [rip + 0xde3d]              ; [0x1f268:8]=0x21680
@@ -4004,7 +4004,7 @@ FILE=-
 CMDS=<<EOF
 e asm.arch=x86
 e asm.bits=64
-e bin.cache=1
+e bin.relocs.apply=1
 e anal.onchange=1
 s 0x0
 f func

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3852,10 +3852,10 @@ EXPECT=<<EOF
             ;-- section..init_array:
             ;-- segment.LOAD1:
             ;-- segment.GNU_RELRO:
-            0x0021bfa8      .qword 0x0000000000005d20 ; entry.init0    ; [18] -rw- section size 8 named .init_array
+            0x0021bfa8      .qword 0x0000000000005d20 ; entry.init0    ; RELOC 64  ; [18] -rw- section size 8 named .init_array
 
             ;-- section..fini_array:
-            0x0021bfb0      .qword 0x0000000000005ce0 ; entry.fini0    ; [19] -rw- section size 8 named .fini_array
+            0x0021bfb0      .qword 0x0000000000005ce0 ; entry.fini0    ; RELOC 64  ; [19] -rw- section size 8 named .fini_array
 EOF
 EXPECT_ERR=<<EOF
 DEBUG: (section .dynstr) Css 1477 @ 0xf70

--- a/test/db/cmd/cmd_ie
+++ b/test/db/cmd/cmd_ie
@@ -9,9 +9,7 @@ EXPECT=<<EOF
 
 0 entrypoints
 EOF
-EXPECT_ERR=<<EOF
-WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
-EOF
+EXPECT_ERR=
 RUN
 
 NAME=iee preinit

--- a/test/db/cmd/cmd_pd_str
+++ b/test/db/cmd/cmd_pd_str
@@ -56,13 +56,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=relocs and cache
+NAME=relocs and overlay
 FILE=bins/mach0/TrollStore.fat/TrollStore.arm_64.1
-ARGS=-e emu.str=true -e bin.cache=true
+ARGS=-e emu.str=true -e bin.relocs.apply=true
 CMDS=<<EOF
 pd 10 @ 0x100016c40
 pv8 1 @ 0x1000261e8
-uw~1000261e8
 ir~61e8
 EOF
 EXPECT=<<EOF
@@ -77,13 +76,12 @@ EXPECT=<<EOF
             0x100016c60      81000090       adrp x1, 0x100026000
             0x100016c64      218040f9       ldr x1, [x1, 0x100]        ; 0xdb ; 219 ; str.generalPasteboard
 0x000000010001c6e8
-idx=1809 addr=0x1000261e8 size=8 e8c6010001000800 -> e8c6010001000000 (not written)
 EOF
 RUN
 
 NAME=relocs without cache
 FILE=bins/mach0/TrollStore.fat/TrollStore.arm_64.1
-ARGS=-e emu.str=true -e bin.cache=false
+ARGS=-e emu.str=true -e bin.relocs.apply=false
 CMDS=<<EOF
 pd 10 @ 0x100016c40
 pv8 1 @ 0x1000261e8

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -125,7 +125,7 @@ EOF
 RUN
 
 NAME=patched reloc x86
-ARGS=-e io.cache=1
+ARGS=-e bin.relocs.apply=1
 FILE=bins/coff/tif_dir.obj
 CMDS=<<EOF
 af @ sym._TIFFGetField
@@ -146,11 +146,9 @@ EOF
 RUN
 
 NAME=patching REL32 amd64
-ARGS=-e io.cache=1
+ARGS=-e bin.relocs.apply=1
 FILE=bins/coff/coff.obj
-CMDS=<<EOF
-pd 2 @ sym.main+6
-EOF
+CMDS=pd 2 @ sym.main+6
 EXPECT=<<EOF
             0x00000006      4c8d05230000.  lea r8, [0x00000030]        ; sym..data ; "Win64 assembly"; RELOC 32 .data @ 0x00000030
             0x0000000d      488d152b0000.  lea rdx, [0x0000003f]       ; str.Coffee_time_ ; "Coffee time!"; RELOC 32 .data @ 0x00000030 + 0xf

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -701,23 +701,23 @@ line: 3
 addr: 0x00001149
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3269] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3269] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3269] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3269] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3269] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3269] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3269] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3269] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3269] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3269] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3269] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3269] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:2537] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2537] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2537] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2537] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2537] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:3281] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3281] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3281] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3281] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3281] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3281] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3281] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3281] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3281] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3281] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3281] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3281] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:2549] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2549] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2549] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2549] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2549] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -701,23 +701,23 @@ line: 3
 addr: 0x00001149
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3284] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3284] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3284] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3284] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3284] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3284] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3284] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3284] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3284] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3284] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3284] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3284] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:2552] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2552] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2552] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2552] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2552] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:3269] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3269] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3269] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3269] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3269] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3269] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3269] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3269] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3269] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3269] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3269] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3269] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:2537] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2537] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2537] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2537] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2537] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -51,7 +51,7 @@ EOF
 RUN
 
 NAME=ELF: arm sh relocs
-ARGS=-e bin.cache=true
+ARGS=-e bin.relocs.apply=true
 FILE=bins/elf/r2pay-arm32.so
 CMDS=<<EOF
 ir*~reloc?
@@ -75,7 +75,7 @@ EOF
 RUN
 
 NAME=ELF: arm sh unpatched relocs
-ARGS=-e bin.cache=false
+ARGS=-e bin.relocs.apply=false
 FILE=bins/elf/r2pay-arm32.so
 CMDS=<<EOF
 ir*~reloc?
@@ -99,7 +99,7 @@ EOF
 RUN
 
 NAME=ELF: arm64 sh relocs
-ARGS=-e bin.cache=true
+ARGS=-e bin.relocs.apply=true
 FILE=bins/elf/r2pay-arm64.so
 CMDS=<<EOF
 ir*~reloc?

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -55,7 +55,7 @@ RUN
 
 NAME=ELF: R_X86_64_PLT32 patch reloc
 FILE=bins/elf/radare2.c.obj
-ARGS=-e io.cache=true
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 e asm.comments=false
 e asm.lines=false
@@ -68,7 +68,7 @@ RUN
 
 NAME=ELF: R_X86_64_PLT32 patch reloc 2
 FILE=bins/elf/test.ko
-ARGS=-e io.cache=true
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 e asm.comments=false
 e asm.lines=false
@@ -103,7 +103,7 @@ RUN
 
 NAME=x86 32bit relocs in kernel module
 FILE=bins/elf/linux-example-x86-32.ko
-ARGS=-e bin.cache=true
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 s 0x0800007c
 pi 15
@@ -132,7 +132,7 @@ ret
 EOF
 RUN
 
-NAME=x86 32bit relocs in kernel module (bin.cache=false)
+NAME=x86 32bit relocs in kernel module (bin.relocs.apply=false)
 FILE=bins/elf/linux-example-x86-32.ko
 CMDS=<<EOF
 s 0x0800007c
@@ -188,7 +188,7 @@ RUN
 
 NAME=ELF: relocs r2pay
 FILE=bins/elf/r2pay-arm64.so
-ARGS=-e bin.cache=true
+ARGS=-e bin.relocs.apply=true
 CMDS=<<EOF
 s section..init_array
 pd 10

--- a/test/db/formats/rel
+++ b/test/db/formats/rel
@@ -1,17 +1,16 @@
 NAME=uncached err
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=false
+ARGS=-e bin.relocs.apply=false
 CMDS=
 EXPECT_ERR=<<EOF
 INFO: REL module ID 00000001
 INFO: REL version 3
-WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 EOF
 RUN
 
 NAME=sections
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=true -B 0x80500000
+ARGS=-e bin.relocs.apply=true -B 0x80500000
 CMDS=iS
 EXPECT=<<EOF
 [Sections]
@@ -29,7 +28,7 @@ RUN
 
 NAME=dump relocs
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=true -B 0x80500000 -e log.level=5
+ARGS=-e bin.relocs.apply=true -B 0x80500000 -e log.level=5
 CMDS=
 EXPECT_ERR=<<EOF
 DEBUG: RCoreCmd: =!
@@ -77,7 +76,7 @@ RUN
 
 NAME=R_PPC_ADDR16
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=true -B 0x80500000
+ARGS=-e bin.relocs.apply=true -B 0x80500000
 CMDS=pd 3 @0x80500144
 EXPECT=<<EOF
             0x80500144      3c608024       lis r3, -0x7fdc             ; RELOC 16 
@@ -88,7 +87,7 @@ RUN
 
 NAME=R_PPC_REL24
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=true -B 0x80500000
+ARGS=-e bin.relocs.apply=true -B 0x80500000
 CMDS=pd 1 @0x805000e4
 EXPECT=<<EOF
             0x805000e4      4bb1acbd       bl 0x8001ada0               ; RELOC 32 
@@ -97,7 +96,7 @@ RUN
 
 NAME=R_PPC_ADDR32
 FILE=bins/rel/d_profileNP.rel
-ARGS=-e bin.cache=true -B 0x80500000
+ARGS=-e bin.relocs.apply=true -B 0x80500000
 CMDS=pxW 16 @0x80500180
 EXPECT=<<EOF
 0x80500180 0x8023a588

--- a/test/db/io/write
+++ b/test/db/io/write
@@ -56,7 +56,6 @@ EXPECT=<<EOF
 hello
 EOF
 EXPECT_ERR=<<EOF
-WARN: run r2 with -e bin.cache=true to fix relocations in disassembly
 ERROR: [cmd_write_fail] Cannot write. Use `omf`, `io.cache` or reopen the file in rw with `oo+`
 EOF
 RUN


### PR DESCRIPTION
Ok, so why is this better than cache abuse and reloc_maps:

reloc_maps spams a shitload of maps, rwx perms are fuzzy to handle, potentially causes crashes when a dynamic loaded plugin gets dlclosed at runtime

cache abuse cannot handle remapping, map priorization and it allows esil to ignore w perms, because iocache disables checks in io. Also it renders iocache useless for it's primary purpose

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
