### PR TITLE
Add warning for instructions larger than 32 bytes in p8fm

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -9562,6 +9562,9 @@ static void cmd_anal_opcode_bits(RCore *core, const char *arg, int mode) {
 	r_anal_op_set_bytes (&analop, core->addr, buf, sizeof (ut64));
 	(void)r_anal_op (core->anal, &analop, core->addr, buf, sizeof (buf), R_ARCH_OP_MASK_DISASM);
 	int last = R_MIN (sizeof (buf), analop.size);
+	if (analop.size > sizeof (buf)) {
+		R_LOG_WARN ("Instruction size (%d bytes) exceeds buffer limit (%zu bytes), truncating", analop.size, sizeof (buf));
+	}
 	PJ *pj = (mode == 'j')? r_core_pj_new (core): NULL;
 	if (last < 1) {
 		return;


### PR DESCRIPTION
## Description

Follow-up to PR #24724 as requested by mentor @trufae.

Adds a warning when instruction size exceeds the 32-byte buffer limit in the `p8fm` command (`cmd_anal_opcode_bits`).

## Changes

- Add `R_LOG_WARN` when `analop.size > sizeof(buf)` (32 bytes)
- Warning message shows both instruction size and buffer limit
- Informs users when truncation occurs

## Why This Matters (My personal opinion)

While most architectures have instructions under 32 bytes, some can exceed this limit:
- x86/x86_64 with multiple prefixes
- Other architectures with variable-length encoding

The truncation already happens via `R_MIN(sizeof(buf), analop.size)`, but users weren't informed when data was being truncated.

## Testing

```sh
# Normal case - no warning
r2 -qc 'aaa; s <addr>; p8fm' <binary>

# Large instruction case - warning will appear
# (Rare - most instructions are < 32 bytes)