### PR TITLE
Add WASI API into release files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: linux-wasi-api
-        path: radare2-*-wasi.zip
+        path: radare2-*-wasi-api.zip
   # capstone-next
   linux-csnext:
     runs-on: ubuntu-22.04
@@ -670,6 +670,7 @@ jobs:
         dist/artifacts/linux-static/*.tar.xz
         dist/artifacts/linux-acr-deb-*/radare2-dev_*.deb
         dist/artifacts/linux-wasi/*.zip
+        dist/artifacts/linux-wasi-api/*.zip
         dist/artifacts/w64-static/*.zip
     steps:
       - name: Checkout code

--- a/sys/wasi-api.sh
+++ b/sys/wasi-api.sh
@@ -40,7 +40,7 @@ ERR=0
 ./configure --with-static-themes --without-gperf --with-compiler=wasi --disable-debugger --without-fork --with-ostype=wasi-api --with-checks-level=0 --disable-threads --without-dylink --with-libr --without-gpl
 make -j
 R2V=`./configure -qV`
-D="radare2-$R2V-wasi"
+D="radare2-$R2V-wasi-api"
 mkdir -p $D
 for a in ${TOOLS} ; do
 	make -C binr/$a


### PR DESCRIPTION
Renamed WASI API zip (and subfolder) to include -api in their name.
And added into the release files list.