### PR TITLE
Fix arrow keys on some terminals ##cons

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1783,6 +1783,9 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 					buf[1] = r_cons_readchar_timeout (50);
 				}
 #endif
+				if (buf[0] == 'O' && strchr("ABCDFH", buf[1]) != NULL) { // O
+					buf[0] = '[';
+				}
 				if (buf[0] == '[') { // [
 					switch (buf[1]) {
 					case '3': // supr or mouse click

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1577,8 +1577,7 @@ R_API const char *r_line_readline_cb(RLineReadCallback cb, void *user) {
 		case 6:	// ^f // emacs right
 			__move_cursor_right ();
 			break;
-		case 12:// ^L -- right
-			__move_cursor_right ();
+		case 12:// ^L -- clear screen
 			if (I.echo) {
 				eprintf ("\x1b[2J\x1b[0;0H");
 			}

--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -145,7 +145,13 @@ R_API int r_cons_arrow_to_hjkl(int ch) {
 			ch = r_cons_readchar ();
 		}
 #else
-		ch = 0xf1 + (ch & 0xf);
+		switch (ch) { // Arrow keys
+		case 'A': ch = 'k'; break;
+		case 'B': ch = 'j'; break;
+		case 'C': ch = 'l'; break;
+		case 'D': ch = 'h'; break;
+		default: ch = 0xf1 + (ch & 0xf); break;
+		}
 		break;
 	case '[': // function keys (2)
 		ch = r_cons_readchar ();


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Some terminals (xterm, tmux, screen...) use the escape sequences `^[{A,B,C,D}` for the arrow keys.
This M.R. adds support for those escape sequences.

Additionally, it fixes the behavior of Ctrl-L which does a cursor move before clearing the screen.