### PR TITLE
Alternative implementations of PEF (Mac OS 7-9/BeOS) executables

### DIFF
--- a/dist/plugins-cfg/plugins.def.cfg
+++ b/dist/plugins-cfg/plugins.def.cfg
@@ -131,6 +131,7 @@ bin.p9
 bin.pe
 bin.pe64
 bin.pebble
+bin.pef
 bin.pcap
 bin.prg
 bin.psxexe

--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -152,6 +152,7 @@ R_API RBinImport *r_bin_import_clone(RBinImport *o) {
 	RBinImport *res = r_mem_dup (o, sizeof (*o));
 	if (res) {
 		res->name = r_bin_name_clone (o->name);
+		res->libname = R_STR_DUP (o->libname);
 		res->classname = R_STR_DUP (o->classname);
 		res->descriptor = R_STR_DUP (o->descriptor);
 	}

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -22,7 +22,7 @@ FORMATS+=bios.mk mach064.mk dyldcache.mk xnu_kernelcache.mk java.mk
 FORMATS+=dex.mk fs.mk ningb.mk coff.mk xcoff64.mk ningba.mk xbe.mk zimg.mk
 FORMATS+=omf.mk cgc.mk dol.mk rel.mk nes.mk mbn.mk psxexe.mk
 FORMATS+=vsf.mk nin3ds.mk bflt.mk wasm.mk sfc.mk uf2.mk
-FORMATS+=mdmp.mk z64.mk qnx.mk prg.mk dmp64.mk xtac.mk
+FORMATS+=mdmp.mk z64.mk qnx.mk prg.mk dmp64.mk xtac.mk pef.mk
 
 FORMATS+=xtr_dyldcache.mk
 FORMATS+=xtr_fatmach0.mk

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -157,7 +157,6 @@ static RList *do_reloc_bytecode(RBuffer *b, ut32 at, ut32 instCount) {
 			at + 2*printpc, printpc, r_buf_read_be16_at(b, at+2*printpc), name, buf, codeA, dataA, rSymI, rAddr); \
 	}
 
-	// Abuse the RBinReloc struct fields slightly
 	#define PUSH_RELOC(ofs, targ, imp) { \
 		PEFReloc *r = R_NEW0(PEFReloc); \
 		r->offset = ofs; \

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -460,11 +460,6 @@ static RList *fields(RBinFile *bf) {
 	return ret;
 }
 
