### PR TITLE
Change read timeout for sockets created using the connect option in r…

### DIFF
--- a/libr/socket/run.c
+++ b/libr/socket/run.c
@@ -975,6 +975,8 @@ R_API bool r_run_config_env(RRunProfile *p) {
 				r_socket_free (fd);
 				return false;
 			}
+			r_socket_block_time(fd, true, 99999, 0);
+
 			if (p->_pty) {
 				if (!redirect_socket_to_pty (fd)) {
 					R_LOG_ERROR ("socket redirection failed");


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
When using rarun2 to connect the stdin and stdout to a socket so is there a 1-second timeout when reading from the socket. This makes it hard to interact with the program in an interactive way.