### PR TITLE
fix: prevent null deref in `cmd_afsv`

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -5134,6 +5134,9 @@ static void cmd_afsv(RCore *core, ut64 pcv, int mode) {
 	RListIter *nextele;
 	const char *fcn_name = NULL;
 	RAnalOp *aop = r_core_anal_op (core, pcv, 0);
+	if (R_UNLIKELY (!aop)) {
+		return;
+	}
 	switch (aop->type) {
 	case R_ANAL_OP_TYPE_JMP:
 	case R_ANAL_OP_TYPE_CALL:


### PR DESCRIPTION
When calling `cmd_afsv` with a funky address, the call to `r_core_anal_op` can return a NULL pointer. The latter is check before further use.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

Here is minimal repro case (macOS tahoe 26.0.1):

```sh
$ r2 -qc 'afsv @ +1' /bin/ls
```