### PR TITLE
Do not make THREAD_CONVERT_THREAD_STATE_TO_SELF mandatory for old macs

### DIFF
--- a/libr/debug/p/native/xnu/xnu_threads.c
+++ b/libr/debug/p/native/xnu/xnu_threads.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2009-2022 - pancake */
+/* radare - LGPL - Copyright 2009-2024 - pancake */
 
 #include <r_userconf.h>
 #include <sys/sysctl.h>
@@ -264,13 +264,14 @@ static bool xnu_thread_get_gpr(RDebug *dbg, xnu_thread_t *thread) {
 				     sizeof (x86_thread_state64_t) :
 				     sizeof (x86_thread_state32_t);
 #endif
+#if defined(THREAD_CONVERT_THREAD_STATE_TO_SELF)
 #if !__POWERPC__
 	rc = thread_get_state (thread->port, thread->flavor,
 			       (thread_state_t)regs, &thread->count);
 
 	if (rc == KERN_SUCCESS) {
 		ut32 count = thread->count;
-	    kern_return_t rc;
+		kern_return_t rc;
 		rc = xnu_convert_thread_state (
 			thread->port,
 			THREAD_CONVERT_THREAD_STATE_TO_SELF,
@@ -290,6 +291,7 @@ static bool xnu_thread_get_gpr(RDebug *dbg, xnu_thread_t *thread) {
 #endif
 #if !__POWERPC__
 	}
+#endif
 #endif
 	if (rc != KERN_SUCCESS) {
 		r_sys_perror (__FUNCTION__);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
