### PR TITLE
Fix checkpoint snapshot ownership double free ##crash

### DIFF
--- a/libr/debug/dsession.c
+++ b/libr/debug/dsession.c
@@ -74,7 +74,7 @@ R_API bool r_debug_add_checkpoint(RDebug *dbg) {
 	}
 
 	// Save current memory maps
-	checkpoint.snaps = r_list_newf ((RListFree)r_debug_snap_free);
+	checkpoint.snaps = r_list_new ();
 	if (!checkpoint.snaps) {
 		return false;
 	}


### PR DESCRIPTION
### Motivation
- Prevent a double free of `RDebugSnap` objects during debugger teardown by removing duplicate ownership of snapshot pointers stored in checkpoints.

### Description
- Make checkpoint snapshot lists non-owning by creating `checkpoint.snaps` with `r_list_new()` instead of `r_list_newf((RListFree)r_debug_snap_free)` in `libr/debug/dsession.c` so only `dbg->snaps` frees the snap objects.

### Testing
- Attempted a build with `make -j2` which failed in this environment due to a missing configured build tree (`libr/config.mk`), so no automated tests were executed; the fix was validated via code inspection of the affected teardown/ownership paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b110d455c48331b19a32e38f0bdb9b)