### PR TITLE
Fix incorrect NX information for QNX ELF binaries

### DIFF
--- a/libr/bin/format/elf/glibc_elf.h
+++ b/libr/bin/format/elf/glibc_elf.h
@@ -1244,6 +1244,9 @@ typedef struct
 /* Note entries for GNU systems have this name.  */
 #define ELF_NOTE_GNU		"GNU"
 
+/* Note entries for QNX systems have this name.  */
+#define ELF_NOTE_QNX		"QNX"
+
 
 /* Defined types of notes for Solaris.  */
 
@@ -1346,6 +1349,9 @@ typedef struct
 /* This indicates that all executable sections are compatible with
 //   SHSTK.  */
 #define GNU_PROPERTY_X86_FEATURE_1_SHSTK	(1U << 1)
+
+/* Defined note types for QNX systems.  */
+#define QNT_STACK	3
 
 /* Move records.  */
 typedef struct

--- a/test/db/formats/elf/qnx-nx-note
+++ b/test/db/formats/elf/qnx-nx-note
@@ -1,0 +1,8 @@
+NAME=qnx note sets nx
+FILE=bins/elf/hello_world_qnx_nx
+ARGS=-e bin.relocs.apply=true
+CMDS=iI~nx
+EXPECT=<<EOF
+nx       true
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Radare2 considers the NX bit to be unset for all modern QNX binaries right now. This fixes it.

The NX information on QNX ELF binaries is stored in the `.note` section. Specifically in the `.note` part owned by "QNX" with type 0x3 aka `QNT_STACK`.

This part contains 3 little-endian integers corresponding to:
  - stacksize
  - stackalloc (in bytes, usually 4096)
  - executable (boolean, 1 if non-executable)

We make sure that r2 checks that entry when verifying the nx bit, therefore returning valid information for QNX ELF files.

Opened a PR for the test file at https://github.com/radareorg/radare2-testbins/pull/117

The code was written with the help of a coding agent, but reviewed and validated by a human.

Reference: [QNX Stack Protection](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.security.system/topic/manual/stack_protection.html)

