### PR TITLE
Convert r_num_minmax_swap_i from R_API function to static inline ##util

### DIFF
--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -85,7 +85,13 @@ R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex);
 R_API ut64 r_num_tail_base(RNum *num, ut64 addr, ut64 off);
 R_API bool r_num_segaddr(ut64 addr, ut64 sb, int sg, ut32 *a, ut32 *b);
 R_API void r_num_minmax_swap(ut64 *a, ut64 *b);
-R_API void r_num_minmax_swap_i(int *a, int *b); // XXX this can be a cpp macro :??
+static inline void r_num_minmax_swap_i(int *a, int *b) {
+	if (*a > *b) {
+		int tmp = *a;
+		*a = *b;
+		*b = tmp;
+	}
+}
 
 R_API ut64 r_num_get(RNum *num, const char *str);
 R_API ut64 r_num_get_err(RNum *num, const char *str, const char **err);

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -88,13 +88,6 @@ R_API void r_num_minmax_swap(ut64 *a, ut64 *b) {
 	}
 }
 
-R_API void r_num_minmax_swap_i(int *a, int *b) {
-	if (*a > *b) {
-		ut64 tmp = *a;
-		*a = *b;
-		*b = tmp;
-	}
-}
 
 R_API RNum *r_num_new(RNumCallback cb, RNumCallback2 cb2, void *ptr) {
 	RNum *num = R_NEW0 (RNum);


### PR DESCRIPTION
The XXX comment noted this simple swap function should be a macro/inline.
Convert it to a static inline in the header and remove the function body
from unum.c, avoiding unnecessary function call overhead. Also fix the
temp variable type from ut64 to int to match the parameter types.

https://claude.ai/code/session_01QCqsmpxEnAN7bAv9pp3AqF