### PR TITLE
Rework e? and e?? commands for better output

### DIFF
--- a/libr/config/config.c
+++ b/libr/config/config.c
@@ -163,7 +163,7 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 	const char *sfx = "";
 	const char *pfx = "";
 	int len = 0;
-	bool verbose = false;
+	bool found, verbose = false;
 	PJ *pj = NULL;
 
 	if (!IS_NULLSTR (str)) {
@@ -215,15 +215,21 @@ R_API void r_config_list(RConfig *cfg, const char *str, int rad) {
 	case 2:
 		r_list_foreach (cfg->nodes, iter, node) {
 			if (!str || (str && (!strncmp (str, node->name, len)))) {
-				if (!str || !strncmp (str, node->name, len)) {
-					if (R_STR_ISNOTEMPTY (str)) {
-						cfg->cb_printf ("%s\n", r_str_get (node->desc));
-					} else {
-						cfg->cb_printf ("%20s: %s\n", node->name,
-							r_str_get (node->desc));
-					}
-				}
+				cfg->cb_printf ("%20s: %s\n", node->name, r_str_get (node->desc));
 			}
+		}
+		break;
+	case 3:
+		found = false;
+		r_list_foreach (cfg->nodes, iter, node) {
+			if (!str || (str && (!strcmp (str, node->name)))) {
+				found = true;
+				cfg->cb_printf ("%s\n", r_str_get (node->desc));
+				break;
+			}
+		}
+		if (!found) {
+			cfg->cb_printf ("Key not found. Try e??%s\n", str);
 		}
 		break;
 	case 's':

--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -420,7 +420,7 @@ static int cmd_eval(void *data, const char *input) {
 		switch (input[1]) {
 		case '\0': r_core_cmd_help (core, help_msg_e); break;
 		case '?': r_config_list (core->config, input + 2, 2); break;
-		default: r_config_list (core->config, input + 1, 2); break;
+		default: r_config_list (core->config, input + 1, 3); break;
 		}
 		break;
 	case 't': // "et"


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
 Reworked `e?` and `e??` commands to have these behavior:

When the `e?` command supplied with a correct key, gives out the (only correct) description:
```
[0x00006ab0]> e?asm.bytes
display the bytes of each instruction
```

When `e?` is given incomplete key/var name. Notice the missing 's': byte instead of bytes:
```
[0x00006ab0]> e?asm.byte
Key not found. Try e??asm.byte
```
Will always suggest to try `e??` even for non existent key

The `e??` will supply any key and descriptions when given something similar to available keys. Again notice the missing 's':
```
[0x00006ab0]> e??asm.byte
           asm.bytes: display the bytes of each instruction
     asm.bytes.align: align bytes at right (left padding space)
    asm.bytes.asbits: show instruction bits instead of bytes
   asm.bytes.opcolor: colorize bytes depending on opcode size + variant information
     asm.bytes.right: display the bytes at the right of the disassembly
     asm.bytes.space: separate hexadecimal bytes with a whitespace
```

Another `e??` example:
```
[0x00006ab0]> e??asm.b
        asm.bbmiddle: realign disassembly if a basic block starts in the middle of an instruction
            asm.bits: word size in bits at assembler
           asm.bytes: display the bytes of each instruction
     asm.bytes.align: align bytes at right (left padding space)
    asm.bytes.asbits: show instruction bits instead of bytes
   asm.bytes.opcolor: colorize bytes depending on opcode size + variant information
     asm.bytes.right: display the bytes at the right of the disassembly
     asm.bytes.space: separate hexadecimal bytes with a whitespace
```

`e??` will return nothing when supplied with a key which is not even remotely similar to available keys:
```
[0x00006ab0]> e??asbvz
[0x00006ab0]>
```