### PR TITLE
horisontal swipe in termux

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -179,6 +179,10 @@ R_API int r_cons_arrow_to_hjkl(int ch) {
 					return 'k';
 				case 65: // wheel down
 					return 'j';
+				case 66: // wheel left
+					return 'h';
+				case 67: // wheel right
+					return 'l';
 				}
 				pos[p++] = 0;
 				y = atoi (pos);

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4581,8 +4581,10 @@ R_API int r_core_visual_graph(RCore *core, RAGraph *g, RAnalFunction *_fcn, int 
 		if (core->cons->mouse_event) {
 			movspeed = r_config_get_i (core->config, "scr.wheel.speed");
 			switch (key) {
+			case 'h':
 			case 'j':
 			case 'k':
+			case 'l':
 				switch (core->visual.mousemode) {
 				case 0: break;
 				case 1: key = key == 'k'? 'h': 'l'; break;


### PR DESCRIPTION
normal panning works now in termux. the graph follows the finger 

```
binr/radare2/radare2 -c "aa;s main;VV" binr/rabin2/rabin2
```

this branch emit the horizontal codes

https://github.com/john-peterson/termux-app/tree/scroll