### PR TITLE
Size pointer members with the target word width in the type api ##types

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -157,7 +157,7 @@ R_API void r_anal_types_load_sdb(RAnal *anal, const char *name) {
 	load_types_from (anal, "%s", name);
 }
 
-// a pointer is one target word wide, which r_type_get_bitsize cannot know from the sdb alone
+// for pointers prefer the live target width over the one baked into the type sdb
 R_API ut64 r_anal_type_bitsize(RAnal *anal, const char *type) {
 	R_RETURN_VAL_IF_FAIL (anal && anal->config && type, 0);
 	return strchr (type, '*')? anal->config->bits: r_type_get_bitsize (anal->sdb_types, type);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -272,18 +272,21 @@ static const char *type_aggregate_prefixed(const char *R_NONNULL type, const cha
 	return NULL;
 }
 
+// the per-target type dbs carry the pointer width as the size of "char *"
+static ut64 type_ptr_bitsize(Sdb *R_NONNULL TDB) {
+	const ut64 bits = sdb_num_get (TDB, "type.char *.size", NULL);
+	return bits? bits: 32;
+}
+
 R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 	R_RETURN_VAL_IF_FAIL (TDB && type, 0);
-	/* Filter out qualifiers and the structure keyword if type looks like "struct mystruc" */
 	const char *type_view = type_skip_qualifiers (type);
-	const char *tmptype = type_view;
+	if (strchr (type_view, '*')) {
+		return type_ptr_bitsize (TDB);
+	}
+	// a type may be spelled with its aggregate keyword, as in "struct mystruct"
 	const char *name = NULL;
-	if (type_aggregate_prefixed (tmptype, &name)) {
-		tmptype = name;
-	}
-	if ((strstr (type_view, "*(") || strstr (type_view, " *")) && strcmp (type_view, "char *")) {
-		return 32;
-	}
+	const char *tmptype = type_aggregate_prefixed (type_view, &name)? name: type_view;
 	const char *t = sdb_const_get (TDB, tmptype, 0);
 	if (!t) {
 		if (r_str_startswith (tmptype, "enum ")) {

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3959,3 +3959,35 @@ struct Bird {
 };
 EOF
 RUN
+
+NAME=struct and union members are sized with the target pointer width
+FILE=-
+ARGS=-b 64
+CMDS=<<EOF
+'td struct VB { void *a; void *b; };
+'td struct AR { char *p[4]; int n; };
+'td union U { void *p; int n; };
+tss struct VB
+tss struct AR
+tss union U
+EOF
+EXPECT=<<EOF
+16
+36
+8
+EOF
+RUN
+
+NAME=struct size follows the target word size
+FILE=-
+ARGS=-b 16
+CMDS=<<EOF
+'td struct VB { void *a; void *b; };
+tss char *
+tss struct VB
+EOF
+EXPECT=<<EOF
+2
+4
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r_type_get_bitsize` hardcoded 32 bits for every pointer except `char *`, so struct/union sums disagreed with their own member offsets on 64-bit targets (`struct { void *a; void *b; }` sized 8 while `b` sits at 8). Read the width the per-target type dbs already carry (`type.char *.size`), which also drops the `char *` special case. Completes #26428 one layer down; 2 tests, gate clean.