### PR TITLE
WIP: Use memoization for RBinSection search ##bin

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -899,8 +899,14 @@ R_API RVecRBinSection *r_bin_file_get_sections_vec(RBinFile *bf) {
 
 R_API RBinSection *r_bin_get_section_at(RBinObject *o, ut64 off, int va) {
 	R_RETURN_VAL_IF_FAIL (o, NULL);
-	RBinSection *section;
-	// TODO: must be O (1) .. use memoization or tree or so
+	RBinSection *section = o->cached_section;
+	if (section) {
+		ut64 from = va? o->baddr_shift + section->vaddr: section->paddr;
+		ut64 to = from + (va? section->vsize: section->size);
+		if (off >= from && off < to) {
+			return section;
+		}
+	}
 	R_VEC_FOREACH (&o->sections_vec, section) {
 		if (section->is_segment) {
 			continue;
@@ -908,9 +914,11 @@ R_API RBinSection *r_bin_get_section_at(RBinObject *o, ut64 off, int va) {
 		ut64 from = va? o->baddr_shift + section->vaddr: section->paddr;
 		ut64 to = from + (va? section->vsize: section->size);
 		if (off >= from && off < to) {
+			o->cached_section = section;
 			return section;
 		}
 	}
+	o->cached_section = NULL;
 	return NULL;
 }
 

--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -213,6 +213,7 @@ static void object_delete_items(RBinObject *o) {
 	RVecRBinImport_fini (&o->imports_vec);
 	RVecRBinSymbol_fini (&o->symbols_vec);
 	RVecRBinSection_fini (&o->sections_vec);
+	o->cached_section = NULL;
 
 	r_list_free (o->classes);
 	ht_pp_free (o->classes_ht);
@@ -597,6 +598,7 @@ R_API int r_bin_object_set_items(RBinFile *bf, RBinObject *bo) {
 				r_bin_filter_sections_vec (bf, &bo->sections_vec);
 			}
 		}
+		bo->cached_section = NULL;
 	}
 	// Load classes before reloc creation. Class-method-creating plugins
 	// (objc/pe/java/demangler/...) push into bo->symbols_vec via

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -421,6 +421,7 @@ typedef struct r_bin_object_t {
 	RVecRBinImport imports_vec;
 	RVecRBinSymbol symbols_vec;
 	RVecRBinSection sections_vec;
+	RBinSection *cached_section;
 	RVecRBinEntry entries_vec;
 	RList/*<??>*/ *entries;
 	RList/*<??>*/ *fields;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Replace O(n) RVec linear scan in r_bin_get_section_at() with lazy-built RIntervalTree lookup (based on a TODO comment in this function). We maintain backwards compatibility and fallback to RVec linear scan if section trees build fails.

I am opening this as a Draft PR to request a thorough review from maintainers more familiar with the deeper intricacies of the radare2 binary object lifecycle. There is a possibility of me missing some code paths which require trees invalidation besides those two in libr/bin/bobj.c.

Also, I am not sure whether this change is actually going to "speed" some things up, since typical binaries contain moderate amount of sections and linear scan might be as fast in this case. Feel free to close the PR if the change only complicates things without any actual benefit!

Any feedback is appreciated. Thank you for your time!

<!-- explain your changes if necessary -->
