### PR TITLE
Zero-extend every W register the arm64 ESIL writes ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1414,30 +1414,54 @@ static void arm64fpmath(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf
 	}
 }
 
-/* A write to a 32-bit `w` register zero-extends into the whole 64-bit `x` one.
- * ESIL does not do that on its own: naming `w9` stores four bytes and leaves the
- * top half of `x9` as it was, so `add w9, w9, w10` kept whatever `x9` used to
- * hold above bit 31. Appended once here rather than at each of the dozens of
- * sites that spell a destination, and after the flag assignments so that the
- * extension cannot disturb the comparison state they read. */
-static void arm64_esil_zero_extend_dst(RAnalOp *op, csh *handle, cs_insn *insn) {
-	if (!insn->detail || insn->detail->arm64.op_count < 1) {
+// w0..w30 -> 0..30, wsp -> 31, anything else -> -1
+static int arm64_wreg_bit(const char *tok, size_t len) {
+	if (len == 3 && !memcmp (tok, "wsp", 3)) {
+		return 31;
+	}
+	if (len < 2 || len > 3 || tok[0] != 'w' || !isdigit ((ut8)tok[1])) {
+		return -1;
+	}
+	if (len == 3 && !isdigit ((ut8)tok[2])) {
+		return -1;
+	}
+	int n = atoi (tok + 1);
+	return n <= 30? n: -1;
+}
+
+// W writes zero-extend into X; the profile maps wN onto xN's low half only
+static void arm64_esil_zext_wregs(RAnalOp *op) {
+	const char *tok = r_strbuf_get (&op->esil);
+	if (R_STR_ISEMPTY (tok)) {
 		return;
 	}
-	const cs_arm64_op *dst = &insn->detail->arm64.operands[0];
-	if (dst->type != ARM64_OP_REG || !(dst->access & CS_AC_WRITE)) {
-		return;
+	ut32 regs = 0;
+	const char *prev = NULL;
+	size_t prevlen = 0;
+	while (tok) {
+		const char *end = strchr (tok, ',');
+		size_t len = end? (size_t)(end - tok): strlen (tok);
+		// '=' assigns; "==" "<=" ">=" compare and "=[N]" stores
+		bool assign = len > 0 && tok[len - 1] == '='
+			&& !(len == 2 && strchr ("=<>", tok[0]))
+			&& !memchr (tok, '[', len);
+		int bit = assign && prev? arm64_wreg_bit (prev, prevlen): -1;
+		if (bit >= 0) {
+			regs |= 1u << bit;
+		}
+		prev = tok;
+		prevlen = len;
+		tok = end? end + 1: NULL;
 	}
-	const char *wide = cs_reg_name (*handle, dst->reg);
-	if (!wide || *wide != 'w' || !isdigit ((ut8)wide[1])) {
-		return;
+	int n;
+	for (n = 0; n < 31; n++) {
+		if (regs & (1u << n)) {
+			r_strbuf_appendf (&op->esil, ",w%d,x%d,=", n, n);
+		}
 	}
-	if (r_strbuf_length (&op->esil) < 1) {
-		return;
+	if (regs & (1u << 31)) {
+		r_strbuf_append (&op->esil, ",wsp,sp,=");
 	}
-	/* Storing through the 64-bit name clears the top half without reading it,
-	 * so the register-access analysis still reports only what is really read. */
-	r_strbuf_appendf (&op->esil, ",%s,x%s,=", wide, wide + 1);
 }
 
 static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len, csh *handle, cs_insn *insn) {
@@ -2619,8 +2643,8 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		break;
 	}
 
+	arm64_esil_zext_wregs (op);
 	r_strbuf_append (&op->esil, postfix);
-	arm64_esil_zero_extend_dst (op, handle, insn);
 
 	return 0;
 }

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1693,3 +1693,128 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=w-register writes zero-extend into the x register
+FILE=malloc://0x200
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 2000020b
+ar x0=0xffffffff00000000
+ar x1=1
+ar x2=2
+aes
+ar x0
+wx 8046a272
+ar x0=0xa5a5000089abcdef
+ar pc=0
+aes
+ar x0
+wx 2000821a
+ar x0=0xa5a5000000000000
+ar x1=0xffffffff80000005
+ar x2=0x0000000100000003
+ar zf=1
+ar pc=0
+aes
+ar x0
+wx 60044029
+ar x0=0xa5a5000000000000
+ar x1=0xa5a5000100000000
+ar x3=0x100
+wx 88776655a5a5a5a5@0x100
+ar pc=0
+aes
+ar x0
+ar x1
+wx ff430011
+ar sp=0xffffffff00001000
+ar pc=0
+aes
+ar sp
+EOF
+EXPECT=<<EOF
+0x00000003
+0x1234cdef
+0x80000005
+0x55667788
+0xa5a5a5a5
+0x00001010
+EOF
+RUN
+
+NAME=ldrsb w sign-extends to 32 bits then zero-extends, sxtw x untouched
+FILE=malloc://0x200
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 2000c039
+ar x0=0xa5a5000000000000
+ar x1=0x100
+wx 88@0x100
+aes
+ar x0
+wx 207c4093
+ar x1=0xa5a50001ff887766
+ar pc=0
+aes
+ar x0
+EOF
+EXPECT=<<EOF
+0xffffff88
+0xffffffffff887766
+EOF
+RUN
+
+NAME=cmp cmn tst on w registers do not touch the source x register
+FILE=malloc://0x200
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 3f00026b
+ar x1=0xa5a5000180000000
+ar x2=0xa5a5000200000001
+aes
+ar x1
+ar nf
+wx 3f00022b
+ar pc=0
+aes
+ar x1
+wx 3f00026a
+ar pc=0
+aes
+ar x1
+wx 3f000071
+ar pc=0
+aes
+ar x1
+aoe @ 0
+EOF
+EXPECT=<<EOF
+0xa5a5000180000000
+0x00000000
+0xa5a5000180000000
+0xa5a5000180000000
+0xa5a5000180000000
+0x0 0x0,w1,==,$z,zf,:=,31,$s,nf,:=,32,$b,!,cf,:=,31,0x0,w1,^,0x0,w1,-,w1,^,&,>>,vf,:=
+EOF
+RUN
+
+NAME=zero-extension is appended after the flag block and only for written w registers
+FILE=malloc://0x200
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 2000022b
+aoe
+wx 200080b9
+aoe
+wx 41000088
+aoe
+EOF
+EXPECT=<<EOF
+0x0 w2,-1,*,w1,==,$z,zf,:=,31,$s,nf,:=,31,$c,cf,:=,31,$o,vf,:=,w2,w1,+,w0,=,w0,x0,=
+0x0 32,0,x1,+,DUP,tmp,=,[4],~,x0,=
+0x0 0,w0,=,w1,w1,0,+,=[8],w0,x0,=
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

#26498 appends wN,xN,= when capstone marks operand 0 as written. Capstone marks the first source of cmp/cmn/tst (and cmp wN, #imm) as written, so cmp w1, w2 now clears bits 63:32 of x1; ldp w0, w1 only extends w0 and wsp is skipped.

This keys the extension on the ESIL itself instead: scan the emitted string for W-register assignments and append wN,xN,= (or wsp,sp,=) for each one, before the condition postfix. Every W write zero-extends on AArch64, so this is exact by construction and needs no operand metadata.

Tests: 4 new db/esil/arm_64 cases (add/movk/csel/ldp/wsp, ldrsb-w vs sxtw-x, cmp/cmn/tst leave the source untouched, aoe shape); two of them fail on master.