### PR TITLE
Fix null-deref in afvt when called without a variable name ##analysis

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2190,10 +2190,11 @@ static int cmd_afv(RCore *core, const char *str) {
 	case 't': // "afvt"
 		if (fcn) {
 			p = strchr (ostr, ' ');
-			if (!p++) {
+			if (!p) {
 				free (ostr);
 				return false;
 			}
+			p++;
 
 			char *type = strchr (p, ' ');
 			if (type) {

--- a/test/db/cmd/cmd_afv
+++ b/test/db/cmd/cmd_afv
@@ -10,3 +10,16 @@ EXPECT=<<EOF
 not segfaulted
 EOF
 RUN
+
+NAME=afvt without variable name
+FILE=bins/elf/truechin.so
+CMDS=<<EOF
+s 0x1750
+af
+afvt
+?e survived
+EOF
+EXPECT=<<EOF
+survived
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`afvt` (used to set a variable's type) incremented the result of `strchr()` before checking it for `NULL`:

```c
p = strchr (ostr, ' ');
if (!p++) {
    free (ostr);
    return false;
}
```

`!p++` post-increments `p` regardless of whether the check passes, so calling `afvt` with no argument (no space in `ostr`) dereferences a NULL pointer on the next line via `strchr (p, ' ')`. Fixed to check for NULL before incrementing:

```c
p = strchr (ostr, ' ');
if (!p) {
    free (ostr);
    return false;
}
p++;
```

Split out of #26181 as an independent fix, unrelated to the calling-convention clobber work in that PR.

Added a regression test (`test/db/cmd/cmd_afv`) that calls `afvt` with no argument after `af` and confirms r2 doesn't crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhhvgXUWtZpiKibT8XjyiZ)_