### PR TITLE
Make rasm2 -L exit 0 like r2 -L and rafind2 -L ##tools

### DIFF
--- a/libr/main/rasm2.c
+++ b/libr/main/rasm2.c
@@ -997,7 +997,6 @@ R_API int r_main_rasm2(int argc, const char *argv[]) {
 		} else {
 			rarch2_list (as, opt.argv[opt.ind]);
 		}
-		ret = 1;
 		goto beach;
 	}
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`rasm2 -L` has exited 1 after printing the plugin listing since ~2014, unlike `r2 -L` and `rafind2 -L` which exit 0. Since 67353f1f2d the r2r arch probe (`r2r_archs`) discards the listing unless the exit code is 0, so every r2r run has been silently skipping the entire `db/asm` suite — ~10500 tests reported as SK, both locally and in CI.

The fix removes the `ret = 1` in the `list_plugins` path (`ret` is already initialized to 0), so `-L`/`-LL` now exit 0 and the arch probe picks up the listing again.