### PR TITLE
Add asm.lines.limit config variable to hide asm.lines if disasm is la…

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3653,6 +3653,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.lbytes", "true", "align disasm bytes to left");
 	SETBPREF ("asm.lines", "true", "show ASCII-art lines at disassembly");
 	SETBPREF ("asm.lines.jmp", "true", "show flow lines at jumps");
+	SETI ("asm.lines.limit", 8096, "dont show control flow lines if function is larger than X bytes");
 	SETBPREF ("asm.lines.bb", "false", "show empty line after every basic block");
 	SETBPREF ("asm.lines.call", "false", "enable call lines");
 	SETBPREF ("asm.lines.ret", "false", "show separator lines after ret");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -925,8 +925,10 @@ static void ds_reflines_init(RDisasmState *ds) {
 	RAnal *anal = ds->core->anal;
 
 	lastaddr = UT64_MAX;
+	int limit = r_config_get_i (ds->core->config, "asm.lines.limit");
+	const bool inlimit = (limit > 0 && ds->len < limit);
 
-	if (ds->show_lines_bb || ds->pj) {
+	if (inlimit && (ds->show_lines_bb || ds->pj)) {
 		ds_reflines_fini (ds);
 		anal->reflines = r_anal_reflines_get (anal,
 			ds->addr, ds->buf, ds->len, ds->count,


### PR DESCRIPTION
…rger ##disasm

* Fix huge memory usage/slowdown by accident on some large functions

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
