### PR TITLE
Fix nondeterministic PPC test from uninitialized capstone mnemonic ##arch

### DIFF
--- a/libr/arch/p/capstone.inc.c
+++ b/libr/arch/p/capstone.inc.c
@@ -8,6 +8,8 @@ typedef struct {
 
 static inline bool r_arch_cs_disasm(csh handle, const uint8_t **code, size_t *size, uint64_t *addr, RArchCSInsn *ci) {
 	ci->insn.detail = &ci->detail;
+	// capstone post printers inspect the mnemonic before fill_insn writes it
+	ci->insn.mnemonic[0] = 0;
 	return cs_disasm_iter (handle, code, size, addr, &ci->insn);
 }
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes the random db/cmd/cmd_meta pdj1 failure (seen on the #26320 CI thread), where the ESIL for mr r9, r1 would sometimes grow a spurious ...,cr0,= tail.

Root cause (confirmed with valgrind): capstone's fill_insn (cs.c:592) invokes the arch post-printer before it writes insn->mnemonic — the memset at cs.c:596 is commented out upstream. PPC_post_printer (PPCInstPrinter.c:83) then runs strrchr (insn->mnemonic, '.') on whatever garbage the caller's buffer holds. Our r_arch_cs_disasm helper in capstone.inc.c passes a stack-allocated cs_insn without initializing the mnemonic, so whether the leftover stack bytes happen to contain a '.' decides if capstone reports update_cr0 — making the result depend on build flags and stack layout, hence "random". The detail struct is not affected (the PPC disassembler memsets it); only the mnemonic leaks. The same uninitialized read feeds the '+'/'-' branch-hint detection.

This became visible once the record-form cr0 support started consuming update_cr0, and it also explains an earlier unreproducible linux-test CI failure on an unrelated PR (x86-64 -O2 stack layout).

Fix: zero mnemonic[0] in r_arch_cs_disasm before calling cs_disasm_iter, which covers every plugin using the shared helper (ppc, s390, m68k, sh, tms320, 6502, ...). The deeper fix — restoring the memset in capstone's fill_insn — belongs in capstone itself.