### PR TITLE
Improve RBitMap and fix some bugs ##perf

### DIFF
--- a/libr/bin/format/dmp/dmp64.c
+++ b/libr/bin/format/dmp/dmp64.c
@@ -91,8 +91,15 @@ static int r_bin_dmp64_init_header(struct r_bin_dmp64_obj_t *obj) {
 }
 
 static int r_bin_dmp64_init_bmp_pages(struct r_bin_dmp64_obj_t *obj) {
-	int i;
 	if (!obj->bmp_header) {
+		return false;
+	}
+	ut64 pages = obj->bmp_header->Pages;
+	if (!pages || pages > SZT_MAX) {
+		return false;
+	}
+	size_t num_pages = (size_t)pages;
+	if (num_pages > SIZE_MAX - 7) {
 		return false;
 	}
 	obj->pages = r_list_newf (free);
@@ -100,29 +107,29 @@ static int r_bin_dmp64_init_bmp_pages(struct r_bin_dmp64_obj_t *obj) {
 		return false;
 	}
 	ut64 paddr_base = obj->bmp_header->FirstPage;
-	int num_pages = obj->bmp_header->Pages;
-	if (num_pages < 1) {
+	RBitmap *bitmap = r_bitmap_new (num_pages);
+	if (!bitmap) {
 		return false;
 	}
-	RBitmap *bitmap = r_bitmap_new (num_pages);
-	r_bitmap_set_bytes (bitmap, obj->bitmap, num_pages / 8);
+	r_bitmap_set_bytes (bitmap, obj->bitmap, (num_pages + 7) / 8);
 
 	ut64 num_bitset = 0;
-	for (i = 0; i < num_pages; i++) {
-		if (!r_bitmap_test(bitmap, i)) {
-			continue;
-		}
+	size_t i = 0;
+	while ((i = r_bitmap_find_next_set (bitmap, i)) != SZT_MAX) {
 		dmp_page_desc *page = R_NEW0 (dmp_page_desc);
 		if (R_UNLIKELY (!page)) {
+			r_bitmap_free (bitmap);
 			return false;
 		}
-		page->start = i * DMP_PAGE_SIZE;
+		page->start = (ut64)i * DMP_PAGE_SIZE;
 		page->file_offset = paddr_base + num_bitset * DMP_PAGE_SIZE;
 		r_list_append (obj->pages, page);
 		num_bitset++;
+		i++;
 	}
 	if (obj->bmp_header->TotalPresentPages != num_bitset) {
 		R_LOG_WARN ("TotalPresentPages not matched");
+		r_bitmap_free (bitmap);
 		return false;
 	}
 
@@ -147,12 +154,19 @@ static int r_bin_dmp64_init_bmp_header(struct r_bin_dmp64_obj_t *obj) {
 		R_LOG_WARN ("Invalid Bitmap Magic");
 		return false;
 	}
-	ut64 bitmapsize = obj->bmp_header->Pages / 8;
+	if (obj->bmp_header->Pages > UT64_MAX - 7) {
+		R_LOG_WARN ("Invalid Bitmap Size");
+		return false;
+	}
+	ut64 bitmapsize = (obj->bmp_header->Pages + 7) / 8;
 	if (bitmapsize < 1 || bitmapsize > ST32_MAX) {
 		R_LOG_WARN ("Invalid Bitmap Size");
 		return false;
 	}
 	obj->bitmap = calloc (1, bitmapsize);
+	if (!obj->bitmap) {
+		return false;
+	}
 	if (r_buf_read_at (obj->b, sizeof (dmp64_header) + offsetof (dmp_bmp_header, Bitmap), obj->bitmap, bitmapsize) < 0) {
 		R_LOG_WARN ("read bitmap");
 		return false;
@@ -169,8 +183,9 @@ static int r_bin_dmp64_init(struct r_bin_dmp64_obj_t *obj) {
 	switch (obj->header->DumpType) {
 	case DMP_DUMPTYPE_BITMAPFULL:
 	case DMP_DUMPTYPE_BITMAPKERNEL:
-		r_bin_dmp64_init_bmp_header (obj);
-		r_bin_dmp64_init_bmp_pages (obj);
+		if (!r_bin_dmp64_init_bmp_header (obj) || !r_bin_dmp64_init_bmp_pages (obj)) {
+			return false;
+		}
 		break;
 	case DMP_DUMPTYPE_FULL:
 		r_bin_dmp64_init_memory_runs (obj);

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -2115,6 +2115,12 @@ static void pfb(RCore *core, const char *arg, int mode) {
 	}
 
 	RBitmap *bm = r_bitmap_new (core->blocksize * 8);
+	if (!bm) {
+		R_LOG_ERROR ("Cannot allocate bitmap");
+		r_list_free (lnames);
+		pj_free (pj);
+		return;
+	}
 	r_bitmap_set_bytes (bm, core->block, core->blocksize);
 	RList *lart = lart_new ();
 

--- a/libr/include/r_util/r_bitmap.h
+++ b/libr/include/r_util/r_bitmap.h
@@ -25,16 +25,20 @@ extern "C" {
 #endif
 
 typedef struct r_bitmap_t {
-	int length;
+	size_t length;
 	RBitword *bitmap;
 } RBitmap;
 
 R_API RBitmap *r_bitmap_new(size_t len);
-R_API void r_bitmap_set_bytes(RBitmap *b, const ut8 *buf, int len);
+/* len is the number of bytes available in buf */
+R_API void r_bitmap_set_bytes(RBitmap *b, const ut8 *buf, size_t len);
 R_API void r_bitmap_free(RBitmap *b);
 R_API void r_bitmap_set(RBitmap *b, size_t bit);
 R_API void r_bitmap_unset(RBitmap *b, size_t bit);
-R_API int r_bitmap_test(RBitmap *b, size_t bit);
+R_API bool r_bitmap_test(const RBitmap *b, size_t bit);
+R_API size_t r_bitmap_count(const RBitmap *b);
+/* returns the next set bit at or after from, or SZT_MAX if none */
+R_API size_t r_bitmap_find_next_set(const RBitmap *b, size_t from);
 
 #ifdef __cplusplus
 }

--- a/libr/util/bitmap.c
+++ b/libr/util/bitmap.c
@@ -54,23 +54,14 @@ static RBitword bitmap_tail_mask(size_t bits) {
 }
 
 R_API RBitmap *r_bitmap_new(size_t len) {
-	RBitmap *b = R_NEW0 (RBitmap);
-	if (!b) {
-		return NULL;
-	}
 	size_t word_count = 0;
 	if (!bitmap_word_count (len, &word_count)) {
-		free (b);
 		return NULL;
 	}
+	RBitmap *b = R_NEW0 (RBitmap);
 	b->length = len;
 	if (!word_count) {
 		return b;
-	}
-	size_t alloc_size = 0;
-	if (r_mul_overflow_size_t (word_count, sizeof (RBitword), &alloc_size)) {
-		free (b);
-		return NULL;
 	}
 	b->bitmap = calloc (word_count, sizeof (RBitword));
 	if (!b->bitmap) {
@@ -107,26 +98,23 @@ R_API void r_bitmap_free(RBitmap *b) {
 R_API void r_bitmap_set(RBitmap *b, size_t bit) {
 	R_RETURN_IF_FAIL (b);
 	if (bit < b->length) {
-		b->bitmap[(bit >> BITWORD_BITS_SHIFT)] |=
-			((RBitword)1 << (bit & BITWORD_BITS_MASK));
+		b->bitmap[bit >> BITWORD_BITS_SHIFT] |= (RBitword)1 << (bit & BITWORD_BITS_MASK);
 	}
 }
 
 R_API void r_bitmap_unset(RBitmap *b, size_t bit) {
 	R_RETURN_IF_FAIL (b);
 	if (bit < b->length) {
-		b->bitmap[(bit >> BITWORD_BITS_SHIFT)] &=
-			~((RBitword)1 << (bit & BITWORD_BITS_MASK));
+		b->bitmap[bit >> BITWORD_BITS_SHIFT] &= ~((RBitword)1 << (bit & BITWORD_BITS_MASK));
 	}
 }
 
 R_API bool r_bitmap_test(const RBitmap *b, size_t bit) {
 	R_RETURN_VAL_IF_FAIL (b, false);
-	if (bit < b->length) {
-		RBitword bword = b->bitmap[bit >> BITWORD_BITS_SHIFT];
-		return BITWORD_TEST (bword, (bit & BITWORD_BITS_MASK));
+	if (bit >= b->length) {
+		return false;
 	}
-	return false;
+	return BITWORD_TEST (b->bitmap[bit >> BITWORD_BITS_SHIFT], bit & BITWORD_BITS_MASK);
 }
 
 R_API size_t r_bitmap_count(const RBitmap *b) {
@@ -136,15 +124,13 @@ R_API size_t r_bitmap_count(const RBitmap *b) {
 		return 0;
 	}
 	R_RETURN_VAL_IF_FAIL (b->bitmap, 0);
+	const size_t last = word_count - 1;
 	size_t count = 0;
 	size_t i;
-	for (i = 0; i < word_count; i++) {
-		RBitword word = b->bitmap[i];
-		if (i == word_count - 1) {
-			word &= bitmap_tail_mask (b->length);
-		}
-		count += BITWORD_POPCOUNT (word);
+	for (i = 0; i < last; i++) {
+		count += BITWORD_POPCOUNT (b->bitmap[i]);
 	}
+	count += BITWORD_POPCOUNT (b->bitmap[last] & bitmap_tail_mask (b->length));
 	return count;
 }
 
@@ -158,23 +144,22 @@ R_API size_t r_bitmap_find_next_set(const RBitmap *b, size_t from) {
 		return SZT_MAX;
 	}
 	R_RETURN_VAL_IF_FAIL (b->bitmap, SZT_MAX);
-	size_t word_index = from >> BITWORD_BITS_SHIFT;
+	const size_t last = word_count - 1;
+	size_t idx = from >> BITWORD_BITS_SHIFT;
 	const size_t start_bit = from & BITWORD_BITS_MASK;
-	RBitword word = b->bitmap[word_index];
+	RBitword word = b->bitmap[idx];
 	if (start_bit) {
 		word &= ~(((RBitword)1 << start_bit) - 1);
 	}
-	while (word_index < word_count) {
-		if (word_index == word_count - 1) {
-			word &= bitmap_tail_mask (b->length);
-		}
+	while (idx < last) {
 		if (word) {
-			return (word_index << BITWORD_BITS_SHIFT) + BITWORD_CTZ (word);
+			return (idx << BITWORD_BITS_SHIFT) + BITWORD_CTZ (word);
 		}
-		word_index++;
-		if (word_index < word_count) {
-			word = b->bitmap[word_index];
-		}
+		word = b->bitmap[++idx];
+	}
+	word &= bitmap_tail_mask (b->length);
+	if (word) {
+		return (last << BITWORD_BITS_SHIFT) + BITWORD_CTZ (word);
 	}
 	return SZT_MAX;
 }

--- a/libr/util/bitmap.c
+++ b/libr/util/bitmap.c
@@ -2,38 +2,110 @@
 
 #include <r_util.h>
 
-#define BITMAP_TEST 0
-
 #define BITWORD_BITS (sizeof (RBitword) * 8)
 #define BITWORD_BITS_MASK (BITWORD_BITS - 1)
-#define BITWORD_MULT(bit)  (((bit) + (BITWORD_BITS_MASK)) & ~(BITWORD_BITS_MASK))
-#define BITWORD_TEST(x, y) (((x)>>(y)) & 1)
+#define BITWORD_TEST(x, y) (((x) >> (y)) & 1)
 
-#define BITMAP_WORD_COUNT(bit) (BITWORD_MULT(bit) >> BITWORD_BITS_SHIFT)
+#if defined(__GNUC__) || defined(__clang__)
+#define BITWORD_POPCOUNT(x) __builtin_popcountll ((unsigned long long)(x))
+#define BITWORD_CTZ(x)      __builtin_ctzll ((unsigned long long)(x))
+#else
+static inline int BITWORD_POPCOUNT(RBitword x) {
+	int count = 0;
+	while (x) {
+		x &= x - 1;
+		count++;
+	}
+	return count;
+}
+
+static inline int BITWORD_CTZ(RBitword x) {
+	int count = 0;
+	while (!(x & 1)) {
+		x >>= 1;
+		count++;
+	}
+	return count;
+}
+#endif
+
+static bool bitmap_word_count(size_t bits, size_t *count) {
+	if (bits > SIZE_MAX - BITWORD_BITS_MASK) {
+		return false;
+	}
+	*count = (bits + BITWORD_BITS_MASK) >> BITWORD_BITS_SHIFT;
+	return true;
+}
+
+static bool bitmap_byte_count(size_t bits, size_t *count) {
+	if (bits > SIZE_MAX - 7) {
+		return false;
+	}
+	*count = (bits + 7) >> 3;
+	return true;
+}
+
+static RBitword bitmap_tail_mask(size_t bits) {
+	const size_t tail = bits & BITWORD_BITS_MASK;
+	if (!tail) {
+		return (RBitword)~(RBitword)0;
+	}
+	return ((RBitword)1 << tail) - 1;
+}
 
 R_API RBitmap *r_bitmap_new(size_t len) {
 	RBitmap *b = R_NEW0 (RBitmap);
 	if (!b) {
 		return NULL;
 	}
+	size_t word_count = 0;
+	if (!bitmap_word_count (len, &word_count)) {
+		free (b);
+		return NULL;
+	}
 	b->length = len;
-	b->bitmap = calloc (BITMAP_WORD_COUNT (len), sizeof (RBitword));
+	if (!word_count) {
+		return b;
+	}
+	size_t alloc_size = 0;
+	if (r_mul_overflow_size_t (word_count, sizeof (RBitword), &alloc_size)) {
+		free (b);
+		return NULL;
+	}
+	b->bitmap = calloc (word_count, sizeof (RBitword));
+	if (!b->bitmap) {
+		free (b);
+		return NULL;
+	}
 	return b;
 }
 
-R_API void r_bitmap_set_bytes(RBitmap *b, const ut8 *buf, int len) {
-	if (b->length < len) {
-		len = b->length;
+R_API void r_bitmap_set_bytes(RBitmap *b, const ut8 *buf, size_t len) {
+	R_RETURN_IF_FAIL (b);
+	size_t byte_count = 0;
+	if (!bitmap_byte_count (b->length, &byte_count)) {
+		return;
 	}
+	if (len > byte_count) {
+		len = byte_count;
+	}
+	if (!len) {
+		return;
+	}
+	R_RETURN_IF_FAIL (buf && b->bitmap);
 	memcpy (b->bitmap, buf, len);
 }
 
 R_API void r_bitmap_free(RBitmap *b) {
+	if (!b) {
+		return;
+	}
 	free (b->bitmap);
 	free (b);
 }
 
 R_API void r_bitmap_set(RBitmap *b, size_t bit) {
+	R_RETURN_IF_FAIL (b);
 	if (bit < b->length) {
 		b->bitmap[(bit >> BITWORD_BITS_SHIFT)] |=
 			((RBitword)1 << (bit & BITWORD_BITS_MASK));
@@ -41,16 +113,68 @@ R_API void r_bitmap_set(RBitmap *b, size_t bit) {
 }
 
 R_API void r_bitmap_unset(RBitmap *b, size_t bit) {
+	R_RETURN_IF_FAIL (b);
 	if (bit < b->length) {
 		b->bitmap[(bit >> BITWORD_BITS_SHIFT)] &=
 			~((RBitword)1 << (bit & BITWORD_BITS_MASK));
 	}
 }
 
-R_API int r_bitmap_test(RBitmap *b, size_t bit) {
+R_API bool r_bitmap_test(const RBitmap *b, size_t bit) {
+	R_RETURN_VAL_IF_FAIL (b, false);
 	if (bit < b->length) {
-		RBitword bword = b->bitmap[ (bit >> BITWORD_BITS_SHIFT)];
+		RBitword bword = b->bitmap[bit >> BITWORD_BITS_SHIFT];
 		return BITWORD_TEST (bword, (bit & BITWORD_BITS_MASK));
 	}
-	return -1;
+	return false;
+}
+
+R_API size_t r_bitmap_count(const RBitmap *b) {
+	R_RETURN_VAL_IF_FAIL (b, 0);
+	size_t word_count = 0;
+	if (!bitmap_word_count (b->length, &word_count) || !word_count) {
+		return 0;
+	}
+	R_RETURN_VAL_IF_FAIL (b->bitmap, 0);
+	size_t count = 0;
+	size_t i;
+	for (i = 0; i < word_count; i++) {
+		RBitword word = b->bitmap[i];
+		if (i == word_count - 1) {
+			word &= bitmap_tail_mask (b->length);
+		}
+		count += BITWORD_POPCOUNT (word);
+	}
+	return count;
+}
+
+R_API size_t r_bitmap_find_next_set(const RBitmap *b, size_t from) {
+	R_RETURN_VAL_IF_FAIL (b, SZT_MAX);
+	if (from >= b->length) {
+		return SZT_MAX;
+	}
+	size_t word_count = 0;
+	if (!bitmap_word_count (b->length, &word_count) || !word_count) {
+		return SZT_MAX;
+	}
+	R_RETURN_VAL_IF_FAIL (b->bitmap, SZT_MAX);
+	size_t word_index = from >> BITWORD_BITS_SHIFT;
+	const size_t start_bit = from & BITWORD_BITS_MASK;
+	RBitword word = b->bitmap[word_index];
+	if (start_bit) {
+		word &= ~(((RBitword)1 << start_bit) - 1);
+	}
+	while (word_index < word_count) {
+		if (word_index == word_count - 1) {
+			word &= bitmap_tail_mask (b->length);
+		}
+		if (word) {
+			return (word_index << BITWORD_BITS_SHIFT) + BITWORD_CTZ (word);
+		}
+		word_index++;
+		if (word_index < word_count) {
+			word = b->bitmap[word_index];
+		}
+	}
+	return SZT_MAX;
 }

--- a/test/unit/test_bitmap.c
+++ b/test/unit/test_bitmap.c
@@ -11,7 +11,7 @@ bool test_r_bitmap_set(void) {
 		r_bitmap_set (bitmap, values[i]);
 	}
 	for (i = 0; i < len; i++) {
-		mu_assert_eq (r_bitmap_test(bitmap, values[i]), true,
+		mu_assert_eq (r_bitmap_test (bitmap, values[i]), true,
 				"Bit should be set.");
 	}
 	for (i = 0; i < len; i++) {
@@ -25,8 +25,28 @@ bool test_r_bitmap_set(void) {
 	mu_end;
 }
 
+bool test_r_bitmap_set_bytes(void) {
+	const ut8 bytes[] = { 0xb2, 0x03, 0xff };
+	RBitmap *bitmap = r_bitmap_new (10);
+	r_bitmap_set_bytes (bitmap, bytes, sizeof (bytes));
+	mu_assert_eq (r_bitmap_count (bitmap), 6, "Count should ignore tail bits.");
+	mu_assert_eq (r_bitmap_test (bitmap, 0), false, "Bit should not be set.");
+	mu_assert_eq (r_bitmap_test (bitmap, 1), true, "Bit should be set.");
+	mu_assert_eq (r_bitmap_test (bitmap, 10), false, "Out of range bit should be false.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 0), 1, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 2), 4, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 5), 5, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 6), 7, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 8), 8, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 9), 9, "Next set bit mismatch.");
+	mu_assert_eq (r_bitmap_find_next_set (bitmap, 10), SZT_MAX, "No set bit expected.");
+	r_bitmap_free (bitmap);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_r_bitmap_set);
+	mu_run_test (test_r_bitmap_set_bytes);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
  What changed:

  - RBitmap.length is now size_t.
  - r_bitmap_new handles backing allocation failure.
  - r_bitmap_set_bytes now treats len as bytes and clamps by bitmap byte
    capacity.
  - r_bitmap_test returns bool.
  - Added r_bitmap_count and r_bitmap_find_next_set.
  - Updated the DMP64 bitmap page loop to use r_bitmap_find_next_set.
  - Added focused bitmap unit coverage.
