### PR TITLE
Set cr0 on PPC record-form instructions and fix sraw/srawi word sign extension in ESIL ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -875,8 +875,15 @@ static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 static void set_sra(RAnalOp *op, const char *rd, const char *rs, const char *cnt, bool w64, const char *mask) {
 	const char *sgn = w64? "0x8000000000000000": "0x80000000";
 	const char *lo = w64? "0xffffffffffffffff": "0xffffffff";
+	char sx[48];
+	const char *v = rs;
+	if (!w64) {
+		// the word forms shift the sign-extended low word, not the raw 64-bit register
+		snprintf (sx, sizeof (sx), "32,%s,~", rs);
+		v = sx;
+	}
 	esilprintf (op, "%s,%s,&,!,!,%s,%s,&,%s,&,!,!,&,ca,=,%s,%s,ASR,%s,=",
-		sgn, rs, mask, rs, lo, cnt, rs, rd);
+		sgn, rs, mask, rs, lo, cnt, v, rd);
 }
 
 // ca = (val <unsigned a) | (cin & val==a), then store val into rd LAST so the carry stays
@@ -2533,6 +2540,19 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				op->type = R_ANAL_OP_TYPE_MOV;
 				esilprintf (op, "%s,xer,=", ARG (0));
 			}
+		}
+		if (insn->detail->ppc.update_cr0 && !r_strbuf_is_empty (&op->esil)
+				&& (op->type & R_ANAL_OP_TYPE_MASK) != R_ANAL_OP_TYPE_STORE
+				&& INSOP (0).type == PPC_OP_REG
+				&& INSOP (0).reg >= PPC_REG_R0 && INSOP (0).reg <= PPC_REG_R31) {
+			// Rc=1: cr0 from the result signed-compared to zero; SO not modelled (as in cmp)
+			char sx[48];
+			const char *rd = ARG (0);
+			if (as->config->bits == 32) {
+				snprintf (sx, sizeof (sx), "32,%s,~", rd);
+				rd = sx;
+			}
+			r_strbuf_appendf (&op->esil, ",0x80,0,%s,<,*,%s,0,<,+,cr0,=", rd, rd);
 		}
 		if (mask & R_ARCH_OP_MASK_VAL) {
 			op_fillval (op, handle, insn);

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1481,3 +1481,89 @@ dtalign 2
 codealign 2
 EOF
 RUN
+
+NAME=ppc record forms append cr0 esil and plain forms do not
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7c8532147c85321570a400017c80292d
+aoj 4~{0.esil}
+aoj 4~{1.esil}
+aoj 4~{2.esil}
+aoj 4~{3.esil}
+EOF
+EXPECT=<<EOF
+r6,r5,+,r4,=
+r6,r5,+,r4,=,0x80,0,r4,<,*,r4,0,<,+,cr0,=
+0x1,r5,&,r4,=,0x80,0,r4,<,*,r4,0,<,+,cr0,=
+r4,r5,=[4]
+EOF
+RUN
+
+NAME=ppc record form cr0 result drives a following branch
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 2c2500007c863a154182000839000001 @ 0
+wx 38e00007 @ 16
+aei
+aeim
+ar r5=5
+ar r6=1
+ar r7=0xffffffffffffffff
+aes
+aes
+aes
+aes
+ar cr0
+ar r7
+ar r8
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000007
+0x00000000
+EOF
+RUN
+
+NAME=ppc32 record form cr0 compares the word result
+FILE=malloc://16
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 34850001
+aoj 1~{0.esil}
+aei
+aeim
+ar r5=0x7fffffff
+aes
+ar r4
+ar cr0
+EOF
+EXPECT=<<EOF
+0x8000000000000000,r5,^,0x8000000000000000,0x1,r5,+,0xffffffff,&,^,<,0x1,r5,+,r4,=,ca,=,0x80,0,32,r4,~,<,*,32,r4,~,0,<,+,cr0,=
+0x80000000
+0x00000080
+EOF
+RUN
+
+NAME=ppc srawi shifts the sign-extended low word
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7ca41e71
+aoj 1~{0.esil}
+aei
+aeim
+ar r5=0x8000000f
+aes
+ar r4
+ar ca
+ar cr0
+EOF
+EXPECT=<<EOF
+0x80000000,r5,&,!,!,0x7,r5,&,0xffffffff,&,!,!,&,ca,=,0x3,32,r5,~,ASR,r4,=,0x80,0,r4,<,*,r4,0,<,+,cr0,=
+0xfffffffff0000001
+0x00000001
+0x00000080
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ESIL only sets cr0 for `cmp`, so record-form (Rc=1) instructions leave stale flags and an emulated conditional branch right after `addic.`/`add.`/`and.`/… tests the wrong cr0.

- Append the cr0 side effect (same lossless flag byte as cmp, word-sized on 32-bit) after decode for any instruction capstone marks `update_cr0`, with a GPR-destination gate so FP/vector dot forms (CR1/CR6) and `stwcx.`/`stdcx.` (reservation-dependent CR0) stay untouched.
- Fix `sraw`/`srawi` to shift the sign-extended low word instead of the raw 64-bit register (`srawi` of `0x8000000f` by 3 returned `0x10000001` instead of `0xfffffffff0000001`); exposed by the new tests.

Validated differentially against qemu-ppc64 (record form + branch witness for every predicate, 539/539) and with new tests in `test/db/anal/ppc`.