### PR TITLE
Fix memleak in function bochs_open and revert PR-24289

### DIFF
--- a/shlr/bochs/src/libbochs.c
+++ b/shlr/bochs/src/libbochs.c
@@ -245,6 +245,7 @@ bool bochs_open(libbochs_t* b, const char * pathBochs, const char * pathConfig) 
 		}
 		free (commandline_);
 	}
+	return result;
 #elif __wasi__
 	// nothing
 #else
@@ -256,13 +257,13 @@ bool bochs_open(libbochs_t* b, const char * pathBochs, const char * pathConfig) 
 
 	if (pipe (aStdinPipe) < 0) {
 		R_LOG_ERROR ("allocating pipe for child input redirect");
-		return false;
+		goto done;
 	}
 	if (pipe(aStdoutPipe) < 0) {
 		close (aStdinPipe[PIPE_READ]);
 		close (aStdinPipe[PIPE_WRITE]);
 		R_LOG_ERROR ("allocating pipe for child output redirect");
-		return false;
+		goto done;
 	}
 
 	nChild = fork ();
@@ -313,6 +314,7 @@ bool bochs_open(libbochs_t* b, const char * pathBochs, const char * pathConfig) 
 				bochs_close (b);
 			}
 		}
+		return result;
 	} else {
 		perror ("pipe");
 		// failed to create child
@@ -322,5 +324,8 @@ bool bochs_open(libbochs_t* b, const char * pathBochs, const char * pathConfig) 
 		close (aStdoutPipe[PIPE_WRITE]);
 	}
 #endif
+done:
+	R_FREE (b->data);
+	R_FREE (lpTmpBuffer);
 	return result;
 }

--- a/shlr/zip/zip/zip_hash.c
+++ b/shlr/zip/zip/zip_hash.c
@@ -245,7 +245,6 @@ _zip_hash_add(zip_hash_t *hash, const zip_uint8_t *name, zip_uint64_t index, zip
         hash->nentries++;
         if (hash->nentries > hash->table_size * HASH_MAX_FILL && hash->table_size < HASH_MAX_SIZE) {
             if (!hash_resize(hash, hash->table_size * 2, error)) {
-                free(entry);
                 return false;
             }
         }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
1. Fix memleak in function bochs_open
2. Revert #24289  for the incorrect modification：
    Confirmed by the maintainer of libzip，there is no memory leak. The entry has already been added to the hash
