### PR TITLE
Include the switch default target in block successor iteration ##anal

### DIFF
--- a/libr/anal/block.c
+++ b/libr/anal/block.c
@@ -466,11 +466,25 @@ R_API bool r_anal_block_successor_addrs_foreach(RAnalBlock *block, RAnalAddrCb c
 
 	CB_ADDR (block->jump);
 	CB_ADDR (block->fail);
-	if (block->switch_op && block->switch_op->cases) {
+	if (block->switch_op) {
 		RListIter *iter;
 		RAnalCaseOp *caseop;
-		r_list_foreach (block->switch_op->cases, iter, caseop) {
-			CB_ADDR (caseop->jump);
+		// callers building CFGs miss an edge without the default; 0 means unset
+		// (jmptbl.c maps the UT64_MAX "none" to 0), so it is not a target
+		ut64 def = block->switch_op->def_val;
+		if (def == block->jump || def == block->fail) {
+			def = 0;
+		}
+		if (block->switch_op->cases) {
+			r_list_foreach (block->switch_op->cases, iter, caseop) {
+				if (caseop->jump == def) {
+					def = 0;
+				}
+				CB_ADDR (caseop->jump);
+			}
+		}
+		if (def) {
+			CB_ADDR (def);
 		}
 	}
 

--- a/test/db/cmd/cmd_pdc_ast
+++ b/test/db/cmd/cmd_pdc_ast
@@ -173,3 +173,46 @@ seq 0x00415694
   bb 0x00415760
 EOF
 RUN
+
+NAME=pdct region ast joins a switch through its default edge
+FILE=bins/elf/bomb
+CMDS=<<EOF
+aaa
+pdct @ 0x400f43
+EOF
+EXPECT=<<EOF
+seq 0x00400f43
+  if 0x00400f43
+    bb 0x00400f65
+  if-else 0x00400f6a
+    bb 0x00400fad
+    switch 0x00400f71
+      seq 0x00400f7c
+        bb 0x00400f7c
+        if 0x00400fbe
+          bb 0x00400fc4
+        bb 0x00400fc9
+      seq 0x00400fb9
+        bb 0x00400fb9
+        goto 0x00400fbe
+      seq 0x00400f83
+        bb 0x00400f83
+        goto 0x00400fbe
+      seq 0x00400f8a
+        bb 0x00400f8a
+        goto 0x00400fbe
+      seq 0x00400f91
+        bb 0x00400f91
+        goto 0x00400fbe
+      seq 0x00400f98
+        bb 0x00400f98
+        goto 0x00400fbe
+      seq 0x00400f9f
+        bb 0x00400f9f
+        goto 0x00400fbe
+      seq 0x00400fa6
+        bb 0x00400fa6
+        goto 0x00400fbe
+      goto 0x00400fad
+EOF
+RUN

--- a/test/unit/test_anal_block.c
+++ b/test/unit/test_anal_block.c
@@ -546,13 +546,30 @@ bool test_r_anal_block_successors(void) {
 	r_list_purge (result);
 
 	r_anal_block_successor_addrs_foreach (blocks[2], addr_list_cb, result);
-	mu_assert_eq (r_list_length (result), 6, "switch successors count");
+	mu_assert_eq (r_list_length (result), 7, "switch successors count");
 	mu_assert ("jmp successor", addr_list_contains (result, 0x10));
 	mu_assert ("case successor", addr_list_contains (result, 0x100));
 	mu_assert ("case successor", addr_list_contains (result, 0x110));
 	mu_assert ("case successor", addr_list_contains (result, 0x120));
 	mu_assert ("case successor", addr_list_contains (result, 0x130));
 	mu_assert ("case successor", addr_list_contains (result, 0x140));
+	mu_assert ("default successor", addr_list_contains (result, 0x42));
+	r_list_purge (result);
+
+	// a default already reachable as the jump or a case is not repeated, and 0
+	// is the unset value both r_anal_switch_op_new call sites leave behind
+	sop->def_val = 0x120;
+	r_anal_block_successor_addrs_foreach (blocks[2], addr_list_cb, result);
+	mu_assert_eq (r_list_length (result), 6, "default duplicating a case");
+	r_list_purge (result);
+	sop->def_val = 0x10;
+	r_anal_block_successor_addrs_foreach (blocks[2], addr_list_cb, result);
+	mu_assert_eq (r_list_length (result), 6, "default duplicating the jump");
+	r_list_purge (result);
+	sop->def_val = 0;
+	r_anal_block_successor_addrs_foreach (blocks[2], addr_list_cb, result);
+	mu_assert_eq (r_list_length (result), 6, "unset default is no successor");
+	sop->def_val = 0x42;
 	r_list_free (result);
 
 	result = r_anal_block_recurse_list (blocks[0]);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_anal_block_successor_addrs_foreach` yielded `jump`, `fail` and the case targets but never `switch_op->def_val`, so every CFG built by `r_anal_function_get_graph` was missing a real edge — the default is a distinct successor on 1/1 switch blocks in `bomb`, 5/14 in `ls` and 7/36 in `bash`.

The default is skipped when it duplicates the jump, the fail or a case, and when it is 0, which is the unset value both `r_anal_switch_op_new` call sites leave behind (emitting it would fail the graph with "Broken fcn").

`test_r_anal_block_successors` already encoded the old count and failed on the fix; it now also covers the duplicate and unset cases.