### PR TITLE
Fix per-section reloc cap dropping relocs on multi-section ET_REL objects ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4099,9 +4099,12 @@ static size_t populate_relocs_record_from_section(ELFOBJ *eo, size_t pos, size_t
 			}
 			ut64 dim_relocs = section->size / size;
 			dim_relocs = R_MIN (dim_relocs, num_relocs) + 2;
+			// ET_REL: cap per-section (scount), else cumulative pos (also dedups the dynamic pass)
+			const bool etrel = is_bin_etrel (eo);
+			ut64 scount = 0;
 			ut64 j;
 			for (j = get_next_not_analysed_offset (eo, section->rva, 0);
-				j < section->size && pos <= dim_relocs;
+				j < section->size && (etrel? scount: pos) <= dim_relocs;
 				j = get_next_not_analysed_offset (eo, section->rva, j + size)) {
 
 				RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
@@ -4113,6 +4116,7 @@ static size_t populate_relocs_record_from_section(ELFOBJ *eo, size_t pos, size_t
 				int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
 				ht_uu_insert (eo->rel_cache, reloc->sym, index);
 				fix_rva_and_offset (eo, reloc, i);
+				scount++;
 				pos++;
 			}
 		}

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -13,7 +13,7 @@ NAME=PPC64 ELFv1 ET_REL: R_PPC64_REL24 maps to ADD_24
 FILE=bins/elf/ppc64v1-crc32_generic.ko
 CMDS=ir~?ADD_24
 EXPECT=<<EOF
-10
+13
 EOF
 RUN
 
@@ -39,14 +39,17 @@ EXPECT=<<EOF
 .crc32_le
 ._mcount
 .crc32_le
+._mcount
+.crypto_register_shash
+.crypto_unregister_shash
 EOF
 RUN
 
-NAME=PPC64 ELFv1 ET_REL: R_PPC64_TOC maps to ADD_16 (TOC base reloc)
+NAME=PPC64 ELFv1 ET_REL: R_PPC64_TOC/TOC16 map to ADD_16 (incl. .rela.init.text TOC16_HA/LO_DS)
 FILE=bins/elf/ppc64v1-crc32_generic.ko
 CMDS=ir~?ADD_16
 EXPECT=<<EOF
-5
+13
 EOF
 RUN
 
@@ -54,7 +57,15 @@ NAME=PPC64 ELFv1 ET_REL: R_PPC64_ADDR64 in .opd produces SET_64 entries
 FILE=bins/elf/ppc64v1-crc32_generic.ko
 CMDS=ir~?SET_64
 EXPECT=<<EOF
-6
+22
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: all .rela.* sections loaded (per-section cap fix, was 23)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+CMDS=ir~?
+EXPECT=<<EOF
+50
 EOF
 RUN
 
@@ -68,7 +79,32 @@ EXPECT=<<EOF
 0x08000130
 0x080001a0
 0x080001f0
+0x08000270
+0x080002f0
 0x08000358
+0x0800038c
+0x08000708
+0x08000720
+0x08000738
+0x08000738
+0x08000750
+0x08000768
+0x08000780
+0x08000798
+0x080007b0
+0x080007c8
+0x080007c8
+0x080007e0
+0x08000a00
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: .rela.init.text REL24 now applied (2nd section no longer capped)
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=pi 1 @ section..init.text+0x1c
+EXPECT=<<EOF
+bl .crypto_register_shash
 EOF
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`populate_relocs_record_from_section` bounded its per-section REL/RELA loop with the *global cumulative* counter `pos` against a *per-section* cap (`dim_relocs`). Once `pos` passed a later section's small cap, that section read zero relocs — so objects with many `.rela.*` sections lost most of them.

On `ppc64v1-crc32_generic.ko` (PPC64 ELFv1 kernel module, 56 relocs across 10 `.rela.*` sections) only the first section's 10 survived; all later sections, including the `.rela.init.text` `TOC16_HA`/`LO_DS` pair, were dropped.
  
Fix: gate the cap per-section for ET_REL (which has no PT_DYNAMIC and sources all relocs from sections), while keeping the cumulative `pos` cap for ET_DYN/ET_EXEC.

Verified against `readelf`/`objdump` (binutils 2.46): all 56 relocs now load, every reloc-type count matches, and the recovered `.rela.init.text` `R_PPC64_REL24` resolves to `.crypto_register_shash`.