### PR TITLE
Fix #26262 - backward pdi/pdj drift when the window contains invalid instructions ##disasm

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -605,7 +605,9 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		return NULL;
 	}
 
-	for (idx = addrbytes; idx < len; idx += addrbytes) {
+	bool found = false;
+	// <= so the full window is tried; len is clamped to addr near file start
+	for (idx = addrbytes; idx <= len; idx += addrbytes) {
 		if (r_cons_is_breaked (core->cons)) {
 			break;
 		}
@@ -628,8 +630,14 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		}
 		r_asm_code_free (c);
 		if (numinstr >= n || idx > 16 * n) { // assume average instruction length <= 16
+			found = true;
 			break;
 		}
+	}
+	if (!found) {
+		// no window ending at addr disassembles cleanly; an empty list beats far-away hits
+		free (buf);
+		return hits;
 	}
 
 	ut64 at = addr - (idx / addrbytes);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7776,24 +7776,26 @@ static bool handle_backwards_disasm(RCore *core, int *nb_opcodes, int *nb_bytes)
 	if (!*nb_bytes) {
 		*nb_bytes = core->blocksize;
 		if (*nb_opcodes < 0) {
-			/* Backward disassembly of nb_opcodes opcodes
-			 * - We compute the new starting offset
-			 * - Read at the new offset */
 			*nb_opcodes = -*nb_opcodes;
+			if (*nb_opcodes > 0xffff) {
+				R_LOG_ERROR ("Too many backward instructions");
+				return false;
+			}
 
 			const ut64 old_offset = core->addr;
 			int nbytes = 0;
 
-			// We have some anal_info.
-			if (r_core_prevop_addr (core, core->addr, *nb_opcodes, &core->addr)) {
+			// same backward walk as pd, so all backward disasm commands agree
+			core->addr = r_core_prevop_addr_force (core, old_offset, *nb_opcodes);
+			if (core->addr < old_offset) {
 				nbytes = old_offset - core->addr;
-			} else {
-				// core->addr is modified by r_core_prevop_addr
-				core->addr = old_offset;
-				r_core_asm_bwdis_len (core, &nbytes, &core->addr, *nb_opcodes);
 			}
 			if (nbytes > core->blocksize) {
 				r_core_block_size (core, nbytes);
+				if (nbytes > core->blocksize) {
+					R_LOG_ERROR ("Cannot read that much!");
+					return false;
+				}
 			}
 			if (nbytes < 1) {
 				return false;
@@ -7865,17 +7867,17 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 				R_LOG_ERROR ("Too many backward instructions");
 				return false;
 			}
-			int nbytes = 0;
-			if (r_core_prevop_addr (core, core->addr, nb_opcodes, &addr)) {
-				nbytes = old_offset - addr;
-			} else {
-				// r_core_prevop_addr sets addr to UT64_MAX on failure
-				addr = old_offset;
-				if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
-					pj_end (pj);
-					return false;
+			// same backward walk as pd, one op at a time so the window fits in buf
+			addr = old_offset;
+			int bw;
+			for (bw = 0; bw < nb_opcodes; bw++) {
+				const ut64 prev = r_core_prevop_addr_force (core, addr, 1);
+				if (prev >= addr || old_offset - prev > (ut64)nb_bytes) {
+					break;
 				}
+				addr = prev;
 			}
+			const int nbytes = old_offset - addr;
 			if (nbytes < 1) {
 				pj_end (pj);
 				return false;

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -355,3 +355,26 @@ EXPECT=<<EOF
 0x00000004             e50300aa  mov x5, x0
 EOF
 RUN
+
+NAME=pdi negative count with invalid instruction in window
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+wx ffffffff @ 0x24
+s 0x40
+pdi -9
+EOF
+EXPECT=<<EOF
+0x0000001c             1f2003d5  nop
+0x00000020             1f2003d5  nop
+0x00000024             ffffffff  invalid
+0x00000028             1f2003d5  nop
+0x0000002c             1f2003d5  nop
+0x00000030             1f2003d5  nop
+0x00000034             1f2003d5  nop
+0x00000038             1f2003d5  nop
+0x0000003c             1f2003d5  nop
+EOF
+RUN

--- a/test/db/cmd/cmd_pdj
+++ b/test/db/cmd/cmd_pdj
@@ -63,3 +63,24 @@ mov x30, 0
 mov x5, x0
 EOF
 RUN
+
+NAME=pdj negative count with invalid instruction in window
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+wx ffffffff @ 0x24
+s 0x40
+pdj -9~{[0].addr}
+pdj -9~{[2].opcode}
+pdj -9~{[2].size}
+pdj -9~{[8].addr}
+EOF
+EXPECT=<<EOF
+28
+invalid
+4
+60
+EOF
+RUN

--- a/test/db/cmd/cmd_pi
+++ b/test/db/cmd/cmd_pi
@@ -24,9 +24,9 @@ mov rdx, rsp
 and rsp, 0xfffffffffffffff0
 mov rdx, rsp
 and rsp, 0xfffffffffffffff0
-mov ecx, edx
+mov r9, rdx
 pop rsi
-mov ecx, edx
+mov r9, rdx
 pop rsi
 EOF
 RUN

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -502,7 +502,7 @@ wx b8010000004839ca7f00
 pi -3 @ 10
 EOF
 EXPECT=<<EOF
-add byte [rax], al
+mov eax, 1
 cmp rdx, rcx
 jg 0xa
 EOF
@@ -519,19 +519,20 @@ EOF
 EXPECT=<<EOF
 [
   {
-    "addr": 3,
-    "esil": "al,rax,+=[1],7,$o,of,:=,7,$s,sf,:=,$z,zf,:=,7,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
-    "refptr": 1,
+    "addr": 0,
+    "val": 1,
+    "esil": "1,rax,=",
+    "refptr": 0,
     "fcn_addr": 0,
     "fcn_last": 0,
-    "size": 2,
-    "opcode": "add byte [rax], al",
-    "disasm": "add byte [rax], al",
-    "bytes": "0000",
+    "size": 5,
+    "opcode": "mov eax, 1",
+    "disasm": "mov eax, 1",
+    "bytes": "b801000000",
     "family": "cpu",
-    "type": "add",
+    "type": "mov",
     "reloc": false,
-    "type_num": 17,
+    "type_num": 9,
     "type2_num": 0
   },
   {


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up for the reopened #26262: with an invalid instruction inside the backward window, `pdi -N` / `pdj -N` rejected every candidate window and fell back to disassembling from `addr - blocksize`, returning instructions far from the requested address.
  
- pdi/pdj now compute the backward start with `r_core_prevop_addr_force`, the same walk `pd` uses, so `pdj -8 @ 0x420` returns `[0x400, 0x420)` on aligned archs regardless of instruction validity; pdj walks one op at a time so the window always fits its buffer
- `r_core_asm_bwdisassemble` returns an empty list instead of far-away hits when no window ending at the address disassembles cleanly, and the scan now also tries the full window (off-by-one, mattered near the start of file)
- pdi caps backward counts at 0xffff like pdj, and verifies the block was actually grown before reading into it
- tests: new invalid-instruction-in-window cases for pdi/pdj; updated three goldens that encoded the old fallback's misaligned decodes
    
