### PR TITLE
Adds floating-point support to the PPC analysis plugin (`ppc_cs`).

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -406,7 +406,39 @@ static char *regs(RArchSession *as) {
 			"gpr	dbat1u .32 268 0\n"
 			"gpr	dbat2u .32 276 0\n"
 			"gpr	dbat3u .32 284 0\n"
-			"gpr	mask   .32 288 0\n";
+			"gpr	mask   .32 288 0\n"
+			"fpu	f0  .64 292 0\n"
+			"fpu	f1  .64 300 0\n"
+			"fpu	f2  .64 308 0\n"
+			"fpu	f3  .64 316 0\n"
+			"fpu	f4  .64 324 0\n"
+			"fpu	f5  .64 332 0\n"
+			"fpu	f6  .64 340 0\n"
+			"fpu	f7  .64 348 0\n"
+			"fpu	f8  .64 356 0\n"
+			"fpu	f9  .64 364 0\n"
+			"fpu	f10 .64 372 0\n"
+			"fpu	f11 .64 380 0\n"
+			"fpu	f12 .64 388 0\n"
+			"fpu	f13 .64 396 0\n"
+			"fpu	f14 .64 404 0\n"
+			"fpu	f15 .64 412 0\n"
+			"fpu	f16 .64 420 0\n"
+			"fpu	f17 .64 428 0\n"
+			"fpu	f18 .64 436 0\n"
+			"fpu	f19 .64 444 0\n"
+			"fpu	f20 .64 452 0\n"
+			"fpu	f21 .64 460 0\n"
+			"fpu	f22 .64 468 0\n"
+			"fpu	f23 .64 476 0\n"
+			"fpu	f24 .64 484 0\n"
+			"fpu	f25 .64 492 0\n"
+			"fpu	f26 .64 500 0\n"
+			"fpu	f27 .64 508 0\n"
+			"fpu	f28 .64 516 0\n"
+			"fpu	f29 .64 524 0\n"
+			"fpu	f30 .64 532 0\n"
+			"fpu	f31 .64 540 0\n";
 		return strdup (p);
 	}
 
@@ -510,7 +542,39 @@ static char *regs(RArchSession *as) {
 		"gpr	dbat1u .32 468 0\n"
 		"gpr	dbat2u .32 476 0\n"
 		"gpr	dbat3u .32 484 0\n"
-		"gpr	mask   .64 488 0\n"; //not a real register used on complex functions
+		"gpr	mask   .64 488 0\n" //not a real register used on complex functions
+		"fpu	f0  .64 496 0\n"
+		"fpu	f1  .64 504 0\n"
+		"fpu	f2  .64 512 0\n"
+		"fpu	f3  .64 520 0\n"
+		"fpu	f4  .64 528 0\n"
+		"fpu	f5  .64 536 0\n"
+		"fpu	f6  .64 544 0\n"
+		"fpu	f7  .64 552 0\n"
+		"fpu	f8  .64 560 0\n"
+		"fpu	f9  .64 568 0\n"
+		"fpu	f10 .64 576 0\n"
+		"fpu	f11 .64 584 0\n"
+		"fpu	f12 .64 592 0\n"
+		"fpu	f13 .64 600 0\n"
+		"fpu	f14 .64 608 0\n"
+		"fpu	f15 .64 616 0\n"
+		"fpu	f16 .64 624 0\n"
+		"fpu	f17 .64 632 0\n"
+		"fpu	f18 .64 640 0\n"
+		"fpu	f19 .64 648 0\n"
+		"fpu	f20 .64 656 0\n"
+		"fpu	f21 .64 664 0\n"
+		"fpu	f22 .64 672 0\n"
+		"fpu	f23 .64 680 0\n"
+		"fpu	f24 .64 688 0\n"
+		"fpu	f25 .64 696 0\n"
+		"fpu	f26 .64 704 0\n"
+		"fpu	f27 .64 712 0\n"
+		"fpu	f28 .64 720 0\n"
+		"fpu	f29 .64 728 0\n"
+		"fpu	f30 .64 736 0\n"
+		"fpu	f31 .64 744 0\n";
 	return strdup (p);
 }
 
