### PR TITLE
Fix bug in r_str_split_list ##util

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3477,6 +3477,7 @@ R_API RList *r_str_split_list(char *str, const char *c, int n)  {
 	char *aux = str; // XXX should be an strdup
 	int i = 0;
 	char *e = aux;
+	const size_t clen = strlen (c);
 	for (;e;) {
 		e = strstr (aux, c);
 		if (n > 0) {
@@ -3486,7 +3487,8 @@ R_API RList *r_str_split_list(char *str, const char *c, int n)  {
 			}
 		}
 		if (e) {
-			*e++ =  0;
+			*e = 0;
+			e += clen;
 		}
 		r_str_trim (aux);
 		r_list_append (lst, aux);


### PR DESCRIPTION
bug happened when strlen (c) > 1

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
