### PR TITLE
Keep duplicate single-instruction import trampolines distinct ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -621,8 +621,13 @@ static void autoname_imp_trampoline(RCore *core, RAnalFunction *fcn) {
 			if (rt != R_ANAL_REF_TYPE_CALL) { /* Some fcns don't return */
 				RFlagItem *flg = r_flag_get_in (core->flags, ref->addr);
 				if (flg && r_str_startswith (flg->name, "sym.imp.")) {
-					R_FREE (fcn->name);
-					fcn->name = r_str_newf ("sub.%s", flg->name + 8);
+					char *newname = r_str_newf ("sub.%s", flg->name + 8);
+					if (r_anal_get_function_byname (core->anal, newname)) {
+						free (newname);
+						newname = r_str_newf ("sub.%s_%"PFMT64x, flg->name + 8, fcn->addr);
+					}
+					free (fcn->name);
+					fcn->name = newname;
 				}
 			}
 		}

--- a/test/db/anal/autoname
+++ b/test/db/anal/autoname
@@ -327,3 +327,115 @@ EXPECT=<<EOF
 0x1000073cc    1     44 sub.printscol_1000073cc
 EOF
 RUN
+
+NAME=duplicate single-instruction import trampolines kept distinct
+FILE=bins/pe/bdc1.ex
+CMDS=<<EOF2
+af @ 0x40706c
+af @ 0x407014
+af @ 0x40709c
+af @ 0x4070a4
+s 0x40706c
+afn
+s 0x407014
+afn
+s 0x40709c
+afn
+s 0x4070a4
+afn
+EOF2
+EXPECT=<<EOF2
+sub.user32.dll_GetWindow
+sub.user32.dll_GetWindow_407014
+sub.user32.dll_GetWindowThreadProcessId
+sub.user32.dll_GetWindowThreadProcessId_4070a4
+EOF2
+RUN
+
+NAME=duplicate single-instruction import trampolines x86-64
+FILE=malloc://4096
+ARGS=-a x86 -b 64
+CMDS=<<EOF2
+f sym.imp.foo @ 0x800
+wa jmp 0x800 @ 0x100
+wa jmp 0x800 @ 0x200
+axc 0x800 @ 0x100
+axc 0x800 @ 0x200
+af @ 0x100
+af @ 0x200
+s 0x100
+afn
+s 0x200
+afn
+EOF2
+EXPECT=<<EOF2
+sub.foo
+sub.foo_200
+EOF2
+RUN
+
+NAME=duplicate single-instruction import trampolines arm64
+FILE=malloc://4096
+ARGS=-a arm -b 64
+CMDS=<<EOF2
+f sym.imp.foo @ 0x800
+wa b 0x800 @ 0x100
+wa b 0x800 @ 0x200
+axc 0x800 @ 0x100
+axc 0x800 @ 0x200
+af @ 0x100
+af @ 0x200
+s 0x100
+afn
+s 0x200
+afn
+EOF2
+EXPECT=<<EOF2
+sub.foo
+sub.foo_200
+EOF2
+RUN
+
+NAME=duplicate single-instruction import trampolines arm
+FILE=malloc://4096
+ARGS=-a arm -b 32
+CMDS=<<EOF2
+f sym.imp.foo @ 0x800
+wa b 0x800 @ 0x100
+wa b 0x800 @ 0x200
+axc 0x800 @ 0x100
+axc 0x800 @ 0x200
+af @ 0x100
+af @ 0x200
+s 0x100
+afn
+s 0x200
+afn
+EOF2
+EXPECT=<<EOF2
+sub.foo
+sub.foo_200
+EOF2
+RUN
+
+NAME=duplicate single-instruction import trampolines ppc64
+FILE=malloc://4096
+ARGS=-a ppc -b 64
+CMDS=<<EOF2
+f sym.imp.foo @ 0x800
+wa b 0x800 @ 0x100
+wa b 0x800 @ 0x200
+axc 0x800 @ 0x100
+axc 0x800 @ 0x200
+af @ 0x100
+af @ 0x200
+s 0x100
+afn
+s 0x200
+afn
+EOF2
+EXPECT=<<EOF2
+sub.foo
+sub.foo_200
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The single-instruction path of autoname_imp_trampoline named every stub sub.<import> with no uniqueness check. When two single-instruction trampolines branch to the same import, the second collides on the name in r_anal_add_function and is silently dropped, so callers through that stub lose the named function. Fall back to sub.<import>_<addr> on collision, matching the guard already used in the multi-instruction tail-jump path.
  
Tests added in db/anal/autoname: the real PE case (bins/pe/bdc1.ex, two collisions) plus synthetic x86-64/arm64/arm/ppc64 cases.