### PR TITLE
Model the mips 32-bit instruction forms at 32 bits ##esil

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -170,6 +170,12 @@ static inline void es_add_ck(RAnalOp *op, const char *a1, const char *a2, const 
 			ARG(1), REG(0));\
 	}
 
+#define ESIL_LOAD_SIGNED(size, sbits) \
+	PROTECT_ZERO () {\
+		r_strbuf_appendf (&op->esil, sbits",%s,["size"],~,%s,=",\
+			ARG(1), REG(0));\
+	}
+
 static void opex(RStrBuf *buf, csh handle, cs_insn *insn) {
 	int i;
 	PJ *pj = pj_new ();
@@ -320,22 +326,29 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 			r_strbuf_appendf (&op->esil,
 				"0xffffffff,%s,%s,>>,&,31,%s,>>,?{,%s,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
 				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
+			ES_SIGN32_64 (ARG (0));
 			break;
 		case MIPS_INS_SRAV:
 			// like SRA but the shift amount is rs & 0x1f
 			r_strbuf_appendf (&op->esil,
 				"0xffffffff,%s,0x1f,&,%s,>>,&,31,%s,>>,?{,%s,0x1f,&,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
 				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
+			ES_SIGN32_64 (ARG (0));
 			break;
 		case MIPS_INS_SHRL:
 			// suffix 'S' forces conditional flag to be updated
 		case MIPS_INS_SRLV:
 		case MIPS_INS_SRL:
-			r_strbuf_appendf (&op->esil, "%s,%s,>>,%s,=", ARG (2), ARG (1), ARG (0));
+			// srl shifts the zero-extended low word, not the whole register
+			r_strbuf_appendf (&op->esil, "0x1f,%s,&," ES_W ("%s") ",>>,%s,=",
+				ARG (2), ARG (1), ARG (0));
+			ES_SIGN32_64 (ARG (0));
 			break;
 		case MIPS_INS_SLLV:
 		case MIPS_INS_SLL:
-			r_strbuf_appendf (&op->esil, "%s,%s,<<,%s,=", ARG (2), ARG (1), ARG (0));
+			r_strbuf_appendf (&op->esil, "0x1f,%s,&,%s,<<,%s,=",
+				ARG (2), ARG (1), ARG (0));
+			ES_SIGN32_64 (ARG (0));
 			break;
 		case MIPS_INS_BALC:
 			// BALC address
@@ -555,12 +568,16 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				PROTECT_ZERO () {
 					r_strbuf_appendf (&op->esil, "%s,%s,-,%s,=",
 						ARG (2), ARG (1), ARG (0));
+					if (insn->id == MIPS_INS_SUB || insn->id == MIPS_INS_SUBU) {
+						ES_SIGN32_64 (ARG (0));
+					}
 				}
 				break;
 			case MIPS_INS_NEG:
 			case MIPS_INS_NEGU:
-				r_strbuf_appendf (&op->esil, "%s,0,-,%s,=,",
+				r_strbuf_appendf (&op->esil, "%s,0,-,%s,=",
 					ARG (1), ARG (0));
+				ES_SIGN32_64 (ARG (0));
 				break;
 
 			/** signed -- sets overflow flag */
@@ -597,6 +614,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 							r_strbuf_appendf (&op->esil, "%s,%s,+,%s,=",
 								arg2, arg1, arg0);
 						}
+						if (insn->id == MIPS_INS_ADDU || insn->id == MIPS_INS_ADDIU) {
+							ES_SIGN32_64 (arg0);
+						}
 					}
 				}
 				break;
@@ -606,22 +626,29 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				break;
 			case MIPS_INS_LUI:
 				r_strbuf_appendf (&op->esil, "0x%" PFMT64x "0000,%s,=", (ut64)IMM(1), ARG(0));
+				ES_SIGN32_64 (ARG (0));
 				break;
 			case MIPS_INS_LB:
 				op->sign = true;
-				ESIL_LOAD ("1");
+				ESIL_LOAD_SIGNED ("1", "8");
 				break;
 			case MIPS_INS_LBU:
-				//one of these is wrong
 				ESIL_LOAD ("1");
 				break;
 			case MIPS_INS_LW:
+			case MIPS_INS_LL:
+				// on mips64 the word is sign-extended; lwu is the other form
+				if (as->config->bits == 64) {
+					ESIL_LOAD_SIGNED ("4", "32");
+				} else {
+					ESIL_LOAD ("4");
+				}
+				break;
 			case MIPS_INS_LWC1:
 			case MIPS_INS_LWC2:
 			case MIPS_INS_LWL:
 			case MIPS_INS_LWR:
 			case MIPS_INS_LWU:
-			case MIPS_INS_LL:
 				ESIL_LOAD ("4");
 				break;
 
@@ -633,10 +660,13 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				ESIL_LOAD ("8");
 				break;
 
-			case MIPS_INS_LWX:
 			case MIPS_INS_LH:
-			case MIPS_INS_LHU:
 			case MIPS_INS_LHX:
+				op->sign = true;
+				ESIL_LOAD_SIGNED ("2", "16");
+				break;
+			case MIPS_INS_LWX:
+			case MIPS_INS_LHU:
 				ESIL_LOAD ("2");
 				break;
 

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -722,22 +722,17 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				break;
 			case MIPS_INS_SLT:
 			case MIPS_INS_SLTI:
-				if (OPCOUNT () < 3) {
-					r_strbuf_appendf (&op->esil, "%s,%s,<,t,=", ARG(1), ARG(0));
-				} else {
-					r_strbuf_appendf (&op->esil, "%s,%s,<,%s,=", ARG(2), ARG(1), ARG(0));
-				}
-				break;
 			case MIPS_INS_SLTU:
 			case MIPS_INS_SLTIU:
 				{
 					const bool two = OPCOUNT () < 3;
+					const bool sign = insn->id == MIPS_INS_SLT || insn->id == MIPS_INS_SLTI;
 					const char *rt = two? ARG (1): ARG (2);
 					const char *rs = two? ARG (0): ARG (1);
 					const char *rd = two? "t": ARG (0);
-					r_strbuf_appendf (&op->esil, (as->config->bits == 64)
-						? ES_U("%s")","ES_U("%s")",<,%s,="
-						: ES_W("%s")","ES_W("%s")",<,%s,=", rt, rs, rd);
+					r_strbuf_appendf (&op->esil, sign? "%s,%s,<,%s,=":
+						(as->config->bits == 64)? ES_U("%s")","ES_U("%s")",<,%s,=":
+						ES_W("%s")","ES_W("%s")",<,%s,=", rt, rs, rd);
 				}
 				break;
 			case MIPS_INS_MUL:

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -98,6 +98,8 @@ R_IPI int mips_assemble(const char *str, ut64 pc, ut8 *out);
 #define ES_B(x) "0xff,"x",&"
 #define ES_H(x) "0xffff,"x",&"
 #define ES_W(x) "0xffffffff,"x",&"
+// esil '<' is signed: biasing by the sign bit makes it order values unsigned
+#define ES_U(x) "0x8000000000000000,"x",^"
 
 // sign extend 32 -> 64
 #define ES_SIGN32_64(arg)	es_sign_n_64 (as, op, arg, 32)
@@ -728,12 +730,14 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				break;
 			case MIPS_INS_SLTU:
 			case MIPS_INS_SLTIU:
-				if (OPCOUNT () < 3) {
-					r_strbuf_appendf (&op->esil, ES_W("%s")","ES_W("%s")",<,t,=",
-						ARG (1), ARG (0));
-				} else {
-					r_strbuf_appendf (&op->esil, ES_W("%s")","ES_W("%s")",<,%s,=",
-						ARG (2), ARG (1), ARG (0));
+				{
+					const bool two = OPCOUNT () < 3;
+					const char *rt = two? ARG (1): ARG (2);
+					const char *rs = two? ARG (0): ARG (1);
+					const char *rd = two? "t": ARG (0);
+					r_strbuf_appendf (&op->esil, (as->config->bits == 64)
+						? ES_U("%s")","ES_U("%s")",<,%s,="
+						: ES_W("%s")","ES_W("%s")",<,%s,=", rt, rs, rd);
 				}
 				break;
 			case MIPS_INS_MUL:
@@ -748,9 +752,12 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				ES_SIGN32_64 ("hi");
 				break;
 			case MIPS_INS_MULTU:
-				r_strbuf_appendf (&op->esil, ES_W("%s,%s,*")",lo,=", ARG (0), ARG (1));
+				// the low words are the operands: masking the product is not enough
+				r_strbuf_appendf (&op->esil, ES_W(ES_W("%s")","ES_W("%s")",*")",lo,=",
+					ARG (0), ARG (1));
 				ES_SIGN32_64 ("lo");
-				r_strbuf_appendf (&op->esil, ES_W("32,%s,%s,*,>>")",hi,=", ARG (0), ARG (1));
+				r_strbuf_appendf (&op->esil, "32,"ES_W("%s")","ES_W("%s")",*,>>,hi,=",
+					ARG (0), ARG (1));
 				ES_SIGN32_64 ("hi");
 				break;
 			case MIPS_INS_MFLO:

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -43,6 +43,8 @@ DECLARE_GENERIC_FPRINTF_FUNC_NOGLOBALS ()
 #define ES_B(x) "0xff," x ",&"
 #define ES_H(x) "0xffff," x ",&"
 #define ES_W(x) "0xffffffff," x ",&"
+// esil '<' is signed: biasing by the sign bit makes it order values unsigned
+#define ES_U(x) "0x8000000000000000," x ",^"
 
 // Call with delay slot.
 #define ES_CALL_DR(ra, addr) "pc,4,+,"ra",=,"ES_J_D(addr)
@@ -76,6 +78,19 @@ static inline void es_sign_n_64(RArchSession *as, RAnalOp *op, const char *arg, 
 	} else {
 		r_strbuf_append (&op->esil, ",");
 	}
+}
+
+// mips64 compares the whole register; at 32 bits the 64-bit gpr profile needs the narrowing
+static inline const char *es_slt_fmt(RArchSession *as) {
+	return (as->config->bits == 64)
+		? "%s,%s,<,%s,="
+		: "32,%s,~,32,%s,~,<,%s,=";
+}
+
+static inline const char *es_sltu_fmt(RArchSession *as) {
+	return (as->config->bits == 64)
+		? ES_U ("%s") "," ES_U ("%s") ",<,%s,="
+		: ES_W ("%s") "," ES_W ("%s") ",<,%s,=";
 }
 
 static inline void es_add_ck(RAnalOp *op, const char *a1, const char *a2, const char *re, int bit) {
@@ -1177,21 +1192,20 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		r_strbuf_appendf (&op->esil, "%s,%s,^,%s,=", I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_NOR:
-		r_strbuf_appendf (&op->esil, "%s,%s,|,0xffffffff,^,%s,=", R_REG (rs), R_REG (rt), R_REG (rd));
+		r_strbuf_appendf (&op->esil, "%s,%s,|,%s,^,%s,=", R_REG (rs), R_REG (rt),
+			(as->config->bits == 64)? "0xffffffffffffffff": "0xffffffff", R_REG (rd));
 		break;
 	case MIPS_INS_SLT:
-		r_strbuf_appendf (&op->esil, "32,%s,~,32,%s,~,<,%s,=", R_REG (rt), R_REG (rs), R_REG (rd));
+		r_strbuf_appendf (&op->esil, es_slt_fmt (as), R_REG (rt), R_REG (rs), R_REG (rd));
 		break;
 	case MIPS_INS_SLTI:
-		r_strbuf_appendf (&op->esil, "32,%s,~,32,%s,~,<,%s,=", I_REG (imm), I_REG (rs), I_REG (rt));
+		r_strbuf_appendf (&op->esil, es_slt_fmt (as), I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_SLTU:
-		r_strbuf_appendf (&op->esil, "%s,0xffffffff,&,%s,0xffffffff,&,<,%s,=",
-			R_REG (rt), R_REG (rs), R_REG (rd));
+		r_strbuf_appendf (&op->esil, es_sltu_fmt (as), R_REG (rt), R_REG (rs), R_REG (rd));
 		break;
 	case MIPS_INS_SLTIU:
-		r_strbuf_appendf (&op->esil, "%s,0xffffffff,&,%s,0xffffffff,&,<,%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		r_strbuf_appendf (&op->esil, es_sltu_fmt (as), I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_MUL:
 		r_strbuf_appendf (&op->esil, ES_W ("%s,%s,*") ",%s,=", R_REG (rs), R_REG (rt), R_REG (rd));
@@ -1205,9 +1219,12 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		ES_SIGN32_64 ("hi");
 		break;
 	case MIPS_INS_MULTU:
-		r_strbuf_appendf (&op->esil, ES_W ("%s,%s,*") ",lo,=", R_REG (rs), R_REG (rt));
+		// the low words are the operands: masking the product is not enough
+		r_strbuf_appendf (&op->esil, ES_W (ES_W ("%s") "," ES_W ("%s") ",*") ",lo,=",
+			R_REG (rs), R_REG (rt));
 		ES_SIGN32_64 ("lo");
-		r_strbuf_appendf (&op->esil, ES_W ("32,%s,%s,*,>>") ",hi,=", R_REG (rs), R_REG (rt));
+		r_strbuf_appendf (&op->esil, "32," ES_W ("%s") "," ES_W ("%s") ",*,>>,hi,=",
+			R_REG (rs), R_REG (rt));
 		ES_SIGN32_64 ("hi");
 		break;
 	case MIPS_INS_MFLO:

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -855,8 +855,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_SRA:
 		r_strbuf_appendf (&op->esil,
-			ES_W ("%s,%s") ",>>,31,%s,>>,?{,%s,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
+			ES_W ("%s,%s,>>") ",31,%s,>>,?{,%s,32,-,0xffffffff,<<,0xffffffff,&,}{,0,},|,%s,=",
 			R_REG (sa), R_REG (rt), R_REG (rt), R_REG (sa), R_REG (rd));
+		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_DSRA:
 		r_strbuf_appendf (&op->esil,
@@ -868,13 +869,16 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_SRLV:
 	case MIPS_INS_SRL:
-		r_strbuf_appendf (&op->esil, "%s,%s,>>,%s,=",
+		// srl shifts the zero-extended low word, not the whole register
+		r_strbuf_appendf (&op->esil, "0x1f,%s,&," ES_W ("%s") ",>>,%s,=",
 			R_REG (rs) ? R_REG (rs) : R_REG (sa), R_REG (rt), R_REG (rd));
+		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_SLLV:
 	case MIPS_INS_SLL:
-		r_strbuf_appendf (&op->esil, "%s,%s,<<,%s,=",
+		r_strbuf_appendf (&op->esil, "0x1f,%s,&,%s,<<,%s,=",
 			R_REG (rs) ? R_REG (rs) : R_REG (sa), R_REG (rt), R_REG (rd));
+		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_BALC:
 		r_strbuf_appendf (&op->esil, ES_TRAP_DS ("0x%"PFMT64x) "" ES_CALL_ND ("%s"), addr, I_REG (jump));
@@ -1062,6 +1066,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 	case MIPS_INS_DSUBU:
 		r_strbuf_appendf (&op->esil, "%s,%s,-,%s,=",
 			R_REG (rt), R_REG (rs), R_REG (rd));
+		if (insn->id == MIPS_INS_SUB || insn->id == MIPS_INS_SUBU) {
+			ES_SIGN32_64 (R_REG (rd));
+		}
 		break;
 	case MIPS_INS_NEG:
 	case MIPS_INS_NEGU:
@@ -1080,6 +1087,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 	case MIPS_INS_ADDU:
 		r_strbuf_appendf (&op->esil, "%s,%s,+,%s,=",
 			R_REG (rt), R_REG (rs), R_REG (rd));
+		if (insn->id == MIPS_INS_ADDU) {
+			ES_SIGN32_64 (R_REG (rd));
+		}
 		break;
 	case MIPS_INS_DADDI:
 		ES_ADD_CK64_OVERF (I_REG (imm), I_REG (rs), I_REG (rt));
@@ -1088,7 +1098,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 	case MIPS_INS_DADDIU:
 		r_strbuf_appendf (&op->esil, "%s,%s,+,%s,=",
 			I_REG (imm), I_REG (rs), I_REG (rt));
-		ES_SIGN32_64 (I_REG (rt));
+		if (insn->id == MIPS_INS_ADDIU) {
+			ES_SIGN32_64 (I_REG (rt));
+		}
 		break;
 	case MIPS_INS_LI:
 	case MIPS_INS_LDI:
@@ -1096,22 +1108,33 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_LUI:
 		r_strbuf_appendf (&op->esil, "%s0000,%s,=", I_REG (imm), I_REG (rt));
+		ES_SIGN32_64 (I_REG (rt));
 		break;
 	case MIPS_INS_LB:
 		op->sign = true; // To load a byte from memory as a signed value
-		/* fallthrough */
+		r_strbuf_appendf (&op->esil, "8,%s,%s,+,[1],~,%s,=",
+			I_REG (imm), I_REG (rs), I_REG (rt));
+		break;
 	case MIPS_INS_LBU:
-		// one of these is wrong
 		r_strbuf_appendf (&op->esil, "%s,%s,+,[1],%s,=",
 			I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_LW:
+	case MIPS_INS_LL:
+		// on mips64 the word is sign-extended; lwu is the other form
+		if (as->config->bits == 64) {
+			r_strbuf_appendf (&op->esil, "32,%s,%s,+,[4],~,%s,=",
+				I_REG (imm), I_REG (rs), I_REG (rt));
+		} else {
+			r_strbuf_appendf (&op->esil, "%s,%s,+,[4],%s,=",
+				I_REG (imm), I_REG (rs), I_REG (rt));
+		}
+		break;
 	case MIPS_INS_LWC1:
 	case MIPS_INS_LWC2:
 	case MIPS_INS_LWL:
 	case MIPS_INS_LWR:
 	case MIPS_INS_LWU:
-	case MIPS_INS_LL:
 		r_strbuf_appendf (&op->esil, "%s,%s,+,[4],%s,=",
 			I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
@@ -1124,8 +1147,10 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 			I_REG (imm), I_REG (rs), I_REG (rt));
 		break;
 	case MIPS_INS_LH:
-		op->sign = true; // To load a byte from memory as a signed value
-		/* fallthrough */
+		op->sign = true; // To load a halfword from memory as a signed value
+		r_strbuf_appendf (&op->esil, "16,%s,%s,+,[2],~,%s,=",
+			I_REG (imm), I_REG (rs), I_REG (rt));
+		break;
 	case MIPS_INS_LHU:
 		r_strbuf_appendf (&op->esil, "%s,%s,+,[2],%s,=",
 			I_REG (imm), I_REG (rs), I_REG (rt));

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -770,6 +770,14 @@ typedef struct gnu_insn {
 #define I_REG(x) ((const char *)insn->i_reg.x)
 #define J_REG(x) ((const char *)insn->j_reg.x)
 
+#define ESIL_LOAD(size) \
+	r_strbuf_appendf (&op->esil, "%s,%s,+,["size"],%s,=",\
+		I_REG (imm), I_REG (rs), I_REG (rt))
+
+#define ESIL_LOAD_SIGNED(size, sbits) \
+	r_strbuf_appendf (&op->esil, sbits",%s,%s,+,["size"],~,%s,=",\
+		I_REG (imm), I_REG (rs), I_REG (rt))
+
 /* Return a mapping from the register number i.e. $0 .. $31 to string name */
 static const char *mips_reg_decode(ut32 reg_num) {
 	/* See page 36 of "See Mips Run Linux, 2e, D. Sweetman, 2007"*/
@@ -1126,23 +1134,19 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		ES_SIGN32_64 (I_REG (rt));
 		break;
 	case MIPS_INS_LB:
-		op->sign = true; // To load a byte from memory as a signed value
-		r_strbuf_appendf (&op->esil, "8,%s,%s,+,[1],~,%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		op->sign = true;
+		ESIL_LOAD_SIGNED ("1", "8");
 		break;
 	case MIPS_INS_LBU:
-		r_strbuf_appendf (&op->esil, "%s,%s,+,[1],%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		ESIL_LOAD ("1");
 		break;
 	case MIPS_INS_LW:
 	case MIPS_INS_LL:
 		// on mips64 the word is sign-extended; lwu is the other form
 		if (as->config->bits == 64) {
-			r_strbuf_appendf (&op->esil, "32,%s,%s,+,[4],~,%s,=",
-				I_REG (imm), I_REG (rs), I_REG (rt));
+			ESIL_LOAD_SIGNED ("4", "32");
 		} else {
-			r_strbuf_appendf (&op->esil, "%s,%s,+,[4],%s,=",
-				I_REG (imm), I_REG (rs), I_REG (rt));
+			ESIL_LOAD ("4");
 		}
 		break;
 	case MIPS_INS_LWC1:
@@ -1150,25 +1154,21 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 	case MIPS_INS_LWL:
 	case MIPS_INS_LWR:
 	case MIPS_INS_LWU:
-		r_strbuf_appendf (&op->esil, "%s,%s,+,[4],%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		ESIL_LOAD ("4");
 		break;
 	case MIPS_INS_LDL:
 	case MIPS_INS_LDC1:
 	case MIPS_INS_LDC2:
 	case MIPS_INS_LLD:
 	case MIPS_INS_LD:
-		r_strbuf_appendf (&op->esil, "%s,%s,+,[8],%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		ESIL_LOAD ("8");
 		break;
 	case MIPS_INS_LH:
-		op->sign = true; // To load a halfword from memory as a signed value
-		r_strbuf_appendf (&op->esil, "16,%s,%s,+,[2],~,%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		op->sign = true;
+		ESIL_LOAD_SIGNED ("2", "16");
 		break;
 	case MIPS_INS_LHU:
-		r_strbuf_appendf (&op->esil, "%s,%s,+,[2],%s,=",
-			I_REG (imm), I_REG (rs), I_REG (rt));
+		ESIL_LOAD ("2");
 		break;
 	case MIPS_INS_LHX:
 	case MIPS_INS_LWX:

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -1535,16 +1535,19 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			insn.id = MIPS_INS_DADDU;
 			break;
 		case 34: // sub
-		case 35: // subu
 			insn.id = MIPS_INS_SUB;
+			op->type = R_ANAL_OP_TYPE_SUB;
+			break;
+		case 35: // subu
+			insn.id = MIPS_INS_SUBU;
 			op->type = R_ANAL_OP_TYPE_SUB;
 			break;
 		case 46: // dsub
-			insn.id = MIPS_INS_SUB;
+			insn.id = MIPS_INS_DSUB;
 			op->type = R_ANAL_OP_TYPE_SUB;
 			break;
 		case 47: // dsubu
-			insn.id = MIPS_INS_SUB;
+			insn.id = MIPS_INS_DSUBU;
 			op->type = R_ANAL_OP_TYPE_SUB;
 			break;
 		case 36: // and
@@ -1838,7 +1841,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case 33: // lh
 			if (!op->refptr) {
 				op->refptr = 2;
-				insn.id = MIPS_INS_LB;
+				insn.id = MIPS_INS_LH;
 			}
 			/* fallthrough */
 		case 35: // lw
@@ -2159,7 +2162,7 @@ const RArchPlugin r_arch_plugin_mips_gnu = {
 	},
 	.cpus = "micro,mips1,mips2,mips3,mips4,mips5,mips64r2,mips32r2,mips64,mips32,loongson3a,gs464,gs464e,gs264e,loongson2e,loongson2f,mips32/64",
 	.arch = "mips",
-	.bits = R_SYS_BITS_PACK1 (32),
+	.bits = R_SYS_BITS_PACK2 (32, 64),
 	.info = archinfo,
 	.decode = decode,
 	.regs = regs,

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -708,7 +708,7 @@ aes
 ar v1
 EOF
 EXPECT=<<EOF
-0x0000bbaa
+0xffffbbaa
 EOF
 RUN
 
@@ -729,7 +729,7 @@ aes
 ar v1
 EOF
 EXPECT=<<EOF
-0x0000bbaa
+0xffffbbaa
 EOF
 RUN
 
@@ -749,7 +749,7 @@ aes
 ar v1
 EOF
 EXPECT=<<EOF
-0x0000ddcc
+0xffffddcc
 EOF
 RUN
 
@@ -2101,5 +2101,87 @@ EOF
 EXPECT=<<EOF
 0x00000008
 0x00000008
+EOF
+RUN
+
+NAME=sllv and srlv use only the low five bits of the count register
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 04404901
+ar t1=0x80000005
+ar t2=33
+ar pc=0
+s 0
+aes
+ar t0
+wx 06404901
+ar t1=0x80000000
+ar t2=33
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x0000000a
+0x40000000
+EOF
+RUN
+
+NAME=mips.gnu sra shifts the value by the count instead of masking one with the other
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 03410900
+ar t1=0x80000000
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xf8000000
+EOF
+RUN
+
+NAME=lb and lh sign-extend while lbu and lhu do not
+FILE=malloc://0x200
+ARGS=-a mips -b 32
+CMDS=<<EOF
+ar > /dev/null
+s 4
+wx 84ff0000
+ar t3=4
+wx 00006881 @ 8
+s 8
+aei
+aeim
+aeip
+aes
+ar t0
+wx 00006885 @ 8
+ar pc=8
+s 8
+aes
+ar t0
+wx 00006891 @ 8
+ar pc=8
+s 8
+aes
+ar t0
+wx 00006895 @ 8
+ar pc=8
+s 8
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffff84
+0xffffff84
+0x00000084
+0x0000ff84
 EOF
 RUN

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2185,3 +2185,24 @@ EXPECT=<<EOF
 0x0000ff84
 EOF
 RUN
+
+NAME=mips.gnu lh reads a halfword and not a byte
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+ar > /dev/null
+s 4
+wx 34120000
+ar t3=4
+wx 00006885 @ 8
+s 8
+aei
+aeim
+aeip
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x00001234
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -143,3 +143,38 @@ EXPECT=<<EOF
 0xffffff84
 EOF
 RUN
+
+NAME=mips64 sltu compares the whole register and multu multiplies the low words
+FILE=malloc://64
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 2b402a01
+ar t1=0x100000000
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+ar t1=1
+ar t2=0x100000000
+ar pc=0
+s 0
+aes
+ar t0
+wx 19002a01
+ar t1=0xffffffffffffffff
+ar t2=2
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000001
+0x00000001
+0xfffffffffffffffe
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -178,3 +178,51 @@ EXPECT=<<EOF
 0xfffffffffffffffe
 EOF
 RUN
+
+NAME=mips.gnu can be selected at 64 bits and sign-extends the 32-bit forms
+FILE=malloc://64
+ARGS=-a mips.gnu -b 64
+CMDS=<<EOF
+e asm.bits
+aei
+wx 00410900
+ar t0=0xa5a5000300000000
+ar t1=0x08000000
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+64
+0xffffffff80000000
+EOF
+RUN
+
+NAME=mips.gnu dsubu keeps all 64 bits while subu narrows to a word
+FILE=malloc://64
+ARGS=-a mips.gnu -b 64
+CMDS=<<EOF
+aei
+wx 2f402a01
+ar t0=0xa5a5000300000000
+ar t1=0x100000000
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 23402a01
+ar t0=0xa5a5000300000000
+ar t1=0xffffffff80000000
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffff
+0x7fffffff
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -14,3 +14,132 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=mips64 sll srl and sra deliver a sign-extended word
+FILE=malloc://64
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 00410900
+ar t0=0xa5a5000300000000
+ar t1=0x08000000
+ar pc=0
+s 0
+aes
+ar t0
+wx 02410900
+ar t0=0xa5a5000300000000
+ar t1=0xffffffff80000000
+ar pc=0
+s 0
+aes
+ar t0
+wx 03410900
+ar t0=0xa5a5000300000000
+ar t1=0xffffffff80000000
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffff80000000
+0x08000000
+0xfffffffff8000000
+EOF
+RUN
+
+NAME=mips64 addu subu negu and lui sign-extend but daddu does not
+FILE=malloc://64
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 21402a01
+ar t0=0xa5a5000300000000
+ar t1=0x7fffffff
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 2d402a01
+ar t0=0xa5a5000300000000
+ar t1=0x7fffffff
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 23402a01
+ar t0=0xa5a5000300000000
+ar t1=0xffffffff80000000
+ar t2=1
+ar pc=0
+s 0
+aes
+ar t0
+wx 23400900
+ar t0=0xa5a5000300000000
+ar t1=0xffffffff80000000
+ar pc=0
+s 0
+aes
+ar t0
+wx 0080083c
+ar t0=0xa5a5000300000000
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffff80000000
+0x80000000
+0x7fffffff
+0xffffffff80000000
+0xffffffff80000000
+EOF
+RUN
+
+NAME=mips64 lb lh and lw sign-extend into the full register but lwu does not
+FILE=malloc://0x200
+ARGS=-a mips -b 64
+CMDS=<<EOF
+ar > /dev/null
+s 4
+wx 84ffffff
+ar t0=0xa5a5000300000000
+ar t3=4
+wx 00006881 @ 8
+s 8
+aei
+aeim
+aeip
+aes
+ar t0
+wx 00006885 @ 8
+ar t0=0xa5a5000300000000
+ar pc=8
+s 8
+aes
+ar t0
+wx 0000688d @ 8
+ar t0=0xa5a5000300000000
+ar pc=8
+s 8
+aes
+ar t0
+wx 0000689d @ 8
+ar t0=0xa5a5000300000000
+ar pc=8
+s 8
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffffffffff84
+0xffffffffffffff84
+0xffffffffffffff84
+0xffffff84
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The MIPS 32-bit forms were emulated as 64-bit operations, so their results never sign-extended into the register on mips64. Some of it is wrong on mips32 too.

- `sllv`/`srlv` used the whole count register instead of its low 5 bits, and `srl` shifted all 64 bits instead of the zero-extended low word.
- `lb`/`lh` never sign-extended, at either width; `lw`/`ll` now do on mips64.
- The shifts, `addu`/`addiu`, `sub`/`subu`, `neg`/`negu` and `lui` deliver a sign-extended word on mips64. The `d`-forms stay full width.
- `sltu`/`sltiu` narrowed both operands to 32 bits, so any unsigned compare above 4 GB was wrong; they now compare the whole register (esil `<` is signed, so both sides are biased by the sign bit). `multu` masked the product instead of its sources, giving `hi = -1` where the answer is `1`.

`mips.gnu` carries copy-pasted versions of the same emitters and is fixed alongside. That exposed three bugs there: it declared 32-bit-only support although ts register profile is 64-bit (so `-b 64` silently downgraded and its existing sign-extension code had never run), `lh` was decoded as `lb` and read one byte, and `sub`/`subu`/`dsub`/`dsubu` all shared one instruction id.

Validated by differential execution against the Unicorn engine over six mips variants (mips, mipsbe, mips64, mips64be and both `mips.gnu` widths): 275 → 71 failing cases, none new. Everything remaining is the `lwl`/`lwr`/`swl`/`swr`/`ldl` partial-word family and `rotr`, neither touched here.