### PR TITLE
Fix MIPS conditional branch-and-link (bgezal/bltzal) jump target ##arch

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -994,6 +994,17 @@ static void t9_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 	}
 }
 
+// target is the first immediate operand; reg-first forms (bgezal, bltzal, ...) keep it in op1, not op0
+static void set_jump_target(RAnalOp *op, cs_insn *insn) {
+	int i;
+	for (i = 0; i < OPCOUNT (); i++) {
+		if (OPERAND (i).type == MIPS_OP_IMM) {
+			op->jump = IMM (i);
+			return;
+		}
+	}
+}
+
 static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	ut64 addr = op->addr;
 	const ut8 *buf = op->bytes;
@@ -1157,7 +1168,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case MIPS_INS_JIALC:
 	case MIPS_INS_JIC:
 		op->type = R_ANAL_OP_TYPE_CALL;
-		op->jump = IMM(0);
+		set_jump_target (op, insn);
 
 		switch (insn->id) {
 		case MIPS_INS_JIALC:
@@ -1296,13 +1307,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			op->type = R_ANAL_OP_TYPE_CJMP;
 		}
 
-		if (OPERAND (0).type == MIPS_OP_IMM) {
-			op->jump = IMM (0);
-		} else if (OPERAND (1).type == MIPS_OP_IMM) {
-			op->jump = IMM (1);
-		} else if (OPERAND (2).type == MIPS_OP_IMM) {
-			op->jump = IMM (2);
-		}
+		set_jump_target (op, insn);
 
 		switch (insn->id) {
 		case MIPS_INS_BEQC:

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -835,7 +835,7 @@ aac
 afl~?
 EOF
 EXPECT=<<EOF
-1268
+1274
 EOF
 RUN
 
@@ -847,7 +847,7 @@ aac
 afl~?
 EOF
 EXPECT=<<EOF
-4
+10
 EOF
 RUN
 
@@ -1174,5 +1174,43 @@ aer pc
 EOF
 EXPECT=<<EOF
 0x00000010
+EOF
+RUN
+
+NAME=mips bgezal branch-and-link target is the pc-relative offset not the register
+FILE=malloc://64
+ARGS=-a mips -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 04910010
+ao 1~jump:
+ao 1~type:
+EOF
+EXPECT=<<EOF
+jump: 0x00000044
+type: call
+EOF
+RUN
+
+NAME=mips bltzal branch-and-link target is the pc-relative offset
+FILE=malloc://64
+ARGS=-a mips -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 04900010
+ao 1~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00000044
+EOF
+RUN
+
+NAME=mips bgezall likely branch-and-link target is the pc-relative offset
+FILE=malloc://64
+ARGS=-a mips -e asm.bits=32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 04930010
+ao 1~jump:
+EOF
+EXPECT=<<EOF
+jump: 0x00000044
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The CALL group in the MIPS analysis plugin computed op->jump = IMM(0), which is correct for the imm-first forms (jal/bal) but wrong for the REGIMM link branches bltzal/bgezal/bltzall/bgezall: there operand 0 is the condition register and the PC-relative target is operand 1, so IMM(0) read the capstone register enum (e.g. a0 = 6) as an address. Every branch-and-link produced a call xref / CFG edge to a garbage address instead of the real callee.
  
Extracted a set_jump_target() helper that picks the first immediate operand as the target, and used it in both the CALL group (the fix) and the CJMP group (which already did the same scan inline). The ESIL path was already correct.

On test/bins/elf/analysis/mipsbe-busybox this recovers 6 more real callees via aac (the two golden counts are updated accordingly). Adds three ao tests.

Repro before this patch:

    r2 -a mips -b 32 -e cfg.bigendian=true -qc 'wx 04910010; ao 1~jump:' malloc://64
  
The bytes decode to `bgezal a0, 0x44` (target = PC + 4 + (offset << 2)); ao reports `jump: 0x00000006` — the a0 register enum, not the branch target.