### PR TITLE
Fix caller to RTable.toString() memory leaks

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1089,7 +1089,9 @@ R_API void r_bin_list_archs(RBin *bin, PJ *pj, int mode) {
 			str_fmt = get_arch_string (arch, bits, info);
 			r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, machine);
 			free (str_fmt);
-			bin->cb_printf ("%s", r_table_tostring (table));
+			char *s = r_table_tostring (table);
+			bin->cb_printf ("%s", s);
+			free (s);
 		}
 		snprintf (archline, sizeof (archline) - 1,
 			"0x%08" PFMT64x ":%" PFMT64u ":%s:%d:%s",
@@ -1124,7 +1126,9 @@ R_API void r_bin_list_archs(RBin *bin, PJ *pj, int mode) {
 				str_fmt = get_arch_string (arch, bits, info);
 				r_table_add_rowf (table, fmt, 0, boffset, obj_size, str_fmt, "");
 				free (str_fmt);
-				bin->cb_printf ("%s", r_table_tostring (table));
+				char *s = r_table_tostring (table);
+				bin->cb_printf ("%s", s);
+				free (s);
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",
@@ -1147,7 +1151,9 @@ R_API void r_bin_list_archs(RBin *bin, PJ *pj, int mode) {
 				break;
 			default:
 				r_table_add_rowf (table, fmt, 0, boffset, obj_size, "", "");
-				bin->cb_printf ("%s", r_table_tostring (table));
+				char *s = r_table_tostring (table);
+				bin->cb_printf ("%s", s);
+				free (s);
 			}
 			snprintf (archline, sizeof (archline),
 				"0x%08" PFMT64x ":%" PFMT64u ":%s:%d",

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3466,7 +3466,9 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad) 
 		RTable *table = r_core_table (core, "functions");
 		r_table_visual_list (table, flist, core->offset, core->blocksize,
 			r_cons_get_size (NULL), r_config_get_i (core->config, "scr.color"));
-		r_cons_printf ("\n%s\n", r_table_tostring (table));
+		char *s = r_table_tostring (table);
+		r_cons_printf ("\n%s\n", s);
+		free (s);
 		r_table_free (table);
 		r_list_free (flist);
 		break;

--- a/libr/core/cmd_anal.c
+++ b/libr/core/cmd_anal.c
@@ -3164,7 +3164,9 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 		RTable *table = r_core_table (core, "fcnbbs");
 		r_table_visual_list (table, flist, core->offset, core->blocksize,
 			r_cons_get_size (NULL), r_config_get_i (core->config, "scr.color"));
-		r_cons_printf ("\n%s\n", r_table_tostring (table));
+		char *s = r_table_tostring (table);
+		r_cons_printf ("\n%s\n", s);
+		free (s);
 		r_table_free (table);
 		r_list_free (flist);
 		return true;

--- a/libr/core/dmh_windows.inc.c
+++ b/libr/core/dmh_windows.inc.c
@@ -590,7 +590,7 @@ static bool GetSegmentHeapBlocks(RDebug *dbg, HANDLE h_proc, PVOID heapBase, PHe
 	WPARAM lfhKeyLocation = RtlpHpHeapGlobalsOffset + sizeof (WPARAM);
 	if (!ReadProcessMemory (h_proc, (PVOID)lfhKeyLocation, &lfhKey, sizeof (WPARAM), &bytesRead)) {
 		r_sys_perror ("ReadProcessMemory");
-		eprintf ("LFH key not found.\n");
+		R_LOG_ERROR ("LFH key not found");
 		return false;
 	}
 
@@ -1225,9 +1225,13 @@ static void w32_list_heaps(RCore *core, const char format) {
 	}
 	if (format == 'j') {
 		pj_end (pj);
-		r_cons_println (pj_string (pj));
+		char *s = pj_string (pj);
+		r_cons_println (s);
+		free (s);
 	} else {
-		r_cons_println (r_table_tostring (tbl));
+		char *s = r_table_tostring (tbl);
+		r_cons_println (s);
+		free (s);
 	}
 	r_table_free (tbl);
 	pj_free (pj);
@@ -1315,7 +1319,9 @@ static void w32_list_heaps_blocks(RCore *core, const char format) {
 		pj_end (pj);
 		r_cons_println (pj_string (pj));
 	} else if (format != 'f') {
-		r_cons_println (r_table_tostring (tbl));
+		char *s = r_table_tostring (tbl);
+		r_cons_println (s);
+		free (s);
 	}
 	r_table_free (tbl);
 	pj_free (pj);
@@ -1355,7 +1361,9 @@ static void cmd_debug_map_heap_block_win(RCore *core, const char *input) {
 			switch (input[0]) {
 			case ' ':
 				r_table_add_rowf (tbl, "xxnnns", headerAddr, off, (ut64)hb->dwSize, granularity, (ut64)hb->extraInfo->unusedBytes, type);
-				r_cons_println (r_table_tostring (tbl));
+				char *s = r_table_tostring (tbl);
+				r_cons_println (s);
+				free (s);
 				break;
 			case 'j':
 				pj_o (pj);

--- a/libr/debug/trace.c
+++ b/libr/debug/trace.c
@@ -286,7 +286,9 @@ R_API void r_debug_trace_list(RDebug *dbg, int mode, ut64 offset) {
 		RIO *io = dbg->iob.io;
 		r_table_visual_list (table, info_list, offset, 1,
 			r_cons_get_size (NULL), io->va);
-		io->cb_printf ("\n%s\n", r_table_tostring (table));
+		char *s = r_table_tostring (table);
+		io->cb_printf ("\n%s\n", s);
+		free (s);
 		r_table_free (table);
 		r_list_free (info_list);
 	}

--- a/sys/lint.sh
+++ b/sys/lint.sh
@@ -4,6 +4,7 @@ cd "$(dirname $0)"/..
 
 # NAME=no preincrement/predecrement in 3rd part of for statement
 (git grep -n -e '++[a-z][a-z]*[);]' libr | grep -v arch) && exit 1
+(git grep table_tostring libr | grep -e printf -e cons_print) && exit 1
 
 # Bad: static void foo() {
 # Good: static void foo(void) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
