### PR TITLE
Typo fixes in command help

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -1110,7 +1110,7 @@ static RCoreHelpMessage help_msg_axf= {
 	"axfg", " [addr]", "display commands to generate graphs according to the xrefs",
 	"axfq", " [addr]", "find and list the data/code references in quiet mode",
 	"axfm", " [addr]", "show refs to in 'make' syntax (see aflm and axtm)",
-	"axf*", " [addr]", "same as axt, but prints as r2 commands",
+	"axf*", " [addr]", "same as axf, but prints as r2 commands",
 	NULL
 };
 

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -150,7 +150,7 @@ static RCoreHelpMessage help_msg_slash_a = {
 	"/ad/", " ins1;ins2", "search for regex instruction 'ins1' followed by regex 'ins2'",
 	"/ad/a", " instr", "search for every byte instruction that matches regexp 'instr'",
 	"/ae", " esil", "search for esil expressions matching substring",
-	"/af", "[l] family", "search for instruction of specific family (afl=list",
+	"/af", "[l] family", "search for instruction of specific family (afl=list)",
 	"/aF", "[d] opstr", "find instructions matching given opstr only in analyzed code",
 	"/ai", "[j] 0x300 [0x500]", "find all the instructions using that immediate (in range)",
 	"/al", "", "same as aoml, list all opcodes",


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Fixes two minor typos in command help text