### PR TITLE
Fix off-by-one heap buffer over-read in OMF parser ##bin

### DIFF
--- a/libr/bin/format/omf/omf.c
+++ b/libr/bin/format/omf/omf.c
@@ -704,7 +704,7 @@ bool r_bin_omf_get_entry(r_bin_omf_obj *obj, RBinAddr *addr) {
 	}
 	while (ct_sym < obj->nb_symbol) {
 		if (!strcmp (obj->symbols[ct_sym]->name, "_start")) {
-			if (obj->symbols[ct_sym]->seg_idx - 1 > obj->nb_section) {
+			if (obj->symbols[ct_sym]->seg_idx - 1 >= obj->nb_section) {
 				eprintf ("Invalid segment index for symbol _start\n");
 				return false;
 			}
@@ -773,7 +773,7 @@ ut64 r_bin_omf_get_paddr_sym(r_bin_omf_obj *obj, OMF_symbol *sym) {
 	if (!obj->sections) {
 		return 0LL;
 	}
-	if (sym->seg_idx - 1 > obj->nb_section) {
+	if (sym->seg_idx - 1 >= obj->nb_section) {
 		return 0LL;
 	}
 	int sidx = sym->seg_idx - 1;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix bounds check using `>` instead of `>=` in OMF segment index validation.  Prevents heap OOB read when `seg_idx = nb_section + 1`

Fixes : #25277 