### PR TITLE
Fix infinite loop in the afla command spawned by a^5 ##crash

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -4882,16 +4882,22 @@ static bool afla_purge(void *user, const ut64 key, const void *val) {
 	RVecAddr *va = (RVecAddr *)val;
 	rcd->inloop = true;
 	int index = 0;
+	bool hasdone = false;
 repeat:
 	index = 0;
 	R_VEC_FOREACH (va, v) {
 		R_VEC_FOREACH (rcd->togo, v2) {
 			if (*v == *v2) {
 				RVecAddr_remove (va, index);
+				hasdone = true;
 				goto repeat;
 			}
 		}
 		index++;
+	}
+	if (!hasdone) {
+		R_LOG_WARN ("Leaving an infinite loop before it's too late");
+		rcd->inloop = false;
 	}
 	return true;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
