### PR TITLE
Fix iS/iSS flags column showing garbage upper bits ##bin

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -3793,12 +3793,12 @@ static bool bin_sections(RCore *core, PJ *pj, int mode, ut64 laddr, int va, ut64
 				r_table_add_rowf (table, "dXxXxsxsss", i,
 					(ut64)section->paddr, (ut64)section->size,
 					(ut64)addr, (ut64)section->vsize,
-					disp_perms, section->flags, r_str_get (hashstr), stype, section_name);
+					disp_perms, (ut64)section->flags, r_str_get (hashstr), stype, section_name);
 			} else {
 				r_table_add_rowf (table, "dXxXxsxss", i,
 					(ut64)section->paddr, (ut64)section->size,
 					(ut64)addr, (ut64)section->vsize,
-					disp_perms, section->flags, stype, section_name);
+					disp_perms, (ut64)section->flags, stype, section_name);
 			}
 			free (hashstr);
 		}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`bin_sections()` passes `section->flags` (ut32) where the format slot reads `va_arg(ap, ut64)`. On aarch64 the compiler emits a 4-byte stack store for the arg, leaving the upper 4 bytes of the varargs slot uninitialised — `iS` and `iSS` then print flags like `0xfd2800000003` instead of `0x3`. x86_64 masks this via register-passing zero-extend, so CI hasn't caught it.

**Effect:** non-deterministic garbage in the `iS`/`iSS` flags column on aarch64 (changes every run); breaks 5 r2r tests under `test/db/formats/elf/` and anything that parses this column as a number.

Cast to `ut64` at both call sites.