### PR TITLE
Respect RBinLimit when preallocating arrays in ELF and MACHO ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4448,14 +4448,13 @@ static bool _add_sections_from_phdr(RBinFile *bf, ELFOBJ *eo, bool *found_load) 
 	ut16 mach = eo->ehdr.e_machine;
 
 	ut64 num = Elf_(get_phnum) (eo);
-	if (!RVecRBinSection_reserve (&eo->cached_sections, RVecRBinSection_length (&eo->cached_sections) + num)) {
-		return false;
-	}
-
 	const int limit = bf->rbin->options.limit;
 	if (limit > 0 && num > limit) {
 		R_LOG_WARN ("eo.limit reached for sections");
 		num = limit;
+	}
+	if (!RVecRBinSection_reserve (&eo->cached_sections, RVecRBinSection_length (&eo->cached_sections) + num)) {
+		return false;
 	}
 
 	int i = 0, n = 0;

--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -3574,16 +3574,15 @@ RVecRBinImport *MACH0_(load_imports)(RBinFile *bf, struct MACH0_(obj_t) * bin) {
 		return NULL;
 	}
 
-	if (!RVecRBinImport_reserve (&bin->imports_cache, nundefsym)) {
-		return NULL;
-	}
-
 	if (!bin->sects || !bin->symtab || !bin->symstr || !bin->indirectsyms) {
 		return NULL;
 	}
 
 	const int limit = bf->rbin->options.limit;
 	const int amount = clamp_count (nundefsym, limit);
+	if (!RVecRBinImport_reserve (&bin->imports_cache, amount)) {
+		return NULL;
+	}
 	bin->has_canary = false;
 	bin->has_retguard = -1;
 	bin->has_sanitizers = false;
@@ -3640,7 +3639,12 @@ static void parse_relocation_info(struct MACH0_(obj_t) * mo, RSkipList *relocs, 
 		total_size = mo->size - offset;
 		num = total_size /= sizeof (struct relocation_info);
 	}
-	struct relocation_info *info = calloc (num, sizeof (struct relocation_info));
+	const int amount = clamp_count (num, mo->limit);
+	if (amount < 1) {
+		return;
+	}
+	total_size = (ut64)amount * sizeof (struct relocation_info);
+	struct relocation_info *info = calloc (amount, sizeof (struct relocation_info));
 	if (!info) {
 		return;
 	}
@@ -3650,7 +3654,6 @@ static void parse_relocation_info(struct MACH0_(obj_t) * mo, RSkipList *relocs, 
 		return;
 	}
 
-	const int amount = clamp_count (num, mo->limit);
 	size_t i;
 	for (i = 0; i < amount; i++) {
 		struct relocation_info a_info = info[i];


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
