### PR TITLE
Add op-type/ESIL for PPC dword shifts, X-form ld/st, cntlz, mulh, CR moves ##arch

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1319,7 +1319,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_SRW:
 		case PPC_INS_SRWI:
 		case PPC_INS_SRD:
-		case PPC_INS_SRDI:
+		// case PPC_INS_SRDI: // not available in some capstone versions
 			op->type = R_ANAL_OP_TYPE_SHR;
 			esilprintf (op, "%s,%s,>>,%s,=", ARG (2), ARG (1), ARG (0));
 			break;

--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1082,6 +1082,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			ppc_esil_brx (op, pd, &gop, 8, true);
 			break;
 		case PPC_INS_STB:
+		case PPC_INS_STBX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[1]"));
 			/* PPC64 ELFv1 TOC chain: stb rY, LO(rX) following addis rX, r2, HA */
@@ -1108,6 +1109,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_STH:
+		case PPC_INS_STHX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[2]"));
 			/* PPC64 ELFv1 TOC chain: sth rY, LO(rX) following addis rX, r2, HA */
@@ -1134,6 +1136,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_STD:
+		case PPC_INS_STDX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[8]"));
 			/* PPC64 ELFv1 TOC chain: std rY, LO(rX) following addis rX, r2, HA */
@@ -1259,6 +1262,10 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
+		case PPC_INS_LHZX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "%s,%s,=", ARG2 (1, "[2]"), ARG (0));
+			break;
 		case PPC_INS_LHBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			ppc_esil_brx (op, pd, &gop, 2, false);
@@ -1304,13 +1311,30 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_SLW:
 		case PPC_INS_SLWI:
