### PR TITLE
suppress R_X86_64_TPOFF64 relocation spam

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -727,7 +727,10 @@ static RList* relocs(RBinFile *bf) {
 		if (already_inserted) {
 			continue;
 		}
-
+		// TODO: implement this, this stops spam for glibc main_arena resolving
+		if (reloc->type == R_X86_64_TPOFF64) {
+			continue;
+		}
 		RBinReloc *ptr = reloc_convert (eo, reloc, got_addr);
 		if (ptr && ptr->paddr != UT64_MAX) {
 			r_list_append (ret, ptr);


### PR DESCRIPTION
This just suppresses error messages we get because R_X86_64_TPOFF64 relocations are not implemented and newer libc uses them. 
And since we resolve `main_arena` via relocations we get a lot of errors.

The issue to really fix this is https://github.com/radareorg/radare2/issues/22742