### PR TITLE
Fix aac on rebased files

### DIFF
--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -1003,7 +1003,9 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, R_UNUSED int perm, const ch
 				if (maskMatches (s->perm, mask, only)) {
 					continue;
 				}
-				ut64 addr = core->io->va? s->vaddr: s->paddr;
+				ut64 addr = core->io->va?
+					(s->perm && R_PERM_R)? r_bin_get_vaddr(core->bin, s->paddr, s->vaddr) : s->vaddr
+				: s->paddr;
 				ut64 size = core->io->va? s->vsize: s->size;
 				append_bound (list, core->io, search_itv, addr, size, s->perm);
 			}

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -1004,8 +1004,7 @@ R_API RList *r_core_get_boundaries_prot(RCore *core, R_UNUSED int perm, const ch
 					continue;
 				}
 				ut64 addr = core->io->va?
-					(s->perm && R_PERM_R)? r_bin_get_vaddr(core->bin, s->paddr, s->vaddr) : s->vaddr
-				: s->paddr;
+					r_bin_file_get_vaddr(core->bin->cur, s->paddr, s->vaddr) : s->paddr;
 				ut64 size = core->io->va? s->vsize: s->size;
 				append_bound (list, core->io, search_itv, addr, size, s->perm);
 			}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`aac` on rebased (`-B`) files searches incorrect ranges. The impact of this is that it breaks autoanalysis of rebased files.

This issue was introduced by the following commit:

```
commit dec3698578a0057703af07b2f679f18bf6563c00
Author: pancake <pancake@nowsecure.com>
Date:   Fri Feb 16 12:52:27 2024 +0100

    Fix aac bug caused by anal.in on binaries with sections ##analysis
```

Below is a short description of my findings: 

In the function `cmd_anal_calls` in `libr/core/cmd_anal.inc.c`:

```
RBinFile *binfile = r_bin_cur (core->bin);
addr = core->offset;  // <--- this address is correct

if (binfile) {
    if (len) {
        // not taken
    } else {
        ranges = r_core_get_boundaries_prot (core, R_PERM_X, NULL, "anal");
    }
}

if (!binfile || (ranges && !r_list_length (ranges))) {
    // Not taken
} else {
    if (binfile) {
        r_list_foreach (ranges, iter, r) {
            addr = r->itv.addr; // <--- This address is incorrect when the sample is rebased
            _anal_calls (core, addr, r_itv_end (r->itv), printCommands, importsOnly);
        }
    }
}
```

In the function `r_core_get_boundaries_prot` in `libr/core/cmd_search.inc.c` (phase 1):

On first invocation, `mode` is set to `NULL`, which means we get the mode via `r_config_get`:

```
if (!mode) {
    mode = r_config_get (core->config, bound_in);
}
```

For me, the mode is set to: `bin.ormaps.x`, which means we end up in the corresponding `else if` to call `r_core_get_boundaries_prot` once more with the mode set to `bin.sections.x`.

Then, in the function `r_core_get_boundaries_prot` (phase 2) with mode set to `bin.sections.x`:

(Note that there are two similar `else if`s. We are triggering the `r_str_startswith (mode, "bin.sections")` one, and not the `!strcmp (mode, "bin.section")` below it.)

```
else if (r_str_startswith (mode, "bin.sections")) {
    <...>
    RBinObject *obj = r_bin_cur_object (core->bin);
    if (obj) {
        <...>
        ut64 addr = core->io->va? s->vaddr: s->paddr; // <--- This address (vaddr) is incorrect when the sample is rebased
        append_bound (list, core->io, search_itv, addr, size, s->perm); // <-- The address is passed as an argument here, leading us to search the wrong address with `aac` and consequently we find no functions
    }
```

I noticed that the sections are printed correctly with the `iS` command, and that there is some additional logic in that command to calculate the virtual address.

In the function `bin_sections` in `libr/core/cbin.c`:

```
int va_sect = va;

if (va && !(section->perm & R_PERM_R)) {
    va_sect = VA_NOREBASE;
}
ut64 addr = rva (r->bin, section->paddr, section->vaddr, va_sect);
```

Upon entry, va is `1`.

```
static ut64 rva(RBin *bin, ut64 paddr, ut64 vaddr, int va) {
    if (va == VA_TRUE) {
        if (paddr != UT64_MAX) {
            return r_bin_get_vaddr (bin, paddr, vaddr);
        }
    }
    if (va == VA_NOREBASE) {
        return vaddr;
    }
    return paddr;
}
```

This logic should boil down to:

```
ut64 addr = core->io->va?
    (s->perm && R_PERM_R)? r_bin_get_vaddr(core->bin, s->paddr, s->vaddr) : s->vaddr
: s->paddr;
```

