### PR TITLE
Fix the v35 plugin build and stop typing valid arm64 instructions as ILL ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_v35.c
+++ b/libr/arch/p/arm/plugin_v35.c
@@ -893,6 +893,7 @@ static void anop64(RArchSession *as, RAnalOp *op, Instruction *insn) {
 		op->cycles = 1;
 		/* fallthru */
 	case ARM64_MSUB:
+	case ARM64_SBC:
 		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
 	case ARM64_FDIV:
@@ -999,6 +1000,7 @@ static void anop64(RArchSession *as, RAnalOp *op, Instruction *insn) {
 		break;
 	case ARM64_BRK:
 	case ARM64_HLT:
+	case ARM64_UDF:
 		op->type = R_ANAL_OP_TYPE_TRAP;
 		// hlt stops the process, not skips some cycles like in x86
 		break;
@@ -1015,7 +1017,13 @@ static void anop64(RArchSession *as, RAnalOp *op, Instruction *insn) {
 	case ARM64_DUP:
 	case ARM64_XTN:
 	case ARM64_XTN2:
+	case ARM64_REV:
+	case ARM64_REV16:
+	case ARM64_REV32:
 	case ARM64_REV64:
+	case ARM64_RBIT:
+	case ARM64_CLZ:
+	case ARM64_CLS:
 	case ARM64_EXT:
 	case ARM64_INS:
 		op->type = R_ANAL_OP_TYPE_MOV;
@@ -2550,13 +2558,14 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		r_str_replace_char (output, '\t', ' ');
 		r_str_replace_char (output, '#', ' ');
 		if (r_str_startswith (output, "UNDEF")) {
+			op->type = R_ANAL_OP_TYPE_ILL;
 			if (mask & R_ARCH_OP_MASK_DISASM) {
 				op->mnemonic = strdup ("undefined");
 			}
 			return 4;
 		}
-		//r_strbuf_set (&op->buf_asm, output);
-		op->type = R_ANAL_OP_TYPE_ILL;
+		// valid but unclassified ops must not become ILL or analysis rejects them
+		op->type = R_ANAL_OP_TYPE_UNK;
 		if (mask & R_ARCH_OP_MASK_DISASM) {
 			op->mnemonic = strdup (output);
 		}

--- a/libr/arch/p/arm/v35/deps-arm64.mk
+++ b/libr/arch/p/arm/v35/deps-arm64.mk
@@ -15,7 +15,8 @@ V35ARM64_OBJS+=gofer.o
 V35ARM64_OBJS+=operations.o
 V35ARM64_OBJS+=pcode.o
 V35ARM64_OBJS+=regs.o
-V35ARM64_OBJS+=sysregs.o
+V35ARM64_OBJS+=sysregs_gen.o
+V35ARM64_OBJS+=sysregs_fmt_gen.o
 
 V35ARM64_LINK=$(addprefix $(V35ARM64_SRCDIR),$(V35ARM64_OBJS))
 # V35ARM64_LIBS=$(V35ARM64_HOME)/v35arm64.a

--- a/subprojects/packagefiles/binaryninja/meson.build
+++ b/subprojects/packagefiles/binaryninja/meson.build
@@ -14,7 +14,8 @@ sources_arm64 = [
   'arch/arm64/disassembler/operations.c',
   'arch/arm64/disassembler/pcode.c',
   'arch/arm64/disassembler/regs.c',
-  'arch/arm64/disassembler/sysregs.c'
+  'arch/arm64/disassembler/sysregs_gen.c',
+  'arch/arm64/disassembler/sysregs_fmt_gen.c'
 ]
 
 incs_arm64 = include_directories(['arch/arm64/disassembler'])

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56271,3 +56271,66 @@ x0,x1,x2,x3,x4,x5,x6,x7,x8,x9,x10,x11,x12,x13,x14,x15,x16,x17,x30,v0,v1,v2,v3,v4
 x19,x20,x21,x22,x23,x24,x25,x26,x27,x28,x29,sp,v8,v9,v10,v11,v12,v13,v14,v15
 EOF
 RUN
+
+NAME=arm.v35 rev rbit clz sbc are not typed ill
+FILE=malloc://64
+ARGS=-a arm -b 64
+REQUIRE=arm.v35
+CMDS=<<EOF
+e asm.arch=arm.v35
+wx 0008c05a
+ao~type
+wx 2004c05a
+ao~type
+wx 2008c0da
+ao~type
+wx 2000c05a
+ao~type
+wx 2010c05a
+ao~type
+wx 2000025a
+ao~type
+EOF
+EXPECT=<<EOF
+type: mov
+type: mov
+type: mov
+type: mov
+type: mov
+type: sub
+EOF
+RUN
+
+NAME=arm.v35 af covers rev and stops at udf
+FILE=malloc://64
+ARGS=-a arm -b 64
+REQUIRE=arm.v35
+CMDS=<<EOF
+e asm.arch=arm.v35
+wx 0008c05ac0035fd6
+af
+afl
+af-
+wx 00000000 @ 4
+af
+afl
+EOF
+EXPECT=<<EOF
+0x00000000    1      8 fcn.00000000
+0x00000000    1      8 fcn.00000000
+EOF
+RUN
+
+NAME=arm.v35 udf types trap
+FILE=malloc://64
+ARGS=-a arm -b 64
+REQUIRE=arm.v35
+CMDS=<<EOF
+e asm.arch=arm.v35
+wx 00000000
+ao~type
+EOF
+EXPECT=<<EOF
+type: trap
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The v35 arm64 plugin no longer built: the vendored binaryninja disassembler replaced sysregs.c with generated sysregs_gen.c/sysregs_fmt_gen.c, so both the make and meson file lists needed updating.

With the build repaired, decode() was marking every valid-but-unclassified instruction as R_ANAL_OP_TYPE_ILL, which makes analysis reject real code. Only true UNDEF decodes are ILL now; everything else falls back to UNK. Also classify SBC (sub), UDF (trap), and REV/REV16/REV32/RBIT/CLZ/CLS (mov) instead of leaving them unclassified.

Adds arm64 anal tests covering the new op types.
