### PR TITLE
Add iP command to dsc ##io

### DIFF
--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -308,11 +308,9 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 
 					ut64 raw_value = r_read_le64 (raw_value_buf);
 
-					char * tmp;
-
 					pj_o (pj);
 
-					tmp = r_str_newf ("0x%"PFMT64x, trimmed->slice->start + off_local);
+					char * tmp = r_str_newf ("0x%"PFMT64x, trimmed->slice->start + off_local);
 					pj_ks (pj, "paddr", tmp);
 					free (tmp);
 
@@ -325,38 +323,38 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 					free (tmp);
 
 					switch (trimmed_info->info->info->version) {
-						case 1:
-						case 2:
-						case 4:
-							break;
-						case 3:
-							if (R_IS_PTR_AUTHENTICATED (raw_value)) {
-								bool has_diversity = (raw_value & (1ULL << 48)) != 0;
-								pj_kb (pj, "has_diversity", has_diversity);
-								if (has_diversity) {
-									ut64 diversity = (raw_value >> 32) & 0xFFFF;
-									pj_kn (pj, "diversity", diversity);
-								}
-								ut64 key = (raw_value >> 49) & 3;
-								const char * names[4] = { "ia", "ib", "da", "db" };
-								pj_ks (pj, "key", names[key]);
+					case 1:
+					case 2:
+					case 4:
+						break;
+					case 3:
+						if (R_IS_PTR_AUTHENTICATED (raw_value)) {
+							bool has_diversity = (raw_value & (1ULL << 48)) != 0;
+							pj_kb (pj, "has_diversity", has_diversity);
+							if (has_diversity) {
+								ut64 diversity = (raw_value >> 32) & 0xFFFF;
+								pj_kn (pj, "diversity", diversity);
 							}
-							break;
-						case 5:
-							if (R_IS_PTR_AUTHENTICATED (raw_value)) {
-								bool has_diversity = (raw_value & (1ULL << 50)) != 0;
-								pj_kb (pj, "has_diversity", has_diversity);
-								if (has_diversity) {
-									ut64 diversity = (raw_value >> 34) & 0xFFFF;
-									pj_kn (pj, "diversity", diversity);
-								}
-								ut64 key = (raw_value >> 51) & 1;
-								const char * names[2] = { "ia", "da" };
-								pj_ks (pj, "key", names[key]);
+							ut64 key = (raw_value >> 49) & 3;
+							const char * names[4] = { "ia", "ib", "da", "db" };
+							pj_ks (pj, "key", names[key]);
+						}
+						break;
+					case 5:
+						if (R_IS_PTR_AUTHENTICATED (raw_value)) {
+							bool has_diversity = (raw_value & (1ULL << 50)) != 0;
+							pj_kb (pj, "has_diversity", has_diversity);
+							if (has_diversity) {
+								ut64 diversity = (raw_value >> 34) & 0xFFFF;
+								pj_kn (pj, "diversity", diversity);
 							}
-							break;
-						default:
-							R_LOG_ERROR ("Unsupported rebase info version %d", trimmed_info->info->info->version);
+							ut64 key = (raw_value >> 51) & 1;
+							const char * names[2] = { "ia", "da" };
+							pj_ks (pj, "key", names[key]);
+						}
+						break;
+					default:
+						R_LOG_ERROR ("Unsupported rebase info version %d", trimmed_info->info->info->version);
 					}
 					pj_end (pj);
 				}
@@ -368,9 +366,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 
 		pj_end (pj);
 
-		char * result = strdup (pj_string (pj));
-		pj_free (pj);
-		return result;
+		return pj_drain (pj);
 	}
 
 	return NULL;

