### PR TITLE
Circumvent gcc 12.2.0 segfault

### DIFF
--- a/libr/arch/p/pickle/dis_helper.inc
+++ b/libr/arch/p/pickle/dis_helper.inc
@@ -156,7 +156,7 @@ static const struct opmap op_name_map[] = {
 	{ "readonly_buffer", '\x98' }
 };
 
-static inline int name_to_op(const char *opstr) {
+static inline char name_to_op(const char *opstr) {
 	size_t i;
 	for (i = 0; i < R_ARRAY_SIZE (op_name_map); i++) {
 		if (!r_str_casecmp (opstr, op_name_map[i].name)) {

--- a/libr/arch/p/pickle/plugin.c
+++ b/libr/arch/p/pickle/plugin.c
@@ -620,7 +620,7 @@ static bool pickle_encode(RArchSession *s, RAnalOp *op, RArchEncodeMask mask) {
 		arg = "";
 	}
 
-	int ob = name_to_op (opstr);
+	char ob = name_to_op (opstr);
 	if (ob == OP_FAILURE) {
 		R_LOG_ERROR ("Unknown pickle verb: %s", opstr);
 		wlen = -1;

--- a/libr/arch/p/pickle/pseudo.c
+++ b/libr/arch/p/pickle/pseudo.c
@@ -4,7 +4,7 @@
 #include <r_asm.h>
 #include "dis_helper.inc"
 
-static inline char *parse_no_args(int op) {
+static inline char *parse_no_args(char op) {
 	switch (op) {
 	case OP_FAILURE:
 		return NULL; // opcode not found in table
@@ -80,7 +80,7 @@ static inline char *parse_no_args(int op) {
 	return NULL;
 }
 
-static inline char *parse_with_args(int op, char *args) {
+static inline char *parse_with_args(char op, char *args) {
 	switch (op) {
 	case OP_FAILURE:
 		return NULL; // opcode not found in table


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix gcc 12.2.0 segfault ##crash

gcc 12.2.0 segfaults prior to these patches when compiled with any
optimization level:

```bash
$ make clean && ./configure && CFLAGS=-O2 make -j 4
```

which produces:

```
during RTL pass: expand
p/pickle/plugin.c: In function ‘pickle_encode’:
p/pickle/plugin.c:632:17: internal compiler error: Segmentation fault
  632 |                 switch (ob) {
      |                 ^~~~~~
0x7fc4bd56604f ???
        ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
0x7fc4bd697f7a __memset_avx512_unaligned_erms
        ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:236
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <file:///usr/share/doc/gcc-12/README.Bugs> for instructions.
```

gcc 14.2.0 doesn't segfault, but tries and fails to allocate 32G of
memory:

```
cc1: out of memory allocating 34359738352 bytes after a total of 3411968 bytes
```
```
╭─vagrant@testing ~/scratch/radare2 (master)
╰─➤ sudo dmesg | tail -3
[ 4137.211190] __vm_enough_memory: pid: 90750, comm: cc1, bytes: 34359742464 not enough memory for the allocation
[ 4137.211210] __vm_enough_memory: pid: 90750, comm: cc1, bytes: 34359635968 not enough memory for the allocation
[ 4137.211217] __vm_enough_memory: pid: 90750, comm: cc1, bytes: 34359873536 not enough memory for the allocation
```

The root cause requires additional debugging and should possibly be
reported upstream to the gcc bug tracker. However, these patches fix
compilation for now.