### PR TITLE
Fix x86 SHL/SAL and NEG condition flags in ESIL (incl. memory destinations) ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -1226,49 +1226,27 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_SAL:
 		{
 		ut32 bitsize;
-		src = getarg (&gop, 1, 0, NULL, &bitsize);
-		dst = getarg (&gop, 0, 0, NULL, NULL);
-		// dst2 = getarg (&gop, 0, 1, "<<", &bitsize);
-#if 0
-	// https://c9x.me/x86/html/file_module_x86_id_285.html
-	The CF flag contains the value of the last bit shifted out of the destination operand;
-		it is undefined for SHL and SHR instructions where the count is greater than or equal to the size (in bits) of the destination operand.
-	The OF flag is affected only for 1-bit shifts (see "Description" above); otherwise, it is undefined.
-	The SF, ZF, and PF flags are set according to the result
-	If the count is 0, the flags are not affected.
-	For a non-zero count, the AF flag is undefined.
-#endif
-		ut64 val = 0;
-		switch (gop.insn->detail->x86.operands[0].size) {
-		case 1:
-			val = 0x80;
-			break;
-		case 2:
-			val = 0x8000;
-			break;
-		case 4:
-			val = 0x80000000;
-			break;
-		case 8:
-			val = (ut64)0x8000000000000000ULL;
-			break;
-		default:
-			R_LOG_ERROR ("unknown operand size: %d", gop.insn->detail->x86.operands[0].size);
-			val = 256;
-		}
-		// OLD: esilprintf (op, "0,%s,!,!,?{,1,%s,-,%s,<<,0x%"PFMT64x",&,!,!,^,},%s,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=,cf,=", src, src, dst, val, src, dst2, bitsize - 1);
+		src = getarg (&gop, 1, 0, NULL, NULL);
+		dst_r = getarg (&gop, 0, 0, NULL, &bitsize);
+		dst_w = getarg (&gop, 0, 1, NULL, NULL);
+		// CF = last bit shifted out = (dst >> (width - count)) & 1 from the
+		// pre-shift value; OF is defined only for 1-bit shifts as msb(result) ^ CF.
+		// Read via dst_r, write via dst_w so memory destinations store the result.
 		esilprintf (op,
-			"%s,0x%"PFMT64x",&,POP,$z,cf,:=,"
-			"%s,%s,<<=,"
+			"%s,%d,-,%s,>>,1,&,cf,:=,"
+			"%s,%s,<<,%s,"
 			"$z,zf,:=,"
 			"$p,pf,:=,"
-			"%d,$s,sf,:=",
-			dst, val,
-			src, dst,
-			bitsize - 1);
+			"%d,$s,sf,:=,"
+			"%d,%s,>>,1,&,cf,^,of,:=",
+			src, bitsize, dst_r,
+			src, dst_r, dst_w,
+			bitsize - 1,
+			bitsize - 1, dst_r);
 		free (src);
-		free (dst);
-	   	}
+		free (dst_r);
+		free (dst_w);
+		}
 		break;
 	case X86_INS_SALC:
 		esilprintf (op, "$z,DUP,zf,=,al,=");
@@ -2304,8 +2282,11 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			default:
 				R_LOG_ERROR ("Neg: Unhandled bitsize %d", bitsize);
 			}
-			esilprintf (op, "%s,!,!,cf,:=,%s,0x%"PFMT64x",^,1,+,%s,$z,zf,:=,0,of,:=,%d,$s,sf,:=,%d,$o,pf,:=",
-				src, src, xor, dst, bitsize - 1, bitsize - 1);
+			// OF set iff the operand is INT_MIN (the only value that overflows on
+			// negation); PF from the parity term, not the overflow term
+			ut64 intmin = 1ULL << (bitsize - 1);
+			esilprintf (op, "%s,!,!,cf,:=,%s,0x%"PFMT64x",^,1,+,%s,$z,zf,:=,%s,0x%"PFMT64x",^,!,of,:=,%d,$s,sf,:=,$p,pf,:=",
+				src, src, xor, dst, src, intmin, bitsize - 1);
 			free (src);
 			free (dst);
 		}

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2462,3 +2462,157 @@ esp before :0x00178000
 esp after  :0x00178000
 EOF
 RUN
