### PR TITLE
Fix 1 byte oobread in the h8300 by defining the archinfo details ##crash

### DIFF
--- a/libr/arch/p/h8300/plugin.c
+++ b/libr/arch/p/h8300/plugin.c
@@ -536,7 +536,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RAnalOpMask mask) {
 	const ut64 addr = op->addr;
 	const ut8 *buf = op->bytes;
 	const int len = op->size;
-	if (len < 1) {
+	if (len < 2) {
 		return false;
 	}
 
@@ -727,9 +727,19 @@ static char* regs(RArchSession *as) {
 }
 
 static int archinfo(RArchSession *as, ut32 q) {
-	return 0;
+	switch (q) {
+	case R_ARCH_INFO_ALIGN:
+	case R_ARCH_INFO_DATA_ALIGN:
+		return 2;
+	case R_ANAL_ARCHINFO_MAX_OP_SIZE:
+		return 4;
+	case R_ANAL_ARCHINFO_INV_OP_SIZE:
+		return 2;
+	case R_ANAL_ARCHINFO_MIN_OP_SIZE:
+		return 2;
+	}
+	return 2;
 }
-
 
 const RArchPlugin r_arch_plugin_h8300 = {
 	.meta = {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
