### PR TITLE
Fix early bail out in dwarf-only Mach-O symbol parsing ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3001,13 +3001,12 @@ static void _parse_symbols(RBinFile *bf, struct MACH0_(obj_t) *mo, HtPP *symcach
 		return;
 	}
 	/* parse dynamic symbol table */
-	symbols_count = mo->dysymtab.nextdefsym + mo->dysymtab.nlocalsym + mo->dysymtab.nundefsym;
+	symbols_count = mo->dysymtab.nextdefsym + mo->dysymtab.nlocalsym + mo->dysymtab.nundefsym + mo->nsymtab;
 	if (symbols_count == 0) {
 		ht_pp_free (hash);
 		return;
 	}
 
-	symbols_count += mo->nsymtab;
 	if (SZT_MUL_OVFCHK (symbols_count, 2 * sizeof (RBinSymbol))) {
 		// overflow may happen here
 		ht_pp_free (hash);

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -157,6 +157,16 @@ addr: 0x0000a24e
 EOF
 RUN
 
+NAME="Mach-O dSYM symbols (armv7)"
+FILE=bins/mach0/TestRTTI-armv7-dSYM
+CMDS=<<EOF
+is~main[1]
+EOF
+EXPECT=<<EOF
+0x00006376
+EOF
+RUN
+
 NAME="function info integration c++"
 FILE=bins/elf/dwarf3_many_comp_units.elf 
 CMDS=<<EOF


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`_parse_symbols()` exited too early where the only symbol count comes from `nsymtab`, effectively preventing from parsing any symbols contained in dwarf-only Mach-O files (like dSYM ones).
