### PR TITLE
Add iz:enc filter to list strings by encoding

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -347,7 +347,35 @@ R_API bool r_core_bin_set_cur(RCore *core, RBinFile *binfile) {
 	return true;
 }
 
-static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+// match a user given encoding filter (from "iz:enc") against a string type.
+// accepts the short type char (a/u/w/W/b), the canonical name reported by
+// r_bin_string_type() and a few friendly aliases. NULL/empty means "no filter".
+static bool str_enc_match(const char *enc, int type) {
+	if (R_STR_ISEMPTY (enc)) {
+		return true;
+	}
+	if (!enc[1]) {
+		return *enc == type;
+	}
+	if (!strcmp (enc, r_bin_string_type (type))) {
+		return true;
+	}
+	if (!r_str_casecmp (enc, "ascii")) {
+		return type == R_STRING_TYPE_ASCII;
+	}
+	if (!r_str_casecmp (enc, "unicode") || !r_str_casecmp (enc, "utf8")) {
+		return type == R_STRING_TYPE_UTF8;
+	}
+	if (!r_str_casecmp (enc, "wide") || !r_str_casecmp (enc, "utf16")) {
+		return type == R_STRING_TYPE_WIDE;
+	}
+	if (!r_str_casecmp (enc, "utf32")) {
+		return type == R_STRING_TYPE_WIDE32;
+	}
+	return false;
+}
+
+static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, int va, ut64 skip, ut64 count, const char *enc) {
 	RTable *table = r_core_table_new (core, "strings");
 	if (!table) {
 		return;
@@ -388,6 +416,9 @@ static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, 
 			continue;
 		}
 		if (maxstr && string->length > maxstr) {
+			continue;
+		}
+		if (!str_enc_match (enc, string->type)) {
 			continue;
 		}
 #if FALSE_POSITIVES
@@ -600,7 +631,7 @@ static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, 
 	R_CRITICAL_LEAVE (core);
 }
 
-R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, const char *enc) {
 	RBinFile *bf = r_bin_cur (core->bin);
 	bool new_bf = false;
 	if (bf && bf->file && strstr (bf->file, "malloc://")) {
@@ -643,7 +674,7 @@ R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut6
 		va = false;
 	}
 	RVecRBinString *strings = r_bin_raw_strings (bf, 0);
-	_print_strings (core, strings, pj, mode, va, skip, count);
+	_print_strings (core, strings, pj, mode, va, skip, count, enc);
 	RVecRBinString_free (strings);
 	if (new_bf) {
 		r_unref (bf->buf);
@@ -654,7 +685,7 @@ R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut6
 	return true;
 }
 
-R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, const char *enc) {
 	RBinFile *binfile = r_bin_cur (core->bin);
 	RBinPlugin *plugin = r_bin_file_cur_plugin (binfile);
 	int rawstr = r_config_get_i (core->config, "bin.str.raw");
@@ -676,7 +707,7 @@ R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 co
 	}
 	RVecRBinString *list = r_bin_get_strings (core->bin);
 	if (list) {
-		_print_strings (core, list, pj, mode, va, skip, count);
+		_print_strings (core, list, pj, mode, va, skip, count, enc);
 		return true;
 	}
 	return false;
