### PR TITLE
Select the MIPS calling convention from the ELF o32/n32 abi ##analysis

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1726,12 +1726,13 @@ static RBinInfo* info(RBinFile *bf) {
 		ret->flags = r_str_newf ("0x%x", elf_flags);
 	}
 	ret->abi = Elf_(get_abi) (obj);
-	if (ret->abi) {
-		// both abis pick a cc so switching binaries in one session updates anal.cc
-		if (!strcmp (ret->abi, "elfv2")) {
-			ret->default_cc = strdup ("elfv2");
-		} else if (!strcmp (ret->abi, "elfv1")) {
+	const char *abi = ret->abi;
+	if (abi) {
+		// the abi picks a cc so switching binaries in one session updates anal.cc
+		if (!strcmp (abi, "elfv1")) {
 			ret->default_cc = strdup ("ppc-64");
+		} else if (!strcmp (abi, "elfv2") || !strcmp (abi, "o32") || !strcmp (abi, "n32")) {
+			ret->default_cc = strdup (abi);
 		}
 	}
 	ret->rclass = strdup ("elf");

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1115,7 +1115,7 @@ za sym.fpathconf o 0x00051490
 za sym.fpathconf R ZnBhdGhjb25m
 za sym.fpathconf t void sym.fpathconf (int32_t arg1, int32_t arg2)
 za sym.fpathconf r sym.__errno_location sym.__errno_location
-za sym.fpathconf v fs-8:var_100h:int32_t, fs-12:var_fch:int32_t, fs-16:var_f8h:int32_t, fs-248:var_10h:int32_t, tr4:arg1:int32_t, tr5:arg2:int32_t
+za sym.fpathconf v fs-24:var_100h:int32_t, fs-28:var_fch:int32_t, fs-32:var_f8h:int32_t, fs-264:var_10h:int32_t, tr4:arg1:int32_t, tr5:arg2:int32_t
 za sym.fpathconf h 52f232c2d8158ce806cadf84ed77273fb11711dfa6cb5feb997ce03c1459be43
 EOF
 RUN
@@ -1136,7 +1136,7 @@ za sym._dl_malloc o 0x00002a1c
 za sym._dl_malloc R X2RsX21hbGxvYw==
 za sym._dl_malloc t void sym._dl_malloc (int32_t arg1)
 za sym._dl_malloc r sym._dl_dprintf sym._dl_dprintf
-za sym._dl_malloc v fs-4:var_4h:int32_t, fs-12:var_24h:int32_t, fs-16:var_20h:int32_t, fs-20:var_1ch:int32_t, fs-8:var_28h:int32_t, fs-24:var_18h:int32_t, fs-32:var_10h:int32_t, fs-80:var_10h_2:int32_t, fs-76:var_14h:int32_t, fs-28:var_24h_2:int32_t, fs-36:var_1ch_2:int32_t, fs-40:var_18h_2:int32_t, tr4:arg1:int32_t
+za sym._dl_malloc v fs-20:var_4h:int32_t, fs-28:var_24h:int32_t, fs-32:var_20h:int32_t, fs-36:var_1ch:int32_t, fs-24:var_28h:int32_t, fs-40:var_18h:int32_t, fs-48:var_10h:int32_t, fs-96:var_10h_2:int32_t, fs-92:var_14h:int32_t, fs-44:var_24h_2:int32_t, fs-52:var_1ch_2:int32_t, fs-56:var_18h_2:int32_t, tr4:arg1:int32_t
 za sym._dl_malloc h ec986971438cf486e01f14e9bc442d9f4c457854207d30fe4aa9f1ffdf892911
 EOF
 RUN

--- a/test/db/formats/elf/mips-abi
+++ b/test/db/formats/elf/mips-abi
@@ -1,0 +1,41 @@
+NAME=ELF MIPS: o32 e_flags selects the o32 abi and the default cc
+FILE=bins/elf/mipsloop
+CMDS=<<EOF
+e asm.abi
+e anal.cc
+k anal/cc/cc.o32.shadow
+EOF
+EXPECT=<<EOF
+o32
+o32
+16
+EOF
+RUN
+
+NAME=ELF MIPS: n64 reports the abi but has no matching cc
+FILE=bins/elf/analysis/mips64r2-busybox
+CMDS=<<EOF
+e asm.abi
+e anal.cc
+EOF
+EXPECT=<<EOF
+n64
+n32
+EOF
+RUN
+
+NAME=ELF MIPS: anal.cc tracks the abi when switching binaries in one session
+FILE=bins/elf/mipsloop
+CMDS=<<EOF
+e anal.cc
+o bins/elf/ppc64v1-more
+e anal.cc
+o bins/elf/mipsloop
+e anal.cc
+EOF
+EXPECT=<<EOF
+o32
+ppc-64
+o32
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`Elf_(get_abi)` already derives o32/n32 from `e_flags`, but nothing mapped it to a cc, so every 32-bit MIPS ELF was analysed with the sdb default `n32` (8 arg regs) instead of `o32` (4 arg regs plus a 16-byte save area). Extends the block that already does this for ppc64 elfv1/elfv2.

Effect on real binaries: boundaries unchanged, fabricated arguments gone — `entry0` goes from `(int32_t arg_0h, int32_t arg_4h)` to `()`, those two slots being o32's save area.

`n64` is left alone since no such cc exists. Note MIPS ELFs now print a `cc` line in `iI`, as ppc64 already does.