### PR TITLE
Assume x27 as global pointer only in dart binaries ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5834,13 +5834,10 @@ R_API void r_core_anal_esil(RCore *core, const char *str /* len */, const char *
 		gp_reg = "gp";
 		arch = R2_ARCH_MIPS;
 	} else if (arch == R2_ARCH_ARM64) {
-		// Dart binaries only
-		char *s = r_core_cmd_str (core, "i~lang~dart");
-		r_str_trim (s);
-		if (R_STR_ISNOTEMPTY (s)) {
+		RBinInfo *info = r_bin_get_info (core->bin);
+		if (info && info->lang && !strcmp (info->lang, "dart")) {
 			gp_reg = "x27";
 		}
-		free (s);
 	}
 
 	r_reg_arena_push (core->anal->reg);

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5835,7 +5835,12 @@ R_API void r_core_anal_esil(RCore *core, const char *str /* len */, const char *
 		arch = R2_ARCH_MIPS;
 	} else if (arch == R2_ARCH_ARM64) {
 		// Dart binaries only
-		gp_reg = "x27";
+		char *s = r_core_cmd_str (core, "i~lang~dart");
+		r_str_trim (s);
+		if (R_STR_ISNOTEMPTY (s)) {
+			gp_reg = "x27";
+		}
+		free (s);
 	}
 
 	r_reg_arena_push (core->anal->reg);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