@@ -5590,9 +5621,9 @@ R_API bool r_core_bin_info(RCore *core, ut64 action, PJ *pj, int mode, int va, R
 		}
 	}
 	if ((action & R_CORE_BIN_ACC_RAW_STRINGS)) {
-		ret &= bin_raw_strings (core, pj, mode, va, 0, 0);
+		ret &= bin_raw_strings (core, pj, mode, va, 0, 0, NULL);
 	} else if ((action & R_CORE_BIN_ACC_STRINGS)) {
-		ret &= bin_strings (core, pj, mode, va, 0, 0);
+		ret &= bin_strings (core, pj, mode, va, 0, 0, NULL);
 	}
 	if ((action & R_CORE_BIN_ACC_INFO)) {
 		ret &= bin_info (core, pj, mode, loadaddr);

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -1920,6 +1920,20 @@ static void cmd_izminus(RCore *core, const char *input) {
 	r_bin_file_string_delete (bf, args.addr, args.len, args.type);
 }
 
+// Parse an optional ":encoding" filter (as in "iz:utf8") at *p, advancing *p
+// past it. Returns a newly allocated encoding name, or NULL when absent.
+static char *iz_parse_enc(const char **p) {
+	if (**p != ':') {
+		return NULL;
+	}
+	(*p)++;
+	const char *s = *p;
+	while (**p && **p != ' ') {
+		(*p)++;
+	}
+	return r_str_ndup (s, *p - s);
+}
+
 static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const char *input) {
 	switch (input[1]) {
 	case '+': // "iz+"
@@ -1970,14 +1984,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		return;
 	}
 	// Encoding filter can come right after the z's: "iz:utf8", "izz:ascii"
-	if (*p == ':') {
-		p++;
-		const char *s = p;
-		while (*p && *p != ' ') {
-			p++;
-		}
-		enc = r_str_ndup (s, p - s);
-	}
+	enc = iz_parse_enc (&p);
 	// Parse suffix (j, jq, qj, q, qq, *, ,)
 	bool local_pj = false;
 	bool dotmode = false;
@@ -2016,13 +2023,8 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		p = ""; // consume rest
 	}
 	// Also accept the filter after a mode char: "izj:utf8", "izq:ascii"
