### PR TITLE
Do not treat 'test eax, eax' on a returned int as a variadic marker

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2108,7 +2108,19 @@ analopfinish:
 				RRegItem *ri0 = r_reg_get (anal->reg, dst->reg, R_REG_TYPE_GPR);
 				RRegItem *ri1 = r_reg_get (anal->reg, variadic_reg, R_REG_TYPE_GPR);
 				if (ri0 && ri1 && ri0->offset == ri1->offset) {
-					dst_is_variadic = true;
+					// the convention passes the vector-register count in the low subregister, so only that one marks a variadic
+					int lowest = ri1->size;
+					RList *gprs = r_reg_get_list (anal->reg, R_REG_TYPE_GPR);
+					if (gprs) {
+						RRegItem *gpr;
+						RListIter *gpr_iter;
+						r_list_foreach (gprs, gpr_iter, gpr) {
+							if (gpr->offset == ri1->offset && gpr->size < lowest) {
+								lowest = gpr->size;
+							}
+						}
+					}
+					dst_is_variadic = ri0->size == lowest;
 				}
 			}
 #else


### PR DESCRIPTION
The amd64 variadic heuristic in `fcn.c` marks a function variadic when a
`cmp`/`test` has the same register as destination and first source, and that
register is in the rax family:

```c
RRegItem *ri0 = r_reg_get (anal->reg, dst->reg, R_REG_TYPE_GPR);
RRegItem *ri1 = r_reg_get (anal->reg, variadic_reg, R_REG_TYPE_GPR);
if (ri0 && ri1 && ri0->offset == ri1->offset) {
    dst_is_variadic = true;
}
```

Only offsets are compared, so `al`, `ax`, `eax` and `rax` all match. The
convention being detected passes the number of vector registers in the **low
byte**, so what a variadic function's prologue actually emits is `test al, al`.
Matching the whole family also matches `test eax, eax`, which is how a function
checks an `int` a callee just returned.

Concretely, in `test/bins/elf/bomb`:

```
0x00400ee9  call sym.strings_not_equal
0x00400eee  test eax, eax
```

`sym.phase_1` is marked variadic on the strength of that, and it takes one
`char *`.

The change requires the compared register to be the one byte the convention
uses.

### Effects I measured

`afl` is byte-identical before and after on `bomb`, `ls`, `crackme0x00b` and
`dwarf2_many_comp_units.elf` — function discovery, sizes and names are
unaffected.

`db/anal` is unchanged: **890 OK, 35 BR, 0 XX, 3 SK, 1 FX** with and without
the change, both built and run. `db/cmd/types` passes 191 of 191.

### The argument-recovery fallout, which goes the wrong way

`is_variadic` also feeds register-argument recovery (`r_anal_extract_rarg` via
`var.c`), so `pdf` function headers move for the few functions affected. On
`bomb`, three change:

```
- sym.secret_phase ()                            + sym.secret_phase (int size)
- sym.read_line ()                               + sym.read_line (int size)
- sym.phase_1 (const char *s, int64_t arg2)      + sym.phase_1 ()
```

None of these is an improvement. I checked what those registers actually do:

`sym.secret_phase` — its first use of `rdi` is `mov rdi, rax`, a write. It takes
no arguments, so the `(int size)` it gains is spurious.

`sym.read_line` — every `edi`/`rdi` use is `mov edi, <constant>`, setting up
arguments for calls it makes. It takes no arguments either, so its `(int size)`
is spurious too.

`sym.phase_1` — its `rdi` is the incoming string, passed straight through to
`strings_not_equal` and therefore never read explicitly, and the `esi` in its
body is a write setting up that call's second argument. So the old
`(const char *s, int64_t arg2)` was one correct argument plus one spurious one,
and the new `()` has neither.

So all three changes are noise, and in the one case where a real argument was
being shown it is now lost. The argument-recovery output is worse after this
change, not better.

The flag correction itself still looks right: `test eax, eax` on a returned int
is not the vector-register count guard, and the convention is unambiguous that
the guard uses `al`. What this shows is that `r_anal_extract_rarg` was getting
usable answers partly because of the wrong flag, and correcting the flag
exposes that its register-argument recovery does not handle an argument passed
straight through to a callee.

That is your call rather than mine: take the flag fix and treat the recovery
weakness separately, or hold this until the recovery side is handled so the
visible output does not regress. I am happy to look at the recovery path if you
want them landed together.

### On a test

I did not add one. The only shell-observable effect is that argument-recovery
output, and every line of it I could pin is wrong both before and after, so
encoding it in `db/` would make incorrect output a contract. `is_variadic` is
not exposed anywhere (`afij` has no field for it); if it were, the property
itself would be directly testable and I would add that instead. Say which you
would prefer and I will follow it.