### PR TITLE
Improve sigdb file format detection ##anal

### DIFF
--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -3010,7 +3010,7 @@ static int signdb_type(const char *file) {
 				continue;
 			}
 		}
-		if (is_sdb == 0) {
+		if (is_sdb < 0) {
 			t = SIGNDB_TYPE_SDB;
 		} else if (is_r2 < 0) {
 			t = SIGNDB_TYPE_R2;

--- a/libr/anal/sign.c
+++ b/libr/anal/sign.c
@@ -2990,35 +2990,24 @@ static int signdb_type(const char *file) {
 	sz = R_MIN (sz, 0x200);
 	int is_sdb = 16;
 	int is_kv = 4;
-	int is_r2 = 4;
+	int is_r2 = 2;
 	int t = SIGNDB_TYPE_INVALID;
 	if (r_str_startswith (data, "[{\"name\":")) {
 		t = SIGNDB_TYPE_JSON;
 	} else {
 		for (i = 0; i < sz; i++) {
-			if (!strncmp (data + i, "\nza ", sz - i)) {
+			if (!strncmp (data + i, "\nza ", 4)) {
 				is_r2--;
-				i++;
+				i += 3;
 				continue;
 			}
-			switch (i) {
-			case 3:
-			case 7:
-			case 0xb:
-			case 0xf:
-				if (data[i] == 0) {
-					is_sdb--;
-				}
-				break;
-			case '=':
-			case '\n':
+			if ((i & 3) == 3 && data[i] == 0) {
+				is_sdb--;
+				continue;
+			}
+			if (data[i] == '=' || data[i] == '\n') {
 				is_kv--;
-				break;
-			default:
-				if (data[i] != 0) {
-					is_sdb--;
-				}
-				break;
+				continue;
 			}
 		}
 		if (is_sdb == 0) {

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1767,3 +1767,54 @@ za main N sym.imp.atoi
 za sym.foo_int_ N sym.foo_int__int_
 EOF
 RUN
+
+
+NAME=Saves and loads sdb zignatures without sdb extension
+FILE=-
+CMDS=<<EOF
+rm .tmp_file
+za s1 x xref1
+za s2 r ref1
+za s3 n sym1
+za s4 n sym2
+zos .tmp_file
+z-*
+zo .tmp_file
+z~s1
+z~s2
+z~s3
+z~s4
+rm .tmp_file
+EOF
+EXPECT=<<EOF
+s1:
+s2:
+s3:
+s4:
+EOF
+RUN
+
+NAME=Saves and loads r2 zignatures without r2 extension
+FILE=-
+CMDS=<<EOF
+rm .tmp_file
+za s1 x xref1
+za s2 r ref1
+za s3 n sym1
+za s4 n sym2
+z* > .tmp_file
+z-*
+zo .tmp_file
+z~s1
+z~s2
+z~s3
+z~s4
+rm .tmp_file
+EOF
+EXPECT=<<EOF
+s1:
+s2:
+s3:
+s4:
+EOF
+RUN

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1768,7 +1768,6 @@ za sym.foo_int_ N sym.foo_int__int_
 EOF
 RUN
 
-
 NAME=Saves and loads sdb zignatures without sdb extension
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Detection code in signdb_type doesn't seem to work when the correct extension is not provided. This also happens when trying to load from a gzipped sdb file (because temporary file does not have sdb extension).

I did't know that signature files created by zos should have .sdb extension and I did zos test.sig, but didn't load when I tried zo test.sig. Now it loads fine.

I don't know if the sdb format has changed over time, there are parts of the current detection code that seem odd to me. I think this commit should make detection a bit better than before.