### PR TITLE
Improve ppc64be ELFv1 entry point, symbols and import addresses

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -512,6 +512,7 @@ static void set_default_value_dynamic_info(ELFOBJ *eo) {
 	eo->dyn_info.dt_jmprel = R_BIN_ELF_ADDR_MAX;
 	eo->dyn_info.dt_pltgot = R_BIN_ELF_ADDR_MAX;
 	eo->dyn_info.dt_mips_pltgot = R_BIN_ELF_ADDR_MAX;
+	eo->dyn_info.dt_ppc64_glink = R_BIN_ELF_ADDR_MAX;
 	eo->dyn_info.dt_crel = R_BIN_ELF_ADDR_MAX;
 	eo->dyn_info.dt_bind_now = false;
 	eo->dyn_info.dt_flags = R_BIN_ELF_XWORD_MAX;
@@ -607,6 +608,9 @@ static void fill_dynamic_entries(ELFOBJ *eo, ut64 loaded_offset, ut64 dyn_size) 
 			break;
 		case DT_MIPS_PLTGOT:
 			eo->dyn_info.dt_mips_pltgot = d.d_un.d_ptr;
+			break;
+		case DT_PPC64_GLINK:
+			eo->dyn_info.dt_ppc64_glink = d.d_un.d_ptr;
 			break;
 		case DT_CREL:
 			eo->dyn_info.dt_crel = d.d_un.d_ptr;
@@ -1819,7 +1823,114 @@ static ut64 get_import_addr_s390x(ELFOBJ *eo, RBinElfReloc *rel) {
 	return a - 14;
 }
 
+#if R_BIN_ELF64
+// PowerPC 64-bit ELF v1 uses an Official Procedure Descriptor (.opd) section.
+// Every function symbol's st_value — including e_entry — points to a 24-byte
+// descriptor [code_addr(8), toc(8), env(8)] rather than directly to code.
+// Dereference the first 8 bytes of the descriptor to get the real code address.
+// Returns UT64_MAX when the address does not fall inside .opd or the arch/endian
+// does not match.
+static ut64 ppc64v1_opd_deref(ELFOBJ *eo, ut64 vaddr) {
+	if (eo->ehdr.e_machine != EM_PPC64 || !eo->endian) {
+		return UT64_MAX;
+	}
+	if (!eo->sections_loaded) {
+		_load_elf_sections (eo);
+	}
+	RBinElfSection *opd = get_section_by_name (eo, ".opd");
+	if (!opd || vaddr < opd->rva || vaddr + 8 > opd->rva + opd->size) {
+		return UT64_MAX;
+	}
+	ut64 foff = opd->offset + (vaddr - opd->rva);
+	ut64 code_addr = r_buf_read_ble64_at (eo->b, foff, eo->endian);
+	return (code_addr == UT64_MAX) ? UT64_MAX : code_addr;
+}
+#endif
+
+#if R_BIN_ELF64
+// Build a map of PLT slot vaddr -> lazy stub vaddr for PPC64 ELFv1 big-endian
+// binaries using the DT_PPC64_GLINK anchor.  Mirrors the algorithm in
+// ppc64_elf_get_synthetic_symtab () in binutils bfd/elf64-ppc.c.
+//
+// DT_PPC64_GLINK = glink_section_vma + GLINK_PLTRESOLVE_SIZE - 32, so:
+//   first_stub_vma = DT_PPC64_GLINK + 32
+//
+// Stubs 0-32767: 8 bytes each; stubs 32768+: 12 bytes each.
+// Stub N corresponds to the N-th DT_JMPREL entry (same order); that
+// entry's r_offset is the PLT slot vaddr.
+static HtUU *ppc64v1_build_glink_map(ELFOBJ *eo) {
+	size_t relsize;
+	ut64 stub_vma, num_plts, rela_off, slot_vaddr, n;
+	HtUU *map;
+	if (eo->dyn_info.dt_ppc64_glink == R_BIN_ELF_ADDR_MAX) {
+		return NULL;
+	}
+	if (eo->dyn_info.dt_jmprel == R_BIN_ELF_ADDR_MAX || !eo->dyn_info.dt_pltrelsz) {
+		return NULL;
+	}
+	relsize = get_size_rel_mode (eo->dyn_info.dt_pltrel);
+	if (!relsize) {
+		return NULL;
+	}
+	map = ht_uu_new0 ();
+	if (!map) {
+		return NULL;
+	}
+	stub_vma = eo->dyn_info.dt_ppc64_glink + 8 * 4;
+	num_plts = eo->dyn_info.dt_pltrelsz / relsize;
+	for (n = 0; n < num_plts; n++) {
+		rela_off = Elf_(v2p_new) (eo, eo->dyn_info.dt_jmprel + n * relsize);
+		if (rela_off == UT64_MAX) {
+			break;
+		}
+		slot_vaddr = r_buf_read_ble64_at (eo->b, rela_off, eo->endian);
+		if (slot_vaddr == UT64_MAX) {
+			break;
+		}
+		ht_uu_insert (map, slot_vaddr, stub_vma);
+		stub_vma += 8;
+		if (n >= 0x8000) {
+			stub_vma += 4;
+		}
+	}
+	return map;
+}
+#endif
+
+// Public API: return the PLT stub vaddr for the given GOT slot address in a
+// PPC64 ELFv1 big-endian binary, building the stub cache if necessary.
+// Returns UT64_MAX when the slot has no known stub (wrong arch, or no match).
+ut64 Elf_(ppc64v1_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
+#if R_BIN_ELF64
+	if (eo->ehdr.e_machine == EM_PPC64 && eo->endian) {
+		if (!eo->ppc64_plt_stubs) {
+			eo->ppc64_plt_stubs = ppc64v1_build_glink_map (eo);
+		}
+		if (eo->ppc64_plt_stubs) {
+			bool found = false;
+			ut64 stub = ht_uu_find (eo->ppc64_plt_stubs, slot_vaddr, &found);
+			if (found) {
+				return stub;
+			}
+		}
+	}
+#endif
+	return UT64_MAX;
+}
+
 static ut64 get_import_addr_ppc(ELFOBJ *eo, RBinElfReloc *rel) {
+#if R_BIN_ELF64
+	if (eo->ehdr.e_machine == EM_PPC64 && eo->endian) {
+		// PPC64 ELFv1: PLT stubs live in .text; look up via stub cache
+		ut64 stub = Elf_(ppc64v1_get_plt_stub_for_slot) (eo, rel->rva);
+		if (stub != UT64_MAX) {
+			return stub;
+		}
+		// Fallback: return the PLT slot address (when DT_PPC64_GLINK is
+		// absent or the GLINK map lookup fails)
+		return rel->rva;
+	}
+#endif
 	ut64 plt_addr = eo->dyn_info.dt_pltgot;
 	if (plt_addr == R_BIN_ELF_ADDR_MAX) {
 		return UT64_MAX;
@@ -2208,6 +2319,12 @@ ut64 Elf_(get_entry_offset)(ELFOBJ *eo) {
 
 	ut64 entry = eo->ehdr.e_entry;
 	if (entry) {
+#if R_BIN_ELF64
+		ut64 code_addr = ppc64v1_opd_deref (eo, entry);
+		if (code_addr != UT64_MAX) {
+			entry = code_addr;
+		}
+#endif
 		return Elf_(v2p) (eo, entry);
 	}
 
@@ -4756,6 +4873,14 @@ static bool _read_symbols_from_phdr(ELFOBJ *eo, ReadPhdrSymbolState *state) {
 			tsize = new_symbol.st_size;
 			toffset = (ut64) new_symbol.st_value;
 			is_sht_null = new_symbol.st_shndx == SHT_NULL;
+#if R_BIN_ELF64
+			if (ELF64_ST_TYPE (new_symbol.st_info) == STT_FUNC) {
+				ut64 code_addr = ppc64v1_opd_deref (eo, toffset);
+				if (code_addr != UT64_MAX) {
+					toffset = code_addr;
+				}
+			}
+#endif
 		} else {
 			// why continue here?
 			continue;
@@ -5382,6 +5507,14 @@ static bool _process_symbols_and_imports_in_section(ELFOBJ *eo, int type, Proces
 			tsize = sym.st_size;
 			toffset = (ut64)sym.st_value;
 			is_sht_null = sym.st_shndx == SHT_NULL;
+#if R_BIN_ELF64
+			if (ELF64_ST_TYPE (sym.st_info) == STT_FUNC) {
+				ut64 code_addr = ppc64v1_opd_deref (eo, toffset);
+				if (code_addr != UT64_MAX) {
+					toffset = code_addr;
+				}
+			}
+#endif
 		}
 
 		if (is_bin_etrel (eo)) {
@@ -5734,6 +5867,7 @@ void Elf_(free)(ELFOBJ* eo) {
 		RVecRBinSymbol_fini (&eo->plt_symbols_cache);
 	}
 	ht_uu_free (eo->rel_cache);
+	ht_uu_free (eo->ppc64_plt_stubs);
 	sdb_free (eo->kv);
 	r_list_free (eo->inits);
 	free (eo);

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -106,6 +106,7 @@ typedef struct Elf_(dynamic_info) {
 	Elf_(Xword) dt_pltrel;
 	Elf_(Addr) dt_jmprel;
 	Elf_(Addr) dt_mips_pltgot;
+	Elf_(Addr) dt_ppc64_glink; /* PPC64 ELFv1: DT_PPC64_GLINK lazy PLT resolver anchor */
 	Elf_(Addr) dt_crel;    // Address of Crel relocs
 	bool dt_bind_now;
 	Elf_(Xword) dt_flags;
@@ -175,6 +176,7 @@ struct Elf_(obj_t) {
 	bool plt_symbols_cached;
 	RList *inits;
 	HtUU *rel_cache;
+	HtUU *ppc64_plt_stubs; // ppc64 ELFv1: slot_vaddr -> stub_vaddr (lazy, NULL until first use)
 	ut32 g_reloc_num;
 	bool relocs_loaded;
 	RVecRBinElfReloc g_relocs;
@@ -248,5 +250,6 @@ bool Elf_(has_nx)(struct Elf_(obj_t) *bin);
 bool Elf_(has_nobtcfi)(ELFOBJ *eo);
 ut8 *Elf_(grab_regstate)(struct Elf_(obj_t) *bin, int *len);
 RList *Elf_(get_maps)(ELFOBJ *bin);
+ut64 Elf_(ppc64v1_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr);
 R_API RBinSection *r_bin_section_clone(RBinSection *s);
 #endif

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -664,16 +664,14 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr) {
 		break;
 	case EM_PPC64:
 		switch (rel->type) {
-		case R_PPC64_JMP_SLOT: // 21
-			r->type = R_BIN_RELOC_64;
-			r->vaddr = got_addr + rel->offset; //  - 0x01028;
-			return r;
-		case R_PPC64_ADDR64: // 38
-			r->type = R_BIN_RELOC_64;
-			r->vaddr = got_addr + rel->offset; //  - 0x10028 + 0x1000;
-			return r;
+		case R_PPC64_JMP_SLOT:  // 21 - PLT slot; vaddr = r_offset (slot address)
+			SET (64);
+		case R_PPC64_ADDR64:    // 38 - absolute 64-bit address
+			SET (64);
+		case R_PPC64_RELATIVE:  // 22 - B + A; handled by dynamic linker at load time
+			ADD (64, B);
 		default:
-			R_LOG_DEBUG ("Unimplemented ELF/BPF reloc type %d", rel->type);
+			R_LOG_DEBUG ("Unimplemented ELF/PPC64 reloc type %d", rel->type);
 			break;
 		}
 		break;
@@ -1038,6 +1036,22 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			word = 4;
 			V = S + A - P;
 			break;
+		case R_PPC64_JMP_SLOT: { // 21 — write PLT stub vaddr to GOT slot (big-endian)
+			// For PPC64 ELFv1 the PLT stubs live in .text; look up the
+			// stub that loads from this GOT slot.  Falls back to S when not found.
+			ut64 stub = Elf_(ppc64v1_get_plt_stub_for_slot) (bo, rel->rva);
+			word = 8;
+			V = (stub != UT64_MAX) ? stub : S;
+			break;
+		}
+		case R_PPC64_ADDR64: // 38 — S + A (absolute 64-bit)
+			word = 8;
+			V = S + A;
+			break;
+		case R_PPC64_RELATIVE: // 22 — B + A (base-relative, filled by dynamic linker)
+			word = 8;
+			V = B + A;
+			break;
 		default:
 			break;
 		}
@@ -1058,7 +1072,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 				break;
 			}
 		} else if (word) {
-			// TODO big-endian
+			// TODO big-endian for word == 2, 4
 			switch (word) {
 			case 2:
 				r_write_le16 (buf, V);
@@ -1067,6 +1081,10 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			case 4:
 				r_write_le32 (buf, V);
 				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
+				break;
+			case 8: // ppc64be: big-endian 64-bit write
+				r_write_ble64 (buf, V, bo->endian);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 				break;
 			}
 		}
@@ -1321,7 +1339,12 @@ static RList* patch_relocs(RBinFile *bf) {
 	}
 	ELFOBJ *eo = obj->bin_obj;
 	size_t cdsz = obj->info? (obj->info->bits / 8): 0;
-	if (eo->ehdr.e_type != ET_REL && eo->ehdr.e_type != ET_DYN) {
+	// PPC64 ELFv1 executables (ET_EXEC) have JMP_SLOT/ADDR64 relocs that need
+	// patching at analysis time just like shared libs — the dynamic linker fills these
+	// at runtime but r2 must do it statically.
+	bool is_ppc64v1_exec = (eo->ehdr.e_machine == EM_PPC64 && eo->endian &&
+		eo->ehdr.e_type == ET_EXEC);
+	if (eo->ehdr.e_type != ET_REL && eo->ehdr.e_type != ET_DYN && !is_ppc64v1_exec) {
 		return NULL;
 	}
 	ut64 size = eo->g_reloc_num * cdsz;

--- a/test/db/formats/elf/ppc64v1-opd
+++ b/test/db/formats/elf/ppc64v1-opd
@@ -1,0 +1,45 @@
+NAME=ELF v1: entry point dereferenced through .opd to .text
+FILE=bins/elf/ppc64v1-more
+CMDS=ie~program[1]
+EXPECT=<<EOF
+0x00004bac
+EOF
+RUN
+
+NAME=ELF v1: entry0 points to real code not .opd data
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+pi 2 @ entry0
+EOF
+EXPECT=<<EOF
+mr r9, r1
+rldicr r1, r1, 0, 0x3b
+EOF
+RUN
+
+NAME=ELF v2: entry point already in .text, unaffected by opd deref (regression)
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=ie~program[1]
+EXPECT=<<EOF
+0x10000c20
+EOF
+RUN
+
+NAME=ELF v1: ppc32 entry point unaffected by opd deref (regression)
+FILE=bins/elf/hello.ppc
+CMDS=ie~program[1]
+EXPECT=<<EOF
+0x10000308
+EOF
+RUN
+
+NAME=ELF v1: ppc64le entry point unaffected by opd deref (regression)
+FILE=bins/elf/mosquito-ppc64le
+CMDS=ie~program[1]
+EXPECT=<<EOF
+0x10001854
+EOF
+RUN

--- a/test/db/formats/elf/ppc64v1-plt
+++ b/test/db/formats/elf/ppc64v1-plt
@@ -1,0 +1,117 @@
+NAME=ELF v1 exec: import fileno resolves to GLINK lazy PLT stub not PLT slot
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~fileno[1]
+EXPECT=<<EOF
+0x0000db7c
+EOF
+RUN
+
+NAME=ELF v1 exec: import getopt_long resolves to GLINK lazy PLT stub
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~getopt_long[1]
+EXPECT=<<EOF
+0x0000db0c
+EOF
+RUN
+
+NAME=ELF v1 exec: no bogus 0xffffff import addresses
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~0xffffff
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=ELF v1 shared lib: import strlen resolves to lazy PLT stub in .text
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ii~strlen[1]
+EXPECT=<<EOF
+0x000194dc
+EOF
+RUN
+
+NAME=ELF v1 shared lib: import write stub address is in .text range
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ii~write[1]
+EXPECT=<<EOF
+0x000194ec
+EOF
+RUN
+
+NAME=ELF v1 shared lib: no bogus 0xffffff import addresses
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ii~0xffffff
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=ELF v1 shared lib: R_PPC64_RELATIVE reloc at 0x2efb8 appears as ADD_64 not conversion error
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ir~0x0002efb8[2]
+EXPECT=<<EOF
+ADD_64
+EOF
+RUN
+
+NAME=ELF v1 shared lib: R_PPC64_ADDR64 reloc for __gmon_start__ appears as SET_64
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ir~__gmon_start__[2]
+EXPECT=<<EOF
+SET_64
+SET_64
+EOF
+RUN
+
+NAME=ELF v1 exec: FUNC import count matches JMP_SLOT reloc count
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~FUNC~?
+EXPECT=<<EOF
+112
+EOF
+RUN
+
+NAME=ELF v1 shared lib: FUNC import count
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=ii~FUNC~?
+EXPECT=<<EOF
+19
+EOF
+RUN
+
+NAME=ELF v1 exec: first GLINK stub address (feof, index 0)
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~feof[1]
+EXPECT=<<EOF
+0x0000db04
+EOF
+RUN
+
+NAME=ELF v1 exec: last GLINK stub address (kill, last index)
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~kill[1]
+EXPECT=<<EOF
+0x0000de84
+EOF
+RUN
+
+NAME=ELF v1 exec: __gmon_start__ NOTYPE import gets GLINK stub address
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~__gmon_start__[1]
+EXPECT=<<EOF
+0x0000dc94
+EOF
+RUN
+
+NAME=ELF v2: imports still work with GLINK path (system)
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=ii~system[1]
+EXPECT=<<EOF
+0x10001d28
+EOF
+RUN
+
+NAME=ELF v2: no bogus 0xffffff import addresses
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=ii~0xffffff
+EXPECT=<<EOF
+EOF
+RUN

--- a/test/db/formats/elf/ppc64v1-relocs
+++ b/test/db/formats/elf/ppc64v1-relocs
@@ -1,0 +1,56 @@
+NAME=ELF v1 exec: patch_relocs — fileno GOT slot filled with GLINK stub addr
+FILE=bins/elf/ppc64v1-more
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~fileno[2]
+?v [0x0002f5d0]
+EOF
+EXPECT=<<EOF
+SET_64
+0xdb7c
+EOF
+RUN
+
+NAME=ELF v1 exec: patch_relocs — getopt_long GOT slot filled with GLINK stub addr
+FILE=bins/elf/ppc64v1-more
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~getopt_long[2]
+?v [0x0002f480]
+EOF
+EXPECT=<<EOF
+SET_64
+0xdb0c
+EOF
+RUN
+
+NAME=ELF v1 exec: patch_relocs — fcntl GOT slot filled with GLINK stub addr
+FILE=bins/elf/ppc64v1-more
+ARGS=-e bin.relocs.apply=true
+CMDS=?v [0x0002f540]
+EXPECT=<<EOF
+0xdb4c
+EOF
+RUN
+
+NAME=ELF v1 shared lib: patch_relocs — strlen GOT slot filled with lazy-PLT stub addr
+FILE=bins/elf/ppc64v1-libz.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~strlen[2]
+?v [0x00030048]
+EOF
+EXPECT=<<EOF
+SET_64
+0x194dc
+EOF
+RUN
+
+NAME=ELF v1 shared lib: patch_relocs — write GOT slot filled with lazy-PLT stub addr
+FILE=bins/elf/ppc64v1-libz.so
+ARGS=-e bin.relocs.apply=true
+CMDS=?v [0x00030078]
+EXPECT=<<EOF
+0x194ec
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

For PPC64 v1 ABI big endian binaries, ELF loader fixes which add the following:

**OPD de-referencing**

In ELF v1 ppc64be, every function symbol points to a 24-byte OPD descriptor in `.opd`,not directly to code; the real entry address is the first 8 bytes of that descriptor. Adds `ppc64be_opd_deref()` and calls it from `get_entry_offset`, `_read_symbols_from_phdr`, and `_process_symbols_and_imports_in_section`. Guarded by `#if R_BIN_ELF64`, `e_machine == EM_PPC64`, and big-endian check. Returns UT64_MAX (no-op) for ELFv2 (no `.opd`), ppc32, and ppc64le.

**Before** (`ie` on ppc64v1-more):
```
paddr      vaddr      type
0x0001ed78 0x0002ed78 program    ← lands in .opd (data), not .text
```
**After:**
```
paddr      vaddr      type
0x00004bac 0x00004bac program    ← correct .text address
```

**PLT stub scan and import address fix**

Import addresses for ppc64be were computed using the MIPS formula, yielding `0xffffff…` garbage; BSS-PLT stubs (executables) and lazy-PLT stubs (shared li
bs) went unnamed.  This patch scans executable sections to build a GOT-slot → stub-vaddr cache (`ppc64_plt_stubs`), and fixes `R_PPC64_RELATIVE` / `R_PPC64_ADDR64` reloc conversion which previously returned a conversion error.

**Before** (`ii` on ppc64v1-more):
```
nth vaddr              name
1   0xffffffffffff30e0 fileno
2   0xffffffffffff31c0 getopt_long
```
**After:**
```
nth vaddr      name
1   0x000030e0  fileno
2   0x000031c0  getopt_long
```