### PR TITLE
Select CS_ROOT after including config-user.mk so configure --with-capstone-next takes effect ##build

### DIFF
--- a/libr/config.mk.tail
+++ b/libr/config.mk.tail
@@ -14,14 +14,6 @@ MSVC=$(R2DIR)/msvc
 endif
 endif
 
-ifeq ($(USE_CSNEXT),1)
-CS_ROOT:=$(LIBR)/../subprojects/capstone-next
-else ifeq ($(USE_CS4),1)
-CS_ROOT:=$(LIBR)/../subprojects/capstone-v4
-else
-CS_ROOT:=$(LIBR)/../subprojects/capstone-v5
-endif
-
 ZYDIS_ROOT:=$(LIBR)/../subprojects/zydis
 WANT_ZYDIS?=1
 USE_ZYDIS?=0
@@ -33,6 +25,15 @@ SHLR:=$(LIBR)/../shlr
 
 include $(LIBR)/../global.mk
 include $(LIBR)/../mk/${COMPILER}.mk
+
+# USE_CSNEXT/USE_CS4 come from config-user.mk, included via global.mk
+ifeq ($(USE_CSNEXT),1)
+CS_ROOT:=$(LIBR)/../subprojects/capstone-next
+else ifeq ($(USE_CS4),1)
+CS_ROOT:=$(LIBR)/../subprojects/capstone-v4
+else
+CS_ROOT:=$(LIBR)/../subprojects/capstone-v5
+endif
 
 ifeq ($(WANT_CAPSTONE),1)
 ifeq ($(USE_CAPSTONE),1)


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

In the acr/make build, libr/config.mk chose CS_ROOT before including global.mk (which pulls in config-user.mk), so USE_CSNEXT/USE_CS4 were always empty at that point and the include/link paths silently stayed on capstone-v5 regardless of --with-capstone-next / --with-capstone4. Meanwhile shlr/Makefile honored the option and built libcapstone from the selected branch, producing a header/library version mismatch (or a fatal missing capstone/capstone.h in a clean tree).

Move the CS_ROOT selection below the includes, next to the CS_CFLAGS / CS_LDFLAGS block that consumes it. Default v5 builds are unaffected (identical compile commands); with --with-capstone-next a plain make now compiles against the capstone-next headers.
