### PR TITLE
Fix long func type keys

### DIFF
--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -830,8 +830,10 @@ R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name) {
 }
 
 R_API int r_type_func_args_count(Sdb *TDB, const char *R_NONNULL func_name) {
-	r_strf_var (query, 64, "func.%s.args", trim_lodashes (func_name));
-	return sdb_num_get (TDB, query, 0);
+	char *query = r_str_newf ("func.%s.args", trim_lodashes (func_name));
+	int ret = sdb_num_get (TDB, query, 0);
+	free (query);
+	return ret;
 }
 
 R_API R_OWNED char *r_type_func_args_type(Sdb *TDB, const char *R_NONNULL func_name, int i) {

--- a/package.nix
+++ b/package.nix
@@ -33,7 +33,7 @@ let
   sdb = fetchFromGitHub {
     owner = "radareorg";
     repo = "sdb";
-    tag = "2.4.4";
+    rev = "b2c50e519f0b1dc7edf2417281e46bc793cd40a6";
     hash = "sha256-JN27SkDqHtX83d1CPUF9hbVKwE/dwhDgn5MlCX9RPrc=";
   };
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

### Summary

Fix function signature argument lookup for long function names.

`r_type_func_args_count()` used a fixed 64-byte stack buffer:

```c
r_strf_var (query, 64, "func.%s.args", trim_lodashes (func_name));
```

This truncates SDB keys for long function names. As a result, signatures parsed by `afs` are saved correctly into `anal->sdb_types`, but later read back as having zero arguments.

Radare2 allows functions to be renamed to names longer than this internal lookup buffer, so the rename succeeds and no clear error is shown.  The function actually gets renamed but with 0 arguments.

The failure happens later when the signature is read back and the argument count is resolved through `r_type_func_args_count()`.

### Root cause

For a long function name such as:
```
rowbasee63ef6__createNewInstance3f00e2_d__27__System_Collections_IEnumerator_get_Current_6505428
```
To debug this, logs were added in the signature application/readback path:

- [After](https://github.com/radareorg/radare2/blob/6.1.6/libr/anal/fcn.c#L2957) `r_anal_save_parsed_type()` in `r_anal_str_to_fcn()`, to confirm that the parsed type was saved into `anal->sdb_types`.
![](https://i.imgur.com/f7VjmHC.png)

- [inside](https://github.com/radareorg/radare2/blob/6.1.6/libr/anal/fcn.c#L2849) `r_anal_function_get_signature()`, to compare direct SDB lookup with `r_type_func_args_count()`
![](https://i.imgur.com/zhg3czK.png)


In the debug test, direct SDB lookup worked:

```
GETSIG args key len=107 val='2'
GETSIG sdb_num args=2
```

but the wrapper failed:
```
GETSIG r_type argc=0
```
This confirmed that the data was saved correctly and that the failure was caused by the truncated query inside `r_type_func_args_count()`.

### Reproducer

Applying a signature to a function with a short name works:

```bash
[0x006343d4]> s 6505428
[0x006343d4]> afs Il2CppObject* dummy_6505428(rowbasee63ef6__createNewInstance3f00e2_d__27_o* __this, const MethodInfo* method);
[0x006343d4]>pd 1
┌ 8: dummy_6505428(rowbasee63ef6__createNewInstance3f00e2_d__27_o *__this, const MethodInfo *method);
│ `- args(x0)
│           0x006505428      000c40f9       ldr x0, [x0, 0x18]          ; arg1
```

The parsed type contains:
```
func.dummy_6505428.args=2
```
and `r_type_func_args_count()` returns 2.

Applying the same signature after restoring the long function name saves the correct keys:
```c
func.rowbasee63ef6__createNewInstance3f00e2_d__27__System_Collections_IEnumerator_get_Current_6303438.args=2
```

But `r_type_func_args_count()` returns 0 because the internal query[64] buffer truncates the key.

Function with longe name after applying signature:
```bash
pd 1@ 6505428
┌ 8: rowbasee63ef6__createNewInstance3e00e2_d__27__System_Collections_IEnumerator_get_Current_6505428 ();
│ `- args(x0)
│           0x006505428      000c40f9       ldr x0, [x0, 0x18]          ; arg1
```

### Fix
Build the SDB key dynamically with `r_str_newf()` instead of using a fixed 64-byte buffer.

This avoids truncating valid long function names and allows `afs` / `r_anal_function_get_signature()` to correctly recover the argument count.

### Testing

Manually verified that after the change:
```
GETSIG args key len=107 val='2'
GETSIG sdb_num args=2
GETSIG r_type argc=2
signature argc=2
```

The original long-name afs case now applies arguments correctly:
```bash
pd 1@6505428
┌ 8: rowbasee63ef6__createNewInstance3f00e2_d__27__System_Collections_IEnumerator_get_Current_6505428 (rowbasee63ef6__createNewInstance3f00e2_d__27_o *__this, const MethodInfo *method);
│ `- args(x0)
│           0x006505428      000c40f9       ldr x0, [x0, 0x18]          ; arg1
```
