### PR TITLE
Fix ARM reloc patching and add bin.cache regression test

### DIFF
--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -19,6 +19,21 @@ fs relocs
 EOF
 RUN
 
+NAME=ELF: arm relocs bin.cache patching
+ARGS=-e bin.cache=true
+FILE=bins/elf/analysis/arm-relocs
+CMDS=<<EOF
+s 0x0800004c
+pd 4
+EOF
+EXPECT=<<EOF
+            0x0800004c      c10000eb       bl reloc.r0
+            0x08000050      c00000eb       bl reloc.r0
+            0x08000054      c00000eb       bl reloc.r2
+            0x08000058      bf0000eb       bl reloc.r2
+EOF
+RUN
+
 NAME=ELF: ppc relocs
 FILE=bins/elf/hello.ppc
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Before
```python
./binr/radare2/radare2 -e bin.cache=true -qc "s 0x08000060; pd 10" /tmp/media_clock/media_clock.ko
WARN: ABI version mismatch: (ABI 38) vs radare2 (ABI 39) for '/home/aviuser/.local/share/radare2/plugins/core_retdec.so'
WARN: ABI version mismatch: (ABI 38) vs radare2 (ABI 39) for '/home/aviuser/.local/share/radare2/plugins/core_ghidra.so'
WARN: truncated dwarf block
            0x08000060      04b04ce2       sub fp, ip, 4               ; chips.c:164
            0x08000064      04e02de5       str lr, [sp, -4]!           ; clk.h:134
            0x08000068      42930a08       stmdaeq sl, {r1, r6, r8, sb, ip, pc}
            0x0800006c      04230008       stmdaeq r0, {r2, r8, sb, sp} ; chips.c:102
            0x08000070      582c0008       stmdaeq r0, {r3, r4, r6, sl, fp, sp} ; clkg12.c:461
            0x08000074      04230008       stmdaeq r0, {r2, r8, sb, sp} ; register_ops.h:108
            0x08000078      582c0008       stmdaeq r0, {r3, r4, r6, sl, fp, sp} ; clkg12.c:461
            0x0800007c      901083e2       add r1, r3, 0x90            ; register_ops.h:108
            0x08000080      0020a0e3       mov r2, 0                   ; chips.c:102
        ┌─< 0x08000084      000000ea       b 0x800008c                 ; clk.h:141
```

After
```python
./binr/radare2/radare2 -e bin.cache=true -qc "s 0x08000060; pd 10" /tmp/media_clock/media_clock.ko
WARN: ABI version mismatch: (ABI 38) vs radare2 (ABI 39) for '/home/aviuser/.local/share/radare2/plugins/core_retdec.so'
WARN: ABI version mismatch: (ABI 38) vs radare2 (ABI 39) for '/home/aviuser/.local/share/radare2/plugins/core_ghidra.so'
WARN: truncated dwarf block
            0x08000060      04b04ce2       sub fp, ip, 4               ; chips.c:164
            0x08000064      04e02de5       str lr, [sp, -4]!           ; clk.h:134
            0x08000068      b4a402eb       bl __gnu_mcount_nc
            0x0800006c      043302e3       movw r3, 0x2304             ; chips.c:102
            0x08000070      58cc02e3       movw ip, 0x2c58             ; clkg12.c:461 ; 'X,'
            0x08000074      003840e3       movt r3, 0x800              ; register_ops.h:108
            0x08000078      00c840e3       movt ip, 0x800              ; clkg12.c:461
            0x0800007c      901083e2       add r1, r3, 0x90            ; register_ops.h:108
            0x08000080      0020a0e3       mov r2, 0                   ; chips.c:102
        ┌─< 0x08000084      000000ea       b 0x800008c                 ; clk.h:141
```
