### PR TITLE
Select the ppc64 calling convention and glink layout from the ELF ABI ##analysis

### DIFF
--- a/libr/anal/d/cc-ppc-64.sdb.txt
+++ b/libr/anal/d/cc-ppc-64.sdb.txt
@@ -15,3 +15,18 @@ cc.ppc-64.ret0=r3
 cc.ppc-64.clobber=r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
 cc.ppc-64.preserve=r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
 
+elfv2=cc
+cc.elfv2.arg0=r3
+cc.elfv2.arg1=r4
+cc.elfv2.arg2=r5
+cc.elfv2.arg3=r6
+cc.elfv2.arg4=r7
+cc.elfv2.arg5=r8
+cc.elfv2.arg6=r9
+cc.elfv2.arg7=r10
+cc.elfv2.argn=stack
+cc.elfv2.shadow=96
+cc.elfv2.ret0=r3
+cc.elfv2.clobber=r0,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,lr,ctr,xer,cr0,cr1,cr5,cr6,cr7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13
+cc.elfv2.preserve=r1,r2,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,cr2,cr3,cr4,f14,f15,f16,f17,f18,f19,f20,f21,f22,f23,f24,f25,f26,f27,f28,f29,f30,f31
+

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1839,15 +1839,23 @@ static ut64 get_import_addr_s390x(ELFOBJ *eo, RBinElfReloc *rel) {
 	return a - 14;
 }
 
+// EF_PPC64_ABI: 1 = ELFv1, 2 = ELFv2, 3 = undefined; unflagged objects predate the field, so guess from the endian
+static int ppc64_abi(ELFOBJ *eo) {
+	if (eo->ehdr.e_machine != EM_PPC64) {
+		return 0;
+	}
+	switch (eo->ehdr.e_flags & EF_PPC64_ABI) {
+	case 1: return 1;
+	case 2: return 2;
+	case 3: return 0;
+	}
+	return eo->endian? 1: 2;
+}
+
 #if R_BIN_ELF64
