### PR TITLE
Avoid rbinfiles to UAF if the rbin plugin associated is unloaded ##crash

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -451,6 +451,15 @@ R_API bool r_bin_plugin_remove(RBin *bin, RBinPlugin *plugin) {
 			if (plug->fini) {
 				plug->fini (bin);
 			}
+			// Nullify plugin pointers in all RBinFiles using this plugin
+			// to prevent use-after-free when files are freed later
+			RListIter *fit;
+			RBinFile *bf;
+			r_list_foreach (bin->binfiles, fit, bf) {
+				if (bf && bf->bo && bf->bo->plugin == plug) {
+					bf->bo->plugin = NULL;
+				}
+			}
 			r_list_delete (bin->plugins, iter);
 			return true;
 		}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
