### PR TITLE
Fixing ext3 detection while detecting filesystem details

### DIFF
--- a/libr/fs/p/fs_ext2.c
+++ b/libr/fs/p/fs_ext2.c
@@ -74,9 +74,11 @@ static void details_ext2(RFSRoot *root, RStrBuf *sb) {
 		return;
 	}
 
+	ut32 feature_compat = r_read_le32 ((ut8 *)&super.s_feature_compat);
 	ut32 feature_incompat = r_read_le32 ((ut8 *)&super.s_feature_incompat);
+
 	const char *fs_type = "ext2";
-	if (feature_incompat & 0x0004) { // EXT3_FEATURE_INCOMPAT_RECOVER
+	if (feature_compat & 0x0004) { // EXT3_FEATURE_COMPAT_HAS_JOURNAL
 		fs_type = "ext3";
 	}
 	if (feature_incompat & 0x0040) { // EXT4_FEATURE_INCOMPAT_EXTENTS
@@ -99,7 +101,6 @@ static void details_ext2(RFSRoot *root, RStrBuf *sb) {
 	ut16 state = r_read_le16 ((ut8 *)&super.s_state);
 	ut32 rev_level = r_read_le32 ((ut8 *)&super.s_rev_level);
 	ut32 creator_os = r_read_le32 ((ut8 *)&super.s_creator_os);
-	ut32 feature_compat = r_read_le32 ((ut8 *)&super.s_feature_compat);
 	ut32 feature_ro_compat = r_read_le32 ((ut8 *)&super.s_feature_ro_compat);
 
 	ut32 block_size = 1024 << log_block_size;

--- a/test/db/cmd/cmd_mn
+++ b/test/db/cmd/cmd_mn
@@ -42,7 +42,7 @@ m /mnt ext2 @ 0
 mn
 EOF
 EXPECT=<<EOF
-Filesystem Type: ext2
+Filesystem Type: ext3
 Volume Name: MIKI_FS_TEST
 UUID: f0640c63-5163-4e94-91e5-2cd257b82419
 Last Mounted: /tmp/ext3_mount


### PR DESCRIPTION
In the Extended File Systems, the version is not stored in a dedicated single "version" field that says "This is ext2/ext3/ext4." Instead, the version is implied through a combination of feature flags stored in the superblock.

I made a mistake while checking if the filesystem has journal, the main difference between ext2 and ext3.

- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)