### PR TITLE
anal: fix zignature drop for functions with empty-typed vars (varargs)

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -485,11 +485,11 @@ R_API RList *r_anal_var_deserialize(const char *ser) {
 		nxt++;
 		ser = nxt;
 
-		// type
+		// type (may be empty, e.g. the "..." vararg argument)
 		for (i = 0; *nxt && *nxt != ','; i++) {
 			nxt++;
 		}
-		v->type = R_STR_NDUP (ser, i);
+		v->type = i > 0 ? r_str_ndup (ser, i) : strdup ("");
 		if (!v->type) {
 			goto bad_serial;
 		}


### PR DESCRIPTION
## Problem

`zaf` (zignature add-function) silently produces **zero** signatures for any
function that has a variable with an **empty type** — most commonly the `...`
vararg argument of variadic functions (e.g. anything wrapping `snprintf`,
`printf`, …). The function gets a signature on `zaf`, but it is dropped the
moment the signature DB is round-tripped (`zos`/`zo`, or any internal
re-deserialize), and `zj` comes back empty.

This is **arch-agnostic** — it just shows up easily on ARM32 because variadic
wrappers are common there. It is not a `zaf`/ARM limitation.

## Root cause

Var serialization (`serialize_single_var`) happily emits an empty type field,
e.g. for the vararg arg: `ts4:...:`.

On the way back in, `r_anal_var_deserialize` parses the (empty) type with:

    v->type = R_STR_NDUP (ser, i);   // i == 0 for empty type

`R_STR_NDUP` collapses `len <= 0` to `NULL`, so the next check
`if (!v->type) goto bad_serial;` fails, `r_anal_var_deserialize` reports an
error, and `foreachCB` in `sign.c` drops the **entire** signature with a generic
`cannot deserialize zign`. So the serializer accepts a value the deserializer
rejects — an asymmetry.

## Fix

Treat an empty type as a valid empty string instead of a parse failure:

    // type (may be empty, e.g. the "..." vararg argument)
    v->type = i > 0 ? r_str_ndup (ser, i) : strdup ("");

One-line change in `libr/anal/var.c`, symmetric with the serializer.

## Verification

Repro: ARM32 ELF whose `sym.snprintf` wrapper (afij size 64, 25 insns, A32)
produced 0 zignatures.

- Before: 1 signature dropped corpus-wide, `cannot deserialize zign` logged,
  `snprintf` signature missing.
- After: `snprintf` signature survives the round-trip, **0** deserialize errors,
  951/951 functions covered, no regression on the rest of the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)