### PR TITLE
Fix maybe-uninitialized warn from ubuntu22 gcc in xpatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
           - arch: i386
             gcc: multilib
     # TODO: Update to 22.04 when xpatch.c warnings have been fixed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/libr/core/xpatch.c
+++ b/libr/core/xpatch.c
@@ -97,9 +97,9 @@ static bool ubp_parseBlock(char *line, UBP_Block *b) {
 R_API bool r_core_patch_unified(RCore *core, const char *patch, int level, bool revert) {
 	R_RETURN_VAL_IF_FAIL (core && patch, false);
 	RIODesc *desc = NULL;
-	UBP_File ubpFileAdd;
-	UBP_File ubpFileDel;
-	UBP_Block ubpBlock;
+	UBP_File ubpFileAdd = {0};
+	UBP_File ubpFileDel = {0};
+	UBP_Block ubpBlock = {0};
 #if 0
 	UBP_Entry ubpAdd;
 	UBP_Entry ubpDel;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
