### PR TITLE
Fix command injection via bclass field in binary loading (CVE) ##security

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -532,14 +532,29 @@ static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr
 	if (bf) {
 		const char *bclass = R_UNWRAP4 (bf, bo, info, bclass);
 		if (bclass && strstr (bclass, "://")) {
-			// perform a redirection!
-			char *sb = strdup (bclass);
-			r_str_sanitize (sb);
-			char *uri = r_str_newf ("%s%s", sb, bf->file);
-			free (sb);
-			r_core_cmdf (r, "ob-*");
-			r_core_cmdf (r, "'o %s", uri);
-			free (uri);
+			// bclass containing "://" signals a bin-to-io plugin
+			// redirection. Validate the scheme resolves to a real
+			// IO plugin and guard against infinite redirection.
+			static bool redirecting;
+			if (redirecting) {
+				R_LOG_WARN ("Skipping recursive bclass IO redirection");
+			} else {
+				char *uri = r_str_newf ("%s%s", bclass, bf->file);
+				RIOPlugin *iop = r_io_plugin_resolve (r->io, uri, false);
+				if (iop && strcmp (iop->meta.name, "default")) {
+					redirecting = true;
+					r_bin_file_delete_all (r->bin);
+					RIODesc *desc = r_core_file_open (r, uri, R_PERM_R, 0);
+					if (desc) {
+						r_core_bin_load (r, uri, UT64_MAX);
+					}
+					redirecting = false;
+				} else {
+					R_LOG_WARN ("bclass URI scheme has no matching IO plugin, ignoring redirection");
+				}
+				free (uri);
+			}
+			R_CRITICAL_LEAVE (r);
 			return false;
 		}
 	}


### PR DESCRIPTION
The bclass field from binary metadata (smd, pebble, io plugins) was passed
unsanitized to r_core_cmdf() in cfile.c, allowing arbitrary command execution
via crafted binaries containing newlines and shell metacharacters in the
bclass field.

Multi-layered fix:
- Replace r_core_cmdf("o %s") with direct r_core_file_open() API call in
  cfile.c to eliminate the command injection vector entirely
- Sanitize bclass at the source in bin_smd, bin_io, bin_pebble plugins
- Harden r_str_sanitize() to also strip newlines, backslashes, quotes,
  and the r2 shell escape character (!)
- Sanitize file paths in cmd_debug.inc.c get_bin_info() before passing
  to r_core_cmdf on macOS
- Replace r_core_cmdf("e anal.cc=...") with direct r_config_set() API
  call in cbin.c to avoid command parsing of binary metadata

Fixes https://github.com/radareorg/radare2/issues/25708

https://claude.ai/code/session_01XrfBCsbvdH1yZToZLeLQh3