### PR TITLE
Fix pd-- heap overflow on long offsets

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -7168,19 +7168,22 @@ static int cmd_pd(RCore *core, const char *input, int len, int l, ut8 *block) {
 			if (offs) {
 				ut64 sz = r_num_math (core->num, offs);
 				char *fmt;
+				char *next;
 				if (((st64)sz * -1) > core->addr) {
 					// the offset is smaller than the negative value
 					// so only print -offset
 					fmt = r_str_newf ("d %" PFMT64d, -1 * core->addr);
+					next = r_str_newf ("d %s", input + 3);
 				} else {
 					fmt = r_str_newf ("d %s", input + 2);
+					next = r_str_newf ("d %s", input + 3);
 				}
-				if (fmt) {
+				if (fmt && next) {
 					cmd_print (core, fmt);
-					strcpy (fmt + 2, input + 3);
-					cmd_print (core, fmt);
-					free (fmt);
+					cmd_print (core, next);
 				}
+				free (fmt);
+				free (next);
 				free (offs);
 			}
 			ret = 0;


### PR DESCRIPTION
### Motivation

- The `pd--` (context disassembly) path in `cmd_pd` built a small `fmt` buffer from `core->addr` and then performed an in-place `strcpy(fmt + 2, input + 3)`, which allows a heap overflow if the user-supplied offset string is longer than the computed `fmt` allocation. 
- The change aims to remove the unsafe in-place mutation while preserving the original behavior of producing two disassembly outputs for the `pd--` form.

### Description

- Replace the unsafe in-place `strcpy` use by allocating a separate `next` string with `r_str_newf` for the second command instead of copying into `fmt`. 
- Ensure both `fmt` and `next` are allocated before use by checking `if (fmt && next)` and call `cmd_print(core, fmt)` and `cmd_print(core, next)` to preserve behavior. 
- Add explicit `free` calls for `fmt`, `next`, and `offs` to keep memory handling correct.
- All changes are contained in `libr/core/cmd_print.inc.c` in the `cmd_pd` `pd--` handling block.

### Testing

- Ran `./configure` successfully to validate the project configuration in this environment. 
- Attempted a full build with `make -j`, but the build failed due to network restrictions when cloning required subprojects (`sdb`, `qjs`, `otezip`, `capstone-v5`), preventing full compilation and runtime tests. 
- Performed automated code inspections with `rg`/file diffs to confirm removal of the unsafe `strcpy` and presence of the new `next` allocation, and verified the patched lines in `libr/core/cmd_print.inc.c`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1df90c0c88331b8da3b8c9d8311fc)