### PR TITLE
Reduce memory moving barely used RFlagItem fields into Meta ##performance

### DIFF
--- a/libr/anal/global.c
+++ b/libr/anal/global.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2021 - pancake */
+/* radare - LGPL - Copyright 2021-2025 - pancake */
 
 #include <r_anal.h>
 #include <r_util/r_print.h>
@@ -28,7 +28,7 @@ R_API bool r_anal_global_add(RAnal *anal, ut64 addr, const char *type_name, cons
 	// check if type exist
 	RFlagItem *fi = r_flag_set_inspace (flags, GLOBAL_FLAGSPACE, name, addr, 1);
 	if (fi) {
-		r_flag_item_set_type (fi, fmtstr);
+		r_flag_item_set_type (flags, fi, fmtstr);
 	}
 	r_meta_set (anal, R_META_TYPE_FORMAT, addr, fmtsize, fmtstr);
 	// implicit
@@ -51,7 +51,8 @@ R_API bool r_anal_global_del(RAnal *anal, ut64 addr) {
 R_API bool r_anal_global_retype(RAnal *anal, ut64 addr, const char *new_type) {
 	RFlagItem *fi = r_anal_global_get (anal, addr);
 	if (fi) {
-		r_flag_item_set_type (fi, new_type);
+		RFlag *flags = anal->flb.f;
+		r_flag_item_set_type (flags, fi, new_type);
 		return true;
 	}
 	return false;
@@ -70,7 +71,13 @@ R_API bool r_anal_global_rename(RAnal *anal, ut64 addr, const char *new_name) {
 R_API const char *r_anal_global_get_type(RAnal *anal, ut64 addr) {
 	RFlagItem *fi = r_anal_global_get (anal, addr);
 	if (fi) {
+#if METAFLAG
+		RFlag *flags = anal->flb.f;
+		RFlagItemMeta *fim = r_flag_get_meta (flags, fi->id);
+		return fim? fim->type: NULL;
+#else
 		return fi->type;
+#endif
 	}
 	return NULL;
 }

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2627,7 +2627,15 @@ static bool bin_symbols(RCore *core, PJ *pj, int mode, ut64 laddr, int va, ut64 
 					RFlagItem *fi = r_flag_set (core->flags, fnp, addr, symbol->size);
 					if (fi) {
 						r_flag_item_set_realname (fi, n);
-						fi->demangled = (bool)(size_t)sn.demname;
+#if 0 && METAFLAG
+						bool is_demangled = (bool)(size_t)sn.demname;
+						if (is_demangled) {
+							RFlagItemMeta *fim = r_flag_get_meta2 (core->flags, fi);
+							fim->demangled = true;
+						}
+#else
+						fi->demangled = true;
+#endif
 					} else {
 						if (fn) {
 							R_LOG_WARN ("Can't find flag (%s)", fn);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -14650,7 +14650,16 @@ static void cmd_avg(RCore *core, const char* input) {
 			} else {
 				RFlagItem *fi = r_anal_global_get (core->anal, core->addr);
 				if (fi) {
-					R_LOG_INFO ("type %s", fi->type);
+#if METAFLAG
+					RFlagItemMeta *fim = r_flag_get_meta (core->flags, fi->id);
+					if (fim && fim->type) {
+						R_LOG_INFO ("type %s", fim->type);
+					}
+#else
+					if (fi->type) {
+						R_LOG_INFO ("type %s", fi->type);
+					}
+#endif
 				}
 			}
 			free (a);

--- a/libr/core/cmd_flag.inc.c
+++ b/libr/core/cmd_flag.inc.c
@@ -1070,7 +1070,7 @@ static bool cmd_flag_add(R_NONNULL RCore *core, const char *str, bool addsign) {
 		item = r_flag_set (core->flags, cstr, off, bsze);
 	}
 	if (item && comment) {
-		r_flag_item_set_comment (item, comment);
+		r_flag_item_set_comment (core->flags, item, comment);
 		if (comment_needs_free) {
 			free (comment);
 		}
@@ -1641,21 +1641,24 @@ static int cmd_flag(void *data, const char *input) {
 					if (!strncmp (q + 1, "base64:", 7)) {
 						dec = (char *) r_base64_decode_dyn (q + 8, -1);
 						if (dec) {
-							r_flag_item_set_comment (item, dec);
+							r_flag_item_set_comment (core->flags, item, dec);
 							free (dec);
 						} else {
 							R_LOG_ERROR ("Failed to decode base64-encoded string");
 						}
 					} else {
-						r_flag_item_set_comment (item, q + 1);
+						r_flag_item_set_comment (core->flags, item, q + 1);
 					}
 				} else {
 					R_LOG_ERROR ("Cannot find flag with name '%s'", p);
 				}
 			} else {
 				item = r_flag_get_in (core->flags, r_num_math (core->num, p));
-				if (item && item->comment) {
-					r_cons_println (item->comment);
+				if (item) {
+					const char *cmt = r_flag_item_set_comment (core->flags, item, NULL);
+					if (cmt) {
+						r_cons_println (cmt);
+					}
 				} else {
 					R_LOG_ERROR ("Cannot find item");
 				}
@@ -1722,7 +1725,7 @@ static int cmd_flag(void *data, const char *input) {
 				item = r_flag_get_in (core->flags, core->addr);
 			}
 			if (item) {
-				r_flag_item_set_realname (item, realname);
+				r_flag_item_set_realname (core->flags, item, realname);
 			}
 			break;
 		}

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -2620,9 +2620,12 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 							free (flagname);
 							flagname = fnear->name;
 						}
+#if 0
+// TODO missing color here?
 						if (fnear->color) {
 							curflag = fnear;
 						}
+#endif
 						if (!curflag) {
 							curflag = fnear;
 						}
@@ -2632,16 +2635,17 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 			} else {
 				r_list_foreach (list, iter, fi) {
 					flagsize = R_MAX (flagsize, fi->size);
-					if (fi->color) {
+					const char *fi_color = r_flag_item_set_color (core->flags, fi, NULL);
+					if (fi_color) {
 						curflag = fi;
 					}
-					if (!flagaddr || fi->color) {
+					if (!flagaddr || fi_color) {
 						flagaddr = fi->addr;
 						if (fi->addr == at) {
 							free (flagname);
 							flagname = strdup (fi->name);
 						}
-						if (!fi->color) {
+						if (!fi_color) {
 							curflag = fi;
 						}
 					}
@@ -2705,8 +2709,15 @@ static void annotated_hexdump(RCore *core, const char *str, int len) {
 					}
 				} else if (!hascolor) {
 					hascolor = true;
-					if (curflag && curflag->color) {
-						char *ansicolor = r_cons_pal_parse (curflag->color, NULL);
+					const char *curcolor = NULL;
+					if (curflag) {
+						const char *fimcolor = r_flag_item_set_color (core->flags, curflag, NULL);
+						if (fimcolor) {
+							curcolor = fimcolor;
+						}
+					}
+					if (curcolor) {
+						char *ansicolor = r_cons_pal_parse (curcolor, NULL);
 						if (ansicolor) {
 							append (ebytes, ansicolor);
 							append (echars, ansicolor);

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2102,10 +2102,13 @@ R_API const char *r_core_anal_optype_colorfor(RCore *core, ut64 addr, ut8 ch, bo
 	if (!verbose) {
 		// check for flag colors
 		RFlagItem *fi = r_flag_get_at (core->flags, addr, true);
-		if (fi && fi->addr + fi->size >= addr && fi->color) {
-			free (const_color);
-			const_color = r_cons_pal_parse (fi->color, NULL);
-			return const_color;
+		if (fi && fi->addr + fi->size >= addr) {
+			const char *ficolor = r_flag_item_set_color (core->flags, fi, NULL);
+			if (ficolor) {
+				free (const_color);
+				const_color = r_cons_pal_parse (ficolor, NULL);
+				return const_color;
+			}
 		}
 		return NULL;
 	}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -2576,7 +2576,7 @@ static void __preline_flag(RDisasmState *ds, RFlagItem *fi) {
 	if (ds->show_color) {
 		bool hasColor = false;
 #if METAFLAG
-		RFlagItemMeta *fim = r_flag_get_meta (ds->core, fi->id);
+		RFlagItemMeta *fim = r_flag_get_meta (ds->core->flags, fi->id);
 		if (fim && fim->color) {
 			char *color = r_cons_pal_parse (fim->color, NULL);
 			if (color) {

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -4496,7 +4496,7 @@ onemoretime:
 				r_cons_flush ();
 				r_line_set_prompt ("color: ");
 				if (r_cons_fgets (cmd, sizeof (cmd), 0, NULL) > 0) {
-					r_flag_item_set_color (item, cmd);
+					r_flag_item_set_color (core->flags, item, cmd);
 					r_cons_set_raw (1);
 					r_cons_show_cursor (false);
 				}

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -858,7 +858,7 @@ R_API const char *r_flag_item_set_realname(RFlag *f, RFlagItem *item, const char
 
 /* add/replace/remove the color of a flag item */
 R_API const char *r_flag_item_set_color(RFlag *f, RFlagItem *fi, R_NULLABLE const char *color) {
-	R_RETURN_VAL_IF_FAIL (f && fi && color, NULL);
+	R_RETURN_VAL_IF_FAIL (f && fi, NULL);
 #if METAFLAG
 	RFlagItemMeta *fim;
 	if (color) {

--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -186,6 +186,16 @@ static void ht_free_flag(HtPPKv *kv) {
 	}
 }
 
+static void ht_free_meta(HtUPKv *kv) {
+	if (kv) {
+		// free (kv->key);
+		RFlagItemMeta *fim = (RFlagItemMeta *)kv->value;
+		free (fim->comment);
+		free (fim->color);
+		free (fim);
+	}
+}
+
 static bool count_flags(RFlagItem *fi, void *user) {
 	int *count = (int *)user;
 	(*count)++;
@@ -230,6 +240,7 @@ R_API RFlag *r_flag_new(void) {
 	f->zones = r_list_newf (r_flag_zone_item_free);
 	f->tags = sdb_new0 ();
 	f->ht_name = ht_pp_new (NULL, ht_free_flag, NULL);
+	f->ht_meta = ht_up_new (NULL, ht_free_meta, NULL);
 	f->by_addr = r_skiplist_new (flag_skiplist_free, flag_skiplist_cmp);
 	new_spaces (f);
 	R_DIRTY_SET (f);
@@ -795,7 +806,7 @@ R_API RFlagItem *r_flag_set(RFlag *f, const char *name, ut64 addr, ut32 size) {
 		is_new = true;
 		f->lastid++;
 	}
-
+	item->id = f->lastid;
 	item->space = r_flag_space_cur (f);
 	item->size = size;
 

--- a/libr/include/r_flag.h
+++ b/libr/include/r_flag.h
@@ -36,8 +36,8 @@ typedef struct r_flags_at_addr_t {
 typedef struct r_flag_item_meta_t {
 	char *type;
 	char *color;    /* item color */
-#if 0
 	char *comment;  /* item comment */
+#if 0
 	char *alias;    /* used to define a flag based on a math expression (e.g. foo + 3) */
 	bool demangled; /* real name from demangling? */
 #endif
@@ -50,10 +50,10 @@ typedef struct r_flag_item_t {
 	ut64 addr;      /* address of the flag */
 	ut64 size;      /* size of the flag item */
 	RSpace *space;  /* flag space this item belongs to */
-	char *comment;  /* item comment */
 	char *alias;    /* used to define a flag based on a math expression (e.g. foo + 3) */
 	bool demangled; /* real name from demangling? */
 #if 0
+	char *comment;  /* item comment */
 	char *color;    /* item color */
 	char *type;
 #endif
@@ -157,8 +157,8 @@ R_API RFlagItem *r_flag_set_inspace(RFlag *f, const char *space, const char *nam
 R_API RFlagItem *r_flag_set_next(RFlag *fo, const char *name, ut64 addr, ut32 size);
 R_API void r_flag_item_set_alias(RFlagItem *item, const char *alias);
 R_API void r_flag_item_free(RFlagItem *item);
-R_API void r_flag_item_set_comment(RFlagItem *item, const char *comment);
-R_API void r_flag_item_set_realname(RFlagItem *item, const char *realname);
+R_API const char *r_flag_item_set_comment(RFlag *f, RFlagItem *fi, R_NULLABLE const char *comment);
+R_API const char *r_flag_item_set_realname(RFlag *f, RFlagItem *fi, const char *realname);
 R_API const char *r_flag_item_set_color(RFlag *f, RFlagItem *item, R_NULLABLE const char *color);
 R_API RFlagItem *r_flag_item_clone(RFlagItem *item);
 R_API int r_flag_unset_glob(RFlag *f, const char *name);

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -733,28 +733,28 @@ colu: 1
 addr: 0x00001176
 EOF
 EXPECT_ERR=<<EOF
-DEBUG: [cbin.c:3378] (section .dynsym) Cd 8[21] @ 0x3d8
-DEBUG: [cbin.c:3378] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3378] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3378] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3378] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3378] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3378] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3378] (section .got) Cd 8[9] @ 0x3fb8
-DEBUG: [cbin.c:3378] (section .dynsym) Cd 8[21] @ 0x3d8
-DEBUG: [cbin.c:3378] (section .dynstr) Css 141 @ 0x480
-DEBUG: [cbin.c:3378] (section .rela.dyn) Cd 8[24] @ 0x550
-DEBUG: [cbin.c:3378] (section .rela.plt) Cd 8[3] @ 0x610
-DEBUG: [cbin.c:3378] (section .init_array) Cd 8[1] @ 0x3db8
-DEBUG: [cbin.c:3378] (section .fini_array) Cd 8[1] @ 0x3dc0
-DEBUG: [cbin.c:3378] (section .dynamic) Cd 8[62] @ 0x3dc8
-DEBUG: [cbin.c:3378] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3387] (section .dynsym) Cd 8[21] @ 0x3d8
+DEBUG: [cbin.c:3387] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3387] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3387] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3387] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3387] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3387] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3387] (section .got) Cd 8[9] @ 0x3fb8
+DEBUG: [cbin.c:3387] (section .dynsym) Cd 8[21] @ 0x3d8
+DEBUG: [cbin.c:3387] (section .dynstr) Css 141 @ 0x480
+DEBUG: [cbin.c:3387] (section .rela.dyn) Cd 8[24] @ 0x550
+DEBUG: [cbin.c:3387] (section .rela.plt) Cd 8[3] @ 0x610
+DEBUG: [cbin.c:3387] (section .init_array) Cd 8[1] @ 0x3db8
+DEBUG: [cbin.c:3387] (section .fini_array) Cd 8[1] @ 0x3dc0
+DEBUG: [cbin.c:3387] (section .dynamic) Cd 8[62] @ 0x3dc8
+DEBUG: [cbin.c:3387] (section .got) Cd 8[9] @ 0x3fb8
 WARN: [cbin.c:1937] Relocs has not been applied. Please use `-e bin.relocs.apply=true` or `-e bin.cache=true` next time
-DEBUG: [cbin.c:2625] Cannot resolve symbol address __libc_start_main
-DEBUG: [cbin.c:2625] Cannot resolve symbol address _ITM_deregisterTMCloneTable
-DEBUG: [cbin.c:2625] Cannot resolve symbol address __gmon_start__
-DEBUG: [cbin.c:2625] Cannot resolve symbol address _ITM_registerTMCloneTable
-DEBUG: [cbin.c:2625] Cannot resolve symbol address __cxa_finalize
+DEBUG: [cbin.c:2626] Cannot resolve symbol address __libc_start_main
+DEBUG: [cbin.c:2626] Cannot resolve symbol address _ITM_deregisterTMCloneTable
+DEBUG: [cbin.c:2626] Cannot resolve symbol address __gmon_start__
+DEBUG: [cbin.c:2626] Cannot resolve symbol address _ITM_registerTMCloneTable
+DEBUG: [cbin.c:2626] Cannot resolve symbol address __cxa_finalize
 EOF
 RUN
 


### PR DESCRIPTION
The RFlagItem has several metadata fields: color, comment, alias, type​. These provide useful annotations (color coding, comments, expression alias, and a user-defined type tag). If any of these are rarely used or redundant, they could be candidates for removal in a future major version to streamline the struct. For example, if “type” is not actively used by radare2 (one might check how it’s used in practice), its purpose might be covered by either flag spaces or tags. If so, it could be dropped. However, removing a field is a breaking change, so only do so with strong justification (memory savings or replacing with a better system).