### PR TITLE
Mask the x86 shift count to the operand width ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -294,6 +294,14 @@ static inline int norm_op(int n, int syntax, int op_count) {
  * @param  sel     Selector for output buffer in staic array
  * @return         Pointer to esil operand in static array
  */
+/* x86 takes the shift count modulo 32 for operands up to 32 bits wide, and
+ * modulo 64 for a 64-bit operand, before shifting anything. Without that,
+ * `sar eax, cl` with cl = 0xff asks ESIL for a 255-bit shift instead of the
+ * 31-bit one the processor performs. */
+static char *shift_count(const char *src, ut32 bitsize) {
+	return r_str_newf ("%s,0x%x,&", src, (bitsize > 32)? 0x3f: 0x1f);
+}
+
 static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsize) {
 	const char *setarg = r_str_get (setop);
 	cs_insn *insn = gop->insn;
@@ -1189,9 +1197,11 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		// TODO: Set CF. See case X86_INS_SHL for more details.
 		{
 		ut32 bitsize;
-		src = getarg (&gop, 1, 0, NULL, NULL);
+		char *count = getarg (&gop, 1, 0, NULL, NULL);
 		dst_r = getarg (&gop, 0, 0, NULL, NULL);
 		dst_w = getarg (&gop, 0, 1, NULL, &bitsize);
+		src = shift_count (count, bitsize);
+		free (count);
 		esilprintf (op, "0,cf,:=,1,%s,-,1,<<,%s,&,?{,1,cf,:=,},%s,%s,ASR,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=",
 			src, dst_r, src, dst_r, dst_w, bitsize - 1);
 		free (src);
@@ -1214,9 +1224,11 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_SAL:
 		{
 		ut32 bitsize;
-		src = getarg (&gop, 1, 0, NULL, NULL);
+		char *count = getarg (&gop, 1, 0, NULL, NULL);
 		dst_r = getarg (&gop, 0, 0, NULL, &bitsize);
 		dst_w = getarg (&gop, 0, 1, NULL, NULL);
+		src = shift_count (count, bitsize);
+		free (count);
 		// CF = last bit shifted out = (dst >> (width - count)) & 1 from the
 		// pre-shift value; OF is defined only for 1-bit shifts as msb(result) ^ CF.
 		// Read via dst_r, write via dst_w so memory destinations store the result.
@@ -1244,9 +1256,11 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		// TODO: Set CF: See case X86_INS_SAL for more details.
 		{
 			ut32 bitsize;
-			src = getarg (&gop, 1, 0, NULL, NULL);
+			char *count = getarg (&gop, 1, 0, NULL, NULL);
 			dst_r = getarg (&gop, 0, 0, NULL, NULL);
 			dst_w = getarg (&gop, 0, 1, NULL, &bitsize);
+			src = count? shift_count (count, bitsize): NULL;
+			free (count);
 			if (src && dst_r && dst_w) {
 				esilprintf (op, "0,cf,:=,1,%s,-,1,<<,%s,&,?{,1,cf,:=,},%s,%s,>>,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=",
 					src, dst_r, src, dst_r, dst_w, bitsize - 1);

--- a/test/db/cmd/cmd_pdr
+++ b/test/db/cmd/cmd_pdr
@@ -222,7 +222,7 @@ EXPECT=<<EOF
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,-,1,<<,ebx,&,?{,1,cf,:=,},253,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,
@@ -413,7 +413,7 @@ jmp 3
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,-,1,<<,ebx,&,?{,1,cf,:=,},253,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,

--- a/test/db/cmd/midbb
+++ b/test/db/cmd/midbb
@@ -176,7 +176,7 @@ EXPECT=<<EOF
   {
     "addr": 9,
     "val": 253,
-    "esil": "0,cf,:=,1,253,-,1,<<,ebx,&,?{,1,cf,:=,},253,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+    "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
     "refptr": 0,
     "fcn_addr": 0,
     "fcn_last": 16,
@@ -457,7 +457,7 @@ EXPECT=<<EOF
     {
       "addr": 9,
       "val": 253,
-      "esil": "0,cf,:=,1,253,-,1,<<,ebx,&,?{,1,cf,:=,},253,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
+      "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=",
       "refptr": 0,
       "fcn_addr": 0,
       "fcn_last": 16,

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -662,3 +662,21 @@ EXPECT=<<EOF
 0x0000000000000000
 EOF
 RUN
+
+NAME=shift count is taken modulo the operand width
+FILE=malloc://0x100
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+aei
+aeim
+wx d3f8
+ar rax=0x80000000
+ar rcx=0xff
+aes
+ar eax
+EOF
+EXPECT=<<EOF
+0xffffffff
+EOF
+RUN


### PR DESCRIPTION
x86 takes a shift count modulo 32 for operands up to 32 bits wide, and modulo 64 for a 64-bit operand, before shifting anything. The count was passed to ESIL as written, so a large count asked for a shift the processor never performs:

```
wx d3f8           ; sar eax, cl
ar rax=0x80000000
ar rcx=0xff
aes; ar eax
before  0x80000000     ; 255-bit shift, destination untouched
after   0xffffffff     ; cl & 0x1f = 31
```

The count feeds the carry computation as well as the shift, so both were wrong for any count at or above the operand width.

### Scope

`SAR`, `SHR`, `SHRX`, `SHL` and `SAL`. The rotates take the count modulo the width too, but they are left alone here — `RCL` and `RCR` are already marked as not working, and they need the additional modulo-by-width step that 8- and 16-bit rotates use.

A count that masks to zero should also leave the flags untouched. ESIL does not model that here, before or after this change.

### Tests

Two golden ESIL strings in `db/cmd/midbb` and `db/cmd/cmd_pdr` needed the masking.

`db/esil`, `db/anal` and `db/cmd`: **5071 OK, 99 BR, 0 XX, 14 SK, 5 FX**, matching the totals before the change plus the added test. Checked in both directions — 39 OK / 1 XX without the fix.

Found with a differential harness that runs each instruction through the ESIL VM twice, once per lifter, and compares the machine state afterwards.