### PR TITLE
Fix null pointer dereference in sanitize_c_identifier

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1534,7 +1534,9 @@ static char *sanitize_c_identifier(const char *name) {
 	R_RETURN_VAL_IF_FAIL (name, NULL);
 	const size_t len = strlen (name);
 	char *out = malloc (len + 2);
-	R_RETURN_VAL_IF_FAIL (out, NULL);
+	if (!out) {
+		return NULL;
+	}
 	size_t j = 0;
 	size_t i;
 	for (i = 0; i < len; i++) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
