### PR TITLE
Show the instruction under a typelink that has no format ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -7126,28 +7126,27 @@ toro:
 				free (fmt);
 				continue;
 			}
+		}
+		int left = ds_left (ds);
+		R_LOG_DEBUG ("BEFORE: ds->index=%#x len=%#x left=%#x ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x",
+			ds->index, len, left, ds->addr, ds->at, ds->count, ds->lines);
+		if (left < max_op_size && !count_bytes) {
+			R_LOG_DEBUG ("Not enough bytes to disassemble, going to retry");
+			goto retry;
+		}
+		const int real_oplen = ds->oplen;
+		int disasm_ret = ds_disassemble (ds, (ut8 *)ds_bufat (ds), left);
+		// hack over hack, this tracks metadata size vs instruction size vs padding
+		if (disasm_ret == ds->oplen) {
+			ds->oplen = disasm_ret;
 		} else {
-			int left = ds_left (ds);
-			R_LOG_DEBUG ("BEFORE: ds->index=%#x len=%#x left=%#x ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x",
-				ds->index, len, left, ds->addr, ds->at, ds->count, ds->lines);
-			if (left < max_op_size && !count_bytes) {
-				R_LOG_DEBUG ("Not enough bytes to disassemble, going to retry");
-				goto retry;
-			}
-			const int real_oplen = ds->oplen;
-			int ret = ds_disassemble (ds, (ut8 *)ds_bufat (ds), left);
-			// hack over hack, this tracks metadata size vs instruction size vs padding
-			if (ret == ds->oplen) {
-				ds->oplen = ret;
-			} else {
-				ds->oplen = real_oplen; // overwritten by ds_disassemble
-			}
-			R_LOG_DEBUG ("AFTER: ret=%d len=%#x left=%#x ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x",
-				ret, len, left, ds->addr, ds->at, ds->count, ds->lines);
-			if (ret == -31337) {
-				inc = ds->oplen; // minopsz maybe? or we should add invopsz
-				continue;
-			}
+			ds->oplen = real_oplen; // overwritten by ds_disassemble
+		}
+		R_LOG_DEBUG ("AFTER: ret=%d len=%#x left=%#x ds->addr=%#" PFMT64x " ds->at=%#" PFMT64x " ds->count=%#x ds->lines=%#x",
+			disasm_ret, len, left, ds->addr, ds->at, ds->count, ds->lines);
+		if (disasm_ret == -31337) {
+			inc = ds->oplen; // minopsz maybe? or we should add invopsz
+			continue;
 		}
 
 		ds_atabs_option (ds);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3991,3 +3991,18 @@ EXPECT=<<EOF
 4
 EOF
 RUN
+
+NAME=pd shows the instruction under a function typelink without a format
+FILE=malloc://8
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 9090c3
+'td int foo(int x);
+tl foo = 0
+pd 2
+EOF
+EXPECT=<<EOF
+            0x00000000      90             nop
+            0x00000001      90             nop
+EOF
+RUN


### PR DESCRIPTION
A function type linked at an address has no pf format, and the disassembly loop skipped the instruction entirely instead of falling through to disassemble it.