### PR TITLE
Shadow phantom stack vars overlaid by array-typed variables ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -163,33 +163,35 @@ R_API bool r_anal_function_rebase_vars(RAnal *a, RAnalFunction *fcn) {
 	return true;
 }
 
-// Total byte size of an array type like "char[4]"/"int[9][9]", or 0 if not a sized array
-static int array_type_extent(Sdb *TDB, const char *type) {
+// Element size (bytes) and count of an array type like "char[4]"/"int[9][9]".
+// False if it is not a sized array (unknown element type or missing [N]).
+static bool array_type_info(Sdb *TDB, const char *type, int *esize, int *count) {
 	const char *br = strchr (type, '[');
 	if (!br) {
-		return 0;
+		return false;
 	}
 	char *base = r_str_ndup (type, br - type);
 	if (!base) {
-		return 0;
+		return false;
 	}
 	r_str_trim (base);
 	const ut64 bits = r_type_get_bitsize (TDB, base);
 	free (base);
-	if (!bits) {
-		return 0;
+	if (bits < 8) {
+		return false;
 	}
-	ut64 count = 1;
+	ut64 n = 1;
 	const char *p;
 	for (p = br; p; p = strchr (p + 1, '[')) {
-		const int n = atoi (p + 1);
-		if (n <= 0) {
-			return 0;
+		const int dim = atoi (p + 1);
+		if (dim <= 0) {
+			return false;
 		}
-		count *= (ut64)n;
+		n *= (ut64)dim;
 	}
-	const ut64 total = count * bits / 8;
-	return (int)total;
+	*esize = bits / 8;
+	*count = (int)n;
+	return true;
 }
 
 // If the type of var is a struct,
@@ -197,8 +199,10 @@ static int array_type_extent(Sdb *TDB, const char *type) {
 static void shadow_var_struct_members(RAnal *anal, RAnalVar *var) {
 	Sdb *TDB = var->fcn->anal->sdb_types;
 	// drop emulation slots synthesised inside an array var's extent (e.g. ucTemp[4] byte stores that became arg_81h..83h)
-	if ((var->kind == R_ANAL_VAR_KIND_SPV || var->kind == R_ANAL_VAR_KIND_BPV) && var->type) {
-		const int extent = array_type_extent (TDB, var->type);
+	int esize, count;
+	if ((var->kind == R_ANAL_VAR_KIND_SPV || var->kind == R_ANAL_VAR_KIND_BPV)
+			&& var->type && array_type_info (TDB, var->type, &esize, &count)) {
+		const int extent = esize * count;
 		int off;
 		for (off = 1; off < extent; off++) {
 			RAnalVar *other = r_anal_function_get_var (var->fcn, var->kind, var->delta + off);
@@ -1044,6 +1048,18 @@ static bool var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, RList *list
 			free (field_name);
 		}
 		free (type_key);
+		return true;
+	}
+	int esize, count;
+	if (av->type && array_type_info (TDB, av->type, &esize, &count) && count >= 2 && count <= 256) {
+		int i;
+		for (i = 0; i < count; i++) {
+			RAnalVarField *field = R_NEW0 (RAnalVarField);
+			field->name = i? r_str_newf ("%s[%d]", av->name, i): strdup (av->name);
+			field->delta = av->delta + i * esize;
+			field->field = true;
+			r_list_append (list, field);
+		}
 		return true;
 	}
 	return false;

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -163,10 +163,50 @@ R_API bool r_anal_function_rebase_vars(RAnal *a, RAnalFunction *fcn) {
 	return true;
 }
 
+// Total byte size of an array type like "char[4]"/"int[9][9]", or 0 if not a sized array
+static int array_type_extent(Sdb *TDB, const char *type) {
+	const char *br = strchr (type, '[');
+	if (!br) {
+		return 0;
+	}
+	char *base = r_str_ndup (type, br - type);
+	if (!base) {
+		return 0;
+	}
+	r_str_trim (base);
+	const ut64 bits = r_type_get_bitsize (TDB, base);
+	free (base);
+	if (!bits) {
+		return 0;
+	}
+	ut64 count = 1;
+	const char *p;
+	for (p = br; p; p = strchr (p + 1, '[')) {
+		const int n = atoi (p + 1);
+		if (n <= 0) {
+			return 0;
+		}
+		count *= (ut64)n;
+	}
+	const ut64 total = count * bits / 8;
+	return (int)total;
+}
+
 // If the type of var is a struct,
 // remove all other vars that are overlapped by var and are at the offset of one of its struct members
 static void shadow_var_struct_members(RAnal *anal, RAnalVar *var) {
 	Sdb *TDB = var->fcn->anal->sdb_types;
+	// drop emulation slots synthesised inside an array var's extent (e.g. ucTemp[4] byte stores that became arg_81h..83h)
+	if ((var->kind == R_ANAL_VAR_KIND_SPV || var->kind == R_ANAL_VAR_KIND_BPV) && var->type) {
+		const int extent = array_type_extent (TDB, var->type);
+		int off;
+		for (off = 1; off < extent; off++) {
+			RAnalVar *other = r_anal_function_get_var (var->fcn, var->kind, var->delta + off);
+			if (other && other != var) {
+				r_anal_var_delete (anal, other);
+			}
+		}
+	}
 	const char *type_kind = sdb_const_get (TDB, var->type, 0);
 	if (type_kind && r_str_startswith (type_kind, "struct")) {
 		char *field;

--- a/libr/arch/p/tricore/pseudo.c
+++ b/libr/arch/p/tricore/pseudo.c
@@ -339,7 +339,7 @@ static char *subvar(RAsmPluginSession *aps, RAnalFunction *f, ut64 addr, int opl
 				? p->get_ptr_at (f, sparg->delta, addr)
 				: ST64_MAX;
 			if (delta == ST64_MAX && sparg->field) {
-				delta = sparg->delta;
+				delta = f->maxstack + sparg->delta;
 			} else if (delta == ST64_MAX) {
 				R_FREE (ireg);
 				continue;

--- a/libr/arch/p/x86_nz/pseudo.c
+++ b/libr/arch/p/x86_nz/pseudo.c
@@ -523,7 +523,7 @@ static char *subvar(RAsmPluginSession *aps, RAnalFunction *f, ut64 addr, int opl
 				? p->get_ptr_at (f, sparg->delta, addr)
 				: ST64_MAX;
 			if (delta == ST64_MAX && sparg->field) {
-				delta = sparg->delta;
+				delta = f->maxstack + sparg->delta;
 			} else if (delta == ST64_MAX) {
 				R_FREE (ireg);
 				continue;

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -991,3 +991,53 @@ sradi_pos
 0x00000020
 EOF2
 RUN
+
+NAME=array stack var shadows interior phantom slots
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 986100809861008198610082986100834e800020
+af
+afvs 0x80 ucTemp char[4]
+afvs
+EOF
+EXPECT=<<EOF
+arg char[4] ucTemp @ r1+0x80
+EOF
+RUN
+
+NAME=multidim array stack var shadows interior slots
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 9861002090610040906100884e800020
+af
+afvs 0x20 grid int[9][9]
+afvs
+EOF
+EXPECT=<<EOF
+arg int[9][9] grid @ r1+0x20
+EOF
+RUN
+
+NAME=scalar stack var keeps neighbour slots
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 9061008090610088906100904e800020
+af
+afvs 0x80 x int64_t
+afvs
+EOF
+EXPECT=<<EOF
+arg int64_t x @ r1+0x80
+arg int64_t arg_88h @ r1+0x88
+arg int64_t arg_90h @ r1+0x90
+EOF
+RUN

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -4290,3 +4290,20 @@ family: vec
             0x140021040     .string "\n*,2.)%#1%#)a~" ; len=15
 EOF
 RUN
+
+NAME=array stack var renders interior accesses as name[i]
+FILE=-
+CMDS=<<EOF2
+e asm.arch=x86
+e asm.bits=64
+wx c744242001000000c744242402000000c744242803000000c3
+af
+afvs 0x20 arr int[3]
+pdf~mov dword
+EOF2
+EXPECT=<<EOF2
+|           0x00000000      c744242001..   mov dword [arr], 1
+|           0x00000008      c744242402..   mov dword [arr[1]], 2
+|           0x00000010      c744242803..   mov dword [arr[2]], 3
+EOF2
+RUN

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -293,16 +293,6 @@ EXPECT=<<EOF
 |           ; var int64_t var_70h @ rsp+0x70
 |           ; var int64_t var_78h @ rsp+0x78
 |           ; var i32[11] numbers @ rsp+0x80
-|           ; var int64_t var_84h @ rsp+0x84
-|           ; var int64_t var_88h @ rsp+0x88
-|           ; var int64_t var_8ch @ rsp+0x8c
-|           ; var int64_t var_90h @ rsp+0x90
-|           ; var int64_t var_94h @ rsp+0x94
-|           ; var int64_t var_98h @ rsp+0x98
-|           ; var int64_t var_9ch @ rsp+0x9c
-|           ; var int64_t var_a0h @ rsp+0xa0
-|           ; var int64_t var_a4h @ rsp+0xa4
-|           ; var int64_t var_a8h @ rsp+0xa8
 |           ; var int64_t var_d8h @ rsp+0xd8
 |           ; var int64_t var_e0h @ rsp+0xe0
 |           ; var int64_t var_e8h @ rsp+0xe8
@@ -334,15 +324,15 @@ EXPECT=<<EOF
 |           ; var &str[6] *arg0 @ rsp+0x230
 |           0x00005750      4881ec3802..   sub rsp, 0x238              ; void main();
 |           0x00005757      c784248000..   mov dword [numbers], 8
-|           0x00005762      c784248400..   mov dword [var_84h], 7
-|           0x0000576d      c784248800..   mov dword [var_88h], 1
-|           0x00005778      c784248c00..   mov dword [var_8ch], 2
-|           0x00005783      c784249000..   mov dword [var_90h], 9
-|           0x0000578e      c784249400..   mov dword [var_94h], 3
-|           0x00005799      c784249800..   mov dword [var_98h], 4
-|           0x000057a4      c784249c00..   mov dword [var_9ch], 5
-|           0x000057af      c78424a000..   mov dword [var_a0h], 0
-|           0x000057ba      c78424a400..   mov dword [var_a4h], 6
+|           0x00005762      c784248400..   mov dword [rsp + 0x84], 7
+|           0x0000576d      c784248800..   mov dword [rsp + 0x88], 1
+|           0x00005778      c784248c00..   mov dword [rsp + 0x8c], 2
+|           0x00005783      c784249000..   mov dword [rsp + 0x90], 9
+|           0x0000578e      c784249400..   mov dword [rsp + 0x94], 3
+|           0x00005799      c784249800..   mov dword [rsp + 0x98], 4
+|           0x000057a4      c784249c00..   mov dword [rsp + 0x9c], 5
+|           0x000057af      c78424a000..   mov dword [rsp + 0xa0], 0
+|           0x000057ba      c78424a400..   mov dword [rsp + 0xa4], 6
 |           0x000057c5      488b05842b..   mov rax, qword [0x00038350] ; [0x38350:8]=0x38330 reloc.fixup.Before:_After:_beachartcardeal
 |           0x000057cc      488d8c2480..   lea rcx, [numbers]
 |           0x000057d4      48898c24e8..   mov qword [var_e8h], rcx
@@ -359,7 +349,7 @@ EXPECT=<<EOF
 |           0x00005817      488b4c2468     mov rcx, qword [var_68h]
 |           0x0000581c      48898c24e0..   mov qword [var_e0h], rcx
 |           0x00005824      488d9424d8..   lea rdx, [var_d8h]
-|           0x0000582c      488dbc24a8..   lea rdi, [var_a8h]          ; int64_t arg1
+|           0x0000582c      488dbc24a8..   lea rdi, [rsp + 0xa8]       ; int64_t arg1
 |           0x00005834      488b742478     mov rsi, qword [var_78h]    ; int64_t arg2
 |           0x00005839      41b802000000   mov r8d, 2
 |           0x0000583f      4889542460     mov qword [var_60h], rdx
@@ -367,7 +357,7 @@ EXPECT=<<EOF
 |           0x00005847      488b4c2460     mov rcx, qword [var_60h]    ; int64_t arg4
 |           0x0000584c      41b801000000   mov r8d, 1                  ; int64_t arg5
 |           0x00005852      e8591b0000     call dbg.new_v1             ; core::fmt::Arguments::new_v1::h2673b5bf555c0288 ; Arguments new_v1(&[&str] pieces, &[core::fmt::ArgumentV1] args)
-|           0x00005857      488dbc24a8..   lea rdi, [var_a8h]
+|           0x00005857      488dbc24a8..   lea rdi, [rsp + 0xa8]
 |           0x0000585f      ff15b3430300   call qword [dbg._print]     ; [0x39c18:8]=0xa2d0 dbg._print
 |           0x00005865      488d842480..   lea rax, [numbers]
 |           0x0000586d      4889c7         mov rdi, rax                ; int64_t arg1

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -324,15 +324,15 @@ EXPECT=<<EOF
 |           ; var &str[6] *arg0 @ rsp+0x230
 |           0x00005750      4881ec3802..   sub rsp, 0x238              ; void main();
 |           0x00005757      c784248000..   mov dword [numbers], 8
-|           0x00005762      c784248400..   mov dword [rsp + 0x84], 7
-|           0x0000576d      c784248800..   mov dword [rsp + 0x88], 1
-|           0x00005778      c784248c00..   mov dword [rsp + 0x8c], 2
-|           0x00005783      c784249000..   mov dword [rsp + 0x90], 9
-|           0x0000578e      c784249400..   mov dword [rsp + 0x94], 3
-|           0x00005799      c784249800..   mov dword [rsp + 0x98], 4
-|           0x000057a4      c784249c00..   mov dword [rsp + 0x9c], 5
-|           0x000057af      c78424a000..   mov dword [rsp + 0xa0], 0
-|           0x000057ba      c78424a400..   mov dword [rsp + 0xa4], 6
+|           0x00005762      c784248400..   mov dword [numbers[1]], 7
+|           0x0000576d      c784248800..   mov dword [numbers[2]], 1
+|           0x00005778      c784248c00..   mov dword [numbers[3]], 2
+|           0x00005783      c784249000..   mov dword [numbers[4]], 9
+|           0x0000578e      c784249400..   mov dword [numbers[5]], 3
+|           0x00005799      c784249800..   mov dword [numbers[6]], 4
+|           0x000057a4      c784249c00..   mov dword [numbers[7]], 5
+|           0x000057af      c78424a000..   mov dword [numbers[8]], 0
+|           0x000057ba      c78424a400..   mov dword [numbers[9]], 6
 |           0x000057c5      488b05842b..   mov rax, qword [0x00038350] ; [0x38350:8]=0x38330 reloc.fixup.Before:_After:_beachartcardeal
 |           0x000057cc      488d8c2480..   lea rcx, [numbers]
 |           0x000057d4      48898c24e8..   mov qword [var_e8h], rcx
@@ -349,7 +349,7 @@ EXPECT=<<EOF
 |           0x00005817      488b4c2468     mov rcx, qword [var_68h]
 |           0x0000581c      48898c24e0..   mov qword [var_e0h], rcx
 |           0x00005824      488d9424d8..   lea rdx, [var_d8h]
-|           0x0000582c      488dbc24a8..   lea rdi, [rsp + 0xa8]       ; int64_t arg1
+|           0x0000582c      488dbc24a8..   lea rdi, [numbers[10]]      ; int64_t arg1
 |           0x00005834      488b742478     mov rsi, qword [var_78h]    ; int64_t arg2
 |           0x00005839      41b802000000   mov r8d, 2
 |           0x0000583f      4889542460     mov qword [var_60h], rdx
@@ -357,7 +357,7 @@ EXPECT=<<EOF
 |           0x00005847      488b4c2460     mov rcx, qword [var_60h]    ; int64_t arg4
 |           0x0000584c      41b801000000   mov r8d, 1                  ; int64_t arg5
 |           0x00005852      e8591b0000     call dbg.new_v1             ; core::fmt::Arguments::new_v1::h2673b5bf555c0288 ; Arguments new_v1(&[&str] pieces, &[core::fmt::ArgumentV1] args)
-|           0x00005857      488dbc24a8..   lea rdi, [rsp + 0xa8]
+|           0x00005857      488dbc24a8..   lea rdi, [numbers[10]]
 |           0x0000585f      ff15b3430300   call qword [dbg._print]     ; [0x39c18:8]=0xa2d0 dbg._print
 |           0x00005865      488d842480..   lea rax, [numbers]
 |           0x0000586d      4889c7         mov rdi, rax                ; int64_t arg1


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

r2 already drops stack slots overlaid by struct members (`shadow_var_struct_members`); this extends the same cleanup to arrays.

When an array-typed stack var is set (DWARF during `aaa`, or `afvt`/`afvs name T[N]`), emulation-invented slots landing inside its `[delta, delta+size)` extent are removed. Previously a declared `int buf[11]` showed up alongside ~10 phantom `var_NNh` locals, cluttering `afv`/`pdf` and the frame layout. Gated to array types, so scalars and structs are unchanged.

Tests added in `test/db/anal/ppc` (single/multi-dim + a guard that adjacent scalars survive); `test/db/cmd/dwarf` rust output updated.