### PR TITLE
Fix improper display of IPv4 addresses in big-endian machines

### DIFF
--- a/libr/asm/filter.c
+++ b/libr/asm/filter.c
@@ -535,8 +535,7 @@ static bool filter(RParse *p, ut64 addr, RFlag *f, RAnalHint *hint, char *data, 
 				break;
 			case 32:
 				{
-					ut32 ip32 = off;
-					ut8 *ip = (ut8*)&ip32;
+					ut8 ip[4] = { off & 0xff, (off >> 8) & 0xff, (off >> 16) & 0xff, (off >> 24) & 0xff };
 					snprintf (num, sizeof (num), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
 				}
 				break;


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`ut8 *ip = (ut8*)&ip32` is assuming that the host machine is little-endian. The fix makes the code endianness-independent.