### PR TITLE
Improve dyldcache ##io and ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1141,12 +1141,28 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 }
 
 static RList *entries(RBinFile *bf) {
+	RDyldCache *cache = (RDyldCache*) bf->bo->bin_obj;
+	if (!cache) {
+		return NULL;
+	}
+
 	RBinAddr *ptr = NULL;
 	RList *ret = r_list_newf (free);
 	if (!ret) {
 		return NULL;
 	}
 	if ((ptr = R_NEW0 (RBinAddr))) {
+		if (cache->n_maps > 0) {
+			size_t i;
+			for (i = 0; i < cache->n_maps; i++) {
+				cache_map_t * map = &cache->maps[i];
+				if (map->fileOffset == 0) {
+					ptr->paddr = 0;
+					ptr->vaddr = map->address;
+					break;
+				}
+			}
+		}
 		r_list_append (ret, ptr);
 	}
 	return ret;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR brings three changes:
- add the `:iF` command to get information about what file is contributing the physical address corresponding to the current seek. This is mostly useful for multi-file caches.
- set the dyldcache entry point to the first map (the one which maps the offset 0) so the user is pointed by default to an address which is mapped (instead of being left floating over address 0 which is unmapped).
- create sections for stub islands: modern multi-file caches clump all import stubs in "stub islands". These live in specific stub-only subcaches which can be detected by checking that they contain no images and have only one `r-x` mapping which extends beyond the cache header page. This change creates specific sections called `STUB_ISLAND` (followed by an incremental number) so that they can be easily picked apart and emulated if needed.
