### PR TITLE
Unify ESIL constructors behind an REsilOptions struct ##esil

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -237,17 +237,19 @@ R_API RAnal *r_anal_new(void) {
 	anal->zign_path = strdup ("");
 	anal->cb_printf = (PrintfCallback) printf;
 	anal->reg = r_reg_new ();
-	anal->esil = r_esil_new_simple (1, anal->reg, &anal->iob);
-	anal->esil->mem_if = (REsilMemInterface) {
+	REsilOptions esil_opt = r_esil_options (anal->reg, NULL);
+	esil_opt.addrsize = 1;
+	esil_opt.ifaces.mem = (REsilMemInterface) {
 		.mem = anal,
 		.mem_switch = anal_esil_mem_switch,
 		.mem_read = anal_esil_mem_read,
 		.mem_write = anal_esil_mem_write,
 	};
-	anal->esil->util_if = (REsilUtilInterface) {
+	esil_opt.ifaces.util = (REsilUtilInterface) {
 		.user = anal,
 		.set_bits = anal_esil_set_bits,
 	};
+	anal->esil = r_esil_new (&esil_opt);
 	anal->esil->anal = anal;
 	(void)r_anal_pin_init (anal);
 	(void)r_anal_xrefs_init (anal);

--- a/libr/anal/esil_dfg.c
+++ b/libr/anal/esil_dfg.c
@@ -1526,7 +1526,9 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_new(RAnal *anal, bool use_map_info, bool use
 		free (dfg);
 		return NULL;
 	}
-	dfg->esil = r_esil_new_simple (1, anal->reg, &anal->iob);
+	REsilOptions dfg_opt = r_esil_options (anal->reg, &anal->iob);
+	dfg_opt.addrsize = 1;
+	dfg->esil = r_esil_new (&dfg_opt);
 	if (!dfg->esil) {
 		r_reg_free (dfg->reg);
 		free (dfg);
@@ -1616,7 +1618,9 @@ R_API void r_anal_esil_dfg_free(RAnalEsilDFG *dfg) {
 R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *R_NULLABLE dfg, const char *expr,
 	bool use_map_info, bool use_maps) {
 	R_RETURN_VAL_IF_FAIL (anal && expr, NULL);
-	REsil *esil = r_esil_new_simple (1, anal->reg, &anal->iob);
+	REsilOptions esil_opt = r_esil_options (anal->reg, &anal->iob);
+	esil_opt.addrsize = 1;
+	REsil *esil = r_esil_new (&esil_opt);
 	if (!esil) {
 		return NULL;
 	}
@@ -1974,7 +1978,9 @@ R_API void r_anal_esil_dfg_fold_const(RAnal *anal, RAnalEsilDFG *dfg) {
 		}
 	}
 
-	REsil *esil = r_esil_new (4096, 0, 1);
+	REsilOptions esil_opt = r_esil_options (NULL, NULL);
+	esil_opt.addrsize = 1;
+	REsil *esil = r_esil_new (&esil_opt);
 	r_esil_setup (esil, anal, 1, 0, 0);
 	RGraphVisitor vi = { _dfg_const_reducer_rev_dfs_cb, NULL, NULL, NULL, NULL, &reducer };
 	RRBNode *first_node;

--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -1140,7 +1140,11 @@ static TPState *tps_init(RAnal *anal) {
 	// todo: this probably needs some boundary checks
 	r_reg_setv (reg, "SP", sp);
 	r_reg_setv (reg, "BP", sp);
-	if (!r_esil_init (&tps->esil, 4096, false, anal->config->bits, &tps->reg_if, &tps->mem_if, NULL)) {
+	REsilOptions esil_opt = r_esil_options (NULL, NULL);
+	esil_opt.addrsize = anal->config->bits;
+	esil_opt.ifaces.reg = tps->reg_if;
+	esil_opt.ifaces.mem = tps->mem_if;
+	if (!r_esil_init (&tps->esil, &esil_opt)) {
 		r_reg_free (reg);
 		if (anal->iob.fd_close) {
 			anal->iob.fd_close (io, tps->stack_fd);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2559,7 +2559,12 @@ static int esil_cost(RCore *core, ut64 addr, const char *expr) {
 		.mem_read = ec_mem_read,
 		.mem_write = ec_mem_write_silent,
 	};
-	REsil *e = r_esil_new_ex (256, false, 0, &reg_if, &mem_if, NULL);
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = 256;
+	opt.addrsize = 0;
+	opt.ifaces.reg = reg_if;
+	opt.ifaces.mem = mem_if;
+	REsil *e = r_esil_new (&opt);
 	if (!e) {
 		return ec.cost;
 	}
@@ -2585,10 +2590,11 @@ static void cmd_syscall_do(RCore *core, st64 n, ut64 addr) {
 }
 
 static inline REsil *esil_new_setup(RCore *core) {
-	int stacksize = r_config_get_i (core->config, "esil.stack.depth");
-	bool iotrap = r_config_get_b (core->config, "esil.iotrap");
-	unsigned int addrsize = r_config_get_i (core->config, "esil.addr.size");
-	REsil *esil = r_esil_new (stacksize, iotrap, addrsize);
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = r_config_get_i (core->config, "esil.stack.depth");
+	opt.iotrap = r_config_get_b (core->config, "esil.iotrap");
+	opt.addrsize = r_config_get_i (core->config, "esil.addr.size");
+	REsil *esil = r_esil_new (&opt);
 	if (esil) {
 		esil->anal = core->anal;
 		r_io_bind (core->io, &(core->anal->iob));
@@ -2636,7 +2642,9 @@ static void mr2(void *null, ut64 addr, const ut8 *buf, int len) {
 }
 
 static void esilmemrefs(RCore *core, const char *expr) {
-	REsil *e = r_esil_new_simple (0, core->anal->reg, &core->anal->iob);
+	REsilOptions opt = r_esil_options (core->anal->reg, &core->anal->iob);
+	opt.addrsize = 0;
+	REsil *e = r_esil_new (&opt);
 	r_esil_add_voyeur (e, NULL, mw2, R_ESIL_VOYEUR_MEM_WRITE);
 	r_esil_add_voyeur (e, NULL, mr2, R_ESIL_VOYEUR_MEM_READ);
 	e->anal = core->anal;	//XXX

--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -6272,13 +6272,14 @@ static int cmd_debug(void *data, const char *input) {
 #if 0
 		case 'e': // "dte"
 			if (!core->anal->esil) {
-				int stacksize = r_config_get_i (core->config, "esil.stack.depth");
 				int romem = r_config_get_i (core->config, "esil.romem");
 				int stats = r_config_get_i (core->config, "esil.stats");
-				int iotrap = r_config_get_i (core->config, "esil.iotrap");
 				int nonull = r_config_get_i (core->config, "esil.nonull");
-				unsigned int addrsize = r_config_get_i (core->config, "esil.addr.size");
-				if (!(core->anal->esil = r_esil_new (stacksize, iotrap, addrsize))) {
+				REsilOptions opt = r_esil_options (NULL, NULL);
+				opt.stacksize = r_config_get_i (core->config, "esil.stack.depth");
+				opt.iotrap = r_config_get_i (core->config, "esil.iotrap");
+				opt.addrsize = r_config_get_i (core->config, "esil.addr.size");
+				if (!(core->anal->esil = r_esil_new (&opt))) {
 					return 0;
 				}
 				r_esil_setup (core->anal->esil, core->anal, romem, stats, nonull);

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -1967,7 +1967,11 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 	const bool nonull = r_config_get_b (core->config, "esil.nonull");
 	const int stacksize = R_MAX (r_config_get_i (core->config, "esil.stack.size"), 16);
 	REsil esil = {0};
-	if (!r_esil_init (&esil, stacksize, iotrap, addrsize, NULL, NULL, NULL)) {
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = stacksize;
+	opt.iotrap = iotrap;
+	opt.addrsize = addrsize;
+	if (!r_esil_init (&esil, &opt)) {
 		R_LOG_ERROR ("Cannot initialize search esil instance");
 		return;
 	}
@@ -1976,8 +1980,7 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 		R_LOG_ERROR ("Cannot push reg arena instance");
 		return;
 	}
-	RArch *arch = core->anal->arch;
-	const bool arch_inited = r_esil_setup (&esil, core->anal, false,
+	r_esil_setup (&esil, core->anal, false,
 		r_config_get_b (core->config, "esil.stats"),
 		nonull);
 	esil.cb.hook_mem_write = search_esil_mem_write_ro;
@@ -2070,9 +2073,6 @@ static void do_esil_search(RCore *core, struct search_parameters *param, const c
 	r_cons_clear_line (core->cons, true, true);
 	if (param->outmode == R_MODE_JSON) {
 		pj_end (param->pj);
-	}
-	if (arch_inited && arch) {
-		r_arch_esilcb (arch, &esil, R_ARCH_ESIL_ACTION_FINI);
 	}
 	r_esil_fini (&esil);
 	r_reg_arena_pop (core->anal->reg);

--- a/libr/core/cmd_search_gadget.inc.c
+++ b/libr/core/cmd_search_gadget.inc.c
@@ -322,10 +322,11 @@ static bool gadget_esil_find_cond_end(RCore *core, RList *hitlist, int gadget_ty
 }
 
 static REsil *gadget_esil_new(RCore *core) {
-	int stacksize = r_config_get_i (core->config, "esil.stack.depth");
-	bool iotrap = r_config_get_b (core->config, "esil.iotrap");
-	unsigned int addrsize = r_config_get_i (core->config, "esil.addr.size");
-	REsil *esil = r_esil_new (stacksize, iotrap, addrsize);
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = r_config_get_i (core->config, "esil.stack.depth");
+	opt.iotrap = r_config_get_b (core->config, "esil.iotrap");
+	opt.addrsize = r_config_get_i (core->config, "esil.addr.size");
+	REsil *esil = r_esil_new (&opt);
 	if (esil) {
 		esil->anal = core->anal;
 		r_io_bind (core->io, &core->anal->iob);

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -1962,12 +1962,13 @@ R_API void r_core_link_stroff(RCore *core, RAnalFunction *fcn) {
 	const char *varpfx;
 	int dbg_follow = r_config_get_i (core->config, "dbg.follow");
 	Sdb *TDB = core->anal->sdb_types;
-	int iotrap = r_config_get_i (core->config, "esil.iotrap");
-	int stacksize = r_config_get_i (core->config, "esil.stack.depth");
-	unsigned int addrsize = r_config_get_i (core->config, "esil.addr.size");
 	RRegItem *pc = r_reg_get (core->anal->reg, "PC", -1);
 
-	REsil *esil = r_esil_new (stacksize, iotrap, addrsize);
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = r_config_get_i (core->config, "esil.stack.depth");
+	opt.iotrap = r_config_get_i (core->config, "esil.iotrap");
+	opt.addrsize = r_config_get_i (core->config, "esil.addr.size");
+	REsil *esil = r_esil_new (&opt);
 	if (!esil) {
 		return;
 	}

--- a/libr/core/core_esil.c
+++ b/libr/core/core_esil.c
@@ -419,7 +419,12 @@ R_API bool r_core_esil_init(RCore *core) {
 		.user = core,
 		.set_bits = core_esil_set_bits,
 	};
-	if (!r_esil_init (&core->esil.esil, 4096, true, 64, &reg_if, &mem_if, &util_if)) {
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.iotrap = true;
+	opt.ifaces.reg = reg_if;
+	opt.ifaces.mem = mem_if;
+	opt.ifaces.util = util_if;
+	if (!r_esil_init (&core->esil.esil, &opt)) {
 		goto init_fail;
 	}
 	core->esil.esil.anal = core->anal;

--- a/libr/core/vmenus.c
+++ b/libr/core/vmenus.c
@@ -193,7 +193,9 @@ static void showreg(RCore *core, const char *rn, const char *desc) {
 }
 
 static REsil *visual_esil_new(RCore *core, unsigned int addrsize) {
-	REsil *esil = r_esil_new_simple (addrsize, core->anal->reg, &core->anal->iob);
+	REsilOptions opt = r_esil_options (core->anal->reg, &core->anal->iob);
+	opt.addrsize = addrsize;
+	REsil *esil = r_esil_new (&opt);
 	if (esil) {
 		if (r_esil_setup (esil, core->anal, false, false, false)) {
 			r_esil_set_pc (esil, core->addr);

--- a/libr/debug/desil.c
+++ b/libr/debug/desil.c
@@ -221,7 +221,10 @@ R_API bool r_debug_esil_stepi(RDebug *d) {
 	int ret = 1;
 	dbg = d;
 	if (!ESIL) {
-		ESIL = r_esil_new (32, true, 64);
+		REsilOptions opt = r_esil_options (NULL, NULL);
+		opt.stacksize = 32;
+		opt.iotrap = true;
+		ESIL = r_esil_new (&opt);
 		// TODO setup something?
 		if (!ESIL) {
 			return false;

--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -98,97 +98,9 @@ static bool esil_stack_alloc(REsil *esil, int stacksize) {
 	return true;
 }
 
-R_API REsil *r_esil_new(int stacksize, int iotrap, unsigned int addrsize) {
-	REsil *esil = R_NEW0 (REsil);
-	if (stacksize < 4) {
-		R_LOG_ERROR ("Esil stacksize must be at least 4 bytes");
-		free (esil);
-		return NULL;
-	}
-	if (!esil_stack_alloc (esil, stacksize)) {
-		free (esil);
-		return NULL;
-	}
-	esil->stacksize = stacksize;
-	esil->parse_goto_count = R_ESIL_GOTO_LIMIT;
-	esil->ops = esil_ops_new ();
-	esil->iotrap = iotrap;
-	r_esil_handlers_init (esil);
-	r_esil_plugins_init (esil);
-	if (R_UNLIKELY (!esil_voyeurs_init (esil))) {
-		r_esil_plugins_fini (esil);
-		r_esil_handlers_fini (esil);
-		ht_pp_free (esil->ops);
-		free (esil->stack);
-		free (esil->stack_buf);
-		free (esil);
-		return NULL;
-	}
-	esil->addrmask = r_num_genmask (addrsize - 1);
-	esil->trace = r_esil_trace_new (esil);
-	r_esil_setup_ops (esil);
-	return esil;
-}
-
-R_API bool r_esil_init(REsil *esil, int stacksize, bool iotrap, ut32 addrsize,
-	REsilRegInterface *reg_if, REsilMemInterface *mem_if, REsilUtilInterface *R_NULLABLE util_if) {
-	R_RETURN_VAL_IF_FAIL (esil && (stacksize > 2), false);
-	R_RETURN_VAL_IF_FAIL (!reg_if || (reg_if->is_reg && reg_if->reg_read &&
-		reg_if->reg_write && reg_if->reg_size), false);
-	R_RETURN_VAL_IF_FAIL (!mem_if || (mem_if->mem_read && mem_if->mem_write), false);
-	//do not check for mem_switch, as that is optional
-	if (R_UNLIKELY (!esil_stack_alloc (esil, stacksize))) {
-		return false;
-	}
-	esil->ops = esil_ops_new ();
-	if (R_UNLIKELY (!r_esil_setup_ops (esil) || !r_esil_handlers_init (esil))) {
-		goto ops_setup_fail;
-	}
-	if (R_UNLIKELY (!r_esil_plugins_init (esil))) {
-		goto plugins_fail;
-	}
-	if (R_UNLIKELY (!esil_voyeurs_init (esil))) {
-		goto voyeur_fail;
-	}
-	//not initializing stats here, it needs get reworked and should live in anal
-	//same goes for trace, probably
-	esil->stacksize = stacksize;
-	esil->parse_goto_count = R_ESIL_GOTO_LIMIT;
-	esil->iotrap = iotrap;
-	esil->addrmask = r_num_genmask (addrsize - 1);
-	if (reg_if) {
-		esil->reg_if = *reg_if;
-	}
-	if (mem_if) {
-		esil->mem_if = *mem_if;
-	}
-	if (util_if) {
-		esil->util_if = *util_if;
-	}
-	return true;
-voyeur_fail:
-	r_esil_plugins_fini (esil);
-plugins_fail:
-	r_esil_handlers_fini (esil);
-ops_setup_fail:
-	ht_pp_free (esil->ops);
-	esil->ops = NULL;
-	free (esil->stack);
-	free (esil->stack_buf);
-	return false;
-}
-
-R_API REsil *r_esil_new_ex(int stacksize, bool iotrap, ut32 addrsize,
-	REsilRegInterface *reg_if, REsilMemInterface *mem_if, REsilUtilInterface *R_NULLABLE util_if) {
-	REsil *esil = R_NEW0 (REsil);
-	if (R_UNLIKELY (!r_esil_init (esil, stacksize, iotrap,
-		addrsize, reg_if, mem_if, util_if))) {
-		free (esil);
-		return NULL;
-	}
-	return esil;
-}
-
+// Default "simple" host callbacks: registers via RReg, memory via RIOBind.
+// Used both by r_esil_options and as the fallbacks filled in by r_esil_init
+// when a host provides only a user pointer.
 static bool default_is_reg(void *reg, const char *name) {
 	RRegItem *ri = r_reg_get ((RReg *)reg, name, -1);
 	if (!ri) {
@@ -232,15 +144,6 @@ static bool default_reg_alias(void *reg, int alias, const char *name) {
 	return r_reg_alias_setname (reg, alias, name);
 }
 
-static REsilRegInterface simple_reg_if = {
-	.is_reg = default_is_reg,
-	.reg_read = default_reg_read,
-	.reg_write = (REsilRegWrite)r_reg_setv,
-	.reg_alias = default_reg_alias,
-	.reg_size = default_reg_size,
-	.reg_packed_size = default_reg_packed_size,
-};
-
 static bool simple_mem_switch(void *iob, ut32 idx) {
 	RIOBind *bnd = iob;
 	return bnd->bank_use? bnd->bank_use (bnd->io, idx): false;
@@ -256,17 +159,110 @@ static bool simple_mem_write(void *iob, ut64 addr, const ut8 *buf, int len) {
 	return bnd->write_at? bnd->write_at (bnd->io, addr, buf, len): false;
 }
 
-R_API REsil *r_esil_new_simple(ut32 addrsize, void *reg, void *iob) {
-	RIOBind *bnd = iob;
-	R_RETURN_VAL_IF_FAIL (reg && iob, NULL);
-	simple_reg_if.reg = reg;
-	REsilMemInterface simple_mem_if = {
-		.mem = bnd,
-		.mem_switch = simple_mem_switch,
-		.mem_read = simple_mem_read,
-		.mem_write = simple_mem_write,
+// Fill in any missing callback slots with the default implementations, leaving
+// host-provided ones untouched.
+static void fill_default_reg_if(REsilRegInterface *r) {
+	if (!r->is_reg) {
+		r->is_reg = default_is_reg;
+	}
+	if (!r->reg_read) {
+		r->reg_read = default_reg_read;
+	}
+	if (!r->reg_write) {
+		r->reg_write = (REsilRegWrite)r_reg_setv;
+	}
+	if (!r->reg_alias) {
+		r->reg_alias = default_reg_alias;
+	}
+	if (!r->reg_size) {
+		r->reg_size = default_reg_size;
+	}
+	if (!r->reg_packed_size) {
+		r->reg_packed_size = default_reg_packed_size;
+	}
+}
+
+static void fill_default_mem_if(REsilMemInterface *m) {
+	if (!m->mem_switch) {
+		m->mem_switch = simple_mem_switch;
+	}
+	if (!m->mem_read) {
+		m->mem_read = simple_mem_read;
+	}
+	if (!m->mem_write) {
+		m->mem_write = simple_mem_write;
+	}
+}
+
+R_API REsilOptions r_esil_options(void *reg, void *iob) {
+	REsilOptions opt = {
+		.stacksize = 4096,
+		.iotrap = false,
+		.addrsize = 64,
 	};
-	return r_esil_new_ex (4096, false, addrsize, &simple_reg_if, &simple_mem_if, NULL);
+	opt.ifaces.reg.reg = reg;
+	opt.ifaces.mem.mem = iob;
+	return opt;
+}
+
+R_API bool r_esil_init(REsil *esil, REsilOptions *R_NULLABLE opt) {
+	R_RETURN_VAL_IF_FAIL (esil, false);
+	REsilOptions defopt = r_esil_options (NULL, NULL);
+	if (!opt) {
+		opt = &defopt;
+	}
+	const int stacksize = opt->stacksize;
+	R_RETURN_VAL_IF_FAIL (stacksize > 2, false);
+	if (R_UNLIKELY (!esil_stack_alloc (esil, stacksize))) {
+		return false;
+	}
+	esil->ops = esil_ops_new ();
+	if (R_UNLIKELY (!r_esil_setup_ops (esil) || !r_esil_handlers_init (esil))) {
+		goto ops_setup_fail;
+	}
+	if (R_UNLIKELY (!r_esil_plugins_init (esil))) {
+		goto plugins_fail;
+	}
+	if (R_UNLIKELY (!esil_voyeurs_init (esil))) {
+		goto voyeur_fail;
+	}
+	//not initializing stats here, it needs get reworked and should live in anal
+	//trace is created on demand once the vm stack is set up (see aeim)
+	esil->stacksize = stacksize;
+	esil->parse_goto_count = R_ESIL_GOTO_LIMIT;
+	esil->iotrap = opt->iotrap;
+	esil->addrmask = r_num_genmask (opt->addrsize - 1);
+	esil->reg_if = opt->ifaces.reg;
+	esil->mem_if = opt->ifaces.mem;
+	esil->util_if = opt->ifaces.util;
+	// A host that only handed us a user pointer gets the simple defaults; a
+	// fully-zeroed interface is left for r_esil_setup to wire up later.
+	if (esil->reg_if.reg && !esil->reg_if.reg_read) {
+		fill_default_reg_if (&esil->reg_if);
+	}
+	if (esil->mem_if.mem && !esil->mem_if.mem_read) {
+		fill_default_mem_if (&esil->mem_if);
+	}
+	return true;
+voyeur_fail:
+	r_esil_plugins_fini (esil);
+plugins_fail:
+	r_esil_handlers_fini (esil);
+ops_setup_fail:
+	ht_pp_free (esil->ops);
+	esil->ops = NULL;
+	free (esil->stack);
+	free (esil->stack_buf);
+	return false;
+}
+
+R_API REsil *r_esil_new(REsilOptions *R_NULLABLE opt) {
+	REsil *esil = R_NEW0 (REsil);
+	if (R_UNLIKELY (!r_esil_init (esil, opt))) {
+		free (esil);
+		return NULL;
+	}
+	return esil;
 }
 
 R_API ut32 r_esil_add_voyeur(REsil *esil, void *user, void *vfn, REsilVoyeurType vt) {
@@ -367,21 +363,6 @@ R_API void r_esil_fini(REsil *esil) {
 	if (!esil) {
 		return;
 	}
-	esil_voyeurs_fini (esil);
-	r_esil_plugins_fini (esil);
-	r_esil_handlers_fini (esil);
-	ht_pp_free (esil->ops);
-	esil->ops = NULL;
-	r_esil_stack_free (esil);
-	free (esil->stack);
-	free (esil->stack_buf);
-}
-
-R_API void r_esil_free(REsil *esil) {
-	if (!esil) {
-		return;
-	}
-
 	// Try arch esil fini cb first, then anal as fallback
 	RArch *arch = R_UNWRAP3 (esil, anal, arch);
 	RArchSession *as = R_UNWRAP2 (arch, session);
@@ -403,19 +384,27 @@ R_API void r_esil_free(REsil *esil) {
 	ht_pp_free (esil->ops);
 	esil->ops = NULL;
 	sdb_free (esil->stats);
+	esil->stats = NULL;
 	r_esil_stack_free (esil);
-	free (esil->stack);
-	free (esil->stack_buf);
-
+	R_FREE (esil->stack);
+	R_FREE (esil->stack_buf);
 	r_esil_trace_free (esil->trace);
-	free (esil->cmd_intr);
-	free (esil->cmd_trap);
-	free (esil->cmd_mdev);
-	free (esil->cmd_todo);
-	free (esil->cmd_step);
-	free (esil->cmd_step_out);
-	free (esil->cmd_ioer);
-	free (esil->mdev_range);
+	esil->trace = NULL;
+	R_FREE (esil->cmd_intr);
+	R_FREE (esil->cmd_trap);
+	R_FREE (esil->cmd_mdev);
+	R_FREE (esil->cmd_todo);
+	R_FREE (esil->cmd_step);
+	R_FREE (esil->cmd_step_out);
+	R_FREE (esil->cmd_ioer);
+	R_FREE (esil->mdev_range);
+}
+
+R_API void r_esil_free(REsil *esil) {
+	if (!esil) {
+		return;
+	}
+	r_esil_fini (esil);
 	free (esil);
 }
 

--- a/libr/esil/esil_toc.c
+++ b/libr/esil/esil_toc.c
@@ -181,7 +181,9 @@ static void esil2c_setup(REsil *esil) {
 R_API REsilC *r_esil_toc_new(RAnal *anal, const int bits) {
 	R_RETURN_VAL_IF_FAIL (anal, NULL);
 	REsilC *ec = R_NEW0 (REsilC);
-	REsil *esil = r_esil_new_simple (bits, anal->reg, &anal->iob);
+	REsilOptions opt = r_esil_options (anal->reg, &anal->iob);
+	opt.addrsize = bits;
+	REsil *esil = r_esil_new (&opt);
 	if (esil) {
 		esil->anal = anal;
 		esil->user = ec;

--- a/libr/include/r_esil.h
+++ b/libr/include/r_esil.h
@@ -174,6 +174,25 @@ typedef struct r_esil_util_interface_t {
 	REsilSetBits set_bits;
 } REsilUtilInterface;
 
+// Bundle of the callback interfaces an esil talks to its host through. An
+// interface left fully zeroed is wired later by r_esil_setup. An interface
+// with a user pointer but no read callback gets the default implementations
+// at init time (reg via r_reg, mem via RIOBind).
+typedef struct r_esil_ifaces_t {
+	REsilRegInterface reg;
+	REsilMemInterface mem;
+	REsilUtilInterface util;
+} REsilIfaces;
+
+// Write-once construction options. Build one on the stack with r_esil_options
+// (or zero-init + tweak the fields) and hand it to r_esil_init / r_esil_new.
+typedef struct r_esil_options_t {
+	int stacksize;
+	bool iotrap;
+	ut32 addrsize;
+	REsilIfaces ifaces;
+} REsilOptions;
+
 typedef void (*REsilVoyeurRegRead)(void *user, const char *name, ut64 val);
 typedef void (*REsilVoyeurRegWrite)(void *user, const char *name, ut64 old, ut64 val);
 typedef void (*REsilVoyeurRegAlias)(void *user, int alias, const char *name);
@@ -213,12 +232,6 @@ typedef enum {
 #define	VOYEUR_SHIFT_LEFT	((sizeof (ut32) << 3) - VOYEUR_TYPE_BITS)
 #define	VOYEUR_TYPE_MASK	((ut32)R_ESIL_VOYEUR_HIGH_MASK << VOYEUR_SHIFT_LEFT)
 #define	MAX_VOYEURS	(UT32_MAX ^ VOYEUR_TYPE_MASK)
-
-typedef struct r_esil_options_t {
-	int nowrite;
-	int iotrap;
-	int exectrap;
-} REsilOptions;
 
 typedef struct r_esil_t {
 	struct r_anal_t *anal; // required for io, reg, and call esil_init/fini of the selected arch plugin
@@ -314,14 +327,12 @@ typedef struct r_esil_active_plugin_t {
 	void *user;
 } REsilActivePlugin;
 
-R_API REsil *r_esil_new(int stacksize, int iotrap, unsigned int addrsize);
-R_API bool r_esil_init(REsil *esil, int stacksize, bool iotrap,
-	ut32 addrsize, REsilRegInterface *reg_if, REsilMemInterface *mem_if, REsilUtilInterface *util_if);
-R_API REsil *r_esil_new_ex(int stacksize, bool iotrap, ut32 addrsize,
-	REsilRegInterface *reg_if, REsilMemInterface *mem_if, REsilUtilInterface *R_NULLABLE util_if);
-//this should replace existing r_esil_new
-R_API REsil *r_esil_new_simple(ut32 addrsize, void *reg, void *iob);
-//R_API REsil *r_esil_new_simple(ut32 addrsize, struct r_reg_t *reg, struct r_io_bind_t *iob);
+// Stack-built options for the common "simple" host: reg via r_reg, mem via
+// RIOBind. Pass NULL,NULL for an anal-backed/standalone base (interfaces wired
+// later by r_esil_setup). Tweak the returned struct's fields before use.
+R_API REsilOptions r_esil_options(void *reg, void *iob);
+R_API bool r_esil_init(REsil *esil, REsilOptions *R_NULLABLE opt);
+R_API REsil *r_esil_new(REsilOptions *R_NULLABLE opt);
 R_API ut32 r_esil_add_voyeur(REsil *esil, void *user, void *vfn, REsilVoyeurType vt);
 R_API void r_esil_del_voyeur(REsil *esil, ut32 vid);
 R_API void r_esil_reset(REsil *esil);

--- a/man/3/r_esil.3
+++ b/man/3/r_esil.3
@@ -20,15 +20,20 @@ which maintains a stack, registers, memory interfaces, and operation handlers fo
 Create and configure ESIL contexts and their runtime dependencies so they are ready
 for parsing, execution and interaction with radare2 analysis and I/O layers.
 .Pp
-.Ft REsil *
-.Fn r_esil_new "int stacksize" "int iotrap" "unsigned int addrsize"
+.Ft REsilOptions
+.Fn r_esil_options "void *reg" "void *iob"
 .Pp
-Creates a new ESIL instance with the specified stack size, I/O trap settings, and address size.
+Returns a stack-allocated REsilOptions struct prefilled with sane defaults (stacksize 4096, no iotrap, 64bit addresses). When reg and/or iob are passed they bind the simple register (RReg) and memory (RIOBind) interfaces; pass NULL,NULL for an anal-backed or standalone instance whose interfaces are wired later by r_esil_setup. Tweak the returned struct's fields before handing it to a constructor.
+.Pp
+.Ft REsil *
+.Fn r_esil_new "REsilOptions *opt"
+.Pp
+Allocates and initializes a new ESIL instance from the given options (or built-in defaults when opt is NULL).
 .Pp
 .Ft bool
-.Fn r_esil_init "REsil *esil" "int stacksize" "bool iotrap" "ut32 addrsize" "REsilRegInterface *reg_if" "REsilMemInterface *mem_if"
+.Fn r_esil_init "REsil *esil" "REsilOptions *opt"
 .Pp
-Initializes an existing ESIL structure with register and memory interfaces.
+Initializes a caller-owned ESIL structure in place from the given options. Any interface that has a user pointer but no callbacks is filled with the default implementations.
 .Pp
 .Ft void
 .Fn r_esil_free "REsil *esil"
@@ -225,7 +230,11 @@ int main(void) {
     REsilRegInterface reg_if = { .reg = NULL, .is_reg = my_is_reg, .reg_read = my_reg_read, .reg_write = my_reg_write, .reg_size = my_reg_size };
     REsilMemInterface mem_if = { .mem = NULL, .mem_read = my_mem_read, .mem_write = my_mem_write };
 
-    REsil *esil = r_esil_new_ex (128, false, 64, &reg_if, &mem_if);
+    REsilOptions opt = r_esil_options (NULL, NULL);
+    opt.stacksize = 128;
+    opt.ifaces.reg = reg_if;
+    opt.ifaces.mem = mem_if;
+    REsil *esil = r_esil_new (&opt);
     if (!esil) return -1;
 
     // Evaluate an expression that reads RAX, adds 8 and leaves the result on the stack
@@ -245,7 +254,9 @@ int main(void) {
 Low-level example: push/pop and expression-level debugging similar to the
 esil debugger (show stack, run a single operation):
 .Bd -literal -offset indent
-REsil *esil = r_esil_new (32, 0, 64);
+REsilOptions opt = r_esil_options (NULL, NULL);
+opt.stacksize = 32;
+REsil *esil = r_esil_new (&opt);
 // push two numbers, run the '+' op and inspect the result
 r_esil_pushnum (esil, 2);
 r_esil_pushnum (esil, 3);

--- a/test/unit/test_esil.c
+++ b/test/unit/test_esil.c
@@ -69,8 +69,13 @@ bool test_setup_keeps_custom_interfaces(void) {
 		.mem_read = test_mem_read,
 		.mem_write = test_mem_write,
 	};
-	REsil *esil = r_esil_new_ex (32, false, 32, &reg_if, &mem_if, NULL);
-	mu_assert_notnull (esil, "r_esil_new_ex failed");
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = 32;
+	opt.addrsize = 32;
+	opt.ifaces.reg = reg_if;
+	opt.ifaces.mem = mem_if;
+	REsil *esil = r_esil_new (&opt);
+	mu_assert_notnull (esil, "r_esil_new failed");
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "r_anal_new failed");
 
@@ -92,7 +97,10 @@ bool test_setup_keeps_custom_interfaces(void) {
 }
 
 bool test_setup_installs_default_interfaces(void) {
-	REsil *esil = r_esil_new (32, false, 32);
+	REsilOptions opt = r_esil_options (NULL, NULL);
+	opt.stacksize = 32;
+	opt.addrsize = 32;
+	REsil *esil = r_esil_new (&opt);
 	mu_assert_notnull (esil, "r_esil_new failed");
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "r_anal_new failed");

--- a/test/unit/test_esil_dfg_filter.c
+++ b/test/unit/test_esil_dfg_filter.c
@@ -12,7 +12,9 @@ bool test_filter_regs(void) {
 	r_anal_set_reg_profile (anal, NULL);
 	RIO *io = r_io_new ();
 	r_io_bind (io, &anal->iob);
-	REsil *esil = r_esil_new_simple (1, anal->reg, &anal->iob);
+	REsilOptions opt = r_esil_options (anal->reg, &anal->iob);
+	opt.addrsize = 1;
+	REsil *esil = r_esil_new (&opt);
 	esil->anal = anal;
 
 	// create expected results


### PR DESCRIPTION
r_esil_new and r_esil_init had drifted into two independent
implementations: the legacy r_esil_new took loose (stacksize, iotrap,
addrsize) args and reimplemented the init body inline (different op/
handler ordering, no error unwinding, dead trace creation), while
r_esil_init/r_esil_new_ex used the callback-interface model.

Collapse everything onto a single options-based API:

- Add REsilIfaces (reg/mem/util callback bundle) and REsilOptions
  (stacksize, iotrap, addrsize, ifaces) to r_esil.h. Drop the unused
  legacy REsilOptions (nowrite/iotrap/exectrap) type.
- r_esil_options(reg, iob) returns a stack-built options struct with
  sane defaults; callers tweak fields before use.
- r_esil_init(esil, opt) is now the single source of truth;
  r_esil_new(opt) just allocates and delegates to it. Remove
  r_esil_new_ex and r_esil_new_simple.
- Default callbacks (reg via RReg, mem via RIOBind) are filled in
  r_esil_init only when a host supplies a user pointer but no read
  callback, leaving fully custom or fully-deferred interfaces intact.
- Align fini/free: r_esil_fini is the complete teardown (now also
  releasing stats, trace, the cmd_* strings and mdev_range, running the
  arch esil fini cb and clearing anal/arch back-pointers), and
  r_esil_free is just r_esil_fini + free.
- Migrate all call sites, the unit tests and man/3/r_esil.3.