### PR TITLE
Simplify dist/iso build flow to bare essentials

### DIFF
--- a/dist/iso/Makefile
+++ b/dist/iso/Makefile
@@ -1,91 +1,28 @@
 SHELL := /bin/sh
-
 include config.mk
 
-.PHONY: all iso run run-usb clean help
+.PHONY: all iso run clean help
 
 all: iso
 
 iso:
 	docker run --rm --privileged \
-		--platform "$(DOCKER_PLATFORM)" \
+		-v "$(CURDIR):/src" -w /src \
 		-e ISO_NAME="$(ISO_NAME)" \
-		-e OUTPUT_DIR="$(OUTPUT_DIR)" \
-		-e WORK_DIR="$(WORK_DIR)" \
 		-e DEBIAN_RELEASE="$(DEBIAN_RELEASE)" \
 		-e ARCH="$(ARCH)" \
-		-e BOOTLOADERS="$(BOOTLOADERS)" \
+		-e OUTPUT_DIR="$(OUTPUT_DIR)" \
+		-e WORK_DIR="$(WORK_DIR)" \
 		-e R2_GIT_URL="$(R2_GIT_URL)" \
 		-e R2_GIT_REF="$(R2_GIT_REF)" \
 		-e R2PM_PLUGINS="$(R2PM_PLUGINS)" \
-		-e KEEP_R2_SOURCE="$(KEEP_R2_SOURCE)" \
-		-e KEEP_R2PM_CACHE="$(KEEP_R2PM_CACHE)" \
-		-e ROOTFS_DIR="$(ROOTFS_DIR)" \
-		-e BOOT_BRANDING_DIR="$(BOOT_BRANDING_DIR)" \
-		-e ISO_MOTD="$(ISO_MOTD)" \
-		-e ROOT_PASSWORD_MODE="$(ROOT_PASSWORD_MODE)" \
-		-e ROOT_PASSWORD="$(ROOT_PASSWORD)" \
-		-e HOST_BUILD_PACKAGES="$(HOST_BUILD_PACKAGES)" \
-		-e ISO_CHROOT_PACKAGES="$(ISO_CHROOT_PACKAGES)" \
-		-e ISO_CHROOT_PURGE_PACKAGES="$(ISO_CHROOT_PURGE_PACKAGES)" \
-		-e SOURCE_DIR="$(CONTAINER_WORKDIR)" \
-		-e BUILD_ROOT="$(CONTAINER_BUILD_ROOT)" \
-		-v "$(CURDIR):$(CONTAINER_WORKDIR)" \
-		-w "$(CONTAINER_WORKDIR)" \
-		"$(DOCKER_IMAGE)" \
-		/bin/bash "./$(BUILD_SCRIPT)"
+		"$(DOCKER_IMAGE)" /bin/bash ./scripts/build-iso.sh
 
 run:
-	@if [ "$(ARCH)" = "amd64" ]; then \
-		qemu-system-x86_64 -m "$(QEMU_MEMORY)" -boot d -cdrom "$(ISO_PATH)"; \
-	elif [ "$(ARCH)" = "arm64" ] || [ "$(ARCH)" = "aarch64" ]; then \
-		if [ -z "$(QEMU_AARCH64_EFI)" ]; then \
-			echo "Set QEMU_AARCH64_EFI to an AArch64 UEFI firmware file (example: /opt/homebrew/share/qemu/edk2-aarch64-code.fd)"; \
-			exit 1; \
-		fi; \
-		qemu-system-aarch64 -M virt -cpu cortex-a72 -m "$(QEMU_MEMORY)" -bios "$(QEMU_AARCH64_EFI)" -cdrom "$(ISO_PATH)"; \
-	else \
-		echo "Unsupported ARCH='$(ARCH)'"; \
-		exit 1; \
-	fi
-
-run-usb: iso
-	@if [ "$(ARCH)" = "amd64" ]; then \
-		qemu-system-x86_64 -m "$(QEMU_MEMORY)" -machine q35 -device qemu-xhci -drive if=none,id=usbstick,format=raw,file="$(ISO_PATH)" -device usb-storage,drive=usbstick -boot c; \
-	else \
-		echo "run-usb target currently supports ARCH=amd64 only"; \
-		exit 1; \
-	fi
+	qemu-system-x86_64 -m "$(QEMU_MEMORY)" -boot d -cdrom "$(ISO_PATH)"
 
 clean:
 	rm -rf build output
 
 help:
