### PR TITLE
Fix null format when displaying unknown argument types ##decompiler

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5404,7 +5404,7 @@ static void print_fcn_arg(RCore *core, int nth, const char *type, const char *na
 	if (on_stack == 1 && asm_types > 1) {
 		r_cons_printf ("%s", type);
 	}
-	if (addr != UT32_MAX && addr != UT64_MAX  && addr != 0) {
+	if (fmt && addr != UT32_MAX && addr != UT64_MAX  && addr != 0) {
 		char *res = r_core_cmd_strf (core, "pf%s %s%s %s @ 0x%08" PFMT64x,
 				(asm_types==2)? "": "q", (on_stack == 1) ? "*" : "", fmt, name, addr);
 		r_str_trim (res);

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -568,7 +568,7 @@ R_API int r_core_pseudo_code(RCore *core, const char *input) {
 					if (!sdb_get (db, K_INDENT (fail), 0)) {
 						bb = r_anal_bb_from_offset (core->anal, fail);
 					} else {
-						R_LOG_ERROR ("sdb.get fail");
+						R_LOG_ERROR ("pdc: unknown branch from 0x%08"PFMT64x, jump);
 					}
 				} else {
 					bb = r_anal_bb_from_offset (core->anal, jump);

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1876,7 +1876,6 @@ R_API int r_print_format_struct_size(RPrint *p, const char *f, int mode, int n) 
 				size += tabsize * 8;
 			} else {
 				R_LOG_ERROR ("Invalid n format in (%s)", fmt);
-				r_sys_breakpoint ();
 				free (o);
 				free (args);
 				return -2;

--- a/libr/util/format.c
+++ b/libr/util/format.c
@@ -1866,16 +1866,17 @@ R_API int r_print_format_struct_size(RPrint *p, const char *f, int mode, int n) 
 			break;
 		case 'n':
 		case 'N':
-			if (fmt[i+1] == '1') {
+			if (fmt[i + 1] == '1') {
 				size += tabsize * 1;
-			} else if (fmt[i+1] == '2') {
+			} else if (fmt[i + 1] == '2') {
 				size += tabsize * 2;
-			} else if (fmt[i+1] == '4') {
+			} else if (fmt[i + 1] == '4') {
 				size += tabsize * 4;
-			} else if (fmt[i+1] == '8') {
+			} else if (fmt[i + 1] == '8') {
 				size += tabsize * 8;
 			} else {
 				R_LOG_ERROR ("Invalid n format in (%s)", fmt);
+				r_sys_breakpoint ();
 				free (o);
 				free (args);
 				return -2;


### PR DESCRIPTION
* r2 -qc pdc /bin/sleep

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
