### PR TITLE
Use r_str_ncpy to fill the pseudo parser word buffers ##arch

### DIFF
--- a/libr/arch/p/arm/pseudo.c
+++ b/libr/arch/p/arm/pseudo.c
@@ -283,8 +283,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		if (ptr) {
 			*ptr = '\0';
 			ptr = (char *)r_str_trim_head_ro (ptr + 1);
-			strncpy (w0, buf, sizeof (w0) - 1);
-			strncpy (w1, ptr, sizeof (w1) - 1);
+			r_str_ncpy (w0, buf, sizeof (w0));
+			r_str_ncpy (w1, ptr, sizeof (w1));
 			optr = ptr;
 			if (*ptr == '(') {
 				ptr = strchr (ptr + 1, ')');
@@ -304,22 +304,22 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			if (ptr) {
 				*ptr = '\0';
 				ptr = (char *)r_str_trim_head_ro (ptr + 1);
-				strncpy (w1, optr, sizeof (w1) - 1);
-				strncpy (w2, ptr, sizeof (w2) - 1);
+				r_str_ncpy (w1, optr, sizeof (w1));
+				r_str_ncpy (w2, ptr, sizeof (w2));
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
 					*ptr = '\0';
 					ptr = (char *)r_str_trim_head_ro (ptr + 1);
-					strncpy (w2, optr, sizeof (w2) - 1);
-					strncpy (w3, ptr, sizeof (w3) - 1);
+					r_str_ncpy (w2, optr, sizeof (w2));
+					r_str_ncpy (w3, ptr, sizeof (w3));
 					optr = ptr;
 					ptr = strchr (ptr, ',');
 					if (ptr) {
 						*ptr = '\0';
 						ptr = (char *)r_str_trim_head_ro (ptr + 1);
-						strncpy (w3, optr, sizeof (w3) - 1);
-						strncpy (w4, ptr, sizeof (w4) - 1);
+						r_str_ncpy (w3, optr, sizeof (w3));
+						r_str_ncpy (w4, ptr, sizeof (w4));
 					}
 				}
 			}

--- a/libr/arch/p/avr/pseudo.c
+++ b/libr/arch/p/avr/pseudo.c
@@ -158,8 +158,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				//nothing to see here
 			}
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr = ptr;
 			ptr = strchr (ptr, ',');
@@ -168,8 +168,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					//nothing to see here
 				}
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -177,8 +177,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						//nothing to see here
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr = ptr;
 					// bonus
 					ptr = strchr (ptr, ',');
