### PR TITLE
Invalidate the cached t9 call target on untracked MIPS register writes ##arch

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -890,8 +890,9 @@ typedef struct plugin_data_t {
 	CapstonePluginData cpd;
 	RRegItem reg;
 	char *cpu;
-	int bigendian;
 	ut64 t9_pre;
+	ut64 t9_adj;
+	bool bigendian;
 	int last_syntax;
 } PluginData;
 
@@ -910,6 +911,7 @@ static bool init(RArchSession *as) {
 	}
 
 	pd->t9_pre = UT64_MAX;
+	pd->t9_adj = UT64_MAX;
 	pd->bigendian = R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config);
 	pd->cpu = as->config->cpu? strdup (as->config->cpu): NULL;
 	if (!r_arch_cs_init (as, &pd->cpd.cs_handle)) {
@@ -946,6 +948,46 @@ static bool plugin_changed(RArchSession *as) {
 		return true;
 	}
 	return strcmp (r_str_get (cpd->cpu), r_str_get (as->config->cpu)) != 0;
+}
+
+// t9_pre only survives writes the decoder models (gp-load set, addiu lo-adjust); any other write to t9 stales it
+static void t9_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
+	if (pd->t9_pre == UT64_MAX || insn->detail->mips.op_count < 1) {
+		return;
+	}
+	if (OPERAND (0).type != MIPS_OP_REG || REGID (0) != MIPS_REG_T9) {
+		return;
+	}
+	if ((insn->id == MIPS_INS_ADDIU || insn->id == MIPS_INS_DADDIU) && insn->detail->mips.op_count == 3
+			&& OPERAND (1).type == MIPS_OP_REG && REGID (1) == MIPS_REG_T9 && OPERAND (2).type == MIPS_OP_IMM) {
+		// decode runs several times per op; apply the lo-adjust only once per address
+		if (pd->t9_adj != op->addr) {
+			pd->t9_pre += IMM (2);
+			pd->t9_adj = op->addr;
+		}
+		return;
+	}
+	switch (op->type) {
+	case R_ANAL_OP_TYPE_NULL: // slt/mflo and friends leave no type; treat any untyped op0 write as a clobber
+	case R_ANAL_OP_TYPE_MOV:
+	case R_ANAL_OP_TYPE_ADD:
+	case R_ANAL_OP_TYPE_SUB:
+	case R_ANAL_OP_TYPE_MUL:
+	case R_ANAL_OP_TYPE_DIV:
+	case R_ANAL_OP_TYPE_MOD:
+	case R_ANAL_OP_TYPE_AND:
+	case R_ANAL_OP_TYPE_OR:
+	case R_ANAL_OP_TYPE_XOR:
+	case R_ANAL_OP_TYPE_SHL:
+	case R_ANAL_OP_TYPE_SHR:
+	case R_ANAL_OP_TYPE_SAR:
+	case R_ANAL_OP_TYPE_NOT:
+	case R_ANAL_OP_TYPE_CMOV:
+	case R_ANAL_OP_TYPE_ROL:
+	case R_ANAL_OP_TYPE_ROR:
+		pd->t9_pre = UT64_MAX;
+		break;
+	}
 }
 
 static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
@@ -1040,6 +1082,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 					op->ptr = as->config->gp + OPERAND (1).mem.disp;
 					if (REGID (0) == MIPS_REG_T9) {
 						pd->t9_pre = op->ptr;
+						pd->t9_adj = UT64_MAX;
 						RBin *bin = as->arch->binb.bin;
 						const ut64 ptrv = mips_read_ptr_at (bin, op->ptr, R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config), as->config->bits);
 						if (ptrv != UT64_MAX) {
@@ -1144,9 +1187,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		SET_VAL (op, 2);
 		op->sign = (insn->id == MIPS_INS_ADDI || insn->id == MIPS_INS_ADD);
 		op->type = R_ANAL_OP_TYPE_ADD;
-		if (REGID(0) == MIPS_REG_T9) {
-				pd->t9_pre += IMM(2);
-		}
 		if (REGID(0) == MIPS_REG_SP) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = -IMM(2);
@@ -1319,6 +1359,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		SET_VAL (op,2);
 		break;
 	}
