### PR TITLE
Update macos github action runner images ##build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,12 +199,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - arch: arm64
-            macos: 13
-          - arch: x86_64
-            macos: 12
-    runs-on: macos-${{ matrix.macos }}
+        arch:
+          - arm64
+          - x86_64
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -232,7 +230,7 @@ jobs:
         include:
           - type: cydia
             sdk: true
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Install pkg-config/ldid2 with Homebrew

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         meson -Dnogpl=true build-nogpl
         ninja -C build-nogpl
   macos-test:
-    runs-on: macos-12
+    runs-on: macos-13
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
     steps:
     - name: Checkout
@@ -211,7 +211,7 @@ jobs:
     if: contains(github.ref, 'master') || contains(github.ref, 'ci-')
     name: macos-rpath
     continue-on-error: true
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

update macos github action runner images. probably not critical but ive been watching this project for a little while and keep seeing these failures

>The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

example failures:
- [radareorg/radare2/actions/workflows/build.yml](https://github.com/radareorg/radare2/actions/workflows/build.yml?query=branch%3Amaster)
  - [macos-acr (x86_64, 12)](https://github.com/radareorg/radare2/actions/runs/12418209216/job/34670912552)
  - [ios (cydia)](https://github.com/radareorg/radare2/actions/runs/12418209216/job/34670908821)
  - [ios (cydia32)](https://github.com/radareorg/radare2/actions/runs/12418209216/job/34670909573)
- [radareorg/radare2/actions/workflows/ci.yml](https://github.com/radareorg/radare2/actions/workflows/ci.yml?query=branch%3Amaster)
  - [macos-test](https://github.com/radareorg/radare2/actions/runs/12418209254/job/34670910011)
  - [macos-rpath](https://github.com/radareorg/radare2/actions/runs/12418209254/job/34670908187)

example successes:
- [jjaareet/radare2/actions/workflows/build.yml](https://github.com/jjaareet/radare2/actions/workflows/build.yml?query=branch%3Amaster)
  - [macos-acr (x86_64, 12)](https://github.com/jjaareet/radare2/actions/runs/12419539971/job/34675077880)
  - [ios (cydia)](https://github.com/jjaareet/radare2/actions/runs/12419539971/job/34675072199)
  - [ios (cydia32)](https://github.com/jjaareet/radare2/actions/runs/12419539971/job/34675074006)
- [jjaareet/radare2/actions/workflows/ci.yml](https://github.com/jjaareet/radare2/actions/workflows/ci.yml?query=branch%3Amaster)
  - [~macos-test~](https://github.com/jjaareet/radare2/actions/runs/12419539942/job/34675076320)
    - some tests are failing under the new image (details below). i suspect these would have been failing under the old image if they actually ran. i have not attempted to fix the tests at this point but I can look into it if required for merging
  - [macos-rpath](https://github.com/jjaareet/radare2/actions/runs/12419539942/job/34675070612)

<details>

<summary>macos-test errors</summary>

https://github.com/jjaareet/radare2/actions/runs/12419539942/job/34675076320

```
Run pip3 install r2pipe; make tests
...
test_get_glibc_version OK
bin/test_get_main_arena_offset
ERROR: reloc conversion failed for 0x3c3d80
ERROR: reloc conversion failed for 0x3c3d80
INFO: Found main_arena with symbol
ERROR: reloc conversion failed for 0x3d9d60
ERROR: reloc conversion failed for 0x3d9d60
INFO: Found main_arena with symbol
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
WARN: Found main_arena offset with relocations
test_get_main_arena_offset_with_symbol OK
...
test_va_malloc_zero OK
bin/test_json
ERROR: no closing quote for string (unterminated string)
ERROR: unexpected chars ()
test_json (1) OK
ERROR: no closing quote for string (unterminated \string" ]
test_json (2) OK
...
test_json (7) OK
ERROR: unexpected end of text ()
ERROR: unexpected end of text ()
ERROR: unexpected chars ()
ERROR: unexpected chars ()
ERROR: invalid number (100000000000000000000000000000, -100000000000000000000000000000, "end" ]
)
ERROR: unexpected chars (ture,
 "who says JSON is easy for humans to generate?"]
)
ERROR: invalid number (- 
]

)
ERROR: unexpected chars (}
)
ERROR: endless comment (/*)
ERROR: endless comment (/*abc /)
ERROR: endless comment (/*/ 123)
ERROR: invalid unicode surrogate (\ud800"
)
ERROR: invalid unicode escape (\u04FG")
ERROR: invalid unicode escape (\u0)
ERROR: invalid unicode escape (\u04")
ERROR: unexpected chars (,}
)
ERROR: unexpected chars (,]
)
ERROR: unexpected chars ({}]
)
ERROR: unexpected chars (,1337]
)
ERROR: unexpected chars (,"invalid":123}
)
test_json (8) OK
...
test_pdb_type_save OK
ERROR: return code 127 for rodoro2 -N -q0 -
bin/test_pj
ERROR: [+] r2pipe link error
test_pj_reset OK
...
test_r_rbtree_augmented_insert_delete2 OK
bin/test_reg
ERROR: =A0 is not defined
ERROR: =A0 is not defined
ERROR: =A0 is not defined
ERROR: =A0 is not defined
ERROR: =A0 is not defined
ERROR: =A0 is not defined
test_r_reg_set_name OK
...
test_pvector_lower_bound OK
make[3]: *** [run] Error 1
make[2]: *** [unit-tests] Error 2
make[1]: *** [r2r-tests] Error 2
make: *** [tests] Error 2
unit1
Error: Process completed with exit code 2.
```

</details>