### PR TITLE
Make r_str_ichr const-correct ##refactor

### DIFF
--- a/libr/arch/p/pickle/plugin.c
+++ b/libr/arch/p/pickle/plugin.c
@@ -617,7 +617,7 @@ static bool pickle_encode(RArchSession *s, RAnalOp *op, RArchEncodeMask mask) {
 	if (arg && *arg == ' ') {
 		*arg = '\0';
 		arg++;
-		arg = r_str_ichr (arg, ' ');
+		arg = (char *) r_str_ichr (arg, ' ');
 	} else {
 		arg = "";
 	}

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -213,7 +213,7 @@ R_API char *r_str_lstr(const char *s, const char *sub);
 #endif
 R_API const char *r_sub_str_lchr(const char *str, int start, int end, char chr);
 R_API const char *r_sub_str_rchr(const char *str, int start, int end, char chr);
-R_API char *r_str_ichr(char *str, char chr);
+R_API const char *r_str_ichr(const char *str, char chr);
 R_API bool r_str_ccmp(const char *dst, const char *orig, int ch);
 R_API bool r_str_cmp_list(const char *list, const char *item, char sep);
 R_API int r_str_casecmp(const char *dst, const char *orig);

--- a/libr/io/p/io_r2k_linux.c
+++ b/libr/io/p/io_r2k_linux.c
@@ -209,7 +209,7 @@ static const char* getargpos(const char *buf, int pos) {
 		if (!buf) {
 			break;
 		}
-		buf = r_str_ichr ((char *) buf, ' ');
+		buf = r_str_ichr (buf, ' ');
 	}
 	return buf;
 }
@@ -828,7 +828,7 @@ int run_new_command(RIO *io, RIODesc *iodesc, const char *buf) {
 }
 
 int run_ioctl_command(RIO *io, RIODesc *iodesc, const char *buf) {
-	buf = r_str_ichr ((char *) buf, ' ');
+	buf = r_str_ichr (buf, ' ');
 
 	if (!run_new_command (io, iodesc, buf)) {
 		return run_old_command (io, iodesc, buf);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -559,10 +559,9 @@ R_API int r_str_word_count(const char *string) {
 
 // Returns a pointer to the first instance of a character that isn't chr in a
 // string.
-// TODO: make this const-correct.
 // XXX if the string is only made up of chr, then the pointer will just point to
 // a null byte!
-R_API char *r_str_ichr(char *str, char chr) {
+R_API const char *r_str_ichr(const char *str, char chr) {
 	while (*str == chr) {
 		str++;
 	}

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -238,8 +238,8 @@ bool test_r_str_word_count(void) {
 }
 
 bool test_r_str_ichr(void) {
-	char* test = "rrrrrradare2";
-	char* out = r_str_ichr (test, 'r');
+	const char* test = "rrrrrradare2";
+	const char* out = r_str_ichr (test, 'r');
 	mu_assert_streq (out, "adare2",
 			"string after the first non-r character in rrrrrradare2");
 	mu_end;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Make r_str_ichr() both accept and return const char * like many other similar RStr functions (e.g., r_str_lchr) do, as suggested by the TODO.

<!-- explain your changes if necessary -->
