### PR TITLE
Fix esil that writes a destination aliasing its own source ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -2407,8 +2407,7 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		char sign = (disp >= 0)? '+': '-';
 		ut64 abs = (ut64)((disp >= 0)? MEMDISP64 (2): (st64)(-disp));
 		const int size = REGSIZE64 (0);
-		// Pre-index case
-		// x2,x8,32,+,=[8],x3,x8,32,+,8,+,=[8]
+		// a writeback form is unpredictable when rt == rn, so it may write first
 		if (ISPREINDEX64 ()) {
 			// "ldp x0, x1, [x8, -0x10]!"
 			// 16,x8,-=,x8,[8],x0,=,x8,8,+,[8],x1,=
@@ -2419,7 +2418,6 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 					abs, MEMBASE64 (2), sign,
 					MEMBASE64 (2), size, REG64 (0),
 					size, MEMBASE64 (2), size, REG64 (1));
-		// Post-index case
 		} else if (ISPOSTINDEX64 ()) {
 			int val = IMM64 (3);
 			sign = (val >= 0)?'+':'-';
@@ -2434,11 +2432,14 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 					MEMBASE64 (2), size, size, REG64 (1),
 					abs, MEMBASE64 (2), sign);
 		} else {
+			// both words are loaded first, so the base may be a destination
 			r_strbuf_setf (&op->esil,
-					"%"PFMT64d",%s,%c,[%d],%s,=,"
-					"%d,%"PFMT64d",%s,%c,+,[%d],%s,=",
-					abs, MEMBASE64 (2), sign, size, REG64 (0),
-					size, abs, MEMBASE64 (2), sign, size, REG64 (1));
+					"%"PFMT64d",%s,%c,[%d],"
+					"%d,%"PFMT64d",%s,%c,+,[%d],"
+					"%s,=,%s,=",
+					abs, MEMBASE64 (2), sign, size,
+					size, abs, MEMBASE64 (2), sign, size,
+					REG64 (1), REG64 (0));
 		}
 		break;
 	}
@@ -2733,9 +2734,13 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 
 	switch (insn->id) {
 	case ARM_INS_CLZ:
-		r_strbuf_appendf (&op->esil, "%s,!,?{,32,%s,=,BREAK,},"
-			"0,%s,=,%s,%s,<<,0x80000000,&,!,?{,1,%s,+=,11,GOTO,}",
-			REG (1), REG (0), REG (0), REG (0), REG (1), REG (0));
+		{
+			// counts on the stack, so the source may be the destination
+			const ut32 head = r_str_char_count (r_strbuf_get (&op->esil), ',') + 12;
+			r_strbuf_appendf (&op->esil, "%s,!,?{,32,%s,=,BREAK,},"
+				"%s,%s,:=,0,%s,0x80000000,&,!,?{,1,%s,<<=,++,%d,GOTO,},%s,=",
+				REG (1), REG (0), REG (1), REG (0), REG (0), REG (0), head, REG (0));
+		}
 		break;
 	case ARM_INS_IT:
 		r_strbuf_appendf (&op->esil, "0x%"PFMT64x",pc,:=", addr + 2);
@@ -3493,35 +3498,33 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 	{
 		const char *r0 = REG(0);
 		const char *r1 = REG(1);
-		r_strbuf_setf (&op->esil,
-			"24,0xff,%s,&,<<,%s,=,"
-			"16,0xff,8,%s,>>,&,<<,%s,|=,"
-			"8,0xff,16,%s,>>,&,<<,%s,|=,"
-			"0xff,24,%s,>>,&,%s,|=,",
-			r1, r0, r1, r0, r1, r0, r1, r0);
+		// the whole source is read before the write, so rd == rn works
+		r_strbuf_appendf (&op->esil,
+			"24,0xff,%s,&,<<,"
+			"16,0xff,8,%s,>>,&,<<,|,"
+			"8,0xff,16,%s,>>,&,<<,|,"
+			"0xff,24,%s,>>,&,|,%s,=",
+			r1, r1, r1, r1, r0);
 		break;
 	}
 	case ARM_INS_REV16:
 	{
 		const char *r0 = REG(0);
 		const char *r1 = REG(1);
-		r_strbuf_setf (&op->esil,
-			"8,0xff00ff00,%s,&,>>,%s,=,"
-			"8,0x00ff00ff,%s,&,<<,%s,|=,",
-			r1, r0, r1, r0);
+		r_strbuf_appendf (&op->esil,
+			"8,0xff00ff00,%s,&,>>,"
+			"8,0x00ff00ff,%s,&,<<,|,%s,=",
+			r1, r1, r0);
 		break;
 	}
 	case ARM_INS_REVSH:
 	{
 		const char *r0 = REG(0);
 		const char *r1 = REG(1);
-		r_strbuf_setf (&op->esil,
-			"8,0xff00,%s,&,>>,%s,=,"
-			"8,0x00ff,%s,&,<<,%s,|=,"
-			"0x8000,%s,&,?{,"
-				"0xffff0000,%s,|=,"
-			"}",
-			r1, r0, r1, r0, r0, r0);
+		r_strbuf_appendf (&op->esil,
+			"16,8,0xff00,%s,&,>>,"
+			"8,0x00ff,%s,&,<<,|,~,%s,=",
+			r1, r1, r0);
 		break;
 	}
 	case ARM_INS_TBB:

--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -414,6 +414,12 @@ static char *byteswap_expr(const char *v, int bytes) {
 	return r_strbuf_drain (sb);
 }
 
+// the flags an addition defines, shared by add and xadd
+static char *add_flags(ut32 bitsize) {
+	return r_str_newf ("%d,$o,of,:=,%d,$s,sf,:=,$z,zf,:=,%d,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
+		bitsize - 1, bitsize - 1, bitsize - 1);
+}
+
 static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsize) {
 	const char *setarg = r_str_get (setop);
 	cs_insn *insn = gop->insn;
@@ -606,7 +612,6 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	char *dst2 = NULL;
 	char *dst_r = NULL;
 	char *dst_w = NULL;
-	char *dstAdd = NULL;
 	char *arg0 = NULL;
 	char *arg1 = NULL;
 	char *arg2 = NULL;
@@ -2036,59 +2041,25 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		}
 		break;
 	case X86_INS_BSF:
