### PR TITLE
Fix use-after-free in LE/LX reloc parsing ##crash

### DIFF
--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -656,6 +656,11 @@ R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
 				fixupinfo = r_buf_read_ble32_at (bin->buf, cur_page_offset + source, h->worder);
 				RBinReloc *new = R_NEW0 (RBinReloc);
 				*new = *rel;
+				if (rel->import) {
+					new->import = R_NEW0 (RBinImport);
+					new->import->name = rel->import->name ? r_bin_name_clone (rel->import->name) : NULL;
+					new->import->ordinal = rel->import->ordinal;
+				}
 				new->addend = base_target_address + (fixupinfo & 0xFFFFF);
 				r_list_append (l, new);
 				source = (fixupinfo >> 20) & 0xFFF;
@@ -668,6 +673,11 @@ R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
 			rel->paddr = cur_section ? cur_section->paddr + off : 0;
 			RBinReloc *new = R_NEW0 (RBinReloc);
 			*new = *rel;
+			if (rel->import) {
+				new->import = R_NEW0 (RBinImport);
+				new->import->name = rel->import->name ? r_bin_name_clone (rel->import->name) : NULL;
+				new->import->ordinal = rel->import->ordinal;
+			}
 			r_list_append (l, new);
 			offset += sizeof (ut16);
 			repeat--;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Deep copy import struct when duplicating relocs in F_SOURCE_LIST and F_TARGET_CHAIN paths. 

Fixes : #25310 
