### PR TITLE
Detect ppc32 e500/e500mc CPU from .PPC.EMB.apuinfo  ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2933,6 +2933,45 @@ static const char *v850_flags_to_cpu(ut32 type) {
 	return NULL;
 }
 
+#define PPC_APU_ISEL 0x40
+#define PPC_APU_SPE  0x100
+#define PPC_APU_EFS  0x101
+
+static char *ppc_apuinfo_to_cpu(ELFOBJ *eo) {
+	if (eo->ehdr.e_machine != EM_PPC) {
+		return NULL;
+	}
+	RBinElfSection *sec = get_section_by_name (eo, ".PPC.EMB.apuinfo");
+	if (!sec || sec->offset > eo->size || sec->size < sizeof (Elf_(Nhdr))
+		|| sec->size > eo->size - sec->offset) {
+		return NULL;
+	}
+	const ut64 base = sec->offset;
+	const ut32 namesz = r_buf_read_ble32_at (eo->b, base, eo->endian);
+	const ut32 descsz = r_buf_read_ble32_at (eo->b, base + 4, eo->endian);
+	const ut64 desc_off = base + sizeof (Elf_(Nhdr)) + round_up (namesz);
+	if (namesz > sec->size || desc_off + descsz > base + sec->size) {
+		return NULL;
+	}
+	bool has_isel = false, has_spe = false;
+	ut32 off;
+	for (off = 0; off + 4 <= descsz; off += 4) {
+		switch (r_buf_read_ble32_at (eo->b, desc_off + off, eo->endian) >> 16) {
+		case PPC_APU_SPE:
+		case PPC_APU_EFS:
+			has_spe = true;
+			break;
+		case PPC_APU_ISEL:
+			has_isel = true;
+			break;
+		}
+	}
+	if (has_spe) {
+		return strdup ("e500");
+	}
+	return has_isel? strdup ("e500mc"): NULL;
+}
+
 char* Elf_(get_cpu)(ELFOBJ *eo) {
 	char *cpu = NULL;
 
@@ -2958,6 +2997,9 @@ char* Elf_(get_cpu)(ELFOBJ *eo) {
 		break;
 	case EM_SBPF:
 		cpu = r_str_newf ("sbpfv%d", eo->ehdr.e_flags);
+		break;
+	case EM_PPC:
+		cpu = ppc_apuinfo_to_cpu (eo);
 		break;
 	default:
 		break;

--- a/test/db/formats/elf/ppc32-apuinfo
+++ b/test/db/formats/elf/ppc32-apuinfo
@@ -1,0 +1,15 @@
+NAME=ELF PPC: cpu derived from .PPC.EMB.apuinfo isel APU
+FILE=bins/elf/ppc32-e500mc-isel
+CMDS=iI~cpu[1]
+EXPECT=<<EOF
+e500mc
+EOF
+RUN
+
+NAME=ELF PPC: apuinfo cpu also exposed via ij
+FILE=bins/elf/ppc32-e500mc-isel
+CMDS=ij~{bin.cpu}
+EXPECT=<<EOF
+e500mc
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ppc32 ELF binaries built for Freescale e500/e500mc cores carry a .PPC.EMB.apuinfo note listing the APUs (SPE/EFS, isel) the code uses, but r2 reported no cpu for them.

Parse the note's APU entries in get_cpu: SPE/EFS → "e500", isel-only → "e500mc". Bounds-checked against the section/buffer; EM_PPC only, so other arches are unaffected. The cpu is surfaced via iI and ij (bin.cpu).