### PR TITLE
Fix null deref bug in the swift demangler ##crash

### DIFF
--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -844,7 +844,11 @@ repeat:;
 							r_strbuf_appendf (out, "...%s", q);
 							break;
 						}
-						q = n + 1;
+						if (n) {
+							q = n + 1;
+						} else {
+							q++;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
