### PR TITLE
Split r_core_cmd_help_match and add r_core_cmd_help_contains

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -420,12 +420,20 @@ R_API void r_core_cmd_help(const RCore *core, RCoreHelpMessage help) {
 	r_cons_cmd_help (help, core->print->flags & R_PRINT_FLAGS_COLOR);
 }
 
-R_API void r_core_cmd_help_match(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd, bool exact) {
-	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0, exact);
+R_API void r_core_cmd_help_match(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0, true);
 }
 
-R_API void r_core_cmd_help_match_spec(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd, char spec, bool exact) {
-	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec, exact);
+R_API void r_core_cmd_help_contains(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, 0, false);
+}
+
+R_API void r_core_cmd_help_match_spec(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd, char spec) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec, true);
+}
+
+R_API void r_core_cmd_help_contains_spec(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd, char spec) {
+	r_cons_cmd_help_match (help, core->print->flags & R_PRINT_FLAGS_COLOR, cmd, spec, false);
 }
 
 struct duplicate_flag_t {
@@ -637,7 +645,7 @@ static int cmd_uniq(void *data, const char *input) { // "uniq"
 	}
 	switch (*input) {
 	case '?': // "uniq?"
-		r_core_cmd_help_match (core, help_msg_u, "uniq", true);
+		r_core_cmd_help_match (core, help_msg_u, "uniq");
 		break;
 	default: // "uniq"
 		if (!arg) {
@@ -713,7 +721,7 @@ static int cmd_undo(void *data, const char *input) {
 				RCoreUndo *undo = r_core_undo_new (core->offset, cmd, rcmd);
 				r_core_undo_push (core, undo);
 			} else {
-				r_core_cmd_help_match (core, help_msg_uc, "uc", true);
+				r_core_cmd_help_match (core, help_msg_uc, "uc");
 			}
 			free (cmd);
 			}
@@ -967,7 +975,7 @@ static void cmd_remote(RCore *core, const char *input, bool retry) {
 		return;
 	}
 	if (*input == '?') {
-		r_core_cmd_help_match (core, help_msg_equal, "=r", true);
+		r_core_cmd_help_match (core, help_msg_equal, "=r");
 		return;
 	}
 	char *host = strdup (input);
@@ -1210,12 +1218,12 @@ static int cmd_yank(void *data, const char *input) {
 				}
 				free (out);
 			} else {
-				r_core_cmd_help_match (core, help_msg_y, "ywx", true);
+				r_core_cmd_help_match (core, help_msg_y, "ywx");
 			}
 			// r_core_yank_write_hex (core, input + 2);
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_y, "ywx", true);
+			r_core_cmd_help_match (core, help_msg_y, "ywx");
 			break;
 		}
 		break;
