### PR TITLE
Resolve PPC64 ELFv1 TOC-relative address chains in analysis

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -641,7 +641,18 @@ typedef struct plugin_data_t {
 	CapstonePluginData cpd;
 	char cspr[16];
 	char words[8][64];
+	/* PPC64 ELFv1 TOC-relative address resolution.
+	 * addis rX, r2, HA  stores  config->gp + (HA<<16)  in toc_map[X].
+	 * A later ld/addi/st rY, LO(rX)  resolves op->ptr/val from toc_map[X].
+	 * Indexed by logical GPR number (0..31); 0 means "no pending value". */
+	ut64 toc_map[32];
 } PluginData;
+
+/* Map a capstone PPC register ID to a GPR index 0..31, or -1 for non-GPRs. */
+static inline int toc_reg_idx(unsigned int cs_reg) {
+	int idx = (int)cs_reg - (int)PPC_REG_R0;
+	return (idx >= 0 && idx < 32) ? idx : -1;
+}
 
 static const char* getspr(PluginData *pd, struct Getarg *gop, int n) {
 	ut32 spr = 0;
@@ -771,7 +782,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		return false;
 	}
 
-	int ret;
+	int ret, ridx;
 	cs_insn *insn;
 	char *op1;
 
@@ -937,6 +948,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_STWCX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[4]"));
+			/* PPC64 ELFv1 TOC chain: stw rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STWU:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -949,6 +967,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				op->stackop = R_ANAL_STACK_INC;
 				op->stackptr = -atoi (op1);
 			}
+			/* PPC64 ELFv1 TOC chain: stwu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STWBRX:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -956,6 +981,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_STB:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[1]"));
+			/* PPC64 ELFv1 TOC chain: stb rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STBU:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -964,10 +996,24 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,%s,=[1],%s=", ARG (0), op1, op1);
+			/* PPC64 ELFv1 TOC chain: stbu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STH:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[2]"));
+			/* PPC64 ELFv1 TOC chain: sth rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STHU:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -976,10 +1022,24 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,%s,=[2],%s=", ARG (0), op1, op1);
+			/* PPC64 ELFv1 TOC chain: sthu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STD:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[8]"));
+			/* PPC64 ELFv1 TOC chain: std rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_STDU:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -988,6 +1048,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,%s,=[8],%s=", ARG (0), op1, op1);
+			/* PPC64 ELFv1 TOC chain: stdu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LBZU:
 		case PPC_INS_LBZUX:
@@ -997,6 +1064,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,[1],%s,=,%s=", op1, ARG (0), op1);
+			/* PPC64 ELFv1 TOC chain: lbzu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LBZ:
 #if CS_API_MAJOR >= 4
@@ -1005,6 +1079,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_LBZX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[1]"), ARG (0));
+			/* PPC64 ELFv1 TOC chain: lbz rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LD:
 		case PPC_INS_LDARX:
@@ -1014,11 +1095,18 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_LDU:
 		case PPC_INS_LDUX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
-			op1 = shrink(ARG(1));
+			op1 = shrink (ARG(1));
 			if (!op1) {
 				break;
 			}
 			esilprintf (op, "%s,[8],%s,=,%s=", op1, ARG (0), op1);
+			/* PPC64 ELFv1 TOC chain: ld rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LDX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -1039,6 +1127,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_LFSX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[4]"), ARG (0));
+			/* PPC64 ELFv1 TOC chain: lfd/lfs fY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LHA:
 		case PPC_INS_LHAU:
@@ -1052,6 +1147,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,[2],%s,=,%s=", op1, ARG (0), op1);
+			/* PPC64 ELFv1 TOC chain: lha/lhz rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LHBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -1067,6 +1169,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_LWZX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[4]"), ARG (0));
+			/* PPC64 ELFv1 TOC chain: lwz rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LWZU:
 		case PPC_INS_LWZUX:
@@ -1076,6 +1185,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,[4],%s,=,%s=", op1, ARG (0), op1);
+			/* PPC64 ELFv1 TOC chain: lwzu rY, LO(rX) following addis rX, r2, HA */
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
 			break;
 		case PPC_INS_LWBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -1110,6 +1226,14 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->sign = true;
 			op->type = R_ANAL_OP_TYPE_ADD;
 			esilprintf (op, "%s,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
+			/* PPC64 ELFv1 TOC chain: addi rY, rX, LO following addis rX, r2, HA
+			 * materialises a TOC-relative address (e.g. address-of-global). */
+			if (INSOP(1).type == PPC_OP_REG && INSOP(2).type == PPC_OP_IMM) {
+				ridx = toc_reg_idx (INSOP(1).reg);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->val = pd->toc_map[ridx] + (ut64)(st64)INSOP(2).imm;
+				}
+			}
 			break;
 		case PPC_INS_CRCLR:
 		case PPC_INS_CRSET:
