### PR TITLE
Bring seek error back to UT64_MAX in dsc ##io

### DIFF
--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -651,7 +651,7 @@ static int r_io_internal_read(RIODscObject * dsc, ut64 off_global, ut8 *buf, int
 
 static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int whence) {
 	if (!dsc || offset == UT64_MAX) {
-		return UT64_MAX - 1;
+		return UT64_MAX;
 	}
 
 	ut64 off_global;
@@ -667,7 +667,7 @@ static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int wh
 			off_global = dsc->total_size + offset;
 			break;
 		default:
-			return UT64_MAX - 1;
+			return UT64_MAX;
 	}
 
 	RIODscSlice * slice = r_io_dsc_object_get_slice(dsc, off_global);
@@ -676,13 +676,13 @@ static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int wh
 			io->off = dsc->total_size;
 			return io->off;
 		}
-		return UT64_MAX - 1;
+		return UT64_MAX;
 	}
 
 	ut64 off_local = off_global - slice->start;
 	off_local = lseek (slice->fd, off_local, SEEK_SET);
 	if (off_local == UT64_MAX) {
-		return UT64_MAX - 1;
+		return UT64_MAX;
 	}
 
 	io->off = off_local + slice->start;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Otherwise seeks beyond the end of the file will not be detected as failures and this causes the dyldcache bin plugin to load single-slice caches 128 times instead of 1, with obvious performance implications.

