### PR TITLE
Fix Fish Shell Detection In The Install Script 

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -165,7 +165,7 @@ fi
 umask 0002
 
 
-${SHELL} --help 2> /dev/null | grep -q fish
+${SHELL} --version 2> /dev/null | grep -q fish
 if [ $? = 0 ]; then
 	SHELL=/bin/sh
 else


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The installation script `sys/install.sh` used `${SHELL} --help` to detect  fish shell, however the `fish` command does not have a `--help` argument. I changed it to `--version` which outputs something like `fish, version 4.0.0-g1e069b0`.