### PR TITLE
Fix 'Cannot redirect the same fd twice' bug in the command parser ##shell

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -4534,7 +4534,7 @@ repeat:;
 		}
 
 		char *nextgt = strchr (r_str_trim_head_ro (ptr + 1), '>');
-		if (nextgt) {
+		if (nextgt && nextgt[0] != '>') {
 			char *back = ptr + 1;
 			while (nextgt > back) {
 				if (!isdigit (*nextgt) && *nextgt != 'H') {
@@ -4588,6 +4588,7 @@ repeat:;
 				// R_LOG_ERROR ("Cannot open pipe with fd %d", fdn);
 				// goto errorout;
 			}
+			*str = 0;
 			if (next_redirect) {
 				ptr = next_redirect;
 				*next_redirect = ' ';

--- a/libr/util/token.c
+++ b/libr/util/token.c
@@ -225,7 +225,7 @@ static void indent(RTokenizer *tok) {
 	if (data->incase) {
 		n++;
 	}
-	// R_LOG_DEBUG ("%s", r_str_pad (' ', n));
+	R_LOG_DEBUG ("%s", r_str_pad (' ', n));
 }
 
 bool callback(RTokenizer *tok) {


### PR DESCRIPTION
<img width="341" alt="Screenshot 2024-06-27 at 12 41 33" src="https://github.com/radareorg/radare2/assets/6431515/bd48b73b-8662-486b-955d-2313b93d0123">
