### PR TITLE
Handle Kotlin as an alias for Java in icc classdump ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3804,7 +3804,7 @@ static bool bin_classes(RCore *r, PJ *pj, int mode) {
 				const char *vlang = r_config_get (r->config, "bin.lang");
 				r_str_var (lang, 16, vlang);
 				if (*lang) {
-					if (!strcmp (lang, "java")) {
+					if (!strcmp (lang, "java") || !strcmp (lang, "kotlin")) {
 						classdump_java (r, c);
 					} else if (!strcmp (lang, "swift")) {
 						classdump_swift (r, c);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
