### PR TITLE
Add r_type_get_member so comma member types survive sizeof, pf and tsc ##types

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -221,15 +221,14 @@ static void shadow_var_struct_members(RAnal *anal, RAnalVar *var) {
 			if (snprintf (field_key, sizeof (field_key), "%s.%s", type_key, field) < 0) {
 				continue;
 			}
-			char *field_type = sdb_array_get (TDB, field_key, 0, NULL);
-			ut64 field_offset = sdb_array_get_num (TDB, field_key, 1, NULL);
+			ut64 field_offset = 0;
+			free (r_type_get_member (TDB, field_key, &field_offset, NULL));
 			if (field_offset != 0) { // delete variables which are overlaid by structure
 				RAnalVar *other = r_anal_function_get_var (var->fcn, var->kind, var->delta + field_offset);
 				if (other && other != var) {
 					r_anal_var_delete (anal, other);
 				}
 			}
-			free (field_type);
 			free (field);
 		}
 		free (type_key);
@@ -1035,15 +1034,14 @@ static bool var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, RList *list
 		char *type_key = r_str_newf ("%s.%s", type_kind, av->type);
 		for (field_n = 0; (field_name = sdb_array_get (TDB, type_key, field_n, NULL)); field_n++) {
 			char *field_key = r_str_newf ("%s.%s", type_key, field_name);
-			char *field_type = sdb_array_get (TDB, field_key, 0, NULL);
-			ut64 field_offset = sdb_array_get_num (TDB, field_key, 1, NULL);
+			ut64 field_offset = 0;
+			free (r_type_get_member (TDB, field_key, &field_offset, NULL));
 			new_name = r_str_newf ("%s.%s", av->name, field_name);
 			RAnalVarField *field = R_NEW0 (RAnalVarField);
 			field->name = new_name;
 			field->delta = av->delta + field_offset;
 			field->field = true;
 			r_list_append (list, field);
-			free (field_type);
 			free (field_key);
 			free (field_name);
 		}

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -885,12 +885,10 @@ static void print_struct_union_in_c_format(RCore *core, Sdb *TDB, SdbForeachCall
 		for (n = 0; (p = sdb_array_get (TDB, var, n, NULL)); n++) {
 			char *var2 = r_str_newf ("%s.%s", var, p);
 			if (var2) {
-				char *val = sdb_array_get (TDB, var2, 0, NULL);
+				ut64 moff = 0;
+				int arrnum = 0;
+				char *val = r_type_get_member (TDB, var2, &moff, &arrnum);
 				if (val) {
-					char *arr = sdb_array_get (TDB, var2, 2, NULL);
-					int arrnum = arr? atoi (arr): 0;
-					free (arr);
-					const ut64 moff = sdb_array_get_num (TDB, var2, 1, NULL);
 					if (is_struct) {
 						// function-pointer members store a func alias as their type; the parser lays them out as pointers
 						const char *tv = sdb_const_get (TDB, val, 0);
@@ -1171,11 +1169,10 @@ static void print_struct_union_with_offsets(RCore *core, Sdb *TDB, SdbForeachCal
 		for (n = 0; (p = sdb_array_get (TDB, var, n, NULL)); n++) {
 			char *var2 = r_str_newf ("%s.%s", var, p);
 			if (var2) {
-				char *val = sdb_array_get (TDB, var2, 0, NULL);
+				ut64 moff = 0;
+				int arrnum = 0;
+				char *val = r_type_get_member (TDB, var2, &moff, &arrnum);
 				if (val) {
-					char *arr = sdb_array_get (TDB, var2, 2, NULL);
-					int arrnum = arr? atoi (arr): 0;
-					free (arr);
 					ut32 type_size;
 					if (strchr (val, '*')) {
 						type_size = core->anal->config->bits / 8;

--- a/libr/include/r_util/r_type.h
+++ b/libr/include/r_util/r_type.h
@@ -31,6 +31,7 @@ R_API char *r_type_enum_getbitfield(Sdb *TDB, const char *name, ut64 val);
 R_API RList *r_type_get_enum(Sdb *TDB, const char *name);
 R_API void r_type_enum_free(RTypeEnum *member);
 R_API ut64 r_type_get_bitsize(Sdb * R_NONNULL TDB, const char * R_NONNULL type);
+R_API R_OWNED char *r_type_get_member(Sdb * R_NONNULL TDB, const char * R_NONNULL key, ut64 * R_NULLABLE offset, int * R_NULLABLE count);
 R_API RList *r_type_get_by_offset(Sdb * R_NONNULL TDB, ut64 offset);
 R_API char *r_type_get_struct_memb(Sdb * R_NONNULL TDB, const char * R_NONNULL type, int offset);
 R_API char *r_type_link_at(Sdb *TDB, ut64 addr);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -12,9 +12,10 @@ R_API bool r_type_set(Sdb *TDB, ut64 at, const char *field, ut64 val) {
 		const char *p = sdb_const_get (TDB, kind, NULL);
 		if (p) {
 			char *v = r_str_newf ("%s.%s.%s", p, kind, field);
-			int off = sdb_array_get_num (TDB, v, 1, NULL);
+			ut64 off = 0;
+			char *mtype = r_type_get_member (TDB, v, &off, NULL);
+			free (mtype);
 			free (v);
-			// int siz = sdb_array_get_num (DB, var, 2, NULL);
 			eprintf ("wv 0x%08" PFMT64x " @ 0x%08" PFMT64x "\n", val, at + off);
 			return true;
 		}
@@ -47,6 +48,40 @@ R_API RTypeKind r_type_kind(Sdb *TDB, const char *name) {
 		}
 	}
 	return R_TYPE_INVALID;
+}
+
+// key is "struct.name.member" holding "type,offset,count"; split from the end since the type may itself contain commas
+R_API R_OWNED char *r_type_get_member(Sdb *TDB, const char *key, ut64 *offset, int *count) {
+	R_RETURN_VAL_IF_FAIL (TDB && key, NULL);
+	if (offset) {
+		*offset = 0;
+	}
+	if (count) {
+		*count = 0;
+	}
+	char *val = sdb_get (TDB, key, NULL);
+	if (R_STR_ISEMPTY (val)) {
+		free (val);
+		return NULL;
+	}
+	char *last = (char *)r_str_rchr (val, NULL, ',');
+	if (!last) {
+		return val;
+	}
+	*last = 0;
+	char *mid = (char *)r_str_rchr (val, last - 1, ',');
+	const char *offstr = last + 1;
+	if (mid) {
+		*mid = 0;
+		offstr = mid + 1;
+		if (count) {
+			*count = (int)sdb_atoi (last + 1);
+		}
+	}
+	if (offset) {
+		*offset = sdb_atoi (offstr);
+	}
+	return val;
 }
 
 R_API RList *r_type_get_enum(Sdb *TDB, const char *name) {
@@ -211,28 +246,20 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 					break;
 				}
 				char *query = r_str_newf ("%s.%s.%s", t, tmptype, name);
-				char *subtype = sdb_get (TDB, query, 0);
+				int elements = 0;
+				char *subtype = r_type_get_member (TDB, query, NULL, &elements);
 				free (query);
 				if (!subtype) {
 					break;
 				}
-				char *tmp = strchr (subtype, ',');
-				if (tmp) {
-					*tmp++ = 0;
-					tmp = strchr (tmp, ',');
-					if (tmp) {
-						*tmp++ = 0;
-					}
-					int elements = r_num_math (NULL, tmp);
-					if (elements == 0) {
-						elements = 1;
-					}
-					if (!strcmp (t, "struct")) {
-						ret += r_type_get_bitsize (TDB, subtype) * elements;
-					} else {
-						ut64 sz = r_type_get_bitsize (TDB, subtype) * elements;
-						ret = sz > ret ? sz : ret;
-					}
+				if (elements == 0) {
+					elements = 1;
+				}
+				if (!strcmp (t, "struct")) {
+					ret += r_type_get_bitsize (TDB, subtype) * elements;
+				} else {
+					ut64 sz = r_type_get_bitsize (TDB, subtype) * elements;
+					ret = sz > ret ? sz : ret;
 				}
 				free (subtype);
 				ptr = next;
@@ -504,7 +531,10 @@ static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
 		bool isfp = false;
 		bool isHidden = false;
 		snprintf (var2, sizeof (var2), "%s.%s", var, p);
-		int field_offset = sdb_array_get_num (TDB, var2, 1, NULL);
+		ut64 member_offset = 0;
+		int elements = 0;
+		char *type = r_type_get_member (TDB, var2, &member_offset, &elements);
+		int field_offset = (int)member_offset;
 		if (field_offset > current_offset) {
 			int pad = field_offset - current_offset;
 			r_strbuf_appendf (fmt_sb, "[%d].", pad);
@@ -517,9 +547,6 @@ static char *fmt_struct_union(Sdb *TDB, char *var, bool is_typedef) {
 		if (visibility && !strcmp (visibility, "hidden")) {
 			isHidden = true;
 		}
-		size_t alen = sdb_array_size (TDB, var2);
-		int elements = sdb_array_get_num (TDB, var2, alen - 1, NULL);
-		char *type = sdb_array_get (TDB, var2, 0, NULL);
 		if (type) {
 			char var3[128] = { 0 };
 			char type_name[256] = { 0 };

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -2698,3 +2698,65 @@ struct Hex {
 };
 EOF
 RUN
+
+NAME=tsc struct member type with comma survives
+FILE=-
+CMDS=<<EOF
+tk tpl=struct
+tk struct.tpl=p
+'tk struct.tpl.p=pair<int, char>,8,0
+tsc tpl
+tsv tpl
+EOF
+EXPECT=<<EOF
+struct tpl {
+  uint8_t pad_0x0[8]; // gap
+  pair<int, char> p;
+};
+0x00000000 struct tpl {
+0x00000000   pair<int, char> p;
+0x00000001 };
+EOF
+RUN
+
+NAME=tuc union member type with comma survives
+FILE=-
+CMDS=<<EOF
+tk utpl=union
+tk union.utpl=p,q
+'tk union.utpl.p=pair<int, char>,0,4
+tk union.utpl.q=int32_t,0,0
+tuc utpl
+tuv utpl
+EOF
+EXPECT=<<EOF
+union utpl {
+  pair<int, char> p[4];
+  int32_t q;
+};
+0x00000000 union utpl {
+0x00000000   pair<int, char> p[4];
+0x00000000   int32_t q;
+0x00000000 };
+EOF
+RUN
+
+NAME=comma member type resolves for sizeof and pf format
+FILE=-
+CMDS=<<EOF
+'tk pair<int, char>=struct
+'tk struct.pair<int, char>=a,b
+'tk struct.pair<int, char>.a=int32_t,0,0
+'tk struct.pair<int, char>.b=int32_t,4,0
+tk outer=struct
+tk struct.outer=p,x
+'tk struct.outer.p=pair<int, char>,0,0
+tk struct.outer.x=int32_t,8,0
+tss outer
+ts outer
+EOF
+EXPECT=<<EOF
+12
+pf ?[4].d (pair<int, char>)p x
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Several readers parse the sdb member value "type,offset,count" front-first, so a member type containing commas (C++ template names, fn-pointer protos from DWARF/PDB) is truncated and its offset/count fields misread: tsc prints "pair<int p[8];", sizeof drops the member, and pf formats break.

Add r_type_get_member(), which splits the value from the end (offset and count never contain commas), and use it in the tsc/tsv printers, sizeof(r_type_get_bitsize), the pf format generator, r_type_set, and the var.c struct-field reads (dropping two dead type fetches). Companion to #26208, which fixes the base-type loader the same way. Adds three tests that fail on master. 