### PR TITLE
Fix memory leak in main_print_var

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -399,6 +399,7 @@ static int main_print_var(const char *var_name) {
 	free (libdir);
 	free (bindir);
 	free (mandir);
+	free (docdir);
 	free (confighome);
 	free (historyhome);
 	free (datahome);


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

AddressSanitizer catched this

```sh
==268683==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 18 byte(s) in 1 object(s) allocated from:
	  #0 0x78ce7cb1bf08 in strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:593
	  #1 0x78ce7c393cc5 in main_print_var ../libr/main/radare2.c:334
	  #2 0x78ce7c3972c2 in r_main_radare2 ../libr/main/radare2.c:805
	  #3 0x5ce0b78254ea in main ../binr/radare2/radare2.c:119
	  #4 0x78ce7c02a574 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
	  #5 0x78ce7c02a627 in __libc_start_main_impl ../csu/libc-start.c:360
	  #6 0x5ce0b7824cd4 in _start (/home/user/.local/bin/radare2+0x14cd4) (BuildId: 517f13968e6e09f3e49f3ae44aac2b7b22f0eb6f)

SUMMARY: AddressSanitizer: 18 byte(s) leaked in 1 allocation(s).
```
