### PR TITLE
Fix arch.riscv.vs plugin (decoding always failed) ##arch

### DIFF
--- a/libr/arch/p/capstone.inc.c
+++ b/libr/arch/p/capstone.inc.c
@@ -76,14 +76,18 @@ static bool r_arch_cs_init(RArchSession *as, csh *cs_handle) {
 	}
 #else
 	if (*cs_handle) {
-		if (as->config->syntax == R_ARCH_SYNTAX_ATT) {
+		switch (as->config->syntax) {
+		case R_ARCH_SYNTAX_ATT:
 			cs_option (*cs_handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_ATT);
+			break;
 #if CS_API_MAJOR >= 4
-		} else if (as->config->syntax == R_ARCH_SYNTAX_MASM) {
+		case R_ARCH_SYNTAX_MASM:
 			cs_option (*cs_handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_MASM);
+			break;
 #endif
-		} else {
+		default:
 			cs_option (*cs_handle, CS_OPT_SYNTAX, CS_OPT_SYNTAX_INTEL);
+			break;
 		}
 	}
 #endif

--- a/libr/arch/p/mcs96/plugin.c
+++ b/libr/arch/p/mcs96/plugin.c
@@ -119,7 +119,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 
 // WORDs must be aligned at even byte boundaries in the address space
 static int archinfo(RArchSession *as, ut32 q) {
-	// R2_590
 	switch (q) {
 	case R_ANAL_ARCHINFO_ALIGN:
 		return 1;

--- a/libr/arch/p/riscv_cs/plugin.c
+++ b/libr/arch/p/riscv_cs/plugin.c
@@ -259,7 +259,7 @@ static void set_opdir(RAnalOp *op) {
 }
 
 #define CSINC RISCV
-#define CSINC_MODE (as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32
+#define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
 #include "../capstone.inc.c"
 
 static bool riscv_decode(RArchSession *a, RAnalOp *op, RArchDecodeMask mask) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
