### PR TITLE
Test that the block state restore does not rewind esil memory ##analysis

### DIFF
--- a/libr/anal/p/anal_tp.c
+++ b/libr/anal/p/anal_tp.c
@@ -2637,7 +2637,7 @@ static void tp_restore_block_writes(TypeTrace *tt, TPLoopHdr *hdr, const ut8 *sn
 	}
 }
 
-// restore the GPR arena from the nearest direct-edge predecessor with a snapshot (memory is not rewound); transitive reachers do not count
+// memory is never rewound, so the stack keeps sibling branch writes
 static bool tp_restore_pred_state(TPState *tps, RVecUT64 *bblist, int j, ut64 bbat, HtUP *bbstate, HtUP *loop_headers, int arena_size) {
 	if (j < 1) {
 		return false;

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3599,6 +3599,48 @@ var int64_t s @ rbp-0x20
 EOF2
 RUN
 
+NAME=a restored block reads the sibling branch stack writes
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true -e types.bbstate=true
+CMDS=<<EOF2
+# entry sets size 0x100 in edx and at rbp-0x10; the sibling branch lowers both to 0x40 and returns; the join memsets with the register size, then with the reloaded stack size
+wx 554889e54883ec70ba0001000048c745f00001000085ff750eba4000000048c745f040000000c3488d7de031f6e84e000000488d7da031f6488b55f0e83f000000c9c3
+wx c3 @ 0x80
+af+ 0x80 memset
+afb+ 0x80 0x80 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_
+EOF2
+EXPECT=<<EOF2
+var uint8_t [256] var_20h @ rbp-0x20
+var uint8_t [64] var_60h @ rbp-0x60
+EOF2
+RUN
+
+NAME=disabling the state restore takes registers and stack from the same block
+FILE=malloc://256
+ARGS=-a x86 -b 64 -e types.sizes=true -e types.bbstate=false
+CMDS=<<EOF2
+# entry sets size 0x100 in edx and at rbp-0x10; the sibling branch lowers both to 0x40 and returns; the join memsets with the register size, then with the reloaded stack size
+wx 554889e54883ec70ba0001000048c745f00001000085ff750eba4000000048c745f040000000c3488d7de031f6e84e000000488d7da031f6488b55f0e83f000000c9c3
+wx c3 @ 0x80
+af+ 0x80 memset
+afb+ 0x80 0x80 1
+'td void *memset(void *s, int c, size_t n);
+af @ 0
+s 0
+aft
+afv~var_
+EOF2
+EXPECT=<<EOF2
+var uint8_t [64] var_20h @ rbp-0x20
+var uint8_t [64] var_60h @ rbp-0x60
+EOF2
+RUN
+
 NAME=a header byte write keeps the rest of the body's register value
 FILE=malloc://128
 ARGS=-a x86 -b 64 -e types.sizes=true


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Pins the known limitation in #26389: types.bbstate restores the GPR arena per block, but esil memory is never rewound, so a restored block mixes one branch's registers with another branch's stack.

Two tests make the split visible in one join block. The entry block puts the size 0x100 in both edx and [rbp-0x10]; the sibling branch lowers both to 0x40 and returns; the join then memsets one buffer with the register size and another with the reloaded stack size:

    var uint8_t [256] var_20h @ rbp-0x20    # register size, restored from the entry block
    var uint8_t [64]  var_60h @ rbp-0x60    # stack size, left by the sibling branch

The types.bbstate=false sibling test shows both sizes coming from the same block, which is what makes the split unambiguous.

Worth noting against the issue's own framing: this is not only a missed match. A stale slot holds a plausible size, so the buffer gets typed with the sibling branch's size rather than left untyped — a wrong type, not an absent one. Leaving #26389 open for that reason.

No behavior change: one comment line plus two additive tests.