### PR TITLE
Tighten GNS1 detection to avoid dyldcache false positives ##bin

### DIFF
--- a/dist/plugins-cfg/plugins.cs4.cfg
+++ b/dist/plugins-cfg/plugins.cs4.cfg
@@ -145,6 +145,7 @@ bin.z64
 bin.zimg
 bin_ldr.ldr_linux
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_xtr.xtr_pemixed
 bin_xtr.xtr_xalz
 bp.arm

--- a/dist/plugins-cfg/plugins.cs6.cfg
+++ b/dist/plugins-cfg/plugins.cs6.cfg
@@ -133,6 +133,7 @@ bin.z64
 bin.zimg
 bin_ldr.ldr_linux
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_xtr.xtr_pemixed
 bin_xtr.xtr_xalz
 bp.arm

--- a/dist/plugins-cfg/plugins.def.cfg
+++ b/dist/plugins-cfg/plugins.def.cfg
@@ -176,6 +176,7 @@ bin.z64
 bin.zimg
 bin_ldr.ldr_linux
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_xtr.xtr_pemixed
 bin_xtr.xtr_xalz
 bp.null

--- a/dist/plugins-cfg/plugins.sdk.cfg
+++ b/dist/plugins-cfg/plugins.sdk.cfg
@@ -170,6 +170,7 @@ bin.z64
 bin.zimg
 bin_ldr.ldr_linux
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_xtr.xtr_pemixed
 bin_xtr.xtr_xalz
 bp.null

--- a/dist/plugins-cfg/plugins.static.cfg
+++ b/dist/plugins-cfg/plugins.static.cfg
@@ -101,6 +101,7 @@ bin.dyldcache
 bin.xcoff64
 bin.xnu_kernelcache
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_ldr.ldr_linux
 bin.zimg
 bin.psxexe

--- a/dist/plugins-cfg/plugins.uefi.cfg
+++ b/dist/plugins-cfg/plugins.uefi.cfg
@@ -108,6 +108,7 @@ bin.z64
 bin.zimg
 bin_ldr.ldr_linux
 bin_xtr.xtr_dyldcache
