### PR TITLE
Minor dwarf getsection fix

### DIFF
--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -383,6 +383,9 @@ static RBinSection *getsection(RBin *bin, int sn) {
 			? dwarf_sn_xcoff64
 			: dwarf_sn_elf;
 		const char *name_str = name_tab[sn];
+		if (!name_str) {
+			return NULL;
+		}
 		r_list_foreach (o->sections, iter, section) {
 			if (strstr (section->name, name_str)) {
 				if (strstr (section->name, "zdebug")) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

#22449 introduces a bug where NULL can be passed to strstr in some cases. 