### PR TITLE
Fix FreeBSD x64 register profile ##debug

### DIFF
--- a/libr/debug/p/native/reg/kfbsd-x64.h
+++ b/libr/debug/p/native/reg/kfbsd-x64.h
@@ -76,7 +76,6 @@ return strdup (
 "flg	eflags	.32	152	0	c1p.a.zstido.n.rv\n"
 "gpr	rsp	.64	160	0\n"
 "seg	ss	.64	168	0\n"
-"flg	rflags	.64	144	0	c1p.a.zstido.n.rv\n"
 "flg	cf	.1	.1216	0	carry\n"
 "flg	pf	.1	.1218	0	parity\n"
 "flg	af	.1	.1220	0	adjust\n"


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

rflags was defined twice and always printed warnings:

```
WARN: Duplicated register definition for 'rflags' has been ignored
```