### PR TITLE
Run aavr during aaa on Swift bins ##core

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -13925,6 +13925,15 @@ static bool cmd_aa(RCore *core, bool aaa) {
 	return true;
 }
 
+static bool is_swift(RCore *core) {
+	const char *vlang = r_config_get (core->config, "bin.lang");
+	r_str_var (lang, 16, vlang);
+	if (*lang) {
+		return !strcmp (lang, "swift");
+	}
+	return false;
+}
+
 static void cmd_aaa(RCore *core, const char *input) {
 	if (strchr (input, '?')) {
 		r_core_cmd_help (core, help_msg_aaa);
@@ -14183,6 +14192,9 @@ static void cmd_aaa(RCore *core, const char *input) {
 				r_core_cmd_call (core, "aavq");
 			}
 			r_core_task_yield (&core->tasks);
+		}
+		if (is_swift (core)) {
+			r_core_cmd0 (core, "aavr@e:anal.in=bin.sections.rw");
 		}
 		r_core_cmd_call (core, "s-");
 		if (dh_orig) {

--- a/test/db/anal/aavr
+++ b/test/db/anal/aavr
@@ -10,3 +10,15 @@ EXPECT=<<EOF
 0x100011328
 EOF
 RUN
+
+NAME=aaa in swift implies avr on rw sections
+FILE=bins/mach0/SwiftAsynciOS
+CMDS=<<EOF
+s 0x100007504
+aaa
+axtq
+EOF
+EXPECT=<<EOF
+0x100011328
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

When `bin.lang` is set to `swift`, the `aaa` command will now also run `aavr@e:anal.in=bin.sections.rw`.
This helps finding references to code from Swift metadata.
