### PR TITLE
Fix leak in canvas.c

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -483,15 +483,7 @@ R_API int r_cons_canvas_resize(RConsCanvas *c, int w, int h) {
 		c->blen[i] = w;
 		c->bsize[i] = w + 1;
 		if (!newline) {
-			size_t j;
-			for (j = 0; j <= i; j++) {
-				free (c->b[i]);
-			}
-			ht_up_free (c->attrs);
-			free (c->blen);
-			free (c->bsize);
-			free (c->b);
-			free (c);
+			r_cons_canvas_free (c);
 			return false;
 		}
 		c->b[i] = newline;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This patch fixes a memory leak within `r_cons_canvas_resize`.  In one location the authors manually free memory of individual fields and even miss fields such as `bgcolor` of `RConsCanvas`. Please do note that entire `c->b` is deallocated by authors. The patch instead frees using `r_cons_canvas_free` which includes free for `bgcolor`.

<!-- explain your changes if necessary -->
