### PR TITLE
Fix mips.gnu add/mult decode fallthrough and add missing hi/lo registers ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -1167,6 +1167,12 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_MULT:
+		// signed: sign-extend both operands so hi holds the signed high word
+		r_strbuf_appendf (&op->esil, ES_W ("32,%s,~,32,%s,~,*") ",lo,=", R_REG (rs), R_REG (rt));
+		ES_SIGN32_64 ("lo");
+		r_strbuf_appendf (&op->esil, ES_W ("32,32,%s,~,32,%s,~,*,>>") ",hi,=", R_REG (rs), R_REG (rt));
+		ES_SIGN32_64 ("hi");
+		break;
 	case MIPS_INS_MULTU:
 		r_strbuf_appendf (&op->esil, ES_W ("%s,%s,*") ",lo,=", R_REG (rs), R_REG (rt));
 		ES_SIGN32_64 ("lo");
@@ -1448,6 +1454,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case 24: // mult
 			insn.id = MIPS_INS_MULT;
+			op->type = R_ANAL_OP_TYPE_MUL;
+			break;
 		case 25: // multu
 			insn.id = MIPS_INS_MULTU;
 			op->type = R_ANAL_OP_TYPE_MUL;
@@ -1459,7 +1467,9 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case 32: // add
 			insn.id = MIPS_INS_ADD;
-		case 33: // addu	//TODO:表明位数
+			op->type = R_ANAL_OP_TYPE_ADD;
+			break;
+		case 33: // addu
 			insn.id = MIPS_INS_ADDU;
 			op->type = R_ANAL_OP_TYPE_ADD;
 			break;
@@ -2039,6 +2049,8 @@ static char *regs(RArchSession *as) {
 		"gpr	sp	.64	232	0\n"
 		"gpr	fp	.64	240	0\n"
 		"gpr	ra	.64	248	0\n"
+		"gpr	hi	.64	256	0\n"
+		"gpr	lo	.64	264	0\n"
 		/* extra */
 		"gpr	pc	.64	272	0\n";
 	return strdup (p);

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -1911,3 +1911,45 @@ EXPECT=<<EOF
 sar
 EOF
 RUN
+
+NAME=mips.gnu mult signed hi and add overflow decode with hi lo registers
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 18000901
+ar t0=0xffffffff
+ar t1=2
+ar pc=0
+aes
+ar hi
+ar lo
+wx 19000901
+ar t0=0xffffffff
+ar t1=2
+ar pc=0
+aes
+ar hi
+ar lo
+wx 20108500
+ao 1~mnemonic
+ar a0=5
+ar a1=3
+ar pc=0
+aes
+ar v0
+wx 12480000
+ar pc=0
+aes
+ar t1
+EOF
+EXPECT=<<EOF
+0xffffffff
+0xfffffffe
+0x00000001
+0xfffffffe
+mnemonic: add
+0x00000008
+0xfffffffe
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The R-type function-code switch fell through case 32 (add) into 33 (addu) and case 24 (mult) into 25 (multu), overwriting insn.id — so add lost its signed overflow-trap ESIL (dead code) and mult was emulated with multu's unsigned product (wrong HI for negative operands, same bug as the recently fixed capstone plugin; the ESIL now mirrors that shape).

Fixing those exposed that the mips.gnu register profile had no hi/lo registers at all, so mult/multu/mfhi/mflo/mthi/mtlo emulated as silent no-ops; they now occupy the free slots between ra and pc.

Validated against Unicorn (mips-gnu differential suite extended with mult/multu/add, 9/9) plus tests in db/esil/mips_32. 