### PR TITLE
Fix GDB register cache bounds and ownership checks

### DIFF
--- a/shlr/gdb/src/gdbclient/core.c
+++ b/shlr/gdb/src/gdbclient/core.c
@@ -75,6 +75,7 @@ static struct {
 	ut8 *buf;
 	ut64 buflen, maxlen;
 	bool valid, init;
+	libgdbr_t *owner;
 } reg_cache;
 
 static bool reg_cache_ensure_size(size_t len) {
@@ -98,6 +99,7 @@ static void reg_cache_fini(void) {
 	reg_cache.maxlen = 0;
 	reg_cache.valid = false;
 	reg_cache.init = false;
+	reg_cache.owner = NULL;
 }
 
 static void reg_cache_update(libgdbr_t *g) {
@@ -112,12 +114,14 @@ static void reg_cache_update(libgdbr_t *g) {
 	memcpy (reg_cache.buf, g->data, len);
 	reg_cache.buflen = (ut64)len;
 	reg_cache.valid = true;
+	reg_cache.owner = g;
 }
 
 static void reg_cache_init(libgdbr_t *g) {
 	reg_cache.buflen = 0;
 	reg_cache.valid = false;
 	reg_cache.init = false;
+	reg_cache.owner = NULL;
 	if (g && g->data_max > 0) {
 		reg_cache_ensure_size ((size_t)g->data_max);
 	}
@@ -722,7 +726,7 @@ int gdbr_read_registers(libgdbr_t *g) {
 	if (!g || !g->data) {
 		return -1;
 	}
-	if (reg_cache.init && reg_cache.valid) {
+	if (reg_cache.init && reg_cache.valid && reg_cache.owner == g && reg_cache.buflen <= g->data_max) {
 		g->data_len = reg_cache.buflen;
 		memcpy (g->data, reg_cache.buf, reg_cache.buflen);
 		return 0;


### PR DESCRIPTION
### Motivation
- The process-wide GDB register cache could be resized and populated from one `libgdbr_t` session and later be copied into another session's smaller `g->data` buffer, enabling a heap overflow from a malicious remote GDB server. 
- The intent of this change is to prevent cross-session reuse of the global cache and to ensure cached payloads are only memcpy()'d when the destination instance can safely hold them.

### Description
- Add an `owner` pointer to the file-static `reg_cache` so the cache can be associated with the `libgdbr_t` instance that populated it. 
- Set `reg_cache.owner = g` when updating the cache and clear `owner` in cache init/fini paths. 
- Harden the fast-path in `gdbr_read_registers()` to only reuse the cache if `reg_cache.owner == g` and `reg_cache.buflen <= g->data_max` before performing `memcpy()`. 
- These changes keep behaviour identical for single-session use while preventing unsafe cross-session copies.

### Testing
- Attempted to build the GDB client component with `make -C shlr/gdb -j`, which failed in this environment due to missing build infrastructure files (`../../mk/.mk`), so no successful local binary build or unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14821dc77c8331b551fc54a2b04631)