### PR TITLE
Autoresolve ppc32 small-data base into anal.gp for executables ##bin

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -56,31 +56,62 @@ static void load_gp_mips(RCore *core) {
 	r_config_set_i (core->config, "anal.gp", gp);
 }
 
-static void load_gp_ppc(RCore *core) {
-	// PPC64: set anal.gp to the TOC base (.opd[0]+8, else .toc/.got+0x8000) for ppc_cs
-	ut64 gp = UT64_MAX;
+static ut64 sda_base_sym(RCore *core) {
+	// flag prefix depends on symbol type: NOTYPE -> loc, OBJECT -> obj
+	ut64 v;
+	if (num_get (core, "loc._SDA_BASE_", &v) && v != UT64_MAX) {
+		return v;
+	}
+	if (num_get (core, "obj._SDA_BASE_", &v) && v != UT64_MAX) {
+		return v;
+	}
+	return UT64_MAX;
+}
+
+static ut64 ppc32_sda_base(RCore *core) {
+	RBinInfo *info = r_bin_get_info (core->bin);
+	if (!info || !info->type || !strstr (info->type, "EXEC")) {
+		return UT64_MAX;
+	}
+	ut64 sdata = UT64_MAX;
+	if (!num_get (core, "section..sdata", &sdata) || sdata == UT64_MAX) {
+		return UT64_MAX;
+	}
+	ut64 base = sdata + 0x8000;
+	ut64 sym = sda_base_sym (core);
+	if (sym != UT64_MAX && sym != base) {
+		// r2 isn't the SDA base (eg. ppc32 TLS pointer)
+		return UT64_MAX;
+	}
+	return base;
+}
+
+static ut64 ppc64_toc_base(RCore *core) {
 	ut64 opd = UT64_MAX;
 	if (num_get (core, "section..opd", &opd) && opd != UT64_MAX) {
 		ut8 buf[8];
 		if (r_io_read_at (core->io, opd + 8, buf, 8)) {
 			ut64 v = r_read_be64 (buf);
 			if (v && v != UT64_MAX) {
-				gp = v;
+				return v;
 			}
 		}
 	}
-	if (gp == UT64_MAX) {
-		ut64 t = UT64_MAX;
-		bool has_t = num_get (core, "section..toc", &t);
-		if (!has_t || t == UT64_MAX) {
-			has_t = num_get (core, "section..got", &t);
-		}
-		if (has_t && t != UT64_MAX) {
-			gp = t + 0x8000;
-		}
+	ut64 t = UT64_MAX;
+	bool has_t = num_get (core, "section..toc", &t);
+	if (!has_t || t == UT64_MAX) {
+		has_t = num_get (core, "section..got", &t);
 	}
+	if (has_t && t != UT64_MAX) {
+		return t + 0x8000;
+	}
+	return UT64_MAX;
+}
+
+static void load_gp_ppc(RCore *core) {
+	ut64 gp = (core->rasm->config->bits == 64)? ppc64_toc_base (core): ppc32_sda_base (core);
 	if (gp != UT64_MAX) {
-		R_LOG_DEBUG ("[ppc64] toc: 0x%"PFMT64x, gp);
+		R_LOG_DEBUG ("[ppc] gp: 0x%"PFMT64x, gp);
 		r_config_set_i (core->config, "anal.gp", gp);
 		r_reg_setv (core->anal->reg, "r2", gp);
 	}
@@ -89,19 +120,15 @@ static void load_gp_ppc(RCore *core) {
 // R2R db/cmd/cmd_eval
 static void load_gp(RCore *core) {
 	RArchConfig *cfg = core->rasm->config;
-	if (cfg) {
-		bool isppc = false;
-		bool ismips = r_str_startswith (cfg->arch, "mips");
-		if (!ismips) {
-			isppc = r_str_startswith (cfg->arch, "ppc")
-				&& cfg->bits == 64
-				&& R_ARCH_CONFIG_IS_BIG_ENDIAN (cfg);
-		}
-		if (isppc) {
-			load_gp_ppc (core);
-		} else if (ismips) {
-			load_gp_mips (core);
-		}
+	if (!cfg) {
+		return;
+	}
+	if (r_str_startswith (cfg->arch, "mips")) {
+		load_gp_mips (core);
+	} else if (r_str_startswith (cfg->arch, "ppc")
+			&& (cfg->bits == 64 || cfg->bits == 32)
+			&& R_ARCH_CONFIG_IS_BIG_ENDIAN (cfg)) {
+		load_gp_ppc (core);
 	}
 }
 

--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -69,6 +69,30 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=e anal.gp(ppc32 sda base)
+FILE=bins/elf/ppc_classes
+CMDS=e anal.gp
+EXPECT=<<EOF
+0x10028034
+EOF
+RUN
+
+NAME=e anal.gp(ppc32 no sdata, not seeded)
+FILE=bins/elf/hello.ppc
+CMDS=e anal.gp
+EXPECT=<<EOF
+0
+EOF
+RUN
+
+NAME=e anal.gp(ppc32 shared object not seeded)
+FILE=bins/elf/dropbear_powerpc-linux-gnu_gcc_-O2
+CMDS=e anal.gp
+EXPECT=<<EOF
+0
+EOF
+RUN
+
 NAME=e asm.os
 FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=e asm.os=?


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Seeds anal.gp (and r2) with the ppc32 small-data base for big-endian ELF executables, extending the existing ppc64 TOC autoresolution in load_gp().

- Base = `.sdata + 0x8000`, validated against the `_SDA_BASE_` symbol when present; bails on disagreement (TLS-pointer toolchains).
- Only applies to EXEC types; shared objects and no-sdata binaries are left unseeded.
- Refactors load_gp_ppc() into ppc64_toc_base()/ppc32_sda_base() helpers.