### PR TITLE
Fix panels menu double free causes segfault on quit ##panels

### DIFF
--- a/libr/core/panels.inc.c
+++ b/libr/core/panels.inc.c
@@ -1860,7 +1860,6 @@ static void r_panels_free_menu_item(RPanelsMenuItem *item) {
 
 static void r_panels_mht_free_kv(HtPPKv *kv) {
 	free (kv->key);
-	r_panels_free_menu_item ((RPanelsMenuItem *)kv->value);
 }
 
 static void r_panels_free_root_menu(RPanelsMenu *menu) {
@@ -1868,11 +1867,7 @@ static void r_panels_free_root_menu(RPanelsMenu *menu) {
 		return;
 	}
 	if (menu->root) {
-		free (menu->root->name);
-		free (menu->root->desc);
-		free (menu->root->args);
-		free (menu->root->sub);
-		free (menu->root);
+		r_panels_free_menu_item (menu->root);
 	}
 	free (menu->history);
 	free (menu->refreshPanels);
@@ -3464,6 +3459,7 @@ static void r_panels_update_menu(RCore *core, const char *parent, R_NULLABLE RPa
 		r_strf_var (key, 128, "%s.%s", parent, sub->name);
 		ht_pp_delete (core->panels->mht, key);
 	}
+	free (p_item->sub);
 	p_item->sub = NULL;
 	p_item->n_sub = 0;
 	if (cb) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
## Bug
Radare2 segfaults on quit after using visual mode (V).

## Repro
r2 <binary>
aaa
s main
V
q

## Root Cause
RPanelsMenuItem pointers are stored in two places — the mht hashtable 
and the sub[] array in the menu tree. Both code paths attempted to free 
the same items, causing a double free / use-after-free on cleanup.

- ht_pp_free() calls r_panels_mht_free_kv() which freed items via the hashtable
- r_panels_free_root_menu() also freed items via the menu tree

## Fix
- Remove r_panels_free_menu_item() from r_panels_mht_free_kv() — hashtable 
  no longer owns the items, just the keys
- Replace manual frees in r_panels_free_root_menu() with r_panels_free_menu_item() 
  so the menu tree properly owns and recursively frees all items
- Add free(p_item->sub) in r_panels_update_menu() to fix a related memory leak
