### PR TITLE
Unset struct.<struct_name>.<field_name>.meta keys when deleting a type, fixes #22136

### DIFF
--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -509,11 +509,12 @@ R_API void r_type_del(Sdb *TDB, const char *name) {
 		sdb_unset (TDB, r_strf ("type.%s.meta", name), 0);
 		sdb_unset (TDB, name, 0);
 	} else if (!strcmp (kind, "struct") || !strcmp (kind, "union")) {
-		int i, n = sdb_array_length (TDB, r_strf ("%s.%s", kind, name));
 		char *elements_key = r_str_newf ("%s.%s", kind, name);
+		int i, n = sdb_array_length (TDB, elements_key);
 		for (i = 0; i < n; i++) {
 			char *p = sdb_array_get (TDB, elements_key, i, NULL);
 			sdb_unset (TDB, r_strf ("%s.%s", elements_key, p), 0);
+			sdb_unset (TDB, r_strf ("%s.%s.meta", elements_key, p), 0);
 			free (p);
 		}
 		sdb_unset (TDB, elements_key, 0);


### PR DESCRIPTION


<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
<!-- your changes if necessary -->
Unset `struct.<struct_name>.<field_name>.meta` keys when deleting a struct type, fixes #22136

<!--
**Copilot**
copilot:all
-->
