### PR TITLE
Prevent clang-format-radare2 failing with cross-device errors ##build

### DIFF
--- a/sys/clang-format-radare2
+++ b/sys/clang-format-radare2
@@ -642,7 +642,7 @@ def format_file(path, clang_format, style_file, check_only=False):
 	if check_only:
 		show_diff(path, original, indented)
 		return True
-	with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+	with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=os.path.dirname(path)) as tmp:
 		tmp.write(indented)
 		temp_name = tmp.name
 	os.replace(temp_name, path)


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

clang-format-radare2 uses os.replace to atomically replace the file being reformatted with the temporary file containing clang-format's output. Unfortunately os.replace only works if the source and destination files are in the same filesystem. As the output file is created with tempfile.NamedTemporaryFile, it is (at least for me on Linux fedora) always in a tmpfs filesystem, and so the script always errors out.

The solution is to create the temporary file in the same directory as the file being reformatted.