### PR TITLE
Fix NULL deref in r_core log handling ##bug

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -3039,8 +3039,13 @@ static bool cbcore(void *user, int type, const char *origin, const char *msg) {
 	if (!msg) {
 		return false;
 	}
+	if (!origin) {
+		origin = "*";
+	}
 	RCore *core = (RCore*)user;
-	char *s = R_STR_ISNOTEMPTY (msg)? r_str_newf ("%s %s", origin? origin: "*", msg): strdup (origin);
+	char *s = R_STR_ISNOTEMPTY (msg)
+		? r_str_newf ("%s %s", origin, msg)
+		: strdup (origin);
 	r_core_log_add (core, s);
 	free (s);
 	return false;

--- a/test/unit/test_util.c
+++ b/test/unit/test_util.c
@@ -1,5 +1,6 @@
 #include <r_util.h>
 #include <r_util/r_ref.h>
+#include <r_core.h>
 #include "minunit.h"
 
 static Sdb *setup_sdb(void) {
@@ -227,6 +228,18 @@ bool test_references(void) {
 	mu_end;
 }
 
+bool test_log(void) {
+	// Stand up a semi-realistic log environment with an RCore
+	RCore *core = r_core_new ();
+	r_log_set_quiet (true);
+
+	// https://github.com/radareorg/radare2/issues/22468
+	R_LOG_INFO ("%s", "");
+
+	r_core_free (core);
+	mu_end;
+}
+
 int all_tests() {
 	mu_run_test (test_ignore_prefixes);
 	mu_run_test (test_remove_r2_prefixes);
@@ -236,6 +249,7 @@ int all_tests() {
 	mu_run_test (test_file_slurp);
 	mu_run_test (test_initial_underscore);
 	mu_run_test (test_tagged_pointers);
+	mu_run_test (test_log);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Closes https://github.com/radareorg/radare2/issues/22468
- Adds a regression test