### PR TITLE
Use the target word size for pointer types in the anal type api ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -142,7 +142,7 @@ static int fcn_type_stack_pop(RAnal *anal, const char *cc, const char *callee, i
 			continue;
 		}
 		char *type = r_type_func_args_type (anal->sdb_types, callee, i);
-		ut64 bitsize = type? r_type_get_bitsize (anal->sdb_types, type): 0;
+		ut64 bitsize = type? r_anal_type_bitsize (anal, type): 0;
 		free (type);
 		ut64 slot = bitsize? R_ROUND (R_MAX (bitsize, 8), 8) / 8: word;
 		slot = R_ROUND (slot, word);

--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -753,7 +753,7 @@ static char *tp_type_meet(RAnal *anal, const char *a, int rank_a, const char *b,
 		return strdup ("double");
 	}
 	// equal-rank scalar conflict: the order-independent common knowledge is the wider side's default int
-	const ut64 w = R_MAX (r_type_get_bitsize (anal->sdb_types, a), r_type_get_bitsize (anal->sdb_types, b));
+	const ut64 w = R_MAX (r_anal_type_bitsize (anal, a), r_anal_type_bitsize (anal, b));
 	switch (w) {
 	case 64: return strdup ("int64_t");
 	case 16: return strdup ("int16_t");
@@ -998,7 +998,7 @@ static void tp_selfsize_var(TPState *tps, ut64 baddr, RAnalVar *var, ut64 n) {
 		if (!tp_prim_scalar (cur)) {
 			return; // named and debug-provided types stay
 		}
-		if (n * 8 < r_type_get_bitsize (anal->sdb_types, cur)) {
+		if (n * 8 < r_anal_type_bitsize (anal, cur)) {
 			return; // a partial copy or clear cannot shrink the var below its own width
 		}
 	}
@@ -1295,7 +1295,7 @@ static char *tp_unwrap_typedef(RAnal *anal, const char *name) {
 	return cur;
 }
 
-// r_type_get_bitsize returns 32 for any non-char* pointer and 0 for typedefs, so handle both here
+// r_anal_type_bitsize handles the pointer width, this adds the typedef unwrap
 static ut64 tp_type_bits(RAnal *anal, const char *t) {
 	if (R_STR_ISEMPTY (t)) {
 		return 0;
@@ -1304,8 +1304,7 @@ static ut64 tp_type_bits(RAnal *anal, const char *t) {
 	if (!name) {
 		return 0;
 	}
-	const ut64 bits = strchr (name, '*')
-		? anal->config->bits: r_type_get_bitsize (anal->sdb_types, name);
+	const ut64 bits = r_anal_type_bitsize (anal, name);
 	free (name);
 	return bits;
 }

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -157,6 +157,12 @@ R_API void r_anal_types_load_sdb(RAnal *anal, const char *name) {
 	load_types_from (anal, "%s", name);
 }
 
+// a pointer is one target word wide, which r_type_get_bitsize cannot know from the sdb alone
+R_API ut64 r_anal_type_bitsize(RAnal *anal, const char *type) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->config && type, 0);
+	return strchr (type, '*')? anal->config->bits: r_type_get_bitsize (anal->sdb_types, type);
+}
+
 R_API void r_anal_remove_parsed_type(RAnal *anal, const char *name) {
 	R_RETURN_IF_FAIL (anal && name);
 	Sdb *TDB = anal->sdb_types;

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -169,7 +169,7 @@ R_API bool r_anal_function_rebase_vars(RAnal *a, RAnalFunction *fcn) {
 
 // Element size (bytes) and count of an array type like "char[4]"/"int[9][9]".
 // False if it is not a sized array (unknown element type or missing [N]).
-static bool array_type_info(Sdb *TDB, const char *type, int *esize, int *count) {
+static bool array_type_info(RAnal *anal, const char *type, int *esize, int *count) {
 	const char *br = strchr (type, '[');
 	if (!br) {
 		return false;
@@ -179,7 +179,7 @@ static bool array_type_info(Sdb *TDB, const char *type, int *esize, int *count) 
 		return false;
 	}
 	r_str_trim (base);
-	const ut64 bits = r_type_get_bitsize (TDB, base);
+	const ut64 bits = r_anal_type_bitsize (anal, base);
 	free (base);
 	if (bits < 8) {
 		return false;
@@ -205,7 +205,7 @@ static void shadow_var_struct_members(RAnal *anal, RAnalVar *var) {
 	// drop emulation slots synthesised inside an array var's extent (e.g. ucTemp[4] byte stores that became arg_81h..83h)
 	int esize, count;
 	if ((var->kind == R_ANAL_VAR_KIND_SPV || var->kind == R_ANAL_VAR_KIND_BPV)
-			&& var->type && array_type_info (TDB, var->type, &esize, &count)) {
+			&& var->type && array_type_info (anal, var->type, &esize, &count)) {
 		const int extent = esize * count;
 		int off;
 		for (off = 1; off < extent; off++) {
@@ -1073,7 +1073,7 @@ static bool var_add_structure_fields_to_list(RAnal *a, RAnalVar *av, RList *list
 		return true;
 	}
 	int esize, count;
-	if (av->type && array_type_info (TDB, av->type, &esize, &count) && count >= 2 && count <= 256) {
+	if (av->type && array_type_info (a, av->type, &esize, &count) && count >= 2 && count <= 256) {
 		int i;
 		for (i = 0; i < count; i++) {
 			RAnalVarField *field = R_NEW0 (RAnalVarField);
@@ -1377,7 +1377,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 						varname = strdup (r_type_func_args_name (anal->sdb_types, fname, i));
 						break;
 					}
-					ut64 bit_sz = r_type_get_bitsize (anal->sdb_types, tp);
+					ut64 bit_sz = r_anal_type_bitsize (anal, tp);
 					sum_sz += bit_sz ? bit_sz / 8 : bytes;
 					sum_sz = R_ROUND (sum_sz, bytes);
 					free (tp);

--- a/libr/core/carg.c
+++ b/libr/core/carg.c
@@ -28,7 +28,7 @@ static int ctype_size(RAnal *anal, const char *cc, const char *ctype) {
 		const char *arch = anal->config->arch;
 		return (arch && r_str_startswith (arch, "x86"))? 12: 8;
 	}
-	return r_type_get_bitsize (anal->sdb_types, t) / 8;
+	return r_anal_type_bitsize (anal, t) / 8;
 }
 
 static void set_fcn_args_info(RAnalFuncArg *arg, RAnal *anal, const char *cc, const char *fcn_name, int arg_num) {

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -418,6 +418,12 @@ static void cmd_tcc(RCore *core, const char *input) {
 	}
 }
 
+// byte width of a type, falling back for the sizeless ones the sdb cannot resolve
+static ut32 type_bytesize(RAnal *anal, const char *type, ut32 fallback) {
+	const ut32 size = r_anal_type_bitsize (anal, type) / 8;
+	return size? size: fallback;
+}
+
 static void add_type_fields_to_json(RCore *core, PJ *pj, const char *struct_name, const char *type_name) {
 	const bool is_union = !strcmp (type_name, "union");
 	// Get struct members list
@@ -448,17 +454,7 @@ static void add_type_fields_to_json(RCore *core, PJ *pj, const char *struct_name
 			const char *arr_size_str = r_str_word_get0 (member_details, 2);
 			ut32 arr_size = r_num_get (NULL, arr_size_str);
 			arr_size = arr_size ? arr_size : 1;
-			ut32 type_size;
-			if (strchr (type, '*')) {
-				type_size = core->anal->config->bits / 8;
-			} else {
-				ut64 type_bits = r_type_get_bitsize (core->anal->sdb_types, type);
-				type_size = type_bits / 8;
-				if (type_size == 0) {
-					type_size = 1;
-				}
-			}
-			ut32 size = type_size * arr_size;
+			ut32 size = type_bytesize (core->anal, type, 1) * arr_size;
 			pj_o (pj);
 			pj_ks (pj, "name", member_name);
 			pj_ks (pj, "type", type);
@@ -816,14 +812,14 @@ static int print_struct_union_list_json(RCore *core, Sdb *TDB, SdbForeachCallbac
 	return 1;
 }
 
-static ut64 struct_type_size(Sdb *TDB, const char *name, const char *kind) {
+static ut64 struct_type_size(RAnal *anal, const char *name, const char *kind) {
 	if (!strcmp (kind, "typedef")) {
-		const char *type = sdb_const_getf (TDB, NULL, "typedef.%s", name);
+		const char *type = sdb_const_getf (anal->sdb_types, NULL, "typedef.%s", name);
 		if (R_STR_ISNOTEMPTY (type)) {
-			return r_type_get_bitsize (TDB, type) / 8;
+			return r_anal_type_bitsize (anal, type) / 8;
 		}
 	}
-	return r_type_get_bitsize (TDB, name) / 8;
+	return r_anal_type_bitsize (anal, name) / 8;
 }
 
 static void print_structs_by_size(RCore *core, Sdb *TDB, ut64 size) {
@@ -839,7 +835,7 @@ static void print_structs_by_size(RCore *core, Sdb *TDB, ut64 size) {
 		if (R_STR_ISEMPTY (name) || !kind) {
 			continue;
 		}
-		if (struct_type_size (TDB, name, kind) == size) {
+		if (struct_type_size (core->anal, name, kind) == size) {
 			r_cons_println (core->cons, name);
 		}
 	}
@@ -1167,18 +1163,8 @@ static void print_struct_union_with_offsets(RCore *core, Sdb *TDB, SdbForeachCal
 				int arrnum = 0;
 				char *val = r_type_get_member (TDB, var2, &moff, &arrnum);
 				if (val) {
-					ut32 type_size;
-					if (strchr (val, '*')) {
-						type_size = core->anal->config->bits / 8;
-					} else {
-						ut64 type_bits = r_type_get_bitsize (TDB, val);
-						type_size = type_bits / 8;
-						if (type_size == 0) {
-							type_size = 1;
-						}
-					}
 					ut32 arr_size = arrnum ? arrnum : 1;
-					ut32 size = type_size * arr_size;
+					ut32 size = type_bytesize (core->anal, val, 1) * arr_size;
 					r_strbuf_appendf (sb, "%s0x%08x%s   %s%s%s", color_addr, current_offset, color_reset, color_type, val, color_reset);
 					if (p && p[0] != '\0') {
 						r_strbuf_appendf (sb, "%s%s%s%s", strstr (val, " *")? "": " ", color_name, p, color_reset);
@@ -1473,15 +1459,7 @@ static void print_func_with_offsets(RCore *core, Sdb *TDB, const char *arg) {
 					color_comment, "varargs", color_reset);
 				type_size = 0;
 			} else {
-				if (strchr (type, '*')) {
-					type_size = core->anal->config->bits / 8;
-				} else {
-					ut64 type_bits = r_type_get_bitsize (TDB, type);
-					type_size = type_bits / 8;
-					if (type_size == 0) {
-						type_size = core->anal->config->bits / 8;
-					}
-				}
+				type_size = type_bytesize (core->anal, type, core->anal->config->bits / 8);
 				r_strbuf_appendf (sb, "%s0x%08x%s   %s%s%s %s%s%s%s // %s%s\n",
 					color_addr, current_offset, color_reset,
 					color_type, type, color_reset,
@@ -1783,15 +1761,7 @@ static void printFunctionTypeJson(TypePrintCtx *ctx, const char *input) {
 			}
 			ut32 type_size = 0;
 			if (strcmp (type, "...")) {
-				if (strchr (type, '*')) {
-					type_size = core->anal->config->bits / 8;
-				} else {
-					ut64 type_bits = r_type_get_bitsize (tdb, type);
-					type_size = type_bits / 8;
-					if (type_size == 0) {
-						type_size = core->anal->config->bits / 8;
-					}
-				}
+				type_size = type_bytesize (core->anal, type, core->anal->config->bits / 8);
 			}
 			pj_o (pj);
 			pj_ks (pj, "type", type);
@@ -2493,7 +2463,7 @@ static int cmd_type(void *data, const char *input) {
 			break;
 		case 's': // "tss"
 			if (input[2] == ' ') {
-				r_cons_printf (core->cons, "%" PFMT64u "\n", (r_type_get_bitsize (TDB, input + 3) / 8));
+				r_cons_printf (core->cons, "%" PFMT64u "\n", (r_anal_type_bitsize (core->anal, input + 3) / 8));
 			} else {
 				r_cons_cmd_help (core->cons, help_msg_ts);
 			}
@@ -3133,7 +3103,7 @@ static int cmd_type(void *data, const char *input) {
 							}
 						}
 					}
-					int type_size = r_type_get_bitsize (core->anal->sdb_types, type) / 8;
+					int type_size = r_anal_type_bitsize (core->anal, type) / 8;
 					int obs = core->blocksize;
 					if (type_size > obs) {
 						r_core_block_size (core, type_size);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7119,7 +7119,7 @@ toro:
 			if (fmt) {
 				r_cons_printf (core->cons, "(%s)\n", link_type);
 				r_core_callf_at (core, ds->addr + ds->index, "pf %s", fmt);
-				const ut32 type_bitsize = r_type_get_bitsize (core->anal->sdb_types, link_type);
+				const ut32 type_bitsize = r_anal_type_bitsize (core->anal, link_type);
 				// always round up when calculating byte_size from bit_size of types
 				// could be struct with a bitfield entry
 				inc = (type_bitsize >> 3) + (!!(type_bitsize & 0x7));

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1797,6 +1797,7 @@ R_API SdbGperf *r_anal_get_gperf_cc(const char *k);
 R_API SdbGperf *r_anal_get_gperf_types(const char *k);
 R_API void r_anal_types_reload(RAnal *anal, const char *dir_prefix, const char *os, const char *subsystem);
 R_API void r_anal_types_load_sdb(RAnal *anal, const char *name);
+R_API ut64 r_anal_type_bitsize(RAnal *anal, const char *type);
 
 R_API RAnalEsilDFGNode *r_anal_esil_dfg_node_new(RAnalEsilDFG *edf, const char *c);
 R_API RAnalEsilDFG *r_anal_esil_dfg_new(RAnal *anal, bool use_map_info, bool use_maps);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3575,3 +3575,35 @@ func.A2.m.cc=cdecl
 func.A2.m.ret=float
 EOF
 RUN
+
+NAME=tss reports the target word size for pointers
+FILE=-
+ARGS=-b 64
+CMDS=<<EOF
+tss int *
+tss void *
+tss int
+EOF
+EXPECT=<<EOF
+8
+8
+4
+EOF
+RUN
+
+NAME=an array of pointers uses the target word size as its stride
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e asm.sub.var=true
+CMDS=<<EOF
+wx 48890424488944240848894424104889442418c3
+af
+"afvt arg_8h int *[4]"
+pdf~mov
+EOF
+EXPECT=<<EOF
+|           0x00000000      48890424       mov qword [rsp], rax
+|           0x00000004      4889442408     mov qword [arg_8h], rax
+|           0x00000009      4889442410     mov qword [arg_8h[1]], rax
+|           0x0000000e      4889442418     mov qword [arg_8h[2]], rax
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_type_get_bitsize` only gets an `Sdb`, so it cannot know the target word size and returns a hardcoded 32 for every pointer except `char *` — which is special-cased only because `type.char *.size` is already in the per-target sdb. On 64-bit that gave 4-byte pointers for array strides, argument sums, `tss` and struct links.

Its signature is public ABI, so this adds `r_anal_type_bitsize()` at the layer that owns `RArchConfig` and converts all 14 callers, deleting four copies of an inline `if (strchr (type, '*')) size = config->bits / 8` workaround.

With a var typed `int *[4]` on x86-64:

    before:  mov qword [arg_8h[2]], rax   (rsp+0x10, should be [1])
             mov qword [arg_18h], rax     (rsp+0x18, unrecognised)
    after:   mov qword [arg_8h[1]], rax
             mov qword [arg_8h[2]], rax

Pointer members inside structs are still summed at 32 bits by the `utype.c` recursion — unchanged here, and noted as follow-up.
