### PR TITLE
Handle URL safe base64 decoding

### DIFF
--- a/libr/util/ubase64.c
+++ b/libr/util/ubase64.c
@@ -10,7 +10,9 @@
 
 #define SZ 1024
 static const char cb64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-static const char cd64[] = "|$$$}rstuvwxyz{$$$$$$$>?@ABCDEFGHIJKLMNOPQRSTUVW$$$$$$XYZ[\\]^_`abcdefghijklmnopq";
+
+// This table will handle standard base64 decoding and also url safe decoding with characteres "-" and "_"
+static const char cd64[] = "|$|$}rstuvwxyz{$$$$$$$>?@ABCDEFGHIJKLMNOPQRSTUVW$$$$}$XYZ[\\]^_`abcdefghijklmnopq";
 
 static void local_b64_encode(const ut8 in[3], char out[4], int len) {
 	if (len < 1) {

--- a/test/db/tools/rax2
+++ b/test/db/tools/rax2
@@ -84,6 +84,14 @@ CMDS=rax2 -E "\x60\x00\x66\x00\x67"
 EXPECT=YABmAGc=
 RUN
 
+NAME=r rax2 -D URL safe
+FILE=-
+CMDS=rax2 -D __-_ |rax2 -S
+EXPECT=<<EOF
+ffffbf
+EOF
+RUN
+
 NAME=rax2 -S hello | rax2 -s
 FILE=-
 CMDS=!rax2 -S hello | rax2 -s


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

According to [RFC 4648 §5](https://datatracker.ietf.org/doc/html/rfc4648#section-5) another way of doing base64 encoding  is using "-" instead of "+" and "_" instead of "/". This modification allows r2 to decode such strings.
