### PR TITLE
Follow deref chains when typing struct fields from return values ##anal

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -1109,8 +1109,8 @@ static void tp_flush_pending_const(TPState *tps) {
 
 #define TP_REGCOPY_MAX 4
 
-// resolve a register to the type of the reg arg it was copied from, following plain reg copies
-static char *tp_reg_var_type(TPState *tps, RAnalFunction *fcn, const char *reg) {
+// resolve a register to the type of the reg arg it was copied from, following copies and deref hops
+static char *tp_reg_var_type(TPState *tps, RAnalFunction *fcn, const char *reg, TPFieldChain *chain) {
 	RAnal *anal = tps->anal;
 	TypeTrace *tt = &tps->tt;
 	char cur[REGNAME_SIZE] = { 0 };
@@ -1142,7 +1142,7 @@ static char *tp_reg_var_type(TPState *tps, RAnalFunction *fcn, const char *reg) 
 			}
 			return NULL;
 		}
-		RAnalOp *op = tp_anal_op (anal, etrace_addrof (tt, j), R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_ESIL);
+		RAnalOp *op = tp_anal_op (anal, etrace_addrof (tt, j), R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL | R_ARCH_OP_MASK_ESIL);
 		if (!op) {
 			return NULL;
 		}
@@ -1150,6 +1150,9 @@ static char *tp_reg_var_type(TPState *tps, RAnalFunction *fcn, const char *reg) 
 		char src[REGNAME_SIZE] = { 0 };
 		if (copy) {
 			get_src_regname_from_esil (anal, r_strbuf_get (&op->esil), op->addr, src, sizeof (src));
+		} else {
+			// a base+disp load is a deref hop, keep following the base pointer
+			tp_chain_collect (tt, j, op, chain, src, sizeof (src));
 		}
 		r_anal_op_free (op);
 		if (!src[0]) {
@@ -1183,13 +1186,20 @@ static bool tp_field_from_ret(TPState *tps, RAnalFunction *fcn, RAnalOp *op, con
 	if (!base[0]) {
 		return false;
 	}
-	char *ptr_type = tp_reg_var_type (tps, fcn, base);
+	TPFieldChain chain = { .slot_addr = UT64_MAX, .ok = true };
+	char *ptr_type = tp_reg_var_type (tps, fcn, base, &chain);
 	if (!ptr_type) {
 		return false;
 	}
 	// the assignment itself disproves const on the member
 	ret_type = r_str_skip_prefix (ret_type, "const ");
-	const bool changed = tp_retype_field_chain (anal, ptr_type, &disp, 1, ret_type, op->refptr, true);
+	ut64 seq[TP_CHAIN_MAX + 1];
+	int i, n = 0;
+	for (i = chain.len - 1; i >= 0; i--) { // hops were collected walking backwards
+		seq[n++] = chain.hops[i];
+	}
+	seq[n++] = disp;
+	const bool changed = tp_retype_field_chain (anal, ptr_type, seq, n, ret_type, op->refptr, true);
 	free (ptr_type);
 	return changed;
 }

--- a/test/db/anal/types
+++ b/test/db/anal/types
@@ -497,6 +497,103 @@ struct Ctx {
 EOF
 RUN
 
+NAME=struct field typed from return value stored through a nested pointer
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.fields=true
+CMDS=<<EOF
+wa mov rbx, [rdi+8]
+wa call 0x20 @ 4
+wa mov [rbx+0x10], rax @ 9
+wa ret @ 0xd
+wa ret @ 0x20
+af @ 0x20
+afn helper @ 0x20
+af @ 0
+afn caller @ 0
+"td struct Inner { char pad2[16]; int field_16; };"
+"td struct Outer { char pad[8]; struct Inner *inner; };"
+"td char *helper();"
+afvt arg1 "struct Outer *" @ 0
+aei
+aeim
+aaft
+tsc Outer
+tsc Inner
+EOF
+EXPECT=<<EOF
+struct Outer {
+  char pad[8];
+  struct Inner *inner;
+};
+struct Inner {
+  char pad2[16];
+  char *field_16;
+};
+EOF
+RUN
+
+NAME=struct field typed from return value through a copied deref base
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.fields=true
+CMDS=<<EOF
+wa mov rbx, [rdi+8]
+wa mov rcx, rbx @ 4
+wa call 0x20 @ 7
+wa mov [rcx+0x10], rax @ 0xc
+wa ret @ 0x10
+wa ret @ 0x20
+af @ 0x20
+afn helper @ 0x20
+af @ 0
+afn caller @ 0
+"td struct Inner { char pad2[16]; int field_16; };"
+"td struct Outer { char pad[8]; struct Inner *inner; };"
+"td char *helper();"
+afvt arg1 "struct Outer *" @ 0
+aei
+aeim
+aaft
+tsc Inner
+EOF
+EXPECT=<<EOF
+struct Inner {
+  char pad2[16];
+  char *field_16;
+};
+EOF
+RUN
+
+NAME=struct field not retyped when the store base was modified by arithmetic
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.fields=true
+CMDS=<<EOF
+wa mov rbx, [rdi+8]
+wa add rbx, 8 @ 4
+wa call 0x20 @ 8
+wa mov [rbx+0x10], rax @ 0xd
+wa ret @ 0x11
+wa ret @ 0x20
+af @ 0x20
+afn helper @ 0x20
+af @ 0
+afn caller @ 0
+"td struct Inner { char pad2[16]; int field_16; };"
+"td struct Outer { char pad[8]; struct Inner *inner; };"
+"td char *helper();"
+afvt arg1 "struct Outer *" @ 0
+aei
+aeim
+aaft
+tsc Inner
+EOF
+EXPECT=<<EOF
+struct Inner {
+  char pad2[16];
+  int field_16;
+};
+EOF
+RUN
+
 NAME=struct field typed from address passed as out parameter
 FILE=malloc://64
 ARGS=-a x86 -b 64 -e types.fields=true
@@ -887,7 +984,7 @@ struct Ctx {
 EOF
 RUN
 
-NAME=struct field not retyped through a rebased store pointer
+NAME=struct field not retyped when the deref hop offset matches no member
 FILE=malloc://64
 ARGS=-a x86 -b 64 -e types.fields=true
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With types.fields=true, a callee return value stored through a derefed struct pointer now types the nested member:

    mov rbx, [rdi+8]        ; rdi = struct Outer *, ->inner
    call helper             ; returns char *
    mov [rbx+0x10], rax     ; Inner.field_16 becomes char *

Previously only stores through the plain reg arg (or copies of it) were typed. Reuses the existing deref-chain collection from the call-arg path; bases modified by arithmetic or with no matching member are left untouched.