### PR TITLE
R_API function to count xrefs at a specific address ##anal

### DIFF
--- a/libr/anal/vtable.c
+++ b/libr/anal/vtable.c
@@ -208,11 +208,8 @@ R_API RVTableInfo *r_anal_vtable_parse_at(RVTableContext *context, ut64 addr) {
 		addr += context->word_size;
 
 		// a ref means the vtable has ended
-		RVecAnalRef *ll = r_anal_xrefs_get (context->anal, addr);
-		// TODO add R_API function that only returns if there are xrefs for an addr
-		// to avoid several allocations
-		const bool has_refs = ll && !RVecAnalRef_empty (ll);
-		RVecAnalRef_free (ll);
+		const ut64 number_of_refs = r_anal_xrefs_count_at (context->anal, addr);
+		const bool has_refs = number_of_refs > 0;
 		if (has_refs) {
 			break;
 		}

--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -135,6 +135,24 @@ static ut64 ref_manager_count_xrefs(RefManager *rm) {
 	return count;
 }
 
+static ut64 ref_manager_count_xrefs_at(RefManager *rm, ut64 to) {
+	r_return_val_if_fail (rm, 0);
+
+	ut64 count = 0;
+
+	const Edges *edges = NULL;
+	{
+		AdjacencyList_CIter iter = AdjacencyList_cfind (&rm->xrefs, &to);
+		const AdjacencyList_Entry *entry = AdjacencyList_CIter_get (&iter);
+		edges = entry? entry->val: NULL;
+	}
+
+	if (edges) {
+		count = Edges_size (edges);
+	}
+	return count;
+}
+
 static RVecAnalRef *_collect_all_refs(RefManager *rm, const AdjacencyList *adj_list) {
 	RVecAnalRef *result = RVecAnalRef_new ();
 	if (R_UNLIKELY (!result)) {
@@ -498,6 +516,11 @@ R_API void r_anal_xrefs_list(RAnal *anal, int rad, const char *arg) {
 R_API ut64 r_anal_xrefs_count(RAnal *anal) {
 	r_return_val_if_fail (anal && anal->rm, 0);
 	return ref_manager_count_xrefs (anal->rm);
+}
+
+R_API ut64 r_anal_xrefs_count_at(RAnal *anal, ut64 to) {
+	r_return_val_if_fail (anal && anal->rm, 0);
+	return ref_manager_count_xrefs_at (anal->rm, to);
 }
 
 R_API RVecAnalRef *r_anal_function_get_xrefs(RAnalFunction *fcn) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1082,6 +1082,7 @@ R_API RVecAnalRef *r_anal_refs_get(RAnal *anal, ut64 from);
 R_API RVecAnalRef *r_anal_xrefs_get_from(RAnal *anal, ut64 to);
 R_API void r_anal_xrefs_list(RAnal *anal, int rad, const char *arg);
 R_API ut64 r_anal_xrefs_count(RAnal *anal);
+R_API ut64 r_anal_xrefs_count_at(RAnal *anal, ut64 to);
 R_API RVecAnalRef *r_anal_function_get_refs(RAnalFunction *fcn);
 R_API RVecAnalRef *r_anal_function_get_all_xrefs(RAnalFunction *fcn);
 R_API RVecAnalRef *r_anal_function_get_xrefs(RAnalFunction *fcn);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Copy pasted logic from `_collect_refs_from` into a new function to count xrefs at an address without making allocations.
<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
