### PR TITLE
Added support for /V range search logic

### DIFF
--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -498,44 +498,60 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 			{
 				char *arg = strdup (opt.arg);
 				char *colon = strchr (arg, ':');
+				char *comma = NULL;
 				ut8 buf[8] = {0};
 				int size = (R_SYS_BITS & R_SYS_BITS_64)? 8: 4;
-				ut64 value = 0;
+				ut64 min_value = 0, max_value = 0;
+
 				if (colon) {
 					*colon++ = 0;
 					size = atoi (arg);
 					size = R_MIN (8, size);
 					size = R_MAX (1, size);
-					value = r_num_math (NULL, colon);
+					comma = strchr(colon, ',');
+
+					if (comma) {
+						*comma++ = 0;
+						min_value = r_num_math(NULL, colon);
+						max_value = r_num_math(NULL, comma);
+					} else {
+						min_value = r_num_math(NULL, colon);
+						max_value = min_value;
+					}
 				} else {
-					value = r_num_math (NULL, arg);
+					min_value = r_num_math(NULL, arg);
+					max_value = min_value;
 				}
-				switch (size) {
-				case 1:
-					buf[0] = value;
-					break;
-				case 2:
-					r_write_ble16 (buf, value, ro.bigendian);
-					break;
-				case 4:
-					r_write_ble32 (buf, value, ro.bigendian);
-					break;
-				case 8:
-					r_write_ble64 (buf, value, ro.bigendian);
-					break;
-				default:
-					R_LOG_ERROR ("Invalid value size. Must be 1, 2, 4 or 8");
-					rafind_options_fini (&ro);
-					return 1;
+				for (ut64 value = min_value; value <= max_value; value++) {
+					switch (size) {
+					case 1:
+						buf[0] = value;
+						break;
+					case 2:
+						r_write_ble16 (buf, value, ro.bigendian);
+						break;
+					case 4:
+						r_write_ble32 (buf, value, ro.bigendian);
+						break;
+					case 8:
+						r_write_ble64 (buf, value, ro.bigendian);
+						break;
+					default:
+						R_LOG_ERROR ("Invalid value size. Must be 1, 2, 4 or 8");
+						rafind_options_fini (&ro);
+						free(arg);
+						return 1;
+					}
+					char *hexdata = r_hex_bin2strdup((ut8 *)buf, size);
+					if (hexdata) {
+						ro.align = size;
+						ro.mode = R_SEARCH_KEYWORD;
+						ro.hexstr = true;
+						ro.widestr = false;
+						r_list_append (ro.keywords, (void*)hexdata);
+					}
 				}
-				char *hexdata = r_hex_bin2strdup ((ut8*)buf, size);
-				if (hexdata) {
-					ro.align = size;
-					ro.mode = R_SEARCH_KEYWORD;
-					ro.hexstr = true;
-					ro.widestr = false;
-					r_list_append (ro.keywords, (void*)hexdata);
-				}
+				free(arg);
 			}
 			break;
 		case 'v':

--- a/libr/main/rafind2.c
+++ b/libr/main/rafind2.c
@@ -189,7 +189,7 @@ static int show_help(const char *argv0, int line) {
 	" -t [to]    stop search at address 'to'\n"
 	" -q         quiet: fewer output do not show headings or filenames.\n"
 	" -v         print version and exit\n"
-	" -V [s:num] search for given value in given endian (-V 4:123)\n"
+	" -V [s:num | s:num1,num2] search for a value or range in the specified endian (-V 4:123 or -V 4:100,200)\n"
 	" -x [hex]   search for hexpair string (909090) (can be used multiple times)\n"
 	" -X         show hexdump of search results\n"
 	" -z         search for zero-terminated strings\n"
@@ -501,28 +501,28 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 				char *comma = NULL;
 				ut8 buf[8] = {0};
 				int size = (R_SYS_BITS & R_SYS_BITS_64)? 8: 4;
-				ut64 min_value = 0, max_value = 0;
+				ut64 value, min_value = 0, max_value = 0;
 
 				if (colon) {
 					*colon++ = 0;
 					size = atoi (arg);
 					size = R_MIN (8, size);
 					size = R_MAX (1, size);
-					comma = strchr(colon, ',');
+					comma = strchr (colon, ',');
 
 					if (comma) {
 						*comma++ = 0;
-						min_value = r_num_math(NULL, colon);
-						max_value = r_num_math(NULL, comma);
+						min_value = r_num_math (NULL, colon);
+						max_value = r_num_math (NULL, comma);
 					} else {
-						min_value = r_num_math(NULL, colon);
+						min_value = r_num_math (NULL, colon);
 						max_value = min_value;
 					}
 				} else {
-					min_value = r_num_math(NULL, arg);
+					min_value = r_num_math (NULL, arg);
 					max_value = min_value;
 				}
-				for (ut64 value = min_value; value <= max_value; value++) {
+				for (value = min_value; value <= max_value; value++) {
 					switch (size) {
 					case 1:
 						buf[0] = value;
@@ -539,10 +539,10 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 					default:
 						R_LOG_ERROR ("Invalid value size. Must be 1, 2, 4 or 8");
 						rafind_options_fini (&ro);
-						free(arg);
+						free (arg);
 						return 1;
 					}
-					char *hexdata = r_hex_bin2strdup((ut8 *)buf, size);
+					char *hexdata = r_hex_bin2strdup ((ut8*)buf, size);
 					if (hexdata) {
 						ro.align = size;
 						ro.mode = R_SEARCH_KEYWORD;
@@ -551,7 +551,7 @@ R_API int r_main_rafind2(int argc, const char **argv) {
 						r_list_append (ro.keywords, (void*)hexdata);
 					}
 				}
-				free(arg);
+				free (arg);
 			}
 			break;
 		case 'v':

--- a/man/rafind2.1
+++ b/man/rafind2.1
@@ -24,7 +24,7 @@
 .Op Fl S Ar str
 .Op Fl t Ar to
 .Op Fl v
-.Op Fl V Ar s:num
+.Op Fl V Ar s:num | s:num1,num2
 .Op Fl x Ar hex
 .Op Fl X
 .Op Fl z
@@ -74,8 +74,8 @@ Search for wide strings (Unicode) in the file(s).
 Specify the ending address for the search. (See -f)
 .It Fl v
 Display the version of rafind2 and exit.
-.It Fl V Ar s:num
-Search for the given value using little-endian notation (e.g., -V 4:123).
+.It Fl V Ar s:num | s:num1,num2
+Search for the given value using little-endian notation. A single value can be specified (e.g., -V 4:123) or a range of values can be searched by providing two values separated by a comma (e.g., -V 4:100,200).
 .It Fl x Ar hex
 Search for the specified hex pattern(s) in the file(s).
 .It Fl X


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ * ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR adds support for the `V` flag in the `rafind2` command, enabling value-range searches as specified in issue [#22704](https://github.com/radareorg/radare2/issues/22704). Users can now specify a range of values using the format `/V<size>:<min_value>[,<max_value>]`, which enhances data manipulation capabilities. The implementation includes input parsing and size validation.

Please review my implementation and provide feedback.