### PR TITLE
Validate asm.cpu against plugin CPU list (minimal alternative to #26061)

### DIFF
--- a/libr/arch/arch_config.c
+++ b/libr/arch/arch_config.c
@@ -43,16 +43,12 @@ R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cp
 
 R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin) {
 	R_RETURN_VAL_IF_FAIL (plugin, NULL);
-	return plugin->cpus
+	return R_STR_ISNOTEMPTY (plugin->cpus)
 		? r_str_split_duplist (plugin->cpus, ",", true)
 		: r_list_newf (free);
 }
 
-// Returns the canonical (plugin-cased) spelling of `cpu` for `plugin`, or NULL
-// if `cpu` is not a valid CPU. The empty string is valid (the default cpu), the
-// arch/plugin name is always accepted, and a plugin that exposes no cpu list
-// accepts any value, preserving old behavior.
-R_API char *r_arch_plugin_cpu_canonical(RArchPlugin *plugin, const char *cpu) {
+R_API char *r_arch_plugin_cpucheck(RArchPlugin *plugin, const char *cpu) {
 	R_RETURN_VAL_IF_FAIL (plugin, NULL);
 	if (R_STR_ISEMPTY (cpu)) {
 		return strdup ("");

--- a/libr/arch/arch_config.c
+++ b/libr/arch/arch_config.c
@@ -41,6 +41,44 @@ R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cp
 	config->cpu = R_STR_ISNOTEMPTY (cpu) ? strdup (cpu) : NULL;
 }
 
+R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin) {
+	R_RETURN_VAL_IF_FAIL (plugin, NULL);
+	return plugin->cpus
+		? r_str_split_duplist (plugin->cpus, ",", true)
+		: r_list_newf (free);
+}
+
+// Returns the canonical (plugin-cased) spelling of `cpu` for `plugin`, or NULL
+// if `cpu` is not a valid CPU. The empty string is valid (the default cpu), the
+// arch/plugin name is always accepted, and a plugin that exposes no cpu list
+// accepts any value, preserving old behavior.
+R_API char *r_arch_plugin_cpu_canonical(RArchPlugin *plugin, const char *cpu) {
+	R_RETURN_VAL_IF_FAIL (plugin, NULL);
+	if (R_STR_ISEMPTY (cpu)) {
+		return strdup ("");
+	}
+	if (plugin->meta.name && !r_str_casecmp (plugin->meta.name, cpu)) {
+		return strdup (plugin->meta.name);
+	}
+	if (plugin->arch && !r_str_casecmp (plugin->arch, cpu)) {
+		return strdup (plugin->arch);
+	}
+	if (R_STR_ISEMPTY (plugin->cpus)) {
+		return strdup (cpu);
+	}
+	char *res = NULL, *word;
+	RListIter *iter;
+	RList *cpus = r_arch_plugin_cpus (plugin);
+	r_list_foreach (cpus, iter, word) {
+		if (!r_str_casecmp (word, cpu)) {
+			res = strdup (word);
+			break;
+		}
+	}
+	r_list_free (cpus);
+	return res;
+}
+
 R_API bool r_arch_config_set_bits(RArchConfig *config, int bits) {
 	R_RETURN_VAL_IF_FAIL (config, false);
 	// if the config is tied to a session, there must be a callback to notify the plugin

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4867,8 +4867,10 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != pd->bigendian) {
 		return true;
 	}
-	if (pd->cpu && as->config->cpu && strcmp (pd->cpu, as->config->cpu)) {
-		return true;
+	if (pd->cpu || as->config->cpu) {
+		if (!pd->cpu || !as->config->cpu || strcmp (pd->cpu, as->config->cpu)) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -4867,12 +4867,7 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != pd->bigendian) {
 		return true;
 	}
-	if (pd->cpu || as->config->cpu) {
-		if (!pd->cpu || !as->config->cpu || strcmp (pd->cpu, as->config->cpu)) {
-			return true;
-		}
-	}
-	return false;
+	return strcmp (r_str_get (pd->cpu), r_str_get (as->config->cpu)) != 0;
 }
 
 static bool init(RArchSession *as);

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -945,12 +945,7 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != cpd->bigendian) {
 		return true;
 	}
