### PR TITLE
Fix Coverity-reported null derefs, tainted loops and integer overflows

### DIFF
--- a/libr/core/p/newprj/format.inc.c
+++ b/libr/core/p/newprj/format.inc.c
@@ -44,12 +44,15 @@ static ut32 rprj_st_append(R2ProjectStringTable *st, const char *s) {
 	const size_t newsize = st->size + slen;
 	if (newsize > st->capacity) {
 		const size_t new_capacity = newsize + 1024;
-		ut8 *nb = realloc (st->data, new_capacity);
+		ut8 *nb = st->data? realloc (st->data, new_capacity): malloc (new_capacity);
 		if (!nb) {
 			return UT32_MAX;
 		}
 		st->data = nb;
 		st->capacity = new_capacity;
+	}
+	if (!st->data) {
+		return UT32_MAX;
 	}
 	memcpy (st->data + st->size, s, slen);
 	ut32 index = st->size;

--- a/libr/core/p/newprj/load.inc.c
+++ b/libr/core/p/newprj/load.inc.c
@@ -781,6 +781,11 @@ static void rprj_function_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 		free (colors);
 		return;
 	}
+	const ut64 fbmax = rprj_entry_remaining (b, next_entry) / RPRJ_FUNCTION_SIZE;
+	if (count > fbmax) {
+		R_LOG_WARN ("Invalid function record count %u", count);
+		count = (ut32)fbmax;
+	}
 	RList *pfcns = (mode & R_CORE_NEWPRJ_MODE_DIFF)? r_list_newf (free): NULL;
 	ut32 i;
 	for (i = 0; i < count && r_buf_at (b) < next_entry; i++) {
@@ -831,6 +836,11 @@ static void rprj_function_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 		}
 		RList *pbbs = (mode & R_CORE_NEWPRJ_MODE_DIFF)? r_list_newf (free): NULL;
 		RList *pvars = (mode & R_CORE_NEWPRJ_MODE_DIFF)? r_list_newf ((RListFree)rprj_diff_var_free): NULL;
+		const ut64 bbmax = rprj_entry_remaining (b, next_entry) / RPRJ_BLOCK_SIZE;
+		if (pfcn.nbbs > bbmax) {
+			R_LOG_WARN ("Invalid basic block count %u in function %u/%u", pfcn.nbbs, i, count);
+			pfcn.nbbs = (ut32)bbmax;
+		}
 		ut32 j;
 		for (j = 0; j < pfcn.nbbs && r_buf_at (b) < next_entry; j++) {
 			R2ProjectBlock pbb;
@@ -867,6 +877,11 @@ static void rprj_function_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 			if (resolved) {
 				rprj_block_load (cur, fcn, &pbb, mode, va, colors, ncolors);
 			}
+		}
+		const ut64 vbmax = rprj_entry_remaining (b, next_entry) / RPRJ_VAR_SIZE;
+		if (pfcn.nvars > vbmax) {
+			R_LOG_WARN ("Invalid variable count %u in function %u/%u", pfcn.nvars, i, count);
+			pfcn.nvars = (ut32)vbmax;
 		}
 		for (j = 0; j < pfcn.nvars && r_buf_at (b) < next_entry; j++) {
 			R2ProjectVar pvar;
@@ -1126,7 +1141,7 @@ static void r_core_newprj_load(RCore *core, const char *file, int mode) {
 				ut64 at = r_buf_at (b);
 				ut64 last = at + entry.size - sizeof (R2ProjectEntry);
 				RList *seen = (mode & R_CORE_NEWPRJ_MODE_DIFF)? r_list_newf (free): NULL;
-				while (at + sizeof (R2ProjectComment) <= last) {
+				while (at < last && last - at >= sizeof (R2ProjectComment)) {
 					R2ProjectComment cmnt;
 					if (!rprj_cmnt_read (b, &cmnt)) {
 						R_LOG_WARN ("Truncated comment record at 0x%08"PFMT64x, at);
@@ -1269,7 +1284,7 @@ static void r_core_newprj_load(RCore *core, const char *file, int mode) {
 				ut64 at = r_buf_at (b);
 				ut64 last = at + entry.size - sizeof (R2ProjectEntry);
 				RList *seen = (mode & R_CORE_NEWPRJ_MODE_DIFF)? r_list_newf (free): NULL;
-				while (at + sizeof (R2ProjectHint) <= last) {
+				while (at < last && last - at >= sizeof (R2ProjectHint)) {
 					R2ProjectHint hint;
 					if (!rprj_hint_read (b, &hint)) {
 						R_LOG_WARN ("Truncated hint record at 0x%08"PFMT64x, at);
@@ -1280,7 +1295,7 @@ static void r_core_newprj_load(RCore *core, const char *file, int mode) {
 						.delta = hint.delta,
 					};
 					ut64 va = UT64_MAX;
-					if (!rprj_project_addr_to_va (&cur, &addr, &va)) {
+					if (!rprj_project_addr_to_va (&cur, &addr, &va) || va == UT64_MAX) {
 						R_LOG_WARN ("Cannot resolve hint record at 0x%08"PFMT64x, at);
 						at += sizeof (hint);
 						continue;

--- a/libr/fs/p/fs_grub_base.inc.c
+++ b/libr/fs/p/fs_grub_base.inc.c
@@ -8,7 +8,14 @@
 
 static RFSFile* FSP(_open)(RFSRoot *root, const char *path, bool create) {
 	RFSFile *file = r_fs_file_new (root, path);
+	if (!file) {
+		return NULL;
+	}
 	GrubFS *gfs = grubfs_new (&FSIPTR, &root->iob);
+	if (!gfs) {
+		r_fs_file_free (file);
+		return NULL;
+	}
 	file->ptr = gfs;
 	file->p = root->p;
 	grubfs_bind_io (NULL, file->root->delta);


### PR DESCRIPTION
- newprj/save: handle null string-table data in rprj_st_append by
  switching to malloc when data is NULL and bailing if still NULL,
  silencing the FORWARD_NULL warning (CID 1655821).
- newprj/load: bound function/block/variable counts by the remaining
  entry size to satisfy TAINTED_SCALAR (CID 1655819) and rewrite the
  comment and hint loop conditions to avoid possible 64-bit address
  arithmetic overflow (CID 1655818). Skip hint records that resolve
  to UT64_MAX so the va<<8 hash key does not lose meaningful bits.
- fs_grub: bail out of the open() helper when r_fs_file_new() or
  grubfs_new() return NULL, fixing the deref reported for the fb,
  fat, tar and xfs grub plugins (CIDs 1655815/1655816/1655817/1655820).