### PR TITLE
Throw error when python>3.11 in preconfigure.bat ##build

### DIFF
--- a/preconfigure.bat
+++ b/preconfigure.bat
@@ -8,6 +8,11 @@ echo === Finding Python...
 python --version > NUL 2> NUL
 if %ERRORLEVEL% == 0 (
   echo OK
+  pip show setuptools 1> NUL
+  if not errorlevel 1 (
+    echo === Installing setuptools
+    python -m pip install -UI pip setuptools
+  )
 ) else (
   echo ERROR
   echo You need to install Python from the windows store or something


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
