### PR TITLE
Fix invalid mem free when one DIE has two or more DW_AT_name attributes ##bin #25537

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -747,7 +747,6 @@ static void parse_atomic_type(Context *ctx, ut64 idx) {
 	R_VEC_FOREACH(die->attr_values, value) {
 		switch (value->attr_name) {
 		case DW_AT_name:
-			R_FREE (name);
 			if (value->kind == DW_AT_KIND_STRING) {
 				if (!value->string.content) {
 					name = create_type_name_from_offset (ctx->arena, die->offset);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes #25537

## Analysis (Copied from issue description):
Abort/Crash happens because the DWARF DIE (in the PoC provided it's at offset 0xA8) contains two or more DW_AT_name entries.  
In the PoC provided, the first DW_AT_name encountered, the code returns a string created with _**create_type_name_from_offset**_ (see **libr/anal/dwarf_process.c:753**), the second time a DW_AT_name is encountered, the arena allocated string is free'd which is incorrect.  
There are two cases, one where name points to a string inside of the arena, another where the string points inside en element in the _**RVecDwarfAttrValue**_ vector.  
In both cases, doing R_FREE(name) ( **libr/anal/dwarf_process.c:750** ) is incorrect.  