### PR TITLE
Fix #24680 - Increase the timeout to 1s in socket_slurp to avoid read timeout when download a PDB

### DIFF
--- a/libr/socket/socket_http.c
+++ b/libr/socket/socket_http.c
@@ -15,7 +15,7 @@ static size_t socket_slurp(RSocket *s, RBuffer *buf) {
 	if (r_socket_ready (s, 1, 0) != 1) {
 		return 0;
 	}
-	r_socket_block_time (s, true, 0, 1000);
+	r_socket_block_time (s, true, 1, 0);
 	for (i = 0; i < SOCKET_HTTP_MAX_HEADER_LENGTH; i += 1) {
 		ut8 c;
 		int olen = r_socket_read_block (s, &c, 1);


### PR DESCRIPTION
**Description**

This timeout wasn't reset to something else after the execution, everywhere else the timeout is set to 1s. If we don't reset it, it causes issues latter when reading the content of the PDB file as it could be longer than this initial timeout of 1000 microseconds.