### PR TITLE
Sanitize callconv in fcn_print_detail output ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3398,11 +3398,14 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	if (fcn->bits != 0) {
 		r_cons_printf (cons, "'@0x%08"PFMT64x"'afB %d\n", fcn->addr, fcn->bits);
 	}
-	// FIXME command injection vuln here
 	if (fcn->callconv || defaultCC) {
-		r_cons_printf (cons, "s 0x%"PFMT64x"\n", fcn->addr);
-		r_cons_printf (cons, "'afc %s\n", fcn->callconv? fcn->callconv: defaultCC);
-		r_cons_println (cons, "s-");
+		char *cc = r_str_sanitize_r2 (fcn->callconv? fcn->callconv: defaultCC);
+		if (cc) {
+			r_cons_printf (cons, "s 0x%"PFMT64x"\n", fcn->addr);
+			r_cons_printf (cons, "'afc %s\n", cc);
+			r_cons_println (cons, "s-");
+			free (cc);
+		}
 	}
 	if (fcn->folded) {
 		r_cons_printf (cons, "afF @ 0x%08"PFMT64x"\n", fcn->addr);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

callconv string was not sanitized in afl* output, use r_str_sanitize_r2 to prevent command injection when replaying output
