### PR TITLE
get_main_arena_offset_with_relocs for different libc versions ##debug

### DIFF
--- a/libr/include/r_heap_glibc.h
+++ b/libr/include/r_heap_glibc.h
@@ -115,7 +115,39 @@ typedef RHeapChunk32 *mfastbinptr32;
 typedef RHeapChunk32 *mchunkptr32;
 */
 
-typedef struct r_malloc_state_32 {
+// 2.23 > GLIBC_VERSION >= 2.12
+// https://github.com/bminor/glibc/blob/glibc-2.12/malloc/malloc.c#L2362-L2400
+typedef struct r_malloc_state_212_32 {
+	int mutex;
+	int flags;
+	ut32 fastbinsY[NFASTBINS];
+	ut32 top;
+	ut32 last_remainder;
+	ut32 bins[NBINS * 2 - 2];
+	unsigned int binmap[BINMAPSIZE];
+	ut32 next;
+	ut32 next_free;
+	ut32 system_mem;
+	ut32 max_system_mem;
+} RHeap_MallocState_212_32;
+
+typedef struct r_malloc_state_212_64 {
+	int mutex;
+	int flags;
+	ut64 fastbinsY[NFASTBINS];
+	ut64 top;
+	ut64 last_remainder;
+	ut64 bins[NBINS * 2 - 2];
+	unsigned int binmap[BINMAPSIZE];
+	ut64 next;
+	ut64 next_free;
+	ut64 system_mem;
+	ut64 max_system_mem;
+} RHeap_MallocState_212_64;
+
+// 2.27 > GLIBC_VERSION >= 2.23
+// https://github.com/bminor/glibc/blob/1c9a5c270d8b66f30dcfaf1cb2d6cf39d3e18369/malloc/malloc.c#L1678-L1716
+typedef struct r_malloc_state_223_32 {
 	int mutex;                              /* serialized access */
 	int flags;                              /* flags */
 	ut32 fastbinsY[NFASTBINS];              /* array of fastchunks */
@@ -128,9 +160,9 @@ typedef struct r_malloc_state_32 {
 	unsigned int attached_threads;          /* threads attached */
 	ut32 system_mem;                        /* current allocated memory of current arena */
 	ut32 max_system_mem;                    /* maximum system memory */
-} RHeap_MallocState_32;
+} RHeap_MallocState_223_32;
 
-typedef struct r_malloc_state_64 {
+typedef struct r_malloc_state_223_64 {
 	int mutex;                              /* serialized access */
 	int flags;                              /* flags */
 	ut64 fastbinsY[NFASTBINS];              /* array of fastchunks */
@@ -143,7 +175,7 @@ typedef struct r_malloc_state_64 {
 	unsigned int attached_threads;          /* threads attached */
 	ut64 system_mem;                        /* current allocated memory of current arena */
 	ut64 max_system_mem;                    /* maximum system memory */
-} RHeap_MallocState_64;
+} RHeap_MallocState_223_64;
 
 typedef struct r_tcache_perthread_struct_32 {
 	ut16 counts[TCACHE_MAX_BINS];
@@ -183,7 +215,9 @@ typedef struct {
 	} RHeapTcache;
 } RTcache_32;
 
-typedef struct r_malloc_state_tcache_32 {
+// GLIBC_VERSION >= 2.27
+// https://github.com/bminor/glibc/blob/glibc-2.34/malloc/malloc.c#L1831
+typedef struct r_malloc_state_227_32 {
 	int mutex;                              /* serialized access */
 	int flags;                              /* flags */
 	int have_fast_chunks;                   /* have fast chunks */
@@ -194,12 +228,12 @@ typedef struct r_malloc_state_tcache_32 {
 	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
 	ut32 next;                              /* double linked list of chunks */
 	ut32 next_free;                         /* double linked list of free chunks */
-	unsigned int attached_threads;          /* threads attached */
+	ut32 attached_threads; 			        /* threads attached */
 	ut32 system_mem;                        /* current allocated memory of current arena */
 	ut32 max_system_mem;                    /* maximum system memory */
-} RHeap_MallocState_tcache_32;
+} RHeap_MallocState_227_32;
 
-typedef struct r_malloc_state_tcache_64 {
+typedef struct r_malloc_state_227_64 {
 	int mutex;                              /* serialized access */
 	int flags;                              /* flags */
 	int have_fast_chunks;                   /* have fast chunks */
@@ -210,10 +244,10 @@ typedef struct r_malloc_state_tcache_64 {
 	unsigned int binmap[BINMAPSIZE];        /* bitmap of bins */
 	ut64 next;                              /* double linked list of chunks */
 	ut64 next_free;                         /* double linked list of free chunks */
-	unsigned int attached_threads;          /* threads attached */
+	ut64 attached_threads;  		        /* threads attached */
 	ut64 system_mem;                        /* current allocated memory of current arena */
 	ut64 max_system_mem;                    /* maximum system memory */
-} RHeap_MallocState_tcache_64;
+} RHeap_MallocState_227_64;
 
 typedef struct r_malloc_state {
 	int mutex;                              /* serialized access */

--- a/test/unit/test_get_main_arena_offset.c
+++ b/test/unit/test_get_main_arena_offset.c
@@ -1,0 +1,85 @@
+#include <r_bin.h>
+#include <r_core.h>
+#include <math.h>
+#include "../../libr/include/r_heap_glibc.h"
+#define R_INCLUDE_BEGIN 1
+#include "../../libr/core/dmh_glibc.inc.c"
+#undef R_INCLUDE_BEGIN
+#include "minunit.h"
+
+bool test_get_main_arena_offset_with_symbol (void) {
+	RCore * core = r_core_new();
+	GHT arena_offset;
+
+	// 2.21
+	arena_offset = 0;
+	arena_offset = GH (get_main_arena_offset_with_symbol) (core, "bins/elf/libc-2.21-debug.so");
+	mu_assert_eq (arena_offset, 0x003c4c00, "Incorrect main_arena_offset for debug 2.21");
+
+	// 2.26
+	arena_offset = 0;
+	arena_offset = GH (get_main_arena_offset_with_symbol) (core, "bins/elf/libc-2.26-debug.so");
+	mu_assert_eq (arena_offset, 0x003dac20, "Incorrect main_arena_offset for debug 2.26");
+
+	r_core_free (core);
+	mu_end;
+}
+
+bool test_get_main_arena_offset_with_relocs (void) {
+	RCore *core = r_core_new ();
+
+	GHT arena_offset;
+	core->dbg->glibc_version_resolved = true;
+
+	// 2.21
+	arena_offset = 0;
+	core->dbg->glibc_version_d = 2.21;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.21.so");
+	mu_assert_eq (arena_offset, 0xb80, "Incorrect main_arena_offset for 2.21");
+
+	// 2.23
+	arena_offset = 0;
+	core->dbg->glibc_version_d = 2.23;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.23.so");
+	mu_assert_eq (arena_offset, 0xaa0, "Incorrect main_arena_offset for 2.23");
+
+	// 2.26
+	arena_offset = 0;
+	core->dbg->glibc_version_d = 2.26;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.26.so");
+	mu_assert_eq (arena_offset, 0xaa0, "Incorrect main_arena_offset for 2.26");
+
+	// 2.27
+	arena_offset = 0;
+	core->dbg->glibc_version_d = 2.27;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.27.so");
+	mu_assert_eq (arena_offset, 0xaa0, "Incorrect main_arena_offset for 2.27");
+
+	// 2.28
+	arena_offset = 0;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc.so.6");
+	mu_assert_eq (arena_offset, 0xaa0, "Incorrect main_arena_offset for 2.28");
+
+	// 2.31
+	arena_offset = 0;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.31.so");
+	mu_assert_eq (arena_offset, 0x9e0, "Incorrect main_arena_offset for 2.31");
+
+	// 2.32
+	arena_offset = 0;
+	arena_offset = GH (get_main_arena_offset_with_relocs) (core, "bins/elf/libc-2.32.so");
+	mu_assert_eq (arena_offset, 0xa00, "Incorrect main_arena_offset for 2.32");
+
+	r_core_free (core);
+	mu_end;
+}
+
+bool all_tests () {
+	mu_run_test (test_get_main_arena_offset_with_symbol);
+	mu_run_test (test_get_main_arena_offset_with_relocs);
+	return tests_passed != tests_run;
+}
+
+int main (int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

This adapts `get_main_arena_offset_with_relocs` to 3 different `main_arena` structure versions. This should now work for all >= 2.12