### PR TITLE
Fix iter page underflow in le parser ##bin

### DIFF
--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -320,7 +320,11 @@ static void __create_iter_sections(RList *l, RBinLEObj *bin, RBinSection *sec, L
 			r_list_append (l, s);
 			iter_cnt++;
 		}
-		bytes_left -= sizeof (ut16) * 2 + data_size;
+		ut64 consumed = sizeof (ut16) * 2 + data_size;
+		if (consumed > bytes_left) {
+			break;
+		}
+		bytes_left -= consumed;
 		// Get the next iter record
 		offset += data_size;
 		iter_n = r_buf_read_ble16_at (bin->buf, offset, h->worder);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

bytes_left can wrap around when consumed > bytes_left, add check. Found while testing crafted LX binaries with iterated pages.
