### PR TITLE
fix missing header install for r_base36.h

### DIFF
--- a/libr/meson.build
+++ b/libr/meson.build
@@ -477,6 +477,7 @@ r_util_files = [
   'include/r_util/r_asn1.h',
   'include/r_util/r_assert.h',
   'include/r_util/r_axml.h',
+  'include/r_util/r_base36.h',
   'include/r_util/r_base64.h',
   'include/r_util/r_base91.h',
   'include/r_util/r_big.h',


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Building iaito with latest commit checkout for radare2 reveals:
```
/packages/radare2_x86-5.8.9-1/.self/develop/headers/x86/libr/r_util.h:38:10: fatal error: r_util/r_base36.h: No such file or directory
```
This fixes the installation for the header.