### PR TITLE
Fix memory leaks in MDMP plugin and RBinMem ##bin

### DIFF
--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -14,6 +14,7 @@ R_API void r_bin_mem_free(void *data) {
 		r_list_free (mem->mirrors);
 		mem->mirrors = NULL;
 	}
+	free (mem->name);
 	free (mem);
 }
 

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -230,6 +230,7 @@ static RList *sections(RBinFile *bf) {
 		str = (struct minidump_string *)b;
 		int ptr_name_len = (str->length + 2) * 4;
 		if (ptr_name_len < 1 || ptr_name_len > sizeof (b) - 4) {
+			free (ptr);
 			continue;
 		}
 		if (module->module_name_rva + str->length > r_buf_size (obj->b)) {


### PR DESCRIPTION
`bin_mdmp.c`(sections_function): First one is in `sections()` , we allocate a RBinSection but if the name length check fails we just continue without freeing it.
`bobj.c`: Second one is actually in the core  `r_bin_mem_free()` , it never frees the name field. This probably affects other plugins too, not just MDMP

Tested with calc.dmp from testbins(https://github.com/radareorg/radare2-testbins/blob/master/mdmp/calc.dmp), leaks are gone now.

ASan Log: 

```
radare2 git:(master)  ./binr/rabin2/rabin2 -I /tmp/testbins/mdmp/*
.rwxrwxr-x  37k oblivionsage 18 Jan 08:20  calc.dmp
.rwxrwxr-x 6.6M oblivionsage 18 Jan 08:20  hello.dmp
.rwxrwxr-x 5.0M oblivionsage 18 Jan 08:20  hello64.dmp
.rwxrwxr-x 6.1M oblivionsage 18 Jan 08:20  radare2.exe.12964.dmp
WARN: Invalid or unsupported enumeration encountered 21
WARN: Invalid or unsupported enumeration encountered 22
INFO: Parsing data sections for large dumps can take time
INFO: Please be patient (but if strings ain't your thing try with -z)
arch     x86
binsz    36724
bintype  mdmp
bits     64
canary   false
injprot  false
retguard false
crypto   false
endian   little
flags    0x00040000
havecode true
hdr.csum 0x00000000
laddr    0x0
linenum  false
lsyms    false
machine  AMD64
nx       false
os       Windows NT Workstation 6.1.7601
pic      false
relocs   false
rpath    NONE
sanitize false
static   true
streams  13
stripped false
va       true

=================================================================
==3764==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 855 byte(s) in 9 object(s) allocated from:
    #0 0x7fbffa2f4610 in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7fbff9b2df96 in r_str_newf /home/oblivionsage/Desktop/radare2/libr/util/str.c:771
    #2 0x7fbff5f32fc1 in mem /home/oblivionsage/Desktop/radare2/libr/..//libr/bin/p/bin_mdmp.c:317
    #3 0x7fbff5d712c2 in r_bin_object_set_items /home/oblivionsage/Desktop/radare2/libr/bin/bobj.c:546
    #4 0x7fbff5d6e4cd in r_bin_object_new /home/oblivionsage/Desktop/radare2/libr/bin/bobj.c:256
    #5 0x7fbff5d67242 in r_bin_file_new_from_buffer /home/oblivionsage/Desktop/radare2/libr/bin/bfile.c:827
    #6 0x7fbff5d3b340 in r_bin_open_buf /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:308
    #7 0x7fbff5d3babb in r_bin_open_io /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:373
    #8 0x7fbff5d3a819 in r_bin_open /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:252
    #9 0x7fbff5789d22 in r_main_rabin2 /home/oblivionsage/Desktop/radare2/libr/main/rabin2.c:1203
    #10 0x564e356fc3ec in main /home/oblivionsage/Desktop/radare2/binr/rabin2/rabin2.c:16
    #11 0x7fbff4833ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

Direct leak of 224 byte(s) in 2 object(s) allocated from:
    #0 0x7fbffa2f4610 in calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7fbff5f32902 in sections /home/oblivionsage/Desktop/radare2/libr/..//libr/bin/p/bin_mdmp.c:224
    #2 0x7fbff5d70705 in r_bin_object_set_items /home/oblivionsage/Desktop/radare2/libr/bin/bobj.c:462
    #3 0x7fbff5d6e4cd in r_bin_object_new /home/oblivionsage/Desktop/radare2/libr/bin/bobj.c:256
    #4 0x7fbff5d67242 in r_bin_file_new_from_buffer /home/oblivionsage/Desktop/radare2/libr/bin/bfile.c:827
    #5 0x7fbff5d3b340 in r_bin_open_buf /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:308
    #6 0x7fbff5d3babb in r_bin_open_io /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:373
    #7 0x7fbff5d3a819 in r_bin_open /home/oblivionsage/Desktop/radare2/libr/bin/bin.c:252
    #8 0x7fbff5789d22 in r_main_rabin2 /home/oblivionsage/Desktop/radare2/libr/main/rabin2.c:1203
    #9 0x564e356fc3ec in main /home/oblivionsage/Desktop/radare2/binr/rabin2/rabin2.c:16
    #10 0x7fbff4833ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: 1079 byte(s) leaked in 11 allocation(s).
```

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)




