### PR TITLE
Add ESIL for the PPC isel conditional-select instruction ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -777,6 +777,24 @@ static char *getarg2(PluginData *pd, struct Getarg *gop, int n, const char *sets
 	return pd->words[n];
 }
 
+// Decode an isel CR-bit operand (named "cr<N><suffix>") into profile reg "crN"
+// and a condition 0=lt 1=gt 2=eq (-1 = unparseable or unmodelled so/un bit).
+static int ppc_isel_crbit(struct Getarg *gop, int n, char *regbuf, size_t sz) {
+	cs_ppc_op op = gop->insn->detail->ppc.operands[n];
+	if (op.type != PPC_OP_REG) {
+		return -1;
+	}
+	const char *name = cs_reg_name (gop->handle, op.reg);
+	if (!name || strncmp (name, "cr", 2) || name[2] < '0' || name[2] > '7') {
+		return -1;
+	}
+	const char *suf = name + 3;
+	snprintf (regbuf, sz, "cr%c", name[2]);
+	return !strcmp (suf, "lt") ? 0
+		: !strcmp (suf, "gt") ? 1
+		: !strcmp (suf, "eq") ? 2 : -1;
+}
+
 // Byte-reverse load/store ESIL for `nbytes` (2/4/8) at the indexed (rA|0)+rB
 // address, built per-byte so it is endianness-independent (ESIL has no bswap).
 static void ppc_esil_brx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int nbytes, bool store) {
@@ -974,10 +992,33 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_RMOV;
 			esilprintf (op, "%s,%s,=", ARG (1), ARG (0));
 			break;
-		case PPC_INS_ISEL:
+		case PPC_INS_ISEL: {
+			// isel rD, rA, rB, crb -> rD = CR[crb] ? (rA|0) : rB
+			// unmodelled so/un bits decode to cond < 0: keep the type, emit no ESIL
 			op->type = R_ANAL_OP_TYPE_CMOV;
-			// no ESIL: BC selects an arbitrary CR bit but the CR model only tracks cr0
+			char crbuf[8];
+			int cond = ppc_isel_crbit (&gop, 3, crbuf, sizeof (crbuf));
+			if (cond < 0) {
+				break;
+			}
+			const char *src = (INSOP (1).type == PPC_OP_REG
+				&& INSOP (1).reg != PPC_REG_INVALID) ? ARG (1) : "0";
+			const char *rb = ARG (2);
+			const char *dst = ARG (0);
+			switch (cond) {
+			case 2:
+				esilprintf (op, "%s,!,?{,%s,}{,%s,},%s,=", crbuf, src, rb, dst);
+				break;
+			case 0:
+				esilprintf (op, "0x80,%s,&,!,!,?{,%s,}{,%s,},%s,=", crbuf, src, rb, dst);
+				break;
+			case 1:
+				esilprintf (op, "0x80,%s,&,!,%s,!,!,&,?{,%s,}{,%s,},%s,=",
+					crbuf, crbuf, src, rb, dst);
+				break;
+			}
 			break;
+		}
 		case PPC_INS_LI:
 			op->type = R_ANAL_OP_TYPE_MOV;
 			esilprintf (op, "%s,%s,=", ARG (1), ARG (0));

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -265,3 +265,62 @@ EXPECT=<<EOF
 efbeadde
 EOF
 RUN
+
+NAME=isel selects rA when eq condition bit set ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c64289e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000011
+EOF
+RUN
+
+NAME=isel selects rB when eq condition bit clear ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c64289e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0x40
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000022
+EOF
+RUN
+
+NAME=isel uses literal zero for rA field r0 ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c604f9e @ 0
+aei
+aeim
+ar r9=0x99
+ar cr7=0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000000
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -46,3 +46,122 @@ EXPECT=<<EOF
 0xefcdab8967452301
 EOF
 RUN
+
+NAME=isel selects rA when eq condition bit set ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c64289e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000011
+EOF
+RUN
+
+NAME=isel selects rB when eq condition bit clear ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c64289e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0x40
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000022
+EOF
+RUN
+
+NAME=isel selects rA when lt condition bit set ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c64281e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0x80
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000011
+EOF
+RUN
+
+NAME=isel selects rA when gt condition true ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c64285e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0x10
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000011
+EOF
+RUN
+
+NAME=isel gt condition is false on equality ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c64285e @ 0
+aei
+aeim
+ar r4=0x11
+ar r5=0x22
+ar cr0=0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000022
+EOF
+RUN
+
+NAME=isel uses literal zero for rA field r0 ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c604f9e @ 0
+aei
+aeim
+ar r9=0x99
+ar cr7=0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`isel rD, rA, rB, crb` was typed `cmov` but emitted no ESIL, breaking emulation and value tracking.

Decode the CR-bit operand and emit a conditional select that reads the existing crN byte model:
- eq -> crN == 0
- lt -> sign bit set
- gt -> sign clear and nonzero

rA field r0 selects literal 0; so/un bits stay type-only (no overflow bit in the CR model). Also, adds isel ESIL emulation tests to test/db/esil/ppc_{32,64}.
