### PR TITLE
Support bin details from non-arch bin files ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -958,51 +958,53 @@ static int bin_info(RCore *r, PJ *pj, int mode, ut64 laddr) {
 			}
 		}
 		pair_bool (pj, "havecode", havecode);
-		if (info->claimed_checksum) {
-			/* checksum specified in header */
-			pair_str (pj, "hdr.csum", info->claimed_checksum);
-		}
-		pair_str (pj, "guid", info->guid);
-		pair_str (pj, "intrp", info->intrp);
-		pair_ut64x (pj, "laddr", laddr);
-		if (info->lang && *info->lang != '?') {
-			pair_str (pj, "lang", info->lang);
-		}
-		pair_bool (pj, "linenum", R_BIN_DBG_LINENUMS & info->dbg_info);
-		pair_bool (pj, "lsyms", R_BIN_DBG_SYMS & info->dbg_info);
-		pair_str (pj, "machine", info->machine);
-		pair_bool (pj, "nx", info->has_nx);
-		pair_str (pj, "os", info->os);
-		if (info->rclass && !strcmp (info->rclass, "pe")) {
-			pair_bool (pj, "overlay", info->pe_overlay);
-		}
-		pair_str (pj, "cc", info->default_cc);
-		pair_bool (pj, "pic", info->has_pi);
-		pair_bool (pj, "relocs", R_BIN_DBG_RELOCS & info->dbg_info);
-		Sdb *sdb_info = sdb_ns (obj->kv, "info", false);
-		if (sdb_info) {
-			tmp_buf = sdb_get (sdb_info, "elf.relro", 0);
-			if (R_STR_ISNOTEMPTY (tmp_buf)) {
-				pair_str (pj, "relro", tmp_buf);
+		if (havecode) {
+			if (info->claimed_checksum) {
+				/* checksum specified in header */
+				pair_str (pj, "hdr.csum", info->claimed_checksum);
 			}
-			free (tmp_buf);
-		}
-		pair_str (pj, "rpath", info->rpath);
-		if (info->rclass && !strcmp (info->rclass, "pe")) {
-			//this should be moved if added to mach0 (or others)
-			pair_bool (pj, "signed", info->signature);
-		}
-		pair_bool (pj, "sanitize", info->has_sanitizers);
-		pair_bool (pj, "static", r_bin_is_static (r->bin));
-		if (info->rclass && !strcmp (info->rclass, "mdmp")) {
-			v = sdb_num_get (bf->sdb, "mdmp.streams", 0);
-			if (v != -1) {
-				pair_int (pj, "streams", v);
+			pair_str (pj, "guid", info->guid);
+			pair_str (pj, "intrp", info->intrp);
+			pair_ut64x (pj, "laddr", laddr);
+			if (info->lang && *info->lang != '?') {
+				pair_str (pj, "lang", info->lang);
 			}
+			pair_bool (pj, "linenum", R_BIN_DBG_LINENUMS & info->dbg_info);
+			pair_bool (pj, "lsyms", R_BIN_DBG_SYMS & info->dbg_info);
+			pair_str (pj, "machine", info->machine);
+			pair_bool (pj, "nx", info->has_nx);
+			pair_str (pj, "os", info->os);
+			if (info->rclass && !strcmp (info->rclass, "pe")) {
+				pair_bool (pj, "overlay", info->pe_overlay);
+			}
+			pair_str (pj, "cc", info->default_cc);
+			pair_bool (pj, "pic", info->has_pi);
+			pair_bool (pj, "relocs", R_BIN_DBG_RELOCS & info->dbg_info);
+			Sdb *sdb_info = sdb_ns (obj->kv, "info", false);
+			if (sdb_info) {
+				tmp_buf = sdb_get (sdb_info, "elf.relro", 0);
+				if (R_STR_ISNOTEMPTY (tmp_buf)) {
+					pair_str (pj, "relro", tmp_buf);
+				}
+				free (tmp_buf);
+			}
+			pair_str (pj, "rpath", info->rpath);
+			if (info->rclass && !strcmp (info->rclass, "pe")) {
+				//this should be moved if added to mach0 (or others)
+				pair_bool (pj, "signed", info->signature);
+			}
+			pair_bool (pj, "sanitize", info->has_sanitizers);
+			pair_bool (pj, "static", r_bin_is_static (r->bin));
+			if (info->rclass && !strcmp (info->rclass, "mdmp")) {
+				v = sdb_num_get (bf->sdb, "mdmp.streams", 0);
+				if (v != -1) {
+					pair_int (pj, "streams", v);
+				}
+			}
+			pair_bool (pj, "stripped", R_BIN_DBG_STRIPPED & info->dbg_info);
+			pair_str (pj, "subsys", info->subsystem);
+			pair_bool (pj, "va", info->has_va);
 		}
-		pair_bool (pj, "stripped", R_BIN_DBG_STRIPPED & info->dbg_info);
-		pair_str (pj, "subsys", info->subsystem);
-		pair_bool (pj, "va", info->has_va);
 		if (IS_MODE_JSON (mode)) {
 			pj_ko (pj, "checksums");
 		}

--- a/libr/core/cmd_info.c
+++ b/libr/core/cmd_info.c
@@ -313,6 +313,9 @@ static int bin_is_executable(RBinObject *obj) {
 				return true;
 			}
 		}
+		if (obj->info && obj->info->bclass) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -223,16 +223,6 @@ canary   false
 crypto   false
 endian   little
 havecode false
-laddr    0x0
-linenum  false
-lsyms    false
-nx       false
-pic      false
-relocs   false
-sanitize false
-static   true
-stripped false
-va       false
 [Imports]
 nth vaddr bind type lib name
 ----------------------------
@@ -297,16 +287,6 @@ canary   false
 crypto   false
 endian   little
 havecode false
-laddr    0x0
-linenum  false
-lsyms    false
-nx       false
-pic      false
-relocs   false
-sanitize false
-static   true
-stripped false
-va       false
 e cfg.bigendian=false
 e asm.bits=64
 e asm.dwarf=false

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -701,23 +701,23 @@ line: 3
 addr: 0x00001149
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3281] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3281] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3281] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3281] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3281] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3281] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3281] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3281] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3281] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3281] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3281] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3281] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:2549] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2549] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2549] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2549] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2549] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:3283] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3283] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3283] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3283] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3283] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3283] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3283] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3283] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3283] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3283] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3283] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3283] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:2551] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2551] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2551] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2551] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2551] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 


### PR DESCRIPTION
* Needed for bin.pcap to display extra details
* Maybe good to have an opex-like string in RBinInfo

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
