### PR TITLE
Fix header miscalculation ##bin

### DIFF
--- a/libr/bin/format/p9/p9bin.c
+++ b/libr/bin/format/p9/p9bin.c
@@ -3,7 +3,7 @@
 #include "p9bin.h"
 #include <r_asm.h>
 
-bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
+bool r_bin_p9_get_arch(RBuffer *b, const char **arch, int *bits, int *big_endian) {
 	ut32 header = r_buf_read_be32_at (b, 0);
 	if (header == UT32_MAX) {
 		return false;
@@ -15,14 +15,14 @@ bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
 	switch (header) {
 	case MAGIC_68020:
 		*big_endian = 1;
-		*arch = R_SYS_ARCH_M68K;
+		*arch = "m68k";
 		return true;
 
 	case MAGIC_AMD64:
 		*bits = 64;
 		/* fallthrough */
 	case MAGIC_INTEL_386:
-		*arch = R_SYS_ARCH_X86;
+		*arch = "x86";
 		return true;
 
 	case MAGIC_SPARC64:
@@ -30,7 +30,7 @@ bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
 		/* fallthrough */
 	case MAGIC_SPARC:
 		*big_endian = 1;
-		*arch = R_SYS_ARCH_SPARC;
+		*arch = "sparc";
 		return true;
 
 	case MAGIC_MIPS_4000BE:
@@ -38,21 +38,21 @@ bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
 		/* fallthrough */
 	case MAGIC_MIPS_4000LE:
 		*bits = 64;
-		*arch = R_SYS_ARCH_MIPS;
+		*arch = "mips";
 		return true;
 
 	case MAGIC_MIPS_3000BE:
 		*big_endian = 1;
 		/* fallthrough */
 	case MAGIC_MIPS_3000LE:
-		*arch = R_SYS_ARCH_MIPS;
+		*arch = "mips";
 		return true;
 
 	case MAGIC_ARM64:
 		*bits = 64;
 		/* fallthrough */
 	case MAGIC_ARM:
-		*arch = R_SYS_ARCH_ARM;
+		*arch = "arm";
 		return true;
 
 	case MAGIC_PPC64:
@@ -60,7 +60,7 @@ bool r_bin_p9_get_arch(RBuffer *b, RSysArch *arch, int *bits, int *big_endian) {
 		/* fallthrough */
 	case MAGIC_PPC:
 		*big_endian = 1;
-		*arch = R_SYS_ARCH_PPC;
+		*arch = "ppc";
 		return true;
 	}
 

--- a/libr/bin/format/p9/p9bin.h
+++ b/libr/bin/format/p9/p9bin.h
@@ -62,6 +62,6 @@ typedef struct r_bin_plan9_obj_t {
 #define KERNEL_MASK 0xffff800000000000ULL
 
 /* Reads four bytes from b. */
-bool r_bin_p9_get_arch(R_NONNULL RBuffer *b, R_NONNULL RSysArch *arch, R_NONNULL int *bits, R_NONNULL int *big_endian);
+bool r_bin_p9_get_arch(R_NONNULL RBuffer *b, R_NONNULL const char **arch, R_NONNULL int *bits, R_NONNULL int *big_endian);
 
 #endif


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

We accidentally truncate the final 40 bytes of the text section in regular binaries because we do not consider the header size in the size of the text section on disk. This fixes that.

**Copilot**

<!--
copilot:all
-->
