### PR TITLE
Fix struct member and enum case round-trip for names needing sdb sanitization

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -566,13 +566,21 @@ static void save_composite(const RAnal *anal, const RAnalBaseType *type) {
 	RAnalTypeMember *member;
 	R_VEC_FOREACH (members, member) {
 		// struct.name.param=type,offset,arraycount
+		// The member list has to name members by the same key that addresses
+		// them, so it stores the sanitized form. Listing the raw name instead
+		// makes every member whose name needs sanitizing unreadable: the reader
+		// would look up a key that was never written, and the stale-member
+		// cleanup above would fail to unset the key that was.
 		char *member_sname = r_str_sanitize_sdb_key (member->name);
+		if (!member_sname) {
+			break;
+		}
 		r_strf_var (k, KSZ, "%s.%s.%s", kind, sname, member_sname);
 		sdb_set_owned (db, k,
 			member_value_kv (member->type, member->offset, member->count), 0);
-		free (member_sname);
 
-		r_strbuf_appendf (arglist, (i++ == 0) ? "%s" : ",%s", member->name);
+		r_strbuf_appendf (arglist, (i++ == 0) ? "%s" : ",%s", member_sname);
+		free (member_sname);
 	}
 	// struct.name=param1,param2,paramN
 	sdb_set_owned (db, key, r_strbuf_drain (arglist), 0);

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -613,12 +613,19 @@ static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	RAnalEnumCase *cas;
 	R_VEC_FOREACH (&type->enum_data.cases, cas) {
 		// enum.name.arg1=type,offset,???
+		// As with struct members, the case list has to name cases by the key
+		// that addresses them. get_enum_type looks each list entry up as
+		// enum.<name>.<entry>, so listing the raw name makes an enum with a
+		// sanitized case name unreadable in its entirety.
 		char *case_sname = r_str_sanitize_sdb_key (cas->name);
+		if (!case_sname) {
+			break;
+		}
 		r_strf_var (param_val, KSZ, "0x%" PFMT32x, cas->val);
 		sdb_setf (anal->sdb_types, param_val, 0, "enum.%s.%s", sname, case_sname);
 		sdb_setf (anal->sdb_types, case_sname, 0, "enum.%s.0x%" PFMT32x, sname, cas->val);
+		r_strbuf_appendf (arglist, (i++ == 0) ? "%s" : ",%s", case_sname);
 		free (case_sname);
-		r_strbuf_appendf (arglist, (i++ == 0) ? "%s" : ",%s", cas->name);
 	}
 	// enum.name=arg1,arg2,argN
 	char *key = r_str_newf ("enum.%s", sname);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3942,3 +3942,20 @@ EXPECT=<<EOF
 int64_t,arg2
 EOF
 RUN
+
+NAME=DWARF struct member needing sdb sanitization survives the save round-trip
+FILE=bins/elf/dwarf2_many_comp_units.elf
+ARGS=-e bin.dbginfo=true
+CMDS=<<EOF
+tk struct.Bird
+tk struct.Bird._vptr_Bird
+tsc Bird
+EOF
+EXPECT=<<EOF
+_vptr_Bird
+int (**)(),2,0
+struct Bird {
+  int (**)() _vptr_Bird;
+};
+EOF
+RUN

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -118,6 +118,80 @@ static bool test_anal_save_base_type_struct(void) {
 	mu_end;
 }
 
+static bool test_anal_base_type_struct_member_needing_sanitization_roundtrip(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	// A member name that sdb keys cannot hold verbatim. DWARF produces these
+	// for C++ vtable pointers, e.g. "_vptr.Bird".
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("Bird");
+
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int (**)()"),
+		.name = strdup ("_vptr.Bird")
+	};
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	// The member list has to name the member by the key that addresses it,
+	// otherwise the reader looks up a key that was never written and the whole
+	// type becomes unreadable.
+	mu_assert_streq (sdb_const_get (anal->sdb_types, "struct.Bird", 0), "_vptr_Bird",
+		"member list names the sanitized key");
+	mu_assert_notnull (sdb_const_get (anal->sdb_types, "struct.Bird._vptr_Bird", 0),
+		"member is stored under the sanitized key");
+
+	RAnalBaseType *got = r_anal_get_base_type (anal, "Bird");
+	mu_assert_notnull (got, "reload struct whose member name needed sanitization");
+	mu_assert_eq (RVecAnalTypeMember_length (&got->struct_data.members), 1,
+		"member survives the round trip");
+	RAnalStructMember *m = RVecAnalTypeMember_at (&got->struct_data.members, 0);
+	mu_assert_streq (m->name, "_vptr_Bird", "member is named by its key");
+	mu_assert_streq (m->type, "int (**)()", "member type survives");
+	r_anal_base_type_free (got);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
+static bool test_anal_base_type_enum_case_needing_sanitization_roundtrip(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "Couldn't create new RAnal");
+
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_ENUM);
+	base->name = strdup ("Mode");
+
+	RAnalEnumCase cas = {
+		.name = strdup ("Mode.One"),
+		.val = 1
+	};
+	RVecAnalEnumCase_push_back (&base->enum_data.cases, &cas);
+
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+
+	mu_assert_streq (sdb_const_get (anal->sdb_types, "enum.Mode", 0), "Mode_One",
+		"case list names the sanitized key");
+
+	// get_enum_type treats a missing case key as fatal, so a single case name
+	// needing sanitization made the whole enum unreadable.
+	RAnalBaseType *got = r_anal_get_base_type (anal, "Mode");
+	mu_assert_notnull (got, "reload enum whose case name needed sanitization");
+	mu_assert_eq (RVecAnalEnumCase_length (&got->enum_data.cases), 1,
+		"case survives the round trip");
+	RAnalEnumCase *c = RVecAnalEnumCase_at (&got->enum_data.cases, 0);
+	mu_assert_streq (c->name, "Mode_One", "case is named by its key");
+	mu_assert_eq (c->val, 1, "case value survives");
+	r_anal_base_type_free (got);
+
+	r_anal_free (anal);
+	mu_end;
+}
+
 static bool test_anal_get_base_type_union(void) {
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "Couldn't create new RAnal");
@@ -634,6 +708,8 @@ int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_struct);
 	mu_run_test (test_anal_save_base_type_struct);
 	mu_run_test (test_anal_base_type_struct_array_roundtrip);
