### PR TITLE
Initial import of our custom and safe r_str_scanf ##util

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -314,6 +314,8 @@ R_API char *r_str_version(const char *program);
 R_API char *r_str_ss(const char* msg, const char *nl, int cs);
 
 R_API char *r_str_after(char *s, char c);
+R_API int r_str_scanf(R_NONNULL const char *buffer, R_NONNULL const char *format, ...);
+  /// __attribute__ ((format (scanf, 2, 3)));
 
 // rstr
 

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -15,7 +15,7 @@ OBJS+=udiff.o bdiff.o stack.o queue.o tree.o idpool.o assert.o bplist.o
 OBJS+=punycode.o pkcs7.o x509.o asn1.o asn1_str.o json_parser.o json_indent.o skiplist.o
 OBJS+=pj.o rbtree.o intervaltree.o qrcode.o vector.o str_constpool.o str_trim.o
 OBJS+=ascii_table.o protobuf.o graph_drawable.o axml.o sstext.o new_rbtree.o token.o
-OBJS+=rvc.o rvc_git.o rvc_rvc.o
+OBJS+=rvc.o rvc_git.o rvc_rvc.o bscanf.o
 
 ifeq (${HAVE_GPERF},1)
 OBJS+=d/ascii.o

--- a/libr/util/bscanf.c
+++ b/libr/util/bscanf.c
@@ -240,7 +240,7 @@ R_API int r_str_scanf(const char *buffer, const char *format, ...) {
 				} else if ('L' == length_mod) {
 					ut64_ptr = va_arg(args, ut64*);
 					_BSCANF_CHECK_NULL(long_ptr);
-					*long_ptr = (ut64) strtoll(buf_ptr, &end_ptr, base);
+					*ut64_ptr = (ut64) strtoll(buf_ptr, &end_ptr, base);
 				} else if ('h' == length_mod) {
 					short_ptr = va_arg(args, short*);
 					_BSCANF_CHECK_NULL(short_ptr);

--- a/libr/util/bscanf.c
+++ b/libr/util/bscanf.c
@@ -129,7 +129,7 @@ R_API int r_str_scanf(const char *buffer, const char *format, ...) {
 			} else if ('c' == *fmt_ptr || 's' == *fmt_ptr) {
 				/* 'c'/'s': match a character sequence/string. */
 				/* String conversion requires a width. */
-				// _BSCANF_CHECK_STRING(); -- we want to actually *str=0 instead of early fail
+				// _BSCANF_CHECK_STRING(); -- we want to actually *str = 0 instead of early fail
 
 				/* 'c' conversion specifiers DO NOT consume whitespace. */
 				if ('c' != *fmt_ptr) {

--- a/libr/util/bscanf.c
+++ b/libr/util/bscanf.c
@@ -187,7 +187,6 @@ R_API int r_str_scanf(const char *buffer, const char *format, ...) {
 					_BSCANF_CHECK_NULL(char_ptr);
 					*char_ptr = 0; // null byte the first char before failing
 					if (max_width < 1) {
-						num_args_set--;
 						R_LOG_DEBUG ("Missing length specifier for string");
 					} else {
 						for (; max_width > 0; max_width--) {

--- a/libr/util/bscanf.c
+++ b/libr/util/bscanf.c
@@ -1,0 +1,306 @@
+// MIT licensed code inspired by https://github.com/tusharjois/bscanf
+
+#define R_LOG_ORIGIN "r_str_scanf"
+
+#include <r_util.h>
+
+#define _BSCANF_CONSUME_WSPACE() while (isspace(*buf_ptr)) {buf_ptr++;}
+#define _BSCANF_CHECK(x) if (!(x)) goto exit;
+#define _BSCANF_MATCH() _BSCANF_CHECK(*buf_ptr == *fmt_ptr);
+#define _BSCANF_CHECK_NULL(ptr) _BSCANF_CHECK(NULL != ptr);
+#define _BSCANF_CHECK_STRING() _BSCANF_CHECK(0 != max_width);
+#define _BSCANF_CHECK_BUFFER() _BSCANF_CHECK('\0' != *buffer);
+#define _BSCANF_CHECK_STRTONUM() _BSCANF_CHECK(buf_ptr != end_ptr);
+
+R_API int r_str_scanf(const char *buffer, const char *format, ...) {
+	/* Our return value. On a conversion error, we return this immediately. */
+	int num_args_set = 0;
+
+	/* We use these to index into our buffer and format string. */
+	const char *buf_ptr = buffer;
+	const char *fmt_ptr = format;
+
+	/* Variadic arguments -- pointers in which we put our conversion results. */
+	va_list args;
+	long *long_ptr;
+	int *int_ptr;
+	short *short_ptr;
+	ut64 *ut64_ptr;
+	unsigned long *ulong_ptr;
+	unsigned short *ushort_ptr;
+	unsigned int *uint_ptr;
+	double *double_ptr;
+	float*float_ptr;
+	char *char_ptr;
+	wchar_t *wchar_ptr;
+
+	/* These are useful variables when doing string to number conversion. */
+	char* end_ptr;
+	int base;
+
+	/* These are flags that are used by different conversion specifiers. */
+	bool is_suppressed = false;
+	size_t max_width = 0;
+	char length_mod = '\0';
+
+	/* Return a special value when one of the arguments is NULL. */
+	if (NULL == buffer || NULL == format) {
+		return -1;
+	}
+
+	va_start(args, format);
+
+	while ('\0' != *fmt_ptr) {
+		/* We ignore spaces before specifiers. */
+		if (isspace(*fmt_ptr)) {
+			/* Any whitespace in the format consumes all of the whitespace in the
+			   buffer. */
+			_BSCANF_CONSUME_WSPACE();
+			fmt_ptr++;
+			continue;
+		}
+
+		if ('%' == *fmt_ptr) {
+			/* Handle conversion specifier. */
+			fmt_ptr++;
+
+			/* Check for assignment-suppressing character. */
+			if ('*' == *fmt_ptr) {
+				is_suppressed = true;
+				fmt_ptr++;
+			} else {
+				is_suppressed = false;
+			}
+
+			/* Check for maximum field width. */
+			if (*fmt_ptr == '.') {
+				// R2SCANF extension. '.' works like %*s in printf
+				max_width = va_arg (args, size_t) - 1;
+				fmt_ptr++;
+			} else if (isdigit(*fmt_ptr)) {
+				max_width = strtoul(fmt_ptr, &end_ptr, 0);
+				/* Check if the sequence is a number > 0. */
+				_BSCANF_CHECK(fmt_ptr != end_ptr);
+				_BSCANF_CHECK(max_width > 0);
+
+				fmt_ptr = end_ptr;
+			}
+
+			/* Check for a length modifier. */
+			if ('h' == *fmt_ptr || 'l' == *fmt_ptr || 'L' == *fmt_ptr) {
+				length_mod = *fmt_ptr;
+				fmt_ptr++;
+			} else {
+				length_mod = '\0';
+			}
+
+			/* Handle the conversion format specifier. */
+			if ('n' == *fmt_ptr) {
+				/* 'n': number of characters read so far. */
+				/* 'n' conversion specifiers DO NOT consume whitespace. */
+				/* Technically undefined, but just stop here for safety. */
+				_BSCANF_CHECK(!is_suppressed);
+				if ('l' == length_mod) {
+					long_ptr = va_arg(args, long*);
+					_BSCANF_CHECK_NULL(long_ptr);
+					*long_ptr = (long) (buf_ptr - buffer);
+				} else if ('h' == length_mod) {
+					short_ptr = va_arg(args, short*);
+					_BSCANF_CHECK_NULL(short_ptr);
+					*short_ptr = (short) (buf_ptr - buffer);
+				} else {
+					int_ptr = va_arg(args, int*);
+					_BSCANF_CHECK_NULL(int_ptr);
+					*int_ptr = (int) (buf_ptr - buffer);
+				}
+				fmt_ptr++;
+				num_args_set++;
+				continue;
+			}
+
+			/* All other specifiers move the buffer pointer, so check that it's not NUL. */
+			_BSCANF_CHECK_BUFFER();
+
+			if ('%' == *fmt_ptr) {
+				/* '%': match literal %. */
+				_BSCANF_CONSUME_WSPACE();
+				_BSCANF_MATCH();
+				buf_ptr++;
+			} else if ('c' == *fmt_ptr || 's' == *fmt_ptr) {
+				/* 'c'/'s': match a character sequence/string. */
+				/* String conversion requires a width. */
+				// _BSCANF_CHECK_STRING(); -- we want to actually *str=0 instead of early fail
+
+				/* 'c' conversion specifiers DO NOT consume whitespace. */
+				if ('c' != *fmt_ptr) {
+					_BSCANF_CONSUME_WSPACE();
+				}
+
+				if (is_suppressed) {
+					/* Consume the character (string) and ignore it in this case. */
+					for (; max_width > 0; max_width--) {
+						buf_ptr++;
+						if (*buf_ptr == '\0' || (isspace(*buf_ptr) && 's' == *fmt_ptr)) {
+							break;
+						}
+					}
+					fmt_ptr++;
+					continue;
+
+				} else if ('l' == length_mod) {
+					wchar_ptr = va_arg(args, wchar_t*);
+					_BSCANF_CHECK_NULL(char_ptr);
+					/* TODO: Implementation. */
+					_BSCANF_CHECK(0);
+				} else {
+					char_ptr = va_arg(args, char*);
+					_BSCANF_CHECK_NULL(char_ptr);
+					*char_ptr = 0; // null byte the first char before failing
+					if (max_width < 1) {
+						num_args_set--;
+						R_LOG_DEBUG ("Missing length specifier for string");
+					} else {
+						for (; max_width > 0; max_width--) {
+							*char_ptr = *buf_ptr;
+							if (*buf_ptr == '\0' || (isspace (*buf_ptr) && 's' == *fmt_ptr)) {
+								break;
+							}
+							char_ptr++;
+							buf_ptr++;
+						}
+						if (max_width == 0 && *fmt_ptr == 's') {
+							R_LOG_DEBUG ("Truncated string in scanf");
+							while (*buf_ptr) {
+								if (isspace (*buf_ptr)) {
+									break;
+								}
+								buf_ptr++;
+							}
+						}
+					}
+					// reset max width value
+					max_width = 0;
+
+					/* Strings are null-terminated. */
+					if ('s' == *fmt_ptr) {
+						*char_ptr = '\0';
+					}
+					num_args_set++;
+				}
+
+			} else if ('[' == *fmt_ptr) {
+				/* TODO: '[': match a non-empty sequence of characters from a set. */
+				_BSCANF_CHECK(0);
+
+				/* String conversion requires a width. */
+				_BSCANF_CHECK_STRING();
+				/* '[' conversion specifiers DO NOT consume whitespace. */
+
+			} else if ('i' == *fmt_ptr || 'd' == *fmt_ptr) {
+				/* 'i'/'d': match a integer/decimal integer. */
+
+				_BSCANF_CONSUME_WSPACE();
+				base = ('d' == *fmt_ptr) * 10;
+
+				if (is_suppressed) {
+					/* Consume the integer and ignore it in this case. */
+					strtol(buf_ptr, &end_ptr, base);
+				} else if ('l' == length_mod) {
+					long_ptr = va_arg(args, long*);
+					_BSCANF_CHECK_NULL(long_ptr);
+					*long_ptr = (long) strtol(buf_ptr, &end_ptr, base);
+				} else if ('L' == length_mod) {
+					ut64_ptr = va_arg(args, ut64*);
+					_BSCANF_CHECK_NULL(long_ptr);
+					*long_ptr = (ut64) strtoll(buf_ptr, &end_ptr, base);
+				} else if ('h' == length_mod) {
+					short_ptr = va_arg(args, short*);
+					_BSCANF_CHECK_NULL(short_ptr);
+					*short_ptr = (short) (strtol(buf_ptr, &end_ptr, base));
+				} else {
+					int_ptr = va_arg(args, int*);
+					_BSCANF_CHECK_NULL(int_ptr);
+					*int_ptr = (int) (strtol(buf_ptr, &end_ptr, base));
+				}
+
+				_BSCANF_CHECK_STRTONUM();
+				buf_ptr = end_ptr;
+				num_args_set++;
+
+			} else if ('g' == *fmt_ptr || 'e' == *fmt_ptr || 'f' == *fmt_ptr ||
+					'G' == *fmt_ptr || 'E' == *fmt_ptr || 'F' == *fmt_ptr) {
+				/* 'g'/'e'/'f': match a float in strtod form. */
+				/* TODO: 'a': match a float in C99 binary floating-point form. */
+
+				_BSCANF_CONSUME_WSPACE();
+
+				if (is_suppressed) {
+					/* Consume the float and ignore it in this case. */
+					strtod(buf_ptr, &end_ptr);
+				} else if ('l' == length_mod) {
+					double_ptr = va_arg(args, double*);
+					_BSCANF_CHECK_NULL(double_ptr);
+					*double_ptr = (double) (strtod(buf_ptr, &end_ptr));
+				} else {
+					float_ptr = va_arg(args, float*);
+					_BSCANF_CHECK_NULL(float_ptr);
+					*float_ptr = (float) (strtod(buf_ptr, &end_ptr));
+				}
+
+				_BSCANF_CHECK_STRTONUM();
+				buf_ptr = end_ptr;
+				num_args_set++;
+
+			} else if ('u' == *fmt_ptr || 'o' == *fmt_ptr || 'x' == *fmt_ptr || 'X' == *fmt_ptr) {
+				/* 'u'/'o'/'x': match a unsigned decimal/octal/hexadecimal integer */
+
+				_BSCANF_CONSUME_WSPACE();
+				base = ('u' == *fmt_ptr) * 10 + ('o' == *fmt_ptr) * 8 +
+					('x' == *fmt_ptr || 'X' == *fmt_ptr) * 16;
+
+				if (is_suppressed) {
+					/* Consume the unsigned integer and ignore it in this case. */
+					strtoul(buf_ptr, &end_ptr, base);
+				} else if ('l' == length_mod) {
+					ulong_ptr = va_arg(args, unsigned long*);
+					_BSCANF_CHECK_NULL(ulong_ptr);
+					*ulong_ptr = (unsigned long) strtoul(buf_ptr, &end_ptr, base);
+				} else if ('L' == length_mod) {
+					ut64_ptr = va_arg(args, ut64*);
+					_BSCANF_CHECK_NULL(ut64_ptr);
+					*ut64_ptr = (ut64) strtoull(buf_ptr, &end_ptr, base);
+				} else if ('h' == length_mod) {
+					ushort_ptr = va_arg(args, unsigned short*);
+					_BSCANF_CHECK_NULL(ushort_ptr);
+					*ushort_ptr = (unsigned short) (strtoul(buf_ptr, &end_ptr, base));
+				} else {
+					uint_ptr = va_arg(args, unsigned int*);
+					_BSCANF_CHECK_NULL(uint_ptr);
+					*uint_ptr = (unsigned int) (strtoul(buf_ptr, &end_ptr, base));
+				}
+
+				_BSCANF_CHECK_STRTONUM();
+				buf_ptr = end_ptr;
+				num_args_set++;
+
+			} else {
+				/* Unknown conversion specifier. */
+				_BSCANF_CHECK(0);
+			}
+
+			/* TODO: 'p': match a (implementation-defined) pointer. */
+
+		} else {
+			/* Match character with that in buffer. */
+			_BSCANF_MATCH();
+			buf_ptr++;
+		}
+
+		/* Get the next format specifier. */
+		fmt_ptr++;
+	}
+
+exit:
+	va_end(args);
+	return num_args_set;
+}

--- a/libr/util/meson.build
+++ b/libr/util/meson.build
@@ -41,6 +41,7 @@ r_util_sources = [
   'lib.c',
   'list.c',
   'log.c',
+  'bscanf.c',
   'mem.c',
   'name.c',
   'new_rbtree.c',

--- a/test/unit/test_scanf.c
+++ b/test/unit/test_scanf.c
@@ -7,19 +7,19 @@ bool test_r_str_scanf(void) {
 	int res = r_str_scanf ("Hello World", "%.s %.s", sizeof (what), what, sizeof (who), who);
 	mu_assert_streq (what, "He", "truncated string in custom scanf failed");
 	mu_assert_streq (who, "World", "truncated string in custom scanf failed");
-	mu_assert_eq (2, res, "return value for scanf failed");
+	mu_assert_eq (res, 2, "return value for scanf failed");
 
 	strcpy (what, "tr");
 	strcpy (who, "trash");
 	res = r_str_scanf ("Hello World", "%s %s", what, who);
 	mu_assert_streq (what, "", "string scanf fails if no length provided");
 	mu_assert_streq (who, "", "string scanf fails if no length given");
-	mu_assert_eq (0, res, "return value for scanf failed");
+	mu_assert_eq (res, 0, "return value for scanf failed");
 
 	ut64 bignum = 0;
 	res = r_str_scanf ("0x120000023b2d8000", "0x%Lx", &bignum);
 	mu_assert_eq (0x120000023b2d8000, bignum, "portable ut64 scanf failed");
-	mu_assert_eq (1, res, "return value for scanf failed");
+	mu_assert_eq (res, 1, "return value for scanf failed");
 	mu_end;
 }
 

--- a/test/unit/test_scanf.c
+++ b/test/unit/test_scanf.c
@@ -1,0 +1,34 @@
+#include <r_util.h>
+#include "minunit.h"
+
+bool test_r_str_scanf(void) {
+	char what[3] = {0};
+	char who[8] = {0};
+	int res = r_str_scanf ("Hello World", "%.s %.s", sizeof (what), what, sizeof (who), who);
+	mu_assert_streq (what, "He", "truncated string in custom scanf failed");
+	mu_assert_streq (who, "World", "truncated string in custom scanf failed");
+	mu_assert_eq (2, res, "return value for scanf failed");
+
+	strcpy (what, "tr");
+	strcpy (who, "trash");
+	res = r_str_scanf ("Hello World", "%s %s", what, who);
+	mu_assert_streq (what, "", "string scanf fails if no length provided");
+	mu_assert_streq (who, "", "string scanf fails if no length given");
+	mu_assert_eq (0, res, "return value for scanf failed");
+
+	ut64 bignum = 0;
+	res = r_str_scanf ("0x120000023b2d8000", "0x%Lx", &bignum);
+	mu_assert_eq (0x120000023b2d8000, bignum, "portable ut64 scanf failed");
+	mu_assert_eq (1, res, "return value for scanf failed");
+	mu_end;
+}
+
+
+bool all_tests(void) {
+	mu_run_test (test_r_str_scanf);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
* %s requires length via %.s
* cant use %*s for backward compat reasons (printf vs scanf inconsistencies)
* support %Lx as a portable ut64 modifier
* add some unit tests

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
