### PR TITLE
Return NULL instead of false in the dalvik pseudo parser ##pseudo

### DIFF
--- a/libr/arch/p/dalvik/pseudo.c
+++ b/libr/arch/p/dalvik/pseudo.c
@@ -246,8 +246,8 @@ static char *patch(RAsmPluginSession *aps, RAnalOp *aop, const char *op) {
 	} while (0)
 
 static char *parse(RAsmPluginSession *aps, const char *data) {
-	int i, len = strlen (data);
-	char *buf, *ptr, *optr, *ptr2;
+	int i;
+	char *ptr, *optr, *ptr2;
 	char w0[64];
 	char w1[64];
 	char w2[64];
@@ -261,11 +261,10 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 		return strdup ("");
 	}
 
-	// malloc can be slow here :?
-	if (!(buf = malloc (len + 1))) {
-		return false;
+	char *buf = strdup (data);
+	if (!buf) {
+		return NULL;
 	}
-	memcpy (buf, data, len + 1);
 
 	r_str_trim (buf);
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

parse() returns char * but yielded `return false;` on allocation failure. Also collapse the equivalent malloc+memcpy into strdup().