### PR TITLE
Fix AArch64 ELF relocation patching ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1059,7 +1059,6 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			r_write_ble64 (buf, V, bo->endian);
 			iob->overlay_write_at (iob->io, rel->rva, buf, 8);
 			break;
-
 		case R_AARCH64_GLOB_DAT:
 		case R_AARCH64_JUMP_SLOT:
 		case R_AARCH64_ABS64:

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1054,6 +1054,19 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			iob->overlay_write_at (iob->io, rel->rva, buf, 4);
 			break;
 		}
+		case R_AARCH64_RELATIVE:
+			V = B + A;
+			r_write_ble64 (buf, V, bo->endian);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 8);
+			break;
+
+		case R_AARCH64_GLOB_DAT:
+		case R_AARCH64_JUMP_SLOT:
+		case R_AARCH64_ABS64:
+			V = S + A;
+			r_write_ble64 (buf, V, bo->endian);
+			iob->overlay_write_at (iob->io, rel->rva, buf, 8);
+			break;
 		default:
 			V = S + A;
 			iob->read_at (iob->io, rel->rva, buf, 8);

--- a/test/db/formats/elf/reloc-arm64
+++ b/test/db/formats/elf/reloc-arm64
@@ -395,3 +395,29 @@ vaddr      paddr      type   ntype name
 0x0007ce98 0x0007be98 SET_64 1027
 EOF
 RUN
+
+NAME=elf/arm64 relocs.apply patches RELATIVE entries
+FILE=bins/elf/libtool-checker.so
+ARGS=-e bin.relocs.apply=true -e bin.cache=true
+CMDS=<<EOF
+pxq 8 @ 0x2d78
+pxq 8 @ 0x2d80
+pxq 8 @ 0x2d88
+EOF
+EXPECT=<<EOF
+0x00002d78  0x00000000000009a0                       ........
+0x00002d80  0x0000000000000990                       ........
+0x00002d88  0x0000000000002d88                       .-......
+EOF
+RUN
+
+NAME=elf/arm64 relocs.apply patches JUMP_SLOT entries
+FILE=bins/elf/ls-toybox
+ARGS=-e bin.relocs.apply=true -e bin.cache=true
+CMDS=<<EOF
+pxq 8 @ 0x0007b480
+EOF
+EXPECT=<<EOF
+0x0007b480  0x0000000000083a09                       .:......
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix AArch64 ELF relocation application for common 64-bit data relocations.

The Arm AArch64 ELF ABI defines the relocation nomenclature in `aaelf64.rst`:

- `S` is the address of the symbol.
- `A` is the addend for the relocation.
- `P` is the address of the place being relocated, derived from `r_offset`.
- `Delta` is the difference between the static link address of `P` and the execution address of `P`.

Reference:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1042-L1064

The same document defines the relevant dynamic relocation operations as:

- `R_<CLS>_ABS64`: `S + A`
- `R_<CLS>_GLOB_DAT`: `S + A`
- `R_<CLS>_JUMP_SLOT`: `S + A`
- `R_<CLS>_RELATIVE`: `Delta + A`

Reference:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1891-L1916

It also notes that, except for `R_<CLS>_COPY`, dynamic relocations relocate aligned data locations: 8-byte aligned 64-bit data locations for ELF64, or 4-byte aligned 32-bit data locations for ELF32.

Reference:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1940-L1942

Previously, the AArch64 relocation patching path could fall through to the generic fallback, which writes:

```c
addr ? A : S
```

This can produce incorrect results. In particular, for `R_AARCH64_JUMP_SLOT` entries where `A == 0` and the destination slot is already nonzero, the fallback writes `0` instead of the resolved `S + A` value.

The ABI notes that `R_<CLS>_JUMP_SLOT` is used for code targets that will be executed. It also states that the initial value stored in the place is not related to the ultimate target of the relocation, and that the addend `A` for such a REL-type relocation should be zero instead of the initial content of the place.

Reference:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1950-L1960

For `R_<CLS>_RELATIVE`, the ABI describes it as a relative adjustment to the place based on the load address of the object relative to its original link address.

References:
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1962-L1962
https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst?plain=1#L1915

This patch adds explicit handling for:

- `R_AARCH64_RELATIVE`: `B + A`, corresponding to the ABI `Delta + A` load-base adjustment
- `R_AARCH64_GLOB_DAT`: `S + A`
- `R_AARCH64_JUMP_SLOT`: `S + A`
- `R_AARCH64_ABS64`: `S + A`

This improves relocation application for AArch64 ELF binaries, which helps reverse engineering Android shared libraries and improves pointer/string resolution in cases such as Unity/IL2CPP binaries.

Regression coverage was added to:

```text
test/db/formats/elf/reloc-arm64
```

The new tests cover `bin.relocs.apply=true` for:

- `RELATIVE` relocation patching
- `JUMP_SLOT` relocation patching

Before this fix, the new `JUMP_SLOT` regression test failed:

```text
expected: 0x0007b480  0x0000000000083a09
actual:   0x0007b480  0x0000000000000000
```

After this fix:

```text
r2r test/db/formats/elf/reloc-arm64

[4/4] 4 OK
```