### PR TITLE
Fix #12007 (partially): send RLog via REvent

### DIFF
--- a/libr/include/r_event.h
+++ b/libr/include/r_event.h
@@ -204,6 +204,9 @@ typedef enum {
 	R_EVENT_CORE_TASK_FINISHED,
 	R_EVENT_CORE_TASK_INTERRUPTED,
 
+	// util
+	R_EVENT_LOG,
+
 	R_EVENT_LAST,
 } REventType;
 
@@ -270,6 +273,14 @@ typedef struct r_event_msg_t {
 	void *data;
 	size_t data_len;
 } REventMessage;
+
+typedef struct r_event_log_t {
+	int level;
+	const char *origin;
+	const char *func;
+	int line;
+	const char *msg;
+} REventLog;
 
 typedef struct r_event_t REvent;
 typedef void (*REventCallback)(REvent *ev, int type, void *user, void *data);

--- a/libr/include/r_util/r_log.h
+++ b/libr/include/r_util/r_log.h
@@ -60,6 +60,8 @@ typedef struct r_log_source_t {
 	const char *source;
 } RLogSource;
 
+typedef struct r_event_t REvent;
+
 R_API bool r_log_init(void);
 R_API void r_log_fini(void);
 R_API bool r_log_match(int level, const char *origin);
@@ -67,6 +69,7 @@ R_API void r_log_message(RLogLevel level, const char *origin, const char *func, 
 R_API void r_log_vmessage(RLogLevel level, const char *origin, const char *func, int line, const char *fmt, va_list ap);
 R_API void r_log_add_callback(RLogCallback cb, void *user);
 R_API void r_log_del_callback(RLogCallback cb);
+R_API REvent *r_log_event(void);
 
 #if R_LOG_DISABLE
 #define R_LOG(f,...) do {} while(0)


### PR DESCRIPTION
Partially addresses #12007.

This PR integrates RLog with the existing REvent API.

Changes:
- Add R_EVENT_LOG and an REventLog payload.
- Add r_log_event() accessor to lazily create a thread-local REvent bus for logging.
- Emit R_EVENT_LOG from r_log_vmessage() only when the bus exists (no overhead otherwise).
- Add a unit test that hooks R_EVENT_LOG and validates delivery/unhook.