@@ -831,6 +895,40 @@ static void ppc_esil_brx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int nb
 	r_strbuf_free (sb);
 }
 
+static char *ppc_idx_ea(PluginData *pd, struct Getarg *gop, char *buf, size_t sz) {
+	cs_insn *insn = gop->insn;
+	const char *rb = getarg2 (pd, gop, 2, "");
+	if (INSOP (1).type == PPC_OP_REG && INSOP (1).reg != PPC_REG_INVALID) {
+		snprintf (buf, sz, "%s,%s,+", getarg2 (pd, gop, 1, ""), rb);
+	} else {
+		snprintf (buf, sz, "%s", rb);
+	}
+	return buf;
+}
+
+static void ppc_fpop(RAnalOp *op, PluginData *pd, struct Getarg *gop, bool single, int nsrc, const char *fop) {
+	char body[96];
+	switch (nsrc) {
+	case 3:
+		snprintf (body, sizeof (body), "%s,%s,%s,%s",
+			getarg2 (pd, gop, 3, ""), getarg2 (pd, gop, 2, ""), getarg2 (pd, gop, 1, ""), fop);
+		break;
+	case 2:
+		snprintf (body, sizeof (body), "%s,%s,%s",
+			getarg2 (pd, gop, 2, ""), getarg2 (pd, gop, 1, ""), fop);
+		break;
+	default:
+		snprintf (body, sizeof (body), "%s,%s", getarg2 (pd, gop, 1, ""), fop);
+		break;
+	}
+	const char *dst = getarg2 (pd, gop, 0, "");
+	if (single) {
+		esilprintf (op, "32,DUP,%s,D2F,F2D,%s,=", body, dst);
+	} else {
+		esilprintf (op, "%s,%s,=", body, dst);
+	}
+}
+
 static int decompile_vle(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len) {
 	vle_t* instr = 0;
 	vle_handle handle = {0};
@@ -896,6 +994,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 
 	int ret, ridx;
 	char *op1;
+	char ea[64];
 
 	PluginData *pd = as->data;
 	const char *cpu = as->config->cpu;
@@ -1271,18 +1370,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			ppc_esil_brx (op, pd, &gop, 8, false);
 			break;
 		case PPC_INS_LFD:
-		case PPC_INS_LFDU:
-		case PPC_INS_LFDUX:
-		case PPC_INS_LFDX:
-		case PPC_INS_LFIWAX:
-		case PPC_INS_LFIWZX:
-		case PPC_INS_LFS:
-		case PPC_INS_LFSU:
-		case PPC_INS_LFSUX:
-		case PPC_INS_LFSX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
-			esilprintf (op, "%s,%s,=", ARG2 (1, "[4]"), ARG (0));
-			/* PPC64 ELFv1 TOC chain: lfd/lfs fY, LO(rX) following addis rX, r2, HA */
+			esilprintf (op, "%s,%s,=", ARG2 (1, "[8]"), ARG (0));
 			if (INSOP(1).type == PPC_OP_MEM) {
 				ridx = toc_reg_idx (INSOP(1).mem.base);
 				if (ridx >= 0 && pd->toc_map[ridx]) {
@@ -1290,35 +1379,158 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
+		case PPC_INS_LFDU:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			op1 = shrink (ARG (1));
+			if (!op1) {
+				break;
+			}
+			esilprintf (op, "%s,[8],%s,=,%s=", op1, ARG (0), op1);
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
+			break;
+		case PPC_INS_LFDX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "%s,[8],%s,=", ppc_idx_ea (pd, &gop, ea, sizeof (ea)), ARG (0));
+			break;
+		case PPC_INS_LFDUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_idx_ea (pd, &gop, ea, sizeof (ea));
+			esilprintf (op, "%s,[8],%s,=,%s,%s,=", ea, ARG (0), ea, ARG (1));
+			break;
+		case PPC_INS_LFS:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "32,%s,F2D,%s,=", ARG2 (1, "[4]"), ARG (0));
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
+			break;
+		case PPC_INS_LFSU:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			op1 = shrink (ARG (1));
+			if (!op1) {
+				break;
+			}
+			esilprintf (op, "32,%s,[4],F2D,%s,=,%s=", op1, ARG (0), op1);
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
+			break;
+		case PPC_INS_LFSX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "32,%s,[4],F2D,%s,=", ppc_idx_ea (pd, &gop, ea, sizeof (ea)), ARG (0));
+			break;
+		case PPC_INS_LFSUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_idx_ea (pd, &gop, ea, sizeof (ea));
+			esilprintf (op, "32,%s,[4],F2D,%s,=,%s,%s,=", ea, ARG (0), ea, ARG (1));
+			break;
+		case PPC_INS_LFIWAX:
+		case PPC_INS_LFIWZX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "%s,[4],%s,=", ppc_idx_ea (pd, &gop, ea, sizeof (ea)), ARG (0));
+			break;
 		case PPC_INS_STFD:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[8]"));
