### PR TITLE
Don't ask sections if fixed arch / bits are set ##core

### DIFF
--- a/libr/core/cio.c
+++ b/libr/core/cio.c
@@ -353,19 +353,21 @@ R_API void r_core_arch_bits_at(RCore *core, ut64 addr, R_OUT R_NULLABLE int *bit
 	int bitsval = 0;
 	const char *archval = NULL;
 	RBinObject *o = r_bin_cur_object (core->bin);
-	RBinSection *s = o ? r_bin_get_section_at (o, addr, core->io->va) : NULL;
-	if (s) {
-		if (!core->fixedarch) {
-			archval = s->arch;
-		}
-		if (!core->fixedbits && s->bits) {
-			// only enforce if there's one bits set
-			switch (s->bits) {
-			case R_SYS_BITS_16:
-			case R_SYS_BITS_32:
-			case R_SYS_BITS_64:
-				bitsval = s->bits * 8;
-				break;
+	if (!core->fixedarch || !core->fixedbits) {
+		RBinSection *s = o ? r_bin_get_section_at (o, addr, core->io->va) : NULL;
+		if (s) {
+			if (!core->fixedarch) {
+				archval = s->arch;
+			}
+			if (!core->fixedbits && s->bits) {
+				// only enforce if there's one bits set
+				switch (s->bits) {
+				case R_SYS_BITS_16:
+				case R_SYS_BITS_32:
+				case R_SYS_BITS_64:
+					bitsval = s->bits * 8;
+					break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Avoids unnecessary iteration of all the sections to get the value of bits and arch, in case they're both fixed.

Not a big deal most of the time, unless you try to emulate code in a binary which has a lot of sections (like an unfiltered dyld cache).
