### PR TITLE
Fix use-after-free when commenting in visual mode

### DIFF
--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -85,14 +85,13 @@ R_IPI void visual_add_comment(RCore *core, ut64 at) {
 			} else {
 				// Open editor with current comment
 				const char *current_comment = r_meta_get_string (core->anal, R_META_TYPE_COMMENT, at);
-				if (current_comment) {
-					r_meta_del (core->anal, R_META_TYPE_COMMENT, at, 1);
-				}
 				char *out = r_core_editor (core, NULL, current_comment);
 				if (out) {
 					r_str_ansi_strip (out);
 					r_meta_set_string (core->anal, R_META_TYPE_COMMENT, at, out);
 					free (out);
+				} else {
+					r_meta_del (core->anal, R_META_TYPE_COMMENT, at, 1);
 				}
 			}
 			break;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This also caused a bug in which the existing comment was deleted (turned into gibberish) when attempting to comment again. The gibberish was then displayed in the editor. Instead of unconditionally deleting the existing comment (before using it), we should only delete it after it is passed to the editor. Note that this will still delete the existing comment if there was an error with the editor (which is tbh unintuitive).
