### PR TITLE
xnu_debug: fixes for powerpc

### DIFF
--- a/libr/debug/p/native/xnu/xnu_debug.c
+++ b/libr/debug/p/native/xnu/xnu_debug.c
@@ -21,6 +21,7 @@
 #include <mach/host_priv.h>
 #include <mach/thread_status.h>
 #include <mach/vm_statistics.h>
+#include <AvailabilityMacros.h>
 
 #if APPLE_SDK_IPHONEOS
 kern_return_t mach_vm_protect
@@ -631,7 +632,11 @@ RList *xnu_thread_list(RDebug *dbg, int pid, RList *list) {
 	#define CPU_PC R_SYS_BITS_CHECK (dbg->bits, 64)? \
 		state.ts_64.__pc : state.ts_32.__pc
 #elif __POWERPC__
-	#define CPU_PC state.srr0
+	#if MAC_OS_X_VERSION_MAX_ALLOWED < 1050
+		#define CPU_PC state.srr0
+	#else
+		#define CPU_PC state.__srr0
+	#endif
 #elif __x86_64__ || __i386__
 	#define CPU_PC R_SYS_BITS_CHECK (dbg->bits, 64)? \
 		state.uts.ts64.__rip : state.uts.ts32.__eip

--- a/libr/debug/p/native/xnu/xnu_debug.h
+++ b/libr/debug/p/native/xnu/xnu_debug.h
@@ -70,7 +70,7 @@ int ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <mach/ppc/_types.h>
+#include <ppc/_types.h>
 #include <mach/ppc/thread_status.h>
 // iPhone5
 #elif __aarch64


### PR DESCRIPTION
There is no such header `mach/ppc/_types.h`. There is an arch-specific `ppc/_types.h` and generic `machine/_types.h`, which includes respective arch-specific headers. Since here it is used only for powerpc, `ppc/_types.h` should be the right one.