### PR TITLE
Fix x86 assembler accepting invalid register names like r1 ##asm

### DIFF
--- a/libr/arch/p/x86_nz/nzasm.c
+++ b/libr/arch/p/x86_nz/nzasm.c
@@ -142,6 +142,10 @@ static inline bool is_debug_or_control(Operand op) {
 	return (op.type & OT_REGTYPE) & (OT_CONTROLREG | OT_DEBUGREG);
 }
 
+static inline bool exactmatch(const char *reg, const char *token, size_t length) {
+	return strlen (reg) == length && !r_str_ncasecmp (reg, token, length);
+}
+
 static ut8 getsib(const ut8 sib) {
 	if (!sib) {
 		return 0;
@@ -5488,7 +5492,7 @@ static Register parseReg(RArchSession *a, const char *str, size_t *pos, ut32 *ty
 	// General purpose registers
 	if (length == 3 && token[0] == 'e') {
 		for (i = 0; regs[i]; i++) {
-			if (!r_str_ncasecmp (regs[i], token, length)) {
+			if (exactmatch (regs[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_DWORD;
 				return i;
 			}
@@ -5528,21 +5532,21 @@ static Register parseReg(RArchSession *a, const char *str, size_t *pos, ut32 *ty
 	if (length == 2) {
 		if (token[1] == 'l' || token[1] == 'h') {
 			for (i = 0; regs8[i]; i++) {
-				if (!r_str_ncasecmp (regs8[i], token, length)) {
+				if (exactmatch (regs8[i], token, length)) {
 					*type = (OT_GPREG & OT_REG (i)) | OT_BYTE;
 					return i;
 				}
 			}
 		}
 		for (i = 0; regs16[i]; i++) {
-			if (!r_str_ncasecmp (regs16[i], token, length)) {
+			if (exactmatch (regs16[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_WORD;
 				return i;
 			}
 		}
 		// This isn't working properly yet
 		for (i = 0; sregs[i]; i++) {
-			if (!r_str_ncasecmp (sregs[i], token, length)) {
+			if (exactmatch (sregs[i], token, length)) {
 				*type = (OT_SEGMENTREG & OT_REG (i)) | OT_WORD;
 				return i;
 			}
@@ -5550,14 +5554,14 @@ static Register parseReg(RArchSession *a, const char *str, size_t *pos, ut32 *ty
 	}
 	if (token[0] == 'r') {
 		for (i = 0; regs64[i]; i++) {
-			if (!r_str_ncasecmp (regs64[i], token, length)) {
+			if (exactmatch (regs64[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_QWORD;
 				a->config->bits = 64;
 				return i;
 			}
 		}
 		for (i = 0; regs64ext[i]; i++) {
-			if (!r_str_ncasecmp (regs64ext[i], token, length)) {
+			if (exactmatch (regs64ext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_QWORD;
 				a->config->bits = 64;
 				*extended = true;
@@ -5565,7 +5569,7 @@ static Register parseReg(RArchSession *a, const char *str, size_t *pos, ut32 *ty
 			}
 		}
 		for (i = 0; regsext[i]; i++) {
-			if (!r_str_ncasecmp (regsext[i], token, length)) {
+			if (exactmatch (regsext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_DWORD;
 				if (a->config->bits < 32) {
 					a->config->bits = 32;
@@ -5575,14 +5579,14 @@ static Register parseReg(RArchSession *a, const char *str, size_t *pos, ut32 *ty
 			}
 		}
 		for (i = 0; regs16ext[i]; i++) {
-			if (!r_str_ncasecmp (regs16ext[i], token, length)) {
+			if (exactmatch (regs16ext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_WORD;
 				*extended = true;
 				return i;
 			}
 		}
 		for (i = 0; regs8ext[i]; i++) {
-			if (!r_str_ncasecmp (regs8ext[i], token, length)) {
+			if (exactmatch (regs8ext[i], token, length)) {
 				*type = (OT_GPREG & OT_REG (i)) | OT_BYTE;
 				*extended = true;
 				return i;

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -906,3 +906,43 @@ EXPECT=<<EOF
 c3f5c840
 EOF
 RUN
+
+NAME=rasm2 #25036 (reject invalid x86-64 register r1)
+FILE=-
+CMDS=!rasm2 -a x86 -b 64 "add rax, r1"
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Cannot assemble 'add rax, r1' at line 1
+EOF
+RUN
+
+NAME=rasm2 #25036 (reject invalid x86-64 register r1 in mov)
+FILE=-
+CMDS=!rasm2 -a x86 -b 64 "mov rax, r1"
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Cannot assemble 'mov rax, r1' at line 1
+EOF
+RUN
+
+NAME=rasm2 #25036 (valid r10 register still works)
+FILE=-
+CMDS=!rasm2 -a x86 -b 64 "add rax, r10"
+EXPECT=<<EOF
+4c01d0
+EOF
+RUN
+
+NAME=rasm2 #25036 (valid r8-r15 registers work)
+FILE=-
+CMDS=<<EOF
+!rasm2 -a x86 -b 64 "push r8"
+!rasm2 -a x86 -b 64 "push r15"
+!rasm2 -a x86 -b 64 "mov rax, r15"
+EOF
+EXPECT=<<EOF
+4150
+4157
+4c89f8
+EOF
+RUN


### PR DESCRIPTION
The parseReg() function in x86_nz assembler used r_str_ncasecmp() with only the input token length, causing prefix matching. For example, 'r1' (length=2) would match the first 2 characters of 'r10', producing incorrect machine code.

Fix by adding strlen() check to ensure the register name length matches the token length exactly before comparing.

Fixes #25036

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
