### PR TITLE
Port the pseudo plugin to the new command handler ##core

### DIFF
--- a/libr/core/p/pseudo/plugin.c
+++ b/libr/core/p/pseudo/plugin.c
@@ -3,6 +3,19 @@
 #include <r_core.h>
 #include "pseudo.h"
 
+static RCoreHelpMessage help_msg_pdc = {
+	"Usage: pdc[acjlot*]", "", "experimental, unreliable and hacky pseudo-decompiler",
+	"pdc", "", "pseudo decompile function in current offset",
+	"pdc*", "", "emit decompiled lines as CCu comment commands",
+	"pdca", "", "side by side comparing assembly and pseudo",
+	"pdcc", "", "pseudo-decompile with C helpers around",
+	"pdcl", "", "linear pseudo-decompilation scrolling across functions",
+	"pdco", "", "show associated offset next to pseudecompiled output",
+	"pdcj", "", "in json format for codemeta annotations (used by frontends like iaito)",
+	"pdct", "", "dump the structuring region AST (decompiler debug)",
+	NULL
+};
+
 static ut64 find_nextop(RCore *core, ut64 addr) {
 	RAnalOp *op = r_core_anal_op (core, addr, R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_HINT);
 	if (op && (int)op->size > 0) {
@@ -132,19 +145,52 @@ repeat:;
 	r_core_seek (core, initial_addr, true);
 }
 
+static RCmdResult pseudo_help(RCmdContext *ctx) {
+	RCore *core = ctx->user;
+	r_cons_cmd_help (ctx->cons, help_msg_pdc, core->print->flags & R_PRINT_FLAGS_COLOR);
+	return (RCmdResult) { 0 };
+}
 
-static bool r_cmd_pseudo_call(RCorePluginSession *cps, const char *input) {
+static RCmdResult pseudo_callback(RCmdContext *ctx) {
+	RCore *core = ctx->user;
+	const size_t argc = RVecRStrs_length (&ctx->args);
+	RStrs *args = R_VEC_START_ITER (&ctx->args);
+	if (r_cmd_ctx_help (ctx) || (argc == 1 && r_strs_equals_str (args[0], "?"))) {
+		const char sub = r_cmd_ctx_mode (ctx, "acjlot*");
+		if (sub && r_strs_len (ctx->subcmd) == 2) {
+			const char subhelp[] = { 'p', 'd', 'c', sub, 0 };
+			if (r_cons_cmd_help_match (ctx->cons, help_msg_pdc,
+					core->print->flags & R_PRINT_FLAGS_COLOR, subhelp, 0, true) > 0) {
+				return (RCmdResult) { 0 };
+			}
+		}
+		return pseudo_help (ctx);
+	}
+	// subcmd slices the input line, so its start is the NUL-terminated raw tail
+	const char *tail = ctx->subcmd.a;
+	if (r_strs_at (ctx->subcmd, 0) == 'l') {
+		linear_pseudo (core, tail + 1);
+		return (RCmdResult) { 0 };
+	}
+	return (RCmdResult) { .status = pdc_decompile (core, tail)? 0: 1 };
+}
+
+static bool plugin_init(RCorePluginSession *cps) {
 	RCore *core = cps->core;
 	if (!core) {
+		return true;
+	}
+	RCmd *cmd = core->rcmd;
+	if (!r_cmd_register (cmd, "pdc", pseudo_callback, NULL)) {
 		return false;
 	}
-	if (!r_str_startswith (input, "pdc") && !r_str_startswith (input, "pDc")) {
-		return false;
-	}
-	if (input[3] == 'l') { // "pdcl"
-		linear_pseudo (core, input + 4);
-	} else {
-		pdc_decompile (core, input + 3);
+	cps->data = cmd;
+	return true;
+}
+
+static bool plugin_fini(RCorePluginSession *cps) {
+	if (cps->data) {
+		r_cmd_unregister (cps->data, "pdc");
 	}
 	return true;
 }
@@ -156,7 +202,8 @@ RCorePlugin r_core_plugin_pseudo = {
 		.license = "LGPL-3.0-only",
 		.author = "pancake",
 	},
-	.call = r_cmd_pseudo_call,
+	.init = plugin_init,
+	.fini = plugin_fini,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -406,18 +406,6 @@ static char *fold_resolved_refs(RCore *core, char *code) {
 	return r_strbuf_drain (sb);
 }
 
-static RCoreHelpMessage help_msg_pdc = {
-	"Usage: pdc[oj*]", "", "experimental, unreliable and hacky pseudo-decompiler",
-	"pdc", "", "pseudo decompile function in current offset",
-	"pdc*", "", "emit decompiled lines as CCu comment commands",
-	"pdca", "", "side by side comparing assembly and pseudo",
-	"pdcc", "", "pseudo-decompile with C helpers around",
-	"pdco", "", "show associated offset next to pseudecompiled output",
-	"pdcj", "", "in json format for codemeta annotations (used by frontends like iaito)",
-	"pdct", "", "dump the structuring region AST (decompiler debug)",
-	NULL
-};
-
 static void unvisit(RList *visited, RAnalBlock *bb) {
 	RListIter *iter;
 	RAnalBlock *b;
@@ -1355,12 +1343,8 @@ static void pdc_print_comment_cmds(RCore *core, const char *s) {
 	}
 }
 
-int pdc_decompile(RCore *core, const char *input) {
+R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	bool show_c_headers = *input == 'c';
-	if (*input == '?') {
-		r_core_cmd_help (core, help_msg_pdc);
-		return false;
-	}
 	if (*input == 't') {
 		RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, R_ANAL_FCN_TYPE_NULL);
 		if (!fcn) {
@@ -1388,14 +1372,12 @@ int pdc_decompile(RCore *core, const char *input) {
 				input = " -r2";
 			} else if (!strcmp (input, "=")) {
 				input = " -a";
-			} else if (!strcmp (input, "?")) {
-				input = " -h";
 			}
 		}
-		int ret = r_core_cmdf (core, "%s%s", cmdPdc, input);
+		const bool ok = r_core_cmdf (core, "%s%s", cmdPdc, input) == 0;
 		r_config_hold_restore (hc);
 		r_config_hold_free (hc);
-		return ret;
+		return ok;
 	}
 
 	PDCState state = { 0 };

--- a/libr/core/p/pseudo/pseudo.h
+++ b/libr/core/p/pseudo/pseudo.h
@@ -5,6 +5,6 @@
 
 #include <r_core.h>
 
-int pdc_decompile(RCore *core, const char *input);
+R_IPI bool pdc_decompile(RCore *core, const char *input);
 
 #endif

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -690,3 +690,78 @@ EXPECT=<<EOF2
         sym.imp.printf () // int printf("IOLI Crackme Level 0x00\n", -1)
 EOF2
 RUN
+
+NAME=pdc help lists all subcommands
+FILE=--
+CMDS=<<EOF
+pdc?
+EOF
+EXPECT=<<EOF
+Usage: pdc[acjlot*]  experimental, unreliable and hacky pseudo-decompiler
+| pdc   pseudo decompile function in current offset
+| pdc*  emit decompiled lines as CCu comment commands
+| pdca  side by side comparing assembly and pseudo
+| pdcc  pseudo-decompile with C helpers around
+| pdcl  linear pseudo-decompilation scrolling across functions
+| pdco  show associated offset next to pseudecompiled output
+| pdcj  in json format for codemeta annotations (used by frontends like iaito)
+| pdct  dump the structuring region AST (decompiler debug)
+EOF
+RUN
+
+NAME=pdc subcommand help prints only the matching row
+FILE=--
+CMDS=<<EOF
+pdcj?
+EOF
+EXPECT=<<EOF
+| pdcj  in json format for codemeta annotations (used by frontends like iaito)
+EOF
+RUN
+
+NAME=pdc without a function reports failure status
+FILE=--
+CMDS=<<EOF
+pdc && ?e SHOULD_NOT_RUN
+pdc || ?e reported-failure
+EOF
+EXPECT=<<EOF
+reported-failure
+EOF
+EXPECT_ERR=<<EOF
+ERROR: Cannot find function in 0x00000000
+ERROR: Cannot find function in 0x00000000
+EOF
+RUN
+
+NAME=pdc success reports zero status
+FILE=malloc://32
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx c3
+af
+pdc && ?e decompile-ok
+EOF
+EXPECT=<<EOF
+// callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+void fcn.00000000 (void) {
+        return
+}
+
+decompile-ok
+EOF
+RUN
+
+NAME=failing external decompiler propagates through cmd.pdc
+FILE=--
+CMDS=<<EOF
+e cmd.pdc=prj open /this/does/not/exist/x.prj
+pdc || ?e external-failed
+EOF
+EXPECT=<<EOF
+external-failed
+EOF
+EXPECT_ERR=<<EOF
+ERROR: Cannot find project file: /this/does/not/exist/x.prj
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Register pdc/pDc via r_cmd_register in plugin init/fini instead of the legacy .call prefix matcher, following the prj/agD/writedwarf ports.
  
Output is byte-identical for all pdc modes. Three small help improvements: `pdcX?` prints just that subcommand's row, pdcl is now listed in `pdc?`, and the usage token is corrected to pdc[acjlot*]. Adds two help tests.
