### PR TITLE
README: Fix unit tests target after fd9f8d631

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -20,7 +20,7 @@ Originally based on work by and now in collaboration with pancake.
 # Usage
 
  * To run *all* tests, use `make -k all`.
- * To execute only the unit tests use `make -k unit_tests`.
+ * To execute only the unit tests use `make -k unit-tests`.
 
 ## Failure Levels
 


### PR DESCRIPTION
Seems the underscore got transformed into a dash.

- [x] Mark this if you consider it ready to merge
