### PR TITLE
Fix the space for the null byte in seven.c ##crash

### DIFF
--- a/libr/core/cmd_seek.inc.c
+++ b/libr/core/cmd_seek.inc.c
@@ -1,8 +1,10 @@
-/* radare - LGPL - Copyright 2009-2025 - pancake */
+/* radare - LGPL - Copyright 2009-2026 - pancake */
 
 #if R_INCLUDE_BEGIN
 
 static void __core_cmd_search_backward_prelude(RCore *core, bool doseek, bool forward);
+
+// clang-format off
 
 static RCoreHelpMessage help_msg_s = {
 	"Usage: s", "", " # Help for the seek commands. See ?$? to see all variables",
@@ -105,11 +107,13 @@ static RCoreHelpMessage help_msg_ss = {
 	NULL
 };
 
+// clang-format off
+
 static void __init_seek_line(RCore *core) {
 	r_config_bump (core->config, "lines.to");
-	ut64 from = r_config_get_i (core->config, "lines.from");
+	const ut64 from = r_config_get_i (core->config, "lines.from");
 	const char *to_str = r_config_get (core->config, "lines.to");
-	ut64 to = r_num_math (core->num, (to_str && *to_str) ? to_str : "$s");
+	const ut64 to = r_num_math (core->num, (to_str && *to_str) ? to_str : "$s");
 	if (r_core_lines_initcache (core, from, to) == -1) {
 		R_LOG_ERROR ("lines.from and lines.to are not defined");
 	}

--- a/libr/util/seven.c
+++ b/libr/util/seven.c
@@ -1,8 +1,8 @@
-/* radare - LGPL - Copyright 2012-2025 - pancake */
+/* radare - LGPL - Copyright 2012-2026 - pancake */
 
 #include <r_util.h>
-// TODO: This api must be used from RCrypto. renamed to RCodec as a plugin
 
+// TODO: rewrite as a muta plugin
 R_API char *r_print_pack7bit(const char *src) {
 	R_RETURN_VAL_IF_FAIL (src, NULL);
 	int i, j = 0, shift = 0;
@@ -11,26 +11,24 @@ R_API char *r_print_pack7bit(const char *src) {
 
 	int len = strlen (src);
 	char *dest = calloc (1, len);
-	if (!dest) {
-		return NULL;
-	}
+	if (dest) {
+		for (i = 0; i < len; i++) {
+			ch1 = src[i] & 0x7F;
+			ch1 = ch1 >> shift;
+			ch2 = src[(i + 1)] & 0x7F;
+			ch2 = ch2 << (7 - shift);
+			ch1 = ch1 | ch2;
 
-	for (i = 0; i < len; i++) {
-		ch1 = src[i] & 0x7F;
-		ch1 = ch1 >> shift;
-		ch2 = src[(i + 1)] & 0x7F;
-		ch2 = ch2 << (7 - shift);
-		ch1 = ch1 | ch2;
-
-		snprintf (tmp, sizeof (tmp), "%x", (ch1 >> 4));
-		dest[j++] = tmp[0];
-		snprintf (tmp, sizeof (tmp), "%x", (ch1 & 0x0F));
-		dest[j++] = tmp[0];
-		dest[j++] = '\0';
-		shift++;
-		if (shift == 7) {
-			shift = 0;
-			i++;
+			snprintf (tmp, sizeof (tmp), "%x", (ch1 >> 4));
+			dest[j++] = tmp[0];
+			snprintf (tmp, sizeof (tmp), "%x", (ch1 & 0x0F));
+			dest[j++] = tmp[0];
+			dest[j++] = '\0';
+			shift++;
+			if (shift == 7) {
+				shift = 0;
+				i++;
+			}
 		}
 	}
 	return dest;
@@ -41,19 +39,19 @@ R_API char *r_print_unpack7bit(const char *src) {
 	int i, j, shift = 0, len = strlen (src);
 	ut8 ch1, ch2 = '\0';
 	char buf[8];
-
-	char *dest = calloc (1, len);
-	if (!dest) {
-		return NULL;
-	}
-	for (i = 0; i < len; i += 2) {
-		snprintf (buf, sizeof (buf), "%c%c", src[i], src[i + 1]);
-		ch1 = strtol (buf, NULL, 16);
-		j = strlen (dest);
-		dest[j++] = ((ch1 & (0x7F >> shift)) << shift) | ch2;
-		dest[j++] = '\0';
-		ch2 = ch1 >> (7 - shift);
-		shift++;
+	char *dest = calloc (1, (len / 2) * 8 / 7 + 2);
+	if (dest) {
+		for (i = 0; i < len; i += 2) {
+			buf[0] = src[i];
+			buf[1] = src[i + 1];
+			buf[2] = 0;
+			ch1 = strtol (buf, NULL, 16);
+			j = strlen (dest);
+			dest[j++] = ((ch1 &(0x7F >> shift)) << shift) | ch2;
+			dest[j++] = '\0';
+			ch2 = ch1 >> (7 - shift);
+			shift++;
+		}
 	}
 	return dest;
 }


### PR DESCRIPTION
* Ref https://github.com/radareorg/radare2/security/code-scanning/393

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
