### PR TITLE
Name MIPS global GOT slots by synthesizing their implicit relocs ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -517,6 +517,9 @@ static void set_default_value_dynamic_info(ELFOBJ *eo) {
 	di->dt_jmprel = R_BIN_ELF_ADDR_MAX;
 	di->dt_pltgot = R_BIN_ELF_ADDR_MAX;
 	di->dt_mips_pltgot = R_BIN_ELF_ADDR_MAX;
+	di->dt_mips_local_gotno = 0;
+	di->dt_mips_gotsym = R_BIN_ELF_XWORD_MAX;
+	di->dt_mips_symtabno = 0;
 	di->dt_ppc64_glink = R_BIN_ELF_ADDR_MAX;
 	di->dt_crel = R_BIN_ELF_ADDR_MAX;
 	di->dt_bind_now = false;
@@ -614,6 +617,15 @@ static void fill_dynamic_entries(ELFOBJ *eo, ut64 loaded_offset, ut64 dyn_size) 
 			break;
 		case DT_MIPS_PLTGOT:
 			di->dt_mips_pltgot = d.d_un.d_ptr;
+			break;
+		case DT_MIPS_LOCAL_GOTNO:
+			di->dt_mips_local_gotno = d.d_un.d_val;
+			break;
+		case DT_MIPS_GOTSYM:
+			di->dt_mips_gotsym = d.d_un.d_val;
+			break;
+		case DT_MIPS_SYMTABNO:
+			di->dt_mips_symtabno = d.d_un.d_val;
 			break;
 		case DT_PPC64_GLINK:
 			di->dt_ppc64_glink = d.d_un.d_ptr;
@@ -3858,6 +3870,14 @@ static bool read_reloc(ELFOBJ *eo, RBinElfReloc *r, Elf_(Xword) rel_mode, ut64 v
 	return true;
 }
 
+static size_t get_num_relocs_mips_got(ELFOBJ *eo) {
+	const RBinElfDynamicInfo *di = &eo->dyn_info;
+	if (eo->ehdr.e_machine != EM_MIPS || di->dt_pltgot == R_BIN_ELF_ADDR_MAX || di->dt_mips_gotsym == R_BIN_ELF_XWORD_MAX || di->dt_mips_symtabno <= di->dt_mips_gotsym) {
+		return 0;
+	}
+	return di->dt_mips_symtabno - di->dt_mips_gotsym;
+}
+
 static size_t get_num_relocs_dynamic(ELFOBJ *eo) {
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
 	size_t res = 0;
@@ -3878,7 +3898,7 @@ static size_t get_num_relocs_dynamic(ELFOBJ *eo) {
 		// If relrent is not set, assume it's the size of an address
 		res += di->dt_relrsz / sizeof (Elf_(Addr));
 	}
-	return res + get_num_relocs_dynamic_plt (eo);
+	return res + get_num_relocs_dynamic_plt (eo) + get_num_relocs_mips_got (eo);
 }
 
 static bool section_is_valid(ELFOBJ *eo, RBinElfSection *sect) {
@@ -4027,6 +4047,39 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 			fix_rva_and_offset_exec_file (eo, reloc);
 			pos++;
 		}
+	}
+	return pos;
+}
+
+// MIPS has no explicit relocs for its global GOT (dynsym [gotsym, symtabno)); synthesize them so cbin names the slots
+static size_t populate_relocs_record_from_mips_got(ELFOBJ *eo, size_t pos, size_t num_relocs) {
+	const RBinElfDynamicInfo *di = &eo->dyn_info;
+	if (!get_num_relocs_mips_got (eo)) {
+		return pos;
+	}
+	const ut64 wordsize = sizeof (Elf_(Addr));
+	const ut64 gotsym = di->dt_mips_gotsym;
+	const ut64 symtabno = di->dt_mips_symtabno;
+	const ut64 global_got = di->dt_pltgot + di->dt_mips_local_gotno * wordsize;
+	ut64 i;
+	for (i = gotsym; i < symtabno && pos < num_relocs; i++) {
+		// skip entries already covered by an explicit reloc to avoid a duplicate flag
+		if (ht_uu_find (eo->rel_cache, i + 1, NULL) > 0) {
+			continue;
+		}
+		RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
+		if (!reloc) {
+			break;
+		}
+		memset (reloc, 0, sizeof (*reloc));
+		reloc->sym = (int)i;
+		reloc->type = R_MIPS_REL32;
+		reloc->mode = DT_REL;
+		reloc->offset = global_got + (i - gotsym) * wordsize;
+		fix_rva_and_offset_exec_file (eo, reloc);
+		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
+		ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+		pos++;
 	}
 	return pos;
 }