+			break;
 		case PPC_INS_STFDU:
-		case PPC_INS_STFDUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			op1 = shrink (ARG (1));
+			if (!op1) {
+				break;
+			}
+			esilprintf (op, "%s,%s,=[8],%s=", ARG (0), op1, op1);
+			break;
 		case PPC_INS_STFDX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			esilprintf (op, "%s,%s,=[8]", ARG (0), ppc_idx_ea (pd, &gop, ea, sizeof (ea)));
+			break;
+		case PPC_INS_STFDUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_idx_ea (pd, &gop, ea, sizeof (ea));
+			esilprintf (op, "%s,%s,=[8],%s,%s,=", ARG (0), ea, ea, ARG (1));
+			break;
 		case PPC_INS_STFS:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			esilprintf (op, "32,%s,D2F,%s", ARG (0), ARG2 (1, "=[4]"));
+			break;
 		case PPC_INS_STFSU:
-		case PPC_INS_STFSUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			op1 = shrink (ARG (1));
+			if (!op1) {
+				break;
+			}
+			esilprintf (op, "32,%s,D2F,%s,=[4],%s=", ARG (0), op1, op1);
+			break;
 		case PPC_INS_STFSX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			esilprintf (op, "32,%s,D2F,%s,=[4]", ARG (0), ppc_idx_ea (pd, &gop, ea, sizeof (ea)));
+			break;
+		case PPC_INS_STFSUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_idx_ea (pd, &gop, ea, sizeof (ea));
+			esilprintf (op, "32,%s,D2F,%s,=[4],%s,%s,=", ARG (0), ea, ea, ARG (1));
+			break;
 		case PPC_INS_STFIWX:
 			op->type = R_ANAL_OP_TYPE_STORE;
+			esilprintf (op, "%s,%s,=[4]", ARG (0), ppc_idx_ea (pd, &gop, ea, sizeof (ea)));
 			break;
 		case PPC_INS_FADD:
 		case PPC_INS_FADDS:
+			op->type = R_ANAL_OP_TYPE_ADD;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FADDS, 2, "F+");
+			break;
 		case PPC_INS_FSUB:
 		case PPC_INS_FSUBS:
+			op->type = R_ANAL_OP_TYPE_SUB;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FSUBS, 2, "F-");
+			break;
 		case PPC_INS_FMUL:
 		case PPC_INS_FMULS:
+			op->type = R_ANAL_OP_TYPE_MUL;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FMULS, 2, "F*");
+			break;
 		case PPC_INS_FDIV:
 		case PPC_INS_FDIVS:
