### PR TITLE
[security] fix(project): ignore symlinked imported notes

### DIFF
--- a/libr/core/project.c
+++ b/libr/core/project.c
@@ -813,6 +813,11 @@ R_API char *r_core_project_notes_file(RCore *core, const char *prj_name) {
 	const char *prjdir = r_config_get (core->config, "dir.projects");
 	char *prjpath = r_file_abspath (prjdir);
 	char *notes_txt = r_file_new (prjpath, prj_name, "notes.txt", NULL);
+	char *link = notes_txt? r_file_readlink (notes_txt): NULL;
+	if (link && strcmp (link, notes_txt)) {
+		R_FREE (notes_txt);
+	}
+	free (link);
 	free (prjpath);
 	return notes_txt;
 }

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -676,6 +676,50 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=Ignore symlinked notes in an imported .zrp project
+FILE=bins/elf/analysis/main
+ARGS=-n
+CMDS=<<EOF
+e prj.vc=false
+e dir.projects = /tmp/r2r-project-import-notes
+!rm -rf /tmp/r2r-project-import-notes /tmp/r2r-zrp-malicious /tmp/r2r-zrp-outside /tmp/r2r-malicious.zrp
+!mkdir -p /tmp/r2r-zrp-malicious/evil /tmp/r2r-zrp-outside
+!printf '# r2 rdb project file\n' > /tmp/r2r-zrp-malicious/evil/rc.r2
+!ln -sf /tmp/r2r-zrp-outside/owned.txt /tmp/r2r-zrp-malicious/evil/notes.txt
+!cd /tmp/r2r-zrp-malicious && zip -y -r /tmp/r2r-malicious.zrp evil >/dev/null
+Pzi /tmp/r2r-malicious.zrp > /dev/null
+P evil > /dev/null
+Pn hello
+!python3 -c "import os; print('clean' if not os.path.exists('/tmp/r2r-zrp-outside/owned.txt') else 'written')"
+!rm -rf /tmp/r2r-project-import-notes /tmp/r2r-zrp-malicious /tmp/r2r-zrp-outside /tmp/r2r-malicious.zrp
+EOF
+EXPECT=<<EOF
+clean
+EOF
+RUN
+
+NAME=Import a .zrp project without symlinked notes
+FILE=bins/elf/analysis/main
+ARGS=-n
+CMDS=<<EOF
+e prj.vc=false
+e dir.projects = /tmp/r2r-project-import-ok
+!rm -rf /tmp/r2r-project-import-ok /tmp/r2r-zrp-regular /tmp/r2r-regular.zrp
+!mkdir -p /tmp/r2r-zrp-regular/ok
+!printf '# r2 rdb project file\n' > /tmp/r2r-zrp-regular/ok/rc.r2
+!printf 'SAFE_NOTE\n' > /tmp/r2r-zrp-regular/ok/notes.txt
+!cd /tmp/r2r-zrp-regular && zip -r /tmp/r2r-regular.zrp ok >/dev/null
+Pzi /tmp/r2r-regular.zrp > /dev/null
+P ok > /dev/null
+Pn
+!rm -rf /tmp/r2r-project-import-ok /tmp/r2r-zrp-regular /tmp/r2r-regular.zrp
+EOF
+EXPECT=<<EOF
+SAFE_NOTE
+
+EOF
+RUN
+
 NAME=Delete a saved project and used directory (with Pd)
 FILE=bins/elf/analysis/main
 ARGS=-n


### PR DESCRIPTION
## Summary
This PR narrows the fix to the exploited notes path used after `.zrp` import.

A malicious project archive can preserve a symlinked `notes.txt` under an imported project directory. Before this change, normal `Pn` note operations trusted that path and could read from or write to files outside `dir.projects`.

This patch keeps the import flow unchanged and instead hardens `r_core_project_notes_file()` so symlinked notes paths are ignored.

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Imported project notes can point outside `dir.projects` through a preserved symlink | local arbitrary file read/write as the importing user through normal `Pn` operations | Medium |

## Before this PR
- `.zrp` import could preserve a symlinked `notes.txt` inside an imported project directory
- `r_core_project_notes_file()` returned that notes path as if it were a normal project-local file
- `Pn` note operations then followed the symlink and accessed files outside `dir.projects`

## After this PR
- `r_core_project_notes_file()` resolves the notes path and ignores it if it is symlinked away from the project-local path
- `Pn` note operations no longer read from or write to external files through imported symlinked notes
- normal imported projects with a regular `notes.txt` still work unchanged

## Why this matters
- imported project notes should stay inside the configured project directory
- before this patch, an imported archive could redirect ordinary note reads/writes to an attacker-chosen file outside `dir.projects`
- the impact remains local to the importing user, but it breaks the expected filesystem boundary for imported project metadata

## How this differs from related issue/PR
This is different from the previously public project-deletion boundary issue fixed in #25830.

