### PR TITLE
Widen the PowerPC word rotate masks to the full ISA MASK ##arch

### DIFF
--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -7,10 +7,6 @@
 #include <r_anal.h>
 #include <r_asm.h>
 
-#ifndef PFMT32x
-#define PFMT32x "lx"
-#endif
-
 #define SPR_MQ          0x0
 #define SPR_XER         0x1
 #define SPR_RTCU        0x4
@@ -89,17 +85,10 @@
 #define SPR_PIR         0x3ff
 
 #define PPC_UT64(x) (strtol(x, NULL, 16))
-#define PPC_UT32(x) ((ut32)PPC_UT64(x))
 
 static ut64 mask64(ut64 mb, ut64 me) {
 	ut64 maskmb = UT64_MAX >> mb;
 	ut64 maskme = UT64_MAX << (63 - me);
-	return (mb <= me) ? maskmb & maskme : maskmb | maskme;
-}
-
-static ut32 mask32(ut32 mb, ut32 me) {
-	ut32 maskmb = UT32_MAX >> mb;
-	ut32 maskme = UT32_MAX << (31 - me);
 	return (mb <= me) ? maskmb & maskme : maskmb | maskme;
 }
 
@@ -1492,34 +1481,32 @@ static int replace(int argc, const char *argv[], char *newstr) {
 						int letter = ops[i].str[j] - '@';
 						const char *w = argv[letter];
 						// eprintf("%s:%d %s\n", ops[i].op, letter, w);
-						if (letter == 4 && r_str_startswith (argv[0], "rlwinm")) {
-							// { "rlwinm", "A = rol32(B, C) & D", 5},
+						// word rotates duplicate the word into both halves, so a wrapping mask keeps high bits
+						if (letter == 4 && (r_str_startswith (argv[0], "rlwinm")
+								|| r_str_startswith (argv[0], "rlwimi")
+								|| r_str_startswith (argv[0], "rlwnm"))) {
 							w = ppc_mask;
 							//MASK(MB+32, ME+32)
 							ut64 MB = PPC_UT64(argv[4]) + 32;
 							ut64 ME = PPC_UT64(argv[5]) + 32;
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, ME));
 						} else if (letter == 4 && (r_str_startswith (argv[0], "rldcl") || r_str_startswith (argv[0], "rldicl"))) {
-							// { "rld[i]cl", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							//MASK(MB, 63)
 							ut64 MB = PPC_UT64(argv[4]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, 63));
 						} else if (letter == 4 && !strcmp (argv[0], "rldic")) {
-							// { "rldic", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)
 							ut64 MB = PPC_UT64(argv[4]);
 							ut64 ME = 63 - PPC_UT64(argv[3]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, ME));
 						} else if (letter == 4 && (r_str_startswith (argv[0], "rldcr") || r_str_startswith (argv[0], "rldicr"))) {
-							// { "rld[i]cr", "A = rol64(B, C) & D", 4},
 							w = ppc_mask;
 							//MASK(0, ME)
 							ut64 ME = PPC_UT64(argv[4]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (0, ME));
 						} else if (letter == 4 && r_str_startswith (argv[0], "rldimi")) {
-							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}
 							// first mask (normal)
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)
@@ -1527,7 +1514,6 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 ME = 63 - PPC_UT64(argv[3]);
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, mask64 (MB, ME));
 						} else if (letter == 5 && r_str_startswith (argv[0], "rldimi")) {
-							// { "rldimi", "A = (rol64(B, C) & D) | (A & E)", 5}
 							// second mask (inverted)
 							w = ppc_mask;
 							//MASK(MB, 63 - SH)
@@ -1535,30 +1521,12 @@ static int replace(int argc, const char *argv[], char *newstr) {
 							ut64 ME = 63 - PPC_UT64(argv[3]);
 							ut64 inverted = ~ (mask64 (MB, ME));
 							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, inverted);
-						} else if (letter == 4 && r_str_startswith (argv[0], "rlwimi")) {
-							// { "rlwimi", "A = (rol64(B, C) & D) | (A & E)", 5}
-							// first mask (normal)
-							w = ppc_mask;
-							//MASK(MB, ME)
-							ut32 MB = PPC_UT32(argv[4]);
-							ut32 ME = PPC_UT32(argv[5]);
-							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, mask32 (MB, ME));
 						} else if (letter == 5 && r_str_startswith (argv[0], "rlwimi")) {
-							// { "rlwimi", "A = (rol32(B, C) & D) | (A & E)", 5}
-							// second mask (inverted)
 							w = ppc_mask;
-							//MASK(MB, ME)
-							ut32 MB = PPC_UT32(argv[4]);
-							ut32 ME = PPC_UT32(argv[5]);
-							ut32 inverted = ~mask32 (MB, ME);
-							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, inverted);
-						} else if (letter == 4 && r_str_startswith (argv[0], "rlwnm")) {
-							// { "rlwnm", "A = rol32(B, C) & D", 5}
-							w = ppc_mask;
-							//MASK(MB, ME)
-							ut32 MB = PPC_UT32(argv[4]);
-							ut32 ME = PPC_UT32(argv[5]);
-							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT32x, mask32 (MB, ME));
+							//MASK(MB+32, ME+32) inverted
+							ut64 MB = PPC_UT64(argv[4]) + 32;
+							ut64 ME = PPC_UT64(argv[5]) + 32;
+							snprintf (ppc_mask, sizeof (ppc_mask), "0x%"PFMT64x, ~mask64 (MB, ME));
 						} else if (letter == 1 && op_is_trap (argv[0])) {
 							int to = PPC_UT64 (w);
 							switch(to) {

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -116,12 +116,13 @@ NAME=PPC64 pseudo rotate instructions keep their destination register
 FILE=malloc://32
 ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
 CMDS=<<EOF
-wx 5c83298e5483298f
-pi 2
+wx 5c83298e5483298f5083298e
+pi 3
 EOF
 EXPECT=<<EOF
 r3 = rol32(r4, r5) & 0x3000000
 r3 = rol32(r4, 5) & 0x3000000
+r3 = (rol32(r4, 5) & 0x3000000) | (r3 & 0xfffffffffcffffff)
 EOF
 RUN
 
@@ -167,5 +168,19 @@ r3 = rol64(r4, 5) & 0x1ffffffffffffff
 r3 = rol64(r4, 5) & 0xff00000000000000
 r3 = rol64(r4, 5) & 0x1ffffffffffffe0
 r3 = (rol64(r4, 5) & 0x1ffffffffffffe0) | (r3 & 0xfe0000000000001f)
+EOF
+RUN
+
+NAME=PPC64 pseudo word rotate wrapping mask keeps the high half
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 54ef7f9550ef7f945cef2f94
+pi 3
+EOF
+EXPECT=<<EOF
+r15 = rol32(r7, 0xf) & 0xffffffffffe00003
+r15 = (rol32(r7, 0xf) & 0xffffffffffe00003) | (r15 & 0x1ffffc)
+r15 = rol32(r7, r5) & 0xffffffffffe00003
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`rlwimi` and `rlwnm` masked in 32 bits, but the Power ISA defines all three word rotates as `r <- ROTL32((RS)32:63, n)` masked by `MASK(MB+32, ME+32)`. `ROTL32` rotates `x || x`, duplicating the word into both halves, so a wrapping mask (MB > ME) legitimately keeps bits 0..31:

    rlwimi r15, r7, 0xf, 0x1e, 0xa   was  & 0xffe00003
                                     now  & 0xffffffffffe00003

Confirmed on qemu-ppc64: with `r7 = 0xAAAAAAAA55555555`, `rlwinm`/`rlwimi`/`rlwnm` at MB=30,ME=10 all leave `0xaa` in the destination's top byte; the non-wrapping forms leave `0x00`. `db/esil/ppc_64` already asserted the wide value for `rlwnm`, so the ESIL implementation and the pseudo filter now agree.

`rlwinm` was already correct, which makes the three arms identical — merged here, leaving the local `mask32` helper unused and removed.