### PR TITLE
Fix #23937 - fix rahash2 JSON ssdeep output ##json ##print

### DIFF
--- a/libr/main/rahash2.c
+++ b/libr/main/rahash2.c
@@ -148,7 +148,7 @@ static void do_hash_print(RHash *ctx, RahashOptions *ro, ut64 hash, int dlen, PJ
 		pj_o (pj);
 		pj_ks (pj, "name", hname);
 		if (hash & R_HASH_SSDEEP) {
-			pj_ks (pj, "hash", c);
+			pj_ks (pj, "hash", (const char *)c);
 		} else {
 			do_hash_hexprint (c, dlen, ule, pj, rad);
 		}

--- a/libr/main/rahash2.c
+++ b/libr/main/rahash2.c
@@ -147,7 +147,11 @@ static void do_hash_print(RHash *ctx, RahashOptions *ro, ut64 hash, int dlen, PJ
 	case 'j':
 		pj_o (pj);
 		pj_ks (pj, "name", hname);
-		do_hash_hexprint (c, dlen, ule, pj, rad);
+		if (hash & R_HASH_SSDEEP) {
+			pj_ks (pj, "hash", c);
+		} else {
+			do_hash_hexprint (c, dlen, ule, pj, rad);
+		}
 		pj_end (pj);
 		break;
 	case 'J':

--- a/test/db/tools/rahash2
+++ b/test/db/tools/rahash2
@@ -1098,6 +1098,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rahash2 -j file ssdeep
+FILE=-
+CMDS=!rahash2 -j -a ssdeep bins/elf/analysis/hello-linux-x86_64
+EXPECT=<<EOF
+[{"name":"ssdeep","hash":"96:aPsZ7JSRX4hHmfSz/XWwZpxI9LGr5lar87cZGbbgb:aPeJiam6zWQpxKLElZE"}]
+EOF
+RUN
+
 NAME=rahash2 -j string
 FILE=-
 CMDS=!rahash2 -j -a sha1,sha256 -s 233


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ x] Mark this if you consider it ready to merge
- [ x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This should be a straight-forward code change to ensure `> rahash2 -a ssdeep -j /path/to/bin` actually prints the correct `ssdeep` hash as expected.

This is my first PR. I believe I followed everything correctly and expect this to be good to go, but I'm happy to learn and make updates if needed. Specifically, I:
* Recompiled and tested the expected output locally
* Added a test and reran the `r2r` test suite. Everything finished and I didn't see my test throw an error but I was unclear on how to specifically confirm that my new test actually ran.

I tracked some of my analysis to identify the fix on my personal fork [here](https://github.com/mattunleashed/radare2/issues/1).
