### PR TITLE
Add rafs2 - radare2 filesystem tool ##fs

### DIFF
--- a/binr/Makefile
+++ b/binr/Makefile
@@ -6,7 +6,7 @@ BTOP=$(shell pwd)
 
 .PHONY: all clean install install-symlink deinstall uninstall mrproper preload
 
-BINS=r2r r2pm ravc2 rax2 rasm2 rabin2 rahash2 radiff2 rapatch2 radare2 rafind2 rarun2 ragg2 r2agent rasign2
+BINS=r2r r2pm ravc2 rax2 rasm2 rabin2 rahash2 radiff2 rapatch2 radare2 rafind2 rarun2 ragg2 r2agent rasign2 rafs2
 
 LIBR2=$(call libname-version,libr2.$(EXT_SO),${LIBVERSION})
 

--- a/binr/rafs2/Makefile
+++ b/binr/rafs2/Makefile
@@ -1,0 +1,9 @@
+BIN=rafs2
+
+BINDEPS=r_fs r_io r_cons r_util r_main
+
+include ../rules.mk
+
+include ../../libr/main/deps.mk
+
+LDFLAGS+=$(LINK)

--- a/binr/rafs2/rafs2.c
+++ b/binr/rafs2/rafs2.c
@@ -1,0 +1,7 @@
+/* radare - LGPL - Copyright 2025 - MiKi (mikelloc) */
+
+#include <r_main.h>
+
+int main(int argc, const char **argv) {
+	return r_main_rafs2 (argc, argv);
+}

--- a/libr/include/r_main.h
+++ b/libr/include/r_main.h
@@ -40,6 +40,7 @@ R_API int r_main_ragg2(int argc, const char **argv);
 R_API int r_main_rasign2(int argc, const char **argv);
 R_API int r_main_r2pm(int argc, const char **argv);
 R_API int r_main_rapatch2(int argc, const char **argv);
+R_API int r_main_rafs2(int argc, const char **argv);
 
 #ifdef __cplusplus
 }

--- a/libr/main/Makefile
+++ b/libr/main/Makefile
@@ -19,6 +19,7 @@ OBJS+=radiff2.o
 OBJS+=rapatch2.o
 OBJS+=radare2.o
 OBJS+=rahash2.o
+OBJS+=rafs2.o
 
 # See MAIN_LINK_ALL
 include deps.mk