@@ -1238,7 +1246,7 @@ static int cmd_yank(void *data, const char *input) {
 			if (*file == '$') {
 				r_cmd_alias_set_raw (core->rcmd, file+1, tmp, tmpsz);
 			} else if (*file == '?' || !*file) {
-				r_core_cmd_help_match (core, help_msg_y, "ytf", true);
+				r_core_cmd_help_match (core, help_msg_y, "ytf");
 			} else {
 				if (!r_file_dump (file, tmp, tmpsz, false)) {
 					R_LOG_ERROR ("Cannot dump to '%s'", file);
@@ -1247,7 +1255,7 @@ static int cmd_yank(void *data, const char *input) {
 		} else if (input[1] == ' ') {
 			r_core_yank_to (core, input + 1);
 		} else {
-			r_core_cmd_help_match (core, help_msg_y, "yt", false);
+			r_core_cmd_help_contains (core, help_msg_y, "yt");
 		}
 		break;
 	case 'f': // "yf"
@@ -1262,7 +1270,7 @@ static int cmd_yank(void *data, const char *input) {
 			r_core_yank_file_all (core, input + 2);
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_y, "yf", false);
+			r_core_cmd_help_contains (core, help_msg_y, "yf");
 			break;
 		}
 		break;
@@ -1600,7 +1608,7 @@ static int cmd_l(void *data, const char *input) { // "l"
 	switch (*input) {
 	case 'l': // "ll"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_l, "ll", true);
+			r_core_cmd_help_match (core, help_msg_l, "ll");
 			break;
 		}
 		{
@@ -1616,14 +1624,14 @@ static int cmd_l(void *data, const char *input) { // "l"
 		break;
 	case 'e': // "le"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_l, "le", true);
+			r_core_cmd_help_match (core, help_msg_l, "le");
 			break;
 		}
 
 		if (*arg) {
 			r_core_cmdf (core, "cat %s~..", arg);
 		} else {
-			r_core_cmd_help_match (core, help_msg_l, "le", true);
+			r_core_cmd_help_match (core, help_msg_l, "le");
 		}
 		break;
 	case 'i': // "li"
@@ -1631,7 +1639,7 @@ static int cmd_l(void *data, const char *input) { // "l"
 		break;
 	case 'r': // "lr"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_l, "lr", true);
+			r_core_cmd_help_match (core, help_msg_l, "lr");
 			break;
 		}
 		cmd_lr (core, arg);
@@ -1650,7 +1658,7 @@ static int cmd_l(void *data, const char *input) { // "l"
 		break;
 	case 's': // "ls"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_l, "ls", true);
+			r_core_cmd_help_match (core, help_msg_l, "ls");
 			break;
 		}
 		if (r_fs_check (core->fs, arg)) {
@@ -1739,7 +1747,7 @@ static int cmd_join(void *data, const char *input) { // "join"
 				r_core_cmdf (core, "#!pipe node -e '%s'", input + 1);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_j, "js", false);
+			r_core_cmd_help_contains (core, help_msg_j, "js");
 		}
 		return R_CMD_RC_SUCCESS;
 	}
@@ -2144,7 +2152,7 @@ static int cmd_table(void *data, const char *input) {
 		break;
 	case '.': // ",."
 		if (R_STR_ISEMPTY (input + 1)) {
-			r_core_cmd_help_match (core, help_msg_comma, ",.", true);
+			r_core_cmd_help_match (core, help_msg_comma, ",.");
 		} else {
 			const char *file = r_str_trim_head_ro (input + 1);
 			if (*file == '$' && !file[1]) {
@@ -2274,7 +2282,7 @@ static int cmd_interpret(void *data, const char *input) {
 		break;
 	case '-': // ".-"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_dot, ".-", true);
+			r_core_cmd_help_match (core, help_msg_dot, ".-");
 		} else {
 			r_core_run_script (core, "-");
 		}
@@ -2551,7 +2559,7 @@ static int cmd_kuery(void *data, const char *input) {
 			}
 			free (fn);
 		} else {
-			r_core_cmd_help_match (core, help_msg_k, "ko", true);
+			r_core_cmd_help_match (core, help_msg_k, "ko");
 		}
 		break;
 	case 'd': // "kd"
@@ -2576,7 +2584,7 @@ static int cmd_kuery(void *data, const char *input) {
 			}
 			free (fn);
 		} else {
-			r_core_cmd_help_match (core, help_msg_k, "kd", true);
+			r_core_cmd_help_match (core, help_msg_k, "kd");
 		}
 		break;
 	case '?':
@@ -2618,7 +2626,7 @@ static int cmd_bsize(void *data, const char *input) {
 			r_core_cmd_call (core, cmd);
 			free (cmd);
 		} else {
-			r_core_cmd_help_match (core, help_msg_b, "b64:", false);
+			r_core_cmd_help_contains (core, help_msg_b, "b64:");
 		}
 		break;
 	case 'm': // "bm"
@@ -2646,7 +2654,7 @@ static int cmd_bsize(void *data, const char *input) {
 				R_LOG_ERROR ("bf: cannot find flag named '%s'", input + 2);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_b, "bf", true);
+			r_core_cmd_help_match (core, help_msg_b, "bf");
 		}
 		break;
 	case 'j': { // "bj"
@@ -2740,7 +2748,7 @@ static bool cmd_r2cmd(RCore *core, const char *_input) {
 static int cmd_rebase(RCore *core, const char *input) {
 	ut64 addr = r_num_math (core->num, input);
 	if (!addr) {
-		r_core_cmd_help_match (core, help_msg_r, "rb", true);
+		r_core_cmd_help_match (core, help_msg_r, "rb");
 		return 0;
 	}
 	// old base = addr
@@ -2782,7 +2790,7 @@ static int cmd_resize(void *data, const char *input) {
 				const char *file = r_str_trim_head_ro (input + 3);
 				return r_file_rm_rf (file);
 			}
-			r_core_cmd_help_match (core, help_msg_r, "rmrf", true);
+			r_core_cmd_help_match (core, help_msg_r, "rmrf");
 			return false;
 		}
 		if (input[1] == ' ') {
@@ -2793,7 +2801,7 @@ static int cmd_resize(void *data, const char *input) {
 				r_file_rm (file);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_r, "rm", false);
+			r_core_cmd_help_contains (core, help_msg_r, "rm");
 		}
 		return true;
 	case '\0':
@@ -2956,7 +2964,7 @@ static int cmd_panels(void *data, const char *input) {
 static int cmd_visual(void *data, const char *input) {
 	RCore *core = (RCore*) data;
 	if (*input == '?') { // "mL?"
-		r_core_cmd_help_match_spec (core, help_msg_root, "V", 0, true);
+		r_core_cmd_help_match_spec (core, help_msg_root, "V", 0);
 		return true;
 	}
 	if (core->http_up) {
@@ -3276,8 +3284,8 @@ static int cmd_system(void *data, const char *input) {
 		break;
 	case '=': //!=
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_exclamation, "!=!", true);
-			r_core_cmd_help_match (core, help_msg_exclamation, "=!=", true);
+			r_core_cmd_help_match (core, help_msg_exclamation, "!=!");
+			r_core_cmd_help_match (core, help_msg_exclamation, "=!=");
 		} else {
 			if (!r_sandbox_enable (0)) {
 				R_FREE (core->cmdremote);
@@ -4806,7 +4814,7 @@ repeat_arroba:
 					}
 					is_arch_set = set_tmp_arch (core, ptr + 2, &tmpasm);
 				} else {
-					r_core_cmd_help_match (core, help_msg_at, "@a:", true);
+					r_core_cmd_help_match (core, help_msg_at, "@a:");
 				}
 				break;
 			case 's': // "@s:" // wtf syntax
@@ -4927,7 +4935,7 @@ next_arroba:
 				char *range = ptr + 2;
 				char *p = strchr (range, ' ');
 				if (!p) {
-					r_core_cmd_help_match (core, help_msg_at, "@{", true);
+					r_core_cmd_help_match (core, help_msg_at, "@{");
 					free (tmpeval);
 					free (tmpasm);
 					free (tmpbits);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -1353,7 +1353,7 @@ static void find_refs(RCore *core, const char *glob) {
 		glob = "str.";
 	}
 	if (*glob == '?') {
-		r_core_cmd_help_match (core, help_msg_ax, "axF", true);
+		r_core_cmd_help_match (core, help_msg_ax, "axF");
 		return;
 	}
 	R_LOG_WARN ("Finding references of flags matching '%s'", glob);
@@ -4236,7 +4236,7 @@ static void cmd_afbc(RCore *core, const char *input) {
 		return;
 	}
 	if (*ptr == '?') {
-		r_core_cmd_help_match (core, help_msg_afb, "afbc", true);
+		r_core_cmd_help_match (core, help_msg_afb, "afbc");
 	} else if (!*ptr) {
 		RAnalBlock *bb = r_anal_get_block_at (core->anal, core->offset);
 		if (bb && (bb->color.r || bb->color.g || bb->color.b)) {
@@ -4501,7 +4501,7 @@ static void cmd_afci(RCore *core, RAnalFunction *fcn) {
 static void cmd_afix(RCore *core, const char *input) {
 	switch (input[3]) {
 	case '?': // "afix?"
-		r_core_cmd_help_match (core, help_msg_afi, "afix", false);
+		r_core_cmd_help_contains (core, help_msg_afi, "afix");
 		break;
 	case 'q': // "afixq"
 	case 'j': // "afixj"
@@ -4788,7 +4788,7 @@ static int cmd_af(RCore *core, const char *input) {
 		{
 		ut64 addr = 0;
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_af, "afd", true);
+			r_core_cmd_help_match (core, help_msg_af, "afd");
 		} else if (input[2] == ' ') {
 			addr = r_num_math (core->num, input + 2);
 		} else {
@@ -4927,7 +4927,7 @@ static int cmd_af(RCore *core, const char *input) {
 	case 'o': // "afo"
 		switch (input[2]) {
 		case '?':
-			r_core_cmd_help_match (core, help_msg_af, "afo", true);
+			r_core_cmd_help_match (core, help_msg_af, "afo");
 			break;
 		case 'j':
 			{
@@ -5312,7 +5312,7 @@ static int cmd_af(RCore *core, const char *input) {
 		}
 		case 'v': // "afsv"
 			if (strchr (input, '?')) {
-				r_core_cmd_help_match (core, help_msg_af, "afsv", true);
+				r_core_cmd_help_match (core, help_msg_af, "afsv");
 			} else if (input[3] == 'j') { // "afsvj"
 				ut64 pc = core->offset;
 				if (input[4] == ' ') {
@@ -5397,7 +5397,7 @@ static int cmd_af(RCore *core, const char *input) {
 			if (input[3] == 'j') {
 				r_core_cmd_call (core, "afcfj");
 			} else if (input[3] == '?') {
-				r_core_cmd_help_match (core, help_msg_afc, "afci", true);
+				r_core_cmd_help_match (core, help_msg_afc, "afci");
 			} else {
 				cmd_afci (core, fcn);
 			}
@@ -5407,7 +5407,7 @@ static int cmd_af(RCore *core, const char *input) {
 			break;
 		case 'k': // "afck"
 			if (input[3] == '?') {
-				r_core_cmd_help_match (core, help_msg_afc, "afck", true);
+				r_core_cmd_help_match (core, help_msg_afc, "afck");
 			} else {
 				cmd_afck (core, NULL);
 			}
@@ -5429,7 +5429,7 @@ static int cmd_af(RCore *core, const char *input) {
 						  sdb_free (db);
 					  }
 				  } else {
-					  r_core_cmd_help_match (core, help_msg_afc, "afco", true);
+					  r_core_cmd_help_match (core, help_msg_afc, "afco");
 				  }
 				  free (dbpath);
 			  }
@@ -5546,7 +5546,7 @@ static int cmd_af(RCore *core, const char *input) {
 				R_LOG_ERROR ("afB: Cannot find function to set bits at 0x%08"PFMT64x, core->offset);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_af, "afB", true);
+			r_core_cmd_help_match (core, help_msg_af, "afB");
 		}
 		break;
 	case 'b': // "afb"
@@ -5643,7 +5643,7 @@ static int cmd_af(RCore *core, const char *input) {
 				off = r_num_math (core->num, p);
 			}
 			if (*name == '?') {
-				r_core_cmd_help_match (core, help_msg_afn, "afn", true);
+				r_core_cmd_help_match (core, help_msg_afn, "afn");
 			} else {
 				if (r_str_startswith (name, "base64:")) {
 					char *res = (char *)r_base64_decode_dyn (name + 7, -1);
@@ -6074,7 +6074,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 //				r_core_cmd0 (core, "ar A0,A1,A2,A3");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_af, "afA", true);
+			r_core_cmd_help_match (core, help_msg_af, "afA");
 		}
 		break;
 	case 'C': // "arC"
@@ -6138,7 +6138,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 	case 'r': // "arr"
 		switch (str[1]) {
 		case '?':
-			r_core_cmd_help_match (core, help_msg_dr, "drr", false);
+			r_core_cmd_help_contains (core, help_msg_dr, "drr");
 			break;
 		case 'j': // "arrj"
 			r_core_debug_rr (core, core->anal->reg, 'j');
@@ -6156,7 +6156,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 		} break;
 	case 'b':
 		if (str[1] == '?') { // "arb" WORK IN PROGRESS // DEBUG COMMAND
-			r_core_cmd_help_match (core, help_msg_ar, "arb", false);
+			r_core_cmd_help_contains (core, help_msg_ar, "arb");
 		} else {
 			int len, type = R_REG_TYPE_GPR;
 			arg = strchr (str, ' ');
@@ -6273,7 +6273,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 		break;
 	case 't': // "art"
 		if (str[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_dr, "drt", false);
+			r_core_cmd_help_contains (core, help_msg_dr, "drt");
 		} else {
 			for (i = 0; (name = r_reg_get_type (i)); i++) {
 				r_cons_println (name);
@@ -6828,7 +6828,7 @@ static void cmd_anal_info(RCore *core, const char *input) {
 			} else if (input[1] == '-') {
 				r_anal_purge_imports (core->anal);
 			} else {
-				r_core_cmd_help_match (core, help_msg_ai, "aii", true);
+				r_core_cmd_help_match (core, help_msg_ai, "aii");
 			}
 		} else {
 			if (core->anal->imports) {
@@ -7928,7 +7928,7 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 				reg_name_roll_set (core, "PC", r_num_math (core->num, input + 3));
 				r_core_cmd0 (core, ".ar*");
 			} else {
-				r_core_cmd_help_match (core, help_msg_aep, "aepc", true);
+				r_core_cmd_help_match (core, help_msg_aep, "aepc");
 			}
 			break;
 		case 'k':
@@ -8028,14 +8028,14 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 				ut64 nth = n2? r_num_math (core->num, n2): 1;
 				cmd_aespc (core, core->offset, off, (int)nth);
 			} else {
-				r_core_cmd_help_match (core, help_msg_aes, "aesB", true);
+				r_core_cmd_help_match (core, help_msg_aes, "aesB");
 			}
 			break;
 		case 'u': // "aesu"
 			until_expr = NULL;
 			until_addr = UT64_MAX;
 			if (r_str_endswith (input, "?")) {
-				r_core_cmd_help_match (core, help_msg_aes, "aesu", true);
+				r_core_cmd_help_match (core, help_msg_aes, "aesu");
 			} else switch (input[2]) {
 			case 'e': // "aesue"
 				until_expr = r_str_trim_head_ro (input + 3);
@@ -8085,14 +8085,14 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 				r_anal_op_free (op);
 				r_core_cmd0 (core, ".ar*");
 			} else {
-				r_core_cmd_help_match (core, help_msg_aes, "aesou", true);
+				r_core_cmd_help_match (core, help_msg_aes, "aesou");
 			}
 			break;
 		case 'p': //"aesp"
 			n = strchr (input, ' ');
 			n1 = R_STR_ISNOTEMPTY (n) ? strchr (n + 1, ' ') : NULL;
 			if ((!n || !n1) || (!*n || !*n1)) {
-				r_core_cmd_help_match (core, help_msg_aes, "aesp", true);
+				r_core_cmd_help_match (core, help_msg_aes, "aesp");
 				break;
 			}
 			adr = R_STR_ISNOTEMPTY (n)? r_num_math (core->num, n + 1): 0;
@@ -8371,7 +8371,7 @@ static void cmd_anal_esil(RCore *core, const char *input, bool verbose) {
 	case 't': // "aet"
 		switch (input[1]) {
 		case '?':
-			r_core_cmd_help_match (core, help_msg_ae, "aet", false);
+			r_core_cmd_help_contains (core, help_msg_ae, "aet");
 			break;
 		case 's': // "aets"
 			switch (input[2]) {
@@ -8923,7 +8923,7 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 				input++;
 				break;
 			case '?': // "aoe?"
-				r_core_cmd_help_match (core, help_msg_ao, "aoe", false);
+				r_core_cmd_help_contains (core, help_msg_ao, "aoe");
 				return;
 			}
 		}
@@ -9063,7 +9063,7 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 				R_LOG_ERROR ("Unknown mnemonic");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_ao, "aod", false);
+			r_core_cmd_help_contains (core, help_msg_ao, "aod");
 		}
 		break;
 	case '*':
@@ -10336,7 +10336,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 	case ' ': // "ax "
 		if (input[1] == '?') {
 			char *s = r_str_newf ("ax%c", input[0]);
-			r_core_cmd_help_match (core, help_msg_ax, s, true);
+			r_core_cmd_help_match (core, help_msg_ax, s);
 			free (s);
 		} else {
 			char *ptr = strdup (r_str_trim_head_ro ((char *)input + 1));
@@ -10559,7 +10559,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 		} else if (input[1] == '-') {
 			r_anal_hint_unset_syntax (core->anal, core->offset);
 		} else {
-			r_core_cmd_help_match (core, help_msg_ah, "ahS", true);
+			r_core_cmd_help_match (core, help_msg_ah, "ahS");
 		}
 		break;
 	case 'd': // "ahd" set opcode string
@@ -10568,7 +10568,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 		} else if (input[1] == '-') {
 			r_anal_hint_unset_opcode (core->anal, core->offset);
 		} else {
-			r_core_cmd_help_match (core, help_msg_ah, "ahd", true);
+			r_core_cmd_help_match (core, help_msg_ah, "ahd");
 		}
 		break;
 	case 'e': // "ahe" set ESIL string
@@ -10577,7 +10577,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 		} else if (input[1] == '-') {
 			r_anal_hint_unset_esil (core->anal, core->offset);
 		} else {
-			r_core_cmd_help_match (core, help_msg_ah, "ahe", true);
+			r_core_cmd_help_match (core, help_msg_ah, "ahe");
 		}
 		break;
 #if 0
@@ -13112,7 +13112,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			cmd_anal_calls (core, input + 1, input[2] == '*', true);
 			break;
 		case '?': // "aac?"
-			r_core_cmd_help_match (core, help_msg_aa, "aac", false);
+			r_core_cmd_help_contains (core, help_msg_aa, "aac");
 			break;
 		default: // "aac"
 			cmd_anal_calls (core, input + 1, false, false);
@@ -13121,14 +13121,14 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 'j': // "aaj"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aaj", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aaj");
 		} else {
 			cmd_anal_jumps (core, input + 1);
 		}
 		break;
 	case 'd': // "aad"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aad", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aad");
 		} else {
 			cmd_anal_aad (core, input);
 		}
@@ -13142,28 +13142,28 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 'w': // "aaw"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aaw", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aaw");
 		} else {
 			cmd_anal_aaw (core, input);
 		}
 		break;
 	case 'u': // "aau" - print areas not covered by functions
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aau", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aau");
 		} else {
 			r_core_anal_nofunclist (core, input + 1);
 		}
 		break;
 	case 'i': // "aai"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aai", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aai");
 		} else {
 			r_core_anal_info (core, input + 1);
 		}
 		break;
 	case 's': // "aas"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aas", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aas");
 		} else {
 			r_core_cmd0 (core, "af @@= `isq~[0]`");
 			r_core_cmd0 (core, "af @@f:entry*");
@@ -13171,7 +13171,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 'S': // "aaS"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aaS", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aaS");
 		} else {
 			r_core_cmd0 (core, "af @@f:sym.*");
 			r_core_cmd0 (core, "af @@f:entry*");
@@ -13181,7 +13181,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		if (!input[1] || input[1] == ' ' || input[1] == 'a') {
 			r_core_anal_inflags (core, input + 1);
 		} else {
-			r_core_cmd_help_match (core, help_msg_aa, "aaF", false);
+			r_core_cmd_help_contains (core, help_msg_aa, "aaF");
 		}
 		break;
 	case 'n': // "aan"
@@ -13202,7 +13202,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 'p': // "aap"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aap", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aap");
 		} else {
 			r_core_search_preludes (core, true);
 		}
@@ -13448,7 +13448,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 't': // "aat"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_aa, "aat", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aat");
 		} else {
 			char *off = input[1]? r_str_trim_dup (input + 2): NULL;
 			RAnalFunction *fcn;
@@ -13481,7 +13481,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 		break;
 	case 'o': // "aao"
 		if (input[1] == '?') { // "aao?"
-			r_core_cmd_help_match (core, help_msg_aa, "aao", true);
+			r_core_cmd_help_match (core, help_msg_aa, "aao");
 		} else {
 			cmd_anal_objc (core, input + 1, false);
 		}
@@ -13489,7 +13489,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 	case 'e': // "aae"
 		if (input[1] == 'f') { // "aaef"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_aae, "aaef", true);
+				r_core_cmd_help_match (core, help_msg_aae, "aaef");
 			} else {
 				r_core_cmd0 (core, "aeim");
 				RListIter *it;
@@ -13506,7 +13506,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 			r_core_cmd_help (core, help_msg_aae);
 		} else if (input[1] == 'p') { // "aaep" // auto define all esil pins
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_aae, "aaef", true);
+				r_core_cmd_help_match (core, help_msg_aae, "aaef");
 			} else {
 				r_core_cmd0 (core, "aep ret0@@@i");
 				r_core_cmd0 (core, "aepa@@@i");
@@ -14234,7 +14234,7 @@ static void cmd_anal_aC(RCore *core, const char *input) {
 
 static bool core_anal_abf(RCore *core, const char* input) {
 	if (strchr (input, '?')) {
-		r_core_cmd_help_match (core, help_msg_ab, "abf", true);
+		r_core_cmd_help_match (core, help_msg_ab, "abf");
 		return false;
 	}
 	ut64 addr = r_num_math (core->num, input);
@@ -14296,7 +14296,7 @@ static void match_prelude(RCore *core, const char *input) {
 static int cmd_apt(RCore *core, const char *input) {
 	switch (*input) {
 	case '?':
-		r_core_cmd_help_match (core, help_msg_ap, "apt", false);
+		r_core_cmd_help_contains (core, help_msg_ap, "apt");
 		break;
 	case '=':
 	case ' ':
@@ -14402,7 +14402,7 @@ static int cmd_anal(void *data, const char *input) {
 			{
 				const char *arg = r_str_trim_head_ro (input + 2);
 				if (*arg == '?') {
-					r_core_cmd_help_match (core, help_msg_ab, "abe", true);
+					r_core_cmd_help_match (core, help_msg_ab, "abe");
 				} else {
 					RListIter *iter;
 					RAnalBlock *bb;

--- a/libr/core/cmd_cmp.inc.c
+++ b/libr/core/cmd_cmp.inc.c
@@ -518,7 +518,7 @@ static int cmd_cmp_watcher(RCore *core, const char *input) {
 				R_LOG_ERROR ("Failed to add watcher");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_cw, "cw ", true);
+			r_core_cmd_help_match (core, help_msg_cw, "cw ");
 		}
 out_free_argv:
 		r_str_argv_free (argv);
@@ -526,7 +526,7 @@ out_free_argv:
 	}
 	case 'd': // "cwd"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_cw, "cwd", true);
+			r_core_cmd_help_match (core, help_msg_cw, "cwd");
 			return 0;
 		}
 		if (input[1]) {
@@ -542,7 +542,7 @@ out_free_argv:
 		break;
 	case 'r': // "cwr"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_cw, "cwr", true);
+			r_core_cmd_help_match (core, help_msg_cw, "cwr");
 			return 0;
 		}
 
@@ -562,7 +562,7 @@ out_free_argv:
 		break;
 	case 'u': // "cwu"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_cw, "cwu", true);
+			r_core_cmd_help_match (core, help_msg_cw, "cwu");
 			return 0;
 		}
 		if (input[1]) {
@@ -1009,7 +1009,7 @@ static void cmd_curl(RCore *core, const char *arg) {
 				free (s);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_cu, "curl", true);
+			r_core_cmd_help_match (core, help_msg_cu, "curl");
 		}
 	}
 }
@@ -1093,10 +1093,10 @@ static int cmd_cmp(void *data, const char *input) {
 					}
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_c, "cat", true);
+				r_core_cmd_help_match (core, help_msg_c, "cat");
 			}
 		} else { // "ca"
-			r_core_cmd_help_match (core, help_msg_c, "cat", true);
+			r_core_cmd_help_match (core, help_msg_c, "cat");
 		}
 		break;
 	case 'w':
@@ -1104,7 +1104,7 @@ static int cmd_cmp(void *data, const char *input) {
 		break;
 	case '*': // "c*"
 		if (!input[2]) {
-			r_core_cmd_help_match (core, help_msg_c, "c*", true);
+			r_core_cmd_help_match (core, help_msg_c, "c*");
 			return 0;
 		}
 
@@ -1120,7 +1120,7 @@ static int cmd_cmp(void *data, const char *input) {
 	}
 	case 'j': // "cj"
 		if (input[1] != ' ') {
-			r_core_cmd_help_match (core, help_msg_c, "cj", true);
+			r_core_cmd_help_match (core, help_msg_c, "cj");
 		} else {
 			char *str = strdup (input + 2);
 			int len = r_str_unescape (str);
@@ -1136,14 +1136,14 @@ static int cmd_cmp(void *data, const char *input) {
 			break;
 		case '*':
 			if (input[2] != ' ') {
-				r_core_cmd_help_match (core, help_msg_c, "cx*", true);
+				r_core_cmd_help_match (core, help_msg_c, "cx*");
 				return 0;
 			}
 			mode = '*';
 			input += 3;
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_c, "cx", true);
+			r_core_cmd_help_match (core, help_msg_c, "cx");
 			return 0;
 		}
 		if (!(filled = (char *) malloc (strlen (input) + 1))) {
@@ -1264,14 +1264,14 @@ static int cmd_cmp(void *data, const char *input) {
 		arg = *input? r_str_trim_head_ro (input + 1): NULL;
 
 		if (input[0] == '?' || R_STR_ISEMPTY (arg)) {
-			r_core_cmd_help_match_spec (core, help_msg_c, "c", width, true);
+			r_core_cmd_help_match_spec (core, help_msg_c, "c", width);
 			break;
 		}
 
 		if (width == '1') {
 			if (mode == '*') {
 				R_LOG_ERROR ("c1 does not support * mode");
-				r_core_cmd_help_match (core, help_msg_c, "c1", true);
+				r_core_cmd_help_match (core, help_msg_c, "c1");
 			} else {
 				val = cmp_bits (core, r_num_math (core->num, arg));
 			}
@@ -1289,7 +1289,7 @@ static int cmd_cmp(void *data, const char *input) {
 	}
 	case 'c': // "cc"
 		if (input[1] == '?') { // "cc?"
-			r_core_cmd_help_match (core, help_msg_c, "cc", false);
+			r_core_cmd_help_contains (core, help_msg_c, "cc");
 		} else if (input[1] == 'd') { // "ccd"
 			if (input[2] == 'd') { // "ccdd"
 				cmd_cmp_disasm (core, input + 3, 'd');
@@ -1333,7 +1333,7 @@ static int cmd_cmp(void *data, const char *input) {
 			if (*file2) {
 				r_anal_diff_setup (core->anal, true, -1, -1);
 			} else {
-				r_core_cmd_help_match (core, help_msg_cg, "cgo", true);
+				r_core_cmd_help_match (core, help_msg_cg, "cgo");
 				return false;
 			}
 			break;
@@ -1483,7 +1483,7 @@ static int cmd_cmp(void *data, const char *input) {
 			r_core_return_value (core, 1);
 			// fallthrough
 		case '?':
-			r_core_cmd_help_match (core, help_msg_c, "cv", true);
+			r_core_cmd_help_match (core, help_msg_c, "cv");
 			break;
 		}
 	}
@@ -1499,7 +1499,7 @@ static int cmd_cmp(void *data, const char *input) {
 			default: sz = '4'; break; // default
 			}
 		} else if (sz == '?') {
-			r_core_cmd_help_match (core, help_msg_c, "cV", true);
+			r_core_cmd_help_match (core, help_msg_c, "cV");
 		}
 		sz -= '0';
 		if (sz > 0) {

--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -888,7 +888,7 @@ static bool step_until_optype(RCore *core, const char *_optypes) {
 	st64 maxsteps = r_config_get_i (core->config, "esil.maxsteps");
 	ut64 countsteps = 0;
 	if (R_STR_ISEMPTY (optypes)) {
-		r_core_cmd_help_match (core, help_msg_dsu, "dsuo", true);
+		r_core_cmd_help_match (core, help_msg_dsu, "dsuo");
 		res = false;
 		goto end;
 	}
@@ -1122,7 +1122,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 			break;
 		case '?': // "dpt?"
 		default:
-			r_core_cmd_help_match (core, help_msg_dp, "dpt", false);
+			r_core_cmd_help_contains (core, help_msg_dp, "dpt");
 			break;
 		}
 		break;
@@ -1602,7 +1602,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 	switch (input[0]) {
 	case 's': // "dms"
 		if (strchr (input, '?')) {
-			r_core_cmd_help_match (core, help_msg_dm, "dms", false);
+			r_core_cmd_help_contains (core, help_msg_dm, "dms");
 		}
 		cmd_debug_map_snapshot (core, input+1);
 		break;
@@ -1670,13 +1670,13 @@ static int cmd_debug_map(RCore *core, const char *input) {
 		case 0: return dump_maps (core, -1, NULL);
 		case '?':
 		default:
-			r_core_cmd_help_match (core, help_msg_dm, "dmd", true);
+			r_core_cmd_help_match (core, help_msg_dm, "dmd");
 			break;
 		}
 		break;
 	case 'l': // "dml"
 		if (input[1] != ' ') {
-			r_core_cmd_help_match (core, help_msg_dm, "dml", true);
+			r_core_cmd_help_match (core, help_msg_dm, "dml");
 			return false;
 		}
 		r_debug_map_sync (core->dbg); // update process memory maps
@@ -1936,14 +1936,14 @@ static int cmd_debug_map(RCore *core, const char *input) {
 				size = r_num_math (core->num, p);
 				r_debug_map_alloc (core->dbg, addr, size, false);
 			} else {
-				r_core_cmd_help_match (core, help_msg_dm, "dm", true);
+				r_core_cmd_help_match (core, help_msg_dm, "dm");
 				return false;
 			}
 		}
 		break;
 	case '-': // "dm-"
 		if (input[1] != ' ') {
-			r_core_cmd_help_match (core, help_msg_dm, "dm-", true);
+			r_core_cmd_help_match (core, help_msg_dm, "dm-");
 			break;
 		}
 		addr = r_num_math (core->num, input + 2);
@@ -1966,7 +1966,7 @@ static int cmd_debug_map(RCore *core, const char *input) {
 				size = r_num_math (core->num, p);
 				r_debug_map_alloc (core->dbg, addr, size, true);
 			} else {
-				r_core_cmd_help_match (core, help_msg_dm, "dmL", true);
+				r_core_cmd_help_match (core, help_msg_dm, "dmL");
 				return false;
 			}
 		}
@@ -2241,7 +2241,7 @@ static void cmd_reg_profile(RCore *core, char from, const char *str) { // "arp" 
 				R_LOG_WARN ("Cannot parse gdb profile");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_drp, "drpg", true);
+			r_core_cmd_help_match (core, help_msg_drp, "drpg");
 		}
 		break;
 	case ' ': // "drp " "arp "
@@ -2787,7 +2787,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 					r_debug_reg_sync (core->dbg, R_REG_TYPE_DRX, true);
 			        }
 			} else {
-				r_core_cmd_help_match (core, help_msg_dr, "drx", true);
+				r_core_cmd_help_match (core, help_msg_dr, "drx");
 			}
 			free (s);
 			}
@@ -2962,7 +2962,7 @@ static void cmd_debug_reg(RCore *core, const char *str) {
 	case 'f': // "drf"
 		//r_debug_drx_list (core->dbg);
 		if (str[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_dr, "drf", true);
+			r_core_cmd_help_match (core, help_msg_dr, "drf");
 		} else if (str[1] == ' ') {
 			char *p, *name = strdup (str + 2);
 			char *eq = strchr (name, '=');
@@ -3492,10 +3492,10 @@ static void core_cmd_dbi(RCore *core, const char *input, const ut64 idx) {
 					R_LOG_ERROR ("Cannot set command");
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_db, "dbic", true);
+				r_core_cmd_help_match (core, help_msg_db, "dbic");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_db, "dbic", true);
+			r_core_cmd_help_match (core, help_msg_db, "dbic");
 		}
 		break;
 	case 'e': // "dbie"
@@ -3849,7 +3849,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			st64 delta = 0;
 			char *sdelta = (char *)r_str_lchr (module, ' ');
 			if (!sdelta) {
-				r_core_cmd_help_match (core, help_msg_db, "dbm", true);
+				r_core_cmd_help_match (core, help_msg_db, "dbm");
 				free (module);
 				break;
 			}
@@ -3996,7 +3996,7 @@ static void r_core_cmd_bp(RCore *core, const char *input) {
 			break;
 		case '?':
 		default:
-			r_core_cmd_help_match (core, help_msg_d, "dh", true);
+			r_core_cmd_help_match (core, help_msg_d, "dh");
 			break;
 		}
 		break;
@@ -4263,10 +4263,10 @@ static void r_core_debug_esil(RCore *core, const char *input) {
 					dev = p[0];
 					r_debug_esil_watch (core->dbg, perm, dev, q);
 				} else {
-					r_core_cmd_help_match (core, help_msg_de, "de ", true);
+					r_core_cmd_help_match (core, help_msg_de, "de ");
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_de, "de ", true);
+				r_core_cmd_help_match (core, help_msg_de, "de ");
 			}
 			free (line);
 		}
@@ -4625,7 +4625,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'b': // "dcb"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dcb", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dcb");
 		} else {
 			if (!core->dbg->session) {
 				R_LOG_ERROR ("Session has not started");
@@ -4636,7 +4636,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		}
 	case 'e': // "dce"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dce", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dce");
 		} else {
 			r_reg_arena_swap (core->dbg->reg, true);
 			r_debug_continue_with_signal (core->dbg);
@@ -4644,7 +4644,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'f': // "dcf"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dcf", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dcf");
 		} else {
 			// we should stop in fork and vfork syscalls
 			//TODO: multiple syscalls not handled yet
@@ -4653,7 +4653,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'c': // "dcc"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dcc", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dcc");
 		} else {
 			r_reg_arena_swap (core->dbg->reg, true);
 			if (input[2] == 'u') {
@@ -4665,7 +4665,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'r': // "dcr"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dcr", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dcr");
 		} else {
 			r_reg_arena_swap (core->dbg->reg, true);
 			r_debug_continue_until_optype (core->dbg, R_ANAL_OP_TYPE_RET, 1);
@@ -4673,7 +4673,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'k':
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dck", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dck");
 		} else {
 			// select pid and r_debug_continue_kill (core->dbg,
 			r_reg_arena_swap (core->dbg->reg, true);
@@ -4712,7 +4712,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 'p': // "dcp"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dcp", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dcp");
 		} else {
 			// XXX: this is very slow
 			RIOMap *s;
@@ -4756,7 +4756,7 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		break;
 	case 't':
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_dc, "dct", true);
+			r_core_cmd_help_match (core, help_msg_dc, "dct");
 		} else {
 			cmd_debug_backtrace (core, input + 2);
 		}
@@ -4832,7 +4832,7 @@ static int cmd_debug_step(RCore *core, const char *input) {
 		break;
 	case 'u': // "dsu"
 		if (input[3] == '?') {
-			r_core_cmd_help_match_spec (core, help_msg_dsu, "dsu", input[2], true);
+			r_core_cmd_help_match_spec (core, help_msg_dsu, "dsu", input[2]);
 			return 0;
 		}
 		switch (input[2]) {
@@ -4842,7 +4842,7 @@ static int cmd_debug_step(RCore *core, const char *input) {
 		case 'i': // dsui
 			if (input[3] == 'r') {
 				if (input[4] == '?') {
-					r_core_cmd_help_match (core, help_msg_dsu, "dsuir", true);
+					r_core_cmd_help_match (core, help_msg_dsu, "dsuir");
 				}
 				step_until_inst (core, input + 4, true);
 			} else {
@@ -5006,7 +5006,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 	}
 
 	if (!strncmp (input, "d*?", 3)) { // "dd*?"
-		r_core_cmd_help_match (core, help_msg_dd, "dd", true);
+		r_core_cmd_help_match (core, help_msg_dd, "dd");
 		return 0;
 	}
 
@@ -5032,7 +5032,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 				/* "ddt*?" -> "ddt?" */
 				input--;
 			}
-			r_core_cmd_help_match_spec (core, help_msg_dd, "dd", input[0], true);
+			r_core_cmd_help_match_spec (core, help_msg_dd, "dd", input[0]);
 			goto out_free_argv;
 		}
 
@@ -5075,7 +5075,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 				if (!input[0] || input[0] == '*') {
 					ret = r_debug_desc_list (core->dbg, print);
 				} else {
-					r_core_cmd_help_match_spec (core, help_msg_dd, "dd", input[0], true);
+					r_core_cmd_help_match_spec (core, help_msg_dd, "dd", input[0]);
 				}
 				break;
 			}
@@ -5117,7 +5117,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 		ut64 offset;
 
 		if (argc < 2) {
-			r_core_cmd_help_match (core, help_msg_dd, "dds", true);
+			r_core_cmd_help_match (core, help_msg_dd, "dds");
 			break;
 		}
 
@@ -5146,7 +5146,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 		int newfd;
 
 		if (argc < 3) {
-			r_core_cmd_help_match (core, help_msg_dd, "ddd", true);
+			r_core_cmd_help_match (core, help_msg_dd, "ddd");
 			break;
 		}
 
@@ -5172,7 +5172,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 		char *perms;
 
 		if (argc < 4) {
-			r_core_cmd_help_match (core, help_msg_dd, "ddr", true);
+			r_core_cmd_help_match (core, help_msg_dd, "ddr");
 			break;
 		}
 
@@ -5209,7 +5209,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 		char *perms;
 
 		if (argc < 4) {
-			r_core_cmd_help_match (core, help_msg_dd, "ddw", true);
+			r_core_cmd_help_match (core, help_msg_dd, "ddw");
 			break;
 		}
 
@@ -5247,7 +5247,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 			fd = 0;
 		} else {
 			if (argc < 2) {
-				r_core_cmd_help_match (core, help_msg_dd, "dd-", true);
+				r_core_cmd_help_match (core, help_msg_dd, "dd-");
 				break;
 			}
 			fd = (int) r_num_math (core->num, argv[1]);
@@ -5268,7 +5268,7 @@ static int cmd_debug_desc(RCore *core, const char *input) {
 		ut64 addr;
 
 		if (argc < 2) {
-			r_core_cmd_help_match (core, help_msg_dd, "ddf", true);
+			r_core_cmd_help_match (core, help_msg_dd, "ddf");
 			break;
 		}
 
@@ -5348,7 +5348,7 @@ static int cmd_debug(void *data, const char *input) {
 	}
 	if (!strncmp (input, "ate", 3)) { // "date" -- same as pt.
 		if (strstr (input, "-h") || strstr (input, "?")) {
-			r_core_cmd_help_match (core, help_msg_d, "date", true);
+			r_core_cmd_help_match (core, help_msg_d, "date");
 			return 0;
 		}
 		bool use_beat = strstr (input, "-b");
@@ -5408,7 +5408,7 @@ static int cmd_debug(void *data, const char *input) {
 			break;
 		case 'c': // "dtc"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_dt, "dtc", true);
+				r_core_cmd_help_match (core, help_msg_dt, "dtc");
 			} else {
 				debug_trace_calls (core, input + 2);
 			}
@@ -5576,7 +5576,7 @@ static int cmd_debug(void *data, const char *input) {
 						R_LOG_ERROR ("esil->trace is null. run 'e dbg.trace=true;dtei' to fix that. ");
 					}
 				} else {
-					r_core_cmd_help_match (core, help_msg_dte, "dtek", true);
+					r_core_cmd_help_match (core, help_msg_dte, "dtek");
 				}
 				break;
 #endif
@@ -5756,7 +5756,7 @@ static int cmd_debug(void *data, const char *input) {
 				break;
 			case 'f': // "dif" "diff"
 				if (input[1] == '?') {
-					r_core_cmd_help_match (core, help_msg_di, "dif", true);
+					r_core_cmd_help_match (core, help_msg_di, "dif");
 				} else {
 					char *arg = strchr (input, ' ');
 					if (arg) {
@@ -5782,7 +5782,7 @@ static int cmd_debug(void *data, const char *input) {
 						}
 						free (arg);
 					} else {
-						r_core_cmd_help_match (core, help_msg_di, "dif", true);
+						r_core_cmd_help_match (core, help_msg_di, "dif");
 					}
 				}
 				break;
@@ -5992,11 +5992,11 @@ static int cmd_debug(void *data, const char *input) {
 		case 'r':   // "dxr"
 			if (input[2] == 's') { // "dxrs"
 				if (input[3] != ' ') {
-					r_core_cmd_help_match (core, help_msg_dx, "dxrs", true);
+					r_core_cmd_help_match (core, help_msg_dx, "dxrs");
 					break;
 				}
 			} else if (input[2] != ' ') {
-				r_core_cmd_help_match (core, help_msg_dx, "dxr", true);
+				r_core_cmd_help_match (core, help_msg_dx, "dxr");
 				break;
 			}
 			/* fall through */
@@ -6029,7 +6029,7 @@ static int cmd_debug(void *data, const char *input) {
 		case 'a': { // "dxa"
 			RAsmCode *acode;
 			if (input[2] == '?' || input[2] != ' ') {
-				r_core_cmd_help_match (core, help_msg_dx, "dxa", true);
+				r_core_cmd_help_match (core, help_msg_dx, "dxa");
 				break;
 			}
 			r_asm_set_pc (core->rasm, core->offset);

--- a/libr/core/cmd_egg.inc.c
+++ b/libr/core/cmd_egg.inc.c
@@ -122,7 +122,7 @@ static int cmd_egg(void *data, const char *input) {
 			}
 			egg->lang.nsyscalls = 0;
 		} else {
-			r_core_cmd_help_match (core, help_msg_g, "gs", false);
+			r_core_cmd_help_contains (core, help_msg_g, "gs");
 		}
 		break;
 	case ' ': // "g "
@@ -132,7 +132,7 @@ static int cmd_egg(void *data, const char *input) {
 				R_LOG_ERROR ("Cannot compile '%s'", input + 2);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_g, "g ", true);
+			r_core_cmd_help_match (core, help_msg_g, "g ");
 		}
 		break;
 	case '\0': // "g"
@@ -146,7 +146,7 @@ static int cmd_egg(void *data, const char *input) {
 				r_egg_option_set (egg, "egg.padding", input + 2);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_g, "gp", true);
+			r_core_cmd_help_match (core, help_msg_g, "gp");
 		}
 		break;
 	case 'e': // "ge"
@@ -164,11 +164,11 @@ static int cmd_egg(void *data, const char *input) {
 				r_egg_option_set (egg, "key", p + 1);
 				r_egg_option_set (egg, "egg.encoder", oa);
 			} else {
-				r_core_cmd_help_match (core, help_msg_g, "ge", true);
+				r_core_cmd_help_match (core, help_msg_g, "ge");
 			}
 			free (oa);
 		} else {
-			r_core_cmd_help_match (core, help_msg_g, "ge", true);
+			r_core_cmd_help_match (core, help_msg_g, "ge");
 		}
 		break;
 	case 'i': // "gi"
@@ -182,10 +182,10 @@ static int cmd_egg(void *data, const char *input) {
 			if (input[0] && input[2]) {
 				r_egg_option_set (egg, "egg.shellcode", input + 2);
 			} else {
-				r_core_cmd_help_match (core, help_msg_g, "gi", false);
+				r_core_cmd_help_contains (core, help_msg_g, "gi");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_g, "gi", false);
+			r_core_cmd_help_contains (core, help_msg_g, "gi");
 		}
 		break;
 	case 'L': // "gL"
@@ -274,7 +274,7 @@ static int cmd_egg(void *data, const char *input) {
 			R_LOG_TODO ("list options");
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_g, "gc", false);
+			r_core_cmd_help_contains (core, help_msg_g, "gc");
 			break;
 		}
 		break;

--- a/libr/core/cmd_eval.inc.c
+++ b/libr/core/cmd_eval.inc.c
@@ -435,12 +435,12 @@ static int cmd_eval(void *data, const char *input) {
 				}
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_e, "et", false);
+			r_core_cmd_help_contains (core, help_msg_e, "et");
 		}
 		break;
 	case 'n': // "en" "env"
 		if (strchr (input, '?')) {
-			r_core_cmd_help_match (core, help_msg_e, "en", false);
+			r_core_cmd_help_contains (core, help_msg_e, "en");
 			break;
 		} else if (!strchr (input, '=')) {
 			const char *var = strchr (input, ' ');
@@ -634,7 +634,7 @@ static int cmd_eval(void *data, const char *input) {
 				break;
 			case 'w': // "ecHw"
 				if (!argc) {
-					r_core_cmd_help_match (core, help_msg_ecH, "ecHw", true);
+					r_core_cmd_help_match (core, help_msg_ecH, "ecHw");
 					r_str_argv_free (argv);
 					return true;
 				}
@@ -690,7 +690,7 @@ static int cmd_eval(void *data, const char *input) {
 		break;
 	case 'd': // "ed"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_e, "ed", false);
+			r_core_cmd_help_contains (core, help_msg_e, "ed");
 		} else if (input[1] == '-') { // "ed-"
 			char *file = r_file_home (".radare2rc");
 			if (file) {
@@ -725,7 +725,7 @@ static int cmd_eval(void *data, const char *input) {
 				r_config_set (core->config, input2, p);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_e, "ee", false);
+			r_core_cmd_help_contains (core, help_msg_e, "ee");
 		}
 		break;
 	case '!': // "e!"
@@ -735,7 +735,7 @@ static int cmd_eval(void *data, const char *input) {
 				R_LOG_ERROR ("'%s' is not a boolean variable", input);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_e, "e!", true);
+			r_core_cmd_help_match (core, help_msg_e, "e!");
 		}
 		break;
 	case 's': // "es"
@@ -755,7 +755,7 @@ static int cmd_eval(void *data, const char *input) {
 				R_LOG_ERROR ("cannot find key '%s'", key);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_e, "er", false);
+			r_core_cmd_help_contains (core, help_msg_e, "er");
 		}
 		break;
 	case ':': // "e:"

--- a/libr/core/cmd_flag.inc.c
+++ b/libr/core/cmd_flag.inc.c
@@ -813,7 +813,7 @@ rep:
 	switch (*input) {
 	case 'f': // "ff"
 		if (input[1] == '?') { // "ff?"
-			r_core_cmd_help_match (core, help_msg_f, "ff", false);
+			r_core_cmd_help_contains (core, help_msg_f, "ff");
 		} else if (input[1] == 's') { // "ffs"
 			int delta = flag_to_flag (core, input + 2);
 			if (delta > 0) {
@@ -835,7 +835,7 @@ rep:
 			flagenum = 0;
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_f, "fe", false);
+			r_core_cmd_help_contains (core, help_msg_f, "fe");
 			break;
 		}
 		break;
@@ -878,7 +878,7 @@ rep:
 				R_LOG_ERROR ("Cannot find flag '%s'", name);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_f, "fa", true);
+			r_core_cmd_help_match (core, help_msg_f, "fa");
 		}
 		break;
 	case 'V': // "fV" visual marks
@@ -933,7 +933,7 @@ rep:
 	case 'R': // "fR"
 		switch (*str) {
 		case '\0':
-			r_core_cmd_help_match (core, help_msg_f, "fR", true);
+			r_core_cmd_help_match (core, help_msg_f, "fR");
 			R_LOG_INFO ("Relocate PIE flags in debugger with f.ex: fR entry0 `dm~:1[1]`");
 			break;
 		case '?':
@@ -956,7 +956,7 @@ rep:
 					ret = r_flag_relocate (core->flags, from, mask, to);
 					R_LOG_INFO ("Relocated %d flags", ret);
 				} else {
-					r_core_cmd_help_match (core, help_msg_f, "fR", true);
+					r_core_cmd_help_match (core, help_msg_f, "fR");
 					R_LOG_INFO ("Relocate PIE flags in debugger with f.ex: fR entry0 `dm~:1[1]`");
 				}
 			}
@@ -984,7 +984,7 @@ rep:
 				core->flags->base);
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_f, "fb", true);
+			r_core_cmd_help_match (core, help_msg_f, "fb");
 			break;
 		}
 		break;
@@ -1101,7 +1101,7 @@ rep:
 		input = r_str_trim_head_ro (input + 1) - 1;
 		if (input[1]) {
 			if (input[1] == '?') {
-				r_core_cmd_help_match (core, help_msg_f, "f.", false);
+				r_core_cmd_help_contains (core, help_msg_f, "f.");
 			} else if (input[1] == '*' || input[1] == 'j') {
 				if (input[2] == '*') {
 					print_function_labels (core->anal, NULL, input[1]);
@@ -1146,12 +1146,12 @@ rep:
 		break;
 	case 'l': // "fl"
 		if (input[1] == '?') { // "fl?"
-			r_core_cmd_help_match (core, help_msg_f, "fl", false);
+			r_core_cmd_help_contains (core, help_msg_f, "fl");
 		} else if (input[1] == 'a') { // "fla"
 			// TODO: we can optimize this if core->flags->flags is sorted by flagitem->offset
 			char *glob;
 			if (input[2] == '?') { // "fla?"
-				r_core_cmd_help_match (core, help_msg_f, "fla", true);
+				r_core_cmd_help_match (core, help_msg_f, "fla");
 			}
 			glob = strchr (input, ' ');
 			if (glob) {
@@ -1242,7 +1242,7 @@ rep:
 				r_flag_space_rename (core->flags, NULL, newname);
 				free (newname);
 			} else {
-				r_core_cmd_help_match (core, help_msg_fs, "fsr", true);
+				r_core_cmd_help_match (core, help_msg_fs, "fsr");
 			}
 			break;
 		case 's': // "fss"
@@ -1313,7 +1313,7 @@ rep:
 			__flag_graph (core, r_str_trim_head_ro (input + 1), 0);
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_f, "fg", false);
+			r_core_cmd_help_contains (core, help_msg_f, "fg");
 			break;
 		}
 		break;
@@ -1425,7 +1425,7 @@ rep:
 			}
 			free (p);
 		} else {
-			r_core_cmd_help_match (core, help_msg_f, "fC", true);
+			r_core_cmd_help_match (core, help_msg_f, "fC");
 		}
 		break;
 	case 'o': // "fo"
@@ -1436,7 +1436,7 @@ rep:
 		break;
 	case 'r': // "fr"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_f, "fr", false);
+			r_core_cmd_help_contains (core, help_msg_f, "fr");
 		} else if (input[1] == ' ' && input[2]) {
 			RFlagItem *item = NULL;
 			char *old = str + 1;
@@ -1458,7 +1458,7 @@ rep:
 				}
 			} else {
 				R_LOG_ERROR ("Cannot find flag with given name");
-				// r_core_cmd_help_match (core, help_msg_f, "fr", false);
+				// r_core_cmd_help_contains (core, help_msg_f, "fr");
 			}
 		}
 		break;
