### PR TITLE
Add format checking to `r_cons_printf` and fix the printf-width bugs it exposes ##cons

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -10530,7 +10530,7 @@ static void cmd_aoc(RCore *core, const char *input) {
 		char *ins = r_core_disassemble_instr (core, hook->addr, 1);
 		if (ins) {
 			size_t count = ccl - hook->cycles;
-			r_cons_printf (core->cons, "after %i cycles: %s\n", count, ins);
+			r_cons_printf (core->cons, "after %"PFMT64u" cycles: %s\n", (ut64)count, ins);
 			free (ins);
 		}
 	}

--- a/libr/core/cmd_flag.inc.c
+++ b/libr/core/cmd_flag.inc.c
@@ -560,7 +560,7 @@ static void cmd_fz(RCore *core, const char *input) {
 			const char *name = r_str_trim_head_ro (input + 1);
 			RFlagZoneItem *fz = r_flag_zone_get (core->flags, name);
 			if (fz) {
-				r_cons_printf (core->cons, "0x08"PFMT64x, fz->from);
+				r_cons_printf (core->cons, "0x%08"PFMT64x, fz->from);
 			} else {
 				R_LOG_ERROR ("There is no flag zone with this name");
 			}
@@ -1487,7 +1487,7 @@ static void cmd_fu(RCore *core, const char *input) {
 		if (item) {
 			char *rawname = item->rawname? r_base64_encode_dyn ((void*)item->rawname, strlen (item->rawname)): NULL;
 			char *realname = item->realname? r_base64_encode_dyn ((void*)item->realname, strlen (item->realname)): NULL;
-			r_cons_printf (core->cons, "'@0x%08"PFMT64x"'fu %d %s %s %s\n",
+			r_cons_printf (core->cons, "'@0x%08"PFMT64x"'fu %"PFMT64u" %s %s %s\n",
 					item->addr, item->size, item->name, rawname, realname);
 			free (rawname);
 			free (realname);

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -3344,7 +3344,7 @@ static void search_similar_pattern_in(RCore *core, int count, ut64 from, ut64 to
 			int equal = core->blocksize - diff;
 			if (equal >= count) {
 				int pc = (equal * 100) / core->blocksize;
-				r_cons_printf (core->cons, "0x%08"PFMT64x " %4d/%d %3d%%  ", addr, equal, bsz, pc);
+				r_cons_printf (core->cons, "0x%08"PFMT64x " %4d/%"PFMT64u" %3d%%  ", addr, equal, bsz, pc);
 				ut8 ptr[2] = {
 					(ut8)(pc * 2.5), 0
 				};

--- a/libr/core/cmd_write.inc.c
+++ b/libr/core/cmd_write.inc.c
@@ -602,7 +602,7 @@ static void cmd_write_value(RCore *core, const char *input) {
 	case 'g': // "wvg"
 		{
 			if (input[1] == '?') {
-				r_cons_printf (core->cons, fpuhelp);
+				r_cons_printf (core->cons, "%s", fpuhelp);
 			} else {
 				const RCFloatProfile *profile = &core->rasm->config->cfloat_profile;
 				double value = strtod (r_str_trim_head_ro (input + 1), NULL);

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -1189,7 +1189,7 @@ R_API void r_cons_newline(RCons *cons);
 R_API bool r_cons_write(RCons *cons, const void *str, size_t len);
 R_API void r_cons_memset(RCons *cons, char ch, int len);
 R_API void r_cons_printf_list(RCons *cons, const char *format, va_list ap);
-R_API int r_cons_printf(RCons *cons, const char *format, ...);
+R_API int r_cons_printf(RCons *cons, const char *format, ...) R_PRINTF_CHECK(2, 3);
 R_API void r_cons_gotoxy(RCons * R_NONNULL cons, int x, int y);
 R_API void r_cons_set_interactive(RCons *cons, bool x);
 R_API void r_cons_set_last_interactive(RCons *cons);

--- a/test/db/cmd/flags
+++ b/test/db/cmd/flags
@@ -65,3 +65,16 @@ EXPECT=<<EOF
 0x0
 EOF
 RUN
+
+NAME=fz prints zone start address
+FILE=malloc://64
+CMDS=<<EOF
+s 0x1234
+fz+ myzone
+fz myzone
+?e
+EOF
+EXPECT=<<EOF
+0x00001234
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_cons_printf` is the most-used output function but was the only printf-like API in the tree without a `format(printf)` attribute, so `-Wformat` never checked its callers. Add `R_PRINTF_CHECK` to it and fix the five mismatches it exposed:
  
* `fz`: format string was missing its `%`, printing the literal `0x08lx` instead of the zone address (the one user-visible bug)
* `fz`/`fu` dump, anal cycle listing, `/c` search: pass `ut64`/`size_t` with `%d`/`%i` (correct on LP64-LE for small values, but truncate large ones and break on LLP64)
* `wvg?`: pass the help string via `"%s"` (`-Wformat-security` hardening, no behavioural change)
* Add a `db/cmd/flags` regression test for the `fz` output
