### PR TITLE
Fix UB cast in container_of macro ##crash

### DIFF
--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -750,7 +750,7 @@ static inline void r_run_call10(void *fcn, void *arg1, void *arg2, void *arg3, v
 }
 
 #ifndef container_of
-#define container_of(ptr, type, member) (ptr? ((type *)((char *)(ptr) - r_offsetof(type, member))): NULL)
+#define container_of(ptr, type, member) ((ptr)? ((type *)(void *)((char *)(ptr) - r_offsetof(type, member))): NULL)
 #endif
 
 #endif // R2_TYPES_H


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
