### PR TITLE
Add string formatting functions similar to asprintf()

### DIFF
--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -325,6 +325,12 @@ R_API int r_str_printf(R_NONNULL char *buffer, size_t buffer_size, R_NONNULL con
   /// __attribute__ ((format (printf, 3, 4)));
 R_API int r_str_scanf(R_NONNULL const char *buffer, R_NONNULL const char *format, ...);
   /// __attribute__ ((format (scanf, 2, 3)));
+R_API int r_str_vasnprintf(char **buffer, R_NONNULL size_t *buffer_size, R_NONNULL const char *format, va_list ap);
+R_API int r_str_asnprintf(char **buffer, R_NONNULL size_t *buffer_size, R_NONNULL const char *format, ...);
+  /// __attribute__ ((format (printf, 3, 4)));
+R_API int r_str_vasprintf(char **buffer, R_NONNULL const char *format, va_list ap);
+R_API int r_str_asprintf(char **buffer, R_NONNULL const char *format, ...);
+  /// __attribute__ ((format (printf, 2, 3)));
 
 // rstr
 

--- a/libr/util/Makefile
+++ b/libr/util/Makefile
@@ -15,7 +15,7 @@ OBJS+=udiff.o bdiff.o stack.o queue.o tree.o idpool.o assert.o bplist.o
 OBJS+=punycode.o pkcs7.o x509.o asn1.o asn1_str.o json_parser.o json_indent.o skiplist.o
 OBJS+=pj.o rbtree.o intervaltree.o qrcode.o vector.o str_constpool.o str_trim.o
 OBJS+=chartable.o protobuf.o graph_drawable.o axml.o sstext.o new_rbtree.o token.o
-OBJS+=rvc.o rvc_git.o rvc_rvc.o bscanf.o rprintf.o base32.o
+OBJS+=rvc.o rvc_git.o rvc_rvc.o bscanf.o rprintf.o base32.o rasprintf.o
 
 ifeq (${HAVE_GPERF},1)
 OBJS+=d/ascii.o

--- a/libr/util/rasprintf.c
+++ b/libr/util/rasprintf.c
@@ -1,0 +1,67 @@
+/* radare2 - LGPL - Copyright 2025 - Robert Gill */
+
+#include <r_util.h>
+
+// Allocate a buffer of specified buffer size if *buf = NULL. Reallocates as
+// necessary to fit string returning new buffer size in &buf_size.
+// A preallocated buffer may be used and its size may be specified in
+// &buf_size, it will be resized accordingly.
+R_API int r_str_vasnprintf(char **buf, R_NONNULL size_t *buf_size, R_NONNULL const char *fmt, va_list ap) {
+	va_list aq;
+	int ret;
+
+	if (*buf == NULL)
+		*buf = r_malloc (*buf_size * sizeof (char));
+
+	va_copy (aq, ap);
+	while (true) {
+		ret = vsnprintf (*buf, *buf_size, fmt, aq);
+
+		if (ret < 0) {
+			free (*buf);
+			*buf = NULL;
+			return ret;
+		}
+
+		if (ret >= *buf_size) {
+			// double buffer size and reallocate
+			*buf_size += *buf_size;
+			*buf = r_realloc (*buf, *buf_size);
+			va_copy (aq, ap);
+			continue;
+		}
+		break;
+	}
+
+	return ret;
+}
+
+R_API int r_str_asnprintf(char **buf, R_NONNULL size_t *buf_size, R_NONNULL const char *fmt, ...) {
+	va_list ap;
+	int ret;
+
+	va_start (ap, fmt);
+	ret = r_str_vasnprintf (buf, buf_size, fmt, ap);
+	va_end (ap);
+	return ret;
+}
+
+R_API int r_str_vasprintf(char **buf, R_NONNULL const char *fmt, va_list ap) {
+	int ret;
+	size_t buf_size;
+
+	*buf = NULL;
+	buf_size = BUFSIZ;
+	ret = r_str_vasnprintf (buf, &buf_size, fmt, ap);
+	return ret;
+}
+
+R_API int r_str_asprintf(char **buf, R_NONNULL const char *fmt, ...) {
+	va_list ap;
+	int ret;
+
+	va_start (ap, fmt);
+	ret = r_str_vasprintf (buf, fmt, ap);
+	va_end (ap);
+	return ret;
+}

--- a/test/unit/test_asprintf.c
+++ b/test/unit/test_asprintf.c
@@ -1,0 +1,33 @@
+#include <r_util.h>
+#include "minunit.h"
+
+bool test_r_str_asnprintf (void) {
+	// Allocate buffer 1 byte too short.
+	size_t buf_size = 11;
+	char *res = r_malloc (buf_size);
+	int count = r_str_asnprintf (&res, &buf_size, "Hello %s", "World");
+	mu_assert_streq (res, "Hello World", "allocating printf failed");
+	mu_assert_eq (count, 11, "return value");
+	mu_assert_eq (buf_size, 22, "unexpected new buffer size");
+
+	mu_end;
+}
+
+bool test_r_str_asprintf (void) {
+	char *res = NULL;
+	int count = r_str_asprintf (&res, "Hello %s", "World");
+	mu_assert_streq (res, "Hello World", "allocating printf failed");
+	mu_assert_eq (count, 11, "return value");
+
+	mu_end;
+}
+
+bool all_tests (void) {
+	mu_run_test (test_r_str_asnprintf);
+	mu_run_test (test_r_str_asprintf);
+	return tests_passed != tests_run;
+}
+
+int main (int argc, char **argv) {
+	return all_tests ();
+}


### PR DESCRIPTION
- [x ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add a string formatting functions that automatically allocate memory similarly to asprintf(). Also provide a function that will automatically reallocate a buffer as necessary, allowing a single buffer to be reused without constantly having to malloc()/free().