### PR TITLE
Implement asm.lines.split to show backward branch lines in a separated column ##disasm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3658,7 +3658,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETDESC (n, "set arch endianness");
 	SETOPTIONS (n, "big", "little", "bigswap", "littleswap", NULL);
 	// SETCB ("arch.autoselect", "false", &cb_archautoselect, "automagically select matching decoder on arch related config changes (has no effect atm)");
-	SETICB ("asm.lines.maxref", 0, &cb_analmaxrefs, "maximum number of reflines to be analyzed and displayed in asm.lines with pd");
 
 	SETCB ("anal.jmp.tbl", "true", &cb_anal_jmptbl, "analyze jump tables in switch statements");
 
@@ -3786,7 +3785,6 @@ R_API int r_core_config_init(RCore *core) {
 	SETBPREF ("asm.sub.names", "true", "replace numeric values by flags (e.g. 0x4003e0 -> sym.imp.printf)");
 	SETPREF ("asm.strip", "", "strip all instructions given comma separated types");
 	SETBPREF ("asm.optype", "false", "show opcode type next to the instruction bytes");
-	SETBPREF ("asm.lines.fcn", "true", "show function boundary lines");
 	SETBPREF ("asm.flags", "true", "show flags");
 	SETBPREF ("asm.flags.prefix", "true", "show ;-- before the flags");
 	SETICB ("asm.flags.maxname", 0, &cb_maxname, "maximum length of flag name with smart chopping");
@@ -3804,8 +3802,11 @@ R_API int r_core_config_init(RCore *core) {
 	       "show flags' unfiltered realnames instead of names, except realnames from demangling");
 	SETBPREF ("asm.lbytes", "true", "align disasm bytes to left");
 	SETBPREF ("asm.lines", "true", "show ASCII-art lines at disassembly");
+	SETBPREF ("asm.lines.fcn", "true", "show function boundary lines");
+	SETICB ("asm.lines.maxref", 0, &cb_analmaxrefs, "maximum number of reflines to be analyzed and displayed in asm.lines with pd");
 	SETBPREF ("asm.lines.jmp", "true", "show flow lines at jumps");
 	SETI ("asm.lines.limit", 4096*4, "dont show control flow lines if function is larger than X bytes");
+	SETBPREF ("asm.lines.split", "false", "show up/down lines splitted form");
 	SETBPREF ("asm.lines.bb", "false", "show empty line after every basic block");
 	SETBPREF ("asm.lines.call", "false", "enable call lines");
 	SETBPREF ("asm.lines.ret", "false", "show separator lines after ret");

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -62,6 +62,15 @@ typedef struct r_anal_range_t {
 } RAnalRange;
 
 enum {
+	R_ANAL_REFLINE_TYPE_UTF8 = 1,
+	R_ANAL_REFLINE_TYPE_WIDE = 2,  /* reflines have a space between them */
+	R_ANAL_REFLINE_TYPE_MIDDLE_BEFORE = 4, /* do not consider starts/ends of
+	                                        * reflines (used for comment lines before disasm) */
+	R_ANAL_REFLINE_TYPE_MIDDLE_AFTER = 8, /* as above but for lines after disasm */
+	R_ANAL_REFLINE_TYPE_SPLIT = 16 /* use reflines2 for upward lines */
+};
+
+enum {
 	R_ANAL_DATA_TYPE_NULL = 0,
 	R_ANAL_DATA_TYPE_UNKNOWN = 1,
 	R_ANAL_DATA_TYPE_STRING = 2,
@@ -472,6 +481,7 @@ typedef struct r_anal_t {
 	RAnalCallbacks cb;
 	RAnalOptions opt;
 	RList *reflines;
+	RList *reflines2;
 	RListComparator columnSort;
 	int stackptr;
 	bool (*log)(struct r_anal_t *anal, const char *msg);
@@ -1232,7 +1242,7 @@ R_API int walkthrough_arm_jmptbl_style(RAnal *anal, RAnalFunction *fcn, RAnalBlo
 
 /* reflines.c */
 R_API RList* /*<RAnalRefline>*/ r_anal_reflines_get(RAnal *anal,
-		ut64 addr, const ut8 *buf, ut64 len, int nlines, int linesout, int linescall);
+		ut64 addr, const ut8 *buf, ut64 len, int nlines, int linesout, int linescall, int splitmode);
 R_API int r_anal_reflines_middle(RAnal *anal, RList *list, ut64 addr, int len);
 R_API RAnalRefStr *r_anal_reflines_str(void *core, ut64 addr, int opts);
 R_API void r_anal_reflines_str_free(RAnalRefStr *refstr);

--- a/libr/include/r_anal/op.h
+++ b/libr/include/r_anal/op.h
@@ -185,14 +185,6 @@ typedef enum {
 } RAnalCondType;
 
 enum {
-	R_ANAL_REFLINE_TYPE_UTF8 = 1,
-	R_ANAL_REFLINE_TYPE_WIDE = 2,  /* reflines have a space between them */
-	R_ANAL_REFLINE_TYPE_MIDDLE_BEFORE = 4, /* do not consider starts/ends of
-	                                        * reflines (used for comment lines before disasm) */
-	R_ANAL_REFLINE_TYPE_MIDDLE_AFTER = 8 /* as above but for lines after disasm */
-};
-
-enum {
 	R_ANAL_RET_NOP = 0,
 	R_ANAL_RET_ERROR = -1,
 	R_ANAL_RET_DUP = -2,

--- a/test/db/cmd/metadata
+++ b/test/db/cmd/metadata
@@ -75,8 +75,8 @@ EXPECT=<<EOF
 0x00000002 ; (Cr 2 pd 1)
 0x00000002 ; (Cr 2 pd 1)
 0x00000002 ; (Cr 2 pd 1)
-  0x00000004      c3             ret
-  0x00000005      c3             ret
+            0x00000004      c3             ret
+            0x00000005      c3             ret
 EOF
 RUN
 


### PR DESCRIPTION
![photo_2025-03-14 22 53 16](https://github.com/user-attachments/assets/aeb531d5-d0c4-4d0c-ab0c-77dfaef309ea)
![photo_2025-03-14 22 53 13](https://github.com/user-attachments/assets/e2a74db3-5123-44b8-8394-af66b5abae8d)
