### PR TITLE
Fix security issues in coff plugin ##bin

### DIFF
--- a/libr/bin/format/coff/coff.c
+++ b/libr/bin/format/coff/coff.c
@@ -302,10 +302,11 @@ static bool r_bin_xcoff_init_ldhdr(RBinCoffObj *obj) {
 static bool r_bin_xcoff_init_ldsyms(RBinCoffObj *obj) {
 	int ret;
 	size_t size;
-	ut64 offset = obj->scn_hdrs[obj->x_opt_hdr.o_snloader-1].s_scnptr + sizeof (struct xcoff32_ldhdr);
+	ut64 offset;
 	if (!obj->x_ldhdr.l_nsyms) {
 		return true;
 	}
+	offset = obj->scn_hdrs[obj->x_opt_hdr.o_snloader-1].s_scnptr + sizeof (struct xcoff32_ldhdr);
 	if (obj->x_ldhdr.l_nsyms >= 0xffff) { // too much symbols, probably not allocatable
 		R_LOG_DEBUG ("too many loader symbols (%u)", obj->x_ldhdr.l_nsyms);
 		return false;


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Kudos to @trufae for reporting.

1. Fix out-of-bounds read in XCOFF ldsym handling (Affected versions: none, as this was a recent regression in https://github.com/radareorg/radare2/pull/22458)
2. Fix unbounded memory allocation in (X)COFF section handling 

The second bug has probably been there for a while. If `RBinSection::size` is not bounded, then the generic logic to find strings will calloc a large buffer. It is low severity, as the alloc failure will be gracefully handled without terminating the process. We should probably harden the RBinObject logic regardless to always truncate the section file ranges to the bounds of the file. It's better to never attempt to alloc that much memory in the first place.