### PR TITLE
FIx aaa for x86-32 systems and ensure aaef is used ##analysis

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3427,6 +3427,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("anal.limits", "false", (RConfigCallback)&cb_anal_limits, "restrict analysis to address range [anal.from:anal.to]");
 	SETCB ("anal.noret.refs", "false", (RConfigCallback)&cb_anal_noret_refs, "recursive no return checks (EXPERIMENTAL)");
 	SETCB ("anal.slow", "true", (RConfigCallback)&cb_anal_slow, "uses emulation and deeper analysis for better results");
+	SETPREF ("anal.emu", "false", "run aaef after analysis (EXPERIMENTAL)");
 	SETCB ("anal.noret", "true", (RConfigCallback)&cb_anal_noret, "propagate noreturn attributes (EXPERIMENTAL)");
 	SETCB ("anal.limits", "false", (RConfigCallback)&cb_anal_limits, "restrict analysis to address range [anal.from:anal.to]");
 	SETICB ("anal.from", -1, (RConfigCallback)&cb_anal_from, "lower limit on the address range for analysis");

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -13806,17 +13806,24 @@ static int cmd_anal_all(RCore *core, const char *input) {
 						r_core_cmd_call (core, "aavq");
 					}
 					r_core_task_yield (&core->tasks);
+				}
+				if (!r_str_startswith (asm_arch, "hex")) {
 					// XXX moving this oustide the x86 guard breaks some tests, missing types
 					if (cfg_debug) {
 						logline (core, 70, "Skipping function emulation in debugger mode (aaef)");
 						// nothing to do
 					} else {
-						const bool io_cache = r_config_get_i (core->config, "io.pcache");
-						r_config_set_b (core->config, "io.pcache", true);
+						bool use_pcache = true; // false;
+						const bool io_cache = r_config_get_b (core->config, "io.pcache");
+						if (use_pcache) {
+							r_config_set_b (core->config, "io.pcache", true);
+						}
 						logline (core, 70, "Emulate functions to find computed references (aaef)");
 						r_core_cmd_call (core, "aaef");
 						r_core_task_yield (&core->tasks);
-						r_config_set_b (core->config, "io.pcache", io_cache);
+						if (use_pcache) {
+							r_config_set_b (core->config, "io.pcache", io_cache);
+						}
 					}
 				}
 				if (r_cons_is_breaked ()) {

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -13810,7 +13810,7 @@ static int cmd_anal_all(RCore *core, const char *input) {
 					}
 					r_core_task_yield (&core->tasks);
 				}
-				const bool run_aaef = r_config_get_b (core->config, "anal.emu");;
+				const bool run_aaef = r_config_get_b (core->config, "anal.emu");
 				/// if (!r_str_startswith (asm_arch, "x86") && !r_str_startswith (asm_arch, "hex")) {
 				if (run_aaef) { // emulate all functions
 					// if (!r_str_startswith (asm_arch, "hex"))  maybe?

--- a/test/db/anal/avr
+++ b/test/db/anal/avr
@@ -646,7 +646,7 @@ NAME=avr stop anal when invalid instruction is found
 FILE=bins/firmware/arduino_avr.bin
 CMDS=<<EOF
 e asm.arch=avr
-aeim
+e anal.emu=true
 aaa
 f
 EOF
@@ -745,7 +745,6 @@ EXPECT=<<EOF
 0x00001bde 46 fcn.00001bde
 0x00001c4e 48 fcn.00001c4e
 0x00001c84 44 fcn.00001c84
-0x00001dfe 30 fcn.00001dfe
 0x00001e78 88 fcn.00001e78
 0x00001efe 38 fcn.00001efe
 0x00001f24 14 fcn.00001f24

--- a/test/db/anal/emu
+++ b/test/db/anal/emu
@@ -1,3 +1,20 @@
+NAME=emu x86-32 aaef via aaa
+FILE=bins/elf/libtest_32.so
+CMDS=<<EOF
+aaa
+s 0x00000500
+pd 1
+axt
+EOF
+EXPECT=<<EOF
+            ;-- section..rodata:
+            ;-- str.Hello_World__n:
+            ; STRN XREF from sym.test @ 0x4d3(r)
+            0x00000500     .string "Hello World!\n" ; len=14           ; [13] -r-- section size 14 named .rodata
+sym.test 0x4d3 [STRN:r--] lea ecx, str.Hello_World__n
+EOF
+RUN
+
 NAME=emu ret0
 FILE=bins/mach0/ret0ret1restr
 ARGS=-2

--- a/test/db/anal/emu
+++ b/test/db/anal/emu
@@ -1,7 +1,9 @@
 NAME=emu x86-32 aaef via aaa
 FILE=bins/elf/libtest_32.so
 CMDS=<<EOF
+e anal.emu=true
 aaa
+aaef
 s 0x00000500
 pd 1
 axt

--- a/test/db/cmd/r2pipe2
+++ b/test/db/cmd/r2pipe2
@@ -98,11 +98,6 @@ EXPECT=<<EOF
     {
       "type": "WARN",
       "origin": "logline",
-      "message": "Emulate functions to find computed references (aaef)"
-    },
-    {
-      "type": "WARN",
-      "origin": "logline",
       "message": "Recovering local variables (afva@@@F)"
     },
     {

--- a/test/db/formats/elf/helloworld-gcc-elf
+++ b/test/db/formats/elf/helloworld-gcc-elf
@@ -13,6 +13,7 @@ RUN
 NAME=armr - functions bits
 FILE=bins/arm/elf/hello_world
 CMDS=<<EOF
+e anal.emu=true
 aaa
 pid 1@@f
 EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
