### PR TITLE
Fix #26312 - Build of the zydis plugin against zydis 5 headers ##build

### DIFF
--- a/libr/arch/p/x86/plugin_zydis.c
+++ b/libr/arch/p/x86/plugin_zydis.c
@@ -11,6 +11,16 @@
 #include <Zydis.h>
 #endif
 
+/* Zydis 5 replaced mem.disp.has_displacement with mem.disp.size. ZYDIS_VERSION
+ * cannot be used here because 4.1.0 defines it as `(ZyanU64)0x...`, and that
+ * cast makes any `#if` comparison a preprocessor syntax error. Key off a macro
+ * that only 5.x defines instead (ZYDIS_ATTRIB_HAS_REX2 came with APX). */
+#if defined(ZYDIS_ATTRIB_HAS_REX2)
+#define HAS_MEM_DISP(op) ((op)->mem.disp.size != 0)
+#else
+#define HAS_MEM_DISP(op) ((op)->mem.disp.has_displacement)
+#endif
+
 #define ZYDIS_MAX_INSN_SIZE 16
 
 typedef struct plugin_data_t {
@@ -146,13 +156,13 @@ static bool is_mem_abs(const ZydisDecodedOperand *op) {
 	return op && op->type == ZYDIS_OPERAND_TYPE_MEMORY
 		&& op->mem.base == ZYDIS_REGISTER_NONE
 		&& op->mem.index == ZYDIS_REGISTER_NONE
-		&& op->mem.disp.has_displacement;
+		&& HAS_MEM_DISP (op);
 }
 
 static bool is_mem_riprel(const ZydisDecodedOperand *op) {
 	return op && op->type == ZYDIS_OPERAND_TYPE_MEMORY
 		&& (op->mem.base == ZYDIS_REGISTER_RIP || op->mem.base == ZYDIS_REGISTER_EIP)
-		&& op->mem.disp.has_displacement;
+		&& HAS_MEM_DISP (op);
 }
 
 static int cond_x86_zydis(ZydisMnemonic mnemonic) {
@@ -316,7 +326,7 @@ static void set_mem_ref(RAnalOp *op, const ZydisDecodedInstruction *insn, const 
 		op->ptr = op->addr + insn->length + mop->mem.disp.value;
 	} else if (is_mem_abs (mop)) {
 		op->ptr = mop->mem.disp.value;
-	} else if (mop->mem.disp.has_displacement) {
+	} else if (HAS_MEM_DISP (mop)) {
 		op->disp = mop->mem.disp.value;
 	}
 	if (mop->mem.base != ZYDIS_REGISTER_NONE) {
@@ -497,7 +507,7 @@ static char *memaddr_esil(const ZydisDecodedInstruction *insn, const ZydisDecode
 		append_esil_mem_component (sb, &count, index, false);
 		free (index);
 	}
-	if (op->mem.disp.has_displacement && op->mem.disp.value) {
+	if (HAS_MEM_DISP (op) && op->mem.disp.value) {
 		const st64 disp = op->mem.disp.value;
 		char *d = r_str_newf ("0x%"PFMT64x, (ut64)R_ABS (disp));
 		append_esil_mem_component (sb, &count, d, disp < 0);
@@ -1128,7 +1138,7 @@ static void set_op_type(RArchSession *as, RAnalOp *op, const ZydisDecodedInstruc
 				&& is_sp_reg (op0->reg.value)
 				&& is_sp_reg (op1->mem.base)
 				&& op1->mem.index == ZYDIS_REGISTER_NONE
-				&& op1->mem.disp.has_displacement) {
+				&& HAS_MEM_DISP (op1)) {
 			op->stackop = R_ANAL_STACK_INC;
 			op->stackptr = op1->mem.disp.value;
 		}


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Minimal split of the compile fix from #26313, without the vendored Zydis 5 snapshot.

Zydis git-master (5.0.0-dev) removed `mem.disp.has_displacement` in favor of `mem.disp.size` (zyantific/zydis#489, merged March 2024, not in any tagged release), so building with `--with-syszydis` against a system-wide Zydis snapshot fails as reported in #26312. This adds a `HAS_MEM_DISP()` macro that picks the right field for both 4.x and 5.x headers.

The 5.x detection keys off `ZYDIS_ATTRIB_HAS_REX2` instead of `ZYDIS_VERSION`, because 4.1.0 defines `ZYDIS_VERSION` with a `(ZyanU64)` cast that makes any `#if` comparison a preprocessor syntax error.

Verified that the plugin compiles both against the bundled 4.1.0 amalgamated headers and against the 5.0.0-dev amalgamated headers from #26313. The bundled dependency is left untouched (still the 4.1.0 wrap), so no test id shifts and no large diff; updating the bundle to 5.x can wait for an upstream release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114JDUduJGWUTTYr5P1a1sN

---
_Generated by [Claude Code](https://claude.ai/code/session_0114JDUduJGWUTTYr5P1a1sN)_