### PR TITLE
Fix warning spotted in latest gcc failing msvc demangler ##bin

### DIFF
--- a/libr/bin/blang.c
+++ b/libr/bin/blang.c
@@ -131,7 +131,8 @@ static bool check_symbol_lang(RBinFile *bf, LangCheck *lc, RBinSymbol *sym, int 
 				}
 				if (strstr (lib, "msvcp")) {
 					info->lang = "msvc";
-					return R_BIN_LANG_MSVC;
+					*type = R_BIN_LANG_MSVC;
+					return false;
 				}
 			}
 			lc->cxxIsChecked = true;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
