### PR TITLE
Model the mips unaligned loads and stores ##esil

### DIFF
--- a/libr/arch/p/mips/mips_utils.h
+++ b/libr/arch/p/mips/mips_utils.h
@@ -4,6 +4,7 @@
 #define R_MIPS_UTILS_H
 
 #include <r_endian.h>
+#include <r_arch.h>
 #include <r_bin.h>
 
 static inline ut64 mips_read_ptr_at(RBin *bin, ut64 addr, bool be, int bits) {
@@ -13,6 +14,33 @@ static inline ut64 mips_read_ptr_at(RBin *bin, ut64 addr, bool be, int bits) {
 		return UT64_MAX;
 	}
 	return ptrsz == 8 ? r_read_ble64 (v, be) : r_read_ble32 (v, be);
+}
+
+// esil for the unaligned lwl/lwr/ldl/ldr loads and swl/swr/sdl/sdr stores
+static inline void mips_esil_unaligned(RStrBuf *esil, const RArchConfig *cfg, const char *addr, const char *rt, int w, bool left, bool store) {
+	const char *mask = (w == 8)? "0xffffffffffffffff": "0xffffffff";
+	const char *align = (w == 8)? "0xfffffffffffffff8": "0xfffffffffffffffc";
+	const bool sx = !store && w == 4 && cfg->bits == 64;
+	// a le cpu counts the addressed byte from the other end of the word
+	char *sh = (R_ARCH_CONFIG_IS_BIG_ENDIAN (cfg) == left)
+		? r_str_newf ("3,%s,%d,&,<<", addr, w - 1)
+		: r_str_newf ("3,%s,%d,&,%d,-,<<", addr, w - 1, w - 1);
+	char *mem = r_str_newf ("%s,%s,&,[%d]", addr, align, w);
+	if (store && left) {
+		r_strbuf_appendf (esil, "%s,%s,>>,%s,^,%s,&,%s,%s,%s,&,>>,|,%s,%s,&,=[%d]",
+			sh, mask, mask, mem, sh, mask, rt, addr, align, w);
+	} else if (store) {
+		r_strbuf_appendf (esil, "%s,%s,%s,&,<<,1,%s,1,<<,-,%s,&,|,%s,%s,&,=[%d]",
+			sh, mask, rt, sh, mem, addr, align, w);
+	} else if (left) {
+		r_strbuf_appendf (esil, "%s%s,%s,<<,%s,&,1,%s,1,<<,-,%s,&,|,%s%s,=",
+			sx? "32,": "", sh, mem, mask, sh, rt, sx? "~,": "", rt);
+	} else {
+		r_strbuf_appendf (esil, "%s%s,%s,>>,%s,%s,%s,>>,^,%s,&,|,%s%s,=",
+			sx? "32,": "", sh, mem, mask, sh, mask, rt, sx? "~,": "", rt);
+	}
+	free (sh);
+	free (mem);
 }
 
 #endif

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -291,10 +291,18 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				ARG (0), ARG (1));
 			break;
 		case MIPS_INS_SW:
-		case MIPS_INS_SWL:
-		case MIPS_INS_SWR:
 			r_strbuf_appendf (&op->esil, "%s,%s,=[4]",
 				ARG (0), ARG (1));
+			break;
+		case MIPS_INS_SWL:
+		case MIPS_INS_SWR:
+		case MIPS_INS_SDL:
+		case MIPS_INS_SDR:
+			{
+				const bool wide = insn->id == MIPS_INS_SDL || insn->id == MIPS_INS_SDR;
+				const bool left = insn->id == MIPS_INS_SWL || insn->id == MIPS_INS_SDL;
+				mips_esil_unaligned (&op->esil, as->config, ARG (1), ARG (0), wide? 8: 4, left, true);
+			}
 			break;
 		case MIPS_INS_SH:
 			r_strbuf_appendf (&op->esil, "%s,%s,=[2]",
@@ -648,13 +656,19 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				break;
 			case MIPS_INS_LWC1:
 			case MIPS_INS_LWC2:
-			case MIPS_INS_LWL:
-			case MIPS_INS_LWR:
 			case MIPS_INS_LWU:
 				ESIL_LOAD ("4");
 				break;
-
+			case MIPS_INS_LWL:
+			case MIPS_INS_LWR:
 			case MIPS_INS_LDL:
+			case MIPS_INS_LDR:
+				PROTECT_ZERO () {
+					const bool wide = insn->id == MIPS_INS_LDL || insn->id == MIPS_INS_LDR;
+					const bool left = insn->id == MIPS_INS_LWL || insn->id == MIPS_INS_LDL;
+					mips_esil_unaligned (&op->esil, as->config, ARG (1), REG (0), wide? 8: 4, left, false);
+				}
+				break;
 			case MIPS_INS_LDC1:
 			case MIPS_INS_LDC2:
 			case MIPS_INS_LLD:
@@ -1172,6 +1186,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case MIPS_INS_SWL:
 	case MIPS_INS_SWR:
 	case MIPS_INS_SWXC1:
+	case MIPS_INS_SDL:
+	case MIPS_INS_SDR:
 		op->type = R_ANAL_OP_TYPE_STORE;
 		break;
 	case MIPS_INS_NOP:

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -849,8 +849,6 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 			I_REG (rt), I_REG (imm), I_REG (rs));
 		break;
 	case MIPS_INS_SW:
