### PR TITLE
Fix heap out of bounds read in the ppc64 plt stub segment scan ##bin

### DIFF
--- a/libr/bin/format/elf/plt.c
+++ b/libr/bin/format/elf/plt.c
@@ -645,8 +645,9 @@ void Elf_(plt_ppc64v1_load_text_stubs)(ELFOBJ *eo) {
 		}
 	}
 	if (!scanned && eo->phdr) {
-		int i;
-		for (i = 0; i < eo->ehdr.e_phnum; i++) {
+		size_t i;
+		// phnum is the resolved count, e_phnum is 0xffff under PN_XNUM
+		for (i = 0; i < eo->phnum; i++) {
 			const Elf_(Phdr) *p = &eo->phdr[i];
 			if (p->p_type == PT_LOAD && (p->p_flags & PF_X)) {
 				ppc64v1_scan_stubs (eo, &sc, p->p_offset, p->p_vaddr, p->p_filesz);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to cb8192b829, which added the segment fallback to the ppc64 ELFv1 stub scan. That loop bounds on the raw `ehdr.e_phnum`, but `eo->phdr` is allocated by `init_phdr` with `eo->phnum` — the count `Elf_(get_phnum)` resolves, which under `e_phnum == PN_XNUM (0xffff)` comes from section 0's sh_info`. A file claiming PN_XNUM while resolving to a small count reads ~65527 entries past the allocation, on open:

```
AddressSanitizer: heap-buffer-overflow
READ of size 4 ... in Elf64_plt_ppc64v1_load_text_stubs plt.c:651
allocated by thread T0 here: ... init_phdr elf.c:322
0x... is located 0 bytes after 448-byte region       (448 = 8 phdrs x 56)
```

The same mismatch truncates the scan on a legitimate file with more than 65535 program headers. Fixed by iterating `eo->phnum`, as every other phdr loop in the ELF code already does.