### PR TITLE
Fix Windows (mingw) installs failing on r2sdb install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ install: install-doc install-man install-panels install-www install-pkgconfig
 	cp -f doc/hud "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud/main"
 	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/"
 	$(SHELL) ./configure-plugins --rm-static $(DESTDIR)$(LIBDIR)/radare2/last/
-	${INSTALL_PROGRAM} "subprojects/sdb/sdb${EXT_EXE}" "${DESTDIR}${BINDIR}/r2sdb${EXT_EXE}"
+	${INSTALL_PROGRAM} "subprojects/sdb/sdb${BUILD_EXT_EXE}" "${DESTDIR}${BINDIR}/r2sdb${BUILD_EXT_EXE}"
 
 install-panels:
 	rm -rf "${DESTDIR}${PANELS}"
@@ -328,12 +328,12 @@ symstall install-symlink: install-man-symlink install-doc-symlink install-pkgcon
 	cd "$(DESTDIR)$(DATADIR)/radare2/" && rm -f last && ln -fs $(VERSION) last
 	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/"
 	$(SHELL) ./configure-plugins --rm-static $(DESTDIR)/$(LIBDIR)/radare2/last/
-	rm -f "${DESTDIR}${BINDIR}/r2sdb${EXT_EXE}"
-	ln -fs "${PWD}/subprojects/sdb/sdb${EXT_EXE}" "${DESTDIR}${BINDIR}/r2sdb${EXT_EXE}"
+	rm -f "${DESTDIR}${BINDIR}/r2sdb${BUILD_EXT_EXE}"
+	ln -fs "${PWD}/subprojects/sdb/sdb${BUILD_EXT_EXE}" "${DESTDIR}${BINDIR}/r2sdb${BUILD_EXT_EXE}"
 
 deinstall uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/clang-format-radare2
-	rm -f "$(DESTDIR)$(BINDIR)/r2sdb${EXT_EXE}"
+	rm -f "$(DESTDIR)$(BINDIR)/r2sdb${BUILD_EXT_EXE}"
 	cd libr && ${MAKE} uninstall
 	cd binr && ${MAKE} uninstall
 	cd shlr && ${MAKE} uninstall


### PR DESCRIPTION
The sdb binary built at subprojects/sdb/sdb is a host binary produced
by sdb-host using HOST_CC, so its filename uses BUILD_EXT_EXE (the
build-host extension), not EXT_EXE (the target extension).

When cross-compiling to Windows from Linux, BUILD_EXT_EXE is empty but
EXT_EXE is ".exe", so "subprojects/sdb/sdb.exe" does not exist and
INSTALL_PROGRAM fails, breaking the w32-mingw and w64-mingw CI jobs.

Use BUILD_EXT_EXE consistently in the install, symstall and uninstall
recipes to match the actual built path.