### PR TITLE
Fix typo in desil exprmatchreg == handling ##debug

### DIFF
--- a/libr/debug/desil.c
+++ b/libr/debug/desil.c
@@ -164,7 +164,7 @@ static int exprmatchreg(RDebug *dbg, const char *regname, const char *expr) {
 			if (CURVAL <= r_num_math (dbg->num, p))
 				ret = 1;
 		} else if (exprtoken (dbg, s, "==", &p)) {
-			if (CURVAL <= r_num_math (dbg->num, p))
+			if (CURVAL == r_num_math (dbg->num, p))
 				ret = 1;
 		} else if (exprtoken (dbg, s, "<", &p)) {
 			if (CURVAL < r_num_math (dbg->num, p))


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The '==' case handling seems to incorrectly (unless I miss something) copy-paste 'CURVAL <= r_num_math(...)' from previous '<=' case instead of expected 'CURVAL == ...'.

<!-- explain your changes if necessary -->
