### PR TITLE
fix memleak in function r2r_subprocess_init

### DIFF
--- a/binr/r2r/run.c
+++ b/binr/r2r/run.c
@@ -504,22 +504,22 @@ R_API bool r2r_subprocess_init(void) {
 	}
 	sigchld_thread = r_th_new (sigchld_th, NULL, 0);
 	if (!r_th_start (sigchld_thread)) {
-		if (sigchld_thread) {
-			r_th_free (sigchld_thread);
-			sigchld_thread = NULL;
-		}
-		close (sigchld_pipe [0]);
-		close (sigchld_pipe [1]);
-		r_th_lock_free (subprocs_mutex);
-		return false;
+		goto error;
 	}
 	if (r_sys_signal (SIGCHLD, handle_sigchld) < 0) {
-		close (sigchld_pipe [0]);
-		close (sigchld_pipe [1]);
-		r_th_lock_free (subprocs_mutex);
-		return false;
+		goto error;
 	}
 	return true;
+
+error:
+	if (sigchld_thread) {
+		r_th_free (sigchld_thread);
+		sigchld_thread = NULL;
+	}
+	close (sigchld_pipe [0]);
+	close (sigchld_pipe [1]);
+	r_th_lock_free (subprocs_mutex);
+	return false;
 }
 
 R_API void r2r_subprocess_fini(void) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
