### PR TITLE
Better way to determine the glibc version

### DIFF
--- a/libr/core/dmh_glibc.inc.c
+++ b/libr/core/dmh_glibc.inc.c
@@ -117,8 +117,11 @@ static bool GH(is_tcache)(RCore *core) {
 			}
 			fp = strstr (map->name, "libc.");
 			if (fp) {
-				v = r_num_get_double (core->num, fp + 5);
-				core->dbg->glibc_version = (int) round((v * 100));
+				v = r_num_get_double  (core->num, fp + 5);
+				if (!v) {
+					v = get_glibc_version (core, map->name);
+				}
+				core->dbg->glibc_version = (int)round ((v * 100));
 				return (v > 2.25);
 			}
 		}

--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -269,6 +269,8 @@ typedef struct r_heap_info_64 {
 	/* char pad[NPAD * SZ & MALLOC_ALIGN_MASK]; */
 } RHeapInfo_64;
 
+R_API double get_glibc_version(RCore *core, const char *libc_path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -153,7 +153,7 @@ R_API RList *r_regex_match_list(RRegex *rx, const char *text) {
 	match.rm_so = 0;
 	match.rm_eo = strlen (text);
 	while (!r_regex_exec (rx, text, 1, &match, rx->re_flags | R_REGEX_STARTEND)) {
-		size_t entry_len = match.rm_eo - match.rm_so + 1;
+		size_t entry_len = match.rm_eo - match.rm_so;
 		char *entry = r_str_ndup (text + match.rm_so, entry_len);
 		r_list_append (list, entry);
 		/* Update the boundaries for R_REGEX_STARTEND */

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,6 +1,7 @@
 BINDIR := bin
 BINS=$(patsubst %.c,$(BINDIR)/%,$(wildcard *.c))
 LDFLAGS+=$(shell pkg-config --libs r_core)
+LDFLAGS+=-lm
 CFLAGS+=-I../../libr/include
 CFLAGS+=-I../../shlr/sdb/include
 CFLAGS+=-g

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -63,7 +63,8 @@ if get_option('enable_tests')
     'util',
     'vec',
     'vector',
-    'crbtree'
+    'crbtree',
+    'glibc_version'
   ]
 
   foreach test : tests

--- a/test/unit/test_glibc_version.c
+++ b/test/unit/test_glibc_version.c
@@ -1,0 +1,48 @@
+#include <r_bin.h>
+#include <r_core.h>
+#include <math.h>
+#include "../../libr/include/r_heap_glibc.h"
+#include "minunit.h"
+
+bool test_glibc_version (void) {
+	RCore *core = r_core_new ();
+
+	double version = 0.0f;
+	int glibc_version = 0;
+
+	// 2.27
+	version = get_glibc_version (core, "bins/elf/libc-2.27.so");
+	glibc_version = (int)round ((version * 100));
+
+	mu_assert_eq (227, glibc_version, "Incorrect libc version, expected 2.27");
+
+	// 2.31
+	version = get_glibc_version (core, "bins/elf/libc-2.31.so");
+	glibc_version = (int)round ((version * 100));
+
+	mu_assert_eq (231, glibc_version, "Incorrect libc version, expected 2.31");
+
+	// 2.32
+	version = get_glibc_version (core, "bins/elf/libc-2.32.so");
+	glibc_version = (int)round ((version * 100));
+
+	mu_assert_eq (232, glibc_version, "Incorrect libc version, expected 2.32");
+
+	// 2.28
+	version = get_glibc_version (core, "bins/elf/libc.so.6");
+	glibc_version = (int)round ((version * 100));
+
+	mu_assert_eq (228, glibc_version, "Incorrect libc version, expected 2.28");
+
+	r_core_free (core);
+	mu_end;
+}
+
+bool all_tests () {
+	mu_run_test (test_glibc_version);
+	return tests_passed != tests_run;
+}
+
+int main (int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
So I wrote a new function that determines the glibc version based on the strings inside the .so.
This is similar to what pwndbg/GEF do. Previously, the version was parsed out of the filename, but this is not
relevant for newer versions of libc as they will all be named `libc.so.6`
