### PR TITLE
Ragg2 FIx Saving Call Returns

### DIFF
--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -566,9 +566,11 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 		}
 		str[len] = '\0';
 		snprintf (foo, sizeof (foo) - 1, ".fix%d", egg->lang.nargs * 16);	/* XXX FIX DELTA !!!1 */
-		free (egg->lang.dstvar);
+		char* tmp = egg->lang.dstvar;
 		egg->lang.dstvar = r_str_trim_dup (foo);
 		rcc_pushstr (egg, str, mustfilter);
+		free (egg->lang.dstvar);
+		egg->lang.dstvar = tmp;
 		ret = r_egg_mkvar (egg, out, foo, 0);
 		free (oldstr);
 	}

--- a/test/unit/test_egg.c
+++ b/test/unit/test_egg.c
@@ -1,0 +1,75 @@
+#include <sys/mman.h>
+#include <string.h>
+#include <r_egg.h>
+#include "minunit.h" 
+
+const char *arch = R_SYS_ARCH;
+const char *os = R_EGG_OS_NAME;
+int bits = (R_SYS_BITS & R_SYS_BITS_64)? 64: 32;
+const char program[] = "                \
+read@syscall(0);                        \
+write@syscall(1);                       \
+open@syscall(2);                        \
+exit@syscall(60);                       \
+main@global(2000, 6) {			\
+.var17 = open(\"./file\", 2);		\
+.var25 = read(.var17, &.var33, 2000);	\
+write(1, &.var33, .var25);		\
+exit(0);				\
+}                                       \
+";
+
+
+bool test_r_egg_save(void) {
+	REgg *egg = r_egg_new ();
+	RAnal *a = r_anal_new ();
+	r_anal_bind (a, &egg->rasm->analb);
+
+	r_egg_setup (egg, arch, bits, 0, os);
+	r_egg_load (egg, program, 0);
+
+	mu_assert ("Compilation", r_egg_compile (egg)); 
+	mu_assert ("Assembly", r_egg_assemble (egg)); 
+	mu_assert ("Binary", r_egg_get_bin (egg));
+
+	r_egg_finalize (egg); 
+
+	int out = memfd_create ("out", 0);
+	/* TODO use tempfile */ 
+	int in = open ("./file", O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR); 
+	write (in, "test file", 9);
+	close (in); 
+
+	if (!fork ()) {
+		dup2 (out, STDOUT_FILENO);
+		r_egg_run (egg);
+	}
+
+	wait (NULL);
+
+	struct stat sz; 
+	fstat (out, &sz);
+	char buf[sz.st_size + 1];
+
+	lseek (out, 0, 0);
+	read (out, buf, sz.st_size);
+
+	buf[sz.st_size] = '\0';
+
+	mu_assert_eq (strcmp (buf, "test file"), 0, "Save");
+
+	close (out);
+	unlink ("./file");
+	r_egg_free (egg);
+	
+	mu_end;
+}
+
+bool all_tests() {
+	mu_run_test (test_r_egg_save);
+	return tests_passed != tests_run;
+}
+
+int main(int argc, char **argv) {
+	return all_tests();
+}


### PR DESCRIPTION

- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description** 
Ragg2 when processing immediate strings in function call arguments previously didn't save call returns due to the string processing. String processing now creates a temporary destination variable, and frees that, allowing for the destination variable to be processed. 

Haven't fully checked ASAN output yet. 