### PR TITLE
Make struct redefinitions replace the saved member list ##anal

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -543,7 +543,7 @@ R_API RList *r_anal_types_baselist(RAnal *anal) {
 static void save_struct(const RAnal *anal, const RAnalBaseType *type) {
 	R_RETURN_IF_FAIL (anal && type && type->name
 		&& type->kind == R_ANAL_BASE_TYPE_KIND_STRUCT);
-	char *kind = "struct";
+	const char *kind = "struct";
 	/*
 		C:
 		struct name {type param1; type param2; type paramN;};
@@ -554,9 +554,30 @@ static void save_struct(const RAnal *anal, const RAnalBaseType *type) {
 		struct.name.param2=type,4,0
 		struct.name.paramN=type,8,0
 	*/
+	Sdb *db = anal->sdb_types;
 	char *sname = r_str_sanitize_sdb_key (type->name);
+	char *key = r_str_newf ("%s.%s", kind, sname);
+	char *old = sdb_get (db, key, 0);
+	if (old && RVecAnalStructMember_empty (&type->struct_data.members)) {
+		// a forward declaration must not clobber the full definition
+		R_LOG_DEBUG ("Ignoring overwrite of type '%s' with an empty declaration", key);
+		free (old);
+		free (key);
+		free (sname);
+		return;
+	}
+	if (old) {
+		// drop the members of the replaced definition before writing the new ones
+		char *p;
+		sdb_aforeach (p, old) {
+			r_strf_var (mk, KSZ, "%s.%s.%s", kind, sname, p);
+			sdb_unset (db, mk, 0);
+			sdb_aforeach_next (p);
+		}
+		free (old);
+	}
 	// name=struct
-	sdb_set (anal->sdb_types, sname, kind, 0);
+	sdb_set (db, sname, kind, 0);
 
 	RStrBuf *arglist = r_strbuf_new ("");
 
@@ -567,19 +588,13 @@ static void save_struct(const RAnal *anal, const RAnalBaseType *type) {
 		char *member_sname = r_str_sanitize_sdb_key (member->name);
 		r_strf_var (k, KSZ, "%s.%s.%s", kind, sname, member_sname);
 		r_strf_var (v, KSZ, "%s,%u,%u", member->type, (unsigned int)member->offset, (unsigned int)member->count);
-		sdb_set (anal->sdb_types, k, v, 0);
+		sdb_set (db, k, v, 0);
 		free (member_sname);
 
 		r_strbuf_appendf (arglist, (i++ == 0) ? "%s" : ",%s", member->name);
 	}
 	// struct.name=param1,param2,paramN
-	char *key = r_str_newf ("%s.%s", kind, sname);
-	if (sdb_exists (anal->sdb_types, key)) {
-		R_LOG_DEBUG ("Ignoring overwrite of type '%s' in sdb_types", key);
-		r_strbuf_free (arglist);
-	} else {
-		sdb_set_owned (anal->sdb_types, key, r_strbuf_drain (arglist), 0);
-	}
+	sdb_set_owned (db, key, r_strbuf_drain (arglist), 0);
 
 	free (key);
 	free (sname);

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -376,10 +376,59 @@ static bool test_anal_base_type_struct_array_roundtrip(void) {
 	mu_end;
 }
 
+static bool test_anal_save_base_type_struct_redefine(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("kappa");
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("bar")
+	};
+	RVecAnalStructMember_push_back (&base->struct_data.members, &member);
+	member.offset = 4;
+	member.type = strdup ("int32_t");
+	member.name = strdup ("cow");
+	RVecAnalStructMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	// a redefinition replaces the member list and drops the stale member keys
+	base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("kappa");
+	member.offset = 0;
+	member.type = strdup ("int64_t");
+	member.name = strdup ("cow");
+	RVecAnalStructMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	Sdb *reg = sdb_new0 ();
+	sdb_set (reg, "kappa", "struct", 0);
+	sdb_set (reg, "struct.kappa", "cow", 0);
+	sdb_set (reg, "struct.kappa.cow", "int64_t,0,0", 0);
+	assert_sdb_eq (anal->sdb_types, reg, "redefined struct type");
+
+	// an empty declaration must not clobber the full definition
+	base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("kappa");
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	assert_sdb_eq (anal->sdb_types, reg, "empty declaration kept the definition");
+	sdb_free (reg);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_struct);
 	mu_run_test (test_anal_save_base_type_struct);
 	mu_run_test (test_anal_base_type_struct_array_roundtrip);
+	mu_run_test (test_anal_save_base_type_struct_redefine);
 	mu_run_test (test_anal_get_base_type_union);
 	mu_run_test (test_anal_save_base_type_union);
 	mu_run_test (test_anal_get_base_type_enum);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`save_struct` refused to update the struct.<name> member-list key when it already existed (a workaround for #23557, where DWARF forward declarations clobbered complete definitions) while still rewriting the per-member keys — so re-saving a struct left a half-updated definition: stale member list, orphaned keys, new fields invisible.

Now an empty-member declaration still never overwrites an existing definition (keeping #23557 fixed), but a real redefinition replaces the member list and drops the previous member keys first, matching what save_union and save_enum already do.

Adds a unit test covering both cases (shrinking redefinition, empty declaration).
