### PR TITLE
Fix #24748 - Avoid double free in pyc parser ##crash

### DIFF
--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -579,6 +579,7 @@ static pyc_object *get_dict_object(RBuffer *buffer) {
 			break;
 		}
 		if (!r_list_append (ret->data, key)) {
+			((RList *)ret->data)->free = NULL;
 			r_list_free (ret->data);
 			R_FREE (ret);
 			free_object (key);
@@ -590,6 +591,7 @@ static pyc_object *get_dict_object(RBuffer *buffer) {
 		}
 		if (!r_list_append (ret->data, val)) {
 			free_object (val);
+			((RList *)ret->data)->free = NULL;
 			r_list_free (ret->data);
 			R_FREE (ret);
 			return NULL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
