### PR TITLE
Store canonical function argument types in the C types parser ##types

### DIFF
--- a/libr/anal/c2/kv.c
+++ b/libr/anal/c2/kv.c
@@ -550,44 +550,10 @@ static const char *kvc_lookup_typedef(KVCParser *kvc, const char *name) {
 	return NULL;
 }
 
-static int emit_func_args(KVCParser *kvc, const char *fname, const char *args) {
-	int arg_idx = 0;
-	RStrBuf *fnames = r_strbuf_new ("");
-	if (R_STR_ISNOTEMPTY (args)) {
-		char *args_copy = strdup (args);
-		char *p = args_copy;
-		while (p) {
-			char *comma = strchr (p, ',');
-			char *tok = comma? r_str_ndup (p, comma - p): strdup (p);
-			p = comma? comma + 1: NULL;
-			r_str_trim (tok);
-			char *last_space = strrchr (tok, ' ');
-			char *arg_type, *arg_name;
-			if (last_space) {
-				arg_type = r_str_ndup (tok, last_space - tok);
-				r_str_trim (arg_type);
-				arg_name = strdup (last_space + 1);
-				r_str_trim (arg_name);
-			} else {
-				arg_type = strdup (tok);
-				r_str_trim (arg_type);
-				arg_name = strdup ("");
-			}
-			r_strbuf_appendf (fnames, "%s%s", arg_idx? ",": "", arg_name);
-			r_strbuf_appendf (kvc->sb, "func.%s.arg.%d=%s,%s\n", fname, arg_idx, arg_type, arg_name);
-			free (arg_type);
-			free (arg_name);
-			free (tok);
-			arg_idx++;
-		}
-		free (args_copy);
-	}
-	char *fnames_s = r_strbuf_drain (fnames);
-	r_strbuf_appendf (kvc->sb, "func.%s=%s\n", fname, fnames_s);
-	r_strbuf_appendf (kvc->sb, "func.%s.cc=cdecl\n", fname);
-	r_strbuf_appendf (kvc->sb, "func.%s.args=%d\n", fname, arg_idx);
-	free (fnames_s);
-	return arg_idx;
+static void emit_func_signature(KVCParser *kvc, const char *fn, RStrs fun_parm, bool is_static);
+
+static void emit_func_args(KVCParser *kvc, const char *fname, const char *args) {
+	emit_func_signature (kvc, fname, r_strs_from (args), false);
 }
 
 static void emit_func_typedef(KVCParser *kvc, const char *name, const char *rtype, const char *args) {
@@ -1354,8 +1320,6 @@ static bool parse_struct(KVCParser *kvc, const char *type) {
 				r_strbuf_appendf (kvc->sb, "type.%s.%s=func\n", sn, mname);
 				r_strbuf_appendf (kvc->sb, "%s.%s=func\n", sn, mname);
 				r_strbuf_appendf (kvc->sb, "func.%s.%s.ret=%s\n", sn, mname, rtype? rtype: "void");
-				// store the canonical signature too
-				r_strbuf_appendf (kvc->sb, "func.%s.%s=%s\n", sn, mname, args? args: "");
 				off += kvc_typesize (kvc, fulltype, 1);
 				{
 					r_strf_var (full_scope, 512, "%s.%s", sn, mname);
@@ -1572,10 +1536,13 @@ static bool parse_enum(KVCParser *kvc, const char *name) {
 	return true;
 }
 
-static int emit_func_signature(KVCParser *kvc, const char *fn, RStrs fun_parm, bool is_static) {
+static void emit_func_signature(KVCParser *kvc, const char *fn, RStrs fun_parm, bool is_static) {
 	RStrBuf *func_args_sb = r_strbuf_new ("");
 	int arg_idx = 0;
-	if (fun_parm.a < fun_parm.b) {
+	RStrs parms = fun_parm;
+	r_strs_trim (&parms);
+	// C spells the empty parameter list as (void); () and ( ) trim down to nothing
+	if (!r_strs_empty (parms) && !r_strs_equals_str (parms, "void")) {
 		const char *pa = fun_parm.a;
 		const char *pb = fun_parm.b;
 		const char *argp = pa;
@@ -1613,12 +1580,8 @@ static int emit_func_signature(KVCParser *kvc, const char *fn, RStrs fun_parm, b
 				an = r_str_newf ("arg%d", arg_idx);
 			}
 			if (an) {
-				if (R_STR_ISEMPTY (at) && !strcmp (an, "void") && arg_idx == 0) {
-					arg_idx--;
-				} else {
-					r_strbuf_appendf (kvc->sb, "func.%s.arg.%d=%s,%s\n", fn, arg_idx, at, an);
-					r_strbuf_appendf (func_args_sb, "%s%s", arg_idx? ",": "", an);
-				}
+				r_strbuf_appendf (kvc->sb, "func.%s.arg.%d=%s,%s\n", fn, arg_idx, at, an);
+				r_strbuf_appendf (func_args_sb, "%s%s", arg_idx? ",": "", an);
 				free (an);
 			}
 			free (at);
@@ -1630,19 +1593,18 @@ static int emit_func_signature(KVCParser *kvc, const char *fn, RStrs fun_parm, b
 	char *func_args = r_strbuf_drain (func_args_sb);
 	r_strbuf_appendf (kvc->sb, "func.%s.cc=cdecl\n", fn);
 	r_strbuf_appendf (kvc->sb, "func.%s=%s\n", fn, func_args);
+	r_strbuf_appendf (kvc->sb, "func.%s.args=%d\n", fn, arg_idx);
 	if (is_static) {
 		r_strbuf_appendf (kvc->sb, "func.%s.@.static=true\n", fn);
 	}
 	free (func_args);
-	return arg_idx;
 }
 
 static void emit_func_decl(KVCParser *kvc, const char *fn, const char *fr, RStrs fun_parm, bool is_static) {
 	r_strbuf_appendf (kvc->sb, "%s=func\n", fn);
 	apply_attributes (kvc, "func", fn);
-	int arg_idx = emit_func_signature (kvc, fn, fun_parm, is_static);
+	emit_func_signature (kvc, fn, fun_parm, is_static);
 	r_strbuf_appendf (kvc->sb, "func.%s.ret=%s\n", fn, fr);
-	r_strbuf_appendf (kvc->sb, "func.%s.args=%d\n", fn, arg_idx);
 }
 
 static bool parse_function(KVCParser *kvc) {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3528,3 +3528,50 @@ EXPECT=<<EOF2
 var uint8_t [256] var_20h @ rbp-0x20
 EOF2
 RUN
+
+NAME=td keeps the pointer with the type in function pointer members
+FILE=-
+CMDS=<<EOF
+'td struct S { int (*cb)(int *n, char *s); };
+tk~func.S
+EOF
+EXPECT=<<EOF
+func.S.cb=n,s
+func.S.cb.arg.0=int *,n
+func.S.cb.arg.1=char *,s
+func.S.cb.args=2
+func.S.cb.cc=cdecl
+func.S.cb.ret=int
+EOF
+RUN
+
+NAME=td stores an empty parameter list as zero arguments
+FILE=-
+CMDS=<<EOF
+'td int voidfn(void);
+'td int spacedfn( );
+tk~func.voidfn
+tk~func.spacedfn
+EOF
+EXPECT=<<EOF
+func.voidfn.args=0
+func.voidfn.cc=cdecl
+func.voidfn.ret=int
+func.spacedfn.args=0
+func.spacedfn.cc=cdecl
+func.spacedfn.ret=int
+EOF
+RUN
+
+NAME=td stores a void parameter list on a member as zero arguments
+FILE=-
+CMDS=<<EOF
+'td struct A2 { float (*m)(void); void *x; };
+tk~func.A2
+EOF
+EXPECT=<<EOF
+func.A2.m.args=0
+func.A2.m.cc=cdecl
+func.A2.m.ret=float
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three defects in how the c2 header parser stores function arguments.

**Pointer lands in the name half.** The function-pointer-member path split each parameter at the last space, so `td struct S { float (*m)(void *a); };` stored:

    func.S.m.arg.0=void,*a     # canonical: void *,a

`r_type_func_args_type()` returns only the pre-comma half, so every consumer silently loses a pointer level (`int *` → `int`, `struct X *` → by value). That path now routes through the same emitter top-level prototypes use, which also gives members varargs and unnamed-argument handling.

**An empty parameter list stored a phantom argument.** Not only on that path — `td int foo(void);` stored `func.foo.arg.0=void,arg0` with `args=1`, and `( )` did too, while `()` worked by accident. The guard meant to catch this could never fire: the branch above it renames the argument to `arg0` first, so the `strcmp` against `"void"` never matched. It now runs before the token loop. The shipped `types.sdb.txt` is the reference — `func.getchar.args=0`, no arg key, and no `void,arg0` entry anywhere.

**`func.<struct>.<member>` was overwritten with raw argument text**, clobbering the comma-separated argument-name list that key holds everywhere else (`dwarf_process.c` writes names there; nothing in tree reads it as a signature).

Three tests, each verified failing before the fix.