### PR TITLE
Model PPC XER.CA in ESIL for carry-arithmetic and algebraic shifts ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -438,7 +438,8 @@ static char *regs(RArchSession *as) {
 			"fpu	f28 .64 516 0\n"
 			"fpu	f29 .64 524 0\n"
 			"fpu	f30 .64 532 0\n"
-			"fpu	f31 .64 540 0\n";
+			"fpu	f31 .64 540 0\n"
+			"gpr	ca .1 292 0\n";
 		return strdup (p);
 	}
 
@@ -574,7 +575,8 @@ static char *regs(RArchSession *as) {
 		"fpu	f28 .64 720 0\n"
 		"fpu	f29 .64 728 0\n"
 		"fpu	f30 .64 736 0\n"
-		"fpu	f31 .64 744 0\n";
+		"fpu	f31 .64 744 0\n"
+		"gpr	ca .1 496 0\n";
 	return strdup (p);
 }
 
@@ -842,6 +844,33 @@ static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 			}
 		}
 		break;
+	}
+}
+
+// algebraic shift right: ca = sign(rs) & (low bits shifted out != 0); set ca before rd to stay alias-safe
+static void set_sra(RAnalOp *op, const char *rd, const char *rs, const char *cnt, bool w64, const char *mask) {
+	const char *sgn = w64? "0x8000000000000000": "0x80000000";
+	const char *lo = w64? "0xffffffffffffffff": "0xffffffff";
+	esilprintf (op, "%s,%s,&,!,!,%s,%s,&,%s,&,!,!,&,ca,=,%s,%s,ASR,%s,=",
+		sgn, rs, mask, rs, lo, cnt, rs, rd);
+}
+
+// ca = (val <unsigned a) | (cin & val==a), then store val into rd LAST so the carry stays
+// correct when rd aliases ra. wm masks val to the register width; sub uses ~ra (subf forms).
+static void set_ca(RAnalOp *op, const char *ra, const char *wm, bool sub, const char *rd, const char *cin, const char *val) {
+	const char *sb = "0x8000000000000000"; // sign bit for the unsigned-< sign flip
+	char abuf[80], v[128];
+	const char *a = ra;
+	if (sub) {
+		snprintf (abuf, sizeof (abuf), "%s,%s,^", ra, wm);
+		a = abuf;
+	}
+	snprintf (v, sizeof (v), "%s,%s,&", val, wm);
+	if (!strcmp (cin, "0")) {
+		esilprintf (op, "%s,%s,^,%s,%s,^,<,%s,%s,=,ca,=", sb, a, sb, v, val, rd);
+	} else {
+		esilprintf (op, "%s,%s,^,%s,%s,^,<,%s,%s,%s,-,!,&,|,%s,%s,=,ca,=",
+			sb, a, sb, v, cin, a, v, val, rd);
 	}
 }
 
@@ -1116,9 +1145,11 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	int ret, ridx;
 	char *op1;
 	char ea[64];
+	char vbuf[96];
 
 	PluginData *pd = as->data;
 	const char *cpu = as->config->cpu;
+	const char *cm = (as->config->bits == 32)? "0xffffffff": "0xffffffffffffffff";
 	const bool be = R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config);
 	ut8 csbuf[4];
 	memcpy (csbuf, buf, 4);
