### PR TITLE
Fix arm64 =SN syscall register alias to follow asm.os ##anal

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -424,10 +424,16 @@ R_API bool r_anal_set_triplet(RAnal *anal, const char * R_NULLABLE os, const cha
 R_API bool r_anal_set_os(RAnal *anal, const char *os) {
 	R_RETURN_VAL_IF_FAIL (anal && os, false);
 	const char *old_os = anal->config? anal->config->os: NULL;
-	if (!old_os || strcmp (old_os, os)) {
+	const bool changed = !old_os || strcmp (old_os, os);
+	if (changed) {
 		R_ANAL_PRIV (anal)->types_dirty = true;
 	}
-	return r_anal_set_triplet (anal, os, NULL, -1);
+	const bool res = r_anal_set_triplet (anal, os, NULL, -1);
+	if (res && changed) {
+		// os-dependent register aliases (e.g. arm64 =SN) must follow
+		r_anal_set_reg_profile (anal, NULL);
+	}
+	return res;
 }
 
 R_API bool r_anal_set_bits(RAnal *anal, int bits) {

--- a/libr/arch/p/arm/arm_regprofile.inc.c
+++ b/libr/arch/p/arm/arm_regprofile.inc.c
@@ -27,7 +27,7 @@ static char *regs(RArchSession *as) {
 		"=SF	nf\n"
 		"=OF	vf\n"
 		"=CF	cf\n"
-		"=SN	x16\n" // x8 on linux?
+		"=SN	%s\n" // x8 on linux/android, x16 on darwin
 
 		/* 8bit sub-registers */
 		"fpu	b0	.8	0	0\n"
@@ -644,10 +644,13 @@ static char *regs(RArchSession *as) {
 		"fpu	q15	.128	308	0\n"
 		;
 	}
+	if (as->config->bits != 64) {
+		return strdup (p);
+	}
 	const char *os = as->config->os;
-	if (!os) {
+	if (R_STR_ISEMPTY (os)) {
 		os = R_SYS_OS;
 	}
-	const char *snReg = (!strcmp (os, "android") || !strcmp (os, "linux"))? "x8": "x16";
-	return r_str_newf (p, snReg);
+	const char *snreg = (!strcmp (os, "android") || !strcmp (os, "linux"))? "x8": "x16";
+	return r_str_newf (p, snreg);
 }

--- a/libr/arch/p/arm/plugin_v35.c
+++ b/libr/arch/p/arm/plugin_v35.c
@@ -2687,7 +2687,7 @@ static char *regs(RArchSession *as) {
 		"=SF	nf\n"
 		"=OF	vf\n"
 		"=CF	cf\n"
-		"=SN	x16\n" // x8 on linux?
+		"=SN	%s\n" // x8 on linux/android, x16 on darwin
 
 		/* 8bit sub-registers */
 		"fpu	b0	.8	0	0\n"
@@ -3304,12 +3304,15 @@ static char *regs(RArchSession *as) {
 		"fpu	q15	.128	308	0\n"
 		;
 	}
+	if (as->config->bits != 64) {
+		return strdup (p);
+	}
 	const char *os = as->config->os;
-	if (!os) {
+	if (R_STR_ISEMPTY (os)) {
 		os = R_SYS_OS;
 	}
-	const char *snReg = (!strcmp (os, "android") || !strcmp (os, "linux"))? "x8": "x16";
-	return r_str_newf (p, snReg);
+	const char *snreg = (!strcmp (os, "android") || !strcmp (os, "linux"))? "x8": "x16";
+	return r_str_newf (p, snreg);
 }
 
 #if 0

--- a/libr/core/cmd_scsearch.inc.c
+++ b/libr/core/cmd_scsearch.inc.c
@@ -1,26 +1,5 @@
 // Private helpers for /as syscall search. Included by cmd_search.inc.c.
 
-static const char *get_syscall_register(RCore *core) {
-	const char *sn = r_reg_alias_getname (core->anal->reg, R_REG_ALIAS_SN);
-	RArchConfig *cfg = R_UNWRAP3 (core, anal, config);
-	const char *arch = cfg? cfg->arch: NULL;
-	if (arch && !strcmp (arch, "arm") && cfg->bits == 64) {
-		const char *os = cfg->os;
-		if (R_STR_ISEMPTY (os)) {
-			os = r_config_get (core->config, "asm.os");
-		}
-		if (R_STR_ISEMPTY (os)) {
-			return sn;
-		}
-		if (!strcmp (os, "linux") || !strcmp (os, "android")) {
-			sn = "x8";
-		} else if (!strcmp (os, "macos")) {
-			sn = "x16";
-		}
-	}
-	return sn;
-}
-
 typedef enum {
 	SYSREG_VAL_UNKNOWN,
 	SYSREG_VAL_CONST,
@@ -860,7 +839,7 @@ static void do_syscall_search(RCore *core, RSearchParameters *param) {
 	SyscallRegMap regmap;
 	SyscallRegState local_state;
 	RVecSyscallFunctionCache fcn_cache;
-	const char *screg = get_syscall_register (core);
+	const char *screg = r_reg_alias_getname (core->anal->reg, R_REG_ALIAS_SN);
 	ut8 *buf = malloc (bsize);
 
 	if (!buf) {

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56370,3 +56370,17 @@ EXPECT=<<EOF
 and
 EOF
 RUN
+
+NAME=arm64 syscall number register follows asm.os
+FILE=malloc://64
+ARGS=-a arm -b 64 -e asm.os=linux
+CMDS=<<EOF
+arp~=SN
+e asm.os=macos
+arp~=SN
+EOF
+EXPECT=<<EOF
+=SN	x8
+=SN	x16
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The arm64 register profile computed the right syscall-number register (x8 for linux/android, x16 otherwise) and passed it to r_str_newf (profile, snReg) — but the profile string said "=SN x16" with no %s placeholder, so the substitution silently never happened and linux binaries kept the darwin register. Same latent pattern in the v35 plugin's copy of the profile.

- Put the %s in both 64-bit profiles; the 32-bit path returns a plain strdup since its string has no placeholder.
- r_anal_set_os now refreshes the register profile when the os actually changes (mirroring r_anal_set_bits), so a runtime asm.os change moves the alias along with the syscall database instead of leaving them inconsistent.
- /as had grown an os-sniffing workaround (get_syscall_register) to paper over the unreliable alias — deleted; its existing arm64/arm32 goldens now pass through the plain =SN lookup. The ESIL syscall annotation path used the raw alias with no workaround, so arm64 linux emulation was resolving syscalls via x16 and is fixed by this.