### PR TITLE
Add libandroid-spawn to Termux package installation ##build

### DIFF
--- a/sys/install.sh
+++ b/sys/install.sh
@@ -94,7 +94,7 @@ unset LINK
 
 if command -v termux-setup-storage; then
     echo "Termux environment detected. Installing necessary packages"  
-    pkg update -y && pkg install git build-essential binutils pkg-config -y
+    pkg update -y && pkg install git build-essential binutils pkg-config libandroid-spawn -y
     ${PWD}/sys/termux.sh
     exit $?
 fi


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes issue where installation from source on termux gives:
<img width="1220" height="627" alt="image" src="https://github.com/user-attachments/assets/4738a39b-b77b-435d-9364-742fc2433872" />