### PR TITLE
Fix a few long-standing issues in dyldcache parsing

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -496,16 +496,16 @@ static void carve_deps_at_address(RDyldCache *cache, cache_img_t *img, HtSU *pat
 			size_t dep_index = (size_t)ht_su_find (path_to_idx, key, &found);
 			if (!found || dep_index >= cache->hdr->imagesCount) {
 				R_LOG_WARN ("alien dep '%s'", key);
-				continue;
+				goto nextcmd;
 			}
 			deps[dep_index]++;
 			if (printing) {
 				eprintf ("-> %s\n", key);
 			}
 		}
+nextcmd:
 		cursor += cmdsize;
 	}
-
 beach:
 	free (cmds);
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

This change gets rid of a couple of wrong assumptions:

- we assumed that entries in the images array were unique: wrong because multiple items with different names can refer to a single image in the dyld cache, for example when links are present when the cache is built (like `/usr/lib/libobjc.A.dylib` and `/usr/lib/libobjc.dylib` in iOS 9.x caches) and in that case we don't want to load and parse duplicated information
- we assumed that local symbol entries were 1:1 in terms of number and ordering with the images in the image list: wrong, symbol entries can come in any number - instead they reference the corresponding image by offset in the file, we just need to correct those offsets for some overhead we have when dealing with multi-file caches and we're now sure to not miss symbols or load more than the user is interested in

While at it, now also the old "alien dep" infinite loop is gone 😅 
