### PR TITLE
Fixed null pointer dereference issue in treeblock

### DIFF
--- a/shlr/grub/fs/sfs.c
+++ b/shlr/grub/fs/sfs.c
@@ -159,6 +159,9 @@ grub_sfs_read_extent (struct grub_sfs_data *data, unsigned int block,
     return 0;
 
   treeblock = grub_malloc (data->blocksize);
+  if(!treeblock){
+    return grub_error(GRUB_ERR_OUT_OF_MEMORY, "Failed to allocate memory for treeblock");
+  }
 
   next = grub_be_to_cpu32 (data->rblock.btree);
   tree = (struct grub_sfs_btree *) treeblock;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
