### PR TITLE
Fix #26390: ASAN OOBR when namelen > 30 in hsfplus

### DIFF
--- a/libr/fs/p/grub/fs/hfsplus.c
+++ b/libr/fs/p/grub/fs/hfsplus.c
@@ -518,7 +518,7 @@ static int grub_hfsplus_cmp_catkey(struct grub_hfsplus_key *keya,
 		return namelen;
 	}
 
-	if (namelen > sizeof (catkey_a->name)){
+	if (namelen > sizeof (catkey_a->name)) {
 		namelen = sizeof (catkey_a->name);
 	}
 
@@ -708,7 +708,7 @@ list_nodes(void *record, void *closure) {
 	catkey = (struct grub_hfsplus_catkey *)record;
 	namelen = grub_be_to_cpu16 (catkey->namelen);
 
-	if (namelen > sizeof (catkey->name)){
+	if (namelen > sizeof (catkey->name)) {
 		namelen = sizeof (catkey->name);
 	}
 

--- a/libr/fs/p/grub/fs/hfsplus.c
+++ b/libr/fs/p/grub/fs/hfsplus.c
@@ -518,6 +518,10 @@ static int grub_hfsplus_cmp_catkey(struct grub_hfsplus_key *keya,
 		return namelen;
 	}
 
+	if (namelen > sizeof (catkey_a->name)){
+		namelen = sizeof (catkey_a->name);
+	}
+
 	char *filename = grub_hfsplus_catkey_to_utf8 (catkey_a, namelen);
 	if (!filename) {
 		return -1;
@@ -703,6 +707,10 @@ list_nodes(void *record, void *closure) {
 
 	catkey = (struct grub_hfsplus_catkey *)record;
 	namelen = grub_be_to_cpu16 (catkey->namelen);
+
+	if (namelen > sizeof (catkey->name)){
+		namelen = sizeof (catkey->name);
+	}
 
 	fileinfo =
 		(struct grub_hfsplus_catfile *) ((char *)record + grub_be_to_cpu16 (catkey->keylen) + 2 + (grub_be_to_cpu16 (catkey->keylen) % 2));


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes #26390
TBH it's hard for this bug to cause a crash because of the way records are stored in memory, but since I've come across this i wanted to fix it if it's acceptable.
