### PR TITLE
Fix ELF extended phnum allocation check ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -317,11 +317,13 @@ static int init_phdr(ELFOBJ *eo) {
 		return false;
 	}
 	ut64 phnum = Elf_(get_phnum) (eo);
-#if 0
 	if (phnum > SIZE_MAX / sizeof (Elf_(Phdr))) {
 		return false;
 	}
-#endif
+	// Ensure phnum-based allocation doesn't exceed file size
+	if (phnum * sizeof (Elf_(Phdr)) > eo->size) {
+		return false;
+	}
 	if (!(eo->phdr = R_NEWS0 (Elf_(Phdr), phnum))) {
 		r_sys_perror ("malloc (phdr)");
 		return false;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes : #25290

When `e_phnum=0xFFFF`, `get_phnum()` reads from `sh_info` but size validation used `e_phnum`. added file size check after `get_phnum()` call
