### PR TITLE
Handle more builtin types in the swift demangler and be more flexible ##bin

### DIFF
--- a/libr/bin/demangle.c
+++ b/libr/bin/demangle.c
@@ -129,6 +129,12 @@ R_API char *r_bin_demangle(RBinFile *bf, const char *def, const char *str, ut64 
 			}
 		}
 	}
+	if (r_str_startswith (str, "So") && isdigit (str[2])) {
+		char *ss = r_str_newf ("$s%s", str);
+		char *res = r_bin_demangle (bf, def, ss, vaddr, libs);
+		free (ss);
+		return res;
+	}
 	if (r_str_startswith (str, "__")) {
 		if (str[2] == 'T') {
 			type = R_BIN_LANG_SWIFT;

--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -20,7 +20,12 @@ typedef struct {
 /* basic types */
 static const SwiftType types[] = {
 	{ "Bi1", "Builtin.Int1" },
+	{ "Bb", "Builtin.BridgeObject" },
+	{ "BB", "Builtin.UnsafeValueBuffer" },
+	{ "Bo", "Builtin.NativeObject" },
+	{ "BO", "Builtin.UnknownObject" },
 	{ "Bp", "Builtin.RawPointer" },
+	{ "Bt", "Builtin.SILToken" },
 	{ "Bw", "Builtin.Word" },
 	{ "FS", "String" },
 	{ "GV", "mutableAddressor" },
@@ -37,6 +42,7 @@ static const SwiftType types[] = {
 	{ "Sq", "Optional" },
 	{ "SR", "UnsafeBufferPointer" },
 	{ "Sr", "UnsafeMutableBufferPointer" },
+	{ "So", "ObjC.Symbol" },
 	{ "Ss", "generic" },
 	{ "SS", "Swift.String" },
 	{ "Su", "UInt" },
@@ -611,6 +617,12 @@ R_API char *r_bin_demangle_swift(const char *s, bool syscmd, bool trylib) {
 #if USE_THIS_CODE
 	syscmd = trylib = false; // debugging on macos
 #endif
+	if (r_str_startswith (s, "So") && isdigit (s[2])) {
+		char *ss = r_str_newf ("$s%s", s);
+		char *res = r_bin_demangle_swift (ss, syscmd, trylib);
+		free (ss);
+		return res;
+	}
 	s = str_removeprefix (s, "imp.");
 	s = str_removeprefix (s, "reloc.");
 	// check if string doesnt start with __ then return

--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -180,6 +180,7 @@ static int show_help(const char *argv0, int line) {
 	" -M [str]   set a binary mask to be applied on keywords\n"
 	" -n         do not stop on read errors\n"
 	" -r         print using radare commands\n"
+	// " -R         replace in place every search hit with the given argument\n"
 	" -s [str]   search for a string (more than one string can be passed)\n"
 	" -S [str]   search for a wide string (more than one string can be passed).\n"
 	" -t [to]    stop search at address 'to'\n"


### PR DESCRIPTION

* No _$s prefix is needed when string starts with So#

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
