### PR TITLE
Disable the RConsMark api because getCursor is too slow ##cons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -1492,6 +1492,9 @@ now the console color is reset with each \n (same stuff do it here but in correc
 /* return the aproximated x,y of cursor before flushing */
 // XXX this function is a huge bottleneck
 R_API int r_cons_get_cursor(int *rows) {
+	// This implementation is very slow
+	return 0;
+#if 0
 	RConsContext *c = C;
 	int i, col = 0;
 	int row = 0;
@@ -1523,6 +1526,7 @@ R_API int r_cons_get_cursor(int *rows) {
 		*rows = row;
 	}
 	return col;
+#endif
 }
 
 R_API bool r_cons_is_windows(void) {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3037,7 +3037,7 @@ static void ds_print_offset(RDisasmState *ds) {
 			}
 		}
 	}
-	r_print_set_screenbounds (core->print, at);
+	// r_print_set_screenbounds (core->print, at);
 	if (ds->show_offset) {
 		const char *label = NULL;
 		int delta = -1;


### PR DESCRIPTION
* iow: Speedups console access by disabling an unused feature

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
