### PR TITLE
Fix integer overflow in parse_symbol_table() (CID 1646630)

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -917,7 +917,12 @@ static struct r_bin_pe_export_t *parse_symbol_table(RBinPEObj *pe, struct r_bin_
 	exports_sz = (int)tmp_exports_sz;
 	if (exports) {
 		int osz = sz;
-		sz += exports_sz;
+		int newsz;
+		if (r_add_overflow (sz, exports_sz, &newsz) || newsz < 0 || (size_t)newsz + export_t_sz < (size_t)newsz) {
+			free (buf);
+			return NULL;
+		}
+		sz = newsz;
 		new_exports = realloc (exports, sz + export_t_sz);
 		if (!new_exports) {
 			free (buf);


### PR DESCRIPTION
Add overflow check using r_add_overflow() before adding sz + exports_sz
to prevent integer overflow that could result in an undersized realloc.

https://claude.ai/code/session_01F5RQpzRNvtXGDGzy5BVEFy