### PR TITLE
Fix invalid macro identifies in r_print ##bug

### DIFF
--- a/libr/cons/pixel.c
+++ b/libr/cons/pixel.c
@@ -109,17 +109,17 @@ R_API char *r_cons_pixel_drain(RConsPixel *p) {
 static int pixel_get(RConsPixel *p, int x, int y) {
 	ut8 *X = p->buf + (x + (y * p->w));
 	int u = 0;
-	u |= (X[0]?$00:0);
-	u |= (X[1]?$01:0);
+	u |= (X[0]?_BR00:0);
+	u |= (X[1]?_BR01:0);
 	X = p->buf + (x + ((y + 1) * p->w));
-	u |= (X[0]?$10:0);
-	u |= (X[1]?$11:0);
+	u |= (X[0]?_BR10:0);
+	u |= (X[1]?_BR11:0);
 	X = p->buf + (x + ((y + 2) * p->w));
-	u |= (X[0]?$20:0);
-	u |= (X[1]?$21:0);
+	u |= (X[0]?_BR20:0);
+	u |= (X[1]?_BR21:0);
 	X = p->buf + (x + ((y + 3) * p->w));
-	u |= (X[0]?$30:0);
-	u |= (X[1]?$31:0);
+	u |= (X[0]?_BR30:0);
+	u |= (X[1]?_BR31:0);
 	return u;
 }
 

--- a/libr/include/r_util/r_print.h
+++ b/libr/include/r_util/r_print.h
@@ -45,23 +45,23 @@ extern "C" {
 
 */
 
-#define $00 1
-#define $01 8
-#define $10 2
-#define $11 16
-#define $20 4
-#define $21 32
-#define $30 (1 << 8)
-#define $31 (2 << 8)
-#define BRAILE_ONE $00+$01+$11+$21+$31
-#define BRAILE_TWO $00+$01+$11+$20+$30+$31
-#define BRAILE_TRI $00+$01+$11+$21+$30+$31
-#define BRAILE_FUR $00+$10+$11+$21+$31
-#define BRAILE_FIV $00+$01+$10+$21+$30
-#define BRAILE_SIX $01+$10+$20+$21+$30+$31
-#define BRAILE_SEV $00+$01+$11+$20+$30
-#define BRAILE_EIG $00+$01+$10+$11+$20+$21+$30+$31
-#define BRAILE_NIN $00+$01+$10+$11+$21+$30
+#define _BR00 1
+#define _BR01 8
+#define _BR10 2
+#define _BR11 16
+#define _BR20 4
+#define _BR21 32
+#define _BR30 (1 << 8)
+#define _BR31 (2 << 8)
+#define _BRAILE_ONE _BR00+_BR01+_BR11+_BR21+_BR31
+#define _BRAILE_TWO _BR00+_BR01+_BR11+_BR20+_BR30+_BR31
+#define _BRAILE_TRI _BR00+_BR01+_BR11+_BR21+_BR30+_BR31
+#define _BRAILE_FUR _BR00+_BR10+_BR11+_BR21+_BR31
+#define _BRAILE_FIV _BR00+_BR01+_BR10+_BR21+_BR30
+#define _BRAILE_SIX _BR01+_BR10+_BR20+_BR21+_BR30+_BR31
+#define _BRAILE_SEV _BR00+_BR01+_BR11+_BR20+_BR30
+#define _BRAILE_EIG _BR00+_BR01+_BR10+_BR11+_BR20+_BR21+_BR30+_BR31
+#define _BRAILE_NIN _BR00+_BR01+_BR10+_BR11+_BR21+_BR30
 
 typedef struct {
 	char str[4];

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -2592,16 +2592,16 @@ R_API void r_print_graphline(RPrint *print, const ut8 *buf, size_t len) {
 			ut8 ch = buf[i];
 			switch (0|(ch / 64)) {
 			case 0:
-				brailechar = $30 + $31;
+				brailechar = _BR30 + _BR31;
 				break;
 			case 1:
-				brailechar = $20 + $21;
+				brailechar = _BR20 + _BR21;
 				break;
 			case 2:
-				brailechar = $10 + $11;
+				brailechar = _BR10 + _BR11;
 				break;
 			case 3:
-				brailechar = $00 + $01;
+				brailechar = _BR00 + _BR01;
 				break;
 			}
 			if (brailechar) {


### PR DESCRIPTION
On AIX with GCC 10, "#define $00" does not compile.
Apparently, '$' in identifiers is a GCC extension.

See https://stackoverflow.com/a/369524

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
