### PR TITLE
Fix leak in esil.c

### DIFF
--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -201,6 +201,7 @@ R_API void r_esil_free(REsil *esil) {
 	free (esil->cmd_step);
 	free (esil->cmd_step_out);
 	free (esil->cmd_ioer);
+	free (esil->mdev_range);
 	free (esil);
 }
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 /bin/ls` with LeakSanitizer followed by visual mode by  'q' to exit.

```
Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7fb50e4333ed in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7fb50a312739 in cb_mdevrange /home/aniruddhan/radare2/libr/core/cconfig.c:2161
    #2 0x7fb50c524b03 in r_config_set_cb /home/aniruddhan/radare2/libr/config/config.c:404
    #3 0x7fb50a32c0f9 in r_core_config_init /home/aniruddhan/radare2/libr/core/cconfig.c:4209
    #4 0x7fb509f72090 in r_core_init /home/aniruddhan/radare2/libr/core/core.c:3339
    #5 0x7fb509f4a255 in r_core_new /home/aniruddhan/radare2/libr/core/core.c:960
    #6 0x7fb50d3245a9 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:686
    #7 0x56147c889eaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #8 0x7fb50c711082 in __libc_start_main ../csu/libc-start.c:308
```
This leak happens because the `mdev_range` field of `esil` is allocated but not deallocated in `r_esil_free` before  freeing the entire object. The patch corrects this.


<!-- explain your changes if necessary -->
