### PR TITLE
Harden SOM string-table bounds checks

### DIFF
--- a/libr/bin/format/som/som.c
+++ b/libr/bin/format/som/som.c
@@ -1,6 +1,7 @@
 /* radare2 - LGPL - Copyright 2025 - pancake */
 
 #define R_LOG_ORIGIN "bin.som"
+#define SOM_STRING_TABLE_LIMIT (1U << 24)
 
 #include "som.h"
 #include <string.h>
@@ -68,6 +69,10 @@ R_IPI bool r_bin_som_check_buffer(RBuffer *b) {
 
 static void read_string_table(RBuffer *b, ut64 location, ut32 size, char **strings) {
 	if (location > 0 && size > 0) {
+		const ut64 file_size = r_buf_size (b);
+		if (size > SOM_STRING_TABLE_LIMIT || location >= file_size || (ut64)size > file_size - location) {
+			return;
+		}
 		char *data = malloc (size);
 		if (data) {
 			if (r_buf_read_at (b, location, (ut8 *)data, size) == size) {


### PR DESCRIPTION
### Motivation
- Prevent untrusted SOM header fields from driving unbounded `malloc` calls that can exhaust memory or crash the process when opening crafted SOM files.

### Description
- Add a conservative upper bound `SOM_STRING_TABLE_LIMIT` (16 MiB) and validate the requested range against the backing buffer size in `read_string_table` before calling `malloc`, returning early for oversized or out-of-bounds requests to preserve behavior for valid files.

### Testing
- Attempted an automated build with `make -j2`, but it failed in this environment due to missing project files (`libr/config.mk`), so no full build or test-suite run was possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b221197c248331af23c274f180efc0)