### PR TITLE
test: allow r2r to pick an alternative r2 binary

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -501,7 +501,14 @@ int main(int argc, char **argv) {
 		r_num_irand ();
 		state.run_config.shallow = shallow;
 	}
-	state.run_config.r2_cmd = "radare2";
+
+	char *r2_binary = r_sys_getenv("R2R_RADARE2");
+	if (R_STR_ISNOTEMPTY (r2_binary)) {
+			R_LOG_INFO("Using custom r2 binary: %s", r2_binary);
+			state.run_config.r2_cmd = r2_binary;
+	} else {
+			state.run_config.r2_cmd = "radare2";
+	}
 	state.run_config.skip_cmd = r_sys_getenv_asbool ("R2R_SKIP_CMD");
 	state.run_config.skip_asm = r_sys_getenv_asbool ("R2R_SKIP_ASM");
 	state.run_config.skip_json = r_sys_getenv_asbool ("R2R_SKIP_JSON");


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

As part of our work on #24769, I figured out that `r2r` is supposed to accept a custom `r2` binary, but the environment variable was not read.

<!-- explain your changes if necessary -->
