### PR TITLE
Add asm.flags.prefix (true by default) ##disasm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3648,6 +3648,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.optype", "false", "show opcode type next to the instruction bytes");
 	SETBPREF ("asm.lines.fcn", "true", "show function boundary lines");
 	SETBPREF ("asm.flags", "true", "show flags");
+	SETBPREF ("asm.flags.prefix", "true", "show ;-- before the flags");
 	SETICB ("asm.flags.maxname", 0, &cb_maxname, "maximum length of flag name with smart chopping");
 	SETI ("asm.flags.limit", 0, "maximum number of flags to show in a single offset");
 	SETBPREF ("asm.flags.right", "false", "show flags as comments at the right side of the disassembly");

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -484,7 +484,7 @@ pd 3 @ 0x3ec1
 EOF
 EXPECT=<<EOF
 |           0x00003ec1      add rax, rbx
-|           ;-- switch
+|           ;-- switch:
 |           0x00003ec4      jmp rax                                    ; switch table (275 cases) at 0x172d8
 |           ;-- case 110:                                              ; from 0x00003ec4
 |           ; CODE XREF from main @ 0x3ec4(x)

--- a/test/db/cmd/print
+++ b/test/db/cmd/print
@@ -147,7 +147,7 @@ EXPECT=<<EOF
 0x10000116e call sym.func.100004401
 0x100001179 str.1_ABCFGHLOPRSTUWabcdefghiklmnopqrstuvwx
 0x100001186 call sym.imp.getopt
-;-- switch
+;-- switch:
 0x100001233 str.CLICOLOR
 0x100001246 call sym.imp.setenv
 0x100001253 str.bin_ls


### PR DESCRIPTION
* Drops the ;-- prefix in all the flags in the disasm
* Evaluate switching to true, after testing iaito and other tools

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
