### PR TITLE
Fix backward pdi/pdj drift and unify the pd/pi/pdj backward walk ##disasm

### DIFF
--- a/libr/core/casm.c
+++ b/libr/core/casm.c
@@ -605,7 +605,9 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		return NULL;
 	}
 
-	for (idx = addrbytes; idx < len; idx += addrbytes) {
+	bool found = false;
+	// <= so the full window is tried; len is clamped to addr near file start
+	for (idx = addrbytes; idx <= len; idx += addrbytes) {
 		if (r_cons_is_breaked (core->cons)) {
 			break;
 		}
@@ -628,8 +630,14 @@ R_API RList *r_core_asm_bwdisassemble(RCore *core, ut64 addr, int n, int len) {
 		}
 		r_asm_code_free (c);
 		if (numinstr >= n || idx > 16 * n) { // assume average instruction length <= 16
+			found = true;
 			break;
 		}
+	}
+	if (!found) {
+		// no window ending at addr disassembles cleanly; an empty list beats far-away hits
+		free (buf);
+		return hits;
 	}
 
 	ut64 at = addr - (idx / addrbytes);

--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -1714,14 +1714,30 @@ static void cmd_pDj(RCore *core, const char *arg) {
 
 static void cmd_pdj(RCore *core, const char *arg, ut8 *block) {
 	int nblines = r_num_math (core->num, arg);
+	ut8 *buf = block;
+	ut8 *mybuf = NULL;
+	int buflen = core->blocksize;
+	if (nblines < 0 && nblines > -0xffff) {
+		// backward window can be larger than the block, like pd/pdi grow it
+		const int maxopsz = R_MAX (1, r_arch_info (core->anal->arch, R_ARCH_INFO_MAXOP_SIZE));
+		const int needed = -nblines * maxopsz;
+		if (needed > buflen) {
+			mybuf = malloc (needed);
+			if (mybuf) {
+				buf = mybuf;
+				buflen = needed;
+			}
+		}
+	}
 	PJ *pj = r_core_pj_new (core);
 	if (pj) {
 		pj_a (pj);
-		r_core_print_disasm_json_ipi (core, core->addr, block, core->blocksize, nblines, pj, NULL);
+		r_core_print_disasm_json_ipi (core, core->addr, buf, buflen, nblines, pj, NULL);
 		pj_end (pj);
 		r_cons_println (core->cons, pj_string (pj));
 		pj_free (pj);
 	}
+	free (mybuf);
 }
 
 static bool cmd_p_minus_entropy_count(RCore *core, ut64 from, ut64 to, ut64 *count, ut64 *total) {
@@ -7898,10 +7914,7 @@ static int cmd_pd(RCore *core, const char *input, int len, int l, ut8 *block) {
 					int dislen = r_core_print_disasm (core, addr - l, block1, l, l, 0, NULL, true, formatted_json, NULL, NULL);
 					r_core_return_value (core, dislen);
 				} else { // pd
-					if (!r_core_prevop_addr (core, core->addr, l, &start)) {
-						// anal ignorance.
-						start = r_core_prevop_addr_force (core, core->addr, l);
-					}
+					start = r_core_prevop_addr_force (core, core->addr, l);
 					int instr_len = core->addr - start;
 					ut64 prevaddr = core->addr;
 					int bs = core->blocksize;

--- a/libr/core/cmd_search.inc.c
+++ b/libr/core/cmd_search.inc.c
@@ -4403,6 +4403,10 @@ reread:
 				  addr = UT64_MAX;
 				  (void)r_core_asm_bwdis_len (core, NULL, &addr, n);
 			  }
+			  if (addr == UT64_MAX) {
+				  // no window disassembles cleanly, fall back to the same walk as pd
+				  addr = r_core_prevop_addr_force (core, core->addr, n);
+			  }
 			  if (param.outmode == R_MODE_JSON) {
 				  r_cons_printf (core->cons, "[%"PFMT64u "]", addr);
 			  } else {

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7940,6 +7940,10 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 			if (j >= nb_opcodes) {
 				break;
 			}
+			if (!dis_opcodes && i >= nb_bytes) {
+				// backward mode never refills buf, stop at its end
+				break;
+			}
 		} else if (i >= nb_bytes) {
 			break;
 		}

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7776,24 +7776,26 @@ static bool handle_backwards_disasm(RCore *core, int *nb_opcodes, int *nb_bytes)
 	if (!*nb_bytes) {
 		*nb_bytes = core->blocksize;
 		if (*nb_opcodes < 0) {
-			/* Backward disassembly of nb_opcodes opcodes
-			 * - We compute the new starting offset
-			 * - Read at the new offset */
 			*nb_opcodes = -*nb_opcodes;
+			if (*nb_opcodes > 0xffff) {
+				R_LOG_ERROR ("Too many backward instructions");
+				return false;
+			}
 
 			const ut64 old_offset = core->addr;
 			int nbytes = 0;
 
-			// We have some anal_info.
-			if (r_core_prevop_addr (core, core->addr, *nb_opcodes, &core->addr)) {
+			// same backward walk as pd, so all backward disasm commands agree
+			core->addr = r_core_prevop_addr_force (core, old_offset, *nb_opcodes);
+			if (core->addr < old_offset) {
 				nbytes = old_offset - core->addr;
-			} else {
-				// core->addr is modified by r_core_prevop_addr
-				core->addr = old_offset;
-				r_core_asm_bwdis_len (core, &nbytes, &core->addr, *nb_opcodes);
 			}
 			if (nbytes > core->blocksize) {
 				r_core_block_size (core, nbytes);
+				if (nbytes > core->blocksize) {
+					R_LOG_ERROR ("Cannot read that much!");
+					return false;
+				}
 			}
 			if (nbytes < 1) {
 				return false;
@@ -7865,17 +7867,17 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 				R_LOG_ERROR ("Too many backward instructions");
 				return false;
 			}
-			int nbytes = 0;
-			if (r_core_prevop_addr (core, core->addr, nb_opcodes, &addr)) {
-				nbytes = old_offset - addr;
-			} else {
-				// r_core_prevop_addr sets addr to UT64_MAX on failure
-				addr = old_offset;
-				if (!r_core_asm_bwdis_len (core, &nbytes, &addr, nb_opcodes)) {
-					pj_end (pj);
-					return false;
+			// same backward walk as pd, one op at a time so the window fits in buf
+			addr = old_offset;
+			int bw;
+			for (bw = 0; bw < nb_opcodes; bw++) {
+				const ut64 prev = r_core_prevop_addr_force (core, addr, 1);
+				if (prev >= addr || old_offset - prev > (ut64)nb_bytes) {
+					break;
 				}
+				addr = prev;
 			}
+			const int nbytes = old_offset - addr;
 			if (nbytes < 1) {
 				pj_end (pj);
 				return false;

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7769,6 +7769,13 @@ toro:
 	return len;
 }
 
+// bb-aware start of the window of nb_opcodes instructions ending at `from`; *nbytes is the span (0 at the map start)
+static ut64 bwdisasm_window(RCore *core, ut64 from, int nb_opcodes, int *nbytes) {
+	const ut64 start = r_core_prevop_addr_force (core, from, nb_opcodes);
+	*nbytes = (start < from)? (int)(from - start): 0;
+	return start;
+}
+
 static bool handle_backwards_disasm(RCore *core, int *nb_opcodes, int *nb_bytes) {
 	if (!*nb_opcodes && !*nb_bytes) {
 		return false;
@@ -7786,9 +7793,11 @@ static bool handle_backwards_disasm(RCore *core, int *nb_opcodes, int *nb_bytes)
 			int nbytes = 0;
 
 			// same backward walk as pd, so all backward disasm commands agree
-			core->addr = r_core_prevop_addr_force (core, old_offset, *nb_opcodes);
-			if (core->addr < old_offset) {
-				nbytes = old_offset - core->addr;
+			core->addr = bwdisasm_window (core, old_offset, *nb_opcodes, &nbytes);
+			if (nbytes < 1) {
+				// nothing before the cursor (map start): show the window forward, like pd
+				core->addr = old_offset;
+				nbytes = core->blocksize;
 			}
 			if (nbytes > core->blocksize) {
 				r_core_block_size (core, nbytes);
@@ -7796,9 +7805,6 @@ static bool handle_backwards_disasm(RCore *core, int *nb_opcodes, int *nb_bytes)
 					R_LOG_ERROR ("Cannot read that much!");
 					return false;
 				}
-			}
-			if (nbytes < 1) {
-				return false;
 			}
 			r_io_read_at (core->io, core->addr, core->block, nbytes);
 		}
@@ -7867,20 +7873,12 @@ R_IPI int r_core_print_disasm_json_ipi(RCore *core, ut64 addr, ut8 *buf, int nb_
 				R_LOG_ERROR ("Too many backward instructions");
 				return false;
 			}
-			// same backward walk as pd, one op at a time so the window fits in buf
-			addr = old_offset;
-			int bw;
-			for (bw = 0; bw < nb_opcodes; bw++) {
-				const ut64 prev = r_core_prevop_addr_force (core, addr, 1);
-				if (prev >= addr || old_offset - prev > (ut64)nb_bytes) {
-					break;
-				}
-				addr = prev;
-			}
-			const int nbytes = old_offset - addr;
+			// same bb-aware backward walk as pd
+			int nbytes;
+			addr = bwdisasm_window (core, old_offset, nb_opcodes, &nbytes);
 			if (nbytes < 1) {
-				pj_end (pj);
-				return false;
+				// nothing before the cursor (map start): show the window forward, like pd
+				addr = old_offset;
 			}
 			const int count = R_MIN (nb_bytes, nbytes);
 			r_io_read_at (core->io, addr, buf, count);

--- a/libr/core/visual.c
+++ b/libr/core/visual.c
@@ -1375,7 +1375,11 @@ static ut64 prevop_addr(RCore *core, ut64 addr) {
 	}
 	if (minop == maxop) {
 		if (minop == -1) {
-			return addr - 4;
+			return addr > 4 ? addr - 4 : 0;
+		}
+		if (addr < (ut64)minop) {
+			// clamp instead of wrapping around the top of the address space
+			return 0;
 		}
 		ut64 prev = addr - minop;
 		if (addr >= (ut64)minop && core->anal->config->codealign == minop) {

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -412,3 +412,21 @@ EXPECT=<<EOF
             0x0000000c      1f2003d5       nop
 EOF
 RUN
+
+NAME=pi negative count at the very start of the file shows the forward window like pd
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+s 0
+e asm.lines=0
+pi -4
+EOF
+EXPECT=<<EOF
+nop
+nop
+nop
+nop
+EOF
+RUN

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -378,3 +378,37 @@ EXPECT=<<EOF
 0x0000003c             1f2003d5  nop
 EOF
 RUN
+
+NAME=pdi negative count near start of file
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+s 8
+pdi -4
+EOF
+EXPECT=<<EOF
+0x00000000             1f2003d5  nop
+0x00000004             1f2003d5  nop
+0x00000008             1f2003d5  nop
+0x0000000c             1f2003d5  nop
+EOF
+RUN
+
+NAME=pd negative count near start of file does not wrap around
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+s 8
+pd -4
+EOF
+EXPECT=<<EOF
+            0x00000000      1f2003d5       nop
+            0x00000004      1f2003d5       nop
+            0x00000008      1f2003d5       nop
+            0x0000000c      1f2003d5       nop
+EOF
+RUN

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -355,3 +355,26 @@ EXPECT=<<EOF
 0x00000004             e50300aa  mov x5, x0
 EOF
 RUN
+
+NAME=pdi negative count with invalid instruction in window
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+wx ffffffff @ 0x24
+s 0x40
+pdi -9
+EOF
+EXPECT=<<EOF
+0x0000001c             1f2003d5  nop
+0x00000020             1f2003d5  nop
+0x00000024             ffffffff  invalid
+0x00000028             1f2003d5  nop
+0x0000002c             1f2003d5  nop
+0x00000030             1f2003d5  nop
+0x00000034             1f2003d5  nop
+0x00000038             1f2003d5  nop
+0x0000003c             1f2003d5  nop
+EOF
+RUN

--- a/test/db/cmd/cmd_pdj
+++ b/test/db/cmd/cmd_pdj
@@ -101,6 +101,22 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=pdj negative count at the very start of the file shows the forward window like pd
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+s 0
+pdj -4~{[0].addr}
+pdj -4~{[3].addr}
+EOF
+EXPECT=<<EOF
+0
+12
+EOF
+RUN
+
 NAME=pdj negative count with window larger than blocksize
 FILE=malloc://512
 ARGS=-a arm -e asm.bits=64

--- a/test/db/cmd/cmd_pdj
+++ b/test/db/cmd/cmd_pdj
@@ -63,3 +63,24 @@ mov x30, 0
 mov x5, x0
 EOF
 RUN
+
+NAME=pdj negative count with invalid instruction in window
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+wx ffffffff @ 0x24
+s 0x40
+pdj -9~{[0].addr}
+pdj -9~{[2].opcode}
+pdj -9~{[2].size}
+pdj -9~{[8].addr}
+EOF
+EXPECT=<<EOF
+28
+invalid
+4
+60
+EOF
+RUN

--- a/test/db/cmd/cmd_pdj
+++ b/test/db/cmd/cmd_pdj
@@ -84,3 +84,36 @@ invalid
 60
 EOF
 RUN
+
+NAME=pdj negative count near start of file
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+s 8
+pdj -4~{[0].addr}
+pdj -4~{[3].addr}
+EOF
+EXPECT=<<EOF
+0
+12
+EOF
+RUN
+
+NAME=pdj negative count with window larger than blocksize
+FILE=malloc://512
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 512
+wow 1f2003d5
+b 64
+s 0x100
+pdj -20~{[0].addr}
+pdj -20~{[19].addr}
+EOF
+EXPECT=<<EOF
+176
+252
+EOF
+RUN

--- a/test/db/cmd/cmd_pi
+++ b/test/db/cmd/cmd_pi
@@ -24,9 +24,9 @@ mov rdx, rsp
 and rsp, 0xfffffffffffffff0
 mov rdx, rsp
 and rsp, 0xfffffffffffffff0
-mov ecx, edx
+mov r9, rdx
 pop rsi
-mov ecx, edx
+mov r9, rdx
 pop rsi
 EOF
 RUN

--- a/test/db/cmd/cmd_print
+++ b/test/db/cmd/cmd_print
@@ -502,7 +502,7 @@ wx b8010000004839ca7f00
 pi -3 @ 10
 EOF
 EXPECT=<<EOF
-add byte [rax], al
+mov eax, 1
 cmp rdx, rcx
 jg 0xa
 EOF
@@ -519,19 +519,20 @@ EOF
 EXPECT=<<EOF
 [
   {
-    "addr": 3,
-    "esil": "al,rax,+=[1],7,$o,of,:=,7,$s,sf,:=,$z,zf,:=,7,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
-    "refptr": 1,
+    "addr": 0,
+    "val": 1,
+    "esil": "1,rax,=",
+    "refptr": 0,
     "fcn_addr": 0,
     "fcn_last": 0,
-    "size": 2,
-    "opcode": "add byte [rax], al",
-    "disasm": "add byte [rax], al",
-    "bytes": "0000",
+    "size": 5,
+    "opcode": "mov eax, 1",
+    "disasm": "mov eax, 1",
+    "bytes": "b801000000",
     "family": "cpu",
-    "type": "add",
+    "type": "mov",
     "reloc": false,
-    "type_num": 17,
+    "type_num": 9,
     "type2_num": 0
   },
   {

--- a/test/db/cmd/cmd_search
+++ b/test/db/cmd/cmd_search
@@ -825,6 +825,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=/o with invalid instruction in window
+FILE=malloc://64
+ARGS=-a arm -e asm.bits=64
+CMDS=<<EOF
+b 64
+wow 1f2003d5
+wx ffffffff @ 0x24
+s 0x40
+/o 9
+EOF
+EXPECT=<<EOF
+0x0000001c
+EOF
+RUN
+
 NAME=/x search from/to (seek 0)
 FILE=malloc://1024
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fix #26262. Supersedes #26286 and #26292 (rebased onto current master).

Backward disassembly (`pd`/`pi`/`pdj -N`) drifted or returned misaligned instructions when the window contained invalid bytes, ran off the start of the file, or exceeded the block size. This walks back with the same bb-aware step as `pd` in all three commands, clamps at address 0 instead of wrapping, and grows the pdj buffer when the window is larger than the block.

The three commands now share one helper (`bwdisasm_window`) instead of three separate walks — `pdj` had reimplemented `r_core_prevop_addr_force` inline — so they produce identical windows, including the forward fallback at the very start of the file where nothing precedes the cursor.

Commit 1 is the original #26286 fix; commit 2 is @trufae's hardening (#26292); commit 3 is the rebase + walk unification + map-start parity. Tests cover invalid instructions in the window, negative counts near/at the file start, pdj windows larger than the block, and `/o` with an invalid instruction. 