### PR TITLE
Fix #23966 - Avoid %p on windows because is not prefixing with 0x ##crash

### DIFF
--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -51,7 +51,7 @@ R_API RIODesc *r_io_open_buffer(RIO *io, RBuffer *b, int perm, int mode) {
 	free (uri);
 	return desc;
 #else
-	char *uri = r_str_newf ("rbuf://%p", b);
+	char *uri = r_str_newf ("rbuf://0x%08"PFMT64x, (ut64)(size_t)(void *)b);
 	RIODesc *desc = r_io_open_nomap (io, uri, perm, mode);
 	free (uri);
 	return desc;


### PR DESCRIPTION

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
