### PR TITLE
Fix PPC indexed load/store, shift/rotate/divide and sign-extend ESIL ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -906,6 +906,64 @@ static char *ppc_idx_ea(PluginData *pd, struct Getarg *gop, char *buf, size_t sz
 	return buf;
 }
 
+// signbits != 0 sign-extends the load (algebraic forms)
+static void ppc_ldbody(char *load, size_t sz, const char *ea, int width, int signbits) {
+	if (signbits) {
+		snprintf (load, sz, "%d,%s,[%d],~", signbits, ea, width);
+	} else {
+		snprintf (load, sz, "%s,[%d]", ea, width);
+	}
+}
+
+static void ppc_esil_ldx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int width, bool update, int signbits) {
+	char ea[64], load[96];
+	ppc_idx_ea (pd, gop, ea, sizeof (ea));
+	const char *rd = getarg2 (pd, gop, 0, "");
+	ppc_ldbody (load, sizeof (load), ea, width, signbits);
+	if (update) {
+		esilprintf (op, "%s,%s,=,%s,%s,=", load, rd, ea, getarg2 (pd, gop, 1, ""));
+	} else {
+		esilprintf (op, "%s,%s,=", load, rd);
+	}
+}
+
+// D-form load; update writes back rA via ea+=
+static void ppc_esil_ld(RAnalOp *op, const char *ea, const char *rd, int width, bool update, int signbits) {
+	char load[96];
+	ppc_ldbody (load, sizeof (load), ea, width, signbits);
+	if (update) {
+		esilprintf (op, "%s,%s,=,%s=", load, rd, ea);
+	} else {
+		esilprintf (op, "%s,%s,=", load, rd);
+	}
+}
+
+static void ppc_esil_stx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int width, bool update) {
+	char ea[64];
+	ppc_idx_ea (pd, gop, ea, sizeof (ea));
+	const char *rs = getarg2 (pd, gop, 0, "");
+	if (update) {
+		esilprintf (op, "%s,%s,=[%d],%s,%s,=", rs, ea, width, ea, getarg2 (pd, gop, 1, ""));
+	} else {
+		esilprintf (op, "%s,%s,=[%d]", rs, ea, width);
+	}
+}
+
+// 32-bit rotate by hand (ESIL ROL is 64-bit); wrapping mask (MB>ME) also fills bits 32:63
+static void ppc_esil_rlwnm(RAnalOp *op, PluginData *pd, struct Getarg *gop, const char *mask, bool wrap) {
+	const char *sh = getarg2 (pd, gop, 2, "");
+	const char *rs = getarg2 (pd, gop, 1, "");
+	const char *rd = getarg2 (pd, gop, 0, "");
+	char rot[128];
+	snprintf (rot, sizeof (rot), "%s,0x1f,&,%s,<<,%s,0x1f,&,32,-,%s,0xffffffff,&,>>,|,0xffffffff,&",
+		sh, rs, sh, rs);
+	if (wrap) {
+		esilprintf (op, "%s,%s,&,32,%s,<<,|,%s,=", rot, mask, rot, rd);
+	} else {
+		esilprintf (op, "%s,%s,&,%s,=", rot, mask, rd);
+	}
+}
+
 static void ppc_fpop(RAnalOp *op, PluginData *pd, struct Getarg *gop, bool single, int nsrc, const char *fop) {
 	char body[96];
 	switch (nsrc) {
@@ -1139,7 +1197,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_RLWINM:
 			op->type = R_ANAL_OP_TYPE_ROL;
-			esilprintf (op, "%s,%s,ROL,%s,&,%s,=", ARG (2), ARG (1), cmask32 (cmaskbuf, ARG (3), ARG (4)), ARG (0));
+			ppc_esil_rlwnm (op, pd, &gop, cmask32 (cmaskbuf, ARG (3), ARG (4)), getarg (&gop, 3) > getarg (&gop, 4));
 			break;
 		case PPC_INS_SC:
 			op->type = R_ANAL_OP_TYPE_SWI;
@@ -1184,9 +1242,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			esilprintf (op, ",");
 			break;
 		case PPC_INS_STW:
-		case PPC_INS_STWUX:
-		case PPC_INS_STWX:
-		case PPC_INS_STWCX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[4]"));
 			/* PPC64 ELFv1 TOC chain: stw rY, LO(rX) following addis rX, r2, HA */
@@ -1229,7 +1284,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			ppc_esil_brx (op, pd, &gop, 8, true);
 			break;
 		case PPC_INS_STB:
-		case PPC_INS_STBX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[1]"));
 			/* PPC64 ELFv1 TOC chain: stb rY, LO(rX) following addis rX, r2, HA */
@@ -1256,7 +1310,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_STH:
-		case PPC_INS_STHX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[2]"));
 			/* PPC64 ELFv1 TOC chain: sth rY, LO(rX) following addis rX, r2, HA */
@@ -1283,7 +1336,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_STD:
-		case PPC_INS_STDX:
 			op->type = R_ANAL_OP_TYPE_STORE;
 			esilprintf (op, "%s,%s", ARG (0), ARG2 (1, "=[8]"));
 			/* PPC64 ELFv1 TOC chain: std rY, LO(rX) following addis rX, r2, HA */
@@ -1310,7 +1362,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_LBZU:
-		case PPC_INS_LBZUX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			op1 = shrink(ARG(1));
 			if (!op1) {
@@ -1329,7 +1380,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 #if CS_API_MAJOR >= 4
 		case PPC_INS_LBZCIX:
 #endif
-		case PPC_INS_LBZX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[1]"), ARG (0));
 			/* PPC64 ELFv1 TOC chain: lbz rY, LO(rX) following addis rX, r2, HA */
@@ -1341,12 +1391,10 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_LD:
-		case PPC_INS_LDARX:
 #if CS_API_MAJOR >= 4
 		case PPC_INS_LDCIX:
 #endif
 		case PPC_INS_LDU:
-		case PPC_INS_LDUX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			op1 = shrink (ARG(1));
 			if (!op1) {
@@ -1361,9 +1409,103 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
+		// X-form indexed: EA = rA + rB (separate capstone regs)
+		case PPC_INS_LBZX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 1, false, 0);
+			break;
+		case PPC_INS_LBZUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 1, true, 0);
+			break;
+		case PPC_INS_LHZX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 2, false, 0);
+			break;
+		case PPC_INS_LHAX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 2, false, 16);
+			break;
+		case PPC_INS_LHZUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 2, true, 0);
+			break;
+		case PPC_INS_LHAUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 2, true, 16);
+			break;
+		case PPC_INS_LWZX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 4, false, 0);
+			break;
+		case PPC_INS_LWAX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 4, false, 32);
+			break;
+		case PPC_INS_LWZUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 4, true, 0);
+			break;
+		case PPC_INS_LWAUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 4, true, 32);
+			break;
 		case PPC_INS_LDX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
