### PR TITLE
Drop stale func arg keys when reanalysis recovers fewer arguments ##analysis

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -1420,10 +1420,22 @@ static void __add_vars_sdb(RCore *core, RAnalFunction *fcn) {
 		free (k);
 		arg_count++;
 	}
-	//	sdb_num_set (core->anal->sdb_types, args, (int)arg_count, 0);
 	if (arg_count > 0) {
+		Sdb *TDB = core->anal->sdb_types;
 		r_strf_buffer (16);
-		sdb_setf (core->anal->sdb_types, r_strf ("%d", (int)arg_count), 0, "func.%s.args", fcn->name);
+		const int oargs = (int)sdb_num_getf (TDB, NULL, "func.%s.args", fcn->name);
+		sdb_setf (TDB, r_strf ("%d", (int)arg_count), 0, "func.%s.args", fcn->name);
+		// a previous wider recovery leaves stale higher keys behind
+		int i;
+		for (i = (int)arg_count; i < oargs; i++) {
+			char *k = r_str_newf ("func.%s.arg.%d", fcn->name, i);
+			const int ok = sdb_unset (TDB, k, 0);
+			free (k);
+			if (!ok) {
+				// an unset only fails when sdb cannot take writes, so the rest would too
+				break;
+			}
+		}
 	}
 	r_anal_function_vars_cache_fini (&cache);
 }

--- a/test/db/cmd/cmd_afn
+++ b/test/db/cmd/cmd_afn
@@ -107,7 +107,6 @@ main
 --
 func.main.arg.0=int,argc
 func.main.arg.1=char **,argv
-func.main.arg.2=char **,envp
 func.main.args=2
 func.main.ret=int
 --

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3669,3 +3669,24 @@ func.N.cb.cc=cdecl
 func.N.cb.ret=int
 EOF
 RUN
+
+NAME=reanalysis drops the stale higher arg keys of a previously wider function
+FILE=bins/elf/pltrel/add.so
+CMDS=<<EOF
+s sym.add2
+af
+tk func.sym.add2.arg.2=int,stale2
+tk func.sym.add2.arg.3=int,stale3
+tk func.sym.add2.args=4
+af-
+af
+k anal/types/func.sym.add2.args
+k anal/types/func.sym.add2.arg.1
+k anal/types/func.sym.add2.arg.2
+k anal/types/func.sym.add2.arg.3
+EOF
+EXPECT=<<EOF
+2
+int64_t,arg2
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

af/aaft write func.<name>.arg.N and .args from the recovered variables, but never deleted the higher-numbered keys left by a previous wider recovery — the sdb ends up with args=2 and a live arg.4 beside it. The afn rename path already works around these leftovers (it unsets args..args+8 when renaming); now the writer trims them at the source, using the same sdb_num_getf idiom as r_type_del.

The cmd_afn golden loses exactly one line — func.main.arg.2=char **,envp next to func.main.args=2 — which was this bug: consumers iterate 0..args-1, and the test's own post-rename half already showed only two args.