-	@printf '%s\n' \
-		'Targets:' \
-		'  make            Build Debian live ISO with radare2 and r2pm plugins' \
-		'  make run        Boot generated ISO in QEMU as CD-ROM (architecture-aware)' \
-		'  make run-usb    Boot generated ISO in QEMU as a raw disk (hybrid USB check)' \
-		'  make clean      Remove build artifacts and generated ISOs' \
-		'' \
-		'Variables (override with make VAR=value):' \
-		'  Defaults are set in dist/iso/config.mk' \
-		'  ISO_NAME         Output ISO basename (default: r2iso)' \
-		'  DEBIAN_RELEASE   Debian suite (default: bookworm)' \
-		'  ARCH             Debian architecture (default: amd64)' \
-		'  DOCKER_PLATFORM  Container architecture (auto from ARCH)' \
-		'  BOOTLOADERS      live-build bootloaders (auto by ARCH if empty)' \
-		'  R2_GIT_REF       radare2 git ref (default: master)' \
-		'  R2PM_PLUGINS     Space-separated plugins (default: r2dec)' \
-		'  QEMU_MEMORY      RAM for make run targets in MB (default: 4096)' \
-		'  QEMU_AARCH64_EFI Required only for make run ARCH=arm64' \
-		'  KEEP_R2_SOURCE   Keep /usr/src/radare2 in final ISO (0|1, default: 0)' \
-		'  KEEP_R2PM_CACHE  Keep r2pm cache in final ISO (0|1, default: 0)' \
-		'  ROOTFS_DIR       Overlay dir copied into final ISO rootfs (default: rootfs)' \
-		'  BOOT_BRANDING_DIR Bootloader branding assets dir (default: assets/boot)' \
-		'  ISO_MOTD         /etc/motd text written into final ISO rootfs' \
-		'  ROOT_PASSWORD_MODE Root password policy: empty|password|locked' \
-		'  ROOT_PASSWORD    Used when ROOT_PASSWORD_MODE=password' \
-		'  HOST_BUILD_PACKAGES      Packages installed in builder container' \
-		'  ISO_CHROOT_PACKAGES      Packages installed in final ISO rootfs' \
-		'  ISO_CHROOT_PURGE_PACKAGES Packages purged after radare2 install'
+	@echo "make [iso|run|clean]"

--- a/dist/iso/README.md
+++ b/dist/iso/README.md
@@ -1,6 +1,6 @@
 # R2ISO
 
-Build a small Debian live ISO with the latest `radare2` from git and optional `r2pm` plugins.
+Minimal Debian live ISO builder for radare2.
 
 ## Usage
 
@@ -8,99 +8,20 @@ Build a small Debian live ISO with the latest `radare2` from git and optional `r
 make
 ```
 
-All defaults are centralized in `dist/iso/config.mk`.
-Files under `dist/iso/rootfs/` are copied directly into the ISO root filesystem.
-
-Default build architecture is `amd64` (x86_64).
-
-To build ARM64 explicitly:
+Optional overrides:
 
 ```sh
-make ARCH=arm64
+make R2_GIT_REF=master R2PM_PLUGINS="r2dec"
 ```
 
-The ISO will be written to `output/` as:
+Output file:
 
 ```text
-<ISO_NAME>-<DEBIAN_RELEASE>-<ARCH>.iso
+output/<ISO_NAME>-<DEBIAN_RELEASE>-<ARCH>.iso
 ```
 
