### PR TITLE
Fix to symlink of DLL which causes link loop

### DIFF
--- a/libr/bin/d/Makefile
+++ b/libr/bin/d/Makefile
@@ -51,7 +51,7 @@ CWD=$(shell pwd)
 symstall install-symlink:
 	mkdir -p "$P"
 	for FILE in * ; do \
-		if [ "$$FILE" != Makefile  && "$$FILE" != dll ]; then \
+		if [ "$$FILE" != Makefile  -a "$$FILE" != dll ]; then \
 			ln -fs "${CWD}/$$FILE" "$P/$$FILE" ; \
 		fi ; \
 	done

--- a/libr/bin/d/Makefile
+++ b/libr/bin/d/Makefile
@@ -51,7 +51,7 @@ CWD=$(shell pwd)
 symstall install-symlink:
 	mkdir -p "$P"
 	for FILE in * ; do \
-		if [ "$$FILE" != Makefile ]; then \
+		if [ "$$FILE" != Makefile  && "$$FILE" != dll ]; then \
 			ln -fs "${CWD}/$$FILE" "$P/$$FILE" ; \
 		fi ; \
 	done


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Without the fix, install-symlink in Makefile causes link loop of libr/bin/d/dll directory:
`lrwxrwxrwx 1 root root 40 Jun 19 01:06 libr/bin/d/dll/dll -> /home/dvertx/radare2/libr/bin/d/dll`

Output of `lr` command:
`...
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/kernel32.sdb.txt
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/keyboard.sdb
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/keyboard.sdb.txt
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/lzexpand.sdb
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/lzexpand.sdb.txt
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/maincp16.sdb
./libr/bin/d/dll/dll/dll/dll/dll/dll/dll/dll/maincp16.sdb.txt
...`