### PR TITLE
Add offset on MK hit for SM4 ##crypto

### DIFF
--- a/libr/search/sm4_find.c
+++ b/libr/search/sm4_find.c
@@ -12,14 +12,14 @@ static bool sm4_key_test(const unsigned char *buf) {
 }
 
 // Display the corresponding master key which is not directly in memory for SM4.
-static void sm4_master_key(const unsigned char *buf) {
+static void sm4_master_key(const unsigned char *buf, ut64 offset) {
 	ut32 *ptr = (ut32 *)buf;
 	ut32 master_key[4] = { 0 };
 	master_key[3] = ptr[3] ^ (sm4_RK (ptr[2] ^ ptr[1] ^ ptr[0] ^ sm4_CK[3]));
 	master_key[2] = ptr[2] ^ (sm4_RK (ptr[1] ^ ptr[0] ^ master_key[3] ^ sm4_CK[2]));
 	master_key[1] = ptr[1] ^ (sm4_RK (ptr[0] ^ master_key[3] ^ master_key[2] ^ sm4_CK[1]));
 	master_key[0] = ptr[0] ^ (sm4_RK (master_key[3] ^ master_key[2] ^ master_key[1] ^ sm4_CK[0]));
-	R_LOG_INFO ("Master key found: %08x%08x%08x%08x", FK[0] ^ master_key[0], FK[1] ^ master_key[1], FK[2] ^ master_key[2], FK[3] ^ master_key[3]);
+	R_LOG_INFO ("Master key found: %08x%08x%08x%08x @%#8"PFMT64x, FK[0] ^ master_key[0], FK[1] ^ master_key[1], FK[2] ^ master_key[2], FK[3] ^ master_key[3], offset);
 	return;
 }
 
@@ -32,7 +32,7 @@ R_IPI int search_sm4_update(RSearch *s, ut64 from, const ut8 *buf, int len) {
 	r_list_foreach (s->kws, iter, kw) {
 		for (i = 0; i < last + 1; i++) {
 			if (sm4_key_test (buf + i)) {
-				sm4_master_key (buf + i);
+				sm4_master_key (buf + i, from + i);
 				kw->keyword_length = SM4_KEY_LENGTH;
 				t = r_search_hit_new (s, kw, from + i);
 				if (!t) {


### PR DESCRIPTION
- [* ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add the offset to the SM4 "Master key found" message 