### PR TITLE
Optimize symbol loading for large binaries

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -932,11 +932,12 @@ beach:
 		const char *basename = r_file_basename (filenameuri);
 		char *macdwarf = r_str_newf ("%s.dSYM/Contents/Resources/DWARF/%s", filenameuri, basename);
 		if (r_file_exists (macdwarf)) {
-			// RBinObject *obj = r_bin_cur_object (r->bin);
-			// ut64 nbaddr = obj? obj->baddr: baddr;
+			// Skip symbols for dSYM since they duplicate main binary
+			bool old_skipsyms = r->bin->options.skip_symbols;
+			r->bin->options.skip_symbols = true;
 			r_core_cmd_callf (r, "o %s", macdwarf);
+			r->bin->options.skip_symbols = old_skipsyms;
 			r_core_cmd_call (r, "obm-");
-			// r_core_cmd_callf (r, "o-."); // causes uaf
 		}
 		free (macdwarf);
 	}

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -433,6 +433,7 @@ typedef struct r_bin_file_options_t {
 	int fd;
 	int rawstr;
 	bool nofuncstarts;
+	bool skip_symbols; // skip symbol loading (e.g., for companion debug files)
 	const char *filename;
 } RBinFileOptions;
 
@@ -514,6 +515,7 @@ typedef struct r_bin_options_t {
 	bool use_xtr; // use extract plugins when loading a file?
 	bool use_ldr; // use loader plugins when loading a file?
 	bool debase64;
+	bool skip_symbols; // skip symbol loading (e.g., for companion debug files)
 	int minstrlen;
 	int maxstrlen;
 	int maxsymlen;


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

  - Bulk read symbol table instead of per-symbol I/O in parse_symtab
  - Check for "<redacted>" once per binary instead of per-symbol
  - Add skip_symbols option to avoid re-parsing symbols for dSYM files
  - Use lookup tables for r_name_validate_char/dash/shell functions
  - ~Cache demangled names to avoid redundant r_bin_demangle calls~
  - Remove redundant flag lookups in bin_symbols

  Reduces load time for 450k symbol binary from ~35s to ~13s (on mac m3).
