### PR TITLE
Rename m1 to arm64 for mac builds

### DIFF
--- a/dist/macos/build.sh
+++ b/dist/macos/build.sh
@@ -31,10 +31,10 @@ ${MAKE} install PREFIX="${PREFIX}" DESTDIR=${SRC} || exit 1
 ARM64CHK=`echo "$CFLAGS $ARCHFLAGS" | grep arm64`
 if [ -n "$ARM64CHK" ]; then
 	# crossbuild arm64 build
-	ARCH=m1
+	ARCH=arm64
 elif [ "`uname -m`" = arm64 ]; then
 	# local arm64 build
-	ARCH=m1
+	ARCH=arm64
 else
 	ARCH=x64
 fi


### PR DESCRIPTION
As it has been requested:
https://github.com/radareorg/iaito/issues/170#issuecomment-2130003128

This PR intends to change all artifact names from `m1` to `arm64`.

> [!Note]
> The rest of the projects will need to update the download path when they want to update to the next radare2 version in their workflows if this PR gets merged.