### PR TITLE
Properly null-terminate readlink() buffer

### DIFF
--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -149,7 +149,7 @@ static char *r2r_test_directory(const char *argv0) {
 		: r_file_path (argv0);
 	if (r2r_path) {
 		char *check_path = r2r_path;
-		ssize_t len = readlink (r2r_path, src_path, PATH_MAX - 1);
+		ssize_t len = readlink (r2r_path, src_path, sizeof (src_path) - 1);
 		if (len != -1) {
 			src_path[len] = '\0';
 			check_path = src_path;

--- a/binr/r2r/r2r.c
+++ b/binr/r2r/r2r.c
@@ -149,8 +149,9 @@ static char *r2r_test_directory(const char *argv0) {
 		: r_file_path (argv0);
 	if (r2r_path) {
 		char *check_path = r2r_path;
-		if (readlink (r2r_path, src_path, PATH_MAX) != -1) {
-			src_path[PATH_MAX - 1] = 0;
+		ssize_t len = readlink (r2r_path, src_path, PATH_MAX - 1);
+		if (len != -1) {
+			src_path[len] = '\0';
 			check_path = src_path;
 		}
 		char *p = strstr (check_path, "/binr/r2r/r2r");


### PR DESCRIPTION
Unlike almost any other function, readlink() does not null terminate the buffer. hence we need to explicitly handle that. without proper null termination, we have undefined behavior later on.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
