### PR TITLE
Fix #25803 - Replace execl with execlp on r_sandbox_system ##sys

### DIFF
--- a/libr/util/sandbox.c
+++ b/libr/util/sandbox.c
@@ -343,7 +343,7 @@ R_API int r_sandbox_system(const char *x, int n) {
 	}
 #endif
 	char *bin_sh = r_file_binsh ();
-	int rc = execl (bin_sh, bin_sh, "-c", x, (const char*)NULL);
+	int rc = execlp (bin_sh, bin_sh, "-c", x, (const char*)NULL);
 	if (rc == -1) {
 		r_sys_perror ("execl");
 	}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Within r_sandbox_system, whenever execl executes it doesn't receive the full path for the file to be executed. Replacing it by execlp will search for the filename in the path if the full path is not given.


<!-- explain your changes if necessary -->
