### PR TITLE
Improve asm.offset.relto only via pd ##disasm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -1680,6 +1680,16 @@ static bool cb_color_getter(void *user, RConfigNode *node) {
 	return true;
 }
 
+static bool cb_reloff(void *user, void *data) {
+	// RCore *core = (RCore *) user;
+	RConfigNode *node = (RConfigNode *) data;
+	if (strchr (node->value, '?')) {
+		r_cons_printf ("func\nflag\nmaps\ndmap\nfmap\nsect\nsymb\nlibs\nfile\n");
+		return false;
+	}
+	return true;
+}
+
 static bool cb_decoff(void *user, void *data) {
 	RCore *core = (RCore *) user;
 	RConfigNode *node = (RConfigNode *) data;
@@ -3714,8 +3724,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("asm.offset.segment", "false", &cb_segoff, "show segmented address in prompt (x86-16)");
 	SETICB ("asm.offset.segment.bits", 4, &cb_asm_offset_segment_bits, "segment granularity in bits (x86-16)");
 	SETCB ("asm.offset.base10", "false", &cb_decoff, "show address in base 10 instead of hexadecimal");
-	SETBPREF ("asm.offset.relative", "false", "show relative offsets instead of absolute address in disasm");
-	SETBPREF ("asm.offset.flags", "false", "show relative offsets to flags (not only functions)");
+	SETCB ("asm.offset.relto", "", &cb_reloff, "show offset relative to fun,map,sec,flg");
 	SETBPREF ("asm.offset.focus", "false", "show only the addresses that branch or located at the beginning of a basic block");
 	SETBPREF ("asm.section", "false", "show section name before offset");
 	SETBPREF ("asm.section.perm", "false", "show section permissions in the disasm");

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -149,6 +149,16 @@ typedef struct r_core_times_t {
 #define R_CORE_ASMQJMPS_MAX_LETTERS (26 * 26 * 26 * 26 * 26)
 #define R_CORE_ASMQJMPS_LEN_LETTERS 5
 
+#define RELOFF_TO_FLAG 1
+#define RELOFF_TO_MAPS 2
+#define RELOFF_TO_DMAP 4
+#define RELOFF_TO_FILE 8
+#define RELOFF_TO_FUNC 16
+#define RELOFF_TO_FMAP 32
+#define RELOFF_TO_SECT 64
+#define RELOFF_TO_SYMB 128
+#define RELOFF_TO_LIBS 256
+
 typedef enum r_core_autocomplete_types_t {
 	R_CORE_AUTOCMPLT_DFLT = 0,
 	R_CORE_AUTOCMPLT_FLAG,

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -34,7 +34,7 @@ NAME=pd+reloff+colors
 FILE=bins/elf/analysis/ls-alxchk
 CMDS=<<EOF
 af
-e asm.offset.relative=true
+e asm.offset.relto=fun
 pd 10
 e scr.color=1
 pd 10


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [x] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

## r2ai conclussion

 The patch adds a new option `-e asm.offset.relto` to the `pd` command, which allows users to specify relative offsets for functions, maps, sections, and symbols.

https://github.com/radareorg/radare2/assets/6431515/013e6cb5-c423-438e-be1a-33f7bf0742e0

* Previously known as `bool asm.offset.relative`
* It's now a comma separated string, ..
* Well in fact just the 2 first chars is needed
* Support file, disk, maps, dmap, flag, func, symb, libs

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

## r2ai explain
```
[r2ai:0x100003a38]>> -i /tmp/p Explain this patch, what it does and determine if its a bugfix or new feature
```
  This patch appears to be a bugfix for the `r_core` library. The changes made are:

  1. A new `RELOFF_TO_*` constant is added to the `libr/include/r_core.h` header file, which defines the different types of offsets
  that can be shown in the disassembler.
  2. The `ds_print_offset()` function has been modified to use the new `RELOFF_TO_*` constants instead of the old `asm.offset.relative`
  and `asm.offset.flags` constants.
  3. The `get_reloff()` function has been added to the `libr/core/disasm.c` source file, which is used to get the relative offset of a
  given address based on the current configuration.
  4. The `ds_print_offset()` function now takes an additional argument `delta`, which is used to calculate the absolute offset of the
  address being disassembled.
  5. The `label` variable is now initialized with the result of the `get_reloff()` function, instead of using the old
  `asm.offset.relative` and `asm.offset.flags` constants.

## r2ai 

`[r2ai:0x100003a38]>> which are the new options for asm.offset.relto?`

  The new options added to the `asm.offset` configuration option for `asm.offset.relto` in the patch code are:

  * `RELOFF_TO_FUNC`: shows function offsets
  * `RELOFF_TO_MAPS`: shows map offsets
  * `RELOFF_TO_DMAP`: shows DMAP offsets
  * `RELOFF_TO_FILE`: shows file offsets
  * `RELOFF_TO_FUNC`: shows function offsets
  * `RELOFF_TO_FMAP`: shows function map offsets
  * `RELOFF_TO_SECT`: shows section offsets
  * `RELOFF_TO_SYMB`: shows symbol offsets
  * `RELOFF_TO_LIBS`: shows library offsets

  These new options allow the user to customize the types of offsets that are shown in the disassembler, depending on their needs. For
  example, a user might want to show only function offsets when debugging a specific function, or show map offsets when working with a
  particular type of file. By adding these new options, the patch makes it easier for users to customize the disassembler's behavior to
  suit their needs.

