### PR TITLE
Emulate basic blocks in CFG order in the type matcher ##anal

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -704,7 +704,7 @@ static bool etrace_memread_first_addr(TypeTrace *etrace, ut32 idx, ut64 *addr) {
  *
  * \param fcn_name name of the callee
  * \param addr addr of the call instruction
- * \param baddr addr of the caller function
+ * \param baddr addr of the basic block containing the call
  * \param cc cc of the callee
  * \param prev_idx index in the esil trace
  * \param userfnc whether the callee is a user function (affects propagation direction)
@@ -913,6 +913,71 @@ static void type_match(TPState *tps, char *fcn_name, ut64 addr, ut64 baddr, cons
 static int bb_cmpaddr(const void *_a, const void *_b) {
 	const RAnalBlock *a = _a, *b = _b;
 	return a->addr > b->addr? 1: (a->addr < b->addr? -1: 0);
+}
+
+typedef struct {
+	HtUP *blocks;
+	HtUU *seen;
+	RVecUT64 postorder;
+} RpoCtx;
+
+static bool rpo_visit(RAnalBlock *bb, void *user) {
+	return true;
+}
+
+static bool rpo_collect(RAnalBlock *bb, void *user) {
+	RpoCtx *ctx = user;
+	if (ht_up_find (ctx->blocks, bb->addr, NULL)) {
+		ht_uu_update (ctx->seen, bb->addr, 1);
+		RVecUT64_push_back (&ctx->postorder, &bb->addr);
+	}
+	return true;
+}
+
+// reverse post-order via r_anal_block_recurse_depth_first's on_exit callback
+static bool bblist_from_cfg(RAnalFunction *fcn, RVecUT64 *bblist) {
+	RAnalBlock *bb;
+	RAnalBlock *entry = NULL;
+	RListIter *it;
+	RpoCtx ctx = { ht_up_new0 (), ht_uu_new0 () };
+	RVecUT64_init (&ctx.postorder);
+	if (!ctx.blocks || !ctx.seen) {
+		ht_up_free (ctx.blocks);
+		ht_uu_free (ctx.seen);
+		return false;
+	}
+	r_list_foreach (fcn->bbs, it, bb) {
+		ht_up_insert (ctx.blocks, bb->addr, bb);
+		if (!entry && r_anal_block_contains (bb, fcn->addr)) {
+			entry = bb;
+		}
+	}
+	if (!entry) {
+		ht_up_free (ctx.blocks);
+		ht_uu_free (ctx.seen);
+		return false;
+	}
+	r_anal_block_recurse_depth_first (entry, rpo_visit, rpo_collect, &ctx);
+	ht_up_free (ctx.blocks);
+	ut64 *pa;
+	R_VEC_FOREACH_PREV (&ctx.postorder, pa) {
+		RVecUT64_push_back (bblist, pa);
+	}
+	RVecUT64_fini (&ctx.postorder);
+	// blocks unreachable from the entry still get emulated, in address order
+	r_list_foreach (fcn->bbs, it, bb) {
+		bool found = false;
+		ht_uu_find (ctx.seen, bb->addr, &found);
+		if (!found) {
+			RVecUT64_push_back (bblist, &bb->addr);
+		}
+	}
+	ht_uu_free (ctx.seen);
+	if (RVecUT64_length (bblist) != r_list_length (fcn->bbs)) {
+		RVecUT64_clear (bblist);
+		return false;
+	}
+	return true;
 }
 
 static void tps_fini(TPState *tps) {
@@ -1239,7 +1304,7 @@ R_API void r_anal_type_match(RAnal *anal, RAnalFunction *fcn) {
 	RVecUT64 bblist;
 	RVecUT64_init (&bblist);
 	RAnalOp *next_op = R_NEW0 (RAnalOp);
-	r_list_sort (fcn->bbs, bb_cmpaddr); // TODO: The algorithm can be more accurate if blocks are followed by their jmp/fail, not just by address
+	r_list_sort (fcn->bbs, bb_cmpaddr);
 	int retries = 2;
 repeat:
 	if (retries < 0) {
@@ -1251,9 +1316,11 @@ repeat:
 	RVecUT64_clear (&bblist);
 	size_t bblist_size = r_list_length (fcn->bbs); // TODO: Use ut64
 	RVecUT64_reserve (&bblist, bblist_size);
-	// TODO: add a dependency graph out of it, maybe just saving the depth index is enough so we save and restore the state on each level
-	r_list_foreach (fcn->bbs, it, bb) {
-		RVecUT64_push_back (&bblist, &bb->addr);
+	if (!bblist_from_cfg (fcn, &bblist)) {
+		R_LOG_DEBUG ("cannot compute cfg order at 0x%08" PFMT64x ", using address order", fcn->addr);
+		r_list_foreach (fcn->bbs, it, bb) {
+			RVecUT64_push_back (&bblist, &bb->addr);
+		}
 	}
 	int i, j;
 	TypeTrace *etrace = &tps->tt;

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1554,7 +1554,7 @@ var int32_t var_1460h @ sp+0x0
 var char * option @ fp-0xc
 var int32_t var_14h @ fp-0x10
 var int32_t var_18h @ fp-0x14
-var char * var_1ch @ fp-0x18
+var char * options @ fp-0x18
 var char * s @ fp-0x1c
 var char * var_24h @ fp-0x20
 var int32_t var_28h @ fp-0x24
@@ -1887,6 +1887,7 @@ fcn.00010010
 fcn.0000e780
 fcn.0000c0f0
 =
+fcn.0000bd00
 fcn.00011b90
 fcn.00014d50
 EOF
@@ -2573,5 +2574,67 @@ EXPECT=<<EOF
 0x00000000 int sym.imp.bar ( // cc:cdecl ret:?
 0x00000000   int myarg // stack
 0x00000004 );
+EOF
+RUN
+
+NAME=aaft function with switch table
+FILE=bins/jmptbl/test_gcc_5.5.0_64.out
+CMDS=<<EOF
+aa
+aaft
+s main
+afv
+?e =
+afb
+EOF
+EXPECT=<<EOF
+arg uint32_t argc @ rdi
+=
+0x00000580 0x0000058d 00:0000 13 j 0x00000622 f 0x0000058d
+0x0000058d 0x0000059f 00:0000 18 s 0x00000622 s 0x000005b2 s 0x000005c0 s 0x000005ce s 0x000005dc s 0x000005ea s 0x000005f8 s 0x00000606 s 0x00000614 s 0x0000059f
+0x0000059f 0x000005ab 00:0000 12 j 0x000005ab
+0x000005ab 0x000005b2 00:0000 7
+0x000005b2 0x000005c0 00:0000 14 j 0x000005ab
+0x000005c0 0x000005ce 00:0000 14 j 0x000005ab
+0x000005ce 0x000005dc 00:0000 14 j 0x000005ab
+0x000005dc 0x000005ea 00:0000 14 j 0x000005ab
+0x000005ea 0x000005f8 00:0000 14 j 0x000005ab
+0x000005f8 0x00000606 00:0000 14 j 0x000005ab
+0x00000606 0x00000614 00:0000 14 j 0x000005ab
+0x00000614 0x00000622 00:0000 14 j 0x000005ab
+0x00000622 0x00000633 00:0000 17 j 0x000005ab
+EOF
+RUN
+
+NAME=aaft function with unreachable block
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 4889f8c3
+wx 48c7c303000000c3 @ 0x10
+af+ 0 fcn.unreach
+afb+ 0 0 4
+afb+ 0 0x10 8
+aaft
+afb
+?e ok
+EOF
+EXPECT=<<EOF
+0x00000000 0x00000004 00:0000 4
+0x00000010 0x00000018 00:0000 8
+ok
+EOF
+RUN
+
+NAME=aaft function without basic blocks
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+af+ 0 fcn.empty
+aaft
+?e ok
+EOF
+EXPECT=<<EOF
+ok
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

aaft used to emulate basic blocks in plain address order, so type facts from a block's real predecessors were often not in the trace yet. This fills the worklist in reverse post-order via r_anal_block_recurse_depth_first() over the control flow edges (resolves the old TODO in r_anal_type_match).

- The fail edge is explored last so fall-through blocks stay adjacent (keeps the canary-rename trace heuristic working)
- Unreachable blocks are appended in address order; any inconsistency falls back to the previous address-order behavior
- Recovers more var names/types from call-site backtraces, e.g. `char *options` and `char *s` in the bashbot test instead of `var_1ch`/`var_24h`
- New tests: switch-table function ordering and unreachable-block stability; existing goldens updated where recovery improved