### PR TITLE
Ignore unset switch default and table addresses in pdc ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pdc_ast.c
+++ b/libr/core/p/pseudo/pdc_ast.c
@@ -194,7 +194,7 @@ static PdcRegion *build_switch(PdcCtx *ctx, RAnalBlock *bb, ut64 *next) {
 		region_add_child (sw, region_seq (ctx, co->jump, join));
 	}
 	const ut64 defv = bb->switch_op->def_val;
-	if (defv != UT64_MAX && !htuu_get (seen, defv, 0)) {
+	if (valid_addr (defv) && !htuu_get (seen, defv, 0)) {
 		region_add_child (sw, region_seq (ctx, defv, join));
 	}
 	ht_uu_free (seen);

--- a/libr/core/p/pseudo/pdc_ast.h
+++ b/libr/core/p/pseudo/pdc_ast.h
@@ -25,6 +25,12 @@ struct pdc_region_t {
 	RVecPdcRegionPtr children;
 };
 
+// an unset switch default or table addr reads as 0 (jmptbl.c maps the UT64_MAX
+// "none" to 0), while other paths do write UT64_MAX: neither is an address
+static inline bool valid_addr(ut64 addr) {
+	return addr && addr != UT64_MAX;
+}
+
 // build the structuring region AST for fcn (caller frees with pdc_ast_free)
 PdcRegion *pdc_ast_build(RCore *core, RAnalFunction *fcn);
 void pdc_ast_free(PdcRegion *root);

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -587,7 +587,7 @@ static bool bb_addr_is_goto_target(RAnalFunction *fcn, ut64 addr) {
 		if (!sop) {
 			continue;
 		}
-		if (sop->def_val == addr) {
+		if (valid_addr (sop->def_val) && sop->def_val == addr) {
 			return true;
 		}
 		r_list_foreach (sop->cases, cit, co) {
@@ -1038,7 +1038,7 @@ static void render_switch(PDCState *state, RAnalBlock *sw_bb, RList *visited, in
 		i = w;
 	}
 	char *expr = find_switch_expr (state->core, state->fcn, sw_bb);
-	ut64 table_addr = sop->daddr != UT64_MAX? sop->daddr: sw_bb->addr;
+	ut64 table_addr = valid_addr (sop->daddr)? sop->daddr: sw_bb->addr;
 	print_newline (state, sw_bb->addr, indent, false);
 	print_str (state, "switch (%s) { // jump table of %d cases at 0x%08" PFMT64x,
 		expr, i, table_addr);
@@ -1063,7 +1063,7 @@ static void render_switch(PDCState *state, RAnalBlock *sw_bb, RList *visited, in
 		c = k + 1;
 	}
 
-	if (sop->def_val != UT64_MAX) {
+	if (valid_addr (sop->def_val)) {
 		print_newline (state, sop->def_val, indent + 1, false);
 		print_str (state, "default: // 0x%08" PFMT64x, sop->def_val);
 		render_arm_body (state, visited, sop->def_val, indent + 2);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -955,3 +955,15 @@ EXPECT=<<EOF
     loc_0x100003a6c: // case 300
 EOF
 RUN
+
+NAME=pdc renders no switch default when the switch op has none
+FILE=bins/elf/boa-mips
+CMDS=<<EOF
+af @ 0x415694
+s 0x415694
+pdc~switch (,default:
+EOF
+EXPECT=<<EOF
+    switch (switch_var) { // jump table of 1 cases at 0x004156b8
+EOF
+RUN

--- a/test/db/cmd/cmd_pdc_ast
+++ b/test/db/cmd/cmd_pdc_ast
@@ -156,3 +156,20 @@ seq 0x00000000
   bb 0x0000000c
 EOF
 RUN
+
+NAME=pdct region ast has no arm for an unset switch default
+FILE=bins/elf/boa-mips
+CMDS=<<EOF
+af @ 0x415694
+pdct @ 0x415694
+EOF
+EXPECT=<<EOF
+seq 0x00415694
+  if 0x00415694
+    seq 0x004156b8
+      switch 0x004156b8
+      bb 0x004156e0
+      bb 0x0041573c
+  bb 0x00415760
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

An unset switch default or jump-table address reads as 0 (`jmptbl.c` maps the UT64_MAX "none" to 0, `block.c` constructs with it) while other paths do write UT64_MAX. pdc only tested `!= UT64_MAX`, so it rendered the sentinel as a real address: `bins/elf/boa-mips` printed both `default: // 0x00000000` and `jump table of N cases at 0x00000000` 12 times each, in the linear and the structured renderer alike.

One `pdc_switch_addr_set()` predicate now gates the default arm in the region builder, the default arm and table address in the switch renderer, and the goto-target check. Two tests on `boa-mips`, full suite clean.