### PR TITLE
out-of-bounds read in NSO parser ##crash

### DIFF
--- a/libr/bin/p/bin_nso.c
+++ b/libr/bin/p/bin_nso.c
@@ -87,6 +87,14 @@ static bool load_bytes(RBinFile *bf, const ut8 *buf, ut64 sz, ut64 loadaddr) {
 		R_LOG_WARN ("prevented oom");
 		return false;
 	}
+	if (toff >= sz || rooff >= sz || doff >= sz) {
+		R_LOG_ERROR ("invalid section offset");
+		return false;
+	}
+	if (toff > rooff || rooff > doff) {
+		R_LOG_ERROR ("invalid section offset order");
+		return false;
+	}
 	RBuffer *newbuf = r_buf_new_empty (total_size);
 	ut64 ba = baddr (bf);
 	ut8 *tmp = NULL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

bounds check for section offsets before pointer arithmetic.

Fixes : #25338