### PR TITLE
Replace RList/RRBTree store of RBinRelocs into RVec ##bin

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1020,16 +1020,37 @@ R_API RList *r_bin_get_libs(RBin *bin) {
 	return o? o->libs: NULL;
 }
 
-R_API RRBTree *r_bin_patch_relocs(RBinFile *bf) {
+R_API RVecRBinReloc *r_bin_patch_relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->rbin, NULL);
 	RBinObject *o = r_bin_cur_object (bf->rbin);
 	return o? r_bin_object_patch_relocs (bf, o): NULL;
 }
 
-R_API RRBTree *r_bin_get_relocs(RBin *bin) {
+R_API RVecRBinReloc *r_bin_get_relocs(RBin *bin) {
 	R_RETURN_VAL_IF_FAIL (bin, NULL);
 	RBinObject *o = r_bin_cur_object (bin);
 	return o? o->relocs: NULL;
+}
+
+// find the first reloc whose vaddr is inside [vaddr, vaddr + size)
+R_API RBinReloc *r_bin_reloc_at(RVecRBinReloc *relocs, ut64 vaddr, int size) {
+	R_RETURN_VAL_IF_FAIL (relocs, NULL);
+	if (size < 1 || vaddr == UT64_MAX) {
+		return NULL;
+	}
+	// relocs are sorted by vaddr, plain binary search for the lower bound
+	RBinReloc *a = R_VEC_START_ITER (relocs);
+	const size_t len = RVecRBinReloc_length (relocs);
+	size_t lo = 0, hi = len;
+	while (lo < hi) {
+		const size_t mid = lo + ((hi - lo) >> 1);
+		if (a[mid].vaddr < vaddr) {
+			lo = mid + 1;
+		} else {
+			hi = mid;
+		}
+	}
+	return (lo < len && a[lo].vaddr < vaddr + size)? &a[lo]: NULL;
 }
 
 R_API RVecRBinSection *r_bin_get_sections_vec(RBin *bin) {

--- a/libr/bin/bobj.c
+++ b/libr/bin/bobj.c
@@ -19,16 +19,45 @@ R_API void r_bin_mem_free(void *data) {
 	}
 }
 
-static int reloc_cmp(void *incoming, void *in, void *user) {
-	RBinReloc *_incoming = (RBinReloc *)incoming;
-	RBinReloc *_in = (RBinReloc *)in;
-	if (_incoming->vaddr > _in->vaddr) {
-		return 1;
+// stable sort by vaddr: relocs with the same vaddr keep the plugin order
+static void sort_relocs(RVecRBinReloc *relocs) {
+	const size_t n = RVecRBinReloc_length (relocs);
+	RBinReloc *a = R_VEC_START_ITER (relocs);
+	size_t i;
+	for (i = 1; i < n && a[i - 1].vaddr <= a[i].vaddr; i++) {
+		;
 	}
-	if (_incoming->vaddr < _in->vaddr) {
-		return -1;
+	if (i >= n) {
+		return; // already sorted, the common case
 	}
-	return 0;
+	RBinReloc *tmp = R_NEWS (RBinReloc, n);
+	if (!tmp) {
+		return;
+	}
+	RBinReloc *src = a, *dst = tmp;
+	size_t width;
+	for (width = 1; width < n; width *= 2) {
+		for (i = 0; i < n; i += 2 * width) {
+			size_t l = i, m = R_MIN (i + width, n), k = i;
+			const size_t lend = m, r = R_MIN (i + 2 * width, n);
+			while (l < lend && m < r) {
+				dst[k++] = (src[m].vaddr < src[l].vaddr)? src[m++]: src[l++];
+			}
+			while (l < lend) {
+				dst[k++] = src[l++];
+			}
+			while (m < r) {
+				dst[k++] = src[m++];
+			}
+		}
+		RBinReloc *t = src;
+		src = dst;
+		dst = t;
+	}
+	if (src != a) {
+		memcpy (a, src, n * sizeof (RBinReloc));
+	}
+	free (tmp);
 }
 
 R_API void r_bin_object_import_cache_cleanup(RBinObject *o) {
@@ -77,6 +106,21 @@ static void clamp_strings_vec(RVecRBinString *vec, int limit) {
 		T##_erase_back (_v, T##_at (_v, (size_t)_l)); \
 	} \
 } while (0)
+
+// take ownership of the relocs returned by the plugin: clamp, rebase and sort by vaddr
+static void set_relocs(RBinObject *bo, RVecRBinReloc *relocs, int limit) {
+	RVecRBinReloc_free (bo->relocs);
+	CLAMP_VEC (RVecRBinReloc, relocs, limit);
+	if (bo->loadaddr) {
+		RBinReloc *r;
+		R_VEC_FOREACH (relocs, r) {
+			r->paddr += bo->loadaddr;
+		}
+	}
+	sort_relocs (relocs);
+	RVecRBinReloc_shrink_to_fit (relocs);
+	bo->relocs = relocs;
+}
 
 static void rebase_sections_vec(RBinObject *bo) {
 	RBinSection *section;
@@ -213,7 +257,7 @@ static void object_delete_items(RBinObject *o) {
 	r_list_free (o->entries);
 	r_list_free (o->fields);
 	r_list_free (o->libs);
-	r_crbtree_free (o->relocs);
+	RVecRBinReloc_free (o->relocs);
 	RVecRBinString_fini (&o->strings);
 	ht_up_free (o->strings_db);
 
@@ -487,18 +531,6 @@ static bool filter_classes(RBinFile *bf, RList *list) {
 	return rc;
 }
 
-static RRBTree *list2rbtree(RList *relocs) {
-	RRBTree *tree = r_crbtree_new ((RListFree)r_bin_reloc_free);
-	if (tree) {
-		RListIter *it;
-		RBinReloc *reloc;
-		r_list_foreach (relocs, it, reloc) {
-			r_crbtree_insert (tree, reloc, reloc_cmp, NULL);
-		}
-	}
-	return tree;
-}
-
 static void r_bin_object_rebuild_classes_ht(RBinObject *bo) {
 	ht_pp_free (bo->classes_ht);
 	bo->classes_ht = ht_pp_new0 ();
@@ -656,13 +688,9 @@ R_API int r_bin_object_set_items(RBinFile *bf, RBinObject *bo) {
 	RVecRBinImport_shrink_to_fit (&bo->imports_vec);
 	if (bin->filter_rules & (R_BIN_REQ_RELOCS | R_BIN_REQ_IMPORTS)) {
 		if (p->relocs) {
-			RList *l = (RList *)p->relocs (bf);
-			if (l) {
-				clamp_list (l, limit);
-				REBASE_PADDR (bo, l, RBinReloc);
-				bo->relocs = list2rbtree ((RList*)l);
-				l->free = NULL; // owned by tree now, via clone with proper cleanup
-				r_list_free (l);
+			RVecRBinReloc *relocs = p->relocs (bf);
+			if (relocs) {
+				set_relocs (bo, relocs, limit);
 			}
 		}
 	}
@@ -729,20 +757,14 @@ R_API int r_bin_object_set_items(RBinFile *bf, RBinObject *bo) {
 	return true;
 }
 
-R_IPI RRBTree *r_bin_object_patch_relocs(RBinFile *bf, RBinObject *bo) {
+R_IPI RVecRBinReloc *r_bin_object_patch_relocs(RBinFile *bf, RBinObject *bo) {
 	R_RETURN_VAL_IF_FAIL (bf && bo, NULL);
 
 	if (!bo->is_reloc_patched && bo->plugin && bo->plugin->patch_relocs) {
-		RList *tmp = bo->plugin->patch_relocs (bf);
-		if (R_LIKELY (tmp)) {
-			const int limit = bf->rbin->options.limit;
-			r_crbtree_free (bo->relocs);
-			clamp_list (tmp, limit);
-			REBASE_PADDR (bo, tmp, RBinReloc);
-			bo->relocs = list2rbtree (tmp);
+		RVecRBinReloc *relocs = bo->plugin->patch_relocs (bf);
+		if (R_LIKELY (relocs)) {
+			set_relocs (bo, relocs, bf->rbin->options.limit);
 			bo->is_reloc_patched = true;
-			tmp->free = NULL;
-			r_list_free (tmp);
 		}
 	}
 	return bo->relocs;

--- a/libr/bin/format/bflt/bflt.c
+++ b/libr/bin/format/bflt/bflt.c
@@ -78,10 +78,6 @@ static bool r_bin_bflt_init(RBinBfltObj *obj, RBuffer *buf) {
 
 R_IPI void r_bin_bflt_free(RBinBfltObj *o) {
 	if (o) {
-		if (o->relocs_list) {
-			o->relocs_list->free = NULL;
-			r_list_free (o->relocs_list);
-		}
 		R_FREE (o->reloc_table);
 		R_FREE (o->got_table);
 		R_FREE (o->hdr);

--- a/libr/bin/format/bflt/bflt.h
+++ b/libr/bin/format/bflt/bflt.h
@@ -48,7 +48,6 @@ typedef struct r_bin_bflt_obj {
 	RBinBfltHeader *hdr;
 	RBinBfltReloc *reloc_table;
 	RBinBfltReloc *got_table;
-	RList *relocs_list;
 	RBuffer *b;
 	ut8 endian;
 	size_t size;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -5554,7 +5554,6 @@ void Elf_(free)(ELFOBJ* eo) {
 	if (!eo) {
 		return;
 	}
-	r_list_free (eo->relocs_list);
 	if (eo->imports_by_ord) {
 		size_t i;
 		for (i = 0; i < eo->imports_by_ord_size; i++) {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -192,7 +192,6 @@ struct Elf_(obj_t) {
 	ut32 g_reloc_num;
 	bool relocs_loaded;
 	RVecRBinElfReloc g_relocs;
-	RList *relocs_list;
 	bool sections_loaded;
 	bool sections_cached;
 	RVecRBinElfSection g_sections;

--- a/libr/bin/format/le/le.c
+++ b/libr/bin/format/le/le.c
@@ -661,21 +661,18 @@ static st32 reloc_source_offset(ut16 raw) {
 	return raw & 0x8000 ? (st32)raw - 0x10000 : raw;
 }
 
-static void reloc_emit(RList *relocs, const RBinReloc *reloc, const LEObjectPage *page, st32 source, st64 addend) {
+static void reloc_emit(RVecRBinReloc *relocs, const RBinReloc *reloc, const LEObjectPage *page, st32 source, st64 addend) {
 	ut64 vaddr;
 	if (!page || source < 0 || (ut32)source >= page->vsize
 		|| r_add_overflow (page->vaddr, (ut32)source, &vaddr)) {
 		return;
 	}
-	RBinReloc *clone = R_NEW0 (RBinReloc);
+	RBinReloc *clone = RVecRBinReloc_emplace_back (relocs);
 	*clone = *reloc;
 	clone->import = reloc->import ? r_bin_import_clone (reloc->import) : NULL;
 	clone->vaddr = vaddr;
 	clone->paddr = page->has_data && (ut32)source < page->data_size ? page->paddr + source : 0;
 	clone->addend = addend;
-	if (!r_list_append (relocs, clone)) {
-		r_bin_reloc_free (clone);
-	}
 }
 
 static bool reloc_page_bounds(RBinLEObj *bin, ut64 page, ut64 fixup_end, ut64 *start, ut64 *end) {
@@ -738,8 +735,8 @@ static bool reloc_record_end(RBuffer *buf, ut64 offset, ut64 limit, ut64 *end) {
 	return true;
 }
 
-R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
-	RList *l = r_list_newf ((RListFree)r_bin_reloc_free);
+R_IPI RVecRBinReloc *r_bin_le_get_relocs(RBinLEObj *bin) {
+	RVecRBinReloc *l = RVecRBinReloc_new ();
 	if (!l) {
 		return NULL;
 	}
@@ -763,7 +760,8 @@ R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
 				R_LOG_WARN ("Invalid LE relocation record");
 				break;
 			}
-			RBinReloc *rel = R_NEW0 (RBinReloc);
+			RBinReloc reltmp = {0}; // template for the emitted relocs
+			RBinReloc *rel = &reltmp;
 			ut8 header_source = r_buf_read8_at (bin->buf, offset);
 			ut8 header_target = r_buf_read8_at (bin->buf, offset + 1);
 			offset += sizeof (LE_fixup_record_header);
@@ -882,7 +880,7 @@ R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
 			ut64 source_list_size = repeat * sizeof (ut16);
 			if (offset != record_end - source_list_size) {
 				offset = record_end;
-				r_bin_reloc_free (rel);
+				r_bin_reloc_fini (rel);
 				continue;
 			}
 			if (repeat) {
@@ -913,7 +911,7 @@ R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin) {
 			} else {
 				reloc_emit (l, rel, page_ref, source, rel->addend);
 			}
-			r_bin_reloc_free (rel);
+			r_bin_reloc_fini (rel);
 		}
 	}
 	r_list_free (entries);

--- a/libr/bin/format/le/le.h
+++ b/libr/bin/format/le/le.h
@@ -27,5 +27,5 @@ R_IPI void r_bin_le_load_symbols(RBinLEObj *bin, RVecRBinSymbol *vec);
 R_IPI void r_bin_le_load_imports(RBinLEObj *bin, RVecRBinImport *vec);
 R_IPI bool r_bin_le_load_resources(RBinLEObj *bin, RVecRBinResource *resources);
 R_IPI RList *r_bin_le_get_libs(RBinLEObj *bin);
-R_IPI RList *r_bin_le_get_relocs(RBinLEObj *bin);
+R_IPI RVecRBinReloc *r_bin_le_get_relocs(RBinLEObj *bin);
 #endif

--- a/libr/bin/format/mdmp/mdmp.c
+++ b/libr/bin/format/mdmp/mdmp.c
@@ -129,6 +129,7 @@ void r_bin_mdmp_free(struct r_bin_mdmp_obj *obj) {
 
 	r_list_free (obj->pe32_bins);
 	r_list_free (obj->pe64_bins);
+	RVecRBinReloc_fini (&obj->relocs);
 
 	r_unref (obj->b);
 	free (obj->hdr);
@@ -1206,6 +1207,7 @@ struct r_bin_mdmp_obj *r_bin_mdmp_new_buf(RBuffer *buf, const char *sdbdir) {
 	struct r_bin_mdmp_obj *obj = R_NEW0 (struct r_bin_mdmp_obj);
 	obj->kv = sdb_new0 ();
 	obj->size = (ut32) r_buf_size (buf);
+	RVecRBinReloc_init (&obj->relocs);
 
 	fail |= (!(obj->streams.ex_threads = r_list_newf ((RListFree)free)));
 	fail |= (!(obj->streams.memories = r_list_newf ((RListFree)free)));

--- a/libr/bin/format/mdmp/mdmp.h
+++ b/libr/bin/format/mdmp/mdmp.h
@@ -49,6 +49,7 @@ typedef struct r_bin_mdmp_obj {
 	/* Binary memory objects */
 	RList *pe32_bins;
 	RList *pe64_bins;
+	RVecRBinReloc relocs; // import relocs of all the embedded pe bins
 
 	RBuffer *b;
 	size_t size;

--- a/libr/bin/format/mdmp/mdmp_pe.c
+++ b/libr/bin/format/mdmp/mdmp_pe.c
@@ -80,17 +80,11 @@ static inline void filter_import(ut8 *n) {
 	}
 }
 
-void PE_(r_bin_mdmp_pe_load_imports) (struct PE_(r_bin_mdmp_pe_bin) * pe_bin, RVecRBinImport *vec) {
+void PE_(r_bin_mdmp_pe_load_imports) (struct PE_(r_bin_mdmp_pe_bin) * pe_bin, RVecRBinImport *vec, RVecRBinReloc *relocs) {
 	RVecPEImport *imports = PE_(r_bin_pe_get_imports) (pe_bin->bin);
 	if (!imports) {
 		return;
 	}
-	RList *relocs = r_list_newf ((RListFree)r_bin_reloc_free);
-	if (!relocs) {
-		RVecPEImport_free (imports);
-		return;
-	}
-	pe_bin->bin->relocs = relocs;
 	struct r_bin_pe_import_t *import;
 	R_VEC_FOREACH (imports, import) {
 		filter_import (import->name);
@@ -101,10 +95,7 @@ void PE_(r_bin_mdmp_pe_load_imports) (struct PE_(r_bin_mdmp_pe_bin) * pe_bin, RV
 		ptr->type = R_BIN_TYPE_FUNC_STR;
 		ptr->ordinal = import->ordinal;
 
-		RBinReloc *rel = R_NEW0 (RBinReloc);
-		if (!rel) {
-			break;
-		}
+		RBinReloc *rel = RVecRBinReloc_emplace_back (relocs);
 #ifdef R_BIN_PE64
 		rel->type = R_BIN_RELOC_64;
 #else
@@ -114,12 +105,9 @@ void PE_(r_bin_mdmp_pe_load_imports) (struct PE_(r_bin_mdmp_pe_bin) * pe_bin, RV
 		if (offset > pe_bin->vaddr) {
 			offset -= pe_bin->vaddr;
 		}
-		rel->additive = 0;
 		rel->import = r_bin_import_clone (ptr);
-		rel->addend = 0;
 		rel->vaddr = offset + pe_bin->vaddr;
 		rel->paddr = import->paddr + pe_bin->paddr;
-		r_list_append (relocs, rel);
 	}
 	RVecPEImport_free (imports);
 }

--- a/libr/bin/format/mdmp/mdmp_pe.h
+++ b/libr/bin/format/mdmp/mdmp_pe.h
@@ -17,7 +17,7 @@ typedef struct PE_(r_bin_mdmp_pe_bin) {
 } PE_(RBinMdmp);
 
 RList *PE_(r_bin_mdmp_pe_get_entrypoint)(PE_(RBinMdmp) *mdmp);
-void PE_(r_bin_mdmp_pe_load_imports)(PE_(RBinMdmp) *mdmp, RVecRBinImport *vec);
+void PE_(r_bin_mdmp_pe_load_imports)(PE_(RBinMdmp) *mdmp, RVecRBinImport *vec, RVecRBinReloc *relocs);
 void PE_(r_bin_mdmp_pe_load_sections)(PE_(RBinMdmp) *mdmp, RVecRBinSection *vec);
 void PE_(r_bin_mdmp_pe_load_symbols)(RBin *rbin, PE_(RBinMdmp) *mdmp, RVecRBinSymbol *vec);
 

--- a/libr/bin/format/mdt/mdt.c
+++ b/libr/bin/format/mdt/mdt.c
@@ -38,7 +38,6 @@ R_IPI void r_bin_mdt_part_free(RBinMdtPart *part) {
 		free (part->map->file);
 		free (part->map);
 	}
-	r_list_free (part->relocs);
 	r_list_free (part->sub_maps);
 	free (part->patches_vfile_name);
 	free (part->relocs_vfile_name);

--- a/libr/bin/format/mdt/mdt.h
+++ b/libr/bin/format/mdt/mdt.h
@@ -73,7 +73,6 @@ typedef struct {
 	ut64 vsize; ///< The segment p_memsz.
 	char *patches_vfile_name; ///< Name of the vfile of patches to the binary. If NULL, no patches are supported.
 	char *relocs_vfile_name; ///< Name of the vfile of relocs to the binary. If NULL, no relocs are supported.
-	RList/*<RBinReloc *>*/ *relocs; ///< Relocs in this part.
 	RList/*<RBinMap *>*/ *sub_maps; ///< Maps of the obj, if any.
 } RBinMdtPart;
 

--- a/libr/bin/format/mz/mz.c
+++ b/libr/bin/format/mz/mz.c
@@ -145,28 +145,26 @@ bool r_bin_mz_load_segments(const struct r_bin_mz_obj_t *bin, ut64 filesize, RVe
 	return true;
 }
 
-struct r_bin_mz_reloc_t *r_bin_mz_get_relocs (const struct r_bin_mz_obj_t *bin) {
-	int i, j;
+RVecRBinReloc *r_bin_mz_get_relocs(const struct r_bin_mz_obj_t *bin) {
+	int i;
 	const int num_relocs = bin->dos_header->num_relocs;
 	const MZ_image_relocation_entry *const rel_entry = bin->relocation_entries;
 
-	struct r_bin_mz_reloc_t *relocs = calloc (num_relocs + 1, sizeof (*relocs));
+	RVecRBinReloc *relocs = RVecRBinReloc_new ();
 	if (!relocs) {
-		R_LOG_ERROR ("calloc (struct r_bin_mz_reloc_t)");
 		return NULL;
 	}
-	for (i = 0, j = 0; i < num_relocs; i++) {
-		relocs[j].vaddr = r_bin_mz_va_to_la (rel_entry[i].segment,
-			rel_entry[i].offset);
-		relocs[j].paddr = r_bin_mz_la_to_pa (bin, relocs[j].vaddr);
-
+	RVecRBinReloc_reserve (relocs, num_relocs);
+	for (i = 0; i < num_relocs; i++) {
+		const ut64 vaddr = r_bin_mz_va_to_la (rel_entry[i].segment, rel_entry[i].offset);
 		/* Add only relocations which resides inside dos executable */
-		if (relocs[j].vaddr < bin->load_module_size) {
-			j++;
+		if (vaddr < bin->load_module_size) {
+			RBinReloc *rel = RVecRBinReloc_emplace_back (relocs);
+			rel->type = R_BIN_RELOC_16;
+			rel->vaddr = vaddr;
+			rel->paddr = r_bin_mz_la_to_pa (bin, vaddr);
 		}
 	}
-	relocs[j].last = 1;
-
 	return relocs;
 }
 

--- a/libr/bin/format/mz/mz.h
+++ b/libr/bin/format/mz/mz.h
@@ -16,12 +16,6 @@ struct r_bin_mz_segment_t {
 	int last;
 };
 
-struct r_bin_mz_reloc_t {
-	ut64 paddr;
-	ut64 vaddr;
-	int last;
-};
-
 struct r_bin_mz_obj_t {
 	const MZ_image_dos_header *dos_header;
 	const void *dos_extended_header;
@@ -39,7 +33,7 @@ struct r_bin_mz_obj_t {
 
 RBinAddr *r_bin_mz_get_entrypoint (const struct r_bin_mz_obj_t *bin);
 bool r_bin_mz_load_segments(const struct r_bin_mz_obj_t *bin, ut64 filesize, RVecRBinSection *segments);
-struct r_bin_mz_reloc_t *r_bin_mz_get_relocs (const struct r_bin_mz_obj_t *bin);
+RVecRBinReloc *r_bin_mz_get_relocs(const struct r_bin_mz_obj_t *bin);
 void *r_bin_mz_free (struct r_bin_mz_obj_t *bin);
 struct r_bin_mz_obj_t *r_bin_mz_new (const char *file);
 struct r_bin_mz_obj_t *r_bin_mz_new_buf(RBuffer *buf);

--- a/libr/bin/format/ne/ne.c
+++ b/libr/bin/format/ne/ne.c
@@ -100,8 +100,7 @@ static char *__func_name_from_ord(const char *module, ut16 ordinal) {
 		Sdb *sdb = sdb_new (NULL, path, 0);
 		const char *value = sdb_const_getf (sdb, NULL, "%d", ordinal);
 		name = value? strdup (value): NULL;
-		sdb_close (sdb);
-		free (sdb);
+		sdb_free (sdb);
 	}
 	if (!name) {
 		name = r_str_newf ("%d", ordinal);
@@ -448,7 +447,7 @@ RList *r_bin_ne_get_entrypoints(r_bin_ne_obj_t *bin) {
 	return entries;
 }
 
-RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBinSection *sections) {
+RVecRBinReloc *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBinSection *sections) {
 	if (!bin || !bin->ne_header || !sections || RVecRBinSection_empty (sections)) {
 		return NULL;
 	}
@@ -468,7 +467,7 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBi
 	}
 	r_buf_fread_at (bin->buf, (ut64)bin->ne_header->ModRefTable + bin->header_offset, (ut8 *)modref, "s", bin->ne_header->ModRefs);
 
-	RList *relocs = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *relocs = RVecRBinReloc_new ();
 	if (!relocs) {
 		free (modref);
 		r_list_free (entries);
@@ -494,12 +493,12 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBi
 			// && off + sizeof (NE_image_reloc_item) < buf_size)
 			NE_image_reloc_item rel = {0};
 			if (r_buf_fread_at (bin->buf, off, (ut8 *)&rel, "2c3s", 1) < 1) {
-				free (modref); return NULL;
+				free (modref);
+				r_list_free (entries);
+				RVecRBinReloc_free (relocs);
+				return NULL;
 			}
-			RBinReloc *reloc = R_NEW0 (RBinReloc);
-			if (!reloc) {
-				free (modref); return NULL;
-			}
+			RBinReloc *reloc = RVecRBinReloc_emplace_back (relocs);
 			reloc->paddr = seg->paddr + rel.offset;
 			reloc->ntype = rel.type;
 			switch (rel.type) {
@@ -522,10 +521,6 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBi
 			ut64 offset;
 			if (rel.flags & (IMPORTED_ORD | IMPORTED_NAME)) {
 				RBinImport *imp = R_NEW0 (RBinImport);
-				if (!imp) {
-					free (reloc);
-					break;
-				}
 				char *name = NULL;
 				if (rel.index > bin->ne_header->ModRefs) {
 					name = r_str_newf ("UnknownModule%d_%x", rel.index, off); // ????
@@ -576,10 +571,8 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBi
 
 			if (rel.flags & ADDITIVE) {
 				reloc->additive = 1;
-				r_list_append (relocs, reloc);
 			} else {
 				RBitset *visited = r_bitset_new ();
-				r_list_append (relocs, reloc);
 				if (r_bitset_set (visited, rel.offset)) {
 					while (reloc->paddr <= bufsz && bufsz - reloc->paddr >= sizeof (ut16)) {
 						offset = r_buf_read_le16_at (bin->buf, reloc->paddr);
@@ -593,13 +586,15 @@ RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBi
 						if (bufsz - next_paddr < sizeof (ut16)) {
 							break;
 						}
-						RBinReloc *next = R_NEW0 (RBinReloc);
+						// emplace may realloc: re-fetch the previous reloc by index
+						const size_t prev = RVecRBinReloc_length (relocs) - 1;
+						RBinReloc *next = RVecRBinReloc_emplace_back (relocs);
+						reloc = RVecRBinReloc_at (relocs, prev);
 						*next = *reloc;
 						if (next->import) {
 							next->import = r_bin_import_clone (next->import);
 						}
 						next->paddr = next_paddr;
-						r_list_append (relocs, next);
 						reloc = next;
 					}
 				}

--- a/libr/bin/format/ne/ne.h
+++ b/libr/bin/format/ne/ne.h
@@ -37,7 +37,7 @@ typedef struct {
 bool r_bin_ne_get_header_offset(RBuffer *buf, R_OUT ut32 *offset);
 void r_bin_ne_free(r_bin_ne_obj_t *bin);
 r_bin_ne_obj_t *r_bin_ne_new_buf(RBuffer *buf, bool verbose);
-RList *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBinSection *sections);
+RVecRBinReloc *r_bin_ne_get_relocs(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols, RVecRBinSection *sections);
 void r_bin_ne_load_imports(r_bin_ne_obj_t *bin, RVecRBinImport *vec);
 void r_bin_ne_load_symbols(r_bin_ne_obj_t *bin, RVecRBinSymbol *symbols);
 bool r_bin_ne_load_segments(r_bin_ne_obj_t *bin, RVecRBinSection *segments);

--- a/libr/bin/format/pe/pe.c
+++ b/libr/bin/format/pe/pe.c
@@ -3625,7 +3625,7 @@ static int bin_pe_init(RBinPEObj *pe) {
 	bin_pe_init_metadata_hdr (pe);
 	bin_pe_init_overlay (pe);
 	PE_(bin_pe_parse_resource) (pe);
-	pe->relocs = NULL;
+	RVecRBinReloc_init (&pe->relocs);
 	return true;
 }
 
@@ -4665,7 +4665,7 @@ void *PE_(r_bin_pe_free)(RBinPEObj *pe) {
 	free (pe->authentihash);
 	free (pe->sdbdir);
 	r_list_free (pe->rich_entries);
-	r_list_free (pe->relocs);
+	RVecRBinReloc_fini (&pe->relocs);
 	r_list_free (pe->resources);
 	r_list_free (pe->dotnet_symbols);
 	r_pkcs7_cms_free (pe->cms);

--- a/libr/bin/format/pe/pe.h
+++ b/libr/bin/format/pe/pe.h
@@ -146,7 +146,7 @@ struct PE_(r_bin_pe_obj_t) {
 	bool verbose;
 	int big_endian;
 	RList* rich_entries;
-	RList* relocs;
+	RVecRBinReloc relocs; // one per import, moved out by the relocs() callback
 	RList* resources; //RList of r_pe_resources
 	const char* file;
 	char *sdbdir;

--- a/libr/bin/format/qnx/qnx.h
+++ b/libr/bin/format/qnx/qnx.h
@@ -85,7 +85,7 @@ typedef struct lmf_rw_end {
 typedef struct {
 	Sdb *kv;
 	lmf_header lmfh;
-	RList* fixups;
+	RVecRBinReloc fixups;
 	RVecRBinSection sections;
 	RList *resources;
 	lmf_rw_end rwend;

--- a/libr/bin/format/som/som.c
+++ b/libr/bin/format/som/som.c
@@ -572,11 +572,6 @@ R_IPI RList *r_bin_som_get_libs(void *o) {
 	return list;
 }
 
-R_IPI RList *r_bin_som_get_relocs(void *o) {
-	// TODO: not yet implemented
-	return NULL;
-}
-
 R_IPI RList *r_bin_som_get_entries(void *o) {
 	RSomFile *obj = (RSomFile *)o;
 	RBinAddr *entry = get_entry (obj);

--- a/libr/bin/format/som/som.h
+++ b/libr/bin/format/som/som.h
@@ -215,7 +215,6 @@ R_IPI bool r_bin_som_load_sections(void *o, RVecRBinSection *sections);
 R_IPI bool r_bin_som_get_symbols_vec(void *o, RVecRBinSymbol *vec, bool load_unnamed);
 R_IPI void r_bin_som_load_imports(void *o, RVecRBinImport *vec);
 R_IPI RList *r_bin_som_get_libs(void *o);
-R_IPI RList *r_bin_som_get_relocs(void *o);
 R_IPI RList *r_bin_som_get_entries(void *o);
 R_IPI RBinInfo *r_bin_som_get_info(void *o);
 R_IPI ut64 r_bin_som_get_baddr(void *o);

--- a/libr/bin/i/private.h
+++ b/libr/bin/i/private.h
@@ -129,7 +129,7 @@ static inline void r_bin_object_drop_strings_db(RBinObject *bo) {
 R_IPI RBinObject *r_bin_object_new(RBinFile *binfile, RBinPlugin *plugin, ut64 baseaddr, ut64 loadaddr, ut64 offset, ut64 sz);
 R_IPI RBinObject *r_bin_object_get_cur(RBin *bin);
 R_IPI RBinObject *r_bin_object_find_by_arch_bits(RBinFile *binfile, const char *arch, int bits, const char *name);
-R_IPI RRBTree *r_bin_object_patch_relocs(RBinFile *binfile, RBinObject *o);
+R_IPI RVecRBinReloc *r_bin_object_patch_relocs(RBinFile *binfile, RBinObject *o);
 
 R_IPI bool r_bin_name_is_unnamed(const char *name);
 

--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -46,7 +46,7 @@ static bool read_be32_at(RBuffer *b, ut64 offset, ut32 *out) {
 	return true;
 }
 
-static RList *patch_relocs(RBinFile *bf) {
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->rbin && bf->rbin->iob.io, NULL);
 	RBin *b = bf->rbin;
 	RBinObject *obj = r_bin_cur_object (b);
@@ -54,7 +54,7 @@ static RList *patch_relocs(RBinFile *bf) {
 		return NULL;
 	}
 	struct r_bin_bflt_obj *bin = obj->bin_obj;
-	RList *list = r_list_newf ((RListFree)free);
+	RVecRBinReloc *list = RVecRBinReloc_new ();
 	if (!list) {
 		return NULL;
 	}
@@ -63,11 +63,10 @@ static RList *patch_relocs(RBinFile *bf) {
 		int i;
 		for (i = 0; i < bin->n_got; i++) {
 			__patch_reloc (&b->iob, got_table[i].addr_to_patch, got_table[i].data_offset);
-			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			RBinReloc *reloc = RVecRBinReloc_emplace_back (list);
 			reloc->type = R_BIN_RELOC_32;
 			reloc->paddr = got_table[i].addr_to_patch;
 			reloc->vaddr = reloc->paddr;
-			r_list_append (list, reloc);
 		}
 		R_FREE (bin->got_table);
 	}
@@ -84,11 +83,10 @@ static RList *patch_relocs(RBinFile *bf) {
 			} else {
 				__patch_reloc (&b->iob, reloc_table[i].addr_to_patch, reloc_table[i].data_offset);
 			}
-			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			RBinReloc *reloc = RVecRBinReloc_emplace_back (list);
 			reloc->type = R_BIN_RELOC_32;
 			reloc->paddr = reloc_table[i].addr_to_patch;
 			reloc->vaddr = reloc->paddr;
-			r_list_append (list, reloc);
 		}
 		R_FREE (bin->reloc_table);
 	}
@@ -117,15 +115,14 @@ static ut32 get_ngot_entries(struct r_bin_bflt_obj *obj) {
 	return n_got;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	struct r_bin_bflt_obj *obj = (struct r_bin_bflt_obj *)bf->bo->bin_obj;
-	if (obj->relocs_list) {
-		return r_list_clone (obj->relocs_list, NULL);
+	if (!obj) {
+		return NULL;
 	}
-	RList *list = r_list_newf ((RListFree)free);
+	RVecRBinReloc *list = RVecRBinReloc_new ();
 	ut32 i, len, n_got, amount;
-	if (!list || !obj) {
-		r_list_free (list);
+	if (!list) {
 		return NULL;
 	}
 	if (obj->hdr->flags & FLAT_FLAG_GOTPIC) {
@@ -209,21 +206,18 @@ static RList *relocs(RBinFile *bf) {
 				reloc_table[i].addr_to_patch = reloc_offset;
 				reloc_table[i].data_offset = reloc_data_offset;
 
-				RBinReloc *reloc = R_NEW0 (RBinReloc);
+				RBinReloc *reloc = RVecRBinReloc_emplace_back (list);
 				reloc->type = R_BIN_RELOC_32;
-				// reloc->ntype = R_BIN_RELOC_32;
 				reloc->paddr = reloc_table[i].addr_to_patch;
 				reloc->vaddr = reloc->paddr;
-				r_list_append (list, reloc);
 			}
 		}
 		free (reloc_pointer_table);
 		obj->reloc_table = reloc_table;
 	}
-	obj->relocs_list = list;
-	return r_list_clone (list, NULL);
+	return list;
 out_error:
-	r_list_free (list);
+	RVecRBinReloc_free (list);
 	return NULL;
 }
 

--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -526,7 +526,7 @@ static ut16 _read_le16(RBin *rbin, ut64 addr) {
 
 #define BYTES_PER_IMP_RELOC 8
 
-static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *co, bool patch, ut64 imp_map) {
+static RVecRBinReloc *_relocs_list(RBin *rbin, struct r_bin_coff_obj *co, bool patch, ut64 imp_map) {
 	if (!rbin || !co || !co->scn_hdrs) {
 		return NULL;
 	}
@@ -543,7 +543,7 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *co, bool patch, ut
 		ht_uu_free (imp_vaddr_ht);
 		return NULL;
 	}
-	RList *list_rel = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *list_rel = RVecRBinReloc_new ();
 	for (i = 0; i < f_nscns; i++) {
 		if (!co->scn_hdrs[i].s_nreloc) {
 			continue;
@@ -564,7 +564,7 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *co, bool patch, ut
 			if (!symbol) {
 				continue;
 			}
-			RBinReloc *reloc = R_NEW0 (RBinReloc);
+			RBinReloc *reloc = RVecRBinReloc_emplace_back (list_rel);
 			reloc->symbol = symbol;
 			reloc->paddr = co->scn_hdrs[i].s_scnptr + rel.r_vaddr;
 			if (co->scn_va) {
@@ -681,19 +681,18 @@ static RList *_relocs_list(RBin *rbin, struct r_bin_coff_obj *co, bool patch, ut
 					}
 				}
 			}
-			r_list_append (list_rel, reloc);
 		}
 	}
 	ht_uu_free (imp_vaddr_ht);
 	return list_rel;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	struct r_bin_coff_obj *bin = (struct r_bin_coff_obj*)bf->bo->bin_obj;
 	return _relocs_list (bf->rbin, bin, false, UT64_MAX);
 }
 
-static RList *patch_relocs(RBinFile *bf) {
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->rbin && bf->rbin->iob.io && bf->rbin->iob.io->desc, NULL);
 	RBin *b = bf->rbin;
 	RBinObject *bo = r_bin_cur_object (b);

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -487,12 +487,13 @@ static RList* libs(RBinFile *bf) {
 	return ret;
 }
 
-static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr) {
+// appends the converted reloc to `out` and returns it, or NULL if unsupported
+static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr, RVecRBinReloc *out) {
 	R_RETURN_VAL_IF_FAIL (eo && rel, NULL);
 	ut64 B = eo->baddr;
 	ut64 P = rel->rva; // rva has taken baddr into account
 
-	RBinReloc *r = R_NEW0 (RBinReloc);
+	RBinReloc *r = RVecRBinReloc_emplace_back (out);
 	r->ntype = rel->type;
 	r->addend = rel->addend;
 	r->vaddr = rel->rva;
@@ -886,7 +887,7 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr) {
 	}
 #undef SET
 #undef ADD
-	r_bin_reloc_free (r);
+	RVecRBinReloc_pop_back (out);
 	return NULL;
 }
 
@@ -939,13 +940,10 @@ static ut32 murmur3_32(const char* data, ut32 len, ut32 seed) {
 	return hash;
 }
 
-static RList* relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
 	ELFOBJ *eo = bf->bo->bin_obj;
-	if (eo->relocs_list) {
-		return eo->relocs_list;
-	}
-	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
 	if (!ret) {
 		return NULL;
 	}
@@ -968,6 +966,7 @@ static RList* relocs(RBinFile *bf) {
 		return ret;
 	}
 
+	RVecRBinReloc_reserve (ret, RVecRBinElfReloc_length (relocs));
 	RBinElfReloc *reloc;
 	R_VEC_FOREACH (relocs, reloc) {
 		bool already_inserted = false;
@@ -975,39 +974,24 @@ static RList* relocs(RBinFile *bf) {
 		if (already_inserted) {
 			continue;
 		}
-
-		RBinReloc *ptr = reloc_convert (eo, reloc, got_addr);
-		if (ptr && ptr->paddr != UT64_MAX) {
-			r_list_append (ret, ptr);
-			ht_up_insert (reloc_ht, reloc->rva, ptr);
-		} else {
-			if (ptr) {
-				ht_up_insert (reloc_ht, reloc->rva, NULL);
-				r_bin_reloc_free (ptr);
-			} else {
-				if (reloc->rva != reloc->offset) {
-					ht_up_insert (reloc_ht, reloc->rva, ptr);
-					R_LOG_DEBUG ("Suspicious reloc patching at 0x%"PFMT64x" for 0x%08"PFMT64x" via 0x%"PFMT64x,
-						got_addr, reloc->rva, reloc->offset);
-				} else {
-					if (reloc->rva) {
-						R_LOG_WARN ("reloc conversion failed for 0x%"PFMT64x, got_addr);
-					} else {
-						R_LOG_DEBUG ("wrong reloc conversion failed for 0x%"PFMT64x, got_addr);
-					}
-				}
+		RBinReloc *ptr = reloc_convert (eo, reloc, got_addr, ret);
+		if (ptr) {
+			ht_up_insert (reloc_ht, reloc->rva, NULL);
+			if (ptr->paddr == UT64_MAX) {
+				RVecRBinReloc_pop_back (ret);
 			}
+		} else if (reloc->rva != reloc->offset) {
+			ht_up_insert (reloc_ht, reloc->rva, NULL);
+			R_LOG_DEBUG ("Suspicious reloc patching at 0x%"PFMT64x" for 0x%08"PFMT64x" via 0x%"PFMT64x,
+				got_addr, reloc->rva, reloc->offset);
+		} else if (reloc->rva) {
+			R_LOG_WARN ("reloc conversion failed for 0x%"PFMT64x, got_addr);
+		} else {
+			R_LOG_DEBUG ("wrong reloc conversion failed for 0x%"PFMT64x, got_addr);
 		}
 	}
 	ht_up_free (reloc_ht);
-	eo->relocs_list = ret;
-#if 0
-	ret->free = NULL; // already freed in the hashtable
-	return r_list_clone (eo->relocs_list, NULL);
-#endif
-	RList *result = ret;
-	eo->relocs_list = NULL; // caller takes ownership
-	return result;
+	return ret;
 }
 
 static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc *rel, ut64 S, ut64 B, ut64 L, ut64 toc) {
@@ -1530,7 +1514,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 	}
 }
 
-static RList* patch_relocs(RBinFile *bf) {
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->rbin, NULL);
 	RBinReloc *ptr = NULL;
 	RBin *b = bf->rbin;
@@ -1599,13 +1583,13 @@ static RList* patch_relocs(RBinFile *bf) {
 	if (!relocs) {
 		return NULL;
 	}
-	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
 	if (!ret) {
 		return NULL;
 	}
 	HtUU *relocs_by_sym = ht_uu_new0 ();
 	if (!relocs_by_sym) {
-		r_list_free (ret);
+		RVecRBinReloc_free (ret);
 		return NULL;
 	}
 	ut64 vaddr = n_vaddr;
@@ -1645,7 +1629,7 @@ static RList* patch_relocs(RBinFile *bf) {
 			raddr = vaddr;
 		}
 		_patch_reloc (eo, eo->ehdr.e_machine, &b->iob, reloc, raddr, eo->baddr, plt_entry_addr, toc_base);
-		ptr = reloc_convert (eo, reloc, n_vaddr);
+		ptr = reloc_convert (eo, reloc, n_vaddr, ret);
 		if (!ptr) {
 			continue;
 		}
@@ -1666,7 +1650,6 @@ static RList* patch_relocs(RBinFile *bf) {
 				vaddr += cdsz;
 			}
 		}
-		r_list_append (ret, ptr);
 	}
 	ht_uu_free (relocs_by_sym);
 	return ret;

--- a/libr/bin/p/bin_le.c
+++ b/libr/bin/p/bin_le.c
@@ -121,41 +121,27 @@ static RList *libs(RBinFile *bf) {
 	return r_bin_le_get_libs (bf->bo->bin_obj);
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	return r_bin_le_get_relocs (bf->bo->bin_obj);
 }
 
-static RList* patch_relocs(RBinFile * bf) {
-	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
+static RVecRBinReloc *patch_relocs(RBinFile * bf) {
 	RBin *b = bf->rbin;
 	RBinLEObj *bin = bf->bo->bin_obj;
 	LE_image_header *h = bin->header;
 
-	RList * all_relocs = relocs (bf);
-	if (all_relocs == NULL) {
-		goto beach;
+	RVecRBinReloc *all_relocs = relocs (bf);
+	if (!all_relocs) {
+		return NULL;
 	}
-
-	RListIter * it;
-	RBinReloc * original;
-
-	r_list_foreach (all_relocs, it, original) {
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
+	RBinReloc *original;
+	R_VEC_FOREACH (all_relocs, original) {
 		if (original->import || original->symbol) {
 			continue;
 		}
-
-		RBinReloc * r = R_NEW0 (RBinReloc);
-		r->import = NULL;
-		r->symbol = NULL;
-		r->is_ifunc = false;
-		r->vaddr = original->vaddr;
-		r->paddr = original->paddr;
-		r->laddr = original->laddr;
-		r->addend = original->addend;
-		r->type = original->type;
-		r->ntype = original->ntype;
-
-		r_list_append (ret, r);
+		RBinReloc *r = RVecRBinReloc_emplace_back (ret);
+		*r = *original;
 
 		int size = 0, offset = 0;
 		ut8 buf[8] = {0};
@@ -188,16 +174,8 @@ static RList* patch_relocs(RBinFile * bf) {
 			}
 		}
 	}
-
-end:
-	r_list_free (all_relocs);
-
+	RVecRBinReloc_free (all_relocs);
 	return ret;
-
-beach:
-	r_list_free (ret);
-	ret = NULL;
-	goto end;
 }
 
 static RBinInfo *info(RBinFile *bf) {

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -315,14 +315,14 @@ static bool imports_vec(RBinFile *bf) {
 	return true;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
 	struct MACH0_(obj_t) *mo = bf->bo->bin_obj;
 	const RSkipList *relocs = MACH0_(load_relocs) (mo);
 	if (!relocs) {
 		return NULL;
 	}
-	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
 
 	RVecRBinImport *imports = mo->imports_loaded
 		? &mo->imports_cache
@@ -333,10 +333,9 @@ static RList *relocs(RBinFile *bf) {
 		if (reloc->external) {
 			continue;
 		}
-		RBinReloc *ptr = R_NEW0 (RBinReloc);
+		RBinReloc *ptr = RVecRBinReloc_emplace_back (ret);
 		ptr->type = reloc->type;
 		ptr->ntype = reloc->ntype;
-		ptr->additive = 0;
 		RBinImport *imp = NULL;
 		if (reloc->name[0]) {
 			imp = import_from_name (bf->rbin, (char*) reloc->name, mo->imports_by_name);
@@ -349,24 +348,16 @@ static RList *relocs(RBinFile *bf) {
 		ptr->addend = reloc->addend;
 		ptr->vaddr = reloc->addr;
 		ptr->paddr = reloc->offset;
-		r_list_append (ret, ptr);
 	}
-	RVecRBinReloc *fixups = &mo->reloc_fixups;
-	if (!RVecRBinReloc_empty (fixups)) {
-		RBinReloc *r;
-
-		R_VEC_FOREACH (fixups, r) {
-			RBinReloc *ptr = R_NEW0 (RBinReloc);
-			ptr->type = R_BIN_RELOC_64;
-			ptr->ntype = r->ntype;
-			ut64 paddr = r->paddr + mo->baddr;
-			ptr->vaddr = paddr;
-			ptr->paddr = r->vaddr;
-			ptr->addend = r->vaddr;
-			r_list_append (ret, ptr);
-		}
+	RBinReloc *r;
+	R_VEC_FOREACH (&mo->reloc_fixups, r) {
+		RBinReloc *ptr = RVecRBinReloc_emplace_back (ret);
+		ptr->type = R_BIN_RELOC_64;
+		ptr->ntype = r->ntype;
+		ptr->vaddr = r->paddr + mo->baddr;
+		ptr->paddr = r->vaddr;
+		ptr->addend = r->vaddr;
 	}
-
 	return ret;
 }
 
@@ -490,10 +481,10 @@ static bool _patch_reloc(struct MACH0_(obj_t) *mo, RIOBind *iob, struct reloc_t 
 	return true;
 }
 
-static RList* patch_relocs(RBinFile *bf) {
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->rbin, NULL);
 
-	RList *ret = NULL;
+	RVecRBinReloc *ret = NULL;
 	RIOMap *g = NULL;
 	HtUU *relocs_by_sym = NULL;
 	RIODesc *gotr2desc = NULL;
@@ -595,7 +586,7 @@ static RList* patch_relocs(RBinFile *bf) {
 	}
 	gotr2map->name = strdup (".got.r2");
 
-	if (!(ret = r_list_newf ((RListFree)r_bin_reloc_free))) {
+	if (!(ret = RVecRBinReloc_new ())) {
 		goto beach;
 	}
 	if (!(relocs_by_sym = ht_uu_new0 ())) {
@@ -615,20 +606,16 @@ static RList* patch_relocs(RBinFile *bf) {
 		if (!_patch_reloc (mo, iob, reloc, sym_addr)) {
 			continue;
 		}
-		RBinReloc *ptr = R_NEW0 (RBinReloc);
-		ptr->type = reloc->type;
-		ptr->ntype = reloc->ntype;
-		ptr->additive = 0;
 		RBinImport *imp = import_from_name (b, (char*) reloc->name, mo->imports_by_name);
 		if (R_LIKELY (imp)) {
+			RBinReloc *ptr = RVecRBinReloc_emplace_back (ret);
+			ptr->type = reloc->type;
+			ptr->ntype = reloc->ntype;
 			ptr->vaddr = sym_addr;
 			ptr->import = r_bin_import_clone (imp);
-			r_list_append (ret, ptr);
-		} else {
-			free (ptr);
 		}
 	}
-	if (r_list_empty (ret)) {
+	if (RVecRBinReloc_empty (ret)) {
 		goto beach;
 	}
 	ht_uu_free (relocs_by_sym);
@@ -639,7 +626,7 @@ static RList* patch_relocs(RBinFile *bf) {
 beach:
 	RVecExtReloc_fini (&ext_relocs);
 	r_io_desc_free (gotr2desc);
-	r_list_free (ret);
+	RVecRBinReloc_free (ret);
 	ht_uu_free (relocs_by_sym);
 	return NULL;
 }

--- a/libr/bin/p/bin_mdmp.c
+++ b/libr/bin/p/bin_mdmp.c
@@ -444,24 +444,12 @@ static RList *mem(RBinFile *bf) {
 	return ret;
 }
 
-static RList* relocs(RBinFile *bf) {
-	struct Pe32_r_bin_mdmp_pe_bin *pe32_bin;
-	struct Pe64_r_bin_mdmp_pe_bin *pe64_bin;
-	RListIter *it;
-	RList* ret = r_list_newf (free);
-	if (!ret) {
-		return NULL;
-	}
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	RBinMdmpObj *mdmp = (RBinMdmpObj*)bf->bo->bin_obj;
-	r_list_foreach (mdmp->pe32_bins, it, pe32_bin) {
-		if (pe32_bin->bin && pe32_bin->bin->relocs) {
-			r_list_join (ret, pe32_bin->bin->relocs);
-		}
-	}
-	r_list_foreach (mdmp->pe64_bins, it, pe64_bin) {
-		if (pe64_bin->bin && pe64_bin->bin->relocs) {
-			r_list_join (ret, pe64_bin->bin->relocs);
-		}
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
+	if (ret) {
+		// filled by imports_vec
+		RVecRBinReloc_swap (ret, &mdmp->relocs);
 	}
 	return ret;
 }
@@ -473,11 +461,12 @@ static bool imports_vec(RBinFile *bf) {
 
 	RVecRBinImport *ret = &bf->bo->imports_vec;
 	RBinMdmpObj *mdmp = (RBinMdmpObj*)bf->bo->bin_obj;
+	RVecRBinReloc_clear (&mdmp->relocs);
 	r_list_foreach (mdmp->pe32_bins, it, pe32_bin) {
-		Pe32_r_bin_mdmp_pe_load_imports (pe32_bin, ret);
+		Pe32_r_bin_mdmp_pe_load_imports (pe32_bin, ret, &mdmp->relocs);
 	}
 	r_list_foreach (mdmp->pe64_bins, it, pe64_bin) {
-		Pe64_r_bin_mdmp_pe_load_imports (pe64_bin, ret);
+		Pe64_r_bin_mdmp_pe_load_imports (pe64_bin, ret, &mdmp->relocs);
 	}
 	return true;
 }

--- a/libr/bin/p/bin_mdt.c
+++ b/libr/bin/p/bin_mdt.c
@@ -377,10 +377,10 @@ static bool sections_vec(RBinFile *bf) {
 	return true;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	r_return_val_if_fail (bf && bf->bo && bf->bo->bin_obj, NULL);
 	const RBinMdtObj *mdt = bf->bo->bin_obj;
-	RList *relocs = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *relocs = RVecRBinReloc_new ();
 	if (!relocs) {
 		return NULL;
 	}
@@ -388,39 +388,23 @@ static RList *relocs(RBinFile *bf) {
 	RListIter *iter;
 	RBinMdtPart *part;
 	r_list_foreach (mdt->parts, iter, part) {
-		if (part->relocs) {
-			RListIter *it;
-			RBinReloc *rel;
-			r_list_foreach (part->relocs, it, rel) {
-				RBinReloc *clone = R_NEW0 (RBinReloc);
-				if (!clone) {
-					continue;
-				}
-				*clone = *rel;
-				if (!clone->ntype) {
-					clone->ntype = clone->type;
-				}
-				r_list_append (relocs, clone);
-			}
-		} else if (part->format == R_BIN_MDT_PART_ELF && part->obj.elf) {
-			// Get relocs from nested ELF
-			const RVecRBinElfReloc *elf_relocs = Elf_(load_relocs) (part->obj.elf);
-			if (elf_relocs) {
-				RBinElfReloc *erel;
-				R_VEC_FOREACH (elf_relocs, erel) {
-					RBinReloc *rel = R_NEW0 (RBinReloc);
-					if (!rel) {
-						continue;
-					}
-					rel->vaddr = erel->rva + part->map->addr;
-					rel->paddr = erel->offset;
-					rel->type = erel->type;
-					rel->ntype = erel->type;
-					rel->addend = erel->addend;
-					// Skip complex symbol resolution for now
-					r_list_append (relocs, rel);
-				}
-			}
+		if (part->format != R_BIN_MDT_PART_ELF || !part->obj.elf) {
+			continue;
+		}
+		// Get relocs from nested ELF
+		const RVecRBinElfReloc *elf_relocs = Elf_(load_relocs) (part->obj.elf);
+		if (!elf_relocs) {
+			continue;
+		}
+		RBinElfReloc *erel;
+		R_VEC_FOREACH (elf_relocs, erel) {
+			RBinReloc *rel = RVecRBinReloc_emplace_back (relocs);
+			rel->vaddr = erel->rva + part->map->addr;
+			rel->paddr = erel->offset;
+			rel->type = erel->type;
+			rel->ntype = erel->type;
+			rel->addend = erel->addend;
+			// Skip complex symbol resolution for now
 		}
 	}
 

--- a/libr/bin/p/bin_mz.c
+++ b/libr/bin/p/bin_mz.c
@@ -191,27 +191,9 @@ static char *header(RBinFile *bf, int mode) {
 	return r_strbuf_drain (sb);
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
-	const struct r_bin_mz_reloc_t *relocs = NULL;
-	int i;
-
-	RList *ret = r_list_newf (free);
-	if (!ret) {
-		return NULL;
-	}
-	if (!(relocs = r_bin_mz_get_relocs (bf->bo->bin_obj))) {
-		return ret;
-	}
-	for (i = 0; !relocs[i].last; i++) {
-		RBinReloc *rel = R_NEW0 (RBinReloc);
-		rel->type = R_BIN_RELOC_16;
-		rel->vaddr = relocs[i].vaddr;
-		rel->paddr = relocs[i].paddr;
-		r_list_append (ret, rel);
-	}
-	free ((void *)relocs);
-	return ret;
+	return r_bin_mz_get_relocs (bf->bo->bin_obj);
 }
 
 static RList* fields(RBinFile *bf) {

--- a/libr/bin/p/bin_ne.c
+++ b/libr/bin/p/bin_ne.c
@@ -96,7 +96,7 @@ static bool imports_vec(RBinFile *bf) {
 	return true;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	return r_bin_ne_get_relocs (bf->bo->bin_obj, &bf->bo->symbols_vec, &bf->bo->sections_vec);
 }
 

--- a/libr/bin/p/bin_pe.inc.c
+++ b/libr/bin/p/bin_pe.inc.c
@@ -555,12 +555,8 @@ static bool imports_vec(RBinFile *bf) {
 		return false;
 	}
 	RVecRBinImport *ret = &bf->bo->imports_vec;
-	r_list_free (pe->relocs);
-	RList *relocs = r_list_newf ((RListFree)r_bin_reloc_free);
-	if (!relocs) {
-		return false;
-	}
-	pe->relocs = relocs;
+	RVecRBinReloc *relocs = &pe->relocs;
+	RVecRBinReloc_clear (relocs);
 
 	RVecPEImport *imports = PE_(r_bin_pe_get_imports)(pe);
 	if (!imports) {
@@ -579,33 +575,31 @@ static bool imports_vec(RBinFile *bf) {
 		ptr->type = "FUNC";
 		ptr->ordinal = imp->ordinal;
 
-		RBinReloc *rel = R_NEW0 (RBinReloc);
+		RBinReloc *rel = RVecRBinReloc_emplace_back (relocs);
 #ifdef R_BIN_PE64
 		rel->type = R_BIN_RELOC_64;
 #else
 		rel->type = R_BIN_RELOC_32;
 #endif
-		rel->additive = 0;
 		rel->import = r_bin_import_clone (ptr);
-		rel->addend = 0;
 		rel->vaddr = r_buf_read_le32_at (bf->buf, imp->paddr);
 		rel->paddr = imp->paddr;
 		rel->ntype = imp->ntype;
-		r_list_append (relocs, rel);
 	}
 	RVecPEImport_free (imports);
 	return true;
 }
 
-static RList* relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	RBinPEObj *pe = PE_(get) (bf);
-	if (pe && pe->relocs) {
-		RList *l = r_list_clone (pe->relocs, NULL);
-		// ownership transferred
-		pe->relocs->free = NULL;
-		return l;
+	if (!pe || RVecRBinReloc_empty (&pe->relocs)) {
+		return NULL;
 	}
-	return NULL;
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
+	if (ret) {
+		RVecRBinReloc_swap (ret, &pe->relocs);
+	}
+	return ret;
 }
 
 static RList* libs(RBinFile *bf) {
@@ -785,29 +779,12 @@ static bool has_canary(RBinFile *bf) {
 	if (check_inlined_canary (bf)) {
 		return true;
 	}
-	RBinPEObj *pe = PE_(get) (bf);
-	if (pe) {
-		const RList *relocs_list = pe->relocs;
-		if (relocs_list) {
-			RListIter *iter;
-			RBinReloc *rel;
-			r_list_foreach (relocs_list, iter, rel) {
-				if (rel->import) {
-					const char *name = r_bin_name_tostring2 (rel->import->name, 'o');
-					if (!strcmp (name, "__security_init_cookie")) {
-						return true;
-					}
-				}
-			}
-		}
-	} else {  // rabin2 needs this as it will not initialise bin
-		imports_vec (bf);
-		RBinImport *imp;
-		R_VEC_FOREACH (&bf->bo->imports_vec, imp) {
-			const char *name = r_bin_name_tostring2 (imp->name, 'o');
-			if (!strcmp (name, "__security_init_cookie")) {
-				return true;
-			}
+	// the reloc list is 1:1 with the imports, so check those instead
+	RBinImport *imp;
+	R_VEC_FOREACH (&bf->bo->imports_vec, imp) {
+		const char *name = r_bin_name_tostring2 (imp->name, 'o');
+		if (!strcmp (name, "__security_init_cookie")) {
+			return true;
 		}
 	}
 	return false;

--- a/libr/bin/p/bin_pef.c
+++ b/libr/bin/p/bin_pef.c
@@ -862,10 +862,10 @@ static void pef_decode_reloc_blocks(RBinFile *bf) {
 	}
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	RBinPEFObj *pef = bf->bo->bin_obj;
 	pef_decode_reloc_blocks (bf);
-	RList *ret = r_list_newf ((RListFree)r_bin_reloc_free);
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
 	/* ensure imports vec is populated; safe even if already filled */
 	if (RVecRBinImport_empty (&bf->bo->imports_vec)) {
 		imports_vec (bf);
@@ -878,34 +878,27 @@ static RList *relocs(RBinFile *bf) {
 
 	for (i = 0; i < pef->nsec; i++) {
 		r_list_foreach (pef->sec[i].relocs, iter, r) {
-			RBinReloc *ptr = R_NEW0 (RBinReloc);
+			if (r->target >= (r->isimport? importCount: pef->nsec)) {
+				continue;
+			}
+			RBinReloc *ptr = RVecRBinReloc_emplace_back (ret);
 			ptr->type = R_BIN_RELOC_32;
 			ptr->additive = 1;
 			ptr->vaddr = pef->sec[i].addr + r->offset;
 			if (r->isimport) {
-				if (r->target >= importCount) {
-					free (ptr);
-					continue;
-				}
 				ptr->import = r_bin_import_clone (RVecRBinImport_at (importVec, r->target));
 			} else {
-				if (r->target >= pef->nsec) {
-					free (ptr);
-					continue;
-				}
 				ptr->addend = pef->sec[r->target].addr;
 			}
-			r_list_append (ret, ptr);
 		}
 	}
 	return ret;
 }
 
-static RList *patch_relocs(RBinFile *bf) {
-	RList *list = relocs (bf);
-	RListIter *iter;
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
+	RVecRBinReloc *list = relocs (bf);
 	RBinReloc *reloc;
-	r_list_foreach (list, iter, reloc) {
+	R_VEC_FOREACH (list, reloc) {
 		if (reloc->import) {
 			continue;
 		}

--- a/libr/bin/p/bin_qnx.c
+++ b/libr/bin/p/bin_qnx.c
@@ -40,7 +40,7 @@ static bool check(RBinFile *bf, RBuffer *buf) {
 static void destroy(RBinFile *bf) {
 	QnxObj *qo = bf->bo->bin_obj;
 	RVecRBinSection_fini (&qo->sections);
-	r_list_free (qo->fixups);
+	RVecRBinReloc_fini (&qo->fixups);
 	r_list_free (qo->resources);
 	bf->bo->bin_obj = NULL;
 	free (qo);
@@ -52,14 +52,14 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 	lmf_resource lres;
 	lmf_data ldata;
 	ut64 offset = QNX_RECORD_SIZE;
-	RList *fixups = NULL;
 	RList *resources = NULL;
 
 	if (!qo) {
 		goto beach;
 	}
 	RVecRBinSection_init (&qo->sections);
-	if (!(fixups = r_list_new ()) || !(resources = r_list_newf (free))) {
+	RVecRBinReloc_init (&qo->fixups);
+	if (!(resources = r_list_newf (free))) {
 		goto beach;
 	}
 	qo->kv = sdb_new0 ();
@@ -116,31 +116,19 @@ static bool load(RBinFile *bf, RBuffer *buf, ut64 loadaddr) {
 			ptr->vsize = lrec.data_nbytes - sizeof (lmf_data);
 			ptr->size = ptr->vsize;
 			ptr->add = true;
-		} else if (lrec.rec_type == LMF_FIXUP_REC) {
-			RBinReloc *ptr = R_NEW0 (RBinReloc);
+		} else if (lrec.rec_type == LMF_FIXUP_REC || lrec.rec_type == LMF_8087_FIXUP_REC) {
 			if (r_buf_fread_at (bf->buf, offset, (ut8 *)&ldata, "si", 1) != sizeof (lmf_data)) {
-				free (ptr);
 				goto beach;
 			}
+			RBinReloc *ptr = RVecRBinReloc_emplace_back (&qo->fixups);
 			ptr->vaddr = ptr->paddr = ldata.offset;
-			ptr->type = 'f'; // "LMF_FIXUP";
-			r_list_append (fixups, ptr);
-		} else if (lrec.rec_type == LMF_8087_FIXUP_REC) {
-			RBinReloc *ptr = R_NEW0 (RBinReloc);
-			if (r_buf_fread_at (bf->buf, offset, (ut8 *)&ldata, "si", 1) != sizeof (lmf_data)) {
-				free (ptr);
-				goto beach;
-			}
-			ptr->vaddr = ptr->paddr = ldata.offset;
-			ptr->type = 'F'; // "LMF_8087_FIXUP";
-			r_list_append (fixups, ptr);
+			ptr->type = (lrec.rec_type == LMF_FIXUP_REC)? 'f': 'F'; // "LMF_FIXUP" / "LMF_8087_FIXUP"
 		} else if (lrec.rec_type == LMF_RW_END_REC) {
 			r_buf_fread_at (bf->buf, offset, (ut8 *)&qo->rwend, "si", 1);
 		}
 		offset += lrec.data_nbytes;
 	}
 	sdb_ns_set (bf->sdb, "info", qo->kv);
-	qo->fixups = fixups;
 	qo->resources = resources;
 	bf->bo->bin_obj = qo;
 	return true;
@@ -148,9 +136,9 @@ beach:
 	if (qo) {
 		sdb_free (qo->kv);
 		RVecRBinSection_fini (&qo->sections);
+		RVecRBinReloc_fini (&qo->fixups);
 		free (qo);
 	}
-	r_list_free (fixups);
 	r_list_free (resources);
 	return false;
 }
@@ -176,13 +164,17 @@ static RBinInfo *info(RBinFile *bf) {
 	return ret;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	R_RETURN_VAL_IF_FAIL (bf && bf->bo, NULL);
 	QnxObj *qo = bf->bo->bin_obj;
-	if (qo && qo->fixups) {
-		return r_list_clone (qo->fixups, NULL);
+	if (!qo) {
+		return NULL;
 	}
-	return NULL;
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
+	if (ret) {
+		RVecRBinReloc_swap (ret, &qo->fixups);
+	}
+	return ret;
 }
 
 static char *header(RBinFile *bf, int mode) {

--- a/libr/bin/p/bin_rel.c
+++ b/libr/bin/p/bin_rel.c
@@ -445,7 +445,8 @@ static bool _overlay_write_at_hack(RIO *io, ut64 addr, const ut8 *buf, int len) 
 
 // Applies a relocation on the current program.
 // Does not generate RBinReloc/RBinImport entries.
-static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *reloc, ut32 module, ut32 P) {
+// patches the reloc and appends it to `out`, returns false if unsupported
+static bool patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *reloc, ut32 module, ut32 P, RVecRBinReloc *out) {
 	ut32 value_old, value; // (*P)
 	ut32 S; // Section vaddr of symbol
 	ut32 A = reloc->addend; // sym vaddr = S + A
@@ -458,7 +459,7 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 		S = get_section_vaddr (rel, reloc->section);
 		if (!S) {
 			R_LOG_ERROR ("Invalid reloc against section %d with unknown virtual addr", reloc->section);
-			return NULL;
+			return false;
 		}
 	}
 
@@ -466,7 +467,7 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 	// if (r_buf_fread_at (buf, paddr, (void *)&V, "I", 1) == -1) {
 	if (!vread_at_be32 (b, P, &value)) {
 		R_LOG_ERROR ("REL: Cannot read reloc target at %#08x", P);
-		return NULL;
+		return false;
 	}
 	value_old = value;
 	int size = 0;
@@ -475,7 +476,7 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 	switch (reloc->type) {
 	case R_RVL_NONE:
 	case R_RVL_SECT:
-		return NULL;
+		return false;
 	case R_PPC_ADDR32:     size = 4; value = S + A;                              break;
 	case R_PPC_ADDR24:     size = 4; value = set_low24 (value, (S + A) >> 2);     break;
 	case R_PPC_REL24:      size = 4; value = set_low24 (value, (S + A - P) >> 2); break;
@@ -486,7 +487,7 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 		if (b->iob.overlay_write_at != _overlay_write_at_hack) {
 			R_LOG_ERROR ("REL: Unsupported reloc type %d", reloc->type);
 		}
-		return NULL;
+		return false;
 	}
 	// clang-format on
 
@@ -506,20 +507,12 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 	// if (r_buf_fwrite_at (buf, paddr, (void *)&V, "I", 1) == -1) {
 	if (!vwriten_at_be32 (b, P, value, size)) {
 		R_LOG_ERROR ("REL: Cannot write reloc target at %#08x", P);
-		return NULL;
+		return false;
 	}
 
-	RBinReloc *ret = R_NEW0 (RBinReloc);
-	switch (size) {
-	// UNREACHABLE case 1: ret->type = R_BIN_RELOC_8; break;
-	case 2: ret->type = R_BIN_RELOC_16; break;
-	// UNREACHABLE case 3: ret->type = R_BIN_RELOC_24; break;
-	case 4: ret->type = R_BIN_RELOC_32; break;
-	default:
-		R_LOG_DEBUG ("Cannot convert reloc of size %d to RBinReloc", size);
-		free (ret);
-		return NULL;
-	}
+	RBinReloc *ret = RVecRBinReloc_emplace_back (out);
+	// sizes 1 and 3 are unreachable, see the switch above
+	ret->type = (size == 2)? R_BIN_RELOC_16: R_BIN_RELOC_32;
 	ret->ntype = reloc->type;
 	ret->addend = A;
 	ret->vaddr = P;
@@ -527,15 +520,15 @@ static RBinReloc *patch_reloc(RBin *b, const LoadedRel *rel, const RelReloc *rel
 	if (s && s->paddr != 0) {
 		ret->paddr = P - b->cur->bo->baddr;
 	}
-	return ret;
+	return true;
 }
 
-static RList *patch_relocs(RBinFile *bf) {
+static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	int i, j;
 	RBin *b = bf->rbin;
 	const LoadedRel *rel = b->cur->bo->bin_obj;
 
-	RList *ret = r_list_new ();
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
 	for (i = 0; i < rel->num_imps; i++) {
 		const RelImp *imp = &rel->imps[i];
 		if (imp->module != 0 && imp->module != rel->hdr.module_id) {
@@ -553,23 +546,20 @@ static RList *patch_relocs(RBinFile *bf) {
 			if (!reloc_step_vaddr (rel, reloc, &P)) {
 				break;
 			}
-			RBinReloc *r_reloc = patch_reloc (b, rel, reloc, imp->module, P);
-			if (ret && r_reloc) {
-				r_list_append (ret, r_reloc);
-			}
+			patch_reloc (b, rel, reloc, imp->module, P, ret);
 		}
 	}
 	return ret;
 }
 
-static RList *relocs(RBinFile *bf) {
+static RVecRBinReloc *relocs(RBinFile *bf) {
 	if (!bf || !bf->rbin) {
 		return NULL;
 	}
 	RBin *b = bf->rbin;
 	void *tmp = b->iob.overlay_write_at;
 	b->iob.overlay_write_at = _overlay_write_at_hack;
-	RList *ret = patch_relocs (bf);
+	RVecRBinReloc *ret = patch_relocs (bf);
 	b->iob.overlay_write_at = tmp;
 	return ret;
 }

--- a/libr/bin/p/bin_som.c
+++ b/libr/bin/p/bin_som.c
@@ -59,13 +59,6 @@ static RList *libs(RBinFile *bf) {
 	return r_bin_som_get_libs (bf->bo->bin_obj);
 }
 
-static RList *relocs(RBinFile *bf) {
-	if (!bf || !bf->bo || !bf->bo->bin_obj) {
-		return NULL;
-	}
-	return r_bin_som_get_relocs (bf->bo->bin_obj);
-}
-
 static RBinInfo *info(RBinFile *bf) {
 	if (!bf || !bf->bo || !bf->bo->bin_obj) {
 		return NULL;
@@ -146,7 +139,6 @@ RBinPlugin r_bin_plugin_som = {
 	.header = &header,
 	.size = &size,
 	.libs = &libs,
-	.relocs = &relocs,
 };
 
 #ifndef R2_PLUGIN_INCORE

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -2071,7 +2071,7 @@ static bool bin_relocs(RCore *core, PJ *pj, int mode, int va) {
 
 	va = VA_TRUE; // XXX relocs always vaddr?
 	// this has been created for reloc object files
-	RRBTree *relocs = r_bin_get_relocs (core->bin);
+	RVecRBinReloc *relocs = r_bin_get_relocs (core->bin);
 	const bool apply_relocs = r_config_get_b (core->config, "bin.relocs.apply");
 	const bool bc = r_config_get_b (core->config, "bin.cache");
 	if (apply_relocs) {
@@ -2124,11 +2124,10 @@ static bool bin_relocs(RCore *core, PJ *pj, int mode, int va) {
 		r_flag_space_set (core->flags, R_FLAGS_FS_RELOCS);
 	}
 
-	RRBNode *node;
 	RBinReloc *reloc;
 	RelocInfo ri = { 0 };
 	ri_init (core, &ri);
-	r_crbtree_foreach (relocs, node, RBinReloc, reloc) {
+	R_VEC_FOREACH (relocs, reloc) {
 		ut64 addr = rva (core->bin, reloc->paddr, reloc->vaddr, va);
 		if (IS_MODE_SET (mode) && (is_section_reloc (reloc) || is_file_reloc (reloc))) {
 			/*

--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -6232,14 +6232,11 @@ static RList *foreach3list(RCore *core, char type, const char *glob) {
 		break;
 	case 'R': // "@@@R" relocs
 		{
-			RRBTree *rels = r_bin_get_relocs (core->bin);
+			RVecRBinReloc *rels = r_bin_get_relocs (core->bin);
 			if (rels) {
-				RRBNode *node = r_crbtree_first_node (rels);
-				while (node) {
-					RBinReloc *rel = (RBinReloc *)node->data;
-					ut64 addr = va? rel->vaddr: rel->paddr;
-					append_item (list, NULL, addr, UT64_MAX);
-					node = r_rbnode_next (node);
+				RBinReloc *rel;
+				R_VEC_FOREACH (rels, rel) {
+					append_item (list, NULL, va? rel->vaddr: rel->paddr, UT64_MAX);
 				}
 			}
 		}

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -84,37 +84,10 @@ static void r_core_debug_syscall_hit(RCore *core) {
 	}
 }
 
-struct getreloc_t {
-	ut64 vaddr;
-	int size;
-};
-
-static int getreloc_tree(void *incoming, void *in, void *user) {
-	struct getreloc_t *gr = (struct getreloc_t *)incoming;
-	RBinReloc *r = (RBinReloc *)in;
-	if ((r->vaddr >= gr->vaddr) && (r->vaddr < (gr->vaddr + gr->size))) {
-		return 0;
-	}
-	if (gr->vaddr > r->vaddr) {
-		return 1;
-	}
-	if (gr->vaddr < r->vaddr) {
-		return -1;
-	}
-	return 0;
-}
-
 R_API RBinReloc *r_core_getreloc(RCore *core, ut64 addr, int size) {
 	R_RETURN_VAL_IF_FAIL (core, NULL);
-	if (size < 1 || addr == UT64_MAX) {
-		return NULL;
-	}
-	RRBTree *relocs = r_bin_get_relocs (core->bin);
-	if (R_LIKELY (relocs)) {
-		struct getreloc_t gr = { .vaddr = addr, .size = size };
-		return r_crbtree_find (relocs, &gr, getreloc_tree, NULL);
-	}
-	return NULL;
+	RVecRBinReloc *relocs = r_bin_get_relocs (core->bin);
+	return relocs? r_bin_reloc_at (relocs, addr, size): NULL;
 }
 
 /* returns the address of a jmp/call given a shortcut by the user or UT64_MAX

--- a/libr/core/dmh_glibc.inc.c
+++ b/libr/core/dmh_glibc.inc.c
@@ -572,7 +572,7 @@ static GHT GH (get_main_arena_offset_with_relocs) (RCore *core, const char *libc
 		R_LOG_WARN ("get_main_arena_with_relocs: Failed to open libc %s", libc_path);
 		return GHT_MAX;
 	}
-	RRBTree *relocs = r_bin_get_relocs (bin);
+	RVecRBinReloc *relocs = r_bin_get_relocs (bin);
 	if (!relocs) {
 		R_LOG_WARN ("get_main_arena_with_relocs: Failed to get relocs from libc %s", libc_path);
 		return GHT_MAX;
@@ -618,10 +618,8 @@ static GHT GH (get_main_arena_offset_with_relocs) (RCore *core, const char *libc
 	}
 
 	// Iterate over relocations and look for malloc_state structure
-	RRBNode *node;
 	RBinReloc *reloc;
-
-	r_crbtree_foreach (relocs, node, RBinReloc, reloc) {
+	R_VEC_FOREACH (relocs, reloc) {
 		// We only care about relocations in .data section
 		if (reloc->vaddr - next_field_offset < data_section->vaddr ||
 			reloc->vaddr > data_section->vaddr + data_section->size)

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -449,6 +449,35 @@ R_VEC_TYPE_WITH_FINI (RVecRBinResource, RBinResource, r_bin_resource_fini);
 R_VEC_TYPE(RVecRBinEntry, RBinSymbol);
 R_VEC_TYPE(RVecBinSymclassGlob, char *);
 
+typedef struct r_bin_reloc_t {
+	ut8 type; // type have implicit size.. but its anoying
+	ut8 additive;
+	bool is_ifunc;
+	ut32 visibility;
+	ut64 ntype; // type number coming from the bin file
+	RBinSymbol *symbol;
+	RBinImport *import;
+	ut64 laddr; // local symbol address | UT64_MAX
+	// RBinSymbol *lsymbol; // still unused
+	st64 addend;
+	ut64 vaddr;
+	ut64 paddr;
+	/* is_ifunc: indirect function, `addend` points to a resolver function
+	 * that returns the actual relocation value, e.g. chooses
+	 * an optimized version depending on the CPU.
+	 * cf. https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+	 */
+} RBinReloc;
+
+R_API void r_bin_import_free(RBinImport *imp);
+static inline void r_bin_reloc_fini(RBinReloc *reloc) {
+	if (reloc) {
+		r_bin_import_free (reloc->import);
+	}
+}
+// sorted by vaddr, relocs own their import (if any)
+R_VEC_TYPE_WITH_FINI (RVecRBinReloc, RBinReloc, r_bin_reloc_fini);
+
 typedef struct r_bin_object_t {
 	ut64 baddr;
 	st64 baddr_shift;
@@ -465,7 +494,7 @@ typedef struct r_bin_object_t {
 	RList/*<??>*/ *entries;
 	RList/*<??>*/ *fields;
 	RList/*<??>*/ *libs;
-	RRBTree/*<RBinReloc>*/ *relocs;
+	RVecRBinReloc *relocs;
 	RVecRBinString strings;
 	RList/*<RBinClass>*/ *classes;
 	HtPP *classes_ht;
@@ -732,11 +761,11 @@ typedef struct r_bin_plugin_t {
 	RBinInfo/*<RBinInfo>*/* (*info)(RBinFile *bf);
 	RList/*<RBinField>*/* (*fields)(RBinFile *bf);
 	RList/*<char *>*/* (*libs)(RBinFile *bf);
-	RList/*<RBinReloc>*/* (*relocs)(RBinFile *bf);
+	RVecRBinReloc *(*relocs)(RBinFile *bf);
 	RList/*<RBinTrycatch>*/* (*trycatch)(RBinFile *bf);
 	RList/*<RBinClass>*/* (*classes)(RBinFile *bf);
 	RList/*<RBinMem>*/* (*mem)(RBinFile *bf);
-	RList/*<RBinReloc>*/* (*patch_relocs)(RBinFile *bf);
+	RVecRBinReloc *(*patch_relocs)(RBinFile *bf); // NULL keeps the current relocs
 	RList/*<RBinMap>*/* (*maps)(RBinFile *bf); // this should be segments!
 	RList/*<RBinFileHash>*/* (*hashes)(RBinFile *bf);
 	char* (*header)(RBinFile *bf, int mode);
@@ -806,27 +835,6 @@ typedef struct r_bin_class_t {
 		}\
 	} while (0)
 
-typedef struct r_bin_reloc_t {
-	ut8 type; // type have implicit size.. but its anoying
-	ut8 additive;
-	bool is_ifunc;
-	ut32 visibility;
-	ut64 ntype; // type number coming from the bin file
-	RBinSymbol *symbol;
-	RBinImport *import;
-	ut64 laddr; // local symbol address | UT64_MAX
-	// RBinSymbol *lsymbol; // still unused
-	st64 addend;
-	ut64 vaddr;
-	ut64 paddr;
-	/* is_ifunc: indirect function, `addend` points to a resolver function
-	 * that returns the actual relocation value, e.g. chooses
-	 * an optimized version depending on the CPU.
-	 * cf. https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
-	 */
-} RBinReloc;
-
-R_VEC_TYPE (RVecRBinReloc, RBinReloc);
 
 R_API const char *r_bin_field_kindstr(RBinField *f);
 R_API RBinField *r_bin_field_new(ut64 paddr, ut64 vaddr, ut64 value, int size, const char *name, const char *comment, const char *format, bool format_named);
@@ -900,13 +908,6 @@ R_API void r_bin_string_free(void *_str);
 
 #ifdef R_API
 
-static inline void r_bin_reloc_free(RBinReloc *reloc) {
-	if (reloc) {
-		r_bin_import_free (reloc->import);
-		free (reloc);
-	}
-}
-
 R_API RBinImport *r_bin_import_clone(RBinImport *o);
 typedef void (*RBinSymbolCallback)(RBinObject *obj, RBinSymbol *symbol);
 
@@ -962,8 +963,9 @@ R_API RVecRBinString *r_bin_dump_strings(RBinFile *a, int min, int raw);
 // use RBinFile instead
 R_API const RList *r_bin_get_entries(RBin *bin);
 R_API RList *r_bin_get_libs(RBin *bin);
-R_API RRBTree *r_bin_patch_relocs(RBinFile *bin);
-R_API RRBTree *r_bin_get_relocs(RBin *bin);
+R_API RVecRBinReloc *r_bin_patch_relocs(RBinFile *bin);
+R_API RVecRBinReloc *r_bin_get_relocs(RBin *bin);
+R_API RBinReloc *r_bin_reloc_at(RVecRBinReloc *relocs, ut64 vaddr, int size);
 R_API RVecRBinSection *r_bin_get_sections_vec(RBin *bin);
 R_API RList *r_bin_get_classes(RBin *bin);
 R_API char* r_bin_get_types(RBin *bin);


### PR DESCRIPTION
* Perf wise its 3x faster to construct and 2x lookups
* RBinReloc lifetime depends on PatchRelocs/Reload calls
* 10% memory usage reduced

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
