### PR TITLE
fix heap buffer overflow in qnxr_read_memory

### DIFF
--- a/shlr/qnx/src/core.c
+++ b/shlr/qnx/src/core.c
@@ -373,11 +373,15 @@ int qnxr_read_memory (libqnxr_t *g, ut64 address, ut8 *data, ut64 len) {
 			  sizeof (g->recv.pkt.hdr);
 		if (rcv_len <= 0) break;
 		if (g->recv.pkt.hdr.cmd == DSrMsg_okdata) {
+			int remaining = len - tot_len;
+			if (rcv_len > remaining) {
+				rcv_len = remaining;
+			}
 			memcpy (data + tot_len, g->recv.pkt.okdata.data, rcv_len);
 			tot_len += rcv_len;
 		} else
 			break;
-	} while (tot_len != len);
+	} while (tot_len < (int)len);
 
 	return tot_len;
 }


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

clamp rcv_len to remaining buffer space before memcpy and fix loop termination condition in qnxr_read_memory(). malicious pdebug server can return up to DS_DATA_MAX_SIZE bytes regardless of requested size, overwriting the caller's heap/stack buffer. loop condition != vs < causes infinite overwrites once tot_len overshoots len.

fixes #25786

<!-- explain your changes if necessary -->
