### PR TITLE
Fix asm.emu derefenced word issue on big endian ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5102,6 +5102,7 @@ static bool myregwrite(REsil *esil, const char *name, ut64 *val) {
 	if (!ds) {
 		return false;
 	}
+	const bool be = R_ARCH_CONFIG_IS_BIG_ENDIAN (ds->core->rasm->config);
 	if (!ds->show_emu_strlea && ds->analop.type == R_ANAL_OP_TYPE_LEA) {
 		// useful for ARM64
 		// reduce false positives in emu.str=true when loading strings via adrp+add
@@ -5226,7 +5227,8 @@ static bool myregwrite(REsil *esil, const char *name, ut64 *val) {
 				/* nothing */
 			} else {
 				if (!ds->show_emu_str) {
-					msg = r_str_appendf (msg, "-> 0x%x", *n32);
+					ut32 v = r_read_ble32 (n32, be);
+					msg = r_str_appendf (msg, "-> 0x%x", v);
 				}
 			}
 		}

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -517,7 +517,7 @@ R_API ut8 r_buf_read8(RBuffer *b) {
 R_API ut8 r_buf_read8_at(RBuffer *b, ut64 addr) {
 	ut8 res;
 	st64 r = r_buf_read_at (b, addr, &res, sizeof (res));
-	return r == sizeof (res)? res: b->Oxff_priv;
+	return (r == sizeof (res))? res: b->Oxff_priv;
 }
 
 static st64 buf_format(RBuffer *dst, RBuffer *src, const char *fmt, int n) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
