### PR TITLE
Fix UAF in REsil.free() when called from RAnal.free()

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -175,6 +175,7 @@ R_API void r_anal_free(RAnal *a) {
 	r_unref (a->config);
 	a->arch->esil = NULL;
 	r_arch_free (a->arch);
+	a->arch = NULL;
 	free (a->zign_path);
 	r_list_free (a->plugins);
 	r_rbtree_free (a->bb_tree, __block_free_rb, NULL);
@@ -188,6 +189,7 @@ R_API void r_anal_free(RAnal *a) {
 	r_list_free (a->threads);
 	r_list_free (a->leaddrs);
 	sdb_free (a->sdb);
+	a->esil->anal = NULL;
 	r_esil_free (a->esil);
 	free (a->last_disasm_reg);
 	r_list_free (a->imports);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
