### PR TITLE
Add asm.cmt.strings to disable aop.ptr strings ##disasm

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4103,6 +4103,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETB ("asm.cmt.off", "nodup", "show offset comment in disasm (true, false, nodup)");
 	SETB ("asm.cmt.fold", "false", "fold comments, toggle with Vz");
 	SETB ("asm.cmt.token", ";", "token to use before printing a comment");
+	SETB ("asm.cmt.strings", "true", "show comment strings referenced by aop.ptr");
 	SETB ("asm.cmt.flgrefs", "true", "show comment flags associated to branch reference");
 	SETB ("asm.cmt.right", "true", "show comments at right of disassembly if they fit in screen");
 	SETB ("asm.cmt.esil", "false", "show ESIL expressions as comments");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -191,6 +191,7 @@ typedef struct r_disasm_state_t {
 	bool show_cmt_flgrefs;
 	bool show_cmt_esil;
 	bool show_cmt_pseudo;
+	bool show_cmt_strings;
 	bool show_cycles;
 	bool show_refptr;
 	bool show_stackptr;
@@ -868,6 +869,7 @@ static RDisasmState *ds_init(RCore *core) {
 	ds->cmtcol = r_config_get_i (core->config, "asm.cmt.col");
 	ds->show_cmt_esil = r_config_get_b (core->config, "asm.cmt.esil");
 	ds->show_cmt_pseudo = r_config_get_b (core->config, "asm.cmt.pseudo");
+	ds->show_cmt_strings = r_config_get_b (core->config, "asm.cmt.strings");
 	ds->show_cmt_flgrefs = r_config_get_b (core->config, "asm.cmt.flgrefs");
 	ds->show_cycles = r_config_get_i (core->config, "asm.cycles");
 	ds->show_stackptr = r_config_get_i (core->config, "asm.stackptr");
@@ -4826,6 +4828,9 @@ static char *ds_esc_str(RDisasmState *ds, const char *str, int len, const char *
 }
 
 static void ds_print_str(RDisasmState *ds, const char *str, int len, ut64 refaddr) {
+	if (!ds->show_cmt_strings) {
+		return;
+	}
 	if (ds->core->flags->realnames || !r_bin_string_filter (ds->core->bin, str, refaddr)) {
 		return;
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
