### PR TITLE
Fix warning when rasm2 fails to load core plugins

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -372,7 +372,7 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 
 	if (!p->handler) {
 		rlibplugin_free (p);
-		return NULL;
+		return -1;
 	}
 
 	int ret = r_lib_run_handler (lib, p, stru);

--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -175,7 +175,7 @@ R_API RLib *r_lib_new(const char *symname, const char *symnamefunc) {
 		for (i = 0; i < R_LIB_TYPE_LAST; i++) {
 			lib->handlers_bytype[i] = NULL;
 		}
-		lib->plugins = r_list_newf (rlibplugin_free);
+		lib->plugins = r_list_newf ((RListFree)rlibplugin_free);
 		lib->plugins_ht = ht_pp_new0 ();
 		lib->symname = strdup (symname? symname: R_LIB_SYMNAME);
 		lib->symnamefunc = strdup (symnamefunc? symnamefunc: R_LIB_SYMFUNC);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Before patch
```
$ rasm2 -a x86 'xor eax,eax'
ERROR: Library handler has failed for '~/.local/share/radare2/plugins/core_ghidra.dylib'
ERROR: Library handler has failed for '/usr/local/lib/radare2/5.8.9/pickle_dec.dylib'
31c0
```

This is because rasm2 does not set up any callbacks for core plugins. So the `p->handler` for core plugins is `NULL` and `r_lib_run_handler` treats this as an error. 

A byproduct of this patch is `p->file` won't leak when the `lib->plugins` `RList` list is free'd. 

I think there are a couple other potential leaks that this patch does not address. Namely using `RLibPlugin->free` on `RLibPlugin->data` and  closing `RLibPlugin->dl_handler` with `r_lib_dl_close`. I want to double check the logic before adding these. A small leak is preferable to a double free.


For reference `RLibPlugin` is seen below.
From: `libr/include/r_lib.h:56 - 66`
```c
typedef struct r_lib_plugin_t {
	int type;
	char *file;
	void *data; /* user pointer */
	struct r_lib_handler_t *handler;
	void *dl_handler; // DL HANDLER
	void (*free)(void *data);
#if 0
	RPluginMeta meta;
#endif
} RLibPlugin;
```