### PR TITLE
Add bin.relocs.xrefs to avoid creating them if not needed ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2487,6 +2487,7 @@ void *MACH0_(mach0_free)(struct MACH0_(obj_t) * mo) {
 	if (mo->relocs_loaded) {
 		r_skiplist_free (mo->relocs_cache);
 	}
+	r_list_free (mo->reloc_fixups);
 	free_chained_starts (mo);
 	sdb_free (mo->kv);
 	r_unref (mo->b);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1862,6 +1862,7 @@ typedef struct {
 	bool keep_lib;
 	const char *lang;
 	bool is_sandbox;
+	bool reloc_xrefs;
 	bool is_pe;
 	bool is32;
 } RelocInfo;
@@ -1870,6 +1871,7 @@ static void ri_init(RCore *core, RelocInfo *ri) {
 	ri->core = core;
 	ri->bin_demangle = r_config_get_b (core->config, "bin.demangle");
 	ri->keep_lib = r_config_get_b (core->config, "bin.demangle.pfxlib");
+	ri->reloc_xrefs = r_config_get_b (core->config, "bin.relocs.xrefs");
 	ri->lang = r_config_get (core->config, "bin.lang");
 	const RBinInfo *info = r_bin_get_info (core->bin);
 	const char *rclass = info->rclass;
@@ -1944,8 +1946,9 @@ static void set_bin_relocs(RelocInfo *ri, RBinReloc *reloc, ut64 addr, Sdb **db,
 			R_LOG_DEBUG ("Naming fixup reloc with string %s", name);
 			free (reloc_name);
 			reloc_name = r_str_newf ("fixup.%s", name);
-			// add xref from fixup to string
-			r_anal_xrefs_set (core->anal, reloc->vaddr, reloc->addend, R_ANAL_REF_TYPE_DATA);
+			if (ri->reloc_xrefs) {
+				r_anal_xrefs_set (core->anal, reloc->vaddr, reloc->addend, R_ANAL_REF_TYPE_DATA);
+			}
 		} else {
 			free (reloc_name);
 			return;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4350,6 +4350,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETCB ("bin.dbginfo", "true", &cb_bindbginfo, "load debug information at startup if available");
 	SETB ("bin.relocs", "true", "load relocs information at startup if available");
 	SETB ("bin.relocs.apply", "false", "apply reloc information");
+	SETB ("bin.relocs.xrefs", "true", "register xrefs from reloc information");
 	SETICB ("bin.maxsymlen", 0, &cb_binmaxsymlen, "maximum length for symbol names");
 	SETICB ("bin.str.min", 0, &cb_binminstr, "minimum string length for r_bin");
 	SETICB ("bin.str.max", 0, &cb_binmaxstr, "maximum string length for r_bin");

--- a/test/db/formats/mach0/mach0
+++ b/test/db/formats/mach0/mach0
@@ -63,6 +63,15 @@ pf.mach0_dylib_command @ 0x0000147c
 EOF
 RUN
 
+NAME=mach0 chained fixup xrefs config
+ARGS=-e bin.relocs.xrefs=false
+FILE=bins/mach0/hello-macos-arm64-chained
+CMDS=axlc
+EXPECT=<<EOF
+0
+EOF
+RUN
+
 NAME=mach0 headers big-endian
 FILE=bins/mach0/ppc-ls
 CMDS=iH


### PR DESCRIPTION
maybe at some point we can disable them by default