### PR TITLE
Fix #22029 ESIL for REP[Z] [BRANCH INSTR] ##esil 

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2452,8 +2452,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	}
 
 	// AMD K8 optimization lead some compilation to emit REPZ RET which should be treated as RET
-	ut32 ignore_op_mask = (R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET) & ~1;
-	if (op->prefix & R_ANAL_OP_PREFIX_REP && !(op->type & ignore_op_mask)) {
+	if (op->prefix & R_ANAL_OP_PREFIX_REP && op->type != R_ANAL_OP_TYPE_RET) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		if (repe) {
@@ -2464,7 +2463,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	}
 	// Intel MPX changes the REPNE prefix to mean BND for jmps, etc
 	// its barely used anymore so the best thing to do is ignore
-	if (op->prefix & R_ANAL_OP_PREFIX_REPNE && !(op->type & ignore_op_mask)) {
+	if (op->prefix & R_ANAL_OP_PREFIX_REPNE && (op->type == R_ANAL_OP_TYPE_MOV || op->type == R_ANAL_OP_TYPE_STORE)) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		r_strbuf_appendf (&op->esil, ",%s,--=,zf,?{,BREAK,},0,GOTO", counter);

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2452,7 +2452,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	}
 
 	// AMD K8 optimization lead some compilation to emit REPZ RET which should be treated as RET
-	if (op->prefix & R_ANAL_OP_PREFIX_REP && !(op->type & (R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET))) {
+	if (op->prefix & R_ANAL_OP_PREFIX_REP && op->type != R_ANAL_OP_TYPE_RET) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		if (repe) {

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2451,7 +2451,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		break;
 	}
 
-	if (op->prefix & R_ANAL_OP_PREFIX_REP) {
+	// AMD K8 optimization lead some compilation to emit REPZ RET which should be treated as RET
+	if (op->prefix & R_ANAL_OP_PREFIX_REP && !(op->type & (R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET))) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		if (repe) {

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2452,7 +2452,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	}
 
 	// AMD K8 optimization lead some compilation to emit REPZ RET which should be treated as RET
-	if (op->prefix & R_ANAL_OP_PREFIX_REP && op->type != R_ANAL_OP_TYPE_RET) {
+	ut32 ignore_op_mask = (R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET) & ~1;
+	if (op->prefix & R_ANAL_OP_PREFIX_REP && !(op->type & ignore_op_mask)) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		if (repe) {
@@ -2463,7 +2464,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	}
 	// Intel MPX changes the REPNE prefix to mean BND for jmps, etc
 	// its barely used anymore so the best thing to do is ignore
-	if (op->prefix & R_ANAL_OP_PREFIX_REPNE && !(op->type & (R_ANAL_OP_TYPE_UJMP | R_ANAL_OP_TYPE_CALL | R_ANAL_OP_TYPE_RET))) {
+	if (op->prefix & R_ANAL_OP_PREFIX_REPNE && !(op->type & ignore_op_mask)) {
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		r_strbuf_appendf (&op->esil, ",%s,--=,zf,?{,BREAK,},0,GOTO", counter);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix #22029 an issue with `repz ret` instruction which should not actually have the ESIL for the REP prefix as it is undefined for non-string instructions like `ret`. The `repz` prefix only serves to create a single 2 byte `ret` instruction for branch prediction optimization as noted [here](https://repzret.org/p/repzret/). Specifically these changes remove the `rep` ESIL for any of the control flow instruction types also excluded from `repne` already. 