### PR TITLE
Fix glitch when parsing fuzzed swift metadata ##bin

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2015-2024 - inisider, pancake */
+/* radare - LGPL - Copyright 2015-2025 - inisider, pancake */
 
 #define R_LOG_ORIGIN "bin"
 
@@ -2103,7 +2103,6 @@ static char *readstr(RBinFile *bf, mach0_ut p, ut32 *offset, ut32 *left) {
 			R_FREE (name);
 			return NULL;
 		}
-		return name;
 	} else {
 		const size_t name_len = MAX_CLASS_NAME_LEN;
 		name = calloc (1, name_len + 1);
@@ -2118,6 +2117,9 @@ static char *readstr(RBinFile *bf, mach0_ut p, ut32 *offset, ut32 *left) {
 		return s;
 #endif
 	}
-
+	if ((ut8)name[0] == 0xff || !*name) {
+		R_FREE (name);
+		return NULL;
+	}
 	return name;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