-	case MIPS_INS_SWL:
-	case MIPS_INS_SWR:
 		r_strbuf_appendf (&op->esil, "%s,%s,%s,+,=[4]",
 			I_REG (rt), I_REG (imm), I_REG (rs));
 		break;
@@ -1151,17 +1149,32 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_LWC1:
 	case MIPS_INS_LWC2:
-	case MIPS_INS_LWL:
-	case MIPS_INS_LWR:
 	case MIPS_INS_LWU:
 		ESIL_LOAD ("4");
 		break;
-	case MIPS_INS_LDL:
 	case MIPS_INS_LDC1:
 	case MIPS_INS_LDC2:
 	case MIPS_INS_LLD:
 	case MIPS_INS_LD:
 		ESIL_LOAD ("8");
+		break;
+	case MIPS_INS_LWL:
+	case MIPS_INS_LWR:
+	case MIPS_INS_LDL:
+	case MIPS_INS_LDR:
+	case MIPS_INS_SWL:
+	case MIPS_INS_SWR:
+	case MIPS_INS_SDL:
+	case MIPS_INS_SDR:
+		{
+			const int id = insn->id;
+			const bool wide = id == MIPS_INS_LDL || id == MIPS_INS_LDR || id == MIPS_INS_SDL || id == MIPS_INS_SDR;
+			const bool left = id == MIPS_INS_LWL || id == MIPS_INS_LDL || id == MIPS_INS_SWL || id == MIPS_INS_SDL;
+			const bool store = id == MIPS_INS_SWL || id == MIPS_INS_SWR || id == MIPS_INS_SDL || id == MIPS_INS_SDR;
+			char a[REG_BUF_MAX * 2 + 4];
+			snprintf (a, sizeof (a), "%s,%s,+", I_REG (imm), I_REG (rs));
+			mips_esil_unaligned (&op->esil, as->config, a, I_REG (rt), wide? 8: 4, left, store);
+		}
 		break;
 	case MIPS_INS_LH:
 		op->sign = true;
@@ -1833,6 +1846,30 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 				insn.id = MIPS_INS_LDI;
 				snprintf ((char *)insn.i_reg.imm, REG_BUF_MAX, "0x%" PFMT32x, imm);
 			}
+			break;
+		case 26: // ldl
+		case 27: // ldr
+			insn.id = (optype == 26)? MIPS_INS_LDL: MIPS_INS_LDR;
+			op->refptr = 8;
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			break;
+		case 34: // lwl
+		case 38: // lwr
+			insn.id = (optype == 34)? MIPS_INS_LWL: MIPS_INS_LWR;
+			op->refptr = 4;
+			op->type = R_ANAL_OP_TYPE_LOAD;
+			break;
+		case 42: // swl
+		case 46: // swr
+			insn.id = (optype == 42)? MIPS_INS_SWL: MIPS_INS_SWR;
+			op->refptr = 4;
+			op->type = R_ANAL_OP_TYPE_STORE;
+			break;
+		case 44: // sdl
+		case 45: // sdr
+			insn.id = (optype == 44)? MIPS_INS_SDL: MIPS_INS_SDR;
+			op->refptr = 8;
+			op->type = R_ANAL_OP_TYPE_STORE;
 			break;
 		case 32: // lb
 			op->refptr = 1;

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2324,3 +2324,33 @@ EXPECT=<<EOF
 11887766
 EOF
 RUN
+
+NAME=mips.gnu decodes the unaligned word loads and stores
+FILE=malloc://0x200
+ARGS=-a mips.gnu -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+wx 11223344 @ 4
+aei
+aeim
+s 8
+ar t3=4
+wx 89680001 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 11223344 @ 4
+wx a9690001 @ 8
+ar t1=0x55667788
+ar pc=8
+aes
+p8 4 @ 4
+ao 1~type
+EOF
+EXPECT=<<EOF
+0x223344dd
+11556677
+type: store
+EOF
+RUN

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2206,3 +2206,121 @@ EXPECT=<<EOF
 0x00001234
 EOF
 RUN
