### PR TITLE
Fix break regressions in the deferred console interrupt design ##cons

### DIFF
--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -16,22 +16,37 @@ static RCons *I = NULL;
 #define WRITE_LIT(fd, s) (write ((fd), (s), sizeof (s) - 1) == (int)(sizeof (s) - 1))
 
 #if R2__UNIX__
-static volatile sig_atomic_t break_signal_pending = 0;
+static volatile R_ATOMIC_BOOL break_signal_pending = 0;
 
 static void __break_signal(int sig) {
 	(void)sig;
-	break_signal_pending = 1;
+	r_atomic_store (&break_signal_pending, true);
+	// Data-only store so code polling context->breaked directly
+	// (r_cons_write, r_print loops, ..) observes the interrupt
+	// immediately. The interrupt callbacks are not run here: they may
+	// allocate or lock, so they are deferred to the next
+	// r_cons_is_breaked() call, which consumes the pending flag.
+	RCons *cons = I;
+	if (cons && cons->context) {
+		cons->context->breaked = true;
+	}
 }
 #endif
 
 #if R2__WINDOWS__
-static volatile LONG break_signal_pending = 0;
 static volatile LONG control_handler_registered = 0;
 static HANDLE h = 0;
 
 static BOOL __w32_control(DWORD type) {
 	if (type == CTRL_C_EVENT) {
-		InterlockedExchange (&break_signal_pending, 1);
+		// Unlike a UNIX signal handler, this runs in a dedicated thread,
+		// so it is safe to dispatch the break (and its callbacks, which
+		// blocking waiters like WaitForDebugEvent depend on) right away.
+		RCons *cons = I;
+		if (cons) {
+			r_cons_context_break (cons->context);
+		}
+		eprintf ("^C pressed\n");
 		return true;
 	}
 	return false;
@@ -39,15 +54,11 @@ static BOOL __w32_control(DWORD type) {
 #endif
 
 static bool consume_break_signal(void) {
-#if R2__WINDOWS__
-	return InterlockedExchange (&break_signal_pending, 0) != 0;
-#elif R2__UNIX__
-	if (break_signal_pending) {
-		break_signal_pending = 0;
-		return true;
-	}
-#endif
+#if R2__UNIX__
+	return r_atomic_exchange (&break_signal_pending, false);
+#else
 	return false;
+#endif
 }
 
 static unsigned int count_display_lines(RCons *cons, const char *buffer, size_t len) {
@@ -480,6 +491,8 @@ R_API void r_cons_context_break_push(RCons *cons, RConsContext *context, RConsBr
 	// if we don't have any element in the stack start the signal
 	RConsBreakStack *b = R_NEW0 (RConsBreakStack);
 	if (r_stack_is_empty (context->break_stack)) {
+		// Discard any stale pending signal from a previous break scope so
+		// the first poll in this scope doesn't fire its callback spuriously
 		consume_break_signal ();
 #if R2__UNIX__
 		if (!context->unbreakable && !cons->is_embedded) {
@@ -541,11 +554,11 @@ R_API bool r_cons_was_breaked(RCons *cons) {
 }
 
 R_API bool r_cons_is_breaked(RCons *cons) {
+#if WANT_DEBUGSTUFF
 	RConsContext *C = cons->context;
 	if (R_UNLIKELY (consume_break_signal ())) {
 		r_cons_context_break (C);
 	}
-#if WANT_DEBUGSTUFF
 	if (R_UNLIKELY (cons->cb_break)) {
 		cons->cb_break (cons->user);
 	}

--- a/libr/cons/cons.c
+++ b/libr/cons/cons.c
@@ -15,27 +15,40 @@ static RCons *I = NULL;
 // The argument MUST be a string literal or char[] (sizeof must be the array size).
 #define WRITE_LIT(fd, s) (write ((fd), (s), sizeof (s) - 1) == (int)(sizeof (s) - 1))
 
-#if R2__UNIX__ || R2__WINDOWS__
+#if R2__UNIX__
+static volatile sig_atomic_t break_signal_pending = 0;
+
 static void __break_signal(int sig) {
-	if (I) {
-		r_cons_context_break (I->context);
-	} else {
-		R_LOG_WARN ("Global cons is null");
-	}
+	(void)sig;
+	break_signal_pending = 1;
 }
 #endif
 
 #if R2__WINDOWS__
+static volatile LONG break_signal_pending = 0;
+static volatile LONG control_handler_registered = 0;
 static HANDLE h = 0;
+
 static BOOL __w32_control(DWORD type) {
 	if (type == CTRL_C_EVENT) {
-		__break_signal (2); // SIGINT
-		eprintf ("^C pressed\n");
+		InterlockedExchange (&break_signal_pending, 1);
 		return true;
 	}
 	return false;
 }
 #endif
+
+static bool consume_break_signal(void) {
+#if R2__WINDOWS__
+	return InterlockedExchange (&break_signal_pending, 0) != 0;
+#elif R2__UNIX__
+	if (break_signal_pending) {
+		break_signal_pending = 0;
+		return true;
+	}
+#endif
+	return false;
+}
 
 static unsigned int count_display_lines(RCons *cons, const char *buffer, size_t len) {
 	int columns, rows;
@@ -292,9 +305,11 @@ R_API RCons *r_cons_new2(void) {
 	h = GetStdHandle (STD_INPUT_HANDLE);
 	GetConsoleMode (h, &cons->term_buf);
 	cons->term_raw = 0;
-	I = cons;
-	if (!SetConsoleCtrlHandler ((PHANDLER_ROUTINE)__w32_control, TRUE)) {
-		R_LOG_ERROR ("Cannot set control console handler");
+	if (InterlockedCompareExchange (&control_handler_registered, 1, 0) == 0) {
+		if (!SetConsoleCtrlHandler ((PHANDLER_ROUTINE)__w32_control, TRUE)) {
+			InterlockedExchange (&control_handler_registered, 0);
+			R_LOG_ERROR ("Cannot set control console handler");
+		}
 	}
 #endif
 	cons->pager = NULL; /* no pager by default */
@@ -453,6 +468,7 @@ R_API RCons *r_cons_singleton(void) {
 
 R_API void r_cons_break_clear(RCons *cons) {
 	RConsContext *ctx = cons->context;
+	consume_break_signal ();
 	ctx->was_breaked = false;
 	ctx->breaked = false;
 }
@@ -464,6 +480,7 @@ R_API void r_cons_context_break_push(RCons *cons, RConsContext *context, RConsBr
 	// if we don't have any element in the stack start the signal
 	RConsBreakStack *b = R_NEW0 (RConsBreakStack);
 	if (r_stack_is_empty (context->break_stack)) {
+		consume_break_signal ();
 #if R2__UNIX__
 		if (!context->unbreakable && !cons->is_embedded) {
 			if (sig && r_cons_context_is_main (cons, context)) {
@@ -524,8 +541,11 @@ R_API bool r_cons_was_breaked(RCons *cons) {
 }
 
 R_API bool r_cons_is_breaked(RCons *cons) {
-#if WANT_DEBUGSTUFF
 	RConsContext *C = cons->context;
+	if (R_UNLIKELY (consume_break_signal ())) {
+		r_cons_context_break (C);
+	}
+#if WANT_DEBUGSTUFF
 	if (R_UNLIKELY (cons->cb_break)) {
 		cons->cb_break (cons->user);
 	}
@@ -1602,6 +1622,7 @@ R_API bool r_cons_context_is_main(RCons *cons, RConsContext *ctx) {
 
 R_API void r_cons_break_end(RCons *cons) {
 	RConsContext *C = cons->context;
+	consume_break_signal ();
 	C->breaked = false;
 	cons->timeout = 0;
 #if R2__UNIX__ && !__wasi__

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -1648,7 +1648,9 @@ R_API int r_debug_continue_syscalls(RDebug *dbg, int *sc, int n_sc) {
 		RDebugReasonType reason;
 		RCore *core = (RCore *)dbg->coreb.core;
 
-		if (core->cons->context->breaked) {
+		// r_cons_is_breaked also consumes a pending SIGINT, which a direct
+		// read of context->breaked would never observe
+		if (r_cons_is_breaked (core->cons)) {
 			break;
 		}
 #if __linux__

--- a/libr/debug/p/native/linux/linux_debug.c
+++ b/libr/debug/p/native/linux/linux_debug.c
@@ -646,14 +646,19 @@ RDebugReasonType linux_dbg_wait(RDebug *dbg, int pid) {
 		} else {
 			ret = waitpid (pid, &status, flags);
 		}
+		const int wait_errno = errno;
 		r_cons_sleep_end (core->cons, bed);
+		if (ret < 0 && wait_errno == EINTR) {
+			// A signal interrupted the wait. Consume any pending break
+			// while our wait-break handler is still pushed, so a ^C stops
+			// the debuggee before waitpid blocks again.
+			r_cons_is_breaked (core->cons);
+			r_cons_break_pop (core->cons);
+			continue;
+		}
 		r_cons_break_pop (core->cons);
 
 		if (ret < 0) {
-			// Continue when interrupted by user;
-			if (errno == EINTR) {
-				continue;
-			}
 			r_sys_perror ("waitpid");
 			break;
 		} else if (ret == 0) {

--- a/libr/lang/p/qjs.c
+++ b/libr/lang/p/qjs.c
@@ -34,7 +34,10 @@ static R_TH_LOCAL JSContext *current_ctx = NULL;
 
 static int qjs_interrupt_handler(JSRuntime *rt, void *opaque) {
 	RCons *cons = (RCons *)opaque;
-	if (cons && cons->context && cons->context->breaked) {
+	// Use r_cons_is_breaked instead of reading context->breaked directly
+	// so a pending SIGINT is consumed and aborts a runaway script: while
+	// the VM runs, this handler is the only break poll point
+	if (cons && cons->context && r_cons_is_breaked (cons)) {
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #26215 (includes its commit) addressing the review findings on the deferred break design, so both can be validated in CI together. The flag-consumption approach in `r_cons_is_breaked()` silently changed the contract "break callbacks run at signal time" to "break callbacks run at the next poll", which regressed consumers that depend on the old contract:

- **UNIX signal handler**: additionally do a data-only, async-signal-safe store of `context->breaked`, so the direct readers of that field (`r_cons_write`, `r_print` loops, the socket http server) observe ^C immediately. Only the interrupt callbacks stay deferred to the next `r_cons_is_breaked()` call, which is a safe context to run them (they may allocate or lock).
- **w32 control handler**: restore direct break dispatch. It runs in a dedicated thread, not in async-signal context, so the deferral is unnecessary there — and blocking waiters without a poll loop (windbg's `WaitForDebugEvent`) depend on the callback firing at interrupt time. The one-time handler registration and the removal of the `I = cons` assignment from `r_cons_new2` are kept.
- **`linux_dbg_wait`**: consume a pending break when `waitpid` is interrupted, while the wait-break handler is still pushed, so ^C stops a debuggee running in another process group instead of silently re-entering `waitpid` (`dc` on attached processes was unbreakable with the deferred design alone).
- **`dcs` loop guard and qjs interrupt handler**: poll `r_cons_is_breaked()` instead of reading `context->breaked`, so a pending break is consumed and can abort a runaway `js` script. This also moves the qjs break callback out of signal context.
- **Atomicity**: use `r_atomic_exchange`/`r_atomic_store` for the pending flag so the consume is a proper atomic test-and-clear across threads.
- The stale-flag discard in `break_push`/`clear`/`end` is kept: with the handler storing `breaked` directly, the discard can only drop a deferred callback of an already-ended scope, never a break.

Verified locally on Linux: SIGINT aborts a long `aaa`, aborts `js while(true){}` (deferred qjs break callback fires), and interrupts `dc` on a debuggee in a different process group (r2-only SIGINT, exercising `linux_dbg_wait_break_main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lccou2Xu6ky4aQZG5rQbZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lccou2Xu6ky4aQZG5rQbZF)_