### PR TITLE
Free leak in reg.c

### DIFF
--- a/libr/reg/reg.c
+++ b/libr/reg/reg.c
@@ -435,6 +435,7 @@ R_API bool r_reg_ro_reset(RReg *reg, const char *arg) {
 				res = false;
 			}
 		}
+		r_list_free (roregs);
 	}
 	return res;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Hi, I love reverse engineering binaries using radare and would love to contribute to this repository :).

**Description**
The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 ls` with LeakSanitizer

```
Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x55c8b678a627 in calloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:154:3
    #1 0x7f95161a89a6 in r_list_new /home/aniruddhan/radare2/libr/util/list.c:184:16
    #2 0x7f95161a8a00 in r_list_newf /home/aniruddhan/radare2/libr/util/list.c:193:13
    #3 0x7f951616e006 in r_str_split_duplist /home/aniruddhan/radare2/libr/util/str.c:3460:15
    #4 0x7f9511120495 in r_reg_ro_reset /home/aniruddhan/radare2/libr/reg/reg.c:429:19
    #5 0x7f95158a64b7 in cb_anal_roregs /home/aniruddhan/radare2/libr/core/cconfig.c:3053:2
    #6 0x7f951676e891 in r_config_set_cb /home/aniruddhan/radare2/libr/config/config.c:404:9
    #7 0x7f951589c2d1 in r_core_config_init /home/aniruddhan/radare2/libr/core/cconfig.c:3452:2
    #8 0x7f95155fab9d in r_core_init /home/aniruddhan/radare2/libr/core/core.c:3339:2
    #9 0x7f95155f464e in r_core_new /home/aniruddhan/radare2/libr/core/core.c:960:3
    #10 0x7f9510ebd1e5 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:686:13
    #11 0x55c8b67bfd2d in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118:9
    #12 0x7f9510c5b082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
```
<!-- explain your changes if necessary -->
The leak happens in `r_reg_ro_reset` where `roregs` is allocated but not freed before return of the function. Therefore the patch deallocates `roregs` before it's scope runs out.

I was able to verify that the PR fixes the leak and there is no double-free thereafter. Thank you for considering the fix!
