### PR TITLE
Fix ESIL of `movn` insn (MIPS) ##emu

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -495,6 +495,11 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 			}
 			break;
 		case MIPS_INS_MOVN:
+			PROTECT_ZERO () {
+				r_strbuf_appendf (&op->esil, "0,%s,==,$z,!,?{,%s,%s,=,}",
+					ARG (2), ARG (1), REG (0));
+			}
+			break;
 		case MIPS_INS_MOVT:
 			PROTECT_ZERO () {
 				r_strbuf_appendf (&op->esil, "1,%s,==,$z,?{,%s,%s,=,}",

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -965,6 +965,10 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		r_strbuf_appendf (&op->esil, "0,%s,==,$z,?{,%s,%s,=,}",
 			R_REG (rt), R_REG (rs), R_REG (rd));
 		break;
+	case MIPS_INS_MOVN:
+		r_strbuf_appendf (&op->esil, "0,%s,==,$z,!,?{,%s,%s,=,}",
+			R_REG (rt), R_REG (rs), R_REG (rd));
+		break;
 	case MIPS_INS_MOVT:
 		r_strbuf_appendf (&op->esil, "1,%s,==,$z,?{,%s,%s,=,}",
 			R_REG (rt), R_REG (rs), R_REG (rd));


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The semantics of `movn` and `movt` are:

```
MOVN rd, rs, rt
If the value in GPR rt is not equal to zero, then the contents of GPR rs are placed into GPR rd.
```

and

```
MOVT rd, rs, cc
If the floating-point condition code specified by cc is one then the contents of GPR rs are placed into GPR rd.
```

respectively.

Thus, my previous assessment in #23295 that the same case can be used is wrong. This PR should correct the situation by giving it its own case. It also adds the insn for GNU Mips.