### PR TITLE
Fix log warn typo "descriptores" -> "descriptors"

### DIFF
--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -5061,7 +5061,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 	case '+': // "dd+"
 	case ' ': // "dd"
 		if (r_config_get_b (core->config, "cfg.debug")) {
-			R_LOG_WARN ("Child file descriptores require the debugger. No alternative for static yet");
+			R_LOG_WARN ("Child file descriptors require the debugger. No alternative for static yet");
 		} else {
 			RBuffer *buf;
 			char *filename;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
