### PR TITLE
Fix 3 critical bugs in the regex engine ##crash

### DIFF
--- a/libr/util/regex/engine.c
+++ b/libr/util/regex/engine.c
@@ -155,7 +155,7 @@ static int matcher(struct re_guts *g, char *string, size_t nmatch, RRegexMatch p
 	m->beginp = start;
 	m->endp = stop;
 
-	if (m->g->nstates * 4 < m->g->nstates) {
+	if (m->g->nstates > LONG_MAX / 4) {
 		return R_REGEX_NOMATCH;
 	}
 	STATESETUP (m, 4);
@@ -574,10 +574,11 @@ static char *backref(struct match *m, char *start, char *stop, sopno startst, so
 	switch (OP (s)) {
 	case OBACK_:		/* the vilest depths */
 		i = OPND (s);
-		if (i > 0 && i <= m->g->nsub) {
-			if (m->pmatch[i].rm_eo == -1) {
-				return NULL;
-			}
+		if (i <= 0 || i > m->g->nsub) {
+			return NULL;
+		}
+		if (m->pmatch[i].rm_eo == -1) {
+			return NULL;
 		}
 		if (m->pmatch[i].rm_so != -1) {
 			len = m->pmatch[i].rm_eo - m->pmatch[i].rm_so;

--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -1374,7 +1374,7 @@ static void mcadd( struct parse *p, cset *cs, const char *cp) {
 	}
 	cs->multis = np;
 
-	r_str_ncpy (cs->multis + oldend - 1, cp, cs->smultis - oldend + 1);
+	r_str_ncpy (cs->multis + oldend, cp, cs->smultis - oldend);
 }
 
 /*


### PR DESCRIPTION
— Integer overflow check now uses nstates > LONG_MAX / 4 (division-based, correct for sopno = long) — OBACK_ now returns NULL immediately when i is out of bounds, preventing OOB access to pmatch[i] — Fixed off-by-one: oldend - 1 → oldend, preventing heap underflow on first call when oldend == 0

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
