### PR TITLE
Zero-extend 32-bit register writes on arm64 ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1414,6 +1414,32 @@ static void arm64fpmath(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf
 	}
 }
 
+/* A write to a 32-bit `w` register zero-extends into the whole 64-bit `x` one.
+ * ESIL does not do that on its own: naming `w9` stores four bytes and leaves the
+ * top half of `x9` as it was, so `add w9, w9, w10` kept whatever `x9` used to
+ * hold above bit 31. Appended once here rather than at each of the dozens of
+ * sites that spell a destination, and after the flag assignments so that the
+ * extension cannot disturb the comparison state they read. */
+static void arm64_esil_zero_extend_dst(RAnalOp *op, csh *handle, cs_insn *insn) {
+	if (!insn->detail || insn->detail->arm64.op_count < 1) {
+		return;
+	}
+	const cs_arm64_op *dst = &insn->detail->arm64.operands[0];
+	if (dst->type != ARM64_OP_REG || !(dst->access & CS_AC_WRITE)) {
+		return;
+	}
+	const char *wide = cs_reg_name (*handle, dst->reg);
+	if (!wide || *wide != 'w' || !isdigit ((ut8)wide[1])) {
+		return;
+	}
+	if (r_strbuf_length (&op->esil) < 1) {
+		return;
+	}
+	/* Storing through the 64-bit name clears the top half without reading it,
+	 * so the register-access analysis still reports only what is really read. */
+	r_strbuf_appendf (&op->esil, ",%s,x%s,=", wide, wide + 1);
+}
+
 static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
 	r_strbuf_init (&op->esil);
 	r_strbuf_set (&op->esil, "");
@@ -2594,6 +2620,7 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	}
 
 	r_strbuf_append (&op->esil, postfix);
+	arm64_esil_zero_extend_dst (op, handle, insn);
 
 	return 0;
 }

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -358,9 +358,9 @@ pd 10
 EOF
 EXPECT=<<EOF
 ;-- pc:
-0x1000040c0      mov w0, 0
-0x1000040c4      mov w1, 2
-0x1000040c8      mov w2, 1
+0x1000040c0      mov w0, 0                                             ; CCOperation op
+0x1000040c4      mov w1, 2                                             ; CCAlgorithm alg
+0x1000040c8      mov w2, 1                                             ; int32_t options
 0x1000040cc      mov x3, x23
 0x1000040d0      mov w4, 0x18
 0x1000040d4      mov x5, 0

--- a/test/db/anal/types
+++ b/test/db/anal/types
@@ -26,7 +26,7 @@ var int64_t var_10h @ sp+0x10
 |           0x100003f78      08b13e91       add x8, x8, 0xfac
 |           0x100003f7c      e80700f9       str x8, [ptr]
 |           0x100003f80      e10740f9       ldr x1, [ptr]              ; const char *ptr
-|           0x100003f84      20008052       mov w0, 1
+|           0x100003f84      20008052       mov w0, 1                  ; int fd
 |           0x100003f88      420180d2       mov x2, 0xa                ; size_t nbytes
 |           0x100003f8c      05000094       bl sym.imp.write           ; ssize_t write(int fd, const char *ptr, size_t nbytes)
 |           0x100003f90      00008052       mov w0, 0

--- a/test/db/cmd/charset
+++ b/test/db/cmd/charset
@@ -246,9 +246,9 @@ s 0x000017f4
 pdui ret
 EOF
 EXPECT=<<EOF
-0x000017f4      add x0, sp, 0x28                  ; int64_t arg1
+0x000017f4      add x0, sp, 0x28
 0x000017f8      mov x1, x0                        ; char *arg2
-0x000017fc      ldr w0, [var_clob_8ch]
+0x000017fc      ldr w0, [var_clob_8ch]            ; int64_t arg1
 0x00001800      bl sym.getXa_int__char_const_     ; getXa(int, char const*) ; sym.getXa_int__char_const_(0x0, 0x178028)
 0x00001804      str x0, [var_clob_80h]
 0x00001808      ldr x1, [var_clob_80h]
