### PR TITLE
Fix x86 jump table autosizing for Rust niche switches ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1681,8 +1681,8 @@ noskip:
 						}
 					}
 					if (!try_get_jmptbl_info (anal, fcn, op->addr, bb, &table_size, &default_case, &case_shift)) {
-						table_size = anal->cmpval + 1;
-						default_case = -1;
+						table_size = 0;
+						default_case = UT64_MAX;
 					}
 					ret = r_anal_jmptbl_walk (anal, fcn, bb, depth - 1, op->addr, case_shift, jmptbl_base + movdisp, jmptbl_base, movscale, table_size, default_case, ret);
 					anal->cmpval = UT64_MAX;

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -4,6 +4,8 @@
 #include <r_anal_priv.h>
 
 #define JMPTBL_DISPATCH_LOOKBACK 16
+#define JMPTBL_TARGET_MAX_OPS 6
+#define JMPTBL_TARGET_PROBE_CAP 128
 #define SWITCH_SDB_NS "switches"
 
 typedef struct {
@@ -160,15 +162,20 @@ static bool check_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 cas
 			return false;
 		}
 	}
-	ut8 probe[96];
-	if (!anal->iob.read_at (anal->iob.io, case_addr, probe, sizeof (probe))) {
+	ut8 probe[JMPTBL_TARGET_PROBE_CAP];
+	int maxop = r_arch_info (anal->arch, R_ARCH_INFO_MAXOP_SIZE);
+	if (maxop < 1) {
+		maxop = 16;
+	}
+	const size_t probe_sz = R_MIN (sizeof (probe), (size_t)maxop * JMPTBL_TARGET_MAX_OPS);
+	if (!anal->iob.read_at (anal->iob.io, case_addr, probe, probe_sz)) {
 		return false;
 	}
 	RAnalOp op = { 0 };
 	ut64 off = 0;
 	int nops = 0;
-	while (off < sizeof (probe) && nops++ < 6) {
-		int len = r_anal_op (anal, &op, case_addr + off, probe + off, sizeof (probe) - off, R_ARCH_OP_MASK_BASIC);
+	while (off < probe_sz && nops++ < JMPTBL_TARGET_MAX_OPS) {
+		int len = r_anal_op (anal, &op, case_addr + off, probe + off, probe_sz - off, R_ARCH_OP_MASK_BASIC);
 		if (len < 1 || (op.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_ILL) {
 			r_anal_op_fini (&op);
 			return false;
@@ -422,7 +429,7 @@ static RAnalBlock *analyze_new_case_once(RAnal *anal, RAnalFunction *fcn, RAnalB
 }
 
 static bool function_has_ret_between(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 to) {
-	if (!anal || !fcn || !fcn->bbs || to <= from) {
+	if (!fcn || !fcn->bbs || to <= from) {
 		return false;
 	}
 	RListIter *iter;
@@ -462,8 +469,24 @@ static Sdb *switch_sdb(RAnal *anal, bool create) {
 	return sdb_ns (anal->sdb, SWITCH_SDB_NS, create);
 }
 
-static ut32 switch_spec_ncases(const RAnalSwitchSpec *spec) {
-	return spec->ncases? R_MIN (spec->ncases, (ut32)R_ANAL_SWITCH_MAXCASES): R_ANAL_SWITCH_MAXCASES;
+static ut32 jmptbl_maxcases(RAnal *anal) {
+	const int maxcases = anal->opt.jmptbl_maxcases;
+	return maxcases > 0? (ut32)maxcases: R_ANAL_SWITCH_MAXCASES;
+}
+
+static ut64 jmptbl_limit_cases(RAnal *anal, ut64 ncases, ut64 at) {
+	const ut32 maxcases = jmptbl_maxcases (anal);
+	if (ncases > maxcases) {
+		R_LOG_WARN ("Limiting jump table at 0x%08" PFMT64x " to %u cases",
+			at, (unsigned)maxcases);
+		return maxcases;
+	}
+	return ncases;
+}
+
+static ut32 switch_spec_ncases(RAnal *anal, const RAnalSwitchSpec *spec) {
+	const ut32 maxcases = jmptbl_maxcases (anal);
+	return spec->ncases? R_MIN (spec->ncases, maxcases): maxcases;
 }
 
 static char *switch_spec_serialize(const RAnalSwitchSpec *spec) {
@@ -544,7 +567,7 @@ R_API void r_anal_switch_unset(RAnal *anal, ut64 startea) {
 // INDIRECT with vsize > 1, SPARSE).
 static bool switch_apply_flagged(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, int depth, const RAnalSwitchSpec *spec) {
 	JmptblTargetCtx target_ctx = { 0 };
-	const ut32 ncases = switch_spec_ncases (spec);
+	const ut32 ncases = switch_spec_ncases (anal, spec);
 	if (spec->jtbl_addr == UT64_MAX) {
 		R_LOG_DEBUG ("Invalid JumpTable location");
 		return false;
@@ -698,13 +721,11 @@ static bool spec_needs_flag_walker(const RAnalSwitchSpec *spec) {
 R_API bool r_anal_switch_apply(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, int depth, const RAnalSwitchSpec *spec) {
 	R_RETURN_VAL_IF_FAIL (anal && spec, false);
 	RAnalSwitchSpec limited_spec;
-	if (spec->ncases > R_ANAL_SWITCH_MAXCASES) {
+	const ut64 ncases = jmptbl_limit_cases (anal, spec->ncases, spec->startea);
+	if (spec->ncases > ncases) {
 		limited_spec = *spec;
-		limited_spec.ncases = R_ANAL_SWITCH_MAXCASES;
+		limited_spec.ncases = ncases;
 		spec = &limited_spec;
-		R_LOG_DEBUG ("Limiting JumpTable size at 0x%08" PFMT64x " to %u cases",
-			spec->startea,
-			(unsigned)R_ANAL_SWITCH_MAXCASES);
 	}
 	if (spec->jtbl_addr == UT64_MAX) {
 		return false;
@@ -870,7 +891,9 @@ R_API bool try_walkthrough_casetbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *
 	bool ret = ret0;
 	JmptblTargetCtx target_ctx = { 0 };
 	if (jmptbl_size == 0) {
-		jmptbl_size = R_ANAL_SWITCH_MAXCASES;
+		jmptbl_size = jmptbl_maxcases (anal);
+	} else {
+		jmptbl_size = jmptbl_limit_cases (anal, jmptbl_size, ip);
 	}
 	if (jmptbl_loc == UT64_MAX) {
 		R_LOG_DEBUG ("Invalid JumpTable location 0x%08" PFMT64x, jmptbl_loc);
@@ -937,9 +960,11 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 	// jmptbl_size can not always be determined
 	if (jmptbl_size == 0) {
 		jmptbl_size = jmptbl_size_from_next_ref (anal, &a, jmptbl_loc, sz);
-		if (!jmptbl_size) {
-			jmptbl_size = R_ANAL_SWITCH_MAXCASES;
-		}
+		jmptbl_size = jmptbl_size
+			? jmptbl_limit_cases (anal, jmptbl_size, ip)
+			: jmptbl_maxcases (anal);
+	} else {
+		jmptbl_size = jmptbl_limit_cases (anal, jmptbl_size, ip);
 	}
 	if (jmptbl_loc == UT64_MAX) {
 		R_LOG_DEBUG ("Invalid JumpTable location 0x%08" PFMT64x, jmptbl_loc);
@@ -1196,7 +1221,9 @@ R_API int walkthrough_arm_jmptbl_style(RAnal *anal, RAnalFunction *fcn, RAnalBlo
 	jmptbl_target_ctx_init (&target_ctx, anal, ip);
 
 	if (jmptbl_size == 0) {
-		jmptbl_size = R_ANAL_SWITCH_MAXCASES;
+		jmptbl_size = jmptbl_maxcases (anal);
+	} else {
+		jmptbl_size = jmptbl_limit_cases (anal, jmptbl_size, ip);
 	}
 
 	ut64 jmptblsz;
@@ -1368,7 +1395,7 @@ R_API void r_anal_jmptbl_list(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, u
 }
 
 R_IPI bool r_anal_jmptbl_arm64_from_br(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bb, int depth, RAnalOp *op, int loadsize) {
-	if (!anal || !op || !op->reg || !anal->leaddrs) {
+	if (!op || !op->reg || !anal->leaddrs) {
 		return false;
 	}
 	if (loadsize != 1 && loadsize != 2 && loadsize != 4) {

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -160,11 +160,27 @@ static bool check_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 cas
 			return false;
 		}
 	}
-	ut8 probe[32];
+	ut8 probe[96];
 	if (!anal->iob.read_at (anal->iob.io, case_addr, probe, sizeof (probe))) {
 		return false;
 	}
-	return !r_anal_is_invalid_code (anal, probe, sizeof (probe), true);
+	RAnalOp op = { 0 };
+	ut64 off = 0;
+	int nops = 0;
+	while (off < sizeof (probe) && nops++ < 6) {
+		int len = r_anal_op (anal, &op, case_addr + off, probe + off, sizeof (probe) - off, R_ARCH_OP_MASK_BASIC);
+		if (len < 1 || (op.type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_ILL) {
+			r_anal_op_fini (&op);
+			return false;
+		}
+		const ut32 type = op.type & R_ANAL_OP_TYPE_MASK;
+		r_anal_op_fini (&op);
+		if (type == R_ANAL_OP_TYPE_JMP || type == R_ANAL_OP_TYPE_RET || type == R_ANAL_OP_TYPE_TRAP) {
+			break;
+		}
+		off += len;
+	}
+	return true;
 }
 
 static bool is_valid_jmptbl_case_target(RAnal *anal, JmptblTargetCtx *ctx, ut64 case_addr) {
@@ -366,7 +382,7 @@ R_API bool r_anal_jmptbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, ut6
 	return r_anal_jmptbl_walk (anal, fcn, block, depth, jmpaddr, 0, table, table, tablesize, tablesize, default_addr, false);
 }
 
-static inline void analyze_new_case(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, ut64 ip, ut64 jmpptr, int depth) {
+static inline RAnalBlock *analyze_new_case(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, ut64 ip, ut64 jmpptr, int depth) {
 	const ut64 block_size = block? block->size: 0;
 	r_anal_function_materialize_switch_case (anal, fcn, jmpptr, depth);
 	if (block && block->size != block_size) {
@@ -378,38 +394,31 @@ static inline void analyze_new_case(RAnal *anal, RAnalFunction *fcn, RAnalBlock 
 			block = r_anal_bb_from_offset (anal, ip);
 			if (!block) {
 				R_LOG_ERROR ("Major disaster at 0x%08" PFMT64x, ip);
-				return;
+				return NULL;
 			}
 			if (block->addr != ip) {
-				if (anal->opt.jmptbl_split) {
-					// split the block so switch instruction is at the start of its block
-					RAnalBlock *newblock = r_anal_block_split (block, ip);
-					if (newblock) {
-						r_unref (newblock);
-						block = r_anal_get_block_at (anal, ip);
-					}
-					if (!block) {
-						R_LOG_ERROR ("Failed to split block for switch at 0x%08" PFMT64x, ip);
-						return;
-					}
-				} else {
-					st64 d = block->addr - ip;
-					R_LOG_WARN ("Cannot find basic block case for jmptbl switch from 0x%08" PFMT64x " bbdelta = %d. Try -e anal.jmptbl.split=true and let us know", ip, (int)R_ABS (d));
-					block = NULL;
-					return;
+				RAnalBlock *newblock = r_anal_block_split (block, ip);
+				if (newblock) {
+					r_unref (newblock);
+					block = r_anal_get_block_at (anal, ip);
+				}
+				if (!block) {
+					R_LOG_ERROR ("Failed to split block for switch at 0x%08" PFMT64x, ip);
+					return NULL;
 				}
 			}
 		}
 		block->switch_op = sop;
 	}
+	return block;
 }
 
-static void analyze_new_case_once(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, JmptblTargetCtx *ctx, ut64 ip, ut64 jmpptr, int depth) {
+static RAnalBlock *analyze_new_case_once(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, JmptblTargetCtx *ctx, ut64 ip, ut64 jmpptr, int depth) {
 	if (ht_up_find_kv (ctx->analyzed_targets, jmpptr, NULL)) {
-		return;
+		return block;
 	}
 	ht_up_insert (ctx->analyzed_targets, jmpptr, (void *)1);
-	analyze_new_case (anal, fcn, block, ip, jmpptr, depth);
+	return analyze_new_case (anal, fcn, block, ip, jmpptr, depth);
 }
 
 static bool function_has_ret_between(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 to) {
@@ -648,7 +657,7 @@ static bool switch_apply_flagged(RAnal *anal, RAnalFunction *fcn, RAnalBlock *bl
 			continue;
 		}
 		apply_case (anal, fcn, block, spec->startea, esize, jmpptr, (ut64)casenum, entry_addr, insn_entry);
-		analyze_new_case_once (anal, fcn, block, &target_ctx, spec->startea, jmpptr, depth);
+		block = analyze_new_case_once (anal, fcn, block, &target_ctx, spec->startea, jmpptr, depth);
 		last_applied = i + 1;
 	}
 	if (last_applied > 0) {
@@ -781,13 +790,53 @@ static bool jmptbl_fixup_jmpptr(RAnal *anal, const JmptblArch *a, ut64 ip, ut64 
 	return true;
 }
 
+static bool jmptbl_ref_is_table(RAnal *anal, const JmptblArch *a, ut64 ref, ut64 sz) {
+	ut8 buf[8];
+	if (sz < 1 || sz > sizeof (buf) || !anal->iob.read_at (anal->iob.io, ref, buf, sz)) {
+		return false;
+	}
+	ut64 jmpptr = switch_read_entry (buf, (ut8)sz, false);
+	return jmptbl_fixup_jmpptr (anal, a, ref, sz, ref, &jmpptr);
+}
+
+static void jmptbl_update_next_ref(RAnal *anal, const JmptblArch *a, ut64 jmptbl_loc, ut64 sz, ut64 ref, ut64 *next) {
+	if (ref <= jmptbl_loc || ref >= *next || (ref - jmptbl_loc) % sz) {
+		return;
+	}
+	if (anal->iob.map_get_at) {
+		RIOMap *base_map = anal->iob.map_get_at (anal->iob.io, jmptbl_loc);
+		RIOMap *ref_map = anal->iob.map_get_at (anal->iob.io, ref);
+		if (base_map && ref_map && base_map != ref_map) {
+			return;
+		}
+	}
+	if (jmptbl_ref_is_table (anal, a, ref, sz)) {
+		*next = ref;
+	}
+}
+
+static ut64 jmptbl_size_from_next_ref(RAnal *anal, const JmptblArch *a, ut64 jmptbl_loc, ut64 sz) {
+	if (!sz) {
+		return 0;
+	}
+	ut64 next = UT64_MAX;
+	RListIter *iter;
+	RLeaddrPair *pair;
+	if (anal->leaddrs) {
+		r_list_foreach (anal->leaddrs, iter, pair) {
+			jmptbl_update_next_ref (anal, a, jmptbl_loc, sz, pair->leaddr, &next);
+		}
+	}
+	return next == UT64_MAX? 0: (next - jmptbl_loc) / sz;
+}
+
 typedef enum {
 	JMPTBL_WALK_STOP,
 	JMPTBL_WALK_SKIP,
 	JMPTBL_WALK_APPLY,
 } JmptblWalkResult;
 
-static JmptblWalkResult jmptbl_apply_legacy_case(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block, JmptblTargetCtx *target_ctx, const JmptblArch *a, int depth, ut64 ip, st64 start_casenum_shift, ut64 jmptbl_off, ut64 sz, ut64 jmpptr, ut64 case_idx, ut64 meta_loc, ut64 meta_sz, ut64 case_addr_loc, ut64 case_addr_sz, bool arm64_ip_relative) {
+static JmptblWalkResult jmptbl_apply_legacy_case(RAnal *anal, RAnalFunction *fcn, RAnalBlock **blockp, JmptblTargetCtx *target_ctx, const JmptblArch *a, int depth, ut64 ip, st64 start_casenum_shift, ut64 jmptbl_off, ut64 sz, ut64 jmpptr, ut64 case_idx, ut64 meta_loc, ut64 meta_sz, ut64 case_addr_loc, ut64 case_addr_sz, bool arm64_ip_relative) {
 	if (arm64_ip_relative && a->arm && anal->config->bits == 64 && ip > 4096 && jmpptr < 4096 && jmpptr < ip) {
 		jmpptr += ip;
 	}
@@ -809,8 +858,11 @@ static JmptblWalkResult jmptbl_apply_legacy_case(RAnal *anal, RAnalFunction *fcn
 		return JMPTBL_WALK_SKIP;
 	}
 	int casenum = case_idx + start_casenum_shift;
+	RAnalBlock *block = blockp? *blockp: NULL;
 	apply_case (anal, fcn, block, ip, case_addr_sz, jmpptr, casenum, case_addr_loc, false);
-	analyze_new_case_once (anal, fcn, block, target_ctx, ip, jmpptr, depth);
+	if (blockp) {
+		*blockp = analyze_new_case_once (anal, fcn, block, target_ctx, ip, jmpptr, depth);
+	}
 	return JMPTBL_WALK_APPLY;
 }
 
@@ -828,6 +880,10 @@ R_API bool try_walkthrough_casetbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *
 		R_LOG_DEBUG ("Invalid CaseTable location 0x%08" PFMT64x, jmptbl_loc);
 		return false;
 	}
+	JmptblArch a;
+	if (!jmptbl_detect_arch (anal, &a)) {
+		return false;
+	}
 	ut8 *jmptbl = jmptbl_read_table (anal, jmptbl_loc, jmptbl_size, sz, NULL);
 	if (!jmptbl) {
 		return false;
@@ -835,12 +891,6 @@ R_API bool try_walkthrough_casetbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *
 	ut8 *casetbl = jmptbl_read_table (anal, casetbl_loc, jmptbl_size, 1, NULL);
 	if (!casetbl) {
 		free (jmptbl);
-		return false;
-	}
-	JmptblArch a;
-	if (!jmptbl_detect_arch (anal, &a)) {
-		free (jmptbl);
-		free (casetbl);
 		return false;
 	}
 	jmptbl_target_ctx_init (&target_ctx, anal, ip);
@@ -855,7 +905,7 @@ R_API bool try_walkthrough_casetbl(RAnal *anal, RAnalFunction *fcn, RAnalBlock *
 		const ut64 case_addr_sz = jmptbl_loc == jmptbl_off? 1: sz;
 		const ut64 case_addr_loc = jmptbl_loc == jmptbl_off? casetbl_loc + case_idx: jmptbl_loc + entry_off;
 		const ut64 jmpptr = switch_read_entry (jmptbl + entry_off, (ut8)sz, false);
-		JmptblWalkResult walk = jmptbl_apply_legacy_case (anal, fcn, block, &target_ctx, &a, depth, ip, start_casenum_shift, jmptbl_off, sz, jmpptr, case_idx, casetbl_loc + case_idx, 1, case_addr_loc, case_addr_sz, false);
+		JmptblWalkResult walk = jmptbl_apply_legacy_case (anal, fcn, &block, &target_ctx, &a, depth, ip, start_casenum_shift, jmptbl_off, sz, jmpptr, case_idx, casetbl_loc + case_idx, 1, case_addr_loc, case_addr_sz, false);
 		if (walk == JMPTBL_WALK_STOP) {
 			break;
 		}
@@ -880,9 +930,16 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 	ut64 default_target = default_case;
 	JmptblTargetCtx target_ctx = { 0 };
 	const bool autosize = jmptbl_size == 0;
+	JmptblArch a;
+	if (!jmptbl_detect_arch (anal, &a)) {
+		return false;
+	}
 	// jmptbl_size can not always be determined
 	if (jmptbl_size == 0) {
-		jmptbl_size = R_ANAL_SWITCH_MAXCASES;
+		jmptbl_size = jmptbl_size_from_next_ref (anal, &a, jmptbl_loc, sz);
+		if (!jmptbl_size) {
+			jmptbl_size = R_ANAL_SWITCH_MAXCASES;
+		}
 	}
 	if (jmptbl_loc == UT64_MAX) {
 		R_LOG_DEBUG ("Invalid JumpTable location 0x%08" PFMT64x, jmptbl_loc);
@@ -891,11 +948,6 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 	ut8 *jmptbl = jmptbl_read_table (anal, jmptbl_loc, jmptbl_size, sz, NULL);
 	if (!jmptbl) {
 		R_LOG_DEBUG ("Invalid jump table size at 0x%08" PFMT64x, jmptbl_loc);
-		return false;
-	}
-	JmptblArch a;
-	if (!jmptbl_detect_arch (anal, &a)) {
-		free (jmptbl);
 		return false;
 	}
 	jmptbl_target_ctx_init (&target_ctx, anal, ip);
@@ -910,7 +962,7 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 		if (autosize_target != UT64_MAX && case_idx > 0 && function_has_ret_between (anal, fcn, ip, autosize_target)) {
 			break;
 		}
-		JmptblWalkResult walk = jmptbl_apply_legacy_case (anal, fcn, block, &target_ctx, &a, depth, ip, start_casenum_shift, jmptbl_off, sz, jmpptr, case_idx, jmptbl_loc + offs, sz, jmptbl_loc + offs, sz, true);
+		JmptblWalkResult walk = jmptbl_apply_legacy_case (anal, fcn, &block, &target_ctx, &a, depth, ip, start_casenum_shift, jmptbl_off, sz, jmpptr, case_idx, jmptbl_loc + offs, sz, jmptbl_loc + offs, sz, true);
 		if (walk == JMPTBL_WALK_STOP) {
 			break;
 		}
@@ -921,7 +973,7 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 		// default case for mips is right after the 'jr v0' instruction unless specified otherwise
 		ut64 mips_default = default_target != UT64_MAX? default_target: ip + 8;
 		apply_case (anal, fcn, block, ip, sz, mips_default, -1, jmptbl_loc + stop_off, false);
-		analyze_new_case_once (anal, fcn, block, &target_ctx, ip, mips_default, depth);
+		block = analyze_new_case_once (anal, fcn, block, &target_ctx, ip, mips_default, depth);
 		default_target = mips_default;
 		ret = true;
 	}
@@ -1001,6 +1053,10 @@ static bool cmp_bound_reg(RAnalOp *op, char *reg, size_t regsz) {
 	return true;
 }
 
+static bool is_reg_src(RAnalValue *src) {
+	return src && src->reg && src->type != R_ANAL_VAL_MEM && !src->memref;
+}
+
 static bool backtrack_small_bound(RAnal *anal, RAnalBlock *bb, ut8 *bb_buf, int from, const char *reg, ut64 *cmp_val) {
 	char bound_reg[32];
 	if (R_STR_ISEMPTY (reg)) {
@@ -1028,7 +1084,8 @@ static bool backtrack_small_bound(RAnal *anal, RAnalBlock *bb, ut8 *bb_buf, int 
 			continue;
 		}
 		const ut32 type = op.type & R_ANAL_OP_TYPE_MASK;
-		if (type == R_ANAL_OP_TYPE_LEA && op.disp > 0 && op.disp < 0x200) {
+		if (type == R_ANAL_OP_TYPE_LEA && op.disp > 0 && op.disp < 0x200
+				&& (!src || !src->reg || !strcmp (src->reg, dst_reg))) {
 			*cmp_val = op.disp;
 			r_anal_op_fini (&op);
 			return true;
@@ -1038,7 +1095,7 @@ static bool backtrack_small_bound(RAnal *anal, RAnalBlock *bb, ut8 *bb_buf, int 
 			r_anal_op_fini (&op);
 			return true;
 		}
-		if (type == R_ANAL_OP_TYPE_MOV && src && src->reg) {
+		if (type == R_ANAL_OP_TYPE_MOV && is_reg_src (src)) {
 			r_str_ncpy (bound_reg, src->reg, sizeof (bound_reg));
 			r_anal_op_fini (&op);
 			continue;
@@ -1155,7 +1212,7 @@ R_API int walkthrough_arm_jmptbl_style(RAnal *anal, RAnalFunction *fcn, RAnalBlo
 			continue;
 		}
 		apply_case (anal, fcn, block, ip, sz, jmpptr, case_idx, jmptbl_loc + offs, true);
-		analyze_new_case_once (anal, fcn, block, &target_ctx, ip, jmpptr, depth);
+		block = analyze_new_case_once (anal, fcn, block, &target_ctx, ip, jmpptr, depth);
 		ret = true;
 	}
 

--- a/libr/anal/jmptbl.c
+++ b/libr/anal/jmptbl.c
@@ -412,6 +412,35 @@ static void analyze_new_case_once(RAnal *anal, RAnalFunction *fcn, RAnalBlock *b
 	analyze_new_case (anal, fcn, block, ip, jmpptr, depth);
 }
 
+static bool function_has_ret_between(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 to) {
+	if (!anal || !fcn || !fcn->bbs || to <= from) {
+		return false;
+	}
+	RListIter *iter;
+	RAnalBlock *bb;
+	r_list_foreach (fcn->bbs, iter, bb) {
+		if (bb->ninstr < 1) {
+			continue;
+		}
+		const ut64 addr = r_anal_bb_opaddr_i (bb, bb->ninstr - 1);
+		if (addr <= from || addr >= to) {
+			continue;
+		}
+		ut8 buf[32];
+		if (!anal->iob.read_at (anal->iob.io, addr, buf, sizeof (buf))) {
+			continue;
+		}
+		RAnalOp op = { 0 };
+		const int len = r_anal_op (anal, &op, addr, buf, sizeof (buf), R_ARCH_OP_MASK_BASIC);
+		const ut32 type = op.type & R_ANAL_OP_TYPE_MASK;
+		r_anal_op_fini (&op);
+		if (len > 0 && type == R_ANAL_OP_TYPE_RET) {
+			return true;
+		}
+	}
+	return false;
+}
+
 // --- Persistence ---------------------------------------------------------
 // User-pinned switch overrides live in a flat sdb namespace under
 // anal->sdb, keyed by the dispatching insn address. Format:
@@ -850,6 +879,7 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 	bool ret = ret0;
 	ut64 default_target = default_case;
 	JmptblTargetCtx target_ctx = { 0 };
+	const bool autosize = jmptbl_size == 0;
 	// jmptbl_size can not always be determined
 	if (jmptbl_size == 0) {
 		jmptbl_size = R_ANAL_SWITCH_MAXCASES;
@@ -873,6 +903,13 @@ R_API bool r_anal_jmptbl_walk(RAnal *anal, RAnalFunction *fcn, RAnalBlock *block
 	for (case_idx = 0; case_idx < jmptbl_size; case_idx++) {
 		const ut64 offs = case_idx * sz;
 		const ut64 jmpptr = switch_read_entry (jmptbl + offs, (ut8)sz, false);
+		ut64 autosize_target = UT64_MAX;
+		if (autosize && sz == 4 && !anal->iob.is_valid_offset (anal->iob.io, jmpptr, 0)) {
+			autosize_target = jmptbl_off + (st32)jmpptr;
+		}
+		if (autosize_target != UT64_MAX && case_idx > 0 && function_has_ret_between (anal, fcn, ip, autosize_target)) {
+			break;
+		}
 		JmptblWalkResult walk = jmptbl_apply_legacy_case (anal, fcn, block, &target_ctx, &a, depth, ip, start_casenum_shift, jmptbl_off, sz, jmpptr, case_idx, jmptbl_loc + offs, sz, jmptbl_loc + offs, sz, true);
 		if (walk == JMPTBL_WALK_STOP) {
 			break;
@@ -949,6 +986,67 @@ static bool jmptbl_cmp_info(RAnalOp *op, bool prefer_refptr, ut64 *table_size, u
 	*table_size = value + 1;
 	*cmp_val = value;
 	return value < 0x200;
+}
+
+static bool cmp_bound_reg(RAnalOp *op, char *reg, size_t regsz) {
+	RAnalValue *src0 = RVecRArchValue_at (&op->srcs, 0);
+	RAnalValue *src1 = RVecRArchValue_at (&op->srcs, 1);
+	const char *name = (src1 && src1->reg && src1->type != R_ANAL_VAL_MEM && !src1->memref)? src1->reg
+		: (src0 && src0->reg && src0->type != R_ANAL_VAL_MEM && !src0->memref)? src0->reg
+		: op->reg;
+	if (R_STR_ISEMPTY (name)) {
+		return false;
+	}
+	r_str_ncpy (reg, name, regsz);
+	return true;
+}
+
+static bool backtrack_small_bound(RAnal *anal, RAnalBlock *bb, ut8 *bb_buf, int from, const char *reg, ut64 *cmp_val) {
+	char bound_reg[32];
+	if (R_STR_ISEMPTY (reg)) {
+		return false;
+	}
+	r_str_ncpy (bound_reg, reg, sizeof (bound_reg));
+	RAnalOp op = { 0 };
+	int i;
+	for (i = from; i >= 0; i--) {
+		const ut64 pos = r_anal_bb_offset_inst (bb, i);
+		const ut64 op_addr = r_anal_bb_opaddr_i (bb, i);
+		if (pos >= bb->size) {
+			continue;
+		}
+		const int buflen = bb->size - pos;
+		if (r_anal_op (anal, &op, op_addr, bb_buf + pos, buflen, R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL) < 1) {
+			r_anal_op_fini (&op);
+			continue;
+		}
+		RAnalValue *dst = RVecRArchValue_at (&op.dsts, 0);
+		RAnalValue *src = RVecRArchValue_at (&op.srcs, 0);
+		const char *dst_reg = (dst && dst->reg)? dst->reg: op.reg;
+		if (!dst_reg || strcmp (dst_reg, bound_reg)) {
+			r_anal_op_fini (&op);
+			continue;
+		}
+		const ut32 type = op.type & R_ANAL_OP_TYPE_MASK;
+		if (type == R_ANAL_OP_TYPE_LEA && op.disp > 0 && op.disp < 0x200) {
+			*cmp_val = op.disp;
+			r_anal_op_fini (&op);
+			return true;
+		}
+		if ((type == R_ANAL_OP_TYPE_ADD || type == R_ANAL_OP_TYPE_MOV) && op.val != UT64_MAX && op.val < 0x200) {
+			*cmp_val = op.val;
+			r_anal_op_fini (&op);
+			return true;
+		}
+		if (type == R_ANAL_OP_TYPE_MOV && src && src->reg) {
+			r_str_ncpy (bound_reg, src->reg, sizeof (bound_reg));
+			r_anal_op_fini (&op);
+			continue;
+		}
+		r_anal_op_fini (&op);
+		return false;
+	}
+	return false;
 }
 
 R_API bool try_get_delta_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 jmp_addr, ut64 lea_addr, ut64 *table_size, ut64 *default_case, st64 *start_casenum_shift) {
@@ -1148,6 +1246,19 @@ R_API bool try_get_jmptbl_info(RAnal *anal, RAnalFunction *fcn, ut64 addr, RAnal
 			continue;
 		}
 		isValid = jmptbl_cmp_info (&tmp_aop, false, table_size, &cmp_val, &cmp_reg);
+		if (isValid && tmp_aop.val == UT64_MAX) {
+			char bound_reg[32];
+			ut64 bound = UT64_MAX;
+			if (cmp_bound_reg (&tmp_aop, bound_reg, sizeof (bound_reg))
+					&& backtrack_small_bound (anal, prev_bb, bb_buf, i - 1, bound_reg, &bound)) {
+				cmp_val = bound;
+				const bool table_on_jump = prev_bb->jump == my_bb->addr;
+				const bool equal_skips_table = prev_bb->cond
+					&& ((table_on_jump && prev_bb->cond->type == R_ANAL_CONDTYPE_NE)
+						|| (!table_on_jump && prev_bb->cond->type == R_ANAL_CONDTYPE_EQ));
+				*table_size = equal_skips_table? bound: bound + 1;
+			}
+		}
 		if (tmp_aop.cond == R_ANAL_CONDTYPE_HI) {
 			*table_size = cmp_val;
 			r_anal_op_fini (&tmp_aop);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3555,6 +3555,13 @@ static bool cb_anal_jmptbl(void *user, void *data) {
 	return true;
 }
 
+static bool cb_anal_jmptbl_maxcases(void *user, void *data) {
+	RCore *core = (RCore *)user;
+	RConfigNode *node = (RConfigNode *)data;
+	core->anal->opt.jmptbl_maxcases = node->i_value;
+	return true;
+}
+
 static bool cb_anal_jmptbl_split(void *user, void *data) {
 	RCore *core = (RCore *)user;
 	RConfigNode *node = (RConfigNode *)data;
@@ -4042,6 +4049,7 @@ R_API int r_core_config_init(RCore *core) {
 	// SETCB ("arch.autoselect", "false", &cb_archautoselect, "automagically select matching decoder on arch related config changes (has no effect atm)");
 
 	SETCB ("anal.jmptbl", "true", &cb_anal_jmptbl, "analyze jump tables in switch statements");
+	SETICB ("anal.jmptbl.maxcases", R_ANAL_SWITCH_MAXCASES, &cb_anal_jmptbl_maxcases, "maximum number of jump table cases to analyze");
 	SETCB ("anal.jmptbl.split", "false", &cb_anal_jmptbl_split, "enable splitting blocks in jump table analysis");
 
 	SETCB ("anal.jmp.cref", "false", &cb_anal_cjmpref, "create references for conditional jumps");

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -3838,9 +3838,11 @@ static bool afbt_parse_kv(RCore *core, const char *args, RAnalSwitchSpec *spec) 
 			spec->esize = (ut8) r_num_math (core->num, v);
 		} else if (MATCH ("n")) {
 			const ut64 ncases = r_num_math (core->num, v);
-			if (ncases > R_ANAL_SWITCH_MAXCASES) {
-				R_LOG_WARN ("afbt: limiting ncases to %u", (unsigned)R_ANAL_SWITCH_MAXCASES);
-				spec->ncases = R_ANAL_SWITCH_MAXCASES;
+			const int maxcases = core->anal->opt.jmptbl_maxcases;
+			const ut32 limit = maxcases > 0? maxcases: R_ANAL_SWITCH_MAXCASES;
+			if (ncases > limit) {
+				R_LOG_WARN ("afbt: limiting ncases to %u", (unsigned)limit);
+				spec->ncases = limit;
 			} else {
 				spec->ncases = (ut32)ncases;
 			}

--- a/libr/core/pseudo.c
+++ b/libr/core/pseudo.c
@@ -1,4 +1,4 @@
-/* radare - LGPL - Copyright 2015-2025 - pancake */
+/* radare - LGPL - Copyright 2015-2026 - pancake */
 
 #include <r_core.h>
 
@@ -511,6 +511,9 @@ static ut64 emit_code_lines(PDCState *state, char *code, ut64 start_addr, int in
 			// drop tail goto into a structured loop header (the while/do owns that edge)
 			const char *t = r_str_trim_head_ro (line);
 			if (r_str_startswith (t, "goto ") || r_str_startswith (t, "jmp ")) {
+				if (strstr (t, "switch table")) {
+					continue;
+				}
 				const char *num = strstr (t, "0x");
 				if (num) {
 					ut64 dst = r_num_get (NULL, num);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -460,6 +460,7 @@ typedef struct r_anal_options_t {
 	bool nopskip; // skip nops at the beginning of functions
 	int hpskip; // skip `mov reg,reg` and `lea reg,[reg]`
 	int jmptbl; // analyze jump tables
+	int jmptbl_maxcases; // maximum number of jump table cases to analyze
 	bool jmptbl_split; // enable splitting blocks in jump table analysis
 	int nonull;
 	bool pushret; // analyze push+ret as jmp

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -61,6 +61,30 @@ CODE 0x0000002c 0x00000036 case.0x2c.1
 EOF
 RUN
 
+NAME=x86_64 nested jmptbl keeps switch metadata after split
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 83fa00773b488d056400000048630c904801c1ffe1488d055c00000048630c904801c1ffe1c3c300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a5ffffff00000000a8ffffffadffffff
+s 0
+afr
+afbt @ 0x23
+axff~0x00000023
+EOF
+EXPECT=<<EOF
+switch at  0x23
+  jtbl     0x78
+  esize    4
+  ncases   2
+  shift    0
+  default  0xffffffffffffffff
+  lowcase  0
+CODE 0x00000023 0x00000020 case.0x23.0
+CODE 0x00000023 0x00000025 case.0x23.1
+EOF
+RUN
+
 NAME=x86_64 getenv this maybe & jmp noret fix
 FILE=bins/elf/ls.odd
 CMDS=<<EOF

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -41,6 +41,26 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=x86_64 rust niche jmptbl autosize stops before adjacent table
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 49bf00000000000000804c8b24244c89e04c31f84d85e46a0159480f48c8488d053b00000048630c884801c1ffe1eb1890eb1590eb1290eb0f909090909090909090909090909090c390909090909090c3909090909090909090909090909090ceffffffd6ffffffd0ffffffd3fffffff0ffffff
+s 0
+afr
+CC. @ 0x2c
+axff~0x0000002c
+EOF
+EXPECT=<<EOF
+switch table (4 cases) at 0x60
+CODE 0x0000002c 0x0000002e case.0x2c.0
+CODE 0x0000002c 0x00000030 case.0x2c.2
+CODE 0x0000002c 0x00000033 case.0x2c.3
+CODE 0x0000002c 0x00000036 case.0x2c.1
+EOF
+RUN
+
 NAME=x86_64 getenv this maybe & jmp noret fix
 FILE=bins/elf/ls.odd
 CMDS=<<EOF

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -206,6 +206,24 @@ void sym.func.100003a54 (int64_t arg1, int64_t arg2) {
 EOF
 RUN
 
+NAME=pdc suppress switch table goto
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 49bf00000000000000804c8b24244c89e04c31f84d85e46a0159480f48c8488d053b00000048630c884801c1ffe1eb1890eb1590eb1290eb0f909090909090909090909090909090c390909090909090c3909090909090909090909090909090ceffffffd6ffffffd0ffffffd3fffffff0ffffff
+s 0
+afr
+pdc~goto loc_rcx
+?e --
+pdc~switch (switch_var)
+EOF
+EXPECT=<<EOF
+--
+    switch (switch_var) { // jump table of 4 cases at 0x00000000
+EOF
+RUN
+
 NAME=movk pseudo
 FILE=-
 CMDS=<<EOF

--- a/test/db/cmd/numvars
+++ b/test/db/cmd/numvars
@@ -217,7 +217,7 @@ afl
 ?vi $BF
 EOF
 EXPECT=<<EOF
-0x00011e90  285   7152 main
+0x00011e90  286   7152 main
 9320
 7152
 9320


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
