### PR TITLE
Clarify immediate arguments in snes/6502 disassembly

### DIFF
--- a/libr/arch/p/snes/snesdis.c
+++ b/libr/arch/p/snes/snesdis.c
@@ -38,16 +38,16 @@ static int snesDisass(int M_flag, int X_flag, ut64 pc, RAnalOp *op, const ut8 *b
 		break;
 	case SNES_OP_IMM_M:
 		if (M_flag) {
-			op->mnemonic = r_str_newf ("%s 0x%02x", s_op->name, buf[1]);
+			op->mnemonic = r_str_newf ("%s #0x%02x", s_op->name, buf[1]);
 		} else {
-			op->mnemonic = r_str_newf ("%s 0x%04x", s_op->name, ut8p_bw (buf + 1));
+			op->mnemonic = r_str_newf ("%s #0x%04x", s_op->name, ut8p_bw (buf + 1));
 		}
 		break;
 	case SNES_OP_IMM_X:
 		if (X_flag) {
-			op->mnemonic = r_str_newf ("%s 0x%02x", s_op->name, buf[1]);
+			op->mnemonic = r_str_newf ("%s #0x%02x", s_op->name, buf[1]);
 		} else {
-			op->mnemonic = r_str_newf ("%s 0x%04x", s_op->name, ut8p_bw (buf + 1));
+			op->mnemonic = r_str_newf ("%s #0x%04x", s_op->name, ut8p_bw (buf + 1));
 		}
 		break;
 	}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I've been using radare2 to look at 6502 assembly, and I noticed that `lda #0x00` and `lda 0x00` (load immediate, and load from address) look the same in r2. I've updated the syntax to show immediate arguments with a `#` prefix.

This also modifies snes disassembly, which I haven't used, so I'm not sure if this is the correct fix, but it definitely makes things clearer when looking at 6502 assembly.
