### PR TITLE
Don't use /dev/stderr ##port

### DIFF
--- a/configure
+++ b/configure
@@ -903,7 +903,7 @@ pcgen() {
 	PCNAME="${1}" ; shift
 	REQUIRES="$@"
 
-	echo "generating ${PCFILE}" > /dev/stderr
+	echo "generating ${PCFILE}" >&2
 	echo "prefix=${PREFIX}" > ${PCFILE}
 	echo "exec_prefix=\${prefix}" >> ${PCFILE}
 	echo "libdir=${PKGCFG_LIBDIR}" >> ${PCFILE}

--- a/dist/docker/fuzz-asm/fuzz.sh
+++ b/dist/docker/fuzz-asm/fuzz.sh
@@ -43,6 +43,6 @@ if [ -z "${OPS}" ]; then
 fi
 for a in ${OPS} ; do
 	LINE=`args $a`
-	echo "INPUT=$LINE" > /dev/stderr
+	echo "INPUT=$LINE" >&2
 	rasm2 -a $R2_ARCH -b $R2_BITS "$LINE"
 done

--- a/sys/install.sh
+++ b/sys/install.sh
@@ -34,8 +34,8 @@ fi
 
 echo "$PWD" | grep -q " "
 if [ $? = 0 ]; then
-	echo "You can't build radare from a directory with spaces with make" > /dev/stderr
-	echo "To solve this you must 'meson' instead" > /dev/stderr
+	echo "You can't build radare from a directory with spaces with make" >&2
+	echo "To solve this you must 'meson' instead" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`/dev/stderr` is not supported on AIX.