### PR TITLE
Add ESIL translation for `movn` instruction (fixes #23286) ##emu

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -456,6 +456,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 					ARG (2), ARG (1), REG (0));
 			}
 			break;
+		case MIPS_INS_MOVN:
 		case MIPS_INS_MOVT:
 			PROTECT_ZERO () {
 				r_strbuf_appendf (&op->esil, "1,%s,==,$z,?{,%s,%s,=,}",


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add missing translation for MIPS `movn` instruction.
Its a conditional move instruction with semantics

            movn d,s,t      if (t) d = s;

Which is quite similar to the existing:

            movt d,s,$fccN  if (fcc(N)) d = s;

In fact, we can reuse the exact same implementation.

PS: Would be nice if someone could explain to me what the `$z` does and why it is there. 