@@ -187,13 +187,13 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							//nothing to see here
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 					}
 				}
 			}
 		} else {
-			strncpy (w0, buf, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };

--- a/libr/arch/p/cosmac/pseudo.c
+++ b/libr/arch/p/cosmac/pseudo.c
@@ -105,8 +105,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		if (ptr) {
 			*ptr = '\0';
 			ptr = (char *)r_str_trim_head_ro (ptr + 1);
-			strncpy (w0, buf, sizeof (w0) - 1);
-			strncpy (w1, ptr, sizeof (w1) - 1);
+			r_str_ncpy (w0, buf, sizeof (w0));
+			r_str_ncpy (w1, ptr, sizeof (w1));
 			optr = ptr;
 			if (ptr && *ptr == '[') {
 				ptr = strchr (ptr + 1, ']');
@@ -121,22 +121,22 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			if (ptr) {
 				*ptr = '\0';
 				ptr = (char *)r_str_trim_head_ro (ptr + 1);
-				strncpy (w1, optr, sizeof (w1) - 1);
-				strncpy (w2, ptr, sizeof (w2) - 1);
+				r_str_ncpy (w1, optr, sizeof (w1));
+				r_str_ncpy (w2, ptr, sizeof (w2));
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
 					*ptr = '\0';
 					ptr = (char *)r_str_trim_head_ro (ptr + 1);
-					strncpy (w2, optr, sizeof (w2) - 1);
-					strncpy (w3, ptr, sizeof (w3) - 1);
+					r_str_ncpy (w2, optr, sizeof (w2));
+					r_str_ncpy (w3, ptr, sizeof (w3));
 					optr = ptr;
 					ptr = strchr (ptr, ',');
 					if (ptr) {
 						*ptr = '\0';
 						ptr = (char *)r_str_trim_head_ro (ptr + 1);
-						strncpy (w3, optr, sizeof (w3) - 1);
-						strncpy (w4, ptr, sizeof (w4) - 1);
+						r_str_ncpy (w3, optr, sizeof (w3));
+						r_str_ncpy (w4, ptr, sizeof (w4));
 					}
 				}
 			}

--- a/libr/arch/p/dalvik/pseudo.c
+++ b/libr/arch/p/dalvik/pseudo.c
@@ -283,10 +283,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		if (ptr) {
 			*ptr = '\0';
 			ptr = (char *)r_str_trim_head_ro (ptr + 1);
-			strncpy (w0, buf, sizeof (w0) - 1);
-			w0[sizeof (w0)-1] = '\0';
-			strncpy (w1, ptr, sizeof (w1) - 1);
-			w1[sizeof (w1)-1] = '\0';
+			r_str_ncpy (w0, buf, sizeof (w0));
+			r_str_ncpy (w1, ptr, sizeof (w1));
 
 			optr=ptr;
 			ptr2 = strchr (ptr, '}');
@@ -299,10 +297,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					;
 				}
-				strncpy (w1, optr, sizeof (w1) - 1);
-				w1[sizeof (w1)-1] = '\0';
-				strncpy (w2, ptr, sizeof (w2) - 1);
-				w2[sizeof (w2)-1] = '\0';
+				r_str_ncpy (w1, optr, sizeof (w1));
+				r_str_ncpy (w2, ptr, sizeof (w2));
 				optr=ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -310,10 +306,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						;
 					}
-					strncpy (w2, optr, sizeof (w2) - 1);
-					w2[sizeof (w2)-1] = '\0';
-					strncpy (w3, ptr, sizeof (w3) - 1);
-					w3[sizeof (w3)-1] = '\0';
+					r_str_ncpy (w2, optr, sizeof (w2));
+					r_str_ncpy (w3, ptr, sizeof (w3));
 					optr=ptr;
 // bonus
 					ptr = strchr (ptr, ',');
@@ -322,10 +316,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							;
 						}
-						strncpy (w3, optr, sizeof (w3) - 1);
-						w3[sizeof (w3) - 1] = '\0';
-						strncpy (w4, ptr, sizeof (w4) - 1);
-						w4[sizeof (w4) - 1] = '\0';
+						r_str_ncpy (w3, optr, sizeof (w3));
+						r_str_ncpy (w4, ptr, sizeof (w4));
 					}
 				}
 			}

--- a/libr/arch/p/m68k_cs/pseudo.c
+++ b/libr/arch/p/m68k_cs/pseudo.c
@@ -134,16 +134,16 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		if (ptr) {
 			*ptr = '\0';
 			ptr = (char *)r_str_trim_head_ro (ptr + 1);
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr=ptr;
 			ptr = strchr (ptr, ',');
 			if (ptr) {
 				*ptr = '\0';
 				ptr = (char *)r_str_trim_head_ro (ptr + 1);
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr=ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -151,8 +151,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						;
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr=ptr;
 // bonus
 					ptr = strchr (ptr, ',');
@@ -161,8 +161,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							;
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 					}
 				}
 			}

--- a/libr/arch/p/mips/pseudo.c
+++ b/libr/arch/p/mips/pseudo.c
@@ -168,8 +168,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				;
 			}
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr=ptr;
 			ptr = strchr (ptr, ',');
@@ -178,8 +178,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					;
 				}
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -187,8 +187,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						;
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr=ptr;
 // bonus
 					ptr = strchr (ptr, ',');
@@ -197,13 +197,13 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							;
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 					}
 				}
 			}
 		} else {
-			strncpy (w0, buf, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -1640,8 +1640,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				//nothing to see here
 			}
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr = ptr;
 			ptr = strchr (ptr, ',');
@@ -1650,8 +1650,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					//nothing to see here
 				}
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -1659,8 +1659,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						//nothing to see here
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr = ptr;
 					// bonus
 					ptr = strchr (ptr, ',');
