### PR TITLE
Fix preconfigure.bat setuptools installation ##build

### DIFF
--- a/preconfigure.bat
+++ b/preconfigure.bat
@@ -8,8 +8,8 @@ echo === Finding Python...
 python --version > NUL 2> NUL
 if %ERRORLEVEL% == 0 (
   echo OK
-  pip show setuptools 1> NUL
-  if not errorlevel 1 (
+  pip show setuptools > NUL 1> NUL
+  if errorlevel 1 (
     echo === Installing setuptools
     python -m pip install -UI pip setuptools
   )


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

Now it will work. batch error handling is a mess.