### PR TITLE
Handle 'asm.os=android' syscall as an alias for 'linux' ##analysis

### DIFF
--- a/libr/syscall/syscall.c
+++ b/libr/syscall/syscall.c
@@ -122,6 +122,8 @@ R_API bool r_syscall_setup(RSyscall *s, const char *arch, int bits, const char *
 		s->sysport = sysport_avr;
 	} else if (!strcmp (os, "darwin") || !strcmp (os, "osx") || !strcmp (os, "macos")) {
 		os = "darwin";
+	} else if (!strcmp (os, "android")) {
+		os = "linux";
 	} else if (!strcmp (arch, "x86")) {
 		s->sysport = sysport_x86;
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
