### PR TITLE
Fix large offset passed to the pascal demangler ##crash

### DIFF
--- a/libr/bin/mangling/pascal.c
+++ b/libr/bin/mangling/pascal.c
@@ -75,7 +75,11 @@ static void demangle_freepascal_unit(RStrBuf *ds, char *mangled, size_t mangled_
 				r_strbuf_append_n (ds, mangled, end - mangled);
 			}
 		} else {
-			r_strbuf_append_n (ds, mangled, end - mangled);
+			if (end > mangled) {
+				r_strbuf_append_n (ds, mangled, end - mangled);
+			} else {
+				// should never happen
+			}
 		}
 	} else {
 		r_strbuf_append_n (ds, mangled, mangled_len);

--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -229,12 +229,16 @@ R_API bool r_strbuf_prepend(RStrBuf *sb, const char *s) {
 R_API bool r_strbuf_append(RStrBuf *sb, const char *s) {
 	r_return_val_if_fail (sb && s, false);
 
-	int l = strlen (s);
+	size_t l = strlen (s);
 	return r_strbuf_append_n (sb, s, l);
 }
 
 R_API bool r_strbuf_append_n(RStrBuf *sb, const char *s, size_t l) {
 	r_return_val_if_fail (sb && s, false);
+	if (l > ST32_MAX) {
+		R_LOG_WARN ("Negative length used in r_strbuf_append_n");
+		return false;
+	}
 
 	if (sb->weakref) {
 		return false;


### PR DESCRIPTION
* Causes a negative memcpy, but it's not detected because size_t

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
