### PR TITLE
Fix the bug in r_str_wrap taking sometimes one less char ##util

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3339,14 +3339,12 @@ R_API char *r_str_wrap(const char *str, int w) {
 			*r++ = *str++;
 			cw = 0;
 		} else {
-			if (cw > w) {
+			if (cw >= w) {
 				*r++ = '\n';
-				*r++ = *str++;
-				cw = 1;
-			} else {
-				*r++ = *str++;
-				cw++;
+				cw = 0;
 			}
+			*r++ = *str++;
+			cw++;
 		}
 	}
 	*r = 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
