### PR TITLE
Bring back the ig command to guess binary size ##bin

### DIFF
--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -82,7 +82,7 @@ static RCoreHelpMessage help_msg_i = {
 	"iD", " lang sym", "demangle symbolname for given language",
 	"ie", "[?]e[e]", "entrypoint (iee to list constructors and destructors, ieee = entries+constructors)",
 	"iE", "[?]", "exports (global symbols)",
-	"ig", "", "guess size of binary program",
+	"ig", "[?][h]", "guess size of binary program (igh use human units instead of number of bytes)",
 	"ih", "[?]", "show binary headers (same as iH/-H to avoid conflict with -h in rabin2)",
 	"iH", "[H]", "show binary headers in plain text (iHH verbose output)", // XXX pretty bad description
 	"ii", "[?][j*,]", "list the symbols imported from other libraries",
@@ -1971,6 +1971,20 @@ static int cmd_info(void *data, const char *input) {
 		break;
 	case 'R': // "iR"
 		RBININFO ("resources", R_CORE_BIN_ACC_RESOURCES, NULL, 0);
+		break;
+	case 'g': // "ig"
+		if (input[1] == '?') {
+			r_core_cmd_help_match (core, help_msg_i, "ig");
+		} else if (input[1] == 'h') {
+			char ss[64];
+			ut64 bs = r_bin_get_size (core->bin);
+			if (r_num_units (ss, sizeof (ss), bs)) {
+				r_cons_printf ("%s\n", ss);
+			}
+		} else {
+			ut64 bs = r_bin_get_size (core->bin);
+			r_cons_printf ("0x%08"PFMT64x"\n", bs);
+		}
 		break;
 	case 'c': // "ic"
 		cmd_ic (core, input + 1, pj, is_array, va);

--- a/test/db/cmd/cmd_ih
+++ b/test/db/cmd/cmd_ih
@@ -317,3 +317,15 @@ EXPECT=<<EOF
 0x00000032  ShrStrndx   27
 EOF
 RUN
+
+NAME=ig and igh
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+ig
+igh
+EOF
+EXPECT=<<EOF
+0x00001323
+4.8K
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
