### PR TITLE
Fix the case tags on pdc orphan blocks ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -601,6 +601,22 @@ static bool bb_addr_is_goto_target(RAnalFunction *fcn, ut64 addr) {
 
 static int bb_last_op_type(RCore *core, RAnalBlock *bb);
 
+// a case flag names the orphan it labels, renames included, so never truncate it
+static char *orphan_tag(RCore *core, ut64 addr) {
+	RFlagItem *fi = r_flag_get_in (core->flags, addr);
+	if (!fi || !r_str_startswith (fi->name, "case.")) {
+		return strdup ("orphan");
+	}
+	const char *val = r_str_lchr (fi->name, '.') + 1;
+	char *hex = r_str_newf ("0x%s", val);
+	const int nval = r_num_get (NULL, hex);
+	free (hex);
+	if (IS_PRINTABLE (nval)) {
+		return r_str_newf ("case '%c'", nval);
+	}
+	return r_str_newf ("case %s", val);
+}
+
 static bool pdc_is_ret_only_bb(RCore *core, ut64 addr) {
 	RAnalBlock *bb = addr != UT64_MAX? r_anal_bb_from_offset (core->anal, addr): NULL;
 	if (!bb || bb->jump != UT64_MAX || bb->fail != UT64_MAX) {
@@ -2085,22 +2101,9 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 				NEWLINE (bb->addr, 1);
 			}
 			if (labeled) {
-				RFlagItem *fi = r_flag_get_in (core->flags, bb->addr);
-				char tagbuf[32];
-				const char *tag = "orphan";
-				if (fi && r_str_startswith (fi->name, "case.")) {
-					const char *val = r_str_lchr (fi->name, '.') + 1;
-					char *hex = r_str_newf ("0x%s", val);
-					int nval = r_num_get (NULL, hex);
-					free (hex);
-					if (IS_PRINTABLE (nval)) {
-						snprintf (tagbuf, sizeof (tagbuf), "case '%c'", nval);
-					} else {
-						snprintf (tagbuf, sizeof (tagbuf), "case %s", val);
-					}
-					tag = tagbuf;
-				}
+				char *tag = orphan_tag (core, bb->addr);
 				PRINTF ("loc_0x%08" PFMT64x ": // %s\n%s", bb->addr, tag, s);
+				free (tag);
 			} else {
 				PRINTF ("%s", s);
 			}

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -608,9 +608,8 @@ static char *orphan_tag(RCore *core, ut64 addr) {
 		return strdup ("orphan");
 	}
 	const char *val = r_str_lchr (fi->name, '.') + 1;
-	char *hex = r_str_newf ("0x%s", val);
-	const int nval = r_num_get (NULL, hex);
-	free (hex);
+	// the jmptbl flag carries the case value in decimal, as disasm reads it
+	const int nval = atoi (val);
 	if (IS_PRINTABLE (nval)) {
 		return r_str_newf ("case '%c'", nval);
 	}

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -939,3 +939,19 @@ EXPECT=<<EOF
     loc_0x100003a6c: // orphan
 EOF
 RUN
+
+NAME=pdc reads the case value of an orphan tag in decimal like the jmptbl writer
+FILE=bins/mach0/ls-m1
+ARGS=-a arm -b64
+CMDS=<<EOF
+s 0x100003a54
+af
+f case.strcoll.65 @ 0x100003a78
+f case.strcoll.300 @ 0x100003a6c
+pdc~loc_0x100003a78,loc_0x100003a6c
+EOF
+EXPECT=<<EOF
+    loc_0x100003a78: // case 'A'
+    loc_0x100003a6c: // case 300
+EOF
+RUN

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -924,3 +924,18 @@ void fcn.00000000 (void) {
 
 EOF
 RUN
+
+NAME=pdc keeps a renamed case tag on an orphan block untruncated
+FILE=bins/mach0/ls-m1
+ARGS=-a arm -b64
+CMDS=<<EOF
+s 0x100003a54
+af
+f case.strcoll.result_when_greater_than_other @ 0x100003a78
+pdc~loc_0x100003a78,loc_0x100003a6c
+EOF
+EXPECT=<<EOF
+    loc_0x100003a78: // case result_when_greater_than_other
+    loc_0x100003a6c: // orphan
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Two fixes to the // case ... tag on pdc orphan blocks:

- It went through a char tagbuf[32], so a renamed case flag longer than 26 chars was silently cut (case.strcoll.result_when_greater_than_other printed as // case result_when_greater_than_o). The block is now an orphan_tag() helper returning an owned string.
- The flag's value was parsed as hex, but both writers (jmptbl.c, fcn.c) emit it in decimal and disasm reads it with atoi — so case.X.65 tagged as 'e' instead of 'A'. Now aligned on decimal.