### PR TITLE
Fix mips.gnu jal ESIL empty jump target ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -877,8 +877,11 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "" ES_CALL_ND ("%s"), addr, I_REG (jump));
 		break;
 	case MIPS_INS_BAL:
-	case MIPS_INS_JAL:
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "" ES_CALL_D ("%s"), addr, I_REG (jump));
+		break;
+	case MIPS_INS_JAL:
+		// jal is J-type: the target lives in j_reg, not the i_reg union member bal uses
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "" ES_CALL_D ("%s"), addr, J_REG (jump));
 		break;
 	case MIPS_INS_JALR:
 	case MIPS_INS_JALRS:

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -1953,3 +1953,19 @@ mnemonic: add
 0xfffffffe
 EOF
 RUN
+
+NAME=mips.gnu jal writes the link register and branches to the target
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0400000c
+aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000010
+0x00000008
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`jal` on the mips.gnu analyzer emitted an empty ESIL jump target (`...,ra,=,,SETJT,1,SETD`), so emulation never branched to the call target — PC just fell through the delay slots.
  
`gnu_insn` is a union of `r_reg`/`i_reg`/`j_reg`. J-type instructions decode into `j_reg.jump`, but the `JAL` case read `I_REG(jump)` — a different, uninitialized union member — because it shared a `case` with the I-type `BAL`. Split them so `JAL` reads `J_REG(jump)` (matching the sibling `J` case); `BAL` keeps `I_REG(jump)`.

`jal` now emits `...,ra,=,0x100040,SETJT,1,SETD`, matching the default mips plugin. Adds a db/esil/mips_32 regression test (jal writes ra and reaches the target). No test regressions.