### PR TITLE
Use stateful decoding in the /r, aea and aespc linear sweeps ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -4235,6 +4235,13 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 	// ???
 	// XXX must read bytes correctly
 	do_bckwrd_srch = bckwrds = core->search->bckwrds;
+	// backwards scans decode out of address order, so only forward scans are one stateful window
+	const bool stateful = !bckwrds && core->anal->opt.stateful;
+	const ut32 opmask = R_ARCH_OP_MASK_BASIC
+		| (stateful? R_ARCH_OP_MASK_STATEFUL: 0);
+	if (stateful && core->anal->arch->session) {
+		r_arch_session_reset (core->anal->arch->session);
+	}
 	r_cons_break_push (core->cons, NULL, NULL);
 	if (core->blocksize > OPSZ) {
 		if (bckwrds) {
@@ -4278,7 +4285,7 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 				case 'w':
 				case 'x':
 					r_anal_op_fini (&op);
-					r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, R_ARCH_OP_MASK_BASIC);
+					r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, opmask);
 					const int mask = (mode == 'r') ? 1 : mode == 'w' ? 2: mode == 'x' ? 4: 0;
 					if (op.direction == mask) {
 						i += op.size;
@@ -4288,7 +4295,7 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 				case 'a':
 				default:
 					r_anal_op_fini (&op);
-					if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, R_ARCH_OP_MASK_BASIC)) {
+					if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, opmask)) {
 						r_anal_op_fini (&op);
 						continue;
 					}
@@ -4312,6 +4319,10 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 					if (op.ptr != UT64_MAX &&
 						core_anal_followptr (core, R_ANAL_REF_TYPE_JUMP, at + i, op.ptr, ref, true ,1)) {
 						count++;
+					} else if (op.jump != UT64_MAX &&
+						core_anal_followptr (core, R_ANAL_REF_TYPE_JUMP, at + i, op.jump, ref, true, 0)) {
+						// stateful decode can resolve a register jump into op.jump
+						count++;
 					}
 					break;
 				case R_ANAL_OP_TYPE_UCALL:
@@ -4322,12 +4333,16 @@ R_API int r_core_anal_search(RCore *core, ut64 from, ut64 to, ut64 ref, int mode
 					if (op.ptr != UT64_MAX &&
 						core_anal_followptr (core, R_ANAL_REF_TYPE_CALL, at + i, op.ptr, ref, true ,1)) {
 						count++;
+					} else if (op.jump != UT64_MAX &&
+						core_anal_followptr (core, R_ANAL_REF_TYPE_CALL, at + i, op.jump, ref, true, 0)) {
+						// stateful decode can resolve a register call into op.jump
+						count++;
 					}
 					break;
 				default:
 					{
 						r_anal_op_fini (&op);
-						if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, R_ARCH_OP_MASK_BASIC)) {
+						if (!r_anal_op (core->anal, &op, at + i, buf + i, core->blocksize - i, opmask)) {
 							r_anal_op_fini (&op);
 							continue;
 						}

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -8786,6 +8786,13 @@ static bool cmd_aea_stuff(RCore* core, int mode, ut64 addr, int length, const ch
 	esil->cb.hook_mem_write = mymemwrite;
 	esil->cb.hook_mem_read = mymemread;
 	esil->nowrite = true;
+	const bool stateful = core->anal->opt.stateful;
+	const ut32 opmask = R_ARCH_OP_MASK_ESIL | R_ARCH_OP_MASK_HINT
+		| (stateful? R_ARCH_OP_MASK_STATEFUL: 0);
+	if (stateful && core->anal->arch->session) {
+		// the whole sweep is one linear decode window
+		r_arch_session_reset (core->anal->arch->session);
+	}
 	r_cons_break_push (core->cons, NULL, NULL);
 	for (ops = ptr = 0; ptr < buf_sz && hasNext (); ops++, ptr += len) {
 		if (r_cons_is_breaked (core->cons)) {
@@ -8795,7 +8802,7 @@ static bool cmd_aea_stuff(RCore* core, int mode, ut64 addr, int length, const ch
 			len = 100;
 			esilstr = esilexpr;
 		} else {
-			len = r_anal_op (core->anal, &aop, addr + ptr, buf + ptr, buf_sz - ptr, R_ARCH_OP_MASK_ESIL | R_ARCH_OP_MASK_HINT);
+			len = r_anal_op (core->anal, &aop, addr + ptr, buf + ptr, buf_sz - ptr, opmask);
 			esilstr = R_STRBUF_SAFEGET (&aop.esil);
 		}
 		if (len < 1) {
@@ -8968,7 +8975,13 @@ static void cmd_aespc(RCore *core, ut64 addr, ut64 until_addr, int ninstr) {
 	}
 	ut64 cursp = r_reg_getv (core->dbg->reg, "SP");
 	ut64 oldoff = core->addr;
-	const ut64 flags = R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_HINT | R_ARCH_OP_MASK_ESIL | R_ARCH_OP_MASK_DISASM;
+	const bool stateful = core->anal->opt.stateful;
+	const ut64 flags = R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_HINT | R_ARCH_OP_MASK_ESIL | R_ARCH_OP_MASK_DISASM
+		| (stateful? R_ARCH_OP_MASK_STATEFUL: 0);
+	if (stateful && core->anal->arch->session) {
+		// calls are skipped but stepping stays in address order, so this is one linear window
+		r_arch_session_reset (core->anal->arch->session);
+	}
 	for (i = 0, j = 0; j < ninstr; i++, j++) {
 		if (r_cons_is_breaked (core->cons)) {
 			break;

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -1214,3 +1214,17 @@ EXPECT=<<EOF
 jump: 0x00000044
 EOF
 RUN
+
+NAME=mips: /r resolves a t9-mediated register call in the forward scan
+FILE=bins/elf/boa-mips
+CMDS=<<EXPECT_END
+e search.in=io.maps.x
+e anal.stateful=false
+/r 0x49a660
+e anal.stateful=true
+/r 0x49a660
+EXPECT_END
+EXPECT=<<EXPECT_END
+(nofunc) 0x407454 [CALL] jalr t9
+EXPECT_END
+RUN

--- a/test/db/formats/elf/ppc64v1-toc
+++ b/test/db/formats/elf/ppc64v1-toc
@@ -192,3 +192,17 @@ EOF
 EXPECT=<<EOF
 EOF
 RUN
+
+NAME=PPC64 ELFv1: /r resolves TOC-mediated data refs in the forward scan
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EXPECT_END
+e search.in=io.maps.x
+e anal.stateful=false
+/r 0x2f918
+e anal.stateful=true
+/r 0x2f918
+EXPECT_END
+EXPECT=<<EXPECT_END
+(nofunc) 0x3088 [DATA] ld r12, 0x7a18(r11)
+EXPECT_END
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to the #26264 review: adopt R_ARCH_OP_MASK_STATEFUL in the  remaining linear-decode loops, same pattern as the aar sweep.

- /r (r_core_anal_search): forward scans only — backwards scans decode out of address order; reset once per map window
- aea and aespc: one linear window each
- /r now also matches op.jump on indirect call/jump ops: stateful decode resolves register calls (e.g. mips jalr t9) into op.jump, the same field function analysis already consumes; previously only op.ptr was checked so those hits were silently missed

pdc needs no change: its instruction decoding goes through pdb/disasm which is already stateful, and its own op lookups are random-access.

Tests: /r finds a TOC-mediated load on a ppc64 ELFv1 binary and a t9-mediated register call on boa-mips, both gated on anal.stateful.