### PR TITLE
Fix x86 rip-relative ptr for zero-displacement destination operands ##arch

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2973,13 +2973,12 @@ static void op0_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 	switch (INSOP (0).type) {
 	case X86_OP_MEM:
 		op->cycles = CYCLE_MEM;
-		op->disp = INSOP (0).mem.disp;
-		if (!op->disp) {
-			op->disp = UT64_MAX;
-		}
+		// keep the real displacement for rip math; op->disp uses UT64_MAX as the no-disp sentinel
+		const st64 disp = INSOP (0).mem.disp;
+		op->disp = disp? (ut64)disp: UT64_MAX;
 		op->refptr = INSOP (0).size;
 		if (INSOP (0).mem.base == X86_REG_RIP) {
-			op->ptr = addr + insn->size + op->disp;
+			op->ptr = addr + insn->size + disp;
 		} else if (INSOP (0).mem.base == X86_REG_RBP || INSOP (0).mem.base == X86_REG_EBP) {
 			op->type |= R_ANAL_OP_TYPE_REG;
 			op->stackop = R_ANAL_STACK_SET;

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -4311,3 +4311,24 @@ EXPECT=<<EOF2
 |           0x00000010      c744242803..   mov dword [arr[2]], 3
 EOF2
 RUN
+
+NAME=rip-relative destination operand ptr with zero displacement
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 48ff0500000000
+ao 1~^ptr
+wx 48f71d00000000
+ao 1~^ptr
+wx 488b0500000000
+ao 1~^ptr
+wx 48ff0508000000
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x00000007
+ptr: 0x00000007
+ptr: 0x00000007
+ptr: 0x0000000f
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

op0_memimmhandle() replaces op->disp with the UT64_MAX no-displacement sentinel before computing the rip-relative target, so every zero-disp rip-relative destination operand (inc/neg/not/rol/... qword [rip]) got ptr = addr + size - 1 — one byte short, pointing into the instruction itself and producing wrong data xrefs. The op1 path (mov reg, [rip]) reads the operand displacement directly and was always correct.

Capture the real displacement in a local for the rip math; op->disp keeps its sentinel semantics for the other branches. Tests in db/anal/x86_64 cover inc/neg [rip] against the mov control and a non-zero displacement. No r2r regressions.
