### PR TITLE
r2pm: Add env for man pages.

### DIFF
--- a/libr/main/r2pm.c
+++ b/libr/main/r2pm.c
@@ -430,6 +430,10 @@ static void r2pm_setenv(R2Pm *r2pm) {
 	r_sys_setenv ("R2PM_BINDIR", bindir);
 	free (bindir);
 
+	char *mandir = r_str_newf ("%s/man", r2_prefix);
+	r_sys_setenv("R2PM_MANDIR", mandir);
+	free (mandir);
+
 	char *libdir = r_str_newf ("%s/lib", r2_prefix);
 	r_sys_setenv ("R2PM_LIBDIR", libdir);
 	free (libdir);
@@ -1099,6 +1103,7 @@ static void r2pm_envhelp(void) {
 	int r2pm_log_level = r_sys_getenv_asint ("R2_LOG_LEVEL");
 	char *r2pm_plugdir = r_sys_getenv ("R2PM_PLUGDIR");
 	char *r2pm_bindir = r_sys_getenv ("R2PM_BINDIR");
+	char *r2pm_mandir = r_sys_getenv ("R2PM_MANDIR");
 	char *r2pm_libdir = r_sys_getenv ("R2PM_LIBDIR");
 	char *r2pm_dbdir = r_sys_getenv ("R2PM_DBDIR");
 	char *r2pm_prefix = r_sys_getenv ("R2PM_PREFIX");
@@ -1116,6 +1121,7 @@ static void r2pm_envhelp(void) {
 		"R2PM_PLUGDIR=%s (global)\n"
 		"R2PM_PREFIX=%s\n"
 		"R2PM_BINDIR=%s\n"
+		"R2PM_MANDIR=%s\n"
 		"R2PM_LIBDIR=%s\n"
 		"R2PM_DBDIR=%s\n"
 		"R2PM_GITDIR=%s\n"
@@ -1126,6 +1132,7 @@ static void r2pm_envhelp(void) {
 		r2pm_plugdir2,
 		r2pm_prefix,
 		r2pm_bindir,
+		r2pm_mandir,
 		r2pm_libdir,
 		r2pm_dbdir,
 		r2pm_gitdir,
@@ -1134,6 +1141,7 @@ static void r2pm_envhelp(void) {
 	free (r2pm_plugdir2);
 	free (r2pm_prefix);
 	free (r2pm_bindir);
+	free (r2pm_mandir);
 	free (r2pm_dbdir);
 	free (r2pm_gitdir);
 	free (r2pm_giturl);


### PR DESCRIPTION
This commit adds an environment variable for `MANDIR` which can be used by `r2pm` managed plugins to determine where to place any manfiles they contain.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Currently `r2pm` doesn't provide a consistent way to handle manfiles provided for the plugins it installs. This MR adds a directory under the `r2_prefix` for this. It'll end up being something like `$HOME/.local/share/radare2/prefix/man`.

NOTE: This relies on the behavior of how a `manpath` is constructed where `../man` (and `../share/man`) are both added to the `manpath` if they exist for a given element in `PATH`. This means manpages will only be accessible if the user has added the `R2PM_BINDIR` to their `PATH`. We deliberately do _not_ set the `MANPATH` explicitly as it will override manpage discovery based on `PATH` which most users are probably relying on for other things. 
