### PR TITLE
Guess the registered prototype for a decorated function name ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2492,7 +2492,7 @@ R_API bool r_anal_function_del_signature(RAnal *a, const char *name) {
 
 	R_RETURN_VAL_IF_FAIL (a && a->sdb_types && name, false);
 	Sdb *db = a->sdb_types;
-	char *type_name = r_type_func_name (db, name);
+	char *type_name = r_type_func_key (db, name);
 	if (!type_name) {
 		type_name = strdup (name);
 	}
@@ -2551,7 +2551,7 @@ static const char *function_signature_lookup_name(RAnal *anal, RAnalFunction *fc
 
 static char *function_signature_try_type_name(Sdb *types, const char *candidate) {
 	R_RETURN_VAL_IF_FAIL (types && candidate && *candidate, NULL);
-	char *name = r_type_func_name (types, candidate);
+	char *name = r_type_func_key (types, candidate);
 	if (name) {
 		const char *kind = sdb_const_get (types, name, 0);
 		if (kind && !strcmp (kind, "func")) {
@@ -2902,7 +2902,10 @@ R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *funct
 		&& !function_signature_fallback_to_vars (anal, function, signature)) {
 		goto beach;
 	}
-	signature->signature = function_signature_string (type_name, signature->ret_type, signature->params, true, false);
+	// the declaration carries the function's own name; the key is only a lookup handle
+	signature->signature = function_signature_string (
+		R_STR_ISNOTEMPTY (function->name)? function->name: type_name,
+		signature->ret_type, signature->params, true, false);
 	if (!signature->signature) {
 		goto beach;
 	}
@@ -2934,7 +2937,9 @@ R_API char *r_anal_function_get_signature_string(RAnalFunction *fcn) {
 	}
 	type_name = function_signature_type_name (fcn->anal, fcn);
 	if (type_name) {
-		res = function_signature_string (type_name, signature->ret_type, signature->params, true, false);
+		res = function_signature_string (
+			R_STR_ISNOTEMPTY (fcn->name)? fcn->name: type_name,
+			signature->ret_type, signature->params, true, false);
 		free (type_name);
 	}
 	r_anal_function_signature_free (signature);

--- a/libr/include/r_util/r_type.h
+++ b/libr/include/r_util/r_type.h
@@ -51,6 +51,7 @@ R_API R_OWNED char *r_type_func_args_type(Sdb *TDB, const char * R_NONNULL func_
 R_API const char *r_type_func_args_name(Sdb *TDB, const char * R_NONNULL func_name, int i);
 R_API R_OWNED char *r_type_func_guess(Sdb *TDB, const char * R_NONNULL func_name);
 R_API R_OWNED char *r_type_func_name(Sdb *types, const char *fname);
+R_API R_OWNED char *r_type_func_key(Sdb *types, const char *fname);
 R_API bool r_type_func_is_variadic(Sdb *TDB, const char * R_NONNULL func_name);
 
 // the variadic slot is named "..." (r2 <= 6.1.8 stored it in the type half instead)

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -1112,3 +1112,20 @@ R_API char *r_type_func_name(Sdb *types, const char *fname) {
 	}
 	return r_type_func_guess (types, fname);
 }
+
+// same walk as r_type_func_name, but hands back the db key the match went through
+R_API char *r_type_func_key(Sdb *types, const char *fname) {
+	const char *str = fname;
+	const char *name = fname;
+	if (r_type_func_exist (types, fname)) {
+		return strdup (trim_lodashes (types, fname));
+	}
+	while ( (str = strchr (str, '.'))) {
+		str++;
+		name = str;
+	}
+	if (r_type_func_exist (types, name)) {
+		return strdup (trim_lodashes (types, name));
+	}
+	return r_type_func_guess (types, fname);
+}

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -1097,35 +1097,30 @@ R_API R_OWNED char *r_type_func_guess(Sdb *TDB, const char *R_NONNULL func_name)
 	return result;
 }
 
-R_API char *r_type_func_name(Sdb *types, const char *fname) {
+// walks name, then the last dotted component, then the fuzzy guesser. When
+// `key` is set the db key the match went through is returned instead of the
+// name that was matched, because r_type_func_exist trims leading lodashes
+static char *type_func_lookup(Sdb *types, const char *fname, bool key) {
 	const char *str = fname;
 	const char *name = fname;
 	if (r_type_func_exist (types, fname)) {
-		return strdup (fname);
+		return strdup (key? trim_lodashes (types, fname): fname);
 	}
 	while ( (str = strchr (str, '.'))) {
 		str++;
 		name = str;
 	}
 	if (r_type_func_exist (types, name)) {
-		return strdup (name);
+		return strdup (key? trim_lodashes (types, name): name);
 	}
 	return r_type_func_guess (types, fname);
 }
 
+R_API char *r_type_func_name(Sdb *types, const char *fname) {
+	return type_func_lookup (types, fname, false);
+}
+
 // same walk as r_type_func_name, but hands back the db key the match went through
 R_API char *r_type_func_key(Sdb *types, const char *fname) {
-	const char *str = fname;
-	const char *name = fname;
-	if (r_type_func_exist (types, fname)) {
-		return strdup (trim_lodashes (types, fname));
-	}
-	while ( (str = strchr (str, '.'))) {
-		str++;
-		name = str;
-	}
-	if (r_type_func_exist (types, name)) {
-		return strdup (trim_lodashes (types, name));
-	}
-	return r_type_func_guess (types, fname);
+	return type_func_lookup (types, fname, true);
 }

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1212,10 +1212,20 @@ NAME=ppc plt-call stub toc save is not recovered as an argument
 FILE=bins/elf/ppc64_sudoku_dwarf
 CMDS=<<EOF2
 aa
+afv @ loc.00000018.plt_call.__libc_start_main
+EOF2
+EXPECT=<<EOF2
+EOF2
+RUN
+
+NAME=a decorated stub name still finds its prototype in the types db
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF2
+aa
 afs @ loc.00000018.plt_call.__libc_start_main
 EOF2
 EXPECT=<<EOF2
-void loc.00000018.plt_call.__libc_start_main ();
+int loc.00000018.plt_call.__libc_start_main (func main, int argc, char **ubp_av, func init, func fini, func rtld_fini, void *stack_end);
 EOF2
 RUN
 

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1005,7 +1005,7 @@ za sym.__write b f30f1efa488d05256d0d008b0085c07517b8010000000f05483d00f0ffff775
 za sym.__write g cc=6 nbbs=7 edges=7 ebbs=3 bbsum=148
 za sym.__write o 0x000ec800
 za sym.__write R X193cml0ZQ==
-za sym.__write t void sym.__write (int fd, const char *ptr, size_t nbytes)
+za sym.__write t ssize_t sym.__write (int fd, const char *ptr, size_t nbytes)
 za sym.__write r sym.__libc_enable_asynccancel sym.__libc_disable_asynccancel
 za sym.__write v fs-32:var_8h:int64_t, tr73:nbytes:size_t, tr79:ptr:const char *, tr83:fd:int
 za sym.__write h 4f2d194bae72345352b26e0a36531e7d6ff6cb5d6b50b92487246507b8dafdc5
@@ -1272,7 +1272,7 @@ za sym.memset b 200c014e0400028b5f8001f1c80300545f4000f102020054013c084ea2001836
 za sym.memset g cc=28 nbbs=35 edges=47 ebbs=8 bbsum=460
 za sym.memset o 0x00012180
 za sym.memset R bWVtc2V0
-za sym.memset t void * memset (void *s, int c, size_t n)
+za sym.memset t void * sym.memset (void *s, int c, size_t n)
 za sym.memset v tr10:c:int, tr6:s:void *, tr14:n:size_t
 za sym.memset h 82e8b18bbf263f9ed0e31d6b68099efe6eb8805a429444f8aa119af00c47369c
 EOF

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -169,8 +169,8 @@ afs
 EOF
 EXPECT=<<EOF
 int fallback_signature (int fallback);
-char linked_signature (char linked);
-char linked_signature (char linked);
+char fallback_signature (char linked);
+char renamed_signature (char linked);
 int renamed_signature (int fallback);
 int renamed_signature (int fallback);
 EOF
@@ -2034,7 +2034,7 @@ af
 afs
 EOF
 EXPECT=<<EOF
-size_t strlen (const char *s);
+size_t sym.imp.strlen (const char *s);
 EOF
 RUN
 
@@ -2282,7 +2282,7 @@ int main (int argc, char **argv, char **envp);
     }
   ]
 }
-char * strcpy (char *dest, const char *src);
+char * sym.imp.strcpy (char *dest, const char *src);
 {
   "name": "sym.imp.strcpy",
   "noreturn": false,

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -27,11 +27,11 @@ afs @ 0x130e
 EOF
 EXPECT=<<EOF
 main_1169
-int main_1169 ();
+int dbg.main ();
 Bird_Bird_
-void Bird_Bird_ (Bird * const this);
-void Bird_Bird_ (Bird * const this);
-int overridden (int x);
+void dbg.Bird__Bird__ (Bird * const this);
+void dbg.Bird__Bird__ (Bird * const this);
+int dbg.Bird__Bird__ (int x);
 EOF
 RUN
 
@@ -48,7 +48,7 @@ EXPECT=<<EOF
 void unicode_utf8_RuneCount([]uint8 p,int ~r1);
 int,~r1
 unicode_utf8_RuneCount
-void unicode_utf8_RuneCount ([]uint8 p, int ~r1);
+void sym.unicode_utf8.RuneCount ([]uint8 p, int ~r1);
 EOF
 RUN
 
@@ -79,7 +79,7 @@ EOF
 EXPECT=<<EOF
 fly
 0
-FutureType * fly ();
+FutureType * dbg.fly ();
 fly
 FutureType *
 0
@@ -102,7 +102,7 @@ EXPECT=<<EOF
 Mammal
 Mammal_401300
 struct
-void Mammal_401300 (Mammal *this);
+void method.Mammal.Mammal__ (Mammal *this);
 Mammal_401300
 EOF
 RUN
@@ -118,7 +118,7 @@ k anal/dwarf/fcn.__adddf3.typed_name
 EOF
 EXPECT=<<EOF
 __adddf3
-FLO_type __adddf3 (FLO_type arg_a, FLO_type arg_b);
+FLO_type sym.__adddf3 (FLO_type arg_a, FLO_type arg_b);
 __adddf3
 EOF
 RUN
@@ -135,7 +135,7 @@ k anal/types/fcnlink.00025ad0
 EOF
 EXPECT=<<EOF
 check
-bool check (u16 x, &[(u8, u8)] singletonuppers, &[u8] singletonlowers, &[u8] normal);
+bool sym.core__unicode__printable__check__h1d9e8c426a95acd5__clone_llvm3277309261110959063_ (u16 x, &[(u8, u8)] singletonuppers, &[u8] singletonlowers, &[u8] normal);
 check
 check
 EOF

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -102,7 +102,7 @@ EXPECT=<<EOF
 Mammal
 Mammal_401300
 struct
-void method.Mammal.Mammal__ (Mammal *this);
+void method.constructor.Mammal.Mammal__ (Mammal *this);
 Mammal_401300
 EOF
 RUN

--- a/test/db/formats/jni
+++ b/test/db/formats/jni
@@ -309,7 +309,7 @@ ao @ 0x294~opcode
 tk struct.JNINativeInterface.RegisterNatives
 EOF
 EXPECT=<<EOF
-jint JNI_OnLoad (JavaVM *vm, void *reserved);
+jint sym.JNI_OnLoad (JavaVM *vm, void *reserved);
 JavaVM *
 opcode: ldr x8, [x0]
 opcode: ldr x8, [x8, 0x30]

--- a/test/unit/test_anal_function.c
+++ b/test/unit/test_anal_function.c
@@ -395,7 +395,8 @@ bool test_r_anal_function_set_signature_uses_canonical_type_name(void) {
 	mu_assert_streq (arg0->type, "const char *", "first typed param type");
 	mu_assert_streq (arg1->name, "value", "second typed param name");
 	mu_assert_streq (arg1->type, "int *", "second typed param type");
-	mu_assert_streq (signature->signature, "int scanf (const char *format, int *value);", "canonical signature string");
+	mu_assert_streq (signature->signature, "int sym.imp.__isoc99_scanf (const char *format, int *value);",
+		"declaration must carry the function's own name, not the type db key");
 	r_anal_function_signature_free (signature);
 	mu_assert_streq (f->callconv, "amd64", "typed apply must sync live callconv");
 
@@ -426,7 +427,7 @@ bool test_r_anal_function_set_signature_uses_canonical_type_name(void) {
 	mu_end;
 }
 
-bool test_r_anal_function_get_signature_string_uses_import_flag_name(void) {
+bool test_r_anal_function_get_signature_string_resolves_import_flag_prototype(void) {
 	RCore *core = r_core_new ();
 	mu_assert_notnull (core, "Couldn't create new RCore");
 	RAnal *anal = core->anal;
@@ -442,7 +443,9 @@ bool test_r_anal_function_get_signature_string_uses_import_flag_name(void) {
 
 	char *sig = r_anal_function_get_signature_string (f);
 	mu_assert_notnull (sig, "import flag signature");
-	mu_assert_streq (sig, "int scanf (const char *fmt);", "import flag must resolve canonical type name");
+	// the prototype is resolved through the import flag, but the declaration
+	// names the function so that an unedited afs! cannot rename it
+	mu_assert_streq (sig, "int fcn.00003000 (const char *fmt);", "import flag must resolve canonical prototype");
 	free (sig);
 	r_core_free (core);
 	mu_end;
@@ -662,7 +665,7 @@ int all_tests(void) {
 	mu_run_test (test_r_anal_function_get_signature);
 	mu_run_test (test_r_anal_function_get_signature_prefers_exact_type_link);
 	mu_run_test (test_r_anal_function_set_signature_uses_canonical_type_name);
-	mu_run_test (test_r_anal_function_get_signature_string_uses_import_flag_name);
+	mu_run_test (test_r_anal_function_get_signature_string_resolves_import_flag_prototype);
 	mu_run_test (test_r_anal_function_get_signature_uses_basename_for_dbg_prefixed_function);
 	mu_run_test (test_r_anal_function_get_signature_string_falls_back_to_vars);
 	mu_run_test (test_r_anal_function_get_signature_string_hides_variadic_placeholder);


### PR DESCRIPTION
afs on sym.__write or a plt_call flag printed a void stub even when the types db carries the write prototype; consult r_type_func_guess before giving up on the name.