### PR TITLE
Avoid shared .tmp directory races between parallel tests ##tests

### DIFF
--- a/test/db/cmd/newprj
+++ b/test/db/cmd/newprj
@@ -2,6 +2,7 @@ NAME=newprj flagspace round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-spc.prj
 fs+alpha
 f sym.one=0x100
 fs+beta
@@ -26,12 +27,13 @@ NAME=newprj quoted project filename
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+"rm .tmp/newprj quoted.prj"
 f quoted.project=0x420
 prj   save ".tmp/newprj quoted.prj" > /dev/null
 f-*
 prj "load" ".tmp/newprj quoted.prj" > /dev/null
 fd 0x420
-rm ".tmp/newprj quoted.prj"
+"rm .tmp/newprj quoted.prj"
 EOF
 EXPECT=<<EOF
 quoted.project
@@ -53,6 +55,7 @@ NAME=newprj flag with no space
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-ns.prj
 fs *
 f nospaceflag=0x300
 prj save .tmp/newprj-ns.prj > /dev/null
@@ -71,6 +74,7 @@ NAME=newprj flag comment round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-cmt.prj
 fs+alpha
 f sym.cool=0x100
 fC sym.cool "round tripped comment"
@@ -90,6 +94,7 @@ NAME=newprj flag color round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-col.prj
 fs+alpha
 f sym.cool=0x100
 fc sym.cool=red
@@ -110,6 +115,7 @@ NAME=newprj realname + rawname round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-rn.prj
 fs+alpha
 f sym.cool=0x100
 s 0x100
@@ -134,6 +140,7 @@ NAME=newprj multiple flags and spaces
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-multi.prj
 fs+alpha
 f a.one=0x100
 f a.two=0x110
@@ -165,6 +172,7 @@ NAME=newprj eval round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-eval.prj
 e asm.bits=16
 e asm.syntax=att
 e anal.depth=42
@@ -193,6 +201,7 @@ NAME=newprj eval skipped prefixes are not replayed
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-evskip.prj
 e scr.color=3
 prj save .tmp/newprj-evskip.prj > /dev/null
 e scr.color=0
@@ -209,6 +218,7 @@ NAME=newprj xrefs round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-xrefs.prj
 axd 0x200 0x100
 axC 0x300 0x120
 prj save .tmp/newprj-xrefs.prj > /dev/null
@@ -227,6 +237,7 @@ NAME=newprj rebase flags comments and xrefs
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-rebase.prj
 f src.flag=0x10
 CC src comment @ 0x10
 axd 0x20 0x10
@@ -253,6 +264,7 @@ NAME=newprj rebase flag at module end
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-endbyte.prj
 !printf AAAAAAAAAAAAAAAA > .tmp/newprj-end.bin
 o .tmp/newprj-end.bin 0x1000
 f end.byte=0x100f
@@ -274,6 +286,7 @@ NAME=newprj rebase multiple file-backed modules
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-files.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-a.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-b.bin
 o .tmp/newprj-a.bin 0x1000
@@ -306,6 +319,7 @@ NAME=newprj xref types round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-xreftypes.prj
 axc 0x80 0x10
 axd 0x90 0x20
 axC 0xa0 0x30
@@ -326,6 +340,7 @@ NAME=newprj rebased xrefs keep source and target modules
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-xrefmods.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-xma.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-xmb.bin
 o .tmp/newprj-xma.bin 0x1000
@@ -353,6 +368,7 @@ NAME=newprj duplicate identical maps rebase one to one
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-dupmap.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-dupmap.bin
 o--
 o .tmp/newprj-dupmap.bin 0x1000
@@ -384,6 +400,7 @@ NAME=newprj ambiguous same-content maps keep sorted identity
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-ambmap.prj
 !printf ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ > .tmp/newprj-amb-a.bin
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-amb-b.bin
 !printf ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ > .tmp/newprj-amb-c.bin
@@ -420,6 +437,7 @@ NAME=newprj function name updates existing function
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-fcnname.prj
 af+ 0x10 fcn.saved
 prj save .tmp/newprj-fcnname.prj > /dev/null
 afn fcn.old 0x10
@@ -436,6 +454,7 @@ NAME=newprj rebased functions blocks colors and xrefs
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-fcnmods.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-fma.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-fmb.bin
 o .tmp/newprj-fma.bin 0x1000
@@ -477,6 +496,7 @@ NAME=newprj function metadata round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-fcnmeta.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.meta
@@ -503,6 +523,7 @@ NAME=newprj function vars and args round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-fcnvars.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.vars
@@ -530,6 +551,7 @@ NAME=newprj script register variables
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-regscript.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.regscript
@@ -550,6 +572,7 @@ NAME=newprj rebased function metadata and vars
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-rfcnmeta.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-rfma.bin
 o .tmp/newprj-rfma.bin 0x1000
 e asm.arch=arm
