### PR TITLE
Fix double-ESC returning 'q' instead of ESC in r_cons_arrow_to_hjkl

### DIFF
--- a/libr/cons/input.c
+++ b/libr/cons/input.c
@@ -118,7 +118,7 @@ R_API int r_cons_arrow_to_hjkl(RCons *cons, int ch) {
 	}
 	switch (ch) {
 	case 0x1b:
-		ch = 'q'; // XXX: must be 0x1b (R_CONS_KEY_ESC)
+		ch = R_CONS_KEY_ESC;
 		break;
 	case 0x4f: // function keys from f1 to f4
 		ch = r_cons_readchar (cons);


### PR DESCRIPTION
When a double-ESC sequence was received, r_cons_arrow_to_hjkl incorrectly
returned 'q' (quit) instead of 0x1b (ESC). This caused callers like the
hex editor column mode to quit instead of just exiting the current sub-mode.

https://claude.ai/code/session_014RwCQkr7TqXUzN5zLXhAG3