### PR TITLE
Fix r_str_wrap allocation sizing for invalid UTF-8 input

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3341,7 +3341,11 @@ R_API char *r_str_wrap(const char *str, int w) {
 	if (w < 1 || !str) {
 		return strdup ("");
 	}
-	size_t r_size = 8 * r_utf8_strlen ((const ut8 *)str);
+	size_t r_size = 0;
+	size_t str_len = strlen (str);
+	if (r_mul_overflow (str_len, (size_t)8, &r_size) || r_add_overflow (r_size, (size_t)1, &r_size)) {
+		return NULL;
+	}
 	char *r = malloc (r_size);
 	if (!r) {
 		return NULL;


### PR DESCRIPTION
### Motivation
- `r_str_wrap` previously sized its output buffer from `r_utf8_strlen`, which undercounts bytes for invalid UTF-8 streams and can lead to under-allocation and heap out-of-bounds writes. 

### Description
- Replace UTF-8 character-count sizing with a byte-length based allocation using `strlen(str)` and compute `r_size = str_len * 8 + 1` with overflow-checked arithmetic via `r_mul_overflow` and `r_add_overflow` in `libr/util/str.c`. 

### Testing
- Ran `./configure` which completed successfully in this environment. 
- Attempted `make -j` which failed due to blocked network access when fetching subprojects (GitHub clone errors), so a full build could not be performed. 
- Attempted `make -C libr/util -j` which failed due to missing `sdb/sdb.h` when subprojects were not available, so unit/build verification in-tree could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b212f0e9e48331a20e7d8b67583419)