### PR TITLE
Fix mnemonic output in m680x plugin ##fix

### DIFF
--- a/libr/arch/p/m680x_cs/plugin.c
+++ b/libr/arch/p/m680x_cs/plugin.c
@@ -513,7 +513,7 @@ beach:
 		} else {
 			op->mnemonic = r_str_newf ("%s%s%s", insn->mnemonic,
 					insn->op_str[0]?" ": "", insn->op_str);
-			r_str_replace_in (op->mnemonic, strlen (op->mnemonic),
+			r_str_replace_in (op->mnemonic, strlen (op->mnemonic) + 1,
 				"ptr ", "", true);
 		}
 	}

--- a/test/db/extras/asm/m680x_6805_8
+++ b/test/db/extras/asm/m680x_6805_8
@@ -1,0 +1,2 @@
+d "decx" 5A
+d "inc $ae" 3CAE


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)

Seems r_str_replace_in wants the buffer size, not the string size, so it was truncating the last character.