### PR TITLE
Fix signedness and endianness in branch-target analysis across several arch plugins ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_gnu.c
+++ b/libr/arch/p/arm/plugin_gnu.c
@@ -140,7 +140,7 @@ static int op_thumb(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *data, i
 			high |= B4 (B1111, B1000, 0, 0) << 16;
 		}
 		int delta = high + ((nextins & B4 (0, B0111, B1111, B1111)) * 2);
-		op->jump = (int) (addr + 4 + (delta));
+		op->jump = addr + 4 + delta;
 		op->type = R_ANAL_OP_TYPE_CALL;
 		op->fail = addr + 4;
 	} else if ((ins & B4 (B1111, B1111, 0, 0)) == B4 (B1011, B1110, 0, 0)) {

--- a/libr/arch/p/dalvik/plugin.c
+++ b/libr/arch/p/dalvik/plugin.c
@@ -1097,7 +1097,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		break;
 	case 0x28: // goto
 		if (len > 1) {
-			op->jump = addr + ((char)data[1])*2;
+			op->jump = addr + ((st8)data[1]) * 2;
 			op->type = R_ANAL_OP_TYPE_JMP;
 			op->eob = true;
 			if (mask & R_ARCH_OP_MASK_ESIL) {
@@ -1117,7 +1117,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		break;
 	case 0x2a: // goto/32
 		if (len > 5) {
-			st64 dst = (st64)(data[2]|(data[3]<<8)|(data[4]<<16)|((ut32)data[5]<<24));
+			st64 dst = (st32)(data[2] | (data[3] << 8) | (data[4] << 16) | ((ut32)data[5] << 24));
 			op->jump = addr + (dst * 2);
 			op->type = R_ANAL_OP_TYPE_JMP;
 			op->eob = true;

--- a/libr/arch/p/vax/vax.c
+++ b/libr/arch/p/vax/vax.c
@@ -108,7 +108,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case 0x19:
 	case 0x1e:
 		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = op->addr + op->size + ((len > 1)? ((char)buf[1]): 0);
+		op->jump = op->addr + op->size + ((len > 1) ? ((st8)buf[1]) : 0);
 		op->fail = op->addr + op->size;
 		break;
 	case 0xd0: // mcoml
@@ -123,11 +123,17 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case 0xca: // bicl
 		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
-	case 0x31:
-	case 0xe9:
+	case 0x31: // brw: signed 16-bit little-endian word displacement at buf[1]
 		op->type = R_ANAL_OP_TYPE_CJMP;
 		if (len > 2) {
-			op->jump = op->addr + op->size + ((buf[1] << 8) + buf[2]);
+			op->jump = op->addr + op->size + (st16)(buf[1] | (buf[2] << 8));
+			op->fail = op->addr + op->size;
+		}
+		break;
+	case 0xe9: // blbc: signed byte displacement in the last instruction byte
+		op->type = R_ANAL_OP_TYPE_CJMP;
+		if (op->size > 1 && op->size <= len) {
+			op->jump = op->addr + op->size + (st8)buf[op->size - 1];
 			op->fail = op->addr + op->size;
 		}
 		break;

--- a/libr/arch/p/xap/plugin.c
+++ b/libr/arch/p/xap/plugin.c
@@ -9,7 +9,7 @@ static int label_off(struct directive *d) {
 	int lame = off & 0x80;
 
 	if (!d->d_prefix) { // WTF
-		off = (char) (off & 0xff);
+		off = (st8)(off & 0xff);
 	} else if (d->d_prefix == 1) {
 		off = (short) (off & 0xffff);
 		if (lame) {

--- a/shlr/java/code.c
+++ b/shlr/java/code.c
@@ -44,7 +44,7 @@ R_API int java_print_opcode(RBinJavaObj *obj, ut64 addr, int idx, const ut8 *byt
 	switch (op_byte) {
 	case 0x10: // "bipush"
 		if (len > 1) {
-			snprintf (output, outlen, "%s %d", JAVA_OPS[idx].name, (char)bytes[1]);
+			snprintf(output, outlen, "%s %d", JAVA_OPS[idx].name, (st8)bytes[1]);
 			output[outlen - 1] = 0;
 			return JAVA_OPS[idx].size;
 		}

--- a/test/db/anal/dalvik
+++ b/test/db/anal/dalvik
@@ -25,3 +25,19 @@ EXPECT=<<EOF
 entry0 0x26e [CALL:--x] invoke-direct {v0}, LHello.<init>()V ; 0x0
 EOF
 RUN
+
+NAME=dalvik goto and goto/32 signed backward branch (op->jump)
+FILE=malloc://0x2000
+CMDS=<<EOF
+e asm.arch=dalvik
+s 0x1000
+wx 28f8
+ao~jump:
+wx 2a00f0ffffff
+ao~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00000ff0
+jump: 0x00000fe0
+EOF
+RUN

--- a/test/db/anal/vax
+++ b/test/db/anal/vax
@@ -1,0 +1,30 @@
+NAME=vax brw signed little-endian word displacement (op->jump)
+FILE=malloc://0x2000
+CMDS=<<EOF
+e asm.arch=vax
+e asm.bits=32
+s 0x1000
+wx 31f0ff
+ao~jump:
+wx 310401
+ao~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00000ff3
+jump: 0x00001107
+EOF
+RUN
+
+NAME=vax blbc signed byte displacement (op->jump)
+FILE=malloc://0x2000
+CMDS=<<EOF
+e asm.arch=vax
+e asm.bits=32
+s 0x1000
+wx e950f0
+ao~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00000ff3
+EOF
+RUN

--- a/test/db/asm/java
+++ b/test/db/asm/java
@@ -74,3 +74,4 @@ d "goto 0x003b" a70037 0x00000004
 d "bipush 32" 1020
 d "nop" 00
 d "iadd" 60
+d "bipush -1" 10ff


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Several arch analysis plugins computed `op->jump` (and one disasm immediate) with the wrong integer interpretation. The common root cause is `(char)byte`, which does not sign-extend on hosts where `char` is unsigned by default (e.g. AArch64), so negative branch displacements became large positives.

* **vax**: byte conditional branches used `(char)`; `brw` read its 16-bit displacement big-endian and unsigned (vax is little-endian); `blbc` was  wrongly grouped with `brw` (its displacement is a signed byte in the last instruction byte). Result: backward branches landed far forward and `entry0` ballooned from 74 to ~37k bytes. Now `(st8)`/`(st16)` with correct LE order.
* **dalvik**: `goto` used `(char)` for the byte offset; `goto/32` cast a forced-unsigned expression to `st64`, zero-extending negative offsets. Now `(st8)` and `(st32)` (matching the adjacent packed-switch path).
* **xap**: 1-byte branch displacement used `(char)` -> `(st8)`.
* **arm.gnu**: Thumb `BL` target was truncated through `(int)`, corrupting addresses >= 2GB -> drop the cast. 
* **shlr/java**: `bipush` printed its signed byte operand via `(char)` (showed `255` instead of `-1` on unsigned-char hosts) -> `(st8)`.
