### PR TITLE
ragg2/egg: make ESIL backend usable as an expression compiler

### DIFF
--- a/libr/egg/egg.c
+++ b/libr/egg/egg.c
@@ -397,6 +397,9 @@ R_API bool r_egg_compile(REgg *egg) {
 		R_LOG_ERROR ("expected '}' at the end of the file. %d left", egg->context);
 		return false;
 	}
+	if (egg->remit && egg->remit->finalize) {
+		egg->remit->finalize (egg);
+	}
 	return true;
 }
 

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -251,38 +251,49 @@ static const char *find_alias(REgg *egg, const char *str) {
 }
 
 static void rcc_internal_mathop(REgg *egg, const char *ptr, char *ep, char op) {
-	char *p, *q, *oldp; // avoid mem leak
+	char *q, *oldp;
+	const char *p;
+	char *allocated = NULL; // extra heap pointer that needs freeing
 	char type = ' ';
 	char buf[64]; // may cause stack overflow
-	oldp = p = q = strdup (ptr);
+	oldp = q = strdup (ptr);
 	if (get_op (&q)) {
 		*q = '\x00';
 	}
 	REggEmit *e = egg->remit;
-	p = (char *)r_str_trim_head_ro (p);
-	if (is_var (p)) {
-		p = r_egg_mkvar (egg, buf, p, 0);
+	p = r_str_trim_head_ro (oldp);
+	/* also strip trailing whitespace in-place (we own oldp) */
+	{
+		char *end = (char *)p + strlen (p);
+		while (end > p && (end[-1] == ' ' || end[-1] == '\t')) {
+			end--;
+			*end = '\0';
+		}
+	}
+	if (is_var ((char *)p)) {
+		allocated = r_egg_mkvar (egg, buf, p, 0);
+		p = allocated;
 		if (egg->lang.varxs == '*') {
 			e->load (egg, p, egg->lang.varsize);
-			R_FREE (oldp);
-			oldp = p = strdup (e->regs (egg, 0));
+			R_FREE (allocated);
+			allocated = strdup (e->regs (egg, 0));
+			p = allocated;
 			// XXX: which will go wrong in arm
 			// for reg used in emit.load in arm is r7 not r0
 		} else if (egg->lang.varxs == '&') {
 			e->load_ptr (egg, p);
-			R_FREE (oldp);
-			oldp = p = strdup (e->regs (egg, 0));
+			R_FREE (allocated);
+			allocated = strdup (e->regs (egg, 0));
+			p = allocated;
 		}
 		type = ' ';
 	} else {
 		type = '$';
 	}
-	if (*p) {
+	if (p && *p) {
 		e->mathop (egg, op, egg->lang.varsize, type, p, ep);
 	}
-	if (p != oldp) {
-		R_FREE (p);
-	}
+	R_FREE (allocated);
 	R_FREE (oldp);
 	R_FREE (ep);
 }
@@ -1188,10 +1199,20 @@ static void rcc_next(REgg *egg) {
 	} else { // handle mathop
 		int vs = 'l';
 		char type, *eq, *ptr = egg->lang.elem, *tmp;
+		char compound_op = 0; // 0 = plain '=', otherwise +,-,*,/,|,&,^
 		egg->lang.elem[egg->lang.elem_n] = '\0';
 		ptr = (char *)r_str_trim_head_ro (ptr);
 		if (*ptr) {
 			eq = strchr (ptr, '=');
+			if (eq && eq > ptr) {
+				/* detect compound operators: +=, -=, *=, /=, |=, &=, ^= */
+				char prev = eq[-1];
+				if (prev == '+' || prev == '-' || prev == '*' || prev == '/'
+				    || prev == '|' || prev == '&' || prev == '^') {
+					compound_op = prev;
+					eq[-1] = '\x00'; /* chop the operator off the LHS */
+				}
+			}
 			if (eq) {
 				vs = egg->lang.varsize;
 				*buf = *eq = '\x00';
@@ -1218,7 +1239,12 @@ static void rcc_next(REgg *egg) {
 				} else {
 					type = '$';
 				}
-				e->mathop (egg, '=', vs, type, e->regs (egg, 1), p);
+				if (compound_op) {
+					/* emit: p <compound_op>= tmpreg */
+					e->mathop (egg, compound_op, vs, type, e->regs (egg, 1), p);
+				} else {
+					e->mathop (egg, '=', vs, type, e->regs (egg, 1), p);
+				}
 				free (p);
 #if 0
 				char str2[64], *p, ch = *(eq-1);
@@ -1259,6 +1285,9 @@ static void rcc_next(REgg *egg) {
 		}
 	}
 	free (str);
+	/* reset the element buffer so the next statement starts clean */
+	egg->lang.elem[0] = '\0';
+	egg->lang.elem_n = 0;
 }
 
 R_API int r_egg_lang_parsechar(REgg *egg, char c) {

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -581,19 +581,39 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 	}
 	if (str[0] == '.') {
 		REggEmit *e = egg->remit;
+		/* parse_leading_idx parses only the leading digits (possibly
+		 * with a 0x prefix) of s and returns the number. This avoids
+		 * r_num_math evaluating trailing operators as part of the
+		 * index, so ".var0 == 0" resolves to offset 0 rather than 1. */
+		char numbuf[32];
+#define PARSE_LEADING_IDX(s) ({ \
+		const char *_p = (s); \
+		int _k = 0; \
+		if (_p[0] == '0' && (_p[1] == 'x' || _p[1] == 'X')) { \
+			while (_k < 31 && _p[_k]) { \
+				if (_k < 2 || isxdigit ((unsigned char)_p[_k])) { \
+					numbuf[_k] = _p[_k]; _k++; \
+				} else { break; } \
+			} \
+		} else { \
+			while (_k < 31 && isdigit ((unsigned char)_p[_k])) { \
+				numbuf[_k] = _p[_k]; _k++; \
+			} \
+		} \
+		numbuf[_k] = '\0'; \
+		(int)r_num_math (NULL, numbuf); \
+	})
 		if (r_str_startswith (str + 1, "ret")) {
 			strcpy (out, e->retvar);
 		} else if (r_str_startswith (str + 1, "fix")) {
-			int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
+			int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx - egg->lang.stackfixed);
-			// snprintf (out, 32, "%d(%%"R_BP")", - (atoi (str+4)+delta+R_SZ-egg->lang.stackfixed));
 		} else if (r_str_startswith (str + 1, "var")) {
-			int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
+			int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx);
-			// snprintf (out, 32, "%d(%%"R_BP")", - (atoi (str+4)+delta+R_SZ));
 		} else if (r_str_startswith (str + 1, "rarg")) {
 			if (e->get_arg) {
-				int idx = (int)r_num_math (NULL, str + 5);
+				int idx = PARSE_LEADING_IDX (str + 5);
 				e->get_arg (egg, out, idx);
 			}
 		} else if (r_str_startswith (str + 1, "arg")) {
@@ -601,7 +621,7 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				if (egg->lang.stackframe == 0) {
 					e->get_var (egg, 1, out, 4); // idx-4);
 				} else {
-					int idx = (int)r_num_math (NULL, str + 4) + delta + e->size;
+					int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
 					e->get_var (egg, 2, out, idx + 4);
 				}
 			} else {
@@ -620,11 +640,11 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				}
 			}
 		} else if (r_str_startswith (str + 1, "reg")) {
-			// XXX: can overflow if out is small
+			int idx = PARSE_LEADING_IDX (str + 4);
 			if (egg->lang.attsyntax) {
-				snprintf (out, 32, "%%%s", e->regs (egg, atoi (str + 4)));
+				snprintf (out, 32, "%%%s", e->regs (egg, idx));
 			} else {
-				snprintf (out, 32, "%s", e->regs (egg, atoi (str + 4)));
+				snprintf (out, 32, "%s", e->regs (egg, idx));
 			}
 		} else {
 			/* Unknown keyword: first check for a user-defined alias

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -627,8 +627,24 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				snprintf (out, 32, "%s", e->regs (egg, atoi (str + 4)));
 			}
 		} else {
-			out = str; /* TODO: show error, invalid var name? */
-			R_LOG_ERROR ("Something is really wrong in here");
+			/* Unknown keyword: first check for a user-defined alias
+			 * (e.g. `foo@alias(rax)` then `.foo` becomes "rax"); if
+			 * nothing matches, treat the name as a native register or
+			 * symbol name. This allows the .r program to directly
+			 * reference target registers like `.rax` or `.x0`. */
+			const char *name = str + 1;
+			int i;
+			for (i = 0; i < egg->lang.nalias; i++) {
+				const char *aname = egg->lang.aliases[i].name;
+				if (aname && !strcmp (name, aname)) {
+					const char *content = egg->lang.aliases[i].content;
+					r_str_ncpy (out, content? content: "", 32);
+					break;
+				}
+			}
+			if (i == egg->lang.nalias) {
+				r_str_ncpy (out, name, 32);
+			}
 		}
 		ret = strdup (out);
 		free (oldstr);

--- a/libr/egg/egg_lang.c
+++ b/libr/egg/egg_lang.c
@@ -556,6 +556,42 @@ static void rcc_pushstr(REgg *egg, char *str, int filter) {
 	R_FREE (egg->lang.dstvar);
 }
 
+/* Emit a branch-target label in a backend-appropriate form. Backends that
+ * assemble to native code keep the classic ".S" style "name:\n"; backends
+ * like ESIL override the callback to drop labels entirely. */
+static void emit_label(REgg *egg, const char *name) {
+	if (egg->remit && egg->remit->label) {
+		egg->remit->label (egg, name);
+	} else {
+		r_egg_printf (egg, "%s:\n", name);
+	}
+}
+
+/* Return the integer value of the leading (decimal or hex) number in s.
+ * Unlike r_num_math this stops at the first non-digit character so that
+ * trailing tokens like "==" or whitespace do not affect the result. This
+ * is used when resolving `.varN` / `.argN` / `.regN` names out of strings
+ * that may still contain comparison operators. */
+static int parse_leading_idx(const char *s) {
+	char buf[32];
+	int k = 0;
+	if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+		buf[k++] = s[0];
+		buf[k++] = s[1];
+		while (k < (int)sizeof (buf) - 1 && isxdigit ((unsigned char)s[k])) {
+			buf[k] = s[k];
+			k++;
+		}
+	} else {
+		while (k < (int)sizeof (buf) - 1 && isdigit ((unsigned char)s[k])) {
+			buf[k] = s[k];
+			k++;
+		}
+	}
+	buf[k] = '\0';
+	return (int)r_num_math (NULL, buf);
+}
+
 R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 	int i, len, qi;
 	char *oldstr = NULL, *str = NULL, foo[32], *q, *ret = NULL;
