### PR TITLE
Fix: Popd throws an error incorrectly on final pop

### DIFF
--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -608,7 +608,6 @@ R_API bool r_syscmd_popd(void) {
 	if (r_list_empty (dirstack)) {
 		r_list_free (dirstack);
 		dirstack = NULL;
-		return false;
 	}
 	return true;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Popd throws an error incorrectly on final pop. An empty stack should not be considered an error, after emptying it.
