### PR TITLE
Remove unnecessary log warning in find_refs function

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -1500,7 +1500,6 @@ static void find_refs(RCore *core, const char *glob) {
 		r_core_cmd_help_match (core, help_msg_ax, "axF");
 		return;
 	}
-	R_LOG_WARN ("Finding references of flags matching '%s'", glob);
 	char *cmd = r_str_newf (".(findstref) @@=`f~%s[0]`", glob);
 	r_core_cmd0 (core, "(findstref;f here=$$;s entry0;/r here;f-here)");
 	r_core_cmd0 (core, cmd);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
