### PR TITLE
Fix 8 typos in 6 files

### DIFF
--- a/libr/anal/c/tccgen.c
+++ b/libr/anal/c/tccgen.c
@@ -1046,8 +1046,8 @@ do_decl:
 					}
 					lbit_pos = 0;
 					// FIXME: Here it handles bitfields only in a way
-					// of the same endianess as the host system (this code was compiled for)
-					// It should depend on the endianess of the `asm.arch` instead.
+					// of the same endianness as the host system (this code was compiled for)
+					// It should depend on the endianness of the `asm.arch` instead.
 					if (bit_size >= 0) {
 						bt = type1.t & VT_BTYPE;
 						if (bt != VT_INT8 &&

--- a/libr/arch/p/pic/pic_pic18.c
+++ b/libr/arch/p/pic/pic_pic18.c
@@ -157,7 +157,7 @@ char *pic_pic18_disassemble(const ut8 *b, int blen, int *opsz) {
 		{
 		ut32 dword_instr = *(ut32 *)b;
 		//I dont even know how the bits are arranged but it works !!!
-		//`the wierdness of little endianess`
+		//`the wierdness of little endianness`
 		if (dword_instr >> 28 != 0xf) {
 			return NULL;
 		}

--- a/libr/bin/dwarf.c
+++ b/libr/bin/dwarf.c
@@ -2110,7 +2110,7 @@ static const ut8 *parse_attr_value(RBin *bin, const ut8 *obuf, int obuf_len, RBi
 		value->address = READ16 (buf);
 		break;
 	case DW_FORM_addrx3:
-		// I need to add 3byte endianess free read here TODO
+		// I need to add 3byte endianness free read here TODO
 		value->kind = DW_AT_KIND_ADDRESS;
 		buf += 3;
 		break;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3556,7 +3556,7 @@ R_API int r_core_config_init(RCore *core) {
 	r_config_set_getter (cfg, "arch.bits", (RConfigCallback)cb_archbits_getter);
 	SETCB ("arch.platform", "", &cb_arch_platform, "define arch platform to use");
 	n = NODECB ("arch.endian", R_SYS_ENDIAN? "big": "little", &cb_archendian);
-	SETDESC (n, "set arch endianess");
+	SETDESC (n, "set arch endianness");
 	SETOPTIONS (n, "big", "little", "bigswap", "littleswap", NULL);
 	n = NODECB ("arch.arch", "null", &cb_archarch);
 	SETDESC (n, "select the architecture to use");

--- a/man/rax2.1
+++ b/man/rax2.1
@@ -33,7 +33,7 @@ Print the result in decimal (base 10)
 .It Fl D
 Decode the input data using base64
 .It Fl e
-Swap endianess
+Swap endianness
 .It Fl E
 Encode the input data using base64
 .It Fl f

--- a/test/db/cmd/cmd_pf
+++ b/test/db/cmd/cmd_pf
@@ -224,7 +224,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=swap endianess
+NAME=swap endianness
 FILE=malloc://1024
 CMDS=<<EOF
 wx deadbeef00000000adde


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge

Fix 8 times the typo `endianess` --> `endianness` in 6 files.

There is one more in `shlr/zip/zlib/crc32.c` but that seems to have an external source.