### PR TITLE
Add bounds check for MDMP comment stream size ##bin

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -644,6 +644,9 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case COMMENT_STREAM_A:
 		/* TODO: Not yet fully parsed or utilised */
+		if (entry->location.data_size < 1 || entry->location.data_size > r_buf_size (obj->b)) {
+			break;
+		}
 		obj->streams.comments_a = R_NEWS (ut8, entry->location.data_size);
 		if (!obj->streams.comments_a) {
 			break;
@@ -661,6 +664,9 @@ static bool r_bin_mdmp_init_directory_entry(struct r_bin_mdmp_obj *obj, struct m
 		break;
 	case COMMENT_STREAM_W:
 		/* TODO: Not yet fully parsed or utilised */
+		if (entry->location.data_size < 1 || entry->location.data_size > r_buf_size (obj->b)) {
+			break;
+		}
 		obj->streams.comments_w = R_NEWS (ut8, entry->location.data_size);
 		if (!obj->streams.comments_w) {
 			break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #25398. Validate data_size against buffer size before allocating comment stream data to prevent excessive memory usage from malformed minidump files.
