### PR TITLE
Add ESIL for PowerPC byte-reverse loads/stores

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -209,7 +209,10 @@ static void opex(RStrBuf *buf, csh handle, cs_insn *insn) {
 		switch (op->type) {
 		case PPC_OP_REG:
 			pj_ks (pj, "type", "reg");
-			pj_ks (pj, "value", cs_reg_name (handle, op->reg));
+			// rA==0 in indexed forms (e.g. lwbrx r0, 0, rB) is an invalid reg
+			if (op->reg != PPC_REG_INVALID) {
+				pj_ks (pj, "value", cs_reg_name (handle, op->reg));
+			}
 			break;
 		case PPC_OP_IMM:
 			pj_ks (pj, "type", "imm");
@@ -718,6 +721,36 @@ static char *getarg2(PluginData *pd, struct Getarg *gop, int n, const char *sets
 	return pd->words[n];
 }
 
+// Byte-reverse load/store ESIL for `nbytes` (2/4/8) at the indexed (rA|0)+rB
+// address, built per-byte so it is endianness-independent (ESIL has no bswap).
+static void ppc_esil_brx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int nbytes, bool store) {
+	cs_insn *insn = gop->insn;
+	const char *reg = getarg2 (pd, gop, 0, "");
+	const char *rb = getarg2 (pd, gop, 2, "");
+	char ea[32];
+	// rA==0 in indexed forms (e.g. lwbrx r0, 0, rB) is an invalid reg
+	if (INSOP (1).type == PPC_OP_REG && INSOP (1).reg != PPC_REG_INVALID) {
+		snprintf (ea, sizeof (ea), "%s,%s,+", getarg2 (pd, gop, 1, ""), rb);
+	} else {
+		snprintf (ea, sizeof (ea), "%s", rb);
+	}
+	RStrBuf *sb = r_strbuf_new ("");
+	int i;
+	if (store) {
+		r_strbuf_appendf (sb, "0xff,%s,&,%s,=[1]", reg, ea);
+		for (i = 1; i < nbytes; i++) {
+			r_strbuf_appendf (sb, ",%d,%s,>>,0xff,&,%d,%s,+,=[1]", i * 8, reg, i, ea);
+		}
+	} else {
+		r_strbuf_appendf (sb, "%s,[1]", ea);
+		for (i = 1; i < nbytes; i++) {
+			r_strbuf_appendf (sb, ",%d,%d,%s,+,[1],<<,|", i * 8, i, ea);
+		}
+		r_strbuf_appendf (sb, ",%s,=", reg);
+	}
+	esilprintf (op, "%s", r_strbuf_get (sb));
+	r_strbuf_free (sb);
+}
 
 static int decompile_vle(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	vle_t* instr = 0;
@@ -976,8 +1009,17 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
+		case PPC_INS_STHBRX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_brx (op, pd, &gop, 2, true);
+			break;
 		case PPC_INS_STWBRX:
 			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_brx (op, pd, &gop, 4, true);
+			break;
+		case PPC_INS_STDBRX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_brx (op, pd, &gop, 8, true);
 			break;
 		case PPC_INS_STB:
 			op->type = R_ANAL_OP_TYPE_STORE;
@@ -1115,6 +1157,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_LDBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_brx (op, pd, &gop, 8, false);
 			break;
 		case PPC_INS_LFD:
 		case PPC_INS_LFDU:
@@ -1158,6 +1201,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_LHBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_brx (op, pd, &gop, 2, false);
 			break;
 		case PPC_INS_LWA:
 		case PPC_INS_LWARX:
@@ -1196,6 +1240,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_LWBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_brx (op, pd, &gop, 4, false);
 			break;
 		case PPC_INS_SLW:
 		case PPC_INS_SLWI:

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -132,3 +132,136 @@ addis r2, r12, -3
 0x00000000 16,0xfffffffffffffffd,<<,r12,+,r2,=
 EOF
 RUN
+
+NAME=load word byte-reverse indexed ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c00642c)
+EOF
+EXPECT=<<EOF
+lwbrx r0, 0, r12
+0x00000000 r12,[1],8,1,r12,+,[1],<<,|,16,2,r12,+,[1],<<,|,24,3,r12,+,[1],<<,|,r0,=
+EOF
+RUN
+
+NAME=load word byte-reverse indexed with base reg ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c642c2c)
+EOF
+EXPECT=<<EOF
+lwbrx r3, r4, r5
+0x00000000 r4,r5,+,[1],8,1,r4,r5,+,+,[1],<<,|,16,2,r4,r5,+,+,[1],<<,|,24,3,r4,r5,+,+,[1],<<,|,r3,=
+EOF
+RUN
+
+NAME=load halfword byte-reverse indexed ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c00662c)
+EOF
+EXPECT=<<EOF
+lhbrx r0, 0, r12
+0x00000000 r12,[1],8,1,r12,+,[1],<<,|,r0,=
+EOF
+RUN
+
+NAME=store word byte-reverse indexed ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c00652c)
+EOF
+EXPECT=<<EOF
+stwbrx r0, 0, r12
+0x00000000 0xff,r0,&,r12,=[1],8,r0,>>,0xff,&,1,r12,+,=[1],16,r0,>>,0xff,&,2,r12,+,=[1],24,r0,>>,0xff,&,3,r12,+,=[1]
+EOF
+RUN
+
+NAME=store halfword byte-reverse indexed ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c00672c)
+EOF
+EXPECT=<<EOF
+sthbrx r0, 0, r12
+0x00000000 0xff,r0,&,r12,=[1],8,r0,>>,0xff,&,1,r12,+,=[1]
+EOF
+RUN
+
+NAME=lwbrx byte-reverse emulation ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx deadbeef @ 0x100
+wx 7c00642c @ 0
+aei
+aeim
+ar r12=0x100
+aes
+ar r0
+EOF
+EXPECT=<<EOF
+0xefbeadde
+EOF
+RUN
+
+NAME=lwbrx indexed rA+rB byte-reverse emulation ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx deadbeef @ 0x100
+wx 7c642c2c @ 0
+aei
+aeim
+ar r4=0x40
+ar r5=0xc0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xefbeadde
+EOF
+RUN
+
+NAME=stwbrx byte-reverse store emulation ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c00652c @ 0
+aei
+aeim
+ar r0=0xdeadbeef
+ar r12=0x100
+aes
+p8 4 @ 0x100
+EOF
+EXPECT=<<EOF
+efbeadde
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -1,0 +1,48 @@
+NAME=load doubleword byte-reverse indexed ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c006428)
+EOF
+EXPECT=<<EOF
+ldbrx r0, 0, r12
+0x00000000 r12,[1],8,1,r12,+,[1],<<,|,16,2,r12,+,[1],<<,|,24,3,r12,+,[1],<<,|,32,4,r12,+,[1],<<,|,40,5,r12,+,[1],<<,|,48,6,r12,+,[1],<<,|,56,7,r12,+,[1],<<,|,r0,=
+EOF
+RUN
+
+NAME=store doubleword byte-reverse indexed ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c006528)
+EOF
+EXPECT=<<EOF
+stdbrx r0, 0, r12
+0x00000000 0xff,r0,&,r12,=[1],8,r0,>>,0xff,&,1,r12,+,=[1],16,r0,>>,0xff,&,2,r12,+,=[1],24,r0,>>,0xff,&,3,r12,+,=[1],32,r0,>>,0xff,&,4,r12,+,=[1],40,r0,>>,0xff,&,5,r12,+,=[1],48,r0,>>,0xff,&,6,r12,+,=[1],56,r0,>>,0xff,&,7,r12,+,=[1]
+EOF
+RUN
+
+NAME=ldbrx byte-reverse emulation ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 0123456789abcdef @ 0x100
+wx 7c006428 @ 0
+aei
+aeim
+ar r12=0x100
+aes
+ar r0
+EOF
+EXPECT=<<EOF
+0xefcdab8967452301
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The PowerPC byte-reverse indexed load/store ops — `lwbrx`, `lhbrx`, `ldbrx`, `stwbrx`, `sthbrx`, `stdbrx` — decoded but emitted no ESIL, so emulation silently no-op'd. `sthbrx`/`stdbrx` weren't decoded at all. This adds ESIL for all six.

- New `ppc_esil_brx()` helper emits per-byte (endian-independent) byte-reverse load/store ESIL, handling the `rA == 0` indexed form.
- Adds the missing `sthbrx`/`stdbrx` cases (now typed `STORE`).
- Guards the `PPC_OP_REG` branch in `opex()` against the invalid `rA` operand, which made `cs_reg_name()` return NULL and trip a `pj_ks` assertion (mirrors the existing `PPC_OP_MEM` check).

## Tests

`test/db/esil/ppc_32` + new `ppc_64`: ESIL-string assertions for all six plus emulation tests (`aei`/`aeim`/`aes`) verifying the byte-reversed value.
