### PR TITLE
wx+ nibble writes no longer depend on block size ##io

### DIFF
--- a/libr/core/cmd_write.inc.c
+++ b/libr/core/cmd_write.inc.c
@@ -255,7 +255,8 @@ static void write_encrypted_block(RCore *core, const char *algo, const char *key
 	if (r_str_startswith (key, "s:")) {
 		binkey = (ut8*)strdup (key + 2);
 		keylen = strlen (key + 2);
-	// AITODO: support base64: prefix
+	} else if (r_str_startswith (key, "base64:")) {
+		binkey = r_base64_decode_dyn (key + 7, -1, (int *)&keylen);
 	} else {
 		binkey = (ut8 *)strdup (key);
 		keylen = r_hex_str2bin (key, binkey);
@@ -308,7 +309,8 @@ static void write_block_signature(RCore *core, const char *algo, const char *key
 	if (r_str_startswith (key, "s:")) {
 		binkey = (ut8 *)strdup (key + 2);
 		keylen = strlen (key + 2);
-	// AITODO: support base64: prefix
+	} else if (r_str_startswith (key, "base64:")) {
+		binkey = r_base64_decode_dyn (key + 7, -1, (int *)&keylen);
 	} else {
 		binkey = (ut8 *)strdup (key);
 		keylen = r_hex_str2bin (key, binkey);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
