### PR TITLE
Fix compiler warning in rvec, not supporting null in the hard way

### DIFF
--- a/libr/include/r_vec.h
+++ b/libr/include/r_vec.h
@@ -114,10 +114,8 @@ extern "C" {
 #define R_VEC_CAPACITY(vec) (vec)->_capacity
 
 // Helper macros for doing a foreach-style loop over the elements of a vector.
-#define R_VEC_FOREACH(vec, iter) \
-	if (vec && (vec)->_start != (vec)->_end) for (iter = (vec)->_start; iter != (vec)->_end; iter++)
-#define R_VEC_FOREACH_PREV(vec, iter) \
-	if (vec && (vec)->_start != (vec)->_end) for (iter = (vec)->_end - 1; iter >= (vec)->_start; iter--)
+#define R_VEC_FOREACH(vec, iter) for (iter = (vec)->_start; iter != (vec)->_end; iter++)
+#define R_VEC_FOREACH_PREV(vec, iter) for (iter = (vec)->_end - 1; iter >= (vec)->_start; iter--)
 
 #define R_CONCAT_INNER(a, b) a ## b
 #define R_CONCAT(a, b) R_CONCAT_INNER(a, b)


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
