### PR TITLE
Fix memory leak in SOM import parser ##bin

### DIFF
--- a/libr/bin/format/som/som.c
+++ b/libr/bin/format/som/som.c
@@ -509,7 +509,7 @@ R_IPI RList *r_bin_som_get_imports(void *o) {
 	RListIter *iter;
 	RSomImportListEntry *import_entry;
 	r_list_foreach (obj->imports, iter, import_entry) {
-		if (import_entry->import_name == (ut32)-1) {
+		if (import_entry->import_name == UT32_MAX) {
 			continue;
 		}
 		RBinImport *imp = R_NEW0 (RBinImport);


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge

**Description**

`r_bin_som_get_imports()` was allocating `RBinImport` before checking if `import_name == -1`. When that condition was true, it would continue without freeing the allocation.

Moved the check before the allocation to avoid the leak. Tested with ASAN , leak gone


Fixes : #25242