### PR TITLE
Fixes for x86 operand parsing for x87 FPU instructions

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -3082,6 +3082,7 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_CMOVP:
 	case X86_INS_CMOVS:
 		op->type = R_ANAL_OP_TYPE_CMOV;
+		op1_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_STOSB:
 	case X86_INS_STOSD:
@@ -3249,12 +3250,14 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		// TODO: RCL Still does not work as intended
 		//  - Set flags
 		op->type = R_ANAL_OP_TYPE_ROL;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_ROR:
 	case X86_INS_RCR:
 		// TODO: RCR Still does not work as intended
 		//  - Set flags
 		op->type = R_ANAL_OP_TYPE_ROR;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_SHL:
 	case X86_INS_SHLD:
@@ -3264,24 +3267,29 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		// number of bits shifted is greater than the size of the
 		// destination.
 		op->type = R_ANAL_OP_TYPE_SHL;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_SAR:
 	case X86_INS_SARX:
 		// TODO: Set CF. See case X86_INS_SHL for more details.
 		op->type = R_ANAL_OP_TYPE_SAR;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_SAL:
 		// TODO: Set CF: See case X86_INS_SAL for more details.
 		op->type = R_ANAL_OP_TYPE_SAL;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_SALC:
 		op->type = R_ANAL_OP_TYPE_SAL;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_SHR:
 	case X86_INS_SHRD:
 	case X86_INS_SHRX:
 		// TODO: Set CF: See case X86_INS_SAL for more details.
 		op->type = R_ANAL_OP_TYPE_SHR;
+		op0_memimmhandle (op, insn, addr, regsz);
 		op->val = INSOP(1).imm;
 		// XXX this should be op->imm
 		//op->src[0] = r_anal_value_new ();
@@ -3644,21 +3652,25 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		// The CF flag is not affected. The OF, SF, ZF, AF, and PF flags
 		// are set according to the result.
 		op->type = R_ANAL_OP_TYPE_ADD;
+		op0_memimmhandle (op, insn, addr, regsz);
 		op->val = 1;
 		break;
 	case X86_INS_DEC:
 		// The CF flag is not affected. The OF, SF, ZF, AF, and PF flags
 		// are set according to the result.
 		op->type = R_ANAL_OP_TYPE_SUB;
+		op0_memimmhandle (op, insn, addr, regsz);
 		op->val = 1;
 		break;
 	case X86_INS_NEG:
 		op->type = R_ANAL_OP_TYPE_SUB;
 		op->family = R_ANAL_OP_FAMILY_CPU;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_NOT:
 		op->type = R_ANAL_OP_TYPE_NOT;
 		op->family = R_ANAL_OP_FAMILY_CPU;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_PSUBB:
 	case X86_INS_PSUBW:
@@ -3727,16 +3739,22 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_IDIV:
 		op->type = R_ANAL_OP_TYPE_DIV;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_DIV:
 		op->type = R_ANAL_OP_TYPE_DIV;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_IMUL:
 		op->type = R_ANAL_OP_TYPE_MUL;
 		op->sign = true;
+		op0_memimmhandle (op, insn, addr, regsz);
+		op1_memimmhandle (op, insn, addr, regsz);
 		break;
-	case X86_INS_AAM:
 	case X86_INS_MUL:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
+	case X86_INS_AAM:
 	case X86_INS_MULX:
 	case X86_INS_MULPD:
 	case X86_INS_MULPS:
@@ -3797,6 +3815,8 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_ADC:
 		op->type = R_ANAL_OP_TYPE_ADD;
+		op0_memimmhandle (op, insn, addr, regsz);
+		op1_memimmhandle (op, insn, addr, regsz);
 		break;
 		/* Direction flag */
 	case X86_INS_CLD:

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2914,17 +2914,25 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FBLD:
 	case X86_INS_FBSTP:
+	case X86_INS_FINCSTP:
+	case X86_INS_FNSTCW:
+	case X86_INS_FNSTSW:
+	case X86_INS_FRSTOR:
+	case X86_INS_FNSAVE:
+	case X86_INS_FNSTENV:
+	case X86_INS_FXSAVE:
+	case X86_INS_FXSAVE64:
+	case X86_INS_FISTTP:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthu */
 	case X86_INS_FCOMPP:
 	case X86_INS_FDECSTP:
 	case X86_INS_FEMMS:
 	case X86_INS_FFREE:
 	case X86_INS_FICOM:
 	case X86_INS_FICOMP:
-	case X86_INS_FINCSTP:
 	case X86_INS_FNCLEX:
 	case X86_INS_FNINIT:
-	case X86_INS_FNSTCW:
-	case X86_INS_FNSTSW:
 	case X86_INS_FPATAN:
 	case X86_INS_FPREM:
 	case X86_INS_FPREM1:
@@ -2933,19 +2941,13 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_FFREEP:
 #endif
 	case X86_INS_FRNDINT:
-	case X86_INS_FRSTOR:
-	case X86_INS_FNSAVE:
 	case X86_INS_FSCALE:
 	case X86_INS_FSETPM:
 	case X86_INS_FSINCOS:
-	case X86_INS_FNSTENV:
 	case X86_INS_FXAM:
-	case X86_INS_FXSAVE:
-	case X86_INS_FXSAVE64:
 	case X86_INS_FXTRACT:
 	case X86_INS_FYL2X:
 	case X86_INS_FYL2XP1:
-	case X86_INS_FISTTP:
 	case X86_INS_FSQRT:
 	case X86_INS_FXCH:
 		op->family = R_ANAL_OP_FAMILY_FPU;
@@ -2964,6 +2966,7 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_BTR:
 	case X86_INS_BTS:
 		op->type = R_ANAL_OP_TYPE_CMP;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_FABS:
 		op->type = R_ANAL_OP_TYPE_ABS;
@@ -2971,6 +2974,8 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FLDCW:
 	case X86_INS_FLDENV:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FLDL2E:
 	case X86_INS_FLDL2T:
 	case X86_INS_FLDLG2:
@@ -2986,14 +2991,18 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_FISTP:
 	case X86_INS_FST:
 	case X86_INS_FSTP:
-	case X86_INS_FSTPNCE:
 	case X86_INS_FXRSTOR:
 	case X86_INS_FXRSTOR64:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
+	case X86_INS_FSTPNCE:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		break;
 	case X86_INS_FDIV:
 	case X86_INS_FIDIV:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FDIVP:
 	case X86_INS_FDIVR:
 	case X86_INS_FIDIVR:
@@ -3003,15 +3012,19 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FSUBR:
 	case X86_INS_FISUBR:
-	case X86_INS_FSUBRP:
 	case X86_INS_FSUB:
 	case X86_INS_FISUB:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
+	case X86_INS_FSUBRP:
 	case X86_INS_FSUBP:
 		op->type = R_ANAL_OP_TYPE_SUB;
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		break;
 	case X86_INS_FMUL:
 	case X86_INS_FIMUL:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FMULP:
 		op->type = R_ANAL_OP_TYPE_MUL;
 		op->family = R_ANAL_OP_FAMILY_FPU;


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Further fixes for #23857, this time focused on the x87 FPU. Not all instructions take an operand and some operate only on registers / the FPU stack, so switch cases have been reordered in places.