### PR TITLE
WIP: ASN.1 printings enhancements

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -121,7 +121,7 @@ static RCoreHelpMessage help_msg_p6 = {
 
 static RCoreHelpMessage help_msg_pF = {
 	"Usage: pF[apdbA][*vqj]", "[len]", "parse ASN1, PKCS, X509, DER, protobuf, axml",
-	"pFa", "[jq] [len]", "decode ASN1/DER from current block (PEM is B64(DER))",
+	"pFa", "[jqt] [len]", "decode ASN1/DER from current block (PEM is B64(DER))",
 	"pFA", "[j] [len]", "decode Android Binary XML from current block",
 	"pFb", "[vj] [len]", "decode raw proto buffers in (verbose, JSON) format",
 	"pFB", "[j] [len]", "decode iOS Binary PLIST from current block",

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -1491,6 +1491,11 @@ static void cmd_print_fromage(RCore *core, const char *input, const ut8* data, i
 	case 'a': // "pFa" // DER/ASN1 encoding
 		{
 			int fmt = input[1];
+
+			if (fmt == 't' && !r_config_get_b (core->config, "scr.utf8")) {
+				R_LOG_ERROR ("Tree view requires utf8 support");
+				break;
+			}
 			RAsn1 *a = r_asn1_new (data, size, fmt);
 			// RASN1Object *asn1 = r_asn1_object_parse (data, data, size, fmt);
 			if (a) {

--- a/libr/include/r_util/r_asn1.h
+++ b/libr/include/r_util/r_asn1.h
@@ -77,6 +77,7 @@ typedef struct r_asn1_bin_t {
 } RASN1Binary;
 
 typedef struct r_asn1_object_t {
+	ut8 head; /* object head*/
 	ut8 klass; /* class type */
 	ut8 form; /* defines if contains data or objects */
 	ut8 tag; /* tag type */

--- a/libr/include/r_util/r_asn1.h
+++ b/libr/include/r_util/r_asn1.h
@@ -81,6 +81,7 @@ typedef struct r_asn1_object_t {
 	ut8 form; /* defines if contains data or objects */
 	ut8 tag; /* tag type */
 	const ut8 *sector; /* Sector containing data */
+	ut64 h_len; /* Object Header Length */
 	ut32 length; /* Sector Length */
 	ut32 bitlength; /* Sector length in bits */
 	ut64 offset; /* Object offset */

--- a/libr/include/r_util/r_asn1.h
+++ b/libr/include/r_util/r_asn1.h
@@ -77,12 +77,10 @@ typedef struct r_asn1_bin_t {
 } RASN1Binary;
 
 typedef struct r_asn1_object_t {
-	ut8 head; /* object head*/
 	ut8 klass; /* class type */
 	ut8 form; /* defines if contains data or objects */
 	ut8 tag; /* tag type */
 	const ut8 *sector; /* Sector containing data */
-	ut64 h_len; /* Object Header Length */
 	ut32 length; /* Sector Length */
 	ut32 bitlength; /* Sector length in bits */
 	ut64 offset; /* Object offset */

--- a/libr/util/asn1.c
+++ b/libr/util/asn1.c
@@ -95,6 +95,7 @@ static RASN1Object *asn1_parse_header(const ut8 *buffer_base, const ut8 *buffer,
 		R_LOG_DEBUG ("Truncated object");
 		goto out_error;
 	}
+	obj->h_len = obj->sector - buffer;
 	return obj;
 out_error:
 	free (obj);
@@ -500,7 +501,7 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 		string = asn1str->string;
 	}
 	switch (fmtmode) {
-	case 'q':
+	case 'q': // pFaq
 		// QUIET MODE
 		asn1_printkv (sb, obj, depth, name, string);
 		if (obj->list.objects) {
@@ -515,7 +516,7 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 	case 'r':
 		// TODO: add comments
 		break;
-	case 'j':
+	case 'j': // pFaj
 		// return pj_drain (pj);
 		pj_o (pj);
 		pj_kn (pj, "offset", obj->offset);
@@ -535,11 +536,66 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 		}
 		pj_end (pj);
 		break;
+	case 't': // pFat
+		if (root) {
+			r_strbuf_append (sb, ".\n");
+		} else {
+			for (i = 0; i < depth; i++) {
+				r_strbuf_append (sb, "│ ");
+			}
+		}
+
+		if (obj->tag == TAG_SEQUENCE || obj->tag == TAG_SET) {
+			r_strbuf_append (sb, "├─┬ ");
+		} else {
+			if (obj->list.objects) {
+				r_strbuf_append (sb, "├── ");
+			} else {
+				r_strbuf_append (sb, "└── ");
+			}
+		}
+		r_strbuf_appendf (sb, " [@ 0x%lx](0x%lx bytes)", obj->offset, obj->h_len + obj->length);
+		if (R_STR_ISNOTEMPTY (string)) {
+			if (obj->tag == TAG_BITSTRING || obj->tag == TAG_INTEGER || obj->tag == TAG_GENERALSTRING) {
+				asn1_hexstring (obj, temp_name, sizeof (temp_name), depth, fmtmode);
+				if (strlen (temp_name) > 100) {
+					r_strbuf_appendf (sb, " - %s...\n", r_str_newlen (temp_name, 100));
+				} else {
+					r_strbuf_appendf (sb, " - %s\n", temp_name);
+				}
+			} else {
+				r_strbuf_appendf (sb, " - %s\n", string);
+			}
+		} else {
+			r_strbuf_append (sb, "\n");
+		}
+
+		if (obj->list.objects) {
+			for (i = 0; i < obj->list.length; i++) {
+				r_asn1_object_tostring (obj->list.objects[i], depth + 1, sb, pj, fmtmode);
+			}
+		}
+		break;
 	case 0: // verbose default
 	default:
-		r_strbuf_appendf (sb, "%4"PFMT64d"  ", obj->offset);
-		r_strbuf_appendf (sb, "%4u:%2d: %s %-20s: %s", obj->length,
-			depth, obj->form? "cons": "prim", name, string);
+		if (root) {
+			r_strbuf_append (sb, "  OFFSET   LENGTH DEPTH FORM NAME                : VALUE\n");
+		}
+		r_strbuf_appendf (sb, "%#8lx", obj->offset);
+		r_strbuf_appendf (sb, " %#8lx  %4d %4s %-20s: ", obj->h_len + obj->length,
+			depth, obj->form? "cons": "prim", name);
+
+		if (obj->tag == TAG_BITSTRING || obj->tag == TAG_INTEGER || obj->tag == TAG_GENERALSTRING) {
+			asn1_hexstring (obj, temp_name, sizeof (temp_name), depth, fmtmode);
+			if (strlen (temp_name) > 100) {
+				r_strbuf_appendf (sb, "%s...", r_str_newlen (temp_name, 100));
+			} else {
+				r_strbuf_appendf (sb, "%s", temp_name);
+			}
+		} else {
+			r_strbuf_appendf (sb, "%s", string);
+		}
+
 		// We may have a bit length diffrent than the length
 		if (obj->length * 8 != obj->bitlength) {
 			r_strbuf_appendf (sb, " (%u bits)\n", obj->bitlength);

--- a/libr/util/asn1.c
+++ b/libr/util/asn1.c
@@ -568,7 +568,7 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 		} else {
 			hlen += 1;
 		}
-		r_strbuf_appendf (sb, " [@ 0x%lx](0x%x bytes)", obj->offset, hlen + obj->length);
+		r_strbuf_appendf (sb, " [@ 0x%" PFMT64x "](0x%x bytes)", obj->offset, hlen + obj->length);
 		if (obj->tag == TAG_BITSTRING || obj->tag == TAG_INTEGER || obj->tag == TAG_GENERALSTRING) {
 			asn1_hexstring (obj, temp_name, sizeof (temp_name), depth, fmtmode);
 			if (strlen (temp_name) > 100) {
@@ -598,7 +598,7 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 		if (root) {
 			r_strbuf_append (sb, "  OFFSET   LENGTH DEPTH FORM NAME                : VALUE\n");
 		}
-		r_strbuf_appendf (sb, "%#8lx", obj->offset);
+		r_strbuf_appendf (sb, "%#8" PFMT64x, obj->offset);
 
 		if (obj->tag == TAG_SEQUENCE || obj->tag == TAG_SET || obj->klass == CLASS_CONTEXT) {
 			hlen += 2;

--- a/libr/util/asn1.c
+++ b/libr/util/asn1.c
@@ -502,9 +502,9 @@ R_API char *r_asn1_object_tostring(RASN1Object *obj, ut32 depth, RStrBuf *sb, PJ
 	if (asn1str) {
 		string = asn1str->string;
 	}
-	for (int i = 0; i < 4; i++) {
-		if ( len & 0xFF) {
-			hlen ++;
+	for (i = 0; i < 4; i++) {
+		if (len & 0xFF) {
+			hlen++;
 		}
 		len >>= 8;
 	}

--- a/test/db/cmd/cmd_pFa
+++ b/test/db/cmd/cmd_pFa
@@ -6,9 +6,9 @@ EOF
 EXPECT=<<EOF
   OFFSET   LENGTH DEPTH FORM NAME                : VALUE
        0     0xa2     0 cons SEQUENCE            : 30
-     0x3      0xf     1 cons SEQUENCE            : 30
+     0x3     0x10     1 cons SEQUENCE            : 30
      0x5      0xb     2 prim OBJECT_IDENTIFIER   : rsaEncryption
-    0x12     0x90     1 prim BIT_STRING          : 30818902818100cc61f9ef5ad0bc21de5b3ca69ee725d2c504edf99a6e97a0279d959f2364ed21aaef8c704552d5d1a3deb2...
+    0x12     0x8e     1 prim BIT_STRING          : 30818902818100cc61f9ef5ad0bc21de5b3ca69ee725d2c504edf99a6e97a0279d959f2364ed21aaef8c704552d5d1a3deb2...
 
 EOF
 RUN
@@ -60,7 +60,7 @@ pFa
 EOF
 EXPECT=<<EOF
   OFFSET   LENGTH DEPTH FORM NAME                : VALUE
-       0      0xa     0 prim BIT_STRING          : 016e500dc00000 (55 bits)
+       0      0x9     0 prim BIT_STRING          : 016e500dc00000 (55 bits)
 
 EOF
 RUN
@@ -86,7 +86,7 @@ pFa
 EOF
 EXPECT=<<EOF
   OFFSET   LENGTH DEPTH FORM NAME                : VALUE
-       0      0xb     0 cons SEQUENCE            : 30
+       0      0xc     0 cons SEQUENCE            : 30
      0x2      0x4     1 prim OCTET_STRING        : e!
      0x6      0x5     1 prim OCTET_STRING        : 650065
 

--- a/test/db/cmd/cmd_pFa
+++ b/test/db/cmd/cmd_pFa
@@ -4,18 +4,11 @@ CMDS=<<EOF
 pFa
 EOF
 EXPECT=<<EOF
-   0   159: 0: cons SEQUENCE            : 
-   3    13: 1: cons SEQUENCE            : 
-   5     9: 2: prim OBJECT_IDENTIFIER   : rsaEncryption
-  18   140: 1: prim BIT_STRING          : 30 81 89 02 81 81 00 cc 61 f9 ef 5a d0 bc 21 de |0.......a..Z..!.|
-                                        : 5b 3c a6 9e e7 25 d2 c5 04 ed f9 9a 6e 97 a0 27 |[<...%......n..'|
-                                        : 9d 95 9f 23 64 ed 21 aa ef 8c 70 45 52 d5 d1 a3 |...#d.!...pER...|
-                                        : de b2 ee 1a 0b e1 55 8e 3c a1 82 b1 1a 8c 14 39 |......U.<......9|
-                                        : 2b 6d e5 23 46 bc 7c 88 bf 75 e3 fb 2b 9f 27 fa |+m.#F.|..u..+.'.|
-                                        : b2 1f 5c f1 99 34 e3 11 0e a4 ad 72 a6 f0 73 f8 |..\..4.....r..s.|
-                                        : ab 38 b9 93 9b b6 39 e7 8a d7 f4 34 11 9d 8c c2 |.8....9....4....|
-                                        : b1 bd e4 ea f9 51 3b 05 65 08 c9 08 ed 43 c9 9b |.....Q;.e....C..|
-                                        : 0c eb 22 2c bb e1 ef 02 03 01 00 01             |..",........    |
+  OFFSET   LENGTH DEPTH FORM NAME                : VALUE
+       0     0xa2     0 cons SEQUENCE            : 30
+     0x3      0xf     1 cons SEQUENCE            : 30
+     0x5      0xb     2 prim OBJECT_IDENTIFIER   : rsaEncryption
+    0x12     0x90     1 prim BIT_STRING          : 30818902818100cc61f9ef5ad0bc21de5b3ca69ee725d2c504edf99a6e97a0279d959f2364ed21aaef8c704552d5d1a3deb2...
 
 EOF
 RUN
@@ -66,7 +59,8 @@ wx 030801016e500dc00000
 pFa
 EOF
 EXPECT=<<EOF
-   0     7: 0: prim BIT_STRING          : 016e500dc00000 (55 bits)
+  OFFSET   LENGTH DEPTH FORM NAME                : VALUE
+       0      0xa     0 prim BIT_STRING          : 016e500dc00000 (55 bits)
 
 EOF
 RUN
@@ -78,7 +72,8 @@ wx 06032b6570
 pFa
 EOF
 EXPECT=<<EOF
-   0     3: 0: prim OBJECT_IDENTIFIER   : id-Ed25519
+  OFFSET   LENGTH DEPTH FORM NAME                : VALUE
+       0      0x5     0 prim OBJECT_IDENTIFIER   : id-Ed25519
 
 EOF
 RUN
@@ -90,9 +85,10 @@ wx 3009040265210403650065
 pFa
 EOF
 EXPECT=<<EOF
-   0     9: 0: cons SEQUENCE            : 
-   2     2: 1: prim OCTET_STRING        : e!
-   6     3: 1: prim OCTET_STRING        : 650065
+  OFFSET   LENGTH DEPTH FORM NAME                : VALUE
+       0      0xb     0 cons SEQUENCE            : 30
+     0x2      0x4     1 prim OCTET_STRING        : e!
+     0x6      0x5     1 prim OCTET_STRING        : 650065
 
 EOF
 RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR aims at enhancing the `pFa` command output with the following:
- Fix length miscalculation
- Add header on `pFa` output for better understanding
![image](https://github.com/user-attachments/assets/b9e38809-d86e-4145-82be-689c5a7eb5b6)
- Change the output format of some ASN.1 tags (hexstring), truncate to 100 characters if too long
![image](https://github.com/user-attachments/assets/b36df947-4379-4a1d-b477-69be5b007447)



- Tree view using `pFat`
![image](https://github.com/user-attachments/assets/a6edc33d-fb46-4b62-bf6d-cfb923671d17)