### PR TITLE
Deprecate r_anal_op_hexstr() ##api

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -452,22 +452,6 @@ R_API RList* r_anal_get_fcns(RAnal *anal) {
 	return anal->fcns;
 }
 
-R_API RAnalOp *r_anal_op_hexstr(RAnal *anal, ut64 addr, const char *str) {
-	RAnalOp *op = R_NEW0 (RAnalOp);
-	if (!op) {
-		return NULL;
-	}
-	ut8 *buf = calloc (1, strlen (str) + 1);
-	if (!buf) {
-		free (op);
-		return NULL;
-	}
-	int len = r_hex_str2bin (str, buf);
-	r_anal_op (anal, op, addr, buf, len, R_ARCH_OP_MASK_BASIC);
-	free (buf);
-	return op;
-}
-
 R_API bool r_anal_op_is_eob(RAnalOp *op) {
 	if (op->eob) {
 		return true;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1049,7 +1049,6 @@ R_API bool r_anal_op_is_eob(RAnalOp *op);
 R_API RList *r_anal_op_list_new(void);
 R_API int r_anal_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *data, int len, RAnalOpMask mask);
 R_API int r_anal_opasm(RAnal *anal, ut64 pc, const char *s, ut8 *outbuf, int outlen);
-R_API RAnalOp *r_anal_op_hexstr(RAnal *anal, ut64 addr, const char *hexstr);
 R_API char *r_anal_op_tostring(RAnal *anal, RAnalOp *op);
 
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
