### PR TITLE
Render loops and switches in the structured pdc output ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pdc_ast.c
+++ b/libr/core/p/pseudo/pdc_ast.c
@@ -13,7 +13,7 @@ typedef struct {
 	HtUU *idom;	// block addr => immediate dominator addr (entry => UT64_MAX)
 	HtUU *ipdom;	// block addr => immediate post-dominator addr (UT64_MAX => exit)
 	HtUP *loops;	// natural-loop header addr => HtUU* member set
-	HtUU *cur_loop;	// member set of the innermost loop body being walked
+	HtUU *cur_loop;	// members of the innermost loop being walked (NULL outside one)
 	HtUU *emitted;	// block addr => 1 (each block heads a region at most once)
 	int build_calls;
 	int cap;
@@ -23,6 +23,7 @@ static PdcRegion *region_new(PdcRegionType type, ut64 addr) {
 	PdcRegion *r = R_NEW0 (PdcRegion);
 	r->type = type;
 	r->addr = addr;
+	r->exit = UT64_MAX;
 	RVecPdcRegionPtr_init (&r->children);
 	return r;
 }
@@ -39,10 +40,27 @@ static void region_free(PdcRegion *r) {
 	free (r);
 }
 
-static void region_add_child(PdcRegion *parent, PdcRegion *child) {
+static void region_add_child(PdcRegion *parent, PdcRegion *child, PdcRole role) {
 	if (child) {
+		child->role = role;
 		RVecPdcRegionPtr_push_back (&parent->children, &child);
 	}
+}
+
+// the conditional headed by addr, or NULL when neither arm yields a region
+static PdcRegion *region_cond(ut64 addr, PdcRegion *then_r, PdcRegion *else_r) {
+	if (then_r && else_r) {
+		PdcRegion *r = region_new (PDC_R_IFELSE, addr);
+		region_add_child (r, then_r, PDC_ROLE_JUMP);
+		region_add_child (r, else_r, PDC_ROLE_FAIL);
+		return r;
+	}
+	if (!then_r && !else_r) {
+		return NULL;
+	}
+	PdcRegion *r = region_new (PDC_R_IF, addr);
+	region_add_child (r, then_r? then_r: else_r, then_r? PDC_ROLE_JUMP: PDC_ROLE_FAIL);
+	return r;
 }
 
 static ut64 htuu_get(HtUU *m, ut64 key, ut64 dflt) {
@@ -170,12 +188,19 @@ static PdcRegion *build_loop(PdcCtx *ctx, RAnalBlock *bb, HtUU *set, ut64 *next)
 		exit = loop_exit_addr (ctx, set, h);
 	}
 	PdcRegion *loop = region_new (lt, h);
-	if (body_start != UT64_MAX && body_start != h) {
-		HtUU *prev = ctx->cur_loop;
-		ctx->cur_loop = set;
-		region_add_child (loop, region_seq (ctx, body_start, h));
-		ctx->cur_loop = prev;
+	loop->exit = exit;
+	HtUU *prev = ctx->cur_loop;
+	ctx->cur_loop = set;
+	if (j_in && f_in) {
+		// both edges stay inside, so the header's own conditional is the body
+		PdcRegion *then_r = region_seq (ctx, j, h);	// order is load-bearing
+		PdcRegion *else_r = region_seq (ctx, f, h);
+		region_add_child (loop, region_cond (h, then_r, else_r), PDC_ROLE_HEAD);
+	} else if (body_start != UT64_MAX && body_start != h) {
+		region_add_child (loop, region_seq (ctx, body_start, h),
+			(body_start == j)? PDC_ROLE_JUMP: PDC_ROLE_FAIL);
 	}
+	ctx->cur_loop = prev;
 	*next = exit;
 	return loop;
 }
@@ -183,6 +208,7 @@ static PdcRegion *build_loop(PdcCtx *ctx, RAnalBlock *bb, HtUU *set, ut64 *next)
 static PdcRegion *build_switch(PdcCtx *ctx, RAnalBlock *bb, ut64 *next) {
 	const ut64 join = htuu_get (ctx->ipdom, bb->addr, UT64_MAX);
 	PdcRegion *sw = region_new (PDC_R_SWITCH, bb->addr);
+	sw->exit = join;
 	HtUU *seen = ht_uu_new0 ();
 	RListIter *it;
 	RAnalCaseOp *co;
@@ -191,11 +217,11 @@ static PdcRegion *build_switch(PdcCtx *ctx, RAnalBlock *bb, ut64 *next) {
 			continue;
 		}
 		ht_uu_update (seen, co->jump, 1);
-		region_add_child (sw, region_seq (ctx, co->jump, join));
+		region_add_child (sw, region_seq (ctx, co->jump, join), PDC_ROLE_CASE);
 	}
 	const ut64 defv = bb->switch_op->def_val;
 	if (valid_addr (defv) && !htuu_get (seen, defv, 0)) {
-		region_add_child (sw, region_seq (ctx, defv, join));
+		region_add_child (sw, region_seq (ctx, defv, join), PDC_ROLE_CASE);
 	}
 	ht_uu_free (seen);
 	*next = join;
@@ -229,18 +255,8 @@ static PdcRegion *build_region(PdcCtx *ctx, ut64 cur, ut64 stop, ut64 *next) {
 		PdcRegion *then_r = (bb->jump == join)? NULL: region_seq (ctx, bb->jump, join);
 		PdcRegion *else_r = (bb->fail == join)? NULL: region_seq (ctx, bb->fail, join);
 		*next = join;
-		if (!then_r && !else_r) {
-			return region_new (PDC_R_BB, cur);
-		}
-		if (then_r && else_r) {
-			PdcRegion *r = region_new (PDC_R_IFELSE, cur);
-			region_add_child (r, then_r);
-			region_add_child (r, else_r);
-			return r;
-		}
-		PdcRegion *r = region_new (PDC_R_IF, cur);
-		region_add_child (r, then_r? then_r: else_r);
-		return r;
+		PdcRegion *r = region_cond (cur, then_r, else_r);
+		return r? r: region_new (PDC_R_BB, cur);
 	}
 	// one-way (continue the enclosing seq) or return block; a block may carry
 	// only a fail edge (fall-through split) with no jump
@@ -253,12 +269,10 @@ static PdcRegion *region_seq(PdcCtx *ctx, ut64 addr, ut64 stop) {
 	ut64 cur = addr;
 	int guard = ctx->cap;
 	while (cur != UT64_MAX && cur != stop && guard-- > 0) {
-		if (ctx->cur_loop && !htuu_get (ctx->cur_loop, cur, 0)) {
-			// left the enclosing loop: the loop region resumes at its exit
-			break;
-		}
-		if (htuu_get (ctx->emitted, cur, 0)) {
-			region_add_child (seq, region_new (PDC_R_GOTO, cur));
+		// leaving the loop or hitting an owned block ends the run with a jump
+		const bool left = ctx->cur_loop && !htuu_get (ctx->cur_loop, cur, 0);
+		if (left || htuu_get (ctx->emitted, cur, 0)) {
+			region_add_child (seq, region_new (PDC_R_GOTO, cur), PDC_ROLE_SEQ);
 			break;
 		}
 		ut64 next = UT64_MAX;
@@ -266,7 +280,7 @@ static PdcRegion *region_seq(PdcCtx *ctx, ut64 addr, ut64 stop) {
 		if (!r) {
 			break;
 		}
-		region_add_child (seq, r);
+		region_add_child (seq, r, PDC_ROLE_SEQ);
 		cur = next;
 	}
 	const ut64 n = RVecPdcRegionPtr_length (&seq->children);
@@ -292,6 +306,8 @@ static const char *region_kind(PdcRegionType t) {
 	case PDC_R_WHILE: return "while";
 	case PDC_R_DOWHILE: return "do-while";
 	case PDC_R_SWITCH: return "switch";
+	case PDC_R_BREAK: return "break";
+	case PDC_R_CONTINUE: return "continue";
 	case PDC_R_GOTO: return "goto";
 	}
 	return "?";
@@ -306,11 +322,61 @@ static void dump_region(PdcRegion *r, int indent, RStrBuf *sb) {
 	}
 }
 
-void pdc_ast_free(PdcRegion *root) {
-	region_free (root);
+typedef struct pdc_scope_t {
+	const struct pdc_scope_t *up;
+	ut64 brk;	// where break leaves this scope
+	ut64 cont;	// where continue restarts it, UT64_MAX for a switch
+} PdcScope;
+
+// break binds to the innermost loop or switch and continue to the innermost
+// loop, which the CFG walk cannot tell apart
+static void classify_transfers(PdcRegion *r, const PdcScope *scope) {
+	if (r->type == PDC_R_GOTO && scope) {
+		const PdcScope *s = scope;
+		while (s && s->cont == UT64_MAX) {	// continue skips switch scopes
+			s = s->up;
+		}
+		if (s && r->addr == s->cont) {
+			r->type = PDC_R_CONTINUE;
+		} else if (r->addr == scope->brk) {
+			r->type = PDC_R_BREAK;
+		}
+	}
+	PdcScope inner = { scope, r->exit, r->addr };
+	const PdcScope *sub = scope;
+	if (r->type == PDC_R_WHILE || r->type == PDC_R_DOWHILE) {
+		sub = &inner;
+	} else if (r->type == PDC_R_SWITCH) {
+		inner.cont = UT64_MAX;
+		sub = &inner;
+	}
+	PdcRegion **it;
+	R_VEC_FOREACH (&r->children, it) {
+		classify_transfers (*it, sub);
+	}
 }
 
-PdcRegion *pdc_ast_build(RCore *core, RAnalFunction *fcn) {
+void pdc_plan_free(PdcPlan *plan) {
+	if (plan) {
+		region_free (plan->root);
+		free (plan);
+	}
+}
+
+// a two-way block left to the orphan pass would lose one of its successors
+static bool blocks_are_owned(RAnalFunction *fcn, HtUU *emitted) {
+	RListIter *it;
+	RAnalBlock *bb;
+	r_list_foreach (fcn->bbs, it, bb) {
+		if (bb->jump != UT64_MAX && bb->fail != UT64_MAX
+				&& !htuu_get (emitted, bb->addr, 0)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+PdcPlan *pdc_plan_build(RCore *core, RAnalFunction *fcn) {
 	R_RETURN_VAL_IF_FAIL (core && fcn, NULL);
 	RGraphNode *entry = NULL;
 	RGraph *g = r_anal_function_get_graph (fcn, &entry, fcn->addr);
@@ -358,6 +424,27 @@ PdcRegion *pdc_ast_build(RCore *core, RAnalFunction *fcn) {
 	}
 
 	PdcRegion *root = region_seq (&ctx, fcn->addr, UT64_MAX);
+	// the orphan renderer drops a successor, so give unreached blocks a region
+	if (root) {
+		RListIter *bit;
+		RAnalBlock *b;
+		PdcRegion *extra = NULL;
+		r_list_foreach (fcn->bbs, bit, b) {
+			if (htuu_get (ctx.emitted, b->addr, 0)) {
+				continue;
+			}
+			PdcRegion *r = region_seq (&ctx, b->addr, UT64_MAX);
+			if (!r) {
+				continue;
+			}
+			if (!extra) {
+				extra = region_new (PDC_R_SEQ, root->addr);
+				region_add_child (extra, root, PDC_ROLE_SEQ);
+				root = extra;
+			}
+			region_add_child (extra, r, PDC_ROLE_SEQ);
+		}
+	}
 
 	r_graph_free (dt);
 	r_graph_free (g);
@@ -365,16 +452,22 @@ PdcRegion *pdc_ast_build(RCore *core, RAnalFunction *fcn) {
 	ht_uu_free (ctx.ipdom);
 	ht_up_foreach (ctx.loops, free_loop_set_cb, NULL);
 	ht_up_free (ctx.loops);
+	if (root) {
+		classify_transfers (root, NULL);
+	}
+	PdcPlan *plan = R_NEW0 (PdcPlan);
+	plan->root = root;
+	plan->complete = blocks_are_owned (fcn, ctx.emitted);
 	ht_uu_free (ctx.emitted);
-	return root;
+	return plan;
 }
 
 char *pdc_ast_dump(RCore *core, RAnalFunction *fcn) {
-	PdcRegion *root = pdc_ast_build (core, fcn);
+	PdcPlan *plan = pdc_plan_build (core, fcn);
 	RStrBuf *sb = r_strbuf_new ("");
-	if (root) {
-		dump_region (root, 0, sb);
-		pdc_ast_free (root);
+	if (plan && plan->root) {
+		dump_region (plan->root, 0, sb);
 	}
+	pdc_plan_free (plan);
 	return r_strbuf_drain (sb);
 }

--- a/libr/core/p/pseudo/pdc_ast.h
+++ b/libr/core/p/pseudo/pdc_ast.h
@@ -13,15 +13,28 @@ typedef enum {
 	PDC_R_WHILE,	// top-test loop
 	PDC_R_DOWHILE,	// tail/self test loop
 	PDC_R_SWITCH,	// jump table (children: one per unique case target)
+	PDC_R_BREAK,	// edge to the innermost loop exit
+	PDC_R_CONTINUE,	// edge back to the innermost loop header
 	PDC_R_GOTO	// irreducible / already-emitted fallback, never fails
 } PdcRegionType;
+
+// which edge of the parent's heading block a child came from
+typedef enum {
+	PDC_ROLE_SEQ,	// plain element of a run
+	PDC_ROLE_JUMP,	// the heading block's taken edge
+	PDC_ROLE_FAIL,	// the heading block's fall-through edge
+	PDC_ROLE_CASE,	// a switch arm
+	PDC_ROLE_HEAD	// heads the parent's own block
+} PdcRole;
 
 typedef struct pdc_region_t PdcRegion;
 R_VEC_TYPE (RVecPdcRegionPtr, PdcRegion *);
 
 struct pdc_region_t {
 	PdcRegionType type;
+	PdcRole role;
 	ut64 addr;
+	ut64 exit;	// where a break leaves this loop or switch (UT64_MAX if none)
 	RVecPdcRegionPtr children;
 };
 
@@ -31,9 +44,14 @@ static inline bool valid_addr(ut64 addr) {
 	return addr && addr != UT64_MAX;
 }
 
-// build the structuring region AST for fcn (caller frees with pdc_ast_free)
-PdcRegion *pdc_ast_build(RCore *core, RAnalFunction *fcn);
-void pdc_ast_free(PdcRegion *root);
+typedef struct {
+	PdcRegion *root;
+	bool complete;	// false when a two-way block heads no region: must use the linear pass
+} PdcPlan;
+
+// build the structuring plan for fcn (caller frees with pdc_plan_free)
+PdcPlan *pdc_plan_build(RCore *core, RAnalFunction *fcn);
+void pdc_plan_free(PdcPlan *plan);
 // build the AST for fcn and return its textual dump (pdct)
 char *pdc_ast_dump(RCore *core, RAnalFunction *fcn);
 

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -576,6 +576,14 @@ static void print_newline(PDCState *state, ut64 addr, int indent, bool synthetic
 	r_strbuf_pad (sb, ' ', indent * 4);
 }
 
+static void print_line(PDCState *state, ut64 addr, int indent, const char *fmt, ...) {
+	print_newline (state, addr, indent, false);
+	va_list ap;
+	va_start (ap, fmt);
+	r_strbuf_vappendf (state_sb (state), fmt, ap);
+	va_end (ap);
+}
+
 static bool bb_addr_is_goto_target(RAnalFunction *fcn, ut64 addr) {
 	RListIter *iter, *cit;
 	RAnalBlock *b;
@@ -1168,6 +1176,10 @@ static char *cond_or_addr(const char *cond, ut64 addr, bool invert) {
 	return invert? invert_cond (cond): strdup (cond);
 }
 
+static char *cond_str(PDCState *state, RAnalBlock *bb, bool invert) {
+	return cond_or_addr (cond_at (state, bb), bb->addr, invert);
+}
+
 static bool line_is_branch_to(const char *line, const char *target_hex) {
 	const char *t = r_str_trim_head_ro (line);
 	return strstr (t, target_hex) && (line_is_goto (t) || line_is_cond_goto (t));
@@ -1566,40 +1578,47 @@ static bool region_tail_transfers(PDCState *state, PdcRegion *r) {
 	}
 }
 
+static bool region_emits_cond(PdcRegion *r, RAnalBlock *bb) {
+	switch (r->type) {
+	case PDC_R_IF:
+	case PDC_R_IFELSE:
+		return true;
+	case PDC_R_WHILE:
+	case PDC_R_DOWHILE:
+		// a bodyless loop renders a do/while test only as a self edge
+		return region_first_child (r)? r->type == PDC_R_WHILE: bb->jump == bb->addr;
+	default:
+		return false;
+	}
+}
+
 // the header carries work too, so emit while (true) plus an explicit break
 static void render_loop(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos) {
 	PdcRegion *body = region_first_child (r);
-	if (!body && bb->jump != bb->addr) {
+	if (!body && !region_emits_cond (r, bb)) {
 		// no body and no self edge: degrade rather than emit an empty loop
 		render_bb_body_lines (state, bb, indent);
 		return;
 	}
 	if (!body) {
-		print_newline (state, bb->addr, indent, false);
-		print_str (state, "do {");
+		print_line (state, bb->addr, indent, "do {");
 		render_bb_body_lines (state, bb, indent + 1);
-		print_newline (state, bb->addr, indent, false);
-		char *tc = cond_or_addr (cond_at (state, bb), bb->addr, false);
-		print_str (state, "} while (%s);", tc);
+		char *tc = cond_str (state, bb, false);
+		print_line (state, bb->addr, indent, "} while (%s);", tc);
 		free (tc);
 		return;
 	}
-	print_newline (state, bb->addr, indent, false);
-	print_str (state, "while (true) {");
+	print_line (state, bb->addr, indent, "while (true) {");
 	if (body->role != PDC_ROLE_HEAD) {
 		// a body that heads the loop block is its conditional, and renders it
 		render_bb_body_lines (state, bb, indent + 1);
 	}
-	if (r->type == PDC_R_WHILE) {
+	if (region_emits_cond (r, bb)) {
 		// the header picks between body and exit; break on the exit edge
-		char *ec = cond_or_addr (cond_at (state, bb), bb->addr,
-			body->role == PDC_ROLE_JUMP);
-		print_newline (state, bb->addr, indent + 1, false);
-		print_str (state, "if (%s) {", ec);
-		print_newline (state, bb->addr, indent + 2, false);
-		print_str (state, "break;");
-		print_newline (state, bb->addr, indent + 1, false);
-		print_str (state, "}");
+		char *ec = cond_str (state, bb, body->role == PDC_ROLE_JUMP);
+		print_line (state, bb->addr, indent + 1, "if (%s) {", ec);
+		print_line (state, bb->addr, indent + 2, "break;");
+		print_line (state, bb->addr, indent + 1, "}");
 		free (ec);
 	}
 	if (body->role == PDC_ROLE_HEAD) {
@@ -1608,8 +1627,7 @@ static void render_loop(PDCState *state, PdcRegion *r, RAnalBlock *bb, int inden
 	} else {
 		render_region (state, body, indent + 1, gotos);
 	}
-	print_newline (state, bb->addr, indent, false);
-	print_str (state, "}");
+	print_line (state, bb->addr, indent, "}");
 }
 
 static void render_arm(PDCState *state, PdcArms *arms, ut64 target, int indent, bool owns_body) {
@@ -1629,8 +1647,7 @@ static void render_arm(PDCState *state, PdcArms *arms, ut64 target, int indent, 
 			return;
 		}
 	}
-	print_newline (state, target, indent, false);
-	print_str (state, "break;");
+	print_line (state, target, indent, "break;");
 }
 
 // jump table emitter shared by the linear and the region renderers
@@ -1643,8 +1660,8 @@ static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arm
 	}
 	char *expr = find_switch_expr (state->core, state->fcn, sw_bb);
 	const ut64 table_addr = valid_addr (sop->daddr)? sop->daddr: sw_bb->addr;
-	print_newline (state, sw_bb->addr, indent, false);
-	print_str (state, "switch (%s) { // jump table of %d cases at 0x%08" PFMT64x,
+	print_line (state, sw_bb->addr, indent,
+		"switch (%s) { // jump table of %d cases at 0x%08" PFMT64x,
 		expr, n, table_addr);
 	free (expr);
 	int c = 0;
@@ -1666,13 +1683,12 @@ static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arm
 		c = k + 1;
 	}
 	if (valid_addr (sop->def_val)) {
-		print_newline (state, sop->def_val, indent + 1, false);
-		print_str (state, "default: // 0x%08" PFMT64x, sop->def_val);
+		print_line (state, sop->def_val, indent + 1,
+			"default: // 0x%08" PFMT64x, sop->def_val);
 		render_arm (state, arms, sop->def_val, indent + 2,
 			!case_table_has (arr, n, sop->def_val));
 	}
-	print_newline (state, sw_bb->addr, indent, false);
-	print_str (state, "}");
+	print_line (state, sw_bb->addr, indent, "}");
 	free (arr);
 }
 
@@ -1694,18 +1710,14 @@ static void render_ifelse(PDCState *state, PdcRegion *r, RAnalBlock *bb, int ind
 		then_arm = else_arm;
 		else_arm = tmp;
 	}
-	char *cond = cond_or_addr (cond_at (state, bb), bb->addr,
-		then_arm->role == PDC_ROLE_FAIL);
-	print_newline (state, bb->addr, indent, false);
-	print_str (state, "if (%s) {", cond);
+	char *cond = cond_str (state, bb, then_arm->role == PDC_ROLE_FAIL);
+	print_line (state, bb->addr, indent, "if (%s) {", cond);
 	render_region (state, then_arm, indent + 1, gotos);
 	if (else_arm) {
-		print_newline (state, bb->addr, indent, false);
-		print_str (state, "} else {");
+		print_line (state, bb->addr, indent, "} else {");
 		render_region (state, else_arm, indent + 1, gotos);
 	}
-	print_newline (state, bb->addr, indent, false);
-	print_str (state, "}");
+	print_line (state, bb->addr, indent, "}");
 	free (cond);
 }
 
@@ -1718,13 +1730,11 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		return;
 	}
 	if (r->type == PDC_R_BREAK || r->type == PDC_R_CONTINUE) {
-		print_newline (state, r->addr, indent, false);
-		print_str (state, "%s;", (r->type == PDC_R_BREAK)? "break": "continue");
+		print_line (state, r->addr, indent, "%s;", (r->type == PDC_R_BREAK)? "break": "continue");
 		return;
 	}
 	if (r->type == PDC_R_GOTO) {
-		print_newline (state, r->addr, indent, false);
-		print_str (state, "goto loc_0x%08" PFMT64x ";", r->addr);
+		print_line (state, r->addr, indent, "goto loc_0x%08" PFMT64x ";", r->addr);
 		return;
 	}
 	RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
@@ -1732,8 +1742,7 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		return;
 	}
 	if (r_bitset_test (gotos, r->addr)) {
-		print_newline (state, r->addr, indent, false);
-		print_str (state, "loc_0x%08" PFMT64x ":", r->addr);
+		print_line (state, r->addr, indent, "loc_0x%08" PFMT64x ":", r->addr);
 	}
 	switch (r->type) {
 	case PDC_R_IF:
@@ -1756,23 +1765,16 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 // an if with no recoverable condition would hide which way the branch went
 static bool regions_have_conds(PDCState *state, PdcRegion *r) {
 	const bool loop = r->type == PDC_R_WHILE || r->type == PDC_R_DOWHILE;
-	// a loop with no body renders its test only when it is a self edge
-	const bool tested = r->type == PDC_R_IF || r->type == PDC_R_IFELSE
-		|| r->type == PDC_R_WHILE
-		|| (r->type == PDC_R_DOWHILE && !region_first_child (r));
-	if (loop || tested) {
+	if (loop || r->type == PDC_R_IF || r->type == PDC_R_IFELSE) {
 		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
 		if (!bb) {
 			return false;
 		}
-		// build_loop wins over build_switch, and the loop renderer emits no
-		// table, so a dispatching header would lose every case
+		// build_loop beats build_switch and emits no table: a dispatcher bails
 		if (loop && bb->switch_op && !r_list_empty (bb->switch_op->cases)) {
 			return false;
 		}
-		// a bodyless header that is not a self edge renders flat, with no test
-		const bool flat = r->type == PDC_R_DOWHILE && bb->jump != bb->addr;
-		if (tested && !flat && !cond_at (state, bb)) {
+		if (region_emits_cond (r, bb) && !cond_at (state, bb)) {
 			return false;
 		}
 	}

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -733,6 +733,21 @@ static bool line_is_cond_goto(const char *line) {
 	return r_str_startswith (line, "if ") && strstr (line, "goto ");
 }
 
+// a rendered goto target: loc_ label, bare number or flag name, else UT64_MAX
+static ut64 goto_target(PDCState *state, const char *tok) {
+	tok = r_str_trim_head_ro (tok);
+	if (r_str_startswith (tok, "loc_")) {
+		tok += 4;
+	}
+	if (isdigit ((unsigned char)*tok)) {
+		return r_num_get (NULL, tok);
+	}
+	char *name = r_str_ndup (tok, strcspn (tok, " \t;"));
+	RFlagItem *fi = name? r_flag_get (state->core->flags, name): NULL;
+	free (name);
+	return fi? fi->addr: UT64_MAX;
+}
+
 // only the block's own two edges belong to its region, so a tail call, an indirect jump
 // or a call rendered as `jmp` (riscv jal) is the sole remaining transfer and must survive
 static bool line_targets_own_edge(PDCState *state, const char *line) {
@@ -746,20 +761,9 @@ static bool line_targets_own_edge(PDCState *state, const char *line) {
 		}
 		p += 4;
 	}
-	// the target is printed as loc_0xADDR, 0xADDR or a plain number, but a symbolic one
-	// (an import, a register, a reloc slot) leaves the function and has no region to own it
-	if (r_str_startswith (p, "loc_")) {
-		p += 4;
-	}
-	if (!isdigit ((unsigned char)*p)) {
-		return false;
-	}
-	const ut64 dst = r_num_get (NULL, p);
-	if (dst == UT64_MAX) {
-		// an unset jump or fail edge is UT64_MAX too, so it must not match
-		return false;
-	}
-	return dst == state->bb_jump || dst == state->bb_fail;
+	const ut64 dst = goto_target (state, p);
+	// an unset jump or fail edge is UT64_MAX too, so it must not match
+	return dst != UT64_MAX && (dst == state->bb_jump || dst == state->bb_fail);
 }
 
 static bool line_is_known_loop_goto(PDCState *state, const char *line) {
@@ -891,6 +895,7 @@ static void mark_bb_visited(PDCState *state, RList *visited, RAnalBlock *cbb) {
 typedef struct {
 	ut64 value;
 	ut64 jump;
+	bool first; // no lower value shares this target, so this run owns the body
 } PDCSwCase;
 
 static int pdc_case_cmp(const void *a, const void *b) {
@@ -1016,11 +1021,16 @@ static PDCSwCase *switch_cases(RAnalSwitchOp *sop, int *n) {
 	RListIter *iter;
 	RAnalCaseOp *co;
 	r_list_foreach (sop->cases, iter, co) {
+		// build_switch skips unresolved entries too, so neither side invents an arm
+		if (co->jump == UT64_MAX) {
+			continue;
+		}
 		arr[i].value = co->value;
 		arr[i].jump = co->jump;
 		i++;
 	}
 	qsort (arr, i, sizeof (PDCSwCase), pdc_case_cmp);
+	HtUU *seen = ht_uu_new0 ();
 	int w = 0;
 	int r;
 	for (r = 0; r < i; r++) {
@@ -1028,8 +1038,14 @@ static PDCSwCase *switch_cases(RAnalSwitchOp *sop, int *n) {
 				&& arr[w - 1].jump == arr[r].jump) {
 			continue;
 		}
-		arr[w++] = arr[r];
+		arr[w] = arr[r];
+		arr[w].first = !seen || !ht_uu_find (seen, arr[r].jump, NULL);
+		if (seen) {
+			ht_uu_insert (seen, arr[r].jump, 1);
+		}
+		w++;
 	}
+	ht_uu_free (seen);
 	*n = w;
 	return arr;
 }
@@ -1072,23 +1088,9 @@ static char *extract_loop_cond(PDCState *state, RAnalBlock *test_bb, ut64 back_t
 		if (!r_str_startswith (t, "if ")) {
 			continue;
 		}
-		const char *g = strstr (t, "goto");
-		if (!g) {
+		const char *g = strstr (t, "goto ");
+		if (!g || goto_target (state, g + 5) != back_target) {
 			continue;
-		}
-		const char *num = strstr (g, "0x");
-		if (!num || r_num_get (NULL, num) != back_target) {
-			// a case.0x4319.127 flag or a loc_ label is not a bare address
-			const char *tok = r_str_trim_head_ro (g + 4);
-			if (r_str_startswith (tok, "loc_")) {
-				tok += 4;
-			}
-			char *tgt = r_str_ndup (tok, strcspn (tok, " \t"));
-			const ut64 resolved = r_num_math (state->core->num, tgt);
-			free (tgt);
-			if (resolved != back_target) {
-				continue;
-			}
 		}
 		const char *open = strchr (t, '(');
 		if (!open) {
@@ -1438,11 +1440,6 @@ static bool case_table_has(const PDCSwCase *arr, int n, ut64 target) {
 	return false;
 }
 
-// interleaved values give one target two label runs; only the first owns a body
-static bool case_run_is_first(const PDCSwCase *arr, int c) {
-	return !case_table_has (arr, c, arr[c].jump);
-}
-
 static void collect_goto_targets(PDCState *state, PdcRegion *r, RBitset *gotos) {
 	if (r->type == PDC_R_GOTO) {
 		r_bitset_set (gotos, r->addr);
@@ -1455,7 +1452,7 @@ static void collect_goto_targets(PDCState *state, PdcRegion *r, RBitset *gotos) 
 		// mid-run entries repeat their own target, so only run starts count
 		for (c = 0; c < n; c++) {
 			const bool run_start = !c || arr[c].jump != arr[c - 1].jump;
-			if (run_start && !case_run_is_first (arr, c)) {
+			if (run_start && !arr[c].first) {
 				r_bitset_set (gotos, arr[c].jump);
 			}
 		}
@@ -1665,7 +1662,7 @@ static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arm
 				emit_case_label (state, arr[j].value, arr[j].value, target, indent + 1);
 			}
 		}
-		render_arm (state, arms, target, indent + 2, case_run_is_first (arr, c));
+		render_arm (state, arms, target, indent + 2, arr[c].first);
 		c = k + 1;
 	}
 	if (valid_addr (sop->def_val)) {
@@ -1681,6 +1678,8 @@ static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arm
 
 static void render_switch_region(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos) {
 	render_bb_body_lines (state, bb, indent);
+	// mark even on a failed body fetch, or the hoist pass emits the table twice
+	r_bitset_set (state->marked, bb->addr);
 	PdcArms arms = { .sw = r, .gotos = gotos };
 	render_switch_cases (state, bb, &arms, indent);
 }

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -20,6 +20,7 @@ typedef struct {
 	RAnalFunction *fcn;
 	ut64 bb_jump; // edges of the block being rendered, owned by its region in structured mode
 	ut64 bb_fail;
+	HtUP *conds; // block addr => recovered condition, recovered once per block
 	const char *r0;
 } PDCState;
 
@@ -1000,78 +1001,51 @@ static void render_arm_body(PDCState *state, RList *visited, ut64 target, int in
 	}
 }
 
-static void render_switch(PDCState *state, RAnalBlock *sw_bb, RList *visited, int indent) {
-	RAnalSwitchOp *sop = sw_bb->switch_op;
-	if (!sop->cases) {
-		return;
+// value-sorted, de-duplicated case table; *n returns its length, caller frees
+static PDCSwCase *switch_cases(RAnalSwitchOp *sop, int *n) {
+	*n = 0;
+	const int ncases = sop->cases? r_list_length (sop->cases): 0;
+	if (ncases < 1) {
+		return NULL;
 	}
-	int n = r_list_length (sop->cases);
-	if (n < 1) {
-		return;
-	}
-	PDCSwCase *arr = calloc (n, sizeof (PDCSwCase));
+	PDCSwCase *arr = R_NEWS0 (PDCSwCase, ncases);
 	if (!arr) {
-		return;
+		return NULL;
 	}
 	int i = 0;
 	RListIter *iter;
 	RAnalCaseOp *co;
 	r_list_foreach (sop->cases, iter, co) {
-		if (i >= n) {
-			break;
-		}
 		arr[i].value = co->value;
 		arr[i].jump = co->jump;
 		i++;
 	}
 	qsort (arr, i, sizeof (PDCSwCase), pdc_case_cmp);
-	{
-		int w = 0;
-		int r;
-		for (r = 0; r < i; r++) {
-			if (w > 0 && arr[w - 1].value == arr[r].value
-					&& arr[w - 1].jump == arr[r].jump) {
-				continue;
-			}
-			arr[w++] = arr[r];
+	int w = 0;
+	int r;
+	for (r = 0; r < i; r++) {
+		if (w > 0 && arr[w - 1].value == arr[r].value
+				&& arr[w - 1].jump == arr[r].jump) {
+			continue;
 		}
-		i = w;
+		arr[w++] = arr[r];
 	}
-	char *expr = find_switch_expr (state->core, state->fcn, sw_bb);
-	ut64 table_addr = valid_addr (sop->daddr)? sop->daddr: sw_bb->addr;
-	print_newline (state, sw_bb->addr, indent, false);
-	print_str (state, "switch (%s) { // jump table of %d cases at 0x%08" PFMT64x,
-		expr, i, table_addr);
-	free (expr);
+	*n = w;
+	return arr;
+}
 
-	int c = 0;
-	while (c < i) {
-		int k = c;
-		while (k + 1 < i && arr[k + 1].jump == arr[c].jump) {
-			k++;
-		}
-		ut64 target = arr[c].jump;
-		if (k - c >= 2 && pdc_range_is_contiguous (arr, c, k)) {
-			emit_case_label (state, arr[c].value, arr[k].value, target, indent + 1);
-		} else {
-			int j;
-			for (j = c; j <= k; j++) {
-				emit_case_label (state, arr[j].value, arr[j].value, target, indent + 1);
-			}
-		}
-		render_arm_body (state, visited, target, indent + 2);
-		c = k + 1;
-	}
+// where a jump table arm comes from: the region AST, or the linear walk
+typedef struct {
+	RList *visited;
+	PdcRegion *sw;
+	RBitset *gotos;
+} PdcArms;
 
-	if (valid_addr (sop->def_val)) {
-		print_newline (state, sop->def_val, indent + 1, false);
-		print_str (state, "default: // 0x%08" PFMT64x, sop->def_val);
-		render_arm_body (state, visited, sop->def_val, indent + 2);
-	}
+static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arms, int indent);
 
-	print_newline (state, sw_bb->addr, indent, false);
-	print_str (state, "}");
-	free (arr);
+static void render_switch(PDCState *state, RAnalBlock *sw_bb, RList *visited, int indent) {
+	PdcArms arms = { .visited = visited };
+	render_switch_cases (state, sw_bb, &arms, indent);
 }
 
 static char *extract_loop_cond(PDCState *state, RAnalBlock *test_bb, ut64 back_target) {
@@ -1104,7 +1078,17 @@ static char *extract_loop_cond(PDCState *state, RAnalBlock *test_bb, ut64 back_t
 		}
 		const char *num = strstr (g, "0x");
 		if (!num || r_num_get (NULL, num) != back_target) {
-			continue;
+			// a case.0x4319.127 flag or a loc_ label is not a bare address
+			const char *tok = r_str_trim_head_ro (g + 4);
+			if (r_str_startswith (tok, "loc_")) {
+				tok += 4;
+			}
+			char *tgt = r_str_ndup (tok, strcspn (tok, " \t"));
+			const ut64 resolved = r_num_math (state->core->num, tgt);
+			free (tgt);
+			if (resolved != back_target) {
+				continue;
+			}
 		}
 		const char *open = strchr (t, '(');
 		if (!open) {
@@ -1155,6 +1139,31 @@ static char *extract_loop_cond(PDCState *state, RAnalBlock *test_bb, ut64 back_t
 	}
 	free (vexpr);
 	return result;
+}
+
+static void cond_kvfree(HtUPKv *kv) {
+	free (kv->value);
+}
+
+// recovery costs a pi command and a parse, and every caller wants the same one
+static const char *cond_at(PDCState *state, RAnalBlock *bb) {
+	bool found = false;
+	char *cond = ht_up_find (state->conds, bb->addr, &found);
+	if (!found) {
+		cond = extract_loop_cond (state, bb, bb->jump);
+		ht_up_insert (state->conds, bb->addr, cond);
+	}
+	return cond;
+}
+
+static char *invert_cond(const char *cond);
+
+// an unrecovered condition still shows the block it came from
+static char *cond_or_addr(const char *cond, ut64 addr, bool invert) {
+	if (!cond) {
+		return r_str_newf ("/* 0x%08" PFMT64x " */", addr);
+	}
+	return invert? invert_cond (cond): strdup (cond);
 }
 
 static bool line_is_branch_to(const char *line, const char *target_hex) {
@@ -1223,23 +1232,17 @@ static RAnalBlock *render_loop_while(PDCState *state, RAnalBlock *test_bb, RList
 	if (self_loop) {
 		print_str (state, "do {");
 	} else {
-		if (cond) {
-			print_str (state, "while (%s) {", cond);
-		} else {
-			print_str (state, "while (/* 0x%08" PFMT64x " */) {",
-				test_bb->addr);
-		}
+		char *c = cond_or_addr (cond, test_bb->addr, false);
+		print_str (state, "while (%s) {", c);
+		free (c);
 	}
 	if (self_loop) {
 		emit_bb_body_no_back_jump (state, test_bb, test_bb->addr, indent + 1);
 		mark_bb_visited (state, visited, test_bb);
 		print_newline (state, test_bb->addr, indent, false);
-		if (cond) {
-			print_str (state, "} while (%s);", cond);
-		} else {
-			print_str (state, "} while (/* 0x%08" PFMT64x " */);",
-				test_bb->addr);
-		}
+		char *c = cond_or_addr (cond, test_bb->addr, false);
+		print_str (state, "} while (%s);", c);
+		free (c);
 	} else {
 		ut64 body_start = test_bb->jump;
 		ut64 body_end = test_bb->addr;
@@ -1425,26 +1428,46 @@ static void pdc_print_comment_cmds(RCore *core, const char *s) {
 	}
 }
 
-static bool region_has_loop_or_switch(PdcRegion *r) {
-	if (r->type == PDC_R_WHILE || r->type == PDC_R_DOWHILE || r->type == PDC_R_SWITCH) {
-		return true;
-	}
-	PdcRegion **it;
-	R_VEC_FOREACH (&r->children, it) {
-		if (region_has_loop_or_switch (*it)) {
+static bool case_table_has(const PDCSwCase *arr, int n, ut64 target) {
+	int i;
+	for (i = 0; i < n; i++) {
+		if (arr[i].jump == target) {
 			return true;
 		}
 	}
 	return false;
 }
 
-static void collect_goto_targets(PdcRegion *r, RBitset *gotos) {
+// interleaved values give one target two label runs; only the first owns a body
+static bool case_run_is_first(const PDCSwCase *arr, int c) {
+	return !case_table_has (arr, c, arr[c].jump);
+}
+
+static void collect_goto_targets(PDCState *state, PdcRegion *r, RBitset *gotos) {
 	if (r->type == PDC_R_GOTO) {
 		r_bitset_set (gotos, r->addr);
 	}
+	if (r->type == PDC_R_SWITCH) {
+		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
+		int n = 0;
+		PDCSwCase *arr = bb && bb->switch_op? switch_cases (bb->switch_op, &n): NULL;
+		int c;
+		// mid-run entries repeat their own target, so only run starts count
+		for (c = 0; c < n; c++) {
+			const bool run_start = !c || arr[c].jump != arr[c - 1].jump;
+			if (run_start && !case_run_is_first (arr, c)) {
+				r_bitset_set (gotos, arr[c].jump);
+			}
+		}
+		if (arr && valid_addr (bb->switch_op->def_val)
+				&& case_table_has (arr, n, bb->switch_op->def_val)) {
+			r_bitset_set (gotos, bb->switch_op->def_val);
+		}
+		free (arr);
+	}
 	PdcRegion **it;
 	R_VEC_FOREACH (&r->children, it) {
-		collect_goto_targets (*it, gotos);
+		collect_goto_targets (state, *it, gotos);
 	}
 }
 
@@ -1499,32 +1522,181 @@ static char *invert_cond(const char *cond) {
 }
 
 static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *gotos);
+static void render_ifelse(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos);
+
+static PdcRegion *region_first_child(PdcRegion *r) {
+	PdcRegion **first = RVecPdcRegionPtr_at (&r->children, 0);
+	return first? *first: NULL;
+}
+
+static PdcRegion *region_child_at(PdcRegion *r, ut64 addr) {
+	PdcRegion **it;
+	R_VEC_FOREACH (&r->children, it) {
+		if ((*it)->addr == addr) {
+			return *it;
+		}
+	}
+	return NULL;
+}
+
+// whether the region's last statement already transfers control elsewhere
+static bool region_tail_transfers(PDCState *state, PdcRegion *r) {
+	switch (r->type) {
+	case PDC_R_GOTO:
+	case PDC_R_BREAK:
+	case PDC_R_CONTINUE:
+		return true;
+	case PDC_R_SEQ: {
+		PdcRegion **last = RVecPdcRegionPtr_last (&r->children);
+		return last? region_tail_transfers (state, *last): false;
+	}
+	case PDC_R_BB: {
+		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
+		// a jump to the block's own edge is dropped, a ret or ujmp is not
+		const int t = bb? bb_last_op_type (state->core, bb): -1;
+		return t == R_ANAL_OP_TYPE_RET || t == R_ANAL_OP_TYPE_CRET
+			|| t == R_ANAL_OP_TYPE_UJMP;
+	}
+	case PDC_R_IFELSE: {
+		// both arms must leave, or control falls out of the conditional
+		PdcRegion **a = RVecPdcRegionPtr_at (&r->children, 0);
+		PdcRegion **b = RVecPdcRegionPtr_at (&r->children, 1);
+		return a && b && region_tail_transfers (state, *a)
+			&& region_tail_transfers (state, *b);
+	}
+	default:
+		return false;
+	}
+}
+
+// the header carries work too, so emit while (true) plus an explicit break
+static void render_loop(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos) {
+	PdcRegion *body = region_first_child (r);
+	if (!body && bb->jump != bb->addr) {
+		// no body and no self edge: degrade rather than emit an empty loop
+		render_bb_body_lines (state, bb, indent);
+		return;
+	}
+	if (!body) {
+		print_newline (state, bb->addr, indent, false);
+		print_str (state, "do {");
+		render_bb_body_lines (state, bb, indent + 1);
+		print_newline (state, bb->addr, indent, false);
+		char *tc = cond_or_addr (cond_at (state, bb), bb->addr, false);
+		print_str (state, "} while (%s);", tc);
+		free (tc);
+		return;
+	}
+	print_newline (state, bb->addr, indent, false);
+	print_str (state, "while (true) {");
+	if (body->role != PDC_ROLE_HEAD) {
+		// a body that heads the loop block is its conditional, and renders it
+		render_bb_body_lines (state, bb, indent + 1);
+	}
+	if (r->type == PDC_R_WHILE) {
+		// the header picks between body and exit; break on the exit edge
+		char *ec = cond_or_addr (cond_at (state, bb), bb->addr,
+			body->role == PDC_ROLE_JUMP);
+		print_newline (state, bb->addr, indent + 1, false);
+		print_str (state, "if (%s) {", ec);
+		print_newline (state, bb->addr, indent + 2, false);
+		print_str (state, "break;");
+		print_newline (state, bb->addr, indent + 1, false);
+		print_str (state, "}");
+		free (ec);
+	}
+	if (body->role == PDC_ROLE_HEAD) {
+		// the loop region already emitted this block's label and owns its lines
+		render_ifelse (state, body, bb, indent + 1, gotos);
+	} else {
+		render_region (state, body, indent + 1, gotos);
+	}
+	print_newline (state, bb->addr, indent, false);
+	print_str (state, "}");
+}
+
+static void render_arm(PDCState *state, PdcArms *arms, ut64 target, int indent, bool owns_body) {
+	if (!arms->sw) {
+		render_arm_body (state, arms->visited, target, indent);
+		return;
+	}
+	if (!owns_body) {
+		print_newline (state, target, indent, false);
+		print_goto_or_return (state, target, "");
+		return;
+	}
+	PdcRegion *arm = region_child_at (arms->sw, target);
+	if (arm) {
+		render_region (state, arm, indent, arms->gotos);
+		if (region_tail_transfers (state, arm)) {
+			return;
+		}
+	}
+	print_newline (state, target, indent, false);
+	print_str (state, "break;");
+}
+
+// jump table emitter shared by the linear and the region renderers
+static void render_switch_cases(PDCState *state, RAnalBlock *sw_bb, PdcArms *arms, int indent) {
+	RAnalSwitchOp *sop = sw_bb->switch_op;
+	int n = 0;
+	PDCSwCase *arr = switch_cases (sop, &n);
+	if (!arr) {
+		return;
+	}
+	char *expr = find_switch_expr (state->core, state->fcn, sw_bb);
+	const ut64 table_addr = valid_addr (sop->daddr)? sop->daddr: sw_bb->addr;
+	print_newline (state, sw_bb->addr, indent, false);
+	print_str (state, "switch (%s) { // jump table of %d cases at 0x%08" PFMT64x,
+		expr, n, table_addr);
+	free (expr);
+	int c = 0;
+	while (c < n) {
+		int k = c;
+		while (k + 1 < n && arr[k + 1].jump == arr[c].jump) {
+			k++;
+		}
+		const ut64 target = arr[c].jump;
+		if (k - c >= 2 && pdc_range_is_contiguous (arr, c, k)) {
+			emit_case_label (state, arr[c].value, arr[k].value, target, indent + 1);
+		} else {
+			int j;
+			for (j = c; j <= k; j++) {
+				emit_case_label (state, arr[j].value, arr[j].value, target, indent + 1);
+			}
+		}
+		render_arm (state, arms, target, indent + 2, case_run_is_first (arr, c));
+		c = k + 1;
+	}
+	if (valid_addr (sop->def_val)) {
+		print_newline (state, sop->def_val, indent + 1, false);
+		print_str (state, "default: // 0x%08" PFMT64x, sop->def_val);
+		render_arm (state, arms, sop->def_val, indent + 2,
+			!case_table_has (arr, n, sop->def_val));
+	}
+	print_newline (state, sw_bb->addr, indent, false);
+	print_str (state, "}");
+	free (arr);
+}
+
+static void render_switch_region(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos) {
+	render_bb_body_lines (state, bb, indent);
+	PdcArms arms = { .sw = r, .gotos = gotos };
+	render_switch_cases (state, bb, &arms, indent);
+}
 
 static void render_ifelse(PDCState *state, PdcRegion *r, RAnalBlock *bb, int indent, RBitset *gotos) {
 	render_bb_body_lines (state, bb, indent);
-	char *cond = extract_loop_cond (state, bb, bb->jump);
-	if (!cond) {
-		cond = r_str_newf ("/* 0x%08" PFMT64x " */", bb->addr);
-	}
 	PdcRegion *then_arm = *RVecPdcRegionPtr_at (&r->children, 0);
 	PdcRegion *else_arm = (r->type == PDC_R_IFELSE)? *RVecPdcRegionPtr_at (&r->children, 1): NULL;
-	// pseudo says `if (cond) goto jump`, so the fall-through (fail arm) becomes the then
-	bool invert = (then_arm->addr == bb->fail);
-	if (else_arm) {
-		const bool swap = (then_arm->addr == bb->jump && else_arm->addr == bb->fail);
-		// an unexpected arm layout keeps the faithful jump-then order
-		invert = swap || (invert && else_arm->addr == bb->jump);
-		if (swap) {
-			PdcRegion *tmp = then_arm;
-			then_arm = else_arm;
-			else_arm = tmp;
-		}
+	// pseudo says `if (cond) goto jump`, so the fall-through arm reads as the then
+	if (else_arm && then_arm->role == PDC_ROLE_JUMP && else_arm->role == PDC_ROLE_FAIL) {
+		PdcRegion *tmp = then_arm;
+		then_arm = else_arm;
+		else_arm = tmp;
 	}
-	if (invert) {
-		char *ic = invert_cond (cond);
-		free (cond);
-		cond = ic;
-	}
+	char *cond = cond_or_addr (cond_at (state, bb), bb->addr,
+		then_arm->role == PDC_ROLE_FAIL);
 	print_newline (state, bb->addr, indent, false);
 	print_str (state, "if (%s) {", cond);
 	render_region (state, then_arm, indent + 1, gotos);
@@ -1546,6 +1718,11 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		}
 		return;
 	}
+	if (r->type == PDC_R_BREAK || r->type == PDC_R_CONTINUE) {
+		print_newline (state, r->addr, indent, false);
+		print_str (state, "%s;", (r->type == PDC_R_BREAK)? "break": "continue");
+		return;
+	}
 	if (r->type == PDC_R_GOTO) {
 		print_newline (state, r->addr, indent, false);
 		print_str (state, "goto loc_0x%08" PFMT64x ";", r->addr);
@@ -1559,28 +1736,46 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		print_newline (state, r->addr, indent, false);
 		print_str (state, "loc_0x%08" PFMT64x ":", r->addr);
 	}
-	if (r->type == PDC_R_IF || r->type == PDC_R_IFELSE) {
+	switch (r->type) {
+	case PDC_R_IF:
+	case PDC_R_IFELSE:
 		render_ifelse (state, r, bb, indent, gotos);
 		return;
+	case PDC_R_WHILE:
+	case PDC_R_DOWHILE:
+		render_loop (state, r, bb, indent, gotos);
+		return;
+	case PDC_R_SWITCH:
+		render_switch_region (state, r, bb, indent, gotos);
+		return;
+	default:
+		render_bb_body_lines (state, bb, indent);
+		return;
 	}
-	// PDC_R_BB leaf
-	render_bb_body_lines (state, bb, indent);
 }
 
-// render the structured body for fully reducible (no loop/switch) functions;
-// returns false to defer to the linear renderer
 // an if with no recoverable condition would hide which way the branch went
 static bool regions_have_conds(PDCState *state, PdcRegion *r) {
-	if (r->type == PDC_R_IF || r->type == PDC_R_IFELSE) {
+	const bool loop = r->type == PDC_R_WHILE || r->type == PDC_R_DOWHILE;
+	// a loop with no body renders its test only when it is a self edge
+	const bool tested = r->type == PDC_R_IF || r->type == PDC_R_IFELSE
+		|| r->type == PDC_R_WHILE
+		|| (r->type == PDC_R_DOWHILE && !region_first_child (r));
+	if (loop || tested) {
 		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
 		if (!bb) {
 			return false;
 		}
-		char *cond = extract_loop_cond (state, bb, bb->jump);
-		if (!cond) {
+		// build_loop wins over build_switch, and the loop renderer emits no
+		// table, so a dispatching header would lose every case
+		if (loop && bb->switch_op && !r_list_empty (bb->switch_op->cases)) {
 			return false;
 		}
-		free (cond);
+		// a bodyless header that is not a self edge renders flat, with no test
+		const bool flat = r->type == PDC_R_DOWHILE && bb->jump != bb->addr;
+		if (tested && !flat && !cond_at (state, bb)) {
+			return false;
+		}
 	}
 	PdcRegion **it;
 	R_VEC_FOREACH (&r->children, it) {
@@ -1593,22 +1788,27 @@ static bool regions_have_conds(PDCState *state, PdcRegion *r) {
 
 // renders the whole function from the region AST, or returns false to defer to the linear pass
 static bool pdc_structured_body(PDCState *state, int indent) {
-	PdcRegion *root = pdc_ast_build (state->core, state->fcn);
-	if (!root) {
+	PdcPlan *plan = pdc_plan_build (state->core, state->fcn);
+	if (!plan || !plan->root) {
+		pdc_plan_free (plan);
 		return false;
 	}
-	const bool reducible = !region_has_loop_or_switch (root) && regions_have_conds (state, root);
+	PdcRegion *root = plan->root;
+	state->conds = ht_up_new (NULL, cond_kvfree, NULL);
+	const bool reducible = plan->complete && regions_have_conds (state, root);
 	if (reducible) {
 		// scoped to this walk: the later orphan switch pass renders blocks no region owns
 		const bool was_structured = state->structured;
 		state->structured = true;
 		RBitset *gotos = r_bitset_new ();
-		collect_goto_targets (root, gotos);
+		collect_goto_targets (state, root, gotos);
 		render_region (state, root, indent, gotos);
 		r_bitset_free (gotos);
 		state->structured = was_structured;
 	}
-	pdc_ast_free (root);
+	ht_up_free (state->conds);
+	state->conds = NULL;
+	pdc_plan_free (plan);
 	return reducible;
 }
 

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -820,16 +820,63 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=pdc structured bails to linear on loops
+NAME=pdc structured renders a self loop as do while
 FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
 CMDS=<<EOF
 aa
-s 0x15c80
-e pdc.structured=1
-pdc~goto loc_0x15c60
+s 0x15e70
+pdc~do {,} while
 EOF
 EXPECT=<<EOF
-        if (!v) goto loc_0x15c60 // likely
+        do {
+        } while (rdx & rdx);
+EOF
+RUN
+
+NAME=pdc structured recovers continue and break in a loop body
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 31c0eb0c83c00183f80a7504c390909089c3ebf0
+af
+pdc~while (true),continue,break
+EOF
+EXPECT=<<EOF
+    while (true) {
+            continue;
+        break;
+EOF
+RUN
+
+NAME=pdc structured keeps the loop header body inside the loop
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x102b0
+pdc~while (true),eax += 0x30,break
+EOF
+EXPECT=<<EOF
+    while (true) {
+        eax += 0x30
+            break;
+EOF
+RUN
+
+NAME=pdc structured renders each jump table case with its own body
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x145b0
+pdc~switch (r12),case 0:,abort,break
+EOF
+EXPECT=<<EOF
+        switch (r12) { // jump table of 10 cases at 0x0001bca4
+            case 0: // 0x00004056
+                qword [reloc.abort] () // [0x21ca8:8]=0 // void abort(void)
+                break;
 EOF
 RUN
 
@@ -965,5 +1012,111 @@ pdc~switch (,default:
 EOF
 EXPECT=<<EOF
     switch (switch_var) { // jump table of 1 cases at 0x004156b8
+EOF
+RUN
+
+NAME=pdc structured keeps both arms of a loop header that branches inside the loop
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 85c0750583c001ebf783e80183f8057402ebedc3
+af
+pdc~while (true),eax += 1,eax -= 1,continue,break
+EOF
+EXPECT=<<EOF
+    while (true) {
+            eax += 1
+            eax -= 1
+                continue;
+            break;
+EOF
+RUN
+
+NAME=pdc structured ends every switch arm with an explicit transfer
+FILE=bins/elf/bomb
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x400f43
+pdc~case ,goto loc_0x00400fbe
+EOF
+EXPECT=<<EOF
+            case 0: // 0x00400f7c
+            case 1: // 0x00400fb9
+                goto loc_0x00400fbe;
+            case 2: // 0x00400f83
+                goto loc_0x00400fbe;
+            case 3: // 0x00400f8a
+                goto loc_0x00400fbe;
+            case 4: // 0x00400f91
+                goto loc_0x00400fbe;
+            case 5: // 0x00400f98
+                goto loc_0x00400fbe;
+            case 6: // 0x00400f9f
+                goto loc_0x00400fbe;
+            case 7: // 0x00400fa6
+                goto loc_0x00400fbe;
+EOF
+RUN
+
+NAME=pdc structured renders a repeated case target once and jumps to it
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x5c40
+pdc~case 88:,loc_0x00005d80:,case 120:,goto loc_0x00005d80
+EOF
+EXPECT=<<EOF
+                                    case 88: // 'X' 0x00005d80
+                                        loc_0x00005d80:
+                                    case 120: // 'x' 0x00005d80
+                                        goto loc_0x00005d80;
+EOF
+RUN
+
+NAME=pdc structured keeps the body of a loop whose header jumps to itself
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 85c074fc83c00183f80575f4c3
+af
+pdc~while (true),eax += 1,continue,break
+EOF
+EXPECT=<<EOF
+    while (true) {
+            eax += 1
+                continue;
+            break;
+EOF
+RUN
+
+NAME=pdc structured labels no arm for an adjacent only case run
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x5c40
+pdc~case 48...55:,loc_0x00005d48:
+EOF
+EXPECT=<<EOF
+                                    case 48...55: // '0'..'7' 0x00005d48
+EOF
+RUN
+
+NAME=pdc structured renders both arms behind a loop secondary exit
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 85c0741483c00183f80574f483f807750483c002c383c003c3
+af
+pdc~loc_0x0000000c:,eax - 7,eax += 2,eax += 3
+EOF
+EXPECT=<<EOF
+    loc_0x0000000c:
+    v = eax - 7
+    if (!(eax - 7)) {
+        eax += 2
+        eax += 3
 EOF
 RUN

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1075,6 +1075,23 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=pdc structured strips a flag-named own edge instead of rendering it twice
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+s 0x5c40
+pdc~goto case.~?
+pdc~switch (cl)~?
+pdc~if (((unsigned) v) <= 0) {~?
+EOF
+EXPECT=<<EOF
+0
+1
+2
+EOF
+RUN
+
 NAME=pdc structured keeps the body of a loop whose header jumps to itself
 FILE=malloc://64
 ARGS=-a x86 -b 64 -e pdc.structured=1

--- a/test/db/cmd/cmd_pdc_ast
+++ b/test/db/cmd/cmd_pdc_ast
@@ -132,9 +132,31 @@ EXPECT=<<EOF
 seq 0x00000000
   bb 0x00000000
   do-while 0x00000010
-    if 0x00000004
-      goto 0x00000010
+    seq 0x00000004
+      if 0x00000004
+        continue 0x00000010
+      break 0x0000000c
   bb 0x0000000c
+EOF
+RUN
+
+NAME=pdct region ast owns a second loop exit target and jumps to it
+FILE=bins/elf/ls
+CMDS=<<EOF
+aaa
+pdct @ 0xd350
+EOF
+EXPECT=<<EOF
+seq 0x0000d350
+  if-else 0x0000d350
+    bb 0x0000d36b
+    seq 0x0000d360
+      while 0x0000d360
+        if-else 0x0000d370
+          continue 0x0000d360
+          goto 0x0000d379
+      goto 0x0000d36b
+  bb 0x0000d379
 EOF
 RUN
 
@@ -214,5 +236,48 @@ seq 0x00400f43
         bb 0x00400fa6
         goto 0x00400fbe
       goto 0x00400fad
+EOF
+RUN
+
+NAME=pdct region ast keeps both arms when a loop header branches inside the loop
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 85c0750583c001ebf783e80183f8057402ebedc3
+af
+pdct
+EOF
+EXPECT=<<EOF
+seq 0x00000000
+  do-while 0x00000000
+    if-else 0x00000000
+      seq 0x00000009
+        if 0x00000009
+          seq 0x00000011
+            bb 0x00000011
+            continue 0x00000000
+        break 0x00000013
+      bb 0x00000004
+  bb 0x00000013
+EOF
+RUN
+
+NAME=pdct region ast keeps the body of a loop whose header jumps to itself
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 85c074fc83c00183f80575f4c3
+af
+pdct
+EOF
+EXPECT=<<EOF
+seq 0x00000000
+  do-while 0x00000000
+    if 0x00000000
+      seq 0x00000004
+        if 0x00000004
+          continue 0x00000000
+        break 0x0000000c
+  bb 0x0000000c
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With `pdc.structured=1` the region builder bailed on any function containing a loop or a switch, so most real functions fell back to the linear renderer. Now WHILE/DOWHILE/SWITCH regions are built (natural loops via back edges, post-dominator joins) and rendered with `break`/`continue`/`case` instead of gotos; two-way blocks that head no region still force the linear pass, and `pdc.structured=0` output is unchanged. Gotos drop 28% on `bomb`, 39% on `ppc64v1-more`.