### PR TITLE
Fix wrong size used in realloc ##debug

### DIFF
--- a/libr/debug/p/debug_evm.c
+++ b/libr/debug/p/debug_evm.c
@@ -193,8 +193,13 @@ static bool r_debug_evm_breakpoint (struct r_bp_t *bp, RBreakpointItem *b, bool 
 			return true;
 		}
 		if (rios->breakpoints_length >= rios->breakpoints_capacity) {
-			rios->breakpoints = realloc (rios->breakpoints, rios->breakpoints_capacity + 64);
-			rios->breakpoints_capacity += 64;
+			size_t new_capacity = rios->breakpoints_capacity + 64;
+			ut64 *new_breakpoints = realloc (rios->breakpoints, new_capacity * sizeof (ut64));
+			if (!new_breakpoints) {
+				return false;
+			}
+			rios->breakpoints = new_breakpoints;
+			rios->breakpoints_capacity = new_capacity;
 		}
 		rios->breakpoints[rios->breakpoints_length] = b->addr;
 		rios->breakpoints_length++;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The capacity (and length, which compared to it) are in terms of array elements, but the second argument to realloc() must be the number of bytes, not array elements (which are ut64).

<!-- explain your changes if necessary -->