@@ -4187,6 +4240,7 @@ static bool populate_relocs_record(ELFOBJ *eo) {
 
 	size_t i = 0;
 	i = populate_relocs_record_from_dynamic (eo, i, num_relocs);
+	i = populate_relocs_record_from_mips_got (eo, i, num_relocs);
 	i = populate_relocs_record_from_section (eo, i, num_relocs);
 	eo->g_reloc_num = i;
 	return true;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -106,6 +106,9 @@ typedef struct Elf_(dynamic_info) {
 	Elf_(Xword) dt_pltrel;
 	Elf_(Addr) dt_jmprel;
 	Elf_(Addr) dt_mips_pltgot;
+	Elf_(Xword) dt_mips_local_gotno;
+	Elf_(Xword) dt_mips_gotsym;
+	Elf_(Xword) dt_mips_symtabno;
 	Elf_(Addr) dt_ppc64_glink; /* PPC64 ELFv1: DT_PPC64_GLINK lazy PLT resolver anchor */
 	Elf_(Addr) dt_crel;    // Address of Crel relocs
 	bool dt_bind_now;

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -815,14 +815,14 @@ s 0x00402088
 pd 10
 EOF
 EXPECT=<<EOF
-            0x00402088      8f84814c       lw a0, -main(gp)            ; [0x43522c:4]=0x402558 sym.main
+            0x00402088      8f84814c       lw a0, -main(gp)            ; [reloc.main:4]=0x402558 sym.main
             0x0040208c      8fa50000       lw a1, (sp)
             0x00402090      27a60004       addiu a2, sp, 4
             0x00402094      2401fff8       addiu at, zero, -8
             0x00402098      03a1e824       and sp, sp, at
             0x0040209c      27bdffe0       addiu sp, sp, -0x20
-            0x004020a0      8f878230       lw a3, -sym._init(gp)       ; [0x435310:4]=0x401ff4 sym._init
-            0x004020a4      8f888114       lw t0, -sym._fini(gp)       ; [0x4351f4:4]=0x41eca0 sym._fini
+            0x004020a0      8f878230       lw a3, -sym._init(gp)       ; [reloc._init:4]=0x401ff4 sym._init
+            0x004020a4      8f888114       lw t0, -sym._fini(gp)       ; [reloc._fini:4]=0x41eca0 sym._fini
             0x004020a8      afa80010       sw t0, 0x10(sp)
             0x004020ac      afa20014       sw v0, 0x14(sp)
 EOF

--- a/test/db/formats/elf/mips
+++ b/test/db/formats/elf/mips
@@ -64,3 +64,11 @@ jal sym.imp.__uClibc_main
 sw sp, 0x18(sp)
 EOF
 RUN
+
+NAME=mips implicit global GOT slots get named relocs
+FILE=bins/elf/boa-mips
+CMDS=ir~strftime[0,4]
+EXPECT=<<EOF
+0x004f4ac0 strftime
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

MIPS maps dynsym [DT_MIPS_GOTSYM, DT_MIPS_SYMTABNO) onto global GOT entries with no explicit relocs, so r2 left those slots unnamed — `pd`/`pdg` showed gp-relative GOT loads as raw `**0x…` addresses.
  
Parse DT_MIPS_LOCAL_GOTNO/GOTSYM/SYMTABNO and synthesize a reloc per global GOT slot (addr = DT_PLTGOT + (local_gotno + (i - gotsym)) * wordsize), so the existing reloc→flag path names them (e.g. `reloc.strftime`). Skips slots already covered by an explicit reloc.
