### PR TITLE
Resolve afs prototypes stored under prefixed function names ##types

### DIFF
--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -950,7 +950,7 @@ static void clean_function_name(char *func_name) {
 // - symbol names are long and noisy, some of them might not be matched due
 //	 to additional information added around name
 R_API R_OWNED char *r_type_func_guess(Sdb *TDB, const char *R_NONNULL func_name) {
-	R_RETURN_VAL_IF_FAIL (TDB && func_name, false);
+	R_RETURN_VAL_IF_FAIL (TDB && func_name, NULL);
 	const char *str = func_name;
 	char *result = NULL;
 
@@ -965,6 +965,11 @@ R_API R_OWNED char *r_type_func_guess(Sdb *TDB, const char *R_NONNULL func_name)
 	str = strip_dll_prefix (str, &dll_stripped);
 
 	if ((result = type_func_try_guess (TDB, str))) {
+		return result;
+	}
+
+	// afs stores prototypes under the prefixed name, retry it unstripped
+	if (str != func_name && (result = type_func_try_guess (TDB, func_name))) {
 		return result;
 	}
 

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -2446,3 +2446,49 @@ EXPECT=<<EOF
 0x00000004
 EOF
 RUN
+
+NAME=tfv xref resolves afs prototype on prefixed function name
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.xrefs=true
+CMDS=<<EOF
+wa mov edi, 5
+wa call 0x20 @ 0x5
+wa ret @ 0x20
+af @ 0x20
+afn sym.foo @ 0x20
+s 0x20
+'afs int sym.foo(int myarg)
+af @ 0x0
+afn caller @ 0x0
+tfv sym.foo
+EOF
+EXPECT=<<EOF
+             ; XREF[x] 0x00000005 caller
+0x00000000 int sym.foo ( // cc:cdecl ret:?
+0x00000000   int myarg // stack
+0x00000004 );
+EOF
+RUN
+
+NAME=tfv xref resolves afs prototype on import-prefixed function name
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.xrefs=true
+CMDS=<<EOF
+wa mov edi, 5
+wa call 0x20 @ 0x5
+wa ret @ 0x20
+af @ 0x20
+afn sym.imp.bar @ 0x20
+s 0x20
+'afs int sym.imp.bar(int myarg)
+af @ 0x0
+afn caller @ 0x0
+tfv sym.imp.bar
+EOF
+EXPECT=<<EOF
+             ; XREF[x] 0x00000005 caller
+0x00000000 int sym.imp.bar ( // cc:cdecl ret:?
+0x00000000   int myarg // stack
+0x00000004 );
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_type_func_guess` strips `sym.`/`sub.` prefixes before lookup, but `afs` stores prototypes under the prefixed name (`func.sym.foo`), so guess-only consumers (type propagation, r2ghidra) never find them. Retry the original unstripped name as a fallback.