### PR TITLE
Add missing cutils.c linkage problem for qjs ##build

### DIFF
--- a/shlr/qjs/deps.mk
+++ b/shlr/qjs/deps.mk
@@ -13,6 +13,7 @@ ifeq ($(LINK_QJS_ARCHIVE),1)
 QJSFILES=$(QJS_NAME)/libquickjs.a
 else
 QJSFILES+=quickjs.c
+QJSFILES+=cutils.c
 QJSFILES+=libregexp.c
 QJSFILES+=libunicode.c
 # https://github.com/quickjs-ng/quickjs/issues/17

--- a/subprojects/packagefiles/qjs/meson.build
+++ b/subprojects/packagefiles/qjs/meson.build
@@ -3,6 +3,7 @@ project('qjs', 'c', meson_version : '>=0.60.0', version : '7e292050a21d3dd5076f7
 sources = [
   'libregexp.c',
   'libunicode.c',
+  'cutils.c',
   'quickjs.c',
   'dtoa.c'
 ]


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
