### PR TITLE
Fix dSYM loading when binary is opened through symlink

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -1007,15 +1007,29 @@ beach:
 		}
 		if (r_config_get_b (r->config, "bin.dbginfo") && R_STR_ISNOTEMPTY (dbginfo_uri)) {
 			// TODO only for macho
-			// load companion dwarf files
+			// load the companion dwarf from the sidecar dSYM bundle, which
+			// sits next to the binary and is named after it:
+			// <path>.dSYM/Contents/Resources/DWARF/<basename>
 			const char *basename = r_file_basename (dbginfo_uri);
 			char *macdwarf = r_str_newf ("%s.dSYM/Contents/Resources/DWARF/%s", dbginfo_uri, basename);
+			if (!r_file_exists (macdwarf)) {
+				// when the binary is opened through a symlink the bundle lives
+				// next to the link target and takes its basename, so retry with
+				// the resolved path (r_file_abspath uses realpath on unix)
+				char *target = r_file_abspath (dbginfo_uri);
+				if (target) {
+					free (macdwarf);
+					macdwarf = r_str_newf ("%s.dSYM/Contents/Resources/DWARF/%s", target, r_file_basename (target));
+					free (target);
+				}
+			}
 			if (r_file_exists (macdwarf)) {
 				// Skip symbols for dSYM since they duplicate main binary
 				bool old_skipsyms = r->bin->options.skip_symbols;
 				r->bin->options.skip_symbols = true;
 				r_core_callf (r, "o %s", macdwarf);
 				r->bin->options.skip_symbols = old_skipsyms;
+				// merge the dwarf binfile into the main one and drop it
 				r_core_call (r, "obm-");
 			}
 			free (macdwarf);

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -188,6 +188,17 @@ addr: 0x100003f90
 EOF
 RUN
 
+NAME="open companion dSYM file through a symlink"
+FILE=bins/mach0/dwarf/a.out
+ARGS=-e bin.dbginfo=false
+CMDS=<<EOF
+!sh -c 'tmp=$(mktemp -d "${TMPDIR:-/tmp}/r2r-dsym.XXXXXX") || exit 1; mkdir -p "$tmp/a.out.dSYM/Contents/Resources/DWARF" && cp "${R2_FILE}" "$tmp/a.out" && cp "${R2_FILE}.dSYM/Contents/Resources/DWARF/a.out" "$tmp/a.out.dSYM/Contents/Resources/DWARF/a.out" && ln -s "$tmp/a.out" "$tmp/alias" && radare2 -Nq -e bin.dbginfo=true -c "CL~file:~?" "$tmp/alias"; rm -rf "$tmp"'
+EOF
+EXPECT=<<EOF
+7
+EOF
+RUN
+
 NAME="pdf dwarf invalid main for analysis not found (aa)"
 FILE=bins/src/dwarftest
 CMDS=<<EOF


### PR DESCRIPTION
## Description

This PR fixes an issue where radare2 fails to load companion dSYM debug files when the binary is opened through a symlink. The dSYM bundle is located next to the actual binary file (the symlink target), not next to the symlink itself.

### Changes

- **Enhanced dSYM path resolution**: When the initial dSYM path doesn't exist, the code now resolves the symlink to its target using `r_file_abspath()` and retries with the resolved path
- **Improved comments**: Added clarification about the dSYM bundle structure and the symlink resolution logic
- **Added test case**: New test verifies that dSYM files are correctly loaded when the binary is accessed through a symlink

### Technical Details

The fix handles the common macOS development scenario where:
1. A binary is accessed via a symlink (e.g., `alias` → `/tmp/a.out`)
2. The dSYM bundle exists next to the actual binary (`/tmp/a.out.dSYM/...`)
3. The bundle is named after the actual binary, not the symlink

The code now attempts to load from the symlink path first, and if that fails, resolves the symlink and tries again with the target's basename.

- [x] I've added tests
- [ ] I wrote some lines in the book (not applicable)

https://claude.ai/code/session_01Mbp2ZbZCnX2s8yavSYNcXs