### PR TITLE
Type the variable receiving a synthesized allocator return object ##types

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -3343,43 +3343,139 @@ static RAnalVar *synth_rec_var(RAnal *anal, RAnalFunction *fcn, const char *cc, 
 	return synth_arg_var (anal, fcn, cc, rec->arg);
 }
 
-// true when the var still carries a pointer to one of the synthesized structs being replaced
-static bool synth_type_is_stale(Sdb *db, const char *key, const char *vtype) {
-	if (!vtype || !r_str_startswith (vtype, "struct ")) {
+// the first allocation storing into a reused local keeps it, so the name is not handed out twice
+static bool synth_var_claimed(RVecSynthRec *recs, const SynthRec *rec, const char *name) {
+	SynthRec *r;
+	R_VEC_FOREACH (recs, r) {
+		if (r == rec) {
+			break;
+		}
+		if (!r->child && r->var && !strcmp (r->var, name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// NULL when an earlier rec already resolved to this var, so arg and ret recs cannot both claim a slot
+static RAnalVar *synth_bound_var(RAnal *anal, RAnalFunction *fcn, const char *cc, RVecSynthRec *recs, const SynthRec *rec) {
+	RAnalVar *av = synth_rec_var (anal, fcn, cc, rec);
+	if (!av) {
+		return NULL;
+	}
+	SynthRec *r;
+	R_VEC_FOREACH (recs, r) {
+		if (r == rec) {
+			break;
+		}
+		if (!r->child && synth_rec_var (anal, fcn, cc, r) == av) {
+			return NULL;
+		}
+	}
+	return av;
+}
+
+// the type may carry qualifiers and any pointer depth around the struct name
+static bool synth_type_names(const char *vtype, const char *name) {
+	const char *p = strstr (r_str_get (vtype), "struct ");
+	if (!p) {
 		return false;
 	}
-	const char *base = vtype + strlen ("struct ");
-	const char *sp = strchr (base, ' ');
-	char *name = sp? r_str_ndup (base, sp - base): strdup (base);
-	const bool stale = name && sdb_array_contains (db, key, name, NULL);
-	free (name);
-	return stale;
+	p += strlen ("struct ");
+	const size_t len = strlen (name);
+	return strcspn (p, " *") == len && !strncmp (p, name, len);
+}
+
+// a member of a kept parent, so dropping it would dangle the parent rather than a var
+static bool synth_member_names(RAnal *anal, const char *parent, const char *name) {
+	RAnalBaseType *bt = r_anal_get_base_type (anal, parent);
+	if (!bt) {
+		return false;
+	}
+	bool hit = false;
+	if (bt->kind == R_ANAL_BASE_TYPE_KIND_STRUCT) {
+		RAnalTypeMember *m;
+		R_VEC_FOREACH (&bt->struct_data.members, m) {
+			if (synth_type_names (m->type, name)) {
+				hit = true;
+				break;
+			}
+		}
+	}
+	r_anal_base_type_free (bt);
+	return hit;
+}
+
+// dropping a generated type a user-edited var still reaches would leave that var unresolvable
+static bool synth_type_referenced(RAnal *anal, RAnalFunction *fcn, const char *name) {
+	RAnalVar **vp;
+	R_VEC_FOREACH (&fcn->vars, vp) {
+		const char *vt = r_str_get ((*vp)->type);
+		if (synth_type_names (vt, name)) {
+			return true;
+		}
+		const char *p = strstr (vt, "struct ");
+		if (!p) {
+			continue;
+		}
+		p += strlen ("struct ");
+		char *parent = r_str_ndup (p, strcspn (p, " *"));
+		const bool hit = parent && synth_member_names (anal, parent, name);
+		free (parent);
+		if (hit) {
+			return true;
+		}
+	}
+	return false;
 }
 
 // a rerun may bind elsewhere or not at all, so put back the type each var had before we touched it
-static void synth_restore_vars(RAnal *anal, RAnalFunction *fcn, Sdb *bookdb, const char *key, const char *vkey) {
+static void synth_restore_vars(RAnal *anal, RAnalFunction *fcn, Sdb *bookdb, const char *vkey) {
 	char *vrec = sdb_get (bookdb, vkey, 0);
 	if (!vrec) {
 		return;
 	}
 	char *vp;
 	sdb_aforeach (vp, vrec) {
-		char *colon = strchr (vp, ':');
-		if (colon) {
-			*colon = 0;
-			char *vname = (char *)sdb_decode (vp, NULL);
-			char *prev = (char *)sdb_decode (colon + 1, NULL);
-			RAnalVar *v = vname? r_anal_function_get_var_byname (fcn, vname): NULL;
-			// a type the user changed since the last run is not ours to replace
-			if (v && prev && synth_type_is_stale (bookdb, key, v->type)) {
+		if (r_str_split (vp, ':') == 4) {
+			RAnalVar *v = r_anal_function_get_var (fcn, *vp, atoi (r_str_word_get0 (vp, 1)));
+			char *applied = (char *)sdb_decode (r_str_word_get0 (vp, 2), NULL);
+			char *prev = (char *)sdb_decode (r_str_word_get0 (vp, 3), NULL);
+			// only the exact type the last run applied is ours to replace
+			if (v && applied && prev && !strcmp (r_str_get (v->type), applied)) {
 				r_anal_var_set_type (anal, v, prev);
 			}
-			free (vname);
+			free (applied);
 			free (prev);
 		}
 		sdb_aforeach_next (vp);
 	}
 	free (vrec);
+}
+
+// point the bound var at the synthesized struct, booking the replaced type so a rerun can undo it
+static void synth_bind_var(RAnal *anal, RAnalFunction *fcn, const char *cc, RVecSynthRec *recs, SynthRec *rec, RStrBuf *vsb) {
+	RAnalVar *av = synth_bound_var (anal, fcn, cc, recs, rec);
+	if (!av) {
+		return;
+	}
+	char *ty = r_str_newf ("struct %s *", rec->bt->name);
+	if (ty) {
+		char *ap64 = sdb_encode ((const ut8 *)ty, -1);
+		char *pt64 = sdb_encode ((const ut8 *)r_str_get (av->type), -1);
+		if (ap64 && pt64) {
+			// keyed by location, so a later rename cannot orphan the record
+			r_strbuf_appendf (vsb, "%s%c:%d:%s:%s",
+				r_strbuf_length (vsb)? ",": "", av->kind, av->delta, ap64, pt64);
+		}
+		free (ap64);
+		free (pt64);
+		r_anal_var_set_type (anal, av, ty);
+		free (ty);
+	}
+	if (!rec->var) {
+		rec->var = strdup (av->name);
+	}
 }
 
 // each pointer slot holds a strided poison pointer into its own child window (a deref decodes back to the parent offset); one level deep, child windows hold no further poison
@@ -3876,7 +3972,7 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 			continue;
 		}
 		RAnalVar *rv = synth_ret_var (tps, fcn, sbase + (ut64)rrec->arg * SYNTH_WINDOW, spv, psz);
-		if (rv) {
+		if (rv && !synth_var_claimed (recs, rrec, rv->name)) {
 			rrec->var = strdup (rv->name);
 		}
 	}
@@ -3885,13 +3981,15 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 		Sdb *bookdb = anal->sdb;
 		char *key = r_str_newf ("synth.%08" PFMT64x, fcn->addr);
 		char *vkey = r_str_newf ("synth.vars.%08" PFMT64x, fcn->addr);
+		synth_restore_vars (anal, fcn, bookdb, vkey);
 		// re-runs and function renames would leave stale types behind otherwise
 		char *stale = sdb_get (bookdb, key, 0);
 		if (stale) {
-			synth_restore_vars (anal, fcn, bookdb, key, vkey);
 			char *sp;
 			sdb_aforeach (sp, stale) {
-				r_anal_remove_parsed_type (anal, sp);
+				if (!synth_type_referenced (anal, fcn, sp)) {
+					r_anal_remove_parsed_type (anal, sp);
+				}
 				sdb_aforeach_next (sp);
 			}
 			free (stale);
@@ -3908,25 +4006,7 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 				r_anal_save_base_type (anal, rec->bt);
 				r_strbuf_appendf (&sb, "%s%s", r_strbuf_length (&sb)? ",": "", rec->bt->name);
 				if (!rec->child) {
-					RAnalVar *av = synth_rec_var (anal, fcn, cc, rec);
-					if (av) {
-						char *ty = r_str_newf ("struct %s *", rec->bt->name);
-						if (ty) {
-							char *vn64 = sdb_encode ((const ut8 *)av->name, -1);
-							char *pt64 = sdb_encode ((const ut8 *)r_str_get (av->type), -1);
-							if (vn64 && pt64) {
-								r_strbuf_appendf (&vsb, "%s%s:%s",
-									r_strbuf_length (&vsb)? ",": "", vn64, pt64);
-							}
-							free (vn64);
-							free (pt64);
-							r_anal_var_set_type (anal, av, ty);
-							free (ty);
-						}
-						if (!rec->var) {
-							rec->var = strdup (av->name);
-						}
-					}
+					synth_bind_var (anal, fcn, cc, recs, rec, &vsb);
 				}
 			}
 			sdb_set (bookdb, key, r_strbuf_get (&sb), 0);
@@ -4041,7 +4121,7 @@ static char *synth_commands(RAnal *anal, RAnalFunction *fcn, RVecSynthRec *recs)
 		if (rec->child) {
 			continue;
 		}
-		RAnalVar *av = synth_rec_var (anal, fcn, cc, rec);
+		RAnalVar *av = synth_bound_var (anal, fcn, cc, recs, rec);
 		if (!av) {
 			continue;
 		}

--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -22,6 +22,7 @@ typedef struct {
 
 typedef struct {
 	ut64 addr;
+	ut64 value; // written value when the store is a power-of-two width up to 8 bytes (write records only)
 	int size;
 } TypeTraceMemoryAccess;
 
@@ -73,6 +74,7 @@ typedef struct type_trace_t {
 	ut32 voy[TP_VOYEUR_NMAX];
 	RStrBuf rollback;  // ESIL string to rollback state (inspired by PR #24428)
 	bool enable_rollback;
+	bool be; // decode recorded store values with the target's endianness
 	// TODO: Add REsil instance here
 } TypeTrace;
 
@@ -136,6 +138,8 @@ static void type_trace_voyeur_mem_write(void *user, ut64 addr, const ut8 *old, c
 	access->is_reg = false;
 	access->mem.addr = addr;
 	access->mem.size = len;
+	const bool pow2 = len <= 8 && !(len & (len - 1));
+	access->mem.value = pow2? r_read_ble (buf, trace->be, len * 8): 0;
 	access->is_write = true;
 
 	if (trace->enable_rollback && old) {
@@ -2356,6 +2360,7 @@ static TPState *tps_init(RAnal *anal) {
 		tps->cfg_rollback = false;
 	}
 	tps->tt.enable_rollback = tps->cfg_rollback;
+	tps->tt.be = R_ARCH_CONFIG_IS_BIG_ENDIAN (anal->config);
 	return tps;
 }
 
@@ -3240,6 +3245,16 @@ static int synth_arg_label(RAnal *anal, const char *cc, int win) {
 	return win;
 }
 
+static RAnalVar *synth_reg_var(RAnal *anal, RAnalFunction *fcn, const char *rname) {
+	RRegItem *ri = r_reg_get (anal->reg, rname, -1);
+	if (!ri) {
+		return NULL;
+	}
+	const int index = ri->index;
+	r_unref (ri);
+	return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_REG, index);
+}
+
 // resolve with the arg count the seeding used, or a reverse-stack cc maps to different slots here
 static RAnalVar *synth_arg_var(RAnal *anal, RAnalFunction *fcn, const char *cc, int argi) {
 	if (SYNTH_IS_RET (argi)) {
@@ -3250,13 +3265,7 @@ static RAnalVar *synth_arg_var(RAnal *anal, RAnalFunction *fcn, const char *cc, 
 		return NULL;
 	}
 	if (slot.reg) {
-		RRegItem *ri = r_reg_get (anal->reg, slot.reg, -1);
-		if (!ri) {
-			return NULL;
-		}
-		const int index = ri->index;
-		r_unref (ri);
-		return r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_REG, index);
+		return synth_reg_var (anal, fcn, slot.reg);
 	}
 	// rank this slot among the stack args, so the n-th lowest maps to the n-th stack var in delta order
 	const int nth = synth_stack_rank (anal, cc, argi, slot.off, NULL);
@@ -3287,29 +3296,38 @@ static RAnalVar *synth_arg_var(RAnal *anal, RAnalFunction *fcn, const char *cc, 
 	return pick;
 }
 
-// the store of a ret-window sentinel into a stack slot marks the variable receiving the allocation
+// the first traced write of a ret-window sentinel names the receiving var, so a later reassignment (p = NULL) cannot erase it
 static RAnalVar *synth_ret_var(TPState *tps, RAnalFunction *fcn, ut64 want, ut64 spv, int psz) {
-	RIOBind *iob = &tps->anal->iob;
-	const bool be = R_ARCH_CONFIG_IS_BIG_ENDIAN (tps->anal->config);
+	RAnal *anal = tps->anal;
 	TypeTraceAccess *a;
 	R_VEC_FOREACH (&tps->tt.db.accesses, a) {
-		if (a->is_reg || !a->is_write || a->mem.size != psz) {
+		if (!a->is_write) {
+			continue;
+		}
+		if (a->is_reg) {
+			if (a->reg.value != want) {
+				continue;
+			}
+			RAnalVar *v = synth_reg_var (anal, fcn, a->reg.name);
+			// an arg register still names the incoming argument, which the arg windows own
+			if (v && !v->isarg) {
+				return v;
+			}
+			continue;
+		}
+		if (a->mem.size != psz || a->mem.value != want) {
 			continue;
 		}
 		const ut64 ma = a->mem.addr;
 		if (ma < tps->stack_base || ma >= tps->stack_base + tps->stack_size) {
 			continue;
 		}
-		ut8 buf[8] = {0};
-		// the slot's final content decides: an overwritten pointer no longer names its var
-		if (!iob->read_at (iob->io, ma, buf, psz) || r_read_ble (buf, be, psz * 8) != want) {
-			continue;
-		}
+		// arg slots stay eligible: the seeding writes bypass the trace, so this store is the program's own
 		const st64 delta = (st64)(ma - spv);
 		RAnalVar **vp;
 		R_VEC_FOREACH (&fcn->vars, vp) {
 			RAnalVar *v = *vp;
-			if (v->kind != R_ANAL_VAR_KIND_REG && !v->isarg && v->delta == delta) {
+			if (v->kind != R_ANAL_VAR_KIND_REG && v->delta == delta) {
 				return v;
 			}
 		}
@@ -3323,6 +3341,45 @@ static RAnalVar *synth_rec_var(RAnal *anal, RAnalFunction *fcn, const char *cc, 
 		return rec->var? r_anal_function_get_var_byname (fcn, rec->var): NULL;
 	}
 	return synth_arg_var (anal, fcn, cc, rec->arg);
+}
+
+// true when the var still carries a pointer to one of the synthesized structs being replaced
+static bool synth_type_is_stale(Sdb *db, const char *key, const char *vtype) {
+	if (!vtype || !r_str_startswith (vtype, "struct ")) {
+		return false;
+	}
+	const char *base = vtype + strlen ("struct ");
+	const char *sp = strchr (base, ' ');
+	char *name = sp? r_str_ndup (base, sp - base): strdup (base);
+	const bool stale = name && sdb_array_contains (db, key, name, NULL);
+	free (name);
+	return stale;
+}
+
+// a rerun may bind elsewhere or not at all, so put back the type each var had before we touched it
+static void synth_restore_vars(RAnal *anal, RAnalFunction *fcn, Sdb *bookdb, const char *key, const char *vkey) {
+	char *vrec = sdb_get (bookdb, vkey, 0);
+	if (!vrec) {
+		return;
+	}
+	char *vp;
+	sdb_aforeach (vp, vrec) {
+		char *colon = strchr (vp, ':');
+		if (colon) {
+			*colon = 0;
+			char *vname = (char *)sdb_decode (vp, NULL);
+			char *prev = (char *)sdb_decode (colon + 1, NULL);
+			RAnalVar *v = vname? r_anal_function_get_var_byname (fcn, vname): NULL;
+			// a type the user changed since the last run is not ours to replace
+			if (v && prev && synth_type_is_stale (bookdb, key, v->type)) {
+				r_anal_var_set_type (anal, v, prev);
+			}
+			free (vname);
+			free (prev);
+		}
+		sdb_aforeach_next (vp);
+	}
+	free (vrec);
 }
 
 // each pointer slot holds a strided poison pointer into its own child window (a deref decodes back to the parent offset); one level deep, child windows hold no further poison
@@ -3827,9 +3884,11 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 		// bookkeeping lives in the root sdb to keep it out of the type namespace
 		Sdb *bookdb = anal->sdb;
 		char *key = r_str_newf ("synth.%08" PFMT64x, fcn->addr);
+		char *vkey = r_str_newf ("synth.vars.%08" PFMT64x, fcn->addr);
 		// re-runs and function renames would leave stale types behind otherwise
 		char *stale = sdb_get (bookdb, key, 0);
 		if (stale) {
+			synth_restore_vars (anal, fcn, bookdb, key, vkey);
 			char *sp;
 			sdb_aforeach (sp, stale) {
 				r_anal_remove_parsed_type (anal, sp);
@@ -3838,9 +3897,12 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 			free (stale);
 			sdb_unset (bookdb, key, 0);
 		}
+		sdb_unset (bookdb, vkey, 0);
 		if (!RVecSynthRec_empty (recs)) {
 			RStrBuf sb;
+			RStrBuf vsb;
 			r_strbuf_init (&sb);
+			r_strbuf_init (&vsb);
 			SynthRec *rec;
 			R_VEC_FOREACH (recs, rec) {
 				r_anal_save_base_type (anal, rec->bt);
@@ -3850,6 +3912,14 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 					if (av) {
 						char *ty = r_str_newf ("struct %s *", rec->bt->name);
 						if (ty) {
+							char *vn64 = sdb_encode ((const ut8 *)av->name, -1);
+							char *pt64 = sdb_encode ((const ut8 *)r_str_get (av->type), -1);
+							if (vn64 && pt64) {
+								r_strbuf_appendf (&vsb, "%s%s:%s",
+									r_strbuf_length (&vsb)? ",": "", vn64, pt64);
+							}
+							free (vn64);
+							free (pt64);
 							r_anal_var_set_type (anal, av, ty);
 							free (ty);
 						}
@@ -3860,7 +3930,11 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 				}
 			}
 			sdb_set (bookdb, key, r_strbuf_get (&sb), 0);
+			if (r_strbuf_length (&vsb)) {
+				sdb_set (bookdb, vkey, r_strbuf_get (&vsb), 0);
+			}
 			r_strbuf_fini (&sb);
+			r_strbuf_fini (&vsb);
 			// annotate the accessing instructions so disasm renders member names
 			R_VEC_FOREACH (recs, rec) {
 				SynthSite *st;
@@ -3870,6 +3944,7 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 			}
 		}
 		free (key);
+		free (vkey);
 	}
 	free (fname);
 	RVecSynthField_fini (&szctx.childwant);

--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -3287,6 +3287,44 @@ static RAnalVar *synth_arg_var(RAnal *anal, RAnalFunction *fcn, const char *cc, 
 	return pick;
 }
 
+// the store of a ret-window sentinel into a stack slot marks the variable receiving the allocation
+static RAnalVar *synth_ret_var(TPState *tps, RAnalFunction *fcn, ut64 want, ut64 spv, int psz) {
+	RIOBind *iob = &tps->anal->iob;
+	const bool be = R_ARCH_CONFIG_IS_BIG_ENDIAN (tps->anal->config);
+	TypeTraceAccess *a;
+	R_VEC_FOREACH (&tps->tt.db.accesses, a) {
+		if (a->is_reg || !a->is_write || a->mem.size != psz) {
+			continue;
+		}
+		const ut64 ma = a->mem.addr;
+		if (ma < tps->stack_base || ma >= tps->stack_base + tps->stack_size) {
+			continue;
+		}
+		ut8 buf[8] = {0};
+		// the slot's final content decides: an overwritten pointer no longer names its var
+		if (!iob->read_at (iob->io, ma, buf, psz) || r_read_ble (buf, be, psz * 8) != want) {
+			continue;
+		}
+		const st64 delta = (st64)(ma - spv);
+		RAnalVar **vp;
+		R_VEC_FOREACH (&fcn->vars, vp) {
+			RAnalVar *v = *vp;
+			if (v->kind != R_ANAL_VAR_KIND_REG && !v->isarg && v->delta == delta) {
+				return v;
+			}
+		}
+	}
+	return NULL;
+}
+
+// the var a root rec binds to: the named ret receiver, or the cc-mapped argument
+static RAnalVar *synth_rec_var(RAnal *anal, RAnalFunction *fcn, const char *cc, const SynthRec *rec) {
+	if (SYNTH_IS_RET (rec->arg)) {
+		return rec->var? r_anal_function_get_var_byname (fcn, rec->var): NULL;
+	}
+	return synth_arg_var (anal, fcn, cc, rec->arg);
+}
+
 // each pointer slot holds a strided poison pointer into its own child window (a deref decodes back to the parent offset); one level deep, child windows hold no further poison
 static int synth_poison_map(RAnal *anal, ut64 sbase, int align, int psz, int nwin, ut64 *pbase) {
 	RIOBind *iob = &anal->iob;
@@ -3774,6 +3812,17 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 	// remember the access sites per struct, for hints and command emission
 	synth_collect_sites (recs, &vfields, false);
 	synth_collect_sites (recs, &vporig, true);
+	// returned objects bind to no argument; the sentinel store names the receiving var instead
+	SynthRec *rrec;
+	R_VEC_FOREACH (recs, rrec) {
+		if (rrec->child || !SYNTH_IS_RET (rrec->arg)) {
+			continue;
+		}
+		RAnalVar *rv = synth_ret_var (tps, fcn, sbase + (ut64)rrec->arg * SYNTH_WINDOW, spv, psz);
+		if (rv) {
+			rrec->var = strdup (rv->name);
+		}
+	}
 	if (apply) {
 		// bookkeeping lives in the root sdb to keep it out of the type namespace
 		Sdb *bookdb = anal->sdb;
@@ -3797,14 +3846,16 @@ static void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec
 				r_anal_save_base_type (anal, rec->bt);
 				r_strbuf_appendf (&sb, "%s%s", r_strbuf_length (&sb)? ",": "", rec->bt->name);
 				if (!rec->child) {
-					RAnalVar *av = synth_arg_var (anal, fcn, cc, rec->arg);
+					RAnalVar *av = synth_rec_var (anal, fcn, cc, rec);
 					if (av) {
 						char *ty = r_str_newf ("struct %s *", rec->bt->name);
 						if (ty) {
 							r_anal_var_set_type (anal, av, ty);
 							free (ty);
 						}
-						rec->var = strdup (av->name);
+						if (!rec->var) {
+							rec->var = strdup (av->name);
+						}
 					}
 				}
 			}
@@ -3915,7 +3966,7 @@ static char *synth_commands(RAnal *anal, RAnalFunction *fcn, RVecSynthRec *recs)
 		if (rec->child) {
 			continue;
 		}
-		RAnalVar *av = synth_arg_var (anal, fcn, cc, rec->arg);
+		RAnalVar *av = synth_rec_var (anal, fcn, cc, rec);
 		if (!av) {
 			continue;
 		}

--- a/test/db/cmd/cmd_afts
+++ b/test/db/cmd/cmd_afts
@@ -927,7 +927,7 @@ var struct fcn_00000000_ret1 * var_10h @ rbp-0x10
 EOF
 RUN
 
-NAME=afts leaves the local untyped when the stored pointer is overwritten
+NAME=afts keeps the binding when the pointer is later cleared
 FILE=malloc://256
 ARGS=-a x86 -b 64 -e types.sizes=true
 CMDS=<<EOF
@@ -940,7 +940,80 @@ afts > /dev/null
 afv
 EOF
 EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+EOF
+RUN
+
+NAME=afts keeps the binding when one branch clears the pointer
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e83e000000488985f8ffffffc70001000000c740080200000085c0750848c745f800000000488b45f8c9c3
+wx c3 @ 0x50
+af @ 0x50
+afn malloc @ 0x50
+af @ 0
+afts > /dev/null
+afv~var_8h
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+EOF
+RUN
+
+NAME=afts rerun restores the receiving var when the binding disappears
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e81e000000488985f8ffffff488b45f8c70001000000488b45f8c7400802000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afv
+e types.sizefns=malloc/-
+afts
+afv
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
 var int64_t var_8h @ rbp-0x8
+EOF
+RUN
+
+NAME=afts types a stack argument slot reused for the returned object
+FILE=malloc://256
+ARGS=-a x86 -b 32 -e types.sizes=true
+CMDS=<<EOF
+wx 5589e56888000000e82300000083c4048985080000008b4508c70001000000c74008020000005dc3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afv
+EOF
+EXPECT=<<EOF
+arg struct fcn_00000000_ret0 * arg_8h @ ebp+0x8
+EOF
+RUN
+
+NAME=afts does not rebind an argument register holding the returned pointer
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e5bf88000000e8220000004889c3c70301000000c74308020000005dc3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afvr rbx obj int64_t
+afts > /dev/null
+afv~obj
+EOF
+EXPECT=<<EOF
+arg int64_t obj @ rbx
 EOF
 RUN
 

--- a/test/db/cmd/cmd_afts
+++ b/test/db/cmd/cmd_afts
@@ -855,7 +855,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=afts* emits no variable command for a returned object
+NAME=afts* emits no variable command when nothing stores the returned pointer
 FILE=malloc://256
 ARGS=-a x86 -b 64 -e types.sizes=true
 CMDS=<<EOF
@@ -870,6 +870,93 @@ EOF
 EXPECT=<<EOF
 0
 1
+EOF
+RUN
+
+NAME=afts types the local receiving a malloc return
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e81e000000488985f8ffffff488b45f8c70001000000488b45f8c7400802000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afv
+aftsj~{0.var}
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+var_8h
+EOF
+RUN
+
+NAME=afts types the sp-relative local receiving a malloc return
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 4883ec18bf88000000e8220000004889442408488b442408c70001000000c74008020000004883c418c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afv
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rsp+0x8
+EOF
+RUN
+
+NAME=afts binds each returned object to its own local
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf18000000e84e000000488985f8ffffffbf28000000e83d000000488985f0ffffff488b45f8c70001000000c7400802000000488b45f0c70003000000c7401004000000c9c3
+wx c3 @ 0x60
+af @ 0x60
+afn malloc @ 0x60
+af @ 0
+afts > /dev/null
+afv
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+var struct fcn_00000000_ret1 * var_10h @ rbp-0x10
+EOF
+RUN
+
+NAME=afts leaves the local untyped when the stored pointer is overwritten
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e82e000000488985f8ffffffc70001000000c740080200000048c745f800000000c9c3
+wx c3 @ 0x40
+af @ 0x40
+afn malloc @ 0x40
+af @ 0
+afts > /dev/null
+afv
+EOF
+EXPECT=<<EOF
+var int64_t var_8h @ rbp-0x8
+EOF
+RUN
+
+NAME=afts* emits the variable command for a bound returned object
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e81e000000488985f8ffffff488b45f8c70001000000488b45f8c7400802000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts*~afv
+EOF
+EXPECT=<<EOF
+'afvb -8 var_8h struct fcn_00000000_ret0 *
 EOF
 RUN
 

--- a/test/db/cmd/cmd_afts
+++ b/test/db/cmd/cmd_afts
@@ -1033,6 +1033,137 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=afts binds a local reused across allocations to the first allocation
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf18000000e86e000000488985f8ffffff488b45f8c70001000000c7400802000000bf28000000e84c000000488985f8ffffff488b45f8c70003000000c7401004000000c9c3
+wx c3 @ 0x80
+af @ 0x80
+afn malloc @ 0x80
+af @ 0
+afts > /dev/null
+afv
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+EOF
+RUN
+
+NAME=afts* emits one variable command for a local reused across allocations
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf18000000e86e000000488985f8ffffff488b45f8c70001000000c7400802000000bf28000000e84c000000488985f8ffffff488b45f8c70003000000c7401004000000c9c3
+wx c3 @ 0x80
+af @ 0x80
+afn malloc @ 0x80
+af @ 0
+afts*~afv
+EOF
+EXPECT=<<EOF
+'afvb -8 var_8h struct fcn_00000000_ret0 *
+EOF
+RUN
+
+NAME=afts rerun restores a renamed receiving var when the binding disappears
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e81e000000488985f8ffffff488b45f8c70001000000488b45f8c7400802000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afvn p var_8h
+e types.sizefns=malloc/-
+afts
+afv
+EOF
+EXPECT=<<EOF
+var int64_t p @ rbp-0x8
+EOF
+RUN
+
+NAME=afts rerun keeps a user-selected type naming another synthesized struct
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf18000000e84e000000488985f8ffffffbf28000000e83d000000488985f0ffffff488b45f8c70001000000c7400802000000488b45f0c70003000000c7401004000000c9c3
+wx c3 @ 0x60
+af @ 0x60
+afn malloc @ 0x60
+af @ 0
+afts > /dev/null
+afvt var_8h "struct fcn_00000000_ret1 *"
+e types.sizefns=malloc/-
+afts
+afv~var_8h
+ts~fcn_
+EOF
+EXPECT=<<EOF
+var struct fcn_00000000_ret1 * var_8h @ rbp-0x8
+fcn_00000000_ret1
+EOF
+RUN
+
+NAME=afts keeps a synthesized type a qualified user edit still points at
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf88000000e81e000000488985f8ffffff488b45f8c70001000000488b45f8c7400802000000c9c3
+wx c3 @ 0x30
+af @ 0x30
+afn malloc @ 0x30
+af @ 0
+afts > /dev/null
+afvt var_8h "const struct fcn_00000000_ret0 *"
+e types.sizefns=malloc/-
+afts
+afv
+ts~fcn_
+EOF
+EXPECT=<<EOF
+var const struct fcn_00000000_ret0 * var_8h @ rbp-0x8
+fcn_00000000_ret0
+EOF
+RUN
+
+NAME=aftsj reports the bound variable once for a local reused across allocations
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true
+CMDS=<<EOF
+wx 554889e54883ec10bf18000000e86e000000488985f8ffffff488b45f8c70001000000c7400802000000bf28000000e84c000000488985f8ffffff488b45f8c70003000000c7401004000000c9c3
+wx c3 @ 0x80
+af @ 0x80
+afn malloc @ 0x80
+af @ 0
+aftsj~{}~var
+EOF
+EXPECT=<<EOF
+    "var": "var_8h",
+EOF
+RUN
+
+NAME=afts keeps a nested child of a synthesized type a user edit still points at
+FILE=malloc://256
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 8b07488b4f088b118b711001d001f0c3
+af @ 0
+afts > /dev/null
+afvt arg1 "const struct fcn_00000000_arg0 *"
+afn other
+afts > /dev/null
+ts~fcn_00000000
+EOF
+EXPECT=<<EOF
+fcn_00000000_arg0
+fcn_00000000_arg0_0x8
+EOF
+RUN
+
 NAME=allocator returns stay invisible without types.sizes
 FILE=malloc://256
 ARGS=-a x86 -b 64


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

afts synthesizes a struct for the object behind an allocator return, but the variable receiving the pointer kept its generic type.

The emulation already seeds the return register with a per-call-site sentinel. The first traced store of that value now names the receiver:

- a stack slot binds by entry-SP-relative delta (bp- and sp-based frames)
- a register write binds a non-argument register variable
- a reused stack argument slot is eligible, since seeding writes bypass the trace
- argument registers are excluded: passing the pointer onward writes the sentinel into one, and binding it would mistype the incoming argument

Matching at the write, rather than at the final stack image, keeps the binding stable under a later `p = NULL`, a branch that clears the pointer, and sweep order.

The bound variable is typed `struct fcn_X_retN *`, aftsj reports it in the existing "var" key, and afts* emits the matching afvb/afvs/afvr command. A local reused across allocations binds to the first one, so those three paths never disagree about a slot.

Reruns record each bound variable's location and the exact type applied. The next run restores the previous type before rebinding, and only when the variable still carries exactly what the last run applied. So a variable renamed in between is still found, and a type the user chose is left alone — as is any synthesized struct that type still reaches.

Tests cover the receiver kinds and the argument-register exclusion, binding stability across clears and branches, reuse of one local across two allocations, and rerun behaviour: restore after the allocator entry is dropped, restore after a rename, and user-chosen types surviving untouched.
