### PR TITLE
Implement filesystem details command (mn) for mounted filesystems ##fs

### DIFF
--- a/libr/fs/p/fs_ext2.c
+++ b/libr/fs/p/fs_ext2.c
@@ -1,4 +1,7 @@
-/* radare - LGPL - Copyright 2011-2023 pancake */
+/* radare - LGPL - Copyright 2011-2025 pancake, MiKi (mikelloc) */
+
+#include <r_userconf.h>
+#include <r_fs.h>
 
 #define FSP(x) ext2_##x
 #define FSS(x) x##_ext2
@@ -6,5 +9,240 @@
 #define FSDESC "ext2 filesystem"
 #define FSPRFX ext2
 #define FSIPTR grub_ext2_fs
+
+#if WITH_GPL
+
+R_PACKED(
+typedef struct {
+	ut32 s_inodes_count;
+	ut32 s_blocks_count;
+	ut32 s_r_blocks_count;
+	ut32 s_free_blocks_count;
+	ut32 s_free_inodes_count;
+	ut32 s_first_data_block;
+	ut32 s_log_block_size;
+	ut32 s_log_frag_size;
+	ut32 s_blocks_per_group;
+	ut32 s_frags_per_group;
+	ut32 s_inodes_per_group;
+	ut32 s_mtime;
+	ut32 s_wtime;
+	ut16 s_mnt_count;
+	ut16 s_max_mnt_count;
+	ut16 s_magic;
+	ut16 s_state;
+	ut16 s_errors;
+	ut16 s_minor_rev_level;
+	ut32 s_lastcheck;
+	ut32 s_checkinterval;
+	ut32 s_creator_os;
+	ut32 s_rev_level;
+	ut16 s_def_resuid;
+	ut16 s_def_resgid;
+	ut32 s_first_ino;
+	ut16 s_inode_size;
+	ut16 s_block_group_nr;
+	ut32 s_feature_compat;
+	ut32 s_feature_incompat;
+	ut32 s_feature_ro_compat;
+	ut8  s_uuid[16];
+	char s_volume_name[16];
+	char s_last_mounted[64];
+	ut32 s_algorithm_usage_bitmap;
+	ut8  s_prealloc_blocks;
+	ut8  s_prealloc_dir_blocks;
+	ut16 s_reserved_gdt_blocks;
+	ut8  s_journal_uuid[16];
+	ut32 s_journal_inum;
+	ut32 s_journal_dev;
+	ut32 s_last_orphan;
+}) ext2_superblock_t;
+
+static void details_ext2(RFSRoot *root, RStrBuf *sb) {
+	ext2_superblock_t super;
+	// Superblock is at offset 1024
+	ut64 sb_offset = root->delta + 1024;
+
+	if (!root->iob.read_at (root->iob.io, sb_offset, (ut8 *)&super, sizeof (super))) {
+		r_strbuf_append (sb, "ERROR: Could not read ext2/3/4 superblock\n");
+		return;
+	}
+
+	ut16 magic = r_read_le16 ((ut8 *)&super.s_magic);
+	if (magic != 0xEF53) {
+		r_strbuf_append (sb, "ERROR: Invalid ext2/3/4 magic number\n");
+		return;
+	}
+
+	ut32 feature_incompat = r_read_le32 ((ut8 *)&super.s_feature_incompat);
+	const char *fs_type = "ext2";
+	if (feature_incompat & 0x0004) { // EXT3_FEATURE_INCOMPAT_RECOVER
+		fs_type = "ext3";
+	}
+	if (feature_incompat & 0x0040) { // EXT4_FEATURE_INCOMPAT_EXTENTS
+		fs_type = "ext4";
+	}
+
+	ut32 inodes_count = r_read_le32 ((ut8 *)&super.s_inodes_count);
+	ut32 blocks_count = r_read_le32 ((ut8 *)&super.s_blocks_count);
+	ut32 r_blocks_count = r_read_le32 ((ut8 *)&super.s_r_blocks_count);
+	ut32 free_blocks_count = r_read_le32 ((ut8 *)&super.s_free_blocks_count);
+	ut32 free_inodes_count = r_read_le32 ((ut8 *)&super.s_free_inodes_count);
+	ut32 log_block_size = r_read_le32 ((ut8 *)&super.s_log_block_size);
+	ut32 blocks_per_group = r_read_le32 ((ut8 *)&super.s_blocks_per_group);
+	ut32 inodes_per_group = r_read_le32 ((ut8 *)&super.s_inodes_per_group);
+	ut32 mtime = r_read_le32 ((ut8 *)&super.s_mtime);
+	ut32 wtime = r_read_le32 ((ut8 *)&super.s_wtime);
+	ut32 lastcheck = r_read_le32 ((ut8 *)&super.s_lastcheck);
+	ut16 mnt_count = r_read_le16 ((ut8 *)&super.s_mnt_count);
+	ut16 max_mnt_count = r_read_le16 ((ut8 *)&super.s_max_mnt_count);
+	ut16 state = r_read_le16 ((ut8 *)&super.s_state);
+	ut32 rev_level = r_read_le32 ((ut8 *)&super.s_rev_level);
+	ut32 creator_os = r_read_le32 ((ut8 *)&super.s_creator_os);
+	ut32 feature_compat = r_read_le32 ((ut8 *)&super.s_feature_compat);
+	ut32 feature_ro_compat = r_read_le32 ((ut8 *)&super.s_feature_ro_compat);
+
+	ut32 block_size = 1024 << log_block_size;
+	ut64 total_size = (ut64)blocks_count * block_size;
+	ut64 used_size = (ut64)(blocks_count - free_blocks_count) * block_size;
+	ut64 free_size = (ut64)free_blocks_count * block_size;
+	ut64 reserved_size = (ut64)r_blocks_count * block_size;
+
+	char volume_name[17] = {0};
+	char last_mounted[65] = {0};
+	int i;
+	memcpy (volume_name, super.s_volume_name, 16);
+	volume_name[16] = 0;
+	for (i = 15; i >= 0 && volume_name[i] == ' '; i--) {
+		volume_name[i] = 0;
+	}
+
+	memcpy (last_mounted, super.s_last_mounted, 64);
+	last_mounted[64] = 0;
+
+	r_strbuf_appendf (sb, "Filesystem Type: %s\n", fs_type);
+	if (*volume_name) {
+		r_strbuf_appendf (sb, "Volume Name: %s\n", volume_name);
+	}
+
+	r_strbuf_append (sb, "UUID: ");
+	for (i = 0; i < 16; i++) {
+		r_strbuf_appendf (sb, "%02x", super.s_uuid[i]);
+		if (i == 3 || i == 5 || i == 7 || i == 9) {
+			r_strbuf_append (sb, "-");
+		}
+	}
+	r_strbuf_append (sb, "\n");
+
+	if (*last_mounted) {
+		r_strbuf_appendf (sb, "Last Mounted: %s\n", last_mounted);
+	}
+
+	if (mtime) {
+		time_t t = (time_t)mtime;
+		struct tm *tm = gmtime (&t);
+		if (tm) {
+			r_strbuf_appendf (sb, "Last Mount Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec);
+		}
+	}
+	if (wtime) {
+		time_t t = (time_t)wtime;
+		struct tm *tm = gmtime (&t);
+		if (tm) {
+			r_strbuf_appendf (sb, "Last Write Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec);
+		}
+	}
+	if (lastcheck) {
+		time_t t = (time_t)lastcheck;
+		struct tm *tm = gmtime (&t);
+		if (tm) {
+			r_strbuf_appendf (sb, "Last Check Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec);
+		}
+	}
+
+	r_strbuf_appendf (sb, "Block Size: %u bytes\n", block_size);
+	r_strbuf_appendf (sb, "Total Blocks: %u\n", blocks_count);
+	r_strbuf_appendf (sb, "Free Blocks: %u\n", free_blocks_count);
+	r_strbuf_appendf (sb, "Reserved Blocks: %u\n", r_blocks_count);
+	r_strbuf_appendf (sb, "Total Size: %"PFMT64u" bytes (%.2f MB)\n", total_size, (double)total_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Used Size: %"PFMT64u" bytes (%.2f MB)\n", used_size, (double)used_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Free Size: %"PFMT64u" bytes (%.2f MB)\n", free_size, (double)free_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Reserved Size: %"PFMT64u" bytes (%.2f MB)\n", reserved_size, (double)reserved_size / (1024.0 * 1024.0));
+
+	r_strbuf_appendf (sb, "Inodes Count: %u\n", inodes_count);
+	r_strbuf_appendf (sb, "Free Inodes: %u\n", free_inodes_count);
+	r_strbuf_appendf (sb, "Inodes per Group: %u\n", inodes_per_group);
+	r_strbuf_appendf (sb, "Blocks per Group: %u\n", blocks_per_group);
+
+	if (rev_level >= 1) {
+		ut16 inode_size = r_read_le16 ((ut8 *)&super.s_inode_size);
+		r_strbuf_appendf (sb, "Inode Size: %u bytes\n", inode_size);
+	}
+
+	const char *state_str = "unknown";
+	if (state == 1) state_str = "cleanly unmounted";
+	else if (state == 2) state_str = "errors detected";
+	else if (state == 4) state_str = "orphans being recovered";
+	r_strbuf_appendf (sb, "Filesystem State: %s\n", state_str);
+
+	r_strbuf_appendf (sb, "Mount Count: %u\n", mnt_count);
+	r_strbuf_appendf (sb, "Max Mount Count: %d\n", (st16)max_mnt_count);
+
+	const char *os_str = "unknown";
+	if (creator_os == 0) os_str = "Linux";
+	else if (creator_os == 1) os_str = "Hurd";
+	else if (creator_os == 2) os_str = "Masix";
+	else if (creator_os == 3) os_str = "FreeBSD";
+	else if (creator_os == 4) os_str = "Lites";
+	r_strbuf_appendf (sb, "Creator OS: %s\n", os_str);
+
+	r_strbuf_appendf (sb, "Revision Level: %u\n", rev_level);
+
+	// Feature flags
+	if (feature_compat) {
+		r_strbuf_append (sb, "Compatible Features:");
+		if (feature_compat & 0x0001) r_strbuf_append (sb, " DIR_PREALLOC");
+		if (feature_compat & 0x0002) r_strbuf_append (sb, " IMAGIC_INODES");
+		if (feature_compat & 0x0004) r_strbuf_append (sb, " HAS_JOURNAL");
+		if (feature_compat & 0x0008) r_strbuf_append (sb, " EXT_ATTR");
+		if (feature_compat & 0x0010) r_strbuf_append (sb, " RESIZE_INODE");
+		if (feature_compat & 0x0020) r_strbuf_append (sb, " DIR_INDEX");
+		r_strbuf_append (sb, "\n");
+	}
+
+	if (feature_incompat) {
+		r_strbuf_append (sb, "Incompatible Features:");
+		if (feature_incompat & 0x0001) r_strbuf_append (sb, " COMPRESSION");
+		if (feature_incompat & 0x0002) r_strbuf_append (sb, " FILETYPE");
+		if (feature_incompat & 0x0004) r_strbuf_append (sb, " RECOVER");
+		if (feature_incompat & 0x0008) r_strbuf_append (sb, " JOURNAL_DEV");
+		if (feature_incompat & 0x0010) r_strbuf_append (sb, " META_BG");
+		if (feature_incompat & 0x0040) r_strbuf_append (sb, " EXTENTS");
+		if (feature_incompat & 0x0080) r_strbuf_append (sb, " 64BIT");
+		if (feature_incompat & 0x0100) r_strbuf_append (sb, " MMP");
+		if (feature_incompat & 0x0200) r_strbuf_append (sb, " FLEX_BG");
+		r_strbuf_append (sb, "\n");
+	}
+
+	if (feature_ro_compat) {
+		r_strbuf_append (sb, "Read-Only Compatible Features:");
+		if (feature_ro_compat & 0x0001) r_strbuf_append (sb, " SPARSE_SUPER");
+		if (feature_ro_compat & 0x0002) r_strbuf_append (sb, " LARGE_FILE");
+		if (feature_ro_compat & 0x0004) r_strbuf_append (sb, " BTREE_DIR");
+		if (feature_ro_compat & 0x0008) r_strbuf_append (sb, " HUGE_FILE");
+		if (feature_ro_compat & 0x0010) r_strbuf_append (sb, " GDT_CSUM");
+		if (feature_ro_compat & 0x0020) r_strbuf_append (sb, " DIR_NLINK");
+		if (feature_ro_compat & 0x0040) r_strbuf_append (sb, " EXTRA_ISIZE");
+		r_strbuf_append (sb, "\n");
+	}
+}
+#define FSDETAILS details_ext2
+#endif
 
 #include "fs_grub_base.inc.c"

--- a/libr/fs/p/fs_fat.c
+++ b/libr/fs/p/fs_fat.c
@@ -1,4 +1,7 @@
-/* radare - LGPL - Copyright 2011-2023 pancake */
+/* radare - LGPL - Copyright 2011-2025 pancake, MiKi (mikelloc) */
+
+#include <r_userconf.h>
+#include <r_fs.h>
 
 #define FSP(x) fat_##x
 #define FSS(x) x##_fat
@@ -6,5 +9,171 @@
 #define FSDESC "FAT filesystem"
 #define FSPRFX fat
 #define FSIPTR grub_fat_fs
+
+#if WITH_GPL
+
+R_PACKED(
+typedef struct {
+	ut8 jmp_boot[3];
+	ut8 oem_name[8];
+	ut16 bytes_per_sector;
+	ut8 sectors_per_cluster;
+	ut16 num_reserved_sectors;
+	ut8 num_fats;
+	ut16 num_root_entries;
+	ut16 num_total_sectors_16;
+	ut8 media;
+	ut16 sectors_per_fat_16;
+	ut16 sectors_per_track;
+	ut16 num_heads;
+	ut32 num_hidden_sectors;
+	ut32 num_total_sectors_32;
+	union {
+		struct {
+			ut8 num_ph_drive;
+			ut8 reserved;
+			ut8 boot_sig;
+			ut32 num_serial;
+			ut8 label[11];
+			ut8 fstype[8];
+		} fat12_or_fat16;
+		struct {
+			ut32 sectors_per_fat_32;
+			ut16 extended_flags;
+			ut16 fs_version;
+			ut32 root_cluster;
+			ut16 fs_info;
+			ut16 backup_boot_sector;
+			ut8 reserved[12];
+			ut8 num_ph_drive;
+			ut8 reserved1;
+			ut8 boot_sig;
+			ut32 num_serial;
+			ut8 label[11];
+			ut8 fstype[8];
+		} fat32;
+	} version_specific;
+}) fat_bpb_t;
+
+static void details_fat(RFSRoot *root, RStrBuf *sb) {
+	fat_bpb_t bpb;
+	if (!root->iob.read_at (root->iob.io, root->delta, (ut8 *)&bpb, sizeof (bpb))) {
+		r_strbuf_append (sb, "ERROR: Could not read boot sector\n");
+		return;
+	}
+
+	ut16 bytes_per_sector = r_read_le16 ((ut8 *)&bpb.bytes_per_sector);
+	ut8 sectors_per_cluster = bpb.sectors_per_cluster;
+	ut16 reserved_sectors = r_read_le16 ((ut8 *)&bpb.num_reserved_sectors);
+	ut16 root_entries = r_read_le16 ((ut8 *)&bpb.num_root_entries);
+	ut32 total_sectors = r_read_le16 ((ut8 *)&bpb.num_total_sectors_16);
+	if (total_sectors == 0) {
+		total_sectors = r_read_le32 ((ut8 *)&bpb.num_total_sectors_32);
+	}
+
+	ut32 sectors_per_fat = r_read_le16 ((ut8 *)&bpb.sectors_per_fat_16);
+	bool is_fat32 = false;
+	ut32 root_cluster = 0;
+	if (sectors_per_fat == 0) {
+		sectors_per_fat = r_read_le32 ((ut8 *)&bpb.version_specific.fat32.sectors_per_fat_32);
+		root_cluster = r_read_le32 ((ut8 *)&bpb.version_specific.fat32.root_cluster);
+		is_fat32 = true;
+	}
+
+	ut32 root_dir_sectors = ((root_entries * 32) + (bytes_per_sector - 1)) / bytes_per_sector;
+	ut32 first_data_sector = reserved_sectors + (bpb.num_fats * sectors_per_fat) + root_dir_sectors;
+	ut32 data_sectors = total_sectors - first_data_sector;
+	ut32 total_clusters = data_sectors / sectors_per_cluster;
+
+	const char *fat_type = "FAT12";
+	if (is_fat32) {
+		fat_type = "FAT32";
+	} else if (total_clusters >= 4085) {
+		fat_type = "FAT16";
+	}
+
+	char label[12] = {0};
+	char fstype[9] = {0};
+	char oem[9] = {0};
+	ut32 serial = 0;
+	ut8 boot_sig = 0;
+	ut8 bpb_buf[90];
+	int i;
+
+	if (!root->iob.read_at (root->iob.io, root->delta, bpb_buf, sizeof (bpb_buf))) {
+		r_strbuf_append (sb, "ERROR: Could not re-read boot sector\n");
+		return;
+	}
+
+	if (is_fat32) {
+		// FAT32: offsets 0x47, 0x47+4, 0x47+4+1, 0x47+4+1+1
+		boot_sig = bpb_buf[0x42];
+		serial = r_read_le32 (bpb_buf + 0x43);
+		memcpy (label, bpb_buf + 0x47, 11);
+		memcpy (fstype, bpb_buf + 0x52, 8);
+	} else {
+		// FAT12/16: offsets 0x26 (boot_sig), 0x27 (serial), 0x2B (label), 0x36 (fstype)
+		boot_sig = bpb_buf[0x26];
+		serial = r_read_le32 (bpb_buf + 0x27);
+		memcpy (label, bpb_buf + 0x2B, 11);
+		memcpy (fstype, bpb_buf + 0x36, 8);
+	}
+	label[11] = 0;
+	fstype[8] = 0;
+
+	// Trim trailing spaces and non-printable characters
+	for (i = 10; i >= 0 && (label[i] == ' ' || label[i] < 32); i--) {
+		label[i] = 0;
+	}
+	for (i = 7; i >= 0 && (fstype[i] == ' ' || fstype[i] < 32); i--) {
+		fstype[i] = 0;
+	}
+
+	memcpy (oem, bpb.oem_name, 8);
+	oem[8] = 0;
+	for (i = 7; i >= 0 && (oem[i] == ' ' || oem[i] < 32); i--) {
+		oem[i] = 0;
+	}
+
+	ut64 total_size = (ut64)total_sectors * bytes_per_sector;
+	ut32 cluster_size = bytes_per_sector * sectors_per_cluster;
+	ut64 fat_size = (ut64)sectors_per_fat * bytes_per_sector;
+
+	r_strbuf_appendf (sb, "Filesystem Type: %s\n", fat_type);
+	if (*label) {
+		r_strbuf_appendf (sb, "Volume Label: %s\n", label);
+	}
+	if (*oem) {
+		r_strbuf_appendf (sb, "OEM Name: %s\n", oem);
+	}
+	if (boot_sig == 0x29) {
+		r_strbuf_appendf (sb, "Serial Number: %08X\n", serial);
+	}
+	if (*fstype) {
+		r_strbuf_appendf (sb, "FS Type String: %s\n", fstype);
+	}
+	r_strbuf_appendf (sb, "Media Type: 0x%02x\n", bpb.media);
+	r_strbuf_appendf (sb, "Bytes per Sector: %u\n", bytes_per_sector);
+	r_strbuf_appendf (sb, "Sectors per Cluster: %u\n", sectors_per_cluster);
+	r_strbuf_appendf (sb, "Cluster Size: %u bytes\n", cluster_size);
+	r_strbuf_appendf (sb, "Reserved Sectors: %u\n", reserved_sectors);
+	r_strbuf_appendf (sb, "Number of FATs: %u\n", bpb.num_fats);
+	r_strbuf_appendf (sb, "Sectors per FAT: %u\n", sectors_per_fat);
+	r_strbuf_appendf (sb, "FAT Size: %"PFMT64u" bytes\n", fat_size);
+
+	if (!is_fat32) {
+		r_strbuf_appendf (sb, "Root Directory Entries: %u\n", root_entries);
+		r_strbuf_appendf (sb, "Root Directory Sectors: %u\n", root_dir_sectors);
+	} else {
+		r_strbuf_appendf (sb, "Root Directory Cluster: %u\n", root_cluster);
+	}
+	r_strbuf_appendf (sb, "Total Sectors: %u\n", total_sectors);
+	r_strbuf_appendf (sb, "Data Sectors: %u\n", data_sectors);
+	r_strbuf_appendf (sb, "Total Clusters: %u\n", total_clusters);
+	r_strbuf_appendf (sb, "First Data Sector: %u\n", first_data_sector);
+	r_strbuf_appendf (sb, "Total Size: %"PFMT64u" bytes (%.2f MB)\n", total_size, (double)total_size / (1024.0 * 1024.0));
+}
+#define FSDETAILS details_fat
+#endif
 
 #include "fs_grub_base.inc.c"

--- a/libr/fs/p/fs_grub_base.inc.c
+++ b/libr/fs/p/fs_grub_base.inc.c
@@ -80,6 +80,13 @@ static void FSP(_umount)(RFSRoot *root) {
 	root->ptr = NULL;
 }
 
+#ifdef FSDETAILS
+static void FSP(details)(RFSRoot *root, RStrBuf *sb) {
+	R_RETURN_IF_FAIL (root && sb);
+	FSDETAILS (root, sb);
+}
+#endif
+
 RFSPlugin FSS(r_fs_plugin) = {
 	.meta = {
 		.name = FSNAME,
@@ -93,6 +100,9 @@ RFSPlugin FSS(r_fs_plugin) = {
 	.dir = FSP(_dir),
 	.mount = FSP(_mount),
 	.umount = FSP(_umount),
+#ifdef FSDETAILS
+	.details = FSP(details),
+#endif
 };
 #else
 RFSPlugin FSS(r_fs_plugin) = {

--- a/libr/fs/p/fs_hfs.c
+++ b/libr/fs/p/fs_hfs.c
@@ -1,4 +1,7 @@
-/* radare - LGPL - Copyright 2011-2023 pancake */
+/* radare - LGPL - Copyright 2011-2025 pancake, MiKi (mikelloc) */
+
+#include <r_userconf.h>
+#include <r_fs.h>
 
 #define FSP(x) grub_hfs##x
 #define FSS(x) x##_hfs
@@ -6,5 +9,137 @@
 #define FSDESC "HFS filesystem"
 #define FSPRFX hfs
 #define FSIPTR grub_hfs_fs
+
+#if WITH_GPL
+
+R_PACKED(
+typedef struct {
+	ut16 signature;
+	ut32 create_date;
+	ut32 modify_date;
+	ut16 attributes;
+	ut16 root_file_count;
+	ut16 volume_bitmap_block;
+	ut16 alloc_block_start;
+	ut16 total_blocks;
+	ut32 block_size;
+	ut32 clump_size;
+	ut16 first_alloc_block;
+	ut32 next_cnid;
+	ut16 free_blocks;
+	ut8 volume_name_length;
+	char volume_name[27];
+	ut32 backup_date;
+	ut16 backup_seq_num;
+	ut32 write_count;
+	ut32 extents_clump_size;
+	ut32 catalog_clump_size;
+	ut16 root_dir_count;
+	ut32 file_count;
+	ut32 dir_count;
+	ut32 finder_info[8];
+	ut16 embed_sig;
+	ut16 embed_extent_block;
+	ut16 embed_extent_count;
+	ut32 extents_size;
+	ut32 extents_first_blocks[3];
+	ut32 catalog_size;
+	ut32 catalog_first_blocks[3];
+}) hfs_mdb_t;
+
+static void details_hfs(RFSRoot *root, RStrBuf *sb) {
+	hfs_mdb_t mdb;
+	// MDB is at offset 1024 from the start
+	ut64 mdb_offset = root->delta + 1024;
+
+	if (!root->iob.read_at (root->iob.io, mdb_offset, (ut8 *)&mdb, sizeof (mdb))) {
+		r_strbuf_append (sb, "ERROR: Could not read HFS Master Directory Block\n");
+		return;
+	}
+
+	ut16 signature = r_read_be16 ((ut8 *)&mdb.signature);
+	// Check for HFS signature (0x4244 = "BD")
+	if (signature != 0x4244) {
+		r_strbuf_append (sb, "ERROR: Invalid HFS signature\n");
+		return;
+	}
+
+	char volume_name[28] = {0};
+	ut8 name_len = mdb.volume_name_length;
+	if (name_len > 27) {
+		name_len = 27;
+	}
+	memcpy (volume_name, mdb.volume_name, name_len);
+	volume_name[name_len] = 0;
+
+	ut16 total_blocks = r_read_be16 ((ut8 *)&mdb.total_blocks);
+	ut32 block_size = r_read_be32 ((ut8 *)&mdb.block_size);
+	ut16 free_blocks = r_read_be16 ((ut8 *)&mdb.free_blocks);
+	ut32 file_count = r_read_be32 ((ut8 *)&mdb.file_count);
+	ut32 dir_count = r_read_be32 ((ut8 *)&mdb.dir_count);
+	ut32 create_date = r_read_be32 ((ut8 *)&mdb.create_date);
+	ut32 modify_date = r_read_be32 ((ut8 *)&mdb.modify_date);
+	ut32 backup_date = r_read_be32 ((ut8 *)&mdb.backup_date);
+
+	ut64 total_size = (ut64)total_blocks * block_size;
+	ut64 used_size = (ut64)(total_blocks - free_blocks) * block_size;
+	ut64 free_size = (ut64)free_blocks * block_size;
+
+	r_strbuf_append (sb, "Filesystem Type: HFS\n");
+	if (*volume_name) {
+		r_strbuf_appendf (sb, "Volume Name: %s\n", volume_name);
+	}
+
+	// HFS uses Mac epoch (January 1, 1904) - convert to Unix epoch
+	// Mac epoch is 2082844800 seconds before Unix epoch (Jan 1, 1970)
+	const ut64 mac_epoch_offset = 2082844800ULL;
+
+	if (create_date) {
+		time_t unix_time = (time_t)(create_date - mac_epoch_offset);
+		struct tm *tm = gmtime (&unix_time);
+		if (tm) {
+			r_strbuf_appendf (sb, "Create Date: %04d-%02d-%02d %02d:%02d:%02d (HFS timestamp: %u)\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec, create_date);
+		}
+	}
+	if (modify_date) {
+		time_t unix_time = (time_t)(modify_date - mac_epoch_offset);
+		struct tm *tm = gmtime (&unix_time);
+		if (tm) {
+			r_strbuf_appendf (sb, "Modify Date: %04d-%02d-%02d %02d:%02d:%02d (HFS timestamp: %u)\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec, modify_date);
+		}
+	}
+	if (backup_date) {
+		time_t unix_time = (time_t)(backup_date - mac_epoch_offset);
+		struct tm *tm = gmtime (&unix_time);
+		if (tm) {
+			r_strbuf_appendf (sb, "Backup Date: %04d-%02d-%02d %02d:%02d:%02d (HFS: %u)\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec, backup_date);
+		}
+	}
+
+	r_strbuf_appendf (sb, "Block Size: %u bytes\n", block_size);
+	r_strbuf_appendf (sb, "Total Blocks: %u\n", total_blocks);
+	r_strbuf_appendf (sb, "Free Blocks: %u\n", free_blocks);
+	r_strbuf_appendf (sb, "Total Size: %"PFMT64u" bytes (%.2f MB)\n", total_size, (double)total_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Used Size: %"PFMT64u" bytes (%.2f MB)\n", used_size, (double)used_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Free Size: %"PFMT64u" bytes (%.2f MB)\n", free_size, (double)free_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "File Count: %u\n", file_count);
+	r_strbuf_appendf (sb, "Directory Count: %u\n", dir_count);
+
+	ut32 clump_size = r_read_be32 ((ut8 *)&mdb.clump_size);
+	ut32 catalog_clump_size = r_read_be32 ((ut8 *)&mdb.catalog_clump_size);
+	ut32 extents_clump_size = r_read_be32 ((ut8 *)&mdb.extents_clump_size);
+
+	r_strbuf_appendf (sb, "Allocation Clump Size: %u bytes\n", clump_size);
+	r_strbuf_appendf (sb, "Catalog Clump Size: %u bytes\n", catalog_clump_size);
+	r_strbuf_appendf (sb, "Extents Clump Size: %u bytes\n", extents_clump_size);
+}
+#define FSDETAILS details_hfs
+#endif
 
 #include "fs_grub_base.inc.c"

--- a/libr/fs/p/fs_iso9660.c
+++ b/libr/fs/p/fs_iso9660.c
@@ -1,4 +1,7 @@
-/* radare - LGPL - Copyright 2011-2023 pancake */
+/* radare - LGPL - Copyright 2011-2025 pancake, MiKi (mikelloc) */
+
+#include <r_userconf.h>
+#include <r_fs.h>
 
 #define FSP(x) iso9660_##x
 #define FSS(x) x##_iso9660
@@ -6,5 +9,154 @@
 #define FSDESC "ISO9660 filesystem"
 #define FSPRFX iso9660
 #define FSIPTR grub_iso9660_fs
+
+#if WITH_GPL
+
+R_PACKED(
+typedef struct {
+	ut8 type;
+	char id[5];
+	ut8 version;
+	ut8 unused1;
+	char system_id[32];
+	char volume_id[32];
+	ut8 unused2[8];
+	ut32 volume_space_size_le;
+	ut32 volume_space_size_be;
+	ut8 unused3[32];
+	ut16 volume_set_size_le;
+	ut16 volume_set_size_be;
+	ut16 volume_sequence_number_le;
+	ut16 volume_sequence_number_be;
+	ut16 logical_block_size_le;
+	ut16 logical_block_size_be;
+	ut32 path_table_size_le;
+	ut32 path_table_size_be;
+	ut32 type_l_path_table;
+	ut32 opt_type_l_path_table;
+	ut32 type_m_path_table;
+	ut32 opt_type_m_path_table;
+	ut8 root_directory_record[34];
+	char volume_set_id[128];
+	char publisher_id[128];
+	char preparer_id[128];
+	char application_id[128];
+	char copyright_file_id[37];
+	char abstract_file_id[37];
+	char bibliographic_file_id[37];
+	char creation_date[17];
+	char modification_date[17];
+	char expiration_date[17];
+	char effective_date[17];
+	ut8 file_structure_version;
+	ut8 unused4;
+	ut8 application_data[512];
+	ut8 reserved[653];
+}) iso9660_pvd_t;
+
+static void details_iso9660(RFSRoot *root, RStrBuf *sb) {
+	iso9660_pvd_t pvd;
+	// Primary Volume Descriptor is at sector 16
+	ut64 pvd_offset = root->delta + (16 * 2048);
+
+	if (!root->iob.read_at (root->iob.io, pvd_offset, (ut8 *)&pvd, sizeof (pvd))) {
+		r_strbuf_append (sb, "ERROR: Could not read Primary Volume Descriptor\n");
+		return;
+	}
+
+	if (pvd.type != 1 || memcmp (pvd.id, "CD001", 5) != 0) {
+		r_strbuf_append (sb, "ERROR: Invalid Primary Volume Descriptor\n");
+		return;
+	}
+
+	char volume_id[33] = {0};
+	char system_id[33] = {0};
+	char publisher_id[129] = {0};
+	char preparer_id[129] = {0};
+	char application_id[129] = {0};
+	char volume_set_id[129] = {0};
+	int i;
+
+	memcpy (volume_id, pvd.volume_id, 32);
+	memcpy (system_id, pvd.system_id, 32);
+	memcpy (publisher_id, pvd.publisher_id, 128);
+	memcpy (preparer_id, pvd.preparer_id, 128);
+	memcpy (application_id, pvd.application_id, 128);
+	memcpy (volume_set_id, pvd.volume_set_id, 128);
+
+	for (i = 31; i >= 0 && volume_id[i] == ' '; i--) {
+		volume_id[i] = 0;
+	}
+	for (i = 31; i >= 0 && system_id[i] == ' '; i--) {
+		system_id[i] = 0;
+	}
+	for (i = 127; i >= 0 && publisher_id[i] == ' '; i--) {
+		publisher_id[i] = 0;
+	}
+	for (i = 127; i >= 0 && preparer_id[i] == ' '; i--) {
+		preparer_id[i] = 0;
+	}
+	for (i = 127; i >= 0 && application_id[i] == ' '; i--) {
+		application_id[i] = 0;
+	}
+	for (i = 127; i >= 0 && volume_set_id[i] == ' '; i--) {
+		volume_set_id[i] = 0;
+	}
+
+	ut16 logical_block_size = r_read_le16 ((ut8 *)&pvd.logical_block_size_le);
+	ut32 volume_space_size = r_read_le32 ((ut8 *)&pvd.volume_space_size_le);
+	ut16 volume_set_size = r_read_le16 ((ut8 *)&pvd.volume_set_size_le);
+	ut16 volume_sequence_number = r_read_le16 ((ut8 *)&pvd.volume_sequence_number_le);
+	ut32 path_table_size = r_read_le32 ((ut8 *)&pvd.path_table_size_le);
+
+	ut64 total_size = (ut64)volume_space_size * logical_block_size;
+
+	r_strbuf_append (sb, "Filesystem Type: ISO9660\n");
+	if (*volume_id) {
+		r_strbuf_appendf (sb, "Volume ID: %s\n", volume_id);
+	}
+	if (*system_id) {
+		r_strbuf_appendf (sb, "System ID: %s\n", system_id);
+	}
+	if (*volume_set_id) {
+		r_strbuf_appendf (sb, "Volume Set ID: %s\n", volume_set_id);
+	}
+	if (*publisher_id) {
+		r_strbuf_appendf (sb, "Publisher: %s\n", publisher_id);
+	}
+	if (*preparer_id) {
+		r_strbuf_appendf (sb, "Preparer: %s\n", preparer_id);
+	}
+	if (*application_id) {
+		r_strbuf_appendf (sb, "Application: %s\n", application_id);
+	}
+
+	// Parse ISO9660 timestamp format: YYYYMMDDHHMMSSmmz (mm = centiseconds, z = timezone offset)
+	char creation_date[18] = {0};
+	memcpy (creation_date, pvd.creation_date, 17);
+	if (creation_date[0] != '0' && creation_date[0] != ' ' && creation_date[0] >= '1' && creation_date[0] <= '9') {
+		char year[5] = {0}, month[3] = {0}, day[3] = {0};
+		char hour[3] = {0}, minute[3] = {0}, second[3] = {0}, centisec[3] = {0};
+		memcpy (year, creation_date, 4);
+		memcpy (month, creation_date + 4, 2);
+		memcpy (day, creation_date + 6, 2);
+		memcpy (hour, creation_date + 8, 2);
+		memcpy (minute, creation_date + 10, 2);
+		memcpy (second, creation_date + 12, 2);
+		memcpy (centisec, creation_date + 14, 2);
+		r_strbuf_appendf (sb, "Creation Date: %s-%s-%s %s:%s:%s.%s\n",
+			year, month, day, hour, minute, second, centisec);
+	}
+
+	r_strbuf_appendf (sb, "Logical Block Size: %u bytes\n", logical_block_size);
+	r_strbuf_appendf (sb, "Volume Space Size: %u blocks\n", volume_space_size);
+	r_strbuf_appendf (sb, "Total Size: %"PFMT64u" bytes (%.2f MB)\n", total_size, (double)total_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "Path Table Size: %u bytes\n", path_table_size);
+	r_strbuf_appendf (sb, "Volume Set Size: %u\n", volume_set_size);
+	r_strbuf_appendf (sb, "Volume Sequence Number: %u\n", volume_sequence_number);
+	r_strbuf_appendf (sb, "File Structure Version: %u\n", pvd.file_structure_version);
+}
+#define FSDETAILS details_iso9660
+#endif
 
 #include "fs_grub_base.inc.c"

--- a/libr/fs/p/fs_ntfs.c
+++ b/libr/fs/p/fs_ntfs.c
@@ -1,4 +1,7 @@
-/* radare - LGPL - Copyright 2011-2023 pancake */
+/* radare - LGPL - Copyright 2011-2025 pancake, MiKi (mikelloc) */
+
+#include <r_userconf.h>
+#include <r_fs.h>
 
 #define FSP(x) ntfs_##x
 #define FSS(x) x##_ntfs
@@ -6,5 +9,231 @@
 #define FSDESC "NTFS filesystem"
 #define FSPRFX ntfs
 #define FSIPTR grub_ntfs_fs
+
+#if WITH_GPL
+
+R_PACKED(
+typedef struct {
+	ut8 jump[3];
+	char oem_id[8];
+	ut16 bytes_per_sector;
+	ut8 sectors_per_cluster;
+	ut16 reserved_sectors;
+	ut8 unused1[3];
+	ut16 unused2;
+	ut8 media_descriptor;
+	ut16 unused3;
+	ut16 sectors_per_track;
+	ut16 num_heads;
+	ut32 hidden_sectors;
+	ut32 unused4;
+	ut32 unused5;
+	ut64 total_sectors;
+	ut64 mft_cluster;
+	ut64 mft_mirror_cluster;
+	st8 clusters_per_mft_record;
+	ut8 unused6[3];
+	st8 clusters_per_index_block;
+	ut8 unused7[3];
+	ut64 volume_serial;
+	ut32 checksum;
+}) ntfs_bpb_t;
+
+R_PACKED(
+typedef struct {
+	char signature[4];           // "FILE"
+	ut16 update_seq_offset;
+	ut16 update_seq_size;
+	ut64 logfile_seq_number;
+	ut16 sequence_number;
+	ut16 hard_link_count;
+	ut16 first_attr_offset;
+	ut16 flags;
+	ut32 used_size;
+	ut32 allocated_size;
+	ut64 base_record;
+	ut16 next_attr_id;
+}) ntfs_mft_record_t;
+
+R_PACKED(
+typedef struct {
+	ut32 type;
+	ut32 length;
+	ut8 non_resident;
+	ut8 name_length;
+	ut16 name_offset;
+	ut16 flags;
+	ut16 id;
+	ut32 value_length;
+	ut16 value_offset;
+}) ntfs_attr_header_t;
+
+R_PACKED(
+typedef struct {
+	ut64 creation_time;
+	ut64 modification_time;
+	ut64 mft_modification_time;
+	ut64 access_time;
+	ut32 file_attributes;
+}) ntfs_std_info_t;
+
+// Convert NTFS FILETIME (100-nanosecond intervals since 1601-01-01) to Unix time
+static time_t ntfs_filetime_to_unix(ut64 filetime) {
+	// NTFS epoch (1601-01-01) to Unix epoch (1970-01-01) is 11644473600 seconds
+	const ut64 ntfs_epoch_offset = 11644473600ULL;
+	ut64 seconds = filetime / 10000000ULL;
+	if (seconds < ntfs_epoch_offset) {
+		return 0;
+	}
+	return (time_t)(seconds - ntfs_epoch_offset);
+}
+
+static void details_ntfs(RFSRoot *root, RStrBuf *sb) {
+	ntfs_bpb_t bpb;
+	if (!root->iob.read_at (root->iob.io, root->delta, (ut8 *)&bpb, sizeof (bpb))) {
+		r_strbuf_append (sb, "ERROR: Could not read NTFS boot sector\n");
+		return;
+	}
+
+	char oem_id[9] = {0};
+	int i;
+	memcpy (oem_id, bpb.oem_id, 8);
+	if (memcmp (oem_id, "NTFS    ", 8) != 0) {
+		r_strbuf_append (sb, "ERROR: Invalid NTFS signature\n");
+		return;
+	}
+	// Trim trailing spaces and non-printable characters
+	for (i = 7; i >= 0 && (oem_id[i] == ' ' || oem_id[i] < 32); i--) {
+		oem_id[i] = 0;
+	}
+
+	ut16 bytes_per_sector = r_read_le16 ((ut8 *)&bpb.bytes_per_sector);
+	ut8 sectors_per_cluster = bpb.sectors_per_cluster;
+	ut64 total_sectors = r_read_le64 ((ut8 *)&bpb.total_sectors);
+	ut64 mft_cluster = r_read_le64 ((ut8 *)&bpb.mft_cluster);
+	ut64 mft_mirror_cluster = r_read_le64 ((ut8 *)&bpb.mft_mirror_cluster);
+	ut64 volume_serial = r_read_le64 ((ut8 *)&bpb.volume_serial);
+
+	ut32 cluster_size = bytes_per_sector * sectors_per_cluster;
+	ut64 total_size = total_sectors * bytes_per_sector;
+	ut64 mft_offset = root->delta + (mft_cluster * cluster_size);
+
+	st8 clusters_per_mft = bpb.clusters_per_mft_record;
+	ut32 mft_record_size;
+	if (clusters_per_mft > 0) {
+		mft_record_size = clusters_per_mft * cluster_size;
+	} else {
+		mft_record_size = 1 << (-clusters_per_mft);
+	}
+
+	st8 clusters_per_index = bpb.clusters_per_index_block;
+	ut32 index_block_size;
+	if (clusters_per_index > 0) {
+		index_block_size = clusters_per_index * cluster_size;
+	} else {
+		index_block_size = 1 << (-clusters_per_index);
+	}
+
+	char volume_label[256] = {0};
+	ut64 creation_time = 0;
+	ut64 modification_time = 0;
+
+	ut8 *mft_record = malloc(mft_record_size);
+	if (mft_record) {
+		ut64 volume_mft_offset = mft_offset + (3 * mft_record_size);
+		if (root->iob.read_at (root->iob.io, volume_mft_offset, mft_record, mft_record_size)) {
+			ntfs_mft_record_t *mft = (ntfs_mft_record_t *)mft_record;
+
+			if (memcmp (mft->signature, "FILE", 4) == 0) {
+				ut16 attr_offset = r_read_le16 ((ut8 *)&mft->first_attr_offset);
+
+				while (attr_offset < mft_record_size - sizeof (ntfs_attr_header_t)) {
+					ntfs_attr_header_t *attr = (ntfs_attr_header_t *)(mft_record + attr_offset);
+					ut32 attr_type = r_read_le32 ((ut8 *)&attr->type);
+					ut32 attr_length = r_read_le32 ((ut8 *)&attr->length);
+
+					if (attr_type == 0xFFFFFFFF || attr_length == 0 || attr_length > mft_record_size) {
+						break;
+					}
+
+					// 0x10 = $STANDARD_INFORMATION
+					if (attr_type == 0x10 && !attr->non_resident) {
+						ut16 value_offset = r_read_le16 ((ut8 *)&attr->value_offset);
+						ntfs_std_info_t *std_info = (ntfs_std_info_t *)(mft_record + attr_offset + value_offset);
+						creation_time = r_read_le64 ((ut8 *)&std_info->creation_time);
+						modification_time = r_read_le64 ((ut8 *)&std_info->modification_time);
+					}
+
+					// 0x60 = $VOLUME_NAME
+					if (attr_type == 0x60 && !attr->non_resident) {
+						ut32 value_length = r_read_le32 ((ut8 *)&attr->value_length);
+						ut16 value_offset = r_read_le16 ((ut8 *)&attr->value_offset);
+
+						if (value_length > 0 && value_length < 512) {
+							// Volume name is in UTF-16LE, simple conversion to ASCII
+							// Better conversion needed for non ASCII characters
+							ut8 *name_utf16 = mft_record + attr_offset + value_offset;
+							int name_chars = value_length / 2;
+							int j;
+							if (name_chars > 127) {
+								name_chars = 127;
+							}
+							for (j = 0; j < name_chars; j++) {
+								ut16 c = r_read_le16(name_utf16 + (j * 2));
+								volume_label[j] = (c < 128) ? (char)c : '?';
+							}
+							volume_label[name_chars] = 0;
+						}
+					}
+
+					attr_offset += attr_length;
+				}
+			}
+		}
+		free (mft_record);
+	}
+
+	r_strbuf_append (sb, "Filesystem Type: NTFS\n");
+	r_strbuf_appendf (sb, "OEM ID: %s\n", oem_id);
+
+	if (*volume_label) {
+		r_strbuf_appendf (sb, "Volume Label: %s\n", volume_label);
+	}
+
+	r_strbuf_appendf (sb, "Volume Serial Number: %016"PFMT64x"\n", volume_serial);
+
+	if (creation_time) {
+		time_t t = ntfs_filetime_to_unix(creation_time);
+		struct tm *tm = gmtime(&t);
+		if (tm) {
+			r_strbuf_appendf (sb, "Volume Creation Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec);
+		}
+	}
+	if (modification_time) {
+		time_t t = ntfs_filetime_to_unix(modification_time);
+		struct tm *tm = gmtime(&t);
+		if (tm) {
+			r_strbuf_appendf (sb, "Volume Modification Time: %04d-%02d-%02d %02d:%02d:%02d\n",
+				tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+				tm->tm_hour, tm->tm_min, tm->tm_sec);
+		}
+	}
+
+	r_strbuf_appendf (sb, "Bytes per Sector: %u\n", bytes_per_sector);
+	r_strbuf_appendf (sb, "Sectors per Cluster: %u\n", sectors_per_cluster);
+	r_strbuf_appendf (sb, "Cluster Size: %u bytes\n", cluster_size);
+	r_strbuf_appendf (sb, "Total Sectors: %"PFMT64u"\n", total_sectors);
+	r_strbuf_appendf (sb, "Total Size: %"PFMT64u" bytes (%.2f MB)\n", total_size, (double)total_size / (1024.0 * 1024.0));
+	r_strbuf_appendf (sb, "MFT Cluster: %"PFMT64u"\n", mft_cluster);
+	r_strbuf_appendf (sb, "MFT Offset: 0x%"PFMT64x"\n", mft_offset - root->delta);
+	r_strbuf_appendf (sb, "MFT Mirror Cluster: %"PFMT64u"\n", mft_mirror_cluster);
+	r_strbuf_appendf (sb, "MFT Record Size: %u bytes\n", mft_record_size);
+	r_strbuf_appendf (sb, "Index Block Size: %u bytes\n", index_block_size);
+	r_strbuf_appendf (sb, "Media Descriptor: 0x%02x\n", bpb.media_descriptor);
+}
+#define FSDETAILS details_ntfs
+#endif
 
 #include "fs_grub_base.inc.c"

--- a/libr/include/r_fs.h
+++ b/libr/include/r_fs.h
@@ -74,6 +74,8 @@ typedef struct r_fs_plugin_t {
 	void (*umount)(RFSRoot *root);
 	/* callback to run plugin-specific commands (e.g. m:cmd) */
 	bool (*cmd)(RFS *fs, const char *cmd);
+	/* callback to print filesystem-specific details */
+	void (*details)(RFSRoot *root, RStrBuf *sb);
 } RFSPlugin;
 
 typedef struct r_fs_partition_t {

--- a/test/db/cmd/cmd_mn
+++ b/test/db/cmd/cmd_mn
@@ -1,0 +1,216 @@
+NAME=mn ext2 details
+FILE=bins/fs/ext2.img
+CMDS=<<EOF
+m /mnt ext2 @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: ext2
+UUID: 201f53c3-fc0f-4d0c-ae45-aa999efcfe7f
+Last Mounted: /mnt
+Last Mount Time: 2017-11-06 17:51:29
+Last Write Time: 2017-11-06 17:52:01
+Last Check Time: 2017-11-06 17:51:27
+Block Size: 1024 bytes
+Total Blocks: 1024
+Free Blocks: 837
+Reserved Blocks: 51
+Total Size: 1048576 bytes (1.00 MB)
+Used Size: 191488 bytes (0.18 MB)
+Free Size: 857088 bytes (0.82 MB)
+Reserved Size: 52224 bytes (0.05 MB)
+Inodes Count: 128
+Free Inodes: 112
+Inodes per Group: 128
+Blocks per Group: 8192
+Inode Size: 128 bytes
+Filesystem State: cleanly unmounted
+Mount Count: 1
+Max Mount Count: -1
+Creator OS: Linux
+Revision Level: 1
+Compatible Features: EXT_ATTR RESIZE_INODE DIR_INDEX
+Incompatible Features: FILETYPE
+Read-Only Compatible Features: SPARSE_SUPER LARGE_FILE
+EOF
+RUN
+
+NAME=mn ext3 details
+FILE=bins/fs/ext3.img
+CMDS=<<EOF
+m /mnt ext2 @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: ext2
+Volume Name: MIKI_FS_TEST
+UUID: f0640c63-5163-4e94-91e5-2cd257b82419
+Last Mounted: /tmp/ext3_mount
+Last Mount Time: 2025-10-04 03:11:58
+Last Write Time: 2025-10-04 03:17:01
+Last Check Time: 2025-10-04 03:09:29
+Block Size: 1024 bytes
+Total Blocks: 2048
+Free Blocks: 904
+Reserved Blocks: 102
+Total Size: 2097152 bytes (2.00 MB)
+Used Size: 1171456 bytes (1.12 MB)
+Free Size: 925696 bytes (0.88 MB)
+Reserved Size: 104448 bytes (0.10 MB)
+Inodes Count: 256
+Free Inodes: 220
+Inodes per Group: 256
+Blocks per Group: 8192
+Inode Size: 256 bytes
+Filesystem State: cleanly unmounted
+Mount Count: 2
+Max Mount Count: -1
+Creator OS: Linux
+Revision Level: 1
+Compatible Features: HAS_JOURNAL EXT_ATTR RESIZE_INODE DIR_INDEX
+Incompatible Features: FILETYPE
+Read-Only Compatible Features: SPARSE_SUPER LARGE_FILE
+EOF
+RUN
+
+NAME=mn ext4 details
+FILE=bins/fs/ext4.img
+CMDS=<<EOF
+m /mnt ext2 @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: ext4
+Volume Name: MIKI_FS_TEST
+UUID: 6ae0a5d0-f36d-4361-985c-adf92365736f
+Last Mounted: /tmp/ext4_mount
+Last Mount Time: 2025-10-04 03:43:41
+Last Write Time: 2025-10-04 03:43:41
+Last Check Time: 2025-10-04 03:29:32
+Block Size: 1024 bytes
+Total Blocks: 2048
+Free Blocks: 909
+Reserved Blocks: 102
+Total Size: 2097152 bytes (2.00 MB)
+Used Size: 1166336 bytes (1.11 MB)
+Free Size: 930816 bytes (0.89 MB)
+Reserved Size: 104448 bytes (0.10 MB)
+Inodes Count: 256
+Free Inodes: 220
+Inodes per Group: 256
+Blocks per Group: 8192
+Inode Size: 256 bytes
+Filesystem State: cleanly unmounted
+Mount Count: 2
+Max Mount Count: -1
+Creator OS: Linux
+Revision Level: 1
+Compatible Features: HAS_JOURNAL EXT_ATTR RESIZE_INODE DIR_INDEX
+Incompatible Features: FILETYPE RECOVER EXTENTS FLEX_BG
+Read-Only Compatible Features: SPARSE_SUPER LARGE_FILE HUGE_FILE DIR_NLINK EXTRA_ISIZE
+EOF
+RUN
+
+NAME=mn fat details
+FILE=bins/fs/fat.img
+CMDS=<<EOF
+m /mnt fat @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: FAT12
+Volume Label: NO NAME
+OEM Name: mkfs.fat
+Serial Number: 25192549
+FS Type String: FAT12
+Media Type: 0xf8
+Bytes per Sector: 512
+Sectors per Cluster: 4
+Cluster Size: 2048 bytes
+Reserved Sectors: 1
+Number of FATs: 2
+Sectors per FAT: 1
+FAT Size: 512 bytes
+Root Directory Entries: 512
+Root Directory Sectors: 32
+Total Sectors: 1024
+Data Sectors: 989
+Total Clusters: 247
+First Data Sector: 35
+Total Size: 524288 bytes (0.50 MB)
+EOF
+RUN
+
+NAME=mn iso9660 details
+FILE=bins/fs/iso.img
+CMDS=<<EOF
+m /mnt iso9660 @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: ISO9660
+Volume ID: CDROM
+System ID: Mac OS X
+Application: MKISOFS ISO9660/HFS/UDF FILESYSTEM BUILDER & CDRECORD CD/DVD/BluRay CREATOR (C) 1993 E.YOUNGDALE (C) 1997 J.PEARSON/J.SCHILLING
+Creation Date: 2017-11-06 23:38:57.93
+Logical Block Size: 2048 bytes
+Volume Space Size: 526 blocks
+Total Size: 1077248 bytes (1.03 MB)
+Path Table Size: 10 bytes
+Volume Set Size: 1
+Volume Sequence Number: 1
+File Structure Version: 1
+EOF
+RUN
+
+NAME=mn hfs details
+FILE=bins/fs/hfs.img
+CMDS=<<EOF
+m /mnt hfs @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: HFS
+Volume Name: Untitled
+Create Date: 2017-11-06 09:32:06 (HFS timestamp: 3592805526)
+Modify Date: 2017-11-06 17:34:43 (HFS timestamp: 3592834483)
+Block Size: 512 bytes
+Total Blocks: 2042
+Free Blocks: 1724
+Total Size: 1045504 bytes (1.00 MB)
+Used Size: 162816 bytes (0.16 MB)
+Free Size: 882688 bytes (0.84 MB)
+File Count: 3
+Directory Count: 2
+Allocation Clump Size: 2048 bytes
+Catalog Clump Size: 7680 bytes
+Extents Clump Size: 7680 bytes
+EOF
+RUN
+
+NAME=mn ntfs details
+FILE=bins/fs/ntfs.img
+CMDS=<<EOF
+m /mnt ntfs @ 0
+mn
+EOF
+EXPECT=<<EOF
+Filesystem Type: NTFS
+OEM ID: NTFS
+Volume Label: MIKI_FS_TEST
+Volume Serial Number: 05021d2f1a141f34
+Volume Creation Time: 2025-10-04 02:35:28
+Volume Modification Time: 2025-10-04 02:35:28
+Bytes per Sector: 512
+Sectors per Cluster: 8
+Cluster Size: 4096 bytes
+Total Sectors: 4095
+Total Size: 2096640 bytes (2.00 MB)
+MFT Cluster: 4
+MFT Offset: 0x4000
+MFT Mirror Cluster: 255
+MFT Record Size: 1024 bytes
+Index Block Size: 4096 bytes
+Media Descriptor: 0xf8
+EOF
+RUN


### PR DESCRIPTION
Add RFSPlugin.details callback and mn (Mountpoint iNformation) command to show filesystem metadata.

It prints information like volume labels, UUIDs, timestamps, disk geometry (block/sector sizes), space usage, and filesystem-specific details by parsing boot sectors, superblocks, and metadata structures from ext2/3/4, FAT, NTFS, ISO9660, HFS, and UBIFS filesystems.

The rest of the filesystems can be easily updated to this feature just by adding a `.details` function. If that pointer is not available the command will just fail safely and warn the user.

I think it's crucial when analyzing images to get access to this kind of metadata.

There is some tricky-magic to convert between different timestamp formats. And some quick-and-dirty volume name cleanup to show only printable characters (i.e: NTFS uses UTF-16LE)

Core changes:
- Add `details` function pointer to RFSPlugin
- Implement `mn` command for Mountpoint iNformation.
- Add optional FSDETAILS macro in fs_grub_base.inc.c for a generic solution.

I added all the metadata structures for this file systems (also provided proper images for each format on `radare2-testbins`):

**ext2/3/4**: Detect type via feature_incompat flags (RECOVER=ext3, EXTENTS=ext4). Display volume name, UUID, mount/write/check timestamps, block/inode counts and sizes, feature flags, filesystem state, creator OS. All types are mounted using `m ext2...`.

**FAT12/16/32**: Parse BPB structure. Detect type by cluster count. Read label/serial/fstype directly from file offsets. Display volume label, OEM name, serial number, sector/cluster geometry, FAT size, root directory info.

**NTFS**: Parse BPB and validate OEM ID. Read MFT entry 3 ($Volume) for volume label and timestamps. Convert FILETIME (100ns intervals since 1601-01-01) to Unix time. Parse $STANDARD_INFORMATION and $VOLUME_NAME attributes. Display cluster/sector geometry, MFT location, record sizes.

**ISO9660**: Parse Primary Volume Descriptor. Display volume/system/application IDs with creation date including centiseconds precision.

**HFS**: Parse Master Directory Block at offset 1024 (signature 0x4244). Convert timestamps from Mac epoch (1904-01-01) to Unix time. Display volume name, create/modify dates with raw HFS timestamps, block counts, file/directory counts, clump sizes.

**UBIFS**: Display LEB/PEB sizes, min I/O unit, LEB counts, compression type.

Add test/db/cmd/cmd_mn with tests for ext2, ext3, ext4, FAT12, ISO9660, HFS, NTFS.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Examples:
## Examples

### ext4 filesystem
```
[0x00000000]> m /mnt ext2 @ 0
[0x00000000]> mn
Filesystem Type: ext4
Volume Name: MIKI_FS_TEST
UUID: 6ae0a5d0-f36d-4361-985c-adf92365736f
Last Mounted: /tmp/ext4_mount
Last Mount Time: 2025-10-04 03:43:41
Last Write Time: 2025-10-04 03:43:41
Last Check Time: 2025-10-04 03:29:32
Block Size: 1024 bytes
Total Blocks: 2048
Free Blocks: 909
Reserved Blocks: 102
Total Size: 2097152 bytes (2.00 MB)
Used Size: 1166336 bytes (1.11 MB)
Free Size: 930816 bytes (0.89 MB)
Reserved Size: 104448 bytes (0.10 MB)
Inodes Count: 256
Free Inodes: 220
Inodes per Group: 256
Blocks per Group: 8192
Inode Size: 256 bytes
Filesystem State: cleanly unmounted
Mount Count: 2
Max Mount Count: -1
Creator OS: Linux
Revision Level: 1
Compatible Features: HAS_JOURNAL EXT_ATTR RESIZE_INODE DIR_INDEX
Incompatible Features: FILETYPE RECOVER EXTENTS FLEX_BG
Read-Only Compatible Features: SPARSE_SUPER LARGE_FILE HUGE_FILE DIR_NLINK EXTRA_ISIZE
```

### ext3 filesystem
```
[0x00000000]> m /mnt ext2 @ 0
[0x00000000]> mn
Filesystem Type: ext2
Volume Name: MIKI_FS_TEST
UUID: f0640c63-5163-4e94-91e5-2cd257b82419
Last Mounted: /tmp/ext3_mount
Last Mount Time: 2025-10-04 03:11:58
Last Write Time: 2025-10-04 03:17:01
Last Check Time: 2025-10-04 03:09:29
Block Size: 1024 bytes
Total Blocks: 2048
Free Blocks: 904
Reserved Blocks: 102
Total Size: 2097152 bytes (2.00 MB)
Used Size: 1171456 bytes (1.12 MB)
Free Size: 925696 bytes (0.88 MB)
Reserved Size: 104448 bytes (0.10 MB)
Inodes Count: 256
Free Inodes: 220
Inodes per Group: 256
Blocks per Group: 8192
Inode Size: 256 bytes
Filesystem State: cleanly unmounted
Mount Count: 2
Max Mount Count: -1
Creator OS: Linux
Revision Level: 1
Compatible Features: HAS_JOURNAL EXT_ATTR RESIZE_INODE DIR_INDEX
Incompatible Features: FILETYPE
Read-Only Compatible Features: SPARSE_SUPER LARGE_FILE
```

### FAT12 filesystem
```
[0x00000000]> m /mnt fat @ 0
[0x00000000]> mn
Filesystem Type: FAT12
Volume Label: NO NAME
OEM Name: mkfs.fat
Serial Number: 25192549
FS Type String: FAT12
Media Type: 0xf8
Bytes per Sector: 512
Sectors per Cluster: 4
Cluster Size: 2048 bytes
Reserved Sectors: 1
Number of FATs: 2
Sectors per FAT: 1
FAT Size: 512 bytes
Root Directory Entries: 512
Root Directory Sectors: 32
Total Sectors: 1024
Data Sectors: 989
Total Clusters: 247
First Data Sector: 35
Total Size: 524288 bytes (0.50 MB)
```

### NTFS filesystem
```
[0x00000000]> m /mnt ntfs @ 0
[0x00000000]> mn
Filesystem Type: NTFS
OEM ID: NTFS
Volume Label: MIKI_FS_TEST
Volume Serial Number: 05021d2f1a141f34
Volume Creation Time: 2025-10-04 02:35:28
Volume Modification Time: 2025-10-04 02:35:28
Bytes per Sector: 512
Sectors per Cluster: 8
Cluster Size: 4096 bytes
Total Sectors: 4095
Total Size: 2096640 bytes (2.00 MB)
MFT Cluster: 4
MFT Offset: 0x4000
MFT Mirror Cluster: 255
MFT Record Size: 1024 bytes
Index Block Size: 4096 bytes
Media Descriptor: 0xf8
```

### ISO9660 filesystem
```
[0x00000000]> m /mnt iso9660 @ 0
[0x00000000]> mn
Filesystem Type: ISO9660
Volume ID: CDROM
System ID: Mac OS X
Application: MKISOFS ISO9660/HFS/UDF FILESYSTEM BUILDER & CDRECORD CD/DVD/BluRay CREATOR (C) 1993 E.YOUNGDALE (C) 1997 J.PEARSON/J.SCHILLING
Creation Date: 2017-11-06 23:38:57.93
Logical Block Size: 2048 bytes
Volume Space Size: 526 blocks
Total Size: 1077248 bytes (1.03 MB)
Path Table Size: 10 bytes
Volume Set Size: 1
Volume Sequence Number: 1
File Structure Version: 1
```

### HFS filesystem
```
[0x00000000]> m /mnt hfs @ 0
[0x00000000]> mn
Filesystem Type: HFS
Volume Name: Untitled
Create Date: 2017-11-06 09:32:06 (HFS timestamp: 3592805526)
Modify Date: 2017-11-06 17:34:43 (HFS timestamp: 3592834483)
Block Size: 512 bytes
Total Blocks: 2042
Free Blocks: 1724
Total Size: 1045504 bytes (1.00 MB)
Used Size: 162816 bytes (0.16 MB)
Free Size: 882688 bytes (0.84 MB)
File Count: 3
Directory Count: 2
Allocation Clump Size: 2048 bytes
Catalog Clump Size: 7680 bytes
Extents Clump Size: 7680 bytes
```