### PR TITLE
Use temporary variable for safe realloc in libtcc.c

### DIFF
--- a/libr/anal/c/libtcc.c
+++ b/libr/anal/c/libtcc.c
@@ -67,7 +67,7 @@ ST_FUNC void dynarray_add(void ***ptab, int *nb_ptr, void *data) {
 			nb_alloc = nb * 2;
 		}
 		void **tmp_pp = realloc (pp, nb_alloc * sizeof (void *));
-		if (!tmp_pp){
+		if (!tmp_pp) {
 			return;
 		}
 		pp = tmp_pp;

--- a/libr/anal/c/libtcc.c
+++ b/libr/anal/c/libtcc.c
@@ -66,7 +66,11 @@ ST_FUNC void dynarray_add(void ***ptab, int *nb_ptr, void *data) {
 		} else {
 			nb_alloc = nb * 2;
 		}
-		pp = realloc (pp, nb_alloc * sizeof (void *));
+		void **tmp_pp = realloc (pp, nb_alloc * sizeof (void *));
+		if (!tmp_pp){
+			return;
+		}
+		pp = tmp_pp;
 		*ptab = pp;
 	}
 	pp[nb++] = data;


### PR DESCRIPTION
- [√ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix memory leak and null dereference in dynarray_add when realloc fails

Signed-off-by: wanhui [wanhui@uniontech.com](mailto:wanhui@uniontech.com)