-		{
-			src = getarg (&gop, 1, 0, NULL, NULL);
-			dst = getarg (&gop, 0, 0, NULL, NULL);
-			char pre[24];
-			zext_prefix (&gop, dst, pre, sizeof (pre));
-			if (strcmp (src, dst)) {
-				// the loop target shifts by the tokens the prefix and src add
-				const ut32 extra = r_str_char_count (src, ',')
-					+ r_str_char_count (pre, ',');
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s,"
-						"0x%"PFMT64x",%s,:=,"
-						"%s,++,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, pre, UT64_MAX, dst, dst, dst, dst, src, 11 + extra);
-			} else {
-				// unroll the loop to avoid use of DUP operation
-				const ut32 bits = INSOP (0).size * 8;
-				ut32 i = 0;
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s", src, pre);
-				for (; i < bits - 1; i++) {
-					r_strbuf_appendf (&op->esil, ",0x%"PFMT64x",%s,&,?{,%d,%s,:=,BREAK,}",
-						((ut64)1) << i, src, i, dst);
-				}
-				r_strbuf_appendf (&op->esil, ",%d,%s,:=", i, dst);
-			}
-			R_FREE (src);
-			R_FREE (dst);
-		}
-		break;
 	case X86_INS_BSR:
 		{
+			// bsr scans from the top bit downwards, bsf from bit zero up
+			const bool up = insn->id == X86_INS_BSF;
+			const ut32 bits = INSOP (0).size * 8;
+			const int start = up? 0: (int)bits - 1;
+			const ut64 bit = up? 1: (ut64)1 << (bits - 1);
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
-			const ut32 bits = INSOP (0).size * 8;
 			char pre[24];
-
 			zext_prefix (&gop, dst, pre, sizeof (pre));
-			if (strcmp (src, dst)) {
-				const ut32 extra = r_str_char_count (src, ',')
-					+ r_str_char_count (pre, ',');
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s,"
-						"%d,%s,:=,"
-						"%s,--,%s,:=,%s,1,<<,%s,&,!,?{,%d,GOTO,}",
-						src, pre, bits, dst, dst, dst, dst, src, 11 + extra);
-			} else {
-				// unroll the loop to avoid use of DUP operation
-				ut32 i = bits - 1;
-				esilprintf (op, "%s,!,zf,:=,zf,?{,BREAK,}%s", src, pre);
-				for (; i; i--) {
-					r_strbuf_appendf (&op->esil, ",0x%"PFMT64x",%s,&,?{,%d,%s,:=,BREAK,}",
-						((ut64)1) << i, src, i, dst);
-				}
-				r_strbuf_appendf (&op->esil, ",0,%s,:=", dst);
-			}
+			// the source is staged first, so dst may be src or address it
+			const ut32 head = r_str_char_count (src, ',')
+				+ r_str_char_count (pre, ',') + 13;
+			esilprintf (op, "%s,NUM,DUP,!,zf,:=,zf,?{,BREAK,}%s,"
+					"%d,%s,:=,"
+					"DUP,0x%"PFMT64x",&,!,?{,1,SWAP,%s,1,%s,%s,%d,GOTO,}",
+					src, pre, start, dst, bit, up? ">>": "<<",
+					dst, up? "+=": "-=", head);
 			R_FREE (src);
 			R_FREE (dst);
 		}
