### PR TITLE
Grow strbuf pads with the append slack instead of an exact fit ##util

### DIFF
--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -447,7 +447,10 @@ R_API bool r_strbuf_pad(RStrBuf *sb, char ch, int sz) {
 	if (sz < 1) {
 		return true;
 	}
-	if (!r_strbuf_reserve (sb, sb->len + sz)) {
+	const size_t cap = sb->ptr? sb->ptrlen: sizeof (sb->buf);
+	size_t required;
+	// grow with the same slack as the append paths instead of an exact fit
+	if (r_add_overflow (sb->len, (size_t)sz + 1, &required) || !r_strbuf_reserve (sb, growlog (cap, required) - 1)) {
 		return false;
 	}
 	char *buf = sb->ptr? sb->ptr: sb->buf;

--- a/test/unit/test_strbuf.c
+++ b/test/unit/test_strbuf.c
@@ -11,6 +11,32 @@ bool test_r_strbuf_slice(void) {
 	mu_end;
 }
 
+bool test_r_strbuf_pad(void) {
+	RStrBuf sb;
+	r_strbuf_init (&sb);
+	r_strbuf_set (&sb, "ab");
+	mu_assert_true (r_strbuf_pad (&sb, '-', 3), "pad in place");
+	mu_assert_streq (r_strbuf_get (&sb), "ab---", "pad content");
+	// crossing into the heap must keep slack like the append paths, not fit exactly
+	mu_assert_true (r_strbuf_pad (&sb, ' ', 500), "pad grows");
+	mu_assert_eq (r_strbuf_length (&sb), 505, "pad length");
+	mu_assert_true (r_strbuf_size (&sb) > 507, "pad capacity keeps growth slack");
+	mu_assert_true (r_strbuf_append (&sb, "!"), "append after pad");
+	mu_assert_eq (r_strbuf_length (&sb), 506, "append length");
+	r_strbuf_fini (&sb);
+
+	// a weakref buffer must be copied before the pad writes into it
+	char backing[8] = "xy";
+	r_strbuf_init (&sb);
+	r_strbuf_setptr (&sb, backing, -1);
+	mu_assert_true (r_strbuf_pad (&sb, 'z', 4), "pad weakref");
+	mu_assert_streq (r_strbuf_get (&sb), "xyzzzz", "pad weakref content");
+	mu_assert_streq (backing, "xy", "weakref backing untouched");
+	r_strbuf_fini (&sb);
+
+	mu_end;
+}
+
 bool test_r_strbuf_append(void) {
 	RStrBuf *sa = r_strbuf_new ("foo");
 	r_strbuf_append (sa, "bar");
@@ -236,6 +262,7 @@ bool test_r_strbuf_initf(void) {
 }
 
 bool all_tests(void) {
+	mu_run_test (test_r_strbuf_pad);
 	mu_run_test (test_r_strbuf_append);
 	mu_run_test (test_r_strbuf_prependf);
 	mu_run_test (test_r_strbuf_strong_string);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

r_strbuf_pad reserved an exact fit, leaving capacity at len + 1 — so every subsequent pad past capacity realloc'd again: 200k pads means 200k realloc calls where the append paths would do ~30 geometric growths. It now sizes the reservation with the same growlog slack as r_strbuf_append_n/r_strbuf_prepend_n, with the overflow guard the siblings carry.

The new unit test covers in-place pads, the slack-preserving growth (fails against the old exact fit), and that padding a weakref buffer copies it out instead of writing into the borrowed memory.