@@ -268,7 +268,7 @@ EXPECT=<<EOF
 0x00001838      add x0, x0, 0xa08                 ; 0x1a08 ; "\n步数地址=%lx\n" ; const char *format ; str._n_lx_n
 0x0000183c      bl sym.imp.printf                 ; int printf(const char *format, ...)
                                                   ; int printf("步数地址=%lx", 0)
-0x00001840      mov w1, 0x63                      ; 'c'
+0x00001840      mov w1, 0x63                      ; 'c' ; int64_t arg2
 0x00001844      ldr x0, [var_clob_78h]            ; int64_t arg1
 0x00001848      bl sym.WriteAddress_DWORD_long__int_ ; WriteAddress_DWORD(long, int) ; sym.WriteAddress_DWORD_long__int_(0x0, 0x63)
 0x0000184c      adrp x0, 0x1000
@@ -294,9 +294,9 @@ s 0x000017f4
 pdui ret
 EOF
 EXPECT=<<EOF
-0x000017f4      add x0, sp, 0x28                  ; int64_t arg1
+0x000017f4      add x0, sp, 0x28
 0x000017f8      mov x1, x0                        ; char *arg2
-0x000017fc      ldr w0, [var_clob_8ch]
+0x000017fc      ldr w0, [var_clob_8ch]            ; int64_t arg1
 0x00001800      bl sym.getXa_int__char_const_     ; getXa(int, char const*) ; sym.getXa_int__char_const_(0x0, 0x178028)
 0x00001804      str x0, [var_clob_80h]
 0x00001808      ldr x1, [var_clob_80h]
@@ -316,7 +316,7 @@ EXPECT=<<EOF
 0x00001838      add x0, x0, 0xa08                 ; 0x1a08 ; "\n步数地址=%lx\n" ; const char *format ; str._n_lx_n
 0x0000183c      bl sym.imp.printf                 ; int printf(const char *format, ...)
                                                   ; int printf("\n\xe6\xad\xa5\xe6\x95\xb0\xe5\x9c\xb0\xe5\x9d\x80=%lx\n", 0)
-0x00001840      mov w1, 0x63                      ; 'c'
+0x00001840      mov w1, 0x63                      ; 'c' ; int64_t arg2
 0x00001844      ldr x0, [var_clob_78h]            ; int64_t arg1
 0x00001848      bl sym.WriteAddress_DWORD_long__int_ ; WriteAddress_DWORD(long, int) ; sym.WriteAddress_DWORD_long__int_(0x0, 0x63)
 0x0000184c      adrp x0, 0x1000


### PR DESCRIPTION
A write to a `w` register clears the top half of the `x` register it sits in. ESIL does not do that on its own: naming `w9` stores four bytes and leaves the rest of `x9` as it was.

```
ar x9=0xffffffff00000001
ar x10=1
wx 29010a0b       ; add w9, w9, w10
aes; ar x9
before  0xffffffff00000002
after   0x2
```

The same held for every `w` destination — the arithmetic helpers, the loads, the moves.

### Approach

Appended once where the instruction's ESIL is finished, rather than at each of the dozens of sites that spell a destination, and after the flag assignments so the extension cannot disturb the comparison state they read.

Written as a store through the 64-bit name (`w9,x9,=`) rather than a mask of it (`0xffffffff,x9,&=`), so `aea` still reports only the registers the instruction really reads.

This is the arm64 counterpart of e3d433fb8e, which did the same for x86-64.

### Tests

Two expectations move because emulation now tracks these values correctly and type propagation reaches further:

- `db/anal/types` — `mov w0, 1` picks up `; int fd`
- `db/anal/jmptbl` — the three CCCrypt argument registers pick up their parameter types, which is what "ccccrypt argument values from esil" is named for

`db/esil`, `db/anal`, `db/asm/arm_64`: **2810 OK, 64 BR, 0 XX, 10 SK, 1 FX**, no regressions.

Found with a differential harness that runs each instruction through the ESIL VM twice, once per lifter, and compares machine state afterwards. With this applied, agreement on an arm64 corpus goes from 94.3% to 100%.