### PR TITLE
PE section flags

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -4377,7 +4377,7 @@ static struct r_bin_pe_section_t* PE_(r_bin_pe_get_sections)(RBinPEObj* pe) {
 				}
 			}
 		}
-        sections[j].flags = shdr[i].Characteristics;
+		sections[j].flags = shdr[i].Characteristics;
 		sections[j].perm = shdr[i].Characteristics;
 		sections[j].last = 0;
 		j++;

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -4377,6 +4377,7 @@ static struct r_bin_pe_section_t* PE_(r_bin_pe_get_sections)(RBinPEObj* pe) {
 				}
 			}
 		}
+        sections[j].flags = shdr[i].Characteristics;
 		sections[j].perm = shdr[i].Characteristics;
 		sections[j].last = 0;
 		j++;

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -24,6 +24,7 @@ struct r_bin_pe_section_t {
 	ut64 vaddr;
 	ut64 paddr;
 	ut64 perm;
+    ut32 flags;
 	int last;
 };
 

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -24,7 +24,7 @@ struct r_bin_pe_section_t {
 	ut64 vaddr;
 	ut64 paddr;
 	ut64 perm;
-    ut32 flags;
+	ut32 flags;
 	int last;
 };
 

--- a/libr/bin/p/bin_pe.inc.c
+++ b/libr/bin/p/bin_pe.inc.c
@@ -154,6 +154,7 @@ static RList* sections(RBinFile *bf) {
 		sec->vaddr = sections[i].vaddr + ba;
 		sec->add = true;
 		sec->perm = 0;
+        sec->flags = sections[i].flags;
 		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].perm)) {
 			sec->perm |= R_PERM_X;
 			sec->perm |= R_PERM_R; // implicit

--- a/libr/bin/p/bin_pe.inc.c
+++ b/libr/bin/p/bin_pe.inc.c
@@ -154,7 +154,7 @@ static RList* sections(RBinFile *bf) {
 		sec->vaddr = sections[i].vaddr + ba;
 		sec->add = true;
 		sec->perm = 0;
-        sec->flags = sections[i].flags;
+		sec->flags = sections[i].flags;
 		if (R_BIN_PE_SCN_IS_EXECUTABLE (sections[i].perm)) {
 			sec->perm |= R_PERM_X;
 			sec->perm |= R_PERM_R; // implicit

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3228,7 +3228,7 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 				pj_ks (pj, "type", section->type);
 			}
 			pj_ks (pj, "perm", perms);
-            pj_kN (pj, "flags", section->flags);
+			pj_kN (pj, "flags", section->flags);
 			if (hashtypes && (int)section->size > 0) {
 				int datalen = section->size;
 				if (datalen > 0 && datalen < plimit) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3047,11 +3047,11 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 	}
 	if (IS_MODE_NORMAL (mode)) {
 		if (hashtypes) {
-			r_table_set_columnsf (table, "dXxXxssss",
-				"nth", "paddr", "size", "vaddr", "vsize", "perm", hashtypes, "type", "name");
+			r_table_set_columnsf (table, "dXxXxssssx",
+				"nth", "paddr", "size", "vaddr", "vsize", "perm", hashtypes, "type", "name", "flags");
 		} else {
-			r_table_set_columnsf (table, "dXxXxsss",
-				"nth", "paddr", "size", "vaddr", "vsize", "perm", "type", "name");
+			r_table_set_columnsf (table, "dXxXxsssx",
+				"nth", "paddr", "size", "vaddr", "vsize", "perm", "type", "name", "flags");
 		}
 		// r_table_align (table, 0, R_TABLE_ALIGN_CENTER);
 		r_table_align (table, 2, R_TABLE_ALIGN_RIGHT);
@@ -3228,6 +3228,7 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 				pj_ks (pj, "type", section->type);
 			}
 			pj_ks (pj, "perm", perms);
+            pj_kN (pj, "flags", section->flags);
 			if (hashtypes && (int)section->size > 0) {
 				int datalen = section->size;
 				if (datalen > 0 && datalen < plimit) {
@@ -3287,15 +3288,15 @@ static bool bin_sections(RCore *r, PJ *pj, int mode, ut64 laddr, int va, ut64 at
 				stype = print_segments? "MAP": "----";
 			}
 			if (hashtypes) {
-				r_table_add_rowf (table, "dXxXxssss", i,
+				r_table_add_rowf (table, "dXxXxssssx", i,
 					(ut64)section->paddr, (ut64)section->size,
 					(ut64)addr, (ut64)section->vsize,
-					perms, r_str_get (hashstr), stype, section_name);
+					perms, r_str_get (hashstr), stype, section_name, section->flags);
 			} else {
-				r_table_add_rowf (table, "dXxXxsss", i,
+				r_table_add_rowf (table, "dXxXxsssx", i,
 					(ut64)section->paddr, (ut64)section->size,
 					(ut64)addr, (ut64)section->vsize,
-					perms, stype, section_name);
+					perms, stype, section_name, section->flags);
 			}
 			free (hashstr);
 		}


### PR DESCRIPTION
Ideally the section->perm item is not necesary because can be infered from section->flags
both come from PE section Characteristics but perm is transformed in the way, we keep the orignal flags on flags item.