### PR TITLE
Fix #12007 (partially): use RVec for RLog callbacks

### DIFF
--- a/libr/include/r_util/r_log.h
+++ b/libr/include/r_util/r_log.h
@@ -2,7 +2,10 @@
 #define R_LOG_H
 
 #include <r_userconf.h>
-#include <r_list.h>
+#include <r_types.h>
+#include <stdarg.h>
+// NOTE: avoid including <r_vec.h> here because it includes r_assert.h, which
+// includes this header, causing a circular dependency.
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +42,8 @@ typedef enum r_log_level {
 
 typedef bool (*RLogCallback)(void *user, int type, const char *origin, const char *msg);
 
+typedef struct r_vec_RVecRLogCallbackUser_t RVecRLogCallbackUser;
+
 typedef struct r_log_t {
 	int level; // skip messages lower than this level
 	int traplevel; // skip messages lower than this level
@@ -50,7 +55,7 @@ typedef struct r_log_t {
 	bool show_origin;
 	bool show_source;
 	bool show_ts;
-	RList *cbs;
+	RVecRLogCallbackUser *cbs;
 	PrintfCallback cb_printf;
 } RLog;
 


### PR DESCRIPTION
Partially addresses #12007.

This PR migrates the internal RLog callback storage from RList to the newer RVec implementation.

Changes:
- Store callbacks in an RVec (less allocation per callback, simpler iteration).
- Keep r_log_add_callback/r_log_del_callback API unchanged.
- Add a unit test to ensure r_log_del_callback unregisters callbacks.

Note:
This does not yet integrate REvent logging.
