### PR TITLE
Take the x86 operand details from an intel-only capstone handle ##esil

### DIFF
--- a/libr/arch/p/x86/plugin_cs.c
+++ b/libr/arch/p/x86/plugin_cs.c
@@ -113,7 +113,6 @@ struct Getarg {
 	csh handle;
 	cs_insn *insn;
 	int bits;
-	int syntax; // R_ARCH_SYNTAX_ATT or R_ARCH_SYNTAX_INTEL
 	// pending zero-extensions for the 32-bit registers this op writes
 	char zext[32];
 };
@@ -275,17 +274,6 @@ static bool is_xmm_reg(cs_x86_op op) {
 }
 
 /**
- * Get normalized operand index for AT&T syntax
- * In AT&T, operands are source,dest so we swap for 2-operand instructions
- */
-static inline int norm_op(int n, int syntax, int op_count) {
-	if (syntax == R_ARCH_SYNTAX_ATT && op_count == 2) {
-		return 1 - n; // swap 0<->1
-	}
-	return n;
-}
-
-/**
  * Translates operand N to esil
  *
  * @param  handle  csh
@@ -339,8 +327,7 @@ static void zext_reg(struct Getarg *gop, const char *reg) {
 }
 
 static void zext_opnd(struct Getarg *gop, int n) {
-	const cs_x86 *x = &gop->insn->detail->x86;
-	const cs_x86_op *op = &x->operands[norm_op (n, gop->syntax, x->op_count)];
+	const cs_x86_op *op = &gop->insn->detail->x86.operands[n];
 	if (op->type == X86_OP_REG) {
 		zext_reg (gop, cs_reg_name (gop->handle, op->reg));
 	}
@@ -429,19 +416,10 @@ static char *getarg(struct Getarg* gop, int n, int set, char *setop, ut32 *bitsi
 		// default blind bitsize which may be wrong
 		*bitsize = 8;
 	}
-	// For AT&T syntax, capstone reports operands in source,dest order
-	// We need to swap indices for 2-operand instructions to normalize
-	int actual_n = n;
-	if (gop->syntax == R_ARCH_SYNTAX_ATT && INSOPS == 2) {
-		actual_n = 1 - n; // swap 0<->1
-	}
-	cs_x86_op op = INSOP (actual_n);
-	if (!insn->detail) {
+	if (!insn->detail || n < 0 || n >= INSOPS) {
 		return NULL;
 	}
-	if (actual_n < 0 || actual_n >= INSOPS) {
-		return NULL;
-	}
+	cs_x86_op op = INSOP (n);
 	if (bitsize) {
 		size_t bs = op.size * 8;
 		*bitsize = bs? bs: 8;
@@ -603,7 +581,6 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		.handle = handle,
 		.insn = insn,
 		.bits = bits,
-		.syntax = as->config->syntax,
 		.zext = {0}
 	};
 	char *src = NULL;
@@ -1164,15 +1141,12 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_MOVDQA:
 	case X86_INS_MOVDQ2Q:
 		{
-		// Use normalized operand indices for AT&T syntax support
-		int dst_idx = norm_op (0, gop.syntax, INSOPS);
-		int src_idx = norm_op (1, gop.syntax, INSOPS);
-		switch (INSOP (dst_idx).type) {
+		switch (INSOP (0).type) {
 		case X86_OP_MEM:
 			if (op->prefix & R_ANAL_OP_PREFIX_REP) {
-				int width = INSOP (dst_idx).size;
-				const char *src = cs_reg_name (handle, INSOP (src_idx).mem.base);
-				const char *dst = cs_reg_name (handle, INSOP (dst_idx).mem.base);
+				int width = INSOP (0).size;
+				const char *src = cs_reg_name (handle, INSOP (1).mem.base);
+				const char *dst = cs_reg_name (handle, INSOP (0).mem.base);
 				const char *counter = (bits == 16)?"cx": (bits==32)?"ecx":"rcx";
 				esilprintf (op, "%s,!,?{,BREAK,},%s,NUM,%s,NUM,"\
 						"%s,[%d],%s,=[%d],df,?{,%d,%s,-=,%d,%s,-=,},"\
@@ -1191,17 +1165,14 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			break;
 		case X86_OP_REG:
 		default:
-			if (INSOP (dst_idx).type == X86_OP_MEM) {
-				op->direction = R_ANAL_OP_DIR_READ;
-			}
-			if (INSOP (src_idx).type == X86_OP_MEM) {
+			if (INSOP (1).type == X86_OP_MEM) {
 				// MOV REG, [PTR + IREG*SCALE]
-				op->ireg = cs_reg_name (handle, INSOP (src_idx).mem.index);
-				op->disp = INSOP (src_idx).mem.disp;
-				op->scale = INSOP (src_idx).mem.scale;
+				op->ireg = cs_reg_name (handle, INSOP (1).mem.index);
+				op->disp = INSOP (1).mem.disp;
+				op->scale = INSOP (1).mem.scale;
 			}
 			{
-				int width = INSOP (src_idx).size;
+				int width = INSOP (1).size;
 
 				src = getarg (&gop, 1, 0, NULL, NULL);
 				// dst is name of register from instruction.
@@ -2078,13 +2049,12 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 	case X86_INS_LZCNT:
 	case X86_INS_TZCNT:
 		{
-			const int dst_idx = norm_op (0, gop.syntax, INSOPS);
-			const char *reg = (INSOP (dst_idx).type == X86_OP_REG)
-				? cs_reg_name (handle, INSOP (dst_idx).reg): NULL;
+			const char *reg = (INSOP (0).type == X86_OP_REG)
+				? cs_reg_name (handle, INSOP (0).reg): NULL;
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			if (reg && src) {
 				const int id = insn->id;
-				const int bits = INSOP (dst_idx).size * 8;
+				const int bits = INSOP (0).size * 8;
 				RStrBuf *sb = r_strbuf_new ("");
 				zext_reg (&gop, reg);
 				r_strbuf_appendf (sb, "%s,%s,=", src, reg);
@@ -2117,16 +2087,14 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 		break;
 	case X86_INS_MOVBE:
 		{
-			const int dst_idx = norm_op (0, gop.syntax, INSOPS);
-			const int src_idx = norm_op (1, gop.syntax, INSOPS);
 			src = getarg (&gop, 1, 0, NULL, NULL);
 			dst = getarg (&gop, 0, 1, NULL, NULL);
 			if (src && dst) {
 				// swapping in place reads memory once
-				const bool to_reg = INSOP (dst_idx).type == X86_OP_REG;
+				const bool to_reg = INSOP (0).type == X86_OP_REG;
 				const char *val = to_reg
-					? cs_reg_name (handle, INSOP (dst_idx).reg): src;
-				char *sw = byteswap_expr (val, INSOP (src_idx).size);
+					? cs_reg_name (handle, INSOP (0).reg): src;
+				char *sw = byteswap_expr (val, INSOP (1).size);
 				if (to_reg) {
 					esilprintf (op, "%s,%s,%s,%s", src, dst, sw, dst);
 				} else {
@@ -2531,7 +2499,7 @@ static void anop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, 
 			zext_opnd (&gop, 1);
 			char *fl = add_flags (bitsize);
 			// the sum is staged, so xadd r,r doubles r instead of zeroing it
-			if (INSOP (norm_op (0, gop.syntax, INSOPS)).type == X86_OP_MEM) {
+			if (INSOP (0).type == X86_OP_MEM) {
 				// src may address dst, so the store goes before it
 				esilprintf (op, "%s,DUP,%s,+,%s,%s,%s,=", dst, src, dst2, fl, src);
 			} else {
@@ -3272,18 +3240,15 @@ static void op_stackidx(RAnalOp *op, cs_insn *insn, bool minus) {
 	}
 }
 
-static void set_opdir(RAnalOp *op, cs_insn *insn, int syntax) {
-	// Use normalized operand indices for AT&T syntax support
-	int dst_idx = norm_op (0, syntax, INSOPS);
-	int src_idx = norm_op (1, syntax, INSOPS);
+static void set_opdir(RAnalOp *op, cs_insn *insn) {
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_MOV:
-		switch (INSOP (dst_idx).type) {
+		switch (INSOP (0).type) {
 		case X86_OP_MEM:
 			op->direction = R_ANAL_OP_DIR_WRITE;
 			break;
 		case X86_OP_REG:
-			if (INSOP (src_idx).type == X86_OP_MEM) {
+			if (INSOP (1).type == X86_OP_MEM) {
 				op->direction = R_ANAL_OP_DIR_READ;
 			}
 			break;
@@ -3710,11 +3675,10 @@ static void anop(RArchSession *a, RAnalOp *op, ut64 addr, const ut8 *buf, int le
 		op->type = R_ANAL_OP_TYPE_MOV;
 		op0_memimmhandle (op, insn, addr, regsz);
 		op1_memimmhandle (op, insn, addr, regsz);
-		const int src_idx = norm_op (1, a->config->syntax, INSOPS);
-		if (INSOP (src_idx).type == X86_OP_MEM) {
-			op->ireg = cs_reg_name (*handle, INSOP (src_idx).mem.index);
-			op->disp = INSOP (src_idx).mem.disp;
-			op->scale = INSOP (src_idx).mem.scale;
+		if (INSOP (1).type == X86_OP_MEM) {
+			op->ireg = cs_reg_name (*handle, INSOP (1).mem.index);
+			op->disp = INSOP (1).mem.disp;
+			op->scale = INSOP (1).mem.scale;
 		}
 		}
 		break;
@@ -4445,7 +4409,7 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		}
 		anop (as, op, addr, buf, len, &handle, insn);
-		set_opdir (op, insn, as->config->syntax);
+		set_opdir (op, insn);
 		if (mask & R_ARCH_OP_MASK_ESIL) {
 			anop_esil (as, op, addr, buf, len, handle, insn);
 		}

--- a/subprojects/capstone-v5.mk
+++ b/subprojects/capstone-v5.mk
@@ -4,7 +4,7 @@ WRAP_wrap_git_url:=https://github.com/capstone-engine/capstone.git
 WRAP_wrap_git_revision:=49e5aef5bc8b1abb1840f56db4340a9051397df7
 WRAP_wrap_git_patch_directory:=capstone-v5
 WRAP_wrap_git_directory:=capstone-v5
-WRAP_wrap_git_diff_files:=capstone-v5/capstone-patches/fix-x86-16.patch,capstone-v5/capstone-patches/fix-arm-post-index.patch
+WRAP_wrap_git_diff_files:=capstone-v5/capstone-patches/fix-x86-16.patch,capstone-v5/capstone-patches/fix-arm-post-index.patch,capstone-v5/capstone-patches/fix-x86-att-detail.patch
 WRAP_wrap_git_depth:=1
 
 .PHONY: capstone-v5_clean capstone-v5_all
@@ -17,7 +17,7 @@ capstone-v5_all:
 	cd capstone-v5 && git fetch --depth=1 origin 49e5aef5bc8b1abb1840f56db4340a9051397df7
 	cd capstone-v5 && git checkout FETCH_HEAD
 	cp -rf packagefiles/capstone-v5/* capstone-v5
-	for a in capstone-v5/capstone-patches/fix-x86-16.patch capstone-v5/capstone-patches/fix-arm-post-index.patch ; do echo "patch -d capstone-v5 -p1 < $$a" ; patch -d capstone-v5 -p1 < $$a ; done
+	for a in capstone-v5/capstone-patches/fix-x86-16.patch capstone-v5/capstone-patches/fix-arm-post-index.patch capstone-v5/capstone-patches/fix-x86-att-detail.patch ; do echo "patch -d capstone-v5 -p1 < $$a" ; patch -d capstone-v5 -p1 < $$a ; done
 
 capstone-v5_clean:
 	rm -rf capstone-v5

--- a/subprojects/capstone-v5.wrap
+++ b/subprojects/capstone-v5.wrap
@@ -3,5 +3,5 @@ url = https://github.com/capstone-engine/capstone.git
 revision = 49e5aef5bc8b1abb1840f56db4340a9051397df7
 patch_directory = capstone-v5
 directory = capstone-v5
-diff_files = capstone-v5/capstone-patches/fix-x86-16.patch, capstone-v5/capstone-patches/fix-arm-post-index.patch
+diff_files = capstone-v5/capstone-patches/fix-x86-16.patch, capstone-v5/capstone-patches/fix-arm-post-index.patch, capstone-v5/capstone-patches/fix-x86-att-detail.patch
 depth = 1

--- a/subprojects/packagefiles/capstone-v5/capstone-patches/fix-x86-att-detail.patch
+++ b/subprojects/packagefiles/capstone-v5/capstone-patches/fix-x86-att-detail.patch
@@ -1,0 +1,173 @@
+--- a/arch/X86/X86ATTInstPrinter.c
++++ b/arch/X86/X86ATTInstPrinter.c
+@@ -596,23 +596,24 @@
+ 						SStream_concat(O, "$%"PRIu64, imm);
+ 				} else {
+ 					if (MI->csh->imm_unsigned) {
++						int64_t p = imm;
+ 						if (opsize) {
+ 							switch(opsize) {
+ 								default:
+ 									break;
+ 								case 1:
+-									imm &= 0xff;
++									p &= 0xff;
+ 									break;
+ 								case 2:
+-									imm &= 0xffff;
++									p &= 0xffff;
+ 									break;
+ 								case 4:
+-									imm &= 0xffffffff;
++									p &= 0xffffffff;
+ 									break;
+ 							}
+ 						}
+ 
+-						SStream_concat(O, "$0x%"PRIx64, imm);
++						SStream_concat(O, "$0x%"PRIx64, p);
+ 					} else {
+ 						if (imm == 0x8000000000000000LL)  // imm == -imm
+ 							SStream_concat0(O, "$0x8000000000000000");
+@@ -873,8 +874,10 @@
+ 							MI->flat_insn->detail->x86.operands[MI->flat_insn->detail->x86.op_count - 1].size;
+ 				}
+ 			}
+-		} else
++		} else if (!MI->flat_insn->detail->x86.operands[0].size) {
++			// printPCRelImm leaves the size unset; printOperand does not
+ 			MI->flat_insn->detail->x86.operands[0].size = MI->imm_size;
++		}
+ 	}
+ 
+ 	if (MI->csh->detail) {
+@@ -951,9 +954,10 @@
+ 				// shift all the ops right to leave 1st slot for this new register op
+ 				memmove(&(MI->flat_insn->detail->x86.operands[1]), &(MI->flat_insn->detail->x86.operands[0]),
+ 						sizeof(MI->flat_insn->detail->x86.operands[0]) * (ARR_SIZE(MI->flat_insn->detail->x86.operands) - 1));
++				memset(&(MI->flat_insn->detail->x86.operands[0]), 0, sizeof(MI->flat_insn->detail->x86.operands[0]));
+ 				MI->flat_insn->detail->x86.operands[0].type = X86_OP_IMM;
+ 				MI->flat_insn->detail->x86.operands[0].imm = 1;
+-				MI->flat_insn->detail->x86.operands[0].size = 1;
++				MI->flat_insn->detail->x86.operands[0].size = MI->flat_insn->detail->x86.operands[1].size;
+ 				MI->flat_insn->detail->x86.op_count++;
+ 		}
+ 
+@@ -968,6 +972,7 @@
+ 			// shift all the ops right to leave 1st slot for this new register op
+ 			memmove(&(MI->flat_insn->detail->x86.operands[1]), &(MI->flat_insn->detail->x86.operands[0]),
+ 					sizeof(MI->flat_insn->detail->x86.operands[0]) * (ARR_SIZE(MI->flat_insn->detail->x86.operands) - 1));
++			memset(&(MI->flat_insn->detail->x86.operands[0]), 0, sizeof(MI->flat_insn->detail->x86.operands[0]));
+ 			MI->flat_insn->detail->x86.operands[0].type = X86_OP_REG;
+ 			MI->flat_insn->detail->x86.operands[0].reg = reg;
+ 			MI->flat_insn->detail->x86.operands[0].size = MI->csh->regsize_map[reg];
+@@ -994,6 +999,31 @@
+ 		MI->flat_insn->detail->x86.operands[0].access = access[0];
+ 		MI->flat_insn->detail->x86.operands[1].access = access[1];
+ #endif
++
++		// the public operand array is built as a side effect of printing, so it
++		// comes out in att order; enter/bound/lcall/ljmp are not reversed
++		switch (MI->flat_insn->id) {
++			case X86_INS_ENTER:
++			case X86_INS_BOUND:
++			case X86_INS_LCALL:
++			case X86_INS_LJMP:
++				if (MI->flat_insn->detail->x86.op_count > 1) {
++					uint8_t a0 = MI->flat_insn->detail->x86.operands[0].access;
++					MI->flat_insn->detail->x86.operands[0].access =
++						MI->flat_insn->detail->x86.operands[1].access;
++					MI->flat_insn->detail->x86.operands[1].access = a0;
++				}
++				break;
++			default: {
++				int lo = 0, hi = MI->flat_insn->detail->x86.op_count - 1;
++				for (; lo < hi; lo++, hi--) {
++					cs_x86_op t = MI->flat_insn->detail->x86.operands[lo];
++					MI->flat_insn->detail->x86.operands[lo] = MI->flat_insn->detail->x86.operands[hi];
++					MI->flat_insn->detail->x86.operands[hi] = t;
++				}
++				break;
++			}
++		}
+ 	}
+ }
+ 
+--- a/arch/X86/X86Mapping.c
++++ b/arch/X86/X86Mapping.c
+@@ -1278,33 +1278,61 @@
+ 	{ X86_PUSHGS64, X86_REG_GS, CS_AC_READ },
+ 	{ X86_PUSHSS16, X86_REG_SS, CS_AC_READ },
+ 	{ X86_PUSHSS32, X86_REG_SS, CS_AC_READ },
++	{ X86_RCL16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCL16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCL32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCL32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCL64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCL64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCL8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCL8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCR16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCR16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCR32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCR32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCR64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCR64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_RCR8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_RCR8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROL16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROL16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROL32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROL32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROL64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROL64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROL8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROL8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROR16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROR16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROR32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROR32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROR64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROR64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_ROR8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_ROR8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAL16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAL16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAL32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAL32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAL64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAL64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAL8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAL8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAR16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAR16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAR32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAR32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAR64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAR64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SAR8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SAR8rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHL16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHL16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHL32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHL32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHL64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHL64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHL8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHL8rCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHLD16mrCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHLD16rrCL, X86_REG_CL, CS_AC_READ },
+@@ -1312,9 +1340,13 @@
+ 	{ X86_SHLD32rrCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHLD64mrCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHLD64rrCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHR16mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHR16rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHR32mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHR32rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHR64mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHR64rCL, X86_REG_CL, CS_AC_READ },
++	{ X86_SHR8mCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHR8rCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHRD16mrCL, X86_REG_CL, CS_AC_READ },
+ 	{ X86_SHRD16rrCL, X86_REG_CL, CS_AC_READ },

--- a/test/db/esil/x86_32
+++ b/test/db/esil/x86_32
@@ -2665,3 +2665,64 @@ EXPECT=<<EOF
 51000000
 EOF
 RUN
+
+NAME=x86-32 esil does not depend on asm.syntax
+FILE=malloc://0x200
+ARGS=-a x86 -b 32
+CMDS=<<EOF
+wx 8739
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx a5
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx 6bc805
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx 83f8ab
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: ecx,[4],edi,^,edi,=,edi,ecx,[4],^,ecx,=[4],ecx,[4],edi,^,edi,=
+esil: ecx,[4],edi,^,edi,=,edi,ecx,[4],^,ecx,=[4],ecx,[4],edi,^,edi,=
+esil: esi,[4],edi,=[4],df,?{,4,esi,-=,4,edi,-=,},df,!,?{,4,esi,+=,4,edi,+=,}
+esil: esi,[4],edi,=[4],df,?{,4,esi,-=,4,edi,-=,},df,!,?{,4,esi,+=,4,edi,+=,}
+esil: 32,5,~,32,eax,~,*,DUP,ecx,=,32,ecx,~,-,!,!,DUP,cf,:=,of,:=
+esil: 32,5,~,32,eax,~,*,DUP,ecx,=,32,ecx,~,-,!,!,DUP,cf,:=,of,:=
+esil: 18446744073709551531,eax,==,$z,zf,:=,32,$b,cf,:=,$p,pf,:=,31,$s,sf,:=,18446744073709551531,0x80000000,-,!,31,$o,^,of,:=,4,$b,af,:=
+esil: 18446744073709551531,eax,==,$z,zf,:=,32,$b,cf,:=,$p,pf,:=,31,$s,sf,:=,18446744073709551531,0x80000000,-,!,31,$o,^,of,:=,4,$b,af,:=
+EOF
+RUN
+
+NAME=att string move copies from esi to edi
+FILE=malloc://0x200
+ARGS=-a x86 -b 32 -e asm.syntax=att
+CMDS=<<EOF
+wx 11223344 @ 0x40
+wx a5 @ 0
+aei
+aeim
+ar esi=0x40
+ar edi=0x80
+s 0
+aeip
+aes
+pv4 @ 0x80
+ar esi
+ar edi
+EOF
+EXPECT=<<EOF
+0x44332211
+0x00000044
+0x00000084
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -1971,3 +1971,121 @@ EXPECT=<<EOF
 5100000000000000
 EOF
 RUN
+
+NAME=x86-64 esil does not depend on asm.syntax
+FILE=malloc://0x200
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 8739
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx a5
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx 6bc805
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx d323
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx d313
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx 83f8ab
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+wx c8080000
+e asm.syntax=intel
+ao 1~esil:
+e asm.syntax=att
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: rcx,[4],edi,^,edi,=,edi,rcx,[4],^,rcx,=[4],rcx,[4],edi,^,edi,=,edi,rdi,=
+esil: rcx,[4],edi,^,edi,=,edi,rcx,[4],^,rcx,=[4],rcx,[4],edi,^,edi,=,edi,rdi,=
+esil: rsi,[4],rdi,=[4],df,?{,4,rsi,-=,4,rdi,-=,},df,!,?{,4,rsi,+=,4,rdi,+=,}
+esil: rsi,[4],rdi,=[4],df,?{,4,rsi,-=,4,rdi,-=,},df,!,?{,4,rsi,+=,4,rdi,+=,}
+esil: 32,5,~,32,eax,~,*,DUP,ecx,=,32,ecx,~,-,!,!,DUP,cf,:=,of,:=,ecx,rcx,=
+esil: 32,5,~,32,eax,~,*,DUP,ecx,=,32,ecx,~,-,!,!,DUP,cf,:=,of,:=,ecx,rcx,=
+esil: cl,0x1f,&,?{,cl,0x1f,&,32,-,rbx,[4],>>,1,&,cf,:=,cl,0x1f,&,rbx,[4],<<,rbx,=[4],$z,zf,:=,$p,pf,:=,31,$s,sf,:=,31,rbx,[4],>>,1,&,cf,^,of,:=,}
+esil: cl,0x1f,&,?{,cl,0x1f,&,32,-,rbx,[4],>>,1,&,cf,:=,cl,0x1f,&,rbx,[4],<<,rbx,=[4],$z,zf,:=,$p,pf,:=,31,$s,sf,:=,31,rbx,[4],>>,1,&,cf,^,of,:=,}
+esil: cl,0x1f,&,?{,1,cl,0x1f,&,-,!,?{,30,rbx,[4],>>,1,&,31,rbx,[4],>>,1,&,^,of,:=,},cl,0x1f,&,rbx,[4],<<,1,cl,0x1f,&,-,cf,<<,|,1,cl,0x1f,&,32,-,rbx,[4],>>,>>,|,1,cl,0x1f,&,32,-,rbx,[4],>>,&,cf,:=,rbx,=[4],}
+esil: cl,0x1f,&,?{,1,cl,0x1f,&,-,!,?{,30,rbx,[4],>>,1,&,31,rbx,[4],>>,1,&,^,of,:=,},cl,0x1f,&,rbx,[4],<<,1,cl,0x1f,&,-,cf,<<,|,1,cl,0x1f,&,32,-,rbx,[4],>>,>>,|,1,cl,0x1f,&,32,-,rbx,[4],>>,&,cf,:=,rbx,=[4],}
+esil: 18446744073709551531,eax,==,$z,zf,:=,32,$b,cf,:=,$p,pf,:=,31,$s,sf,:=,18446744073709551531,0x80000000,-,!,31,$o,^,of,:=,4,$b,af,:=
+esil: 18446744073709551531,eax,==,$z,zf,:=,32,$b,cf,:=,$p,pf,:=,31,$s,sf,:=,18446744073709551531,0x80000000,-,!,31,$o,^,of,:=,4,$b,af,:=
+esil: 8,8,rsp,-,=[8],8,rsp,-=
+esil: 8,8,rsp,-,=[8],8,rsp,-=
+EOF
+RUN
+
+NAME=att xchg with a memory destination stores to memory
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e asm.syntax=att
+CMDS=<<EOF
+wx 1122334455667788 @ 0x40
+wx 8739 @ 0
+aei
+aeim
+ar rcx=0x40
+ar rdi=0xaabbccdd
+s 0
+aeip
+aes
+ar rdi
+pv4 @ 0x40
+EOF
+EXPECT=<<EOF
+0x44332211
+0xaabbccdd
+EOF
+RUN
+
+NAME=att shift by cl takes its count from cl
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e asm.syntax=att
+CMDS=<<EOF
+wx 44332211 @ 0x40
+wx d323 @ 0
+aei
+aeim
+ar rbx=0x40
+ar rcx=4
+s 0
+aeip
+aes
+pv4 @ 0x40
+EOF
+EXPECT=<<EOF
+0x12233440
+EOF
+RUN
+
+NAME=att three-operand imul writes the register destination
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e asm.syntax=att
+CMDS=<<EOF
+wx 6bc805
+aei
+ar rax=7
+ar rcx=0
+s 0
+aeip
+aes
+ar rcx
+EOF
+EXPECT=<<EOF
+0x00000023
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Reworked per @trufae's suggestion — the fix is in capstone now, not in r2.

Under `asm.syntax=att`, r2 computed different ESIL for the same bytes: 909 of 20000 random windows on x86-64, 945 on x86-32. `xchg [rcx], edi` emitted no store, `movsd` copied the wrong direction, 3-operand `imul` assigned to its immediate, and `rol dword [rbx], cl` emitted nothing at all.

The cause is capstone's AT&T printer building `insn->detail` while printing: it stores operands in print order, stores the print-masked immediate, and `insn_regs_att` was missing the 32 memory-form implicit-CL rows. Fixed in `capstone-patches/fix-x86-att-detail.patch`, next to the existing `fix-x86-16.patch` in the same file.

r2 then compensates for nothing — `norm_op()` and its eight call sites are deleted.

Verification: syntax invariance 4065/4065 across all arches; over 20000 random windows per bitness, Intel/MASM/AT&T-text are byte-identical to master and AT&T now matches Intel on every field r2 reads. Full r2r clean, 6 new tests.