### PR TITLE
Fix register response too large warning in gdb client ##debug

### DIFF
--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -77,29 +77,49 @@ static struct {
 	bool valid, init;
 } reg_cache;
 
+static bool reg_cache_ensure_size(size_t len) {
+	if ((ut64)len <= reg_cache.maxlen) {
+		reg_cache.init = reg_cache.buf != NULL;
+		return reg_cache.init;
+	}
+	ut8 *buf = realloc (reg_cache.buf, len);
+	if (!buf) {
+		return false;
+	}
+	reg_cache.buf = buf;
+	reg_cache.maxlen = (ut64)len;
+	reg_cache.init = true;
+	return true;
+}
+
+static void reg_cache_fini(void) {
+	R_FREE (reg_cache.buf);
+	reg_cache.buflen = 0;
+	reg_cache.maxlen = 0;
+	reg_cache.valid = false;
+	reg_cache.init = false;
+}
+
 static void reg_cache_update(libgdbr_t *g) {
 	reg_cache.valid = false;
-	if (!reg_cache.init || !g || g->data_len < 0) {
+	if (!g || g->data_len < 0) {
 		return;
 	}
-	const ut64 len = (ut64)g->data_len;
-	if (len > reg_cache.maxlen) {
-		R_LOG_WARN ("gdb: register response too large (%"PFMT64u" > %"PFMT64u" bytes), skipping cache",
-			len, reg_cache.maxlen);
+	const size_t len = (size_t)g->data_len;
+	if (!reg_cache_ensure_size (len)) {
 		return;
 	}
-	memcpy (reg_cache.buf, g->data, (size_t)len);
-	reg_cache.buflen = len;
+	memcpy (reg_cache.buf, g->data, len);
+	reg_cache.buflen = (ut64)len;
 	reg_cache.valid = true;
 }
 
 static void reg_cache_init(libgdbr_t *g) {
-	reg_cache.maxlen = g->data_max;
 	reg_cache.buflen = 0;
 	reg_cache.valid = false;
 	reg_cache.init = false;
-	if ((reg_cache.buf = malloc (reg_cache.maxlen))) {
-		reg_cache.init = true;
+	if (g && g->data_max > 0) {
+		reg_cache_ensure_size ((size_t)g->data_max);
 	}
 }
 
@@ -313,7 +333,7 @@ int gdbr_disconnect(libgdbr_t *g) {
 	}
 	reg_cache.valid = false;
 	g->stop_reason.is_valid = false;
-	free (reg_cache.buf);
+	reg_cache_fini ();
 	if (g->target.valid) {
 		free (g->target.regprofile);
 		free (g->registers);

--- a/test/unit/test_debug.c
+++ b/test/unit/test_debug.c
@@ -385,8 +385,8 @@ bool test_r2_gdb_oversized_reg_response(void) {
 
 	r_sys_usleep (500000);
 	char *uri = r_str_newf ("gdb://127.0.0.1:%d", port);
-	const char *argv[] = { "radare2", "-q", "-d", "-D", "gdb", "-Qc", "dr;q", uri, NULL };
-	int ret = r_main_radare2 (8, argv);
+	const char *argv[] = { "radare2", "-q", "-d", "-D", "gdb", "-escr.null=true", "-Qc", "dr;q", uri, NULL };
+	int ret = r_main_radare2 (9, argv);
 	int status = 0;
 	int waited = 0;
 	int wpid = 0;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
