### PR TITLE
Early exit when resizing fails with r ##crash

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2954,6 +2954,7 @@ static int cmd_resize(void *data, const char *input) {
 		ret = r_io_resize (core->io, newsize);
 		if (ret < 1) {
 			R_LOG_ERROR ("r_io_resize: cannot resize");
+			return false;
 		}
 	}
 	if (delta && core->addr < newsize) {
@@ -2963,6 +2964,7 @@ static int cmd_resize(void *data, const char *input) {
 		ret = r_io_resize (core->io, newsize);
 		if (ret < 1) {
 			R_LOG_ERROR ("cannot resize");
+			return false;
 		}
 	}
 	if (newsize < (core->addr + core->blocksize) || oldsize < (core->addr + core->blocksize)) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
