### PR TITLE
Fix memory leak in PE parser ##bin

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -4582,6 +4582,7 @@ void *PE_(r_bin_pe_free)(RBinPEObj *pe) {
 	r_list_free (pe->dotnet_symbols);
 	r_pkcs7_cms_free (pe->cms);
 	r_pkcs7_spcinfo_free (pe->spcinfo);
+	sdb_free (pe->kv);
 	r_unref (pe->b);
 	pe->b = NULL;
 	free (pe);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add missing sdb_free(pe->kv) call in r_bin_pe_free() to properly clean up the SDB instance allocated in r_bin_pe_new_buf()
