### PR TITLE
Add initial Plan 9 RISC-V 64 support ##bin

### DIFF
--- a/libr/bin/format/p9/p9bin.c
+++ b/libr/bin/format/p9/p9bin.c
@@ -62,6 +62,11 @@ bool r_bin_p9_get_arch(RBuffer *b, const char **arch, int *bits, int *big_endian
 		*big_endian = 1;
 		*arch = "ppc";
 		return true;
+
+	case MAGIC_RISCV64:
+		*bits = 64;
+		*arch = "riscv";
+		return true;
 	}
 
 	return false;

--- a/libr/bin/format/p9/p9bin.h
+++ b/libr/bin/format/p9/p9bin.h
@@ -53,6 +53,8 @@ typedef struct r_bin_plan9_obj_t {
 #define	MAGIC_PPC _MAGIC(0, 21)
 #define	MAGIC_PPC64 _MAGIC(HDR_MAGIC, 27)
 
+#define MAGIC_RISCV64 _MAGIC(HDR_MAGIC, 30)
+
 /* Retired, and subsequently unsupported, architectures. */
 #define	MAGIC_INTEL_960 _MAGIC(0, 12)
 #define	MAGIC_ATT_DSP_3210 _MAGIC(0, 17)

--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -55,6 +55,7 @@ static bool load(RBinFile *bf, RBuffer *b, ut64 loadaddr) {
 		break;
 	case MAGIC_ARM64:
 	case MAGIC_PPC64:
+	case MAGIC_RISCV64:
 	case MAGIC_SPARC:
 	case MAGIC_SPARC64:
 	case MAGIC_MIPS_3000BE:
@@ -94,6 +95,11 @@ static ut64 baddr(RBinFile *bf) {
 		// fallthrough
 	case MAGIC_PPC64:
 		return 0x200000ULL;
+	case MAGIC_RISCV64:
+		if (o->is_kernel) {
+			return 0xffffffffc0200000ULL;
+		}
+		return 0x10000ULL;
 	case MAGIC_68020:
 	case MAGIC_INTEL_386:
 	case MAGIC_SPARC:


### PR DESCRIPTION
Opening this as a draft since 9front RISC-V support is WIP, not yet upstream, bringup still being debugged.

See
- load address: https://shithub.us/moody/riscv/d82d996819447cd5896553a8405e51d43f9d0599/sys/src/9/riscv64/mkfile/f.html
- magic: https://shithub.us/moody/riscv/d82d996819447cd5896553a8405e51d43f9d0599/sys/include/a.out.h/f.html

I managed to get the disassembly, functions and symbols in r2. :partying_face: 