### PR TITLE
Tidy input to pdu before comparison

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -1098,6 +1098,28 @@ R_API ut8 *r_asm_from_string(RAsm *a, ut64 addr, const char *b, int *l) {
 	return NULL;
 }
 
+R_API char *r_asm_string_tidy(RAsm *a, const char *name) {
+	r_return_val_if_fail (name, NULL);
+	int l;
+	RAsmCode *code = r_asm_massemble (a, name);
+	if (code) {
+		ut8 *buf = code->bytes;
+		l = code->len;
+		RAsmCode *newcode = r_asm_mdisassemble (a, buf, l);
+		r_asm_code_free (code);
+		if (newcode) {
+			char *buf_asm = newcode->assembly;
+			buf_asm[strlen(newcode->assembly) - 1] = (char) 0; // overwrite newline char
+			newcode->assembly = NULL;
+			r_asm_code_free (newcode);
+			return buf_asm;
+		}
+	} else {
+		eprintf("Invalid code\n");
+	}
+	return NULL;
+}
+
 R_API int r_asm_syntax_from_string(const char *name) {
 	r_return_val_if_fail (name, -1);
 	if (!strcmp (name, "regnum")) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5672,6 +5672,7 @@ R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int cou
 	/* pdu vars */
 	bool pdu_condition_met = false;
 	char *opstr_nocolor = NULL;
+	char *tidy_asm = NULL;
 	int opcode_len = -1;
 	//const char *pdu_condition_esil = NULL;
 	const char *pdu_condition_instruction = NULL;
@@ -5693,13 +5694,19 @@ R_API int r_core_print_disasm(RCore *core, ut64 addr, ut8 *buf, int len, int cou
 		ds->count_bytes = false;
 		ds->count = INT_MAX;
 
+		tidy_asm = r_asm_string_tidy(core->rasm, pdu_condition);
+		if (!tidy_asm) {
+			ds_free (ds);
+			return 0;
+		}
+
 		/*if (pdu_condition_type == esil) {
 			pdu_condition_esil = (const char *)pdu_condition;
 		} else*/
 		if (pdu_condition_type == pdu_instruction) {
-			pdu_condition_instruction = (const char *)pdu_condition;
+			pdu_condition_instruction = (const char *)tidy_asm;
 		} else if (pdu_condition_type == pdu_opcode) {
-			pdu_condition_opcode = (const char *)pdu_condition;
+			pdu_condition_opcode = (const char *)tidy_asm;
 			opcode_len = strlen (pdu_condition_opcode);
 		}
 	}
@@ -6232,6 +6239,9 @@ toro:
 	// TODO: this too (must review)
 	ds_print_esil_anal_fini (ds);
 	ds_reflines_fini (ds);
+	if (tidy_asm) {
+		R_FREE (tidy_asm);
+	}
 	R_FREE (nbuf);
 	p->calc_row_offsets = calc_row_offsets;
 	/* used by asm.emu */

--- a/libr/include/r_asm.h
+++ b/libr/include/r_asm.h
@@ -86,6 +86,7 @@ R_API RAsmCode* r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len);
 R_API RAsmCode* r_asm_mdisassemble_hexstr(RAsm *a, RParse *p, const char *hexstr);
 R_API RAsmCode* r_asm_massemble(RAsm *a, const char *buf);
 R_API RAsmCode* r_asm_rasm_assemble(RAsm *a, const char *buf, bool use_spp);
+R_API char *r_asm_string_tidy(RAsm *a, const char *name);
 R_API char *r_asm_tostring(RAsm *a, ut64 addr, const ut8 *b, int l);
 /* to ease the use of the native bindings (not used in r2) */
 R_API ut8 *r_asm_from_string(RAsm *a, ut64 addr, const char *b, int *l);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
This handles user input while using pdui (and pduo), see examples below.
User input gets assembled and disassembled using available R_API(s).

Tests with `/bin/ls`:
```
$ r2 /bin/ls
 -- Use the 'id' command to see the source line related to the current seek
[0x00006ab0]> aa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze all functions arguments/locals (afva@@@F)
[0x00006ab0]>
```

New output after _tidy_ allows for **no space between comma and the second ebp** register:
```
[0x00006ab0]> pdui xor ebp,ebp
            ;-- rip:
┌ 37: entry0 (int64_t arg3);
│           ; arg int64_t arg3 @ rdx
│           0x00006ab0      f30f1efa       endbr64
│           0x00006ab4      31ed           xor ebp, ebp
[0x00006ab0]>
```

Before:
```
[0x00006ab0]> pdui xor ebp,ebp
Failed to find instruction meeting pdu condition.
```

Some insensible assembly code as input would output this:
```
[0x00006ab0]> pdui xor ebp,ews
ERROR: Cannot assemble 'xor ebp,ews' at line 3
Invalid code
```