-## Main Makefile Variables
-
-Override variables like:
-
-```sh
-make R2_GIT_REF=master R2PM_PLUGINS="r2ghidra r2frida"
-```
-
-- `ISO_NAME`: output ISO basename (`r2iso`)
-- `DEBIAN_RELEASE`: Debian suite (`bookworm`)
-- `ARCH`: Debian architecture (`amd64` by default, use `arm64` if needed)
-- `BOOTLOADERS`: override live-build bootloaders (default auto: `syslinux,grub-efi` for amd64, `grub-efi` for arm64)
-- `R2_GIT_URL`: radare2 git URL
-- `R2_GIT_REF`: git branch/tag/commit to build (`master`)
-- `R2PM_PLUGINS`: space-separated plugin list
-- `KEEP_R2_SOURCE`: keep `/usr/src/radare2` in final ISO (`0`/`1`)
-- `KEEP_R2PM_CACHE`: keep r2pm cache in final ISO (`0`/`1`)
-- `ROOTFS_DIR`: overlay directory copied into the final rootfs (`rootfs`)
-- `BOOT_BRANDING_DIR`: bootloader branding assets directory (`assets/boot`)
-- `ISO_MOTD`: text written to `/etc/motd`
-- `ROOT_PASSWORD_MODE`: root password policy (`empty`, `password`, or `locked`)
-- `ROOT_PASSWORD`: root password when `ROOT_PASSWORD_MODE=password`
-- `HOST_BUILD_PACKAGES`: packages installed in the builder container
-- `ISO_CHROOT_PACKAGES`: packages installed in final ISO rootfs
-- `ISO_CHROOT_PURGE_PACKAGES`: packages purged after building radare2
-
-Default `ISO_CHROOT_PACKAGES` includes the tools needed by `r2pm` plugin builds:
-`gcc`, `meson`, `ninja` (`ninja-build` package), `git`, and `vim`.
-
-Default overlay includes `rootfs/etc/r2ascii.txt` and `rootfs/etc/profile.d/r2ascii.sh`
-to display the ASCII banner from `doc/r2ascii.txt` before the shell prompt.
-
-Default login is `root` / `radare2` (`ROOT_PASSWORD_MODE=password`).
-
-## QEMU Testing
-
-For x86_64 ISO (default):
+## Run in QEMU (amd64)
 
 ```sh
 make run
 ```
-
-This uses `qemu-system-x86_64` with `-cdrom`.
-
-Important:
-- `qemu-system-x86_64 -hda output/r2iso-bookworm-arm64.iso` is not correct for your arm64 ISO.
-- `-hda` is for disk images, not ISO CD media.
-- `qemu-system-x86_64` cannot boot an `arm64` ISO.
-
-If you build `ARCH=arm64`, use:
-
-```sh
-make run ARCH=arm64 QEMU_AARCH64_EFI=/path/to/edk2-aarch64-code.fd
-```
-
-You can also test hybrid/USB-style boot for x86_64 with:
-
-```sh
-make run-usb
-```
-
-## Flashing To USB
-
-The generated image is `iso-hybrid`, so it is directly writable to a pendrive.
-
-Example (`/dev/sdX` is your USB disk, not a partition):
-
-```sh
-sudo dd if=output/r2iso-bookworm-amd64.iso of=/dev/sdX bs=4M status=progress conv=fsync
-sync
-```
-
-## Cleaning
-
-```sh
-make clean
-```
-
-Removes generated build workspace and output artifacts.

--- a/dist/iso/config.mk
+++ b/dist/iso/config.mk
@@ -1,34 +1,12 @@
 DOCKER_IMAGE ?= debian:bookworm
-CONTAINER_WORKDIR ?= /work
-CONTAINER_BUILD_ROOT ?= /tmp/r2iso-build
-BUILD_SCRIPT ?= scripts/build-iso.sh
-
 ISO_NAME ?= r2iso
-OUTPUT_DIR ?= output
-WORK_DIR ?= build/live-build
 DEBIAN_RELEASE ?= bookworm
 ARCH ?= amd64
