### PR TITLE
Indent pdc orphan blocks at the walk depth instead of leftover state ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -852,6 +852,10 @@ static char *pdc_prefix_lines(const char *s, const char *prefix, bool addr_pipe)
 	}
 	RStrBuf *sb = r_strbuf_new ("");
 	while (*s) {
+		if (!addr_pipe) {
+			// the prefix replaces pdb's own leading indent
+			s += strspn (s, " \t");
+		}
 		const char *end = s + strcspn (s, "\n");
 		r_strbuf_append (sb, prefix);
 		if (addr_pipe && end - s > 2 && r_str_startswith (s, "0x")) {
@@ -2026,6 +2030,8 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 		r_list_append (visited, bb);
 		r_bitset_set (state.marked, bb->addr);
 	}
+	// orphans render at the walk depth: labels one level in, statements two
+	indent = 2;
 	r_list_foreach (state.fcn->bbs, iter, bb) {
 		if (r_list_contains (visited, bb)) {
 			continue;
@@ -2080,7 +2086,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			free (s);
 			s = os;
 		} else {
-			char *ind = r_str_pad (NULL, 0, ' ', indent * 2);
+			char *ind = r_str_pad (NULL, 0, ' ', indent * 4);
 			char *os = pdc_prefix_lines (s, r_str_get (ind), false);
 			free (ind);
 			free (s);
@@ -2097,7 +2103,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			} else if (state.show_addr) {
 				NEWLINE (bb->addr, 0);
 			} else {
-				NEWLINE (bb->addr, 1);
+				NEWLINE (bb->addr, labeled? 1: 0);
 			}
 			if (labeled) {
 				char *tag = orphan_tag (core, bb->addr);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -199,10 +199,10 @@ void sym.func.100003a54 (int64_t arg1, int64_t arg2) {
         x0 = x8
         goto sym.imp.strcoll // int strcoll("", "")
     loc_0x100003a78: // orphan
-         w0 = -1
+        w0 = -1
 
     loc_0x100003a6c: // orphan
-         w0 = 1
+        w0 = 1
 
 }
 
@@ -308,8 +308,8 @@ void fcn.00000000 (int64_t arg1) {
         r3 = 0
         return
     loc_0x00000008: // orphan
-         r3 = 1                   // "#"
-         return
+        r3 = 1                   // "#"
+        return
 
 }
 
@@ -684,8 +684,8 @@ pdc~printf("Results
 pdc~printf("msg
 EOF2
 EXPECT=<<EOF2
-         sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 21)
-         sym.imp.printf () // int printf("msg : %s\n", "")
+        sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 21)
+        sym.imp.printf () // int printf("msg : %s\n", "")
 EOF2
 RUN
 
@@ -858,8 +858,8 @@ pdcj~{annotations[12]}
 EOF
 EXPECT=<<EOF
 {"start":519,"end":571,"offset":4294982284,"type":"offset"}
-{"start":571,"end":620,"offset":4294982264,"type":"offset"}
-{"start":620,"end":668,"offset":4294982252,"type":"offset"}
+{"start":571,"end":619,"offset":4294982264,"type":"offset"}
+{"start":619,"end":666,"offset":4294982252,"type":"offset"}
 EOF
 RUN
 
@@ -877,8 +877,8 @@ EXPECT=<<EOF
 void fcn.00000000 (void) {
         eax = 0
         return eax
-             eax = 1
-         return 1
+        eax = 1
+        return 1
 
 }
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The orphan-block body prefix was indent * 2 with whatever indent the structured walk happened to end at — a different unit from print_newline's indent * 4 and a function-dependent depth (9 or 13 spaces in practice). Orphans now render at pinned depth with the walk's own unit: labels at one level, statements at two, exactly like structured output. pdc_prefix_lines replaces pdb's own leading indent instead of stacking on it, and unlabeled first lines lose their double pad.

The five golden updates are pure whitespace realignments (9→8 spaces, and the two pdcj annotation offsets that shrink with them).