### PR TITLE
Preserve spaces in constructed string comments

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4328,17 +4328,18 @@ static void add_string_ref(RCore *core, ut64 xref_from, ut64 xref_to) {
 	}
 	if (is_string_at (core, xref_to, str, &len) && str[0] && len > 0) {
 		r_anal_xrefs_set (core->anal, xref_from, xref_to, reftype);
-		r_name_filter (str, -1);
-		if (*str) {
+		char *str_flagname = r_name_filter_dup (str);
+		if (R_STR_ISNOTEMPTY (str_flagname)) {
 			RFlagItem *flag = r_core_flag_get_by_spaces (core->flags, false, xref_to);
 			if (!flag || !r_str_startswith (flag->name, "str.")) {
 				r_flag_space_push (core->flags, R_FLAGS_FS_STRINGS);
-				char *strf = r_str_newf ("str.%s", str);
+				char *strf = r_str_newf ("str.%s", str_flagname);
 				r_flag_set (core->flags, strf, xref_to, len);
 				free (strf);
 				r_flag_space_pop (core->flags);
 			}
 		}
+		free (str_flagname);
 		RAnalMetaItem *mi = r_meta_get_at (core->anal, xref_to, R_META_TYPE_ANY, NULL);
 		if (!mi || mi->type != R_META_TYPE_STRING) {
 			r_meta_set (core->anal, R_META_TYPE_STRING, xref_to, len, str);

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -2354,19 +2354,29 @@ static void search_hit_at(RCore *core, struct search_parameters *param, RCoreAsm
 	}
 	if (param->searchflags) {
 		if (R_STR_ISNOTEMPTY (str)) {
-			// TODO: use the api instead
-			char *s = r_str_newf ("string \"%s\"", str);
-			r_core_cmdf (core, "'0x%08"PFMT64x"'CC %s", hit->addr, s);
-			free (s);
+			char *escaped = r_str_escape (str);
+			if (escaped) {
+				char *comment = r_str_newf ("string \"%s\"", escaped);
+				if (comment) {
+					r_meta_set_string (core->anal, R_META_TYPE_COMMENT, hit->addr, comment);
+					free (comment);
+				}
+				free (escaped);
+			}
 		}
 		if (param->outmode != R_MODE_SIMPLE) {
-			char *flagname = (R_STR_ISNOTEMPTY (str)) // XXX i think hit->code is not used anywhere
-				? r_str_newf ("asm.str.%d_%s_%d", kwidx, str, param->count)
+			char *flagstr = NULL;
+			if (R_STR_ISNOTEMPTY (str)) {
+				flagstr = r_name_filter_dup (str);
+			}
+			char *flagname = R_STR_ISNOTEMPTY (flagstr) // XXX i think hit->code is not used anywhere
+				? r_str_newf ("asm.str.%d_%s_%d", kwidx, flagstr, param->count)
 				: r_str_newf ("%s%d_%d", param->searchprefix, kwidx, param->count);
 			if (flagname) {
 				r_flag_set (core->flags, flagname, hit->addr, hit->len);
 				free (flagname);
 			}
+			free (flagstr);
 		}
 	}
 }
@@ -2720,7 +2730,6 @@ static bool do_analstr_search(RCore *core, struct search_parameters *param, bool
 									pj_end (pj);
 								} else {
 									r_strbuf_appendf (rb, "0x%08"PFMT64x" %s\n", firstch, ss);
-									r_name_filter (ss, -1);
 									RCoreAsmHit cah = {
 										.addr = firstch,
 										.len = lastch - firstch,

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5093,9 +5093,12 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		canHaveChar = true;
 		break;
 	}
+	const bool scalar_stack_imm = ds->analop.stackop == R_ANAL_STACK_SET
+		&& ds->analop.refptr <= 1 && ds->analop.val == ds->analop.ptr
+		&& ds->analop.val <= UT8_MAX;
 
 	ds->chref = 0;
-	if ((char)v > 0 && v >= '!') {
+	if ((ut8)v >= ' ') {
 		ds->chref = (char)v;
 		if (ds->immstr) {
 			char *str = r_str_from_ut64 (r_read_ble64 (&v, be));
@@ -5120,7 +5123,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			}
 			free (str);
 		} else {
-			if (canHaveChar && (char)v > 0 && v >= (int)'!' && v <= (int)'~') {
+			if (canHaveChar && (char)v > 0 && v >= (int)' ' && v <= (int)'~') {
 				ds_begin_comment (ds);
 				aligned = true;
 				if (v != ds->analop.ptr) {
@@ -5129,23 +5132,29 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			}
 		}
 	}
+	if (canHaveChar && scalar_stack_imm) {
+		refaddr = UT64_MAX;
+	}
 
-	RVecAnalRef *refs = r_anal_refs_get (core->anal, ds->at);
-	if (refs) {
-		RAnalRef *ref;
-		R_VEC_FOREACH (refs, ref) {
-			int rt = R_ANAL_REF_TYPE_MASK (ref->type);
-			if (rt == R_ANAL_REF_TYPE_STRN || rt == R_ANAL_REF_TYPE_DATA) {
-				if ((f = r_flag_get_in (core->flags, ref->addr))) {
-					refaddr = ref->addr;
-					break;
+	if (!scalar_stack_imm) {
+		RVecAnalRef *refs = r_anal_refs_get (core->anal, ds->at);
+		if (refs) {
+			RAnalRef *ref;
+			R_VEC_FOREACH (refs, ref) {
+				int rt = R_ANAL_REF_TYPE_MASK (ref->type);
+				if (rt == R_ANAL_REF_TYPE_STRN || rt == R_ANAL_REF_TYPE_DATA) {
+					if ((f = r_flag_get_in (core->flags, ref->addr))) {
+						refaddr = ref->addr;
+						break;
+					}
 				}
 			}
+			RVecAnalRef_free (refs);
 		}
 	}
-	RVecAnalRef_free (refs);
 
-	if (ds->analop.type == (R_ANAL_OP_TYPE_MOV | R_ANAL_OP_TYPE_REG)
+	if (!scalar_stack_imm
+	    && ds->analop.type == (R_ANAL_OP_TYPE_MOV | R_ANAL_OP_TYPE_REG)
 	    && ds->analop.stackop == R_ANAL_STACK_SET
 	    && ds->analop.val != UT64_MAX && ds->analop.val > 10) {
 		const char *arch = r_config_get (core->config, "asm.arch");

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5098,7 +5098,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 		&& ds->analop.val <= UT8_MAX;
 
 	ds->chref = 0;
-	if ((ut8)v >= ' ') {
+	if ((char)v > 0 && (v >= '!' || (scalar_stack_imm && v == ' '))) {
 		ds->chref = (char)v;
 		if (ds->immstr) {
 			char *str = r_str_from_ut64 (r_read_ble64 (&v, be));

--- a/test/db/cmd/cmd_search_asm
+++ b/test/db/cmd/cmd_search_asm
@@ -227,6 +227,23 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=constructed string spaces keep display and flag domains separate
+FILE=hex://554889e5c645d041c645d172c645d237c645d368c645d455c645d572c645d620c645d763c645d82ec645d920c645da43c645db6cc645dc34c645dd72c645de6bc645df335dc3
+ARGS=-a x86 -b 64 -e scr.color=0
+CMDS=<<EOF
+af
+/az 5
+CC. @ 4
+f~asm.str
+EOF
+EXPECT=<<EOF
+0x00000004 Ar7hUr c. Cl4rk3
+
+string "Ar7hUr c. Cl4rk3"
+0x00000004 60 asm.str.0_Ar7hUr_c._Cl4rk3_1
+EOF
+RUN
 NAME=search constructed strings
 FILE=bins/mach0/iGoat-Swift.arm_64.1
 CMDS=<<EOF
@@ -478,4 +495,3 @@ EXPECT=<<EOF
 ]
 EOF
 RUN
-


### PR DESCRIPTION
## Summary

This keeps constructed-string display text separate from command-safe flag names.

- Preserve spaces in constructed-string comments and `/az` output.
- Continue sanitizing generated `asm.str.*` flag names with a separate filtered copy.
- Avoid treating byte-sized stack-store immediates like `0x20` as pointer references in disassembly comments.
- Add an r2r regression using a lightweight `hex://` x86 snippet.

## Root Cause

The constructed-string search path reused one sanitized string for both display comments and generated flag names. That leaked identifier-safe transformations into user-facing string output, so spaces were shown as underscores. Separately, `pd` could treat scalar byte-store immediates as data references, so `0x20` was dereferenced and displayed as `"@"` instead of as a space character.

## Validation

- `make -j > /dev/null`
- `R2R_RADARE2=/Users/priyanshu/code/radare2/binr/radare2/radare2 R2R_RASM2=/Users/priyanshu/code/radare2/binr/rasm2/rasm2 ./binr/r2r/r2r test/db/cmd/cmd_search_asm`
- `R2R_RADARE2=/Users/priyanshu/code/radare2/binr/radare2/radare2 R2R_RASM2=/Users/priyanshu/code/radare2/binr/rasm2/rasm2 ./binr/r2r/r2r test/db/cmd/cmd_pd_str`

Note: local build prints existing macOS/Xcode command-line-tools and linker warnings, but exits successfully.