### PR TITLE
Fixed old_offset not restored on pdj ##print

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7578,6 +7578,7 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 	}
 	r_cons_break_pop ();
 	r_anal_op_fini (&ds->analop);
+	core->offset = old_offset;
 	ds_free (ds);
 	if (!result) {
 		pj_o (pj);

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -432,9 +432,11 @@ wx 56687cd3400090
 aaa
 s 6
 pdj -1
+s
 EOF
 EXPECT=<<EOF
 [{"offset":1,"ptr":4248444,"val":4248444,"esil":"4248444,4,esp,-,=[4],4,esp,-=","refptr":0,"fcn_addr":0,"fcn_last":1020,"size":5,"opcode":"push 0x40d37c","disasm":"push 0x40d37c","bytes":"687cd34000","family":"cpu","type":"push","reloc":false,"type_num":13,"type2_num":0}]
+0x6
 EOF
 RUN
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ X ] Mark this if you consider it ready to merge
- [ X ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Currently, when using negative numbers in the `pdj` command, in `r_core_print_disasm_json_ipi` a new offset (computed going backward) is assigned to the `core->offset` variable. However, the `old_offset` is not restored before returning from the function, which has the undesired side-effect that the cursor goes back after the command (annoyingly breaking r2pipe automations).

PoC:
![image](https://github.com/user-attachments/assets/4e985206-ca1e-4959-bdff-1661882cb41f)

radare2 version:
5.9.6-158-gc72b9514ad

This pull request should fix this behaviour.

Same command, with the patch:
![image](https://github.com/user-attachments/assets/f97ff870-655b-4fa1-a71a-a14d34c331c3)

 