### PR TITLE
[fix] Respects bin.demangle configuration flag when parsing mach0 symbols

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1536,11 +1536,11 @@ R_API char *r_bin_name_tostring(RBinName *bn) {
 	if (!bn) {
 		return NULL;
 	}
-	if (bn->name) {
-		return bn->name;
-	}
 	if (bn->oname) {
 		return bn->oname;
+	}
+	if (bn->name) {
+		return bn->name;
 	}
 	return bn->fname;
 }


### PR DESCRIPTION

After this fix, the `bin.demangle` is taken into account when showing the different symbols when parsing machO files:


```
➜  radare2 -e bin.demangle=false a.out
 -- Default scripting languages are NodeJS and Python.
[0x100003154]> iE
[Exports]
nth paddr      vaddr       bind   type size lib name                                       demangled
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00003bec 0x100003bec GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE11eq_int_typeEii
1   0x00003c14 0x100003c14 GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE3eofEv
2   0x000033cc 0x1000033cc GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE6lengthEPKc
3   0x00000000 0x100000000 GLOBAL FUNC 0        __mh_execute_header
4   0x00003154 0x100003154 GLOBAL FUNC 0        _main

➜  radare2 -e bin.demangle=true a.out
 -- Thanks for using radare2!
[0x100003154]> iE
[Exports]
nth paddr      vaddr       bind   type size lib name                                       demangled
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00003bec 0x100003bec GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE11eq_int_typeEii std::__1::char_traits<char>::eq_int_type(int, int)
1   0x00003c14 0x100003c14 GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE3eofEv           std::__1::char_traits<char>::eof()
2   0x000033cc 0x1000033cc GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE6lengthEPKc      std::__1::char_traits<char>::length(char const*)
3   0x00000000 0x100000000 GLOBAL FUNC 0        __mh_execute_header
4   0x00003154 0x100003154 GLOBAL FUNC 0        _main
[0x100003154]>
```