### PR TITLE
Support whole address space for IO

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -642,7 +642,7 @@ error:
 
 int PE_(read_dos_header)(RBuffer *b, PE_(image_dos_header) *header) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, 0, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, 0, R_BUF_SET) == -1) {
 		return -1;
 	}
 	header->e_magic = r_buf_read_le16 (b);
@@ -669,7 +669,7 @@ int PE_(read_dos_header)(RBuffer *b, PE_(image_dos_header) *header) {
 		header->e_res2[i] = r_buf_read_le16 (b);
 	}
 	header->e_lfanew = r_buf_read_le32 (b);
-	if (r_buf_seek (b, o_addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, o_addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	return sizeof (PE_(image_dos_header));
@@ -677,7 +677,7 @@ int PE_(read_dos_header)(RBuffer *b, PE_(image_dos_header) *header) {
 
 int PE_(read_nt_headers)(RBuffer *b, ut64 addr, PE_(image_nt_headers) *headers) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	headers->Signature = r_buf_read_le32 (b);
@@ -734,7 +734,7 @@ int PE_(read_nt_headers)(RBuffer *b, ut64 addr, PE_(image_nt_headers) *headers) 
 		headers->optional_header.DataDirectory[i].VirtualAddress = r_buf_read_le32 (b);
 		headers->optional_header.DataDirectory[i].Size = r_buf_read_le32 (b);
 	}
-	if (r_buf_seek (b, o_addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, o_addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	return sizeof (PE_(image_nt_headers));
@@ -947,7 +947,7 @@ static struct r_bin_pe_export_t* parse_symbol_table(RBinPEObj* pe, struct r_bin_
 
 int PE_(read_image_section_header)(RBuffer *b, ut64 addr, PE_(image_section_header) *section_header) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		section_header->Name[0] = 0;
 		return -1;
 	}
@@ -1391,7 +1391,7 @@ static int bin_pe_init_overlay(RBinPEObj* pe) {
 
 static int read_image_clr_header(RBuffer *b, ut64 addr, PE_(image_clr_header) *header) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (PE_(image_clr_header))];
@@ -1450,7 +1450,7 @@ static int bin_pe_init_clr_hdr(RBinPEObj* pe) {
 
 static int read_image_import_directory(RBuffer *b, ut64 addr, PE_(image_import_directory) *import_dir) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (PE_(image_import_directory))];
@@ -1466,7 +1466,7 @@ static int read_image_import_directory(RBuffer *b, ut64 addr, PE_(image_import_d
 
 static int read_image_delay_import_directory(RBuffer *b, ut64 addr, PE_(image_delay_import_directory) *directory) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (PE_(image_delay_import_directory))];
@@ -1600,7 +1600,7 @@ fail:
 
 static int read_image_export_directory(RBuffer *b, ut64 addr, PE_(image_export_directory) *export_dir) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (PE_(image_export_directory))];
@@ -1655,7 +1655,7 @@ static void _free_resource(r_pe_resource *rs) {
 
 static int read_image_resource_directory(RBuffer *b, ut64 addr, Pe_image_resource_directory *dir) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	dir->Characteristics = r_buf_read_le32 (b);
@@ -1729,7 +1729,7 @@ static void bin_pe_store_tls_callbacks(RBinPEObj* pe, PE_DWord callbacks) {
 
 static int read_tls_directory(RBuffer *b, ut64 addr, PE_(image_tls_directory) *tls_directory) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	tls_directory->StartAddressOfRawData = r_buf_read_le32 (b);
@@ -2988,7 +2988,7 @@ static char* _resource_type_str(int type) {
 
 static int read_image_resource_directory_entry(RBuffer *b, ut64 addr, Pe_image_resource_directory_entry *entry) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	entry->u1.Name = r_buf_read_le32 (b);
@@ -2999,7 +2999,7 @@ static int read_image_resource_directory_entry(RBuffer *b, ut64 addr, Pe_image_r
 
 static int read_image_resource_data_entry(RBuffer *b, ut64 addr, Pe_image_resource_data_entry *entry) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (Pe_image_resource_data_entry)];
@@ -3731,7 +3731,7 @@ static int get_debug_info(RBinPEObj* pe, PE_(image_debug_directory_entry)* dbg_d
 
 static int read_image_debug_directory_entry(RBuffer *b, ut64 addr, PE_(image_debug_directory_entry) *entry) {
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r_buf_seek (b, addr, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, addr, R_BUF_SET) == -1) {
 		return -1;
 	}
 	ut8 buf[sizeof (PE_(image_debug_directory_entry))];

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -4513,6 +4513,12 @@ R_API RBinPEObj* PE_(r_bin_pe_new_buf)(RBuffer *buf, bool verbose) {
 	pe->b = r_buf_ref (buf);
 	pe->verbose = verbose;
 	pe->size = r_buf_size (buf);
+	// buffer can be a lot larger so we might overflow
+	if (pe->size < 0) {
+		// in that case just clamp it
+		// it's unlikely that whole buffer is just PE alone
+		pe->size = INT_MAX;
+	}
 	if (!bin_pe_init (pe)) {
 		return PE_(r_bin_pe_free)(pe);
 	}

--- a/libr/io/p/io_cyclic.c
+++ b/libr/io/p/io_cyclic.c
@@ -9,7 +9,7 @@ R_IPI ut64 cyclic_seek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
 	switch (whence) {
 	case 0: offset %= mal->cycle; break;
 	case 1: offset += mal->offset; offset %= mal->cycle; break;
-	case 2: return UT64_MAX; break;
+	case 2: return UT64_MAX - 1; break;
 	}
 	return io_memory_lseek (io, desc, offset, whence);
 }

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -43,14 +43,14 @@ static int __io_posix_open(const char *file, int perm, int mode) {
 
 static ut64 r_io_def_mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
 	if (!mmo) {
-		return UT64_MAX;
+		return UT64_MAX - 1;
 	}
 	if (mmo->rawio) {
 		io->off = lseek (mmo->fd, offset, whence);
 		return io->off;
 	}
 	if (!mmo->buf) {
-		return UT64_MAX;
+		return UT64_MAX - 1;
 	}
 	io->off = r_buf_seek (mmo->buf, offset, whence);
 	return io->off;

--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -651,7 +651,7 @@ static int r_io_internal_read(RIODscObject * dsc, ut64 off_global, ut8 *buf, int
 
 static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int whence) {
 	if (!dsc || offset == UT64_MAX) {
-		return UT64_MAX;
+		return UT64_MAX - 1;
 	}
 
 	ut64 off_global;
@@ -667,7 +667,7 @@ static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int wh
 			off_global = dsc->total_size + offset;
 			break;
 		default:
-			return UT64_MAX;
+			return UT64_MAX - 1;
 	}
 
 	RIODscSlice * slice = r_io_dsc_object_get_slice(dsc, off_global);
@@ -676,13 +676,13 @@ static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int wh
 			io->off = dsc->total_size;
 			return io->off;
 		}
-		return UT64_MAX;
+		return UT64_MAX - 1;
 	}
 
 	ut64 off_local = off_global - slice->start;
 	off_local = lseek (slice->fd, off_local, SEEK_SET);
 	if (off_local == UT64_MAX) {
-		return UT64_MAX;
+		return UT64_MAX - 1;
 	}
 
 	io->off = off_local + slice->start;

--- a/libr/io/p/io_r2k.c
+++ b/libr/io/p/io_r2k.c
@@ -78,7 +78,7 @@ static bool r2k__close(RIODesc *fd) {
 
 static ut64 r2k__lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	return (!whence) ? offset : whence == 1
-		? io->off + offset : UT64_MAX;
+		? io->off + offset : UT64_MAX - 1;
 }
 
 static bool r2k__plugin_open(RIO *io, const char *pathname, bool many) {

--- a/libr/io/p/io_r2pipe.c
+++ b/libr/io/p/io_r2pipe.c
@@ -135,7 +135,7 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	switch (whence) {
 	case SEEK_SET: return offset;
 	case SEEK_CUR: return io->off + offset;
-	case SEEK_END: return UT64_MAX;
+	case SEEK_END: return UT64_MAX - 1;
 	}
 	return offset;
 }

--- a/libr/io/p/io_r2web.c
+++ b/libr/io/p/io_r2web.c
@@ -81,7 +81,7 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	switch (whence) {
 	case SEEK_SET: return offset;
 	case SEEK_CUR: return io->off + offset;
-	case SEEK_END: return UT64_MAX;
+	case SEEK_END: return UT64_MAX - 1;
 	}
 	return offset;
 }

--- a/libr/io/p/io_self.c
+++ b/libr/io/p/io_self.c
@@ -425,7 +425,8 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		} else {
 			io->off = UT32_MAX;
 		}
-		return UT64_MAX;
+		// UT64_MAX means error
+		return UT64_MAX - 1;
 	}
 	return offset;
 }

--- a/libr/io/p/io_shm.c
+++ b/libr/io/p/io_shm.c
@@ -80,8 +80,12 @@ static ut64 shm__lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		}
 		break;
 	case SEEK_END:
-		io->off = ((int)shm->size > 0) ? shm->size : UT64_MAX;
-		io->off += (int)offset;
+		if ((int)shm->size > 0) {
+			io->off = shm->size + (int)offset;
+		} else {
+			// UT64_MAX means error
+			io->off = UT64_MAX - 1;
+		}
 		break;
 	}
 	return io->off;

--- a/libr/io/p/io_sysgdb.c
+++ b/libr/io/p/io_sysgdb.c
@@ -246,7 +246,7 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = UT64_MAX;
+		io->off = UT64_MAX - 1; // UT64_MAX reserved for error case
 	}
 	return io->off;
 }

