### PR TITLE
Added new operators and sub-expression support for negation operators

### DIFF
--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -27,6 +27,7 @@ typedef union {
 typedef enum {
 	RNCNAME, RNCNUMBER, RNCEND, RNCINC, RNCDEC,
 	RNCLT, RNCGT, // comparison operators
+    RNCBNOT, RNCBAND, RNCBOR, RNCBXOR, RNCBXNOR, RNCBEQ, RNCBNEQ,
 	RNCPLUS='+', RNCMINUS='-', RNCMUL='*', RNCDIV='/', RNCMOD='%',
 	RNCNEG='~', RNCAND='&', RNCOR='|', RNCXOR='^',
 	RNCPRINT=';', RNCASSIGN='=', RNCLEFTP='(', RNCRIGHTP=')',

--- a/libr/util/math.c
+++ b/libr/util/math.c
@@ -63,6 +63,13 @@ static inline RNumCalcValue Ndiv(RNumCalcValue n, RNumCalcValue v) {
 	return n;
 }
 
+static inline RNumCalcValue Bnot(RNumCalcValue n) { n.n = !n.n; return n; }
+static inline RNumCalcValue Bor(RNumCalcValue n, RNumCalcValue v) { n.d = v.d; n.n = n.n || v.n; return n; }
+static inline RNumCalcValue Band(RNumCalcValue n, RNumCalcValue v) { n.d = v.d; n.n = n.n && v.n; return n; }
+static inline RNumCalcValue Bxor(RNumCalcValue n, RNumCalcValue v) { n.d = v.d; n.n = n.n && !v.n || !n.n && v.n; return n; }
+static inline RNumCalcValue Beq(RNumCalcValue n, RNumCalcValue v) { n.d = v.d; n.n = n.n == v.n; return n; }
+static inline RNumCalcValue Bneq(RNumCalcValue n, RNumCalcValue v) { n.d = v.d; n.n = n.n != v.n; return n; }
+
 static RNumCalcValue expr(RNum*, RNumCalc*, int);
 static RNumCalcValue term(RNum*, RNumCalc*, int);
 static void error(RNum*, RNumCalc*, const char *);
@@ -90,6 +97,11 @@ static RNumCalcValue expr(RNum *num, RNumCalc *nc, int get) {
 		case RNCAND: left = Nand (left, term (num, nc, 1)); break;
 		case RNCLT: left = Nlt (left, term (num, nc, 1)); break;
 		case RNCGT: left = Ngt (left, term (num, nc, 1)); break;
+		case RNCBOR: left = Bor (left, term (num, nc, 1)); break;
+		case RNCBAND: left = Band (left, term (num, nc, 1)); break;
+		case RNCBXOR: left = Bxor (left, term (num, nc, 1)); break;
+		case RNCBEQ: left = Beq (left, term (num, nc, 1)); break;
+		case RNCBNEQ: left = Bneq (left, term (num, nc, 1)); break;
 		default:
 			return left;
 		}
@@ -156,6 +168,9 @@ static RNumCalcValue prim(RNum *num, RNumCalc *nc, int get) {
 			Nsubi (v, 1);
 		}
 		return v;
+	case RNCBNOT:
+		get_token (num, nc);
+		return Bnot (nc->number_value); //prim (num, nc, 1), 1);
 	case RNCNEG:
 		get_token (num, nc);
 		return Nneg (nc->number_value); //prim (num, nc, 1), 1);
@@ -190,6 +205,10 @@ static RNumCalcValue prim(RNum *num, RNumCalc *nc, int get) {
 	case RNCSHR:
 	case RNCROL:
 	case RNCROR:
+	case RNCBOR:
+	case RNCBAND:
+	case RNCBXOR:
+	case RNCBEQ:
 		return v;
 	//default: error (num, nc, "primary expected");
 	}
@@ -327,12 +346,37 @@ static RNumCalcToken get_token(RNum *num, RNumCalc *nc) {
 	case '^':
 	case '&':
 	case '|':
+	case '=':
+		if (cin_get (num, nc, &c) && c == ch) {
+			switch (ch) {
+				case '^':
+					// "^^" = boolean xor
+					return nc->curr_tok = RNCBXOR;
+				case '&':
+					// "&&" = boolean and
+					return nc->curr_tok = RNCBAND;
+				case '|':
+					// "||" = boolean or
+					return nc->curr_tok = RNCBOR;
+				case '=':
+					// "==" = equality test
+					return nc->curr_tok = RNCBEQ;
+			}
+		}
+		cin_putback (num, nc, c);
+		return nc->curr_tok = (RNumCalcToken) ch;
+	case '!':
+		if (cin_get (num, nc, &c) && c == '=') {
+			// "!=" = inequality test
+			return nc->curr_tok = RNCBNEQ;
+		}
+		cin_putback (num, nc, c);
+		return nc->curr_tok = RNCBNOT;
 	case '*':
 	case '%':
 	case '/':
 	case '(':
 	case ')':
-	case '=':
 		return nc->curr_tok = (RNumCalcToken) ch;
 	case '0': case '1': case '2': case '3': case '4':
 	case '5': case '6': case '7': case '8': case '9':

--- a/libr/util/math.c
+++ b/libr/util/math.c
@@ -170,10 +170,10 @@ static RNumCalcValue prim(RNum *num, RNumCalc *nc, int get) {
 		return v;
 	case RNCBNOT:
 		get_token (num, nc);
-		return Bnot (nc->number_value); //prim (num, nc, 1), 1);
+		return Bnot (expr (num, nc, 1));
 	case RNCNEG:
 		get_token (num, nc);
-		return Nneg (nc->number_value); //prim (num, nc, 1), 1);
+		return Nneg (expr (num, nc, 1));
 	case RNCINC:
 		return Naddi (prim (num, nc, 1), 1);
 	case RNCDEC:


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I added these operators:

* boolean not operator (`!` operator)
* boolean or operator (`||` operator)
* boolean and operator (`&&` operator)
* boolean xor operator (`^^` operator, I made this up)
* boolean equality operator (`==` operator)
* boolean inequality operator (`!=` operator)

All these operators will give 0 or 1, according to their semantic

Also changed a bit the semantics on the `~` so it acts on sub-expressions (the same applies to the newly introduced `!` operator)

Now the numeric and boolean negation will act on sub-expressions, e.g.
`'? !(2+2-4)` will correctly give 1 and `'? (~(-5)+1)` will correctly
give -5 (i.e. the two's complement representation)

The downside is that whenever you combine negation with other operator
you HAVE to surround the outer expression with parenthesis (refer to the
two's complement example)