-		case PPC_INS_FMADD:
-		case PPC_INS_FMADDS:
-		case PPC_INS_FMSUB:
-		case PPC_INS_FMSUBS:
-		case PPC_INS_FNMADD:
-		case PPC_INS_FNMADDS:
-		case PPC_INS_FNMSUB:
-		case PPC_INS_FNMSUBS:
+			op->type = R_ANAL_OP_TYPE_DIV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FDIVS, 2, "F/");
+			break;
 		case PPC_INS_FSQRT:
 		case PPC_INS_FSQRTS:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FSQRTS, 1, "SQRT");
+			break;
+		case PPC_INS_FMADD:
+		case PPC_INS_FMADDS:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FMADDS, 3, "F*,F+");
+			break;
+		case PPC_INS_FMSUB:
+		case PPC_INS_FMSUBS:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FMSUBS, 3, "F*,F-");
+			break;
+		case PPC_INS_FNMADD:
+		case PPC_INS_FNMADDS:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FNMADDS, 3, "F*,F+,-F");
+			break;
+		case PPC_INS_FNMSUB:
+		case PPC_INS_FNMSUBS:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FNMSUBS, 3, "F*,F-,-F");
+			break;
 		case PPC_INS_FRE:
 		case PPC_INS_FRES:
 		case PPC_INS_FRSQRTE:
@@ -1330,21 +1542,41 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_MOV;
 			break;
 		case PPC_INS_FMR:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "%s,%s,=", ARG (1), ARG (0));
+			break;
 		case PPC_INS_FNEG:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "0x8000000000000000,%s,^,%s,=", ARG (1), ARG (0));
+			break;
 		case PPC_INS_FCPSGN:
 			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "0x8000000000000000,%s,&,0x7fffffffffffffff,%s,&,|,%s,=",
+				ARG (1), ARG (2), ARG (0));
+			break;
+		case PPC_INS_FABS:
+			op->type = R_ANAL_OP_TYPE_ABS;
+			esilprintf (op, "0x7fffffffffffffff,%s,&,%s,=", ARG (1), ARG (0));
+			break;
+		case PPC_INS_FNABS:
+			op->type = R_ANAL_OP_TYPE_ABS;
+			esilprintf (op, "0x8000000000000000,%s,|,%s,=", ARG (1), ARG (0));
 			break;
 		case PPC_INS_FCMPU:
 			op->type = R_ANAL_OP_TYPE_CMP;
-			break;
-		case PPC_INS_FABS:
-		case PPC_INS_FNABS:
-			op->type = R_ANAL_OP_TYPE_ABS;
+			esilprintf (op, "0x80,%s,%s,F<,*,%s,%s,F<,+,%s,=",
+				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
 			break;
 		case PPC_INS_FCFID:
 		case PPC_INS_FCFIDS:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FCFIDS, 1, "I2D");
+			break;
 		case PPC_INS_FCFIDU:
 		case PPC_INS_FCFIDUS:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, insn->id == PPC_INS_FCFIDUS, 1, "U2D");
+			break;
 		case PPC_INS_FCTID:
 		case PPC_INS_FCTIDUZ:
 		case PPC_INS_FCTIDZ:
@@ -1355,12 +1587,28 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_FCTIWU:
 #endif
 		case PPC_INS_FCTIWZ:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, false, 1, "D2I");
+			break;
 		case PPC_INS_FRSP:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			esilprintf (op, "32,DUP,%s,D2F,F2D,%s,=", ARG (1), ARG (0));
+			break;
 		case PPC_INS_FRIM:
-		case PPC_INS_FRIN:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, false, 1, "FLOOR");
+			break;
 		case PPC_INS_FRIP:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, false, 1, "CEIL");
+			break;
+		case PPC_INS_FRIN:
+			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, false, 1, "ROUND");
+			break;
 		case PPC_INS_FRIZ:
 			op->type = R_ANAL_OP_TYPE_CAST;
