### PR TITLE
Name defined dynsym GOT slots in section-less ELFs ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -5836,6 +5836,9 @@ RVecRBinSymbol *Elf_(load_symbols_vec)(ELFOBJ *eo) {
 		return NULL;
 	}
 	RBinElfSymbol *symbol;
+	// section-less ELFs skip the section path that fills symbols_by_ord; their dynsym ordinals equal reloc->sym, so name defined slots here
+	RBinSymbol **sbo = eo->ehdr.e_shnum? NULL: eo->symbols_by_ord;
+	const size_t sbo_size = eo->symbols_by_ord_size;
 	R_VEC_FOREACH (elf_symbols, symbol) {
 		if (symbol->is_sht_null) {
 			continue;
@@ -5845,6 +5848,9 @@ RVecRBinSymbol *Elf_(load_symbols_vec)(ELFOBJ *eo) {
 		}
 		RBinSymbol sym;
 		fill_symbol (eo, symbol, &sym);
+		if (sbo && !symbol->is_imported && symbol->ordinal < sbo_size && !sbo[symbol->ordinal]) {
+			sbo[symbol->ordinal] = r_bin_symbol_clone (&sym);
+		}
 		RVecRBinSymbol_push_back (&eo->symbols_cache, &sym);
 	}
 	eo->symbols_cached = true;

--- a/test/db/formats/elf/mips
+++ b/test/db/formats/elf/mips
@@ -72,3 +72,11 @@ EXPECT=<<EOF
 0x004f4ac0 strftime
 EOF
 RUN
+
+NAME=mips defined global GOT slot gets named reloc in section-less elf
+FILE=bins/elf/boa-mips
+CMDS=ir~tc_meter_enable[0,4]
+EXPECT=<<EOF
+0x004f50ac tc_meter_enable
+EOF
+RUN

--- a/test/db/formats/elf/relro
+++ b/test/db/formats/elf/relro
@@ -21,3 +21,11 @@ EXPECT=<<EOF
 full
 EOF
 RUN
+
+NAME=arm defined global gets named reloc in section-less elf
+FILE=bins/elf/relro/netifd
+CMDS=ir~in6addr_any[0,4]
+EXPECT=<<EOF
+0x0003b5d4 in6addr_any
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ELFs with no section headers load symbols via the phdr path, which fills imports_by_ord but never symbols_by_ord. So reloc_convert's symbols_by_ord[rel->sym] fallback misses for *defined* dynsym globals, leaving their GOT relocs unnamed (e.g. boa-mips tc_meter_enable).

Fill symbols_by_ord for defined symbols on this path, gated on !e_shnum since only there does the dynsym ordinal equal reloc->sym (a section binary's .symtab ordinals would alias and corrupt names).

Arch-neutral; tests added for MIPS (boa-mips) and ARM (netifd).