### PR TITLE
Zero-extend the 32-bit registers the x86 esil writes by hand ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -1219,22 +1219,6 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			free (dst);
 		}
 		break;
-	case X86_INS_SAR:
-		// TODO: Set CF. See case X86_INS_SHL for more details.
-		{
-		ut32 bitsize;
-		char *count = getarg (&gop, 1, 0, NULL, NULL);
-		dst_r = getarg (&gop, 0, 0, NULL, NULL);
-		dst_w = getarg (&gop, 0, 1, NULL, &bitsize);
-		src = shift_count (count, bitsize);
-		free (count);
-		esilprintf (op, "0,cf,:=,1,%s,-,1,<<,%s,&,?{,1,cf,:=,},%s,%s,ASR,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=",
-			src, dst_r, src, dst_r, dst_w, bitsize - 1);
-		free (src);
-		free (dst_r);
-		free (dst_w);
-	}
-	break;
 	case X86_INS_SARX:
 		{
 			dst = getarg (&gop, 0, 1, NULL, NULL);
@@ -1259,12 +1243,14 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		// pre-shift value; OF is defined only for 1-bit shifts as msb(result) ^ CF.
 		// Read via dst_r, write via dst_w so memory destinations store the result.
 		esilprintf (op,
+			"%s,?{,"
 			"%s,%d,-,%s,>>,1,&,cf,:=,"
 			"%s,%s,<<,%s,"
 			"$z,zf,:=,"
 			"$p,pf,:=,"
 			"%d,$s,sf,:=,"
-			"%d,%s,>>,1,&,cf,^,of,:=",
+			"%d,%s,>>,1,&,cf,^,of,:=,}",
+			src,
 			src, bitsize, dst_r,
 			src, dst_r, dst_w,
 			bitsize - 1,
@@ -1277,9 +1263,9 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_SALC:
 		esilprintf (op, "$z,DUP,zf,=,al,=");
 		break;
+	case X86_INS_SAR:
 	case X86_INS_SHR:
 	case X86_INS_SHRX:
-		// TODO: Set CF: See case X86_INS_SAL for more details.
 		{
 			ut32 bitsize;
 			char *count = getarg (&gop, 1, 0, NULL, NULL);
@@ -1288,8 +1274,10 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			src = count? shift_count (count, bitsize): NULL;
 			free (count);
 			if (src && dst_r && dst_w) {
-				esilprintf (op, "0,cf,:=,1,%s,-,1,<<,%s,&,?{,1,cf,:=,},%s,%s,>>,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=",
-					src, dst_r, src, dst_r, dst_w, bitsize - 1);
+				// x86 leaves the destination and all flags alone on a 0 count
+				const char *shop = (insn->id == X86_INS_SAR)? "ASR": ">>";
+				esilprintf (op, "%s,?{,1,%s,-,%s,>>,1,&,cf,:=,%s,%s,%s,%s,$z,zf,:=,$p,pf,:=,%d,$s,sf,:=,}",
+					src, src, dst_r, src, dst_r, shop, dst_w, bitsize - 1);
 			}
 			free (src);
 			free (dst_r);

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -1896,11 +1896,12 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
 			if (strcmp (src, dst)) {
+				// the loop target counts the extra tokens of a memory source
 				const ut32 commas = r_str_char_count (src, ',');
 				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,},"
 						"0x%"PFMT64x",%s,:=,"
 						"%s,++,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, UT64_MAX, dst, dst, dst, dst, src, 11 + commas * 2);
+						src, UT64_MAX, dst, dst, dst, dst, src, 11 + commas);
 			} else {
 				// unroll the loop to avoid use of DUP operation
 				const ut32 bits = INSOP (0).size * 8;
@@ -1927,7 +1928,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,},"
 						"%d,%s,:=,"
 						"%s,--,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, bits, dst, dst, dst, dst, src, 11 + commas * 2);
+						src, bits, dst, dst, dst, dst, src, 11 + commas);
 			} else {
 				// unroll the loop to avoid use of DUP operation
 				ut32 i = bits - 1;

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -114,9 +114,8 @@ struct Getarg {
 	cs_insn *insn;
 	int bits;
 	int syntax; // R_ARCH_SYNTAX_ATT or R_ARCH_SYNTAX_INTEL
-	// bare 32-bit register destination in 64-bit mode, and its 64-bit name
-	char zext32[16];
-	char zext64[16];
+	// pending zero-extensions for the 32-bit registers this op writes
+	char zext[32];
 };
 
 // TODO: get rid of this unnecessary wrapper
@@ -319,6 +318,37 @@ static inline bool get64from32(const char *s, char *out, size_t outsz) {
 	return false;
 }
 
+// writing a 32-bit register zero-extends into its 64-bit half, which ESIL wont
+static void zext_reg(struct Getarg *gop, const char *reg) {
+	char r64[16], pair[24];
+	if (!reg || gop->bits != 64 || !get64from32 (reg, r64, sizeof (r64))) {
+		return;
+	}
+	snprintf (pair, sizeof (pair), ",%s,%s,=", reg, r64);
+	const size_t len = strlen (gop->zext);
+	// drop rather than truncate: a half-copied pair is a corrupt esil token
+	if (!strstr (gop->zext, pair) && len + strlen (pair) < sizeof (gop->zext)) {
+		r_str_ncpy (gop->zext + len, pair, sizeof (gop->zext) - len);
+	}
+}
+
+static void zext_opnd(struct Getarg *gop, int n) {
+	const cs_x86 *x = &gop->insn->detail->x86;
+	const cs_x86_op *op = &x->operands[norm_op (n, gop->syntax, x->op_count)];
+	if (op->type == X86_OP_REG) {
+		zext_reg (gop, cs_reg_name (gop->handle, op->reg));
+	}
+}
+
+// a scan that breaks out never reaches the tail, so it extends before scanning
+static void zext_prefix(struct Getarg *gop, const char *reg, char *out, size_t sz) {
+	char r64[16];
+	*out = 0;
+	if (gop->bits == 64 && reg && get64from32 (reg, r64, sizeof (r64))) {
+		snprintf (out, sz, ",%s,%s,=", reg, r64);
+	}
+}
+
 static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsize) {
 	const char *setarg = r_str_get (setop);
 	cs_insn *insn = gop->insn;
@@ -358,11 +388,7 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsi
 					rn = stbuf;
 				}
 				if (set == 1) {
-					// writing eax zero-extends into rax, which ESIL wont do on its own
-					if (gop->bits == 64
-						&& get64from32 (rn, gop->zext64, sizeof (gop->zext64))) {
-						r_str_ncpy (gop->zext32, rn, sizeof (gop->zext32));
-					}
+					zext_reg (gop, rn);
 					return r_str_newf ("%s,%s=", rn, setarg);
 				}
 				return strdup (rn);
