### PR TITLE
Fix leak in cmd_meta.inc.c

### DIFF
--- a/libr/core/cmd_meta.inc.c
+++ b/libr/core/cmd_meta.inc.c
@@ -974,6 +974,7 @@ static int cmd_meta_others(RCore *core, const char *input) {
 					r_search_begin (ss);
 					r_search_update (ss, addr, buf, range);
 					r_search_free (ss);
+					free (buf);
 				} else {
 					R_LOG_ERROR ("Cannot allocate");
 				}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 /bin/ls` with LeakSanitizer followed by visual mode 'V!' and 'q' followed by another 'q' to exit.

```
Direct leak of 1613 byte(s) in 1 object(s) allocated from:
    #0 0x555a112c946f in malloc /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x7f85c20fad09 in cmd_meta_others /home/aniruddhan/radare2/libr/core/./cmd_meta.inc.c:948:16
    #2 0x7f85c1fd8b47 in cmd_meta /home/aniruddhan/radare2/libr/core/./cmd_meta.inc.c:1333:3
    #3 0x7f85c22eabff in r_cmd_call /home/aniruddhan/radare2/libr/core/cmd_api.c:520:11
    #4 0x7f85c2067681 in r_core_cmd_subst_i /home/aniruddhan/radare2/libr/core/cmd.c:5001:10
    #5 0x7f85c205b925 in r_core_cmd_subst /home/aniruddhan/radare2/libr/core/cmd.c:3862:10
    #6 0x7f85c1faf70a in run_cmd_depth /home/aniruddhan/radare2/libr/core/cmd.c:6004:9
    #7 0x7f85c1f9fb6c in r_core_cmd /home/aniruddhan/radare2/libr/core/cmd.c:6097:8
    #8 0x7f85c1f6a695 in r_core_cmdf /home/aniruddhan/radare2/libr/core/cmd.c:6264:12
    #9 0x7f85c22af2f6 in bin_sections /home/aniruddhan/radare2/libr/core/cbin.c:3303:5
    #10 0x7f85c229e9ad in r_core_bin_info /home/aniruddhan/radare2/libr/core/cbin.c:4768:10
    #11 0x7f85c229e440 in r_core_bin_set_env /home/aniruddhan/radare2/libr/core/cbin.c:316:3
    #12 0x7f85c21d9121 in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:450:6
    #13 0x7f85c21d3363 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658:4
    #14 0x7f85bd8106b4 in binload /home/aniruddhan/radare2/libr/main/radare2.c:547:8
    #15 0x7f85bd806e80 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488:10
    #16 0x555a112fed2d in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118:9
    #17 0x7f85bd59a082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
```

<!-- explain your changes if necessary -->
The leak occurs because `buf` is a variable allocated in a switch branch  in function `cmd_meta_others` but not deallocated at end of the switch branch. The variable is only used to store a string used for an `r_search_update` but is unused thereafter. The patch deallocates it at the end of the switch branch.

I was able to verify that the PR fixes the leak and there is no double-free thereafter. Thank you for considering the fix!

