### PR TITLE
Fix segfault in __set_read_only when string pointer is NULL

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -646,7 +646,10 @@ static void __set_decompiler_cache(RCore *core, char *s) {
 
 static void __set_read_only(RCore *core, RPanel *p, const char * R_NULLABLE s) {
 	free (p->model->readOnly);
-	p->model->readOnly = strdup (s);
+	if(s)
+		p->model->readOnly = strdup (s);
+	else
+		p->model->readOnly = NULL; 
 	__set_dcb (core, p);
 	__set_pcb (p);
 }


### PR DESCRIPTION
### Issue
Running the `v` command in radare2 after `-e bin.relocs.apply=true` can cause a segmentation fault.

### Steps to reproduce
1. Launch radare2 with a binary where relocations are applied:
   ./binr/radare2/radare2 -e bin.relocs.apply=true ~/a.out
2. At the radare2 prompt, run:
   v
3. Observe the segmentation fault.

### Cause
The function `__set_read_only` in panels.c was calling `strdup(s)` without checking if `s` is NULL.  
When `v` triggers this code and `s` is NULL, it leads to a crash in `__strlen_avx2` via `strdup`.

Backtrace from GDB:
╭─jbahmida@e2r5p15 ~ 
╰─$ radare2 -e bin.relocs.apply=true ~/a.out                                    

[0x00001100]> aaa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze imports (af@@@i)
WARN: select the calling convention with `e anal.cc=?`
INFO: Analyze entrypoint (af@ entry0)
INFO: Analyze symbols (af@@@s)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Analyzing methods (af @@ method.*)
INFO: Recovering local variables (afva@@@F)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Integrate dwarf function information
INFO: Use -AA or aaaa to perform additional experimental analysis
[0x00001100]> aaaa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze imports (af@@@i)
INFO: Analyze entrypoint (af@ entry0)
INFO: Analyze symbols (af@@@s)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Analyzing methods (af @@ method.*)
INFO: Recovering local variables (afva@@@F)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Integrate dwarf function information
INFO: Scanning for strings constructed in code (/azs)
INFO: Finding function preludes (aap)
INFO: Enable anal.types.constraint for experimental type propagation
[0x00001100]> pdf
            ;-- section..text:
            ;-- _start:
            ;-- rip:
┌ 38: entry0 (int64_t arg3);
│ `- args(rdx)
│           0x00001100      f30f1efa       endbr64                     ; [16] -r-x section size 2036 named .text
│           0x00001104      31ed           xor ebp, ebp
│           0x00001106      4989d1         mov r9, rdx                 ; arg3
│           0x00001109      5e             pop rsi
│           0x0000110a      4889e2         mov rdx, rsp
│           0x0000110d      4883e4f0       and rsp, 0xfffffffffffffff0
│           0x00001111      50             push rax
│           0x00001112      54             push rsp
│           0x00001113      4531c0         xor r8d, r8d
│           0x00001116      31c9           xor ecx, ecx
│           0x00001118      488d3d5507..   lea rdi, [dbg.main]         ; 0x1874
│           0x0000111f      ff15b32e0000   call qword [reloc.__libc_start_main] ; [0x3fd8:8]=0x4068 reloc.__libc_start_main ; "h@"
└           0x00001125      f4             hlt
[0x00001100]> v
[1]    1723847 segmentation fault (core dumped)  radare2 -e bin.relocs.apply=true ~/a.out
╭─jbahmida@e2r5p15 ~ 
╰─$ gdb --args radare2 a.out                                                                                                                                                                                                             139 ↵
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04.2) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from radare2...
(gdb) run
Starting program: /goinfre/jbahmida/my_r2/binr/radare2/radare2 a.out
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
WARN: Relocs has not been applied. Please use `-e bin.relocs.apply=true` or `-e bin.cache=true` next time
[0x00001100]> aaa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze imports (af@@@i)
WARN: select the calling convention with `e anal.cc=?`
INFO: Analyze entrypoint (af@ entry0)
INFO: Analyze symbols (af@@@s)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Analyzing methods (af @@ method.*)
INFO: Recovering local variables (afva@@@F)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Integrate dwarf function information
INFO: Use -AA or aaaa to perform additional experimental analysis
[0x00001100]> aaaa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze imports (af@@@i)
INFO: Analyze entrypoint (af@ entry0)
INFO: Analyze symbols (af@@@s)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Analyzing methods (af @@ method.*)
INFO: Recovering local variables (afva@@@F)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Integrate dwarf function information
INFO: Scanning for strings constructed in code (/azs)
INFO: Finding function preludes (aap)
INFO: Enable anal.types.constraint for experimental type propagation
[0x00001100]> v

Program received signal SIGSEGV, Segmentation fault.
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
74	../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:74
#1  0x00007ffff7c24583 in __GI___strdup (s=0x0) at ./string/strdup.c:41
#2  0x00007ffff783a1b5 in __set_read_only (core=0x7ffff5db1010, p=0x5555558a4770, s=0x0) at panels.c:649
#3  0x00007ffff783c0d8 in __init_panel_param (core=0x7ffff5db1010, p=0x5555558a4770, title=0x7ffff78ea3e0 "Disassembly", cmd=0x5555558b20e0 "pd") at panels.c:1208
#4  0x00007ffff7849ee5 in __create_default_panels (core=0x7ffff5db1010) at panels.c:5140
#5  0x00007ffff785348d in __init_new_panels_root (core=0x7ffff5db1010) at panels.c:7672
#6  0x00007ffff78530da in r_core_panels_root (core=0x7ffff5db1010, panels_root=0x555555715e40) at panels.c:7601
#7  0x00007ffff776370e in cmd_panels (data=0x7ffff5db1010, input=0x555555715d91 "") at cmd.c:3094
#8  0x00007ffff77d85f1 in r_cmd_call (cmd=0x5555555d6b80, input=0x555555715d90 "v") at cmd_api.c:414
#9  0x00007ffff776b52c in r_core_cmd_subst_i (core=0x7ffff5db1010, cmd=0x555555715d90 "v", colon=0x0, tmpseek=0x7fffffffafe8) at cmd.c:5438
#10 0x00007ffff77664fd in r_core_cmd_subst (core=0x7ffff5db1010, cmd=0x555555715d90 "v") at cmd.c:4125
#11 0x00007ffff776ecbf in run_cmd_depth (core=0x7ffff5db1010, cmd=0x55555571f670 "v") at cmd.c:6418
#12 0x00007ffff776f27b in r_core_cmd (core=0x7ffff5db1010, cstr=0x555555715d50 "v", log=true) at cmd.c:6521
#13 0x00007ffff765fe2c in r_core_prompt_exec (r=0x7ffff5db1010) at core.c:3120
#14 0x00007ffff765f118 in r_core_prompt_loop (r=0x7ffff5db1010) at core.c:2917
#15 0x00007ffff7deefd0 in r_main_radare2 (argc=2, argv=0x7fffffffb638) at radare2.c:1876
#16 0x00005555555557c3 in main (argc=2, argv=0x7fffffffb638) at radare2.c:119
(gdb) 

zx
### Fix
Added a NULL check before calling `strdup`:

```c
if (s)
    p->model->readOnly = strdup(s);
else
    p->model->readOnly = NULL;
