### PR TITLE
Fix #17391: preserve UTF-8 in graph output

### DIFF
--- a/libr/cons/canvas.c
+++ b/libr/cons/canvas.c
@@ -451,6 +451,7 @@ R_API char *r_cons_canvas_tostring(RConsCanvas *c) {
 	}
 
 	olen = 0;
+	const bool useutf = c->flags & R_CONS_CANVAS_FLAG_UTF8;
 	for (y = 0; y < c->h; y++) {
 		if (!is_first) {
 			o[olen++] = '\n';
@@ -470,6 +471,17 @@ R_API char *r_cons_canvas_tostring(RConsCanvas *c) {
 					attr_x++;
 					x++;
 					continue;
+				}
+				if (useutf) {
+					RRune ch;
+					int ulen = r_utf8_decode ((const ut8 *)c->b[y] + x, c->blen[y] - x, &ch);
+					if (ulen > 1) {
+						memcpy (o + olen, c->b[y] + x, ulen);
+						olen += ulen;
+						attr_x += rune_display_width (ch);
+						x += ulen;
+						continue;
+					}
 				}
 				const char *rune = r_cons_get_rune ((const ut8)c->b[y][x]);
 				if (rune) {

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -3621,8 +3621,8 @@ static int agraph_print(RCore *core, RAGraph *g, bool is_interactive, RAnalFunct
 		}
 	}
 
-	r_cons_canvas_print_region (g->can);
 	g->can->flags = r_cons_canvas_flags (core->cons);
+	r_cons_canvas_print_region (g->can);
 
 	if (is_interactive) {
 		r_cons_newline (core->cons);

--- a/test/db/cmd/cmd_graph
+++ b/test/db/cmd/cmd_graph
@@ -50,6 +50,18 @@ agraph.nodes.title1.body=base64:aGVsbG8gd29ybGQ=
 EOF
 RUN
 
+NAME=utf8 base64 body
+FILE=-
+CMDS=<<EOF
+e scr.utf8=true
+agn "Phi" base64:zqY=
+agg~Φ
+EOF
+EXPECT=<<EOF
+| Φ                  |
+EOF
+RUN
+
 NAME=long base64 body
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
- render UTF-8 bytes before rune table mapping in canvas

- refresh canvas flags before graph print

- add graph test for base64 UTF-8 node body