### PR TITLE
Make p8s an alias for pcs (escaped hex string) Fix #10058

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -56,7 +56,7 @@ static RCoreHelpMessage help_msg_p8 = {
 	"p8f", "[j]", "print hexpairs of function (linear)",
 	"p8fm", "[j]", "print linear function byte:mask pattern (zero-filled bbgaps)",
 	"p8j", "", "print hexpairs in JSON array",
-	"p8s", "", "space separated hex bytes",
+	"p8s", "", "print escaped string (alias for pcs)",
 	"p8x", "", "print hexpairs honoring hex.cols",
 	NULL
 };
@@ -9096,9 +9096,7 @@ static int cmd_print(void *data, const char *input) {
 			if (input[1] == 'j') { // "p8j"
 				r_core_cmdf (core, "pcj %s", input + 2);
 			} else if (input[1] == 's') { // "p8s"
-				r_core_block_read (core);
-				block = core->block;
-				r_print_bytes (core->print, block, l, "%02x", ' ');
+				r_core_cmdf (core, "pcs %s", input + 2);
 			} else if (input[1] == ',') { // "p8,"
 				r_core_block_read (core);
 				block = core->block;


### PR DESCRIPTION
The p8s command was printing space-separated hex bytes, which was not intuitive. Many users expect it to print escaped hex strings like pcs does (e.g., "\x68\x65\x6c\x6c\x6f").

Changes:
- Changed p8s to call pcs internally
- Updated help message to clarify p8s is now an alias for pcs
- Provides more intuitive behavior for creating escaped strings

Before:
  p8s 11  →  68 65 6c 6c 6f 20 77 6f 72 6c 64

After:
  p8s 11  →  "\x68\x65\x6c\x6c\x6f\x20\x77\x6f\x72\x6c\x64"

This makes p8s behave as users naturally expect when looking for escaped hex string output.

Fixes #10058

