### PR TITLE
Check only the program basename when dispatching r2 into the r2pipe launcher ##shell

### DIFF
--- a/binr/radare2/radare2.c
+++ b/binr/radare2/radare2.c
@@ -99,7 +99,7 @@ static int r_main_r2pipe(int argc, const char **argv) {
 }
 
 int main(int argc, const char **argv) {
-	if (argc > 0 && strstr (argv[0], "r2p")) {
+	if (argc > 0 && strstr (r_file_basename (argv[0]), "r2p")) {
 		return r_main_r2pipe (argc, argv);
 	}
 	char *ea = r_sys_getenv ("R2_ARGS");


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

r2 dispatches into the r2pipe launcher when argv[0] contains "r2p", but the match ran on the full path, so any install prefix with "r2p" in a directory name (e.g. --prefix=$HOME/r2prefix) made every r2/radare2 invocation die with "R2PIPE_(IN|OUT) environment not set".

Match on r_file_basename(argv[0]) instead: the launcher names (r2p, r2p.exe, r2pipe) still divert, directory names no longer do.

Adds a REQUIRE=linux regression test in db/cmd/cmd_pipe that runs the binary under test through a .tmp/r2prefix/ symlink; it fails before the fix.