### PR TITLE
Add fasttime debugger support

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2047,8 +2047,7 @@ static bool cb_dbg_aftersc(void *user, void *data) {
 static bool cb_dbg_fasttime(void *user, void *data) {
 	RCore *core = (RCore *)user;
 	RConfigNode *node = (RConfigNode *)data;
-	core->dbg->fasttime = node->i_value;
-	r_debug_fasttime_reset (core->dbg);
+	r_debug_fasttime_set (core->dbg, node->i_value);
 	return true;
 }
 
@@ -4498,7 +4497,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("dbg.threads", "false", &cb_stopthreads, "stop all threads when debugger breaks (see dbg.forks)");
 	SETCB ("dbg.clone", "false", &cb_dbg_clone, "stop execution if new thread is created");
 	SETCB ("dbg.aftersyscall", "true", &cb_dbg_aftersc, "stop execution before the syscall is executed (see dcs)");
-	SETCB ("dbg.fasttime", "false", &cb_dbg_fasttime, "virtualize timer syscalls during continue on supported debugger backends");
+	SETCB ("dbg.fasttime", "false", &cb_dbg_fasttime, "skip nanosleep and clock_nanosleep while continuing (linux)");
 	SETCB ("dbg.profile", "", &cb_runprofile, "path to RRunProfile file (or base64:string)");
 	SETCB ("dbg.args", "", &cb_dbg_args, "set the args of the program to debug");
 	SETCB ("dbg.follow.child", "false", &cb_dbg_follow_child, "continue tracing the child process on fork. By default the parent process is traced");

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -2044,6 +2044,14 @@ static bool cb_dbg_aftersc(void *user, void *data) {
 	return true;
 }
 
+static bool cb_dbg_fasttime(void *user, void *data) {
+	RCore *core = (RCore *)user;
+	RConfigNode *node = (RConfigNode *)data;
+	core->dbg->fasttime = node->i_value;
+	r_debug_fasttime_reset (core->dbg);
+	return true;
+}
+
 static bool cb_runprofile(void *user, void *data) {
 	RCore *r = (RCore *)user;
 	RConfigNode *node = (RConfigNode *)data;
@@ -4490,6 +4498,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("dbg.threads", "false", &cb_stopthreads, "stop all threads when debugger breaks (see dbg.forks)");
 	SETCB ("dbg.clone", "false", &cb_dbg_clone, "stop execution if new thread is created");
 	SETCB ("dbg.aftersyscall", "true", &cb_dbg_aftersc, "stop execution before the syscall is executed (see dcs)");
+	SETCB ("dbg.fasttime", "false", &cb_dbg_fasttime, "virtualize timer syscalls during continue on supported debugger backends");
 	SETCB ("dbg.profile", "", &cb_runprofile, "path to RRunProfile file (or base64:string)");
 	SETCB ("dbg.args", "", &cb_dbg_args, "set the args of the program to debug");
 	SETCB ("dbg.follow.child", "false", &cb_dbg_follow_child, "continue tracing the child process on fork. By default the parent process is traced");

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -395,6 +395,7 @@ R_API RDebug *r_debug_new(int hard) {
 	dbg->glibc_version = 231; /* default version ubuntu 20 */
 	dbg->glibc_version_d = 0; /* no default glibc version */
 	dbg->coredump_filter = -1;
+	dbg->fasttime_threads = ht_up_new (NULL, NULL, NULL);
 	r_debug_signal_init (dbg);
 	if (hard) {
 		dbg->bp = r_bp_new ();
@@ -403,6 +404,74 @@ R_API RDebug *r_debug_new(int hard) {
 		dbg->bp->baddr = 0;
 	}
 	return dbg;
+}
+
+static bool free_fasttime_thread_cb(void *user, const ut64 key, const void *value) {
+	(void)user;
+	(void)key;
+	r_debug_fasttime_thread_free ((RDebugFasttimeThread *)value);
+	return true;
+}
+
+static RDebugFasttimeThread *fasttime_thread_state(RDebug *dbg, int tid, bool create) {
+	R_RETURN_VAL_IF_FAIL (dbg && tid > 0, NULL);
+	if (!dbg->fasttime_threads) {
+		if (!create) {
+			return NULL;
+		}
+		dbg->fasttime_threads = ht_up_new (NULL, NULL, NULL);
+		if (!dbg->fasttime_threads) {
+			return NULL;
+		}
+	}
+	RDebugFasttimeThread *thread_state = ht_up_find (dbg->fasttime_threads, (ut64)(ut32)tid, NULL);
+	if (!thread_state && create) {
+		thread_state = R_NEW0 (RDebugFasttimeThread);
+		if (!thread_state) {
+			return NULL;
+		}
+		thread_state->pending_syscall = -1;
+		ht_up_insert (dbg->fasttime_threads, (ut64)(ut32)tid, thread_state);
+	}
+	return thread_state;
+}
+
+static void fasttime_clear_thread_state(RDebug *dbg, int tid) {
+	R_RETURN_IF_FAIL (dbg && dbg->fasttime_threads && tid > 0);
+	RDebugFasttimeThread *thread_state = ht_up_find (dbg->fasttime_threads, (ut64)(ut32)tid, NULL);
+	if (!thread_state) {
+		return;
+	}
+	thread_state->in_syscall = false;
+	thread_state->skip_timer = false;
+	thread_state->pending_syscall = -1;
+}
+
+static bool fasttime_is_timer_syscall(RDebug *dbg, int syscall_num) {
+	R_RETURN_VAL_IF_FAIL (dbg, false);
+	if (!dbg->anal || !dbg->anal->syscall || syscall_num < 0) {
+		return false;
+	}
+	const int nanosleep_num = r_syscall_get_num (dbg->anal->syscall, "nanosleep");
+	const int clock_nanosleep_num = r_syscall_get_num (dbg->anal->syscall, "clock_nanosleep");
+	return syscall_num == nanosleep_num || syscall_num == clock_nanosleep_num;
+}
+
+R_API bool r_debug_fasttime_prepare_syscall_entry(RDebug *dbg, int tid, int syscall_num) {
+	R_RETURN_VAL_IF_FAIL (dbg && tid > 0, false);
+	RDebugFasttimeThread *thread_state = fasttime_thread_state (dbg, tid, true);
+	if (!thread_state) {
+		return false;
+	}
+	thread_state->in_syscall = true;
+	thread_state->pending_syscall = syscall_num;
+	thread_state->skip_timer = dbg->fasttime && !dbg->fasttime_suppress
+		&& fasttime_is_timer_syscall (dbg, syscall_num);
+	if (thread_state->skip_timer && !r_debug_reg_set_alias (dbg, R_REG_ALIAS_SN, UT64_MAX)) {
+		thread_state->skip_timer = false;
+		return false;
+	}
+	return true;
 }
 
 static int free_tracenodes_entry(RDebug *dbg, const char *k, const char *v) {
@@ -435,6 +504,10 @@ R_API void r_debug_free(RDebug *dbg) {
 		r_debug_signal_fini (dbg);
 		r_debug_trace_free (dbg->trace);
 		r_list_free (dbg->snaps);
+		if (dbg->fasttime_threads) {
+			ht_up_foreach (dbg->fasttime_threads, free_fasttime_thread_cb, NULL);
+			ht_up_free (dbg->fasttime_threads);
+		}
 		r_debug_session_free (dbg->session);
 		r_anal_op_free (dbg->cur_op);
 		dbg->trace = NULL;
@@ -445,6 +518,17 @@ R_API void r_debug_free(RDebug *dbg) {
 		free (dbg->glob_unlibs);
 		free (dbg);
 	}
+}
+
+R_API void r_debug_fasttime_reset(RDebug *dbg) {
+	R_RETURN_IF_FAIL (dbg);
+	if (!dbg->fasttime_threads) {
+		dbg->fasttime_threads = ht_up_new (NULL, NULL, NULL);
+		return;
+	}
+	ht_up_foreach (dbg->fasttime_threads, free_fasttime_thread_cb, NULL);
+	ht_up_free (dbg->fasttime_threads);
+	dbg->fasttime_threads = ht_up_new (NULL, NULL, NULL);
 }
 
 R_API bool r_debug_attach(RDebug *dbg, int pid) {
@@ -459,6 +543,7 @@ R_API bool r_debug_attach(RDebug *dbg, int pid) {
 		if (ret) {
 			dbg->pid = pid;
 			dbg->tid = pid;
+			r_debug_fasttime_reset (dbg);
 			// dbg->pid = pid;
 			// r_debug_select (dbg, pid, ret);
 			r_debug_select (dbg, dbg->pid, dbg->tid);
@@ -636,6 +721,7 @@ R_API bool r_debug_detach(RDebug *dbg, int pid) {
 	if (plugin && plugin->detach) {
 		ret = plugin->detach (dbg, pid);
 		if (dbg->pid == pid) {
+			r_debug_fasttime_reset (dbg);
 			dbg->pid = -1;
 			dbg->tid = -1;
 		}
@@ -1576,24 +1662,32 @@ static int show_syscall(RDebug *dbg, const char *sysreg) {
 R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc) {
 	R_RETURN_VAL_IF_FAIL (dbg, false);
 	int i, reg;
+	const bool prev_fasttime_suppress = dbg->fasttime_suppress;
+	dbg->fasttime_suppress = true;
 	if (!dbg->current || r_debug_is_dead (dbg)) {
+		dbg->fasttime_suppress = prev_fasttime_suppress;
 		return -1;
 	}
 	RDebugPlugin *plugin = R_UNWRAP3 (dbg, current, plugin);
 	if (plugin && !plugin->contsc) {
 		/* user-level syscall tracing */
 		r_debug_continue_until_optype (dbg, R_ANAL_OP_TYPE_SWI, 0);
-		return show_syscall (dbg, "A0");
+		reg = show_syscall (dbg, "A0");
+		dbg->fasttime_suppress = prev_fasttime_suppress;
+		fasttime_clear_thread_state (dbg, dbg->tid);
+		return reg;
 	}
 
 	if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false)) {
 		R_LOG_ERROR ("--> cannot read registers");
+		dbg->fasttime_suppress = prev_fasttime_suppress;
 		return -1;
 	}
 	bool err;
 	reg = (int)r_debug_reg_get_err (dbg, "SN", &err, NULL);
 	if (err) {
 		R_LOG_ERROR ("Cannot find 'sn' register for current arch-os");
+		dbg->fasttime_suppress = prev_fasttime_suppress;
 		return -1;
 	}
 	for (;;) {
@@ -1624,6 +1718,7 @@ R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc) {
 #endif
 		if (!r_debug_reg_sync (dbg, R_REG_TYPE_GPR, false)) {
 			R_LOG_ERROR ("cannot sync regs, process is probably dead");
+			dbg->fasttime_suppress = prev_fasttime_suppress;
 			return -1;
 		}
 		reg = show_syscall (dbg, "SN");
@@ -1636,15 +1731,20 @@ R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc) {
 			continue;
 		}
 		if (n_sc == 0) {
+			dbg->fasttime_suppress = prev_fasttime_suppress;
+			fasttime_clear_thread_state (dbg, dbg->tid);
 			break;
 		}
 		for (i = 0; i < n_sc; i++) {
 			if (sc[i] == reg) {
+				dbg->fasttime_suppress = prev_fasttime_suppress;
+				fasttime_clear_thread_state (dbg, dbg->tid);
 				return reg;
 			}
 		}
 		// TODO: must use r_core_cmd(as)..import code from rcore
 	}
+	dbg->fasttime_suppress = prev_fasttime_suppress;
 	return -1;
 }
 

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -427,9 +427,6 @@ static RDebugFasttimeThread *fasttime_thread_state(RDebug *dbg, int tid, bool cr
 	RDebugFasttimeThread *thread_state = ht_up_find (dbg->fasttime_threads, (ut64)(ut32)tid, NULL);
 	if (!thread_state && create) {
 		thread_state = R_NEW0 (RDebugFasttimeThread);
-		if (!thread_state) {
-			return NULL;
-		}
 		thread_state->pending_syscall = -1;
 		ht_up_insert (dbg->fasttime_threads, (ut64)(ut32)tid, thread_state);
 	}
@@ -472,6 +469,12 @@ R_API bool r_debug_fasttime_prepare_syscall_entry(RDebug *dbg, int tid, int sysc
 		return false;
 	}
 	return true;
+}
+
+R_API void r_debug_fasttime_set(RDebug *dbg, bool enabled) {
+	R_RETURN_IF_FAIL (dbg);
+	dbg->fasttime = enabled;
+	r_debug_fasttime_reset (dbg);
 }
 
 static int free_tracenodes_entry(RDebug *dbg, const char *k, const char *v) {

--- a/libr/debug/dreg.c
+++ b/libr/debug/dreg.c
@@ -324,6 +324,11 @@ beach:
 	return n != 0;
 }
 
+static const char *debug_reg_alias_name(RDebug *dbg, RRegAlias alias) {
+	R_RETURN_VAL_IF_FAIL (dbg && dbg->reg, NULL);
+	return r_reg_alias_getname (dbg->reg, alias);
+}
+
 R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num) {
 	R_RETURN_VAL_IF_FAIL (dbg && name, false);
 	if (!dbg->reg) {
@@ -342,6 +347,11 @@ R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num) {
 		r_unref (ri);
 	}
 	return (ri);
+}
+
+R_API bool r_debug_reg_set_alias(RDebug *dbg, RRegAlias alias, ut64 num) {
+	const char *name = debug_reg_alias_name (dbg, alias);
+	return R_STR_ISNOTEMPTY (name)? r_debug_reg_set (dbg, name, num): false;
 }
 
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, bool *err, utX *value) {
@@ -388,7 +398,21 @@ R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, bool *err, utX *va
 	return ret;
 }
 
+R_API ut64 r_debug_reg_get_alias_err(RDebug *dbg, RRegAlias alias, bool *err, utX *value) {
+	const char *name = debug_reg_alias_name (dbg, alias);
+	if (R_STR_ISEMPTY (name)) {
+		if (err) {
+			*err = true;
+		}
+		return UT64_MAX;
+	}
+	return r_debug_reg_get_err (dbg, name, err, value);
+}
+
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name) {
 	return r_debug_reg_get_err (dbg, name, NULL, NULL);
 }
 
+R_API ut64 r_debug_reg_get_alias(RDebug *dbg, RRegAlias alias) {
+	return r_debug_reg_get_alias_err (dbg, alias, NULL, NULL);
+}

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -225,6 +225,7 @@ static bool r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 	return ptrace (PTRACE_CONT, pid, (void*)(size_t)pc, (int)(size_t)data) == 0;
 #else
 	int ret = -1;
+	const int ptrace_cmd = (dbg->fasttime && !dbg->fasttime_suppress)? PTRACE_SYSCALL: PTRACE_CONT;
 	if (sig == -1) {
 		   sig = dbg->reason.signum;
 	}
@@ -237,15 +238,15 @@ static bool r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 		RDebugPid *th;
 		RListIter *it;
 		r_list_foreach (dbg->threads, it, th) {
-			ret = r_debug_ptrace (dbg, PTRACE_CONT, th->pid, 0, 0);
+			ret = r_debug_ptrace (dbg, ptrace_cmd, th->pid, 0, 0);
 			if (ret) {
 				R_LOG_ERROR ("(%d) is running or dead", th->pid);
 			}
 		}
 	} else {
-		ret = r_debug_ptrace (dbg, PTRACE_CONT, tid, NULL, (r_ptrace_data_t)(size_t) sig);
+		ret = r_debug_ptrace (dbg, ptrace_cmd, tid, NULL, (r_ptrace_data_t)(size_t) sig);
 		if (ret) {
-			r_sys_perror ("PTRACE_CONT");
+			r_sys_perror (ptrace_cmd == PTRACE_SYSCALL? "PTRACE_SYSCALL": "PTRACE_CONT");
 		}
 	}
 	return ret >= 0;

--- a/libr/debug/p/debug_native.c
+++ b/libr/debug/p/debug_native.c
@@ -225,7 +225,7 @@ static bool r_debug_native_continue(RDebug *dbg, int pid, int tid, int sig) {
 	return ptrace (PTRACE_CONT, pid, (void*)(size_t)pc, (int)(size_t)data) == 0;
 #else
 	int ret = -1;
-	const int ptrace_cmd = (dbg->fasttime && !dbg->fasttime_suppress)? PTRACE_SYSCALL: PTRACE_CONT;
+	const int ptrace_cmd = r_debug_fasttime_enabled (dbg)? PTRACE_SYSCALL: PTRACE_CONT;
 	if (sig == -1) {
 		   sig = dbg->reason.signum;
 	}

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -87,6 +87,75 @@ static void linux_dbg_wait_break_main(RDebug *dbg);
 static void linux_dbg_wait_break(RDebug *dbg);
 static RDebugReasonType linux_handle_new_task(RDebug *dbg, int tid);
 
+static bool linux_is_syscall_stop(int status) {
+	return WIFSTOPPED (status) && WSTOPSIG (status) == (SIGTRAP | 0x80);
+}
+
+static RDebugFasttimeThread *linux_fasttime_thread_state(RDebug *dbg, int tid, bool create) {
+	R_RETURN_VAL_IF_FAIL (dbg && tid > 0, NULL);
+	if (!dbg->fasttime_threads) {
+		if (!create) {
+			return NULL;
+		}
+		dbg->fasttime_threads = ht_up_new (NULL, NULL, NULL);
+		if (!dbg->fasttime_threads) {
+			return NULL;
+		}
+	}
+	RDebugFasttimeThread *thread_state = ht_up_find (dbg->fasttime_threads, (ut64)(ut32)tid, NULL);
+	if (!thread_state && create) {
+		thread_state = R_NEW0 (RDebugFasttimeThread);
+		if (!thread_state) {
+			return NULL;
+		}
+		thread_state->pending_syscall = -1;
+		ht_up_insert (dbg->fasttime_threads, (ut64)(ut32)tid, thread_state);
+	}
+	return thread_state;
+}
+
+static bool linux_fasttime_enabled(RDebug *dbg) {
+	return dbg && dbg->fasttime && !dbg->fasttime_suppress;
+}
+
+static bool linux_fasttime_resume_syscall(RDebug *dbg, int tid) {
+	if (r_debug_ptrace (dbg, PTRACE_SYSCALL, tid, 0, 0) == -1) {
+		r_sys_perror ("PTRACE_SYSCALL");
+		return false;
+	}
+	return true;
+}
+
+static bool linux_fasttime_handle_syscall_stop(RDebug *dbg, int tid) {
+	if (!linux_fasttime_enabled (dbg)) {
+		return false;
+	}
+	RDebugFasttimeThread *thread_state = linux_fasttime_thread_state (dbg, tid, true);
+	if (!thread_state) {
+		return false;
+	}
+	r_debug_select (dbg, dbg->pid, tid);
+	dbg->tid = tid;
+	bool err = false;
+	int syscall_num = (int)r_debug_reg_get_alias_err (dbg, R_REG_ALIAS_SN, &err, NULL);
+	if (err) {
+		return false;
+	}
+	if (!thread_state->in_syscall) {
+		if (!r_debug_fasttime_prepare_syscall_entry (dbg, tid, syscall_num)) {
+			return false;
+		}
+	} else {
+		thread_state->in_syscall = false;
+		if (thread_state->skip_timer && !r_debug_reg_set_alias (dbg, R_REG_ALIAS_R0, 0)) {
+			return false;
+		}
+		thread_state->skip_timer = false;
+		thread_state->pending_syscall = -1;
+	}
+	return linux_fasttime_resume_syscall (dbg, tid);
+}
+
 int linux_handle_signals(RDebug *dbg, int tid) {
 	RCore *core = dbg->coreb.core;
 	siginfo_t siginfo = {0};
@@ -526,6 +595,10 @@ RDebugReasonType linux_dbg_wait(RDebug *dbg, int pid) {
 			flags &= ~WNOHANG;
 		} else {
 			tid = ret;
+
+			if (linux_is_syscall_stop (status) && linux_fasttime_handle_syscall_stop (dbg, tid)) {
+				continue;
+			}
 
 			// Handle SIGTRAP with PTRACE_EVENT_*
 			reason = linux_ptrace_event (dbg, tid, status, true);

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -87,11 +87,11 @@ static void linux_dbg_wait_break_main(RDebug *dbg);
 static void linux_dbg_wait_break(RDebug *dbg);
 static RDebugReasonType linux_handle_new_task(RDebug *dbg, int tid);
 
-static bool linux_is_syscall_stop(int status) {
+static bool is_syscall_stop(int status) {
 	return WIFSTOPPED (status) && WSTOPSIG (status) == (SIGTRAP | 0x80);
 }
 
-static RDebugFasttimeThread *linux_fasttime_thread_state(RDebug *dbg, int tid, bool create) {
+static RDebugFasttimeThread *ft_thread_state(RDebug *dbg, int tid, bool create) {
 	R_RETURN_VAL_IF_FAIL (dbg && tid > 0, NULL);
 	if (!dbg->fasttime_threads) {
 		if (!create) {
@@ -105,20 +105,13 @@ static RDebugFasttimeThread *linux_fasttime_thread_state(RDebug *dbg, int tid, b
 	RDebugFasttimeThread *thread_state = ht_up_find (dbg->fasttime_threads, (ut64)(ut32)tid, NULL);
 	if (!thread_state && create) {
 		thread_state = R_NEW0 (RDebugFasttimeThread);
-		if (!thread_state) {
-			return NULL;
-		}
 		thread_state->pending_syscall = -1;
 		ht_up_insert (dbg->fasttime_threads, (ut64)(ut32)tid, thread_state);
 	}
 	return thread_state;
 }
 
-static bool linux_fasttime_enabled(RDebug *dbg) {
-	return dbg && dbg->fasttime && !dbg->fasttime_suppress;
-}
-
-static bool linux_fasttime_resume_syscall(RDebug *dbg, int tid) {
+static bool ft_resume_syscall(RDebug *dbg, int tid) {
 	if (r_debug_ptrace (dbg, PTRACE_SYSCALL, tid, 0, 0) == -1) {
 		r_sys_perror ("PTRACE_SYSCALL");
 		return false;
@@ -126,16 +119,15 @@ static bool linux_fasttime_resume_syscall(RDebug *dbg, int tid) {
 	return true;
 }
 
-static bool linux_fasttime_handle_syscall_stop(RDebug *dbg, int tid) {
-	if (!linux_fasttime_enabled (dbg)) {
+static bool ft_handle_syscall_stop(RDebug *dbg, int tid) {
+	if (!r_debug_fasttime_enabled (dbg)) {
 		return false;
 	}
-	RDebugFasttimeThread *thread_state = linux_fasttime_thread_state (dbg, tid, true);
+	RDebugFasttimeThread *thread_state = ft_thread_state (dbg, tid, true);
 	if (!thread_state) {
 		return false;
 	}
 	r_debug_select (dbg, dbg->pid, tid);
-	dbg->tid = tid;
 	bool err = false;
 	int syscall_num = (int)r_debug_reg_get_alias_err (dbg, R_REG_ALIAS_SN, &err, NULL);
 	if (err) {
@@ -153,7 +145,7 @@ static bool linux_fasttime_handle_syscall_stop(RDebug *dbg, int tid) {
 		thread_state->skip_timer = false;
 		thread_state->pending_syscall = -1;
 	}
-	return linux_fasttime_resume_syscall (dbg, tid);
+	return ft_resume_syscall (dbg, tid);
 }
 
 int linux_handle_signals(RDebug *dbg, int tid) {
@@ -596,7 +588,7 @@ RDebugReasonType linux_dbg_wait(RDebug *dbg, int pid) {
 		} else {
 			tid = ret;
 
-			if (linux_is_syscall_stop (status) && linux_fasttime_handle_syscall_stop (dbg, tid)) {
+			if (is_syscall_stop (status) && ft_handle_syscall_stop (dbg, tid)) {
 				continue;
 			}
 

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -409,7 +409,7 @@ typedef struct r_debug_t {
 	bool consbreak; /* SIGINT handle for attached processes */
 	bool continue_all_threads;
 	int coredump_filter; /* override coredump filter, -1 to use default */
-	bool fasttime; /* virtualize timer syscalls during continue */
+	bool fasttime; /* skip sleep syscalls during continue */
 	bool fasttime_suppress; /* disable fasttime during explicit syscall tracing */
 
 	/* tracking debugger state */
@@ -470,6 +470,10 @@ typedef struct r_debug_t {
 	int glibc_version;
 	double glibc_version_d; // TODO: move over to this only
 } RDebug;
+
+static inline bool r_debug_fasttime_enabled(RDebug *dbg) {
+	return dbg->fasttime && !dbg->fasttime_suppress;
+}
 
 // TODO: rename to r_debug_process_t ? maybe a thread too ?
 typedef struct r_debug_pid_t {
@@ -610,6 +614,7 @@ R_API bool r_debug_map_protect(RDebug *dbg, ut64 addr, int size, int perms);
 R_API ut64 r_debug_arg_get(RDebug *dbg, const char *cc, int num);
 R_API bool r_debug_arg_set(RDebug *dbg, const char *cc, int num, ut64 value);
 R_API void r_debug_fasttime_reset(RDebug *dbg);
+R_API void r_debug_fasttime_set(RDebug *dbg, bool enabled);
 R_API bool r_debug_fasttime_prepare_syscall_entry(RDebug *dbg, int tid, int syscall_num);
 
 /* breakpoints (most in r_bp, this calls those) */

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -242,6 +242,16 @@ typedef struct r_snap_entry {
 	int perm;
 } RSnapEntry;
 
+typedef struct r_debug_fasttime_thread_t {
+	bool in_syscall;
+	bool skip_timer;
+	int pending_syscall;
+} RDebugFasttimeThread;
+
+static inline void r_debug_fasttime_thread_free(RDebugFasttimeThread *thread_state) {
+	free (thread_state);
+}
+
 R_VEC_FORWARD_DECLARE (RVecDebugTracepoint);
 
 typedef struct r_debug_trace_t {
@@ -399,6 +409,8 @@ typedef struct r_debug_t {
 	bool consbreak; /* SIGINT handle for attached processes */
 	bool continue_all_threads;
 	int coredump_filter; /* override coredump filter, -1 to use default */
+	bool fasttime; /* virtualize timer syscalls during continue */
+	bool fasttime_suppress; /* disable fasttime during explicit syscall tracing */
 
 	/* tracking debugger state */
 	int steps; /* counter of steps done */
@@ -441,6 +453,7 @@ typedef struct r_debug_t {
 	bool trace_continue;
 	RAnalOp *cur_op;
 	RDebugSession *session;
+	HtUP *fasttime_threads; /* tid -> RDebugFasttimeThread* */
 
 	Sdb *sgnls;
 	RCoreBind coreb;
@@ -577,8 +590,11 @@ R_API int r_debug_desc_list(RDebug *dbg, bool show_commands);
 R_API bool r_debug_reg_sync(RDebug *dbg, int type, int write);
 R_API bool r_debug_reg_list(RDebug *dbg, int type, int size, PJ *pj, int rad, const char *use_color);
 R_API bool r_debug_reg_set(RDebug *dbg, const char *name, ut64 num);
+R_API bool r_debug_reg_set_alias(RDebug *dbg, RRegAlias alias, ut64 num);
 R_API ut64 r_debug_reg_get(RDebug *dbg, const char *name);
+R_API ut64 r_debug_reg_get_alias(RDebug *dbg, RRegAlias alias);
 R_API ut64 r_debug_reg_get_err(RDebug *dbg, const char *name, bool *err, utX *value);
+R_API ut64 r_debug_reg_get_alias_err(RDebug *dbg, RRegAlias alias, bool *err, utX *value);
 
 R_API bool r_debug_execute(RDebug *dbg, const ut8 *buf, int len, R_OUT ut64 *ret, bool restore, bool ignore_stack);
 R_API bool r_debug_map_sync(RDebug *dbg);
@@ -593,6 +609,8 @@ R_API bool r_debug_map_protect(RDebug *dbg, ut64 addr, int size, int perms);
 /* args XXX: weird food */
 R_API ut64 r_debug_arg_get(RDebug *dbg, const char *cc, int num);
 R_API bool r_debug_arg_set(RDebug *dbg, const char *cc, int num, ut64 value);
+R_API void r_debug_fasttime_reset(RDebug *dbg);
+R_API bool r_debug_fasttime_prepare_syscall_entry(RDebug *dbg, int tid, int syscall_num);
 
 /* breakpoints (most in r_bp, this calls those) */
 R_API RBreakpointItem *r_debug_bp_add(RDebug *dbg, ut64 addr, int hw, bool watch, int rw, char *module, st64 m_delta);

--- a/test/db/archos/linux-x86_64/dbg_fasttime
+++ b/test/db/archos/linux-x86_64/dbg_fasttime
@@ -27,10 +27,10 @@ dr SN
 q!
 EOF
 EXPECT=<<EOF
-Running child until syscalls:230 35
 0x00000023
 EOF
-EXPECT_ERR=<<EOF
+REGEXP_ERR=<<EOF
 child received signal 9
+Running child until syscalls:230 35 ?
 EOF
 RUN

--- a/test/db/archos/linux-x86_64/dbg_fasttime
+++ b/test/db/archos/linux-x86_64/dbg_fasttime
@@ -29,8 +29,4 @@ EOF
 EXPECT=<<EOF
 0x00000023
 EOF
-REGEXP_ERR=<<EOF
-child received signal 9
-Running child until syscalls:230 35 ?
-EOF
 RUN

--- a/test/db/archos/linux-x86_64/dbg_fasttime
+++ b/test/db/archos/linux-x86_64/dbg_fasttime
@@ -1,0 +1,36 @@
+NAME=fasttime continue reaches post-sleep code without waiting
+FILE=bins/elf/analysis/fasttime-sleep
+ARGS=-d -e log.level=0
+CMDS=<<EOF
+ood
+e dbg.fasttime=true
+dcu sym.after_sleep
+?e reached
+q!
+EOF
+EXPECT=<<EOF
+reached
+EOF
+EXPECT_ERR=<<EOF
+child received signal 9
+EOF
+RUN
+
+NAME=fasttime does not bypass explicit syscall tracing
+FILE=bins/elf/analysis/fasttime-sleep
+ARGS=-d -e log.level=0
+CMDS=<<EOF
+ood
+e dbg.fasttime=true
+dcs clock_nanosleep nanosleep
+dr SN
+q!
+EOF
+EXPECT=<<EOF
+Running child until syscalls:230 35
+0x00000023
+EOF
+EXPECT_ERR=<<EOF
+child received signal 9
+EOF
+RUN

--- a/test/db/archos/linux-x86_64/dbg_fasttime
+++ b/test/db/archos/linux-x86_64/dbg_fasttime
@@ -11,9 +11,6 @@ EOF
 EXPECT=<<EOF
 reached
 EOF
-EXPECT_ERR=<<EOF
-child received signal 9
-EOF
 RUN
 
 NAME=fasttime does not bypass explicit syscall tracing


### PR DESCRIPTION
This extracts the dbg.fasttime feature into its own branch.

Scope:
- dbg.fasttime config
- debugger fasttime state tracking
- Linux native debugger timer-syscall virtualization
- Linux r2r coverage for fasttime

Note:
- local build is clean
- the dbg_fasttime r2r still needs one more validation pass in this split branch before this should leave draft