-			esilprintf (op, "%s,%s,=", ARG2 (1, "[8]"), ARG (0));
+			ppc_esil_ldx (op, pd, &gop, 8, false, 0);
+			break;
+		case PPC_INS_LDUX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 8, true, 0);
+			break;
+		case PPC_INS_STBX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 1, false);
+			break;
+		case PPC_INS_STBUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 1, true);
+			break;
+		case PPC_INS_STHX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 2, false);
+			break;
+		case PPC_INS_STHUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 2, true);
+			break;
+		case PPC_INS_STWX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 4, false);
+			break;
+		case PPC_INS_STWUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 4, true);
+			break;
+		case PPC_INS_STDX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 8, false);
+			break;
+		case PPC_INS_STDUX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 8, true);
+			break;
+		// larx/stcx.: only the memory access is modelled, not the reservation/CR0
+		case PPC_INS_LWARX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 4, false, 0);
+			break;
+		case PPC_INS_LDARX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			ppc_esil_ldx (op, pd, &gop, 8, false, 0);
+			break;
+		case PPC_INS_STWCX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 4, false);
+			break;
+		case PPC_INS_STDCX:
+			op->type = R_ANAL_OP_TYPE_STORE;
+			ppc_esil_stx (op, pd, &gop, 8, false);
 			break;
 		case PPC_INS_LDBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -1620,8 +1762,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_LHA:
 		case PPC_INS_LHAU:
-		case PPC_INS_LHAUX:
-		case PPC_INS_LHAX:
 		case PPC_INS_LHZ:
 		case PPC_INS_LHZU:
 			op->type = R_ANAL_OP_TYPE_LOAD;
@@ -1629,8 +1769,10 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			if (!op1) {
 				break;
 			}