-DOCKER_PLATFORM ?= $(if $(filter amd64,$(ARCH)),linux/amd64,$(if $(filter arm64 aarch64,$(ARCH)),linux/arm64,linux/amd64))
+OUTPUT_DIR ?= output
+WORK_DIR ?= build/live-build
 ISO_PATH ?= $(OUTPUT_DIR)/$(ISO_NAME)-$(DEBIAN_RELEASE)-$(ARCH).iso
-QEMU_MEMORY ?= 4096
-QEMU_AARCH64_EFI ?=
-BOOTLOADERS ?=
 
 R2_GIT_URL ?= https://github.com/radareorg/radare2.git
 R2_GIT_REF ?= master
 R2PM_PLUGINS ?=
-# R2PM_PLUGINS ?= r2dec r2ghidra r2frida
-KEEP_R2_SOURCE ?= 0
-KEEP_R2PM_CACHE ?= 0
-ROOTFS_DIR ?= rootfs
-BOOT_BRANDING_DIR ?= assets/boot
-ISO_MOTD ?= Welcome to r2iso
-# ROOT_PASSWORD_MODE: empty | password | locked
-ROOT_PASSWORD_MODE ?= password
-ROOT_PASSWORD ?= radare2
-
-HOST_BUILD_PACKAGES ?= ca-certificates cpio curl debootstrap git live-build mtools squashfs-tools syslinux-common xorriso
-
-ISO_CHROOT_PACKAGES ?= ca-certificates curl file git gcc meson ninja-build vim libcapstone-dev liblz4-dev libmagic-dev libssl-dev libuv1-dev libxxhash-dev libzstd-dev libzip-dev make pkg-config python3 wget zlib1g-dev build-essential
-
-ISO_CHROOT_PURGE_PACKAGES ?= build-essential libcapstone-dev liblz4-dev libmagic-dev libssl-dev libuv1-dev libxxhash-dev libzstd-dev libzip-dev zlib1g-dev
+QEMU_MEMORY ?= 4096

--- a/dist/iso/scripts/build-iso.sh
+++ b/dist/iso/scripts/build-iso.sh
@@ -1,193 +1,42 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eu
 
-SOURCE_DIR="${SOURCE_DIR:-$(pwd)}"
-BUILD_ROOT="${BUILD_ROOT:-/tmp/r2iso-build}"
 ISO_NAME="${ISO_NAME:-r2iso}"
-OUTPUT_DIR="${OUTPUT_DIR:-output}"
-WORK_DIR="${WORK_DIR:-build/live-build}"
 DEBIAN_RELEASE="${DEBIAN_RELEASE:-bookworm}"
 ARCH="${ARCH:-amd64}"
+OUTPUT_DIR="${OUTPUT_DIR:-output}"
+WORK_DIR="${WORK_DIR:-build/live-build}"
 R2_GIT_URL="${R2_GIT_URL:-https://github.com/radareorg/radare2.git}"
 R2_GIT_REF="${R2_GIT_REF:-master}"
-R2PM_PLUGINS="${R2PM_PLUGINS}" # :-r2dec}"
-KEEP_R2_SOURCE="${KEEP_R2_SOURCE:-0}"
-KEEP_R2PM_CACHE="${KEEP_R2PM_CACHE:-0}"
-BOOTLOADERS="${BOOTLOADERS:-}"
-ROOTFS_DIR="${ROOTFS_DIR:-rootfs}"
-BOOT_BRANDING_DIR="${BOOT_BRANDING_DIR:-assets/boot}"
-ISO_MOTD="${ISO_MOTD:-Welcome to r2iso}"
-ROOT_PASSWORD_MODE="${ROOT_PASSWORD_MODE:-password}"
-ROOT_PASSWORD="${ROOT_PASSWORD:-radare2}"
-HOST_BUILD_PACKAGES="${HOST_BUILD_PACKAGES:-ca-certificates cpio curl debootstrap git live-build mtools squashfs-tools syslinux-common xorriso}"
-ISO_CHROOT_PACKAGES="${ISO_CHROOT_PACKAGES:-ca-certificates curl file git gcc meson ninja-build vim libcapstone-dev liblz4-dev libmagic-dev libssl-dev libuv1-dev libxxhash-dev libzstd-dev libzip-dev make pkg-config python3 wget zlib1g-dev build-essential}"
-ISO_CHROOT_PURGE_PACKAGES="${ISO_CHROOT_PURGE_PACKAGES:-build-essential libcapstone-dev liblz4-dev libmagic-dev libssl-dev libuv1-dev libxxhash-dev libzstd-dev libzip-dev zlib1g-dev}"
+R2PM_PLUGINS="${R2PM_PLUGINS:-}"
 
