### PR TITLE
refactor resolve_glibc_version, improve libc regex

### DIFF
--- a/libr/core/dmh_glibc.inc.c
+++ b/libr/core/dmh_glibc.inc.c
@@ -110,7 +110,7 @@ static GH(section_content) GH(get_section_content)(RCore *core, const char *path
 	RBinFileOptions opt;
 	r_bin_file_options_init (&opt, -1, 0, 0, false);
 	if (!r_bin_open (bin, path, &opt)) {
-		R_LOG_ERROR ("section_content: r_bin_open failed on path %s", path);
+		R_LOG_ERROR ("get_section_content: r_bin_open failed on path %s", path);
 		return content;
 	}
 
@@ -129,21 +129,21 @@ static GH(section_content) GH(get_section_content)(RCore *core, const char *path
 	}
 
 	if (!found_section) {
-		R_LOG_WARN ("section_content: section %s not found", section_name);
+		R_LOG_WARN ("get_section_content: section %s not found", section_name);
 		goto cleanup_exit;
 	}
 
 	// eprintf ("get_section_bytes: section found: %s content.size: %#08x  paddr: %#08x\n", section_name, content.size, paddr);
 	content.buf = calloc (content.size, 1);
 	if (!content.buf) {
-		R_LOG_ERROR ("section_content: calloc failed");
+		R_LOG_ERROR ("get_section_content: calloc failed");
 		goto cleanup_exit;
 	}
 
 	st64 read_size = r_buf_read_at (libc_bf->buf, paddr, content.buf, content.size);
 
 	if (read_size != content.size) {
-		R_LOG_ERROR ("section_content: section read unexpected content.size: %#08x  (section->size: %d)", read_size, content.size);
+		R_LOG_ERROR ("get_section_content: section read unexpected content.size: %#08x  (section->size: %d)", read_size, content.size);
 		free (content.buf);
 		content.buf = NULL;
 	}

--- a/libr/core/dmh_glibc.inc.c
+++ b/libr/core/dmh_glibc.inc.c
@@ -215,22 +215,23 @@ R_API double GH(get_glibc_version)(RCore *core, const char *libc_path) {
 }
 
 static const char* GH(get_libc_filename_from_maps)(RCore *core) {
+	r_return_val_if_fail (core && core->dbg && core->dbg->maps && core->bin && core->bin->file, NULL);
 	RListIter *iter;
 	RDebugMap *map = NULL;
 
-	r_return_val_if_fail (core && core->dbg && core->dbg->maps, NULL);
 	r_debug_map_sync (core->dbg);
 
 	// Search for binary in memory maps named *libc-* or *libc.*  *libc6_* or similiar
 	// TODO: This is very brittle, other bin names or LD_PRELOAD could be a problem
 	r_list_foreach (core->dbg->maps, iter, map) {
-		if (r_str_startswith (core->bin->file, map->name)) {
+		if (!map->name || r_str_startswith (core->bin->file, map->name)) {
 			continue;
 		}
-		if (r_regex_match (".*libc6?[-_\\.]", "e", map->name))
-			break;
+		if (r_regex_match (".*libc6?[-_\\.]", "e", map->name)) {
+			return map->file;
+		}
 	}
-	return map->file;
+	return NULL;
 }
 
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge

**Description**

Breaks out the function to get libc filename from memory maps since it is gonna be needed in other functions later.
Also changes the regex for finding libc. (inspired by pwndbg)