@@ -1669,8 +1669,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							//nothing to see here
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 						optr = ptr;
 						// bonus
 						ptr = strchr (ptr, ',');
@@ -1679,14 +1679,14 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 							for (ptr++; *ptr == ' '; ptr++) {
 								//nothing to see here
 							}
-							strncpy (w4, optr, WSZ - 1);
-							strncpy (w5, ptr, WSZ - 1);
+							r_str_ncpy (w4, optr, WSZ);
+							r_str_ncpy (w5, ptr, WSZ);
 						}
 					}
 				}
 			}
 		} else {
-			strncpy (w0, buf, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4, w5 };

--- a/libr/arch/p/riscv/pseudo.c
+++ b/libr/arch/p/riscv/pseudo.c
@@ -154,8 +154,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				;
 			}
-			strncpy (w0, buf, sizeof (w0) - 1);
-			strncpy (w1, ptr, sizeof (w1) - 1);
+			r_str_ncpy (w0, buf, sizeof (w0));
+			r_str_ncpy (w1, ptr, sizeof (w1));
 
 			optr = ptr;
 			if (*ptr == '(') {
@@ -179,8 +179,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					;
 				}
-				strncpy (w1, optr, sizeof (w1) - 1);
-				strncpy (w2, ptr, sizeof (w2) - 1);
+				r_str_ncpy (w1, optr, sizeof (w1));
+				r_str_ncpy (w2, ptr, sizeof (w2));
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -188,8 +188,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						;
 					}
-					strncpy (w2, optr, sizeof (w2) - 1);
-					strncpy (w3, ptr, sizeof (w3) - 1);
+					r_str_ncpy (w2, optr, sizeof (w2));
+					r_str_ncpy (w3, ptr, sizeof (w3));
 				}
 			}
 			ptr = strchr (buf, '(');

--- a/libr/arch/p/sh/pseudo.c
+++ b/libr/arch/p/sh/pseudo.c
@@ -183,8 +183,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				//nothing to see here
 			}
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr = ptr;
 			par = strchr (ptr, '(');
