### PR TITLE
Fix incorrect plugin references in RLibStruct structures ##arch

### DIFF
--- a/libr/arch/p/bpf_cs/plugin.c
+++ b/libr/arch/p/bpf_cs/plugin.c
@@ -1009,7 +1009,7 @@ const RArchPlugin r_arch_plugin_bpf_cs = {0};
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
 #if CS_API_MAJOR >= 5
-	.data = &r_anal_plugin_bpf_cs,
+	.data = &r_arch_plugin_bpf_cs,
 #endif
 	.version = R2_VERSION
 };

--- a/libr/arch/p/chip8/plugin.c
+++ b/libr/arch/p/chip8/plugin.c
@@ -242,7 +242,7 @@ const RArchPlugin r_arch_plugin_chip8 = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_chip8,
+	.data = &r_arch_plugin_chip8,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/cosmac/plugin.c
+++ b/libr/arch/p/cosmac/plugin.c
@@ -705,7 +705,7 @@ const RArchPlugin r_arch_plugin_cosmac = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_cosmac,
+	.data = &r_arch_plugin_cosmac,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/fslsp/plugin.c
+++ b/libr/arch/p/fslsp/plugin.c
@@ -257,7 +257,7 @@ const RArchPlugin r_arch_plugin_fslsp = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_fslsp,
+	.data = &r_arch_plugin_fslsp,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/lm32/plugin.c
+++ b/libr/arch/p/lm32/plugin.c
@@ -492,7 +492,7 @@ const RArchPlugin r_arch_plugin_lm32 = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_lm32,
+	.data = &r_arch_plugin_lm32,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/m680x_cs/plugin.c
+++ b/libr/arch/p/m680x_cs/plugin.c
@@ -693,7 +693,7 @@ const RArchPlugin r_arch_plugin_m680x_cs = {
 	.fini = fini,
 };
 #else
-const RArchPlugin r_anal_plugin_m680x_cs = {
+const RArchPlugin r_arch_plugin_m680x_cs = {
 	.meta = {
 		.name = "m680x (unsupported)",
 		.desc = "Capstone M680X (unsupported)",
@@ -707,7 +707,7 @@ const RArchPlugin r_anal_plugin_m680x_cs = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_m680x_cs,
+	.data = &r_arch_plugin_m680x_cs,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/m68k_cs/plugin.c
+++ b/libr/arch/p/m68k_cs/plugin.c
@@ -953,7 +953,7 @@ const RArchPlugin r_arch_plugin_m68k_cs = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_m68k_cs,
+	.data = &r_arch_plugin_m68k_cs,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/mcore/plugin.c
+++ b/libr/arch/p/mcore/plugin.c
@@ -138,7 +138,7 @@ const RArchPlugin r_arch_plugin_mcore = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_mcore,
+	.data = &r_arch_plugin_mcore,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/pdp11/plugin.c
+++ b/libr/arch/p/pdp11/plugin.c
@@ -133,7 +133,7 @@ const RArchPlugin r_arch_plugin_pdp11 = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_pdp11,
+	.data = &r_arch_plugin_pdp11,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/pic/plugin.c
+++ b/libr/arch/p/pic/plugin.c
@@ -1202,7 +1202,7 @@ const RArchPlugin r_arch_plugin_pic = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_pic,
+	.data = &r_arch_plugin_pic,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/sparc_cs/plugin.c
+++ b/libr/arch/p/sparc_cs/plugin.c
@@ -496,7 +496,7 @@ const RArchPlugin r_arch_plugin_sparc_cs = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_sparc_cs,
+	.data = &r_arch_plugin_sparc_cs,
 	.version = R2_VERSION
 };
 #endif

--- a/libr/arch/p/ws/plugin.c
+++ b/libr/arch/p/ws/plugin.c
@@ -158,7 +158,7 @@ const RArchPlugin r_arch_plugin_ws = {
 #ifndef R2_PLUGIN_INCORE
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_ARCH,
-	.data = &r_anal_plugin_ws,
+	.data = &r_arch_plugin_ws,
 	.version = R2_VERSION
 };
 #endif


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
Fixed incorrect plugin references in `.data` field of `RLibStruct` structures, changing  from `r_anal_plugin_*` to `r_arch_plugin_*` across multiple architecture plugins.