### PR TITLE
Fix r2_fortunes path inconsistency in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -235,7 +235,7 @@ else
   r2_platform = join_paths(r2_datdir_r2, r2_version, 'platform')
   r2_themes = join_paths(r2_datdir_r2, r2_version, 'cons')
   r2_panels = join_paths(r2_datdir_r2, r2_version, 'panels')
-  r2_fortunes = join_paths(r2_datdir, r2_version, 'fortunes')
+  r2_fortunes = join_paths(r2_datdir_r2, r2_version, 'fortunes')
   r2_flags = join_paths(r2_datdir_r2, r2_version, 'flag')
   r2_hud = join_paths(r2_datdir_r2, r2_version, 'hud')
   r2_plugins = join_paths(r2_libdir, 'radare2', r2_version)


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The fortunes are stored in `.local/share/6.0.x/` instead of `.local/share/radare2/6.0.x/` like the other data.

<!-- explain your changes if necessary -->
