### PR TITLE
fix(parse_def): prevent buffer overflow in register name copy

### DIFF
--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -22,7 +22,7 @@ gdb_reg_t *parse_def(char **tok) {
 		return NULL;
 	}
 
-	strcpy (r->name, tok[1]);
+	snprintf (r->name, sizeof (r->name), "%s", tok[1]);
 	r->size = parse_size (tok[2], &end);
 	if (*end != '\0' || !r->size) {
 		free (r);

--- a/shlr/gdb/src/arch.c
+++ b/shlr/gdb/src/arch.c
@@ -22,7 +22,7 @@ gdb_reg_t *parse_def(char **tok) {
 		return NULL;
 	}
 
-	snprintf (r->name, sizeof (r->name), "%s", tok[1]);
+	r_str_ncpy (r->name, tok[1], sizeof (r->name));
 	r->size = parse_size (tok[2], &end);
 	if (*end != '\0' || !r->size) {
 		free (r);


### PR DESCRIPTION
## Buffer Overflow in arch_parse_reg_profile and parse_def

### Description:
In the `parse_def` function, `r->name` is a buffer that holds the name of a register. However, it is only 32 bytes in size. But in the arch_parse_reg_profile function, there is a buffer `tmp` which is `128` bytes long and is used to hold parsed tokens from the `reg_profile` string.

As you see in `parse_def`, The **strcpy** function is used to copy the string from `tok[1]` into `r->name` and there is no check to ensure that `tok[1]` will fit into `r->name` (which is only 32 bytes). To fix this issue, I replaced `strcpy` with `snprintf`, which allows you to specify the maximum size of the destination buffer, ensuring that the string is copied safely and that the buffer boundary is respected. 


