### PR TITLE
Fix #23930 - fix ssdeep output formatting

### DIFF
--- a/libr/crypto/hash/hash.c
+++ b/libr/crypto/hash/hash.c
@@ -395,7 +395,10 @@ R_API R_MUSTUSE char *r_hash_tostring(R_NULLABLE RHash *ctx, const char *name, c
 		digest_hex = calloc (digest_hex_size, 1);
 		snprintf (digest_hex, digest_hex_size, "%02.8f", ctx->entropy);
 	} else if (digest_size > 0) {
-		if (digest_size * 2 < digest_size) {
+		if (algo & R_HASH_SSDEEP) {
+			digest_hex = malloc (digest_size + 1);
+			snprintf (digest_hex, digest_size + 1, "%s", ctx->digest);
+		} else if (digest_size * 2 < digest_size) {
 			digest_hex = NULL;
 		} else {
 			digest_hex_size = (digest_size * 2) + 1;

--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3721,6 +3721,29 @@ nth  paddr      vaddr       bind  type size lib name       demangled
 EOF
 RUN
 
+NAME=iS ssdeep
+FILE=bins/mach0/ls-m1
+ARGS=-a arm -b64
+CMDS=<<EOF
+iS ssdeep
+EOF
+EXPECT=<<EOF
+nth paddr         size vaddr         vsize perm flags ssdeep                                                                                             type             name
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+0   0x00003830  0x3c10 0x100003830  0x3c10 -r-x 0x0   24:xecd/8FGEE8Z6J/QJl38o38x8bzLbLyJgLVlnLeJLrrXLPLIgjjhob6qXK:xFE/w/QJbdLHyJOVtet/bTIgnmOy         REGULAR          0.__TEXT.__text
+1   0x00007440   0x520 0x100007440   0x520 -r-x 0x0   1:lllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll:                                 SYMBOL_STUBS     1.__TEXT.__auth_stubs
+2   0x00007960    0xdc 0x100007960    0xdc -r-x 0x0   3:Rbis8AaroSr4o4eANUFRtlU/sGYao05teAC/mef7HZlNCvlBAevsn:Wx1piU40S5teAg77NCvlBC                     REGULAR          2.__TEXT.__const
+3   0x00007a3c   0x4e9 0x100007a3c   0x4e9 -r-x 0x0   24:HfvlIEf751ylc4cBcLo6d6sV36oYEhsQNGfltM0LtIsBNSntfTioY:Hf97fl1ohcBcLB3MQN2ysPibBY                CSTRINGS         3.__TEXT.__cstring
+4   0x00007f28    0xd8 0x100007f28    0xd8 -r-x 0x0   6:wUyeplqMyLtCLM+oMCgMligBpbwof/PUQ:Qwlf5kiE6of5                                                   REGULAR          4.__TEXT.__unwind_info
+5   0x00008000   0x290 0x100008000   0x290 -rw- 0x0   12:N+OK+tQR0i5B96/PZPr6cld+UBlBF2FKp7lVsV4JlziVNNnpMGfRB3fn:N+8tKd5B0/JPBlBF2FKp7cNNaABv           NONLAZY_POINTERS 5.__DATA_CONST.__auth_got
+6   0x00008290    0x30 0x100008290    0x30 -rw- 0x0   1:qh2kllmdnR3toYDSllNMXlltglQ7toY4dllN9XlltglqhNkln:qh2kURdouievWQGVnX9qlqAln                      NONLAZY_POINTERS 6.__DATA_CONST.__got
+7   0x000082c0   0x268 0x1000082c0   0x268 -rw- 0x0   12:YZUFJj6p4T/tuP7+ltE/fg8SaRtHU4jLnmtd5FrblVUJC+ElwtSI1g0PRt1gGE:YZuJj6p4rmeu3gxaRm4jbEdYcKSIbptM REGULAR          7.__DATA_CONST.__const
+8   0x0000c000    0x20 0x10000c000    0x20 -rw- 0x0   1:llllllllllllllllllllllllllllllll:                                                                REGULAR          8.__DATA.__data
+9   0x00000000     0x0 0x10000c020    0xb0 -rw- 0x0                                                                                                      ZEROFILL         9.__DATA.__common
+10  0x00000000     0x0 0x10000c0d0   0x150 -rw- 0x0                                                                                                      ZEROFILL         10.__DATA.__bss
+EOF
+RUN
+
 NAME=iS sha1
 FILE=bins/mach0/ls-m1
 ARGS=-a arm -b64


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x ] Mark this if you consider it ready to merge
- [x ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR fixes a bug similar to the one fixed in https://github.com/radareorg/radare2/pull/23938. Since a `ssdeep` hash is a printable buffer, we can just print it straight away instead of printing the hex representation.
