### PR TITLE
Remove the boffset() callback from bin plugins

### DIFF
--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -297,10 +297,6 @@ R_API int r_bin_object_set_items(RBinFile *bf, RBinObject *bo) {
 		}
 	}
 
-	if (p->boffset) {
-		// XXX this is implemented only for ELF. so im not sure why its useful
-		bo->boffset = p->boffset (bf);
-	}
 	// XXX: no way to get info from xtr pluginz?
 	// Note, object size can not be set from here due to potential
 	// inconsistencies

--- a/libr/bin/p/bin_cgc.c
+++ b/libr/bin/p/bin_cgc.c
@@ -104,7 +104,6 @@ RBinPlugin r_bin_plugin_cgc = {
 	.destroy = &destroy,
 	.check = &check,
 	.baddr = &baddr,
-	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
 	.sections = &sections,

--- a/libr/bin/p/bin_elf.c
+++ b/libr/bin/p/bin_elf.c
@@ -135,7 +135,6 @@ RBinPlugin r_bin_plugin_elf = {
 	.destroy = &destroy,
 	.check = &check,
 	.baddr = &baddr,
-	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
 	.sections = &sections,

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -88,10 +88,6 @@ static ut64 baddr(RBinFile *bf) {
 	return Elf_(get_baddr) (bf->bo->bin_obj);
 }
 
-static ut64 boffset(RBinFile *bf) {
-	return Elf_(get_boffset) (bf->bo->bin_obj);
-}
-
 static RBinAddr* binsym(RBinFile *bf, int sym) {
 	ELFOBJ* eo = bf->bo->bin_obj;
 	RBinAddr *ret = NULL;

--- a/libr/bin/p/bin_elf64.c
+++ b/libr/bin/p/bin_elf64.c
@@ -134,7 +134,6 @@ RBinPlugin r_bin_plugin_elf64 = {
 	.load = &load,
 	.destroy = &destroy,
 	.baddr = &baddr,
-	.boffset = &boffset,
 	.binsym = &binsym,
 	.entries = &entries,
 #if R2_590

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -505,7 +505,6 @@ typedef struct r_bin_plugin_t {
 	void (*destroy)(RBinFile *bf);
 	bool (*check)(RBinFile *bf, RBuffer *buf);
 	ut64 (*baddr)(RBinFile *bf);
-	ut64 (*boffset)(RBinFile *bf);
 	RBinAddr* (*binsym)(RBinFile *bf, int num);
 	RList/*<RBinAddr>*/* (*entries)(RBinFile *bf);
 	RList/*<RBinSection>*/* (*sections)(RBinFile *bf); // R2_600 - deprecate


### PR DESCRIPTION
* it was used only for ELF, but it was already used internally

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
