### PR TITLE
Update preconfigure.bat

### DIFF
--- a/preconfigure.bat
+++ b/preconfigure.bat
@@ -1,5 +1,7 @@
 :: This is a comment
 @echo off
+SETLOCAL EnableDelayedExpansion
+
 :: Preconfigure script for Windows
 
 echo === Finding Python...
@@ -46,13 +48,48 @@ if %ERRORLEVEL% == 0 (
 REM vs uses HOST_TARGET syntax, so: x86_amd64 means 32bit compiler for 64bit target
 REM: Hosts: x86 amd64 x64
 REM: Targets: x86 amd64 x64 arm arm64
-IF "%*" == "x86" (
-  set VSARCH=x86
-) ELSE IF "%*" == "arm64" (
-  set VSARCH=x86_arm64
+REM Detect the host architecture intuitively and easily
+
+IF "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    SET "HOST_ARCH=x64"
+) ELSE IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
+    SET "HOST_ARCH=x86"
 ) ELSE (
-  set VSARCH=x86_amd64
+    SET "HOST_ARCH=unknown"
 )
+
+REM Check if arguments are passed
+IF "%~1"=="" (
+    echo Your current Host Architecture is !HOST_ARCH!
+    ECHO Please select the Target Architecture:
+    ECHO 1. x86
+    ECHO 2. x64 [amd64]
+    ECHO 3. arm
+    ECHO 4. arm64
+    SET /P "CHOICE=Enter your choice (1-4): "
+
+    REM Set target architecture based on user input
+    IF "!CHOICE!"=="1" (
+        SET "TARGET_ARCH=x86"
+    ) ELSE IF "!CHOICE!"=="2" (
+        SET "TARGET_ARCH=x64"
+    ) ELSE IF "!CHOICE!"=="3" (
+        SET "TARGET_ARCH=arm"
+    ) ELSE IF "!CHOICE!"=="4" (
+        SET "TARGET_ARCH=arm64"
+    ) ELSE (
+        ECHO Invalid choice. Defaulting to arm64.
+        SET "TARGET_ARCH=arm64"
+    )
+
+    REM Combine host and target into VSARCH
+    SET "VSARCH=!HOST_ARCH!_!TARGET_ARCH!"
+) ELSE (
+    REM Use provided host_target argument
+    SET "VSARCH=%1"
+)
+
+ECHO VSARCH is set to: %VSARCH%
 
 echo === Finding Visual Studio...
 cl --help > NUL 2> NUL
@@ -116,4 +153,5 @@ if EXIST "libr\arch\p\arm\v35\arch-armv7" (
 )
 
 echo Now you can run 'configure'
+ENDLOCAL
 cmd


### PR DESCRIPTION
Made selection of Host and target platform more simple and intuitive

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
In previous code, if a user didn't provide any argument with the command then x86 will be selected as Host by default which is kind of Flawed.

This change will detect the Host system on its and will allow the user to select the target system
