### PR TITLE
Double Free In Visual Mode ##core #25982

### DIFF
--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -4926,7 +4926,6 @@ dodo:
 		if (highlight_mode && highlight_sb) {
 			char *s = r_strbuf_tostring (highlight_sb);
 			r_config_set (core->config, "scr.highlight", s);
-			free (s);
 		}
 		core->print->vflush = !skip;
 		visual_refresh (core);
@@ -4935,7 +4934,6 @@ dodo:
 			char *s = r_strbuf_tostring (highlight_sb);
 			r_cons_printf (core->cons, "%s[Highlight] %s|", R_CONS_CLEAR_LINE, s);
 			r_cons_flush (core->cons);
-			free (s);
 		}
 		if (insert_mode_enabled (core)) {
 			goto dodo;
@@ -4983,7 +4981,6 @@ dodo:
 						r_strbuf_append_n (highlight_sb, (const char*)&ch, 1);
 						char *s = r_strbuf_tostring (highlight_sb);
 						r_config_set (core->config, "scr.highlight", s);
-						free (s);
 					}
 					break;
 				}

--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -498,7 +498,9 @@ R_API char *r_strbuf_drain(RStrBuf *sb) {
 
 R_API char *r_strbuf_tostring(RStrBuf *sb) {
 	R_RETURN_VAL_IF_FAIL (sb, NULL);
-	return drain (sb);
+	void *tmp = drain (sb);
+	sb->ptr = tmp;
+	return tmp;
 }
 
 R_API char *r_strbuf_drain_nofree(RStrBuf *sb) {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Fixes issue described in #25982
I've also ran the code under valgrind and it shows no memory leaks from the **_r_strbuf_tostring_** function


Valgrind output:
```
==34448== Memcheck, a memory error detector
==34448== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==34448== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==34448== Command: r2 -A /usr/bin/ls
==34448== Parent PID: 34428
==34448== 
==34448== Conditional jump or move depends on uninitialised value(s)
==34448==    at 0x58EEA93: cs_insn_group (cs.c:1258)
==34448==    by 0x588C783: decode (plugin_cs.c:4311)
==34448==    by 0x56CAD2D: r_arch_session_decode (arch_session.c:42)
==34448==    by 0x6A35CFA: r_anal_op (op.c:188)
==34448==    by 0x6A38EA8: is_delta_pointer_table (fcn.c:175)
==34448==    by 0x6A3D764: fcn_recurse (fcn.c:1213)
==34448==    by 0x6A40CB1: r_anal_function_bb (fcn.c:1988)
==34448==    by 0x6A3ECE4: fcn_recurse (fcn.c:1529)
==34448==    by 0x6A40CB1: r_anal_function_bb (fcn.c:1988)
==34448==    by 0x6A3EC84: fcn_recurse (fcn.c:1526)
==34448==    by 0x6A40CB1: r_anal_function_bb (fcn.c:1988)
==34448==    by 0x6A414E3: r_anal_function (fcn.c:2125)
==34448==  Uninitialised value was created by a stack allocation
==34448==    at 0x588C0DD: decode (plugin_cs.c:4214)
==34448== 
==34448== 
==34448== HEAP SUMMARY:
==34448==     in use at exit: 66 bytes in 2 blocks
==34448==   total heap usage: 2,727,525 allocs, 2,727,523 frees, 532,945,077 bytes allocated
==34448== 
==34448== 1 bytes in 1 blocks are definitely lost in loss record 1 of 2
==34448==    at 0x4856F4F: realloc (vg_replace_malloc.c:1801)
==34448==    by 0x49E3905: r_cons_readpush (input.c:657)
==34448==    by 0x5064958: r_core_visual (visual.c:5026)
==34448==    by 0x5026F9B: cmd_visual (cmd.c:3196)
==34448==    by 0x50A89CE: r_cmd_call (cmd_api.c:398)
==34448==    by 0x502F69A: r_core_cmd_subst_i (cmd.c:5596)
==34448==    by 0x5029B12: r_core_cmd_subst (cmd.c:4149)
==34448==    by 0x503330F: run_cmd_depth (cmd.c:6600)
==34448==    by 0x50339B1: r_core_cmd (cmd.c:6716)
==34448==    by 0x4EF466C: r_core_prompt_exec (core.c:3061)
==34448==    by 0x4EF3807: r_core_prompt_loop (core.c:2851)
==34448==    by 0x6D7A15A: r_main_radare2 (radare2.c:1970)
==34448== 
==34448== 65 bytes in 1 blocks are definitely lost in loss record 2 of 2
==34448==    at 0x484F8A8: malloc (vg_replace_malloc.c:446)
==34448==    by 0x6E4E4FF: strdup (strdup.c:42)
==34448==    by 0x49D9177: r_cons_highlight (cons.c:1847)
==34448==    by 0x5042228: cb_scrhighlight (cconfig.c:2834)
==34448==    by 0x4A08700: r_config_set (config.c:501)
==34448==    by 0x5064788: r_core_visual (visual.c:4985)
==34448==    by 0x5026F9B: cmd_visual (cmd.c:3196)
==34448==    by 0x50A89CE: r_cmd_call (cmd_api.c:398)
==34448==    by 0x502F69A: r_core_cmd_subst_i (cmd.c:5596)
==34448==    by 0x5029B12: r_core_cmd_subst (cmd.c:4149)
==34448==    by 0x503330F: run_cmd_depth (cmd.c:6600)
==34448==    by 0x50339B1: r_core_cmd (cmd.c:6716)
==34448== 
==34448== LEAK SUMMARY:
==34448==    definitely lost: 66 bytes in 2 blocks
==34448==    indirectly lost: 0 bytes in 0 blocks
==34448==      possibly lost: 0 bytes in 0 blocks
==34448==    still reachable: 0 bytes in 0 blocks
==34448==         suppressed: 0 bytes in 0 blocks
==34448== 
==34448== For lists of detected and suppressed errors, rerun with: -s
==34448== ERROR SUMMARY: 10 errors from 3 contexts (suppressed: 0 from 0)
```

