### PR TITLE
Zero-extend 32-bit register writes on x86-64 ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -114,6 +114,9 @@ struct Getarg {
 	cs_insn *insn;
 	int bits;
 	int syntax; // R_ARCH_SYNTAX_ATT or R_ARCH_SYNTAX_INTEL
+	// bare 32-bit register destination in 64-bit mode, and its 64-bit name
+	char zext32[16];
+	char zext64[16];
 };
 
 // TODO: get rid of this unnecessary wrapper
@@ -302,6 +305,20 @@ static char *shift_count(const char *src, ut32 bitsize) {
 	return r_str_newf ("%s,0x%x,&", src, (bitsize > 32)? 0x3f: 0x1f);
 }
 
+static inline bool get64from32(const char *s, char *out, size_t outsz) {
+	if (*s == 'e') {
+		snprintf (out, outsz, "r%s", s + 1);
+		return true;
+	}
+	if (*s == 'r' && isdigit (s[1])) {
+		if (s[2] == 'd' || (s[2] != 0 && isdigit(s[2]) && s[3] == 'd')) {
+			snprintf (out, outsz, "r%d", atoi (s + 1));
+			return true;
+		}
+	}
+	return false;
+}
+
 static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsize) {
 	const char *setarg = r_str_get (setop);
 	cs_insn *insn = gop->insn;
@@ -341,6 +358,11 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsi
 					rn = stbuf;
 				}
 				if (set == 1) {
+					// writing eax zero-extends into rax, which ESIL wont do on its own
+					if (gop->bits == 64
+						&& get64from32 (rn, gop->zext64, sizeof (gop->zext64))) {
+						r_str_ncpy (gop->zext32, rn, sizeof (gop->zext32));
+					}
 					return r_str_newf ("%s,%s=", rn, setarg);
 				}
 				return strdup (rn);
@@ -454,20 +476,6 @@ static const char *reg32_to_name(ut8 reg) {
 }
 #endif
 
-static inline bool get64from32(const char *s, char *out, size_t outsz) {
-	if (*s == 'e') {
-		snprintf (out, outsz, "r%s", s + 1);
-		return true;
-	}
-	if (*s == 'r' && isdigit (s[1])) {
-		if (s[2] == 'd' || (s[2] != 0 && isdigit(s[2]) && s[3] == 'd')) {
-			snprintf (out, outsz, "r%d", atoi (s + 1));
-			return true;
-		}
-	}
-	return false;
-}
-
 static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh handle, cs_insn *insn) {
 	RAnalValue *val = NULL;
 	const int bits = as->config->bits;
@@ -498,7 +506,9 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		.handle = handle,
 		.insn = insn,
 		.bits = bits,
-		.syntax = as->config->syntax
+		.syntax = as->config->syntax,
+		.zext32 = {0},
+		.zext64 = {0}
 	};
 	char *src = NULL;
 	char *src2 = NULL;
@@ -2735,6 +2745,10 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		r_strbuf_prepend (&op->esil, ",!,?{,BREAK,},");
 		r_strbuf_prepend (&op->esil, counter);
 		r_strbuf_appendf (&op->esil, ",%s,--=,zf,?{,BREAK,},0,GOTO", counter);
+	}
+	if (*gop.zext64 && r_strbuf_length (&op->esil) > 0) {
+		// after the flag assignments, so this doesnt disturb the comparison state
+		r_strbuf_appendf (&op->esil, ",%s,%s,=", gop.zext32, gop.zext64);
 	}
 }
 

--- a/test/db/cmd/cmd_pdr
+++ b/test/db/cmd/cmd_pdr
@@ -222,7 +222,7 @@ EXPECT=<<EOF
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,
@@ -413,7 +413,7 @@ jmp 3
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,

--- a/test/db/cmd/midbb
+++ b/test/db/cmd/midbb
@@ -176,7 +176,7 @@ EXPECT=<<EOF
   {
     "addr": 9,
     "val": 253,
-    "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+    "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
     "refptr": 0,
     "fcn_addr": 0,
     "fcn_last": 16,
@@ -457,7 +457,7 @@ EXPECT=<<EOF
     {
       "addr": 9,
       "val": 253,
-      "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+      "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
       "refptr": 0,
       "fcn_addr": 0,
       "fcn_last": 16,

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -548,9 +548,9 @@ EXPECT=<<EOF
 0x00000001
 0x300020100
 0x00000001
-0x3fffdff00
+0xfffdff00
 0x00000001
-0xfffffffc00020100
+0xffffffff00020100
 0x00000001
 EOF
 RUN
@@ -678,5 +678,27 @@ ar eax
 EOF
 EXPECT=<<EOF
 0xffffffff
+EOF
+RUN
+
+NAME=32-bit register write zero-extends
+FILE=malloc://0x100
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+aei
+aeim
+wx 01c1
+ar rcx=0xffffffff00000001
+ar rax=1
+aes
+ar rcx
+ar cf
+ar of
+EOF
+EXPECT=<<EOF
+0x00000002
+0x00000000
+0x00000000
 EOF
 RUN


### PR DESCRIPTION
Writing a 32-bit register on x86-64 clears the top half of the 64-bit one. ESIL does not do that on its own: naming `eax` stores four bytes and leaves the rest of `rax` as it was.

MOV, XOR and AND already spell their destination out and mask for this — `get64from32` exists for exactly that. Everything reaching the generic register-destination path in `getarg` did not:

```
wx 01c1           ; add ecx, eax
ar rcx=0xffffffff00000001
ar rax=1
aes; ar rcx
before  0xffffffff00000002
after   0x2
```

The same held for `sub`, `adc`, `sbb`, `inc`, `dec`, `neg`, `not` and the shifts.

### Approach

`getarg` now records when it rendered a bare 32-bit register destination in 64-bit mode, and the caller appends the zero-extension once the flag assignments are done — masking updates the comparison state that `$c`, `$o` and `$z` read from, so it cannot go first.

The extension is written as an assignment through the 64-bit name (`ecx,rcx,=`) rather than a mask of it (`0xffffffff,rcx,&=`), so `aea` still reports only the registers the instruction really reads. The masking form made `aea 5` list `rax` and `rdx` as read.

### Tests

Two existing expectations encoded the old behaviour and are updated:

- `db/esil/x86_64` `neg` expected `rbx` to keep its high half after `neg ebx`.
- Two golden ESIL strings in `db/cmd/midbb` and `db/cmd/cmd_pdr` needed the new suffix.

`db/esil`, `db/anal` and `db/cmd`: **5071 OK, 99 BR, 0 XX, 14 SK, 5 FX**, against 5070 OK / 0 XX before the change. The extra pass is the added test, checked in both directions.

Verified by emulation against the ISA on `add`, `sub`, `dec`, `and`, `or`, `neg`, `not` and `shl`.

Found with a differential harness that runs each instruction through the ESIL VM twice, once per lifter, and compares the machine state afterwards.