### PR TITLE
Remove r_num_minmax_swap_i function and inline its usage

### DIFF
--- a/libr/include/r_util/r_num.h
+++ b/libr/include/r_util/r_num.h
@@ -85,7 +85,6 @@ R_API ut64 r_num_tail(RNum *num, ut64 addr, const char *hex);
 R_API ut64 r_num_tail_base(RNum *num, ut64 addr, ut64 off);
 R_API bool r_num_segaddr(ut64 addr, ut64 sb, int sg, ut32 *a, ut32 *b);
 R_API void r_num_minmax_swap(ut64 *a, ut64 *b);
-R_API void r_num_minmax_swap_i(int *a, int *b); // XXX this can be a cpp macro :??
 
 R_API ut64 r_num_get(RNum *num, const char *str);
 R_API ut64 r_num_get_err(RNum *num, const char *str, const char **err);

--- a/libr/util/print.c
+++ b/libr/util/print.c
@@ -362,7 +362,11 @@ R_API bool r_print_have_cursor(RPrint *p, int cur, int len) {
 	if (p->ocur != -1) {
 		int from = p->ocur;
 		int to = p->cur;
-		r_num_minmax_swap_i (&from, &to);
+		if (from > to) {
+				int tmp = from;
+				from = to;
+				to = tmp;
+			}
 		do {
 			if (cur + len - 1 >= from && cur + len - 1 <= to) {
 				return true;

--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -88,14 +88,6 @@ R_API void r_num_minmax_swap(ut64 *a, ut64 *b) {
 	}
 }
 
-R_API void r_num_minmax_swap_i(int *a, int *b) {
-	if (*a > *b) {
-		ut64 tmp = *a;
-		*a = *b;
-		*b = tmp;
-	}
-}
-
 R_API RNum *r_num_new(RNumCallback cb, RNumCallback2 cb2, void *ptr) {
 	RNum *num = R_NEW0 (RNum);
 	r_ref_init (num, r_num_free);

--- a/test/unit/test_unum.c
+++ b/test/unit/test_unum.c
@@ -44,16 +44,6 @@ bool test_r_num_units(void) {
 	mu_end;
 }
 
-bool test_r_num_minmax_swap_i(void) {
-	int a = -1, b = 2;
-	r_num_minmax_swap_i (&a, &b);
-	mu_assert_eq (a == -1 && b == 2, 1, "a < b -> a < b");
-	a = 2, b = -1;
-	r_num_minmax_swap_i (&a, &b);
-	mu_assert_eq (a == -1 && b == 2, 1, "b < a -> a < b");
-	mu_end;
-}
-
 bool test_r_num_minmax_swap(void) {
 	ut64 a = 1, b = 2;
 	r_num_minmax_swap (&a, &b);
@@ -128,7 +118,6 @@ bool test_r_num_str_split_list(void) {
 
 bool all_tests(void) {
 	mu_run_test (test_r_num_units);
-	mu_run_test (test_r_num_minmax_swap_i);
 	mu_run_test (test_r_num_minmax_swap);
 	mu_run_test (test_r_num_between);
 	mu_run_test (test_r_num_str_len);


### PR DESCRIPTION
## Description

This PR removes the `r_num_minmax_swap_i()` function which was a specialized integer version of `r_num_minmax_swap()`. The function was only used in one place (`libr/util/print.c`) and has been replaced with an inline implementation.

The removal includes:
- Deletion of `r_num_minmax_swap_i()` function from `libr/util/unum.c`
- Removal of function declaration from `libr/include/r_util/r_num.h`
- Inlining the swap logic directly in `libr/util/print.c` where it was the sole caller
- Removal of the corresponding unit test

This simplification reduces API surface area and eliminates a single-use utility function, as suggested by the original comment in the header file ("XXX this can be a cpp macro :??").

## Testing

Existing unit tests for the remaining `r_num_minmax_swap()` function continue to validate the swap logic for 64-bit unsigned integers.

- [ ] Mark this if you consider it ready to merge

https://claude.ai/code/session_01Cx5vYgfRFuhrasG3B8ixCA