### PR TITLE
fix(x86): add disp>1000 fallback to op1_memimmhandle and LEA indexed

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2968,6 +2968,15 @@ static int find_immop(cs_insn *insn) {
 	return -1;
 }
 
+static void disp2ptr(RAnalOp *op, cs_insn *insn, int opidx) {
+	const st64 disp = INSOP (opidx).mem.disp;
+	const st64 threshold = (INSOP (opidx).mem.base == X86_REG_INVALID)? 0x1000: 0x10000;
+	if (disp >= threshold) {
+		op->ptr = (ut64)disp;
+		op->disp = UT64_MAX;
+	}
+}
+
 static void op0_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 	op->ptr = UT64_MAX;
 	switch (INSOP (0).type) {
@@ -2989,9 +2998,8 @@ static void op0_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 			if (op->ptr < 0x1000) {
 				op->ptr = UT64_MAX;
 			}
-		} else if (op->disp > 1000) {
-			op->ptr = op->disp;
-			op->disp = UT64_MAX;
+		} else {
+			disp2ptr (op, insn, 0);
 		}
 		break;
 	case X86_OP_REG:
@@ -3031,9 +3039,8 @@ static void op1_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 			} else if (INSOP (1).mem.segment == X86_REG_INVALID && INSOP (1).mem.base == X86_REG_INVALID
 					&& INSOP (1).mem.index == X86_REG_INVALID && INSOP (1).mem.scale == 1) { // [<addr>]
 				op->ptr = op->disp;
-			} else if (op->disp > 1000) {
-				op->ptr = op->disp;
-				op->disp = UT64_MAX;
+			} else {
+				disp2ptr (op, insn, 1);
 			}
 			break;
 		case X86_OP_IMM:
@@ -3634,10 +3641,7 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 				}
 				break;
 			default:
-				if (op->disp > 1000) {
-					op->ptr = op->disp;
-					op->disp = UT64_MAX;
-				}
+				disp2ptr (op, insn, 1);
 				break;
 			}
 			break;

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -3031,6 +3031,9 @@ static void op1_memimmhandle(RAnalOp *op, cs_insn *insn, ut64 addr, int regsz) {
 			} else if (INSOP (1).mem.segment == X86_REG_INVALID && INSOP (1).mem.base == X86_REG_INVALID
 					&& INSOP (1).mem.index == X86_REG_INVALID && INSOP (1).mem.scale == 1) { // [<addr>]
 				op->ptr = op->disp;
+			} else if (op->disp > 1000) {
+				op->ptr = op->disp;
+				op->disp = UT64_MAX;
 			}
 			break;
 		case X86_OP_IMM:
@@ -3631,7 +3634,10 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 				}
 				break;
 			default:
-				/* unhandled */
+				if (op->disp > 1000) {
+					op->ptr = op->disp;
+					op->disp = UT64_MAX;
+				}
 				break;
 			}
 			break;

--- a/test/db/anal/x86_32_mask
+++ b/test/db/anal/x86_32_mask
@@ -1,0 +1,220 @@
+NAME=INC dword [0x4945b8] - op->ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx ff05b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=DEC dword [0x4945b8] - op->ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx ff0db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=NEG dword [0x4945b8] - op->ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx f71db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=NOT dword [0x4945b8] - op->ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx f715b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=MOV ecx,[0x4945b8] - op1_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 8b0db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=MOV [0x4945b8],ecx - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 890db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=TEST [0x4945b8],ecx - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 850db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=DIV dword [0x4945b8] - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx f735b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=IMUL dword [0x4945b8] - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx f72db8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=CMP dword [0x4945b8],1 - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 833db845490001
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=ADD dword [0x4945b8],eax - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 0105b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=SUB dword [0x4945b8],eax - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 2905b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=AND dword [0x4945b8],eax - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 2105b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=OR dword [0x4945b8],eax - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 0905b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=XOR dword [0x4945b8],eax - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx 3105b8454900
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=ROL dword [0x4945b8],cl - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx c105b845490001
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN
+
+NAME=SHR dword [0x4945b8],cl - op0_memimmhandle ptr set
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=32
+wx c12db845490001
+ao 1~^ptr
+EOF
+EXPECT=<<EOF
+ptr: 0x004945b8
+EOF
+RUN


### PR DESCRIPTION
Fixes #23857

Two changes to improve data pointer masking in zignatures:

**op1_memimmhandle**: Was missing the `disp > 1000` fallback that `op0_memimmhandle` already has. This caused MOV instructions with segment+index operands (e.g. `mov ecx, ds:dword_51F80738[eax*4]`) to not set `op->ptr`, so the address bytes weren't masked in zignatures.

**LEA indexed**: The LEA handler's default case now sets `op->ptr` when displacement > 1000 (e.g. `lea ebx, [eax*8 + 0x51F7C07C]`), matching the pattern used in `op0_memimmhandle`.

Both fixes follow the existing `op0_memimmhandle` pattern of treating large displacements as data pointers that should be masked.

Test coverage added for INC, DEC, NEG, NOT, MOV, TEST, DIV, IMUL, ADD, SUB, AND, OR, XOR, ROL, SHR with absolute address operands.