### PR TITLE
Skip __objc_catlist2 in dyldcache parsing ##bin

### DIFF
--- a/libr/bin/p/bin_dyldcache.c
+++ b/libr/bin/p/bin_dyldcache.c
@@ -1483,7 +1483,7 @@ static RList *classes(RBinFile *bf) {
 			}
 
 			bool is_classlist = strstr (section->name, "__objc_classlist");
-			bool is_catlist = strstr (section->name, "__objc_catlist");
+			bool is_catlist = strstr (section->name, "__objc_catlist") && !strstr (section->name, "__objc_catlist2");
 
 			if (!is_classlist && !is_catlist) {
 				continue;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Because it's not the same as `__objc_catlist`, so attempting to parse the same structures there fails with noisy warnings.
