### PR TITLE
Fix xnu kernelcache syscalls misalignment ##bin

### DIFF
--- a/libr/bin/p/bin_xnu_kernelcache.c
+++ b/libr/bin/p/bin_xnu_kernelcache.c
@@ -1443,10 +1443,12 @@ static RList *resolve_syscalls(RKernelCacheObj *obj, ut64 enosys_addr) {
 	ut8 *cursor = data_const;
 	ut8 *end = data_const + data_const_size;
 	ut64 offset = 24;
+	ut64 array_offset = 24;
 	ut64 pattern = enosys_addr;
 	if (enosys_addr == 0) {
 		pattern = 0x0004000100000000;
 		offset += 40;
+		array_offset += 24;
 	}
 	while (cursor < end) {
 		ut64 test = r_read_le64 (cursor);
@@ -1514,7 +1516,7 @@ static RList *resolve_syscalls(RKernelCacheObj *obj, ut64 enosys_addr) {
 	r_list_append (syscalls, sym);
 
 	int i = 1;
-	cursor += 24;
+	cursor += array_offset;
 	int num_syscalls = sdb_count (syscall->db);
 	while (cursor < end && i < num_syscalls) {
 		ut64 addr = K_PPTR (r_read_le64 (cursor));


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Syscalls array was mapped off-by-one element on "modern" kernels.
