### PR TITLE
Harden r_str_sanitize to cover more dangerous characters ##security

### DIFF
--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -1255,6 +1255,12 @@ R_API void r_str_sanitize(char *c) {
 			case '&':
 			case '<':
 			case '>':
+			case '!':
+			case '\n':
+			case '\r':
+			case '\\':
+			case '"':
+			case '\'':
 				*c = '_';
 				continue;
 			}


### PR DESCRIPTION
Add newlines (\n, \r), shell/r2 escape (!), backslash, and quotes to the set of characters replaced by r_str_sanitize(). These were missing but are command separators or shell metacharacters in r2 contexts, enabling injection when unsanitized binary metadata flows into r_core_cmdf() or r_cons_printf() command output.

https://claude.ai/code/session_01XrfBCsbvdH1yZToZLeLQh3

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
