### PR TITLE
Fix MIPS bgezal/bltzal to always write the link register ##esil

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -476,7 +476,8 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 					addr, ARG (0), ARG (1));
 				break;
 		case MIPS_INS_BGEZAL:
-				r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_IS_NEGATIVE ("%s") ",!,?{," ES_CALL_D ("%s") ",}",
+				// the link (ra=pc+8) is unconditional; only the jump is conditional
+				r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "pc,4,+,ra,=," ES_IS_NEGATIVE ("%s") ",!,?{," ES_J_D ("%s") ",}",
 					addr, ARG (0), ARG (1));
 				break;
 		case MIPS_INS_BGEZALC:
@@ -488,7 +489,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 					addr, ARG (0), ARG (1));
 			break;
 		case MIPS_INS_BLTZAL:
-				r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_IS_NEGATIVE ("%s") ",?{," ES_CALL_D ("%s") ",}",
+				r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "pc,4,+,ra,=," ES_IS_NEGATIVE ("%s") ",?{," ES_J_D ("%s") ",}",
 						addr, ARG (0), ARG (1));
 				break;
 		case MIPS_INS_BLTZC:

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -1969,3 +1969,63 @@ EXPECT=<<EOF
 0x00000008
 EOF
 RUN
+
+NAME=mips bgezal links ra unconditionally (not taken still links)
+FILE=malloc://0x200
+ARGS=-a mips -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f001105
+ar t0=0xffffffff
+ar ra=0
+ar pc=0
+s 0
+2aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000008
+0x00000008
+EOF
+RUN
+
+NAME=mips bltzal links ra unconditionally (not taken still links)
+FILE=malloc://0x200
+ARGS=-a mips -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f001005
+ar t0=1
+ar ra=0
+ar pc=0
+s 0
+2aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000008
+0x00000008
+EOF
+RUN
+
+NAME=mips bgezal branches and links when taken
+FILE=malloc://0x200
+ARGS=-a mips -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f001105
+ar t0=1
+ar ra=0
+ar pc=0
+s 0
+aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000040
+0x00000008
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

MIPS `bgezal`/`bltzal` write `ra = PC+8` unconditionally (the link is the I-step, before the branch test), but the ESIL emitted `pc,4,+,ra,=` inside the branch `?{}` — so a not-taken branch never linked.

Move the link before the condition (`pc,4,+,ra,=,<cond>,?{,<target>,SETJT, 1,SETD,}`); only the jump stays conditional. Adds db/esil/mips_32 tests (not-taken still links, taken branches+links). No test regressions.