### PR TITLE
Fix Dalvik get_name ownership mismatch ##crash

### DIFF
--- a/libr/arch/p/dalvik/plugin.c
+++ b/libr/arch/p/dalvik/plugin.c
@@ -15,7 +15,8 @@ static inline ut64 _anal_get_offset(RArch *a, int type, int idx) {
 
 static inline char *_anal_get_name(RArch *a, int type, int idx) {
 	if (a && a->binb.bin && a->binb.get_name) {
-		return (char *)a->binb.get_name (a->binb.bin, type, idx, false);
+		const char *name = a->binb.get_name (a->binb.bin, type, idx, false);
+		return name? strdup (name): NULL;
 				// (bool)a->coreb.cfggeti (a->coreb.core, "asm.pseudo"));
 	}
 	return NULL;


### PR DESCRIPTION
### Motivation
- The DEX prototype cache began returning cache-owned strings from `dex_get_proto()`, while the Dalvik decoder continued to assume `get_name` returns caller-owned strings and unconditionally frees them, leading to use-after-free/double-free during analysis.

### Description
- Duplicate the `get_name` result at the decoder boundary by updating `_anal_get_name()` in `libr/arch/p/dalvik/plugin.c` to `strdup` the returned `const char *` and return a caller-owned `char *`, preserving existing decoder semantics and avoiding freeing cache-owned pointers.

### Testing
- Verified the source change and context with `sed -n '1,120p' libr/arch/p/dalvik/plugin.c`, inspected the patched lines with `nl -ba libr/arch/p/dalvik/plugin.c | sed -n '10,35p'`, and created the commit with `git commit` (patch applied and recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00bb8dbe048331a9fcffef17d6805f)