### PR TITLE
Adjust OpenBSD code to set the process state to be less wrong.

### DIFF
--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -189,18 +189,20 @@ RDebugInfo *bsd_info(RDebug *dbg, const char *arg) {
 		rdi->gid = kp->p__pgid;
 		rdi->exe = strdup (kp->p_comm);
 
-		rdi->status = R_DBG_PROC_STOP;
-
-		if (kp->p_psflags & PS_ZOMBIE) {
-				rdi->status = R_DBG_PROC_ZOMBIE;
-		} else if (kp->p_psflags & PS_STOPPED) {
+		switch (kp->p_stat) {
+			case SDEAD:
+				rdi->status = R_DBG_PROC_DEAD;
+				break;
+			case SSTOP:
 				rdi->status = R_DBG_PROC_STOP;
-		} else if (kp->p_psflags & PS_PPWAIT) {
+				break;
+			case SSLEEP:
 				rdi->status = R_DBG_PROC_SLEEP;
-		} else if ((kp->p_psflags & PS_EXEC) || (kp->p_psflags & PS_INEXEC)) {
+				break;
+			default:
 				rdi->status = R_DBG_PROC_RUN;
+				break;
 		}
-
 	}
 
 	kvm_close (kd);


### PR DESCRIPTION
Use the p_stat of the main thread to decide in which state the process is. For multi-threaded applications this is still not quite correct but at least this compiles on OpenBSD-current.

See also https://github.com/openbsd/ports/commit/290aac569141a2c69255a1dc864d2053249031e1

Fix for #23158

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
