### PR TITLE
Optimize aa by doing full var recovery per-function, removing redundant afva loop

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -105,6 +105,31 @@ static void r_meta_item_free(void *_item) {
 	}
 }
 
+R_API void r_anal_update_arch_type(RAnal *anal) {
+	const char *arch = anal->config ? anal->config->arch : NULL;
+	if (R_STR_ISEMPTY (arch)) {
+		anal->arch_type = R_ANAL_ARCHTYPE_UNKNOWN;
+	} else if (r_str_startswith (arch, "arm")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_ARM;
+	} else if (r_str_startswith (arch, "mips")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_MIPS;
+	} else if (r_str_startswith (arch, "x86")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_X86;
+	} else if (r_str_startswith (arch, "v850")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_V850;
+	} else if (r_str_startswith (arch, "dalvik")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_DALVIK;
+	} else if (r_str_startswith (arch, "stm8")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_STM8;
+	} else if (r_str_startswith (arch, "riscv")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_RISCV;
+	} else if (r_str_startswith (arch, "ppc")) {
+		anal->arch_type = R_ANAL_ARCHTYPE_PPC;
+	} else {
+		anal->arch_type = R_ANAL_ARCHTYPE_UNKNOWN;
+	}
+}
+
 // Take nullable RArchConfig as argument?
 R_API RAnal *r_anal_new(void) {
 	int i;
@@ -120,6 +145,7 @@ R_API RAnal *r_anal_new(void) {
 	anal->ht_name_fun = ht_pp_new0 ();
 	anal->config = r_arch_config_new ();
 	anal->arch = r_arch_new ();
+	anal->arch_type = R_ANAL_ARCHTYPE_UNKNOWN;
 	anal->esil_goto_limit = R_ESIL_GOTO_LIMIT;
 	anal->opt.nopskip = true; // skip nops in code analysis
 	anal->opt.hpskip = false; // skip `mov reg,reg` and `lea reg,[reg]`

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -2196,18 +2196,19 @@ R_API bool r_core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int dep
 	if (r_cons_is_breaked (core->cons)) {
 		return false;
 	}
-	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, at, 0);
+	RAnalFunction *fcn = r_anal_get_function_at (core->anal, at);
 	if (fcn) {
-		if (fcn->addr == at) {
-			// if the function was already analyzed as a "loc.",
-			// convert it to function and rename it to "fcn.",
-			// because we found a call to this address
-			const int rt = R_ANAL_REF_TYPE_MASK (reftype);
-			if (rt == R_ANAL_REF_TYPE_CALL && fcn->type == R_ANAL_FCN_TYPE_LOC) {
-				function_rename (core->flags, fcn);
-			}
-			return 0;  // already analyzed function
+		// if the function was already analyzed as a "loc.",
+		// convert it to function and rename it to "fcn.",
+		// because we found a call to this address
+		const int rt = R_ANAL_REF_TYPE_MASK (reftype);
+		if (rt == R_ANAL_REF_TYPE_CALL && fcn->type == R_ANAL_FCN_TYPE_LOC) {
+			function_rename (core->flags, fcn);
 		}
+		return 0;
+	}
+	fcn = r_anal_get_fcn_in (core->anal, at, 0);
+	if (fcn) {
 		if (r_anal_function_contains (fcn, from)) { // inner function
 			if (r_anal_xrefs_has_xrefs_at (core->anal, from)) {
 				return true;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -83,6 +83,18 @@ enum {
 	R_ANAL_DATA_TYPE_ZERO = 10,
 };
 
+typedef enum {
+	R_ANAL_ARCHTYPE_UNKNOWN = 0,
+	R_ANAL_ARCHTYPE_ARM,
+	R_ANAL_ARCHTYPE_MIPS,
+	R_ANAL_ARCHTYPE_X86,
+	R_ANAL_ARCHTYPE_V850,
+	R_ANAL_ARCHTYPE_DALVIK,
+	R_ANAL_ARCHTYPE_STM8,
+	R_ANAL_ARCHTYPE_RISCV,
+	R_ANAL_ARCHTYPE_PPC,
+} RAnalArchType;
+
 // used from core/anal.c
 #define R_ANAL_ADDR_TYPE_EXEC      1
 #define R_ANAL_ADDR_TYPE_READ      1 << 1
@@ -451,6 +463,7 @@ typedef struct r_ref_manager_t RefManager;
 
 typedef struct r_anal_t {
 	RArchConfig *config;
+	RAnalArchType arch_type;
 	int lineswidth; // asm.lines.width
 	int sleep;      // anal.sleep, sleep some usecs before analyzing more (avoid 100% cpu usages)
 	RAnalCPPABI cxxabi; // anal.cpp.abi
@@ -1086,6 +1099,7 @@ R_API int r_anal_function_bb(RAnal *anal, RAnalFunction *fcn, ut64 addr, int dep
 R_API void r_anal_bind(RAnal *b, RAnalBind *bnd);
 R_API void r_anal_type_match(RAnal *anal, RAnalFunction *fcn);
 R_API bool r_anal_set_triplet(RAnal *anal, const char *os, const char *arch, int bits);
+R_API void r_anal_update_arch_type(RAnal *anal);
 R_API void r_anal_add_import(RAnal *anal, const char *imp);
 R_API void r_anal_remove_import(RAnal *anal, const char *imp);
 R_API void r_anal_purge_imports(RAnal *anal);


### PR DESCRIPTION

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
should be a 2.5x speedup