### PR TITLE
Enable winkd

### DIFF
--- a/libr/debug/p/debug_winkd.c
+++ b/libr/debug/p/debug_winkd.c
@@ -111,7 +111,7 @@ static bool r_debug_winkd_attach(RDebug *dbg, int pid) {
 	if (!desc || !desc->plugin || !desc->plugin->meta.name || !desc->data) {
 		return false;
 	}
-	if (r_str_startswith (desc->plugin->meta.name, "winkd")) {
+	if (!r_str_startswith (desc->plugin->meta.name, "winkd")) {
 		return false;
 	}
 	if (dbg->arch && strcmp (dbg->arch, "x86")) {


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Currently `winkd` debugger never attaches because plugin's name is never not `winkd` so fix that...

PS. Looks like 9878dd0ad9f004edbd095623d880ecf04d224ce4 broke it

