### PR TITLE
Split struct and union member values from the end so comma types survive ##types

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -304,6 +304,25 @@ error:
 	return NULL;
 }
 
+// values is "type,offset,count"; split from the end since the type may itself contain commas
+static void split_member_csv(char *values, const char **offset, const char **count) {
+	*offset = NULL;
+	*count = NULL;
+	char *last = (char *)r_str_rchr (values, NULL, ',');
+	if (!last) {
+		return;
+	}
+	*last = 0;
+	char *mid = (char *)r_str_rchr (values, last - 1, ',');
+	if (mid) {
+		*mid = 0;
+		*offset = mid + 1;
+		*count = last + 1;
+	} else {
+		*offset = last + 1;
+	}
+}
+
 static RAnalBaseType *get_composite_type(RAnal *anal, const char *sname, RAnalBaseTypeKind kind) {
 	R_RETURN_VAL_IF_FAIL (anal && sname, NULL);
 
@@ -335,17 +354,14 @@ static RAnalBaseType *get_composite_type(RAnal *anal, const char *sname, RAnalBa
 		if (!values) {
 			goto error;
 		}
-		char *offset = NULL;
-		char *type = sdb_anext (values, &offset);
-		char *count = NULL;
-		if (offset) {
-			offset = sdb_anext (offset, &count);
-		}
+		const char *offset = NULL;
+		const char *count = NULL;
+		split_member_csv (values, &offset, &count);
 		RAnalTypeMember memb = {
 			.name = strdup (cur),
-			.type = strdup (type),
+			.type = strdup (values),
 			.offset = offset? strtoul (offset, NULL, 10): 0,
-			.count = count? strtoul (count, NULL, 10): 0
+			.count = R_STR_ISNOTEMPTY (count)? strtoul (count, NULL, 10): 0
 		};
 		free (values);
 

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -423,6 +423,67 @@ static bool test_anal_save_base_type_struct_redefine(void) {
 	mu_end;
 }
 
+static bool test_anal_base_type_struct_comma_type_roundtrip(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("tpl");
+
+	RAnalStructMember member = {
+		.offset = 8,
+		.type = strdup ("pair<int, char>"),
+		.name = strdup ("p"),
+		.count = 0
+	};
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	RAnalBaseType *got = r_anal_get_base_type (anal, "tpl");
+	mu_assert_notnull (got, "reload struct with comma in member type");
+
+	RAnalStructMember *m = RVecAnalTypeMember_at (&got->struct_data.members, 0);
+	mu_assert_streq (m->type, "pair<int, char>", "member type with comma survives the roundtrip");
+	mu_assert_eq (m->offset, 8, "offset not shifted by the comma in the type");
+	mu_assert_eq (m->count, 0, "no count fabricated from comma-shifted fields");
+
+	r_anal_base_type_free (got);
+	r_anal_free (anal);
+	mu_end;
+}
+
+static bool test_anal_base_type_union_comma_type_roundtrip(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_UNION);
+	base->name = strdup ("utpl");
+
+	RAnalUnionMember member = {
+		.offset = 0,
+		.type = strdup ("pair<int, char>"),
+		.name = strdup ("p"),
+		.count = 4
+	};
+	RVecAnalTypeMember_push_back (&base->union_data.members, &member);
+
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	RAnalBaseType *got = r_anal_get_base_type (anal, "utpl");
+	mu_assert_notnull (got, "reload union with comma in member type");
+
+	RAnalUnionMember *m = RVecAnalTypeMember_at (&got->union_data.members, 0);
+	mu_assert_streq (m->type, "pair<int, char>", "member type with comma survives the roundtrip");
+	mu_assert_eq (m->count, 4, "count not shifted by the comma in the type");
+
+	r_anal_base_type_free (got);
+	r_anal_free (anal);
+	mu_end;
+}
+
 static bool test_anal_base_type_union_array_roundtrip(void) {
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "Couldn't create new RAnal");
@@ -561,6 +622,8 @@ int all_tests(void) {
 	mu_run_test (test_anal_save_base_type_struct);
 	mu_run_test (test_anal_base_type_struct_array_roundtrip);
 	mu_run_test (test_anal_save_base_type_struct_redefine);
+	mu_run_test (test_anal_base_type_struct_comma_type_roundtrip);
+	mu_run_test (test_anal_base_type_union_comma_type_roundtrip);
 	mu_run_test (test_anal_base_type_union_array_roundtrip);
 	mu_run_test (test_anal_save_base_type_union_redefine);
 	mu_run_test (test_anal_base_type_to_kv);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Loading a struct/union from sdb splits the member value "type,offset,count" front-first with sdb_anext, so a member type that itself contains commas (DWARF/PDB function-pointer prototypes, C++ template names like pair<int, char>) leaks its tail into the offset/count fields — the type is truncated and a bogus count is fabricated.

Split from the end instead: offset and count never contain commas, so the type keeps its commas intact. Struct stays strict on malformed values and union stays lenient, as before. Adds two unit roundtrip tests that fail on master. 