### PR TITLE
Fix #23827 - oba not loading bin info from fat macho headers ##bin

### DIFF
--- a/libr/core/cmd_open.inc.c
+++ b/libr/core/cmd_open.inc.c
@@ -255,6 +255,14 @@ static ut64 oba_memsize(RDebug *dbg, ut64 addr) {
 	return R_MIN (hi - lo, (ut64)32 * 1024 * 1024);
 }
 
+// fat Mach-O and other xtr containers defer their slice load, finish it here
+static void oba_finish_load(RCore *core) {
+	RBinFile *bf = r_bin_cur (core->bin);
+	if (bf && !bf->bo && bf->xtr_data && !r_list_empty (bf->xtr_data)) {
+		r_core_bin_update_arch_bits (core);
+	}
+}
+
 static void cmd_oba(RCore *core, const char *input) {
 	if (input[2] == '?') {
 		r_core_cmd_help (core, help_msg_oba);
@@ -306,6 +314,7 @@ static void cmd_oba(RCore *core, const char *input) {
 					opt.sz = 1024 * 1024;
 				}
 				r_bin_open_io (core->bin, &opt);
+				oba_finish_load (core);
 				r_core_cmd0 (core, ".is*");
 			} else {
 				R_LOG_ERROR ("No file to load bin from?");
@@ -322,6 +331,7 @@ static void cmd_oba(RCore *core, const char *input) {
 					opt.sz = 1024 * 1024;
 				}
 				r_bin_open_io (core->bin, &opt);
+				oba_finish_load (core);
 				r_core_cmd0 (core, ".is*");
 			} else {
 				R_LOG_ERROR ("No file to load bin from?");

--- a/test/db/cmd/cmd_open
+++ b/test/db/cmd/cmd_open
@@ -325,6 +325,20 @@ b32ae931000000000200
 EOF
 RUN
 
+NAME=oba loads default slice from fat macho header
+FILE=bins/mach0/libexpat.1.dylib
+ARGS=-n
+CMDS=<<EOF
+oba $$
+i~^arch[1]
+i~^bintype[1]
+EOF
+EXPECT=<<EOF
+x86
+mach0
+EOF
+RUN
+
 NAME=ob select files
 FILE=malloc://1024
 CMDS=<<EOF


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`oba` at the header of a fat mach-o printed nothing:
```
$ r2 -n some.fat.macho
[0x0]> oba $$
[0x0]> ob
[0x0]>
```
When oba points at the fat header, the fs probe detects the slices, and a binfile is created, but the slice load is deferred, i.e. bf->bo stays NULL, and slices live in xtr_data. However, a normal open finishes that by picking a default slice; the address form of oba never did, so ob/.is* saw an objectless binfile and showed nothing. The filename form already worked since it called `r_core_bin_load`.

This finishes the deferred load the same way a normal open does; otherwise, it's a no-op for thin binaries.

Fixes #23827