### PR TITLE
Update docker readme

### DIFF
--- a/dist/docker/Makefile
+++ b/dist/docker/Makefile
@@ -27,8 +27,8 @@ all:
 install:
 	${INSTALL_SCRIPT} r2-docker.sh "${DESTDIR}${BINDIR}/r2-docker"
 
-pub:
-	docker buildx build --push --platform=linux/arm64,linux/amd64 . -t radare/radare2
+#pub:
+# docker buildx build --push --platform=linux/arm64,linux/amd64 . -t radare/radare2
 # docker buildx build --push --platform linux/amd64 --tag radare/radare2:latest .
 #docker buildx build --push --platform linux/arm64,linux/amd64 --tag radare/radare2:latest .
 #docker buildx build --push --platform linux/amd64,linux/arm64 --tag radare/radare2:latest .

--- a/dist/docker/README.md
+++ b/dist/docker/README.md
@@ -1,26 +1,58 @@
-# r2docker
+# radare2 docker image
 
-To build the image and get a shell run the following line
+## Official stable version
 
+The [prebuild docker image](https://hub.docker.com/r/radare/radare2) for the stable version is based on **Ubuntu** and the [radare2 snap](https://snapcraft.io/radare2) build.
+The Dockerfile to build can be found in this [dedicated repository](https://github.com/radareorg/radare2-snap).
+Any issue found in this packaging can be opened [there](https://github.com/radareorg/radare2-snap/issues).
+
+The resulting build only includes the following plugins by default:
+
+* [r2ghidra](https://github.com/radareorg/r2ghidra)
+* [r2frida](https://github.com/nowsecure/r2frida) (only in supported platforms)
+* [r2dec](https://github.com/wargio/r2dec-js)
+
+### Run
+
+To use the prebuild docker image you can use either:
 ```
 docker run -ti radare/radare2
+podman run -ti docker.io/radare/radare2
+nerdctl run -ti radare/radare2
 ```
 
-It is also possible to specify which r2pm packages to be compiled into the image to make them persistent across runs. Share the folder you like from your host with `-v` to get files. Debugging
+To use the prebuild docker image as one shot so it removes everything inside the container on exit just add `--rm` as follows:
+```
+docker run --rm -ti radare/radare2
+```
 
-## Building
+Another example to use for debugging inside the docker:
+```
+docker run --tty --interactive --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined radare/radare2
+```
 
-The source code of this Dockerfile is inside the `dist/docker` directory inside the  radare2 source tree.
+## GIT version (r2docker)
+
+Alternatively there is a version with radare2 GIT aimed to be build locally.
+
+This will build an image using **Debian** with radare2 from git with latest changes.
+The Dockerfile to build can be found inside this folder (`dist/docker` directory inside the radare2 source tree).
+
+### Build from GIT
+
+To build this other image run the following lines:
 
 ```sh
+git clone https://github.com/radareorg/radare2.git
+cd radare2
 make -C dist/docker
 ```
 
-Note that this makefile will build an image using Debian11 with r2 from git and the following plugins:
+This will build an image with the following plugins:
 
-* r2frida
-* r2ghidra
-* r2dec
+* [r2ghidra](https://github.com/radareorg/r2ghidra)
+* [r2frida](https://github.com/nowsecure/r2frida)
+* [r2dec](https://github.com/wargio/r2dec-js)
 
 It is possible to specify more packages using the `R2PM` make variable:
 
@@ -28,18 +60,4 @@ It is possible to specify more packages using the `R2PM` make variable:
 make -C dist/docker R2PM=radius2
 ```
 
-## Debugging
-
-The makefile in dist/docker takes care about passing the right flags to get ptrace support inside the image. Also, you can select the architecture (amd64 / arm64) to compile the image and run it. This is what it does under the hood:
-
-```sh
-docker run -ti r2docker --privileged --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --security-opt apparmor=unconfined
-```
-
-## Links
-
-You can read more about the project in the following links
-
-* https://www.radare.org
-* https://github.com/radareorg/radare2
-
+Also, you can select the architecture (amd64 / arm64) to compile the image by using the `ARCH` make variable.

--- a/doc/snap.md
+++ b/doc/snap.md
@@ -26,20 +26,23 @@ Running commands
 Currently, the radare2 commands can be invoked with the following names:
 
 - `radare2` or `radare2.r2` or `radare2.radare2`: The `r2`/`radare2` command.
+- `radare2.r2` : The `r2` command.
+- `radare2.r2agent` : The `r2agent` command.
+- `radare2.r2frida-compile` : The `r2frida-compile` command.
 - `radare2.r2p` : The `r2p` command.
 - `radare2.r2pm` : The `r2pm` command.
 - `radare2.r2r` : The `r2r` command.
-- `radare2.r2agent` : The `r2agent` command.
-- `radare2.rafind2` : The `rafind2` command.
-- `radare2.rahash2` : The `rahash2` command.
-- `radare2.rasm2` : The `rasm2` command.
 - `radare2.rabin2` : The `rabin2` command.
 - `radare2.radiff2` : The `radiff2` command.
+- `radare2.rafind2` : The `rafind2` command.
 - `radare2.ragg2` : The `ragg2` command.
+- `radare2.rahash2` : The `rahash2` command.
 - `radare2.rarun2` : The `rarun2` command.
+- `radare2.rasign2` : The `rasign2` command.
+- `radare2.rasm2` : The `rasm2` command.
 - `radare2.ravc2` : The `ravc2` command.
 - `radare2.rax2` : The `rax2` command.
-- `radare2.rasign2` : The `rasign2` command.
+- `radare2.sleighc` : The `sleighc` command.
 
 Getting info about the radare2 snap package
 -------------------------------------------
@@ -109,6 +112,10 @@ The radare2 snap package is currently available for the following architectures:
 1. `amd64`
 1. `arm64`
 1. `armhf`
+1. `i386`
+1. `ppc64el`
+1. `riscv64`
+1. `s390x`
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
- Disable GIT docker publish via Makefile (since this is done via github actions on [radare2-snap](https://github.com/radareorg/radare2-snap)).
- Update docker README with all the details of the 2 versions available (also fix the build commands).
- Update snap doc to include all new architectures and commands.