+	mu_run_test (test_anal_base_type_struct_member_needing_sanitization_roundtrip);
+	mu_run_test (test_anal_base_type_enum_case_needing_sanitization_roundtrip);
 	mu_run_test (test_anal_save_base_type_struct_redefine);
 	mu_run_test (test_anal_base_type_struct_comma_type_roundtrip);
 	mu_run_test (test_anal_base_type_union_comma_type_roundtrip);


### PR DESCRIPTION
`save_composite` and `save_enum` write each member/case under a key produced by
`r_str_sanitize_sdb_key`, but list the member/case in the parent key by its raw,
unsanitized name. The two disagree whenever a name contains a character an sdb
key cannot hold.

The readers index by the list entry:

- `get_composite_type` looks up `struct.<name>.<entry>` and returns `NULL` when
  it is missing, so the whole struct becomes unreadable.
- `get_enum_type` looks up `enum.<name>.<entry>` and treats a miss as fatal, so
  the whole enum becomes unreadable.

The stale-member cleanup at the top of `save_composite` has the same problem in
reverse: it unsets `struct.<name>.<raw>`, which was never written, and leaves
`struct.<name>.<sanitized>` behind.

`r_anal_base_type_to_kv` already serializes both sides sanitized, so the two
save functions were the outliers rather than the readers.

DWARF C++ input hits this immediately. A vtable pointer member is named
`_vptr.Bird`, so radare2 stores:

```
Bird=struct
struct.Bird=_vptr.Bird
struct.Bird._vptr_Bird=int (**)(),2,0
```

and `r_anal_get_base_type(anal, "Bird")` then returns `NULL`.

Fix both writers to list members and cases by the same key that addresses them.
After the change the same input stores `struct.Bird=_vptr_Bird` and the type
reads back.

Verified on `test/bins/elf/dwarf2_many_comp_units.elf` with `-e bin.dbginfo=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)