### PR TITLE
Automatically show long user comments on top (ignore asm.cmt.right) #…

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3828,6 +3828,7 @@ R_API int r_core_config_init(RCore *core) {
 	// options for the comments in the disassembly
 	SETBPREF ("asm.anos", "true", "show annotations (see ano command)");
 	SETBPREF ("asm.comments", "true", "show comments in disassembly view (see 'e asm.cmt.')");
+	SETBPREF ("asm.cmt.wrap", "true", "wrap long comments lines on top ignoring asm.cmt.right");
 	SETBPREF ("asm.cmt.calls", "true", "show callee function related info as comments in disasm");
 	SETBPREF ("asm.cmt.user", "false", "show user comments even if asm.comments is false");
 	SETBPREF ("asm.cmt.pseudo", "false", "show pseudo disasm as comments (see asm.pseudo)");

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -465,10 +465,60 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME="function info integration ada - wrap"
+FILE=bins/elf/ada_test_dwarf 
+CMDS=<<EOF
+e asm.dwarf=false
+e asm.cmt.wrap=true
+e asm.var.summary=0
+aaa
+pdf @  dbg.main
+EOF
+EXPECT=<<EOF
+            ;-- main:
+            ; DATA XREF from entry0 @ 0x2271(r)
+/ 101: int dbg.main (int argc, char **argv, char **envp);
+|           ; arg int argc @ rdi
+|           ; arg char **argv @ rsi
+|           ; arg char **envp @ rdx
+|           ; var ada_main__main__seh___PAD seh @ rbp-0x8
+|           ; var system__address volatile ensure_reference @ rbp-0x10
+|           ; var int64_t var_14h @ rbp-0x14
+|           ; var char **var_20h @ rbp-0x20
+|           ; var char **var_28h @ rbp-0x28
+; integer main(integer const argc,void * const argv,void * const envp)
+|           0x00002742      55             push rbp
+|           0x00002743      4889e5         mov rbp, rsp
+|           0x00002746      4883ec30       sub rsp, 0x30
+|           0x0000274a      897dec         mov dword [var_14h], edi    ; argc
+|           0x0000274d      488975e0       mov qword [var_20h], rsi    ; argv
+|           0x00002751      488955d8       mov qword [var_28h], rdx    ; envp
+|           0x00002755      488d05dc08..   lea rax, obj.__gnat_ada_main_program_name ; 0x3038 ; "_ada_ada_test"
+|           0x0000275c      488945f0       mov qword [ensure_reference], rax
+|           0x00002760      8b45ec         mov eax, dword [var_14h]
+|           0x00002763      8905572a0000   mov dword [obj.gnat_argc], eax ; [0x51c0:4]=0
+|           0x00002769      488b45e0       mov rax, qword [var_20h]
+|           0x0000276d      488905b429..   mov qword [obj.gnat_argv], rax ; [0x5128:8]=0
+|           0x00002774      488b45d8       mov rax, qword [var_28h]
+|           0x00002778      4889051129..   mov qword [obj.gnat_envp], rax ; [0x5090:8]=0
+|           0x0000277f      488d45f8       lea rax, [seh.F]
+|           0x00002783      4889c7         mov rdi, rax
+|           0x00002786      e875f9ffff     call sym.imp.__gnat_initialize
+|           0x0000278b      e8e8fcffff     call dbg.adainit
+|           0x00002790      e847000000     call dbg._ada_ada_test
+|           0x00002795      e8b6fcffff     call dbg.adafinal
+|           0x0000279a      e8d1f8ffff     call sym.imp.__gnat_finalize
+|           0x0000279f      8b054b290000   mov eax, dword [obj.gnat_exit_status] ; [0x50f0:4]=0
+|           0x000027a5      c9             leave
+\           0x000027a6      c3             ret
+EOF
+RUN
+
 NAME="function info integration ada"
 FILE=bins/elf/ada_test_dwarf 
 CMDS=<<EOF
 e asm.dwarf=false
+e asm.cmt.wrap=false
 e asm.var.summary=0
 aaa
 pdf @  dbg.main


### PR DESCRIPTION
…#disasm

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
