### PR TITLE
Fix pcap buffer unref on parse failure

### DIFF
--- a/libr/bin/format/pcap/pcap.c
+++ b/libr/bin/format/pcap/pcap.c
@@ -6,7 +6,7 @@ void pcap_obj_free(pcap_obj_t *obj) {
 	if (obj) {
 		free (obj->header);
 		r_list_free (obj->recs);
-		r_buf_fini (obj->b);
+		r_unref (obj->b);
 		free (obj);
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent a use-after-free where `pcap_obj_new_buf` takes a reference (`r_ref`) then on parse failure `pcap_obj_free` called `r_buf_fini`, which could free the underlying storage while other owners still held references.

### Description
- Replace `r_buf_fini(obj->b)` with `r_unref(obj->b)` in `libr/bin/format/pcap/pcap.c` so the `RBuffer` is released via its reference-counting API instead of being unconditionally finalized, preserving shared ownership semantics.

### Testing
- Ran `./configure` successfully; attempted `make -j` but it failed due to inability to clone external subprojects (HTTP 403), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb3fb92548331b6a1eb4582288f12)