### PR TITLE
Apply project script meta, hint and var commands at the recorded address ##projects

### DIFF
--- a/libr/core/p/newprj/load.inc.c
+++ b/libr/core/p/newprj/load.inc.c
@@ -447,7 +447,7 @@ static void rprj_diff_seen_addr(RList *seen, ut64 addr) {
 static void rprj_print_meta_script(RPrjCursor *cur, RAnalMetaType type, ut64 addr, const char *text) {
 	const bool vartype = type == R_META_TYPE_VARTYPE;
 	if (R_STR_ISEMPTY (text)) {
-		r_strbuf_appendf (cur->out, "'%s- @ 0x%08"PFMT64x"\n", vartype? "Ct": "CC", addr);
+		r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'%s-\n", addr, vartype? "Ct": "CC");
 		return;
 	}
 	char *b64 = sdb_encode ((const ut8 *)text, strlen (text));
@@ -527,6 +527,11 @@ static void rprj_print_xref_script(RPrjCursor *cur, RAnalRef *ref) {
 		(char)R_ANAL_REF_TYPE_MASK (ref->type), ref->addr, ref->at);
 }
 
+static void rprj_print_hint_script(RPrjCursor *cur, ut64 addr, RAnalAddrHintType ht, int value) {
+	const char *cmd = (ht == R_ANAL_ADDR_HINT_TYPE_IMMBASE)? "ahi": "ahb";
+	r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'%s %d\n", addr, cmd, value);
+}
+
 static bool rprj_diff_flag_foreach_cb(RFlagItem *fi, void *user) {
 	R2ProjectDiffCtx *ctx = (R2ProjectDiffCtx *)user;
 	if (fi && !rprj_diff_has_addr (ctx->seen, fi->id)) {
@@ -545,10 +550,10 @@ static bool rprj_diff_hints_cb(ut64 addr, const RVecAnalAddrHintRecord *records,
 		}
 		switch (record->type) {
 		case R_ANAL_ADDR_HINT_TYPE_IMMBASE:
-			r_strbuf_appendf (ctx->cur->out, "'ahi %d @ 0x%08"PFMT64x"\n", record->immbase, addr);
+			rprj_print_hint_script (ctx->cur, addr, record->type, record->immbase);
 			break;
 		case R_ANAL_ADDR_HINT_TYPE_NEW_BITS:
-			r_strbuf_appendf (ctx->cur->out, "'ahb %d @ 0x%08"PFMT64x"\n", record->newbits, addr);
+			rprj_print_hint_script (ctx->cur, addr, record->type, record->newbits);
 			break;
 		default:
 			break;
@@ -703,7 +708,7 @@ static void rprj_diff_function_vars(RPrjCursor *cur, RAnalFunction *fcn, RList *
 	R2ProjectDiffVar *pvar;
 	r_list_foreach (pvars, iter, pvar) {
 		if (!pvar->seen && R_STR_ISNOTEMPTY (pvar->name)) {
-			r_strbuf_appendf (cur->out, "'afv- %s @ 0x%08"PFMT64x"\n", pvar->name, fcn->addr);
+			r_strbuf_appendf (cur->out, "'0x%08"PFMT64x"'afv- %s\n", fcn->addr, pvar->name);
 		}
 	}
 }
@@ -1111,24 +1116,25 @@ static void rprj_xref_load(RPrjCursor *cur, int mode, ut64 next_entry) {
 
 static void rprj_hint_apply(RPrjCursor *cur, int mode, ut64 va, ut32 hint_kind, int value, RList *seen) {
 	RCore *core = cur->core;
-	const char *fmt = (hint_kind == 1)? "'ahi %d @ 0x%08"PFMT64x"\n": "'ahb %d @ 0x%08"PFMT64x"\n";
-	const RAnalAddrHintType ht = (hint_kind == 1)? R_ANAL_ADDR_HINT_TYPE_IMMBASE: R_ANAL_ADDR_HINT_TYPE_NEW_BITS;
+	const bool immbase = hint_kind == 1;
+	const RAnalAddrHintType ht = immbase? R_ANAL_ADDR_HINT_TYPE_IMMBASE: R_ANAL_ADDR_HINT_TYPE_NEW_BITS;
 	if (mode & R_CORE_NEWPRJ_MODE_SCRIPT) {
-		r_strbuf_appendf (cur->out, fmt, value, va);
+		rprj_print_hint_script (cur, va, ht, value);
 	}
 	if (mode & R_CORE_NEWPRJ_MODE_DIFF) {
 		rprj_diff_seen_addr (seen, (va << 8) | (ut64)ht);
 		int curval = 0;
 		if (!rprj_current_hint_value (core->anal, va, ht, &curval) || curval != value) {
 			if (curval) {
-				r_strbuf_appendf (cur->out, fmt, curval, va);
+				rprj_print_hint_script (cur, va, ht, curval);
 			} else {
-				r_strbuf_appendf (cur->out, "'ah- @ 0x%08"PFMT64x"\n", va);
+				// bare ah- clears every hint, so the address must be an argument
+				r_strbuf_appendf (cur->out, "'ah- 0x%08"PFMT64x"\n", va);
 			}
 		}
 	}
 	if (mode & R_CORE_NEWPRJ_MODE_LOAD) {
-		if (hint_kind == 1) {
+		if (immbase) {
 			r_anal_hint_set_immbase (core->anal, va, value);
 		} else {
 			r_anal_hint_set_newbits (core->anal, va, value);

--- a/test/db/cmd/newprj
+++ b/test/db/cmd/newprj
@@ -681,7 +681,7 @@ EXPECT=<<EOF
 'f- saved.flag
 'f live.flag 1 0x00000011
 '@0x00000020'CCu base64:bGl2ZQ==
-'ahi 16 @ 0x00000020
+'0x00000020'ahi 16
 'ax- 0x00000030 0x00000020
 'axc 0x00000031 0x00000020
 EOF
@@ -801,5 +801,49 @@ EOF
 EXPECT=<<EOF
 '0x00000000'afvb -12 renamed int
 '0x00000000'afvb -12 var_4h int32_t
+EOF
+RUN
+
+NAME=newprj script applies hints at the recorded address
+FILE=malloc://0x100
+CMDS=<<EOF
+mkdir .tmp
+rm .tmp/newprj-hintat.prj
+rm .tmp/newprj-hintat.r2
+ahi 10 @ 0x20
+prj save .tmp/newprj-hintat.prj > /dev/null
+prj r2 .tmp/newprj-hintat.prj~ahi > .tmp/newprj-hintat.r2
+ah-*
+s 0x40
+. .tmp/newprj-hintat.r2
+ah*
+rm .tmp/newprj-hintat.prj
+rm .tmp/newprj-hintat.r2
+EOF
+EXPECT=<<EOF
+'@0x20'ahi 10
+EOF
+RUN
+
+NAME=newprj diff removes only the hint at the recorded address
+FILE=malloc://0x100
+CMDS=<<EOF
+mkdir .tmp
+rm .tmp/newprj-ahdel.prj
+rm .tmp/newprj-ahdel.r2
+ahi 2 @ 0x10
+ahi 10 @ 0x20
+ahi 16 @ 0x40
+prj save .tmp/newprj-ahdel.prj > /dev/null
+ah- 0x40
+prj diff .tmp/newprj-ahdel.prj~ah- > .tmp/newprj-ahdel.r2
+. .tmp/newprj-ahdel.r2
+ah*
+rm .tmp/newprj-ahdel.prj
+rm .tmp/newprj-ahdel.r2
+EOF
+EXPECT=<<EOF
+'@0x10'ahi 2
+'@0x20'ahi 10
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Six emissions in the project script used `'cmd ... @ 0xADDR`. The leading `'` is the quoted-command prefix, so `@ 0xADDR` was passed through as a literal argument and the command ran at the current seek instead:

    ahi 10 @ 0x20 ; prj save ; prj r2     ->  'ahi 10 @ 0x00000020
    replay it with the seek at 0x40       ->  hint lands at 0x40

Three of the six were destructive rather than merely misplaced: `'ah- @ 0x40` parses as address `@`=0 with size `0x40` and deletes the whole `[0, 0x40)` hint range, `'CC- @ …` deleted nothing, and `'Ct- @ …` printed the help text.

They now use `'0xADDR'cmd`, which seeks with `tmpseek` set exactly as `@` does — except `ah-`, which emits `'ah- 0xADDR`, since a bare `ah-` means "remove every hint".

Three tests, each verified failing before the fix; one existing golden updated because it pinned the broken form.
