### PR TITLE
One more strbuf reserve and unnecessary uses of it ##perf

### DIFF
--- a/binr/r2r/load.c
+++ b/binr/r2r/load.c
@@ -65,16 +65,8 @@ static char *read_string_val(char **nextline, const char *val, ut64 *linenum) {
 			R_LOG_ERROR ("Missing opening end token after <<");
 			return NULL;
 		}
-#if 0
-		if (strcmp (endtoken, "EOF") != 0) {
-			// In case there will be strings containing "EOF" inside of them, this requirement
-			// can be weakened to only apply for strings which do not contain "EOF".
-			R_LOG_ERROR ("End token must be \"EOF\", got \"%s\" instead", endtoken);
-			return NULL;
-		}
-#endif
 		RStrBuf *sb = r_strbuf_new (NULL);
-		// r_strbuf_reserve (sb, 8192);
+		r_strbuf_reserve (sb, 8192);
 		char *line = *nextline;
 		size_t linesz = 0;
 		while (line) {

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -1313,16 +1313,13 @@ beach:
 }
 
 static char *format_cmd_kv(const char *key, const char *val) {
-	RStrBuf *sb = r_strbuf_newf ("%s=", key);
 	if (strchr (val, '\n')) {
 		if (strstr (val, "EOF")) {
-			R_LOG_TODO ("Value cannot contain 'EOF'");
+			R_LOG_TODO ("Value cannot contain multiline text with 'EOF'");
 		}
-		r_strbuf_appendf (sb, "<<EOF\n%sEOF", val);
-	} else {
-		r_strbuf_append (sb, val);
+		return r_str_newf ("%s=<<EOF\n%sEOF", key, val);
 	}
-	return r_strbuf_drain (sb);
+	return r_str_newf ("%s=%s", key, val);
 }
 
 static char *replace_lines(const char *src, size_t from, size_t to, const char *news) {


### PR DESCRIPTION
* Reduce 200 allocations in 'r2r cmd_i'
* RStrbuf for 1 allocation is unnecessary

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
