### PR TITLE
Fix #26262 - pdj and pdi with negative count on aligned archs ##disasm

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -549,12 +549,13 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		if (r_cons_is_breaked (core->cons)) {
 			break;
 		}
+		r_asm_set_pc (core->rasm, addr - (idx / addrbytes));
 		c = r_asm_mdisassemble (core->rasm, buf + len - idx, idx);
 		if (!c || !c->assembly) {
 			r_asm_code_free (c);
 			continue;
 		}
-		if (strstr (c->assembly, "invalid") || strstr (c->assembly, ".byte")) {
+		if (strstr (c->assembly, "invalid") || strstr (c->assembly, ".byte") || strstr (c->assembly, "unaligned")) {
 			r_asm_code_free (c);
 			continue;
 		}
@@ -571,16 +572,19 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		}
 	}
 
-	ut64 at = addr - idx / addrbytes;
+	ut64 at = addr - (idx / addrbytes);
 
-	r_asm_set_pc (core->rasm, at);
 	for (hit_count = 0; hit_count < n; hit_count++) {
 		RAnalOp op;
+		r_asm_set_pc (core->rasm, at);
 		int instrlen = r_asm_disassemble (core->rasm, &op,
 			buf + len - addrbytes * (addr - at), addrbytes * (addr - at));
+		r_anal_op_fini (&op);
+		if (instrlen < 1) {
+			break;
+		}
 		add_hit_to_hits (hits, at, instrlen, true);
 		at += instrlen;
-		r_anal_op_fini (&op);
 	}
 	free (buf);
 	return hits;
@@ -817,15 +821,19 @@ R_API ut32 r_core_asm_bwdis_len(RCore* core, int* instr_len, ut64* start_addr, u
 		*instr_len = 0;
 	}
 	if (hits && r_list_length (hits) > 0) {
-		hit = r_list_first (hits);
-		if (start_addr) {
-			*start_addr = hit->addr;
-		}
 		r_list_foreach (hits, iter, hit) {
-			instr_run += hit->len;
+			if (hit->len > 0) {
+				instr_run += hit->len;
+			}
 		}
-		if (instr_len) {
-			*instr_len = instr_run;
+		if (instr_run > 0) {
+			hit = r_list_first (hits);
+			if (start_addr) {
+				*start_addr = hit->addr;
+			}
+			if (instr_len) {
+				*instr_len = instr_run;
+			}
 		}
 	}
 	r_list_free (hits);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7840,41 +7840,29 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 	}
 	if (nb_opcodes) { // Disassemble `nb_opcodes` opcodes.
 		if (nb_opcodes < 0) {
-			int count, nbytes = 0;
-
-			/* Backward disassembly of `nb_opcodes` opcodes:
-			 * - We compute the new starting offset
-			 * - Read at the new offset */
 			nb_opcodes = -nb_opcodes;
-
 			if (nb_opcodes > 0xffff) {
 				R_LOG_ERROR ("Too many backward instructions");
 				return false;
 			}
+			int nbytes = 0;
 			if (r_core_prevop_addr (core, core->addr, nb_opcodes, &addr)) {
 				nbytes = old_offset - addr;
-			} else if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
-				/* workaround to avoid empty arrays */
-#define BWRETRY 0
-#if BWRETRY
-				nb_opcodes ++;
+			} else {
+				// r_core_prevop_addr sets addr to UT64_MAX on failure
+				addr = old_offset;
 				if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
-#endif
 					pj_end (pj);
 					return false;
-#if BWRETRY
-				}
-#endif
-			}
-			count = R_MIN (nb_bytes, nbytes);
-			if (count > 0) {
-				r_io_read_at (core->io, addr, buf, count);
-				r_io_read_at (core->io, addr + count, buf + count, nb_bytes - count);
-			} else {
-				if (nb_bytes > 0) {
-					memset (buf, core->io->Oxff, nb_bytes);
 				}
 			}
+			if (nbytes < 1) {
+				pj_end (pj);
+				return false;
+			}
+			const int count = R_MIN (nb_bytes, nbytes);
+			r_io_read_at (core->io, addr, buf, count);
+			r_io_read_at (core->io, addr + count, buf + count, nb_bytes - count);
 		} else {
 			// If we are disassembling a positive number of lines, enable dis_opcodes
 			// to be used to finish the loop

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -341,3 +341,17 @@ EXPECT=<<EOF
 ]
 EOF
 RUN
+
+NAME=pdi negative count without analysis
+FILE=malloc://32
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+wx 1e0080d2e50300aa1f2003d5c0035fd6
+s 8
+pdi -2
+EOF
+EXPECT=<<EOF
+0x00000000             1e0080d2  mov x30, 0
+0x00000004             e50300aa  mov x5, x0
+EOF
+RUN

--- a/test/db/cmd/cmd_pdj
+++ b/test/db/cmd/cmd_pdj
@@ -45,3 +45,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=pdj negative count without analysis
+FILE=malloc://32
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+wx 1e0080d2e50300aa1f2003d5c0035fd6
+s 8
+pdj -2~{[0].addr}
+pdj -2~{[0].opcode}
+pdj -2~{[1].addr}
+pdj -2~{[1].opcode}
+EOF
+EXPECT=<<EOF
+0
+mov x30, 0
+4
+mov x5, x0
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Without analysis info, `pdj -N` printed invalid 0xff entries at bogus addresses (and `pdi -N` printed nothing) on architectures with instruction alignment (arm64, ppc), while `pd -N` worked.
  
The backward scan in r_core_asm_bwdisassemble never set the pc for each candidate window and accepted "unaligned" pseudo-ops as valid instructions, locking onto misaligned start addresses. Downstream, r_core_asm_bwdis_len summed the resulting -1 hit lengths and returned the negative total as success, so the json path rendered a memset-0xff buffer.
  
* Set the pc per scan window and reject "unaligned" like "invalid"
* Stop the hit loop on failed decodes instead of storing negative lengths
* Only report bwdis_len success when the total length is positive
* Fail with an empty array instead of rendering 0xff bytes; drop dead BWRETRY code
* Add regression tests for `pdj -N` and `pdi -N` without analysis