### PR TITLE
Validate asm.cpu through arch CPU metadata

### DIFF
--- a/libr/arch/arch_config.c
+++ b/libr/arch/arch_config.c
@@ -41,6 +41,151 @@ R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cp
 	config->cpu = R_STR_ISNOTEMPTY (cpu) ? strdup (cpu) : NULL;
 }
 
+static void set_cpu_canonical(char **canonical, const char *cpu) {
+	if (canonical) {
+		*canonical = strdup (cpu);
+	}
+}
+
+static void set_cpu_canonical_n(char **canonical, const char *cpu, size_t len) {
+	if (canonical) {
+		*canonical = r_str_ndup (cpu, len);
+	}
+}
+
+static RArchCpuMatch match_cpu_name(const char *name, const char *cpu, char **canonical) {
+	R_RETURN_VAL_IF_FAIL (name && cpu, R_ARCH_CPU_MATCH_INVALID);
+	if (!strcmp (name, cpu)) {
+		set_cpu_canonical (canonical, name);
+		return R_ARCH_CPU_MATCH_VALID;
+	}
+	if (!r_str_casecmp (name, cpu)) {
+		set_cpu_canonical (canonical, name);
+		return R_ARCH_CPU_MATCH_CANONICALIZED;
+	}
+	return R_ARCH_CPU_MATCH_INVALID;
+}
+
+static RArchCpuMatch match_cpu_aliases(const char **aliases, const char *cpu, char **canonical, const char *name) {
+	R_RETURN_VAL_IF_FAIL (name && cpu, R_ARCH_CPU_MATCH_INVALID);
+	if (!aliases) {
+		return R_ARCH_CPU_MATCH_INVALID;
+	}
+	int i;
+	for (i = 0; aliases[i]; i++) {
+		RArchCpuMatch match = match_cpu_name (aliases[i], cpu, NULL);
+		if (match != R_ARCH_CPU_MATCH_INVALID) {
+			set_cpu_canonical (canonical, name);
+			return R_ARCH_CPU_MATCH_CANONICALIZED;
+		}
+	}
+	return R_ARCH_CPU_MATCH_INVALID;
+}
+
+static RArchCpuMatch match_cpu_csv(const char *cpus, const char *cpu, char **canonical) {
+	R_RETURN_VAL_IF_FAIL (cpu, R_ARCH_CPU_MATCH_INVALID);
+	if (R_STR_ISEMPTY (cpus)) {
+		return R_ARCH_CPU_MATCH_UNKNOWN_DOMAIN;
+	}
+	const size_t cpu_len = strlen (cpu);
+	const char *p = cpus;
+	while (*p) {
+		const char *q = strchr (p, ',');
+		size_t len = q? q - p: strlen (p);
+		if (len && cpu_len == len && !r_str_ncasecmp (p, cpu, len)) {
+			set_cpu_canonical_n (canonical, p, len);
+			return !strncmp (p, cpu, len)? R_ARCH_CPU_MATCH_VALID: R_ARCH_CPU_MATCH_CANONICALIZED;
+		}
+		p = q? q + 1: p + len;
+	}
+	return R_ARCH_CPU_MATCH_INVALID;
+}
+
+R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin) {
+	R_RETURN_VAL_IF_FAIL (plugin, NULL);
+	RList *list = r_list_newf (free);
+	if (!list) {
+		return NULL;
+	}
+	if (plugin->cpu_models && plugin->cpu_models_count > 0) {
+		size_t i;
+		for (i = 0; i < plugin->cpu_models_count; i++) {
+			const char *name = plugin->cpu_models[i].name;
+			if (R_STR_ISNOTEMPTY (name)) {
+				r_list_append (list, strdup (name));
+			}
+		}
+	} else if (plugin->cpus) {
+		char *c = strdup (plugin->cpus);
+		int i, n = r_str_split (c, ',');
+		for (i = 0; i < n; i++) {
+			const char *word = r_str_word_get0 (c, i);
+			if (R_STR_ISNOTEMPTY (word)) {
+				r_list_append (list, strdup (word));
+			}
+		}
+		free (c);
+	}
+	return list;
+}
+
+R_API RArchCpuMatch r_arch_plugin_match_cpu(RArchPlugin *plugin, const char *cpu, char **canonical) {
+	R_RETURN_VAL_IF_FAIL (plugin, R_ARCH_CPU_MATCH_INVALID);
+	if (canonical) {
+		*canonical = NULL;
+	}
+	if (R_STR_ISEMPTY (cpu)) {
+		if (canonical) {
+			*canonical = strdup ("");
+		}
+		return R_ARCH_CPU_MATCH_VALID;
+	}
+	RArchCpuMatch match = R_ARCH_CPU_MATCH_INVALID;
+	if (plugin->meta.name) {
+		match = match_cpu_name (plugin->meta.name, cpu, canonical);
+		if (match != R_ARCH_CPU_MATCH_INVALID) {
+			return match;
+		}
+	}
+	if (plugin->arch) {
+		match = match_cpu_name (plugin->arch, cpu, canonical);
+		if (match != R_ARCH_CPU_MATCH_INVALID) {
+			return match;
+		}
+	}
+	if (plugin->cpu_models && plugin->cpu_models_count > 0) {
+		size_t i;
+		for (i = 0; i < plugin->cpu_models_count; i++) {
+			const RArchCpu *model = &plugin->cpu_models[i];
+			if (model->name) {
+				match = match_cpu_name (model->name, cpu, canonical);
+				if (match != R_ARCH_CPU_MATCH_INVALID) {
+					return match;
+				}
+				match = match_cpu_aliases (model->aliases, cpu, canonical, model->name);
+				if (match != R_ARCH_CPU_MATCH_INVALID) {
+					return match;
+				}
+			}
+		}
+		return R_ARCH_CPU_MATCH_INVALID;
+	}
+	return match_cpu_csv (plugin->cpus, cpu, canonical);
+}
+
+R_API char *r_arch_plugin_cpu_match(RArchPlugin *plugin, const char *cpu) {
+	char *canonical = NULL;
+	RArchCpuMatch match = r_arch_plugin_match_cpu (plugin, cpu, &canonical);
+	if (match == R_ARCH_CPU_MATCH_INVALID) {
+		free (canonical);
+		return NULL;
+	}
+	if (match == R_ARCH_CPU_MATCH_UNKNOWN_DOMAIN && !canonical) {
+		return strdup (r_str_get (cpu));
+	}
+	return canonical;
+}
+
 R_API bool r_arch_config_set_bits(RArchConfig *config, int bits) {
 	R_RETURN_VAL_IF_FAIL (config, false);
 	// if the config is tied to a session, there must be a callback to notify the plugin

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4983,7 +4983,6 @@ static bool fini(RArchSession *as) {
 }
 
 static const RArchCpu arm_cpu_models[] = {
-	{ "cortex", "ARM Cortex", NULL, 0 },
 	{ "v8", "ARMv8", NULL, 0 },
 };
 
@@ -4996,7 +4995,7 @@ const RArchPlugin r_arch_plugin_arm_cs = {
 	.arch = "arm",
 	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
 	.bits = R_SYS_BITS_PACK3 (16, 32, 64),
-	.cpus = "cortex,v8",
+	.cpus = "v8",
 	.cpu_models = arm_cpu_models,
 	.cpu_models_count = R_ARRAY_SIZE (arm_cpu_models),
 #if 0

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4867,8 +4867,10 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != pd->bigendian) {
 		return true;
 	}
-	if (pd->cpu && as->config->cpu && strcmp (pd->cpu, as->config->cpu)) {
-		return true;
+	if (pd->cpu || as->config->cpu) {
+		if (!pd->cpu || !as->config->cpu || strcmp (pd->cpu, as->config->cpu)) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4983,6 +4983,7 @@ static bool fini(RArchSession *as) {
 }
 
 static const RArchCpu arm_cpu_models[] = {
+	{ "cortex", "ARM Cortex", NULL, 0 },
 	{ "v8", "ARMv8", NULL, 0 },
 };
 
@@ -4995,7 +4996,7 @@ const RArchPlugin r_arch_plugin_arm_cs = {
 	.arch = "arm",
 	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
 	.bits = R_SYS_BITS_PACK3 (16, 32, 64),
-	.cpus = "v8",
+	.cpus = "cortex,v8",
 	.cpu_models = arm_cpu_models,
 	.cpu_models_count = R_ARRAY_SIZE (arm_cpu_models),
 #if 0

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4982,6 +4982,11 @@ static bool fini(RArchSession *as) {
 	return true;
 }
 
+static const RArchCpu arm_cpu_models[] = {
+	{ "cortex", "ARM Cortex", NULL, 0 },
+	{ "v8", "ARMv8", NULL, 0 },
+};
+
 const RArchPlugin r_arch_plugin_arm_cs = {
 	.meta = {
 		.name = "arm",
@@ -4992,6 +4997,8 @@ const RArchPlugin r_arch_plugin_arm_cs = {
 	.endian = R_SYS_ENDIAN_LITTLE | R_SYS_ENDIAN_BIG,
 	.bits = R_SYS_BITS_PACK3 (16, 32, 64),
 	.cpus = "cortex,v8",
+	.cpu_models = arm_cpu_models,
+	.cpu_models_count = R_ARRAY_SIZE (arm_cpu_models),
 #if 0
 	// made obsolete by "e anal.mask = true"
 	.anal_mask = anal_mask,

--- a/libr/arch/p/avr/plugin.c
+++ b/libr/arch/p/avr/plugin.c
@@ -201,7 +201,7 @@ static CPU_MODEL *__get_cpu_model_recursive(PluginData *pd, const char *model) {
 
 static CPU_MODEL *get_cpu_model(PluginData *pd, const char *model) {
 	if (!model) {
-		model = "ATmega8";
+		model = "ATxmega128a4u";
 	}
 	// cache
 	if (pd->cpu && pd->cpu->model && !r_str_casecmp (model, pd->cpu->model)) {

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -945,9 +945,10 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != cpd->bigendian) {
 		return true;
 	}
-	if (cpd->cpu && as->config->cpu && strcmp (cpd->cpu, as->config->cpu)) {
-		eprintf ("cpudif\n");
-		return true;
+	if (cpd->cpu || as->config->cpu) {
+		if (!cpd->cpu || !as->config->cpu || strcmp (cpd->cpu, as->config->cpu)) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -1471,10 +1471,9 @@ R_API int r_asm_mnemonics_byname(RAsm *a, const char *name) {
 
 R_API RList *r_asm_cpus(RAsm *a) {
 	R_RETURN_VAL_IF_FAIL (a, NULL);
-	// R2_600 move to r_arch api instead?
-	const char *cpus = R_UNWRAP5 (a, arch, session, plugin, cpus);
-	RList *list = cpus
-		? r_str_split_duplist (cpus, ",", 0)
+	RArchPlugin *plugin = R_UNWRAP4 (a, arch, session, plugin);
+	RList *list = plugin
+		? r_arch_plugin_cpus (plugin)
 		: r_list_newf (free);
 	r_list_sort (list, (RListComparator)strcmp);
 	return list;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -770,30 +770,58 @@ static void update_asmcpu_options(RCore *core, RConfigNode *node) {
 	r_config_node_purge_options (node);
 	RArchPlugin *h;
 	r_list_foreach (core->anal->arch->libstore->plugins, iter, h) {
-		if (h->cpus && !strcmp (arch, h->meta.name)) {
-			char *c = strdup (h->cpus);
-			int i, n = r_str_split (c, ',');
-			for (i = 0; i < n; i++) {
-				const char *word = r_str_word_get0 (c, i);
-				if (word && *word) {
+		if (!strcmp (arch, h->meta.name)) {
+			RList *cpus = r_arch_plugin_cpus (h);
+			RListIter *iter2;
+			char *word;
+			r_list_foreach (cpus, iter2, word) {
+				if (R_STR_ISNOTEMPTY (word)) {
 					node->options->free = free;
 					SETOPTIONS (node, word, NULL);
 				}
 			}
-			free (c);
+			r_list_free (cpus);
 		}
 	}
 }
 static void list_cpus(RCore *core) {
 	RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
-	if (ap && ap->cpus) {
-		char *c = strdup (ap->cpus);
-		int i, n = r_str_split (c, ',');
-		for (i = 0; i < n; i++) {
-			r_cons_println (core->cons, r_str_word_get0 (c, i));
+	if (ap) {
+		RList *cpus = r_arch_plugin_cpus (ap);
+		RListIter *iter;
+		char *cpu;
+		r_list_foreach (cpus, iter, cpu) {
+			r_cons_println (core->cons, cpu);
 		}
-		free (c);
+		r_list_free (cpus);
 	}
+}
+
+static char *canonical_asmcpu(RCore *core, const char *cpu) {
+	RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
+	return ap? r_arch_plugin_cpu_match (ap, cpu): strdup (r_str_get (cpu));
+}
+
+static bool normalize_asmcpu(RCore *core, RConfigNode *node, bool warn) {
+	char *cpu = canonical_asmcpu (core, node? node->value: NULL);
+	if (!cpu) {
+		if (warn) {
+			const char *arch = r_config_get (core->config, "asm.arch");
+			if (R_STR_ISNOTEMPTY (arch)) {
+				R_LOG_WARN ("asm.cpu: invalid value '%s' for '%s'. See 'e asm.cpu=?'", node->value, arch);
+			} else {
+				R_LOG_WARN ("asm.cpu: invalid value '%s'. See 'e asm.cpu=?'", node->value);
+			}
+		}
+		return false;
+	}
+	if (strcmp (cpu, node->value)) {
+		free (node->value);
+		node->value = cpu;
+	} else {
+		free (cpu);
+	}
+	return true;
 }
 
 static bool cb_asmcpu(void *user, void *data) {
@@ -805,6 +833,9 @@ static bool cb_asmcpu(void *user, void *data) {
 		update_asmcpu_options (core, node);
 #endif
 		return 0;
+	}
+	if (!normalize_asmcpu (core, node, true)) {
+		return false;
 	}
 	r_core_esil_unload_arch (core);
 	r_arch_config_set_cpu (core->rasm->config, node->value);
@@ -894,16 +925,6 @@ static bool cb_asmarch(void *user, void *data) {
 			free (s);
 		}
 	}
-	// set codealign
-	if (core->anal) {
-		const char *asmcpu = r_config_get (core->config, "asm.cpu");
-		const char *asmos = r_config_get (core->config, "asm.os");
-		int bits = (core->anal->config)? core->anal->config->bits: r_config_get_i (core->config, "asm.bits");
-		if (!r_syscall_setup (core->anal->syscall, node->value, bits, asmcpu, asmos)) {
-			// R_LOG_ERROR ("asm.arch: Cannot setup syscall '%s/%s' from '%s'",
-			//	node->value, asmos, R2_LIBDIR"/radare2/"R2_VERSION"/syscall");
-		}
-	}
 	// if (!strcmp (node->value, "bf"))
 	//	r_config_set (core->config, "dbg.backend", "bf");
 	__setsegoff (core->config, node->value, core->rasm->config->bits);
@@ -919,8 +940,22 @@ static bool cb_asmarch(void *user, void *data) {
 
 	RConfigNode *asmcpu = r_config_node_get (core->config, "asm.cpu");
 	if (asmcpu) {
-		r_arch_config_set_cpu (core->rasm->config, asmcpu->value);
 		update_asmcpu_options (core, asmcpu);
+		if (!normalize_asmcpu (core, asmcpu, false)) {
+			(void)r_config_set (core->config, "asm.cpu", "");
+		} else {
+			r_arch_config_set_cpu (core->rasm->config, asmcpu->value);
+		}
+	}
+	// set codealign
+	if (core->anal) {
+		const char *asmcpu_value = r_config_get (core->config, "asm.cpu");
+		const char *asmos = r_config_get (core->config, "asm.os");
+		int bits = (core->anal->config)? core->anal->config->bits: r_config_get_i (core->config, "asm.bits");
+		if (!r_syscall_setup (core->anal->syscall, node->value, bits, asmcpu_value, asmos)) {
+			// R_LOG_ERROR ("asm.arch: Cannot setup syscall '%s/%s' from '%s'",
+			//	node->value, asmos, R2_LIBDIR"/radare2/"R2_VERSION"/syscall");
+		}
 	}
 	{
 		int v = r_arch_info (core->anal->arch, R_ARCH_INFO_CODE_ALIGN);

--- a/libr/core/cmd_log.inc.c
+++ b/libr/core/cmd_log.inc.c
@@ -539,15 +539,15 @@ static int cmd_plugins(void *data, const char *input) {
 						pj_ks (pj, "arch", item->arch);
 					}
 					pj_ks (pj, "endian", (item->endian == R_SYS_ENDIAN_BIG)? "big": "little");
-					if (item->cpus) {
+					list = r_arch_plugin_cpus (item);
+					if (!r_list_empty (list)) {
 						pj_ka (pj, "cpus");
-						list = r_str_split_list (strdup (item->cpus), ",", 0);
 						r_list_foreach (list, iter2, cpu) {
 							pj_s (pj, cpu);
 						}
-						r_list_free (list);
 						pj_end (pj);
 					}
+					r_list_free (list);
 					pj_ka (pj, "bits");
 					int i;
 					for (i = 0; i < 8; i++) {

--- a/libr/include/r_arch.h
+++ b/libr/include/r_arch.h
@@ -153,6 +153,20 @@ typedef bool (*RArchPluginInitCallback)(RArchSession *s);
 typedef bool (*RArchPluginFiniCallback)(RArchSession *s);
 typedef bool (*RArchPluginEsilCallback)(RArchSession *s, REsil *esil, RArchEsilAction action);
 
+typedef struct r_arch_cpu_t {
+	const char *name;
+	const char *desc;
+	const char **aliases;
+	ut32 flags;
+} RArchCpu;
+
+typedef enum r_arch_cpu_match_t {
+	R_ARCH_CPU_MATCH_INVALID = 0,
+	R_ARCH_CPU_MATCH_VALID,
+	R_ARCH_CPU_MATCH_CANONICALIZED,
+	R_ARCH_CPU_MATCH_UNKNOWN_DOMAIN,
+} RArchCpuMatch;
+
 // TODO: use `const char *const` instead of `char*`
 typedef struct r_arch_plugin_t {
 	RPluginMeta meta;
@@ -174,6 +188,8 @@ typedef struct r_arch_plugin_t {
 	const RArchPluginMnemonicsCallback mnemonics;
 	const RArchPluginPreludesCallback preludes;
 	const RArchPluginEsilCallback esilcb;
+	const RArchCpu *cpu_models;
+	size_t cpu_models_count;
 } RArchPlugin;
 
 R_API char *r_arch_platform_unset(RArch *arch, const char *name);
@@ -216,6 +232,9 @@ R_API void r_arch_free(RArch *arch);
 // aconfig.c
 R_API void r_arch_config_use(RArchConfig *config, const char * R_NULLABLE arch);
 R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cpu);
+R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin);
+R_API RArchCpuMatch r_arch_plugin_match_cpu(RArchPlugin *plugin, const char *cpu, char **canonical);
+R_API char *r_arch_plugin_cpu_match(RArchPlugin *plugin, const char *cpu);
 R_API bool r_arch_config_set_syntax(RArchConfig *config, int syntax);
 R_API bool r_arch_config_set_bits(RArchConfig *c, int bits);
 R_API RArchConfig *r_arch_config_new(void);

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -983,9 +983,6 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		rasm_env_print (opt.arg);
 		goto beach;
 	}
-	if (as->opt.cpu) {
-		r_arch_config_set_cpu (as->a->config, as->opt.cpu);
-	}
 	if (arch) {
 		if (!r_asm_use (as->a, arch)) {
 			R_LOG_ERROR ("Unknown asm plugin '%s'", arch);
@@ -1010,16 +1007,18 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 	r_asm_set_bits (as->a, R_STR_ISNOTEMPTY (env_bits)? atoi (env_bits): bits);
 	r_anal_set_bits (as->anal, R_STR_ISNOTEMPTY (env_bits)? atoi (env_bits): bits);
 	as->a->syscall = r_syscall_new ();
+	char *asmcpu = NULL;
 	if (R_STR_ISNOTEMPTY (as->opt.cpu)) {
-		// check if selected cpu is valid
-		const char *cpus = R_UNWRAP4 (as->anal->arch, session, plugin, cpus);
-		if (cpus && !strstr (cpus, as->opt.cpu)) {
-			R_LOG_WARN ("Invalid CPU. See -a, -b and asm.cpu values (%s)", cpus);
+		RArchPlugin *ap = R_UNWRAP3 (as->anal->arch, session, plugin);
+		asmcpu = ap? r_arch_plugin_cpu_match (ap, as->opt.cpu): strdup (as->opt.cpu);
+		if (asmcpu) {
+			r_arch_config_set_cpu (as->a->config, asmcpu);
 		} else {
-			R_LOG_WARN ("Ignored -c asm.cpu, provided plugin exposes no CPUs models");
+			R_LOG_WARN ("Invalid CPU '%s'. See -a, -b and asm.cpu values", as->opt.cpu);
 		}
 	}
-	r_syscall_setup (as->a->syscall, arch, bits, as->opt.cpu, as->opt.kernel);
+	r_syscall_setup (as->a->syscall, arch, bits, asmcpu, as->opt.kernel);
+	free (asmcpu);
 	{
 		bool canbebig = r_asm_set_big_endian (as->a, as->opt.isbig);
 		if (as->opt.isbig && !canbebig) {

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -143,6 +143,56 @@ all
 EOF
 RUN
 
+NAME=e asm.cpu rejects invalid value
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=cortex
+e asm.cpu=tetris
+e asm.cpu
+EOF
+EXPECT=<<EOF
+cortex
+EOF
+RUN
+
+NAME=e asm.cpu rejects partial match
+FILE=-
+ARGS=-a mips
+CMDS=<<EOF
+e asm.cpu=v
+e asm.cpu
+EOF
+EXPECT=<<EOF
+
+EOF
+RUN
+
+NAME=e asm.cpu canonicalizes valid value
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=CORTEX
+e asm.cpu
+EOF
+EXPECT=<<EOF
+cortex
+EOF
+RUN
+
+NAME=e asm.cpu clears invalid value on arch switch
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=cortex
+e asm.arch=v850
+e asm.cpu
+EOF
+EXPECT=<<EOF
+
+EOF
+RUN
+
 NAME=e asm.syntax
 FILE=-
 CMDS=<<EOF

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -147,12 +147,12 @@ NAME=e asm.cpu rejects invalid value
 FILE=-
 ARGS=-a arm -b 16
 CMDS=<<EOF
-e asm.cpu=cortex
+e asm.cpu=v8
 e asm.cpu=tetris
 e asm.cpu
 EOF
 EXPECT=<<EOF
-cortex
+v8
 EOF
 RUN
 
@@ -172,11 +172,11 @@ NAME=e asm.cpu canonicalizes valid value
 FILE=-
 ARGS=-a arm -b 16
 CMDS=<<EOF
-e asm.cpu=CORTEX
+e asm.cpu=V8
 e asm.cpu
 EOF
 EXPECT=<<EOF
-cortex
+v8
 EOF
 RUN
 
@@ -184,7 +184,7 @@ NAME=e asm.cpu clears invalid value on arch switch
 FILE=-
 ARGS=-a arm -b 16
 CMDS=<<EOF
-e asm.cpu=cortex
+e asm.cpu=v8
 e asm.arch=v850
 e asm.cpu
 EOF

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -31,18 +31,15 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pd v8 and cortex
+NAME=pd v8
 FILE=malloc://128
 ARGS=-a arm -b 16
 CMDS=<<EOF
 ?e
 pad fff7c0ea@e:asm.cpu=v8
-pad fff7c0ea@e:asm.cpu=cortex
 pad fff7c0ea@e:asm.cpu=v8
-pad fff7c0ea@e:asm.cpu=cortex
 pad fff7c0ea@e:asm.cpu=v8
 pad fff7c0ea@e:asm.cpu=
-pad fff7c0ea@e:asm.cpu=tetris
 EOF
 EXPECT=<<EOF
 
@@ -50,14 +47,6 @@ blx 0xfffff584
 blx 0xfffff584
 blx 0xfffff584
 blx 0xfffff584
-blx 0xfffff584
-blx 0xfffff584
-blx 0xfffff584
-EOF
-EXPECT_ERR=<<EOF
-WARN: asm.cpu: invalid value 'cortex' for 'arm'. See 'e asm.cpu=?'
-WARN: asm.cpu: invalid value 'cortex' for 'arm'. See 'e asm.cpu=?'
-WARN: asm.cpu: invalid value 'tetris' for 'arm'. See 'e asm.cpu=?'
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -47,12 +47,17 @@ EOF
 EXPECT=<<EOF
 
 blx 0xfffff584
-invalid
-blx 0xfffff584
-invalid
 blx 0xfffff584
 blx 0xfffff584
 blx 0xfffff584
+blx 0xfffff584
+blx 0xfffff584
+blx 0xfffff584
+EOF
+EXPECT_ERR=<<EOF
+WARN: asm.cpu: invalid value 'cortex' for 'arm'. See 'e asm.cpu=?'
+WARN: asm.cpu: invalid value 'cortex' for 'arm'. See 'e asm.cpu=?'
+WARN: asm.cpu: invalid value 'tetris' for 'arm'. See 'e asm.cpu=?'
 EOF
 RUN
 


### PR DESCRIPTION
## Summary

This fixes `asm.cpu` validation by moving CPU matching into the arch layer and making `asm.cpu` use that shared validation path.

- Add typed `RArchCpu` metadata and CPU match status APIs with legacy `.cpus` compatibility
- Reject invalid `asm.cpu` values while preserving the previous valid value
- Canonicalize valid CPU names case-insensitively
- Reject partial CPU matches from legacy comma-separated CPU metadata
- Clear incompatible `asm.cpu` silently when `asm.arch` changes
- Route `rasm2 -c`, `e asm.cpu=?`, `r_asm_cpus()`, and `La j` through the shared arch API

## Root Cause

`asm.cpu` accepted arbitrary values and `rasm2 -c` used substring-style checks against plugin CPU metadata. That allowed invalid or partial CPU names to enter arch/syscall setup paths.

## Validation

- `make -j > /dev/null`
- `git diff --check`
- `R2R_RADARE2=$PWD/binr/radare2/radare2 R2R_RASM2=$PWD/binr/rasm2/rasm2 ./binr/r2r/r2r -j16 test/db/cmd/cmd_eval`
- `R2R_RADARE2=$PWD/binr/radare2/radare2 R2R_RASM2=$PWD/binr/rasm2/rasm2 ./binr/r2r/r2r -j16 test/db/formats/rel`
- Full `./binr/r2r/r2r -j16 test/db` was also run locally. It still exits non-zero due to local/environment failures unrelated to this change, mainly missing testbins and existing Swift demangling differences; no `asm.cpu` warnings remained after the fix.