+
+NAME=x86 shl cf/of/sf from result and destination width
+FILE=malloc://64
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+aei
+aeim
+wx d1e0
+ar eax=1
+ar eip=0
+aes
+ar cf
+ar of
+ar sf
+ar eax=0x80000000
+ar eip=0
+aes
+ar cf
+ar of
+ar zf
+wx c1e005
+ar eax=0x04000000
+ar eip=0
+aes
+ar cf
+ar sf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000000
+0x00000000
+0x00000001
+0x00000001
+0x00000001
+0x00000000
+0x00000001
+EOF
+RUN
+
+NAME=x86 neg pf from parity and of on int_min
+FILE=malloc://64
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+aei
+aeim
+wx f7d8
+ar eax=4
+ar eip=0
+aes
+ar pf
+ar of
+ar eax=0x80000000
+ar eip=0
+aes
+ar of
+ar pf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=x86 shl variants 8/16-bit cl and memory destination
+FILE=malloc://64
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+aei
+aeim
+wx d0e0
+ar al=0x40
+ar eip=0
+s 0
+aes
+ar cf
+ar sf
+ar of
+wx 66d1e0
+ar ax=0x4000
+ar eip=0
+s 0
+aes
+ar cf
+ar sf
+wx d3e0
+ar eax=0x10000000
+ar ecx=3
+ar eip=0
+s 0
+aes
+ar cf
+ar sf
+wx d120
+ar eax=0x20
+wv4 0x80000000 @ 0x20
+ar eip=0
+s 0
+aes
+ar cf
+ar of
+ar zf
+pv4 @ 0x20
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+0x00000001
+0x00000000
+0x00000001
+0x00000000
+0x00000001
+0x00000001
+0x00000001
+0x00000001
+0x00000000
+EOF
+RUN
+
+NAME=x86 neg variants 8/16-bit and memory destination
+FILE=malloc://64
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+aei
+aeim
+wx f6d8
+ar al=4
+ar eip=0
+s 0
+aes
+ar pf
+ar cf
+wx 66f7d8
+ar ax=0x8000
+ar eip=0
+s 0
+aes
+ar of
+wx f718
+ar eax=0x20
+wv4 4 @ 0x20
+ar eip=0
+s 0
+aes
+ar pf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000001
+0x00000001
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -612,3 +612,53 @@ EXPECT=<<EOF
 0x100003ad0
 EOF
 RUN
+
+NAME=x86-64 shl and neg flags
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 48d1e0
+ar rax=0x8000000000000000
+ar rip=0
+aes
+ar cf
+ar of
+wx 48f7d8
+ar rax=0x8000000000000000
+ar rip=0
+aes
+ar of
+ar pf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=x86-64 shl memory destination writes back and sets flags
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 48d120
+ar rax=0x20
+wv8 0x8000000000000000 @ 0x20
+ar rip=0
+s 0
+aes
+ar cf
+ar zf
+pv8 @ 0x20
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x0000000000000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

SHL/SAL and NEG produced wrong ESIL condition flags:

- SHL/SAL CF was stuck at 1 (the AND result was POPped before $z read it); now CF = last bit shifted out = (dst >> (width - count)) & 1
- SHL/SAL OF was unset; now msb(result) ^ CF (defined for 1-bit shifts)
- SHL/SAL SF took its width from the count operand, which is 1 byte for the imm8/CL forms, so SF used bit 7 not the destination MSB; width now comes from the destination
- SHL/SAL on a memory destination used `<<=` on the read form and never wrote the result back (pre-existing); now uses the SHR/SAR dst_r/dst_w split
- NEG PF was taken from the overflow term ($o) instead of parity ($p)
- NEG OF was hardcoded 0, wrong when the operand is INT_MIN

Repro (eg. CF stuck at 1 — shl of 1 by 1 = 2, nothing shifted out of the top, so CF must be 0):

    $ r2 -a x86 -b 32 -qc 'wx d1e0; aei; aeim; ar eax=1; ar eip=0; aes; ar cf' malloc://64
    before: 0x00000001   after: 0x00000000

Each flag was cross-checked against the Unicorn CPU emulator as a reference oracle (assemble → run once under Unicorn, once under r2 ESIL, diff all GPRs + NZCV/EFLAGS): x86-32 and x86-64 now match 15/15, with discriminating cases that fail on master and pass here. Instruction encodings independently confirmed with objdump.

Also removes the dead sign-mask switch and #if 0 block. Adds x86_32/x86_64 esil tests covering 8/16/32/64-bit registers, imm8/CL counts, and memory destinations.