### PR TITLE
Fix memory leak in zimg plugin ##bin

### DIFF
--- a/libr/bin/p/bin_zimg.c
+++ b/libr/bin/p/bin_zimg.c
@@ -17,6 +17,15 @@ static bool load(RBinFile *bf, RBuffer *b, ut64 loadaddr) {
 	return bf->bo->bin_obj != NULL;
 }
 
+
+static void destroy(RBinFile *bf) {
+	struct r_bin_zimg_obj_t *obj = bf->bo->bin_obj;
+	if (obj) {
+		r_unref (obj->b);
+		free (obj);
+	}
+}
+
 static ut64 baddr(RBinFile *bf) {
 	return 0;
 }
@@ -62,6 +71,7 @@ RBinPlugin r_bin_plugin_zimg = {
 	},
 	.get_sdb = &get_sdb,
 	.load = &load,
+	.destroy = &destroy,
 	.check = &check,
 	.baddr = &baddr,
 	.info = &info,


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Add missing `destroy()` function to zimg plugin to fix memory leak
