### PR TITLE
r_sys_cmd empty output fix

### DIFF
--- a/libr/util/sys.c
+++ b/libr/util/sys.c
@@ -864,10 +864,12 @@ R_API int r_sys_cmd_str_full(const char *cmd, const char *input, int ilen, char 
 				FD_SET (sh_in[1], &wfds);
 			}
 			memset (buffer, 0, sizeof (buffer));
+
 			nfd = select (sh_err[0] + 1, &rfds, &wfds, NULL, NULL);
-			if (nfd < 0) {
-				// eprintf ("nfd %d 2%c", nfd, 10);
+			if (nfd < 0 && errno == EINTR) {
+				continue;
 			}
+
 			if (output && FD_ISSET (sh_out[0], &rfds)) {
 				if ((bytes = read (sh_out[0], buffer, sizeof (buffer))) < 1) {
 					break;

--- a/libr/util/udiff.c
+++ b/libr/util/udiff.c
@@ -277,6 +277,10 @@ R_API char *r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b,
 	char *fb = NULL;
 	int fd = r_file_mkstemp ("r_diff", &fa);
 	int fe = r_file_mkstemp ("r_diff", &fb);
+	// immediately close fds, as we only need filenames later
+	close (fd);
+	close (fe);
+
 	if (fd == -1 || fe == -1) {
 		R_LOG_ERROR ("Failed to create temporary files");
 		return NULL;
@@ -306,8 +310,6 @@ R_API char *r_diff_buffers_unified(RDiff *d, const ut8 *a, int la, const ut8 *b,
 		(void)r_sys_cmd_str_full (diff_cmdline, NULL, 0, &out, &out_len, &err);
 		free (diff_cmdline);
 	}
-	close (fd);
-	close (fe);
 	r_file_rm (fa);
 	r_file_rm (fb);
 	free (fa);


### PR DESCRIPTION
Do not stop reading if SIGCHLD arrives as there might be more unread data in kernel buffer.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
