### PR TITLE
Keep the function frame size when analysis continues in a second pass ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2279,11 +2279,11 @@ R_API int r_anal_function(RAnal *anal, RAnalFunction *fcn, ut64 addr, int reftyp
 	if (fcn->addr == UT64_MAX) {
 		fcn->addr = addr;
 	}
-	fcn->maxstack = 0;
-	const int shadow = r_anal_cc_shadow (anal, fcn->callconv);
-	if (shadow > 0) {
-		const int word = r_anal_cc_wordsize (anal, fcn->callconv);
-		fcn->stack = fcn->maxstack = fcn->reg_save_area = shadow + r_anal_cc_raslot (anal, word);
+	// re-entry continues an in-progress frame, so only preset a function with no blocks yet
+	if (r_list_empty (fcn->bbs)) {
+		const int shadow = r_anal_cc_shadow (anal, fcn->callconv);
+		const int frame = (shadow > 0)? shadow + r_anal_cc_raslot (anal, r_anal_cc_wordsize (anal, fcn->callconv)): 0;
+		fcn->stack = fcn->maxstack = fcn->reg_save_area = frame;
 	}
 	// XXX -1 here results in lots of errors
 	int ret = r_anal_function_bb (anal, fcn, addr, anal->opt.depth);

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -489,3 +489,32 @@ EXPECT=<<EOF
 |           0x1000047ac      fc6fbaa9       stp x28, x27, [sp, -0x60]!
 EOF
 RUN
+
+NAME=af keeps the frame size when analysis continues in a second pass
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e anal.bb.maxsize=8
+CMDS=<<EOF
+wx 554889e54883ec404883ec104889ec5dc3
+af
+afi~stackframe
+EOF
+EXPECT=<<EOF
+stackframe: 88
+EOF
+RUN
+
+NAME=af keeps the frame size when a tail call continues the function
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 554889e54883ec40eb00554889e55dc3
+af @ 0xa
+f- fcn.0000000a
+af @ 0
+afi @ 0~name,stackframe
+EOF
+EXPECT=<<EOF
+name: fcn.00000000
+stackframe: 72
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_anal_function()` reset `fcn->maxstack` to 0 on every entry, but it is re-entered to *continue* an in-progress function — from the `do/while (fcnlen != R_ANAL_RET_END)` loop in `__core_anal_fcn`, and from the tail-call fallback in `fcn_recurse`. Each continuation therefore discarded the frame size the previous pass had computed.

With `anal.bb.maxsize=8`, a `push rbp; sub rsp,0x40; sub rsp,0x10` function:

| cc | before | after | real frame |
|---|---|---|---|
| `amd64` | 72 | 88 | 88 |
| `ms` | 40 | 128 | 128 |

The `ms` case collapses to the bare shadow-store preset — everything analyzed so far is gone. The tail-call path reports 0.

The preset now applies only to a function with no basic blocks yet, so a continuation keeps its accounting. Fresh analysis is unchanged: those fields are already 0 on a new function, and `aaa; aflj` is byte-identical across 7 binaries.

Two tests, one per re-entry path, both verified failing before the fix.
