### PR TITLE
Fix att imm display

### DIFF
--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -2346,15 +2346,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 
 	memset (o, 0, COLORIZE_BUFSIZE);
 	for (i = j = 0; p[i]; i++, j++) {
-		if (i > 0 && p[i - 1] == ' ' && (p[i] == '$')) {
-			if (p[i + 1] == '0') {
-				snprintf (o + j, COLORIZE_BUFSIZE - j, "%s$0", num);
-			} else {
-				snprintf (o + j, COLORIZE_BUFSIZE - j, "%s$", num);
-			}
-			i += strlen (o + j);
-			j += strlen (o + j);
-		} else if (i > 0 && p[i - 1] == ' ' && (p[i] == '0' && p[i + 1] == 0)) {
+		if (i > 0 && p[i - 1] == ' ' && (p[i] == '0' && p[i + 1] == 0)) {
 			snprintf (o + j, COLORIZE_BUFSIZE - j, "%s0", num);
 			j += strlen (o + j);
 			i++;
@@ -2367,7 +2359,7 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 		}
 		/* colorize numbers */
 		if ((ishexprefix (p + i) && previous != ':') \
-		     || (p[i] == '$' || (isdigit (p[i] & 0xff) && issymbol (previous)))) {
+		     || (isdigit (p[i] & 0xff) && issymbol (previous))) {
 			const char *num2 = num;
 			ut64 n = r_num_get (NULL, p + i);
 			const char *name = print->offname (print->user, n)? color_flag: NULL;
@@ -2407,6 +2399,9 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 			o[j++] = p[i++];
 #endif
 		case '$':
+			snprintf (o + j, COLORIZE_BUFSIZE - j, "%s$", num);
+			j += strlen (o + j);
+			i++;
 			break;
 		case '+':
 		case '-':


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Fix for the $ prefix for imm values in AT&T mode

I reverted the changes in the if statements at the beginning of the function, and added the colorization stuff in the '$' case:
 