### PR TITLE
Flags without a space are priorized in RCoreFlag.getBySpace ##disasm

### DIFF
--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -573,6 +573,10 @@ R_API RFlagItem *r_flag_get_by_spaces(RFlag *f, ut64 off, ...) {
 	r_list_foreach (list, iter, flg) {
 		// get the "priority" of the flag flagspace and
 		// check if better than what we found so far
+		if (!flg->space) {
+			ret = flg;
+			break;
+		}
 		for (i = 0; i < n_spaces; i++) {
 			if (flg->space == spaces[i]) {
 				break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
