### PR TITLE
Fix unaligned ptrace reads - spotted on s390 ##debug

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1,4 +1,4 @@
-/* radare - Copyright 2009-2021 - pancake, nibble */
+/* radare - Copyright 2009-2024 - pancake, nibble */
 
 #include "r_core.h"
 #include "r_socket.h"

--- a/libr/io/p/io_ptrace.c
+++ b/libr/io/p/io_ptrace.c
@@ -118,8 +118,11 @@ static int __read(RIO *io, RIODesc *desc, ut8 *buf, int len) {
 #endif
 	ut8 *aligned_buf = (ut8*)r_malloc_aligned (len, sizeof (ptrace_word));
 	if (aligned_buf) {
-		int res = debug_os_read_at (io, RIOPTRACE_PID (desc), aligned_buf, len, addr);
-		memcpy (buf, aligned_buf, len);
+		int aligned_delta = addr % sizeof (ptrace_word);
+		ut64 aligned_addr = addr - aligned_delta;
+		int res = debug_os_read_at (io, RIOPTRACE_PID (desc), aligned_buf,
+				len + sizeof (ptrace_word), aligned_addr);
+		memcpy (buf, aligned_buf + aligned_delta, len);
 		r_free_aligned (aligned_buf);
 		return res;
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