-			esilprintf (op, "%s,[2],%s,=,%s=", op1, ARG (0), op1);
-			/* PPC64 ELFv1 TOC chain: lha/lhz rY, LO(rX) following addis rX, r2, HA */
+			// algebraic (sign-extend 16); only *u forms update rA
+			ppc_esil_ld (op, op1, ARG (0), 2,
+				insn->id == PPC_INS_LHAU || insn->id == PPC_INS_LHZU,
+				(insn->id == PPC_INS_LHA || insn->id == PPC_INS_LHAU)? 16: 0);
 			if (INSOP(1).type == PPC_OP_MEM) {
 				ridx = toc_reg_idx (INSOP(1).mem.base);
 				if (ridx >= 0 && pd->toc_map[ridx]) {
@@ -1638,23 +1780,24 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				}
 			}
 			break;
-		case PPC_INS_LHZX:
-			op->type = R_ANAL_OP_TYPE_LOAD;
-			esilprintf (op, "%s,%s,=", ARG2 (1, "[2]"), ARG (0));
-			break;
 		case PPC_INS_LHBRX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			ppc_esil_brx (op, pd, &gop, 2, false);
 			break;
 		case PPC_INS_LWA:
-		case PPC_INS_LWARX:
-		case PPC_INS_LWAUX:
-		case PPC_INS_LWAX:
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			esilprintf (op, "32,%s,~,%s,=", ARG2 (1, "[4]"), ARG (0));
+			if (INSOP(1).type == PPC_OP_MEM) {
+				ridx = toc_reg_idx (INSOP(1).mem.base);
+				if (ridx >= 0 && pd->toc_map[ridx]) {
+					op->ptr = pd->toc_map[ridx] + INSOP(1).mem.disp;
+				}
+			}
+			break;
 		case PPC_INS_LWZ:
 #if CS_API_MAJOR >= 4
 		case PPC_INS_LWZCIX:
 #endif
-		case PPC_INS_LWZX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			esilprintf (op, "%s,%s,=", ARG2 (1, "[4]"), ARG (0));
 			/* PPC64 ELFv1 TOC chain: lwz rY, LO(rX) following addis rX, r2, HA */