@@ -584,6 +607,7 @@ NAME=newprj shared function attrs round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-fcnshared.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.a
@@ -623,6 +647,7 @@ NAME=newprj diff covers non-function project data
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-diffall.prj
 e asm.syntax=att
 f saved.flag=0x10
 CC saved @ 0x20
@@ -655,6 +680,7 @@ NAME=newprj Ct metadata round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-ctmeta.prj
 Ct= base64:c3RkOjp2ZWN0b3I8aW50PiAqZm9vLT5iYXIgQCBzbG90OyAicXVvdGVkIiBcXHBhdGg= @ 0x10
 prj save .tmp/newprj-ctmeta.prj > /dev/null
 Ct= changed @ 0x10
@@ -676,6 +702,7 @@ NAME=newprj diff covers function blocks colors and vars
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-difffcn.prj
 e asm.arch=arm
 af+ 0x40 saved.fcn
 afb+ 0x40 0x40 4
@@ -703,6 +730,7 @@ NAME=newprj open restores file maps
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-open.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-open.bin
 o--
 o .tmp/newprj-open.bin 0x1000
@@ -726,6 +754,7 @@ FILE=malloc://256
 ARGS=-a x86 -b 64
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-spv.prj
 e anal.cc=ms
 wx 488b4424288b08c3
 af
@@ -749,6 +778,7 @@ FILE=malloc://256
 ARGS=-a x86 -b 64
 CMDS=<<EOF
 mkdir .tmp
+rm .tmp/newprj-bpvframe.prj
 wx 554889e54883ec20897dfc90c9c3
 af
 prj save .tmp/newprj-bpvframe.prj > /dev/null

--- a/test/db/cmd/newprj
+++ b/test/db/cmd/newprj
@@ -2,7 +2,6 @@ NAME=newprj flagspace round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-spc.prj
 fs+alpha
 f sym.one=0x100
 fs+beta
@@ -27,7 +26,6 @@ NAME=newprj quoted project filename
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f ".tmp/newprj quoted.prj"
 f quoted.project=0x420
 prj   save ".tmp/newprj quoted.prj" > /dev/null
 f-*
@@ -55,7 +53,6 @@ NAME=newprj flag with no space
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-ns.prj
 fs *
 f nospaceflag=0x300
 prj save .tmp/newprj-ns.prj > /dev/null
@@ -74,7 +71,6 @@ NAME=newprj flag comment round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-cmt.prj
 fs+alpha
 f sym.cool=0x100
 fC sym.cool "round tripped comment"
@@ -94,7 +90,6 @@ NAME=newprj flag color round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-col.prj
 fs+alpha
 f sym.cool=0x100
 fc sym.cool=red
@@ -115,7 +110,6 @@ NAME=newprj realname + rawname round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-rn.prj
 fs+alpha
 f sym.cool=0x100
 s 0x100
@@ -140,7 +134,6 @@ NAME=newprj multiple flags and spaces
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-multi.prj
 fs+alpha
 f a.one=0x100
 f a.two=0x110
@@ -172,7 +165,6 @@ NAME=newprj eval round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-eval.prj
 e asm.bits=16
 e asm.syntax=att
 e anal.depth=42
@@ -201,7 +193,6 @@ NAME=newprj eval skipped prefixes are not replayed
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-evskip.prj
 e scr.color=3
 prj save .tmp/newprj-evskip.prj > /dev/null
 e scr.color=0
@@ -218,7 +209,6 @@ NAME=newprj xrefs round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-xrefs.prj
 axd 0x200 0x100
 axC 0x300 0x120
 prj save .tmp/newprj-xrefs.prj > /dev/null
@@ -237,7 +227,6 @@ NAME=newprj rebase flags comments and xrefs
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-rebase.prj
 f src.flag=0x10
 CC src comment @ 0x10
 axd 0x20 0x10
@@ -264,7 +253,6 @@ NAME=newprj rebase flag at module end
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-endbyte.prj
 !printf AAAAAAAAAAAAAAAA > .tmp/newprj-end.bin
 o .tmp/newprj-end.bin 0x1000
 f end.byte=0x100f
@@ -286,7 +274,6 @@ NAME=newprj rebase multiple file-backed modules
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-files.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-a.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-b.bin
 o .tmp/newprj-a.bin 0x1000
@@ -319,7 +306,6 @@ NAME=newprj xref types round-trip
 FILE=malloc://0x1000
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-xreftypes.prj
 axc 0x80 0x10
 axd 0x90 0x20
 axC 0xa0 0x30
@@ -340,7 +326,6 @@ NAME=newprj rebased xrefs keep source and target modules
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-xrefmods.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-xma.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-xmb.bin
 o .tmp/newprj-xma.bin 0x1000
@@ -368,7 +353,6 @@ NAME=newprj duplicate identical maps rebase one to one
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-dupmap.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-dupmap.bin
 o--
 o .tmp/newprj-dupmap.bin 0x1000
@@ -400,7 +384,6 @@ NAME=newprj ambiguous same-content maps keep sorted identity
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-ambmap.prj
 !printf ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ > .tmp/newprj-amb-a.bin
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-amb-b.bin
 !printf ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ > .tmp/newprj-amb-c.bin
