### PR TITLE
Enable Dependabot and update some GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "##build "
+      prefix-development: "##build "
+    labels:
+      - buildsystem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         sys/install.sh
     - name: Running tests
       run: r2r -o /tmp/r2r.json test/db/cmd
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: r2r.json
         path: /tmp/r2r.json
@@ -148,7 +148,7 @@ jobs:
       run: |
         export LD_LIBRARY_PATH=/usr/local/lib
         make tests
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: results.json
         path: test/results.json
@@ -372,7 +372,7 @@ jobs:
         export PATH=${HOME}/.local/bin:${HOME}/Library/Python/3.9/bin:${PATH}
         sudo apt-get --assume-yes install python3-wheel gperf python3-setuptools cabextract gperf gcc-mingw-w64
         sys/mingw32.sh
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: w32-mingw
         path: radare2*.zip
@@ -387,7 +387,7 @@ jobs:
         export PATH=${HOME}/.local/bin:${HOME}/Library/Python/3.9/bin:${PATH}
         sudo apt-get --assume-yes install python3-wheel gperf python3-setuptools cabextract gperf gcc-mingw-w64
         sys/mingw64.sh
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: w64-mingw
         path: radare2*.zip

--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -24,7 +24,7 @@ jobs:
           sys/debian.sh
           make -C dist/debian
     - name: Pub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-acr-deb-arm64
         path: dist/debian/*/*.deb
@@ -45,7 +45,7 @@ jobs:
           sys/debian.sh
           make -C dist/debian
     - name: Pub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-acr-deb-riscv64
         path: dist/debian/*/*.deb
@@ -66,7 +66,7 @@ jobs:
           sys/debian.sh
           make -C dist/debian
     - name: Pub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-acr-deb-s390x
         path: dist/debian/*/*.deb


### PR DESCRIPTION
Enable Dependabot just for GitHub Actions dependencies.
Configure the commit message to start with `##build ` (there is no setting to set suffix instead of prefix).

Also update upload-artifact to v4.