### PR TITLE
Fix ESIL trace register rollback off-by-one ##esil

### DIFF
--- a/libr/esil/esil_trace.c
+++ b/libr/esil/esil_trace.c
@@ -341,10 +341,11 @@ R_API void r_esil_trace_op(REsil *esil, struct r_anal_op_t *op) {
 		to->addr = op->addr;
 	}
 
+	// Tag every change recorded for this op with a fresh step number, so
+	// later restore lookups can locate the post-state of any prior step.
+	esil->trace->cur_idx = esil->trace->idx + 1;
 	RRegItem *pc_ri = r_reg_get (esil->anal->reg, "PC", -1);
-	if (pc_ri) {
-		add_reg_change (esil->trace, pc_ri, op->addr);
-	}
+	const ut64 pc_before = pc_ri? r_reg_get_value (esil->anal->reg, pc_ri): 0;
 	/* set hooks */
 	esil->cb.hook_reg_read = trace_hook_reg_read;
 	esil->cb.hook_reg_write = trace_hook_reg_write;
@@ -360,6 +361,15 @@ R_API void r_esil_trace_op(REsil *esil, struct r_anal_op_t *op) {
 	esil->cb = esil->ocb;
 	esil->ocb_set = false;
 	// update_last_trace_op (esil);
+	// Record the post-state PC so a later step-back finds the right value.
+	// If the ESIL expression did not modify PC, the caller will advance it
+	// to op->addr + op->size, so persist that value as the final PC.
+	if (pc_ri) {
+		const ut64 pc_after = r_reg_get_value (esil->anal->reg, pc_ri);
+		const ut64 final_pc = (pc_after == pc_before)? op->addr + op->size: pc_after;
+		add_reg_change (esil->trace, pc_ri, final_pc);
+		r_unref (pc_ri);
+	}
 	/* increment idx */
 	esil->trace->idx++;
 	esil->trace->end_idx++; // should be vector length
@@ -385,7 +395,7 @@ static bool restore_register(REsil *esil, RRegItem *ri, int idx) {
 	if (vreg) {
 		REsilRegChange needle = { .idx = idx };
 		index = RVecEsilRegChange_upper_bound (vreg, &needle, reg_change_compare);
-		if (index > 1 && index <= RVecEsilRegChange_length (vreg)) {
+		if (index > 0 && index <= RVecEsilRegChange_length (vreg)) {
 			REsilRegChange *c = RVecEsilRegChange_at (vreg, index - 1);
 			if (c) {
 				// printf ("set value %s 0x%"PFMT64x"\n", ri->name, c->data);

--- a/libr/esil/esil_trace.c
+++ b/libr/esil/esil_trace.c
@@ -385,8 +385,8 @@ static bool restore_register(REsil *esil, RRegItem *ri, int idx) {
 	if (vreg) {
 		REsilRegChange needle = { .idx = idx };
 		index = RVecEsilRegChange_upper_bound (vreg, &needle, reg_change_compare);
-		if (index > 0 && index <= RVecEsilRegChange_length (vreg)) {
-			REsilRegChange *c = RVecEsilRegChange_at (vreg, index - 2);
+		if (index > 1 && index <= RVecEsilRegChange_length (vreg)) {
+			REsilRegChange *c = RVecEsilRegChange_at (vreg, index - 1);
 			if (c) {
 				// printf ("set value %s 0x%"PFMT64x"\n", ri->name, c->data);
 				r_reg_set_value (esil->anal->reg, ri, c->data);


### PR DESCRIPTION
Summary

  The previous commit e75bb7c982 flipped at(index - 2) → at(index - 1) in restore_register but only treated
   a symptom. The real problem was deeper:

  Root causes (introduced in the 2023 "Massage the code to make tests pass" commit d4955f0cff):
  1. trace->cur_idx is never advanced during recording, so every entry in vreg/vmem is tagged with idx=0.
  The upper_bound lookup is therefore meaningless and always returns the vector length.
  2. r_esil_trace_op records the pre-execution PC (op->addr), so the post-state of the last step is never
  persisted.

  The old index - 2 was a hack compensating for both (lucky offset) but underflows when index == 1. The new
   commit fixed nothing and just shifted the off-by-one, breaking the test.

  Cleaner fix in libr/esil/esil_trace.c:
  - Set trace->cur_idx = trace->idx + 1 at the start of r_esil_trace_op so each step's recorded changes
  carry a real, monotonically increasing step number.
  - Replace the pre-PC add_reg_change(pc_ri, op->addr) with a post-PC entry computed after the ESIL parse:
  if the parse didn't touch PC, store op->addr + op->size (what the caller will set); otherwise the
  reg_write hook already captured the new value.
  - r_unref the leaked pc_ri.
  - restore_register reverts to the natural at(index - 1) with index > 0, matching the existing
  memory-restore logic.

  With proper step tagging the natural lookup gives the "state after step K" the test wants, no off-by-one
  needed and no underflow on the idx=1 → 0 rollback edge case.
