### PR TITLE
Fix phantom imports in the section-less ELF symbol scan ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -497,6 +497,7 @@ static void set_default_value_dynamic_info(ELFOBJ *eo) {
 	RBinElfDynamicInfo *di = &eo->dyn_info;
 	di->dt_pltrelsz = 0;
 	di->dt_hash = R_BIN_ELF_ADDR_MAX;
+	di->dt_gnu_hash = R_BIN_ELF_ADDR_MAX;
 	di->dt_strtab = R_BIN_ELF_ADDR_MAX;
 	di->dt_symtab = R_BIN_ELF_ADDR_MAX;
 	di->dt_rela = R_BIN_ELF_ADDR_MAX;
@@ -567,6 +568,9 @@ static void fill_dynamic_entries(ELFOBJ *eo, ut64 loaded_offset, ut64 dyn_size) 
 			break;
 		case DT_HASH:
 			di->dt_hash = d.d_un.d_ptr;
+			break;
+		case DT_GNU_HASH:
+			di->dt_gnu_hash = d.d_un.d_ptr;
 			break;
 		case DT_STRTAB:
 			di->dt_strtab = d.d_un.d_ptr;
@@ -665,7 +669,6 @@ static void fill_dynamic_entries(ELFOBJ *eo, ut64 loaded_offset, ut64 dyn_size) 
 		case DT_PREINIT_ARRAY:
 		case DT_PREINIT_ARRAYSZ:
 		case DT_SONAME:
-		case DT_GNU_HASH:
 			// common dynamic entries in ELF, but we don't need to
 			// do anything with them.
 			break;
@@ -4701,10 +4704,20 @@ static bool _read_symbols_from_phdr(ELFOBJ *eo, ReadPhdrSymbolState *state) {
 static ut64 get_phdr_symtab_upper_bound(ELFOBJ *eo, ut64 addr_sym_table) {
 	ut64 bound = eo->size;
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
-	if (di->dt_strtab != R_BIN_ELF_ADDR_MAX) {
-		ut64 strtab_addr = Elf_(v2p) (eo, di->dt_strtab);
-		if (strtab_addr != UT64_MAX && strtab_addr > addr_sym_table) {
-			bound = R_MIN (bound, strtab_addr);
+	// no tag holds the symtab size, so it ends where the next table starts
+	const ut64 vsym = eo->version_info[DT_VERSIONTAGIDX (DT_VERSYM)];
+	const Elf_(Addr) table_vaddrs[] = {
+		di->dt_strtab, di->dt_gnu_hash, di->dt_hash,
+		vsym? (Elf_(Addr))vsym: R_BIN_ELF_ADDR_MAX
+	};
+	size_t t;
+	for (t = 0; t < R_ARRAY_SIZE (table_vaddrs); t++) {
+		if (table_vaddrs[t] == R_BIN_ELF_ADDR_MAX) {
+			continue;
+		}
+		const ut64 table_off = Elf_(v2p) (eo, table_vaddrs[t]);
+		if (table_off != UT64_MAX && table_off > addr_sym_table) {
+			bound = R_MIN (bound, table_off);
 		}
 	}
 	if (eo->shdr && eo->ehdr.e_shnum && eo->ehdr.e_shnum != 0xffff) {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4701,10 +4701,26 @@ static bool _read_symbols_from_phdr(ELFOBJ *eo, ReadPhdrSymbolState *state) {
 	return true;
 }
 
+// exact symtab entry count for the layouts that state one, 0 when none does
+static ut64 get_phdr_symtab_count(ELFOBJ *eo) {
+	const RBinElfDynamicInfo *di = &eo->dyn_info;
+	if (eo->ehdr.e_machine == EM_MIPS && di->dt_mips_symtabno) {
+		return di->dt_mips_symtabno;
+	}
+	if (di->dt_hash != R_BIN_ELF_ADDR_MAX) {
+		const ut64 off = Elf_(v2p) (eo, di->dt_hash);
+		// sysv hash is nbucket, nchain, and nchain counts the symtab entries
+		if (off != UT64_MAX && off + 8 <= eo->size) {
+			return r_buf_read_ble32_at (eo->b, off + 4, eo->endian);
+		}
+	}
+	return 0;
+}
+
 static ut64 get_phdr_symtab_upper_bound(ELFOBJ *eo, ut64 addr_sym_table) {
 	ut64 bound = eo->size;
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
-	// no tag holds the symtab size, so it ends where the next table starts
+	// with no exact count the symtab ends where the next table starts
 	const ut64 vsym = eo->version_info[DT_VERSIONTAGIDX (DT_VERSYM)];
 	const Elf_(Addr) table_vaddrs[] = {
 		di->dt_strtab, di->dt_gnu_hash, di->dt_hash,
@@ -4760,6 +4776,10 @@ static RVecRBinElfSymbol* load_symbols_from_phdr(ELFOBJ *eo, int type) {
 	// Stop at the next table boundary so the phdr fallback does not decode
 	// adjacent dynamic metadata as synthetic dynsym entries.
 	int nsym = (symtab_end - addr_sym_table) / sym_size;
+	const ut64 nexact = get_phdr_symtab_count (eo);
+	if (nexact && nexact < (ut64)nsym) {
+		nsym = (int)nexact;
+	}
 	if (nsym < 1) {
 		return NULL;
 	}

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -4607,7 +4607,7 @@ static bool _read_symbols_from_phdr(ELFOBJ *eo, ReadPhdrSymbolState *state) {
 		ut64 toffset = 0;
 		// Zero symbol is always empty
 		// Examine entry and maybe store
-		if (type == R_BIN_ELF_IMPORT_SYMBOLS && (new_symbol.st_shndx == SHT_NULL || new_symbol.st_shndx == SHT_DYNSYM)) {
+		if (type == R_BIN_ELF_IMPORT_SYMBOLS && is_imported) {
 			if (new_symbol.st_value) {
 				toffset = new_symbol.st_value;
 			} else if ((toffset = Elf_(plt_get_import_addr) (eo, i)) == UT64_MAX) {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -89,6 +89,7 @@ typedef struct Elf_(dynamic_info) {
 	Elf_(Xword) dt_pltrelsz;
 	Elf_(Addr) dt_pltgot;
 	Elf_(Addr) dt_hash;
+	Elf_(Addr) dt_gnu_hash;
 	Elf_(Addr) dt_strtab;
 	Elf_(Addr) dt_symtab;
 	Elf_(Addr) dt_rela;

--- a/test/db/formats/elf/dynimports
+++ b/test/db/formats/elf/dynimports
@@ -26,3 +26,27 @@ EXPECT=<<EOF
             0x00011b84     .string "strncmp" ; len=8
 EOF
 RUN
+
+NAME=ELF: section-less dynsym ends at the gnu hash table
+FILE=bins/elf/pltrel/aarch64-bti-lld-one-noshdr.so
+CMDS=<<EOF
+iiq
+isq
+EOF
+EXPECT=<<EOF
+0x000013b8 16 foo
+0x000013c8 28 call_foo
+EOF
+RUN
+
+NAME=ELF: section-less dynsym with no sysv hash table
+FILE=bins/elf/pltrel/x86_64-retpoline-one-noshdr.so
+CMDS=<<EOF
+iiq
+isq
+EOF
+EXPECT=<<EOF
+0x00001340 4 add2
+0x00001350 5 caller
+EOF
+RUN

--- a/test/db/formats/elf/dynimports
+++ b/test/db/formats/elf/dynimports
@@ -50,3 +50,14 @@ EXPECT=<<EOF
 0x00001350 5 caller
 EOF
 RUN
+
+NAME=ELF: section-less mips defined symbol is not an import
+FILE=bins/elf/analysis/mipsbe-ubusd
+CMDS=<<EOF
+iiq~_ftext
+isq~_ftext
+EOF
+EXPECT=<<EOF
+0x00400ec0 0 _ftext
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`.dynsym` carries no size tag, so with no section headers the scan bounded it at `DT_STRTAB` alone. lld places `.gnu.hash`/`.hash` — and `.gnu.version` when symbols are versioned — between `.dynsym` and `.dynstr`, so those tables were decoded as symbols:

 ```
$ rabin2 -i bins/elf/pltrel/aarch64-bti-lld-one-noshdr.so
3   0x1a00000001 LOCAL OBJ      foo
```

That line is the gnu-hash header read as an `Elf64_Sym`: `nbuckets` (1) became the name index, `bloom_size | bloom_shift << 32` became the address. It also appeared in `is` as `imp.foo` and in `imports_by_ord`.

Three commits:

- Bound the scan at `DT_STRTAB`/`DT_GNU_HASH`/`DT_HASH`/`DT_VERSYM`; `DT_GNU_HASH` is now parsed.
- The import filter compared `st_shndx` against `SHT_NULL`/`SHT_DYNSYM` — section *types*, not indices — so a symbol defined in section 11 was emitted as an import (`_ftext` in `bins/elf/analysis/mipsbe-ubusd`). It now uses the `is_imported` it already computes, matching the section-header path.
- Cap the count with `DT_HASH`'s `nchain` (or `DT_MIPS_SYMTABNO`), so layouts where every table precedes `.dynsym` are bounded too; positional bounds remain the fallback. `nchain` matches the real `.dynsym` size on 145 of the 146 test binaries carrying both, and the one outlier states a larger count, so the cap cannot truncate.