### PR TITLE
  Fix oobread when skipping subtests in softmagic match ##crash

### DIFF
--- a/libr/magic/softmagic.c
+++ b/libr/magic/softmagic.c
@@ -1069,8 +1069,8 @@ static int match(RMagic *ms, struct r_magic *magic, ut32 nmagic, const ut32 *min
 
 		if ((m->flag & BINTEST) != mode) {
 			/* Skip sub-tests */
-			while (magic[magindex + 1].cont_level != 0 && ++magindex < nmagic - 1) {
-				continue;
+			while (magindex < nmagic - 1 && magic[magindex + 1].cont_level != 0) {
+				magindex++;
 			}
 			continue; /* Skip to next top-level test*/
 		}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

match() reads magic[magindex + 1].cont_level before checking the bound, so when the last top-level entry is skipped by the BINTEST/TEXTTEST mode filter it reads past the end of the magic array. Triggered by any single-rule text magic database (e.g. the long-regex unit test), which has been aborting the unit-tests step of the linux-asan-fuzz CI job on every master run since July 2. Fix checks the bound first, matching the two adjacent skip loops.
