### PR TITLE
Add the missing operand count to the PowerPC lfiwax pseudo rule ##arch

### DIFF
--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -721,7 +721,7 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "lfdu", "A = double[C + B]", 3},
 		{ "lfdux", "A = double[C + B]", 3},
 		{ "lfdx", "A = double[C + B]", 3},
-		{ "lfiwax", "A = float[C + B]", },
+		{ "lfiwax", "A = float[C + B]", 3},
 		{ "lfiwzx", "A = float[C + B]", 3},
 		{ "lfs", "A = float[C + B]", 3},
 		{ "lfsu", "A = float[C + B]", 3},

--- a/test/db/cmd/cmd_pseudo_ppc
+++ b/test/db/cmd/cmd_pseudo_ppc
@@ -184,3 +184,15 @@ r15 = (rol32(r7, 0xf) & 0xffffffffffe00003) | (r15 & 0x1ffffc)
 r15 = rol32(r7, r5) & 0xffffffffffe00003
 EOF
 RUN
+
+NAME=PPC64 pseudo lfiwax renders its operands
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 7c6436ae
+pi 1
+EOF
+EXPECT=<<EOF
+f3 = float[r6 + r4]
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The `lfiwax` row in the ppc pseudo `ops[]` table omitted its operand-count field, the only row in the table missing it. The field defaulted to 0, so `can_replace()` rejected every template letter above `A` and the rendered pseudo kept the literal placeholders:

    $ r2 -a ppc -b 64 -e cfg.bigendian=true -e asm.pseudo=true malloc://32
    > wx 7c6436ae   # lfiwax f3, r4, r6
    > pi 1
    f3 = float[C + B]

With the count set to 3 (matching the neighbouring indexed FP loads `lfiwzx`/`lfsx`/`lfdx`) it renders as expected:

    f3 = float[r6 + r4]

Adds a test to `db/cmd/cmd_pseudo_ppc`, confirmed failing before the fix.
