### PR TITLE
Fix zip source double free in fs_zip_dir

### DIFF
--- a/libr/fs/p/fs_zip.c
+++ b/libr/fs/p/fs_zip.c
@@ -189,7 +189,6 @@ static RList *fs_zip_dir(RFSRoot *root, const char *path, R_UNUSED int view) {
 	}
 
 	zip_close (za);
-	zip_source_free (zs);
 	free (buf);
 	if (!hasdir || hasfailed) {
 		r_list_free (list);

--- a/libr/fs/p/fs_zip.c
+++ b/libr/fs/p/fs_zip.c
@@ -104,6 +104,19 @@ static void append_file(RList *list, const char *name, int type, int time, ut64 
 	}
 }
 
+static void fs_zip_close_archive(zip_t *za, zip_source_t *zs) {
+	zip_close (za);
+#ifdef OTEZIP_H_
+	/* otezip's zip_open_from_source() copies the data and never takes
+	 * ownership of the source, so it must be freed by the caller. With
+	 * libzip the archive owns the source after a successful open and
+	 * zip_close() frees it, so freeing it here would be a double free */
+	zip_source_free (zs);
+#else
+	(void)zs;
+#endif
+}
+
 static RList *fs_zip_dir(RFSRoot *root, const char *path, R_UNUSED int view) {
 	ut64 addr = 0;
 	RIOMap *map = root->iob.map_get_at (root->iob.io, addr);
@@ -146,7 +159,7 @@ static RList *fs_zip_dir(RFSRoot *root, const char *path, R_UNUSED int view) {
 	bool hasfailed = false;
 	RList *list = r_list_new ();
 	if (!list) {
-		zip_close (za);
+		fs_zip_close_archive (za, zs);
 		free (buf);
 		return NULL;
 	}
@@ -188,7 +201,7 @@ static RList *fs_zip_dir(RFSRoot *root, const char *path, R_UNUSED int view) {
 		free (k);
 	}
 
-	zip_close (za);
+	fs_zip_close_archive (za, zs);
 	free (buf);
 	if (!hasdir || hasfailed) {
 		r_list_free (list);
@@ -224,6 +237,6 @@ RFSPlugin r_fs_plugin_zip = {
 R_API RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_FS,
 	.data = &r_fs_plugin_zip,
-	.verszipn = R2_VERSION
+	.version = R2_VERSION
 };
 #endif


### PR DESCRIPTION
### Motivation
- With system libzip, `zip_open_from_source()` transfers ownership of the `zip_source_t` to the archive on success and `zip_close()` frees it, so the extra `zip_source_free (zs)` in `fs_zip_dir()` was a use-after-free/double-free on every successful directory listing of a mounted zip (confirmed with an ASan reproducer against libzip 1.7.3: SEGV inside `zip_source_free`).
- However, the bundled default backend (otezip) has different semantics: its `zip_open_from_source()` copies the data into a temp file and never takes ownership of the source, so there the free is required — dropping it unconditionally would leak the `zip_source_t` on every call (also confirmed with ASan/LeakSanitizer).

### Description
- Add a `fs_zip_close_archive()` helper that calls `zip_close()` and frees the source only under `#ifdef OTEZIP_H_` (otezip's include guard), matching each backend's ownership semantics.
- Use it in both the success path and the early `!list` error path, which previously leaked the source under otezip.
- Fix the `.verszipn` → `.version` typo in the out-of-core `RLibStruct` (leftover of an old `s/io/zip/` rename) that broke out-of-tree builds of this plugin.

### Testing
- ASan harness replicating the exact open/close sequence: 100 rounds clean against both system libzip 1.7.3 and otezip 0.4.8; the pre-PR code crashes (UAF) under libzip, and the unconditional removal leaks under otezip.
- `gcc -fsyntax-only` of `libr/fs/p/fs_zip.c` against both otezip and system libzip headers, with and without `R2_PLUGIN_INCORE`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db91c5a6b4833182c562ccef41508f)