### PR TITLE
Fix mach0 chained fixup function call ##bin

### DIFF
--- a/libr/bin/format/mach0/mach0.c
+++ b/libr/bin/format/mach0/mach0.c
@@ -2463,7 +2463,7 @@ static int init_items(struct MACH0_(obj_t) * mo) {
 		}
 	}
 
-	if (!has_chained_fixups && mo->hdr.cputype == CPU_TYPE_ARM64 && (mo->hdr.cpusubtype & ~CPU_SUBTYPE_MASK) == CPU_SUBTYPE_ARM64E) {
+	if (has_chained_fixups && mo->hdr.cputype == CPU_TYPE_ARM64 && (mo->hdr.cpusubtype & ~CPU_SUBTYPE_MASK) == CPU_SUBTYPE_ARM64E) {
 		reconstruct_chained_fixup (mo);
 	}
 	return true;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Before the change, the code called **_reconstruct_chained_fixup ()_** if some flags in the header were set and the function **_parse_chained_fixups ()_** returned **false**.  
**_parse_chained_fixups ()_** returns **false** only if the chained fixups are malformed, e.g the offset for the chained fixups lies outside of the file.
I think that running **_reconstruct_chained_fixup ()_** when **_parse_chained_fixups ()_** returns **false** is wrong.
