### PR TITLE
Remove needless uses of r_io_bind_init

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -125,7 +125,6 @@ R_API RAnal *r_anal_new(void) {
 	anal->diff_thbb = R_ANAL_THRESHOLDBB;
 	anal->diff_thfcn = R_ANAL_THRESHOLDFCN;
 	anal->syscall = r_syscall_new ();
-	r_io_bind_init (anal->iob);
 	r_flag_bind_init (anal->flb);
 	anal->reg = r_reg_new ();
 	anal->last_disasm_reg = NULL;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -454,7 +454,7 @@ R_API void r_io_drain_overlay(RIO *io);
 R_API bool r_io_get_region_at(RIO *io, RIORegion *region, ut64 addr);
 R_API void r_io_fini(RIO *io);
 R_API void r_io_free(RIO *io);
-#define r_io_bind_init(x) memset (&(x), 0, sizeof (x))
+#define r_io_bind_init(x) (x) = (const RIOBind){0}
 
 R_API bool r_io_plugin_init(RIO *io);
 R_API bool r_io_plugin_add(RIO *io, RIOPlugin *plugin);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -307,7 +307,6 @@ R_API RPrint* r_print_new(void) {
 		return NULL;
 	}
 	r_str_ncpy (p->datefmt, "%Y-%m-%d %H:%M:%S %u", sizeof (p->datefmt));
-	r_io_bind_init (p->iob);
 	p->pairs = true;
 	p->resetbg = true;
 	p->cb_printf = libc_printf;


### PR DESCRIPTION
both previously existing uses of r_io_bind_init were applied to instances of RIOBind, which were previously allocated with R_NEW0, so r_io_bind_init cleared memory, that was already clear.

r_io_bind_init no longer calls memset

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
