### PR TITLE
Fix calloc(-1) when no arch plugin selected in disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -3633,6 +3633,10 @@ static void ds_print_bytes(RDisasmState *ds) {
 #if 0
 			str = r_asm_op_get_hex (&ds->asmop);
 #else
+			if (ds->oplen < 1) {
+				int minopsz = r_anal_archinfo (core->anal, R_ANAL_ARCHINFO_MIN_OP_SIZE);
+				ds->oplen = minopsz;
+			}
 			if (ds->analop.bytes && ds->analop.size > ds->oplen) {
 				str = r_hex_bin2strdup (ds->analop.bytes, ds->oplen);
 			} else {
@@ -3642,7 +3646,7 @@ static void ds_print_bytes(RDisasmState *ds) {
 					str = r_hex_bin2strdup (bytes, ds->oplen);
 					free (bytes);
 				} else {
-					str = strdup ("");
+					str = strdup ("??");
 				}
 			}
 #endif

--- a/libr/core/hack.c
+++ b/libr/core/hack.c
@@ -296,7 +296,7 @@ R_API bool r_core_hack(RCore *core, const char *op) {
 	if (core->blocksize < 4) {
 		return false;
 	}
-#if R2_580
+#if R2_600
 	// R2_590 TODO: call RArch.patch() if available, otherwise just do this hack until all anal plugs are moved to arch
 	// r_arch_patch (aop, 0);
 	RArchSession *acur = R_UNWRAP3 (core, rasm, acur);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
