### PR TITLE
Fix Coverity static analysis findings ##bin

### DIFF
--- a/libr/bin/p/bin_p9.c
+++ b/libr/bin/p/bin_p9.c
@@ -365,6 +365,7 @@ static bool symbols_vec(RBinFile *bf) {
 	SymVec *history = NULL; // <Sym>
 	HtUP *histories = NULL; // <ut64, SymVec *>
 	StrVec *names = NULL; // <char *>
+	RList *all_histories = NULL; // owns every allocated SymVec*
 	const RBinPlan9Obj *o = (RBinPlan9Obj *)bf->bo->bin_obj;
 	ut64 i;
 	Sym sym = {0};
@@ -377,7 +378,16 @@ static bool symbols_vec(RBinFile *bf) {
 		goto error;
 	}
 
+	if (!(all_histories = r_list_newf ((RListFree)SymVec_free))) {
+		goto error;
+	}
+
 	const ut64 syms = o->header_size + o->header.text + o->header.data;
+	const ut64 bsize = r_buf_size (bf->buf);
+	// clamp tainted header fields against the actual buffer size
+	if (syms > bsize || o->header.syms > bsize - syms) {
+		goto error;
+	}
 
 	ut64 offset = 0;
 	while (offset < o->header.syms) {
@@ -389,7 +399,7 @@ static bool symbols_vec(RBinFile *bf) {
 
 		// source file name components
 		if (sym.type == 'f') {
-			if (sym.value * 4 > r_buf_size (bf->buf)) {
+			if (sym.value > bsize / 4) {
 				R_LOG_ERROR ("Prevented huge memory allocation");
 				break;
 			}
@@ -453,6 +463,11 @@ static bool symbols_vec(RBinFile *bf) {
 
 			if (!history) {
 				history = SymVec_new ();
+				if (!history) {
+					free (name);
+					goto error;
+				}
+				r_list_append (all_histories, history);
 			}
 
 			Sym history_sym = {sym.value, 'z', name};
@@ -510,6 +525,10 @@ static bool symbols_vec(RBinFile *bf) {
 	history = NULL;
 
 	const ut64 pcs = syms + o->header.syms + o->header.spsz;
+	// clamp tainted header fields against the actual buffer size
+	if (pcs > bsize || o->header.pcsz > bsize - pcs) {
+		goto error;
+	}
 
 	ut64 line = 0;
 	// base address (for kernels the header is NOT mapped)
@@ -556,11 +575,13 @@ static bool symbols_vec(RBinFile *bf) {
 
 	ht_up_free (histories);
 	StrVec_free (names);
+	r_list_free (all_histories);
 	return true;
 error:
 	sym_fini_vec (&sym);
 	StrVec_free (names);
 	ht_up_free (histories);
+	r_list_free (all_histories);
 	return false;
 }
 

--- a/libr/bin/p/bin_pe.inc.c
+++ b/libr/bin/p/bin_pe.inc.c
@@ -525,7 +525,9 @@ static bool symbols_vec(RBinFile *bf) {
 						// Add methoddef at its RVA
 						ptr = RVecRBinSymbol_emplace_back (ret);
 						if (dsym->namespace && dsym->namespace[0]) {
-							ptr->name = r_bin_name_new (r_str_newf ("%s.%s", dsym->namespace, dsym->name));
+							char *full_name = r_str_newf ("%s.%s", dsym->namespace, dsym->name);
+							ptr->name = r_bin_name_new (full_name);
+							free (full_name);
 						} else {
 							ptr->name = r_bin_name_new (dsym->name);
 						}

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -903,10 +903,17 @@ static bool symbols_vec(RBinFile *bf) {
 	if (exportHashTablePower >= 30) {
 		return true;
 	}
+	// guard against a hostile exportedSymbolCount that would overflow
+	// the ut32 arithmetic below (stringLenTable + 4 * exportedSymbolCount)
+	// and against using it as a loop boundary
+	if (exportedSymbolCount > 0x10000000) {
+		return true;
+	}
 	ut64 hashTableSize = 4ULL << exportHashTablePower;
 	if (hashTableSize > 0xffffffffULL) {
 		return true;
 	}
+	const ut64 bsize = r_buf_size (bf->buf);
 	ut32 stringLenTable = pef->ldrsec + exportHashOffset + (ut32)hashTableSize;
 	ut32 exportTable = stringLenTable + 4 * exportedSymbolCount;
 	int i;
@@ -922,8 +929,12 @@ static bool symbols_vec(RBinFile *bf) {
 		if (index < 0 || index >= pef->nsec) {
 			continue; // re-exported func or absolute mem address, not supported
 		}
+		// guard against tainted nameLen/nameOfs that would read past the buffer
+		if (nameOfs > bsize || (ut64)nameLen > bsize - nameOfs) {
+			continue;
+		}
 
-		char *name = calloc (1, nameLen + 1); // +1 for the null terminator, which is not on disk
+		char *name = calloc (1, (size_t)nameLen + 1); // +1 for the null terminator, which is not on disk
 		if (!name) {
 			continue;
 		}

--- a/libr/util/markdown.c
+++ b/libr/util/markdown.c
@@ -366,6 +366,7 @@ R_API char *r_str_md2txt(const char *page, bool usecolor, bool useutf8, void *co
 						} else {
 							r_strbuf_append (sb, "   \n");
 						}
+						free (line);
 						p = nextlist + 1;
 						nextlist = strstr (p, "\n");
 					}


### PR DESCRIPTION
- bin_p9.c (CID 1659642, 1659638): track every allocated SymVec via an
  owning RList so duplicate hashmap entries are freed exactly once and
  the trailing/error-path orphan history is no longer leaked. Clamp the
  tainted header.syms/header.pcsz/sym.value fields against the buffer
  size before using them as loop bounds.
- bin_pe.inc.c (CID 1659639): free the r_str_newf result after handing
  it to r_bin_name_new, which strdups its input.
- bin_pef.c (CID 1659640, 1659638): bound exportedSymbolCount before it
  is used in arithmetic/as a loop limit, and bounds-check tainted
  nameOfs/nameLen before reading or allocating.
- markdown.c (CID 1659641): free the per-iteration r_str_ndup line in
  r_str_md2txt's headline-rendering loop.