### PR TITLE
[security] fix(project): confine project deletion to dir.projects

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -51,6 +51,26 @@ static char *get_project_script_path(RCore *core, const char *file) {
 	return prjfile;
 }
 
+static bool project_path_is_within_projects_dir(RCore *core, const char *path) {
+	if (!core || R_STR_ISEMPTY (path)) {
+		return false;
+	}
+	char *projects_dir = r_file_abspath (r_config_get (core->config, "dir.projects"));
+	char *project_path = r_file_abspath (path);
+	if (!projects_dir || !project_path) {
+		free (projects_dir);
+		free (project_path);
+		return false;
+	}
+	const size_t projects_dir_len = strlen (projects_dir);
+	const bool in_projects_dir = !strncmp (project_path, projects_dir, projects_dir_len)
+		&& (project_path[projects_dir_len] == '\0'
+			|| project_path[projects_dir_len] == R_SYS_DIR[0]);
+	free (projects_dir);
+	free (project_path);
+	return in_projects_dir;
+}
+
 static bool make_projects_directory(RCore *core) {
 	char *prjdir = r_file_abspath (r_config_get (core->config, "dir.projects"));
 	bool ret = r_sys_mkdirp (prjdir);
@@ -143,6 +163,11 @@ R_API int r_core_project_delete(RCore *core, const char *prjfile) {
 	char *path = get_project_script_path (core, prjfile);
 	if (!path) {
 		R_LOG_ERROR ("Invalid project name '%s'", prjfile);
+		return false;
+	}
+	if (!project_path_is_within_projects_dir (core, path)) {
+		R_LOG_ERROR ("Refusing to delete project outside dir.projects");
+		free (path);
 		return false;
 	}
 	if (r_core_is_project (core, prjfile)) {

--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -52,23 +52,14 @@ static char *get_project_script_path(RCore *core, const char *file) {
 }
 
 static bool project_path_is_within_projects_dir(RCore *core, const char *path) {
-	if (!core || R_STR_ISEMPTY (path)) {
-		return false;
-	}
-	char *projects_dir = r_file_abspath (r_config_get (core->config, "dir.projects"));
-	char *project_path = r_file_abspath (path);
-	if (!projects_dir || !project_path) {
-		free (projects_dir);
-		free (project_path);
-		return false;
-	}
-	const size_t projects_dir_len = strlen (projects_dir);
-	const bool in_projects_dir = !strncmp (project_path, projects_dir, projects_dir_len)
-		&& (project_path[projects_dir_len] == '\0'
-			|| project_path[projects_dir_len] == R_SYS_DIR[0]);
-	free (projects_dir);
-	free (project_path);
-	return in_projects_dir;
+	char *pdir = r_file_abspath (r_config_get (core->config, "dir.projects"));
+	char *ppath = r_file_abspath (path);
+	char *prefix = (pdir && ppath) ? r_str_newf ("%s%s", pdir, R_SYS_DIR) : NULL;
+	bool inside = prefix ? r_str_startswith (ppath, prefix) : false;
+	free (prefix);
+	free (pdir);
+	free (ppath);
+	return inside;
 }
 
 static bool make_projects_directory(RCore *core) {

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -638,6 +638,43 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=Reject deleting an absolute-path project outside dir.projects
+FILE=bins/elf/analysis/main
+ARGS=-n
+CMDS=<<EOF
+e prj.vc=false
+e scr.interactive=false
+e dir.projects = .tmp/
+!rm -rf /tmp/r2r-project-delete-absolute-path
+!mkdir -p /tmp/r2r-project-delete-absolute-path/sub
+!printf '# r2 rdb project file\n' > /tmp/r2r-project-delete-absolute-path/rc.r2
+P- /tmp/r2r-project-delete-absolute-path/rc.r2 > /dev/null
+!python3 -c "import os; print('kept' if os.path.isdir('/tmp/r2r-project-delete-absolute-path') else 'deleted')"
+!rm -rf /tmp/r2r-project-delete-absolute-path
+EOF
+EXPECT=<<EOF
+kept
+EOF
+RUN
+
+NAME=Allow deleting an absolute-path project inside dir.projects
+FILE=bins/elf/analysis/main
+ARGS=-n
+CMDS=<<EOF
+e prj.vc=false
+e scr.interactive=false
+e dir.projects = /tmp/r2r-project-delete-root
+!rm -rf /tmp/r2r-project-delete-root
+P+ inside > /dev/null
+P- /tmp/r2r-project-delete-root/inside/rc.r2 > /dev/null
+!python3 -c "import os; print('removed' if not os.path.exists('/tmp/r2r-project-delete-root/inside') else 'still-there')"
+!rm -rf /tmp/r2r-project-delete-root
+EOF
+EXPECT=<<EOF
+removed
+EOF
+RUN
+
 NAME=Delete a saved project and used directory (with Pd)
 FILE=bins/elf/analysis/main
 ARGS=-n

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -644,16 +644,16 @@ ARGS=-n
 CMDS=<<EOF
 e prj.vc=false
 e scr.interactive=false
-e dir.projects = .tmp/
-!rm -rf /tmp/r2r-project-delete-absolute-path
-!mkdir -p /tmp/r2r-project-delete-absolute-path/sub
-!printf '# r2 rdb project file\n' > /tmp/r2r-project-delete-absolute-path/rc.r2
-P- /tmp/r2r-project-delete-absolute-path/rc.r2 > /dev/null
-!python3 -c "import os; print('kept' if os.path.isdir('/tmp/r2r-project-delete-absolute-path') else 'deleted')"
-!rm -rf /tmp/r2r-project-delete-absolute-path
+e dir.projects = .tmp/project-delete-outside-check
+rmrf /tmp/r2r-project-delete-outside-target
+mkdir -p /tmp/r2r-project-delete-outside-target/sub
+?e # r2 rdb project file > /tmp/r2r-project-delete-outside-target/rc.r2
+P- /tmp/r2r-project-delete-outside-target/rc.r2 > /dev/null
+ls -q /tmp/r2r-project-delete-outside-target~sub[0]
+rmrf /tmp/r2r-project-delete-outside-target
 EOF
 EXPECT=<<EOF
-kept
+/tmp/r2r-project-delete-outside-target/sub/
 EOF
 RUN
 
@@ -663,15 +663,16 @@ ARGS=-n
 CMDS=<<EOF
 e prj.vc=false
 e scr.interactive=false
-e dir.projects = /tmp/r2r-project-delete-root
-!rm -rf /tmp/r2r-project-delete-root
+e dir.projects = /tmp/r2r-project-delete-inside-root
+rmrf /tmp/r2r-project-delete-inside-root
 P+ inside > /dev/null
-P- /tmp/r2r-project-delete-root/inside/rc.r2 > /dev/null
-!python3 -c "import os; print('removed' if not os.path.exists('/tmp/r2r-project-delete-root/inside') else 'still-there')"
-!rm -rf /tmp/r2r-project-delete-root
+ls -q /tmp/r2r-project-delete-inside-root~inside[0]
+P- /tmp/r2r-project-delete-inside-root/inside/rc.r2 > /dev/null
+ls -q /tmp/r2r-project-delete-inside-root~inside[0]
+rmrf /tmp/r2r-project-delete-inside-root
 EOF
 EXPECT=<<EOF
-removed
+/tmp/r2r-project-delete-inside-root/inside/
 EOF
 RUN
 


### PR DESCRIPTION
## Summary
This PR hardens project deletion so `P-` can only remove projects that resolve inside the configured `dir.projects` root.

- it adds an explicit boundary check before `r_core_project_delete()` reaches `r_file_rm_rf()`
- it blocks absolute-path project deletion requests that resolve outside `dir.projects`
- it preserves legitimate absolute-path deletion for project files that still resolve inside `dir.projects`
- it adds command-db regression coverage for both the reject and allow cases

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Absolute-path project deletion escapes `dir.projects` and can recursively delete arbitrary directories | local destructive delete of attacker-chosen directories containing a project marker file, limited by the permissions of the radare2 process | High |

## Before this PR
- `P-` accepted absolute project paths through `get_project_script_path()`
- `r_core_project_delete()` used the resolved path to derive a parent directory and then called `r_file_rm_rf()` on that directory
- there was no containment check ensuring the deletion target stayed inside `dir.projects`
- there was no regression test covering absolute-path deletion outside the configured project root

## After this PR
- `r_core_project_delete()` refuses deletion when the resolved project path is outside `dir.projects`
- the boundary check uses canonical absolute paths before the destructive delete step
- absolute-path deletion still works when the project file resolves inside `dir.projects`
- regression tests now lock both behaviors in place

## Why this matters
- the broken trust boundary was: user-supplied project path -> resolved project file -> parent directory -> recursive delete
- a crafted absolute path to a marker file such as `/tmp/victim/rc.r2` could turn `P-` into a recursive delete of `/tmp/victim`
- the impact is integrity and availability loss in any location writable by the radare2 process

## Attack flow
```text
attacker-controlled absolute project path
    -> get_project_script_path() accepts the path as-is
        -> r_core_project_delete() derives the parent directory
            -> r_file_rm_rf() recursively deletes outside dir.projects
```

## Affected code
| Issue | Files |
|-------|-------|
| Absolute-path project deletion escapes `dir.projects` | `libr/core/project.c` |
| Regression coverage for outside-root and inside-root absolute-path deletion | `test/db/cmd/projects` |

## Root cause
Issue 1: project deletion escaped the configured project root
- `get_project_script_path()` allowed absolute paths for deletion flows
- `r_core_project_delete()` trusted the resolved path and recursively deleted its parent directory without checking that the target stayed under `dir.projects`

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Absolute-path project deletion escapes `dir.projects` | 7.1 High | `AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H` |

Rationale:
- exploitation is local and requires a user to open a crafted path, but successful abuse can recursively delete arbitrary writable directories outside the configured project store

## Safe reproduction steps
### 1. Outside-root absolute-path delete should be rejected
1. Create a directory outside `dir.projects`, for example `/tmp/r2r-project-delete-absolute-path/`.
2. Place a marker file at `/tmp/r2r-project-delete-absolute-path/rc.r2` with the contents `# r2 rdb project file`.
3. Run radare2 with a different project root, for example `e dir.projects=.tmp/`.
4. Execute `P- /tmp/r2r-project-delete-absolute-path/rc.r2`.
5. On vulnerable code, the directory is removed. With this patch, radare2 refuses the delete and the directory remains in place.

### 2. In-root absolute-path delete should still work
1. Set `dir.projects` to an absolute path such as `/tmp/r2r-project-delete-root`.
2. Save a project there with `P+ inside`.
3. Execute `P- /tmp/r2r-project-delete-root/inside/rc.r2`.
4. Confirm that the in-root project directory is removed.

## Expected vulnerable behavior
- `P- /tmp/victim/rc.r2` should never have been able to recursively delete `/tmp/victim` when that path was outside `dir.projects`
- before this patch, any directory containing a project marker file could be turned into a recursive deletion target if the process had permission to remove it

## Changes in this PR
- add a dedicated helper to compare the resolved project path against the configured `dir.projects` root
- fail closed in `r_core_project_delete()` before any recursive delete when the project path is outside `dir.projects`
- add a regression test that verifies outside-root absolute-path deletion is rejected
- add a regression test that verifies inside-root absolute-path deletion still works when `dir.projects` itself is absolute

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Security boundary enforcement | `libr/core/project.c` | add path containment check before recursive delete |
| Regression tests | `test/db/cmd/projects` | add reject/allow coverage for absolute-path deletion behavior |

## Maintainer impact
- the patch is narrowly scoped to project deletion
- project save/open behavior is unchanged
- destructive deletion now respects the same configured storage boundary that project management already implies
- the tests make future regressions visible without requiring manual filesystem inspection

## Suggested fix rationale
- `P-` is a destructive command, so its delete target must stay anchored to the configured project storage root
- enforcing the boundary in `r_core_project_delete()` is narrow, explicit, and durable because it protects the exact path that reaches `r_file_rm_rf()`
- keeping absolute-path deletion working only for in-root project paths preserves valid workflows while removing the escape condition

## Reference patterns from other software
- this follows the standard principle that destructive filesystem operations should stay rooted to an explicitly configured workspace or storage directory, even when callers supply absolute paths

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Added a command-db regression test that rejects absolute-path deletion outside `dir.projects`
- [x] Added a command-db regression test that allows absolute-path deletion inside `dir.projects`
- [x] Re-ran the `test/db/cmd/projects` suite after the patch
- [x] Reproduced the patched behavior manually with `R2_DEBUG=1`, following the guidance in `DEVELOPERS.md#Error_diagnosis`

Executed with:
- `./sys/install.sh /tmp/r2dbgprefix`
- `R2R_OFFLINE=1 ./binr/r2r/r2r -q -j1 test/db/cmd/projects`
- `R2_DEBUG=1 /private/tmp/r2dbgprefix/bin/radare2 -q -n -c 'e prj.vc=false;e scr.interactive=false;e dir.projects=.tmp/;P- /tmp/r2r-project-delete-absolute-path/rc.r2' /tmp/radare2/test/bins/elf/analysis/main`

Reference:
- https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#Error_diagnosis

## Disclosure notes
- this PR is intentionally bounded to the project deletion trust boundary in `P-`
- claims are limited to the reviewed and reproduced filesystem deletion behavior
- no unrelated files were changed
