### PR TITLE
Invalidate the toc_map base register on PPC update-form loads and stores ##arch

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -799,6 +799,36 @@ static void set_toc_val(RAnalOp *op, PluginData *pd, cs_insn *insn, int regidx, 
 	}
 }
 
+// Update-form ld/st writes the EA back into the base register; op0 keying misses it and capstone has no writeback flag
+static int toc_update_form_base(cs_insn *insn) {
+	switch (insn->id) {
+	case PPC_INS_LBZU: case PPC_INS_LBZUX: case PPC_INS_LHZU: case PPC_INS_LHZUX:
+	case PPC_INS_LHAU: case PPC_INS_LHAUX: case PPC_INS_LWZU: case PPC_INS_LWZUX:
+	case PPC_INS_LWAUX: case PPC_INS_LDU: case PPC_INS_LDUX: case PPC_INS_LFSU:
+	case PPC_INS_LFSUX: case PPC_INS_LFDU: case PPC_INS_LFDUX: case PPC_INS_STBU:
+	case PPC_INS_STBUX: case PPC_INS_STHU: case PPC_INS_STHUX: case PPC_INS_STWU:
+	case PPC_INS_STWUX: case PPC_INS_STDU: case PPC_INS_STDUX: case PPC_INS_STFSU:
+	case PPC_INS_STFSUX: case PPC_INS_STFDU: case PPC_INS_STFDUX:
+		break;
+	default:
+		return -1;
+	}
+	cs_ppc_op *base = &INSOP (1);
+	if (base->type == PPC_OP_MEM) {
+		return toc_reg_idx (base->mem.base);
+	}
+	return (base->type == PPC_OP_REG)? toc_reg_idx (base->reg): -1;
+}
+
+// A write into r2 drops every derived entry, any other GPR only its own
+static void toc_clobber(PluginData *pd, int ridx) {
+	if (ridx == 2) {
+		memset (pd->toc_map, 0, sizeof (pd->toc_map));
+	} else if (ridx >= 0) {
+		pd->toc_map[ridx] = 0;
+	}
+}
+
 // Invalidate toc_map entries made stale by a return, a call, or a write to the holding/r2 base
 static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 	if (op->type == R_ANAL_OP_TYPE_RET || op->type == R_ANAL_OP_TYPE_CRET) {
@@ -813,6 +843,7 @@ static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 		}
 		return;
 	}
+	toc_clobber (pd, toc_update_form_base (insn));
 	// addis owns its entry; PPC capstone lacks cs_regs_access so infer the written GPR from op0
 	if (insn->id == PPC_INS_ADDIS || INSOP (0).type != PPC_OP_REG) {
 		return;
@@ -835,14 +866,7 @@ static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 	case R_ANAL_OP_TYPE_ROR:
 	case R_ANAL_OP_TYPE_NOT:
 	case R_ANAL_OP_TYPE_CPL:
-		{
-			int ridx = toc_reg_idx (INSOP (0).reg);
-			if (ridx == 2) {
-				memset (pd->toc_map, 0, sizeof (pd->toc_map)); // r2 reload drops every derived entry
-			} else if (ridx >= 0) {
-				pd->toc_map[ridx] = 0;
-			}
-		}
+		toc_clobber (pd, toc_reg_idx (INSOP (0).reg));
 		break;
 	}
 }

--- a/test/db/formats/elf/ppc64v1-toc
+++ b/test/db/formats/elf/ppc64v1-toc
@@ -146,3 +146,49 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=PPC64 ELFv1: update-form store writes back the base so its pending TOC entry drops
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true -e anal.gp=0x10020000
+FILE=malloc://64
+CMDS=<<EOF
+wx 3d22ffff94090010e9890000
+ao 3~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x10010010
+EOF
+RUN
+
+NAME=PPC64 ELFv1: indexed update-form store writes back the base so its pending TOC entry drops
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true -e anal.gp=0x10020000
+FILE=malloc://64
+CMDS=<<EOF
+wx 3d22ffff7c09296ee9890000
+ao 3~^ptr
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=PPC64 ELFv1: update-form load invalidates the base register entry, not only the destination
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true -e anal.gp=0x10020000
+FILE=malloc://64
+CMDS=<<EOF
+wx 3d22ffff84890010e9890000
+ao 3~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x10010010
+EOF
+RUN
+
+NAME=PPC64 ELFv1: update-form store through r2 rewrites the TOC base and drops every entry
+ARGS=-a ppc -e asm.bits=64 -e cfg.bigendian=true -e anal.gp=0x10020000
+FILE=malloc://64
+CMDS=<<EOF
+wx 3d22fffff922ffe1e9890000
+ao 3~^ptr
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

In PPC, update-form loads and stores (`stwu`, `ldu`, `lwzux`, ...) write the effective address back into the base register, but `toc_invalidate()` only keys clobber detection off the destination operand, so a stale toc_map entry survived the writeback and later loads through that register resolved to bogus addresses (phantom `ptr:` annotations and false data xrefs on ppc64 ELFv1 binaries). Capstone's PPC module has no writeback/register-access info, so this uses an explicit opcode table, handling both D-form (mem operand) and X-form (register operand) bases. A writeback into r2 rewrites the TOC base itself and drops the whole map. Tests cover the D-form, X-form and r2-base cases.