### PR TITLE
Escape colon in count greps now that ~? honors line ranges ##test

### DIFF
--- a/test/db/cmd/cmd_arm64_kernelcache
+++ b/test/db/cmd/cmd_arm64_kernelcache
@@ -40,9 +40,9 @@ af+ 0x24 helper loc
 afb+ 0x24 0x24 4
 aac
 afij @ 0~?\"name\":\"wrapper\"
-afij @ 0~?\"size\":48
+afij @ 0~?\"size\"\:48
 afij @ 0x24~?\"name\":\"helper\"
-afij @ 0x24~?\"indegree\":1
+afij @ 0x24~?\"indegree\"\:1
 EOF
 EXPECT=<<EOF
 1


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Since 2912e0d946 the ~? counter honors line-range stages, so the trailing :48 / :1 in these grep expressions is now parsed as a line range instead of pattern text, selecting a line that doesn't exist and printing 0. This is the single test failing across all CI jobs. Escape the colon (\:) so it is matched literally; the aac analysis output itself is unchanged.