### PR TITLE
Revert "Parse file and  flag on autocomplete ##shell"

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1403,26 +1403,6 @@ R_API void r_core_autocomplete(RCore * R_NULLABLE core, RLineCompletion *complet
 			r_line_completion_clear (completion);
 			char *s = r_core_cmd_strf (core, "%s?", buf->data);
 			eprintf ("%s%s\n%s", core->cons->line->prompt, buf->data, s);
-			RList *list = r_str_split_list (s, "\n", 0);
-			RListIter *iter;
-			char *line;
-			r_list_foreach (list, iter, line) {
-				char *bracket_start = strstr (line, " [");
-				if (bracket_start) {
-					if (r_str_startswith (bracket_start, " [addr]") || r_str_startswith (bracket_start, " [file]")) {
-						const char *registered_option = strstr (bracket_start, "addr") ? "!!!%s $flag" : "!!!%s $file";
-						char *cur = strchr (line, '[');
-						if (cur) {
-							*cur = 0;
-						}
-						*bracket_start = 0;
-						const char *cmd = line;
-						r_core_cmdf (core, "!!!-%s", cmd);
-						r_core_cmdf (core, registered_option, cmd);
-					}
-				}
-			}
-			r_list_free (list);
 			free (s);
 			return;
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This reverts commit 148784001349cc5038296919214f80d9f67784f6.

The aformentioned commit breaks autocompletion on fish:
```
$ r2 -
<tab>
.
.
.
| ?$?                     show available '$' variables and aliases
| ?@?                     misc help for '@' (seek), '~' (grep) (see ~?""?)
| ?>?                     output redirection
| ?|?                     help for '|' (pipe)
fish: Unknown command: \e
fish:

ile
^
fish: Unknown command: \e
fish:

lag
^
fish: Unknown command: \e
fish:

lag
^
[0x00000000]>
```
I'm not sure if simply reverting this messes things up in r2frida. Any better ideas are welcome as well. ping @trufae @as0ler