-// PowerPC 64-bit ELF v1 uses an Official Procedure Descriptor (.opd) section.
-// Every function symbol's st_value — including e_entry — points to a 24-byte
-// descriptor [code_addr(8), toc(8), env(8)] rather than directly to code.
-// Dereference the first 8 bytes of the descriptor to get the real code address.
-// Returns UT64_MAX when the address does not fall inside .opd or the arch/endian
-// does not match.
+// ELFv1 function st_value points at a .opd descriptor [code, toc, env]; deref the code address
 static ut64 ppc64v1_opd_deref(ELFOBJ *eo, ut64 vaddr) {
-	if (eo->ehdr.e_machine != EM_PPC64 || !eo->endian) {
+	if (ppc64_abi (eo) != 1) {
 		return UT64_MAX;
 	}
 	if (!eo->sections_loaded) {
@@ -1858,77 +1866,62 @@ static ut64 ppc64v1_opd_deref(ELFOBJ *eo, ut64 vaddr) {
 		return UT64_MAX;
 	}
 	ut64 foff = opd->offset + (vaddr - opd->rva);
-	ut64 code_addr = r_buf_read_ble64_at (eo->b, foff, eo->endian);
-	return (code_addr == UT64_MAX) ? UT64_MAX : code_addr;
+	return r_buf_read_ble64_at (eo->b, foff, eo->endian);
 }
-#endif
 
-#if R_BIN_ELF64
-// Build a map of PLT slot vaddr -> lazy stub vaddr for PPC64 ELFv1 big-endian
-// binaries using the DT_PPC64_GLINK anchor.  Mirrors the algorithm in
-// ppc64_elf_get_synthetic_symtab () in binutils bfd/elf64-ppc.c.
-//
-// DT_PPC64_GLINK = glink_section_vma + GLINK_PLTRESOLVE_SIZE - 32, so:
-//   first_stub_vma = DT_PPC64_GLINK + 32
-//
-// Stubs 0-32767: 8 bytes each; stubs 32768+: 12 bytes each.
-// Stub N corresponds to the N-th DT_JMPREL entry (same order); that
-// entry's r_offset is the PLT slot vaddr.
-static HtUU *ppc64v1_build_glink_map(ELFOBJ *eo) {
+// PLT slot vaddr -> lazy glink stub vaddr; the N-th DT_JMPREL entry owns the N-th
+// stub after DT_PPC64_GLINK + 32 (binutils ppc64_elf_get_synthetic_symtab)
+static HtUU *ppc64_build_glink_map(ELFOBJ *eo, int abi) {
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
-	size_t relsize;
-	ut64 stub_vma, num_plts, rela_off, slot_vaddr, n;
-	HtUU *map;
 	if (di->dt_ppc64_glink == R_BIN_ELF_ADDR_MAX) {
 		return NULL;
 	}
 	if (di->dt_jmprel == R_BIN_ELF_ADDR_MAX || !di->dt_pltrelsz) {
 		return NULL;
 	}
-	relsize = get_size_rel_mode (di->dt_pltrel);
+	size_t relsize = get_size_rel_mode (di->dt_pltrel);
 	if (!relsize) {
 		return NULL;
 	}
-	map = ht_uu_new0 ();
+	HtUU *map = ht_uu_new0 ();
 	if (!map) {
 		return NULL;
 	}
-	stub_vma = di->dt_ppc64_glink + 8 * 4;
-	num_plts = di->dt_pltrelsz / relsize;
+	ut64 stub_vma = di->dt_ppc64_glink + 32;
+	ut64 num_plts = di->dt_pltrelsz / relsize;
+	ut64 n;
 	for (n = 0; n < num_plts; n++) {
-		rela_off = Elf_(v2p) (eo, di->dt_jmprel + n * relsize);
+		ut64 rela_off = Elf_(v2p) (eo, di->dt_jmprel + n * relsize);
 		if (rela_off == UT64_MAX) {
 			break;
 		}
-		slot_vaddr = r_buf_read_ble64_at (eo->b, rela_off, eo->endian);
+		ut64 slot_vaddr = r_buf_read_ble64_at (eo->b, rela_off, eo->endian);
 		if (slot_vaddr == UT64_MAX) {
 			break;
 		}
 		ht_uu_insert (map, slot_vaddr, stub_vma);
-		stub_vma += 8;
-		if (n >= 0x8000) {
-			stub_vma += 4;
-		}
+		// an ELFv2 stub is a single branch; ELFv1 stubs grow to 12 bytes past slot 0x8000
+		stub_vma += (abi == 2)? 4: (n >= 0x8000)? 12: 8;
 	}
 	return map;
 }
 #endif
 
-// Public API: return the PLT stub vaddr for the given GOT slot address in a
-// PPC64 ELFv1 big-endian binary, building the stub cache if necessary.
-// Returns UT64_MAX when the slot has no known stub (wrong arch, or no match).
-ut64 Elf_(ppc64v1_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
+// PLT stub vaddr for the given GOT slot in a ppc64 binary, building the stub cache on demand
+ut64 Elf_(ppc64_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
 #if R_BIN_ELF64
-	if (eo->ehdr.e_machine == EM_PPC64 && eo->endian) {
-		if (!eo->ppc64_plt_stubs) {
-			eo->ppc64_plt_stubs = ppc64v1_build_glink_map (eo);
-		}
-		if (eo->ppc64_plt_stubs) {
-			bool found = false;
-			ut64 stub = ht_uu_find (eo->ppc64_plt_stubs, slot_vaddr, &found);
-			if (found) {
-				return stub;
-			}
+	const int abi = ppc64_abi (eo);
+	if (!abi) {
+		return UT64_MAX;
+	}
+	if (!eo->ppc64_plt_stubs) {
+		eo->ppc64_plt_stubs = ppc64_build_glink_map (eo, abi);
+	}
+	if (eo->ppc64_plt_stubs) {
+		bool found = false;
+		ut64 stub = ht_uu_find (eo->ppc64_plt_stubs, slot_vaddr, &found);
+		if (found) {
+			return stub;
 		}
 	}
 #endif
@@ -1937,15 +1930,12 @@ ut64 Elf_(ppc64v1_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
 
 static ut64 get_import_addr_ppc(ELFOBJ *eo, RBinElfReloc *rel) {
 #if R_BIN_ELF64
-	if (eo->ehdr.e_machine == EM_PPC64 && eo->endian) {
-		// PPC64 ELFv1: PLT stubs live in .text; look up via stub cache
-		ut64 stub = Elf_(ppc64v1_get_plt_stub_for_slot) (eo, rel->rva);
+	if (ppc64_abi (eo)) {
+		ut64 stub = Elf_(ppc64_get_plt_stub_for_slot) (eo, rel->rva);
 		if (stub != UT64_MAX) {
 			return stub;
 		}
-		// Fallback: return the PLT slot address (when DT_PPC64_GLINK is
-		// absent or the GLINK map lookup fails)
-		return rel->rva;
+		return rel->rva; // no DT_PPC64_GLINK or no map entry
 	}
 #endif
 	ut64 plt_addr = eo->dyn_info.dt_pltgot;
@@ -2891,12 +2881,11 @@ char* Elf_(get_abi)(ELFOBJ *eo) {
 		}
 		break;
 	case EM_PPC64:
-		switch (eflags & EF_PPC64_ABI) {
+		switch (ppc64_abi (eo)) {
 		case 1: return strdup ("elfv1");
 		case 2: return strdup ("elfv2");
 		}
-		// e_flags doesnt tell, so guess from the endian: BE is ELFv1, LE is ELFv2
-		return strdup (eo->endian? "elfv1": "elfv2");
+		break;
 	case EM_V800:
 	case EM_V850:
 		break;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -2890,6 +2890,13 @@ char* Elf_(get_abi)(ELFOBJ *eo) {
 			}
 		}
 		break;
+	case EM_PPC64:
+		switch (eflags & EF_PPC64_ABI) {
+		case 1: return strdup ("elfv1");
+		case 2: return strdup ("elfv2");
+		}
+		// e_flags doesnt tell, so guess from the endian: BE is ELFv1, LE is ELFv2
+		return strdup (eo->endian? "elfv1": "elfv2");
 	case EM_V800:
 	case EM_V850:
 		break;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -182,7 +182,7 @@ struct Elf_(obj_t) {
 	bool plt_symbols_cached;
 	RList *inits;
 	HtUU *rel_cache;
-	HtUU *ppc64_plt_stubs; // ppc64 ELFv1: slot_vaddr -> stub_vaddr (lazy, NULL until first use)
+	HtUU *ppc64_plt_stubs; // ppc64: slot_vaddr -> stub_vaddr (lazy, NULL until first use)
 	ut32 g_reloc_num;
 	bool relocs_loaded;
 	RVecRBinElfReloc g_relocs;
@@ -256,6 +256,6 @@ bool Elf_(has_nx)(struct Elf_(obj_t) *bin);
 bool Elf_(has_nobtcfi)(ELFOBJ *eo);
 ut8 *Elf_(grab_regstate)(struct Elf_(obj_t) *bin, int *len);
 RList *Elf_(get_maps)(ELFOBJ *bin);
-ut64 Elf_(ppc64v1_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr);
+ut64 Elf_(ppc64_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr);
 R_API RBinSection *r_bin_section_clone(RBinSection *s);
 #endif

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1110,10 +1110,8 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			word = 4;
 			V = S + A - P;
 			break;
-		case R_PPC64_JMP_SLOT: { // 21 — write PLT stub vaddr to GOT slot (big-endian)
-			// For PPC64 ELFv1 the PLT stubs live in .text; look up the
-			// stub that loads from this GOT slot.  Falls back to S when not found.
-			ut64 stub = Elf_(ppc64v1_get_plt_stub_for_slot) (bo, rel->rva);
+		case R_PPC64_JMP_SLOT: { // 21 — write the PLT stub vaddr to the GOT slot, S when no stub is known
+			ut64 stub = Elf_(ppc64_get_plt_stub_for_slot) (bo, rel->rva);
 			word = 8;
 			V = (stub != UT64_MAX) ? stub : S;
 			break;
@@ -1728,8 +1726,13 @@ static RBinInfo* info(RBinFile *bf) {
 		ret->flags = r_str_newf ("0x%x", elf_flags);
 	}
 	ret->abi = Elf_(get_abi) (obj);
-	if (ret->abi && !strcmp (ret->abi, "elfv2")) {
-		ret->default_cc = strdup ("elfv2");
+	if (ret->abi) {
+		// both abis pick a cc so switching binaries in one session updates anal.cc
+		if (!strcmp (ret->abi, "elfv2")) {
+			ret->default_cc = strdup ("elfv2");
+		} else if (!strcmp (ret->abi, "elfv1")) {
+			ret->default_cc = strdup ("ppc-64");
+		}
 	}
 	ret->rclass = strdup ("elf");
 	ret->bits = Elf_(get_bits) (obj);

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1728,6 +1728,9 @@ static RBinInfo* info(RBinFile *bf) {
 		ret->flags = r_str_newf ("0x%x", elf_flags);
 	}
 	ret->abi = Elf_(get_abi) (obj);
+	if (ret->abi && !strcmp (ret->abi, "elfv2")) {
+		ret->default_cc = strdup ("elfv2");
+	}
 	ret->rclass = strdup ("elf");
 	ret->bits = Elf_(get_bits) (obj);
 	if (!strcmp (ret->arch, "avr")) {

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1689,3 +1689,43 @@ EXPECT=<<EOF
 int nine("AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II")
 EOF
 RUN
+
+NAME=ppc-64 elfv2 cc parameter save area
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e anal.arch=ppc
+CMDS=<<EOF
+k anal/cc/cc.elfv2.argn
+k anal/cc/cc.elfv2.shadow
+EOF
+EXPECT=<<EOF
+stack
+96
+EOF
+RUN
+
+NAME=callargs reads an elfv2 stack argument above the parameter save area
+FILE=malloc://256
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 386000503880005438a0005838c0005c38e0006039000064392000683940006c39600070f9610060480000594e800020
+wx 4e800020 @ 0x80
+w AA @ 0x50
+w BB @ 0x54
+w CC @ 0x58
+w DD @ 0x5c
+w EE @ 0x60
+w FF @ 0x64
+w GG @ 0x68
+w HH @ 0x6c
+w II @ 0x70
+af @ 0x80
+afn nine @ 0x80
+'td int nine(const char *a, const char *b, const char *c, const char *d, const char *e, const char *f, const char *g, const char *h, const char *i);
+tk func.nine.cc=elfv2
+af @ 0
+a:callargs-q 0x28
+EOF
+EXPECT=<<EOF
+int nine("AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II")
+EOF
+RUN

--- a/test/db/formats/elf/ppc64-abi
+++ b/test/db/formats/elf/ppc64-abi
@@ -1,0 +1,37 @@
+NAME=ELF PPC64: ELFv1 e_flags selects the elfv1 abi and the default cc
+FILE=bins/elf/ppc64v1-more
+CMDS=<<EOF
+e asm.abi
+e anal.cc
+EOF
+EXPECT=<<EOF
+elfv1
+ppc-64
+EOF
+RUN
+
+NAME=ELF PPC64: big-endian ELFv2 e_flags selects the elfv2 cc
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF
+e asm.abi
+e anal.cc
+k anal/cc/cc.elfv2.shadow
+EOF
+EXPECT=<<EOF
+elfv2
+elfv2
+96
+EOF
+RUN
+
+NAME=ELF PPC64: little-endian ELFv2 selects the elfv2 cc
+FILE=bins/elf/mosquito-ppc64le
+CMDS=<<EOF
+e asm.abi
+e anal.cc
+EOF
+EXPECT=<<EOF
+elfv2
+elfv2
+EOF
+RUN

--- a/test/db/formats/elf/ppc64-abi
+++ b/test/db/formats/elf/ppc64-abi
@@ -35,3 +35,60 @@ elfv2
 elfv2
 EOF
 RUN
+
+NAME=ELF PPC64: anal.cc tracks the abi when switching binaries in one session
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF
+e anal.cc
+o bins/elf/ppc64v1-more
+e anal.cc
+o bins/elf/ppc64_sudoku_dwarf
+e anal.cc
+EOF
+EXPECT=<<EOF
+elfv2
+ppc-64
+elfv2
+EOF
+RUN
+
+NAME=ELF PPC64: a new function inherits the elfv2 cc
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF
+af @ entry0
+afc @ entry0
+EOF
+EXPECT=<<EOF
+elfv2
+EOF
+RUN
+
+NAME=ELF PPC64: big-endian ELFv2 glink stubs use the 4-byte stride
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=ii~FUNC[1]:0..3
+EXPECT=<<EOF
+0x10001d10
+0x10001d14
+0x10001d18
+EOF
+RUN
+
+NAME=ELF PPC64: little-endian ELFv2 imports resolve to glink stubs
+FILE=bins/elf/mosquito-ppc64le
+CMDS=ii~FUNC[1]:0..3
+EXPECT=<<EOF
+0x10002ae0
+0x10002ae4
+0x10002ae8
+EOF
+RUN
+
+NAME=ELF PPC64: ELFv1 glink stubs keep the 8-byte stride
+FILE=bins/elf/ppc64v1-more
+CMDS=ii~FUNC[1]:0..3
+EXPECT=<<EOF
+0x0000db04
+0x0000db0c
+0x0000db14
+EOF
+RUN

--- a/test/db/formats/elf/ppc64v1-plt
+++ b/test/db/formats/elf/ppc64v1-plt
@@ -105,7 +105,7 @@ NAME=ELF v2: imports still work with GLINK path (system)
 FILE=bins/elf/ppc64_sudoku_dwarf
 CMDS=ii~system[1]
 EXPECT=<<EOF
-0x10001d28
+0x10001d1c
 EOF
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #26367, which modelled the ELFv1 parameter save area (shadow=112) in the generic ppc-64 convention and thus misplaced stack args for ELFv2, including ppc64le. I don't generally look at ppc64le but nice to resolve.

- Add an elfv2 cc with shadow=96 (32-byte frame header + 8 register-backed doublewords); ppc-64 keeps the ELFv1 layout and stays the default
- Detect the ppc64 ABI from e_flags (1=ELFv1, 2=ELFv2, unflagged guesses from the endian) and report it in the bin info; the ELF plugin selects the matching cc via default_cc, in both directions when switching binaries within one session
- Gate the .opd deref and glink stub map by ABI instead of endianness: ELFv2 glink stubs are single 4-byte branches at DT_PPC64_GLINK+32, so big-endian ELFv2 imports were mapped with the wrong 8-byte stride, and little-endian ELFv2 imports had no address at all (the fallback path needs DT_PLTGOT, which ELFv2 lacks)

Tested on ELFv1 (flags 0x1 BE), ELFv2 big-endian (flags 0x2, proving e_flags wins over the endian guess) and ppc64le fixtures: abi/cc selection, session switching, cc inheritance, ninth-argument recovery at the ELFv2 offset, and glink stub addresses asserted across multiple imports for both strides.