### PR TITLE
Fix the PowerPC pseudo output for isel and unmodelled instructions ##arch

### DIFF
--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -1614,7 +1614,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 	} while (0)
 
 static char *parse(RAsmPluginSession *aps, const char *data) {
-	int i, len = strlen (data);
+	int len = strlen (data);
 	char w0[WSZ];
 	char w1[WSZ];
 	char w2[WSZ];
@@ -1644,6 +1644,7 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		w2[0] = '\0';
 		w3[0] = '\0';
 		w4[0] = '\0';
+		w5[0] = '\0';
 		ptr = strchr (buf, ' ');
 		if (!ptr) {
 			ptr = strchr (buf, '\t');
@@ -1703,8 +1704,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4, w5 };
-			int nw = 0;
-			for (i = 0; i < 4; i++) {
+			size_t i, nw = 0;
+			for (i = 0; i < R_ARRAY_SIZE (wa); i++) {
 				if (wa[i][0] != '\0') {
 					nw++;
 				}

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -695,10 +695,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "icbi", "inst_cache_block_inval", 0},
 		{ "icbt", "inst_cache_block_touch", 3},
 		{ "iccci", "inst_cache_inval(A,B)", 2},
-		// isel lt   Rx,Ry,Rz (equivalent to: isel Rx,Ry,Rz,0)
-		// isel gt  Rx,Ry,Rz (equivalent to: isel Rx,Ry,Rz,1)
-		// isel eq Rx,Ry,Rz (equivalent to: isel Rx,Ry,Rz,2)
-		//  { "isel", "", 4},
+		{ "isel", "A = select(D, B, C)", 4},
 		{ "isync", "sync_instr_cache", 0},
 		{ "la", "A = C + B", 3},
 		{ "lbz", "A = byte[C + B]", 3},

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -99,3 +99,15 @@ r3 = select(cr2eq, r4, r5)
 r3 = select(cr0lt, 0, r5)
 EOF
 RUN
+
+NAME=PPC64 pseudo keeps every operand when no rule matches
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 1022192b
+pi 1
+EOF
+EXPECT=<<EOF
+vperm v1, v2, v3, v4
+EOF
+RUN

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -84,3 +84,18 @@ cmpdi r9, 0
 beq 0x20c
 EOF
 RUN
+
+NAME=PPC64 pseudo isel keeps the condition register bit
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 7c64281e7c64289e7c642a9e7c60281e
+pi 4
+EOF
+EXPECT=<<EOF
+r3 = select(cr0lt, r4, r5)
+r3 = select(cr0eq, r4, r5)
+r3 = select(cr2eq, r4, r5)
+r3 = select(cr0lt, 0, r5)
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`pdc` had no rule for `isel`, so the raw assembly was passed through into the C output — and the fallback path dropped the trailing operand, which for `isel` is the CR bit deciding the select. Two different instructions rendered identically:

    isel r3, r4, r5, cr0eq  ->  isel r3, r4, r5
    isel r3, r4, r5, cr2eq  ->  isel r3, r4, r5

Now `r3 = select(cr0eq, r4, r5)` and `r3 = select(cr2eq, r4, r5)`.

The second commit fixes the operand loss generally: `parse()` hardcoded a word count of 4 while `wa[]` holds 6, so any unmodelled instruction with more operands was truncated (`vperm v1, v2, v3, v4` lost `v4`). It also initialises `w5`, which was an uninitialised stack read.

`select(...)` is used rather than `fsel`'s `if (c) a = b; else a = d` idiom because pdc rewrites `;` to `//`, and rather than arm64 `csel`'s ternary because this parser rewrites `:` to `0000`.

Two tests in `db/cmd/cmd_pseudo_ppc`, each confirmed failing before its fix.