### PR TITLE
Fix inconsistency in `pq` command help message

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -562,9 +562,11 @@ static RCoreHelpMessage help_msg_po = {
 };
 
 static RCoreHelpMessage help_msg_pq = {
-	"Usage:", "pq[?z] [len]", "generate QR code in ascii art",
+	"Usage:", "pq[?isz] [len]", "generate QR code in ascii art",
 	"pq", " 32", "print QR code with the current 32 bytes",
-	"pqz", "", "print QR code with current string in current offset",
+	"pqi", "", "print inverted QR code",
+	"pqs", "", "print QR code with current string in current offset",
+	"pqz", "", "alias for pqs",
 	NULL
 };
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

The code also mentions `pq0` in a cryptic _TODO_ comment. As the current changes only imply documentation, I did not change the logic itself.