--- a/libr/main/rafs2.c
+++ b/libr/main/rafs2.c
@@ -1,0 +1,320 @@
+/* radare - LGPL - Copyright 2025 - MiKi (mikelloc) */
+
+#define R_LOG_ORIGIN "rafs2"
+
+#include <r_main.h>
+#include <r_fs.h>
+#include <r_io.h>
+#include <r_cons.h>
+
+typedef struct {
+	RFS *fs;
+	RIO *io;
+	const char *fstype;
+	const char *file;
+	const char *mountpoint;
+	ut64 offset;
+	bool interactive;
+} Rafs2Options;
+
+static void rafs2_options_init(Rafs2Options *opt) {
+	memset(opt, 0, sizeof (Rafs2Options));
+	opt->mountpoint = "/";
+	opt->offset = 0;
+	opt->interactive = false;
+}
+
+static void rafs2_options_fini(Rafs2Options *opt) {
+	if (opt) {
+		r_fs_free(opt->fs);
+		r_io_free(opt->io);
+	}
+}
+
+static void show_usage(void) {
+	printf("Usage: rafs2 [options] -t <fstype> <file>\n"
+	       "Options:\n"
+	       "  -t <type>    Filesystem type (ext2, fat, ntfs, iso9660, hfs, ubifs, etc.)\n"
+	       "  -o <offset>  Offset to mount filesystem (default: 0)\n"
+	       "  -m <path>    Mount point path (default: /)\n"
+	       "  -i           Interactive mode (shell)\n"
+	       "  -l <path>    List directory contents\n"
+	       "  -c <file>    Cat file contents\n"
+	       "  -x <src:dst> Extract file from image to host\n"
+	       "  -n           Show filesystem details (like 'mn' command)\n"
+	       "  -L           List available filesystem types\n"
+	       "  -h           Show this help\n"
+	       "  -v           Show version\n"
+	       "\n"
+	       "Examples:\n"
+	       "  rafs2 -L\n"
+	       "  rafs2 -t ext2 -l / image.img\n"
+	       "  rafs2 -t fat -o 0x1000 -c /boot/config.txt disk.img\n"
+	       "  rafs2 -t ntfs -n filesystem.img\n"
+	       "  rafs2 -t iso9660 -i cdrom.iso\n"
+	       "  rafs2 -t ext2 -x /etc/passwd:passwd.txt image.img\n");
+}
+
+static int rafs2_list_plugins(void) {
+	RFS *fs = r_fs_new();
+	if (!fs) {
+		R_LOG_ERROR("Cannot create FS instance");
+		return 1;
+	}
+
+	printf("Available filesystem types:\n");
+	RListIter *iter;
+	RFSPlugin *plugin;
+	r_list_foreach (fs->plugins, iter, plugin) {
+		if (plugin->meta.name) {
+			const char *desc = plugin->meta.desc ? plugin->meta.desc : "";
+			printf("  %-12s %s\n", plugin->meta.name, desc);
+		}
+	}
+
+	r_fs_free(fs);
+	return 0;
+}
+
+static int rafs2_list(Rafs2Options *opt, const char *path) {
+	RList *list = r_fs_dir(opt->fs, path);
+	if (!list) {
+		R_LOG_ERROR("Cannot list directory: %s", path);
+		return 1;
+	}
+
+	RListIter *iter;
+	RFSFile *file;
+	r_list_foreach (list, iter, file) {
+		char type = file->type;
+		printf("%c %10u  %s\n", type, file->size, file->name);
+	}
+	r_list_free(list);
+	return 0;
+}
+
+static int rafs2_cat(Rafs2Options *opt, const char *path) {
+	RFSFile *file = r_fs_open(opt->fs, path, false);
+	if (!file) {
+		R_LOG_ERROR("Cannot open file: %s", path);
+		return 1;
+	}
+
+	if (file->size > 0) {
+		int len = r_fs_read(opt->fs, file, 0, file->size);
+		if (len > 0 && file->data) {
+			fwrite(file->data, 1, len, stdout);
+		}
+	}
+
+	r_fs_close(opt->fs, file);
+	return 0;
+}
+
+static int rafs2_details(Rafs2Options *opt) {
+	RList *roots = r_fs_root(opt->fs, opt->mountpoint);
+	if (!roots || r_list_empty(roots)) {
+		R_LOG_ERROR("No mounted filesystem found at %s", opt->mountpoint);
+		return 1;
+	}
+
+	RFSRoot *root = (RFSRoot *)r_list_get_n(roots, 0);
+	if (!root || !root->p || !root->p->details) {
+		R_LOG_ERROR("This filesystem doesn't support details");
+		return 1;
+	}
+
+	RStrBuf *sb = r_strbuf_new("");
+	root->p->details(root, sb);
+	printf("%s", r_strbuf_get(sb));
+	r_strbuf_free(sb);
+	return 0;
+}
+
+static int rafs2_extract(Rafs2Options *opt, const char *paths) {
+	char *colon = strchr(paths, ':');
+	if (!colon) {
+		R_LOG_ERROR("Invalid extract syntax. Use: -x <src:dst>");
+		return 1;
+	}
+
+	char *src = r_str_ndup(paths, colon - paths);
+	const char *dst = colon + 1;
+
+	if (!src || !*src || !*dst) {
+		R_LOG_ERROR("Invalid source or destination path");
+		free (src);
+		return 1;
+	}
+
+	RFSFile *file = r_fs_open(opt->fs, src, false);
+	if (!file) {
+		R_LOG_ERROR("Cannot open file in image: %s", src);
+		free (src);
+		return 1;
+	}
+
+	if (file->size > 0) {
+		int len = r_fs_read(opt->fs, file, 0, file->size);
+		if (len > 0 && file->data) {
+			FILE *fp = fopen(dst, "wb");
+			if (!fp) {
+				R_LOG_ERROR("Cannot create output file: %s", dst);
+				r_fs_close(opt->fs, file);
+				free (src);
+				return 1;
+			}
+			fwrite(file->data, 1, len, fp);
+			fclose(fp);
+			printf("Extracted %s -> %s (%d bytes)\n", src, dst, len);
+		} else {
+			R_LOG_ERROR("Failed to read file: %s", src);
+			r_fs_close(opt->fs, file);
+			free (src);
+			return 1;
+		}
+	} else {
+		printf("Extracted %s -> %s (0 bytes)\n", src, dst);
+		FILE *fp = fopen(dst, "wb");
+		if (fp) {
+			fclose(fp);
+		}
+	}
+
+	r_fs_close(opt->fs, file);
+	free (src);
+	return 0;
+}
+
+static int rafs2_shell(Rafs2Options *opt) {
+	RFSShell *shell = r_fs_shell_new();
+	if (!shell) {
+		R_LOG_ERROR("Cannot create filesystem shell");
+		return 1;
+	}
+
+	shell->cwd = strdup(opt->mountpoint);
+	shell->cons = r_cons_singleton();
+
+	bool ret = r_fs_shell(shell, opt->fs, opt->mountpoint);
+	r_fs_shell_free(shell);
+
+	return ret ? 0 : 1;
+}
+
+R_API int r_main_rafs2(int argc, const char **argv) {
+	Rafs2Options opt;
+	int c;
+	const char *list_path = NULL;
+	const char *cat_path = NULL;
+	const char *extract_path = NULL;
+	bool show_details = false;
+
+	rafs2_options_init(&opt);
+
+	RGetopt go;
+	r_getopt_init(&go, argc, argv, "t:o:m:il:c:x:nLhv");
+	while ((c = r_getopt_next(&go)) != -1) {
+		switch (c) {
+		case 't':
+			opt.fstype = go.arg;
+			break;
+		case 'o':
+			opt.offset = r_num_math(NULL, go.arg);
+			break;
+		case 'm':
+			opt.mountpoint = go.arg;
+			break;
+		case 'i':
+			opt.interactive = true;
+			break;
+		case 'l':
+			list_path = go.arg;
+			break;
+		case 'c':
+			cat_path = go.arg;
+			break;
+		case 'x':
+			extract_path = go.arg;
+			break;
+		case 'n':
+			show_details = true;
+			break;
+		case 'L':
+			return rafs2_list_plugins();
+		case 'v':
+			return r_main_version_print("rafs2", 0);
+		case 'h':
+		default:
+			show_usage();
+			return c == 'h' ? 0 : 1;
+		}
+	}
+
+	if (go.ind >= argc) {
+		R_LOG_ERROR("No file specified");
+		show_usage();
+		return 1;
+	}
+
+	if (!opt.fstype) {
+		R_LOG_ERROR("Filesystem type not specified (use -t)");
+		show_usage();
+		return 1;
+	}
+
+	opt.file = argv[go.ind];
+
+	opt.io = r_io_new();
+	if (!opt.io) {
+		R_LOG_ERROR("Cannot create IO instance");
+		return 1;
+	}
+
+	RIODesc *desc = r_io_open(opt.io, opt.file, R_PERM_R, 0);
+	if (!desc) {
+		R_LOG_ERROR("Cannot open file: %s", opt.file);
+		rafs2_options_fini(&opt);
+		return 1;
+	}
+
+	opt.fs = r_fs_new();
+	if (!opt.fs) {
+		R_LOG_ERROR("Cannot create FS instance");
+		rafs2_options_fini(&opt);
+		return 1;
+	}
+
+	r_fs_view(opt.fs, R_FS_VIEW_NORMAL);
+	opt.fs->iob.io = opt.io;
+	opt.fs->iob.read_at = (void *)r_io_read_at;
+	opt.fs->iob.write_at = (void *)r_io_write_at;
+
+	RFSRoot *root = r_fs_mount(opt.fs, opt.fstype, opt.mountpoint, opt.offset);
+	if (!root) {
+		R_LOG_ERROR("Cannot mount %s filesystem at offset 0x%" PFMT64x, opt.fstype, opt.offset);
+		rafs2_options_fini(&opt);
+		return 1;
+	}
+
+	int ret = 0;
+
+	if (show_details) {
+		ret = rafs2_details(&opt);
+	} else if (list_path) {
+		ret = rafs2_list(&opt, list_path);
+	} else if (cat_path) {
+		ret = rafs2_cat(&opt, cat_path);
+	} else if (extract_path) {
+		ret = rafs2_extract(&opt, extract_path);
+	} else if (opt.interactive) {
+		ret = rafs2_shell(&opt);
+	} else {
+		R_LOG_ERROR("No action specified (use -l, -c, -x, -n, or -i)");
+		show_usage();
+		ret = 1;
+	}
+
+	rafs2_options_fini(&opt);
+	return ret;
+}