@@ -2553,37 +2524,23 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		break;
 	case X86_INS_XADD: /* xchg + add */
 		{
+			ut32 bitsize;
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 0, NULL, NULL);
-			dstAdd = getarg (&gop, 0, 1, "+", NULL);
+			dst2 = getarg (&gop, 0, 1, NULL, &bitsize);
 			zext_opnd (&gop, 1);
-			if (INSOP(0).type == X86_OP_MEM) {
-				dst2 = getarg (&gop, 0, 1, NULL, NULL);
-				esilprintf (op,
-					"%s,%s,^,%s,=,"
-					"%s,%s,^,%s,"
-					"%s,%s,^,%s,=,"
-					"%s,%s",
-					dst, src, src,	// x = x ^ y
-					src, dst, dst2,	// y = y ^ x
-					dst, src, src,  // x = x ^ y
-					src, dstAdd);
-				R_FREE (dst2);
+			char *fl = add_flags (bitsize);
+			// the sum is staged, so xadd r,r doubles r instead of zeroing it
+			if (INSOP (norm_op (0, gop.syntax, INSOPS)).type == X86_OP_MEM) {
+				// src may address dst, so the store goes before it
+				esilprintf (op, "%s,DUP,%s,+,%s,%s,%s,=", dst, src, dst2, fl, src);
 			} else {
-				esilprintf (op,
-					"%s,%s,^,%s,=,"
-					"%s,%s,^,%s,=,"
-					"%s,%s,^,%s,=,"
-					"%s,%s",
-					dst, src, src,  // x = x ^ y
-					src, dst, dst,  // y = y ^ x
-					dst, src, src,  // x = x ^ y
-					src, dstAdd);
-				//esilprintf (op, "%s,%s,%s,=,%s", src, dst, src, dst);
+				esilprintf (op, "%s,DUP,%s,+,SWAP,%s,=,%s,%s", dst, src, src, dst2, fl);
 			}
+			free (fl);
 			free (src);
 			free (dst);
-			free (dstAdd);
+			free (dst2);
 		}
 		break;
 	case X86_INS_FADD:
@@ -2771,8 +2728,9 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 1, "+", &bitsize);
 			if (src && dst) {
-				esilprintf (op, "%s,%s,%d,$o,of,:=,%d,$s,sf,:=,$z,zf,:=,%d,$c,cf,:=,$p,pf,:=,3,$c,af,:=",
-					src, dst, bitsize - 1, bitsize - 1, bitsize - 1);
+				char *fl = add_flags (bitsize);
+				esilprintf (op, "%s,%s,%s", src, dst, fl);
+				free (fl);
 			}
 			free (src);
 			free (dst);

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3132,3 +3132,95 @@ EXPECT=<<EOF
 0xabcdffff
 EOF
 RUN
+
+NAME=rev family reverses a register into itself
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 300fbfe6
+aer r0=0x12345680
+aes
+aer r0
+wx b00fbfe6
+aer r0=0x12345680
+aer PC=0
+aes
+aer r0
+wx b00fffe6
+aer r0=0x12345680
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x80563412
+0x34128056
+0xffff8056
+EOF
+RUN
+
+NAME=clz counts the zeros of a register that is also its destination
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 100f6fe1
+aer r0=0x1234f680
+aes
+aer r0
+aer r0=0x00001234
+aer PC=0
+aes
+aer r0
+aer r0=0
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x00000003
+0x00000013
+0x00000020
+EOF
+RUN
+
+NAME=a conditional rev keeps its condition
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 300fbf16
+aer cpsr=0
+aer r0=0x12345680
+aes
+aer r0
+aer cpsr=0x40000000
+aer r0=0x12345680
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x80563412
+0x12345680
+EOF
+RUN
+
+NAME=a conditional clz jumps to its own loop head
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 100f6f11
+aer cpsr=0
+aer r0=0x00001234
+aes
+aer r0
+aer cpsr=0x40000000
+aer r0=0x00001234
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x00000013
+0x00001234
+EOF
+RUN

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1837,3 +1837,22 @@ EXPECT=<<EOF
 0x0 0,w0,=,w1,w1,0,+,=[8],w0,x0,=
 EOF
 RUN