@@ -1489,7 +1489,7 @@ rep:
 			}
 			break;
 		}
-		r_core_cmd_help_match (core, help_msg_f, "fN", false);
+		r_core_cmd_help_contains (core, help_msg_f, "fN");
 		break;
 	case '\0':
 	case 'n': // "fn" "fnj"
@@ -1509,7 +1509,7 @@ rep:
 		if (input[0] && input[1] == '?') {
 			char cmd[3] = "fn";
 			cmd[1] = input[0];
-			r_core_cmd_help_match (core, help_msg_f, cmd, false);
+			r_core_cmd_help_contains (core, help_msg_f, cmd);
 			break;
 		}
 		if (input[0] && input[1] == '.') {

--- a/libr/core/cmd_hash.inc.c
+++ b/libr/core/cmd_hash.inc.c
@@ -371,7 +371,7 @@ static int cmd_hash_bang(RCore *core, const char *input) {
 				if (*name) {
 					R_LOG_ERROR ("Unknown rlang plugin '%s'", name);
 				} else {
-					r_core_cmd_help_match (core, help_msg_hash, "#!", false);
+					r_core_cmd_help_contains (core, help_msg_hash, "#!");
 				}
 			}
 			free (name);

--- a/libr/core/cmd_help.inc.c
+++ b/libr/core/cmd_help.inc.c
@@ -638,7 +638,7 @@ static int cmd_help(void *data, const char *input) {
 	switch (input[0]) {
 	case ':':
 		// show help for ':' command
-		r_core_cmd_help_match (core, help_msg_at, ":", true);
+		r_core_cmd_help_match (core, help_msg_at, ":");
 		break;
 	case 't': { // "?t"
 		switch (input[1]) {
@@ -726,7 +726,7 @@ static int cmd_help(void *data, const char *input) {
 			free (buf);
 		} else if (input[1] == 't' && input[2] == 'w') { // "?btw"
 			if (r_num_between (core->num, input + 3) == -1) {
-				r_core_cmd_help_match (core, help_msg_question, "?btw", true);
+				r_core_cmd_help_match (core, help_msg_question, "?btw");
 			}
 		} else {
 			n = r_num_math (core->num, input + 1);
@@ -749,7 +749,7 @@ static int cmd_help(void *data, const char *input) {
 		if (input[1] == ' ') {
 			r_cons_printf ("0x%08x\n", (ut32)r_str_hash (input + 2));
 		} else {
-			r_core_cmd_help_match (core, help_msg_question, "?h", false);
+			r_core_cmd_help_contains (core, help_msg_question, "?h");
 		}
 		break;
 	case 'F': // "?F"
@@ -769,11 +769,11 @@ static int cmd_help(void *data, const char *input) {
 				r_str_bits (out, (const ut8*)&n, sizeof (n) * 8, q + 1);
 				r_cons_println (out);
 			} else {
-				r_core_cmd_help_match (core, help_msg_question, "?f", true);
+				r_core_cmd_help_match (core, help_msg_question, "?f");
 			}
 			free (p);
 		} else {
-			r_core_cmd_help_match (core, help_msg_question, "?f", true);
+			r_core_cmd_help_match (core, help_msg_question, "?f");
 		}
 		break;
 	case 'o': // "?o"
@@ -923,7 +923,7 @@ static int cmd_help(void *data, const char *input) {
 			R_LOG_ERROR ("Division by Zero");
 		}
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_question, "?q", true);
+			r_core_cmd_help_match (core, help_msg_question, "?q");
 		} else {
 			const char *space = strchr (input, ' ');
 			if (space) {
@@ -955,7 +955,7 @@ static int cmd_help(void *data, const char *input) {
 		}
 		switch (input[1]) {
 		case '?':
-			r_core_cmd_help_match (core, help_msg_question, "?v", false);
+			r_core_cmd_help_contains (core, help_msg_question, "?v");
 			break;
 		case '\0':
 			r_cons_printf ("%d\n", (st32)n);
@@ -1006,7 +1006,7 @@ static int cmd_help(void *data, const char *input) {
 				}
 				free (s);
 			} else {
-				r_core_cmd_help_match (core, help_msg_question, "?==", true);
+				r_core_cmd_help_match (core, help_msg_question, "?==");
 			}
 		} else {
 			if (input[1]) { // ?=

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -807,7 +807,7 @@ static int cmd_info(void *data, const char *input) {
 				break;
 			case '?':
 			default:
-				r_core_cmd_help_match (core, help_msg_i, "ik", false);
+				r_core_cmd_help_contains (core, help_msg_i, "ik");
 			}
 			goto done;
 		}
@@ -1434,7 +1434,7 @@ static int cmd_info(void *data, const char *input) {
 		case 'c': // "ic"
 			// XXX this is dupe of cbin.c:bin_classes()
 			if (input[1] == '?') {
-				r_core_cmd_help_match (core, help_msg_i, "ic", false);
+				r_core_cmd_help_contains (core, help_msg_i, "ic");
 			} else if (input[1] == ',') { // "ic,"
 				cmd_ic_comma (core, input);
 			} else if (input[1] == '-') { // "ic-"
@@ -1693,7 +1693,7 @@ static int cmd_info(void *data, const char *input) {
 			break;
 		case 'D': // "iD"
 			if (input[1] != ' ' || !demangle (core, input + 2)) {
-				r_core_cmd_help_match (core, help_msg_i, "iD", true);
+				r_core_cmd_help_match (core, help_msg_i, "iD");
 			}
 			return 0;
 		case 'a': // "ia"

--- a/libr/core/cmd_log.inc.c
+++ b/libr/core/cmd_log.inc.c
@@ -425,7 +425,7 @@ static int cmd_plugins(void *data, const char *input) {
 		case 'j': r_core_cmd_call (core, "phj"); break;
 		case 'q': r_core_cmd_call (core, "phq"); break;
 		case 0: r_core_cmd_call (core, "ph"); break;
-		default: r_core_cmd_help_match (core, help_msg_L, "Lh", true); break;
+		default: r_core_cmd_help_match (core, help_msg_L, "Lh"); break;
 		}
 		break;
 	case 'A': // "LA"
@@ -437,14 +437,14 @@ static int cmd_plugins(void *data, const char *input) {
 		break;
 	case 's': // "Ls"
 		if (input[1] == '?') { // "Ls?"
-			r_core_cmd_help_match (core, help_msg_L, "Ls", true);
+			r_core_cmd_help_match (core, help_msg_L, "Ls");
 		} else { // asm plugins
 			ranal2_list (core, NULL, input[1]);
 		}
 		break;
 	case 'a': // "La" // list arch plugins
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_L, "La", true);
+			r_core_cmd_help_match (core, help_msg_L, "La");
 		} else {
 			int mode = input[1];
 			PJ *pj = (mode == 'j')? r_core_pj_new (core): NULL;

--- a/libr/core/cmd_meta.inc.c
+++ b/libr/core/cmd_meta.inc.c
@@ -509,7 +509,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 		break;
 	case 'F': // "CC,"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_CC, "CCF", true);
+			r_core_cmd_help_match (core, help_msg_CC, "CCF");
 		} else if (input[2] == ' ') {
 			const char *fn = input + 2;
 			const char *comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, addr);
@@ -681,7 +681,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 		if (s) {
 			s = strdup (s + 1);
 		} else {
-			r_core_cmd_help_match (core, help_msg_CC, "CCa", true);
+			r_core_cmd_help_match (core, help_msg_CC, "CCa");
 			return false;
 		}
 		p = strchr (s, ' ');
@@ -696,7 +696,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 						R_META_TYPE_COMMENT,
 						addr, 1);
 			} else {
-				r_core_cmd_help_match (core, help_msg_CC, "CCa", true);
+				r_core_cmd_help_match (core, help_msg_CC, "CCa");
 			}
 			free (s);
 			return true;
@@ -717,7 +717,7 @@ static int cmd_meta_comment(RCore *core, const char *input) {
 				r_meta_set (core->anal, R_META_TYPE_COMMENT, addr, 1, p);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_CC, "CCa", true);
+			r_core_cmd_help_match (core, help_msg_CC, "CCa");
 		}
 		free (s);
 		return true;
@@ -815,7 +815,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 	case '?':
 		switch (input[0]) {
 		case 'f': // "Cf?"
-			r_core_cmd_help_match (core, help_msg_C, "Cf", true);
+			r_core_cmd_help_match (core, help_msg_C, "Cf");
 			r_cons_println (
 				"'sz' indicates the byte size taken up by struct.\n"
 				"'fmt' is a 'pf?' style format string. It controls only the display format.\n\n"
@@ -1069,7 +1069,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 							n  = -1;
 						}
 					} else {
-						r_core_cmd_help_match (core, help_msg_C, "Cf", true);
+						r_core_cmd_help_match (core, help_msg_C, "Cf");
 						break;
 					}
 				} else if (type == 's') { // "Cs"
@@ -1364,7 +1364,7 @@ static int cmd_meta(void *data, const char *input) {
 			if (input[2] == ' ') {
 				r_spaces_rename (ms, NULL, input + 2);
 			} else {
-				r_core_cmd_help_match (core, help_msg_CS, "CSr", true);
+				r_core_cmd_help_match (core, help_msg_CS, "CSr");
 			}
 			break;
 		case '-': // "CS-"

--- a/libr/core/cmd_mount.inc.c
+++ b/libr/core/cmd_mount.inc.c
@@ -303,14 +303,14 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case '-':
 		if (input[1] == '?') { // "m-?"
-			r_core_cmd_help_match (core, help_msg_m, "m-", true);
+			r_core_cmd_help_match (core, help_msg_m, "m-");
 		} else {
 			r_fs_umount (core->fs, input + 1);
 		}
 		break;
 	case 'j':
 		if (input[1] == '?') { // "mj?"
-			r_core_cmd_help_match (core, help_msg_m, "mj", true);
+			r_core_cmd_help_match (core, help_msg_m, "mj");
 		} else {
 			PJ *pj = r_core_pj_new (core);
 			pj_o (pj);
@@ -353,7 +353,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 'L': // "mL" list of plugins
 		if (input[1] == '?') { // "mL?"
-			r_core_cmd_help_match (core, help_msg_m, "mL", true);
+			r_core_cmd_help_match (core, help_msg_m, "mL");
 		} else if (input[1] == 'L') {
 			r_list_foreach (core->fs->plugins, iter, plug) {
 				r_cons_printf ("%s\n", plug->meta.name);
@@ -379,7 +379,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 'd': // "md"
 		if (input[1] == '?') { // "md?"
-			r_core_cmd_help_match (core, help_msg_m, "md", true);
+			r_core_cmd_help_match (core, help_msg_m, "md");
 		} else {
 			cmd_mount_ls (core, input + 1);
 		}
@@ -387,7 +387,7 @@ static int cmd_mount(void *data, const char *_input) {
 	case 'p': // "mp"
 		input = (char *)r_str_trim_head_ro (input + 1);
 		if (input[0] == '?') { // "mp?"
-			r_core_cmd_help_match (core, help_msg_m, "mp", true);
+			r_core_cmd_help_match (core, help_msg_m, "mp");
 			break;
 		}
 		ptr = strchr (input, ' ');
@@ -410,7 +410,7 @@ static int cmd_mount(void *data, const char *_input) {
 	case 'o': // "mo"
 		input = (char *)r_str_trim_head_ro (input + 1);
 		if (*input == '?') { // "mo?"
-			r_core_cmd_help_match (core, help_msg_m, "mo", true);
+			r_core_cmd_help_match (core, help_msg_m, "mo");
 		} else {
 			file = r_fs_open (core->fs, input, false);
 			if (file) {
@@ -427,7 +427,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 'i':
 		if (input[1] == '?') { // "mi?"
-			r_core_cmd_help_match (core, help_msg_m, "mi", true);
+			r_core_cmd_help_match (core, help_msg_m, "mi");
 		} else {
 			input = (char *)r_str_trim_head_ro (input + 1);
 			file = r_fs_open (core->fs, input, false);
@@ -443,7 +443,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 'c': // "mc"
 		if (input[1] == '?') { // "mc?"
-			r_core_cmd_help_match (core, help_msg_m, "mc", true);
+			r_core_cmd_help_match (core, help_msg_m, "mc");
 		} else {
 			input = (char *)r_str_trim_head_ro (input + 1);
 			ptr = strchr (input, ' ');
@@ -465,7 +465,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 'g': // "mg"
 		if (input[1] == '?') { // "mg?"
-			r_core_cmd_help_match (core, help_msg_m, "mg", true);
+			r_core_cmd_help_match (core, help_msg_m, "mg");
 			break;
 		}
 		input = (char *)r_str_trim_head_ro (input + 1);
@@ -579,7 +579,7 @@ static int cmd_mount(void *data, const char *_input) {
 		break;
 	case 's': // "ms"
 		if (input[1] == '?') { // "ms?"
-			r_core_cmd_help_match (core, help_msg_m, "ms", true);
+			r_core_cmd_help_match (core, help_msg_m, "ms");
 			break;
 		};
 		if (!r_config_get_b (core->config, "scr.interactive")) {
@@ -613,7 +613,7 @@ static int cmd_mount(void *data, const char *_input) {
 			if (arg1) {
 				*arg1++ = 0;
 			} else {
-				r_core_cmd_help_match (core, help_msg_m, "mwf", true);
+				r_core_cmd_help_match (core, help_msg_m, "mwf");
 				free (arg0);
 				break;
 			}
@@ -645,12 +645,12 @@ static int cmd_mount(void *data, const char *_input) {
 			}
 			free (args);
 		} else {
-			r_core_cmd_help_match (core, help_msg_m, "mw", false);
+			r_core_cmd_help_contains (core, help_msg_m, "mw");
 		}
 		break;
 	case 'y':
 		if (input[1] == '?') { // "my?"
-			r_core_cmd_help_match (core, help_msg_m, "my", true);
+			r_core_cmd_help_match (core, help_msg_m, "my");
 			break;
 		}
 		input = (char *)r_str_trim_head_ro (input + 1);

--- a/libr/core/cmd_open.inc.c
+++ b/libr/core/cmd_open.inc.c
@@ -315,7 +315,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 		}
 		int n = r_str_word_set0 (v);
 		if (n < 1 || n > 2) {
-			r_core_cmd_help_match (core, help_msg_o, "ob", true);
+			r_core_cmd_help_match (core, help_msg_o, "ob");
 			free (v);
 			break;
 		}
@@ -333,7 +333,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 	}
 	case 'r': // "obr"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_ob, "obr", true);
+			r_core_cmd_help_match (core, help_msg_ob, "obr");
 		} else {
 			r_core_bin_rebase (core, r_num_math (core->num, input + 3));
 			r_core_cmd0 (core, ".is*");
@@ -393,7 +393,7 @@ static void cmd_open_bin(RCore *core, const char *input) {
 				R_LOG_ERROR ("Invalid RBinFile.id number");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_ob, "obo", true);
+			r_core_cmd_help_match (core, help_msg_ob, "obo");
 		}
 		break;
 	case '-': // "ob-"
@@ -731,7 +731,7 @@ static bool cmd_om(RCore *core, const char *input, int arg) {
 
 static void cmd_omd(RCore *core, const char* input) {
 	if (*input == '?') {
-		r_core_cmd_help_match (core, help_msg_om, "omd", true);
+		r_core_cmd_help_match (core, help_msg_om, "omd");
 		return;
 	}
 	int fd = r_io_fd_get_current (core->io);
@@ -752,7 +752,7 @@ static void cmd_omd(RCore *core, const char* input) {
 				R_LOG_ERROR ("Invalid map range");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_om, "omd", true);
+			r_core_cmd_help_match (core, help_msg_om, "omd");
 		}
 		r_list_free (args);
 		r_free (inp);
@@ -926,7 +926,7 @@ static void cmd_open_map(RCore *core, const char *input) {
 		break;
 	case 'r': // "omr"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_om, "omr", true);
+			r_core_cmd_help_match (core, help_msg_om, "omr");
 			break;
 		}
 		if (input[2] != ' ') {
@@ -1095,13 +1095,13 @@ static void cmd_open_map(RCore *core, const char *input) {
 					r_io_map_set_name (map, desc->name);
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_om, "oma", false);
+				r_core_cmd_help_contains (core, help_msg_om, "oma");
 			}
 		}
 		break;
 	case 'm': // "omm"
 		if (input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_om, "omm", false);
+			r_core_cmd_help_contains (core, help_msg_om, "omm");
 		} else {
 			ut32 fd = input[2]? r_num_math (core->num, input + 2): r_io_fd_get_current (core->io);
 			RIODesc *desc = r_io_desc_get (core->io, fd);
@@ -1681,7 +1681,7 @@ static bool cmd_onn(RCore *core, const char* input) {
 	}
 	arg0 = r_str_trim_head_ro (arg0);
 	if (!*arg0) {
-		r_core_cmd_help_match (core, help_msg_on, "onn", false);
+		r_core_cmd_help_contains (core, help_msg_on, "onn");
 		return false;
 	}
 	char *ptr = r_str_trim_dup (arg0);
@@ -1749,7 +1749,7 @@ static int cmd_open(void *data, const char *input) {
 			}
 			break;
 		case '?': // "oa?"
-			r_core_cmd_help_match (core, help_msg_o, "oa", true);
+			r_core_cmd_help_match (core, help_msg_o, "oa");
 			return 1;
 		case ' ': { // "oa "
 			int i;
@@ -1795,7 +1795,7 @@ static int cmd_open(void *data, const char *input) {
 			}
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_o, "oa", true);
+			r_core_cmd_help_match (core, help_msg_o, "oa");
 			return 0;
 		}
 		break;
@@ -1815,7 +1815,7 @@ static int cmd_open(void *data, const char *input) {
 		if (input[1] == '+') { // "on+"
 			perms |= R_PERM_W;
 			if (input[2] != ' ') {
-				r_core_cmd_help_match (core, help_msg_on, "on+", true);
+				r_core_cmd_help_match (core, help_msg_on, "on+");
 				return 0;
 			}
 			ptr = r_str_trim_head_ro (input + 3);
@@ -1861,7 +1861,7 @@ static int cmd_open(void *data, const char *input) {
 			const char *arg = r_str_trim_head_ro (input + 1);
 			free (r_core_editor (core, arg, NULL));
 		} else {
-			r_core_cmd_help_match (core, help_msg_o, "oe", false);
+			r_core_cmd_help_contains (core, help_msg_o, "oe");
 		}
 		return 0;
 	// XXX projects use the of command, but i think we should deprecate it... keeping it for now
@@ -1870,7 +1870,7 @@ static int cmd_open(void *data, const char *input) {
 			ptr = r_str_trim_head_ro (input + 2);
 			argv = r_str_argv (ptr, &argc);
 			if (argc == 0 || input[1] == '?') {
-				r_core_cmd_help_match (core, help_msg_o, "of", true);
+				r_core_cmd_help_match (core, help_msg_o, "of");
 				r_str_argv_free (argv);
 				return 0;
 			}
@@ -1881,7 +1881,7 @@ static int cmd_open(void *data, const char *input) {
 			r_core_return_value (core, fd);
 			r_str_argv_free (argv);
 		} else {
-			r_core_cmd_help_match (core, help_msg_o, "of", true);
+			r_core_cmd_help_match (core, help_msg_o, "of");
 		}
 		return 0;
 	case 't': // "ot"
@@ -1909,7 +1909,7 @@ static int cmd_open(void *data, const char *input) {
 						}
 #endif
 					} else {
-						r_core_cmd_help_match (core, help_msg_o, "open", true);
+						r_core_cmd_help_match (core, help_msg_o, "open");
 					}
 				}
 				break;
@@ -1942,7 +1942,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case '+': // "o+"
 		if (input[1] == '?' || (input[1] && input[2] == '?')) {
-			r_core_cmd_help_match (core, help_msg_o, "o+", false);
+			r_core_cmd_help_contains (core, help_msg_o, "o+");
 			return 0;
 		}
 		perms |= R_PERM_W;
@@ -1956,9 +1956,9 @@ static int cmd_open(void *data, const char *input) {
 		argv = r_str_argv (ptr, &argc);
 		if (argc == 0) {
 			if (perms & R_PERM_W) {
-				r_core_cmd_help_match (core, help_msg_o, "o+", false);
+				r_core_cmd_help_contains (core, help_msg_o, "o+");
 			} else {
-				r_core_cmd_help_match (core, help_msg_o, "o", true);
+				r_core_cmd_help_match (core, help_msg_o, "o");
 			}
 			r_str_argv_free (argv);
 			return 0;
@@ -2058,7 +2058,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case '*': // "o*"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_o, "o*", true);
+			r_core_cmd_help_match (core, help_msg_o, "o*");
 		} else if (input[1] == '*') {
 			r_id_storage_foreach (core->io->files, desc_list_cmds_cb2, core);
 		} else {
@@ -2067,7 +2067,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case 'j': // "oj"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_o, "oj", true);
+			r_core_cmd_help_match (core, help_msg_o, "oj");
 			break;
 		}
 		PJ *pj = pj_new ();
@@ -2113,21 +2113,21 @@ static int cmd_open(void *data, const char *input) {
 		switch (input[1]) {
 		case '!': // "o-!"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_o_dash, "o-!", true);
+				r_core_cmd_help_match (core, help_msg_o_dash, "o-!");
 			} else {
 				r_core_file_close_all_but (core);
 			}
 			break;
 		case '$': // "o-$"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_o_dash, "o-$", true);
+				r_core_cmd_help_match (core, help_msg_o_dash, "o-$");
 			} else {
 				R_LOG_TODO ("o-$: close last fd is not implemented");
 			}
 			break;
 		case '.': // "o-."
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_o_dash, "o-*", true);
+				r_core_cmd_help_match (core, help_msg_o_dash, "o-*");
 			} else {
 				RBinFile *bf = r_bin_cur (core->bin);
 				if (bf && bf->fd >= 0) {
@@ -2141,7 +2141,7 @@ static int cmd_open(void *data, const char *input) {
 			break;
 		case '*': // "o-*"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_o_dash, "o-*", true);
+				r_core_cmd_help_match (core, help_msg_o_dash, "o-*");
 			} else {
 				r_io_close_all (core->io);
 				r_bin_file_delete_all (core->bin);
@@ -2149,7 +2149,7 @@ static int cmd_open(void *data, const char *input) {
 			break;
 		case '-': // "o--"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_o_dash, "o--", true);
+				r_core_cmd_help_match (core, help_msg_o_dash, "o--");
 			} else {
 				r_io_close_all (core->io);
 				r_bin_file_delete_all (core->bin);
@@ -2229,7 +2229,7 @@ static int cmd_open(void *data, const char *input) {
 			case 'f': // "oodf"
 				argv = r_str_argv (input + 3, &argc);
 				if (argc < 1 || argc > 2) {
-					r_core_cmd_help_match (core, help_msg_ood, "oodf", true);
+					r_core_cmd_help_match (core, help_msg_ood, "oodf");
 					r_str_argv_free (argv);
 					return 0;
 				}
@@ -2251,14 +2251,14 @@ static int cmd_open(void *data, const char *input) {
 			break;
 		case 'c': // "ooc"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_oo, "ooc", true);
+				r_core_cmd_help_match (core, help_msg_oo, "ooc");
 			} else {
 				r_core_cmd0 (core, "oc `o.`");
 			}
 			break;
 		case 'b': // "oob" : reopen with bin info
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_oo, "oob", true);
+				r_core_cmd_help_match (core, help_msg_oo, "oob");
 			} else {
 				r_core_file_reopen (core, input + 2, 0, 2);
 			}
@@ -2273,7 +2273,7 @@ static int cmd_open(void *data, const char *input) {
 				break;
 			case 'n': // "oonn"
 				if (input[3] == '?' || !core->io->desc) {
-					r_core_cmd_help_match (core, help_msg_oo, "oonn", false);
+					r_core_cmd_help_contains (core, help_msg_oo, "oonn");
 					break;
 				}
 				RIODesc *desc = r_io_desc_get (core->io, core->io->desc->fd);
@@ -2293,13 +2293,13 @@ static int cmd_open(void *data, const char *input) {
 				break;
 			case '?':
 			default:
-				r_core_cmd_help_match (core, help_msg_oo, "oon", false);
+				r_core_cmd_help_contains (core, help_msg_oo, "oon");
 				break;
 			}
 			break;
 		case '+': // "oo+"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_oo, "oo+", true);
+				r_core_cmd_help_match (core, help_msg_oo, "oo+");
 			} else if (core && core->io && core->io->desc) {
 				int fd;
 				int perms = R_PERM_RW;
@@ -2369,7 +2369,7 @@ static int cmd_open(void *data, const char *input) {
 		break;
 	case 'c': // "oc"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_o, "oc", true);
+			r_core_cmd_help_match (core, help_msg_o, "oc");
 		} else if (input[1] && input[2]) {
 			if (r_sandbox_enable (0)) {
 				R_LOG_ERROR ("This command is disabled in sandbox mode");
@@ -2414,7 +2414,7 @@ static int cmd_open(void *data, const char *input) {
 			free (inp);
 			r_core_block_read (core);
 		} else {
-			r_core_cmd_help_match (core, help_msg_o, "oxr", true);
+			r_core_cmd_help_match (core, help_msg_o, "oxr");
 		}
 		break;
 	case '?': // "o?"

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -639,7 +639,7 @@ static const ut32 colormap[256] = {
 
 static void __cmd_pad(RCore *core, const char *arg) {
 	if (*arg == '?') {
-		r_core_cmd_help_match (core, help_msg_pa, "pad", false);
+		r_core_cmd_help_contains (core, help_msg_pa, "pad");
 		return;
 	}
 	r_asm_set_pc (core->rasm, core->offset);
@@ -766,7 +766,7 @@ static void cmd_printmsg(RCore *core, const char *input) {
 	} else if (r_str_startswith (input, "fln ")) {
 		R_LOG_TODO ("waiting for r2shell");
 	} else {
-		r_core_cmd_help_match (core, help_msg_pr, "print", true);
+		r_core_cmd_help_match (core, help_msg_pr, "print");
 	}
 }
 
@@ -1154,7 +1154,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 	case 'a': // "pdua"
 		{
 		if (input[1] == '?' || (input[1] && input[2] == '?') || !arg) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pdua", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pdua");
 			break;
 		}
 		ut64 to = r_num_get (core->num, arg);
@@ -1179,7 +1179,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'c': // "pduc"
 		if (input[1] == '?' || (input[1] && input[2] == '?')) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pduc", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pduc");
 			break;
 		}
 
@@ -1188,7 +1188,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	/*case 'e': // "pdue"
 		if (input[1] == '?' || input[2] == '?' || !arg) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pdue", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pdue");
 			break;
 		}
 
@@ -1197,7 +1197,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;*/
 	case 'i': // "pdui"
 		if (input[1] == '?' || (input[1] && input[2] == '?') || !arg) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pdui", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pdui");
 			break;
 		}
 		ret = r_core_print_disasm (core, addr, buf, len, 0, pdu_instruction, arg, false,
@@ -1205,7 +1205,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 'o': // "pduo"
 		if (input[1] == '?' || (input[1] && input[2] == '?') || !arg) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pduo", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pduo");
 			break;
 		}
 		ret = r_core_print_disasm (core, addr, buf, len, 0, pdu_opcode, arg, false,
@@ -1213,7 +1213,7 @@ static int cmd_pdu(RCore *core, const char *input) {
 		break;
 	case 's': // "pdus"
 		if (input[1] == '?' || (input[1] && input[2] == '?')) {
-			r_core_cmd_help_match (core, help_msg_pdu, "pdus", true);
+			r_core_cmd_help_match (core, help_msg_pdu, "pdus");
 			break;
 		}
 		ret = r_core_print_disasm (core, addr, buf, len, 0, pdu_instruction, "syscall", false,
@@ -1393,7 +1393,7 @@ static void cmd_print_fromage(RCore *core, const char *input, const ut8* data, i
 		break;
 	case 'b': // "pFb"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_pF, "pFb", false);
+			r_core_cmd_help_contains (core, help_msg_pF, "pFb");
 		} else {
 			char *s = r_protobuf_decode (data, size, input[1]);
 			if (s) {
@@ -1424,7 +1424,7 @@ static void cmd_print_fromage(RCore *core, const char *input, const ut8* data, i
 		break;
 	case 'B': // "pFB"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_pF, "pFB", true);
+			r_core_cmd_help_match (core, help_msg_pF, "pFB");
 		} else {
 			PJ *pj = r_core_pj_new (core);
 			if (size > 0) {
@@ -1767,7 +1767,7 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8* block, 
 				r_cons_printf ("%d\n", r_print_format_struct_size (core->print, val, mode, 0));
 			} else {
 				R_LOG_WARN ("Struct %s not defined", _input);
-				r_core_cmd_help_match (core, help_msg_pf, "pfs", true);
+				r_core_cmd_help_match (core, help_msg_pf, "pfs");
 			}
 		} else if (*_input == ' ') {
 			while (*_input == ' ' && *_input != '\0') {
@@ -1777,10 +1777,10 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8* block, 
 				r_cons_printf ("%d\n", r_print_format_struct_size (core->print, _input, mode, 0));
 			} else {
 				R_LOG_WARN ("Struct %s not defined", _input);
-				r_core_cmd_help_match (core, help_msg_pf, "pfs", true);
+				r_core_cmd_help_match (core, help_msg_pf, "pfs");
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_pf, "pfs", true);
+			r_core_cmd_help_match (core, help_msg_pf, "pfs");
 		}
 		return;
 	}
@@ -1816,12 +1816,12 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8* block, 
 		if (_input[2] == ' ') {
 			r_core_cmd_print_binformat (core, r_str_trim_head_ro (_input + 2), PFB_ART);
 		} else {
-			r_core_cmd_help_match (core, help_msg_pf, "pfb", true);
+			r_core_cmd_help_match (core, help_msg_pf, "pfb");
 		}
 		return;
 	case 'o': // "pfo"
 		if (_input[2] == '?') {
-			r_core_cmd_help_match (core, help_msg_pf, "pfo", true);
+			r_core_cmd_help_match (core, help_msg_pf, "pfo");
 		} else if (_input[2] == ' ') {
 			const char *fname = r_str_trim_head_ro (_input + 3);
 			char *tmp = r_str_newf (R_JOIN_2_PATHS (R2_SDB_FORMAT, "%s"), fname);
@@ -2031,7 +2031,7 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8* block, 
 		char *save_ptr = NULL;
 		const char *arg1 = r_str_tok_r (args, " ", &save_ptr);
 		if (arg1 && r_str_isnumber (arg1)) {
-			r_core_cmd_help_match (core, help_msg_pf, "pf", true);
+			r_core_cmd_help_match (core, help_msg_pf, "pf");
 			goto err_arg1;
 		}
 		r_print_format (core->print, core->offset,
@@ -5790,7 +5790,7 @@ static int cmd_print(void *data, const char *input) {
 			}
 		}
 		if (halp) {
-			r_core_cmd_help_match (core, help_msg_p, "pushd", true);
+			r_core_cmd_help_match (core, help_msg_p, "pushd");
 			r_core_return_value (core, 1);
 		}
 		return 0;
@@ -5799,7 +5799,7 @@ static int cmd_print(void *data, const char *input) {
 		bool all = strstr (input, "-a");
 		bool halp = strstr (input, "-h");
 		if (halp) {
-			r_core_cmd_help_match (core, help_msg_p, "popd", true);
+			r_core_cmd_help_match (core, help_msg_p, "popd");
 			r_core_return_value (core, 1);
 		} else {
 			bool suc = all
@@ -5974,7 +5974,7 @@ static int cmd_print(void *data, const char *input) {
 
 		int want = r_num_math (core->num, input + 1);
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pA", false);
+			r_core_cmd_help_contains (core, help_msg_p, "pA");
 		} else {
 			r_config_set_i (core->config, "search.maxhits", want);
 			r_config_set_i (core->config, "search.from", core->offset);
@@ -5994,7 +5994,7 @@ static int cmd_print(void *data, const char *input) {
 		}
 		if (input[1] == 'e') { // "pae"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pa, "pae", true);
+				r_core_cmd_help_match (core, help_msg_pa, "pae");
 			} else {
 				int printed = 0;
 				int bufsz;
@@ -6024,7 +6024,7 @@ static int cmd_print(void *data, const char *input) {
 			}
 		} else if (input[1] == 'D') { // "paD"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pa, "paD", true);
+				r_core_cmd_help_match (core, help_msg_pa, "paD");
 			} else {
 				r_core_cmdf (core, "pdi@x:%s", input + 2);
 			}
@@ -6032,7 +6032,7 @@ static int cmd_print(void *data, const char *input) {
 			switch (input[2]) {
 			case 'e': // "pade"
 				if (input[3] == '?') {
-					r_core_cmd_help_match (core, help_msg_pa, "pade", true);
+					r_core_cmd_help_match (core, help_msg_pa, "pade");
 				} else {
 					int printed = 0;
 					int bufsz;
@@ -6065,7 +6065,7 @@ static int cmd_print(void *data, const char *input) {
 				__cmd_pad (core, arg);
 				break;
 			case '?': // "pad?"
-				r_core_cmd_help_match (core, help_msg_pa, "pad", false);
+				r_core_cmd_help_contains (core, help_msg_pa, "pad");
 				break;
 			default:
 				r_core_cmd_help (core, help_msg_pa);
@@ -6082,7 +6082,7 @@ static int cmd_print(void *data, const char *input) {
 			RAsmCode *acode = r_asm_massemble (core->rasm, input + 1);
 			if (acode) {
 				if (!acode->len) {
-					r_core_cmd_help_match (core, help_msg_pa, "pa", false);
+					r_core_cmd_help_contains (core, help_msg_pa, "pa");
 				} else {
 					size_t i;
 					for (i = 0; i < acode->len; i++) {
@@ -6098,7 +6098,7 @@ static int cmd_print(void *data, const char *input) {
 	break;
 	case 'b': { // "pb"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pb", true);
+			r_core_cmd_help_match (core, help_msg_p, "pb");
 		} else if (l != 0) {
 			int from, to;
 			const int size = len * 8;
@@ -6143,7 +6143,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'B': { // "pB"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pB", true);
+			r_core_cmd_help_match (core, help_msg_p, "pB");
 		} else if (l != 0) {
 			int size;
 			char *buf;
@@ -6308,7 +6308,7 @@ static int cmd_print(void *data, const char *input) {
 		case ',': // "pd,"
 		case 't': // "pdt" // R_DEPRECATE pdt imho
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pd,", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pd,");
 				return 0;
 			} else {
 				r_core_disasm_table (core, l, r_str_trim_head_ro (input + 2));
@@ -6318,7 +6318,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'k': // "pdk" -print class
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdk", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdk");
 				return 0;
 			} else {
 				int len = 0;
@@ -6328,7 +6328,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'i': // "pdi" // "pDi"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdi", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdi");
 				return 0;
 			} else {
 				processed_cmd = true;
@@ -6343,9 +6343,9 @@ static int cmd_print(void *data, const char *input) {
 		case 'a': // "pda"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pda", false);
+				r_core_cmd_help_contains (core, help_msg_pd, "pda");
 			} else if (input[2] == 'j' && input[3] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdaj", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdaj");
 			} else {
 				r_core_print_disasm_all (core, core->offset, l, len, input[2]);
 				pd_result = true;
@@ -6353,7 +6353,7 @@ static int cmd_print(void *data, const char *input) {
 			break;
 		case 'o': // "pdo"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdo", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdo");
 				return 0;
 			}
 			core_print_decompile (core, input + 2);
@@ -6372,20 +6372,20 @@ static int cmd_print(void *data, const char *input) {
 			int mode = R_MODE_PRINT;
 			if (input[2] == 'j') {
 				if (input[3] == '?') {
-					r_core_cmd_help_match (core, help_msg_pde, "pdej", true);
+					r_core_cmd_help_match (core, help_msg_pde, "pdej");
 					return 0;
 				}
 				mode = R_MODE_JSON;
 			} else if (input[2] == 'q') {
 				if (input[3] == 'q') { // "pdeqq"
 					if (input[4] == '?') {
-						r_core_cmd_help_match (core, help_msg_pde, "pdeqq", true);
+						r_core_cmd_help_match (core, help_msg_pde, "pdeqq");
 						return 0;
 					}
 					mode = R_MODE_SIMPLEST; // Like pi
 				} else { // "pdeq"
 					if (input[3] == '?') {
-						r_core_cmd_help_match (core, help_msg_pde, "pdeq", false);
+						r_core_cmd_help_contains (core, help_msg_pde, "pdeq");
 						return 0;
 					}
 					mode = R_MODE_SIMPLE; // Like pdi
@@ -6406,11 +6406,11 @@ static int cmd_print(void *data, const char *input) {
 		case 'r': // "pdr"
 			processed_cmd = true;
 			if (input[2] == '?') { // "pdr?"
-				r_core_cmd_help_match (core, help_msg_pd, "pdr", false);
+				r_core_cmd_help_contains (core, help_msg_pd, "pdr");
 				pd_result = true;
 				break;
 			} else if (input[2] == '.' && input[3] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdr.", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdr.");
 			} else {
 				RAnalFunction *f = r_anal_get_fcn_in (core->anal, core->offset, 0);
 				// R_ANAL_FCN_TYPE_FCN|R_ANAL_FCN_TYPE_SYM);
@@ -6425,7 +6425,7 @@ static int cmd_print(void *data, const char *input) {
 		case 'b': // "pdb"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdb", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdb");
 			} else {
 				RAnalBlock *b = r_anal_bb_from_offset (core->anal, core->offset);
 				if (b) {
@@ -6462,10 +6462,10 @@ static int cmd_print(void *data, const char *input) {
 		case 's': // "pds"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pds", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pds");
 			} else {
 				if (input[2] && input[3] == '?') {
-					r_core_cmd_help_match (core, help_msg_pd, "pds", true);
+					r_core_cmd_help_match (core, help_msg_pd, "pds");
 				} else {
 					disasm_strings (core, input, NULL);
 				}
@@ -6474,7 +6474,7 @@ static int cmd_print(void *data, const char *input) {
 		case 'f': // "pdf"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdf", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdf");
 			} else if (input[2] == 's') { // "pdfs"
 				ut64 oseek = core->offset;
 				int oblock = core->blocksize;
@@ -6562,7 +6562,7 @@ static int cmd_print(void *data, const char *input) {
 		case 'p': // "pdp"
 			processed_cmd = true;
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pd, "pdp", true);
+				r_core_cmd_help_match (core, help_msg_pd, "pdp");
 				pd_result = true;
 				break;
 			};
@@ -7074,7 +7074,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'u': // "pu"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pu", true);
+			r_core_cmd_help_match (core, help_msg_p, "pu");
 		} else {
 			if (l > 0) {
 				r_print_string (core->print, core->offset, core->block, len,
@@ -7144,7 +7144,7 @@ static int cmd_print(void *data, const char *input) {
 			cmd_pCx (core, input + 2, "pc");
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_p, "pC", true);
+			r_core_cmd_help_match (core, help_msg_p, "pC");
 			break;
 		}
 		break;
@@ -7152,7 +7152,7 @@ static int cmd_print(void *data, const char *input) {
 		switch (input[1]) {
 		case 'i': // "pri" // color raw image
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_pr, "pri", true);
+				r_core_cmd_help_match (core, help_msg_pr, "pri");
 			} else if (input[2] == 'n') {
 				cmd_printmsg (core, input + 4);
 			} else if (input[2] == '1') {
@@ -7279,7 +7279,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case '3': // "p3" [file]
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "p3", true);
+			r_core_cmd_help_match (core, help_msg_p, "p3");
 		} else if (input[1] == ' ') {
 			char *data = r_file_slurp (input + 2, NULL);
 			if (!data) {
@@ -7300,7 +7300,7 @@ static int cmd_print(void *data, const char *input) {
 	case 'y': // "py"
 		switch (input[1]) {
 		case '?':
-			r_core_cmd_help_match (core, help_msg_p, "py", false);
+			r_core_cmd_help_contains (core, help_msg_p, "py");
 			break;
 		case '-':
 			if (r_config_get_b (core->config, "scr.interactive")) {
@@ -7648,7 +7648,7 @@ static int cmd_print(void *data, const char *input) {
 				int mode = input[2];
 				int wordsize = core->anal->config->bits / 8;
 				if (mode == '?') {
-					r_core_cmd_help_match (core, help_msg_px, "pxr", false);
+					r_core_cmd_help_contains (core, help_msg_px, "pxr");
 					break;
 				}
 				if (mode && isdigit (mode)) {
@@ -7917,7 +7917,7 @@ static int cmd_print(void *data, const char *input) {
 	case '2': // "p2"
 		if (l) {
 			if (input[1] == '?') {
-				r_core_cmd_help_match (core, help_msg_p, "p2", true);
+				r_core_cmd_help_match (core, help_msg_p, "p2");
 			} else {
 				RConsContext *c = core->cons->context;
 				const char **colors = (const char *[]) {
@@ -7943,11 +7943,11 @@ static int cmd_print(void *data, const char *input) {
 			case 'd': // "p6d"
 				switch (input[2]) {
 				case '?':
-					r_core_cmd_help_match (core, help_msg_p6, "p6d", true);
+					r_core_cmd_help_match (core, help_msg_p6, "p6d");
 					break;
 				case 's': // "p6ds"
 					if (input[3] == '?') {
-						r_core_cmd_help_match (core, help_msg_p6, "p6ds", true);
+						r_core_cmd_help_match (core, help_msg_p6, "p6ds");
 					} else {
 						char *a = r_str_trim_dup (input + 3);
 						char *out = malloc ((4 + strlen (a)) * 4);
@@ -7962,7 +7962,7 @@ static int cmd_print(void *data, const char *input) {
 					break;
 				case 'z': // "p6dz"
 					if (input[3] == '?') {
-						r_core_cmd_help_match (core, help_msg_p6, "p6dz", true);
+						r_core_cmd_help_match (core, help_msg_p6, "p6dz");
 					} else {
 						len = r_str_nlen ((const char *)block, len);
 						if (r_base64_decode (buf, (const char *) block, len)) {
@@ -7986,11 +7986,11 @@ static int cmd_print(void *data, const char *input) {
 			case 'e': // "p6e"
 				switch (input[2]) {
 				case '?':
-					r_core_cmd_help_match (core, help_msg_p6, "p6e", true);
+					r_core_cmd_help_match (core, help_msg_p6, "p6e");
 					break;
 				case 's': // "p6es"
 					if (input[3] == '?') {
-						r_core_cmd_help_match (core, help_msg_p6, "p6es", true);
+						r_core_cmd_help_match (core, help_msg_p6, "p6es");
 					} else {
 						char *a = r_str_trim_dup (input + 3);
 						char *out = calloc ((4 + strlen (a)), 4);
@@ -8002,7 +8002,7 @@ static int cmd_print(void *data, const char *input) {
 					break;
 				case 'z': // "p6ez"
 					if (input[3] == '?') {
-						r_core_cmd_help_match (core, help_msg_p6, "p6ez", true);
+						r_core_cmd_help_match (core, help_msg_p6, "p6ez");
 					} else {
 						len = r_str_nlen ((const char *)block, len);
 						r_base64_encode ((char *) buf, block, len);
@@ -8077,7 +8077,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'k': // "pk"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pk", false);
+			r_core_cmd_help_contains (core, help_msg_p, "pk");
 		} else if (!strncmp (input, "kill", 4)) {
 			RListIter *iter;
 			RDebugPid *pid;
@@ -8103,7 +8103,7 @@ static int cmd_print(void *data, const char *input) {
 		break;
 	case 'K': // "pK"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_p, "pK", true);
+			r_core_cmd_help_match (core, help_msg_p, "pK");
 		} else if (l > 0) {
 			len = len > core->blocksize? core->blocksize: len;
 			int w, h;

--- a/libr/core/cmd_project.inc.c
+++ b/libr/core/cmd_project.inc.c
@@ -209,7 +209,7 @@ static int cmd_project(void *data, const char *input) {
 		break;
 	case '!': // "P!"
 		if (input [1] == '?') {
-			r_core_cmd_help_match (core, help_msg_P, "P!", false);
+			r_core_cmd_help_contains (core, help_msg_P, "P!");
 		} else if (r_config_get_b (core->config, "scr.interactive")) {
 			char *pdir = r_file_new (
 				r_config_get (core->config, "dir.projects"),
@@ -253,7 +253,7 @@ static int cmd_project(void *data, const char *input) {
 				}
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_P, "PS", false);
+			r_core_cmd_help_contains (core, help_msg_P, "PS");
 		}
 		break;
 	case 'n': // "Pn"
@@ -359,7 +359,7 @@ static int cmd_project(void *data, const char *input) {
 						free (data);
 					}
 				} else {
-					r_core_cmd_help_match (core, help_msg_P, "Pn", false);
+					r_core_cmd_help_contains (core, help_msg_P, "Pn");
 				}
 				break;
 			case 'x': // "Pnx"

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -2247,7 +2247,7 @@ static void do_ref_search(RCore *core, ut64 addr,ut64 from, ut64 to, struct sear
 static void cmd_search_aF(RCore *core, const char *input) {
 	bool quiet = *input == 'd';
 	if (*input && *input != ' ' && *input != 'd') {
-		r_core_cmd_help_match (core, help_msg_slash_a, "aF", false);
+		r_core_cmd_help_contains (core, help_msg_slash_a, "aF");
 		return;
 	}
 	RAnalFunction *fcn;
@@ -3969,7 +3969,7 @@ reread:
 		goto reread;
 	case 'o': { // "/o" print the offset of the Previous opcode
 			  if (input[1] == '?') {
-				  r_core_cmd_help_match (core, help_msg_slash, "/o", true);
+				  r_core_cmd_help_match (core, help_msg_slash, "/o");
 				  break;
 			  }
 			  ut64 addr, n = input[param_offset - 1] ? r_num_math (core->num, input + param_offset) : 1;
@@ -3990,7 +3990,7 @@ reread:
 		break;
 	case 'O': { // "/O" alternative to "/o"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_slash, "/O", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/O");
 			break;
 		}
 		ut64 addr, n = input[param_offset - 1] ? r_num_math (core->num, input + param_offset) : 1;
@@ -4106,7 +4106,7 @@ reread:
 					r_core_seek (core, curseek, true);
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_slash_r, "/re", true);
+				r_core_cmd_help_match (core, help_msg_slash_r, "/re");
 				dosearch = false;
 			}
 			break;
@@ -4229,7 +4229,7 @@ reread:
 		case 'z': // "/az"
 			switch (input[2]) {
 			case '?': // "/az"
-				r_core_cmd_help_match (core, help_msg_slash_a, "/az", true);
+				r_core_cmd_help_match (core, help_msg_slash_a, "/az");
 				break;
 			case 'q': // "/azq"
 				do_analstr_search (core, &param, true, r_str_trim_head_ro (input + 3));
@@ -4244,7 +4244,7 @@ reread:
 				do_analstr_search (core, &param, false, "");
 				break;
 			default:
-				r_core_cmd_help_match (core, help_msg_slash_a, "/az", true);
+				r_core_cmd_help_match (core, help_msg_slash_a, "/az");
 				break;
 			}
 			dosearch = false;
@@ -4415,7 +4415,7 @@ reread:
 				char *space = strchr (input, ' ');
 				const char *arg = space? r_str_trim_head_ro (space + 1): NULL;
 				if (!arg || *(space - 1) == '?') {
-					r_core_cmd_help_match (core, help_msg_slash_c, "/ca", true);
+					r_core_cmd_help_match (core, help_msg_slash_c, "/ca");
 					goto beach;
 				} else {
 					if (input[2] == 'j') {
@@ -4560,7 +4560,7 @@ reread:
 			r_core_cmd_help (core, help_msg_slash_pattern);
 		} else if (input[1] == 'p') { // "/pp" -- find next prelude
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_slash_pattern, "/pp", true);
+				r_core_cmd_help_match (core, help_msg_slash_pattern, "/pp");
 			} else {
 				__core_cmd_search_backward_prelude (core, false, true);
 			}
@@ -4613,14 +4613,14 @@ reread:
 				}
 			}
 			if (err) {
-				r_core_cmd_help_match (core, help_msg_slash, "/V", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/V");
 			}
 		}
 		dosearch = false;
 		break;
 	case 'v': // "/v"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_slash, "/v", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/v");
 			break;
 		}
 		r_search_reset (core->search, R_SEARCH_KEYWORD);
@@ -4637,7 +4637,7 @@ reread:
 				bsize = sizeof (ut64) * len;
 				v_buf = v_writebuf (core, nums, len, '8', bsize);
 			} else {
-				r_core_cmd_help_match (core, help_msg_slash, "/v", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/v");
 			}
 			break;
 		case '1':
@@ -4645,7 +4645,7 @@ reread:
 				bsize = sizeof (ut8) * len;
 				v_buf = v_writebuf (core, nums, len, '1', bsize);
 			} else {
-				r_core_cmd_help_match (core, help_msg_slash, "/v", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/v");
 			}
 			break;
 		case '2':
@@ -4653,7 +4653,7 @@ reread:
 				bsize = sizeof (ut16) * len;
 				v_buf = v_writebuf (core, nums, len, '2', bsize);
 			} else {
-				r_core_cmd_help_match (core, help_msg_slash, "/v", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/v");
 			}
 			break;
 		default: // default size
@@ -4664,7 +4664,7 @@ reread:
 					v_buf = v_writebuf (core, nums, len, '4', bsize);
 				}
 			} else {
-				r_core_cmd_help_match (core, help_msg_slash, "/v", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/v");
 			}
 			break;
 		}
@@ -4715,7 +4715,7 @@ reread:
 		break;
 	case 'i': // "/i"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_slash, "/i", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/i");
 			break;
 		}
 		if (input[param_offset - 1] != ' ') {
@@ -4778,7 +4778,7 @@ reread:
 		break;
 	case 'e': // "/e" match regexp
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_slash, "/e", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/e");
 		} else if (input[1]) {
 			RSearchKeyword *kw;
 			kw = r_search_keyword_new_regexp (input + 1, NULL);
@@ -4825,7 +4825,7 @@ reread:
 		if (p) {
 			*p++ = 0;
 			if (*arg == '?') {
-				r_core_cmd_help_match (core, help_msg_slash, "/h", true);
+				r_core_cmd_help_match (core, help_msg_slash, "/h");
 			} else {
 				ut32 min = UT32_MAX;
 				ut32 max = UT32_MAX;
@@ -4865,7 +4865,7 @@ reread:
 		break;
 	case 'g': // "/g" graph search
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_slash, "/g", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/g");
 		} else {
 			ut64 addr = UT64_MAX;
 			if (input[1]) {
@@ -4934,7 +4934,7 @@ reread:
 			r_str_argv_free (args);
 			free (buf);
 		} else {
-			r_core_cmd_help_match (core, help_msg_slash, "/F", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/F");
 		}
 		break;
 	case 'x': // "/x" search hex
@@ -5005,7 +5005,7 @@ again:
 			free (str);
 			free (buf);
 		} else {
-			r_core_cmd_help_match (core, help_msg_slash, "/+", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/+");
 		}
 		break;
 	case 'z': // "/z" search strings of min-max range
@@ -5013,7 +5013,7 @@ again:
 		char *p;
 		ut32 min, max;
 		if (!input[1]) {
-			r_core_cmd_help_match (core, help_msg_slash, "/z", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/z");
 			break;
 		}
 		const char *maxstr = NULL;
@@ -5022,7 +5022,7 @@ again:
 			maxstr = r_str_trim_head_ro (p + 1);
 			max = r_num_math (core->num, maxstr);
 		} else {
-			r_core_cmd_help_match (core, help_msg_slash, "/z", true);
+			r_core_cmd_help_match (core, help_msg_slash, "/z");
 			break;
 		}
 		const char *minstr = r_str_trim_head_ro (input + 2);

--- a/libr/core/cmd_seek.inc.c
+++ b/libr/core/cmd_seek.inc.c
@@ -249,7 +249,7 @@ static int cmd_sort(void *data, const char *input) { // "sort"
 	}
 	switch (*input) {
 	case '?': // "sort?"
-		r_core_cmd_help_match (core, help_msg_s, "sort", true);
+		r_core_cmd_help_match (core, help_msg_s, "sort");
 		break;
 	default: // "ls"
 		if (!arg) {
@@ -392,7 +392,7 @@ static int cmd_seek(void *data, const char *input) {
 		if (input[1] && input[2]) {
 			seek_to_register (core, input + 2, silent);
 		} else {
-			r_core_cmd_help_match (core, help_msg_s, "sr", false);
+			r_core_cmd_help_contains (core, help_msg_s, "sr");
 		}
 		break;
 	case 'C': // "sC"
@@ -482,7 +482,7 @@ static int cmd_seek(void *data, const char *input) {
 			r_config_set_i (core->config, "search.maxhits", saved_maxhits);
 			break;
 		case '?':
-			r_core_cmd_help_match (core, help_msg_s, "s/", false);
+			r_core_cmd_help_contains (core, help_msg_s, "s/");
 			break;
 		default:
 			R_LOG_ERROR ("unknown search subcommand");
@@ -757,13 +757,13 @@ static int cmd_seek(void *data, const char *input) {
 			if (input[2] == 't') {
 				cmd_sort (core, input);
 			} else if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_s, "sort", true);
+				r_core_cmd_help_match (core, help_msg_s, "sort");
 			} else {
 				return -1;
 			}
 			break;
 		case '?':
-			r_core_cmd_help_match (core, help_msg_s, "so", false);
+			r_core_cmd_help_contains (core, help_msg_s, "so");
 		case ' ':
 		case '\0':
 		case '+':
@@ -844,7 +844,7 @@ static int cmd_seek(void *data, const char *input) {
 					}
 					r_cons_sleep_end (bed);
 				} else {
-					r_core_cmd_help_match (core, help_msg_sl, "sleep", true);
+					r_core_cmd_help_match (core, help_msg_sl, "sleep");
 				}
 			}
 			break;

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -237,12 +237,12 @@ static void cmd_tcc(RCore *core, const char *input) {
 	case '-':
 		if (input[1] == '*') {
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_tcc, "tcc-*", true);
+				r_core_cmd_help_match (core, help_msg_tcc, "tcc-*");
 			} else {
 				sdb_reset (core->anal->sdb_cc);
 			}
 		} else if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_tcc, "tcc-", false);
+			r_core_cmd_help_contains (core, help_msg_tcc, "tcc-");
 		} else {
 			r_anal_cc_del (core->anal, r_str_trim_head_ro (input + 1));
 		}
@@ -252,14 +252,14 @@ static void cmd_tcc(RCore *core, const char *input) {
 	case 'j':
 	case '*':
 		if (*input && input[1] == '?') {
-			r_core_cmd_help_match_spec (core, help_msg_tcc, "tcc", *input, true);
+			r_core_cmd_help_match_spec (core, help_msg_tcc, "tcc", *input);
 		} else {
 			cmd_afcl (core, input);
 		}
 		break;
 	case 'k':
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_tcc, "tcck", true);
+			r_core_cmd_help_match (core, help_msg_tcc, "tcck");
 		} else {
 			cmd_afck (core, NULL);
 		}
@@ -328,7 +328,7 @@ static int cmd_tac(void *data, const char *_input) { // "tac"
 	}
 	switch (*input) {
 	case '?': // "tac?"
-		r_core_cmd_help_match (core, help_msg_t, "tac", true);
+		r_core_cmd_help_match (core, help_msg_t, "tac");
 		break;
 	default: // "tac"
 		if (R_STR_ISNOTEMPTY (arg)) {
@@ -342,7 +342,7 @@ static int cmd_tac(void *data, const char *_input) { // "tac"
 			r_list_free (lines);
 			free (filedata);
 		} else {
-			r_core_cmd_help_match (core, help_msg_t, "tac", true);
+			r_core_cmd_help_match (core, help_msg_t, "tac");
 		}
 		break;
 	}
@@ -367,7 +367,7 @@ static int cmd_tail(void *data, const char *_input) { // "tail"
 	}
 	switch (*input) {
 	case '?': // "tail?"
-		r_core_cmd_help_match (core, help_msg_t, "tail", true);
+		r_core_cmd_help_match (core, help_msg_t, "tail");
 		break;
 	default: // "tail"
 		if (!arg) {
@@ -1117,7 +1117,7 @@ static int cmd_type(void *data, const char *input) {
 	}
 	case 'k': // "tk"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_t, "tk", true);
+			r_core_cmd_help_match (core, help_msg_t, "tk");
 		} else {
 			res = (input[1] == ' ')
 				? sdb_querys (TDB, NULL, -1, input + 2)
@@ -1165,7 +1165,7 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case 'd': // "tcd"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_tc, "tcd", true);
+				r_core_cmd_help_match (core, help_msg_tc, "tcd");
 			} else {
 				r_core_cmd0 (core, "tud;tsd;ttc;ted");
 			}
@@ -1280,7 +1280,7 @@ static int cmd_type(void *data, const char *input) {
 				free (name);
 				ls_free (l);
 			} else if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_te, "tej", false);
+				r_core_cmd_help_contains (core, help_msg_te, "tej");
 			} else { // "tej ENUM"
 				RListIter *iter;
 				PJ *pj = pj_new ();
@@ -1309,21 +1309,21 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case 'b': // "teb"
 			if (R_STR_ISEMPTY (name) || input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_te, "teb", true);
+				r_core_cmd_help_match (core, help_msg_te, "teb");
 			} else {
 				res = r_type_enum_member (TDB, name, member_name, 0);
 			}
 			break;
 		case 'c': // "tec"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_te, "tec", true);
+				r_core_cmd_help_match (core, help_msg_te, "tec");
 			} else {
 				print_enum_in_c_format (TDB, r_str_trim_head_ro (input + 2), true);
 			}
 			break;
 		case 'd': // "ted"
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_te, "ted", true);
+				r_core_cmd_help_match (core, help_msg_te, "ted");
 			} else {
 				print_enum_in_c_format (TDB, r_str_trim_head_ro (input + 2), false);
 			}
@@ -1392,7 +1392,7 @@ static int cmd_type(void *data, const char *input) {
 	case '*': // "t*"
 	case '\0': // "t"
 		if (input[0] && input[1] == '?') {
-			r_core_cmd_help_match_spec (core, help_msg_t, "t", input[0], true);
+			r_core_cmd_help_match_spec (core, help_msg_t, "t", input[0]);
 		} else {
 			typesList (core, input[0]);
 		}
@@ -1447,7 +1447,7 @@ static int cmd_type(void *data, const char *input) {
 				if (arg) {
 					r_file_touch (arg + 1);
 				} else {
-					r_core_cmd_help_match (core, help_msg_to, "touch", true);
+					r_core_cmd_help_match (core, help_msg_to, "touch");
 				}
 			} else if (input[1] == 's') {
 				const char *dbpath = input + 3;
@@ -1485,7 +1485,7 @@ static int cmd_type(void *data, const char *input) {
 	case 'd': // "td"
 		if (input[1] == '?') {
 			// TODO #7967 help refactor: move to detail
-			r_core_cmd_help_match (core, help_msg_t, "td", true);
+			r_core_cmd_help_match (core, help_msg_t, "td");
 		} else if (input[1] == ' ') {
 			char *tmp = r_str_newf ("%s;", input + 2);
 			if (!tmp) {
@@ -1605,11 +1605,11 @@ static int cmd_type(void *data, const char *input) {
 			if (input[2] == 'l') {
 				cmd_tail (core, input);
 			} else {
-				r_core_cmd_help_match (core, help_msg_t, "tail", true);
+				r_core_cmd_help_match (core, help_msg_t, "tail");
 			}
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_t, "ta", false);
+			r_core_cmd_help_contains (core, help_msg_t, "ta");
 			break;
 		}
 		break;
@@ -1712,7 +1712,7 @@ static int cmd_type(void *data, const char *input) {
 				ut64 val = core->offset;
 				r_core_cmdf (core, "pf %s @v:0x%08" PFMT64x, fmt, val);
 			} else {
-				r_core_cmd_help_match (core, help_msg_tp, "tpv", true);
+				r_core_cmd_help_match (core, help_msg_tp, "tpv");
 			}
 		} else if (input[1] == ' ' || input[1] == 'x' || !input[1]) {
 			char *tmp = strdup (input);
@@ -1777,10 +1777,10 @@ static int cmd_type(void *data, const char *input) {
 		break;
 	case '-': // "t-"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_t, "t-", false);
+			r_core_cmd_help_contains (core, help_msg_t, "t-");
 		} else if (input[1] == '*') {
 			if (input[2] == '?') {
-				r_core_cmd_help_match (core, help_msg_t, "t-*", true);
+				r_core_cmd_help_match (core, help_msg_t, "t-*");
 			} else {
 				sdb_reset (TDB);
 			}

--- a/libr/core/cmd_write.inc.c
+++ b/libr/core/cmd_write.inc.c
@@ -336,7 +336,7 @@ static int cmd_wo(void *data, const char *input) {
 	switch (input[0]) {
 	case 'e': // "woe"
 		if (input[1]!=' ') {
-			r_core_cmd_help_match (core, help_msg_wo, "woe", true);
+			r_core_cmd_help_match (core, help_msg_wo, "woe");
 			return -1;
 		}
 		/* fallthrough */
@@ -355,7 +355,7 @@ static int cmd_wo(void *data, const char *input) {
 	case '4': // "wo4"
 	case '8': // "wo8"
 		if (input[1] == '?') {  // parse val from arg
-			r_core_cmd_help_match_spec (core, help_msg_wo, "wo", input[0], true);
+			r_core_cmd_help_match_spec (core, help_msg_wo, "wo", input[0]);
 		} else if (input[1]) {  // parse val from arg
 			r_core_write_op (core, r_str_trim_head_ro (input + 1), input[0]);
 		} else {  // use clipboard instead of val
@@ -393,7 +393,7 @@ static int cmd_wo(void *data, const char *input) {
 				encrypt_or_decrypt_block (core, algo, key, direction, iv);
 			} else {
 				r_crypto_list (core->crypto, r_cons_printf, 0);
-				r_core_cmd_help_match_spec (core, help_msg_wo, "wo", input[0], true);
+				r_core_cmd_help_match_spec (core, help_msg_wo, "wo", input[0]);
 			}
 			free (args);
 		}
@@ -576,7 +576,7 @@ static bool cmd_wff(RCore *core, const char *input) {
 	}
 
 	if (*arg == '?' || !*arg) {
-		r_core_cmd_help_match (core, help_msg_w, "wf", false);
+		r_core_cmd_help_contains (core, help_msg_w, "wf");
 	} else if (!strcmp (arg, "-")) {
 		char *out = r_core_editor (core, NULL, NULL);
 		if (out) {
@@ -691,7 +691,7 @@ static bool cmd_wfx(RCore *core, const char *input) {
 static bool cmd_wfs(RCore *core, const char *input) {
 	char *str = strdup (input);
 	if (str[0] != ' ') {
-		r_core_cmd_help_match (core, help_msg_wf, "wfs", false);
+		r_core_cmd_help_contains (core, help_msg_wf, "wfs");
 		free (str);
 		return false;
 	}
@@ -699,7 +699,7 @@ static bool cmd_wfs(RCore *core, const char *input) {
 	char *host = str + 1;
 	char *port = strchr (host, ':');
 	if (!port) {
-		r_core_cmd_help_match (core, help_msg_wf, "wfs", true);
+		r_core_cmd_help_match (core, help_msg_wf, "wfs");
 		free (str);
 		return false;
 	}
@@ -889,7 +889,7 @@ static int cmd_wB(void *data, const char *input) {
 		cmd_write_bits (core, 0, r_num_math (core->num, input + 1));
 		break;
 	default:
-		r_core_cmd_help_match (core, help_msg_w, "wB", true);
+		r_core_cmd_help_match (core, help_msg_w, "wB");
 		break;
 	}
 	return 0;
@@ -931,7 +931,7 @@ static int w_incdec_handler(void *data, const char *input, int inc) {
 		cmd_write_inc (core, inc, -num);
 		break;
 	default:
-		r_core_cmd_help_match (core, help_msg_w, "w", true);
+		r_core_cmd_help_match (core, help_msg_w, "w");
 	}
 	return 0;
 }
@@ -1012,7 +1012,7 @@ static int cmd_w6(void *data, const char *input) {
 		r_core_block_read (core);
 		free (buf);
 	} else {
-		r_core_cmd_help_match (core, help_msg_w, "w6", true);
+		r_core_cmd_help_match (core, help_msg_w, "w6");
 	}
 	return 0;
 }
@@ -1057,7 +1057,7 @@ static int cmd_we(void *data, const char *input) {
 				}
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_we, "wen", true);
+			r_core_cmd_help_match (core, help_msg_we, "wen");
 			cmd_suc = true;
 		}
 		break;
@@ -1254,7 +1254,7 @@ static int cmd_wu(RCore *core, const char *input) {
 			free (data);
 		}
 	} else {
-		r_core_cmd_help_match (core, help_msg_we, "wu", true);
+		r_core_cmd_help_match (core, help_msg_we, "wu");
 	}
 	return 0;
 }
@@ -1316,7 +1316,7 @@ static int cmd_wA(void *data, const char *input) {
 				eprintf ("r_asm_modify = %d\n", len);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_w, "wA", true);
+			r_core_cmd_help_match (core, help_msg_w, "wA");
 		}
 		break;
 	case '?':
@@ -1423,7 +1423,7 @@ static int cmd_wc(void *data, const char *input) {
 		if (input[1] == ' ') {
 			cmd_wcf (core, r_str_trim_head_ro (input + 1));
 		} else {
-			r_core_cmd_help_match (core, help_msg_wc, "wcf", true);
+			r_core_cmd_help_match (core, help_msg_wc, "wcf");
 		}
 		break;
 	case '*': // "wc*"
@@ -1433,7 +1433,7 @@ static int cmd_wc(void *data, const char *input) {
 		if (input[1] == '+') { // "wc++"
 			r_io_cache_push (core->io);
 		} else if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_wc, "wc+", false);
+			r_core_cmd_help_contains (core, help_msg_wc, "wc+");
 		} else if (input[1] == ' ') { // "wc+ "
 			ut64 to;
 			ut64 from = r_num_math (core->num, input + 2);
@@ -1464,7 +1464,7 @@ static int cmd_wc(void *data, const char *input) {
 				r_io_cache_pop (core->io);
 			}
 		} else if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_wc, "wc-", false);
+			r_core_cmd_help_contains (core, help_msg_wc, "wc-");
 		} else {
 			ut64 from, to;
 			if (input[1] == ' ') { // "wc- "
@@ -1583,7 +1583,7 @@ static int cmd_wz(RCore *core, const char *input) {
 	/* write zero-terminated string */
 	if (*input == '?' || *input != ' ' || len < 1) {
 		free (str);
-		r_core_cmd_help_match (core, help_msg_w, "wz", true);
+		r_core_cmd_help_match (core, help_msg_w, "wz");
 		r_core_return_value (core, 0);
 		return 0;
 	}
@@ -1627,7 +1627,7 @@ static int cmd_wt(RCore *core, const char *input) {
 			RSocket *sock;
 
 			if (argc < 2) {
-				r_core_cmd_help_match (core, help_msg_wt, "wts", true);
+				r_core_cmd_help_match (core, help_msg_wt, "wts");
 				ret = 1;
 				goto leave;
 			}
@@ -1644,7 +1644,7 @@ static int cmd_wt(RCore *core, const char *input) {
 			host = host_port;
 			port = strchr (host_port, ':');
 			if (!port) {
-				r_core_cmd_help_match (core, help_msg_wt, "wts", true);
+				r_core_cmd_help_match (core, help_msg_wt, "wts");
 				free (host_port);
 				ret = 1;
 				goto leave;
@@ -1692,13 +1692,13 @@ static int cmd_wt(RCore *core, const char *input) {
 			switch (input[1]) {
 			case '\0':
 			case '?': // "wtf?"
-				r_core_cmd_help_match (core, help_msg_wt, "wtf", true);
+				r_core_cmd_help_match (core, help_msg_wt, "wtf");
 				ret = 1;
 				goto leave;
 			case '!': { // "wtf!"
 				RIOMap *map;
 				if (input[2] == '?') {
-					r_core_cmd_help_match (core, help_msg_wt, "wtf!", true);
+					r_core_cmd_help_match (core, help_msg_wt, "wtf!");
 					ret = 1;
 					goto leave;
 				}
@@ -1719,7 +1719,7 @@ static int cmd_wt(RCore *core, const char *input) {
 			}
 			case 'f': // "wtff"
 				if (input[2] == '?') {
-					r_core_cmd_help_match (core, help_msg_wt, "wtff", true);
+					r_core_cmd_help_match (core, help_msg_wt, "wtff");
 					ret = 1;
 					goto leave;
 				}
@@ -1732,7 +1732,7 @@ static int cmd_wt(RCore *core, const char *input) {
 				break;
 			default: // "wtf"
 				if (input[2] == '?') {
-					r_core_cmd_help_match (core, help_msg_wt, "wtf", true);
+					r_core_cmd_help_match (core, help_msg_wt, "wtf");
 					ret = 1;
 					goto leave;
 				}
@@ -2136,7 +2136,7 @@ static int cmd_wb(void *data, const char *input) {
 		b |= (n << shift);
 		r_io_write_at (core->io, core->offset, &b, 1);
 	} else {
-		r_core_cmd_help_match (core, help_msg_w, "wb", true);
+		r_core_cmd_help_match (core, help_msg_w, "wb");
 	}
 
 	return 0;
@@ -2229,11 +2229,11 @@ static int cmd_wd(void *data, const char *input) {
 				free (data);
 			}
 		} else {
-			r_core_cmd_help_match (core, help_msg_w, "wd", true);
+			r_core_cmd_help_match (core, help_msg_w, "wd");
 		}
 		free (inp);
 	} else {
-		r_core_cmd_help_match (core, help_msg_w, "wd", true);
+		r_core_cmd_help_match (core, help_msg_w, "wd");
 	}
 	return 0;
 }

--- a/libr/core/cmd_zign.inc.c
+++ b/libr/core/cmd_zign.inc.c
@@ -184,7 +184,7 @@ static int cmdAdd(void *data, const char *input) {
 	RCore *core = (RCore *)data;
 	if (*input && input[1] == '?') {
 		char two[3] = { input[0], input[1], 0 };
-		r_core_cmd_help_match (core, help_msg_za, two, false);
+		r_core_cmd_help_contains (core, help_msg_za, two);
 		return 0;
 	}
 
@@ -196,7 +196,7 @@ static int cmdAdd(void *data, const char *input) {
 			char *args = r_str_trim_dup (input + 1);
 			int n = r_str_word_set0 (args);
 			if (input[1] == '?' || n > 2) {
-				r_core_cmd_help_match (core, help_msg_za, "zaf", false);
+				r_core_cmd_help_contains (core, help_msg_za, "zaf");
 				free (args);
 				return false;
 			}
@@ -219,7 +219,7 @@ static int cmdAdd(void *data, const char *input) {
 		break;
 	case 'c': // "zac"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_za, "zac", false);
+			r_core_cmd_help_contains (core, help_msg_za, "zac");
 		} else {
 			r_cons_break_push (NULL, NULL);
 			r_sign_resolve_collisions (core->anal);
@@ -228,7 +228,7 @@ static int cmdAdd(void *data, const char *input) {
 		break;
 	case 'F': // "zaF"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_za, "zaF", false);
+			r_core_cmd_help_contains (core, help_msg_za, "zaF");
 		} else {
 			int count = r_sign_all_functions (core->anal, false);
 			R_LOG_INFO ("generated zignatures: %d", count);
@@ -236,7 +236,7 @@ static int cmdAdd(void *data, const char *input) {
 		break;
 	case 'M': // "zaM"
 		if (input[1] == '?') {
-			r_core_cmd_help_match (core, help_msg_za, "zaM", false);
+			r_core_cmd_help_contains (core, help_msg_za, "zaM");
 		} else {
 			int count = r_sign_all_functions (core->anal, true);
 			R_LOG_INFO ("generated zignatures: %d", count);
@@ -294,19 +294,19 @@ static int cmdOpen(void *data, const char *input) {
 		if (input[1]) {
 			return r_sign_load (core->anal, r_str_trim_head_ro (input + 1), false);
 		}
-		r_core_cmd_help_match (core, help_msg_zo, "zo", false);
+		r_core_cmd_help_contains (core, help_msg_zo, "zo");
 		return false;
 	case 's':
 		if (input[1] == ' ' && input[2]) {
 			return r_sign_save (core->anal, r_str_trim_head_ro (input + 2));
 		}
-		r_core_cmd_help_match (core, help_msg_zo, "zos", false);
+		r_core_cmd_help_contains (core, help_msg_zo, "zos");
 		return false;
 	case 'z':
 		if (input[1] == ' ' && input[2]) {
 			return r_sign_load_gz (core->anal, input + 2, false);
 		}
-		r_core_cmd_help_match (core, help_msg_zo, "zoz", false);
+		r_core_cmd_help_contains (core, help_msg_zo, "zoz");
 		return false;
 	case '?':
 		r_core_cmd_help (core, help_msg_zo);
@@ -325,7 +325,7 @@ static int cmdSpace(void *data, const char *input) {
 	switch (*input) {
 	case '+':
 		if (!input[1]) {
-			r_core_cmd_help_match (core, help_msg_zs, "zs+", false);
+			r_core_cmd_help_contains (core, help_msg_zs, "zs+");
 			return false;
 		}
 		char *sp = r_str_trim_dup (input + 1);
@@ -336,7 +336,7 @@ static int cmdSpace(void *data, const char *input) {
 		break;
 	case 'r':
 		if (input[1] != ' ' || !input[2]) {
-			r_core_cmd_help_match (core, help_msg_zs, "zsr", false);
+			r_core_cmd_help_contains (core, help_msg_zs, "zsr");
 			return false;
 		}
 		r_spaces_rename (zs, NULL, input + 2);
@@ -366,7 +366,7 @@ static int cmdSpace(void *data, const char *input) {
 		r_core_cmd_help (core, help_msg_zs);
 		break;
 	default:
-		r_core_cmd_help_match (core, help_msg_zs, "zs", false);
+		r_core_cmd_help_contains (core, help_msg_zs, "zs");
 		return false;
 	}
 
@@ -380,7 +380,7 @@ static int cmdFlirt(void *data, const char *input) {
 	case 'd':
 		// TODO
 		if (input[1] != ' ') {
-			r_core_cmd_help_match (core, help_msg_zf, "zfd", false);
+			r_core_cmd_help_contains (core, help_msg_zf, "zfd");
 			return false;
 		}
 		r_sign_flirt_dump (core->anal, input + 2);
@@ -388,7 +388,7 @@ static int cmdFlirt(void *data, const char *input) {
 	case 's':
 		// TODO
 		if (input[1] != ' ') {
-			r_core_cmd_help_match (core, help_msg_zf, "zfs", false);
+			r_core_cmd_help_contains (core, help_msg_zf, "zfs");
 			return false;
 		}
 		int depth = r_config_get_i (core->config, "dir.depth");
@@ -1149,7 +1149,7 @@ static int cmdCompare(void *data, const char *input) {
 		switch (input[1]) {
 		case ' ':
 			if (!input[2]) {
-				r_core_cmd_help_match (core, help_msg_zc, "zcn", false);
+				r_core_cmd_help_contains (core, help_msg_zc, "zcn");
 				result = false;
 				break;
 			}
@@ -1157,14 +1157,14 @@ static int cmdCompare(void *data, const char *input) {
 			break;
 		case '!':
 			if (input[2] != ' ' || !input[3]) {
-				r_core_cmd_help_match (core, help_msg_zc, "zcn", false);
+				r_core_cmd_help_contains (core, help_msg_zc, "zcn");
 				result = false;
 				break;
 			}
 			result = r_sign_diff_by_name (core->anal, options, input + 3, true);
 			break;
 		default:
-			r_core_cmd_help_match (core, help_msg_zc, "zcn", false);
+			r_core_cmd_help_contains (core, help_msg_zc, "zcn");
 			result = false;
 		}
 		break;
@@ -1240,7 +1240,7 @@ static int cmdSearch(void *data, const char *input) {
 		case '*':
 			return search (core, input[1] == '*', true);
 		default:
-			r_core_cmd_help_match (core, help_msg_z_slash, "z/f", false);
+			r_core_cmd_help_contains (core, help_msg_z_slash, "z/f");
 			return false;
 		}
 	case '?':

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -906,8 +906,10 @@ R_API PJ *r_core_pj_new(RCore *core);
 /* help */
 R_API void r_core_cmd_help(const RCore *core, RCoreHelpMessage help);
 R_API void r_core_cmd_help_json(const RCore *core, RCoreHelpMessage help);
-R_API void r_core_cmd_help_match(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd, bool exact);
-R_API void r_core_cmd_help_match_spec(const RCore *core, const char * const help[], R_BORROW R_NONNULL char *cmd, char spec, bool exact);
+R_API void r_core_cmd_help_match(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd);
+R_API void r_core_cmd_help_contains(const RCore *core, RCoreHelpMessage help, R_BORROW R_NONNULL char *cmd);
+R_API void r_core_cmd_help_match_spec(const RCore *core, const char * const help[], R_BORROW R_NONNULL char *cmd, char spec);
+R_API void r_core_cmd_help_contains_spec(const RCore *core, const char * const help[], R_BORROW R_NONNULL char *cmd, char spec);
 
 /* anal stats */
 


### PR DESCRIPTION
Closes #21437. Reads much better now.

Used the following regex:

```
$ find libr -type f -exec sed -i {} -E \
  -e 's/r_core_cmd_help_match (\(.*), true/r_core_cmd_help_match \1/' \
  -e 's/r_core_cmd_help_match (\(.*), false/r_core_cmd_help_contains \1/' \
  -e 's/r_core_cmd_help_match_spec (\(.*), true/r_core_cmd_help_match_spec \1/' \
  -e 's/r_core_cmd_help_match_spec (\(.*), false/r_core_cmd_help_contains_spec \1/' \;
```