### PR TITLE
Add strndup to lint checks

### DIFF
--- a/sys/lint.sh
+++ b/sys/lint.sh
@@ -46,6 +46,7 @@ cd "$(dirname $0)"/..
 (git grep "`printf '\tfree('`" libr | grep c: ) && exit 1
 (git grep cfg.debug libr| grep get_i) && exit 1
 (git grep -e 'asm.bytes"' -e 'asm.xrefs"' -e 'asm.functions"' -e 'asm.emu"' -e 'emu.str"' libr| grep get_i) && exit 1
+(git grep -n " strndup (" | grep -v sys/) && exit 1
 
 (git grep eprintf libr| grep -i error | grep -v '/native/' | grep -v spp | grep -v cons) && exit 1
 


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Probably useful to have this since this symbol is not available on Windows.