### PR TITLE
Add current fd selection to project script ##projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -538,6 +538,7 @@ R_API bool r_core_project_save_script(RCore *core, const char *file, int opts) {
 	}
 	r_core_cmd (core, "o*", 0);
 	r_core_cmd (core, "om*", 0);
+	r_cons_printf ("o=%d\n", core->io->desc->fd);
 	r_core_cmd0 (core, "tcc*");
 	if (opts & R_CORE_PRJ_FCNS) {
 		r_cons_printf ("# functions\n");

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -408,9 +408,10 @@ onnu null://8 rw-
 omu 4 0x00600910 0x00000008 0x00000000 rw- mmap.LOAD1
 omu 3 0x006006e0 0x00000230 0x000006e0 r-- fmap.LOAD1
 omu 3 0x00400000 0x000006dc 0x00000000 r-x fmap.LOAD0
+o=3
 files:
- 3 - r-x 0x000021da bins/elf/analysis/main
- 4 * rw- 0x00000008 null://8
+ 3 * r-x 0x000021da bins/elf/analysis/main
+ 4 - rw- 0x00000008 null://8
 count:
 4
 EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

## Description

I had the issue with an AVR bare metal binary, that after saving and reloading the project, the selected fd was not restored. For some reason, this results in radare2 only showing 0x00 bytes (in `pd` and `px`). Only after selecting the correct fd using `o=X`, I could see the correct bytes again.

### Steps I did to encounter this issue:
1. `r2 -a avr my-avr-binary.bin`
2. `aaaa` (creates fd 4)
3. ```
   [0x0000a360]> o
    3 * r-x 0x0001f800 my-avr-binary.bin
    4 - rw- 0x000f0000 malloc://983040
   ```
4. `Ps project-name` and quit
5. `r2 -p project-name`
6. ```
   [0x0000a360]> o
    3 - r-x 0x0001f800 my-avr-binary.bin
    4 * rw- 0x000f0000 malloc://983040
   ```
7. `o=3` to revert to the state in 3. and fixes 0x00 bytes explained above

### Reproducibility
The behavior with the changing fd selection after loading a project is reproducible with other binaries and architectures, e.g., `lscpu` on x86:
After `aaaa`
```
[0x00006090]> o
 3 * r-x 0x00019860 /usr/bin/lscpu
 4 - rw- 0x000001dc null://476
 5 - rw- 0x000f0000 malloc://983040
```
After saving and loading project:
```
[0x00006090]> o
 3 - r-x 0x00019860 /usr/bin/lscpu
 4 - rw- 0x000001dc null://476
 5 * rw- 0x000f0000 malloc://983040
```
But I was not able to reproduce the behavior with only seeing null bytes if the wrong fd is selected with other binaries. I don't know what selecting the fd is for, but I guess this is expected behavior if two mapped ranges overlap or something (?). Currently, I'm not comfortable sharing the AVR binary in question due to copyright concerns, sorry. I think, it's just a binary where the fd selection matters, and I assume it's not the only one.

## Fix
So, for most binaries the fd selection seems to be not that important for displaying the data, but for some binaries it is. Therefore, I suggest including the currently selected fd into the project script. My commit adds a `o=X` command to the script, where `X` is the currently selected fd at time of saving.