### PR TITLE
Fix incorrect parsing of MZ headers in big-endian machines

### DIFF
--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -199,7 +199,7 @@ static int r_bin_mz_init_hdr(struct r_bin_mz_obj_t *bin) {
 	}
 	bin->dos_header = mz;
 
-	ut8 raw[sizeof(*mz)];
+	ut8 raw[sizeof (*mz)];
 	if (r_buf_read_at (bin->b, 0, raw, sizeof (raw)) == -1) {
 		R_LOG_ERROR ("read (MZ_image_dos_header)");
 		return false;

--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -198,12 +198,27 @@ static int r_bin_mz_init_hdr(struct r_bin_mz_obj_t *bin) {
 		return false;
 	}
 	bin->dos_header = mz;
-	// TODO: read field by field to avoid endian and alignment issues
-	if (r_buf_read_at (bin->b, 0, (ut8 *)mz, sizeof (*mz)) == -1) {
+
+	ut8 raw[sizeof(*mz)];
+	if (r_buf_read_at (bin->b, 0, raw, sizeof (raw)) == -1) {
 		R_LOG_ERROR ("read (MZ_image_dos_header)");
 		return false;
 	}
-	// dos_header is not endian safe here in this point
+	mz->signature = r_read_le16 (&raw[0]);
+	mz->bytes_in_last_block = r_read_le16 (&raw[2]);
+	mz->blocks_in_file = r_read_le16 (&raw[4]);
+	mz->num_relocs = r_read_le16 (&raw[6]);
+	mz->header_paragraphs = r_read_le16 (&raw[8]);
+	mz->min_extra_paragraphs = r_read_le16 (&raw[10]);
+	mz->max_extra_paragraphs = r_read_le16 (&raw[12]);
+	mz->ss = r_read_le16 (&raw[14]);
+	mz->sp = r_read_le16 (&raw[16]);
+	mz->checksum = r_read_le16 (&raw[18]);
+	mz->ip = r_read_le16 (&raw[20]);
+	mz->cs = r_read_le16 (&raw[22]);
+	mz->reloc_table_offset = r_read_le16 (&raw[24]);
+	mz->overlay_number = r_read_le16 (&raw[26]);
+
 	if (mz->blocks_in_file < 1) {
 		return false;
 	}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The comment in the code says it all:
```
// TODO: read field by field to avoid endian and alignment issues
...
// dos_header is not endian safe here in this point
```

A struct is directly loaded in a single read operation, so, on machines with a different endianness than the file format, loading failed.
Reading field by field using `r_read_le16` fixes 10+ tests.
