### PR TITLE
Add MiKNix platform support ##build

### DIFF
--- a/libr/include/r_th.h
+++ b/libr/include/r_th.h
@@ -31,6 +31,12 @@
 # define HAVE_STDATOMIC_H 0
 # define R_ATOMIC_BOOL int
 
+#elif defined(__miknix__)
+# define HAVE_TH_LOCAL 1
+# define R_TH_LOCAL __thread
+# define HAVE_STDATOMIC_H 0
+# define R_ATOMIC_BOOL int
+
 #elif defined (__GNUC__) && !__TINYC__
 # define HAVE_TH_LOCAL 1
 # define R_TH_LOCAL __thread

--- a/libr/include/r_types.h
+++ b/libr/include/r_types.h
@@ -180,13 +180,13 @@
 #endif
 
 #undef HAVE_PTY
-#if EMSCRIPTEN || __wasi__ || defined(__serenity__)
+#if EMSCRIPTEN || __wasi__ || defined(__serenity__) || defined(__miknix__)
 #define HAVE_PTY 0
 #else
 #define HAVE_PTY R2__UNIX__ && LIBC_HAVE_FORK && !__sun
 #endif
 
-#if defined(EMSCRIPTEN) || defined(__wasi__) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__) || defined(__vinix__) || defined(_AIX)
+#if defined(EMSCRIPTEN) || defined(__wasi__) || defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || defined(__ANDROID__) || defined(__QNX__) || defined(__sun) || defined(__HAIKU__) || defined(__serenity__) || defined(__vinix__) || defined(__miknix__) || defined(_AIX)
   #define R2__BSD__ 0
   #define R2__UNIX__ 1
 #endif


### PR DESCRIPTION
MiKNix is a small from-scratch Unix-like operating system. Register it in the platform switches so radare2 cross-compiles for it out of the box:

- r_types.h: MiKNix has no pseudo-terminals, so add it to the HAVE_PTY 0 list, and add it to the R2__UNIX__ family alongside the other Unix targets.
- r_th.h: MiKNix supports __thread thread-local storage (each thread carries a control block through the thread-pointer register) but has no <stdatomic.h> yet, so enable HAVE_TH_LOCAL with a plain-int atomic bool, matching the nearby branches.

The target is selected with -D__miknix__ by the cross toolchain.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3115b8ea-40d2-412a-af11-3559d4a3982a" />
