### PR TITLE
Don't recover TOC-pointer stack save as function argument ##anal

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1231,6 +1231,19 @@ static bool extract_arm_stack_restore_arg(RAnal *anal, RAnalFunction *fcn, RAnal
 	return true;
 }
 
+// the ppc PLT/call stubs save the TOC pointer (std/ld r2, N(r1)) into the caller linkage area, which is not an incoming stack arg
+static bool op_is_ppc_toc_save(RAnal *anal, RAnalOp *op) {
+	const ut32 ot = op->type & R_ANAL_OP_TYPE_MASK;
+	if (ot != R_ANAL_OP_TYPE_STORE && ot != R_ANAL_OP_TYPE_LOAD) {
+		return false;
+	}
+	if (strcmp (anal->config->arch, "ppc")) {
+		return false;
+	}
+	RAnalValue *toc = RVecRArchValue_at (ot == R_ANAL_OP_TYPE_STORE? &op->srcs: &op->dsts, 0);
+	return toc && toc->reg && !strcmp (toc->reg, "r2");
+}
+
 static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char *reg, const char *sign, char type) {
 	st64 ptr = 0;
 	const st64 maxstackframe = 1024 * 8;
@@ -1243,6 +1256,10 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 	R_RETURN_IF_FAIL (anal && fcn && op && reg);
 
 	r_anal_function_cc (fcn); // resolve a lazy dyncc marker before reading fcn->callconv
+
+	if (op_is_ppc_toc_save (anal, op)) {
+		return;
+	}
 
 	R_VEC_FOREACH (&op->srcs, val) {
 		if (extract_arg_from_value (anal, val, reg, sign, &ptr, &access_size)) {

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1202,3 +1202,25 @@ EXPECT=<<EOF2
 "sh -c clear"
 EOF2
 RUN
+
+NAME=ppc plt-call stub toc save is not recovered as an argument
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF2
+aa
+afs @ loc.00000018.plt_call.__libc_start_main
+EOF2
+EXPECT=<<EOF2
+void loc.00000018.plt_call.__libc_start_main ();
+EOF2
+RUN
+
+NAME=ppc toc restore load is not recovered as an argument
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF2
+aa
+afs @ fcn.10000c54
+EOF2
+EXPECT=<<EOF2
+void fcn.10000c54 (int64_t arg1, int64_t arg_10h);
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ppc PLT/call stubs save the TOC pointer into the caller linkage area (std r2, N(r1)). r2's stack-arg recovery misread that ABI store as an incoming argument, so every ppc64 import trampoline gained a phantom arg. extract_arg now skips a store of r2 on ppc but requires arch==ppc; test in db/anal/ppc (reuses ppc64_sudoku_dwarf). 
