### PR TITLE
Fix p8fm mask size mismatch for instructions longer than 8 bytes #24712

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -9561,7 +9561,7 @@ static void cmd_anal_opcode_bits(RCore *core, const char *arg, int mode) {
 	r_anal_op_init (&analop);
 	r_anal_op_set_bytes (&analop, core->addr, buf, sizeof (ut64));
 	(void)r_anal_op (core->anal, &analop, core->addr, buf, sizeof (buf), R_ARCH_OP_MASK_DISASM);
-	int last = R_MIN (8, analop.size);
+	int last = R_MIN (sizeof (buf), analop.size);
 	PJ *pj = (mode == 'j')? r_core_pj_new (core): NULL;
 	if (last < 1) {
 		return;
@@ -9668,7 +9668,7 @@ static void cmd_anal_opcode_bits(RCore *core, const char *arg, int mode) {
 			int pi = 0;
 			char *s = r_strbuf_drain (sb);
 			char *p = s;
-			ut8 finalmask[8] = {0};
+			ut8 finalmask[32] = {0};
 			for (; *p; p++) {
 				int byte_index = (pi / 8);
 				int bit_index = (pi % 8);
@@ -9685,7 +9685,7 @@ static void cmd_anal_opcode_bits(RCore *core, const char *arg, int mode) {
 				}
 			}
 			free (s);
-			for (i = 0; i < 8 && i < last; i++) {
+			for (i = 0; i < last; i++) {
 				r_cons_printf (core->cons, "%02x", finalmask[i]);
 			}
 			r_cons_newline (core->cons);


### PR DESCRIPTION
Fixes #24712

The aobm command was capping instruction mask generation at 8 bytes, causing p8fm to produce masks shorter than the actual function bytes when functions contained instructions longer than 8 bytes.

Changes:
- Increase last from R_MIN(8, analop.size) to R_MIN(sizeof(buf), analop.size)
- Increase finalmask buffer from 8 to 32 bytes to match input buf size
- Remove redundant '&& i < last' check in final loop

Test case: VLC binary function at 0x1a60 previously showed 310 bytes but only 308 mask bytes. Now correctly shows 310:310 match.

