### PR TITLE
Fix autocomplete NULL deref

### DIFF
--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1228,6 +1228,7 @@ static bool find_e_opts(RCore *core, RLineCompletion *completion, RLineBuffer *b
 
 static bool find_autocomplete(RCore *core, RLineCompletion *completion, RLineBuffer *buf) {
 	RCoreAutocomplete *child = NULL;
+	ensure_autocomplete (core);
 	RCoreAutocomplete *parent = core->autocomplete;
 	const char *p = buf->data;
 	if (!*p) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Depending on how autocomplete is used, you can end up with `core->autocomplete == NULL` causing `autocomplete->types` to segfualt in `find_autocomplete`.

This will occur if right after starting r2 you type `s <TAB>`. If you TAB complete by itself then autocomplete takes a different code path where initialization is done properly. At that point, `s <TAB>` will work.

This is a probably not the best way to fix this, but it is a fix.