### PR TITLE
Use RStrConstPool for RConsMark names ##cons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -145,13 +145,6 @@ static void cons_grep_reset(RConsGrep *grep) {
 	}
 }
 
-static void mark_free(RConsMark *m) {
-	if (m) {
-		free (m->name);
-		free (m);
-	}
-}
-
 /*
  * Update the color_limit based on TERM environment variable.
  *
@@ -201,7 +194,7 @@ static void rcons_update_color_limit_from_term(RCons *cons) {
 static void init_cons_context(RCons *cons, RConsContext *R_NULLABLE parent) {
 	RConsContext *ctx = cons->context;
 	r_ref_init (ctx, r_cons_context_free_internal);
-	ctx->marks = r_list_newf ((RListFree)mark_free);
+	ctx->marks = r_list_newf (free);
 	ctx->breaked = false;
 	// ctx->cmd_depth = R_CONS_CMD_DEPTH + 1;
 	ctx->buffer_sz = 0;
@@ -216,6 +209,7 @@ static void init_cons_context(RCons *cons, RConsContext *R_NULLABLE parent) {
 	ctx->log_callback = NULL;
 	ctx->cmd_str_depth = 0;
 	ctx->noflush = false;
+	r_str_constpool_init (&ctx->constpool);
 	if (parent) {
 		ctx->color_mode = parent->color_mode;
 		ctx->color_limit = parent->color_limit;
@@ -1330,7 +1324,7 @@ R_API void r_cons_mark(RCons *cons, ut64 addr, const char *name) {
 	RConsContext *ctx = cons->context;
 	mark->addr = addr;
 	int row = 0, col = r_cons_get_cursor (cons, &row);
-	mark->name = strdup (name); // TODO. use a const pool instead
+	mark->name = r_str_constpool_get (&ctx->constpool, name);
 	mark->pos = ctx->buffer_len;
 	mark->col = col;
 	mark->row = row;
@@ -1343,7 +1337,7 @@ R_API RConsMark *r_cons_mark_at(RCons *cons, ut64 addr, const char *name) {
 	RConsMark *mark;
 	r_list_foreach (C->marks, iter, mark) {
 		if (R_STR_ISNOTEMPTY (name)) {
-			if (strcmp (mark->name, name)) {
+			if (!mark->name || strcmp (mark->name, name)) {
 				continue;
 			}
 			return mark;
@@ -1539,6 +1533,7 @@ R_API bool r_cons_reset_terminal(RCons *cons) {
 static void r_cons_context_free_internal(RConsContext *ctx) {
 	r_cons_context_pal_free (ctx);
 	r_stack_free (ctx->break_stack);
+	r_str_constpool_fini (&ctx->constpool);
 	r_list_free (ctx->marks);
 	r_list_free (ctx->grep.strings);
 	r_list_free (ctx->sorted_lines);
@@ -1573,8 +1568,9 @@ R_API RConsContext *r_cons_context_clone(RConsContext *R_NULLABLE ctx) {
 	if (ctx->lastOutput) {
 		c->lastOutput = r_mem_dup (ctx->lastOutput, ctx->lastLength);
 	}
+	r_str_constpool_init (&c->constpool);
 	// Don't clone marks to avoid double free issues
-	c->marks = r_list_newf ((RListFree)mark_free);
+	c->marks = r_list_newf (free);
 	if (ctx->sorted_lines) {
 		c->sorted_lines = r_list_clone (ctx->sorted_lines, (RListClone)strdup);
 	}

--- a/libr/include/r_cons.h
+++ b/libr/include/r_cons.h
@@ -82,7 +82,7 @@ typedef struct r_cons_code_colors_t {
 
 typedef struct r_cons_mark_t {
 	ut64 addr;
-	char *name;
+	const char *name;
 	int row;
 	int col;
 	int pos;
@@ -472,6 +472,7 @@ typedef struct r_cons_context_t {
 	bool flush;
 	int colors[256];
 	RList *marks;
+	RStrConstPool constpool; // Pool for mark names
 } RConsContext;
 
 #define HUD_BUF_SIZE 512


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Use RStrConstPool for storing RConsMark names instead of just strdup()'ing them (as suggested by the TODO).

<!-- explain your changes if necessary -->
