### PR TITLE
Fix #26294 - Search stops on 0xffffffff data when io.cache is enabled ##io

### DIFF
--- a/libr/io/io_cache.c
+++ b/libr/io/io_cache.c
@@ -278,10 +278,9 @@ R_API bool r_io_cache_readable(RIO *io) {
 	return (io->cache.mode & mode) == mode;
 }
 
-// used only by the testsuite
 R_API bool r_io_cache_at(RIO *io, ut64 addr) {
 	R_RETURN_VAL_IF_FAIL (io, false);
-	RInterval itv = (RInterval){addr, 0};
+	RInterval itv = (RInterval){addr, 1};
 	RIOCacheLayer *layer;
 	RListIter *liter;
 	r_list_foreach (io->cache.layers, liter, layer) {

--- a/libr/io/ioutils.c
+++ b/libr/io/ioutils.c
@@ -15,22 +15,12 @@ R_API bool r_io_addr_is_mapped(RIO *io, ut64 vaddr) {
 // when io.va is false it only checks for the desc
 R_API bool r_io_is_valid_offset(RIO* io, ut64 offset, int hasperm) {
 	R_RETURN_VAL_IF_FAIL (io, false);
-	if ((io->cache.mode & R_PERM_X) == R_PERM_X) {
-		// io.cache must be set to true for this codeblock to be executed
-		ut8 word[4] = { 0xff, 0xff, 0xff, 0xff};
-		// TODO: check for (io->cache.mode & R_PERM_S) ?
-		(void)r_io_read_at (io, offset, (ut8*)&word, 4);
-		if (!r_io_cache_read_at (io, offset, (ut8*)&word, 4)) {
-			if (!r_io_read_at (io, offset, (ut8*)&word, 4)) {
-				return false;
-			}
-		}
-		return memcmp (word, "\xff\xff\xff\xff", 4) != 0;
+	// with io.cache, offsets covered by a cache layer are valid even when unmapped
+	if ((io->cache.mode & R_PERM_X) == R_PERM_X && r_io_cache_at (io, offset)) {
+		return true;
 	}
-	if (io->mask) {
-		if (offset > io->mask && hasperm & R_PERM_X) {
-			return false;
-		}
+	if (io->mask && offset > io->mask && (hasperm & R_PERM_X)) {
+		return false;
 	}
 	if (io->va) {
 		if (!hasperm) {

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -410,7 +410,7 @@ EXPECT=<<EOF
         ,=< 0x00005b02      7d0a           jge 0x5b0e                  ; rip=0x5b0e -> 0x8d4890f4 ; likely
        ,==< 0x00005b04      7f08           jg 0x5b0e                   ; rip=0x5b0e -> 0x8d4890f4 ; likely
       ,===< 0x00005b06      eb00           jmp 0x5b08                  ; rip=0x5b08 -> 0xc30a15ff
-      `---> 0x00005b08      ff150ac30100   call qword [reloc.__libc_start_main] ; [0x21e18:8]=0 ; rsp=0xfffffffffffffff8 -> 0x4c457fff ; [0xfffffffffffffff8:8] = 0x5b0e ; rip=0x0
+      `---> 0x00005b08      ff150ac30100   call qword [reloc.__libc_start_main] ; [0x21e18:8]=0 ; rsp=0xfffffffffffffff8 ; [0xfffffffffffffff8:8] = 0x5b0e ; rip=0x0
        ||                                                              ; int __libc_start_main(0, 0, 0, 0, 0, 0, 0)
 EOF
 RUN

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -2029,3 +2029,16 @@ EXPECT=<<EOF
 [{"start":134520588,"end":134520844,"entropy":2.877},{"start":134520844,"end":134521100,"entropy":0.550},{"start":134512640,"end":134512896,"entropy":3.073},{"start":134512896,"end":134513408,"entropy":4.166}]
 EOF
 RUN
+
+NAME=search with io.cache over 0xffffffff data
+FILE=malloc://512
+CMDS=<<EOF
+wx ffffffffffffffff @ 0x100
+w GIF8 @ 0x1f0
+e io.cache=true
+/ GIF8
+EOF
+EXPECT=<<EOF
+0x000001f0 hit0_0 "GIF8"
+EOF
+RUN

--- a/test/db/esil/cmd
+++ b/test/db/esil/cmd
@@ -39,9 +39,7 @@ EXPECT=<<EOF
 type: ill
 its a trap 0x0 0x7
 EOF
-EXPECT_ERR=<<EOF
-ERROR: ESIL stopped at 0x00000000: invalid instruction (invalid)
-EOF
+EXPECT_ERR=
 RUN
 
 NAME=aesu steps over invalid op by default


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With io.cache enabled, r_io_is_valid_offset() treated any offset whose 4 bytes read as 0xffffffff as invalid, and the search loop aborts the whole map on the first invalid offset — so `/ foo` on big ISO/firmware images (which always contain 0xff runs) silently returned truncated or zero results.

Validity is now: covered by a cache layer (r_io_cache_at) or the normal map/desc permission checks. This keeps the intended behavior of executing code written into unmapped memory through the cache, stops rejecting mapped data that legitimately contains 0xffffffff, and avoids 3 reads per probe.

Also fixes r_io_cache_at() using a zero-size interval for its point query, which never matched a cache item starting exactly at the queried address.

Adds a regression test; updates two tests that pinned the old heuristic (behavior now matches the non-cached equivalents).