### PR TITLE
Fix heap overflow in seven-bit charset decoder

### DIFF
--- a/libr/muta/p/muta_charset_seven.c
+++ b/libr/muta/p/muta_charset_seven.c
@@ -30,18 +30,17 @@ static int decode(RMutaSession *ms, const ut8 *in, int len, ut8 **out, int *cons
 		ch1 = strtol (buf, NULL, 16);
 		int j = out_len;
 		dest[j++] = ((ch1 &(0x7F >> shift)) << shift) | ch2;
-		dest[j++] = '\0';
 		ch2 = ch1 >> (7 - shift);
 		shift++;
 		if (shift == 7) {
 			dest[j++] = ch2;
-			dest[j++] = '\0';
 			ch2 = 0;
 			shift = 0;
 		}
 		out_len = j;
 		processed += 2;
 	}
+	dest[out_len] = '\0';
 
 	*out = (ut8 *)dest;
 	*consumed = processed;


### PR DESCRIPTION
### Motivation
- The `seven` charset decoder in `libr/muta/p/muta_charset_seven.c` allocated `((len/2)*8/7 + 2)` bytes for the decoded payload but wrote an extra `\0` after every decoded byte, causing `out_len` to grow by two per character and allowing writes past the allocation for longer inputs.
- This mismatch produced a heap buffer overflow when decoding attacker-controlled input (e.g. 6 hex chars), leading to memory corruption risks.
- A minimal change is required to make output length accounting match actual writes while preserving the decoded payload behavior.

### Description
- Remove per-iteration null terminator writes (`dest[j++] = '\0'`) so each loop iteration only appends the decoded byte(s). 
- Remove the extra `\0` write performed when `shift == 7` so that the decoder no longer writes a terminator per-block. 
- Append a single trailing null terminator once after the decoding loop with `dest[out_len] = '\0'`, ensuring the allocated buffer is not overrun and `out_len` counts only decoded bytes.

### Testing
- Ran `git diff --check` to verify no whitespace or trailing-diff issues and it passed. 
- Attempted a build with `make -j` in this environment which failed due to a missing bootstrap/config file (`libr/config.mk`), so a full project build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa7a484588331a439705bb51af3d7)