### PR TITLE
Convert only whitespace-preceded semicolons to comments in pdc ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -144,11 +144,17 @@ static void swap_strings(RFindCTX *ctx) {
 	free (copy);
 }
 
+// r2 renders comments as "<whitespace>; text", arch pseudo templates emit ';' with no space before it
+static bool is_comment_semicolon(const char *begin, const char *p) {
+	return *p == ';' && (p == begin || IS_WHITECHAR (p[-1]));
+}
+
 static void find_and_change(char *in, int len) {
 	if (len < 1) {
 		return;
 	}
 	RFindCTX ctx = { 0 };
+	char *start = in;
 	char *end = in + len;
 	for (ctx.linebegin = in; in < end; in++) {
 		if (*in == '\n' || !*in) {
@@ -162,7 +168,7 @@ static void find_and_change(char *in, int len) {
 			}
 			memset (&ctx, 0, sizeof (ctx));
 			ctx.linebegin = in + 1;
-		} else if (!ctx.comment && *in == ';' && in[1] == ' ') {
+		} else if (!ctx.comment && in > start && in[1] == ' ' && is_comment_semicolon (start, in)) {
 			ctx.comment = in - 1;
 			ctx.comment[1] = '/';
 			ctx.comment[2] = '/';
@@ -452,6 +458,25 @@ static void remove_double_spaces(char *s) {
 	}
 }
 
+static char *comments_to_c(char *s) {
+	if (!strchr (s, ';')) {
+		return s;
+	}
+	RStrBuf *sb = r_strbuf_new ("");
+	const char *chunk = s;
+	const char *p;
+	for (p = s; *p; p++) {
+		if (is_comment_semicolon (s, p)) {
+			r_strbuf_append_n (sb, chunk, p - chunk);
+			r_strbuf_append (sb, "//");
+			chunk = p + 1;
+		}
+	}
+	r_strbuf_append_n (sb, chunk, p - chunk);
+	free (s);
+	return r_strbuf_drain (sb);
+}
+
 static char *cleancomments(char *s) {
 	char *p = s;
 	char *nl = NULL;
@@ -668,7 +693,7 @@ static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
 		return NULL;
 	}
 	code = r_str_replace (code, "\n\n", "\n", true);
-	code = r_str_replace (code, ";", "//", true);
+	code = comments_to_c (code);
 	code = cleancomments (code);
 	size_t len = strlen (code);
 	if (len < 1) {
@@ -2006,7 +2031,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 		if (use_html) {
 			r_config_set_b (core->config, "scr.html", true);
 		}
-		s = r_str_replace (s, ";", "//", true);
+		s = comments_to_c (s);
 		s = r_str_replace (s, "goto ", "// goto loc_", true);
 		s = cleancomments (s);
 		s = fold_resolved_refs (core, s);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -906,3 +906,21 @@ EXPECT=<<EOF
 
 EOF
 RUN
+
+NAME=pdc keeps a semicolon that comes from the arch pseudo template
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx fc20102e4e800020
+af
+pdc
+EOF
+EXPECT=<<EOF
+// callconv: r3 ppc-64 (r3, r4, r5, r6, r7, r8, r9, r10, stack);
+void fcn.00000000 (void) {
+        if (f0 >= 0.0) f1 = f0; else f1 = f2
+        return
+}
+
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

pdc turns r2's `;` comment marker into `//`, but it did so for every `;` in the block, including the ones arch pseudo templates emit — so ppc's `fsel` decompiled with its else branch commented out:

    if (f0 >= 0.0) f1 = f0// else f1 = f2      before
    if (f0 >= 0.0) f1 = f0; else f1 = f2       after

Two places did the conversion: `r_str_replace` at two call sites, and an in-place one in `find_and_change` keyed on `;` followed by a space. Both now share one predicate — a `;` is a comment only at buffer start or after whitespace. That separates the two cases cleanly: `ds_align_comment` always emits at least one space before a comment, and none of the 113 distinct arch pseudo templates containing `;` has a space before it.

Also stops corrupting string literals that contain a semicolon (`U"();&|..."` was rendering as `U"()//&|..."`).

An A/B of ~4700 lines of pdc output across x86-64, arm, mips and ppc shows three changed lines, all of them these fixes.