### PR TITLE
Avoid over-unsetting fixed arch / bits ##core

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -5283,8 +5283,6 @@ beach:
 		r_io_desc_close (tmpdesc);
 		tmpdesc = NULL;
 	}
-	core->fixedarch = oldfixedarch;
-	core->fixedbits = oldfixedbits;
 	if (tmpseek) {
 		*tmpseek = cmd_tmpseek;
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

They're already set back to the original value on the `is_arch_set` / `is_bits_set` branches above, removing the second restoration allows for actually setting them via the `anal.fixed.arch` / `anal.fixed.bits` configs.
