### PR TITLE
Fix archos detection on AIX ##port

### DIFF
--- a/binr/r2r/r2r.h
+++ b/binr/r2r/r2r.h
@@ -5,19 +5,6 @@
 
 #include <r_util.h>
 
-#if __i386__
-#define R2R_ARCH "x86"
-#elif __x86_64__
-#define R2R_ARCH "x64"
-#elif __arm64__ || __aarch64__
-#define R2R_ARCH "arm64"
-#elif __arm__
-#define R2R_ARCH "arm"
-#elif __mips__
-#define R2R_ARCH "mips"
-#else
-#define R2R_ARCH "unknown"
-#endif
 #define R2R_ARCH_OS R_SYS_OS "-"R_SYS_ARCH
 
 typedef struct r2r_cmd_test_string_record {

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -705,6 +705,8 @@ typedef enum {
 #define R_SYS_OS "freebsd"
 #elif defined (__HAIKU__)
 #define R_SYS_OS "haiku"
+#elif defined (_AIX)
+#define R_SYS_OS "aix"
 #else
 #define R_SYS_OS "unknown"
 #endif


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Removes unused `R2R_ARCH`
- Adds `R_SYS_OS` detection for AIX