+
+NAME=mips lwl and lwr merge the addressed bytes into the register
+FILE=malloc://0x200
+ARGS=-a mips -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+wx 11223344 @ 4
+aei
+aeim
+s 8
+ar t3=4
+wx 89680001 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 99680001 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 89680003 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 99680003 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x223344dd
+0xaabb1122
+0x44bbccdd
+0x11223344
+EOF
+RUN
+
+NAME=mips swl and swr write only the addressed bytes
+FILE=malloc://0x200
+ARGS=-a mips -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+aei
+aeim
+s 8
+ar t3=4
+ar t1=0x55667788
+wx 11223344 @ 4
+wx a9690001 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+wx 11223344 @ 4
+wx b9690001 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+wx 11223344 @ 4
+wx a9690003 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+wx 11223344 @ 4
+wx b9690003 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+EOF
+EXPECT=<<EOF
+11556677
+77883344
+11223355
+55667788
+EOF
+RUN
+
+NAME=mips counts the unaligned bytes from the other end when little endian
+FILE=malloc://0x200
+ARGS=-a mips -b 32
+CMDS=<<EOF
+ar > /dev/null
+wx 11223344 @ 4
+aei
+aeim
+s 8
+ar t3=4
+ar t1=0x55667788
+wx 01006889 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 01006899 @ 8
+ar t0=0xaabbccdd
+ar pc=8
+aes
+ar t0
+wx 11223344 @ 4
+wx 010069a9 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+wx 11223344 @ 4
+wx 010069b9 @ 8
+ar pc=8
+aes
+p8 4 @ 4
+EOF
+EXPECT=<<EOF
+0x2211ccdd
+0xaa443322
+66553344
+11887766
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -226,3 +226,90 @@ EXPECT=<<EOF
 0x7fffffff
 EOF
 RUN
+
+NAME=mips64 ldl and ldr merge the addressed bytes into the register
+FILE=malloc://0x200
+ARGS=-a mips -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+wx 1122334455667788 @ 8
+aei
+aeim
+s 0x20
+ar t3=8
+wx 69680001 @ 0x20
+ar t0=0xa1a2a3a4a5a6a7a8
+ar pc=0x20
+aes
+ar t0
+wx 6d680001 @ 0x20
+ar t0=0xa1a2a3a4a5a6a7a8
+ar pc=0x20
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x22334455667788a8
+0xa1a2a3a4a5a61122
+EOF
+RUN
+
+NAME=mips64 sdl and sdr write only the addressed bytes
+FILE=malloc://0x200
+ARGS=-a mips -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+aei
+aeim
+s 0x20
+ar t3=8
+ar t1=0xf1f2f3f4f5f6f7f8
+wx 1122334455667788 @ 8
+wx b1690001 @ 0x20
+ar pc=0x20
+aes
+p8 8 @ 8
+wx 1122334455667788 @ 8
+wx b5690001 @ 0x20
+ar pc=0x20
+aes
+p8 8 @ 8
+EOF
+EXPECT=<<EOF
+11f1f2f3f4f5f6f7
+f7f8334455667788
+EOF
+RUN
+
+NAME=mips64 lwl and lwr sign-extend the merged word
+FILE=malloc://0x200
+ARGS=-a mips -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+ar > /dev/null
+wx 80223344 @ 4
+aei
+aeim
+s 0x20
+ar t3=4
+wx 89680000 @ 0x20
+ar t0=0xa1a2a3a4a5a6a7a8
+ar pc=0x20
+aes
+ar t0
+wx 99680003 @ 0x20
+ar t0=0xa1a2a3a4a5a6a7a8
+ar pc=0x20
+aes
+ar t0
+wx 89680002 @ 0x20
+ar t0=0xa1a2a3a4a5a6a7a8
+ar pc=0x20
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffff80223344
+0xffffffff80223344
+0x3344a7a8
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

lwl/lwr/swl/swr and the mips64 ldl/ldr/sdl/sdr were emitted as ordinary aligned accesses: lwl loaded the whole word, swl overwrote four bytes, and ldr/sdl/sdr had no ESIL at all. They now merge the addressed bytes with what the register (loads) or the memory (stores) already holds, honouring the endian-dependent byte index and sign-extending the merged word on mips64.

The emitter is shared by both plugins through libr/arch/p/mips/mips_utils.h, which mips_gnu/plugin.c already includes. mips.gnu additionally never decoded any of the eight opcodes — insn.id stayed 0, so its existing LWL/LDL ESIL arms were dead and the ops carried no op->type; that decode is added here too, along with SDL/SDR in the capstone plugin's store type arm.

Checked against the Unicorn engine over every byte offset, both endiannesses and both widths on all six mips arch variants: 66 failures -> 0, none new. 7 tests in db/esil/mips_32 and db/esil/mips_64.