### PR TITLE
Encode full-width compare results in the PPC cr ESIL model ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1119,7 +1119,7 @@ static void ppc_cond_branch(RAnalOp *op, int bc, const char *cr, const char *tar
 		esilprintf (op, "0x80,%s,&,!,%s,!,|,?{,%s,pc,=,},", cr, cr, target);
 		break;
 	case PPC_BC_GT:
-		esilprintf (op, "0x80,%s,&,!,?{,%s,pc,=,},", cr, target);
+		esilprintf (op, "0x80,%s,&,!,%s,!,!,&,?{,%s,pc,=,},", cr, cr, target);
 		break;
 	case PPC_BC_NE:
 		esilprintf (op, "%s,!,!,?{,%s,pc,=,},", cr, target);
@@ -1265,6 +1265,9 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		switch (insn->id) {
 #if CS_API_MAJOR >= 4
 		case PPC_INS_CMPB:
+			// per-byte equality mask into a gpr, not a cr compare; not modeled in esil
+			op->type = R_ANAL_OP_TYPE_CMP;
+			break;
 #endif
 		case PPC_INS_CMPD:
 		case PPC_INS_CMPDI:
@@ -1280,14 +1283,57 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_CMPL:
 		case PPC_INS_CMPLI:
 #endif
-			op->type = R_ANAL_OP_TYPE_CMP;
-			op->sign = true;
-			if (ARG (2)[0] == '\0') {
-				esilprintf (op, "%s,%s,-,0xff,&,cr0,=", ARG (1), ARG (0));
-			} else {
-				esilprintf (op, "%s,%s,-,0xff,&,%s,=", ARG (2), ARG (1), ARG (0));
+		{
+			bool usig = false, word = false;
+			switch (insn->id) {
+			case PPC_INS_CMPLW:
+			case PPC_INS_CMPLWI:
+				usig = true;
+				// fallthrough
+			case PPC_INS_CMPW:
+			case PPC_INS_CMPWI:
+				word = true;
+				break;
+			case PPC_INS_CMPLD:
+			case PPC_INS_CMPLDI:
+				usig = true;
+				break;
+#if CS_API_MAJOR > 4
+			case PPC_INS_CMPL:
+			case PPC_INS_CMPLI:
+				usig = true;
+				// fallthrough
+			case PPC_INS_CMP:
+			case PPC_INS_CMPI:
+				word = as->config->bits == 32;
+				break;
+#endif
 			}
+			op->type = R_ANAL_OP_TYPE_CMP;
+			op->sign = !usig;
+			const bool impcr = ARG (2)[0] == '\0';
+			const char *cr = impcr? "cr0": ARG (0);
+			const char *a = impcr? ARG (0): ARG (1);
+			const char *b = impcr? ARG (1): ARG (2);
+			char wa[96], wb[96];
+			if (word && usig) {
+				// zero-extended low words are positive in the 64-bit signed esil <, so it orders them unsigned
+				snprintf (wa, sizeof (wa), "0xffffffff,%s,&", a);
+				snprintf (wb, sizeof (wb), "0xffffffff,%s,&", b);
+			} else if (word) {
+				snprintf (wa, sizeof (wa), "32,%s,~", a);
+				snprintf (wb, sizeof (wb), "32,%s,~", b);
+			} else if (usig) {
+				snprintf (wa, sizeof (wa), "0x8000000000000000,%s,^", a);
+				snprintf (wb, sizeof (wb), "0x8000000000000000,%s,^", b);
+			} else {
+				r_str_ncpy (wa, a, sizeof (wa));
+				r_str_ncpy (wb, b, sizeof (wb));
+			}
+			// lossless flag byte like fcmpu: lt 0x80, gt 1, eq 0
+			esilprintf (op, "0x80,%s,%s,<,*,%s,%s,<,+,%s,=", wb, wa, wa, wb, cr);
 			break;
+		}
 		case PPC_INS_MFLR:
 			op->type = R_ANAL_OP_TYPE_MOV;
 			esilprintf (op, "lr,%s,=", ARG (0));

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -711,3 +711,47 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=cmpw vs cmplw sign boundary emulation ppc-32
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c0320007c032040 @ 0
+aei
+ar r3=0x80000000
+ar r4=1
+aepc 0
+aes
+ar cr0
+ar r3=0x80000000
+ar r4=1
+aepc 4
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000080
+0x00000001
+EOF
+RUN
+
+NAME=cmpw no false equality when operands differ by 0x100 ppc-32
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c032000 @ 0
+aei
+ar r3=0x100
+ar r4=0
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000001
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -2013,3 +2013,162 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=cmpd sets cr byte lt/gt/eq emulation ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c232000 @ 0
+aei
+ar r3=1
+ar r4=2
+aepc 0
+aes
+ar cr0
+ar r3=2
+ar r4=1
+aepc 0
+aes
+ar cr0
+ar r3=5
+ar r4=5
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000080
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=cmpw no false equality when operands differ by 0x100 ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c032000 @ 0
+aei
+ar r3=0x100
+ar r4=0
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000001
+EOF
+RUN
+
+NAME=cmpw compares only the low words ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c032000 @ 0
+aei
+ar r3=0x100000000
+ar r4=0
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000000
+EOF
+RUN
+
+NAME=cmpd vs cmpld order -1 against 1 signed and unsigned ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c2320007c232040 @ 0
+aei
+ar r3=0xffffffffffffffff
+ar r4=1
+aepc 0
+aes
+ar cr0
+ar r3=0xffffffffffffffff
+ar r4=1
+aepc 4
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000080
+0x00000001
+EOF
+RUN
+
+NAME=cmplw orders the low words unsigned ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c032040 @ 0
+aei
+ar r3=0x80000000
+ar r4=1
+aepc 0
+aes
+ar cr0
+ar r3=1
+ar r4=0x80000000
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000080
+EOF
+RUN
+
+NAME=cmpwi sign-extends the negative immediate ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 2c03fffc @ 0
+aei
+ar r3=0xfffffffffffffff8
+aepc 0
+aes
+ar cr0
+ar r3=0
+aepc 0
+aes
+ar cr0
+EOF
+EXPECT=<<EOF
+0x00000080
+0x00000001
+EOF
+RUN
+
+NAME=bgt is not taken on equal operands ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 38600055388000557c03200041810008 @ 0
+aei
+aeim
+4aes
+ar pc
+EOF
+EXPECT=<<EOF
+0x00000010
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The cmp/cmpl ESIL stored `(a-b) & 0xff` into crN, so any operand pair differing by a multiple of 0x100 emulated as equal (beq wrongly taken under aes/aesu-driven analysis), the lt/gt bit tests read bit 7 of the low byte instead of the real sign, and the unsigned cmpl* forms reused the signed subtraction.

Compares now write the same lossless flag byte fcmpu already uses (0 eq / 0x80 lt / 1 gt), with proper width and signedness per form: cmpw/cmpwi sign-extend the low words, cmplw/cmplwi compare them zero-extended, and cmpld/cmpldi order unsigned via a sign-bit bias. op->sign is no longer true for the unsigned forms.

The bgt predicate reader had a related bug: it tested only "lt bit clear", so it fired on equal operands. It now requires a nonzero flag as well, matching the isel gt reader. cmpb is split out as type-only — it is a per-byte mask op writing a GPR, and its old ESIL stored a bogus masked subtraction there.

Validated differentially against qemu-ppc64 (cmp + conditional branch outcome matrix across all forms, six predicates and the boundary operand classes, in both operand orders — all match), plus 9 new emulation tests in test/db/esil/ppc_64 and ppc_32. 

Repro before this patch:

    r2 -e anal.arch=ppc -e asm.bits=32 -e cfg.bigendian=true \
       -qc 'wx 38600100388000007c03200041820008; aei; aeim; 4aes; ar pc' malloc://32

pc lands at 0x14 — beq taken although r3 (0x100) != r4 (0).