### PR TITLE
Fix signed overflow when massaging ppc imports below the plt ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1944,10 +1944,8 @@ static ut64 get_import_addr_ppc(ELFOBJ *eo, RBinElfReloc *rel) {
 	}
 
 	if (rel->rva < plt_addr) {
-		ut64 orva = rel->rva;
-		int delta = plt_addr - rel->rva;
-		orva += (2* delta);
-		// orva += 0xef0;
+		ut64 delta = plt_addr - rel->rva;
+		ut64 orva = rel->rva + (2 * delta);
 		R_LOG_DEBUG ("Massaged pointer below plt from 0x%"PFMT64x" to 0x%"PFMT64x, rel->rva, orva);
 		return orva;
 	}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

get_import_addr_ppc computed the below-plt massage delta as int delta = plt_addr - rel->rva, truncating a ut64 difference, and multiplied 2*delta in int — signed-overflow UB once the plt/reloc gap exceeds 1GiB. Compute in ut64 instead: bit-identical for every gap below 1GiB, defined (instead of UB) above it. Also drops a dead commented-out line in the same block.
