### PR TITLE
Parse hex array dimensions in struct and union members ##types

### DIFF
--- a/libr/anal/c2/kv.c
+++ b/libr/anal/c2/kv.c
@@ -797,7 +797,7 @@ static bool parse_typedef(KVCParser *kvc, const char *unused) {
 				}
 			}
 			if (!_is_fp_field) {
-				kvc_basetype_add_member (bt, mn, mt, off, R_STR_ISNOTEMPTY (md)? atoi (md): 0);
+				kvc_basetype_add_member (bt, mn, mt, off, R_STR_ISNOTEMPTY (md)? (int)r_num_math (NULL, md): 0);
 				r_strbuf_appendf (kvc->sb, "struct.%s.%s.meta=0\n", struct_tag, mn);
 				off += kvc_typesize (kvc, mt, 1);
 				apply_attributes (kvc, "struct", full_scope);
@@ -936,7 +936,7 @@ static bool parse_typedef(KVCParser *kvc, const char *unused) {
 				}
 			}
 			if (!_is_fp_field) {
-				kvc_basetype_add_member (bt, mn, mt, off, R_STR_ISNOTEMPTY (md)? atoi (md): 0);
+				kvc_basetype_add_member (bt, mn, mt, off, R_STR_ISNOTEMPTY (md)? (int)r_num_math (NULL, md): 0);
 				apply_attributes (kvc, "union", full_scope);
 				free (mt);
 				free (mn);
@@ -1485,7 +1485,7 @@ static bool parse_struct(KVCParser *kvc, const char *type) {
 			off += rest;
 		}
 		if (R_STR_ISNOTEMPTY (md)) {
-			dimension = atoi (md);
+			dimension = (int)r_num_math (NULL, md);
 		}
 		kvc_basetype_add_member (bt, mn, mt, off, R_STR_ISNOTEMPTY (md)? dimension: 0);
 		if (!is_union) {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -2673,3 +2673,28 @@ union KU {
 };
 EOF
 RUN
+
+NAME=td array dimensions in hex
+FILE=malloc://32
+CMDS=<<EOF
+"td struct Hex { char pad[0x8]; int x; char tail[0x10]; };"
+tk struct.Hex.x
+tk struct.Hex.tail
+"td typedef struct Tg { char b[0x10]; } TgT;"
+tk struct.Tg.b
+"td typedef union Ug { char c[0x18]; int v; } UgT;"
+tk union.Ug.c
+tsc Hex
+EOF
+EXPECT=<<EOF
+int,8,0
+char,12,16
+char,0,16
+char,0,24
+struct Hex {
+  char pad[8];
+  int x;
+  char tail[16];
+};
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The member parser used atoi() for array dimensions, so hex sizes like char buf[0x10] silently became count 0, corrupting the offsets of all following members. Used r_num_math() instead. 
