### PR TITLE
Remove single quotes

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1387,7 +1387,7 @@ R_API bool r_file_copy(const char *src, const char *dst) {
 #else
 	char *src2 = r_str_replace (strdup (src), "'", "\\'", 1);
 	char *dst2 = r_str_replace (strdup (dst), "'", "\\'", 1);
-	int rc = r_sys_cmdf ("cp -f '%s' '%s'", src2, dst2);
+	int rc = r_sys_cmdf ("cp -f %s %s", src2, dst2);
 	free (src2);
 	free (dst2);
 	return rc == 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Copy command does not work because of single quotes
Current error message:, even though several .c files exists above current working directory:
```
[0x000010a0]> cp ../*c .
cp: cannot stat '../*c': No such file or directory
```