### PR TITLE
Avoid failing reg read if conversion fails on xnu native ##debug

### DIFF
--- a/libr/debug/p/native/xnu/xnu_threads.c
+++ b/libr/debug/p/native/xnu/xnu_threads.c
@@ -271,6 +271,7 @@ static bool xnu_thread_get_gpr(RDebug *dbg, xnu_thread_t *thread) {
 
 	if (rc == KERN_SUCCESS) {
 		ut32 count = thread->count;
+	    kern_return_t rc;
 		rc = xnu_convert_thread_state (
 			thread->port,
 			THREAD_CONVERT_THREAD_STATE_TO_SELF,
@@ -281,8 +282,10 @@ static bool xnu_thread_get_gpr(RDebug *dbg, xnu_thread_t *thread) {
 			R_LOG_WARN ("failed to convert %d", rc);
 		}
 #if  __arm64e__
-		if (dbg->bits == R_SYS_BITS_64) {
-			arm_thread_state64_ptrauth_strip (regs->ts_64);
+		else {
+			if (dbg->bits == R_SYS_BITS_64) {
+				arm_thread_state64_ptrauth_strip (regs->ts_64);
+			}
 		}
 #endif
 	}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

So that if you have SIP disabled, but running an arm64 version of r2 on an arm64e target, it's still possible to read the target registers and step (but you can't modify the registers).
