### PR TITLE
Add missing ut64 casts to r_table_add_rowf calls ##anal

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -368,7 +368,7 @@ static void r_anal_xrefs_list_table(RAnal *anal, RVecAnalRef *anal_refs, const c
 		char *toname = anal->coreb.getNameDelta (anal->coreb.core, ref->at);
 		r_table_add_rowf (table, "xxnssss",
 				ref->at, ref->addr,
-				r_anal_ref_size (ref),
+				(ut64)r_anal_ref_size (ref),
 				r_anal_ref_type_tostring (t),
 				r_anal_ref_perm_tostring (ref),
 				toname, fromname

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -11699,7 +11699,7 @@ static bool cmd_anal_refs(RCore *core, const char *input) {
 							fcn_addr,
 							ref->addr,
 							addr,
-							size,
+							(ut64)size,
 							typestr,
 							permstr
 							);

--- a/libr/core/dmh_windows.inc.c
+++ b/libr/core/dmh_windows.inc.c
@@ -1265,7 +1265,7 @@ static void w32_list_heaps_blocks(RCore *core, const char format) {
 					pj_end (pj);
 					break;
 				default:
-					r_table_add_rowf (tbl, "xxnnns", address, (ut64)block->dwAddress, block->dwSize, granularity, unusedBytes, type);
+					r_table_add_rowf (tbl, "xxnnns", address, (ut64)block->dwAddress, (ut64)block->dwSize, granularity, unusedBytes, type);
 					break;
 				}
 			} while (GetNextHeapBlock (&heapInfo->heaps[i], block));


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

You were correct. This is the same bug class fixed recently. All 31 `r_table_add_rowf` call sites were audited; the three below were the remaining mismatches:

- `libr/anal/xrefs.c` — xref table "size" column fed `int r_anal_ref_size()` at an `n` position 
- `libr/core/cmd_anal.inc.c` — same `r_anal_ref_size()` value at an `n` position (`ax` table path)
- `libr/core/dmh_windows.inc.c` — `block->dwSize` uncast at an `n` position (its sibling line already casts)

Haven't tested the Windows variant but "looks ok".