### PR TITLE
Fix entry point determination and info for HUNK file parser ##bin

### DIFF
--- a/libr/bin/p/bin_hunk.c
+++ b/libr/bin/p/bin_hunk.c
@@ -82,9 +82,6 @@ static RList* entries(RBinFile *bf) {
 		}
 	}
 	R_LOG_ERROR ("Cannot determine entrypoint, cannot find HUNK_CODE");
-	ptr->paddr = 0;
-	ptr->vaddr = 0;
-	r_list_append (ret, ptr);
 	return ret;
 }
 

--- a/libr/bin/p/bin_hunk.c
+++ b/libr/bin/p/bin_hunk.c
@@ -6,15 +6,17 @@
 #if 0
 https://es.wikipedia.org/wiki/Amiga_Hunk
 http://amiga-dev.wikidot.com/file-format:hunk
+https://retro-commodore.eu/files/downloads/amigamanuals-xiik.net/eBooks/AmigaDOS%20Technical%20Reference%20Manual%20-%20eBook-ENG.pdf
 #endif
 
-#define HUNK_MAGIC "\x00\x00\x03\xf3"
+#define HUNK_HEADER "\x00\x00\x03\xf3"
+#define HUNK_CODE "\x00\x00\x03\xe9"
 
 static bool check(RBinFile *bf, RBuffer *b) {
 	if (r_buf_size (b) > 4) {
 		ut8 buf[4];
 		r_buf_read_at (b, 0, buf, sizeof (buf));
-		return (!memcmp (buf, HUNK_MAGIC, sizeof (buf)));
+		return (!memcmp (buf, HUNK_HEADER, sizeof (buf)));
 	}
 	return false;
 }
@@ -29,38 +31,13 @@ static RBinInfo *info(RBinFile *bf) {
 		return NULL;
 	}
 	ret->file = strdup (bf->file);
-	ret->type = strdup ("ROM");
+	ret->type = strdup ("Hunk (Executable file)");
 	ret->machine = strdup ("Amiga");
-	ret->os = strdup ("Workbench");
+	ret->os = strdup ("AmigaOS");
 	ret->arch = strdup ("m68k");
-	ret->cpu = strdup ("68040");
-	ret->bits = 8;
+	ret->bits = 32;
 	ret->has_va = 1;
-	return ret;
-}
-
-#if 0
-static void addsym(RList *ret, const char *name, ut64 addr, ut32 size) {
-	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
-	if (!ptr) {
-		return;
-	}
-	ptr->name = strdup (r_str_get (name));
-	ptr->paddr = ptr->vaddr = addr;
-	ptr->size = size;
-	ptr->ordinal = 0;
-	r_list_append (ret, ptr);
-}
-#endif
-
-static RList* symbols(RBinFile *bf) {
-	RList *ret = NULL;
-	if (!(ret = r_list_newf (free))) {
-		return NULL;
-	}
-#if 0
-	addsym (ret, "NMI_VECTOR_START_ADDRESS", NMI_VECTOR_START_ADDRESS,2);
-#endif
+	ret->big_endian = true;
 	return ret;
 }
 
