### PR TITLE
Don't rotate asm.emu on visual prompt

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4059,7 +4059,6 @@ R_API int r_core_visual_cmd(RCore *core, const char *arg) {
 #endif
 		case ':':
 			r_core_visual_prompt_input (core);
-			rotateAsmemu (core);
 			break;
 		case '_':
 			r_core_visual_hudstuff (core);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Opening the visual prompt shouldn't change the configuration. Probably this was leftover debug code.
