### PR TITLE
Add string type filtering for iz/izz commands (issue #18821)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ crash-*
 corpus*
 libr/anal/d/types-windows.sdb.txt
 libr/bin/d/dll/*.c
+
+# Personal work files
+.personal_files/
+TESTING_*.md
+*:Zone.Identifier
+test/db/cmd/*.backup

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -1426,7 +1426,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 	bool rdump = false;
 	int str_type_filter = 0;
 	RCoreBinFilter filter = {0};
-	
+
 	if (input[1] == '-') { // "iz-"
 		char *strpurge = core->bin->strpurge;
 		ut64 addr = core->addr;
@@ -1460,7 +1460,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			}
 			input--; // Will be incremented in switch
 		}
-		
+
 		switch (input[2]) {
 		case 'z':// "izzz"
 			rdump = true;
@@ -1499,7 +1499,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 	} else {
 		// "iz"
 		bool validcmd = true;
-		
+
 		// Check for type filter after iz
 		if (input[1] == 'a' || input[1] == 'u' || input[1] == 'w' || input[1] == 'W' || input[1] == 'b') {
 			str_type_filter = parse_str_type_filter (input[1], NULL);
@@ -1513,7 +1513,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			}
 			input--; // Will be incremented below
 		}
-		
+
 		switch (input[1]) {
 		case ',': // "iz,"
 			R_FREE (core->table_query);

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -1549,7 +1549,6 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			filter.str_type = str_type_filter;
 			r_list_foreach (bfiles, iter, bf) {
 				core->bin->cur = bf;
-				RBinObject *bo = r_bin_cur_object (core->bin);
 				r_core_bin_info (core, R_CORE_BIN_ACC_STRINGS, pj, mode, va, &filter, NULL);
 			}
 			core->bin->cur = cur;

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -864,6 +864,7 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly);
 typedef struct r_core_bin_filter_t {
 	ut64 addr;
 	const char *name;
+	int str_type; // filter strings by type (0 = no filter, 'a' = ascii, 'u' = utf8, 'w' = wide, 'W' = wide32, 'b' = base64)
 } RCoreBinFilter;
 
 R_API bool r_core_bin_info(RCore *core, int action, PJ *pj, int mode, int va, RCoreBinFilter *filter, const char *chksum);


### PR DESCRIPTION
- Added support for filtering strings by type: iza (ascii), izu (utf8), izw (wide/utf16), izW (wide32)
- Implemented colon syntax for charset names: iz:ascii, iz:utf8, iz:wide, iz:wide32, iz:base64
- Added str_type field to RCoreBinFilter struct for passing filter through call chain
- Modified _print_strings to filter based on RBinString type field
- Updated help messages to document new filtering options
- All filters work with both iz (data sections) and izz (whole binary) commands
- Supports combination with other modifiers (json, quiet, radare mode)
