### PR TITLE
Fix some ls cmd part

### DIFF
--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -177,20 +177,15 @@ R_API char *r_syscmd_ls(const char *input, int cons_width) {
 		}
 		if ((!strncmp (input, "-e", 2))) {
 			printfmt = FMT_EMOJI;
-			path = r_str_trim_head_ro (path + 1);
+			path = r_str_trim_head_ro (input + 2);
 		} else if ((!strncmp (input, "-q", 2))) {
 			printfmt = FMT_QUIET;
-			path = r_str_trim_head_ro (path + 1);
+			path = r_str_trim_head_ro (input + 2);
 		} else if ((!strncmp (input, "-l", 2)) || (!strncmp (input, "-j", 2))) {
-			// mode = 'l';
-			if (input[2]) {
-				printfmt = (input[2] == 'j') ? FMT_JSON : FMT_RAW;
-				path = r_str_trim_head_ro (input + 2);
-				if (!*path) {
-					path = ".";
-				}
-			} else {
-				printfmt = FMT_RAW;
+			printfmt = (input[1] == 'j') ? FMT_JSON : FMT_RAW;
+			path = r_str_trim_head_ro (input + 2);
+			if (!*path) {
+				path = ".";
 			}
 		} else {
 			path = input;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Found some errors in ls cmd which are obvious. Some are not so obvious and would like more time to delve in it to create a fix in another PR.
I also put a note as a remark: tilde (~) is always received as 0x00, why is that, masked in the shell part or what?