### PR TITLE
Restore emulation state from a real predecessor block in the type matcher ##analysis

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -510,7 +510,9 @@ typedef struct tp_state_t {
 	bool cfg_chk_constraint;
 	bool cfg_fields;
 	bool cfg_rollback;
+	bool cfg_bbstate;
 	bool old_follow;
+	bool lineage_reset; // set when a block's machine state was restored from a real predecessor
 	RVecTPSizeFn sizefns; // empty unless types.sizes is set
 	RList *clobber; // caller-saved regs to poison across skipped calls (synth only)
 	char *seed_reg; // ret reg to seed after the current call's clobber (allocator harvest)
@@ -2341,6 +2343,7 @@ static TPState *tps_init(RAnal *anal) {
 		tps->cfg_chk_constraint = anal->coreb.cfgGetB (core, "types.constraint");
 		tps->cfg_fields = anal->coreb.cfgGetB (core, "types.fields");
 		tps->cfg_rollback = anal->coreb.cfgGetB (core, "types.rollback");
+		tps->cfg_bbstate = anal->coreb.cfgGetB (core, "types.bbstate");
 		if (anal->coreb.cfgGetB (core, "types.sizes")) {
 			tp_sizefns_init (&tps->sizefns, anal->coreb.cfgGet (core, "types.sizefns"));
 		}
@@ -2354,6 +2357,7 @@ static TPState *tps_init(RAnal *anal) {
 		tps->cfg_chk_constraint = false;
 		tps->cfg_fields = false;
 		tps->cfg_rollback = false;
+		tps->cfg_bbstate = true;
 	}
 	tps->tt.enable_rollback = tps->cfg_rollback;
 	return tps;
@@ -2400,8 +2404,51 @@ typedef enum {
 // next_op is zeroed when no lookahead op was decoded
 typedef void (*TPEmulateOpCb)(void *user, RAnalOp *aop, RAnalOp *next_op, ut64 addr, ut64 bb_addr);
 
+// how far back in emulation order a real predecessor is looked for before giving up
+#define TP_PRED_SCAN_MAX 64
+
+static void tp_bbstate_kv_free(HtUPKv *kv) {
+	free (kv->value);
+}
+
+static bool tp_bb_edge_cb(ut64 addr, void *user) {
+	return addr != *(ut64 *)user;
+}
+
+static bool tp_bb_leads_to(RAnal *anal, ut64 from, ut64 to) {
+	RAnalBlock *bb = r_anal_get_block_at (anal, from);
+	return bb && !r_anal_block_successor_addrs_foreach (bb, tp_bb_edge_cb, &to);
+}
+
+// restore the GPR arena from the nearest direct-edge predecessor (memory is not rewound); transitive reachers do not count
+static bool tp_restore_pred_state(TPState *tps, RVecUT64 *bblist, int j, ut64 bbat, HtUP *bbstate, int arena_size) {
+	if (j < 1) {
+		return false;
+	}
+	RAnal *anal = tps->anal;
+	// straight line: the live state is already this block's lineage
+	if (tp_bb_leads_to (anal, *RVecUT64_at (bblist, j - 1), bbat)) {
+		return false;
+	}
+	const int oldest = R_MAX (0, j - TP_PRED_SCAN_MAX);
+	int k;
+	for (k = j - 2; k >= oldest; k--) {
+		const ut64 pa = *RVecUT64_at (bblist, k);
+		if (!tp_bb_leads_to (anal, pa, bbat)) {
+			continue;
+		}
+		ut8 *snap = ht_up_find (bbstate, pa, NULL);
+		if (snap) {
+			r_reg_arena_poke (tps->tt.reg, snap, arena_size);
+			return true;
+		}
+		return false;
+	}
+	return false;
+}
+
 // step the type-trace esil over the linear ops of every block; op_cb also enables the one-op lookahead
-static TPEmuResult tp_emulate_linear(TPState *tps, RAnalFunction *fcn, int max_ops, TPEmulateOpCb op_cb, void *user, bool lookahead) {
+static TPEmuResult tp_emulate_linear(TPState *tps, RAnalFunction *fcn, int max_ops, TPEmulateOpCb op_cb, void *user, bool lookahead, bool restore_state) {
 	RAnal *anal = tps->anal;
 	const int op_tions = R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_HINT | R_ARCH_OP_MASK_ESIL;
 	const int minopcode = R_MAX (1, r_arch_info (anal->arch, R_ARCH_INFO_MINOP_SIZE));
@@ -2429,9 +2476,11 @@ static TPEmuResult tp_emulate_linear(TPState *tps, RAnalFunction *fcn, int max_o
 	int i, j;
 	TypeTrace *etrace = &tps->tt;
 	RIO *io = anal->iob.io;
-	// blocks swept in CFG order still inherit register state across non-adjacent boundaries: a coverage/accuracy tradeoff
+	HtUP *bbstate = (restore_state && tps->cfg_bbstate)? ht_up_new (NULL, tp_bbstate_kv_free, NULL): NULL;
+	int arena_size = 0;
 	for (j = 0; j < bblist_size; j++) {
 		const ut64 bbat = *RVecUT64_at (&bblist, j);
+		tps->lineage_reset = bbstate && tp_restore_pred_state (tps, &bblist, j, bbat, bbstate, arena_size);
 		bb = r_anal_get_block_at (anal, bbat);
 		if (!bb) {
 			R_LOG_WARN ("basic block at 0x%08" PFMT64x " was removed during analysis", bbat);
@@ -2545,8 +2594,17 @@ static TPEmuResult tp_emulate_linear(TPState *tps, RAnalFunction *fcn, int max_o
 		if (tps->cfg_rollback) {
 			type_trace_rollback_clear (etrace);
 		}
+		if (bbstate) {
+			ut8 *snap = r_reg_arena_peek (etrace->reg, &arena_size);
+			if (snap) {
+				if (!ht_up_update (bbstate, bb_addr, snap)) {
+					free (snap);
+				}
+			}
+		}
 	}
 beach:
+	ht_up_free (bbstate);
 	r_anal_op_fini (&aop);
 	r_anal_op_free (next_op); // a cached lookahead op may still be live on a break/budget exit
 	r_cons_break_pop (cons);
@@ -2727,6 +2785,14 @@ static void type_match_op_cb(void *user, RAnalOp *aop, RAnalOp *next_op, ut64 ad
 	Sdb *TDB = anal->sdb_types;
 	char *fcn_name = NULL;
 	c->tp.userfnc = false;
+	if (tps->lineage_reset) {
+		// state came from another predecessor: call-return and one-op adjacency tracking are stale
+		tp_state_fini (&c->tp);
+		tp_state_reset (&c->tp);
+		c->tp.resolved = false;
+		c->tp.prev_var = NULL;
+		tps->lineage_reset = false;
+	}
 	tps->tt.cur_idx = etrace_index (etrace);
 	int cur_idx = tps->tt.cur_idx - 1;
 	if (cur_idx < 0) {
@@ -2924,7 +2990,7 @@ R_API void r_anal_type_match(RAnal *anal, RAnalFunction *fcn) {
 	};
 	int retries = 2;
 	for (;;) {
-		const TPEmuResult res = tp_emulate_linear (tps, fcn, 0, type_match_op_cb, &ctx, true);
+		const TPEmuResult res = tp_emulate_linear (tps, fcn, 0, type_match_op_cb, &ctx, true, true);
 		if (res == TP_EMU_DONE || res == TP_EMU_BUDGET) {
 			break;
 		}
@@ -3544,7 +3610,7 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 	RVecSynthField_init (&szctx.childwant);
 	const bool harvest = !RVecTPSizeFn_empty (&tps->sizefns);
 	r_reg_setv (tps->tt.reg, "PC", fcn->addr);
-	if (tp_emulate_linear (tps, fcn, SYNTH_MAXOPS, harvest? synth_size_cb: NULL, harvest? &szctx: NULL, false) == TP_EMU_BUDGET) {
+	if (tp_emulate_linear (tps, fcn, SYNTH_MAXOPS, harvest? synth_size_cb: NULL, harvest? &szctx: NULL, false, false) == TP_EMU_BUDGET) {
 		R_LOG_WARN ("Struct synthesis hit the %d-op budget at 0x%08" PFMT64x "; result is partial", SYNTH_MAXOPS, fcn->addr);
 	}
 

--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -2420,7 +2420,7 @@ static bool tp_bb_leads_to(RAnal *anal, ut64 from, ut64 to) {
 	return bb && !r_anal_block_successor_addrs_foreach (bb, tp_bb_edge_cb, &to);
 }
 
-// restore the GPR arena from the nearest direct-edge predecessor (memory is not rewound); transitive reachers do not count
+// restore the GPR arena from the nearest direct-edge predecessor with a snapshot (memory is not rewound); transitive reachers do not count
 static bool tp_restore_pred_state(TPState *tps, RVecUT64 *bblist, int j, ut64 bbat, HtUP *bbstate, int arena_size) {
 	if (j < 1) {
 		return false;
@@ -2442,7 +2442,7 @@ static bool tp_restore_pred_state(TPState *tps, RVecUT64 *bblist, int j, ut64 bb
 			r_reg_arena_poke (tps->tt.reg, snap, arena_size);
 			return true;
 		}
-		return false;
+		// a predecessor without a snapshot (arena peek failed) is no reason to stop: an older one may have state
 	}
 	return false;
 }

--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4113,6 +4113,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETB ("types.constraint", "false", "enable constraint types analysis for variables");
 	SETB ("types.fields", "false", "propagate callee types into struct and union members during type analysis");
 	SETB ("types.rollback", "false", "enable state rollback for type propagation recovery");
+	SETB ("types.bbstate", "true", "restore register state from a real predecessor block during type analysis (memory is not rewound)");
 	SETB ("types.synth", "false", "synthesize struct types for untyped pointer args and allocator returns (see afts)");
 	SETB ("types.sizes", "false", "harvest object sizes from memset-style and allocator call sites during type analysis");
 	SETS ("types.sizefns", "", "name/ptrarg/sizearg[*mularg] fns; ptrarg r/rN = allocator ret; name/- drops; an entry replaces its builtins");

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3487,3 +3487,40 @@ var uint8_t [256] var_20h @ rbp-0x20
 EOF
 RUN
 
+NAME=a loop body value the header never touches is also lost after the loop
+FILE=malloc://128
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF2
+wx 554889e54883ec20ba0400000085ff7407ba00010000ebf5488d7de031f6e81d000000c9c3
+wx c3 @ 0x40
+af+ 0x40 memset
+afb+ 0x40 0x40 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_20h
+EOF2
+EXPECT=<<EOF2
+var int64_t var_20h @ rbp-0x20
+EOF2
+RUN
+
+NAME=disabling bbstate keeps the loop body value after the loop
+FILE=malloc://128
+ARGS=-a x86 -b 64 -e types.sizes=true -e types.bbstate=false
+CMDS=<<EOF2
+wx 554889e54883ec20ba0400000085ff7407ba00010000ebf5488d7de031f6e81d000000c9c3
+wx c3 @ 0x40
+af+ 0x40 memset
+afb+ 0x40 0x40 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_20h
+EOF2
+EXPECT=<<EOF2
+var uint8_t [256] var_20h @ rbp-0x20
+EOF2
+RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3410,3 +3410,80 @@ EXPECT=<<EOF
 var uint8_t [136] var_88h @ rbp-0x88
 EOF
 RUN
+
+NAME=single block function with the state restore enabled
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e types.bbstate=true
+CMDS=<<EOF
+wx 488b3ee808000000c3909090909090904889f8c3
+af @ 0x10
+af @ 0
+afvt arg1 char **
+s 0
+aaft
+afv @ 0x10
+EOF
+EXPECT=<<EOF
+arg char * arg1 @ rdi
+EOF
+RUN
+
+NAME=a loop body value does not survive the header that overwrites it
+FILE=malloc://128
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec20ba0400000085ff740aba00010000ebf0909090488d7de031f6e81a000000c9c3
+wx c3 @ 0x40
+af+ 0x40 memset
+afb+ 0x40 0x40 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_20h
+EOF
+EXPECT=<<EOF
+var int64_t var_20h @ rbp-0x20
+EOF
+RUN
+
+NAME=a sibling branch size does not leak into a call on another path
+FILE=malloc://128
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec2085ff740cba00010000eb149090909090488d7de031f6e81d000000eb029090c9c3
+wx c3 @ 0x40
+af+ 0x40 memset
+afb+ 0x40 0x40 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv
+EOF
+EXPECT=<<EOF
+arg int64_t arg1 @ rdi
+arg size_t n @ rdx
+var int64_t s @ rbp-0x20
+EOF
+RUN
+
+NAME=disabling the per-block state restore keeps the inherited sibling branch state
+FILE=malloc://128
+ARGS=-a x86 -b 64 -e types.sizes=true -e types.bbstate=false
+CMDS=<<EOF
+wx 554889e54883ec2085ff740cba00010000eb149090909090488d7de031f6e81d000000eb029090c9c3
+wx c3 @ 0x40
+af+ 0x40 memset
+afb+ 0x40 0x40 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_20h
+EOF
+EXPECT=<<EOF
+var uint8_t [256] var_20h @ rbp-0x20
+EOF
+RUN
+


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The type matcher sweeps basic blocks in CFG order but the ESIL register state flows linearly across the block list, so a block whose sweep-predecessor is not a CFG predecessor (the far arm of a diamond, code after an early return) inherits register values from a sibling arm — producing false or missed type matches on the wrong lineage.

This snapshots the GPR arena at the end of each emulated block and, on a non-adjacent boundary, restores the nearest already-emulated direct CFG predecessor's state (scanned up to 64 blocks back), clearing the stale call-return/adjacency tracking. Fallthrough is a no-op, so straight-line code behaves byte-identically. Memory is not rewound; only registers. Gated by types.bbstate (default true). Four tests in db/cmd/types pin the false-inheritance case (both gate states), fallthrough identity, and propagation after a join.

This deliberately does not touch the types.rollback machinery from #24428 — snapshots handle cross-block lineage, rollback stays the retry mechanism. Happy to rework if required.