+bin_xtr.xtr_ftab
 bin_xtr.xtr_pemixed
 bin_xtr.xtr_xalz
 bp.null

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -80,6 +80,7 @@ r_bin_sources = [
   'p/bin_xcoff64.c',
   'p/bin_xnu_kernelcache.c',
   'p/bin_xtr_dyldcache.c',
+  'p/bin_xtr_ftab.c',
   'p/bin_xtr_pemixed.c',
   'p/bin_xtr_xalz.c',
   'p/bin_z64.c',

--- a/libr/bin/p/Makefile
+++ b/libr/bin/p/Makefile
@@ -24,7 +24,7 @@ FORMATS+=omf.mk cgc.mk dol.mk rel.mk nes.mk mbn.mk psxexe.mk
 FORMATS+=vsf.mk nin3ds.mk bflt.mk wasm.mk sfc.mk uf2.mk
 FORMATS+=mdmp.mk z64.mk qnx.mk prg.mk dmp64.mk xtac.mk pef.mk mdt.mk som.mk
 
-FORMATS+=xtr_dyldcache.mk
+FORMATS+=xtr_dyldcache.mk xtr_ftab.mk
 
 include $(FORMATS)
 

--- a/libr/bin/p/bin_gns1.c
+++ b/libr/bin/p/bin_gns1.c
@@ -5,8 +5,15 @@
 
 #define GNS1_SEGMENT_ENTRY_SIZE 12
 #define GNS1_MIN_FILE_SIZE 64
+#define GNS1_FTAB_HEADER_SIZE 0x30
+#define GNS1_FTAB_MAGIC_OFFSET 0x20
+#define GNS1_FTAB_ENTRY_COUNT_OFFSET 0x28
+#define GNS1_FTAB_ENTRY_OFFSET 0x30
+#define GNS1_FTAB_ENTRY_SIZE 16
+#define GNS1_FTAB_MAX_ENTRIES 4096
 #define GNS1_REGION1_BASE 0x12000000
 #define GNS1_REGION2_BASE 0x15000000
+#define GNS1_REGION2_END 0x16000000
 #define GNS1_INTERNAL_BASE 0x10000000
 #define GNS1_ADDRMASK 0xFFFFFF
 #define GNS1_MAX_VALID_SEGMENTS 1000
@@ -30,17 +37,31 @@ typedef struct gns1_segment_entry {
 	Gns1Region region;
 } Gns1SegmentEntry;
 
+typedef struct gns1_ftab_entry {
+	char tag[5];
+	ut32 offset;
+	ut32 size;
+	ut32 zero;
+} Gns1FtabEntry;
+
 R_VEC_TYPE(RVecGns1Segment, Gns1SegmentEntry);
+R_VEC_TYPE(RVecGns1FtabEntry, Gns1FtabEntry);
 
 typedef struct gns1_obj {
 	RVecGns1Segment segments;
+	RVecGns1FtabEntry ftab_entries;
+	ut64 base_offset;
+	ut64 image_size;
+	ut64 table_size;
+	ut32 n_ftab_entries;
+	bool is_ftab;
 } Gns1Obj;
 
 static inline ut32 region_type(ut32 pa) {
 	if (pa >= GNS1_REGION1_BASE && pa < GNS1_REGION2_BASE) {
 		return GNS1_REGION_A;
 	}
-	if (pa >= GNS1_REGION2_BASE) {
+	if (pa >= GNS1_REGION2_BASE && pa < GNS1_REGION2_END) {
 		return GNS1_REGION_B;
 	}
 	return GNS1_REGION_UNKNOWN;
@@ -62,9 +83,21 @@ static bool is_first_segment(const Gns1SegmentEntry *e) {
 	return !is_erased_segment (e) && e->type == GNS1_SEG_TEXT && e->region != GNS1_REGION_UNKNOWN;
 }
 
-static bool parse_segment(RBuffer *b, ut64 *off, Gns1SegmentEntry *e) {
+static bool is_valid_segment(const Gns1SegmentEntry *e, ut64 file_size, ut64 min_offset) {
+	if (e->size == 0 || is_erased_segment (e) || e->region == GNS1_REGION_UNKNOWN) {
+		return false;
+	}
+	ut64 seg_size = e->size;
+	ut64 seg_off = e->offset;
+	return seg_size <= file_size && seg_off >= min_offset && seg_off < file_size && seg_off <= file_size - seg_size;
+}
+
+static bool parse_segment(RBuffer *b, ut64 base, ut64 *off, Gns1SegmentEntry *e) {
 	ut8 buf[12];
-	if (r_buf_read_at (b, *off, buf, sizeof (buf)) != sizeof (buf)) {
+	if (*off > UT64_MAX - base) {
+		return false;
+	}
+	if (r_buf_read_at (b, base + *off, buf, sizeof (buf)) != sizeof (buf)) {
 		return false;
 	}
 	e->size = r_read_le32 (buf);
@@ -76,59 +109,193 @@ static bool parse_segment(RBuffer *b, ut64 *off, Gns1SegmentEntry *e) {
 	return true;
 }
 
-static bool check_buffer(RBuffer *b) {
-	if (!b || r_buf_size (b) < GNS1_MIN_FILE_SIZE) {
+static bool is_zero_filled(RBuffer *b, ut64 base, ut64 off, ut64 end) {
+	ut8 buf[64];
+	while (off < end) {
+		int len = (int)R_MIN ((ut64)sizeof (buf), end - off);
+		if (off > UT64_MAX - base || r_buf_read_at (b, base + off, buf, len) != len) {
+			return false;
+		}
+		int i;
+		for (i = 0; i < len; i++) {
+			if (buf[i]) {
+				return false;
+			}
+		}
+		off += len;
+	}
+	return true;
+}
+
+static bool parse_segment_table(RBuffer *b, RVecGns1Segment *segments, ut64 base, ut64 image_size, ut64 *table_size) {
+	if (!b || image_size < GNS1_MIN_FILE_SIZE) {
+		return false;
+	}
+	const ut64 buf_size = r_buf_size (b);
+	if (base > buf_size || image_size > buf_size - base) {
 		return false;
 	}
 	ut64 off = 0;
 	Gns1SegmentEntry entry;
-	if (!parse_segment (b, &off, &entry)) {
+	if (!parse_segment (b, base, &off, &entry)) {
 		return false;
 	}
 	if (!is_first_segment (&entry)) {
 		return false;
 	}
-	ut64 buf_size = r_buf_size (b);
-	ut64 seg_size = entry.size;
-	ut64 seg_off = entry.offset;
-	if (entry.size == 0 || entry.size > buf_size ||
-		entry.offset < 0x64 || seg_off >= buf_size ||
-		seg_off > buf_size - seg_size) {
+	const ut64 data_start = entry.offset;
+	if (data_start < 0x64 || !is_valid_segment (&entry, image_size, data_start)) {
 		return false;
 	}
-	return r_buf_read_le32_at (b, entry.offset - 4) == 0;
+	off = 0;
+	size_t n_segments = 0;
+	bool terminated = false;
+	while (off < data_start) {
+		if (n_segments > GNS1_MAX_VALID_SEGMENTS) {
+			return false;
+		}
+		if (data_start - off < GNS1_SEGMENT_ENTRY_SIZE) {
+			terminated = is_zero_filled (b, base, off, data_start);
+			off = data_start;
+			break;
+		}
+		if (!parse_segment (b, base, &off, &entry) || off > data_start) {
+			return false;
+		}
+		if (is_erased_segment (&entry)) {
+			terminated = true;
+			break;
+		}
+		if (entry.size == 0) {
+			if (entry.paddr || entry.offset) {
+				return false;
+			}
+			terminated = true;
+			break;
+		}
+		if (!is_valid_segment (&entry, image_size, data_start)) {
+			return false;
+		}
+		if (segments) {
+			RVecGns1Segment_push_back (segments, &entry);
+		}
+		n_segments++;
+	}
+	if (!terminated || n_segments == 0 || !is_zero_filled (b, base, off, data_start)) {
+		return false;
+	}
+	if (table_size) {
+		*table_size = data_start;
+	}
+	return true;
+}
+
+static bool parse_ftab(RBuffer *b, RVecGns1FtabEntry *entries, ut64 *base, ut64 *image_size, ut32 *n_entries_out) {
+	if (!b || r_buf_size (b) < GNS1_FTAB_ENTRY_OFFSET + GNS1_FTAB_ENTRY_SIZE) {
+		return false;
+	}
+	ut8 buf[GNS1_FTAB_ENTRY_SIZE];
+	if (r_buf_read_at (b, GNS1_FTAB_MAGIC_OFFSET, buf, 8) != 8 || memcmp (buf, "rkosftab", 8)) {
+		return false;
+	}
+	if (r_buf_read_at (b, GNS1_FTAB_ENTRY_COUNT_OFFSET, buf, 8) != 8) {
+		return false;
+	}
+	const ut64 buf_size = r_buf_size (b);
+	const ut32 n_entries = r_read_le32 (buf);
+	const ut32 zero = r_read_le32 (buf + 4);
+	if (!n_entries || n_entries > GNS1_FTAB_MAX_ENTRIES || zero) {
+		return false;
+	}
+	ut64 table_size = (ut64)n_entries * GNS1_FTAB_ENTRY_SIZE;
+	if (table_size > buf_size - GNS1_FTAB_ENTRY_OFFSET) {
+		return false;
+	}
+	ut64 off = GNS1_FTAB_ENTRY_OFFSET;
+	ut32 i;
+	for (i = 0; i < n_entries; i++, off += GNS1_FTAB_ENTRY_SIZE) {
+		if (r_buf_read_at (b, off, buf, sizeof (buf)) != sizeof (buf)) {
+			return false;
+		}
+		const ut32 entry_off = r_read_le32 (buf + 4);
+		const ut32 entry_size = r_read_le32 (buf + 8);
+		const ut32 entry_zero = r_read_le32 (buf + 12);
+		if (entry_off > buf_size || entry_size > buf_size - entry_off) {
+			return false;
+		}
+		if (entries) {
+			Gns1FtabEntry entry = {0};
+			memcpy (entry.tag, buf, 4);
+			entry.offset = entry_off;
+			entry.size = entry_size;
+			entry.zero = entry_zero;
+			RVecGns1FtabEntry_push_back (entries, &entry);
+		}
+		if (!memcmp (buf, "GNS1", 4)) {
+			if (!entry_size) {
+				return false;
+			}
+			*base = entry_off;
+			*image_size = entry_size;
+		}
+	}
+	if (n_entries_out) {
+		*n_entries_out = n_entries;
+	}
+	return image_size && *image_size > 0;
+}
+
+static bool parse_gns1(RBuffer *b, RVecGns1Segment *segments, Gns1Obj *obj) {
+	if (!b) {
+		return false;
+	}
+	const ut64 buf_size = r_buf_size (b);
+	ut64 table_size = 0;
+	if (parse_segment_table (b, NULL, 0, buf_size, &table_size)) {
+		if (segments && !parse_segment_table (b, segments, 0, buf_size, &table_size)) {
+			return false;
+		}
+		if (obj) {
+			obj->base_offset = 0;
+			obj->image_size = buf_size;
+			obj->table_size = table_size;
+			obj->is_ftab = false;
+		}
+		return true;
+	}
+	ut64 base = 0;
+	ut64 image_size = 0;
+	ut32 n_entries = 0;
+	RVecGns1FtabEntry *ftab_entries = obj? &obj->ftab_entries: NULL;
+	if (parse_ftab (b, ftab_entries, &base, &image_size, &n_entries) && parse_segment_table (b, NULL, base, image_size, &table_size)) {
+		if (segments && !parse_segment_table (b, segments, base, image_size, &table_size)) {
+			return false;
+		}
+		if (obj) {
+			obj->base_offset = base;
+			obj->image_size = image_size;
+			obj->table_size = table_size;
+			obj->n_ftab_entries = n_entries;
+			obj->is_ftab = true;
+		}
+		return true;
+	}
+	return false;
+}
+
+static bool check_buffer(RBuffer *b) {
+	return parse_gns1 (b, NULL, NULL);
 }
 
 static Gns1Obj *load_buffer(RBuffer *b) {
 	R_RETURN_VAL_IF_FAIL (b, NULL);
 	Gns1Obj *gns1 = R_NEW0 (Gns1Obj);
 	RVecGns1Segment_init (&gns1->segments);
-	ut64 off = 0;
-	Gns1SegmentEntry entry;
-	ut64 file_size = r_buf_size (b);
-	int invalid = 0;
-	while (parse_segment (b, &off, &entry)) {
-		ut64 seg_size = entry.size;
-		ut64 seg_off = entry.offset;
-		if (entry.size == 0 || is_erased_segment (&entry)) {
-			break;
-		}
-		if (seg_size > file_size || seg_off >= file_size || seg_off > file_size - seg_size) {
-			if (invalid++ > 3) {
-				R_LOG_ERROR ("GNS1: Too many invalid segments found");
-				break;
-			}
-			continue;
-		}
-		RVecGns1Segment_push_back (&gns1->segments, &entry);
-		if (RVecGns1Segment_length (&gns1->segments) > GNS1_MAX_VALID_SEGMENTS) {
-			R_LOG_ERROR ("GNS1: too many segments");
-			break;
-		}
-	}
-	if (RVecGns1Segment_empty (&gns1->segments)) {
-		R_LOG_ERROR ("GNS1: no valid segments found");
+	RVecGns1FtabEntry_init (&gns1->ftab_entries);
+	if (!parse_gns1 (b, &gns1->segments, gns1) || RVecGns1Segment_empty (&gns1->segments)) {
+		R_LOG_ERROR ("GNS1: invalid segment table");
 		RVecGns1Segment_fini (&gns1->segments);
+		RVecGns1FtabEntry_fini (&gns1->ftab_entries);
 		free (gns1);
 		return NULL;
 	}
@@ -138,6 +305,7 @@ static Gns1Obj *load_buffer(RBuffer *b) {
 static void obj_free(Gns1Obj *gns1) {
 	if (gns1) {
 		RVecGns1Segment_fini (&gns1->segments);
+		RVecGns1FtabEntry_fini (&gns1->ftab_entries);
 		R_FREE (gns1);
 	}
 }
@@ -166,18 +334,45 @@ static ut64 gns1_baddr(RBinFile *bf) {
 	return GNS1_INTERNAL_BASE;
 }
 
+static RBinSection *add_section(RBinFile *bf, const char *name, ut64 paddr, ut64 size, ut64 vaddr, ut32 perm, const char *type, const char *format) {
+	RBinSection *sec = RVecRBinSection_emplace_back (&bf->bo->sections_vec);
+	sec->name = strdup (name);
+	sec->paddr = paddr;
+	sec->vaddr = vaddr;
+	sec->size = sec->vsize = size;
+	sec->perm = perm;
+	sec->type = type;
+	sec->format = format? strdup (format): NULL;
+	return sec;
+}
+
 static bool gns1_sections_vec(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, false);
 	Gns1Obj *obj = bf->bo->bin_obj;
 	RVecRBinSection_clear (&bf->bo->sections_vec);
+	if (obj->is_ftab) {
+		add_section (bf, "ftab_header", 0, GNS1_FTAB_HEADER_SIZE, 0, R_PERM_R, "FTAB",
+			"8x magic[8] entries zero");
+		add_section (bf, "ftab_entries", GNS1_FTAB_ENTRY_OFFSET, (ut64)obj->n_ftab_entries * GNS1_FTAB_ENTRY_SIZE,
+			GNS1_FTAB_ENTRY_OFFSET, R_PERM_R, "FTAB", "4cxxx tag offset size zero");
+		Gns1FtabEntry *fe;
+		R_VEC_FOREACH (&obj->ftab_entries, fe) {
+			char name[32];
+			snprintf (name, sizeof (name), "ftab_%s", fe->tag);
+			add_section (bf, name, fe->offset, fe->size, fe->offset, R_PERM_R, "FTAB", NULL);
+		}
+	}
+	add_section (bf, "gns1_segments", obj->base_offset, obj->table_size, obj->base_offset, R_PERM_R,
+		"GNS1", "xxx size paddr offset");
 	Gns1SegmentEntry *e;
 	ut32 idx = 0;
 	R_VEC_FOREACH (&obj->segments, e) {
 		RBinSection *sec = RVecRBinSection_emplace_back (&bf->bo->sections_vec);
-		sec->paddr = e->offset;
+		sec->paddr = obj->base_offset + e->offset;
 		sec->size = sec->vsize = e->size;
 		sec->vaddr = translate_vaddr (e->paddr);
 		sec->perm = ((e->paddr & GNS1_ADDRMASK) == 0)? R_PERM_RX: R_PERM_RW;
+		sec->add = true;
 		const char *seg_type = e->type == GNS1_SEG_TEXT? "text": "data";
 		const char *region = e->region == GNS1_REGION_A? "region_a": (e->region == GNS1_REGION_B? "region_b": NULL);
 		sec->name = region? r_str_newf ("%s_%s_%u", region, seg_type, idx)
@@ -212,13 +407,13 @@ static RList *gns1_entries(RBinFile *bf) {
 	}
 	if (ra_text) {
 		RBinAddr *entry = R_NEW0 (RBinAddr);
-		entry->paddr = ra_text->offset;
+		entry->paddr = obj->base_offset + ra_text->offset;
 		entry->vaddr = translate_vaddr (ra_text->paddr);
 		r_list_append (ret, entry);
 	}
 	if (rb_text) {
 		RBinAddr *entry = R_NEW0 (RBinAddr);
-		entry->paddr = rb_text->offset;
+		entry->paddr = obj->base_offset + rb_text->offset;
 		entry->vaddr = translate_vaddr (rb_text->paddr);
 		r_list_append (ret, entry);
 	}
@@ -226,14 +421,19 @@ static RList *gns1_entries(RBinFile *bf) {
 }
 
 static RBinInfo *gns1_info(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
+	Gns1Obj *obj = bf->bo->bin_obj;
 	RBinInfo *info = R_NEW0 (RBinInfo);
 	info->file = bf->file? strdup (bf->file): NULL;
-	info->type = strdup ("GNS1");
+	info->type = strdup (obj->is_ftab? "FTAB/GNS1": "GNS1");
+	info->bclass = strdup (obj->is_ftab? "ftab": "raw");
 	info->machine = strdup ("Apple C4000 Baseband");
 	info->arch = strdup ("arc");
 	info->rclass = strdup ("firmware");
 	info->subsystem = strdup ("baseband");
-	info->cpu = strdup ("ARC700");
+	info->cpu = strdup ("hs");
+	info->flags = r_str_newf ("gns1.offset=0x%08"PFMT64x",gns1.size=0x%08"PFMT64x,
+		obj->base_offset, obj->image_size);
 	info->has_va = true;
 	info->bits = 16;
 	info->big_endian = false;
@@ -243,7 +443,7 @@ static RBinInfo *gns1_info(RBinFile *bf) {
 RBinPlugin r_bin_plugin_gns1 = {
 	.meta = {
 		.name = "gns1",
-		.desc = "Apple C4000 baseband firmware (GNS1.bin)",
+		.desc = "Apple C4000 baseband firmware (FTAB/GNS1.bin)",
 		.license = "LGPL3",
 		.author = "Zapper9982",
 	},

--- a/libr/bin/p/bin_gns1.c
+++ b/libr/bin/p/bin_gns1.c
@@ -54,6 +54,14 @@ static ut64 translate_vaddr(ut32 paddr) {
 	return paddr;
 }
 
+static bool is_erased_segment(const Gns1SegmentEntry *e) {
+	return e->size == UT32_MAX && e->paddr == UT32_MAX && e->offset == UT32_MAX;
+}
+
+static bool is_first_segment(const Gns1SegmentEntry *e) {
+	return !is_erased_segment (e) && e->type == GNS1_SEG_TEXT && e->region != GNS1_REGION_UNKNOWN;
+}
+
 static bool parse_segment(RBuffer *b, ut64 *off, Gns1SegmentEntry *e) {
 	ut8 buf[12];
 	if (r_buf_read_at (b, *off, buf, sizeof (buf)) != sizeof (buf)) {
@@ -75,6 +83,9 @@ static bool check_buffer(RBuffer *b) {
 	ut64 off = 0;
 	Gns1SegmentEntry entry;
 	if (!parse_segment (b, &off, &entry)) {
+		return false;
+	}
+	if (!is_first_segment (&entry)) {
 		return false;
 	}
 	ut64 buf_size = r_buf_size (b);
@@ -99,7 +110,7 @@ static Gns1Obj *load_buffer(RBuffer *b) {
 	while (parse_segment (b, &off, &entry)) {
 		ut64 seg_size = entry.size;
 		ut64 seg_off = entry.offset;
-		if (entry.size == 0) {
+		if (entry.size == 0 || is_erased_segment (&entry)) {
 			break;
 		}
 		if (seg_size > file_size || seg_off >= file_size || seg_off > file_size - seg_size) {

--- a/libr/bin/p/bin_xtr_ftab.c
+++ b/libr/bin/p/bin_xtr_ftab.c
@@ -1,0 +1,199 @@
+/* radare2 - LGPL - Copyright 2026 - pancake */
+
+#include <r_bin.h>
+
+#define FTAB_HEADER_SIZE 0x30
+#define FTAB_MAGIC_OFFSET 0x20
+#define FTAB_ENTRY_COUNT_OFFSET 0x28
+#define FTAB_ENTRY_OFFSET 0x30
+#define FTAB_ENTRY_SIZE 16
+#define FTAB_MAX_ENTRIES 4096
+
+typedef struct ftab_entry_t {
+	char tag[5];
+	ut32 offset;
+	ut32 size;
+	ut32 zero;
+} FtabEntry;
+
+R_VEC_TYPE(RVecFtabEntry, FtabEntry);
+
+static bool ftab_check_buffer(RBuffer *b) {
+	ut8 buf[8];
+	return b && r_buf_size (b) >= FTAB_HEADER_SIZE &&
+		r_buf_read_at (b, FTAB_MAGIC_OFFSET, buf, sizeof (buf)) == sizeof (buf) &&
+		!memcmp (buf, "rkosftab", 8);
+}
+
+static bool check(RBinFile *bf, RBuffer *b) {
+	return ftab_check_buffer (b);
+}
+
+static bool parse_ftab_entries(RBuffer *b, RVecFtabEntry *entries) {
+	if (!ftab_check_buffer (b)) {
+		return false;
+	}
+	ut8 buf[FTAB_ENTRY_SIZE];
+	if (r_buf_read_at (b, FTAB_ENTRY_COUNT_OFFSET, buf, 8) != 8) {
+		return false;
+	}
+	const ut64 buf_size = r_buf_size (b);
+	const ut32 n_entries = r_read_le32 (buf);
+	const ut32 zero = r_read_le32 (buf + 4);
+	if (!n_entries || n_entries > FTAB_MAX_ENTRIES || zero) {
+		return false;
+	}
+	const ut64 table_size = (ut64)n_entries * FTAB_ENTRY_SIZE;
+	if (table_size > buf_size - FTAB_ENTRY_OFFSET) {
+		return false;
+	}
+	ut64 off = FTAB_ENTRY_OFFSET;
+	ut32 i;
+	for (i = 0; i < n_entries; i++, off += FTAB_ENTRY_SIZE) {
+		if (r_buf_read_at (b, off, buf, sizeof (buf)) != sizeof (buf)) {
+			return false;
+		}
+		FtabEntry entry = {0};
+		memcpy (entry.tag, buf, 4);
+		entry.offset = r_read_le32 (buf + 4);
+		entry.size = r_read_le32 (buf + 8);
+		entry.zero = r_read_le32 (buf + 12);
+		if (entry.zero || entry.offset > buf_size || entry.size > buf_size - entry.offset) {
+			return false;
+		}
+		RVecFtabEntry_push_back (entries, &entry);
+	}
+	return !RVecFtabEntry_empty (entries);
+}
+
+static RBinXtrMetadata *metadata_from_entry(const FtabEntry *entry) {
+	RBinXtrMetadata *meta = R_NEW0 (RBinXtrMetadata);
+	meta->libname = strdup (entry->tag);
+	meta->machine = strdup ("Apple C4000");
+	meta->type = "firmware";
+	meta->xtr_type = "ftab";
+	if (!strcmp (entry->tag, "GNS1")) {
+		meta->arch = strdup ("arc");
+		meta->bits = 16;
+	} else {
+		meta->arch = strdup ("unknown");
+	}
+	return meta;
+}
+
+static RBinXtrData *extract_entry(RBuffer *b, const FtabEntry *entry, ut32 n_entries) {
+	if (!entry) {
+		return NULL;
+	}
+	RBuffer *slice = r_buf_new_slice (b, entry->offset, entry->size);
+	if (!slice) {
+		return NULL;
+	}
+	RBinXtrMetadata *meta = metadata_from_entry (entry);
+	RBinXtrData *data = r_bin_xtrdata_new (slice, 0, entry->size, n_entries, meta);
+	data->offset = entry->offset;
+	r_unref (slice);
+	return data;
+}
+
+static bool is_gns1_entry(const FtabEntry *entry) {
+	return entry && !strcmp (entry->tag, "GNS1");
+}
+
+static const FtabEntry *entry_at_index(RVecFtabEntry *entries, int idx) {
+	if (idx < 0) {
+		return NULL;
+	}
+	const FtabEntry *gns1 = NULL;
+	FtabEntry *entry;
+	R_VEC_FOREACH (entries, entry) {
+		if (is_gns1_entry (entry)) {
+			gns1 = entry;
+			break;
+		}
+	}
+	if (!gns1) {
+		return idx < RVecFtabEntry_length (entries)? RVecFtabEntry_at (entries, idx): NULL;
+	}
+	if (!idx) {
+		return gns1;
+	}
+	size_t n = 1;
+	R_VEC_FOREACH (entries, entry) {
+		if (is_gns1_entry (entry)) {
+			continue;
+		}
+		if (n == (size_t)idx) {
+			return entry;
+		}
+		n++;
+	}
+	return NULL;
+}
+
+static RBinXtrData *extract_from_buffer(RBin *bin, RBuffer *b, int idx) {
+	RVecFtabEntry entries;
+	RVecFtabEntry_init (&entries);
+	RBinXtrData *ret = NULL;
+	if (parse_ftab_entries (b, &entries)) {
+		const FtabEntry *entry = entry_at_index (&entries, idx);
+		ret = extract_entry (b, entry, RVecFtabEntry_length (&entries));
+	}
+	RVecFtabEntry_fini (&entries);
+	return ret;
+}
+
+static RList *extractall_from_buffer(RBin *bin, RBuffer *b) {
+	RVecFtabEntry entries;
+	RVecFtabEntry_init (&entries);
+	if (!parse_ftab_entries (b, &entries)) {
+		RVecFtabEntry_fini (&entries);
+		return NULL;
+	}
+	RList *list = r_list_newf (r_bin_xtrdata_free);
+	if (!list) {
+		RVecFtabEntry_fini (&entries);
+		return NULL;
+	}
+	const ut32 n_entries = RVecFtabEntry_length (&entries);
+	FtabEntry *entry;
+	R_VEC_FOREACH (&entries, entry) {
+		if (is_gns1_entry (entry)) {
+			RBinXtrData *data = extract_entry (b, entry, n_entries);
+			if (data) {
+				r_list_append (list, data);
+			}
+			break;
+		}
+	}
+	R_VEC_FOREACH (&entries, entry) {
+		if (!is_gns1_entry (entry)) {
+			RBinXtrData *data = extract_entry (b, entry, n_entries);
+			if (data) {
+				r_list_append (list, data);
+			}
+		}
+	}
+	RVecFtabEntry_fini (&entries);
+	return list;
+}
+
+RBinXtrPlugin r_bin_xtr_plugin_xtr_ftab = {
+	.meta = {
+		.name = "xtr.ftab",
+		.author = "pancake",
+		.desc = "Apple C4000 FTAB firmware extractor",
+		.license = "LGPL3",
+	},
+	.extract_from_buffer = &extract_from_buffer,
+	.extractall_from_buffer = &extractall_from_buffer,
+	.check = &check,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_BIN_XTR,
+	.data = &r_bin_xtr_plugin_xtr_ftab,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/bin/p/xtr_ftab.mk
+++ b/libr/bin/p/xtr_ftab.mk
@@ -1,0 +1,10 @@
+OBJ_XTR_FTAB=bin_xtr_ftab.o
+
+STATIC_OBJ+=${OBJ_XTR_FTAB}
+TARGET_XTR_FTAB=bin_xtr_ftab.${EXT_SO}
+
+ALL_TARGETS+=${TARGET_XTR_FTAB}
+
+${TARGET_XTR_FTAB}: ${OBJ_XTR_FTAB}
+	-${CC} $(call libname,bin_xtr_ftab) -shared ${CFLAGS} \
+		-o ${TARGET_XTR_FTAB} ${OBJ_XTR_FTAB} $(LINK) $(LDFLAGS)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -1142,6 +1142,7 @@ extern RBinPlugin r_bin_plugin_z64;
 extern RBinPlugin r_bin_plugin_zimg;
 extern RBinPlugin r_bin_plugin_gns1;
 extern RBinXtrPlugin r_bin_xtr_plugin_xtr_dyldcache;
+extern RBinXtrPlugin r_bin_xtr_plugin_xtr_ftab;
 extern RBinXtrPlugin r_bin_xtr_plugin_xtr_pemixed;
 extern RBinXtrPlugin r_bin_xtr_plugin_xtr_xalz;
 

--- a/test/db/formats/firmware
+++ b/test/db/formats/firmware
@@ -226,7 +226,7 @@ iorw     false
 block    0x100
 type     GNS1
 arch     arc
-cpu      ARC700
+cpu      hs
 baddr    0x10000000
 binsz    148
 bintype  firmware
@@ -234,6 +234,8 @@ bits     16
 canary   false
 injprot  false
 retguard false
+class    raw
+flags    gns1.offset=0x00000000,gns1.size=0x00000094
 crypto   false
 endian   little
 havecode true
@@ -252,9 +254,26 @@ subsys   baseband
 va       true
 nth paddr       size vaddr       vsize perm flags type name
 -----------------------------------------------------------
-0   0x00000064  0x10 0x10000000   0x10 -r-x 0x0   ---- region_a_text_0
-1   0x00000074   0x8 0x10001000    0x8 -rw- 0x0   ---- region_a_data_1
-2   0x0000007c  0x10 0x15000000   0x10 -r-x 0x0   ---- region_b_text_2
-3   0x0000008c   0x8 0x15001000    0x8 -rw- 0x0   ---- region_b_data_3
+0   0x00000000  0x64 0x00000000   0x64 -r-- 0x0   GNS1 gns1_segments
+1   0x00000064  0x10 0x10000000   0x10 -r-x 0x0   ---- region_a_text_0
+2   0x00000074   0x8 0x10001000    0x8 -rw- 0x0   ---- region_a_data_1
+3   0x0000007c  0x10 0x15000000   0x10 -r-x 0x0   ---- region_b_text_2
+4   0x0000008c   0x8 0x15001000    0x8 -rw- 0x0   ---- region_b_data_3
+EOF
+RUN
+
+NAME=apple baseband rejects dyldcache
+FILE=bins/firmware/gns1_test.bin
+CMDS=!!rabin2 -I -F gns1 bins/mach0/dyld_shared_cache_arm64-macOS~Apple~?
+EXPECT=<<EOF
+0
+EOF
+RUN
+
+NAME=dyldcache dsc handler is not gns1
+FILE=bins/firmware/gns1_test.bin
+CMDS=!!rabin2 -I dsc://bins/mach0/dyld_shared_cache_arm64-macOS~class
+EXPECT=<<EOF
+class    dyldcache
 EOF
 RUN


### PR DESCRIPTION
Root cause: the new GNS1 bin plugin was too permissive and misclassified dsc:// dyldcache input as Apple C4000 baseband firmware before dyldcache handling could run. The dyldcache symbol parser was not reached. I tightened GNS1 detection so the first segment must be a real text segment in a known GNS1 region, and erased 0xffffffff segment entries terminate loading.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
