### PR TITLE
Expand printf-family varargs from the format string in emu call comments ##disasm

### DIFF
--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -201,6 +201,94 @@ static void r_anal_function_arg_free(RAnalFuncArg *arg) {
 	}
 }
 
+// printf-family formatters whose vararg list is described by the fixed arg right before "..."
+static bool is_format_function(const char *name) {
+	const char *base = r_str_rchr (name, NULL, '.');
+	base = base? base + 1: name;
+	static const char *const fns[] = {
+		"printf", "fprintf", "dprintf", "sprintf", "snprintf", "asprintf",
+		"syslog", "err", "errx", "warn", "warnx",
+		"wprintf", "fwprintf", "swprintf",
+		"__printf_chk", "__fprintf_chk", "__sprintf_chk", "__snprintf_chk", NULL
+	};
+	int i;
+	for (i = 0; fns[i]; i++) {
+		if (!strcmp (base, fns[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static char *read_format_string(RCore *core, ut64 ptr) {
+	if (!ptr || ptr == UT64_MAX) {
+		return NULL;
+	}
+	ut8 buf[256];
+	if (!r_io_read_at (core->io, ptr, buf, sizeof (buf) - 1)) {
+		return NULL;
+	}
+	buf[sizeof (buf) - 1] = 0;
+	if (!buf[0] || !IS_PRINTABLE (buf[0])) {
+		return NULL;
+	}
+	return strdup ((const char *)buf);
+}
+
+static RAnalFuncArg *make_vararg(RCore *core, const char *cc, int slot, const char *ctype, ut64 *spv, ut64 s_width) {
+	RAnalFuncArg *arg = R_NEW0 (RAnalFuncArg);
+	arg->orig_c_type = strdup (ctype);
+	arg->c_type = arg->orig_c_type;
+	arg->name = "";
+	arg->size = s_width;
+	// "z" makes print_fcn_arg/print_format_values render the string; scalars print their raw value
+	arg->fmt = !strcmp (ctype, "char *")? "z": NULL;
+	arg->cc_source = r_anal_cc_argloc (core->anal, cc, slot, 0, -1);
+	if (cc_source_on_stack (core->anal, arg->cc_source)) {
+		arg->src = *spv;
+		*spv += s_width;
+	} else {
+		const char *reg = cc_source_reg (core->anal, arg->cc_source);
+		if (reg) {
+			arg->src = r_reg_getv (core->anal->reg, reg);
+		}
+	}
+	return arg;
+}
+
+// false leaves the "..." placeholder in place: the format arg isn't a resolvable literal
+static bool append_format_varargs(RCore *core, RList *list, const char *cc, int nargs, ut64 *spv, ut64 s_width) {
+	const char *floc = r_anal_cc_argloc (core->anal, cc, nargs - 2, 0, -1);
+	const char *freg = cc_source_reg (core->anal, floc);
+	if (!freg) {
+		return false;
+	}
+	char *fmt = read_format_string (core, r_reg_getv (core->anal->reg, freg));
+	if (!fmt) {
+		return false;
+	}
+	char *types = r_str_printfmt (fmt, core->anal->config->bits, 0);
+	free (fmt);
+	if (!types) {
+		return false;
+	}
+	int k = 0;
+	char *vt = types;
+	while (*vt) {
+		char *comma = strchr (vt, ',');
+		char *t = comma? r_str_ndup (vt, comma - vt): strdup (vt);
+		r_list_append (list, make_vararg (core, cc, nargs - 1 + k, t, spv, s_width));
+		free (t);
+		k++;
+		if (!comma) {
+			break;
+		}
+		vt = comma + 1;
+	}
+	free (types);
+	return true;
+}
+
 /* Returns a list of RAnalFuncArg */
 R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 	if (!fcn_name || !core->anal) {
@@ -231,7 +319,13 @@ R_API RList *r_core_get_func_args(RCore *core, const char *fcn_name) {
 			r_list_append (list, arg);
 		}
 	} else {
+		bool variadic = nargs > 1 && is_format_function (key)
+			&& !strcmp (r_type_func_args_name (TDB, key, nargs - 1), "...");
 		for (i = 0; i < nargs; i++) {
+			if (variadic && i == nargs - 1
+				&& append_format_varargs (core, list, cc, nargs, &spv, s_width)) {
+				continue;
+			}
 			RAnalFuncArg *arg = R_NEW0 (RAnalFuncArg);
 			set_fcn_args_info (arg, core->anal, key, cc, i);
 			if (cc_source_on_stack (core->anal, arg->cc_source)) {

--- a/test/db/cmd/cmd_pd
+++ b/test/db/cmd/cmd_pd
@@ -2363,3 +2363,18 @@ EXPECT=<<EOF
             0x00000000      48b8000000..   movabs rax, -9223372036854775808
 EOF
 RUN
+
+NAME=pdf emu expands printf-family varargs from the format string
+FILE=bins/elf/format
+CMDS=<<EOF2
+aa
+s main
+e asm.emu=1
+e emu.str=1
+e emu.write=1
+pdf~int printf("Results
+EOF2
+EXPECT=<<EOF2
+|                                                                      ; int printf("Results : a : %u , b: %ld\n", 0xffffffff, -1)
+EOF2
+RUN

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -664,3 +664,29 @@ EXPECT=<<EOF
         v0 = [obj.tc_meter_enable]
 EOF
 RUN
+
+NAME=pdc expands printf varargs from the literal format string
+FILE=bins/elf/format
+CMDS=<<EOF2
+aa
+s main
+pdc~printf("Results
+pdc~printf("msg
+EOF2
+EXPECT=<<EOF2
+         sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 21)
+         sym.imp.printf () // int printf("msg : %s\n", "")
+EOF2
+RUN
+
+NAME=pdc leaves x86-32 cdecl stack varargs unexpanded (register-ABI only)
+FILE=bins/elf/ioli/crackme0x00
+CMDS=<<EOF2
+aa
+s main
+pdc~printf("IOLI
+EOF2
+EXPECT=<<EOF2
+        sym.imp.printf () // int printf("IOLI Crackme Level 0x00\n", -1)
+EOF2
+RUN

--- a/test/db/formats/elf/riscv
+++ b/test/db/formats/elf/riscv
@@ -681,7 +681,7 @@ EXPECT=<<EOF
 |      ..-> 0x00010170      b7170200       lui a5, 0x21                ; a5=0x21000
 |      ::   0x00010174      1385874f       addi a0, a5, 1272           ; a0=0x214f8 "Enter your guess : " section..rodata
 |      ::   0x00010178      ef00c01f       jal ra, sym.printf          ; ra=0x1017c -> 0xfe840793 ; pc=0x10374 -> 0x8101b283
-|      ::                                                              ; int printf("Enter your guess : ", 0)
+|      ::                                                              ; int printf("Enter your guess : ")
 |      ::   0x0001017c      930784fe       addi a5, s0, -24            ; a5=0x177fe8
 |      ::   0x00010180      93850700       mv a1, a5                   ; a1=0x177fe8
 |      ::   0x00010184      b7170200       lui a5, 0x21                ; a5=0x21000


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_core_get_func_args` only returned the fixed args, so `pdc`/`pdf` emu call comments rendered a printf's `...` as one bogus placeholder:
  
    - int printf("count=%d name=%s\n", 0)
    + int printf("count=%d name=%s\n", 0, "")
      
When a printf-family callee has a literal format, parse it with `r_str_printfmt` and emit one typed arg per conversion. Falls back to the old placeholder when the format isn't a resolvable literal. Register-ABI only (x86-32 cdecl/stack args and FP-register `%f` values are left as-is).