### PR TITLE
Link DWARF types only when prototypes match ##analysis

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1751,7 +1751,8 @@ static void import_dwarf_function_type(Context *ctx, const char *sname, const ch
 			(void)import_dwarf_function_fallback (anal, typed_name, ret_type, variables, has_unspecified_parameters);
 		}
 	}
-	if (dwarf_fcn->prototype_complete && r_type_func_exist (anal->sdb_types, typed_name)) {
+	if (dwarf_fcn->prototype_complete && dwarf_function_type_matches (anal->sdb_types,
+			typed_name, ret_type, variables, has_unspecified_parameters)) {
 		const char *linked = sdb_const_getf (anal->sdb_types, NULL,
 			"fcnlink.%08" PFMT64x, dwarf_fcn->addr);
 		if (!linked || !strcmp (linked, typed_name)) {

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1620,8 +1620,8 @@ static char *dwarf_function_type_name(Context *ctx, const char *sname, const Fun
 	const char *previous_name = sdb_const_getf (ctx->sdb, NULL, "fcn.%s.name", sname);
 	const char *previous = sdb_const_getf (ctx->sdb, NULL, "fcn.%s.typed_name", sname);
 	if (previous_name && !strcmp (previous_name, dwarf_fcn->name)
-		&& previous && dwarf_function_type_matches (types, previous,
-			ret_type, variables, has_unspecified_parameters)) {
+		&& previous && r_type_kind (types, previous) == R_TYPE_FUNCTION
+		&& sdb_num_getf (ctx->sdb, NULL, "fcn.%s.addr", sname) == dwarf_fcn->addr) {
 		return strdup (previous);
 	}
 	char *name = sanitize_c_identifier (dwarf_fcn->name);
@@ -1731,34 +1731,32 @@ static void import_dwarf_function_type(Context *ctx, const char *sname, const ch
 	sdb_setf (ctx->sdb, csig, 0, "fcn.%s.csig", sname);
 	r_strbuf_fini (&args_buf);
 
-	if (!r_type_func_exist (anal->sdb_types, typed_name)) {
+	if (!sdb_const_get (anal->sdb_types, typed_name, 0)) {
 		/* Only attempt C parsing for C-like languages.  Non-C languages
 		   (Rust, Go, D, etc.) produce type names that are not valid C and
 		   would choke the parser.  Use the fallback which writes the same
 		   sdb entries directly. */
 		const char *lang = ctx->lang;
 		bool is_c_like = !lang || !strcmp (lang, "cxx") || !strcmp (lang, "objc");
-		bool imported = false;
 		if (is_c_like) {
 			char *errmsg = NULL;
-			imported = r_anal_import_c_decls (anal, csig, &errmsg);
-			if (!imported && errmsg) {
+			if (!r_anal_import_c_decls (anal, csig, &errmsg) && errmsg) {
 				R_LOG_DEBUG ("DWARF type import fallback for %s: %s", typed_name, errmsg);
 			}
 			free (errmsg);
 		}
-		if (!imported) {
-			(void)import_dwarf_function_fallback (anal, typed_name, ret_type, variables, has_unspecified_parameters);
+		if (!dwarf_function_type_matches (anal->sdb_types, typed_name,
+				ret_type, variables, has_unspecified_parameters)) {
+			/* The C importer can fail or normalize the declaration into a
+			   different prototype. Replace only the function record; the
+			   types it references stay registered. */
+			r_anal_function_del_signature (anal, typed_name);
+			import_dwarf_function_fallback (anal, typed_name, ret_type, variables, has_unspecified_parameters);
 		}
 	}
 	if (dwarf_fcn->prototype_complete && dwarf_function_type_matches (anal->sdb_types,
 			typed_name, ret_type, variables, has_unspecified_parameters)) {
-		const char *linked = sdb_const_getf (anal->sdb_types, NULL,
-			"fcnlink.%08" PFMT64x, dwarf_fcn->addr);
-		if (!linked || !strcmp (linked, typed_name)) {
-			sdb_setf (anal->sdb_types, typed_name, 0,
-				"fcnlink.%08" PFMT64x, dwarf_fcn->addr);
-		}
+		sdb_setf (anal->sdb_types, typed_name, 0, "fcnlink.%08" PFMT64x, dwarf_fcn->addr);
 	}
 	free (csig);
 }

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -882,10 +882,10 @@ R_API void r_type_del(Sdb *TDB, const char *name) {
 	}
 }
 
-// Strip leading __ prefix for type database lookup
-// This allows __strcpy_chk to match strcpy_chk in the database
-static inline const char *trim_lodashes(const char *name) {
-	while (r_str_startswith (name, "__")) {
+// Strip leading __ prefix for type database lookup when the exact name
+// is not registered. This allows __strcpy_chk to match strcpy_chk
+static inline const char *trim_lodashes(Sdb *TDB, const char *name) {
+	while (!sdb_const_get (TDB, name, 0) && r_str_startswith (name, "__")) {
 		name += 2;
 	}
 	return name;
@@ -893,23 +893,23 @@ static inline const char *trim_lodashes(const char *name) {
 
 // Function prototypes api
 R_API int r_type_func_exist(Sdb *TDB, const char *func_name) {
-	const char *fcn = sdb_const_get (TDB, trim_lodashes (func_name), 0);
+	const char *fcn = sdb_const_get (TDB, trim_lodashes (TDB, func_name), 0);
 	return fcn && !strcmp (fcn, "func");
 }
 
 R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name) {
-	return sdb_const_getf (TDB, NULL, "func.%s.ret", trim_lodashes (func_name));
+	return sdb_const_getf (TDB, NULL, "func.%s.ret", trim_lodashes (TDB, func_name));
 }
 
 R_API int r_type_func_args_count(Sdb *TDB, const char *R_NONNULL func_name) {
-	return sdb_num_getf (TDB, NULL, "func.%s.args", trim_lodashes (func_name));
+	return sdb_num_getf (TDB, NULL, "func.%s.args", trim_lodashes (TDB, func_name));
 }
 
 R_API R_OWNED char *r_type_func_args_type(Sdb *TDB, const char *R_NONNULL func_name, int i) {
-	const char *value = sdb_const_getf (TDB, NULL, "func.%s.arg.%d", trim_lodashes (func_name), i);
+	const char *value = sdb_const_getf (TDB, NULL, "func.%s.arg.%d", trim_lodashes (TDB, func_name), i);
 	char *ret = value? strdup (value): NULL;
 	if (ret) {
-		char *comma = strchr (ret, ',');
+		char *comma = strrchr (ret, ',');
 		if (comma) {
 			*comma = 0;
 		}
@@ -923,9 +923,9 @@ static const char *const argnames[10] = {
 };
 
 R_API const char *r_type_func_args_name(Sdb *TDB, const char *R_NONNULL func_name, int i) {
-	const char *row = sdb_const_getf (TDB, NULL, "func.%s.arg.%d", trim_lodashes (func_name), i);
+	const char *row = sdb_const_getf (TDB, NULL, "func.%s.arg.%d", trim_lodashes (TDB, func_name), i);
 	if (row) {
-		const char *ret = strchr (row, ',');
+		const char *ret = strrchr (row, ',');
 		if (ret) {
 			return ret + 1;
 		}

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -107,6 +107,40 @@ Mammal_401300
 EOF
 RUN
 
+NAME="DWARF prototype with __ prefix is linked"
+FILE=bins/elf/analysis/guess-number-riscv64
+CMDS=<<EOF
+k anal/types/fcnlink.0001ffbc
+af @ 0x1ffbc
+afs @ 0x1ffbc
+iddi
+k anal/dwarf/fcn.__adddf3.typed_name
+EOF
+EXPECT=<<EOF
+__adddf3
+FLO_type __adddf3 (FLO_type arg_a, FLO_type arg_b);
+__adddf3
+EOF
+RUN
+
+NAME="DWARF prototype with commas in argument types is linked"
+FILE=bins/elf/dwarf_rust_bubble
+CMDS=<<EOF
+k anal/types/fcnlink.00025ad0
+af @ 0x25ad0
+afs @ 0x25ad0
+iddi
+k anal/dwarf/fcn.check.typed_name
+k anal/types/fcnlink.00025ad0
+EOF
+EXPECT=<<EOF
+check
+bool check (u16 x, &[(u8, u8)] singletonuppers, &[u8] singletonlowers, &[u8] normal);
+check
+check
+EOF
+RUN
+
 NAME=test dwarf2
 FILE=bins/elf/dwarf/hello-dwarf2
 CMDS=<<EOF

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -35,7 +35,7 @@ int overridden (int x);
 EOF
 RUN
 
-NAME="DWARF link skips prototypes normalized by the C parser"
+NAME="DWARF prototype normalized by the C parser is repaired and linked"
 FILE=bins/elf/dwarf_go_tree
 CMDS=<<EOF
 k anal/dwarf/fcn.unicode_utf8_RuneCount.csig
@@ -46,8 +46,64 @@ afs @ 0x4635a0
 EOF
 EXPECT=<<EOF
 void unicode_utf8_RuneCount([]uint8 p,int ~r1);
-int ~,r1
-void sym.unicode_utf8.RuneCount (int64_t arg_20h, int64_t arg_28h, int64_t arg_38h);
+int,~r1
+unicode_utf8_RuneCount
+void unicode_utf8_RuneCount ([]uint8 p, int ~r1);
+EOF
+RUN
+
+NAME="DWARF mismatch preserves registered type and stable name"
+FILE=bins/elf/dwarf3_cpp.elf
+ARGS=-e bin.dbginfo=false -e asm.dwarf=false
+CMDS=<<EOF
+t- fly
+e bin.dbginfo=true
+iddi
+aaa
+tf- fly
+k anal/types/fly=func
+k anal/types/func.fly.ret=FutureType *
+k anal/types/func.fly.args=0
+k anal/types/func.fly.cc=cdecl
+k anal/types/func.fly=
+iddi
+aaa
+k anal/dwarf/fcn.fly.typed_name
+k anal/types/fcnlink.0000137a~?
+afs @ 0x137a
+iddi
+k anal/dwarf/fcn.fly.typed_name
+k anal/types/func.fly.ret
+k anal/types/*~^fly_137a~?
+EOF
+EXPECT=<<EOF
+fly
+0
+FutureType * fly ();
+fly
+FutureType *
+0
+EOF
+RUN
+
+NAME="DWARF function typed name moves off a colliding struct on reimport"
+FILE=bins/elf/dwarf4_many_comp_units.elf
+CMDS=<<EOF
+k anal/dwarf/fcn.Mammal.typed_name
+iddi
+k anal/dwarf/fcn.Mammal.typed_name
+k anal/types/Mammal
+af @ 0x401300
+afs @ 0x401300
+iddi
+k anal/dwarf/fcn.Mammal.typed_name
+EOF
+EXPECT=<<EOF
+Mammal
+Mammal_401300
+struct
+void Mammal_401300 (Mammal *this);
+Mammal_401300
 EOF
 RUN
 

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -15,6 +15,8 @@ FILE=bins/elf/dwarf3_cpp.elf
 CMDS=<<EOF
 e asm.dwarf=false
 aaa
+k anal/types/fcnlink.00001169
+afs @ 0x1169
 k anal/types/fcnlink.0000130e
 afs @ 0x130e
 aaa
@@ -24,10 +26,28 @@ tl overridden = 0x130e
 afs @ 0x130e
 EOF
 EXPECT=<<EOF
+main_1169
+int main_1169 ();
 Bird_Bird_
 void Bird_Bird_ (Bird * const this);
 void Bird_Bird_ (Bird * const this);
 int overridden (int x);
+EOF
+RUN
+
+NAME="DWARF link skips prototypes normalized by the C parser"
+FILE=bins/elf/dwarf_go_tree
+CMDS=<<EOF
+k anal/dwarf/fcn.unicode_utf8_RuneCount.csig
+k anal/types/func.unicode_utf8_RuneCount.arg.1
+k anal/types/fcnlink.004635a0
+af @ 0x4635a0
+afs @ 0x4635a0
+EOF
+EXPECT=<<EOF
+void unicode_utf8_RuneCount([]uint8 p,int ~r1);
+int ~,r1
+void sym.unicode_utf8.RuneCount (int64_t arg_20h, int64_t arg_28h, int64_t arg_38h);
 EOF
 RUN
 


### PR DESCRIPTION
## PR 26455: Link DWARF types only when prototypes match

### What it does (one line)
Only install the `fcnlink.<addr>` address link when the type stored in
`sdb_types` actually has the same shape (return type, arg count, arg types,
variadic) as the prototype DWARF describes. Before, the link was installed as
soon as the type existed, even if `r_anal_import_c_decls` had normalized the
declaration into something else.

### Why
The C importer can rewrite declarations while importing (known case: `main`
gets conventional parameters appended; typedef resolution can also change the
spelling). With the old code, `afs` would then authoritatively show the
importer's shape as if DWARF said so. This PR makes the link fail-closed:
no exact match, no link.

### Behavior change
- Functions whose imported type round-trips exactly: unchanged, link installed.
- Functions where the importer changed the shape: **no address link anymore**.
  They fall back to the old name-based signature lookup, i.e. exactly the
  pre-fcnlink behavior. Nothing is deleted, no metadata is lost.
- Non-C languages (Rust, Go...) use the fallback writer which stores types
  verbatim, so they always match and always keep their links.

### Pros
- A wrong authoritative signature is worse than no signature; this removes the
  only known path that could install a wrong one.
- Reuses the existing `dwarf_function_type_matches` helper; +26/-11 lines, no
  new APIs, no format changes, no extra sdb walk when the match was already
  verified during name selection.
- Test pins both sides: `main` (collides with libc main from the types db,
  gets suffixed to `main_1169`, links with exact `int main_1169 ();`) and the
  C++ ctor (`Bird * const this` survives the C parser round-trip and stays
  linked).

### Cons / what you might not want
- The match is a strict per-arg `strcmp`: a type the importer spells
  differently but equivalently (qualifier order, resolved typedef) also loses
  its link. Conservative by design; if this turns out common, the fix is
  canonicalizing both sides through one serializer, not loosening the compare.
- The skip is silent: no log when a link is withheld, so "why does afs not
  show my dwarf signature" needs debugging. A one-line R_LOG_DEBUG would help.
- Cosmetic (preexisting, now visible in the test): colliding names get an
  address suffix, so `afs` shows `main_1169` instead of `main`.

### How to test
    r2 -q -c 'e asm.dwarf=false; aaa; afs @ 0x1169; afs @ 0x130e; k anal/types/fcnlink.00001169' bins/elf/dwarf3_cpp.elf
Expect `int main_1169 ();`, `void Bird_Bird_ (Bird * const this);` and the
fcnlink key present. Then check any binary with DWARF where the C importer
rewrites a prototype: the address must have NO fcnlink key and afs must show
the legacy signature, never the importer's rewritten one attributed to DWARF.

### Verdict
Safe to merge: strictly reduces the cases where a link is installed, never
produces new output, and every skipped case degrades to pre-26451 behavior.