### PR TITLE
Autoname PPC import call stubs after the imported function ##anal

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -571,6 +571,46 @@ static void function_rename(RFlag *flags, RAnalFunction *fcn) {
 	}
 }
 
+static void autoname_tail_jmp_stub(RCore *core, RAnalFunction *fcn) {
+	if (!r_str_startswith (fcn->name, "fcn.") || r_anal_function_linear_size (fcn) > 64
+			|| r_anal_function_count_refs (fcn, R_ANAL_REF_TYPE_CALL) > 0) {
+		return;
+	}
+	RListIter *iter;
+	RAnalBlock *bb;
+	const char *impname = NULL;
+	r_list_foreach (fcn->bbs, iter, bb) {
+		if (bb->ninstr < 1) {
+			continue;
+		}
+		ut64 last = r_anal_bb_opaddr_i (bb, bb->ninstr - 1);
+		RAnalOp *op = r_core_anal_op (core, last, R_ARCH_OP_MASK_BASIC);
+		if (!op) {
+			continue;
+		}
+		if ((op->type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_JMP) {
+			RFlagItem *flg = r_flag_get_in (core->flags, op->jump);
+			if (flg && (r_str_startswith (flg->name, "sym.imp.") || r_str_startswith (flg->name, "loc.imp."))) {
+				impname = flg->name + strlen ("sym.imp.");
+			}
+		}
+		r_anal_op_free (op);
+		if (impname) {
+			break;
+		}
+	}
+	if (impname) {
+		char *newname = r_str_newf ("sub.%s", impname);
+		if (r_anal_get_function_byname (core->anal, newname)) {
+			// duplicate names make r_anal_add_function drop the function
+			free (newname);
+			newname = r_str_newf ("sub.%s_%"PFMT64x, impname, fcn->addr);
+		}
+		free (fcn->name);
+		fcn->name = newname;
+	}
+}
+
 static void autoname_imp_trampoline(RCore *core, RAnalFunction *fcn) {
 	if (r_list_length (fcn->bbs) == 1 && ((RAnalBlock *) r_list_first (fcn->bbs))->ninstr == 1) {
 		// TODO seems wasteful, maybe we should add a function to only retrieve the first?
@@ -587,7 +627,9 @@ static void autoname_imp_trampoline(RCore *core, RAnalFunction *fcn) {
 			}
 		}
 		RVecAnalRef_free (refs);
+		return;
 	}
+	autoname_tail_jmp_stub (core, fcn);
 }
 
 static bool set_fcn_name_from_flag(RCore *core, RAnalFunction *fcn, RFlagItem *f, const char *fcnpfx) {

--- a/test/db/anal/path
+++ b/test/db/anal/path
@@ -190,7 +190,7 @@ pdb @@= 0x000067d0 0x00004df0 0x000132d0 0x000132de 0x00004960
 |           0x00004e4b      e800faffff     call sym.imp.textdomain     ; char *textdomain(char *domainname)
 |           0x00004e50      488d3d8991..   lea rdi, [0x0000dfe0]
 |           0x00004e57      c70597e301..   mov dword [obj.exit_failure], 2 ; [0x231f8:4]=1
-|           0x00004e61      e8fa260100     call fcn.00017560
+|           0x00004e61      e8fa260100     call sub.__cxa_atexit
 |           0x00004e66      c6054bf401..   mov byte [0x000242b8], 1    ; [0x242b8:1]=0
 |           0x00004e6d      48b8000000..   movabs rax, 0x8000000000000000
 |           0x00004e77      488905f2f4..   mov qword [0x00024370], rax ; [0x24370:8]=0

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -3543,7 +3543,7 @@ FILE=bins/mach0/ls-osx-x86_64
 CMDS=<<EOF
 f-sym.func.*
 aap
-pi 2 @ fcn.1000010f8
+pi 2 @ sub.strcoll
 EOF
 EXPECT=<<EOF
 push rbp

--- a/test/db/cmd/cmd_afl
+++ b/test/db/cmd/cmd_afl
@@ -259,7 +259,7 @@ EXPECT=<<EOF
   1 sym.imp.getopt_long
   1 sym.imp.ioctl
   1 fcn.00016d50
-  1 fcn.00017560
+  1 sub.__cxa_atexit
   1 sym.imp.setlocale
   1 fcn.00015b10
   1 sym.imp.strcmp

--- a/test/db/formats/elf/ppc64v1-plt
+++ b/test/db/formats/elf/ppc64v1-plt
@@ -115,3 +115,53 @@ CMDS=ii~0xffffff
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=ELF v1 shared lib: import call stub named after the import
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aa
+afi @ 0x3c60 ~name[1]
+afi @ 0x3d00 ~name[1]
+EOF2
+EXPECT=<<EOF2
+sub.memcpy
+sub.malloc
+EOF2
+RUN
+
+NAME=ELF v1 shared lib: import stub call site renders the import name
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aa
+pi 1 @ 0x7be8
+EOF2
+EXPECT=<<EOF2
+bl sub.memcpy
+EOF2
+RUN
+
+NAME=ELF v1 shared lib: exactly the import stubs are named, no others
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aa
+afl~sub.?
+EOF2
+EXPECT=<<EOF2
+5
+EOF2
+RUN
+
+NAME=ELF v1 exec: direct-PLT imports yield no spurious stub names
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aa
+afl~sub.?
+EOF2
+EXPECT=<<EOF2
+0
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

On PPC ELFv1, imports are called through a small TOC-save glink stub in `.text` that tail-branches to the import. r2 resolved the tail branch but left the stub entry as `fcn.XXXX`, so every import call rendered as a bare address:

    bl fcn.00003c60     ->     bl sub.memcpy

`autoname_imp_trampoline` now names such stubs `sub.<import>` (ppc-gated; a small, call-free function whose terminating jump targets a `sym.imp.*`/`loc.imp.*` flag). 

Bonus: naming the `__stack_chk_fail` stub restores noreturn recognition, so r2 no longer over-runs functions into trailing data — eliminating spurious `pdg` `halt_baddata` truncations (14/30 sampled functions -> 0).

Finally, 4 tests in db/formats/elf/ppc64v1-plt (naming, call site, exact coverage, ET_EXEC negative)