### PR TITLE
Fix qjs subproject build on i386 (alpine-x86-32 / iSH) ##build

### DIFF
--- a/shlr/qjs/deps.mk
+++ b/shlr/qjs/deps.mk
@@ -3,6 +3,11 @@ include ../../libr/config.mk
 LINK_QJS_ARCHIVE=0
 QJS_LIBC=0
 QJS_CFLAGS+=-Dutf8_encode=utf8_encode_r2
+# Build qjs without inline assembly. Its only inline asm is the 32-bit x86
+# x87 FPU control-word macro in cutils.h, which on i386 (e.g. alpine-x86-32 /
+# iSH) expands to a declaration right after a label and breaks the build (and
+# the fnstcw/fldcw ops are unreliable under x86 emulators). No-op elsewhere.
+QJS_CFLAGS+=-DJS_NO_INLINE_ASM
 
 ifeq ($(OSTYPE),android)
 # Android's clang/lld can leave references to QuickJS cutils static inlines.

--- a/subprojects/packagefiles/qjs/meson.build
+++ b/subprojects/packagefiles/qjs/meson.build
@@ -11,6 +11,12 @@ incs = include_directories('.')
 
 qjs_c_args = ['-DWIN32_LEAN_AND_MEAN', '-D_WIN32_WINNT=0x0602']
 
+# Build qjs without inline assembly (see the cutils.h i386-fpcw-optout patch).
+# Its only inline asm is the 32-bit x86 x87 FPU control-word macro, which on
+# i386 (e.g. alpine-x86-32 / iSH) expands to a declaration right after a label
+# and breaks the build. No-op on every other target.
+qjs_c_args += ['-DJS_NO_INLINE_ASM']
+
 visibility_flags = [
   '-fvisibility=hidden',
   '-Dutf8_encode=utf8_encode_r2'

--- a/subprojects/packagefiles/qjs/qjs-patches/i386-fpcw-optout.patch
+++ b/subprojects/packagefiles/qjs/qjs-patches/i386-fpcw-optout.patch
@@ -1,0 +1,13 @@
+diff --git a/cutils.h b/cutils.h
+index 358fa79..c192310 100644
+--- a/cutils.h
++++ b/cutils.h
+@@ -684,7 +684,7 @@ static inline int js_thread_join(js_thread_t thrd);
+ // and disable x87 80-bits extended precision for intermediate floating-point
+ // results. 0x300 is extended  precision, 0x200 is double precision.
+ // Note that `*&cw` in the asm constraints looks redundant but isn't.
+-#if defined(__i386__) && !defined(_MSC_VER)
++#if defined(__i386__) && !defined(_MSC_VER) && !defined(JS_NO_INLINE_ASM)
+ #define JS_X87_FPCW_SAVE_AND_ADJUST(cw)                                     \
+     unsigned short cw;                                                      \
+     __asm__ __volatile__("fnstcw %0" : "=m"(*&cw));                         \

--- a/subprojects/qjs.mk
+++ b/subprojects/qjs.mk
@@ -4,6 +4,7 @@ WRAP_wrap_git_url:=https://github.com/quickjs-ng/quickjs.git
 WRAP_wrap_git_revision:=3087a2ce5bcb66cc1fcd9f34d3e5ce3bd43a67d9
 WRAP_wrap_git_directory:=qjs
 WRAP_wrap_git_patch_directory:=qjs
+WRAP_wrap_git_diff_files:=qjs/qjs-patches/i386-fpcw-optout.patch
 WRAP_wrap_git_depth:=1
 
 .PHONY: qjs_clean qjs_all
@@ -16,6 +17,7 @@ qjs_all:
 	cd qjs && git fetch --depth=1 origin 3087a2ce5bcb66cc1fcd9f34d3e5ce3bd43a67d9
 	cd qjs && git checkout FETCH_HEAD
 	cp -rf packagefiles/qjs/* qjs
+	for a in qjs/qjs-patches/i386-fpcw-optout.patch ; do echo "patch -d qjs -p1 < $$a" ; patch -d qjs -p1 < $$a ; done
 
 qjs_clean:
 	rm -rf qjs

--- a/subprojects/qjs.wrap
+++ b/subprojects/qjs.wrap
@@ -3,4 +3,5 @@ url = https://github.com/quickjs-ng/quickjs.git
 revision = 3087a2ce5bcb66cc1fcd9f34d3e5ce3bd43a67d9
 directory = qjs
 patch_directory = qjs
+diff_files = qjs/qjs-patches/i386-fpcw-optout.patch
 depth = 1


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The qjs subproject fails to compile on 32-bit x86 (e.g. Alpine x86-32 under iSH) with:

```
subprojects/qjs/cutils.h:689:5: error: a label can only be part of a
statement and a declaration is not a statement
  689 |     unsigned short cw;
note: in expansion of macro 'JS_X87_FPCW_SAVE_AND_ADJUST'
```

**Root cause:** quickjs-ng's `JS_X87_FPCW_SAVE_AND_ADJUST` macro (in `cutils.h`) expands to a *declaration* (`unsigned short cw;`) as its very first token. On i386 this macro is used immediately after the `handle_float64:` label in `js_binary_arith_slow()` (`quickjs.c`). In C a label can only be followed by a *statement*, not a declaration, so strict compilers reject it. This only affects the `#if defined(__i386__) && !defined(_MSC_VER)` path, which is why it shows up on 32-bit x86 builds and not on x86-64/arm.

**Fix:** this x87 control-word macro is the *only* inline assembly in the entire qjs codebase (verified by grepping `quickjs.c`, `libregexp.c`, `libunicode.c`, `dtoa.c` and their headers at the pinned revision). So the patch adds a `JS_NO_INLINE_ASM` opt-out to the macro's i386 guard, and the qjs subproject is built with `-DJS_NO_INLINE_ASM` — compiling the inline asm out entirely. With the macro empty, the call site collapses to a lone `;` (a valid null statement after the label), so the build error is gone. It also avoids the `fnstcw`/`fldcw` instructions, which are unreliable under x86 emulators like iSH. The define is a no-op on every non-i386 target (the macro is already empty there).

Trade-off: on 32-bit x86 this disables the strict double-precision rounding of x87 intermediate float results. In rare edge cases that means extra (80-bit) precision instead of spec-mandated double rounding — invisible in practice for r2's scripting use, and only on i386.

**Changes:**

- `subprojects/packagefiles/qjs/qjs-patches/i386-fpcw-optout.patch` — adds `&& !defined(JS_NO_INLINE_ASM)` to the macro guard
- `subprojects/qjs.wrap` / `subprojects/qjs.mk` — wire the patch in via the same `diff_files` mechanism capstone already uses
- `shlr/qjs/deps.mk` — adds `-DJS_NO_INLINE_ASM` to `QJS_CFLAGS` (Makefile build)
- `subprojects/packagefiles/qjs/meson.build` — adds `-DJS_NO_INLINE_ASM` to `qjs_c_args` (meson build)

Verified with `gcc -m32 -std=c99 -pedantic-errors`: reproduces the exact `-Wpedantic` error without the define and compiles cleanly with `-DJS_NO_INLINE_ASM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)