### PR TITLE
Fix memory leak in x86_nz parseOpcode error paths ##asm

### DIFF
--- a/libr/arch/p/x86_nz/nzasm.c
+++ b/libr/arch/p/x86_nz/nzasm.c
@@ -5994,7 +5994,7 @@ static int parseOpcode(RArchSession *a, const char *op, Opcode *out) {
 		isrepop = true;
 	}
 	if (parseOperand (a, args, &(out->operands[0]), isrepop) == -1) {
-		return -1;
+		goto err;
 	}
 	out->operands_count = 1;
 	while (out->operands_count < MAX_OPERANDS) {
@@ -6004,11 +6004,14 @@ static int parseOpcode(RArchSession *a, const char *op, Opcode *out) {
 		}
 		args++;
 		if (parseOperand (a, args, &(out->operands[out->operands_count]), isrepop) == -1) {
-			return -1;
+			goto err;
 		}
 		out->operands_count++;
 	}
 	return 0;
+err:
+	R_FREE (out->mnemonic);
+	return -1;
 }
 
 static int oprep(RArchSession *a, ut8 *data, const Opcode *op) {

--- a/test/unit/test_x86_nz_leak.c
+++ b/test/unit/test_x86_nz_leak.c
@@ -1,0 +1,74 @@
+#include <r_asm.h>
+#include <r_anal.h>
+#include "minunit.h"
+
+static void make_x86_asm(RAsm **out_asm, RAnal **out_anal) {
+	RAsm *a = r_asm_new ();
+	RAnal *anal = r_anal_new ();
+	r_unref (anal->config);
+	a->num = r_num_new (NULL, NULL, NULL);
+	anal->config = r_ref_ptr (a->config);
+	r_anal_bind (anal, &a->analb);
+	r_asm_use (a, "x86");
+	r_asm_set_bits (a, 32);
+	*out_asm = a;
+	*out_anal = anal;
+}
+
+static void free_x86_asm(RAsm *a, RAnal *anal) {
+	r_num_free (a->num);
+	a->num = NULL;
+	r_asm_free (a);
+	r_anal_free (anal);
+}
+
+// Inputs that previously leaked out->mnemonic on the parseOpcode -1 return:
+// they tokenize past the mnemonic (so r_str_ndup runs) but then fail inside
+// parseOperand. If the fix regresses, ASan+LSan at program exit will report
+// the leak and flip this test from PASS to the LSan-induced nonzero exit.
+static int test_failed_assemble_no_leak(void) {
+	RAsm *a;
+	RAnal *anal;
+	make_x86_asm (&a, &anal);
+
+	const char *bad[] = {
+		"movl $33, %eax",
+		"addl %eax, %ebx",
+		"mov %nonsense, %eax",
+		NULL
+	};
+	int i;
+	for (i = 0; bad[i]; i++) {
+		RAsmCode *code = r_asm_assemble (a, bad[i]);
+		bool failed = !code || code->len <= 0;
+		mu_assert_true (failed, bad[i]);
+		r_asm_code_free (code);
+	}
+
+	free_x86_asm (a, anal);
+	mu_end;
+}
+
+static int test_clean_assemble_still_works(void) {
+	RAsm *a;
+	RAnal *anal;
+	make_x86_asm (&a, &anal);
+
+	const char *good[] = { "mov eax, 1", "ret", "nop", NULL };
+	int i;
+	for (i = 0; good[i]; i++) {
+		RAsmCode *code = r_asm_assemble (a, good[i]);
+		mu_assert_notnull (code, good[i]);
+		mu_assert_true (code->len > 0, good[i]);
+		r_asm_code_free (code);
+	}
+
+	free_x86_asm (a, anal);
+	mu_end;
+}
+
+int main(int argc, char **argv) {
+	mu_run_test (test_failed_assemble_no_leak);
+	mu_run_test (test_clean_assemble_still_works);
+	return tests_passed != tests_run;
+}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`parseOpcode` in `libr/arch/p/x86_nz/nzasm.c` allocates `out->mnemonic`
via `r_str_ndup`/`strdup` up front, then has two `return -1` paths when
`parseOperand` fails that leaked the mnemonic. Triggered by any x86 input
that tokenizes past the mnemonic but fails operand parsing — e.g. under
ASan+LSan, `rasm2 -a x86 -b 32 'movl $33, %eax'` leaks 15 bytes per call.

Callers (`x86nz_assemble`, `oprep`) do
`Opcode instr = {0}; if (parseOpcode(...) == -1) return -1;`,
so cleanup has to happen inside `parseOpcode` itself. Used a single
`err:` label so future error paths can't reintroduce the regression —
this is the third iteration of the same leak class in this function,
previously patched by #8598 (2017) and `3ec4d2d942` (2022).

Verified under `SANITIZE="address leak undefined" sys/sanitize.sh -u`:
three trigger inputs plus three clean controls produce zero LSan reports;
TDD-verified that the new `test/unit/test_x86_nz_leak.c` flips from
exit 0 to exit 1 when the fix is reverted. No regressions in
`test/db/asm/x86_32` (0 XX failures).