### PR TITLE
util: Add binary string validation to prevent parsing bugs

### DIFF
--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -194,6 +194,19 @@ static void error(RNum * R_NULLABLE num, const char *err_str) {
 	}
 }
 
+static bool is_valid_binary_string(const char *str) {
+	if (R_STR_ISEMPTY (str)) {
+		return false;
+	}
+	while (*str) {
+		if (*str != '0' && *str != '1' && *str != '_') {
+			return false;
+		}
+		str++;
+	}
+	return true;
+}
+
 static ut64 r_num_from_binary(RNum *num, const char *str) {
 	int i, j;
 	ut64 ret = 0;
@@ -301,7 +314,7 @@ R_API ut64 r_num_get_err(RNum * R_NULLABLE num, const char *str, const char **er
 			return (ut64) ((s << 4) + a);
 		}
 	}
-	if (str[0] == '0' && str[1] == 'b') { // XXX this is wrong and causes bugs
+	if (str[0] == '0' && str[1] == 'b' && is_valid_binary_string (str + 2)) {
 		ret = r_num_from_binary (num, str + 2);
 	} else if (str[0] == '\'') {
 		ret = str[1] & 0xff;


### PR DESCRIPTION
## Description

This PR fixes a bug in binary number parsing by adding proper validation of binary strings before conversion.

### Changes

- Added `is_valid_binary_string()` function to validate that a string contains only valid binary characters ('0', '1', and '_')
- Updated the binary number parsing condition in `r_num_get_err()` to validate the binary string before attempting conversion
- This prevents the XXX comment issue where invalid binary strings could cause parsing bugs

### Rationale

The original code had a known issue (marked with "XXX this is wrong and causes bugs") where it would attempt to parse any string starting with "0b" as binary without validating the actual content. This could lead to incorrect parsing results or undefined behavior. The validation function ensures only properly formatted binary strings are processed.

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

https://claude.ai/code/session_015oZnZw2vWUWQ4ZnbAN5yn8