### PR TITLE
##crash Fix integer underflow in QNX parser

### DIFF
--- a/libr/bin/p/bin_qnx.c
+++ b/libr/bin/p/bin_qnx.c
@@ -85,6 +85,10 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 				free (ptr);
 				goto beach;
 			}
+			if (lrec.data_nbytes < sizeof (lmf_resource)) {
+				free (ptr);
+				goto beach;
+			}
 			ptr->name = strdup ("LMF_RESOURCE");
 			ptr->paddr = offset;
 			ptr->vsize = lrec.data_nbytes - sizeof (lmf_resource);
@@ -94,6 +98,10 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 		} else if (lrec.rec_type == LMF_LOAD_REC) {
 			RBinSection *ptr = R_NEW0 (RBinSection);
 			if (r_buf_fread_at (bf->buf, offset, (ut8 *)&ldata, "si", 1) != sizeof (lmf_data)) {
+				free (ptr);
+				goto beach;
+			}
+			if (lrec.data_nbytes < sizeof (lmf_data)) {
 				free (ptr);
 				goto beach;
 			}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

bounds check before subtracting struct size from `data_nbytes` in `LMF_RESOURCE_REC` and `LMF_LOAD_REC` handlers

Fixes : #25336
