### PR TITLE
Allow io_memory_resize to truncate to 0 bytes ##io

### DIFF
--- a/libr/core/cmd_open.inc.c
+++ b/libr/core/cmd_open.inc.c
@@ -2458,7 +2458,11 @@ static int cmd_open(void *data, const char *input) {
 		if (argc > 1) {
 			const int fd = (int)r_num_math (core->num, argv[0]);
 			const ut64 size = r_num_math (core->num, argv[1]);
-			r_io_fd_resize (core->io, fd, size);
+			if (r_io_fd_resize (core->io, fd, size)) {
+				R_LOG_WARN ("maps cant have zero size, use omu command to re-create it when file resized");
+			} else {
+				R_LOG_ERROR ("fdresize failed");
+			}
 		}
 		r_str_argv_free (argv);
 		return 0;

--- a/libr/io/io_memory.c
+++ b/libr/io/io_memory.c
@@ -59,14 +59,19 @@ R_IPI int io_memory_write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 
 R_IPI bool io_memory_resize(RIO *io, RIODesc *fd, ut64 count) {
 	R_RETURN_VAL_IF_FAIL (io && fd, false);
-	if (count == 0) { // TODO: why cant truncate to 0 bytes
-		return false;
-	}
-	ut32 mallocsz = _io_malloc_sz (fd);
-	if (_io_malloc_off (fd) > mallocsz) {
-		return false;
-	}
 	RIOMalloc *mal = (RIOMalloc*)fd->data;
+	if (!mal) {
+		return false;
+	}
+	if (count == 0) {
+		R_FREE (mal->buf);
+		mal->size = 0;
+		mal->offset = 0;
+		return true;
+	}
+	if (mal->offset > mal->size) {
+		return false;
+	}
 	ut8 *new_buf = realloc (mal->buf, count);
 	if (!new_buf) {
 		return false;
@@ -94,7 +99,9 @@ R_IPI int io_memory_read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (off + count > mallocsz) {
 		left = mallocsz - off;
 	}
-	memcpy (buf, _io_malloc_buf (fd) + off, left);
+	if (left > 0) {
+		memcpy (buf, _io_malloc_buf (fd) + off, left);
+	}
 	_io_malloc_set_off (fd, off + left);
 	return count;
 }

--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -81,15 +81,21 @@ static int __write(RIO *io, RIODesc *fd, const ut8 *buf, int count) {
 }
 
 static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
-	ut8 * new_buf = NULL;
-	if (!fd || !fd->data || count == 0) {
+	if (!fd || !fd->data) {
 		return false;
+	}
+	if (count == 0) {
+		free (_io_malloc_buf (fd));
+		_io_malloc_set_buf (fd, NULL);
+		_io_malloc_set_sz (fd, 0);
+		_io_malloc_set_off (fd, 0);
+		return true;
 	}
 	ut32 mallocsz = _io_malloc_sz (fd);
 	if (_io_malloc_off (fd) > mallocsz) {
 		return false;
 	}
-	new_buf = malloc (count);
+	ut8 *new_buf = malloc (count);
 	if (!new_buf) {
 		return false;
 	}
@@ -115,7 +121,9 @@ static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
 	if (_io_malloc_off (fd) + count >= mallocsz) {
 		count = mallocsz - _io_malloc_off (fd);
 	}
-	memcpy (buf, _io_malloc_buf (fd) + _io_malloc_off (fd), count);
+	if (count > 0) {
+		memcpy (buf, _io_malloc_buf (fd) + _io_malloc_off (fd), count);
+	}
 	return count;
 }
 

--- a/libr/io/p/io_gzip.c
+++ b/libr/io/p/io_gzip.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2008-2024 - pancake */
+/* radare - LGPL - Copyright 2008-2026 - pancake */
 
 #include <r_io.h>
 
@@ -99,7 +99,9 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	if (!new_buf) {
 		return false;
 	}
-	memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
+	if (mallocsz > 0) {
+		memcpy (new_buf, _io_malloc_buf (fd), R_MIN (count, mallocsz));
+	}
 	if (count > mallocsz) {
 		memset (new_buf + mallocsz, 0, count - mallocsz);
 	}

--- a/libr/io/p/io_malloc.c
+++ b/libr/io/p/io_malloc.c
@@ -183,15 +183,23 @@ static bool __resize(RIO *io, RIODesc *fd, ut64 count) {
 	}
 	if (r_str_startswith (fd->uri, "hex://")) {
 		RIOMalloc *mal = (RIOMalloc *)fd->data;
-		char *hex = r_hex_bin2strdup (mal->buf, mal->size);
-		if (!hex) {
-			return true;
-		}
-		char *uri = r_str_newf ("hex://%s", hex);
-		free (hex);
-		if (uri) {
-			free (fd->uri);
-			fd->uri = uri;
+		if (mal->buf && mal->size > 0) {
+			char *hex = r_hex_bin2strdup (mal->buf, mal->size);
+			if (!hex) {
+				return true;
+			}
+			char *uri = r_str_newf ("hex://%s", hex);
+			free (hex);
+			if (uri) {
+				free (fd->uri);
+				fd->uri = uri;
+			}
+		} else {
+			char *uri = strdup ("hex://");
+			if (uri) {
+				free (fd->uri);
+				fd->uri = uri;
+			}
 		}
 	}
 	return true;

--- a/libr/io/p/io_null.c
+++ b/libr/io/p/io_null.c
@@ -65,6 +65,10 @@ static ut64 __lseek(RIO* io, RIODesc* fd, ut64 offset, int whence) {
 		return offset;
 	}
 	null = (RIONull*) fd->data;
+	if (null->size == 0) {
+		null->offset = 0;
+		return 0;
+	}
 	switch (whence) {
 	case R_IO_SEEK_SET:
 		if (offset >= null->size) {

--- a/libr/io/p/io_xattr.c
+++ b/libr/io/p/io_xattr.c
@@ -106,7 +106,7 @@ static bool __close(RIODesc *fd) {
 	RIOMalloc *riom = fd->data;
 	char *attrname;
 	char *path = split_xattr_uri (fd->name, &attrname);
-	if (attrname) {
+	if (attrname && riom->buf && riom->size > 0) {
 		write_xattr (path, attrname, riom->buf, riom->size);
 	}
 	free (path);

--- a/test/db/cmd/cmd_or
+++ b/test/db/cmd/cmd_or
@@ -1,0 +1,119 @@
+NAME=or resize malloc to zero
+FILE=malloc://16
+CMDS=<<EOF
+w hello
+s 0
+p8 5
+or 3 0
+p8 8
+EOF
+EXPECT=<<EOF
+68656c6c6f
+ffffffffffffffff
+EOF
+RUN
+
+NAME=or resize malloc to zero and back
+FILE=malloc://16
+CMDS=<<EOF
+w hello
+or 3 0
+or 3 16
+omu 3 0 16 rwx
+s 0
+p8 16
+EOF
+EXPECT=<<EOF
+00000000000000000000000000000000
+EOF
+RUN
+
+NAME=or resize malloc to zero and write after grow
+FILE=malloc://16
+CMDS=<<EOF
+w hello
+or 3 0
+or 3 16
+omu 3 0 16 rwx
+s 0
+w world
+p8 5
+EOF
+EXPECT=<<EOF
+776f726c64
+EOF
+RUN
+
+NAME=or shrink preserves data
+FILE=malloc://16
+CMDS=<<EOF
+w ABCDEFGH
+or 3 4
+s 0
+p8 4
+EOF
+EXPECT=<<EOF
+41424344
+EOF
+RUN
+
+NAME=or shrink and grow preserves partial data
+FILE=malloc://16
+CMDS=<<EOF
+w ABCDEFGH
+or 3 4
+or 3 8
+omu 3 0 8 rwx
+s 0
+p8 8
+EOF
+EXPECT=<<EOF
+4142434400000000
+EOF
+RUN
+
+NAME=or resize zero map is removed
+FILE=malloc://16
+CMDS=<<EOF
+or 3 0
+om~[0]
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=or resize malloc seek after zero
+FILE=malloc://16
+CMDS=<<EOF
+or 3 0
+s 0
+s
+or 3 8
+omu 3 0 8 rwx
+s 4
+s
+EOF
+EXPECT=<<EOF
+0x0
+0x4
+EOF
+RUN
+
+NAME=or resize hex to zero and back
+FILE=hex://41424344
+CMDS=<<EOF
+s 0
+p8 4
+or 3 0
+p8 4
+or 3 4
+omu 3 0 4 rwx
+s 0
+p8 4
+EOF
+EXPECT=<<EOF
+41424344
+ffffffff
+00000000
+EOF
+RUN


### PR DESCRIPTION
The TODO asked why truncation to 0 bytes was not allowed. There was no
fundamental reason - we just need to free the buffer and reset size/offset
instead of calling realloc(ptr, 0) which has implementation-defined behavior.

Also add a NULL guard for the RIOMalloc pointer and protect the read path
from calling memcpy with a NULL source when the buffer is empty.

https://claude.ai/code/session_01H9JNeHBKZngDR8pf47GeH4