### PR TITLE
Fixed ESIL PPC32 lbz/lbzcix instructions to not update register.

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -879,10 +879,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RAnalOpMask mask) {
 			}
 			esilprintf (op, "%s,%s,=[8],%s=", ARG (0), op1, op1);
 			break;
-		case PPC_INS_LBZ:
-#if CS_API_MAJOR >= 4
-		case PPC_INS_LBZCIX:
-#endif
 		case PPC_INS_LBZU:
 		case PPC_INS_LBZUX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -892,6 +888,10 @@ static bool decode(RArchSession *as, RAnalOp *op, RAnalOpMask mask) {
 			}
 			esilprintf (op, "%s,[1],%s,=,%s=", op1, ARG (0), op1);
 			break;
+		case PPC_INS_LBZ:
+#if CS_API_MAJOR >= 4
+		case PPC_INS_LBZCIX:
+#endif
 		case PPC_INS_LBZX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[1]"), ARG (0));

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -1,3 +1,63 @@
+NAME=load word and zero ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 8041fff8)
+EOF
+EXPECT=<<EOF
+lwz r2, -8(r1)
+0x00000000 -8,r1,+,[4],r2,=
+EOF
+RUN
+
+NAME=load byte and zero ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 8841fff8)
+EOF
+EXPECT=<<EOF
+lbz r2, -8(r1)
+0x00000000 -8,r1,+,[1],r2,=
+EOF
+RUN
+
+NAME=load word and zero with update ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 8441fff8)
+EOF
+EXPECT=<<EOF
+lwzu r2, -8(r1)
+0x00000000 -8,r1,+,[4],r2,=,-8,r1,+=
+EOF
+RUN
+
+NAME=load byte and zero with update ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 8c41fff8)
+EOF
+EXPECT=<<EOF
+lbzu r2, -8(r1)
+0x00000000 -8,r1,+,[1],r2,=,-8,r1,+=
+EOF
+RUN
+
 NAME=load with update ppc-32
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
- [ X] Mark this if you consider it ready to merge
- [ X ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The PPC32 lbz instruction was being treated as the lbzu instruction in ESIL so the 'source' register was being updated. Fixed to mirror the lwz/lwzu instructions and added some simple tests for lbz/lbzu/lwz/lwzu.

**Copilot**

<!--
copilot:all
-->