--- a/test/db/tools/rafs2
+++ b/test/db/tools/rafs2
@@ -1,0 +1,135 @@
+NAME=rafs2 -l list FAT root directory
+FILE=--
+CMDS=!rafs2 -t fat -l / bins/fs/fat.img 2>/dev/null
+EXPECT=<<EOF
+d          0  etc
+d          0  bin
+f          0  README.md
+EOF
+RUN
+
+NAME=rafs2 -l list ext2 root directory
+FILE=--
+CMDS=!rafs2 -t ext2 -l / bins/fs/ext2.img 2>/dev/null
+EXPECT=<<EOF
+d          0  .
+d          0  ..
+d          0  lost+found
+d          0  bin
+d          0  etc
+f          0  README.md
+EOF
+RUN
+
+NAME=rafs2 -l list ntfs root directory
+FILE=--
+CMDS=!rafs2 -t ntfs -l / bins/fs/ntfs.img 2>/dev/null | grep folder
+EXPECT=<<EOF
+d          0  folder1
+d          0  folder2
+d          0  folder3
+EOF
+RUN
+
+NAME=rafs2 -c cat file from ext2
+FILE=--
+CMDS=!rafs2 -t ext2 -c /README.md bins/fs/ext2.img 2>/dev/null
+EXPECT=<<EOF
+This is an EXT2 partition
+EOF
+RUN
+
+NAME=rafs2 -c cat file from FAT
+FILE=--
+CMDS=!rafs2 -t fat -c /README.md bins/fs/fat.img 2>/dev/null
+EXPECT=<<EOF
+This is a FAT partition
+EOF
+RUN
+
+NAME=rafs2 -x extract file from ext2
+FILE=--
+CMDS=!rafs2 -t ext2 -x /README.md:/tmp/rafs2_test_ext2.txt bins/fs/ext2.img 2>/dev/null
+EXPECT=<<EOF
+Extracted /README.md -> /tmp/rafs2_test_ext2.txt (26 bytes)
+EOF
+RUN
+
+NAME=rafs2 -x extract file from FAT
+FILE=--
+CMDS=!rafs2 -t fat -x /README.md:/tmp/rafs2_test_fat.txt bins/fs/fat.img 2>/dev/null
+EXPECT=<<EOF
+Extracted /README.md -> /tmp/rafs2_test_fat.txt (24 bytes)
+EOF
+RUN
+
+NAME=rafs2 -n FAT filesystem details
+FILE=--
+CMDS=!rafs2 -t fat -n bins/fs/fat.img 2>/dev/null | head -5
+EXPECT=<<EOF
+Filesystem Type: FAT12
+Volume Label: NO NAME
+OEM Name: mkfs.fat
+Serial Number: 25192549
+FS Type String: FAT12
+EOF
+RUN
+
+NAME=rafs2 -n ext2 filesystem details
+FILE=--
+CMDS=!rafs2 -t ext2 -n bins/fs/ext2.img 2>/dev/null | head -3
+EXPECT=<<EOF
+Filesystem Type: ext2
+UUID: 201f53c3-fc0f-4d0c-ae45-aa999efcfe7f
+Last Mounted: /mnt
+EOF
+RUN
+
+NAME=rafs2 -n ISO9660 filesystem details
+FILE=--
+CMDS=!rafs2 -t iso9660 -n bins/fs/iso.img 2>/dev/null | head -3
+EXPECT=<<EOF
+Filesystem Type: ISO9660
+Volume ID: CDROM
+System ID: Mac OS X
+EOF
+RUN
+
+NAME=rafs2 -n NTFS filesystem details
+FILE=--
+CMDS=!rafs2 -t ntfs -n bins/fs/ntfs.img 2>/dev/null | head -3
+EXPECT=<<EOF
+Filesystem Type: NTFS
+OEM ID: NTFS
+Volume Label: MIKI_FS_TEST
+EOF
+RUN
+
+NAME=rafs2 with offset
+FILE=--
+CMDS=!rafs2 -t ext2 -o 0 -l / bins/fs/ext2.img 2>/dev/null | head -3
+EXPECT=<<EOF
+d          0  .
+d          0  ..
+d          0  lost+found
+EOF
+RUN
+
+NAME=rafs2 help output
+FILE=--
+CMDS=!rafs2 -h | head -1
+EXPECT=<<EOF
+Usage: rafs2 [options] -t <fstype> <file>
+EOF
+RUN
+
+NAME=rafs2 -L list filesystem types
+FILE=--
+CMDS=!rafs2 -L | grep -E "(ext2|fat|ntfs|iso9660)"
+EXPECT=<<EOF
+  ext2         ext2 filesystem
+  fat          FAT filesystem
+  iso9660      ISO9660 filesystem
+  ntfs         NTFS filesystem
+EOF
+RUN


