### PR TITLE
Fix MVN handling in SNES plugin and add tests ##arch

### DIFF
--- a/libr/arch/p/snes/optable.h
+++ b/libr/arch/p/snes/optable.h
@@ -113,7 +113,7 @@ static snes_op_t snes_op[] = {
 { "eor (0x%02x),y",	SNES_OP_16BIT},
 { "eor (0x%02x)",	SNES_OP_16BIT},
 { "eor (0x%02x,s),y",	SNES_OP_16BIT},
-{ "mvn 0x%02x,0x%02x",	SNES_OP_16BIT},
+{ "mvn 0x%02x,0x%02x",	SNES_OP_24BIT},
 { "eor 0x%02x,x",	SNES_OP_16BIT},
 { "lsr 0x%02x,x",	SNES_OP_16BIT},
 { "eor [0x%02x],y",	SNES_OP_16BIT},

--- a/test/db/asm/snes_16
+++ b/test/db/asm/snes_16
@@ -6,3 +6,5 @@ d "lda #0x8d8d" a98d8d
 d "brk 0x80" 0080
 d "bne 0x000010" d00e
 d "php" 08
+d "mvn 0xaa,0xbb" 54aabb
+d "mvp 0xcc,0xdd" 44ccdd


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes the incorrect opcode type for MVN and adds tests for both MVN and MVP disassembly. Fixes #22653.
