### PR TITLE
Fix the sbb carry, adjust and overflow flags in the x86 esil ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2046,13 +2046,24 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		{
 			ut32 bitsize;
 			src = getarg (&gop, 1, 0, NULL, NULL);
-			dst = getarg (&gop, 0, 1, "-", &bitsize);
-			if (src && dst) {
-				esilprintf (op, "cf,%s,+,%s,%d,$o,of,:=,%d,$s,sf,:=,$z,zf,:=,$p,pf,:=,%d,$b,cf,:=",
-					src, dst, bitsize - 1, bitsize - 1, bitsize);
+			dst_r = getarg (&gop, 0, 0, NULL, &bitsize);
+			dst_w = getarg (&gop, 0, 1, "-", NULL);
+			if (src && dst_r && dst_w && bitsize && bitsize <= 64) {
+				// borrows pushed before the write clobbers dst, popped after
+				esilprintf (op, "%s,%s,==,%u,$b,cf,$z,&,|,"
+					"0xf,%s,&,0xf,%s,&,==,4,$b,cf,$z,&,|,"
+					"cf,%s,+,%s,"
+					"%s,0x%"PFMT64x",-,!,cf,!,&,%u,$o,^,of,:=,"
+					"%u,$s,sf,:=,$z,zf,:=,$p,pf,:=,af,:=,cf,:=",
+					src, dst_r, bitsize,
+					src, dst_r,
+					src, dst_w,
+					src, (ut64)1ULL << (bitsize - 1), bitsize - 1,
+					bitsize - 1);
 			}
 			free (src);
-			free (dst);
+			free (dst_r);
+			free (dst_w);
 		}
 		break;
 	case X86_INS_LIDT:

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -2046,9 +2046,11 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		{
 			ut32 bitsize;
 			src = getarg (&gop, 1, 0, NULL, NULL);
-			dst = getarg (&gop, 0, 0, NULL, &bitsize);
-			esilprintf (op, "cf,%s,+,%s,-=,%d,$o,of,:=,%d,$s,sf,:=,$z,zf,:=,$p,pf,:=,%d,$b,cf,:=",
-				src, dst, bitsize - 1, bitsize - 1, bitsize);
+			dst = getarg (&gop, 0, 1, "-", &bitsize);
+			if (src && dst) {
+				esilprintf (op, "cf,%s,+,%s,%d,$o,of,:=,%d,$s,sf,:=,$z,zf,:=,$p,pf,:=,%d,$b,cf,:=",
+					src, dst, bitsize - 1, bitsize - 1, bitsize);
+			}
 			free (src);
 			free (dst);
 		}

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -739,3 +739,98 @@ EXPECT=<<EOF
 0x1111110f
 EOF
 RUN
+
+NAME=sbb borrows when the carry-in wraps the operand width
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 19c1
+ar rcx=0x0
+ar rax=0xffffffff
+ar cf=1
+aes
+ar rcx
+ar cf
+ar af
+ar zf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=sbb keeps the overflow correction off when the carry-in is set
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 19c1
+ar rcx=0x1
+ar rax=0x80000000
+ar cf=1
+aes
+ar rcx
+ar of
+ar cf
+ar sf
+EOF
+EXPECT=<<EOF
+0x80000000
+0x00000001
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=sbb overflows on an INT_MIN source without carry-in
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 19c1
+ar rcx=0x1
+ar rax=0x80000000
+ar cf=0
+aes
+ar rcx
+ar of
+ar cf
+EOF
+EXPECT=<<EOF
+0x80000001
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=sbb sets the adjust flag when the source nibble wraps
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 19c1
+ar rcx=0x0
+ar rax=0xf
+ar cf=1
+ar of=1
+aes
+ar rcx
+ar af
+ar cf
+ar of
+EOF
+EXPECT=<<EOF
+0xfffffff0
+0x00000001
+0x00000001
+0x00000000
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -702,3 +702,40 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=sbb 32-bit register write zero-extends
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 19c1
+ar rcx=0xffffffff00000005
+ar rax=1
+ar cf=1
+aes
+ar rcx
+EOF
+EXPECT=<<EOF
+0x00000003
+EOF
+RUN
+
+NAME=sbb stores to its memory destination
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 190e
+ar rsi=0x100100
+ar rcx=1
+ar cf=1
+wv4 0x11111111 @ 0x100100
+aes
+pv4 @ 0x100100
+EOF
+EXPECT=<<EOF
+0x1111110f
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Depends on #26513 (same `esilprintf`); merge that first.

`sbb`'s three flag defects, all in one expression:

- **CF** lost the borrow whenever `src + cf` wrapped the operand width. The sum is evaluated at 64 bits, so an all-ones source with carry-in never wraps and the `$b` borrow test read 0. Now `borrow | (cf & (dst == src))`, from a comparison taken before the destination is written.
- **AF** was never emitted. Note `esil_bf` maps `n,$b` to `genmask(n-1)`, so the `3,$b` used elsewhere tests bit 2 rather than the nibble borrow out of bit 4;  this uses a nibble-masked compare with `4,$b`.
- **OF** was wrong for an INT_MIN source. The correction has to be suppressed when carry-in is set: `sbb src=0x7f,cf=1` and `sub src=0x80` are the same arithmetic but different overflow, since the signed subtrahend is +127 rather than -128.

CF and AF are pushed before the write and popped after it, as their operands are gone once the destination changes — the same shape aarch64 `SBCS` uses.

A Unicorn differential over widths 8/16/32/64 and all (dst, src, carry) combinations goes from 420/926 to 926/926, and 4562/9398 to 9398/9398 on randomized inputs; all 131072 exhaustive 8-bit cases match. Four tests added, and the full r2r suite is clean.

`sub`'s own `3,$b` adjust flag has the bit-position bug described above; left for a separate change as it moves x86 goldens.