### PR TITLE
Add error if pdb7 root size negative ##bin

### DIFF
--- a/libr/bin/format/pdb/pdb.c
+++ b/libr/bin/format/pdb/pdb.c
@@ -514,7 +514,7 @@ static bool pdb7_parse(RBinPdb *pdb) {
 		goto error;
 	}
 
-	if (root_size < 0) {
+	if (root_size <= 0) {
 		R_LOG_ERROR ("Invalid root size");
 		goto error;
 	}

--- a/libr/bin/format/pdb/pdb.c
+++ b/libr/bin/format/pdb/pdb.c
@@ -514,6 +514,11 @@ static bool pdb7_parse(RBinPdb *pdb) {
 		goto error;
 	}
 
+	if (root_size < 0) {
+		R_LOG_ERROR ("Invalid root size");
+		goto error;
+	}
+
 	int num_root_pages = count_pages (root_size, page_size);
 	if (num_root_pages < 1) {
 		R_LOG_ERROR ("Invalid page count");


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**
Not 100% sure about this. 
From what i understood, the root size reported in the actual root stream cannot be -1, while a stream size can be -1. 

It might be worthwhile to error out early if the root_size is negative.

As it stands, **root_size** can be -1 and that would cause **num_root_pages** and **num_root_index_pages** to be 1.  
**root_size** is also flows into **_init_r_stream_file ()_** and **_init_r_pdb_stream ()_** by way of
**_init_pdb7_root_stream ()_** -> **__init_r_pdb_stream ()_** -> **__init_r_stream_file ()_**
When **__init_r_stream_file ()_** and **__init_r_pdb_stream ()_** receive -1 will set:
```c
if (size == -1) {
        pdb_stream->size = (size_t)pages_amount * page_size;
}
```
And 
```c
stream_file->end = (size == -1)
		? (size_t)pages_amount * page_size
		: size;
```
Which sets it to exactly one page because **pages_amount** comes from **num_root_pages**. This might cause minor inconveniences such as thinking that the file is longer in size or less in size than it is and filling some fields with the 0xff value.
