### PR TITLE
Fix arm32 CMN flags and MOVT top-halfword replacement in ESIL ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -2946,10 +2946,12 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 		r_strbuf_appendf (&op->esil, "%s,%s,==", ARG (1), ARG (0));
 		break;
 	case ARM_INS_CMN:
-		r_strbuf_appendf (&op->esil, "%s,%s,^,!,!,zf,=", ARG (1), ARG (0));
+		// rn + op2 as rn - (-op2) so == commits old/cur for the shared $z/$c/$o block
+		r_strbuf_appendf (&op->esil, "%s,-1,*,%s,==", ARG (1), ARG (0));
 		break;
 	case ARM_INS_MOVT:
-		r_strbuf_appendf (&op->esil, "16,%s,<<,%s,|=", ARG (1), REG (0));
+		// replace rd[31:16] with imm16, preserving rd[15:0]
+		r_strbuf_appendf (&op->esil, "16,%s,<<,0xffff,%s,&,|,%s,=", ARG (1), REG (0), REG (0));
 		break;
 	case ARM_INS_ADR:
 		r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%s,+,0xfffffffc,&,%s,=",

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3063,3 +3063,72 @@ EXPECT=<<EOF
 0x00000002
 EOF
 RUN
+
+NAME=arm cmn sets nzcv from rn+op2 (reg, overflow, immediate)
+FILE=malloc://64
+ARGS=-a arm -b 32
+CMDS=<<EOF
+aei
+aeim
+wx 010070e1
+ar r0=1
+ar r1=0xffffffff
+ar pc=0
+s 0
+aes
+ar zf
+ar cf
+ar nf
+ar vf
+ar r0=0x40000000
+ar r1=0x40000000
+ar pc=0
+aes
+ar nf
+ar vf
+ar cf
+ar zf
+wx 050070e3
+ar r0=0xfffffffb
+ar pc=0
+aes
+ar zf
+ar cf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000000
+0x00000000
+0x00000001
+0x00000001
+0x00000000
+0x00000000
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=arm movt replaces top16 preserving low16
+FILE=malloc://64
+ARGS=-a arm -b 32
+CMDS=<<EOF
+aei
+aeim
+wx 340241e3
+ar r0=0xffffffff
+ar pc=0
+s 0
+aes
+ar r0
+wx cd0b4ae3
+ar r0=0x0000ffff
+ar pc=0
+aes
+ar r0
+EOF
+EXPECT=<<EOF
+0x1234ffff
+0xabcdffff
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

CMN set NZCV from a bitwise XOR of its operands (an equality test) instead of rn + op2, so every flag after it was wrong; MOVT ORed the immediate into rd without clearing rd[31:16], corrupting the register when its top half was nonzero.

- CMN: now rn + op2 as rn - (-op2) via ==, so the shared update_flags block reads correct N/Z/C/V (same idiom as arm64 CMN)
- MOVT: now rd = (rd & 0xffff) | (imm16 << 16)

Repro (CMN of x and -x should give Z=1, C=1; XOR gave Z=0):

    $ r2 -a arm -b 32 -qc 'wx 010070e1; aei; aeim; ar r0=1; ar r1=0xffffffff; ar pc=0; aes; ar zf; ar cf' malloc://64
    before: zf=0 cf=0   after: zf=1 cf=1

Each flag was cross-checked against the Unicorn CPU emulator as a reference oracle across the register, immediate, and shifted-operand CMN forms, with cases that fail on master and pass here; encodings confirmed with objdump. Adds arm_32 esil tests for CMN N/Z/C/V and MOVT.
