### PR TITLE
Fix concurrency issue ##test

### DIFF
--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -463,9 +463,9 @@ static RThreadFunctionRet sigchld_th(RThread *th) {
 				proc->ret = -1;
 			}
 			ut8 r = 0;
-			int ret = write (proc->killpipe[1], &r, 1);
 			r_th_lock_leave (proc->lock);
 			r_th_lock_leave (subprocs_mutex);
+			int ret = write (proc->killpipe[1], &r, 1);
 			if (ret != 1) {
 				break;
 			}
@@ -1159,7 +1159,6 @@ R_API R2RAsmTestOutput *r2r_run_asm_test(R2RRunConfig *config, R2RAsmTest *test)
 		out->bytes_size = (size_t)byteslen;
 rip:
 		r_pvector_pop (&args);
-		r_th_lock_leave (proc->lock);
 		r_th_lock_free (proc->lock);
 		r2r_subprocess_free (proc);
 	}
@@ -1186,7 +1185,6 @@ ship:
 		free (hex);
 		r_pvector_pop (&args);
 		r_pvector_pop (&args);
-		r_th_lock_leave (proc->lock);
 		r_th_lock_free (proc->lock);
 		r2r_subprocess_free (proc);
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

### **Description**
There's a bit of a problem with r2r on Android aarch64.
```
$ r2r test/db/asm
INFO: Running from /data/data/com.termux/files/home/project/radare2/test
Already up to date.
Loaded 10298 tests.
INFO: Skipping json tests because jq is not available
[41/10298]                 41 OK         0 BR        0 XX        0 FXFORTIFY: pthread_mutex_unlock called on a destroyed mutex (0xb400007303ff884c)
[1]    6672 abort      r2r test/db/asm
```
This patch makes sure that sigchild thread will fire a signal to the subprocess wait func only after it has done with the lock.

Also a small fix about unlocking an unlocked lock.