### PR TITLE
skip descriptor restoration in WASI to avoid invalid binary parsing 

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -934,12 +934,14 @@ beach:
 		}
 		free (macdwarf);
 	}
-	if (mustclose) {
-		r_io_desc_close (mustclose);
-		if (odesc) {
-			r_io_use_fd (r->io, odesc->fd);
+	#ifndef __wasi__
+		if (mustclose) {
+			r_io_desc_close (mustclose);
+			if (odesc) {
+				r_io_use_fd (r->io, odesc->fd);
+			}
 		}
-	}
+	#endif
 	r_flag_space_set (r->flags, "*");
 	return true;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
