### PR TITLE
Add unique coloring for immediate values #19003

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4569,6 +4569,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("scr.color.grep", "false", &cb_scr_color_grep, "enable colors when using ~grep");
 	SETB ("scr.color.pipe", "false", "enable colors when using pipes");
 	SETB ("scr.color.ops", "true", "colorize numbers and registers in opcodes");
+	SETB ("scr.color.ops.unique", "false", "use unique colors for each immediate value");
 	SETCB ("scr.color.ophex", "false", &cb_scr_color_ophex, "colorize in hexdump depending on opcode type (px)");
 	SETB ("scr.color.args", "true", "colorize arguments and variables of functions");
 	SETB ("scr.color.bytes", "true", "colorize bytes that represent the opcodes of the instruction");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -728,6 +728,7 @@ static RDisasmState *ds_init(RCore *core) {
 	ds->show_color_bytes = r_config_get_i (core->config, "scr.color.bytes");
 	ds->show_color_args = r_config_get_i (core->config, "scr.color.args");
 	ds->colorop = r_config_get_b (core->config, "scr.color.ops");
+	core->print->unique_colors = r_config_get_b (core->config, "scr.color.ops.unique");
 	ds->show_utf8 = r_config_get_i (core->config, "scr.utf8");
 	ds->acase = r_config_get_b (core->config, "asm.ucase");
 	ds->capitalize = r_config_get_b (core->config, "asm.capitalize");

--- a/libr/include/r_util/r_print.h
+++ b/libr/include/r_util/r_print.h
@@ -110,6 +110,7 @@ typedef struct r_print_t {
 	int cols;
 	int flags;
 	bool use_comments;
+	bool unique_colors;
 	int addrmod;
 	int col;
 	int stride;

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -2314,6 +2314,29 @@ static bool is_flag(const char *p) {
 	return len > 3;
 }
 
+// Helper function to generate unique color for immediate values
+static const char* get_unique_imm_color(ut64 value) {
+	// Define a palette of visually distinct colors for immediates
+	static const char *color_palette[] = {
+		Color_BYELLOW,    // Bright Yellow
+		Color_BCYAN,      // Bright Cyan  
+		Color_BMAGENTA,   // Bright Magenta
+		Color_BGREEN,     // Bright Green
+		Color_BRED,       // Bright Red
+		Color_BBLUE,      // Bright Blue
+		Color_YELLOW,     // Yellow
+		Color_CYAN,       // Cyan
+		Color_MAGENTA,    // Magenta
+		Color_BLUE,       // Blue
+	};
+	
+	// Hash the value to get a consistent color index
+	const size_t palette_size = sizeof(color_palette) / sizeof(color_palette[0]);
+	size_t color_idx = value % palette_size;
+	
+	return color_palette[color_idx];
+}
+
 R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, const char *num, bool partial_reset, ut64 func_addr) {
 	bool expect_reg = true;
 	int i, j, k, is_mod, is_float = 0, is_arg = 0;
@@ -2360,6 +2383,9 @@ R_API char* r_print_colorize_opcode(RPrint *print, char *p, const char *reg, con
 			const char *name = print->offname (print->user, n)? color_flag: NULL;
 			if (name) {
 				num2 = name;
+			} else if (print->unique_colors) {
+				// Use unique color for each immediate value
+				num2 = get_unique_imm_color (n);
 			}
 			const size_t nlen = strlen (num2);
 			if (nlen + j >= sizeof (o)) {


### PR DESCRIPTION
## Description
Implements unique color assignment for immediate values in disassembly output, making it easier to distinguish similar hex values like `0x1234567890abcdef` vs `0x1234567890abcdee`.

## Changes
- Added config option `scr.color.ops.unique` (default: false)
- Added `unique_colors` boolean field to `RPrint` structure
- Implemented hash-based deterministic color palette with 10 distinct colors
- Identical immediate values consistently receive the same color
- Different values receive different colors (with acceptable ~10% collision rate)

## Usage
```bash
e scr.color.ops.unique=true
pd 20
```

### Testing

```c
int main() {
    int a = 0xDEADBEEF;
    int b = 0xDEADBEEF;  // Same as a
    int c = 0xDEADBEEF;  // Same as a
    int d = 0xCAFEBABE;  // Different
    int e = 0xDEADBEEF;  // Same as a
    return a + b + c + d + e;
}
```

```bash
gcc -o /tmp/test_colors /tmp/test_colors.c
```

### Test 1: Without Unique Colors (Default Behavior)
```bash
r2 -qc 'e scr.color=3; e scr.color.ops=true; e scr.color.ops.unique=false; s main; pd 15' /tmp/test_colors
```
<img width="1213" height="486" alt="image" src="https://github.com/user-attachments/assets/5aadf67f-8171-48c3-8e01-2d72ead1059c" />

> Expected: All immediate values (0xdeadbeef and 0xcafebabe) appear in the SAME default color.

### Test 2: With Unique Colors (New Feature)
```bash
r2 -qc 'e scr.color=3; e scr.color.ops=true; e scr.color.ops.unique=true; s main; pd 15' /tmp/test_colors
```

<img width="1190" height="507" alt="image" src="https://github.com/user-attachments/assets/781c6477-3b78-46f3-b22f-c2537c8abe78" />

> Expected:
> 
> All four 0xDEADBEEF values appear in the SAME color (e.g., blue)
>0xCAFEBABE appears in a DIFFERENT color (e.g., magenta)
> 

### Test 3: Similar Hex Values (Main Use Case)

```c
int main() {
    long long a = 0x1234567890ABCDEF;
    long long b = 0x1234567890ABCDEE;  // Differs by last digit only
    return 0;
}
```
```bash
gcc -o /tmp/test_similar /tmp/test_similar.c
```
<img width="1207" height="354" alt="image" src="https://github.com/user-attachments/assets/e15260d1-a171-4242-b404-fe55a2cf5ffd" />

> Expected: The two similar hex values will have DIFFERENT colors, making it easy to spot they're different.