### PR TITLE
Fix integer overflow in parse_symbol_table ##crash

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -907,7 +907,12 @@ static struct r_bin_pe_export_t *parse_symbol_table(RBinPEObj *pe, struct r_bin_
 	if (!buf) {
 		return NULL;
 	}
-	exports_sz = export_t_sz * num;
+	st64 tmp_exports_sz;
+	if (r_mul_overflow ((st64)export_t_sz, (st64)num, &tmp_exports_sz) || tmp_exports_sz > ST32_MAX) {
+		free (buf);
+		return NULL;
+	}
+	exports_sz = (int)tmp_exports_sz;
 	if (exports) {
 		int osz = sz;
 		sz += exports_sz;


### PR DESCRIPTION
`exports_sz` was `export_t_sz * num` unguarded, a big NumberOfSymbols in the PE header overflows the int and leads to heap corruption, fixed with `r_mul_overflow()` + ST32_MAX check
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**


