### PR TITLE
Fix leak due to r_bin_field_free

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1397,7 +1397,7 @@ R_API RBinField *r_bin_field_new(ut64 paddr, ut64 vaddr, ut64 value, int size, c
 R_API void r_bin_field_free(void *_field) {
 	RBinField *field = (RBinField*) _field;
 	if (field) {
-		free (field->name);
+		r_bin_name_free (field->name);
 		free (field->comment);
 		free (field->format);
 		free (field);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

The PR fixes the below leak. It happens when I ran `./binr/radare2/radare2 /bin/ls` with LeakSanitizer followed by visual mode 'V!' and 'q' followed by another 'q' to exit.

**Description**
```
Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7f0bb2a933ed in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7f0ba4f1fbe6 in r_bin_name_new /home/aniruddhan/radare2/libr/bin/bin.c:1493
    #2 0x7f0ba4f1e421 in r_bin_field_new /home/aniruddhan/radare2/libr/bin/bin.c:1383
    #3 0x7f0ba50e2f64 in fields /home/aniruddhan/radare2/libr/..//libr/bin/p/bin_elf.inc.c:1140
    #4 0x7f0ba4f687a4 in r_bin_object_set_items /home/aniruddhan/radare2/libr/bin/bobj.c:362
    #5 0x7f0ba4f65d18 in r_bin_object_new /home/aniruddhan/radare2/libr/bin/bobj.c:234
    #6 0x7f0ba4f58509 in r_bin_file_new_from_buffer /home/aniruddhan/radare2/libr/bin/bfile.c:629
    #7 0x7f0ba4f0e5eb in r_bin_open_buf /home/aniruddhan/radare2/libr/bin/bin.c:308
    #8 0x7f0ba4f0f4fc in r_bin_open_io /home/aniruddhan/radare2/libr/bin/bin.c:374
    #9 0x7f0bae943f3c in r_core_file_load_for_io_plugin /home/aniruddhan/radare2/libr/core/cfile.c:445
    #10 0x7f0bae946761 in r_core_bin_load /home/aniruddhan/radare2/libr/core/cfile.c:658
    #11 0x7f0bb19830fd in binload /home/aniruddhan/radare2/libr/main/radare2.c:547
    #12 0x7f0bb198ed23 in r_main_radare2 /home/aniruddhan/radare2/libr/main/radare2.c:1488
    #13 0x560b4a707eaa in main /home/aniruddhan/radare2/binr/radare2/radare2.c:118
    #14 0x7f0bb0d71082 in __libc_start_main ../csu/libc-start.c:308
```
This leak happens because `field->name` has to be deallocated by `r_bin_name_free` instead of `free`. The patch corrects this.

<!-- explain your changes if necessary -->
