### PR TITLE
Fix kernelcache sections vaddr offset ##bin

### DIFF
--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -1210,7 +1210,7 @@ static void sections_from_mach0(RList *ret, struct MACH0_(obj_t) *mach0, RBinFil
 		ptr->size = section->size;
 		ptr->vsize = section->vsize;
 		ptr->paddr = section->paddr + bf->bo->boffset + paddr;
-		ptr->vaddr = K_PPTR (section->vaddr) + 0x1c;
+		ptr->vaddr = K_PPTR (section->vaddr);
 		if (!ptr->vaddr) {
 			ptr->vaddr = ptr->paddr;
 		}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix #22604 by removing an hardcoded offset added by mistake in https://github.com/radareorg/radare2/commit/b447f4f04777326372b653560448ec498600eada (when such an offset in strings appears is instead because the binary is fat and must be thinned before opening)
