### PR TITLE
Fix #16549 - r_regex_init leaks when called on initialized RRegex ##util

### DIFF
--- a/libr/magic/softmagic.c
+++ b/libr/magic/softmagic.c
@@ -72,7 +72,7 @@ static bool magic_hasbytes(size_t nbytes, st64 offset, size_t need) {
 #define R_MAGIC_DESC ((ms->flags & R_MAGIC_MIME)? m->mimetype: m->desc)
 
 static int check_fmt(RMagic *ms, struct r_magic *m) {
-	RRegex rx;
+	RRegex rx = { 0 };
 	int rc;
 
 	if (!strchr (R_MAGIC_DESC, '%')) {
@@ -916,7 +916,7 @@ static int magiccheck(RMagic *ms, struct r_magic *m) {
 	case FILE_REGEX:
 		{
 			int rc;
-			RRegex rx;
+			RRegex rx = { 0 };
 			char *errmsg;
 
 			if (!ms->search.s) {

--- a/libr/util/regex/regcomp.c
+++ b/libr/util/regex/regcomp.c
@@ -134,7 +134,7 @@ static sopno pluscount(struct parse *, struct re_guts *);
 #define DROP(n) (p->slen -= (n))
 
 R_API bool r_regex_match(const char *pattern, const char *flags, const char *text) {
-	RRegex rx;
+	RRegex rx = { 0 };
 	int re_flags = r_regex_flags (flags);
 	if (r_regex_init (&rx, pattern, re_flags)) {
 		R_LOG_ERROR ("r_regex_match: /%s/ fails to compile", pattern);
@@ -172,6 +172,7 @@ R_API RRegex *r_regex_new(const char *pattern, const char *flags) {
 	}
 	r = R_NEW (RRegex);
 	if (!r) {
+		r_regex_fini (&rx);
 		return NULL;
 	}
 	*r = rx;
@@ -248,6 +249,11 @@ R_API int r_regex_init(RRegex *preg, const char *pattern, int cflags) {
 	if (!preg || ((cflags & R_REGEX_EXTENDED) && (cflags & R_REGEX_NOSPEC))) {
 		return R_REGEX_INVARG;
 	}
+	// Release any prior compilation so re-initializing the same RRegex does
+	// not leak. r_regex_fini magic-checks, so it is a safe no-op on a freshly
+	// zero-initialized struct. Callers must zero-initialize RRegex on first
+	// use (RRegex rx = {0}) so this read sees a defined value.
+	r_regex_fini (preg);
 	if (cflags & R_REGEX_PEND) {
 		if (preg->re_endp < pattern) {
 			return R_REGEX_INVARG;

--- a/test/unit/test_regex.c
+++ b/test/unit/test_regex.c
@@ -22,7 +22,7 @@ static int test_new_free(void) {
 }
 
 static int test_init_fini(void) {
-	RRegex rx;
+	RRegex rx = { 0 };
 	int rc = r_regex_init (&rx, "hello", R_REGEX_EXTENDED);
 	mu_assert_eq (rc, 0, "r_regex_init should succeed");
 	r_regex_fini (&rx);
@@ -30,6 +30,28 @@ static int test_init_fini(void) {
 	rc = r_regex_init (&rx, "hello", R_REGEX_NOSUB);
 	mu_assert_eq (rc, 0, "r_regex_init nosub");
 	r_regex_fini (&rx);
+	mu_end;
+}
+
+// Issue #16549: r_regex_init/r_regex_new must not leak the prior compilation
+// when called on an already-initialized RRegex. Catches a regression only when
+// the test binary is built with LeakSanitizer (e.g. `make asan` in test/unit).
+static int test_double_init(void) {
+	// Pattern A: r_regex_init twice on the same struct, no fini between.
+	RRegex rx = { 0 };
+	int rc = r_regex_init (&rx, "hello", R_REGEX_EXTENDED);
+	mu_assert_eq (rc, 0, "first init succeeded");
+	rc = r_regex_init (&rx, "world", R_REGEX_EXTENDED);
+	mu_assert_eq (rc, 0, "second init succeeded");
+	r_regex_fini (&rx);
+
+	// Pattern B: r_regex_new then r_regex_init on the returned pointer.
+	RRegex *rxp = r_regex_new ("hello", "");
+	mu_assert_notnull (rxp, "new succeeded");
+	rc = r_regex_init (rxp, "world", R_REGEX_EXTENDED);
+	mu_assert_eq (rc, 0, "init-after-new succeeded");
+	r_regex_free (rxp);
+
 	mu_end;
 }
 
@@ -407,7 +429,7 @@ static int test_match_list(void) {
 // === Error messages ===
 
 static int test_error_messages(void) {
-	RRegex rx;
+	RRegex rx = { 0 };
 	int rc = r_regex_init (&rx, "hello", R_REGEX_EXTENDED);
 	mu_assert_eq (rc, 0, "init for error test");
 
@@ -621,6 +643,7 @@ int main(int argc, char **argv) {
 	// lifecycle
 	mu_run_test (test_new_free);
 	mu_run_test (test_init_fini);
+	mu_run_test (test_double_init);
 	mu_run_test (test_invalid_pattern);
 	mu_run_test (test_flags);
 


### PR DESCRIPTION

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes #16549.

r_regex_init (formerly r_regex_comp per the issue title) overwrites preg->re_g without first releasing any prior compilation. Calling it on an already-initialized RRegex — the r_regex_new(...) + r_regex_init(rx, ...) pattern the issue describes — silently leaks the first compile (~922 bytes: re_g + strip + must).

Commit fdb75d3b fixed the original /ad/ call site in casm.c back in 2020, but the underlying API hazard was never plugged. No in-tree callers double-init today, so this is latent rather than user-visible.

Fix

r_regex_init now calls r_regex_fini(preg) at entry to release any prior compilation. r_regex_fini already magic-checks (re_magic == MAGIC1), so it's a safe no-op on a freshly zero-initialized struct. The contract — callers must zero-initialize RRegex on first use — is documented inline, and the in-tree stack instances in r_regex_match, softmagic, and the unit tests are updated to RRegex rx = {0}; accordingly.

While in the file I also plugged a small OOM-window leak in r_regex_new: if the post-init R_NEW(RRegex) failed, the just-compiled rx was leaked. Now it's r_regex_fini'd on the OOM path.

Tests
Added test_double_init covering both forms of the bug (init+init, new+init). The test is a regression guard — it only fails when the suite is built with LeakSanitizer (make asan in test/unit/), which is the right place to catch this kind of regression.

Verification
Built libr_util with SANITIZE="address leak undefined" sys/sanitize.sh -u, then:

Standalone repro of both bug patterns: pre-fix → 922 bytes / 6 allocations leaked; post-fix → no leaks.
test/unit/bin/test_regex under ASan/LSan/UBSan: 37/37 OK including the new test, no leaks.
r2 -qc 'pi 1' /bin/ls smoke run: clean.
