### PR TITLE
Optimize relocation name construction and string formatting

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1837,31 +1837,47 @@ static ut8 bin_reloc_size(RBinReloc *reloc) {
 }
 
 // name can be optionally used to explicitly set the used base name (for example for demangling), otherwise the import name will be used.
-static char *construct_reloc_name(RBinReloc *R_NONNULL reloc, const char *R_NULLABLE name) {
-	RStrBuf *buf = r_strbuf_new ("");
-
+// builds "<pfx><libname_><name>" in a single allocation, NULL if the reloc has no name
+static char *construct_reloc_name(RBinReloc *R_NONNULL reloc, const char *R_NULLABLE name, const char *pfx) {
+	char ifunc[32];
+	if (!name) {
+		if (reloc->import) {
+			name = r_bin_name_tostring (reloc->import->name);
+		} else if (reloc->symbol) {
+			name = r_bin_name_tostring (reloc->symbol->name);
+		} else if (reloc->is_ifunc) {
+			// addend is the function pointer for the resolving ifunc
+			snprintf (ifunc, sizeof (ifunc), "ifunc_%" PFMT64x, reloc->addend);
+			name = ifunc;
+		} else {
+			// TODO implement constant relocs.
+			return NULL;
+		}
+	}
 	// (optional) libname_
+	const char *lib = NULL;
 	if (reloc->import && reloc->import->libname) {
-		r_strbuf_appendf (buf, "%s_", reloc->import->libname);
+		lib = reloc->import->libname;
 	} else if (reloc->symbol && reloc->symbol->libname) {
-		r_strbuf_appendf (buf, "%s_", reloc->symbol->libname);
+		lib = reloc->symbol->libname;
 	}
-
-	// actual name
-	if (name) {
-		r_strbuf_append (buf, name);
-	} else if (reloc->import) {
-		r_strbuf_append (buf, r_bin_name_tostring (reloc->import->name));
-	} else if (reloc->symbol) {
-		r_strbuf_append (buf, r_bin_name_tostring (reloc->symbol->name));
-	} else if (reloc->is_ifunc) {
-		// addend is the function pointer for the resolving ifunc
-		r_strbuf_appendf (buf, "ifunc_%" PFMT64x, reloc->addend);
-	} else {
-		// TODO implement constant relocs.
-		r_strbuf_set (buf, "");
+	const size_t plen = strlen (pfx);
+	const size_t llen = lib? strlen (lib): 0;
+	const size_t nlen = strlen (name);
+	char *res = malloc (plen + llen + 1 + nlen + 1);
+	if (!res) {
+		return NULL;
 	}
-	return r_strbuf_drain (buf);
+	char *p = res;
+	memcpy (p, pfx, plen);
+	p += plen;
+	if (lib) {
+		memcpy (p, lib, llen);
+		p += llen;
+		*p++ = '_';
+	}
+	memcpy (p, name, nlen + 1);
+	return res;
 }
 
 typedef struct {
@@ -1873,10 +1889,18 @@ typedef struct {
 	bool reloc_xrefs;
 	bool is_pe;
 	bool is32;
+	char *flagpfx; // "[bin.prefix.]reloc."
+	size_t flagpfx_len;
 } RelocInfo;
+
+static void ri_fini(RelocInfo *ri) {
+	free (ri->flagpfx);
+}
 
 static void ri_init(RCore *core, RelocInfo *ri) {
 	ri->core = core;
+	ri->flagpfx = core->bin->prefix? r_str_newf ("%s.reloc.", core->bin->prefix): strdup ("reloc.");
+	ri->flagpfx_len = strlen (ri->flagpfx);
 	ri->bin_demangle = r_config_get_b (core->config, "bin.demangle");
 	ri->keep_lib = r_config_get_b (core->config, "bin.demangle.pfxlib");
 	ri->reloc_xrefs = r_config_get_b (core->config, "bin.relocs.xrefs");
@@ -1926,33 +1950,28 @@ static void set_bin_relocs(RelocInfo *ri, RBinReloc *reloc, ut64 addr, Sdb **db,
 		free (module);
 	}
 
-	char *reloc_name = construct_reloc_name (reloc, NULL);
-	if (R_STR_ISEMPTY (reloc_name)) {
+	// "[prefix.]reloc.[lib_]name" built in one go, r_flag_set filters the name itself
+	char *flagname = construct_reloc_name (reloc, NULL, ri->flagpfx);
+	if (!flagname) {
 		char name[32] = { 0 };
 		r_io_read_at (core->io, reloc->addend, (ut8 *)name, sizeof (name));
 		name[sizeof (name) - 1] = 0;
 		if (name[0] && name[1] && isalpha (name[0]) && isalpha (name[1])) {
 			r_name_filter (name, -1);
 			R_LOG_DEBUG ("Naming fixup reloc with string %s", name);
-			free (reloc_name);
-			reloc_name = r_str_newf ("fixup.%s", name);
+			flagname = r_str_newf ("%sfixup.%s", ri->flagpfx, name);
 			if (ri->reloc_xrefs) {
 				r_anal_xrefs_set (core->anal, reloc->vaddr, reloc->addend, R_ANAL_REF_TYPE_DATA);
 			}
 		} else {
-			free (reloc_name);
 			return;
 		}
 	}
-	char *flagname = core->bin->prefix
-		? r_str_newf ("%s.reloc.%s", core->bin->prefix, reloc_name)
-		: r_str_newf ("reloc.%s", reloc_name);
 	if (reloc->laddr) {
-		char *internal_reloc = r_str_newf ("rsym.%s", reloc_name);
+		char *internal_reloc = r_str_newf ("rsym.%s", flagname + ri->flagpfx_len);
 		(void)r_flag_set (core->flags, internal_reloc, reloc->laddr, bin_reloc_size (reloc));
 		free (internal_reloc);
 	}
-	free (reloc_name);
 	char *demname = NULL;
 	if (ri->bin_demangle) {
 		demname = r_bin_demangle (core->bin->cur, ri->lang, flagname, addr, ri->keep_lib);
@@ -1961,7 +1980,6 @@ static void set_bin_relocs(RelocInfo *ri, RBinReloc *reloc, ut64 addr, Sdb **db,
 			flagname = r_str_newf ("reloc.%s", demname);
 		}
 	}
-	r_name_filter (flagname, 0);
 	if (addr == UT64_MAX) {
 		R_LOG_DEBUG ("Cannot resolve reloc %s", demname);
 	} else {
@@ -2235,7 +2253,7 @@ static bool bin_relocs(RCore *core, PJ *pj, int mode, int va) {
 					name = mn;
 				}
 			}
-			char *reloc_name = construct_reloc_name (reloc, name);
+			char *reloc_name = construct_reloc_name (reloc, name, "");
 			RStrBuf *buf = r_strbuf_new (reloc_name);
 			free (reloc_name);
 			R_FREE (name);
@@ -2277,7 +2295,7 @@ static bool bin_relocs(RCore *core, PJ *pj, int mode, int va) {
 	r_table_free (table);
 	R_FREE (sdb_module);
 	sdb_free (db);
-	db = NULL;
+	ri_fini (&ri);
 
 	R_TIME_PROFILE_END;
 	return true;

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -1845,13 +1845,16 @@ static char *construct_reloc_name(RBinReloc *R_NONNULL reloc, const char *R_NULL
 			name = r_bin_name_tostring (reloc->import->name);
 		} else if (reloc->symbol) {
 			name = r_bin_name_tostring (reloc->symbol->name);
-		} else if (reloc->is_ifunc) {
-			// addend is the function pointer for the resolving ifunc
-			snprintf (ifunc, sizeof (ifunc), "ifunc_%" PFMT64x, reloc->addend);
-			name = ifunc;
-		} else {
-			// TODO implement constant relocs.
-			return NULL;
+		}
+		if (R_STR_ISEMPTY (name)) {
+			if (reloc->is_ifunc) {
+				// addend is the function pointer for the resolving ifunc
+				snprintf (ifunc, sizeof (ifunc), "ifunc_%" PFMT64x, reloc->addend);
+				name = ifunc;
+			} else {
+				// TODO implement constant relocs.
+				return NULL;
+			}
 		}
 	}
 	// (optional) libname_
@@ -1968,6 +1971,7 @@ static void set_bin_relocs(RelocInfo *ri, RBinReloc *reloc, ut64 addr, Sdb **db,
 		}
 	}
 	if (reloc->laddr) {
+		// the "[lib_]name" part of the flag, skipping the "[prefix.]reloc." prefix
 		char *internal_reloc = r_str_newf ("rsym.%s", flagname + ri->flagpfx_len);
 		(void)r_flag_set (core->flags, internal_reloc, reloc->laddr, bin_reloc_size (reloc));
 		free (internal_reloc);
@@ -1977,7 +1981,7 @@ static void set_bin_relocs(RelocInfo *ri, RBinReloc *reloc, ut64 addr, Sdb **db,
 		demname = r_bin_demangle (core->bin->cur, ri->lang, flagname, addr, ri->keep_lib);
 		if (demname) {
 			free (flagname);
-			flagname = r_str_newf ("reloc.%s", demname);
+			flagname = r_str_newf ("%s%s", ri->flagpfx, demname);
 		}
 	}
 	if (addr == UT64_MAX) {

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -747,44 +747,35 @@ R_API char *r_str_trunc_ellipsis(const char *str, int len) {
 }
 
 R_API char *r_str_newvf(const char *fmt, va_list ap) {
+	// format into a stack buffer first, most strings fit and this avoids
+	// running the formatter twice (once to measure, once to fill)
+	char tmp[256];
 	va_list ap2;
 	va_copy (ap2, ap);
-	int ret = vsnprintf (NULL, 0, fmt, ap2);
-	ret++;
-	char *p = calloc (1, ret);
-	if (p) {
-		(void)vsnprintf (p, ret, fmt, ap);
-	}
+	int ret = vsnprintf (tmp, sizeof (tmp), fmt, ap2);
 	va_end (ap2);
+	if (ret < 0) {
+		return NULL;
+	}
+	const size_t len = (size_t)ret;
+	char *p = malloc (len + 1);
+	if (p) {
+		if (len < sizeof (tmp)) {
+			memcpy (p, tmp, len + 1);
+		} else {
+			(void)vsnprintf (p, len + 1, fmt, ap);
+		}
+	}
 	return p;
 }
 
 R_API char *r_str_newf(const char *fmt, ...) {
-	va_list ap, ap2;
-
-	va_start (ap, fmt);
 	if (!strchr (fmt, '%')) {
-		char *p = strdup (fmt);
-		va_end (ap);
-		return p;
+		return strdup (fmt);
 	}
-	// format into a stack buffer first, most strings fit and this avoids
-	// running the formatter twice (once to measure, once to fill)
-	char tmp[256];
-	va_copy (ap2, ap);
-	int ret = vsnprintf (tmp, sizeof (tmp), fmt, ap2);
-	va_end (ap2);
-	char *p = NULL;
-	if (ret >= 0) {
-		p = malloc ((size_t)ret + 1);
-		if (p) {
-			if ((size_t)ret < sizeof (tmp)) {
-				memcpy (p, tmp, (size_t)ret + 1);
-			} else {
-				(void)vsnprintf (p, (size_t)ret + 1, fmt, ap);
-			}
-		}
-	}
+	va_list ap;
+	va_start (ap, fmt);
+	char *p = r_str_newvf (fmt, ap);
 	va_end (ap);
 	return p;
 }

--- a/libr/util/str.c
+++ b/libr/util/str.c
@@ -768,14 +768,23 @@ R_API char *r_str_newf(const char *fmt, ...) {
 		va_end (ap);
 		return p;
 	}
+	// format into a stack buffer first, most strings fit and this avoids
+	// running the formatter twice (once to measure, once to fill)
+	char tmp[256];
 	va_copy (ap2, ap);
-	int ret = vsnprintf (NULL, 0, fmt, ap2);
-	ret++;
-	char *p = calloc (1, ret);
-	if (p) {
-		(void)vsnprintf (p, ret, fmt, ap);
-	}
+	int ret = vsnprintf (tmp, sizeof (tmp), fmt, ap2);
 	va_end (ap2);
+	char *p = NULL;
+	if (ret >= 0) {
+		p = malloc ((size_t)ret + 1);
+		if (p) {
+			if ((size_t)ret < sizeof (tmp)) {
+				memcpy (p, tmp, (size_t)ret + 1);
+			} else {
+				(void)vsnprintf (p, (size_t)ret + 1, fmt, ap);
+			}
+		}
+	}
 	va_end (ap);
 	return p;
 }


### PR DESCRIPTION
## Description

This PR refactors relocation name handling and string formatting to improve performance and code clarity:

### Changes in `libr/core/cbin.c`:

1. **Optimized `construct_reloc_name()` function**:
   - Changed from using `RStrBuf` (which involves multiple allocations and string operations) to a single pre-calculated allocation
   - Added `pfx` parameter to allow callers to specify the flag prefix, eliminating redundant string concatenation
   - Moved name resolution logic into the function to handle empty names more cleanly (including ifunc handling)
   - Returns `NULL` for relocations with no valid name instead of empty strings

2. **Refactored `RelocInfo` structure**:
   - Added `flagpfx` and `flagpfx_len` fields to cache the computed flag prefix
   - Added `ri_fini()` cleanup function to properly free allocated resources
   - Updated `ri_init()` to compute the prefix once instead of repeatedly in the loop

3. **Simplified `set_bin_relocs()` function**:
   - Eliminated intermediate `reloc_name` variable and redundant string concatenations
   - Directly constructs the full flag name with prefix in one allocation
   - Removed unnecessary `r_name_filter()` call (filtering is handled by `r_flag_set()`)
   - Properly cleans up resources with `ri_fini()`

### Changes in `libr/util/str.c`:

1. **Optimized `r_str_newvf()` function**:
   - Uses a 256-byte stack buffer for most strings, avoiding the need to run the formatter twice
   - Only allocates heap memory when the formatted string exceeds the stack buffer size
   - Reduces allocations and formatter invocations for typical use cases

2. **Simplified `r_str_newf()` function**:
   - Removed redundant format string checking and duplicate code
   - Now delegates to `r_str_newvf()` to avoid code duplication

### Benefits:
- Reduced memory allocations and string operations
- Better cache locality with stack-based formatting
- Cleaner, more maintainable code
- Proper resource cleanup with `ri_fini()`

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

https://claude.ai/code/session_014EPZQ7gAYFbnaf3pKW7etw