### PR TITLE
Fix percentage in `cf` logs always showing 0% or 100%

### DIFF
--- a/libr/core/cmd_cmp.inc.c
+++ b/libr/core/cmd_cmp.inc.c
@@ -470,7 +470,7 @@ static int radare_compare(RCore *core, const ut8 *f, const ut8 *d, int len, int 
 		}
 	}
 	if (mode == 0) {
-		R_LOG_INFO ("Compare %d/%d equal bytes (%d%%)", eq, len, (eq / len) * 100);
+		R_LOG_INFO ("Compare %d/%d equal bytes (%d%%)", eq, len, 100 * eq / len);
 	} else if (mode == 'j') {
 		pj_end (pj);
 		pj_ki (pj, "equal_bytes", eq);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

The percentage calculation used `(eq / len) * 100`, which truncated values to either 0 or 100 due to integer division order. Changed it to `100 * eq / len` to compute the correct percentage.
