### PR TITLE
AIX fixes ##port

### DIFF
--- a/libr/config.mk.tail
+++ b/libr/config.mk.tail
@@ -163,6 +163,13 @@ EXT_SO=so
 EXT_EXE=
 TH_LIBS=
 endif
+ifeq (${OSTYPE},aix)
+CFLAGS+=-DR2__UNIX__=1
+EXT_AR=a
+EXT_SO=so
+EXT_EXE=
+TH_LIBS=
+endif
 
 ifeq (${EXT_SO},)
 main:

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -185,7 +185,7 @@
 #define HAVE_PTY R2__UNIX__ && LIBC_HAVE_FORK && !__sun
 #endif
 
-#if defined(EMSCRIPTEN) || defined(__wasi__) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__) || defined(__vinix__)
+#if defined(EMSCRIPTEN) || defined(__wasi__) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__) || defined(__vinix__) || defined(_AIX)
   #define R2__BSD__ 0
   #define R2__UNIX__ 1
 #endif
@@ -672,7 +672,7 @@ typedef enum {
 
 
 #define HAS_CLOCK_NANOSLEEP 0
-#if defined(__wasi__)
+#if defined(__wasi__) || defined(_AIX)
 # define HAS_CLOCK_MONOTONIC 0
 #elif CLOCK_MONOTONIC && MONOTONIC_UNIX
 # define HAS_CLOCK_MONOTONIC 1

--- a/libr/util/deps.mk
+++ b/libr/util/deps.mk
@@ -43,3 +43,6 @@ LINK+=-lm
 endif
 endif
 
+ifeq (${OSTYPE},aix)
+LINK+=-pthread
+endif

--- a/libr/util/thread_lock.c
+++ b/libr/util/thread_lock.c
@@ -7,7 +7,7 @@
 #include <r_util/r_log.h>
 
 /* locks/mutex/sems */
-static bool lock_init(RThreadLock *thl, bool recursive) {
+static bool _lock_init(RThreadLock *thl, bool recursive) {
 #if HAVE_PTHREAD
 	if (recursive) {
 		pthread_mutexattr_t attr;
@@ -70,7 +70,7 @@ R_API RThreadLock *r_th_lock_new(bool recursive) {
 	R_LOG_DEBUG ("r_th_lock_new");
 	RThreadLock *thl = R_NEW0 (RThreadLock);
 	if (thl) {
-		if (lock_init (thl, recursive)) {
+		if (_lock_init (thl, recursive)) {
 			thl->type = R_TH_LOCK_TYPE_HEAP;
 			thl->active = true;
 			thl->activating = false;
@@ -100,7 +100,7 @@ R_API bool r_th_lock_enter(RThreadLock *thl) {
 			// spinning
 		}
 		if (!thl->active) {
-			lock_init (thl, false);
+			_lock_init (thl, false);
 			thl->active = true;
 		}
 		// finish spinning


### PR DESCRIPTION
First of many patches to support AIX.

- Add AIX config support ##port
- Fix lock_init sym collision on AIX ##port

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
