### PR TITLE
Fix afv mislabeling DWARF register locals as args

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1958,8 +1958,8 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 					R_LOG_ERROR ("Register not found");
 					break;
 				}
-				anal->cb_printf ("arg %s %s @ %s\n",
-					var->type, var->name, i->name);
+				anal->cb_printf ("%s %s %s @ %s\n",
+					var->isarg ? "arg" : "var", var->type, var->name, i->name);
 				}
 				break;
 			case R_ANAL_VAR_KIND_SPV:

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -531,6 +531,20 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME="dwarf register local vs arg classification"
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF
+e asm.dwarf=false
+aaa
+s 0x100014c8
+afv~ @ r3,@ r4
+EOF
+EXPECT=<<EOF
+arg int v @ r4
+var int w @ r3
+EOF
+RUN
+
 NAME="function info integration ada - wrap"
 FILE=bins/elf/ada_test_dwarf 
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `afv` printer's `R_ANAL_VAR_KIND_REG` case hardcoded the `arg` prefix, unlike the BPV/SPV cases which honor `var->isarg`. DWARF register locals were mislabeled `arg` despite being stored correctly. Now prints `arg`/`var` per `var->isarg`.
  
Only DWARF produces `isarg=false` register vars, so nothing else changes. Adds a regression test on `ppc64_sudoku_dwarf`. 
