### PR TITLE
Fix arm.gnu Thumb branch offsets, SVC/UDF classification and svc immediates ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_gnu.c
+++ b/libr/arch/p/arm/plugin_gnu.c
@@ -92,7 +92,7 @@ static int op_thumb(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *data, i
 			return op->size;
 		}
 	}
-	if (ins == 0xbf) {
+	if (ins == 0xbf00) {
 		// TODO: add support for more NOP instructions
 		op->type = R_ANAL_OP_TYPE_NOP;
 	} else if (((op_code = ((ins & B4 (B1111, B1000, 0, 0)) >> 11)) >= 12 && op_code <= 17)) {
@@ -108,18 +108,18 @@ static int op_thumb(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *data, i
 		} else {
 			op->type = R_ANAL_OP_TYPE_STORE;
 		}
-	} else if ((ins & B4 (B1111, 0, 0, 0)) == B4 (B1101, 0, 0, 0)) {
-		// BNE..
-		int delta = (ins & B4 (0, 0, B1111, B1111));
+	} else if ((ins & B4 (B1111, 0, 0, 0)) == B4 (B1101, 0, 0, 0) && ((ins >> 8) & 0xf) < 0xe) {
+		// B<cond> T1: signed imm8 (cond 0xe/0xf are UDF/SVC, handled below)
+		int delta = (st8) (ins & 0xff);
 		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = addr + 4 + (delta << 1);
-		op->fail = addr + 4;
+		op->jump = addr + 4 + (delta * 2);
+		op->fail = addr + 2;
 	} else if ((ins & B4 (B1111, B1000, 0, 0)) == B4 (B1110, 0, 0, 0)) {
-		// B
-		int delta = (ins & B4 (0, 0, B1111, B1111));
+		// B T2: signed imm11
+		int delta = ((st16) (ins << 5)) >> 5;
 		op->type = R_ANAL_OP_TYPE_JMP;
-		op->jump = addr + 4 + (delta << 1);
-		op->fail = addr + 4;
+		op->jump = addr + 4 + (delta * 2);
+		op->fail = UT64_MAX;
 	} else if ((ins & B4 (B1111, B1111, B1000, 0)) == B4 (B0100, B0111, B1000, 0)) {
 		// BLX
 		op->type = R_ANAL_OP_TYPE_UCALL;
@@ -141,12 +141,12 @@ static int op_thumb(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *data, i
 		op->jump = addr + 4 + delta;
 		op->type = R_ANAL_OP_TYPE_CALL;
 		op->fail = addr + 4;
-	} else if ((ins & B4 (B1111, B1111, 0, 0)) == B4 (B1011, B1110, 0, 0)) {
-		op->type = R_ANAL_OP_TYPE_TRAP;
-		op->val = (ut64) (ins >> 8);
-	} else if ((ins & B4 (B1111, B1111, 0, 0)) == B4 (B1101, B1111, 0, 0)) {
-		op->type = R_ANAL_OP_TYPE_SWI;
-		op->val = (ut64) (ins >> 8);
+	} else if ((ins >> 8) == 0xbe || (ins >> 8) == 0xde || (ins >> 8) == 0xdf) {
+		// BKPT and UDF trap, SVC is a swi
+		op->type = ((ins >> 8) == 0xdf)? R_ANAL_OP_TYPE_SWI: R_ANAL_OP_TYPE_TRAP;
+		op->val = ins & 0xff;
+		op->jump = UT64_MAX;
+		op->fail = UT64_MAX;
 	}
 	return op->size;
 }
@@ -392,7 +392,7 @@ static int arm_op32(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *data, i
 		}
 	} else if (b[3] == 0xef) {
 		op->type = R_ANAL_OP_TYPE_SWI;
-		op->val = (b[0] | (b[1] << 8) | (b[2] << 2));
+		op->val = (b[0] | (b[1] << 8) | (b[2] << 16));
 	} else if ((b[3] & 0xf) == 5) {  // [reg,0xa4]
 #if 0
 		0x00000000      a4a09fa4 ldrge sl, [pc], 0xa4

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -1318,3 +1318,17 @@ r0,r1,r2,r3,r12,lr
 r4,r5,r6,r7,r8,r9,r10,r11,sp
 EOF
 RUN
+
+NAME=arm.gnu svc imm24
+FILE=malloc://16
+ARGS=-a arm.gnu -b 32
+CMDS=<<EOF
+wx 000001ef
+ao~type
+ao~val
+EOF
+EXPECT=<<EOF
+type: swi
+val: 0x00010000
+EOF
+RUN

--- a/test/db/anal/arm.gnu_16
+++ b/test/db/anal/arm.gnu_16
@@ -25,8 +25,7 @@ ao~fail
 EOF
 EXPECT=<<EOF
 type: jmp
-jump: 0x0000014c
-fail: 0x00000044
+jump: 0x0000054c
 EOF
 RUN
 
@@ -207,9 +206,11 @@ e asm.bits=16
 s 0x40
 wx 6fbe
 ao~type
+ao~val
 EOF
 EXPECT=<<EOF
 type: trap
+val: 0x0000006f
 EOF
 RUN
 
@@ -269,6 +270,20 @@ wx bf00
 ao~type
 EOF
 EXPECT=<<EOF
+type: unk
+EOF
+RUN
+
+NAME=nop
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=arm.gnu
+e asm.bits=16
+s 0x40
+wx 00bf
+ao~type
+EOF
+EXPECT=<<EOF
 type: nop
 EOF
 RUN
@@ -281,8 +296,62 @@ e asm.bits=16
 s 0x40
 wx 05df
 ao~type
+ao~val
+ao~jump
+EOF
+EXPECT=<<EOF
+type: swi
+val: 0x00000005
+EOF
+RUN
+
+NAME=udf
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=arm.gnu
+e asm.bits=16
+s 0x40
+wx 01de
+ao~type
+ao~val
+ao~jump
+EOF
+EXPECT=<<EOF
+type: trap
+val: 0x00000001
+EOF
+RUN
+
+NAME=bne.n backward
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=arm.gnu
+e asm.bits=16
+s 0x40
+wx fbd1
+ao~type
+ao~jump
+ao~fail
 EOF
 EXPECT=<<EOF
 type: cjmp
+jump: 0x0000003a
+fail: 0x00000042
+EOF
+RUN
+
+NAME=b.n backward
+FILE=malloc://512
+CMDS=<<EOF
+e asm.arch=arm.gnu
+e asm.bits=16
+s 0x40
+wx fee7
+ao~type
+ao~jump
+EOF
+EXPECT=<<EOF
+type: jmp
+jump: 0x00000040
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes several decoding bugs in the arm.gnu anal plugin:

- Thumb `svc`/`udf` (0xDF/0xDE) were typed as conditional branches with a bogus jump target, injecting phantom CFG edges at every syscall; now swi/trap with the correct imm8 in op->val and no jump/fail
- Thumb unconditional B (T2) truncated its 11-bit offset to 8 bits and never sign-extended; conditional B (T1) offsets were not sign-extended either, so all backward branches resolved to wrong targets
- Conditional branch fall-through was addr+4 instead of addr+2 (Thumb-16)
- Thumb `nop` was never typed (compared the 16-bit ins against 0xbf)
- ARM `svc` reconstructed the imm24 with `b[2] << 2` instead of `<< 16`
  
Updates the tests that pinned the old behavior and adds coverage for each fix.
