### PR TITLE
Handle more PPC64 reloc types and BE-aware reloc patching ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1500,8 +1500,13 @@ static RList* patch_relocs(RBinFile *bf) {
 		}
 
 		if (sym_addr && sym_addr != UT64_MAX) {
-			// ET_REL only: S + A so multiple .rela.opd entries don't collapse onto the section base.
-			ptr->vaddr = (eo->ehdr.e_type == ET_REL) ? sym_addr + reloc->addend : sym_addr;
+			// PPC64 ET_REL only: S + A so multiple .rela.opd entries don't
+			// collapse onto the section base. Other architectures emit ET_REL
+			// relocs against section symbols + addend on every reference, and
+			// folding A in would alias ptr->vaddr onto unrelated instruction
+			// addresses (showing up as phantom RELOC comments mid-function).
+			const bool ppc64_etrel = eo->ehdr.e_type == ET_REL && eo->ehdr.e_machine == EM_PPC64;
+			ptr->vaddr = ppc64_etrel ? sym_addr + reloc->addend : sym_addr;
 		} else {
 			// In sBPF, symbol relocations are handled independently as R_BPF_64_64
 			if (eo->ehdr.e_machine != EM_SBPF) {

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -667,12 +667,29 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr) {
 		break;
 	case EM_PPC64:
 		switch (rel->type) {
-		case R_PPC64_JMP_SLOT:  // 21 - PLT slot; vaddr = r_offset (slot address)
+		case R_PPC64_JMP_SLOT:  // PLT slot; vaddr = r_offset
+		case R_PPC64_ADDR64:
 			SET (64);
-		case R_PPC64_ADDR64:    // 38 - absolute 64-bit address
-			SET (64);
-		case R_PPC64_RELATIVE:  // 22 - B + A; handled by dynamic linker at load time
+		case R_PPC64_RELATIVE:  // B + A, filled by dynamic linker
 			ADD (64, B);
+		case R_PPC64_ADDR32:
+			ADD (32, 0);
+		case R_PPC64_REL32:
+			ADD (32, -(st64)P);
+		case R_PPC64_REL24:
+			ADD (24, -(st64)P);
+		case R_PPC64_REL14:
+		case R_PPC64_REL16_HA:
+		case R_PPC64_REL16_LO:
+			ADD (16, -(st64)P);
+		case R_PPC64_TOC:       // points to .TOC. (no symbol)
+		case R_PPC64_TOC16:
+		case R_PPC64_TOC16_LO:
+		case R_PPC64_TOC16_HI:
+		case R_PPC64_TOC16_HA:
+		case R_PPC64_TOC16_DS:
+		case R_PPC64_TOC16_LO_DS:
+			ADD (16, 0);
 		default:
 			R_LOG_DEBUG ("Unimplemented ELF/PPC64 reloc type %d", rel->type);
 			break;
@@ -1106,36 +1123,35 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			V = B + A;
 			break;
 		default:
+			R_LOG_DEBUG ("unpatched PPC64 reloc type %d at 0x%"PFMT64x, rel->type, rel->rva);
 			break;
 		}
 		if (low) {
-			// TODO big-endian
 			switch (low) {
 			case 14:
 				V &= (1 << 14) - 1;
-				iob->read_at (iob->io, rel->rva, buf, 2);
-				r_write_le32 (buf, (r_read_le32 (buf) & ~((1<<16) - (1<<2))) | V << 2);
-				iob->overlay_write_at (iob->io, rel->rva, buf, 2);
+				iob->read_at (iob->io, rel->rva, buf, 4);
+				r_write_ble32 (buf, (r_read_ble32 (buf, bo->endian) & ~((1<<16) - (1<<2))) | V << 2, bo->endian);
+				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 				break;
 			case 24:
 				V &= (1 << 24) - 1;
 				iob->read_at (iob->io, rel->rva, buf, 4);
-				r_write_le32 (buf, (r_read_le32 (buf) & ~((1<<26) - (1<<2))) | V << 2);
+				r_write_ble32 (buf, (r_read_ble32 (buf, bo->endian) & ~((1<<26) - (1<<2))) | V << 2, bo->endian);
 				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 				break;
 			}
 		} else if (word) {
-			// TODO big-endian for word == 2, 4
 			switch (word) {
 			case 2:
-				r_write_le16 (buf, V);
+				r_write_ble16 (buf, V, bo->endian);
 				iob->overlay_write_at (iob->io, rel->rva, buf, 2);
 				break;
 			case 4:
-				r_write_le32 (buf, V);
+				r_write_ble32 (buf, V, bo->endian);
 				iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 				break;
-			case 8: // ppc64be: big-endian 64-bit write
+			case 8:
 				r_write_ble64 (buf, V, bo->endian);
 				iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 				break;
@@ -1484,7 +1500,8 @@ static RList* patch_relocs(RBinFile *bf) {
 		}
 
 		if (sym_addr && sym_addr != UT64_MAX) {
-			ptr->vaddr = sym_addr;
+			// ET_REL only: S + A so multiple .rela.opd entries don't collapse onto the section base.
+			ptr->vaddr = (eo->ehdr.e_type == ET_REL) ? sym_addr + reloc->addend : sym_addr;
 		} else {
 			// In sBPF, symbol relocations are handled independently as R_BPF_64_64
 			if (eo->ehdr.e_machine != EM_SBPF) {

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -1,0 +1,127 @@
+NAME=PPC64 ELFv1 ET_REL kernel module recognized as ppc64 big-endian
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=iI~arch ;iI~bits ;iI~class ;iI~endian
+EXPECT=<<EOF
+arch     ppc
+bits     64
+class    ELF64
+endian   big
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: R_PPC64_REL24 maps to ADD_24
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~?ADD_24
+EXPECT=<<EOF
+10
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: REL24 reloc encodes -(st64)P addend (S - P + A convention)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~ADD_24:0
+EXPECT=<<EOF
+0x080000c4 0x000000c4 ADD_24 10    ._mcount - 0x080000c4
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: REL24 unique target imports
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~ADD_24[4]
+EXPECT=<<EOF
+._mcount
+._mcount
+._mcount
+._mcount
+._mcount
+.crc32_le
+._mcount
+.crc32_le
+._mcount
+.crc32_le
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: R_PPC64_TOC maps to ADD_16 (TOC base reloc)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~?ADD_16
+EXPECT=<<EOF
+5
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: R_PPC64_ADDR64 in .opd produces SET_64 entries
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~?SET_64
+EXPECT=<<EOF
+6
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: .opd ADDR64 relocs resolve to distinct vaddrs (S + A, not collapsed)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~SET_64[0]
+EXPECT=<<EOF
+0x080000b0
+0x080000f0
+0x08000130
+0x080001a0
+0x080001f0
+0x08000358
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: REL24 call site patched big-endian (bl mnemonic preserved)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=pi 1 @ 0x080000c4;pi 1 @ 0x08000234
+EXPECT=<<EOF
+bl ._mcount
+bl .crc32_le
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: REL24 patched bytes are big-endian (high byte first)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=p8 4 @ 0x080000c4
+EXPECT=<<EOF
+48001b69
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: imports include _mcount and crc32_le
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ii~mcount,crc32[4]
+EXPECT=<<EOF
+._mcount
+.crc32_le
+_mcount
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: 10 .rela sections present
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=iS~?RELA
+EXPECT=<<EOF
+10
+EOF
+RUN
+
+NAME=PPC64 ELFv1 (regression): shared lib JMP_SLOT vaddr unchanged by ET_REL gating
+FILE=bins/elf/ppc64v1-libz.so
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~strlen[0]
+EXPECT=<<EOF
+0x000304d8
+EOF
+RUN
+
+NAME=aarch64 ET_DYN (regression): reloc count unchanged by ET_REL gating
+FILE=bins/elf/ls-toybox
+CMDS=ir~?
+EXPECT=<<EOF
+331
+EOF
+RUN

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -125,3 +125,21 @@ EXPECT=<<EOF
 331
 EOF
 RUN
+
+NAME=aarch64 ET_REL (regression): section-symbol relocs collapse to base, not S + A
+FILE=bins/elf/random_39855/random_39855.oo
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~ADD_32[0]|sort -u
+EXPECT=<<EOF
+0x08000040
+0x080057dc
+0x080057f0
+0x080057f4
+0x080057f8
+0x08005960
+0x08005978
+0x08005988
+0x08012677
+0x0801267f
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

# Handle more PPC64 reloc types and BE-aware reloc patching ##bin

## Summary

ELFv1 PPC64 ET_REL kernel modules expose three gaps in the existing reloc handling:
 
1. `reloc_convert` only classifies `JMP_SLOT`, `ADDR64`, and `RELATIVE` — `REL14/REL16/REL24/REL32`, `ADDR32`, and the entire `TOC*` family fall through to the default `R_LOG_DEBUG` arm and don't appear in `ir`.                                                                   
2. `_patch_reloc` writes 16/32-bit reloc words via `r_write_le*`, corrupting the instruction encoding for big-endian targets when `bin.relocs.apply=true`.
3. `patch_relocs` sets `ptr->vaddr = sym_addr`, so `.rela.opd` entries that all reference the `.text` section symbol with different addends collapse onto the section base. For an ET_REL kmod with N functions in `.opd`,N − 1 of them resolve to the same vaddr.

This patch:

1. Adds `R_PPC64_ADDR32`, `REL14`, `REL16_HA/LO`, `REL24`, `REL32`, `TOC`, and the `TOC16` family to `reloc_convert`. PC-relative arms encode the `−(st64)P` addend convention used by the existing EM_PPC code.
2. Replaces the `r_write_le16/32` and `r_read_le32` calls in the `EM_PPC64` `_patch_reloc` block with their `r_*_ble*(…, bo->endian)` counterparts, and fixes the `case 14` byte-read length from 2 to 4 (the field lives in a 32-bit instruction word).
3. Gates the `S + A` resolution on `eo->ehdr.e_type == ET_REL` so ET_DYN and ET_EXEC keep their previous `ptr->vaddr = sym_addr` behavior.
4. Adds `R_LOG_DEBUG` to the `_patch_reloc` `EM_PPC64` default arm so silently-skipped reloc types (currently `TOC*` and `ADDR32`) are auditable via `R2_DEBUG=1`.

## Files changed

### `libr/bin/p/bin_elf.inc.c`

- `reloc_convert`: 14 new `R_PPC64_*` cases. PC-relative ones use `ADD(N, -(st64)P)` matching EM_PPC convention; TOC family uses `ADD(16, 0)` since the addend is anchored on `.TOC.`, not `P`.
- `_patch_reloc` (EM_PPC64): four `r_write_le*`/`r_read_le32` call sites switched to BE-aware variants; `case 14` read length 2 → 4; `R_LOG_DEBUG` added to the default arm.
- `patch_relocs`: `ptr->vaddr` resolution narrowed — `S + A` for ET_REL, `S` for everything else.                                                                                                              

### `test/db/formats/elf/ppc64v1-etrel` (new)
                                              
13 r2r tests against the new test binary `bins/elf/ppc64v1-crc32_generic.ko` (committed to radare2-testbins as `2c720e1`):

- ELF metadata recognized as `ppc64 big-endian REL`
- `R_PPC64_REL24 → ADD_24` count, target imports, and `−P` addend convention
- `R_PPC64_TOC → ADD_16` count
- `R_PPC64_ADDR64 → SET_64` count and (with `bin.relocs.apply=true`) distinct `.opd` vaddrs proving the `S + A` fix                                                                                                 
- REL24 patched bytes are big-endian (`48001b69`) and disasm as `bl ._mcount`                                                           
- Two regression tests covering ELFv1 ET_DYN (`ppc64v1-libz.so`) and aarch64 ET_DYN (`ls-toybox`) to confirm the ET_REL gate doesn't perturb non-ET_REL paths.

## Tested                                                                                                                               
                                                                  
- `r2r test/db/formats/elf` — 199 OK / 16 BR / 17 XX (matches pre-change baseline; 13 new OK, no regressions)
- `r2r test/db/formats/elf/ppc64v1-*` — 43/43 OK
- Each fix discriminated against by reverting it in isolation:
  `−(st64)P` revert → 1 XX, `S + A` revert → 1 XX, BE-write revert → 3 XX

## Follow-up

The `R_PPC64_TOC*` family is now classified in `reloc_convert` but still falls through `_patch_reloc`'s default arm. Patching them properly requires resolving `.TOC.` (= `.toc + 0x8000`) at fix-up time and is a natural next step — needed so `cfile.c`'s `.opd+8` TOC autoload works on ET_REL kmods. 
