### PR TITLE
Name local plt stubs in x86 retpoline layouts ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -5823,14 +5823,14 @@ static void plt_stub_flag(RCore *core, ut64 entry, ut64 size, ut64 slot) {
 	free (fname);
 }
 
-// walk the section decoding entries: remember the last lea and load, and when an
-// entry ends in an indirect jump derive the got slot it goes through
+// decode entries, tracking the last lea/load to derive each got slot
 static void plt_stub_scan_section(RCore *core, RBinSection *sec) {
 	if (sec->vsize < 8 || sec->vsize > 0x100000) {
 		return;
 	}
 	const ut64 sec_vaddr = r_bin_get_vaddr (core->bin, sec->paddr, sec->vaddr);
 	const int len = (int)sec->vsize;
+	const ut64 sec_end = sec_vaddr + len;
 	ut8 *buf = malloc (len);
 	if (!buf || !r_io_read_at (core->io, sec_vaddr, buf, len)) {
 		free (buf);
@@ -5840,43 +5840,38 @@ static void plt_stub_scan_section(RCore *core, RBinSection *sec) {
 	ut64 entry = sec_vaddr;
 	ut64 lea_ptr = UT64_MAX;
 	ut64 load_disp = UT64_MAX;
+	// a dereferencing op yields the slot itself, lea/adrp only give its base
+	bool lea_is_load = false;
 	int i = 0;
 	while (i < len) {
 		const ut64 at = sec_vaddr + i;
 		RAnalOp op;
-		const int oplen = r_anal_op (core->anal, &op, at, buf + i, len - i, R_ARCH_OP_MASK_BASIC);
+		int oplen = r_anal_op (core->anal, &op, at, buf + i, len - i, R_ARCH_OP_MASK_BASIC);
 		const int type = op.type & R_ANAL_OP_TYPE_MASK & ~R_ANAL_OP_TYPE_COND;
 		const bool indirect = type == R_ANAL_OP_TYPE_UJMP
 			|| (type == R_ANAL_OP_TYPE_JMP && (op.type & R_ANAL_OP_TYPE_MEM));
 		bool ends = true;
+		ut64 slot = UT64_MAX;
 		if (oplen < 1) {
-			r_anal_op_fini (&op);
-			i += minop;
-			entry = sec_vaddr + i;
-			lea_ptr = UT64_MAX;
-			load_disp = UT64_MAX;
-			continue;
-		}
-		if (indirect) {
+			oplen = minop;
+		} else if (indirect) {
 			// x86 encodes the slot in one op; arm64-alikes split it lea/load/branch
-			ut64 slot = (op.ptr > 0 && op.ptr != -1)? (ut64)op.ptr: UT64_MAX;
+			slot = (op.ptr > 0)? (ut64)op.ptr: UT64_MAX;
 			if (slot == UT64_MAX && lea_ptr != UT64_MAX && load_disp != UT64_MAX) {
 				slot = lea_ptr + load_disp;
-			}
-			if (slot != UT64_MAX) {
-				plt_stub_flag (core, entry, at + oplen - entry, slot);
 			}
 		} else {
 			switch (type) {
 			case R_ANAL_OP_TYPE_LEA:
 			case R_ANAL_OP_TYPE_MOV:
-				if (op.ptr > 0 && op.ptr != -1) {
+				if (op.ptr > 0) {
 					lea_ptr = (ut64)op.ptr;
+					lea_is_load = op.direction == R_ANAL_OP_DIR_READ;
 				}
 				ends = false;
 				break;
 			case R_ANAL_OP_TYPE_LOAD:
-				if (op.ptr > 0 && op.ptr != -1) {
+				if (op.ptr > 0) {
 					// riscv-style loads resolve the slot in the op itself
 					lea_ptr = (ut64)op.ptr;
 					load_disp = 0;
@@ -5887,6 +5882,16 @@ static void plt_stub_scan_section(RCore *core, RBinSection *sec) {
 				break;
 			case R_ANAL_OP_TYPE_JMP:
 			case R_ANAL_OP_TYPE_CALL:
+				// retpoline stubs reach an in-section thunk unconditionally
+				if (lea_ptr != UT64_MAX && !(op.type & R_ANAL_OP_TYPE_COND)
+						&& op.jump >= sec_vaddr && op.jump < sec_end) {
+					if (load_disp != UT64_MAX) {
+						slot = lea_ptr + load_disp;
+					} else if (lea_is_load) {
+						slot = lea_ptr;
+					}
+				}
+				break;
 			case R_ANAL_OP_TYPE_UCALL:
 			case R_ANAL_OP_TYPE_RET:
 			case R_ANAL_OP_TYPE_TRAP:
@@ -5900,12 +5905,16 @@ static void plt_stub_scan_section(RCore *core, RBinSection *sec) {
 				break;
 			}
 		}
+		if (slot != UT64_MAX) {
+			plt_stub_flag (core, entry, at + oplen - entry, slot);
+		}
 		r_anal_op_fini (&op);
 		i += oplen;
 		if (ends) {
 			entry = sec_vaddr + i;
 			lea_ptr = UT64_MAX;
 			load_disp = UT64_MAX;
+			lea_is_load = false;
 		}
 	}
 	free (buf);

--- a/test/db/anal/plt-local
+++ b/test/db/anal/plt-local
@@ -181,3 +181,71 @@ EXPECT=<<EOF2
 0x00025550 11 sym.plt.calloc
 EOF2
 RUN
+
+# the scan flags 12 bytes here, up to the call; the 17 below is what the later
+# function analysis resizes the flag to
+NAME=x86_64 lazy retpoline: stubs calling the shared thunk get named
+FILE=bins/elf/pltrel/x86_64-retpoline.so
+CMDS=<<EOF
+aa
+fs symbols
+f~plt.
+EOF
+EXPECT=<<EOF
+0x000014b0 17 sym.plt.add2
+0x000014d0 17 sym.plt.mul2
+0x000014f0 17 sym.plt.sub2
+EOF
+RUN
+
+NAME=x86_64 lazy retpoline: a call through the stub reads its target name
+FILE=bins/elf/pltrel/x86_64-retpoline.so
+CMDS=<<EOF
+aa
+pd 1 @ 0x144b
+EOF
+EXPECT=<<EOF
+|           0x0000144b      e860000000     call sym.plt.add2
+EOF
+RUN
+
+NAME=x86_64 retpoline with -z now: stubs jumping to the shared thunk get named
+FILE=bins/elf/pltrel/x86_64-retpoline-now.so
+CMDS=<<EOF
+aa
+fs symbols
+f~plt.
+EOF
+EXPECT=<<EOF
+0x00001460 12 sym.plt.add2
+0x00001470 12 sym.plt.mul2
+0x00001480 12 sym.plt.sub2
+EOF
+RUN
+
+NAME=x86_64 retpoline with -z now: a call through the stub reads its target name
+FILE=bins/elf/pltrel/x86_64-retpoline-now.so
+CMDS=<<EOF
+aa
+pd 1 @ 0x140b
+EOF
+EXPECT=<<EOF
+|           0x0000140b      e850000000     call sym.plt.add2
+EOF
+RUN
+
+# 75 e7 is a jne to the same thunk the call at 0x14b7 reaches, then nop padding
+NAME=x86_64 retpoline: a conditional branch to the thunk does not name a stub
+FILE=bins/elf/pltrel/x86_64-retpoline.so
+ARGS=-e io.cache=true
+CMDS=<<EOF
+wx 75e7909090 @ 0x14b7
+aa
+fs symbols
+f~plt.
+EOF
+EXPECT=<<EOF
+0x000014d0 17 sym.plt.mul2
+0x000014f0 17 sym.plt.sub2
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Step 5 of the plan, done the way you recommended — a small extension to #26457's scanner rather than the elf.c byte matcher.

lld's retpoline PLT loads the GOT slot into r11 and then reaches the shared thunk with a direct branch instead of jumping through the  slot, so the scan never saw an indirect terminator. An unconditional call/jmp whose target stays inside the section being scanned now yields a slot candidate too — but only when one is actually complete: a dereferencing load gives the slot outright, a bare lea/adrp  gives a base and is only usable once a displacement has been seen.

```asm
; -z retpolineplt (lazy)          ; -z retpolineplt -z now
14b0: mov r11, [rip+0x2111]       1460: mov r11, [rip+0x1101]
14b7: call 0x14a0                 1467: jmp 0x1440
```

One difference from your sketch: it named only the call-terminated form, but -z now ends in a direct jmp, so accepting only calls leaves that half at zero. Both are handled.

No testbins dependency after all — elf/pltrel/x86_64-retpoline.so and -now.so are already merged, so the five tests land here. caller in both goes from call fcn.000014b0 to call sym.plt.add2.

Section-less retpoline stays at zero, since sections are picked by name — same as every other arch here.