-	if (!enc && *p == ':') {
-		p++;
-		const char *s = p;
-		while (*p && *p != ' ') {
-			p++;
-		}
-		enc = r_str_ndup (s, p - s);
+	if (!enc) {
+		enc = iz_parse_enc (&p);
 	}
 	// Check for '.' suffix after mode specifier
 	if (*p == '.') {

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -7,8 +7,8 @@
 
 #include "../bin/format/pdb/pdb_downloader.h"
 
-R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count);
-R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count);
+R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, const char *enc);
+R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, const char *enc);
 
 // clang-format off
 static RCoreHelpMessage help_msg_ih = {
@@ -143,6 +143,7 @@ static RCoreHelpMessage help_msg_iy = {
 static RCoreHelpMessage help_msg_iz = {
 	"Usage: iz", "[?jq*] ([skip] [count])", "List strings",
 	"iz", " ([skip]) ([count])", "strings in data sections (skip N strings, show count)",
+	"iz:", "[enc]", "only list strings of the given encoding (a/u/w/W or ascii/utf8/wide..)",
 	"iz.", "", "show string at current address",
 	"iz,", "[:help]", "perform a table query on strings listing",
 	"iz-", " ([addr]) ([len]) ([type])", "delete string at address (uses current seek if addr not specified, len/type for matching)",
@@ -1948,6 +1949,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 	bool rdump = false; // izzz = dump mode
 	ut64 skip = 0;
 	ut64 count = 0;
+	char *enc = NULL; // "iz:utf8" -> only list strings of that encoding
 	// Count 'z' characters
 	while (*p == 'z') {
 		if (!raw) {
@@ -1966,6 +1968,15 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			RVecRBinString_free (strings);
 		}
 		return;
+	}
+	// Encoding filter can come right after the z's: "iz:utf8", "izz:ascii"
+	if (*p == ':') {
+		p++;
+		const char *s = p;
+		while (*p && *p != ' ') {
+			p++;
+		}
+		enc = r_str_ndup (s, p - s);
 	}
 	// Parse suffix (j, jq, qj, q, qq, *, ,)
 	bool local_pj = false;
@@ -2004,6 +2015,15 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		core->table_query = strdup (p + 1);
 		p = ""; // consume rest
 	}
+	// Also accept the filter after a mode char: "izj:utf8", "izq:ascii"
+	if (!enc && *p == ':') {
+		p++;
+		const char *s = p;
+		while (*p && *p != ' ') {
+			p++;
+		}
+		enc = r_str_ndup (s, p - s);
+	}
 	// Check for '.' suffix after mode specifier
 	if (*p == '.') {
 		dotmode = true;
@@ -2011,6 +2031,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 	}
 	// Handle "iz.", "izj.", "izq." - show string at current address
 	if (dotmode) {
+		R_FREE (enc); // filtering by encoding does not apply to the "." lookup
 		RVecRBinString *list = r_bin_get_strings (core->bin);
 		if (list) {
 			ut64 addr = core->addr;
@@ -2070,7 +2091,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			RVecRBinString_free (res);
 		}
 	} else if (raw) {
-		bin_raw_strings (core, pj, mode, va, skip, count);
+		bin_raw_strings (core, pj, mode, va, skip, count, enc);
 	} else {
 		RList *bfiles = r_core_bin_files (core);
 		RListIter *iter;
@@ -2078,11 +2099,12 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		RBinFile *cur = core->bin->cur;
 		r_list_foreach (bfiles, iter, bf) {
 			core->bin->cur = bf;
-			bin_strings (core, pj, mode, va, skip, count);
+			bin_strings (core, pj, mode, va, skip, count, enc);
 		}
 		core->bin->cur = cur;
 		r_list_free (bfiles);
 	}
+	free (enc);
 	if (local_pj) {
 		r_cons_println (core->cons, pj_string (pj));
 		pj_free (pj);

--- a/test/db/cmd/cmd_iz_enc
+++ b/test/db/cmd/cmd_iz_enc
@@ -1,0 +1,37 @@
+NAME=izz filter by encoding
+FILE=malloc://256
+CMDS=<<EOF
+wx 48656c6c6f4173636969537472696e6700570069006400650053007400720069006e006700000075746638206d6561737572c3a920636166c3a900
+?e -- all --
+izzq
+?e -- ascii --
+izzq:ascii
+?e -- short a --
+izzq:a
+?e -- wide --
+izzq:wide
+?e -- short w --
+izzq:w
+?e -- utf8 --
+izzq:utf8
+?e -- no match --
+izzq:base64
+EOF
+EXPECT=<<EOF
+-- all --
+0x0 17 16 HelloAsciiString
+0x11 22 10 WideString
+0x27 20 17 utf8 measuré café
+-- ascii --
+0x0 17 16 HelloAsciiString
+-- short a --
+0x0 17 16 HelloAsciiString
+-- wide --
+0x11 22 10 WideString
+-- short w --
+0x11 22 10 WideString
+-- utf8 --
+0x27 20 17 utf8 measuré café
+-- no match --
+EOF
+RUN


### PR DESCRIPTION
Implements #18821, adds an optional encoding filter to `iz`/`izz` so you can list just the ascii, utf8/unicode or wide strings instead of dumping all of them.

Syntax is `iz:<enc>` (and `izz:<enc>`), which follows trufae's suggestion in the ticket. The filter accepts either the short type char that rbin already uses (a/u/w/W/b) or a friendly name like ascii, utf8, unicode, wide, utf16, utf32, or whatever `r_bin_string_type()` reports for the detected type. It composes with the mode suffixes too, so `izzj:wide` gives you JSON of only the wide strings and `izzq:ascii` the quiet form.

I hooked it into `_print_strings` in cbin.c since that's the single place both `iz` and `izz` funnel through, and every RBinString already carries its detected `->type`. Went with the type field rather than routing through rtable/cfg.charset because filtering here covers all the output modes (normal table, json, quiet, r2 commands) in one spot and keeps the existing output identical when no filter is passed. Happy to move it onto a table query instead if you'd rather keep that path.

Tested against a crafted `malloc://` buffer holding one ascii, one utf16le and one utf8 string. New test at test/db/cmd/cmd_iz_enc runs `izzq` plus each filter and the no-match case and passes under r2r; the existing cmd_iz/izz tests still pass. Also checked `izz:utf8`, `izzj:wide` and `izzq:ascii` by hand on the same buffer.
