### PR TITLE
fix: pass LDFLAGS to io_shm.so link step

### DIFF
--- a/libr/io/p/shm.mk
+++ b/libr/io/p/shm.mk
@@ -24,4 +24,4 @@ R_IO_SHM_LINKFLAGS+=-L.. -lr_io
 endif
 
 $(N) p/${TARGET_SHM}: p/${OBJ_SHM}
-	cd p && $(CC) $(CFLAGS) -shared -L.. $(CSRC_SHM) -fPIC -o $(TARGET_SHM) -I../../include -I../../../subprojects/sdb/src $(R_IO_SHM_LINKFLAGS)
+	cd p && $(CC) $(CFLAGS) $(LDFLAGS) -shared -L.. $(CSRC_SHM) -fPIC -o $(TARGET_SHM) -I../../include -I../../../subprojects/sdb/src $(R_IO_SHM_LINKFLAGS)

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -37,6 +37,8 @@ endif
 ifeq ($(shell gcc -v > /dev/null 2>&1 && echo works),works)
 HOST_CC?=gcc
 endif
+HOST_CFLAGS?=$(CFLAGS)
+HOST_LDFLAGS?=$(LDFLAGS)
 SHLR?=$(shell pwd)
 AR?=ar
 RANLIB?=ranlib

--- a/shlr/Makefile
+++ b/shlr/Makefile
@@ -37,8 +37,6 @@ endif
 ifeq ($(shell gcc -v > /dev/null 2>&1 && echo works),works)
 HOST_CC?=gcc
 endif
-HOST_CFLAGS?=$(CFLAGS)
-HOST_LDFLAGS?=$(LDFLAGS)
 SHLR?=$(shell pwd)
 AR?=ar
 RANLIB?=ranlib


### PR DESCRIPTION
## Problem

`/usr/lib64/radare2/<ver>/io_shm.so` is built without respecting LDFLAGS,
causing QA failures on distributions that inject hardening flags
(Gentoo, Arch, Fedora) such as `-Wl,-z,relro`, `-Wl,-z,now`, or LTO
link flags.

## Root cause

`libr/io/p/shm.mk` link rule passes `$(CFLAGS)` to the compiler but omits
`$(LDFLAGS)`, so linker hardening flags and any other LDFLAGS are silently
dropped for this plugin.

## Fix

Add `$(LDFLAGS)` to the `io_shm.so` link command.

## Note on r2sdb / HOST_CFLAGS

`r2sdb` has a similar issue where `HOST_CFLAGS`/`HOST_LDFLAGS` are unset
on plain native builds. The correct fix there is for package build systems
to set these explicitly (e.g. `make HOST_CFLAGS="$CFLAGS"`) rather than
defaulting them to `$(CFLAGS)`, since that would break sanitizer/fuzzer
builds where CFLAGS contains ASAN flags incompatible with a host tool.