### PR TITLE
Fix arm64 jmptbl detection for multi-LEA dispatchers ##anal

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -382,6 +382,158 @@ static void leaddr_free(void *pair) {
 	free (_pair);
 }
 
+// Returns the most recent leaddr_pair whose register matches `reg` and whose
+// op_addr is strictly less than `before_addr`. This is needed to handle arm64
+// dispatchers that reassign the same register between the load and the
+// indirect branch:
+//     adr x17, table_addr           ; pair (x17, table_addr)
+//     ldrsw x16, [x17, x16, lsl 2]  ; the load uses the *first* x17
+//     adr x17, basedest_addr        ; pair (x17, basedest_addr) — overrides
+//     add x16, x17, x16             ; the add uses the *second* x17
+//     br x16
+static leaddr_pair *leaddrs_find_by_reg_before(RList *leaddrs, const char *reg, ut64 before_addr) {
+	if (!leaddrs || !reg) {
+		return NULL;
+	}
+	RListIter *iter;
+	leaddr_pair *la;
+	r_list_foreach_prev (leaddrs, iter, la) {
+		if (!la->reg || strcmp (la->reg, reg)) {
+			continue;
+		}
+		if (la->op_addr >= before_addr) {
+			continue;
+		}
+		return la;
+	}
+	return NULL;
+}
+
+// For arm64 jmptbl dispatchers like:
+//     ldr* Rload, [Rtable, Ridx, lsl N]
+//     add  Rdst, Rdst, Rload [, lsl N]    ; Rdst can be the same as Rtable
+//     br   Rdst
+// extract the base and table register names from the two instructions
+// preceding the indirect branch. Some compilers schedule unrelated
+// instructions (movs, etc.) between the load, the add and the br, so
+// this routine scans up to ARM64_JMPTBL_LOOKBACK instructions backwards
+// looking for the matching pair, anchored on the indirect branch's
+// target register.
+//
+// Returns true on success and stores non-owning pointers into *base_reg
+// and *table_reg (the storage belongs to the temporary RAnalOps that
+// are released by the caller via fini).
+#define ARM64_JMPTBL_LOOKBACK 16
+static bool arm64_jmptbl_extract_dispatch_regs(RAnal *anal, ut64 br_addr,
+		const char *br_target_reg,
+		RAnalOp *ldr_op, RAnalOp *add_op,
+		const char **base_reg, const char **table_reg,
+		ut64 *load_addr, ut64 *add_addr) {
+	if (!anal || !anal->iob.read_at) {
+		return false;
+	}
+	const ut64 lookback_bytes = ARM64_JMPTBL_LOOKBACK * 4;
+	if (br_addr < lookback_bytes) {
+		return false;
+	}
+	memset (ldr_op, 0, sizeof (*ldr_op));
+	memset (add_op, 0, sizeof (*add_op));
+	ut8 buf[ARM64_JMPTBL_LOOKBACK * 4];
+	const ut64 scan_base = br_addr - lookback_bytes;
+	if (!anal->iob.read_at (anal->iob.io, scan_base, buf, sizeof (buf))) {
+		return false;
+	}
+	// First locate the `add Rdst, ..., ...` whose destination is the
+	// indirect branch's target register, scanning the most recent
+	// instructions first.
+	bool found_add = false;
+	int add_idx = -1;
+	int i;
+	for (i = ARM64_JMPTBL_LOOKBACK - 1; i >= 0; i--) {
+		RAnalOp tmp = {0};
+		int len = r_anal_op (anal, &tmp, scan_base + i * 4, buf + i * 4, 4,
+				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL);
+		if (len < 1) {
+			r_anal_op_fini (&tmp);
+			continue;
+		}
+		if ((tmp.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_ADD) {
+			RAnalValue *d = RVecRArchValue_at (&tmp.dsts, 0);
+			if (d && d->reg && br_target_reg && !strcmp (d->reg, br_target_reg)) {
+				memcpy (add_op, &tmp, sizeof (tmp));
+				memset (&tmp, 0, sizeof (tmp));
+				add_idx = i;
+				if (add_addr) {
+					*add_addr = scan_base + i * 4;
+				}
+				found_add = true;
+				break;
+			}
+		}
+		r_anal_op_fini (&tmp);
+	}
+	if (!found_add || add_idx < 0) {
+		return false;
+	}
+	RAnalValue *add_dst = RVecRArchValue_at (&add_op->dsts, 0);
+	RAnalValue *add_src0 = RVecRArchValue_at (&add_op->srcs, 0);
+	RAnalValue *add_src1 = RVecRArchValue_at (&add_op->srcs, 1);
+	if (!add_dst || !add_dst->reg) {
+		return false;
+	}
+	const char *src0_reg = add_src0 ? add_src0->reg : NULL;
+	const char *src1_reg = add_src1 ? add_src1->reg : NULL;
+	// Now find the `ldr* Rload, [Rtable, ...]` before the add. The
+	// dispatcher's loaded value reg must be one of the add sources.
+	bool found_ldr = false;
+	const char *load_reg = NULL;
+	for (i = add_idx - 1; i >= 0; i--) {
+		RAnalOp tmp = {0};
+		int len = r_anal_op (anal, &tmp, scan_base + i * 4, buf + i * 4, 4,
+				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL);
+		if (len < 1) {
+			r_anal_op_fini (&tmp);
+			continue;
+		}
+		if ((tmp.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_LOAD) {
+			RAnalValue *ld_dst = RVecRArchValue_at (&tmp.dsts, 0);
+			if (ld_dst && ld_dst->reg) {
+				bool dst_is_add_src = (src0_reg && !strcmp (src0_reg, ld_dst->reg))
+					|| (src1_reg && !strcmp (src1_reg, ld_dst->reg));
+				if (dst_is_add_src) {
+					memcpy (ldr_op, &tmp, sizeof (tmp));
+					memset (&tmp, 0, sizeof (tmp));
+					load_reg = RVecRArchValue_at (&ldr_op->dsts, 0)->reg;
+					if (load_addr) {
+						*load_addr = scan_base + i * 4;
+					}
+					found_ldr = true;
+					break;
+				}
+			}
+		}
+		r_anal_op_fini (&tmp);
+	}
+	if (!found_ldr) {
+		return false;
+	}
+	RAnalValue *ldr_src0 = RVecRArchValue_at (&ldr_op->srcs, 0);
+	if (!ldr_src0 || !ldr_src0->reg) {
+		return false;
+	}
+	*table_reg = ldr_src0->reg;
+	// The base register of the dispatch is the source of the add that
+	// is not the loaded value reg.
+	if (src0_reg && load_reg && strcmp (src0_reg, load_reg)) {
+		*base_reg = src0_reg;
+	} else if (src1_reg && load_reg && strcmp (src1_reg, load_reg)) {
+		*base_reg = src1_reg;
+	} else {
+		*base_reg = add_dst->reg;
+	}
+	return true;
+}
+
 static RAnalBlock *bbget(RAnal *anal, ut64 addr, bool jumpmid) {
 	RList *intersecting = r_anal_get_blocks_in (anal, addr);
 	RListIter *iter;
@@ -1314,17 +1466,24 @@ noskip:
 #endif
 					// ut64 jmpptr_table = UT64_MAX;
 					// ut64 jmptbl_addr = UT64_MAX;
-					if (last_is_reg_mov_lea) {
-						// incremement the leaddr
+					// Increment the leaddr that matches the destination register of the
+					// `add Rd, Rd, #imm` instruction. Previously this blindly bumped the
+					// last lea entry which broke jmptbl detection on patterns like:
+					//   adrp x22, 0xe000  ; add x22, x22, 0x80
+					//   adrp x19, 0x20000 ; ... ; add x22, x22, 0x80 (after another adrp)
+					// where multiple adrp's appear before their matching adds.
+					if (op->val != UT64_MAX && dst && dst->reg && src0 && src0->reg
+							&& !strcmp (dst->reg, src0->reg)) {
 						leaddr_pair *la;
-						last_is_reg_mov_lea = false;
 						RListIter *iter;
 						r_list_foreach_prev (anal->leaddrs, iter, la) {
-							la->leaddr += op->val;
-							// jmptbl_addr = la->leaddr;
-							break;
+							if (la->reg && !strcmp (la->reg, dst->reg)) {
+								la->leaddr += op->val;
+								break;
+							}
 						}
 					}
+					last_is_reg_mov_lea = false;
 #if 0
 					ut64 casetbl_addr = jmptbl_addr;
 					RAnalOp jmp_aop ;
@@ -1624,14 +1783,59 @@ bx = jmptbl_base + (byte[x9]<<2)
 0x100000b2c      add x16, x17, x16
 0x100000b30      br x16
 #endif
-				if (anal->leaddrs && r_list_length (anal->leaddrs) >= 2) {
-					leaddr_pair *x10 = r_list_pop (anal->leaddrs);
-					leaddr_pair *x9 = r_list_pop (anal->leaddrs);
-					ut64 opaddr = x10->op_addr;
-					ut64 basptr = x10->leaddr;
-					ut64 tblptr = x9->leaddr;
-					leaddr_free (x9);
-					leaddr_free (x10);
+				if (anal->leaddrs && r_list_length (anal->leaddrs) >= 1) {
+					RAnalOp ldr_probe = {0};
+					RAnalOp add_probe = {0};
+					const char *base_reg_name = NULL;
+					const char *table_reg_name = NULL;
+					ut64 dispatch_load_addr = UT64_MAX;
+					ut64 dispatch_add_addr = UT64_MAX;
+					bool dispatch_ok = arm64_jmptbl_extract_dispatch_regs (anal,
+							op->addr, op->reg, &ldr_probe, &add_probe,
+							&base_reg_name, &table_reg_name,
+							&dispatch_load_addr, &dispatch_add_addr);
+					leaddr_pair *base_pair = NULL;
+					leaddr_pair *table_pair = NULL;
+					if (dispatch_ok) {
+						// Look up the leas relative to where they are
+						// actually consumed: the load uses the table reg's
+						// most recent value before the load instruction,
+						// and the add uses the base reg's most recent
+						// value before the add. This matters when the
+						// dispatcher reuses a single register name (e.g.
+						// `adr x17, table; ldrsw x16, [x17, ...]; adr x17, base; add x16, x17, x16`).
+						base_pair = leaddrs_find_by_reg_before (anal->leaddrs,
+								base_reg_name, dispatch_add_addr);
+						table_pair = leaddrs_find_by_reg_before (anal->leaddrs,
+								table_reg_name, dispatch_load_addr);
+					}
+					ut64 opaddr;
+					ut64 basptr;
+					ut64 tblptr;
+					if (base_pair && table_pair) {
+						// Found the leas that match the actual dispatcher registers.
+						opaddr = base_pair->op_addr;
+						basptr = base_pair->leaddr;
+						tblptr = table_pair->leaddr;
+					} else if (r_list_length (anal->leaddrs) >= 2) {
+						// Legacy fall back: blindly take the last two leas. This
+						// covers cases where the disassembler did not expose the
+						// register info but the heuristic still happens to match.
+						leaddr_pair *x10 = r_list_pop (anal->leaddrs);
+						leaddr_pair *x9 = r_list_pop (anal->leaddrs);
+						opaddr = x10->op_addr;
+						basptr = x10->leaddr;
+						tblptr = x9->leaddr;
+						leaddr_free (x9);
+						leaddr_free (x10);
+					} else {
+						r_anal_op_fini (&ldr_probe);
+						r_anal_op_fini (&add_probe);
+						R_LOG_DEBUG ("arm64 SwitchTable dont have enough leas to work at 0x%08"PFMT64x, op->addr);
+						break;
+					}
+					r_anal_op_fini (&ldr_probe);
+					r_anal_op_fini (&add_probe);
 
 					if (loadsize == 0) {
 						R_LOG_DEBUG ("Probably not not a SwitchTable, just indirect branch at 0x%08"PFMT64x, op->addr);
@@ -1658,9 +1862,34 @@ bx = jmptbl_base + (byte[x9]<<2)
 					ut8 *table = calloc (sizeof_table, 1);
 					st16 *table2 = (st16*)table;
 					st32 *table4 = (st32*)table;
+					// Determine the number of cases. anal->cmpval is global state
+					// and may be stale (it gets clobbered by other branches of
+					// the function that get analysed first). When that happens
+					// we fall back to walking the predecessor bb to find the
+					// actual cmp that gates this dispatcher.
+					ut64 jmptbl_table_size = anal->cmpval;
+					{
+						ut64 alt_table_size = 0;
+						ut64 jmptbl_default_case = 0;
+						st64 jmptbl_case_shift = 0;
+						if (try_get_jmptbl_info (anal, fcn, op->addr, bb,
+								&alt_table_size, &jmptbl_default_case,
+								&jmptbl_case_shift) && alt_table_size > 0) {
+							// If anal->cmpval is implausibly small compared
+							// to the count derived from the predecessor bb,
+							// trust the latter; otherwise preserve the
+							// long-standing behaviour of using anal->cmpval
+							// directly (which avoids over-counting in the
+							// `cmp X; b.eq default; jmptbl` pattern where
+							// the dispatcher only handles cmp_val cases).
+							if (alt_table_size > anal->cmpval + 1) {
+								jmptbl_table_size = alt_table_size;
+							}
+						}
+					}
 					// TODO: eliminate hard limit
-					int max = R_MIN (anal->cmpval, sizeof_table / loadsize);
-					R_LOG_DEBUG ("JumpTable for 0x%08"PFMT64x" is at 0x%"PFMT64x, op->addr, tblptr);
+					int max = R_MIN (jmptbl_table_size, sizeof_table / loadsize);
+					R_LOG_DEBUG ("JumpTable for 0x%08"PFMT64x" is at 0x%"PFMT64x" max=%d", op->addr, tblptr, max);
 					(void)anal->iob.read_at (anal->iob.io, tblptr, (ut8 *) table, sizeof_table);
 					ut64 caseaddr;
 					RList *kases = r_list_newf (free);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -370,168 +370,10 @@ static void check_purity(HtUP *ht, RAnalFunction *fcn) {
 	RVecAnalRef_free (refs);
 }
 
-typedef struct {
-	ut64 op_addr;
-	ut64 leaddr;
-	char *reg;
-} leaddr_pair;
-
 static void leaddr_free(void *pair) {
-	leaddr_pair *_pair = pair;
+	RLeaddrPair *_pair = pair;
 	free (_pair->reg);
 	free (_pair);
-}
-
-// Returns the most recent leaddr_pair whose register matches `reg` and whose
-// op_addr is strictly less than `before_addr`. This is needed to handle arm64
-// dispatchers that reassign the same register between the load and the
-// indirect branch:
-//     adr x17, table_addr           ; pair (x17, table_addr)
-//     ldrsw x16, [x17, x16, lsl 2]  ; the load uses the *first* x17
-//     adr x17, basedest_addr        ; pair (x17, basedest_addr) — overrides
-//     add x16, x17, x16             ; the add uses the *second* x17
-//     br x16
-static leaddr_pair *leaddrs_find_by_reg_before(RList *leaddrs, const char *reg, ut64 before_addr) {
-	if (!leaddrs || !reg) {
-		return NULL;
-	}
-	RListIter *iter;
-	leaddr_pair *la;
-	r_list_foreach_prev (leaddrs, iter, la) {
-		if (!la->reg || strcmp (la->reg, reg)) {
-			continue;
-		}
-		if (la->op_addr >= before_addr) {
-			continue;
-		}
-		return la;
-	}
-	return NULL;
-}
-
-// For arm64 jmptbl dispatchers like:
-//     ldr* Rload, [Rtable, Ridx, lsl N]
-//     add  Rdst, Rdst, Rload [, lsl N]    ; Rdst can be the same as Rtable
-//     br   Rdst
-// extract the base and table register names from the two instructions
-// preceding the indirect branch. Some compilers schedule unrelated
-// instructions (movs, etc.) between the load, the add and the br, so
-// this routine scans up to ARM64_JMPTBL_LOOKBACK instructions backwards
-// looking for the matching pair, anchored on the indirect branch's
-// target register.
-//
-// Returns true on success and stores non-owning pointers into *base_reg
-// and *table_reg (the storage belongs to the temporary RAnalOps that
-// are released by the caller via fini).
-#define ARM64_JMPTBL_LOOKBACK 16
-static bool arm64_jmptbl_extract_dispatch_regs(RAnal *anal, ut64 br_addr,
-		const char *br_target_reg,
-		RAnalOp *ldr_op, RAnalOp *add_op,
-		const char **base_reg, const char **table_reg,
-		ut64 *load_addr, ut64 *add_addr) {
-	if (!anal || !anal->iob.read_at) {
-		return false;
-	}
-	const ut64 lookback_bytes = ARM64_JMPTBL_LOOKBACK * 4;
-	if (br_addr < lookback_bytes) {
-		return false;
-	}
-	memset (ldr_op, 0, sizeof (*ldr_op));
-	memset (add_op, 0, sizeof (*add_op));
-	ut8 buf[ARM64_JMPTBL_LOOKBACK * 4];
-	const ut64 scan_base = br_addr - lookback_bytes;
-	if (!anal->iob.read_at (anal->iob.io, scan_base, buf, sizeof (buf))) {
-		return false;
-	}
-	// First locate the `add Rdst, ..., ...` whose destination is the
-	// indirect branch's target register, scanning the most recent
-	// instructions first.
-	bool found_add = false;
-	int add_idx = -1;
-	int i;
-	for (i = ARM64_JMPTBL_LOOKBACK - 1; i >= 0; i--) {
-		RAnalOp tmp = {0};
-		int len = r_anal_op (anal, &tmp, scan_base + i * 4, buf + i * 4, 4,
-				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL);
-		if (len < 1) {
-			r_anal_op_fini (&tmp);
-			continue;
-		}
-		if ((tmp.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_ADD) {
-			RAnalValue *d = RVecRArchValue_at (&tmp.dsts, 0);
-			if (d && d->reg && br_target_reg && !strcmp (d->reg, br_target_reg)) {
-				memcpy (add_op, &tmp, sizeof (tmp));
-				memset (&tmp, 0, sizeof (tmp));
-				add_idx = i;
-				if (add_addr) {
-					*add_addr = scan_base + i * 4;
-				}
-				found_add = true;
-				break;
-			}
-		}
-		r_anal_op_fini (&tmp);
-	}
-	if (!found_add || add_idx < 0) {
-		return false;
-	}
-	RAnalValue *add_dst = RVecRArchValue_at (&add_op->dsts, 0);
-	RAnalValue *add_src0 = RVecRArchValue_at (&add_op->srcs, 0);
-	RAnalValue *add_src1 = RVecRArchValue_at (&add_op->srcs, 1);
-	if (!add_dst || !add_dst->reg) {
-		return false;
-	}
-	const char *src0_reg = add_src0 ? add_src0->reg : NULL;
-	const char *src1_reg = add_src1 ? add_src1->reg : NULL;
-	// Now find the `ldr* Rload, [Rtable, ...]` before the add. The
-	// dispatcher's loaded value reg must be one of the add sources.
-	bool found_ldr = false;
-	const char *load_reg = NULL;
-	for (i = add_idx - 1; i >= 0; i--) {
-		RAnalOp tmp = {0};
-		int len = r_anal_op (anal, &tmp, scan_base + i * 4, buf + i * 4, 4,
-				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL);
-		if (len < 1) {
-			r_anal_op_fini (&tmp);
-			continue;
-		}
-		if ((tmp.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_LOAD) {
-			RAnalValue *ld_dst = RVecRArchValue_at (&tmp.dsts, 0);
-			if (ld_dst && ld_dst->reg) {
-				bool dst_is_add_src = (src0_reg && !strcmp (src0_reg, ld_dst->reg))
-					|| (src1_reg && !strcmp (src1_reg, ld_dst->reg));
-				if (dst_is_add_src) {
-					memcpy (ldr_op, &tmp, sizeof (tmp));
-					memset (&tmp, 0, sizeof (tmp));
-					load_reg = RVecRArchValue_at (&ldr_op->dsts, 0)->reg;
-					if (load_addr) {
-						*load_addr = scan_base + i * 4;
-					}
-					found_ldr = true;
-					break;
-				}
-			}
-		}
-		r_anal_op_fini (&tmp);
-	}
-	if (!found_ldr) {
-		return false;
-	}
-	RAnalValue *ldr_src0 = RVecRArchValue_at (&ldr_op->srcs, 0);
-	if (!ldr_src0 || !ldr_src0->reg) {
-		return false;
-	}
-	*table_reg = ldr_src0->reg;
-	// The base register of the dispatch is the source of the add that
-	// is not the loaded value reg.
-	if (src0_reg && load_reg && strcmp (src0_reg, load_reg)) {
-		*base_reg = src0_reg;
-	} else if (src1_reg && load_reg && strcmp (src1_reg, load_reg)) {
-		*base_reg = src1_reg;
-	} else {
-		*base_reg = add_dst->reg;
-	}
-	return true;
 }
 
 static RAnalBlock *bbget(RAnal *anal, ut64 addr, bool jumpmid) {
@@ -1311,9 +1153,9 @@ noskip:
 				ut8 buf[4];
 				anal->iob.read_at (anal->iob.io, op->ptr, buf, sizeof (buf));
 				if ((buf[2] == 0xff || buf[2] == 0xfe) && buf[3] == 0xff) {
-					leaddr_pair *pair = R_NEW0 (leaddr_pair);
+					RLeaddrPair *pair = R_NEW0 (RLeaddrPair);
 					if (!pair) {
-						R_LOG_ERROR ("Cannot create leaddr_pair");
+						R_LOG_ERROR ("Cannot create RLeaddrPair");
 						gotoBeach (R_ANAL_RET_ERROR);
 					}
 					pair->op_addr = op->addr;
@@ -1333,7 +1175,7 @@ noskip:
 			}
 #else
 			if (op->ptr != UT64_MAX) {
-				leaddr_pair *pair = R_NEW0 (leaddr_pair);
+				RLeaddrPair *pair = R_NEW0 (RLeaddrPair);
 				pair->op_addr = op->addr;
 				pair->leaddr = op->ptr; // XXX movdisp is dupped but seems to be trashed sometimes(?), better track leaddr separately
 				pair->reg = op->reg
@@ -1464,24 +1306,12 @@ noskip:
 #if JTDBG
 					eprintf ("0x%08llx - ADD %lld\n", op->addr, op->val);
 #endif
-					// ut64 jmpptr_table = UT64_MAX;
-					// ut64 jmptbl_addr = UT64_MAX;
-					// Increment the leaddr that matches the destination register of the
-					// `add Rd, Rd, #imm` instruction. Previously this blindly bumped the
-					// last lea entry which broke jmptbl detection on patterns like:
-					//   adrp x22, 0xe000  ; add x22, x22, 0x80
-					//   adrp x19, 0x20000 ; ... ; add x22, x22, 0x80 (after another adrp)
-					// where multiple adrp's appear before their matching adds.
+					// Finalise `adrp Rd, page; add Rd, Rd, #imm` by bumping
+					// the matching leaddr entry. Done per-register so that
+					// multiple in-flight adrp's don't cross-contaminate.
 					if (op->val != UT64_MAX && dst && dst->reg && src0 && src0->reg
 							&& !strcmp (dst->reg, src0->reg)) {
-						leaddr_pair *la;
-						RListIter *iter;
-						r_list_foreach_prev (anal->leaddrs, iter, la) {
-							if (la->reg && !strcmp (la->reg, dst->reg)) {
-								la->leaddr += op->val;
-								break;
-							}
-						}
+						r_anal_jmptbl_leaddrs_bump (anal->leaddrs, dst->reg, op->val);
 					}
 					last_is_reg_mov_lea = false;
 #if 0
@@ -1753,176 +1583,10 @@ noskip:
 					break;
 				}
 			} else if (is_arm && anal->config->bits == 64 && anal->opt.jmptbl) {
-#if 0
-0x183997020      cmp x20, 6           ; x20 is the index
-0x183997024      b.hi 0x183997054
-0x183997028      adrp x8, 0x1da2f6000
-0x18399702c      add x8, x8, 0x370    ; unrelated
-0x183997030      adrp x9, 0xbaseaddr  ; tableptr
-0x183997034      add x9, x9, 0x8ef    ; tableptr += delta
-0x183997038      adr x10, 0x183997048 ; basedest_addr
-0x18399703c      ldrb w11, [x9, x20]
-0x183997040      add x10, x10, x11, lsl 2 ; TODO: the code assumes <<2 right now
-0x183997044      br x10
-
-x9 = lea + add
-jmptbl_base = x10 = lea
-bx = jmptbl_base + (byte[x9]<<2)
-
---- example for ldrsw in macs /bin/ls
-
-0x100000b08      sub w16, w0, 0x25
-0x100000b0c      cmp w16, 0x5b
-0x100000b10      b.hi 0x100000fd8
-0x100000b14      cmp x16, 0x5b
-0x100000b18      csel x16, x16, xzr, ls
-0x100000b1c      adrp x17, 0x100001000
-0x100000b20      add x17, x17, 0x558
-0x100000b24      ldrsw x16, [x17, x16, lsl 2]
-0x100000b28      adr x17, 0x100000b28
-0x100000b2c      add x16, x17, x16
-0x100000b30      br x16
-#endif
-				if (anal->leaddrs && r_list_length (anal->leaddrs) >= 1) {
-					RAnalOp ldr_probe = {0};
-					RAnalOp add_probe = {0};
-					const char *base_reg_name = NULL;
-					const char *table_reg_name = NULL;
-					ut64 dispatch_load_addr = UT64_MAX;
-					ut64 dispatch_add_addr = UT64_MAX;
-					bool dispatch_ok = arm64_jmptbl_extract_dispatch_regs (anal,
-							op->addr, op->reg, &ldr_probe, &add_probe,
-							&base_reg_name, &table_reg_name,
-							&dispatch_load_addr, &dispatch_add_addr);
-					leaddr_pair *base_pair = NULL;
-					leaddr_pair *table_pair = NULL;
-					if (dispatch_ok) {
-						// Look up the leas relative to where they are
-						// actually consumed: the load uses the table reg's
-						// most recent value before the load instruction,
-						// and the add uses the base reg's most recent
-						// value before the add. This matters when the
-						// dispatcher reuses a single register name (e.g.
-						// `adr x17, table; ldrsw x16, [x17, ...]; adr x17, base; add x16, x17, x16`).
-						base_pair = leaddrs_find_by_reg_before (anal->leaddrs,
-								base_reg_name, dispatch_add_addr);
-						table_pair = leaddrs_find_by_reg_before (anal->leaddrs,
-								table_reg_name, dispatch_load_addr);
-					}
-					ut64 opaddr;
-					ut64 basptr;
-					ut64 tblptr;
-					if (base_pair && table_pair) {
-						// Found the leas that match the actual dispatcher registers.
-						opaddr = base_pair->op_addr;
-						basptr = base_pair->leaddr;
-						tblptr = table_pair->leaddr;
-					} else if (r_list_length (anal->leaddrs) >= 2) {
-						// Legacy fall back: blindly take the last two leas. This
-						// covers cases where the disassembler did not expose the
-						// register info but the heuristic still happens to match.
-						leaddr_pair *x10 = r_list_pop (anal->leaddrs);
-						leaddr_pair *x9 = r_list_pop (anal->leaddrs);
-						opaddr = x10->op_addr;
-						basptr = x10->leaddr;
-						tblptr = x9->leaddr;
-						leaddr_free (x9);
-						leaddr_free (x10);
-					} else {
-						r_anal_op_fini (&ldr_probe);
-						r_anal_op_fini (&add_probe);
-						R_LOG_DEBUG ("arm64 SwitchTable dont have enough leas to work at 0x%08"PFMT64x, op->addr);
-						break;
-					}
-					r_anal_op_fini (&ldr_probe);
-					r_anal_op_fini (&add_probe);
-
-					if (loadsize == 0) {
-						R_LOG_DEBUG ("Probably not not a SwitchTable, just indirect branch at 0x%08"PFMT64x, op->addr);
-						anal->cmpval = 0;
-						loadsize = 0;
-						break;
-					}
-					if (loadsize == 8) {
-						R_LOG_DEBUG ("Not a SwitchTable so maybe just indirect branch at 0x%08"PFMT64x, op->addr);
-						anal->cmpval = 0;
-						loadsize = 0;
-						break;
-					}
-					if (loadsize != 1 && loadsize != 2 && loadsize != 4) {
-						R_LOG_WARN ("SwitchTable of %d not properly supported at 0x%08"PFMT64x, loadsize, op->addr);
-						anal->cmpval = 0;
-						loadsize = 0;
-						break;
-					}
-					// TODO: move this code into jmptbl.c
-					lea_cnt -= 2; // XXX eliminate this thing . we have r_list_length
-					int i, delta;
-					const size_t sizeof_table = 4096;
-					ut8 *table = calloc (sizeof_table, 1);
-					st16 *table2 = (st16*)table;
-					st32 *table4 = (st32*)table;
-					// Determine the number of cases. anal->cmpval is global state
-					// and may be stale (it gets clobbered by other branches of
-					// the function that get analysed first). When that happens
-					// we fall back to walking the predecessor bb to find the
-					// actual cmp that gates this dispatcher.
-					ut64 jmptbl_table_size = anal->cmpval;
-					{
-						ut64 alt_table_size = 0;
-						ut64 jmptbl_default_case = 0;
-						st64 jmptbl_case_shift = 0;
-						if (try_get_jmptbl_info (anal, fcn, op->addr, bb,
-								&alt_table_size, &jmptbl_default_case,
-								&jmptbl_case_shift) && alt_table_size > 0) {
-							// If anal->cmpval is implausibly small compared
-							// to the count derived from the predecessor bb,
-							// trust the latter; otherwise preserve the
-							// long-standing behaviour of using anal->cmpval
-							// directly (which avoids over-counting in the
-							// `cmp X; b.eq default; jmptbl` pattern where
-							// the dispatcher only handles cmp_val cases).
-							if (alt_table_size > anal->cmpval + 1) {
-								jmptbl_table_size = alt_table_size;
-							}
-						}
-					}
-					// TODO: eliminate hard limit
-					int max = R_MIN (jmptbl_table_size, sizeof_table / loadsize);
-					R_LOG_DEBUG ("JumpTable for 0x%08"PFMT64x" is at 0x%"PFMT64x" max=%d", op->addr, tblptr, max);
-					(void)anal->iob.read_at (anal->iob.io, tblptr, (ut8 *) table, sizeof_table);
-					ut64 caseaddr;
-					RList *kases = r_list_newf (free);
-					for (i = 0; i < max; i++) {
-						if (loadsize == 1) {
-							delta = table[i];
-							caseaddr = basptr + (delta << 2);
-						} else if (loadsize == 2) {
-							delta = table2[i];
-							caseaddr = basptr + (delta << 1);
-						} else if (loadsize == 4) {
-							delta = table4[i];
-							delta = r_read_le32 (&table4[i]);
-							caseaddr = basptr + delta;
-						}
-						if (!anal->iob.is_valid_offset (anal->iob.io, caseaddr, 0)) {
-							R_LOG_DEBUG ("Invalid case %d offset 0x%08"PFMT64x" for switch at 0x%08"PFMT64x, i, caseaddr, op->addr);
-							continue;
-						}
-						RAnalCaseOp *kase = R_NEW0 (RAnalCaseOp);
-						kase->addr = caseaddr; // wtf? <- is this jaddr too?
-						kase->jump = caseaddr;
-						kase->value = i;
-						r_list_append (kases, kase);
-					}
-					r_anal_jmptbl_list (anal, fcn, bb, opaddr, tblptr, kases, loadsize);
-					anal->cmpval = 0;
-					loadsize = 0;
-					free (table);
-				} else {
-					R_LOG_DEBUG ("arm64 SwitchTable dont have enough leas to work at 0x%08"PFMT64x, op->addr);
-				}
-		//		gotoBeach (R_ANAL_RET_END);
+				// arm64 jmptbl dispatcher resolved in libr/anal/jmptbl.c.
+				r_anal_jmptbl_arm64_from_br (anal, fcn, bb, depth, op, loadsize);
+				anal->cmpval = 0;
+				loadsize = 0;
 				break;
 			} else if (is_mips && anal->opt.jmptbl) {
 				// lw v1, -0x7fc4(gp) ; gp = 0x684c00 - 0x7fc4 // read 4 bytes at gp-0x7fc4
@@ -2011,7 +1675,7 @@ bx = jmptbl_base + (byte[x9]<<2)
 					ut64 jmptbl_base = 0; //UT64_MAX;
 					ut64 lea_op_off = UT64_MAX;
 					RListIter *iter;
-					leaddr_pair *pair;
+					RLeaddrPair *pair;
 					if (movbasereg) {
 						// find nearest candidate leaddr before op.addr
 						r_list_foreach_prev (anal->leaddrs, iter, pair) {
@@ -2073,7 +1737,7 @@ bx = jmptbl_base + (byte[x9]<<2)
 					ALGO
 						x10 = [..4000+0x114]
 #endif
-						leaddr_pair *la;
+						RLeaddrPair *la;
 						RListIter *iter;
 						ut64 table_addr = UT64_MAX;
 						int count = 0;
@@ -2258,7 +1922,7 @@ analopfinish:
 	}
 beach:
 	while (lea_cnt > 0) {
-		leaddr_pair *lea = r_list_pop (anal->leaddrs);
+		RLeaddrPair *lea = r_list_pop (anal->leaddrs);
 		if (!lea) {
 			lea_cnt = 0;
 			break;

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -6,6 +6,10 @@
 #include <r_vec.h>
 
 #define JMPTBL_MAXSZ 512
+// How many instructions back from the indirect branch to scan when
+// looking for the load/add dispatcher pattern. 16 * 4 = 64 bytes, which
+// easily covers any reasonable scheduling of movs between load/add/br.
+#define JMPTBL_DISPATCH_LOOKBACK 16
 
 R_VEC_TYPE (RVecUT64, ut64);
 
@@ -13,6 +17,128 @@ typedef struct {
 	RIOMap *switch_map;
 	HtUP *validated_targets;
 } JmptblTargetCtx;
+
+R_IPI void r_anal_jmptbl_leaddrs_bump(RList *leaddrs, const char *reg, ut64 delta) {
+	if (!leaddrs || !reg) {
+		return;
+	}
+	RListIter *iter;
+	RLeaddrPair *la;
+	r_list_foreach_prev (leaddrs, iter, la) {
+		if (la->reg && !strcmp (la->reg, reg)) {
+			la->leaddr += delta;
+			return;
+		}
+	}
+}
+
+// Return the most recent RLeaddrPair matching `reg` whose op_addr is
+// strictly less than `before`. This lets the dispatcher resolver pick
+// the right value of a register that gets reassigned between the load
+// and the add (classic `adr Rt, table; ldr ..., [Rt]; adr Rt, base; add ..., Rt`).
+static RLeaddrPair *leaddrs_find_before(RList *leaddrs, const char *reg, ut64 before) {
+	RListIter *iter;
+	RLeaddrPair *la;
+	r_list_foreach_prev (leaddrs, iter, la) {
+		if (la->reg && !strcmp (la->reg, reg) && la->op_addr < before) {
+			return la;
+		}
+	}
+	return NULL;
+}
+
+static bool arm64_resolve_dispatch(RAnal *anal, RList *leaddrs,
+		ut64 br_addr, const char *target_reg,
+		ut64 *opaddr, ut64 *basptr, ut64 *tblptr) {
+	if (!anal || !leaddrs || !target_reg || !opaddr || !basptr || !tblptr) {
+		return false;
+	}
+	const ut64 lookback_bytes = JMPTBL_DISPATCH_LOOKBACK * 4;
+	if (br_addr < lookback_bytes) {
+		return false;
+	}
+	ut8 buf[JMPTBL_DISPATCH_LOOKBACK * 4];
+	const ut64 scan_base = br_addr - lookback_bytes;
+	if (!anal->iob.read_at (anal->iob.io, scan_base, buf, sizeof (buf))) {
+		return false;
+	}
+	// Locate the `add Rdst, Rs0, Rs1[, lsl N]` whose destination matches
+	// the indirect branch's target register. Scan the most recent
+	// instructions first so unrelated adds don't fool us.
+	char add_s0[32] = {0};
+	char add_s1[32] = {0};
+	ut64 add_addr = UT64_MAX;
+	int add_idx = -1;
+	int i;
+	for (i = JMPTBL_DISPATCH_LOOKBACK - 1; i >= 0; i--) {
+		RAnalOp op = {0};
+		if (r_anal_op (anal, &op, scan_base + i * 4, buf + i * 4, 4,
+				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL) > 0
+				&& (op.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_ADD) {
+			RAnalValue *d = RVecRArchValue_at (&op.dsts, 0);
+			if (d && d->reg && !strcmp (d->reg, target_reg)) {
+				RAnalValue *s0 = RVecRArchValue_at (&op.srcs, 0);
+				RAnalValue *s1 = RVecRArchValue_at (&op.srcs, 1);
+				if (s0 && s0->reg) {
+					r_str_ncpy (add_s0, s0->reg, sizeof (add_s0));
+				}
+				if (s1 && s1->reg) {
+					r_str_ncpy (add_s1, s1->reg, sizeof (add_s1));
+				}
+				add_addr = scan_base + i * 4;
+				add_idx = i;
+				r_anal_op_fini (&op);
+				break;
+			}
+		}
+		r_anal_op_fini (&op);
+	}
+	if (add_idx < 0 || (!*add_s0 && !*add_s1)) {
+		return false;
+	}
+	// Walk back from the add to find the `ldr* Rload, [Rtable, ...]`
+	// whose destination is one of the add's sources.
+	char table_reg[32] = {0};
+	char load_reg[32] = {0};
+	ut64 load_addr = UT64_MAX;
+	for (i = add_idx - 1; i >= 0; i--) {
+		RAnalOp op = {0};
+		if (r_anal_op (anal, &op, scan_base + i * 4, buf + i * 4, 4,
+				R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL) > 0
+				&& (op.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_LOAD) {
+			RAnalValue *ld = RVecRArchValue_at (&op.dsts, 0);
+			RAnalValue *ls = RVecRArchValue_at (&op.srcs, 0);
+			if (ld && ld->reg && ls && ls->reg
+					&& ((*add_s0 && !strcmp (add_s0, ld->reg))
+						|| (*add_s1 && !strcmp (add_s1, ld->reg)))) {
+				r_str_ncpy (load_reg, ld->reg, sizeof (load_reg));
+				r_str_ncpy (table_reg, ls->reg, sizeof (table_reg));
+				load_addr = scan_base + i * 4;
+				r_anal_op_fini (&op);
+				break;
+			}
+		}
+		r_anal_op_fini (&op);
+	}
+	if (!*load_reg || !*table_reg) {
+		return false;
+	}
+	// The dispatch base is the add source that is not the loaded value.
+	const char *base_reg = (*add_s0 && strcmp (add_s0, load_reg)) ? add_s0
+		: (*add_s1 && strcmp (add_s1, load_reg)) ? add_s1 : NULL;
+	if (!base_reg) {
+		return false;
+	}
+	RLeaddrPair *bp = leaddrs_find_before (leaddrs, base_reg, add_addr);
+	RLeaddrPair *tp = leaddrs_find_before (leaddrs, table_reg, load_addr);
+	if (!bp || !tp) {
+		return false;
+	}
+	*opaddr = bp->op_addr;
+	*basptr = bp->leaddr;
+	*tblptr = tp->leaddr;
+	return true;
+}
 
 static inline ut64 get_mips_gp_base(RAnal *anal, ut64 ip) {
 	ut64 gp = anal ? anal->gp : 0;
@@ -816,4 +942,74 @@ R_API void r_anal_jmptbl_list(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, u
 	}
 	apply_switch (anal, fcn, bb, saddr, jaddr, r_list_length (cases), UT64_MAX);
 	set_u_free (s);
+}
+
+R_IPI bool r_anal_jmptbl_arm64_from_br(RAnal *anal, RAnalFunction *fcn,
+		RAnalBlock *bb, int depth, RAnalOp *op, int loadsize) {
+	if (!anal || !op || !op->reg || !anal->leaddrs) {
+		return false;
+	}
+	if (loadsize != 1 && loadsize != 2 && loadsize != 4) {
+		return false;
+	}
+	ut64 opaddr = UT64_MAX, basptr = UT64_MAX, tblptr = UT64_MAX;
+	if (!arm64_resolve_dispatch (anal, anal->leaddrs, op->addr, op->reg,
+			&opaddr, &basptr, &tblptr)) {
+		return false;
+	}
+	// anal->cmpval can be stale (clobbered by another branch of the
+	// function that was analysed first); when the predecessor-bb walker
+	// yields a clearly larger count, trust that one instead.
+	ut64 table_size = anal->cmpval;
+	ut64 alt_size = 0, alt_default = 0;
+	st64 alt_shift = 0;
+	if (try_get_jmptbl_info (anal, fcn, op->addr, bb, &alt_size, &alt_default, &alt_shift)
+			&& alt_size > anal->cmpval + 1) {
+		table_size = alt_size;
+	}
+	if (table_size == 0 || table_size == UT64_MAX) {
+		return false;
+	}
+	const size_t table_bytes = R_MIN ((size_t)table_size * loadsize, 4096);
+	ut8 *table = calloc (1, table_bytes);
+	if (!table) {
+		return false;
+	}
+	if (!anal->iob.read_at (anal->iob.io, tblptr, table, table_bytes)) {
+		free (table);
+		return false;
+	}
+	RList *kases = r_list_newf (free);
+	const size_t max = table_bytes / loadsize;
+	size_t i;
+	for (i = 0; i < max; i++) {
+		st64 delta;
+		ut64 caseaddr;
+		switch (loadsize) {
+		case 1:
+			delta = ((st8 *)table)[i];
+			caseaddr = basptr + (delta << 2);
+			break;
+		case 2:
+			delta = (st16)r_read_le16 (table + i * 2);
+			caseaddr = basptr + (delta << 1);
+			break;
+		default:
+			delta = (st32)r_read_le32 (table + i * 4);
+			caseaddr = basptr + delta;
+			break;
+		}
+		if (!anal->iob.is_valid_offset (anal->iob.io, caseaddr, 0)) {
+			continue;
+		}
+		RAnalCaseOp *kase = R_NEW0 (RAnalCaseOp);
+		kase->addr = caseaddr;
+		kase->jump = caseaddr;
+		kase->value = i;
+		r_list_append (kases, kase);
+	}
+	r_anal_jmptbl_list (anal, fcn, bb, opaddr, tblptr, kases, loadsize);
+	r_list_free (kases);
+	free (table);
+	return true;
 }

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -6,9 +6,6 @@
 #include <r_vec.h>
 
 #define JMPTBL_MAXSZ 512
-// How many instructions back from the indirect branch to scan when
-// looking for the load/add dispatcher pattern. 16 * 4 = 64 bytes, which
-// easily covers any reasonable scheduling of movs between load/add/br.
 #define JMPTBL_DISPATCH_LOOKBACK 16
 
 R_VEC_TYPE (RVecUT64, ut64);
@@ -19,9 +16,7 @@ typedef struct {
 } JmptblTargetCtx;
 
 R_IPI void r_anal_jmptbl_leaddrs_bump(RList *leaddrs, const char *reg, ut64 delta) {
-	if (!leaddrs || !reg) {
-		return;
-	}
+	R_RETURN_IF_FAIL (leaddrs && reg);
 	RListIter *iter;
 	RLeaddrPair *la;
 	r_list_foreach_prev (leaddrs, iter, la) {
@@ -32,10 +27,6 @@ R_IPI void r_anal_jmptbl_leaddrs_bump(RList *leaddrs, const char *reg, ut64 delt
 	}
 }
 
-// Return the most recent RLeaddrPair matching `reg` whose op_addr is
-// strictly less than `before`. This lets the dispatcher resolver pick
-// the right value of a register that gets reassigned between the load
-// and the add (classic `adr Rt, table; ldr ..., [Rt]; adr Rt, base; add ..., Rt`).
 static RLeaddrPair *leaddrs_find_before(RList *leaddrs, const char *reg, ut64 before) {
 	RListIter *iter;
 	RLeaddrPair *la;
@@ -50,9 +41,7 @@ static RLeaddrPair *leaddrs_find_before(RList *leaddrs, const char *reg, ut64 be
 static bool arm64_resolve_dispatch(RAnal *anal, RList *leaddrs,
 		ut64 br_addr, const char *target_reg,
 		ut64 *opaddr, ut64 *basptr, ut64 *tblptr) {
-	if (!anal || !leaddrs || !target_reg || !opaddr || !basptr || !tblptr) {
-		return false;
-	}
+	R_RETURN_VAL_IF_FAIL (anal && leaddrs && target_reg && opaddr && basptr && tblptr, false);
 	const ut64 lookback_bytes = JMPTBL_DISPATCH_LOOKBACK * 4;
 	if (br_addr < lookback_bytes) {
 		return false;
@@ -63,8 +52,7 @@ static bool arm64_resolve_dispatch(RAnal *anal, RList *leaddrs,
 		return false;
 	}
 	// Locate the `add Rdst, Rs0, Rs1[, lsl N]` whose destination matches
-	// the indirect branch's target register. Scan the most recent
-	// instructions first so unrelated adds don't fool us.
+	// the indirect branch's target register. Scan the most recent instructions
 	char add_s0[32] = {0};
 	char add_s1[32] = {0};
 	ut64 add_addr = UT64_MAX;
@@ -141,11 +129,11 @@ static bool arm64_resolve_dispatch(RAnal *anal, RList *leaddrs,
 }
 
 static inline ut64 get_mips_gp_base(RAnal *anal, ut64 ip) {
-	ut64 gp = anal ? anal->gp : 0;
-	if (!gp && anal && anal->reg) {
+	ut64 gp = anal->gp;
+	if (!gp && anal->reg) {
 		gp = r_reg_getv (anal->reg, "gp");
 	}
-	if (!gp && anal && anal->config) {
+	if (!gp && anal->config) {
 		gp = anal->config->gp;
 	}
 	if (!gp || gp == UT64_MAX) {
@@ -155,61 +143,50 @@ static inline ut64 get_mips_gp_base(RAnal *anal, ut64 ip) {
 }
 
 static void jmptbl_target_ctx_init(JmptblTargetCtx *ctx, RAnal *anal, ut64 switch_addr) {
-	if (!ctx) {
-		return;
-	}
-	ctx->switch_map = anal && anal->iob.map_get_at
+	ctx->switch_map = anal->iob.map_get_at
 		? anal->iob.map_get_at (anal->iob.io, switch_addr)
 		: NULL;
 	ctx->validated_targets = ht_up_new0 ();
 }
 
 static void jmptbl_target_ctx_fini(JmptblTargetCtx *ctx) {
-	if (!ctx) {
-		return;
-	}
 	ht_up_free (ctx->validated_targets);
 	ctx->validated_targets = NULL;
 	ctx->switch_map = NULL;
 }
 
-static bool is_valid_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 case_addr) {
-	if (!anal || !anal->iob.io) {
-		return false;
-	}
-	bool found = false;
-	if (ctx && ctx->validated_targets) {
-		void *v = ht_up_find (ctx->validated_targets, case_addr, &found);
-		if (found) {
-			return v == (void *)1;
-		}
-	}
-	bool valid = false;
+static bool check_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 case_addr) {
 	if (!anal->iob.is_valid_offset (anal->iob.io, case_addr, 0)) {
-		goto beach;
+		return false;
 	}
 	if (anal->iob.map_get_at) {
 		RIOMap *case_map = anal->iob.map_get_at (anal->iob.io, case_addr);
 		if (!case_map) {
-			goto beach;
+			return false;
 		}
 		// Keep jump-table targets in the same map as the dispatcher, matching direct-jump behavior.
-		if (ctx && ctx->switch_map && !r_io_map_contain (ctx->switch_map, case_addr)) {
-			goto beach;
+		if (ctx->switch_map && !r_io_map_contain (ctx->switch_map, case_addr)) {
+			return false;
 		}
 	}
 	ut8 probe[32];
 	if (!anal->iob.read_at (anal->iob.io, case_addr, probe, sizeof (probe))) {
-		goto beach;
+		return false;
 	}
-	if (r_anal_is_invalid_code (anal, probe, sizeof (probe), true)) {
-		goto beach;
+	return !r_anal_is_invalid_code (anal, probe, sizeof (probe), true);
+}
+
+static bool is_valid_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 case_addr) {
+	if (!anal->iob.io) {
+		return false;
 	}
-	valid = true;
-beach:
-	if (ctx && ctx->validated_targets) {
-		ht_up_insert (ctx->validated_targets, case_addr, valid? (void *)1: (void *)2);
+	bool found = false;
+	void *v = ht_up_find (ctx->validated_targets, case_addr, &found);
+	if (found) {
+		return v == (void *)1;
 	}
+	bool valid = check_jmptbl_case_target (anal, ctx, case_addr);
+	ht_up_insert (ctx->validated_targets, case_addr, valid? (void *)1: (void *)2);
 	return valid;
 }
 
@@ -240,26 +217,22 @@ static void update_switch_op(RAnalBlock *block, ut64 switch_addr, ut64 default_c
 	if (!block || !block->switch_op) {
 		return;
 	}
-	block->switch_op->def_val = default_case_addr;
-	block->switch_op->amount = cases_count;
-	if (!block->switch_op->cases) {
+	RAnalSwitchOp *sop = block->switch_op;
+	sop->def_val = default_case_addr;
+	sop->amount = cases_count;
+	if (!sop->cases || r_list_empty (sop->cases)) {
 		return;
 	}
 	RListIter *iter;
 	RAnalCaseOp *caseop;
-	bool first = true;
-	r_list_foreach (block->switch_op->cases, iter, caseop) {
-		if (first) {
-			block->switch_op->min_val = caseop->value;
-			block->switch_op->max_val = caseop->value;
-			first = false;
-			continue;
+	sop->min_val = UT64_MAX;
+	sop->max_val = 0;
+	r_list_foreach (sop->cases, iter, caseop) {
+		if (caseop->value < sop->min_val) {
+			sop->min_val = caseop->value;
 		}
-		if (caseop->value < block->switch_op->min_val) {
-			block->switch_op->min_val = caseop->value;
-		}
-		if (caseop->value > block->switch_op->max_val) {
-			block->switch_op->max_val = caseop->value;
+		if (caseop->value > sop->max_val) {
+			sop->max_val = caseop->value;
 		}
 	}
 }
@@ -372,11 +345,6 @@ R_API bool try_walkthrough_casetbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *
 			ret = false;
 			break;
 		}
-#if 0
-		if (jmptbl_loc == jmptbl_off) {
-			jmpptr = jmptbl_off + (jmpptr_idx << (sz >> 1));
-		}
-#endif
 		switch (sz) {
 		case 1:
 			jmpptr = r_read_le8 (jmptbl + jmpptr_idx);

--- a/libr/include/r_anal_priv.h
+++ b/libr/include/r_anal_priv.h
@@ -15,11 +15,31 @@ typedef struct r_anal_priv_t {
 	char *dir_prefix;
 } RAnalPriv;
 
+// Recorded adrp/add (or lea) target for a register. Populated by the
+// function recurser as it walks a basic block and consumed by the jmptbl
+// dispatcher resolver.
+typedef struct r_leaddr_pair_t {
+	ut64 op_addr;
+	ut64 leaddr;
+	char *reg;
+} RLeaddrPair;
+
 #define R_ANAL_PRIV(x) ((RAnalPriv*)(x)->priv)
 
 R_IPI void r_anal_types_ensure_loaded(RAnal *anal);
 R_IPI bool r_anal_var_is_default_argname(const char *name);
 R_IPI bool r_anal_function_materialize_switch_case(RAnal *anal, RAnalFunction *fcn, ut64 case_addr, int depth);
+
+// Bump the recorded leaddr of the most recent entry that matches `reg` by
+// `delta`. Used on arm64 to finalise `adrp Rd, page; add Rd, Rd, #imm`
+// sequences where multiple adrp's can interleave before their matching adds.
+R_IPI void r_anal_jmptbl_leaddrs_bump(RList *leaddrs, const char *reg, ut64 delta);
+
+// Detect and walk an arm64 jmptbl dispatcher at the indirect branch `op`.
+// Scans the preceding add/load pair, resolves the base/table lea pairs
+// via the recorded `leaddrs`, reads the table and registers each case.
+// Returns true when a jmptbl was successfully resolved and applied.
+R_IPI bool r_anal_jmptbl_arm64_from_br(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, int depth, RAnalOp *op, int loadsize);
 
 #ifdef __cplusplus
 }

--- a/test/db/anal/autoname
+++ b/test/db/anal/autoname
@@ -123,7 +123,7 @@ EXPECT=<<EOF
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
 0x100007950    1     24 sym.imp.write
-0x100003a90  182   2972 main
+0x100003a90  182   2976 main
 0x100003830    1     12 sub.strcoll_100003830
 0x10000383c    1     16 sub.strcoll_10000383c
 0x10000384c    7    100 sub.strcoll_10000384c
@@ -146,10 +146,9 @@ EXPECT=<<EOF
 0x1000055fc    5     60 sym.func.1000055fc
 0x100005638   82   1840 sub.total__qu_n_100005638
 0x100005d68    6    156 sub.humanize_number_100005d68
-0x100005e04   33    736 sub.nl_langinfo_100005e04
+0x100005e04   34    740 sub.nl_langinfo_100005e04
 0x100006184    1      4 sub.fcn.100006184_100006184
-0x1000060e8   16    168 sub.fcn.100006184_100006184_1000060e8
-0x1000060e4    1      4 sub.__stack_chk_fail_1000060e4
+0x1000060e8   13    168 sub.fcn.100006184_100006184_1000060e8
 0x100006188    1      4 case.0x100006120.11
 0x10000618c    1     24 case.0x100006120.9
 0x1000069ec   21    456 sub.printf_1000069ec
@@ -177,7 +176,7 @@ EXPECT=<<EOF
 0x100007348    1     24 sub.malloc_100007348
 0x100007360    1     24 sub.fflagstostr_100007360
 0x100007378    1     84 sub.strerror_100007378
-0x1000073cc    1     44 sub.printscol_1000073cc
+0x1000073cc    1    116 sub.printscol_1000073cc
 EOF
 RUN
 
@@ -272,7 +271,7 @@ EXPECT=<<EOF
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
 0x100007950    1     24 sym.imp.write
-0x100003a90  182   2972 main
+0x100003a90  182   2976 main
 0x100003830    1     12 sub.strcoll_100003830
 0x10000383c    1     16 sub.strcoll_10000383c
 0x10000384c    7    100 sub.strcoll_10000384c
@@ -295,10 +294,9 @@ EXPECT=<<EOF
 0x1000055fc    5     60 sym.func.1000055fc
 0x100005638   82   1840 sub.total__qu_n_100005638
 0x100005d68    6    156 sub.humanize_number_100005d68
-0x100005e04   33    736 sub.nl_langinfo_100005e04
+0x100005e04   34    740 sub.nl_langinfo_100005e04
 0x100006184    1      4 sub.fcn.100006184_100006184
-0x1000060e8   16    168 sub.fcn.100006184_100006184_1000060e8
-0x1000060e4    1      4 case.0x100006118.111
+0x1000060e8   13    168 sub.fcn.100006184_100006184_1000060e8
 0x100006188    1      4 case.0x100006120.11
 0x10000618c    1     24 case.0x100006120.9
 0x1000069ec   21    456 sub.printf_1000069ec
@@ -326,6 +324,6 @@ EXPECT=<<EOF
 0x100007348    1     24 sub.malloc_100007348
 0x100007360    1     24 sub.fflagstostr_100007360
 0x100007378    1     84 sub.strerror_100007378
-0x1000073cc    1     44 sub.printscol_1000073cc
+0x1000073cc    1    116 sub.printscol_1000073cc
 EOF
 RUN

--- a/test/db/anal/autoname
+++ b/test/db/anal/autoname
@@ -123,7 +123,7 @@ EXPECT=<<EOF
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
 0x100007950    1     24 sym.imp.write
-0x100003a90  182   2976 main
+0x100003a90  182   2972 main
 0x100003830    1     12 sub.strcoll_100003830
 0x10000383c    1     16 sub.strcoll_10000383c
 0x10000384c    7    100 sub.strcoll_10000384c
@@ -176,7 +176,7 @@ EXPECT=<<EOF
 0x100007348    1     24 sub.malloc_100007348
 0x100007360    1     24 sub.fflagstostr_100007360
 0x100007378    1     84 sub.strerror_100007378
-0x1000073cc    1    116 sub.printscol_1000073cc
+0x1000073cc    1     44 sub.printscol_1000073cc
 EOF
 RUN
 
@@ -271,7 +271,7 @@ EXPECT=<<EOF
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
 0x100007950    1     24 sym.imp.write
-0x100003a90  182   2976 main
+0x100003a90  182   2972 main
 0x100003830    1     12 sub.strcoll_100003830
 0x10000383c    1     16 sub.strcoll_10000383c
 0x10000384c    7    100 sub.strcoll_10000384c
@@ -324,6 +324,6 @@ EXPECT=<<EOF
 0x100007348    1     24 sub.malloc_100007348
 0x100007360    1     24 sub.fflagstostr_100007360
 0x100007378    1     84 sub.strerror_100007378
-0x1000073cc    1    116 sub.printscol_1000073cc
+0x1000073cc    1     44 sub.printscol_1000073cc
 EOF
 RUN

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -686,7 +686,6 @@ CC.@0x0000b5a4
 CC.@0x0000badc
 EOF
 EXPECT=<<EOF
-switch table (7 cases) at 0xe080
 switch table (7 cases) at 0xe09c
 switch table (14 cases) at 0xe100
 switch table (31 cases) at 0xe13c

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -675,3 +675,20 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=arm64 jmptbl with multiple adrp before adds
+FILE=bins/elf/libarm64.so
+CMDS=<<EOF
+aaa
+CC.@0x00005ba4
+CC.@0x0000aa4c
+CC.@0x0000b5a4
+CC.@0x0000badc
+EOF
+EXPECT=<<EOF
+switch table (7 cases) at 0xe080
+switch table (7 cases) at 0xe09c
+switch table (14 cases) at 0xe100
+switch table (31 cases) at 0xe13c
+EOF
+RUN


### PR DESCRIPTION
The arm64 switch-table detection had two long-standing issues that caused
missing/incorrect cases on real binaries (e.g. test/bins/elf/libarm64.so):

1. The `add Rd, Rd, #imm` handler that finalises an `adrp/add` pair
   blindly bumped the *most recent* leaddr, even when the add operated
   on a different register than the last adrp. With multiple adrp's
   appearing before their matching adds, the wrong leaddr got bumped
   and the table base resolved to a bogus address (manifesting as
   "switch table (0 cases)" comments).

2. The br dispatcher inferred the table/base registers by popping the
   last two leaddr entries instead of looking at which registers the
   `ldr*`/`add`/`br` actually consume. That broke patterns where the
   compiler emits unrelated adrp's between the dispatcher prologue and
   the indirect branch, or where it reassigns the same register
   between the load and the add (single-register dispatchers and the
   classic Swift `adr Rt, table; ldrsw Rl, [Rt,...]; adr Rt, base;
   add Rd, Rt, Rl; br Rd` shape).

Fixes:

* `add` now matches the destination reg back to its leaddr_pair before
  bumping, so multiple in-flight adrp's no longer cross-contaminate.
* The br handler scans backwards from the indirect branch (skipping
  unrelated movs) to identify the actual `add` and `ldr*` consumed by
  the dispatch, then resolves the corresponding leaddr entries by
  matching both the register name *and* the most recent op_addr that
  precedes each consumer (so a single register reassigned mid-block
  resolves to the correct value at each use site).
* When `anal->cmpval` is implausibly stale (clobbered by a previously
  analysed branch), the case count now falls back to walking the
  predecessor bb via `try_get_jmptbl_info`.

A regression test on bins/elf/libarm64.so covers four switches that
went from 0/wrong cases to the correct values (7, 7, 14 and 31).