@@ -507,8 +533,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		.insn = insn,
 		.bits = bits,
 		.syntax = as->config->syntax,
-		.zext32 = {0},
-		.zext64 = {0}
+		.zext = {0}
 	};
 	char *src = NULL;
 	char *src2 = NULL;
@@ -1113,23 +1138,14 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 				// dst is name of register from instruction.
 				dst = getarg (&gop, 0, 0, NULL, NULL);
 				char dst64[16];
-				const bool havedst = get64from32 (dst, dst64, sizeof (dst64));
-				if (bits == 64 && havedst) {
-					// Here it is still correct, because 'e** = X'
-					// turns into 'r** = X' (first one will keep higher bytes,
-					// second one will overwrite them with zeros).
-					if (insn->id == X86_INS_MOVSX || insn->id == X86_INS_MOVSXD) {
-						esilprintf (op, "%d,%s,~,%s,=", width*8, src, dst64);
-					} else {
-						esilprintf (op, "%s,%s,=", src, dst64);
-					}
-
+				const bool wide = bits == 64 && get64from32 (dst, dst64, sizeof (dst64));
+				if (insn->id == X86_INS_MOVSX || insn->id == X86_INS_MOVSXD) {
+					// the sign extension stops at the 32-bit destination
+					zext_opnd (&gop, 0);
+					esilprintf (op, "%d,%s,~,%s,=", width*8, src, dst);
 				} else {
-					if (insn->id == X86_INS_MOVSX || insn->id == X86_INS_MOVSXD) {
-						esilprintf (op, "%d,%s,~,%s,=", width*8, src, dst);
-					} else {
-						esilprintf (op, "%s,%s,=", src, dst);
-					}
+					// writing the 64-bit name zeroes the high half in one go
+					esilprintf (op, "%s,%s,=", src, wide? dst64: dst);
 				}
 				free (src);
 				free (dst);
@@ -1326,12 +1342,14 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		esilprintf (op, "al,ax,=,7,ax,>>,?{,0xff00,ax,|=,}");
 		break;
 	case X86_INS_CWDE:
+		zext_reg (&gop, "eax");
 		esilprintf (op, "ax,eax,=,15,eax,>>,?{,0xffff0000,eax,|=,}");
 		break;
 	case X86_INS_CWD:
 		esilprintf (op, "0,dx,=,15,ax,>>,?{,0xffff,dx,=,}");
 		break;
 	case X86_INS_CDQ:
+		zext_reg (&gop, "edx");
 		esilprintf (op, "0,edx,=,31,eax,>>,?{,0xffffffff,edx,=,}");
 		break;
 	case X86_INS_CQO:
@@ -1895,18 +1913,21 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		{
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
+			char pre[24];
+			zext_prefix (&gop, dst, pre, sizeof (pre));
 			if (strcmp (src, dst)) {
-				// the loop target counts the extra tokens of a memory source
-				const ut32 commas = r_str_char_count (src, ',');
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,},"
+				// the loop target shifts by the tokens the prefix and src add
+				const ut32 extra = r_str_char_count (src, ',')
+					+ r_str_char_count (pre, ',');
+				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s,"
 						"0x%"PFMT64x",%s,:=,"
 						"%s,++,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, UT64_MAX, dst, dst, dst, dst, src, 11 + commas);
+						src, pre, UT64_MAX, dst, dst, dst, dst, src, 11 + extra);
 			} else {
 				// unroll the loop to avoid use of DUP operation
 				const ut32 bits = INSOP (0).size * 8;
 				ut32 i = 0;
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}", src);
+				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s", src, pre);
 				for (; i < bits - 1; i++) {
 					r_strbuf_appendf (&op->esil, ",0x%"PFMT64x",%s,&,?{,%d,%s,:=,BREAK,}",
 						((ut64)1) << i, src, i, dst);
@@ -1922,17 +1943,20 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
 			const ut32 bits = INSOP (0).size * 8;
+			char pre[24];
 
+			zext_prefix (&gop, dst, pre, sizeof (pre));
 			if (strcmp (src, dst)) {
-				const ut32 commas = r_str_char_count (src, ',');
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,},"
+				const ut32 extra = r_str_char_count (src, ',')
+					+ r_str_char_count (pre, ',');
+				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s,"
 						"%d,%s,:=,"
 						"%s,--,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, bits, dst, dst, dst, dst, src, 11 + commas);
+						src, pre, bits, dst, dst, dst, dst, src, 11 + extra);
 			} else {
 				// unroll the loop to avoid use of DUP operation
 				ut32 i = bits - 1;
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}", src);
+				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s", src, pre);
 				for (; i; i--) {
 					r_strbuf_appendf (&op->esil, ",0x%"PFMT64x",%s,&,?{,%d,%s,:=,BREAK,}",
 						((ut64)1) << i, src, i, dst);
@@ -1946,6 +1970,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_BSWAP:
 		{
 			dst = getarg (&gop, 0, 0, NULL, NULL);
+			zext_opnd (&gop, 0);
 			if (INSOP(0).size == 4) {
 				esilprintf (op, "0xff000000,24,%s,NUM,<<,&,24,%s,NUM,>>,|,"
 						"8,0x00ff0000,%s,NUM,&,>>,|,"
@@ -2169,6 +2194,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 					const char *r_rema = (width == 1)?"ah": (width == 2)?"dx": (width == 4)?"edx":"rdx";
 					const char *r_nume = (width == 1)?"ax": r_quot;
 
+					zext_reg (&gop, r_quot);
+					zext_reg (&gop, r_rema);
 					esilprintf (op, "%d,%s,~,%d,%s,<<,%s,+,~%%,%d,%s,~,%d,%s,<<,%s,+,~/,%s,=,%s,=",
 							width*8, arg0, width*8, r_rema, r_nume, width*8, arg0, width*8, r_rema, r_nume, r_quot, r_rema);
 				}
@@ -2194,6 +2221,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			const char *r_nume = (width == 1)?"ax": r_quot;
 			// DIV does not change flags and is unsigned
 
+			zext_reg (&gop, r_quot);
+			zext_reg (&gop, r_rema);
 			esilprintf (op, "%s,%d,%s,<<,%s,+,%%,%s,%d,%s,<<,%s,+,/,%s,=,%s,=",
 					dst, width*8, r_rema, r_nume, dst, width*8, r_rema, r_nume, r_quot, r_rema);
 			free (dst);
@@ -2212,6 +2241,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 				if (arg2) {
 					multiplier = arg2;
 				}
+				zext_opnd (&gop, 0);
 				esilprintf (op, "%d,%s,~,%d,%s,~,*,DUP,%s,=,%d,%s,~,-,!,!,DUP,cf,:=,of,:=",
 					width*8, multiplier, width*8, arg1, arg0, width*8, arg0);
 			} else {
@@ -2220,6 +2250,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 					const char *r_rema = (width == 1)?"ah": (width==2)?"dx": (width==4)?"edx":"rdx";
 					const char *r_nume = (width == 1)?"ax": r_quot;
 
+					zext_reg (&gop, r_nume);
+					zext_reg (&gop, r_rema);
 					if (width == 8) { // TODO still needs to be fixed to handle correct signed 128 bit value
 						esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=", // flags will be sometimes wrong
 								arg0, r_nume, r_nume, r_rema);
@@ -2243,6 +2275,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 				const char *r_rema = (width == 1)?"ah": (width == 2)?"dx": (width == 4)?"edx":"rdx";
 				const char *r_nume = (width == 1)?"ax": r_quot;
 
+				zext_reg (&gop, r_nume);
+				zext_reg (&gop, r_rema);
 				if (width == 8 ) {
 					esilprintf (op, "%s,%s,L*,%s,=,DUP,%s,=,!,!,DUP,cf,:=,of,:=",
 							src, r_nume, r_nume, r_rema);
@@ -2320,6 +2354,8 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		{
 			dst = getarg (&gop, 0, 0, NULL, NULL);
 			src = getarg (&gop, 1, 0, NULL, NULL);
+			zext_opnd (&gop, 0);
+			zext_opnd (&gop, 1);
 			if (!strcmp (src, dst)) {
 				esilprintf (op, ",");
 			} else if (INSOP(0).type == X86_OP_MEM) {
@@ -2351,6 +2387,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
 			dstAdd = getarg (&gop, 0, 1, "+", NULL);
+			zext_opnd (&gop, 1);
 			if (INSOP(0).type == X86_OP_MEM) {
 				dst2 = getarg (&gop, 0, 1, NULL, NULL);
 				esilprintf (op,
@@ -2743,9 +2780,9 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		r_strbuf_prepend (&op->esil, counter);
 		r_strbuf_appendf (&op->esil, ",%s,--=,zf,?{,BREAK,},0,GOTO", counter);
 	}
-	if (*gop.zext64 && r_strbuf_length (&op->esil) > 0) {
+	if (R_STR_ISNOTEMPTY (gop.zext) && r_strbuf_length (&op->esil) > 0) {
 		// after the flag assignments, so this doesnt disturb the comparison state
-		r_strbuf_appendf (&op->esil, ",%s,%s,=", gop.zext32, gop.zext64);
+		r_strbuf_append (&op->esil, gop.zext);
 	}
 }
 

--- a/test/db/cmd/cmd_aea
+++ b/test/db/cmd/cmd_aea
@@ -4,7 +4,7 @@ ARGS=-a x86 -b64
 CMDS=wx 4889e5b8ffff000089c2c1ea1f01d0;aea 5
 EXPECT=<<EOF
  I: rsp eax edx
- A: rsp rbp rax eax rdx cf edx zf pf sf of af
+ A: rsp rbp rax eax rdx edx cf zf pf sf of af
  R: rsp eax edx
  W: rbp rax rdx cf edx zf pf sf eax of af
  V: 0 65535 1
@@ -24,8 +24,8 @@ EXPECT=<<EOF
     "rax",
     "eax",
     "rdx",
-    "cf",
     "edx",
+    "cf",
     "zf",
     "pf",
     "sf",
@@ -73,7 +73,7 @@ ARGS=-a x86 -b64
 CMDS=wx 4889e5b8ffff000089c2c1ea1f01d0;aeA 15
 EXPECT=<<EOF
  I: rsp eax edx
- A: rsp rbp rax eax rdx cf edx zf pf sf of af
+ A: rsp rbp rax eax rdx edx cf zf pf sf of af
  R: rsp eax edx
  W: rbp rax rdx cf edx zf pf sf eax of af
  V: 0 65535 1

--- a/test/db/cmd/cmd_pdr
+++ b/test/db/cmd/cmd_pdr
@@ -222,7 +222,7 @@ EXPECT=<<EOF
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
+          "esil": "253,0x1f,&,?{,1,253,0x1f,&,-,ebx,>>,1,&,cf,:=,253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,},ebx,rbx,=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,
@@ -413,7 +413,7 @@ jmp 3
         {
           "addr": 9,
           "val": 253,
-          "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
+          "esil": "253,0x1f,&,?{,1,253,0x1f,&,-,ebx,>>,1,&,cf,:=,253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,},ebx,rbx,=",
           "refptr": 0,
           "fcn_addr": 0,
           "fcn_last": 16,

--- a/test/db/cmd/midbb
+++ b/test/db/cmd/midbb
@@ -176,7 +176,7 @@ EXPECT=<<EOF
   {
     "addr": 9,
     "val": 253,
-    "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
+    "esil": "253,0x1f,&,?{,1,253,0x1f,&,-,ebx,>>,1,&,cf,:=,253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,},ebx,rbx,=",
     "refptr": 0,
     "fcn_addr": 0,
     "fcn_last": 16,
@@ -457,7 +457,7 @@ EXPECT=<<EOF
     {
       "addr": 9,
       "val": 253,
-      "esil": "0,cf,:=,1,253,0x1f,&,-,1,<<,ebx,&,?{,1,cf,:=,},253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,ebx,rbx,=",
+      "esil": "253,0x1f,&,?{,1,253,0x1f,&,-,ebx,>>,1,&,cf,:=,253,0x1f,&,ebx,>>,ebx,=,$z,zf,:=,$p,pf,:=,31,$s,sf,:=,},ebx,rbx,=",
       "refptr": 0,
       "fcn_addr": 0,
       "fcn_last": 16,

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -119,7 +119,7 @@ e asm.bits=64
 EOF
 EXPECT=<<EOF
 imul eax, ecx
-0x00000000 32,eax,~,32,ecx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=
+0x00000000 32,eax,~,32,ecx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=,eax,rax,=
 EOF
 RUN
 
@@ -209,7 +209,7 @@ EOF
 EXPECT=<<EOF
 opcode: imul eax, ebx, 0x89
 esilcost: 0
-esil: 32,137,~,32,ebx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=
+esil: 32,137,~,32,ebx,~,*,DUP,eax,=,32,eax,~,-,!,!,DUP,cf,:=,of,:=,eax,rax,=
 EOF
 RUN
 
@@ -1047,36 +1047,197 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=bsf scans a memory source
+NAME=imul zero-extends its 32-bit register destination
 FILE=malloc://0x100
 ARGS=-a x86 -b 64
 CMDS=<<EOF
 aei
 aeim
-wx 0fbc0e
-ar rsi=0x100100
-wv4 0x100 @ 0x100100
+wx 0fafca
+ar rcx=0xffffffff00000003
+ar rdx=4
 aes
-ar ecx
+ar rcx
+EOF
+EXPECT=<<EOF
+0x0000000c
+EOF
+RUN
+
+NAME=mul zero-extends both of its implicit destinations
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx f7e1
+ar rax=0xffffffff00000003
+ar rcx=0xffffffff00000002
+ar rdx=0xdeadbeef00000000
+aes
+ar rax
+ar rdx
+EOF
+EXPECT=<<EOF
+0x00000006
+0x00000000
+EOF
+RUN
+
+NAME=div zero-extends the quotient and the remainder
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx f7f1
+ar rax=0xffffffff0000000d
+ar rdx=0xdeadbeef00000000
+ar rcx=4
+aes
+ar rax
+ar rdx
+EOF
+EXPECT=<<EOF
+0x00000003
+0x00000001
+EOF
+RUN
+
+NAME=bswap zero-extends its 32-bit destination
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fc9
+ar rcx=0xffffffff12345678
+aes
+ar rcx
+EOF
+EXPECT=<<EOF
+0x78563412
+EOF
+RUN
+
+NAME=bsf zero-extends when the destination is also the source
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fbcc9
+ar rcx=0xffffffff00000100
+aes
+ar rcx
 EOF
 EXPECT=<<EOF
 0x00000008
 EOF
 RUN
 
-NAME=bsr scans a memory source
+NAME=bsr zero-extends its 32-bit destination
 FILE=malloc://0x100
 ARGS=-a x86 -b 64
 CMDS=<<EOF
 aei
 aeim
-wx 0fbd0e
-ar rsi=0x100100
-wv4 0x100 @ 0x100100
+wx 0fbdca
+ar rcx=0xffffffff00000000
+ar rdx=0x80000100
 aes
-ar ecx
+ar rcx
+EOF
+EXPECT=<<EOF
+0x0000001f
+EOF
+RUN
+
+NAME=cwde zero-extends eax into rax
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 98
+ar rax=0xffffffff00008000
+aes
+ar rax
+EOF
+EXPECT=<<EOF
+0xffff8000
+EOF
+RUN
+
+NAME=cdq zero-extends edx into rdx
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 99
+ar rax=0x80000000
+ar rdx=0xa5a5000100000000
+aes
+ar rdx
+EOF
+EXPECT=<<EOF
+0xffffffff
+EOF
+RUN
+
+NAME=movsx stops the sign extension at its 32-bit destination
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fbec8
+ar rax=0x80
+ar rcx=0xffffffff00000000
+aes
+ar rcx
+EOF
+EXPECT=<<EOF
+0xffffff80
+EOF
+RUN
+
+NAME=xchg zero-extends both of its 32-bit registers
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 87ca
+ar rdx=0xffffffff00000001
+ar rcx=0xaaaaaaaa00000002
+aes
+ar rdx
+ar rcx
+EOF
+EXPECT=<<EOF
+0x00000002
+0x00000001
+EOF
+RUN
+
+NAME=xadd zero-extends the register it exchanges into
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fc1d1
+ar rcx=0xffffffff00000005
+ar rdx=0xaaaaaaaa00000003
+aes
+ar rcx
+ar rdx
 EOF
 EXPECT=<<EOF
 0x00000008
+0x00000005
 EOF
 RUN
+

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1241,3 +1241,90 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=shr does nothing when the count masks to zero
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx d3ea
+ar rdx=0xa5a5000380000005
+ar rcx=32
+ar cf=1
+ar zf=1
+aes
+ar rdx
+ar cf
+ar zf
+EOF
+EXPECT=<<EOF
+0x80000005
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=sar does nothing when the count is zero
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx d3fa
+ar rdx=0xa5a5000380000005
+ar rcx=0
+ar cf=1
+ar sf=1
+aes
+ar rdx
+ar cf
+ar sf
+EOF
+EXPECT=<<EOF
+0x80000005
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=shl does nothing when the count masks to zero
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx d3e2
+ar rdx=0xa5a5000380000005
+ar rcx=64
+ar cf=1
+ar of=1
+aes
+ar rdx
+ar cf
+ar of
+EOF
+EXPECT=<<EOF
+0x80000005
+0x00000001
+0x00000001
+EOF
+RUN
+
+NAME=shr by one still shifts and sets the carry
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx d3ea
+ar rdx=0xa5a5000380000004
+ar rcx=1
+aes
+ar rdx
+ar cf
+EOF
+EXPECT=<<EOF
+0x40000002
+0x00000000
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1046,3 +1046,37 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=bsf scans a memory source
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fbc0e
+ar rsi=0x100100
+wv4 0x100 @ 0x100100
+aes
+ar ecx
+EOF
+EXPECT=<<EOF
+0x00000008
+EOF
+RUN
+
+NAME=bsr scans a memory source
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx 0fbd0e
+ar rsi=0x100100
+wv4 0x100 @ 0x100100
+aes
+ar ecx
+EOF
+EXPECT=<<EOF
+0x00000008
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three related x86 ESIL fixes, one commit each.

- **bsf/bsr with a memory source computed nothing.** The hand-written `GOTO` target counted `commas * 2`, but a token is worth one comma, so the scan jumped past its loop head and hit `++` on an empty stack: `bsf ecx, [rsi]` left the destination untouched, silently, on every memory source.
- **Zero-extension of hand-written destinations.** The tail added in #26495 only fires for destinations written through `getarg (…, set=1, …)`; `imul`, `mul`, `div`, `idiv`, `bswap`, `bsf`, `bsr`, `cwde`, `cdq`, `xchg`, `xadd` and `movsx` all write their 32-bit destination by hand and so never reached it. A small recorder now feeds that same tail from those sites, and `movsx` stops sign-extending past its 32-bit destination.
- **A shift count that masks to zero.** `1,count,-` underflows to `UT64_MAX` and `esil_lsl` refuses a shift above 64, so the rest of the expression was dropped — including the destination write. Skipping the body on a zero count is what x86 requires anyway: no write, no flags.

Measured against Unicorn over poisoned register seeds (high halves neither 0 nor all-ones, so stale / zero-extended / sign-extended are distinguishable): x86-64 88 -> 47 failing cases, 41 fixed and none introduced; x86-32 32 -> 27, none introduced. 17 tests in `db/esil/x86_64`, each confirmed to fail without the fix. Three goldens outside `db/esil` (`cmd_aea`, `cmd_pdr`, `midbb`) pin shift ESIL text and are updated with it; the register sets are unchanged.