### PR TITLE
Fix r_sys_breakpoint on gcc ##debug

### DIFF
--- a/libr/include/r_util/r_sys.h
+++ b/libr/include/r_util/r_sys.h
@@ -109,9 +109,7 @@ R_API bool r_sys_tts(const char *txt, bool bg);
 #if R2__WINDOWS__
 #  define r_sys_breakpoint() { __debugbreak  (); }
 #else
-#if __GNUC__ && !defined(__TINYC__)
-#  define r_sys_breakpoint() __builtin_trap()
-#elif __i386__ || __x86_64__
+#if __i386__ || __x86_64__
 #   define r_sys_breakpoint() __asm__ volatile ("int3");
 #elif __arm64__ || __aarch64__ || __arm64e__
 #  define r_sys_breakpoint() __asm__ volatile ("brk 0");
@@ -130,6 +128,8 @@ R_API bool r_sys_tts(const char *txt, bool bg);
 #elif __EMSCRIPTEN__
 // TODO: cannot find a better way to breakpoint in wasm/asm.js
 #  define r_sys_breakpoint() { char *a = NULL; *a = 0; }
+#elif __GNUC__ && !defined(__TINYC__)
+#  define r_sys_breakpoint() __builtin_trap()
 #else
 #  warning r_sys_breakpoint not implemented for this platform
 #  define r_sys_trap() __asm__ __volatile__ (".word 0");


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Move `__GNUC__ && !defined(__TINYC__)` to the bottom of the if statement. `__builtin_trap()` uses illegal instructions to force program to quit abnormally:

https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html#index-_005f_005fbuiltin_005ftrap

Use architecture specific traps before falling back to the gcc `__builtin_trap()`.