@@ -1666,7 +1809,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_LWZU:
-		case PPC_INS_LWZUX:
 			op->type = R_ANAL_OP_TYPE_LOAD;
 			op1 = shrink(ARG(1));
 			if (!op1) {
@@ -1687,17 +1829,25 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_SLW:
 		case PPC_INS_SLWI:
+			op->type = R_ANAL_OP_TYPE_SHL;
+			esilprintf (op, "%s,0x3f,&,%s,<<,0xffffffff,&,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
 		case PPC_INS_SLD:
 		case PPC_INS_SLDI:
 			op->type = R_ANAL_OP_TYPE_SHL;
-			esilprintf (op, "%s,%s,<<,%s,=", ARG (2), ARG (1), ARG (0));
+			// rB[57:63] shift count; >= 64 yields 0
+			esilprintf (op, "%s,0x40,&,!,%s,0x3f,&,%s,<<,*,%s,=", ARG (2), ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_SRW:
 		case PPC_INS_SRWI:
+			op->type = R_ANAL_OP_TYPE_SHR;
+			esilprintf (op, "%s,0x3f,&,%s,0xffffffff,&,>>,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
 		case PPC_INS_SRD:
 		// case PPC_INS_SRDI: // not available in some capstone versions
 			op->type = R_ANAL_OP_TYPE_SHR;
-			esilprintf (op, "%s,%s,>>,%s,=", ARG (2), ARG (1), ARG (0));
+			// rB[57:63] shift count; >= 64 yields 0
+			esilprintf (op, "%s,0x40,&,!,%s,0x3f,&,%s,>>,*,%s,=", ARG (2), ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_SRAW:
 		case PPC_INS_SRAWI:
@@ -2162,15 +2312,22 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			esilprintf (op, "16,%s,<<,%s,^,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_DIVD:
+			op->sign = true;
+			op->type = R_ANAL_OP_TYPE_DIV;
+			esilprintf (op, "%s,%s,~/,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
 		case PPC_INS_DIVW:
 			op->sign = true;
 			op->type = R_ANAL_OP_TYPE_DIV;
-			esilprintf (op, "%s,%s,/,%s,=", ARG (2), ARG (1), ARG (0));
+			esilprintf (op, "32,%s,~,32,%s,~,~/,0xffffffff,&,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_DIVDU:
-		case PPC_INS_DIVWU:
 			op->type = R_ANAL_OP_TYPE_DIV;
 			esilprintf (op, "%s,%s,/,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_DIVWU:
+			op->type = R_ANAL_OP_TYPE_DIV;
+			esilprintf (op, "%s,0xffffffff,&,%s,0xffffffff,&,/,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 #if CS_API_MAJOR > 4
 		case PPC_INS_DIVDE:
@@ -2299,16 +2456,19 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_ROL;
 			esilprintf (op, "%s,%s,ROL,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
-		case PPC_INS_ROTLW:
-		case PPC_INS_ROTLWI:
 		case PPC_INS_ROTLD:
 			op->type = R_ANAL_OP_TYPE_ROL;
 			esilprintf (op, "%s,%s,ROL,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
+		case PPC_INS_ROTLW:
+		case PPC_INS_ROTLWI:
+			op->type = R_ANAL_OP_TYPE_ROL;
+			ppc_esil_rlwnm (op, pd, &gop, "0xffffffff", false);
+			break;
 		case PPC_INS_RLWNM:
 			op->type = R_ANAL_OP_TYPE_ROL;
 			if (ARG (3)[0] && ARG (4)[0]) {
-				esilprintf (op, "%s,%s,ROL,%s,&,%s,=", ARG (2), ARG (1), cmask32 (cmaskbuf, ARG (3), ARG (4)), ARG (0));
+				ppc_esil_rlwnm (op, pd, &gop, cmask32 (cmaskbuf, ARG (3), ARG (4)), getarg (&gop, 3) > getarg (&gop, 4));
 			}
 			break;
 		case PPC_INS_RLWIMI:

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1025,11 +1025,11 @@ EOF
 EXPECT=<<EOF
 mnemonic: sld
 type: shl
-esil: r10,r9,<<,r9,=
+esil: r10,0x40,&,!,r10,0x3f,&,r9,<<,*,r9,=
 --
 mnemonic: srd
 type: shr
-esil: r28,r9,>>,r9,=
+esil: r28,0x40,&,!,r28,0x3f,&,r9,>>,*,r9,=
 --
 mnemonic: sradi
 type: sar
@@ -1043,19 +1043,19 @@ type: mov
 --
 mnemonic: stbx
 type: store
-esil: r7,r30=[1]
+esil: r7,r30,r10,+,=[1]
 --
 mnemonic: sthx
 type: store
-esil: r9,r30=[2]
+esil: r9,r30,r8,+,=[2]
 --
 mnemonic: stdx
 type: store
-esil: r30,r10=[8]
+esil: r30,r10,r9,+,=[8]
 --
 mnemonic: lhzx
 type: load
-esil: r8[2],r10,=
+esil: r8,r10,+,[2],r10,=
 --
 mnemonic: mfcr
 type: mov

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -441,7 +441,7 @@ e cfg.bigendian=true
 EOF
 EXPECT=<<EOF
 rotlw r3, r4, r5
-0x00000000 r5,r4,ROL,r3,=
+0x00000000 r5,0x1f,&,r4,<<,r5,0x1f,&,32,-,r4,0xffffffff,&,>>,|,0xffffffff,&,0xffffffff,&,r3,=
 EOF
 RUN
 
@@ -456,7 +456,7 @@ e cfg.bigendian=true
 EOF
 EXPECT=<<EOF
 rlwnm r3, r4, r5, 0x10, 0x1e
-0x00000000 r5,r4,ROL,0xfffe,&,r3,=
+0x00000000 r5,0x1f,&,r4,<<,r5,0x1f,&,32,-,r4,0xffffffff,&,>>,|,0xffffffff,&,0xfffe,&,r3,=
 EOF
 RUN
 

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -956,3 +956,753 @@ EXPECT=<<EOF
 0x55667788
 EOF
 RUN
+
+NAME=lwzx indexed load uses both base and index registers ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c85302e @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x11223344
+EOF2
+RUN
+
+NAME=lwzx esil string adds index register ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c85302e @ 0
+aoj 1 @ 0~{[0].esil}
+EOF2
+EXPECT=<<EOF2
+r5,r6,+,[4],r4,=
+EOF2
+RUN
+
+NAME=ldx indexed load full doubleword ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c85302a @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x1122334455667788
+EOF2
+RUN
+
+NAME=lhzux indexed load with update writes back effective address ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c85326e @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+aes
+ar r4
+ar r5
+EOF2
+EXPECT=<<EOF2
+0x00001122
+0x00000108
+EOF2
+RUN
+
+NAME=stwx indexed store uses both base and index registers ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c85312e @ 0
+aei
+aeim
+ar r4=0xaabbccddeeff0011
+ar r5=0x100
+ar r6=8
+aes
+pv4 @ 0x108
+EOF2
+EXPECT=<<EOF2
+0xeeff0011
+EOF2
+RUN
+
+NAME=stbux indexed store with update writes byte and updates base ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c8531ee @ 0
+aei
+aeim
+ar r4=0xaabbccddeeff0011
+ar r5=0x100
+ar r6=8
+aes
+pv1 @ 0x108
+ar r5
+EOF2
+EXPECT=<<EOF2
+0x11
+0x00000108
+EOF2
+RUN
+
+NAME=slw word shift left zero-extends to 32 bits ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43030 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xffffff00
+EOF2
+RUN
+
+NAME=srw word shift right is 32-bit logical ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43430 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x0fffffff
+EOF2
+RUN
+
+NAME=rlwinm rotates the low 32 bits not the full register ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 54a4183e @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xffffff87
+EOF2
+RUN
+
+NAME=divw is a 32-bit signed divide ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c8533d6 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar r6=7
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xfffffffe
+EOF2
+RUN
+
+NAME=divwu is a 32-bit unsigned divide ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c853396 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar r6=7
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x24924922
+EOF2
+RUN
+
+NAME=divd is a 64-bit signed divide ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c8533d2 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+ar r6=7
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xfffffffffffffffe
+EOF2
+RUN
+
+NAME=lbzx byte indexed load ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c8530ae @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x00000011
+EOF2
+RUN
+
+NAME=ldux doubleword indexed load with update ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c85306a @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+ar r5
+EOF2
+EXPECT=<<EOF2
+0x1122334455667788
+0x00000108
+EOF2
+RUN
+
+NAME=stdux doubleword indexed store with update ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c85316a @ 0
+aei
+aeim
+ar r4=0xaabbccddeeff0011
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+pv8 @ 0x108
+ar r5
+EOF2
+EXPECT=<<EOF2
+0xaabbccddeeff0011
+0x00000108
+EOF2
+RUN
+
+NAME=lwax algebraic indexed load uses both base and index ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c8532aa @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x11223344
+EOF2
+RUN
+
+NAME=sld doubleword shift left is 64-bit ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43036 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x00000030
+EOF2
+RUN
+
+NAME=srd doubleword shift right is 64-bit logical ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43436 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x800000000000000
+EOF2
+RUN
+
+NAME=rotld doubleword rotate left is 64-bit ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 78a43010 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x00000038
+EOF2
+RUN
+
+NAME=divdu is a 64-bit unsigned divide ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c853392 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=4
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x2000000000000000
+EOF2
+RUN
+
+NAME=lhax algebraic indexed load sign-extends ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 8001800280038004 @ 0x108
+wx 7c8532ae @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xffffffffffff8001
+EOF2
+RUN
+
+NAME=lwax algebraic indexed load sign-extends 32 bits ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 8001800280038004 @ 0x108
+wx 7c8532aa @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xffffffff80018002
+EOF2
+RUN
+
+NAME=lha D-form load halfword algebraic sign-extends without writeback ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 8001800280038004 @ 0x110
+wx a8850010 @ 0
+aei
+aeim
+ar r5=0x100
+ar pc=0
+s 0
+aes
+ar r4
+ar r5
+EOF2
+EXPECT=<<EOF2
+0xffffffffffff8001
+0x00000100
+EOF2
+RUN
+
+NAME=lwa D-form load word algebraic sign-extends ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 8001800280038004 @ 0x110
+wx e8850012 @ 0
+aei
+aeim
+ar r5=0x100
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0xffffffff80018002
+EOF2
+RUN
+
+NAME=lhz D-form non-update load does not write back the base register ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 8001800280038004 @ 0x110
+wx a0850010 @ 0
+aei
+aeim
+ar r5=0x100
+ar pc=0
+s 0
+aes
+ar r4
+ar r5
+EOF2
+EXPECT=<<EOF2
+0x00008001
+0x00000100
+EOF2
+RUN
+
+NAME=lwarx load word and reserve uses both base and index registers ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c853028 @ 0
+aoj 1 @ 0~{[0].esil}
+EOF2
+EXPECT=<<EOF2
+r5,r6,+,[4],r4,=
+EOF2
+RUN
+
+NAME=lwarx load word and reserve indexed execution ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c853028 @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x11223344
+EOF2
+RUN
+
+NAME=ldarx load doubleword and reserve indexed execution ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 1122334455667788 @ 0x108
+wx 7c8530a8 @ 0
+aei
+aeim
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x1122334455667788
+EOF2
+RUN
+
+NAME=stwcx store word conditional uses both base and index registers ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c85312d @ 0
+aoj 1 @ 0~{[0].esil}
+EOF2
+EXPECT=<<EOF2
+r4,r5,r6,+,=[4]
+EOF2
+RUN
+
+NAME=stwcx store word conditional indexed execution ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c85312d @ 0
+aei
+aeim
+ar r4=0xaabbccddeeff0011
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+pv4 @ 0x108
+EOF2
+EXPECT=<<EOF2
+0xeeff0011
+EOF2
+RUN
+
+NAME=stdcx store doubleword conditional indexed execution ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c8531ad @ 0
+aei
+aeim
+ar r4=0xaabbccddeeff0011
+ar r5=0x100
+ar r6=8
+ar pc=0
+s 0
+aes
+pv8 @ 0x108
+EOF2
+EXPECT=<<EOF2
+0xaabbccddeeff0011
+EOF2
+RUN
+
+NAME=sld doubleword shift left of count >= 64 yields zero ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43036 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=65
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x00000000
+EOF2
+RUN
+
+NAME=sld doubleword shift left count uses low 7 bits ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43036 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=128
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x8000000000000003
+EOF2
+RUN
+
+NAME=srd doubleword shift right of count >= 64 yields zero ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7ca43436 @ 0
+aei
+aeim
+ar r5=0x8000000000000003
+ar r6=64
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x00000000
+EOF2
+RUN
+
+NAME=rlwinm wrapping mask fills the high word with the rotated value ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 54a42706 @ 0
+aei
+aeim
+ar r5=0x12345678
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x2345678120000001
+EOF2
+RUN
+
+NAME=rlwnm wrapping mask fills the high word with the rotated value ppc-64
+FILE=malloc://0x200
+CMDS=<<EOF2
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 5ca43706 @ 0
+aei
+aeim
+ar r5=0x12345678
+ar r6=8
+ar pc=0
+s 0
+aes
+ar r4
+EOF2
+EXPECT=<<EOF2
+0x3456781230000002
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Corrects and completes ESIL for several PPC instruction families.

 - **Indexed (X-form) load/store** (`lbzx`/`lhzx`/`lwzx`/`ldx`, algebraic `lhax`/`lwax`, all `*ux` update forms, `stbx`..`stdx`/`*ux`): now compute EA = rA + rB instead of ignoring the index register. Also adds the previously-unhandled `stbux`/`sthux`/`stdux`.
 - **Load-and-reserve / store-conditional** (`lwarx`/`ldarx`/`stwcx.`/`stdcx.`): were mis-grouped with D-form ops (ignored rB; `ldarx` corrupted the reg name). Now use the indexed EA.
 - **Algebraic loads** (`lha`/`lwa`/`lhax`/`lwax`/`lhaux`/`lwaux`): sign-extend correctly; non-update forms no longer write back the base register.
- **32-bit shifts** (`slw`/`srw`): mask to 32 bits with the 6-bit count field.
- **64-bit shifts** (`sld`/`srd`): honour the 7-bit count field (count >= 64 yields 0).
- **32-bit rotate** (`rlwinm`/`rlwnm`/`rotlw`/`rotlwi`): use a real 32-bit rotate (ESIL ROL is 64-bit), including wrapping masks (MB > ME).
 - **Divide** (`divw`/`divd` signed, `divw`/`divwu` proper 32-bit width).

### Known gaps (pre-existing, out of scope)
- `subfe` emits no ESIL (needs XER.CA carry modelling).
- `stwcx.`/`stdcx.` model the memory store only — the reservation and CR0 result are not represented.
- Byte/halfword reserve variants `lbarx`/`lharx`/`stbcx.`/`sthcx.` remain unhandled.

