### PR TITLE
Preserve struct member array counts through the base-type roundtrip ##types

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -606,6 +606,13 @@ static void parse_structure_type(Context *ctx, ut64 idx) {
 				RAnalStructMember *result = parse_struct_member (ctx, j, &member);
 				if (!result) {
 					goto cleanup;
+				}
+				if (kind == R_ANAL_BASE_TYPE_KIND_UNION) {
+					RAnalUnionMember *slot = RVecAnalUnionMember_emplace_back (&base_type->union_data.members);
+					slot->name = member.name;
+					slot->type = member.type;
+					slot->offset = member.offset;
+					slot->size = member.size;
 				} else {
 					RAnalStructMember *slot = RVecAnalStructMember_emplace_back (&base_type->struct_data.members);
 					*slot = member;

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -361,11 +361,13 @@ static RAnalBaseType *get_struct_type(RAnal *anal, const char *sname) {
 			free (values);
 			goto error;
 		}
-		offset = sdb_anext (offset, NULL);
+		char *count = NULL;
+		offset = sdb_anext (offset, &count);
 		RAnalStructMember cas = {
 			.name = strdup (cur),
 			.type = strdup (type),
-			.offset = strtol (offset, NULL, 10)
+			.offset = strtol (offset, NULL, 10),
+			.count = (count && *count) ? strtoul (count, NULL, 10) : 0
 		};
 
 		free (values);
@@ -561,10 +563,10 @@ static void save_struct(const RAnal *anal, const RAnalBaseType *type) {
 	int i = 0;
 	RAnalStructMember *member;
 	R_VEC_FOREACH (&type->struct_data.members, member) {
-		// struct.name.param=type,offset,argsize
+		// struct.name.param=type,offset,arraycount
 		char *member_sname = r_str_sanitize_sdb_key (member->name);
 		r_strf_var (k, KSZ, "%s.%s.%s", kind, sname, member_sname);
-		r_strf_var (v, KSZ, "%s,%u,0", member->type, (unsigned int)member->offset);
+		r_strf_var (v, KSZ, "%s,%u,%u", member->type, (unsigned int)member->offset, (unsigned int)member->count);
 		sdb_set (anal->sdb_types, k, v, 0);
 		free (member_sname);
 

--- a/libr/anal/type_pdb.c
+++ b/libr/anal/type_pdb.c
@@ -171,7 +171,9 @@ static void parse_structure(const RAnal *anal, STpiStream *ss, SType *type, RLis
 		type_info->get_name &&
 		type_info->get_val);
 
-	RAnalBaseType *base_type = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	bool is_struct = (type_info->leaf_type == eLF_STRUCTURE || type_info->leaf_type == eLF_CLASS);
+	RAnalBaseType *base_type = r_anal_base_type_new (
+		is_struct? R_ANAL_BASE_TYPE_KIND_STRUCT: R_ANAL_BASE_TYPE_KIND_UNION);
 	if (!base_type) {
 		return;
 	}
@@ -196,14 +198,17 @@ static void parse_structure(const RAnal *anal, STpiStream *ss, SType *type, RLis
 		if (!struct_member) {
 			continue; // skip the failure
 		}
-		RAnalStructMember *slot = RVecAnalStructMember_emplace_back (&base_type->struct_data.members);
-		*slot = *struct_member;
+		if (is_struct) {
+			RAnalStructMember *slot = RVecAnalStructMember_emplace_back (&base_type->struct_data.members);
+			*slot = *struct_member;
+		} else {
+			RAnalUnionMember *slot = RVecAnalUnionMember_emplace_back (&base_type->union_data.members);
+			slot->name = struct_member->name;
+			slot->type = struct_member->type;
+			slot->offset = struct_member->offset;
+			slot->size = struct_member->size;
+		}
 		free (struct_member);
-	}
-	if (type_info->leaf_type == eLF_STRUCTURE || type_info->leaf_type == eLF_CLASS) {
-		base_type->kind = R_ANAL_BASE_TYPE_KIND_STRUCT;
-	} else { // union
-		base_type->kind = R_ANAL_BASE_TYPE_KIND_UNION;
 	}
 	char *sname = r_str_sanitize_sdb_key (name);
 	base_type->name = sname;

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -206,6 +206,7 @@ typedef struct r_anal_struct_member_t {
 	char *type;
 	size_t offset; // in bytes
 	size_t size; // in bits? rename to 'bitsize'
+	size_t count; // array element count, 0 when not an array
 } RAnalStructMember;
 
 typedef struct r_anal_union_member_t {

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -338,9 +338,48 @@ static bool test_anal_get_base_type_not_found(void) {
 	mu_end;
 }
 
+static bool test_anal_base_type_struct_array_roundtrip(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("arr");
+
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("scalar"),
+		.count = 0
+	};
+	RVecAnalStructMember_push_back (&base->struct_data.members, &member);
+
+	member.offset = 4;
+	member.type = strdup ("char");
+	member.name = strdup ("buf");
+	member.count = 16;
+	RVecAnalStructMember_push_back (&base->struct_data.members, &member);
+
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	RAnalBaseType *got = r_anal_get_base_type (anal, "arr");
+	mu_assert_notnull (got, "reload struct with array member");
+
+	RAnalStructMember *m = RVecAnalStructMember_at (&got->struct_data.members, 0);
+	mu_assert_eq (m->count, 0, "scalar member count survives as 0");
+	m = RVecAnalStructMember_at (&got->struct_data.members, 1);
+	mu_assert_eq (m->offset, 4, "array member offset survives");
+	mu_assert_eq (m->count, 16, "array member count survives the roundtrip");
+
+	r_anal_base_type_free (got);
+	r_anal_free (anal);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_struct);
 	mu_run_test (test_anal_save_base_type_struct);
+	mu_run_test (test_anal_base_type_struct_array_roundtrip);
 	mu_run_test (test_anal_get_base_type_union);
 	mu_run_test (test_anal_save_base_type_union);
 	mu_run_test (test_anal_get_base_type_enum);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds an array element `count` to `RAnalStructMember` and wires it through `get_struct_type`/`save_struct`, so struct array fields survive the in-memory base-type roundtrip (the SDB already reserved the 3rd token; the model dropped it).

Growing the struct exposed a latent crash: `type_pdb.c` and `dwarf_process.c` built union types but filled `struct_data.members`, which only worked while struct and union members were the same size. First commit fixes both to fill the union member vec; second adds the count. Unit test covers the roundtrip; full r2r clean (0 regressions).
