### PR TITLE
Fix dominator tree construction and switch case graph edges ##util

### DIFF
--- a/libr/anal/function.c
+++ b/libr/anal/function.c
@@ -728,8 +728,7 @@ R_API RGraph *r_anal_function_get_graph(RAnalFunction *fcn, RGraphNode **node_pt
 			RListIter *ator;
 			RAnalCaseOp *co;
 			r_list_foreach (bb->switch_op->cases, ator, co) {
-				RGraphNode *_node = NULL;
-				_node = (RGraphNode *)ht_up_find (nodes, co->addr, NULL);
+				RGraphNode *_node = (RGraphNode *)ht_up_find (nodes, co->jump, NULL);
 				if (!_node) {
 					R_LOG_ERROR ("Broken fcn");
 					ht_up_free (nodes);

--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -2507,7 +2507,7 @@ static inline bool cur_points_to_bb(RAnalBlock *curbb, RAnalBlock *bb) {
 		RListIter *it;
 		RAnalCaseOp *cop;
 		r_list_foreach (curbb->switch_op->cases, it, cop) {
-			if (cop->addr == bb->addr) {
+			if (cop->jump == bb->addr) {
 				return true;
 			}
 		}
@@ -2626,7 +2626,7 @@ static int get_bbnodes(RAGraph *g, RCore *core, RAnalFunction *fcn) {
 			RListIter *it;
 			RAnalCaseOp *cop;
 			r_list_foreach (bb->switch_op->cases, it, cop) {
-				add_child (core, g, u, cop->addr);
+				add_child (core, g, u, cop->jump);
 			}
 		}
 	}

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -1505,18 +1505,18 @@ static int core_anal_graph_construct_edges(RCore *core, RAnalFunction *fcn, int 
 				} else if (is_html) {
 					r_cons_printf (core->cons, "<div class=\"connector _0x%08" PFMT64x " _0x%08" PFMT64x "\">\n"
 							"  <img class=\"connector-end\" src=\"img/arrow.gif\"/></div>\n",
-							bbi->addr, caseop->addr);
+							bbi->addr, caseop->jump);
 				} else if (!is_json) {
 					if (is_star) {
 						char *from = get_title (bbi->addr);
-						char *to = get_title (caseop->addr);
+						char *to = get_title (caseop->jump);
 						r_cons_printf (core->cons, "age %s %s\n", from ,to);
 						free (from);
 						free (to);
 					} else {
 						r_cons_printf (core->cons, "        \"0x%08" PFMT64x "\" -> \"0x%08" PFMT64x "\" "
 								"[color=\"%s\"];\n",
-								bbi->addr, caseop->addr, pal_trfa);
+								bbi->addr, caseop->jump, pal_trfa);
 						core_anal_color_curr_node (core, bbi);
 					}
 				}
@@ -2078,7 +2078,7 @@ R_API int r_core_print_bb_custom(RCore *core, RAnalFunction *fcn) {
 			RListIter *it;
 			RAnalCaseOp *cop;
 			r_list_foreach (bb->switch_op->cases, it, cop) {
-				v = get_title (cop->addr);
+				v = get_title (cop->jump);
 				r_cons_printf (core->cons, "age %s %s\n", u, v);
 				free (v);
 			}

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -3722,7 +3722,7 @@ static bool anal_fcn_list_bb(RCore *core, const char *input, bool one) {
 				RListIter *iter;
 				r_list_uniq_inplace (b->switch_op->cases, caseval);
 				r_list_foreach (b->switch_op->cases, iter, cop) {
-					r_cons_printf (core->cons, " s 0x%08" PFMT64x, cop->addr);
+					r_cons_printf (core->cons, " s 0x%08" PFMT64x, cop->jump);
 				}
 			}
 			r_cons_newline (core->cons);
@@ -13690,7 +13690,7 @@ static bool r_core_print_bb_gml(RCore *core, RAnalFunction *fcn) {
 				bool found;
 				int i = ht_uu_find (ht, bb->addr, &found);
 				if (found) {
-					int i2 = ht_uu_find (ht, cop->addr, &found);
+					int i2 = ht_uu_find (ht, cop->jump, &found);
 					if (found) {
 						r_cons_printf (core->cons, "  edge [\n"
 								"    source  %d\n"

--- a/libr/core/p/core_agD.c
+++ b/libr/core/p/core_agD.c
@@ -75,7 +75,6 @@ static bool r_cmd_agD_call(RCorePluginSession *cps, const char *input) {
 		r_agraph_free (dtagraph);
 		r_graph_free (fcn_dtgraph);
 		r_graph_free (fcn_graph);
-		r_cons_flush (core->cons);
 		return true;
 	}
 	switch (sub) {
@@ -125,7 +124,6 @@ static bool r_cmd_agD_call(RCorePluginSession *cps, const char *input) {
 	r_agraph_free (dtagraph);
 	r_graph_free (fcn_dtgraph);
 	r_graph_free (fcn_graph);
-	r_cons_flush (core->cons);
 	return true;
 }
 

--- a/libr/include/r_util/r_graph.h
+++ b/libr/include/r_util/r_graph.h
@@ -44,11 +44,6 @@ typedef struct r_graph_visitor_t {
 typedef void (*RGraphNodeCallback)(RGraphNode *n, RGraphVisitor *vis);
 typedef void (*RGraphEdgeCallback)(const RGraphEdge *e, RGraphVisitor *vis);
 
-typedef struct r_graph_dom_node_t {
-	RGraphNode *node;
-	ut32 idx;
-} RGraphDomNode;
-
 // Contrructs a new RGraph, returns heap-allocated graph.
 R_API RGraph *r_graph_new(void);
 // Destroys the graph and all nodes.

--- a/libr/util/graph.c
+++ b/libr/util/graph.c
@@ -351,142 +351,79 @@ R_API void r_graph_dfs(RGraph *g, RGraphVisitor *vis) {
 	}
 }
 
-typedef struct _dfs_inserter {
-	RGraph *g;
-	HtUP *reverse;	//reverse lookup of nodes
-//	RList *mo;	//multiple out nodes
-	RVecGraphNodePtr mi; // multiple in nodes
-	size_t mi_index;
-	ut32 idx;
-	bool fail;
-} DfsInserter;
-
-static void _dfs_ins_node(RGraphNode *n, RGraphVisitor *vi) {
-	DfsInserter *di = (DfsInserter *)vi->data;
-	if (di->fail) {
-		return;
-	}
-	RGraphDomNode *dn = R_NEW0 (RGraphDomNode);
-	if (!dn) {
-		di->fail = true;
-		return;
-	}
-	RGraphNode *node = r_graph_add_nodef (di->g, dn, free);
-	if (!node) {
-		free (dn);
-		di->fail = true;
-		return;
-	}
-	dn->node = n;
-	ht_up_insert (di->reverse, (ut64)(size_t)n, node);
-	if (RVecGraphNodePtr_length (&n->in_nodes) > 1 && di->idx) {
-		RGraphNode **slot = RVecGraphNodePtr_emplace_back (&di->mi);
-		*slot = node;
-	}
-	dn->idx = di->idx++;
+static void _postorder_collect(RGraphNode *n, RGraphVisitor *vis) {
+	RVecGraphNodePtr_push_back ((RVecGraphNodePtr *)vis->data, &n);
 }
 
-static void _dfs_ins_edge(const RGraphEdge *e, RGraphVisitor *vi) {
-	DfsInserter *di = (DfsInserter *)vi->data;
-	if (di->fail) {
-		return;
-	}
-	bool found;
-	RGraphNode *from = (RGraphNode *)ht_up_find (di->reverse, (ut64)(size_t)e->from, &found);
-	if (!found) {
-		_dfs_ins_node (e->from, vi);
-		if (di->fail) {
-			return;
+static size_t dom_intersect(const size_t *idom, size_t f1, size_t f2) {
+	while (f1 != f2) {
+		while (f1 < f2) {
+			f1 = idom[f1];
 		}
-		from = (RGraphNode *)ht_up_find (di->reverse, (ut64)(size_t)e->from, &found);
-		if (!found) {
-			return;
+		while (f2 < f1) {
+			f2 = idom[f2];
 		}
 	}
-	RGraphNode *to = (RGraphNode *)ht_up_find (di->reverse, (ut64)(size_t)e->to, &found);
-	if (!found) {
-		_dfs_ins_node (e->to, vi);
-		if (di->fail) {
-			return;
-		}
-		to = (RGraphNode *)ht_up_find (di->reverse, (ut64)(size_t)e->to, &found);
-		if (!found) {
-			return;
-		}
-	}
-	r_graph_add_edge (di->g, from, to);
+	return f1;
 }
 
+// Cooper-Harvey-Kennedy iterative dominators; tree node data points at the input graph nodes
 R_API RGraph *r_graph_dom_tree(RGraph *graph, RGraphNode *root) {
 	R_RETURN_VAL_IF_FAIL (graph && root, NULL);
+	RVecGraphNodePtr order;
+	RVecGraphNodePtr_init (&order);
+	RGraphVisitor vis = { .finish_node = _postorder_collect, .data = &order };
+	r_graph_dfs_node (graph, root, &vis);
+	const size_t n = RVecGraphNodePtr_length (&order);
+	// pon[node->idx] is the postorder number plus one; 0 marks unreachable nodes
+	size_t *pon = R_NEWS0 (size_t, graph->last_index);
+	size_t *idom = R_NEWS (size_t, n);
+	RGraphNode **tnodes = R_NEWS0 (RGraphNode *, n);
 	RGraph *g = r_graph_new ();
-	if (!g) {
-		return NULL;
-	}
-	DfsInserter di = { .g = g, .reverse = ht_up_new0 () };
-	RVecGraphNodePtr_init (&di.mi);
-	if (!di.reverse) {
-		RVecGraphNodePtr_fini (&di.mi);
+	if (!n || !pon || !idom || !tnodes) {
 		r_graph_free (g);
-		return NULL;
+		g = NULL;
+		goto beach;
 	}
-	RGraphVisitor vi = { NULL, NULL, _dfs_ins_edge, NULL, NULL, &di};
-	//create a spanning tree
-	r_graph_dfs_node (graph, root, &vi);
-	if (di.fail) {
-		RVecGraphNodePtr_fini (&di.mi);
-		ht_up_free (di.reverse);
-		r_graph_free (g);
-		return NULL;
+	size_t i;
+	for (i = 0; i < n; i++) {
+		pon[(*RVecGraphNodePtr_at (&order, i))->idx] = i + 1;
+		idom[i] = SZT_MAX;
 	}
-	while (di.mi_index < RVecGraphNodePtr_length (&di.mi)) {
-		RGraphNode *n = *RVecGraphNodePtr_at (&di.mi, di.mi_index++);
-		RGraphNode *p = *RVecGraphNodePtr_at (&n->in_nodes, 0);
-		if (p && ((RGraphDomNode *)(p->data))->idx == 0) {
-			//parent is root node
-			continue;
-		}
-		RGraphDomNode *dn = (RGraphDomNode *)n->data;
-		RGraphNode *max_n = NULL, *min_n = NULL;
-		RGraphNode **it;
-		R_VEC_FOREACH (&dn->node->in_nodes, it) {
-			RGraphNode *nn = *it;
-			RGraphNode *in = (RGraphNode *)ht_up_find (di.reverse, (ut64)(size_t)nn, NULL);
-			if (nn == root) {
-				r_graph_del_edge (g, *RVecGraphNodePtr_at (&n->in_nodes, 0), n);
-				r_graph_add_edge (g, in, n);
-				goto cont;
+	// the root finishes last, so it takes the highest postorder number
+	idom[n - 1] = n - 1;
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (i = n - 1; i-- > 0;) {
+			RGraphNode *b = *RVecGraphNodePtr_at (&order, i);
+			size_t nid = SZT_MAX;
+			RGraphNode **it;
+			R_VEC_FOREACH (&b->in_nodes, it) {
+				size_t p = pon[(*it)->idx];
+				if (!p || idom[p - 1] == SZT_MAX) {
+					continue;
+				}
+				p--;
+				nid = (nid == SZT_MAX)? p: dom_intersect (idom, p, nid);
 			}
-			if (!max_n || (((RGraphDomNode *)(max_n->data))->idx < ((RGraphDomNode *)(in->data))->idx)) {
-				max_n = in;
-			}
-			if (!min_n || (((RGraphDomNode *)(min_n->data))->idx > ((RGraphDomNode *)(in->data))->idx)) {
-				min_n = in;
+			if (nid != SZT_MAX && idom[i] != nid) {
+				idom[i] = nid;
+				changed = true;
 			}
 		}
-		while (max_n && ((RGraphDomNode *)max_n->data)->idx > dn->idx) {
-			max_n = *RVecGraphNodePtr_at (&max_n->in_nodes, 0);
-		}
-// at this point max_n refers to the semi dominator (i hope this is correct)
-		RGraphNode *dom = min_n;
-		while (max_n && ((RGraphDomNode *)max_n->data)->idx < ((RGraphDomNode *)dom->data)->idx) {
-			dom = *RVecGraphNodePtr_at (&dom->in_nodes, 0);
-		}
-// dom <= sdom
-		r_graph_del_edge (g, p, n);
-		r_graph_add_edge (g, dom, n);
-cont:;
 	}
-	RVecGraphNodePtr_fini (&di.mi);
-	ht_up_free (di.reverse);
-	RListIter *iter;
-	RGraphNode *n;
-	r_list_foreach (g->nodes, iter, n) {
-		RGraphDomNode *dn = (RGraphDomNode *)n->data;
-		n->free = NULL;
-		n->data = dn->node;
-		free (dn);
+	for (i = n; i-- > 0;) {
+		tnodes[i] = r_graph_add_node (g, *RVecGraphNodePtr_at (&order, i));
 	}
+	for (i = n - 1; i-- > 0;) {
+		r_graph_add_edge (g, tnodes[idom[i]], tnodes[i]);
+	}
+beach:
+	free (pon);
+	free (idom);
+	free (tnodes);
+	RVecGraphNodePtr_fini (&order);
 	return g;
 }
 
@@ -505,8 +442,5 @@ R_API RGraph *r_graph_pdom_tree(RGraph *graph, RGraphNode *root) {
 	_invert_edges (graph);
 	RGraph *g = r_graph_dom_tree (graph, root);
 	_invert_edges (graph);
-	if (g) {
-		_invert_edges (graph);
-	}
 	return g;
 }

--- a/test/db/anal/java
+++ b/test/db/anal/java
@@ -628,3 +628,27 @@ EXPECT=<<EOF
   "n2" -> "n6";
 EOF
 RUN
+
+NAME=java tableswitch case edges point at the case targets in agf output
+FILE=malloc://128
+ARGS=-a java
+CMDS=<<EOF
+wx 033b033ca7003c1a08703d1caa0000000000003200000000000000030000002000000026000000320000002c840202a70011840203a7000b840209a70005033c1a100aa1ffc41bac00000003000a0000
+af
+agfd~-\>
+EOF
+EXPECT=<<EOF
+        "0x00000000" -> "0x00000040" [color="#3a96dd"];
+        "0x00000040" -> "0x00000007" [color="#13a10e"];
+        "0x00000040" -> "0x00000046" [color="#c50f1f"];
+        "0x00000007" -> "0x0000000d" [color="#c50f1f"];
+        "0x00000007" -> "0x0000000d" [color="#c50f1f"];
+        "0x00000007" -> "0x0000002c" [color="#3a96dd"];
+        "0x00000007" -> "0x00000032" [color="#3a96dd"];
+        "0x00000007" -> "0x0000003e" [color="#3a96dd"];
+        "0x0000002c" -> "0x00000040" [color="#3a96dd"];
+        "0x00000032" -> "0x00000040" [color="#3a96dd"];
+        "0x0000003e" -> "0x00000040" [color="#3a96dd"];
+        "0x0000000d" -> "0x0000002c" [color="#3a96dd"];
+EOF
+RUN

--- a/test/db/anal/java
+++ b/test/db/anal/java
@@ -607,3 +607,24 @@ ireturn
 EOF
 BROKEN=1
 RUN
+
+NAME=java tableswitch case edges reach the dominator tree
+FILE=malloc://128
+ARGS=-a java
+CMDS=<<EOF
+wx 033b033ca7003c1a08703d1caa0000000000003200000000000000030000002000000026000000320000002c840202a70011840203a7000b840209a70005033c1a100aa1ffc41bac00000003000a0000
+af
+agDd~?label
+agDd~-\>
+EOF
+EXPECT=<<EOF
+8
+  "n0" -> "n1";
+  "n1" -> "n2";
+  "n1" -> "n7";
+  "n2" -> "n3";
+  "n2" -> "n4";
+  "n2" -> "n5";
+  "n2" -> "n6";
+EOF
+RUN

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -26,7 +26,8 @@ $(UNITS_BINDIR)/%: %.c
 	mkdir -p "$(UNITS_BINDIR)"
 	$(CC) $(CPPFLAGS) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LDLIBS)
 
-test_debug: $(UNITS_BINDIR)/test_debug
+# keep the built-in %: %.c rule from dropping binaries next to the sources
+test_%: $(UNITS_BINDIR)/test_%
 	@:
 
 run: $(BINS)

--- a/test/unit/test_graph.c
+++ b/test/unit/test_graph.c
@@ -156,8 +156,361 @@ static bool test_legacy_graph(void) {
 	mu_end;
 }
 
+#define DOM_MAXN 32
+
+typedef struct {
+	RGraph *g;
+	RGraphNode *n[DOM_MAXN];
+	size_t count;
+} DomTestGraph;
+
+static void dom_graph_init(DomTestGraph *tg, size_t count) {
+	tg->g = r_graph_new ();
+	tg->count = count;
+	size_t i;
+	for (i = 0; i < count; i++) {
+		tg->n[i] = r_graph_add_node (tg->g, (void *)(size_t)(i + 1));
+	}
+}
+
+// edges are (from, to) pairs terminated by -1
+static void dom_graph_edges(DomTestGraph *tg, const int *edges) {
+	size_t i;
+	for (i = 0; edges[i] >= 0; i += 2) {
+		r_graph_add_edge (tg->g, tg->n[edges[i]], tg->n[edges[i + 1]]);
+	}
+}
+
+static size_t dom_node_index(RGraphNode *const *nodes, size_t n, const RGraphNode *x) {
+	size_t i;
+	for (i = 0; i < n; i++) {
+		if (nodes[i] == x) {
+			return i;
+		}
+	}
+	return SZT_MAX;
+}
+
+static ut64 dom_reachable(RGraphNode *const *nodes, size_t n, size_t root) {
+	ut64 reach = 1ULL << root;
+	size_t stack[DOM_MAXN];
+	size_t sp = 0;
+	stack[sp++] = root;
+	while (sp) {
+		size_t v = stack[--sp];
+		RGraphNode **it;
+		R_VEC_FOREACH (&nodes[v]->out_nodes, it) {
+			size_t w = dom_node_index (nodes, n, *it);
+			if (!(reach & (1ULL << w))) {
+				reach |= 1ULL << w;
+				stack[sp++] = w;
+			}
+		}
+	}
+	return reach;
+}
+
+// brute-force iterative-dataflow oracle; idom[i] = i for the root, SZT_MAX if unreachable
+static void dom_oracle(RGraphNode *const *nodes, size_t n, size_t root, size_t *idom) {
+	ut64 reach = dom_reachable (nodes, n, root);
+	ut64 dom[DOM_MAXN];
+	size_t i, j;
+	for (i = 0; i < n; i++) {
+		dom[i] = (i == root)? (1ULL << i): reach;
+	}
+	bool changed = true;
+	while (changed) {
+		changed = false;
+		for (i = 0; i < n; i++) {
+			if (i == root || !(reach & (1ULL << i))) {
+				continue;
+			}
+			ut64 d = reach;
+			RGraphNode **it;
+			R_VEC_FOREACH (&nodes[i]->in_nodes, it) {
+				size_t p = dom_node_index (nodes, n, *it);
+				if (reach & (1ULL << p)) {
+					d &= dom[p];
+				}
+			}
+			d |= 1ULL << i;
+			if (d != dom[i]) {
+				dom[i] = d;
+				changed = true;
+			}
+		}
+	}
+	for (i = 0; i < n; i++) {
+		if (!(reach & (1ULL << i))) {
+			idom[i] = SZT_MAX;
+			continue;
+		}
+		if (i == root) {
+			idom[i] = i;
+			continue;
+		}
+		// strict dominators are totally ordered; the immediate one has the largest dominator set
+		size_t best = SZT_MAX;
+		for (j = 0; j < n; j++) {
+			if (j == i || !(dom[i] & (1ULL << j))) {
+				continue;
+			}
+			if (best == SZT_MAX || r_bits_popcount64 (dom[j]) > r_bits_popcount64 (dom[best])) {
+				best = j;
+			}
+		}
+		idom[i] = best;
+	}
+}
+
+static bool dom_tree_check(DomTestGraph *tg, size_t root, const char *descr) {
+	size_t idom[DOM_MAXN];
+	size_t i, n = tg->count;
+	dom_oracle (tg->n, n, root, idom);
+	RGraph *t = r_graph_dom_tree (tg->g, tg->n[root]);
+	if (!t) {
+		eprintf ("[-][%s] dom tree is NULL\n", descr);
+		return false;
+	}
+	bool ok = true;
+	RGraphNode *tnodes[DOM_MAXN] = {0};
+	RListIter *it;
+	RGraphNode *tn;
+	r_list_foreach (t->nodes, it, tn) {
+		size_t oi = dom_node_index (tg->n, n, (RGraphNode *)tn->data);
+		if (oi == SZT_MAX) {
+			eprintf ("[-][%s] tree node data is not a node of the input graph\n", descr);
+			ok = false;
+			continue;
+		}
+		if (tnodes[oi]) {
+			eprintf ("[-][%s] duplicated tree node for %u\n", descr, (ut32)oi);
+			ok = false;
+		}
+		tnodes[oi] = tn;
+	}
+	for (i = 0; i < n; i++) {
+		if (idom[i] == SZT_MAX) {
+			if (tnodes[i]) {
+				eprintf ("[-][%s] unreachable node %u is in the tree\n", descr, (ut32)i);
+				ok = false;
+			}
+			continue;
+		}
+		if (!tnodes[i]) {
+			eprintf ("[-][%s] reachable node %u is missing from the tree\n", descr, (ut32)i);
+			ok = false;
+			continue;
+		}
+		size_t nin = RVecGraphNodePtr_length (&tnodes[i]->in_nodes);
+		if (i == root) {
+			if (nin) {
+				eprintf ("[-][%s] root has %u parents\n", descr, (ut32)nin);
+				ok = false;
+			}
+			continue;
+		}
+		if (nin != 1) {
+			eprintf ("[-][%s] node %u has %u parents\n", descr, (ut32)i, (ut32)nin);
+			ok = false;
+			continue;
+		}
+		RGraphNode *parent = *RVecGraphNodePtr_at (&tnodes[i]->in_nodes, 0);
+		size_t pi = dom_node_index (tg->n, n, (RGraphNode *)parent->data);
+		if (pi != idom[i]) {
+			eprintf ("[-][%s] idom(%u) is %u, expected %u\n", descr, (ut32)i, (ut32)pi, (ut32)idom[i]);
+			ok = false;
+		}
+	}
+	r_graph_free (t);
+	return ok;
+}
+
+static bool test_dom_tree_linear(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 3);
+	const int edges[] = { 0, 1, 1, 2, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "linear"), "linear chain idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_diamond(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 4);
+	const int edges[] = { 0, 1, 0, 2, 1, 3, 2, 3, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "diamond"), "diamond idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_nested_loops(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 6);
+	// 1 is the outer loop header, 2 the inner one; 3->2 and 4->1 are the back edges
+	const int edges[] = { 0, 1, 1, 2, 2, 3, 3, 2, 2, 4, 3, 4, 4, 1, 4, 5, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "nested_loops"), "nested loop idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_irreducible(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 4);
+	// two-entry loop between 1 and 2; only the root dominates 1, 2 and 3
+	const int edges[] = { 0, 1, 0, 2, 1, 2, 2, 1, 1, 3, 2, 3, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "irreducible"), "irreducible loop idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_self_loop(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 3);
+	const int edges[] = { 0, 1, 1, 1, 1, 2, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "self_loop"), "self loop idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_back_to_root(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 3);
+	const int edges[] = { 0, 1, 1, 0, 1, 2, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "back_to_root"), "back edge to root idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_unreachable_node(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 5);
+	// node 4 is disconnected and must not appear in the tree
+	const int edges[] = { 0, 1, 0, 2, 1, 3, 2, 3, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "unreachable_node"), "unreachable node idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_unreachable_pred(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 4);
+	// 3 is unreachable but is a predecessor of the join node 2
+	const int edges[] = { 0, 1, 1, 2, 3, 2, -1 };
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "unreachable_pred"), "unreachable predecessor idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_single_node(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 1);
+	mu_assert_true (dom_tree_check (&tg, 0, "single_node"), "single node tree");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static bool test_dom_tree_dense(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 12);
+	// mix of joins, cross edges, back edges and an irreducible region
+	const int edges[] = {
+		0, 1, 0, 2, 1, 3, 2, 3, 2, 4, 3, 5, 4, 5, 4, 6, 5, 7, 6, 7,
+		7, 8, 8, 9, 9, 8, 9, 10, 10, 2, 3, 11, 10, 11, 6, 11, 5, 6, 8, 3, -1
+	};
+	dom_graph_edges (&tg, edges);
+	mu_assert_true (dom_tree_check (&tg, 0, "dense"), "dense graph idoms");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
+static ut32 dom_rng_state = 0x2545f491;
+
+static ut32 dom_rng(void) {
+	ut32 x = dom_rng_state;
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	dom_rng_state = x;
+	return x;
+}
+
+static bool test_dom_tree_random_sweep(void) {
+	size_t iter;
+	for (iter = 0; iter < 500; iter++) {
+		DomTestGraph tg;
+		const size_t n = 2 + (dom_rng () % 15);
+		dom_graph_init (&tg, n);
+		// random density from sparse chains to multigraphs with self loops
+		const size_t m = dom_rng () % (3 * n);
+		size_t k;
+		for (k = 0; k < m; k++) {
+			r_graph_add_edge (tg.g, tg.n[dom_rng () % n], tg.n[dom_rng () % n]);
+		}
+		char descr[32];
+		snprintf (descr, sizeof (descr), "random_sweep_%u", (ut32)iter);
+		const bool ok = dom_tree_check (&tg, 0, descr);
+		r_graph_free (tg.g);
+		mu_assert_true (ok, "random sweep idoms match the oracle");
+	}
+	mu_end;
+}
+
+static bool test_pdom_tree(void) {
+	DomTestGraph tg;
+	dom_graph_init (&tg, 4);
+	const int edges[] = { 0, 1, 0, 2, 1, 3, 2, 3, -1 };
+	dom_graph_edges (&tg, edges);
+	RGraph *t = r_graph_pdom_tree (tg.g, tg.n[3]);
+	mu_assert_notnull (t, "pdom tree");
+	RGraphNode *tnodes[DOM_MAXN] = {0};
+	RListIter *it;
+	RGraphNode *tn;
+	r_list_foreach (t->nodes, it, tn) {
+		size_t oi = dom_node_index (tg.n, tg.count, (RGraphNode *)tn->data);
+		mu_assert_neq ((ut64)oi, (ut64)SZT_MAX, "pdom node maps to the input graph");
+		tnodes[oi] = tn;
+	}
+	size_t i;
+	for (i = 0; i < 3; i++) {
+		mu_assert_notnull (tnodes[i], "node in pdom tree");
+		mu_assert_eq (RVecGraphNodePtr_length (&tnodes[i]->in_nodes), 1, "single pdom parent");
+		RGraphNode *parent = *RVecGraphNodePtr_at (&tnodes[i]->in_nodes, 0);
+		mu_assert_ptreq (parent->data, tg.n[3], "ipdom is the exit node");
+	}
+	r_graph_free (t);
+	// the input graph must come back with its original orientation
+	mu_assert_eq (tg.g->n_edges, 4, "input edge count preserved");
+	mu_assert_true (r_graph_adjacent (tg.g, tg.n[0], tg.n[1]), "input edge 0->1 preserved");
+	mu_assert_true (r_graph_adjacent (tg.g, tg.n[1], tg.n[3]), "input edge 1->3 preserved");
+	mu_assert_false (r_graph_adjacent (tg.g, tg.n[1], tg.n[0]), "input graph not inverted");
+	mu_assert_false (r_graph_adjacent (tg.g, tg.n[3], tg.n[1]), "input graph not inverted");
+	r_graph_free (tg.g);
+	mu_end;
+}
+
 static int all_tests(void) {
 	mu_run_test (test_legacy_graph);
+	mu_run_test (test_dom_tree_linear);
+	mu_run_test (test_dom_tree_diamond);
+	mu_run_test (test_dom_tree_nested_loops);
+	mu_run_test (test_dom_tree_irreducible);
+	mu_run_test (test_dom_tree_self_loop);
+	mu_run_test (test_dom_tree_back_to_root);
+	mu_run_test (test_dom_tree_unreachable_node);
+	mu_run_test (test_dom_tree_unreachable_pred);
+	mu_run_test (test_dom_tree_single_node);
+	mu_run_test (test_dom_tree_dense);
+	mu_run_test (test_dom_tree_random_sweep);
+	mu_run_test (test_pdom_tree);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

- Rewrite r_graph_dom_tree using the iterative Cooper-Harvey-Kennedy algorithm on top of r_graph_dfs_node. The previous implementation computed wrong idoms on join nodes and loops, leaked on failure, and left the input graph inverted after r_graph_pdom_tree.
- Add unit tests for the dominator/post-dominator trees, including a 500-graph random sweep against a brute-force dataflow oracle.
- Point switch case graph edges at RAnalCaseOp.jump instead of the case instruction address (agf/agD/gml/star outputs), with java tableswitch tests covering both.
