### PR TITLE
Register pdc.structured from the pseudo plugin ##pseudo

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4638,7 +4638,6 @@ R_API int r_core_config_init(RCore *core) {
 	RConfigNode *cmdpdc = NODECB ("cmd.pdc", "", &cb_cmdpdc);
 	SETDESC (cmdpdc, "select pseudo-decompiler command to run after pdc");
 	update_cmdpdc_options (core, cmdpdc);
-	SETB ("pdc.structured", "false", "emit structured if/else instead of goto in pdc (experimental)");
 	SETCB ("cmd.log", "", &cb_cmdlog, "every time a new T log is added run this command");
 	SETS ("cmd.prompt", "", "prompt commands");
 	SETCB ("cmd.repeat", "false", &cb_cmdrepeat, "empty command an alias for '..' (repeat last command)");

--- a/libr/core/p/pseudo/plugin.c
+++ b/libr/core/p/pseudo/plugin.c
@@ -170,16 +170,25 @@ static RCmdResult pseudo_callback(RCmdContext *ctx) {
 
 static bool plugin_init(RCorePluginSession *cps) {
 	RCore *core = cps->core;
-	RCmd *cmd = core->rcmd;
-	if (!r_cmd_register (cmd, "pdc", pseudo_callback, NULL)) {
+	if (!r_cmd_register (core->rcmd, "pdc", pseudo_callback, NULL)) {
 		return false;
 	}
+	RConfig *cfg = core->config;
+	r_config_lock (cfg, false);
+	RConfigNode *node = r_config_set_b (cfg, "pdc.structured", false);
+	r_config_node_desc (node, "emit structured if/else instead of goto in pdc (experimental)");
+	r_config_lock (cfg, true);
 	return true;
 }
 
 static bool plugin_fini(RCorePluginSession *cps) {
 	R_RETURN_VAL_IF_FAIL (cps && cps->core && cps->core->rcmd, false);
-	r_cmd_unregister (cps->core->rcmd, "pdc");
+	RCore *core = cps->core;
+	r_cmd_unregister (core->rcmd, "pdc");
+	// r_core_fini frees the config before it unloads the core plugins
+	if (core->config) {
+		r_config_rm (core->config, "pdc.structured");
+	}
 	return true;
 }
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`pdc.structured` was registered in `cconfig.c` although its only reader is the `core.pseudo` plugin (`libr/core/p/pseudo/pseudo.c`). Profiles that drop that plugin — `plugins.tiny.cfg`, `plugins.static.cfg`, `plugins.static.nogpl.cfg` — therefore advertise a key that does nothing.

Registration moves into the plugin's `init` and is removed in `fini`. The config is locked by `r_core_config_init` before `r_core_plugins_load` runs, so the set is bracketed by `r_config_lock (cfg, false)` / `(cfg, true)`; the relock re-sorts the node list, so listing order is unchanged. `fini` checks `core->config` because `r_core_fini` frees it before unloading core plugins.

`cmd.pdc` deliberately stays in `cconfig.c`: it selects among decompilers provided by *other* plugins and is refreshed from `r_core_config_update`.

No behaviour change, so no new test: `e` and `ej` full dumps are byte-identical to master (same value, type and sorted position), `-e pdc.structured=true` at startup and `e pdc.structured=1` behave as before. 