### PR TITLE
Measure typedefs in r_type_get_bitsize ##types

### DIFF
--- a/libr/include/r_util/r_type.h
+++ b/libr/include/r_util/r_type.h
@@ -40,6 +40,7 @@ R_API int r_type_unlink(Sdb *TDB, ut64 addr);
 R_API int r_type_link_offset(Sdb *TDB, const char *val, ut64 addr);
 R_API char *r_type_format(Sdb *TDB, const char *t);
 R_API bool r_type_is_signed(Sdb * R_NONNULL TDB, const char * R_NONNULL type);
+R_API R_OWNED char *r_type_resolve_typedef(Sdb * R_NONNULL TDB, const char * R_NONNULL type);
 
 // Function prototypes api
 R_API int r_type_func_exist(Sdb *TDB, const char *func_name);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -213,7 +213,8 @@ static bool type_has_any_word(const char *R_NONNULL type, const char *const *R_N
 #define TYPEDEF_MAX_DEPTH 8
 
 // the depth bound keeps a cyclic typedef from hanging
-static R_OWNED char *type_resolve_typedef(Sdb *TDB, const char *R_NONNULL type) {
+R_API R_OWNED char *r_type_resolve_typedef(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
+	R_RETURN_VAL_IF_FAIL (TDB && type, NULL);
 	char *ret = NULL;
 	int depth;
 	for (depth = 0; depth < TYPEDEF_MAX_DEPTH; depth++) {
@@ -249,7 +250,7 @@ static bool type_name_is_signed(const char *R_NONNULL t) {
 R_API bool r_type_is_signed(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 	R_RETURN_VAL_IF_FAIL (TDB && type, false);
 	const char *base = type_skip_qualifiers (type);
-	char *resolved = type_resolve_typedef (TDB, base);
+	char *resolved = r_type_resolve_typedef (TDB, base);
 	const char *t = type_skip_qualifiers (resolved? resolved: base);
 	const bool ret = !strchr (t, '*') && type_name_is_signed (t);
 	free (resolved);
@@ -297,6 +298,23 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 	}
 	if (!strcmp (t, "type")) {
 		return sdb_num_getf (TDB, NULL, "type.%s.size", tmptype); // returns size in bits
+	}
+	if (!strcmp (t, "typedef")) {
+		// a typedef is as wide as the type it names: recorded width first, else the alias
+		ut64 size = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);
+		if (size) {
+			return size; // returns size in bits
+		}
+		char *resolved = r_type_resolve_typedef (TDB, tmptype);
+		if (resolved) {
+			// still a typedef after the resolver bound means a cycle, so fail closed
+			const char *kind = sdb_const_get (TDB, resolved, 0);
+			if (!kind || strcmp (kind, "typedef")) {
+				size = r_type_get_bitsize (TDB, resolved);
+			}
+			free (resolved);
+		}
+		return size;
 	}
 	if (!strcmp (t, "struct") || !strcmp (t, "union")) {
 		const char *value = sdb_const_getf (TDB, NULL, "%s.%s", t, tmptype);

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -322,6 +322,26 @@ static bool test_anal_get_base_type_typedef(void) {
 	mu_assert_streq (base->name, "string", "type name");
 	mu_assert_streq (base->type, "char *", "typedefd type");
 
+	sdb_set (anal->sdb_types, "word", "typedef", 0);
+	sdb_set (anal->sdb_types, "typedef.word", "unsigned long", 0);
+	sdb_num_set (anal->sdb_types, "type.word.size", 64, 0);
+	mu_assert_eq (r_type_get_bitsize (anal->sdb_types, "word"), 64,
+		"Typedef with a declared width measures that width");
+
+	sdb_set (anal->sdb_types, "u64", "type", 0);
+	sdb_num_set (anal->sdb_types, "type.u64.size", 64, 0);
+	sdb_set (anal->sdb_types, "myword", "typedef", 0);
+	sdb_set (anal->sdb_types, "typedef.myword", "u64", 0);
+	mu_assert_eq (r_type_get_bitsize (anal->sdb_types, "myword"), 64,
+		"Typedef without a declared width measures what it aliases");
+
+	sdb_set (anal->sdb_types, "cycle_a", "typedef", 0);
+	sdb_set (anal->sdb_types, "typedef.cycle_a", "cycle_b", 0);
+	sdb_set (anal->sdb_types, "cycle_b", "typedef", 0);
+	sdb_set (anal->sdb_types, "typedef.cycle_b", "cycle_a", 0);
+	mu_assert_eq (r_type_get_bitsize (anal->sdb_types, "cycle_a"), 0,
+		"Cyclic typedefs fail closed");
+
 	r_anal_base_type_free (base);
 	r_anal_free (anal);
 	mu_end;


### PR DESCRIPTION
r_type_get_bitsize handled type, struct and union and fell through to zero for every typedef, so size_t and uint32_t measured zero bits.
It now takes the recorded width when the sdb has one and otherwise measures what the alias resolves to, failing closed on a cyclic chain.