### PR TITLE
Add r_str_printf_to_types/r_str_printf_to_pf and the pfp command ##util

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -436,6 +436,7 @@ static RCoreHelpMessage help_msg_pf = {
 	"pfj ", "fmt_name|fmt", "show data using (named) format in JSON",
 	"pfo", " fdf_name", "load a Format Definition File (fdf)",
 	"pfo", "", "list all format definition files (fdf)",
+	"pfp", " printf-fmt", "convert a printf-style format string to a pf format string (honors asm.bits)",
 	"pfq", " fmt ...", "quiet print format (do now show address)",
 	"pfs", "[.fmt_name|fmt]", "print the size of (named) format in bytes",
 	"pfv.", "fmt_name[.field]", "print value(s) only for named format. Useful for one-liners",
@@ -2444,6 +2445,34 @@ static void cmd_pfb(RCore *core, const char *_input) {
 	}
 }
 
+static void cmd_pfp(RCore *core, const char *_input) {
+	switch (_input[2]) {
+	case ' ':
+		{
+			const char *fmt = r_str_trim_head_ro (_input + 2);
+			if (R_STR_ISEMPTY (fmt)) {
+				r_core_cmd_help_match (core, help_msg_pf, "pfp");
+				break;
+			}
+			char *s = r_str_printfmt (fmt, '*', r_config_get_i (core->config, "asm.bits"));
+			if (!s) {
+				R_LOG_ERROR ("Cannot map printf format string to pf");
+				break;
+			}
+			r_cons_println (core->cons, s);
+			free (s);
+		}
+		break;
+	case '?':
+	case 0:
+		r_core_cmd_help_match (core, help_msg_pf, "pfp");
+		break;
+	default:
+		r_core_return_invalid_command (core, "pfp", _input[2]);
+		break;
+	}
+}
+
 static bool is_pfo_file(const char *fn) {
 	if (*fn != '.') {
 		if (r_str_endswith (fn, ".r2")) {
@@ -2545,6 +2574,9 @@ static void cmd_print_format(RCore *core, const char *_input, const ut8 *block, 
 		return;
 	case 'b': // "pfb"
 		cmd_pfb (core, _input);
+		return;
+	case 'p': // "pfp"
+		cmd_pfp (core, _input);
 		return;
 	case 'o': // "pfo"
 		if (_input[2] == '?') {

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -2454,7 +2454,7 @@ static void cmd_pfp(RCore *core, const char *_input) {
 				r_core_cmd_help_match (core, help_msg_pf, "pfp");
 				break;
 			}
-			char *s = r_str_printfmt (fmt, '*', r_config_get_i (core->config, "asm.bits"));
+			char *s = r_str_printfmt (fmt, r_config_get_i (core->config, "asm.bits"), '*');
 			if (!s) {
 				R_LOG_ERROR ("Cannot map printf format string to pf");
 				break;

--- a/libr/include/r_lib.h
+++ b/libr/include/r_lib.h
@@ -23,7 +23,7 @@ R_LIB_VERSION_HEADER (r_lib);
 // double-indirection required because cpp is crap
 #define STRINGIFY2(x) #x
 #define STRINGIFY(x) STRINGIFY2(x)
-#define R2_ABIVERSION 111
+#define R2_ABIVERSION 112
 #define R2_ABIVERSION_STRING STRINGIFY(R2_ABIVERSION)
 
 #define R_LIB_ENV "R2_LIBR_PLUGINS"

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -149,7 +149,7 @@ R_API const char *r_str_perm(int perm, bool with_dash);
 R_API const char *r_str_rwx_i(int rwx);  // Deprecated: use r_str_perm(rwx, false)
 R_API const char *r_str_srwx_i(int rwx);  // Deprecated: use r_str_perm(rwx, true)
 R_API int r_str_fmtargs(const char *fmt);
-R_API char *r_str_printfmt(const char *fmt, int mode, int bits);
+R_API char *r_str_printfmt(const char *fmt, int bits, int mode);
 R_API char *r_str_arg_escape(const char *arg);
 R_API int r_str_arg_unescape(char *arg);
 R_API char **r_str_argv(const char *str, int *_argc);

--- a/libr/include/r_util/r_str.h
+++ b/libr/include/r_util/r_str.h
@@ -149,6 +149,7 @@ R_API const char *r_str_perm(int perm, bool with_dash);
 R_API const char *r_str_rwx_i(int rwx);  // Deprecated: use r_str_perm(rwx, false)
 R_API const char *r_str_srwx_i(int rwx);  // Deprecated: use r_str_perm(rwx, true)
 R_API int r_str_fmtargs(const char *fmt);
+R_API char *r_str_printfmt(const char *fmt, int mode, int bits);
 R_API char *r_str_arg_escape(const char *arg);
 R_API int r_str_arg_unescape(char *arg);
 R_API char **r_str_argv(const char *str, int *_argc);

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3921,6 +3921,146 @@ R_API char *r_str_from_ut64(ut64 val) {
 	return str;
 }
 
+static void conv_append(RStrBuf *sb, bool as_pf, const char *type, const char *pf) {
+	if (as_pf) {
+		r_strbuf_append (sb, pf);
+		return;
+	}
+	if (r_strbuf_length (sb)) {
+		r_strbuf_append (sb, ",");
+	}
+	r_strbuf_append (sb, type);
+}
+
+static const char *skip_digits(const char *p) {
+	while (isdigit ((unsigned char)*p)) {
+		p++;
+	}
+	return p;
+}
+
+// mode '*' returns a pf format string (bits resolves long/size_t/pointer width); otherwise a comma-separated list of C type names; NULL if any conversion is unsupported
+R_API char *r_str_printfmt(const char *fmt, int mode, int bits) {
+	R_RETURN_VAL_IF_FAIL (fmt, NULL);
+	const bool as_pf = mode == '*';
+	const bool w8 = bits == 64;
+	RStrBuf *sb = r_strbuf_new ("");
+	if (!sb) {
+		return NULL;
+	}
+	for (const char *p = fmt; *p; p++) {
+		if (*p != '%') {
+			continue;
+		}
+		p++;
+		if (*p == '%') {
+			continue;
+		}
+		if (*p == '\0') {
+			goto fail;
+		}
+		if (*skip_digits (p) == '$') {
+			goto fail; // positional %m$ unsupported
+		}
+		while (*p && strchr ("-+ #0'", *p)) {
+			p++;
+		}
+		if (*p == '*') {
+			conv_append (sb, as_pf, "int", "i");
+			p++;
+		} else {
+			p = skip_digits (p);
+		}
+		if (*p == '.') {
+			p++;
+			if (*p == '*') {
+				conv_append (sb, as_pf, "int", "i");
+				p++;
+			} else {
+				p = skip_digits (p);
+			}
+		}
+		int isize = 4; // default-promoted int
+		bool longdbl = false;
+		if (*p == 'h') {
+			p++;
+			if (*p == 'h') {
+				p++;
+			}
+		} else if (*p == 'l') {
+			p++;
+			if (*p == 'l') {
+				p++;
+				isize = 8;
+			} else {
+				isize = 0; // long
+			}
+		} else if (*p == 'L') {
+			p++;
+			longdbl = true;
+		} else if (*p == 'j' || *p == 'q') {
+			p++;
+			isize = 8;
+		} else if (*p == 'z' || *p == 't') {
+			p++;
+			isize = 0;
+		}
+		const bool wide = (isize == 8) || (isize == 0 && w8);
+		const char *type = NULL, *pf = NULL;
+		switch (*p) {
+		case 'd': case 'i':
+			type = isize == 8? "long long": isize == 0? "long": "int";
+			pf = wide? "q": "i";
+			break;
+		case 'u': case 'o': case 'x': case 'X':
+			type = isize == 8? "unsigned long long": isize == 0? "unsigned long": "unsigned int";
+			pf = wide? "q": "x";
+			break;
+		case 'c':
+			type = "int";
+			pf = "i";
+			break;
+		case 's':
+			type = "char *";
+			pf = w8? "S": "s";
+			break;
+		case 'p':
+			type = "void *";
+			pf = "p";
+			break;
+		case 'n':
+			type = "int *";
+			pf = "p";
+			break;
+		case 'f': case 'F': case 'e': case 'E': case 'g': case 'G': case 'a': case 'A':
+			type = longdbl? "long double": "double";
+			pf = longdbl? "G": "F";
+			break;
+		default:
+			goto fail;
+		}
+		conv_append (sb, as_pf, type, pf);
+	}
+	return r_strbuf_drain (sb);
+fail:
+	r_strbuf_free (sb);
+	return NULL;
+}
+
+R_API int r_str_fmtargs(const char *fmt) {
+	int n = 0;
+	while (*fmt) {
+		if (*fmt == '%') {
+			if (fmt[1] == '*') {
+				n++;
+			}
+			n++;
+		}
+		fmt++;
+	}
+	return n;
+}
+
 // Strips all the lines in str that contain key
 R_API void r_str_stripLine(char *str, const char *key) {
 	if (!str || !key) {
@@ -3979,21 +4119,6 @@ R_API char *r_str_array_join(const char **a, size_t n, const char *sep) {
 		r_strbuf_append (sb, a[i]);
 	}
 	return r_strbuf_drain (sb);
-}
-
-/* return the number of arguments expected as extra arguments */
-R_API int r_str_fmtargs(const char *fmt) {
-	int n = 0;
-	while (*fmt) {
-		if (*fmt == '%') {
-			if (fmt[1] == '*') {
-				n++;
-			}
-			n++;
-		}
-		fmt++;
-	}
-	return n;
 }
 
 // str-bool

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -3940,7 +3940,7 @@ static const char *skip_digits(const char *p) {
 }
 
 // mode '*' returns a pf format string (bits resolves long/size_t/pointer width); otherwise a comma-separated list of C type names; NULL if any conversion is unsupported
-R_API char *r_str_printfmt(const char *fmt, int mode, int bits) {
+R_API char *r_str_printfmt(const char *fmt, int bits, int mode) {
 	R_RETURN_VAL_IF_FAIL (fmt, NULL);
 	const bool as_pf = mode == '*';
 	const bool w8 = bits == 64;

--- a/test/db/cmd/cmd_pf
+++ b/test/db/cmd/cmd_pf
@@ -1069,3 +1069,28 @@ EXPECT=<<EOF
 ]
 EOF
 RUN
+
+NAME=pfp printf format string to pf (64bit)
+FILE=-
+ARGS=-e asm.bits=64
+CMDS=pfp %s%d%f%x
+EXPECT=<<EOF2
+SiFx
+EOF2
+RUN
+
+NAME=pfp printf format string to pf (32bit)
+FILE=-
+ARGS=-e asm.bits=32
+CMDS=pfp %ld%s
+EXPECT=<<EOF2
+is
+EOF2
+RUN
+
+NAME=pfp rejects unsupported format
+FILE=-
+CMDS=pfp %1$s
+EXPECT=<<EOF2
+EOF2
+RUN

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -831,6 +831,33 @@ bool test_r_str_font(void) {
 	mu_end;
 }
 
+bool test_r_str_printfmt_types(void) {
+	mu_assert_streq_free (r_str_printfmt ("%s %d %f %x\n", 0, 0),
+		"char *,int,double,unsigned int", "printf conversions to C types");
+	mu_assert_streq_free (r_str_printfmt ("%ld %lld %zu", 0, 0),
+		"long,long long,unsigned long", "length modifiers");
+	mu_assert_streq_free (r_str_printfmt ("%c %p %Lf", 0, 0),
+		"int,void *,long double", "char/pointer/long double");
+	mu_assert_streq_free (r_str_printfmt ("%*d", 0, 0),
+		"int,int", "star width consumes an int arg");
+	mu_assert_streq_free (r_str_printfmt ("100%% done", 0, 0),
+		"", "literal percent takes no arg");
+	mu_assert_null (r_str_printfmt ("%1$s", 0, 0), "positional args unsupported");
+	mu_assert_null (r_str_printfmt ("%y", 0, 0), "unknown conversion rejected");
+	mu_end;
+}
+
+bool test_r_str_printfmt_pf(void) {
+	mu_assert_streq_free (r_str_printfmt ("%s %d %f %x\n", '*', 64),
+		"SiFx", "printf conversions to pf (64-bit)");
+	mu_assert_streq_free (r_str_printfmt ("%ld %p", '*', 64),
+		"qp", "long is qword on 64-bit");
+	mu_assert_streq_free (r_str_printfmt ("%ld %s", '*', 32),
+		"is", "long is dword-signed and string ptr is 32-bit on 32-bit");
+	mu_assert_null (r_str_printfmt ("%y", '*', 64), "unknown conversion rejected");
+	mu_end;
+}
+
 bool all_tests(void) {
 	mu_run_test (test_r_file);
 	mu_run_test (test_r_str_wrap);
@@ -873,6 +900,8 @@ bool all_tests(void) {
 	mu_run_test (test_r_str_ndup_zero_len);
 	mu_run_test (test_r_str_word_get0set);
 	mu_run_test (test_r_str_font);
+	mu_run_test (test_r_str_printfmt_types);
+	mu_run_test (test_r_str_printfmt_pf);
 	return tests_passed != tests_run;
 }
 

--- a/test/unit/test_str.c
+++ b/test/unit/test_str.c
@@ -848,13 +848,13 @@ bool test_r_str_printfmt_types(void) {
 }
 
 bool test_r_str_printfmt_pf(void) {
-	mu_assert_streq_free (r_str_printfmt ("%s %d %f %x\n", '*', 64),
+	mu_assert_streq_free (r_str_printfmt ("%s %d %f %x\n", 64, '*'),
 		"SiFx", "printf conversions to pf (64-bit)");
-	mu_assert_streq_free (r_str_printfmt ("%ld %p", '*', 64),
+	mu_assert_streq_free (r_str_printfmt ("%ld %p", 64, '*'),
 		"qp", "long is qword on 64-bit");
-	mu_assert_streq_free (r_str_printfmt ("%ld %s", '*', 32),
+	mu_assert_streq_free (r_str_printfmt ("%ld %s", 32, '*'),
 		"is", "long is dword-signed and string ptr is 32-bit on 32-bit");
-	mu_assert_null (r_str_printfmt ("%y", '*', 64), "unknown conversion rejected");
+	mu_assert_null (r_str_printfmt ("%y", 64, '*'), "unknown conversion rejected");
 	mu_end;
 }
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Two `r_str` helpers that map a printf-family format string to its variadic argument types:

- `r_str_printf_to_types(fmt)` → CSV of C types (`"char *,int,double"`)
- `r_str_printf_to_pf(fmt, bits)` → pf format string (`"Sif"`), width-aware

Returns NULL on any unmodelable/positional conversion. Exposed via the new `pfp` command (honors `asm.bits`). Unit tests in `test_str` and command tests in `db/cmd/cmd_pf`.
  
Lets decompilers (pdc, and r2ghidra via the API) recover printf call-site varargs from the format string.