### PR TITLE
Apply the pseudo filter only once in rasm2 and pad ##asm

### DIFF
--- a/libr/asm/asm.c
+++ b/libr/asm/asm.c
@@ -741,15 +741,8 @@ R_API RAsmCode *r_asm_mdisassemble(RAsm *a, const ut8 *buf, int len) {
 		r_anal_op_init (&op);
 		r_asm_set_pc (a, pc + idx);
 		// we can change this to return RAnalOp* instead of passing it as arg here
-		ret = r_asm_disassemble_do (a, &op, buf + idx, len - idx);
+		r_asm_disassemble_do (a, &op, buf + idx, len - idx);
 		ret = (op.size > 0)? op.size: mininstrsize;
-		if (a->pseudo) {
-			char *newtext = r_asm_parse_pseudo (a, op.mnemonic);
-			if (newtext) {
-				free (op.mnemonic);
-				op.mnemonic = newtext;
-			}
-		}
 		if (op.mnemonic) {
 			r_strbuf_append (sb, op.mnemonic);
 			r_strbuf_append (sb, "\n");
@@ -772,7 +765,7 @@ R_API RAsmCode *r_asm_mdisassemble_hexstr(RAsm *a, RParse *p, const char *hexstr
 		return NULL;
 	}
 	RAsmCode *ret = r_asm_mdisassemble (a, buf, (ut64)len);
-	if (ret && p) {
+	if (ret && p && !a->pseudo) {
 		char *res = r_asm_parse_pseudo (a, ret->assembly);
 		if (res) {
 			free (ret->assembly);

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -55,3 +55,32 @@ EXPECT=<<EOF
 EOF
 RUN
 
+
+NAME=PPC64 pad applies the pseudo filter once
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+e asm.pseudo=true
+pad 2c29000041820208
+EOF
+EXPECT=<<EOF
+cr0 = (r9 == 0)
+if (cr0 & FLG_EQ) goto 0x20c
+EOF
+RUN
+
+NAME=PPC64 pad without pseudo is unfiltered
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+pad 2c29000041820208
+EOF
+EXPECT=<<EOF
+cmpdi r9, 0
+beq 0x20c
+EOF
+RUN

--- a/test/db/tools/rasm2
+++ b/test/db/tools/rasm2
@@ -1007,3 +1007,28 @@ EXPECT=<<EOF
 4c89f8
 EOF
 RUN
+
+NAME=rasm2 -d ppc pseudo applied once
+FILE=-
+CMDS=!rasm2 -a ppc -b 64 -e -F ppc.pseudo -d 2c29000041820208
+EXPECT=<<EOF
+cr0 = (r9 == 0)
+if (cr0 & FLG_EQ) goto 0x20c
+EOF
+RUN
+
+NAME=rasm2 -D ppc pseudo applied once
+FILE=-
+CMDS=!rasm2 -a ppc -b 64 -e -F ppc.pseudo -D 2c290000
+EXPECT=<<EOF
+0x00000000   4                 2c290000  cr0 = (r9 == 0)
+EOF
+RUN
+
+NAME=rasm2 -d arm64 pseudo branch applied once
+FILE=-
+CMDS=!rasm2 -a arm -b 64 -F arm.pseudo -d 800000b4
+EXPECT=<<EOF
+if (!x0) goto 0x10
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Counterpart of the earlier disasm-pipeline fix: `libr/asm/asm.c` still re-applied the arch pseudo filter on already-translated text, which mangles output on arches whose pseudo parser is not idempotent (ppc, arm):

    rasm2 -a ppc -b 64 -e -F ppc.pseudo -d 2c29000041820208
    before: cr0 = , r9 == 0          after: cr0 = (r9 == 0)
            if                              if (cr0 & FLG_EQ) goto 0x20c

`r_asm_disassemble_do` now owns the single application: the re-apply in the `r_asm_mdisassemble` loop is removed (double for `rasm2 -d`), and `r_asm_mdisassemble_hexstr` skips its extra pass when `a->pseudo` already did the work (`pad` with `asm.pseudo` was applying it three times). No API change.

Also, 5 new tests: rasm2 -d/-D ppc, rasm2 -d arm64, pad with/without asm.pseudo