### PR TITLE
Fix typo in dbg.px0 test

### DIFF
--- a/test/db/archos/linux-x64/dbg_px0
+++ b/test/db/archos/linux-x64/dbg_px0
@@ -3,6 +3,6 @@ FILE=bins/elf/analysis/elf-nx
 ARGS=-d
 CMDS=px0
 EXPECT=<<EOF
-89e083ec0c50e8a50c
+89e083ec0c50e8350c
 EOF
 RUN


### PR DESCRIPTION
- [x ] Mark this if you consider it ready to merge

Fix a one byte typo in test for `dbg.px0`