### PR TITLE
Fix JSON encoding of class addresses ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -4105,7 +4105,7 @@ static bool bin_classes(RCore *core, PJ *pj, int mode) {
 			if (c->typename) {
 				pj_ks (pj, "typename", c->typename);
 			}
-			pj_kN (pj, "addr", c->addr);
+			pj_kn (pj, "addr", c->addr);
 			const char *lang = r_bin_lang_tostring (c->lang);
 			if (lang && *lang != '?') {
 				pj_ks (pj, "lang", lang);


### PR DESCRIPTION
The addresses are `ut64`, not `st64`. This fix means `cfg.json.num` is taken into account, and large addresses will not be encoded as negative numbers.

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)