### PR TITLE
Type arm64 flag-setting adds/adcs/subs/ands/bics in ESIL analysis ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -3663,6 +3663,7 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 	case ARM64_INS_NGCS:
 #if CS_API_MAJOR > 4
 	case ARM64_INS_SBCS:
+	case ARM64_INS_SUBS:
 #endif
 		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
@@ -3709,11 +3710,14 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		op->type = R_ANAL_OP_TYPE_ADD;
 		break;
 	case ARM64_INS_ADC:
-	//case ARM64_INS_ADCS:
 	case ARM64_INS_UMADDL:
 	case ARM64_INS_SMADDL:
 	case ARM64_INS_FMADD:
 	case ARM64_INS_MADD:
+#if CS_API_MAJOR > 4
+	case ARM64_INS_ADDS:
+	case ARM64_INS_ADCS:
+#endif
 		op->type = R_ANAL_OP_TYPE_ADD;
 		break;
 	case ARM64_INS_CSEL:
@@ -3843,6 +3847,10 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		op->type = R_ANAL_OP_TYPE_ROR;
 		break;
 	case ARM64_INS_AND:
+#if CS_API_MAJOR > 4
+	case ARM64_INS_ANDS:
+	case ARM64_INS_BICS:
+#endif
 		op->type = R_ANAL_OP_TYPE_AND;
 		break;
 	case ARM64_INS_ORR:

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56334,3 +56334,27 @@ EXPECT=<<EOF
 type: trap
 EOF
 RUN
+
+NAME=arm64 flag-setting ops get op type
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200002ab
+ao 1~type[1]
+wx 200002ba
+ao 1~type[1]
+wx 200002eb
+ao 1~type[1]
+wx 200002ea
+ao 1~type[1]
+wx 200022ea
+ao 1~type[1]
+EOF
+EXPECT=<<EOF
+add
+add
+sub
+and
+and
+EOF
+RUN

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -43,7 +43,7 @@ EXPECT=<<EOF
 ;-- case 1:                                                            ; from 0x100004048
 ; CODE XREF from sym.func.100004000 @ 0x100004048(x)
 0x100004060      lsr x8, x3, 0x20                                      ; arg4
-0x100004064      subs w8, w8, w3
+0x100004064      subs w8, w8, w3                                       ; arg4
 0x100004068      b.vs 0x10000410c
 | // true: 0x10000410c  false: 0x10000406c
 0x10000406c      sxtw x25, w8
@@ -418,7 +418,7 @@ EXPECT=<<EOF
 ;-- case 1:                                                            ; from 0x100004170
 ; CODE XREF from sym.func.100004124 @ 0x100004170(x)
 0x10000418c      lsr x8, x0, 0x20                                      ; arg1
-0x100004190      subs w8, w8, w0
+0x100004190      subs w8, w8, w0                                       ; arg1
 0x100004194      b.vs 0x100004498
 | // true: 0x100004498  false: 0x100004198
 0x100004198      sxtw x26, w8


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

anop64 left op->type unset for the arm64 flag-setting S-variants, so consumers saw them as untyped. Type them like their base ops:

- ADDS, ADCS -> ADD
- SUBS -> SUB
- ANDS, BICS -> AND

Guarded for capstone v5 (the ids don't exist in v4, where the S-variants fold to base + update_flags), matching the existing SBCS case.

Two db/anal/jmptbl goldens gain a correct arg annotation now that subs is typed (e.g. `subs w8, w8, w3 ; arg4`).