### PR TITLE
Forward register args through direct tail jumps and match them by register ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1563,10 +1563,14 @@ static void extract_dyncc_reguse(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, i
 	}
 }
 
-static bool op_is_call(RAnalOp *op) {
-	// Keep the full base opcode. A low-nibble check aliases MUL (0x14) with UCALL.
+// a direct jump out of the function is a tail call and forwards args like one
+static bool op_forwards_args(RAnalFunction *fcn, RAnalOp *op) {
+	// full opcode: a low-nibble check aliases MUL (0x14) with UCALL
 	const int type = op->type & 0xffff;
-	return type == R_ANAL_OP_TYPE_CALL || type == R_ANAL_OP_TYPE_UCALL;
+	if (type == R_ANAL_OP_TYPE_CALL || type == R_ANAL_OP_TYPE_UCALL) {
+		return true;
+	}
+	return type == R_ANAL_OP_TYPE_JMP && op->jump != UT64_MAX && !r_anal_function_contains (fcn, op->jump);
 }
 
 // arg count excluding the trailing "..." slot, which is no real caller arg register
@@ -1597,7 +1601,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		argc = func_fixed_args (TDB, fname);
 	}
 
-	if (op_is_call (op) && scan_args) {
+	if (scan_args && op_forwards_args (fcn, op)) {
 		int callee_rargs = 0;
 		char *callee = NULL;
 		ut64 offset = op->jump == UT64_MAX ? op->ptr : op->jump;

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1598,7 +1598,6 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 	}
 
 	if (op_is_call (op) && scan_args) {
-		RVecAnalVarPtr *callee_rargs_vec = NULL;
 		int callee_rargs = 0;
 		char *callee = NULL;
 		ut64 offset = op->jump == UT64_MAX ? op->ptr : op->jump;
@@ -1636,7 +1635,6 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			callee_rargs = callee_rargs
 				? callee_rargs
 				: r_anal_var_count (anal, f, R_ANAL_VAR_KIND_REG, 1);
-			callee_rargs_vec = r_anal_var_vec (anal, f, R_ANAL_VAR_KIND_REG);
 		}
 		int i;
 		const int total = callee_rargs;
@@ -1665,18 +1663,9 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			if (vname) {
 				reg_set[i] = 1;
 			} else {
-				RAnalVar *found_arg = NULL;
-				RAnalVar **it;
-				if (callee_rargs_vec) {
-					R_VEC_FOREACH (callee_rargs_vec, it) {
-						RAnalVar *arg = *it;
-						if (r_anal_var_get_argnum (arg) == i) {
-							found_arg = arg;
-							break;
-						}
-					}
-				}
-				if (found_arg) {
+				// argnum can be discovery order, so match the register
+				RAnalVar *found_arg = f? r_anal_function_get_var (f, R_ANAL_VAR_KIND_REG, delta): NULL;
+				if (found_arg && found_arg->isarg) {
 					type = strdup (found_arg->type);
 					vname = name = strdup (found_arg->name);
 				}
@@ -1696,7 +1685,6 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			free (type);
 		}
 		free (callee);
-		RVecAnalVarPtr_free (callee_rargs_vec);
 		free (fname);
 		return;
 	}

--- a/test/db/anal/mips
+++ b/test/db/anal/mips
@@ -589,7 +589,7 @@ EXPECT=<<EOF
 0x8060b570      000080a0   sb zero, (a0)
 0x8060b574      00000000   nop
 (fcn) fcn.8060b578 20
-// void fcn.8060b578 (int32_t arg2, int32_t arg1);
+// void fcn.8060b578 (int32_t arg1, int32_t arg2);
 `- args(a0, a1)
 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 0x8060b57c      542d180c   jal fcn.8060b550
@@ -725,7 +725,7 @@ EXPECT=<<EOF
 0x8060b570      000080a0   sb zero, (a0)
 0x8060b574      00000000   nop
 (fcn) fcn.8060b578 20
-// void fcn.8060b578 (int32_t arg2, int32_t arg1);
+// void fcn.8060b578 (int32_t arg1, int32_t arg2);
 `- args(a0, a1)
 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 0x8060b57c      542d180c   jal fcn.8060b550
@@ -797,7 +797,7 @@ EXPECT=<<EOF
 \ 0x8060b570      000080a0   sb zero, (a0)
   0x8060b574      00000000   nop
 / (fcn) fcn.8060b578 20
-// void fcn.8060b578 (int32_t arg2, int32_t arg1);
+// void fcn.8060b578 (int32_t arg1, int32_t arg2);
 | `- args(a0, a1)
 | 0x8060b578      e0ffbd27   addiu sp, sp, -0x20
 | 0x8060b57c      542d180c   jal fcn.8060b550

--- a/test/db/anal/plt-local
+++ b/test/db/anal/plt-local
@@ -199,6 +199,20 @@ void sym.crc32_z (int64_t arg1, int64_t arg2, int64_t arg3);
 EOF2
 RUN
 
+NAME=ppc64 ELFv1 forwarded args keep the register of the callee arg they inherit
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF2
+aa
+afva @ sym.crc32
+afvr @ sym.crc32
+EOF2
+EXPECT=<<EOF2
+arg int64_t arg1 @ r3
+arg int64_t arg2 @ r4
+arg int64_t arg3 @ r5
+EOF2
+RUN
+
 NAME=ppc64 ELFv1 stub args survive a non default base address
 FILE=bins/elf/ppc64v1-libz.so
 ARGS=-B 0x400000

--- a/test/db/anal/plt-local
+++ b/test/db/anal/plt-local
@@ -213,6 +213,30 @@ arg int64_t arg3 @ r5
 EOF2
 RUN
 
+NAME=x86_64 tail jump through a local plt stub inherits the target args
+FILE=bins/elf/pltrel/add2.so
+CMDS=<<EOF
+aa
+afvr @ sym.add
+EOF
+EXPECT=<<EOF
+arg int64_t arg1 @ rdi
+EOF
+RUN
+
+NAME=ppc64 ELFv1 import stub takes the prototype of the import it branches to
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF2
+aa
+afvr @ sym.plt.memcpy
+EOF2
+EXPECT=<<EOF2
+arg void * s1 @ r3
+arg const void * s2 @ r4
+arg size_t n @ r5
+EOF2
+RUN
+
 NAME=ppc64 ELFv1 stub args survive a non default base address
 FILE=bins/elf/ppc64v1-libz.so
 ARGS=-B 0x400000

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -697,3 +697,35 @@ EXPECT=<<EOF
 'afvs 66 var_32h int16_t
 EOF
 RUN
+
+NAME=a direct tail jump forwards the callee args to the function it leaves
+FILE=bins/elf/ppc64v1-libz.so
+CMDS=<<EOF
+aa
+afs @ sym.gzopen
+afvr @ sym.gzwrite
+EOF
+EXPECT=<<EOF
+void sym.gzopen (int64_t arg1, int64_t arg2);
+arg int64_t arg1 @ r3
+arg int64_t arg3 @ r5
+arg int64_t arg2 @ r4
+EOF
+RUN
+
+NAME=x86_64 conditional and unconditional tail jumps forward args, own writes do not
+FILE=bins/elf/pltrel/x86_64-thunks.so
+CMDS=<<EOF
+aa
+afvr @ sym.forkwrap
+afvr @ sym.top_fork
+afs @ sym.setwrap
+afs @ sym.top_set
+EOF
+EXPECT=<<EOF
+arg int64_t arg1 @ rdi
+arg int64_t arg1 @ rdi
+void sym.setwrap ();
+void sym.top_set ();
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Two fixes in the callee-forwarding path of r_anal_extract_rarg (the one that gives a caller the args of a callee whose argument registers it never writes, extended by #26457 with the sym.plt.X -> sym.X join):

* Match the callee's arg by register, not by argnum. argnum is discovery order until assign_reg_argnums densifies it, so a callee that reads r5 before r3 handed its names out crosswise: `aa; afva @ sym.crc32` on ppc64v1-libz.so gave `arg2 @ r3, arg3 @ r4, arg1 @ r5`. Uses r_anal_function_get_var by delta and drops the vector walk. Three db/anal/mips goldens pinned the permutation and move with it.
* A direct jump leaving the function is a tail call and forwards the argument registers exactly like a call, so treat it as one (base type JMP, conditional included since clang emits `je sym.plt.X` sibcalls, with a resolved op->jump outside the function). Everything after is the unchanged call path. pltrel/add2.so `sym.add` (endbr64; jmp sym.plt.add2) now gets add2's arg, libz gzopen 1->2 / gzwrite 2->3, ELFv1 import stubs take their libc prototypes through their `b sym.imp.X` tail.

Per-function `afvr` A/B against master: 0 losses on bash, vim, libc-2.27, libz, dropbear-ppc32, libstdc++, ls, boa-mips (aa and aaa); gains under aaa bash 21, vim 71, libc 96, libz 18, dropbear 69, libstdc++ 16, hand-checked bash 20/21 and vim 41/43 correct against source (the rest are the pre-existing unknown-variadic-callee over-approximation reached over one more edge). Five new tests in db/anal/plt-local and db/anal/vars, each failing on master.