@@ -1805,12 +1836,26 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			esilprintf (op, "%s,0x40,&,!,%s,0x3f,&,%s,>>,*,%s,=", ARG (2), ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_SRAW:
-		case PPC_INS_SRAWI:
 		case PPC_INS_SRAD:
+			{
+				char m[32];
+				const bool w64 = insn->id == PPC_INS_SRAD;
+				op->sign = true;
+				op->type = R_ANAL_OP_TYPE_SAR;
+				snprintf (m, sizeof (m), "1,%s,0x3f,&,1,<<,-", ARG (2));
+				set_sra (op, ARG (0), ARG (1), ARG (2), w64, m);
+			}
+			break;
+		case PPC_INS_SRAWI:
 		case PPC_INS_SRADI:
-			op->sign = true;
-			op->type = R_ANAL_OP_TYPE_SAR;
-			esilprintf (op, "%s,%s,ASR,%s,=", ARG (2), ARG (1), ARG (0));
+			{
+				char m[24];
+				const bool w64 = insn->id == PPC_INS_SRADI;
+				op->sign = true;
+				op->type = R_ANAL_OP_TYPE_SAR;
+				snprintf (m, sizeof (m), "0x%"PFMT64x, (ut64)((1ULL << (INSOP (2).imm & (w64? 63: 31))) - 1));
+				set_sra (op, ARG (0), ARG (1), ARG (2), w64, m);
+			}
 			break;
 		case PPC_INS_CNTLZW:
 		case PPC_INS_CNTLZD:
@@ -1835,19 +1880,33 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_SUB:
 		case PPC_INS_SUBC:
 		case PPC_INS_SUBF:
+			op->type = R_ANAL_OP_TYPE_SUB;
+			esilprintf (op, "%s,%s,-,%s,=", ARG (1), ARG (2), ARG (0));
+			break;
 		case PPC_INS_SUBFIC:
 		case PPC_INS_SUBFC:
 			op->type = R_ANAL_OP_TYPE_SUB;
-			esilprintf (op, "%s,%s,-,%s,=", ARG (1), ARG (2), ARG (0));
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,-", ARG (1), ARG (2));
+			set_ca (op, ARG (1), cm, true, ARG (0), "1", vbuf);
 			break;
 		case PPC_INS_NEG:
 			op->type = R_ANAL_OP_TYPE_SUB;
 			esilprintf (op, "%s,0,-,%s,=", ARG (1), ARG (0));
 			break;
-		case PPC_INS_SUBFZE:
 		case PPC_INS_SUBFE:
+			op->type = R_ANAL_OP_TYPE_SUB;
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,^,%s,+,ca,+", ARG (1), cm, ARG (2));
+			set_ca (op, ARG (1), cm, true, ARG (0), "ca", vbuf);
+			break;
+		case PPC_INS_SUBFZE:
+			op->type = R_ANAL_OP_TYPE_SUB;
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,^,ca,+", ARG (1), cm);
+			set_ca (op, ARG (1), cm, true, ARG (0), "ca", vbuf);
+			break;
 		case PPC_INS_SUBFME:
 			op->type = R_ANAL_OP_TYPE_SUB;
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,^,%s,+,ca,+", ARG (1), cm, cm);
+			set_ca (op, ARG (1), cm, true, ARG (0), "ca", vbuf);
 			break;
 		case PPC_INS_ADD:
 		case PPC_INS_ADDI:
@@ -1868,7 +1927,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_ADDC:
 		case PPC_INS_ADDIC:
 			op->type = R_ANAL_OP_TYPE_ADD;
-			esilprintf (op, "%s,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,+", ARG (2), ARG (1));
+			set_ca (op, ARG (1), cm, false, ARG (0), "0", vbuf);
 			break;
 		case PPC_INS_ADDIS:
 			op->type = R_ANAL_OP_TYPE_ADD;
@@ -1895,10 +1955,19 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			}
 			break;
 		case PPC_INS_ADDE:
-		case PPC_INS_ADDME:
+			op->type = R_ANAL_OP_TYPE_ADD;
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,+,ca,+", ARG (2), ARG (1));
+			set_ca (op, ARG (1), cm, false, ARG (0), "ca", vbuf);
+			break;
 		case PPC_INS_ADDZE:
 			op->type = R_ANAL_OP_TYPE_ADD;
-			esilprintf (op, "%s,%s,+,%s,=", ARG (2), ARG (1), ARG (0));
+			snprintf (vbuf, sizeof (vbuf), "ca,%s,+", ARG (1));
+			set_ca (op, ARG (1), cm, false, ARG (0), "ca", vbuf);
+			break;
+		case PPC_INS_ADDME:
+			op->type = R_ANAL_OP_TYPE_ADD;
+			snprintf (vbuf, sizeof (vbuf), "%s,%s,+,ca,+", ARG (1), cm);
+			set_ca (op, ARG (1), cm, false, ARG (0), "ca", vbuf);
 			break;
 		case PPC_INS_MTSPR:
 			op->type = R_ANAL_OP_TYPE_MOV;

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1033,7 +1033,7 @@ esil: r28,0x40,&,!,r28,0x3f,&,r9,>>,*,r9,=
 --
 mnemonic: sradi
 type: sar
-esil: 0x3,r4,ASR,r4,=
+esil: 0x8000000000000000,r4,&,!,!,0x7,r4,&,0xffffffffffffffff,&,!,!,&,ca,=,0x3,r4,ASR,r4,=
 --
 mnemonic: cntlzw
 type: mov

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -351,7 +351,7 @@ e cfg.bigendian=true
 EOF
 EXPECT=<<EOF
 subfc r3, r4, r5
-0x00000000 r4,r5,-,r3,=
+0x00000000 0x8000000000000000,r4,0xffffffff,^,^,0x8000000000000000,r4,r5,-,0xffffffff,&,^,<,1,r4,0xffffffff,^,r4,r5,-,0xffffffff,&,-,!,&,|,r4,r5,-,r3,=,ca,=
 EOF
 RUN
 
@@ -490,7 +490,7 @@ rfi
 EOF
 RUN
 
-NAME=subtract from zero extended has no esil without carry model ppc-32
+NAME=subtract from zero extended carrying ppc-32
 FILE=-
 CMDS=<<EOF
 e asm.arch=ppc
