### PR TITLE
Fix #21171 - Infinite loop caused by a weak tovisit check on large functions

### DIFF
--- a/libr/anal/block.c
+++ b/libr/anal/block.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2019-2023 - pancake, thestr4ng3r */
+/* radare - LGPL - Copyright 2019-2024 - pancake, thestr4ng3r */
 
 #include <r_anal.h>
 #include <r_hash.h>

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -664,16 +664,16 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 		existing_bb = r_anal_block_split (existing_bb, addr);
 		if (!existing_in_fcn && existing_bb) {
 			if (existing_bb->addr == fcn->addr) {
-#if 1
-				r_list_delete_data (fcn->bbs, existing_bb);
-				r_anal_block_unref (existing_bb);
-				R_LOG_INFO ("Basic block collides with function 0x%08"PFMT64x, fcn->addr);
-				// our function starts directly there, so we steal what is ours!
-				return R_ANAL_RET_END; // MUST BE NOT FOUND
-#else
-				// XXX this call causes an infinite loop if not commented
-				fcn_takeover_block_recursive (fcn, existing_bb);
-#endif
+				if (anal->opt.slow) {
+					// XXX this call causes an infinite loop if not commented
+					fcn_takeover_block_recursive (fcn, existing_bb);
+				} else {
+					r_list_delete_data (fcn->bbs, existing_bb);
+					r_anal_block_unref (existing_bb);
+					R_LOG_INFO ("Basic block collides with function 0x%08"PFMT64x, fcn->addr);
+					// our function starts directly there, so we steal what is ours!
+					return R_ANAL_RET_END; // MUST BE NOT FOUND
+				}
 			}
 		}
 		// r_unref (existing_bb);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -664,8 +664,16 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 		existing_bb = r_anal_block_split (existing_bb, addr);
 		if (!existing_in_fcn && existing_bb) {
 			if (existing_bb->addr == fcn->addr) {
+#if 1
+				r_list_delete_data (fcn->bbs, existing_bb);
+				r_anal_block_unref (existing_bb);
+				R_LOG_INFO ("Basic block collides with function 0x%08"PFMT64x, fcn->addr);
 				// our function starts directly there, so we steal what is ours!
+				return R_ANAL_RET_END; // MUST BE NOT FOUND
+#else
+				// XXX this call causes an infinite loop if not commented
 				fcn_takeover_block_recursive (fcn, existing_bb);
+#endif
 			}
 		}
 		// r_unref (existing_bb);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -666,13 +666,13 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 			if (existing_bb->addr == fcn->addr) {
 				if (anal->opt.slow) {
 					// XXX this call causes an infinite loop if not commented
+					// our function starts directly there, so we steal what is ours!
 					fcn_takeover_block_recursive (fcn, existing_bb);
 				} else {
 					r_list_delete_data (fcn->bbs, existing_bb);
-					r_anal_block_unref (existing_bb);
 					R_LOG_INFO ("Basic block collides with function 0x%08"PFMT64x, fcn->addr);
-					// our function starts directly there, so we steal what is ours!
-					return R_ANAL_RET_END; // MUST BE NOT FOUND
+					// r_anal_block_unref (existing_bb);
+					// return R_ANAL_RET_END; // MUST BE NOT FOUND
 				}
 			}
 		}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5188,7 +5188,7 @@ bool fcn_merge_touch_cb(ut64 addr, struct r_merge_ctx_t *ctx) {
 
 /* Adds BB to function */
 bool fcn_merge_add_cb(RAnalBlock *block, RAnalFunction *fcn) {
-	r_anal_function_add_block(fcn, block);
+	r_anal_function_add_block (fcn, block);
 	return true;
 }
 


### PR DESCRIPTION
<img width="603" alt="Screenshot 2024-09-27 at 20 50 18" src="https://github.com/user-attachments/assets/59ad55ea-9070-452f-86dc-18fb97dc698b">
