### PR TITLE
Fix unsupported reloc type 1027 on ELF-x64 binaries ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3321,13 +3321,14 @@ typedef struct {
 
 static bool read_relr_entry(ELFOBJ *eo, RBinElfReloc *r, ut64 vaddr, ut64 entry, RelrInfo *info) {
 	R_RETURN_VAL_IF_FAIL (eo && r && info, false);
+	bool arm64 = eo->ehdr.e_machine == EM_AARCH64;
 
 	// If entry is even (LSB == 0), it's an address to relocate
 	if ((entry & 1) == 0) {
 		r->mode = DT_RELR;
 		r->offset = entry;
 		r->rva = entry;
-		r->type = R_AARCH64_RELATIVE;
+		r->type = arm64? R_AARCH64_RELATIVE: R_X86_64_RELATIVE;
 		r->sym = 0; // RELR relocations don't refer to symbols
 		r->addend = 0;
 		// Set next_addr to the word after the one pointed to by entry
@@ -3347,7 +3348,7 @@ static bool read_relr_entry(ELFOBJ *eo, RBinElfReloc *r, ut64 vaddr, ut64 entry,
 			r->mode = DT_RELR;
 			r->offset = info->next_addr + (bit_pos * sizeof (Elf_(Addr)));
 			r->rva = r->offset;
-			r->type = R_AARCH64_RELATIVE;
+			r->type = arm64? R_AARCH64_RELATIVE: R_X86_64_RELATIVE;
 			r->sym = 0; // RELR relocations don't refer to symbols
 			r->addend = 0;
 			return true;

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -590,6 +590,7 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr) {
 		case R_X86_64_TPOFF64:   ADD(64, 0); break;
 		case R_X86_64_DTPMOD64:  break; // id of module containing symbol (keep it as zero)
 		case R_X86_64_DTPOFF64:  ADD(64, 0); break; // offset inside module's tls
+		// case 1027: // this is aarc64_relative, if this appears here we are mixing x64 and arm64 reloc types
 		default:
 			R_LOG_WARN ("Unsupported reloc type %d for x64", rel->type);
 			break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
