### PR TITLE
Avoid an unbounded memcpy in handle_vFile_pread

### DIFF
--- a/shlr/gdb/include/gdbclient/responses.h
+++ b/shlr/gdb/include/gdbclient/responses.h
@@ -27,7 +27,7 @@ int handle_setbp(libgdbr_t* g);
 int handle_removebp(libgdbr_t* g);
 int handle_attach(libgdbr_t* g);
 int handle_vFile_open(libgdbr_t *g);
-int handle_vFile_pread(libgdbr_t *g, ut8 *buf);
+int handle_vFile_pread(libgdbr_t *g, ut8 *buf, size_t max_len);
 int handle_vFile_close(libgdbr_t *g);
 int handle_stop_reason(libgdbr_t *g);
 

--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -1495,7 +1495,7 @@ int gdbr_read_file(libgdbr_t *g, ut8 *buf, ut64 max_len) {
 			ret = -1;
 			goto end;
 		}
-		if ((ret1 = handle_vFile_pread (g, buf + ret)) < 0) {
+		if ((ret1 = handle_vFile_pread (g, buf + ret, max_len - ret)) < 0) {
 			ret = ret1;
 			goto end;
 		}

--- a/shlr/gdb/src/gdbclient/responses.c
+++ b/shlr/gdb/src/gdbclient/responses.c
@@ -114,7 +114,7 @@ int handle_vFile_open(libgdbr_t *g) {
 	return send_ack (g);
 }
 
-int handle_vFile_pread(libgdbr_t *g, ut8 *buf) {
+int handle_vFile_pread(libgdbr_t *g, ut8 *buf, size_t max_len) {
 	send_ack (g);
 	char *ptr;
 	int len;
@@ -141,6 +141,7 @@ int handle_vFile_pread(libgdbr_t *g, ut8 *buf) {
 	}
 	ptr++;
 	if (len > 0) {
+		len = R_MIN (len, max_len);
 		memcpy (buf, ptr, len);
 	}
 	return len;

--- a/shlr/gdb/src/gdbclient/xml.c
+++ b/shlr/gdb/src/gdbclient/xml.c
@@ -425,7 +425,9 @@ static int gdbr_parse_processes_xml(libgdbr_t *g, char *xml_data, ut64 len, int 
 		// correct pid and cmdline from the xml with everything else set to default
 		proc_filename = r_str_newf ("/proc/%d/status", ipid);
 		if (gdbr_open_file (g, proc_filename, O_RDONLY, 0) == 0) {
-			if (gdbr_read_file (g, (unsigned char *)status, sizeof (status)) != -1) {
+			int read_len = gdbr_read_file (g, (ut8 *)status, sizeof (status) - 1);
+			if (read_len >= 0) {
+				status[read_len] = '\0';
 				pid_info = _extract_pid_info (status, cmdline, ipid);
 			} else {
 				R_LOG_ERROR ("Failed to read from data from procfs file of pid (%d)", ipid);


### PR DESCRIPTION
This is potentially stored on the stack, so we need to length-limit this. Pass down the maxlength and update callers to handle error cases accordingly.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
