### PR TITLE
Meson use_sys_zydis: find library as capital "Zydis" ##build 

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -315,7 +315,7 @@ if want_zydis
   if get_option('use_sys_zydis')
     zydis_dep = dependency('zydis', required: false)
     if not zydis_dep.found()
-      zydis_dep = cc.find_library('zydis', required: true)
+      zydis_dep = cc.find_library('Zydis', required: true)
     endif
     cc.has_header('Zydis/Zydis.h', dependencies: zydis_dep, required: true)
     zydis_dep = declare_dependency(


### PR DESCRIPTION
Fix #26058 - meson.build cannot find system zydis (casing of library different than expected)

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

I built it successfully after this!

**Description**

<!-- explain your changes if necessary -->
