### PR TITLE
Fix leaks in profile.c

### DIFF
--- a/libr/reg/profile.c
+++ b/libr/reg/profile.c
@@ -122,7 +122,8 @@ static const char *parse_def(RReg *reg, char **tok, const int n) {
 	}
 
 	item->arena = type2;
-	if (!reg->regset[type2].regs) {
+	if (!reg->regset[type2].regs || reg->regset[type2].regs->length == 0) {
+		r_list_free(reg->regset[type2].regs);
 		reg->regset[type2].regs = r_list_newf ((RListFree)r_reg_item_free);
 	}
 	r_ref (item);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 ls` with LeakSanitizer

```
Direct leak of 9792 byte(s) in 136 object(s) allocated from:
    #0 0x559ab5f87627 in calloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:154:3
    #1 0x7f4be5245f05 in parse_def /home/aniruddhan/radare2/libr/reg/profile.c:64:19
    #2 0x7f4be5245208 in r_reg_set_profile_string /home/aniruddhan/radare2/libr/reg/profile.c:249:8
    #3 0x7f4be53f37d6 in r_anal_set_reg_profile /home/aniruddhan/radare2/libr/anal/anal.c:248:9
    #4 0x7f4be99c53cd in cb_asmbits /home/aniruddhan/radare2/libr/core/cconfig.c:940:9
    #5 0x7f4bea8830d4 in r_config_set_i /home/aniruddhan/radare2/libr/config/config.c:627:13
    #6 0x7f4be970dbff in r_core_init /home/aniruddhan/radare2/libr/core/core.c:3349:3
    #7 0x7f4be970764e in r_core_new /home/aniruddhan/radare2/libr/core/core.c:960:3
    #8 0x7f4be4fd01e5 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:686:13
    #9 0x559ab5fbcd2d in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118:9
    #10 0x7f4be4d6e082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
```

<!-- explain your changes if necessary -->
The leak occurs because the variable `reg->regset[type2].regs` is a list whose item-level free function is not correctly assigned. In the function `parse_def` there is a guard condition that checks `if (!reg->regset[type2].regs)` before assigning it to `r_list_newf ((RListFree)r_reg_item_free)` adding correct free function for item level deallocation.

 However, it so happens that this guard condition fails to trigger when `reg->regset[type2].regs`  is already a list with length 0 and free function `r_reg_item_unref`  (which only unrefs the item but does not have correct free function assigned at this point yet)

GDB output of how `reg->regset[type2].regs` looks like before guard condition:
`{head = 0x0, tail = 0x0, free = 0x7ffff2707a90 <r_reg_item_unref>, length = 0, sorted = false}`

In order to fix this I modified the guard condition to also check the length of the array before assigning to a new list with correct item-level deallocation function. This removes a large leak problem on simple executions.

I was able to verify that the PR fixes the leak and there is no double-free thereafter. Thank you for considering the fix!