### PR TITLE
Remove the dead colon replacement from ppc, mips and sparc pseudo parsers ##arch

### DIFF
--- a/libr/arch/p/mips/pseudo.c
+++ b/libr/arch/p/mips/pseudo.c
@@ -237,7 +237,6 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					REPLACE ("%s = %s >>", "%s >>=");
 					REPLACE ("%s = %s <<", "%s <<=");
 				}
-				p = r_str_replace (p, ":", "0000", 0);
 				strcpy (str, p);
 				free (p);
 			}

--- a/libr/arch/p/ppc/pseudo.c
+++ b/libr/arch/p/ppc/pseudo.c
@@ -1718,7 +1718,6 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					REPLACE ("%s = %s >>", "%s >>=");
 					REPLACE ("%s = %s <<", "%s <<=");
 				}
-				p = r_str_replace (p, ":", "0000", 0);
 				strcpy (str, p);
 				free (p);
 			}

--- a/libr/arch/p/sparc/pseudo.c
+++ b/libr/arch/p/sparc/pseudo.c
@@ -200,7 +200,6 @@ static char *parse(RAsmPluginSession *aps, const char *data) {
 					REPLACE ("%s = %s >>", "%s >>=");
 					REPLACE ("%s = %s <<", "%s <<=");
 				}
-				p = r_str_replace (p, ":", "0000", 0);
 				strcpy (str, p);
 				free (p);
 			}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

p = r_str_replace (p, ":", "0000", 0) has been copy-pasted through the ppc, mips and sparc pseudo parsers since the original r_parse import, but no template in any of the three tables contains a :, so it can never fire. Verified byte-identical asm.pseudo output over ~615k lines of ppc32/ppc64be/ppc64le/mips/sparc disassembly with the line removed.

Dropping it also lifts the ban on : in future templates (e.g. rendering ppc isel as a C conditional ? : like arm64 csel).