-// There is a "preferred base address" in PEF section headers but it is never used.
-static ut64 baddr(RBinFile *bf) {
-	return 0;
-}
-
 static ut64 size(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
 	ut64 s = 0;
@@ -738,7 +733,6 @@ RBinPlugin r_bin_plugin_pef = {
 	.destroy = &destroy,
 	.info = &info,
 	.fields = &fields,
-	.baddr = &baddr,
 	.size = &size,
 	.binsym = &binsym,
 	.sections = &sections,

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -734,7 +734,9 @@ static RList *symbols(RBinFile *bf) {
 		ut32 addr = r_buf_read_be32_at(bf->buf, ofs + 4);
 		st16 index = r_buf_read_be16_at(bf->buf, ofs + 8);
 		ut16 nameLen = r_buf_read_be16_at(bf->buf, stringLenTable + 4*i);
-		if (index < 0 || index >= pef->nsec) continue; // re-exported func or absolute mem address, not supported
+		if (index < 0 || index >= pef->nsec) {
+			continue; // re-exported func or absolute mem address, not supported
+		}
 
 		RBinSymbol *ptr = R_NEW0(RBinSymbol);
 		char *name = calloc(1, nameLen + 1);

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -599,7 +599,7 @@ static RList *imports(RBinFile *bf) {
 	ut32 importedLibraryCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 24);
 	ut32 totalImportedSymbolCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 28);
 	ut32 loaderStringsOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 40);
-	RBinImport **ary = R_NEWS (RBinImport *, totalImportedSymbolCount);
+	RBinImport **ary = calloc (RBinImport, totalImportedSymbolCount);
 	int i, j;
 
 	for (i=0; i<totalImportedSymbolCount; i++) {

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -60,7 +60,7 @@ static int unpack_pidata(char *dest, size_t dlen, const char *src, size_t slen) 
 		ut8 opcode = firstbyte >> 5;
 		ut32 arg = firstbyte & 0x1f;
 		if (arg == 0) {
-			if (pidata_getcount(&src, slim, &arg)) return 1;
+			if (pidata_getcount (&src, slim, &arg)) return 1;
 		}
 
 		if (opcode == 0) { // put zeros
@@ -76,7 +76,7 @@ static int unpack_pidata(char *dest, size_t dlen, const char *src, size_t slen) 
 		} else if (opcode == 2) { // repeated block
 			ut32 blockSize = arg;
 			ut32 repeatCountMin1;
-			if (pidata_getcount(&src, slim, &repeatCountMin1)) return 4;
+			if (pidata_getcount (&src, slim, &repeatCountMin1)) return 4;
 
 			do {
 				for (i=0; i<blockSize; i++) {
@@ -88,8 +88,8 @@ static int unpack_pidata(char *dest, size_t dlen, const char *src, size_t slen) 
 		} else if (opcode == 3) { // interleave repeatblock with customblock
 			ut32 commonSize = arg;
 			ut32 customSize, repeatCount;
-			if (pidata_getcount(&src, slim, &customSize)) return 6;
-			if (pidata_getcount(&src, slim, &repeatCount)) return 7;
+			if (pidata_getcount (&src, slim, &customSize)) return 6;
+			if (pidata_getcount (&src, slim, &repeatCount)) return 7;
 
 			const char *common = src;
 			for (i=0; i<commonSize; i++) {
@@ -111,8 +111,8 @@ static int unpack_pidata(char *dest, size_t dlen, const char *src, size_t slen) 
 		} else if (opcode == 4) { // interleave repeatblock with zeroblock
 			ut32 commonSize = arg;
 			ut32 customSize, repeatCount;
-			if (pidata_getcount(&src, slim, &customSize)) return 11;
-			if (pidata_getcount(&src, slim, &repeatCount)) return 12;
+			if (pidata_getcount (&src, slim, &customSize)) return 11;
+			if (pidata_getcount (&src, slim, &repeatCount)) return 12;
 
 			for (i=0; i<commonSize; i++) {
 				if (dest >= dlim) return 13;
@@ -142,141 +142,141 @@ static int reloc_comparator(const PEFReloc *a, const PEFReloc *b) {
 }
 
 static RList *do_reloc_bytecode(RBuffer *b, ut32 at, ut32 instCount) {
-	RList *ret = r_list_newf((RListFree)free);
+	RList *ret = r_list_newf ((RListFree)free);
 	ut32 codeA = 0, dataA = 1, rSymI = 0, rAddr = 0;
 	ut32 loopInstruct = UT32_MAX;
 	ut32 loopDone = 0;
 	int i;
 
 	if (0) {
-		printf("           Instr     Op    Operand           codeA dataA rSymI rAddr\n");
+		printf ("           Instr     Op    Operand           codeA dataA rSymI rAddr\n");
 	}
 
 	#define dbg(name, format, ...) if (0) { \
 		char buf[50]; \
-		sprintf(buf, format, __VA_ARGS__); \
-		printf("%05X [% 2d] %04X      %-5s %-19s %d %5d %5d   %08X\n", \
-			at + 2*printpc, printpc, r_buf_read_be16_at(b, at+2*printpc), name, buf, codeA, dataA, rSymI, rAddr); \
+		sprintf (buf, format, __VA_ARGS__); \
+		printf ("%05X [% 2d] %04X      %-5s %-19s %d %5d %5d   %08X\n", \
+			at + 2*printpc, printpc, r_buf_read_be16_at (b, at+2*printpc), name, buf, codeA, dataA, rSymI, rAddr); \
 	}
 
 	#define PUSH_RELOC(ofs, targ, imp) { \
-		PEFReloc *r = R_NEW0(PEFReloc); \
+		PEFReloc *r = R_NEW0 (PEFReloc); \
 		r->offset = ofs; \
 		r->target = targ; \
 		r->isimport = imp; \
-		r_list_append(ret, r); \
+		r_list_append (ret, r); \
 	}
 
 	ut32 pc = 0;
 	while (pc < instCount) {
 		ut32 printpc = pc;
-		ut16 op = r_buf_read_be16_at(b, at + 2*pc++);
+		ut16 op = r_buf_read_be16_at (b, at + 2*pc++);
 
 		// Some instructions take a wider argument
 		ut32 longop = 0;
 		if (op >= 0xa000) {
 			if (pc >= instCount) return 0;
-			longop = ((ut32)op << 16) | r_buf_read_be16_at(b, at + 2*pc++);
+			longop = ((ut32)op << 16) | r_buf_read_be16_at (b, at + 2*pc++);
 		}
 
 		if (op <= 0x3fff) {
 			// RelocBySectDWithSkip (DDAT)
 			ut8 skipCount = (op >> 6) & 0xff;
 			ut8 relocCount = op & 0x3f;
-			dbg("DDAT", "delta=%d,n=%d", skipCount*4, relocCount);
+			dbg ("DDAT", "delta=%d,n=%d", skipCount*4, relocCount);
 
 			rAddr += 4 * skipCount;
 			for (i=0; i<relocCount; i++) {
-				PUSH_RELOC(rAddr, dataA, false);
+				PUSH_RELOC (rAddr, dataA, false);
 				rAddr += 4;
 			}
 		} else if (op >= 0x4000 && op <= 0x41ff) {
 			// RelocBySectC (CODE)
 			// DumpPEF sometimes gets rAddr wrong for large runLength!
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("CODE", "cnt=%d", runLength);
+			dbg ("CODE", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, codeA, false);
+				PUSH_RELOC (rAddr, codeA, false);
 				rAddr += 4;
 			}
 		} else if (op >= 0x4200 && op <= 0x43ff) {
 			// RelocBySectD (DATA)
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("DATA", "cnt=%d", runLength);
+			dbg ("DATA", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, dataA, false);
+				PUSH_RELOC (rAddr, dataA, false);
 				rAddr += 4;
 			}
 		} else if (op >= 0x4400 && op <= 0x45ff) {
 			// RelocTVector12 (DESC)
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("DESC", "cnt=%d", runLength);
+			dbg ("DESC", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, codeA, false);
+				PUSH_RELOC (rAddr, codeA, false);
 				rAddr += 4;
-				PUSH_RELOC(rAddr, dataA, false);
+				PUSH_RELOC (rAddr, dataA, false);
 				rAddr += 8;
 			}
 		} else if (op >= 0x4600 && op <= 0x47ff) {
 			// RelocTVector8 (DSC2)
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("DSC2", "cnt=%d", runLength);
+			dbg ("DSC2", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, codeA, false);
+				PUSH_RELOC (rAddr, codeA, false);
 				rAddr += 4;
-				PUSH_RELOC(rAddr, dataA, false);
+				PUSH_RELOC (rAddr, dataA, false);
 				rAddr += 4;
 			}
 		} else if (op >= 0x4800 && op <= 0x49ff) {
 			// RelocVTable8 (VTBL)
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("VTBL", "cnt=%d", runLength);
+			dbg ("VTBL", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, dataA, false);
+				PUSH_RELOC (rAddr, dataA, false);
 				rAddr += 8;
 			}
 		} else if (op >= 0x4a00 && op <= 0x4bff) {
 			// RelocImportRun (SYMR)
 			ut16 runLength = (op & 0x1ff) + 1;
-			dbg("SYMR", "cnt=%d", runLength);
+			dbg ("SYMR", "cnt=%d", runLength);
 			for (i=0; i<runLength; i++) {
-				PUSH_RELOC(rAddr, rSymI, true);
+				PUSH_RELOC (rAddr, rSymI, true);
 				rAddr += 4;
 				rSymI += 1;
 			}
 		} else if (op >= 0x6000 && op <= 0x61ff) {
 			// RelocSmByImport (SYMB)
 			ut16 index = op & 0x1ff;;
-			dbg("SYMB", "idx=%d", index);
-			PUSH_RELOC(rAddr, index, true);
+			dbg ("SYMB", "idx=%d", index);
+			PUSH_RELOC (rAddr, index, true);
 			rAddr += 4;
 			rSymI = index + 1;
 		} else if (op >= 0x6200 && op <= 0x63ff) {
 			// RelocSmSetSectC (CDIS)
 			ut16 index = op & 0x1ff;
-			dbg("CDIS", "sct=%d", index);
+			dbg ("CDIS", "sct=%d", index);
 			codeA = index;
 		} else if (op >= 0x6400 && op <= 0x65ff) {
 			// RelocSmSetSectD (DTIS)
 			ut16 index = op & 0x1ff;
-			dbg("DTIS", "sct=%d", index);
+			dbg ("DTIS", "sct=%d", index);
 			dataA = index;
 		} else if (op >= 0x6600 && op <= 0x67ff) {
 			// RelocSmBySection (SECN)
 			ut16 index = op & 0x1ff;
-			dbg("SECN", "sct=%d", index);
-			PUSH_RELOC(rAddr, index, false);
+			dbg ("SECN", "sct=%d", index);
+			PUSH_RELOC (rAddr, index, false);
 			rAddr += 4;
 		} else if (op>>12 == 0b1000) {
 			// RelocIncrPosition (DELT)
 			ut16 offset = (op & 0x0fff) + 1;
-			dbg("DELT", "delta=%d", offset);
+			dbg ("DELT", "delta=%d", offset);
 			rAddr += offset;
 		} else if (op >= 0x9000 && op <= 0x9fff) {
 			// RelocSmRepeat (RPT)
 			ut8 blockCount = ((op >> 8) & 0xf) + 1;
 			ut16 repeatCount = (op & 0xff) + 1;
-			dbg("RPT", "i=%d,rpt=%d", blockCount, repeatCount);
+			dbg ("RPT", "i=%d,rpt=%d", blockCount, repeatCount);
 
 			if (loopInstruct != UT32_MAX && loopInstruct != pc) return NULL; // nested loop
 			loopInstruct = pc;
@@ -292,20 +292,20 @@ static RList *do_reloc_bytecode(RBuffer *b, ut32 at, ut32 instCount) {
 		} else if (op >= 0xa000 && op <= 0xa3ff) {
 			// RelocSetPosition (LABS)
 			ut32 offset = longop & 0x3ffffff;
-			dbg("LABS", "offset=%d", offset);
+			dbg ("LABS", "offset=%d", offset);
 			rAddr = offset;
 		} else if (op >= 0xa400 && op <= 0xa7ff) {
 			// RelocLgByImport (LSYM)
 			ut32 index = longop & 0x3ffffff;
-			dbg("LSYM", "idx=%d", index);
-			PUSH_RELOC(rAddr, index, true);
+			dbg ("LSYM", "idx=%d", index);
+			PUSH_RELOC (rAddr, index, true);
 			rAddr += 4;
 			rSymI = index + 1;
 		} else if (op >= 0xb000 && op <= 0xb3ff) {
 			// RelocLgRepeat (LRPT)
 			ut8 blockCount = ((op >> 8) & 0xf) + 1;
 			ut32 repeatCount = (longop & 0x3fffff) + 1;
-			dbg("LRPT", "i=%d,rpt=%d", blockCount, repeatCount);
+			dbg ("LRPT", "i=%d,rpt=%d", blockCount, repeatCount);
 
 			if (loopInstruct != UT32_MAX && loopInstruct != pc) return NULL; // nested loop
 			loopInstruct = pc;
@@ -321,41 +321,41 @@ static RList *do_reloc_bytecode(RBuffer *b, ut32 at, ut32 instCount) {
 		} else if (op >= 0xb400 && op <= 0xb43f) {
 			// Same as RelocSmBySection (LSEC LSECN)
 			ut32 index = longop & 0x3fffff;
-			dbg("LSEC", "LSECN,sct=%d", index);
-			PUSH_RELOC(rAddr, index, false);
+			dbg ("LSEC", "LSECN,sct=%d", index);
+			PUSH_RELOC (rAddr, index, false);
 			rAddr += 4;
 		} else if (op >= 0xb440 && op <= 0xb47f) {
 			// Same as RelocSmSetSectC (LSEC LDIS)
 			ut32 index = longop & 0x3fffff;
-			dbg("LSEC", "LCDIS,sct=%d", index);
+			dbg ("LSEC", "LCDIS,sct=%d", index);
 			codeA = index;
 		} else if (op >= 0xb480 && op <= 0xb4bf) {
 			// Same as RelocSmSetSectD (LSEC LTIS)
 			ut32 index = longop & 0x3fffff;
-			dbg("LSEC", "LDTIS,sct=%d", index);
+			dbg ("LSEC", "LDTIS,sct=%d", index);
 			dataA = index;
 		} else {
 			return NULL;
 		}
 	}
-	if (r_list_length(ret) == 0) {
-		r_list_free(ret);
+	if (r_list_length (ret) == 0) {
+		r_list_free (ret);
 		return NULL;
 	}
-	r_list_sort(ret, (RListComparator)reloc_comparator);
+	r_list_sort (ret, (RListComparator)reloc_comparator);
 	return ret;
 }
 
 static bool check(RBinFile *bf, RBuffer *b) {
 	char tmp[8];
-	int r = r_buf_read_at(b, 0, (ut8 *)tmp, sizeof (tmp));
-	return r == sizeof (tmp) && !memcmp(tmp, "Joy!peff", sizeof (tmp));
+	int r = r_buf_read_at (b, 0, (ut8 *)tmp, sizeof (tmp));
+	return r == sizeof (tmp) && !memcmp (tmp, "Joy!peff", sizeof (tmp));
 }
 
 static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
-	if (!check(bf, buf)) return false;
-	ut16 nsec = r_buf_read_be16_at(bf->buf, 32);
-	RBinPEFObj *pef = bf->bo->bin_obj = calloc(1, sizeof (RBinPEFObj) + sizeof (PEFSection) * nsec);
+	if (!check (bf, buf)) return false;
+	ut16 nsec = r_buf_read_be16_at (bf->buf, 32);
+	RBinPEFObj *pef = bf->bo->bin_obj = calloc (1, sizeof (RBinPEFObj) + sizeof (PEFSection) * nsec);
 	if (!pef) return false;
 	pef->nsec = nsec;
 	ut64 climb = loadaddr;
@@ -363,14 +363,14 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 	for (i=0; i<nsec; i++) {
 		PEFSection *sec = &pef->sec[i];
 		size_t offset = 40 + 28*i;
-		sec->defAddress = r_buf_read_be32_at(buf, offset + 4);
-		sec->lenTotal = r_buf_read_be32_at(buf, offset + 8);
-		sec->lenUnpack = r_buf_read_be32_at(buf, offset + 12);
-		sec->lenDisk = r_buf_read_be32_at(buf, offset + 16);
-		sec->offset = r_buf_read_be32_at(buf, offset + 20);
-		r_buf_read_at(buf, offset + 24, &sec->kind, 1);
-		r_buf_read_at(buf, offset + 25, &sec->share, 1);
-		r_buf_read_at(buf, offset + 26, &sec->align, 1);
+		sec->defAddress = r_buf_read_be32_at (buf, offset + 4);
+		sec->lenTotal = r_buf_read_be32_at (buf, offset + 8);
+		sec->lenUnpack = r_buf_read_be32_at (buf, offset + 12);
+		sec->lenDisk = r_buf_read_be32_at (buf, offset + 16);
+		sec->offset = r_buf_read_be32_at (buf, offset + 20);
+		r_buf_read_at (buf, offset + 24, &sec->kind, 1);
+		r_buf_read_at (buf, offset + 25, &sec->share, 1);
+		r_buf_read_at (buf, offset + 26, &sec->align, 1);
 
 		if (sec->kind <= 3 || sec->kind == 6) { // exists in memory
 			climb += sec->align - 1;
@@ -382,29 +382,29 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 		if (sec->kind == 4) pef->ldrsec = sec->offset;
 
 		if (sec->kind == 2) { // pidata, extract now
-			void *pac = malloc(sec->lenDisk);
-			sec->unpack = malloc(sec->lenUnpack);
+			void *pac = malloc (sec->lenDisk);
+			sec->unpack = malloc (sec->lenUnpack);
 			if (!pac || !sec->unpack) return false;
-			st64 n = r_buf_read_at(bf->buf, sec->offset, pac, sec->lenDisk);
+			st64 n = r_buf_read_at (bf->buf, sec->offset, pac, sec->lenDisk);
 			if (n != sec->lenDisk) return false;
-			if (unpack_pidata(sec->unpack, sec->lenUnpack, pac, sec->lenDisk)) return false;
-			free(pac);
+			if (unpack_pidata (sec->unpack, sec->lenUnpack, pac, sec->lenDisk)) return false;
+			free (pac);
 		}
 	}
 
 	// Parse the loader section
-	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
-	ut32 totalImportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 28);
-	ut32 relocSecCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 32);
-	ut32 relocInstrOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 36);
+	ut32 importedLibraryCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 24);
+	ut32 totalImportedSymbolCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 28);
+	ut32 relocSecCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 32);
+	ut32 relocInstrOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 36);
 
 	for (i=0; i<relocSecCount; i++) {
 		ut32 at = pef->ldrsec + 56 + 24*importedLibraryCount + 4*totalImportedSymbolCount + 12*i;
-		ut16 sec = r_buf_read_be16_at(bf->buf, at);
-		ut32 instCount = r_buf_read_be32_at(bf->buf, at + 4);
-		ut32 firstInst = r_buf_read_be32_at(bf->buf, at + 8);
+		ut16 sec = r_buf_read_be16_at (bf->buf, at);
+		ut32 instCount = r_buf_read_be32_at (bf->buf, at + 4);
+		ut32 firstInst = r_buf_read_be32_at (bf->buf, at + 8);
 
-		pef->sec[sec].relocs = do_reloc_bytecode(bf->buf, pef->ldrsec + relocInstrOffset + firstInst, instCount);
+		pef->sec[sec].relocs = do_reloc_bytecode (bf->buf, pef->ldrsec + relocInstrOffset + firstInst, instCount);
 	}
 
 	return true;
