### PR TITLE
Fix #25650 - Fix Command Injection in PDB Name - rabin2

### DIFF
--- a/libr/socket/socket_http.c
+++ b/libr/socket/socket_http.c
@@ -286,7 +286,7 @@ static char *socket_http_get_recursive(const char *url, const char **headers, in
 			return NULL;
 		}
 		RStrBuf *sb = r_strbuf_new ("curl -s -D ");
-		r_strbuf_appendf (sb, "'%s' -o '%s' -L --max-redirs %u", escaped_header_file, escaped_body_file, redirections);
+		r_strbuf_appendf (sb, "\"%s\" -o \"%s\" -L --max-redirs %u", escaped_header_file, escaped_body_file, redirections);
 		if (headers) {
 			const char **header = headers;
 			while (*header) {
@@ -300,12 +300,12 @@ static char *socket_http_get_recursive(const char *url, const char **headers, in
 					free (body_file);
 					return NULL;
 				}
-				r_strbuf_appendf (sb, " -H '%s'", escaped_header);
+				r_strbuf_appendf (sb, " -H \"%s\"", escaped_header);
 				free (escaped_header);
 				header++;
 			}
 		}
-		r_strbuf_appendf (sb, " '%s'", escaped_url);
+		r_strbuf_appendf (sb, " \"%s\"", escaped_url);
 		char *command = r_strbuf_drain (sb);
 		free (escaped_url);
 		free (escaped_header_file);


### PR DESCRIPTION
- [ x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This fixes [my vulnerability disclosure](https://github.com/radareorg/radare2/issues/25650).

r_str_escape_sh assumes that the resulting string will be surrounded by double quotes when consumed. This properly uses double quotes.

This is a simple hotfix. For a more robust fix, these PDB filenames should be subject to a character whitelist and `curl` should not be invoked with `system`. I am happy to contribute that later.
