### PR TITLE
#dbg skip leading whitespace in visual panel mode layout filenames when sa…

### DIFF
--- a/libr/core/panels.c
+++ b/libr/core/panels.c
@@ -6637,7 +6637,7 @@ R_API void r_core_panels_save(RCore *core, const char *oname) {
 	if (!core->panels) {
 		return;
 	}
-	const char *name = oname;
+	const char *name = r_str_trim_head_ro (oname); // leading whitespace skipped
 	if (R_STR_ISEMPTY (name)) {
 		name = __show_status_input (core, "Name for the layout: ");
 		if (R_STR_ISEMPTY (name)) {


### PR DESCRIPTION
- [x ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
While pursuing `~/.local/share/radare2/r2panels` i noticed that `v= layout`  saves with a leading space.
```
~/.../radare2/r2panels >>> ls
' layout'
``` 
This skips leading whitespace for the filename.