### PR TITLE
Render arm conditional branches as v conditions in the pseudo output ##disasm

### DIFF
--- a/libr/arch/p/arm/pseudo.c
+++ b/libr/arch/p/arm/pseudo.c
@@ -25,7 +25,6 @@ static char *replace(int argc, const char *argv[]) {
 		{ 3, "mneg ", "# = -(# * #)", { 1, 2, 3 } },
 		{ 3, "adds", "# = # + #", { 1, 2, 3 } },
 		{ 3, "addw", "# = # + #", { 1, 2, 3 } },
-		{ 3, "add.w", "# = # + #", { 1, 2, 3 } },
 		{ 0, "adf", "# = # + #", { 1, 2, 3 } },
 		{ 0, "adrp", "# = #", { 1, 2 } },
 		{ 0, "adr", "# = #", { 1, 2 } },
@@ -39,32 +38,43 @@ static char *replace(int argc, const char *argv[]) {
 		{ 0, "b", "goto #", { 1 } },
 		{ 0, "cbz", "if (!#) goto #", { 1, 2 } },
 		{ 0, "cbnz", "if (#) goto #", { 1, 2 } },
-		{ 0, "b.w", "goto #", { 1 } },
-		{ 0, "b.gt", "if (a > b) goto #", { 1 } },
-		{ 0, "b.le", "if (a <= b) goto #", { 1 } },
-		{ 0, "b.lt", "if (a < b) goto #", { 1 } },
-		{ 0, "b.ls", "if (a < b) goto #", { 1 } },
-		{ 0, "b.ge", "if (a >= b) goto #", { 1 } },
-		{ 0, "beq lr", "ifeq ret", {0} },
-		{ 0, "beq", "je #", { 1 } },
+		// compares set v and the conditional branches test it, like x86
+		{ 0, "beq", "if (!v) goto #", { 1 } },
+		{ 0, "bne", "if (v) goto #", { 1 } },
+		{ 0, "bgt", "if (v > 0) goto #", { 1 } },
+		{ 0, "bge", "if (v >= 0) goto #", { 1 } },
+		{ 0, "blt", "if (v < 0) goto #", { 1 } },
+		{ 0, "ble", "if (v <= 0) goto #", { 1 } },
+		{ 0, "bhi", "if (((unsigned) v) > 0) goto #", { 1 } },
+		{ 0, "bhs", "if (((unsigned) v) >= 0) goto #", { 1 } },
+		{ 0, "bcs", "if (((unsigned) v) >= 0) goto #", { 1 } },
+		{ 0, "blo", "if (((unsigned) v) < 0) goto #", { 1 } },
+		{ 0, "bcc", "if (((unsigned) v) < 0) goto #", { 1 } },
+		{ 0, "bls", "if (((unsigned) v) <= 0) goto #", { 1 } },
+		{ 0, "bmi", "if (v < 0) goto #", { 1 } },
+		{ 0, "bpl", "if (v >= 0) goto #", { 1 } },
+		{ 0, "bvs", "if (overflow) goto #", { 1 } },
+		{ 0, "bvc", "if (!overflow) goto #", { 1 } },
+		{ 0, "bal", "goto #", { 1 } },
+		{ 0, "bnv", "goto #", { 1 } },
 		{ 0, "call", "# ()", { 1 } },
 		{ 0, "bl", "# ()", { 1 } },
 		{ 0, "blx", "# ()", { 1 } },
 		{ 0, "bx lr", "ret", {0} },
 		{ 1, "br", "switch #", { 1 } },
-		{ 0, "bxeq", "je #", { 1 } },
-		{ 0, "b.eq", "if (eq) goto #", { 1 } },
-		{ 0, "b.ne", "if (eq) goto #", { 1 } },
-		{ 0, "b.hi", "goto ifgt #", { 1 } },
-		{ 0, "b.lo", "goto iflt #", { 1 } },
+		{ 0, "bxeq", "if (!v) goto #", { 1 } },
 		{ 0, "cmf", "if (# == #)", { 1, 2 } },
-		{ 0, "cmn", "if (# != #)", { 1, 2 } },
-		{ 0, "cmp", "(a, b) = compare (#, #)", { 1, 2 } },
-		{ 0, "fcmp", "(a, b) = compare (#, #)", { 1, 2 } },
-		{ 0, "tst", "(a, b) = compare (#, #)", { 1, 2 } },
-		// { 0, "cmp", "if (# == #)", { 1, 2 } },
-		// { 0, "fcmp", "if (# == #)", { 1, 2 } },
-		//{ 0, "tst", "if ((# & #) == 0)", { 1, 2 } },
+		// the third operand is a shift or extend of the second: keep it visible
+		{ 2, "cmn", "v = # + #", { 1, 2 } },
+		{ 3, "cmn", "v = # + (# #)", { 1, 2, 3 } },
+		{ 2, "cmp", "v = # - #", { 1, 2 } },
+		{ 3, "cmp", "v = # - (# #)", { 1, 2, 3 } },
+		{ 2, "fcmp", "v = # - #", { 1, 2 } },
+		{ 2, "fcmpe", "v = # - #", { 1, 2 } },
+		{ 2, "teq", "v = # ^ #", { 1, 2 } },
+		{ 3, "teq", "v = # ^ (# #)", { 1, 2, 3 } },
+		{ 2, "tst", "v = # & #", { 1, 2 } },
+		{ 3, "tst", "v = # & (# #)", { 1, 2, 3 } },
 		{ 4, "csel", "# = (#)? # : #", { 1, 4, 2, 3 } },
 		{ 2, "cset", "# = (#)? 1 : 0", { 1, 2 } },
 		{ 0, "dvf", "# = # / #", { 1, 2, 3 } },
@@ -89,7 +99,6 @@ static char *replace(int argc, const char *argv[]) {
 		{ 3, "ldruh", "# = (uword) # + #", { 1, 2, 3 } },
 		{ 2, "ldrb", "# = (byte) #", { 1, 2 } },
 		{ 3, "ldrb", "# = (byte) # + #", { 1, 2, 3 } },
-		{ 2, "ldr.w", "# = #", { 1, 2 } },
 		{ 4, "ldrsb", "# = (byte) # + #", { 1, 2, 3 } },
 		{ 3, "ldrsb", "# = (byte) # + #", { 1, 2, 3 } },
 		{ 2, "ldrsb", "# = (byte) #", { 1, 2 } },
@@ -98,7 +107,6 @@ static char *replace(int argc, const char *argv[]) {
 		{ 3, "ldrsw", "# = # + #", { 1, 2, 3 } },
 		{ 3, "ldr", "# = # + #", { 1, 2, 3 } },
 		{ 3, "ldrb", "# = (byte) # + #", { 1, 2, 3 } },
-		{ 3, "ldr.w", "# = # + #", { 1, 2, 3 } },
 		{ 0, "mov", "# = #", { 1, 2 } },
 		{ 0, "fmov", "# = #", { 1, 2 } },
 		{ 0, "mvn", "# = ~#", { 1, 2 } },
@@ -131,7 +139,6 @@ static char *replace(int argc, const char *argv[]) {
 		{ 0, "orr", "# = # | #", { 1, 2, 3 } },
 		{ 2, "orr", "# |= #", { 1, 2 } },
 		{ 0, "rmf", "# = # % #", { 1, 2, 3 } },
-		{ 0, "bge", "(>=) goto #", { 1 } },
 		{ 0, "sbc", "# = # - #", { 1, 2, 3 } },
 		{ 0, "sqt", "# = sqrt(#)", { 1, 2 } },
 		{ 0, "lsrs", "# = # >> #", { 1, 2, 3 } },
@@ -139,18 +146,14 @@ static char *replace(int argc, const char *argv[]) {
 		{ 1, "blr", "callreg #", { 1 } },
 		{ 0, "lsr", "# = # >> #", { 1, 2, 3 } },
 		{ 0, "lsl", "# = # << #", { 1, 2, 3 } },
-		{ 0, "lsr.w", "# = # >> #", { 1, 2, 3 } },
-		{ 0, "lsl.w", "# = # << #", { 1, 2, 3 } },
 		{ 3, "stxr", "# = #", { 3, 2 } }, // stxr w10, x9, [x8] (w10 is 0 or 1 if exclusively locked)
 		{ 3, "stlxr", "# = #", { 3, 2 } },
 		{ 2, "str", "# = #", { 2, 1 } },
 		{ 2, "strb", "# = (byte) #", { 2, 1 } },
 		{ 2, "strh", "# = (half) #", { 2, 1 } },
-		{ 2, "strh.w", "# = (half) #", { 2, 1 } },
 		{ 3, "str", "# + # = #", { 2, 3, 1 } },
 		{ 3, "strb", "# + # = (byte) #", { 2, 3, 1 } },
 		{ 3, "strh", "# + # = (half) #", { 2, 3, 1 } },
-		{ 3, "strh.w", "# + # = (half) #", { 2, 3, 1 } },
 		{ 3, "sub", "# = # - #", { 1, 2, 3 } },
 		{ 3, "subs", "# = # - #", { 1, 2, 3 } },
 		{ 3, "fsub", "# = # - #", { 1, 2, 3 } },
@@ -164,23 +167,28 @@ static char *replace(int argc, const char *argv[]) {
 		{ 0, "vmov", "# = (float) # . #", { 1, 2, 3 } },
 		{ 0, "vdiv.f64", "# = (float) # / #", { 1, 2, 3 } },
 		{ 0, "addw", "# = # + #", { 1, 2, 3 } },
-		{ 0, "sub.w", "# = # - #", { 1, 2, 3 } },
-		{ 0, "tst.w", "if ((# & #) == 0)", { 1, 2 } },
-		{ 0, "pop.w", "pop #", { 1 } },
+		{ 0, "pop", "pop #", { 1 } },
 		{ 0, "vpop", "pop #", { 1 } },
 		{ 0, "paciza", "", { 1 } },
 		{ 0, "vpush", "push #", { 1 } },
-		{ 0, "push.w", "push #", { 1 } },
+		{ 0, "push", "push #", { 1 } },
 		{ 0, NULL }
 	};
 	RStrBuf *sb = r_strbuf_new ("");
+	// thumb wide/narrow (bne.w, beq.n) and arm64 b.cond (b.ne) share the arm rows
+	char mn[32];
+	r_str_ncpy (mn, argv[0], sizeof (mn));
+	if (r_str_endswith (mn, ".w") || r_str_endswith (mn, ".n")) {
+		mn[strlen (mn) - 2] = 0;
+	}
+	if (r_str_startswith (mn, "b.")) {
+		memmove (mn + 1, mn + 2, strlen (mn + 1));
+	}
 	for (i = 0; ops[i].op; i++) {
-		if (ops[i].narg) {
-			if (argc - 1 != ops[i].narg) {
-				continue;
-			}
+		if (ops[i].narg && argc - 1 != ops[i].narg) {
+			continue;
 		}
-		if (!strcmp (ops[i].op, argv[0])) {
+		if (!strcmp (ops[i].op, mn)) {
 			d = 0;
 			j = 0;
 			ch = ops[i].str[j];

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -187,11 +187,11 @@ void sym.func.100003a54 (int64_t arg1, int64_t arg2) {
         x8 = [x8 + 0x60]
         x9 = [x1 + 0x60] // arg2
         x9 = [x9 + 0x60]
-        (a, b) = compare (x8, x9)
-        if (a <= b) goto 0x100003a74 // likely
+        v = x8 - x9
+        if (v <= 0) goto 0x100003a74 // likely
         return x0;
     loc_0x100003a74:
-        if (a >= b) goto 0x100003a80 // likely
+        if (v >= 0) goto 0x100003a80 // likely
         return x0;
     loc_0x100003a80:
         x8 = x1 + 0x68 // arg2
@@ -266,11 +266,11 @@ EXPECT=<<EOF
  0x100003a58 |         x8 = [x8 + 0x60]
  0x100003a5c |         x9 = [x1 + 0x60] // arg2
  0x100003a60 |         x9 = [x9 + 0x60]
- 0x100003a64 |         (a, b) = compare (x8, x9)
- 0x100003a68 |         if (a <= b) goto 0x100003a74 // likely
+ 0x100003a64 |         v = x8 - x9
+ 0x100003a68 |         if (v <= 0) goto 0x100003a74 // likely
  0x100003a54 |         return x0;
  0x100003a74 |     loc_0x100003a74:
- 0x100003a74 |         if (a >= b) goto 0x100003a80 // likely
+ 0x100003a74 |         if (v >= 0) goto 0x100003a80 // likely
  0x100003a74 |         return x0;
  0x100003a80 |     loc_0x100003a80:
  0x100003a80 |         x8 = x1 + 0x68 // arg2
@@ -921,9 +921,9 @@ pdcj~{annotations[11]}
 pdcj~{annotations[12]}
 EOF
 EXPECT=<<EOF
-{"start":519,"end":571,"offset":4294982284,"type":"offset"}
-{"start":571,"end":619,"offset":4294982264,"type":"offset"}
-{"start":619,"end":666,"offset":4294982252,"type":"offset"}
+{"start":505,"end":557,"offset":4294982284,"type":"offset"}
+{"start":557,"end":605,"offset":4294982264,"type":"offset"}
+{"start":605,"end":652,"offset":4294982252,"type":"offset"}
 EOF
 RUN
 
@@ -1152,5 +1152,41 @@ EXPECT=<<EOF
     if (!(eax - 7)) {
         eax += 2
         eax += 3
+EOF
+RUN
+
+NAME=pdc structured recovers arm64 b.cond operands from the cmp
+FILE=malloc://64
+ARGS=-a arm -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 1f00016b 6c000054 20008052 02000014 40008052 c0035fd6 @ 0
+af @ 0
+pdc~if (,w0 =,else
+pdc~cond_0x~?
+EOF
+EXPECT=<<EOF
+    if (w0 <= w1) {
+        w0 = 1
+    } else {
+        w0 = 2
+0
+EOF
+RUN
+
+NAME=pdc structured recovers arm32 b<cc> operands from the cmp
+FILE=malloc://64
+ARGS=-a arm -b 32 -e pdc.structured=1
+CMDS=<<EOF
+wx 010050e1 010000ca 0100a0e3 000000ea 0200a0e3 1eff2fe1 @ 0
+af @ 0
+pdc~if (,r0 =,else
+pdc~cond_0x~?
+EOF
+EXPECT=<<EOF
+    if (r0 <= r1) {
+        r0 = 1
+    } else {
+        r0 = 2
+0
 EOF
 RUN

--- a/test/db/cmd/cmd_pseudo_arm32
+++ b/test/db/cmd/cmd_pseudo_arm32
@@ -1,0 +1,57 @@
+NAME=ARM pseudo compares set v and b<cc> tests it
+FILE=malloc://80
+ARGS=-a arm -b 32 -e asm.pseudo=true -e asm.comments=false
+CMDS=<<EOF
+wx 020051e1 0100000a 0100001a 010000aa 010000ba 010000ca 010000da 0100008a 0100002a 0100003a 0100009a 0100004a 0100005a 0100006a 0100007a 020071e1 020031e1 020011e1
+pi 18
+EOF
+EXPECT=<<EOF
+v = r1 - r2
+if (!v) goto 0x10
+if (v) goto 0x14
+if (v >= 0) goto 0x18
+if (v < 0) goto 0x1c
+if (v > 0) goto 0x20
+if (v <= 0) goto 0x24
+if (((unsigned) v) > 0) goto 0x28
+if (((unsigned) v) >= 0) goto 0x2c
+if (((unsigned) v) < 0) goto 0x30
+if (((unsigned) v) <= 0) goto 0x34
+if (v < 0) goto 0x38
+if (v >= 0) goto 0x3c
+if (overflow) goto 0x40
+if (!overflow) goto 0x44
+v = r1 + r2
+v = r1 ^ r2
+v = r1 & r2
+EOF
+RUN
+
+NAME=Thumb2 wide compares and branches share the narrow pseudo
+FILE=malloc://32
+ARGS=-a arm -b 16 -e asm.pseudo=true -e asm.comments=false
+CMDS=<<EOF
+wx b1eb020f 40f08080 02d0 11ea020f
+pi 4
+EOF
+EXPECT=<<EOF
+v = r1 - r2
+if (v) goto 0x108
+if (!v) goto 0x10
+v = r1 & r2
+EOF
+RUN
+
+NAME=ARM pseudo keeps the shifted compare operand
+FILE=malloc://16
+ARGS=-a arm -b 32 -e asm.pseudo=true -e asm.comments=false
+CMDS=<<EOF
+wx 020151e1 120251e1 020111e1
+pi 3
+EOF
+EXPECT=<<EOF
+v = r1 - (r2 << 2)
+v = r1 - (r2 << r2)
+v = r1 & (r2 << 2)
+EOF
+RUN

--- a/test/db/cmd/cmd_pseudo_arm64
+++ b/test/db/cmd/cmd_pseudo_arm64
@@ -279,3 +279,46 @@ EXPECT=<<EOF
 \           0x00000008      fd830091       x29 = sp + 0x20
 EOF
 RUN
+
+NAME=ARM64 pseudo compares set v and b.cond tests it
+FILE=malloc://80
+ARGS=-a arm -b 64 -e asm.pseudo=true -e asm.comments=false
+CMDS=<<EOF
+wx 1f0002eb 40000054 41000054 4a000054 4b000054 4c000054 4d000054 48000054 42000054 43000054 49000054 44000054 45000054 46000054 47000054 4e000054 1f00026a 1f0002ab
+pi 18
+EOF
+EXPECT=<<EOF
+v = x0 - x2
+if (!v) goto 0xc
+if (v) goto 0x10
+if (v >= 0) goto 0x14
+if (v < 0) goto 0x18
+if (v > 0) goto 0x1c
+if (v <= 0) goto 0x20
+if (((unsigned) v) > 0) goto 0x24
+if (((unsigned) v) >= 0) goto 0x28
+if (((unsigned) v) < 0) goto 0x2c
+if (((unsigned) v) <= 0) goto 0x30
+if (v < 0) goto 0x34
+if (v >= 0) goto 0x38
+if (overflow) goto 0x3c
+if (!overflow) goto 0x40
+goto 0x44
+v = w0 & w2
+v = x0 + x2
+EOF
+RUN
+
+NAME=ARM64 pseudo keeps the shifted or extended compare operand
+FILE=malloc://16
+ARGS=-a arm -b 64 -e asm.pseudo=true -e asm.comments=false
+CMDS=<<EOF
+wx 1f0801eb 1fc021eb 1f08026a
+pi 3
+EOF
+EXPECT=<<EOF
+v = x0 - (x1 << 2)
+v = x0 - (w1 sxtw)
+v = w0 & (w2 << 2)
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The arm pseudo rendered cmp as (a, b) = compare (...) and the branches as je #, goto ifgt #, if (eq) goto (also for b.ne) or not at all (arm32 bne/bgt/bhi/...), so pdc.structured could not recover a condition on arm32/arm64 and printed cond_0x... placeholders.

Now cmp/cmn/tst/teq/fcmp set v and every b<cc> / b.<cc> tests it in the x86 wording (if (v > 0) goto #, ((unsigned) v) for hi/hs/lo/ls, overflow for vs/vc); shifted/extended compares keep their third operand (v = x0 - (x1 << 2)). replace() normalises Thumb .w/.n and A64 b. mnemonics onto the plain rows, dropping the duplicated .w entries. Structured pdc then folds the compare: if (x8 > x9) instead of if  (!cond_0x...) (0 placeholders left on the arm test binaries).

Tests: A32, Thumb-2 and A64 pseudo tables, two structured pdc diamonds; three ls-m1 goldens move. S-suffixed ALU ops still expose no v (as x86 dec; jne) — follow-up.