### PR TITLE
Apply the delayed branch when the delay slot op emits no ESIL ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -1327,9 +1327,11 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		opcode = r_read_ble16 (b, R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config));
 	}
 
-	// eprintf ("MIPS: %02x %02x %02x %02x (after endian: big=%d)\n", buf[0], buf[1], buf[2], buf[3], as->big_endian);
 	if (opcode == 0) {
 		op->type = R_ANAL_OP_TYPE_NOP;
+		if (mask & R_ARCH_OP_MASK_ESIL) {
+			r_strbuf_set (&op->esil, ",");
+		}
 		return oplen;
 	}
 

--- a/libr/core/core_esil.c
+++ b/libr/core/core_esil.c
@@ -338,11 +338,10 @@ static bool core_esil_step_delay_slot(RCore *core, RArchSession *as, ut64 ds_add
 	}
 	r_esil_reg_write_silent (esil, "PC", ds_addr);
 	char *expr = r_strbuf_drain_nofree (&op.esil);
-	if (R_STR_ISNOTEMPTY (expr)) {
-		esil->addr = ds_addr;
-		(void)r_esil_parse (esil, expr);
-		esil->trap = false;
-	}
+	esil->addr = ds_addr;
+	// "," for ESIL-less slot ops (e.g. mips.gnu movn) so r_esil_parse still consumes the pending branch
+	(void)r_esil_parse (esil, R_STR_ISNOTEMPTY (expr)? expr: ",");
+	esil->trap = false;
 	free (expr);
 	ut64 pc_ds = 0;
 	(void)r_esil_reg_read_silent (esil, "PC", &pc_ds, NULL);

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -1041,3 +1041,72 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=mips.gnu esil step applies delayed jump over nop delay slot
+FILE=malloc://32
+ARGS=-a mips.gnu -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 0320000800000000
+aei
+aeim
+aer t9=0x2000
+aes
+aer pc
+aoj 1 @ 4~{[0].esil}
+EOF
+EXPECT=<<EOF
+0x00002000
+,
+EOF
+RUN
+
+NAME=mips.gnu esil step applies delayed jump over esil-less delay slot op
+FILE=malloc://32
+ARGS=-a mips.gnu -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 0320000800a6200b
+aei
+aeim
+aer t9=0x2000
+aes
+aer pc
+EOF
+EXPECT=<<EOF
+0x00002000
+EOF
+RUN
+
+NAME=mips.gnu esil step falls through not-taken branch with nop delay slot
+FILE=malloc://32
+ARGS=-a mips.gnu -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 1085000300000000
+aei
+aeim
+aer a0=1
+aer a1=2
+aes
+aes
+aer pc
+EOF
+EXPECT=<<EOF
+0x00000008
+EOF
+RUN
+
+NAME=mips.gnu esil step takes conditional branch over nop delay slot
+FILE=malloc://32
+ARGS=-a mips.gnu -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 1085000300000000
+aei
+aeim
+aer a0=1
+aer a1=1
+aes
+aer pc
+EOF
+EXPECT=<<EOF
+0x00000010
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Under `aes`/`aesu`, pc fell straight past a `jr`/`jalr` whose delay slot op emits no ESIL (mips.gnu nop, movn, ...): r_esil_parse owns the delayed-jump bookkeeping but rejects empty input, so the pending branch was never applied and stale delay state leaked into the next step.

The delay-slot handler now always calls r_esil_parse, feeding the no-op `,` when the slot op has no ESIL — the same path capstone nops already take. mips.gnu's nop also emits `,` now, matching the capstone plugin.

Xref recovery (aaa/aae) was never affected, only sequential stepping. 