### PR TITLE
Fix x86 XOR ESIL for 64bit registers ##esil 

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -419,7 +419,7 @@ static char *get64from32(const char *s) {
 			return r_str_newf ("r%d", atoi (s + 1));
 		}
 	}
-	return NULL; // strdup (s);
+	return NULL; 
 }
 
 static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh handle, cs_insn *insn) {

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -419,7 +419,7 @@ static char *get64from32(const char *s) {
 			return r_str_newf ("r%d", atoi (s + 1));
 		}
 	}
-	return NULL; 
+	return NULL;
 }
 
 static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh handle, cs_insn *insn) {

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -419,7 +419,7 @@ static char *get64from32(const char *s) {
 			return r_str_newf ("r%d", atoi (s + 1));
 		}
 	}
-	return strdup (s);
+	return NULL; // strdup (s);
 }
 
 static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh handle, cs_insn *insn) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The ESIL expressions for XOR instructions with 64 bit registers is currently wrong due to the get64from32 function returning strdup(s) instead of NULL when the register does not match a 32bit register. This change lead to the use of the 32bit ESIL instead of the correct 64bit version. 

The change in this PR simply has get64from32 return NULL when the register is already 64bit, ensuring the right ESIL is generated for the instruction. 

**Copilot**

copilot:all
