### PR TITLE
Update quickjs.c

### DIFF
--- a/shlr/qjs/src/quickjs.c
+++ b/shlr/qjs/src/quickjs.c
@@ -11311,6 +11311,8 @@ static int js_ecvt(double d, int n_digits,
                    char dest[minimum_length(JS_ECVT_BUF_SIZE)],
                    size_t size, int *decpt)
 {
+    int i;
+
     if (n_digits == 0) {
         /* find the minimum number of digits (XXX: inefficient but simple) */
         // TODO(chqrlie) use direct method from quickjs-printf
@@ -11360,7 +11362,7 @@ static int js_ecvt(double d, int n_digits,
                 return n_digits;    /* truncate the 2 extra digits */
         }
         /* round up in the string */
-        for(int i = n_digits;; i--) {
+        for(i = n_digits;; i--) {
             /* ignore the locale specific decimal point */
             if (is_digit(dest[i])) {
                 if (dest[i]++ < '9')


### PR DESCRIPTION
avoid error/varning about the need of C99 compatibility mode when the variable is declared vithin the for cycle definition.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
