### PR TITLE
Restore snapshot iteration to avoid iterator invalidation in type propagation

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -1589,12 +1589,10 @@ repeat:
 	}
 
 	// Type propagation for register based args
+	RVecAnalVarPtr *rvars = r_anal_var_vec (anal, fcn, R_ANAL_VAR_KIND_REG);
 	RAnalVar **rvarp;
-	R_VEC_FOREACH (&fcn->vars, rvarp) {
+	R_VEC_FOREACH (rvars, rvarp) {
 		RAnalVar *rvar = *rvarp;
-		if (rvar->kind != R_ANAL_VAR_KIND_REG) {
-			continue;
-		}
 		RAnalVar *lvar = r_anal_var_get_dst_var (rvar);
 		RRegItem *i = r_reg_index_get (anal->reg, rvar->delta);
 		if (i && lvar) {
@@ -1604,6 +1602,7 @@ repeat:
 			var_retype (anal, lvar, NULL, rvar->type, false, false);
 		}
 	}
+	RVecAnalVarPtr_free (rvars);
 out_function:
 	r_anal_op_fini (&aop);
 out_function_no_aop:


### PR DESCRIPTION
### Motivation
- Fix a high-severity iterator invalidation in register-argument type propagation where iterating directly over `&fcn->vars` could be mutated by `var_retype()` -> `r_anal_var_set_type()` -> `shadow_var_struct_members()`, causing out-of-bounds access or crashes.  

### Description
- Replace the unsafe `R_VEC_FOREACH(&fcn->vars, ...)` with a stable snapshot obtained via `r_anal_var_vec(anal, fcn, R_ANAL_VAR_KIND_REG)`, iterate over that snapshot, and free it after use, removing the now-unnecessary in-loop kind check.  

### Testing
- Attempted a local build with `make -j` but it failed in this environment due to a missing `libr/config.mk`, so a full build/test run could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63a24668c8331beb54085d5cf2efe)