### PR TITLE
Fix movaps assembly with xmmword size specifier (#19171)

### DIFF
--- a/libr/arch/p/x86_nasm/plugin.c
+++ b/libr/arch/p/x86_nasm/plugin.c
@@ -21,8 +21,12 @@ static bool encode(RArchSession *a, RAnalOp *op, RArchEncodeMask mask) {
 	}
 
 	const char *buf = op->mnemonic;
+	// Strip size specifiers that NASM doesn't support (xmmword, ymmword, zmmword)
+	char *clean_buf = r_str_replace (r_str_replace (r_str_replace (
+		strdup (buf), "xmmword ", "", 1), "ymmword ", "", 1), "zmmword ", "", 1);
 	char *asm_buf = r_str_newf ("[BITS %i]\nORG 0x%"PFMT64x"\n%s\n",
-		a->config->bits, op->addr, buf);
+		a->config->bits, op->addr, clean_buf);
+	free (clean_buf);
 	if (asm_buf) {
 		int slen = strlen (asm_buf);
 		int wlen = write (ifd, asm_buf, slen);

--- a/libr/arch/p/x86_nz/nzasm.c
+++ b/libr/arch/p/x86_nz/nzasm.c
@@ -5678,6 +5678,10 @@ static int parseOperand(RArchSession *a, const char *str, Operand *op, bool isre
 			op->type |= OT_MEMORY | OT_OWORD | OT_GPREG;
 			op->dest_size = OT_OWORD;
 			explicit_size = true;
+		} else if (!r_str_ncasecmp (str + pos, "xmmword", 7)) {
+			op->type |= OT_MEMORY | OT_OWORD | OT_XMMREG;
+			op->dest_size = OT_OWORD;
+			explicit_size = true;
 		} else if (!r_str_ncasecmp (str + pos, "tbyte", 5)) {
 			op->type |= OT_MEMORY | OT_TBYTE | OT_GPREG;
 			op->dest_size = OT_TBYTE;


### PR DESCRIPTION
## Problem
The `movaps` instruction (and other SSE/AVX instructions) could not be assembled when using Intel-style size specifiers like `xmmword`, `ymmword`, or `zmmword`.

Example error:
```bash
$ rasm2 -a x86.nasm "movaps xmmword [rax], xmm1"
# Failed to assemble
```
## My Findings:
NASM (the underlying assembler used by the x86.nasm plugin) doesn't support these size specifier keywords for SSE/AVX instructions. However, radare2's disassembler outputs instructions with these keywords, causing a mismatch.


This PR implements a minimal fix:

1. x86.nasm plugin: Strip `xmmword`, `ymmword`, and `zmmword `keywords before passing to NASM

      -   Uses existing `r_str_replace()` utility (no wheel reinvention)
      -   Handles SSE, AVX, and AVX-512 instruction families
      -   Backwards compatible - works with or without keywords

2. x86.nz parser (bonus): Add `xmmword `keyword recognition

      - Prepares the handmade assembler for future SSE support
      - Currently parses but doesn't encode (incremental improvement)

### Testing

```bash

# With size specifier (now works!)
$ rasm2 -a x86.nasm "movaps xmmword [rax], xmm1"
0f2908

# Without size specifier (still works)
$ rasm2 -a x86.nasm "movaps [rax], xmm1"
0f2908

# With memory offset
$ rasm2 -a x86.nasm "movaps xmmword [rax+0x10], xmm1"
0f294810

# AVX instruction (ymmword)
$ rasm2 -a x86.nasm "vmovaps ymmword [rcx], ymm0"
c5fc2901

# Disassembly works correctly
$ rasm2 -a x86 -d 0f2908
movaps xmmword [rax], xmm1

```

Closes #19171