### PR TITLE
Fix out-of-bounds read on the SOM dynamic loader string table ##bin

### DIFF
--- a/libr/bin/format/som/som.c
+++ b/libr/bin/format/som/som.c
@@ -253,6 +253,9 @@ R_IPI void *r_bin_som_load_buffer(RBinFile *bf, RBuffer *b, ut64 laddr, Sdb *s) 
 					const ut32 str_len = (ut32)R_MIN (wanted, max_len);
 					if (str_len > 0) {
 						read_string_table (b, str_off, str_len, &obj->dl_strings);
+						if (obj->dl_strings) {
+							obj->dl_strings_size = str_len;
+						}
 					}
 				}
 				if (obj->dl_hdr->shlib_list_count > 0 && obj->dl_hdr->shlib_list_count < 1024 && obj->dl_hdr->shlib_list_loc < dl_subspace->initialization_length) {
@@ -307,9 +310,9 @@ R_IPI void *r_bin_som_load_buffer(RBinFile *bf, RBuffer *b, ut64 laddr, Sdb *s) 
 				}
 			}
 			if (obj->dl_strings) {
-				if (obj->dl_hdr->embedded_path < obj->dl_hdr->string_table_size) {
+				if (obj->dl_hdr->embedded_path < obj->dl_strings_size) {
 					const ut32 off = obj->dl_hdr->embedded_path;
-					const size_t max_len = obj->dl_hdr->string_table_size - off;
+					const size_t max_len = obj->dl_strings_size - off;
 					const char *embedded = obj->dl_strings + off;
 					size_t len = r_str_nlen (embedded, max_len);
 					char *en = r_str_ndup (embedded, len);
@@ -523,9 +526,9 @@ R_IPI void r_bin_som_load_imports(void *o, RVecRBinImport *vec) {
 		}
 		RBinImport *imp = RVecRBinImport_emplace_back (vec);
 		char *name;
-		if (obj->dl_strings && import_entry->import_name < obj->dl_hdr->string_table_size) {
+		if (obj->dl_strings && import_entry->import_name < obj->dl_strings_size) {
 			const char *name_str = obj->dl_strings + import_entry->import_name;
-			size_t len = strnlen (name_str, obj->dl_hdr->string_table_size - import_entry->import_name);
+			size_t len = strnlen (name_str, obj->dl_strings_size - import_entry->import_name);
 			name = r_str_ndup (name_str, len);
 		} else {
 			name = r_str_newf ("import_%d", import_entry->import_name);
@@ -557,9 +560,9 @@ R_IPI RList *r_bin_som_get_libs(void *o) {
 	RSomShlibListEntry *shlib;
 	r_list_foreach (obj->shlibs, iter, shlib) {
 		char *name = NULL;
-		if (obj->dl_strings && shlib->shlib_name < obj->dl_hdr->string_table_size) {
+		if (obj->dl_strings && shlib->shlib_name < obj->dl_strings_size) {
 			const char *name_str = obj->dl_strings + shlib->shlib_name;
-			size_t len = strnlen (name_str, obj->dl_hdr->string_table_size - shlib->shlib_name);
+			size_t len = strnlen (name_str, obj->dl_strings_size - shlib->shlib_name);
 			name = r_str_ndup (name_str, len);
 		} else {
 			name = r_str_newf ("sl_%d", shlib->shlib_name);

--- a/libr/bin/format/som/som.h
+++ b/libr/bin/format/som/som.h
@@ -204,6 +204,7 @@ typedef struct r_bin_som_file_t {
 	RList *shlibs;
 	RList *imports;
 	char *dl_strings;
+	ut32 dl_strings_size;
 	char *interp;
 } RSomFile;
 


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The dynamic-loader string table (`dl_strings`) is read into a buffer whose length is clamped to what actually fits inside the `$SHLIB_INFO$` subspace, but the three name lookups that consume it (the embedded path in `r_bin_som_load_buffer`, imports in `r_bin_som_load_imports`, libs in `r_bin_som_get_libs`) bound their scans by the `string_table_size` field from the dl header instead of the real allocation. A crafted SOM that declares `string_table_size` larger than the subspace lets a name offset land between the allocated length and that field, so `strnlen`/`r_str_nlen` walk off the end of the heap buffer. This tracks the size actually allocated and bounds all three reads by it.
