### PR TITLE
Add anal.gpreg to seed a PIC base register during ESIL analysis ##anal

### DIFF
--- a/libr/core/canal_esil.inc.c
+++ b/libr/core/canal_esil.inc.c
@@ -1053,6 +1053,11 @@ R_API void r_core_anal_esil(RCore *core, const char *str /* len */, const char *
 	}
 
 	r_reg_arena_push (core->anal->reg);
+	// PIC base register (e.g. PPC32 r30): seeded once at entry, then mutated locally, so unlike gp it is never re-fixed
+	const char *gpseed = r_config_get (core->config, "anal.gpseed");
+	if (R_STR_ISNOTEMPTY (gpseed)) {
+		r_reg_setv (core->anal->reg, gpseed, gp);
+	}
 	char *sn = (char *)r_reg_alias_getname (core->anal->reg, R_REG_ALIAS_SN);
 	if (sn) {
 		sn = strdup (sn);

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4139,6 +4139,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("anal.cs", 0, (RConfigCallback)&cb_anal_cs, "set the value for the x86-16 CS segment register (see asm.addr.segment and asm.addr.segment.bits)");
 	SETICB ("anal.gp", 0, (RConfigCallback)&cb_anal_gp, "global pointer value: MIPS gp register / PPC64 ELFv1 TOC base (r2); auto-detected on file load");
 	SETB ("anal.fixed.gp", "true", "set gp register to anal.gp before emulating each instruction in aae");
+	SETS ("anal.gpseed", "", "seed this register with anal.gp at the start of each ESIL function emulation (PIC base register, e.g. PPC32 r30)");
 	SETCB ("anal.fixed.arch", "false", &cb_anal_fixed_arch, "permit arch changes during analysis");
 	SETCB ("anal.fixed.bits", "false", &cb_anal_fixed_bits, "permit bits changes during analysis (arm/thumb)");
 	SETCB ("anal.fixed.thumb", "true", &cb_anal_fixed_thumb, "permit switching between arm:32 and arm:16 during analysis");

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -9255,6 +9255,11 @@ R_API void r_core_anal_esil_function(RCore *core, ut64 addr) {
 	const ut64 old_pc = r_reg_getv (core->anal->reg, "PC");
 	if (fcn) {
 		bool anal_verbose = r_config_get_b (core->config, "anal.verbose");
+		// PIC base register (e.g. PPC32 r30): seed at function entry so its SDA base derivation resolves
+		const char *gpseed = r_config_get (core->config, "anal.gpseed");
+		if (R_STR_ISNOTEMPTY (gpseed)) {
+			r_reg_setv (core->anal->reg, gpseed, r_config_get_i (core->config, "anal.gp"));
+		}
 		// emulate every instruction in the function recursively across all the basic blocks
 		r_list_foreach (fcn->bbs, iter, bb) {
 			ut64 pc = bb->addr;

--- a/test/db/cmd/cmd_aae
+++ b/test/db/cmd/cmd_aae
@@ -6,6 +6,36 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=anal.gpseed seeds a base register during aae emulation
+FILE=malloc://0x1000
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+e anal.gpseed=r30
+e anal.gp=0x800
+wa lwz r3, 0(r30) @ 0
+wa lwz r4, 4(r30) @ 4
+aae 8 0 @ 0
+axq
+EOF
+EXPECT=<<EOF
+0x00000000 -> 0x00000800  DATA:r--
+0x00000004 -> 0x00000804  DATA:r--
+EOF
+RUN
+
+NAME=anal.gpseed unset leaves base register at zero
+FILE=malloc://0x1000
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wa lwz r3, 0(r30) @ 0
+wa lwz r4, 4(r30) @ 4
+aae 8 0 @ 0
+axq
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
 NAME=aae clears call-clobbered regs before xref inference
 FILE=malloc://0x400
 ARGS=-w -a x86 -b 64


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Position-independent code (e.g. PPC32 SDA-style binaries) computes data addresses from a base register held constant across the program  — `r30` in the example that motivated this. ESIL analysis starts that register at 0, so `disp(r30)` accesses resolve nowhere and  `aae` finds no xrefs.

New `anal.gpreg` config (register name, empty by default) seeds that register with `anal.gp` at the start of each ESIL function emulation, in both `r_core_anal_esil` (aae/aaef) and `r_core_anal_esil_function` (aef). Unlike `anal.fixed.gp` it seeds once rather than re-fixing every instruction, so the code can still derive local offsets from the base.

Usage: `-e anal.gpreg=r30 -e anal.gp=0x2000000`

Off by default — no behavior change unless set. Tests in `test/db/cmd/cmd_aae` (seed on → xrefs recovered, off → none).