### PR TITLE
Fix parsing of memory operands for x87 FPU instructions ##arch

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2914,17 +2914,25 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FBLD:
 	case X86_INS_FBSTP:
+	case X86_INS_FINCSTP:
+	case X86_INS_FNSTCW:
+	case X86_INS_FNSTSW:
+	case X86_INS_FRSTOR:
+	case X86_INS_FNSAVE:
+	case X86_INS_FNSTENV:
+	case X86_INS_FXSAVE:
+	case X86_INS_FXSAVE64:
+	case X86_INS_FISTTP:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthu */
 	case X86_INS_FCOMPP:
 	case X86_INS_FDECSTP:
 	case X86_INS_FEMMS:
 	case X86_INS_FFREE:
 	case X86_INS_FICOM:
 	case X86_INS_FICOMP:
-	case X86_INS_FINCSTP:
 	case X86_INS_FNCLEX:
 	case X86_INS_FNINIT:
-	case X86_INS_FNSTCW:
-	case X86_INS_FNSTSW:
 	case X86_INS_FPATAN:
 	case X86_INS_FPREM:
 	case X86_INS_FPREM1:
@@ -2933,19 +2941,13 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_FFREEP:
 #endif
 	case X86_INS_FRNDINT:
-	case X86_INS_FRSTOR:
-	case X86_INS_FNSAVE:
 	case X86_INS_FSCALE:
 	case X86_INS_FSETPM:
 	case X86_INS_FSINCOS:
-	case X86_INS_FNSTENV:
 	case X86_INS_FXAM:
-	case X86_INS_FXSAVE:
-	case X86_INS_FXSAVE64:
 	case X86_INS_FXTRACT:
 	case X86_INS_FYL2X:
 	case X86_INS_FYL2XP1:
-	case X86_INS_FISTTP:
 	case X86_INS_FSQRT:
 	case X86_INS_FXCH:
 		op->family = R_ANAL_OP_FAMILY_FPU;
@@ -2964,6 +2966,7 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_BTR:
 	case X86_INS_BTS:
 		op->type = R_ANAL_OP_TYPE_CMP;
+		op0_memimmhandle (op, insn, addr, regsz);
 		break;
 	case X86_INS_FABS:
 		op->type = R_ANAL_OP_TYPE_ABS;
@@ -2971,6 +2974,8 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FLDCW:
 	case X86_INS_FLDENV:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FLDL2E:
 	case X86_INS_FLDL2T:
 	case X86_INS_FLDLG2:
@@ -2986,14 +2991,18 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 	case X86_INS_FISTP:
 	case X86_INS_FST:
 	case X86_INS_FSTP:
-	case X86_INS_FSTPNCE:
 	case X86_INS_FXRSTOR:
 	case X86_INS_FXRSTOR64:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
+	case X86_INS_FSTPNCE:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		break;
 	case X86_INS_FDIV:
 	case X86_INS_FIDIV:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FDIVP:
 	case X86_INS_FDIVR:
 	case X86_INS_FIDIVR:
@@ -3003,15 +3012,19 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		break;
 	case X86_INS_FSUBR:
 	case X86_INS_FISUBR:
-	case X86_INS_FSUBRP:
 	case X86_INS_FSUB:
 	case X86_INS_FISUB:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
+	case X86_INS_FSUBRP:
 	case X86_INS_FSUBP:
 		op->type = R_ANAL_OP_TYPE_SUB;
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		break;
 	case X86_INS_FMUL:
 	case X86_INS_FIMUL:
+		op0_memimmhandle (op, insn, addr, regsz);
+		/* fallthru */
 	case X86_INS_FMULP:
 		op->type = R_ANAL_OP_TYPE_MUL;
 		op->family = R_ANAL_OP_FAMILY_FPU;

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2303,7 +2303,7 @@ EXPECT=<<EOF
   {
     "offset": 0,
     "esil": "0,cf,:=,32,eax,%,1,<<,32,eax,/,esp,+,[4],&,?{,1,cf,:=,},32,eax,%,1,<<,32,eax,/,esp,+,|=[4]",
-    "refptr": 0,
+    "refptr": 4,
     "fcn_addr": 0,
     "fcn_last": 0,
     "size": 4,


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
