### PR TITLE
Fix leaks in bin_elf.inc.c

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -240,6 +240,7 @@ static void process_constructors(RBinFile *bf, RList *ret, int bits) {
 		}
 		free (buf);
 	}
+	r_list_free (secs);
 }
 
 static RList* entries(RBinFile *bf) {
@@ -1022,6 +1023,7 @@ static void lookup_sections(RBinFile *bf, RBinInfo *ret) {
 			break;
 		}
 	}
+	r_list_free (secs);
 }
 
 static bool has_sanitizers(RBinFile *bf) {
@@ -1198,6 +1200,7 @@ static ut64 size(RBinFile *bf) {
 				len = section->size;
 			}
 		}
+		r_list_free (secs);
 	}
 	return off + len;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The are below are 3 leaks that occur whenever function `sections` is invoked. This function returns an `r_list_new` which means the caller must free the returned list.

```
Indirect leak of 74 byte(s) in 8 object(s) allocated from:
    #0 0x7f98ef3143ed in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7f98e179fd69 in r_bin_section_clone /home/aniruddhan/radare2/libr/bin/bin.c:1420
    #2 0x7f98e194a35c in sections /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:141
    #3 0x7f98e1964ce9 in size /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:1193
    #4 0x7f98e17e8aec in r_bin_object_set_items /home/aniruddhan/radare2/libr/bin/bobj.c:345
    #5 0x7f98e17e6d18 in r_bin_object_new /home/aniruddhan/radare2/libr/bin/bobj.c:233
    #6 0x7f98e17d9509 in r_bin_file_new_from_buffer /home/aniruddhan/radare2/libr/bin/bfile.c:629
    #7 0x7f98e178f5eb in r_bin_open_buf /home/aniruddhan/radare2/libr/bin/bin.c:308
    #8 0x7f98e17904fc in r_bin_open_io /home/aniruddhan/radare2/libr/bin/bin.c:374
    #9 0x7f98eb1c4f3c in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:445
    #10 0x7f98eb1c7761 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658
    #11 0x7f98ee2040fd in binload /home/aniruddhan/radare2/libr/main/radare2.c:547
    #12 0x7f98ee20fd23 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488
    #13 0x5581c97c4eaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #14 0x7f98ed5f2082 in __libc_start_main ../csu/libc-start.c:308
```


```
Indirect leak of 74 byte(s) in 8 object(s) allocated from:
    #0 0x7f7687e373ed in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7f767a2c2d69 in r_bin_section_clone /home/aniruddhan/radare2/libr/bin/bin.c:1420
    #2 0x7f767a46d35c in sections /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:141
    #3 0x7f767a46dc9d in process_constructors /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:179
    #4 0x7f767a46ffe8 in entries /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:333
    #5 0x7f767a30c27c in r_bin_object_set_items /home/aniruddhan/radare2/libr/bin/bobj.c:357
    #6 0x7f767a309d18 in r_bin_object_new /home/aniruddhan/radare2/libr/bin/bobj.c:233
    #7 0x7f767a2fc509 in r_bin_file_new_from_buffer /home/aniruddhan/radare2/libr/bin/bfile.c:629
    #8 0x7f767a2b25eb in r_bin_open_buf /home/aniruddhan/radare2/libr/bin/bin.c:308
    #9 0x7f767a2b34fc in r_bin_open_io /home/aniruddhan/radare2/libr/bin/bin.c:374
    #10 0x7f7683ce7f3c in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:445
    #11 0x7f7683cea761 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658
    #12 0x7f7686d270fd in binload /home/aniruddhan/radare2/libr/main/radare2.c:547
    #13 0x7f7686d32d23 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488
    #14 0x5572d7ffceaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #15 0x7f7686115082 in __libc_start_main ../csu/libc-start.c:308
```

```
Indirect leak of 400 byte(s) in 44 object(s) allocated from:
    #0 0x7fe2231603ed in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7fe21d55eab5 in r_bin_section_clone /home/aniruddhan/Downloads/radare2/libr/bin/bin.c:1419
    #2 0x7fe21d697e40 in sections /home/aniruddhan/Downloads/radare2/libr/../libr/bin/p/bin_elf.inc.c:141
    #3 0x7fe21d69fd74 in lookup_sections /home/aniruddhan/Downloads/radare2/libr/../libr/bin/p/bin_elf.inc.c:1004
    #4 0x7fe21d699964 in info /home/aniruddhan/Downloads/radare2/libr/../libr/bin/p/bin_elf.inc.c:1119
    #5 0x7fe21d593d10 in r_bin_object_set_items /home/aniruddhan/Downloads/radare2/libr/bin/bobj.c:395
    #6 0x7fe21d59235e in r_bin_object_new /home/aniruddhan/Downloads/radare2/libr/bin/bobj.c:233
    #7 0x7fe21d58491f in r_bin_file_new_from_buffer /home/aniruddhan/Downloads/radare2/libr/bin/bfile.c:629
    #8 0x7fe21d553669 in r_bin_open_buf /home/aniruddhan/Downloads/radare2/libr/bin/bin.c:308
    #9 0x7fe21d55250d in r_bin_open_io /home/aniruddhan/Downloads/radare2/libr/bin/bin.c:374
    #10 0x7fe22136f929 in r_core_file_load_for_io_plugin /home/aniruddhan/Downloads/radare2/libr/core/cfile.c:445
    #11 0x7fe221369be3 in r_core_bin_load /home/aniruddhan/Downloads/radare2/libr/core/cfile.c:658
    #12 0x7fe222b1b6f4 in binload /home/aniruddhan/Downloads/radare2/libr/main/radare2.c:547
    #13 0x7fe222b11ec0 in r_main_radare2 /home/aniruddhan/Downloads/radare2/libr/main/radare2.c:1488
    #14 0x556e755e9eaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #15 0x7fe221f5d082 in __libc_start_main ../csu/libc-start.c:308
```

<!-- explain your changes if necessary -->

Therefore the patch includes freeing this list within `process_constructors`, `lookup_sections` and `size` functions which call `sections` but does not free returned list.
