### PR TITLE
Fix bug in 'as command' not showing the right syscall ##analysis

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2329,10 +2329,7 @@ R_API char *cmd_syscall_dostr(RCore *core, st64 n, ut64 addr) {
 	char str[64], snstr[32];
 	st64 N = n;
 	int defVector = r_syscall_get_swi (core->anal->syscall);
-	if (defVector > 0) {
-		n = -1;
-	}
-	if (n == -1 || defVector > 0) {
+	if (n == -1) {
 		n = (int)r_debug_reg_get (core->dbg, "oeax");
 		if (!n || n == -1) {
 			n = r_debug_reg_get (core->dbg, "SN");

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2329,6 +2329,9 @@ R_API char *cmd_syscall_dostr(RCore *core, st64 n, ut64 addr) {
 	char str[64], snstr[32];
 	st64 N = n;
 	int defVector = r_syscall_get_swi (core->anal->syscall);
+	if (addr != UT64_MAX && defVector > 0) {
+		n = -1;
+	}
 	if (n == -1) {
 		n = (int)r_debug_reg_get (core->dbg, "oeax");
 		if (!n || n == -1) {

--- a/test/db/anal/syscalls
+++ b/test/db/anal/syscalls
@@ -17,3 +17,25 @@ EXPECT=<<EOF
 EOF
 EXPECT_ERR=
 RUN
+
+NAME=as <num> honors user argument
+FILE=-
+CMDS=<<EOF
+-a x86
+-b 64
+-e asm.os=linux
+as 0
+as 1
+as 2
+as 4
+as write
+EOF
+EXPECT=<<EOF
+0 = read (0, 0x00000000, 0)
+1 = write (0, 0x00000000, 0)
+2 = open (0x00000000, 0x00000000, 0x00000000)
+4 = stat (0x00000000, 0x00000000)
+1 = write (0, 0x00000000, 0)
+EOF
+EXPECT_ERR=
+RUN

--- a/test/db/anal/syscalls
+++ b/test/db/anal/syscalls
@@ -32,10 +32,10 @@ as write
 EOF
 EXPECT=<<EOF
 0 = read (0, 0x00000000, 0)
-1 = write (0, 0x00000000, 0)
-2 = open (0x00000000, 0x00000000, 0x00000000)
+1 = write (0, "", 0)
+2 = open ("", 0x00000000, 0x00000000)
 4 = stat (0x00000000, 0x00000000)
-1 = write (0, 0x00000000, 0)
+1 = write (0, "", 0)
 EOF
 EXPECT_ERR=
 RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
