### PR TITLE
Implement wide string length measurement in is_string()

### DIFF
--- a/libr/anal/data.c
+++ b/libr/anal/data.c
@@ -106,7 +106,15 @@ static int is_string(const ut8 *buf, int size, int *len) {
 		return 0;
 	}
 	if (size > 3 && buf[0] && !buf[1] && buf[2] && !buf[3]) {
-		*len = 1; // XXX: TODO: Measure wide string length
+		int wlen = 0;
+		int j;
+		for (j = 0; j + 1 < size; j += 2) {
+			if (!buf[j] && !buf[j + 1]) {
+				break;
+			}
+			wlen++;
+		}
+		*len = R_MAX (wlen, 1);
 		return 2; // is wide
 	}
 	for (i = 0; i < size; i++) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -139,7 +139,15 @@ static int is_string(const ut8 *buf, int size, int *len) {
 		len = &fakeLen;
 	}
 	if (size > 3 && buf[0] && !buf[1] && buf[2] && !buf[3]) {
-		*len = 1; // XXX: TODO: Measure wide string length
+		int wlen = 0;
+		int i;
+		for (i = 0; i + 1 < size; i += 2) {
+			if (!buf[i] && !buf[i + 1]) {
+				break;
+			}
+			wlen++;
+		}
+		*len = R_MAX (wlen, 1);
 		return 2; // is wide
 	}
 	for (i = 0; i < size; i++) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1712,7 +1712,15 @@ static int is_string(const ut8 *buf, int size, int *len) {
 		return 0;
 	}
 	if (size > 3 && buf[0] && !buf[1] && buf[2] && !buf[3]) {
-		*len = 1; // XXX: TODO: Measure wide string length
+		int wlen = 0;
+		int j;
+		for (j = 0; j + 1 < size; j += 2) {
+			if (!buf[j] && !buf[j + 1]) {
+				break;
+			}
+			wlen++;
+		}
+		*len = R_MAX (wlen, 1);
 		return 2; // is wide
 	}
 	for (i = 0; i < size; i++) {


### PR DESCRIPTION
The is_string() function detected wide (UTF-16LE) strings but
hardcoded the length to 1. Now it walks the buffer counting
wide characters until a null terminator (two zero bytes).

Fixes the TODO in all three copies: anal/data.c, core/canal.c,
and core/core.c.

https://claude.ai/code/session_01SSRzs47FAPNvo4fP1hq43k