### PR TITLE
Fix mips signed mult high word and add srav ESIL ##esil

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -321,6 +321,12 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				"0xffffffff,%s,%s,>>,&,31,%s,>>,?{,%s,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
 				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
 			break;
+		case MIPS_INS_SRAV:
+			// like SRA but the shift amount is rs & 0x1f
+			r_strbuf_appendf (&op->esil,
+				"0xffffffff,%s,0x1f,&,%s,>>,&,31,%s,>>,?{,%s,0x1f,&,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
+				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
+			break;
 		case MIPS_INS_SHRL:
 			// suffix 'S' forces conditional flag to be updated
 		case MIPS_INS_SRLV:
@@ -704,6 +710,12 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				ES_SIGN32_64 (ARG(0));
 				break;
 			case MIPS_INS_MULT:
+				// signed: sign-extend both operands so hi holds the signed high word
+				r_strbuf_appendf (&op->esil, ES_W("32,%s,~,32,%s,~,*")",lo,=", ARG (0), ARG (1));
+				ES_SIGN32_64 ("lo");
+				r_strbuf_appendf (&op->esil, ES_W("32,32,%s,~,32,%s,~,*,>>")",hi,=", ARG (0), ARG (1));
+				ES_SIGN32_64 ("hi");
+				break;
 			case MIPS_INS_MULTU:
 				r_strbuf_appendf (&op->esil, ES_W("%s,%s,*")",lo,=", ARG (0), ARG (1));
 				ES_SIGN32_64 ("lo");
@@ -1356,6 +1368,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case MIPS_INS_SHRA:
 	case MIPS_INS_SHRA_R:
 	case MIPS_INS_SRA:
+	case MIPS_INS_SRAV:
 		op->type = R_ANAL_OP_TYPE_SAR;
 		SET_VAL (op,2);
 		break;

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -1860,3 +1860,54 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+
+NAME=mips mult signed hi vs multu unsigned hi
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 18000901
+ar t0=0xffffffff
+ar t1=2
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+wx 19000901
+ar t0=0xffffffff
+ar t1=2
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+EOF
+EXPECT=<<EOF
+0xffffffff
+0xfffffffe
+0x00000001
+0xfffffffe
+EOF
+RUN
+
+NAME=mips srav arithmetic variable shift
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 07402a01
+ar t2=0x80000000
+ar t1=4
+ar pc=0
+s 0
+aes
+ar t0
+ao 1~type[1]
+EOF
+EXPECT=<<EOF
+0xf8000000
+sar
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Signed mult reused the unsigned product, so the high word (HI) was wrong for negative operands — split it from multu and sign-extend  both operands. srav had no ESIL at all; add the arithmetic-shift idiom with the shift amount masked to rs & 0x1f, and classify it as sar. Tested against the Unicorn oracle.