+		case PPC_INS_SLD:
+		case PPC_INS_SLDI:
 			op->type = R_ANAL_OP_TYPE_SHL;
 			esilprintf (op, "%s,%s,<<,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_SRW:
 		case PPC_INS_SRWI:
+		case PPC_INS_SRD:
+		case PPC_INS_SRDI:
 			op->type = R_ANAL_OP_TYPE_SHR;
 			esilprintf (op, "%s,%s,>>,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_SRAW:
+		case PPC_INS_SRAWI:
+		case PPC_INS_SRAD:
+		case PPC_INS_SRADI:
+			op->sign = true;
+			op->type = R_ANAL_OP_TYPE_SAR;
+			esilprintf (op, "%s,%s,ASR,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_CNTLZW:
+		case PPC_INS_CNTLZD:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			// type only: ESIL has no count-leading-zeros operator
 			break;
 		case PPC_INS_MULLI:
 			op->sign = true;
@@ -1318,6 +1342,14 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_MULLD:
 			op->type = R_ANAL_OP_TYPE_MUL;
 			esilprintf (op, "%s,%s,*,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_MULHW:
+		case PPC_INS_MULHD:
+			op->sign = true;
+		case PPC_INS_MULHWU:
+		case PPC_INS_MULHDU:
+			op->type = R_ANAL_OP_TYPE_MUL;
+			// type only: ESIL has no high-half multiply operator
 			break;
 		case PPC_INS_SUB:
 		case PPC_INS_SUBC:
@@ -1388,6 +1420,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_MTSPR:
 			op->type = R_ANAL_OP_TYPE_MOV;
 			esilprintf (op, "%s,%s,=", ARG (1), PPCSPR (0));
+			break;
+		case PPC_INS_MFCR:
+		case PPC_INS_MFOCRF:
+		case PPC_INS_MTCRF:
+		case PPC_INS_MTOCRF:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			// type only: the CR model tracks only cr0, not the full cr0-cr7 word
 			break;
 		case PPC_INS_BCTR: // switch table here
 			op->type = R_ANAL_OP_TYPE_UJMP;
@@ -1831,6 +1870,12 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_RLDICR:
 			op->type = R_ANAL_OP_TYPE_ROL;
 			esilprintf (op, "%s,%s,ROL,%s,&,%s,=", ARG (2), ARG (1), cmask64 (cmaskbuf, 0, ARG (3)), ARG (0));
+			break;
+		case PPC_INS_RLDIC:
+		case PPC_INS_RLDIMI:
+			op->type = R_ANAL_OP_TYPE_ROL;
+			// type only: rldic masks mb..63-sh and rldimi inserts into the
+			// destination; neither is expressible via cmask64(mb,me)
 			break;
 		}
 		if (mask & R_ARCH_OP_MASK_VAL) {

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -812,3 +812,161 @@ EXPECT=<<EOF
 (nofunc) 0x100004a0 [DATA:r--] addi r3, r9, str.Simple_PPC_program.
 EOF
 RUN
+
+# Only real (non-alias) instructions are asserted here. Extended mnemonics like
+# sldi/srdi are capstone aliases: cs4/cs5 emit a distinct PPC_INS_SLDI id, but
+# cs6 decodes them as the base rldicr/rldicl, so their op-type differs by
+# capstone version and is not safe to pin in a test.
+NAME=ppc64 op type/esil completeness
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7d295036
+ao~mnemonic:,type:,esil:
+?e --
+wx 7d29e436
+ao~mnemonic:,type:,esil:
+?e --
+wx 7c841e74
+ao~mnemonic:,type:,esil:
+?e --
+wx 7c630034
+ao~mnemonic:,type:,esil:
+?e --
+wx 7c630074
+ao~mnemonic:,type:,esil:
+?e --
+wx 7cfe51ae
+ao~mnemonic:,type:,esil:
+?e --
+wx 7d3e432e
+ao~mnemonic:,type:,esil:
+?e --
+wx 7fca492a
+ao~mnemonic:,type:,esil:
+?e --
+wx 7d48522e
+ao~mnemonic:,type:,esil:
+?e --
+wx 7d200026
+ao~mnemonic:,type:,esil:
+?e --
+wx 7d910120
+ao~mnemonic:,type:,esil:
+?e --
+wx 7fc34816
+ao~mnemonic:,type:,esil:
+?e --
+wx 7b5a1028
+ao~mnemonic:,type:,esil:
+?e --
+wx 7949382c
+ao~mnemonic:,type:,esil:
+EOF
+EXPECT=<<EOF
+mnemonic: sld
+type: shl
+esil: r10,r9,<<,r9,=
+--
+mnemonic: srd
+type: shr
+esil: r28,r9,>>,r9,=
+--
+mnemonic: sradi
+type: sar
+esil: 0x3,r4,ASR,r4,=
+--
+mnemonic: cntlzw
+type: mov
+--
+mnemonic: cntlzd
+type: mov
+--
+mnemonic: stbx
+type: store
+esil: r7,r30=[1]
+--
+mnemonic: sthx
+type: store
+esil: r9,r30=[2]
+--
+mnemonic: stdx
+type: store
+esil: r30,r10=[8]
+--
+mnemonic: lhzx
+type: load
+esil: r8[2],r10,=
+--
+mnemonic: mfcr
+type: mov
+--
+mnemonic: mtocrf
+type: mov
+--
+mnemonic: mulhwu
+type: mul
+--
+mnemonic: rldic
+type: rol
+--
+mnemonic: rldimi
+type: rol
+EOF
+RUN
+
+# Emulation: verify the ESIL actually computes the right value (not just the
+# string). Covers the dword shifts and the arithmetic-shift sign extension
+# (sradi via ASR). Only real, cs-version-stable instructions are used.
+NAME=ppc64 esil emulation: dword + arithmetic shifts
+FILE=-
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+aei
+aeim
+ar r9=0xff
+ar r10=4
+s 0
+wx 7d295036
+ar PC=0
+aes
+?e sld
+ar r9
+ar r9=0xff00
+ar r28=4
+s 0
+wx 7d29e436
+ar PC=0
+aes
+?e srd
+ar r9
+ar r4=0xfffffffffffffff0
+s 0
+wx 7c841e74
+ar PC=0
+aes
+?e sradi_neg
+ar r4
+ar r4=0x100
+s 0
+wx 7c841e74
+ar PC=0
+aes
+?e sradi_pos
+ar r4
+EOF2
+EXPECT=<<EOF2
+sld
+0x00000ff0
+srd
+0x00000ff0
+sradi_neg
+0xfffffffffffffffe
+sradi_pos
+0x00000020
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A batch of PPC opcodes decoded but had op->type=null and no ESIL, so they produced no analysis info (regs, refs, emulation). Common in ppc64 Book-E code (e.g. e5500), where sldi/sld/extsw-class ops appear heavily.

Tests in test/db/anal/ppc: ao type/esil assertions plus an emulation block that executes the shifts and checks the result (incl. sradi sign extension).