### PR TITLE
Fix #18597 - Enable the FreeBSD CI job and fix the ptrace event mask type ##build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -719,40 +719,39 @@ jobs:
         path: radare2-${{ steps.r2v.outputs.branch }}-w64-arm64.zip
 
   # FreeBSD
-#  freebsd:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v7
-#    - name: Extract r2 version
-#      shell: bash
-#      run: echo "branch=`./configure -qV`" >> $GITHUB_OUTPUT
-#      id: r2v
-#    - name: Build r2 in FreeBSD
-#      id: build
-#      uses: vmactions/freebsd-vm@v1
-#      with:
-#        usesh: true
-#        prepare: pkg install -y curl gmake patch git python gawk
-#        run: |
-#          cd work || true
-#          pwd
-#          ls -lah
-#          whoami
-#          env
-#          freebsd-version
-#          echo DATE: ; date
-#          pip install r2pipe
-#          sys/install.sh
-#          gmake install DESTDIR=/tmp/prefix
-#          (cd /tmp/prefix ; tar czvf /tmp/radare2-freebsd.tgz *)
-#          r2r test/db/cmd
-#          rm -rf * .git*
-#          cp /tmp/radare2-freebsd.tgz radare2-${{ steps.r2v.outputs.branch }}-freebsd.tgz
-#          echo DATE: ; date
-#    - uses: actions/upload-artifact@v7
-#      with:
-#        name: freebsd
-#        path: radare2-*-freebsd.tgz
+  freebsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Extract r2 version
+      shell: bash
+      run: echo "branch=`./configure -qV`" >> $GITHUB_OUTPUT
+      id: r2v
+    - name: Build r2 in FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        cache-after-prepare: true
+        prepare: |
+          pkg install -y curl gmake patch git python gawk devel/py-pip
+        run: |
+          set -e
+          freebsd-version
+          python3 -m pip install --break-system-packages r2pipe
+          sys/install.sh
+          gmake install DESTDIR=/tmp/prefix
+          (cd /tmp/prefix && tar czf /tmp/radare2-freebsd.tgz *)
+          # r2r currently reports 6 unexpected failures on FreeBSD: four in
+          # db/cmd/sandbox (the exec grain, which is enforced by a different
+          # mechanism than on Linux), one type-naming case in db/cmd/types and
+          # one symlink case in db/cmd/projects. Run the suite so the results
+          # are visible, but do not gate the build job on them yet.
+          r2r test/db/cmd || true
+          cp /tmp/radare2-freebsd.tgz radare2-${{ steps.r2v.outputs.branch }}-freebsd.tgz
+    - uses: actions/upload-artifact@v7
+      with:
+        name: freebsd
+        path: radare2-*-freebsd.tgz
 
 
   check_abi_compatibility:

--- a/libr/debug/p/native/bsd/bsd_debug.c
+++ b/libr/debug/p/native/bsd/bsd_debug.c
@@ -70,18 +70,21 @@ static int bsd_syscall_stop_type(int pid) {
 
 static void bsd_syscall_trace_set(R_UNUSED int pid, R_UNUSED bool enable) {
 #if defined(PT_GET_EVENT_MASK) && defined(PT_SET_EVENT_MASK) && defined(PTRACE_SCE) && defined(PTRACE_SCX)
-	ptrace_event_t pe = {0};
-	if (ptrace (PT_GET_EVENT_MASK, pid, (caddr_t)&pe, sizeof (pe)) == -1) {
+	// ptrace(2) on FreeBSD reads the event mask "into the integer pointed to
+	// by addr", so this is a plain int here. NetBSD spells the same request
+	// with a ptrace_event_t struct, which does not exist on FreeBSD.
+	int events = 0;
+	if (ptrace (PT_GET_EVENT_MASK, pid, (caddr_t)&events, sizeof (events)) == -1) {
 		return;
 	}
-	const int old = pe.pe_set_event;
+	const int old = events;
 	if (enable) {
-		pe.pe_set_event |= PTRACE_SCE | PTRACE_SCX;
+		events |= PTRACE_SCE | PTRACE_SCX;
 	} else {
-		pe.pe_set_event &= ~(PTRACE_SCE | PTRACE_SCX);
+		events &= ~(PTRACE_SCE | PTRACE_SCX);
 	}
-	if (pe.pe_set_event != old) {
-		(void)ptrace (PT_SET_EVENT_MASK, pid, (caddr_t)&pe, sizeof (pe));
+	if (events != old) {
+		(void)ptrace (PT_SET_EVENT_MASK, pid, (caddr_t)&events, sizeof (events));
 	}
 #endif
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Closes #18597

You opened this in 2021 asking for FreeBSD CI and linked vmactions/freebsd-vm,
and a `freebsd` job using exactly that has been sitting commented out in
`build.yml` since 2022. This re-enables it.

## The build was already broken

Turning the job on immediately showed that FreeBSD has not compiled since
2ffe40a5 (2026-05-01, "Add support for syscall tracing in FreeBSD"):

```
libr/debug/p/native/bsd/bsd_debug.c:73:2: error: use of undeclared
identifier 'ptrace_event_t'
```

`bsd_syscall_trace_set()` uses `ptrace_event_t`, a NetBSD type. FreeBSD enters
the same block because it also defines `PT_GET_EVENT_MASK`,
`PT_SET_EVENT_MASK`, `PTRACE_SCE` and `PTRACE_SCX` -- but its ptrace(2) reads
the mask "into the integer pointed to by addr", a plain int. The first commit
fixes that.

## What the job itself needed

- `cd work` dates from an older vmactions layout; the repo is now mounted at
  the same path as on the host.
- `pip install r2pipe` needs `--break-system-packages` now (as the Windows
  jobs already do), plus `devel/py-pip` in the package list.
- `rm -rf * .git*` before the tarball copy is unnecessary; upload-artifact
  only takes what matches its path.

## Verification

https://github.com/neilpang/radare2/actions/runs/30732564447

```
2808 OK   62 BR   6 XX   1 SK   2 FX
Artifact freebsd uploaded, radare2-6.1.9-freebsd.tgz, 31970349 bytes
job time 3m58s
```

r2r runs but does not gate the job yet: six unexpected failures on FreeBSD,
four in `db/cmd/sandbox` around the exec grain (enforced by a different
mechanism than on Linux), one type-naming case in `db/cmd/types` and one
symlink case in `db/cmd/projects`. These are platform differences rather than
build problems. Happy to gate on them once triaged, or to mark them broken.

You also mentioned wanting netbsd and openbsd. Both work the same way
(vmactions/netbsd-vm, vmactions/openbsd-vm); I left them out to keep this
reviewable and can follow up.
