### PR TITLE
Fixes memory leak in r_core_print_disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6043,12 +6043,12 @@ toro:
 	if (core->print->cur_enabled) {
 		// TODO: support in-the-middle-of-instruction too
 		r_anal_op_fini (&ds->analop);
-		r_anal_op_init (&ds->analop);
 		if (r_anal_op (core->anal, &ds->analop, core->offset + core->print->cur,
 			buf + core->print->cur, (int)(len - core->print->cur), R_ARCH_OP_MASK_ALL)) {
 			// TODO: check for ds->analop.type and ret
 			ds->dest = ds->analop.jump;
 		}
+		r_anal_op_fini (&ds->analop);
 	} else {
 		/* highlight eip */
 		const char *pc = core->anal->reg->name[R_REG_NAME_PC];
@@ -6542,8 +6542,8 @@ toro:
 			inc = 1;
 		}
 		inc += ds->asmop.payload + (ds->asmop.payload % ds->core->rasm->dataalign);
+		r_anal_op_fini (&ds->analop);
 	}
-	r_anal_op_fini (&ds->analop);
 
 	R_FREE (nbuf);
 	r_cons_break_pop ();


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The leak can be easily reproduced by disassembling a function with `pD ` in a loop, e.g. using r_core_cmd_str in a loop.

In the function `r_core_print_disasm` memory allocated for `ds->analop` with `r_anal_op_init` by
```c
ret = r_anal_op (core->anal, &ds->analop, ds->at, ds_bufat (ds), ds_left (ds), R_ARCH_OP_MASK_ALL);
```
is only freed after the loop. So in the next iteration of the loop, `ds->analop` will be initialized again without freeing previously allocated memory.

I detected this memory leak while doing some memory profiling with Tracy
![grafik](https://github.com/radareorg/radare2/assets/10896352/e16527c1-22af-4f96-b160-ceccb2caf049)

This profiling only showed the one leak for which I changed the last line. I changed the two lines above because it also looked like a memory leak was happening there and the init seemed unnecessary as this is also done in `r_anal_op`. However I did not profile that part so maybe that change is wrong.
