### PR TITLE
Fix r_num_units integer check for 80bit long doubles ##util

### DIFF
--- a/libr/util/unum.c
+++ b/libr/util/unum.c
@@ -107,9 +107,11 @@ R_API char *r_num_units(char *buf, size_t len, ut64 num) {
 	} else {
 		unit = '\0';
 	}
-	// fnum is always scaled below 1024 here, so an exact integer check needs
-	// no libm and works the same for double and long double
-	fmt_str = (fnum == (R_LDBL)(ut64)fnum)
+	// compare at double precision: an 80-bit x87 long double can hold a value
+	// infinitesimally below an integer (UT64_MAX / EB == 16 - 2^-60) that
+	// must still print as "16E" and not "16.0E"
+	const double dnum = (double)fnum;
+	fmt_str = (dnum == (double)(ut64)dnum)
 		? "%.0" LDBLFMT "%c"
 		: "%.1" LDBLFMT "%c";
 	snprintf (buf, len, fmt_str, fnum, unit);


### PR DESCRIPTION
UT64_MAX / EB is exactly 16 - 2^-60, which an x87 long double can
represent, so the exact integer comparison introduced in 0fb40e50
printed 16.0E instead of 16E on Linux x86. Compare at double
precision like the previous ceill-based check did, which keeps the
no-libm and no-vararg-corruption properties on 32bit Windows.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JsCkFNjboukUureH21GBKS