@@ -414,53 +414,53 @@ static void destroy(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
 	int i;
 	for (i=0; i<pef->nsec; i++) {
-		free(pef->sec[i].unpack);
-		r_list_free(pef->sec[i].relocs);
+		free (pef->sec[i].unpack);
+		r_list_free (pef->sec[i].relocs);
 	}
-	free(pef);
+	free (pef);
 }
 
 static RBinInfo *info(RBinFile *bf) {
 	char hdr[40];
-	int r = r_buf_read_at(bf->buf, 0, (ut8 *)hdr, sizeof (hdr));
+	int r = r_buf_read_at (bf->buf, 0, (ut8 *)hdr, sizeof (hdr));
 	if (r != sizeof (hdr)) {
 		return NULL;
 	}
 
 	RBinInfo *ret = R_NEW0 (RBinInfo);
-	ret->file = strdup(bf->file);
-	ret->type = strdup("PEF");
-	if (!memcmp(hdr+8, "pwpc", 4)) {
-		ret->arch = strdup("ppc");
-		ret->machine = strdup("Power Macintosh/BeBox");
-	} else if (!memcmp(hdr+8, "m68k", 4)) {
-		ret->arch = strdup("m68k");
-		ret->cpu = strdup("68040");
-		ret->machine = strdup("Macintosh");
+	ret->file = strdup (bf->file);
+	ret->type = strdup ("PEF");
+	if (!memcmp (hdr+8, "pwpc", 4)) {
+		ret->arch = strdup ("ppc");
+		ret->machine = strdup ("Power Macintosh/BeBox");
+	} else if (!memcmp (hdr+8, "m68k", 4)) {
+		ret->arch = strdup ("m68k");
+		ret->cpu = strdup ("68040");
+		ret->machine = strdup ("Macintosh");
 	}
 	ret->bits = 32;
 	ret->has_pi = true;
 	ret->big_endian = true;
-	ret->rclass = strdup("cfm");
+	ret->rclass = strdup ("cfm");
 	ret->has_va = true;
 	return ret;
 }
 
 static RList *fields(RBinFile *bf) {
-	RList *ret = r_list_newf((RListFree)free);
+	RList *ret = r_list_newf ((RListFree)free);
 	#define ROW(nam, siz, val, fmt, cmt) \
 		r_list_append (ret, r_bin_field_new (addr, addr, val, siz, nam, cmt, fmt, false));
 	ut64 addr = 0;
-	ROW("magic", 8, r_buf_read_be64_at(bf->buf, addr), "x", NULL); addr += 8;
-	ROW("architecture", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("formatVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("dateTimeStamp", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("oldDefVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("oldImpVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("currentVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
-	ROW("sectionCount", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
-	ROW("instSectionCount", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
-	ROW("reserved", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
+	ROW ("magic", 8, r_buf_read_be64_at (bf->buf, addr), "x", NULL); addr += 8;
+	ROW ("architecture", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("formatVersion", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("dateTimeStamp", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("oldDefVersion", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("oldImpVersion", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("currentVersion", 4, r_buf_read_be32_at (bf->buf, addr), "x", NULL); addr += 4;
+	ROW ("sectionCount", 2, r_buf_read_be16_at (bf->buf, addr), "x", NULL); addr += 2;
+	ROW ("instSectionCount", 2, r_buf_read_be16_at (bf->buf, addr), "x", NULL); addr += 2;
+	ROW ("reserved", 2, r_buf_read_be16_at (bf->buf, addr), "x", NULL); addr += 2;
 	return ret;
 }
 
@@ -489,10 +489,10 @@ static RBinAddr *binsym(RBinFile *bf, int sym) {
 		return NULL;
 	}
 
-	ut32 sec = r_buf_read_be32_at(bf->buf, pef->ldrsec + n*8);
-	ut32 offset = r_buf_read_be32_at(bf->buf, pef->ldrsec + n*8+4);
+	ut32 sec = r_buf_read_be32_at (bf->buf, pef->ldrsec + n*8);
+	ut32 offset = r_buf_read_be32_at (bf->buf, pef->ldrsec + n*8+4);
 	if (sec < pef->nsec && offset < pef->sec[sec].addr+pef->sec[sec].lenTotal) {
-		RBinAddr *ptr = R_NEW0(RBinAddr);
+		RBinAddr *ptr = R_NEW0 (RBinAddr);
 		ptr->vaddr = pef->sec[sec].addr + offset;
 		return ptr;
 	} else {
@@ -502,12 +502,12 @@ static RBinAddr *binsym(RBinFile *bf, int sym) {
 
 static RList *sections(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	RList *ret = r_list_newf((RListFree)r_bin_section_free);
+	RList *ret = r_list_newf ((RListFree)r_bin_section_free);
 	int i;
 
 	for (i=0; i<pef->nsec; i++) {
 		PEFSection *sec = &pef->sec[i];
-		RBinSection *ptr = R_NEW0(RBinSection);
+		RBinSection *ptr = R_NEW0 (RBinSection);
 		ptr->is_segment = false; // like XCOFF, we have no concept of ELF segments
 		ptr->add = true;
 		ptr->paddr = sec->offset;
@@ -560,10 +560,10 @@ static RList *sections(RBinFile *bf) {
 			ptr->perm = R_PERM_NONE;
 			break;
 		default:
-			r_bin_section_free(ptr);
+			r_bin_section_free (ptr);
 			continue;
 		}
-		ptr->name = r_str_newf(".%s-%d", ptr->type, i); // same naming convention as XCOFF
+		ptr->name = r_str_newf (".%s-%d", ptr->type, i); // same naming convention as XCOFF
 
 		// Exists in memory
 		if (ptr->perm != R_PERM_NONE) {
@@ -583,82 +583,82 @@ static RList *sections(RBinFile *bf) {
 			ptr->size = 0; // cannot be read direct from disk, don't try
 
 			char *muri = r_str_newf ("malloc://%"PFMT32u, sec->lenTotal); // gets zero-inited
-			ptr->backing = r_io_open_nomap(bf->rbin->iob.io, muri, R_PERM_RW, 0);
-			free(muri);
+			ptr->backing = r_io_open_nomap (bf->rbin->iob.io, muri, R_PERM_RW, 0);
+			free (muri);
 			if (ptr->backing != NULL) {
-				r_io_desc_write(ptr->backing, sec->unpack, sec->lenUnpack);
+				r_io_desc_write (ptr->backing, sec->unpack, sec->lenUnpack);
 			}
 		}
 
-		r_list_append(ret, ptr);
+		r_list_append (ret, ptr);
 	}
 	return ret;
 }
 
 static RList *imports(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
-	ut32 totalImportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 28);
-	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
-	RBinImport **ary = R_NEWS(RBinImport *, totalImportedSymbolCount);
+	ut32 importedLibraryCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 24);
+	ut32 totalImportedSymbolCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 28);
+	ut32 loaderStringsOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 40);
+	RBinImport **ary = R_NEWS (RBinImport *, totalImportedSymbolCount);
 	int i, j;
 
 	for (i=0; i<totalImportedSymbolCount; i++) {
-		ary[i] = R_NEW0(RBinImport);
+		ary[i] = R_NEW0 (RBinImport);
 	}
 
 	for (i=0; i<importedLibraryCount; i++) {
 		ut32 at = pef->ldrsec + 56 + 24*i;
-		ut32 libNamePtr = r_buf_read_be32_at(bf->buf, at);
-		ut32 libSymCount = r_buf_read_be32_at(bf->buf, at + 12);
-		ut32 firstSym = r_buf_read_be32_at(bf->buf, at + 16);
+		ut32 libNamePtr = r_buf_read_be32_at (bf->buf, at);
+		ut32 libSymCount = r_buf_read_be32_at (bf->buf, at + 12);
+		ut32 firstSym = r_buf_read_be32_at (bf->buf, at + 16);
 
 		for (j=firstSym; j<firstSym+libSymCount && j<totalImportedSymbolCount; j++) {
 			at = pef->ldrsec + 56 + 24*importedLibraryCount + 4*j;
 			ut8 kind = 0;
-			r_buf_read_at(bf->buf, at, &kind, 1);
-			ut32 symNamePtr = r_buf_read_be32_at(bf->buf, at) & 0xffffff;
+			r_buf_read_at (bf->buf, at, &kind, 1);
+			ut32 symNamePtr = r_buf_read_be32_at (bf->buf, at) & 0xffffff;
 
-			ary[j]->name = r_bin_name_new_from(r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + symNamePtr));
-			ary[j]->libname = r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
+			ary[j]->name = r_bin_name_new_from (r_buf_get_string (bf->buf, pef->ldrsec + loaderStringsOffset + symNamePtr));
+			ary[j]->libname = r_buf_get_string (bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
 			ary[j]->ordinal = j;
-			ary[j]->type = class2string(kind);
+			ary[j]->type = class2string (kind);
 			ary[j]->bind = (kind&0x80) ? R_BIN_BIND_WEAK_STR : R_BIN_BIND_GLOBAL_STR;
 		}
 	}
 
-	RList *ret = r_list_newf((RListFree)r_bin_import_free);
+	RList *ret = r_list_newf ((RListFree)r_bin_import_free);
 	for (i=0; i<totalImportedSymbolCount; i++) {
 		if (ary[i]->name != NULL) {
-			r_list_append(ret, ary[i]);
+			r_list_append (ret, ary[i]);
 		}
 	}
-	free(ary);
+	free (ary);
 	return ret;
 }
 
 static RList *libs(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	RList *ret = r_list_newf((RListFree)free);
-	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
-	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
+	RList *ret = r_list_newf ((RListFree)free);
+	ut32 importedLibraryCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 24);
+	ut32 loaderStringsOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 40);
 	int i;
 
 	for (i=0; i<importedLibraryCount; i++) {
 		ut32 at = pef->ldrsec + 56 + 24*i;
-		ut32 libNamePtr = r_buf_read_be32_at(bf->buf, at);
-		char *name = r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
-		r_list_append(ret, name);
+		ut32 libNamePtr = r_buf_read_be32_at (bf->buf, at);
+		char *name = r_buf_get_string (bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
+		r_list_append (ret, name);
 	}
 	return ret;
 }
 
 void **flatlist(RList *list) {
-	void **flat = R_NEWS(void *, r_list_length(list));
+	void **flat = R_NEWS (void *, r_list_length (list));
 	RListIter *iter;
 	void *ptr;
 	size_t i = 0;
-	r_list_foreach(list, iter, ptr) {
+	r_list_foreach (list, iter, ptr) {
 		flat[i++] = ptr;
 	}
 	return flat;
@@ -666,62 +666,62 @@ void **flatlist(RList *list) {
 
 static RList *relocs(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	RList *ret = r_list_newf(free); // r_bin_reloc_free
-	RList *importList = imports(bf); // Import linked-list
-	void **importArray = flatlist(importList); // Indexable import list
+	RList *ret = r_list_newf (free); // r_bin_reloc_free
+	RList *importList = imports (bf); // Import linked-list
+	void **importArray = flatlist (importList); // Indexable import list
 	PEFReloc *r;
 	RListIter *iter;
 	int i;
 
 	for (i=0; i<pef->nsec; i++) {
-		r_list_foreach(pef->sec[i].relocs, iter, r) {
-			RBinReloc *ptr = R_NEW0(RBinReloc);
+		r_list_foreach (pef->sec[i].relocs, iter, r) {
+			RBinReloc *ptr = R_NEW0 (RBinReloc);
 			ptr->type = R_BIN_RELOC_32;
 			ptr->additive = 1;
 			ptr->vaddr = pef->sec[i].addr + r->offset;
 			if (r->isimport) {
-				if (r->target >= r_list_length(importList)) {
-					free(ptr);
+				if (r->target >= r_list_length (importList)) {
+					free (ptr);
 					continue;
 				}
-				ptr->import = r_bin_import_clone(importArray[r->target]);
+				ptr->import = r_bin_import_clone (importArray[r->target]);
 			} else {
 				if (r->target >= pef->nsec) {
-					free(ptr);
+					free (ptr);
 					continue;
 				}
 				ptr->addend = pef->sec[r->target].addr;
 			}
-			r_list_append(ret, ptr);
+			r_list_append (ret, ptr);
 		}
 	}
-	R_FREE(importArray);
-	r_list_free(importList);
+	R_FREE (importArray);
+	r_list_free (importList);
 	return ret;
 }
 
 static RList *patch_relocs(RBinFile *bf) {
-	RList *list = relocs(bf);
+	RList *list = relocs (bf);
 	RListIter *iter;
 	RBinReloc *reloc;
-	r_list_foreach(list, iter, reloc) {
+	r_list_foreach (list, iter, reloc) {
 		if (reloc->import) continue;
 		RIOBind *b = &bf->rbin->iob;
 		ut8 buf[4] = {};
-		b->read_at(b->io, reloc->vaddr, buf, 4);
-		r_write_be32(buf, r_read_be32(buf) + reloc->addend);
-		b->overlay_write_at(b->io, reloc->vaddr, buf, 4);
+		b->read_at (b->io, reloc->vaddr, buf, 4);
+		r_write_be32 (buf, r_read_be32 (buf) + reloc->addend);
+		b->overlay_write_at (b->io, reloc->vaddr, buf, 4);
 	}
 	return list;
 }
 
 static RList *symbols(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	RList *ret = r_list_newf((RListFree)r_bin_symbol_free);
-	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
-	ut32 exportHashOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 44);
-	ut32 exportHashTablePower = r_buf_read_be32_at(bf->buf, pef->ldrsec + 48);
-	ut32 exportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 52);
+	RList *ret = r_list_newf ((RListFree)r_bin_symbol_free);
+	ut32 loaderStringsOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 40);
+	ut32 exportHashOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 44);
+	ut32 exportHashTablePower = r_buf_read_be32_at (bf->buf, pef->ldrsec + 48);
+	ut32 exportedSymbolCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 52);
 	ut32 stringLenTable = pef->ldrsec + exportHashOffset + (4<<exportHashTablePower);
 	ut32 exportTable = stringLenTable + 4*exportedSymbolCount;
 	int i;
@@ -729,33 +729,33 @@ static RList *symbols(RBinFile *bf) {
 	for (i=0; i<exportedSymbolCount; i++) {
 		ut32 ofs = exportTable + 10*i;
 		ut8 kind = 0;
-		r_buf_read_at(bf->buf, ofs, &kind, 1);
-		ut32 nameOfs = pef->ldrsec + loaderStringsOffset + (r_buf_read_be32_at(bf->buf, ofs) & 0xffffff);
-		ut32 addr = r_buf_read_be32_at(bf->buf, ofs + 4);
-		st16 index = r_buf_read_be16_at(bf->buf, ofs + 8);
-		ut16 nameLen = r_buf_read_be16_at(bf->buf, stringLenTable + 4*i);
+		r_buf_read_at (bf->buf, ofs, &kind, 1);
+		ut32 nameOfs = pef->ldrsec + loaderStringsOffset + (r_buf_read_be32_at (bf->buf, ofs) & 0xffffff);
+		ut32 addr = r_buf_read_be32_at (bf->buf, ofs + 4);
+		st16 index = r_buf_read_be16_at (bf->buf, ofs + 8);
+		ut16 nameLen = r_buf_read_be16_at (bf->buf, stringLenTable + 4*i);
 		if (index < 0 || index >= pef->nsec) {
 			continue; // re-exported func or absolute mem address, not supported
 		}
 
-		RBinSymbol *ptr = R_NEW0(RBinSymbol);
-		char *name = calloc(1, nameLen + 1); // +1 for the null terminator, which is not on disk
+		RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+		char *name = calloc (1, nameLen + 1); // +1 for the null terminator, which is not on disk
 		if (!name) {
 			continue;
 		}
-		r_buf_read_at(bf->buf, nameOfs, (ut8*)name, nameLen);
-		ptr->name = r_bin_name_new_from(name);
+		r_buf_read_at (bf->buf, nameOfs, (ut8*)name, nameLen);
+		ptr->name = r_bin_name_new_from (name);
 		ptr->vaddr = pef->sec[index].addr + addr;
 		ptr->bind = R_BIN_BIND_GLOBAL_STR;
-		ptr->type = class2string(kind);
-		r_list_append(ret, ptr);
+		ptr->type = class2string (kind);
+		r_list_append (ret, ptr);
 	}
 	return ret;
 }
 
 static RList *entries(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
-	RList *ret = r_list_newf(free);
+	RList *ret = r_list_newf (free);
 	static const int types[] = {
 		R_BIN_ENTRY_TYPE_MAIN,
 		R_BIN_ENTRY_TYPE_INIT,
@@ -764,13 +764,13 @@ static RList *entries(RBinFile *bf) {
 	int i;
 
 	for (i=0; i<3; i++) {
-		ut32 sec = r_buf_read_be32_at(bf->buf, pef->ldrsec + i*8);
-		ut32 offset = r_buf_read_be32_at(bf->buf, pef->ldrsec + i*8+4);
+		ut32 sec = r_buf_read_be32_at (bf->buf, pef->ldrsec + i*8);
+		ut32 offset = r_buf_read_be32_at (bf->buf, pef->ldrsec + i*8+4);
 		if (sec < pef->nsec && offset < pef->sec[sec].addr+pef->sec[sec].lenTotal) {
-			RBinAddr *ptr = R_NEW0(RBinAddr);
+			RBinAddr *ptr = R_NEW0 (RBinAddr);
 			ptr->vaddr = pef->sec[sec].addr + offset;
 			ptr->type = types[i];
-			r_list_append(ret, ptr);
+			r_list_append (ret, ptr);
 		}
 	}
 	return ret;

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -739,7 +739,10 @@ static RList *symbols(RBinFile *bf) {
 		}
 
 		RBinSymbol *ptr = R_NEW0(RBinSymbol);
-		char *name = calloc(1, nameLen + 1);
+		char *name = calloc(1, nameLen + 1); // +1 for the null terminator, which is not on disk
+		if (!name) {
+			continue;
+		}
 		r_buf_read_at(bf->buf, nameOfs, (ut8*)name, nameLen);
 		ptr->name = r_bin_name_new_from(name);
 		ptr->vaddr = pef->sec[index].addr + addr;

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -36,13 +36,13 @@ static const char *class2string(ut8 class) {
 	}
 }
 
-static int pidata_getcount(const char **ptr, const char *limit, ut32 *ret) {
+static bool pidata_getcount(const char **ptr, const char *limit, ut32 *ret) {
 	*ret = 0;
 	for (;;) {
-		if (*ptr >= limit) return 1; // fail
+		if (*ptr >= limit) return true; // fail
 		ut8 byte = *(*ptr)++;
 		*ret = (*ret << 7) | (byte & 0x7f);
-		if ((byte & 0x80) == 0) return 0; // OK
+		if ((byte & 0x80) == 0) return false; // OK
 	}
 }
 

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -1,0 +1,769 @@
+/* radare - LGPL - Copyright 2025 - elliotnunn */
+
+#include "r_endian.h"
+#include "r_io.h"
+#include "r_list.h"
+#include "r_types.h"
+#include "r_types_base.h"
+#include "r_util/r_buf.h"
+#include <r_lib.h>
+#include <r_bin.h>
+
+#include <stddef.h>
+#include <stdlib.h>
+
+typedef struct {
+	ut32 offset;
+	ut16 target; // either section or import
+	bool isimport;
+} PEFReloc;
+
+typedef struct {
+	ut64 addr;
+	void *unpack;
+	RList/*<myreloc>*/ *relocs;
+	ut32 defAddress;
+	ut32 lenTotal, lenUnpack, lenDisk;
+	ut32 offset;
+	ut8 kind, share, align;
+} PEFSection;
+
+typedef struct {
+	ut16 nsec;
+	ut32 ldrsec;
+	PEFSection sec[];
+} RBinPEFObj;
+
+static const char *class2string(ut8 class) {
+	switch (class & 0xf) {
+	case 0: return R_BIN_TYPE_FUNC_STR; // code
+	case 1: return R_BIN_TYPE_OBJECT_STR; // data
+	case 2: return R_BIN_TYPE_OBJECT_STR; // tvector
+	case 3: return R_BIN_TYPE_SECTION_STR; // toc
+	case 4: return R_BIN_TYPE_FUNC_STR; // glue
+	default: return R_BIN_TYPE_UNKNOWN_STR;
+	}
+}
+
+static int pidata_getcount(const char **ptr, const char *limit, ut32 *ret) {
+	*ret = 0;
+	for (;;) {
+		if (*ptr >= limit) return 1; // fail
+		ut8 byte = *(*ptr)++;
+		*ret = (*ret << 7) | (byte & 0x7f);
+		if ((byte & 0x80) == 0) return 0; // OK
+	}
+}
+
+// Do a bounds check for every single byte that is read/written,
+// to guard against overflow in pointer arithmetic.
+// Return nonzero on failure.
+static int unpack_pidata(char *dest, size_t dlen, const char *src, size_t slen) {
+	char *dlim = dest + dlen;
+	const char *slim = src + slen;
+
+	while (src < slim) {
+		ut8 firstbyte = *src++;
+		ut8 opcode = firstbyte >> 5;
+		ut32 arg = firstbyte & 0x1f;
+		if (arg == 0) {
+			if (pidata_getcount(&src, slim, &arg)) return 1;
+		}
+
+		if (opcode == 0) { // put zeros
+			for (ut32 i=0; i<arg; i++) {
+				if (dest >= dlim) return 2;
+				*dest++ = 0;
+			}
+		} else if (opcode == 1) { // copy block
+			for (ut32 i=0; i<arg; i++) {
+				if (src >= slim || dest >= dlim) return 3;
+				*dest++ = *src++;
+			}
+		} else if (opcode == 2) { // repeated block
+			ut32 blockSize = arg;
+			ut32 repeatCountMin1;
+			if (pidata_getcount(&src, slim, &repeatCountMin1)) return 4;
+
+			do {
+				for (ut32 i=0; i<blockSize; i++) {
+					if (src + i >= slim || dest >= dlim) return 5;
+					*dest++ = src[i];
+				}
+			} while (repeatCountMin1--);
+			src += blockSize;
+		} else if (opcode == 3) { // interleave repeatblock with customblock
+			ut32 commonSize = arg;
+			ut32 customSize, repeatCount;
+			if (pidata_getcount(&src, slim, &customSize)) return 6;
+			if (pidata_getcount(&src, slim, &repeatCount)) return 7;
+
+			const char *common = src;
+			for (ut32 i=0; i<commonSize; i++) {
+				if (src >= slim || dest >= dlim) return 8;
+				*dest++ = *src++;
+			}
+
+			for (ut32 i=0; i<repeatCount; i++) {
+				for (ut32 j=0; j<customSize; j++) {
+					if (src >= slim || dest >= dlim) return 9;
+					*dest++ = *src++;
+				}
+				const char *comcopy = common;
+				for (ut32 j=0; j<commonSize; j++) {
+					if (dest >= dlim) return 10;
+					*dest++ = *comcopy++;
+				}
+			}
+		} else if (opcode == 4) { // interleave repeatblock with zeroblock
+			ut32 commonSize = arg;
+			ut32 customSize, repeatCount;
+			if (pidata_getcount(&src, slim, &customSize)) return 11;
+			if (pidata_getcount(&src, slim, &repeatCount)) return 12;
+
+			for (ut32 i=0; i<commonSize; i++) {
+				if (dest >= dlim) return 13;
+				*dest++ = 0;
+			}
+
+			for (ut32 i=0; i<repeatCount; i++) {
+				for (ut32 j=0; j<customSize; j++) {
+					if (src >= slim || dest >= dlim) return 14;
+					*dest++ = *src++;
+				}
+				for (ut32 j=0; j<commonSize; j++) {
+					if (dest >= dlim) return 15;
+					*dest++ = 0;
+				}
+			}
+		} else {
+			return 16; // illegal opcode
+		}
+	}
+	if (dest != dlim) return 1;
+	return 0; // ok
+}
+
+static int reloc_comparator(const PEFReloc *a, const PEFReloc *b) {
+	return (a->offset > b->offset) - (a->offset < b->offset);
+}
+
+static RList *do_reloc_bytecode(RBuffer *b, ut32 at, ut32 instCount) {
+	RList *ret = r_list_newf((RListFree)free);
+
+	ut32 codeA = 0, dataA = 1, rSymI = 0, rAddr = 0;
+	ut32 loopInstruct = UT32_MAX;
+	ut32 loopDone = 0;
+
+	if (0) {
+		printf("           Instr     Op    Operand           codeA dataA rSymI rAddr\n");
+	}
+
+	#define dbg(name, format, ...) if (0) { \
+		char buf[50]; \
+		sprintf(buf, format, __VA_ARGS__); \
+		printf("%05X [% 2d] %04X      %-5s %-19s %d %5d %5d   %08X\n", \
+			at + 2*printpc, printpc, r_buf_read_be16_at(b, at+2*printpc), name, buf, codeA, dataA, rSymI, rAddr); \
+	}
+
+	// Abuse the RBinReloc struct fields slightly
+	#define PUSH_RELOC(ofs, targ, imp) { \
+		PEFReloc *r = R_NEW0(PEFReloc); \
+		r->offset = ofs; \
+		r->target = targ; \
+		r->isimport = imp; \
+		r_list_append(ret, r); \
+	}
+
+	ut32 pc = 0;
+	while (pc < instCount) {
+		ut32 printpc = pc;
+		ut16 op = r_buf_read_be16_at(b, at + 2*pc++);
+
+		// Some instructions take a wider argument
+		ut32 longop = 0;
+		if (op >= 0xa000) {
+			if (pc >= instCount) return 0;
+			longop = ((ut32)op << 16) | r_buf_read_be16_at(b, at + 2*pc++);
+		}
+
+		if (op <= 0x3fff) {
+			// RelocBySectDWithSkip (DDAT)
+			ut8 skipCount = (op >> 6) & 0xff;
+			ut8 relocCount = op & 0x3f;
+			dbg("DDAT", "delta=%d,n=%d", skipCount*4, relocCount);
+
+			rAddr += 4 * skipCount;
+			for (ut8 i=0; i<relocCount; i++) {
+				PUSH_RELOC(rAddr, dataA, false);
+				rAddr += 4;
+			}
+		} else if (op >= 0x4000 && op <= 0x41ff) {
+			// RelocBySectC (CODE)
+			// DumpPEF sometimes gets rAddr wrong for large runLength!
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("CODE", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, codeA, false);
+				rAddr += 4;
+			}
+		} else if (op >= 0x4200 && op <= 0x43ff) {
+			// RelocBySectD (DATA)
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("DATA", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, dataA, false);
+				rAddr += 4;
+			}
+		} else if (op >= 0x4400 && op <= 0x45ff) {
+			// RelocTVector12 (DESC)
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("DESC", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, codeA, false);
+				rAddr += 4;
+				PUSH_RELOC(rAddr, dataA, false);
+				rAddr += 8;
+			}
+		} else if (op >= 0x4600 && op <= 0x47ff) {
+			// RelocTVector8 (DSC2)
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("DSC2", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, codeA, false);
+				rAddr += 4;
+				PUSH_RELOC(rAddr, dataA, false);
+				rAddr += 4;
+			}
+		} else if (op >= 0x4800 && op <= 0x49ff) {
+			// RelocVTable8 (VTBL)
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("VTBL", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, dataA, false);
+				rAddr += 8;
+			}
+		} else if (op >= 0x4a00 && op <= 0x4bff) {
+			// RelocImportRun (SYMR)
+			ut16 runLength = (op & 0x1ff) + 1;
+			dbg("SYMR", "cnt=%d", runLength);
+			for (ut16 i=0; i<runLength; i++) {
+				PUSH_RELOC(rAddr, rSymI, true);
+				rAddr += 4;
+				rSymI += 1;
+			}
+		} else if (op >= 0x6000 && op <= 0x61ff) {
+			// RelocSmByImport (SYMB)
+			ut16 index = op & 0x1ff;;
+			dbg("SYMB", "idx=%d", index);
+			PUSH_RELOC(rAddr, index, true);
+			rAddr += 4;
+			rSymI = index + 1;
+		} else if (op >= 0x6200 && op <= 0x63ff) {
+			// RelocSmSetSectC (CDIS)
+			ut16 index = op & 0x1ff;
+			dbg("CDIS", "sct=%d", index);
+			codeA = index;
+		} else if (op >= 0x6400 && op <= 0x65ff) {
+			// RelocSmSetSectD (DTIS)
+			ut16 index = op & 0x1ff;
+			dbg("DTIS", "sct=%d", index);
+			dataA = index;
+		} else if (op >= 0x6600 && op <= 0x67ff) {
+			// RelocSmBySection (SECN)
+			ut16 index = op & 0x1ff;
+			dbg("SECN", "sct=%d", index);
+			PUSH_RELOC(rAddr, index, false);
+			rAddr += 4;
+		} else if (op>>12 == 0b1000) {
+			// RelocIncrPosition (DELT)
+			ut16 offset = (op & 0x0fff) + 1;
+			dbg("DELT", "delta=%d", offset);
+			rAddr += offset;
+		} else if (op >= 0x9000 && op <= 0x9fff) {
+			// RelocSmRepeat (RPT)
+			ut8 blockCount = ((op >> 8) & 0xf) + 1;
+			ut16 repeatCount = (op & 0xff) + 1;
+			dbg("RPT", "i=%d,rpt=%d", blockCount, repeatCount);
+
+			if (loopInstruct != UT32_MAX && loopInstruct != pc) return NULL; // nested loop
+			loopInstruct = pc;
+
+			if (loopDone == repeatCount) {
+				loopDone = 0;
+			} else {
+				loopDone++;
+				pc--; // rewind over "op"
+				if (blockCount > pc) return NULL; // can't go back this far
+				pc -= blockCount;
+			}
+		} else if (op >= 0xa000 && op <= 0xa3ff) {
+			// RelocSetPosition (LABS)
+			ut32 offset = longop & 0x3ffffff;
+			dbg("LABS", "offset=%d", offset);
+			rAddr = offset;
+		} else if (op >= 0xa400 && op <= 0xa7ff) {
+			// RelocLgByImport (LSYM)
+			ut32 index = longop & 0x3ffffff;
+			dbg("LSYM", "idx=%d", index);
+			PUSH_RELOC(rAddr, index, true);
+			rAddr += 4;
+			rSymI = index + 1;
+		} else if (op >= 0xb000 && op <= 0xb3ff) {
+			// RelocLgRepeat (LRPT)
+			ut8 blockCount = ((op >> 8) & 0xf) + 1;
+			ut32 repeatCount = (longop & 0x3fffff) + 1;
+			dbg("LRPT", "i=%d,rpt=%d", blockCount, repeatCount);
+
+			if (loopInstruct != UT32_MAX && loopInstruct != pc) return NULL; // nested loop
+			loopInstruct = pc;
+
+			if (loopDone == repeatCount) {
+				loopDone = 0;
+			} else {
+				loopDone++;
+				pc -= 2; // rewind over "longop"
+				if (blockCount > pc) return NULL; // can't go back this far
+				pc -= blockCount;
+			}
+		} else if (op >= 0xb400 && op <= 0xb43f) {
+			// Same as RelocSmBySection (LSEC LSECN)
+			ut32 index = longop & 0x3fffff;
+			dbg("LSEC", "LSECN,sct=%d", index);
+			PUSH_RELOC(rAddr, index, false);
+			rAddr += 4;
+		} else if (op >= 0xb440 && op <= 0xb47f) {
+			// Same as RelocSmSetSectC (LSEC LDIS)
+			ut32 index = longop & 0x3fffff;
+			dbg("LSEC", "LCDIS,sct=%d", index);
+			codeA = index;
+		} else if (op >= 0xb480 && op <= 0xb4bf) {
+			// Same as RelocSmSetSectD (LSEC LTIS)
+			ut32 index = longop & 0x3fffff;
+			dbg("LSEC", "LDTIS,sct=%d", index);
+			dataA = index;
+		} else {
+			return NULL;
+		}
+	}
+	if (r_list_length(ret) == 0) {
+		r_list_free(ret);
+		return NULL;
+	}
+	r_list_sort(ret, (RListComparator)reloc_comparator);
+	return ret;
+}
+
+static bool check(RBinFile *bf, RBuffer *b) {
+	char tmp[8];
+	int r = r_buf_read_at(b, 0, (ut8 *)tmp, sizeof (tmp));
+	return r == sizeof (tmp) && !memcmp(tmp, "Joy!peff", sizeof (tmp));
+}
+
+static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
+	if (!check(bf, buf)) return false;
+	ut16 nsec = r_buf_read_be16_at(bf->buf, 32);
+	RBinPEFObj *pef = bf->bo->bin_obj = calloc(1, sizeof (RBinPEFObj) + sizeof (PEFSection) * nsec);
+	if (!pef) return false;
+	pef->nsec = nsec;
+	ut64 climb = loadaddr;
+	for (ut16 i=0; i<nsec; i++) {
+		PEFSection *sec = &pef->sec[i];
+		size_t offset = 40 + 28*i;
+		sec->defAddress = r_buf_read_be32_at(buf, offset + 4);
+		sec->lenTotal = r_buf_read_be32_at(buf, offset + 8);
+		sec->lenUnpack = r_buf_read_be32_at(buf, offset + 12);
+		sec->lenDisk = r_buf_read_be32_at(buf, offset + 16);
+		sec->offset = r_buf_read_be32_at(buf, offset + 20);
+		r_buf_read_at(buf, offset + 24, &sec->kind, 1);
+		r_buf_read_at(buf, offset + 25, &sec->share, 1);
+		r_buf_read_at(buf, offset + 26, &sec->align, 1);
+
+		if (sec->kind <= 3 || sec->kind == 6) { // exists in memory
+			climb += sec->align - 1;
+			climb &= ~(ut64)(sec->align - 1);
+			sec->addr = climb;
+			climb += sec->lenTotal;
+		}
+
+		if (sec->kind == 4) pef->ldrsec = sec->offset;
+
+		if (sec->kind == 2) { // pidata, extract now
+			void *pac = malloc(sec->lenDisk);
+			sec->unpack = malloc(sec->lenUnpack);
+			if (!pac || !sec->unpack) return false;
+			st64 n = r_buf_read_at(bf->buf, sec->offset, pac, sec->lenDisk);
+			if (n != sec->lenDisk) return false;
+			if (unpack_pidata(sec->unpack, sec->lenUnpack, pac, sec->lenDisk)) return false;
+			free(pac);
+		}
+	}
+
+	// Parse the loader section
+	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
+	ut32 totalImportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 28);
+	ut32 relocSecCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 32);
+	ut32 relocInstrOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 36);
+
+	for (ut32 i=0; i<relocSecCount; i++) {
+		ut32 at = pef->ldrsec + 56 + 24*importedLibraryCount + 4*totalImportedSymbolCount + 12*i;
+		ut16 sec = r_buf_read_be16_at(bf->buf, at);
+		ut32 instCount = r_buf_read_be32_at(bf->buf, at + 4);
+		ut32 firstInst = r_buf_read_be32_at(bf->buf, at + 8);
+
+		pef->sec[sec].relocs = do_reloc_bytecode(bf->buf, pef->ldrsec + relocInstrOffset + firstInst, instCount);
+	}
+
+	return true;
+}
+
+static void destroy(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+	for (int i=0; i<pef->nsec; i++) {
+		free(pef->sec[i].unpack);
+		r_list_free(pef->sec[i].relocs);
+	}
+	free(pef);
+}
+
+static RBinInfo *info(RBinFile *bf) {
+	char hdr[40];
+	int r = r_buf_read_at(bf->buf, 0, (ut8 *)hdr, sizeof (hdr));
+	if (r != sizeof (hdr)) {
+		return NULL;
+	}
+
+	RBinInfo *ret = R_NEW0 (RBinInfo);
+	ret->file = strdup(bf->file);
+	ret->type = strdup("PEF");
+	if (!memcmp(hdr+8, "pwpc", 4)) {
+		ret->arch = strdup("ppc");
+		ret->machine = strdup("Power Macintosh/BeBox");
+	} else if (!memcmp(hdr+8, "m68k", 4)) {
+		ret->arch = strdup("m68k");
+		ret->cpu = strdup("68040");
+		ret->machine = strdup("Macintosh");
+	}
+	ret->bits = 32;
+	ret->has_pi = true;
+	ret->big_endian = true;
+	ret->rclass = strdup("cfm");
+	ret->has_va = true;
+	return ret;
+}
+
+static RList *fields(RBinFile *bf) {
+	RList *ret = r_list_newf((RListFree)free);
+	#define ROW(nam, siz, val, fmt, cmt) \
+		r_list_append (ret, r_bin_field_new (addr, addr, val, siz, nam, cmt, fmt, false));
+	ut64 addr = 0;
+	ROW("magic", 8, r_buf_read_be64_at(bf->buf, addr), "x", NULL); addr += 8;
+	ROW("architecture", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("formatVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("dateTimeStamp", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("oldDefVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("oldImpVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("currentVersion", 4, r_buf_read_be32_at(bf->buf, addr), "x", NULL); addr += 4;
+	ROW("sectionCount", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
+	ROW("instSectionCount", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
+	ROW("reserved", 2, r_buf_read_be16_at(bf->buf, addr), "x", NULL); addr += 2;
+	return ret;
+}
+
+// There is a "preferred base address" in PEF section headers but it is never used.
+static ut64 baddr(RBinFile *bf) {
+	return 0;
+}
+
+static ut64 size(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+	ut64 s = 0;
+	for (int i=0; i<pef->nsec; i++) {
+		ut64 e = pef->sec[i].offset + pef->sec[i].lenDisk;
+		if (s < e) s = e;
+	}
+	return s;
+}
+
+static RBinAddr *binsym(RBinFile *bf, int sym) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+
+	int n;
+	if (sym == R_BIN_SYM_ENTRY || sym == R_BIN_SYM_MAIN) {
+		n = 0;
+	} else if (sym == R_BIN_SYM_INIT) {
+		n = 1;
+	} else if (sym == R_BIN_SYM_FINI) {
+		n = 2;
+	} else {
+		return NULL;
+	}
+
+	ut32 sec = r_buf_read_be32_at(bf->buf, pef->ldrsec + n*8);
+	ut32 offset = r_buf_read_be32_at(bf->buf, pef->ldrsec + n*8+4);
+	if (sec < pef->nsec && offset < pef->sec[sec].addr+pef->sec[sec].lenTotal) {
+		RBinAddr *ptr = R_NEW0(RBinAddr);
+		ptr->vaddr = pef->sec[sec].addr + offset;
+		return ptr;
+	} else {
+		return NULL;
+	}
+}
+
+static RList *sections(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+	RList *ret = r_list_newf((RListFree)r_bin_section_free);
+
+	for (ut16 i=0; i<pef->nsec; i++) {
+		PEFSection *sec = &pef->sec[i];
+		RBinSection *ptr = R_NEW0(RBinSection);
+		ptr->is_segment = true;
+
+		ptr->paddr = sec->offset;
+		ptr->size = sec->lenDisk;
+		ptr->vaddr = sec->addr;
+		ptr->vsize = sec->lenTotal;
+
+		ptr->type = strdup(
+			sec->kind == 0 ? "TEXT" :
+			sec->kind == 1 ? "DATA" :
+			sec->kind == 2 ? "PIDATA" :
+			sec->kind == 3 ? "RODATA" :
+			sec->kind == 4 ? "LOADER" :
+			"");
+		ptr->name = strdup(ptr->type);
+		ptr->arch = strdup("ppc");
+		ptr->is_data = sec->kind != 0;
+		ptr->add = sec->kind != 4;
+		ptr->perm =
+			sec->kind == 0 ? R_PERM_RX : // text
+			sec->kind == 1 ? R_PERM_RWX : // data
+			sec->kind == 2 ? R_PERM_RWX : // pidata
+			sec->kind == 3 ? R_PERM_R : // rodata
+			sec->kind == 4 ? 0 : // loader
+			R_PERM_RWX; // unknown
+
+		if (sec->kind == 2) { // pidata, need to decompress
+			char *muri = r_str_newf ("malloc://%"PFMT32u, sec->lenTotal); // gets zero-inited
+			ptr->backing = r_io_open_nomap(bf->rbin->iob.io, muri, R_PERM_RW, 0);
+			free(muri);
+			if (ptr->backing != NULL) {
+				r_io_desc_write(ptr->backing, sec->unpack, sec->lenUnpack);
+			}
+
+			ptr->paddr = 0;
+			ptr->size = 0; // hide from R2, nothing good can come from it
+		}
+
+		r_list_append(ret, ptr);
+	}
+	return ret;
+}
+
+static RList *imports(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+
+	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
+	ut32 totalImportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 28);
+	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
+
+	RBinImport **ary = R_NEWS(RBinImport *, totalImportedSymbolCount);
+	for (ut32 i=0; i<totalImportedSymbolCount; i++) {
+		ary[i] = R_NEW0(RBinImport);
+	}
+
+	for (ut32 i=0; i<importedLibraryCount; i++) {
+		ut32 at = pef->ldrsec + 56 + 24*i;
+		ut32 libNamePtr = r_buf_read_be32_at(bf->buf, at);
+		ut32 libSymCount = r_buf_read_be32_at(bf->buf, at + 12);
+		ut32 firstSym = r_buf_read_be32_at(bf->buf, at + 16);
+
+		for (ut32 j=firstSym; j<firstSym+libSymCount && j<totalImportedSymbolCount; j++) {
+			at = pef->ldrsec + 56 + 24*importedLibraryCount + 4*j;
+			ut8 kind = 0;
+			r_buf_read_at(bf->buf, at, &kind, 1);
+			ut32 symNamePtr = r_buf_read_be32_at(bf->buf, at) & 0xffffff;
+
+			ary[j]->name = r_bin_name_new_from(r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + symNamePtr));
+			ary[j]->libname = r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
+			ary[j]->ordinal = j;
+			ary[j]->type = class2string(kind);
+			ary[j]->bind = (kind&0x80) ? R_BIN_BIND_WEAK_STR : R_BIN_BIND_GLOBAL_STR;
+		}
+	}
+
+	RList *ret = r_list_newf((RListFree)r_bin_import_free);
+	for (ut32 i=0; i<totalImportedSymbolCount; i++) {
+		if (ary[i]->name != NULL) {
+			r_list_append(ret, ary[i]);
+		}
+	}
+	free(ary);
+	return ret;
+}
+
+static RList *libs(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+
+	ut32 importedLibraryCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 24);
+	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
+
+	RList *ret = r_list_newf((RListFree)free);
+	for (ut32 i=0; i<importedLibraryCount; i++) {
+		ut32 at = pef->ldrsec + 56 + 24*i;
+		ut32 libNamePtr = r_buf_read_be32_at(bf->buf, at);
+		char *name = r_buf_get_string(bf->buf, pef->ldrsec + loaderStringsOffset + libNamePtr);
+		r_list_append(ret, name);
+	}
+	return ret;
+}
+
+void **flatlist(RList *list) {
+	void **flat = R_NEWS(void *, r_list_length(list));
+	RListIter *iter;
+	void *ptr;
+	size_t i = 0;
+	r_list_foreach(list, iter, ptr) {
+		flat[i++] = ptr;
+	}
+	return flat;
+}
+
+static RList *relocs(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+
+	// Need an indexable list of imports
+	RList *importList = imports(bf);
+	void **importArray = flatlist(importList);
+
+	RList *ret = r_list_newf(free); // r_bin_reloc_free
+	PEFReloc *r;
+	RListIter *iter;
+	for (int i=0; i<pef->nsec; i++) {
+		r_list_foreach(pef->sec[i].relocs, iter, r) {
+			RBinReloc *ptr = R_NEW0(RBinReloc);
+			ptr->type = R_BIN_RELOC_32;
+			ptr->additive = 1;
+			ptr->vaddr = pef->sec[i].addr + r->offset;
+			if (r->isimport) {
+				if (r->target >= r_list_length(importList)) {
+					free(ptr);
+					continue;
+				}
+				ptr->import = r_bin_import_clone(importArray[r->target]);
+			} else {
+				if (r->target >= pef->nsec) {
+					free(ptr);
+					continue;
+				}
+				ptr->addend = pef->sec[r->target].addr;
+			}
+			r_list_append(ret, ptr);
+		}
+	}
+	R_FREE(importArray);
+	r_list_free(importList);
+	return ret;
+}
+
+static RList *patch_relocs(RBinFile *bf) {
+	RList *list = relocs(bf);
+	RListIter *iter;
+	RBinReloc *reloc;
+	r_list_foreach(list, iter, reloc) {
+		if (reloc->import) continue;
+		RIOBind *b = &bf->rbin->iob;
+		ut8 buf[4] = {};
+		b->read_at(b->io, reloc->vaddr, buf, 4);
+		r_write_be32(buf, r_read_be32(buf) + reloc->addend);
+		b->overlay_write_at(b->io, reloc->vaddr, buf, 4);
+	}
+	return list;
+}
+
+static RList *symbols(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+	RList *ret = r_list_newf((RListFree)r_bin_symbol_free);
+
+	ut32 loaderStringsOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 40);
+	ut32 exportHashOffset = r_buf_read_be32_at(bf->buf, pef->ldrsec + 44);
+	ut32 exportHashTablePower = r_buf_read_be32_at(bf->buf, pef->ldrsec + 48);
+	ut32 exportedSymbolCount = r_buf_read_be32_at(bf->buf, pef->ldrsec + 52);
+	ut32 stringLenTable = pef->ldrsec + exportHashOffset + (4<<exportHashTablePower);
+	ut32 exportTable = stringLenTable + 4*exportedSymbolCount;
+
+	for (ut32 i=0; i<exportedSymbolCount; i++) {
+		ut32 ofs = exportTable + 10*i;
+		ut8 kind = 0;
+		r_buf_read_at(bf->buf, ofs, &kind, 1);
+		ut32 nameOfs = pef->ldrsec + loaderStringsOffset + (r_buf_read_be32_at(bf->buf, ofs) & 0xffffff);
+		ut32 addr = r_buf_read_be32_at(bf->buf, ofs + 4);
+		st16 index = r_buf_read_be16_at(bf->buf, ofs + 8);
+		ut16 nameLen = r_buf_read_be16_at(bf->buf, stringLenTable + 4*i);
+		if (index < 0 || index >= pef->nsec) continue; // re-exported func or absolute mem address, not supported
+
+		RBinSymbol *ptr = R_NEW0(RBinSymbol);
+		char *name = calloc(1, nameLen + 1);
+		r_buf_read_at(bf->buf, nameOfs, (ut8*)name, nameLen);
+		ptr->name = r_bin_name_new_from(name);
+		ptr->vaddr = pef->sec[index].addr + addr;
+		ptr->bind = R_BIN_BIND_GLOBAL_STR;
+		ptr->type = class2string(kind);
+		r_list_append(ret, ptr);
+	}
+	return ret;
+}
+
+static RList *entries(RBinFile *bf) {
+	RBinPEFObj *pef = bf->bo->bin_obj;
+	static const int types[] = {
+		R_BIN_ENTRY_TYPE_MAIN,
+		R_BIN_ENTRY_TYPE_INIT,
+		R_BIN_ENTRY_TYPE_FINI
+	};
+
+	RList *ret = r_list_newf(free);
+	for (int i=0; i<3; i++) {
+		ut32 sec = r_buf_read_be32_at(bf->buf, pef->ldrsec + i*8);
+		ut32 offset = r_buf_read_be32_at(bf->buf, pef->ldrsec + i*8+4);
+		if (sec < pef->nsec && offset < pef->sec[sec].addr+pef->sec[sec].lenTotal) {
+			RBinAddr *ptr = R_NEW0(RBinAddr);
+			ptr->vaddr = pef->sec[sec].addr + offset;
+			ptr->type = types[i];
+			r_list_append(ret, ptr);
+		}
+	}
+	return ret;
+}
+
+RBinPlugin r_bin_plugin_pef = {
+	.meta = {
+		.name = "pef",
+		.author = "elliotnunn",
+		.desc = "Vintage-Apple Preferred Executable Format bin plugin",
+		.license = "LGPL-3.0-only",
+	},
+	.check = &check,
+	.load = &load,
+	.destroy = &destroy,
+	.info = &info,
+	.fields = &fields,
+	.baddr = &baddr,
+	.size = &size,
+	.binsym = &binsym,
+	.sections = &sections,
+	.imports = &imports,
+	.libs = &libs,
+	.relocs = &relocs,
+	.patch_relocs = &patch_relocs,
+	.symbols = &symbols,
+	.entries = &entries,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_pef,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -1,16 +1,7 @@
 /* radare - LGPL - Copyright 2025 - elliotnunn */
 
-#include "r_endian.h"
-#include "r_io.h"
-#include "r_list.h"
-#include "r_types.h"
-#include "r_types_base.h"
-#include "r_util/r_buf.h"
 #include <r_lib.h>
 #include <r_bin.h>
-
-#include <stddef.h>
-#include <stdlib.h>
 
 typedef struct {
 	ut32 offset;

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -599,7 +599,7 @@ static RList *imports(RBinFile *bf) {
 	ut32 importedLibraryCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 24);
 	ut32 totalImportedSymbolCount = r_buf_read_be32_at (bf->buf, pef->ldrsec + 28);
 	ut32 loaderStringsOffset = r_buf_read_be32_at (bf->buf, pef->ldrsec + 40);
-	RBinImport **ary = calloc (RBinImport, totalImportedSymbolCount);
+	RBinImport **ary = calloc (sizeof (RBinImport), totalImportedSymbolCount);
 	int i, j;
 
 	for (i=0; i<totalImportedSymbolCount; i++) {

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -516,11 +516,11 @@ static RList *sections(RBinFile *bf) {
 		ptr->vsize = sec->lenTotal;
 
 		ptr->type = strdup(
-			sec->kind == 0 ? "TEXT" :
-			sec->kind == 1 ? "DATA" :
-			sec->kind == 2 ? "PIDATA" :
-			sec->kind == 3 ? "RODATA" :
-			sec->kind == 4 ? "LOADER" :
+			sec->kind == 0 ? "text" :
+			sec->kind == 1 ? "data" :
+			sec->kind == 2 ? "pidata" :
+			sec->kind == 3 ? "rodata" :
+			sec->kind == 4 ? "loader" :
 			"");
 		ptr->name = strdup(ptr->type);
 		ptr->arch = strdup("ppc");

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -373,9 +373,8 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 		r_buf_read_at (buf, offset + 26, &sec->align, 1);
 
 		if (sec->kind <= 3 || sec->kind == 6) { // exists in memory
-			climb += sec->align - 1;
-			climb &= ~(ut64)(sec->align - 1);
-			sec->addr = climb;
+			ut64 alignmask = (1 << sec->align) - 1;
+			sec->addr = climb = (climb + alignmask) & ~alignmask;
 			climb += sec->lenTotal;
 		}
 

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -523,7 +523,6 @@ static RList *sections(RBinFile *bf) {
 			sec->kind == 4 ? "loader" :
 			"");
 		ptr->name = strdup(ptr->type);
-		ptr->arch = strdup("ppc");
 		ptr->is_data = sec->kind != 0;
 		ptr->add = sec->kind != 4;
 		ptr->perm =

--- a/libr/bin/p/pef.mk
+++ b/libr/bin/p/pef.mk
@@ -1,0 +1,10 @@
+OBJ_PEF=bin_pef.o
+
+STATIC_OBJ+=${OBJ_PEF}
+TARGET_PEF=bin_pef.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_PEF}
+
+${TARGET_PEF}: ${OBJ_PEF}
+	${CC} $(call libname,bin_pef) -shared ${CFLAGS} \
+		-o ${TARGET_PEF} ${OBJ_PEF} $(LINK) $(LDFLAGS)

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2918,7 +2918,7 @@ static void add_section(RCore *core, RBinSection *sec, ut64 addr, int fd) {
 	if (sec->backing) {
 		RIOMap *map = r_io_map_add(core->io, sec->backing->fd, R_PERM_RWX, 0LL, addr, sec->vsize);
 		if (map) {
-			free(map->name);
+			free (map->name);
 			map->name = r_str_newf ("unpack.%s", sec->name);
 		} else {
 			R_LOG_ERROR ("map failed!");

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1,5 +1,7 @@
 /* radare - LGPL - Copyright 2011-2025 - pancake */
 
+#include "r_io.h"
+#include "r_types.h"
 #define R_LOG_ORIGIN "core.bin"
 #include <r_core.h>
 
@@ -2912,6 +2914,17 @@ static bool io_create_mem_map(RIO *io, RBinSection *sec, ut64 at, ut64 gap) {
 }
 
 static void add_section(RCore *core, RBinSection *sec, ut64 addr, int fd) {
+	if (sec->backing) {
+		RIOMap *map = r_io_map_add(core->io, sec->backing->fd, R_PERM_RWX, 0LL, addr, sec->vsize);
+		if (map) {
+			free(map->name);
+			map->name = r_str_newf ("unpack.%s", sec->name);
+		} else {
+			printf("map failed!\n");
+		}
+		return;
+	}
+
 	if (!r_io_desc_get (core->io, fd) || UT64_ADD_OVFCHK (sec->size, sec->paddr) ||
 			UT64_ADD_OVFCHK (sec->size, addr) || !sec->vsize) {
 		return;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2920,7 +2920,7 @@ static void add_section(RCore *core, RBinSection *sec, ut64 addr, int fd) {
 			free(map->name);
 			map->name = r_str_newf ("unpack.%s", sec->name);
 		} else {
-			printf("map failed!\n");
+			R_LOG_ERROR ("map failed!");
 		}
 		return;
 	}

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2,6 +2,7 @@
 
 #include "r_io.h"
 #include "r_types.h"
+#undef R_LOG_ORIGIN
 #define R_LOG_ORIGIN "core.bin"
 #include <r_core.h>
 

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -312,6 +312,7 @@ typedef struct r_bin_section_t {
 	bool add; // indicates when you want to add the section to io `S` command
 	bool is_data;
 	bool is_segment;
+	RIODesc *backing;
 } RBinSection;
 
 typedef struct r_bin_import_t {

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -1032,6 +1032,7 @@ extern RBinPlugin r_bin_plugin_pdp11;
 extern RBinPlugin r_bin_plugin_pcap;
 extern RBinPlugin r_bin_plugin_uf2;
 extern RBinPlugin r_bin_plugin_io;
+extern RBinPlugin r_bin_plugin_pef;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follows on from the discussion at https://github.com/radareorg/radare2/pull/24112

I am eager to hear feedback on the edits that I made to cbin.c to make compressed "pidata" sections work.

I will follow up with some test binaries that stress-test the relocation-bytecode and pidata implementations.

Still to come is analysis of data references made through the r2 "rTOC" register. This work might be shared with AIX binaries in the XCOFF32 format.

There is a 68k variant of the PEF format called "CFM-68k". It also uses a base register (I think A5) for data accesses, which might be worth looking into.