### PR TITLE
Reject oversized iz+ length to prevent heap overflow

### DIFF
--- a/libr/bin/bfilter.c
+++ b/libr/bin/bfilter.c
@@ -516,6 +516,10 @@ R_API RBinString *r_bin_file_string_add(RBinFile *bf, ut64 paddr, ut64 vaddr, ut
 	if (max_len < 1) {
 		max_len = 512;
 	}
+	if (max_len > ST32_MAX) {
+		R_LOG_ERROR ("String is too large");
+		return NULL;
+	}
 	ut8 *buf = malloc (max_len);
 	if (!buf) {
 		return NULL;

--- a/test/db/cmd/cmd_iz
+++ b/test/db/cmd/cmd_iz
@@ -530,6 +530,18 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=iz+ rejects oversized length
+FILE=malloc://1024
+CMDS=<<EOF
+w teststring @ 0x100
+iz+ 0x100 0x100000000 a
+izc
+EOF
+EXPECT=<<EOF
+0
+EOF
+RUN
+
 NAME=regression for #9370
 FILE=bins/elf/analysis/hello-arm32
 ARGS=-m 0x10000


### PR DESCRIPTION
### Motivation

- The `iz+` path forwarded an unbounded user-supplied `len` to the shared string-add API which could lead to size truncation and a heap overflow during padding in the read path, so a guard is needed to stop oversized lengths early.

### Description

- Add a central length check in `r_bin_file_string_add` (`libr/bin/bfilter.c`) that returns early with `R_LOG_ERROR` when `max_len > ST32_MAX` to prevent unsafe allocations/reads.  
- Preserve existing default behavior (`max_len = 512`) and normal flows for valid lengths.  
- Add an `r2r` regression test `iz+ rejects oversized length` to `test/db/cmd/cmd_iz` that issues an oversized `iz+` and verifies no string is added via `izc`.

### Testing

- Ran `./configure` which completed successfully.  
- `make -j` could not complete in this environment because fetching subprojects is blocked by network policy, so the full build and test suite were not executed.  
- The regression test was added to the test tree but was not run due to the build blockage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8105da548331aa430c8faaffe7b8)