### PR TITLE
Fix iS. paddr vaddr confusion ##core

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3088,8 +3088,7 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 			continue;
 		}
 
-		if ((printHere && !(section->paddr <= r->offset && r->offset < (section->paddr + section->size)))
-				&& (printHere && !(addr <= r->offset && r->offset < (addr + section->size)))) {
+		if (printHere && !(addr <= r->offset && r->offset < (addr + section->size))) {
 			continue;
 		}
 

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -813,9 +813,14 @@ RUN
 NAME=iS. and iSj. implementation
 FILE=bins/elf/lab1B
 CMDS=<<EOF
-s 0x188
+s 0x08048188
 iS.
 s 0x08058000
+iS.
+s 0x08048760
+iSj.
+e io.va=false
+s 0x188
 iS.
 s 0x760
 iSj.
@@ -833,6 +838,13 @@ nth paddr  size vaddr  vsize perm type name
 -------------------------------------------
 
 {"name":".plt","size":240,"vsize":240,"type":"PROGBITS","perm":"-r-x","paddr":1888,"vaddr":134514528}
+Current section
+
+nth paddr       size vaddr       vsize perm type name
+-----------------------------------------------------
+0   0x00000188  0x24 0x00000188   0x24 -r-- NOTE .note.gnu.build-id
+
+{"name":".plt","size":240,"vsize":240,"type":"PROGBITS","perm":"-r-x","paddr":1888,"vaddr":1888}
 EOF
 RUN
 

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -721,26 +721,26 @@ colu: 12
 addr: 0x00001149
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3337] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3337] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3337] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3337] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3337] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3337] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3337] (section .got) Cd 8[9] @ 0x3fb8
-DEBUG: [cbin.c:3337] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3337] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3337] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3337] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3337] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3337] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3337] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3332] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3332] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3332] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3332] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3332] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3332] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3332] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3332] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3332] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3332] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3332] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3332] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3332] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3332] (section .got) Cd 8[9] @ 0x3fb8
 WARN: [cbin.c:1882] Relocs has not been applied. Please use `-e bin.relocs.apply=true` or `-e bin.cache=true` next time
-DEBUG: [cbin.c:2593] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2593] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2593] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2593] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2593] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:2589] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2589] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2589] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2589] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2589] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -721,26 +721,26 @@ colu: 12
 addr: 0x00001149
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3332] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3332] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3332] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3332] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3332] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3332] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3332] (section .got) Cd 8[9] @ 0x3fb8
-DEBUG: [cbin.c:3332] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3332] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3332] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3332] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3332] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3332] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3332] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3336] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3336] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3336] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3336] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3336] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3336] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3336] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3336] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3336] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3336] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3336] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3336] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3336] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3336] (section .got) Cd 8[9] @ 0x3fb8
 WARN: [cbin.c:1882] Relocs has not been applied. Please use `-e bin.relocs.apply=true` or `-e bin.cache=true` next time
-DEBUG: [cbin.c:2589] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2589] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2589] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2589] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2589] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:2593] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2593] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2593] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2593] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2593] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 

--- a/test/db/formats/le
+++ b/test/db/formats/le
@@ -388,3 +388,15 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=DOOM.LE iS. by vaddr
+FILE=bins/le/DOOM.LE
+CMDS=<<EOF
+?v $$
+iS.~obj.1.page.45
+EOF
+EXPECT=<<EOF
+0x3dde0
+0   0x00041148  0x1000 0x0003d000  0x1000 -r-x ---- obj.1.page.45
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This change removes the part of the `printHere` address check where it explicitly checked for `paddr` even if the paddr / vaddr dichotomy is already handled via the `addr` variable, which is the only one we have to check here.

That caused wrong behaviour in binaries where the vaddr and paddr space numerically overlap (like old DOS/4GW LE binaries) where `iS.` was in fact picking the `paddr` instead of `vaddr` to filter if such an entry came first in the list.