+			ppc_fpop (op, pd, &gop, false, 1, "D2I,I2D");
 			break;
 		case PPC_INS_LMW:
 		case PPC_INS_LSWI:

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -944,7 +944,7 @@ EOF
 EXPECT=<<EOF
 type: store
 family: cpu
-type: mov
+type: add
 family: fpu
 type: cmp
 family: fpu

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -615,3 +615,57 @@ EXPECT=<<EOF
 0x00000040
 EOF
 RUN
+
+NAME=fadd esil string ppc-32
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc22182a)
+EOF
+EXPECT=<<EOF
+fadd f1, f2, f3
+0x00000000 f3,f2,F+,f1,=
+EOF
+RUN
+
+NAME=fmul emulation ppc-32
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx fc2200f2 @ 0
+aei
+ar f2=0x3ff8000000000000
+ar f3=0x4000000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4008000000000000
+EOF
+RUN
+
+NAME=lfs single widened to double emulation ppc-32
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 40400000 @ 0x20
+wx c0230020 @ 0
+aei
+aeim
+ar r3=0
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4008000000000000
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -237,3 +237,722 @@ EXPECT=<<EOF
 0x00000003
 EOF
 RUN
+
+NAME=fadd esil string ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc22182a)
+EOF
+EXPECT=<<EOF
+fadd f1, f2, f3
+0x00000000 f3,f2,F+,f1,=
+EOF
+RUN
+
+NAME=fadds single precision esil string ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi ec22182a)
+EOF
+EXPECT=<<EOF
+fadds f1, f2, f3
+0x00000000 32,DUP,f3,f2,F+,D2F,F2D,f1,=
+EOF
+RUN
+
+NAME=fmadd esil string ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc2220fa)
+EOF
+EXPECT=<<EOF
+fmadd f1, f2, f3, f4
+0x00000000 f4,f3,f2,F*,F+,f1,=
+EOF
+RUN
+
+NAME=fcmpu esil string ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc021800)
+EOF
+EXPECT=<<EOF
+fcmpu cr0, f2, f3
+0x00000000 0x80,f3,f2,F<,*,f2,f3,F<,+,cr0,=
+EOF
+RUN
+
+NAME=fmr/fneg/fabs sign esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc201090)
+.(pi fc201050)
+.(pi fc201210)
+EOF
+EXPECT=<<EOF
+fmr f1, f2
+0x00000000 f2,f1,=
+fneg f1, f2
+0x00000000 0x8000000000000000,f2,^,f1,=
+fabs f1, f2
+0x00000000 0x7fffffffffffffff,f2,&,f1,=
+EOF
+RUN
+
+NAME=lfd/lfs/stfd/stfs esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi c8230010)
+.(pi c0230010)
+.(pi d8230010)
+.(pi d0230010)
+EOF
+EXPECT=<<EOF
+lfd f1, 0x10(r3)
+0x00000000 16,r3,+,[8],f1,=
+lfs f1, 0x10(r3)
+0x00000000 32,16,r3,+,[4],F2D,f1,=
+stfd f1, 0x10(r3)
+0x00000000 f1,16,r3,+,=[8]
+stfs f1, 0x10(r3)
+0x00000000 32,f1,D2F,16,r3,+,=[4]
+EOF
+RUN
+
+NAME=fsub emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc221828 @ 0
+aei
+ar f2=0x4010000000000000
+ar f3=0x3ff8000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4004000000000000
+EOF
+RUN
+
+NAME=fdiv emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc221824 @ 0
+aei
+ar f2=0x4008000000000000
+ar f3=0x4000000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x3ff8000000000000
+EOF
+RUN
+
+NAME=fadds single rounding emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx ec22182a @ 0
+aei
+ar f2=0x3ff199999999999a
+ar f3=0x400199999999999a
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x400a666660000000
+EOF
+RUN
+
+NAME=fmadd emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc2220fa @ 0
+aei
+ar f2=0x4000000000000000
+ar f3=0x4008000000000000
+ar f4=0x3ff0000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x401c000000000000
+EOF
+RUN
+
+NAME=fcfid int to double emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc20169c @ 0
+aei
+ar f2=5
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4014000000000000
+EOF
+RUN
+
+NAME=fctidz double to int emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc20165e @ 0
+aei
+ar f2=0x4004000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x00000002
+EOF
+RUN
+
+NAME=fcmpu sets cr byte lt/gt/eq emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc021800 @ 0
+aei
+ar f2=0x3ff0000000000000
+ar f3=0x4000000000000000
+aepc 0
+aes
+ar cr0
+ar f2=0x4000000000000000
+ar f3=0x3ff0000000000000
+aepc 0
+aes
+ar cr0
+ar f3=0x4000000000000000
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000080
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=stfd then lfd roundtrip emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+aei
+aeim
+ar r3=0
+ar f1=0x4004000000000000
+wx d8230020 @ 0
+aepc 0
+aes
+wx c8a30020 @ 0
+aepc 0
+aes
+ar f5
+EOF
+EXPECT=<<EOF
+0x4004000000000000
+EOF
+RUN
+
+NAME=fp single-precision arith esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi ec221828)
+.(pi ec2200f2)
+.(pi ec221824)
+.(pi fc20102c)
+.(pi ec20102c)
+EOF
+EXPECT=<<EOF
+fsubs f1, f2, f3
+0x00000000 32,DUP,f3,f2,F-,D2F,F2D,f1,=
+fmuls f1, f2, f3
+0x00000000 32,DUP,f3,f2,F*,D2F,F2D,f1,=
+fdivs f1, f2, f3
+0x00000000 32,DUP,f3,f2,F/,D2F,F2D,f1,=
+fsqrt f1, f2
+0x00000000 f2,SQRT,f1,=
+fsqrts f1, f2
+0x00000000 32,DUP,f2,SQRT,D2F,F2D,f1,=
+EOF
+RUN
+
+NAME=fma family esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi ec2220fa)
+.(pi fc2220f8)
+.(pi ec2220f8)
+.(pi fc2220fe)
+.(pi ec2220fe)
+.(pi fc2220fc)
+.(pi ec2220fc)
+EOF
+EXPECT=<<EOF
+fmadds f1, f2, f3, f4
+0x00000000 32,DUP,f4,f3,f2,F*,F+,D2F,F2D,f1,=
+fmsub f1, f2, f3, f4
+0x00000000 f4,f3,f2,F*,F-,f1,=
+fmsubs f1, f2, f3, f4
+0x00000000 32,DUP,f4,f3,f2,F*,F-,D2F,F2D,f1,=
+fnmadd f1, f2, f3, f4
+0x00000000 f4,f3,f2,F*,F+,-F,f1,=
+fnmadds f1, f2, f3, f4
+0x00000000 32,DUP,f4,f3,f2,F*,F+,-F,D2F,F2D,f1,=
+fnmsub f1, f2, f3, f4
+0x00000000 f4,f3,f2,F*,F-,-F,f1,=
+fnmsubs f1, f2, f3, f4
+0x00000000 32,DUP,f4,f3,f2,F*,F-,-F,D2F,F2D,f1,=
+EOF
+RUN
+
+NAME=fnabs/fcpsgn esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc201110)
+.(pi fc221810)
+EOF
+EXPECT=<<EOF
+fnabs f1, f2
+0x00000000 0x8000000000000000,f2,|,f1,=
+fcpsgn f1, f2, f3
+0x00000000 0x8000000000000000,f2,&,0x7fffffffffffffff,f3,&,|,f1,=
+EOF
+RUN
+
+NAME=fp convert esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi fc20179c)
+.(pi ec20169c)
+.(pi ec20179c)
+.(pi fc20165c)
+.(pi fc201018)
+.(pi fc2013d0)
+.(pi fc201390)
+.(pi fc201310)
+.(pi fc201350)
+EOF
+EXPECT=<<EOF
+fcfidu f1, f2
+0x00000000 f2,U2D,f1,=
+fcfids f1, f2
+0x00000000 32,DUP,f2,I2D,D2F,F2D,f1,=
+fcfidus f1, f2
+0x00000000 32,DUP,f2,U2D,D2F,F2D,f1,=
+fctid f1, f2
+0x00000000 f2,D2I,f1,=
+frsp f1, f2
+0x00000000 32,DUP,f2,D2F,F2D,f1,=
+frim f1, f2
+0x00000000 f2,FLOOR,f1,=
+frip f1, f2
+0x00000000 f2,CEIL,f1,=
+frin f1, f2
+0x00000000 f2,ROUND,f1,=
+friz f1, f2
+0x00000000 f2,D2I,I2D,f1,=
+EOF
+RUN
+
+NAME=fp indexed and update load/store esil strings ppc-64
+FILE=-
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+(pi bytes;wx $0;pi 1;pie 1)
+.(pi cc230010)
+.(pi 7c2324ae)
+.(pi 7c2324ee)
+.(pi c4230010)
+.(pi 7c23242e)
+.(pi 7c23246e)
+.(pi dc230010)
+.(pi 7c2325ae)
+.(pi 7c2325ee)
+.(pi d4230010)
+.(pi 7c23252e)
+.(pi 7c23256e)
+.(pi 7c201eae)
+.(pi 7c201eee)
+.(pi 7c201fae)
+EOF
+EXPECT=<<EOF
+lfdu f1, 0x10(r3)
+0x00000000 16,r3,+,[8],f1,=,16,r3,+=
+lfdx f1, r3, r4
+0x00000000 r3,r4,+,[8],f1,=
+lfdux f1, r3, r4
+0x00000000 r3,r4,+,[8],f1,=,r3,r4,+,r3,=
+lfsu f1, 0x10(r3)
+0x00000000 32,16,r3,+,[4],F2D,f1,=,16,r3,+=
+lfsx f1, r3, r4
+0x00000000 32,r3,r4,+,[4],F2D,f1,=
+lfsux f1, r3, r4
+0x00000000 32,r3,r4,+,[4],F2D,f1,=,r3,r4,+,r3,=
+stfdu f1, 0x10(r3)
+0x00000000 f1,16,r3,+,=[8],16,r3,+=
+stfdx f1, r3, r4
+0x00000000 f1,r3,r4,+,=[8]
+stfdux f1, r3, r4
+0x00000000 f1,r3,r4,+,=[8],r3,r4,+,r3,=
+stfsu f1, 0x10(r3)
+0x00000000 32,f1,D2F,16,r3,+,=[4],16,r3,+=
+stfsx f1, r3, r4
+0x00000000 32,f1,D2F,r3,r4,+,=[4]
+stfsux f1, r3, r4
+0x00000000 32,f1,D2F,r3,r4,+,=[4],r3,r4,+,r3,=
+lfiwax f1, 0, r3
+0x00000000 r3,[4],f1,=
+lfiwzx f1, 0, r3
+0x00000000 r3,[4],f1,=
+stfiwx f1, 0, r3
+0x00000000 f1,r3,=[4]
+EOF
+RUN
+
+NAME=fsqrt emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc20102c @ 0
+aei
+ar f2=0x4030000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4010000000000000
+EOF
+RUN
+
+NAME=fmsub emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc2220f8 @ 0
+aei
+ar f2=0x4000000000000000
+ar f3=0x4008000000000000
+ar f4=0x3ff0000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4014000000000000
+EOF
+RUN
+
+NAME=fnmadd negate emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc2220fe @ 0
+aei
+ar f2=0x4000000000000000
+ar f3=0x4008000000000000
+ar f4=0x3ff0000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0xc01c000000000000
+EOF
+RUN
+
+NAME=fnabs emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc201110 @ 0
+aei
+ar f2=0x4004000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0xc004000000000000
+EOF
+RUN
+
+NAME=fcpsgn emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc221810 @ 0
+aei
+ar f2=0xbff0000000000000
+ar f3=0x4004000000000000
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0xc004000000000000
+EOF
+RUN
+
+NAME=fcfidu unsigned int to double emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc20179c @ 0
+aei
+ar f2=0xffffffffffffffff
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x43f0000000000000
+EOF
+RUN
+
+NAME=frsp round to single emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx fc201018 @ 0
+aei
+ar f2=0x400921fb54442d18
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x400921fb60000000
+EOF
+RUN
+
+NAME=frim/frip/frin/friz rounding emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+aei
+ar f2=0x4004000000000000
+wx fc2013d0 @ 0
+aepc 0
+aes
+ar f1
+wx fc201390 @ 0
+aepc 0
+aes
+ar f1
+wx fc201310 @ 0
+aepc 0
+aes
+ar f1
+ar f2=0x4007333333333333
+wx fc201350 @ 0
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4000000000000000
+0x4008000000000000
+0x4008000000000000
+0x4000000000000000
+EOF
+RUN
+
+NAME=fsubs single rounding emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx ec221828 @ 0
+aei
+ar f2=0x4010000000000000
+ar f3=0x3ff199999999999a
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x4007333340000000
+EOF
+RUN
+
+NAME=lfdux indexed load with base update emulation ppc-64
+FILE=malloc://0x80
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 4004000000000000 @ 0x20
+wx 7c2324ee @ 0
+aei
+aeim
+ar r3=0x10
+ar r4=0x10
+aepc 0
+aes
+ar f1
+ar r3
+EOF
+EXPECT=<<EOF
+0x4004000000000000
+0x00000020
+EOF
+RUN
+
+NAME=stfdux indexed store with base update emulation ppc-64
+FILE=malloc://0x80
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c2325ee @ 0
+wx c8a30000 @ 4
+aei
+aeim
+ar f1=0x4004000000000000
+ar r3=0x10
+ar r4=0x10
+aepc 0
+aes
+aes
+ar f5
+ar r3
+EOF
+EXPECT=<<EOF
+0x4004000000000000
+0x00000020
+EOF
+RUN
+
+NAME=lfiwzx integer load to fpr emulation ppc-64
+FILE=malloc://0x80
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 00000005 @ 0x20
+wx 7c201eee @ 0
+aei
+aeim
+ar r3=0x20
+aepc 0
+aes
+ar f1
+EOF
+EXPECT=<<EOF
+0x00000005
+EOF
+RUN
+
+NAME=stfiwx integer store roundtrip emulation ppc-64
+FILE=malloc://0x80
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c201fae @ 0
+wx 7ca01eee @ 4
+aei
+aeim
+ar f1=0x1122334455667788
+ar r3=0x20
+aepc 0
+aes
+aes
+ar f5
+EOF
+EXPECT=<<EOF
+0x55667788
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Register profile: add `f0`–`f31` (64-bit) to the 32-bit and 64-bit profiles.
- ESIL for scalar FP loads/stores (incl. indexed + update-with-writeback), arithmetic, fused multiply-add, sign ops, `fcmpu`, and int↔fp converts; single-precision variants round via `D2F`/`F2D`.
- Correct op-types for FP arithmetic (`fadd`→ADD, etc.).
- Helpers `ppc_idx_ea` (RA0-aware base+index EA) and `ppc_fpop` (shared single-rounding wrapper).

Tests in `test/db/esil/ppc_{32,64}` and `test/db/anal/ppc`.