### PR TITLE
help: show core plugins in root ‘?’ dynamically; remove ‘Lc’ entry

### DIFF
--- a/libr/core/cmd_help.inc.c
+++ b/libr/core/cmd_help.inc.c
@@ -226,6 +226,7 @@ static RCoreHelpMessage help_msg_root = {
 	"k", "[?] [query]", "evaluate an sdb query",
 	"l", "[?] [filepattern]", "list files and directories",
 	"L", "[?] [-] [plugin]", "list, unload load r2 plugins",
+	"Lc", "[j]", "list core plugins",
 	"m", "[?]", "mount filesystems and inspect its contents",
 	"o", "[?] [file] ([addr])", "open file at optional address",
 	"p", "[?] [len]", "print current block with format and length",


### PR DESCRIPTION
## Summary
This PR updates the root ? help in Radare2 to include a dynamic “Core plugins” section and removes the Lc entry. Users can now discover core plugin commands directly from the main help without relying on Lc.

## Changes:
- Modified libr/core/cmd_help.inc.c : 
    - Removed Lc line from help_msg_root.
    - In cmd_help() for root ?, added a dynamic help block built from core->rcmd->plist :
        - Header: “Core plugins:”
        - Per plugin: <name> [ ? ] <desc>   

## Rationale:
- Listing core plugins directly in root help improves discoverability and keeps help consistent with the loaded plugin set.
- Avoids duplicating a static Lc entry when the plugin list is readily available programmatically.

## Testing:
- Build: ./configure && make -j
- Lint: sys/lint.sh

## Impact:
- Help output improvement only; no behavioral changes to command execution.
- Deprecates the Lc row in root ? in favor of the inline dynamic list.

Resolves #23724