### PR TITLE
Fix PPC mfspr/mtspr decoding, stwu/stdu stack detection and vle archinfo ##arch

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -899,11 +899,10 @@ static void set_ca(RAnalOp *op, const char *ra, const char *wm, bool sub, const 
 }
 
 static const char* getspr(PluginData *pd, struct Getarg *gop, int n) {
-	ut32 spr = 0;
 	if (n < 0 || n >= 8) {
 		return NULL;
 	}
-	spr = getarg (gop, 0);
+	const ut32 spr = getarg (gop, n);
 	switch (spr) {
 	case SPR_HID0:
 		return "hid0";
@@ -1436,9 +1435,9 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,%s,=[4],%s=", ARG (0), op1, op1);
-			if (strstr (op1, "r1")) {
+			if (INSOP (1).type == PPC_OP_MEM && INSOP (1).mem.base == PPC_REG_R1) {
 				op->stackop = R_ANAL_STACK_INC;
-				op->stackptr = -atoi (op1);
+				op->stackptr = -INSOP (1).mem.disp;
 			}
 			set_toc_ptr (op, pd, insn, stateful);
 			break;
@@ -1494,6 +1493,10 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				break;
 			}
 			esilprintf (op, "%s,%s,=[8],%s=", ARG (0), op1, op1);
+			if (INSOP (1).type == PPC_OP_MEM && INSOP (1).mem.base == PPC_REG_R1) {
+				op->stackop = R_ANAL_STACK_INC;
+				op->stackptr = -INSOP (1).mem.disp;
+			}
 			set_toc_ptr (op, pd, insn, stateful);
 			break;
 		case PPC_INS_LBZU:
@@ -2515,6 +2518,22 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		} else if (m0 == 'f') {
 			op->family = R_ANAL_OP_FAMILY_FPU;
 		}
+		if (op->type == R_ANAL_OP_TYPE_NULL && m0 == 'm') {
+			// capstone v5 emits per-spr alias ids for these, never PPC_INS_MFSPR/MTSPR
+			if (!strcmp (insn->mnemonic, "mfspr")) {
+				op->type = R_ANAL_OP_TYPE_MOV;
+				esilprintf (op, "%s,%s,=", PPCSPR (1), ARG (0));
+			} else if (!strcmp (insn->mnemonic, "mtspr")) {
+				op->type = R_ANAL_OP_TYPE_MOV;
+				esilprintf (op, "%s,%s,=", ARG (1), PPCSPR (0));
+			} else if (!strcmp (insn->mnemonic, "mfxer")) {
+				op->type = R_ANAL_OP_TYPE_MOV;
+				esilprintf (op, "xer,%s,=", ARG (0));
+			} else if (!strcmp (insn->mnemonic, "mtxer")) {
+				op->type = R_ANAL_OP_TYPE_MOV;
+				esilprintf (op, "%s,xer,=", ARG (0));
+			}
+		}
 		if (mask & R_ARCH_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);
 		}
@@ -2531,7 +2550,8 @@ static int archinfo(RArchSession *as, ut32 q) {
 	}
 	const char *cpu = as->config->cpu;
 	if (cpu && !strncmp (cpu, "vle", 3)) {
-		return 2;
+		// vle mixes 2-byte se_* and 4-byte e_* forms
+		return (q == R_ARCH_INFO_MAXOP_SIZE)? 4: 2;
 	}
 	return 4;
 }

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1413,3 +1413,71 @@ EXPECT=<<EOF
 268501000
 EOF
 RUN
+
+NAME=ppc generic mfspr mtspr and xer moves decode as mov with esil
+FILE=malloc://32
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7c7042a67c7043a67c6102a67c6103a6
+aoj 4~{0.type}
+aoj 4~{0.esil}
+aoj 4~{1.type}
+aoj 4~{1.esil}
+aoj 4~{2.type}
+aoj 4~{2.esil}
+aoj 4~{3.type}
+aoj 4~{3.esil}
+EOF
+EXPECT=<<EOF
+mov
+spr_272,r3,=
+mov
+r3,spr_272,=
+mov
+xer,r3,=
+mov
+r3,xer,=
+EOF
+RUN
+
+NAME=ppc stwu stack tracking only for r1 base
+FILE=malloc://16
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 9421fff894aafff8
+ao 2~stack
+EOF
+EXPECT=<<EOF
+stackop: inc
+stackptr: 8
+EOF
+RUN
+
+NAME=ppc stdu stack tracking only for r1 base
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx f821ff91f8aaff91
+ao 2~stack
+EOF
+EXPECT=<<EOF
+stackop: inc
+stackptr: 112
+EOF
+RUN
+
+NAME=ppc vle archinfo reports 2-byte min and 4-byte max op size
+FILE=malloc://16
+ARGS=-a ppc -b 32
+CMDS=<<EOF
+e asm.cpu=vle
+aia
+EOF
+EXPECT=<<EOF
+minopsz 2
+maxopsz 4
+invopsz 2
+dtalign 2
+codealign 2
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three fixes in the capstone PPC analysis plugin:

- Generic mfspr/mtspr decode as type null with no ESIL on capstone v5, which routes every generic form through per-SPR alias ids instead of PPC_INS_MFSPR/MTSPR. Route them by mnemonic in the post-switch catch (same pattern as the trap mnemonics), and fix getspr() ignoring its operand index — the mfspr case would have read the destination register id as the SPR number. mfxer/mtxer were type-null for the same reason and now emit xer ESIL.
- stwu stack detection substring-matched "r1" against the rendered ESIL, so any base in r10-r19 produced phantom stackop/stackptr. Match the capstone operand base register instead, and give stdu (the ppc64 prologue form) the same stack tracking it was missing entirely.
- archinfo returned 2 for every query under vle; e_* forms are 4 bytes, so MAXOP now reports 4 (min/align stay 2).
