### PR TITLE
Optimize mach0 loading

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -63,15 +63,6 @@ typedef struct {
 	/* followed by dynamic content as located by offset fields above */
 } CodeDirectory;
 
-static inline void r_bin_section_fini(RBinSection *bs) {
-	if (bs) {
-		free (bs->name);
-		free (bs->format);
-	}
-}
-
-R_VEC_TYPE_WITH_FINI(RVecSegment, RBinSection, r_bin_section_fini);
-
 // OMG; THIS SHOULD BE KILLED; this var exposes the local native endian, which is completely unnecessary
 // USE THIS: int ws = bf->o->info->big_endian;
 #define mach0_endian 1
@@ -2453,7 +2444,7 @@ static const char *macho_section_type_tostring(int flags) {
 	return "";
 }
 
-static inline RVecSegment *MACH0_(get_segments_vec)(RBinFile *bf, struct MACH0_(obj_t) *mo) {
+RVecSegment *MACH0_(get_segments_vec)(RBinFile *bf, struct MACH0_(obj_t) *mo) {
 	if (mo->segments_vec) {
 		return mo->segments_vec;
 	}
@@ -3234,7 +3225,7 @@ static inline bool is_debug_segment(const RBinSection *s, const void *user) {
 }
 
 static inline bool _check_if_debug_build(RBinFile *bf, struct MACH0_(obj_t) *mo) {
-	return RVecSegment_find (bf->o->segments_vec, NULL, is_debug_segment) != NULL;
+	return RVecSegment_find (mo->segments_vec, NULL, is_debug_segment) != NULL;
 }
 #else
 static bool _check_if_debug_build(RBinFile *bf, struct MACH0_(obj_t) *mo) {

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -100,7 +100,14 @@ struct MACH0_(opts_t) {
 	RBinFile *bf;
 };
 
-R_VEC_FORWARD_DECLARE(RVecSegment);
+static inline void r_bin_section_fini(RBinSection *bs) {
+	if (bs) {
+		free (bs->name);
+		free (bs->format);
+	}
+}
+
+R_VEC_TYPE_WITH_FINI(RVecSegment, RBinSection, r_bin_section_fini);
 
 struct MACH0_(obj_t) {
 	struct MACH0_(mach_header) hdr;
@@ -251,6 +258,7 @@ struct MACH0_(obj_t) *MACH0_(new_buf)(RBuffer *buf, struct MACH0_(opts_t) *optio
 void *MACH0_(mach0_free)(struct MACH0_(obj_t) *bin);
 const RVector *MACH0_(load_sections)(struct MACH0_(obj_t) *mo);
 RList *MACH0_(get_segments)(RBinFile *bf, struct MACH0_(obj_t) *mo);
+RVecSegment *MACH0_(get_segments_vec)(RBinFile *bf, struct MACH0_(obj_t) *mo);
 const bool MACH0_(load_symbols)(struct MACH0_(obj_t) *mo);
 void MACH0_(pull_symbols)(struct MACH0_(obj_t) *mo, RBinSymbolCallback cb, void *user);
 const RPVector *MACH0_(load_imports)(RBinFile* bf, struct MACH0_(obj_t) *bin);

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -100,6 +100,8 @@ struct MACH0_(opts_t) {
 	RBinFile *bf;
 };
 
+R_VEC_FORWARD_DECLARE(RVecSegment);
+
 struct MACH0_(obj_t) {
 	struct MACH0_(mach_header) hdr;
 	struct MACH0_(segment_command) *segs;
@@ -125,7 +127,6 @@ struct MACH0_(obj_t) {
 	RBinImport **imports_by_ord;
 	size_t imports_by_ord_size;
 	HtPP *imports_by_name;
-	RList *cached_segments;
 	struct MACH0_(opts_t) options;
 
 	struct dysymtab_command dysymtab;
@@ -170,8 +171,8 @@ struct MACH0_(obj_t) {
 	ut64 header_at;
 	bool parse_start_symbols;
 	bool symbols_loaded;
-	//RVector symbols_cache;
 	RVecRBinSymbol *symbols_vec; // pointer to &bf->o->symbols_vec
+	RVecSegment *segments_vec;  // R2_590 pointer of &bf->o->segments_vec
 	ut64 symbols_off;
 	void *user;
 	ut64 (*va2pa)(ut64 p, ut32 *offset, ut32 *left, RBinFile *bf);

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -144,10 +144,9 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) {
 		return bin->va2pa (p, offset, left, bf);
 	}
 	mach0_ut addr = p;
-	RList *sections = MACH0_(get_segments) (bf, bin);  // XXX slow, don't allocate each time
-	RListIter *iter;
+	RVecSegment *sections = MACH0_(get_segments_vec) (bf, bin);  // don't free, cached by bin
 	RBinSection *s;
-	r_list_foreach (sections, iter, s) {
+	R_VEC_FOREACH (sections, s) {
 		if (addr >= s->vaddr && addr < s->vaddr + s->vsize) {
 			if (offset) {
 				*offset = addr - s->vaddr;
@@ -155,11 +154,10 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) {
 			if (left) {
 				*left = s->vsize - (addr - s->vaddr);
 			}
-			r = (s->paddr - obj->boffset  + (addr - s->vaddr));
+			r = s->paddr - obj->boffset + (addr - s->vaddr);
 			break;
 		}
 	}
-	r_list_free (sections);
 	return r;
 }
 

--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -144,7 +144,7 @@ static mach0_ut va2pa(mach0_ut p, ut32 *offset, ut32 *left, RBinFile *bf) {
 		return bin->va2pa (p, offset, left, bf);
 	}
 	mach0_ut addr = p;
-	RList *sections = MACH0_(get_segments) (bf, bin);
+	RList *sections = MACH0_(get_segments) (bf, bin);  // XXX slow, don't allocate each time
 	RListIter *iter;
 	RBinSection *s;
 	r_list_foreach (sections, iter, s) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -77,9 +77,10 @@ static ut64 baddr(RBinFile *bf) {
 	return MACH0_(get_baddr)(mo);
 }
 
+// R2_590 return RVecSegment
 static RList *sections(RBinFile *bf) {
 	struct MACH0_(obj_t) *mo = bf->o->bin_obj;
-	return MACH0_(get_segments) (bf, mo);
+	return MACH0_(get_segments) (bf, mo); // TODO split up sections and segments?
 }
 
 static RBinAddr *newEntry(ut64 hpaddr, ut64 paddr, int type, int bits) {

--- a/libr/include/r_vec.h
+++ b/libr/include/r_vec.h
@@ -174,7 +174,7 @@ extern "C" {
 		r_return_if_fail (vec); \
 		memset (vec, 0, sizeof (vec_type)); \
 	} \
-	static inline R_MAYBE_UNUSED R_MUSTUSE vec_type *R_VEC_FUNC(vec_type, new)() { \
+	static inline R_MAYBE_UNUSED R_MUSTUSE vec_type *R_VEC_FUNC(vec_type, new)(void) { \
 		vec_type *vec = R_NEW (vec_type); \
 		if (R_LIKELY (vec)) { \
 			R_VEC_FUNC(vec_type, init) (vec); \


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

va2pa showed up when profiling loading of mach0 code (30% of total time).
For the app I tested it with, it called va2pa 700k+ times, allocating a new list and computing segments each time.

With the new behavior we cache this computation, and use a vector for an additional perf boost.
Locally I saw a speed up of 13.7s -> 5.2s for a big binary.

In the future, we need to move the vec to bin.c, but this PR is a nice improvement by itself.

**Copilot**

<!--
copilot:all
-->
