### PR TITLE
Place formal parameters that DWARF leaves without a location

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1504,7 +1504,7 @@ static bool parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 						break;
 					case DW_AT_variable_parameter:
 						// go marks a result slot as a formal parameter with this flag set
-						var->is_result = val->uconstant != 0;
+						var->is_result = val->flag != 0;
 						break;
 					default:
 						break;
@@ -1766,15 +1766,36 @@ static void import_dwarf_function_type(Context *ctx, const char *sname, const ch
 	free (csig);
 }
 
-/* A formal parameter can carry a type and a name but no DW_AT_location, which
- * happens routinely at -O2 when the parameter is never spilled. The prototype
- * is still built from every formal, so dropping it here left the recovered
- * signature and the placed arguments disagreeing on arity.
- *
- * The calling convention already answers where the caller left parameter N on
- * entry, so use it instead of discarding the parameter. */
+// the cc argslot tables describe integer slots only, so a float formal would be
+// handed an integer register it never occupies, colliding with a located arg
+static bool dwarf_type_is_fp(const char *type) {
+	if (R_STR_ISEMPTY (type) || strchr (type, '*') || strchr (type, '[')) {
+		return false;
+	}
+	while (r_str_startswith (type, "const ") || r_str_startswith (type, "volatile ")) {
+		type = strchr (type, ' ') + 1;
+	}
+	const char *const names[] = {
+		"float", "double", "long double", "_Float16", "__float128",
+		"f32", "f64", "float32", "float64",
+		"complex64", "complex128", NULL
+	};
+	int i;
+	for (i = 0; names[i]; i++) {
+		if (!strcmp (type, names[i])) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/* Place a formal that carries no DW_AT_location (routine at -O2) in the
+ * entry slot the calling convention assigns it, instead of dropping it. */
 static char *dwarf_formal_convention_meta(Context *ctx, int argno, int argc, const char *type) {
 	if (!ctx || !ctx->anal || argno < 0 || R_STR_ISEMPTY (type)) {
+		return NULL;
+	}
+	if (dwarf_type_is_fp (type)) {
 		return NULL;
 	}
 	RAnal *anal = (RAnal *)ctx->anal;
@@ -1820,24 +1841,34 @@ static void sdb_save_dwarf_function(Context *ctx, Function *dwarf_fcn, const cha
 	RStrBuf args_buf;
 	r_strbuf_init (&vars_buf);
 	r_strbuf_init (&args_buf);
+	// the abi position of a formal counts every parameter the caller passes,
+	// while arg_index below must stay dense: apply_debug_info stops reading at
+	// the first missing fcn.%s.arg.%d key. a skipped formal separates the two
 	int formal_count = 0;
 	{
 		RListIter *count_iter;
 		Variable *count_var;
 		r_list_foreach (variables, count_iter, count_var) {
-			if (count_var->kind == VARIABLE_KIND_FORMAL_PARAMETER) {
+			if (count_var->kind == VARIABLE_KIND_FORMAL_PARAMETER
+				&& !count_var->is_result) {
 				formal_count++;
 			}
 		}
 	}
 	int arg_index = 0;
+	int formal_index = 0;
 	RListIter *iter;
 	Variable *var;
 	r_list_foreach (variables, iter, var) {
+		const bool is_formal = var->kind == VARIABLE_KIND_FORMAL_PARAMETER
+			&& !var->is_result;
+		const int argno = formal_index;
+		if (is_formal) {
+			formal_index++;
+		}
 		char *meta = sdb_variable_data (var);
-		if (!meta && var->kind == VARIABLE_KIND_FORMAL_PARAMETER
-			&& !var->location && !var->is_result) {
-			meta = dwarf_formal_convention_meta (ctx, arg_index, formal_count, var->type);
+		if (!meta && is_formal && !var->location) {
+			meta = dwarf_formal_convention_meta (ctx, argno, formal_count, var->type);
 		}
 		if (!meta || !var->name) {
 			free (meta);

--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -56,6 +56,7 @@ typedef struct dwarf_variable_t {
 	char *name;
 	char *type;
 	VariableKind kind;
+	bool is_result;
 } Variable;
 
 static void variable_free(Variable *var) {
@@ -1501,6 +1502,10 @@ static bool parse_function_args_and_vars(Context *ctx, ut64 idx, RStrBuf *args, 
 					case DW_AT_location:
 						var->location = parse_dwarf_location (ctx, val, frame_base);
 						break;
+					case DW_AT_variable_parameter:
+						// go marks a result slot as a formal parameter with this flag set
+						var->is_result = val->uconstant != 0;
+						break;
 					default:
 						break;
 					}
@@ -1761,6 +1766,30 @@ static void import_dwarf_function_type(Context *ctx, const char *sname, const ch
 	free (csig);
 }
 
+/* A formal parameter can carry a type and a name but no DW_AT_location, which
+ * happens routinely at -O2 when the parameter is never spilled. The prototype
+ * is still built from every formal, so dropping it here left the recovered
+ * signature and the placed arguments disagreeing on arity.
+ *
+ * The calling convention already answers where the caller left parameter N on
+ * entry, so use it instead of discarding the parameter. */
+static char *dwarf_formal_convention_meta(Context *ctx, int argno, int argc, const char *type) {
+	if (!ctx || !ctx->anal || argno < 0 || R_STR_ISEMPTY (type)) {
+		return NULL;
+	}
+	RAnal *anal = (RAnal *)ctx->anal;
+	const char *cc = r_anal_cc_default (anal);
+	if (R_STR_ISEMPTY (cc)) {
+		return NULL;
+	}
+	RAnalCCArgSlot slot = { 0 };
+	if (!r_anal_cc_argslot (anal, cc, argno, argc, false, &slot)
+		|| R_STR_ISEMPTY (slot.reg)) {
+		return NULL;
+	}
+	return r_str_newf ("r,%s,%s", slot.reg, type);
+}
+
 static void sdb_save_dwarf_function(Context *ctx, Function *dwarf_fcn, const char *ret_type, RList/*<Variable*>*/ *variables, bool has_unspecified_parameters) {
 	Sdb *sdb = ctx->sdb;
 	char *real_name = strdup (dwarf_fcn->name);
@@ -1791,11 +1820,25 @@ static void sdb_save_dwarf_function(Context *ctx, Function *dwarf_fcn, const cha
 	RStrBuf args_buf;
 	r_strbuf_init (&vars_buf);
 	r_strbuf_init (&args_buf);
+	int formal_count = 0;
+	{
+		RListIter *count_iter;
+		Variable *count_var;
+		r_list_foreach (variables, count_iter, count_var) {
+			if (count_var->kind == VARIABLE_KIND_FORMAL_PARAMETER) {
+				formal_count++;
+			}
+		}
+	}
 	int arg_index = 0;
 	RListIter *iter;
 	Variable *var;
 	r_list_foreach (variables, iter, var) {
 		char *meta = sdb_variable_data (var);
+		if (!meta && var->kind == VARIABLE_KIND_FORMAL_PARAMETER
+			&& !var->location && !var->is_result) {
+			meta = dwarf_formal_convention_meta (ctx, arg_index, formal_count, var->type);
+		}
 		if (!meta || !var->name) {
 			free (meta);
 			continue;

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -707,7 +707,6 @@ EOF
 EXPECT=<<EOF
 arg int prec @ r8
 arg int64_t arg1 @ rdi
-arg int64_t arg2 @ rsi
 var []uint8 dst @ rdx
 var int i @ rcx
 var bool hasDecimalPoint @ r9

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -684,3 +684,16 @@ EXPECT=<<EOF
 |       |   0x004019ce      e82d280200     call sym.fpc_get_output     ; fpc_get_output()
 EOF
 RUN
+
+NAME=dwarf formal parameter without location
+FILE=bins/elf/dwarf_rust_bubble
+CMDS=<<EOF
+aaa
+afvr @ 0x00010be0
+EOF
+EXPECT=<<EOF
+arg &str msg @ rdi
+arg int64_t arg2 @ rsi
+arg int64_t arg3 @ rdx
+EOF
+RUN

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -697,3 +697,20 @@ arg int64_t arg2 @ rsi
 arg int64_t arg3 @ rdx
 EOF
 RUN
+
+NAME=dwarf float formal keeps out of the integer slots
+FILE=bins/elf/dwarf_go_tree
+CMDS=<<EOF
+aaa > /dev/null
+afvr @ 0x0048a1b0
+EOF
+EXPECT=<<EOF
+arg int prec @ r8
+arg int64_t arg1 @ rdi
+arg int64_t arg2 @ rsi
+var []uint8 dst @ rdx
+var int i @ rcx
+var bool hasDecimalPoint @ r9
+var []uint8 tail @ r10
+EOF
+RUN


### PR DESCRIPTION
A formal parameter can carry a name and a type but no `DW_AT_location` — routine at `-O2` when the parameter is never spilled. `sdb_variable_data()` returns NULL without a location, so the argument was skipped, while the function type is still built from every formal. The prototype then lists a parameter that no argument exists for.

This derives the missing storage from the calling convention instead of discarding the parameter: `r_anal_cc_argslot()` already answers where the caller leaves parameter N on entry, which is the storage an argument describes.

### Go result slots

A formal carrying `DW_AT_variable_parameter` is skipped. Go encodes a function's results as formal parameters with that flag set, so without the check the fallback handed them entry registers they never occupy — `reflect.maplen(h *hmap) int` grew a second argument named `~r1`, and `bins/elf/dwarf_go_tree` gained 1827 register arguments instead of 980.

### Effect

On `bins/elf/dwarf_rust_bubble`:

```
before  void dbg.begin_panic_str_ (int64_t arg1, int64_t arg2, int64_t arg3);
after   void dbg.begin_panic_str_ (&str msg, int64_t arg2, int64_t arg3);
```

### Tests

Rebased onto master. `db/cmd/dwarf` is 19/19; the full suite is 17017 OK with one failure, `db/formats/dwarf "DWARF mismatch preserves registered type and stable name"`, which fails on master with this branch's commits removed.

The added test in `db/cmd/dwarf` was checked in both directions — 18/18 with the patch, 17 OK and 1 XX without it.

One line came out of the float-formal expectation: `arg int64_t arg2 @ rsi`. Master alone no longer reports it either, so it recorded behaviour that changed upstream after the test was written rather than anything this branch does.