--- a/libr/io/p/io_treebuf.c
+++ b/libr/io/p/io_treebuf.c
@@ -78,7 +78,7 @@ static ut64 __lseek(RIO* io, RIODesc *desc, ut64 offset, int whence) {
 	case R_IO_SEEK_SET:
 		return treebuf->seek = offset;
 	case R_IO_SEEK_END:
-		return treebuf->seek = UT64_MAX;
+		return treebuf->seek = UT64_MAX - 1;
 	case R_IO_SEEK_CUR:
 		return treebuf->seek = R_MAX (treebuf->seek, treebuf->seek + offset);
 	}

--- a/libr/io/p/io_w32dbg.c
+++ b/libr/io/p/io_w32dbg.c
@@ -210,7 +210,7 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += (int)offset;
 		break;
 	case 2: // end
-		io->off = UT64_MAX;
+		io->off = UT64_MAX - 1; // UT64_MAX reserved for error case
 		break;
 	}
 	return io->off;

--- a/libr/io/p/io_windbg.c
+++ b/libr/io/p/io_windbg.c
@@ -597,7 +597,7 @@ static ut64 windbg_lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += (st64)offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = UT64_MAX;
+		io->off = UT64_MAX - 1; // UT64_MAX reserved for error case
 		break;
 	}
 	return io->off;

