### PR TITLE
Fix UCALL bitmask misuse in aaft that skipped return-value stores ##anal

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -2019,8 +2019,8 @@ static void type_match_op_cb(void *user, RAnalOp *aop, RAnalOp *next_op, ut64 ad
 	}
 	RAnalVar *var = r_anal_get_used_function_var (anal, aop->addr);
 	ut32 type = aop->type & R_ANAL_OP_TYPE_MASK;
-	// master idiom: type & UCALL also matches RET/ILL/UNK but the body no-ops there (the clobber path needs exact matching)
-	if (type == R_ANAL_OP_TYPE_CALL || type & R_ANAL_OP_TYPE_UCALL) {
+	// UCALL is the base value 4, not a flag: type & UCALL also matches STORE and swallows the return-value consumer below
+	if (type == R_ANAL_OP_TYPE_CALL || type == R_ANAL_OP_TYPE_UCALL || type == R_ANAL_OP_TYPE_UCCALL) {
 		RAnalFunction *fcn_call = NULL;
 		const char *full_name = tp_call_target_name (anal, aop, type, &fcn_call);
 		if (full_name) {

--- a/test/db/anal/types
+++ b/test/db/anal/types
@@ -468,6 +468,35 @@ struct Ctx {
 EOF
 RUN
 
+NAME=struct field typed from callee return value stored on arm64
+FILE=malloc://64
+ARGS=-a arm -b 64 -e types.fields=true
+CMDS=<<EOF
+wa mov x2, x0
+wa bl 0x20 @ 4
+wa str x0, [x2, 0x10] @ 8
+wa ret @ 0xc
+wa ret @ 0x20
+af @ 0x20
+afn helper @ 0x20
+af @ 0
+afn caller @ 0
+"td struct Ctx { char pad[16]; int field_16; };"
+"td char *helper();"
+afvt arg1 "struct Ctx *" @ 0
+aei
+aeim
+aaft
+tsc Ctx
+EOF
+EXPECT=<<EOF
+struct Ctx {
+  char pad[16];
+  char *field_16;
+};
+EOF
+RUN
+
 NAME=struct field typed from address passed as out parameter
 FILE=malloc://64
 ARGS=-a x86 -b 64 -e types.fields=true

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1564,7 +1564,7 @@ var char * v4 @ fp-0x30
 var pid_t pid @ fp-0x34
 var int32_t var_3ch @ fp-0x38
 var int32_t var_40h @ fp-0x3c
-var int32_t var_44h @ fp-0x40
+var void * var_44h @ fp-0x40
 var char * var_48h @ fp-0x44
 var int32_t var_4ch @ fp-0x48
 var int32_t wstatus @ fp-0x4c


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

R_ANAL_OP_TYPE_UCALL is the base value 4, not a flag, so `type & UCALL` in the aaft op callback matched every op type with bit 2 set — including STORE — and those ops were consumed by the call branch instead of reaching the return-value forward-propagation below. x86 was unaffected because its stores are MOV-typed, but on arm32/arm64 a `str` of a call result never typed the destination var or struct field.
  
Match CALL/UCALL/UCCALL exactly. Adds an arm64 test (fails before the fix); the bashbot arm32 golden change is correct: that var holds malloc's return.