-	if (cpd->cpu || as->config->cpu) {
-		if (!cpd->cpu || !as->config->cpu || strcmp (cpd->cpu, as->config->cpu)) {
-			return true;
-		}
-	}
-	return false;
+	return strcmp (r_str_get (cpd->cpu), r_str_get (as->config->cpu)) != 0;
 }
 
 static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -945,9 +945,10 @@ static bool plugin_changed(RArchSession *as) {
 	if (R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config) != cpd->bigendian) {
 		return true;
 	}
-	if (cpd->cpu && as->config->cpu && strcmp (cpd->cpu, as->config->cpu)) {
-		eprintf ("cpudif\n");
-		return true;
+	if (cpd->cpu || as->config->cpu) {
+		if (!cpd->cpu || !as->config->cpu || strcmp (cpd->cpu, as->config->cpu)) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -1465,10 +1465,9 @@ R_API int r_asm_mnemonics_byname(RAsm *a, const char *name) {
 
 R_API RList *r_asm_cpus(RAsm *a) {
 	R_RETURN_VAL_IF_FAIL (a, NULL);
-	// R2_600 move to r_arch api instead?
-	const char *cpus = R_UNWRAP5 (a, arch, session, plugin, cpus);
-	RList *list = cpus
-		? r_str_split_duplist (cpus, ",", 0)
+	RArchPlugin *plugin = R_UNWRAP4 (a, arch, session, plugin);
+	RList *list = plugin
+		? r_arch_plugin_cpus (plugin)
 		: r_list_newf (free);
 	r_list_sort (list, (RListComparator)strcmp);
 	return list;

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -773,29 +773,30 @@ static void update_asmcpu_options(RCore *core, RConfigNode *node) {
 	r_config_node_purge_options (node);
 	RArchPlugin *h;
 	r_list_foreach (core->anal->arch->libstore->plugins, iter, h) {
-		if (h->cpus && !strcmp (arch, h->meta.name)) {
-			char *c = strdup (h->cpus);
-			int i, n = r_str_split (c, ',');
-			for (i = 0; i < n; i++) {
-				const char *word = r_str_word_get0 (c, i);
-				if (word && *word) {
+		if (!strcmp (arch, h->meta.name)) {
+			RList *cpus = r_arch_plugin_cpus (h);
+			RListIter *iter2;
+			char *word;
+			r_list_foreach (cpus, iter2, word) {
+				if (R_STR_ISNOTEMPTY (word)) {
 					node->options->free = free;
 					SETOPTIONS (node, word, NULL);
 				}
 			}
-			free (c);
+			r_list_free (cpus);
 		}
 	}
 }
 static void list_cpus(RCore *core) {
 	RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
-	if (ap && ap->cpus) {
-		char *c = strdup (ap->cpus);
-		int i, n = r_str_split (c, ',');
-		for (i = 0; i < n; i++) {
-			r_cons_println (core->cons, r_str_word_get0 (c, i));
+	if (ap) {
+		RList *cpus = r_arch_plugin_cpus (ap);
+		RListIter *iter;
+		char *cpu;
+		r_list_foreach (cpus, iter, cpu) {
+			r_cons_println (core->cons, cpu);
 		}
-		free (c);
+		r_list_free (cpus);
 	}
 }
 
@@ -804,10 +805,18 @@ static bool cb_asmcpu(void *user, void *data) {
 	RConfigNode *node = (RConfigNode *)data;
 	if (*node->value == '?') {
 		list_cpus (core);
-#if 0
-		update_asmcpu_options (core, node);
-#endif
-		return 0;
+		return false;
+	}
+	RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
+	if (ap) {
+		char *canon = r_arch_plugin_cpu_canonical (ap, node->value);
+		if (!canon) {
+			R_LOG_WARN ("asm.cpu: invalid value '%s'. See 'e asm.cpu=?'", node->value);
+			return false;
+		}
+		// canonicalize case in place (e.g. V8 -> v8)
+		free (node->value);
+		node->value = canon;
 	}
 	r_core_esil_unload_arch (core);
 	r_arch_config_set_cpu (core->rasm->config, node->value);
@@ -914,16 +923,6 @@ static bool cb_asmarch(void *user, void *data) {
 			free (s);
 		}
 	}
-	// set codealign
-	if (core->anal) {
-		const char *asmcpu = r_config_get (core->config, "asm.cpu");
-		const char *asmos = r_config_get (core->config, "asm.os");
-		int bits = (core->anal->config)? core->anal->config->bits: r_config_get_i (core->config, "asm.bits");
-		if (!r_syscall_setup (core->anal->syscall, node->value, bits, asmcpu, asmos)) {
-			// R_LOG_ERROR ("asm.arch: Cannot setup syscall '%s/%s' from '%s'",
-			//	node->value, asmos, R2_LIBDIR"/radare2/"R2_VERSION"/syscall");
-		}
-	}
 	// if (!strcmp (node->value, "bf"))
 	//	r_config_set (core->config, "dbg.backend", "bf");
 	__setsegoff (core->config, node->value, core->rasm->config->bits);
@@ -939,8 +938,28 @@ static bool cb_asmarch(void *user, void *data) {
 
 	RConfigNode *asmcpu = r_config_node_get (core->config, "asm.cpu");
 	if (asmcpu) {
-		r_arch_config_set_cpu (core->rasm->config, asmcpu->value);
 		update_asmcpu_options (core, asmcpu);
+		RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
+		char *canon = ap? r_arch_plugin_cpu_canonical (ap, asmcpu->value): strdup (asmcpu->value);
+		if (!canon) {
+			// asm.cpu is incompatible with the new arch: clear it silently
+			r_config_set (core->config, "asm.cpu", "");
+		} else {
+			if (strcmp (canon, asmcpu->value)) {
+				free (asmcpu->value);
+				asmcpu->value = canon;
+				canon = NULL;
+			}
+			r_arch_config_set_cpu (core->rasm->config, asmcpu->value);
+			free (canon);
+		}
+	}
+	// set up syscalls with the (now validated) cpu
+	if (core->anal) {
+		const char *asmcpu_value = r_config_get (core->config, "asm.cpu");
+		const char *asmos = r_config_get (core->config, "asm.os");
+		int bits = (core->anal->config)? core->anal->config->bits: r_config_get_i (core->config, "asm.bits");
+		(void)r_syscall_setup (core->anal->syscall, node->value, bits, asmcpu_value, asmos);
 	}
 	{
 		int v = r_arch_info (core->anal->arch, R_ARCH_INFO_CODE_ALIGN);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -779,7 +779,6 @@ static void update_asmcpu_options(RCore *core, RConfigNode *node) {
 			char *word;
 			r_list_foreach (cpus, iter2, word) {
 				if (R_STR_ISNOTEMPTY (word)) {
-					node->options->free = free;
 					SETOPTIONS (node, word, NULL);
 				}
 			}
@@ -809,14 +808,13 @@ static bool cb_asmcpu(void *user, void *data) {
 	}
 	RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
 	if (ap) {
-		char *canon = r_arch_plugin_cpu_canonical (ap, node->value);
-		if (!canon) {
+		char *cpu = r_arch_plugin_cpucheck (ap, node->value);
+		if (!cpu) {
 			R_LOG_WARN ("asm.cpu: invalid value '%s'. See 'e asm.cpu=?'", node->value);
 			return false;
 		}
-		// canonicalize case in place (e.g. V8 -> v8)
 		free (node->value);
-		node->value = canon;
+		node->value = cpu;
 	}
 	r_core_esil_unload_arch (core);
 	r_arch_config_set_cpu (core->rasm->config, node->value);
@@ -940,21 +938,19 @@ static bool cb_asmarch(void *user, void *data) {
 	if (asmcpu) {
 		update_asmcpu_options (core, asmcpu);
 		RArchPlugin *ap = R_UNWRAP5 (core, anal, arch, session, plugin);
-		char *canon = ap? r_arch_plugin_cpu_canonical (ap, asmcpu->value): strdup (asmcpu->value);
-		if (!canon) {
-			// asm.cpu is incompatible with the new arch: clear it silently
+		char *cpu = ap? r_arch_plugin_cpucheck (ap, asmcpu->value): strdup (asmcpu->value);
+		if (!cpu) {
 			r_config_set (core->config, "asm.cpu", "");
 		} else {
-			if (strcmp (canon, asmcpu->value)) {
+			r_arch_config_set_cpu (core->rasm->config, cpu);
+			if (strcmp (cpu, asmcpu->value)) {
 				free (asmcpu->value);
-				asmcpu->value = canon;
-				canon = NULL;
+				asmcpu->value = cpu;
+			} else {
+				free (cpu);
 			}
-			r_arch_config_set_cpu (core->rasm->config, asmcpu->value);
-			free (canon);
 		}
 	}
-	// set up syscalls with the (now validated) cpu
 	if (core->anal) {
 		const char *asmcpu_value = r_config_get (core->config, "asm.cpu");
 		const char *asmos = r_config_get (core->config, "asm.os");

--- a/libr/core/cmd_log.inc.c
+++ b/libr/core/cmd_log.inc.c
@@ -539,15 +539,15 @@ static int cmd_plugins(void *data, const char *input) {
 						pj_ks (pj, "arch", item->arch);
 					}
 					pj_ks (pj, "endian", (item->endian == R_SYS_ENDIAN_BIG)? "big": "little");
-					if (item->cpus) {
+					list = r_arch_plugin_cpus (item);
+					if (!r_list_empty (list)) {
 						pj_ka (pj, "cpus");
-						list = r_str_split_list (strdup (item->cpus), ",", 0);
 						r_list_foreach (list, iter2, cpu) {
 							pj_s (pj, cpu);
 						}
-						r_list_free (list);
 						pj_end (pj);
 					}
+					r_list_free (list);
 					pj_ka (pj, "bits");
 					int i;
 					for (i = 0; i < 8; i++) {

--- a/libr/include/r_arch.h
+++ b/libr/include/r_arch.h
@@ -217,7 +217,7 @@ R_API void r_arch_free(RArch *arch);
 R_API void r_arch_config_use(RArchConfig *config, const char * R_NULLABLE arch);
 R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cpu);
 R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin);
-R_API char *r_arch_plugin_cpu_canonical(RArchPlugin *plugin, const char *cpu);
+R_API char *r_arch_plugin_cpucheck(RArchPlugin *plugin, const char *cpu);
 R_API bool r_arch_config_set_syntax(RArchConfig *config, int syntax);
 R_API bool r_arch_config_set_bits(RArchConfig *c, int bits);
 R_API RArchConfig *r_arch_config_new(void);

--- a/libr/include/r_arch.h
+++ b/libr/include/r_arch.h
@@ -216,6 +216,8 @@ R_API void r_arch_free(RArch *arch);
 // aconfig.c
 R_API void r_arch_config_use(RArchConfig *config, const char * R_NULLABLE arch);
 R_API void r_arch_config_set_cpu(RArchConfig *config, const char * R_NULLABLE cpu);
+R_API RList *r_arch_plugin_cpus(RArchPlugin *plugin);
+R_API char *r_arch_plugin_cpu_canonical(RArchPlugin *plugin, const char *cpu);
 R_API bool r_arch_config_set_syntax(RArchConfig *config, int syntax);
 R_API bool r_arch_config_set_bits(RArchConfig *c, int bits);
 R_API RArchConfig *r_arch_config_new(void);

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -1005,9 +1005,6 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		rasm_env_print (opt.arg);
 		goto beach;
 	}
-	if (as->opt.cpu) {
-		r_arch_config_set_cpu (as->a->config, as->opt.cpu);
-	}
 	if (arch) {
 		if (!r_asm_use (as->a, arch)) {
 			R_LOG_ERROR ("Unknown asm plugin '%s'", arch);
@@ -1034,16 +1031,18 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 	r_anal_set_bits (as->anal, bits);
 	as->opt.bits = bits;
 	as->a->syscall = r_syscall_new ();
+	char *asmcpu = NULL;
 	if (R_STR_ISNOTEMPTY (as->opt.cpu)) {
-		// check if selected cpu is valid
-		const char *cpus = R_UNWRAP4 (as->anal->arch, session, plugin, cpus);
-		if (cpus && !strstr (cpus, as->opt.cpu)) {
-			R_LOG_WARN ("Invalid CPU. See -a, -b and asm.cpu values (%s)", cpus);
+		RArchPlugin *ap = R_UNWRAP3 (as->anal->arch, session, plugin);
+		asmcpu = ap? r_arch_plugin_cpu_canonical (ap, as->opt.cpu): strdup (as->opt.cpu);
+		if (asmcpu) {
+			r_arch_config_set_cpu (as->a->config, asmcpu);
 		} else {
-			R_LOG_WARN ("Ignored -c asm.cpu, provided plugin exposes no CPUs models");
+			R_LOG_WARN ("Invalid CPU '%s'. See -a, -b and asm.cpu values", as->opt.cpu);
 		}
 	}
-	r_syscall_setup (as->a->syscall, arch, bits, as->opt.cpu, as->opt.kernel);
+	r_syscall_setup (as->a->syscall, arch, bits, asmcpu, as->opt.kernel);
+	free (asmcpu);
 	{
 		bool canbebig = r_asm_set_big_endian (as->a, as->opt.isbig);
 		if (as->opt.isbig && !canbebig) {

--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -1034,7 +1034,7 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 	char *asmcpu = NULL;
 	if (R_STR_ISNOTEMPTY (as->opt.cpu)) {
 		RArchPlugin *ap = R_UNWRAP3 (as->anal->arch, session, plugin);
-		asmcpu = ap? r_arch_plugin_cpu_canonical (ap, as->opt.cpu): strdup (as->opt.cpu);
+		asmcpu = ap? r_arch_plugin_cpucheck (ap, as->opt.cpu): strdup (as->opt.cpu);
 		if (asmcpu) {
 			r_arch_config_set_cpu (as->a->config, asmcpu);
 		} else {

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -143,6 +143,56 @@ all
 EOF
 RUN
 
+NAME=e asm.cpu rejects invalid value
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=v8
+e asm.cpu=tetris
+e asm.cpu
+EOF
+EXPECT=<<EOF
+v8
+EOF
+RUN
+
+NAME=e asm.cpu rejects partial match
+FILE=-
+ARGS=-a mips
+CMDS=<<EOF
+e asm.cpu=v
+e asm.cpu
+EOF
+EXPECT=<<EOF
+
+EOF
+RUN
+
+NAME=e asm.cpu canonicalizes valid value
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=V8
+e asm.cpu
+EOF
+EXPECT=<<EOF
+v8
+EOF
+RUN
+
+NAME=e asm.cpu clears invalid value on arch switch
+FILE=-
+ARGS=-a arm -b 16
+CMDS=<<EOF
+e asm.cpu=v8
+e asm.arch=v850
+e asm.cpu
+EOF
+EXPECT=<<EOF
+
+EOF
+RUN
+
 NAME=e asm.syntax
 FILE=-
 CMDS=<<EOF

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -143,52 +143,27 @@ all
 EOF
 RUN
 
-NAME=e asm.cpu rejects invalid value
-FILE=-
-ARGS=-a arm -b 16
-CMDS=<<EOF
-e asm.cpu=v8
-e asm.cpu=tetris
-e asm.cpu
-EOF
-EXPECT=<<EOF
-v8
-EOF
-RUN
-
-NAME=e asm.cpu rejects partial match
-FILE=-
-ARGS=-a mips
-CMDS=<<EOF
-e asm.cpu=v
-e asm.cpu
-EOF
-EXPECT=<<EOF
-
-EOF
-RUN
-
-NAME=e asm.cpu canonicalizes valid value
+NAME=e asm.cpu validation
 FILE=-
 ARGS=-a arm -b 16
 CMDS=<<EOF
 e asm.cpu=V8
 e asm.cpu
-EOF
-EXPECT=<<EOF
-v8
-EOF
-RUN
-
-NAME=e asm.cpu clears invalid value on arch switch
-FILE=-
-ARGS=-a arm -b 16
-CMDS=<<EOF
-e asm.cpu=v8
+e asm.cpu=tetris
+e asm.cpu
+e asm.arch=mips
+e asm.cpu=v
+e asm.cpu
+e asm.cpu=v3
+e asm.cpu
 e asm.arch=v850
 e asm.cpu
 EOF
 EXPECT=<<EOF
+v8
+v8
+
+v3
 
 EOF
 RUN


### PR DESCRIPTION
Slimmed-down take on PR #26061: validate asm.cpu by matching against the
existing plugin .cpus metadata instead of introducing a parallel typed
CPU representation.

- Add r_arch_plugin_cpus() to dedup the comma-split loops (cconfig, asm,
  cmd_log) and r_arch_plugin_cpu_canonical() returning the canonical CPU
  spelling or NULL for invalid values.
- Reject invalid asm.cpu (keeping the previous value), canonicalize case,
  reject partial matches, and clear an incompatible asm.cpu on arch switch.
- Accept the arch/plugin name as a valid CPU (matches bin-load behavior).
- Route rasm2 -c through the same canonicalizer, fixing the substring match.
- Fix arm/mips plugin_changed to detect NULL<->value CPU transitions so the
  capstone mode is reconfigured when asm.cpu is set or cleared.

Does not add the RArchCpu struct, RArchCpuMatch enum, aliases/flags, or
per-plugin cpu_models arrays from the original PR.