### PR TITLE
Fix PPC extsb/extsh/extsw ESIL to always sign-extend into the destination ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1397,23 +1397,17 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_EXTSB:
 			op->sign = true;
 			op->type = R_ANAL_OP_TYPE_MOV;
-			if (as->config->bits == 64) {
-				esilprintf (op, "%s,0x80,&,?{,0xFFFFFFFFFFFFFF00,%s,|,%s,=,}", ARG (1), ARG (1), ARG (0));
-			} else {
-				esilprintf (op, "%s,0x80,&,?{,0xFFFFFF00,%s,|,%s,=,}", ARG (1), ARG (1), ARG (0));
-			}
+			esilprintf (op, "8,%s,~,%s,=", ARG (1), ARG (0));
 			break;
 		case PPC_INS_EXTSH:
 			op->sign = true;
-			if (as->config->bits == 64) {
-				esilprintf (op, "%s,0x8000,&,?{,0xFFFFFFFFFFFF0000,%s,|,%s,=,}", ARG (1), ARG (1), ARG (0));
-			} else {
-				esilprintf (op, "%s,0x8000,&,?{,0xFFFF0000,%s,|,%s,=,}", ARG (1), ARG (1), ARG (0));
-			}
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "16,%s,~,%s,=", ARG (1), ARG (0));
 			break;
 		case PPC_INS_EXTSW:
 			op->sign = true;
-			esilprintf (op, "%s,0x80000000,&,?{,0xFFFFFFFF00000000,%s,|,%s,=,}", ARG (1), ARG (1), ARG (0));
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "32,%s,~,%s,=", ARG (1), ARG (0));
 			break;
 		case PPC_INS_SYNC:
 		case PPC_INS_ISYNC:

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -755,3 +755,27 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=extsb sign-extends and always writes the destination ppc-32
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=32
+e cfg.bigendian=true
+wx 7c830774 @ 0
+aei
+ar r4=0x40
+ar r3=0xdeadbeef
+aepc 0
+aes
+ar r3
+ar r4=0x123456f8
+aepc 0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000040
+0xfffffff8
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -2172,3 +2172,75 @@ EXPECT=<<EOF
 0x00000010
 EOF
 RUN
+
+NAME=extsb sign-extends and always writes the destination ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c830774 @ 0
+aei
+ar r4=0x40
+ar r3=0xdeadbeef
+aepc 0
+aes
+ar r3
+ar r4=0x123456f8
+aepc 0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000040
+0xfffffffffffffff8
+EOF
+RUN
+
+NAME=extsh sign-extends the halfword ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c830734 @ 0
+aei
+ar r4=0x12340078
+ar r3=0xdead
+aepc 0
+aes
+ar r3
+ar r4=0x12348765
+aepc 0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000078
+0xffffffffffff8765
+EOF
+RUN
+
+NAME=extsw sign-extends the word and drops the high half ppc-64
+FILE=malloc://0x40
+CMDS=<<EOF
+e asm.arch=ppc
+e asm.bits=64
+e cfg.bigendian=true
+wx 7c8307b4 @ 0
+aei
+ar r4=0xdeadbeef12345678
+ar r3=0
+aepc 0
+aes
+ar r3
+ar r4=0xdeadbeef87654321
+aepc 0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x12345678
+0xffffffff87654321
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The extsb/extsh/extsw ESIL wrote the destination only inside a sign-bit test (`rS,0x80,&,?{,...,rA,=,}`), so any operand with the sign bit clear left rA holding its previous value — every sign-extend of a non-negative value under aes/emulation produced a stale register.

Replaced the idiom with the `~` sign-extend primitive (`8,rS,~,rA,=`, and 16/32 for extsh/extsw), which masks to the low N bits, sign-extends, and always writes. This also removes the duplicated 32/64-bit branches. extsh and extsw were also missing op->type; both now report MOV like extsb.

Validated differentially against qemu-ppc64 (7 register sign-extend cases across the sign-bit-clear/set and high-bits-set operand classes — all match) plus new emulation tests in test/db/esil/ppc_{32,64}. Full r2r run has zero regressions.

Repro before this patch: 

  r2 -a ppc -b 64 -e cfg.bigendian=true \
    -qc 'wx 7c830774; aei; aeim; ar r4=0x40; ar r3=0xdeadbeef; aes; ar r3' malloc://16
 
r3 stays 0xdeadbeef; extsb of 0x40 should give 0x40.