### PR TITLE
Fix PPC bctrl losing CALL type under capstone6 ##analysis

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1429,10 +1429,12 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			// type only: the CR model tracks only cr0, not the full cr0-cr7 word
 			break;
 		case PPC_INS_BCTR: // switch table here
+		case PPC_INS_BCCTR:
 			op->type = R_ANAL_OP_TYPE_UJMP;
 			esilprintf (op, "ctr,pc,=");
 			break;
 		case PPC_INS_BCTRL: // switch table here
+		case PPC_INS_BCCTRL:
 			op->type = R_ANAL_OP_TYPE_CALL;
 			esilprintf (op, "pc,lr,=,ctr,pc,=");
 			break;

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -800,6 +800,27 @@ type: cmov
 EOF
 RUN
 
+NAME=ppc bctr/bctrl typed (cs6 BCCTR/BCCTRL alias coverage)
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 4e800420
+pd 1
+ao~type
+wx 4e800421
+pd 1
+ao~type
+EOF
+EXPECT=<<EOF
+            0x00000000      4e800420       bctr
+type: ujmp
+            0x00000000      4e800421       bctrl
+type: call
+EOF
+RUN
+
 NAME=ppc-hello-ref
 FILE=bins/elf/hello.ppc
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Under capstone6, `bctrl` decodes to base id `PPC_INS_BCCTRL`, but the `ppc_cs` plugin only handled `PPC_INS_BCTRL` — so `bctrl` lost its CALL type and ESIL, dropping indirect-call edges/xrefs (a cs6 CFG regression).

**Fix**: add `PPC_INS_BCCTR`/`BCCTRL` cases next to the existing `BCTR`/`BCTRL` handlers (UJMP/CALL). Enums exist in capstone 4/5/6, so the labels are unconditional.