@@ -502,7 +502,7 @@ pdj 1~{0.esil}
 EOF
 EXPECT=<<EOF
 subfze r3, r4
-
+0x8000000000000000,r4,0xffffffff,^,^,0x8000000000000000,r4,0xffffffff,^,ca,+,0xffffffff,&,^,<,ca,r4,0xffffffff,^,r4,0xffffffff,^,ca,+,0xffffffff,&,-,!,&,|,r4,0xffffffff,^,ca,+,r3,=,ca,=
 EOF
 RUN
 
@@ -667,5 +667,47 @@ ar f1
 EOF
 EXPECT=<<EOF
 0x4008000000000000
+EOF
+RUN
+
+NAME=addc carry-out ppc-32
+ARGS=-a ppc -e asm.bits=32 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c853014 @ 0
+aei
+aeim
+ar r5=0xffffffff
+ar r6=2
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=subfc-subfe subtract borrow chain ppc-32
+ARGS=-a ppc -e asm.bits=32 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7d253010 @ 0
+wx 7c874110 @ 4
+aei
+aeim
+ar r5=1
+ar r6=5
+ar r7=0x10
+ar r8=0x40
+aes
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000030
+0x00000001
 EOF
 RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -1706,3 +1706,310 @@ EXPECT=<<EOF2
 0x3456781230000002
 EOF2
 RUN
+
+NAME=addc carry-out ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c853014 @ 0
+aei
+aeim
+ar r5=0xffffffffffffffff
+ar r6=2
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=addc-adde 128-bit add carry chain ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7d253014 @ 0
+wx 7c874114 @ 4
+aei
+aeim
+ar r5=0xffffffffffffffff
+ar r6=1
+ar r7=0xffffffffffffffff
+ar r8=0
+aes
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+EOF
+RUN
+
+NAME=subfc-subfe 128-bit subtract borrow chain ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7d253010 @ 0
+wx 7c874110 @ 4
+aei
+aeim
+ar r5=1
+ar r6=5
+ar r7=0x10
+ar r8=0x40
+aes
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000030
+0x00000001
+EOF
+RUN
+
+NAME=addic carry-out ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 30850002 @ 0
+aei
+aeim
+ar r5=0xffffffffffffffff
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=subfic no-borrow sets carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 20850002 @ 0
+aei
+aeim
+ar r5=1
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=addze consumes carry-in ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c870194 @ 0
+aei
+aeim
+ar r7=0x100
+ar ca=1
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000101
+0x00000000
+EOF
+RUN
+
+NAME=addme consumes carry-in ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c8701d4 @ 0
+aei
+aeim
+ar r7=0x100
+ar ca=1
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000100
+0x00000001
+EOF
+RUN
+
+NAME=subfme consumes carry-in ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c8701d0 @ 0
+aei
+aeim
+ar r7=0x100
+ar ca=1
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xfffffffffffffeff
+0x00000001
+EOF
+RUN
+
+NAME=subfic borrow clears carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 20850002 @ 0
+aei
+aeim
+ar r5=5
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xfffffffffffffffd
+0x00000000
+EOF
+RUN
+
+NAME=subf does not touch carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c853050 @ 0
+aei
+aeim
+ar r5=2
+ar r6=10
+ar ca=1
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000008
+0x00000001
+EOF
+RUN
+
+NAME=srawi sets carry from shifted-out sign bits ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7ca42670 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff8
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0x00000001
+EOF
+RUN
+
+NAME=srawi on positive value clears carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7ca42670 @ 0
+aei
+aeim
+ar r5=0x1f
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=sraw register count sets carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7ca43630 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff8
+ar r6=4
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0x00000001
+EOF
+RUN
+
+NAME=sradi sets carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7ca4fe76 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff0
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0x00000001
+EOF
+RUN
+
+NAME=addc carry-out with destination aliasing first operand ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7c632014 @ 0
+aei
+aeim
+ar r3=0xffffffffffffffff
+ar r4=2
+aes
+ar r3
+ar ca
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=srad register count sets carry ppc-64
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true
+FILE=malloc://0x100
+CMDS=<<EOF
+wx 7ca43634 @ 0
+aei
+aeim
+ar r5=0xfffffffffffffff8
+ar r6=4
+aes
+ar r4
+ar ca
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds a 1-bit `ca` register to both PPC reg profiles and emits correct carry ESIL for the add/subtract-with-carry family (addc/addic/adde/addze/addme, subfc/subfic/subfe/subfze/subfme) and the algebraic shifts (sraw/srad/srawi/sradi).
  
Also corrects existing wrong/missing ESIL: adde/addze/addme ignored the carry-in entirely, and subfe/subfze/subfme emitted no ESIL at all.
  
Carry is computed by result-compare and is alias-safe (the destination is stored last, so in-place idioms like `addc r3,r3,r4` are correct). Validated against qemu-ppc64. 
