### PR TITLE
Fix dwo_id truncation in the DWARF5 unit header ##bin

### DIFF
--- a/libr/include/r_bin_dwarf.h
+++ b/libr/include/r_bin_dwarf.h
@@ -795,7 +795,7 @@ typedef struct {
 	//  segmented addressing, this value represents the size of the offset portion of an address.
 	ut8 address_size;
 	ut8 unit_type; // DWARF 5 addition
-	ut8 dwo_id; // DWARF 5 addition
+	ut64 dwo_id; // DWARF 5 addition
 	ut64 type_sig; // DWARF 5 addition
 	ut64 type_offset; // DWARF 5 addition
 	ut64 header_size; // excluding length field


### PR DESCRIPTION
The skeleton and split-compile unit parser reads an 8-byte dwo id into a ut8 field, losing the top 56 bits.