### PR TITLE
Fix orphan block rendering and pdcj annotations in the pseudo decompiler ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -508,6 +508,17 @@ static void print_str(PDCState *state, const char *fmt, ...) {
 	va_end (ap);
 }
 
+static void annotate_offset(PDCState *state, size_t start, ut64 addr) {
+	if (state->pj) {
+		pj_o (state->pj);
+		pj_kn (state->pj, "start", start);
+		pj_kn (state->pj, "end", r_strbuf_length (state->codestr));
+		pj_kn (state->pj, "offset", addr);
+		pj_ks (state->pj, "type", "offset");
+		pj_end (state->pj);
+	}
+}
+
 static void asm_append(RStrBuf *sb, RCore *core, ut64 addr, const char *prefix) {
 	int pad;
 	char *s = disat (core, addr, &pad);
@@ -779,13 +790,8 @@ static ut64 emit_code_lines(PDCState *state, char *code, ut64 start_addr, int in
 			print_newline (state, addr, indent, false);
 			print_str (state, "%s", line);
 		}
-		if (emit_pj && state->pj) {
-			pj_o (state->pj);
-			pj_kn (state->pj, "start", start);
-			pj_kn (state->pj, "end", r_strbuf_length (state->codestr));
-			pj_kn (state->pj, "offset", addr);
-			pj_ks (state->pj, "type", "offset");
-			pj_end (state->pj);
+		if (emit_pj) {
+			annotate_offset (state, start, addr);
 		}
 	}
 	r_list_free (lines);
@@ -2040,24 +2046,21 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			free (s);
 			s = os;
 		}
