### PR TITLE
Free all flag metadata strings ##analysis

### DIFF
--- a/libr/flag/flag.c
+++ b/libr/flag/flag.c
@@ -268,10 +268,11 @@ static HtPP *flag_ht_name_new(void) {
 
 static void ht_free_meta(HtUPKv *kv) {
 	if (kv) {
-		// free (kv->key);
 		RFlagItemMeta *fim = (RFlagItemMeta *)kv->value;
+		free (fim->type);
 		free (fim->comment);
 		free (fim->color);
+		free (fim->alias);
 		free (fim);
 	}
 }

--- a/test/unit/test_flags.c
+++ b/test/unit/test_flags.c
@@ -151,11 +151,27 @@ bool test_r_flag_rename_unset_all(void) {
 	mu_end;
 }
 
+bool test_r_flag_metadata_lifetime(void) {
+	RFlag *flags = r_flag_new ();
+	mu_assert_notnull (flags, "r_flag_new () failed");
+
+	RFlagItem *fi = r_flag_set (flags, "with_metadata", 1024, 4);
+	mu_assert_notnull (fi, "cannot set flag");
+	mu_assert_streq (r_flag_item_set_type (flags, fi, "function"),
+		"function", "flag type set");
+	mu_assert_streq (r_flag_item_set_alias (flags, fi, "entry0 + 4"),
+		"entry0 + 4", "flag alias set");
+
+	r_flag_free (flags);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_r_flag_get_set);
 	mu_run_test (test_r_flag_by_spaces);
 	mu_run_test (test_r_flag_get_at);
 	mu_run_test (test_r_flag_rename_unset_all);
+	mu_run_test (test_r_flag_metadata_lifetime);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
## Summary

Free the owned flag metadata type and alias strings when the metadata table is destroyed.

## Root cause

The metadata destructor released comments and colors but omitted the other two heap-owned fields, leaking them when a flag store was freed.

## Tests

- Full `make -j`
- Focused `test_flags`, including the new metadata lifecycle case
- Focused test under AddressSanitizer; LeakSanitizer is unavailable on this macOS host
- `git diff --check`