### PR TITLE
Use size or vsize consistently in iS. ##core

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3077,22 +3077,22 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 	r_list_foreach (sections, iter, section) {
 		char perms[] = "----";
 		int va_sect = va;
-		ut64 addr;
+		ut64 addr, size;
 
 		if (va && !(section->perm & R_PERM_R)) {
 			va_sect = VA_NOREBASE;
 		}
 		addr = rva (r->bin, section->paddr, section->vaddr, va_sect);
-
+		size = va ? section->vsize : section->size;
 		if (name && strcmp (section->name, name)) {
 			continue;
 		}
 
-		if (printHere && !(addr <= r->offset && r->offset < (addr + section->size))) {
+		if (printHere && !(addr <= r->offset && r->offset < (addr + size))) {
 			continue;
 		}
 
-		if (at != UT64_MAX && (!section->size || !is_in_range (at, addr, section->size))) {
+		if (at != UT64_MAX && (!size || !is_in_range (at, addr, size))) {
 			continue;
 		}
 
@@ -3160,7 +3160,7 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 				str = r_str_newf ("%s.%s", type, section->name);
 			}
 			r_name_filter (str, R_FLAG_NAME_SIZE);
-			ut64 size = r->io->va? section->vsize: section->size;
+
 			r_flag_set (r->flags, str, addr, size);
 			R_FREE (str);
 

--- a/test/db/formats/elf/sections
+++ b/test/db/formats/elf/sections
@@ -75,3 +75,11 @@ EXPECT=<<EOF
 ffffffffffffffffffff
 EOF
 RUN
+
+NAME=sections list here bss
+FILE=bins/elf/analysis/main_wrong_sect
+CMDS=iS.@0x00600914~bss~?
+EXPECT=<<EOF
+1
+EOF
+RUN

--- a/test/db/formats/pe/96emptysections
+++ b/test/db/formats/pe/96emptysections
@@ -138,3 +138,16 @@ nth paddr        size vaddr        vsize perm type name
 
 EOF
 RUN
+
+NAME=PE: corkami 96workingsections.exe - iS. pa
+FILE=bins/pe/96emptysections.exe
+ARGS=-e io.va=false
+CMDS=<<EOF
+iS.@0x000013ff~sect_0~?
+iS.@0x00001400~sect_0~?
+EOF
+EXPECT=<<EOF
+1
+0
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Now the size is virtual or physical consistently with the chosen address. This makes it possible to get correct ouput for `iS.` on addresses belonging to sections which have different `vsize` than `size` (like for example bss sections).

