### PR TITLE
Improve quickjs portability ##shlr

### DIFF
--- a/shlr/qjs/aix.patch
+++ b/shlr/qjs/aix.patch
@@ -1,0 +1,32 @@
+diff --git a/shlr/qjs/src/quickjs.c b/shlr/qjs/src/quickjs.c
+index ddb076e0c7..c3714b44d2 100644
+--- a/shlr/qjs/src/quickjs.c
++++ b/shlr/qjs/src/quickjs.c
+@@ -42511,7 +42511,7 @@ static JSValue js___date_clock(JSContext *ctx, JSValueConst this_val,
+ /* OS dependent. d = argv[0] is in ms from 1970. Return the difference
+    between UTC time and local time 'd' in minutes */
+ static int getTimezoneOffset(int64_t time) {
+-#if defined(_WIN32)
++#if defined(_WIN32) || defined(_AIX)
+     /* XXX: TODO */
+     return 0;
+ #else
+diff --git a/shlr/qjs/src/quickjs.h b/shlr/qjs/src/quickjs.h
+index 9e55cb837c..60f559c790 100644
+--- a/shlr/qjs/src/quickjs.h
++++ b/shlr/qjs/src/quickjs.h
+@@ -73,6 +73,14 @@ typedef struct JSRefCountHeader {
+     int ref_count;
+ } JSRefCountHeader;
+ 
++#if defined(_AIX) && defined(__GNUC__)
++/* Make NAN and INFINITY constant expressions */
++#undef NAN
++#define NAN __builtin_nanf("0x7fc00000")
++#undef INFINITY
++#define INFINITY __builtin_huge_valf()
++#endif
++
+ #define JS_FLOAT64_NAN NAN
+ 
+ #if defined(JS_STRICT_NAN_BOXING)

--- a/shlr/qjs/src/quickjs.c
+++ b/shlr/qjs/src/quickjs.c
@@ -42511,7 +42511,7 @@ static JSValue js___date_clock(JSContext *ctx, JSValueConst this_val,
 /* OS dependent. d = argv[0] is in ms from 1970. Return the difference
    between UTC time and local time 'd' in minutes */
 static int getTimezoneOffset(int64_t time) {
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(_AIX)
     /* XXX: TODO */
     return 0;
 #else

--- a/shlr/qjs/src/quickjs.h
+++ b/shlr/qjs/src/quickjs.h
@@ -73,6 +73,14 @@ typedef struct JSRefCountHeader {
     int ref_count;
 } JSRefCountHeader;
 
+#if defined(_AIX) && defined(__GNUC__)
+/* Make NAN and INFINITY constant expressions */
+#undef NAN
+#define NAN __builtin_nanf("0x7fc00000")
+#undef INFINITY
+#define INFINITY __builtin_huge_valf()
+#endif
+
 #define JS_FLOAT64_NAN NAN
 
 #if defined(JS_STRICT_NAN_BOXING)


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- quickjs assumes NAN and INFINITY are constant expressions.
  This is not true on AIX. Adds a workaround.
- Don't use tm_gmtoff on AIX. (tm_gmtoff appeared in 4.3BSD Tahoe,
  but AIX hasn't bothered to backport it in over 35 years)
