### PR TITLE
Fix UB overlapped memcpys in iomaps ##crash

### DIFF
--- a/libr/io/io_map.c
+++ b/libr/io/io_map.c
@@ -683,7 +683,7 @@ R_API void r_io_map_drain_overlay(RIOMap *map) {
 				ut8 *buf = realloc (start->buf, new_size * sizeof (ut8));
 				if (buf) {
 					start->buf = buf;
-					memcpy (&buf[r_itv_begin (cur->itv) - r_itv_begin (start->itv)],
+					memmove (&buf[r_itv_begin (cur->itv) - r_itv_begin (start->itv)],
 						cur->buf, r_itv_size (cur->itv));
 					r_crbtree_delete (map->overlay, cur, _overlay_chunk_insert, NULL);
 					r_queue_dequeue (q);	// first elem is always start
@@ -711,7 +711,7 @@ R_API void r_io_map_drain_overlay(RIOMap *map) {
 		ut8 *buf = realloc (start->buf, new_size * sizeof (ut8));
 		if (buf) {
 			start->buf = buf;
-			memcpy (&buf[r_itv_begin (cur->itv) - r_itv_begin (start->itv)],
+			memmove (&buf[r_itv_begin (cur->itv) - r_itv_begin (start->itv)],
 				cur->buf, r_itv_size (cur->itv));
 			r_crbtree_delete (map->overlay, cur, _overlay_chunk_insert, NULL);
 			r_queue_dequeue (q);	//first elem is always start


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
