### PR TITLE
Memory Slice (.msl) support: io/bin/debug plugins + dgm + reverse-exec

### DIFF
--- a/dist/plugins-cfg/plugins.def.cfg
+++ b/dist/plugins-cfg/plugins.def.cfg
@@ -117,6 +117,7 @@ bin.dex
 bin.dis
 bin.dmp64
 bin.dol
+bin.msl
 bin.dyldcache
 bin.io
 bin.elf
@@ -247,6 +248,7 @@ debug.evm
 debug.rv32ima
 debug.bochs
 debug.esil
+debug.msl
 debug.gdb
 debug.io
 debug.native
@@ -309,6 +311,7 @@ io.pvm
 io.mach
 io.malloc
 io.mmap
+io.msl
 io.null
 io.procpid
 io.ptrace

--- a/dist/plugins-cfg/plugins.static.cfg
+++ b/dist/plugins-cfg/plugins.static.cfg
@@ -67,6 +67,7 @@ bin.off
 bin.coff
 bin.dex
 bin.dol
+bin.msl
 bin.elf
 bin.elf64
 bin.fs
@@ -142,6 +143,7 @@ muta.md4
 debug.bf
 debug.io
 debug.esil
+debug.msl
 debug.gdb
 debug.qnx
 debug.native
@@ -193,6 +195,7 @@ io.mach
 io.malloc
 io.sparse
 io.mmap
+io.msl
 io.procpid
 io.ptrace
 io.rap

