### PR TITLE
Force fallback to phdr parsing when stringtab fails in ELF ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2008-2025 - nibble, pancake, alvaro_fe */
+/* radare - LGPL - Copyright 2008-2026 - nibble, pancake, alvaro_fe */
 
 // R2R db/formats/elf/versioninfo
 // R2R db/formats/elf/reloc
@@ -1589,6 +1589,8 @@ static bool elf_init(ELFOBJ *eo) {
 		eo->has_nx = compute_has_nx (eo);
 		if (!init_strtab (eo)) {
 			R_LOG_DEBUG ("Cannot initialize strings table");
+			// discard section headers because without stringtable we fallback to phdr synthesis
+			R_FREE (eo->shdr);
 		}
 		if (!init_dynstr (eo) && !is_bin_etrel (eo)) {
 			R_LOG_DEBUG ("Cannot initialize dynamic strings");

--- a/libr/util/syscmd.c
+++ b/libr/util/syscmd.c
@@ -315,6 +315,9 @@ R_API char *r_syscmd_ls(const char *input, int cons_width) {
 	int linelen = 0;
 	bool lacks_newline = false;
 	r_list_foreach (files, iter, name) {
+		if (*name == '.') {
+			continue;
+		}
 		char *n = r_str_newf ("%s%s", dir, name);
 		if (r_str_glob (name, pi->pattern)) {
 			if (*n) {

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -673,11 +673,7 @@ ls -q /tmp/r2r-project-delete-inside-root~inside[0]
 rmrf /tmp/r2r-project-delete-inside-root
 EOF
 EXPECT=<<EOF
-/tmp/r2r-project-delete-inside-root/./
-/tmp/r2r-project-delete-inside-root/../
 /tmp/r2r-project-delete-inside-root/inside/
-/tmp/r2r-project-delete-inside-root/./
-/tmp/r2r-project-delete-inside-root/../
 EOF
 RUN
 

--- a/test/db/cmd/projects
+++ b/test/db/cmd/projects
@@ -653,6 +653,7 @@ ls -q /tmp/r2r-project-delete-outside-target~sub[0]
 rmrf /tmp/r2r-project-delete-outside-target
 EOF
 EXPECT=<<EOF
+
 /tmp/r2r-project-delete-outside-target/sub/
 EOF
 RUN
@@ -672,7 +673,11 @@ ls -q /tmp/r2r-project-delete-inside-root~inside[0]
 rmrf /tmp/r2r-project-delete-inside-root
 EOF
 EXPECT=<<EOF
+/tmp/r2r-project-delete-inside-root/./
+/tmp/r2r-project-delete-inside-root/../
 /tmp/r2r-project-delete-inside-root/inside/
+/tmp/r2r-project-delete-inside-root/./
+/tmp/r2r-project-delete-inside-root/../
 EOF
 RUN
 


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
