### PR TITLE
Fix wrong command called on core_esil_op_interrupt ##esil

### DIFF
--- a/libr/core/core_esil.c
+++ b/libr/core/core_esil.c
@@ -24,7 +24,7 @@ static bool core_esil_op_interrupt(REsil *esil) {
 	free (str);
 	RCore *core = esil->user;
 	if (core->esil.cmd_intr) {
-		r_core_cmd0 (core, core->esil.cmd_todo);
+		r_core_cmd0 (core, core->esil.cmd_intr);
 	}
 	return r_esil_fire_interrupt (esil, (ut32)interrupt);
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`core->esil.cmd_intr`is checked but `core->esil.cmd_todo`is called
