### PR TITLE
r_stdin_readline: fix EOF handling ##util

### DIFF
--- a/libr/util/file.c
+++ b/libr/util/file.c
@@ -359,6 +359,9 @@ R_API char *r_stdin_readline(int *sz) {
 	char buf[4096];
 	for (;;) {
 		int n = read (0, buf, sizeof (buf));
+		if (n == 0 && l > 0) {
+			break;
+		}
 		if (n < 1) {
 			r_strbuf_free (sb);
 			return NULL;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Sometimes, if input is a multiple of 4096 (buffer size), the function will return NULL when EOF reached

Now, if EOF reached and there is data in `RStrBuf`, the data will be returned