### PR TITLE
Fix dyldcache parsing for iOS 18 beta changes

### DIFF
--- a/libr/bin/format/mach0/dsc.c
+++ b/libr/bin/format/mach0/dsc.c
@@ -143,12 +143,15 @@ static const RDSCField dsc_header_fields[] = {
 	{ "i", "imagesOffset" },
 	{ "i", "imagesCount" },
 	{ "i", "cacheSubType" },
+	{ "i", "padding" },
 	{ "l", "objcOptsOffset" },
 	{ "l", "objcOptsSize" },
 	{ "l", "cacheAtlasOffset" },
 	{ "l", "cacheAtlasSize" },
 	{ "l", "dynamicDataOffset" },
 	{ "l", "dynamicDataMaxSize" },
+	{ "i", "maybePointsToLinkeditMapAtTheEndOfSubCachesArray" },
+	{ "i", "previousPointerMakesSense" },
 	{ NULL, NULL }
 };
 

--- a/libr/bin/format/mach0/mach0.h
+++ b/libr/bin/format/mach0/mach0.h
@@ -157,7 +157,7 @@ struct MACH0_(obj_t) {
 	bool libs_loaded;
 	RPVector libs_cache;
 	int nlibs;
-	int size;
+	ut64 size;
 	ut64 baddr;
 	ut64 entry;
 	bool big_endian;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

iOS 18 beta introduces a couple new fields to the dyldcache header, the purpose of which is still unclear to me (and it reflects on the bad names i gave 'em) but broke the heuristics for detecting the subcache info format. This change leverages the first of the two new fields to update the format detection logic.

The other big issue was that r2's Mach-O size was represented as an `int`, but the new dyldcache have a logical combined size which now requires 33 bits 😅 , so our bounds checking code was overreacting. Fixed by bringing the `size` field up to `ut64` capacity.
