### PR TITLE
Fix leak in lib.c

### DIFF
--- a/libr/util/lib.c
+++ b/libr/util/lib.c
@@ -185,6 +185,7 @@ R_API void r_lib_free(RLib *lib) {
 		r_lib_close (lib, NULL);
 		r_list_free (lib->handlers);
 		r_list_free (lib->plugins);
+		ht_pp_free(lib->plugins_ht);
 		free (lib->symname);
 		free (lib->symnamefunc);
 		free (lib);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Hi, I love reverse engineering binaries using radare and would love to contribute to this repository :).

**Description**
The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 ls` with LeakSanitizer

```
Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x561a240c046f in malloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x7fa38fb65005 in sdb_gh_malloc /home/aniruddhan/radare2/libr/../shlr/sdb/include/sdb/heap.h:39:9
    #2 0x7fa38fb64f05 in sdb_gh_calloc /home/aniruddhan/radare2/libr/../shlr/sdb/include/sdb/heap.h:63:14
    #3 0x7fa38fb6220b in internal_ht_new /home/aniruddhan/radare2/libr/../shlr/sdb/src/ht.inc.c:107:29
    #4 0x7fa38fb64c4e in internal_ht_default_new /home/aniruddhan/radare2/libr/../shlr/sdb/src/ht_pp.c:18:9
    #5 0x7fa38fb6493e in ht_pp_new /home/aniruddhan/radare2/libr/../shlr/sdb/src/ht_pp.c:23:9
    #6 0x7fa38fb64ce9 in ht_pp_new0 /home/aniruddhan/radare2/libr/../shlr/sdb/src/ht_pp.c:32:9
    #7 0x7fa38fab3fd4 in r_lib_new /home/aniruddhan/radare2/libr/util/lib.c:176:21
    #8 0x7fa38f14cc26 in r_core_loadlibs_init /home/aniruddhan/radare2/libr/core/libs.c:100:14
    #9 0x7fa38ee3bbaf in r_core_init /home/aniruddhan/radare2/libr/core/core.c:3340:2
    #10 0x7fa38ee3564e in r_core_new /home/aniruddhan/radare2/libr/core/core.c:960:3
    #11 0x7fa38a6fe1e5 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:686:13
    #12 0x561a240f5d2d in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118:9
    #13 0x7fa38a49c082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
```

<!-- explain your changes if necessary -->
The leak occurs because `r_lib_new` allocates `lib->plugins_ht` but `r_lib_free` does not deallocate `lib->plugins_ht`. Therefore, the patch deallocates `lib->plugins_ht` in `r_lib_free` to fix the leak.

I was able to verify that the PR fixes the leak and there is no double-free thereafter. Thank you for considering the fix!