### PR TITLE
Stop treating register moves as argument uses in rarg extraction ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1455,7 +1455,7 @@ static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
 #endif
 
 static inline bool op_affect_dst(RAnalOp *op) {
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_ADD:
 	case R_ANAL_OP_TYPE_SUB:
 	case R_ANAL_OP_TYPE_MUL:
@@ -1483,7 +1483,7 @@ static bool is_used_like_arg(const char *regname, const char *opsreg, const char
 	RAnalValue *src = RVecRArchValue_at (&op->srcs, 0);
 	const bool in_src = is_reg_in_src (regname, anal, op);
 	const bool in_dst = opdreg && r_anal_cc_location_uses (anal, regname, opdreg);
-	switch (op->type) {
+	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_POP:
 		return false;
 	case R_ANAL_OP_TYPE_MOV:

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1302,7 +1302,6 @@ afvR @ 0
 EOF
 EXPECT=<<EOF
       arg1  0x0
-      arg2  0x0
 EOF
 RUN
 
@@ -1834,5 +1833,19 @@ EXPECT=<<EOF
 b 0x00000010
 type: jmp
 jump: 0x00000010
+EOF
+RUN
+
+NAME=ppc register move does not make its destination an argument
+FILE=malloc://16
+ARGS=-a ppc -b 64 -e anal.arch=ppc -e cfg.bigendian=true -e anal.cc=ppc-64
+CMDS=<<EOF
+wx 7c681b787d2942144e800020
+af
+afv
+EOF
+EXPECT=<<EOF
+arg int64_t arg1 @ r3
+arg int64_t arg2 @ r9
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

is_used_like_arg() and op_affect_dst() switched on the raw op->type, so a composite type missed its case and fell into default, which returns in_dst || in_src — a written destination register therefore counted as an argument use. ppc is the only arch that trips this: PPC_INS_MR sets R_ANAL_OP_TYPE_RMOV (MOV|REG), the sole RMOV site in the tree.
  
Masking with R_ANAL_OP_TYPE_MASK matches the idiom already used three times in this file. The mask preserves COND, so the CMOV case (9|COND) keeps matching.