### PR TITLE
Flip boolean condition for di command ##debug

### DIFF
--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -5743,7 +5743,7 @@ static int cmd_debug(void *data, const char *input) {
 			RDebugReasonType stop = r_debug_stop_reason (core->dbg);
 			switch (input[1]) {
 			case '\0': // "di"
-				if (r_config_get_b (core->config, "cfg.debug")) {
+				if (!r_config_get_b (core->config, "cfg.debug")) {
 					R_LOG_WARN ("No debugee information available when not using the debugger");
 				} else {
 #define P r_cons_printf


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
This PR flips a boolean condition checking if we are currently in debugging mode (flag `cfg.debug` set). 

Currently, the `di` command only works when we are _not_ in debug mode, and it should be the other way around :)
<!-- explain your changes if necessary -->
