### PR TITLE
Fix memory leak in MDMP parser ##bin

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -120,6 +120,7 @@ void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj) {
 
 	r_buf_free (obj->b);
 	free (obj->hdr);
+	sdb_free (obj->kv);
 	obj->b = NULL;
 	free (obj);
 


### PR DESCRIPTION
Free obj->kv (sdb) in r_bin_mdmp_free() which was allocated in r_bin_mdmp_new_buf() but never freed, causing 24KB leak per parsed MDMP file

I noticed this while fuzzing malformed MDMP headers

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

Fixes : #25248