-		size_t codelen = r_strbuf_length (state.codestr);
-		r_strbuf_append (state.codestr, s);
-		if (state.pj) {
-			pj_o (state.pj);
-			pj_kn (state.pj, "start", codelen);
-			pj_kn (state.pj, "end", r_strbuf_length (state.codestr));
-			pj_kn (state.pj, "offset", addr);
-			pj_ks (state.pj, "type", "offset");
-			pj_end (state.pj);
-		}
-		if (codelen > 0) {
-			if (state.show_addr && !state.show_asm) {
-				r_strbuf_appendf (state.out, "\n 0x%08" PFMT64x " | ", bb->addr);
-			} else if (!state.show_asm) {
+		if (R_STR_ISNOTEMPTY (r_str_trim_head_ro (s))) {
+			const size_t start = r_strbuf_length (state.codestr);
+			const bool labeled = bb_addr_is_goto_target (state.fcn, bb->addr);
+			if (!labeled && (state.show_asm || state.show_addr)) {
+				// without a label the block starts on its body lines, which carry their own columns
+				PRINTF ("\n");
+			} else if (state.show_asm) {
+				print_newline (&state, bb->addr, 0, true);
+			} else if (state.show_addr) {
+				NEWLINE (bb->addr, 0);
+			} else {
 				NEWLINE (bb->addr, 1);
 			}
-			RFlagItem *fi = r_flag_get_in (core->flags, bb->addr);
-			if (bb_addr_is_goto_target (state.fcn, bb->addr)) {
+			if (labeled) {
+				RFlagItem *fi = r_flag_get_in (core->flags, bb->addr);
 				char tagbuf[32];
 				const char *tag = "orphan";
 				if (fi && r_str_startswith (fi->name, "case.")) {
@@ -2085,6 +2088,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			} else {
 				PRINTGOTO (nextbbaddr, bb->jump);
 			}
+			annotate_offset (&state, start, bb->addr);
 		}
 		free (s);
 	}

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -198,6 +198,9 @@ void sym.func.100003a54 (int64_t arg1, int64_t arg2) {
         x1 = x0 + 0x68 // arg1
         x0 = x8
         goto sym.imp.strcoll // int strcoll("", "")
+    loc_0x100003a78: // orphan
+         w0 = -1
+
     loc_0x100003a6c: // orphan
          w0 = 1
 
@@ -274,6 +277,9 @@ EXPECT=<<EOF
  0x100003a84 |         x1 = x0 + 0x68 // arg1
  0x100003a88 |         x0 = x8
  0x100003a8c |         goto sym.imp.strcoll // int strcoll("", "")
+ 0x100003a78 | loc_0x100003a78: // orphan
+ 0x100003a78 |      w0 = -1
+
  0x100003a6c | loc_0x100003a6c: // orphan
  0x100003a6c |      w0 = 1
 
@@ -301,6 +307,10 @@ void fcn.00000000 (int64_t arg1) {
     loc_0x00000010:
         r3 = 0
         return
+    loc_0x00000008: // orphan
+         r3 = 1                   // "#"
+         return
+
 }
 
 EOF
@@ -833,5 +843,66 @@ EOF
 EXPECT=<<EOF
 {"start":52,"end":116,"offset":134513504,"type":"offset"}
 {"start":116,"end":137,"offset":134513506,"type":"offset"}
+EOF
+RUN
+
+NAME=pdcj orphan annotations use the block address
+FILE=bins/mach0/ls-m1
+ARGS=-a arm -b64
+CMDS=<<EOF
+s 0x100003a54
+af
+pdcj~{annotations[10]}
+pdcj~{annotations[11]}
+pdcj~{annotations[12]}
+EOF
+EXPECT=<<EOF
+{"start":519,"end":571,"offset":4294982284,"type":"offset"}
+{"start":571,"end":620,"offset":4294982264,"type":"offset"}
+{"start":620,"end":668,"offset":4294982252,"type":"offset"}
+EOF
+RUN
+
+NAME=pdc keeps a function's only orphan block
+FILE=malloc://32
+ARGS=-a x86 -b64
+CMDS=<<EOF
+wx 31c0c390b801000000c3
+af
+afb+ 0 4 6
+pdc
+EOF
+EXPECT=<<EOF
+// callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+void fcn.00000000 (void) {
+        eax = 0
+        return eax
+             eax = 1
+         return 1
+
+}
+
+EOF
+RUN
+
+NAME=pdca renders an orphan block in the asm column layout
+FILE=malloc://32
+ARGS=-a x86 -b64
+CMDS=<<EOF
+wx 31c0c390b801000000c3
+af
+afb+ 0 4 6
+pdca
+EOF
+EXPECT=<<EOF
+ 0x00000000 |                                | // callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+ 0x00000000 |                                | void fcn.00000000 (void) {
+ 0x00000000 | xor eax, eax                   |         eax = 0
+ 0x00000002 | ret                            |         return eax
+ 0x00000004 | mov eax, 1                     | eax = 1
+ 0x00000009 | ret                            | return 1
+
+ 0x00000004 |                                | }
+
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Four pre-existing bugs in pdc's orphan-block pass, all at one site:

- **`pdc` silently dropped a function's first orphan block.** The render gate was `if (codelen > 0)` — the length of the accumulated `codestr`, not the block's own content — and nothing outside `pdcj` writes `codestr`, so a single-orphan function lost the block entirely. This suite's own `pdc ppc64 conditional branch predicate` golden was missing a whole arm of a 6-instruction function. From 92eb709d8c, which meant "skip a block with no text"; now that is what it tests.
- **`pdcj` emitted each orphan body twice** — appended to `codestr` explicitly and again via the print path, which targets the same buffer in JSON mode. The stray copy was unlabelled and glued to the previous line.
- **`pdcj` annotations carried the wrong address**: the leftover `addr` from the main pass instead of `bb->addr`, and were emitted before the text, so the range covered the stray copy. Ranges now tile the code contiguously.
- **Column layout for the newly visible blocks**: unlabelled orphans took a doubled address column in `pdco`/`pdc*` (the body lines already carry their own), and `pdca` emitted no separator, gluing the block onto the previous line.

The duplicated annotation emitter is now one helper — the two copies drifting apart is what caused the zero-width ranges fixed in d48dac744a.

Tests: 3 new (`pdc`/`pdca`/`pdcj`; there was no `pdca` coverage) and 3 goldens updated, all six verified failing before the fix. 