### PR TITLE
Fix segfault in SSL socket connections when connect() succeeds immediately #socket

### DIFF
--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -402,7 +402,7 @@ R_API bool r_socket_connect(RSocket *s, const char *host, const char *port, int 
 
 			if (ret == 0) {
 				freeaddrinfo (res);
-				return true;
+				goto success;
 			}
 			if (errno == EINPROGRESS) {
 				struct timeval tv = { timeout, 0 };


### PR DESCRIPTION
## Summary

When `r_socket_connect()` establishes a TCP connection and `connect()` returns 0 (immediate success, the common case), the code does `return true` — bypassing the `success:` label where SSL context creation, `SSL_new`, `SSL_set_fd`, and `SSL_connect` all happen.

This leaves `s->sfd` uninitialized, so any subsequent `SSL_write` segfaults.

Reproducible by using `idpd` to download PDB symbols over HTTPS with `use_ssl=true` and `use_sys_openssl=true`.

## Fix

Change `return true` to `goto success` so the SSL handshake is performed regardless of whether `connect()` completed synchronously or asynchronously.

## Backtrace

```
#0  0x00007ffff478c60c in ?? () from libssl.so.3
#1  0x00007ffff478c9f3 in SSL_write ()
#2  r_socket_write (s=...) at libr/socket/socket.c:801
#3  r_socket_printf (s=...) at libr/socket/socket.c:843
#4  socket_http_get_recursive (url="https://msdl.microsoft.com/...") at libr/socket/socket_http.c:324
```