### PR TITLE
Fix the ppc mullw, sraw and srad esil and model the missing forms ##esil

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -885,14 +885,14 @@ static void toc_invalidate(PluginData *pd, RAnalOp *op, cs_insn *insn) {
 	}
 }
 
-// algebraic shift right: ca = sign(rs) & (low bits shifted out != 0); set ca before rd to stay alias-safe
+// ca = sign(rs) & (bits shifted out != 0); ca before rd for alias safety
 static void set_sra(RAnalOp *op, const char *rd, const char *rs, const char *cnt, bool w64, const char *mask) {
 	const char *sgn = w64? "0x8000000000000000": "0x80000000";
 	const char *lo = w64? "0xffffffffffffffff": "0xffffffff";
 	char sx[48];
 	const char *v = rs;
 	if (!w64) {
-		// the word forms shift the sign-extended low word, not the raw 64-bit register
+		// word forms shift the sign-extended low word
 		snprintf (sx, sizeof (sx), "32,%s,~", rs);
 		v = sx;
 	}
@@ -2152,12 +2152,19 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_SRAW:
 		case PPC_INS_SRAD:
 			{
-				char m[32];
 				const bool w64 = insn->id == PPC_INS_SRAD;
+				const char *cbits = w64? "0x3f": "0x1f";
+				const char *obit = w64? "0x40": "0x20";
+				const char *rb = ARG (2);
+				char cnt[64], mask[64];
 				op->sign = true;
 				op->type = R_ANAL_OP_TYPE_SAR;
-				snprintf (m, sizeof (m), "1,%s,0x3f,&,1,<<,-", ARG (2));
-				set_sra (op, ARG (0), ARG (1), ARG (2), w64, m);
+				// a count >= the width shifts every bit out
+				snprintf (cnt, sizeof (cnt), "%s,%s,&,%s,%s,&,!,!,%s,*,|",
+					rb, cbits, rb, obit, cbits);
+				snprintf (mask, sizeof (mask), "1,%s,%s,&,1,<<,-,%s,%s,&,!,!,0,-,|",
+					rb, cbits, rb, obit);
+				set_sra (op, ARG (0), ARG (1), cnt, w64, mask);
 			}
 			break;
 		case PPC_INS_SRAWI:
@@ -2178,10 +2185,14 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_MULLI:
 			op->sign = true;
-		case PPC_INS_MULLW:
 		case PPC_INS_MULLD:
 			op->type = R_ANAL_OP_TYPE_MUL;
 			esilprintf (op, "%s,%s,*,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_MULLW:
+			op->type = R_ANAL_OP_TYPE_MUL;
+			// the word forms multiply the sign-extended low words
+			esilprintf (op, "32,%s,~,32,%s,~,*,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_MULHW:
 		case PPC_INS_MULHD:

--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1128,19 +1128,40 @@ static void ppc_esil_stx(RAnalOp *op, PluginData *pd, struct Getarg *gop, int wi
 	}
 }
 
-// 32-bit rotate by hand (ESIL ROL is 64-bit); wrapping mask (MB>ME) also fills bits 32:63
+// 32-bit rotate by hand, because ESIL ROL is 64-bit
+static void ppc_rotl32(char *buf, size_t sz, const char *sh, const char *rs) {
+	snprintf (buf, sz, "%s,0x1f,&,%s,<<,%s,0x1f,&,32,-,%s,0xffffffff,&,>>,|,0xffffffff,&",
+		sh, rs, sh, rs);
+}
+
 static void ppc_esil_rlwnm(RAnalOp *op, PluginData *pd, struct Getarg *gop, const char *mask, bool wrap) {
 	const char *sh = getarg2 (pd, gop, 2, "");
 	const char *rs = getarg2 (pd, gop, 1, "");
 	const char *rd = getarg2 (pd, gop, 0, "");
 	char rot[128];
-	snprintf (rot, sizeof (rot), "%s,0x1f,&,%s,<<,%s,0x1f,&,32,-,%s,0xffffffff,&,>>,|,0xffffffff,&",
-		sh, rs, sh, rs);
+	ppc_rotl32 (rot, sizeof (rot), sh, rs);
 	if (wrap) {
 		esilprintf (op, "%s,%s,&,32,%s,<<,|,%s,=", rot, mask, rot, rd);
 	} else {
 		esilprintf (op, "%s,%s,&,%s,=", rot, mask, rd);
 	}
+}
+
+// rlwimi/rldimi insert: the bits the mask misses keep rA's old value
+static void ppc_esil_insert(RAnalOp *op, const char *val, ut64 mask, const char *rd) {
+	esilprintf (op, "%s,0x%"PFMT64x",&,%s,0x%"PFMT64x",&,|,%s,=", val, mask, rd, ~mask, rd);
+}
+
+static void ppc_esil_rlwimi(RAnalOp *op, PluginData *pd, struct Getarg *gop, ut64 mask) {
+	char rot[128], val[272];
+	ppc_rotl32 (rot, sizeof (rot), getarg2 (pd, gop, 2, ""), getarg2 (pd, gop, 1, ""));
+	// only a wrapping mask reaches bits 32:63; else the copy is dead
+	if (mask >> 32) {
+		snprintf (val, sizeof (val), "%s,32,%s,<<,|", rot, rot);
+	} else {
+		r_str_ncpy (val, rot, sizeof (val));
+	}
+	ppc_esil_insert (op, val, mask, getarg2 (pd, gop, 0, ""));
 }
 
 static void ppc_fpop(RAnalOp *op, PluginData *pd, struct Getarg *gop, bool single, int nsrc, const char *fop) {
@@ -2195,12 +2216,25 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			esilprintf (op, "32,%s,~,32,%s,~,*,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_MULHW:
+			op->sign = true;
+			op->type = R_ANAL_OP_TYPE_MUL;
+			esilprintf (op, "32,32,%s,~,32,%s,~,*,>>,%s,=", ARG (2), ARG (1), ARG (0));
+			break;
+		case PPC_INS_MULHWU:
+			op->type = R_ANAL_OP_TYPE_MUL;
+			esilprintf (op, "32,0xffffffff,%s,&,0xffffffff,%s,&,*,>>,%s,=",
+				ARG (2), ARG (1), ARG (0));
+			break;
 		case PPC_INS_MULHD:
 			op->sign = true;
-		case PPC_INS_MULHWU:
+			op->type = R_ANAL_OP_TYPE_MUL;
+			// signed high = unsigned high - rA<0?rB:0 - rB<0?rA:0
+			esilprintf (op, "%s,%s,L*,POP,63,%s,>>,%s,*,0,-,+,63,%s,>>,%s,*,0,-,+,%s,=",
+				ARG (2), ARG (1), ARG (1), ARG (2), ARG (2), ARG (1), ARG (0));
+			break;
 		case PPC_INS_MULHDU:
 			op->type = R_ANAL_OP_TYPE_MUL;
-			// type only: ESIL has no high-half multiply operator
+			esilprintf (op, "%s,%s,L*,POP,%s,=", ARG (2), ARG (1), ARG (0));
 			break;
 		case PPC_INS_SUB:
 		case PPC_INS_SUBC:
@@ -2763,6 +2797,14 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			break;
 		case PPC_INS_RLWIMI:
 			op->type = R_ANAL_OP_TYPE_ROL;
+			if (INSOP (2).type == PPC_OP_IMM && INSOP (3).type == PPC_OP_IMM
+					&& INSOP (4).type == PPC_OP_IMM) {
+				const ut32 mb = getarg (&gop, 3) & 0x1f;
+				const ut32 me = getarg (&gop, 4) & 0x1f;
+				// a wrapping mask covers the whole high word
+				const ut64 hi = (mb > me)? 0xffffffff00000000ULL: 0;
+				ppc_esil_rlwimi (op, pd, &gop, mask32 (mb, me) | hi);
+			}
 			break;
 		case PPC_INS_RLDCL:
 		case PPC_INS_RLDICL:
@@ -2777,8 +2819,18 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_RLDIC:
 		case PPC_INS_RLDIMI:
 			op->type = R_ANAL_OP_TYPE_ROL;
-			// type only: rldic masks mb..63-sh and rldimi inserts into the
-			// destination; neither is expressible via cmask64(mb,me)
+			if (INSOP (2).type == PPC_OP_IMM && INSOP (3).type == PPC_OP_IMM) {
+				// both mask mb..63-sh, rldimi also keeps rA
+				const ut64 sh = getarg (&gop, 2) & 0x3f;
+				const ut64 m = mask64 (getarg (&gop, 3) & 0x3f, 63 - sh);
+				char rot[64];
+				snprintf (rot, sizeof (rot), "%s,%s,ROL", ARG (2), ARG (1));
+				if (insn->id == PPC_INS_RLDIMI) {
+					ppc_esil_insert (op, rot, m, ARG (0));
+				} else {
+					esilprintf (op, "%s,0x%"PFMT64x",&,%s,=", rot, m, ARG (0));
+				}
+			}
 			break;
 		}
 		if (stateful) {

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1065,12 +1065,15 @@ type: mov
 --
 mnemonic: mulhwu
 type: mul
+esil: 32,0xffffffff,r9,&,0xffffffff,r3,&,*,>>,r30,=
 --
 mnemonic: rldic
 type: rol
+esil: 0x2,r26,ROL,0xfffffffc,&,r26,=
 --
 mnemonic: rldimi
 type: rol
+esil: 0x7,r10,ROL,0xffffff80,&,r9,0xffffffff0000007f,&,|,r9,=
 EOF
 RUN
 

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -779,3 +779,31 @@ EXPECT=<<EOF
 0xfffffff8
 EOF
 RUN
+
+NAME=sraw takes the low count bits ppc-32
+FILE=malloc://0x100
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7c832e30
+aei
+aeim
+ar r4=0x80000005
+ar r5=64
+aepc 0
+aes
+ar r3
+ar ca
+ar r4=0x80000005
+ar r5=32
+aepc 0
+aes
+ar r3
+ar ca
+EOF
+EXPECT=<<EOF
+0x80000005
+0x00000000
+0xffffffff
+0x00000001
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -2270,3 +2270,63 @@ EXPECT=<<EOF
 0x00000008
 EOF
 RUN
+
+NAME=mullw multiplies the sign-extended low words ppc-64
+FILE=malloc://0x100
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7c6429d6
+aei
+aeim
+ar r4=0xa5a5000400000002
+ar r5=0xa5a5000500000003
+aepc 0
+aes
+ar r3
+ar r4=0xa5a50004ffffffff
+ar r5=0xa5a5000500000002
+aepc 0
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0x00000006
+0xfffffffffffffffe
+EOF
+RUN
+
+NAME=sraw and srad take the low count bits ppc-64
+FILE=malloc://0x100
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 7c832e307c832e34
+aei
+aeim
+ar r4=0xa5a5000480000005
+ar r5=0xa5a5000500000040
+aepc 0
+aes
+ar r3
+ar ca
+ar r4=0xa5a5000480000001
+ar r5=0xa5a5000500000004
+aepc 0
+aes
+ar r3
+ar ca
+ar r4=0x8000000000000005
+ar r5=64
+aepc 4
+aes
+ar r3
+ar ca
+EOF
+EXPECT=<<EOF
+0xffffffff80000005
+0x00000000
+0xfffffffff8000000
+0x00000001
+0xffffffffffffffff
+0x00000001
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -2330,3 +2330,64 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=rotate-insert and high multiply emulation ppc-64
+FILE=malloc://0x100
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+wx 5083221e508327067883440c788322087c6428967c6428167c6428927c642812
+aei
+aeim
+ar r3=0xa5a5000389abcdef
+ar r4=0xa5a50004123456f8
+aepc 0
+aes
+ar r3
+ar r3=0xa5a5000389abcdef
+ar r4=0xa5a5000412345678
+aepc 4
+aes
+ar r3
+ar r3=0x89abcdef01234567
+ar r4=0x123456789abcdef0
+aepc 8
+aes
+ar r3
+ar r4=0x123456789abcdef0
+aepc 0xc
+aes
+ar r3
+ar r4=0xa5a50004ffffffff
+ar r5=0xa5a5000500000002
+aepc 0x10
+aes
+ar r3
+aepc 0x14
+aes
+ar r3
+ar r4=0xffffffffffffffff
+ar r5=0xa5a5000500000002
+aepc 0x18
+aes
+ar r3
+aepc 0x1c
+aes
+ar r3
+ar r4=0x8000000000000000
+ar r5=0x8000000000000000
+aepc 0x18
+aes
+ar r3
+EOF
+EXPECT=<<EOF
+0xa5a500038945cdef
+0x2345678129abcde1
+0x89ab789abcdef067
+0x456789abcdef00
+0xffffffff
+0x00000001
+0x00000000
+0xa5a5000500000001
+0x4000000000000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three fixes and seven new models in `libr/arch/p/ppc_cs/plugin.c`.

- `mullw` shared the `mulld` arm and multiplied the whole registers. The ISA multiplies the sign-extended low words, so any source with a non-zero high half gave a wrong product.
- `sraw`/`srad` passed the raw count register to `ASR`. `esil_asr` rewrites a count above `regsize - 1` to **30**, and `regsize` is 32 under `-b 32`, so a count with a garbage high half, or any count >= the shift width, produced a meaningless result at both bit widths. The count is now taken from the low 6 (word) / 7 (dword) bits the ISA defines, saturating at width - 1.
- `srad` left `CA` clear for counts >= 64, where the whole register shifts out.

**New esil**: `mulhw`, `mulhwu`, `mulhd`, `mulhdu`, `rlwimi`, `rldic`, `rldimi` (`insrwi` assembles to `rlwimi`, so it is covered too). `mulhw`/`mulhwu` leave `RT[0:31]` architecturally undefined; this zero-extends, matching qemu.

Validated against qemu-ppc64 / qemu-ppc single-stepped under gdb, comparing full architectural state per instruction, so no expected value is hand-computed:

| | before | after |
|---|---|---|
| 64-bit width + shift-count suites | 22 FAIL, 20 NOESIL | 0 FAIL, 5 NOESIL |
| 32-bit | 7 FAIL, 13 NOESIL | 0 FAIL, 3 NOESIL |
| everything, incl. operand-alias permutations | | 1347/1347 and 1004/1004 OK |

Adds 4 `db/esil/ppc_{32,64}` emulation tests (seeded from the oracle cases) and updates the `db/anal/ppc` completeness golden for the three that stop being empty. 

Still without esil, both out of scope here: `cntlzw`/`cntlzd` and `popcnt{b,w,d}` need a `CLZ`/`POPCNT` primitive in `libr/esil` (arm's `clz` fakes one with a `GOTO` loop today), and `mullwo` is not decoded by capstone v5.