@@ -581,39 +617,23 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 	}
 	if (str[0] == '.') {
 		REggEmit *e = egg->remit;
-		/* parse_leading_idx parses only the leading digits (possibly
-		 * with a 0x prefix) of s and returns the number. This avoids
-		 * r_num_math evaluating trailing operators as part of the
-		 * index, so ".var0 == 0" resolves to offset 0 rather than 1. */
-		char numbuf[32];
-#define PARSE_LEADING_IDX(s) ({ \
-		const char *_p = (s); \
-		int _k = 0; \
-		if (_p[0] == '0' && (_p[1] == 'x' || _p[1] == 'X')) { \
-			while (_k < 31 && _p[_k]) { \
-				if (_k < 2 || isxdigit ((unsigned char)_p[_k])) { \
-					numbuf[_k] = _p[_k]; _k++; \
-				} else { break; } \
-			} \
-		} else { \
-			while (_k < 31 && isdigit ((unsigned char)_p[_k])) { \
-				numbuf[_k] = _p[_k]; _k++; \
-			} \
-		} \
-		numbuf[_k] = '\0'; \
-		(int)r_num_math (NULL, numbuf); \
-	})
-		if (r_str_startswith (str + 1, "ret")) {
+		if (str[1] == '%') {
+			/* Explicit raw native register: `.%name` skips the alias
+			 * table and copies the register name verbatim. This keeps
+			 * the unambiguous "target register" syntax separate from
+			 * `.varN`, `.regN` and user-defined aliases. */
+			r_str_ncpy (out, str + 2, 32);
+		} else if (r_str_startswith (str + 1, "ret")) {
 			strcpy (out, e->retvar);
 		} else if (r_str_startswith (str + 1, "fix")) {
-			int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
+			int idx = parse_leading_idx (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx - egg->lang.stackfixed);
 		} else if (r_str_startswith (str + 1, "var")) {
-			int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
+			int idx = parse_leading_idx (str + 4) + delta + e->size;
 			e->get_var (egg, 0, out, idx);
 		} else if (r_str_startswith (str + 1, "rarg")) {
 			if (e->get_arg) {
-				int idx = PARSE_LEADING_IDX (str + 5);
+				int idx = parse_leading_idx (str + 5);
 				e->get_arg (egg, out, idx);
 			}
 		} else if (r_str_startswith (str + 1, "arg")) {
@@ -621,7 +641,7 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				if (egg->lang.stackframe == 0) {
 					e->get_var (egg, 1, out, 4); // idx-4);
 				} else {
-					int idx = PARSE_LEADING_IDX (str + 4) + delta + e->size;
+					int idx = parse_leading_idx (str + 4) + delta + e->size;
 					e->get_var (egg, 2, out, idx + 4);
 				}
 			} else {
@@ -640,18 +660,15 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				}
 			}
 		} else if (r_str_startswith (str + 1, "reg")) {
-			int idx = PARSE_LEADING_IDX (str + 4);
+			int idx = parse_leading_idx (str + 4);
 			if (egg->lang.attsyntax) {
 				snprintf (out, 32, "%%%s", e->regs (egg, idx));
 			} else {
 				snprintf (out, 32, "%s", e->regs (egg, idx));
 			}
 		} else {
-			/* Unknown keyword: first check for a user-defined alias
-			 * (e.g. `foo@alias(rax)` then `.foo` becomes "rax"); if
-			 * nothing matches, treat the name as a native register or
-			 * symbol name. This allows the .r program to directly
-			 * reference target registers like `.rax` or `.x0`. */
+			/* Not a builtin keyword and not the `.%name` raw register
+			 * form: look the bare name up in the `@alias` table. */
 			const char *name = str + 1;
 			int i;
 			for (i = 0; i < egg->lang.nalias; i++) {
@@ -663,7 +680,9 @@ R_API char *r_egg_mkvar(REgg *egg, char *out, const char *_str, int delta) {
 				}
 			}
 			if (i == egg->lang.nalias) {
-				r_str_ncpy (out, name, 32);
+				R_LOG_ERROR ("Unknown name '.%s' (use .%%%s for a raw register or `%s@alias(...)`)",
+					name, name, name);
+				*out = '\0';
 			}
 		}
 		ret = strdup (out);
@@ -1452,8 +1471,12 @@ R_API int r_egg_lang_parsechar(REgg *egg, char c) {
 						r_str_newf ("  __end_%d_%d_%d",
 							egg->lang.nfunctions, CTX, egg->lang.nestedi[CTX]);
 				}
-				r_egg_printf (egg, "  __begin_%d_%d_%d:\n",
-					egg->lang.nfunctions, CTX, egg->lang.nestedi[CTX]); // %s:\n", get_frame_label (0));
+				{
+					char lbl[64];
+					snprintf (lbl, sizeof (lbl), "__begin_%d_%d_%d",
+						egg->lang.nfunctions, CTX, egg->lang.nestedi[CTX]);
+					emit_label (egg, lbl);
+				}
 			}
 			rcc_context (egg, 1);
 			break;
@@ -1474,8 +1497,12 @@ R_API int r_egg_lang_parsechar(REgg *egg, char c) {
 						r_str_newf ("__end_%d_%d_%d",
 							egg->lang.nfunctions, CTX - 1, egg->lang.nestedi[CTX - 1] - 1);
 				}
