### PR TITLE
Fix leak in swift-sd

### DIFF
--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -298,11 +298,13 @@ static char *my_swift_demangler(const char *s) {
 	// workaround with tests, need proper testing when format is clarified
 	if (trick) {
 		if (!isdigit (p[1])) {
+			r_strbuf_free (out);
 			return NULL;
 		}
 		if (p[1] && p[2]) {
 			int len = atoi (p + 1);
 			if (len > strlen (p + 2)) {
+				r_strbuf_free (out);
 				return NULL;
 			}
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 /bin/ls` with LeakSanitizer followed by visual mode 'V!' and 'q' followed by another 'q' to exit.

```
Direct leak of 256 byte(s) in 4 object(s) allocated from:
    #0 0x7fc816a66a06 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7fc81607d545 in r_strbuf_new /home/aniruddhan/radare2/libr/util/strbuf.c:6
    #2 0x7fc8093df348 in my_swift_demangler mangling/swift-sd.c:296
    #3 0x7fc8093e3102 in r_bin_demangle_swift mangling/swift-sd.c:729
    #4 0x7fc808e83062 in r_bin_demangle /home/aniruddhan/radare2/libr/bin/demangle.c:165
    #5 0x7fc8129dd9b2 in bin_imports /home/aniruddhan/radare2/libr/core/cbin.c:2162
    #6 0x7fc812a0063a in r_core_bin_info /home/aniruddhan/radare2/libr/core/cbin.c:4782
    #7 0x7fc8129c2c08 in r_core_bin_set_env /home/aniruddhan/radare2/libr/core/cbin.c:316
    #8 0x7fc81289ffce in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:450
    #9 0x7fc8128a2761 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658
    #10 0x7fc8158df0fd in binload /home/aniruddhan/radare2/libr/main/radare2.c:547
    #11 0x7fc8158ead23 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488
    #12 0x557a0aa22eaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #13 0x7fc814ccd082 in __libc_start_main ../csu/libc-start.c:308
```
The leak happens in function `my_swift_demangler` in `swift-fd.c`. In this function, `out` is allocated and is expected to be freed before function exits. On certain branches it is not freed. The patch deallocates `out` on these branches.

I hope all of these leak fixes prove useful for radare! I enjoyed using this amazing tool.

<!-- explain your changes if necessary -->
