### PR TITLE
Make tab-completion respect current cursor position ##shell

### DIFF
--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1117,12 +1117,12 @@ R_API void r_line_autocomplete(RCons *cons) {
 		if (*p) {
 			// TODO: avoid overflow
 			const char *end_word = r_sub_str_rchr (line->buffer.data,
-				line->buffer.index, strlen (line->buffer.data), ' ');
+				line->buffer.index, line->buffer.length, ' ');
 			const char *t = end_word? end_word: "";
 			const char *root = argv[0];
 			int min_common_len = strlen (root);
 			size_t len_t = strlen (t);
-			while (len_t > 0 && t[len_t - 1] == ' ') {
+			while (len_t > 0 && isspace (t[len_t - 1])) {
 				len_t--;
 			}
 

--- a/libr/cons/dietline.c
+++ b/libr/cons/dietline.c
@@ -1085,9 +1085,12 @@ R_API void r_line_autocomplete(RCons *cons) {
 	if (argc == 1) {
 		const char *end_word = r_sub_str_rchr (line->buffer.data,
 			line->buffer.index, strlen (line->buffer.data), ' ');
-		const char *t = end_word? end_word: line->buffer.data + line->buffer.index;
+		const char *t = end_word? end_word: "";
 		int largv0 = strlen (r_str_get (argv[0]));
 		size_t len_t = strlen (t);
+		while (len_t > 0 && t[len_t - 1] == ' ') {
+			len_t--;
+		}
 		p[largv0] = '\0';
 
 		if ((p - line->buffer.data) + largv0 + 1 + len_t < plen) {
@@ -1097,6 +1100,7 @@ R_API void r_line_autocomplete(RCons *cons) {
 					p[tt++] = ' ';
 				}
 				memmove (p + tt, t, len_t);
+				p[tt + len_t] = '\0';
 			}
 			memcpy (p, argv[0], largv0);
 
@@ -1112,10 +1116,15 @@ R_API void r_line_autocomplete(RCons *cons) {
 	} else if (argc > 0) {
 		if (*p) {
 			// TODO: avoid overflow
-			const char *t = line->buffer.data + line->buffer.index;
+			const char *end_word = r_sub_str_rchr (line->buffer.data,
+				line->buffer.index, strlen (line->buffer.data), ' ');
+			const char *t = end_word? end_word: "";
 			const char *root = argv[0];
 			int min_common_len = strlen (root);
 			size_t len_t = strlen (t);
+			while (len_t > 0 && t[len_t - 1] == ' ') {
+				len_t--;
+			}
 
 			// try to autocomplete argument
 			for (i = 0; i < argc; i++) {

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -1202,8 +1202,13 @@ static bool find_autocomplete(RCore *core, RLineCompletion *completion, RLineBuf
 	R_RETURN_VAL_IF_FAIL (core && completion && buf, false);
 	RCoreAutocomplete *child = NULL;
 	RCoreAutocomplete *parent = core->autocomplete;
+	// Only look at text up to cursor
+	size_t len = R_MIN (buf->index, buf->length);
+	char saved = buf->data[len];
+	buf->data[len] = 0;
 	const char *p = buf->data;
 	if (!*p) {
+		buf->data[len] = saved;
 		return false;
 	}
 	char arg[256];
@@ -1211,12 +1216,13 @@ static bool find_autocomplete(RCore *core, RLineCompletion *completion, RLineBuf
 	while (*p) {
 		const char *e = r_str_trim_head_wp (p);
 		if (!e || (e - p) >= 256 || e == p) {
+			buf->data[len] = saved;
 			return false;
 		}
 		memcpy (arg, p, e - p);
 		arg[e - p] = 0;
 		child = r_core_autocomplete_find (parent, arg, false);
-		if (child && child->length < buf->length && p[child->length] == ' ') {
+		if (child && child->length < len && p[child->length] == ' ') {
 			// if is spaced then i can provide the
 			// next subtree as suggestion..
 			p = r_str_trim_head_ro (p + child->length);
@@ -1293,6 +1299,7 @@ static bool find_autocomplete(RCore *core, RLineCompletion *completion, RLineBuf
 		}
 		break;
 	}
+	buf->data[len] = saved;
 	return true;
 }
 

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -981,6 +981,12 @@ static void autocomplete_vars(RCore *core, RLineCompletion *completion, const ch
 	if (!fcn) {
 		return;
 	}
+	// Autocomplete for last argument
+	const char *sp = r_str_rchr (str, NULL, ' ');
+	if (!sp) {
+		return;
+	}
+	str = sp + 1;
 	size_t len = strlen (str);
 	RAnalVar **it;
 	R_VEC_FOREACH (&fcn->vars, it) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

`find_autocomplete()` previously matched against the whole buffer, now it only looks at the text up to the cursor to produce a suggestion so pressing tab in the middle of a command works correctly. Also changes r_line_autocomplete to avoid duplicating the trailing portion of a word when completing in the middle of a word. Fixes completion for `afvn` to complete variable names on the second argument rather than the first one.

<!-- explain your changes if necessary -->
