### PR TITLE
Fix assert on Windows related to signed arg on isalpha* ##crash

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4244,7 +4244,7 @@ static void goto_asmqjmps(RAGraph *g, RCore *core) {
 		char ch = r_cons_readchar ();
 		obuf[i++] = ch;
 		r_cons_write (&ch, 1);
-		cont = isalpha ((ut8) ch) && !islower ((ut8) ch);
+		cont = isalpha (ch & 0xff) && !islower (ch & 0xff);
 	} while (i < R_CORE_ASMQJMPS_LEN_LETTERS && cont);
 	r_cons_flush ();
 

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2121,7 +2121,7 @@ static int var_cmd(RCore *core, const char *str) {
 			r_anal_function_delete_vars_by_kind (fcn, type);
 		} else {
 			RAnalVar *var = NULL;
-			if (isdigit (str[2])) {
+			if (isdigit (str[2] & 0xff)) {
 				var = r_anal_function_get_var (fcn, type, (int)r_num_math (core->num, str + 1));
 			} else {
 				char *name = r_str_trim_dup (str + 2);
@@ -6939,7 +6939,7 @@ void cmd_anal_reg(RCore *core, const char *str) {
 				for (j = i; str[++j] && str[j] != ','; );
 				if (j - i + 1 <= sizeof name) {
 					r_str_ncpy (name, str + i, j - i + 1);
-					if (isdigit (name[0])) { // e.g. ar 32
+					if (isdigit (name[0] & 0xff)) { // e.g. ar 32
 						__anal_reg_list (core, R_REG_TYPE_GPR, atoi (name), '\0');
 					} else if (showreg (core, name) > 0) {
 						// e.g. ar rax
@@ -7699,7 +7699,7 @@ static bool myregwrite(REsil *esil, const char *name, ut64 *val) {
 		r_list_pop (stats->regread);
 		R_FREE (oldregread)
 	}
-	if (!isdigit (*name)) {
+	if (!isdigit (*name & 0xff)) {
 		if (!contains (stats->regs, name)) {
 			r_list_push (stats->regs, strdup (name));
 		}
@@ -7717,7 +7717,7 @@ static bool myregwrite(REsil *esil, const char *name, ut64 *val) {
 
 static bool myregread(REsil *esil, const char *name, ut64 *val, int *len) {
 	AeaStats *stats = esil->user;
-	if (!isdigit (*name)) {
+	if (!isdigit (*name & 0xff)) {
 		if (!contains (stats->inputregs, name)) {
 			if (!contains (stats->regwrite, name)) {
 				r_list_push (stats->inputregs, strdup (name));
@@ -9660,7 +9660,7 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 				free (ops);
 			}
 		} else if (input[1] == 'l' || input[1] == '=' || input[1] == ' ' || input[1] == 'j') {
-			if (input[1] == ' ' && !isdigit (input[2])) {
+			if (input[1] == ' ' && !isdigit (input[2] & 0xff)) {
 				r_cons_printf ("%d\n", r_asm_mnemonics_byname (core->rasm, input + 2));
 			} else {
 				// "aoml"
@@ -10149,7 +10149,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 	case 'c': // "asc"
 		if (input[1] == 'a') {
 			if (input[2] == ' ') {
-				if (!isalpha ((ut8)input[3]) && (n = r_num_math (core->num, input + 3)) >= 0 ) {
+				if (!isalpha (input[3] & 0xff) && (n = r_num_math (core->num, input + 3)) >= 0 ) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf (".equ SYS_%s %s\n", si->name, syscallNumber (snstr, n));
@@ -10174,7 +10174,7 @@ static void cmd_anal_syscall(RCore *core, const char *input) {
 			}
 		} else {
 			if (input[1] == ' ') {
-				if (!isalpha ((ut8)input[2]) && (n = r_num_math (core->num, input + 2)) >= 0) {
+				if (!isalpha (input[2] & 0xff) && (n = r_num_math (core->num, input + 2)) >= 0) {
 					si = r_syscall_get (core->anal->syscall, n, -1);
 					if (si) {
 						r_cons_printf ("#define SYS_%s %s\n", si->name, syscallNumber (snstr, n));
@@ -11255,7 +11255,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 			r_anal_hint_set_immbase (core->anal, addr? addr: core->addr, 0);
 			break;
 		}
-		if (isdigit ((ut8)input[1])) {
+		if (isdigit (input[1] & 0xff)) {
 			r_anal_hint_set_nword (core->anal, core->addr, input[1] - '0');
 			input++;
 		}

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -2375,7 +2375,7 @@ static bool check_false_positive(const char *s) {
 	}
 	bool ok = true;
 	int rep = 0;
-	char s0 = *s;
+	ut8 s0 = *s;
 	if (!isalpha (s0) && !isdigit (s0)) {
 		return false;
 	}

--- a/libr/main/r2pm.c
+++ b/libr/main/r2pm.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2021-2024 - pancake */
+/* radare - LGPL - Copyright 2021-2025 - pancake */
 
 #define R_LOG_ORIGIN "r2pm"
 
@@ -193,10 +193,7 @@ static char *find_newline(char *s) {
 	if (r && n) {
 		return (r < n)? r: n;
 	}
-	if (r) {
-		return r;
-	}
-	return n;
+	return r? r: n;
 
 }
 static char *r2pm_get(const char *file, const char *token, R2pmTokenType type) {

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -1057,7 +1057,7 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		if (dis) {
 			char *usrstr = strdup (opt.argv[opt.ind]);
 			if (dis == 3) {
-				if (isalpha (usrstr[0])) {
+				if (isalpha (usrstr[0]) & 0xff) {
 					// assemble and get the string back
 					RAsmCode *acode = r_asm_rasm_assemble (as->a, usrstr, as->opt.use_spp);
 					if (!acode) {

--- a/libr/search/keyword.c
+++ b/libr/search/keyword.c
@@ -32,9 +32,6 @@ R_API RSearchKeyword* r_search_keyword_new(const ut8 *kwbuf, int kwlen, const ut
 		return NULL;
 	}
 	kw = R_NEW0 (RSearchKeyword);
-	if (!kw) {
-		return NULL;
-	}
 	kw->type = R_SEARCH_KEYWORD_TYPE_BINARY;
 	kw->data = (void *) data;
 	kw->keyword_length = kwlen;
@@ -224,7 +221,7 @@ R_API RSearchKeyword *r_search_keyword_new_regexp(const char *str, const char *d
 	for (start = i; str[i]; i++) {
 		if (str[i] == '/' && str[i - 1] != '\\') {
 			break;
-		} else if (str[i - 1] == '\\' && isalpha ((unsigned char)str[i])) {
+		} else if (str[i - 1] == '\\' && isalpha (str[i] & 0xff)) {
 			specials++;
 		}
 	}

--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2024 - pancake */
+/* radare - LGPL - Copyright 2007-2025 - pancake */
 
 #define R_LOG_ORIGIN "util.file"
 

--- a/libr/util/name.c
+++ b/libr/util/name.c
@@ -5,7 +5,7 @@
 /* Validate if char is printable , why not use ISPRINTABLE() ?? */
 R_API bool r_name_validate_print(const char ch) {
 	// TODO: support utf8
-	if (isalpha (ch) || isdigit (ch)) {
+	if (isalpha (ch & 0xff) || isdigit (ch & 0xff)) {
 		return true;
 	}
 	const char chars[] = "()[]<>+-$%@ .,:_";
@@ -22,7 +22,7 @@ R_API bool r_name_validate_dash(const char ch) {
 }
 
 R_API bool r_name_validate_char(const char ch) {
-	if (isalpha (ch) || isdigit (ch)) {
+	if (isalpha (ch & 0xff) || isdigit (ch & 0xff)) {
 		return true;
 	}
 	return (ch == '.' || ch == ':' || ch == '_');

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -2234,7 +2234,7 @@ static bool issymbol(char c) {
 static bool check_arg_name(RPrint *print, char *p, ut64 func_addr) {
 	if (func_addr && print->exists_var) {
 		int z;
-		for (z = 0; p[z] && (isalpha ((unsigned char)p[z]) || isdigit ((unsigned char)p[z]) || p[z] == '_'); z++) {
+		for (z = 0; p[z] && (isalpha (p[z] & 0xff) || isdigit (p[z] & 0xff) || p[z] == '_'); z++) {
 			;
 		}
 		char tmp = p[z];
@@ -2251,7 +2251,7 @@ static bool ishexprefix(char *p) {
 }
 
 static bool is_not_token(const char p) {
-	if (isalpha (p) || isdigit (p)) {
+	if (isalpha (p & 0xff) || isdigit (p & 0xff)) {
 		return true;
 	}
 	switch (p) {
@@ -2263,7 +2263,7 @@ static bool is_not_token(const char p) {
 }
 
 static bool is_flag(const char *p) {
-	while (*p && !isalpha (*p) && !isdigit (*p)) {
+	while (*p && !isalpha (*p & 0xff) && !isdigit (*p & 0xff)) {
 		if (*p == 0x1b) {
 			while (*p && *p != 'm') {
 				p++;
@@ -2275,7 +2275,7 @@ static bool is_flag(const char *p) {
 	while (*e && is_not_token (*e)) {
 		e++;
 	}
-	if (*p == 'r' && isdigit (p[1])) {
+	if (*p == 'r' && isdigit (p[1] & 0xff)) {
 		p++;
 	}
 	size_t len = e? e - p: strlen (p);
@@ -2317,7 +2317,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 		}
 		/* colorize numbers */
 		if ((ishexprefix (p + i) && previous != ':') \
-		     || (isdigit ((ut8)p[i]) && issymbol (previous))) {
+		     || (isdigit (p[i] & 0xff) && issymbol (previous))) {
 			const char *num2 = num;
 			ut64 n = r_num_get (NULL, p + i);
 			const char *name = print->offname (print->user, n)? color_flag: NULL;
@@ -2382,7 +2382,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 				strcpy (o + j, reset);
 				j += strlen (reset);
 				o[j] = p[i];
-				if (!(p[i + 1] == '$' || isdigit (p[i + 1]))) {
+				if (!(p[i + 1] == '$' || isdigit (p[i + 1] & 0xff))) {
 					const char *color = found_var ? print->cons->context->pal.var_type : reg;
 					expect_reg = false;
 					if (is_flag (p + i)) {

--- a/libr/util/token.c
+++ b/libr/util/token.c
@@ -82,7 +82,7 @@ static bool start_token(RTokenizer *tok, char ch) {
 		tok->type = R_TOKEN_MATH;
 		return false;
 	}
-	if (isalpha (ch)) {
+	if (isalpha (ch & 0xff)) {
 		tok->type = R_TOKEN_WORD;
 	}
 	if (ch >= '0' && ch <= '9') {
@@ -100,7 +100,7 @@ static bool is_token_char(RTokenizer *tok, char ch) {
 		// ERROR
 		return false;
 	case R_TOKEN_HASH:
-		return (isdigit (ch) || ch == '#' || ch == '_') || (isalpha (ch) && !IS_WHITESPACE (ch));
+		return (isdigit (ch & 0xff) || ch == '#' || ch == '_') || (isalpha (ch & 0xff) && !IS_WHITESPACE (ch));
 	case R_TOKEN_COMMENT:
 		if (tok->end-tok->begin == 0) {
 			if (ch != '/') {
@@ -110,7 +110,7 @@ static bool is_token_char(RTokenizer *tok, char ch) {
 		}
 		return (ch != '\n');
 	case R_TOKEN_WORD:
-		return (isdigit (ch) || ch == '#' || ch == '_') || (isalpha (ch) && !IS_WHITESPACE (ch));
+		return (isdigit (ch & 0xff) || ch == '#' || ch == '_') || (isalpha (ch & 0xff) && !IS_WHITESPACE (ch));
 	case R_TOKEN_INT:
 		if (ch == 'x') {
 			tok->hex = true;
@@ -130,7 +130,7 @@ static bool is_token_char(RTokenizer *tok, char ch) {
 		}
 		return ch >= '0' && ch <= '9';
 	case R_TOKEN_FLOAT:
-		return isdigit (ch) || ch == 'f'; // XXX 'f' is the last char
+		return isdigit (ch & 0xff) || ch == 'f'; // XXX 'f' is the last char
 	case R_TOKEN_STRING:
 		if (tok->escape) {
 			tok->escape = false;


### PR DESCRIPTION
* Windows asserts when isalpha/isdigit/isupper/islower gets <-1 as argument
* This happens because char is signed

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