--- a/doc/msl.md
+++ b/doc/msl.md
@@ -1,0 +1,91 @@
+# Memory Slice (.msl) support
+
+radare2 can open and emulate **Memory Slice** (`.msl`) process memory dumps
+produced by [memslicer](https://github.com/MemorySlice/memslicer). A slice is a
+static snapshot of a single process: its virtual address space (with per-page
+acquisition state) plus, when captured, the per-thread CPU registers. Because a
+slice is static, "execution" is driven by **emulation (ESIL)**.
+
+Three plugins implement the support:
+
+| Plugin | File | Role |
+|--------|------|------|
+| `io.msl`    | `libr/io/p/io_msl.c`       | Exposes the virtual address space (`msl://`), and acts as a debug IO so a slice can be opened in debug mode without spawning a process. |
+| `bin.msl`   | `libr/bin/p/bin_msl.c`    | Parses the slice as a CORE object: architecture/bits/OS, entrypoint (the captured PC), and one memory map per contiguous run of captured pages. |
+| `debug.msl` | `libr/debug/p/debug_msl.c`| Emulated debug backend: seeds the register file from the captured Thread Context and steps via ESIL. |
+
+**Compression:** lz4-compressed regions are decoded transparently by the
+`io.msl` plugin (open the slice as `msl://…`). zstd-compressed regions cannot
+be decoded — radare2 has no zstd — and read back as the fill byte with a
+warning; recapture with `memslicer … -c lz4` (or `-c none`), or use the
+Python `memslicer-emu` tool, which handles both codecs. The `bin.msl` map path
+(`r2 dump.msl`) cannot express compressed regions as file maps either, so for
+compressed slices use the `msl://` URI. **Encrypted** slices are not supported.
+Failed and unmapped pages (and unbacked addresses) read back as the fill byte.
+
+## Inspecting a slice (analysis)
+
+Open the file normally — `bin.msl` provides the maps, architecture and
+entrypoint:
+
+```
+$ r2 dump.msl
+[0x00401000]> i~type,arch,bits     # CORE, x86, 64
+[0x00401000]> om                   # memory maps (one per captured run)
+[0x00401000]> s entry0; pd 8       # disassemble from the captured PC
+[0x00401000]> px @ 0x7ffff000      # read captured memory
+```
+
+For a raw virtual-address view without bin metadata, use the `msl://` URI, which
+goes straight through `io.msl`:
+
+```
+$ r2 msl://dump.msl
+[0x00000000]> px @ 0x401000
+```
+
+## Emulated debugging (advancing execution)
+
+Open the slice as an emulated debug target. `io.msl` is a debug IO, so this does
+**not** spawn a process:
+
+```
+$ r2 -D msl -d msl://dump.msl
+```
+
+On attach the backend sets the architecture from the slice header, initializes
+the ESIL VM, enables `io.cache` (so emulated writes don't touch the dump) and
+**seeds every register from the Current thread's Thread Context**, then seeks to
+the captured program counter.
+
+Single-step and inspect with the usual debugger commands:
+
+```
+[0x00401000]> dr rip rax rbx        # registers as captured
+[0x00401000]> ds                    # step one instruction
+[0x00401000]> dr rax                # observe the change
+[0x00401000]> dso                   # step over
+[0x00401000]> db 0x401040 ; dc      # run to a breakpoint
+[0x00401000]> dr rcx=0x10           # modify a register
+[0x00401000]> pd 4 @ rip            # disassemble at the current PC
+```
+
+The backend clears `cfg.debug` after seeding so that `ds`/`dso` dispatch to the
+ESIL stepper instead of radare2's `r_debug_step` machinery (software
+breakpoints, arena swap, trace), which assumes a live ptrace process. The raw
+ESIL commands (`aes`, `aesu 0x401020`, `aer rax=...`) work as well.
+
+`dc` runs to a breakpoint via ESIL. A slice has no program exit and unmapped
+fetches read as the fill byte (which decodes as instructions), so `dc` *without*
+a breakpoint is bounded by `esil.maxsteps` (defaulted to 1,000,000 by this
+backend) rather than running forever — set `e esil.maxsteps=0` for unlimited.
+The seek follows the PC after each step (`dbg.follow=1`), so the disassembly and
+visual modes track execution.
+
+## Format reference
+
+The `.msl` binary format is specified in the
+[Memory Slice specification](https://github.com/MemorySlice). The plugins read:
+the 64/128-byte file header (`MEMSLICE` magic, OS/arch/PID), Memory Region
+blocks (`0x0001`, with the two-bit page-state map), and Thread Context blocks
+(`0x0011`, per-thread register file).

--- a/doc/msl.md
+++ b/doc/msl.md
@@ -65,10 +65,16 @@ Single-step and inspect with the usual debugger commands:
 [0x00401000]> ds                    # step one instruction
 [0x00401000]> dr rax                # observe the change
 [0x00401000]> dso                   # step over
+[0x00401000]> dsb                   # step BACK (reverse / time-travel)
 [0x00401000]> db 0x401040 ; dc      # run to a breakpoint
 [0x00401000]> dr rcx=0x10           # modify a register
 [0x00401000]> pd 4 @ rip            # disassemble at the current PC
 ```
+
+**Reverse execution.** The backend records ESIL step history
+(`esil.maxbacksteps`, default 256), so `dsb` (or `aesb`) steps execution
+*backwards*, reverting both the program counter and register/memory changes —
+useful for walking back from a fault or an interesting state in the snapshot.
 
 The backend clears `cfg.debug` after seeding so that `ds`/`dso` dispatch to the
 ESIL stepper instead of radare2's `r_debug_step` machinery (software

--- a/doc/msl.md
+++ b/doc/msl.md
@@ -82,6 +82,26 @@ backend) rather than running forever — set `e esil.maxsteps=0` for unlimited.
 The seek follows the PC after each step (`dbg.follow=1`), so the disassembly and
 visual modes track execution.
 
+## Producing a slice from radare2
+
+While debugging a process, write the current state as a slice with `dgm`
+(debug-generate memory-slice):
+
+```
+[0xphysical]> dgm dump.msl        # or just `dgm` -> <pid>.msl
+```
+
+It writes the file header, a Process Identity block, a Thread Context with the
+current thread's registers, and one Memory Region per debug map (three-state
+page map: pages that read back become Captured, the rest Failed). The integrity
+chain uses SHA-256 (radare2 has no BLAKE3; the format allows SHA-256 via
+HashAlgo 0x01). The resulting `.msl` is readable by these plugins and by
+memslicer / `memslicer-emu`.
+
+Maps are read in 1 MiB chunks; unreadable maps are skipped. By default `dgm`
+skips very large maps (over 512 MiB — e.g. the macOS dyld shared cache) so the
+dump stays small and fast; use `dgma` to include everything.
+
 ## Format reference
 
 The `.msl` binary format is specified in the

--- a/libr/bin/meson.build
+++ b/libr/bin/meson.build
@@ -27,6 +27,7 @@ r_bin_sources = [
   'p/bin_dis.c',
   'p/bin_dmp64.c',
   'p/bin_dol.c',
+  'p/bin_msl.c',
   'p/bin_dyldcache.c',
   'p/bin_elf.c',
   'p/bin_elf64.c',

--- a/libr/bin/p/bin_msl.c
+++ b/libr/bin/p/bin_msl.c
@@ -1,0 +1,407 @@
+/* radare - LGPL - Copyright 2026 - memslicer */
+
+// RBin plugin for Memory Slice (.msl) process memory dumps.
+//
+// Presents an .msl as a CORE-like object: architecture/bits/OS from the file
+// header, the program counter of the Current thread as entry0, and one memory
+// map per contiguous run of Captured pages (vaddr -> file offset of PageData).
+// Failed/Unmapped pages are left unmapped so radare2 fills them with io.0xff,
+// exactly like the ELF coredump loader.
+//
+// Open a slice with `r2 dump.msl` (default file IO). For a raw virtual-address
+// view without bin metadata, the companion io plugin handles `msl://dump.msl`.
+//
+// MVP scope: uncompressed, unencrypted slices.
+
+#include <r_bin.h>
+
+#define MSL_FILE_MAGIC "MEMSLICE"
+#define MSL_BLOCK_MAGIC "MSLC"
+#define MSL_HDR_FLAG_ENCRYPTED 0x4
+#define MSL_BLOCK_FLAG_COMPRESSED 0x1
+#define MSL_BT_MEMORY_REGION 0x0001
+#define MSL_BT_THREAD_CONTEXT 0x0011
+#define MSL_BT_END_OF_CAPTURE 0x0FFF
+#define MSL_BLOCK_HEADER_SIZE 80
+#define MSL_REG_FLAG_PC 0x1
+#define MSL_THREAD_FLAG_CURRENT 0x1
+#define MSL_MAX_PAGES (1ULL << 28)
+
+typedef struct {
+	RList *maps;       // RBinMap*
+	ut64 entry;        // PC of the Current thread
+	bool has_entry;
+	ut16 os_type;
+	ut16 arch_type;
+	int bits;
+	int compressed_skipped; // compressed regions that can't be file-mapped
+} RBinMslObj;
+
+static inline ut64 msl_pad8(ut64 n) {
+	return (n + 7) & ~(ut64)7;
+}
+
+static const char *msl_arch_str(ut16 arch, int *bits) {
+	switch (arch) {
+	case 0: *bits = 32; return "x86";   // x86
+	case 1: *bits = 64; return "x86";   // x86_64
+	case 2: *bits = 64; return "arm";   // ARM64
+	case 3: *bits = 32; return "arm";   // ARM32
+	case 4: *bits = 32; return "mips";  // MIPS32
+	case 5: *bits = 64; return "mips";  // MIPS64
+	case 6: *bits = 32; return "riscv"; // RV32
+	case 7: *bits = 64; return "riscv"; // RV64
+	case 8: *bits = 32; return "ppc";   // PPC32
+	case 9: *bits = 64; return "ppc";   // PPC64
+	default: *bits = 64; return "x86";
+	}
+}
+
+static const char *msl_os_str(ut16 os) {
+	switch (os) {
+	case 0: return "windows";
+	case 1: return "linux";
+	case 2: return "macos";
+	case 3: return "android";
+	case 4: return "ios";
+	default: return "unknown";
+	}
+}
+
+static int msl_page_state(ut8 *psm, ut64 page) {
+	ut8 byte = psm[page >> 2];
+	int bitpos = 6 - (int)((page & 3) * 2);
+	return (byte >> bitpos) & 3;
+}
+
+// Append one RBinMap per contiguous run of Captured pages in a region.
+static void msl_region_maps(RBinMslObj *o, RBuffer *b, ut64 payload_off, ut16 bflags) {
+	ut8 p[32];
+	if (r_buf_read_at (b, payload_off, p, sizeof (p)) != sizeof (p)) {
+		return;
+	}
+	if (bflags & MSL_BLOCK_FLAG_COMPRESSED) {
+		// Compressed PageData cannot be expressed as a vaddr->file-offset
+		// map. Open the slice with the `msl://` URI instead (the io plugin
+		// decompresses lz4 in memory).
+		o->compressed_skipped++;
+		return;
+	}
+	ut64 base = r_read_le64 (p);
+	ut64 size = r_read_le64 (p + 8);
+	ut8 prot = p[16];
+	ut8 psl = p[18];
+	if (psl < 10 || psl > 40 || size == 0) {
+		return;
+	}
+	ut64 page_size = 1ULL << psl;
+	if (size & (page_size - 1)) {
+		return;
+	}
+	ut64 npages = size >> psl;
+	if (npages > MSL_MAX_PAGES) {
+		return;
+	}
+	ut64 psm_bytes = msl_pad8 ((npages + 3) / 4);
+	ut8 *psm = malloc (psm_bytes? (size_t)psm_bytes: 1);
+	if (!psm) {
+		return;
+	}
+	if (psm_bytes && r_buf_read_at (b, payload_off + 32, psm, psm_bytes) != (st64)psm_bytes) {
+		free (psm);
+		return;
+	}
+	ut64 data_off = payload_off + 32 + psm_bytes;
+	int perm = ((prot & 1)? R_PERM_R: 0) | ((prot & 2)? R_PERM_W: 0) | ((prot & 4)? R_PERM_X: 0);
+
+	ut64 cap_count = 0;    // captured pages seen so far (file offset cursor)
+	ut64 run_start = 0;    // page index where current run began
+	ut64 run_foff = 0;     // file offset of current run start
+	bool in_run = false;
+	ut64 i;
+	for (i = 0; i < npages; i++) {
+		bool captured = msl_page_state (psm, i) == 0;
+		if (captured && !in_run) {
+			in_run = true;
+			run_start = i;
+			run_foff = data_off + cap_count * page_size;
+		} else if (!captured && in_run) {
+			RBinMap *m = R_NEW0 (RBinMap);
+			if (m) {
+				m->addr = base + run_start * page_size;
+				m->offset = run_foff;
+				m->size = (int)((i - run_start) * page_size);
+				m->perms = perm;
+				m->file = strdup ("msl");
+				r_list_append (o->maps, m);
+			}
+			in_run = false;
+		}
+		if (captured) {
+			cap_count++;
+		}
+	}
+	if (in_run) {
+		RBinMap *m = R_NEW0 (RBinMap);
+		if (m) {
+			m->addr = base + run_start * page_size;
+			m->offset = run_foff;
+			m->size = (int)((npages - run_start) * page_size);
+			m->perms = perm;
+			m->file = strdup ("msl");
+			r_list_append (o->maps, m);
+		}
+	}
+	free (psm);
+}
+
+// Extract the program counter from a Thread Context block payload.
+static bool msl_thread_pc(RBuffer *b, ut64 payload_off, ut64 payload_len, ut64 *pc, bool *is_current) {
+	ut8 hdr[32];
+	if (payload_len < sizeof (hdr) || r_buf_read_at (b, payload_off, hdr, sizeof (hdr)) != sizeof (hdr)) {
+		return false;
+	}
+	ut16 tflags = r_read_le16 (hdr + 16);
+	ut32 regcount = r_read_le32 (hdr + 20);
+	ut16 namelen = r_read_le16 (hdr + 24);
+	ut64 off = payload_off + 32 + msl_pad8 (namelen);
+	ut64 end = payload_off + payload_len;
+	ut32 r;
+	for (r = 0; r < regcount; r++) {
+		ut8 e[8];
+		if (off + 8 > end || r_buf_read_at (b, off, e, sizeof (e)) != sizeof (e)) {
+			return false;
+		}
+		ut8 rnamelen = e[0];
+		ut8 width = e[1];
+		ut16 rflags = r_read_le16 (e + 2);
+		ut64 name_pad = msl_pad8 (rnamelen);
+		ut64 val_off = off + 8 + name_pad;
+		if (rflags & MSL_REG_FLAG_PC) {
+			ut8 v[8] = {0};
+			int n = (width > 8)? 8: width;
+			if (r_buf_read_at (b, val_off, v, n) != n) {
+				return false;
+			}
+			*pc = r_read_le64 (v);
+			*is_current = (tflags & MSL_THREAD_FLAG_CURRENT) != 0;
+			return true;
+		}
+		off = val_off + msl_pad8 (width);
+	}
+	return false;
+}
+
+static bool msl_parse(RBinMslObj *o, RBuffer *b) {
+	ut8 h[16];
+	if (r_buf_read_at (b, 0, h, sizeof (h)) != sizeof (h)) {
+		return false;
+	}
+	if (memcmp (h, MSL_FILE_MAGIC, 8)) {
+		return false;
+	}
+	ut32 flags = r_read_le32 (h + 12);
+	if (flags & MSL_HDR_FLAG_ENCRYPTED) {
+		R_LOG_ERROR ("msl: encrypted slices are not supported yet");
+		return false;
+	}
+	ut8 header_size = h[9];
+	ut8 osarch[4];
+	if (r_buf_read_at (b, 0x30, osarch, sizeof (osarch)) == sizeof (osarch)) {
+		o->os_type = r_read_le16 (osarch);
+		o->arch_type = r_read_le16 (osarch + 2);
+	}
+	o->maps = r_list_newf (free);
+	bool have_current_pc = false;
+	ut64 fsize = r_buf_size (b);
+	ut64 off = header_size;
+	while (off + MSL_BLOCK_HEADER_SIZE <= fsize) {
+		ut8 bh[MSL_BLOCK_HEADER_SIZE];
+		if (r_buf_read_at (b, off, bh, sizeof (bh)) != sizeof (bh)) {
+			break;
+		}
+		if (memcmp (bh, MSL_BLOCK_MAGIC, 4)) {
+			break;
+		}
+		ut16 btype = r_read_le16 (bh + 4);
+		ut16 bflags = r_read_le16 (bh + 6);
+		ut32 blen = r_read_le32 (bh + 8);
+		if (blen < MSL_BLOCK_HEADER_SIZE) {
+			break;
+		}
+		ut64 payload_off = off + MSL_BLOCK_HEADER_SIZE;
+		ut64 payload_len = blen - MSL_BLOCK_HEADER_SIZE;
+		if (btype == MSL_BT_MEMORY_REGION) {
+			msl_region_maps (o, b, payload_off, bflags);
+		} else if (btype == MSL_BT_THREAD_CONTEXT && !have_current_pc) {
+			ut64 pc = 0;
+			bool is_current = false;
+			if (msl_thread_pc (b, payload_off, payload_len, &pc, &is_current)) {
+				// Prefer the Current thread; otherwise keep the first PC seen.
+				if (is_current || !o->has_entry) {
+					o->entry = pc;
+					o->has_entry = true;
+				}
+				if (is_current) {
+					have_current_pc = true;
+				}
+			}
+		} else if (btype == MSL_BT_END_OF_CAPTURE) {
+			break;
+		}
+		off += blen;
+	}
+	return true;
+}
+
+static bool check(RBinFile *bf, RBuffer *b) {
+	ut8 magic[8];
+	if (r_buf_read_at (b, 0, magic, sizeof (magic)) != sizeof (magic)) {
+		return false;
+	}
+	return !memcmp (magic, MSL_FILE_MAGIC, 8);
+}
+
+static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
+	RBinMslObj *o = R_NEW0 (RBinMslObj);
+	if (!o) {
+		return false;
+	}
+	if (!msl_parse (o, buf)) {
+		r_list_free (o->maps);
+		free (o);
+		return false;
+	}
+	if (o->compressed_skipped > 0) {
+		R_LOG_WARN ("msl: %d compressed region(s) are not mapped by the bin "
+			"plugin; open the slice as 'msl://%s' to read them (the io "
+			"plugin decompresses lz4).", o->compressed_skipped, bf->file);
+	}
+	bf->bo->bin_obj = o;
+	return true;
+}
+
+static void destroy(RBinFile *bf) {
+	if (bf && bf->bo && bf->bo->bin_obj) {
+		RBinMslObj *o = bf->bo->bin_obj;
+		r_list_free (o->maps);
+		free (o);
+		bf->bo->bin_obj = NULL;
+	}
+}
+
+static RList *maps(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
+	RBinMslObj *o = bf->bo->bin_obj;
+	RList *ret = r_list_newf (free);
+	if (!ret) {
+		return NULL;
+	}
+	RListIter *it;
+	RBinMap *m;
+	r_list_foreach (o->maps, it, m) {
+		RBinMap *c = R_NEW0 (RBinMap);
+		if (c) {
+			*c = *m;
+			c->file = m->file? strdup (m->file): NULL;
+			r_list_append (ret, c);
+		}
+	}
+	return ret;
+}
+
+// Sections with add=true are what radare2 turns into IO maps (the RBinMap
+// list is only used to rename them for CORE files). One section per captured
+// run; failed/unmapped pages stay unmapped and read back as io.0xff.
+static bool sections_vec(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, false);
+	RBinMslObj *o = bf->bo->bin_obj;
+	RVecRBinSection_clear (&bf->bo->sections_vec);
+	RListIter *it;
+	RBinMap *m;
+	int i = 0;
+	r_list_foreach (o->maps, it, m) {
+		RBinSection *s = RVecRBinSection_emplace_back (&bf->bo->sections_vec);
+		if (!s) {
+			continue;
+		}
+		memset (s, 0, sizeof (*s));
+		s->name = r_str_newf ("region.%d", i++);
+		s->paddr = m->offset;
+		s->vaddr = m->addr;
+		s->size = (ut64)(ut32)m->size;
+		s->vsize = s->size;
+		s->perm = m->perms;
+		s->add = true;
+	}
+	return true;
+}
+
+static RList *entries(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
+	RBinMslObj *o = bf->bo->bin_obj;
+	RList *ret = r_list_newf (free);
+	if (!ret || !o->has_entry) {
+		return ret;
+	}
+	RBinAddr *a = R_NEW0 (RBinAddr);
+	if (a) {
+		a->vaddr = o->entry;
+		a->paddr = o->entry;
+		a->bits = o->bits;
+		r_list_append (ret, a);
+	}
+	return ret;
+}
+
+static RBinInfo *info(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
+	RBinMslObj *o = bf->bo->bin_obj;
+	RBinInfo *ret = R_NEW0 (RBinInfo);
+	if (!ret) {
+		return NULL;
+	}
+	int bits = 64;
+	const char *arch = msl_arch_str (o->arch_type, &bits);
+	o->bits = bits;
+	ret->file = strdup (bf->file);
+	ret->type = strdup ("CORE");
+	ret->rclass = strdup ("msl");
+	ret->bclass = strdup ("Memory Slice");
+	ret->arch = strdup (arch);
+	ret->machine = strdup ("Memory Slice dump");
+	ret->os = strdup (msl_os_str (o->os_type));
+	ret->bits = bits;
+	ret->big_endian = false;
+	ret->has_va = true;
+	return ret;
+}
+
+static ut64 baddr(RBinFile *bf) {
+	return 0;
+}
+
+RBinPlugin r_bin_plugin_msl = {
+	.meta = {
+		.name = "msl",
+		.desc = "Memory Slice (.msl) process memory dump",
+		.author = "memslicer",
+		.license = "LGPL-3.0-only",
+	},
+	.load = &load,
+	.destroy = &destroy,
+	.check = &check,
+	.baddr = &baddr,
+	.entries = &entries,
+	.maps = &maps,
+	.sections_vec = &sections_vec,
+	.info = &info,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_BIN,
+	.data = &r_bin_plugin_msl,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -5289,6 +5289,14 @@ static int cmd_debug_continue(RCore *core, const char *input) {
 	// TODO: we must use this for step 'ds' too maybe...
 	switch (input[1]) {
 	case 0: // "dc"
+		if (!r_config_get_b (core->config, "cfg.debug")) {
+			// Emulated target (ESIL / msl): no live process to resume, so
+			// continue via the ESIL VM. Mirrors how "ds" dispatches to "aes"
+			// when cfg.debug is unset; stops at a breakpoint, an invalid
+			// instruction or a memory fault.
+			r_core_cmd0 (core, "aec");
+			break;
+		}
 		r_reg_arena_swap (core->dbg->reg, true);
 #if 0
 		// This has been disabled as it caused `dc; dc; ood; dc` to

--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -24,6 +24,8 @@ static RCoreHelpMessage help_msg_dg = {
 	"Usage:", "dg", "[a] ([file]) # Debug Generate CoreDump",
 	"dg", " [file]", "generate a coredump file",
 	"dga", " [file]", "generate a core-file with all memory maps",
+	"dgm", " [file]", "generate a Memory Slice (.msl) of the debuggee (skips huge maps)",
+	"dgma", " [file]", "generate a Memory Slice including all maps",
 	NULL
 };
 
@@ -6065,6 +6067,326 @@ static ut8 *getFileData(RCore *core, const char *arg, int *sz) {
 	return out;
 }
 
+// ---------------------------------------------------------------------------
+// Memory Slice (.msl) dump of the live debug session.
+//
+// Writes the producer side of the format consumed by the io/bin/debug "msl"
+// plugins and by memslicer (https://github.com/MemorySlice/memslicer): a file
+// header, Process Identity, a Thread Context with the current registers, and
+// one Memory Region per debug map (three-state page map + captured bytes). The
+// integrity chain uses SHA-256 (HashAlgo 0x01) since radare2 has no BLAKE3.
+// ---------------------------------------------------------------------------
+
+#define MSLW_HASH R_HASH_SHA256
+
+typedef struct {
+	RBuffer *out;
+	RHash *fh;        // cumulative file hash (incremental, for End-of-Capture)
+	ut8 prev[32];     // hash of the previous element (the chain)
+} MslDump;
+
+static void mslw_uuid(ut8 *u) {
+	int i;
+	for (i = 0; i < 16; i++) {
+		u[i] = (ut8)r_num_rand (256);
+	}
+	u[6] = (u[6] & 0x0f) | 0x40;  // version 4
+	u[8] = (u[8] & 0x3f) | 0x80;  // variant
+}
+
+static void mslw_sha256(const ut8 *a, ut64 alen, const ut8 *b, ut64 blen, ut8 *out32) {
+	RHash *h = r_hash_new (true, MSLW_HASH);
+	r_hash_do_begin (h, MSLW_HASH);
+	if (alen) {
+		r_hash_do_sha256 (h, a, alen);
+	}
+	if (blen) {
+		r_hash_do_sha256 (h, b, blen);
+	}
+	r_hash_do_end (h, MSLW_HASH);
+	memcpy (out32, h->digest, 32);
+	r_hash_free (h);
+}
+
+static void mslw_append_pad8(RBuffer *b, const ut8 *data, ut64 len) {
+	if (len) {
+		r_buf_append_bytes (b, data, len);
+	}
+	ut64 pad = ((len + 7) & ~(ut64)7) - len;
+	if (pad) {
+		ut8 z[8] = {0};
+		r_buf_append_bytes (b, z, pad);
+	}
+}
+
+// Emit one block: 80-byte header + 8-byte-padded payload; advance the chain.
+static void mslw_block(MslDump *d, ut16 type, const ut8 *payload, ut64 plen, bool feed_file) {
+	ut64 padded = (plen + 7) & ~(ut64)7;
+	ut8 *pl = calloc (1, padded? (size_t)padded: 8);
+	if (plen && pl) {
+		memcpy (pl, payload, plen);
+	}
+	ut8 hdr[80] = {0};
+	memcpy (hdr, "MSLC", 4);
+	r_write_le16 (hdr + 4, type);
+	r_write_le32 (hdr + 8, (ut32)(80 + padded));
+	r_write_le16 (hdr + 12, 1);  // payload version
+	mslw_uuid (hdr + 16);
+	memcpy (hdr + 48, d->prev, 32);
+	r_buf_append_bytes (d->out, hdr, 80);
+	if (padded) {
+		r_buf_append_bytes (d->out, pl, padded);
+	}
+	if (feed_file) {
+		r_hash_do_sha256 (d->fh, hdr, 80);
+		if (padded) {
+			r_hash_do_sha256 (d->fh, pl, padded);
+		}
+	}
+	mslw_sha256 (hdr, 80, pl, padded, d->prev);
+	free (pl);
+}
+
+static ut16 mslw_arch_code(const char *arch, int bits) {
+	if (arch && !strcmp (arch, "x86")) {
+		return bits == 64? 1: 0;
+	}
+	if (arch && !strcmp (arch, "arm")) {
+		return bits == 64? 2: 3;
+	}
+	return 0xFFFF;
+}
+
+static ut16 mslw_os_code(const char *os) {
+	if (os) {
+		if (strstr (os, "linux")) { return 1; }
+		if (strstr (os, "macos") || strstr (os, "darwin")) { return 2; }
+		if (strstr (os, "windows")) { return 0; }
+		if (strstr (os, "android")) { return 3; }
+		if (strstr (os, "ios")) { return 4; }
+	}
+	return 0xFFFF;
+}
+
+static bool mslw_dump(RCore *core, const char *path, bool full) {
+	if (!core->dbg || core->dbg->pid == -1) {
+		R_LOG_ERROR ("Not debugging; cannot write a memory slice");
+		return false;
+	}
+	r_debug_map_sync (core->dbg);
+	r_debug_reg_sync (core->dbg, R_REG_TYPE_ALL, false);
+
+	r_file_rm (path);
+	RBuffer *out = r_buf_new_file (path, O_RDWR | O_CREAT, 0644);
+	if (!out) {
+		R_LOG_ERROR ("Cannot create %s", path);
+		return false;
+	}
+	MslDump d = {0};
+	d.out = out;
+	d.fh = r_hash_new (true, MSLW_HASH);
+	r_hash_do_begin (d.fh, MSLW_HASH);
+
+	int bits = r_config_get_i (core->config, "asm.bits");
+	ut16 arch_type = mslw_arch_code (r_config_get (core->config, "asm.arch"), bits);
+	ut16 os_type = mslw_os_code (r_config_get (core->config, "asm.os"));
+	ut64 now_ns = r_time_now () * 1000;
+
+	// Build the Thread Context payload (current thread) first, to know whether
+	// to advertise the ThreadContexts capability bit.
+	RReg *reg = core->dbg->reg;
+	const char *pcname = r_reg_alias_getname (reg, R_REG_ALIAS_PC);
+	const char *spname = r_reg_alias_getname (reg, R_REG_ALIAS_SP);
+	RBuffer *regs = r_buf_new ();
+	ut32 regcount = 0;
+	RList *items = r_reg_get_list (reg, R_REG_TYPE_GPR);
+	RListIter *it;
+	RRegItem *item;
+	r_list_foreach (items, it, item) {
+		if (!item->name || item->size != bits) {
+			continue;  // emit canonical full-width registers only
+		}
+		int width = item->size / 8;
+		if (width < 1 || width > 8) {
+			continue;
+		}
+		ut64 val = r_reg_get_value (reg, item);
+		int nlen = (int)strlen (item->name) + 1;
+		ut8 e[8] = {0};
+		e[0] = (ut8)nlen;
+		e[1] = (ut8)width;
+		ut16 rflags = 0;
+		if (pcname && !strcmp (item->name, pcname)) {
+			rflags |= 1;
+		} else if (spname && !strcmp (item->name, spname)) {
+			rflags |= 2;
+		}
+		r_write_le16 (e + 2, rflags);
+		r_buf_append_bytes (regs, e, 8);
+		mslw_append_pad8 (regs, (const ut8 *)item->name, nlen);
+		ut8 vbuf[8] = {0};
+		r_write_le64 (vbuf, val);
+		mslw_append_pad8 (regs, vbuf, width);
+		regcount++;
+	}
+
+	ut64 cap = (1ULL << 0) | (1ULL << 8);   // MemoryRegions | ProcessIdentity
+	if (regcount > 0) {
+		cap |= (1ULL << 2);                  // ThreadContexts
+	}
+
+	// File header (64 bytes)
+	ut8 fhdr[64] = {0};
+	memcpy (fhdr, "MEMSLICE", 8);
+	fhdr[8] = 1;                  // endianness: little
+	fhdr[9] = 64;                 // header size
+	r_write_le16 (fhdr + 10, 0x0101);          // version 1.1
+	r_write_le64 (fhdr + 16, cap);
+	mslw_uuid (fhdr + 24);
+	r_write_le64 (fhdr + 40, now_ns);
+	r_write_le16 (fhdr + 48, os_type);
+	r_write_le16 (fhdr + 50, arch_type);
+	r_write_le32 (fhdr + 52, (ut32)core->dbg->pid);
+	fhdr[61] = 0x01;              // HashAlgo: SHA-256
+	r_buf_append_bytes (out, fhdr, 64);
+	r_hash_do_sha256 (d.fh, fhdr, 64);
+	mslw_sha256 (fhdr, 64, NULL, 0, d.prev);
+
+	// Block 0: Process Identity (0x0040)
+	{
+		const char *exe = (core->io && core->io->desc)? core->io->desc->name: "";
+		if (r_str_startswith (exe, "dbg://")) {
+			exe += strlen ("dbg://");
+		}
+		int elen = (int)strlen (exe) + 1;
+		RBuffer *pi = r_buf_new ();
+		ut8 h[24] = {0};
+		r_write_le16 (h + 16, (ut16)elen);       // ExePathLen
+		r_buf_append_bytes (pi, h, 24);
+		mslw_append_pad8 (pi, (const ut8 *)exe, elen);
+		ut64 sz = 0;
+		const ut8 *bytes = r_buf_data (pi, &sz);
+		mslw_block (&d, 0x0040, bytes, sz, true);
+		r_unref (pi);
+	}
+
+	// Thread Context (0x0011)
+	if (regcount > 0) {
+		RBuffer *tc = r_buf_new ();
+		ut8 h[32] = {0};
+		r_write_le64 (h, (ut64)core->dbg->tid);  // ThreadID
+		r_write_le16 (h + 16, 1);                // Flags: Current
+		h[18] = 3;                               // ThreadState: Stopped
+		r_write_le32 (h + 20, regcount);
+		r_buf_append_bytes (tc, h, 32);
+		ut64 rsz = 0;
+		const ut8 *rbytes = r_buf_data (regs, &rsz);
+		if (rsz) {
+			r_buf_append_bytes (tc, rbytes, rsz);
+		}
+		ut64 sz = 0;
+		const ut8 *bytes = r_buf_data (tc, &sz);
+		mslw_block (&d, 0x0011, bytes, sz, true);
+		r_unref (tc);
+	}
+	r_unref (regs);
+
+	// Memory Region blocks (0x0001), one per debug map.
+	// Read in 1 MiB chunks (not page-by-page) for speed; skip unreadable maps
+	// and, unless 'full', skip very large maps (e.g. the macOS dyld shared
+	// cache is multi-GB and would dominate the dump). Use "dgma" for everything.
+	const ut64 page = 4096;
+	const ut64 CHUNK = 1024 * 1024;
+	const ut64 CAP = 512ULL * 1024 * 1024;
+	ut8 *cbuf = malloc (CHUNK);
+	r_cons_break_push (core->cons, NULL, NULL);
+	RDebugMap *map;
+	r_list_foreach (core->dbg->maps, it, map) {
+		if (r_cons_is_breaked (core->cons)) {
+			break;
+		}
+		ut64 base = map->addr;
+		ut64 size = map->addr_end - map->addr;
+		if (size == 0 || (size % page) || !cbuf) {
+			continue;
+		}
+		if (!(map->perm & R_PERM_R)) {
+			continue;  // cannot read it anyway
+		}
+		if (!full && size > CAP) {
+			R_LOG_WARN ("msl: skipping large map 0x%"PFMT64x" (%"PFMT64u" MB); use dgma for a full dump",
+				base, size >> 20);
+			continue;
+		}
+		ut64 npages = size / page;
+		ut64 psm_bytes = (((npages + 3) / 4) + 7) & ~(ut64)7;
+		ut8 *psm = calloc (1, psm_bytes? (size_t)psm_bytes: 1);
+		RBuffer *pdata = r_buf_new ();
+		if (!psm || !pdata) {
+			free (psm);
+			r_unref (pdata);
+			continue;
+		}
+		ut64 done = 0, pidx = 0;
+		while (done < size && !r_cons_is_breaked (core->cons)) {
+			ut64 clen = R_MIN (CHUNK, size - done);
+			ut64 cpages = clen / page;
+			if (r_io_read_at (core->io, base + done, cbuf, (int)clen)) {
+				r_buf_append_bytes (pdata, cbuf, clen);   // whole chunk CAPTURED
+			} else {
+				ut64 j;  // partial: fall back to page granularity for this chunk
+				for (j = 0; j < cpages; j++) {
+					ut64 pi = pidx + j;
+					if (r_io_read_at (core->io, base + done + j * page, cbuf, (int)page)) {
+						r_buf_append_bytes (pdata, cbuf, page);
+					} else {
+						psm[pi >> 2] |= 1 << (6 - (int)(pi & 3) * 2);  // FAILED
+					}
+				}
+			}
+			pidx += cpages;
+			done += clen;
+		}
+		int prot = ((map->perm & R_PERM_R)? 1: 0)
+			| ((map->perm & R_PERM_W)? 2: 0)
+			| ((map->perm & R_PERM_X)? 4: 0);
+		RBuffer *mr = r_buf_new ();
+		ut8 h[32] = {0};
+		r_write_le64 (h, base);
+		r_write_le64 (h + 8, size);
+		h[16] = (ut8)prot;
+		h[18] = 12;                  // PageSizeLog2 (4096)
+		r_write_le64 (h + 24, now_ns);
+		r_buf_append_bytes (mr, h, 32);
+		r_buf_append_bytes (mr, psm, psm_bytes);
+		ut64 dsz = 0;
+		const ut8 *dbytes = r_buf_data (pdata, &dsz);
+		if (dsz) {
+			r_buf_append_bytes (mr, dbytes, dsz);
+		}
+		ut64 sz = 0;
+		const ut8 *bytes = r_buf_data (mr, &sz);
+		mslw_block (&d, 0x0001, bytes, sz, true);
+		r_unref (mr);
+		r_unref (pdata);
+		free (psm);
+	}
+	r_cons_break_pop (core->cons);
+	free (cbuf);
+
+	// End-of-Capture (0x0FFF): FileHash over everything before this block.
+	r_hash_do_end (d.fh, MSLW_HASH);
+	ut8 eoc[48] = {0};
+	memcpy (eoc, d.fh->digest, 32);
+	r_write_le64 (eoc + 32, r_time_now () * 1000);
+	mslw_block (&d, 0x0FFF, eoc, sizeof (eoc), false);
+
+	r_hash_free (d.fh);
+	r_unref (out);
+	R_LOG_INFO ("Wrote memory slice to %s", path);
+	return true;
+}
+
 static void cmd_dg(RCore *core, const char *input) {
 	if (input[1] == '?') {
 		r_core_cmd_help (core, help_msg_dg);
@@ -6096,6 +6418,14 @@ static void cmd_dg(RCore *core, const char *input) {
 			perror ("r_buf_new_file");
 		}
 		free (corefile);
+	} else if (input[1] == 'm') {  // "dgm"/"dgma" - generate a Memory Slice (.msl)
+		bool full = (input[2] == 'a');
+		const char *filename = strchr (input, ' ');
+		char *out = (filename && filename[1])
+			? r_str_trim_dup (filename + 1)
+			: r_str_newf ("%d.msl", core->dbg->pid);
+		mslw_dump (core, out, full);
+		free (out);
 	} else {
 		r_core_return_invalid_command (core, "dg", input[1]);
 	}

--- a/libr/debug/meson.build
+++ b/libr/debug/meson.build
@@ -15,6 +15,7 @@ r_debug_sources = [
   'p/debug_bf.c',
   'p/debug_bochs.c',
   'p/debug_esil.c',
+  'p/debug_msl.c',
   #'p/debug_rv32ima.c',
   'p/debug_gdb.c',
   'p/debug_io.c',

--- a/libr/debug/p/debug_msl.c
+++ b/libr/debug/p/debug_msl.c
@@ -158,6 +158,10 @@ static void msl_ensure(RDebug *dbg) {
 	// without a breakpoint would run forever. Bound it; override with
 	// `e esil.maxsteps=0` for unlimited.
 	dbg->coreb.cmd (core, "e esil.maxsteps=1000000");
+	// Enable ESIL step-back recording (reverse/time-travel debugging via
+	// dsb/aesb). The config callback only applies once esil.reg exists, i.e.
+	// after aei, so (re)set it here.
+	dbg->coreb.cmd (core, "e esil.maxbacksteps=256");
 	// Follow the PC after each step (the default 32-byte threshold leaves the
 	// seek behind for small instructions).
 	dbg->coreb.cmd (core, "e dbg.follow=1");

--- a/libr/debug/p/debug_msl.c
+++ b/libr/debug/p/debug_msl.c
@@ -254,6 +254,66 @@ static char *__msl_reg_profile(RDebug *dbg) {
 	return r_anal_get_reg_profile (dbg->anal);
 }
 
+// Expose the captured memory regions as debug maps (so dm/om work and `dgm`
+// can re-dump). Uncompressed regions only.
+static RList *__msl_map_get(RDebug *dbg) {
+	RCore *core = dbg->coreb.core;
+	const char *path = (core && core->io && core->io->desc)? core->io->desc->name: NULL;
+	if (!path) {
+		return NULL;
+	}
+	if (r_str_startswith (path, "msl://")) {
+		path += strlen ("msl://");
+	}
+	RBuffer *b = r_buf_new_mmap (path, R_PERM_R);
+	if (!b) {
+		return NULL;
+	}
+	RList *list = r_list_newf ((RListFree)r_debug_map_free);
+	ut8 h[16];
+	if (r_buf_read_at (b, 0, h, sizeof (h)) != sizeof (h) || memcmp (h, MSL_FILE_MAGIC, 8)
+			|| (r_read_le32 (h + 12) & MSL_HDR_FLAG_ENCRYPTED)) {
+		r_unref (b);
+		return list;
+	}
+	ut64 fsize = r_buf_size (b);
+	ut64 off = h[9];
+	while (off + MSL_BLOCK_HEADER_SIZE <= fsize) {
+		ut8 bh[MSL_BLOCK_HEADER_SIZE];
+		if (r_buf_read_at (b, off, bh, sizeof (bh)) != sizeof (bh) || memcmp (bh, MSL_BLOCK_MAGIC, 4)) {
+			break;
+		}
+		ut16 btype = r_read_le16 (bh + 4);
+		ut16 bflags = r_read_le16 (bh + 6);
+		ut32 blen = r_read_le32 (bh + 8);
+		if (blen < MSL_BLOCK_HEADER_SIZE) {
+			break;
+		}
+		if (btype == 0x0001 && !(bflags & 1)) {  // uncompressed Memory Region
+			ut8 p[32];
+			if (r_buf_read_at (b, off + MSL_BLOCK_HEADER_SIZE, p, sizeof (p)) == sizeof (p)) {
+				ut64 base = r_read_le64 (p);
+				ut64 size = r_read_le64 (p + 8);
+				ut8 prot = p[16];
+				int perm = ((prot & 1)? R_PERM_R: 0) | ((prot & 2)? R_PERM_W: 0)
+					| ((prot & 4)? R_PERM_X: 0);
+				char *nm = strdup ("msl");
+				RDebugMap *m = r_debug_map_new (nm, base, base + size, perm, 0);
+				free (nm);
+				if (m) {
+					r_list_append (list, m);
+				}
+			}
+		}
+		if (btype == 0x0FFF) {
+			break;
+		}
+		off += blen;
+	}
+	r_unref (b);
+	return list;
+}
+
 // Mirror the ESIL/anal register arena so `dr` reflects emulation progress.
 static bool __msl_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
 	RCore *core = dbg->coreb.core;
@@ -294,6 +354,7 @@ RDebugPlugin r_debug_plugin_msl = {
 	.reg_profile = &__msl_reg_profile,
 	.reg_read = &__msl_reg_read,
 	.reg_write = &__msl_reg_write,
+	.map_get = &__msl_map_get,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/debug/p/debug_msl.c
+++ b/libr/debug/p/debug_msl.c
@@ -1,0 +1,305 @@
+/* radare - LGPL - Copyright 2026 - memslicer */
+
+// Debug backend for Memory Slice (.msl) process memory dumps.
+//
+// A .msl is a static snapshot, so "execution" is driven by emulation: this
+// backend wires the standard debugger commands (ds / dso / dc / dr) onto
+// radare2's ESIL engine. On attach it initializes the ESIL VM and seeds the
+// full register file from the Current thread's Thread Context block (0x0011),
+// so stepping resumes from the real captured CPU state.
+//
+// Usage:  r2 -d msl://dump.msl      (or:  r2 dump.msl; e dbg.backend=msl; ood)
+//
+// Memory comes from the maps created by the bin/io plugins; this backend only
+// provides registers + stepping. MVP scope: uncompressed, unencrypted slices.
+
+#include <r_core.h>
+#include <r_debug.h>
+
+#define MSL_FILE_MAGIC "MEMSLICE"
+#define MSL_BLOCK_MAGIC "MSLC"
+#define MSL_HDR_FLAG_ENCRYPTED 0x4
+#define MSL_BT_THREAD_CONTEXT 0x0011
+#define MSL_BT_END_OF_CAPTURE 0x0FFF
+#define MSL_BLOCK_HEADER_SIZE 80
+#define MSL_THREAD_FLAG_CURRENT 0x1
+
+static inline ut64 msl_pad8(ut64 n) {
+	return (n + 7) & ~(ut64)7;
+}
+
+static const char *msl_arch_str(ut16 arch, int *bits) {
+	switch (arch) {
+	case 0: *bits = 32; return "x86";
+	case 1: *bits = 64; return "x86";
+	case 2: *bits = 64; return "arm";
+	case 3: *bits = 32; return "arm";
+	case 4: *bits = 32; return "mips";
+	case 5: *bits = 64; return "mips";
+	case 8: *bits = 32; return "ppc";
+	case 9: *bits = 64; return "ppc";
+	default: *bits = 64; return "x86";
+	}
+}
+
+// Seed core->anal->reg from the Thread Context register file of the open
+// buffer. Prefers the Current thread; falls back to the first thread context.
+static void msl_seed_regs(RCore *core, RBuffer *b) {
+	RReg *reg = core->anal->reg;
+	ut8 h[16];
+	if (r_buf_read_at (b, 0, h, sizeof (h)) != sizeof (h)) {
+		return;
+	}
+	ut64 fsize = r_buf_size (b);
+	ut64 off = h[9];
+	while (off + MSL_BLOCK_HEADER_SIZE <= fsize) {
+		ut8 bh[MSL_BLOCK_HEADER_SIZE];
+		if (r_buf_read_at (b, off, bh, sizeof (bh)) != sizeof (bh) || memcmp (bh, MSL_BLOCK_MAGIC, 4)) {
+			break;
+		}
+		ut16 btype = r_read_le16 (bh + 4);
+		ut32 blen = r_read_le32 (bh + 8);
+		if (blen < MSL_BLOCK_HEADER_SIZE) {
+			break;
+		}
+		if (btype == MSL_BT_THREAD_CONTEXT) {
+			ut8 th[32];
+			if (r_buf_read_at (b, off + MSL_BLOCK_HEADER_SIZE, th, sizeof (th)) == sizeof (th)) {
+				ut16 tflags = r_read_le16 (th + 16);
+				ut32 regcount = r_read_le32 (th + 20);
+				ut16 namelen = r_read_le16 (th + 24);
+				ut64 ro = off + MSL_BLOCK_HEADER_SIZE + 32 + msl_pad8 (namelen);
+				ut32 i;
+				for (i = 0; i < regcount; i++) {
+					ut8 e[8];
+					if (r_buf_read_at (b, ro, e, sizeof (e)) != sizeof (e)) {
+						break;
+					}
+					ut8 rnamelen = e[0];
+					ut8 width = e[1];
+					char name[64] = {0};
+					if (rnamelen > 0 && rnamelen < sizeof (name)) {
+						r_buf_read_at (b, ro + 8, (ut8 *)name, rnamelen);
+						name[sizeof (name) - 1] = 0;
+					}
+					ut8 v[8] = {0};
+					int n = (width > 8)? 8: width;
+					r_buf_read_at (b, ro + 8 + msl_pad8 (rnamelen), v, n);
+					if (*name) {
+						RRegItem *ri = r_reg_get (reg, name, -1);
+						if (ri) {
+							r_reg_set_value (reg, ri, r_read_le64 (v));
+						}
+					}
+					ro += 8 + msl_pad8 (rnamelen) + msl_pad8 (width);
+				}
+				if (tflags & MSL_THREAD_FLAG_CURRENT) {
+					break; // Current thread wins; stop here
+				}
+			}
+		} else if (btype == MSL_BT_END_OF_CAPTURE) {
+			break;
+		}
+		off += blen;
+	}
+	r_unref (b);
+}
+
+// One-time-per-core initialization: set up the ESIL VM, seed the register
+// file from the Thread Context, and seek to the captured PC. Tracked by core
+// pointer so reopening a different slice re-initializes.
+static void *g_inited_core = NULL;
+
+static void msl_ensure(RDebug *dbg) {
+	RCore *core = dbg->coreb.core;
+	if (!core || g_inited_core == core) {
+		return;
+	}
+	g_inited_core = core;
+	dbg->pid = 1;
+	dbg->tid = 1;
+	// Force hard stepping: r_debug_step must call our plugin->step (which
+	// drives ESIL), not the software-breakpoint step_soft path which assumes
+	// a real process. Set the struct field directly so it takes effect before
+	// the first `ds` (the cached config value would apply too late).
+	dbg->options.swstep = false;
+	const char *path = (core->io && core->io->desc)? core->io->desc->name: NULL;
+	if (!path) {
+		return;
+	}
+	if (r_str_startswith (path, "msl://")) {
+		path += strlen ("msl://");
+	}
+	RBuffer *b = r_buf_new_mmap (path, R_PERM_R);
+	if (!b) {
+		return;
+	}
+	ut8 h[16];
+	if (r_buf_read_at (b, 0, h, sizeof (h)) != sizeof (h) || memcmp (h, MSL_FILE_MAGIC, 8)
+			|| (r_read_le32 (h + 12) & MSL_HDR_FLAG_ENCRYPTED)) {
+		r_unref (b);
+		return;
+	}
+	// Set the architecture from the file header BEFORE initializing ESIL, so
+	// the register profile matches (over msl:// there is no bin to do this).
+	ut8 ab[4];
+	if (r_buf_read_at (b, 0x30, ab, sizeof (ab)) == sizeof (ab) && dbg->coreb.cmdf) {
+		int bits = 64;
+		const char *arch = msl_arch_str (r_read_le16 (ab + 2), &bits);
+		dbg->coreb.cmdf (core, "e asm.arch=%s", arch);
+		dbg->coreb.cmdf (core, "e asm.bits=%d", bits);
+	}
+	// Capture ESIL writes into the io cache (the dump itself is read-only)
+	// and step via the plugin (hard step) rather than software breakpoints.
+	dbg->coreb.cmd (core, "e io.cache=true");
+	dbg->coreb.cmd (core, "e dbg.swstep=false");
+	// Safety net: a snapshot has no program exit, and unmapped fetches read
+	// back as the fill byte (which decodes as instructions), so `dc`/`aec`
+	// without a breakpoint would run forever. Bound it; override with
+	// `e esil.maxsteps=0` for unlimited.
+	dbg->coreb.cmd (core, "e esil.maxsteps=1000000");
+	// Follow the PC after each step (the default 32-byte threshold leaves the
+	// seek behind for small instructions).
+	dbg->coreb.cmd (core, "e dbg.follow=1");
+	// The emulator is the source of truth for registers; r2's debug trace
+	// would re-read PC at sync points and fight the ESIL state.
+	if (dbg->trace) {
+		dbg->trace->enabled = false;
+	}
+	dbg->coreb.cmd (core, "aei");
+	// The debugger register arena was built with the host arch at startup;
+	// rebuild it with the (now arch-correct) anal/ESIL profile so that
+	// dr / trace_pc read the right register slots.
+	char *prof = r_anal_get_reg_profile (core->anal);
+	if (prof) {
+		r_reg_set_profile_string (dbg->reg, prof);
+		free (prof);
+	}
+	msl_seed_regs (core, b);
+	r_unref (b);
+	// Seek to the captured program counter.
+	const char *pcname = r_reg_alias_getname (core->anal->reg, R_REG_ALIAS_PC);
+	if (pcname && dbg->coreb.cmdf) {
+		RRegItem *pc = r_reg_get (core->anal->reg, pcname, -1);
+		if (pc) {
+			dbg->coreb.cmdf (core, "s 0x%"PFMT64x, r_reg_get_value (core->anal->reg, pc));
+		}
+	}
+	// Pull the seeded ESIL/anal register state into the debugger arena so the
+	// r_debug step machinery (PC, trace) sees the captured values.
+	r_debug_reg_sync (dbg, R_REG_TYPE_ALL, false);
+	// Route ds/dso/dc to the ESIL stepper: with cfg.debug set, those commands
+	// go through r_debug_step (arena swap + trace + recoil) which assumes a
+	// live ptrace process and breaks on a static, emulated snapshot. With it
+	// cleared, the debug command handlers dispatch to ESIL (aes/aec) instead.
+	dbg->coreb.cmd (core, "e cfg.debug=false");
+}
+
+static bool __msl_attach(RDebug *dbg, int pid) {
+	RCore *core = dbg->coreb.core;
+	if (!core) {
+		return false;
+	}
+	g_inited_core = NULL; // force re-init on explicit attach
+	msl_ensure (dbg);
+	return true;
+}
+
+static bool __msl_detach(RDebug *dbg, int pid) {
+	return true;
+}
+
+static bool __msl_step(RDebug *dbg) {
+	RCore *core = dbg->coreb.core;
+	if (!core) {
+		return false;
+	}
+	msl_ensure (dbg);
+	// r2 re-enables these when entering debug mode (after attach); keep them
+	// off at step time so ESIL stepping isn't fought by trace/software-step.
+	if (dbg->trace) {
+		dbg->trace->enabled = false;
+	}
+	dbg->options.swstep = false;
+	dbg->coreb.cmd (core, "aes");
+	return true;
+}
+
+static bool __msl_step_over(RDebug *dbg) {
+	RCore *core = dbg->coreb.core;
+	if (!core) {
+		return false;
+	}
+	msl_ensure (dbg);
+	dbg->coreb.cmd (core, "aeso");
+	return true;
+}
+
+static bool __msl_continue(RDebug *dbg, int pid, int tid, int sig) {
+	RCore *core = dbg->coreb.core;
+	if (!core) {
+		return false;
+	}
+	msl_ensure (dbg);
+	// ESIL continue: runs until a breakpoint, trap or invalid instruction.
+	dbg->coreb.cmd (core, "aec");
+	return true;
+}
+
+static RDebugReasonType __msl_wait(RDebug *dbg, int pid) {
+	return R_DEBUG_REASON_NONE;
+}
+
+static char *__msl_reg_profile(RDebug *dbg) {
+	return r_anal_get_reg_profile (dbg->anal);
+}
+
+// Mirror the ESIL/anal register arena so `dr` reflects emulation progress.
+static bool __msl_reg_read(RDebug *dbg, int type, ut8 *buf, int size) {
+	RCore *core = dbg->coreb.core;
+	msl_ensure (dbg);
+	RReg *reg = (core && core->anal)? core->anal->reg: dbg->reg;
+	int sz = 0;
+	ut8 *bytes = r_reg_get_bytes (reg, type, &sz);
+	if (!bytes) {
+		return false;
+	}
+	memcpy (buf, bytes, R_MIN (size, sz));
+	free (bytes);
+	return true;
+}
+
+static bool __msl_reg_write(RDebug *dbg, int type, const ut8 *buf, int size) {
+	RCore *core = dbg->coreb.core;
+	RReg *reg = (core && core->anal)? core->anal->reg: dbg->reg;
+	return r_reg_set_bytes (reg, type, buf, size);
+}
+
+RDebugPlugin r_debug_plugin_msl = {
+	.meta = {
+		.name = "msl",
+		.author = "memslicer",
+		.desc = "Memory Slice (.msl) emulated debug backend (ESIL)",
+		.license = "LGPL-3.0-only",
+	},
+	.arch = "any",
+	.bits = R_SYS_BITS_PACK2 (32, 64),
+	.canstep = 1,
+	.attach = &__msl_attach,
+	.detach = &__msl_detach,
+	.step = &__msl_step,
+	.step_over = &__msl_step_over,
+	.cont = &__msl_continue,
+	.wait = &__msl_wait,
+	.reg_profile = &__msl_reg_profile,
+	.reg_read = &__msl_reg_read,
+	.reg_write = &__msl_reg_write,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_DBG,
+	.data = &r_debug_plugin_msl,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -1079,6 +1079,7 @@ extern RBinPlugin r_bin_plugin_dex;
 extern RBinPlugin r_bin_plugin_dis;
 extern RBinPlugin r_bin_plugin_dmp64;
 extern RBinPlugin r_bin_plugin_dol;
+extern RBinPlugin r_bin_plugin_msl;
 extern RBinPlugin r_bin_plugin_dyldcache;
 extern RBinPlugin r_bin_plugin_elf;
 extern RBinPlugin r_bin_plugin_elf64;

--- a/libr/include/r_debug.h
+++ b/libr/include/r_debug.h
@@ -701,6 +701,7 @@ static inline void *r_debug_ptrace_func(RDebug *dbg, void *(*func)(void *), void
 /* plugin pointers */
 extern RDebugPlugin r_debug_plugin_native;
 extern RDebugPlugin r_debug_plugin_esil;
+extern RDebugPlugin r_debug_plugin_msl;
 extern RDebugPlugin r_debug_plugin_rap;
 extern RDebugPlugin r_debug_plugin_gdb;
 extern RDebugPlugin r_debug_plugin_bf;

--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -671,6 +671,7 @@ extern RIOPlugin r_io_plugin_ihex;
 extern RIOPlugin r_io_plugin_srec;
 extern RIOPlugin r_io_plugin_self;
 extern RIOPlugin r_io_plugin_gzip;
+extern RIOPlugin r_io_plugin_msl;
 extern RIOPlugin r_io_plugin_winkd;
 extern RIOPlugin r_io_plugin_r2pipe;
 extern RIOPlugin r_io_plugin_r2web;

--- a/libr/io/meson.build
+++ b/libr/io/meson.build
@@ -37,6 +37,7 @@ r_io_sources = [
   'p/io_xattr.c',
   'p/io_xalz.c',
   'p/io_mmap.c',
+  'p/io_msl.c',
   'p/io_null.c',
   'p/io_procpid.c',
   'p/io_ptrace.c',

--- a/libr/io/p/io_msl.c
+++ b/libr/io/p/io_msl.c
@@ -1,0 +1,524 @@
+/* radare - LGPL - Copyright 2026 - memslicer */
+
+// IO plugin for Memory Slice (.msl) process memory dumps.
+//
+// The plugin exposes the captured process *virtual* address space: an IO
+// offset is interpreted as a virtual address. Each Memory Region block
+// (type 0x0001) is indexed at open time; reads translate the requested
+// address to the matching page in the region's PageData, honoring the
+// three-state page map (Captured / Failed / Unmapped). Failed, unmapped
+// and unbacked addresses read back as the IO fill byte.
+//
+// MVP scope: uncompressed, unencrypted slices. Compressed regions are
+// indexed but read back as fill bytes (decode is future work); encrypted
+// files are rejected.
+
+#include <r_io.h>
+
+#define MSL_FILE_MAGIC "MEMSLICE"
+#define MSL_BLOCK_MAGIC "MSLC"
+#define MSL_HDR_FLAG_ENCRYPTED 0x4
+#define MSL_BLOCK_FLAG_COMPRESSED 0x1
+#define MSL_COMPALGO_ZSTD 1
+#define MSL_COMPALGO_LZ4 2
+#define MSL_BT_MEMORY_REGION 0x0001
+#define MSL_BT_END_OF_CAPTURE 0x0FFF
+#define MSL_BLOCK_HEADER_SIZE 80
+// Guard against absurd page counts from a corrupt region (256M pages).
+#define MSL_MAX_PAGES (1ULL << 28)
+
+typedef struct {
+	ut64 vaddr;      // region base virtual address
+	ut64 vsize;      // region size in bytes
+	ut32 psl;        // page size log2
+	ut64 npages;
+	ut64 data_off;   // offset of PageData within the source (file or mem)
+	ut32 *cumcap;    // cumcap[i] = captured pages in [0, i); length npages + 1
+	ut8 *mem;        // decompressed payload (NULL = read PageData from file)
+} RMslRegion;
+
+typedef struct {
+	RBuffer *b;
+	RMslRegion *regions;
+	int nregions;
+	ut64 cur;        // current virtual address
+	ut64 maxaddr;    // highest vaddr + vsize seen
+	int pid;         // PID from the file header (for debug mode)
+	int unsupported_comp; // regions skipped due to an undecodable codec (zstd)
+} RIOMsl;
+
+static inline ut64 msl_pad8(ut64 n) {
+	return (n + 7) & ~(ut64)7;
+}
+
+// Decompress one LZ4 block. memslicer emits `lz4.block` (size-prefixed); the
+// caller passes the raw block (after the 4-byte size prefix) and the exact
+// uncompressed length, so decoding stops once `dlen` bytes are produced and
+// any trailing 8-byte alignment padding is ignored. Returns bytes written or
+// -1 on malformed input.
+static int msl_lz4_block(const ut8 *src, int slen, ut8 *dst, int dlen) {
+	int sp = 0, dp = 0;
+	while (dp < dlen) {
+		if (sp >= slen) {
+			return -1;
+		}
+		ut8 token = src[sp++];
+		int litlen = token >> 4;
+		if (litlen == 15) {
+			ut8 e;
+			do {
+				if (sp >= slen) {
+					return -1;
+				}
+				e = src[sp++];
+				litlen += e;
+			} while (e == 255);
+		}
+		if (litlen > dlen - dp || litlen > slen - sp) {
+			return -1;
+		}
+		memcpy (dst + dp, src + sp, litlen);
+		dp += litlen;
+		sp += litlen;
+		if (dp >= dlen) {
+			break; // final literal run
+		}
+		if (sp + 2 > slen) {
+			return -1;
+		}
+		int offset = src[sp] | (src[sp + 1] << 8);
+		sp += 2;
+		if (offset == 0 || offset > dp) {
+			return -1;
+		}
+		int matchlen = token & 0xf;
+		if (matchlen == 15) {
+			ut8 e;
+			do {
+				if (sp >= slen) {
+					return -1;
+				}
+				e = src[sp++];
+				matchlen += e;
+			} while (e == 255);
+		}
+		matchlen += 4;
+		if (matchlen > dlen - dp) {
+			matchlen = dlen - dp;
+		}
+		int mpos = dp - offset;
+		int k;
+		for (k = 0; k < matchlen; k++) {
+			dst[dp + k] = dst[mpos + k];
+		}
+		dp += matchlen;
+	}
+	return dp;
+}
+
+static int msl_page_state(ut8 *psm, ut64 page) {
+	ut8 byte = psm[page >> 2];
+	int bitpos = 6 - (int)((page & 3) * 2);
+	return (byte >> bitpos) & 3;
+}
+
+// Decompress a compressed region payload into a freshly malloc'd buffer.
+// On-disk layout (spec 4.2.1): UncompressedSize(8B) + CompressedData, padded.
+// memslicer's lz4 codec is `lz4.block` (a 4-byte size prefix then the block).
+// Returns the buffer (caller frees) and sets *out_len, or NULL on failure /
+// unsupported codec (zstd has no decoder in radare2).
+static ut8 *msl_decompress_payload(RIOMsl *mo, ut64 payload_off, ut32 blen,
+		int algo, ut64 *out_len) {
+	if (algo != MSL_COMPALGO_LZ4) {
+		mo->unsupported_comp++;   // zstd / unknown: cannot decode here
+		return NULL;
+	}
+	if (blen < MSL_BLOCK_HEADER_SIZE + 8 + 4) {
+		return NULL;
+	}
+	ut8 szbuf[8];
+	if (r_buf_read_at (mo->b, payload_off, szbuf, 8) != 8) {
+		return NULL;
+	}
+	ut64 ulen = r_read_le64 (szbuf);
+	if (ulen == 0 || ulen > (1ULL << 32)) {
+		return NULL;
+	}
+	ut64 comp_len = (ut64)blen - MSL_BLOCK_HEADER_SIZE - 8;
+	ut8 *cbuf = malloc ((size_t)comp_len);
+	if (!cbuf) {
+		return NULL;
+	}
+	if (r_buf_read_at (mo->b, payload_off + 8, cbuf, comp_len) != (st64)comp_len) {
+		free (cbuf);
+		return NULL;
+	}
+	ut8 *mem = malloc ((size_t)ulen);
+	if (!mem) {
+		free (cbuf);
+		return NULL;
+	}
+	// Skip the 4-byte lz4.block size prefix; decode the raw block.
+	int n = msl_lz4_block (cbuf + 4, (int)(comp_len - 4), mem, (int)ulen);
+	free (cbuf);
+	if (n != (int)ulen) {
+		R_LOG_WARN ("msl: lz4 decode failed for a compressed region");
+		free (mem);
+		return NULL;
+	}
+	*out_len = ulen;
+	return mem;
+}
+
+static bool msl_add_region(RIOMsl *mo, ut64 payload_off, ut16 bflags, ut32 blen) {
+	ut8 *mem = NULL;       // decompressed payload (compressed regions)
+	ut64 mem_len = 0;
+	if (bflags & MSL_BLOCK_FLAG_COMPRESSED) {
+		mem = msl_decompress_payload (mo, payload_off, blen,
+			(bflags >> 1) & 3, &mem_len);
+		if (!mem) {
+			return false;
+		}
+	}
+
+	// Read the fixed 32-byte region header from the decompressed buffer or
+	// straight from the file.
+	ut8 p[32];
+	if (mem) {
+		if (mem_len < 32) {
+			free (mem);
+			return false;
+		}
+		memcpy (p, mem, 32);
+	} else if (r_buf_read_at (mo->b, payload_off, p, sizeof (p)) != sizeof (p)) {
+		return false;
+	}
+	ut64 base = r_read_le64 (p);
+	ut64 size = r_read_le64 (p + 8);
+	ut8 psl = p[18];
+	if (psl < 10 || psl > 40) {
+		R_LOG_WARN ("msl: skipping region @ 0x%"PFMT64x" with invalid PageSizeLog2 %d", base, psl);
+		free (mem);
+		return false;
+	}
+	ut64 page_size = 1ULL << psl;
+	if (size == 0 || (size & (page_size - 1))) {
+		R_LOG_WARN ("msl: skipping region @ 0x%"PFMT64x" with misaligned size", base);
+		free (mem);
+		return false;
+	}
+	ut64 npages = size >> psl;
+	if (npages > MSL_MAX_PAGES) {
+		R_LOG_WARN ("msl: skipping oversized region @ 0x%"PFMT64x" (%"PFMT64u" pages)", base, npages);
+		free (mem);
+		return false;
+	}
+	ut64 psm_bytes = msl_pad8 ((npages + 3) / 4);
+
+	// Locate the PageStateMap (in mem or file) and the PageData offset.
+	ut64 data_off;
+	ut8 *psm_tmp = NULL;
+	const ut8 *psm;
+	if (mem) {
+		if (32 + psm_bytes > mem_len) {
+			free (mem);
+			return false;
+		}
+		psm = mem + 32;
+		data_off = 32 + psm_bytes;            // offset within mem
+	} else {
+		data_off = payload_off + 32 + psm_bytes;  // file offset
+		psm_tmp = malloc (psm_bytes? (size_t)psm_bytes: 1);
+		if (!psm_tmp) {
+			return false;
+		}
+		if (psm_bytes && r_buf_read_at (mo->b, payload_off + 32, psm_tmp, psm_bytes) != (st64)psm_bytes) {
+			free (psm_tmp);
+			return false;
+		}
+		psm = psm_tmp;
+	}
+
+	ut32 *cumcap = malloc (sizeof (ut32) * (size_t)(npages + 1));
+	if (!cumcap) {
+		free (mem);
+		free (psm_tmp);
+		return false;
+	}
+	ut32 running = 0;
+	ut64 i;
+	for (i = 0; i < npages; i++) {
+		cumcap[i] = running;
+		if (msl_page_state ((ut8 *)psm, i) == 0) {
+			running++;
+		}
+	}
+	cumcap[npages] = running;
+	free (psm_tmp);
+
+	RMslRegion *nr = realloc (mo->regions, sizeof (RMslRegion) * (mo->nregions + 1));
+	if (!nr) {
+		free (cumcap);
+		free (mem);
+		return false;
+	}
+	mo->regions = nr;
+	RMslRegion *rg = &mo->regions[mo->nregions++];
+	rg->vaddr = base;
+	rg->vsize = size;
+	rg->psl = psl;
+	rg->npages = npages;
+	rg->data_off = data_off;
+	rg->cumcap = cumcap;
+	rg->mem = mem;
+	if (base + size > mo->maxaddr) {
+		mo->maxaddr = base + size;
+	}
+	return true;
+}
+
+static int msl_region_cmp(const void *a, const void *b) {
+	const RMslRegion *ra = a;
+	const RMslRegion *rb = b;
+	if (ra->vaddr < rb->vaddr) {
+		return -1;
+	}
+	if (ra->vaddr > rb->vaddr) {
+		return 1;
+	}
+	return 0;
+}
+
+static RMslRegion *msl_region_at(RIOMsl *mo, ut64 addr) {
+	int lo = 0, hi = mo->nregions - 1;
+	while (lo <= hi) {
+		int mid = (lo + hi) / 2;
+		RMslRegion *rg = &mo->regions[mid];
+		if (addr < rg->vaddr) {
+			hi = mid - 1;
+		} else if (addr >= rg->vaddr + rg->vsize) {
+			lo = mid + 1;
+		} else {
+			return rg;
+		}
+	}
+	return NULL;
+}
+
+// Smallest region base strictly greater than addr, or UT64_MAX.
+static ut64 msl_next_region(RIOMsl *mo, ut64 addr) {
+	ut64 best = UT64_MAX;
+	int i;
+	for (i = 0; i < mo->nregions; i++) {
+		ut64 base = mo->regions[i].vaddr;
+		if (base > addr && base < best) {
+			best = base;
+		}
+	}
+	return best;
+}
+
+static bool msl_parse(RIOMsl *mo) {
+	ut8 h[16];
+	if (r_buf_read_at (mo->b, 0, h, sizeof (h)) != sizeof (h)) {
+		return false;
+	}
+	if (memcmp (h, MSL_FILE_MAGIC, 8)) {
+		return false;
+	}
+	ut32 flags = r_read_le32 (h + 12);
+	if (flags & MSL_HDR_FLAG_ENCRYPTED) {
+		R_LOG_ERROR ("msl: encrypted slices are not supported yet");
+		return false;
+	}
+	ut8 header_size = h[9];
+	ut8 pidbuf[4];
+	if (r_buf_read_at (mo->b, 0x34, pidbuf, sizeof (pidbuf)) == sizeof (pidbuf)) {
+		mo->pid = (int)r_read_le32 (pidbuf);
+	}
+	if (mo->pid <= 0) {
+		mo->pid = 1;
+	}
+	ut64 fsize = r_buf_size (mo->b);
+	ut64 off = header_size;
+	while (off + MSL_BLOCK_HEADER_SIZE <= fsize) {
+		ut8 bh[MSL_BLOCK_HEADER_SIZE];
+		if (r_buf_read_at (mo->b, off, bh, sizeof (bh)) != sizeof (bh)) {
+			break;
+		}
+		if (memcmp (bh, MSL_BLOCK_MAGIC, 4)) {
+			break;
+		}
+		ut16 btype = r_read_le16 (bh + 4);
+		ut16 bflags = r_read_le16 (bh + 6);
+		ut32 blen = r_read_le32 (bh + 8);
+		if (blen < MSL_BLOCK_HEADER_SIZE) {
+			break;
+		}
+		if (btype == MSL_BT_MEMORY_REGION) {
+			msl_add_region (mo, off + MSL_BLOCK_HEADER_SIZE, bflags, blen);
+		}
+		if (btype == MSL_BT_END_OF_CAPTURE) {
+			break;
+		}
+		off += blen;
+	}
+	if (mo->nregions > 1) {
+		qsort (mo->regions, mo->nregions, sizeof (RMslRegion), msl_region_cmp);
+	}
+	if (mo->unsupported_comp > 0) {
+		R_LOG_WARN ("msl: %d region(s) use zstd compression, which radare2 "
+			"cannot decode; those addresses read as the fill byte. "
+			"Recapture with '-c lz4' or '-c none', or use memslicer-emu.",
+			mo->unsupported_comp);
+	}
+	return true;
+}
+
+static int __read(RIO *io, RIODesc *fd, ut8 *buf, int count) {
+	if (!fd || !fd->data || count < 0) {
+		return -1;
+	}
+	RIOMsl *mo = fd->data;
+	memset (buf, io->Oxff, count);
+	ut64 addr = mo->cur;
+	int i = 0;
+	while (i < count) {
+		ut64 cur = addr + i;
+		RMslRegion *rg = msl_region_at (mo, cur);
+		if (!rg) {
+			ut64 next = msl_next_region (mo, cur);
+			if (next == UT64_MAX || next >= addr + count) {
+				break;
+			}
+			i = (int)(next - addr);
+			continue;
+		}
+		ut64 roff = cur - rg->vaddr;
+		ut64 page = roff >> rg->psl;
+		ut64 page_size = 1ULL << rg->psl;
+		ut64 in_page = roff & (page_size - 1);
+		ut64 want = page_size - in_page;
+		ut64 region_left = rg->vsize - roff;
+		want = R_MIN (want, region_left);
+		want = R_MIN (want, (ut64)(count - i));
+		// Page state is recomputed from cumcap deltas to avoid keeping the
+		// raw map resident: a page is captured iff its cumulative count
+		// increases at the next index.
+		bool captured = page < rg->npages
+			&& rg->cumcap[page + 1] > rg->cumcap[page];
+		if (captured) {
+			ut64 src_off = rg->data_off + (ut64)rg->cumcap[page] * page_size + in_page;
+			if (rg->mem) {
+				memcpy (buf + i, rg->mem + src_off, want);
+			} else {
+				r_buf_read_at (mo->b, src_off, buf + i, want);
+			}
+		}
+		i += (int)want;
+	}
+	mo->cur += count;
+	return count;
+}
+
+static ut64 __lseek(RIO *io, RIODesc *fd, ut64 offset, int whence) {
+	if (!fd || !fd->data) {
+		return offset;
+	}
+	RIOMsl *mo = fd->data;
+	switch (whence) {
+	case R_IO_SEEK_SET:
+		mo->cur = offset;
+		break;
+	case R_IO_SEEK_CUR:
+		mo->cur += offset;
+		break;
+	case R_IO_SEEK_END:
+		mo->cur = mo->maxaddr;
+		break;
+	}
+	return mo->cur;
+}
+
+static bool __check(RIO *io, const char *pathname, bool many) {
+	return r_str_startswith (pathname, "msl://");
+}
+
+static int __getpid(RIODesc *desc) {
+	RIOMsl *mo = (desc && desc->data)? desc->data: NULL;
+	return mo? mo->pid: -1;
+}
+
+static int __gettid(RIODesc *desc) {
+	return __getpid (desc);
+}
+
+static RIODesc *__open(RIO *io, const char *pathname, int rw, int mode) {
+	if (!__check (io, pathname, false)) {
+		return NULL;
+	}
+	const char *path = pathname + strlen ("msl://");
+	RBuffer *b = r_buf_new_mmap (path, R_PERM_R);
+	if (!b) {
+		R_LOG_ERROR ("msl: cannot open %s", path);
+		return NULL;
+	}
+	RIOMsl *mo = R_NEW0 (RIOMsl);
+	if (!mo) {
+		r_unref (b);
+		return NULL;
+	}
+	mo->b = b;
+	if (!msl_parse (mo)) {
+		R_LOG_ERROR ("msl: %s is not a valid Memory Slice file", path);
+		r_unref (b);
+		free (mo->regions);
+		free (mo);
+		return NULL;
+	}
+	R_LOG_INFO ("msl: indexed %d memory region(s), VA up to 0x%"PFMT64x, mo->nregions, mo->maxaddr);
+	return r_io_desc_new (io, &r_io_plugin_msl, pathname, R_PERM_R, mode, mo);
+}
+
+static bool __close(RIODesc *fd) {
+	if (!fd || !fd->data) {
+		return false;
+	}
+	RIOMsl *mo = fd->data;
+	int i;
+	for (i = 0; i < mo->nregions; i++) {
+		free (mo->regions[i].cumcap);
+		free (mo->regions[i].mem);
+	}
+	free (mo->regions);
+	r_unref (mo->b);
+	free (mo);
+	fd->data = NULL;
+	return true;
+}
+
+RIOPlugin r_io_plugin_msl = {
+	.meta = {
+		.name = "msl",
+		.desc = "Memory Slice (.msl) process memory dump",
+		.author = "memslicer",
+		.license = "LGPL-3.0-only",
+	},
+	.uris = "msl://",
+	.isdbg = true,
+	.open = __open,
+	.close = __close,
+	.read = __read,
+	.check = __check,
+	.seek = __lseek,
+	.getpid = __getpid,
+	.gettid = __gettid,
+};
+
+#ifndef R2_PLUGIN_INCORE
+R_API RLibStruct radare_plugin = {
+	.type = R_LIB_TYPE_IO,
+	.data = &r_io_plugin_msl,
+	.version = R2_VERSION
+};
+#endif

--- a/libr/meson.build
+++ b/libr/meson.build
@@ -24,7 +24,7 @@ bp_plugins = [ 'null' ]
 muta_plugins = [ 'null' ]
 core_plugins += [ 'prj', 'writedwarf', 'agD' ]
 egg_plugins = [ 'xor' ]
-debug_plugins = [ 'null', 'io', 'esil', 'rap' ]
+debug_plugins = [ 'null', 'io', 'esil', 'msl', 'rap' ]
 lang_plugins = [ 'lib', 'pipe', 'qjs', 'tsc', 'spp' ]
 
 if get_option('nogpl')
@@ -240,6 +240,7 @@ if get_option('plugins') == ''
     'dis',
     'dmp64',
     'dol',
+    'msl',
     'dyldcache',
     'elf',
     'elf64',
@@ -382,6 +383,7 @@ io_plugins += [
     'srec',
     'mach',
     'mmap',
+    'msl',
     'procpid',
     'ptrace',
     'qnx',


### PR DESCRIPTION
## Summary

Adds support for **Memory Slice** (`.msl`) process memory dumps — the format
produced by [memslicer](https://github.com/MemorySlice/memslicer) — so a static
snapshot can be analyzed and **emulated/stepped** in radare2, plus a producer to
write a slice from a live debug session. Three commits (plugins, a small core
fix, the dump command).

## Commits

1. **io,bin,debug: add Memory Slice (.msl) plugins.**
   - `io.msl` — exposes the captured virtual address space (`msl://`), honoring
     the three-state page map; decodes lz4 regions in memory (zstd isn't
     decodable by r2 — warns clearly). Doubles as a debug IO so a slice can be
     opened in debug mode without spawning a process.
   - `bin.msl` — parses a slice as CORE (arch/bits/OS, `entry0` = captured PC,
     one section/map per contiguous run of captured pages).
   - `debug.msl` — emulated backend: sets arch from the header, seeds the full
     register file from the Thread Context, and routes `ds`/`dso`/`dc`/`dr`/`dm`
     to ESIL.
   - Usage: `r2 dump.msl` (analysis) or `r2 -D msl -d msl://dump.msl` (debug).
     See `doc/msl.md`.

2. **core/debug: route `dc` to ESIL when `cfg.debug` is unset.**
   `ds` already dispatches to `aes` for emulated targets; `dc` always went
   through `r_debug_continue` (arena swap + trace + recoil), which assumes a
   live ptrace process and corrupts state on an emulated target (msl / esil).
   Mirror the `ds` behaviour: continue via `aec`. General fix, also helps the
   stock `esil` backend.

3. **debug: `dgm` writes a Memory Slice of the debuggee.**
   Producer side: `dgm [file]` serializes the live session (header, Process
   Identity, Thread Context with the current registers, one Memory Region per
   map). Reads maps in 1 MiB chunks, skips unreadable maps, and by default skips
   very large maps (e.g. the macOS dyld shared cache) — `dgma` for everything.
   Integrity chain uses SHA-256 (HashAlgo 0x01) since r2 has no BLAKE3.

4. **debug: reverse execution (`dsb`/`aesb`).**
   Enable ESIL step-back recording so execution can be stepped *backwards*
   through an emulated slice, reverting PC and register/memory state
   (time-travel debugging of a static snapshot).

## Notes

- New plugins are registered for both the meson and acr/make builds.
- MVP scope: uncompressed or lz4, unencrypted slices.
