### PR TITLE
Fix double free in lua ##bin

### DIFF
--- a/libr/bin/p/bin_lua.c
+++ b/libr/bin/p/bin_lua.c
@@ -204,20 +204,14 @@ static RList *symbols(RBinFile *bf) {
 	if (!lh) {
 		return NULL;
 	}
-	RList *list = r_list_new ();
-	if (!list) {
-		return NULL;
-	}
-	RListIter *iter;
-	RBinSymbol *sym;
-	r_list_foreach (lh->symbols, iter, sym) {
-		r_list_append (list, sym);
-	}
 
 	ParseStruct parseStruct = {0};
 	parseStruct.onFunction = handleFuncSymbol;
 	parseStruct.data = NULL;
-	parseStruct.data = list;
+	parseStruct.data = r_list_clone (lh->symbols, (RListClone)r_bin_symbol_clone);
+	if (!parseStruct.data) {
+		return NULL;
+	}
 
 	ut8 *bytes = malloc (bf->size);
 	if (bytes) {
@@ -228,7 +222,7 @@ static RList *symbols(RBinFile *bf) {
 		free (bytes);
 	}
 
-	return list;
+	return parseStruct.data;
 }
 
 static RBinInfo *info(RBinFile *bf) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes double free, list elements are freed by plugin caller so I had to duplicate them.
