### PR TITLE
Add arm64 BICS ESIL and type BIC as AND ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1596,6 +1596,7 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	case ARM64_INS_ANDS:
 		OPCALL_FLAGS ("&", 'l');
 		break;
+	case ARM64_INS_BICS:
 	case ARM64_INS_NANDS:
 		OPCALL_NEG_FLAGS ("&", 'l');
 		break;
@@ -2289,24 +2290,8 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		break;
 	}
 	case ARM64_INS_BIC:
-	if (OPCOUNT64 () == 2) {
-		if (REGSIZE64 (0) == 4) {
-			r_strbuf_appendf (&op->esil, "%s,0xffffffff,^,%s,&=",
-					REG64 (1), REG64 (0));
-		} else {
-			r_strbuf_appendf (&op->esil, "%s,0xffffffffffffffff,^,%s,&=",
-					REG64 (1), REG64 (0));
-		}
-	} else {
-		if (REGSIZE64 (0) == 4) {
-			r_strbuf_appendf (&op->esil, "%s,0xffffffff,^,%s,&,%s,=",
-					REG64 (2), REG64 (1), REG64 (0));
-		} else {
-			r_strbuf_appendf (&op->esil, "%s,0xffffffffffffffff,^,%s,&,%s,=",
-					REG64 (2), REG64 (1), REG64 (0));
-		}
-	}
-	break;
+		OPCALL_NEG ("&");
+		break;
 	case ARM64_INS_CBZ:
 		r_strbuf_setf (&op->esil, "%s,!,?{,%"PFMT64d",pc,:=,}",
 				REG64 (0), IMM64 (1));
@@ -3751,7 +3736,6 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 	case ARM64_INS_BFI:
 	case ARM64_INS_SBFIZ:
 	case ARM64_INS_UBFIZ:
-	case ARM64_INS_BIC:
 	case ARM64_INS_BFXIL:
 		op->type = R_ANAL_OP_TYPE_MOV;
 		if (ISIMM64 (1)) {
@@ -3847,6 +3831,7 @@ static void anop64(csh handle, RAnalOp *op, cs_insn *insn) {
 		op->type = R_ANAL_OP_TYPE_ROR;
 		break;
 	case ARM64_INS_AND:
+	case ARM64_INS_BIC:
 #if CS_API_MAJOR > 4
 	case ARM64_INS_ANDS:
 	case ARM64_INS_BICS:

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56358,3 +56358,15 @@ and
 and
 EOF
 RUN
+
+NAME=arm64 bic types as and
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000228a
+ao 1~type[1]
+EOF
+EXPECT=<<EOF
+and
+EOF
+RUN

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1648,3 +1648,48 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=arm64 bics computes and-not result and nz flags with cv cleared
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 200022ea
+ar x1=0xff00ff00ff00ff00
+ar x2=0x0f0f0f0f0f0f0f0f
+ar cf=1
+ar vf=1
+ar pc=0
+aes
+ar x0
+ar nf
+ar zf
+ar cf
+ar vf
+wx 200022ea
+ar x1=0x0f0f
+ar x2=0xffff
+ar pc=0
+aes
+ar x0
+ar zf
+wx 2000226a
+ar x1=0xffffffff
+ar x2=0x7fffffff
+ar pc=0
+aes
+ar w0
+ar nf
+EOF
+EXPECT=<<EOF
+0xf000f000f000f000
+0x00000001
+0x00000000
+0x00000000
+0x00000000
+0x00000000
+0x00000001
+0x80000000
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

BICS had an op type (from #26283) but no ESIL case, so it emulated as a no-op with no flags written. It now uses the same negate-variant of the ANDS flag machinery (NZ from result, C and V cleared), guarded for capstone v5 where the id exists.

BIC itself was typed as a mov in the bitfield group; it is an and-with-complement, so it moves to the AND type group — this also makes capstone-v4 builds (where BICS decodes as BIC) agree with the v5 type. Its hand-rolled ESIL ignored shift modifiers (bic x0, x1, x2, lsl 4 used the unshifted register) and vector lanes; replaced with the shared helper, which handles both.

Validated against native aarch64 execution (result + NZCV over a 10x10x2 value matrix for bic/bics/ands in both widths, plus flag preservation on plain bic); tests added in db/anal/arm64 and db/esil/arm_64.
