### PR TITLE
Fix arm64 sbc ESIL carry sense and add sbcs/ngc/ngcs with NZCV flags ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1003,8 +1003,6 @@ static int regsize64(cs_insn *insn, int n) {
 #define REGBITS64(x) (8 * regsize64 (insn, x))
 #define REGBITS32(x) (8 * regsize32 (insn, x))
 
-#define SET_FLAGS() r_strbuf_appendf (&op->esil, ",$z,zf,:=,%d,$s,nf,:=,%d,$c,cf,:=,%d,$o,vf,:=", REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) -1);
-
 static int vector_size(cs_arm64_op *op) {
 #if CS_API_MAJOR == 4
 	if (op->vess) {
@@ -1297,11 +1295,13 @@ static void arg64_append(RStrBuf *sb, csh *handle, cs_insn *insn, int n, int i, 
 	}
 }
 
-#define OPCALL(opchar) arm64math(as, op, addr, buf, len, handle, insn, opchar, 0, 0)
-#define OPCALL_NEG(opchar) arm64math(as, op, addr, buf, len, handle, insn, opchar, 1, 0)
-#define OPCALL_SIGN(opchar, sign) arm64math(as, op, addr, buf, len, handle, insn, opchar, 0, sign)
+#define OPCALL(opchar) arm64math(as, op, addr, buf, len, handle, insn, opchar, 0, 0, 0)
+#define OPCALL_NEG(opchar) arm64math(as, op, addr, buf, len, handle, insn, opchar, 1, 0, 0)
+#define OPCALL_SIGN(opchar, sign) arm64math(as, op, addr, buf, len, handle, insn, opchar, 0, sign, 0)
+#define OPCALL_FLAGS(opchar, fl) arm64math(as, op, addr, buf, len, handle, insn, opchar, 0, 0, fl)
+#define OPCALL_NEG_FLAGS(opchar, fl) arm64math(as, op, addr, buf, len, handle, insn, opchar, 1, 0, fl)
 
-static void arm64math(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn, const char *opchar, int negate, int sign) {
+static void arm64math(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn, const char *opchar, int negate, int sign, char flags) {
 	cs_arm64_op dst = INSOP64 (0);
 	int i, c = (OPCOUNT64 () > 2) ? 1 : 0;
 
@@ -1322,6 +1322,45 @@ static void arm64math(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			}
 		}
 	} else {
+		if (flags) {
+			const int bits = REGBITS64 (0);
+			if (flags == 'l') {
+				r_strbuf_append (&op->esil, "0,");
+			}
+			VECARG64_APPEND (&op->esil, c + 1, -1, sign);
+			if (negate) {
+				r_strbuf_append (&op->esil, ",-1,^");
+			}
+			if (flags == 'a') {
+				// a - (-b) drives $c/$o through esil old/cur as an addition
+				r_strbuf_append (&op->esil, ",-1,*");
+			}
+			COMMA (&op->esil);
+			VECARG64_APPEND (&op->esil, c, -1, sign);
+			switch (flags) {
+			case 'a':
+				r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$c,cf,:=,%d,$o,vf,:=,", bits - 1, bits - 1, bits - 1);
+				break;
+			case 's':
+				// $o after == is unsound for subtraction, V needs ((a^b)&(a^(a-b)))>>msb
+				r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,", bits - 1, bits, bits - 1);
+				VECARG64_APPEND (&op->esil, c + 1, -1, sign);
+				COMMA (&op->esil);
+				VECARG64_APPEND (&op->esil, c, -1, sign);
+				r_strbuf_append (&op->esil, ",^,");
+				VECARG64_APPEND (&op->esil, c + 1, -1, sign);
+				COMMA (&op->esil);
+				VECARG64_APPEND (&op->esil, c, -1, sign);
+				r_strbuf_append (&op->esil, ",-,");
+				VECARG64_APPEND (&op->esil, c, -1, sign);
+				r_strbuf_append (&op->esil, ",^,&,>>,vf,:=,");
+				break;
+			case 'l':
+				// A64 flag-setting logical ops set NZ from the result and clear CV
+				r_strbuf_appendf (&op->esil, ",%s,==,$z,zf,:=,%d,$s,nf,:=,0,cf,:=,0,vf,:=,", opchar, bits - 1);
+				break;
+			}
+		}
 		VECARG64_APPEND (&op->esil, c + 1, -1, sign);
 		if (negate) {
 			r_strbuf_append (&op->esil, ",-1,^");
@@ -1459,8 +1498,11 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	case ARM64_INS_ADDG:
 #endif
 	case ARM64_INS_ADD:
-	case ARM64_INS_ADC: // Add with carry.
 		OPCALL ("+");
+		break;
+	case ARM64_INS_ADC:
+		r_strbuf_setf (&op->esil, "cf,%s,+,%s,+,%s,=",
+			REG64 (2), REG64 (1), REG64 (0));
 		break;
 	case ARM64_INS_SUB:
 		OPCALL ("-");
@@ -1499,33 +1541,45 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		OPCALL_NEG ("&");
 		break;
 	case ARM64_INS_ADDS:
-	case ARM64_INS_ADCS:
-		OPCALL ("+");
-		SET_FLAGS();
+		OPCALL_FLAGS ("+", 'a');
 		break;
+	case ARM64_INS_ADCS: {
+		const int bits = REGBITS64 (0);
+		char sum[64];
+		if (bits == 32) {
+			snprintf (sum, sizeof (sum), "0xffffffff,cf,%s,+,%s,+,&", REG64 (2), REG64 (1));
+		} else {
+			snprintf (sum, sizeof (sum), "cf,%s,+,%s,+", REG64 (2), REG64 (1));
+		}
+		// C=(r<a)|(cf&(r==a)) and V=(~(a^b)&(a^r))>>msb; the new carry stays on the stack until the sum stored below has read the old cf
+		r_strbuf_setf (&op->esil,
+			"0,%s,==,$z,zf,:=,%d,$s,nf,:=,"
+			"%s,%s,==,%d,$b,cf,%s,%s,^,!,&,|,"
+			"%d,%s,%s,^,-1,^,%s,%s,^,&,>>,vf,:=,"
+			"cf,%s,+,%s,+,%s,=,cf,:=",
+			sum, bits - 1,
+			REG64 (1), sum, bits, REG64 (1), sum,
+			bits - 1, REG64 (2), REG64 (1), sum, REG64 (1),
+			REG64 (2), REG64 (1), REG64 (0));
+		break;
+	}
 	case ARM64_INS_SUBS:
-		OPCALL ("-");
-		SET_FLAGS();
+		OPCALL_FLAGS ("-", 's');
 		break;
 	case ARM64_INS_ANDS:
-		OPCALL ("&");
-		SET_FLAGS();
+		OPCALL_FLAGS ("&", 'l');
 		break;
 	case ARM64_INS_NANDS:
-		OPCALL_NEG ("&");
-		SET_FLAGS();
+		OPCALL_NEG_FLAGS ("&", 'l');
 		break;
 	case ARM64_INS_ORRS:
-		OPCALL ("|");
-		SET_FLAGS();
+		OPCALL_FLAGS ("|", 'l');
 		break;
 	case ARM64_INS_EORS:
-		OPCALL ("^");
-		SET_FLAGS();
+		OPCALL_FLAGS ("^", 'l');
 		break;
 	case ARM64_INS_ORNS:
-		OPCALL_NEG ("|");
-		SET_FLAGS();
+		OPCALL_NEG_FLAGS ("|", 'l');
 		break;
 #endif
 	case ARM64_INS_EOR:
@@ -2033,8 +2087,19 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		ARG64_APPEND (&op->esil, 1);
 		COMMA (&op->esil);
 		ARG64_APPEND (&op->esil, 0);
-		r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,$o,vf,:=",
+		r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,",
 			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) - 1);
+		// $o after == is unsound for subtraction, V needs ((a^b)&(a^(a-b)))>>msb
+		ARG64_APPEND (&op->esil, 1);
+		COMMA (&op->esil);
+		ARG64_APPEND (&op->esil, 0);
+		r_strbuf_append (&op->esil, ",^,");
+		ARG64_APPEND (&op->esil, 1);
+		COMMA (&op->esil);
+		ARG64_APPEND (&op->esil, 0);
+		r_strbuf_append (&op->esil, ",-,");
+		ARG64_APPEND (&op->esil, 0);
+		r_strbuf_append (&op->esil, ",^,&,>>,vf,:=");
 
 		if (insn->id == ARM64_INS_CCMP || insn->id == ARM64_INS_CCMN) {
 			r_strbuf_append (&op->esil, ",");
@@ -2044,11 +2109,13 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		break;
 	case ARM64_INS_CMN:
 	case ARM64_INS_CCMN:
+		// negate the src operand so old/cur describe the addition
 		ARG64_APPEND (&op->esil, 1);
+		r_strbuf_append (&op->esil, ",-1,*");
 		COMMA (&op->esil);
 		ARG64_APPEND (&op->esil, 0);
-		r_strbuf_appendf (&op->esil, ",-1,*,==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,$o,vf,:=",
-			REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) - 1);
+		r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$c,cf,:=,%d,$o,vf,:=",
+			REGBITS64 (0) - 1, REGBITS64 (0) - 1, REGBITS64 (0) - 1);
 
 		if (insn->id == ARM64_INS_CCMN) {
 			r_strbuf_append (&op->esil, ",");
@@ -2497,6 +2564,16 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	case ARM64_INS_NEG:
 #if CS_API_MAJOR > 3
 	case ARM64_INS_NEGS:
+		if (insn->id == ARM64_INS_NEGS) {
+			ARG64_APPEND (&op->esil, 1);
+			r_strbuf_appendf (&op->esil, ",0,==,$z,zf,:=,%d,$s,nf,:=,%d,$b,!,cf,:=,%d,",
+				REGBITS64 (0) - 1, REGBITS64 (0), REGBITS64 (0) - 1);
+			// V = (b & -b) >> msb, only INT_MIN overflows on negation
+			ARG64_APPEND (&op->esil, 1);
+			COMMA (&op->esil);
+			ARG64_APPEND (&op->esil, 1);
+			r_strbuf_append (&op->esil, ",0,-,&,>>,vf,:=,");
+		}
 #endif
 		ARG64_APPEND (&op->esil, 1);
 		r_strbuf_appendf (&op->esil, ",0,-,%s,=", REG64 (0));

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -142,6 +142,8 @@ static inline HtUU *ht_it_for_session (RArchSession *as) {
 #define ARM64_INS_SBFX ARM64_INS_ALIAS_SBFX
 #define ARM64_INS_UBFX ARM64_INS_ALIAS_UBFX
 #define ARM64_INS_NEGS ARM64_INS_ALIAS_NEGS
+#define ARM64_INS_NGC ARM64_INS_ALIAS_NGC
+#define ARM64_INS_NGCS ARM64_INS_ALIAS_NGCS
 #define ARM64_INS_PACIA1716 ARM64_INS_ALIAS_PACIA1716
 #define ARM64_INS_PACIASP ARM64_INS_ALIAS_PACIASP
 #define ARM64_INS_PACIAZ ARM64_INS_ALIAS_PACIAZ
@@ -1508,10 +1510,41 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		OPCALL ("-");
 		break;
 	case ARM64_INS_SBC:
-		// TODO have to check this more, VEX does not work
-		r_strbuf_setf (&op->esil, "%s,cf,+,%s,-,%s,=",
-			REG64 (2), REG64 (1), REG64 (0));
+	case ARM64_INS_NGC: {
+		// rd = rn + ~rm + C; ngc is the rn=xzr form
+		const bool ngc = OPCOUNT64 () == 2;
+		const char *rn = ngc? "0": REG64 (1);
+		const char *rm = ngc? REG64 (1): REG64 (2);
+		r_strbuf_setf (&op->esil, "cf,%s,-1,^,+,%s,+,%s,=", rm, rn, REG64 (0));
 		break;
+	}
+	case ARM64_INS_NGCS:
+#if CS_API_MAJOR > 4
+	case ARM64_INS_SBCS:
+#endif
+	{
+		// AddWithCarry (rn, ~rm, C) like ADCS; V reduces to ((rn^rm)&(rn^r))>>msb
+		const int bits = REGBITS64 (0);
+		const bool ngc = OPCOUNT64 () == 2;
+		const char *rn = ngc? "0": REG64 (1);
+		const char *rm = ngc? REG64 (1): REG64 (2);
+		char sum[80];
+		if (bits == 32) {
+			snprintf (sum, sizeof (sum), "0xffffffff,cf,%s,-1,^,+,%s,+,&", rm, rn);
+		} else {
+			snprintf (sum, sizeof (sum), "cf,%s,-1,^,+,%s,+", rm, rn);
+		}
+		r_strbuf_setf (&op->esil,
+			"0,%s,==,$z,zf,:=,%d,$s,nf,:=,"
+			"%s,%s,==,%d,$b,cf,%s,%s,^,!,&,|,"
+			"%d,%s,%s,^,%s,%s,^,&,>>,vf,:=,"
+			"cf,%s,-1,^,+,%s,+,%s,=,cf,:=",
+			sum, bits - 1,
+			rn, sum, bits, rn, sum,
+			bits - 1, rm, rn, sum, rn,
+			rm, rn, REG64 (0));
+		break;
+	}
 	case ARM64_INS_SMULL2:
 	case ARM64_INS_SMULL:
 		OPCALL_SIGN ("*", REGBITS64 (1));
@@ -3633,6 +3666,12 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		op->cycles = 1;
 		/* fallthru */
 	case ARM64_INS_MSUB:
+	case ARM64_INS_SBC:
+	case ARM64_INS_NGC:
+	case ARM64_INS_NGCS:
+#if CS_API_MAJOR > 4
+	case ARM64_INS_SBCS:
+#endif
 		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
 	case ARM64_INS_FDIV:

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1208,3 +1208,269 @@ EXPECT=<<EOF
 (nofunc) 0x8 [ICOD:r--] add x16, x16, 0x40
 EOF
 RUN
+
+NAME=subs x flags nzcv
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002eb
+ar x1=5
+ar x2=1
+aes
+ar cf
+ar vf
+ar zf
+ar pc=0
+ar x1=1
+ar x2=5
+aes
+ar cf
+ar nf
+ar pc=0
+ar x1=0x8000000000000000
+ar x2=1
+aes
+ar vf
+ar pc=0
+ar x1=7
+ar x2=7
+aes
+ar zf
+ar cf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+0x00000000
+0x00000000
+0x00000001
+0x00000001
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=subs w flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000026b
+ar x1=1
+ar x2=5
+aes
+ar cf
+ar nf
+ar pc=0
+ar x1=0x80000000
+ar x2=1
+aes
+ar vf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=adds x flags nzcv
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002ab
+ar x1=0xffffffffffffffff
+ar x2=1
+aes
+ar cf
+ar zf
+ar x0
+ar pc=0
+ar x1=0x7fffffffffffffff
+ar x2=1
+aes
+ar vf
+ar nf
+ar cf
+ar pc=0
+ar x1=2
+ar x2=3
+aes
+ar x0
+ar cf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000000
+0x00000001
+0x00000001
+0x00000000
+0x00000005
+0x00000000
+EOF
+RUN
+
+NAME=adds w flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000022b
+ar x1=0xffffffff
+ar x2=1
+aes
+ar cf
+ar zf
+ar x0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=cmp vf with int64 min subtrahend
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 3f0002eb
+ar x1=0xffffffffffffffff
+ar x2=0x8000000000000000
+aes
+ar vf
+ar cf
+ar nf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=cmn flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 3f0002ab
+ar x1=0
+ar x2=1
+aes
+ar nf
+ar zf
+ar cf
+ar pc=0
+ar x1=0xffffffffffffffff
+ar x2=1
+aes
+ar cf
+ar zf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000000
+0x00000000
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=ands clears cv
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002ea
+ar cf=1
+ar vf=1
+ar x1=0xf0
+ar x2=0x0f
+aes
+ar zf
+ar cf
+ar vf
+ar pc=0
+ar x1=0x8000000000000000
+ar x2=0x8000000000000000
+aes
+ar nf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+0x00000000
+0x00000001
+EOF
+RUN
+
+NAME=adcs carry chain wrap
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002ba
+ar cf=1
+ar x1=5
+ar x2=0xffffffffffffffff
+aes
+ar x0
+ar cf
+ar pc=0
+ar cf=0
+ar x1=5
+ar x2=0xffffffffffffffff
+aes
+ar x0
+ar cf
+EOF
+EXPECT=<<EOF
+0x00000005
+0x00000001
+0x00000004
+0x00000001
+EOF
+RUN
+
+NAME=adc adds carry in
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000029a
+ar cf=1
+ar x1=2
+ar x2=3
+aes
+ar x0
+EOF
+EXPECT=<<EOF
+0x00000006
+EOF
+RUN
+
+NAME=negs flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx e00301eb
+ar x1=0
+aes
+ar cf
+ar zf
+ar pc=0
+ar x1=1
+aes
+ar x0
+ar nf
+ar cf
+ar pc=0
+ar x1=0x8000000000000000
+aes
+ar vf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0xffffffffffffffff
+0x00000001
+0x00000000
+0x00000001
+EOF
+RUN

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1474,3 +1474,177 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=sbc x carry sense
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002da
+ar x1=5
+ar x2=3
+ar cf=1
+aes
+ar x0
+ar pc=0
+ar cf=0
+aes
+ar x0
+EOF
+EXPECT=<<EOF
+0x00000002
+0x00000001
+EOF
+RUN
+
+NAME=sbc w borrow wrap
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000025a
+ar x1=0
+ar x2=0
+ar cf=0
+aes
+ar x0
+EOF
+EXPECT=<<EOF
+0xffffffff
+EOF
+RUN
+
+NAME=sbcs x flags nzcv
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002fa
+ar x1=5
+ar x2=3
+ar cf=1
+aes
+ar x0
+ar cf
+ar zf
+ar pc=0
+ar x1=3
+ar x2=5
+aes
+ar x0
+ar nf
+ar cf
+ar pc=0
+ar x1=7
+ar x2=7
+ar cf=1
+aes
+ar zf
+ar cf
+ar pc=0
+ar x1=7
+ar x2=7
+ar cf=0
+aes
+ar x0
+ar nf
+ar cf
+ar zf
+ar pc=0
+ar x1=0x8000000000000000
+ar x2=1
+ar cf=1
+aes
+ar x0
+ar vf
+ar cf
+EOF
+EXPECT=<<EOF
+0x00000002
+0x00000001
+0x00000000
+0xfffffffffffffffe
+0x00000001
+0x00000000
+0x00000001
+0x00000001
+0xffffffffffffffff
+0x00000001
+0x00000000
+0x00000000
+0x7fffffffffffffff
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=sbcs w flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000027a
+ar x1=0x80000000
+ar x2=1
+ar cf=1
+aes
+ar x0
+ar vf
+ar cf
+ar pc=0
+ar x1=1
+ar x2=5
+aes
+ar x0
+ar nf
+ar cf
+EOF
+EXPECT=<<EOF
+0x7fffffff
+0x00000001
+0x00000001
+0xfffffffc
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=ngc ngcs negate with carry
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx e00301da
+ar x1=5
+ar cf=1
+aes
+ar x0
+ar pc=0
+ar cf=0
+aes
+ar x0
+wx e00301fa @ 0
+ar pc=0
+ar x1=0
+ar cf=1
+aes
+ar x0
+ar zf
+ar cf
+wx e003017a @ 0
+ar pc=0
+ar x1=0x80000000
+ar cf=1
+aes
+ar x0
+ar nf
+ar vf
+ar cf
+EOF
+EXPECT=<<EOF
+0xfffffffffffffffb
+0xfffffffffffffffa
+0x00000000
+0x00000001
+0x00000001
+0x80000000
+0x00000001
+0x00000001
+0x00000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Depends on #26275 (stacked on that branch; will rebase once it lands).

SBC emitted `rn - (rm + cf)`, inverting the A64 carry sense — the correct semantics are `rd = rn + ~rm + C`. SBCS, NGC and NGCS had no case at all (no ESIL, no op->type).

- Fix the SBC value and add NGC (the rn=xzr alias form, detected by operand count so it works on every capstone version)
- Add SBCS/NGCS with full NZCV using the same AddWithCarry recipe as ADCS; the V term reduces to the standard subtraction formula
- Type all four as SUB in anop64
- capstone notes: v4 has no SBCS id (label guarded); v6 needs the two ALIAS_NGC/ALIAS_NGCS compat defines

Validated by differential testing against native aarch64 execution (2480 cases: value + NZCV over edge values and both carry-in states, which also independently confirms the #26275 adc/adcs/adds/subs flag recipes). 5 new r2r esil tests; full test suite clean vs the base branch.