### PR TITLE
Honor address-linked function signatures ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2552,12 +2552,12 @@ static char *function_signature_try_type_name(Sdb *types, const char *candidate)
 
 static char *function_signature_address_type_name(Sdb *types, ut64 addr) {
 	R_RETURN_VAL_IF_FAIL (types, NULL);
-	const char *name = sdb_const_getf (types, NULL, "link.%08" PFMT64x, addr);
-	if (R_STR_ISEMPTY (name)) {
-		return NULL;
+	char *name = r_type_link_at (types, addr);
+	if (name && r_type_kind (types, name) == R_TYPE_FUNCTION) {
+		return name;
 	}
-	const char *kind = sdb_const_get (types, name, 0);
-	return kind && !strcmp (kind, "func")? strdup (name): NULL;
+	free (name);
+	return NULL;
 }
 
 static char *function_signature_type_name(RAnal *anal, RAnalFunction *fcn) {

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2563,9 +2563,9 @@ static char *function_signature_address_type_name(Sdb *types, ut64 addr) {
 static char *function_signature_type_name(RAnal *anal, RAnalFunction *fcn) {
 	const char *basename;
 
-	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn, NULL);
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn && fcn->name, NULL);
 	char *name = function_signature_address_type_name (anal->sdb_types, fcn->addr);
-	if (name || !fcn->name) {
+	if (name) {
 		return name;
 	}
 	const char *lookup_name = function_signature_lookup_name (anal, fcn);

--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2550,12 +2550,26 @@ static char *function_signature_try_type_name(Sdb *types, const char *candidate)
 	return NULL;
 }
 
+static char *function_signature_address_type_name(Sdb *types, ut64 addr) {
+	R_RETURN_VAL_IF_FAIL (types, NULL);
+	const char *name = sdb_const_getf (types, NULL, "link.%08" PFMT64x, addr);
+	if (R_STR_ISEMPTY (name)) {
+		return NULL;
+	}
+	const char *kind = sdb_const_get (types, name, 0);
+	return kind && !strcmp (kind, "func")? strdup (name): NULL;
+}
+
 static char *function_signature_type_name(RAnal *anal, RAnalFunction *fcn) {
 	const char *basename;
 
-	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn && fcn->name, NULL);
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn, NULL);
+	char *name = function_signature_address_type_name (anal->sdb_types, fcn->addr);
+	if (name || !fcn->name) {
+		return name;
+	}
 	const char *lookup_name = function_signature_lookup_name (anal, fcn);
-	char *name = function_signature_try_type_name (anal->sdb_types, lookup_name);
+	name = function_signature_try_type_name (anal->sdb_types, lookup_name);
 	if (name) {
 		return name;
 	}

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -146,6 +146,36 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=exact function type link overrides name lookup
+FILE=-
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx c3
+af
+afn fallback_signature
+'td int fallback_signature(int fallback);
+'td char linked_signature(char linked);
+afs
+tl linked_signature = 0
+afs
+afn renamed_signature
+afs
+tl- 0
+afs
+'td struct NotAFunction { int value; };
+tl NotAFunction = 0
+afs
+EOF
+EXPECT=<<EOF
+int fallback_signature (int fallback);
+char linked_signature (char linked);
+char linked_signature (char linked);
+int renamed_signature (int fallback);
+int renamed_signature (int fallback);
+EOF
+RUN
+
 NAME=List type links
 CMDS=<<EOF
 tl int = 0x4

--- a/test/unit/test_anal_function.c
+++ b/test/unit/test_anal_function.c
@@ -305,11 +305,24 @@ bool test_r_anal_function_get_signature_prefers_exact_type_link(void) {
 	mu_assert_streq (signature->ret_type, "char", "exact link must take precedence over function name");
 	mu_assert_eq ((int)r_list_length (signature->params), 1, "exact linked signature param count");
 	r_anal_function_signature_free (signature);
+	RAnalFunctionParam updated_param = { .name = "changed", .type = "short" };
+	RList *updated_params = r_list_new ();
+	mu_assert_notnull (updated_params, "Couldn't create updated linked param list");
+	r_list_append (updated_params, &updated_param);
+	RAnalFunctionSignature updated = {
+		.ret_type = "short",
+		.params = updated_params,
+	};
+	mu_assert_true (r_anal_function_set_signature (anal, f, &updated),
+		"updating a linked signature must succeed");
+	r_list_free (updated_params);
+	mu_assert_streq (r_type_func_ret (anal->sdb_types, "linked_signature"), "short",
+		"updating a linked function must update the linked type");
 
 	mu_assert_true (r_anal_function_rename (f, "renamed_signature"), "function rename must succeed");
 	signature = r_anal_function_get_signature (f);
 	mu_assert_notnull (signature, "exact linked signature must survive function rename");
-	mu_assert_streq (signature->ret_type, "char", "renaming must not change exact linked signature");
+	mu_assert_streq (signature->ret_type, "short", "renaming must not change exact linked signature");
 	r_anal_function_signature_free (signature);
 
 	mu_assert_true (r_type_unlink (anal->sdb_types, f->addr), "exact function type link must be removed");

--- a/test/unit/test_anal_function.c
+++ b/test/unit/test_anal_function.c
@@ -286,6 +286,50 @@ bool test_r_anal_function_get_signature(void) {
 	mu_end;
 }
 
+bool test_r_anal_function_get_signature_prefers_exact_type_link(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+	bool ok = r_anal_import_c_decls (anal,
+		"int fallback_signature (int fallback);"
+		"char linked_signature (char linked);"
+		"void renamed_signature (void);", NULL);
+	mu_assert_true (ok, "seed linked and fallback signatures");
+
+	RAnalFunction *f = r_anal_create_function (anal, "fallback_signature", 0x2800, 0, NULL);
+	mu_assert_notnull (f, "Couldn't create function for exact type link test");
+	mu_assert_true (r_type_set_link (anal->sdb_types, "linked_signature", f->addr),
+		"exact function type link must be set");
+
+	RAnalFunctionSignature *signature = r_anal_function_get_signature (f);
+	mu_assert_notnull (signature, "exact linked signature must be readable");
+	mu_assert_streq (signature->ret_type, "char", "exact link must take precedence over function name");
+	mu_assert_eq ((int)r_list_length (signature->params), 1, "exact linked signature param count");
+	r_anal_function_signature_free (signature);
+
+	mu_assert_true (r_anal_function_rename (f, "renamed_signature"), "function rename must succeed");
+	signature = r_anal_function_get_signature (f);
+	mu_assert_notnull (signature, "exact linked signature must survive function rename");
+	mu_assert_streq (signature->ret_type, "char", "renaming must not change exact linked signature");
+	r_anal_function_signature_free (signature);
+
+	mu_assert_true (r_type_unlink (anal->sdb_types, f->addr), "exact function type link must be removed");
+	signature = r_anal_function_get_signature (f);
+	mu_assert_notnull (signature, "name-based signature must remain available after unlink");
+	mu_assert_streq (signature->ret_type, "void", "unlink must restore name-based lookup");
+	r_anal_function_signature_free (signature);
+
+	sdb_set (anal->sdb_types, "not_a_function", "type", 0);
+	mu_assert_true (r_type_set_link (anal->sdb_types, "not_a_function", f->addr),
+		"non-function type link must be set for rejection test");
+	signature = r_anal_function_get_signature (f);
+	mu_assert_notnull (signature, "non-function link must fall back to name-based signature");
+	mu_assert_streq (signature->ret_type, "void", "non-function address link must be ignored");
+	r_anal_function_signature_free (signature);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
 bool test_r_anal_function_set_signature_uses_canonical_type_name(void) {
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "Couldn't create new RAnal");
@@ -603,6 +647,7 @@ int all_tests(void) {
 	mu_run_test (test_r_anal_str_to_fcn_returns_status);
 	mu_run_test (test_r_core_anal_fcn_prefers_exact_start_match);
 	mu_run_test (test_r_anal_function_get_signature);
+	mu_run_test (test_r_anal_function_get_signature_prefers_exact_type_link);
 	mu_run_test (test_r_anal_function_set_signature_uses_canonical_type_name);
 	mu_run_test (test_r_anal_function_get_signature_string_uses_import_flag_name);
 	mu_run_test (test_r_anal_function_get_signature_uses_basename_for_dbg_prefixed_function);


### PR DESCRIPTION
## Summary

- prefer an exact address type link when resolving a function signature
- accept the link only when its target is a function type
- preserve the existing import, function-name, basename, and JNI fallbacks
- cover the user-facing `tl`, `afs`, `afn`, and `tl-` workflow with an R2R test

## Why

The `tl <type> = <address>` command already records an exact type link, persists it in projects, and supports explicit unlinking with `tl-`. Function signature lookup ignored that address link and continued guessing from the function name. Renaming a function or having colliding names could therefore select a different prototype than the one explicitly linked to the address.

While an exact function-type link is active, that linked type is the source of truth for signature reads and for `r_anal_function_set_signature()` writes. Updating the signature therefore updates the linked type definition; unlinking restores name-based lookup. Links to non-function types are ignored by signature lookup.

This reuses the existing generic type-link storage. It does not add DWARF ownership/proof state, snapshot APIs, or Sleigh integration.

## Validation

- `make -j > /dev/null`
- `make -C test/unit -B bin/test_anal_function`
- `R2_DEBUG_ASSERT=1 test/unit/bin/test_anal_function` (14/14 passed)
- focused R2R command test (1/1 passed)
- `git diff --check`