### PR TITLE
Harden Mach-O entitlement bounds checks

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -931,7 +931,7 @@ static bool parse_signature(struct MACH0_(obj_t) * mo, ut64 off) {
 	link.datasize = r_read_ble32 (&lit[12], mo->big_endian);
 
 	data = link.dataoff;
-	if (link.datasize < sizeof (struct super_blob_t)) {
+	if (link.datasize < sizeof (struct super_blob_t) || !fits_in (mo->size, data, link.datasize)) {
 		set_malformed_entitlement (mo);
 		return true;
 	}
@@ -989,6 +989,10 @@ static bool parse_signature(struct MACH0_(obj_t) * mo, ut64 off) {
 		case CSSLOT_ENTITLEMENTS:
 			{
 				struct blob_t entitlements = { 0 };
+				if (!fits_in (mo->size, slot_off, sizeof (struct blob_t))) {
+					set_malformed_entitlement (mo);
+					break;
+				}
 				entitlements.magic = r_buf_read_ble32_at (mo->b, slot_off, mach0_endian);
 				entitlements.length = r_buf_read_ble32_at (mo->b, slot_off + 4, mach0_endian);
 				if (entitlements.length <= sizeof (struct blob_t) || entitlements.length > super.blob.length || idx.offset > super.blob.length - entitlements.length) {
@@ -997,6 +1001,10 @@ static bool parse_signature(struct MACH0_(obj_t) * mo, ut64 off) {
 				}
 				ut32 ent_size = entitlements.length - sizeof (struct blob_t);
 				if (ent_size <= 1) {
+					set_malformed_entitlement (mo);
+					break;
+				}
+				if (!fits_in (mo->size, slot_off + sizeof (struct blob_t), ent_size)) {
 					set_malformed_entitlement (mo);
 					break;
 				}


### PR DESCRIPTION
### Motivation
- The Mach-O codesign parser trusted attacker-controlled `link.datasize` and `super.blob.length` without ensuring the codesign region fits inside the actual file buffer, which can be abused to force oversized allocations.
- Entitlement parsing used `entitlements.length` to compute `ent_size` and allocated `mo->signature` before verifying the entitlement payload exists, enabling memory-exhaustion DoS on crafted files.
- The change aims to prevent large allocations and out-of-bounds reads by validating ranges against the real Mach-O buffer size before parsing or allocating.

### Description
- Add a check `fits_in (mo->size, data, link.datasize)` in `parse_signature` to ensure the `LC_CODE_SIGNATURE` payload is fully inside the Mach-O buffer in `libr/bin/format/mach0/mach0.c`. 
- Add `fits_in` verification that the entitlement blob header fits before reading `entitlements.length` and that the entitlement payload fits before allocating `mo->signature` in `libr/bin/format/mach0/mach0.c`.
- Preserve existing error handling by calling `set_malformed_entitlement (mo)` when checks fail so behavior for malformed signatures remains consistent.

### Testing
- Ran `./configure --prefix=/tmp/r2build`, which completed successfully.
- Ran `make -j2`, which failed due to environment network restrictions when cloning subprojects (`sdb` and `qjs`), so no build artifacts were produced.
- No automated runtime tests could be executed in this environment because the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bd8f0b888331a352601a9561a622)