### PR TITLE
Handle local variable accesses of two-operand `imul` on x86 ##analysis

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2931,6 +2931,14 @@ static void set_src_dst(RArchSession *as, RAnalValue *val, csh handle, cs_insn *
 	}
 }
 
+static inline bool is_stackrel_memref(cs_insn* insn, int x) {
+	return INSOP (x).type == X86_OP_MEM
+		&& (INSOP (x).mem.base == X86_REG_RSP
+			|| INSOP (x).mem.base == X86_REG_ESP
+			|| INSOP (x).mem.base == X86_REG_RBP
+			|| INSOP (x).mem.base == X86_REG_EBP);
+}
+
 static void op_fillval(RArchSession *a, RAnalOp *op, csh handle, cs_insn *insn, int mode) {
 	RAnalValue *dst, *src0, *src1, *src2;
 	set_access_info (a, op, handle, insn, mode);
@@ -2962,27 +2970,16 @@ static void op_fillval(RArchSession *a, RAnalOp *op, csh handle, cs_insn *insn, 
 		break;
 	case R_ANAL_OP_TYPE_DIV:
 	case R_ANAL_OP_TYPE_MUL:
-		// Single-operand ops where INSOP(0) is the source. Only fill srcs
+		// Single-operand ops where INSOP (0) is the source. Only fill srcs
 		// when the memref is stack-relative — otherwise we'd manufacture
 		// spurious var accesses for arbitrary addresses.
-		if (INSOP (0).type == X86_OP_MEM
-				&& (INSOP (0).mem.base == X86_REG_RSP
-					|| INSOP (0).mem.base == X86_REG_ESP
-					|| INSOP (0).mem.base == X86_REG_RBP
-					|| INSOP (0).mem.base == X86_REG_EBP)) {
+		if (is_stackrel_memref (insn, 0)) {
 			CREATE_SRC_DST (op);
 			set_src_dst (a, src0, handle, insn, 0);
 		}
 		break;
 	case R_ANAL_OP_TYPE_UPUSH:
-		if (op->type & R_ANAL_OP_TYPE_REG) {
-			CREATE_SRC_DST (op);
-			set_src_dst (a, src0, handle, insn, 0);
-		} else if (INSOP (0).type == X86_OP_MEM
-				&& (INSOP (0).mem.base == X86_REG_RSP
-					|| INSOP (0).mem.base == X86_REG_ESP
-					|| INSOP (0).mem.base == X86_REG_RBP
-					|| INSOP (0).mem.base == X86_REG_EBP)) {
+		if (op->type & R_ANAL_OP_TYPE_REG || is_stackrel_memref (insn, 0)) {
 			CREATE_SRC_DST (op);
 			set_src_dst (a, src0, handle, insn, 0);
 		}

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2977,6 +2977,11 @@ static void op_fillval(RArchSession *a, RAnalOp *op, csh handle, cs_insn *insn, 
 			CREATE_SRC_DST (op);
 			set_src_dst (a, src0, handle, insn, 0);
 		}
+		// Two-operand version, now INSOP (1) is the source.
+		else if (is_stackrel_memref (insn, 1)) {
+			CREATE_SRC_DST (op);
+			set_src_dst (a, src0, handle, insn, 1);
+		}
 		break;
 	case R_ANAL_OP_TYPE_UPUSH:
 		if (op->type & R_ANAL_OP_TYPE_REG || is_stackrel_memref (insn, 0)) {

--- a/test/db/anal/x86_32
+++ b/test/db/anal/x86_32
@@ -1427,6 +1427,67 @@ main 0x804831a [STRN:r--] mov dword [var_ch], str.john
 EOF
 RUN
 
+NAME=imul var sub capstone
+FILE=bins/elf/ioli/crackme0x02
+CMDS=<<EOF
+e asm.arch = x86
+e anal.arch = x86
+aa
+s 0x8048444
+pi 1
+EOF
+EXPECT=<<EOF
+imul eax, dword [var_8h]
+EOF
+RUN
+
+# variable substitution doesnt yet work on zydis
+NAME=imul var sub zydis
+BROKEN=1
+FILE=bins/elf/ioli/crackme0x02
+CMDS=<<EOF
+e asm.arch = x86.zydis
+e anal.arch = x86.zydis
+aa
+s 0x8048444
+pi 1
+EOF
+EXPECT=<<EOF
+imul eax, dword [var_8h]
+EOF
+RUN
+
+# note: use afv[RW] [var]~?[addr] to check for a specific xref,
+# since many xrefs are still missing on both capstone and zydis
+
+NAME=imul var xref capstone
+FILE=bins/elf/ioli/crackme0x02
+CMDS=<<EOF
+e asm.arch = x86
+e anal.arch = x86
+aa
+s 0x8048444
+afvR var_8h~?0x8048444
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN
+
+NAME=imul var xref zydis
+FILE=bins/elf/ioli/crackme0x02
+CMDS=<<EOF
+e asm.arch = x86.zydis
+e anal.arch = x86.zydis
+aa
+s 0x8048444
+afvR var_8h~?0x8048444
+EOF
+EXPECT=<<EOF
+1
+EOF
+RUN
+
 NAME=resolve reloc symbols 1
 FILE=bins/elf/libc.so.6
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Correctly recognize local variable accesses in the operands of two-operand `imul` and `idiv`. For example, if we have a local variable `int var_8h @ ebp-0x8`, this changes `imul ecx, dword [ebp - 8]` into `imul ecx, dword [var_8h]` in the disassembly. This is the expected behavior when substituting recognized local variables (`asm.sub.var = true`). Note that this will also work for three-operand variants (`imul reg, mem, imm`, etc.).

Also refactored a common boolean condition into a separate inline function.