### PR TITLE
Store plugin's by name rather than path

### DIFF
--- a/libr/arch/p/6502/pseudo.c
+++ b/libr/arch/p/6502/pseudo.c
@@ -180,6 +180,8 @@ RParsePlugin r_parse_plugin_6502_pseudo = {
 	.meta = {
 		.name = "6502.pseudo",
 		.desc = "6502 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/arm/pseudo.c
+++ b/libr/arch/p/arm/pseudo.c
@@ -487,6 +487,8 @@ RParsePlugin r_parse_plugin_arm_pseudo = {
 	.meta = {
 		.name = "arm.pseudo",
 		.desc = "ARM/ARM64 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 	.subvar = &subvar,

--- a/libr/arch/p/avr/pseudo.c
+++ b/libr/arch/p/avr/pseudo.c
@@ -212,6 +212,8 @@ RParsePlugin r_parse_plugin_avr_pseudo = {
 	.meta = {
 		.name = "avr.pseudo",
 		.desc = "AVR pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse
 };

--- a/libr/arch/p/bpf/pseudo.c
+++ b/libr/arch/p/bpf/pseudo.c
@@ -86,6 +86,8 @@ RParsePlugin r_parse_plugin_bpf_pseudo = {
 	.meta = {
 		.name = "bpf.pseudo",
 		.desc = "bpf pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/chip8/pseudo.c
+++ b/libr/arch/p/chip8/pseudo.c
@@ -108,6 +108,8 @@ RParsePlugin r_parse_plugin_chip8_pseudo = {
 	.meta = {
 		.name = "chip8.pseudo",
 		.desc = "chip8 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/dalvik/pseudo.c
+++ b/libr/arch/p/dalvik/pseudo.c
@@ -360,6 +360,8 @@ RParsePlugin r_parse_plugin_dalvik_pseudo = {
 	.meta = {
 		.name = "dalvik.pseudo",
 		.desc = "DALVIK pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/evm/pseudo.c
+++ b/libr/arch/p/evm/pseudo.c
@@ -90,6 +90,8 @@ RParsePlugin r_parse_plugin_evm_pseudo = {
 	.meta = {
 		.name = "evm.pseudo",
 		.desc = "evm pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/m68k_cs/pseudo.c
+++ b/libr/arch/p/m68k_cs/pseudo.c
@@ -196,6 +196,8 @@ RParsePlugin r_parse_plugin_m68k_pseudo = {
 	.meta = {
 		.name = "m68k.pseudo",
 		.desc = "M68K pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/mips/pseudo.c
+++ b/libr/arch/p/mips/pseudo.c
@@ -368,6 +368,8 @@ RParsePlugin r_parse_plugin_mips_pseudo = {
 	.meta = {
 		.name = "mips.pseudo",
 		.desc = "MIPS pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 	.subvar = subvar,

--- a/libr/arch/p/null/pseudo.c
+++ b/libr/arch/p/null/pseudo.c
@@ -6,6 +6,8 @@ RParsePlugin r_parse_plugin_null_pseudo = {
 	.meta = {
 		.name = "null.pseudo",
 		.desc = "pseudo nothing",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	}
 };
 

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -1749,6 +1749,8 @@ RParsePlugin r_parse_plugin_ppc_pseudo = {
 	.meta = {
 		.name = "ppc.pseudo",
 		.desc = "PowerPC pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/riscv/pseudo.c
+++ b/libr/arch/p/riscv/pseudo.c
@@ -218,6 +218,8 @@ RParsePlugin r_parse_plugin_riscv_pseudo = {
 	.meta = {
 		.name = "riscv.pseudo",
 		.desc = "riscv pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/sh/pseudo.c
+++ b/libr/arch/p/sh/pseudo.c
@@ -268,6 +268,8 @@ RParsePlugin r_parse_plugin_sh_pseudo = {
 	.meta = {
 		.name = "sh.pseudo",
 		.desc = "SH-4 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse
 };

--- a/libr/arch/p/stm8/pseudo.c
+++ b/libr/arch/p/stm8/pseudo.c
@@ -227,6 +227,8 @@ RParsePlugin r_parse_plugin_stm8_pseudo = {
 	.meta = {
 		.name = "stm8.pseudo",
 		.desc = "STM8 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/tms320/pseudo.c
+++ b/libr/arch/p/tms320/pseudo.c
@@ -178,6 +178,8 @@ RParsePlugin r_parse_plugin_tms320_pseudo = {
 	.meta = {
 		.name = "tms320.pseudo",
 		.desc = "tms320 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 };

--- a/libr/arch/p/tricore/pseudo.c
+++ b/libr/arch/p/tricore/pseudo.c
@@ -465,6 +465,8 @@ RParsePlugin r_parse_plugin_tricore_pseudo = {
 	.meta = {
 		.name = "tricore.pseudo",
 		.desc = "TriCore pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = &parse,
 	.subvar = &subvar,

--- a/libr/arch/p/v850/pseudo.c
+++ b/libr/arch/p/v850/pseudo.c
@@ -224,6 +224,8 @@ RParsePlugin r_parse_plugin_v850_pseudo = {
 	.meta = {
 		.name = "v850.pseudo",
 		.desc = "v850 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = parse,
 	.subvar = &subvar,

--- a/libr/arch/p/wasm/pseudo.c
+++ b/libr/arch/p/wasm/pseudo.c
@@ -30,6 +30,8 @@ RParsePlugin r_parse_plugin_wasm_pseudo = {
 	.meta = {
 		.name = "wasm.pseudo",
 		.desc = "WASM pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.subvar = &subvar,
 };

--- a/libr/arch/p/x86_nz/att2intel.c
+++ b/libr/arch/p/x86_nz/att2intel.c
@@ -168,6 +168,8 @@ RParsePlugin r_parse_plugin_att2intel = {
 	.meta = {
 		.name = "att2intel",
 		.desc = "X86 att 2 intel plugin",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = &parse,
 };

--- a/libr/arch/p/x86_nz/pseudo.c
+++ b/libr/arch/p/x86_nz/pseudo.c
@@ -577,6 +577,8 @@ RParsePlugin r_parse_plugin_x86_pseudo = {
 	.meta = {
 		.name = "x86.pseudo",
 		.desc = "X86 pseudo syntax",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
 	},
 	.parse = &parse,
 	.subvar = &subvar,

--- a/libr/bp/bp_plugin.c
+++ b/libr/bp/bp_plugin.c
@@ -7,7 +7,7 @@ R_API int r_bp_plugin_del(RBreakpoint *bp, const char *name) {
 	RBreakpointPlugin *h;
 	if (name && *name) {
 		r_list_foreach (bp->plugins, iter, h) {
-			if (!strcmp (h->name, name)) {
+			if (!strcmp (h->meta.name, name)) {
 				if (bp->cur == h) {
 					bp->cur = NULL;
 				}
@@ -29,7 +29,7 @@ R_API int r_bp_plugin_add(RBreakpoint *bp, RBreakpointPlugin *foo) {
 	}
 	/* avoid dupped plugins */
 	r_list_foreach (bp->bps, iter, h) {
-		if (!strcmp (h->name, foo->name)) {
+		if (!strcmp (h->meta.name, foo->meta.name)) {
 			return false;
 		}
 	}
@@ -48,7 +48,7 @@ R_API int r_bp_use(RBreakpoint *bp, const char *name, int bits) {
 	bp->bits = bits;
 	RBreakpointPlugin *h;
 	r_list_foreach (bp->plugins, iter, h) {
-		if (!strcmp (h->name, name)) {
+		if (!strcmp (h->meta.name, name)) {
 			bp->cur = h;
 			return true;
 		}
@@ -62,7 +62,7 @@ R_API void r_bp_plugin_list(RBreakpoint *bp) {
 	RBreakpointPlugin *b;
 	r_list_foreach (bp->plugins, iter, b) {
 		bp->cb_printf ("bp %c %s\n",
-			(bp->cur && !strcmp (bp->cur->name, b->name))? '*': '-',
-			b->name);
+			(bp->cur && !strcmp (bp->cur->meta.name, b->meta.name))? '*': '-',
+			b->meta.name);
 	}
 }

--- a/libr/bp/p/bp_arm.c
+++ b/libr/bp/p/bp_arm.c
@@ -31,7 +31,12 @@ static RBreakpointArch r_bp_plugin_arm_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_arm = {
-	.name = "arm",
+	.meta = {
+		.name = "arm",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "arm",
 	.nbps = 10,
 	.bps = r_bp_plugin_arm_bps,

--- a/libr/bp/p/bp_bf.c
+++ b/libr/bp/p/bp_bf.c
@@ -10,7 +10,12 @@ static RBreakpointArch r_bp_plugin_bf_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_bf = {
-	.name = "bf",
+	.meta = {
+		.name = "bf",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "bf",
 	.nbps = 2,
 	.bps = r_bp_plugin_bf_bps,

--- a/libr/bp/p/bp_mips.c
+++ b/libr/bp/p/bp_mips.c
@@ -12,7 +12,12 @@ static RBreakpointArch r_bp_plugin_mips_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_mips = {
-	.name = "mips",
+	.meta = {
+		.name = "mips",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "mips",
 	.nbps = 4,
 	.bps = r_bp_plugin_mips_bps,

--- a/libr/bp/p/bp_null.c
+++ b/libr/bp/p/bp_null.c
@@ -8,7 +8,12 @@ static RBreakpointArch r_bp_plugin_null_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_null = {
-	.name = "null",
+	.meta = {
+		.name = "null",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "null",
 	.nbps = 0,
 	.bps = r_bp_plugin_null_bps,

--- a/libr/bp/p/bp_ppc.c
+++ b/libr/bp/p/bp_ppc.c
@@ -11,7 +11,12 @@ static RBreakpointArch r_bp_plugin_ppc_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_ppc = {
-	.name = "ppc",
+	.meta = {
+		.name = "ppc",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "ppc",
 	.nbps = 2,
 	.bps = r_bp_plugin_ppc_bps,

--- a/libr/bp/p/bp_riscv.c
+++ b/libr/bp/p/bp_riscv.c
@@ -10,7 +10,12 @@ static RBreakpointArch r_bp_plugin_riscv_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_riscv = {
-	.name = "riscv",
+	.meta = {
+		.name = "riscv",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "riscv",
 	.nbps = 2,
 	.bps = r_bp_plugin_riscv_bps,

--- a/libr/bp/p/bp_s390x.c
+++ b/libr/bp/p/bp_s390x.c
@@ -11,7 +11,12 @@ static RBreakpointArch r_bp_plugin_s390x_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_s390x = {
-	.name = "s390",
+	.meta = {
+		.name = "s390",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "s390",
 	.nbps = 3,
 	.bps = r_bp_plugin_s390x_bps,

--- a/libr/bp/p/bp_sh.c
+++ b/libr/bp/p/bp_sh.c
@@ -10,7 +10,12 @@ static RBreakpointArch r_bp_plugin_sh_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_sh = {
-	.name = "sh",
+	.meta = {
+		.name = "sh",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "sh",
 	.nbps = 2,
 	.bps = r_bp_plugin_sh_bps,

--- a/libr/bp/p/bp_x86.c
+++ b/libr/bp/p/bp_x86.c
@@ -10,7 +10,12 @@ static RBreakpointArch r_bp_plugin_x86_bps[] = {
 };
 
 RBreakpointPlugin r_bp_plugin_x86 = {
-	.name = "x86",
+	.meta = {
+		.name = "x86",
+		.desc = "",
+		.author = "pancake",
+		.license = "LGPL-3.0-only",
+	},
 	.arch = "x86",
 	.nbps = 2,
 	.bps = r_bp_plugin_x86_bps,

--- a/libr/core/cmd_log.inc.c
+++ b/libr/core/cmd_log.inc.c
@@ -17,7 +17,7 @@ static RCoreHelpMessage help_msg_L = {
 	"Usage:", "L[acio]", "[-name][ file]",
 	"L",  "", "show this help",
 	"L", " blah."R_LIB_EXT, "load plugin file",
-	"L-", "duk", "unload core plugin by name",
+	"L-", "duk", "unload core plugin by name or file name",
 	"La", "[qj]", "list arch plugins",
 	"LA", "[qj]", "list analysis plugins",
 	"Lb", "[qj]", "list bin plugins",
@@ -623,6 +623,15 @@ static int cmd_plugins(void *data, const char *input) {
 			r_list_foreach (core->rcmd->plist, iter, cp) {
 				pj_o (pj);
 				r_lib_meta_pj (pj, &cp->meta);
+				if (cp->meta.name) {
+					bool found;
+					RLibPlugin *plugin = ht_pp_find (core->lib->plugins_ht, cp->meta.name, &found);
+					if (found && plugin) {
+						if (plugin->file) {
+							pj_ks (pj, "path", plugin->file);
+						}
+					}
+				}
 				pj_end (pj);
 			}
 			pj_end (pj);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2855,6 +2855,7 @@ R_API void r_core_fini(RCore *c) {
 	r_list_free (c->watchers);
 	r_list_free (c->scriptstack);
 	r_core_task_scheduler_fini (&c->tasks);
+	r_lib_free (c->lib);
 	c->rcmd = r_cmd_free (c->rcmd);
 	r_list_free (c->cmd_descriptors);
 	/*
@@ -2864,7 +2865,6 @@ R_API void r_core_fini(RCore *c) {
 	if (c->anal->esil) {
 		c->anal->esil->anal = NULL;
 	}
-	r_lib_free (c->lib);
 	r_anal_free (c->anal);
 	r_asm_free (c->rasm);
 	c->rasm = NULL;

--- a/libr/core/libs.c
+++ b/libr/core/libs.c
@@ -3,34 +3,38 @@
 #include "r_core.h"
 #include "config.h"
 
-#define CB(x, y)\
-	static int __lib_ ## x ## _cb (RLibPlugin * pl, void *user, void *data) {\
-		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data;\
-		RCore *core = (RCore *) user;\
-		pl->free = NULL; \
-		r_ ## x ## _plugin_add (core->y, hand);\
-		return true;\
-	}\
-	static int __lib_ ## x ## _dt (RLibPlugin * pl, void *user, void *data) { \
+#define CB(x, y) \
+	static int __lib_ ## x ## _cb (RLibPlugin *pl, void *user, void *data) { \
 		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data; \
-		RCore *core = (RCore *) user; \
+		RCore *core = (RCore *)user; \
+		pl->free = NULL; \
+		pl->name = strdup (hand->meta.name); \
+		r_ ## x ## _plugin_add (core->y, hand); \
+		return true; \
+	} \
+	static int __lib_ ## x ## _dt (RLibPlugin *pl, void *user, void *data) { \
+		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data; \
+		RCore *core = (RCore *)user; \
+		free (pl->name); \
 		return r_ ## x ## _plugin_remove (core->y, hand); \
 	}
 
 // TODO: deprecate this
-#define CB_COPY(x, y)\
-	static int __lib_ ## x ## _cb (RLibPlugin * pl, void *user, void *data) {\
-		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data;\
-		struct r_ ## x ## _plugin_t *instance;\
-		RCore *core = (RCore *) user;\
-		instance = R_NEW (struct r_ ## x ## _plugin_t);\
-		memcpy (instance, hand, sizeof (struct r_ ## x ## _plugin_t));\
-		r_ ## x ## _plugin_add (core->y, instance);\
-		return true;\
-	}\
+#define CB_COPY(x, y) \
+	static int __lib_ ## x ## _cb (RLibPlugin *pl, void *user, void *data) { \
+		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data; \
+		struct r_ ## x ## _plugin_t *instance; \
+		RCore *core = (RCore *)user; \
+		instance = R_NEW (struct r_ ## x ## _plugin_t); \
+		memcpy (instance, hand, sizeof (struct r_ ## x ## _plugin_t)); \
+		pl->name = strdup (hand->meta.name); \
+		r_ ## x ## _plugin_add (core->y, instance); \
+		return true; \
+	} \
 	static int __lib_ ## x ## _dt (RLibPlugin *pl, void *user, void *data) { \
 		struct r_ ## x ## _plugin_t *hand = (struct r_ ## x ## _plugin_t *)data; \
-		RCore *core = (RCore *) user; \
+		RCore *core = (RCore *)user; \
+		free (pl->name); \
 		return r_ ## x ## _plugin_remove (core->y, hand); \
 	}
 

--- a/libr/include/r_bp.h
+++ b/libr/include/r_bp.h
@@ -15,7 +15,6 @@ R_LIB_VERSION_HEADER(r_bp);
 #define R_BP_MAXPIDS 10
 #define R_BP_CONT_NORMAL 0
 #define R_BP_CONT_NORMAL 0
-
 typedef struct r_bp_arch_t {
 	int bits;
 	int length;
@@ -32,7 +31,7 @@ enum {
 };
 
 typedef struct r_bp_plugin_t {
-	char *name;
+	RPluginMeta meta;
 	char *arch;
 	int type; // R_BP_TYPE_SW
 	int nbps;

--- a/libr/include/r_lib.h
+++ b/libr/include/r_lib.h
@@ -62,9 +62,7 @@ typedef struct r_lib_plugin_t {
 	struct r_lib_handler_t *handler;
 	void *dl_handler; // DL HANDLER
 	void (*free)(void *data);
-#if 0
-	RPluginMeta meta;
-#endif
+	char *name; // From the RPluginMeta's name
 } RLibPlugin;
 
 /* store list of initialized plugin handlers */
@@ -111,7 +109,6 @@ enum {
 	R_LIB_TYPE_LAST
 };
 
-typedef int (*RLibLifeCycleCallback)(RLibPlugin *, void *, void *);
 
 typedef struct r_lib_t {
 	/* linked list with all the plugin handler */


### PR DESCRIPTION

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
So I was looking at #22445 and I figured it would be interesting to store plugins in the hash table by their names instead of their paths.
It makes it easier to detect duplicates and easier to get the path from which the plugin was loaded, but this is more of a proposition.
Code is a little awkward in some places, looking for feedback.