### PR TITLE
CSI escape codes are wrongly handled in Windows

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -53,7 +53,7 @@ static inline bool is_word_break_char(char ch, BreakMode mode) {
 }
 
 static inline bool is_csi_final(char ch) {
-	return (ch == 'm' || ch == 'M' || ch == '~');
+	return (ch >= '@' && ch <= '~');
 }
 
 static inline void swap_case(RLine *line, int index) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
