### PR TITLE
Walk Mach-O exports from LC_DYLD_EXPORTS_TRIE too ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2146,13 +2146,14 @@ static int init_items(struct MACH0_(obj_t) *mo) {
 				}
 			}
 			break;
-		case LC_DYLD_EXPORTS_TRIE:
-			if (mo->verbose) {
+		case LC_DYLD_EXPORTS_TRIE: {
 				ut8 buf[8];
 				r_buf_read_at (mo->b, off + 8, buf, sizeof (buf));
-				ut32 dataoff = r_read_ble32 (buf, mo->big_endian);
-				ut32 datasize = r_read_ble32 (buf + 4, mo->big_endian);
-				R_LOG_INFO ("exports trie at 0x%x size %d", dataoff, datasize);
+				mo->exports_trie_off = r_read_ble32 (buf, mo->big_endian) + mo->symbols_off;
+				mo->exports_trie_size = r_read_ble32 (buf + 4, mo->big_endian);
+				if (mo->verbose) {
+					R_LOG_INFO ("exports trie at 0x%x size %d", mo->exports_trie_off, mo->exports_trie_size);
+				}
 			}
 			break;
 		case LC_DYLD_CHAINED_FIXUPS:
@@ -2731,15 +2732,9 @@ static char *get_name(struct MACH0_(obj_t) *mo, ut32 stridx, bool filter) {
 	return NULL;
 }
 
-static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, void *ctx) {
-	r_return_val_if_fail (bin, 0);
-	if (!bin->dyld_info) {
-		return 0;
-	}
-
+static int walk_exports_trie(struct MACH0_(obj_t) *bin, ut64 trie_off, ut64 size, RExportsIterator iterator, void *ctx) {
 	size_t count = 0;
 	ut8 *p = NULL;
-	ut64 size = bin->dyld_info->export_size;
 	if (!size || size >= SIZE_MAX) {
 		return 0;
 	}
@@ -2748,7 +2743,7 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 		return 0;
 	}
 	ut8 *end = trie + size;
-	if (r_buf_read_at (bin->b, bin->dyld_info->export_off, trie, bin->dyld_info->export_size) != size) {
+	if (r_buf_read_at (bin->b, trie_off, trie, size) != size) {
 		return 0;
 	}
 
@@ -2885,6 +2880,18 @@ static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, vo
 beach:
 	r_list_free (states);
 	R_FREE (trie);
+	return count;
+}
+
+static int walk_exports(struct MACH0_(obj_t) *bin, RExportsIterator iterator, void *ctx) {
+	r_return_val_if_fail (bin, 0);
+	size_t count = 0;
+	if (bin->dyld_info) {
+		count += walk_exports_trie (bin, bin->dyld_info->export_off, bin->dyld_info->export_size, iterator, ctx);
+	}
+	if (bin->exports_trie_off && bin->exports_trie_size) {
+		count += walk_exports_trie (bin, bin->exports_trie_off, bin->exports_trie_size, iterator, ctx);
+	}
 	return count;
 }
 

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -197,6 +197,8 @@ struct MACH0_(obj_t) {
 	int internal_buffer_size;
 	int limit; // user defined
 	bool nofuncstarts;
+	ut64 exports_trie_off;
+	ut32 exports_trie_size;
 };
 
 typedef struct {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Before this change we were walking the exports trie from the `LC_DYLD_INFO*` commands, but they can also be defined directly by the `LC_DYLD_EXPORTS_TRIE` command which was ignored by the Mach-O bin plugin.

This change adds support for that.
