### PR TITLE
Fix leaks related to name of RBinImport

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -158,7 +158,7 @@ R_API RBinImport *r_bin_import_clone(RBinImport *o) {
 
 R_API void r_bin_import_free(RBinImport *imp) {
 	if (imp) {
-		free (imp->name);
+		r_bin_name_free (imp->name);
 		free (imp->libname);
 		free (imp->classname);
 		free (imp->descriptor);

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -39,7 +39,7 @@ static void setimpord(ELFOBJ* eo, ut32 ord, RBinImport *ptr) {
 		return;
 	}
 	// leak or uaf wtf
-	r_bin_import_free (eo->imports_by_ord[ord]);
+	// r_bin_import_free (eo->imports_by_ord[ord]);
 	eo->imports_by_ord[ord] = r_bin_import_clone (ptr);
 }
 

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -39,7 +39,7 @@ static void setimpord(ELFOBJ* eo, ut32 ord, RBinImport *ptr) {
 		return;
 	}
 	// leak or uaf wtf
-	// r_bin_import_free (eo->imports_by_ord[ord]);
+	r_bin_import_free (eo->imports_by_ord[ord]);
 	eo->imports_by_ord[ord] = r_bin_import_clone (ptr);
 }
 
@@ -67,8 +67,7 @@ static void destroy(RBinFile *bf) {
 		for (i = 0; i < eo->imports_by_ord_size; i++) {
 			RBinImport *imp = eo->imports_by_ord[i];
 			if (imp) {
-				free (imp->name);
-				free (imp);
+				r_bin_import_free (eo->imports_by_ord[i]);
 				eo->imports_by_ord[i] = NULL;
 			}
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 /bin/ls` with LeakSanitizer followed by visual mode 'V!' and 'q' followed by another 'q' to exit.

```
Direct leak of 1162 byte(s) in 113 object(s) allocated from:
    #0 0x55bab18cc9d7 in strdup /home/aniruddhan/aflgo/instrument/llvm_tools/compiler-rt/lib/asan/asan_interceptors.cpp:452:3
    #1 0x7fed5a003e46 in r_bin_name_clone /home/aniruddhan/radare2/libr/bin/bin.c:1510:15
    #2 0x7fed5a003b4a in r_bin_import_clone /home/aniruddhan/radare2/libr/bin/bin.c:152:15
    #3 0x7fed5a15256a in setimpord /home/aniruddhan/radare2/libr/../libr/bin/p/bin_elf.inc.c:43:28
    #4 0x7fed5a14b3d3 in imports /home/aniruddhan/radare2/libr/../libr/bin/p/bin_elf.inc.c:434:3
    #5 0x7fed5a04659d in r_bin_object_set_items /home/aniruddhan/radare2/libr/bin/bobj.c:369:17
    #6 0x7fed5a04537e in r_bin_object_new /home/aniruddhan/radare2/libr/bin/bobj.c:233:2
    #7 0x7fed5a03793f in r_bin_file_new_from_buffer /home/aniruddhan/radare2/libr/bin/bfile.c:629:19
    #8 0x7fed5a0065b9 in r_bin_open_buf /home/aniruddhan/radare2/libr/bin/bin.c:308:8
    #9 0x7fed5a00545d in r_bin_open_io /home/aniruddhan/radare2/libr/bin/bin.c:374:13
    #10 0x7fed5de1b0b9 in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:445:7
    #11 0x7fed5de15373 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658:4
    #12 0x7fed594526b4 in binload /home/aniruddhan/radare2/libr/main/radare2.c:547:8
    #13 0x7fed59448e80 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488:10
    #14 0x55bab1987d2d in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118:9
    #15 0x7fed591dc082 in __libc_start_main /build/glibc-wuryBv/glibc-2.31/csu/../csu/libc-start.c:308:16
```


<!-- explain your changes if necessary -->

The leak occurs because of multiple reasons. Firstly in `bin.c`,  `r_bin_import_free` which is supposed to deallocate `name` of `RBinImport` does not do it the right way. It must be deallocated using `r_bin_name_free` because it is a struct with other members such as `oname`, `name` and `fname`.

In the other file `bin_elf.inc.c`,  the function `setimpord` must free `eo->imports_by_ord[ord]` before assigning it. Interestingly, this piece of code exists but was commented out for some reason.

In the same file the function `destroy` again deallocates `name` of `RBinImport* imp` in the wrong way. The patch deallocates using `r_bin_import_free` instead.

I was able to verify that the PR fixes the leak and there is no double-free thereafter. Thank you for considering the fix!
