### PR TITLE
Validate .cfloat bit sizes to prevent negative byte lengths

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -141,6 +141,10 @@ static int r_asm_pseudo_float(RAsm *a, RAnalOp *op, char *input, const RCFloatPr
 	double value = strtod (r_str_trim_head_ro (input), NULL);
 	const int total_bits = profile->sign_bits + profile->exp_bits + profile->mant_bits;
 	const int byte_size = (total_bits + 7) / 8;
+	if (total_bits <= 0 || byte_size <= 0) {
+		R_LOG_ERROR ("Invalid .cfloat format size");
+		return -1;
+	}
 	if (byte_size > sizeof (buf)) {
 		R_LOG_ERROR ("Too many bits");
 		return -1;
@@ -983,7 +987,12 @@ static int parse_asm_directive(RAsm *a, RAnalOp *op, RAsmCode *acode, char *ptr_
 				.big_endian = atoi (r_str_word_get0 (args, 4)),
 				.explicit_leading_bit = atoi (r_str_word_get0 (args, 5))
 			};
-			acode->cfloat_profile = fp;
+			if (fp.sign_bits < 0 || fp.exp_bits < 0 || fp.mant_bits < 0) {
+				R_LOG_ERROR ("Invalid .cfloat field sizes");
+				ret = -1;
+			} else {
+				acode->cfloat_profile = fp;
+			}
 		}
 		free (args);
 	} else if (r_str_startswith (ptr, ".float ")) {

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -907,6 +907,15 @@ c3f5c840
 EOF
 RUN
 
+NAME=rasm2 .cfloat rejects negative sizes
+FILE=-
+CMDS=!rasm2 -a x86 -b 64 ".cfloat -1 8 23 127 0 0;.float 3.14"
+EXPECT=
+EXPECT_ERR=<<EOF
+ERROR: Cannot assemble '.cfloat -1 8 23 127 0 0' at line 1
+EOF
+RUN
+
 NAME=rasm2 #25036 (reject invalid x86-64 register r1)
 FILE=-
 CMDS=!rasm2 -a x86 -b 64 "add rax, r1"


### PR DESCRIPTION
### Motivation

- Prevent a discovered security issue where negative `.cfloat` bit fields produce a negative `byte_size` that is later used in `memcpy`, causing out-of-bounds writes.
- Ensure assembler pseudo-float handling and the `.cfloat` directive validate inputs so attacker-controlled profiles cannot trigger memory corruption.

### Description

- Added a defensive check in `r_asm_pseudo_float` to reject non-positive `total_bits`/`byte_size` and return an error instead of emitting bytes, preventing negative sizes from propagating to `r_anal_op_set_bytes` (`libr/asm/asm.c`).
- Added validation when parsing the `.cfloat` directive to reject negative `sign_bits`, `exp_bits`, or `mant_bits` and fail the directive instead of storing an unsafe profile (`libr/asm/asm.c`).
- Added an r2r regression test that asserts a `.cfloat` directive with a negative size is rejected and produces an assembly error (`test/db/tools/rasm2`).

### Testing

- Ran `./configure` successfully in this environment to regenerate build files. 
- Attempted `make -j2`, which failed due to blocked network fetches for external subprojects (environment limitation), so a full build was not completed.
- Added an automated r2r test case and verified `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b216470250833192ff9ea4440f5e74)