### PR TITLE
Refine the core IOKit types ##types

### DIFF
--- a/libr/anal/d/types-iokit.sdb.txt
+++ b/libr/anal/d/types-iokit.sdb.txt
@@ -13,6 +13,15 @@ typedef.IOAsyncMethod=IOReturn (IOService::*)(natural_t *, void *, void *, void 
 IOByteCount=typedef
 typedef.IOByteCount=unsigned long long
 
+IOCommandGate::Action=typedef
+typedef.IOCommandGate::Action=IOReturn (*)(OSObject *, void *, void *, void *, void *)
+
+IODMACommand::SegmentFunction=typedef
+typedef.IODMACommand::SegmentFunction=bool (*)(IODMACommand *, Segment64, void *, UInt32)
+
+IODMAEventSource::Action=typedef
+typedef.IODMAEventSource::Action=void (*)(OSObject *, IODMAEventSource *, IODMACommand *, IOReturn, IOByteCount, AbsoluteTime)
+
 IODataQueueEntry=typedef
 typedef.IODataQueueEntry=_IODataQueueEntry
 
@@ -25,8 +34,17 @@ typedef.IODirection=unsigned int
 IOEventSource::Action=typedef
 typedef.IOEventSource::Action=void (*)(OSObject *, ...)
 
+IOEventSource::ActionBlock=typedef
+typedef.IOEventSource::ActionBlock=IOReturn (^)()
+
 IOExternalMethodAction=typedef
 typedef.IOExternalMethodAction=IOReturn (*)(OSObject *, void *, IOExternalMethodArguments *)
+
+IOFilterInterruptEventSource::Filter=typedef
+typedef.IOFilterInterruptEventSource::Filter=bool (*)(OSObject *, IOFilterInterruptEventSource *)
+
+IOFilterInterruptEventSource::FilterBlock=typedef
+typedef.IOFilterInterruptEventSource::FilterBlock=bool (^)(IOFilterInterruptEventSource *)
 
 IOHistogramSegmentConfig=typedef
 typedef.IOHistogramSegmentConfig=struct IOHistogramSegmentConfig
@@ -36,6 +54,9 @@ typedef.IOInterruptAction=void (*)(OSObject *, void *, IOService *, int)
 
 IOInterruptEventSource::Action=typedef
 typedef.IOInterruptEventSource::Action=void (*)(OSObject *, IOInterruptEventSource *, int)
+
+IOInterruptEventSource::ActionBlock=typedef
+typedef.IOInterruptEventSource::ActionBlock=void (^)(IOInterruptEventSource *, int)
 
 IOInterruptHandler=typedef
 typedef.IOInterruptHandler=void (*)(void *, void *, void *, int)
@@ -61,6 +82,12 @@ typedef.IOItemCount=unsigned int
 IOLock=typedef
 typedef.IOLock=lck_mtx_t
 
+IOMemoryCursor::SegmentFunction=typedef
+typedef.IOMemoryCursor::SegmentFunction=void (*)(PhysicalSegment, void *, UInt32)
+
+IOMemoryDescriptor::DMACommandOps=typedef
+typedef.IOMemoryDescriptor::DMACommandOps=unsigned int
+
 IOMethod=typedef
 typedef.IOMethod=IOReturn (IOService::*)(void *, void *, void *, void *, void *, void *)
 
@@ -75,6 +102,30 @@ typedef.IOPMPowerFlags=unsigned long
 
 IOPMPowerState=typedef
 typedef.IOPMPowerState=struct IOPMPowerState
+
+IOPerfControlClient::PerfControllerInterface::RegisterDeviceFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::RegisterDeviceFunction=IOReturn (*)(IOService *)
+
+IOPerfControlClient::PerfControllerInterface::RegisterDriverDeviceFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::RegisterDriverDeviceFunction=IOReturn (*)(IOService *, IOService *, DriverState *)
+
+IOPerfControlClient::PerfControllerInterface::WorkBeginFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkBeginFunction=void (*)(IOService *, uint64_t, WorkState *, WorkBeginArgs *)
+
+IOPerfControlClient::PerfControllerInterface::WorkCanSubmitFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkCanSubmitFunction=bool (*)(IOService *, WorkState *, WorkSubmitArgs *)
+
+IOPerfControlClient::PerfControllerInterface::WorkEndFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkEndFunction=void (*)(IOService *, uint64_t, WorkState *, WorkEndArgs *, bool)
+
+IOPerfControlClient::PerfControllerInterface::WorkEndWithResourcesFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkEndWithResourcesFunction=void (*)(IOService *, uint64_t, WorkState *, WorkEndArgs *, ResourceAccounting *, bool)
+
+IOPerfControlClient::PerfControllerInterface::WorkSubmitFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkSubmitFunction=void (*)(IOService *, uint64_t, WorkState *, WorkSubmitArgs *)
+
+IOPerfControlClient::PerfControllerInterface::WorkUpdateFunction=typedef
+typedef.IOPerfControlClient::PerfControllerInterface::WorkUpdateFunction=void (*)(IOService *, uint64_t, WorkState *, WorkUpdateArgs *)
 
 IOPhysicalAddress=typedef
 typedef.IOPhysicalAddress=unsigned long long
@@ -105,6 +156,12 @@ typedef.IORangeScalar=unsigned long long
 
 IORecursiveLock=typedef
 typedef.IORecursiveLock=_IORecursiveLock
+
+IORegistryEntry::Action=typedef
+typedef.IORegistryEntry::Action=IOReturn (*)(OSObject *, void *, void *, void *, void *)
+
+IORegistryEntry::ActionBlock=typedef
+typedef.IORegistryEntry::ActionBlock=IOReturn (^)()
 
 IORegistryEntryApplierFunction=typedef
 typedef.IORegistryEntryApplierFunction=void (*)(IORegistryEntry *, void *)
@@ -142,6 +199,9 @@ typedef.IOServiceApplierFunction=void (*)(IOService *, void *)
 IOServiceInterestHandler=typedef
 typedef.IOServiceInterestHandler=IOReturn (*)(void *, void *, UInt32, IOService *, void *, vm_size_t)
 
+IOServiceStateNotificationEventSource::ActionBlock=typedef
+typedef.IOServiceStateNotificationEventSource::ActionBlock=void (^)()
+
 IOSimpleLock=typedef
 typedef.IOSimpleLock=lck_spin_t
 
@@ -150,6 +210,12 @@ typedef.IOStateNotificationListenerRef=void *
 
 IOThread=typedef
 typedef.IOThread=struct thread *
+
+IOTimerEventSource::Action=typedef
+typedef.IOTimerEventSource::Action=void (*)(OSObject *, IOTimerEventSource *)
+
+IOTimerEventSource::ActionBlock=typedef
+typedef.IOTimerEventSource::ActionBlock=void (^)(IOTimerEventSource *)
 
 IOTrap=typedef
 typedef.IOTrap=IOReturn (IOService::*)(void *, void *, void *, void *, void *, void *)
@@ -162,6 +228,21 @@ typedef.IOVirtualAddress=unsigned long long
 
 IOVirtualRange=typedef
 typedef.IOVirtualRange=struct IOVirtualRange
+
+IOWorkLoop::Action=typedef
+typedef.IOWorkLoop::Action=IOReturn (*)(OSObject *, void *, void *, void *, void *)
+
+IOWorkLoop::ActionBlock=typedef
+typedef.IOWorkLoop::ActionBlock=IOReturn (^)()
+
+OSArray::ArrayPtrType=typedef
+typedef.OSArray::ArrayPtrType=const OSMetaClassBase *
+
+OSBoundedArrayRef=typedef
+typedef.OSBoundedArrayRef=bounded_array_ref<T, os_detail::panic_trapping_policy>
+
+OSData::DeallocFunction=typedef
+typedef.OSData::DeallocFunction=void (*)(void *, unsigned int)
 
 OSKextExcludeLevel=typedef
 typedef.OSKextExcludeLevel=unsigned char
@@ -184,8 +265,17 @@ typedef.OSObjectApplierFunction=void (*)(OSObject *, void *)
 OSObjectRef=typedef
 typedef.OSObjectRef=unsigned long long
 
+OSOrderedSet::OSOrderFunction=typedef
+typedef.OSOrderedSet::OSOrderFunction=SInt32 (*)(const OSMetaClassBase *, const OSMetaClassBase *, void *)
+
+OSPtr=typedef
+typedef.OSPtr=T *
+
 OSReturn=typedef
 typedef.OSReturn=int
+
+OSSerialize::Editor=typedef
+typedef.OSSerialize::Editor=const OSMetaClassBase *(*)(void *, OSSerialize *, OSCollection *, const OSSymbol *, const OSMetaClassBase *)
 
 OSSerializerCallback=typedef
 typedef.OSSerializerCallback=bool (*)(void *, void *, OSSerialize *)
@@ -231,6 +321,9 @@ typedef.coalition_t=struct coalition *
 
 ext_paniclog_handle_t=typedef
 typedef.ext_paniclog_handle_t=ext_paniclog_handle
+
+intrusive_shared_ptr::pointer=typedef
+typedef.intrusive_shared_ptr::pointer=T *
 
 io_object_t=typedef
 typedef.io_object_t=OSObject *
@@ -352,6 +445,11 @@ func.IOBigMemoryCursor_VTable.getPhysicalSegments.ret=UInt32
 func.IOBigMemoryCursor_VTable.getPhysicalSegments=self,descriptor,fromPosition,segments,maxSegments,inMaxTransferSize,transferSize
 func.IOBigMemoryCursor_VTable.getPhysicalSegments=IOBigMemoryCursor * self, IOMemoryDescriptor * descriptor, IOByteCount fromPosition, PhysicalSegment * segments, UInt32 maxSegments, UInt32 inMaxTransferSize, IOByteCount * transferSize
 
+IOBigMemoryCursor::MetaClass_VTable=struct
+struct.IOBigMemoryCursor::MetaClass_VTable=parent
+struct.IOBigMemoryCursor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOBigMemoryCursor::MetaClass_VTable.parent.meta=112
+
 IOBufferMemoryDescriptor_VTable=struct
 struct.IOBufferMemoryDescriptor_VTable=parent,initWithPhysicalMask,setLength,setDirection,getCapacity,getBytesNoCopy__1,getBytesNoCopy__2,appendBytes
 struct.IOBufferMemoryDescriptor_VTable.parent=struct.IOGeneralMemoryDescriptor_VTable,0,0
@@ -423,6 +521,11 @@ func.IOBufferMemoryDescriptor_VTable.appendBytes.cc=cdecl
 func.IOBufferMemoryDescriptor_VTable.appendBytes.ret=bool
 func.IOBufferMemoryDescriptor_VTable.appendBytes=self,bytes,withLength
 func.IOBufferMemoryDescriptor_VTable.appendBytes=IOBufferMemoryDescriptor * self, const void * bytes, vm_size_t withLength
+
+IOBufferMemoryDescriptor::MetaClass_VTable=struct
+struct.IOBufferMemoryDescriptor::MetaClass_VTable=parent
+struct.IOBufferMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOBufferMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IOCPU_VTable=struct
 struct.IOCPU_VTable=parent,setCPUNumber,setCPUState,initCPU,quiesceCPU,startCPU,haltCPU,signalCPU,signalCPUDeferred,signalCPUCancel,enableCPUTimeBase,getCPUNumber,getCPUState,getCPUGroup,getCPUGroupSize,getMachProcessor,getCPUName
@@ -566,6 +669,11 @@ func.IOCPU_VTable.getCPUName.ret=const OSSymbol *
 func.IOCPU_VTable.getCPUName=self
 func.IOCPU_VTable.getCPUName=IOCPU * self
 
+IOCPU::MetaClass_VTable=struct
+struct.IOCPU::MetaClass_VTable=parent
+struct.IOCPU::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCPU::MetaClass_VTable.parent.meta=112
+
 IOCPUInterruptController_VTable=struct
 struct.IOCPUInterruptController_VTable=parent,initCPUInterruptController__1,registerCPUInterruptController,enableCPUInterrupt,initCPUInterruptController__2
 struct.IOCPUInterruptController_VTable.parent=struct.IOInterruptController_VTable,0,0
@@ -607,15 +715,30 @@ func.IOCPUInterruptController_VTable.initCPUInterruptController__2.ret=IOReturn
 func.IOCPUInterruptController_VTable.initCPUInterruptController__2=self,sources,cpus
 func.IOCPUInterruptController_VTable.initCPUInterruptController__2=IOCPUInterruptController * self, int sources, int cpus
 
+IOCPUInterruptController::MetaClass_VTable=struct
+struct.IOCPUInterruptController::MetaClass_VTable=parent
+struct.IOCPUInterruptController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCPUInterruptController::MetaClass_VTable.parent.meta=112
+
 IOCatalogue_VTable=struct
 struct.IOCatalogue_VTable=parent
 struct.IOCatalogue_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOCatalogue_VTable.parent.meta=112
 
+IOCatalogue::MetaClass_VTable=struct
+struct.IOCatalogue::MetaClass_VTable=parent
+struct.IOCatalogue::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCatalogue::MetaClass_VTable.parent.meta=112
+
 IOCommand_VTable=struct
 struct.IOCommand_VTable=parent
 struct.IOCommand_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOCommand_VTable.parent.meta=112
+
+IOCommand::MetaClass_VTable=struct
+struct.IOCommand::MetaClass_VTable=parent
+struct.IOCommand::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCommand::MetaClass_VTable.parent.meta=112
 
 IOCommandGate_VTable=struct
 struct.IOCommandGate_VTable=parent,init,runCommand,runAction,attemptCommand,attemptAction,commandSleep__1,commandWakeup,commandSleep__2
@@ -713,6 +836,11 @@ func.IOCommandGate_VTable.commandSleep__2.ret=IOReturn
 func.IOCommandGate_VTable.commandSleep__2=self,event,deadline,interruptible
 func.IOCommandGate_VTable.commandSleep__2=IOCommandGate * self, void * event, AbsoluteTime deadline, UInt32 interruptible
 
+IOCommandGate::MetaClass_VTable=struct
+struct.IOCommandGate::MetaClass_VTable=parent
+struct.IOCommandGate::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCommandGate::MetaClass_VTable.parent.meta=112
+
 IOCommandPool_VTable=struct
 struct.IOCommandPool_VTable=parent,initWithWorkLoop,init,getCommand,returnCommand,gatedGetCommand,gatedReturnCommand
 struct.IOCommandPool_VTable.parent=struct.OSObject_VTable,0,0
@@ -774,6 +902,11 @@ func.IOCommandPool_VTable.gatedReturnCommand.cc=cdecl
 func.IOCommandPool_VTable.gatedReturnCommand.ret=IOReturn
 func.IOCommandPool_VTable.gatedReturnCommand=self,command
 func.IOCommandPool_VTable.gatedReturnCommand=IOCommandPool * self, IOCommand * command
+
+IOCommandPool::MetaClass_VTable=struct
+struct.IOCommandPool::MetaClass_VTable=parent
+struct.IOCommandPool::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOCommandPool::MetaClass_VTable.parent.meta=112
 
 IOConditionLock_VTable=struct
 struct.IOConditionLock_VTable=parent,initWithCondition,tryLock,lock,unlock,getInterruptible,getCondition,setCondition,lockWhen,unlockWith
@@ -856,6 +989,11 @@ func.IOConditionLock_VTable.unlockWith.cc=cdecl
 func.IOConditionLock_VTable.unlockWith.ret=void
 func.IOConditionLock_VTable.unlockWith=self,condition
 func.IOConditionLock_VTable.unlockWith=IOConditionLock * self, int condition
+
+IOConditionLock::MetaClass_VTable=struct
+struct.IOConditionLock::MetaClass_VTable=parent
+struct.IOConditionLock::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOConditionLock::MetaClass_VTable.parent.meta=112
 
 IODMACommand_VTable=struct
 struct.IODMACommand_VTable=parent,cloneCommand,initWithSpecification__1,setMemoryDescriptor,clearMemoryDescriptor,getMemoryDescriptor,prepare,complete,synchronize,genIOVMSegments,transfer,prepareWithSpecification__1,getPreparedOffsetAndLength,initWithRefCon,initWithSpecification__2,prepareWithSpecification__2,createCopyBuffer
@@ -1045,6 +1183,11 @@ func.IODMACommand_VTable.createCopyBuffer.ret=OSPtr<IOBufferMemoryDescriptor>
 func.IODMACommand_VTable.createCopyBuffer=self,direction,length
 func.IODMACommand_VTable.createCopyBuffer=IODMACommand * self, IODirection direction, UInt64 length
 
+IODMACommand::MetaClass_VTable=struct
+struct.IODMACommand::MetaClass_VTable=parent
+struct.IODMACommand::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODMACommand::MetaClass_VTable.parent.meta=112
+
 IODMAController_VTable=struct
 struct.IODMAController_VTable=parent,registerDMAController,initDMAChannel,startDMACommand,stopDMACommand,completeDMACommand,notifyDMACommand,queryDMACommand,getFIFODepth,setFIFODepth,validFIFODepth,setFrameSize,setDMAConfig,validDMAConfig
 struct.IODMAController_VTable.parent=struct.IOService_VTable,0,0
@@ -1193,6 +1336,11 @@ func.IODMAController_VTable.validDMAConfig.ret=bool
 func.IODMAController_VTable.validDMAConfig=self,dmaIndex,provider,reqIndex
 func.IODMAController_VTable.validDMAConfig=IODMAController * self, UInt32 dmaIndex, IOService * provider, UInt32 reqIndex
 
+IODMAController::MetaClass_VTable=struct
+struct.IODMAController::MetaClass_VTable=parent
+struct.IODMAController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODMAController::MetaClass_VTable.parent.meta=112
+
 IODMAEventSource_VTable=struct
 struct.IODMAEventSource_VTable=parent,completeDMACommand,notifyDMACommand,startDMACommand,stopDMACommand,queryDMACommand,getFIFODepth,setFIFODepth,validFIFODepth,setFrameSize,setDMAConfig,validDMAConfig,init
 struct.IODMAEventSource_VTable.parent=struct.IOEventSource_VTable,0,0
@@ -1320,6 +1468,11 @@ func.IODMAEventSource_VTable.init.ret=bool
 func.IODMAEventSource_VTable.init=self,owner,provider,completion,notification,dmaIndex
 func.IODMAEventSource_VTable.init=IODMAEventSource * self, OSObject * owner, IOService * provider, IODMAEventSource::Action completion, IODMAEventSource::Action notification, UInt32 dmaIndex
 
+IODMAEventSource::MetaClass_VTable=struct
+struct.IODMAEventSource::MetaClass_VTable=parent
+struct.IODMAEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODMAEventSource::MetaClass_VTable.parent.meta=112
+
 IODTNVRAM_VTable=struct
 struct.IODTNVRAM_VTable=parent,registerNVRAMController,sync,reload,getVarDict,readXPRAM,writeXPRAM,readNVRAMProperty,writeNVRAMProperty,getNVRAMPartitions,readNVRAMPartition,writeNVRAMPartition,savePanicInfo
 struct.IODTNVRAM_VTable.parent=struct.IOService_VTable,0,0
@@ -1445,6 +1598,11 @@ func.IODTNVRAM_VTable.savePanicInfo.ret=IOByteCount
 func.IODTNVRAM_VTable.savePanicInfo=self,buffer,length
 func.IODTNVRAM_VTable.savePanicInfo=IODTNVRAM * self, uint8_t * buffer, IOByteCount length
 
+IODTNVRAM::MetaClass_VTable=struct
+struct.IODTNVRAM::MetaClass_VTable=parent
+struct.IODTNVRAM::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODTNVRAM::MetaClass_VTable.parent.meta=112
+
 IODTPlatformExpert_VTable=struct
 struct.IODTPlatformExpert_VTable=parent,processTopLevel,deleteList,excludeList,createNub,createNubs,readNVRAMProperty,writeNVRAMProperty
 struct.IODTPlatformExpert_VTable.parent=struct.IOPlatformExpert_VTable,0,0
@@ -1516,6 +1674,11 @@ func.IODTPlatformExpert_VTable.writeNVRAMProperty.ret=IOReturn
 func.IODTPlatformExpert_VTable.writeNVRAMProperty=self,entry,name,value
 func.IODTPlatformExpert_VTable.writeNVRAMProperty=IODTPlatformExpert * self, IORegistryEntry * entry, const OSSymbol * name, OSData * value
 
+IODTPlatformExpert::MetaClass_VTable=struct
+struct.IODTPlatformExpert::MetaClass_VTable=parent
+struct.IODTPlatformExpert::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODTPlatformExpert::MetaClass_VTable.parent.meta=112
+
 IODataQueue_VTable=struct
 struct.IODataQueue_VTable=parent,sendDataAvailableNotification,initWithCapacity,initWithEntries,enqueue,setNotificationPort,getMemoryDescriptor
 struct.IODataQueue_VTable.parent=struct.OSObject_VTable,0,0
@@ -1575,25 +1738,50 @@ func.IODataQueue_VTable.getMemoryDescriptor.ret=OSPtr<IOMemoryDescriptor>
 func.IODataQueue_VTable.getMemoryDescriptor=self
 func.IODataQueue_VTable.getMemoryDescriptor=IODataQueue * self
 
+IODataQueue::MetaClass_VTable=struct
+struct.IODataQueue::MetaClass_VTable=parent
+struct.IODataQueue::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODataQueue::MetaClass_VTable.parent.meta=112
+
 IODeviceMemory_VTable=struct
 struct.IODeviceMemory_VTable=parent
 struct.IODeviceMemory_VTable.parent=struct.IOMemoryDescriptor_VTable,0,0
 struct.IODeviceMemory_VTable.parent.meta=288
+
+IODeviceMemory::MetaClass_VTable=struct
+struct.IODeviceMemory::MetaClass_VTable=parent
+struct.IODeviceMemory::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODeviceMemory::MetaClass_VTable.parent.meta=112
 
 IODispatchQueue_VTable=struct
 struct.IODispatchQueue_VTable=parent
 struct.IODispatchQueue_VTable.parent=struct.OSObject_VTable,0,0
 struct.IODispatchQueue_VTable.parent.meta=112
 
+IODispatchQueue::MetaClass_VTable=struct
+struct.IODispatchQueue::MetaClass_VTable=parent
+struct.IODispatchQueue::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODispatchQueue::MetaClass_VTable.parent.meta=112
+
 IODispatchSource_VTable=struct
 struct.IODispatchSource_VTable=parent
 struct.IODispatchSource_VTable.parent=struct.OSObject_VTable,0,0
 struct.IODispatchSource_VTable.parent.meta=112
 
+IODispatchSource::MetaClass_VTable=struct
+struct.IODispatchSource::MetaClass_VTable=parent
+struct.IODispatchSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IODispatchSource::MetaClass_VTable.parent.meta=112
+
 IOEventLink_VTable=struct
 struct.IOEventLink_VTable=parent
 struct.IOEventLink_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOEventLink_VTable.parent.meta=112
+
+IOEventLink::MetaClass_VTable=struct
+struct.IOEventLink::MetaClass_VTable=parent
+struct.IOEventLink::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOEventLink::MetaClass_VTable.parent.meta=112
 
 IOEventSource_VTable=struct
 struct.IOEventSource_VTable=parent,init,checkForWork,setWorkLoop,setNext,getNext,setAction,getAction,enable,disable,isEnabled,getWorkLoop,onThread
@@ -1701,10 +1889,20 @@ func.IOEventSource_VTable.onThread.ret=bool
 func.IOEventSource_VTable.onThread=self
 func.IOEventSource_VTable.onThread=const IOEventSource * self
 
+IOEventSource::MetaClass_VTable=struct
+struct.IOEventSource::MetaClass_VTable=parent
+struct.IOEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOEventSource::MetaClass_VTable.parent.meta=112
+
 IOExtensiblePaniclog_VTable=struct
 struct.IOExtensiblePaniclog_VTable=parent
 struct.IOExtensiblePaniclog_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOExtensiblePaniclog_VTable.parent.meta=112
+
+IOExtensiblePaniclog::MetaClass_VTable=struct
+struct.IOExtensiblePaniclog::MetaClass_VTable=parent
+struct.IOExtensiblePaniclog::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOExtensiblePaniclog::MetaClass_VTable.parent.meta=112
 
 IOFilterInterruptEventSource_VTable=struct
 struct.IOFilterInterruptEventSource_VTable=parent,init,signalInterrupt,getFilterAction
@@ -1740,10 +1938,20 @@ func.IOFilterInterruptEventSource_VTable.getFilterAction.ret=IOFilterInterruptEv
 func.IOFilterInterruptEventSource_VTable.getFilterAction=self
 func.IOFilterInterruptEventSource_VTable.getFilterAction=const IOFilterInterruptEventSource * self
 
+IOFilterInterruptEventSource::MetaClass_VTable=struct
+struct.IOFilterInterruptEventSource::MetaClass_VTable=parent
+struct.IOFilterInterruptEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOFilterInterruptEventSource::MetaClass_VTable.parent.meta=112
+
 IOGeneralMemoryDescriptor_VTable=struct
 struct.IOGeneralMemoryDescriptor_VTable=parent
 struct.IOGeneralMemoryDescriptor_VTable.parent=struct.IOMemoryDescriptor_VTable,0,0
 struct.IOGeneralMemoryDescriptor_VTable.parent.meta=288
+
+IOGeneralMemoryDescriptor::MetaClass_VTable=struct
+struct.IOGeneralMemoryDescriptor::MetaClass_VTable=parent
+struct.IOGeneralMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOGeneralMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IOGuardPageMemoryDescriptor_VTable=struct
 struct.IOGuardPageMemoryDescriptor_VTable=parent,initWithSize
@@ -1758,6 +1966,11 @@ func.IOGuardPageMemoryDescriptor_VTable.initWithSize.cc=cdecl
 func.IOGuardPageMemoryDescriptor_VTable.initWithSize.ret=bool
 func.IOGuardPageMemoryDescriptor_VTable.initWithSize=self,size
 func.IOGuardPageMemoryDescriptor_VTable.initWithSize=IOGuardPageMemoryDescriptor * self, vm_size_t size
+
+IOGuardPageMemoryDescriptor::MetaClass_VTable=struct
+struct.IOGuardPageMemoryDescriptor::MetaClass_VTable=parent
+struct.IOGuardPageMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOGuardPageMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IOHistogramReporter_VTable=struct
 struct.IOHistogramReporter_VTable=parent,initWith
@@ -1778,6 +1991,11 @@ func.IOHistogramReporter_VTable.initWith.cc=cdecl
 func.IOHistogramReporter_VTable.initWith.ret=bool
 func.IOHistogramReporter_VTable.initWith=self,reportingService,categories,channelID,channelName,unit,nSegments,config
 func.IOHistogramReporter_VTable.initWith=IOHistogramReporter * self, IOService * reportingService, IOReportCategories categories, uint64_t channelID, const OSSymbol * channelName, IOReportUnit unit, int nSegments, IOHistogramSegmentConfig * config
+
+IOHistogramReporter::MetaClass_VTable=struct
+struct.IOHistogramReporter::MetaClass_VTable=parent
+struct.IOHistogramReporter::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOHistogramReporter::MetaClass_VTable.parent.meta=112
 
 IOInterleavedMemoryDescriptor_VTable=struct
 struct.IOInterleavedMemoryDescriptor_VTable=parent,initWithCapacity,clearMemoryDescriptors,setMemoryDescriptor
@@ -1813,6 +2031,11 @@ func.IOInterleavedMemoryDescriptor_VTable.setMemoryDescriptor.cc=cdecl
 func.IOInterleavedMemoryDescriptor_VTable.setMemoryDescriptor.ret=bool
 func.IOInterleavedMemoryDescriptor_VTable.setMemoryDescriptor=self,descriptor,offset,length
 func.IOInterleavedMemoryDescriptor_VTable.setMemoryDescriptor=IOInterleavedMemoryDescriptor * self, IOMemoryDescriptor * descriptor, IOByteCount offset, IOByteCount length
+
+IOInterleavedMemoryDescriptor::MetaClass_VTable=struct
+struct.IOInterleavedMemoryDescriptor::MetaClass_VTable=parent
+struct.IOInterleavedMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOInterleavedMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IOInterruptController_VTable=struct
 struct.IOInterruptController_VTable=parent,registerInterrupt,unregisterInterrupt,getInterruptType,enableInterrupt,disableInterrupt,causeInterrupt,getInterruptHandlerAddress,handleInterrupt,vectorCanBeShared,initVector,getVectorType,disableVectorHard,enableVector,causeVector,setCPUInterruptProperties,sendIPI,cancelDeferredIPI
@@ -1990,6 +2213,11 @@ func.IOInterruptController_VTable.cancelDeferredIPI.ret=void
 func.IOInterruptController_VTable.cancelDeferredIPI=self,cpu_id
 func.IOInterruptController_VTable.cancelDeferredIPI=IOInterruptController * self, unsigned int cpu_id
 
+IOInterruptController::MetaClass_VTable=struct
+struct.IOInterruptController::MetaClass_VTable=parent
+struct.IOInterruptController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOInterruptController::MetaClass_VTable.parent.meta=112
+
 IOInterruptEventSource_VTable=struct
 struct.IOInterruptEventSource_VTable=parent,init,getProvider,getIntIndex,getAutoDisable,interruptOccurred,normalInterruptOccurred,disableInterruptOccurred
 struct.IOInterruptEventSource_VTable.parent=struct.IOEventSource_VTable,0,0
@@ -2064,15 +2292,30 @@ func.IOInterruptEventSource_VTable.disableInterruptOccurred.ret=void
 func.IOInterruptEventSource_VTable.disableInterruptOccurred=self,a1,nub,ind
 func.IOInterruptEventSource_VTable.disableInterruptOccurred=IOInterruptEventSource * self, void * a1, IOService * nub, int ind
 
+IOInterruptEventSource::MetaClass_VTable=struct
+struct.IOInterruptEventSource::MetaClass_VTable=parent
+struct.IOInterruptEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOInterruptEventSource::MetaClass_VTable.parent.meta=112
+
 IOKitDiagnostics_VTable=struct
 struct.IOKitDiagnostics_VTable=parent
 struct.IOKitDiagnostics_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOKitDiagnostics_VTable.parent.meta=112
 
+IOKitDiagnostics::MetaClass_VTable=struct
+struct.IOKitDiagnostics::MetaClass_VTable=parent
+struct.IOKitDiagnostics::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOKitDiagnostics::MetaClass_VTable.parent.meta=112
+
 IOKitDiagnosticsClient_VTable=struct
 struct.IOKitDiagnosticsClient_VTable=parent
 struct.IOKitDiagnosticsClient_VTable.parent=struct.IOUserClient2022_VTable,0,0
 struct.IOKitDiagnosticsClient_VTable.parent.meta=1488
+
+IOKitDiagnosticsClient::MetaClass_VTable=struct
+struct.IOKitDiagnosticsClient::MetaClass_VTable=parent
+struct.IOKitDiagnosticsClient::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOKitDiagnosticsClient::MetaClass_VTable.parent.meta=112
 
 IOLittleMemoryCursor_VTable=struct
 struct.IOLittleMemoryCursor_VTable=parent,initWithSpecification,getPhysicalSegments
@@ -2103,6 +2346,11 @@ func.IOLittleMemoryCursor_VTable.getPhysicalSegments.cc=cdecl
 func.IOLittleMemoryCursor_VTable.getPhysicalSegments.ret=UInt32
 func.IOLittleMemoryCursor_VTable.getPhysicalSegments=self,descriptor,fromPosition,segments,maxSegments,inMaxTransferSize,transferSize
 func.IOLittleMemoryCursor_VTable.getPhysicalSegments=IOLittleMemoryCursor * self, IOMemoryDescriptor * descriptor, IOByteCount fromPosition, PhysicalSegment * segments, UInt32 maxSegments, UInt32 inMaxTransferSize, IOByteCount * transferSize
+
+IOLittleMemoryCursor::MetaClass_VTable=struct
+struct.IOLittleMemoryCursor::MetaClass_VTable=parent
+struct.IOLittleMemoryCursor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOLittleMemoryCursor::MetaClass_VTable.parent.meta=112
 
 IOMapper_VTable=struct
 struct.IOMapper_VTable=parent,initHardware,getPageSize,iovmMapMemory,iovmUnmapMemory,iovmInsert,mapToPhysicalAddress
@@ -2177,6 +2425,11 @@ func.IOMapper_VTable.mapToPhysicalAddress.ret=uint64_t
 func.IOMapper_VTable.mapToPhysicalAddress=self,mappedAddress
 func.IOMapper_VTable.mapToPhysicalAddress=IOMapper * self, uint64_t mappedAddress
 
+IOMapper::MetaClass_VTable=struct
+struct.IOMapper::MetaClass_VTable=parent
+struct.IOMapper::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOMapper::MetaClass_VTable.parent.meta=112
+
 IOMemoryCursor_VTable=struct
 struct.IOMemoryCursor_VTable=parent,initWithSpecification,genPhysicalSegments
 struct.IOMemoryCursor_VTable.parent=struct.OSObject_VTable,0,0
@@ -2207,6 +2460,11 @@ func.IOMemoryCursor_VTable.genPhysicalSegments.cc=cdecl
 func.IOMemoryCursor_VTable.genPhysicalSegments.ret=UInt32
 func.IOMemoryCursor_VTable.genPhysicalSegments=self,descriptor,fromPosition,segments,maxSegments,maxTransferSize,transferSize
 func.IOMemoryCursor_VTable.genPhysicalSegments=IOMemoryCursor * self, IOMemoryDescriptor * descriptor, IOByteCount fromPosition, void * segments, UInt32 maxSegments, UInt32 maxTransferSize, IOByteCount * transferSize
+
+IOMemoryCursor::MetaClass_VTable=struct
+struct.IOMemoryCursor::MetaClass_VTable=parent
+struct.IOMemoryCursor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOMemoryCursor::MetaClass_VTable.parent.meta=112
 
 IOMemoryDescriptor_VTable=struct
 struct.IOMemoryDescriptor_VTable=parent,initWithOptions,setPurgeable,performOperation,dmaCommandOperation,getPhysicalSegment,getPreparationID,getDirection,getLength,setTag,getTag,readBytes,writeBytes,prepare,complete,map,setMapping,redirect,makeMapping,addMapping,removeMapping,doMap,doUnmap
@@ -2437,6 +2695,11 @@ func.IOMemoryDescriptor_VTable.doUnmap.ret=IOReturn
 func.IOMemoryDescriptor_VTable.doUnmap=self,addressMap,logical,length
 func.IOMemoryDescriptor_VTable.doUnmap=IOMemoryDescriptor * self, vm_map_t addressMap, IOVirtualAddress logical, IOByteCount length
 
+IOMemoryDescriptor::MetaClass_VTable=struct
+struct.IOMemoryDescriptor::MetaClass_VTable=parent
+struct.IOMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOMemoryDescriptor::MetaClass_VTable.parent.meta=112
+
 IOMemoryMap_VTable=struct
 struct.IOMemoryMap_VTable=parent,getVirtualAddress,getPhysicalSegment,getLength,getAddressTask,getMemoryDescriptor,getMapOptions,unmap,taskDied,redirect
 struct.IOMemoryMap_VTable.parent=struct.OSObject_VTable,0,0
@@ -2520,6 +2783,11 @@ func.IOMemoryMap_VTable.redirect.ret=IOReturn
 func.IOMemoryMap_VTable.redirect=self,newBackingMemory,options,offset
 func.IOMemoryMap_VTable.redirect=IOMemoryMap * self, IOMemoryDescriptor * newBackingMemory, IOOptionBits options, mach_vm_size_t offset
 
+IOMemoryMap::MetaClass_VTable=struct
+struct.IOMemoryMap::MetaClass_VTable=parent
+struct.IOMemoryMap::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOMemoryMap::MetaClass_VTable.parent.meta=112
+
 IOMultiMemoryDescriptor_VTable=struct
 struct.IOMultiMemoryDescriptor_VTable=parent,initWithDescriptors
 struct.IOMultiMemoryDescriptor_VTable.parent=struct.IOMemoryDescriptor_VTable,0,0
@@ -2536,6 +2804,11 @@ func.IOMultiMemoryDescriptor_VTable.initWithDescriptors.cc=cdecl
 func.IOMultiMemoryDescriptor_VTable.initWithDescriptors.ret=bool
 func.IOMultiMemoryDescriptor_VTable.initWithDescriptors=self,descriptors,withCount,withDirection,asReference
 func.IOMultiMemoryDescriptor_VTable.initWithDescriptors=IOMultiMemoryDescriptor * self, IOMemoryDescriptor ** descriptors, UInt32 withCount, IODirection withDirection, bool asReference
+
+IOMultiMemoryDescriptor::MetaClass_VTable=struct
+struct.IOMultiMemoryDescriptor::MetaClass_VTable=parent
+struct.IOMultiMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOMultiMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IONVRAMController_VTable=struct
 struct.IONVRAMController_VTable=parent,sync,select,eraseBank,read,write
@@ -2589,6 +2862,11 @@ func.IONVRAMController_VTable.write.ret=IOReturn
 func.IONVRAMController_VTable.write=self,offset,buffer,length
 func.IONVRAMController_VTable.write=IONVRAMController * self, IOByteCount offset, UInt8 * buffer, IOByteCount length
 
+IONVRAMController::MetaClass_VTable=struct
+struct.IONVRAMController::MetaClass_VTable=parent
+struct.IONVRAMController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IONVRAMController::MetaClass_VTable.parent.meta=112
+
 IONaturalMemoryCursor_VTable=struct
 struct.IONaturalMemoryCursor_VTable=parent,initWithSpecification,getPhysicalSegments
 struct.IONaturalMemoryCursor_VTable.parent=struct.IOMemoryCursor_VTable,0,0
@@ -2619,6 +2897,11 @@ func.IONaturalMemoryCursor_VTable.getPhysicalSegments.ret=UInt32
 func.IONaturalMemoryCursor_VTable.getPhysicalSegments=self,descriptor,fromPosition,segments,maxSegments,inMaxTransferSize,transferSize
 func.IONaturalMemoryCursor_VTable.getPhysicalSegments=IONaturalMemoryCursor * self, IOMemoryDescriptor * descriptor, IOByteCount fromPosition, PhysicalSegment * segments, UInt32 maxSegments, UInt32 inMaxTransferSize, IOByteCount * transferSize
 
+IONaturalMemoryCursor::MetaClass_VTable=struct
+struct.IONaturalMemoryCursor::MetaClass_VTable=parent
+struct.IONaturalMemoryCursor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IONaturalMemoryCursor::MetaClass_VTable.parent.meta=112
+
 IONotifier_VTable=struct
 struct.IONotifier_VTable=parent,remove,disable,enable
 struct.IONotifier_VTable.parent=struct.OSObject_VTable,0,0
@@ -2648,6 +2931,11 @@ func.IONotifier_VTable.enable.cc=cdecl
 func.IONotifier_VTable.enable.ret=void
 func.IONotifier_VTable.enable=self,was
 func.IONotifier_VTable.enable=IONotifier * self, bool was
+
+IONotifier::MetaClass_VTable=struct
+struct.IONotifier::MetaClass_VTable=parent
+struct.IONotifier::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IONotifier::MetaClass_VTable.parent.meta=112
 
 IOPMGR_VTable=struct
 struct.IOPMGR_VTable=parent,enableCPUCore__1,enableCPUCore__2,disableCPUCore,enableCPUCluster,disableCPUCluster,initCPUIdle,enterCPUIdle,exitCPUIdle,updateCPUIdle
@@ -2736,6 +3024,11 @@ func.IOPMGR_VTable.updateCPUIdle.ret=void
 func.IOPMGR_VTable.updateCPUIdle=self,newIdleTimeoutTicks
 func.IOPMGR_VTable.updateCPUIdle=IOPMGR * self, UInt64 * newIdleTimeoutTicks
 
+IOPMGR::MetaClass_VTable=struct
+struct.IOPMGR::MetaClass_VTable=parent
+struct.IOPMGR::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPMGR::MetaClass_VTable.parent.meta=112
+
 IOPMPowerSource_VTable=struct
 struct.IOPMPowerSource_VTable=parent,updateStatus
 struct.IOPMPowerSource_VTable.parent=struct.IOService_VTable,0,0
@@ -2749,20 +3042,40 @@ func.IOPMPowerSource_VTable.updateStatus.ret=void
 func.IOPMPowerSource_VTable.updateStatus=self
 func.IOPMPowerSource_VTable.updateStatus=IOPMPowerSource * self
 
+IOPMPowerSource::MetaClass_VTable=struct
+struct.IOPMPowerSource::MetaClass_VTable=parent
+struct.IOPMPowerSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPMPowerSource::MetaClass_VTable.parent.meta=112
+
 IOPMPowerSourceList_VTable=struct
 struct.IOPMPowerSourceList_VTable=parent
 struct.IOPMPowerSourceList_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOPMPowerSourceList_VTable.parent.meta=112
+
+IOPMPowerSourceList::MetaClass_VTable=struct
+struct.IOPMPowerSourceList::MetaClass_VTable=parent
+struct.IOPMPowerSourceList::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPMPowerSourceList::MetaClass_VTable.parent.meta=112
 
 IOPMinformee_VTable=struct
 struct.IOPMinformee_VTable=parent
 struct.IOPMinformee_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOPMinformee_VTable.parent.meta=112
 
+IOPMinformee::MetaClass_VTable=struct
+struct.IOPMinformee::MetaClass_VTable=parent
+struct.IOPMinformee::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPMinformee::MetaClass_VTable.parent.meta=112
+
 IOPMinformeeList_VTable=struct
 struct.IOPMinformeeList_VTable=parent
 struct.IOPMinformeeList_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOPMinformeeList_VTable.parent.meta=112
+
+IOPMinformeeList::MetaClass_VTable=struct
+struct.IOPMinformeeList::MetaClass_VTable=parent
+struct.IOPMinformeeList::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPMinformeeList::MetaClass_VTable.parent.meta=112
 
 IOPerfControlClient_VTable=struct
 struct.IOPerfControlClient_VTable=parent,init,registerDevice,unregisterDevice,workSubmit,workSubmitAndBegin,workBegin,workEnd,registerPerformanceController
@@ -2852,10 +3165,20 @@ func.IOPerfControlClient_VTable.registerPerformanceController.ret=IOReturn
 func.IOPerfControlClient_VTable.registerPerformanceController=self,interface
 func.IOPerfControlClient_VTable.registerPerformanceController=IOPerfControlClient * self, PerfControllerInterface * interface
 
+IOPerfControlClient::MetaClass_VTable=struct
+struct.IOPerfControlClient::MetaClass_VTable=parent
+struct.IOPerfControlClient::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPerfControlClient::MetaClass_VTable.parent.meta=112
+
 IOPlatformDevice_VTable=struct
 struct.IOPlatformDevice_VTable=parent
 struct.IOPlatformDevice_VTable.parent=struct.IOService_VTable,0,0
 struct.IOPlatformDevice_VTable.parent.meta=1336
+
+IOPlatformDevice::MetaClass_VTable=struct
+struct.IOPlatformDevice::MetaClass_VTable=parent
+struct.IOPlatformDevice::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPlatformDevice::MetaClass_VTable.parent.meta=112
 
 IOPlatformExpert_VTable=struct
 struct.IOPlatformExpert_VTable=parent,setBootROMType,setChipSetType,setMachineType,CheckSubTree,RegisterServiceInTree,PMInstantiatePowerDomains,configure,createNub,compareNubName,getNubResources,getBootROMType,getChipSetType,getMachineType,getModelName,getMachineName,haltRestart,sleepKernel,getGMTTimeOfDay,setGMTTimeOfDay,getConsoleInfo,setConsoleInfo,registerNVRAMController,registerInterruptController,lookUpInterruptController,setCPUInterruptProperties,atInterruptLevel,getPhysicalRangeAllocator,platformAdjustService,PMRegisterDevice,PMLog,hasPMFeature,hasPrivPMFeature,numBatteriesSupported,savePanicInfo,createSystemSerialNumberString,deregisterInterruptController,getUTCTimeOfDay,setUTCTimeOfDay,getTargetName,getProductName
@@ -3234,6 +3557,11 @@ func.IOPlatformExpert_VTable.getProductName.ret=bool
 func.IOPlatformExpert_VTable.getProductName=self,name,maxLength
 func.IOPlatformExpert_VTable.getProductName=IOPlatformExpert * self, char * name, int maxLength
 
+IOPlatformExpert::MetaClass_VTable=struct
+struct.IOPlatformExpert::MetaClass_VTable=parent
+struct.IOPlatformExpert::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPlatformExpert::MetaClass_VTable.parent.meta=112
+
 IOPlatformExpertDevice_VTable=struct
 struct.IOPlatformExpertDevice_VTable=parent,init
 struct.IOPlatformExpertDevice_VTable.parent=struct.IOService_VTable,0,0
@@ -3248,6 +3576,11 @@ func.IOPlatformExpertDevice_VTable.init.ret=bool
 func.IOPlatformExpertDevice_VTable.init=self,dtRoot
 func.IOPlatformExpertDevice_VTable.init=IOPlatformExpertDevice * self, void * dtRoot
 
+IOPlatformExpertDevice::MetaClass_VTable=struct
+struct.IOPlatformExpertDevice::MetaClass_VTable=parent
+struct.IOPlatformExpertDevice::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPlatformExpertDevice::MetaClass_VTable.parent.meta=112
+
 IOPlatformIO_VTable=struct
 struct.IOPlatformIO_VTable=parent,handlePlatformError
 struct.IOPlatformIO_VTable.parent=struct.IOService_VTable,0,0
@@ -3261,6 +3594,11 @@ func.IOPlatformIO_VTable.handlePlatformError.cc=cdecl
 func.IOPlatformIO_VTable.handlePlatformError.ret=bool
 func.IOPlatformIO_VTable.handlePlatformError=self,far
 func.IOPlatformIO_VTable.handlePlatformError=IOPlatformIO * self, vm_offset_t far
+
+IOPlatformIO::MetaClass_VTable=struct
+struct.IOPlatformIO::MetaClass_VTable=parent
+struct.IOPlatformIO::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPlatformIO::MetaClass_VTable.parent.meta=112
 
 IOPolledInterface_VTable=struct
 struct.IOPolledInterface_VTable=parent,probe,open,close,startIO,checkForWork,setEncryptionKey
@@ -3326,15 +3664,30 @@ func.IOPolledInterface_VTable.setEncryptionKey.ret=IOReturn
 func.IOPolledInterface_VTable.setEncryptionKey=self,key,keySize
 func.IOPolledInterface_VTable.setEncryptionKey=IOPolledInterface * self, const uint8_t * key, size_t keySize
 
+IOPolledInterface::MetaClass_VTable=struct
+struct.IOPolledInterface::MetaClass_VTable=parent
+struct.IOPolledInterface::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPolledInterface::MetaClass_VTable.parent.meta=112
+
 IOPowerConnection_VTable=struct
 struct.IOPowerConnection_VTable=parent
 struct.IOPowerConnection_VTable.parent=struct.IOService_VTable,0,0
 struct.IOPowerConnection_VTable.parent.meta=1336
 
+IOPowerConnection::MetaClass_VTable=struct
+struct.IOPowerConnection::MetaClass_VTable=parent
+struct.IOPowerConnection::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOPowerConnection::MetaClass_VTable.parent.meta=112
+
 IOProviderPropertyMerger_VTable=struct
 struct.IOProviderPropertyMerger_VTable=parent
 struct.IOProviderPropertyMerger_VTable.parent=struct.IOService_VTable,0,0
 struct.IOProviderPropertyMerger_VTable.parent.meta=1336
+
+IOProviderPropertyMerger::MetaClass_VTable=struct
+struct.IOProviderPropertyMerger::MetaClass_VTable=parent
+struct.IOProviderPropertyMerger::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOProviderPropertyMerger::MetaClass_VTable.parent.meta=112
 
 IORTC_VTable=struct
 struct.IORTC_VTable=parent,getGMTTimeOfDay,setGMTTimeOfDay,getUTCTimeOfDay,setUTCTimeOfDay,setAlarmEnable,getMonotonicClockOffset,setMonotonicClockOffset,getMonotonicClockAndTimestamp
@@ -3414,6 +3767,40 @@ func.IORTC_VTable.getMonotonicClockAndTimestamp.cc=cdecl
 func.IORTC_VTable.getMonotonicClockAndTimestamp.ret=IOReturn
 func.IORTC_VTable.getMonotonicClockAndTimestamp=self,usecs,mach_absolute_time
 func.IORTC_VTable.getMonotonicClockAndTimestamp=IORTC * self, uint64_t * usecs, uint64_t * mach_absolute_time
+
+IORTC::MetaClass_VTable=struct
+struct.IORTC::MetaClass_VTable=parent
+struct.IORTC::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IORTC::MetaClass_VTable.parent.meta=112
+
+IORTCController_VTable=struct
+struct.IORTCController_VTable=parent,getRealTimeClock,setRealTimeClock
+struct.IORTCController_VTable.parent=struct.IOService_VTable,0,0
+struct.IORTCController_VTable.parent.meta=1336
+struct.IORTCController_VTable.getRealTimeClock=IORTCController_VTable.getRealTimeClock,1336,0
+struct.IORTCController_VTable.getRealTimeClock.meta=8
+func.IORTCController_VTable.getRealTimeClock.args=3
+func.IORTCController_VTable.getRealTimeClock.arg.0=IORTCController *, self
+func.IORTCController_VTable.getRealTimeClock.arg.1=UInt8 *, currentTime
+func.IORTCController_VTable.getRealTimeClock.arg.2=IOByteCount *, length
+func.IORTCController_VTable.getRealTimeClock.cc=cdecl
+func.IORTCController_VTable.getRealTimeClock.ret=IOReturn
+func.IORTCController_VTable.getRealTimeClock=self,currentTime,length
+func.IORTCController_VTable.getRealTimeClock=IORTCController * self, UInt8 * currentTime, IOByteCount * length
+struct.IORTCController_VTable.setRealTimeClock=IORTCController_VTable.setRealTimeClock,1344,0
+struct.IORTCController_VTable.setRealTimeClock.meta=8
+func.IORTCController_VTable.setRealTimeClock.args=2
+func.IORTCController_VTable.setRealTimeClock.arg.0=IORTCController *, self
+func.IORTCController_VTable.setRealTimeClock.arg.1=UInt8 *, newTime
+func.IORTCController_VTable.setRealTimeClock.cc=cdecl
+func.IORTCController_VTable.setRealTimeClock.ret=IOReturn
+func.IORTCController_VTable.setRealTimeClock=self,newTime
+func.IORTCController_VTable.setRealTimeClock=IORTCController * self, UInt8 * newTime
+
+IORTCController::MetaClass_VTable=struct
+struct.IORTCController::MetaClass_VTable=parent
+struct.IORTCController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IORTCController::MetaClass_VTable.parent.meta=112
 
 IORangeAllocator_VTable=struct
 struct.IORangeAllocator_VTable=parent,allocElement,deallocElement,init,getFragmentCount,getFragmentCapacity,setFragmentCapacityIncrement,getFreeCount,allocate,allocateRange,deallocate
@@ -3513,6 +3900,11 @@ func.IORangeAllocator_VTable.deallocate.cc=cdecl
 func.IORangeAllocator_VTable.deallocate.ret=void
 func.IORangeAllocator_VTable.deallocate=self,start,size
 func.IORangeAllocator_VTable.deallocate=IORangeAllocator * self, IORangeScalar start, IORangeScalar size
+
+IORangeAllocator::MetaClass_VTable=struct
+struct.IORangeAllocator::MetaClass_VTable=parent
+struct.IORangeAllocator::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IORangeAllocator::MetaClass_VTable.parent.meta=112
 
 IORegistryEntry_VTable=struct
 struct.IORegistryEntry_VTable=parent,copyProperty__1,copyProperty__2,copyProperty__3,copyParentEntry,copyChildEntry,runPropertyAction,init__1,setPropertyTable,setProperty__1,setProperty__2,setProperty__3,setProperty__4,setProperty__5,setProperty__6,setProperty__7,removeProperty__1,removeProperty__2,removeProperty__3,getProperty__1,getProperty__2,getProperty__3,getProperty__4,getProperty__5,getProperty__6,copyProperty__4,copyProperty__5,copyProperty__6,dictionaryWithProperties,serializeProperties,setProperties,getParentIterator,applyToParents,getParentEntry,getChildIterator,applyToChildren,getChildEntry,isChild,isParent,inPlane,getDepth,attachToParent,detachFromParent,attachToChild,detachFromChild,detachAbove,detachAll,getName,copyName,compareNames,compareName,setName__1,setName__2,getLocation,copyLocation,setLocation__1,setLocation__2,getPath,getPathComponent,childFromPath,init__2
@@ -4110,6 +4502,11 @@ func.IORegistryEntry_VTable.init__2.ret=bool
 func.IORegistryEntry_VTable.init__2=self,from,inPlane
 func.IORegistryEntry_VTable.init__2=IORegistryEntry * self, IORegistryEntry * from, const IORegistryPlane * inPlane
 
+IORegistryEntry::MetaClass_VTable=struct
+struct.IORegistryEntry::MetaClass_VTable=parent
+struct.IORegistryEntry::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IORegistryEntry::MetaClass_VTable.parent.meta=112
+
 IORegistryIterator_VTable=struct
 struct.IORegistryIterator_VTable=parent,getNextObjectFlat,getNextObjectRecursive,getCurrentEntry,enterEntry__1,enterEntry__2,exitEntry,iterateAll
 struct.IORegistryIterator_VTable.parent=struct.OSIterator_VTable,0,0
@@ -4172,10 +4569,20 @@ func.IORegistryIterator_VTable.iterateAll.ret=OSPtr<OSOrderedSet>
 func.IORegistryIterator_VTable.iterateAll=self
 func.IORegistryIterator_VTable.iterateAll=IORegistryIterator * self
 
+IORegistryIterator::MetaClass_VTable=struct
+struct.IORegistryIterator::MetaClass_VTable=parent
+struct.IORegistryIterator::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IORegistryIterator::MetaClass_VTable.parent.meta=112
+
 IOReportLegend_VTable=struct
 struct.IOReportLegend_VTable=parent
 struct.IOReportLegend_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOReportLegend_VTable.parent.meta=112
+
+IOReportLegend::MetaClass_VTable=struct
+struct.IOReportLegend::MetaClass_VTable=parent
+struct.IOReportLegend::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOReportLegend::MetaClass_VTable.parent.meta=112
 
 IOReporter_VTable=struct
 struct.IOReporter_VTable=parent,init,handleSwapPrepare,handleAddChannelSwap,handleSwapCleanup,handleConfigureReport,handleUpdateReport,handleCreateLegend,updateChannelValues,setElementValues,getElementValues,getFirstElementIndex,getChannelIndex,getChannelIndices,copyElementValues
@@ -4322,6 +4729,11 @@ func.IOReporter_VTable.copyElementValues.cc=cdecl
 func.IOReporter_VTable.copyElementValues.ret=IOReturn
 func.IOReporter_VTable.copyElementValues=self,element_index,elementValues
 func.IOReporter_VTable.copyElementValues=IOReporter * self, int element_index, IOReportElementValues * elementValues
+
+IOReporter::MetaClass_VTable=struct
+struct.IOReporter::MetaClass_VTable=parent
+struct.IOReporter::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOReporter::MetaClass_VTable.parent.meta=112
 
 IOService_VTable=struct
 struct.IOService_VTable=parent,requestTerminate,willTerminate,didTerminate,nextIdleTimeout,systemWillShutdown,copyClientWithCategory,configureReport,updateReport,getState,registerService,probe,start,stop,open,close,isOpen,handleOpen,handleClose,handleIsOpen,terminate,finalize,lockForArbitration,unlockForArbitration,terminateClient,getBusyState,adjustBusy,matchPropertyTable__1,matchPropertyTable__2,matchLocation,addNeededResource,compareProperty__1,compareProperty__2,compareProperties,attach,detach,getProvider,getWorkLoop,getProviderIterator,getOpenProviderIterator,getClient,getClientIterator,getOpenClientIterator,callPlatformFunction__1,callPlatformFunction__2,getResources,getDeviceMemoryCount,getDeviceMemoryWithIndex,mapDeviceMemoryWithIndex,getDeviceMemory,setDeviceMemory,registerInterrupt,unregisterInterrupt,getInterruptType,enableInterrupt,disableInterrupt,causeInterrupt,requestProbe,message,messageClient,messageClients,registerInterest,applyToProviders,applyToClients,applyToInterested,acknowledgeNotification,newUserClient__1,newUserClient__2,stringFromReturn,errnoFromReturn,PMinit,PMstop,joinPMtree,registerPowerDriver,requestPowerDomainState,activityTickle,setAggressiveness,getAggressiveness,addPowerChild,removePowerChild,setIdleTimerPeriod,setPowerState,maxCapabilityForDomainState,initialPowerStateForDomainState,powerStateForDomainState,powerStateWillChangeTo,powerStateDidChangeTo,askChangeDown,tellChangeDown,tellNoChangeDown,tellChangeUp,allowPowerChange,cancelPowerChange,powerChangeDone
@@ -5223,15 +5635,30 @@ func.IOService_VTable.powerChangeDone.ret=void
 func.IOService_VTable.powerChangeDone=self,stateNumber
 func.IOService_VTable.powerChangeDone=IOService * self, unsigned long stateNumber
 
+IOService::MetaClass_VTable=struct
+struct.IOService::MetaClass_VTable=parent
+struct.IOService::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOService::MetaClass_VTable.parent.meta=112
+
 IOServiceCompatibility_VTable=struct
 struct.IOServiceCompatibility_VTable=parent
 struct.IOServiceCompatibility_VTable.parent=struct.IOService_VTable,0,0
 struct.IOServiceCompatibility_VTable.parent.meta=1336
 
+IOServiceCompatibility::MetaClass_VTable=struct
+struct.IOServiceCompatibility::MetaClass_VTable=parent
+struct.IOServiceCompatibility::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOServiceCompatibility::MetaClass_VTable.parent.meta=112
+
 IOServiceStateNotificationEventSource_VTable=struct
 struct.IOServiceStateNotificationEventSource_VTable=parent
 struct.IOServiceStateNotificationEventSource_VTable.parent=struct.IOEventSource_VTable,0,0
 struct.IOServiceStateNotificationEventSource_VTable.parent.meta=208
+
+IOServiceStateNotificationEventSource::MetaClass_VTable=struct
+struct.IOServiceStateNotificationEventSource::MetaClass_VTable=parent
+struct.IOServiceStateNotificationEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOServiceStateNotificationEventSource::MetaClass_VTable.parent.meta=112
 
 IOSharedDataQueue_VTable=struct
 struct.IOSharedDataQueue_VTable=parent,peek,dequeue
@@ -5256,6 +5683,11 @@ func.IOSharedDataQueue_VTable.dequeue.ret=Boolean
 func.IOSharedDataQueue_VTable.dequeue=self,data,dataSize
 func.IOSharedDataQueue_VTable.dequeue=IOSharedDataQueue * self, void * data, UInt32 * dataSize
 
+IOSharedDataQueue::MetaClass_VTable=struct
+struct.IOSharedDataQueue::MetaClass_VTable=parent
+struct.IOSharedDataQueue::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOSharedDataQueue::MetaClass_VTable.parent.meta=112
+
 IOSharedInterruptController_VTable=struct
 struct.IOSharedInterruptController_VTable=parent,initInterruptController
 struct.IOSharedInterruptController_VTable.parent=struct.IOInterruptController_VTable,0,0
@@ -5270,6 +5702,11 @@ func.IOSharedInterruptController_VTable.initInterruptController.cc=cdecl
 func.IOSharedInterruptController_VTable.initInterruptController.ret=IOReturn
 func.IOSharedInterruptController_VTable.initInterruptController=self,parentController,parentSource
 func.IOSharedInterruptController_VTable.initInterruptController=IOSharedInterruptController * self, IOInterruptController * parentController, OSData * parentSource
+
+IOSharedInterruptController::MetaClass_VTable=struct
+struct.IOSharedInterruptController::MetaClass_VTable=parent
+struct.IOSharedInterruptController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOSharedInterruptController::MetaClass_VTable.parent.meta=112
 
 IOSimpleReporter_VTable=struct
 struct.IOSimpleReporter_VTable=parent,initWith
@@ -5286,6 +5723,11 @@ func.IOSimpleReporter_VTable.initWith.cc=cdecl
 func.IOSimpleReporter_VTable.initWith.ret=bool
 func.IOSimpleReporter_VTable.initWith=self,reportingService,categories,unit
 func.IOSimpleReporter_VTable.initWith=IOSimpleReporter * self, IOService * reportingService, IOReportCategories categories, IOReportUnit unit
+
+IOSimpleReporter::MetaClass_VTable=struct
+struct.IOSimpleReporter::MetaClass_VTable=parent
+struct.IOSimpleReporter::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOSimpleReporter::MetaClass_VTable.parent.meta=112
 
 IOStateReporter_VTable=struct
 struct.IOStateReporter_VTable=parent,initWith,handleSetStateByIndices,handleSetStateID,handleOverrideChannelStateByIndices,handleIncrementChannelStateByIndices
@@ -5353,6 +5795,11 @@ func.IOStateReporter_VTable.handleIncrementChannelStateByIndices.ret=IOReturn
 func.IOStateReporter_VTable.handleIncrementChannelStateByIndices=self,channel_index,state_index,time_in_state,intransitions,last_intransition
 func.IOStateReporter_VTable.handleIncrementChannelStateByIndices=IOStateReporter * self, int channel_index, int state_index, uint64_t time_in_state, uint64_t intransitions, uint64_t last_intransition
 
+IOStateReporter::MetaClass_VTable=struct
+struct.IOStateReporter::MetaClass_VTable=parent
+struct.IOStateReporter::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOStateReporter::MetaClass_VTable.parent.meta=112
+
 IOSubMemoryDescriptor_VTable=struct
 struct.IOSubMemoryDescriptor_VTable=parent,initSubRange
 struct.IOSubMemoryDescriptor_VTable.parent=struct.IOMemoryDescriptor_VTable,0,0
@@ -5369,6 +5816,11 @@ func.IOSubMemoryDescriptor_VTable.initSubRange.cc=cdecl
 func.IOSubMemoryDescriptor_VTable.initSubRange.ret=bool
 func.IOSubMemoryDescriptor_VTable.initSubRange=self,parent,offset,length,withDirection
 func.IOSubMemoryDescriptor_VTable.initSubRange=IOSubMemoryDescriptor * self, IOMemoryDescriptor * parent, IOByteCount offset, IOByteCount length, IODirection withDirection
+
+IOSubMemoryDescriptor::MetaClass_VTable=struct
+struct.IOSubMemoryDescriptor::MetaClass_VTable=parent
+struct.IOSubMemoryDescriptor::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOSubMemoryDescriptor::MetaClass_VTable.parent.meta=112
 
 IOTimerEventSource_VTable=struct
 struct.IOTimerEventSource_VTable=parent,setTimeoutFunc,init__1,setTimeoutTicks,setTimeoutMS,setTimeoutUS,setTimeout__1,setTimeout__2,wakeAtTimeTicks,wakeAtTimeMS,wakeAtTimeUS,wakeAtTime__1,wakeAtTime__2,cancelTimeout,init__2,setTimeout__3,wakeAtTime__3
@@ -5525,6 +5977,11 @@ func.IOTimerEventSource_VTable.wakeAtTime__3.cc=cdecl
 func.IOTimerEventSource_VTable.wakeAtTime__3.ret=IOReturn
 func.IOTimerEventSource_VTable.wakeAtTime__3=self,options,abstime,leeway
 func.IOTimerEventSource_VTable.wakeAtTime__3=IOTimerEventSource * self, uint32_t options, AbsoluteTime abstime, AbsoluteTime leeway
+
+IOTimerEventSource::MetaClass_VTable=struct
+struct.IOTimerEventSource::MetaClass_VTable=parent
+struct.IOTimerEventSource::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOTimerEventSource::MetaClass_VTable.parent.meta=112
 
 IOUserClient_VTable=struct
 struct.IOUserClient_VTable=parent,externalMethod,registerNotificationPort__1,initWithTask__1,initWithTask__2,clientClose,clientDied,getService,registerNotificationPort__2,getNotificationSemaphore,connectClient,clientMemoryForType,exportObjectToClient,getExternalMethodForIndex,getExternalAsyncMethodForIndex,getTargetAndMethodForIndex,getAsyncTargetAndMethodForIndex,getExternalTrapForIndex,getTargetAndTrapForIndex
@@ -5726,6 +6183,16 @@ func.IOUserClient2022_VTable.externalMethod.ret=IOReturn
 func.IOUserClient2022_VTable.externalMethod=self,selector,arguments
 func.IOUserClient2022_VTable.externalMethod=IOUserClient2022 * self, uint32_t selector, IOExternalMethodArgumentsOpaque * arguments
 
+IOUserClient2022::MetaClass_VTable=struct
+struct.IOUserClient2022::MetaClass_VTable=parent
+struct.IOUserClient2022::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserClient2022::MetaClass_VTable.parent.meta=112
+
+IOUserClient::MetaClass_VTable=struct
+struct.IOUserClient::MetaClass_VTable=parent
+struct.IOUserClient::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserClient::MetaClass_VTable.parent.meta=112
+
 IOUserIterator_VTable=struct
 struct.IOUserIterator_VTable=parent,copyNextObject
 struct.IOUserIterator_VTable.parent=struct.OSIterator_VTable,0,0
@@ -5738,6 +6205,11 @@ func.IOUserIterator_VTable.copyNextObject.cc=cdecl
 func.IOUserIterator_VTable.copyNextObject.ret=OSObject *
 func.IOUserIterator_VTable.copyNextObject=self
 func.IOUserIterator_VTable.copyNextObject=IOUserIterator * self
+
+IOUserIterator::MetaClass_VTable=struct
+struct.IOUserIterator::MetaClass_VTable=parent
+struct.IOUserIterator::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserIterator::MetaClass_VTable.parent.meta=112
 
 IOUserNotification_VTable=struct
 struct.IOUserNotification_VTable=parent,setNotification
@@ -5753,20 +6225,40 @@ func.IOUserNotification_VTable.setNotification.ret=void
 func.IOUserNotification_VTable.setNotification=self,obj
 func.IOUserNotification_VTable.setNotification=IOUserNotification * self, IONotifier * obj
 
+IOUserNotification::MetaClass_VTable=struct
+struct.IOUserNotification::MetaClass_VTable=parent
+struct.IOUserNotification::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserNotification::MetaClass_VTable.parent.meta=112
+
 IOUserServer_VTable=struct
 struct.IOUserServer_VTable=parent
 struct.IOUserServer_VTable.parent=struct.IOUserClient2022_VTable,0,0
 struct.IOUserServer_VTable.parent.meta=1488
+
+IOUserServer::MetaClass_VTable=struct
+struct.IOUserServer::MetaClass_VTable=parent
+struct.IOUserServer::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserServer::MetaClass_VTable.parent.meta=112
 
 IOUserServerCheckInToken_VTable=struct
 struct.IOUserServerCheckInToken_VTable=parent
 struct.IOUserServerCheckInToken_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOUserServerCheckInToken_VTable.parent.meta=112
 
+IOUserServerCheckInToken::MetaClass_VTable=struct
+struct.IOUserServerCheckInToken::MetaClass_VTable=parent
+struct.IOUserServerCheckInToken::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserServerCheckInToken::MetaClass_VTable.parent.meta=112
+
 IOUserUserClient_VTable=struct
 struct.IOUserUserClient_VTable=parent
 struct.IOUserUserClient_VTable.parent=struct.IOUserClient_VTable,0,0
 struct.IOUserUserClient_VTable.parent.meta=1480
+
+IOUserUserClient::MetaClass_VTable=struct
+struct.IOUserUserClient::MetaClass_VTable=parent
+struct.IOUserUserClient::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOUserUserClient::MetaClass_VTable.parent.meta=112
 
 IOWatchDogTimer_VTable=struct
 struct.IOWatchDogTimer_VTable=parent,setWatchDogTimer
@@ -5782,10 +6274,20 @@ func.IOWatchDogTimer_VTable.setWatchDogTimer.ret=void
 func.IOWatchDogTimer_VTable.setWatchDogTimer=self,timeOut
 func.IOWatchDogTimer_VTable.setWatchDogTimer=IOWatchDogTimer * self, UInt32 timeOut
 
+IOWatchDogTimer::MetaClass_VTable=struct
+struct.IOWatchDogTimer::MetaClass_VTable=parent
+struct.IOWatchDogTimer::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOWatchDogTimer::MetaClass_VTable.parent.meta=112
+
 IOWorkGroup_VTable=struct
 struct.IOWorkGroup_VTable=parent
 struct.IOWorkGroup_VTable.parent=struct.OSObject_VTable,0,0
 struct.IOWorkGroup_VTable.parent.meta=112
+
+IOWorkGroup::MetaClass_VTable=struct
+struct.IOWorkGroup::MetaClass_VTable=parent
+struct.IOWorkGroup::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOWorkGroup::MetaClass_VTable.parent.meta=112
 
 IOWorkLoop_VTable=struct
 struct.IOWorkLoop_VTable=parent,_maintRequest,threadMain,getThread,onThread,inGate,addEventSource,removeEventSource,enableAllEventSources,disableAllEventSources,enableAllInterrupts,disableAllInterrupts,signalWorkAvailable,openGate,closeGate,tryCloseGate,sleepGate__1,wakeupGate,runAction,runEventSources,sleepGate__2
@@ -5971,15 +6473,30 @@ func.IOWorkLoop_VTable.sleepGate__2.ret=int
 func.IOWorkLoop_VTable.sleepGate__2=self,event,deadline,interuptibleType
 func.IOWorkLoop_VTable.sleepGate__2=IOWorkLoop * self, void * event, AbsoluteTime deadline, UInt32 interuptibleType
 
+IOWorkLoop::MetaClass_VTable=struct
+struct.IOWorkLoop::MetaClass_VTable=parent
+struct.IOWorkLoop::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.IOWorkLoop::MetaClass_VTable.parent.meta=112
+
 OSAction_VTable=struct
 struct.OSAction_VTable=parent
 struct.OSAction_VTable.parent=struct.OSObject_VTable,0,0
 struct.OSAction_VTable.parent.meta=112
 
+OSAction::MetaClass_VTable=struct
+struct.OSAction::MetaClass_VTable=parent
+struct.OSAction::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSAction::MetaClass_VTable.parent.meta=112
+
 OSAction_IOUserClient_KernelCompletion_VTable=struct
 struct.OSAction_IOUserClient_KernelCompletion_VTable=parent
 struct.OSAction_IOUserClient_KernelCompletion_VTable.parent=struct.OSAction_VTable,0,0
 struct.OSAction_IOUserClient_KernelCompletion_VTable.parent.meta=112
+
+OSAction_IOUserClient_KernelCompletion::MetaClass_VTable=struct
+struct.OSAction_IOUserClient_KernelCompletion::MetaClass_VTable=parent
+struct.OSAction_IOUserClient_KernelCompletion::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSAction_IOUserClient_KernelCompletion::MetaClass_VTable.parent.meta=112
 
 OSArray_VTable=struct
 struct.OSArray_VTable=parent,initWithCapacity,initWithObjects,initWithArray,setObject__1,setObject__2,merge,replaceObject,removeObject,isEqualTo,getObject,getLastObject,getNextIndexOfObject
@@ -6099,6 +6616,11 @@ func.OSArray_VTable.getNextIndexOfObject.ret=unsigned int
 func.OSArray_VTable.getNextIndexOfObject=self,anObject,index
 func.OSArray_VTable.getNextIndexOfObject=const OSArray * self, const OSMetaClassBase * anObject, unsigned int index
 
+OSArray::MetaClass_VTable=struct
+struct.OSArray::MetaClass_VTable=parent
+struct.OSArray::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSArray::MetaClass_VTable.parent.meta=112
+
 OSBoolean_VTable=struct
 struct.OSBoolean_VTable=parent,isTrue,isFalse,getValue,isEqualTo
 struct.OSBoolean_VTable.parent=struct.OSObject_VTable,0,0
@@ -6136,6 +6658,11 @@ func.OSBoolean_VTable.isEqualTo.cc=cdecl
 func.OSBoolean_VTable.isEqualTo.ret=bool
 func.OSBoolean_VTable.isEqualTo=self,aBoolean
 func.OSBoolean_VTable.isEqualTo=const OSBoolean * self, const OSBoolean * aBoolean
+
+OSBoolean::MetaClass_VTable=struct
+struct.OSBoolean::MetaClass_VTable=parent
+struct.OSBoolean::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSBoolean::MetaClass_VTable.parent.meta=112
 
 OSCollection_VTable=struct
 struct.OSCollection_VTable=parent,iteratorSize,initIterator,getNextObjectForIterator,getCount,getCapacity,getCapacityIncrement,setCapacityIncrement,ensureCapacity,flushCollection,setOptions,copyCollection
@@ -6239,6 +6766,11 @@ func.OSCollection_VTable.copyCollection.ret=OSPtr<OSCollection>
 func.OSCollection_VTable.copyCollection=self,cycleDict
 func.OSCollection_VTable.copyCollection=OSCollection * self, OSDictionary * cycleDict
 
+OSCollection::MetaClass_VTable=struct
+struct.OSCollection::MetaClass_VTable=parent
+struct.OSCollection::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSCollection::MetaClass_VTable.parent.meta=112
+
 OSCollectionIterator_VTable=struct
 struct.OSCollectionIterator_VTable=parent,initWithCollection
 struct.OSCollectionIterator_VTable.parent=struct.OSIterator_VTable,0,0
@@ -6252,6 +6784,11 @@ func.OSCollectionIterator_VTable.initWithCollection.cc=cdecl
 func.OSCollectionIterator_VTable.initWithCollection.ret=bool
 func.OSCollectionIterator_VTable.initWithCollection=self,inColl
 func.OSCollectionIterator_VTable.initWithCollection=OSCollectionIterator * self, const OSCollection * inColl
+
+OSCollectionIterator::MetaClass_VTable=struct
+struct.OSCollectionIterator::MetaClass_VTable=parent
+struct.OSCollectionIterator::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSCollectionIterator::MetaClass_VTable.parent.meta=112
 
 OSData_VTable=struct
 struct.OSData_VTable=parent,initWithCapacity,initWithBytes,initWithBytesNoCopy,initWithData__1,initWithData__2,getLength,getCapacity,getCapacityIncrement,setCapacityIncrement,ensureCapacity,appendBytes__1,appendBytes__2,getBytesNoCopy__1,getBytesNoCopy__2,isEqualTo__1,isEqualTo__2,isEqualTo__3,appendByte,setDeallocFunction
@@ -6433,10 +6970,20 @@ func.OSData_VTable.setDeallocFunction.ret=void
 func.OSData_VTable.setDeallocFunction=self,func
 func.OSData_VTable.setDeallocFunction=OSData * self, OSData::DeallocFunction func
 
+OSData::MetaClass_VTable=struct
+struct.OSData::MetaClass_VTable=parent
+struct.OSData::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSData::MetaClass_VTable.parent.meta=112
+
 OSDextStatistics_VTable=struct
 struct.OSDextStatistics_VTable=parent
 struct.OSDextStatistics_VTable.parent=struct.OSObject_VTable,0,0
 struct.OSDextStatistics_VTable.parent.meta=112
+
+OSDextStatistics::MetaClass_VTable=struct
+struct.OSDextStatistics::MetaClass_VTable=parent
+struct.OSDextStatistics::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSDextStatistics::MetaClass_VTable.parent.meta=112
 
 OSDictionary_VTable=struct
 struct.OSDictionary_VTable=parent,initWithCapacity,initWithObjects__1,initWithObjects__2,initWithDictionary,setObject__1,setObject__2,setObject__3,removeObject__1,removeObject__2,removeObject__3,merge,getObject__1,getObject__2,getObject__3,isEqualTo__1,isEqualTo__2
@@ -6598,6 +7145,11 @@ func.OSDictionary_VTable.isEqualTo__2.ret=bool
 func.OSDictionary_VTable.isEqualTo__2=self,aDictionary
 func.OSDictionary_VTable.isEqualTo__2=const OSDictionary * self, const OSDictionary * aDictionary
 
+OSDictionary::MetaClass_VTable=struct
+struct.OSDictionary::MetaClass_VTable=parent
+struct.OSDictionary::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSDictionary::MetaClass_VTable.parent.meta=112
+
 OSIterator_VTable=struct
 struct.OSIterator_VTable=parent,reset,isValid,getNextObject
 struct.OSIterator_VTable.parent=struct.OSObject_VTable,0,0
@@ -6626,6 +7178,11 @@ func.OSIterator_VTable.getNextObject.cc=cdecl
 func.OSIterator_VTable.getNextObject.ret=OSObject *
 func.OSIterator_VTable.getNextObject=self
 func.OSIterator_VTable.getNextObject=OSIterator * self
+
+OSIterator::MetaClass_VTable=struct
+struct.OSIterator::MetaClass_VTable=parent
+struct.OSIterator::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSIterator::MetaClass_VTable.parent.meta=112
 
 OSKext_VTable=struct
 struct.OSKext_VTable=parent,initWithBooterData,initWithPrelinkedInfoDict,initWithCodelessInfo,setInfoDictionaryAndPath,setExecutable,registerIdentifier,isInExcludeList,isLoadable,resolveDependencies,addBleedthroughDependencies,flushDependencies,getNumDependencies,getDependencies,load,unload,slidePrelinkedExecutable,loadExecutable,jettisonLinkeditSegment,jettisonDATASegmentPadding,getExecutable,setLinkedExecutable,start,stop,setVMAttributes,segmentShouldBeWired,validateKextMapping,verifySegmentMapping,sendPersonalitiesToCatalog,copyInfo,addClass,removeClass,hasOSMetaClassInstances,getMetaClasses,reportOSMetaClassInstances,invokeOrCancelRequestCallbacks,countRequestCallbacks,getDextUniqueID,setCPPInitialized,setAutounloadEnabled,getBundleExecutable,getIdentifier,getIdentifierCString,getVersion,getCompatibleVersion,isLibrary,isCompatibleWithVersion,getPropertyForHostArch,getLoadTag,getSizeInfo,copyUUID,copyPersonalitiesArray,setDriverKitUUID,removePersonalitiesFromCatalog,updatePersonalitiesInCatalog,declaresExecutable,isInterface,isKernel,isKernelComponent,isExecutable,isSpecialKernelBinary,isLoadableInSafeBoot,isPrelinked,isLoaded,isStarted,isCPPInitialized
@@ -7194,10 +7751,20 @@ func.OSKext_VTable.isCPPInitialized.ret=bool
 func.OSKext_VTable.isCPPInitialized=self
 func.OSKext_VTable.isCPPInitialized=OSKext * self
 
+OSKext::MetaClass_VTable=struct
+struct.OSKext::MetaClass_VTable=parent
+struct.OSKext::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSKext::MetaClass_VTable.parent.meta=112
+
 OSKextSavedMutableSegment_VTable=struct
 struct.OSKextSavedMutableSegment_VTable=parent
 struct.OSKextSavedMutableSegment_VTable.parent=struct.OSObject_VTable,0,0
 struct.OSKextSavedMutableSegment_VTable.parent.meta=112
+
+OSKextSavedMutableSegment::MetaClass_VTable=struct
+struct.OSKextSavedMutableSegment::MetaClass_VTable=parent
+struct.OSKextSavedMutableSegment::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSKextSavedMutableSegment::MetaClass_VTable.parent.meta=112
 
 OSMetaClass_VTable=struct
 struct.OSMetaClass_VTable=parent,destructor,alloc
@@ -7427,6 +7994,11 @@ func.OSNumber_VTable.isEqualTo.ret=bool
 func.OSNumber_VTable.isEqualTo=self,aNumber
 func.OSNumber_VTable.isEqualTo=const OSNumber * self, const OSNumber * aNumber
 
+OSNumber::MetaClass_VTable=struct
+struct.OSNumber::MetaClass_VTable=parent
+struct.OSNumber::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSNumber::MetaClass_VTable.parent.meta=112
+
 OSObject_VTable=struct
 struct.OSObject_VTable=parent,init,free
 struct.OSObject_VTable.parent=struct.OSMetaClassBase_VTable,0,0
@@ -7447,6 +8019,11 @@ func.OSObject_VTable.free.cc=cdecl
 func.OSObject_VTable.free.ret=void
 func.OSObject_VTable.free=self
 func.OSObject_VTable.free=OSObject * self
+
+OSObject::MetaClass_VTable=struct
+struct.OSObject::MetaClass_VTable=parent
+struct.OSObject::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSObject::MetaClass_VTable.parent.meta=112
 
 OSOrderedSet_VTable=struct
 struct.OSOrderedSet_VTable=parent,initWithCapacity,setObject__1,setFirstObject,setLastObject,removeObject,containsObject,member,getFirstObject,getLastObject,orderObject,setObject__2,getObject,getOrderingRef,isEqualTo
@@ -7579,6 +8156,11 @@ func.OSOrderedSet_VTable.isEqualTo.ret=bool
 func.OSOrderedSet_VTable.isEqualTo=self,anOrderedSet
 func.OSOrderedSet_VTable.isEqualTo=const OSOrderedSet * self, const OSOrderedSet * anOrderedSet
 
+OSOrderedSet::MetaClass_VTable=struct
+struct.OSOrderedSet::MetaClass_VTable=parent
+struct.OSOrderedSet::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSOrderedSet::MetaClass_VTable.parent.meta=112
+
 OSSerialize_VTable=struct
 struct.OSSerialize_VTable=parent,text,clearText,previouslySerialized,addXMLStartTag,addXMLEndTag,addChar,addString,initWithCapacity,getLength,getCapacity,getCapacityIncrement,setCapacityIncrement,ensureCapacity
 struct.OSSerialize_VTable.parent=struct.OSObject_VTable,0,0
@@ -7697,10 +8279,20 @@ func.OSSerialize_VTable.ensureCapacity.ret=unsigned int
 func.OSSerialize_VTable.ensureCapacity=self,newCapacity
 func.OSSerialize_VTable.ensureCapacity=OSSerialize * self, unsigned int newCapacity
 
+OSSerialize::MetaClass_VTable=struct
+struct.OSSerialize::MetaClass_VTable=parent
+struct.OSSerialize::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSSerialize::MetaClass_VTable.parent.meta=112
+
 OSSerializer_VTable=struct
 struct.OSSerializer_VTable=parent
 struct.OSSerializer_VTable.parent=struct.OSObject_VTable,0,0
 struct.OSSerializer_VTable.parent.meta=112
+
+OSSerializer::MetaClass_VTable=struct
+struct.OSSerializer::MetaClass_VTable=parent
+struct.OSSerializer::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSSerializer::MetaClass_VTable.parent.meta=112
 
 OSSet_VTable=struct
 struct.OSSet_VTable=parent,initWithCapacity,initWithObjects,initWithArray,initWithSet,setObject,merge__1,merge__2,removeObject,containsObject,member,getAnyObject,isEqualTo
@@ -7818,6 +8410,11 @@ func.OSSet_VTable.isEqualTo.ret=bool
 func.OSSet_VTable.isEqualTo=self,aSet
 func.OSSet_VTable.isEqualTo=const OSSet * self, const OSSet * aSet
 
+OSSet::MetaClass_VTable=struct
+struct.OSSet::MetaClass_VTable=parent
+struct.OSSet::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSSet::MetaClass_VTable.parent.meta=112
+
 OSString_VTable=struct
 struct.OSString_VTable=parent,initWithString,initWithCString,initWithCStringNoCopy,getLength,getChar,setChar,getCStringNoCopy,isEqualTo__1,isEqualTo__2,isEqualTo__3
 struct.OSString_VTable.parent=struct.OSObject_VTable,0,0
@@ -7912,6 +8509,11 @@ func.OSString_VTable.isEqualTo__3.ret=bool
 func.OSString_VTable.isEqualTo__3=self,aDataObject
 func.OSString_VTable.isEqualTo__3=const OSString * self, const OSData * aDataObject
 
+OSString::MetaClass_VTable=struct
+struct.OSString::MetaClass_VTable=parent
+struct.OSString::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSString::MetaClass_VTable.parent.meta=112
+
 OSSymbol_VTable=struct
 struct.OSSymbol_VTable=parent,isEqualTo
 struct.OSSymbol_VTable.parent=struct.OSString_VTable,0,0
@@ -7925,6 +8527,11 @@ func.OSSymbol_VTable.isEqualTo.cc=cdecl
 func.OSSymbol_VTable.isEqualTo.ret=bool
 func.OSSymbol_VTable.isEqualTo=self,aSymbol
 func.OSSymbol_VTable.isEqualTo=const OSSymbol * self, const OSSymbol * aSymbol
+
+OSSymbol::MetaClass_VTable=struct
+struct.OSSymbol::MetaClass_VTable=parent
+struct.OSSymbol::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSSymbol::MetaClass_VTable.parent.meta=112
 
 OSValueObject_VTable=struct
 struct.OSValueObject_VTable=parent,isEqualTo__1,isEqualTo__2
@@ -7949,6 +8556,11 @@ func.OSValueObject_VTable.isEqualTo__2.ret=bool
 func.OSValueObject_VTable.isEqualTo__2=self,value
 func.OSValueObject_VTable.isEqualTo__2=const OSValueObject * self, const T & value
 
+OSValueObject::MetaClass_VTable=struct
+struct.OSValueObject::MetaClass_VTable=parent
+struct.OSValueObject::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.OSValueObject::MetaClass_VTable.parent.meta=112
+
 PassthruInterruptController_VTable=struct
 struct.PassthruInterruptController_VTable=parent,waitForChildController,externalInterrupt
 struct.PassthruInterruptController_VTable.parent=struct.IOInterruptController_VTable,0,0
@@ -7970,2164 +8582,1520 @@ func.PassthruInterruptController_VTable.externalInterrupt.ret=void
 func.PassthruInterruptController_VTable.externalInterrupt=self
 func.PassthruInterruptController_VTable.externalInterrupt=PassthruInterruptController * self
 
+PassthruInterruptController::MetaClass_VTable=struct
+struct.PassthruInterruptController::MetaClass_VTable=parent
+struct.PassthruInterruptController::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct.PassthruInterruptController::MetaClass_VTable.parent.meta=112
+
 _IOUserServerCheckInCancellationHandler_VTable=struct
 struct._IOUserServerCheckInCancellationHandler_VTable=parent
 struct._IOUserServerCheckInCancellationHandler_VTable.parent=struct.OSObject_VTable,0,0
 struct._IOUserServerCheckInCancellationHandler_VTable.parent.meta=112
 
-_IOBigMemoryCursor=struct
-struct._IOBigMemoryCursor=parent
-struct._IOBigMemoryCursor.parent=struct._IOMemoryCursor,0,0
-struct._IOBigMemoryCursor.parent.meta=40
-
-_IOBufferMemoryDescriptor=struct
-struct._IOBufferMemoryDescriptor=parent,reserved,_buffer,_capacity,_alignment,_options,_internalReserved,_internalFlags
-struct._IOBufferMemoryDescriptor.parent=struct._IOGeneralMemoryDescriptor,0,0
-struct._IOBufferMemoryDescriptor.parent.meta=168
-struct._IOBufferMemoryDescriptor.reserved=void *,168,0
-struct._IOBufferMemoryDescriptor.reserved.meta=8
-struct._IOBufferMemoryDescriptor._buffer=void *,176,0
-struct._IOBufferMemoryDescriptor._buffer.meta=8
-struct._IOBufferMemoryDescriptor._capacity=LONG,184,0
-struct._IOBufferMemoryDescriptor._capacity.meta=8
-struct._IOBufferMemoryDescriptor._alignment=LONG,192,0
-struct._IOBufferMemoryDescriptor._alignment.meta=8
-struct._IOBufferMemoryDescriptor._options=int,200,0
-struct._IOBufferMemoryDescriptor._options.meta=4
-struct._IOBufferMemoryDescriptor._internalReserved=uintptr_t,208,0
-struct._IOBufferMemoryDescriptor._internalReserved.meta=8
-struct._IOBufferMemoryDescriptor._internalFlags=unsigned int,216,0
-struct._IOBufferMemoryDescriptor._internalFlags.meta=4
-
-_IOBufferMemoryDescriptor::ExpansionData=struct
-struct._IOBufferMemoryDescriptor::ExpansionData=map
-struct._IOBufferMemoryDescriptor::ExpansionData.map=void *,0,0
-struct._IOBufferMemoryDescriptor::ExpansionData.map.meta=8
-
-_IOCPU=struct
-struct._IOCPU=parent,_cpuGroup,_cpuNumber,_cpuState,cpuNub,machProcessor,ipi_handler,iocpu_reserved
-struct._IOCPU.parent=struct._IOService,0,0
-struct._IOCPU.parent.meta=128
-struct._IOCPU._cpuGroup=void *,128,0
-struct._IOCPU._cpuGroup.meta=8
-struct._IOCPU._cpuNumber=int,136,0
-struct._IOCPU._cpuNumber.meta=4
-struct._IOCPU._cpuState=int,140,0
-struct._IOCPU._cpuState.meta=4
-struct._IOCPU.cpuNub=void *,144,0
-struct._IOCPU.cpuNub.meta=8
-struct._IOCPU.machProcessor=void *,152,0
-struct._IOCPU.machProcessor.meta=8
-struct._IOCPU.ipi_handler=void *,160,0
-struct._IOCPU.ipi_handler.meta=8
-struct._IOCPU.iocpu_reserved=void *,168,0
-struct._IOCPU.iocpu_reserved.meta=8
-
-_IOCPU::ExpansionData=struct
-struct._IOCPU::ExpansionData=
-
-_IOCPUInterruptController=struct
-struct._IOCPUInterruptController=parent,enabledCPUs,numCPUs,numSources,iocpuic_reserved
-struct._IOCPUInterruptController.parent=struct._IOInterruptController,0,0
-struct._IOCPUInterruptController.parent.meta=152
-struct._IOCPUInterruptController.enabledCPUs=int,152,0
-struct._IOCPUInterruptController.enabledCPUs.meta=4
-struct._IOCPUInterruptController.numCPUs=int,156,0
-struct._IOCPUInterruptController.numCPUs.meta=4
-struct._IOCPUInterruptController.numSources=int,160,0
-struct._IOCPUInterruptController.numSources.meta=4
-struct._IOCPUInterruptController.iocpuic_reserved=void *,168,0
-struct._IOCPUInterruptController.iocpuic_reserved.meta=8
-
-_IOCPUInterruptController::ExpansionData=struct
-struct._IOCPUInterruptController::ExpansionData=
-
-_IOCatalogue=struct
-struct._IOCatalogue=parent,lock,generation,personalities
-struct._IOCatalogue.parent=struct._OSObject,0,0
-struct._IOCatalogue.parent.meta=4
-struct._IOCatalogue.lock=void *,8,0
-struct._IOCatalogue.lock.meta=8
-struct._IOCatalogue.generation=int,16,0
-struct._IOCatalogue.generation.meta=4
-struct._IOCatalogue.personalities=void *,24,0
-struct._IOCatalogue.personalities.meta=8
-
-_IOCommand=struct
-struct._IOCommand=parent,fCommandChain
-struct._IOCommand.parent=struct._OSObject,0,0
-struct._IOCommand.parent.meta=4
-struct._IOCommand.fCommandChain=void *,8,0
-struct._IOCommand.fCommandChain.meta=8
-
-_IOCommandGate=struct
-struct._IOCommandGate=parent,reserved
-struct._IOCommandGate.parent=struct._IOEventSource,0,0
-struct._IOCommandGate.parent.meta=72
-struct._IOCommandGate.reserved=void *,72,0
-struct._IOCommandGate.reserved.meta=8
-
-_IOCommandGate::ExpansionData=struct
-struct._IOCommandGate::ExpansionData=
-
-_IOCommandPool=struct
-struct._IOCommandPool=parent,fQueueHead,fSleepers,fSerializer,reserved
-struct._IOCommandPool.parent=struct._OSObject,0,0
-struct._IOCommandPool.parent.meta=4
-struct._IOCommandPool.fQueueHead=void *,8,0
-struct._IOCommandPool.fQueueHead.meta=8
-struct._IOCommandPool.fSleepers=int,16,0
-struct._IOCommandPool.fSleepers.meta=4
-struct._IOCommandPool.fSerializer=void *,24,0
-struct._IOCommandPool.fSerializer.meta=8
-struct._IOCommandPool.reserved=void *,32,0
-struct._IOCommandPool.reserved.meta=8
-
-_IOCommandPool::ExpansionData=struct
-struct._IOCommandPool::ExpansionData=
-
-_IOConditionLock=struct
-struct._IOConditionLock=parent,cond_interlock,condition,sleep_interlock,interruptible,want_lock,waiting
-struct._IOConditionLock.parent=struct._OSObject,0,0
-struct._IOConditionLock.parent.meta=4
-struct._IOConditionLock.cond_interlock=void *,8,0
-struct._IOConditionLock.cond_interlock.meta=8
-struct._IOConditionLock.condition=int,16,0
-struct._IOConditionLock.condition.meta=4
-struct._IOConditionLock.sleep_interlock=void *,24,0
-struct._IOConditionLock.sleep_interlock.meta=8
-struct._IOConditionLock.interruptible=unsigned char,32,0
-struct._IOConditionLock.interruptible.meta=1
-struct._IOConditionLock.want_lock=bool,33,0
-struct._IOConditionLock.want_lock.meta=1
-struct._IOConditionLock.waiting=bool,34,0
-struct._IOConditionLock.waiting.meta=1
-
-_IODMACommand=struct
-struct._IODMACommand=parent,fRefCon,fMaxSegmentSize,fMaxTransferSize,fAlignMaskLength,fAlignMaskInternalSegments,fMapper,fMemory,fOutSeg,fAlignMask,fNumAddressBits,fNumSegments,fMappingOptions,fActive,reserved
-struct._IODMACommand.parent=struct._IOCommand,0,0
-struct._IODMACommand.parent.meta=16
-struct._IODMACommand.fRefCon=void *,16,0
-struct._IODMACommand.fRefCon.meta=8
-struct._IODMACommand.fMaxSegmentSize=LONG,24,0
-struct._IODMACommand.fMaxSegmentSize.meta=8
-struct._IODMACommand.fMaxTransferSize=LONG,32,0
-struct._IODMACommand.fMaxTransferSize.meta=8
-struct._IODMACommand.fAlignMaskLength=int,40,0
-struct._IODMACommand.fAlignMaskLength.meta=4
-struct._IODMACommand.fAlignMaskInternalSegments=int,44,0
-struct._IODMACommand.fAlignMaskInternalSegments.meta=4
-struct._IODMACommand.fMapper=void *,48,0
-struct._IODMACommand.fMapper.meta=8
-struct._IODMACommand.fMemory=void *,56,0
-struct._IODMACommand.fMemory.meta=8
-struct._IODMACommand.fOutSeg=void *,64,0
-struct._IODMACommand.fOutSeg.meta=8
-struct._IODMACommand.fAlignMask=int,72,0
-struct._IODMACommand.fAlignMask.meta=4
-struct._IODMACommand.fNumAddressBits=int,76,0
-struct._IODMACommand.fNumAddressBits.meta=4
-struct._IODMACommand.fNumSegments=int,80,0
-struct._IODMACommand.fNumSegments.meta=4
-struct._IODMACommand.fMappingOptions=uint32_t,84,0
-struct._IODMACommand.fMappingOptions.meta=4
-struct._IODMACommand.fActive=int,88,0
-struct._IODMACommand.fActive.meta=4
-struct._IODMACommand.reserved=void *,96,0
-struct._IODMACommand.reserved.meta=8
-
-_IODMACommand::SegmentOptions=struct
-struct._IODMACommand::SegmentOptions=fStructSize,fNumAddressBits,fMaxSegmentSize,fMaxTransferSize,fAlignment,fAlignmentLength,fAlignmentInternalSegments
-struct._IODMACommand::SegmentOptions.fStructSize=uint8_t,0,0
-struct._IODMACommand::SegmentOptions.fStructSize.meta=1
-struct._IODMACommand::SegmentOptions.fNumAddressBits=uint8_t,1,0
-struct._IODMACommand::SegmentOptions.fNumAddressBits.meta=1
-struct._IODMACommand::SegmentOptions.fMaxSegmentSize=uint64_t,8,0
-struct._IODMACommand::SegmentOptions.fMaxSegmentSize.meta=8
-struct._IODMACommand::SegmentOptions.fMaxTransferSize=uint64_t,16,0
-struct._IODMACommand::SegmentOptions.fMaxTransferSize.meta=8
-struct._IODMACommand::SegmentOptions.fAlignment=uint32_t,24,0
-struct._IODMACommand::SegmentOptions.fAlignment.meta=4
-struct._IODMACommand::SegmentOptions.fAlignmentLength=uint32_t,28,0
-struct._IODMACommand::SegmentOptions.fAlignmentLength.meta=4
-struct._IODMACommand::SegmentOptions.fAlignmentInternalSegments=uint32_t,32,0
-struct._IODMACommand::SegmentOptions.fAlignmentInternalSegments.meta=4
-
-_IODMAController=struct
-struct._IODMAController=parent,_provider,_dmaControllerName
-struct._IODMAController.parent=struct._IOService,0,0
-struct._IODMAController.parent.meta=128
-struct._IODMAController._provider=void *,128,0
-struct._IODMAController._provider.meta=8
-struct._IODMAController._dmaControllerName=void *,136,0
-struct._IODMAController._dmaControllerName.meta=8
-
-_IODMAEventSource=struct
-struct._IODMAEventSource=parent,dmaProvider,dmaController,dmaIndex,dmaCommandsCompleted,dmaCommandsCompletedLock,dmaCompletionAction,dmaNotificationAction,dmaSynchBusy
-struct._IODMAEventSource.parent=struct._IOEventSource,0,0
-struct._IODMAEventSource.parent.meta=72
-struct._IODMAEventSource.dmaProvider=void *,72,0
-struct._IODMAEventSource.dmaProvider.meta=8
-struct._IODMAEventSource.dmaController=void *,80,0
-struct._IODMAEventSource.dmaController.meta=8
-struct._IODMAEventSource.dmaIndex=int,88,0
-struct._IODMAEventSource.dmaIndex.meta=4
-struct._IODMAEventSource.dmaCommandsCompleted=void *,96,0
-struct._IODMAEventSource.dmaCommandsCompleted.meta=8
-struct._IODMAEventSource.dmaCommandsCompletedLock=void *,104,0
-struct._IODMAEventSource.dmaCommandsCompletedLock.meta=8
-struct._IODMAEventSource.dmaCompletionAction=void *,112,0
-struct._IODMAEventSource.dmaCompletionAction.meta=8
-struct._IODMAEventSource.dmaNotificationAction=void *,120,0
-struct._IODMAEventSource.dmaNotificationAction.meta=8
-struct._IODMAEventSource.dmaSynchBusy=bool,128,0
-struct._IODMAEventSource.dmaSynchBusy.meta=1
-
-_IODMAMapPageList=struct
-struct._IODMAMapPageList=pageOffset,pageListCount,pageList
-struct._IODMAMapPageList.pageOffset=uint32_t,0,0
-struct._IODMAMapPageList.pageOffset.meta=4
-struct._IODMAMapPageList.pageListCount=uint32_t,4,0
-struct._IODMAMapPageList.pageListCount.meta=4
-struct._IODMAMapPageList.pageList=void *,8,0
-struct._IODMAMapPageList.pageList.meta=8
-
-_IODMAMapSpecification=struct
-struct._IODMAMapSpecification=alignment,device,options,numAddressBits,resvA,resvB
-struct._IODMAMapSpecification.alignment=uint64_t,0,0
-struct._IODMAMapSpecification.alignment.meta=8
-struct._IODMAMapSpecification.device=void *,8,0
-struct._IODMAMapSpecification.device.meta=8
-struct._IODMAMapSpecification.options=uint32_t,16,0
-struct._IODMAMapSpecification.options.meta=4
-struct._IODMAMapSpecification.numAddressBits=uint8_t,20,0
-struct._IODMAMapSpecification.numAddressBits.meta=1
-struct._IODMAMapSpecification.resvA=uint8_t,21,3
-struct._IODMAMapSpecification.resvA.meta=1
-struct._IODMAMapSpecification.resvB=uint32_t,24,4
-struct._IODMAMapSpecification.resvB.meta=4
-
-_IODTNVRAM=struct
-struct._IODTNVRAM=parent,_notifier,_diags,_format,_commonService,_systemService,_lastDeviceSync,_freshInterval,x86Device
-struct._IODTNVRAM.parent=struct._IOService,0,0
-struct._IODTNVRAM.parent.meta=128
-struct._IODTNVRAM._notifier=void *,128,0
-struct._IODTNVRAM._notifier.meta=8
-struct._IODTNVRAM._diags=void *,136,0
-struct._IODTNVRAM._diags.meta=8
-struct._IODTNVRAM._format=void *,144,0
-struct._IODTNVRAM._format.meta=8
-struct._IODTNVRAM._commonService=void *,152,0
-struct._IODTNVRAM._commonService.meta=8
-struct._IODTNVRAM._systemService=void *,160,0
-struct._IODTNVRAM._systemService.meta=8
-struct._IODTNVRAM._lastDeviceSync=int,168,0
-struct._IODTNVRAM._lastDeviceSync.meta=4
-struct._IODTNVRAM._freshInterval=bool,172,0
-struct._IODTNVRAM._freshInterval.meta=1
-struct._IODTNVRAM.x86Device=bool,173,0
-struct._IODTNVRAM.x86Device.meta=1
-
-_IODTPlatformExpert=struct
-struct._IODTPlatformExpert=parent,dtNVRAM,iodtpe_reserved
-struct._IODTPlatformExpert.parent=struct._IOPlatformExpert,0,0
-struct._IODTPlatformExpert.parent.meta=216
-struct._IODTPlatformExpert.dtNVRAM=void *,216,0
-struct._IODTPlatformExpert.dtNVRAM.meta=8
-struct._IODTPlatformExpert.iodtpe_reserved=void *,224,0
-struct._IODTPlatformExpert.iodtpe_reserved.meta=8
-
-_IODTPlatformExpert::ExpansionData=struct
-struct._IODTPlatformExpert::ExpansionData=
-
-_IODataQueue=struct
-struct._IODataQueue=parent,dataQueue,notifyMsg
-struct._IODataQueue.parent=struct._OSObject,0,0
-struct._IODataQueue.parent.meta=4
-struct._IODataQueue.dataQueue=void *,8,0
-struct._IODataQueue.dataQueue.meta=8
-struct._IODataQueue.notifyMsg=void *,16,0
-struct._IODataQueue.notifyMsg.meta=8
-
-_IODeviceMemory=struct
-struct._IODeviceMemory=parent
-struct._IODeviceMemory.parent=struct._IOMemoryDescriptor,0,0
-struct._IODeviceMemory.parent.meta=88
-
-_IODispatchQueue=struct
-struct._IODispatchQueue=parent,parent2,ivars,lvars
-struct._IODispatchQueue.parent=struct._OSObject,0,0
-struct._IODispatchQueue.parent.meta=4
-struct._IODispatchQueue.parent2=struct._IODispatchQueueInterface,4,0
-struct._IODispatchQueue.parent2.meta=0
-struct._IODispatchQueue.ivars=void *,8,0
-struct._IODispatchQueue.ivars.meta=8
-struct._IODispatchQueue.lvars=void *,16,0
-struct._IODispatchQueue.lvars.meta=8
-
-_IODispatchQueueInterface=struct
-struct._IODispatchQueueInterface=parent
-struct._IODispatchQueueInterface.parent=struct._OSInterface,0,0
-struct._IODispatchQueueInterface.parent.meta=0
-
-_IODispatchSource=struct
-struct._IODispatchSource=parent,parent2,ivars,lvars
-struct._IODispatchSource.parent=struct._OSObject,0,0
-struct._IODispatchSource.parent.meta=4
-struct._IODispatchSource.parent2=struct._IODispatchSourceInterface,4,0
-struct._IODispatchSource.parent2.meta=0
-struct._IODispatchSource.ivars=void *,8,0
-struct._IODispatchSource.ivars.meta=8
-struct._IODispatchSource.lvars=void *,16,0
-struct._IODispatchSource.lvars.meta=8
-
-_IODispatchSourceInterface=struct
-struct._IODispatchSourceInterface=parent
-struct._IODispatchSourceInterface.parent=struct._OSInterface,0,0
-struct._IODispatchSourceInterface.parent.meta=0
-
-_IOEventLink=struct
-struct._IOEventLink=parent,parent2,ivars,lvars
-struct._IOEventLink.parent=struct._OSObject,0,0
-struct._IOEventLink.parent.meta=4
-struct._IOEventLink.parent2=struct._IOEventLinkInterface,4,0
-struct._IOEventLink.parent2.meta=0
-struct._IOEventLink.ivars=void *,8,0
-struct._IOEventLink.ivars.meta=8
-struct._IOEventLink.lvars=void *,16,0
-struct._IOEventLink.lvars.meta=8
-
-_IOEventLinkInterface=struct
-struct._IOEventLinkInterface=parent
-struct._IOEventLinkInterface.parent=struct._OSInterface,0,0
-struct._IOEventLinkInterface.parent.meta=0
-
-_IOEventSource=struct
-struct._IOEventSource=parent,eventChainNext,owner,action,actionBlock,enabled,eventSourceReserved1,flags,eventSourceReserved2,workLoop,refcon,reserved
-struct._IOEventSource.parent=struct._OSObject,0,0
-struct._IOEventSource.parent.meta=4
-struct._IOEventSource.eventChainNext=void *,8,0
-struct._IOEventSource.eventChainNext.meta=8
-struct._IOEventSource.owner=void *,16,0
-struct._IOEventSource.owner.meta=8
-struct._IOEventSource.action=void *,24,0
-struct._IOEventSource.action.meta=8
-struct._IOEventSource.actionBlock=void *,32,0
-struct._IOEventSource.actionBlock.meta=8
-struct._IOEventSource.enabled=bool,40,0
-struct._IOEventSource.enabled.meta=1
-struct._IOEventSource.eventSourceReserved1=uint8_t,41,1
-struct._IOEventSource.eventSourceReserved1.meta=1
-struct._IOEventSource.flags=uint16_t,42,0
-struct._IOEventSource.flags.meta=2
-struct._IOEventSource.eventSourceReserved2=uint8_t,44,4
-struct._IOEventSource.eventSourceReserved2.meta=1
-struct._IOEventSource.workLoop=void *,48,0
-struct._IOEventSource.workLoop.meta=8
-struct._IOEventSource.refcon=void *,56,0
-struct._IOEventSource.refcon.meta=8
-struct._IOEventSource.reserved=void *,64,0
-struct._IOEventSource.reserved.meta=8
-
-_IOEventSource::ExpansionData=struct
-struct._IOEventSource::ExpansionData=iokitstatsReserved
-struct._IOEventSource::ExpansionData.iokitstatsReserved=void *,0,0
-struct._IOEventSource::ExpansionData.iokitstatsReserved.meta=8
-
-_IOExtensiblePaniclog=struct
-struct._IOExtensiblePaniclog=parent,extPaniclogHandle,iomd
-struct._IOExtensiblePaniclog.parent=struct._OSObject,0,0
-struct._IOExtensiblePaniclog.parent.meta=4
-struct._IOExtensiblePaniclog.extPaniclogHandle=void *,8,0
-struct._IOExtensiblePaniclog.extPaniclogHandle.meta=8
-struct._IOExtensiblePaniclog.iomd=void *,16,0
-struct._IOExtensiblePaniclog.iomd.meta=8
-
-_IOExternalAsyncMethod=struct
-struct._IOExternalAsyncMethod=object,func,flags,count0,count1
-struct._IOExternalAsyncMethod.object=void *,0,0
-struct._IOExternalAsyncMethod.object.meta=8
-struct._IOExternalAsyncMethod.func=void *,8,0
-struct._IOExternalAsyncMethod.func.meta=8
-struct._IOExternalAsyncMethod.flags=int,16,0
-struct._IOExternalAsyncMethod.flags.meta=4
-struct._IOExternalAsyncMethod.count0=LONG,24,0
-struct._IOExternalAsyncMethod.count0.meta=8
-struct._IOExternalAsyncMethod.count1=LONG,32,0
-struct._IOExternalAsyncMethod.count1.meta=8
-
-_IOExternalMethod=struct
-struct._IOExternalMethod=object,func,flags,count0,count1
-struct._IOExternalMethod.object=void *,0,0
-struct._IOExternalMethod.object.meta=8
-struct._IOExternalMethod.func=void *,8,0
-struct._IOExternalMethod.func.meta=8
-struct._IOExternalMethod.flags=int,16,0
-struct._IOExternalMethod.flags.meta=4
-struct._IOExternalMethod.count0=LONG,24,0
-struct._IOExternalMethod.count0.meta=8
-struct._IOExternalMethod.count1=LONG,32,0
-struct._IOExternalMethod.count1.meta=8
-
-_IOExternalMethodArguments=struct
-struct._IOExternalMethodArguments=version,selector,asyncWakePort,asyncReference,asyncReferenceCount,scalarInput,scalarInputCount,structureInput,structureInputSize,structureInputDescriptor,scalarOutput,scalarOutputCount,structureOutput,structureOutputSize,structureOutputDescriptor,structureOutputDescriptorSize,__reservedA,structureVariableOutputData,__reserved
-struct._IOExternalMethodArguments.version=uint32_t,0,0
-struct._IOExternalMethodArguments.version.meta=4
-struct._IOExternalMethodArguments.selector=uint32_t,4,0
-struct._IOExternalMethodArguments.selector.meta=4
-struct._IOExternalMethodArguments.asyncWakePort=void *,8,0
-struct._IOExternalMethodArguments.asyncWakePort.meta=8
-struct._IOExternalMethodArguments.asyncReference=void *,16,0
-struct._IOExternalMethodArguments.asyncReference.meta=8
-struct._IOExternalMethodArguments.asyncReferenceCount=uint32_t,24,0
-struct._IOExternalMethodArguments.asyncReferenceCount.meta=4
-struct._IOExternalMethodArguments.scalarInput=void *,32,0
-struct._IOExternalMethodArguments.scalarInput.meta=8
-struct._IOExternalMethodArguments.scalarInputCount=uint32_t,40,0
-struct._IOExternalMethodArguments.scalarInputCount.meta=4
-struct._IOExternalMethodArguments.structureInput=void *,48,0
-struct._IOExternalMethodArguments.structureInput.meta=8
-struct._IOExternalMethodArguments.structureInputSize=uint32_t,56,0
-struct._IOExternalMethodArguments.structureInputSize.meta=4
-struct._IOExternalMethodArguments.structureInputDescriptor=void *,64,0
-struct._IOExternalMethodArguments.structureInputDescriptor.meta=8
-struct._IOExternalMethodArguments.scalarOutput=void *,72,0
-struct._IOExternalMethodArguments.scalarOutput.meta=8
-struct._IOExternalMethodArguments.scalarOutputCount=uint32_t,80,0
-struct._IOExternalMethodArguments.scalarOutputCount.meta=4
-struct._IOExternalMethodArguments.structureOutput=void *,88,0
-struct._IOExternalMethodArguments.structureOutput.meta=8
-struct._IOExternalMethodArguments.structureOutputSize=uint32_t,96,0
-struct._IOExternalMethodArguments.structureOutputSize.meta=4
-struct._IOExternalMethodArguments.structureOutputDescriptor=void *,104,0
-struct._IOExternalMethodArguments.structureOutputDescriptor.meta=8
-struct._IOExternalMethodArguments.structureOutputDescriptorSize=uint32_t,112,0
-struct._IOExternalMethodArguments.structureOutputDescriptorSize.meta=4
-struct._IOExternalMethodArguments.__reservedA=uint32_t,116,0
-struct._IOExternalMethodArguments.__reservedA.meta=4
-struct._IOExternalMethodArguments.structureVariableOutputData=void *,120,0
-struct._IOExternalMethodArguments.structureVariableOutputData.meta=8
-struct._IOExternalMethodArguments.__reserved=uint32_t,128,30
-struct._IOExternalMethodArguments.__reserved.meta=4
-
-_IOExternalMethodDispatch=struct
-struct._IOExternalMethodDispatch=function,checkScalarInputCount,checkStructureInputSize,checkScalarOutputCount,checkStructureOutputSize
-struct._IOExternalMethodDispatch.function=void *,0,0
-struct._IOExternalMethodDispatch.function.meta=8
-struct._IOExternalMethodDispatch.checkScalarInputCount=uint32_t,8,0
-struct._IOExternalMethodDispatch.checkScalarInputCount.meta=4
-struct._IOExternalMethodDispatch.checkStructureInputSize=uint32_t,12,0
-struct._IOExternalMethodDispatch.checkStructureInputSize.meta=4
-struct._IOExternalMethodDispatch.checkScalarOutputCount=uint32_t,16,0
-struct._IOExternalMethodDispatch.checkScalarOutputCount.meta=4
-struct._IOExternalMethodDispatch.checkStructureOutputSize=uint32_t,20,0
-struct._IOExternalMethodDispatch.checkStructureOutputSize.meta=4
-
-_IOExternalTrap=struct
-struct._IOExternalTrap=object,func
-struct._IOExternalTrap.object=void *,0,0
-struct._IOExternalTrap.object.meta=8
-struct._IOExternalTrap.func=void *,8,0
-struct._IOExternalTrap.func.meta=8
-
-_IOFilterInterruptEventSource=struct
-struct._IOFilterInterruptEventSource=parent,filterAction,filterActionBlock,reserved
-struct._IOFilterInterruptEventSource.parent=struct._IOInterruptEventSource,0,0
-struct._IOFilterInterruptEventSource.parent.meta=104
-struct._IOFilterInterruptEventSource.filterAction=void *,104,0
-struct._IOFilterInterruptEventSource.filterAction.meta=8
-struct._IOFilterInterruptEventSource.filterActionBlock=void *,112,0
-struct._IOFilterInterruptEventSource.filterActionBlock.meta=8
-struct._IOFilterInterruptEventSource.reserved=void *,120,0
-struct._IOFilterInterruptEventSource.reserved.meta=8
-
-_IOFilterInterruptEventSource::ExpansionData=struct
-struct._IOFilterInterruptEventSource::ExpansionData=
-
-_IOGeneralMemoryDescriptor=struct
-struct._IOGeneralMemoryDescriptor=parent,_ranges,_rangesCount,_task,v,p,_wireCount,_initialized,_memoryEntries,_pages,_highestPage,__iomd_reservedA,__iomd_reservedB,_prepareLock
-struct._IOGeneralMemoryDescriptor.parent=struct._IOMemoryDescriptor,0,0
-struct._IOGeneralMemoryDescriptor.parent.meta=88
-struct._IOGeneralMemoryDescriptor._ranges=void *,88,0
-struct._IOGeneralMemoryDescriptor._ranges.meta=8
-struct._IOGeneralMemoryDescriptor._rangesCount=unsigned int,96,0
-struct._IOGeneralMemoryDescriptor._rangesCount.meta=4
-struct._IOGeneralMemoryDescriptor._task=void *,104,0
-struct._IOGeneralMemoryDescriptor._task.meta=8
-struct._IOGeneralMemoryDescriptor.v=void *,112,0
-struct._IOGeneralMemoryDescriptor.v.meta=8
-struct._IOGeneralMemoryDescriptor.p=void *,120,0
-struct._IOGeneralMemoryDescriptor.p.meta=8
-struct._IOGeneralMemoryDescriptor._wireCount=unsigned int,128,0
-struct._IOGeneralMemoryDescriptor._wireCount.meta=4
-struct._IOGeneralMemoryDescriptor._initialized=bool,132,0
-struct._IOGeneralMemoryDescriptor._initialized.meta=1
-struct._IOGeneralMemoryDescriptor._memoryEntries=void *,136,0
-struct._IOGeneralMemoryDescriptor._memoryEntries.meta=8
-struct._IOGeneralMemoryDescriptor._pages=unsigned int,144,0
-struct._IOGeneralMemoryDescriptor._pages.meta=4
-struct._IOGeneralMemoryDescriptor._highestPage=int,148,0
-struct._IOGeneralMemoryDescriptor._highestPage.meta=4
-struct._IOGeneralMemoryDescriptor.__iomd_reservedA=uint32_t,152,0
-struct._IOGeneralMemoryDescriptor.__iomd_reservedA.meta=4
-struct._IOGeneralMemoryDescriptor.__iomd_reservedB=uint32_t,156,0
-struct._IOGeneralMemoryDescriptor.__iomd_reservedB.meta=4
-struct._IOGeneralMemoryDescriptor._prepareLock=void *,160,0
-struct._IOGeneralMemoryDescriptor._prepareLock.meta=8
-
-_IOGeneralMemoryDescriptor::Ranges=struct
-struct._IOGeneralMemoryDescriptor::Ranges=v,v64,p,uio
-struct._IOGeneralMemoryDescriptor::Ranges.v=void *,0,0
-struct._IOGeneralMemoryDescriptor::Ranges.v.meta=8
-struct._IOGeneralMemoryDescriptor::Ranges.v64=void *,8,0
-struct._IOGeneralMemoryDescriptor::Ranges.v64.meta=8
-struct._IOGeneralMemoryDescriptor::Ranges.p=void *,16,0
-struct._IOGeneralMemoryDescriptor::Ranges.p.meta=8
-struct._IOGeneralMemoryDescriptor::Ranges.uio=void *,24,0
-struct._IOGeneralMemoryDescriptor::Ranges.uio.meta=8
-
-_IOGuardPageMemoryDescriptor=struct
-struct._IOGuardPageMemoryDescriptor=parent,_buffer,_size
-struct._IOGuardPageMemoryDescriptor.parent=struct._IOGeneralMemoryDescriptor,0,0
-struct._IOGuardPageMemoryDescriptor.parent.meta=168
-struct._IOGuardPageMemoryDescriptor._buffer=LONG,168,0
-struct._IOGuardPageMemoryDescriptor._buffer.meta=8
-struct._IOGuardPageMemoryDescriptor._size=LONG,176,0
-struct._IOGuardPageMemoryDescriptor._size.meta=8
-
-_IOHistogramReporter=struct
-struct._IOHistogramReporter=parent,_segmentCount,_bucketBounds,_bucketCount,_histogramSegmentsConfig
-struct._IOHistogramReporter.parent=struct._IOReporter,0,0
-struct._IOHistogramReporter.parent.meta=128
-struct._IOHistogramReporter._segmentCount=int,128,0
-struct._IOHistogramReporter._segmentCount.meta=4
-struct._IOHistogramReporter._bucketBounds=void *,136,0
-struct._IOHistogramReporter._bucketBounds.meta=8
-struct._IOHistogramReporter._bucketCount=int,144,0
-struct._IOHistogramReporter._bucketCount.meta=4
-struct._IOHistogramReporter._histogramSegmentsConfig=void *,152,0
-struct._IOHistogramReporter._histogramSegmentsConfig.meta=8
-
-_IOInterleavedMemoryDescriptor=struct
-struct._IOInterleavedMemoryDescriptor=parent,_descriptorCapacity,_descriptorCount,_descriptors,_descriptorOffsets,_descriptorLengths,_descriptorPrepared
-struct._IOInterleavedMemoryDescriptor.parent=struct._IOMemoryDescriptor,0,0
-struct._IOInterleavedMemoryDescriptor.parent.meta=88
-struct._IOInterleavedMemoryDescriptor._descriptorCapacity=LONG,88,0
-struct._IOInterleavedMemoryDescriptor._descriptorCapacity.meta=8
-struct._IOInterleavedMemoryDescriptor._descriptorCount=int,96,0
-struct._IOInterleavedMemoryDescriptor._descriptorCount.meta=4
-struct._IOInterleavedMemoryDescriptor._descriptors=void *,104,0
-struct._IOInterleavedMemoryDescriptor._descriptors.meta=8
-struct._IOInterleavedMemoryDescriptor._descriptorOffsets=void *,112,0
-struct._IOInterleavedMemoryDescriptor._descriptorOffsets.meta=8
-struct._IOInterleavedMemoryDescriptor._descriptorLengths=void *,120,0
-struct._IOInterleavedMemoryDescriptor._descriptorLengths.meta=8
-struct._IOInterleavedMemoryDescriptor._descriptorPrepared=bool,128,0
-struct._IOInterleavedMemoryDescriptor._descriptorPrepared.meta=1
-
-_IOInterruptAccountingData=struct
-struct._IOInterruptAccountingData=owner,chain,interruptIndex,enablePrimaryTimestamp,primaryTimestamp,interruptStatistics
-struct._IOInterruptAccountingData.owner=void *,0,0
-struct._IOInterruptAccountingData.owner.meta=8
-struct._IOInterruptAccountingData.chain=void *,8,0
-struct._IOInterruptAccountingData.chain.meta=8
-struct._IOInterruptAccountingData.interruptIndex=int,16,0
-struct._IOInterruptAccountingData.interruptIndex.meta=4
-struct._IOInterruptAccountingData.enablePrimaryTimestamp=bool,20,0
-struct._IOInterruptAccountingData.enablePrimaryTimestamp.meta=1
-struct._IOInterruptAccountingData.primaryTimestamp=uint64_t,24,0
-struct._IOInterruptAccountingData.primaryTimestamp.meta=8
-struct._IOInterruptAccountingData.interruptStatistics=uint64_t,32,10
-struct._IOInterruptAccountingData.interruptStatistics.meta=8
-
-_IOInterruptController=struct
-struct._IOInterruptController=parent,vectors,controllerLock,ioic_reserved
-struct._IOInterruptController.parent=struct._IOService,0,0
-struct._IOInterruptController.parent.meta=128
-struct._IOInterruptController.vectors=void *,128,0
-struct._IOInterruptController.vectors.meta=8
-struct._IOInterruptController.controllerLock=void *,136,0
-struct._IOInterruptController.controllerLock.meta=8
-struct._IOInterruptController.ioic_reserved=void *,144,0
-struct._IOInterruptController.ioic_reserved.meta=8
-
-_IOInterruptController::ExpansionData=struct
-struct._IOInterruptController::ExpansionData=
-
-_IOInterruptEventSource=struct
-struct._IOInterruptEventSource=parent,provider,intIndex,producerCount,consumerCount,autoDisable,explicitDisable,reserved
-struct._IOInterruptEventSource.parent=struct._IOEventSource,0,0
-struct._IOInterruptEventSource.parent.meta=72
-struct._IOInterruptEventSource.provider=void *,72,0
-struct._IOInterruptEventSource.provider.meta=8
-struct._IOInterruptEventSource.intIndex=int,80,0
-struct._IOInterruptEventSource.intIndex.meta=4
-struct._IOInterruptEventSource.producerCount=unsigned int,84,0
-struct._IOInterruptEventSource.producerCount.meta=4
-struct._IOInterruptEventSource.consumerCount=unsigned int,88,0
-struct._IOInterruptEventSource.consumerCount.meta=4
-struct._IOInterruptEventSource.autoDisable=bool,92,0
-struct._IOInterruptEventSource.autoDisable.meta=1
-struct._IOInterruptEventSource.explicitDisable=bool,93,0
-struct._IOInterruptEventSource.explicitDisable.meta=1
-struct._IOInterruptEventSource.reserved=void *,96,0
-struct._IOInterruptEventSource.reserved.meta=8
-
-_IOInterruptEventSource::ExpansionData=struct
-struct._IOInterruptEventSource::ExpansionData=statistics
-struct._IOInterruptEventSource::ExpansionData.statistics=void *,0,0
-struct._IOInterruptEventSource::ExpansionData.statistics.meta=8
-
-_IOInterruptSource=struct
-struct._IOInterruptSource=interruptController,vectorData
-struct._IOInterruptSource.interruptController=void *,0,0
-struct._IOInterruptSource.interruptController.meta=8
-struct._IOInterruptSource.vectorData=void *,8,0
-struct._IOInterruptSource.vectorData.meta=8
-
-_IOInterruptSourcePrivate=struct
-struct._IOInterruptSourcePrivate=vectorBlock
-struct._IOInterruptSourcePrivate.vectorBlock=void *,0,0
-struct._IOInterruptSourcePrivate.vectorBlock.meta=8
-
-_IOInterruptVector=struct
-struct._IOInterruptVector=interruptActive,interruptDisabledSoft,interruptDisabledHard,interruptRegistered,interruptLock,nub,source,target,handler,refCon,sharedController
-struct._IOInterruptVector.interruptActive=char,0,0
-struct._IOInterruptVector.interruptActive.meta=1
-struct._IOInterruptVector.interruptDisabledSoft=char,1,0
-struct._IOInterruptVector.interruptDisabledSoft.meta=1
-struct._IOInterruptVector.interruptDisabledHard=char,2,0
-struct._IOInterruptVector.interruptDisabledHard.meta=1
-struct._IOInterruptVector.interruptRegistered=char,3,0
-struct._IOInterruptVector.interruptRegistered.meta=1
-struct._IOInterruptVector.interruptLock=void *,8,0
-struct._IOInterruptVector.interruptLock.meta=8
-struct._IOInterruptVector.nub=void *,16,0
-struct._IOInterruptVector.nub.meta=8
-struct._IOInterruptVector.source=int,24,0
-struct._IOInterruptVector.source.meta=4
-struct._IOInterruptVector.target=void *,32,0
-struct._IOInterruptVector.target.meta=8
-struct._IOInterruptVector.handler=void *,40,0
-struct._IOInterruptVector.handler.meta=8
-struct._IOInterruptVector.refCon=void *,48,0
-struct._IOInterruptVector.refCon.meta=8
-struct._IOInterruptVector.sharedController=void *,56,0
-struct._IOInterruptVector.sharedController.meta=8
-
-_IOKitDiagnostics=struct
-struct._IOKitDiagnostics=parent
-struct._IOKitDiagnostics.parent=struct._OSObject,0,0
-struct._IOKitDiagnostics.parent.meta=4
-
-_IOKitDiagnosticsClient=struct
-struct._IOKitDiagnosticsClient=parent
-struct._IOKitDiagnosticsClient.parent=struct._IOUserClient2022,0,0
-struct._IOKitDiagnosticsClient.parent.meta=200
-
-_IOLittleMemoryCursor=struct
-struct._IOLittleMemoryCursor=parent
-struct._IOLittleMemoryCursor.parent=struct._IOMemoryCursor,0,0
-struct._IOLittleMemoryCursor.parent.meta=40
-
-_IOMapper=struct
-struct._IOMapper=parent,__reservedA,fAllocName,__reservedB,fPageSize,fIsSystem
-struct._IOMapper.parent=struct._IOService,0,0
-struct._IOMapper.parent.meta=128
-struct._IOMapper.__reservedA=uint64_t,128,6
-struct._IOMapper.__reservedA.meta=8
-struct._IOMapper.fAllocName=void *,176,0
-struct._IOMapper.fAllocName.meta=8
-struct._IOMapper.__reservedB=uint32_t,184,0
-struct._IOMapper.__reservedB.meta=4
-struct._IOMapper.fPageSize=uint32_t,188,0
-struct._IOMapper.fPageSize.meta=4
-struct._IOMapper.fIsSystem=bool,192,0
-struct._IOMapper.fIsSystem.meta=1
-
-_IOMemoryCursor=struct
-struct._IOMemoryCursor=parent,outSeg,maxSegmentSize,maxTransferSize,alignMask
-struct._IOMemoryCursor.parent=struct._OSObject,0,0
-struct._IOMemoryCursor.parent.meta=4
-struct._IOMemoryCursor.outSeg=void *,8,0
-struct._IOMemoryCursor.outSeg.meta=8
-struct._IOMemoryCursor.maxSegmentSize=LONG,16,0
-struct._IOMemoryCursor.maxSegmentSize.meta=8
-struct._IOMemoryCursor.maxTransferSize=LONG,24,0
-struct._IOMemoryCursor.maxTransferSize.meta=8
-struct._IOMemoryCursor.alignMask=LONG,32,0
-struct._IOMemoryCursor.alignMask.meta=8
-
-_IOMemoryCursor::PhysicalSegment=struct
-struct._IOMemoryCursor::PhysicalSegment=location,length
-struct._IOMemoryCursor::PhysicalSegment.location=LONG,0,0
-struct._IOMemoryCursor::PhysicalSegment.location.meta=8
-struct._IOMemoryCursor::PhysicalSegment.length=LONG,8,0
-struct._IOMemoryCursor::PhysicalSegment.length.meta=8
-
-_IOMemoryDescriptor=struct
-struct._IOMemoryDescriptor=parent,reserved,_mappings,_flags,_memRef,_kernelTag,_userTag,_dmaReferences,_internalFlags,_mapName,_iomapperOptions,__iomd_reserved3,__iomd_reserved4,_length,_tag
-struct._IOMemoryDescriptor.parent=struct._OSObject,0,0
-struct._IOMemoryDescriptor.parent.meta=4
-struct._IOMemoryDescriptor.reserved=void *,8,0
-struct._IOMemoryDescriptor.reserved.meta=8
-struct._IOMemoryDescriptor._mappings=void *,16,0
-struct._IOMemoryDescriptor._mappings.meta=8
-struct._IOMemoryDescriptor._flags=int,24,0
-struct._IOMemoryDescriptor._flags.meta=4
-struct._IOMemoryDescriptor._memRef=void *,32,0
-struct._IOMemoryDescriptor._memRef.meta=8
-struct._IOMemoryDescriptor._kernelTag=short,40,0
-struct._IOMemoryDescriptor._kernelTag.meta=2
-struct._IOMemoryDescriptor._userTag=short,42,0
-struct._IOMemoryDescriptor._userTag.meta=2
-struct._IOMemoryDescriptor._dmaReferences=int16_t,44,0
-struct._IOMemoryDescriptor._dmaReferences.meta=2
-struct._IOMemoryDescriptor._internalFlags=uint16_t,46,0
-struct._IOMemoryDescriptor._internalFlags.meta=2
-struct._IOMemoryDescriptor._mapName=void *,48,0
-struct._IOMemoryDescriptor._mapName.meta=8
-struct._IOMemoryDescriptor._iomapperOptions=uint16_t,56,0
-struct._IOMemoryDescriptor._iomapperOptions.meta=2
-struct._IOMemoryDescriptor.__iomd_reserved3=uint16_t,58,3
-struct._IOMemoryDescriptor.__iomd_reserved3.meta=2
-struct._IOMemoryDescriptor.__iomd_reserved4=uintptr_t,64,0
-struct._IOMemoryDescriptor.__iomd_reserved4.meta=8
-struct._IOMemoryDescriptor._length=LONG,72,0
-struct._IOMemoryDescriptor._length.meta=8
-struct._IOMemoryDescriptor._tag=int,80,0
-struct._IOMemoryDescriptor._tag.meta=4
-
-_IOMemoryMap=struct
-struct._IOMemoryMap=parent,fOptions,fMemory,fSuperMap,fOffset,fAddress,fLength,fAddressTask,fAddressMap,fRedirUPL,fUserClientUnmap
-struct._IOMemoryMap.parent=struct._OSObject,0,0
-struct._IOMemoryMap.parent.meta=4
-struct._IOMemoryMap.fOptions=int,4,0
-struct._IOMemoryMap.fOptions.meta=4
-struct._IOMemoryMap.fMemory=void *,8,0
-struct._IOMemoryMap.fMemory.meta=8
-struct._IOMemoryMap.fSuperMap=void *,16,0
-struct._IOMemoryMap.fSuperMap.meta=8
-struct._IOMemoryMap.fOffset=LONG,24,0
-struct._IOMemoryMap.fOffset.meta=8
-struct._IOMemoryMap.fAddress=LONG,32,0
-struct._IOMemoryMap.fAddress.meta=8
-struct._IOMemoryMap.fLength=LONG,40,0
-struct._IOMemoryMap.fLength.meta=8
-struct._IOMemoryMap.fAddressTask=void *,48,0
-struct._IOMemoryMap.fAddressTask.meta=8
-struct._IOMemoryMap.fAddressMap=void *,56,0
-struct._IOMemoryMap.fAddressMap.meta=8
-struct._IOMemoryMap.fRedirUPL=void *,64,0
-struct._IOMemoryMap.fRedirUPL.meta=8
-struct._IOMemoryMap.fUserClientUnmap=uint8_t,72,0
-struct._IOMemoryMap.fUserClientUnmap.meta=1
-
-_IOMultiMemoryDescriptor=struct
-struct._IOMultiMemoryDescriptor=parent,_descriptors,_descriptorsCount,_descriptorsIsAllocated
-struct._IOMultiMemoryDescriptor.parent=struct._IOMemoryDescriptor,0,0
-struct._IOMultiMemoryDescriptor.parent.meta=88
-struct._IOMultiMemoryDescriptor._descriptors=void *,88,0
-struct._IOMultiMemoryDescriptor._descriptors.meta=8
-struct._IOMultiMemoryDescriptor._descriptorsCount=int,96,0
-struct._IOMultiMemoryDescriptor._descriptorsCount.meta=4
-struct._IOMultiMemoryDescriptor._descriptorsIsAllocated=bool,100,0
-struct._IOMultiMemoryDescriptor._descriptorsIsAllocated.meta=1
-
-_IONVRAMController=struct
-struct._IONVRAMController=parent
-struct._IONVRAMController.parent=struct._IOService,0,0
-struct._IONVRAMController.parent.meta=128
-
-_IONaturalMemoryCursor=struct
-struct._IONaturalMemoryCursor=parent
-struct._IONaturalMemoryCursor.parent=struct._IOMemoryCursor,0,0
-struct._IONaturalMemoryCursor.parent.meta=40
-
-_IONotifier=struct
-struct._IONotifier=parent
-struct._IONotifier.parent=struct._OSObject,0,0
-struct._IONotifier.parent.meta=4
-
-_IOPMGR=struct
-struct._IOPMGR=parent
-struct._IOPMGR.parent=struct._IOService,0,0
-struct._IOPMGR.parent.meta=128
-
-_IOPMPowerSource=struct
-struct._IOPMPowerSource=parent,settingsChangedSinceUpdate,properties,externalConnectedKey,externalChargeCapableKey,batteryInstalledKey,chargingKey,warnLevelKey,criticalLevelKey,currentCapacityKey,maxCapacityKey,timeRemainingKey,amperageKey,voltageKey,cycleCountKey,adapterInfoKey,locationKey,errorConditionKey,manufacturerKey,modelKey,serialKey,batteryInfoKey,nextInList
-struct._IOPMPowerSource.parent=struct._IOService,0,0
-struct._IOPMPowerSource.parent.meta=128
-struct._IOPMPowerSource.settingsChangedSinceUpdate=bool,128,0
-struct._IOPMPowerSource.settingsChangedSinceUpdate.meta=1
-struct._IOPMPowerSource.properties=void *,136,0
-struct._IOPMPowerSource.properties.meta=8
-struct._IOPMPowerSource.externalConnectedKey=void *,144,0
-struct._IOPMPowerSource.externalConnectedKey.meta=8
-struct._IOPMPowerSource.externalChargeCapableKey=void *,152,0
-struct._IOPMPowerSource.externalChargeCapableKey.meta=8
-struct._IOPMPowerSource.batteryInstalledKey=void *,160,0
-struct._IOPMPowerSource.batteryInstalledKey.meta=8
-struct._IOPMPowerSource.chargingKey=void *,168,0
-struct._IOPMPowerSource.chargingKey.meta=8
-struct._IOPMPowerSource.warnLevelKey=void *,176,0
-struct._IOPMPowerSource.warnLevelKey.meta=8
-struct._IOPMPowerSource.criticalLevelKey=void *,184,0
-struct._IOPMPowerSource.criticalLevelKey.meta=8
-struct._IOPMPowerSource.currentCapacityKey=void *,192,0
-struct._IOPMPowerSource.currentCapacityKey.meta=8
-struct._IOPMPowerSource.maxCapacityKey=void *,200,0
-struct._IOPMPowerSource.maxCapacityKey.meta=8
-struct._IOPMPowerSource.timeRemainingKey=void *,208,0
-struct._IOPMPowerSource.timeRemainingKey.meta=8
-struct._IOPMPowerSource.amperageKey=void *,216,0
-struct._IOPMPowerSource.amperageKey.meta=8
-struct._IOPMPowerSource.voltageKey=void *,224,0
-struct._IOPMPowerSource.voltageKey.meta=8
-struct._IOPMPowerSource.cycleCountKey=void *,232,0
-struct._IOPMPowerSource.cycleCountKey.meta=8
-struct._IOPMPowerSource.adapterInfoKey=void *,240,0
-struct._IOPMPowerSource.adapterInfoKey.meta=8
-struct._IOPMPowerSource.locationKey=void *,248,0
-struct._IOPMPowerSource.locationKey.meta=8
-struct._IOPMPowerSource.errorConditionKey=void *,256,0
-struct._IOPMPowerSource.errorConditionKey.meta=8
-struct._IOPMPowerSource.manufacturerKey=void *,264,0
-struct._IOPMPowerSource.manufacturerKey.meta=8
-struct._IOPMPowerSource.modelKey=void *,272,0
-struct._IOPMPowerSource.modelKey.meta=8
-struct._IOPMPowerSource.serialKey=void *,280,0
-struct._IOPMPowerSource.serialKey.meta=8
-struct._IOPMPowerSource.batteryInfoKey=void *,288,0
-struct._IOPMPowerSource.batteryInfoKey.meta=8
-struct._IOPMPowerSource.nextInList=void *,296,0
-struct._IOPMPowerSource.nextInList.meta=8
-
-_IOPMPowerSourceList=struct
-struct._IOPMPowerSourceList=parent,firstItem,length
-struct._IOPMPowerSourceList.parent=struct._OSObject,0,0
-struct._IOPMPowerSourceList.parent.meta=4
-struct._IOPMPowerSourceList.firstItem=void *,8,0
-struct._IOPMPowerSourceList.firstItem.meta=8
-struct._IOPMPowerSourceList.length=LONGU,16,0
-struct._IOPMPowerSourceList.length.meta=8
-
-_IOPMPowerState=struct
-struct._IOPMPowerState=version,capabilityFlags,outputPowerCharacter,inputPowerRequirement,staticPower,stateOrder,powerToAttain,timeToAttain,settleUpTime,timeToLower,settleDownTime,powerDomainBudget
-struct._IOPMPowerState.version=LONGU,0,0
-struct._IOPMPowerState.version.meta=8
-struct._IOPMPowerState.capabilityFlags=LONG,8,0
-struct._IOPMPowerState.capabilityFlags.meta=8
-struct._IOPMPowerState.outputPowerCharacter=LONG,16,0
-struct._IOPMPowerState.outputPowerCharacter.meta=8
-struct._IOPMPowerState.inputPowerRequirement=LONG,24,0
-struct._IOPMPowerState.inputPowerRequirement.meta=8
-struct._IOPMPowerState.staticPower=LONGU,32,0
-struct._IOPMPowerState.staticPower.meta=8
-struct._IOPMPowerState.stateOrder=LONGU,40,0
-struct._IOPMPowerState.stateOrder.meta=8
-struct._IOPMPowerState.powerToAttain=LONGU,48,0
-struct._IOPMPowerState.powerToAttain.meta=8
-struct._IOPMPowerState.timeToAttain=LONGU,56,0
-struct._IOPMPowerState.timeToAttain.meta=8
-struct._IOPMPowerState.settleUpTime=LONGU,64,0
-struct._IOPMPowerState.settleUpTime.meta=8
-struct._IOPMPowerState.timeToLower=LONGU,72,0
-struct._IOPMPowerState.timeToLower.meta=8
-struct._IOPMPowerState.settleDownTime=LONGU,80,0
-struct._IOPMPowerState.settleDownTime.meta=8
-struct._IOPMPowerState.powerDomainBudget=LONGU,88,0
-struct._IOPMPowerState.powerDomainBudget.meta=8
-
-_IOPMinformee=struct
-struct._IOPMinformee=parent,whatObject,timer,nextInList,startTime,active
-struct._IOPMinformee.parent=struct._OSObject,0,0
-struct._IOPMinformee.parent.meta=4
-struct._IOPMinformee.whatObject=void *,8,0
-struct._IOPMinformee.whatObject.meta=8
-struct._IOPMinformee.timer=int32_t,16,0
-struct._IOPMinformee.timer.meta=4
-struct._IOPMinformee.nextInList=void *,24,0
-struct._IOPMinformee.nextInList.meta=8
-struct._IOPMinformee.startTime=LONG,32,0
-struct._IOPMinformee.startTime.meta=8
-struct._IOPMinformee.active=bool,40,0
-struct._IOPMinformee.active.meta=1
-
-_IOPMinformeeList=struct
-struct._IOPMinformeeList=parent,firstItem,length
-struct._IOPMinformeeList.parent=struct._OSObject,0,0
-struct._IOPMinformeeList.parent.meta=4
-struct._IOPMinformeeList.firstItem=void *,8,0
-struct._IOPMinformeeList.firstItem.meta=8
-struct._IOPMinformeeList.length=LONGU,16,0
-struct._IOPMinformeeList.length.meta=8
-
-_IOPerfControlClient=struct
-struct._IOPerfControlClient=parent,driverIndex,shared,workTable,workTableLength,workTableNextIndex,workTableLock,clientData
-struct._IOPerfControlClient.parent=struct._OSObject,0,0
-struct._IOPerfControlClient.parent.meta=4
-struct._IOPerfControlClient.driverIndex=uint8_t,4,0
-struct._IOPerfControlClient.driverIndex.meta=1
-struct._IOPerfControlClient.shared=void *,8,0
-struct._IOPerfControlClient.shared.meta=8
-struct._IOPerfControlClient.workTable=void *,16,0
-struct._IOPerfControlClient.workTable.meta=8
-struct._IOPerfControlClient.workTableLength=LONG,24,0
-struct._IOPerfControlClient.workTableLength.meta=8
-struct._IOPerfControlClient.workTableNextIndex=LONG,32,0
-struct._IOPerfControlClient.workTableNextIndex.meta=8
-struct._IOPerfControlClient.workTableLock=void *,40,0
-struct._IOPerfControlClient.workTableLock.meta=8
-struct._IOPerfControlClient.clientData=void *,48,0
-struct._IOPerfControlClient.clientData.meta=8
-
-_IOPerfControlClient::IOPerfControlClientData=struct
-struct._IOPerfControlClient::IOPerfControlClientData=target_thread_group,driverState,device
-struct._IOPerfControlClient::IOPerfControlClientData.target_thread_group=void *,0,0
-struct._IOPerfControlClient::IOPerfControlClientData.target_thread_group.meta=8
-struct._IOPerfControlClient::IOPerfControlClientData.driverState=void *,8,0
-struct._IOPerfControlClient::IOPerfControlClientData.driverState.meta=8
-struct._IOPerfControlClient::IOPerfControlClientData.device=void *,16,0
-struct._IOPerfControlClient::IOPerfControlClientData.device.meta=8
-
-_IOPerfControlClient::IOPerfControlClientShared=struct
-struct._IOPerfControlClient::IOPerfControlClientShared=maxDriverIndex,interface,interfaceLock,deviceRegistrationList
-struct._IOPerfControlClient::IOPerfControlClientShared.maxDriverIndex=void *,0,0
-struct._IOPerfControlClient::IOPerfControlClientShared.maxDriverIndex.meta=8
-struct._IOPerfControlClient::IOPerfControlClientShared.interface=void *,8,0
-struct._IOPerfControlClient::IOPerfControlClientShared.interface.meta=8
-struct._IOPerfControlClient::IOPerfControlClientShared.interfaceLock=void *,16,0
-struct._IOPerfControlClient::IOPerfControlClientShared.interfaceLock.meta=8
-struct._IOPerfControlClient::IOPerfControlClientShared.deviceRegistrationList=void *,24,0
-struct._IOPerfControlClient::IOPerfControlClientShared.deviceRegistrationList.meta=8
-
-_IOPerfControlClient::PerfControllerInterface=struct
-struct._IOPerfControlClient::PerfControllerInterface=version,registerDevice,unregisterDevice,workCanSubmit,workSubmit,workBegin,workEnd,workUpdate,registerDriverDevice,unregisterDriverDevice,workEndWithResources
-struct._IOPerfControlClient::PerfControllerInterface.version=uint64_t,0,0
-struct._IOPerfControlClient::PerfControllerInterface.version.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.registerDevice=void *,8,0
-struct._IOPerfControlClient::PerfControllerInterface.registerDevice.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.unregisterDevice=void *,16,0
-struct._IOPerfControlClient::PerfControllerInterface.unregisterDevice.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workCanSubmit=void *,24,0
-struct._IOPerfControlClient::PerfControllerInterface.workCanSubmit.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workSubmit=void *,32,0
-struct._IOPerfControlClient::PerfControllerInterface.workSubmit.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workBegin=void *,40,0
-struct._IOPerfControlClient::PerfControllerInterface.workBegin.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workEnd=void *,48,0
-struct._IOPerfControlClient::PerfControllerInterface.workEnd.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workUpdate=void *,56,0
-struct._IOPerfControlClient::PerfControllerInterface.workUpdate.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.registerDriverDevice=void *,64,0
-struct._IOPerfControlClient::PerfControllerInterface.registerDriverDevice.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.unregisterDriverDevice=void *,72,0
-struct._IOPerfControlClient::PerfControllerInterface.unregisterDriverDevice.meta=8
-struct._IOPerfControlClient::PerfControllerInterface.workEndWithResources=void *,80,0
-struct._IOPerfControlClient::PerfControllerInterface.workEndWithResources.meta=8
-
-_IOPerfControlClient::PerfControllerInterface::DriverState=struct
-struct._IOPerfControlClient::PerfControllerInterface::DriverState=has_target_thread_group__b0,has_device_info__b1,reserved__b2,target_thread_group_id,target_thread_group_data,device_type,instance_id,resource_accounting
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0=int,0,1
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0.meta=4
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0.@.bitoff=0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1=int,0,1
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1.meta=4
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1.@.bitoff=1
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2=int,0,30
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2.meta=4
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2.@.bitoff=2
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_id=uint64_t,8,0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_id.meta=8
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_data=void *,16,0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_data.meta=8
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.device_type=void *,24,0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.device_type.meta=8
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.instance_id=uint32_t,32,0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.instance_id.meta=4
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.resource_accounting=bool,36,0
-struct._IOPerfControlClient::PerfControllerInterface::DriverState.resource_accounting.meta=1
-
-_IOPerfControlClient::WorkBeginArgs=struct
-struct._IOPerfControlClient::WorkBeginArgs=version,size,begin_time,reserved,driver_data
-struct._IOPerfControlClient::WorkBeginArgs.version=uint32_t,0,0
-struct._IOPerfControlClient::WorkBeginArgs.version.meta=4
-struct._IOPerfControlClient::WorkBeginArgs.size=uint32_t,4,0
-struct._IOPerfControlClient::WorkBeginArgs.size.meta=4
-struct._IOPerfControlClient::WorkBeginArgs.begin_time=uint64_t,8,0
-struct._IOPerfControlClient::WorkBeginArgs.begin_time.meta=8
-struct._IOPerfControlClient::WorkBeginArgs.reserved=uint64_t,16,4
-struct._IOPerfControlClient::WorkBeginArgs.reserved.meta=8
-struct._IOPerfControlClient::WorkBeginArgs.driver_data=void *,48,0
-struct._IOPerfControlClient::WorkBeginArgs.driver_data.meta=8
-
-_IOPerfControlClient::WorkEndArgs=struct
-struct._IOPerfControlClient::WorkEndArgs=version,size,end_time,reserved,driver_data
-struct._IOPerfControlClient::WorkEndArgs.version=uint32_t,0,0
-struct._IOPerfControlClient::WorkEndArgs.version.meta=4
-struct._IOPerfControlClient::WorkEndArgs.size=uint32_t,4,0
-struct._IOPerfControlClient::WorkEndArgs.size.meta=4
-struct._IOPerfControlClient::WorkEndArgs.end_time=uint64_t,8,0
-struct._IOPerfControlClient::WorkEndArgs.end_time.meta=8
-struct._IOPerfControlClient::WorkEndArgs.reserved=uint64_t,16,4
-struct._IOPerfControlClient::WorkEndArgs.reserved.meta=8
-struct._IOPerfControlClient::WorkEndArgs.driver_data=void *,48,0
-struct._IOPerfControlClient::WorkEndArgs.driver_data.meta=8
-
-_IOPerfControlClient::WorkSubmitArgs=struct
-struct._IOPerfControlClient::WorkSubmitArgs=version,size,submit_time,reserved,driver_data
-struct._IOPerfControlClient::WorkSubmitArgs.version=uint32_t,0,0
-struct._IOPerfControlClient::WorkSubmitArgs.version.meta=4
-struct._IOPerfControlClient::WorkSubmitArgs.size=uint32_t,4,0
-struct._IOPerfControlClient::WorkSubmitArgs.size.meta=4
-struct._IOPerfControlClient::WorkSubmitArgs.submit_time=uint64_t,8,0
-struct._IOPerfControlClient::WorkSubmitArgs.submit_time.meta=8
-struct._IOPerfControlClient::WorkSubmitArgs.reserved=uint64_t,16,4
-struct._IOPerfControlClient::WorkSubmitArgs.reserved.meta=8
-struct._IOPerfControlClient::WorkSubmitArgs.driver_data=void *,48,0
-struct._IOPerfControlClient::WorkSubmitArgs.driver_data.meta=8
-
-_IOPerfControlClient::WorkTableEntry=struct
-struct._IOPerfControlClient::WorkTableEntry=thread_group,coal,started,perfcontrol_data
-struct._IOPerfControlClient::WorkTableEntry.thread_group=void *,0,0
-struct._IOPerfControlClient::WorkTableEntry.thread_group.meta=8
-struct._IOPerfControlClient::WorkTableEntry.coal=void *,8,0
-struct._IOPerfControlClient::WorkTableEntry.coal.meta=8
-struct._IOPerfControlClient::WorkTableEntry.started=bool,16,0
-struct._IOPerfControlClient::WorkTableEntry.started.meta=1
-struct._IOPerfControlClient::WorkTableEntry.perfcontrol_data=uint8_t,17,32
-struct._IOPerfControlClient::WorkTableEntry.perfcontrol_data.meta=1
-
-_IOPlatformDevice=struct
-struct._IOPlatformDevice=parent,iopd_reserved
-struct._IOPlatformDevice.parent=struct._IOService,0,0
-struct._IOPlatformDevice.parent.meta=128
-struct._IOPlatformDevice.iopd_reserved=void *,128,0
-struct._IOPlatformDevice.iopd_reserved.meta=8
-
-_IOPlatformDevice::ExpansionData=struct
-struct._IOPlatformDevice::ExpansionData=
-
-_IOPlatformExpert=struct
-struct._IOPlatformExpert=parent,_peBootROMType,_peChipSetType,_peMachineType,root,_pePMFeatures,_pePrivPMFeatures,_peNumBatteriesSupported,thePowerTree,searchingForAdditionalParents,multipleParentKeyValue,numInstancesRegistered,iope_reserved
-struct._IOPlatformExpert.parent=struct._IOService,0,0
-struct._IOPlatformExpert.parent.meta=128
-struct._IOPlatformExpert._peBootROMType=LONG,128,0
-struct._IOPlatformExpert._peBootROMType.meta=8
-struct._IOPlatformExpert._peChipSetType=LONG,136,0
-struct._IOPlatformExpert._peChipSetType.meta=8
-struct._IOPlatformExpert._peMachineType=LONG,144,0
-struct._IOPlatformExpert._peMachineType.meta=8
-struct._IOPlatformExpert.root=void *,152,0
-struct._IOPlatformExpert.root.meta=8
-struct._IOPlatformExpert._pePMFeatures=int,160,0
-struct._IOPlatformExpert._pePMFeatures.meta=4
-struct._IOPlatformExpert._pePrivPMFeatures=int,164,0
-struct._IOPlatformExpert._pePrivPMFeatures.meta=4
-struct._IOPlatformExpert._peNumBatteriesSupported=int,168,0
-struct._IOPlatformExpert._peNumBatteriesSupported.meta=4
-struct._IOPlatformExpert.thePowerTree=void *,176,0
-struct._IOPlatformExpert.thePowerTree.meta=8
-struct._IOPlatformExpert.searchingForAdditionalParents=bool,184,0
-struct._IOPlatformExpert.searchingForAdditionalParents.meta=1
-struct._IOPlatformExpert.multipleParentKeyValue=void *,192,0
-struct._IOPlatformExpert.multipleParentKeyValue.meta=8
-struct._IOPlatformExpert.numInstancesRegistered=int,200,0
-struct._IOPlatformExpert.numInstancesRegistered.meta=4
-struct._IOPlatformExpert.iope_reserved=void *,208,0
-struct._IOPlatformExpert.iope_reserved.meta=8
-
-_IOPlatformExpert::ExpansionData=struct
-struct._IOPlatformExpert::ExpansionData=
-
-_IOPlatformExpertDevice=struct
-struct._IOPlatformExpertDevice=parent,workLoop,ioped_reserved
-struct._IOPlatformExpertDevice.parent=struct._IOService,0,0
-struct._IOPlatformExpertDevice.parent.meta=128
-struct._IOPlatformExpertDevice.workLoop=void *,128,0
-struct._IOPlatformExpertDevice.workLoop.meta=8
-struct._IOPlatformExpertDevice.ioped_reserved=void *,136,0
-struct._IOPlatformExpertDevice.ioped_reserved.meta=8
-
-_IOPlatformExpertDevice::ExpansionData=struct
-struct._IOPlatformExpertDevice::ExpansionData=
-
-_IOPlatformIO=struct
-struct._IOPlatformIO=parent
-struct._IOPlatformIO.parent=struct._IOService,0,0
-struct._IOPlatformIO.parent.meta=128
-
-_IOPolledCompletion=struct
-struct._IOPolledCompletion=target,action,parameter
-struct._IOPolledCompletion.target=void *,0,0
-struct._IOPolledCompletion.target.meta=8
-struct._IOPolledCompletion.action=void *,8,0
-struct._IOPolledCompletion.action.meta=8
-struct._IOPolledCompletion.parameter=void *,16,0
-struct._IOPolledCompletion.parameter.meta=8
-
-_IOPolledInterface=struct
-struct._IOPolledInterface=parent,reserved
-struct._IOPolledInterface.parent=struct._OSObject,0,0
-struct._IOPolledInterface.parent.meta=4
-struct._IOPolledInterface.reserved=void *,8,0
-struct._IOPolledInterface.reserved.meta=8
-
-_IOPolledInterface::ExpansionData=struct
-struct._IOPolledInterface::ExpansionData=
-
-_IOPowerConnection=struct
-struct._IOPowerConnection=parent,stateKnown,currentPowerFlags,desiredDomainState,requestFlag,preventIdleSleepFlag,preventSystemSleepFlag,awaitingAck,readyFlag,delayChildNotification
-struct._IOPowerConnection.parent=struct._IOService,0,0
-struct._IOPowerConnection.parent.meta=128
-struct._IOPowerConnection.stateKnown=bool,128,0
-struct._IOPowerConnection.stateKnown.meta=1
-struct._IOPowerConnection.currentPowerFlags=LONG,136,0
-struct._IOPowerConnection.currentPowerFlags.meta=8
-struct._IOPowerConnection.desiredDomainState=LONGU,144,0
-struct._IOPowerConnection.desiredDomainState.meta=8
-struct._IOPowerConnection.requestFlag=bool,152,0
-struct._IOPowerConnection.requestFlag.meta=1
-struct._IOPowerConnection.preventIdleSleepFlag=LONGU,160,0
-struct._IOPowerConnection.preventIdleSleepFlag.meta=8
-struct._IOPowerConnection.preventSystemSleepFlag=LONGU,168,0
-struct._IOPowerConnection.preventSystemSleepFlag.meta=8
-struct._IOPowerConnection.awaitingAck=bool,176,0
-struct._IOPowerConnection.awaitingAck.meta=1
-struct._IOPowerConnection.readyFlag=bool,177,0
-struct._IOPowerConnection.readyFlag.meta=1
-struct._IOPowerConnection.delayChildNotification=bool,178,0
-struct._IOPowerConnection.delayChildNotification.meta=1
-
-_IOProviderPropertyMerger=struct
-struct._IOProviderPropertyMerger=parent
-struct._IOProviderPropertyMerger.parent=struct._IOService,0,0
-struct._IOProviderPropertyMerger.parent.meta=128
-
-_IORPC=struct
-struct._IORPC=message,reply,sendSize,replySize,kernelContent
-struct._IORPC.message=void *,0,0
-struct._IORPC.message.meta=8
-struct._IORPC.reply=void *,8,0
-struct._IORPC.reply.meta=8
-struct._IORPC.sendSize=uint32_t,16,0
-struct._IORPC.sendSize.meta=4
-struct._IORPC.replySize=uint32_t,20,0
-struct._IORPC.replySize.meta=4
-struct._IORPC.kernelContent=void *,24,0
-struct._IORPC.kernelContent.meta=8
-
-_IORPCMessage=struct
-struct._IORPCMessage=msgid,flags,objectRefs,objects
-struct._IORPCMessage.msgid=uint64_t,0,0
-struct._IORPCMessage.msgid.meta=8
-struct._IORPCMessage.flags=uint64_t,8,0
-struct._IORPCMessage.flags.meta=8
-struct._IORPCMessage.objectRefs=uint64_t,16,0
-struct._IORPCMessage.objectRefs.meta=8
-struct._IORPCMessage.objects=OSObjectRef,24,0
-struct._IORPCMessage.objects.meta=8
-
-_IORPCMessageMach=struct
-struct._IORPCMessageMach=msgh,msgh_body,objects
-struct._IORPCMessageMach.msgh=void *,0,0
-struct._IORPCMessageMach.msgh.meta=8
-struct._IORPCMessageMach.msgh_body=void *,8,0
-struct._IORPCMessageMach.msgh_body.meta=8
-struct._IORPCMessageMach.objects=mach_msg_port_descriptor_t,16,0
-struct._IORPCMessageMach.objects.meta=8
-
-_IORTC=struct
-struct._IORTC=parent,iortc_reserved
-struct._IORTC.parent=struct._IOService,0,0
-struct._IORTC.parent.meta=128
-struct._IORTC.iortc_reserved=void *,128,0
-struct._IORTC.iortc_reserved.meta=8
-
-_IORTC::ExpansionData=struct
-struct._IORTC::ExpansionData=
-
-_IORangeAllocator=struct
-struct._IORangeAllocator=parent,numElements,capacity,capacityIncrement,defaultAlignmentMask,options,elements
-struct._IORangeAllocator.parent=struct._OSObject,0,0
-struct._IORangeAllocator.parent.meta=4
-struct._IORangeAllocator.numElements=int,4,0
-struct._IORangeAllocator.numElements.meta=4
-struct._IORangeAllocator.capacity=int,8,0
-struct._IORangeAllocator.capacity.meta=4
-struct._IORangeAllocator.capacityIncrement=int,12,0
-struct._IORangeAllocator.capacityIncrement.meta=4
-struct._IORangeAllocator.defaultAlignmentMask=LONG,16,0
-struct._IORangeAllocator.defaultAlignmentMask.meta=8
-struct._IORangeAllocator.options=int,24,0
-struct._IORangeAllocator.options.meta=4
-struct._IORangeAllocator.elements=void *,32,0
-struct._IORangeAllocator.elements.meta=8
-
-_IORegistryEntry=struct
-struct._IORegistryEntry=parent,reserved,fRegistryTable,fPropertyTable
-struct._IORegistryEntry.parent=struct._OSObject,0,0
-struct._IORegistryEntry.parent.meta=4
-struct._IORegistryEntry.reserved=void *,8,0
-struct._IORegistryEntry.reserved.meta=8
-struct._IORegistryEntry.fRegistryTable=void *,16,0
-struct._IORegistryEntry.fRegistryTable.meta=8
-struct._IORegistryEntry.fPropertyTable=void *,24,0
-struct._IORegistryEntry.fPropertyTable.meta=8
-
-_IORegistryIterator=struct
-struct._IORegistryIterator=parent,start,where,root,done,plane,options
-struct._IORegistryIterator.parent=struct._OSIterator,0,0
-struct._IORegistryIterator.parent.meta=4
-struct._IORegistryIterator.start=void *,8,0
-struct._IORegistryIterator.start.meta=8
-struct._IORegistryIterator.where=void *,16,0
-struct._IORegistryIterator.where.meta=8
-struct._IORegistryIterator.root=void *,24,0
-struct._IORegistryIterator.root.meta=8
-struct._IORegistryIterator.done=void *,32,0
-struct._IORegistryIterator.done.meta=8
-struct._IORegistryIterator.plane=void *,40,0
-struct._IORegistryIterator.plane.meta=8
-struct._IORegistryIterator.options=int,48,0
-struct._IORegistryIterator.options.meta=4
-
-_IORegistryIterator::IORegCursor=struct
-struct._IORegistryIterator::IORegCursor=next,current,iter
-struct._IORegistryIterator::IORegCursor.next=void *,0,0
-struct._IORegistryIterator::IORegCursor.next.meta=8
-struct._IORegistryIterator::IORegCursor.current=void *,8,0
-struct._IORegistryIterator::IORegCursor.current.meta=8
-struct._IORegistryIterator::IORegCursor.iter=void *,16,0
-struct._IORegistryIterator::IORegCursor.iter.meta=8
-
-_IOReportLegend=struct
-struct._IOReportLegend=parent,_reportLegend
-struct._IOReportLegend.parent=struct._OSObject,0,0
-struct._IOReportLegend.parent.meta=4
-struct._IOReportLegend._reportLegend=void *,8,0
-struct._IOReportLegend._reportLegend.meta=8
-
-_IOReporter=struct
-struct._IOReporter=parent,_channelType,_driver_id,_elements,_enableCounts,_channelDimension,_nElements,_nChannels,_channelNames,_reporterIsLocked,_reporterConfigIsLocked,_swapElements,_swapEnableCounts,_unit,_enabled,_configLock,_interruptState,_reporterLock
-struct._IOReporter.parent=struct._OSObject,0,0
-struct._IOReporter.parent.meta=4
-struct._IOReporter._channelType=void *,8,0
-struct._IOReporter._channelType.meta=8
-struct._IOReporter._driver_id=uint64_t,16,0
-struct._IOReporter._driver_id.meta=8
-struct._IOReporter._elements=void *,24,0
-struct._IOReporter._elements.meta=8
-struct._IOReporter._enableCounts=void *,32,0
-struct._IOReporter._enableCounts.meta=8
-struct._IOReporter._channelDimension=uint16_t,40,0
-struct._IOReporter._channelDimension.meta=2
-struct._IOReporter._nElements=int,44,0
-struct._IOReporter._nElements.meta=4
-struct._IOReporter._nChannels=int,48,0
-struct._IOReporter._nChannels.meta=4
-struct._IOReporter._channelNames=void *,56,0
-struct._IOReporter._channelNames.meta=8
-struct._IOReporter._reporterIsLocked=bool,64,0
-struct._IOReporter._reporterIsLocked.meta=1
-struct._IOReporter._reporterConfigIsLocked=bool,65,0
-struct._IOReporter._reporterConfigIsLocked.meta=1
-struct._IOReporter._swapElements=void *,72,0
-struct._IOReporter._swapElements.meta=8
-struct._IOReporter._swapEnableCounts=void *,80,0
-struct._IOReporter._swapEnableCounts.meta=8
-struct._IOReporter._unit=LONG,88,0
-struct._IOReporter._unit.meta=8
-struct._IOReporter._enabled=int,96,0
-struct._IOReporter._enabled.meta=4
-struct._IOReporter._configLock=void *,104,0
-struct._IOReporter._configLock.meta=8
-struct._IOReporter._interruptState=int,112,0
-struct._IOReporter._interruptState.meta=4
-struct._IOReporter._reporterLock=void *,120,0
-struct._IOReporter._reporterLock.meta=8
-
-_IOService=struct
-struct._IOService=parent,reserved,__provider,__providerGeneration,__resv1,__owner,__state,__timeBusy,__accumBusy,pwrMgt,initialized,__machPortHoldDestroy,__resv2,pm_vars,_numInterruptSources,_interruptSources
-struct._IOService.parent=struct._IORegistryEntry,0,0
-struct._IOService.parent.meta=32
-struct._IOService.reserved=void *,32,0
-struct._IOService.reserved.meta=8
-struct._IOService.__provider=void *,40,0
-struct._IOService.__provider.meta=8
-struct._IOService.__providerGeneration=int,48,0
-struct._IOService.__providerGeneration.meta=4
-struct._IOService.__resv1=uint32_t,52,0
-struct._IOService.__resv1.meta=4
-struct._IOService.__owner=void *,56,0
-struct._IOService.__owner.meta=8
-struct._IOService.__state=IOOptionBits,64,2
-struct._IOService.__state.meta=4
-struct._IOService.__timeBusy=uint64_t,72,0
-struct._IOService.__timeBusy.meta=8
-struct._IOService.__accumBusy=uint64_t,80,0
-struct._IOService.__accumBusy.meta=8
-struct._IOService.pwrMgt=void *,88,0
-struct._IOService.pwrMgt.meta=8
-struct._IOService.initialized=bool,96,0
-struct._IOService.initialized.meta=1
-struct._IOService.__machPortHoldDestroy=bool,97,0
-struct._IOService.__machPortHoldDestroy.meta=1
-struct._IOService.__resv2=uint8_t,98,6
-struct._IOService.__resv2.meta=1
-struct._IOService.pm_vars=void *,104,0
-struct._IOService.pm_vars.meta=8
-struct._IOService._numInterruptSources=int,112,0
-struct._IOService._numInterruptSources.meta=4
-struct._IOService._interruptSources=void *,120,0
-struct._IOService._interruptSources.meta=8
-
-_IOService::ExpansionData=struct
-struct._IOService::ExpansionData=authorizationID,interruptStatisticsLock,interruptStatisticsArray,interruptStatisticsArrayCount,uvars,svars,interruptSourcesPrivate
-struct._IOService::ExpansionData.authorizationID=uint64_t,0,0
-struct._IOService::ExpansionData.authorizationID.meta=8
-struct._IOService::ExpansionData.interruptStatisticsLock=void *,8,0
-struct._IOService::ExpansionData.interruptStatisticsLock.meta=8
-struct._IOService::ExpansionData.interruptStatisticsArray=void *,16,0
-struct._IOService::ExpansionData.interruptStatisticsArray.meta=8
-struct._IOService::ExpansionData.interruptStatisticsArrayCount=int,24,0
-struct._IOService::ExpansionData.interruptStatisticsArrayCount.meta=4
-struct._IOService::ExpansionData.uvars=void *,32,0
-struct._IOService::ExpansionData.uvars.meta=8
-struct._IOService::ExpansionData.svars=void *,40,0
-struct._IOService::ExpansionData.svars.meta=8
-struct._IOService::ExpansionData.interruptSourcesPrivate=void *,48,0
-struct._IOService::ExpansionData.interruptSourcesPrivate.meta=8
-
-_IOServiceCompatibility=struct
-struct._IOServiceCompatibility=parent
-struct._IOServiceCompatibility.parent=struct._IOService,0,0
-struct._IOServiceCompatibility.parent.meta=128
-
-_IOServiceStateNotificationEventSource=struct
-struct._IOServiceStateNotificationEventSource=parent,fStateNotification,fListener,fEnable,fArmed,reserved
-struct._IOServiceStateNotificationEventSource.parent=struct._IOEventSource,0,0
-struct._IOServiceStateNotificationEventSource.parent.meta=72
-struct._IOServiceStateNotificationEventSource.fStateNotification=void *,72,0
-struct._IOServiceStateNotificationEventSource.fStateNotification.meta=8
-struct._IOServiceStateNotificationEventSource.fListener=void *,80,0
-struct._IOServiceStateNotificationEventSource.fListener.meta=8
-struct._IOServiceStateNotificationEventSource.fEnable=bool,88,0
-struct._IOServiceStateNotificationEventSource.fEnable.meta=1
-struct._IOServiceStateNotificationEventSource.fArmed=bool,89,0
-struct._IOServiceStateNotificationEventSource.fArmed.meta=1
-struct._IOServiceStateNotificationEventSource.reserved=void *,96,0
-struct._IOServiceStateNotificationEventSource.reserved.meta=8
-
-_IOSharedDataQueue=struct
-struct._IOSharedDataQueue=parent,_reserved
-struct._IOSharedDataQueue.parent=struct._IODataQueue,0,0
-struct._IOSharedDataQueue.parent.meta=24
-struct._IOSharedDataQueue._reserved=void *,24,0
-struct._IOSharedDataQueue._reserved.meta=8
-
-_IOSharedDataQueue::ExpansionData=struct
-struct._IOSharedDataQueue::ExpansionData=queueSize
-struct._IOSharedDataQueue::ExpansionData.queueSize=int,0,0
-struct._IOSharedDataQueue::ExpansionData.queueSize.meta=4
-
-_IOSharedInterruptController=struct
-struct._IOSharedInterruptController=parent,provider,numVectors,vectorsRegistered,vectorsEnabled,controllerDisabled,sourceIsLevel,iosic_reserved
-struct._IOSharedInterruptController.parent=struct._IOInterruptController,0,0
-struct._IOSharedInterruptController.parent.meta=152
-struct._IOSharedInterruptController.provider=void *,152,0
-struct._IOSharedInterruptController.provider.meta=8
-struct._IOSharedInterruptController.numVectors=int,160,0
-struct._IOSharedInterruptController.numVectors.meta=4
-struct._IOSharedInterruptController.vectorsRegistered=int,164,0
-struct._IOSharedInterruptController.vectorsRegistered.meta=4
-struct._IOSharedInterruptController.vectorsEnabled=int,168,0
-struct._IOSharedInterruptController.vectorsEnabled.meta=4
-struct._IOSharedInterruptController.controllerDisabled=int,172,0
-struct._IOSharedInterruptController.controllerDisabled.meta=4
-struct._IOSharedInterruptController.sourceIsLevel=bool,176,0
-struct._IOSharedInterruptController.sourceIsLevel.meta=1
-struct._IOSharedInterruptController.iosic_reserved=void *,184,0
-struct._IOSharedInterruptController.iosic_reserved.meta=8
-
-_IOSharedInterruptController::ExpansionData=struct
-struct._IOSharedInterruptController::ExpansionData=
-
-_IOSimpleReporter=struct
-struct._IOSimpleReporter=parent
-struct._IOSimpleReporter.parent=struct._IOReporter,0,0
-struct._IOSimpleReporter.parent.meta=128
-
-_IOStateReporter=struct
-struct._IOStateReporter=parent,_currentStates,_lastUpdateTimes,_swapCurrentStates,_swapLastUpdateTimes
-struct._IOStateReporter.parent=struct._IOReporter,0,0
-struct._IOStateReporter.parent.meta=128
-struct._IOStateReporter._currentStates=void *,128,0
-struct._IOStateReporter._currentStates.meta=8
-struct._IOStateReporter._lastUpdateTimes=void *,136,0
-struct._IOStateReporter._lastUpdateTimes.meta=8
-struct._IOStateReporter._swapCurrentStates=void *,144,0
-struct._IOStateReporter._swapCurrentStates.meta=8
-struct._IOStateReporter._swapLastUpdateTimes=void *,152,0
-struct._IOStateReporter._swapLastUpdateTimes.meta=8
-
-_IOSubMemoryDescriptor=struct
-struct._IOSubMemoryDescriptor=parent,_parent,_start
-struct._IOSubMemoryDescriptor.parent=struct._IOMemoryDescriptor,0,0
-struct._IOSubMemoryDescriptor.parent.meta=88
-struct._IOSubMemoryDescriptor._parent=void *,88,0
-struct._IOSubMemoryDescriptor._parent.meta=8
-struct._IOSubMemoryDescriptor._start=LONG,96,0
-struct._IOSubMemoryDescriptor._start.meta=8
-
-_IOTimerEventSource=struct
-struct._IOTimerEventSource=parent,calloutEntry,abstime,reserved
-struct._IOTimerEventSource.parent=struct._IOEventSource,0,0
-struct._IOTimerEventSource.parent.meta=72
-struct._IOTimerEventSource.calloutEntry=void *,72,0
-struct._IOTimerEventSource.calloutEntry.meta=8
-struct._IOTimerEventSource.abstime=LONG,80,0
-struct._IOTimerEventSource.abstime.meta=8
-struct._IOTimerEventSource.reserved=void *,88,0
-struct._IOTimerEventSource.reserved.meta=8
-
-_IOTimerEventSource::ExpansionData=struct
-struct._IOTimerEventSource::ExpansionData=calloutGeneration,calloutGenerationSignaled,workLoop
-struct._IOTimerEventSource::ExpansionData.calloutGeneration=int,0,0
-struct._IOTimerEventSource::ExpansionData.calloutGeneration.meta=4
-struct._IOTimerEventSource::ExpansionData.calloutGenerationSignaled=int,4,0
-struct._IOTimerEventSource::ExpansionData.calloutGenerationSignaled.meta=4
-struct._IOTimerEventSource::ExpansionData.workLoop=void *,8,0
-struct._IOTimerEventSource::ExpansionData.workLoop.meta=8
-
-_IOUserClient=struct
-struct._IOUserClient=parent,reserved,__opaque_start,mappings,sharedInstance,closed,__ipcFinal,messageAppSuspended__b0,uc2022__b1,defaultLocking__b2,defaultLockingSingleThreadExternalMethod__b3,defaultLockingSetProperties__b4,opened__b5,__reservedA__b6,__ipc,owners,lock,filterLock,__reserved,__opaque_end
-struct._IOUserClient.parent=struct._IOService,0,0
-struct._IOUserClient.parent.meta=128
-struct._IOUserClient.reserved=void *,128,0
-struct._IOUserClient.reserved.meta=8
-struct._IOUserClient.__opaque_start=UInt8,136,0
-struct._IOUserClient.__opaque_start.meta=1
-struct._IOUserClient.mappings=void *,144,0
-struct._IOUserClient.mappings.meta=8
-struct._IOUserClient.sharedInstance=char,152,0
-struct._IOUserClient.sharedInstance.meta=1
-struct._IOUserClient.closed=char,153,0
-struct._IOUserClient.closed.meta=1
-struct._IOUserClient.__ipcFinal=char,154,0
-struct._IOUserClient.__ipcFinal.meta=1
-struct._IOUserClient.messageAppSuspended__b0=int,155,1
-struct._IOUserClient.messageAppSuspended__b0.meta=1
-struct._IOUserClient.messageAppSuspended__b0.@.bitoff=0
-struct._IOUserClient.uc2022__b1=int,155,1
-struct._IOUserClient.uc2022__b1.meta=1
-struct._IOUserClient.uc2022__b1.@.bitoff=1
-struct._IOUserClient.defaultLocking__b2=int,155,1
-struct._IOUserClient.defaultLocking__b2.meta=1
-struct._IOUserClient.defaultLocking__b2.@.bitoff=2
-struct._IOUserClient.defaultLockingSingleThreadExternalMethod__b3=int,155,1
-struct._IOUserClient.defaultLockingSingleThreadExternalMethod__b3.meta=1
-struct._IOUserClient.defaultLockingSingleThreadExternalMethod__b3.@.bitoff=3
-struct._IOUserClient.defaultLockingSetProperties__b4=int,155,1
-struct._IOUserClient.defaultLockingSetProperties__b4.meta=1
-struct._IOUserClient.defaultLockingSetProperties__b4.@.bitoff=4
-struct._IOUserClient.opened__b5=int,155,1
-struct._IOUserClient.opened__b5.meta=1
-struct._IOUserClient.opened__b5.@.bitoff=5
-struct._IOUserClient.__reservedA__b6=int,155,2
-struct._IOUserClient.__reservedA__b6.meta=1
-struct._IOUserClient.__reservedA__b6.@.bitoff=6
-struct._IOUserClient.__ipc=int,156,0
-struct._IOUserClient.__ipc.meta=4
-struct._IOUserClient.owners=void *,160,0
-struct._IOUserClient.owners.meta=8
-struct._IOUserClient.lock=void *,168,0
-struct._IOUserClient.lock.meta=8
-struct._IOUserClient.filterLock=void *,176,0
-struct._IOUserClient.filterLock.meta=8
-struct._IOUserClient.__reserved=void *,184,1
-struct._IOUserClient.__reserved.meta=8
-struct._IOUserClient.__opaque_end=UInt8,192,0
-struct._IOUserClient.__opaque_end.meta=1
-
-_IOUserClient2022=struct
-struct._IOUserClient2022=parent
-struct._IOUserClient2022.parent=struct._IOUserClient,0,0
-struct._IOUserClient2022.parent.meta=200
-
-_IOUserClient::ExpansionData=struct
-struct._IOUserClient::ExpansionData=iokitstatsReserved,filterPolicies
-struct._IOUserClient::ExpansionData.iokitstatsReserved=void *,0,0
-struct._IOUserClient::ExpansionData.iokitstatsReserved.meta=8
-struct._IOUserClient::ExpansionData.filterPolicies=void *,8,0
-struct._IOUserClient::ExpansionData.filterPolicies.meta=8
-
-_IOUserIterator=struct
-struct._IOUserIterator=parent,userIteratorObject,lock
-struct._IOUserIterator.parent=struct._OSIterator,0,0
-struct._IOUserIterator.parent.meta=4
-struct._IOUserIterator.userIteratorObject=void *,8,0
-struct._IOUserIterator.userIteratorObject.meta=8
-struct._IOUserIterator.lock=void *,16,0
-struct._IOUserIterator.lock.meta=8
-
-_IOUserNotification=struct
-struct._IOUserNotification=parent
-struct._IOUserNotification.parent=struct._IOUserIterator,0,0
-struct._IOUserNotification.parent.meta=24
-
-_IOUserServer=struct
-struct._IOUserServer=parent,fLock,fInterruptLock,fEntitlements,fClasses,fRootQueue,fServices,fRootNotifier,fSystemPowerAck,fSystemOff,fCheckInToken,fStatistics,fPlatformDriver,fTeamIdentifier,fCSValidationCategory,fWorkLoop,fAllocationName,fOwningTask,fTaskCrashReason
-struct._IOUserServer.parent=struct._IOUserClient2022,0,0
-struct._IOUserServer.parent.meta=200
-struct._IOUserServer.fLock=void *,200,0
-struct._IOUserServer.fLock.meta=8
-struct._IOUserServer.fInterruptLock=void *,208,0
-struct._IOUserServer.fInterruptLock.meta=8
-struct._IOUserServer.fEntitlements=void *,216,0
-struct._IOUserServer.fEntitlements.meta=8
-struct._IOUserServer.fClasses=void *,224,0
-struct._IOUserServer.fClasses.meta=8
-struct._IOUserServer.fRootQueue=void *,232,0
-struct._IOUserServer.fRootQueue.meta=8
-struct._IOUserServer.fServices=void *,240,0
-struct._IOUserServer.fServices.meta=8
-struct._IOUserServer.fRootNotifier=uint8_t,248,0
-struct._IOUserServer.fRootNotifier.meta=1
-struct._IOUserServer.fSystemPowerAck=uint8_t,249,0
-struct._IOUserServer.fSystemPowerAck.meta=1
-struct._IOUserServer.fSystemOff=uint8_t,250,0
-struct._IOUserServer.fSystemOff.meta=1
-struct._IOUserServer.fCheckInToken=void *,256,0
-struct._IOUserServer.fCheckInToken.meta=8
-struct._IOUserServer.fStatistics=void *,264,0
-struct._IOUserServer.fStatistics.meta=8
-struct._IOUserServer.fPlatformDriver=bool,272,0
-struct._IOUserServer.fPlatformDriver.meta=1
-struct._IOUserServer.fTeamIdentifier=void *,280,0
-struct._IOUserServer.fTeamIdentifier.meta=8
-struct._IOUserServer.fCSValidationCategory=unsigned int,288,0
-struct._IOUserServer.fCSValidationCategory.meta=4
-struct._IOUserServer.fWorkLoop=void *,296,0
-struct._IOUserServer.fWorkLoop.meta=8
-struct._IOUserServer.fAllocationName=void *,304,0
-struct._IOUserServer.fAllocationName.meta=8
-struct._IOUserServer.fOwningTask=void *,312,0
-struct._IOUserServer.fOwningTask.meta=8
-struct._IOUserServer.fTaskCrashReason=void *,320,0
-struct._IOUserServer.fTaskCrashReason.meta=8
-
-_IOUserServerCheckInToken=struct
-struct._IOUserServerCheckInToken=parent,fState,fPendingCount,fServerName,fExecutableName,fServerTag,fHandlers,fKextBundleID,fNeedDextDec
-struct._IOUserServerCheckInToken.parent=struct._OSObject,0,0
-struct._IOUserServerCheckInToken.parent.meta=4
-struct._IOUserServerCheckInToken.fState=void *,8,0
-struct._IOUserServerCheckInToken.fState.meta=8
-struct._IOUserServerCheckInToken.fPendingCount=LONG,16,0
-struct._IOUserServerCheckInToken.fPendingCount.meta=8
-struct._IOUserServerCheckInToken.fServerName=void *,24,0
-struct._IOUserServerCheckInToken.fServerName.meta=8
-struct._IOUserServerCheckInToken.fExecutableName=void *,32,0
-struct._IOUserServerCheckInToken.fExecutableName.meta=8
-struct._IOUserServerCheckInToken.fServerTag=void *,40,0
-struct._IOUserServerCheckInToken.fServerTag.meta=8
-struct._IOUserServerCheckInToken.fHandlers=void *,48,0
-struct._IOUserServerCheckInToken.fHandlers.meta=8
-struct._IOUserServerCheckInToken.fKextBundleID=void *,56,0
-struct._IOUserServerCheckInToken.fKextBundleID.meta=8
-struct._IOUserServerCheckInToken.fNeedDextDec=bool,64,0
-struct._IOUserServerCheckInToken.fNeedDextDec.meta=1
-
-_IOUserUserClient=struct
-struct._IOUserUserClient=parent,fTask,fWorkGroups,fEventLinks,fLock
-struct._IOUserUserClient.parent=struct._IOUserClient,0,0
-struct._IOUserUserClient.parent.meta=200
-struct._IOUserUserClient.fTask=void *,200,0
-struct._IOUserUserClient.fTask.meta=8
-struct._IOUserUserClient.fWorkGroups=void *,208,0
-struct._IOUserUserClient.fWorkGroups.meta=8
-struct._IOUserUserClient.fEventLinks=void *,216,0
-struct._IOUserUserClient.fEventLinks.meta=8
-struct._IOUserUserClient.fLock=void *,224,0
-struct._IOUserUserClient.fLock.meta=8
-
-_IOWatchDogTimer=struct
-struct._IOWatchDogTimer=parent,notifier,reserved
-struct._IOWatchDogTimer.parent=struct._IOService,0,0
-struct._IOWatchDogTimer.parent.meta=128
-struct._IOWatchDogTimer.notifier=void *,128,0
-struct._IOWatchDogTimer.notifier.meta=8
-struct._IOWatchDogTimer.reserved=void *,136,0
-struct._IOWatchDogTimer.reserved.meta=8
-
-_IOWatchDogTimer::ExpansionData=struct
-struct._IOWatchDogTimer::ExpansionData=
-
-_IOWorkGroup=struct
-struct._IOWorkGroup=parent,parent2,ivars,lvars
-struct._IOWorkGroup.parent=struct._OSObject,0,0
-struct._IOWorkGroup.parent.meta=4
-struct._IOWorkGroup.parent2=struct._IOWorkGroupInterface,4,0
-struct._IOWorkGroup.parent2.meta=0
-struct._IOWorkGroup.ivars=void *,8,0
-struct._IOWorkGroup.ivars.meta=8
-struct._IOWorkGroup.lvars=void *,16,0
-struct._IOWorkGroup.lvars.meta=8
-
-_IOWorkGroupInterface=struct
-struct._IOWorkGroupInterface=parent
-struct._IOWorkGroupInterface.parent=struct._OSInterface,0,0
-struct._IOWorkGroupInterface.parent.meta=0
-
-_IOWorkLoop=struct
-struct._IOWorkLoop=parent,gateLock,eventChain,controlG,workToDoLock,workThread,workToDo,loopRestart,reserved
-struct._IOWorkLoop.parent=struct._OSObject,0,0
-struct._IOWorkLoop.parent.meta=4
-struct._IOWorkLoop.gateLock=void *,8,0
-struct._IOWorkLoop.gateLock.meta=8
-struct._IOWorkLoop.eventChain=void *,16,0
-struct._IOWorkLoop.eventChain.meta=8
-struct._IOWorkLoop.controlG=void *,24,0
-struct._IOWorkLoop.controlG.meta=8
-struct._IOWorkLoop.workToDoLock=void *,32,0
-struct._IOWorkLoop.workToDoLock.meta=8
-struct._IOWorkLoop.workThread=void *,40,0
-struct._IOWorkLoop.workThread.meta=8
-struct._IOWorkLoop.workToDo=bool,48,0
-struct._IOWorkLoop.workToDo.meta=1
-struct._IOWorkLoop.loopRestart=bool,49,0
-struct._IOWorkLoop.loopRestart.meta=1
-struct._IOWorkLoop.reserved=void *,56,0
-struct._IOWorkLoop.reserved.meta=8
-
-_IOWorkLoop::ExpansionData=struct
-struct._IOWorkLoop::ExpansionData=options,passiveEventChain,iokitstatsReserved,lockInterval,lockTime
-struct._IOWorkLoop::ExpansionData.options=int,0,0
-struct._IOWorkLoop::ExpansionData.options.meta=4
-struct._IOWorkLoop::ExpansionData.passiveEventChain=void *,8,0
-struct._IOWorkLoop::ExpansionData.passiveEventChain.meta=8
-struct._IOWorkLoop::ExpansionData.iokitstatsReserved=void *,16,0
-struct._IOWorkLoop::ExpansionData.iokitstatsReserved.meta=8
-struct._IOWorkLoop::ExpansionData.lockInterval=uint64_t,24,0
-struct._IOWorkLoop::ExpansionData.lockInterval.meta=8
-struct._IOWorkLoop::ExpansionData.lockTime=uint64_t,32,0
-struct._IOWorkLoop::ExpansionData.lockTime.meta=8
-
-_OSAction=struct
-struct._OSAction=parent,parent2,ivars,lvars
-struct._OSAction.parent=struct._OSObject,0,0
-struct._OSAction.parent.meta=4
-struct._OSAction.parent2=struct._OSActionInterface,4,0
-struct._OSAction.parent2.meta=0
-struct._OSAction.ivars=void *,8,0
-struct._OSAction.ivars.meta=8
-struct._OSAction.lvars=void *,16,0
-struct._OSAction.lvars.meta=8
-
-_OSActionInterface=struct
-struct._OSActionInterface=parent
-struct._OSActionInterface.parent=struct._OSInterface,0,0
-struct._OSActionInterface.parent.meta=0
-
-_OSAction_IOUserClient_KernelCompletion=struct
-struct._OSAction_IOUserClient_KernelCompletion=parent,parent2,ivars,lvars
-struct._OSAction_IOUserClient_KernelCompletion.parent=struct._OSAction,0,0
-struct._OSAction_IOUserClient_KernelCompletion.parent.meta=24
-struct._OSAction_IOUserClient_KernelCompletion.parent2=struct._OSAction_IOUserClient_KernelCompletionInterface,24,0
-struct._OSAction_IOUserClient_KernelCompletion.parent2.meta=0
-struct._OSAction_IOUserClient_KernelCompletion.ivars=void *,24,0
-struct._OSAction_IOUserClient_KernelCompletion.ivars.meta=8
-struct._OSAction_IOUserClient_KernelCompletion.lvars=void *,32,0
-struct._OSAction_IOUserClient_KernelCompletion.lvars.meta=8
-
-_OSAction_IOUserClient_KernelCompletionInterface=struct
-struct._OSAction_IOUserClient_KernelCompletionInterface=parent
-struct._OSAction_IOUserClient_KernelCompletionInterface.parent=struct._OSInterface,0,0
-struct._OSAction_IOUserClient_KernelCompletionInterface.parent.meta=0
-
-_OSArray=struct
-struct._OSArray=parent,count,capacity,capacityIncrement,array
-struct._OSArray.parent=struct._OSCollection,0,0
-struct._OSArray.parent.meta=12
-struct._OSArray.count=unsigned int,12,0
-struct._OSArray.count.meta=4
-struct._OSArray.capacity=unsigned int,16,0
-struct._OSArray.capacity.meta=4
-struct._OSArray.capacityIncrement=unsigned int,20,0
-struct._OSArray.capacityIncrement.meta=4
-struct._OSArray.array=void *,24,0
-struct._OSArray.array.meta=8
-
-_OSBoolean=struct
-struct._OSBoolean=parent,value
-struct._OSBoolean.parent=struct._OSObject,0,0
-struct._OSBoolean.parent.meta=4
-struct._OSBoolean.value=bool,4,0
-struct._OSBoolean.value.meta=1
-
-_OSCollection=struct
-struct._OSCollection=parent,updateStamp,fOptions
-struct._OSCollection.parent=struct._OSObject,0,0
-struct._OSCollection.parent.meta=4
-struct._OSCollection.updateStamp=unsigned int,4,0
-struct._OSCollection.updateStamp.meta=4
-struct._OSCollection.fOptions=unsigned int,8,0
-struct._OSCollection.fOptions.meta=4
-
-_OSCollection::ExpansionData=struct
-struct._OSCollection::ExpansionData=
-
-_OSCollectionIterator=struct
-struct._OSCollectionIterator=parent,collection,inlineStorage,__padding,collIterator,initialUpdateStamp,valid
-struct._OSCollectionIterator.parent=struct._OSIterator,0,0
-struct._OSCollectionIterator.parent.meta=4
-struct._OSCollectionIterator.collection=void *,8,0
-struct._OSCollectionIterator.collection.meta=8
-struct._OSCollectionIterator.inlineStorage=uint8_t,16,4
-struct._OSCollectionIterator.inlineStorage.meta=1
-struct._OSCollectionIterator.__padding=uint8_t,20,4
-struct._OSCollectionIterator.__padding.meta=1
-struct._OSCollectionIterator.collIterator=void *,24,0
-struct._OSCollectionIterator.collIterator.meta=8
-struct._OSCollectionIterator.initialUpdateStamp=unsigned int,32,0
-struct._OSCollectionIterator.initialUpdateStamp.meta=4
-struct._OSCollectionIterator.valid=bool,36,0
-struct._OSCollectionIterator.valid.meta=1
-
-_OSData=struct
-struct._OSData=parent,length,capacity,capacityIncrement,data,reserved
-struct._OSData.parent=struct._OSObject,0,0
-struct._OSData.parent.meta=4
-struct._OSData.length=unsigned int,4,0
-struct._OSData.length.meta=4
-struct._OSData.capacity=unsigned int,8,0
-struct._OSData.capacity.meta=4
-struct._OSData.capacityIncrement=unsigned int,12,0
-struct._OSData.capacityIncrement.meta=4
-struct._OSData.data=void *,16,0
-struct._OSData.data.meta=8
-struct._OSData.reserved=void *,24,0
-struct._OSData.reserved.meta=8
-
-_OSData::ExpansionData=struct
-struct._OSData::ExpansionData=deallocFunction,disableSerialization
-struct._OSData::ExpansionData.deallocFunction=void *,0,0
-struct._OSData::ExpansionData.deallocFunction.meta=8
-struct._OSData::ExpansionData.disableSerialization=bool,8,0
-struct._OSData::ExpansionData.disableSerialization.meta=1
-
-_OSDextStatistics=struct
-struct._OSDextStatistics=parent,crashes,lock
-struct._OSDextStatistics.parent=struct._OSObject,0,0
-struct._OSDextStatistics.parent.meta=4
-struct._OSDextStatistics.crashes=void *,8,0
-struct._OSDextStatistics.crashes.meta=8
-struct._OSDextStatistics.lock=void *,16,0
-struct._OSDextStatistics.lock.meta=8
-
-_OSDictionary=struct
-struct._OSDictionary=parent,count,capacity,capacityIncrement,dictionary
-struct._OSDictionary.parent=struct._OSCollection,0,0
-struct._OSDictionary.parent.meta=12
-struct._OSDictionary.count=unsigned int,12,0
-struct._OSDictionary.count.meta=4
-struct._OSDictionary.capacity=unsigned int,16,0
-struct._OSDictionary.capacity.meta=4
-struct._OSDictionary.capacityIncrement=unsigned int,20,0
-struct._OSDictionary.capacityIncrement.meta=4
-struct._OSDictionary.dictionary=void *,24,0
-struct._OSDictionary.dictionary.meta=8
-
-_OSInterface=struct
-struct._OSInterface=
-
-_OSIterator=struct
-struct._OSIterator=parent
-struct._OSIterator.parent=struct._OSObject,0,0
-struct._OSIterator.parent.meta=4
-
-_OSKext=struct
-struct._OSKext=parent,infoDict,bundleID,path,executableRelPath,userExecutableRelPath,version,compatibleVersion,loadTag,kmod_info,dependencies,linkedExecutable,metaClasses,interfaceUUID,driverKitUUID,loggingEnabled__b0,hasAllDependencies__b1,hasBleedthrough__b2,interface__b3,kernelComponent__b4,prelinked__b5,builtin__b6,loaded__b7,dtraceInitialized__b8,starting__b9,started__b10,stopping__b11,unloading__b12,resetSegmentsFromVnode__b13,requireExplicitLoad__b14,autounloadEnabled__b15,delayAutounload__b16,CPPInitialized__b17,jettisonLinkeditSeg__b18,resetSegmentsFromImmutableCopy__b19,unloadUnsupported__b20,dextToReplace__b21,unslidMachO__b22,matchingRefCount,kc_type,pendingPgoHead,instance_uuid,account,builtinKmodIdx,savedMutableSegments,dextStatistics,dextUniqueID,dextLaunchedCount
-struct._OSKext.parent=struct._OSObject,0,0
-struct._OSKext.parent.meta=4
-struct._OSKext.infoDict=void *,8,0
-struct._OSKext.infoDict.meta=8
-struct._OSKext.bundleID=void *,16,0
-struct._OSKext.bundleID.meta=8
-struct._OSKext.path=void *,24,0
-struct._OSKext.path.meta=8
-struct._OSKext.executableRelPath=void *,32,0
-struct._OSKext.executableRelPath.meta=8
-struct._OSKext.userExecutableRelPath=void *,40,0
-struct._OSKext.userExecutableRelPath.meta=8
-struct._OSKext.version=LONG,48,0
-struct._OSKext.version.meta=8
-struct._OSKext.compatibleVersion=LONG,56,0
-struct._OSKext.compatibleVersion.meta=8
-struct._OSKext.loadTag=int,64,0
-struct._OSKext.loadTag.meta=4
-struct._OSKext.kmod_info=void *,72,0
-struct._OSKext.kmod_info.meta=8
-struct._OSKext.dependencies=void *,80,0
-struct._OSKext.dependencies.meta=8
-struct._OSKext.linkedExecutable=void *,88,0
-struct._OSKext.linkedExecutable.meta=8
-struct._OSKext.metaClasses=void *,96,0
-struct._OSKext.metaClasses.meta=8
-struct._OSKext.interfaceUUID=void *,104,0
-struct._OSKext.interfaceUUID.meta=8
-struct._OSKext.driverKitUUID=void *,112,0
-struct._OSKext.driverKitUUID.meta=8
-struct._OSKext.loggingEnabled__b0=int,120,1
-struct._OSKext.loggingEnabled__b0.meta=4
-struct._OSKext.loggingEnabled__b0.@.bitoff=0
-struct._OSKext.hasAllDependencies__b1=int,120,1
-struct._OSKext.hasAllDependencies__b1.meta=4
-struct._OSKext.hasAllDependencies__b1.@.bitoff=1
-struct._OSKext.hasBleedthrough__b2=int,120,1
-struct._OSKext.hasBleedthrough__b2.meta=4
-struct._OSKext.hasBleedthrough__b2.@.bitoff=2
-struct._OSKext.interface__b3=int,120,1
-struct._OSKext.interface__b3.meta=4
-struct._OSKext.interface__b3.@.bitoff=3
-struct._OSKext.kernelComponent__b4=int,120,1
-struct._OSKext.kernelComponent__b4.meta=4
-struct._OSKext.kernelComponent__b4.@.bitoff=4
-struct._OSKext.prelinked__b5=int,120,1
-struct._OSKext.prelinked__b5.meta=4
-struct._OSKext.prelinked__b5.@.bitoff=5
-struct._OSKext.builtin__b6=int,120,1
-struct._OSKext.builtin__b6.meta=4
-struct._OSKext.builtin__b6.@.bitoff=6
-struct._OSKext.loaded__b7=int,120,1
-struct._OSKext.loaded__b7.meta=4
-struct._OSKext.loaded__b7.@.bitoff=7
-struct._OSKext.dtraceInitialized__b8=int,120,1
-struct._OSKext.dtraceInitialized__b8.meta=4
-struct._OSKext.dtraceInitialized__b8.@.bitoff=8
-struct._OSKext.starting__b9=int,120,1
-struct._OSKext.starting__b9.meta=4
-struct._OSKext.starting__b9.@.bitoff=9
-struct._OSKext.started__b10=int,120,1
-struct._OSKext.started__b10.meta=4
-struct._OSKext.started__b10.@.bitoff=10
-struct._OSKext.stopping__b11=int,120,1
-struct._OSKext.stopping__b11.meta=4
-struct._OSKext.stopping__b11.@.bitoff=11
-struct._OSKext.unloading__b12=int,120,1
-struct._OSKext.unloading__b12.meta=4
-struct._OSKext.unloading__b12.@.bitoff=12
-struct._OSKext.resetSegmentsFromVnode__b13=int,120,1
-struct._OSKext.resetSegmentsFromVnode__b13.meta=4
-struct._OSKext.resetSegmentsFromVnode__b13.@.bitoff=13
-struct._OSKext.requireExplicitLoad__b14=int,120,1
-struct._OSKext.requireExplicitLoad__b14.meta=4
-struct._OSKext.requireExplicitLoad__b14.@.bitoff=14
-struct._OSKext.autounloadEnabled__b15=int,120,1
-struct._OSKext.autounloadEnabled__b15.meta=4
-struct._OSKext.autounloadEnabled__b15.@.bitoff=15
-struct._OSKext.delayAutounload__b16=int,120,1
-struct._OSKext.delayAutounload__b16.meta=4
-struct._OSKext.delayAutounload__b16.@.bitoff=16
-struct._OSKext.CPPInitialized__b17=int,120,1
-struct._OSKext.CPPInitialized__b17.meta=4
-struct._OSKext.CPPInitialized__b17.@.bitoff=17
-struct._OSKext.jettisonLinkeditSeg__b18=int,120,1
-struct._OSKext.jettisonLinkeditSeg__b18.meta=4
-struct._OSKext.jettisonLinkeditSeg__b18.@.bitoff=18
-struct._OSKext.resetSegmentsFromImmutableCopy__b19=int,120,1
-struct._OSKext.resetSegmentsFromImmutableCopy__b19.meta=4
-struct._OSKext.resetSegmentsFromImmutableCopy__b19.@.bitoff=19
-struct._OSKext.unloadUnsupported__b20=int,120,1
-struct._OSKext.unloadUnsupported__b20.meta=4
-struct._OSKext.unloadUnsupported__b20.@.bitoff=20
-struct._OSKext.dextToReplace__b21=int,120,1
-struct._OSKext.dextToReplace__b21.meta=4
-struct._OSKext.dextToReplace__b21.@.bitoff=21
-struct._OSKext.unslidMachO__b22=int,120,1
-struct._OSKext.unslidMachO__b22.meta=4
-struct._OSKext.unslidMachO__b22.@.bitoff=22
-struct._OSKext.matchingRefCount=uint32_t,124,0
-struct._OSKext.matchingRefCount.meta=4
-struct._OSKext.kc_type=void *,128,0
-struct._OSKext.kc_type.meta=8
-struct._OSKext.pendingPgoHead=struct.list_head,136,0
-struct._OSKext.pendingPgoHead.meta=16
-struct._OSKext.instance_uuid=char,152,0
-struct._OSKext.instance_uuid.meta=1
-struct._OSKext.account=void *,160,0
-struct._OSKext.account.meta=8
-struct._OSKext.builtinKmodIdx=uint32_t,168,0
-struct._OSKext.builtinKmodIdx.meta=4
-struct._OSKext.savedMutableSegments=void *,176,0
-struct._OSKext.savedMutableSegments.meta=8
-struct._OSKext.dextStatistics=void *,184,0
-struct._OSKext.dextStatistics.meta=8
-struct._OSKext.dextUniqueID=void *,192,0
-struct._OSKext.dextUniqueID.meta=8
-struct._OSKext.dextLaunchedCount=uint32_t,200,0
-struct._OSKext.dextLaunchedCount.meta=4
-
-_OSKextAccount=struct
-struct._OSKextAccount=site,loadTag,kext
-struct._OSKextAccount.site=void *,0,0
-struct._OSKextAccount.site.meta=8
-struct._OSKextAccount.loadTag=uint32_t,8,0
-struct._OSKextAccount.loadTag.meta=4
-struct._OSKextAccount.kext=void *,16,0
-struct._OSKextAccount.kext.meta=8
-
-_OSKextSavedMutableSegment=struct
-struct._OSKextSavedMutableSegment=parent,savedSegment,vmaddr,vmsize,data
-struct._OSKextSavedMutableSegment.parent=struct._OSObject,0,0
-struct._OSKextSavedMutableSegment.parent.meta=4
-struct._OSKextSavedMutableSegment.savedSegment=void *,8,0
-struct._OSKextSavedMutableSegment.savedSegment.meta=8
-struct._OSKextSavedMutableSegment.vmaddr=LONG,16,0
-struct._OSKextSavedMutableSegment.vmaddr.meta=8
-struct._OSKextSavedMutableSegment.vmsize=LONG,24,0
-struct._OSKextSavedMutableSegment.vmsize.meta=8
-struct._OSKextSavedMutableSegment.data=void *,32,0
-struct._OSKextSavedMutableSegment.data.meta=8
-
-_OSMetaClass=struct
-struct._OSMetaClass=parent,reserved,superClassLink,className,classSize,instanceCount
-struct._OSMetaClass.parent=struct._OSMetaClassBase,0,0
-struct._OSMetaClass.parent.meta=0
-struct._OSMetaClass.reserved=void *,0,0
-struct._OSMetaClass.reserved.meta=8
-struct._OSMetaClass.superClassLink=void *,8,0
-struct._OSMetaClass.superClassLink.meta=8
-struct._OSMetaClass.className=void *,16,0
-struct._OSMetaClass.className.meta=8
-struct._OSMetaClass.classSize=unsigned int,24,0
-struct._OSMetaClass.classSize.meta=4
-struct._OSMetaClass.instanceCount=unsigned int,28,0
-struct._OSMetaClass.instanceCount.meta=4
-
-_OSMetaClassBase=struct
-struct._OSMetaClassBase=
-
-_OSNumber=struct
-struct._OSNumber=parent,size,value,fpValue
-struct._OSNumber.parent=struct._OSObject,0,0
-struct._OSNumber.parent.meta=4
-struct._OSNumber.size=unsigned int,4,0
-struct._OSNumber.size.meta=4
-struct._OSNumber.value=unsigned long long,8,0
-struct._OSNumber.value.meta=8
-struct._OSNumber.fpValue=double,16,0
-struct._OSNumber.fpValue.meta=8
-
-_OSObject=struct
-struct._OSObject=parent,retainCount
-struct._OSObject.parent=struct._OSMetaClassBase,0,0
-struct._OSObject.parent.meta=0
-struct._OSObject.retainCount=int,0,0
-struct._OSObject.retainCount.meta=4
-
-_OSObjectUserVars=struct
-struct._OSObjectUserVars=userServer,queueArray,userMeta,openProviders,controllingDriver,willPowerState,willTerminate,didTerminate,serverDied,started,stopped,userServerPM,willPower,powerState,resetPowerOnWake,deferredRegisterService,powerOverride,uvarsLock
-struct._OSObjectUserVars.userServer=void *,0,0
-struct._OSObjectUserVars.userServer.meta=8
-struct._OSObjectUserVars.queueArray=void *,8,0
-struct._OSObjectUserVars.queueArray.meta=8
-struct._OSObjectUserVars.userMeta=void *,16,0
-struct._OSObjectUserVars.userMeta.meta=8
-struct._OSObjectUserVars.openProviders=void *,24,0
-struct._OSObjectUserVars.openProviders.meta=8
-struct._OSObjectUserVars.controllingDriver=void *,32,0
-struct._OSObjectUserVars.controllingDriver.meta=8
-struct._OSObjectUserVars.willPowerState=LONGU,40,0
-struct._OSObjectUserVars.willPowerState.meta=8
-struct._OSObjectUserVars.willTerminate=bool,48,0
-struct._OSObjectUserVars.willTerminate.meta=1
-struct._OSObjectUserVars.didTerminate=bool,49,0
-struct._OSObjectUserVars.didTerminate.meta=1
-struct._OSObjectUserVars.serverDied=bool,50,0
-struct._OSObjectUserVars.serverDied.meta=1
-struct._OSObjectUserVars.started=bool,51,0
-struct._OSObjectUserVars.started.meta=1
-struct._OSObjectUserVars.stopped=bool,52,0
-struct._OSObjectUserVars.stopped.meta=1
-struct._OSObjectUserVars.userServerPM=bool,53,0
-struct._OSObjectUserVars.userServerPM.meta=1
-struct._OSObjectUserVars.willPower=bool,54,0
-struct._OSObjectUserVars.willPower.meta=1
-struct._OSObjectUserVars.powerState=bool,55,0
-struct._OSObjectUserVars.powerState.meta=1
-struct._OSObjectUserVars.resetPowerOnWake=bool,56,0
-struct._OSObjectUserVars.resetPowerOnWake.meta=1
-struct._OSObjectUserVars.deferredRegisterService=bool,57,0
-struct._OSObjectUserVars.deferredRegisterService.meta=1
-struct._OSObjectUserVars.powerOverride=uint32_t,60,0
-struct._OSObjectUserVars.powerOverride.meta=4
-struct._OSObjectUserVars.uvarsLock=void *,64,0
-struct._OSObjectUserVars.uvarsLock.meta=8
-
-_OSOrderedSet=struct
-struct._OSOrderedSet=parent,array,ordering,orderingRef,count,capacity,capacityIncrement,reserved
-struct._OSOrderedSet.parent=struct._OSCollection,0,0
-struct._OSOrderedSet.parent.meta=12
-struct._OSOrderedSet.array=void *,16,0
-struct._OSOrderedSet.array.meta=8
-struct._OSOrderedSet.ordering=void *,24,0
-struct._OSOrderedSet.ordering.meta=8
-struct._OSOrderedSet.orderingRef=void *,32,0
-struct._OSOrderedSet.orderingRef.meta=8
-struct._OSOrderedSet.count=unsigned int,40,0
-struct._OSOrderedSet.count.meta=4
-struct._OSOrderedSet.capacity=unsigned int,44,0
-struct._OSOrderedSet.capacity.meta=4
-struct._OSOrderedSet.capacityIncrement=unsigned int,48,0
-struct._OSOrderedSet.capacityIncrement.meta=4
-struct._OSOrderedSet.reserved=void *,56,0
-struct._OSOrderedSet.reserved.meta=8
-
-_OSOrderedSet::ExpansionData=struct
-struct._OSOrderedSet::ExpansionData=
-
-_OSSerialize=struct
-struct._OSSerialize=parent,data,length,capacity,capacityIncrement,tags,binary,endCollection,editor,editRef,indexData
-struct._OSSerialize.parent=struct._OSObject,0,0
-struct._OSSerialize.parent.meta=4
-struct._OSSerialize.data=void *,8,0
-struct._OSSerialize.data.meta=8
-struct._OSSerialize.length=unsigned int,16,0
-struct._OSSerialize.length.meta=4
-struct._OSSerialize.capacity=unsigned int,20,0
-struct._OSSerialize.capacity.meta=4
-struct._OSSerialize.capacityIncrement=unsigned int,24,0
-struct._OSSerialize.capacityIncrement.meta=4
-struct._OSSerialize.tags=void *,32,0
-struct._OSSerialize.tags.meta=8
-struct._OSSerialize.binary=bool,40,0
-struct._OSSerialize.binary.meta=1
-struct._OSSerialize.endCollection=bool,41,0
-struct._OSSerialize.endCollection.meta=1
-struct._OSSerialize.editor=void *,48,0
-struct._OSSerialize.editor.meta=8
-struct._OSSerialize.editRef=void *,56,0
-struct._OSSerialize.editRef.meta=8
-struct._OSSerialize.indexData=void *,64,0
-struct._OSSerialize.indexData.meta=8
-
-_OSSerializer=struct
-struct._OSSerializer=parent,target,ref,callback
-struct._OSSerializer.parent=struct._OSObject,0,0
-struct._OSSerializer.parent.meta=4
-struct._OSSerializer.target=void *,8,0
-struct._OSSerializer.target.meta=8
-struct._OSSerializer.ref=void *,16,0
-struct._OSSerializer.ref.meta=8
-struct._OSSerializer.callback=void *,24,0
-struct._OSSerializer.callback.meta=8
-
-_OSSet=struct
-struct._OSSet=parent,members
-struct._OSSet.parent=struct._OSCollection,0,0
-struct._OSSet.parent.meta=12
-struct._OSSet.members=void *,16,0
-struct._OSSet.members.meta=8
-
-_OSSharedPtr=struct
-struct._OSSharedPtr=
-
-_OSString=struct
-struct._OSString=parent,flags__b0,length__b14,string
-struct._OSString.parent=struct._OSObject,0,0
-struct._OSString.parent.meta=4
-struct._OSString.flags__b0=int,4,14
-struct._OSString.flags__b0.meta=4
-struct._OSString.flags__b0.@.bitoff=0
-struct._OSString.length__b14=int,4,18
-struct._OSString.length__b14.meta=4
-struct._OSString.length__b14.@.bitoff=14
-struct._OSString.string=void *,8,0
-struct._OSString.string.meta=8
-
-_OSSymbol=struct
-struct._OSSymbol=parent,hashlink
-struct._OSSymbol.parent=struct._OSString,0,0
-struct._OSSymbol.parent.meta=16
-struct._OSSymbol.hashlink=struct.smrq_slink,16,0
-struct._OSSymbol.hashlink.meta=8
-
-_OSValueObject=struct
-struct._OSValueObject=parent,data
-struct._OSValueObject.parent=struct._OSObject,0,0
-struct._OSValueObject.parent.meta=4
-struct._OSValueObject.data=void *,8,0
-struct._OSValueObject.data.meta=8
-
-_PE_Video=struct
-struct._PE_Video=v_baseAddr,v_rowBytes,v_width,v_height,v_depth,v_display,v_pixelFormat,v_offset,v_length,v_rotate,v_scale,reserved1,reserved2
-struct._PE_Video.v_baseAddr=LONGU,0,0
-struct._PE_Video.v_baseAddr.meta=8
-struct._PE_Video.v_rowBytes=LONGU,8,0
-struct._PE_Video.v_rowBytes.meta=8
-struct._PE_Video.v_width=LONGU,16,0
-struct._PE_Video.v_width.meta=8
-struct._PE_Video.v_height=LONGU,24,0
-struct._PE_Video.v_height.meta=8
-struct._PE_Video.v_depth=LONGU,32,0
-struct._PE_Video.v_depth.meta=8
-struct._PE_Video.v_display=LONGU,40,0
-struct._PE_Video.v_display.meta=8
-struct._PE_Video.v_pixelFormat=char,48,64
-struct._PE_Video.v_pixelFormat.meta=1
-struct._PE_Video.v_offset=LONGU,112,0
-struct._PE_Video.v_offset.meta=8
-struct._PE_Video.v_length=LONGU,120,0
-struct._PE_Video.v_length.meta=8
-struct._PE_Video.v_rotate=unsigned char,128,0
-struct._PE_Video.v_rotate.meta=1
-struct._PE_Video.v_scale=unsigned char,129,0
-struct._PE_Video.v_scale.meta=1
-struct._PE_Video.reserved1=char,130,2
-struct._PE_Video.reserved1.meta=1
-struct._PE_Video.reserved2=LONG,136,0
-struct._PE_Video.reserved2.meta=8
-
-_PassthruInterruptController=struct
-struct._PassthruInterruptController=parent,child_handler,child_target,child_refCon,child_nub,child_sentinel
-struct._PassthruInterruptController.parent=struct._IOInterruptController,0,0
-struct._PassthruInterruptController.parent.meta=152
-struct._PassthruInterruptController.child_handler=void *,152,0
-struct._PassthruInterruptController.child_handler.meta=8
-struct._PassthruInterruptController.child_target=void *,160,0
-struct._PassthruInterruptController.child_target.meta=8
-struct._PassthruInterruptController.child_refCon=void *,168,0
-struct._PassthruInterruptController.child_refCon.meta=8
-struct._PassthruInterruptController.child_nub=void *,176,0
-struct._PassthruInterruptController.child_nub.meta=8
-struct._PassthruInterruptController.child_sentinel=void *,184,0
-struct._PassthruInterruptController.child_sentinel.meta=8
-
-__IOUserServerCheckInCancellationHandler=struct
-struct.__IOUserServerCheckInCancellationHandler=parent,fHandler,fHandlerArgs
-struct.__IOUserServerCheckInCancellationHandler.parent=struct._OSObject,0,0
-struct.__IOUserServerCheckInCancellationHandler.parent.meta=4
-struct.__IOUserServerCheckInCancellationHandler.fHandler=void *,8,0
-struct.__IOUserServerCheckInCancellationHandler.fHandler.meta=8
-struct.__IOUserServerCheckInCancellationHandler.fHandlerArgs=void *,16,0
-struct.__IOUserServerCheckInCancellationHandler.fHandlerArgs.meta=8
-
-_intrusive_osobject_retainer=struct
-struct._intrusive_osobject_retainer=
-
-_list_head=struct
-struct._list_head=prev,next
-struct._list_head.prev=void *,0,0
-struct._list_head.prev.meta=8
-struct._list_head.next=void *,8,0
-struct._list_head.next.meta=8
-
-_smrq_slink=struct
-struct._smrq_slink=next
-struct._smrq_slink.next=void *,0,0
-struct._smrq_slink.next.meta=8
+_IOUserServerCheckInCancellationHandler::MetaClass_VTable=struct
+struct._IOUserServerCheckInCancellationHandler::MetaClass_VTable=parent
+struct._IOUserServerCheckInCancellationHandler::MetaClass_VTable.parent=struct.OSMetaClass_VTable,0,0
+struct._IOUserServerCheckInCancellationHandler::MetaClass_VTable.parent.meta=112
+
+IOBigMemoryCursor_Data=struct
+struct.IOBigMemoryCursor_Data=data
+struct.IOBigMemoryCursor_Data.data=struct.IOMemoryCursor_Data,0,0
+struct.IOBigMemoryCursor_Data.data.meta=40
+
+IOBufferMemoryDescriptor_Data=struct
+struct.IOBufferMemoryDescriptor_Data=data,reserved,_buffer,_capacity,_alignment,_options,_internalReserved,_internalFlags
+struct.IOBufferMemoryDescriptor_Data.data=struct.IOGeneralMemoryDescriptor_Data,0,0
+struct.IOBufferMemoryDescriptor_Data.data.meta=168
+struct.IOBufferMemoryDescriptor_Data.reserved=void *,168,0
+struct.IOBufferMemoryDescriptor_Data.reserved.meta=8
+struct.IOBufferMemoryDescriptor_Data._buffer=void *,176,0
+struct.IOBufferMemoryDescriptor_Data._buffer.meta=8
+struct.IOBufferMemoryDescriptor_Data._capacity=LONG,184,0
+struct.IOBufferMemoryDescriptor_Data._capacity.meta=8
+struct.IOBufferMemoryDescriptor_Data._alignment=LONG,192,0
+struct.IOBufferMemoryDescriptor_Data._alignment.meta=8
+struct.IOBufferMemoryDescriptor_Data._options=int,200,0
+struct.IOBufferMemoryDescriptor_Data._options.meta=4
+struct.IOBufferMemoryDescriptor_Data._internalReserved=uintptr_t,208,0
+struct.IOBufferMemoryDescriptor_Data._internalReserved.meta=8
+struct.IOBufferMemoryDescriptor_Data._internalFlags=unsigned int,216,0
+struct.IOBufferMemoryDescriptor_Data._internalFlags.meta=4
+
+IOCPU_Data=struct
+struct.IOCPU_Data=data,_cpuGroup,_cpuNumber,_cpuState,cpuNub,machProcessor,ipi_handler,iocpu_reserved
+struct.IOCPU_Data.data=struct.IOService_Data,0,0
+struct.IOCPU_Data.data.meta=128
+struct.IOCPU_Data._cpuGroup=void *,128,0
+struct.IOCPU_Data._cpuGroup.meta=8
+struct.IOCPU_Data._cpuNumber=int,136,0
+struct.IOCPU_Data._cpuNumber.meta=4
+struct.IOCPU_Data._cpuState=int,140,0
+struct.IOCPU_Data._cpuState.meta=4
+struct.IOCPU_Data.cpuNub=void *,144,0
+struct.IOCPU_Data.cpuNub.meta=8
+struct.IOCPU_Data.machProcessor=void *,152,0
+struct.IOCPU_Data.machProcessor.meta=8
+struct.IOCPU_Data.ipi_handler=void *,160,0
+struct.IOCPU_Data.ipi_handler.meta=8
+struct.IOCPU_Data.iocpu_reserved=void *,168,0
+struct.IOCPU_Data.iocpu_reserved.meta=8
+
+IOCPUInterruptController_Data=struct
+struct.IOCPUInterruptController_Data=data,enabledCPUs,numCPUs,numSources,iocpuic_reserved
+struct.IOCPUInterruptController_Data.data=struct.IOInterruptController_Data,0,0
+struct.IOCPUInterruptController_Data.data.meta=152
+struct.IOCPUInterruptController_Data.enabledCPUs=int,152,0
+struct.IOCPUInterruptController_Data.enabledCPUs.meta=4
+struct.IOCPUInterruptController_Data.numCPUs=int,156,0
+struct.IOCPUInterruptController_Data.numCPUs.meta=4
+struct.IOCPUInterruptController_Data.numSources=int,160,0
+struct.IOCPUInterruptController_Data.numSources.meta=4
+struct.IOCPUInterruptController_Data.iocpuic_reserved=void *,168,0
+struct.IOCPUInterruptController_Data.iocpuic_reserved.meta=8
+
+IOCatalogue_Data=struct
+struct.IOCatalogue_Data=data,lock,generation,personalities
+struct.IOCatalogue_Data.data=struct.OSObject_Data,0,0
+struct.IOCatalogue_Data.data.meta=4
+struct.IOCatalogue_Data.lock=void *,8,0
+struct.IOCatalogue_Data.lock.meta=8
+struct.IOCatalogue_Data.generation=int,16,0
+struct.IOCatalogue_Data.generation.meta=4
+struct.IOCatalogue_Data.personalities=void *,24,0
+struct.IOCatalogue_Data.personalities.meta=8
+
+IOCommand_Data=struct
+struct.IOCommand_Data=data,fCommandChain
+struct.IOCommand_Data.data=struct.OSObject_Data,0,0
+struct.IOCommand_Data.data.meta=4
+struct.IOCommand_Data.fCommandChain=void *,8,0
+struct.IOCommand_Data.fCommandChain.meta=8
+
+IOCommandGate_Data=struct
+struct.IOCommandGate_Data=data,reserved
+struct.IOCommandGate_Data.data=struct.IOEventSource_Data,0,0
+struct.IOCommandGate_Data.data.meta=72
+struct.IOCommandGate_Data.reserved=void *,72,0
+struct.IOCommandGate_Data.reserved.meta=8
+
+IOCommandPool_Data=struct
+struct.IOCommandPool_Data=data,fQueueHead,fSleepers,fSerializer,reserved
+struct.IOCommandPool_Data.data=struct.OSObject_Data,0,0
+struct.IOCommandPool_Data.data.meta=4
+struct.IOCommandPool_Data.fQueueHead=void *,8,0
+struct.IOCommandPool_Data.fQueueHead.meta=8
+struct.IOCommandPool_Data.fSleepers=int,16,0
+struct.IOCommandPool_Data.fSleepers.meta=4
+struct.IOCommandPool_Data.fSerializer=void *,24,0
+struct.IOCommandPool_Data.fSerializer.meta=8
+struct.IOCommandPool_Data.reserved=void *,32,0
+struct.IOCommandPool_Data.reserved.meta=8
+
+IOConditionLock_Data=struct
+struct.IOConditionLock_Data=data,cond_interlock,condition,sleep_interlock,interruptible,want_lock,waiting
+struct.IOConditionLock_Data.data=struct.OSObject_Data,0,0
+struct.IOConditionLock_Data.data.meta=4
+struct.IOConditionLock_Data.cond_interlock=void *,8,0
+struct.IOConditionLock_Data.cond_interlock.meta=8
+struct.IOConditionLock_Data.condition=int,16,0
+struct.IOConditionLock_Data.condition.meta=4
+struct.IOConditionLock_Data.sleep_interlock=void *,24,0
+struct.IOConditionLock_Data.sleep_interlock.meta=8
+struct.IOConditionLock_Data.interruptible=unsigned char,32,0
+struct.IOConditionLock_Data.interruptible.meta=1
+struct.IOConditionLock_Data.want_lock=bool,33,0
+struct.IOConditionLock_Data.want_lock.meta=1
+struct.IOConditionLock_Data.waiting=bool,34,0
+struct.IOConditionLock_Data.waiting.meta=1
+
+IODMACommand_Data=struct
+struct.IODMACommand_Data=data,fRefCon,fMaxSegmentSize,fMaxTransferSize,fAlignMaskLength,fAlignMaskInternalSegments,fMapper,fMemory,fOutSeg,fAlignMask,fNumAddressBits,fNumSegments,fMappingOptions,fActive,reserved
+struct.IODMACommand_Data.data=struct.IOCommand_Data,0,0
+struct.IODMACommand_Data.data.meta=16
+struct.IODMACommand_Data.fRefCon=void *,16,0
+struct.IODMACommand_Data.fRefCon.meta=8
+struct.IODMACommand_Data.fMaxSegmentSize=LONG,24,0
+struct.IODMACommand_Data.fMaxSegmentSize.meta=8
+struct.IODMACommand_Data.fMaxTransferSize=LONG,32,0
+struct.IODMACommand_Data.fMaxTransferSize.meta=8
+struct.IODMACommand_Data.fAlignMaskLength=int,40,0
+struct.IODMACommand_Data.fAlignMaskLength.meta=4
+struct.IODMACommand_Data.fAlignMaskInternalSegments=int,44,0
+struct.IODMACommand_Data.fAlignMaskInternalSegments.meta=4
+struct.IODMACommand_Data.fMapper=void *,48,0
+struct.IODMACommand_Data.fMapper.meta=8
+struct.IODMACommand_Data.fMemory=void *,56,0
+struct.IODMACommand_Data.fMemory.meta=8
+struct.IODMACommand_Data.fOutSeg=void *,64,0
+struct.IODMACommand_Data.fOutSeg.meta=8
+struct.IODMACommand_Data.fAlignMask=int,72,0
+struct.IODMACommand_Data.fAlignMask.meta=4
+struct.IODMACommand_Data.fNumAddressBits=int,76,0
+struct.IODMACommand_Data.fNumAddressBits.meta=4
+struct.IODMACommand_Data.fNumSegments=int,80,0
+struct.IODMACommand_Data.fNumSegments.meta=4
+struct.IODMACommand_Data.fMappingOptions=uint32_t,84,0
+struct.IODMACommand_Data.fMappingOptions.meta=4
+struct.IODMACommand_Data.fActive=int,88,0
+struct.IODMACommand_Data.fActive.meta=4
+struct.IODMACommand_Data.reserved=void *,96,0
+struct.IODMACommand_Data.reserved.meta=8
+
+IODMAController_Data=struct
+struct.IODMAController_Data=data,_provider,_dmaControllerName
+struct.IODMAController_Data.data=struct.IOService_Data,0,0
+struct.IODMAController_Data.data.meta=128
+struct.IODMAController_Data._provider=void *,128,0
+struct.IODMAController_Data._provider.meta=8
+struct.IODMAController_Data._dmaControllerName=void *,136,0
+struct.IODMAController_Data._dmaControllerName.meta=8
+
+IODMAEventSource_Data=struct
+struct.IODMAEventSource_Data=data,dmaProvider,dmaController,dmaIndex,dmaCommandsCompleted,dmaCommandsCompletedLock,dmaCompletionAction,dmaNotificationAction,dmaSynchBusy
+struct.IODMAEventSource_Data.data=struct.IOEventSource_Data,0,0
+struct.IODMAEventSource_Data.data.meta=72
+struct.IODMAEventSource_Data.dmaProvider=void *,72,0
+struct.IODMAEventSource_Data.dmaProvider.meta=8
+struct.IODMAEventSource_Data.dmaController=void *,80,0
+struct.IODMAEventSource_Data.dmaController.meta=8
+struct.IODMAEventSource_Data.dmaIndex=int,88,0
+struct.IODMAEventSource_Data.dmaIndex.meta=4
+struct.IODMAEventSource_Data.dmaCommandsCompleted=void *,96,0
+struct.IODMAEventSource_Data.dmaCommandsCompleted.meta=8
+struct.IODMAEventSource_Data.dmaCommandsCompletedLock=void *,104,0
+struct.IODMAEventSource_Data.dmaCommandsCompletedLock.meta=8
+struct.IODMAEventSource_Data.dmaCompletionAction=void *,112,0
+struct.IODMAEventSource_Data.dmaCompletionAction.meta=8
+struct.IODMAEventSource_Data.dmaNotificationAction=void *,120,0
+struct.IODMAEventSource_Data.dmaNotificationAction.meta=8
+struct.IODMAEventSource_Data.dmaSynchBusy=bool,128,0
+struct.IODMAEventSource_Data.dmaSynchBusy.meta=1
+
+IODTNVRAM_Data=struct
+struct.IODTNVRAM_Data=data,_notifier,_diags,_format,_commonService,_systemService,_lastDeviceSync,_freshInterval,x86Device
+struct.IODTNVRAM_Data.data=struct.IOService_Data,0,0
+struct.IODTNVRAM_Data.data.meta=128
+struct.IODTNVRAM_Data._notifier=void *,128,0
+struct.IODTNVRAM_Data._notifier.meta=8
+struct.IODTNVRAM_Data._diags=void *,136,0
+struct.IODTNVRAM_Data._diags.meta=8
+struct.IODTNVRAM_Data._format=void *,144,0
+struct.IODTNVRAM_Data._format.meta=8
+struct.IODTNVRAM_Data._commonService=void *,152,0
+struct.IODTNVRAM_Data._commonService.meta=8
+struct.IODTNVRAM_Data._systemService=void *,160,0
+struct.IODTNVRAM_Data._systemService.meta=8
+struct.IODTNVRAM_Data._lastDeviceSync=int,168,0
+struct.IODTNVRAM_Data._lastDeviceSync.meta=4
+struct.IODTNVRAM_Data._freshInterval=bool,172,0
+struct.IODTNVRAM_Data._freshInterval.meta=1
+struct.IODTNVRAM_Data.x86Device=bool,173,0
+struct.IODTNVRAM_Data.x86Device.meta=1
+
+IODTPlatformExpert_Data=struct
+struct.IODTPlatformExpert_Data=data,dtNVRAM,iodtpe_reserved
+struct.IODTPlatformExpert_Data.data=struct.IOPlatformExpert_Data,0,0
+struct.IODTPlatformExpert_Data.data.meta=216
+struct.IODTPlatformExpert_Data.dtNVRAM=void *,216,0
+struct.IODTPlatformExpert_Data.dtNVRAM.meta=8
+struct.IODTPlatformExpert_Data.iodtpe_reserved=void *,224,0
+struct.IODTPlatformExpert_Data.iodtpe_reserved.meta=8
+
+IODataQueue_Data=struct
+struct.IODataQueue_Data=data,dataQueue,notifyMsg
+struct.IODataQueue_Data.data=struct.OSObject_Data,0,0
+struct.IODataQueue_Data.data.meta=4
+struct.IODataQueue_Data.dataQueue=void *,8,0
+struct.IODataQueue_Data.dataQueue.meta=8
+struct.IODataQueue_Data.notifyMsg=void *,16,0
+struct.IODataQueue_Data.notifyMsg.meta=8
+
+IODeviceMemory_Data=struct
+struct.IODeviceMemory_Data=data
+struct.IODeviceMemory_Data.data=struct.IOMemoryDescriptor_Data,0,0
+struct.IODeviceMemory_Data.data.meta=88
+
+IODispatchQueue_Data=struct
+struct.IODispatchQueue_Data=data,ivars,lvars
+struct.IODispatchQueue_Data.data=struct.OSObject_Data,0,0
+struct.IODispatchQueue_Data.data.meta=4
+struct.IODispatchQueue_Data.ivars=void *,8,0
+struct.IODispatchQueue_Data.ivars.meta=8
+struct.IODispatchQueue_Data.lvars=void *,16,0
+struct.IODispatchQueue_Data.lvars.meta=8
+
+IODispatchSource_Data=struct
+struct.IODispatchSource_Data=data,ivars,lvars
+struct.IODispatchSource_Data.data=struct.OSObject_Data,0,0
+struct.IODispatchSource_Data.data.meta=4
+struct.IODispatchSource_Data.ivars=void *,8,0
+struct.IODispatchSource_Data.ivars.meta=8
+struct.IODispatchSource_Data.lvars=void *,16,0
+struct.IODispatchSource_Data.lvars.meta=8
+
+IOEventLink_Data=struct
+struct.IOEventLink_Data=data,ivars,lvars
+struct.IOEventLink_Data.data=struct.OSObject_Data,0,0
+struct.IOEventLink_Data.data.meta=4
+struct.IOEventLink_Data.ivars=void *,8,0
+struct.IOEventLink_Data.ivars.meta=8
+struct.IOEventLink_Data.lvars=void *,16,0
+struct.IOEventLink_Data.lvars.meta=8
+
+IOEventSource_Data=struct
+struct.IOEventSource_Data=data,eventChainNext,owner,action,actionBlock,enabled,eventSourceReserved1,flags,eventSourceReserved2,workLoop,refcon,reserved
+struct.IOEventSource_Data.data=struct.OSObject_Data,0,0
+struct.IOEventSource_Data.data.meta=4
+struct.IOEventSource_Data.eventChainNext=void *,8,0
+struct.IOEventSource_Data.eventChainNext.meta=8
+struct.IOEventSource_Data.owner=void *,16,0
+struct.IOEventSource_Data.owner.meta=8
+struct.IOEventSource_Data.action=void *,24,0
+struct.IOEventSource_Data.action.meta=8
+struct.IOEventSource_Data.actionBlock=void *,32,0
+struct.IOEventSource_Data.actionBlock.meta=8
+struct.IOEventSource_Data.enabled=bool,40,0
+struct.IOEventSource_Data.enabled.meta=1
+struct.IOEventSource_Data.eventSourceReserved1=uint8_t,41,1
+struct.IOEventSource_Data.eventSourceReserved1.meta=1
+struct.IOEventSource_Data.flags=uint16_t,42,0
+struct.IOEventSource_Data.flags.meta=2
+struct.IOEventSource_Data.eventSourceReserved2=uint8_t,44,4
+struct.IOEventSource_Data.eventSourceReserved2.meta=1
+struct.IOEventSource_Data.workLoop=void *,48,0
+struct.IOEventSource_Data.workLoop.meta=8
+struct.IOEventSource_Data.refcon=void *,56,0
+struct.IOEventSource_Data.refcon.meta=8
+struct.IOEventSource_Data.reserved=void *,64,0
+struct.IOEventSource_Data.reserved.meta=8
+
+IOExtensiblePaniclog_Data=struct
+struct.IOExtensiblePaniclog_Data=data,extPaniclogHandle,iomd
+struct.IOExtensiblePaniclog_Data.data=struct.OSObject_Data,0,0
+struct.IOExtensiblePaniclog_Data.data.meta=4
+struct.IOExtensiblePaniclog_Data.extPaniclogHandle=void *,8,0
+struct.IOExtensiblePaniclog_Data.extPaniclogHandle.meta=8
+struct.IOExtensiblePaniclog_Data.iomd=void *,16,0
+struct.IOExtensiblePaniclog_Data.iomd.meta=8
+
+IOFilterInterruptEventSource_Data=struct
+struct.IOFilterInterruptEventSource_Data=data,filterAction,filterActionBlock,reserved
+struct.IOFilterInterruptEventSource_Data.data=struct.IOInterruptEventSource_Data,0,0
+struct.IOFilterInterruptEventSource_Data.data.meta=104
+struct.IOFilterInterruptEventSource_Data.filterAction=void *,104,0
+struct.IOFilterInterruptEventSource_Data.filterAction.meta=8
+struct.IOFilterInterruptEventSource_Data.filterActionBlock=void *,112,0
+struct.IOFilterInterruptEventSource_Data.filterActionBlock.meta=8
+struct.IOFilterInterruptEventSource_Data.reserved=void *,120,0
+struct.IOFilterInterruptEventSource_Data.reserved.meta=8
+
+IOGeneralMemoryDescriptor_Data=struct
+struct.IOGeneralMemoryDescriptor_Data=data,_ranges,_rangesCount,_task,v,p,_wireCount,_initialized,_memoryEntries,_pages,_highestPage,__iomd_reservedA,__iomd_reservedB,_prepareLock
+struct.IOGeneralMemoryDescriptor_Data.data=struct.IOMemoryDescriptor_Data,0,0
+struct.IOGeneralMemoryDescriptor_Data.data.meta=88
+struct.IOGeneralMemoryDescriptor_Data._ranges=void *,88,0
+struct.IOGeneralMemoryDescriptor_Data._ranges.meta=8
+struct.IOGeneralMemoryDescriptor_Data._rangesCount=unsigned int,96,0
+struct.IOGeneralMemoryDescriptor_Data._rangesCount.meta=4
+struct.IOGeneralMemoryDescriptor_Data._task=void *,104,0
+struct.IOGeneralMemoryDescriptor_Data._task.meta=8
+struct.IOGeneralMemoryDescriptor_Data.v=void *,112,0
+struct.IOGeneralMemoryDescriptor_Data.v.meta=8
+struct.IOGeneralMemoryDescriptor_Data.p=void *,120,0
+struct.IOGeneralMemoryDescriptor_Data.p.meta=8
+struct.IOGeneralMemoryDescriptor_Data._wireCount=unsigned int,128,0
+struct.IOGeneralMemoryDescriptor_Data._wireCount.meta=4
+struct.IOGeneralMemoryDescriptor_Data._initialized=bool,132,0
+struct.IOGeneralMemoryDescriptor_Data._initialized.meta=1
+struct.IOGeneralMemoryDescriptor_Data._memoryEntries=void *,136,0
+struct.IOGeneralMemoryDescriptor_Data._memoryEntries.meta=8
+struct.IOGeneralMemoryDescriptor_Data._pages=unsigned int,144,0
+struct.IOGeneralMemoryDescriptor_Data._pages.meta=4
+struct.IOGeneralMemoryDescriptor_Data._highestPage=int,148,0
+struct.IOGeneralMemoryDescriptor_Data._highestPage.meta=4
+struct.IOGeneralMemoryDescriptor_Data.__iomd_reservedA=uint32_t,152,0
+struct.IOGeneralMemoryDescriptor_Data.__iomd_reservedA.meta=4
+struct.IOGeneralMemoryDescriptor_Data.__iomd_reservedB=uint32_t,156,0
+struct.IOGeneralMemoryDescriptor_Data.__iomd_reservedB.meta=4
+struct.IOGeneralMemoryDescriptor_Data._prepareLock=void *,160,0
+struct.IOGeneralMemoryDescriptor_Data._prepareLock.meta=8
+
+IOGuardPageMemoryDescriptor_Data=struct
+struct.IOGuardPageMemoryDescriptor_Data=data,_buffer,_size
+struct.IOGuardPageMemoryDescriptor_Data.data=struct.IOGeneralMemoryDescriptor_Data,0,0
+struct.IOGuardPageMemoryDescriptor_Data.data.meta=168
+struct.IOGuardPageMemoryDescriptor_Data._buffer=LONG,168,0
+struct.IOGuardPageMemoryDescriptor_Data._buffer.meta=8
+struct.IOGuardPageMemoryDescriptor_Data._size=LONG,176,0
+struct.IOGuardPageMemoryDescriptor_Data._size.meta=8
+
+IOHistogramReporter_Data=struct
+struct.IOHistogramReporter_Data=data,_segmentCount,_bucketBounds,_bucketCount,_histogramSegmentsConfig
+struct.IOHistogramReporter_Data.data=struct.IOReporter_Data,0,0
+struct.IOHistogramReporter_Data.data.meta=128
+struct.IOHistogramReporter_Data._segmentCount=int,128,0
+struct.IOHistogramReporter_Data._segmentCount.meta=4
+struct.IOHistogramReporter_Data._bucketBounds=void *,136,0
+struct.IOHistogramReporter_Data._bucketBounds.meta=8
+struct.IOHistogramReporter_Data._bucketCount=int,144,0
+struct.IOHistogramReporter_Data._bucketCount.meta=4
+struct.IOHistogramReporter_Data._histogramSegmentsConfig=void *,152,0
+struct.IOHistogramReporter_Data._histogramSegmentsConfig.meta=8
+
+IOInterleavedMemoryDescriptor_Data=struct
+struct.IOInterleavedMemoryDescriptor_Data=data,_descriptorCapacity,_descriptorCount,_descriptors,_descriptorOffsets,_descriptorLengths,_descriptorPrepared
+struct.IOInterleavedMemoryDescriptor_Data.data=struct.IOMemoryDescriptor_Data,0,0
+struct.IOInterleavedMemoryDescriptor_Data.data.meta=88
+struct.IOInterleavedMemoryDescriptor_Data._descriptorCapacity=LONG,88,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptorCapacity.meta=8
+struct.IOInterleavedMemoryDescriptor_Data._descriptorCount=int,96,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptorCount.meta=4
+struct.IOInterleavedMemoryDescriptor_Data._descriptors=void *,104,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptors.meta=8
+struct.IOInterleavedMemoryDescriptor_Data._descriptorOffsets=void *,112,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptorOffsets.meta=8
+struct.IOInterleavedMemoryDescriptor_Data._descriptorLengths=void *,120,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptorLengths.meta=8
+struct.IOInterleavedMemoryDescriptor_Data._descriptorPrepared=bool,128,0
+struct.IOInterleavedMemoryDescriptor_Data._descriptorPrepared.meta=1
+
+IOInterruptController_Data=struct
+struct.IOInterruptController_Data=data,vectors,controllerLock,ioic_reserved
+struct.IOInterruptController_Data.data=struct.IOService_Data,0,0
+struct.IOInterruptController_Data.data.meta=128
+struct.IOInterruptController_Data.vectors=void *,128,0
+struct.IOInterruptController_Data.vectors.meta=8
+struct.IOInterruptController_Data.controllerLock=void *,136,0
+struct.IOInterruptController_Data.controllerLock.meta=8
+struct.IOInterruptController_Data.ioic_reserved=void *,144,0
+struct.IOInterruptController_Data.ioic_reserved.meta=8
+
+IOInterruptEventSource_Data=struct
+struct.IOInterruptEventSource_Data=data,provider,intIndex,producerCount,consumerCount,autoDisable,explicitDisable,reserved
+struct.IOInterruptEventSource_Data.data=struct.IOEventSource_Data,0,0
+struct.IOInterruptEventSource_Data.data.meta=72
+struct.IOInterruptEventSource_Data.provider=void *,72,0
+struct.IOInterruptEventSource_Data.provider.meta=8
+struct.IOInterruptEventSource_Data.intIndex=int,80,0
+struct.IOInterruptEventSource_Data.intIndex.meta=4
+struct.IOInterruptEventSource_Data.producerCount=unsigned int,84,0
+struct.IOInterruptEventSource_Data.producerCount.meta=4
+struct.IOInterruptEventSource_Data.consumerCount=unsigned int,88,0
+struct.IOInterruptEventSource_Data.consumerCount.meta=4
+struct.IOInterruptEventSource_Data.autoDisable=bool,92,0
+struct.IOInterruptEventSource_Data.autoDisable.meta=1
+struct.IOInterruptEventSource_Data.explicitDisable=bool,93,0
+struct.IOInterruptEventSource_Data.explicitDisable.meta=1
+struct.IOInterruptEventSource_Data.reserved=void *,96,0
+struct.IOInterruptEventSource_Data.reserved.meta=8
+
+IOKitDiagnostics_Data=struct
+struct.IOKitDiagnostics_Data=data
+struct.IOKitDiagnostics_Data.data=struct.OSObject_Data,0,0
+struct.IOKitDiagnostics_Data.data.meta=4
+
+IOKitDiagnosticsClient_Data=struct
+struct.IOKitDiagnosticsClient_Data=data
+struct.IOKitDiagnosticsClient_Data.data=struct.IOUserClient2022_Data,0,0
+struct.IOKitDiagnosticsClient_Data.data.meta=200
+
+IOLittleMemoryCursor_Data=struct
+struct.IOLittleMemoryCursor_Data=data
+struct.IOLittleMemoryCursor_Data.data=struct.IOMemoryCursor_Data,0,0
+struct.IOLittleMemoryCursor_Data.data.meta=40
+
+IOMapper_Data=struct
+struct.IOMapper_Data=data,__reservedA,fAllocName,__reservedB,fPageSize,fIsSystem
+struct.IOMapper_Data.data=struct.IOService_Data,0,0
+struct.IOMapper_Data.data.meta=128
+struct.IOMapper_Data.__reservedA=uint64_t,128,6
+struct.IOMapper_Data.__reservedA.meta=8
+struct.IOMapper_Data.fAllocName=void *,176,0
+struct.IOMapper_Data.fAllocName.meta=8
+struct.IOMapper_Data.__reservedB=uint32_t,184,0
+struct.IOMapper_Data.__reservedB.meta=4
+struct.IOMapper_Data.fPageSize=uint32_t,188,0
+struct.IOMapper_Data.fPageSize.meta=4
+struct.IOMapper_Data.fIsSystem=bool,192,0
+struct.IOMapper_Data.fIsSystem.meta=1
+
+IOMemoryCursor_Data=struct
+struct.IOMemoryCursor_Data=data,outSeg,maxSegmentSize,maxTransferSize,alignMask
+struct.IOMemoryCursor_Data.data=struct.OSObject_Data,0,0
+struct.IOMemoryCursor_Data.data.meta=4
+struct.IOMemoryCursor_Data.outSeg=void *,8,0
+struct.IOMemoryCursor_Data.outSeg.meta=8
+struct.IOMemoryCursor_Data.maxSegmentSize=LONG,16,0
+struct.IOMemoryCursor_Data.maxSegmentSize.meta=8
+struct.IOMemoryCursor_Data.maxTransferSize=LONG,24,0
+struct.IOMemoryCursor_Data.maxTransferSize.meta=8
+struct.IOMemoryCursor_Data.alignMask=LONG,32,0
+struct.IOMemoryCursor_Data.alignMask.meta=8
+
+IOMemoryDescriptor_Data=struct
+struct.IOMemoryDescriptor_Data=data,reserved,_mappings,_flags,_memRef,_kernelTag,_userTag,_dmaReferences,_internalFlags,_mapName,_iomapperOptions,__iomd_reserved3,__iomd_reserved4,_length,_tag
+struct.IOMemoryDescriptor_Data.data=struct.OSObject_Data,0,0
+struct.IOMemoryDescriptor_Data.data.meta=4
+struct.IOMemoryDescriptor_Data.reserved=void *,8,0
+struct.IOMemoryDescriptor_Data.reserved.meta=8
+struct.IOMemoryDescriptor_Data._mappings=void *,16,0
+struct.IOMemoryDescriptor_Data._mappings.meta=8
+struct.IOMemoryDescriptor_Data._flags=int,24,0
+struct.IOMemoryDescriptor_Data._flags.meta=4
+struct.IOMemoryDescriptor_Data._memRef=void *,32,0
+struct.IOMemoryDescriptor_Data._memRef.meta=8
+struct.IOMemoryDescriptor_Data._kernelTag=short,40,0
+struct.IOMemoryDescriptor_Data._kernelTag.meta=2
+struct.IOMemoryDescriptor_Data._userTag=short,42,0
+struct.IOMemoryDescriptor_Data._userTag.meta=2
+struct.IOMemoryDescriptor_Data._dmaReferences=int16_t,44,0
+struct.IOMemoryDescriptor_Data._dmaReferences.meta=2
+struct.IOMemoryDescriptor_Data._internalFlags=uint16_t,46,0
+struct.IOMemoryDescriptor_Data._internalFlags.meta=2
+struct.IOMemoryDescriptor_Data._mapName=void *,48,0
+struct.IOMemoryDescriptor_Data._mapName.meta=8
+struct.IOMemoryDescriptor_Data._iomapperOptions=uint16_t,56,0
+struct.IOMemoryDescriptor_Data._iomapperOptions.meta=2
+struct.IOMemoryDescriptor_Data.__iomd_reserved3=uint16_t,58,3
+struct.IOMemoryDescriptor_Data.__iomd_reserved3.meta=2
+struct.IOMemoryDescriptor_Data.__iomd_reserved4=uintptr_t,64,0
+struct.IOMemoryDescriptor_Data.__iomd_reserved4.meta=8
+struct.IOMemoryDescriptor_Data._length=LONG,72,0
+struct.IOMemoryDescriptor_Data._length.meta=8
+struct.IOMemoryDescriptor_Data._tag=int,80,0
+struct.IOMemoryDescriptor_Data._tag.meta=4
+
+IOMemoryMap_Data=struct
+struct.IOMemoryMap_Data=data,fOptions,fMemory,fSuperMap,fOffset,fAddress,fLength,fAddressTask,fAddressMap,fRedirUPL,fUserClientUnmap
+struct.IOMemoryMap_Data.data=struct.OSObject_Data,0,0
+struct.IOMemoryMap_Data.data.meta=4
+struct.IOMemoryMap_Data.fOptions=int,4,0
+struct.IOMemoryMap_Data.fOptions.meta=4
+struct.IOMemoryMap_Data.fMemory=void *,8,0
+struct.IOMemoryMap_Data.fMemory.meta=8
+struct.IOMemoryMap_Data.fSuperMap=void *,16,0
+struct.IOMemoryMap_Data.fSuperMap.meta=8
+struct.IOMemoryMap_Data.fOffset=LONG,24,0
+struct.IOMemoryMap_Data.fOffset.meta=8
+struct.IOMemoryMap_Data.fAddress=LONG,32,0
+struct.IOMemoryMap_Data.fAddress.meta=8
+struct.IOMemoryMap_Data.fLength=LONG,40,0
+struct.IOMemoryMap_Data.fLength.meta=8
+struct.IOMemoryMap_Data.fAddressTask=void *,48,0
+struct.IOMemoryMap_Data.fAddressTask.meta=8
+struct.IOMemoryMap_Data.fAddressMap=void *,56,0
+struct.IOMemoryMap_Data.fAddressMap.meta=8
+struct.IOMemoryMap_Data.fRedirUPL=void *,64,0
+struct.IOMemoryMap_Data.fRedirUPL.meta=8
+struct.IOMemoryMap_Data.fUserClientUnmap=uint8_t,72,0
+struct.IOMemoryMap_Data.fUserClientUnmap.meta=1
+
+IOMultiMemoryDescriptor_Data=struct
+struct.IOMultiMemoryDescriptor_Data=data,_descriptors,_descriptorsCount,_descriptorsIsAllocated
+struct.IOMultiMemoryDescriptor_Data.data=struct.IOMemoryDescriptor_Data,0,0
+struct.IOMultiMemoryDescriptor_Data.data.meta=88
+struct.IOMultiMemoryDescriptor_Data._descriptors=void *,88,0
+struct.IOMultiMemoryDescriptor_Data._descriptors.meta=8
+struct.IOMultiMemoryDescriptor_Data._descriptorsCount=int,96,0
+struct.IOMultiMemoryDescriptor_Data._descriptorsCount.meta=4
+struct.IOMultiMemoryDescriptor_Data._descriptorsIsAllocated=bool,100,0
+struct.IOMultiMemoryDescriptor_Data._descriptorsIsAllocated.meta=1
+
+IONVRAMController_Data=struct
+struct.IONVRAMController_Data=data
+struct.IONVRAMController_Data.data=struct.IOService_Data,0,0
+struct.IONVRAMController_Data.data.meta=128
+
+IONaturalMemoryCursor_Data=struct
+struct.IONaturalMemoryCursor_Data=data
+struct.IONaturalMemoryCursor_Data.data=struct.IOMemoryCursor_Data,0,0
+struct.IONaturalMemoryCursor_Data.data.meta=40
+
+IONotifier_Data=struct
+struct.IONotifier_Data=data
+struct.IONotifier_Data.data=struct.OSObject_Data,0,0
+struct.IONotifier_Data.data.meta=4
+
+IOPMGR_Data=struct
+struct.IOPMGR_Data=data
+struct.IOPMGR_Data.data=struct.IOService_Data,0,0
+struct.IOPMGR_Data.data.meta=128
+
+IOPMPowerSource_Data=struct
+struct.IOPMPowerSource_Data=data,settingsChangedSinceUpdate,properties,externalConnectedKey,externalChargeCapableKey,batteryInstalledKey,chargingKey,warnLevelKey,criticalLevelKey,currentCapacityKey,maxCapacityKey,timeRemainingKey,amperageKey,voltageKey,cycleCountKey,adapterInfoKey,locationKey,errorConditionKey,manufacturerKey,modelKey,serialKey,batteryInfoKey,nextInList
+struct.IOPMPowerSource_Data.data=struct.IOService_Data,0,0
+struct.IOPMPowerSource_Data.data.meta=128
+struct.IOPMPowerSource_Data.settingsChangedSinceUpdate=bool,128,0
+struct.IOPMPowerSource_Data.settingsChangedSinceUpdate.meta=1
+struct.IOPMPowerSource_Data.properties=void *,136,0
+struct.IOPMPowerSource_Data.properties.meta=8
+struct.IOPMPowerSource_Data.externalConnectedKey=void *,144,0
+struct.IOPMPowerSource_Data.externalConnectedKey.meta=8
+struct.IOPMPowerSource_Data.externalChargeCapableKey=void *,152,0
+struct.IOPMPowerSource_Data.externalChargeCapableKey.meta=8
+struct.IOPMPowerSource_Data.batteryInstalledKey=void *,160,0
+struct.IOPMPowerSource_Data.batteryInstalledKey.meta=8
+struct.IOPMPowerSource_Data.chargingKey=void *,168,0
+struct.IOPMPowerSource_Data.chargingKey.meta=8
+struct.IOPMPowerSource_Data.warnLevelKey=void *,176,0
+struct.IOPMPowerSource_Data.warnLevelKey.meta=8
+struct.IOPMPowerSource_Data.criticalLevelKey=void *,184,0
+struct.IOPMPowerSource_Data.criticalLevelKey.meta=8
+struct.IOPMPowerSource_Data.currentCapacityKey=void *,192,0
+struct.IOPMPowerSource_Data.currentCapacityKey.meta=8
+struct.IOPMPowerSource_Data.maxCapacityKey=void *,200,0
+struct.IOPMPowerSource_Data.maxCapacityKey.meta=8
+struct.IOPMPowerSource_Data.timeRemainingKey=void *,208,0
+struct.IOPMPowerSource_Data.timeRemainingKey.meta=8
+struct.IOPMPowerSource_Data.amperageKey=void *,216,0
+struct.IOPMPowerSource_Data.amperageKey.meta=8
+struct.IOPMPowerSource_Data.voltageKey=void *,224,0
+struct.IOPMPowerSource_Data.voltageKey.meta=8
+struct.IOPMPowerSource_Data.cycleCountKey=void *,232,0
+struct.IOPMPowerSource_Data.cycleCountKey.meta=8
+struct.IOPMPowerSource_Data.adapterInfoKey=void *,240,0
+struct.IOPMPowerSource_Data.adapterInfoKey.meta=8
+struct.IOPMPowerSource_Data.locationKey=void *,248,0
+struct.IOPMPowerSource_Data.locationKey.meta=8
+struct.IOPMPowerSource_Data.errorConditionKey=void *,256,0
+struct.IOPMPowerSource_Data.errorConditionKey.meta=8
+struct.IOPMPowerSource_Data.manufacturerKey=void *,264,0
+struct.IOPMPowerSource_Data.manufacturerKey.meta=8
+struct.IOPMPowerSource_Data.modelKey=void *,272,0
+struct.IOPMPowerSource_Data.modelKey.meta=8
+struct.IOPMPowerSource_Data.serialKey=void *,280,0
+struct.IOPMPowerSource_Data.serialKey.meta=8
+struct.IOPMPowerSource_Data.batteryInfoKey=void *,288,0
+struct.IOPMPowerSource_Data.batteryInfoKey.meta=8
+struct.IOPMPowerSource_Data.nextInList=void *,296,0
+struct.IOPMPowerSource_Data.nextInList.meta=8
+
+IOPMPowerSourceList_Data=struct
+struct.IOPMPowerSourceList_Data=data,firstItem,length
+struct.IOPMPowerSourceList_Data.data=struct.OSObject_Data,0,0
+struct.IOPMPowerSourceList_Data.data.meta=4
+struct.IOPMPowerSourceList_Data.firstItem=void *,8,0
+struct.IOPMPowerSourceList_Data.firstItem.meta=8
+struct.IOPMPowerSourceList_Data.length=LONGU,16,0
+struct.IOPMPowerSourceList_Data.length.meta=8
+
+IOPMinformee_Data=struct
+struct.IOPMinformee_Data=data,whatObject,timer,nextInList,startTime,active
+struct.IOPMinformee_Data.data=struct.OSObject_Data,0,0
+struct.IOPMinformee_Data.data.meta=4
+struct.IOPMinformee_Data.whatObject=void *,8,0
+struct.IOPMinformee_Data.whatObject.meta=8
+struct.IOPMinformee_Data.timer=int32_t,16,0
+struct.IOPMinformee_Data.timer.meta=4
+struct.IOPMinformee_Data.nextInList=void *,24,0
+struct.IOPMinformee_Data.nextInList.meta=8
+struct.IOPMinformee_Data.startTime=LONG,32,0
+struct.IOPMinformee_Data.startTime.meta=8
+struct.IOPMinformee_Data.active=bool,40,0
+struct.IOPMinformee_Data.active.meta=1
+
+IOPMinformeeList_Data=struct
+struct.IOPMinformeeList_Data=data,firstItem,length
+struct.IOPMinformeeList_Data.data=struct.OSObject_Data,0,0
+struct.IOPMinformeeList_Data.data.meta=4
+struct.IOPMinformeeList_Data.firstItem=void *,8,0
+struct.IOPMinformeeList_Data.firstItem.meta=8
+struct.IOPMinformeeList_Data.length=LONGU,16,0
+struct.IOPMinformeeList_Data.length.meta=8
+
+IOPerfControlClient_Data=struct
+struct.IOPerfControlClient_Data=data,driverIndex,shared,workTable,workTableLength,workTableNextIndex,workTableLock,clientData
+struct.IOPerfControlClient_Data.data=struct.OSObject_Data,0,0
+struct.IOPerfControlClient_Data.data.meta=4
+struct.IOPerfControlClient_Data.driverIndex=uint8_t,4,0
+struct.IOPerfControlClient_Data.driverIndex.meta=1
+struct.IOPerfControlClient_Data.shared=void *,8,0
+struct.IOPerfControlClient_Data.shared.meta=8
+struct.IOPerfControlClient_Data.workTable=void *,16,0
+struct.IOPerfControlClient_Data.workTable.meta=8
+struct.IOPerfControlClient_Data.workTableLength=LONG,24,0
+struct.IOPerfControlClient_Data.workTableLength.meta=8
+struct.IOPerfControlClient_Data.workTableNextIndex=LONG,32,0
+struct.IOPerfControlClient_Data.workTableNextIndex.meta=8
+struct.IOPerfControlClient_Data.workTableLock=void *,40,0
+struct.IOPerfControlClient_Data.workTableLock.meta=8
+struct.IOPerfControlClient_Data.clientData=void *,48,0
+struct.IOPerfControlClient_Data.clientData.meta=8
+
+IOPlatformDevice_Data=struct
+struct.IOPlatformDevice_Data=data,iopd_reserved
+struct.IOPlatformDevice_Data.data=struct.IOService_Data,0,0
+struct.IOPlatformDevice_Data.data.meta=128
+struct.IOPlatformDevice_Data.iopd_reserved=void *,128,0
+struct.IOPlatformDevice_Data.iopd_reserved.meta=8
+
+IOPlatformExpert_Data=struct
+struct.IOPlatformExpert_Data=data,_peBootROMType,_peChipSetType,_peMachineType,root,_pePMFeatures,_pePrivPMFeatures,_peNumBatteriesSupported,thePowerTree,searchingForAdditionalParents,multipleParentKeyValue,numInstancesRegistered,iope_reserved
+struct.IOPlatformExpert_Data.data=struct.IOService_Data,0,0
+struct.IOPlatformExpert_Data.data.meta=128
+struct.IOPlatformExpert_Data._peBootROMType=LONG,128,0
+struct.IOPlatformExpert_Data._peBootROMType.meta=8
+struct.IOPlatformExpert_Data._peChipSetType=LONG,136,0
+struct.IOPlatformExpert_Data._peChipSetType.meta=8
+struct.IOPlatformExpert_Data._peMachineType=LONG,144,0
+struct.IOPlatformExpert_Data._peMachineType.meta=8
+struct.IOPlatformExpert_Data.root=void *,152,0
+struct.IOPlatformExpert_Data.root.meta=8
+struct.IOPlatformExpert_Data._pePMFeatures=int,160,0
+struct.IOPlatformExpert_Data._pePMFeatures.meta=4
+struct.IOPlatformExpert_Data._pePrivPMFeatures=int,164,0
+struct.IOPlatformExpert_Data._pePrivPMFeatures.meta=4
+struct.IOPlatformExpert_Data._peNumBatteriesSupported=int,168,0
+struct.IOPlatformExpert_Data._peNumBatteriesSupported.meta=4
+struct.IOPlatformExpert_Data.thePowerTree=void *,176,0
+struct.IOPlatformExpert_Data.thePowerTree.meta=8
+struct.IOPlatformExpert_Data.searchingForAdditionalParents=bool,184,0
+struct.IOPlatformExpert_Data.searchingForAdditionalParents.meta=1
+struct.IOPlatformExpert_Data.multipleParentKeyValue=void *,192,0
+struct.IOPlatformExpert_Data.multipleParentKeyValue.meta=8
+struct.IOPlatformExpert_Data.numInstancesRegistered=int,200,0
+struct.IOPlatformExpert_Data.numInstancesRegistered.meta=4
+struct.IOPlatformExpert_Data.iope_reserved=void *,208,0
+struct.IOPlatformExpert_Data.iope_reserved.meta=8
+
+IOPlatformExpertDevice_Data=struct
+struct.IOPlatformExpertDevice_Data=data,workLoop,ioped_reserved
+struct.IOPlatformExpertDevice_Data.data=struct.IOService_Data,0,0
+struct.IOPlatformExpertDevice_Data.data.meta=128
+struct.IOPlatformExpertDevice_Data.workLoop=void *,128,0
+struct.IOPlatformExpertDevice_Data.workLoop.meta=8
+struct.IOPlatformExpertDevice_Data.ioped_reserved=void *,136,0
+struct.IOPlatformExpertDevice_Data.ioped_reserved.meta=8
+
+IOPlatformIO_Data=struct
+struct.IOPlatformIO_Data=data
+struct.IOPlatformIO_Data.data=struct.IOService_Data,0,0
+struct.IOPlatformIO_Data.data.meta=128
+
+IOPolledInterface_Data=struct
+struct.IOPolledInterface_Data=data,reserved
+struct.IOPolledInterface_Data.data=struct.OSObject_Data,0,0
+struct.IOPolledInterface_Data.data.meta=4
+struct.IOPolledInterface_Data.reserved=void *,8,0
+struct.IOPolledInterface_Data.reserved.meta=8
+
+IOPowerConnection_Data=struct
+struct.IOPowerConnection_Data=data,stateKnown,currentPowerFlags,desiredDomainState,requestFlag,preventIdleSleepFlag,preventSystemSleepFlag,awaitingAck,readyFlag,delayChildNotification
+struct.IOPowerConnection_Data.data=struct.IOService_Data,0,0
+struct.IOPowerConnection_Data.data.meta=128
+struct.IOPowerConnection_Data.stateKnown=bool,128,0
+struct.IOPowerConnection_Data.stateKnown.meta=1
+struct.IOPowerConnection_Data.currentPowerFlags=LONG,136,0
+struct.IOPowerConnection_Data.currentPowerFlags.meta=8
+struct.IOPowerConnection_Data.desiredDomainState=LONGU,144,0
+struct.IOPowerConnection_Data.desiredDomainState.meta=8
+struct.IOPowerConnection_Data.requestFlag=bool,152,0
+struct.IOPowerConnection_Data.requestFlag.meta=1
+struct.IOPowerConnection_Data.preventIdleSleepFlag=LONGU,160,0
+struct.IOPowerConnection_Data.preventIdleSleepFlag.meta=8
+struct.IOPowerConnection_Data.preventSystemSleepFlag=LONGU,168,0
+struct.IOPowerConnection_Data.preventSystemSleepFlag.meta=8
+struct.IOPowerConnection_Data.awaitingAck=bool,176,0
+struct.IOPowerConnection_Data.awaitingAck.meta=1
+struct.IOPowerConnection_Data.readyFlag=bool,177,0
+struct.IOPowerConnection_Data.readyFlag.meta=1
+struct.IOPowerConnection_Data.delayChildNotification=bool,178,0
+struct.IOPowerConnection_Data.delayChildNotification.meta=1
+
+IOProviderPropertyMerger_Data=struct
+struct.IOProviderPropertyMerger_Data=data
+struct.IOProviderPropertyMerger_Data.data=struct.IOService_Data,0,0
+struct.IOProviderPropertyMerger_Data.data.meta=128
+
+IORTC_Data=struct
+struct.IORTC_Data=data,iortc_reserved
+struct.IORTC_Data.data=struct.IOService_Data,0,0
+struct.IORTC_Data.data.meta=128
+struct.IORTC_Data.iortc_reserved=void *,128,0
+struct.IORTC_Data.iortc_reserved.meta=8
+
+IORangeAllocator_Data=struct
+struct.IORangeAllocator_Data=data,numElements,capacity,capacityIncrement,defaultAlignmentMask,options,elements
+struct.IORangeAllocator_Data.data=struct.OSObject_Data,0,0
+struct.IORangeAllocator_Data.data.meta=4
+struct.IORangeAllocator_Data.numElements=int,4,0
+struct.IORangeAllocator_Data.numElements.meta=4
+struct.IORangeAllocator_Data.capacity=int,8,0
+struct.IORangeAllocator_Data.capacity.meta=4
+struct.IORangeAllocator_Data.capacityIncrement=int,12,0
+struct.IORangeAllocator_Data.capacityIncrement.meta=4
+struct.IORangeAllocator_Data.defaultAlignmentMask=LONG,16,0
+struct.IORangeAllocator_Data.defaultAlignmentMask.meta=8
+struct.IORangeAllocator_Data.options=int,24,0
+struct.IORangeAllocator_Data.options.meta=4
+struct.IORangeAllocator_Data.elements=void *,32,0
+struct.IORangeAllocator_Data.elements.meta=8
+
+IORegistryEntry_Data=struct
+struct.IORegistryEntry_Data=data,reserved,fRegistryTable,fPropertyTable
+struct.IORegistryEntry_Data.data=struct.OSObject_Data,0,0
+struct.IORegistryEntry_Data.data.meta=4
+struct.IORegistryEntry_Data.reserved=void *,8,0
+struct.IORegistryEntry_Data.reserved.meta=8
+struct.IORegistryEntry_Data.fRegistryTable=void *,16,0
+struct.IORegistryEntry_Data.fRegistryTable.meta=8
+struct.IORegistryEntry_Data.fPropertyTable=void *,24,0
+struct.IORegistryEntry_Data.fPropertyTable.meta=8
+
+IORegistryIterator_Data=struct
+struct.IORegistryIterator_Data=data,start,where,root,done,plane,options
+struct.IORegistryIterator_Data.data=struct.OSIterator_Data,0,0
+struct.IORegistryIterator_Data.data.meta=4
+struct.IORegistryIterator_Data.start=void *,8,0
+struct.IORegistryIterator_Data.start.meta=8
+struct.IORegistryIterator_Data.where=void *,16,0
+struct.IORegistryIterator_Data.where.meta=8
+struct.IORegistryIterator_Data.root=void *,24,0
+struct.IORegistryIterator_Data.root.meta=8
+struct.IORegistryIterator_Data.done=void *,32,0
+struct.IORegistryIterator_Data.done.meta=8
+struct.IORegistryIterator_Data.plane=void *,40,0
+struct.IORegistryIterator_Data.plane.meta=8
+struct.IORegistryIterator_Data.options=int,48,0
+struct.IORegistryIterator_Data.options.meta=4
+
+IOReportLegend_Data=struct
+struct.IOReportLegend_Data=data,_reportLegend
+struct.IOReportLegend_Data.data=struct.OSObject_Data,0,0
+struct.IOReportLegend_Data.data.meta=4
+struct.IOReportLegend_Data._reportLegend=void *,8,0
+struct.IOReportLegend_Data._reportLegend.meta=8
+
+IOReporter_Data=struct
+struct.IOReporter_Data=data,_channelType,_driver_id,_elements,_enableCounts,_channelDimension,_nElements,_nChannels,_channelNames,_reporterIsLocked,_reporterConfigIsLocked,_swapElements,_swapEnableCounts,_unit,_enabled,_configLock,_interruptState,_reporterLock
+struct.IOReporter_Data.data=struct.OSObject_Data,0,0
+struct.IOReporter_Data.data.meta=4
+struct.IOReporter_Data._channelType=void *,8,0
+struct.IOReporter_Data._channelType.meta=8
+struct.IOReporter_Data._driver_id=uint64_t,16,0
+struct.IOReporter_Data._driver_id.meta=8
+struct.IOReporter_Data._elements=void *,24,0
+struct.IOReporter_Data._elements.meta=8
+struct.IOReporter_Data._enableCounts=void *,32,0
+struct.IOReporter_Data._enableCounts.meta=8
+struct.IOReporter_Data._channelDimension=uint16_t,40,0
+struct.IOReporter_Data._channelDimension.meta=2
+struct.IOReporter_Data._nElements=int,44,0
+struct.IOReporter_Data._nElements.meta=4
+struct.IOReporter_Data._nChannels=int,48,0
+struct.IOReporter_Data._nChannels.meta=4
+struct.IOReporter_Data._channelNames=void *,56,0
+struct.IOReporter_Data._channelNames.meta=8
+struct.IOReporter_Data._reporterIsLocked=bool,64,0
+struct.IOReporter_Data._reporterIsLocked.meta=1
+struct.IOReporter_Data._reporterConfigIsLocked=bool,65,0
+struct.IOReporter_Data._reporterConfigIsLocked.meta=1
+struct.IOReporter_Data._swapElements=void *,72,0
+struct.IOReporter_Data._swapElements.meta=8
+struct.IOReporter_Data._swapEnableCounts=void *,80,0
+struct.IOReporter_Data._swapEnableCounts.meta=8
+struct.IOReporter_Data._unit=LONG,88,0
+struct.IOReporter_Data._unit.meta=8
+struct.IOReporter_Data._enabled=int,96,0
+struct.IOReporter_Data._enabled.meta=4
+struct.IOReporter_Data._configLock=void *,104,0
+struct.IOReporter_Data._configLock.meta=8
+struct.IOReporter_Data._interruptState=int,112,0
+struct.IOReporter_Data._interruptState.meta=4
+struct.IOReporter_Data._reporterLock=void *,120,0
+struct.IOReporter_Data._reporterLock.meta=8
+
+IOService_Data=struct
+struct.IOService_Data=data,reserved,__provider,__providerGeneration,__resv1,__owner,__state,__timeBusy,__accumBusy,pwrMgt,initialized,__machPortHoldDestroy,__resv2,pm_vars,_numInterruptSources,_interruptSources
+struct.IOService_Data.data=struct.IORegistryEntry_Data,0,0
+struct.IOService_Data.data.meta=32
+struct.IOService_Data.reserved=void *,32,0
+struct.IOService_Data.reserved.meta=8
+struct.IOService_Data.__provider=void *,40,0
+struct.IOService_Data.__provider.meta=8
+struct.IOService_Data.__providerGeneration=int,48,0
+struct.IOService_Data.__providerGeneration.meta=4
+struct.IOService_Data.__resv1=uint32_t,52,0
+struct.IOService_Data.__resv1.meta=4
+struct.IOService_Data.__owner=void *,56,0
+struct.IOService_Data.__owner.meta=8
+struct.IOService_Data.__state=IOOptionBits,64,2
+struct.IOService_Data.__state.meta=4
+struct.IOService_Data.__timeBusy=uint64_t,72,0
+struct.IOService_Data.__timeBusy.meta=8
+struct.IOService_Data.__accumBusy=uint64_t,80,0
+struct.IOService_Data.__accumBusy.meta=8
+struct.IOService_Data.pwrMgt=void *,88,0
+struct.IOService_Data.pwrMgt.meta=8
+struct.IOService_Data.initialized=bool,96,0
+struct.IOService_Data.initialized.meta=1
+struct.IOService_Data.__machPortHoldDestroy=bool,97,0
+struct.IOService_Data.__machPortHoldDestroy.meta=1
+struct.IOService_Data.__resv2=uint8_t,98,6
+struct.IOService_Data.__resv2.meta=1
+struct.IOService_Data.pm_vars=void *,104,0
+struct.IOService_Data.pm_vars.meta=8
+struct.IOService_Data._numInterruptSources=int,112,0
+struct.IOService_Data._numInterruptSources.meta=4
+struct.IOService_Data._interruptSources=void *,120,0
+struct.IOService_Data._interruptSources.meta=8
+
+IOServiceCompatibility_Data=struct
+struct.IOServiceCompatibility_Data=data
+struct.IOServiceCompatibility_Data.data=struct.IOService_Data,0,0
+struct.IOServiceCompatibility_Data.data.meta=128
+
+IOServiceStateNotificationEventSource_Data=struct
+struct.IOServiceStateNotificationEventSource_Data=data,fStateNotification,fListener,fEnable,fArmed,reserved
+struct.IOServiceStateNotificationEventSource_Data.data=struct.IOEventSource_Data,0,0
+struct.IOServiceStateNotificationEventSource_Data.data.meta=72
+struct.IOServiceStateNotificationEventSource_Data.fStateNotification=void *,72,0
+struct.IOServiceStateNotificationEventSource_Data.fStateNotification.meta=8
+struct.IOServiceStateNotificationEventSource_Data.fListener=void *,80,0
+struct.IOServiceStateNotificationEventSource_Data.fListener.meta=8
+struct.IOServiceStateNotificationEventSource_Data.fEnable=bool,88,0
+struct.IOServiceStateNotificationEventSource_Data.fEnable.meta=1
+struct.IOServiceStateNotificationEventSource_Data.fArmed=bool,89,0
+struct.IOServiceStateNotificationEventSource_Data.fArmed.meta=1
+struct.IOServiceStateNotificationEventSource_Data.reserved=void *,96,0
+struct.IOServiceStateNotificationEventSource_Data.reserved.meta=8
+
+IOSharedDataQueue_Data=struct
+struct.IOSharedDataQueue_Data=data,_reserved
+struct.IOSharedDataQueue_Data.data=struct.IODataQueue_Data,0,0
+struct.IOSharedDataQueue_Data.data.meta=24
+struct.IOSharedDataQueue_Data._reserved=void *,24,0
+struct.IOSharedDataQueue_Data._reserved.meta=8
+
+IOSharedInterruptController_Data=struct
+struct.IOSharedInterruptController_Data=data,provider,numVectors,vectorsRegistered,vectorsEnabled,controllerDisabled,sourceIsLevel,iosic_reserved
+struct.IOSharedInterruptController_Data.data=struct.IOInterruptController_Data,0,0
+struct.IOSharedInterruptController_Data.data.meta=152
+struct.IOSharedInterruptController_Data.provider=void *,152,0
+struct.IOSharedInterruptController_Data.provider.meta=8
+struct.IOSharedInterruptController_Data.numVectors=int,160,0
+struct.IOSharedInterruptController_Data.numVectors.meta=4
+struct.IOSharedInterruptController_Data.vectorsRegistered=int,164,0
+struct.IOSharedInterruptController_Data.vectorsRegistered.meta=4
+struct.IOSharedInterruptController_Data.vectorsEnabled=int,168,0
+struct.IOSharedInterruptController_Data.vectorsEnabled.meta=4
+struct.IOSharedInterruptController_Data.controllerDisabled=int,172,0
+struct.IOSharedInterruptController_Data.controllerDisabled.meta=4
+struct.IOSharedInterruptController_Data.sourceIsLevel=bool,176,0
+struct.IOSharedInterruptController_Data.sourceIsLevel.meta=1
+struct.IOSharedInterruptController_Data.iosic_reserved=void *,184,0
+struct.IOSharedInterruptController_Data.iosic_reserved.meta=8
+
+IOSimpleReporter_Data=struct
+struct.IOSimpleReporter_Data=data
+struct.IOSimpleReporter_Data.data=struct.IOReporter_Data,0,0
+struct.IOSimpleReporter_Data.data.meta=128
+
+IOStateReporter_Data=struct
+struct.IOStateReporter_Data=data,_currentStates,_lastUpdateTimes,_swapCurrentStates,_swapLastUpdateTimes
+struct.IOStateReporter_Data.data=struct.IOReporter_Data,0,0
+struct.IOStateReporter_Data.data.meta=128
+struct.IOStateReporter_Data._currentStates=void *,128,0
+struct.IOStateReporter_Data._currentStates.meta=8
+struct.IOStateReporter_Data._lastUpdateTimes=void *,136,0
+struct.IOStateReporter_Data._lastUpdateTimes.meta=8
+struct.IOStateReporter_Data._swapCurrentStates=void *,144,0
+struct.IOStateReporter_Data._swapCurrentStates.meta=8
+struct.IOStateReporter_Data._swapLastUpdateTimes=void *,152,0
+struct.IOStateReporter_Data._swapLastUpdateTimes.meta=8
+
+IOSubMemoryDescriptor_Data=struct
+struct.IOSubMemoryDescriptor_Data=data,_parent,_start
+struct.IOSubMemoryDescriptor_Data.data=struct.IOMemoryDescriptor_Data,0,0
+struct.IOSubMemoryDescriptor_Data.data.meta=88
+struct.IOSubMemoryDescriptor_Data._parent=void *,88,0
+struct.IOSubMemoryDescriptor_Data._parent.meta=8
+struct.IOSubMemoryDescriptor_Data._start=LONG,96,0
+struct.IOSubMemoryDescriptor_Data._start.meta=8
+
+IOTimerEventSource_Data=struct
+struct.IOTimerEventSource_Data=data,calloutEntry,abstime,reserved
+struct.IOTimerEventSource_Data.data=struct.IOEventSource_Data,0,0
+struct.IOTimerEventSource_Data.data.meta=72
+struct.IOTimerEventSource_Data.calloutEntry=void *,72,0
+struct.IOTimerEventSource_Data.calloutEntry.meta=8
+struct.IOTimerEventSource_Data.abstime=LONG,80,0
+struct.IOTimerEventSource_Data.abstime.meta=8
+struct.IOTimerEventSource_Data.reserved=void *,88,0
+struct.IOTimerEventSource_Data.reserved.meta=8
+
+IOUserClient_Data=struct
+struct.IOUserClient_Data=data,reserved,__opaque_start,mappings,sharedInstance,closed,__ipcFinal,messageAppSuspended__b0,uc2022__b1,defaultLocking__b2,defaultLockingSingleThreadExternalMethod__b3,defaultLockingSetProperties__b4,opened__b5,__reservedA__b6,__ipc,owners,lock,filterLock,__reserved,__opaque_end
+struct.IOUserClient_Data.data=struct.IOService_Data,0,0
+struct.IOUserClient_Data.data.meta=128
+struct.IOUserClient_Data.reserved=void *,128,0
+struct.IOUserClient_Data.reserved.meta=8
+struct.IOUserClient_Data.__opaque_start=UInt8,136,0
+struct.IOUserClient_Data.__opaque_start.meta=1
+struct.IOUserClient_Data.mappings=void *,144,0
+struct.IOUserClient_Data.mappings.meta=8
+struct.IOUserClient_Data.sharedInstance=char,152,0
+struct.IOUserClient_Data.sharedInstance.meta=1
+struct.IOUserClient_Data.closed=char,153,0
+struct.IOUserClient_Data.closed.meta=1
+struct.IOUserClient_Data.__ipcFinal=char,154,0
+struct.IOUserClient_Data.__ipcFinal.meta=1
+struct.IOUserClient_Data.messageAppSuspended__b0=int,155,1
+struct.IOUserClient_Data.messageAppSuspended__b0.meta=1
+struct.IOUserClient_Data.messageAppSuspended__b0.@.bitoff=0
+struct.IOUserClient_Data.uc2022__b1=int,155,1
+struct.IOUserClient_Data.uc2022__b1.meta=1
+struct.IOUserClient_Data.uc2022__b1.@.bitoff=1
+struct.IOUserClient_Data.defaultLocking__b2=int,155,1
+struct.IOUserClient_Data.defaultLocking__b2.meta=1
+struct.IOUserClient_Data.defaultLocking__b2.@.bitoff=2
+struct.IOUserClient_Data.defaultLockingSingleThreadExternalMethod__b3=int,155,1
+struct.IOUserClient_Data.defaultLockingSingleThreadExternalMethod__b3.meta=1
+struct.IOUserClient_Data.defaultLockingSingleThreadExternalMethod__b3.@.bitoff=3
+struct.IOUserClient_Data.defaultLockingSetProperties__b4=int,155,1
+struct.IOUserClient_Data.defaultLockingSetProperties__b4.meta=1
+struct.IOUserClient_Data.defaultLockingSetProperties__b4.@.bitoff=4
+struct.IOUserClient_Data.opened__b5=int,155,1
+struct.IOUserClient_Data.opened__b5.meta=1
+struct.IOUserClient_Data.opened__b5.@.bitoff=5
+struct.IOUserClient_Data.__reservedA__b6=int,155,2
+struct.IOUserClient_Data.__reservedA__b6.meta=1
+struct.IOUserClient_Data.__reservedA__b6.@.bitoff=6
+struct.IOUserClient_Data.__ipc=int,156,0
+struct.IOUserClient_Data.__ipc.meta=4
+struct.IOUserClient_Data.owners=void *,160,0
+struct.IOUserClient_Data.owners.meta=8
+struct.IOUserClient_Data.lock=void *,168,0
+struct.IOUserClient_Data.lock.meta=8
+struct.IOUserClient_Data.filterLock=void *,176,0
+struct.IOUserClient_Data.filterLock.meta=8
+struct.IOUserClient_Data.__reserved=void *,184,1
+struct.IOUserClient_Data.__reserved.meta=8
+struct.IOUserClient_Data.__opaque_end=UInt8,192,0
+struct.IOUserClient_Data.__opaque_end.meta=1
+
+IOUserClient2022_Data=struct
+struct.IOUserClient2022_Data=data
+struct.IOUserClient2022_Data.data=struct.IOUserClient_Data,0,0
+struct.IOUserClient2022_Data.data.meta=200
+
+IOUserIterator_Data=struct
+struct.IOUserIterator_Data=data,userIteratorObject,lock
+struct.IOUserIterator_Data.data=struct.OSIterator_Data,0,0
+struct.IOUserIterator_Data.data.meta=4
+struct.IOUserIterator_Data.userIteratorObject=void *,8,0
+struct.IOUserIterator_Data.userIteratorObject.meta=8
+struct.IOUserIterator_Data.lock=void *,16,0
+struct.IOUserIterator_Data.lock.meta=8
+
+IOUserNotification_Data=struct
+struct.IOUserNotification_Data=data
+struct.IOUserNotification_Data.data=struct.IOUserIterator_Data,0,0
+struct.IOUserNotification_Data.data.meta=24
+
+IOUserServer_Data=struct
+struct.IOUserServer_Data=data,fLock,fInterruptLock,fEntitlements,fClasses,fRootQueue,fServices,fRootNotifier,fSystemPowerAck,fSystemOff,fCheckInToken,fStatistics,fPlatformDriver,fTeamIdentifier,fCSValidationCategory,fWorkLoop,fAllocationName,fOwningTask,fTaskCrashReason
+struct.IOUserServer_Data.data=struct.IOUserClient2022_Data,0,0
+struct.IOUserServer_Data.data.meta=200
+struct.IOUserServer_Data.fLock=void *,200,0
+struct.IOUserServer_Data.fLock.meta=8
+struct.IOUserServer_Data.fInterruptLock=void *,208,0
+struct.IOUserServer_Data.fInterruptLock.meta=8
+struct.IOUserServer_Data.fEntitlements=void *,216,0
+struct.IOUserServer_Data.fEntitlements.meta=8
+struct.IOUserServer_Data.fClasses=void *,224,0
+struct.IOUserServer_Data.fClasses.meta=8
+struct.IOUserServer_Data.fRootQueue=void *,232,0
+struct.IOUserServer_Data.fRootQueue.meta=8
+struct.IOUserServer_Data.fServices=void *,240,0
+struct.IOUserServer_Data.fServices.meta=8
+struct.IOUserServer_Data.fRootNotifier=uint8_t,248,0
+struct.IOUserServer_Data.fRootNotifier.meta=1
+struct.IOUserServer_Data.fSystemPowerAck=uint8_t,249,0
+struct.IOUserServer_Data.fSystemPowerAck.meta=1
+struct.IOUserServer_Data.fSystemOff=uint8_t,250,0
+struct.IOUserServer_Data.fSystemOff.meta=1
+struct.IOUserServer_Data.fCheckInToken=void *,256,0
+struct.IOUserServer_Data.fCheckInToken.meta=8
+struct.IOUserServer_Data.fStatistics=void *,264,0
+struct.IOUserServer_Data.fStatistics.meta=8
+struct.IOUserServer_Data.fPlatformDriver=bool,272,0
+struct.IOUserServer_Data.fPlatformDriver.meta=1
+struct.IOUserServer_Data.fTeamIdentifier=void *,280,0
+struct.IOUserServer_Data.fTeamIdentifier.meta=8
+struct.IOUserServer_Data.fCSValidationCategory=unsigned int,288,0
+struct.IOUserServer_Data.fCSValidationCategory.meta=4
+struct.IOUserServer_Data.fWorkLoop=void *,296,0
+struct.IOUserServer_Data.fWorkLoop.meta=8
+struct.IOUserServer_Data.fAllocationName=void *,304,0
+struct.IOUserServer_Data.fAllocationName.meta=8
+struct.IOUserServer_Data.fOwningTask=void *,312,0
+struct.IOUserServer_Data.fOwningTask.meta=8
+struct.IOUserServer_Data.fTaskCrashReason=void *,320,0
+struct.IOUserServer_Data.fTaskCrashReason.meta=8
+
+IOUserServerCheckInToken_Data=struct
+struct.IOUserServerCheckInToken_Data=data,fState,fPendingCount,fServerName,fExecutableName,fServerTag,fHandlers,fKextBundleID,fNeedDextDec
+struct.IOUserServerCheckInToken_Data.data=struct.OSObject_Data,0,0
+struct.IOUserServerCheckInToken_Data.data.meta=4
+struct.IOUserServerCheckInToken_Data.fState=void *,8,0
+struct.IOUserServerCheckInToken_Data.fState.meta=8
+struct.IOUserServerCheckInToken_Data.fPendingCount=LONG,16,0
+struct.IOUserServerCheckInToken_Data.fPendingCount.meta=8
+struct.IOUserServerCheckInToken_Data.fServerName=void *,24,0
+struct.IOUserServerCheckInToken_Data.fServerName.meta=8
+struct.IOUserServerCheckInToken_Data.fExecutableName=void *,32,0
+struct.IOUserServerCheckInToken_Data.fExecutableName.meta=8
+struct.IOUserServerCheckInToken_Data.fServerTag=void *,40,0
+struct.IOUserServerCheckInToken_Data.fServerTag.meta=8
+struct.IOUserServerCheckInToken_Data.fHandlers=void *,48,0
+struct.IOUserServerCheckInToken_Data.fHandlers.meta=8
+struct.IOUserServerCheckInToken_Data.fKextBundleID=void *,56,0
+struct.IOUserServerCheckInToken_Data.fKextBundleID.meta=8
+struct.IOUserServerCheckInToken_Data.fNeedDextDec=bool,64,0
+struct.IOUserServerCheckInToken_Data.fNeedDextDec.meta=1
+
+IOUserUserClient_Data=struct
+struct.IOUserUserClient_Data=data,fTask,fWorkGroups,fEventLinks,fLock
+struct.IOUserUserClient_Data.data=struct.IOUserClient_Data,0,0
+struct.IOUserUserClient_Data.data.meta=200
+struct.IOUserUserClient_Data.fTask=void *,200,0
+struct.IOUserUserClient_Data.fTask.meta=8
+struct.IOUserUserClient_Data.fWorkGroups=void *,208,0
+struct.IOUserUserClient_Data.fWorkGroups.meta=8
+struct.IOUserUserClient_Data.fEventLinks=void *,216,0
+struct.IOUserUserClient_Data.fEventLinks.meta=8
+struct.IOUserUserClient_Data.fLock=void *,224,0
+struct.IOUserUserClient_Data.fLock.meta=8
+
+IOWatchDogTimer_Data=struct
+struct.IOWatchDogTimer_Data=data,notifier,reserved
+struct.IOWatchDogTimer_Data.data=struct.IOService_Data,0,0
+struct.IOWatchDogTimer_Data.data.meta=128
+struct.IOWatchDogTimer_Data.notifier=void *,128,0
+struct.IOWatchDogTimer_Data.notifier.meta=8
+struct.IOWatchDogTimer_Data.reserved=void *,136,0
+struct.IOWatchDogTimer_Data.reserved.meta=8
+
+IOWorkGroup_Data=struct
+struct.IOWorkGroup_Data=data,ivars,lvars
+struct.IOWorkGroup_Data.data=struct.OSObject_Data,0,0
+struct.IOWorkGroup_Data.data.meta=4
+struct.IOWorkGroup_Data.ivars=void *,8,0
+struct.IOWorkGroup_Data.ivars.meta=8
+struct.IOWorkGroup_Data.lvars=void *,16,0
+struct.IOWorkGroup_Data.lvars.meta=8
+
+IOWorkLoop_Data=struct
+struct.IOWorkLoop_Data=data,gateLock,eventChain,controlG,workToDoLock,workThread,workToDo,loopRestart,reserved
+struct.IOWorkLoop_Data.data=struct.OSObject_Data,0,0
+struct.IOWorkLoop_Data.data.meta=4
+struct.IOWorkLoop_Data.gateLock=void *,8,0
+struct.IOWorkLoop_Data.gateLock.meta=8
+struct.IOWorkLoop_Data.eventChain=void *,16,0
+struct.IOWorkLoop_Data.eventChain.meta=8
+struct.IOWorkLoop_Data.controlG=void *,24,0
+struct.IOWorkLoop_Data.controlG.meta=8
+struct.IOWorkLoop_Data.workToDoLock=void *,32,0
+struct.IOWorkLoop_Data.workToDoLock.meta=8
+struct.IOWorkLoop_Data.workThread=void *,40,0
+struct.IOWorkLoop_Data.workThread.meta=8
+struct.IOWorkLoop_Data.workToDo=bool,48,0
+struct.IOWorkLoop_Data.workToDo.meta=1
+struct.IOWorkLoop_Data.loopRestart=bool,49,0
+struct.IOWorkLoop_Data.loopRestart.meta=1
+struct.IOWorkLoop_Data.reserved=void *,56,0
+struct.IOWorkLoop_Data.reserved.meta=8
+
+OSAction_Data=struct
+struct.OSAction_Data=data,ivars,lvars
+struct.OSAction_Data.data=struct.OSObject_Data,0,0
+struct.OSAction_Data.data.meta=4
+struct.OSAction_Data.ivars=void *,8,0
+struct.OSAction_Data.ivars.meta=8
+struct.OSAction_Data.lvars=void *,16,0
+struct.OSAction_Data.lvars.meta=8
+
+OSAction_IOUserClient_KernelCompletion_Data=struct
+struct.OSAction_IOUserClient_KernelCompletion_Data=data,ivars,lvars
+struct.OSAction_IOUserClient_KernelCompletion_Data.data=struct.OSAction_Data,0,0
+struct.OSAction_IOUserClient_KernelCompletion_Data.data.meta=24
+struct.OSAction_IOUserClient_KernelCompletion_Data.ivars=void *,24,0
+struct.OSAction_IOUserClient_KernelCompletion_Data.ivars.meta=8
+struct.OSAction_IOUserClient_KernelCompletion_Data.lvars=void *,32,0
+struct.OSAction_IOUserClient_KernelCompletion_Data.lvars.meta=8
+
+OSArray_Data=struct
+struct.OSArray_Data=data,count,capacity,capacityIncrement,array
+struct.OSArray_Data.data=struct.OSCollection_Data,0,0
+struct.OSArray_Data.data.meta=12
+struct.OSArray_Data.count=unsigned int,12,0
+struct.OSArray_Data.count.meta=4
+struct.OSArray_Data.capacity=unsigned int,16,0
+struct.OSArray_Data.capacity.meta=4
+struct.OSArray_Data.capacityIncrement=unsigned int,20,0
+struct.OSArray_Data.capacityIncrement.meta=4
+struct.OSArray_Data.array=void *,24,0
+struct.OSArray_Data.array.meta=8
+
+OSBoolean_Data=struct
+struct.OSBoolean_Data=data,value
+struct.OSBoolean_Data.data=struct.OSObject_Data,0,0
+struct.OSBoolean_Data.data.meta=4
+struct.OSBoolean_Data.value=bool,4,0
+struct.OSBoolean_Data.value.meta=1
+
+OSCollection_Data=struct
+struct.OSCollection_Data=data,updateStamp,fOptions
+struct.OSCollection_Data.data=struct.OSObject_Data,0,0
+struct.OSCollection_Data.data.meta=4
+struct.OSCollection_Data.updateStamp=unsigned int,4,0
+struct.OSCollection_Data.updateStamp.meta=4
+struct.OSCollection_Data.fOptions=unsigned int,8,0
+struct.OSCollection_Data.fOptions.meta=4
+
+OSCollectionIterator_Data=struct
+struct.OSCollectionIterator_Data=data,collection,inlineStorage,__padding,collIterator,initialUpdateStamp,valid
+struct.OSCollectionIterator_Data.data=struct.OSIterator_Data,0,0
+struct.OSCollectionIterator_Data.data.meta=4
+struct.OSCollectionIterator_Data.collection=void *,8,0
+struct.OSCollectionIterator_Data.collection.meta=8
+struct.OSCollectionIterator_Data.inlineStorage=uint8_t,16,4
+struct.OSCollectionIterator_Data.inlineStorage.meta=1
+struct.OSCollectionIterator_Data.__padding=uint8_t,20,4
+struct.OSCollectionIterator_Data.__padding.meta=1
+struct.OSCollectionIterator_Data.collIterator=void *,24,0
+struct.OSCollectionIterator_Data.collIterator.meta=8
+struct.OSCollectionIterator_Data.initialUpdateStamp=unsigned int,32,0
+struct.OSCollectionIterator_Data.initialUpdateStamp.meta=4
+struct.OSCollectionIterator_Data.valid=bool,36,0
+struct.OSCollectionIterator_Data.valid.meta=1
+
+OSData_Data=struct
+struct.OSData_Data=data,length,capacity,capacityIncrement,data,reserved
+struct.OSData_Data.data=struct.OSObject_Data,0,0
+struct.OSData_Data.data.meta=4
+struct.OSData_Data.length=unsigned int,4,0
+struct.OSData_Data.length.meta=4
+struct.OSData_Data.capacity=unsigned int,8,0
+struct.OSData_Data.capacity.meta=4
+struct.OSData_Data.capacityIncrement=unsigned int,12,0
+struct.OSData_Data.capacityIncrement.meta=4
+struct.OSData_Data.data=void *,16,0
+struct.OSData_Data.data.meta=8
+struct.OSData_Data.reserved=void *,24,0
+struct.OSData_Data.reserved.meta=8
+
+OSDextStatistics_Data=struct
+struct.OSDextStatistics_Data=data,crashes,lock
+struct.OSDextStatistics_Data.data=struct.OSObject_Data,0,0
+struct.OSDextStatistics_Data.data.meta=4
+struct.OSDextStatistics_Data.crashes=void *,8,0
+struct.OSDextStatistics_Data.crashes.meta=8
+struct.OSDextStatistics_Data.lock=void *,16,0
+struct.OSDextStatistics_Data.lock.meta=8
+
+OSDictionary_Data=struct
+struct.OSDictionary_Data=data,count,capacity,capacityIncrement,dictionary
+struct.OSDictionary_Data.data=struct.OSCollection_Data,0,0
+struct.OSDictionary_Data.data.meta=12
+struct.OSDictionary_Data.count=unsigned int,12,0
+struct.OSDictionary_Data.count.meta=4
+struct.OSDictionary_Data.capacity=unsigned int,16,0
+struct.OSDictionary_Data.capacity.meta=4
+struct.OSDictionary_Data.capacityIncrement=unsigned int,20,0
+struct.OSDictionary_Data.capacityIncrement.meta=4
+struct.OSDictionary_Data.dictionary=void *,24,0
+struct.OSDictionary_Data.dictionary.meta=8
+
+OSIterator_Data=struct
+struct.OSIterator_Data=data
+struct.OSIterator_Data.data=struct.OSObject_Data,0,0
+struct.OSIterator_Data.data.meta=4
+
+OSKext_Data=struct
+struct.OSKext_Data=data,infoDict,bundleID,path,executableRelPath,userExecutableRelPath,version,compatibleVersion,loadTag,kmod_info,dependencies,linkedExecutable,metaClasses,interfaceUUID,driverKitUUID,loggingEnabled__b0,hasAllDependencies__b1,hasBleedthrough__b2,interface__b3,kernelComponent__b4,prelinked__b5,builtin__b6,loaded__b7,dtraceInitialized__b8,starting__b9,started__b10,stopping__b11,unloading__b12,resetSegmentsFromVnode__b13,requireExplicitLoad__b14,autounloadEnabled__b15,delayAutounload__b16,CPPInitialized__b17,jettisonLinkeditSeg__b18,resetSegmentsFromImmutableCopy__b19,unloadUnsupported__b20,dextToReplace__b21,unslidMachO__b22,matchingRefCount,kc_type,pendingPgoHead,instance_uuid,account,builtinKmodIdx,savedMutableSegments,dextStatistics,dextUniqueID,dextLaunchedCount
+struct.OSKext_Data.data=struct.OSObject_Data,0,0
+struct.OSKext_Data.data.meta=4
+struct.OSKext_Data.infoDict=void *,8,0
+struct.OSKext_Data.infoDict.meta=8
+struct.OSKext_Data.bundleID=void *,16,0
+struct.OSKext_Data.bundleID.meta=8
+struct.OSKext_Data.path=void *,24,0
+struct.OSKext_Data.path.meta=8
+struct.OSKext_Data.executableRelPath=void *,32,0
+struct.OSKext_Data.executableRelPath.meta=8
+struct.OSKext_Data.userExecutableRelPath=void *,40,0
+struct.OSKext_Data.userExecutableRelPath.meta=8
+struct.OSKext_Data.version=LONG,48,0
+struct.OSKext_Data.version.meta=8
+struct.OSKext_Data.compatibleVersion=LONG,56,0
+struct.OSKext_Data.compatibleVersion.meta=8
+struct.OSKext_Data.loadTag=int,64,0
+struct.OSKext_Data.loadTag.meta=4
+struct.OSKext_Data.kmod_info=void *,72,0
+struct.OSKext_Data.kmod_info.meta=8
+struct.OSKext_Data.dependencies=void *,80,0
+struct.OSKext_Data.dependencies.meta=8
+struct.OSKext_Data.linkedExecutable=void *,88,0
+struct.OSKext_Data.linkedExecutable.meta=8
+struct.OSKext_Data.metaClasses=void *,96,0
+struct.OSKext_Data.metaClasses.meta=8
+struct.OSKext_Data.interfaceUUID=void *,104,0
+struct.OSKext_Data.interfaceUUID.meta=8
+struct.OSKext_Data.driverKitUUID=void *,112,0
+struct.OSKext_Data.driverKitUUID.meta=8
+struct.OSKext_Data.loggingEnabled__b0=int,120,1
+struct.OSKext_Data.loggingEnabled__b0.meta=4
+struct.OSKext_Data.loggingEnabled__b0.@.bitoff=0
+struct.OSKext_Data.hasAllDependencies__b1=int,120,1
+struct.OSKext_Data.hasAllDependencies__b1.meta=4
+struct.OSKext_Data.hasAllDependencies__b1.@.bitoff=1
+struct.OSKext_Data.hasBleedthrough__b2=int,120,1
+struct.OSKext_Data.hasBleedthrough__b2.meta=4
+struct.OSKext_Data.hasBleedthrough__b2.@.bitoff=2
+struct.OSKext_Data.interface__b3=int,120,1
+struct.OSKext_Data.interface__b3.meta=4
+struct.OSKext_Data.interface__b3.@.bitoff=3
+struct.OSKext_Data.kernelComponent__b4=int,120,1
+struct.OSKext_Data.kernelComponent__b4.meta=4
+struct.OSKext_Data.kernelComponent__b4.@.bitoff=4
+struct.OSKext_Data.prelinked__b5=int,120,1
+struct.OSKext_Data.prelinked__b5.meta=4
+struct.OSKext_Data.prelinked__b5.@.bitoff=5
+struct.OSKext_Data.builtin__b6=int,120,1
+struct.OSKext_Data.builtin__b6.meta=4
+struct.OSKext_Data.builtin__b6.@.bitoff=6
+struct.OSKext_Data.loaded__b7=int,120,1
+struct.OSKext_Data.loaded__b7.meta=4
+struct.OSKext_Data.loaded__b7.@.bitoff=7
+struct.OSKext_Data.dtraceInitialized__b8=int,120,1
+struct.OSKext_Data.dtraceInitialized__b8.meta=4
+struct.OSKext_Data.dtraceInitialized__b8.@.bitoff=8
+struct.OSKext_Data.starting__b9=int,120,1
+struct.OSKext_Data.starting__b9.meta=4
+struct.OSKext_Data.starting__b9.@.bitoff=9
+struct.OSKext_Data.started__b10=int,120,1
+struct.OSKext_Data.started__b10.meta=4
+struct.OSKext_Data.started__b10.@.bitoff=10
+struct.OSKext_Data.stopping__b11=int,120,1
+struct.OSKext_Data.stopping__b11.meta=4
+struct.OSKext_Data.stopping__b11.@.bitoff=11
+struct.OSKext_Data.unloading__b12=int,120,1
+struct.OSKext_Data.unloading__b12.meta=4
+struct.OSKext_Data.unloading__b12.@.bitoff=12
+struct.OSKext_Data.resetSegmentsFromVnode__b13=int,120,1
+struct.OSKext_Data.resetSegmentsFromVnode__b13.meta=4
+struct.OSKext_Data.resetSegmentsFromVnode__b13.@.bitoff=13
+struct.OSKext_Data.requireExplicitLoad__b14=int,120,1
+struct.OSKext_Data.requireExplicitLoad__b14.meta=4
+struct.OSKext_Data.requireExplicitLoad__b14.@.bitoff=14
+struct.OSKext_Data.autounloadEnabled__b15=int,120,1
+struct.OSKext_Data.autounloadEnabled__b15.meta=4
+struct.OSKext_Data.autounloadEnabled__b15.@.bitoff=15
+struct.OSKext_Data.delayAutounload__b16=int,120,1
+struct.OSKext_Data.delayAutounload__b16.meta=4
+struct.OSKext_Data.delayAutounload__b16.@.bitoff=16
+struct.OSKext_Data.CPPInitialized__b17=int,120,1
+struct.OSKext_Data.CPPInitialized__b17.meta=4
+struct.OSKext_Data.CPPInitialized__b17.@.bitoff=17
+struct.OSKext_Data.jettisonLinkeditSeg__b18=int,120,1
+struct.OSKext_Data.jettisonLinkeditSeg__b18.meta=4
+struct.OSKext_Data.jettisonLinkeditSeg__b18.@.bitoff=18
+struct.OSKext_Data.resetSegmentsFromImmutableCopy__b19=int,120,1
+struct.OSKext_Data.resetSegmentsFromImmutableCopy__b19.meta=4
+struct.OSKext_Data.resetSegmentsFromImmutableCopy__b19.@.bitoff=19
+struct.OSKext_Data.unloadUnsupported__b20=int,120,1
+struct.OSKext_Data.unloadUnsupported__b20.meta=4
+struct.OSKext_Data.unloadUnsupported__b20.@.bitoff=20
+struct.OSKext_Data.dextToReplace__b21=int,120,1
+struct.OSKext_Data.dextToReplace__b21.meta=4
+struct.OSKext_Data.dextToReplace__b21.@.bitoff=21
+struct.OSKext_Data.unslidMachO__b22=int,120,1
+struct.OSKext_Data.unslidMachO__b22.meta=4
+struct.OSKext_Data.unslidMachO__b22.@.bitoff=22
+struct.OSKext_Data.matchingRefCount=uint32_t,124,0
+struct.OSKext_Data.matchingRefCount.meta=4
+struct.OSKext_Data.kc_type=void *,128,0
+struct.OSKext_Data.kc_type.meta=8
+struct.OSKext_Data.pendingPgoHead=struct.list_head,136,0
+struct.OSKext_Data.pendingPgoHead.meta=16
+struct.OSKext_Data.instance_uuid=char,152,0
+struct.OSKext_Data.instance_uuid.meta=1
+struct.OSKext_Data.account=void *,160,0
+struct.OSKext_Data.account.meta=8
+struct.OSKext_Data.builtinKmodIdx=uint32_t,168,0
+struct.OSKext_Data.builtinKmodIdx.meta=4
+struct.OSKext_Data.savedMutableSegments=void *,176,0
+struct.OSKext_Data.savedMutableSegments.meta=8
+struct.OSKext_Data.dextStatistics=void *,184,0
+struct.OSKext_Data.dextStatistics.meta=8
+struct.OSKext_Data.dextUniqueID=void *,192,0
+struct.OSKext_Data.dextUniqueID.meta=8
+struct.OSKext_Data.dextLaunchedCount=uint32_t,200,0
+struct.OSKext_Data.dextLaunchedCount.meta=4
+
+OSKextSavedMutableSegment_Data=struct
+struct.OSKextSavedMutableSegment_Data=data,savedSegment,vmaddr,vmsize,data
+struct.OSKextSavedMutableSegment_Data.data=struct.OSObject_Data,0,0
+struct.OSKextSavedMutableSegment_Data.data.meta=4
+struct.OSKextSavedMutableSegment_Data.savedSegment=void *,8,0
+struct.OSKextSavedMutableSegment_Data.savedSegment.meta=8
+struct.OSKextSavedMutableSegment_Data.vmaddr=LONG,16,0
+struct.OSKextSavedMutableSegment_Data.vmaddr.meta=8
+struct.OSKextSavedMutableSegment_Data.vmsize=LONG,24,0
+struct.OSKextSavedMutableSegment_Data.vmsize.meta=8
+struct.OSKextSavedMutableSegment_Data.data=void *,32,0
+struct.OSKextSavedMutableSegment_Data.data.meta=8
+
+OSMetaClass_Data=struct
+struct.OSMetaClass_Data=data,reserved,superClassLink,className,classSize,instanceCount
+struct.OSMetaClass_Data.data=struct.OSMetaClassBase_Data,0,0
+struct.OSMetaClass_Data.data.meta=0
+struct.OSMetaClass_Data.reserved=void *,0,0
+struct.OSMetaClass_Data.reserved.meta=8
+struct.OSMetaClass_Data.superClassLink=void *,8,0
+struct.OSMetaClass_Data.superClassLink.meta=8
+struct.OSMetaClass_Data.className=void *,16,0
+struct.OSMetaClass_Data.className.meta=8
+struct.OSMetaClass_Data.classSize=unsigned int,24,0
+struct.OSMetaClass_Data.classSize.meta=4
+struct.OSMetaClass_Data.instanceCount=unsigned int,28,0
+struct.OSMetaClass_Data.instanceCount.meta=4
+
+OSMetaClassBase_Data=struct
+struct.OSMetaClassBase_Data=
+
+OSNumber_Data=struct
+struct.OSNumber_Data=data,size,value,fpValue
+struct.OSNumber_Data.data=struct.OSObject_Data,0,0
+struct.OSNumber_Data.data.meta=4
+struct.OSNumber_Data.size=unsigned int,4,0
+struct.OSNumber_Data.size.meta=4
+struct.OSNumber_Data.value=unsigned long long,8,0
+struct.OSNumber_Data.value.meta=8
+struct.OSNumber_Data.fpValue=double,16,0
+struct.OSNumber_Data.fpValue.meta=8
+
+OSObject_Data=struct
+struct.OSObject_Data=data,retainCount
+struct.OSObject_Data.data=struct.OSMetaClassBase_Data,0,0
+struct.OSObject_Data.data.meta=0
+struct.OSObject_Data.retainCount=int,0,0
+struct.OSObject_Data.retainCount.meta=4
+
+OSOrderedSet_Data=struct
+struct.OSOrderedSet_Data=data,array,ordering,orderingRef,count,capacity,capacityIncrement,reserved
+struct.OSOrderedSet_Data.data=struct.OSCollection_Data,0,0
+struct.OSOrderedSet_Data.data.meta=12
+struct.OSOrderedSet_Data.array=void *,16,0
+struct.OSOrderedSet_Data.array.meta=8
+struct.OSOrderedSet_Data.ordering=void *,24,0
+struct.OSOrderedSet_Data.ordering.meta=8
+struct.OSOrderedSet_Data.orderingRef=void *,32,0
+struct.OSOrderedSet_Data.orderingRef.meta=8
+struct.OSOrderedSet_Data.count=unsigned int,40,0
+struct.OSOrderedSet_Data.count.meta=4
+struct.OSOrderedSet_Data.capacity=unsigned int,44,0
+struct.OSOrderedSet_Data.capacity.meta=4
+struct.OSOrderedSet_Data.capacityIncrement=unsigned int,48,0
+struct.OSOrderedSet_Data.capacityIncrement.meta=4
+struct.OSOrderedSet_Data.reserved=void *,56,0
+struct.OSOrderedSet_Data.reserved.meta=8
+
+OSSerialize_Data=struct
+struct.OSSerialize_Data=data,data,length,capacity,capacityIncrement,tags,binary,endCollection,editor,editRef,indexData
+struct.OSSerialize_Data.data=struct.OSObject_Data,0,0
+struct.OSSerialize_Data.data.meta=4
+struct.OSSerialize_Data.data=void *,8,0
+struct.OSSerialize_Data.data.meta=8
+struct.OSSerialize_Data.length=unsigned int,16,0
+struct.OSSerialize_Data.length.meta=4
+struct.OSSerialize_Data.capacity=unsigned int,20,0
+struct.OSSerialize_Data.capacity.meta=4
+struct.OSSerialize_Data.capacityIncrement=unsigned int,24,0
+struct.OSSerialize_Data.capacityIncrement.meta=4
+struct.OSSerialize_Data.tags=void *,32,0
+struct.OSSerialize_Data.tags.meta=8
+struct.OSSerialize_Data.binary=bool,40,0
+struct.OSSerialize_Data.binary.meta=1
+struct.OSSerialize_Data.endCollection=bool,41,0
+struct.OSSerialize_Data.endCollection.meta=1
+struct.OSSerialize_Data.editor=void *,48,0
+struct.OSSerialize_Data.editor.meta=8
+struct.OSSerialize_Data.editRef=void *,56,0
+struct.OSSerialize_Data.editRef.meta=8
+struct.OSSerialize_Data.indexData=void *,64,0
+struct.OSSerialize_Data.indexData.meta=8
+
+OSSerializer_Data=struct
+struct.OSSerializer_Data=data,target,ref,callback
+struct.OSSerializer_Data.data=struct.OSObject_Data,0,0
+struct.OSSerializer_Data.data.meta=4
+struct.OSSerializer_Data.target=void *,8,0
+struct.OSSerializer_Data.target.meta=8
+struct.OSSerializer_Data.ref=void *,16,0
+struct.OSSerializer_Data.ref.meta=8
+struct.OSSerializer_Data.callback=bool,24,0
+struct.OSSerializer_Data.callback.meta=1
+
+OSSet_Data=struct
+struct.OSSet_Data=data,members
+struct.OSSet_Data.data=struct.OSCollection_Data,0,0
+struct.OSSet_Data.data.meta=12
+struct.OSSet_Data.members=void *,16,0
+struct.OSSet_Data.members.meta=8
+
+OSString_Data=struct
+struct.OSString_Data=data,flags__b0,length__b14,string
+struct.OSString_Data.data=struct.OSObject_Data,0,0
+struct.OSString_Data.data.meta=4
+struct.OSString_Data.flags__b0=int,4,14
+struct.OSString_Data.flags__b0.meta=4
+struct.OSString_Data.flags__b0.@.bitoff=0
+struct.OSString_Data.length__b14=int,4,18
+struct.OSString_Data.length__b14.meta=4
+struct.OSString_Data.length__b14.@.bitoff=14
+struct.OSString_Data.string=void *,8,0
+struct.OSString_Data.string.meta=8
+
+OSSymbol_Data=struct
+struct.OSSymbol_Data=data,hashlink
+struct.OSSymbol_Data.data=struct.OSString_Data,0,0
+struct.OSSymbol_Data.data.meta=16
+struct.OSSymbol_Data.hashlink=struct.smrq_slink,16,0
+struct.OSSymbol_Data.hashlink.meta=8
+
+OSValueObject_Data=struct
+struct.OSValueObject_Data=data,data
+struct.OSValueObject_Data.data=struct.OSObject_Data,0,0
+struct.OSValueObject_Data.data.meta=4
+struct.OSValueObject_Data.data=void *,8,0
+struct.OSValueObject_Data.data.meta=8
+
+PassthruInterruptController_Data=struct
+struct.PassthruInterruptController_Data=data,child_handler,child_target,child_refCon,child_nub,child_sentinel
+struct.PassthruInterruptController_Data.data=struct.IOInterruptController_Data,0,0
+struct.PassthruInterruptController_Data.data.meta=152
+struct.PassthruInterruptController_Data.child_handler=void *,152,0
+struct.PassthruInterruptController_Data.child_handler.meta=8
+struct.PassthruInterruptController_Data.child_target=void *,160,0
+struct.PassthruInterruptController_Data.child_target.meta=8
+struct.PassthruInterruptController_Data.child_refCon=void *,168,0
+struct.PassthruInterruptController_Data.child_refCon.meta=8
+struct.PassthruInterruptController_Data.child_nub=void *,176,0
+struct.PassthruInterruptController_Data.child_nub.meta=8
+struct.PassthruInterruptController_Data.child_sentinel=void *,184,0
+struct.PassthruInterruptController_Data.child_sentinel.meta=8
+
+_IOUserServerCheckInCancellationHandler_Data=struct
+struct._IOUserServerCheckInCancellationHandler_Data=data,fHandler,fHandlerArgs
+struct._IOUserServerCheckInCancellationHandler_Data.data=struct.OSObject_Data,0,0
+struct._IOUserServerCheckInCancellationHandler_Data.data.meta=4
+struct._IOUserServerCheckInCancellationHandler_Data.fHandler=void *,8,0
+struct._IOUserServerCheckInCancellationHandler_Data.fHandler.meta=8
+struct._IOUserServerCheckInCancellationHandler_Data.fHandlerArgs=void *,16,0
+struct._IOUserServerCheckInCancellationHandler_Data.fHandlerArgs.meta=8
 
 IOBigMemoryCursor=struct
 struct.IOBigMemoryCursor=vtable,data
@@ -10144,9 +10112,9 @@ struct.IOBufferMemoryDescriptor.data=struct.IOBufferMemoryDescriptor_Data,8,0
 struct.IOBufferMemoryDescriptor.data.meta=224
 
 IOBufferMemoryDescriptor::ExpansionData=struct
-struct.IOBufferMemoryDescriptor::ExpansionData=data
-struct.IOBufferMemoryDescriptor::ExpansionData.data=struct.IOBufferMemoryDescriptor::ExpansionData_Data,0,0
-struct.IOBufferMemoryDescriptor::ExpansionData.data.meta=8
+struct.IOBufferMemoryDescriptor::ExpansionData=map
+struct.IOBufferMemoryDescriptor::ExpansionData.map=void *,0,0
+struct.IOBufferMemoryDescriptor::ExpansionData.map.meta=8
 
 IOCPU=struct
 struct.IOCPU=vtable,data
@@ -10156,9 +10124,7 @@ struct.IOCPU.data=struct.IOCPU_Data,8,0
 struct.IOCPU.data.meta=176
 
 IOCPU::ExpansionData=struct
-struct.IOCPU::ExpansionData=data
-struct.IOCPU::ExpansionData.data=struct.IOCPU::ExpansionData_Data,0,0
-struct.IOCPU::ExpansionData.data.meta=0
+struct.IOCPU::ExpansionData=
 
 IOCPUInterruptController=struct
 struct.IOCPUInterruptController=vtable,data
@@ -10168,9 +10134,7 @@ struct.IOCPUInterruptController.data=struct.IOCPUInterruptController_Data,8,0
 struct.IOCPUInterruptController.data.meta=176
 
 IOCPUInterruptController::ExpansionData=struct
-struct.IOCPUInterruptController::ExpansionData=data
-struct.IOCPUInterruptController::ExpansionData.data=struct.IOCPUInterruptController::ExpansionData_Data,0,0
-struct.IOCPUInterruptController::ExpansionData.data.meta=0
+struct.IOCPUInterruptController::ExpansionData=
 
 IOCatalogue=struct
 struct.IOCatalogue=vtable,data
@@ -10194,9 +10158,7 @@ struct.IOCommandGate.data=struct.IOCommandGate_Data,8,0
 struct.IOCommandGate.data.meta=80
 
 IOCommandGate::ExpansionData=struct
-struct.IOCommandGate::ExpansionData=data
-struct.IOCommandGate::ExpansionData.data=struct.IOCommandGate::ExpansionData_Data,0,0
-struct.IOCommandGate::ExpansionData.data.meta=0
+struct.IOCommandGate::ExpansionData=
 
 IOCommandPool=struct
 struct.IOCommandPool=vtable,data
@@ -10206,9 +10168,7 @@ struct.IOCommandPool.data=struct.IOCommandPool_Data,8,0
 struct.IOCommandPool.data.meta=40
 
 IOCommandPool::ExpansionData=struct
-struct.IOCommandPool::ExpansionData=data
-struct.IOCommandPool::ExpansionData.data=struct.IOCommandPool::ExpansionData_Data,0,0
-struct.IOCommandPool::ExpansionData.data.meta=0
+struct.IOCommandPool::ExpansionData=
 
 IOConditionLock=struct
 struct.IOConditionLock=vtable,data
@@ -10225,9 +10185,21 @@ struct.IODMACommand.data=struct.IODMACommand_Data,8,0
 struct.IODMACommand.data.meta=104
 
 IODMACommand::SegmentOptions=struct
-struct.IODMACommand::SegmentOptions=data
-struct.IODMACommand::SegmentOptions.data=struct.IODMACommand::SegmentOptions_Data,0,0
-struct.IODMACommand::SegmentOptions.data.meta=40
+struct.IODMACommand::SegmentOptions=fStructSize,fNumAddressBits,fMaxSegmentSize,fMaxTransferSize,fAlignment,fAlignmentLength,fAlignmentInternalSegments
+struct.IODMACommand::SegmentOptions.fStructSize=uint8_t,0,0
+struct.IODMACommand::SegmentOptions.fStructSize.meta=1
+struct.IODMACommand::SegmentOptions.fNumAddressBits=uint8_t,1,0
+struct.IODMACommand::SegmentOptions.fNumAddressBits.meta=1
+struct.IODMACommand::SegmentOptions.fMaxSegmentSize=uint64_t,8,0
+struct.IODMACommand::SegmentOptions.fMaxSegmentSize.meta=8
+struct.IODMACommand::SegmentOptions.fMaxTransferSize=uint64_t,16,0
+struct.IODMACommand::SegmentOptions.fMaxTransferSize.meta=8
+struct.IODMACommand::SegmentOptions.fAlignment=uint32_t,24,0
+struct.IODMACommand::SegmentOptions.fAlignment.meta=4
+struct.IODMACommand::SegmentOptions.fAlignmentLength=uint32_t,28,0
+struct.IODMACommand::SegmentOptions.fAlignmentLength.meta=4
+struct.IODMACommand::SegmentOptions.fAlignmentInternalSegments=uint32_t,32,0
+struct.IODMACommand::SegmentOptions.fAlignmentInternalSegments.meta=4
 
 IODMAController=struct
 struct.IODMAController=vtable,data
@@ -10244,14 +10216,28 @@ struct.IODMAEventSource.data=struct.IODMAEventSource_Data,8,0
 struct.IODMAEventSource.data.meta=136
 
 IODMAMapPageList=struct
-struct.IODMAMapPageList=data
-struct.IODMAMapPageList.data=struct.IODMAMapPageList_Data,0,0
-struct.IODMAMapPageList.data.meta=16
+struct.IODMAMapPageList=pageOffset,pageListCount,pageList
+struct.IODMAMapPageList.pageOffset=uint32_t,0,0
+struct.IODMAMapPageList.pageOffset.meta=4
+struct.IODMAMapPageList.pageListCount=uint32_t,4,0
+struct.IODMAMapPageList.pageListCount.meta=4
+struct.IODMAMapPageList.pageList=void *,8,0
+struct.IODMAMapPageList.pageList.meta=8
 
 IODMAMapSpecification=struct
-struct.IODMAMapSpecification=data
-struct.IODMAMapSpecification.data=struct.IODMAMapSpecification_Data,0,0
-struct.IODMAMapSpecification.data.meta=40
+struct.IODMAMapSpecification=alignment,device,options,numAddressBits,resvA,resvB
+struct.IODMAMapSpecification.alignment=uint64_t,0,0
+struct.IODMAMapSpecification.alignment.meta=8
+struct.IODMAMapSpecification.device=void *,8,0
+struct.IODMAMapSpecification.device.meta=8
+struct.IODMAMapSpecification.options=uint32_t,16,0
+struct.IODMAMapSpecification.options.meta=4
+struct.IODMAMapSpecification.numAddressBits=uint8_t,20,0
+struct.IODMAMapSpecification.numAddressBits.meta=1
+struct.IODMAMapSpecification.resvA=uint8_t,21,3
+struct.IODMAMapSpecification.resvA.meta=1
+struct.IODMAMapSpecification.resvB=uint32_t,24,4
+struct.IODMAMapSpecification.resvB.meta=4
 
 IODTNVRAM=struct
 struct.IODTNVRAM=vtable,data
@@ -10268,9 +10254,7 @@ struct.IODTPlatformExpert.data=struct.IODTPlatformExpert_Data,8,0
 struct.IODTPlatformExpert.data.meta=232
 
 IODTPlatformExpert::ExpansionData=struct
-struct.IODTPlatformExpert::ExpansionData=data
-struct.IODTPlatformExpert::ExpansionData.data=struct.IODTPlatformExpert::ExpansionData_Data,0,0
-struct.IODTPlatformExpert::ExpansionData.data.meta=0
+struct.IODTPlatformExpert::ExpansionData=
 
 IODataQueue=struct
 struct.IODataQueue=vtable,data
@@ -10294,9 +10278,7 @@ struct.IODispatchQueue.data=struct.IODispatchQueue_Data,8,0
 struct.IODispatchQueue.data.meta=24
 
 IODispatchQueueInterface=struct
-struct.IODispatchQueueInterface=data
-struct.IODispatchQueueInterface.data=struct.IODispatchQueueInterface_Data,0,0
-struct.IODispatchQueueInterface.data.meta=0
+struct.IODispatchQueueInterface=
 
 IODispatchSource=struct
 struct.IODispatchSource=vtable,data
@@ -10306,9 +10288,7 @@ struct.IODispatchSource.data=struct.IODispatchSource_Data,8,0
 struct.IODispatchSource.data.meta=24
 
 IODispatchSourceInterface=struct
-struct.IODispatchSourceInterface=data
-struct.IODispatchSourceInterface.data=struct.IODispatchSourceInterface_Data,0,0
-struct.IODispatchSourceInterface.data.meta=0
+struct.IODispatchSourceInterface=
 
 IOEventLink=struct
 struct.IOEventLink=vtable,data
@@ -10318,9 +10298,7 @@ struct.IOEventLink.data=struct.IOEventLink_Data,8,0
 struct.IOEventLink.data.meta=24
 
 IOEventLinkInterface=struct
-struct.IOEventLinkInterface=data
-struct.IOEventLinkInterface.data=struct.IOEventLinkInterface_Data,0,0
-struct.IOEventLinkInterface.data.meta=0
+struct.IOEventLinkInterface=
 
 IOEventSource=struct
 struct.IOEventSource=vtable,data
@@ -10330,9 +10308,9 @@ struct.IOEventSource.data=struct.IOEventSource_Data,8,0
 struct.IOEventSource.data.meta=72
 
 IOEventSource::ExpansionData=struct
-struct.IOEventSource::ExpansionData=data
-struct.IOEventSource::ExpansionData.data=struct.IOEventSource::ExpansionData_Data,0,0
-struct.IOEventSource::ExpansionData.data.meta=8
+struct.IOEventSource::ExpansionData=iokitstatsReserved
+struct.IOEventSource::ExpansionData.iokitstatsReserved=void *,0,0
+struct.IOEventSource::ExpansionData.iokitstatsReserved.meta=8
 
 IOExtensiblePaniclog=struct
 struct.IOExtensiblePaniclog=vtable,data
@@ -10342,29 +10320,91 @@ struct.IOExtensiblePaniclog.data=struct.IOExtensiblePaniclog_Data,8,0
 struct.IOExtensiblePaniclog.data.meta=24
 
 IOExternalAsyncMethod=struct
-struct.IOExternalAsyncMethod=data
-struct.IOExternalAsyncMethod.data=struct.IOExternalAsyncMethod_Data,0,0
-struct.IOExternalAsyncMethod.data.meta=40
+struct.IOExternalAsyncMethod=object,func,flags,count0,count1
+struct.IOExternalAsyncMethod.object=void *,0,0
+struct.IOExternalAsyncMethod.object.meta=8
+struct.IOExternalAsyncMethod.func=void *,8,0
+struct.IOExternalAsyncMethod.func.meta=8
+struct.IOExternalAsyncMethod.flags=int,16,0
+struct.IOExternalAsyncMethod.flags.meta=4
+struct.IOExternalAsyncMethod.count0=LONG,24,0
+struct.IOExternalAsyncMethod.count0.meta=8
+struct.IOExternalAsyncMethod.count1=LONG,32,0
+struct.IOExternalAsyncMethod.count1.meta=8
 
 IOExternalMethod=struct
-struct.IOExternalMethod=data
-struct.IOExternalMethod.data=struct.IOExternalMethod_Data,0,0
-struct.IOExternalMethod.data.meta=40
+struct.IOExternalMethod=object,func,flags,count0,count1
+struct.IOExternalMethod.object=void *,0,0
+struct.IOExternalMethod.object.meta=8
+struct.IOExternalMethod.func=void *,8,0
+struct.IOExternalMethod.func.meta=8
+struct.IOExternalMethod.flags=int,16,0
+struct.IOExternalMethod.flags.meta=4
+struct.IOExternalMethod.count0=LONG,24,0
+struct.IOExternalMethod.count0.meta=8
+struct.IOExternalMethod.count1=LONG,32,0
+struct.IOExternalMethod.count1.meta=8
 
 IOExternalMethodArguments=struct
-struct.IOExternalMethodArguments=data
-struct.IOExternalMethodArguments.data=struct.IOExternalMethodArguments_Data,0,0
-struct.IOExternalMethodArguments.data.meta=248
+struct.IOExternalMethodArguments=version,selector,asyncWakePort,asyncReference,asyncReferenceCount,scalarInput,scalarInputCount,structureInput,structureInputSize,structureInputDescriptor,scalarOutput,scalarOutputCount,structureOutput,structureOutputSize,structureOutputDescriptor,structureOutputDescriptorSize,__reservedA,structureVariableOutputData,__reserved
+struct.IOExternalMethodArguments.version=uint32_t,0,0
+struct.IOExternalMethodArguments.version.meta=4
+struct.IOExternalMethodArguments.selector=uint32_t,4,0
+struct.IOExternalMethodArguments.selector.meta=4
+struct.IOExternalMethodArguments.asyncWakePort=void *,8,0
+struct.IOExternalMethodArguments.asyncWakePort.meta=8
+struct.IOExternalMethodArguments.asyncReference=void *,16,0
+struct.IOExternalMethodArguments.asyncReference.meta=8
+struct.IOExternalMethodArguments.asyncReferenceCount=uint32_t,24,0
+struct.IOExternalMethodArguments.asyncReferenceCount.meta=4
+struct.IOExternalMethodArguments.scalarInput=void *,32,0
+struct.IOExternalMethodArguments.scalarInput.meta=8
+struct.IOExternalMethodArguments.scalarInputCount=uint32_t,40,0
+struct.IOExternalMethodArguments.scalarInputCount.meta=4
+struct.IOExternalMethodArguments.structureInput=void *,48,0
+struct.IOExternalMethodArguments.structureInput.meta=8
+struct.IOExternalMethodArguments.structureInputSize=uint32_t,56,0
+struct.IOExternalMethodArguments.structureInputSize.meta=4
+struct.IOExternalMethodArguments.structureInputDescriptor=void *,64,0
+struct.IOExternalMethodArguments.structureInputDescriptor.meta=8
+struct.IOExternalMethodArguments.scalarOutput=void *,72,0
+struct.IOExternalMethodArguments.scalarOutput.meta=8
+struct.IOExternalMethodArguments.scalarOutputCount=uint32_t,80,0
+struct.IOExternalMethodArguments.scalarOutputCount.meta=4
+struct.IOExternalMethodArguments.structureOutput=void *,88,0
+struct.IOExternalMethodArguments.structureOutput.meta=8
+struct.IOExternalMethodArguments.structureOutputSize=uint32_t,96,0
+struct.IOExternalMethodArguments.structureOutputSize.meta=4
+struct.IOExternalMethodArguments.structureOutputDescriptor=void *,104,0
+struct.IOExternalMethodArguments.structureOutputDescriptor.meta=8
+struct.IOExternalMethodArguments.structureOutputDescriptorSize=uint32_t,112,0
+struct.IOExternalMethodArguments.structureOutputDescriptorSize.meta=4
+struct.IOExternalMethodArguments.__reservedA=uint32_t,116,0
+struct.IOExternalMethodArguments.__reservedA.meta=4
+struct.IOExternalMethodArguments.structureVariableOutputData=void *,120,0
+struct.IOExternalMethodArguments.structureVariableOutputData.meta=8
+struct.IOExternalMethodArguments.__reserved=uint32_t,128,30
+struct.IOExternalMethodArguments.__reserved.meta=4
 
 IOExternalMethodDispatch=struct
-struct.IOExternalMethodDispatch=data
-struct.IOExternalMethodDispatch.data=struct.IOExternalMethodDispatch_Data,0,0
-struct.IOExternalMethodDispatch.data.meta=24
+struct.IOExternalMethodDispatch=function,checkScalarInputCount,checkStructureInputSize,checkScalarOutputCount,checkStructureOutputSize
+struct.IOExternalMethodDispatch.function=int,0,0
+struct.IOExternalMethodDispatch.function.meta=4
+struct.IOExternalMethodDispatch.checkScalarInputCount=uint32_t,4,0
+struct.IOExternalMethodDispatch.checkScalarInputCount.meta=4
+struct.IOExternalMethodDispatch.checkStructureInputSize=uint32_t,8,0
+struct.IOExternalMethodDispatch.checkStructureInputSize.meta=4
+struct.IOExternalMethodDispatch.checkScalarOutputCount=uint32_t,12,0
+struct.IOExternalMethodDispatch.checkScalarOutputCount.meta=4
+struct.IOExternalMethodDispatch.checkStructureOutputSize=uint32_t,16,0
+struct.IOExternalMethodDispatch.checkStructureOutputSize.meta=4
 
 IOExternalTrap=struct
-struct.IOExternalTrap=data
-struct.IOExternalTrap.data=struct.IOExternalTrap_Data,0,0
-struct.IOExternalTrap.data.meta=16
+struct.IOExternalTrap=object,func
+struct.IOExternalTrap.object=void *,0,0
+struct.IOExternalTrap.object.meta=8
+struct.IOExternalTrap.func=void *,8,0
+struct.IOExternalTrap.func.meta=8
 
 IOFilterInterruptEventSource=struct
 struct.IOFilterInterruptEventSource=vtable,data
@@ -10374,9 +10414,7 @@ struct.IOFilterInterruptEventSource.data=struct.IOFilterInterruptEventSource_Dat
 struct.IOFilterInterruptEventSource.data.meta=128
 
 IOFilterInterruptEventSource::ExpansionData=struct
-struct.IOFilterInterruptEventSource::ExpansionData=data
-struct.IOFilterInterruptEventSource::ExpansionData.data=struct.IOFilterInterruptEventSource::ExpansionData_Data,0,0
-struct.IOFilterInterruptEventSource::ExpansionData.data.meta=0
+struct.IOFilterInterruptEventSource::ExpansionData=
 
 IOGeneralMemoryDescriptor=struct
 struct.IOGeneralMemoryDescriptor=vtable,data
@@ -10386,9 +10424,15 @@ struct.IOGeneralMemoryDescriptor.data=struct.IOGeneralMemoryDescriptor_Data,8,0
 struct.IOGeneralMemoryDescriptor.data.meta=168
 
 IOGeneralMemoryDescriptor::Ranges=struct
-struct.IOGeneralMemoryDescriptor::Ranges=data
-struct.IOGeneralMemoryDescriptor::Ranges.data=struct.IOGeneralMemoryDescriptor::Ranges_Data,0,0
-struct.IOGeneralMemoryDescriptor::Ranges.data.meta=32
+struct.IOGeneralMemoryDescriptor::Ranges=v,v64,p,uio
+struct.IOGeneralMemoryDescriptor::Ranges.v=void *,0,0
+struct.IOGeneralMemoryDescriptor::Ranges.v.meta=8
+struct.IOGeneralMemoryDescriptor::Ranges.v64=void *,8,0
+struct.IOGeneralMemoryDescriptor::Ranges.v64.meta=8
+struct.IOGeneralMemoryDescriptor::Ranges.p=void *,16,0
+struct.IOGeneralMemoryDescriptor::Ranges.p.meta=8
+struct.IOGeneralMemoryDescriptor::Ranges.uio=void *,24,0
+struct.IOGeneralMemoryDescriptor::Ranges.uio.meta=8
 
 IOGuardPageMemoryDescriptor=struct
 struct.IOGuardPageMemoryDescriptor=vtable,data
@@ -10412,9 +10456,19 @@ struct.IOInterleavedMemoryDescriptor.data=struct.IOInterleavedMemoryDescriptor_D
 struct.IOInterleavedMemoryDescriptor.data.meta=136
 
 IOInterruptAccountingData=struct
-struct.IOInterruptAccountingData=data
-struct.IOInterruptAccountingData.data=struct.IOInterruptAccountingData_Data,0,0
-struct.IOInterruptAccountingData.data.meta=112
+struct.IOInterruptAccountingData=owner,chain,interruptIndex,enablePrimaryTimestamp,primaryTimestamp,interruptStatistics
+struct.IOInterruptAccountingData.owner=void *,0,0
+struct.IOInterruptAccountingData.owner.meta=8
+struct.IOInterruptAccountingData.chain=void *,8,0
+struct.IOInterruptAccountingData.chain.meta=8
+struct.IOInterruptAccountingData.interruptIndex=int,16,0
+struct.IOInterruptAccountingData.interruptIndex.meta=4
+struct.IOInterruptAccountingData.enablePrimaryTimestamp=bool,20,0
+struct.IOInterruptAccountingData.enablePrimaryTimestamp.meta=1
+struct.IOInterruptAccountingData.primaryTimestamp=uint64_t,24,0
+struct.IOInterruptAccountingData.primaryTimestamp.meta=8
+struct.IOInterruptAccountingData.interruptStatistics=uint64_t,32,10
+struct.IOInterruptAccountingData.interruptStatistics.meta=8
 
 IOInterruptController=struct
 struct.IOInterruptController=vtable,data
@@ -10424,9 +10478,7 @@ struct.IOInterruptController.data=struct.IOInterruptController_Data,8,0
 struct.IOInterruptController.data.meta=152
 
 IOInterruptController::ExpansionData=struct
-struct.IOInterruptController::ExpansionData=data
-struct.IOInterruptController::ExpansionData.data=struct.IOInterruptController::ExpansionData_Data,0,0
-struct.IOInterruptController::ExpansionData.data.meta=0
+struct.IOInterruptController::ExpansionData=
 
 IOInterruptEventSource=struct
 struct.IOInterruptEventSource=vtable,data
@@ -10436,24 +10488,46 @@ struct.IOInterruptEventSource.data=struct.IOInterruptEventSource_Data,8,0
 struct.IOInterruptEventSource.data.meta=104
 
 IOInterruptEventSource::ExpansionData=struct
-struct.IOInterruptEventSource::ExpansionData=data
-struct.IOInterruptEventSource::ExpansionData.data=struct.IOInterruptEventSource::ExpansionData_Data,0,0
-struct.IOInterruptEventSource::ExpansionData.data.meta=8
+struct.IOInterruptEventSource::ExpansionData=statistics
+struct.IOInterruptEventSource::ExpansionData.statistics=void *,0,0
+struct.IOInterruptEventSource::ExpansionData.statistics.meta=8
 
 IOInterruptSource=struct
-struct.IOInterruptSource=data
-struct.IOInterruptSource.data=struct.IOInterruptSource_Data,0,0
-struct.IOInterruptSource.data.meta=16
+struct.IOInterruptSource=interruptController,vectorData
+struct.IOInterruptSource.interruptController=void *,0,0
+struct.IOInterruptSource.interruptController.meta=8
+struct.IOInterruptSource.vectorData=void *,8,0
+struct.IOInterruptSource.vectorData.meta=8
 
 IOInterruptSourcePrivate=struct
-struct.IOInterruptSourcePrivate=data
-struct.IOInterruptSourcePrivate.data=struct.IOInterruptSourcePrivate_Data,0,0
-struct.IOInterruptSourcePrivate.data.meta=8
+struct.IOInterruptSourcePrivate=vectorBlock
+struct.IOInterruptSourcePrivate.vectorBlock=void *,0,0
+struct.IOInterruptSourcePrivate.vectorBlock.meta=8
 
 IOInterruptVector=struct
-struct.IOInterruptVector=data
-struct.IOInterruptVector.data=struct.IOInterruptVector_Data,0,0
-struct.IOInterruptVector.data.meta=64
+struct.IOInterruptVector=interruptActive,interruptDisabledSoft,interruptDisabledHard,interruptRegistered,interruptLock,nub,source,target,handler,refCon,sharedController
+struct.IOInterruptVector.interruptActive=char,0,0
+struct.IOInterruptVector.interruptActive.meta=1
+struct.IOInterruptVector.interruptDisabledSoft=char,1,0
+struct.IOInterruptVector.interruptDisabledSoft.meta=1
+struct.IOInterruptVector.interruptDisabledHard=char,2,0
+struct.IOInterruptVector.interruptDisabledHard.meta=1
+struct.IOInterruptVector.interruptRegistered=char,3,0
+struct.IOInterruptVector.interruptRegistered.meta=1
+struct.IOInterruptVector.interruptLock=void *,8,0
+struct.IOInterruptVector.interruptLock.meta=8
+struct.IOInterruptVector.nub=void *,16,0
+struct.IOInterruptVector.nub.meta=8
+struct.IOInterruptVector.source=int,24,0
+struct.IOInterruptVector.source.meta=4
+struct.IOInterruptVector.target=void *,32,0
+struct.IOInterruptVector.target.meta=8
+struct.IOInterruptVector.handler=void *,40,0
+struct.IOInterruptVector.handler.meta=8
+struct.IOInterruptVector.refCon=void *,48,0
+struct.IOInterruptVector.refCon.meta=8
+struct.IOInterruptVector.sharedController=void *,56,0
+struct.IOInterruptVector.sharedController.meta=8
 
 IOKitDiagnostics=struct
 struct.IOKitDiagnostics=vtable,data
@@ -10491,9 +10565,11 @@ struct.IOMemoryCursor.data=struct.IOMemoryCursor_Data,8,0
 struct.IOMemoryCursor.data.meta=40
 
 IOMemoryCursor::PhysicalSegment=struct
-struct.IOMemoryCursor::PhysicalSegment=data
-struct.IOMemoryCursor::PhysicalSegment.data=struct.IOMemoryCursor::PhysicalSegment_Data,0,0
-struct.IOMemoryCursor::PhysicalSegment.data.meta=16
+struct.IOMemoryCursor::PhysicalSegment=location,length
+struct.IOMemoryCursor::PhysicalSegment.location=LONG,0,0
+struct.IOMemoryCursor::PhysicalSegment.location.meta=8
+struct.IOMemoryCursor::PhysicalSegment.length=LONG,8,0
+struct.IOMemoryCursor::PhysicalSegment.length.meta=8
 
 IOMemoryDescriptor=struct
 struct.IOMemoryDescriptor=vtable,data
@@ -10559,9 +10635,31 @@ struct.IOPMPowerSourceList.data=struct.IOPMPowerSourceList_Data,8,0
 struct.IOPMPowerSourceList.data.meta=24
 
 IOPMPowerState=struct
-struct.IOPMPowerState=data
-struct.IOPMPowerState.data=struct.IOPMPowerState_Data,0,0
-struct.IOPMPowerState.data.meta=96
+struct.IOPMPowerState=version,capabilityFlags,outputPowerCharacter,inputPowerRequirement,staticPower,stateOrder,powerToAttain,timeToAttain,settleUpTime,timeToLower,settleDownTime,powerDomainBudget
+struct.IOPMPowerState.version=LONGU,0,0
+struct.IOPMPowerState.version.meta=8
+struct.IOPMPowerState.capabilityFlags=LONG,8,0
+struct.IOPMPowerState.capabilityFlags.meta=8
+struct.IOPMPowerState.outputPowerCharacter=LONG,16,0
+struct.IOPMPowerState.outputPowerCharacter.meta=8
+struct.IOPMPowerState.inputPowerRequirement=LONG,24,0
+struct.IOPMPowerState.inputPowerRequirement.meta=8
+struct.IOPMPowerState.staticPower=LONGU,32,0
+struct.IOPMPowerState.staticPower.meta=8
+struct.IOPMPowerState.stateOrder=LONGU,40,0
+struct.IOPMPowerState.stateOrder.meta=8
+struct.IOPMPowerState.powerToAttain=LONGU,48,0
+struct.IOPMPowerState.powerToAttain.meta=8
+struct.IOPMPowerState.timeToAttain=LONGU,56,0
+struct.IOPMPowerState.timeToAttain.meta=8
+struct.IOPMPowerState.settleUpTime=LONGU,64,0
+struct.IOPMPowerState.settleUpTime.meta=8
+struct.IOPMPowerState.timeToLower=LONGU,72,0
+struct.IOPMPowerState.timeToLower.meta=8
+struct.IOPMPowerState.settleDownTime=LONGU,80,0
+struct.IOPMPowerState.settleDownTime.meta=8
+struct.IOPMPowerState.powerDomainBudget=LONGU,88,0
+struct.IOPMPowerState.powerDomainBudget.meta=8
 
 IOPMinformee=struct
 struct.IOPMinformee=vtable,data
@@ -10585,44 +10683,121 @@ struct.IOPerfControlClient.data=struct.IOPerfControlClient_Data,8,0
 struct.IOPerfControlClient.data.meta=56
 
 IOPerfControlClient::IOPerfControlClientData=struct
-struct.IOPerfControlClient::IOPerfControlClientData=data
-struct.IOPerfControlClient::IOPerfControlClientData.data=struct.IOPerfControlClient::IOPerfControlClientData_Data,0,0
-struct.IOPerfControlClient::IOPerfControlClientData.data.meta=24
+struct.IOPerfControlClient::IOPerfControlClientData=target_thread_group,driverState,device
+struct.IOPerfControlClient::IOPerfControlClientData.target_thread_group=void *,0,0
+struct.IOPerfControlClient::IOPerfControlClientData.target_thread_group.meta=8
+struct.IOPerfControlClient::IOPerfControlClientData.driverState=void *,8,0
+struct.IOPerfControlClient::IOPerfControlClientData.driverState.meta=8
+struct.IOPerfControlClient::IOPerfControlClientData.device=void *,16,0
+struct.IOPerfControlClient::IOPerfControlClientData.device.meta=8
 
 IOPerfControlClient::IOPerfControlClientShared=struct
-struct.IOPerfControlClient::IOPerfControlClientShared=data
-struct.IOPerfControlClient::IOPerfControlClientShared.data=struct.IOPerfControlClient::IOPerfControlClientShared_Data,0,0
-struct.IOPerfControlClient::IOPerfControlClientShared.data.meta=32
+struct.IOPerfControlClient::IOPerfControlClientShared=maxDriverIndex,interface,interfaceLock,deviceRegistrationList
+struct.IOPerfControlClient::IOPerfControlClientShared.maxDriverIndex=char,0,0
+struct.IOPerfControlClient::IOPerfControlClientShared.maxDriverIndex.meta=1
+struct.IOPerfControlClient::IOPerfControlClientShared.interface=void *,8,0
+struct.IOPerfControlClient::IOPerfControlClientShared.interface.meta=8
+struct.IOPerfControlClient::IOPerfControlClientShared.interfaceLock=void *,16,0
+struct.IOPerfControlClient::IOPerfControlClientShared.interfaceLock.meta=8
+struct.IOPerfControlClient::IOPerfControlClientShared.deviceRegistrationList=void *,24,0
+struct.IOPerfControlClient::IOPerfControlClientShared.deviceRegistrationList.meta=8
 
 IOPerfControlClient::PerfControllerInterface=struct
-struct.IOPerfControlClient::PerfControllerInterface=data
-struct.IOPerfControlClient::PerfControllerInterface.data=struct.IOPerfControlClient::PerfControllerInterface_Data,0,0
-struct.IOPerfControlClient::PerfControllerInterface.data.meta=88
+struct.IOPerfControlClient::PerfControllerInterface=version,registerDevice,unregisterDevice,workCanSubmit,workSubmit,workBegin,workEnd,workUpdate,registerDriverDevice,unregisterDriverDevice,workEndWithResources
+struct.IOPerfControlClient::PerfControllerInterface.version=uint64_t,0,0
+struct.IOPerfControlClient::PerfControllerInterface.version.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.registerDevice=void *,8,0
+struct.IOPerfControlClient::PerfControllerInterface.registerDevice.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.unregisterDevice=void *,16,0
+struct.IOPerfControlClient::PerfControllerInterface.unregisterDevice.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workCanSubmit=void *,24,0
+struct.IOPerfControlClient::PerfControllerInterface.workCanSubmit.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workSubmit=void *,32,0
+struct.IOPerfControlClient::PerfControllerInterface.workSubmit.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workBegin=void *,40,0
+struct.IOPerfControlClient::PerfControllerInterface.workBegin.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workEnd=void *,48,0
+struct.IOPerfControlClient::PerfControllerInterface.workEnd.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workUpdate=void *,56,0
+struct.IOPerfControlClient::PerfControllerInterface.workUpdate.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.registerDriverDevice=void *,64,0
+struct.IOPerfControlClient::PerfControllerInterface.registerDriverDevice.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.unregisterDriverDevice=void *,72,0
+struct.IOPerfControlClient::PerfControllerInterface.unregisterDriverDevice.meta=8
+struct.IOPerfControlClient::PerfControllerInterface.workEndWithResources=void *,80,0
+struct.IOPerfControlClient::PerfControllerInterface.workEndWithResources.meta=8
 
 IOPerfControlClient::PerfControllerInterface::DriverState=struct
-struct.IOPerfControlClient::PerfControllerInterface::DriverState=data
-struct.IOPerfControlClient::PerfControllerInterface::DriverState.data=struct.IOPerfControlClient::PerfControllerInterface::DriverState_Data,0,0
-struct.IOPerfControlClient::PerfControllerInterface::DriverState.data.meta=40
+struct.IOPerfControlClient::PerfControllerInterface::DriverState=has_target_thread_group__b0,has_device_info__b1,reserved__b2,target_thread_group_id,target_thread_group_data,device_type,instance_id,resource_accounting
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0=int,0,1
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0.meta=4
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_target_thread_group__b0.@.bitoff=0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1=int,0,1
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1.meta=4
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.has_device_info__b1.@.bitoff=1
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2=int,0,30
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2.meta=4
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.reserved__b2.@.bitoff=2
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_id=uint64_t,8,0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_id.meta=8
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_data=void *,16,0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.target_thread_group_data.meta=8
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.device_type=void *,24,0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.device_type.meta=8
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.instance_id=uint32_t,32,0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.instance_id.meta=4
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.resource_accounting=bool,36,0
+struct.IOPerfControlClient::PerfControllerInterface::DriverState.resource_accounting.meta=1
 
 IOPerfControlClient::WorkBeginArgs=struct
-struct.IOPerfControlClient::WorkBeginArgs=data
-struct.IOPerfControlClient::WorkBeginArgs.data=struct.IOPerfControlClient::WorkBeginArgs_Data,0,0
-struct.IOPerfControlClient::WorkBeginArgs.data.meta=56
+struct.IOPerfControlClient::WorkBeginArgs=version,size,begin_time,reserved,driver_data
+struct.IOPerfControlClient::WorkBeginArgs.version=uint32_t,0,0
+struct.IOPerfControlClient::WorkBeginArgs.version.meta=4
+struct.IOPerfControlClient::WorkBeginArgs.size=uint32_t,4,0
+struct.IOPerfControlClient::WorkBeginArgs.size.meta=4
+struct.IOPerfControlClient::WorkBeginArgs.begin_time=uint64_t,8,0
+struct.IOPerfControlClient::WorkBeginArgs.begin_time.meta=8
+struct.IOPerfControlClient::WorkBeginArgs.reserved=uint64_t,16,4
+struct.IOPerfControlClient::WorkBeginArgs.reserved.meta=8
+struct.IOPerfControlClient::WorkBeginArgs.driver_data=void *,48,0
+struct.IOPerfControlClient::WorkBeginArgs.driver_data.meta=8
 
 IOPerfControlClient::WorkEndArgs=struct
-struct.IOPerfControlClient::WorkEndArgs=data
-struct.IOPerfControlClient::WorkEndArgs.data=struct.IOPerfControlClient::WorkEndArgs_Data,0,0
-struct.IOPerfControlClient::WorkEndArgs.data.meta=56
+struct.IOPerfControlClient::WorkEndArgs=version,size,end_time,reserved,driver_data
+struct.IOPerfControlClient::WorkEndArgs.version=uint32_t,0,0
+struct.IOPerfControlClient::WorkEndArgs.version.meta=4
+struct.IOPerfControlClient::WorkEndArgs.size=uint32_t,4,0
+struct.IOPerfControlClient::WorkEndArgs.size.meta=4
+struct.IOPerfControlClient::WorkEndArgs.end_time=uint64_t,8,0
+struct.IOPerfControlClient::WorkEndArgs.end_time.meta=8
+struct.IOPerfControlClient::WorkEndArgs.reserved=uint64_t,16,4
+struct.IOPerfControlClient::WorkEndArgs.reserved.meta=8
+struct.IOPerfControlClient::WorkEndArgs.driver_data=void *,48,0
+struct.IOPerfControlClient::WorkEndArgs.driver_data.meta=8
 
 IOPerfControlClient::WorkSubmitArgs=struct
-struct.IOPerfControlClient::WorkSubmitArgs=data
-struct.IOPerfControlClient::WorkSubmitArgs.data=struct.IOPerfControlClient::WorkSubmitArgs_Data,0,0
-struct.IOPerfControlClient::WorkSubmitArgs.data.meta=56
+struct.IOPerfControlClient::WorkSubmitArgs=version,size,submit_time,reserved,driver_data
+struct.IOPerfControlClient::WorkSubmitArgs.version=uint32_t,0,0
+struct.IOPerfControlClient::WorkSubmitArgs.version.meta=4
+struct.IOPerfControlClient::WorkSubmitArgs.size=uint32_t,4,0
+struct.IOPerfControlClient::WorkSubmitArgs.size.meta=4
+struct.IOPerfControlClient::WorkSubmitArgs.submit_time=uint64_t,8,0
+struct.IOPerfControlClient::WorkSubmitArgs.submit_time.meta=8
+struct.IOPerfControlClient::WorkSubmitArgs.reserved=uint64_t,16,4
+struct.IOPerfControlClient::WorkSubmitArgs.reserved.meta=8
+struct.IOPerfControlClient::WorkSubmitArgs.driver_data=void *,48,0
+struct.IOPerfControlClient::WorkSubmitArgs.driver_data.meta=8
 
 IOPerfControlClient::WorkTableEntry=struct
-struct.IOPerfControlClient::WorkTableEntry=data
-struct.IOPerfControlClient::WorkTableEntry.data=struct.IOPerfControlClient::WorkTableEntry_Data,0,0
-struct.IOPerfControlClient::WorkTableEntry.data.meta=56
+struct.IOPerfControlClient::WorkTableEntry=thread_group,coal,started,perfcontrol_data
+struct.IOPerfControlClient::WorkTableEntry.thread_group=void *,0,0
+struct.IOPerfControlClient::WorkTableEntry.thread_group.meta=8
+struct.IOPerfControlClient::WorkTableEntry.coal=void *,8,0
+struct.IOPerfControlClient::WorkTableEntry.coal.meta=8
+struct.IOPerfControlClient::WorkTableEntry.started=bool,16,0
+struct.IOPerfControlClient::WorkTableEntry.started.meta=1
+struct.IOPerfControlClient::WorkTableEntry.perfcontrol_data=uint8_t,17,32
+struct.IOPerfControlClient::WorkTableEntry.perfcontrol_data.meta=1
 
 IOPlatformDevice=struct
 struct.IOPlatformDevice=vtable,data
@@ -10632,9 +10807,7 @@ struct.IOPlatformDevice.data=struct.IOPlatformDevice_Data,8,0
 struct.IOPlatformDevice.data.meta=136
 
 IOPlatformDevice::ExpansionData=struct
-struct.IOPlatformDevice::ExpansionData=data
-struct.IOPlatformDevice::ExpansionData.data=struct.IOPlatformDevice::ExpansionData_Data,0,0
-struct.IOPlatformDevice::ExpansionData.data.meta=0
+struct.IOPlatformDevice::ExpansionData=
 
 IOPlatformExpert=struct
 struct.IOPlatformExpert=vtable,data
@@ -10644,9 +10817,7 @@ struct.IOPlatformExpert.data=struct.IOPlatformExpert_Data,8,0
 struct.IOPlatformExpert.data.meta=216
 
 IOPlatformExpert::ExpansionData=struct
-struct.IOPlatformExpert::ExpansionData=data
-struct.IOPlatformExpert::ExpansionData.data=struct.IOPlatformExpert::ExpansionData_Data,0,0
-struct.IOPlatformExpert::ExpansionData.data.meta=0
+struct.IOPlatformExpert::ExpansionData=
 
 IOPlatformExpertDevice=struct
 struct.IOPlatformExpertDevice=vtable,data
@@ -10656,9 +10827,7 @@ struct.IOPlatformExpertDevice.data=struct.IOPlatformExpertDevice_Data,8,0
 struct.IOPlatformExpertDevice.data.meta=144
 
 IOPlatformExpertDevice::ExpansionData=struct
-struct.IOPlatformExpertDevice::ExpansionData=data
-struct.IOPlatformExpertDevice::ExpansionData.data=struct.IOPlatformExpertDevice::ExpansionData_Data,0,0
-struct.IOPlatformExpertDevice::ExpansionData.data.meta=0
+struct.IOPlatformExpertDevice::ExpansionData=
 
 IOPlatformIO=struct
 struct.IOPlatformIO=vtable,data
@@ -10668,9 +10837,13 @@ struct.IOPlatformIO.data=struct.IOPlatformIO_Data,8,0
 struct.IOPlatformIO.data.meta=128
 
 IOPolledCompletion=struct
-struct.IOPolledCompletion=data
-struct.IOPolledCompletion.data=struct.IOPolledCompletion_Data,0,0
-struct.IOPolledCompletion.data.meta=24
+struct.IOPolledCompletion=target,action,parameter
+struct.IOPolledCompletion.target=void *,0,0
+struct.IOPolledCompletion.target.meta=8
+struct.IOPolledCompletion.action=void *,8,0
+struct.IOPolledCompletion.action.meta=8
+struct.IOPolledCompletion.parameter=void *,16,0
+struct.IOPolledCompletion.parameter.meta=8
 
 IOPolledInterface=struct
 struct.IOPolledInterface=vtable,data
@@ -10680,9 +10853,7 @@ struct.IOPolledInterface.data=struct.IOPolledInterface_Data,8,0
 struct.IOPolledInterface.data.meta=16
 
 IOPolledInterface::ExpansionData=struct
-struct.IOPolledInterface::ExpansionData=data
-struct.IOPolledInterface::ExpansionData.data=struct.IOPolledInterface::ExpansionData_Data,0,0
-struct.IOPolledInterface::ExpansionData.data.meta=0
+struct.IOPolledInterface::ExpansionData=
 
 IOPowerConnection=struct
 struct.IOPowerConnection=vtable,data
@@ -10699,19 +10870,37 @@ struct.IOProviderPropertyMerger.data=struct.IOProviderPropertyMerger_Data,8,0
 struct.IOProviderPropertyMerger.data.meta=128
 
 IORPC=struct
-struct.IORPC=data
-struct.IORPC.data=struct.IORPC_Data,0,0
-struct.IORPC.data.meta=32
+struct.IORPC=message,reply,sendSize,replySize,kernelContent
+struct.IORPC.message=void *,0,0
+struct.IORPC.message.meta=8
+struct.IORPC.reply=void *,8,0
+struct.IORPC.reply.meta=8
+struct.IORPC.sendSize=uint32_t,16,0
+struct.IORPC.sendSize.meta=4
+struct.IORPC.replySize=uint32_t,20,0
+struct.IORPC.replySize.meta=4
+struct.IORPC.kernelContent=void *,24,0
+struct.IORPC.kernelContent.meta=8
 
 IORPCMessage=struct
-struct.IORPCMessage=data
-struct.IORPCMessage.data=struct.IORPCMessage_Data,0,0
-struct.IORPCMessage.data.meta=32
+struct.IORPCMessage=msgid,flags,objectRefs,objects
+struct.IORPCMessage.msgid=uint64_t,0,0
+struct.IORPCMessage.msgid.meta=8
+struct.IORPCMessage.flags=uint64_t,8,0
+struct.IORPCMessage.flags.meta=8
+struct.IORPCMessage.objectRefs=uint64_t,16,0
+struct.IORPCMessage.objectRefs.meta=8
+struct.IORPCMessage.objects=OSObjectRef,24,0
+struct.IORPCMessage.objects.meta=8
 
 IORPCMessageMach=struct
-struct.IORPCMessageMach=data
-struct.IORPCMessageMach.data=struct.IORPCMessageMach_Data,0,0
-struct.IORPCMessageMach.data.meta=24
+struct.IORPCMessageMach=msgh,msgh_body,objects
+struct.IORPCMessageMach.msgh=void *,0,0
+struct.IORPCMessageMach.msgh.meta=8
+struct.IORPCMessageMach.msgh_body=void *,8,0
+struct.IORPCMessageMach.msgh_body.meta=8
+struct.IORPCMessageMach.objects=mach_msg_port_descriptor_t,16,0
+struct.IORPCMessageMach.objects.meta=8
 
 IORTC=struct
 struct.IORTC=vtable,data
@@ -10721,9 +10910,7 @@ struct.IORTC.data=struct.IORTC_Data,8,0
 struct.IORTC.data.meta=136
 
 IORTC::ExpansionData=struct
-struct.IORTC::ExpansionData=data
-struct.IORTC::ExpansionData.data=struct.IORTC::ExpansionData_Data,0,0
-struct.IORTC::ExpansionData.data.meta=0
+struct.IORTC::ExpansionData=
 
 IORangeAllocator=struct
 struct.IORangeAllocator=vtable,data
@@ -10747,9 +10934,13 @@ struct.IORegistryIterator.data=struct.IORegistryIterator_Data,8,0
 struct.IORegistryIterator.data.meta=56
 
 IORegistryIterator::IORegCursor=struct
-struct.IORegistryIterator::IORegCursor=data
-struct.IORegistryIterator::IORegCursor.data=struct.IORegistryIterator::IORegCursor_Data,0,0
-struct.IORegistryIterator::IORegCursor.data.meta=24
+struct.IORegistryIterator::IORegCursor=next,current,iter
+struct.IORegistryIterator::IORegCursor.next=void *,0,0
+struct.IORegistryIterator::IORegCursor.next.meta=8
+struct.IORegistryIterator::IORegCursor.current=void *,8,0
+struct.IORegistryIterator::IORegCursor.current.meta=8
+struct.IORegistryIterator::IORegCursor.iter=void *,16,0
+struct.IORegistryIterator::IORegCursor.iter.meta=8
 
 IOReportLegend=struct
 struct.IOReportLegend=vtable,data
@@ -10773,9 +10964,21 @@ struct.IOService.data=struct.IOService_Data,8,0
 struct.IOService.data.meta=128
 
 IOService::ExpansionData=struct
-struct.IOService::ExpansionData=data
-struct.IOService::ExpansionData.data=struct.IOService::ExpansionData_Data,0,0
-struct.IOService::ExpansionData.data.meta=56
+struct.IOService::ExpansionData=authorizationID,interruptStatisticsLock,interruptStatisticsArray,interruptStatisticsArrayCount,uvars,svars,interruptSourcesPrivate
+struct.IOService::ExpansionData.authorizationID=uint64_t,0,0
+struct.IOService::ExpansionData.authorizationID.meta=8
+struct.IOService::ExpansionData.interruptStatisticsLock=void *,8,0
+struct.IOService::ExpansionData.interruptStatisticsLock.meta=8
+struct.IOService::ExpansionData.interruptStatisticsArray=void *,16,0
+struct.IOService::ExpansionData.interruptStatisticsArray.meta=8
+struct.IOService::ExpansionData.interruptStatisticsArrayCount=int,24,0
+struct.IOService::ExpansionData.interruptStatisticsArrayCount.meta=4
+struct.IOService::ExpansionData.uvars=void *,32,0
+struct.IOService::ExpansionData.uvars.meta=8
+struct.IOService::ExpansionData.svars=void *,40,0
+struct.IOService::ExpansionData.svars.meta=8
+struct.IOService::ExpansionData.interruptSourcesPrivate=void *,48,0
+struct.IOService::ExpansionData.interruptSourcesPrivate.meta=8
 
 IOServiceCompatibility=struct
 struct.IOServiceCompatibility=vtable,data
@@ -10799,9 +11002,9 @@ struct.IOSharedDataQueue.data=struct.IOSharedDataQueue_Data,8,0
 struct.IOSharedDataQueue.data.meta=32
 
 IOSharedDataQueue::ExpansionData=struct
-struct.IOSharedDataQueue::ExpansionData=data
-struct.IOSharedDataQueue::ExpansionData.data=struct.IOSharedDataQueue::ExpansionData_Data,0,0
-struct.IOSharedDataQueue::ExpansionData.data.meta=4
+struct.IOSharedDataQueue::ExpansionData=queueSize
+struct.IOSharedDataQueue::ExpansionData.queueSize=int,0,0
+struct.IOSharedDataQueue::ExpansionData.queueSize.meta=4
 
 IOSharedInterruptController=struct
 struct.IOSharedInterruptController=vtable,data
@@ -10811,9 +11014,7 @@ struct.IOSharedInterruptController.data=struct.IOSharedInterruptController_Data,
 struct.IOSharedInterruptController.data.meta=192
 
 IOSharedInterruptController::ExpansionData=struct
-struct.IOSharedInterruptController::ExpansionData=data
-struct.IOSharedInterruptController::ExpansionData.data=struct.IOSharedInterruptController::ExpansionData_Data,0,0
-struct.IOSharedInterruptController::ExpansionData.data.meta=0
+struct.IOSharedInterruptController::ExpansionData=
 
 IOSimpleReporter=struct
 struct.IOSimpleReporter=vtable,data
@@ -10844,9 +11045,13 @@ struct.IOTimerEventSource.data=struct.IOTimerEventSource_Data,8,0
 struct.IOTimerEventSource.data.meta=96
 
 IOTimerEventSource::ExpansionData=struct
-struct.IOTimerEventSource::ExpansionData=data
-struct.IOTimerEventSource::ExpansionData.data=struct.IOTimerEventSource::ExpansionData_Data,0,0
-struct.IOTimerEventSource::ExpansionData.data.meta=16
+struct.IOTimerEventSource::ExpansionData=calloutGeneration,calloutGenerationSignaled,workLoop
+struct.IOTimerEventSource::ExpansionData.calloutGeneration=int,0,0
+struct.IOTimerEventSource::ExpansionData.calloutGeneration.meta=4
+struct.IOTimerEventSource::ExpansionData.calloutGenerationSignaled=int,4,0
+struct.IOTimerEventSource::ExpansionData.calloutGenerationSignaled.meta=4
+struct.IOTimerEventSource::ExpansionData.workLoop=void *,8,0
+struct.IOTimerEventSource::ExpansionData.workLoop.meta=8
 
 IOUserClient=struct
 struct.IOUserClient=vtable,data
@@ -10863,9 +11068,11 @@ struct.IOUserClient2022.data=struct.IOUserClient2022_Data,8,0
 struct.IOUserClient2022.data.meta=200
 
 IOUserClient::ExpansionData=struct
-struct.IOUserClient::ExpansionData=data
-struct.IOUserClient::ExpansionData.data=struct.IOUserClient::ExpansionData_Data,0,0
-struct.IOUserClient::ExpansionData.data.meta=16
+struct.IOUserClient::ExpansionData=iokitstatsReserved,filterPolicies
+struct.IOUserClient::ExpansionData.iokitstatsReserved=void *,0,0
+struct.IOUserClient::ExpansionData.iokitstatsReserved.meta=8
+struct.IOUserClient::ExpansionData.filterPolicies=void *,8,0
+struct.IOUserClient::ExpansionData.filterPolicies.meta=8
 
 IOUserIterator=struct
 struct.IOUserIterator=vtable,data
@@ -10910,9 +11117,7 @@ struct.IOWatchDogTimer.data=struct.IOWatchDogTimer_Data,8,0
 struct.IOWatchDogTimer.data.meta=144
 
 IOWatchDogTimer::ExpansionData=struct
-struct.IOWatchDogTimer::ExpansionData=data
-struct.IOWatchDogTimer::ExpansionData.data=struct.IOWatchDogTimer::ExpansionData_Data,0,0
-struct.IOWatchDogTimer::ExpansionData.data.meta=0
+struct.IOWatchDogTimer::ExpansionData=
 
 IOWorkGroup=struct
 struct.IOWorkGroup=vtable,data
@@ -10922,9 +11127,7 @@ struct.IOWorkGroup.data=struct.IOWorkGroup_Data,8,0
 struct.IOWorkGroup.data.meta=24
 
 IOWorkGroupInterface=struct
-struct.IOWorkGroupInterface=data
-struct.IOWorkGroupInterface.data=struct.IOWorkGroupInterface_Data,0,0
-struct.IOWorkGroupInterface.data.meta=0
+struct.IOWorkGroupInterface=
 
 IOWorkLoop=struct
 struct.IOWorkLoop=vtable,data
@@ -10934,9 +11137,17 @@ struct.IOWorkLoop.data=struct.IOWorkLoop_Data,8,0
 struct.IOWorkLoop.data.meta=64
 
 IOWorkLoop::ExpansionData=struct
-struct.IOWorkLoop::ExpansionData=data
-struct.IOWorkLoop::ExpansionData.data=struct.IOWorkLoop::ExpansionData_Data,0,0
-struct.IOWorkLoop::ExpansionData.data.meta=40
+struct.IOWorkLoop::ExpansionData=options,passiveEventChain,iokitstatsReserved,lockInterval,lockTime
+struct.IOWorkLoop::ExpansionData.options=int,0,0
+struct.IOWorkLoop::ExpansionData.options.meta=4
+struct.IOWorkLoop::ExpansionData.passiveEventChain=void *,8,0
+struct.IOWorkLoop::ExpansionData.passiveEventChain.meta=8
+struct.IOWorkLoop::ExpansionData.iokitstatsReserved=void *,16,0
+struct.IOWorkLoop::ExpansionData.iokitstatsReserved.meta=8
+struct.IOWorkLoop::ExpansionData.lockInterval=uint64_t,24,0
+struct.IOWorkLoop::ExpansionData.lockInterval.meta=8
+struct.IOWorkLoop::ExpansionData.lockTime=uint64_t,32,0
+struct.IOWorkLoop::ExpansionData.lockTime.meta=8
 
 OSAction=struct
 struct.OSAction=vtable,data
@@ -10946,9 +11157,7 @@ struct.OSAction.data=struct.OSAction_Data,8,0
 struct.OSAction.data.meta=24
 
 OSActionInterface=struct
-struct.OSActionInterface=data
-struct.OSActionInterface.data=struct.OSActionInterface_Data,0,0
-struct.OSActionInterface.data.meta=0
+struct.OSActionInterface=
 
 OSAction_IOUserClient_KernelCompletion=struct
 struct.OSAction_IOUserClient_KernelCompletion=vtable,data
@@ -10958,9 +11167,7 @@ struct.OSAction_IOUserClient_KernelCompletion.data=struct.OSAction_IOUserClient_
 struct.OSAction_IOUserClient_KernelCompletion.data.meta=40
 
 OSAction_IOUserClient_KernelCompletionInterface=struct
-struct.OSAction_IOUserClient_KernelCompletionInterface=data
-struct.OSAction_IOUserClient_KernelCompletionInterface.data=struct.OSAction_IOUserClient_KernelCompletionInterface_Data,0,0
-struct.OSAction_IOUserClient_KernelCompletionInterface.data.meta=0
+struct.OSAction_IOUserClient_KernelCompletionInterface=
 
 OSArray=struct
 struct.OSArray=vtable,data
@@ -10984,9 +11191,7 @@ struct.OSCollection.data=struct.OSCollection_Data,8,0
 struct.OSCollection.data.meta=12
 
 OSCollection::ExpansionData=struct
-struct.OSCollection::ExpansionData=data
-struct.OSCollection::ExpansionData.data=struct.OSCollection::ExpansionData_Data,0,0
-struct.OSCollection::ExpansionData.data.meta=0
+struct.OSCollection::ExpansionData=
 
 OSCollectionIterator=struct
 struct.OSCollectionIterator=vtable,data
@@ -11003,9 +11208,11 @@ struct.OSData.data=struct.OSData_Data,8,0
 struct.OSData.data.meta=32
 
 OSData::ExpansionData=struct
-struct.OSData::ExpansionData=data
-struct.OSData::ExpansionData.data=struct.OSData::ExpansionData_Data,0,0
-struct.OSData::ExpansionData.data.meta=16
+struct.OSData::ExpansionData=deallocFunction,disableSerialization
+struct.OSData::ExpansionData.deallocFunction=void *,0,0
+struct.OSData::ExpansionData.deallocFunction.meta=8
+struct.OSData::ExpansionData.disableSerialization=bool,8,0
+struct.OSData::ExpansionData.disableSerialization.meta=1
 
 OSDextStatistics=struct
 struct.OSDextStatistics=vtable,data
@@ -11022,9 +11229,7 @@ struct.OSDictionary.data=struct.OSDictionary_Data,8,0
 struct.OSDictionary.data.meta=32
 
 OSInterface=struct
-struct.OSInterface=data
-struct.OSInterface.data=struct.OSInterface_Data,0,0
-struct.OSInterface.data.meta=0
+struct.OSInterface=
 
 OSIterator=struct
 struct.OSIterator=vtable,data
@@ -11041,9 +11246,13 @@ struct.OSKext.data=struct.OSKext_Data,8,0
 struct.OSKext.data.meta=208
 
 OSKextAccount=struct
-struct.OSKextAccount=data
-struct.OSKextAccount.data=struct.OSKextAccount_Data,0,0
-struct.OSKextAccount.data.meta=24
+struct.OSKextAccount=site,loadTag,kext
+struct.OSKextAccount.site=void *,0,0
+struct.OSKextAccount.site.meta=8
+struct.OSKextAccount.loadTag=uint32_t,8,0
+struct.OSKextAccount.loadTag.meta=4
+struct.OSKextAccount.kext=void *,16,0
+struct.OSKextAccount.kext.meta=8
 
 OSKextSavedMutableSegment=struct
 struct.OSKextSavedMutableSegment=vtable,data
@@ -11081,9 +11290,43 @@ struct.OSObject.data=struct.OSObject_Data,8,0
 struct.OSObject.data.meta=4
 
 OSObjectUserVars=struct
-struct.OSObjectUserVars=data
-struct.OSObjectUserVars.data=struct.OSObjectUserVars_Data,0,0
-struct.OSObjectUserVars.data.meta=72
+struct.OSObjectUserVars=userServer,queueArray,userMeta,openProviders,controllingDriver,willPowerState,willTerminate,didTerminate,serverDied,started,stopped,userServerPM,willPower,powerState,resetPowerOnWake,deferredRegisterService,powerOverride,uvarsLock
+struct.OSObjectUserVars.userServer=void *,0,0
+struct.OSObjectUserVars.userServer.meta=8
+struct.OSObjectUserVars.queueArray=void *,8,0
+struct.OSObjectUserVars.queueArray.meta=8
+struct.OSObjectUserVars.userMeta=void *,16,0
+struct.OSObjectUserVars.userMeta.meta=8
+struct.OSObjectUserVars.openProviders=void *,24,0
+struct.OSObjectUserVars.openProviders.meta=8
+struct.OSObjectUserVars.controllingDriver=void *,32,0
+struct.OSObjectUserVars.controllingDriver.meta=8
+struct.OSObjectUserVars.willPowerState=LONGU,40,0
+struct.OSObjectUserVars.willPowerState.meta=8
+struct.OSObjectUserVars.willTerminate=bool,48,0
+struct.OSObjectUserVars.willTerminate.meta=1
+struct.OSObjectUserVars.didTerminate=bool,49,0
+struct.OSObjectUserVars.didTerminate.meta=1
+struct.OSObjectUserVars.serverDied=bool,50,0
+struct.OSObjectUserVars.serverDied.meta=1
+struct.OSObjectUserVars.started=bool,51,0
+struct.OSObjectUserVars.started.meta=1
+struct.OSObjectUserVars.stopped=bool,52,0
+struct.OSObjectUserVars.stopped.meta=1
+struct.OSObjectUserVars.userServerPM=bool,53,0
+struct.OSObjectUserVars.userServerPM.meta=1
+struct.OSObjectUserVars.willPower=bool,54,0
+struct.OSObjectUserVars.willPower.meta=1
+struct.OSObjectUserVars.powerState=bool,55,0
+struct.OSObjectUserVars.powerState.meta=1
+struct.OSObjectUserVars.resetPowerOnWake=bool,56,0
+struct.OSObjectUserVars.resetPowerOnWake.meta=1
+struct.OSObjectUserVars.deferredRegisterService=bool,57,0
+struct.OSObjectUserVars.deferredRegisterService.meta=1
+struct.OSObjectUserVars.powerOverride=uint32_t,60,0
+struct.OSObjectUserVars.powerOverride.meta=4
+struct.OSObjectUserVars.uvarsLock=void *,64,0
+struct.OSObjectUserVars.uvarsLock.meta=8
 
 OSOrderedSet=struct
 struct.OSOrderedSet=vtable,data
@@ -11093,9 +11336,7 @@ struct.OSOrderedSet.data=struct.OSOrderedSet_Data,8,0
 struct.OSOrderedSet.data.meta=64
 
 OSOrderedSet::ExpansionData=struct
-struct.OSOrderedSet::ExpansionData=data
-struct.OSOrderedSet::ExpansionData.data=struct.OSOrderedSet::ExpansionData_Data,0,0
-struct.OSOrderedSet::ExpansionData.data.meta=0
+struct.OSOrderedSet::ExpansionData=
 
 OSSerialize=struct
 struct.OSSerialize=vtable,data
@@ -11119,9 +11360,9 @@ struct.OSSet.data=struct.OSSet_Data,8,0
 struct.OSSet.data.meta=24
 
 OSSharedPtr=struct
-struct.OSSharedPtr=data
-struct.OSSharedPtr.data=struct.OSSharedPtr_Data,0,0
-struct.OSSharedPtr.data.meta=0
+struct.OSSharedPtr=ptr_
+struct.OSSharedPtr.ptr_=void *,0,0
+struct.OSSharedPtr.ptr_.meta=8
 
 OSString=struct
 struct.OSString=vtable,data
@@ -11145,9 +11386,33 @@ struct.OSValueObject.data=struct.OSValueObject_Data,8,0
 struct.OSValueObject.data.meta=16
 
 PE_Video=struct
-struct.PE_Video=data
-struct.PE_Video.data=struct.PE_Video_Data,0,0
-struct.PE_Video.data.meta=144
+struct.PE_Video=v_baseAddr,v_rowBytes,v_width,v_height,v_depth,v_display,v_pixelFormat,v_offset,v_length,v_rotate,v_scale,reserved1,reserved2
+struct.PE_Video.v_baseAddr=LONGU,0,0
+struct.PE_Video.v_baseAddr.meta=8
+struct.PE_Video.v_rowBytes=LONGU,8,0
+struct.PE_Video.v_rowBytes.meta=8
+struct.PE_Video.v_width=LONGU,16,0
+struct.PE_Video.v_width.meta=8
+struct.PE_Video.v_height=LONGU,24,0
+struct.PE_Video.v_height.meta=8
+struct.PE_Video.v_depth=LONGU,32,0
+struct.PE_Video.v_depth.meta=8
+struct.PE_Video.v_display=LONGU,40,0
+struct.PE_Video.v_display.meta=8
+struct.PE_Video.v_pixelFormat=char,48,64
+struct.PE_Video.v_pixelFormat.meta=1
+struct.PE_Video.v_offset=LONGU,112,0
+struct.PE_Video.v_offset.meta=8
+struct.PE_Video.v_length=LONGU,120,0
+struct.PE_Video.v_length.meta=8
+struct.PE_Video.v_rotate=unsigned char,128,0
+struct.PE_Video.v_rotate.meta=1
+struct.PE_Video.v_scale=unsigned char,129,0
+struct.PE_Video.v_scale.meta=1
+struct.PE_Video.reserved1=char,130,2
+struct.PE_Video.reserved1.meta=1
+struct.PE_Video.reserved2=LONG,136,0
+struct.PE_Video.reserved2.meta=8
 
 PassthruInterruptController=struct
 struct.PassthruInterruptController=vtable,data
@@ -11163,18 +11428,20 @@ struct._IOUserServerCheckInCancellationHandler.vtable.meta=8
 struct._IOUserServerCheckInCancellationHandler.data=struct._IOUserServerCheckInCancellationHandler_Data,8,0
 struct._IOUserServerCheckInCancellationHandler.data.meta=24
 
-intrusive_osobject_retainer=struct
-struct.intrusive_osobject_retainer=data
-struct.intrusive_osobject_retainer.data=struct.intrusive_osobject_retainer_Data,0,0
-struct.intrusive_osobject_retainer.data.meta=0
+intrusive_shared_ptr=struct
+struct.intrusive_shared_ptr=ptr_
+struct.intrusive_shared_ptr.ptr_=void *,0,0
+struct.intrusive_shared_ptr.ptr_.meta=8
 
 list_head=struct
-struct.list_head=data
-struct.list_head.data=struct.list_head_Data,0,0
-struct.list_head.data.meta=16
+struct.list_head=prev,next
+struct.list_head.prev=void *,0,0
+struct.list_head.prev.meta=8
+struct.list_head.next=void *,8,0
+struct.list_head.next.meta=8
 
 smrq_slink=struct
-struct.smrq_slink=data
-struct.smrq_slink.data=struct.smrq_slink_Data,0,0
-struct.smrq_slink.data.meta=8
+struct.smrq_slink=next
+struct.smrq_slink.next=void *,0,0
+struct.smrq_slink.next.meta=8
 


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

My first iteration ended up broken because midway through I renamed `_ClassName` to `ClassName_Data`, but forgot to update the instance struct references to it. This splitting of data from the instance struct was also done in cases where it wasn't needed, i.e. for structs/classes without a vtable.