### PR TITLE
Fix #13937: rahash2 -R sdb output

### DIFF
--- a/libr/main/rahash2.c
+++ b/libr/main/rahash2.c
@@ -678,6 +678,10 @@ R_API int r_main_rahash2(int argc, const char **argv) {
 			ret (1);
 		}
 	}
+	if (rad == 3 && !ro->incremental) {
+		R_LOG_ERROR ("Option -R incompatible with -B (per-block hashing)");
+		ret (1);
+	}
 	ro->mode = rad;
 	if ((st64)ro->from >= 0 && (st64)ro->to < 0) {
 		ro->to = 0; // end of file

--- a/man/rahash2.1
+++ b/man/rahash2.1
@@ -70,6 +70,12 @@ $ rahash2 -a sha1 -r file | r2 -qni file
 .Bd -literal -offset indent
 $ rahash2 -a sha1 -R file | r2 -qni file
 .Ed
+.Pp
+.Nm
+.Fl R
+is incompatible with
+.Fl B
+(per-block hashing).
 .It Fl s Ar string
 Hash this string instead of files
 .It Fl t Ar to

--- a/test/db/tools/rahash2
+++ b/test/db/tools/rahash2
@@ -84,6 +84,15 @@ bins/elf/analysis/hello-linux-x86_64: k file.sha256=7bdbf25324af1946ec0b16dbf928
 EOF
 RUN
 
+NAME=rahash2 -R -B rejected
+FILE=-
+CMDS=!rahash2 -a md5 -R -B bins/elf/analysis/hello-linux-x86_64
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Option -R incompatible with -B (per-block hashing)
+EOF
+RUN
+
 NAME=rahash2 -h
 FILE=-
 CMDS=!rahash2~Usage


### PR DESCRIPTION
This improves the usefulness of rahash2's radare output without breaking existing users.

Changes:
- Keep -r output unchanged for backward compatibility.
- Add -R to emit radare2 sdb commands (k file.<algo>=...) so hashes can be stored for any algorithm name.
- Update manpage and add r2r tests.

Rationale:
The issue report expected an e file.<algo>=... style output, but changing -r would be a breaking output change. -R provides a stable, directly usable output for r2 pipelines.
