### PR TITLE
Fix dbg.glibc.path type ##debug

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3552,7 +3552,7 @@ R_API int r_core_config_init(RCore *core) {
 #endif
 	SETDESC (n, "choose malloc structure parser");
 	SETOPTIONS (n, "glibc", "jemalloc", NULL);
-	SETBPREF ("dbg.glibc.path", "", "if not empty, use the given path to resolve the libc");
+	SETPREF ("dbg.glibc.path", "", "if not empty, use the given path to resolve the libc");
 #if __GLIBC_MINOR__ > 25
 	SETBPREF ("dbg.glibc.tcache", "true", "parse the tcache (glibc.minor > 2.25.x)");
 #else


### PR DESCRIPTION
`dbg.glibc.path`  was declared as boolean setting this makes the check in https://github.com/radareorg/radare2/blob/702cbbef4d3a668a9255920b99acdace1e8c58c9/libr/core/dmh_glibc.inc.c#L399 not work as expected. 

An alternative solution would be to use something like this keeping the boolean type (suggested by Lazula)
```
const char *dbg_glibc_path = r_config_get_b (core->config, "dbg.glibc.path")? r_config_get (core->config, "dbg.glibc.path"): NULL;
```