### PR TITLE
Make the afvs stack delta frame relative like afvb ##analysis

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -3894,8 +3894,8 @@ static char *synth_commands(RAnal *anal, RAnalFunction *fcn, RVecSynthRec *recs)
 				r_strbuf_appendf (sb, "'afvr %s %s struct %s *\n", ri->name, av->name, rec->bt->name);
 			}
 		} else {
-			const int delta = av->kind == R_ANAL_VAR_KIND_BPV? av->delta + fcn->bp_off: av->delta;
-			r_strbuf_appendf (sb, "'afv%c %d %s struct %s *\n", av->kind, delta, av->name, rec->bt->name);
+			const st64 delta = r_anal_var_frame_delta (anal, fcn, av->kind, av->delta);
+			r_strbuf_appendf (sb, "'afv%c %"PFMT64d" %s struct %s *\n", av->kind, delta, av->name, rec->bt->name);
 		}
 	}
 	R_VEC_FOREACH (recs, rec) {

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -613,6 +613,26 @@ R_API RAnalVar *r_anal_function_get_var(RAnalFunction *fcn, char kind, int delta
 	return NULL;
 }
 
+static st64 var_frame_base(RAnal *anal, RAnalFunction *fcn, int kind) {
+	if (kind == R_ANAL_VAR_KIND_BPV) {
+		return fcn->bp_off;
+	}
+	if (kind == R_ANAL_VAR_KIND_SPV && !anal->opt.var_newstack) {
+		return fcn->maxstack;
+	}
+	return 0;
+}
+
+R_API st64 r_anal_var_frame_delta(RAnal *anal, RAnalFunction *fcn, int kind, st64 delta) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn, delta);
+	return delta + var_frame_base (anal, fcn, kind);
+}
+
+R_API st64 r_anal_var_raw_delta(RAnal *anal, RAnalFunction *fcn, int kind, st64 delta) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn, delta);
+	return delta - var_frame_base (anal, fcn, kind);
+}
+
 R_API ut64 r_anal_var_addr(RAnalVar *var) {
 	R_RETURN_VAL_IF_FAIL (var, UT64_MAX);
 	RAnal *anal = var->fcn->anal;
@@ -1934,7 +1954,6 @@ static int var_ptr_comparator(RAnalVar * const *a, RAnalVar * const *b) {
 
 R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int mode, PJ *pj) {
 	R_RETURN_IF_FAIL (anal && fcn);
-	bool newstack = anal->opt.var_newstack;
 	if (!pj && mode == 'j') {
 		return;
 	}
@@ -1971,17 +1990,15 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 				anal->cb_printf ("'afv%c %s %s %s\n",
 					kind, i->name, var->name, var->type);
 			} else {
-				int delta = kind == R_ANAL_VAR_KIND_BPV
-					? var->delta + fcn->bp_off
-					: var->delta;
-				anal->cb_printf ("'afv%c %d %s %s\n",
-					kind, delta, var->name, var->type);
+				anal->cb_printf ("'afv%c %"PFMT64d" %s %s\n", kind,
+					r_anal_var_frame_delta (anal, fcn, kind, var->delta),
+					var->name, var->type);
 			}
 			break;
 		case 'j':
 			switch (var->kind) {
 			case R_ANAL_VAR_KIND_BPV: {
-				st64 delta = (st64)var->delta + fcn->bp_off;
+				st64 delta = r_anal_var_frame_delta (anal, fcn, var->kind, var->delta);
 				pj_o (pj);
 				pj_ks (pj, "name", var->name);
 				if (var->isarg) {
@@ -2016,7 +2033,7 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 			}
 				break;
 			case R_ANAL_VAR_KIND_SPV: {
-				st64 delta = (st64)var->delta + fcn->maxstack;
+				st64 delta = r_anal_var_frame_delta (anal, fcn, var->kind, var->delta);
 				pj_o (pj);
 				pj_ks (pj, "name", var->name);
 				if (var->isarg) {
@@ -2067,7 +2084,7 @@ R_API void r_anal_var_list_show(RAnal *anal, RAnalFunction *fcn, int kind, int m
 				break;
 			case R_ANAL_VAR_KIND_SPV:
 			{
-				int delta = newstack? var->delta: fcn->maxstack + var->delta;
+				int delta = (int)r_anal_var_frame_delta (anal, fcn, var->kind, var->delta);
 				const char *spreg = r_reg_alias_getname (anal->reg, R_REG_ALIAS_SP);
 				if (!var->isarg) {
 					char sign = (-var->delta <= fcn->maxstack) ? '+' : '-';

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3169,12 +3169,11 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	if (fcn->folded) {
 		r_cons_printf (cons, "afF @ 0x%08"PFMT64x"\n", fcn->addr);
 	}
-	if (fcn) {
-		/* show variables  and arguments */
-		r_core_cmdf (core, "afvb* @ 0x%"PFMT64x, fcn->addr);
-		r_core_cmdf (core, "afvr* @ 0x%"PFMT64x, fcn->addr);
-		r_core_cmdf (core, "afvs* @ 0x%"PFMT64x, fcn->addr);
-	}
+	// afS goes first, the afv[bs] offsets that follow are relative to the frame size
+	r_cons_printf (cons, "'0x%"PFMT64x"'afS %d\n", fcn->addr, fcn->maxstack);
+	r_core_cmdf (core, "afvb* @ 0x%"PFMT64x, fcn->addr);
+	r_core_cmdf (core, "afvr* @ 0x%"PFMT64x, fcn->addr);
+	r_core_cmdf (core, "afvs* @ 0x%"PFMT64x, fcn->addr);
 	/* Show references */
 	RVecAnalRef *refs = r_anal_function_get_refs (fcn);
 	if (refs) {
@@ -3197,8 +3196,6 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 		}
 	}
 	RVecAnalRef_free (refs);
-	/* Saving Function stack frame */
-	r_cons_printf (cons, "'0x%"PFMT64x"'afS %d\n", fcn->addr, fcn->maxstack);
 	if (fcn->pin) {
 		r_cons_printf (cons, "'0x%"PFMT64x"'aflp %s\n", fcn->addr, fcn->pin);
 	}

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -907,7 +907,7 @@ static RCoreHelpMessage help_msg_afvb = {
 	"afvb*", "", "same as afvb but in r2 commands",
 	"afvb", " [idx] [name] ([type])", "define base pointer based arguments, locals",
 	"afvbj", "", "return list of base pointer based arguments, locals in JSON format",
-	"afvb-", " [name]", "delete argument/locals at the given name",
+	"afvb-", " [name|idx]", "delete the argument/local with that name or frame offset (--N for negative)",
 	"afvbg", " [idx] [addr]", "define var get reference",
 	"afvbs", " [idx] [addr]", "define var set reference",
 	NULL
@@ -919,7 +919,7 @@ static RCoreHelpMessage help_msg_afvr = {
 	"afvr*", "", "same as afvr but in r2 commands",
 	"afvr", " [reg] [name] ([type])", "define register arguments",
 	"afvrj", "", "return list of register arguments in JSON format",
-	"afvr-", " [name]", "delete register arguments at the given index",
+	"afvr-", " [name|idx]", "delete the register argument with that name or index",
 	"afvrg", " [reg] [addr]", "define argument get reference",
 	"afvrs", " [reg] [addr]", "define argument set reference",
 	NULL
@@ -931,7 +931,7 @@ static RCoreHelpMessage help_msg_afvs = {
 	"afvs*", "", "same as afvs but in r2 commands",
 	"afvs", " [idx] [name] [type]", "define stack based arguments,locals",
 	"afvsj", "", "return list of stack based arguments and locals in JSON format",
-	"afvs-", " [name]", "delete stack based argument or locals with the given name",
+	"afvs-", " [name|idx]", "delete the stack argument/local with that name or frame offset (--N for negative)",
 	"afvsg", " [idx] [addr]", "define var get reference",
 	"afvss", " [idx] [addr]", "define var set reference",
 	NULL
@@ -1690,11 +1690,9 @@ static void list_vars(RCore *core, RAnalFunction *fcn, PJ *pj, int type, const c
 								ri->name, sname, stype);
 					}
 				} else {
-					int delta = (var->kind == R_ANAL_VAR_KIND_BPV)
-						? var->delta + fcn->bp_off
-						: var->delta;
-					r_cons_printf (core->cons, "'afv%c %d %s %s\n",
-							var->kind, delta, sname, stype);
+					r_cons_printf (core->cons, "'afv%c %"PFMT64d" %s %s\n", var->kind,
+							r_anal_var_frame_delta (core->anal, fcn, var->kind, var->delta),
+							sname, stype);
 				}
 			}
 			free (sname);
@@ -2276,8 +2274,10 @@ static int cmd_afv(RCore *core, const char *str) {
 			r_anal_function_delete_vars_by_kind (fcn, type);
 		} else {
 			RAnalVar *var = NULL;
-			if (isdigit (str[2] & 0xff)) {
-				var = r_anal_function_get_var (fcn, type, (int)r_num_math (core->num, str + 1));
+			if (isdigit (str[2] & 0xff) || (str[2] == '-' && isdigit (str[3] & 0xff))) {
+				const st64 idx = r_num_math (core->num, str + 2);
+				var = r_anal_function_get_var (fcn, type,
+					(int)r_anal_var_raw_delta (core->anal, fcn, type, idx));
 			} else {
 				char *name = r_str_trim_dup (str + 2);
 				if (name) {
@@ -2305,17 +2305,17 @@ static int cmd_afv(RCore *core, const char *str) {
 			if ((vaddr = strchr (p, ' '))) {
 				addr = r_num_math (core->num, vaddr);
 			}
-			RAnalVar *var = r_anal_function_get_var (fcn, str[0], idx);
+			const st64 delta = r_anal_var_raw_delta (core->anal, fcn, str[0], idx);
+			RAnalVar *var = r_anal_function_get_var (fcn, str[0], (int)delta);
 			if (!var) {
 				R_LOG_ERROR ("Cannot find variable with delta %d", idx);
 				res = false;
 				break;
 			}
 			int rw = (str[1] == 'g') ? R_PERM_R : R_PERM_W;
-			int ptr = *var->type == 's' ? idx - fcn->maxstack : idx;
 			RAnalOp *op = r_core_anal_op (core, addr, 0);
 			const char *ireg = op ? op->ireg : NULL;
-			r_anal_var_set_access (core->anal, var, ireg, addr, rw, ptr);
+			r_anal_var_set_access (core->anal, var, ireg, addr, rw, idx);
 			r_anal_op_free (op);
 		} else {
 			R_LOG_ERROR ("Missing argument");
@@ -2363,13 +2363,9 @@ static int cmd_afv(RCore *core, const char *str) {
 				  *vartype++ = 0;
 				  r_str_trim (vartype);
 			  }
-			  if (type == 'b') {
-				  delta -= fcn->bp_off;
-			  }
-			  if ((type == 'b') && delta > 0) {
-				  isarg = true;
-			  } else if (type == 's' && delta > fcn->maxstack) {
-				  isarg = true;
+			  delta = (int)r_anal_var_raw_delta (core->anal, fcn, type, delta);
+			  if (delta >= 0) {
+				  isarg = true; // frame delta 0 is the first argument slot
 			  }
 			  r_anal_function_set_var (fcn, delta, type, vartype, size, isarg, name);
 		  }

--- a/libr/core/cmd_meta.inc.c
+++ b/libr/core/cmd_meta.inc.c
@@ -1343,6 +1343,20 @@ static void comment_var_help(RCore *core, char type) {
 	}
 }
 
+static RAnalVar *comment_var_find(RCore *core, RAnalFunction *fcn, int kind, const char *name) {
+	RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
+	if (!var && R_STR_ISNOTEMPTY (name)) {
+		const char *err = NULL;
+		const st64 idx = (st64)r_num_get_err (core->num, name, &err);
+		// a name that is not a number must not resolve as offset 0, which is a real slot
+		if (!err) {
+			var = r_anal_function_get_var (fcn, kind,
+				(int)r_anal_var_raw_delta (core->anal, fcn, kind, idx));
+		}
+	}
+	return var;
+}
+
 static void cmd_Cv(RCore *core, const char *input) {
 	// TODO enable base64 and make it the default for C*
 	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, 0);
@@ -1392,11 +1406,7 @@ static void cmd_Cv(RCore *core, const char *input) {
 				comment = heap_comment;
 			}
 		}
-		RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
-		if (!var) {
-			const int idx = (int)strtol (name, NULL, 0);
-			var = r_anal_function_get_var (fcn, input[0], idx);
-		}
+		RAnalVar *var = comment_var_find (core, fcn, input[0], name);
 		if (var) {
 			if (var->comment) {
 				if (R_STR_ISNOTEMPTY (comment)) {
@@ -1418,11 +1428,7 @@ static void cmd_Cv(RCore *core, const char *input) {
 	case '-': { // "Cv-"
 		name++;
 		r_str_trim (name);
-		RAnalVar *var = r_anal_function_get_var_byname (fcn, name);
-		if (!var) {
-			int idx = (int)strtol (name, NULL, 0);
-			var = r_anal_function_get_var (fcn, input[0], idx);
-		}
+		RAnalVar *var = comment_var_find (core, fcn, input[0], name);
 		if (!var) {
 			R_LOG_ERROR ("can't find variable at given offset");
 			break;

--- a/libr/core/p/newprj/load.inc.c
+++ b/libr/core/p/newprj/load.inc.c
@@ -324,10 +324,7 @@ static void rprj_function_attr_load(RPrjCursor *cur, RAnalFunction *fcn, R2Proje
 	const char *cc = attr->cc != UT32_MAX? rprj_st_get (cur->st, attr->cc): NULL;
 	if (mode & R_CORE_NEWPRJ_MODE_SCRIPT) {
 		if (R_STR_ISNOTEMPTY (cc)) {
-			r_strbuf_appendf (cur->out, "'afc %s @ 0x%08"PFMT64x"\n", cc, va);
-		}
-		if ((st64)attr->stack) {
-			r_strbuf_appendf (cur->out, "'afS %"PFMT64d" @ 0x%08"PFMT64x"\n", (st64)attr->stack, va);
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afc %s\n", va, cc);
 		}
 		if (attr->flags & RPRJ_FUNC_ATTR_NORETURN) {
 			r_strbuf_appendf (cur->out, "'tn 0x%08"PFMT64x"\n", va);
@@ -347,7 +344,7 @@ static void rprj_function_attr_load(RPrjCursor *cur, RAnalFunction *fcn, R2Proje
 	}
 }
 
-static void rprj_var_load(RPrjCursor *cur, RAnalFunction *fcn, R2ProjectVar *pvar, int mode, ut64 fcn_addr) {
+static void rprj_var_load(RPrjCursor *cur, RAnalFunction *fcn, R2ProjectVar *pvar, int mode, ut64 fcn_addr, st64 stack) {
 	const char *name = rprj_st_get (cur->st, pvar->name);
 	const char *type = rprj_st_get (cur->st, pvar->type);
 	if (!name) {
@@ -363,18 +360,21 @@ static void rprj_var_load(RPrjCursor *cur, RAnalFunction *fcn, R2ProjectVar *pva
 					? r_reg_index_get (cur->core->anal->reg, R_ABS (pvar->delta))
 					: NULL;
 				if (reg) {
-					r_strbuf_appendf (cur->out, "'afvr %s %s %s @ 0x%08"PFMT64x"\n",
-						reg->name, name, typ, fcn_addr);
+					r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvr %s %s %s\n",
+						fcn_addr, reg->name, name, typ);
 				}
 			}
 			break;
 		case R_ANAL_VAR_KIND_BPV:
-			r_strbuf_appendf (cur->out, "'afvb %d %s %s @ 0x%08"PFMT64x"\n",
-				pvar->delta, name, typ, fcn_addr);
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvb %d %s %s\n",
+				fcn_addr, pvar->delta, name, typ);
 			break;
 		case R_ANAL_VAR_KIND_SPV:
-			r_strbuf_appendf (cur->out, "'afvs %d %s %s @ 0x%08"PFMT64x"\n",
-				pvar->delta, name, typ, fcn_addr);
+			{
+				const st64 delta = cur->core->anal->opt.var_newstack? pvar->delta: stack + pvar->delta;
+				r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvs %"PFMT64d" %s %s\n",
+					fcn_addr, delta, name, typ);
+			}
 			break;
 		default:
 			break;
@@ -572,7 +572,7 @@ static bool rprj_current_hint_value(RAnal *anal, ut64 addr, RAnalAddrHintType ty
 	return false;
 }
 
-static void rprj_print_var_script(RPrjCursor *cur, RAnalVar *var, ut64 fcn_addr) {
+static void rprj_print_var_script(RPrjCursor *cur, RAnalFunction *fcn, RAnalVar *var) {
 	if (!var || R_STR_ISEMPTY (var->name)) {
 		return;
 	}
@@ -580,17 +580,21 @@ static void rprj_print_var_script(RPrjCursor *cur, RAnalVar *var, ut64 fcn_addr)
 	switch (var->kind) {
 	case R_ANAL_VAR_KIND_REG:
 		if (R_STR_ISNOTEMPTY (var->regname)) {
-			r_strbuf_appendf (cur->out, "'afvr %s %s %s @ 0x%08"PFMT64x"\n",
-				var->regname, var->name, type, fcn_addr);
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvr %s %s %s\n",
+				fcn->addr, var->regname, var->name, type);
 		}
 		break;
 	case R_ANAL_VAR_KIND_BPV:
-		r_strbuf_appendf (cur->out, "'afvb %d %s %s @ 0x%08"PFMT64x"\n",
-			var->delta, var->name, type, fcn_addr);
+		// nothing restores bp_off on replay (af+ and the loader both leave it 0), so bp deltas stay raw
+		r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvb %d %s %s\n",
+			fcn->addr, var->delta, var->name, type);
 		break;
 	case R_ANAL_VAR_KIND_SPV:
-		r_strbuf_appendf (cur->out, "'afvs %d %s %s @ 0x%08"PFMT64x"\n",
-			var->delta, var->name, type, fcn_addr);
+		// the afS emitted above restores the frame these offsets are relative to
+		r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afvs %"PFMT64d" %s %s\n",
+			fcn->addr,
+			r_anal_var_frame_delta (cur->core->anal, fcn, var->kind, var->delta),
+			var->name, type);
 		break;
 	default:
 		break;
@@ -599,11 +603,10 @@ static void rprj_print_var_script(RPrjCursor *cur, RAnalVar *var, ut64 fcn_addr)
 
 static void rprj_print_function_attrs(RPrjCursor *cur, RAnalFunction *fcn) {
 	if (R_STR_ISNOTEMPTY (fcn->callconv)) {
-		r_strbuf_appendf (cur->out, "'afc %s @ 0x%08"PFMT64x"\n", fcn->callconv, fcn->addr);
+		r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afc %s\n", fcn->addr, fcn->callconv);
 	}
-	if (fcn->maxstack) {
-		r_strbuf_appendf (cur->out, "'afS %d @ 0x%08"PFMT64x"\n", fcn->maxstack, fcn->addr);
-	}
+	// always emitted, even for an empty frame, because the afv[bs] offsets are relative to it
+	r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afS %d\n", fcn->addr, fcn->maxstack);
 	if (fcn->is_noreturn) {
 		r_strbuf_appendf (cur->out, "'tn 0x%08"PFMT64x"\n", fcn->addr);
 	}
@@ -614,7 +617,6 @@ static void rprj_print_function_script(RPrjCursor *cur, RAnalFunction *fcn) {
 		return;
 	}
 	r_strbuf_appendf (cur->out, "'af+ 0x%08"PFMT64x" %s\n", fcn->addr, fcn->name);
-	rprj_print_function_attrs (cur, fcn);
 	RListIter *iter;
 	RAnalBlock *bb;
 	r_list_foreach (fcn->bbs, iter, bb) {
@@ -625,9 +627,11 @@ static void rprj_print_function_script(RPrjCursor *cur, RAnalFunction *fcn) {
 				bb->color.r, bb->color.g, bb->color.b, bb->addr);
 		}
 	}
+	// after the blocks, before the vars: afS needs a resolvable function and sets the frame the afv[bs] offsets use
+	rprj_print_function_attrs (cur, fcn);
 	RAnalVar **var;
 	R_VEC_FOREACH (&fcn->vars, var) {
-		rprj_print_var_script (cur, *var, fcn->addr);
+		rprj_print_var_script (cur, fcn, *var);
 	}
 }
 
@@ -668,11 +672,11 @@ static void rprj_diff_function_attrs(RPrjCursor *cur, RAnalFunction *fcn, R2Proj
 	const st64 stack = attr? (st64)attr->stack: 0;
 	if (strcmp (r_str_get (cc), r_str_get (fcn->callconv))) {
 		if (R_STR_ISNOTEMPTY (fcn->callconv)) {
-			r_strbuf_appendf (cur->out, "'afc %s @ 0x%08"PFMT64x"\n", fcn->callconv, fcn->addr);
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afc %s\n", fcn->addr, fcn->callconv);
 		}
 	}
 	if (stack != fcn->maxstack) {
-		r_strbuf_appendf (cur->out, "'afS %d @ 0x%08"PFMT64x"\n", fcn->maxstack, fcn->addr);
+		r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afS %d\n", fcn->addr, fcn->maxstack);
 	}
 	if (noret != fcn->is_noreturn) {
 		r_strbuf_appendf (cur->out, fcn->is_noreturn
@@ -692,7 +696,7 @@ static void rprj_diff_function_vars(RPrjCursor *cur, RAnalFunction *fcn, RList *
 		if (!pvar || pvar->isarg != (var->isarg? 1: 0)
 				|| strcmp (r_str_get (pvar->name), r_str_get (var->name))
 				|| strcmp (r_str_get (pvar->type), r_str_get (var->type))) {
-			rprj_print_var_script (cur, var, fcn->addr);
+			rprj_print_var_script (cur, fcn, var);
 		}
 	}
 	RListIter *iter;
@@ -870,6 +874,11 @@ static void rprj_function_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 				rprj_block_load (cur, fcn, &pbb, mode, va, colors, ncolors);
 			}
 		}
+		const st64 fstack = pfcn.attr < nattrs? (st64)attrs[pfcn.attr].stack: 0;
+		if (resolved && (mode & R_CORE_NEWPRJ_MODE_SCRIPT)) {
+			// always emitted, even for an empty frame, because the afvs offsets below are relative to it
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afS %"PFMT64d"\n", va, fstack);
+		}
 		const ut64 vbmax = rprj_entry_remaining (b, next_entry) / RPRJ_VAR_SIZE;
 		if (pfcn.nvars > vbmax) {
 			R_LOG_WARN ("Invalid variable count %u in function %u/%u", pfcn.nvars, i, count);
@@ -885,7 +894,7 @@ static void rprj_function_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 				if (diff) {
 					rprj_function_diff_var (cur, &pvar, pvars);
 				}
-				rprj_var_load (cur, fcn, &pvar, mode, va);
+				rprj_var_load (cur, fcn, &pvar, mode, va, fstack);
 			}
 		}
 		if (diff && resolved) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1339,6 +1339,9 @@ R_API bool r_anal_var_rename(RAnal *anal, RAnalVar *var, const char *new_name);
 R_API void r_anal_var_set_type(RAnal *anal, RAnalVar *var, const char *type);
 R_API bool r_anal_var_delete(RAnal *anal, RAnalVar *var);
 R_API ut64 r_anal_var_addr(RAnalVar *var);
+// convert between a raw variable delta and the frame relative offset afv[bs] shows and takes
+R_API st64 r_anal_var_frame_delta(RAnal *anal, RAnalFunction *fcn, int kind, st64 delta);
+R_API st64 r_anal_var_raw_delta(RAnal *anal, RAnalFunction *fcn, int kind, st64 delta);
 R_API bool r_anal_var_set_access(RAnal *anal, RAnalVar *var, const char *reg, ut64 access_addr, int access_type, st64 stackptr);
 R_API void r_anal_var_remove_access_at(RAnalVar *var, ut64 address);
 R_API void r_anal_var_clear_accesses(RAnalVar *var);

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -686,16 +686,16 @@ EOF
 EXPECT=<<EOF
 'afvr rdi argc int
 'afvr rsi argv char **
-'afvs -64 var_48h int64_t
-'afvs -88 var_30h int64_t
-'afvs -113 var_17h int64_t
-'afvs -128 var_8h int64_t
-'afvs -96 var_28h int64_t
-'afvs -80 var_38h int64_t
-'afvs -67 var_45h int64_t
-'afvs -65 var_47h int64_t
-'afvs -66 var_46h int64_t
-'afvs -112 var_18h int64_t
-'afvs -86 var_32h int64_t
+'afvs 88 var_48h int64_t
+'afvs 64 var_30h int64_t
+'afvs 39 var_17h int64_t
+'afvs 24 var_8h int64_t
+'afvs 56 var_28h int64_t
+'afvs 72 var_38h int64_t
+'afvs 85 var_45h int64_t
+'afvs 87 var_47h int64_t
+'afvs 86 var_46h int64_t
+'afvs 40 var_18h int64_t
+'afvs 66 var_32h int64_t
 EOF
 RUN

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -289,6 +289,7 @@ afb+ 0x100000da0 0x100000e90 9 0x100000eba 0xffffffffffffffff
 s 0x100000da0
 'afc amd64
 s-
+'0x100000da0'afS 8
 s 0x100000da0
 'afvb -1 var_1h int64_t
 'afvb -16 var_10h int64_t
@@ -318,7 +319,6 @@ s-
 'axc 0x100000e99 0x100000e8b
 'axc 0x100000eba 0x100000e94
 'axc 0x100000e9e 0x100000e99
-'0x100000da0'afS 8
 
 EOF
 RUN

--- a/test/db/cmd/cmd_afv
+++ b/test/db/cmd/cmd_afv
@@ -10,3 +10,48 @@ EXPECT=<<EOF
 not segfaulted
 EOF
 RUN
+
+NAME=afvs takes and reports the stack offset the listing shows
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e anal.cc=ms
+CMDS=<<EOF
+wx 488b4424288b08c3
+af
+afvs 0x30 zzz int
+afvs
+afvs*
+afvsj~{}~offset
+afvss 0x30
+?e access set
+EOF
+EXPECT=<<EOF
+arg int64_t arg_28h @ rsp+0x28
+arg int zzz @ rsp+0x30
+s 0x0
+'afvs 40 arg_28h int64_t
+'afvs 48 zzz int
+s-
+      "offset": 40
+      "offset": 48
+access set
+EOF
+RUN
+
+NAME=afvs delete and comment take the offset the listing shows
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e anal.cc=ms
+CMDS=<<EOF
+wx 488b4424288b08c3
+af
+afvs 0x30 zzz int
+Cvs 0x30 hello
+Cvs 0x30
+afvs-0x30
+afvs 40 redef int64_t
+afvs
+EOF
+EXPECT=<<EOF
+hello
+arg int64_t redef @ rsp+0x28
+EOF
+RUN

--- a/test/db/cmd/cmd_meta
+++ b/test/db/cmd/cmd_meta
@@ -153,6 +153,25 @@ EOF
 RUN
 
 
+NAME=Cv only takes the argument as an offset when it is a number
+FILE=malloc://256
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488b4424288b08c3
+af
+afvs 0 zero int
+Cvs zero mycomment
+Cvs nosuchvar clobbered
+Cvs zero
+EOF
+EXPECT=<<EOF
+mycomment
+EOF
+EXPECT_ERR=<<EOF
+ERROR: can't find variable at given offset
+EOF
+RUN
+
 NAME=Cvb variable null pointer deref
 FILE=bins/elf/analysis/x64-simple
 CMDS=<<EOF

--- a/test/db/cmd/newprj
+++ b/test/db/cmd/newprj
@@ -564,7 +564,7 @@ prj r2 .tmp/newprj-regscript.prj~afvr
 rm .tmp/newprj-regscript.prj
 EOF
 EXPECT=<<EOF
-'afvr x0 reg_arg int @ 0x00000010
+'0x00000010'afvr x0 reg_arg int
 EOF
 RUN
 
@@ -722,7 +722,7 @@ EXPECT=<<EOF
 'afn live.fcn 0x00000040
 'afbc rgb:0000ff 0x00000040
 'afb+ 0x00000040 0x00000044 4 0xffffffffffffffff 0xffffffffffffffff
-'afvb -4 live_var int @ 0x00000040
+'0x00000040'afvb -4 live_var int
 EOF
 RUN
 
@@ -746,5 +746,46 @@ EOF
 EXPECT=<<EOF
 open.flag
 41
+EOF
+RUN
+
+NAME=newprj stack vars round-trip across a session with a different frame size
+FILE=malloc://256
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+e anal.cc=ms
+wx 488b4424288b08c3
+af
+afvs 0x30 zzz int
+prj save .tmp/newprj-spv.prj > /dev/null
+af-*
+e anal.cc=amd64
+af
+prj load .tmp/newprj-spv.prj > /dev/null
+afvs
+EOF
+EXPECT=<<EOF
+arg int64_t arg_28h @ rsp+0x28
+arg int zzz @ rsp+0x30
+EOF
+RUN
+
+NAME=newprj bp vars keep their raw delta in the diff and r2 scripts
+FILE=malloc://256
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+mkdir .tmp
+rm -f .tmp/newprj-bpvframe.prj
+wx 554889e54883ec20897dfc90c9c3
+af
+prj save .tmp/newprj-bpvframe.prj > /dev/null
+afvb -4 renamed int
+prj diff .tmp/newprj-bpvframe.prj~afvb
+prj r2 .tmp/newprj-bpvframe.prj~afvb
+rm .tmp/newprj-bpvframe.prj
+EOF
+EXPECT=<<EOF
+'0x00000000'afvb -12 renamed int
+'0x00000000'afvb -12 var_4h int64_t
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`afvb` subtracts `fcn->bp_off` from its input, but `afvs` stored its delta raw while the listing printed `fcn->maxstack + delta`. So on a function with a 0x28-byte frame, `afvs 0x30 x int` created a variable that lists at `rsp+0x58`, and the offset `afvs*` emitted could not be fed back to `afvs`.

Now every `afv[bs]` surface speaks the offset the listing shows: the command input, the `afvs*`/`afts*`/`afvsj` emitters, the `afv[bs]g`/`afv[bs]s` access lookups, delete-by-offset, the `Cv[bs]` variable-comment lookup and the project scripts. Two helpers, `r_anal_var_frame_delta` and `r_anal_var_raw_delta`, replace the conversion that was open-coded at 11 sites; both honor `anal.vars.newstack`.

Fixed in passing:

- `afv[bs]g`/`afv[bs]s` tested `*var->type == 's'` (the type *string*, so it fired on `short`/`signed`/`struct`) instead of the variable kind.
- `isarg` is now `delta >= 0`, matching what the analyzer itself records.
- `afl*` and the project script emitted `afS` *after* the `afv` lines; the new convention makes the offsets depend on it, so it has to come first.
- `Cv[bsr]` treated any unmatched name as a number, so a typo resolved to offset 0 and silently commented the wrong variable.

Basic-pointer deltas in the project scripts stay raw on purpose: nothing restores `bp_off` on replay, so a script's `afvb` offsets are already relative to the frame it rebuilds.

Full test suite: 0 regressions, 5 new tests.