### PR TITLE
Fix left shift of negative value in the arm assembler

### DIFF
--- a/libr/arch/p/arm/armass.c
+++ b/libr/arch/p/arm/armass.c
@@ -6157,7 +6157,7 @@ static int arm_assemble(ArmOpcode *ao, ut64 off, const char *str) {
 				if (!strcmpnull (ao->op, "movs")) {
 					ao->o = 0xb0e1;
 				}
-				ao->o |= getreg (ao->a[0]) << 20;
+				ao->o |= (ut64)getreg (ao->a[0]) << 20;
 				ret = getreg (ao->a[1]);
 				if (ret != -1) {
 					ao->o |= ret << 24;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
