### PR TITLE
Fix opcode decoding and endian selection in the ppc.gnu plugin ##arch

### DIFF
--- a/libr/arch/p/ppc/plugin_gnu.c
+++ b/libr/arch/p/ppc/plugin_gnu.c
@@ -4,6 +4,7 @@
 
 #include <r_arch.h>
 #include "../../include/disas-asm.h"
+#include "../../include/opcode/ppc.h"
 
 static int ppc_buffer_read_memory(bfd_vma memaddr, bfd_byte *myaddr, ut32 length, struct disassemble_info *info) {
 	int delta = (memaddr - info->buffer_vma);
@@ -37,10 +38,7 @@ static int disassemble(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		return -1;
 	}
 	RStrBuf *sb = r_strbuf_new ("");
-	memcpy (bytes, buf, 4); // TODO handle thumb
-
-	/* prepare disassembler */
-	memset (&disasm_obj, '\0', sizeof (struct disassemble_info));
+	memcpy (bytes, buf, 4);
 	*options = 0;
 	const int bits = a->config->bits;
 	if (!R_STR_ISEMPTY (a->config->cpu)) {
@@ -56,10 +54,10 @@ static int disassemble(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	disasm_obj.symbol_at_address_func = &symbol_at_address;
 	disasm_obj.memory_error_func = &memory_error_func;
 	disasm_obj.print_address_func = &generic_print_address_func;
-	disasm_obj.endian = !R_ARCH_CONFIG_IS_BIG_ENDIAN (a->config);
+	disasm_obj.endian = R_ARCH_CONFIG_IS_BIG_ENDIAN (a->config)? BFD_ENDIAN_BIG: BFD_ENDIAN_LITTLE;
 	disasm_obj.fprintf_func = &generic_fprintf_func;
 	disasm_obj.stream = sb;
-	if (disasm_obj.endian) {
+	if (disasm_obj.endian == BFD_ENDIAN_BIG) {
 		op->size = print_insn_big_powerpc ((bfd_vma)addr, &disasm_obj);
 	} else {
 		op->size = print_insn_little_powerpc ((bfd_vma)addr, &disasm_obj);
@@ -81,79 +79,81 @@ static int disassemble(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, 
 static bool ppc_op(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	const ut64 addr = op->addr;
 	const int len = op->size;
-	const ut8 *bytes = op->bytes;
-	// XXX hack
-	int opcode = (bytes[0] & 0xf8) >> 3; // bytes 0-5
-	short baddr = (((ut32) bytes[2] << 8) | (bytes[3] & 0xfc));// 16-29
-	int aa = bytes[3]&0x2;
-	int lk = bytes[3]&0x1;
-	//if (baddr>0x7fff)
-	//      baddr = -baddr;
-
-	op->addr = addr;
-	op->type = 0;
-	op->size = 4;
-	if (mask & R_ARCH_OP_MASK_DISASM) {
-		int res = disassemble (as, op, addr, bytes, len);
-		if (res == -1) {
-			op->type = R_ANAL_OP_TYPE_ILL;
-		}
+	if (len < 4) {
+		return false;
 	}
-//	R_LOG_DEBUG ("OPCODE IS %08x : %02x (opcode=%d) baddr = %d", addr, bytes[0], opcode, baddr);
+	const ut32 insn = r_read_ble32 (op->bytes, R_ARCH_CONFIG_IS_BIG_ENDIAN (as->config));
+	const ut32 opcode = PPC_OP (insn);
+	const st16 bd = (st16) (insn & 0xfffc);
+	const bool aa = insn & 2;
+	const bool lk = insn & 1;
+	const ut32 bo = (insn >> 21) & 0x1f;
+	// BO 20 is the only valid branch-always encoding; anything else keeps the fall-through edge
+	const bool cond = bo != 20;
 
-	switch (opcode) {
-//	case 0: // bl op->type = R_ANAL_OP_TYPE_NOP; break;
+	op->type = R_ANAL_OP_TYPE_NULL;
+	if ((mask & R_ARCH_OP_MASK_DISASM) && disassemble (as, op, addr, op->bytes, len) == -1) {
+		// don't let the switch type reserved-field garbage as a real op
+		op->type = R_ANAL_OP_TYPE_ILL;
+	} else switch (opcode) {
+	case 10: // cmpli
 	case 11: // cmpi
 		op->type = R_ANAL_OP_TYPE_CMP;
 		break;
-	case 9: // pure branch
-		if (bytes[0] == 0x4e) {
-			// bctr
+	case 16: // bc
+		op->jump = aa? bd: addr + bd;
+		if (cond) {
+			op->type = lk? R_ANAL_OP_TYPE_CCALL: R_ANAL_OP_TYPE_CJMP;
+			op->fail = addr + 4;
+		} else if (lk && (aa || op->jump != addr + 4)) {
+			op->type = R_ANAL_OP_TYPE_CALL;
+			op->fail = addr + 4;
 		} else {
-			op->jump = aa? baddr: addr + baddr;
-			if (lk) {
-				op->fail = addr + 4;
-			}
+			// branch-always; bcl 20,31,$+4 only exists for the LR write (ppc32 pic idiom), not a call
+			op->type = R_ANAL_OP_TYPE_JMP;
 		}
-		op->eob = 1;
+		op->eob = !lk;
 		break;
-	case 6: // bc // conditional jump
-		op->type = R_ANAL_OP_TYPE_JMP;
-		op->jump = aa? baddr: addr + baddr + 4;
-		op->eob = 1;
-		break;
-#if 0
-	case 7: // sc/svc
+	case 17: // sc
 		op->type = R_ANAL_OP_TYPE_SWI;
 		break;
-#endif
-#if 0
-	case 15: // bl
-		// OK
-		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = (aa)?(baddr):(addr+baddr);
-		op->fail = addr+4;
-		op->eob = 1;
-		break;
-#endif
-	case 8: // bne i tal
-		// OK
-		op->type = R_ANAL_OP_TYPE_CJMP;
-		op->jump = (aa)?(baddr):(addr+baddr+4);
-		op->fail = addr+4;
-		op->eob = 1;
-		break;
-	case 19: // bclr/bcr/bcctr/bcc
-		op->type = R_ANAL_OP_TYPE_RET; // jump to LR
-		if (lk) {
-			op->jump = UT32_MAX; // LR ?!?
-			op->fail = addr+4;
+	case 18: { // b/ba/bl/bla
+		st32 li = insn & 0x03fffffc;
+		if (li & 0x02000000) {
+			li -= 0x04000000;
 		}
-		op->eob = 1;
+		op->type = lk? R_ANAL_OP_TYPE_CALL: R_ANAL_OP_TYPE_JMP;
+		op->jump = aa? li: addr + li;
+		if (lk) {
+			op->fail = addr + 4;
+		}
+		op->eob = !lk;
 		break;
 	}
+	case 19: { // bclr/bcctr/rfi/cr ops
+		const ut32 xo = (insn >> 1) & 0x3ff;
+		if (xo == 16 || xo == 528) { // bclr/bcctr
+			if (lk) {
+				op->type = cond? R_ANAL_OP_TYPE_UCCALL: R_ANAL_OP_TYPE_UCALL;
+			} else if (xo == 16) {
+				// CTR-decrement forms (bdnzlr/bdzlr) are loop branches, not returns
+				op->type = (bo & 4)? (cond? R_ANAL_OP_TYPE_CRET: R_ANAL_OP_TYPE_RET): R_ANAL_OP_TYPE_CJMP;
+			} else {
+				op->type = cond? R_ANAL_OP_TYPE_UCJMP: R_ANAL_OP_TYPE_UJMP;
+			}
+			if (cond || lk) {
+				op->fail = addr + 4;
+			}
+			op->eob = true;
+		} else if (xo == 18 || xo == 50 || xo == 51) { // rfid/rfi/rfci
+			op->type = R_ANAL_OP_TYPE_RET;
+			op->eob = true;
+		}
+		break;
+	}
+	}
 	op->size = 4;
-	return op->size;
+	return true;
 }
 
 static char *regs(RArchSession *as) {
@@ -244,47 +244,4 @@ R_API RLibStruct radare_plugin = {
 	.data = &r_arch_plugin_ppc_gnu,
 	.version = R2_VERSION
 };
-#endif
-
-#if 0
-NOTES:
-======
-	 10000
-	 AA = absolute address
-	 LK = link bit
-	 BD = bits 16-19
-	   address
-	 if (AA) {
-	   address = (int32) BD << 2
-	 } else {
-	   address += (int32) BD << 2
-	 }
-	AA LK
-	30 31
-	 0  0  bc
-	 1  0  bca
-	 0  1  bcl
-	 1  1  bcla
-
-	 10011
-	 BCCTR
-	 LK = 31
-
-	 bclr or bcr (Branch Conditional Link Register) Instruction
-	 10011
-
-	 6-29 -> LL (addr) ?
-	 B  10010 -> branch
-	 30 31
-	 0  0   b
-	 1  0   ba
-	 0  1   bl
-	 1  1   bla
-	 SC SYSCALL 5 first bytes 10001
-	 SVC SUPERVISORCALL
-	 30 31
-	 0  0  svc
-	 0  1  svcl
-	 1  0  svca
-	 1  1  svcla
 #endif

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1729,3 +1729,110 @@ EXPECT=<<EOF
 int nine("AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II")
 EOF
 RUN
+
+NAME=ppc.gnu decodes the full 6-bit primary opcode
+FILE=malloc://128
+ARGS=-a ppc.gnu -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 980100004400000248000010480000112c030000280300014082001060000000
+wx 4e8000204e8004204e800421 @ 32
+wx 4e8000214d8200204c820420 @ 44
+wx 429f0005408200114280001142800010 @ 56
+ao 1 @ 0~type
+ao 1 @ 4~type
+pi 1 @ 8
+ao 1 @ 8~type,jump
+ao 1 @ 12~type,jump,fail
+ao 1 @ 16~type
+ao 1 @ 20~type
+ao 1 @ 24~type,jump,fail
+ao 1 @ 32~type
+ao 1 @ 36~type
+ao 1 @ 40~type,fail
+ao 1 @ 44~type,fail
+ao 1 @ 48~type,fail
+ao 1 @ 52~type,fail
+ao 1 @ 56~type,jump,fail
+ao 1 @ 60~type,jump,fail
+ao 1 @ 64~type,jump,fail
+ao 1 @ 68~type,jump,fail
+wx 44000000 @ 72
+ao 1 @ 72~type
+wx 4c000064 @ 76
+ao 1 @ 76~type
+wx 4e0000204e40002042a00004 @ 80
+ao 1 @ 80~type,fail
+ao 1 @ 84~type,fail
+ao 1 @ 88~type
+EOF
+EXPECT=<<EOF
+type: null
+type: swi
+b 0x00000018
+type: jmp
+jump: 0x00000018
+type: call
+jump: 0x0000001c
+fail: 0x00000010
+type: cmp
+type: cmp
+type: cjmp
+jump: 0x00000028
+fail: 0x0000001c
+type: ret
+type: ujmp
+type: ucall
+fail: 0x0000002c
+type: ucall
+fail: 0x00000030
+type: cret
+fail: 0x00000034
+type: ucjmp
+fail: 0x00000038
+type: jmp
+jump: 0x0000003c
+type: ccall
+jump: 0x0000004c
+fail: 0x00000040
+type: call
+jump: 0x00000050
+fail: 0x00000044
+type: jmp
+jump: 0x00000054
+type: ill
+type: ret
+type: cjmp
+fail: 0x00000054
+type: cjmp
+fail: 0x00000058
+type: ill
+EOF
+RUN
+
+NAME=ppc.gnu function detection does not stop at byte stores
+FILE=malloc://16
+ARGS=-a ppc.gnu -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 380000009801000060000000 4e800020
+af
+afi~size
+EOF
+EXPECT=<<EOF
+size: 16
+EOF
+RUN
+
+NAME=ppc.gnu little-endian disassembly
+FILE=malloc://16
+ARGS=-a ppc.gnu -b 32 -e cfg.bigendian=false
+CMDS=<<EOF
+wx 10000048
+pi 1
+ao 1~type,jump
+EOF
+EXPECT=<<EOF
+b 0x00000010
+type: jmp
+jump: 0x00000010
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

(Sorry, this was meant to be a simple change but kept finding more things wrong).

Three bugs in the opt-in `ppc.gnu` analyzer (capstone `ppc` is the default and unaffected):

1. **OOB read** — `ppc_op` read `bytes[2]`/`bytes[3]` before any `len < 4` guard. Now checked first, like `ppc_cs`.
2. **5 of 6 primary-opcode bits** — `(bytes[0] & 0xf8) >> 3` dropped bit 5: `stb` typed as `ret` (truncating functions at byte stores), `sc` as `cjmp`, real `bclr` case dead. Now `PPC_OP (insn)` with the switch renumbered.
3. **Inverted endian selection** — `BFD_ENDIAN_BIG` is 0, so BE configs used the LE decoder: `48000010` printed `vmulouh v0, v0, v0` instead of `b 0x10`.

Branch typing now follows `ppc_cs`: 24-bit `LI` sign extension, `BO`/`LK` decoded (`beqlr` → `cret`, `blrl` → `ucall`, `bdnzlr` → `cjmp`, `rfi` → `ret`, `bcl 20,31,$+4` → `jmp`), and failed disassembly stays `ill`.

Three tests in `db/anal/ppc`; all fail before the change.