### PR TITLE
Fix aae behaviour on invalid instructions ##core

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5879,9 +5879,9 @@ R_API void r_core_anal_esil(RCore *core, const char *str /* len */, const char *
 			R_LOG_DEBUG ("thumb unaligned or invalid instructions at 0x%08"PFMT64x, cur);
 			if (is_thumb) {
 				i++; // codelalign is not always the best option to catch unaligned instructions
+				r_anal_op_fini (&op);
+				goto repeat;
 			}
-			r_anal_op_fini (&op);
-			goto repeat;
 		}
 		//we need to check again i because buf+i may goes beyond its boundaries
 		//because of i += minopsize - 1

--- a/test/db/anal/loongarch
+++ b/test/db/anal/loongarch
@@ -18,7 +18,7 @@ aae
 aflc
 EOF
 EXPECT=<<EOF
-74
+89
 EOF
 RUN
 

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -17,7 +17,7 @@ aae
 aflc
 EOF
 EXPECT=<<EOF
-420
+427
 EOF
 RUN
 

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1166,3 +1166,22 @@ pc = 0x00000000
 pstate = 0x00000000
 EOF
 RUN
+
+NAME=invalid instruction skip
+FILE=malloc://0x2048
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+wx 00000000100000d01002019100021fd6
+f sym.something 8 @ 0x2040
+aaex 16
+axt 0x2040
+aaex 12@4
+axt 0x2040
+EOF
+EXPECT=<<EOF
+(nofunc) 0x8 [DATA:-w-] add x16, x16, 0x40
+(nofunc) 0x8 [DATA:-w-] add x16, x16, 0x40
+EOF
+RUN
+


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This prevents a scenario in which an invalid instruction also invalidated the next ones, causing missing references.
