### PR TITLE
Fix jmptable analysis on ARM ##analysis

### DIFF
--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -903,6 +903,8 @@ wx+ d90d9828440d90139d109c
 s 0
 af
 pds 1@0x2e~:1
+(foo;?== `Cd.` 2;?? echo fail;s+2)
+92.(foo) @ switch.0x0000002e + 4
 EOF
 EXPECT=<<EOF
 0x0000002e switch table (92 cases) at 0x32
@@ -1222,5 +1224,19 @@ bx lr
 address    noret size  nbbs edges    cc cost  min bound range max bound  calls locals args xref frame name
 ========== ===== ===== ===== ===== ===== ==== ========== ===== ========== ===== ====== ==== ==== ===== ====
 0x00000000     0   10     1     0     1    7 0x00000000    10 0x0000000a     0    0      0    0    12 fcn.00000000
+EOF
+RUN
+
+NAME=arm jmptbl case check
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=32
+wx 020050e300f18f90030000ea010000ea000000eaffffffea
+af
+(foo;Cd.;s+4)
+4.(foo) @ 0x8
+EOF
+EXPECT=<<EOF
 EOF
 RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
The cases in ARM switch-case is looking a bit funky at the moment.
![Screenshot_2024-04-15-17-30-13-792_com termux-edit](https://github.com/radareorg/radare2/assets/50861563/ec3faf28-80b9-4412-9e75-e4c7393c383c)
The cases are actually jump instructions (not integers) and thus, need to be treated as code.
For this, I've added a switch to turn off the hint insertion at the case locations for this arm-style jmptable.
<!-- explain your changes if necessary -->