+
+NAME=ldp loads both words before writing the register that addresses them
+FILE=malloc://0x200
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 1122334455667788aabbccddeeff0011 @ 0x40
+wx 000440a9 @ 0
+aei
+aeim
+aer x0=0x40
+aes
+aer x0
+aer x1
+EOF
+EXPECT=<<EOF
+0x8877665544332211
+0x1100ffeeddccbbaa
+EOF
+RUN

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2644,3 +2644,24 @@ EXPECT=<<EOF
 0x000000ff
 EOF
 RUN
+
+NAME=xadd stores through the source register it overwrites
+FILE=malloc://0x200
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+wx 11000000 @ 0x40
+wx 0fc136 @ 0
+aei
+aeim
+ar esi=0x40
+s 0
+aeip
+aes
+ar esi
+p8 4 @ 0x40
+EOF
+EXPECT=<<EOF
+0x00000011
+51000000
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1904,3 +1904,70 @@ EXPECT=<<EOF
 0x00000002
 EOF
 RUN
+
+NAME=bsf and bsr scan a memory source addressed by their destination
+FILE=malloc://0x200
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 00010000 @ 0x40
+wx 0fbc09 @ 0
+aei
+aeim
+ar rcx=0x40
+s 0
+aeip
+aes
+ar rcx
+wx 0fbd09 @ 0
+ar rcx=0x40
+s 0
+aeip
+aes
+ar rcx
+EOF
+EXPECT=<<EOF
+0x00000008
+0x00000008
+EOF
+RUN
+
+NAME=xadd adds a register to itself instead of zeroing it
+FILE=malloc://0x200
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 0fc1c9
+aei
+aeim
+ar rcx=0xffffffff80000005
+s 0
+aeip
+aes
+ar rcx
+ar cf
+EOF
+EXPECT=<<EOF
+0x0000000a
+0x00000001
+EOF
+RUN
+
+NAME=xadd stores through the source register it overwrites
+FILE=malloc://0x200
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 1100000000000000 @ 0x40
+wx 480fc136 @ 0
+aei
+aeim
+ar rsi=0x40
+s 0
+aeip
+aes
+ar rsi
+p8 8 @ 0x40
+EOF
+EXPECT=<<EOF
+0x00000011
+5100000000000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Seven esil expressions assigned their destination and then re-read a source that aliases it, so they produced wrong values whenever the same register appeared twice. Found by differential testing against Unicorn with operand aliasing permuted, and each verified against the ISA:

| instruction | r2 | hardware |
|---|---|---|
| `rev r0, r0` (r0=0x12345680) | 0x80000080 | 0x80563412 |
| `clz r1, r1` (r1=0x1234) | 27 | 19 |
| `ldp x0, x1, [x0]` | x1 loaded via the x0 it just wrote | |
| `bsf ecx, [rcx]` | 0x41 (impossible for a 32-bit scan) | 8 |
| `xadd ecx, ecx` | 0 | doubles ecx |

Each is fixed the same way: compute the value first, assign last. `rev`/`rev16`/`revsh` build the result on the stack; `clz` keeps its counter there; `ldp` loads both words before writing either register; `bsf`/`bsr` snapshot the source once with `NUM` and scan the stack copy (this also replaces the unrolled `src == dst` variant, so the emitter is one code path and reads a memory operand once instead of twice); `xadd` stages the sum with `DUP`, ordering the two writes by operand kind, since a register destination must write the source first while a memory destination must store first — its address may read the register the other write changes.

Two related fixes the above needed:

- `xadd` now sets the flags, which it defines exactly like `add` and did not emit at all. `add` and `xadd` share a helper for the string.
- `clz` and the `rev` family keep their condition. `clz` needs a `GOTO` word index, which is now counted from the buffer so a condition prefix cannot shift it, and the `rev` family used `r_strbuf_setf`, erasing the prefix while the closing `,}` was still appended — `revne` reversed unconditionally and left a dangling `}`.

Adds 9 tests under `test/db/esil/`; all fail before the change.