### PR TITLE
Apply the pseudo filter only once in the disasm pipeline ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -1275,6 +1275,14 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 		// asmop works, analop fails hard
 		ds->opstr = strdup (r_str_get (ds->asmop.mnemonic));
 	}
+	if (ds->pseudo) {
+		// applied before any substitution: subvar and flag names must land on pseudo output
+		char *res = r_asm_parse_pseudo (core->rasm, ds->opstr);
+		if (res) {
+			free (ds->opstr);
+			ds->opstr = res;
+		}
+	}
 	/* initialize */
 	core->rasm->parse->subrel = r_config_get_b (core->config, "asm.sub.rel");
 	core->rasm->parse->subreg = r_config_get_b (core->config, "asm.sub.reg");
@@ -1349,13 +1357,6 @@ static void ds_build_op_str(RDisasmState *ds, bool print_color) {
 				ut64 killme = UT64_MAX;
 				r_io_read_i (core->io, ds->analop.ptr, &killme, ds->analop.refptr, be);
 				core->rasm->parse->subrel_addr = killme;
-			}
-		}
-		if (ds->pseudo) {
-			char *res = r_asm_parse_pseudo (core->rasm, ds->opstr);
-			if (res) {
-				free (ds->opstr);
-				ds->opstr = res;
 			}
 		}
 		bool isjmp = false;
@@ -3129,7 +3130,11 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 		}
 	}
 	r_anal_op_fini (&ds->asmop);
+	// keep the mnemonic raw; ds_build_op_str applies the pseudo filter once
+	const bool opseudo = core->rasm->pseudo;
+	core->rasm->pseudo = false;
 	ret = r_asm_disassemble (core->rasm, &ds->asmop, buf, len);
+	core->rasm->pseudo = opseudo;
 	if (len > ds->asmop.size) {
 		len = ds->asmop.size;
 	}
@@ -3270,14 +3275,6 @@ static int ds_disassemble(RDisasmState *ds, ut8 *buf, int len) {
 		}
 	}
 	ds->oplen = ds->asmop.size;
-	if (ds->pseudo) {
-		const char *str = ds->opstr ? ds->opstr : ds->asmop.mnemonic;
-		char *res = r_asm_parse_pseudo (core->rasm, str);
-		if (res) {
-			free (ds->opstr);
-			ds->opstr = strdup (res);
-		}
-	}
 	if (ds->acase) {
 		r_str_case (ds->asmop.mnemonic, 1);
 	} else if (ds->capitalize) {
@@ -7202,9 +7199,8 @@ toro:
 			ds_print_demangled (ds);
 			ds_print_pins (ds);
 			ds_print_color_reset (ds);
-			if (!ds->pseudo) {
-				R_FREE (ds->opstr);
-			}
+			// drop the built opstr so the next ds_build_op_str starts from the raw mnemonic
+			R_FREE (ds->opstr);
 			if (ds->show_emu) {
 				ds_print_esil_anal (ds);
 			}

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -281,3 +281,28 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=pdc ppc64 conditional branch predicate
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 2c2300004182000c386000014e800020386000004e800020
+af
+pdc
+EOF
+EXPECT=<<EOF
+// callconv: r3 ppc-64 (r3, r4, r5, r6, r7, r8, r9, r10, stack_rev);
+void fcn.00000000 (int64_t arg1) {
+        cr0 = (r3 == 0) // arg1
+        if (cr0 & FLG_EQ) goto 0x10 // likely
+        return r3;
+    loc_0x00000010:
+        r3 = 0
+        return
+}
+
+EOF
+RUN
+

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -1,0 +1,57 @@
+NAME=PPC64 pseudo compare and conditional branch
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+e asm.pseudo=true
+wx 2c290000418202083d001000556a063e
+pd 4
+pi 4
+EOF
+EXPECT=<<EOF
+            0x00000000      2c290000       cr0 = (r9 == 0)
+        ,=< 0x00000004      41820208       if (cr0 & FLG_EQ) goto 0x20c
+        |   0x00000008      3d001000       r8 = (0x1000 << 16)
+        |   0x0000000c      556a063e       r10 = r11 & mask(0, 0x18)
+cr0 = (r9 == 0)
+if (cr0 & FLG_EQ) goto 0x20c
+r8 = (0x1000 << 16)
+r10 = r11 & mask(0, 0x18)
+EOF
+RUN
+
+NAME=PPC64 pseudo with asm.sub.names disabled
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+e asm.pseudo=true
+e asm.sub.names=false
+wx 2c29000041820208
+pd 2
+EOF
+EXPECT=<<EOF
+            0x00000000      2c290000       cr0 = (r9 == 0)
+        ,=< 0x00000004      41820208       if (cr0 & FLG_EQ) goto 0x20c
+EOF
+RUN
+
+NAME=PPC64 pseudo with comments printed on their own line
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+e asm.pseudo=true
+e asm.cmt.right=false
+wx 2c29000041820208
+pd 2
+EOF
+EXPECT=<<EOF
+            0x00000000      2c290000       cr0 = (r9 == 0)
+        ,=< 0x00000004      41820208       if (cr0 & FLG_EQ) goto 0x20c
+EOF
+RUN
+


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With `asm.pseudo=true` the `pd`/`pdf`/`pdc` path applied the arch pseudo filter up to three times per instruction (asm layer, `ds_disassemble`, `ds_build_op_str`). x86 hides this because its parse is idempotent, but ppc/arm parses corrupt their own output on re-application, destroying every branch predicate and compare:

    pd 2 @ cmp+beq (ppc64)        # before          # after
    cr0 = , r9 == 0               →  cr0 = (r9 == 0)
    if                            →  if (cr0 & FLG_EQ) goto 0x9040

`pi` was unaffected (it already applied the filter once), so `pd` now matches `pi`.

Changes in `libr/core/disasm.c` only:
- `ds_build_op_str` applies pseudo once, before subvar/flag substitution (those match the pseudo'd text), and no longer gated on `asm.sub.names`
- `ds_disassemble` keeps the mnemonic raw (same `rasm->pseudo` suppression the json printer uses) — also removes a per-instruction leak of the parsed string
- the comments-above path frees the built opstr so the second build starts from raw

On `pdc` for a ppc64 function this restores all branch predicates (115/115 ifs with conditions vs 0/115 before). New tests in `db/cmd/cmd_pseudo_ppc` and `db/cmd/cmd_pdc` fail before this change and pass after.