### PR TITLE
Restore arm32 AAPCS register arguments (r0-r3) ##anal

### DIFF
--- a/libr/anal/d/cc-arm-16.sdb.txt
+++ b/libr/anal/d/cc-arm-16.sdb.txt
@@ -12,5 +12,6 @@ arm32=cc
 cc.arm32.arg0=r0
 cc.arm32.arg1=r1
 cc.arm32.arg2=r2
+cc.arm32.arg3=r3
 cc.arm32.argn=stack
 cc.arm32.ret0=r0

--- a/libr/anal/d/cc-arm-32.sdb.txt
+++ b/libr/anal/d/cc-arm-32.sdb.txt
@@ -3,8 +3,9 @@ default.cc=arm32
 arm32=cc
 cc.arm32.arg0=r0
 cc.arm32.arg1=r1
-# more than two args causes incorrect code analysis, must review
-# cc.arm32.arg2=stack
+cc.arm32.arg2=r2
+cc.arm32.arg3=r3
+cc.arm32.argn=stack
 cc.arm32.ret0=r0
 
 arm16=cc

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -319,12 +319,28 @@ pd 4
 EOF
 EXPECT=<<EOF
 / (fcn) fcn.00000000 16
-// void fcn.00000000 (int32_t arg1);
-| `- args(r1)
-|           0x00000000      021081e0       add r1, r1, r2              ; arg2
+// void fcn.00000000 (int32_t arg1, int32_t arg2);
+| `- args(r1, r2)
+|           0x00000000      021081e0       add r1, r1, r2              ; arg3
 |           0x00000004      1eff2f01       bxeq lr
 |           0x00000008      0020a0e3       mov r2, 0
 \           0x0000000c      1eff2fe1       bx lr
+EOF
+RUN
+
+NAME=arm32 register args r0 to r3
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=32
+CMDS=<<EOF
+wx 010080e0020080e0030080e01eff2fe1
+af
+afv
+EOF
+EXPECT=<<EOF
+arg int32_t arg1 @ r0
+arg int32_t arg2 @ r1
+arg int32_t arg3 @ r2
+arg int32_t arg4 @ r3
 EOF
 RUN
 

--- a/test/db/anal/thumb
+++ b/test/db/anal/thumb
@@ -71,3 +71,21 @@ svc 0x42
 svc 0xb6
 EOF
 RUN
+
+NAME=arm32 convention resolves r0 to r3 in thumb mode
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=16
+CMDS=<<EOF
+wx 40188018c0187047
+af
+afc arm32
+afva
+afv
+EOF
+EXPECT=<<EOF
+arg int16_t arg1 @ r0
+arg int16_t arg2 @ r1
+arg int16_t arg3 @ r2
+arg int16_t arg4 @ r3
+EOF
+RUN

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -364,30 +364,36 @@ pdf
 agf
 EOF
 EXPECT=<<EOF
-/ 4: fcn.00008174 (func main, int argc);
+/ 4: fcn.00008174 (func main, int argc, char **ubp_av, func init);
 |           ; arg func main @ r0
 |           ; arg int argc @ r1
+|           ; arg char **ubp_av @ r2
+|           ; arg func init @ r3
 \           0x00008174      b80000eb       bl sym.__libc_start_main    ; lr=0x8178 -> 0xeb0002a4 ; pc=0x845c -> 0xe92d41f0
-\                                                                      ; int __libc_start_main(0, 0, -1, -1, -1, -1, -1)
+\                                                                      ; int __libc_start_main(0, 0, 0, 0, 0x00000000, 0x00000000, 0x00000000)
 
-/ 4: fcn.00008174 (func main, int argc);
+/ 4: fcn.00008174 (func main, int argc, char **ubp_av, func init);
 |           ; arg func main @ r0
 |           ; arg int argc @ r1
+|           ; arg char **ubp_av @ r2
+|           ; arg func init @ r3
 |              ; lr=0x8178 -> 0xeb0002a4
 |              ; pc=0x845c -> 0xe92d41f0 sym.__libc_start_main
-|              ; int __libc_start_main(0, 0, -1, -1, -1, -1, -1)
+|              ; int __libc_start_main(0, 0, 0, 0, 0x00000000, 0x00000000, 0x00000000)
 \           0x00008174      b80000eb       bl sym.__libc_start_main
 
-.------------------------------------------------------.
-|  0x8174                                              |
-| 4: fcn.00008174 (func main, int argc);               |
-| ; arg func main @ r0                                 |
-| ; arg int argc @ r1                                  |
-|    ; lr=0x8178 -> 0xeb0002a4                         |
-|    ; pc=0x845c -> 0xe92d41f0 sym.__libc_start_main   |
-|    ; int __libc_start_main(0, 0, -1, -1, -1, -1, -1) |
-| bl sym.__libc_start_main;[oa]                        |
-`------------------------------------------------------'
+.------------------------------------------------------------------.
+|  0x8174                                                          |
+| 4: fcn.00008174 (func main, int argc, char **ubp_av, func init); |
+| ; arg func main @ r0                                             |
+| ; arg int argc @ r1                                              |
+| ; arg char **ubp_av @ r2                                         |
+| ; arg func init @ r3                                             |
+|    ; lr=0x8178 -> 0xeb0002a4                                     |
+|    ; pc=0x845c -> 0xe92d41f0 sym.__libc_start_main               |
+|    ; int __libc_start_main(0, 0, 0, 0, NULL, NULL, NULL)         |
+| bl sym.__libc_start_main;[oa]                                    |
+`------------------------------------------------------------------'
 EOF
 RUN
 

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1477,7 +1477,7 @@ var char * var_24h @ fp-0x20
 var int32_t var_28h @ fp-0x24
 var char * src @ fp-0x28
 var int32_t var_30h @ fp-0x2c
-var char * v2 @ fp-0x30
+var char * v4 @ fp-0x30
 var pid_t pid @ fp-0x34
 var int32_t var_3ch @ fp-0x38
 var int32_t var_40h @ fp-0x3c


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The arm32 calling convention only declared r0-r1 as register arguments, so functions taking 3-4 args showed phantom uninitialized r2/r3 reads and short signatures. AAPCS passes the first four integer/pointer args in r0-r3. 

The limit was a "must review" workaround added in 19b59ba9eb alongside an unrelated crash fix. The actual null-deref it hedged against was fixed independently in 93e3c53d55 (the `if (regname)` guards in r_anal_extract_rarg are still in place), so the register limit only degrades analysis.

Restores arg2=r2/arg3=r3 (+ argn=stack) for arm32 in both the 32-bit and 16-bit cc databases. Added related tests.