-if [ "${KEEP_R2_SOURCE}" != "0" ] && [ "${KEEP_R2_SOURCE}" != "1" ]; then
-	echo "KEEP_R2_SOURCE must be 0 or 1" >&2
-	exit 1
-fi
-if [ "${KEEP_R2PM_CACHE}" != "0" ] && [ "${KEEP_R2PM_CACHE}" != "1" ]; then
-	echo "KEEP_R2PM_CACHE must be 0 or 1" >&2
-	exit 1
-fi
-if [ -z "${BOOTLOADERS}" ]; then
-	case "${ARCH}" in
-	amd64) BOOTLOADERS="syslinux,grub-efi" ;;
-	arm64|aarch64) BOOTLOADERS="grub-efi" ;;
-	*) BOOTLOADERS="grub-efi" ;;
-	esac
-fi
-if [ -z "${HOST_BUILD_PACKAGES}" ]; then
-	echo "HOST_BUILD_PACKAGES cannot be empty" >&2
-	exit 1
-fi
-if [ -z "${ISO_CHROOT_PACKAGES}" ]; then
-	echo "ISO_CHROOT_PACKAGES cannot be empty" >&2
-	exit 1
-fi
-case "${ROOT_PASSWORD_MODE}" in
-empty|password|locked) ;;
-*)
-	echo "ROOT_PASSWORD_MODE must be empty, password or locked" >&2
-	exit 1
-	;;
-esac
-if [ "${ROOT_PASSWORD_MODE}" = "password" ] && [ -z "${ROOT_PASSWORD}" ]; then
-	echo "ROOT_PASSWORD cannot be empty when ROOT_PASSWORD_MODE=password" >&2
-	exit 1
-fi
-
-case "${WORK_DIR}" in
-/*) WORK_ABS="${WORK_DIR}" ;;
-*) WORK_ABS="${BUILD_ROOT}/${WORK_DIR}" ;;
-esac
-
-echo "[*] Installing build dependencies in container"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y --no-install-recommends ${HOST_BUILD_PACKAGES}
+apt-get install -y --no-install-recommends ca-certificates git live-build
 
-echo "[*] Preparing live-build workspace at ${WORK_DIR}"
-rm -rf "${WORK_ABS}"
-mkdir -p "${WORK_ABS}" "${SOURCE_DIR:?}/${OUTPUT_DIR}"
-cd "${WORK_ABS}"
+rm -rf "${WORK_DIR}"
+mkdir -p "${WORK_DIR}" "${OUTPUT_DIR}"
+cd "${WORK_DIR}"
 
-lb config \
-	--mode debian \
-	--distribution "${DEBIAN_RELEASE}" \
-	--architectures "${ARCH}" \
-	--binary-images iso-hybrid \
-	--debian-installer none \
-	--bootloaders "${BOOTLOADERS}" \
-	--apt-recommends false \
-	--archive-areas "main"
-
-mkdir -p config/package-lists config/hooks/live config/includes.chroot/usr/local/sbin
-
-: > config/package-lists/r2iso.list.chroot
-for pkg in ${ISO_CHROOT_PACKAGES}; do
-	echo "${pkg}" >> config/package-lists/r2iso.list.chroot
-done
-
-install -m 0755 "${SOURCE_DIR}/scripts/install-r2pm-plugins.sh" \
-	"config/includes.chroot/usr/local/sbin/install-r2pm-plugins.sh"
-if [ -n "${ROOTFS_DIR}" ]; then
-	if [ ! -d "${SOURCE_DIR}/${ROOTFS_DIR}" ]; then
-		echo "ROOTFS_DIR does not exist: ${ROOTFS_DIR}" >&2
-		exit 1
-	fi
-	echo "[*] Copying rootfs overlay from ${ROOTFS_DIR}"
-	cp -a "${SOURCE_DIR}/${ROOTFS_DIR}/." config/includes.chroot/
-fi
-if [ -n "${ISO_MOTD}" ]; then
-	mkdir -p config/includes.chroot/etc
-	printf '%s\n' "${ISO_MOTD}" > config/includes.chroot/etc/motd
-fi
-if [ -n "${BOOT_BRANDING_DIR}" ]; then
-	if [ ! -d "${SOURCE_DIR}/${BOOT_BRANDING_DIR}" ]; then
-		echo "BOOT_BRANDING_DIR does not exist: ${BOOT_BRANDING_DIR}" >&2
-		exit 1
-	fi
-	echo "[*] Copying boot branding from ${BOOT_BRANDING_DIR}"
-	mkdir -p config/includes.binary/boot/grub/live-theme config/includes.binary/boot/grub config/includes.binary/isolinux
-	install -m 0644 "${SOURCE_DIR}/${BOOT_BRANDING_DIR}/grub-theme.txt" config/includes.binary/boot/grub/live-theme/theme.txt
-	install -m 0644 "${SOURCE_DIR}/${BOOT_BRANDING_DIR}/splash800x600.png" config/includes.binary/boot/grub/splash.png
-	install -m 0644 "${SOURCE_DIR}/${BOOT_BRANDING_DIR}/splash800x600.png" config/includes.binary/isolinux/splash800x600.png
-	install -m 0644 "${SOURCE_DIR}/${BOOT_BRANDING_DIR}/splash.png" config/includes.binary/isolinux/splash.png
+lb config --mode debian --distribution "${DEBIAN_RELEASE}" --architectures "${ARCH}" --binary-images iso-hybrid --debian-installer none
+mkdir -p config/hooks/live config/includes.chroot/usr/local/sbin
+install -m 0755 /src/scripts/install-r2pm-plugins.sh config/includes.chroot/usr/local/sbin/install-r2pm-plugins.sh
+if [ -d /src/rootfs ]; then
+	cp -a /src/rootfs/. config/includes.chroot/
 fi
 
-cat > config/hooks/live/010-build-radare2.chroot <<EOF
+cat > config/hooks/live/010-build-radare2.chroot <<HOOK
 #!/usr/bin/env bash
-set -euo pipefail
-
-R2_GIT_URL='${R2_GIT_URL}'
-R2_GIT_REF='${R2_GIT_REF}'
-R2PM_PLUGINS='${R2PM_PLUGINS}'
-KEEP_R2_SOURCE='${KEEP_R2_SOURCE}'
-KEEP_R2PM_CACHE='${KEEP_R2PM_CACHE}'
-ROOT_PASSWORD_MODE='${ROOT_PASSWORD_MODE}'
-ROOT_PASSWORD='${ROOT_PASSWORD}'
-ISO_CHROOT_PACKAGES='${ISO_CHROOT_PACKAGES}'
-ISO_CHROOT_PURGE_PACKAGES='${ISO_CHROOT_PURGE_PACKAGES}'
-
-export DEBIAN_FRONTEND=noninteractive
-mkdir -p /usr/src
-
-git clone --depth 1 --branch "\${R2_GIT_REF}" "\${R2_GIT_URL}" /usr/src/radare2 || {
-	git clone --depth 1 "\${R2_GIT_URL}" /usr/src/radare2
-	cd /usr/src/radare2
-	git fetch --depth 1 origin "\${R2_GIT_REF}"
-	git checkout FETCH_HEAD
-}
-
+set -eu
+git clone --depth 1 --branch "${R2_GIT_REF}" "${R2_GIT_URL}" /usr/src/radare2
 cd /usr/src/radare2
 ./configure --prefix=/usr
 make -j"\$(nproc)"
 make install
-
-/usr/local/sbin/install-r2pm-plugins.sh "\${R2PM_PLUGINS}"
-
-case "\${ROOT_PASSWORD_MODE}" in
-empty)
-	passwd -d root || true
-	usermod -p '' root || true
-	;;
-password)
-	echo "root:\${ROOT_PASSWORD}" | chpasswd
-	;;
-locked)
-	passwd -l root || true
-	;;
-esac
-
-apt-mark manual \${ISO_CHROOT_PACKAGES} >/dev/null 2>&1 || true
-if [ -n "\${ISO_CHROOT_PURGE_PACKAGES}" ]; then
-	apt-get purge -y \${ISO_CHROOT_PURGE_PACKAGES} || true
-fi
-apt-get autoremove -y
-apt-get clean
-rm -rf /var/lib/apt/lists/*
-
-if [ "\${KEEP_R2_SOURCE}" != "1" ]; then
-	rm -rf /usr/src/radare2
-fi
-if [ "\${KEEP_R2PM_CACHE}" != "1" ]; then
-	rm -rf /root/.cache/radare2 /root/.local/share/radare2
-fi
-EOF
+/usr/local/sbin/install-r2pm-plugins.sh "${R2PM_PLUGINS}"
+rm -rf /usr/src/radare2 /root/.cache/radare2 /root/.local/share/radare2
+HOOK
 chmod +x config/hooks/live/010-build-radare2.chroot
 
-echo "[*] Building ISO with live-build"
 lb build
-
-ISO_SOURCE="$(find . -maxdepth 1 -type f -name '*.iso' | head -n 1)"
-if [ -z "${ISO_SOURCE}" ]; then
-	echo "No ISO produced by live-build" >&2
-	exit 1
-fi
-
-ISO_TARGET="${SOURCE_DIR}/${OUTPUT_DIR}/${ISO_NAME}-${DEBIAN_RELEASE}-${ARCH}.iso"
-cp -f "${ISO_SOURCE}" "${ISO_TARGET}"
-
-echo "[+] ISO ready: ${ISO_TARGET}"
+cp -f ./*.iso "/src/${OUTPUT_DIR}/${ISO_NAME}-${DEBIAN_RELEASE}-${ARCH}.iso"


### PR DESCRIPTION
### Motivation

- Reduce the surface area and maintenance overhead of the ISO builder by removing advanced knobs, platform branching and overengineered plumbing while preserving the basic ISO build path.
- Make the `dist/` packaging scripts minimal and easy to reason about so the essential workflow (build radare2 in a container, produce an ISO, run in QEMU) remains available.

### Description

- Simplified `dist/iso/Makefile` to a minimal set of targets (`iso`, `run`, `clean`, `help`) and a straightforward `docker run` invocation that mounts the repo and runs the build script. 
- Reduced `dist/iso/config.mk` to only core variables required to build and run the ISO (image, release, arch, output/work paths, git refs, r2pm and QEMU memory). 
- Rewrote `dist/iso/scripts/build-iso.sh` to the essential steps: install minimal deps, configure `live-build`, add a concise chroot hook that clones and builds `radare2`, optionally installs `r2pm` plugins, and copies the produced ISO into `output/`. 
- Shortened `dist/iso/README.md` to document the simplified usage and output contract for the reduced interface.

### Testing

- Ran a shell syntax check on the build script with `bash -n dist/iso/scripts/build-iso.sh` which completed successfully. 
- Verified `make` help with `make -C dist/iso help`, which printed the simplified usage successfully. 
- Performed a dry-run of the `iso` target with `make -C dist/iso -n iso | head -n 40` to confirm the simplified Docker invocation, which showed the expected command and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b23fea9dc08331afbd137df112e7d2)