### PR TITLE
Add test for aavr on async swift binary

### DIFF
--- a/test/db/anal/aavr
+++ b/test/db/anal/aavr
@@ -1,0 +1,12 @@
+NAME=aavr async swift
+FILE=bins/mach0/SwiftAsynciOS
+CMDS=<<EOF
+s 0x100007504
+e anal.in=bin.sections.rw
+aavr
+axtq
+EOF
+EXPECT=<<EOF
+0x100011328
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Tests the usage of `aavr` to find references to async Swift tasks, by setting `anal.in` accordingly.

Depends on https://github.com/radareorg/radare2-testbins/pull/105
