### PR TITLE
Fix #22349 - oobread in xnu kernelcache ##crash

### DIFF
--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -988,7 +988,7 @@ static void process_constructors(RKernelCacheObj *obj, struct MACH0_(obj_t) *mac
 		}
 		int j;
 		int count = 0;
-		for (j = 0; j < section->size; j += 8) {
+		for (j = 0; j + 7 < section->size; j += 8) {
 			ut64 addr64 = K_RPTR (buf + j);
 			ut64 paddr64 = section->paddr + paddr + j;
 			if (mode == R_K_CONSTRUCTOR_TO_ENTRY) {


### PR DESCRIPTION
* Reproducer rabin_hbo_194
* Reported by @gandalf4a

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

**Copilot**

<!--
copilot:all
-->
