### PR TITLE
Fix #22939 - ub shifts on sixref ##analysis

### DIFF
--- a/libr/core/p/core_sixref.c
+++ b/libr/core/p/core_sixref.c
@@ -22,7 +22,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 			ut32 reg = v & 0x1f;
 			bool is_adrp = (v & 0x80000000) != 0;
 			int64_t base = is_adrp ? (addr & 0xfffffffffffff000) : addr;
-			int64_t off  = ((int64_t)((((v >> 5) & 0x7ffff) << 2) | ((v >> 29) & 0x3)) << 43) >> (is_adrp ? 31 : 43);
+			int64_t off  = (int64_t)((uint64_t)((((v >> 5) & 0x7ffff) << 2) | ((v >> 29) & 0x3)) << 43) >> (is_adrp ? 31 : 43);
 			ut64 target = base + off;
 			if (search == 0) {
 				// r_cons_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x" # %s\n", target, addr, is_adrp? "adrp": "adr");
@@ -102,7 +102,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 										}
 									}
 								} else if ((v & 0x00200000) == 0) {
-									int64_t soff = ((int64_t)((v >> 12) & 0x1ff) << 55) >> 55;
+									int64_t soff = (int64_t)((uint64_t)((v >> 12) & 0x1ff) << 55) >> 55;
 									const char *sign = soff < 0 ? "-" : "";
 									if (target + aoff + soff == search) {
 										if ((v & 0x400) == 0) {
@@ -177,7 +177,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 		}
 		else if ((v & 0xbf000000) == 0x18000000 || (v & 0xff000000) == 0x98000000) // ldr and ldrsw literal
 		{
-			int64_t off = ((int64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
+			int64_t off = (int64_t)((uint64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
 			if (!search) {
 				// r_cons_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", addr + off, addr);
 				addref (core, addr, addr + off, R_ANAL_REF_TYPE_DATA); // is_adrp matters?
@@ -190,7 +190,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 		}
 		else if ((v & 0x7c000000) == 0x14000000) // b and bl
 		{
-			int64_t off = ((int64_t)(v & 0x3ffffff) << 38) >> 36;
+			int64_t off = (int64_t)((uint64_t)(v & 0x3ffffff) << 38) >> 36;
 			bool is_bl = (v & 0x80000000) != 0;
 			if (!search) {
 				// r_cons_printf("ax 0x%"PFMT64x" 0x%"PFMT64x" # %s %#"PFMT64x"\n", addr + off, addr, is_bl ? "bl" : "b", addr + off);
@@ -201,7 +201,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 		}
 		else if ((v & 0xff000010) == 0x54000000) // b.cond
 		{
-			int64_t off = ((int64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
+			int64_t off = (int64_t)((uint64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
 			if (!search) {
 				addref (core, addr, addr + off, R_ANAL_REF_TYPE_CODE);
 				// r_cons_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", addr + off, addr);
@@ -231,7 +231,7 @@ static void siguza_xrefs_chunked(RCore *core, ut64 search, int lenbytes) {
 		}
 		else if ((v & 0x7e000000) == 0x34000000) // cbz and cbnz
 		{
-			int64_t off = ((int64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
+			int64_t off = (int64_t)((uint64_t)((v >> 5) & 0x7ffff) << 45) >> 43;
 			if (!search) {
 				// r_cons_printf ("ax 0x%"PFMT64x" 0x%"PFMT64x"\n", addr + off, addr);
 				addref (core, addr, addr + off, R_ANAL_REF_TYPE_CODE);


### PR DESCRIPTION
* This was fixed three years ago, but never synced back
* https://github.com/Siguza/misc/commit/222e14da3cb57118ed0c8e28eba99a85df7e4742

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
