### PR TITLE
Honor anal.vars.newstack in the esil analysis ##analysis

### DIFF
--- a/libr/core/canal_esil.inc.c
+++ b/libr/core/canal_esil.inc.c
@@ -879,7 +879,7 @@ R_API void r_core_anal_esil(RCore *core, const char *str /* len */, const char *
 	bool cfg_anal_strings = r_config_get_b (core->config, "anal.strings");
 	bool emu_lazy = r_config_get_b (core->config, "emu.lazy");
 	const bool gp_fixed = r_config_get_b (core->config, "anal.fixed.gp");
-	bool newstack = r_config_get_b (core->config, "anal.var.newstack");
+	const bool newstack = core->anal->opt.var_newstack;
 	REsil *ESIL = core->anal->esil;
 	ut64 refptr = 0LL;
 	ut64 ntarget = UT64_MAX;


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The key was read as "anal.var.newstack" but is registered as "anal.vars.newstack", so the newstack gates in r_core_anal_esil (reg_save_area SP seeding, arm sp tracking) were permanently false. Read core->anal->opt.var_newstack instead, like var.c and the other consumers. Default (flag off) behavior is unchanged.