### PR TITLE
Fix issue with detecting if a library/plugin was already loaded

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -381,7 +381,7 @@ R_API int r_lib_open_ptr(RLib *lib, const char *file, void *handler, RLibStruct 
 		r_list_append (lib->plugins, p);
 		const char *fileName = r_str_rstr (file, R_SYS_DIR);
 		if (fileName) {
-			ht_pp_insert (lib->plugins_ht, strdup (fileName), p);
+			ht_pp_insert (lib->plugins_ht, strdup (fileName + 1), p);
 		}
 	}
 	return ret;


### PR DESCRIPTION


<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Previously, the plugin name was stored in the hash table with the preceding slash (like `/core_ghidra.so`).
But `already_loaded` searched for the name without the slash. This PR removes the preceding slash when storing plugin names.