### PR TITLE
Fix resource leaks in NE format parser ##bin

### DIFF
--- a/libr/bin/format/ne/ne.c
+++ b/libr/bin/format/ne/ne.c
@@ -295,7 +295,7 @@ RList *r_bin_ne_get_imports(r_bin_ne_obj_t *bin) {
 		off++;
 		char *name = malloc ((ut64)sz + 1);
 		if (!name) {
-			break;
+			r_bin_import_free (imp); break;
 		}
 		r_buf_read_at (bin->buf, off, (ut8 *)name, sz);
 		name[sz] = '\0';
@@ -437,11 +437,11 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin) {
 			// && off + sizeof (NE_image_reloc_item) < buf_size)
 			NE_image_reloc_item rel = {0};
 			if (r_buf_fread_at (bin->buf, off, (ut8 *)&rel, "2c3s", 1) < 1) {
-				return NULL;
+				free (modref); return NULL;
 			}
 			RBinReloc *reloc = R_NEW0 (RBinReloc);
 			if (!reloc) {
-				return NULL;
+				free (modref); return NULL;
 			}
 			reloc->paddr = seg->paddr + rel.offset;
 			reloc->ntype = rel.type;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix a couple of leaks in the NE parser 

 - missing `r_bin_import_free` on malloc failure in `r_bin_ne_get_imports`
 - `modref` not freed on early return in `r_bin_ne_get_relocs`

also noticed some deeper ownership/lifecycle issues with entries, segments and symbols lists ,they get allocated multiple times without freeing the old ones. tried caching but that causes UAF since the framework takes ownership. @trufae want me to look into this more or should it be a separate refactor?
