### PR TITLE
Fix relative doc link and perma link it

### DIFF
--- a/doc/abi.md
+++ b/doc/abi.md
@@ -47,4 +47,4 @@ What you **MUST** do in X.Y.9:
 
 All this is checked in the CI with the `abidiff` utility.
 
-[.github/workflows/build.yml#L522](.github/workflows/build.yml#L522)
+[.github/workflows/build.yml#L607](../../94a31e97b868ead86d27031280ead2f5c64fecbd/.github/workflows/build.yml#L607)


### PR DESCRIPTION
When clicking the link on github in the CI section https://github.com/radareorg/radare2/blob/94a31e97b868ead86d27031280ead2f5c64fecbd/doc/abi.md#ci

It redirects you to https://github.com/radareorg/radare2/blob/master/doc/.github/workflows/build.yml#L522

Which is wrong since .github is not in the doc folder. Also pinning line 522 without a fixed commit gets outdated quite fast.