--- a/libr/io/p/io_winkd.c
+++ b/libr/io/p/io_winkd.c
@@ -86,7 +86,7 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	case R_IO_SEEK_CUR:
 		return io->off + offset;
 	case R_IO_SEEK_END:
-		return ST64_MAX;
+		return UT64_MAX - 1; // UT64_MAX reserved for error case
 	default:
 		return offset;
 	}

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -276,13 +276,13 @@ R_API bool r_buf_set_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	if (!r_buf_resize (b, 0)) {
 		return false;
 	}
-	if (r_buf_seek (b, 0, R_BUF_SET) < 0) {
+	if (r_buf_seek (b, 0, R_BUF_SET) == -1) {
 		return false;
 	}
 	if (!r_buf_append_bytes (b, buf, length)) {
 		return false;
 	}
-	return r_buf_seek (b, 0, R_BUF_SET) >= 0;
+	return r_buf_seek (b, 0, R_BUF_SET) != -1;
 }
 
 R_API bool r_buf_prepend_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
@@ -307,7 +307,7 @@ R_API char *r_buf_tostring(RBuffer *b) {
 R_API bool r_buf_append_bytes(RBuffer *b, const ut8 *buf, ut64 length) {
 	r_return_val_if_fail (b && buf && !b->readonly, false);
 
-	if (r_buf_seek (b, 0, R_BUF_END) < 0) {
+	if (r_buf_seek (b, 0, R_BUF_END) == -1) {
 		return false;
 	}
 	return r_buf_write (b, buf, length) >= 0;
@@ -327,12 +327,12 @@ R_API bool r_buf_append_nbytes(RBuffer *b, ut64 length) {
 R_API st64 r_buf_insert_bytes(RBuffer *b, ut64 addr, const ut8 *buf, ut64 length) {
 	r_return_val_if_fail (b && !b->readonly, -1);
 	st64 pos, r = r_buf_seek (b, 0, R_BUF_CUR);
-	if (r < 0) {
+	if (r == -1) {
 		return r;
 	}
 	pos = r;
 	r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		goto restore_pos;
 	}
 
@@ -347,7 +347,7 @@ R_API st64 r_buf_insert_bytes(RBuffer *b, ut64 addr, const ut8 *buf, ut64 length
 		goto free_tmp;
 	}
 	r = r_buf_seek (b, addr + length, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		goto free_tmp;
 	}
 	r = r_buf_write (b, tmp, tmp_length);
@@ -355,7 +355,7 @@ R_API st64 r_buf_insert_bytes(RBuffer *b, ut64 addr, const ut8 *buf, ut64 length
 		goto free_tmp;
 	}
 	r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		goto free_tmp;
 	}
 	r = r_buf_write (b, buf, length);
@@ -581,7 +581,7 @@ R_API st64 r_buf_fread_at(RBuffer *b, ut64 addr, ut8 *buf, const char *fmt, int 
 	r_return_val_if_fail (b && buf && fmt, -1);
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		return r;
 	}
 	r = r_buf_fread (b, buf, fmt, n);
@@ -602,7 +602,7 @@ R_API st64 r_buf_fwrite_at(RBuffer *b, ut64 addr, const ut8 *buf, const char *fm
 	r_return_val_if_fail (b && buf && fmt && !b->readonly, -1);
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		return r;
 	}
 	r = r_buf_fwrite (b, buf, fmt, n);
@@ -614,7 +614,7 @@ R_API st64 r_buf_read_at(RBuffer *b, ut64 addr, ut8 *buf, ut64 len) {
 	r_return_val_if_fail (b && buf, -1);
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		return r;
 	}
 	r = r_buf_read (b, buf, len);
@@ -626,7 +626,7 @@ R_API st64 r_buf_write_at(RBuffer *b, ut64 addr, const ut8 *buf, ut64 len) {
 	r_return_val_if_fail (b && buf && !b->readonly, -1);
 	st64 o_addr = r_buf_seek (b, 0, R_BUF_CUR);
 	st64 r = r_buf_seek (b, addr, R_BUF_SET);
-	if (r < 0) {
+	if (r == -1) {
 		return r;
 	}
 	r = r_buf_write (b, buf, len);


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

When debugging recent Windows 10 x64 kernel then it maps kernel modules very high in virtual memory (above `0x7fffffffffffffff`, eg. `0xfffff8018f920000`) that means it's not addressable using `ST64_MAX`.

And that is causing `oba` to not work due to such high address space.

This PR fixes that by:
* Reserving `UT64_MAX` for error case in `RBufferSeek()` 
* Updating  `ST64_MAX` to `UT64_MAX - 1` for `R_IO_SEEK_END`  in `winkd`
* Updating  `UT64_MAX` to `UT64_MAX - 1` for other plugins - they're broken in similar way and would fail above ST64_MAX anyway so this actually increases addressable space
* Use `buf_seek() != -1` instead of `buf_seek() >= 0` because `buf_seek` uses `st64` while `RBufferSeek` uses `ut64` - probably better would be to convert `buf_seek()` to `ut64` aswell but that would be quite massive change...
* Fix PE plugin to be able to handle huge buffers - this is needed because when loaded from IO plugin you don't actually know true size and you get `UT64_MAX - 1 - offset` as PE size...



PS. Tracking this down was incredibly painful...

