### PR TITLE
Add Nix flake and dev shell support ##build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ libr/xps/deps.h
 libr/xps/static.cfg
 libr/xps/p/meson.build
 libr/xps/r2plugins.h
+result*

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ radare2/sys/install.sh
 * Run `sys/install.sh` for the default acr+make+symlink installation
 * meson/ninja (muon/samu also works) and make builds are supported.
 
+### Nix
+
+radare2 provides a Nix flake for reproducible builds and development shells:
+
+```sh
+nix run github:radareorg/radare2     # run radare2
+nix shell github:radareorg/radare2   # shell with r2 in PATH
+nix build github:radareorg/radare2   # build the package
+```
+
+For development, clone the repo and use the dev shell:
+
+```sh
+git clone https://github.com/radareorg/radare2
+cd radare2
+nix develop   # enter dev shell with all build dependencies
+nix build     # build from local source
+```
+
 ### Source Build
 
 * r2 can be installed from `git` or via `pip` using `r2env`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-rcUHdUtJEvMdNEl2Wq+YpHraHKfcer3KsBscpZEF2Yg=",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1017464.567a49d1913c/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+
+      pkgsFor = system: nixpkgs.legacyPackages.${system} or (import nixpkgs { inherit system; });
+
+      supportedSystems = builtins.filter (
+        system: (builtins.tryEval (pkgsFor system).stdenv.hostPlatform).success
+      ) (lib.systems.doubles.linux ++ lib.systems.doubles.darwin);
+
+      forAllSystems = function: lib.genAttrs supportedSystems (system: function (pkgsFor system));
+
+      ciSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+    in
+    {
+      overlays.default = final: _: {
+        radare2 = final.callPackage ./package.nix { src = self; };
+      };
+
+      packages = forAllSystems (pkgs: {
+        radare2 = pkgs.callPackage ./package.nix { src = self; };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.radare2;
+      });
+
+      checks = lib.genAttrs ciSystems (system: self.packages.${system});
+
+      devShells = forAllSystems (pkgs: {
+        default = import ./shell.nix { inherit pkgs; };
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildPackages,
+  capstone,
+  file,
+  libewf,
+  libusb-compat-0_1,
+  libuv,
+  libzip,
+  lz4,
+  meson,
+  ninja,
+  openssl,
+  perl,
+  pkg-config,
+  python3,
+  readline,
+  xxhash,
+  zlib,
+  src,
+}:
+let
+  binaryninja = fetchFromGitHub {
+    owner = "Vector35";
+    repo = "binaryninja-api";
+    rev = "ba13f6ec7d0ce9a18a03a1c895fb72d18e03014a";
+    hash = "sha256-ApBDmrepz27ioEjtqgdGzGF0tPkDghp7dA8L9eHHW6w=";
+  };
+
+  sdb = fetchFromGitHub {
+    owner = "radareorg";
+    repo = "sdb";
+    tag = "2.4.4";
+    hash = "sha256-JN27SkDqHtX83d1CPUF9hbVKwE/dwhDgn5MlCX9RPrc=";
+  };
+
+  qjs = fetchFromGitHub {
+    owner = "quickjs-ng";
+    repo = "quickjs";
+    rev = "3087a2ce5bcb66cc1fcd9f34d3e5ce3bd43a67d9";
+    hash = "sha256-Z6DUe/W1+3SYPRPCiL3oNL5ovXCsW3dsFuGkA9WF3W4=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "radare2";
+  version = "6.1.7";
+
+  inherit src;
+
+  mesonFlags = [
+    (lib.mesonBool "use_sys_capstone" true)
+    (lib.mesonBool "use_sys_lz4" true)
+    (lib.mesonBool "use_sys_magic" true)
+    (lib.mesonBool "use_sys_openssl" true)
+    (lib.mesonBool "use_sys_xxhash" true)
+    (lib.mesonBool "use_sys_zip" true)
+    (lib.mesonBool "use_sys_zlib" true)
+    (lib.mesonOption "r2_gittap" finalAttrs.version)
+  ];
+
+  enableParallelBuilding = true;
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    python3
+  ];
+
+  buildInputs = [
+    capstone
+    file
+    libewf
+    libusb-compat-0_1
+    libuv
+    lz4
+    openssl
+    perl
+    readline
+    zlib
+  ];
+
+  propagatedBuildInputs = [
+    file
+    libzip
+    xxhash
+  ];
+
+  postUnpack = ''
+    pushd $sourceRoot/subprojects
+
+    cp -r ${binaryninja} binaryninja
+    chmod -R +w binaryninja
+    cp packagefiles/binaryninja/meson.build binaryninja
+
+    cp -r ${sdb} sdb
+    chmod -R +w sdb
+
+    cp -r ${qjs} qjs
+    chmod -R +w qjs
+    cp packagefiles/qjs/meson.build qjs
+
+    popd
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install_name_tool -add_rpath $out/lib $out/lib/libr_io.${finalAttrs.version}.dylib
+  '';
+
+  meta = {
+    description = "UNIX-like reverse engineering framework and command-line toolset";
+    homepage = "https://radare.org";
+    changelog = "https://github.com/radareorg/radare2/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      gpl3Only
+      lgpl3Only
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "radare2";
+  };
+})

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,34 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+with pkgs;
+mkShell {
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    python3
+    git
+  ];
+
+  buildInputs =
+    [
+      capstone
+      file
+      libewf
+      libusb-compat-0_1
+      libuv
+      lz4
+      openssl
+      perl
+      readline
+      zlib
+      libzip
+      xxhash
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      libiconv
+    ];
+}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [x] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional) https://github.com/radareorg/radare2-book/pull/466

**Description**

radare2 and iaito are already in nixpkgs, but updates lag behind upstream. Right now nixpkgs ships `6.1.4` while stable is `6.1.6` and master is `6.1.7`. Anyone can bump the nixpkgs package, but that's not why this matters.

The important part is letting users run r2 straight from the repo without waiting for a nixpkgs release:
```shell
nix run github:radareorg/radare2
```

It also gives contributors on Nix systems a proper dev shell. Without it you're stuck in distroboxes or VMs just to get build dependencies.


