### PR TITLE
Add dyld shared cache rebase info v5 ##io

### DIFF
--- a/libr/bin/format/mach0/mach0_specs.h
+++ b/libr/bin/format/mach0/mach0_specs.h
@@ -256,6 +256,14 @@ typedef struct {
 	uint32_t page_size;
 	uint32_t page_starts_count;
 	uint32_t padding;
+	uint64_t value_add;
+} cache_slide5_t;
+
+typedef struct {
+	uint32_t version;
+	uint32_t page_size;
+	uint32_t page_starts_count;
+	uint32_t padding;
 	uint64_t auth_value_add;
 } cache_slide3_t;
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Spotted in macOS 14.4 arm64e, the rebase info v5 didn't make it to the open source yet, this is what i could make out of dyld:

```
struct dyld_cache_slide_info5
{
    uint32_t    version;            // currently 5
    uint32_t    page_size;
    uint32_t    page_starts_count;
    uint64_t    value_add;
    uint16_t    page_starts[/* page_starts_count */];
};

union dyld_cache_slide_pointer5
{
    uint64_t  raw;
    struct {
        uint64_t    pointerValue        : 34,
                    high8               : 8,
                    unused              : 10,
                    offsetToNextPointer : 11,
                    authenticated       :  1; // = 0
    }         plain;

    struct {
        uint64_t    pointerValue              : 34,
                    diversity                 : 16,
                    hasAddressDiversity       :  1,
                    key                       :  1, // 1 = da, 0 = ia
                    offsetToNextPointer       : 11,
                    authenticated             :  1; // = 1;
    }         auth;
};
```

which is pretty much the same as v3 with rearranged bitfields, and `value_add` gets added to non-authenticated pointers as well.
