### PR TITLE
Add dbg.glibc.main_arena config setting to retain resolved main_arena

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3598,6 +3598,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETOPTIONS (n, "glibc", "jemalloc", NULL);
 	SETPREF ("dbg.glibc.path", "", "if not empty, use the given path to resolve the libc");
 	SETPREF ("dbg.glibc.version", "", "if not empty, assume the given libc version");
+	SETI ("dbg.glibc.main_arena", 0x0, "main_arena address");
 #if __GLIBC_MINOR__ > 25
 	SETBPREF ("dbg.glibc.tcache", "true", "parse the tcache (glibc.minor > 2.25.x)");
 #else

--- a/libr/core/dmh_glibc.inc.c
+++ b/libr/core/dmh_glibc.inc.c
@@ -560,6 +560,12 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 	r_return_val_if_fail (core && core->dbg && core->dbg->maps, false);
 
 	if (core->dbg->main_arena_resolved) {
+		GHT dbg_glibc_main_arena = r_config_get_i (core->config, "dbg.glibc.main_arena");
+		if (!dbg_glibc_main_arena) {
+			R_LOG_ERROR ("core->dbg->main_arena_resolved is true but dbg.glibc.main_arena is NULL");
+			return false;
+		}
+		*m_arena = dbg_glibc_main_arena;
 		return true;
 	}
 
@@ -645,6 +651,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 		GH (update_main_arena) (core, main_arena_sym, ta);
 		*m_arena = main_arena_sym;
 		core->dbg->main_arena_resolved = true;
+		r_config_set_i (core->config, "dbg.glibc.main_arena", *m_arena);
 		free (ta);
 		return true;
 	}
@@ -657,6 +664,7 @@ static bool GH(r_resolve_main_arena)(RCore *core, GHT *m_arena) {
 			if (in_debugger) {
 				core->dbg->main_arena_resolved = true;
 			}
+			r_config_set_i (core->config, "dbg.glibc.main_arena", *m_arena);
 			return true;
 		}
 		addr_srch += sizeof (GHT);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

adds `dbg.glibc.main_arena` to retain resolved glbic `main_arena` address, it got resolved once then every subsequent command just did  not work because `m_arena` was not set.
