### PR TITLE
Emit span instead of font in the scr.html filter ##cons

### DIFF
--- a/libr/cons/html.c
+++ b/libr/cons/html.c
@@ -51,14 +51,16 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 	for (; ptr[0]; ptr++) {
 		if (esc == 0 && ptr[0] != 0x1b && need_to_set) {
 			if (has_set) {
-				r_strbuf_append (res, "</font>");
+				r_strbuf_append (res, "</span>");
 				has_set = false;
 			}
 			if (!need_to_clear) {
 				first_style = true;
-				r_strbuf_append (res, "<font");
+				r_strbuf_append (res, "<span");
 				if (text_color[0]) {
-					r_strbuf_appendf (res, " color='%s'", text_color);
+					r_strbuf_append (res, first_style? " style='": ";");
+					r_strbuf_appendf (res, "color:%s", text_color);
+					first_style = false;
 				}
 				if (background_color[0]) {
 					r_strbuf_append (res, first_style? " style='": ";");
@@ -251,7 +253,7 @@ R_API char *r_cons_html_filter(const char *ptr, int *newlen) {
 		r_strbuf_append_n (res, str, ptr - str);
 	}
 	if (has_set) {
-		r_strbuf_append (res, "</font>");
+		r_strbuf_append (res, "</span>");
 	}
 	if (newlen) {
 		*newlen = res->len;

--- a/test/unit/test_cons.c
+++ b/test/unit/test_cons.c
@@ -122,44 +122,44 @@ bool test_cons_to_html(void) {
 	char *html;
 
 	html = r_cons_html_filter ("\x1b[32mhello\x1b[0m", NULL);
-	mu_assert_streq_free (html, "<font color='#0f0'>hello</font>", "Simple font color");
+	mu_assert_streq_free (html, "<span style='color:#0f0'>hello</span>", "Simple font color");
 
 	html = r_cons_html_filter ("\x1b[31mhello\x1b[0mabc", NULL);
-	mu_assert_streq_free (html, "<font color='#f00'>hello</font>abc", "Simple font color2");
+	mu_assert_streq_free (html, "<span style='color:#f00'>hello</span>abc", "Simple font color2");
 
 	html = r_cons_html_filter ("\x1b[31mhe\x1b[44mllo\x1b[0mabc", NULL);
-	mu_assert_streq_free (html, "<font color='#f00'>he</font><font color='#f00' style='background-color:#00f'>llo</font>abc", "Color and background");
+	mu_assert_streq_free (html, "<span style='color:#f00'>he</span><span style='color:#f00;background-color:#00f'>llo</span>abc", "Color and background");
 
 	html = r_cons_html_filter ("\x1b[44mhe\x1b[31mllo\x1b[0mabc", NULL);
-	mu_assert_streq_free (html, "<font style='background-color:#00f'>he</font><font color='#f00' style='background-color:#00f'>llo</font>abc", "Background and color");
+	mu_assert_streq_free (html, "<span style='background-color:#00f'>he</span><span style='color:#f00;background-color:#00f'>llo</span>abc", "Background and color");
 
 	html = r_cons_html_filter ("AA\x1b[31mBB\x1b[32mCC\x1b[0mDD", NULL);
-	mu_assert_streq_free (html, "AA<font color='#f00'>BB</font><font color='#0f0'>CC</font>DD", "Switch color");
+	mu_assert_streq_free (html, "AA<span style='color:#f00'>BB</span><span style='color:#0f0'>CC</span>DD", "Switch color");
 
 	html = r_cons_html_filter ("AA\x1b[31mBB\x1b[32m\x1b[41mCC\x1b[0mDD", NULL);
-	mu_assert_streq_free (html, "AA<font color='#f00'>BB</font><font color='#0f0' style='background-color:#f00'>CC</font>DD", "Multiple changes");
+	mu_assert_streq_free (html, "AA<span style='color:#f00'>BB</span><span style='color:#0f0;background-color:#f00'>CC</span>DD", "Multiple changes");
 
 	html = r_cons_html_filter ("\x1b[33m0x0005d01\x1b[0m \x1b[36mand\x1b[36m foo", NULL);
-	mu_assert_streq_free (html, "<font color='#ff0'>0x0005d01</font>&nbsp;<font color='#aaf'>and</font><font color='#aaf'>&nbsp;foo</font>", "Space and reset");
+	mu_assert_streq_free (html, "<span style='color:#ff0'>0x0005d01</span>&nbsp;<span style='color:#aaf'>and</span><span style='color:#aaf'>&nbsp;foo</span>", "Space and reset");
 
 	html = r_cons_html_filter ("\x1b[33mAAAA\x1b[7mBBBB\x1b[33mBBB\x1b[0mCCC", NULL);
-	mu_assert_streq_free (html, "<font color='#ff0'>AAAA</font>"
-				    "<font color='#ff0' style='text-decoration:underline overline'>BBBB</font>"
-				    "<font color='#ff0' style='text-decoration:underline overline'>BBB</font>CCC",
+	mu_assert_streq_free (html, "<span style='color:#ff0'>AAAA</span>"
+				    "<span style='color:#ff0;text-decoration:underline overline'>BBBB</span>"
+				    "<span style='color:#ff0;text-decoration:underline overline'>BBB</span>CCC",
 		"Invert");
 
 	html = r_cons_html_filter ("\x1b[33mAAAA\x1b[7mBBBB\x1b[33mBBB\x1b[27mCCC", NULL);
-	mu_assert_streq_free (html, "<font color='#ff0'>AAAA</font>"
-				    "<font color='#ff0' style='text-decoration:underline overline'>BBBB</font>"
-				    "<font color='#ff0' style='text-decoration:underline overline'>BBB</font><font color='#ff0'>CCC</font>",
+	mu_assert_streq_free (html, "<span style='color:#ff0'>AAAA</span>"
+				    "<span style='color:#ff0;text-decoration:underline overline'>BBBB</span>"
+				    "<span style='color:#ff0;text-decoration:underline overline'>BBB</span><span style='color:#ff0'>CCC</span>",
 		"Invert rest");
 
 	html = r_cons_html_filter ("\x1b[41m\x1b[31mBB\x1b[39mCC", NULL);
-	mu_assert_streq_free (html, "<font color='#f00' style='background-color:#f00'>BB</font>"
-		"<font style='background-color:#f00'>CC</font>", "Default font color color");
+	mu_assert_streq_free (html, "<span style='color:#f00;background-color:#f00'>BB</span>"
+		"<span style='background-color:#f00'>CC</span>", "Default font color color");
 
 	html = r_cons_html_filter ("\x1b[41m\x1b[31mBB\x1b[49mCC", NULL);
-	mu_assert_streq_free (html, "<font color='#f00' style='background-color:#f00'>BB</font><font color='#f00'>CC</font>", "Default background color");
+	mu_assert_streq_free (html, "<span style='color:#f00;background-color:#f00'>BB</span><span style='color:#f00'>CC</span>", "Default background color");
 
 	mu_end;
 }


### PR DESCRIPTION
The font HTML element is deprecated.

- [x] Mark this if you consider it ready to merge
- [x] I've ~added~ updated tests (optional)
- [/] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)