### PR TITLE
Fix typo in xnu syscall detection

### DIFF
--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -1446,7 +1446,7 @@ static RList *resolve_syscalls(RKernelCacheObj *obj, ut64 enosys_addr) {
 	ut64 pattern = enosys_addr;
 	if (enosys_addr == 0) {
 		pattern = 0x0004000100000000;
-		offset -= 40;
+		offset += 40;
 	}
 	while (cursor < end) {
 		ut64 test = r_read_le64 (cursor);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

oops
