### PR TITLE
debug: Fix cons push leak in io reg profile

### DIFF
--- a/libr/debug/p/debug_io.c
+++ b/libr/debug/p/debug_io.c
@@ -88,6 +88,7 @@ static char *__io_reg_profile(RDebug *dbg) {
 	r_cons_push (cons);
 	char *drp = dbg->iob.system (dbg->iob.io, "drp");
 	if (drp) {
+		r_cons_pop (cons);
 		return drp;
 	}
 	const char *buf = r_cons_get_buffer (cons, NULL);
@@ -96,7 +97,7 @@ static char *__io_reg_profile(RDebug *dbg) {
 		r_cons_pop (cons);
 		return ret;
 	}
-	// r_cons_pop (cons);
+	r_cons_pop (cons);
 	return r_anal_get_reg_profile (dbg->anal);
 }
 


### PR DESCRIPTION
`__io_reg_profile` pushes the cons stack to capture the io backend's `drp` reply, but when the backend returns a profile it returns early without popping. The leaked push leaves `noflush` set on the context, so every later flush becomes a no-op and all console output is swallowed for the rest of the session.

Reproducible with any debug-io backend that answers `drp` (e.g. r2frida): `r2 -qc '?e hi' frida://0` prints nothing, while `malloc://` or native `-d` work fine. The sibling `__reg_read` already pops on every path; this brings `__io_reg_profile` in line and restores the dropped pop on the fall-through.