### PR TITLE
Fix mips.gnu slt-family ESIL destination register and signed comparison ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -1149,14 +1149,14 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		r_strbuf_appendf (&op->esil, "%s,%s,|,0xffffffff,^,%s,=", R_REG (rs), R_REG (rt), R_REG (rd));
 		break;
 	case MIPS_INS_SLT:
-		r_strbuf_appendf (&op->esil, "%s,%s,<,t,=", R_REG (rs), R_REG (rt));
+		r_strbuf_appendf (&op->esil, "32,%s,~,32,%s,~,<,%s,=", R_REG (rt), R_REG (rs), R_REG (rd));
 		break;
 	case MIPS_INS_SLTI:
-		r_strbuf_appendf (&op->esil, "%s,%s,<,%s,=", I_REG (imm), I_REG (rs), I_REG (rt));
+		r_strbuf_appendf (&op->esil, "32,%s,~,32,%s,~,<,%s,=", I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_SLTU:
-		r_strbuf_appendf (&op->esil, "%s,0xffffffff,&,%s,0xffffffff,&,<,t,=",
-			R_REG (rs), R_REG (rt));
+		r_strbuf_appendf (&op->esil, "%s,0xffffffff,&,%s,0xffffffff,&,<,%s,=",
+			R_REG (rt), R_REG (rs), R_REG (rd));
 		break;
 	case MIPS_INS_SLTIU:
 		r_strbuf_appendf (&op->esil, "%s,0xffffffff,&,%s,0xffffffff,&,<,%s,=",

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -1802,3 +1802,61 @@ EXPECT=<<EOF
 0xfa4 = write (1, "Hello, world!.", 15)
 EOF
 RUN
+
+NAME=mips.gnu slt signed vs sltu unsigned
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 2a402a01
+ar t1=0xffffffff
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 2b402a01
+ar t1=0xffffffff
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 2a402a01
+ar t1=5
+ar t2=3
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+0x00000000
+EOF
+RUN
+
+NAME=mips.gnu slti signed vs sltiu unsigned
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 01002829
+ar t1=0xffffffff
+ar pc=0
+s 0
+aes
+ar t0
+wx 0500282d
+ar t1=3
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

slt/sltu wrote a scratch t register with reversed operands instead of rd — the destination was never updated. slt/slti also compared without sign-extending the 32-bit operands, so signed comparisons were wrong for negative values. Write rd/rt with rs < rt ordering and sign-extend to 64 bits for the signed forms; the unsigned sltu/sltiu keep their 0xffffffff masking. Tested against the Unicorn oracle.
