### PR TITLE
Deprecate the old sdb metadata for resources ##bin

### DIFF
--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3395,36 +3395,6 @@ R_API bool PE_(r_bin_pe_load_resources)(RBinPEObj *pe, RVecRBinResource *resourc
 	return true;
 }
 
-static void _store_resource_sdb(RBinPEObj *pe) {
-	r_strf_buffer (64);
-	RListIter *iter;
-	r_pe_resource *rs;
-	int index = 0;
-	ut64 vaddr = 0;
-	char *key;
-	Sdb *sdb = sdb_new0 ();
-	if (!sdb) {
-		return;
-	}
-	r_list_foreach (pe->resources, iter, rs) {
-		key = r_strf ("resource.%d.timestr", index);
-		sdb_set (sdb, key, rs->timestr, 0);
-		key = r_strf ("resource.%d.vaddr", index);
-		vaddr = bin_pe_rva_to_va (pe, rs->data->OffsetToData);
-		sdb_num_set (sdb, key, vaddr, 0);
-		key = r_strf ("resource.%d.name", index);
-		sdb_set (sdb, key, rs->name, 0);
-		key = r_strf ("resource.%d.size", index);
-		sdb_num_set (sdb, key, rs->data->Size, 0);
-		key = r_strf ("resource.%d.type", index);
-		sdb_set (sdb, key, rs->type, 0);
-		key = r_strf ("resource.%d.language", index);
-		sdb_set (sdb, key, rs->language, 0);
-		index++;
-	}
-	sdb_ns_set (pe->kv, "pe_resource", sdb);
-}
-
 R_API void PE_(bin_pe_parse_resource)(RBinPEObj *pe) {
 	int index = 0;
 	ut64 off = 0, rsrc_base = pe->resource_directory_offset;
@@ -3468,7 +3438,6 @@ R_API void PE_(bin_pe_parse_resource)(RBinPEObj *pe) {
 		}
 	}
 	r_bitset_free (dirs);
-	_store_resource_sdb (pe);
 }
 
 static void free_security_directory(Pe_image_security_directory *security_directory) {

--- a/test/db/formats/ne
+++ b/test/db/formats/ne
@@ -75,6 +75,52 @@ nth paddr         size vaddr        vsize perm flags type name
 EOF
 RUN
 
+NAME=NE Resources JSON
+FILE=bins/ne/anim8.exe
+CMDS=iRj~{}~name
+EXPECT=<<EOF
+    "name": "ICONX",
+    "name": "FRAME_1",
+    "name": "FRAME_10",
+    "name": "FRAME_11",
+    "name": "FRAME_12",
+    "name": "FRAME_13",
+    "name": "FRAME_14",
+    "name": "FRAME_15",
+    "name": "FRAME_16",
+    "name": "FRAME_17",
+    "name": "FRAME_18",
+    "name": "FRAME_19",
+    "name": "FRAME_2",
+    "name": "FRAME_20",
+    "name": "FRAME_21",
+    "name": "FRAME_22",
+    "name": "FRAME_23",
+    "name": "FRAME_24",
+    "name": "FRAME_25",
+    "name": "FRAME_26",
+    "name": "FRAME_27",
+    "name": "FRAME_28",
+    "name": "FRAME_29",
+    "name": "FRAME_3",
+    "name": "FRAME_30",
+    "name": "FRAME_4",
+    "name": "FRAME_5",
+    "name": "FRAME_6",
+    "name": "FRAME_7",
+    "name": "FRAME_8",
+    "name": "FRAME_9",
+    "name": "MENUS",
+    "name": "DIAL_ABOUT",
+    "name": "4",
+    "name": "5",
+    "name": "9",
+    "name": "626",
+    "name": "ACCELS",
+    "name": "1",
+EOF
+RUN
+
 NAME=NE Module imports
 FILE=bins/ne/anim8.exe
 CMDS=ii

--- a/test/db/formats/pe/xalz
+++ b/test/db/formats/pe/xalz
@@ -81,7 +81,6 @@ EXPECT=<<EOF
 info
 pe
 vs_version_info
-pe_resource
 --
 archs=0:0:x86:32
 actual_checksum=0x00223928
@@ -138,7 +137,6 @@ EXPECT=<<EOF
 info
 pe
 vs_version_info
-pe_resource
 --
 archs=0:0:x86:32
 actual_checksum=0x00223928

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -1070,6 +1070,28 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=rabin2 -Uj PE
+FILE=bins/pe/standard.exe
+CMDS=!rabin2 -j -U ${R2_FILE}
+EXPECT=<<EOF
+{"resources":[{"name":"1576","index":0,"type":"ICON","vaddr":4198784,"size":5672,"lang":"LANG_NEUTRAL","timestamp":"Thu Jan  1 00:00:00 1970"},{"name":"10","index":1,"type":"STRING","vaddr":4205072,"size":76,"lang":"LANG_NEUTRAL","timestamp":"Thu Jan  1 00:00:00 1970"},{"name":"788","index":2,"type":"GROUP_ICON","vaddr":4204464,"size":20,"lang":"LANG_NEUTRAL","timestamp":"Thu Jan  1 00:00:00 1970"},{"name":"1","index":3,"type":"VERSION","vaddr":4204496,"size":452,"lang":"LANG_NEUTRAL","timestamp":"Thu Jan  1 00:00:00 1970"},{"name":"1","index":4,"type":"MANIFEST","vaddr":4204960,"size":74,"lang":"LANG_NEUTRAL","timestamp":"Thu Jan  1 00:00:00 1970"}]}
+EOF
+RUN
+
+NAME=rabin2 -Uj NE
+FILE=bins/ne/anim8.exe
+CMDS=<<EOF
+!rabin2 -j -U ${R2_FILE} | grep -o '"name":"ICONX","index":0,"type":"GROUP_ICON","vaddr":47104,"size":512'
+!rabin2 -j -U ${R2_FILE} | grep -o '"name":"1","index":38,"type":"ICON","vaddr":312832,"size":1024'
+!rabin2 -j -U ${R2_FILE} | grep -o '"index":' | wc -l | tr -d ' '
+EOF
+EXPECT=<<EOF
+"name":"ICONX","index":0,"type":"GROUP_ICON","vaddr":47104,"size":512
+"name":"1","index":38,"type":"ICON","vaddr":312832,"size":1024
+39
+EOF
+RUN
+
 NAME=rabin2 -E
 FILE=bins/pe/dll.dll
 CMDS=!rabin2 -E ${R2_FILE}


### PR DESCRIPTION
* It was only used in PE and now we have RBinResource apis

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
