### PR TITLE
Keep the dereference count when typing a callee argument ##analysis

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -854,6 +854,12 @@ static char *tp_built_type(RAnalVar *var, const char *vname, const char *type, i
 	} else if (r_str_startswith (tmp1, "int")) {
 		r_strbuf_set (&sb, "int32_t");
 	}
+	r_strbuf_trim (&sb);
+	// a dereferenced void pointer carries no fact, and a void variable is unusable
+	if (!strcmp (r_strbuf_get (&sb), "void")) {
+		r_strbuf_fini (&sb);
+		return NULL;
+	}
 	return r_strbuf_drain_nofree (&sb);
 }
 
@@ -1187,7 +1193,7 @@ static bool parse_format(TPState *tps, const char *fmt, RVecString *vec) {
 	return true;
 }
 
-static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stack, const char *place, int soff, const char *type) {
+static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stack, const char *place, int soff, const char *type, int ref) {
 	R_LOG_DEBUG (">>> CALLE ARG");
 	if (!type) {
 		return;
@@ -1205,7 +1211,7 @@ static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stac
 			return;
 		}
 		// callee vars belong to another function, so their facts stay out of this pass's lattice
-		var_retype (anal, var, NULL, type, false, false);
+		var_retype (anal, var, NULL, type, ref, false);
 	} else {
 		if (R_STR_ISEMPTY (place)) {
 			return;
@@ -1220,10 +1226,10 @@ static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stac
 			return;
 		}
 		char *t = strdup (type);
-		var_retype (anal, rvar, NULL, type, false, false);
+		var_retype (anal, rvar, NULL, type, ref, false);
 		RAnalVar *lvar = r_anal_var_get_dst_var (rvar);
 		if (lvar) {
-			var_retype (anal, lvar, NULL, t, false, false);
+			var_retype (anal, lvar, NULL, t, ref, false);
 		}
 		free (t);
 		r_unref (item);
@@ -1231,11 +1237,11 @@ static void retype_callee_arg(RAnal *anal, const char *callee_name, bool in_stac
 }
 
 static void propagate_arg_type(TPState *tps, ut64 baddr, RAnalVar *var, const char *name, const char *type,
-		int var_memref, const char *fcn_name, bool in_stack, const char *place,
+		int var_memref, int callee_ref, const char *fcn_name, bool in_stack, const char *place,
 		int soff, ut64 addr, bool userfnc) {
 	RAnal *anal = tps->anal;
 	if (userfnc) {
-		retype_callee_arg (anal, fcn_name, in_stack, place, soff, var->type);
+		retype_callee_arg (anal, fcn_name, in_stack, place, soff, var->type, -callee_ref);
 	} else {
 		tp_var_retype (tps, baddr, var, name, type, var_memref, false);
 		var_rename (anal, var, name, addr);
@@ -1597,16 +1603,41 @@ static void tp_field_from_arg(TPState *tps, int idx, RAnalVar *var, RAnalOp *op,
 	tp_retype_field_chain (anal, var->type, &seq, type, width, false);
 }
 
+// a value that arrived from memory: mov, cmov, load, or a memory-operand push, counted
+// only when the trace confirms the read happened, so an untaken cmov never counts
+static bool tp_op_loads_value(TypeTrace *tt, RAnalOp *op, ut32 j) {
+	switch ((op->type & R_ANAL_OP_TYPE_MASK) & ~R_ANAL_OP_TYPE_COND) {
+	case R_ANAL_OP_TYPE_MOV:
+	case R_ANAL_OP_TYPE_LOAD:
+	case R_ANAL_OP_TYPE_PUSH:
+	case R_ANAL_OP_TYPE_UPUSH:
+		return etrace_have_memread (tt, j);
+	}
+	return false;
+}
+
 // with a deref chain the var holds the base pointer, so only its member is typed
 static void tp_apply_arg_type(TPState *tps, ut64 baddr, int j, RAnalVar *var, RAnalOp *op, TPFieldChain *chain,
 		const char *name, const char *type, int memref, bool lea_adjust,
 		const char *fcn_name, bool in_stack, const char *place, int soff, ut64 addr, bool userfnc) {
 	if (!tps->cfg_fields || !chain->len) {
 		int var_memref = var->isarg? 0: memref;
-		if (lea_adjust && op->type == R_ANAL_OP_TYPE_LEA) {
-			var_memref--;
+		int callee_ref = memref;
+		if (lea_adjust) {
+			const bool regvar = var->kind == R_ANAL_VAR_KIND_REG;
+			// the copy chain counted its loads into memref, the hit op's own load is not in it yet
+			if (regvar && tp_op_loads_value (&tps->tt, op, j)) {
+				callee_ref++;
+			}
+			if ((op->type & R_ANAL_OP_TYPE_MASK) == R_ANAL_OP_TYPE_LEA) {
+				var_memref--;
+				// address-of holds for a stack var; on a register var lea is pointer arithmetic
+				if (!regvar && !strchr (var->type, '[')) {
+					callee_ref--;
+				}
+			}
 		}
-		propagate_arg_type (tps, baddr, var, name, type, var_memref,
+		propagate_arg_type (tps, baddr, var, name, type, var_memref, callee_ref,
 			fcn_name, in_stack, place, soff, addr, userfnc);
 	}
 	if (tps->cfg_fields) {
@@ -1888,7 +1919,7 @@ static void type_match(TPState *tps, char *fcn_name, ut64 addr, ut64 baddr, cons
 
 			// Type propagate by following source reg
 			if (!res && *regname && etrace_regwrite_contains (tt, j, regname)) {
-				if (op->type == R_ANAL_OP_TYPE_MOV && etrace_have_memread (tt, j)) {
+				if (tp_op_loads_value (tt, op, j)) {
 					if (!var || var->kind == R_ANAL_VAR_KIND_REG) {
 						ut64 addr_read = UT64_MAX;
 						bool has_addr = etrace_memread_first_addr (tt, j, &addr_read);

--- a/test/db/anal/path
+++ b/test/db/anal/path
@@ -202,7 +202,7 @@ pdb @@= 0x000067d0 0x00004df0 0x000132d0 0x000132de 0x00004960
 |           0x00004eab      83f802         cmp eax, 2
 |       ,=< 0x00004eae      0f842e0e0000   je 0x5ce2
             ; CALL XREF from main @ 0x4e1b(x)
-/ 176: fcn.000132d0 (char **arg1);
+/ 176: fcn.000132d0 (char *arg1);
 | `- args(rdi)
 |           0x000132d0      f30f1efa       endbr64
 |           0x000132d4      53             push rbx

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1449,6 +1449,143 @@ var uint32_t var_28h @ rbp-0x28
 EOF
 RUN
 
+NAME=callee argument loaded through a pointer argument gets the pointee type
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488b3ee808000000c3909090909090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ rdi
+EOF
+RUN
+
+NAME=callee argument loaded through a copy chain strips one level only
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488b064889c7e805000000c39090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ rdi
+EOF
+RUN
+
+NAME=lea on a register pointer argument keeps the callee type flat
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488d7e08e807000000c39090909090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 char *
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ rdi
+EOF
+RUN
+
+NAME=dereferencing a void pointer argument leaves the callee type alone
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488b3ee808000000c3909090909090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 void *
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg int64_t arg1 @ rdi
+EOF
+RUN
+
+NAME=callee argument loaded through an arm64 load and register copy
+FILE=malloc://64
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 080040f9e00308aa02000094c0035fd600040091c0035fd6
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ x0
+EOF
+RUN
+
+NAME=a taken conditional move from memory counts as a dereference
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 480f453ee807000000c39090909090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ rdi
+EOF
+RUN
+
+NAME=a void pointer callee arg does not overwrite an existing type fact
+FILE=malloc://256
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 554889e54883ec20837df80577029090488d7df831f6ba04000000e810000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn memset @ 0x30
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+aft
+afv
+EOF
+EXPECT=<<EOF
+var uint32_t s @ rbp-0x8
+EOF
+RUN
+
+NAME=callee argument dereferenced through an arm64 load gets the pointee type
+FILE=malloc://64
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 200040f903000094c0035fd61f2003d500040091c0035fd6
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ x0
+EOF
+RUN
+
 NAME=canary named from the guard compare and not from the trace position
 FILE=malloc://512
 ARGS=-a x86 -b 64
@@ -3234,7 +3371,7 @@ aft
 afv
 EOF
 EXPECT=<<EOF
-var void  s @ rbp-0x88
+var int64_t s @ rbp-0x88
 EOF
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

When a caller passes a loaded value to a callee, the type matcher handed the callee the caller variable's type verbatim: `mov rdi, qword [rsi]` on a `char **argv` typed the callee's argument `char **` instead of `char *`. The dereference evidence sits on the instruction writing the argument register, which the backtrace counter never included.

The callee now receives the type at the loaded depth: one level stripped per load through a register variable (a load from a stack variable reads the variable itself), one level added when a stack variable's address is taken. `lea` on a register is pointer arithmetic and keeps the type flat. One shared predicate covers mov, conditional move, load and memory-operand push, and is gated on the execution trace, so an untaken conditional move counts nothing and load/store architectures behave like x86.

Riding along: a type stripped down to bare `void` is rejected in every retype path, and star-stripping no longer leaves a trailing space in the spelling — those malformed strings (`char `, `time_t `) failed every later lookup.

Both golden updates are recovered cases: one pinned the malformed `void ` spelling, the other pinned `char **` on exactly this pattern in ls-focal.

Fix #12747

Full test suite: 0 regressions, 8 new tests.