### PR TITLE
Fix typo in help for aaf? ##shell

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -161,7 +161,7 @@ static RCoreHelpMessage help_msg_aC = {
 };
 
 static RCoreHelpMessage help_msg_aaf = {
-	"Usage:", "aaf[efrt?]", " # analyse all functionsee also 'af' and 'afna'",
+	"Usage:", "aaf[efrt?]", " # analyse all function, see also 'af' and 'afna'",
 	"aaf", "", "same as afr@@c:isq",
 	"aafe", " ", "same as aef@@F",
 	"aaff", "", "set a flag for every function",


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)
