### PR TITLE
There's no sense to use r_config_eval in r2 -e ##shell

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -887,10 +887,15 @@ R_API int r_main_radare2(int argc, const char **argv) {
 				if (!strcmp (opt.arg, "q")) {
 					r_core_cmd0 (r, "eq");
 				} else {
-					char *res = r_config_eval (r->config, opt.arg, false, NULL);
-					r_cons_print (r->cons, res);
-					free (res);
-					r_list_append (mr.evals, (void *)strdup (opt.arg));
+					if (strchr (opt.arg, '=')) {
+						// TODO: i think r_config_eval must disapear
+						char *res = r_config_eval (r->config, opt.arg, false, NULL);
+						r_cons_print (r->cons, res);
+						free (res);
+						r_list_append (mr.evals, (void *)strdup (opt.arg));
+					} else {
+						R_LOG_ERROR ("Needed -e key=value");
+					}
 				}
 			}
 			break;


### PR DESCRIPTION
* For now we just forbid the use of k without =v

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
