### PR TITLE
Fix #14715: Validate pid argument in cmd_debug_continue function

### DIFF
--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -4926,22 +4926,26 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 		}
 		break;
 	case ' ':
+	{
 		const char *pidstr = r_str_trim_head_ro (input + 2);
-		if (!pidstr || !*pidstr) {
+		if (R_STR_ISEMPTY (pidstr)) {
 			R_LOG_ERROR ("Missing pid argument");
 			break;
 		}
-		if (!r_num_is_valid_input (core->num, pidstr)) {
+		const char *err = NULL;
+		ut64 pidn = r_num_math_err (core->num, pidstr, &err);
+		if (err || r_num_failed (core->num)) {
 			R_LOG_ERROR ("Invalid pid argument: %s", pidstr);
 			break;
 		}
 		old_pid = core->dbg->pid;
-		pid = (int)r_num_math (core->num, pidstr);
+		pid = (int)pidn;
 		r_reg_arena_swap (core->dbg->reg, true);
 		r_debug_select (core->dbg, pid, core->dbg->tid);
 		r_debug_continue (core->dbg);
 		r_debug_select (core->dbg, old_pid, core->dbg->tid);
 		break;
+	}
 	case 't':
 		if (input[2] == '?') {
 			r_core_cmd_help_match (core, help_msg_dc, "dct");


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
<img width="695" height="133" alt="image" src="https://github.com/user-attachments/assets/ad5fac55-baf6-4a91-8a47-1556f66bc6a8" />

