### PR TITLE
Deprecate Xrefs.Type() and proper naming for getRefs(all)

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -506,6 +506,7 @@ R_API ut64 r_anal_xrefs_count_at(RAnal *anal, ut64 to) {
 	return ref_manager_count_xrefs_at (anal->rm, to);
 }
 
+#if 0
 R_API RVecAnalRef *r_anal_function_get_xrefs(RAnalFunction *fcn) {
 	R_RETURN_VAL_IF_FAIL (fcn, NULL);
 
@@ -517,6 +518,7 @@ R_API RVecAnalRef *r_anal_function_get_xrefs(RAnalFunction *fcn) {
 	}
 	return anal_refs;
 }
+#endif
 
 typedef RVecAnalRef *(*CollectFn)(RefManager *rm, ut64 addr);
 
@@ -545,13 +547,12 @@ static RVecAnalRef *fcn_get_all_refs(RAnalFunction *fcn, RefManager *rm, Collect
 	return anal_refs;
 }
 
-// XXX rename to r_anal_function_get_all_refs?
 R_API RVecAnalRef *r_anal_function_get_refs(RAnalFunction *fcn) {
 	R_RETURN_VAL_IF_FAIL (fcn, NULL);
 	return fcn_get_all_refs (fcn, fcn->anal->rm, ref_manager_get_refs);
 }
 
-R_API RVecAnalRef *r_anal_function_get_all_xrefs(RAnalFunction *fcn) {
+R_API RVecAnalRef *r_anal_function_get_xrefs(RAnalFunction *fcn) {
 	R_RETURN_VAL_IF_FAIL (fcn, NULL);
 	return fcn_get_all_refs (fcn, fcn->anal->rm, ref_manager_get_xrefs);
 }
@@ -627,6 +628,7 @@ R_API const char *r_anal_ref_type_tostring(RAnalRefType type) {
 	}
 }
 
+#if 0
 // UNUSED
 R_API RAnalRefType r_anal_xrefs_type_from_string(const char *s) {
 	RAnalRefType rt = R_ANAL_REF_TYPE_NULL;
@@ -656,6 +658,7 @@ R_API RAnalRefType r_anal_xrefs_type_from_string(const char *s) {
 	}
 	return rt;
 }
+#endif
 
 R_API int r_anal_ref_typemask(int x) {
 	const int maskedType = x & 0xff;
@@ -675,19 +678,4 @@ R_API int r_anal_ref_typemask(int x) {
 	R_LOG_ERROR ("Invalid reftype mask '%c' (0x%02x)", x, x);
 	// SHOULD NEVER HAPPEN MAYBE WARN HERE
 	return 0;
-}
-
-// TODO: deprecate
-R_API RAnalRefType r_anal_xrefs_type(char ch) {
-	switch (ch) {
-	case R_ANAL_REF_TYPE_CODE:
-	case R_ANAL_REF_TYPE_CALL:
-	case R_ANAL_REF_TYPE_DATA:
-	case R_ANAL_REF_TYPE_STRN:
-	case R_ANAL_REF_TYPE_ICOD:
-	case R_ANAL_REF_TYPE_NULL:
-		return (RAnalRefType)ch;
-	default:
-		return R_ANAL_REF_TYPE_NULL;
-	}
 }

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3256,7 +3256,8 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn, bool dorefs, PJ *pj) 
 		}
 		RVecAnalRef_free (xrefs);
 
-		xrefs = r_anal_function_get_all_xrefs (fcn);
+#if 0
+		xrefs = r_anal_function_get_xrefs (fcn);
 		if (xrefs && !RVecAnalRef_empty (xrefs)) {
 			pj_k (pj, "allxrefs");
 			pj_a (pj);
@@ -3276,6 +3277,7 @@ static int fcn_print_json(RCore *core, RAnalFunction *fcn, bool dorefs, PJ *pj) 
 			pj_end (pj);
 		}
 		RVecAnalRef_free (xrefs);
+#endif
 	} else {
 		RVecAnalRef *refs = r_anal_function_get_refs (fcn);
 		if (refs) {
@@ -3520,8 +3522,8 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn, bool dorefs) {
 			}
 		}
 		RVecAnalRef_free (xrefs);
-
-		xrefs = r_anal_function_get_all_xrefs (fcn);
+#if 0
+		xrefs = r_anal_function_get_xrefs (fcn);
 		r_cons_printf ("\nall-code-xrefs:");
 		if (xrefs && !RVecAnalRef_empty (xrefs)) {
 			R_VEC_FOREACH (xrefs, refi) {
@@ -3541,6 +3543,7 @@ static int fcn_print_legacy(RCore *core, RAnalFunction *fcn, bool dorefs) {
 			}
 		}
 		RVecAnalRef_free (xrefs);
+#endif
 	} else {
 		RVecAnalRef *xrefs = r_anal_function_get_xrefs (fcn);
 		if (xrefs) {
@@ -3667,9 +3670,11 @@ static int fcn_list_table(RCore *core, const char *q, int fmt) {
 		snprintf (xref, sizeof (xref), "%"PFMT64u, xrefs ? RVecAnalRef_length (xrefs) : 0);
 		RVecAnalRef_free (xrefs);
 
-		xrefs = r_anal_function_get_all_xrefs (fcn);
+#if 0
+		xrefs = r_anal_function_get_xrefs (fcn);
 		snprintf (axref, sizeof (axref), "%"PFMT64u, xrefs ? RVecAnalRef_length (xrefs) : 0);
 		RVecAnalRef_free (xrefs);
+#endif
 		RVecAnalRef *calls = r_core_anal_fcn_get_calls (core, fcn);
 		if (calls) {
 			RVecAnalRef_sort (calls, RAnalRef_compare_by_addr);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -10524,6 +10524,20 @@ static void axfm(RCore *core) {
 	RVecAnalRef_free (refs);
 }
 
+static RAnalRefType r_anal_xrefs_type(char ch) {
+	switch (ch) {
+	case R_ANAL_REF_TYPE_CODE:
+	case R_ANAL_REF_TYPE_CALL:
+	case R_ANAL_REF_TYPE_DATA:
+	case R_ANAL_REF_TYPE_STRN:
+	case R_ANAL_REF_TYPE_ICOD:
+	case R_ANAL_REF_TYPE_NULL:
+		return (RAnalRefType)ch;
+	default:
+		return R_ANAL_REF_TYPE_NULL;
+	}
+}
+
 static bool cmd_anal_refs(RCore *core, const char *input) {
 	ut64 addr = core->offset;
 	switch (input[0]) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1115,7 +1115,6 @@ R_API RList *r_anal_ref_list_new(void);
 R_API const char *r_anal_ref_type_tostring(RAnalRefType t);
 R_API int r_anal_ref_size(RAnalRef *ref);
 R_API int r_anal_ref_typemask(int x);
-R_DEPRECATE R_API RAnalRefType r_anal_xrefs_type(char ch);
 
 R_API const char *r_anal_ref_perm_tostring(RAnalRef *ref);
 R_API char r_anal_ref_perm_tochar(RAnalRef *ref);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
