### PR TITLE
Add json support to iD command ##shell

### DIFF
--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -182,7 +182,7 @@ static char *demangle_internal(RCore *core, const char *lang, const char *s) {
 	case R_BIN_LANG_RUST: res = r_bin_demangle_rust (core->bin->cur, s, 0); break;
 	case R_BIN_LANG_PASCAL: res = r_bin_demangle_freepascal (s); break;
 	default:
-		r_core_return_code (core, 1);
+		r_core_return_value (core, 1);
 	}
 	return res;
 }
@@ -214,9 +214,10 @@ static void cmd_info_demangle(RCore *core, const char *input, PJ *pj, int mode) 
 	if (!s) {
 		const char *lang = r_config_get (core->config, "bin.lang");
 		char *res = demangle_internal (core, lang, input);
-		if (!res && core->rc != 0) {
+		if (!res) {
 			goto iD_lang_err;
 		}
+		s = input;
 	}
 	char *p = strdup (input);
 	if (R_UNLIKELY (p)) {
@@ -224,7 +225,7 @@ static void cmd_info_demangle(RCore *core, const char *input, PJ *pj, int mode) 
 		char *q = p + (s - input);
 		*q = 0;
 		char *res = demangle_internal (core, p, q + 1);
-		if (!res && core->rc != 0) {
+		if (!res) {
 			goto iD_lang_err;
 		}
 		if (mode == R_MODE_JSON) {
@@ -247,11 +248,11 @@ static void cmd_info_demangle(RCore *core, const char *input, PJ *pj, int mode) 
 	return;
 
 iD_lang_err:
-	if (!pj) {
+	if (pj) {
+		R_LOG_ERROR ("Missing or unknown language.")
+	} else {
 		R_LOG_ERROR ("Missing or unknown language. Use one of the following:");
 		r_bin_demangle_list (core->bin);
-	} else {
-		R_LOG_ERROR ("Missing or unknown language.")
 	}
 	r_core_return_value (core, 1);
 }

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -1300,6 +1300,14 @@ Swift.String.init(_builtinStringLiteral: Builtin.RawPointer, byteSize: Builtin.W
 EOF
 RUN
 
+NAME=iDj
+FILE=bins/elf/libmagic.so
+CMDS=iDj swift _TFSSCfT21_builtinStringLiteralBp8byteSizeBw7isASCIIBi1__SS
+EXPECT=<<EOF
+{"lang":"swift","mangled":"_TFSSCfT21_builtinStringLiteralBp8byteSizeBw7isASCIIBi1__SS","demangled":"Swift.String.init(_builtinStringLiteral: Builtin.RawPointer, byteSize: Builtin.Word, isASCII: Builtin.Int1) -> Swift.String"}
+EOF
+RUN
+
 NAME=ie (file x86)
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=ie

--- a/test/db/json/cmd_i
+++ b/test/db/json/cmd_i
@@ -3,6 +3,8 @@ iAj
 icj
 iCj
 idj
+iDj
+iDj swift _TFSSCfT21_builtinStringLiteralBp8byteSizeBw7isASCIIBi1__SS
 iej
 iEj
 # ihj


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
I'm still unsure if we should drop an error in some cases, as happens in the second one:
```
[0x00000000]> iDj
{}
[0x00000000]> iDj xxx
ERROR: Missing or unknown language.
{}
[0x00000000]> iDj swift xxx
{"lang":"swift","mangled":"xxx","error":"Cannot demangle string"}
```

The thing is that iD without params doesn't drop any kind of error but a help message, so in that case maybe an empty json is just ok.