### PR TITLE
Fix strchr const qualifier warning from newer gcc in afll ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3620,7 +3620,7 @@ R_API int r_core_anal_fcn_list(RCore *core, const char *input, const char *rad) 
 		if (rad[1] == 'j') {
 			fcn_list_verbose_json (core, fcns);
 		} else {
-			char *sp = strchr (rad, ' ');
+			const char *sp = strchr (rad, ' ');
 			fcn_list_verbose (core, fcns, sp? sp + 1: NULL);
 		}
 		break;


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With gcc 15 / newer glibc strchr is const-preserving, so assigning its result on the const rad parameter to char * breaks -Wall -Werror builds; no behavior change.