### PR TITLE
add '%' command to visual graph to search through disassembly and nav…

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4099,7 +4099,7 @@ static void visual_find(RAGraph *g, RCore *core) {
 		printf (Color_RESET);
 		r_cons_flush ();
 
-		r_cons_fgets (buf, sizeof(buf), 0, NULL);
+		r_cons_fgets (buf, sizeof (buf), 0, NULL);
 
 		if (buf[0] == '\0') {
 			break;

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -6216,6 +6216,7 @@ static int cmd_print(void *data, const char *input) {
 		ut8 bw_disassemble = false;
 		ut32 pd_result = false, processed_cmd = false;
 		bool formatted_json = false;
+	        const bool asm_offset_segment = r_config_get_b (core->config, "asm.offset.segment");
 		if (input[1] && input[2]) {
 			// "pd--" // context disasm
 			if (!strncmp (input + 1, "--", 2)) {
@@ -6736,6 +6737,7 @@ static int cmd_print(void *data, const char *input) {
 				r_cons_newline ();
 			}
 		}
+		r_config_set_b (core->config, "asm.offset.segment", asm_offset_segment);
 		if (processed_cmd) {
 			ret = pd_result;
 			goto beach;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6208,6 +6208,11 @@ toro:
 		ds_print_lines_left (ds);
 		core->print->resetbg = (ds->asm_highlight == UT64_MAX);
 		ds_start_line_highlight (ds);
+		if (ds->show_offseg) {
+			core->print->flags |= R_PRINT_FLAGS_SEGOFF;
+		} else {
+			core->print->flags &= ~(R_PRINT_FLAGS_SEGOFF);
+		}
 		ds_print_offset (ds);
 		////
 		RAnalFunction *fcn = f;


### PR DESCRIPTION
add '%' command in visual graph to search in disassemble and navigate to it. works with 'agfv' command

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

added search in visual graph, possible to search via assembly code, commens, variable names, etc.
in general this works as pdr~sentence amd read an address of that and s addr to navigate graph to found line

**Copilot**

<!--
copilot:all
-->
