### PR TITLE
fix the fix for dmh after ood ##debug

### DIFF
--- a/libr/core/cmd_open.inc.c
+++ b/libr/core/cmd_open.inc.c
@@ -1442,6 +1442,7 @@ R_API void r_core_file_reopen_remote_debug(RCore *core, char *uri, ut64 addr) {
 		return;
 	}
 
+	core->dbg->main_arena_resolved = false;
 	RList *old_sections = __save_old_sections (core);
 	ut64 old_base = core->bin->cur->bo->baddr_shift;
 	int bits = core->rasm->config->bits;
@@ -1512,6 +1513,7 @@ R_API void r_core_file_reopen_debug(RCore *core, const char *args) {
 		return;
 	}
 
+	core->dbg->main_arena_resolved = false;
 	RList *old_sections = __save_old_sections (core);
 	ut64 old_base = (core->bin->cur && core->bin->cur->bo)? core->bin->cur->bo->baddr_shift: 0;
 	int bits = core->rasm->config->bits;

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -686,8 +686,6 @@ R_API bool r_debug_select(RDebug *dbg, int pid, int tid) {
 		core->offset = r_debug_reg_get (dbg, "PC");
 	}
 
-	dbg->main_arena_resolved = false;
-
 	return true;
 }
 


### PR DESCRIPTION
This corrects the improper fix from https://github.com/radareorg/radare2/pull/18710, which resets ` core->dbg->main_arena_resolved` after every debugging step or breakpoint. 