### PR TITLE
va2pa fix, rva can be bigger than imagebase and be inside a section

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -440,10 +440,6 @@ struct r_bin_pe_addr_t *PE_(r_bin_pe_get_main_vaddr)(RBinPEObj *pe) {
 R_API PE_DWord PE_(va2pa)(RBinPEObj* pe, PE_DWord rva) {
 	PE_DWord section_base;
 	int i, section_size;
-	ut32 image_base = pe->nt_headers->optional_header.ImageBase;
-	if (rva > image_base) {
-		rva -= image_base;
-	}
 	for (i = 0; i < pe->num_sections; i++) {
 		section_base = pe->sections[i].vaddr;
 		section_size = pe->sections[i].vsize;


### PR DESCRIPTION
va2pa is a conversion used often mainly for convert the address on DataDirectory to the offset on the file.

It would be nice to find the commit that introduced this because could have a sense for a special case, but aparently for me and in a practical prespective don’t have sense this subtraction.
