### PR TITLE
Report exact byte counts through RIOBind.nread_at ##io

### DIFF
--- a/libr/include/r_io.h
+++ b/libr/include/r_io.h
@@ -320,6 +320,7 @@ typedef RIODesc *(*RIOOpen)(RIO *io, const char *uri, int flags, int mode);
 typedef RIODesc *(*RIOOpenAt)(RIO *io, const  char *uri, int flags, int mode, ut64 at);
 typedef bool (*RIOClose)(RIO *io, int fd);
 typedef bool (*RIOReadAt)(RIO *io, ut64 addr, ut8 *buf, int len);
+typedef int (*RIONReadAt)(RIO *io, ut64 addr, ut8 *buf, int len);
 typedef bool (*RIOWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int len);
 typedef bool (*RIOOverlayWriteAt)(RIO *io, ut64 addr, const ut8 *buf, int len);
 typedef char *(*RIOSystem)(RIO *io, const char* cmd);
@@ -362,7 +363,9 @@ typedef struct r_io_bind_t {
 	RIOOpen open;
 	RIOOpenAt open_at;
 	RIOClose close;
+	// read_at reports success; nread_at reports the exact byte count.
 	RIOReadAt read_at;
+	RIONReadAt nread_at;
 	RIOWriteAt write_at;
 	RIOOverlayWriteAt overlay_write_at;
 	RIOSystem system;

--- a/libr/io/io.c
+++ b/libr/io/io.c
@@ -471,6 +471,7 @@ R_API void r_io_bind(RIO *io, RIOBind *bnd) {
 	bnd->open_at = r_io_open_at;
 	bnd->close = r_io_fd_close;
 	bnd->read_at = r_io_read_at;
+	bnd->nread_at = r_io_nread_at;
 	bnd->write_at = r_io_write_at;
 	bnd->overlay_write_at = r_io_vwrite_to_overlay_at;
 	bnd->system = r_io_system;

--- a/test/unit/test_io.c
+++ b/test/unit/test_io.c
@@ -1,4 +1,5 @@
 #include <r_io.h>
+#include <r_util.h>
 #include "minunit.h"
 
 bool test_r_io_cache(void) {
@@ -63,6 +64,26 @@ bool test_r_io_cache(void) {
 	mu_end;
 #endif
 	return true;
+}
+
+bool test_r_io_bind_exact_read_count(void) {
+	char *filename = r_file_temp ("r2-io-nread");
+	mu_assert_notnull (filename, "temporary filename should be created");
+	const ut8 source[] = { 1, 2, 3 };
+	mu_assert_true (r_file_dump (filename, source, sizeof (source), false), "temporary source should be written");
+	char *uri = r_str_newf ("file://%s", filename);
+	RIO *io = r_io_new ();
+	RIOBind bind = { 0 };
+	mu_assert_notnull (r_io_open (io, uri, R_PERM_R, 0), "file IO should open");
+	r_io_bind (io, &bind);
+	mu_assert_notnull (bind.nread_at, "RIO bind should expose exact-count reads");
+	ut8 buf[4] = { 0 };
+	mu_assert_eq (bind.nread_at (io, 0, buf, sizeof (buf)), 3, "exact-count read should expose a short physical read");
+	r_io_free (io);
+	free (uri);
+	r_file_rm (filename);
+	free (filename);
+	mu_end;
 }
 
 bool test_r_io_mapsplit (void) {
@@ -279,6 +300,7 @@ bool test_r_io_priority2(void) {
 
 int all_tests(void) {
 	mu_run_test(test_r_io_cache);
+	mu_run_test(test_r_io_bind_exact_read_count);
 	mu_run_test(test_r_io_mapsplit);
 	mu_run_test(test_r_io_mapsplit2);
 	mu_run_test(test_r_io_mapsplit3);


### PR DESCRIPTION
read_at only reports success, so a bound consumer cannot tell a short read from a full one; bind the existing r_io_nread_at next to it.