### PR TITLE
[fix] Respects bin.demangle configuration flag when parsing mach0 symbols

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2917,10 +2917,10 @@ static void _enrich_symbol(RBinFile *bf, struct MACH0_(obj_t) *bin, HtPP *symcac
 	const char *oname = r_bin_name_tostring2 (sym->name, 'o');
 	if (oname) {
 		bin->dbg_info = r_str_startswith (oname, "radr://");
-	       	if (*oname == '_' && !sym->is_imported) {
+		if (*oname == '_' && !sym->is_imported) {
 			char *demangled = r_bin_demangle (bf, oname, oname, sym->vaddr, false);
 			if (demangled) {
-				r_bin_name_demangled (sym->name, demangled);
+				// r_bin_name_demangled (sym->name, demangled);
 				char *p = strchr (demangled, '.');
 				if (p) {
 					if (IS_UPPER (*demangled)) {

--- a/test/db/cmd/cmd_is
+++ b/test/db/cmd/cmd_is
@@ -1,0 +1,75 @@
+NAME=Mach0 - List symbols demangled
+FILE=bins/mach0/ClassCpp.out
+ARGS=-e bin.demangle=true
+CMDS=<<EOF
+is~My
+f~My
+EOF
+EXPECT=<<EOF
+7   0x00002a20 0x100002a20 LOCAL  FUNC 0        __ZN7MyClassC1Ev                                                                                                                                   MyClass::MyClass()
+11  0x00002b0c 0x100002b0c LOCAL  FUNC 0        __ZN7MyClassD1Ev                                                                                                                                   MyClass::~MyClass()
+13  0x00002b44 0x100002b44 LOCAL  FUNC 0        __ZN7MyClassC2Ev                                                                                                                                   MyClass::MyClass()
+41  0x00003150 0x100003150 LOCAL  FUNC 0        __ZN7MyClassD2Ev                                                                                                                                   MyClass::~MyClass()
+0x00000000 1 class.MyClass
+0x100002b0c 1 method.MyClass.MyClass__
+0x100003150 0 sym.MyClass::MyClass__
+EOF
+RUN
+
+NAME=Mach0 - List symbols mangled
+FILE=bins/mach0/ClassCpp.out
+ARGS=-e bin.demangle=false
+CMDS=<<EOF
+is~My
+f~My
+EOF
+EXPECT=<<EOF
+7   0x00002a20 0x100002a20 LOCAL  FUNC 0        __ZN7MyClassC1Ev
+11  0x00002b0c 0x100002b0c LOCAL  FUNC 0        __ZN7MyClassD1Ev
+13  0x00002b44 0x100002b44 LOCAL  FUNC 0        __ZN7MyClassC2Ev
+41  0x00003150 0x100003150 LOCAL  FUNC 0        __ZN7MyClassD2Ev
+0x00000000 1 class.MyClass
+0x100002a20 0 sym.__ZN7MyClassC1Ev
+0x100002b0c 0 sym.__ZN7MyClassD1Ev
+0x100002b0c 1 method.MyClass.MyClass__
+0x100002b44 0 sym.__ZN7MyClassC2Ev
+0x100003150 0 sym.__ZN7MyClassD2Ev
+EOF
+RUN
+
+NAME=ELF - List symbols demangled
+FILE=bins/elf/ClassCpp.out
+ARGS=-e bin.demangle=true
+CMDS=<<EOF
+is~My
+f~My
+EOF
+EXPECT=<<EOF
+52  0x000013e0 0x000013e0 WEAK   FUNC   35       _ZN7MyClassD1Ev                                                                                         MyClass::~MyClass()
+67  0x000013bc 0x000013bc WEAK   FUNC   35       _ZN7MyClassC2Ev                                                                                         MyClass::MyClass()
+69  0x000013bc 0x000013bc WEAK   FUNC   35       _ZN7MyClassC1Ev                                                                                         MyClass::MyClass()
+70  0x000013e0 0x000013e0 WEAK   FUNC   35       _ZN7MyClassD2Ev                                                                                         MyClass::~MyClass()
+0x00000000 1 class.MyClass
+0x000013bc 1 method.MyClass.MyClass__
+0x000013e0 35 sym.MyClass::MyClass__
+EOF
+RUN
+
+NAME=ELF - List symbols mangled
+FILE=bins/elf/ClassCpp.out
+ARGS=-e bin.demangle=false
+CMDS=<<EOF
+is~My
+f~My
+EOF
+EXPECT=<<EOF
+52  0x000013e0 0x000013e0 WEAK   FUNC   35       _ZN7MyClassD1Ev
+67  0x000013bc 0x000013bc WEAK   FUNC   35       _ZN7MyClassC2Ev
+69  0x000013bc 0x000013bc WEAK   FUNC   35       _ZN7MyClassC1Ev
+70  0x000013e0 0x000013e0 WEAK   FUNC   35       _ZN7MyClassD2Ev
+0x000013bc 35 sym._ZN7MyClassC2Ev
+0x000013bc 35 sym._ZN7MyClassC1Ev
+0x000013e0 35 sym._ZN7MyClassD1Ev
+0x000013e0 35 sym._ZN7MyClassD2Ev
+EOF
+RUN


### PR DESCRIPTION
After this fix, the bin.demangle is taken into account when showing the different symbols when parsing machO files:

```
radare2 -e bin.demangle=false a.out
 -- Default scripting languages are NodeJS and Python.
[0x100003154]> iE
[Exports]
nth paddr      vaddr       bind   type size lib name                                       demangled
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00003bec 0x100003bec GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE11eq_int_typeEii
1   0x00003c14 0x100003c14 GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE3eofEv
2   0x000033cc 0x1000033cc GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE6lengthEPKc
3   0x00000000 0x100000000 GLOBAL FUNC 0        __mh_execute_header
4   0x00003154 0x100003154 GLOBAL FUNC 0        _main

radare2 -e bin.demangle=true a.out
 -- Thanks for using radare2!
[0x100003154]> iE
[Exports]
nth paddr      vaddr       bind   type size lib name                                       demangled
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
0   0x00003bec 0x100003bec GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE11eq_int_typeEii std::__1::char_traits<char>::eq_int_type(int, int)
1   0x00003c14 0x100003c14 GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE3eofEv           std::__1::char_traits<char>::eof()
2   0x000033cc 0x1000033cc GLOBAL FUNC 0        __ZNSt3__111char_traitsIcE6lengthEPKc      std::__1::char_traits<char>::length(char const*)
3   0x00000000 0x100000000 GLOBAL FUNC 0        __mh_execute_header
4   0x00003154 0x100003154 GLOBAL FUNC 0        _main
[0x100003154]>

```