### PR TITLE
Classify PPC op-types (traps, rfi, integer, FP) and add integer/control ESIL

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -36,6 +36,8 @@ struct Getarg {
 
 #define PPC_INS_CMP PPC_INS_ALIAS_CMP
 #define PPC_INS_CMPI PPC_INS_ALIAS_CMPI
+#define PPC_INS_CMPL PPC_INS_ALIAS_CMPL
+#define PPC_INS_CMPLI PPC_INS_ALIAS_CMPLI
 #define PPC_INS_MR PPC_INS_ALIAS_MR
 #define PPC_INS_LI PPC_INS_ALIAS_LI
 #define PPC_INS_LIS PPC_INS_ALIAS_LIS
@@ -168,6 +170,9 @@ struct Getarg {
 #define PPC_INS_MTDEAR PPC_INS_ALIAS_MTDEAR
 #define PPC_INS_CLRLDI PPC_INS_ALIAS_CLRLDI
 #define PPC_INS_ROTLDI PPC_INS_ALIAS_ROTLDI
+#define PPC_INS_ROTLW PPC_INS_ALIAS_ROTLW
+#define PPC_INS_ROTLWI PPC_INS_ALIAS_ROTLWI
+#define PPC_INS_ROTLD PPC_INS_ALIAS_ROTLD
 #define PPC_INS_BDNZLRL PPC_INS_ALIAS_BDNZLRL
 
 #define PPC_BC_LT PPC_PRED_LT
@@ -971,6 +976,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 #if CS_API_MAJOR > 4
 		case PPC_INS_CMP:
 		case PPC_INS_CMPI:
+		case PPC_INS_CMPL:
+		case PPC_INS_CMPLI:
 #endif
 			op->type = R_ANAL_OP_TYPE_CMP;
 			op->sign = true;
@@ -1283,6 +1290,86 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
+		case PPC_INS_STFD:
+		case PPC_INS_STFDU:
+		case PPC_INS_STFDUX:
+		case PPC_INS_STFDX:
+		case PPC_INS_STFS:
+		case PPC_INS_STFSU:
+		case PPC_INS_STFSUX:
+		case PPC_INS_STFSX:
+		case PPC_INS_STFIWX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			break;
+		case PPC_INS_FADD:
+		case PPC_INS_FADDS:
+		case PPC_INS_FSUB:
+		case PPC_INS_FSUBS:
+		case PPC_INS_FMUL:
+		case PPC_INS_FMULS:
+		case PPC_INS_FDIV:
+		case PPC_INS_FDIVS:
+		case PPC_INS_FMADD:
+		case PPC_INS_FMADDS:
+		case PPC_INS_FMSUB:
+		case PPC_INS_FMSUBS:
+		case PPC_INS_FNMADD:
+		case PPC_INS_FNMADDS:
+		case PPC_INS_FNMSUB:
+		case PPC_INS_FNMSUBS:
+		case PPC_INS_FSQRT:
+		case PPC_INS_FSQRTS:
+		case PPC_INS_FRE:
+		case PPC_INS_FRES:
+		case PPC_INS_FRSQRTE:
+		case PPC_INS_FRSQRTES:
+		case PPC_INS_FSEL:
+#if CS_API_MAJOR > 4
+		case PPC_INS_FTSQRT:
+#endif
+			op->type = R_ANAL_OP_TYPE_MOV;
+			break;
+		case PPC_INS_FMR:
+		case PPC_INS_FNEG:
+		case PPC_INS_FCPSGN:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			break;
+		case PPC_INS_FCMPU:
+			op->type = R_ANAL_OP_TYPE_CMP;
+			break;
+		case PPC_INS_FABS:
+		case PPC_INS_FNABS:
+			op->type = R_ANAL_OP_TYPE_ABS;
+			break;
+		case PPC_INS_FCFID:
+		case PPC_INS_FCFIDS:
+		case PPC_INS_FCFIDU:
+		case PPC_INS_FCFIDUS:
+		case PPC_INS_FCTID:
+		case PPC_INS_FCTIDUZ:
+		case PPC_INS_FCTIDZ:
+		case PPC_INS_FCTIW:
+		case PPC_INS_FCTIWUZ:
+#if CS_API_MAJOR > 4
+		case PPC_INS_FCTIDU:
+		case PPC_INS_FCTIWU:
+#endif
+		case PPC_INS_FCTIWZ:
+		case PPC_INS_FRSP:
+		case PPC_INS_FRIM:
+		case PPC_INS_FRIN:
+		case PPC_INS_FRIP:
+		case PPC_INS_FRIZ:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			break;
+		case PPC_INS_LMW:
+		case PPC_INS_LSWI:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			break;
+		case PPC_INS_STMW:
+		case PPC_INS_STSWI:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			break;
 		case PPC_INS_LHA:
 		case PPC_INS_LHAU:
 		case PPC_INS_LHAUX:
@@ -1396,9 +1483,18 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_SUBC:
 		case PPC_INS_SUBF:
 		case PPC_INS_SUBFIC:
-		case PPC_INS_SUBFZE:
+		case PPC_INS_SUBFC:
 			op->type = R_ANAL_OP_TYPE_SUB;
 			esilprintf (op, "%s,%s,-,%s,=", ARG (1), ARG (2), ARG (0));
+			break;
+		case PPC_INS_NEG:
+			op->type = R_ANAL_OP_TYPE_SUB;
+			esilprintf (op, "%s,0,-,%s,=", ARG (1), ARG (0));
+			break;
+		case PPC_INS_SUBFZE:
+		case PPC_INS_SUBFE:
+		case PPC_INS_SUBFME:
+			op->type = R_ANAL_OP_TYPE_SUB;
 			break;
 		case PPC_INS_ADD:
 		case PPC_INS_ADDI:
@@ -1788,9 +1884,25 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			break;
+		case PPC_INS_RFI:
+		case PPC_INS_RFID:
+			op->type = R_ANAL_OP_TYPE_RET;
+			op->eob = true;
+			esilprintf (op, "srr0,pc,=");
+			break;
+		case PPC_INS_RFCI:
+		case PPC_INS_RFDI:
+		case PPC_INS_RFMCI:
+#if CS_API_MAJOR > 4
+		case PPC_INS_RFEBB:
+		case PPC_INS_HRFID:
+#endif
+			op->type = R_ANAL_OP_TYPE_RET;
+			op->eob = true;
+			break;
 		case PPC_INS_NOR:
 			op->type = R_ANAL_OP_TYPE_NOR;
-			esilprintf (op, "%s,%s,|,!,%s,=", ARG (2), ARG (1), ARG (0));
+			esilprintf (op, "%s,%s,|,0xffffffffffffffff,^,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_XOR:
 		case PPC_INS_XORI:
@@ -1812,6 +1924,26 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_DIV;
 			esilprintf (op, "%s,%s,/,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
+#if CS_API_MAJOR > 4
+		case PPC_INS_DIVDE:
+		case PPC_INS_DIVWE:
+			op->sign = true;
+		case PPC_INS_DIVDEU:
+		case PPC_INS_DIVWEU:
+			op->type = R_ANAL_OP_TYPE_DIV;
+			break;
+		case PPC_INS_MODSW:
+		case PPC_INS_MODSD:
+			op->sign = true;
+			op->type = R_ANAL_OP_TYPE_MOD;
+			esilprintf (op, "%s,%s,~%%,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_MODUW:
+		case PPC_INS_MODUD:
+			op->type = R_ANAL_OP_TYPE_MOD;
+			esilprintf (op, "%s,%s,%%,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+#endif
 		case PPC_INS_BL:
 		case PPC_INS_BLA:
 			op->type = R_ANAL_OP_TYPE_CALL;
@@ -1824,10 +1956,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_TRAP;
 			break;
 		case PPC_INS_AND:
-		case PPC_INS_NAND:
 		case PPC_INS_ANDI:
 			op->type = R_ANAL_OP_TYPE_AND;
 			esilprintf (op, "%s,%s,&,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_NAND:
+			op->type = R_ANAL_OP_TYPE_AND;
+			esilprintf (op, "%s,%s,&,0xffffffffffffffff,^,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_ANDIS:
 			op->type = R_ANAL_OP_TYPE_AND;
@@ -1841,6 +1976,18 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_ORIS:
 			op->type = R_ANAL_OP_TYPE_OR;
 			esilprintf (op, "16,%s,<<,%s,|,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_ANDC:
+			op->type = R_ANAL_OP_TYPE_AND;
+			esilprintf (op, "0xffffffffffffffff,%s,^,%s,&,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_ORC:
+			op->type = R_ANAL_OP_TYPE_OR;
+			esilprintf (op, "0xffffffffffffffff,%s,^,%s,|,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_EQV:
+			op->type = R_ANAL_OP_TYPE_XOR;
+			esilprintf (op, "%s,%s,^,0xffffffffffffffff,^,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_MFPVR:
 			op->type = R_ANAL_OP_TYPE_MOV;
@@ -1904,6 +2051,21 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_ROL;
 			esilprintf (op, "%s,%s,ROL,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
+		case PPC_INS_ROTLW:
+		case PPC_INS_ROTLWI:
+		case PPC_INS_ROTLD:
+			op->type = R_ANAL_OP_TYPE_ROL;
+			esilprintf (op, "%s,%s,ROL,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_RLWNM:
+			op->type = R_ANAL_OP_TYPE_ROL;
+			if (ARG (3)[0] && ARG (4)[0]) {
+				esilprintf (op, "%s,%s,ROL,%s,&,%s,=", ARG (2), ARG (1), cmask32 (cmaskbuf, ARG (3), ARG (4)), ARG (0));
+			}
+			break;
+		case PPC_INS_RLWIMI:
+			op->type = R_ANAL_OP_TYPE_ROL;
+			break;
 		case PPC_INS_RLDCL:
 		case PPC_INS_RLDICL:
 			op->type = R_ANAL_OP_TYPE_ROL;
@@ -1920,6 +2082,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			// type only: rldic masks mb..63-sh and rldimi inserts into the
 			// destination; neither is expressible via cmask64(mb,me)
 			break;
+		}
+		const char m0 = insn->mnemonic[0];
+		if (op->type == R_ANAL_OP_TYPE_NULL && m0 == 't' && (insn->mnemonic[1] == 'w' || insn->mnemonic[1] == 'd')) {
+			op->sign = true;
+			op->type = R_ANAL_OP_TYPE_TRAP;
+		} else if (m0 == 'f') {
+			op->family = R_ANAL_OP_FAMILY_FPU;
 		}
 		if (mask & R_ARCH_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -821,6 +821,142 @@ type: call
 EOF
 RUN
 
+# Conditional trap family (tw/twi/td/tdi + extended mnemonics) must type as trap.
+# Type-only assert: capstone gives extended forms version-dependent ids.
+NAME=ppc conditional traps typed
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 0c030000
+ao~type:
+wx 08030000
+ao~type:
+wx 7c632088
+ao~type:
+wx 7c831808
+ao~type:
+wx 7fe00008
+ao~type:
+EOF
+EXPECT=<<EOF
+type: trap
+type: trap
+type: trap
+type: trap
+type: trap
+EOF
+RUN
+
+# Return-from-interrupt terminates the basic block (type-only assert).
+NAME=ppc return-from-interrupt typed as ret
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 4c000064
+ao~type:
+wx 4c000024
+ao~type:
+wx 4c000066
+ao~type:
+EOF
+EXPECT=<<EOF
+type: ret
+type: ret
+type: ret
+EOF
+RUN
+
+# Integer ALU forms that previously fell through to type: null.
+NAME=ppc integer alu classified
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c6400d0
+ao~type:
+wx 7c642810
+ao~type:
+wx 7c832878
+ao~type:
+wx 7c832b38
+ao~type:
+wx 7c832a38
+ao~type:
+wx 7c641e16
+ao~type:
+wx 5083403e
+ao~type:
+EOF
+EXPECT=<<EOF
+type: sub
+type: sub
+type: and
+type: or
+type: xor
+type: mod
+type: rol
+EOF
+RUN
+
+# Load/store multiple and string word.
+NAME=ppc load-store multiple classified
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx bb810008
+ao~type:
+wx bf810008
+ao~type:
+EOF
+EXPECT=<<EOF
+type: load
+type: store
+EOF
+RUN
+
+# Scalar floating point: stores, arith, compare, convert, abs, move.
+NAME=ppc scalar fp classified
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx d8230008
+ao~type:,family:
+wx fc22182a
+ao~type:,family:
+wx fc011000
+ao~type:,family:
+wx fc20081e
+ao~type:,family:
+wx fc200210
+ao~type:,family:
+wx fc201090
+ao~type:,family:
+EOF
+EXPECT=<<EOF
+type: store
+family: cpu
+type: mov
+family: fpu
+type: cmp
+family: fpu
+type: cast
+family: fpu
+type: abs
+family: fpu
+type: mov
+family: fpu
+EOF
+RUN
+
 NAME=ppc-hello-ref
 FILE=bins/elf/hello.ppc
 CMDS=<<EOF

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1170,7 +1170,7 @@ za fcn.100e2b0c g cc=19 nbbs=35 edges=52 ebbs=1 bbsum=448
 za fcn.100e2b0c o 0x100e2b0c
 za fcn.100e2b0c R ZmNuLjEwMGUyYjBj
 za fcn.100e2b0c t void fcn.100e2b0c (int32_t arg1, int32_t arg2, int32_t arg3, int32_t arg_1h, int32_t arg_34h)
-za fcn.100e2b0c v ts4:arg_34h:int32_t, tb1:arg_1h:int32_t, tr6:arg2:int32_t, tr7:arg3:int32_t, tr5:arg1:int32_t
+za fcn.100e2b0c v fs-28:var_14h:int32_t, ts4:arg_34h:int32_t, tb1:arg_1h:int32_t, tr6:arg2:int32_t, tr7:arg3:int32_t, tr5:arg1:int32_t
 za fcn.100e2b0c h 3b28d8f368cb414615bda7313fc4cdc24096498e7183cc05165607770be26928
 EOF
 RUN

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -324,3 +324,294 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=negate ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c6400d0)
+EOF
+EXPECT=<<EOF
+neg r3, r4
+0x00000000 r4,0,-,r3,=
+EOF
+RUN
+
+NAME=subtract from carrying ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c642810)
+EOF
+EXPECT=<<EOF
+subfc r3, r4, r5
+0x00000000 r4,r5,-,r3,=
+EOF
+RUN
+
+NAME=and with complement ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c832878)
+EOF
+EXPECT=<<EOF
+andc r3, r4, r5
+0x00000000 0xffffffffffffffff,r5,^,r4,&,r3,=
+EOF
+RUN
+
+NAME=or with complement ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c832b38)
+EOF
+EXPECT=<<EOF
+orc r3, r4, r5
+0x00000000 0xffffffffffffffff,r5,^,r4,|,r3,=
+EOF
+RUN
+
+NAME=equivalence ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c832a38)
+EOF
+EXPECT=<<EOF
+eqv r3, r4, r5
+0x00000000 r5,r4,^,0xffffffffffffffff,^,r3,=
+EOF
+RUN
+
+NAME=nor bitwise complement ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c8320f8)
+EOF
+EXPECT=<<EOF
+nor r3, r4, r4
+0x00000000 r4,r4,|,0xffffffffffffffff,^,r3,=
+EOF
+RUN
+
+NAME=nand bitwise complement ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c8323b8)
+EOF
+EXPECT=<<EOF
+nand r3, r4, r4
+0x00000000 r4,r4,&,0xffffffffffffffff,^,r3,=
+EOF
+RUN
+
+NAME=rotate left word ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 5c83283e)
+EOF
+EXPECT=<<EOF
+rotlw r3, r4, r5
+0x00000000 r5,r4,ROL,r3,=
+EOF
+RUN
+
+NAME=rotate left word then mask ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 5c832c3c)
+EOF
+EXPECT=<<EOF
+rlwnm r3, r4, r5, 0x10, 0x1e
+0x00000000 r5,r4,ROL,0xfffe,&,r3,=
+EOF
+RUN
+
+NAME=signed modulo word ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c641e16)
+EOF
+EXPECT=<<EOF
+modsw r3, r4, r3
+0x00000000 r3,r4,~%,r3,=
+EOF
+RUN
+
+NAME=return from interrupt restores pc ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 4c000064)
+EOF
+EXPECT=<<EOF
+rfi
+0x00000000 srr0,pc,=
+EOF
+RUN
+
+NAME=subtract from zero extended has no esil without carry model ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c640190
+pi 1
+pdj 1~{0.esil}
+EOF
+EXPECT=<<EOF
+subfze r3, r4
+
+EOF
+RUN
+
+NAME=negate emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c6400d0 @ 0
+aei
+aeim
+ar r4=5
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xfffffffb
+EOF
+RUN
+
+NAME=subtract from carrying emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c642810 @ 0
+aei
+aeim
+ar r4=3
+ar r5=10
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000007
+EOF
+RUN
+
+NAME=and with complement emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c832878 @ 0
+aei
+aeim
+ar r4=0xff
+ar r5=0x0f
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x000000f0
+EOF
+RUN
+
+NAME=nor bitwise complement emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c8320f8 @ 0
+aei
+aeim
+ar r4=0x0f
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xfffffff0
+EOF
+RUN
+
+NAME=nand bitwise complement emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c8323b8 @ 0
+aei
+aeim
+ar r4=0x0f
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xfffffff0
+EOF
+RUN
+
+NAME=return from interrupt restores pc emulates ppc-32
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 4c000064 @ 0
+aei
+aeim
+ar srr0=0x40
+aes
+ar pc
+EOF
+EXPECT=<<EOF
+0x00000040
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -165,3 +165,75 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=unsigned modulo doubleword ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi 7c642a12)
+EOF
+EXPECT=<<EOF
+modud r3, r4, r5
+0x00000000 r5,r4,%,r3,=
+EOF
+RUN
+
+NAME=unsigned modulo doubleword emulates ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c642a12 @ 0
+aei
+aeim
+ar r4=17
+ar r5=5
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000002
+EOF
+RUN
+
+NAME=signed modulo doubleword emulates ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c642e12 @ 0
+aei
+aeim
+ar r4=0xffffffffffffffef
+ar r5=5
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xfffffffffffffffe
+EOF
+RUN
+
+NAME=rotate left doubleword emulates ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 78832810 @ 0
+aei
+aeim
+ar r4=0x8000000000000001
+ar r5=1
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000003
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Type/ESIL coverage for many previously unclassified ppc_cs instructions:

- Type classification: conditional traps (tw/td family) → trap; return-from-interrupt (rfi/rfid/...) → ret+eob; integer ALU (neg, subfc/e/me, andc/orc/eqv, divde*, mod*); rotates; lmw/stmw/lswi/stswi → load/store; cmpl/cmpli → cmp; scalar FP → store/mov/cmp/cast/abs + fpu family.
- ESIL: neg, subfc, andc/orc/eqv, rotlw/rotld/rlwnm, signed/unsigned mod, rfi/rfid (srr0→pc).
- Fixes: subfze emitted malformed ESIL; nor/nand used logical/plain ops instead of bitwise complement.

Tests in test/db/esil/ppc_{32,64} (string + emulation) and test/db/anal/ppc.