### PR TITLE
Remove redundant null checks before free in the C types parser ##types

### DIFF
--- a/libr/anal/c2/kv.c
+++ b/libr/anal/c2/kv.c
@@ -1122,9 +1122,7 @@ static bool parse_typedef(KVCParser *kvc, const char *unused) {
 				}
 				free (alias_str);
 				free (rtype);
-				if (args_str) {
-					free (args_str);
-				}
+				free (args_str);
 				free (fulltype);
 				return true;
 			}
@@ -1364,11 +1362,8 @@ static bool parse_struct(KVCParser *kvc, const char *type) {
 				free (type_name);
 				free (fulltype);
 				free (rtype);
-				if (args) {
-					free (args);
-				}
+				free (args);
 				free (mname);
-				/* mt_check is not defined in this scope */
 				continue;
 			}
 		}
@@ -1412,9 +1407,7 @@ static bool parse_struct(KVCParser *kvc, const char *type) {
 						r_strbuf_appendf (kvc->sb, "func.%s.ret=%s\n", mt_check, rtype);
 						free (mname);
 						free (rtype);
-						if (args_str) {
-							free (args_str);
-						}
+						free (args_str);
 						free (mt_check);
 						continue;
 					}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three `if (args) { free (args); }` guards in the c2 function-pointer paths — two in `parse_struct`, one in `parse_typedef` — each sitting among unguarded frees of its siblings. All three variables are NULL-initialised and assigned at most once, so the checks never fired; AGENTS.md already says not to guard `free()`.

Also drops an adjacent comment that names a symbol from the sibling block.