### PR TITLE
Fix zero-width pdcj annotation ranges in the pseudo decompiler ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -785,17 +785,18 @@ static ut64 emit_code_lines(PDCState *state, char *code, ut64 start_addr, int in
 				continue;
 			}
 		}
+		const size_t start = r_strbuf_length (state->codestr);
+		if (R_STR_ISNOTEMPTY (line)) {
+			print_newline (state, addr, indent, false);
+			print_str (state, "%s", line);
+		}
 		if (emit_pj && state->pj) {
 			pj_o (state->pj);
-			pj_kn (state->pj, "start", r_strbuf_length (state->codestr));
+			pj_kn (state->pj, "start", start);
 			pj_kn (state->pj, "end", r_strbuf_length (state->codestr));
 			pj_kn (state->pj, "offset", addr);
 			pj_ks (state->pj, "type", "offset");
 			pj_end (state->pj);
-		}
-		if (R_STR_ISNOTEMPTY (line)) {
-			print_newline (state, addr, indent, false);
-			print_str (state, "%s", line);
 		}
 	}
 	r_list_free (lines);
@@ -2051,16 +2052,14 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			s = os;
 		}
 		size_t codelen = r_strbuf_length (state.codestr);
+		r_strbuf_append (state.codestr, s);
 		if (state.pj) {
 			pj_o (state.pj);
 			pj_kn (state.pj, "start", codelen);
-			r_strbuf_append (state.codestr, s);
-			pj_kn (state.pj, "end", codelen);
+			pj_kn (state.pj, "end", r_strbuf_length (state.codestr));
 			pj_kn (state.pj, "offset", addr);
 			pj_ks (state.pj, "type", "offset");
 			pj_end (state.pj);
-		} else {
-			r_strbuf_append (state.codestr, s);
 		}
 		if (codelen > 0) {
 			if (state.show_addr && !state.show_asm) {

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -822,3 +822,16 @@ EXPECT=<<EOF
         if (!v) goto loc_0x15c60 // likely
 EOF
 RUN
+
+NAME=pdcj annotation ranges cover the emitted code
+FILE=bins/elf/ioli/crackme0x00
+CMDS=<<EOF
+af
+pdcj~{annotations[0]}
+pdcj~{annotations[1]}
+EOF
+EXPECT=<<EOF
+{"start":52,"end":116,"offset":134513504,"type":"offset"}
+{"start":116,"end":137,"offset":134513506,"type":"offset"}
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Every pdcj annotation was emitted with end == start, because "end" was written from the code-buffer length captured before the code was appended — at both emission sites (the per-line emitter and the orphan-block append). Consumers mapping annotation ranges to the code string (e.g. iaito) got empty spans for every address. Now the start is snapshotted before the print/append and the end is read from the buffer afterwards, so ranges are non-empty and contiguous. Adds a test pinning the ranges on crackme0x00, verified failing before the fix.