### PR TITLE
gitignore: Add .personal_files/ for local testing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,8 @@ crash-*
 corpus*
 libr/anal/d/types-windows.sdb.txt
 libr/bin/d/dll/*.c
+
+# Personal testing and debug files
+.personal_files/
+*:Zone.Identifier
+test/db/cmd/cmd_rop.backup


### PR DESCRIPTION
Added .personal_files/ directory to .gitignore to keep local testing and debug files separate from the repository.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
