### PR TITLE
Apply PPC64 TOC16 relocations to addis/ld immediates on ET_REL ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -898,7 +898,7 @@ static RList* relocs(RBinFile *bf) {
 	return result;
 }
 
-static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc *rel, ut64 S, ut64 B, ut64 L) {
+static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc *rel, ut64 S, ut64 B, ut64 L, ut64 toc) {
 	ut64 V = 0;
 	ut64 A = rel->addend;
 	ut64 P = rel->rva;
@@ -1067,7 +1067,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 		}
 		break;
 	case EM_PPC64: {
-		int low = 0, word = 0;
+		int low = 0, word = 0, ds = 0;
 		switch (rel->type) {
 		case R_PPC64_REL16_HA:
 			word = 2;
@@ -1105,6 +1105,32 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			word = 8;
 			V = B + A;
 			break;
+		case R_PPC64_TOC16_HA:
+			if (toc != UT64_MAX) {
+				word = 2;
+				V = (S + A - toc + 0x8000) >> 16;
+			}
+			break;
+		case R_PPC64_TOC16_HI:
+			if (toc != UT64_MAX) {
+				word = 2;
+				V = (S + A - toc) >> 16;
+			}
+			break;
+		case R_PPC64_TOC16:
+		case R_PPC64_TOC16_LO:
+			if (toc != UT64_MAX) {
+				word = 2;
+				V = (S + A - toc) & 0xffff;
+			}
+			break;
+		case R_PPC64_TOC16_DS:
+		case R_PPC64_TOC16_LO_DS:
+			if (toc != UT64_MAX) {
+				ds = 2;
+				V = (S + A - toc) & 0xfffc;
+			}
+			break;
 		default:
 			R_LOG_DEBUG ("unpatched PPC64 reloc type %d at 0x%"PFMT64x, rel->type, rel->rva);
 			break;
@@ -1139,6 +1165,11 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 				iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 				break;
 			}
+		} else if (ds) {
+			iob->read_at (iob->io, rel->rva, buf, 2);
+			ut16 cur = r_read_ble16 (buf, bo->endian);
+			r_write_ble16 (buf, (cur & 3) | (V & 0xfffc), bo->endian);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 2);
 		}
 		break;
 	}
@@ -1456,6 +1487,16 @@ static RList* patch_relocs(RBinFile *bf) {
 		return NULL;
 	}
 	ut64 vaddr = n_vaddr;
+	ut64 toc_base = UT64_MAX;
+	if (eo->ehdr.e_machine == EM_PPC64) {
+		ut64 t = Elf_(get_section_addr) (eo, ".toc");
+		if (t == UT64_MAX) {
+			t = Elf_(get_section_addr) (eo, ".got");
+		}
+		if (t != UT64_MAX) {
+			toc_base = t + 0x8000;
+		}
+	}
 	RBinElfReloc *reloc;
 	R_VEC_FOREACH (relocs, reloc) {
 		ut64 plt_entry_addr = vaddr;
@@ -1481,7 +1522,7 @@ static RList* patch_relocs(RBinFile *bf) {
 		} else {
 			raddr = vaddr;
 		}
-		_patch_reloc (eo, eo->ehdr.e_machine, &b->iob, reloc, raddr, eo->baddr, plt_entry_addr);
+		_patch_reloc (eo, eo->ehdr.e_machine, &b->iob, reloc, raddr, eo->baddr, plt_entry_addr, toc_base);
 		ptr = reloc_convert (eo, reloc, n_vaddr);
 		if (!ptr) {
 			continue;

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -208,3 +208,22 @@ EXPECT=<<EOF
 8
 EOF
 RUN
+
+NAME=PPC64 ELFv1 ET_REL: TOC16_LO_DS reloc applied to ld immediate
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=pi 2 @ 0x0800036c
+EXPECT=<<EOF
+addis r9, r2, 0
+ld r3, -0x8000(r9)
+EOF
+RUN
+
+NAME=PPC64 ELFv1 ET_REL: TOC16_LO_DS patches the DS halfword keeping the ld sub-opcode
+FILE=bins/elf/ppc64v1-crc32_generic.ko
+ARGS=-e bin.relocs.apply=true
+CMDS=p8 4 @ 0x08000370
+EXPECT=<<EOF
+e8698000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

PPC64 ET_REL objects (e.g. `.ko` modules) parse TOC16 relocations but never apply them, so TOC-relative accesses disassemble with zero immediates (`addis rX, r2, 0` / `ld rX, 0(rX)`), leaving every global/data reference unresolved.

This patches the `R_PPC64_TOC16` family (`TOC16`/`_LO`/`_HI`/`_HA`/`_DS`/`_LO_DS`) into the instruction immediates against the module TOC base (`.toc`/`.got` + 0x8000), DS forms preserving the low 2 opcode bits.

Now `ld rX, 0(rX)` → `ld rX, -0x8000(rX)`, resolving TOC data references.
  
Tests added in `test/db/formats/elf/ppc64v1-etrel`.