### PR TITLE
Fix signed-char Swift super-class and field-type parsing in mach0 ##bin

### DIFF
--- a/libr/bin/format/objc/mach0_classes.c
+++ b/libr/bin/format/objc/mach0_classes.c
@@ -1561,7 +1561,7 @@ static void parse_type(RBinFile *bf, RList *list, SwiftType st, HtUP *symbols_ht
 	klass->origin = R_BIN_CLASS_ORIGIN_BIN;
 	char *super_name = readstr (bf, st.super_addr, NULL, NULL);
 	if (super_name) {
-		if (*super_name > 5) {
+		if ((st8)*super_name > 5) {
 			klass->super = r_list_newf ((void *)r_bin_name_free);
 			RBinName *bn = r_bin_name_new (super_name);
 			char *sname = r_bin_demangle_swift (super_name, usecmd, trylib);
@@ -1684,7 +1684,7 @@ static void parse_type(RBinFile *bf, RList *list, SwiftType st, HtUP *symbols_ht
 			char *field_type = readstr (bf, field_type_addr, NULL, NULL);
 			if (field_type) {
 				const char *ftype = field_type;
-				if (*ftype < 6) {
+				if ((st8)*ftype < 6) {
 					// basic type
 					ftype += r_str_nlen (ftype, 6);
 				}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Sorry, hopefully the last couple of these bugs on aarch64.

`parse_type()` gates Swift super-class and field-type names on a bare `char` dereference (`*super_name > 5`, `*ftype < 6`). On unsigned-char hosts (e.g. AArch64) a garbage high byte like `0xdc` reads as 220 instead of −36, so it passes the gate and a bogus super-class name is emitted — e.g. `swift class 496 Item_4 :: <garbage>` instead of `Item_4`