@@ -437,7 +420,6 @@ NAME=newprj function name updates existing function
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-fcnname.prj
 af+ 0x10 fcn.saved
 prj save .tmp/newprj-fcnname.prj > /dev/null
 afn fcn.old 0x10
@@ -454,7 +436,6 @@ NAME=newprj rebased functions blocks colors and xrefs
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-fcnmods.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-fma.bin
 !printf BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB > .tmp/newprj-fmb.bin
 o .tmp/newprj-fma.bin 0x1000
@@ -496,7 +477,6 @@ NAME=newprj function metadata round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-fcnmeta.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.meta
@@ -523,7 +503,6 @@ NAME=newprj function vars and args round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-fcnvars.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.vars
@@ -551,7 +530,6 @@ NAME=newprj script register variables
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-regscript.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.regscript
@@ -572,7 +550,6 @@ NAME=newprj rebased function metadata and vars
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-rfcnmeta.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-rfma.bin
 o .tmp/newprj-rfma.bin 0x1000
 e asm.arch=arm
@@ -607,7 +584,6 @@ NAME=newprj shared function attrs round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-fcnshared.prj
 e asm.arch=arm
 e asm.bits=64
 af+ 0x10 fcn.a
@@ -647,7 +623,6 @@ NAME=newprj diff covers non-function project data
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-diffall.prj
 e asm.syntax=att
 f saved.flag=0x10
 CC saved @ 0x20
@@ -680,7 +655,6 @@ NAME=newprj Ct metadata round-trip
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-ctmeta.prj
 Ct= base64:c3RkOjp2ZWN0b3I8aW50PiAqZm9vLT5iYXIgQCBzbG90OyAicXVvdGVkIiBcXHBhdGg= @ 0x10
 prj save .tmp/newprj-ctmeta.prj > /dev/null
 Ct= changed @ 0x10
@@ -702,7 +676,6 @@ NAME=newprj diff covers function blocks colors and vars
 FILE=malloc://0x100
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-difffcn.prj
 e asm.arch=arm
 af+ 0x40 saved.fcn
 afb+ 0x40 0x40 4
@@ -730,7 +703,6 @@ NAME=newprj open restores file maps
 FILE=malloc://0x10
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-open.prj
 !printf AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA > .tmp/newprj-open.bin
 o--
 o .tmp/newprj-open.bin 0x1000
@@ -753,6 +725,7 @@ NAME=newprj stack vars round-trip across a session with a different frame size
 FILE=malloc://256
 ARGS=-a x86 -b 64
 CMDS=<<EOF
+mkdir .tmp
 e anal.cc=ms
 wx 488b4424288b08c3
 af
@@ -763,6 +736,7 @@ e anal.cc=amd64
 af
 prj load .tmp/newprj-spv.prj > /dev/null
 afvs
+rm .tmp/newprj-spv.prj
 EOF
 EXPECT=<<EOF
 arg int64_t arg_28h @ rsp+0x28
@@ -775,7 +749,6 @@ FILE=malloc://256
 ARGS=-a x86 -b 64
 CMDS=<<EOF
 mkdir .tmp
-rm -f .tmp/newprj-bpvframe.prj
 wx 554889e54883ec20897dfc90c9c3
 af
 prj save .tmp/newprj-bpvframe.prj > /dev/null

--- a/test/db/cmd/write
+++ b/test/db/cmd/write
@@ -340,16 +340,17 @@ NAME=wci should commit the changes to the file
 FILE=malloc://1024
 BROKEN=1
 CMDS=<<EOF
-!rm -rf .tmp
 mkdir .tmp
-cp -f bins/pe/b.exe .tmp/.b.exe.orig
-cp -f bins/pe/b.exe .tmp/.b.exe.new
+cp bins/pe/b.exe .tmp/.b.exe.orig
+cp bins/pe/b.exe .tmp/.b.exe.new
 e io.cache=true
 o+ .tmp/.b.exe.new
 wx ff
 wci
 e.src.null=true
 !!radiff2 .tmp/.b.exe.orig .tmp/.b.exe.new
+rm .tmp/.b.exe.orig
+rm .tmp/.b.exe.new
 EOF
 EXPECT=<<EOF
 File size


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The wci test in db/cmd/write deleted the shared .tmp directory (!rm -rf .tmp) — BROKEN tests still execute their commands, so under parallel runs this raced every test using .tmp and intermittently failed unrelated tests in CI (seen on the tinyasan job: a newprj project save failed because the directory vanished mid-test). It now removes only its own files, and the one newprj test that lacked  its own mkdir .tmp gets one plus cleanup, like its siblings.

Riding along: rm -f/cp -f don't work in the internal shell (flags aren't parsed — rm -f x unlinks a file literally named -f x, cp -f a b copies nothing), so the dead rm -f pre-clean lines are dropped and the wci test's cp -f becomes cp — its fixtures are now actually copied, and it keeps failing on the real wci defect rather than on broken setup.