### PR TITLE
Fix colorized ops with byte colors when scr.color.ops=false ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4121,7 +4121,7 @@ static void ds_print_bytes(RDisasmState *ds) {
 				pad[0] = 0;
 			}
 			free (str);
-			if (ds->show_color) {
+			if (ds->show_color_bytes && !ds->show_bytes_ascmt) {
 				str = r_str_newf ("%s"Color_RESET, nstr);
 				R_FREE (nstr);
 			} else {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
