### PR TITLE
Use RTime.today() instead of time() in two leftovers

### DIFF
--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -5398,7 +5398,7 @@ static int cmd_debug(void *data, const char *input) {
 			int beats = r_time_beats (r_time_now (), &sub_beats);
 			r_cons_printf ("@%03d.%d\n", beats, sub_beats);
 		} else {
-			char *nostr = r_time_secs_tostring (time (0));
+			char *nostr = r_time_secs_tostring (r_time_today ());
 			r_cons_println (nostr);
 			free (nostr);
 		}

--- a/libr/main/r2pm.c
+++ b/libr/main/r2pm.c
@@ -146,7 +146,7 @@ static void r2pm_register(const char *pkg, bool g) {
 	if (f) {
 		RStrBuf *sb = r_strbuf_new ("");
 		r_strbuf_appendf (sb, "Global: %s\n", r_str_bool (g));
-		char *s = r_time_secs_tostring (time (0));
+		char *s = r_time_secs_tostring (r_time_today ());
 		r_strbuf_appendf (sb, "InstallationDate: %s\n", s);
 		free (s);
 		char *ss = r_strbuf_drain (sb);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
