### PR TITLE
Fix mips.gnu REGIMM branch targets and unconditional link ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -48,6 +48,9 @@ DECLARE_GENERIC_FPRINTF_FUNC_NOGLOBALS ()
 #define ES_CALL_DR(ra, addr) "pc,4,+,"ra",=,"ES_J_D(addr)
 #define ES_CALL_D(addr) ES_CALL_DR("ra", addr)
 
+// Unconditional link (ra = pc + 8).
+#define ES_LINK "pc,4,+,ra,=,"
+
 // Call without delay slot.
 #define ES_CALL_NDR(ra, addr) "pc,"ra",=,"ES_J_ND(addr)
 #define ES_CALL_ND(addr) ES_CALL_NDR("ra", addr)
@@ -990,7 +993,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 			addr, I_REG (rs), I_REG (jump));
 		break;
 	case MIPS_INS_BGEZAL:
-		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_IS_NEGATIVE ("%s") ",!,?{," ES_CALL_D ("%s") ",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_LINK ES_IS_NEGATIVE ("%s") ",!,?{," ES_J_D ("%s") ",}",
 			addr, I_REG (rs), I_REG (jump));
 		break;
 	case MIPS_INS_BGEZALC:
@@ -1002,7 +1005,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		        addr, I_REG (rs), I_REG (jump));
 		break;
 	case MIPS_INS_BLTZAL:
-		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_IS_NEGATIVE ("%s") ",?{," ES_CALL_D ("%s") ",}",
+		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) ES_LINK ES_IS_NEGATIVE ("%s") ",?{," ES_J_D ("%s") ",}",
 		        addr, I_REG (rs), I_REG (jump));
 		break;
 	case MIPS_INS_BLTZC:
@@ -1641,29 +1644,32 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		RAnalValue *dst;
 		switch (optype) {
 		case 1:
+			// all REGIMM branches share the delay slot and target math
+			op->delay = 1;
+			op->fail = addr + 8;
 			switch (rt) {
 			case 0: // bltz
 				insn.id = MIPS_INS_BLTZ;
+				op->type = R_ANAL_OP_TYPE_CJMP;
 				break;
 			case 1: // bgez
 				insn.id = MIPS_INS_BGEZ;
+				op->type = R_ANAL_OP_TYPE_CJMP;
 				break;
-			case 17: // bal  bgezal
-				if (rs == 0) {
-					op->jump = addr + ((ut64)imm << 2) + 4;
-					snprintf ((char *)insn.i_reg.jump, REG_BUF_MAX, "0x%" PFMT64x, op->jump);
-					insn.id = MIPS_INS_BAL;
-				} else {
-					op->fail = addr + 8;
-					insn.id = MIPS_INS_BGEZAL;
-				}
-				op->delay = 1;
+			case 16: // bltzal
+				insn.id = MIPS_INS_BLTZAL;
+				op->type = R_ANAL_OP_TYPE_CALL;
+				break;
+			case 17: // bgezal, or bal when rs==0
+				insn.id = rs == 0 ? MIPS_INS_BAL : MIPS_INS_BGEZAL;
 				op->type = R_ANAL_OP_TYPE_CALL;
 				break;
 			default:
-				op->delay = 1;
-				op->fail = addr + 8;
 				break;
+			}
+			if (insn.id) {
+				op->jump = addr + ((ut64)imm << 2) + 4;
+				snprintf ((char *)insn.i_reg.jump, REG_BUF_MAX, "0x%" PFMT64x, op->jump);
 			}
 			break;
 		case 4: // beq

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2029,3 +2029,77 @@ EXPECT=<<EOF
 0x00000008
 EOF
 RUN
+
+NAME=mips.gnu bgez branches to the decoded target
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f000105
+ar t0=1
+ar pc=0
+s 0
+aes
+ar pc
+EOF
+EXPECT=<<EOF
+0x00000040
+EOF
+RUN
+
+NAME=mips.gnu bltz branches to the decoded target
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f000005
+ar t0=0xffffffffffffffff
+ar pc=0
+s 0
+aes
+ar pc
+EOF
+EXPECT=<<EOF
+0x00000040
+EOF
+RUN
+
+NAME=mips.gnu bltzal emits esil, links ra and branches
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f001005
+ar t0=0xffffffffffffffff
+ar ra=0
+ar pc=0
+s 0
+aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000040
+0x00000008
+EOF
+RUN
+
+NAME=mips.gnu bgezal links ra even when the branch is not taken
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 0f001105
+ar t0=0xffffffffffffffff
+ar ra=0
+ar pc=0
+s 0
+2aes
+ar pc
+ar ra
+EOF
+EXPECT=<<EOF
+0x00000008
+0x00000008
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The mips.gnu REGIMM decode (`case 1`) was broken: bltz/bgez set only the instruction id, so op->jump/delay/type were unset and the ESIL target read the raw immediate (via the i_reg.imm/jump union) instead of the branch target; bltzal (rt=16) had no case at all, so it emitted no ESIL; bgezal omitted its target too.
  
Restructure the case so all four REGIMM branches compute the shared target/delay/fail + i_reg.jump, with per-rt id and type. Also emit the bgezal/bltzal link (ra=pc+8) unconditionally — MIPS links before the branch test — via a new ES_LINK macro. Adds db/esil/mips_32 tests. No regressions.