### PR TITLE
Improve dietline's vi mode ##cons

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -230,7 +230,7 @@ static void backward_kill_word(BreakMode break_mode) {
 }
 
 static void kill_word(BreakMode break_mode, char motion) {
-	int i;
+	int i = 0;
 	if (I.buffer.index == I.buffer.length - 1) {
 		__delete_current_char ();
 		return;

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -220,7 +220,7 @@ static inline void shift_buffer(int start, int end) {
 
 /* https://www.gnu.org/software/bash/manual/html_node/Commands-For-Killing.html */
 static void backward_kill_word(BreakMode break_mode) {
-	int i, len;
+	int i;
 	i = vi_backward_word_motion (break_mode);
 	if (i == I.buffer.index) {
 		return;
@@ -1445,8 +1445,8 @@ static bool __vi_mode(void) {
 			delete_till_end ();
 			break;
 		case 'r':
-			char c = r_cons_readchar ();
-			I.buffer.data[I.buffer.index] = c;
+			ch = r_cons_readchar ();
+			I.buffer.data[I.buffer.index] = ch;
 			break;
 		case 'x':
 			while (rep--) {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Make the behaviour of some vi commands closer to vim's behaviour.
- Fix some bugs in the word deletion functions.
- Implement `c` commands (`cw`, `ce`, ...).
- Implement vi horizontal motions `f`/`F` and `t`/`T` and the corresponding delete commands (`df<char>`, `dT<char>`, ...).
- Implement `dd` and `cc` commands to delete/change the whole line.
- Implement the `~` vi command which swaps the case of the current character.
- Make it possible to submit (by pressing Enter) the line in normal mode (CONTROL_MODE). Currently, we have to go into insert mode and press Enter.

If you're ok with this, I will update the book.

Happy new year!