@@ -201,8 +201,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					//nothing to see here
 				}
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr = ptr;
 				par = strchr (ptr, '(');
 				if (par && strchr (ptr, ',') > par) {
@@ -218,8 +218,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						//nothing to see here
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr = ptr;
 					// bonus
 					par = strchr (ptr, '(');
@@ -236,13 +236,13 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							//nothing to see here
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 					}
 				}
 			}
 		} else {
-			strncpy (w0, buf, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };

--- a/libr/arch/p/sparc/pseudo.c
+++ b/libr/arch/p/sparc/pseudo.c
@@ -131,8 +131,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			for (ptr++; *ptr == ' '; ptr++) {
 				;
 			}
-			strncpy (w0, buf, WSZ - 1);
-			strncpy (w1, ptr, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
+			r_str_ncpy (w1, ptr, WSZ);
 
 			optr=ptr;
 			ptr = strchr (ptr, ',');
@@ -141,8 +141,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 				for (ptr++; *ptr == ' '; ptr++) {
 					;
 				}
-				strncpy (w1, optr, WSZ - 1);
-				strncpy (w2, ptr, WSZ - 1);
+				r_str_ncpy (w1, optr, WSZ);
+				r_str_ncpy (w2, ptr, WSZ);
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
@@ -150,8 +150,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					for (ptr++; *ptr == ' '; ptr++) {
 						;
 					}
-					strncpy (w2, optr, WSZ - 1);
-					strncpy (w3, ptr, WSZ - 1);
+					r_str_ncpy (w2, optr, WSZ);
+					r_str_ncpy (w3, ptr, WSZ);
 					optr=ptr;
 // bonus
 					ptr = strchr (ptr, ',');
@@ -160,13 +160,13 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 						for (ptr++; *ptr == ' '; ptr++) {
 							;
 						}
-						strncpy (w3, optr, WSZ - 1);
-						strncpy (w4, ptr, WSZ - 1);
+						r_str_ncpy (w3, optr, WSZ);
+						r_str_ncpy (w4, ptr, WSZ);
 					}
 				}
 			}
 		} else {
-			strncpy (w0, buf, WSZ - 1);
+			r_str_ncpy (w0, buf, WSZ);
 		}
 		{
 			const char *wa[] = { w0, w1, w2, w3, w4 };

--- a/libr/arch/p/stm8/pseudo.c
+++ b/libr/arch/p/stm8/pseudo.c
@@ -171,8 +171,8 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		if (ptr) {
 			*ptr = '\0';
 			ptr = (char *)r_str_trim_head_ro (ptr + 1);
-			strncpy (w0, buf, sizeof (w0) - 1);
-			strncpy (w1, ptr, sizeof (w1) - 1);
+			r_str_ncpy (w0, buf, sizeof (w0));
+			r_str_ncpy (w1, ptr, sizeof (w1));
 			optr = ptr;
 			if (ptr && *ptr == '[') {
 				ptr = strchr (ptr + 1, ']');
@@ -187,22 +187,22 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 			if (ptr) {
 				*ptr = '\0';
 				ptr = (char *)r_str_trim_head_ro (ptr + 1);
-				strncpy (w1, optr, sizeof (w1) - 1);
-				strncpy (w2, ptr, sizeof (w2) - 1);
+				r_str_ncpy (w1, optr, sizeof (w1));
+				r_str_ncpy (w2, ptr, sizeof (w2));
 				optr = ptr;
 				ptr = strchr (ptr, ',');
 				if (ptr) {
 					*ptr = '\0';
 					ptr = (char *)r_str_trim_head_ro (ptr + 1);
-					strncpy (w2, optr, sizeof (w2) - 1);
-					strncpy (w3, ptr, sizeof (w3) - 1);
+					r_str_ncpy (w2, optr, sizeof (w2));
+					r_str_ncpy (w3, ptr, sizeof (w3));
 					optr = ptr;
 					ptr = strchr (ptr, ',');
 					if (ptr) {
 						*ptr = '\0';
 						ptr = (char *)r_str_trim_head_ro (ptr + 1);
-						strncpy (w3, optr, sizeof (w3) - 1);
-						strncpy (w4, ptr, sizeof (w4) - 1);
+						r_str_ncpy (w3, optr, sizeof (w3));
+						r_str_ncpy (w4, ptr, sizeof (w4));
 					}
 				}
 			}

--- a/libr/arch/p/x86_nz/pseudo.c
+++ b/libr/arch/p/x86_nz/pseudo.c
@@ -624,11 +624,10 @@ static char *subvar(RAsmPluginSession *aps, RAnalFunction *f, ut64 addr, int opl
 
 	char bp[32];
 	if (anal->reg->alias[R_REG_ALIAS_BP]) {
-		strncpy (bp, anal->reg->alias[R_REG_ALIAS_BP], sizeof (bp) - 1);
+		r_str_ncpy (bp, anal->reg->alias[R_REG_ALIAS_BP], sizeof (bp));
 		if (isupper ((ut8)*tstr)) {
 			r_str_case (bp, true);
 		}
-		bp[sizeof (bp) - 1] = 0;
 	} else {
 		bp[0] = 0;
 	}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The pseudo parsers split operands into fixed word buffers with strncpy (wN, src, WSZ - 1), which leaves the buffer unterminated when a token reaches WSZ - 1 chars (only the first byte is pre-zeroed). Convert all ten arch parsers to r_str_ncpy, which always terminates and copies the same maximum length.

Ride-alongs in the same class: dalvik's strncpy + explicit terminator pairs collapse into single r_str_ncpy calls, and x86_nz no longer runs r_str_case over the bp buffer before its terminator is written.

Left alone: 6502 (buffers are zero-initialized, already safe) and tricore (site is inside #if 0). Net -9 LOC, no behavior change for reachable inputs.