### PR TITLE
Fix mdmp loop-count underflow when stream offsets exceed file size

### DIFF
--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -5,9 +5,16 @@
 #include "mdmp.h"
 
 static ut32 safe_loop_count(ut64 offset, ut32 count, size_t item_size, ut64 obj_size, const char *item_name) {
-	if (offset + (ut64)count * item_size > obj_size) {
+	ut64 total_size;
+
+	if (!item_size || offset >= obj_size) {
+		R_LOG_WARN ("%s descriptor out of bounds, reducing from %u to 0",
+			item_name, count);
+		return 0;
+	}
+	if (r_mul_overflow ((ut64)count, (ut64)item_size, &total_size) || offset > obj_size - total_size) {
 		ut32 max_count = (obj_size - offset) / item_size;
-		R_LOG_WARN ("%s descriptor out of bounds, reducing from %d to %d",
+		R_LOG_WARN ("%s descriptor out of bounds, reducing from %u to %u",
 			item_name, count, max_count);
 		return max_count;
 	}


### PR DESCRIPTION
### Motivation
- The MDMP parser computed `(obj_size - offset) / item_size` without checking `offset >= obj_size`, allowing unsigned underflow to produce extremely large loop counts and enabling DoS via excessive allocations. 
- The change hardens the bounds calculation to prevent malformed MDMPs with RVAs near EOF from causing unbounded iterations in module/memory parsing.

### Description
- Hardened `safe_loop_count` in `libr/bin/format/mdmp/mdmp.c` to return `0` when `offset >= obj_size` or `item_size == 0` to avoid underflow and divide-by-zero risks. 
- Replaced unchecked multiplication with `r_mul_overflow` and a safe `offset > obj_size - total_size` comparison to prevent overflow/underflow when computing required size. 
- Kept the existing clamping behavior for truncated descriptor lists and adjusted logging format specifiers to unsigned types to match `ut32`/`ut64` usage.

### Testing
- Attempted a local build with `make -j` but the build failed in this environment due to missing subproject files (`libr/config.mk`), so a full compilation/test run could not be executed here. 
- No automated unit tests were run in-repo because the environment prevents completing a full build and test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af97991f4c833189ce420b83362a20)