### PR TITLE
Scan the last 20 bytes of a range for ppc64 ELFv1 eager call stubs ##bin

### DIFF
--- a/libr/bin/format/elf/plt.c
+++ b/libr/bin/format/elf/plt.c
@@ -456,7 +456,8 @@ ut64 Elf_(ppc64_get_plt_stub_for_slot)(ELFOBJ *eo, ut64 slot_vaddr) {
 //   cmpldi r2, 0; bnectr+; b <glink stub>
 // the trailing branch into a known glink stub names the plt slot it serves
 #define PPC64_STD_R2_40R1 0xf8410028
-#define PPC64_TEXT_STUB_MIN 24
+// shortest form: std, ld, mtctr, ld r2, bctr
+#define PPC64_TEXT_STUB_MIN 20
 // longest form: std, addis, ld, mtctr, ld env, ld r2, cmpldi, bnectr, b
 #define PPC64_TEXT_STUB_MAX 36
 // bytes of executable ranges worth scanning for stubs before giving up

--- a/test/db/formats/elf/plt
+++ b/test/db/formats/elf/plt
@@ -144,6 +144,18 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ppc64 ELFv1: a 20-byte eager stub that fills the whole .text is named
+FILE=bins/elf/ppc64v1-stub-eagerend.so
+CMDS=<<EOF
+is~plt.~?
+is~plt.leaf
+EOF
+EXPECT=<<EOF
+1
+4   0x000002a0 0x000002a0 GLOBAL FUNC   20       plt.leaf
+EOF
+RUN
+
 NAME=ppc64 ELFv1: a bogus .text size is clamped to the file, .init still scanned
 FILE=bins/elf/ppc64v1-libz-badshdr.so
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The ppc64 ELFv1 `.text` call-stub scanner required at least 24 bytes, but the shortest eager stub bfd emits with `--no-plt-thread-safe` is 20:

     std r2, 0x28(r1); ld r12, d(r2); mtctr r12; ld r2, d(r2); bctr

So a stub that ends a scanned range was never offered to the matcher and its plt slot went unnamed. Lower `PPC64_TEXT_STUB_MIN` to 20; the maximum and the matcher itself are unchanged.

Test uses `bins/elf/ppc64v1-stub-eagerend.so` (radareorg/radare2-testbins#134), a `-nostdlib` ELFv1 `.so` whose `.text` is exactly that one 20-byte stub — it exercises both the minimum-size guard and the loop bound. Master names 0 stubs on it, this branch 1 (`plt.leaf`, size 20).