### PR TITLE
Revert e0b19776681 - bring back the full IO address space ##debug

### DIFF
--- a/libr/core/cmd_help.inc.c
+++ b/libr/core/cmd_help.inc.c
@@ -396,6 +396,7 @@ static RCoreHelpMessage help_msg_question_v = {
 	"$MB", "", "alias for $M",
 	"$MD", "", "map distance comparing current offset and map.addr",
 	"$MM", "", "map base address",
+	"$MS", "", "map size",
 
 	"$o", "", "here (current disk io offset)",
 	"$p", "", "getpid()",

--- a/libr/core/numvars.inc.c
+++ b/libr/core/numvars.inc.c
@@ -558,7 +558,7 @@ static ut64 numvar_maps(RCore *core, const char *str, int *ok) {
 	case 'e':
 	case 'E': return r_io_map_end (map);
 	case 'S': return r_io_map_size (map);
-	case 'M':
+	case 'M': // "MM"
 		  {
 			  ut64 lower = r_io_map_begin (map);
 			  const int clear_bits = 16;

--- a/libr/io/p/io_gdb.c
+++ b/libr/io/p/io_gdb.c
@@ -140,7 +140,7 @@ static RIODesc *__open(RIO *io, const char *file, int rw, int mode) {
 }
 
 static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
-	ut64 addr = io->off;
+	const ut64 addr = io->off;
 	if (!desc || !desc->data) {
 		return -1;
 	}
@@ -156,7 +156,8 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = ST64_MAX;
+		io->off = UT64_MAX;
+		break;
 	}
 	return io->off;
 }

--- a/libr/io/p/io_mach.c
+++ b/libr/io/p/io_mach.c
@@ -462,7 +462,8 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = ST64_MAX;
+		io->off = UT64_MAX;
+		break;
 	}
 	return io->off;
 }

--- a/libr/io/p/io_ptrace.c
+++ b/libr/io/p/io_ptrace.c
@@ -272,7 +272,8 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = ST64_MAX;
+		io->off = UT64_MAX;
+		break;
 	}
 	return io->off;
 }

--- a/libr/io/p/io_winedbg.c
+++ b/libr/io/p/io_winedbg.c
@@ -148,9 +148,9 @@ static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
 		io->off += offset;
 		break;
 	case R_IO_SEEK_END:
-		io->off = ST64_MAX;
+		io->off = UT64_MAX;
+		break;
 	}
-	io->off = offset;
 	return offset;
 }
 

--- a/test/db/archos/linux-x86_64/dbg_oo
+++ b/test/db/archos/linux-x86_64/dbg_oo
@@ -63,9 +63,9 @@ ood > /dev/null
 om
 EOF
 EXPECT=<<EOF
-* 1 fd: 3 +0x00000000 0x00000000 - 0x7ffffffffffffffe rwx
+* 1 fd: 3 +0x00000000 0x00000000 - 0xfffffffffffffffe rwx
 ---
-* 1 fd: 4 +0x00000000 0x00000000 - 0x7ffffffffffffffe rwx
+* 1 fd: 4 +0x00000000 0x00000000 - 0xfffffffffffffffe rwx
 EOF
 RUN
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
