### PR TITLE
The 's' suffix in numbers work as an alias for 'seconds' ##analysis

### DIFF
--- a/libr/anal/flirt.c
+++ b/libr/anal/flirt.c
@@ -1254,6 +1254,10 @@ static RFlirtNode *flirt_parse(RFlirt *f) {
 
 	r_buf_seek (f->b, 0, R_BUF_SET);
 	header = parse_header (f);
+	if (!header) {
+		R_LOG_ERROR ("Cannot parse flirt header");
+		goto beach;
+	}
 	if (version >= 6) {
 		idasig_v6_v7_t *v6_v7 = parse_v6_v7_header (f);
 		if (!v6_v7) {

--- a/libr/util/buf.c
+++ b/libr/util/buf.c
@@ -507,7 +507,7 @@ static st64 buf_format(RBuffer *dst, RBuffer *src, const char *fmt, int n) {
 			case '8':
 			case '9':
 				if (m == 1) {
-					m = r_num_get (NULL, &fmt[j]);
+					m = atoi (fmt + j);
 				}
 				continue;
 			case 's': tsize = 2; bigendian = false; break;

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -386,6 +386,11 @@ R_API ut64 r_num_get(R_NULLABLE RNum *num, const char *str) {
 				error (num, "invalid ternary number");
 			}
 			break;
+		case 's':
+			if (isdigit (*str)) {
+				ret *= 60;
+			}
+			break;
 		case 'K': case 'k':
 			if (strchr (str, '.')) {
 				double d = 0;

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -457,7 +457,7 @@ R_API ut64 r_num_get(R_NULLABLE RNum *num, const char *str) {
 #endif
 		default:
 			errno = 0;
-			if (!isdigit (*str)) {
+			if (*str != '-' && !isdigit (*str)) {
 				error (num, "unknown symbol");
 			} else {
 				ret = strtoull (str, &endptr, 10);

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2007-2024 - pancake */
+/* radare - LGPL - Copyright 2007-2025 - pancake */
 
 #define R_LOG_ORIGIN "util.num"
 
@@ -386,11 +386,6 @@ R_API ut64 r_num_get(R_NULLABLE RNum *num, const char *str) {
 				error (num, "invalid ternary number");
 			}
 			break;
-		case 's':
-			if (isdigit (*str)) {
-				ret *= 60;
-			}
-			break;
 		case 'K': case 'k':
 			if (strchr (str, '.')) {
 				double d = 0;
@@ -448,17 +443,29 @@ R_API ut64 r_num_get(R_NULLABLE RNum *num, const char *str) {
 				error (num, "invalid gigabyte number");
 			}
 			break;
+#if 0
+		case 's':
+			// support 's' for miliseconds to seconds
+			if (isdigit (*str)) {
+				if (sscanf (str, "%"PFMT64d"%n", &ret, &chars_read)) {
+					ret *= 1000;
+				} else {
+					error (num, "invalid seconds");
+				}
+			}
+			break;
+#endif
 		default:
 			errno = 0;
-			ret = strtoull (str, &endptr, 10);
-			if (errno == EINVAL) {
-				error (num, "invalid symbol");
-			}
-			if (errno == ERANGE) {
-				error (num, "number won't fit into 64 bits");
-			}
 			if (!isdigit (*str)) {
 				error (num, "unknown symbol");
+			} else {
+				ret = strtoull (str, &endptr, 10);
+				if (errno == EINVAL) {
+					error (num, "invalid symbol");
+				} else if (errno == ERANGE) {
+					error (num, "number won't fit into 64 bits");
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
-e anal.timeout=20s

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
