### PR TITLE
libr/arch/p/bpf/plugin.c: Use r_str_nlen

### DIFF
--- a/libr/arch/p/bpf/plugin.c
+++ b/libr/arch/p/bpf/plugin.c
@@ -618,7 +618,7 @@ static bool parse_alu(RBpfSockFilter *f, const char *m, int opc, const bpf_token
 static bool parse_instruction(RBpfSockFilter *f, BPFAsmParser *p, ut64 pc) {
 	const char *mnemonic_tok = token_next (p);
 	PARSE_NEED_TOKEN (mnemonic_tok);
-	int mlen = strnlen (mnemonic_tok, 5);
+	int mlen = r_str_nlen (mnemonic_tok, 5);
 	if (mlen < 2 || mlen > 4) {
 		R_LOG_ERROR ("invalid mnemonic");
 	}


### PR DESCRIPTION


<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

strnlen(3) might not be available on older systems e.g OS X Tiger.
