### PR TITLE
Add clobber and preserve register sets for ppc and arm calling conventions ##anal

### DIFF
--- a/libr/anal/d/cc-arm-16.sdb.txt
+++ b/libr/anal/d/cc-arm-16.sdb.txt
@@ -7,6 +7,8 @@ cc.arm16.arg2=r2
 cc.arm16.arg3=r3
 cc.arm16.argn=stack
 cc.arm16.ret0=r0
+cc.arm16.clobber=r0,r1,r2,r3,r12,lr
+cc.arm16.preserve=r4,r5,r6,r7,r8,r9,r10,r11,sp
 
 arm32=cc
 cc.arm32.arg0=r0
@@ -15,3 +17,5 @@ cc.arm32.arg2=r2
 cc.arm32.arg3=r3
 cc.arm32.argn=stack
 cc.arm32.ret0=r0
+cc.arm32.clobber=r0,r1,r2,r3,r12,lr,d0,d1,d2,d3,d4,d5,d6,d7,d16,d17,d18,d19,d20,d21,d22,d23,d24,d25,d26,d27,d28,d29,d30,d31
+cc.arm32.preserve=r4,r5,r6,r7,r8,r9,r10,r11,sp,d8,d9,d10,d11,d12,d13,d14,d15

--- a/libr/anal/d/cc-arm-32.sdb.txt
+++ b/libr/anal/d/cc-arm-32.sdb.txt
@@ -7,6 +7,8 @@ cc.arm32.arg2=r2
 cc.arm32.arg3=r3
 cc.arm32.argn=stack
 cc.arm32.ret0=r0
+cc.arm32.clobber=r0,r1,r2,r3,r12,lr,d0,d1,d2,d3,d4,d5,d6,d7,d16,d17,d18,d19,d20,d21,d22,d23,d24,d25,d26,d27,d28,d29,d30,d31
+cc.arm32.preserve=r4,r5,r6,r7,r8,r9,r10,r11,sp,d8,d9,d10,d11,d12,d13,d14,d15
 
 arm16=cc
 cc.arm16.arg0=r0
@@ -16,6 +18,8 @@ cc.arm16.arg3=r3
 cc.arm16.arg4=r4
 cc.arm16.argn=stack
 cc.arm16.ret0=r0
+cc.arm16.clobber=r0,r1,r2,r3,r12,lr
+cc.arm16.preserve=r5,r6,r7,r8,r9,r10,r11,sp
 
 swift=cc
 cc.swift.arg0=r0

--- a/libr/anal/d/cc-arm-64.sdb.txt
+++ b/libr/anal/d/cc-arm-64.sdb.txt
@@ -11,6 +11,8 @@ cc.arm64.arg6=x6
 cc.arm64.arg7=x7
 cc.arm64.argn=stack
 cc.arm64.ret0=x0
+cc.arm64.clobber=x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x30,v0,v1,v2,v3,v4,v5,v6,v7,v16,v17,v18,v19,v20,v21,v22,v23,v24,v25,v26,v27,v28,v29,v30,v31
+cc.arm64.preserve=x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,sp,v8,v9,v10,v11,v12,v13,v14,v15
 
 swift=cc
 cc.swift.arg0=x0

--- a/libr/anal/d/cc-ppc-32.sdb.txt
+++ b/libr/anal/d/cc-ppc-32.sdb.txt
@@ -11,4 +11,6 @@ cc.ppc-32.arg6=r9
 cc.ppc-32.arg7=r10
 cc.ppc-32.argn=stack_rev
 cc.ppc-32.ret0=r3
+cc.ppc-32.clobber=r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
+cc.ppc-32.preserve=r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
 

--- a/libr/anal/d/cc-ppc-64.sdb.txt
+++ b/libr/anal/d/cc-ppc-64.sdb.txt
@@ -11,4 +11,6 @@ cc.ppc-64.arg6=r9
 cc.ppc-64.arg7=r10
 cc.ppc-64.argn=stack_rev
 cc.ppc-64.ret0=r3
