### PR TITLE
Miknight Commander improvements (mouse support et al) ##fs

### DIFF
--- a/libr/core/cmd_mmc.inc.c
+++ b/libr/core/cmd_mmc.inc.c
@@ -1707,6 +1707,9 @@ static bool mmc_handle_mouse_click(RCore *core, MMCState *state, int click_x, in
 	if (click_x < panel_w) {
 		clicked_panel = &state->left;
 	} else if (click_x < state->width) {
+		if (state->interactive_preview) {
+			return false;
+		}
 		clicked_panel = &state->right;
 	} else {
 		return false;


### PR DESCRIPTION
Several improvements on Miknight Commander:

- Introduced mouse support: click any file on any of both panels and you can use the commands (info, view, seek, copy, delete...)
- Change shortcut to switch between radare theme and MC theme using `R` for consistency
- Refactor color switching code to cache it in a struct instead of recalculating the proper color on every use
- Interactive preview mode: using `I`, on the right panel we can see the content of the file in hexadecimal or text. The panel will update as we're selecting a new file on the left panel
- Panel resizing: using z/Z we can now resize the panels changing the share in the width of the screen from the default 50-50%
- Responsive content on resizing terminal (with `r` refresh or using any other shortcut)

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)