### PR TITLE
core: fix rm command silently ignoring -r and -rf flags

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2952,26 +2952,26 @@ static int cmd_resize(void *data, const char *input) {
 		}
 		if (input[1] == ' ') {
 			int index = 2;
-			if (input[3] == 'r') {
-				const char *file =  r_str_trim_head_ro (input + 4);
-				if (input[4] == 'f') {
-					file = r_str_trim_head_ro (input + 5);
+			if (input[2] == '-') {
+				if (input[3] == 'r') {
+					const char *file = r_str_trim_head_ro (input + 4);
+					if (input[4] == 'f') {
+						file = r_str_trim_head_ro (input + 5);
+					}
+					if (*file == '\0') {
+						r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+						return false;
+					}
+					return r_file_rm_rf (file);
 				}
-				if (*file == '\0') {
+				while (input[index] != ' ' && input[index] != '\0') {
+					index++;
+				}
+				if (input[index] == '\0') {
 					r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
 					return false;
 				}
-				return r_file_rm_rf (file);
 			}
-			while (input[index] != ' ' && input[index] != '\0') {
-				index++;
-			}
-
-			if (input[index] == '\0') {
-				r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
-				return false;
-			}
-
 			const char *file = r_str_trim_head_ro (input + index);
 			if (*file == '$') {
 				if (!r_cmd_alias_del (core->rcmd, file + 1)) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2952,11 +2952,14 @@ static int cmd_resize(void *data, const char *input) {
 		}
 		if (input[1] == ' ') {
 			int index = 2;
-			if (input[2] == '-') {
 				if (input[3] == 'r') {
 					const char *file = r_str_trim_head_ro (input + 4);
 					if (input[4] == 'f') {
 						file = r_str_trim_head_ro (input + 5);
+					}
+					if (*file == '\0') {
+						r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+						return false;
 					}
 					return r_file_rm_rf (file);
 				}

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2952,25 +2952,26 @@ static int cmd_resize(void *data, const char *input) {
 		}
 		if (input[1] == ' ') {
 			int index = 2;
-				if (input[3] == 'r') {
-					const char *file = r_str_trim_head_ro (input + 4);
-					if (input[4] == 'f') {
-						file = r_str_trim_head_ro (input + 5);
-					}
-					if (*file == '\0') {
-						r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
-						return false;
-					}
-					return r_file_rm_rf (file);
+			if (input[3] == 'r') {
+				const char *file =  r_str_trim_head_ro (input + 4);
+				if (input[4] == 'f') {
+					file = r_str_trim_head_ro (input + 5);
 				}
-				while (input[index] != ' ' && input[index] != '\0') {
-					index++;
-				}
-				if (input[index] == '\0') {
+				if (*file == '\0') {
 					r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
 					return false;
 				}
+				return r_file_rm_rf (file);
 			}
+			while (input[index] != ' ' && input[index] != '\0') {
+				index++;
+			}
+
+			if (input[index] == '\0') {
+				r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+				return false;
+			}
+
 			const char *file = r_str_trim_head_ro (input + index);
 			if (*file == '$') {
 				if (!r_cmd_alias_del (core->rcmd, file + 1)) {

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2951,7 +2951,24 @@ static int cmd_resize(void *data, const char *input) {
 			return false;
 		}
 		if (input[1] == ' ') {
-			const char *file = r_str_trim_head_ro (input + 2);
+			int index = 2;
+			if (input[2] == '-') {
+				if (input[3] == 'r') {
+					const char *file = r_str_trim_head_ro (input + 4);
+					if (input[4] == 'f') {
+						file = r_str_trim_head_ro (input + 5);
+					}
+					return r_file_rm_rf (file);
+				}
+				while (input[index] != ' ' && input[index] != '\0') {
+					index++;
+				}
+				if (input[index] == '\0') {
+					r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+					return false;
+				}
+			}
+			const char *file = r_str_trim_head_ro (input + index);
 			if (*file == '$') {
 				if (!r_cmd_alias_del (core->rcmd, file + 1)) {
 					R_LOG_ERROR ("Cannot find alias file %s", file);

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -2951,28 +2951,34 @@ static int cmd_resize(void *data, const char *input) {
 			return false;
 		}
 		if (input[1] == ' ') {
-			int index = 2;
 			if (input[2] == '-') {
 				if (input[3] == 'r') {
 					const char *file = r_str_trim_head_ro (input + 4);
 					if (input[4] == 'f') {
+						if (input[5] != ' ')
+						{
+							r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+							return false;
+						}
 						file = r_str_trim_head_ro (input + 5);
+					} else if (input[4] == ' ') {
+						const char *file = r_str_trim_head_ro (input + 5);
+						return r_file_rm_rf (file);
+					} else {
+						r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
+						return false;
 					}
 					if (*file == '\0') {
 						r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
 						return false;
 					}
 					return r_file_rm_rf (file);
-				}
-				while (input[index] != ' ' && input[index] != '\0') {
-					index++;
-				}
-				if (input[index] == '\0') {
+				} else {
 					r_cons_cmd_help_match (core->cons, help_msg_r, "rm", 0, false);
 					return false;
 				}
 			}
-			const char *file = r_str_trim_head_ro (input + index);
+			const char *file = r_str_trim_head_ro (input + 2);
 			if (*file == '$') {
 				if (!r_cmd_alias_del (core->rcmd, file + 1)) {
 					R_LOG_ERROR ("Cannot find alias file %s", file);

--- a/test/db/cmd/shell
+++ b/test/db/cmd/shell
@@ -220,6 +220,40 @@ empty-digits-empty
 EOF
 RUN
 
+NAME=Remove files valid commands
+FILE=malloc://512
+CMDS=<<EOF
+rm file
+rm -r directory
+rm -rf directory
+EOF
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=Remove files invalid commands
+FILE=malloc://512
+CMDS=<<EOF
+rm -r
+rm -rf
+rm -rfoo
+rm -random target
+rm -fr directory
+EOF
+EXPECT=<<EOF
+| rm [file]        remove file
+| rmrf [file|dir]  recursive remove
+| rm [file]        remove file
+| rmrf [file|dir]  recursive remove
+| rm [file]        remove file
+| rmrf [file|dir]  recursive remove
+| rm [file]        remove file
+| rmrf [file|dir]  recursive remove
+| rm [file]        remove file
+| rmrf [file|dir]  recursive remove
+EOF
+RUN
+
 NAME=single quote after conditional boundaries
 FILE=malloc://32
 CMDS=<<EOF


### PR DESCRIPTION
Fixes #26377

The rm command was silently ignoring -r and -rf flags because r2's builtin rm has no flag parsing. This fix adds handling for the -r flag to call r_file_rm_rf instead of r_file_rm.