### PR TITLE
Fix xref cleanup ordering and purge

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -301,6 +301,7 @@ R_API void r_anal_free(RAnal *a) {
 		r_bitset_free (a->visited);
 	}
 	r_anal_hint_storage_fini (a);
+	r_anal_xrefs_free (a);
 	r_th_lock_free (a->lock);
 	r_interval_tree_fini (&a->meta);
 	r_unref (a->config);
@@ -315,7 +316,6 @@ R_API void r_anal_free(RAnal *a) {
 	r_anal_pin_fini (a);
 	r_syscall_free (a->syscall);
 	r_unref (a->reg);
-	r_anal_xrefs_free (a);
 	r_list_free (a->threads);
 	r_list_free (a->leaddrs);
 	sdb_free (a->sdb);
@@ -534,6 +534,7 @@ R_API void r_anal_purge(RAnal *anal) {
 	sdb_reset (anal->sdb_cc);
 	r_list_free (anal->fcns);
 	anal->fcns = r_list_newf ((RListFree)r_anal_function_free);
+	(void)r_anal_xrefs_init (anal);
 	r_anal_purge_imports (anal);
 }
 

--- a/test/unit/test_anal_xrefs.c
+++ b/test/unit/test_anal_xrefs.c
@@ -18,8 +18,26 @@ bool test_r_anal_xrefs_count(void) {
 	mu_end;
 }
 
+bool test_r_anal_purge_clears_xrefs(void) {
+	RAnal *anal = r_anal_new ();
+
+	mu_assert_true (r_anal_xrefs_set (anal, 0x1000, 0x2000, R_ANAL_REF_TYPE_CODE),
+		"add xref before purge");
+	mu_assert_eq (r_anal_xrefs_count (anal), 1, "xref exists before purge");
+
+	r_anal_purge (anal);
+	mu_assert_eq (r_anal_xrefs_count (anal), 0, "purge clears xrefs");
+	mu_assert_true (r_anal_xrefs_set (anal, 0x3000, 0x4000, R_ANAL_REF_TYPE_CALL),
+		"xref manager remains usable after purge");
+	mu_assert_eq (r_anal_xrefs_count (anal), 1, "xref added after purge");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_r_anal_xrefs_count);
+	mu_run_test (test_r_anal_purge_clears_xrefs);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
## Summary

- free the xref manager before destroying the analysis lock
- reset xrefs when purging an analysis context
- verify purge clears old references and leaves the manager reusable

## Root cause

`r_anal_free()` destroyed `anal->lock` before calling `r_anal_xrefs_free()`, even though xref cleanup acquires that lock. This could access a destroyed mutex during teardown.

`r_anal_purge()` reset functions, metadata, types, and imports but retained the old xref manager, allowing references from the previous analysis to survive into the next one.

## Validation

- clean build from current upstream `master`
- `test_anal_xrefs`: 2/2 passing
- `git diff --check`
