### PR TITLE
Update macOs build LDFLAGS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,8 +206,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Install pkg-config with Homebrew
-      run: brew install pkg-config
     - name: Packaging
       env:
         ARCHFLAGS: '-arch ${{ matrix.arch }}'
@@ -233,8 +231,8 @@ jobs:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
-    - name: Install pkg-config/ldid2 with Homebrew
-      run: brew install pkg-config ldid
+    - name: Install ldid2 with Homebrew
+      run: brew install ldid
     - name: Extract r2 version
       shell: bash
       run: echo "branch=`sys/version.py -n`" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,7 @@ jobs:
       env:
         ARCHFLAGS: '-arch ${{ matrix.arch }}'
         CC: gcc -arch ${{ matrix.arch }}
+        LDFLAGS: '-headerpad_max_install_names' # Allow to relocate its dependencies using install_name_tool
       run: make -C dist/macos
     - name: Pub
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Remove `pkg-config` installation from the build pipeline since it already comes installed in the runner image
- Allow to relocate the dependencies from the macOS build pipeline so it can be used in https://github.com/radareorg/iaito/pull/209