### PR TITLE
Name PLT stubs of locally defined functions as sym.plt.<target> ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -15,10 +15,12 @@
 #define RISCV_PLT_OFFSET 0x20
 #define LOONGARCH_PLT_OFFSET 0x20
 #define S390_PLT_OFFSET 0x20
+#define ARM64_PLT_OFFSET 0x20
 
 #define RISCV_PLT_ENTRY_SIZE 0x10
 #define LOONGARCH_PLT_ENTRY_SIZE 0x10
 #define X86_PLT_ENTRY_SIZE 0x10
+#define ARM64_PLT_ENTRY_SIZE 0x10
 
 #define SPARC_OFFSET_PLT_ENTRY_FROM_GOT_ADDR -0x6
 #define X86_OFFSET_PLT_ENTRY_FROM_GOT_ADDR -0x6
@@ -1718,7 +1720,45 @@ static ut64 get_import_addr_arm(ELFOBJ *eo, RBinElfReloc *rel) {
 	return UT64_MAX;
 }
 
-static ut64 get_import_addr_arm64(ELFOBJ *eo, RBinElfReloc *rel) {
+static size_t get_size_rel_mode(Elf_(Xword) mode) {
+	if (mode == DT_RELA) {
+		return sizeof (Elf_(Rela));
+	} else if (mode == DT_REL) {
+		return sizeof (Elf_(Rel));
+	} else if (mode == DT_CREL) {
+		// CREL is variable-length, this is only a placeholder size
+		return sizeof (Elf_(Rela));
+	} else if (mode == DT_RELR) {
+		// RELR entries are the size of an address
+		return sizeof (Elf_(Addr));
+	}
+	return 0;
+}
+
+static ut64 get_num_relocs_dynamic_plt(ELFOBJ *eo) {
+	if (eo->dyn_info.dt_pltrelsz) {
+		const ut64 size = eo->dyn_info.dt_pltrelsz;
+		const ut64 relsize = get_size_rel_mode (eo->dyn_info.dt_pltrel);
+		return relsize ? size / relsize : 0;
+	}
+	return 0;
+}
+
+// the stride is only known when the section accounts for every reloc exactly
+static bool arm64_plt_entry_vouched(ELFOBJ *eo, ut64 pos) {
+	RBinElfSection *plt = get_section_by_name (eo, ".plt");
+	if (!plt || plt->size <= ARM64_PLT_OFFSET) {
+		return false;
+	}
+	const ut64 nrel = get_num_relocs_dynamic_plt (eo);
+	return pos < nrel && plt->size - ARM64_PLT_OFFSET == nrel * ARM64_PLT_ENTRY_SIZE;
+}
+
+static ut64 get_import_addr_arm64(ELFOBJ *eo, RBinElfReloc *rel, ut64 *size) {
+	// only a jump slot names a plt entry, so nothing else may vouch for a size
+	if (rel->type != R_AARCH64_JUMP_SLOT) {
+		size = NULL;
+	}
 	ut64 got_addr = eo->dyn_info.dt_pltgot;
 	if (got_addr == R_BIN_ELF_ADDR_MAX) {
 		return UT64_MAX;
@@ -1735,21 +1775,23 @@ static ut64 get_import_addr_arm64(ELFOBJ *eo, RBinElfReloc *rel) {
 	case R_AARCH64_RELATIVE:
 		// Direct binding: adjust by program base for relative relocations.
 		return eo->baddr + rel->addend;
-	case R_AARCH64_IRELATIVE:
-		if (rel->addend > plt_addr) { // start
-			return (plt_addr + pos * 16 + 32) + rel->addend;
-		}
-		// same as fallback to JUMP_SLOT
-		return plt_addr + pos * 16 + 32;
-	case R_AARCH64_JUMP_SLOT:
-		return plt_addr + pos * 16 + 32;
 	case R_AARCH64_GLOB_DAT:
 		return rel->rva;
+	case R_AARCH64_IRELATIVE:
+	case R_AARCH64_JUMP_SLOT:
+		break;
 	default:
 		R_LOG_WARN ("Unsupported relocation type for imports %d", rel->type);
 		return UT64_MAX;
 	}
-	return UT64_MAX;
+	const ut64 entry = plt_addr + pos * ARM64_PLT_ENTRY_SIZE + ARM64_PLT_OFFSET;
+	if (size && arm64_plt_entry_vouched (eo, pos)) {
+		*size = ARM64_PLT_ENTRY_SIZE;
+	}
+	if (rel->type == R_AARCH64_IRELATIVE && rel->addend > plt_addr) { // start
+		return entry + rel->addend;
+	}
+	return entry;
 }
 
 static ut64 get_import_addr_mips(ELFOBJ *bin, RBinElfReloc *rel) {
@@ -1793,31 +1835,6 @@ static ut64 get_import_addr_loongarch(ELFOBJ *bin, RBinElfReloc *rel) {
 		}
 	}
 	return UT64_MAX;
-}
-
-static size_t get_size_rel_mode(Elf_(Xword) mode) {
-	if (mode == DT_RELA) {
-		return sizeof (Elf_(Rela));
-	} else if (mode == DT_REL) {
-		return sizeof (Elf_(Rel));
-	} else if (mode == DT_CREL) {
-		// CREL uses variable-length encoding, but we need to return a size for alignment
-		// This is just a placeholder - actual parsing will be different
-		return sizeof (Elf_(Rela));
-	} else if (mode == DT_RELR) {
-		// RELR entries are the size of an address
-		return sizeof (Elf_(Addr));
-	}
-	return 0;
-}
-
-static ut64 get_num_relocs_dynamic_plt(ELFOBJ *eo) {
-	if (eo->dyn_info.dt_pltrelsz) {
-		const ut64 size = eo->dyn_info.dt_pltrelsz;
-		const ut64 relsize = get_size_rel_mode (eo->dyn_info.dt_pltrel);
-		return relsize ? size / relsize : 0;
-	}
-	return 0;
 }
 
 static ut64 get_import_addr_sparc(ELFOBJ *eo, RBinElfReloc *rel) {
@@ -1928,11 +1945,19 @@ ut64 Elf_(ppc64_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
 	return UT64_MAX;
 }
 
-static ut64 get_import_addr_ppc(ELFOBJ *eo, RBinElfReloc *rel) {
+static ut64 get_import_addr_ppc(ELFOBJ *eo, RBinElfReloc *rel, ut64 *size) {
+	if (rel->type != R_PPC_JMP_SLOT) {
+		size = NULL;
+	}
 #if R_BIN_ELF64
-	if (ppc64_abi (eo)) {
+	const int abi = ppc64_abi (eo);
+	if (abi) {
 		ut64 stub = Elf_(ppc64_get_plt_stub_for_slot) (eo, rel->rva);
 		if (stub != UT64_MAX) {
+			if (size) {
+				// an ELFv2 stub is a single branch, an ELFv1 one is a pair
+				*size = (abi == 2)? 4: 8;
+			}
 			return stub;
 		}
 		return rel->rva; // no DT_PPC64_GLINK or no map entry
@@ -2038,46 +2063,47 @@ static ut64 get_import_addr_x86_manual(ELFOBJ *eo, RBinElfReloc *rel) {
 	return UT64_MAX;
 }
 
-static ut64 get_import_addr_x86(ELFOBJ *eo, RBinElfReloc *rel) {
-	ut64 tmp = get_got_entry (eo, rel);
+static ut64 get_import_addr_x86(ELFOBJ *eo, RBinElfReloc *rel, ut64 *size) {
+	if (rel->type != R_386_JMP_SLOT && rel->type != R_X86_64_JUMP_SLOT) {
+		size = NULL;
+	}
+	const ut64 tmp = get_got_entry (eo, rel);
 	if (tmp == UT64_MAX) {
 		return get_import_addr_x86_manual (eo, rel);
 	}
 	RBinElfSection *pltsec = get_section_by_name (eo, ".plt.sec");
 	if (pltsec) {
-		ut64 got_addr = eo->dyn_info.dt_pltgot;
-		ut64 pos = COMPUTE_PLTGOT_POSITION (rel, got_addr, 3);
+		const ut64 got_addr = eo->dyn_info.dt_pltgot;
+		const ut64 pos = COMPUTE_PLTGOT_POSITION (rel, got_addr, 3);
+		// an index past the end of the section is not an entry to vouch for
+		if (size && got_addr != R_BIN_ELF_ADDR_MAX && pos < pltsec->size / X86_PLT_ENTRY_SIZE) {
+			*size = X86_PLT_ENTRY_SIZE;
+		}
 		return pltsec->rva + pos * X86_PLT_ENTRY_SIZE;
 	}
-	return tmp + X86_OFFSET_PLT_ENTRY_FROM_GOT_ADDR;
+	const ut64 classic = tmp + X86_OFFSET_PLT_ENTRY_FROM_GOT_ADDR;
+	// a prelinked slot holds the target, not entry+6, so demand a real entry
+	if (size && !(classic & (X86_PLT_ENTRY_SIZE - 1))) {
+		RBinElfSection *plt = get_section_by_name (eo, ".plt");
+		if (plt && classic >= plt->rva && classic - plt->rva < plt->size) {
+			*size = X86_PLT_ENTRY_SIZE;
+		}
+	}
+	return classic;
 }
 
-static ut64 get_import_addr(ELFOBJ *eo, int sym) {
-	if ((!eo->shdr || !eo->strtab) && !eo->phdr) {
-		return UT64_MAX;
+// size stays 0 unless the arch can vouch for the address it derived
+static ut64 get_plt_stub_addr(ELFOBJ *eo, RBinElfReloc *rel, ut64 *size) {
+	if (size) {
+		*size = 0;
 	}
-
-	if (!eo->rel_cache) {
-		return UT64_MAX;
-	}
-
-	int index = ht_uu_find (eo->rel_cache, sym + 1, NULL);
-	if (index < 1) {
-		return UT64_MAX;
-	}
-	// lookup the right rel/rela entry
-	RBinElfReloc *rel = RVecRBinElfReloc_at (&eo->g_relocs, index - 1);
-	if (!rel) {
-		return UT64_MAX;
-	}
-
 	switch (eo->ehdr.e_machine) {
 	case EM_S390:
 		return get_import_addr_s390x (eo, rel);
 	case EM_ARM:
 		return get_import_addr_arm (eo, rel);
 	case EM_AARCH64:
-		return get_import_addr_arm64 (eo, rel);
+		return get_import_addr_arm64 (eo, rel, size);
 	case EM_MIPS: // MIPS32 BIG ENDIAN relocs
 		return get_import_addr_mips (eo, rel);
 	case EM_QDSP6: // also known as HEXAGON
@@ -2093,11 +2119,11 @@ static ut64 get_import_addr(ELFOBJ *eo, int sym) {
 		return get_import_addr_sparc (eo, rel);
 	case EM_PPC:
 	case EM_PPC64:
-		return get_import_addr_ppc (eo, rel);
+		return get_import_addr_ppc (eo, rel, size);
 	case EM_386:
 	case EM_X86_64:
 	case EM_IAMCU:
-		return get_import_addr_x86 (eo, rel);
+		return get_import_addr_x86 (eo, rel, size);
 	case EM_LOONGARCH:
 		return get_import_addr_loongarch (eo, rel);
 	case EM_SBPF:
@@ -2115,6 +2141,25 @@ static ut64 get_import_addr(ELFOBJ *eo, int sym) {
 				(ut64) rel->type, eo->ehdr.e_machine);
 		return UT64_MAX;
 	}
+}
+
+static ut64 get_import_addr(ELFOBJ *eo, int sym) {
+	if ((!eo->shdr || !eo->strtab) && !eo->phdr) {
+		return UT64_MAX;
+	}
+	if (!eo->rel_cache) {
+		return UT64_MAX;
+	}
+	int index = ht_uu_find (eo->rel_cache, sym + 1, NULL);
+	if (index < 1) {
+		return UT64_MAX;
+	}
+	// lookup the right rel/rela entry
+	RBinElfReloc *rel = RVecRBinElfReloc_at (&eo->g_relocs, index - 1);
+	if (!rel) {
+		return UT64_MAX;
+	}
+	return get_plt_stub_addr (eo, rel, NULL);
 }
 
 bool Elf_(has_nobtcfi)(ELFOBJ *eo) {
@@ -5882,6 +5927,111 @@ RVecRBinImport *Elf_(load_imports_vec)(ELFOBJ *eo) {
 	return &eo->imports_cache;
 }
 
+// the executable ranges are file constants, so collect them once
+static RInterval *exec_ranges(ELFOBJ *eo, size_t *count) {
+	(void) _load_elf_sections (eo);
+	const size_t nsec = RVecRBinElfSection_length (&eo->g_sections);
+	RInterval *ranges = R_NEWS0 (RInterval, R_MAX (nsec, eo->phnum) + 1);
+	if (!ranges) {
+		*count = 0;
+		return NULL;
+	}
+	size_t n = 0;
+	RBinElfSection *sec;
+	// r_itv_contain inverts a wrapping range, so drop the broken ones here
+	R_VEC_FOREACH (&eo->g_sections, sec) {
+		if (R_BIN_ELF_SCN_IS_EXECUTABLE (sec->flags) && sec->rva + sec->size > sec->rva) {
+			ranges[n].addr = sec->rva;
+			ranges[n].size = sec->size;
+			n++;
+		}
+	}
+	// section-less objects still carry the segment permissions
+	if (!n && eo->phdr) {
+		size_t i;
+		for (i = 0; i < eo->phnum; i++) {
+			Elf_(Phdr) *p = &eo->phdr[i];
+			if (p->p_type == PT_LOAD && (p->p_flags & PF_X) && p->p_vaddr + p->p_memsz > p->p_vaddr) {
+				ranges[n].addr = p->p_vaddr;
+				ranges[n].size = p->p_memsz;
+				n++;
+			}
+		}
+	}
+	*count = n;
+	return ranges;
+}
+
+// the per-arch stub math is best effort, so it only counts if it lands in code
+static bool is_code_addr(const RInterval *ranges, size_t count, ut64 vaddr) {
+	size_t i;
+	for (i = 0; i < count; i++) {
+		if (r_itv_contain (ranges[i], vaddr)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// a -fPIC object calls its own globals through the plt, never as imports
+static void load_local_plt_symbols(ELFOBJ *eo) {
+	// symbols_vec fills symbols_by_ord before it asks for the plt symbols
+	if (!eo->symbols_by_ord) {
+		return;
+	}
+	HtUU *seen = ht_uu_new0 ();
+	size_t nranges = 0;
+	RInterval *ranges = exec_ranges (eo, &nranges);
+	if (!seen || !nranges) {
+		ht_uu_free (seen);
+		free (ranges);
+		return;
+	}
+	RBinSymbol *ps;
+	R_VEC_FOREACH (&eo->plt_symbols_cache, ps) {
+		ht_uu_insert (seen, ps->vaddr, 1);
+	}
+	RBinElfReloc *rel;
+	R_VEC_FOREACH (&eo->g_relocs, rel) {
+		// laddr means the got scan already resolved this reloc to a stub
+		if (rel->sym < 1 || rel->laddr || (size_t)rel->sym >= eo->symbols_by_ord_size) {
+			continue;
+		}
+		RBinSymbol *target = eo->symbols_by_ord[rel->sym];
+		if (!target || target->is_imported || !target->vaddr || target->vaddr == UT64_MAX
+				|| !target->type || strcmp (target->type, R_BIN_TYPE_FUNC_STR)) {
+			continue;
+		}
+		const char *tname = r_bin_name_tostring2 (target->name, 'o');
+		if (R_STR_ISEMPTY (tname)) {
+			continue;
+		}
+		// a zero size means the arch could not vouch for the address
+		ut64 stub_size = 0;
+		const ut64 stub = get_plt_stub_addr (eo, rel, &stub_size);
+		if (!stub_size || stub == UT64_MAX || stub == target->vaddr
+				|| !is_code_addr (ranges, nranges, stub)) {
+			continue;
+		}
+		// insert fails when the address is already claimed by another reloc
+		if (!ht_uu_insert (seen, stub, 1)) {
+			continue;
+		}
+		RBinSymbol sym = {0};
+		sym.name = r_bin_name_new_from (r_str_newf ("plt.%s", tname));
+		sym.forwarder = "NONE";
+		sym.bind = target->bind;
+		sym.type = target->type;
+		sym.size = stub_size;
+		sym.ordinal = rel->sym;
+		sym.vaddr = stub;
+		sym.paddr = Elf_(v2p) (eo, stub);
+		RVecRBinSymbol_push_back (&eo->plt_symbols_cache, &sym);
+	}
+	free (ranges);
+	ht_uu_free (seen);
+}
+
 RVecRBinSymbol *Elf_(load_plt_symbols_vec)(ELFOBJ *eo) {
 	R_RETURN_VAL_IF_FAIL (eo, NULL);
 	if (eo->plt_symbols_cached) {
@@ -5913,6 +6063,7 @@ RVecRBinSymbol *Elf_(load_plt_symbols_vec)(ELFOBJ *eo) {
 		}
 		RVecRBinSymbol_push_back (&eo->plt_symbols_cache, &sym);
 	}
+	load_local_plt_symbols (eo);
 	eo->plt_symbols_cached = true;
 	return &eo->plt_symbols_cache;
 }

--- a/test/db/anal/autoname
+++ b/test/db/anal/autoname
@@ -1,12 +1,24 @@
-NAME=autonaming elf
+NAME=af names a local plt stub from its bin symbol
 FILE=bins/elf/pltrel/add.so
 CMDS=<<EOF
 s..1050
 af
+afn
+EOF
+EXPECT=<<EOF
+sym.plt.add2
+EOF
+RUN
+
+NAME=autonaming elf
+FILE=bins/elf/pltrel/add.so
+CMDS=<<EOF
+s..1040
+af
 afna
 EOF
 EXPECT=<<EOF
-'0x00001050'afnq sub.add2_1050
+'0x00001040'afnq sub.__cxa_finalize_1040
 EOF
 RUN
 
@@ -27,7 +39,7 @@ EXPECT=<<EOF
       |                         |                      '--------.
       |                         |                               |
 .--------------------.    .---------------------------.   .----------------------------.
-|  sub.add2_1050     |    |  sub.__cxa_finalize_1040  |   |  sym.deregister_tm_clones  |
+|  sym.plt.add2      |    |  sub.__cxa_finalize_1040  |   |  sym.deregister_tm_clones  |
 `--------------------'    `---------------------------'   `----------------------------'
 EOF
 RUN

--- a/test/db/formats/elf/plt-local
+++ b/test/db/formats/elf/plt-local
@@ -1,0 +1,61 @@
+NAME=x86_64 shared lib: PLT stub for a locally defined function gets a symbol
+FILE=bins/elf/pltrel/add.so
+CMDS=is~plt.add2
+EXPECT=<<EOF
+6   0x00001050 0x00001050 GLOBAL FUNC   16       plt.add2
+EOF
+RUN
+
+NAME=x86_64 shared lib: local PLT stub is flagged in the symbols space
+FILE=bins/elf/pltrel/add.so
+CMDS=<<EOF
+fs symbols
+f~plt
+EOF
+EXPECT=<<EOF
+0x00001050 16 sym.plt.add2
+EOF
+RUN
+
+NAME=x86_64 shared lib: call through a local PLT stub names its target
+FILE=bins/elf/pltrel/add.so
+CMDS=<<EOF
+aa
+pd 1 @ 0x1135
+EOF
+EXPECT=<<EOF
+|           0x00001135      e816ffffff     call sym.plt.add2
+EOF
+RUN
+
+NAME=x86_64 shared lib: a locally defined stub target is not an import
+FILE=bins/elf/pltrel/add.so
+CMDS=ii~add2
+EXPECT=<<EOF
+EOF
+RUN
+
+NAME=ELF v1 shared lib: local GLINK stubs get symbols
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=is~plt.inflateReset[2]
+EXPECT=<<EOF
+0x00019544
+0x00019614
+0x0001962c
+EOF
+RUN
+
+NAME=ELF v1 shared lib: a GLINK stub is two instructions, not a flat 16 bytes
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=is~plt.crc32_z
+EXPECT=<<EOF
+29  0x000194cc 0x000194cc GLOBAL FUNC   8         plt.crc32_z
+EOF
+RUN
+
+NAME=ELF v1 exec: no local PLT stubs without locally defined stub targets
+FILE=bins/elf/ppc64v1-more
+CMDS=is~plt.
+EXPECT=<<EOF
+EOF
+RUN

--- a/test/db/perf/elf
+++ b/test/db/perf/elf
@@ -4,7 +4,7 @@ CMDS=<<EOF
 isq~?
 EOF
 EXPECT=<<EOF
-10921
+10925
 EOF
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A `-fPIC` object calls its own globals through the PLT, and those stubs carry no import, so they stayed anonymous — on `bins/elf/pltrel/add.so` the call site reads `call section..plt.sec`, or `call fcn.00001050` after `aa`, even though the disassembler already renders the stub body as `jmp qword [reloc.add2]`. This names them `sym.plt.<target>` in the symbols flagspace.

#26435 reduced to what you asked for: the loop plus the minimum evidence it needs. `get_import_addr` splits into a reloc-keyed `get_plt_stub_addr` and the index lookup, and the per-arch resolvers fill a nullable `ut64 *size` — **0 means the arch cannot vouch for the address**, so a guess never becomes a symbol. Only already-exact layouts vouch here (x86 `.plt.sec` and classic entries landing inside `.plt`, aarch64 when `.plt` accounts for every reloc at 16 bytes, ppc64 glink); hardened layouts decline and emit nothing. The per-arch geometry that turns those on follows in separate PRs.

No import address moves in this PR.

Tests: new `test/db/formats/elf/plt-local`; `db/anal/autoname` gains the stub-naming case and its graph golden follows; `db/perf/elf` glibc count 10921 → 10925. Full local r2r gate clean.

For context, the full split, in landing order — each stacked on the previous, so a PR's diff shows its ancestors until the one before it merges:

1. `elf-plt-local-stub-names` (this PR) Name PLT stubs of locally defined functions as sym.plt.\<target\> ##bin
2. `elf-plt-aarch64-entry-stride` Fix aarch64 plt entry stride for pac-plt and bti-plt layouts ##bin
3. `elf-plt-x86-retpoline` Resolve x86 lld retpoline plt entries for imports and local stubs ##bin
4. `elf-plt-ppc-thunk-map` Decode ppc32 plt call thunks and size ppc64 glink stubs ##bin
5. `elf-plt-ppc64v1-text-stubs` Name ppc64 ELFv1 text call stubs after the plt slot they dispatch through ##bin
6. `anal-plt-stub-arg-join` Recover caller arguments through plt stubs by joining on the symbol name ##analysis

2–4 are the per-arch import-math fixes; 5 is the ELFv1 `.text` stub enumeration; 6 replaces #26436 with the name join.

| # | branch | code | tests | total |
|---|---|---|---|---|
| 1 | `elf-plt-local-stub-names` | +214 −63 | +77 −4 | **+291 −67** |
| 2 | `elf-plt-aarch64-entry-stride` | +111 −10 | +100 | **+211 −10** |
| 3 | `elf-plt-x86-retpoline` | +117 −10 | +50 | **+167 −10** |
| 4 | `elf-plt-ppc-thunk-map` | +208 −28 | +80 | **+288 −28** |
| 5 | `elf-plt-ppc64v1-text-stubs` | +236 −15 | +102 −19 | **+338 −34** |
| 6 | `anal-plt-stub-arg-join` | +103 −55 | +69 | **+172 −55** |
| | **series** | +989 −181 | +478 −23 | **+1467 −204** |

Branch 1 is smaller than it looks: ~40–45 of its 214 code insertions are pure movement (splitting `get_import_addr` into the reloc-keyed resolver plus the index lookup, and hoisting `get_size_rel_mode`/`get_num_relocs_dynamic_plt` above the arm64 code), so net-new is nearer +170/−20. The naming loop proper is ~110 lines