@@ -1128,6 +1252,26 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_ADDIS:
 			op->type = R_ANAL_OP_TYPE_ADD;
 			esilprintf (op, "16,%s,<<,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
+			/* PPC64 ELFv1 TOC-relative pair, first instruction.
+			 * Pattern: addis rX, r2, HA  where r2 holds the TOC base.
+			 * Record  config->gp + (HA<<16)  in toc_map[X] so that any later
+			 * ld/addi/st using rX as base can resolve the full address.
+			 * config->gp is auto-detected by load_toc() or set via
+			 * e anal.gp=<toc_addr>. */
+			if (INSOP(0).type == PPC_OP_REG) {
+				ridx = toc_reg_idx (INSOP(0).reg);
+				if (ridx >= 0) {
+					if (as->config->gp
+							&& INSOP(1).type == PPC_OP_REG
+							&& INSOP(1).reg  == PPC_REG_R2
+							&& INSOP(2).type == PPC_OP_IMM) {
+						pd->toc_map[ridx] = as->config->gp
+							+ (ut64)((st64)INSOP(2).imm << 16);
+					} else {
+						pd->toc_map[ridx] = 0; /* dest clobbered, invalidate */
+					}
+				}
+			}
 			break;
 		case PPC_INS_ADDE:
 		case PPC_INS_ADDME:

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3421,8 +3421,12 @@ static bool cb_anal_roregs(RCore *core, RConfigNode *node) {
 
 static bool cb_anal_gp(RCore *core, RConfigNode *node) {
 	ut64 gpv = node->i_value;
-	gpv = (gpv == UT64_MAX)? gpv: (gpv + 0xf) & ~ (ut64)0xf;
-	node->i_value = gpv;
+	/* 16-byte boundary alignment is a MIPS ABI requirement; skip it for other
+	 * architectures (e.g. PPC64 ELFv1 TOC base) to avoid corrupting the value. */
+	if (r_str_startswith (core->rasm->config->arch, "mips")) {
+		gpv = (gpv == UT64_MAX)? gpv: (gpv + 0xf) & ~(ut64)0xf;
+		node->i_value = gpv;
+	}
 	core->anal->gp = gpv;
 	r_reg_setv (core->anal->reg, "gp", gpv);
 	core->anal->config->gp = gpv;
@@ -3912,7 +3916,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETB ("anal.mask", "false", "use the smart aobm command to compute the binary mask of the instruction"); // TODO: must be true by default
 	SETCB ("anal.roregs", "gp,zero", (RConfigCallback)&cb_anal_roregs, "comma separated list of register names to be readonly");
 	SETICB ("anal.cs", 0, (RConfigCallback)&cb_anal_cs, "set the value for the x86-16 CS segment register (see asm.addr.segment and asm.addr.segment.bits)");
-	SETICB ("anal.gp", 0, (RConfigCallback)&cb_anal_gp, "set the value of the GP register (MIPS)");
+	SETICB ("anal.gp", 0, (RConfigCallback)&cb_anal_gp, "global pointer value: MIPS gp register / PPC64 ELFv1 TOC base (r2); auto-detected on file load");
 	SETB ("anal.fixed.gp", "true", "set gp register to anal.gp before emulating each instruction in aae");
 	SETCB ("anal.fixed.arch", "false", &cb_anal_fixed_arch, "permit arch changes during analysis");
 	SETCB ("anal.fixed.bits", "false", &cb_anal_fixed_bits, "permit bits changes during analysis (arm/thumb)");

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -27,6 +27,42 @@ static inline bool its_a_mips(RCore *core) {
 	return cfg && r_str_startswith (cfg->arch, "mips");
 }
 
+static inline bool its_a_ppc64be(RCore *core) {
+	RArchConfig *cfg = core->rasm->config;
+	return cfg && r_str_startswith (cfg->arch, "ppc")
+		&& cfg->bits == 64
+		&& R_ARCH_CONFIG_IS_BIG_ENDIAN (cfg);
+}
+
+// PPC64 ELFv1: every function symbol points into .opd, an array of
+// 24-byte descriptors [code_ptr(8), toc(8), env(8)].  The TOC base used
+// throughout the binary is the toc field of the *first* .opd entry (offset
+// +8).  We read it here and populate anal->gp / config->gp so that the
+// ppc_cs arch plugin can resolve addis+ld/addi TOC-relative chains.
+// We set the fields directly rather than going through r_config_set_i() to
+// avoid the MIPS-specific 16-byte alignment applied in cb_anal_gp.
+static void load_toc(RCore *core) {
+	if (!its_a_ppc64be (core)) {
+		return;
+	}
+	ut64 opd = r_num_math (core->num, "section..opd");
+	if (!opd || opd == UT64_MAX) {
+		return;
+	}
+	ut8 buf[8];
+	if (!r_io_read_at (core->io, opd + 8, buf, 8)) {
+		return;
+	}
+	ut64 toc = r_read_be64 (buf);
+	if (!toc || toc == UT64_MAX) {
+		return;
+	}
+	R_LOG_DEBUG ("[ppc64v1] toc: 0x%"PFMT64x, toc);
+	core->anal->gp = toc;
+	core->anal->config->gp = toc;
+	r_reg_setv (core->anal->reg, "r2", toc);
+}
+
 static void load_gp(RCore *core) {
 	// R2R db/cmd/cmd_eval
 	if (its_a_mips (core)) {
@@ -206,6 +242,7 @@ R_API bool r_core_file_reopen(RCore *core, const char *args, int perm, int loadb
 		r_core_cmd_call (core, "sr PC");
 	} else {
 		load_gp (core);
+		load_toc (core);
 	}
 	// update anal io bind
 	r_io_bind (core->io, &(core->anal->iob));
@@ -818,6 +855,7 @@ R_API bool r_core_bin_load(RCore *r, const char *filenameuri, ut64 baddr) {
 	}
 	if (!r_config_get_b (r->config, "cfg.debug")) {
 		load_gp (r);
+		load_toc (r);
 	}
 	if (r_config_get_b (r->config, "bin.libs")) {
 		const char *lib;

--- a/test/db/formats/elf/ppc64v1-toc
+++ b/test/db/formats/elf/ppc64v1-toc
@@ -1,0 +1,54 @@
+NAME=PPC64 ELFv1: addis+ld TOC chain resolves op->ptr
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e anal.gp=0x37f00
+ao 2 @ 0x30e4~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x0002f5d0
+EOF
+RUN
+
+NAME=PPC64 ELFv1: second ld from same addis — toc_map persists through intervening instruction
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e anal.gp=0x37f00
+ao 4 @ 0x30e4~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x0002f5d0
+ptr: 0x0002f5d8
+EOF
+RUN
+
+NAME=PPC64 ELFv1: addis+addi TOC chain resolves op->val (address materialisation)
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e anal.gp=0x37f00
+ao 2 @ 0x3fac~^val
+EOF
+EXPECT=<<EOF
+val: 0x0002ef58
+EOF
+RUN
+
+NAME=PPC64 ELFv1: r1-relative load does not get spurious ptr from toc_map (regression)
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e anal.gp=0x37f00
+ao 1 @ 0x3f54~^ptr
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=PPC64 ELFv1: ppc32 binary unaffected by toc_map logic (regression)
+FILE=bins/elf/hello.ppc
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+ao 6 @ 0x10000308~^ptr
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION


- [X ] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This was branch where I overloaded anal.gp for use with the PPCv1 TOC usage.. Did consider re-writing to add anal.toc but looked like lots of changes so thought I'd submit this for consideration.

**Summary**

PPC64 ELFv1 code accesses all globals, PLT GOT slots, and constants through
TOC-relative two-instruction sequences:

```
addis rX, r2, HA       ;  rX = TOC + (HA << 16)
ld    rY, LO(rX)       ;  load from TOC + (HA << 16) + LO
```

radare2 currently produces no `op->ptr` or `op->val` for these instructions,
so data cross-references are missing and the disassembly is less useful than
`objdump -d`.

This patch resolves those chains by:
1. Tracking `addis rX, r2, HA` results in a per-GPR map (`toc_map[32]`)
2. Resolving the full address when any subsequent load, store, or `addi`
   uses that register as a base
3. Auto-detecting the TOC base from `.opd+8` at file load time
4. Fixing `anal.gp` to not apply MIPS-specific 16-byte alignment on non-MIPS
   architectures

## Files changed

### `libr/arch/p/ppc_cs/plugin.c`

- Add `toc_map[32]` array to `PluginData` — one slot per GPR, populated
  by `addis` and consumed by load/store/addi instructions
- Add `toc_reg_idx()` helper mapping Capstone register IDs to GPR indices
- `ADDIS` handler: when the source register is `r2` (TOC pointer) and
  `config->gp` is set, record `gp + (HA << 16)` in `toc_map[dest]`;
  invalidate the entry when the destination is overwritten by a non-TOC addis
- 16 load/store/addi cases resolve `op->ptr` (loads/stores) or `op->val`
  (addi address materialisation) from the map:
  ld, lwz, lbz, lha/lhz, lfd/lfs and their update variants;
  std, stw, stb, sth and their update variants; addi

### `libr/core/cfile.c`

- Add `load_toc()`: for PPC64 big-endian binaries, read the TOC base from
  the second quadword of the first `.opd` entry (offset +8) and set
  `anal->gp`, `config->gp`, and register `r2`
- Called from both `r_core_bin_load()` and `r_core_file_reopen()`

### `libr/core/cconfig.c`

- Gate the 16-byte boundary alignment in `cb_anal_gp()` to MIPS only —
  this is a MIPS ABI requirement that corrupts the PPC64 TOC value
- Update `anal.gp` description to mention PPC64 ELFv1 TOC base

### `test/db/formats/elf/ppc64v1-toc` (new)

5 r2r tests:
1. `addis+ld` chain resolves `op->ptr` to GOT slot address
2. Second `ld` from same `addis` — `toc_map` persists through intervening
   instructions (e.g. `mtctr`)
3. `addis+addi` chain resolves `op->val` (address materialisation)
4. `r1`-relative load does NOT get a spurious `ptr` from `toc_map` (regression guard)
5. PPC32 binary is unaffected by `toc_map` logic (regression guard)

## Before / After

```
$ r2 -q -e anal.gp=0x37f00 -c 'ao 2 @ 0x30e4' bins/elf/ppc64v1-more
```

Before (no ptr on the ld):
```
address: 0x30e4   type: add
address: 0x30e8   type: load
```

After:
```
address: 0x30e4   type: add
address: 0x30e8   type: load   ptr: 0x0002f5d0
```

`0x0002f5d0` is the GOT slot for `fileno` — the first PLT stub's target.
