### PR TITLE
Fix NULL pointer dereference in r_anal_extract_rarg  FIX #24737

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1253,7 +1253,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 					}
 				}
 			}
-		} else if (!f->is_variadic && !strcmp (fcn->callconv, f->callconv)) {
+		} else if (!f->is_variadic && fcn->callconv && f->callconv && !strcmp (fcn->callconv, f->callconv)) {
 			callee = r_type_func_guess (TDB, f->name);
 			if (callee) {
 				callee_rargs = R_MIN (max_count, r_type_func_args_count (TDB, callee));


### PR DESCRIPTION
Fix segfault when f->callconv is NULL in variable recovery. Add NULL checks for both fcn->callconv and f->callconv before strcmp() call.

Fixes #24737

