### PR TITLE
Fix 'mc' for filenames with spaces ##fs

### DIFF
--- a/libr/core/cmd_mount.inc.c
+++ b/libr/core/cmd_mount.inc.c
@@ -718,20 +718,16 @@ static int cmd_mount(void *data, const char *_input) {
 			r_core_cmd_help_match (core, help_msg_m, "mc");
 		} else {
 			input = (char *)r_str_trim_head_ro (input + 1);
-			ptr = strchr (input, ' ');
-			if (ptr) {
-				*ptr++ = 0;
-			} else {
-				ptr = "./";
-			}
 			file = r_fs_open (core->fs, input, false);
 			if (file) {
 				r_fs_read (core->fs, file, 0, file->size);
 				r_cons_write (core->cons, (const char *)file->data, file->size);
 				r_fs_close (core->fs, file);
 				r_cons_write (core->cons, "\n", 1);
-			} else if (!r_fs_dir_dump (core->fs, input, ptr)) {
-				R_LOG_ERROR ("Cannot open file");
+			} else {
+				if (!r_fs_dir_dump (core->fs, input, "")) {
+					R_LOG_ERROR ("Cannot open file");
+				}
 			}
 		}
 		break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