--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -116,6 +116,7 @@ typedef struct {
 	RIO *io_backref;
 	RIODscSlices slices;
 	ut64 total_size;
+	ut64 last_seek;
 } RIODscObject;
 
 typedef enum {
@@ -252,6 +253,131 @@ static bool __close(RIODesc *fd) {
 static ut64 __lseek_dsc(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 	r_return_val_if_fail (fd && fd->data, UT64_MAX);
 	return r_io_dsc_object_seek (io, (RIODscObject *)fd->data, offset, whence);
+}
+
+static char *__system(RIO *io, RIODesc *fd, const char *command) {
+	r_return_val_if_fail (io && fd && fd->data && command, NULL);
+	RIODscObject *dsc = (RIODscObject*) fd->data;
+
+	if (r_str_startswith (command, "iP")) {
+		PJ *pj = pj_new ();
+		if (!pj) {
+			return NULL;
+		}
+
+		ut64 size = 8;
+		if (command[2] == ' ') {
+			size = r_num_math (NULL, command + 3);
+		}
+
+		ut64 paddr = dsc->last_seek;
+
+		RList * slices = r_io_dsc_object_get_slices_by_range (dsc, paddr, size);
+		if (!slices) {
+			return NULL;
+		}
+
+		RListIter * iter;
+		RIODscTrimmedSlice * trimmed;
+		int total = 0;
+		int failures = 0;
+		int index = 0;
+		int n_slices = r_list_length (slices);
+
+		pj_a (pj);
+
+		r_list_foreach (slices, iter, trimmed) {
+			RList * infos = r_io_dsc_slice_get_rebase_infos_by_range (trimmed->slice, trimmed->seek, trimmed->count);
+			if (!infos) {
+				return NULL;
+			}
+
+			RListIter * iter;
+			RIODscTrimmedRebaseInfo * trimmed_info;
+
+			r_list_foreach (infos, iter, trimmed_info) {
+				ut64 remaining_size = trimmed_info->count;
+				ut64 cursor = 0;
+				while (remaining_size > 0) {
+					ut8 raw_value_buf[8];
+					bool got_raw_value;
+					ut64 off_local = trimmed_info->off_local + cursor;
+					RIO_FREAD_AT_INTO_DIRECT (trimmed->slice->fd, off_local, &raw_value_buf, 8, got_raw_value);
+					remaining_size -= 8;
+					cursor += 8;
+					if (!got_raw_value) {
+						R_LOG_ERROR ("Error reading raw pointer");
+						break;
+					}
+
+					ut64 raw_value = r_read_le64 (raw_value_buf);
+
+					char * tmp;
+
+					pj_o (pj);
+
+					tmp = r_str_newf ("0x%"PFMT64x, trimmed->slice->start + off_local);
+					pj_ks (pj, "paddr", tmp);
+					free (tmp);
+
+					tmp = r_str_newf ("0x%"PFMT64x, raw_value);
+					pj_ks (pj, "raw", tmp);
+					free (tmp);
+
+					tmp = r_str_newf ("v%d", trimmed_info->info->info->version);
+					pj_ks (pj, "format", tmp);
+					free (tmp);
+
+					switch (trimmed_info->info->info->version) {
+						case 1:
+						case 2:
+						case 4:
+							break;
+						case 3:
+							if (R_IS_PTR_AUTHENTICATED (raw_value)) {
+								bool has_diversity = (raw_value & (1ULL << 48)) != 0;
+								pj_kb (pj, "has_diversity", has_diversity);
+								if (has_diversity) {
+									ut64 diversity = (raw_value >> 32) & 0xFFFF;
+									pj_kn (pj, "diversity", diversity);
+								}
+								ut64 key = (raw_value >> 49) & 3;
+								const char * names[4] = { "ia", "ib", "da", "db" };
+								pj_ks (pj, "key", names[key]);
+							}
+							break;
+						case 5:
+							if (R_IS_PTR_AUTHENTICATED (raw_value)) {
+								bool has_diversity = (raw_value & (1ULL << 50)) != 0;
+								pj_kb (pj, "has_diversity", has_diversity);
+								if (has_diversity) {
+									ut64 diversity = (raw_value >> 34) & 0xFFFF;
+									pj_kn (pj, "diversity", diversity);
+								}
+								ut64 key = (raw_value >> 51) & 1;
+								const char * names[2] = { "ia", "da" };
+								pj_ks (pj, "key", names[key]);
+							}
+							break;
+						default:
+							R_LOG_ERROR ("Unsupported rebase info version %d", trimmed_info->info->info->version);
+					}
+					pj_end (pj);
+				}
+			}
+			r_list_free (infos);
+		}
+
+		r_list_free (slices);
+
+		pj_end (pj);
+
+		char * result = strdup (pj_string (pj));
+		pj_free (pj);
+		return result;
+	}
+
+	return NULL;
 }
 
 static RIODscObject *r_io_dsc_object_new(RIO  *io, const char *filename, int perm, int mode) {
@@ -706,6 +832,8 @@ static ut64 r_io_dsc_object_seek(RIO *io, RIODscObject *dsc, ut64 offset, int wh
 	}
 
 	io->off = off_local + slice->start;
+
+	dsc->last_seek = io->off;
 
 	return io->off;
 }
@@ -1611,6 +1739,7 @@ RIOPlugin r_io_plugin_dsc = {
 	.read = __read,
 	.check = __check,
 	.seek = __lseek_dsc,
+	.system = __system,
 #if R2__UNIX__
 	.is_blockdevice = __is_blockdevice,
 #endif

--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -306,7 +306,7 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 					remaining_size -= 8;
 					cursor += 8;
 					if (!got_raw_value) {
-						R_LOG_ERROR ("Error reading raw pointer");
+						R_LOG_ERROR ("reading raw pointer");
 						break;
 					}
 

--- a/libr/io/p/io_dsc.c
+++ b/libr/io/p/io_dsc.c
@@ -279,10 +279,6 @@ static char *__system(RIO *io, RIODesc *fd, const char *command) {
 
 		RListIter * iter;
 		RIODscTrimmedSlice * trimmed;
-		int total = 0;
-		int failures = 0;
-		int index = 0;
-		int n_slices = r_list_length (slices);
 
 		pj_a (pj);
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add the iP command to the dsc io plugin, to get **i**nfo about a **P**ointer. That draws information from the underlying rebase infos which are embedded in the pointer itself (whose semantics potentially changes over different maps), which otherwise gets lost as part of rebasing / pointer cleanup.

This is especially useful for getting info about pointer authentication, like the **diversity** and the **key** to use if there's any need to ever re-sign a pointer from the dyld cache.

The usage is `:iP [size][@vaddr]` if no size is provided defaults to 8, runs at current seek (or virtual seek if provided). The output is JSON only.

Example:

```
# this is how we see the pointer stored there normally
> pxq 8@0x1f242f210
0x1f242f210  0x00000001b972985c                       \.r.....

# and this digs the hidden metadata
> :iP @0x1f242f210~{}
[
  {
    "paddr": "0x707b7210",
    "raw": "0x8009b5883972985c",
    "format": "v3",
    "has_diversity": true,
    "diversity": 46472,
    "key": "ia"
  }
]
```

**Experimental** in the sense that it's quite naive and there's no guard against the user pointing it to an unaligned address for example, where the bits will be interpreted in the wrong way.