@@ -73,7 +50,7 @@ static RList* sections(RBinFile *bf) {
 	if (!(ptr = R_NEW0 (RBinSection))) {
 		return ret;
 	}
-	ptr->name = strdup ("hunk");
+	ptr->name = strdup ("HUNK_HEADER");
 	ptr->paddr = 0;
 	ptr->size = r_buf_size (bf->buf);
 	ptr->vaddr = 0;
@@ -84,17 +61,31 @@ static RList* sections(RBinFile *bf) {
 	return ret;
 }
 
-static RList* entries(RBinFile *bf) { //Should be 3 offsets pointed by NMI, RESET, IRQ after mapping && default = 1st CHR
+static RList* entries(RBinFile *bf) {
 	RList *ret;
 	RBinAddr *ptr = NULL;
+	RBuffer *buf;
+	int addr;
+	ut8 b[4];
 	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
 	if (!(ptr = R_NEW0 (RBinAddr))) {
 		return ret;
 	}
-	ptr->paddr = 0x24;
-	ptr->vaddr = 0x24;
+	buf = bf->buf;
+	for (addr = 0x18; addr <= (r_buf_size (buf) - 4); addr += 0x4) {
+		r_buf_read_at (buf, addr, b, sizeof (b));
+			if (!memcmp (b, HUNK_CODE, sizeof (b))) {
+				ptr->paddr = addr + 8;
+				ptr->vaddr = addr + 8;
+				r_list_append (ret, ptr);
+				return ret;
+			}
+	}
+	R_LOG_ERROR ("Cannot determine entrypoint, cannot find HUNK_CODE");
+	ptr->paddr = 0;
+	ptr->vaddr = 0;
 	r_list_append (ret, ptr);
 	return ret;
 }
@@ -109,7 +100,6 @@ RBinPlugin r_bin_plugin_hunk = {
 	.check = &check,
 	.entries = &entries,
 	.sections = sections,
-	.symbols = &symbols,
 	.info = &info,
 };
 

--- a/libr/bin/p/bin_hunk.c
+++ b/libr/bin/p/bin_hunk.c
@@ -63,20 +63,18 @@ static RList* sections(RBinFile *bf) {
 
 static RList* entries(RBinFile *bf) {
 	RList *ret;
-	RBinAddr *ptr = NULL;
-	RBuffer *buf = bf->buf;
-	int addr;
-	ut64 last = r_buf_size (buf) - 4;
-	ut8 b[4];
 	if (!(ret = r_list_new ())) {
 		return NULL;
 	}
+	RBinAddr *ptr = NULL;
 	if (!(ptr = R_NEW0 (RBinAddr))) {
 		return ret;
 	}
+	int addr;
+	ut8 b[1024];
+	int last = r_buf_read_at (bf->buf, 0, b, sizeof (b)) - 4;
 	for (addr = 0x18; addr <= last; addr += 4) {
-		r_buf_read_at (buf, addr, b, sizeof (b));
-		if (!memcmp (b, HUNK_CODE, sizeof (b))) {
+		if (!memcmp (b + addr, HUNK_CODE, 4)) {
 			ptr->paddr = addr + 8;
 			ptr->vaddr = addr + 8;
 			r_list_append (ret, ptr);

--- a/libr/bin/p/bin_hunk.c
+++ b/libr/bin/p/bin_hunk.c
@@ -64,8 +64,9 @@ static RList* sections(RBinFile *bf) {
 static RList* entries(RBinFile *bf) {
 	RList *ret;
 	RBinAddr *ptr = NULL;
-	RBuffer *buf;
+	RBuffer *buf = bf->buf;
 	int addr;
+	ut64 last = r_buf_size (buf) - 4;
 	ut8 b[4];
 	if (!(ret = r_list_new ())) {
 		return NULL;
@@ -73,8 +74,7 @@ static RList* entries(RBinFile *bf) {
 	if (!(ptr = R_NEW0 (RBinAddr))) {
 		return ret;
 	}
-	buf = bf->buf;
-	for (addr = 0x18; addr <= (r_buf_size (buf) - 4); addr += 0x4) {
+	for (addr = 0x18; addr <= last; addr += 4) {
 		r_buf_read_at (buf, addr, b, sizeof (b));
 		if (!memcmp (b, HUNK_CODE, sizeof (b))) {
 			ptr->paddr = addr + 8;

--- a/libr/bin/p/bin_hunk.c
+++ b/libr/bin/p/bin_hunk.c
@@ -76,12 +76,12 @@ static RList* entries(RBinFile *bf) {
 	buf = bf->buf;
 	for (addr = 0x18; addr <= (r_buf_size (buf) - 4); addr += 0x4) {
 		r_buf_read_at (buf, addr, b, sizeof (b));
-			if (!memcmp (b, HUNK_CODE, sizeof (b))) {
-				ptr->paddr = addr + 8;
-				ptr->vaddr = addr + 8;
-				r_list_append (ret, ptr);
-				return ret;
-			}
+		if (!memcmp (b, HUNK_CODE, sizeof (b))) {
+			ptr->paddr = addr + 8;
+			ptr->vaddr = addr + 8;
+			r_list_append (ret, ptr);
+			return ret;
+		}
 	}
 	R_LOG_ERROR ("Cannot determine entrypoint, cannot find HUNK_CODE");
 	ptr->paddr = 0;

--- a/test/db/formats/hunk/grey-final
+++ b/test/db/formats/hunk/grey-final
@@ -1,0 +1,14 @@
+NAME=HUNK: grey-final
+FILE=bins/hunk/grey-final
+CMDS=<<EOF
+pd 3
+EOF
+EXPECT=<<EOF
+[0x00000020]> pd 3
+            ;-- entry0:
+            ;-- pc:
+            0x00000020      4df900dff000   lea.l 0xdff000.l, a6
+            0x00000026      3e3c7fff       move.w 0x7fff, d7
+            0x0000002a      3d470096       move.w d7, 0x96(a6)
+EOF
+RUN

--- a/test/db/formats/hunk/grey-final
+++ b/test/db/formats/hunk/grey-final
@@ -4,9 +4,7 @@ CMDS=<<EOF
 pd 3
 EOF
 EXPECT=<<EOF
-[0x00000020]> pd 3
             ;-- entry0:
-            ;-- pc:
             0x00000020      4df900dff000   lea.l 0xdff000.l, a6
             0x00000026      3e3c7fff       move.w 0x7fff, d7
             0x0000002a      3d470096       move.w d7, 0x96(a6)

--- a/test/db/formats/hunk/mc0201
+++ b/test/db/formats/hunk/mc0201
@@ -1,5 +1,5 @@
-NAME=hunk
-FILE=bins/other/amiga-hunk-mc0201
+NAME=HUNK: mc0201
+FILE=bins/hunk/mc0201
 CMDS=<<EOF
 i
 af
@@ -7,30 +7,29 @@ agf
 EOF
 EXPECT=<<EOF
 fd       3
-file     bins/other/amiga-hunk-mc0201
+file     hunk/mc0201
 size     0xcc
 humansz  204
 mode     r-x
 format   hunk
 iorw     false
 block    0x100
-type     ROM
+type     Hunk (Executable file)
 arch     m68k
-cpu      68040
 binsz    204
-bits     8
+bits     32
 canary   false
 injprot  false
 retguard false
 crypto   false
-endian   little
+endian   big
 havecode true
 laddr    0x0
 linenum  false
 lsyms    false
 machine  Amiga
 nx       false
-os       Workbench
+os       AmigaOS
 pic      false
 relocs   false
 sanitize false

--- a/test/db/formats/hunk/mc0201
+++ b/test/db/formats/hunk/mc0201
@@ -7,7 +7,7 @@ agf
 EOF
 EXPECT=<<EOF
 fd       3
-file     hunk/mc0201
+file     bins/hunk/mc0201
 size     0xcc
 humansz  204
 mode     r-x
@@ -41,8 +41,8 @@ va       true
  |  0x24                        |
  | 76: entry0 ();               |
  | move.w 0x1a0, 0xdff096.l     |
- | lea.l 0x4c.l, a1             |
- | move.l a1, 0xdff080.l        |
+ | lea.l 0x4c, a1               |
+ | move.l a1, 0xdff080          |
  | move.w 0x8080, 0xdff096.l    |
  `------------------------------'
      v
@@ -67,7 +67,7 @@ va       true
 .--------------------------------.
 |  0x4c                          |
 | move.w 0x80, 0xdff096.l        |
-| movea.l 0x4.l, a6              |
+| movea.l 0x4, a6                |
 | movea.l 0x9c(a6), a1           |
 | move.l 0x26(a1), 0xdff080.l    |
 | move.w 0x81a0, 0xdff096.l      |


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

**Test1**
```
radare2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -NN -Qc 'pd 3' radare2-testbins/hunk/mc0201
            ;-- entry0:
            0x00000024      33fc01a000..   move.w 0x1a0, 0xdff096.l
            0x0000002c      43f90000004c   lea.l 0x4c.l, a1
            0x00000032      23c900dff080   move.l a1, 0xdff080.l
```

**Test2**
```
radare2 -escr.utf8=0 -escr.color=0 -escr.interactive=0 -NN -Qc 'pd 3' radare2-testbins/hunk/grey-final 
            ;-- entry0:
            0x00000020      4df900dff000   lea.l 0xdff000.l, a6
            0x00000026      3e3c7fff       move.w 0x7fff, d7
            0x0000002a      3d470096       move.w d7, 0x96(a6)
```

<!-- explain your changes if necessary -->
