### PR TITLE
meson: Split Windows deps to avoid pc leakage ##build

### DIFF
--- a/libr/socket/meson.build
+++ b/libr/socket/meson.build
@@ -10,9 +10,9 @@ r_socket_sources = [
   'run.c',
 ]
 
-r_socket_deps = [r_util_dep, platform_deps]
+r_socket_deps = [r_util_dep, platform_deps, platform_socket_deps]
 if get_option('blob')
-  r_socket_static_deps = [r_util_static_dep, platform_deps]
+  r_socket_static_deps = [r_util_static_dep, platform_deps, platform_socket_deps]
   if use_sys_openssl
     r_socket_static_deps += [sys_openssl]
   endif

--- a/meson.build
+++ b/meson.build
@@ -142,8 +142,10 @@ else
 endif
 
 platform_deps = []
+platform_socket_deps = []
 if host_machine.system() == 'windows'
-  platform_deps = [cc.find_library('ws2_32'), cc.find_library('wininet'), cc.find_library('psapi')]
+  platform_deps = [cc.find_library('psapi')]
+  platform_socket_deps = [cc.find_library('ws2_32'), cc.find_library('wininet')]
 endif
 platform_inc = include_directories(['.', 'libr/include'])
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The Windows platform deps (psapi, ws2_32, wininet) were all attached to r_util via platform_deps. Because every other r_* module transitively requires r_util, each generated pc file inherited all three system libs in its public Libs: line, and any consumer that does not deduplicate link flags (e.g. SwiftPM's Windows driver) saw the flags multiplied by the fan-out.

Split platform_deps into the libs r_util genuinely needs (psapi) and a new platform_socket_deps for r_socket's winsock/wininet usage. r_util still exposes psapi via its Requires chain, but ws2_32 and wininet now appear only on r_socket.