+cc.ppc-64.clobber=r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
+cc.ppc-64.preserve=r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
 

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -1292,3 +1292,29 @@ EXPECT=<<EOF
 EOF
 EXPECT_ERR=
 RUN
+
+NAME=arm32 cc clobber and preserve register sets
+FILE=malloc://16
+ARGS=-a arm -b 32 -e anal.arch=arm
+CMDS=<<EOF
+k anal/cc/cc.arm32.clobber
+k anal/cc/cc.arm32.preserve
+EOF
+EXPECT=<<EOF
+r0,r1,r2,r3,r12,lr,d0,d1,d2,d3,d4,d5,d6,d7,d16,d17,d18,d19,d20,d21,d22,d23,d24,d25,d26,d27,d28,d29,d30,d31
+r4,r5,r6,r7,r8,r9,r10,r11,sp,d8,d9,d10,d11,d12,d13,d14,d15
+EOF
+RUN
+
+NAME=arm16 cc clobber and preserve register sets
+FILE=malloc://16
+ARGS=-a arm -b 16 -e anal.arch=arm
+CMDS=<<EOF
+k anal/cc/cc.arm16.clobber
+k anal/cc/cc.arm16.preserve
+EOF
+EXPECT=<<EOF
+r0,r1,r2,r3,r12,lr
+r4,r5,r6,r7,r8,r9,r10,r11,sp
+EOF
+RUN

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56258,3 +56258,16 @@ EXPECT=<<EOF
 0x1000060e0
 EOF
 RUN
+
+NAME=arm64 cc clobber and preserve register sets
+FILE=malloc://16
+ARGS=-a arm -b 64 -e anal.arch=arm
+CMDS=<<EOF
+k anal/cc/cc.arm64.clobber
+k anal/cc/cc.arm64.preserve
+EOF
+EXPECT=<<EOF
+x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x30,v0,v1,v2,v3,v4,v5,v6,v7,v16,v17,v18,v19,v20,v21,v22,v23,v24,v25,v26,v27,v28,v29,v30,v31
+x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,sp,v8,v9,v10,v11,v12,v13,v14,v15
+EOF
+RUN

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1253,3 +1253,47 @@ ldu
 0x00178008
 EOF2
 RUN
+
+NAME=ppc-64 cc clobber and preserve register sets
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e anal.arch=ppc
+CMDS=<<EOF
+k anal/cc/cc.ppc-64.clobber
+k anal/cc/cc.ppc-64.preserve
+EOF
+EXPECT=<<EOF
+r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
+r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
+EOF
+RUN
+
+NAME=ppc-32 cc clobber and preserve register sets
+FILE=malloc://16
+ARGS=-a ppc -b 32 -e anal.arch=ppc
+CMDS=<<EOF
+k anal/cc/cc.ppc-32.clobber
+k anal/cc/cc.ppc-32.preserve
+EOF
+EXPECT=<<EOF
+r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
+r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
+EOF
+RUN
+
+NAME=ppc-64 clobber kills r3 arg after call
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e anal.arch=ppc -e cfg.bigendian=true -e anal.cc=ppc-64
+CMDS=<<EOF
+wx 7c641b784800000d7c641b784e8000204e800020
+af @ 0
+afc ppc-64 @ 0
+af @ 0x10
+afc ppc-64 @ 0x10
+afva @ 0
+afvR @ 0
+EOF
+EXPECT=<<EOF
+      arg1  0x0
+      arg2  0x0
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The ppc-32/64 and arm16/32/64 calling conventions had no `clobber`/`preserve` register sets (x86 already has them). Adds ABI-accurate volatile and callee-saved lists, so analysis can tell which registers survive a call — e.g. return values in r3/x0/r0 are no longer mistaken for live argument state after a call, and emulation-based type recovery can drop stale register taint across skipped calls (needed by #26166 on ppc/arm).

Data-only (sdb.txt) plus tests: per-CC register-set pins and a ppc-64 test mirroring the existing amd64 "clobber kills arg after call" check.