### PR TITLE
Fix "p8," command output (missing 0x prefix) ##print

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -9131,7 +9131,7 @@ static int cmd_print(void *data, const char *input) {
 			} else if (input[1] == ',') { // "p8,"
 				r_core_block_read (core);
 				block = core->block;
-				r_print_bytes (core->print, block, l, "%02x", ',');
+				r_print_bytes (core->print, block, l, "0x%02x", ',');
 			} else if (input[1] == 'x') { // "p8x"
 				r_core_block_read (core);
 				block = core->block;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
