### PR TITLE
Don't create string metadata at addresses inside  functions ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4320,7 +4320,7 @@ static void add_string_ref(RCore *core, ut64 xref_from, ut64 xref_to) {
 	const int reftype = R_ANAL_REF_TYPE_DATA | R_ANAL_REF_TYPE_READ;
 	int len = 0;
 	char str[STRSZ] = {0};
-	if (xref_to == UT64_MAX || !xref_to) {
+	if (xref_to == UT64_MAX || !xref_to || r_anal_get_fcn_in (core->anal, xref_to, 0)) {
 		return;
 	}
 	if (!xref_from || xref_from == UT64_MAX) {

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1177,3 +1177,28 @@ arg int64_t arg_88h @ r1+0x88
 arg int64_t arg_90h @ r1+0x90
 EOF
 RUN
+
+NAME=esil does not turn analysed code into a string
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aaa
+Cs. @ 0x10001d68
+pi 1 @ 0x10001d68
+EOF2
+EXPECT=<<EOF2
+addi r1, r1, 0x20
+EOF2
+RUN
+
+NAME=esil keeps real strings in data sections
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF2
+e bin.relocs.apply=true
+aaa
+Cs. @ 0x10001d78
+EOF2
+EXPECT=<<EOF2
+"sh -c clear"
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `aae` pass follows false pointers into `.text` and, since MINLEN is 1, two printable code bytes + NUL pass the string check — so `add_string_ref` stamps `Cs`/`str.` metadata onto a function prologue (e.g. ppc64 `cmpdi r3,0` → `.string ",#"`), corrupting `pd`/`pdf`/`pdc`. A string never lives inside analysed code, so skip `add_string_ref` when the target is inside a function.
