### PR TITLE
Support 'e key.?' syntax as alternative to 'e?key.' ##shell

### DIFF
--- a/libr/core/cmd_eval.c
+++ b/libr/core/cmd_eval.c
@@ -768,6 +768,10 @@ static int cmd_eval(void *data, const char *input) {
 	case ' ': // "e "
 		if (r_str_endswith (input, ".") && !r_str_endswith (input, "..")) {
 			r_config_list (core->config, input + 1, 0);
+		} else if (r_str_endswith (input, ".?")) {
+			char *w = r_str_ndup (input, strlen (input) - 1);
+			r_config_list (core->config, w, 2);
+			free (w);
 		} else {
 			// XXX we cant do "e cmd.gprompt=dr=", because the '=' is a token, and quotes dont affect him
 			r_config_eval (core->config, r_str_trim_head_ro (input + 1), false);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

copilot:all
