### PR TITLE
Fix null dereference on prompt exit in visual find ##visual

### DIFF
--- a/libr/core/agraph.c
+++ b/libr/core/agraph.c
@@ -4307,7 +4307,9 @@ R_API void r_core_visual_find(RCore *core, RAGraph *g) {
 			if (c == ':') {
 				cons->event_resize = (RConsEvent)agraph_set_need_reload_nodes;
 				r_core_visual_prompt_input (core);
-				g->can->flags = r_cons_canvas_flags (cons);
+				if (g) {
+					g->can->flags = r_cons_canvas_flags (cons);
+				}
 				r_cons_set_raw (cons, true);
 				cons->event_resize = (RConsEvent)agraph_refresh_queued;
 			}


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

When `r_core_visual_find()` is called from standard visual mode (via `%`), the `RAGraph *g` parameter is `NULL`. If user finds a match and presses `:` to execute a command, the code attempts to access `g->can->flags` without `if (g)` check (note that such check is present for `;` handling code just above), resulting in segmentation fault.

Steps to reproduce (on x86 Linux):

```
$ r2 /bin/ls
[0x1234]> aa
[0x1234]> V
*Press p*
*Press %*
[find]> mov
*Press :*
> mov
*Delete 'mov' and press Enter (or 'q' + Enter) to exit the prompt*
<Segmentation fault (core dumped)>
```

<!-- explain your changes if necessary -->
