### PR TITLE
Fix potential iob_net decrypt bug

### DIFF
--- a/shlr/winkd/iob_net.c
+++ b/shlr/winkd/iob_net.c
@@ -303,6 +303,12 @@ static ut8 *_createKDNetPacket(iobnet_t *obj, const ut8 *buf, int size, int *osi
 
 static bool _decrypt(iobnet_t *obj, ut8 *buf, int size, int type) {
 	bool ret = false;
+
+	if (size < KDNET_DATA_SIZE + KDNET_HMAC_SIZE) {
+		R_LOG_ERROR ("KdNet packet too small");
+		return ret;
+	}
+
 	RMutaBind *mb = _get_mb (obj);
 	if (!mb) {
 		return false;
@@ -326,10 +332,6 @@ static bool _decrypt(iobnet_t *obj, ut8 *buf, int size, int type) {
 		break;
 	default:
 		goto end;
-	}
-
-	if (size < KDNET_HMAC_SIZE) {
-    	goto end;
 	}
 
 	// Set IV to the 16 bytes HMAC at the end of KDNet packet
@@ -364,6 +366,10 @@ end:
 static bool _sendResponsePacket(iobnet_t *obj, const ut8 *pokedata) {
 	size_t i;
 	int size;
+
+	if (obj->size < 10 + 32 + sizeof (kdnet_packet_t)) {
+		return false;
+	}
 
 	// Create the following buffer as the KD packet in the KDNet Response packet:
 	// 0x01
@@ -428,7 +434,7 @@ static bool _processControlPacket(iobnet_t *obj, const ut8 *ctrlbuf, int size) {
 	return true;
 }
 
-bool _verifyhmac(iobnet_t *obj) {
+static bool _verifyhmac(iobnet_t *obj) {
 	RMutaBind *mb = _get_mb (obj);
 	if (!mb) {
 		return false;

--- a/shlr/winkd/iob_net.c
+++ b/shlr/winkd/iob_net.c
@@ -328,6 +328,10 @@ static bool _decrypt(iobnet_t *obj, ut8 *buf, int size, int type) {
 		goto end;
 	}
 
+	if (size < KDNET_HMAC_SIZE) {
+    	goto end;
+	}
+
 	// Set IV to the 16 bytes HMAC at the end of KDNet packet
 	if (!mb->muta_session_set_iv (cj, buf + size - KDNET_HMAC_SIZE, KDNET_HMAC_SIZE)) {
 		goto end;


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

For this one I don't have a test input and the fix is so simple that I decided to not do an issue.
For example, this memcpy is wrong if **size < KDNET_HMAC_SIZE**
```c
memcpy (buf, decbuf, size - KDNET_HMAC_SIZE);
```
The PR addresses that
