### PR TITLE
Rewrite RCore.seekOpForward for the better ##analysis

### DIFF
--- a/test/db/cmd/cmd_seek
+++ b/test/db/cmd/cmd_seek
@@ -2,6 +2,7 @@ NAME=prev seek opcode mill bug
 FILE=bins/elf/runofthemill
 CMDS=<<EOF
 s 0x4117e4
+s
 so+1
 s
 so-1
@@ -11,6 +12,7 @@ s
 aa
 ?e --
 s 0x4117e4
+s
 so+1
 s
 so-1
@@ -19,10 +21,12 @@ so-1
 s
 EOF
 EXPECT=<<EOF
+0x4117e4
 0x4117ef
 0x4117e4
 0x4117dc
 --
+0x4117e4
 0x4117ef
 0x4117e4
 0x4117dc
@@ -476,5 +480,36 @@ EXPECT=<<EOF
 0x44
 0x33
 0x0
+EOF
+RUN
+
+NAME=seek opcode history
+FILE=bins/elf/runofthemill
+CMDS=<<EOF
+so+1
+s
+so+2
+s
+so-3
+s
+echo ---
+s!
+echo ---
+s-
+s
+EOF
+EXPECT=<<EOF
+0x401007
+0x401012
+0x401000
+---
+0x401000 entry0
+0x401007 entry0 + 7
+
+0x401012 entry0 + 18
+
+0x401000 entry0
+---
+0x401012
 EOF
 RUN


### PR DESCRIPTION
* Use local buffer instead of core->block for context safetey
* Read once the whole maxopsz * numinstr
* Ensure numinstr > 0
* Check boundaries in case of seeking above -1u64
* Dont seek on every op, dont seek back to restore position
* Register seek history
* Optimize for fixed-size instr sets
* Improvements in seekOpBackward

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
