### PR TITLE
Fix memory leaks in Java binary parser ##bin

### DIFF
--- a/test/db/leak/open
+++ b/test/db/leak/open
@@ -49,3 +49,26 @@ EXPECT=<<EOF
 hello
 EOF
 RUN
+
+NAME=leak opening java class
+BROKEN=1
+FILE=bins/java/Hello.class
+CMDS=<<EOF
+?e hello
+EOF
+EXPECT=<<EOF
+hello
+EOF
+RUN
+
+NAME=leak analysis java class
+BROKEN=1
+FILE=bins/java/Hello.class
+ARGS=-AA
+CMDS=<<EOF
+?e hello
+EOF
+EXPECT=<<EOF
+hello
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixed some memory leaks in java class parser. `__bin_class_free()` was calling `free()` on RBinName and RList pointers instead of proper free functions. Also added missing NULL check after R_NEW0 and removed dead code.

Found with ASAN.

Fixes : #25261