### PR DESCRIPTION
Introducing `rafs2`, a new command-line tool for working with filesystem images using radare2's filesystem plugins. Similar to GNU mtools but leveraging all radare2 filesystem support (ext2/3/4, FAT, NTFS, ISO9660, HFS, UBIFS, and more).

The tool makes use radare2's existing filesystem infrastructure and provides a standalone alternative to mounting images or using filesystem-specific tools.

Tests:
Added 14  tests covering all major operations across multiple filesystem types (ext2, FAT, NTFS, ISO9660)

```
rafs2 -h
Usage: rafs2 [options] -t <fstype> <file>
Options:
  -t <type>    Filesystem type (ext2, fat, ntfs, iso9660, hfs, ubifs, etc.)
  -o <offset>  Offset to mount filesystem (default: 0)
  -m <path>    Mount point path (default: /)
  -i           Interactive mode (shell)
  -l <path>    List directory contents
  -c <file>    Cat file contents
  -x <src:dst> Extract file from image to host
  -n           Show filesystem details (like 'mn' command)
  -L           List available filesystem types
  -h           Show this help
  -v           Show version

Examples:
  rafs2 -L
  rafs2 -t ext2 -l / image.img
  rafs2 -t fat -o 0x1000 -c /boot/config.txt disk.img
  rafs2 -t ntfs -n filesystem.img
  rafs2 -t iso9660 -i cdrom.iso
  rafs2 -t ext2 -x /etc/passwd:passwd.txt image.img
```

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)