### PR TITLE
Fix riscv_cs capstone mode detection for all capstone versions ##build

### DIFF
--- a/libr/arch/p/riscv_cs/plugin.c
+++ b/libr/arch/p/riscv_cs/plugin.c
@@ -2,10 +2,7 @@
 
 #include <r_arch.h>
 
-/* Forward+backward compat: CS_MODE_RISCVC -> CS_MODE_RISCV_C rename.
- * #if can't pick the right name (identical macros across alpha6/7),
- * so we pre-rename the enum before including capstone.h.
- * ideally remove when capstone 6 gets fully released. */
+// TODO remove as soon as capstone 6 is released
 #define CS_MODE_RISCVC CS_MODE_RISCV_C
 #include <capstone/capstone.h>
 #if CS_API_MAJOR >= 5

--- a/libr/arch/p/riscv_cs/plugin.c
+++ b/libr/arch/p/riscv_cs/plugin.c
@@ -2,6 +2,11 @@
 
 #include <r_arch.h>
 
+/* Forward+backward compat: CS_MODE_RISCVC -> CS_MODE_RISCV_C rename.
+ * #if can't pick the right name (identical macros across alpha6/7),
+ * so we pre-rename the enum before including capstone.h.
+ * ideally remove when capstone 6 gets fully released. */
+#define CS_MODE_RISCVC CS_MODE_RISCV_C
 #include <capstone/capstone.h>
 #if CS_API_MAJOR >= 5
 #include <capstone/riscv.h>
@@ -259,11 +264,7 @@ static void set_opdir(RAnalOp *op) {
 }
 
 #define CSINC RISCV
-#if defined(CS_VERSION_PRE_RELEASE) && CS_VERSION_PRE_RELEASE != CS_VERSION_STABLE
 #define CSINC_MODE (CS_MODE_RISCV_C | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
-#else
-#define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
-#endif
 #include "../capstone.inc.c"
 
 static bool riscv_decode(RArchSession *a, RAnalOp *op, RArchDecodeMask mask) {


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

I was preparing a patch for Pentoo where I ran into similar issues regarding different versions of capstone, and I found a better way to fix [the issue from yesterday.](https://github.com/radareorg/radare2/pull/26124)

The `#if CS_NEXT_VERSION >= 6` guard choosing between `CS_MODE_RISCVC` and `CS_MODE_RISCV_C` fails on capstone 6.0.0 alpha4-6 because those versions set `CS_NEXT_VERSION=7` (same as `next`) but still use the old enum.

Alpha6 and alpha7 share identical preprocessor macros (`CS_API_MAJOR=6`, `CS_NEXT_VERSION=7`, no `CS_VERSION_PRE_RELEASE`), making `#if`-based detection impossible. This includes the `CS_VERSION_PRE_RELEASE` check currently in upstream/master, which also cannot distinguish them.

Replace the guard with a `#define CS_MODE_RISCVC CS_MODE_RISCV_C` placed before `#include <capstone/capstone.h>`. This renames the enum constant in the capstone header during preprocessing on older versions, and is a harmless no-op on alpha7+ where the rename already happened.

Tested against all six capstone versions (5.0.7, alpha4/5/6/7, next). All 192 RISC-V r2r tests pass.