### PR TITLE
Fix null deref in the PEF parser ##crash

### DIFF
--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -789,6 +789,9 @@ static RList *libs(RBinFile *bf) {
 }
 
 static void **flatlist(RList *list) {
+	if (!list) {
+		return NULL;
+	}
 	size_t len = r_list_length (list);
 	if (len == 0) {
 		return NULL;
@@ -808,12 +811,10 @@ static RList *relocs(RBinFile *bf) {
 	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
 	RList *importList = imports (bf); // Import linked-list
 	void **importArray = flatlist (importList); // Indexable import list
+	size_t importCount = importList ? (size_t)r_list_length (importList) : 0;
 	PEFReloc *r;
 	RListIter *iter;
 	int i;
-	if (!importArray) {
-		return NULL;
-	}
 
 	for (i = 0; i < pef->nsec; i++) {
 		r_list_foreach (pef->sec[i].relocs, iter, r) {
@@ -822,7 +823,7 @@ static RList *relocs(RBinFile *bf) {
 			ptr->additive = 1;
 			ptr->vaddr = pef->sec[i].addr + r->offset;
 			if (r->isimport) {
-				if (r->target >= r_list_length (importList)) {
+				if (!importArray || r->target >= importCount) {
 					free (ptr);
 					continue;
 				}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
