### PR TITLE
Fix the drifted table-position dispatch in the PowerPC pseudo filter ##arch

### DIFF
--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -116,46 +116,21 @@ static int can_replace(const char *str, int idx, int max_operands) {
 	return true;
 }
 
+// cmp* and the cr0 conditional branches: b{eq,ge,gt,le,lt,ne} with an optional +/- hint
 static bool op_needs_cr0(const char *op) {
 	if (r_str_startswith (op, "cmp")) {
 		return true;
 	}
-	if (*op != 'b') {
+	if (op[0] != 'b' || !op[1] || !op[2] || (op[3] && (op[4] || !strchr ("+-", op[3])))) {
 		return false;
 	}
-	switch (op[1]) {
-	case 'e':
-		if (op[2] != 'q') {
-			return false;
-		}
-		break;
-	case 'g':
-	case 'l':
-		if (op[2] != 'e' && op[2] != 't') {
-			return false;
-		}
-		break;
-	case 'n':
-		if (op[2] != 'e') {
-			return false;
-		}
-		break;
-	default:
-		return false;
-	}
-	return !op[3] || ((op[3] == '-' || op[3] == '+') && !op[4]);
+	const char cond[] = { op[1], op[2], 0 };
+	return strstr ("eq ge gt le lt ne", cond) != NULL;
 }
 
 // only td/tdi/tw/twi carry a TO code operand, every named form (tweq, tdlgt, tdu..) encodes it in the mnemonic
 static bool op_is_trap(const char *op) {
-	if (*op != 't' || (op[1] != 'd' && op[1] != 'w')) {
-		return false;
-	}
-	const char *s = op + 2;
-	if (*s == 'i') {
-		s++;
-	}
-	return !*s;
+	return !strcmp (op, "td") || !strcmp (op, "tdi") || !strcmp (op, "tw") || !strcmp (op, "twi");
 }
 
 static const char* getspr(const char *reg) {

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -116,6 +116,51 @@ static int can_replace(const char *str, int idx, int max_operands) {
 	return true;
 }
 
+static bool op_needs_cr0(const char *op) {
+	if (r_str_startswith (op, "cmp")) {
+		return true;
+	}
+	if (*op != 'b') {
+		return false;
+	}
+	switch (op[1]) {
+	case 'e':
+		if (op[2] != 'q') {
+			return false;
+		}
+		break;
+	case 'g':
+	case 'l':
+		if (op[2] != 'e' && op[2] != 't') {
+			return false;
+		}
+		break;
+	case 'n':
+		if (op[2] != 'e') {
+			return false;
+		}
+		break;
+	default:
+		return false;
+	}
+	return !op[3] || ((op[3] == '-' || op[3] == '+') && !op[4]);
+}
+
+// only the raw t[dw] forms carry a TO code operand, the extended ones (tweq, tdlgt..) encode it in the mnemonic
+static bool op_is_trap(const char *op) {
+	if (*op != 't' || (op[1] != 'd' && op[1] != 'w')) {
+		return false;
+	}
+	const char *s = op + 2;
+	if (*s == 'u') {
+		s++;
+	}
+	if (*s == 'i') {
+		s++;
+	}
+	return !*s;
+}
+
 static const char* getspr(const char *reg) {
 	static R_TH_LOCAL char cspr[16];
 	ut32 spr = 0;
@@ -294,7 +339,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		const char *str;
 		int max_operands;
 	} ops[] = {
-		{ "cmpb", "A = ((byte) B == (byte) C)", 3}, //0
+		{ "cmpb", "A = ((byte) B == (byte) C)", 3},
 		{ "cmpd", "A = (B == C)", 3},
 		{ "cmpdi", "A = (B == C)", 3},
 		{ "cmpld", "A = ((unsigned) B == (unsigned) C)", 3},
@@ -320,29 +365,29 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "blt+", "if (A & FLG_LT) goto B", 2},
 		{ "bne", "if (A & FLG_NE) goto B", 2},
 		{ "bne-", "if (A & FLG_NE) goto B", 2},
-		{ "bne+", "if (A & FLG_NE) goto B", 2}, //26
-		{ "rldic", "A = rol64(B, C) & D", 4}, //27
-		{ "rldcl", "A = rol64(B, C) & D", 4}, //28
-		{ "rldicl", "A = rol64(B, C) & D", 4}, //29
-		{ "rldcr", "A = rol64(B, C) & D", 4}, //30
-		{ "rldicr", "A = rol64(B, C) & D", 4}, //31
-		{ "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
-		{ "rlwimi", "A = (rol32(B, C) & D) | (A & E)", 5}, //33
-		{ "rlwimi.", "A = (rol32(B, C) & D) | (A & E)", 5}, //33
-		{ "rlwinm", "A = rol32(B, C) & D", 5}, //34
-		{ "rlwinm.", "A = rol32(B, C) & D", 5}, //34
-		{ "rlwnm", "A = rol32(B, C) & D", 5}, //35
-		{ "rlwnm.", "A = rol32(B, C) & D", 5}, //35
-		{ "td", "if (B A C) trap", 3}, //36
+		{ "bne+", "if (A & FLG_NE) goto B", 2},
+		{ "rldic", "A = rol64(B, C) & D", 4},
+		{ "rldcl", "A = rol64(B, C) & D", 4},
+		{ "rldicl", "A = rol64(B, C) & D", 4},
+		{ "rldcr", "A = rol64(B, C) & D", 4},
+		{ "rldicr", "A = rol64(B, C) & D", 4},
+		{ "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5},
+		{ "rlwimi", "A = (rol32(B, C) & D) | (A & E)", 5},
+		{ "rlwimi.", "A = (rol32(B, C) & D) | (A & E)", 5},
+		{ "rlwinm", "A = rol32(B, C) & D", 5},
+		{ "rlwinm.", "A = rol32(B, C) & D", 5},
+		{ "rlwnm", "A = rol32(B, C) & D", 5},
+		{ "rlwnm.", "A = rol32(B, C) & D", 5},
+		{ "td", "if (B A C) trap", 3},
 		{ "tdi", "if (B A C) trap", 3},
 		{ "tdu", "if (B A C) trap", 3},
 		{ "tdui", "if (B A C) trap", 3},
 		{ "tw", "if ((word) B A (word) C) trap", 3},
 		{ "twi", "if ((word) B A (word) C) trap", 3},
 		{ "twu", "if ((word) B A (word) C) trap", 3},
-		{ "twui", "if ((word) B A (word) C) trap", 3}, //43
-		{ "mfspr", "A = B", 2}, //44
-		{ "mtspr", "A = B", 2}, //45
+		{ "twui", "if ((word) B A (word) C) trap", 3},
+		{ "mfspr", "A = B", 2},
+		{ "mtspr", "A = B", 2},
 		{ "add", "A = B + C", 3},
 		{ "addc", "A = B + C", 3},
 		{ "adde", "A = B + C", 3},
@@ -1463,7 +1508,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 			if (newstr) {
 				for (j = k = 0; ops[i].str[j] != '\0'; j++, k++) {
 					if (can_replace(ops[i].str, j, ops[i].max_operands)) {
-						if (i >= 0 && i <= 26 && argv[ops[i].max_operands][0] == 0) {
+						if (op_needs_cr0 (argv[0]) && argv[ops[i].max_operands][0] == 0) {
 							char* tmp = (char*) argv[ops[i].max_operands];
 							argv[ops[i].max_operands] = argv[ops[i].max_operands - 1];
 							if (ops[i].max_operands == 3) {
@@ -1505,7 +1550,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 ME = PPC_UT64(argv[4]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (0, ME));
 						} else if (letter == 4 && !strncmp (argv[0], "rldimi", 6)) {
-							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
+							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}
 							// first mask (normal)
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)
@@ -1513,7 +1558,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 ME = 63 - PPC_UT64(argv[3]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, ME));
 						} else if (letter == 5 && !strncmp (argv[0], "rldimi", 6)) {
-							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
+							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}
 							// second mask (inverted)
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)
@@ -1522,7 +1567,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 inverted = ~ (mask64 (MB, ME));
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, inverted);
 						} else if (letter == 4 && !strncmp (argv[0], "rlwimi", 6)) {
-							// { "rlwimi", "A = (rol64(B, C) & D) | (A & E)", 5}, //32
+							// { "rlwimi", "A = (rol64(B, C) & D) | (A & E)", 5}
 							// first mask (normal)
 							w = ppc_mask;
 							//MASK(MB, ME)
@@ -1530,7 +1575,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut32 ME = PPC_UT32(argv[5]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, mask32 (MB, ME));
 						} else if (letter == 5 && !strncmp (argv[0], "rlwimi", 6)) {
-							// { "rlwimi", "A = (rol32(B, C) & D) | (A & E)", 5}, //32
+							// { "rlwimi", "A = (rol32(B, C) & D) | (A & E)", 5}
 							// second mask (inverted)
 							w = ppc_mask;
 							//MASK(MB, ME)
@@ -1539,13 +1584,13 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut32 inverted = ~mask32 (MB, ME);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, inverted);
 						} else if (letter == 4 && !strncmp (argv[0], "rlwnm", 5)) {
-							// { "rlwnm", "A = rol32(B, C) & D", 5}, //32
+							// { "rlwnm", "A = rol32(B, C) & D", 5}
 							w = ppc_mask;
 							//MASK(MB, ME)
 							ut32 MB = PPC_UT32(argv[4]);
 							ut32 ME = PPC_UT32(argv[5]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, mask32 (MB, ME));
-						} else if (letter == 1 && i >= 36 && i <= 43) {
+						} else if (letter == 1 && op_is_trap (argv[0])) {
 							int to = atoi (w);
 							switch(to) {
 								case 4:
@@ -1578,7 +1623,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 									w = "?";
 									break;
 							}
-						} else if ((i == 44 && letter == 2) || (i == 45 && letter == 1)) { //spr
+						} else if ((letter == 2 && !strcmp (argv[0], "mfspr")) || (letter == 1 && !strcmp (argv[0], "mtspr"))) {
 							w = getspr (w);
 						}
 						if (w) {

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -1536,7 +1536,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							//MASK(MB, 63)
 							ut64 MB = PPC_UT64(argv[4]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, 63));
-						} else if (letter == 4 && !strncmp (argv[0], "rldic", 5)) {
+						} else if (letter == 4 && !strcmp (argv[0], "rldic")) {
 							// { "rldic", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -146,15 +146,12 @@ static bool op_needs_cr0(const char *op) {
 	return !op[3] || ((op[3] == '-' || op[3] == '+') && !op[4]);
 }
 
-// only the raw t[dw] forms carry a TO code operand, the extended ones (tweq, tdlgt..) encode it in the mnemonic
+// only td/tdi/tw/twi carry a TO code operand, every named form (tweq, tdlgt, tdu..) encodes it in the mnemonic
 static bool op_is_trap(const char *op) {
 	if (*op != 't' || (op[1] != 'd' && op[1] != 'w')) {
 		return false;
 	}
 	const char *s = op + 2;
-	if (*s == 'u') {
-		s++;
-	}
 	if (*s == 'i') {
 		s++;
 	}
@@ -380,12 +377,12 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "rlwnm.", "A = rol32(B, C) & D", 5},
 		{ "td", "if (B A C) trap", 3},
 		{ "tdi", "if (B A C) trap", 3},
-		{ "tdu", "if (B A C) trap", 3},
-		{ "tdui", "if (B A C) trap", 3},
+		{ "tdu", "trap", 0},
+		{ "tdui", "trap", 0},
 		{ "tw", "if ((word) B A (word) C) trap", 3},
 		{ "twi", "if ((word) B A (word) C) trap", 3},
-		{ "twu", "if ((word) B A (word) C) trap", 3},
-		{ "twui", "if ((word) B A (word) C) trap", 3},
+		{ "twu", "trap", 0},
+		{ "twui", "trap", 0},
 		{ "mfspr", "A = B", 2},
 		{ "mtspr", "A = B", 2},
 		{ "add", "A = B + C", 3},
@@ -1591,7 +1588,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut32 ME = PPC_UT32(argv[5]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, mask32 (MB, ME));
 						} else if (letter == 1 && op_is_trap (argv[0])) {
-							int to = atoi (w);
+							int to = PPC_UT64 (w);
 							switch(to) {
 								case 4:
 									w = "==";

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -123,3 +123,18 @@ r3 = sprg0
 sprg0 = r3
 EOF
 RUN
+
+NAME=PPC64 pseudo doubleword rotate masks are per mnemonic
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 788329c0788329c4788329c8788329cc
+pi 4
+EOF
+EXPECT=<<EOF
+r3 = rol64(r4, 5) & 0x1ffffffffffffff
+r3 = rol64(r4, 5) & 0xff00000000000000
+r3 = rol64(r4, 5) & 0x1ffffffffffffe0
+r3 = (rol64(r4, 5) & 0x1ffffffffffffe0) | (r3 & 0xfe0000000000001f)
+EOF
+RUN

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -84,3 +84,42 @@ cmpdi r9, 0
 beq 0x20c
 EOF
 RUN
+
+NAME=PPC64 pseudo rotate instructions keep their destination register
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 5c83298e5483298f
+pi 2
+EOF
+EXPECT=<<EOF
+r3 = rol32(r4, r5) & 0x3000000
+r3 = rol32(r4, 5) & 0x3000000
+EOF
+RUN
+
+NAME=PPC64 pseudo trap translates the TO code and keeps its operands
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 0ca300007c832008
+pi 2
+EOF
+EXPECT=<<EOF
+if ((word) r3 >= (word) 0) trap
+if ((word) r3 == (word) r4) trap
+EOF
+RUN
+
+NAME=PPC64 pseudo resolves special purpose register names
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 7c7042a67c7043a6
+pi 2
+EOF
+EXPECT=<<EOF
+r3 = sprg0
+sprg0 = r3
+EOF
+RUN

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -102,12 +102,16 @@ NAME=PPC64 pseudo trap translates the TO code and keeps its operands
 FILE=malloc://32
 ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
 CMDS=<<EOF
-wx 0ca300007c832008
-pi 2
+wx 0ca300007d8320080e8300077c8320087fe320880fe30007
+pi 6
 EOF
 EXPECT=<<EOF
 if ((word) r3 >= (word) 0) trap
+if ((word) r3 >= (word) r4) trap
+if ((word) r3 <= (word) 7) trap
 if ((word) r3 == (word) r4) trap
+trap
+trap
 EOF
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Supersedes #26355 by @phix33: this branch carries their three commits unchanged (authorship preserved), plus the merge with master that resolves the test-file conflict against #26350, plus one cleanup commit on top.

From #26355: `replace()` applied three special cases by hardcoded `ops[]` position (implicit `cr0` for cmp/branch, the trap `TO` code, the SPR name lookup). Three `.`-suffixed rows added later shifted the last two guards 3 rows too early, so `rlwnm`'s destination went through the TO decoder, `twi`'s operand through `getspr()` (`strtol ("r3", NULL, 16) == 0` → `mq`), and `mfspr`/`mtspr` never reached the SPR lookup. Dispatch is now by mnemonic. Two ride-along fixes: the `rldicr` arm was dead behind the `rldic` `strncmp`, and trap TO codes >= 10 are printed in hex by capstone so `atoi` never reached cases 12/20; `tdu`/`tdui`/`twu`/`twui` are TO=31 unconditional traps and fold to plain `trap`.

The extra commit here collapses the two new helpers: both are only called with a mnemonic that already matched the `ops[]` table exactly, so `op_is_trap()` can spell out its four mnemonics and `op_needs_cr0()` can match the two-letter branch condition against a word list instead of walking a switch. Verified equivalent to the originals over all 1134 table mnemonics plus a 111k-string brute force, and `db/cmd/cmd_pseudo_ppc` passes 11/11 before and after.

https://claude.ai/code/session_01UN6z9v2qYSVEzcerhtNxQk