### PR TITLE
Keep every operand in the mips and sparc pseudo fallbacks ##arch

### DIFF
--- a/libr/arch/p/mips/pseudo.c
+++ b/libr/arch/p/mips/pseudo.c
@@ -131,7 +131,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 #define WSZ 64
 
 static char *parse(RAsmPluginSession *aps, const char *data) {
-	int i, len = strlen (data);
+	int len = strlen (data);
 	char w0[WSZ];
 	char w1[WSZ];
 	char w2[WSZ];
@@ -207,8 +207,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };
-			int nw = 0;
-			for (i = 0; i < 4; i++) {
+			size_t i, nw = 0;
+			for (i = 0; i < R_ARRAY_SIZE (wa); i++) {
 				if (wa[i][0] != '\0') {
 					nw++;
 				}

--- a/libr/arch/p/sparc/pseudo.c
+++ b/libr/arch/p/sparc/pseudo.c
@@ -92,7 +92,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 #define WSZ 64
 
 static char *parse(RAsmPluginSession *aps, const char *data) {
-	int i, len = strlen (data);
+	int len = strlen (data);
 	char w0[WSZ];
 	char w1[WSZ];
 	char w2[WSZ];
@@ -170,8 +170,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };
-			int nw = 0;
-			for (i = 0; i < 4; i++) {
+			size_t i, nw = 0;
+			for (i = 0; i < R_ARRAY_SIZE (wa); i++) {
 				if (wa[i][0] != '\0') {
 					nw++;
 				}

--- a/test/db/cmd/cmd_pseudo_mips
+++ b/test/db/cmd/cmd_pseudo_mips
@@ -1,0 +1,13 @@
+NAME=MIPS pseudo keeps every operand when no rule matches
+FILE=malloc://32
+ARGS=-a mips -b 32 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 7ca449407ca449044ef8aa38
+pi 3
+EOF
+EXPECT=<<EOF
+ext a0, a1, 5, 0xa
+ins a0, a1, 4, 6
+nmsub.s f8, f23, f21, f24
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`parse()` counted only the first 4 words while `wa[]` holds 5, so an instruction with no `ops[]` rule lost its last operand in `replace()`'s fallback:

    ext a0, a1, 5, 0xa          ->  ext a0, a1, 5
    ins a0, a1, 4, 6            ->  ins a0, a1, 4
    nmsub.s f8, f23, f21, f24   ->  nmsub.s f8, f23, f21

Same fix already merged for ppc in `6ad5b6e48e`. mips and sparc were the last two parsers with the mismatch — the other nine already bound to their array size.

sparc gets the identical one-liner but no test: a scan of 300 random instructions found no unmodelled 5-word form there, so for that arch it is consistency rather than an observable fix. Test for mips in `db/cmd/cmd_pseudo_mips`.