-				r_egg_printf (egg, "  __end_%d_%d_%d:\n",
-					egg->lang.nfunctions, CTX - 1, egg->lang.nestedi[CTX - 1] - 1);
+				{
+					char lbl[64];
+					snprintf (lbl, sizeof (lbl), "__end_%d_%d_%d",
+						egg->lang.nfunctions, CTX - 1, egg->lang.nestedi[CTX - 1] - 1);
+					emit_label (egg, lbl);
+				}
 			}
 			if (CTX > 0) {
 				egg->lang.nbrackets++;
@@ -1489,7 +1516,9 @@ R_API int r_egg_lang_parsechar(REgg *egg, char c) {
 				for (i = 0; i < 32; i++) {
 					for (j = 0; j < egg->lang.nestedi[i] && j < 32; j++) {
 						if (egg->lang.ifelse_table[i][j]) {
-							r_egg_printf (egg, "  __ifelse_%d_%d:\n", i, j);
+							char lbl[64];
+							snprintf (lbl, sizeof (lbl), "__ifelse_%d_%d", i, j);
+							emit_label (egg, lbl);
 							e->jmp (egg, egg->lang.ifelse_table[i][j], 0);
 							R_FREE (egg->lang.ifelse_table[i][j]);
 						}

--- a/libr/egg/emit_esil.c
+++ b/libr/egg/emit_esil.c
@@ -50,8 +50,9 @@ static char *emit_syscall(REgg *egg, int num) {
 	 * must be valid .r syntax. Use the ":" prefix to escape into raw mode
 	 * and terminate with a newline so the parser leaves raw mode cleanly.
 	 * The syscall number is injected through the `.arg` backtick expansion
-	 * which the parser resolves from the current @syscall declaration. */
-	return strdup ("\n: `.arg`,$,\n");
+	 * which the parser resolves from the current @syscall declaration.
+	 * Note: no space after ":" so the raw line does not add a leading space. */
+	return strdup ("\n:`.arg`,$,\n");
 }
 
 static void emit_frame(REgg *egg, int sz) {

--- a/libr/egg/emit_esil.c
+++ b/libr/egg/emit_esil.c
@@ -144,10 +144,12 @@ static void emit_restore_stack(REgg *egg, int size) {
 }
 
 static void emit_get_while_end(REgg *egg, char *str, const char *ctxpush, const char *label) {
-	/* Store the back-jump expression - it is emitted at the end of
-	 * the while body by the parser. */
+	/* Inserted at the end of a while-loop body: re-push the loop
+	 * condition value (copy ctxpush into a1) and unconditionally
+	 * jump back to the begin label, where emit_branch will re-check
+	 * the comparison against the fresh value. */
 	if (ctxpush && label) {
-		snprintf (str, 64, "%s,?{,%s,PC,:=,},", ctxpush, label);
+		snprintf (str, 64, "%s,a1,:=,%s,PC,:=,", ctxpush, label);
 	} else if (label) {
 		snprintf (str, 64, "%s,PC,:=,", label);
 	} else {
@@ -196,36 +198,61 @@ static void emit_load_ptr(REgg *egg, const char *dst) {
 
 static void emit_branch(REgg *egg, char *b, char *g, char *e, char *n, int sz, const char *dst) {
 	flush_pending_zero (egg);
-	/* dst is the branch target label. The accumulator r1 holds the
-	 * just-computed right-hand side; the condition variable was stored
-	 * on the push stack by the parser as ctxpush. The branch fires when
-	 * the resulting condition is FALSE (it is the "skip body" branch).
+	/* The parser has pushed the LHS of the condition via push_arg,
+	 * which in this backend copies it into a1. emit_branch jumps to
+	 * dst when the condition is FALSE (it is the "skip the body"
+	 * branch), so the operator is the negation of the source cmp.
+	 *
+	 * ESIL comparison semantics:
+	 *   a,b,>    pushes 1 if b > a  (ditto for <, >=, <=)
+	 *   a,b,==   sets $z = (a == b), pushes nothing useful
+	 *   X,!      pushes !X (logical not)
 	 */
-	const char *op;
+	const char *op = NULL;
 	char *arg = NULL;
+	int equality = 0;   /* 1 = test via $z, 0 = ordered comparison */
+	int invert = 0;     /* 1 = invert result (for skip-when-equal) */
 	if (b) {
 		*b = '\0';
-		op = e ? "<" : "<=";
+		/* source: < or <=, skip on >= or > */
+		op = e ? ">" : ">=";
 		arg = b + 1;
 	} else if (g) {
 		*g = '\0';
-		op = e ? ">" : ">=";
+		/* source: > or >=, skip on <= or < */
+		op = e ? "<" : "<=";
 		arg = g + 1;
 	} else if (e) {
+		/* source: == or !=, branch on equality */
 		arg = e + 1;
-		op = "!=";
+		equality = 1;
+		/* n != NULL means source was "!=", so skip when equal;
+		 * n == NULL means source was "==", so skip when not equal. */
+		invert = (n == NULL) ? 1 : 0;
 	} else {
+		/* bare `if(x)` (skip when x == 0) or `if(!x)` (skip when x != 0) */
 		arg = (char *)"0";
-		op = n ? "==" : "!=";
+		equality = 1;
+		/* n != NULL means source had '!', so skip when x != 0 (invert).
+		 * n == NULL means bare `if(x)`, so skip when x == 0 (no invert). */
+		invert = n ? 1 : 0;
 	}
 	if (arg && *arg == '=') {
-		arg++;
+		arg++;  /* step over the second char of <=, >= */
 	}
-	if (!arg) {
+	while (arg && (*arg == ' ' || *arg == '\t')) {
+		arg++;   /* drop any whitespace between the operator and the RHS */
+	}
+	if (!arg || !*arg) {
 		arg = (char *)"0";
 	}
-	/* compare r1 (accumulator) against arg with op: skip body if cond fails */
-	r_egg_printf (egg, "%s,r1,%s,?{,%s,PC,:=,},", arg, op, dst);
+	if (equality) {
+		r_egg_printf (egg, "%s,a1,==,$z,%s?{,%s,PC,:=,},",
+			arg, invert ? "!," : "", dst);
+	} else {
+		r_egg_printf (egg, "%s,a1,%s,?{,%s,PC,:=,},",
+			arg, op, dst);
+	}
 }
 
 static void emit_load(REgg *egg, const char *dst, int sz) {

--- a/libr/egg/emit_esil.c
+++ b/libr/egg/emit_esil.c
@@ -15,6 +15,13 @@
 
 #include <r_egg.h>
 
+/* Sentinels used to defer label / jump resolution until finalize.
+ * Both are emitted in place of a regular token and stripped or
+ * rewritten during emit_finalize(). They use characters that never
+ * appear in a valid ESIL token so recognition is unambiguous. */
+#define ESIL_LABEL_MARK "#L#"
+#define ESIL_JUMP_MARK  "#J#"
+
 #define EMIT_NAME emit_esil
 #define R_ARCH "esil"
 #define R_SZ 8
@@ -70,9 +77,11 @@ static void emit_comment(REgg *egg, const char *fmt, ...) {
 }
 
 static void emit_label(REgg *egg, const char *name) {
-	/* Branch-target labels are not valid ESIL tokens. They're
-	 * referenced symbolically by the jmp/branch emissions; definitions
-	 * are dropped from the output. */
+	/* Emit a sentinel token that records where the label sits in the
+	 * expression. emit_finalize() later converts every jump reference
+	 * into an N,GOTO pair using these positions and then strips the
+	 * sentinels from the output. */
+	r_egg_printf (egg, ESIL_LABEL_MARK "%s,", name);
 }
 
 static void emit_equ(REgg *egg, const char *key, const char *value) {
@@ -98,15 +107,17 @@ static void emit_jmp(REgg *egg, const char *str, int atr) {
 	}
 	flush_pending_zero (egg);
 	if (atr) {
+		/* dereference-then-branch: load the pointer then set PC. */
 		r_egg_printf (egg, "%s,[%d],PC,:=,", str, (egg->bits == 64) ? 8 : 4);
 	} else {
-		r_egg_printf (egg, "%s,PC,:=,", str);
+		/* plain unconditional branch -> N,GOTO (N resolved in finalize). */
+		r_egg_printf (egg, ESIL_JUMP_MARK "%s,GOTO,", str);
 	}
 }
 
 static void emit_call(REgg *egg, const char *str, int atr) {
-	/* a call is represented as a direct PC assignment. Real return
-	 * semantics are left to higher-level analysis tooling. */
+	/* A call has no dedicated ESIL opcode: model it as a GOTO to the
+	 * symbolic target. Return semantics are left to higher-level tools. */
 	if (!str) {
 		return;
 	}
@@ -114,7 +125,7 @@ static void emit_call(REgg *egg, const char *str, int atr) {
 	if (atr) {
 		r_egg_printf (egg, "%s,[%d],PC,:=,", str, (egg->bits == 64) ? 8 : 4);
 	} else {
-		r_egg_printf (egg, "%s,PC,:=,", str);
+		r_egg_printf (egg, ESIL_JUMP_MARK "%s,GOTO,", str);
 	}
 }
 
@@ -155,9 +166,9 @@ static void emit_get_while_end(REgg *egg, char *str, const char *ctxpush, const 
 	 * jump back to the begin label, where emit_branch will re-check
 	 * the comparison against the fresh value. */
 	if (ctxpush && label) {
-		snprintf (str, 64, "%s,a1,:=,%s,PC,:=,", ctxpush, label);
+		snprintf (str, 64, "%s,a1,:=," ESIL_JUMP_MARK "%s,GOTO,", ctxpush, label);
 	} else if (label) {
-		snprintf (str, 64, "%s,PC,:=,", label);
+		snprintf (str, 64, ESIL_JUMP_MARK "%s,GOTO,", label);
 	} else {
 		*str = '\0';
 	}
@@ -166,7 +177,7 @@ static void emit_get_while_end(REgg *egg, char *str, const char *ctxpush, const 
 static void emit_while_end(REgg *egg, const char *labelback) {
 	if (labelback) {
 		flush_pending_zero (egg);
-		r_egg_printf (egg, "%s,PC,:=,", labelback);
+		r_egg_printf (egg, ESIL_JUMP_MARK "%s,GOTO,", labelback);
 	}
 }
 
@@ -253,10 +264,10 @@ static void emit_branch(REgg *egg, char *b, char *g, char *e, char *n, int sz, c
 		arg = (char *)"0";
 	}
 	if (equality) {
-		r_egg_printf (egg, "%s,a1,==,$z,%s?{,%s,PC,:=,},",
+		r_egg_printf (egg, "%s,a1,==,$z,%s?{," ESIL_JUMP_MARK "%s,GOTO,},",
 			arg, invert ? "!," : "", dst);
 	} else {
-		r_egg_printf (egg, "%s,a1,%s,?{,%s,PC,:=,},",
+		r_egg_printf (egg, "%s,a1,%s,?{," ESIL_JUMP_MARK "%s,GOTO,},",
 			arg, op, dst);
 	}
 }
@@ -341,6 +352,185 @@ static void emit_get_arg(REgg *egg, char *out, int idx) {
 	snprintf (out, 32, "a%d", idx);
 }
 
+static bool is_header_line(const char *line) {
+	/* Lines emitted by the parser as non-ESIL directives: ".global foo",
+	 * "name:" function labels, etc. They are kept verbatim by finalize
+	 * so the overall output still looks like the other backends, while
+	 * the ESIL content between them is resolved to GOTO form. */
+	const char *p = line;
+	while (*p == ' ' || *p == '\t') {
+		p++;
+	}
+	if (*p == '.') {
+		return true;
+	}
+	size_t len = strlen (p);
+	if (len >= 2 && p[len - 1] == '\n' && p[len - 2] == ':') {
+		return true;
+	}
+	if (len >= 1 && p[len - 1] == ':') {
+		return true;
+	}
+	return false;
+}
+
+typedef struct {
+	char *name;
+	int idx;
+} EsilLabel;
+
+static EsilLabel *find_label(EsilLabel *labels, int n, const char *name) {
+	int i;
+	for (i = 0; i < n; i++) {
+		if (!strcmp (labels[i].name, name)) {
+			return &labels[i];
+		}
+	}
+	return NULL;
+}
+
+/* Rewrite one contiguous ESIL block: strip label sentinels (recording
+ * their word indices first) then replace `#J#name` tokens with the
+ * numeric word index of the referenced label. */
+static char *resolve_block(const char *block) {
+	enum { MAX_LABELS = 256 };
+	EsilLabel labels[MAX_LABELS];
+	int nlabels = 0;
+	/* Pass 1: walk comma-separated tokens, record label positions.
+	 * Label sentinels do not occupy a word in the output so the
+	 * counter is not incremented for them. Whitespace tokens are
+	 * ignored entirely. */
+	int word_idx = 0;
+	const char *p = block;
+	while (*p) {
+		const char *start = p;
+		while (*p && *p != ',' && *p != '\n') {
+			p++;
+		}
+		size_t len = p - start;
+		while (len && (*start == ' ' || *start == '\t')) {
+			start++;
+			len--;
+		}
+		while (len && (start[len - 1] == ' ' || start[len - 1] == '\t')) {
+			len--;
+		}
+		if (len > strlen (ESIL_LABEL_MARK)
+				&& !strncmp (start, ESIL_LABEL_MARK, strlen (ESIL_LABEL_MARK))) {
+			if (nlabels < MAX_LABELS) {
+				labels[nlabels].name = r_str_ndup (start + strlen (ESIL_LABEL_MARK),
+					len - strlen (ESIL_LABEL_MARK));
+				labels[nlabels].idx = word_idx;
+				nlabels++;
+			}
+		} else if (len > 0) {
+			word_idx++;
+		}
+		if (*p) {
+			p++;
+		}
+	}
+	/* Pass 2: emit resolved tokens. */
+	RStrBuf *out = r_strbuf_new ("");
+	bool first = true;
+	p = block;
+	while (*p) {
+		const char *start = p;
+		while (*p && *p != ',' && *p != '\n') {
+			p++;
+		}
+		size_t len = p - start;
+		while (len && (*start == ' ' || *start == '\t')) {
+			start++;
+			len--;
+		}
+		while (len && (start[len - 1] == ' ' || start[len - 1] == '\t')) {
+			len--;
+		}
+		if (len == 0) {
+			if (*p) {
+				p++;
+			}
+			continue;
+		}
+		if (len > strlen (ESIL_LABEL_MARK)
+				&& !strncmp (start, ESIL_LABEL_MARK, strlen (ESIL_LABEL_MARK))) {
+			/* label sentinel: drop */
+		} else if (len > strlen (ESIL_JUMP_MARK)
+				&& !strncmp (start, ESIL_JUMP_MARK, strlen (ESIL_JUMP_MARK))) {
+			char *name = r_str_ndup (start + strlen (ESIL_JUMP_MARK),
+				len - strlen (ESIL_JUMP_MARK));
+			EsilLabel *lbl = find_label (labels, nlabels, name);
+			if (!first) {
+				r_strbuf_append (out, ",");
+			}
+			r_strbuf_appendf (out, "%d", lbl ? lbl->idx : 0);
+			first = false;
+			free (name);
+		} else {
+			if (!first) {
+				r_strbuf_append (out, ",");
+			}
+			r_strbuf_append_n (out, start, len);
+			first = false;
+		}
+		if (*p) {
+			p++;
+		}
+	}
+	int i;
+	for (i = 0; i < nlabels; i++) {
+		free (labels[i].name);
+	}
+	r_strbuf_append (out, "\n");
+	return r_strbuf_drain (out);
+}
+
+static void emit_finalize(REgg *egg) {
+	char *src = r_buf_tostring (egg->buf);
+	if (!src) {
+		return;
+	}
+	r_unref (egg->buf);
+	egg->buf = r_buf_new ();
+	RStrBuf *block = r_strbuf_new ("");
+	char *cur = src;
+	while (*cur) {
+		char *nl = strchr (cur, '\n');
+		size_t linelen = nl ? (size_t)(nl - cur) + 1 : strlen (cur);
+		char *line = r_str_ndup (cur, linelen);
+		if (is_header_line (line)) {
+			if (r_strbuf_length (block) > 0) {
+				char *resolved = resolve_block (r_strbuf_get (block));
+				r_buf_append_bytes (egg->buf, (const ut8 *)resolved, strlen (resolved));
+				free (resolved);
+				r_strbuf_set (block, "");
+			}
+			r_buf_append_bytes (egg->buf, (const ut8 *)line, linelen);
+		} else if (*r_str_trim_head_ro (line) == '\0') {
+			/* blank line: treat as a block boundary */
+			if (r_strbuf_length (block) > 0) {
+				char *resolved = resolve_block (r_strbuf_get (block));
+				r_buf_append_bytes (egg->buf, (const ut8 *)resolved, strlen (resolved));
+				free (resolved);
+				r_strbuf_set (block, "");
+			}
+			r_buf_append_bytes (egg->buf, (const ut8 *)line, linelen);
+		} else {
+			r_strbuf_append (block, line);
+		}
+		free (line);
+		cur += linelen;
+	}
+	if (r_strbuf_length (block) > 0) {
+		char *resolved = resolve_block (r_strbuf_get (block));
+		r_buf_append_bytes (egg->buf, (const ut8 *)resolved, strlen (resolved));
+		free (resolved);
+	}
+	r_strbuf_free (block);
+	free (src);
+}
+
 REggEmit EMIT_NAME = {
 	.retvar = R_AX,
 	.arch = R_ARCH,
@@ -355,6 +545,7 @@ REggEmit EMIT_NAME = {
 	.frame_end = emit_frame_end,
 	.comment = emit_comment,
 	.label = emit_label,
+	.finalize = emit_finalize,
 	.push_arg = emit_arg,
 	.restore_stack = emit_restore_stack,
 	.get_result = emit_get_result,

--- a/libr/egg/emit_esil.c
+++ b/libr/egg/emit_esil.c
@@ -1,260 +1,302 @@
-/* pancake // nopcode.org 2022 -- esil emiter */
+/* radare2 - LGPL - Copyright 2022-2026 - pancake */
+/* ESIL emitter for the r_egg compiler.
+ *
+ * Translates the high-level .r egg language into ESIL
+ * (Evaluable Strings Intermediate Language) expressions.
+ *
+ * Local variables become abstract ESIL registers named v<idx>.
+ * Function arguments become a<idx>. Temporaries use r0..r4.
+ * The return value lives in "a0".
+ *
+ * The comma separated ESIL tokens are emitted inline, each group
+ * of tokens forming a "statement" is terminated with a comma too
+ * so the output can be concatenated into a larger ESIL string.
+ */
 
 #include <r_egg.h>
-#define attsyntax 0
 
 #define EMIT_NAME emit_esil
 #define R_ARCH "esil"
 #define R_SZ 8
 #define R_SP "SP"
-#define R_BP "BP"
+#define R_BP "FP"
 #define R_PC "PC"
-#define R_AX "A0"
+#define R_AX "a0"
 #define R_GP { "r0", "r1", "r2", "r3", "r4" }
-#define R_TMP "r9"
 #define R_NGP 5
 
-// no attsyntax for arm
 static char *regs[] = R_GP;
 
+/* Peephole state: remember a pending "0,<reg>,:=" init so we can drop it
+ * when the next op overwrites the same register with a plain assignment.
+ * The r_egg library is not thread-safe, so a file-local static is fine. */
+static int g_pending_zero = 0;
+static char g_pending_zero_reg[16];
+
+static void flush_pending_zero(REgg *egg) {
+	if (g_pending_zero) {
+		r_egg_printf (egg, "0,%s,:=,", g_pending_zero_reg);
+		g_pending_zero = 0;
+	}
+}
+
 static void emit_init(REgg *egg) {
-	/* TODO */
+	g_pending_zero = 0;
 }
 
 static char *emit_syscall(REgg *egg, int num) {
-	int svc = 0x80; // XXX
-	return r_str_newf ("%d,A0,:=,%d,(),:=,", svc, num);
+	flush_pending_zero (egg);
+	/* The string returned here is fed back through the egg parser, so it
+	 * must be valid .r syntax. Use the ":" prefix to escape into raw mode
+	 * and terminate with a newline so the parser leaves raw mode cleanly.
+	 * The syscall number is injected through the `.arg` backtick expansion
+	 * which the parser resolves from the current @syscall declaration. */
+	return strdup ("\n: `.arg`,$,\n");
 }
 
 static void emit_frame(REgg *egg, int sz) {
-#if 0
-	r_egg_printf (egg, "  push {fp,lr}\n");
-	if (sz > 0) {
-		r_egg_printf (egg,
-			// "  mov "R_BP", "R_SP"\n"
-			"  add fp, sp, $4\n"	// size of arguments
-			"  sub sp, %d\n", sz);	// size of stackframe 8, 16, ..
-	}
-#endif
+	/* no explicit frame setup for ESIL - variables are abstract */
 }
 
 static void emit_frame_end(REgg *egg, int sz, int ctx) {
-	if (sz < 1 || ctx > 0) {
-		sz = 8; // minimum stack frame size
-	}
-	r_egg_printf (egg, "FP,%d,+,SP,:=,", sz);
+	/* ESIL does not model real function returns. Emit nothing;
+	 * the parser will insert labels that delimit function bodies. */
+	flush_pending_zero (egg);
 }
 
 static void emit_comment(REgg *egg, const char *fmt, ...) {
-	// comments are for the weak, esil dont need that
+	/* ESIL has no comment syntax, drop comments silently */
 }
 
 static void emit_equ(REgg *egg, const char *key, const char *value) {
-	// should keep a K=V database for this no need to reflect that in esil
-	// r_egg_printf (egg, ".equ %s, %s\n", key, value);
+	/* .equ aliases are resolved at parse time, nothing to emit */
 }
 
 static void emit_syscall_args(REgg *egg, int nargs) {
-	return;
-#if 0
-	int j, k;
-	for (j = 0; j < nargs; j++) {
-		k = j * R_SZ;
-		r_egg_printf (egg, "  ldr %s, [sp, %d]\n",
-			regs[j + 1], k? k + 4: k + 8);
-	}
-#endif
+	/* syscall args are already in a1..aN registers, nothing to do */
 }
 
 static void emit_set_string(REgg *egg, const char *dstvar, const char *str, int j) {
-	// not supported
+	flush_pending_zero (egg);
+	/* store the string address into the destination variable.
+	 * Encode the literal as a comment-like token so downstream tooling
+	 * can still resolve it; ESIL has no native string literal.
+	 */
+	r_egg_printf (egg, "\"%s\",%s,:=,", str, dstvar);
 }
 
 static void emit_jmp(REgg *egg, const char *str, int atr) {
+	if (!str) {
+		return;
+	}
+	flush_pending_zero (egg);
 	if (atr) {
-		r_egg_printf (egg, "%s,[%d],PC,:=", str, (egg->bits == 64)? 8: 4);
+		r_egg_printf (egg, "%s,[%d],PC,:=,", str, (egg->bits == 64) ? 8 : 4);
 	} else {
-		r_egg_printf (egg, "%s,PC,:=", str);
+		r_egg_printf (egg, "%s,PC,:=,", str);
 	}
 }
 
 static void emit_call(REgg *egg, const char *str, int atr) {
-#if 0
-	// thats not an esil primitive as the return value can be stored in a register or in the stack.. and this can be maybe specified in the calling convention rule
-	int i;
-	// r_egg_printf (egg, " ARGS=%d CALL(%s,%d)\n", lastarg, str, atr);
-	for (i = 0; i < lastarg; i++) {
-		r_egg_printf (egg, "  ldr r%d, [%s]\n", lastarg - 1 - i, lastargs[i]);
-		lastargs[i][0] = 0;
+	/* a call is represented as a direct PC assignment. Real return
+	 * semantics are left to higher-level analysis tooling. */
+	if (!str) {
+		return;
 	}
-
+	flush_pending_zero (egg);
 	if (atr) {
-		r_egg_printf (egg, "  ldr r0, %s", str);
-		r_egg_printf (egg, "  blx r0\n");
+		r_egg_printf (egg, "%s,[%d],PC,:=,", str, (egg->bits == 64) ? 8 : 4);
 	} else {
-		r_egg_printf (egg, "  bl %s\n", str);
+		r_egg_printf (egg, "%s,PC,:=,", str);
 	}
-#endif
 }
 
 static void emit_arg(REgg *egg, int xs, int num, const char *str) {
-#if 0
-	int d = atoi (str);
-	if (!attsyntax && (*str == '$')) {
-		str++;
-	}
-	lastarg = num;
+	/* arguments are passed via a1..aN abstract registers.
+	 * xs is 0 (value), '*' (deref), or '&' (address-of). */
+	char target[16];
+	flush_pending_zero (egg);
+	snprintf (target, sizeof (target), "a%d", num);
 	switch (xs) {
 	case 0:
-		if (strchr (str, ',')) {
-			// r_egg_printf (egg, ".  str r0, [%s]\n", str);
-			strncpy (lastargs[num - 1], str, sizeof (lastargs[0]) - 1);
-		} else {
-			if (!atoi (str)) {
-				R_LOG_WARN ("probably a bug?");
-			}
-			r_egg_printf (egg, "  mov r0, %s\n", str);
-			snprintf (lastargs[num - 1], sizeof (lastargs[0]), "sp, %d", 8 + (num * 4));
-			r_egg_printf (egg, "  str r0, [%s]\n", lastargs[num - 1]);
-		}
+		r_egg_printf (egg, "%s,%s,:=,", str, target);
 		break;
 	case '*':
-		r_egg_printf (egg, "  push {%s}\n", str);
+		r_egg_printf (egg, "%s,[%d],%s,:=,", str, R_SZ, target);
 		break;
 	case '&':
-		if (d) {
-			r_egg_printf (egg, "  add "R_BP ", %d\n", d);
-		}
-		r_egg_printf (egg, "  push { "R_BP " }\n");
-		if (d) {
-			r_egg_printf (egg, "  sub "R_BP ", %d\n", d);
-		}
+		/* address-of: emit the name as-is */
+		r_egg_printf (egg, "%s,%s,:=,", str, target);
 		break;
 	}
-#endif
 }
 
 static void emit_get_result(REgg *egg, const char *ocn) {
-	//	r_egg_printf (egg, "  mov %s, r0\n", ocn);
+	if (ocn) {
+		flush_pending_zero (egg);
+		r_egg_printf (egg, "a0,%s,:=,", ocn);
+	}
 }
 
 static void emit_restore_stack(REgg *egg, int size) {
-	// XXX: must die.. or add emit_store_stack. not needed by ARM
-	// r_egg_printf (egg, "  add sp, %d\n", size);
+	/* no explicit stack in ESIL abstract output */
 }
 
 static void emit_get_while_end(REgg *egg, char *str, const char *ctxpush, const char *label) {
-	// snprintf (str, 32, "  push {%s}\n  b %s\n", ctxpush, label);
+	/* Store the back-jump expression - it is emitted at the end of
+	 * the while body by the parser. */
+	if (ctxpush && label) {
+		snprintf (str, 64, "%s,?{,%s,PC,:=,},", ctxpush, label);
+	} else if (label) {
+		snprintf (str, 64, "%s,PC,:=,", label);
+	} else {
+		*str = '\0';
+	}
 }
 
 static void emit_while_end(REgg *egg, const char *labelback) {
-#if 0
-	r_egg_printf (egg,
-		"  pop "R_AX "\n"
-		"  cmp "R_AX ", "R_AX "\n"	// XXX MUST SUPPORT != 0 COMPARE HERE
-		"  beq %s\n", labelback);
-#endif
+	if (labelback) {
+		flush_pending_zero (egg);
+		r_egg_printf (egg, "%s,PC,:=,", labelback);
+	}
 }
 
 static void emit_get_var(REgg *egg, int type, char *out, int idx) {
-#if 0
 	switch (type) {
-	case 0:snprintf (out, 32, "sp, %d", idx - 1); break;/* variable */
-	case 1:snprintf (out, 32, "r%d", idx); break;	/* registers */
-// sp,$%d", idx); break; /* argument */ // XXX: MUST BE r0, r1, r2, ..
+	case 0:
+		/* local variable: map by frame offset */
+		snprintf (out, 32, "v%d", idx);
+		break;
+	case 1:
+		/* function argument (naked function) */
+		snprintf (out, 32, "a%d", idx);
+		break;
+	case 2:
+		/* framed function argument */
+		snprintf (out, 32, "v%d", idx);
+		break;
+	default:
+		*out = '\0';
+		break;
 	}
-#endif
 }
 
 static void emit_trap(REgg *egg) {
-#if 0
-	r_egg_printf (egg, "  udf 16\n");
-#endif
+	flush_pending_zero (egg);
+	r_egg_printf (egg, "0,$$,");
 }
 
 static void emit_load_ptr(REgg *egg, const char *dst) {
-#if 0
-	r_egg_printf (egg, "  ldr r0, [fp, %d]\n", atoi (dst));
-#endif
+	if (dst) {
+		/* Writes the address into r0; keeps any pending zero init alive. */
+		r_egg_printf (egg, "%s,r0,:=,", dst);
+	}
 }
 
 static void emit_branch(REgg *egg, char *b, char *g, char *e, char *n, int sz, const char *dst) {
-#if 0
-	char *p, str[64];
+	flush_pending_zero (egg);
+	/* dst is the branch target label. The accumulator r1 holds the
+	 * just-computed right-hand side; the condition variable was stored
+	 * on the push stack by the parser as ctxpush. The branch fires when
+	 * the resulting condition is FALSE (it is the "skip body" branch).
+	 */
+	const char *op;
 	char *arg = NULL;
-	char *op = "beq";
-	/* NOTE that jb/ja are inverted to fit cmp opcode */
 	if (b) {
 		*b = '\0';
-		op = e? "bge": "bgt";
+		op = e ? "<" : "<=";
 		arg = b + 1;
 	} else if (g) {
 		*g = '\0';
-		op = e? "ble": "blt";
+		op = e ? ">" : ">=";
 		arg = g + 1;
+	} else if (e) {
+		arg = e + 1;
+		op = "!=";
+	} else {
+		arg = (char *)"0";
+		op = n ? "==" : "!=";
+	}
+	if (arg && *arg == '=') {
+		arg++;
 	}
 	if (!arg) {
-		if (e) {
-			arg = e + 1;
-			op = "bne";
-		} else {
-			arg = "0";
-			op = n? "bne": "beq";
-		}
+		arg = (char *)"0";
 	}
-
-	if (*arg == '=') {
-		arg++;		/* for <=, >=, ... */
-	}
-	p = r_egg_mkvar (egg, str, arg, 0);
-	r_egg_printf (egg, "  pop "R_AX "\n");	/* TODO: add support for more than one arg get arg0 */
-	r_egg_printf (egg, "  cmp %s, "R_AX "\n", p);
-	// if (context>0)
-	r_egg_printf (egg, "  %s %s\n", op, dst);
-	free (p);
-#endif
+	/* compare r1 (accumulator) against arg with op: skip body if cond fails */
+	r_egg_printf (egg, "%s,r1,%s,?{,%s,PC,:=,},", arg, op, dst);
 }
 
 static void emit_load(REgg *egg, const char *dst, int sz) {
+	int width;
 	switch (sz) {
-	case 'q':
-		r_egg_printf (egg, "%s,[8],%s,:=,", dst, dst);
-		break;
-	case 'b':
-		r_egg_printf (egg, "%s,[1],%s,:=,", dst, dst);
-		break;
-	default:
-		r_egg_printf (egg, "%s,[4],%s,:=,", dst, dst);
-		break;
+	case 'b': width = 1; break;
+	case 'q': width = 8; break;
+	default:  width = 4; break;
 	}
+	/* The load writes to r0 and never reads the accumulator; any
+	 * pending zero init for r1 is preserved so it can still be
+	 * peepholed out by a following plain assignment to r1. */
+	r_egg_printf (egg, "%s,[%d],r0,:=,", dst, width);
 }
 
 static void emit_mathop(REgg *egg, int ch, int vs, int type, const char *eq, const char *p) {
-	char *op;
-	switch (ch) {
-	case '^': op = "^"; break;
-	case '&': op = "&"; break;
-	case '|': op = "|"; break;
-	case '-': op = "-"; break;
-	case '+': op = "+"; break;
-	case '*': op = "*"; break;
-	case '/': op = "/"; break;
-	default: op = ":="; break;
-	}
+	const char *op;
 	if (!eq) {
 		eq = R_AX;
 	}
-	eq = R_AX;
 	if (!p) {
 		p = R_AX;
 	}
-#if 0
-	// TODO:
-	eprintf ("TYPE = %c\n", type);
-	eprintf ("  %s%c %c%s, %s\n", op, vs, type, eq, p);
-	eprintf ("  %s %s, [%s]\n", op, p, eq);
-#endif
-	r_egg_printf (egg, "%s,%s,%s,%s,:=,", eq, p, op, p);
+	switch (ch) {
+	case '^': op = "^="; break;
+	case '&': op = "&="; break;
+	case '|': op = "|="; break;
+	case '-': op = "-="; break;
+	case '+': op = "+="; break;
+	case '*': op = "*="; break;
+	case '/': op = "/="; break;
+	default:  op = NULL; break; /* plain assignment */
+	}
+	if (!op) {
+		/* Peephole: queue the "0,reg,:=" init the parser emits before
+		 * every expression. The init is only needed when the accumulator
+		 * is read before being overwritten (e.g. for unary minus).
+		 * We drop it when a later plain assignment writes the same
+		 * register, and flush it when someone reads from it. */
+		if (type == '$' && !strcmp (eq, "0") && !g_pending_zero) {
+			g_pending_zero = 1;
+			strncpy (g_pending_zero_reg, p, sizeof (g_pending_zero_reg) - 1);
+			g_pending_zero_reg[sizeof (g_pending_zero_reg) - 1] = '\0';
+			return;
+		}
+		if (g_pending_zero) {
+			if (eq && !strcmp (eq, g_pending_zero_reg)) {
+				/* reads pending reg: we must emit the init first */
+				flush_pending_zero (egg);
+			} else if (!strcmp (p, g_pending_zero_reg)) {
+				/* overwrites pending reg: drop the dead init */
+				g_pending_zero = 0;
+			}
+		}
+		/* plain assignment: eq -> p (or *eq -> p if type == '*') */
+		if (type == '*') {
+			int width = (vs == 'b') ? 1 : (vs == 'q' ? 8 : 4);
+			r_egg_printf (egg, "%s,[%d],%s,:=,", eq, width, p);
+		} else {
+			r_egg_printf (egg, "%s,%s,:=,", eq, p);
+		}
+	} else {
+		/* compound assignment reads and writes p; it may also read eq */
+		if (g_pending_zero) {
+			if (!strcmp (p, g_pending_zero_reg)
+			    || (eq && !strcmp (eq, g_pending_zero_reg))) {
+				flush_pending_zero (egg);
+			}
+		}
+		/* compound assignment: p = p <op> eq */
+		r_egg_printf (egg, "%s,%s,%s,", eq, p, op);
+	}
 }
 
 static const char *emit_regs(REgg *egg, int idx) {
@@ -262,11 +304,11 @@ static const char *emit_regs(REgg *egg, int idx) {
 }
 
 static void emit_get_arg(REgg *egg, char *out, int idx) {
-	snprintf (out, 32, "r%d", idx);
+	snprintf (out, 32, "a%d", idx);
 }
 
 REggEmit EMIT_NAME = {
-	.retvar = "r0",
+	.retvar = R_AX,
 	.arch = R_ARCH,
 	.size = R_SZ,
 	.jmp = emit_jmp,
@@ -274,7 +316,6 @@ REggEmit EMIT_NAME = {
 	.init = emit_init,
 	.equ = emit_equ,
 	.regs = emit_regs,
-	// .sc = emit_sc,
 	.trap = emit_trap,
 	.frame = emit_frame,
 	.frame_end = emit_frame_end,

--- a/libr/egg/emit_esil.c
+++ b/libr/egg/emit_esil.c
@@ -69,6 +69,12 @@ static void emit_comment(REgg *egg, const char *fmt, ...) {
 	/* ESIL has no comment syntax, drop comments silently */
 }
 
+static void emit_label(REgg *egg, const char *name) {
+	/* Branch-target labels are not valid ESIL tokens. They're
+	 * referenced symbolically by the jmp/branch emissions; definitions
+	 * are dropped from the output. */
+}
+
 static void emit_equ(REgg *egg, const char *key, const char *value) {
 	/* .equ aliases are resolved at parse time, nothing to emit */
 }
@@ -348,6 +354,7 @@ REggEmit EMIT_NAME = {
 	.frame = emit_frame,
 	.frame_end = emit_frame_end,
 	.comment = emit_comment,
+	.label = emit_label,
 	.push_arg = emit_arg,
 	.restore_stack = emit_restore_stack,
 	.get_result = emit_get_result,

--- a/libr/egg/t/README.md
+++ b/libr/egg/t/README.md
@@ -49,8 +49,9 @@ Language cheat sheet
     .arg0, .arg4                     ; function arguments
     .ret                             ; return register (retvar)
     .regN                            ; generic register by index
-    .rax, .ecx, .x0, ...             ; direct native register (new)
+    .%rax, .%ecx, .%x0, ...          ; raw native register (verbatim)
     .foo (after foo@alias(...))      ; alias-resolved register/symbol
+    (any other .name raises an error)
 
     var = expr                       ; assignment
     var += expr, -=, *=, /=          ; compound assignment

--- a/libr/egg/t/README.md
+++ b/libr/egg/t/README.md
@@ -1,0 +1,64 @@
+Example .r programs for the r_egg compiler (ragg2)
+===================================================
+
+These are short, self contained .r programs that showcase the syntax
+accepted by ragg2. They are intended as both documentation and as a
+quick sandbox for experimenting with the compiler.
+
+Each file can be compiled with:
+
+    ragg2 -a <arch> -b <bits> -k <os> -s FILE.r
+
+Useful backends for experimenting:
+
+    -a trace           pseudo-assembly that mirrors the IR the parser
+                       emits (great for understanding the compiler)
+    -a esil            stack based intermediate language, readable
+                       and directly consumable by the r2 ESIL VM
+    -a x86 -b 32/64    native x86 / x86-64 assembly
+    -a arm -b 32/64    native ARM / AArch64 assembly
+
+Files
+-----
+
+- hi.r              smallest possible "write then exit" program
+- hello.r           loop that repeatedly writes "Hello World"
+- exit.r            raw inline assembly mixed with the high-level language
+- write.r           syscall declarations with string literals
+- arith.r           arithmetic expressions and operator precedence
+- regs.r            direct native-register access via the `.regname` syntax
+- alias.r           register aliases defined with the `@alias` directive
+- customsyscall.r   overriding the `@syscall` body with inline asm
+
+Language cheat sheet
+--------------------
+
+    /* comment */  //comment    #comment
+    : raw asm line                   ; any line starting with ":" is passed
+                                      through verbatim to the assembler
+
+    name@global(S,F) { body }        ; function with S byte stackframe
+                                      and F bytes reserved for constants
+    name@syscall(N);                 ; declare name as a syscall number
+    name@alias(value)                ; textual alias: .name -> value
+    name@fastcall(addr)              ; call a function at addr via fastcall
+    @syscall() { body }              ; override the generated syscall body
+
+    .var0, .var4, .varN              ; local variables at frame offset N
+    .arg0, .arg4                     ; function arguments
+    .ret                             ; return register (retvar)
+    .regN                            ; generic register by index
+    .rax, .ecx, .x0, ...             ; direct native register (new)
+    .foo (after foo@alias(...))      ; alias-resolved register/symbol
+
+    var = expr                       ; assignment
+    var += expr, -=, *=, /=          ; compound assignment
+    var = *addr                      ; dereference (read)
+    fn(arg1, arg2, ...)              ; function / syscall call
+
+Example compile and inspect
+---------------------------
+
+    ragg2 -a esil  -s t/hi.r
+    ragg2 -a trace -s t/arith.r
+    ragg2 -a x86 -b 64 -s t/regs.r

--- a/libr/egg/t/README.md
+++ b/libr/egg/t/README.md
@@ -28,6 +28,7 @@ Files
 - arith.r           arithmetic expressions and operator precedence
 - regs.r            direct native-register access via the `.regname` syntax
 - alias.r           register aliases defined with the `@alias` directive
+- cond.r            conditional statements: if, if/else style, while
 - customsyscall.r   overriding the `@syscall` body with inline asm
 
 Language cheat sheet

--- a/libr/egg/t/alias.r
+++ b/libr/egg/t/alias.r
@@ -1,0 +1,19 @@
+/* register aliases via @alias
+ *
+ * `name@alias(value)` declares that any later reference to
+ * `.name` should resolve to `value`. This lets you give
+ * target registers meaningful names without changing the backend.
+ *
+ *   ragg2 -a esil -s t/alias.r
+ *   ragg2 -a x86 -b 64 -s t/alias.r
+ */
+
+counter@alias(rax)
+limit@alias(rcx)
+
+main@global(16, 0) {
+	.counter = 0;
+	.limit = 10;
+	.counter = .limit - 1;
+	.counter += 1;
+}

--- a/libr/egg/t/alias.r
+++ b/libr/egg/t/alias.r
@@ -1,11 +1,15 @@
 /* register aliases via @alias
  *
- * `name@alias(value)` declares that any later reference to
- * `.name` should resolve to `value`. This lets you give
- * target registers meaningful names without changing the backend.
+ * `name@alias(value)` declares that any later `.name` should
+ * resolve to `value`. Useful for giving target registers
+ * meaningful names without touching the backend, and for keeping
+ * programs portable when the register set differs across arches.
  *
  *   ragg2 -a esil -s t/alias.r
  *   ragg2 -a x86 -b 64 -s t/alias.r
+ *
+ * An unknown `.name` is a compile error unless it is defined via
+ * @alias or prefixed with `%` (see regs.r for the raw form).
  */
 
 counter@alias(rax)

--- a/libr/egg/t/arith.r
+++ b/libr/egg/t/arith.r
@@ -1,0 +1,18 @@
+/* arithmetic expressions and operator precedence
+ *
+ * try compiling with `ragg2 -a esil -s t/arith.r` to see
+ * how each expression becomes a sequence of ESIL tokens. */
+
+main@global(32, 0) {
+	.var0 = 5 + 3;          /* 8 */
+	.var4 = 10 - 4;         /* 6 */
+	.var8 = 2 + 3 * 4;      /* precedence: 2 + 12 */
+	.var12 = 1 | 2 | 4;     /* bitwise or chain */
+	.var16 = 0xff & 0x0f;   /* bitwise and */
+	.var20 = 7 ^ 3;         /* xor */
+
+	/* compound operators */
+	.var24 = 10;
+	.var24 += 5;
+	.var24 *= 2;
+}

--- a/libr/egg/t/cond.r
+++ b/libr/egg/t/cond.r
@@ -1,16 +1,22 @@
-/* conditionals: if/else and while
+/* conditionals: if and while
  *
  *   ragg2 -a esil -s t/cond.r
  *   ragg2 -a x86 -b 64 -s t/cond.r
  *
- * The ESIL backend emits:
- *   - "X,a1,OP,?{,__end,PC,:=,}" for ordered comparisons
- *   - "X,a1,==,$z,!,?{,__end,PC,:=,}" for equality tests
- * so that the body is skipped when the condition is false.
+ * The ESIL backend compiles each function into a single expression
+ * of comma-separated tokens. Labels are resolved at finalize time
+ * into numeric word indices so the output is pure ESIL and can be
+ * fed to r2's `ae` command:
  *
- * While loops additionally re-push the condition variable into a1
- * at the bottom of the body and unconditionally jump back to the
- * begin label, where the same check re-runs.
+ *   - "X,a1,OP,?{,N,GOTO,}"        for ordered comparisons
+ *   - "X,a1,==,$z,[!,]?{,N,GOTO,}" for equality tests
+ *   - "N,GOTO"                     unconditional branch
+ *
+ * where N is the word position of the target inside the expression.
+ *
+ * While loops additionally refresh a1 from the loop variable at the
+ * bottom of the body before jumping back to the begin position, so
+ * the same comparison re-runs against the updated value.
  */
 
 main@global(16, 0) {
@@ -31,7 +37,7 @@ main@global(16, 0) {
 		.var0 = 1;
 	}
 
-	/* countdown loop: keep looping while .var0 > 0 */
+	/* countdown loop: keep looping while .var0 is non-zero */
 	.var0 = 3;
 	while (.var0) {
 		.var0 -= 1;

--- a/libr/egg/t/cond.r
+++ b/libr/egg/t/cond.r
@@ -1,0 +1,39 @@
+/* conditionals: if/else and while
+ *
+ *   ragg2 -a esil -s t/cond.r
+ *   ragg2 -a x86 -b 64 -s t/cond.r
+ *
+ * The ESIL backend emits:
+ *   - "X,a1,OP,?{,__end,PC,:=,}" for ordered comparisons
+ *   - "X,a1,==,$z,!,?{,__end,PC,:=,}" for equality tests
+ * so that the body is skipped when the condition is false.
+ *
+ * While loops additionally re-push the condition variable into a1
+ * at the bottom of the body and unconditionally jump back to the
+ * begin label, where the same check re-runs.
+ */
+
+main@global(16, 0) {
+	.var0 = 5;
+
+	/* execute body only if .var0 == 0 */
+	if (.var0 == 0) {
+		.var0 = 99;
+	}
+
+	/* execute body only if .var0 != 0 */
+	if (.var0 != 0) {
+		.var0 = 42;
+	}
+
+	/* "truthy" form - body runs when .var0 is non-zero */
+	if (.var0) {
+		.var0 = 1;
+	}
+
+	/* countdown loop: keep looping while .var0 > 0 */
+	.var0 = 3;
+	while (.var0) {
+		.var0 -= 1;
+	}
+}

--- a/libr/egg/t/customsyscall.r
+++ b/libr/egg/t/customsyscall.r
@@ -1,0 +1,16 @@
+/* override the syscall body with inline asm
+ *
+ * the `@syscall() { ... }` definition replaces the default
+ * syscall prologue that the backend generates. In this example
+ * every syscall traps into int3 instead of actually issuing one.
+ */
+
+exit@syscall(1);
+
+@syscall() {
+	: int3
+}
+
+main@global() {
+	exit (2);
+}

--- a/libr/egg/t/exit.r
+++ b/libr/egg/t/exit.r
@@ -1,0 +1,10 @@
+/* inline asm only: invoke exit() via raw Linux i386 syscall
+ * any line starting with ":" is copied verbatim into the
+ * assembler stream, no high-level translation happens. */
+
+main@global(128) {
+	: nop
+	: mov eax, 1
+	: push eax
+	: int 0x80
+}

--- a/libr/egg/t/hello.r
+++ b/libr/egg/t/hello.r
@@ -1,0 +1,14 @@
+/* classic hello world with a while-loop counter */
+
+write@syscall(4);
+exit@syscall(1);
+
+main@global(128) {
+	.var0 = 4;
+	.var4 = "Hello World\n";
+	while (.var0 > 0) {
+		write (1, .var4, 12);
+		.var0 -= 2;
+	}
+	exit (0);
+}

--- a/libr/egg/t/hi.r
+++ b/libr/egg/t/hi.r
@@ -1,0 +1,10 @@
+/* smallest "hello world" style program: call write() then exit() */
+
+write@syscall(4);
+exit@syscall(1);
+
+main@global(128) {
+	.var0 = "hi!\n";
+	write (1, .var0, 4);
+	exit (0);
+}

--- a/libr/egg/t/regs.r
+++ b/libr/egg/t/regs.r
@@ -1,0 +1,18 @@
+/* direct native-register access
+ *
+ * Any unrecognised `.name` is emitted verbatim as a register or
+ * symbol name. This lets the high-level language drive target
+ * specific registers (particularly useful with `-a esil`, where
+ * abstract ESIL registers can be named freely).
+ *
+ * Compile for example with:
+ *   ragg2 -a esil -s t/regs.r
+ *   ragg2 -a x86 -b 64 -s t/regs.r
+ */
+
+main@global(16, 0) {
+	.rax = 1;              /* write constant into rax */
+	.rcx = .rax;           /* copy rax into rcx */
+	.rdx = .rax + 41;      /* rax + 41 -> rdx */
+	.rax = .rdx * 2;       /* rax = rdx * 2 */
+}

--- a/libr/egg/t/regs.r
+++ b/libr/egg/t/regs.r
@@ -1,18 +1,17 @@
 /* direct native-register access
  *
- * Any unrecognised `.name` is emitted verbatim as a register or
- * symbol name. This lets the high-level language drive target
- * specific registers (particularly useful with `-a esil`, where
- * abstract ESIL registers can be named freely).
+ * The `.%name` form copies the name verbatim into the instruction
+ * stream. This is the unambiguous way to target a concrete register,
+ * as opposed to `.varN` (frame slot), `.regN` (indexed gpr), or
+ * user-defined aliases.
  *
- * Compile for example with:
  *   ragg2 -a esil -s t/regs.r
  *   ragg2 -a x86 -b 64 -s t/regs.r
  */
 
 main@global(16, 0) {
-	.rax = 1;              /* write constant into rax */
-	.rcx = .rax;           /* copy rax into rcx */
-	.rdx = .rax + 41;      /* rax + 41 -> rdx */
-	.rax = .rdx * 2;       /* rax = rdx * 2 */
+	.%rax = 1;                  /* write constant into rax */
+	.%rcx = .%rax;              /* copy rax into rcx */
+	.%rdx = .%rax + 41;         /* rax + 41 -> rdx */
+	.%rax = .%rdx * 2;          /* rax = rdx * 2 */
 }

--- a/libr/egg/t/write.r
+++ b/libr/egg/t/write.r
@@ -1,0 +1,8 @@
+/* declare the write syscall and push a short string to it */
+
+write@syscall(4);
+
+main@global(128) {
+	.var1 = "sup";
+	write (1, .var1, 3);
+}

--- a/libr/include/r_egg.h
+++ b/libr/include/r_egg.h
@@ -181,6 +181,11 @@ typedef struct r_egg_emit_t {
 	void (*branch)(REgg *egg, char *b, char *g, char *e, char *n, int sz, const char *dst);
 	void (*mathop)(REgg *egg, int ch, int sz, int type, const char *eq, const char *p);
 	void (*get_while_end)(REgg *egg, char *out, const char *ctxpush, const char *label);
+	/* Emit a branch-target label. NULL means the default ".S" style
+	 * "name:\n" is used (kept for the native assembler backends). The
+	 * ESIL backend overrides this to drop labels, since they would
+	 * produce invalid ESIL tokens. */
+	void (*label)(REgg *egg, const char *name);
 } REggEmit;
 
 #ifdef R_API

--- a/libr/include/r_egg.h
+++ b/libr/include/r_egg.h
@@ -182,10 +182,13 @@ typedef struct r_egg_emit_t {
 	void (*mathop)(REgg *egg, int ch, int sz, int type, const char *eq, const char *p);
 	void (*get_while_end)(REgg *egg, char *out, const char *ctxpush, const char *label);
 	/* Emit a branch-target label. NULL means the default ".S" style
-	 * "name:\n" is used (kept for the native assembler backends). The
-	 * ESIL backend overrides this to drop labels, since they would
-	 * produce invalid ESIL tokens. */
+	 * "name:\n" is used (kept for the native assembler backends). */
 	void (*label)(REgg *egg, const char *name);
+	/* Optional hook called at the end of r_egg_compile, after all
+	 * parsing has finished. Backends use this to post-process the
+	 * accumulated output - e.g. the ESIL backend resolves symbolic
+	 * label names into numeric GOTO word indices here. */
+	void (*finalize)(REgg *egg);
 } REggEmit;
 
 #ifdef R_API

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -537,9 +537,9 @@ main:
 EOF
 RUN
 
-NAME=ragg2 esil direct register access
+NAME=ragg2 esil raw register access
 FILE=-
-CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .rax = 5; }'
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .%rax = 5; }'
 EXPECT=<<EOF
 
 .global main
@@ -549,15 +549,23 @@ main:
 EOF
 RUN
 
-NAME=ragg2 esil direct register in expression
+NAME=ragg2 esil raw register in expression
 FILE=-
-CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .rax = .rcx + 3; }'
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .%rax = .%rcx + 3; }'
 EXPECT=<<EOF
 
 .global main
 main:
 rcx,r1,:=,3,r1,+=,r1,rax,:=,
 
+EOF
+RUN
+
+NAME=ragg2 esil unknown dotname is an error
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .rax = 5; }'
+EXPECT_ERR=<<EOF
+ERROR: Unknown name '.rax' (use .%rax for a raw register or `rax@alias(...)`)
 EOF
 RUN
 
@@ -580,10 +588,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
-0,a1,==,$z,!,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
-
-  __ifelse_1_0:
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,!,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
 __end_0_1_0,PC,:=,
 EOF
 RUN
@@ -595,10 +600,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
-0,a1,==,$z,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
-
-  __ifelse_1_0:
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
 __end_0_1_0,PC,:=,
 EOF
 RUN
@@ -610,10 +612,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
-0,a1,==,$z,?{,__end_0_1_0,PC,:=,},0,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
-
-  __ifelse_1_0:
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},0,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
 __end_0_1_0,PC,:=,
 EOF
 RUN
@@ -625,9 +624,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-3,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
-0,a1,==,$z,?{,__end_0_1_0,PC,:=,},1,r1,:=,r1,v8,-=,v8,a1,:=,__begin_0_1_0,PC,:=,  __end_0_1_0:
-
+3,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},1,r1,:=,r1,v8,-=,v8,a1,:=,__begin_0_1_0,PC,:=,
 
 EOF
 RUN

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -379,3 +379,160 @@ EXPECT=<<EOF
 EOF
 EXPECT_ERR=
 RUN
+
+NAME=ragg2 esil assign constant
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil addition
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5 + 3; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,3,r1,+=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil compound plus
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; .var0 += 3; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,3,r1,:=,r1,v8,+=,
+
+EOF
+RUN
+
+NAME=ragg2 esil compound minus
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 10; .var0 -= 4; }'
+EXPECT=<<EOF
+
+.global main
+main:
+10,r1,:=,r1,v8,:=,4,r1,:=,r1,v8,-=,
+
+EOF
+RUN
+
+NAME=ragg2 esil multiplication
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5 * 3; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r2,:=,3,r2,*=,r2,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil division
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 20 / 4; }'
+EXPECT=<<EOF
+
+.global main
+main:
+20,r2,:=,4,r2,/=,r2,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil bitwise and
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 0xff & 0x0f; }'
+EXPECT=<<EOF
+
+.global main
+main:
+0xff,r3,:=,0x0f,r3,&=,r3,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil bitwise or chain
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 1 | 2 | 4; }'
+EXPECT=<<EOF
+
+.global main
+main:
+1,r3,:=,2,r3,|=,4,r3,|=,r3,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil bitwise xor
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5 ^ 3; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r3,:=,3,r3,^=,r3,r1,:=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil operator precedence
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 2 + 3 * 4; }'
+EXPECT=<<EOF
+
+.global main
+main:
+2,r1,:=,3,r2,:=,4,r2,*=,r2,r1,+=,r1,v8,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil variable as rvalue
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; .var8 = .var0 + 1; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,v8,r1,:=,1,r1,+=,r1,v16,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil pointer dereference
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 0x1000; .var8 = *.var0; }'
+EXPECT=<<EOF
+
+.global main
+main:
+0x1000,r1,:=,r1,v8,:=,v8,[4],r0,:=,r0,r1,:=,r1,v16,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil syscall via @syscall
+FILE=-
+CMDS=!ragg2 -a esil -b 64 -k linux -s -e 'exit@syscall(60); main@global(16,0) { exit(42); }'
+EXPECT=<<EOF
+
+.global main
+main:
+42,a1,:=, 60,$,
+
+
+EOF
+RUN

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -387,7 +387,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,
+5,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -399,7 +399,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,3,r1,+=,r1,v8,:=,
+5,r1,:=,3,r1,+=,r1,v8,:=
 
 EOF
 RUN
@@ -411,7 +411,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,3,r1,:=,r1,v8,+=,
+5,r1,:=,r1,v8,:=,3,r1,:=,r1,v8,+=
 
 EOF
 RUN
@@ -423,7 +423,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-10,r1,:=,r1,v8,:=,4,r1,:=,r1,v8,-=,
+10,r1,:=,r1,v8,:=,4,r1,:=,r1,v8,-=
 
 EOF
 RUN
@@ -435,7 +435,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r2,:=,3,r2,*=,r2,r1,:=,r1,v8,:=,
+5,r2,:=,3,r2,*=,r2,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -447,7 +447,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-20,r2,:=,4,r2,/=,r2,r1,:=,r1,v8,:=,
+20,r2,:=,4,r2,/=,r2,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -459,7 +459,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-0xff,r3,:=,0x0f,r3,&=,r3,r1,:=,r1,v8,:=,
+0xff,r3,:=,0x0f,r3,&=,r3,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -471,7 +471,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-1,r3,:=,2,r3,|=,4,r3,|=,r3,r1,:=,r1,v8,:=,
+1,r3,:=,2,r3,|=,4,r3,|=,r3,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -483,7 +483,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r3,:=,3,r3,^=,r3,r1,:=,r1,v8,:=,
+5,r3,:=,3,r3,^=,r3,r1,:=,r1,v8,:=
 
 EOF
 RUN
@@ -495,7 +495,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-2,r1,:=,3,r2,:=,4,r2,*=,r2,r1,+=,r1,v8,:=,
+2,r1,:=,3,r2,:=,4,r2,*=,r2,r1,+=,r1,v8,:=
 
 EOF
 RUN
@@ -507,7 +507,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,r1,:=,1,r1,+=,r1,v16,:=,
+5,r1,:=,r1,v8,:=,v8,r1,:=,1,r1,+=,r1,v16,:=
 
 EOF
 RUN
@@ -519,7 +519,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-0x1000,r1,:=,r1,v8,:=,v8,[4],r0,:=,r0,r1,:=,r1,v16,:=,
+0x1000,r1,:=,r1,v8,:=,v8,[4],r0,:=,r0,r1,:=,r1,v16,:=
 
 EOF
 RUN
@@ -531,7 +531,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-42,a1,:=,60,$,
+42,a1,:=,60,$
 
 
 EOF
@@ -544,7 +544,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,rax,:=,
+5,r1,:=,r1,rax,:=
 
 EOF
 RUN
@@ -556,7 +556,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-rcx,r1,:=,3,r1,+=,r1,rax,:=,
+rcx,r1,:=,3,r1,+=,r1,rax,:=
 
 EOF
 RUN
@@ -576,7 +576,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-42,r1,:=,r1,rax,:=,
+42,r1,:=,r1,rax,:=
 
 EOF
 RUN
@@ -588,8 +588,8 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,!,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
-__end_0_1_0,PC,:=,
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,!,?{,26,GOTO,},99,r1,:=,r1,v8,:=,26,GOTO,26,GOTO
+
 EOF
 RUN
 
@@ -600,8 +600,8 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
-__end_0_1_0,PC,:=,
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,25,GOTO,},99,r1,:=,r1,v8,:=,25,GOTO,25,GOTO
+
 EOF
 RUN
 
@@ -612,8 +612,8 @@ EXPECT=<<EOF
 
 .global main
 main:
-5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},0,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,
-__end_0_1_0,PC,:=,
+5,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,25,GOTO,},0,r1,:=,r1,v8,:=,25,GOTO,25,GOTO
+
 EOF
 RUN
 
@@ -624,7 +624,7 @@ EXPECT=<<EOF
 
 .global main
 main:
-3,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,__end_0_1_0,PC,:=,},1,r1,:=,r1,v8,-=,v8,a1,:=,__begin_0_1_0,PC,:=,
+3,r1,:=,r1,v8,:=,v8,a1,:=,0,a1,==,$z,?{,28,GOTO,},1,r1,:=,r1,v8,-=,v8,a1,:=,9,GOTO
 
 EOF
 RUN

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -531,8 +531,44 @@ EXPECT=<<EOF
 
 .global main
 main:
-42,a1,:=, 60,$,
+42,a1,:=,60,$,
 
+
+EOF
+RUN
+
+NAME=ragg2 esil direct register access
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .rax = 5; }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,rax,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil direct register in expression
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .rax = .rcx + 3; }'
+EXPECT=<<EOF
+
+.global main
+main:
+rcx,r1,:=,3,r1,+=,r1,rax,:=,
+
+EOF
+RUN
+
+NAME=ragg2 esil alias directive
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'myreg@alias(rax) main@global(16,0) { .myreg = 42; }'
+EXPECT=<<EOF
+
+.global main
+main:
+42,r1,:=,r1,rax,:=,
 
 EOF
 RUN

--- a/test/db/tools/ragg2
+++ b/test/db/tools/ragg2
@@ -572,3 +572,62 @@ main:
 
 EOF
 RUN
+
+NAME=ragg2 esil if equality skip
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; if (.var0 == 0) { .var0 = 99; } }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
+0,a1,==,$z,!,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
+
+  __ifelse_1_0:
+__end_0_1_0,PC,:=,
+EOF
+RUN
+
+NAME=ragg2 esil if not-equal skip
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; if (.var0 != 0) { .var0 = 99; } }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
+0,a1,==,$z,?{,__end_0_1_0,PC,:=,},99,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
+
+  __ifelse_1_0:
+__end_0_1_0,PC,:=,
+EOF
+RUN
+
+NAME=ragg2 esil bare truthy if
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 5; if (.var0) { .var0 = 0; } }'
+EXPECT=<<EOF
+
+.global main
+main:
+5,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
+0,a1,==,$z,?{,__end_0_1_0,PC,:=,},0,r1,:=,r1,v8,:=,__ifelse_1_0,PC,:=,  __end_0_1_0:
+
+  __ifelse_1_0:
+__end_0_1_0,PC,:=,
+EOF
+RUN
+
+NAME=ragg2 esil while truthy
+FILE=-
+CMDS=!ragg2 -a esil -s -e 'main@global(16,0) { .var0 = 3; while (.var0) { .var0 -= 1; } }'
+EXPECT=<<EOF
+
+.global main
+main:
+3,r1,:=,r1,v8,:=,v8,a1,:=,  __begin_0_1_0:
+0,a1,==,$z,?{,__end_0_1_0,PC,:=,},1,r1,:=,r1,v8,-=,v8,a1,:=,__begin_0_1_0,PC,:=,  __end_0_1_0:
+
+
+EOF
+RUN


### PR DESCRIPTION
- Fix heap corruption in rcc_internal_mathop where the trimmed pointer
  could be freed even though it pointed into the middle of an allocation,
  causing free() aborts on any arithmetic expression regardless of the
  target backend.
- Teach the statement parser about compound assignments (+=, -=, *=,
  /=, |=, &=, ^=) so the operator character is preserved instead of
  being swallowed with the '='.
- Reset the element buffer after each ';' terminated statement so the
  next statement starts clean instead of concatenating with the previous
  one (previously '.var = 5; .var -= 2;' silently lost the second op).
- Strip trailing whitespace from mathop operands so emitted tokens
  don't carry stray spaces like '5 ,r1,:='.
- Rewrite the ESIL emitter to produce correct, readable ESIL: plain
  '=' becomes ':=', compound ops become '+=', '-=', etc., local
  variables become abstract ESIL registers 'vN', arguments become
  'aN', loads use the '[size]' memory operator, and syscalls emit
  the 'N,$' trigger with the number pulled from the @syscall declaration.
- Add a peephole in emit_esil that drops the redundant zero-init the
  parser emits before each expression when the accumulator is
  overwritten before being read.
- Add 13 regression tests in db/tools/ragg2 covering assignment,
  arithmetic, compound ops, precedence, variables as rvalues,
  pointer dereference and syscalls.

https://claude.ai/code/session_01PvWd2Ez13WXxq9q7FwYwpz