### PR TITLE
Implement Windows block-device detection ##io

### DIFF
--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -4,6 +4,10 @@
 #include <r_lib.h>
 #include "../io_memory.h"
 
+#if R2__WINDOWS__
+#include <io.h>
+#endif
+
 #if R2__UNIX__ && !__wasi__
 #define HAVE_FIFO 1
 #else
@@ -38,8 +42,23 @@ static bool check_for_blockdevice(RIOMMapFileObj *mmo) {
 		}
 	}
 	return mmo->isblk == 1;
-#endif
+#elif R2__WINDOWS__
+	R_RETURN_VAL_IF_FAIL (mmo, false);
+	if (mmo->isblk == -1) {
+		mmo->isblk = 0;
+		if (mmo->fd != -1) {
+			HANDLE h = (HANDLE)_get_osfhandle (mmo->fd);
+			if (h != INVALID_HANDLE_VALUE) {
+				mmo->isblk = (GetFileType (h) == FILE_TYPE_CHAR)? 1: 0;
+			}
+		}
+	}
+	return mmo->isblk == 1;
+#else
+	R_RETURN_VAL_IF_FAIL (mmo, false);
+	mmo->isblk = 0;
 	return false;
+#endif
 }
 
 #if HAVE_FIFO
@@ -139,7 +158,7 @@ static ut64 mmap_seek(RIO *io, RIOMMapFileObj *mmo, ut64 offset, int whence) {
 			if (mmo->isblk == -1) {
 				check_for_blockdevice (mmo);
 			}
-			if (mmo->isblk) {
+			if (mmo->isblk == 1) {
 				return UT64_MAX - 1;
 			}
 		}

--- a/libr/io/p/io_default.c
+++ b/libr/io/p/io_default.c
@@ -31,34 +31,27 @@ typedef struct r_io_mmo_t {
 } RIOMMapFileObj;
 
 static bool check_for_blockdevice(RIOMMapFileObj *mmo) {
-#if R2__UNIX__
-	R_RETURN_VAL_IF_FAIL (mmo, false);
-	if (mmo->isblk == -1) {
-		struct stat buf;
-		if (fstat (mmo->fd, &buf) == -1) {
-			mmo->isblk = 0;
-		} else {
-			mmo->isblk = ((buf.st_mode & S_IFBLK) == S_IFBLK)? 1: 0;
-		}
-	}
-	return mmo->isblk == 1;
-#elif R2__WINDOWS__
 	R_RETURN_VAL_IF_FAIL (mmo, false);
 	if (mmo->isblk == -1) {
 		mmo->isblk = 0;
+#if R2__UNIX__
+		struct stat buf;
+		if (fstat (mmo->fd, &buf) != -1) {
+			mmo->isblk = ((buf.st_mode & S_IFBLK) == S_IFBLK)? 1: 0;
+		}
+#elif R2__WINDOWS__
+		// GetFileType reports FILE_TYPE_CHAR for console, serial and pipe
+		// handles: like a block device, their size can't be obtained by
+		// seeking, so flag them here to avoid a bogus SEEK_END size.
 		if (mmo->fd != -1) {
 			HANDLE h = (HANDLE)_get_osfhandle (mmo->fd);
 			if (h != INVALID_HANDLE_VALUE) {
 				mmo->isblk = (GetFileType (h) == FILE_TYPE_CHAR)? 1: 0;
 			}
 		}
+#endif
 	}
 	return mmo->isblk == 1;
-#else
-	R_RETURN_VAL_IF_FAIL (mmo, false);
-	mmo->isblk = 0;
-	return false;
-#endif
 }
 
 #if HAVE_FIFO
@@ -487,7 +480,7 @@ RIOPlugin r_io_plugin_default = {
 	.seek = __lseek,
 	.write = __write,
 	.resize = __resize,
-#if R2__UNIX__
+#if R2__UNIX__ || R2__WINDOWS__
 	.is_blockdevice = __is_blockdevice,
 #endif
 };


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

By default on windows each file was treated as a block device and `$s` was returning `0xfffffffffffffffe` (U64T_MAX - 1) instead of the actual size.