### PR TITLE
Fix libsdb shared lib install ##build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -502,7 +502,9 @@ install_data(script_files, install_dir: r2_scripts)
 
 libsdb_sp = subproject('sdb')
 libsdb_static = libsdb_sp.get_variable('libsdb_static')
+libsdb_dynamic = libsdb_sp.get_variable('libsdb').get_shared_lib()
 libsdb_includes = libsdb_sp.get_variable('sdb_inc')
+libsdb_version = libsdb_sp.get_variable('sdb_version')
 
 sdb_dep = declare_dependency(
   link_whole: libsdb_static,
@@ -528,7 +530,7 @@ sdb_install = custom_target('r2sdb',
   install_dir : get_option('bindir'))
 
 os_name = host_machine.system()
-lib_extension = '.so'  # Default for Linux
+lib_extension = '.so.' + libsdb_version  # Default for Linux
 
 if os_name == 'darwin'
     lib_extension = '.dylib'
@@ -537,8 +539,8 @@ elif os_name == 'windows'
 endif
 
 libsdb_install = custom_target('libr2sdb',
-  input : libsdb_static,
-  output : 'libr2sdb' + lib_extension,
+  input : libsdb_dynamic,
+  output : 'libsdb' + lib_extension,
   command : copyinout,
   install : true,
   install_dir : get_option('libdir'))


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Since 1d51641e9b725a2d09b31ae7f7b2e5fd0fd4c5fb, a static library is being installed as if it was a shared library. Besides not working, this causes a warning message every time `ldconfig` is run in the machine.

Probably 1d51641e9b725a2d09b31ae7f7b2e5fd0fd4c5fb was intended to fix the issue where the `r2sdb` tool does not work since it is linked to `libsdb.so`. This pull request fixes that issue by installing the correct file, with the correct name. The original original fix is not very clean, this one also isn't very clean, and I apologize since I don't have enough experience with Meson to do it better. A cleaner fix would probably involve changing the libsdb project to somehow allow the parent project to control whether the library is installed when it is used as a subproject (currently, it never install libs if instantiated as a subproject), but I don't know how that would be implemented.

**Before**

```
$ sudo ldconfig
ldconfig: /usr/lib/libr2sdb.so is not an ELF file - it has the wrong magic bytes at the start.
$ ldd /usr/bin/r2sdb
	linux-vdso.so.1 (0x0000799410beb000)
	libsdb.so.2.1.0 => not found
	libc.so.6 => /usr/lib/libc.so.6 (0x0000799410995000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x0000799410bed000)
```

**After**
```
$ sudo ldconfig
$ ldd /usr/bin/r2sdb
	linux-vdso.so.1 (0x0000762a2cd78000)
	libsdb.so.2.1.0 => /usr/lib/libsdb.so.2.1.0 (0x0000762a2ccdd000)
	libc.so.6 => /usr/lib/libc.so.6 (0x0000762a2caeb000)
	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x0000762a2cd7a000)
```