### PR TITLE
Fix graph title not current ##graph

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -3501,9 +3501,6 @@ static bool check_changes(RAGraph *g, bool is_interactive, RCore *core, RAnalFun
 			return false;
 		}
 	}
-	if (fcn) {
-		agraph_update_title (core, g, fcn);
-	}
 	if (core && core->config) {
 		if (r_config_get_b (core->config, "graph.trace")) {
 			// fold all bbs not traced
@@ -3542,6 +3539,9 @@ static bool check_changes(RAGraph *g, bool is_interactive, RCore *core, RAnalFun
 		if (n) {
 			update_seek (g->can, n, g->force_update_seek);
 		}
+	}
+	if (fcn) {
+		agraph_update_title (core, g, fcn);
 	}
 	if (oldpos[0] || oldpos[1]) {
 		g->can->sx = oldpos[0];


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

check_changes was updating graph's title before potentially updating the current node

This resulted in title not showing the correct address in some circumstances, like when pressing '^' to go to beginning of function.