### PR TITLE
Fix compilation error for -D use_libuv=true

### DIFF
--- a/libr/core/rtr.c
+++ b/libr/core/rtr.c
@@ -1409,6 +1409,8 @@ R_API bool r_core_rtr_cmds(RCore *core, const char * R_NULLABLE port) {
 	return true;
 }
 
+#endif
+
 /* Session registration API - used to track HTTP sessions for r2agent -L */
 R_API bool r_core_session_register(RCore *core, const char *uri, int port) {
 	if (!core || !uri) {
@@ -1456,5 +1458,3 @@ R_API bool r_core_session_unregister(RCore *core) {
 	core->sessionfile = NULL;
 	return true;
 }
-
-#endif


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Building with -D use_libuv=true results in a compilation error:

    /usr/bin/ld: libr/core/libr_core.so.6.0.9.p/cmd.c.o: in function `session_listen':
    cmd.c:(.text+0x1132ce): undefined reference to `r_core_session_register'
    /usr/bin/ld: libr/core/libr_core.so.6.0.9.p/rtr.c.o: in function `r_core_rtr_http_run':
    rtr.c:(.text+0x2069): undefined reference to `r_core_session_register'

These functions were in the #else of an #if HAVE_LIBUV block and as such removed by the preprocessor when building with libuv support.

Move them outside of the conditional block to make them available regardless.

See our [PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/radare2/-/blob/main/PKGBUILD?ref_type=heads) for full details on how we build radare2 for Arch Linux.