+	t9_invalidate (pd, op, insn);
 beach:
 	set_opdir (op);
 	if (insn && mask & R_ARCH_OP_MASK_OPEX) {

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -8,7 +8,6 @@
 
 typedef struct plugin_data_t {
 	char *pre_cpu;
-	ut64 t9_pre;
 } PluginData;
 
 static int symbol_at_address(bfd_vma addr, struct disassemble_info *info) {
@@ -1340,7 +1339,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	int optype = buf[0] >> 2;
 	insn.optype = optype;
 	insn.id = 0;
-	PluginData *pd = as->data;
 	if (optype == 0) {
 		/*
 			R-TYPE
@@ -1410,9 +1408,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			insn.id = MIPS_INS_JR;
 			if (rs == 31) {
 				op->type = R_ANAL_OP_TYPE_RET;
-			} else if (rs == 25) {
-				op->type = R_ANAL_OP_TYPE_RJMP;
-				op->jump = pd->t9_pre;
 			} else {
 				op->type = R_ANAL_OP_TYPE_RJMP;
 			}
@@ -1423,7 +1418,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			insn.id = MIPS_INS_JALR;
 			if (rs == 25) {
 				op->type = R_ANAL_OP_TYPE_RCALL;
-				op->jump = pd->t9_pre;
 				break;
 			}
 			op->type = R_ANAL_OP_TYPE_UCALL;
@@ -1800,13 +1794,6 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			} else {
 				op->ptr = imm;
 			}
-			if (rt == 25) {
-				pd->t9_pre = op->ptr;
-				const ut64 ptrv = mips_read_ptr_at (as->arch->binb.bin, op->ptr, R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config), as->config->bits);
-				if (ptrv != UT64_MAX) {
-					pd->t9_pre = ptrv;
-				}
-			}
 			if (mask & R_ARCH_OP_MASK_VAL) {
 				if (mips_reg_is_stack_base (rs)) {
 					mips_fill_load_values (op, rt, rs, imm);
@@ -2086,7 +2073,6 @@ static bool init(RArchSession *as) {
 		return false;
 	}
 
-	pd->t9_pre = UT64_MAX;
 	return true;
 }
 

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -917,3 +917,127 @@ at,v0,v1,a0,a1,a2,a3,a4,a5,a6,a7,t4,t5,t6,t7,t8,t9,ra,f0,f1,f2,f3,f4,f5,f6,f7,f8
 s0,s1,s2,s3,s4,s5,s6,s7,gp,sp,fp,f24,f25,f26,f27,f28,f29,f30,f31
 EOF
 RUN
+
+NAME=mips jalr t9 resolves through the gp-relative got load
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f990010000000000320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00401000
+EOF
+RUN
+
+NAME=mips write into t9 after the gp load drops the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f9900103c1900050320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips three-register addu into t9 does not fabricate a jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f9900100322c8210320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips addiu with a non-t9 source drops the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f990010261900200320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips addiu lo-adjust applies exactly once to the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f990010273900200320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00401020
+EOF
+RUN
+
+NAME=mips addiu on an unknown t9 does not fabricate a jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 273900200320f809
+ao 2~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips conditional move into t9 drops the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f9900100085c80b0320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips rotate into t9 drops the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f9900100039c9020320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=mips.gnu jalr t9 keeps no cross-instruction decoder state
+FILE=malloc://64
+ARGS=-e anal.arch=mips.gnu -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f990010000000000320f809
+ao 3~type,jump
+EOF
+EXPECT=<<EOF
+type: load
+type: nop
+type: rcall
+EOF
+RUN
+
+NAME=mips untyped sltu write into t9 drops the pending jalr target
+FILE=malloc://64
+ARGS=-e anal.arch=mips -e asm.bits=32 -e cfg.bigendian=true -e anal.gp=0x20
+CMDS=<<EOF
+wx 00401000 @ 0x30
+wx 8f9900100085c82b0320f809
+ao 3~jump:
+EOF
+EXPECT=<<EOF
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Both mips plugins cache the value loaded into t9 by `lw t9, off(gp)` so a later `jalr/jr t9` resolves to a concrete target, but the cache was only invalidated by the load itself: any other write to t9 (`lui`, `move`, three-register `addu`, `sltu`, ...) left it stale, so the next `jalr t9` produced a wrong call target and false xrefs. The `addiu` lo-adjust also applied on every decode of the same instruction (decode runs more than once per op), tripling the offset — and with an invalid cache it fabricated targets from `UT64_MAX` wraparound. The gnu plugin additionally seeded the cache from non-gp loads (jumping to raw file bytes) and never consumed the value, replaying one target for every later indirect jump.

Untracked writes to t9 now drop the cached value (via operand 0 in the capstone plugin, via the rd/rt encoding fields in the gnu one), the lo-adjust applies exactly once per address and only for `addiu t9, t9, imm`, consumers reset the cache, and non-gp loads invalidate instead of seeding. Tests cover each path.
