### PR TITLE
Hide otezip symbols from libr_util ##build

### DIFF
--- a/shlr/zip/Makefile
+++ b/shlr/zip/Makefile
@@ -12,15 +12,13 @@ pre: all
 
 include deps.mk
 
-all:
+all: $(OTEZIP_LIBA)
 	rm -f librz.$(EXT_AR)
 ifneq ($(WANT_ZIP),1)
 	@echo zip support disabled
 else
 ifeq ($(USE_LIB_ZIP),1)
 	@echo no bundled zip to build
-else
-	$(MAKE) -C $(OTEZIP_ROOT) CC="$(CC)" EXT_AR="$(EXT_AR)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS) -fPIC" libotezip.$(EXT_AR)
 endif
 endif
 

--- a/shlr/zip/deps.mk
+++ b/shlr/zip/deps.mk
@@ -12,7 +12,7 @@ OTEZIP_ROOT=$(SHLR)/../subprojects/otezip
 OTEZIP_LIBA=$(OTEZIP_ROOT)/libotezip.$(EXT_AR)
 CFLAGS+=-I$(OTEZIP_ROOT)/src/include/otezip
 $(OTEZIP_LIBA):
-	$(MAKE) -C $(OTEZIP_ROOT) CC="$(CC)" EXT_AR="$(EXT_AR)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS) -fPIC" libotezip.$(EXT_AR)
+	$(MAKE) -C $(OTEZIP_ROOT) CC="$(CC)" EXT_AR="$(EXT_AR)" AR="$(AR)" RANLIB="$(RANLIB)" CFLAGS="$(CFLAGS) -fPIC -fvisibility=hidden" libotezip.$(EXT_AR)
 LINK+=$(OTEZIP_LIBA)
 endif
 endif

--- a/shlr/zip/meson.build
+++ b/shlr/zip/meson.build
@@ -5,17 +5,28 @@ if get_option('use_zip')
     zip_dep = dependency('libzip', required: true)
     zlib_dep = dependency('zlib', required: true)
     zip_dep = declare_dependency(dependencies: [zip_dep, zlib_dep])
-  elif get_option('use_otezip')
-    message('Use otezip as libzip replacement (with bundled zlib)')
-    otezip_proj = subproject('otezip')
-    zip_dep = otezip_proj.get_variable('otezip_dep')
-    zlib_dep = declare_dependency()  # otezip has bundled zlib
   else
-    # If use_zip is enabled but no specific implementation chosen,
-    # automatically use otezip as the default bundled implementation
-    message('Using otezip as default libzip implementation (with bundled zlib)')
+    if get_option('use_otezip')
+      message('Use otezip as libzip replacement (with bundled zlib)')
+    else
+      # If use_zip is enabled but no specific implementation chosen,
+      # automatically use otezip as the default bundled implementation
+      message('Using otezip as default libzip implementation (with bundled zlib)')
+    endif
     otezip_proj = subproject('otezip')
-    zip_dep = otezip_proj.get_variable('otezip_dep')
+    otezip_src = otezip_proj.get_variable('otezip_src')
+    otezip_inc = otezip_proj.get_variable('otezip_inc')
+    otezip_hidden_lib = static_library('otezip-hidden',
+      otezip_src,
+      include_directories: otezip_inc,
+      gnu_symbol_visibility: 'hidden',
+      pic: true,
+      install: false
+    )
+    zip_dep = declare_dependency(
+      link_with: otezip_hidden_lib,
+      include_directories: otezip_inc
+    )
     zlib_dep = declare_dependency()  # otezip has bundled zlib
   endif
 else


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The otezip static library ships implementations of zlib (inflate, deflate), lzma, zstd, brotli and lzfse. When it was statically linked into shared libraries like libr_util, those generic symbol names were exported in the dynamic symbol table and could collide at runtime with a system zlib loaded elsewhere in the process.

Build otezip with -fvisibility=hidden / gnu_symbol_visibility: 'hidden' on the consumer side (radare2) so its internals stay local to whichever shared library embeds it, without constraining how otezip itself may be built by other projects.

The acr/make path had a second otezip build invocation in shlr/zip/Makefile that ran before libr/util and produced a default-visibility archive that later build steps happily reused; dedupe through the $(OTEZIP_LIBA) rule in deps.mk so there is a single point that enforces the flag.