### PR TITLE
Show ASAN in -v options when compiling via `gcc` ##shell

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -4014,6 +4014,10 @@ R_API char *r_str_version(const char *program) {
 #if __has_feature(address_sanitizer)
 	asanstr = " asan";
 #endif
+#else
+#if defined(__SANITIZE_ADDRESS__) // gcc < 14
+	asanstr = " asan";
+#endif
 #endif
 #if R2_VERSION_COMMIT == 0
 	release = " release";


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
This adds support for reflecting the status of sanitized builds compiled with `gcc` < 14 when running `-v`. 