### PR TITLE
Strip wrapping quotes from the afvt type argument ##anal

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2206,6 +2206,9 @@ static int cmd_afv(RCore *core, const char *str) {
 				return false;
 			}
 			if (type) {
+				r_str_trim (type);
+				// mid-line quotes reach the handler verbatim, keep them out of the type
+				r_str_trim_args (type);
 				r_anal_var_set_type (core->anal, v1, type);
 			} else {
 				r_cons_printf (core->cons, "%s\n", v1->type);

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -15,6 +15,22 @@ int64_t
 EOF
 RUN
 
+NAME=afvt strips wrapping quotes from the type
+FILE=bins/elf/ls
+CMDS=<<EOF
+s main
+af
+afvt argv "char *"
+afvt argv
+afvt argv 'int **'
+afvt argv
+EOF
+EXPECT=<<EOF
+char *
+int **
+EOF
+RUN
+
 NAME=pdf
 FILE=bins/elf/ls
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`afvt argv "char *"` stored the quotes verbatim in the variable type (mid-line quotes are not interpreted by the shell), producing a corrupt  type like `"char *"` that breaks downstream type consumers. `afvt` prints it unquoted so the corruption is invisible; `afvj` shows it.

Strip a matching pair of wrapping quotes (double or single) before setting the type. Adds a test in db/anal/vars.
