### PR TITLE
Fix elf parser hang on malformed PT_DYNAMIC entry ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4121,8 +4121,11 @@ static void dtproceed(RBinFile *bf, ut64 preinit_addr, ut64 preinit_size, int sy
 	ut64 _baddr = Elf_(get_baddr) (bf->bo->bin_obj);
 	ut64 from = Elf_(v2p) (eo, preinit_addr);
 	ut64 to = from + preinit_size;
+	if (to > eo->size) {
+		to = eo->size;
+	}
 	ut64 at;
-	for (at = from; at < to ; at += R_BIN_ELF_WORDSIZE) {
+	for (at = from; at < to; at += R_BIN_ELF_WORDSIZE) {
 		ut64 addr = 0;
 		if (R_BIN_ELF_WORDSIZE == 8) {
 			addr = r_buf_read_ble64_at (bf->buf, at, big_endian);
@@ -4162,6 +4165,9 @@ static bool parse_pt_dynamic(RBinFile *bf, RBinSection *ptr) {
 
 	ut64 paddr = ptr->paddr;
 	ut64 paddr_end = paddr + ptr->size;
+	if (paddr_end > eo->size) {
+		paddr_end = eo->size;
+	}
 	ut64 at;
 	for (at = paddr; at < paddr_end; at += sizeof (Elf_(Dyn))) {
 #if R_BIN_ELF64


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ELF parser can get stuck in loops in `parse_pt_dynamic()` and `dtproceed()`, as `PT_DYNAMIC` entries are not checked to lie within file, so r2 just reads 0 bytes many many times.

The higher the sizes, the longer it takes to open malformed files. This was enough to freeze my machine in a few seconds and eventually invoke OOM killer:

```sh
$ xxd hang.elf
00000000: 7f45 4c46 1000 0000 454c 4600 0000 e3ff  .ELF....ELF.....
00000010: 0000 c200 0000 6400 0000 0100 0000 0000  ......d.........
00000020: 0200 0000 0000 0000 1900 0000 0200 6900  ..............i.
00000030: 00ff 574c 4600 0001 1b00 0000 d600 0000  ..WLF...........
00000040: 0200 0000 0000 0000 1900 0000 0200 6900  ..............i.
00000050: 00ff 574c 4600 0001 1b00 0000 d6         ..WLF........
```

(similar thing was in #21423)
