### PR TITLE
Convert RLib->plugins_ht to a per-type array of hashtables, fixes #25374

### DIFF
--- a/libr/core/cmd_log.inc.c
+++ b/libr/core/cmd_log.inc.c
@@ -654,7 +654,7 @@ static int cmd_plugins(void *data, const char *input) {
 				r_lib_meta_pj (pj, &cp->meta);
 				if (cp->meta.name) {
 					bool found;
-					RLibPlugin *plugin = ht_pp_find (core->lib->plugins_ht, cp->meta.name, &found);
+					RLibPlugin *plugin = ht_pp_find (core->lib->plugins_ht[R_LIB_TYPE_CORE], cp->meta.name, &found);
 					if (found && plugin) {
 						if (plugin->file) {
 							pj_ks (pj, "path", plugin->file);

--- a/libr/include/r_lib.h
+++ b/libr/include/r_lib.h
@@ -129,7 +129,7 @@ typedef struct r_lib_t {
 	bool ignore_abiversion;
 	bool safe_loading; /* true to enable 2-step loading process */
 	// hashtable plugname = &plugin
-	HtPP *plugins_ht;
+	HtPP *plugins_ht[R_LIB_TYPE_LAST];
 	ut32 abiversion; /* Current ABI version */
 } RLib;
 


### PR DESCRIPTION
This change allows loading user plugins with the same meta.name but different types.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
This solves the problem, but needs review.