- #25830 hardened `P-` deletion boundaries
- this PR hardens the imported project notes path used by `Pn`
- the trigger here is a malicious imported project whose `notes.txt` is a symlink
- the failure mode here is note read/write redirection, not recursive deletion

## Attack flow
```text
attacker-controlled .zrp archive
    -> Pzi imports project with symlinked notes.txt
        -> P evil ; Pn / Pn <text>
            -> radare2 follows the imported notes symlink
                -> file access escapes dir.projects
```

## Affected code
| Issue | Files |
|-------|-------|
| Imported project notes path trusted symlinked `notes.txt` | `libr/core/project.c` |
| Regression coverage for malicious and normal imported project notes | `test/db/cmd/projects` |

## Root cause
- the imported notes path was trusted without checking whether it still resolved to the expected project-local file
- the broken trust boundary was: attacker-controlled imported filesystem object -> trusted project notes path -> normal note read/write operations

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Imported project notes can point outside `dir.projects` through a preserved symlink | 6.6 Medium | `AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:H/A:L` |

Rationale:
- exploitation is local and requires importing a malicious `.zrp` and then using ordinary note commands
- successful exploitation can redirect note reads/writes outside the configured project root
- impact remains bounded by the importing user's filesystem permissions

## Safe reproduction steps
### 1. Build a malicious `.zrp`
1. Create a project directory such as `evil/`.
2. Add `evil/rc.r2` containing `# r2 rdb project file`.
3. Make `evil/notes.txt` a symlink to a file outside the project root.
4. Archive it with symlink preservation enabled, for example `zip -y -r evil.zrp evil`.

### 2. Trigger the vulnerable behavior
1. Import the archive with `Pzi /tmp/evil.zrp`.
2. Open the imported project with `P evil`.
3. Trigger `Pn hello` or `Pn`.

### 3. Observe vulnerable behavior
- on vulnerable code, `Pn hello` writes to the external target file
- on vulnerable code, `Pn` reads from the external target file

### 4. Confirm patched behavior
- with this patch, the imported project still opens
- `Pn` ignores the symlinked notes path instead of following it
- no external file is written and no external note content is printed

## Expected vulnerable behavior
- imported project notes should not have been able to escape `dir.projects`
- before this patch, symlinked imported notes redirected ordinary note operations outside the configured project root

## Changes in this PR
- harden `r_core_project_notes_file()` so symlinked imported notes paths are ignored
- add a regression test showing `Pn hello` no longer writes through a symlinked imported notes file
- add a regression test proving normal imported project notes still work

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Security boundary enforcement | `libr/core/project.c` | ignore symlinked imported notes paths |
| Regression tests | `test/db/cmd/projects` | add malicious-symlink and normal-import note coverage |

## Maintainer impact
- the patch is narrowly scoped to project notes handling
- `.zrp` import behavior itself is unchanged
- normal imported projects with regular notes files continue to work
- imported projects with symlinked `notes.txt` no longer get a usable notes path

## Fix rationale
- the exploit path is through the notes accessor, so the smallest safe boundary is to reject notes paths that resolve away from the expected project-local file
- this keeps the fix small and avoids broader import-flow changes

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] Rebuilt the modified code
- [x] Re-ran the `test/db/cmd/projects` command-db suite against the built binary
- [x] Reproduced the malicious symlinked notes archive locally and confirmed writes are blocked
- [x] Reproduced the malicious symlinked notes archive locally and confirmed reads are blocked
- [x] Revalidated a normal imported project with a regular `notes.txt`
- [x] Followed the project’s debugging guidance in `DEVELOPERS.md#Error_diagnosis`

Executed with:
- `make -j4`
- `R2R_RADARE2=/tmp/radare2/binr/radare2/radare2 R2R_OFFLINE=1 ./binr/r2r/r2r -q -j1 test/db/cmd/projects`
- `python3 - <<'PY' ... crafted malicious symlinked .zrp, ran /tmp/radare2/binr/radare2/radare2 with Pzi/P/Pn hello, and verified no external file was written ... PY`
- `python3 - <<'PY' ... crafted malicious symlinked .zrp, ran /tmp/radare2/binr/radare2/radare2 with Pzi/P/Pn, and verified no external note content was leaked ... PY`
- `python3 - <<'PY' ... crafted normal non-symlink .zrp, ran /tmp/radare2/binr/radare2/radare2 with Pzi/P/Pn, and verified SAFE_NOTE was preserved ... PY`

Reference:
- https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#Error_diagnosis

## Disclosure notes
- this PR is intentionally bounded to the imported project notes path used by `Pn`
- the claims here are limited to the reproduced behavior where imported symlinked `notes.txt` redirected normal note operations outside `dir.projects`
- this PR does not claim a general archive-import hardening across every `.zrp` member type or every archive consumer in radare2
