### PR TITLE
Fix the arm adc, sbc and rsc esil and the post-index writeback ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -2654,6 +2654,22 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 #define MATH32_NEG(opchar) arm32math(as, op, addr, buf, len, handle, insn, pcdelta, str, opchar, 1)
 #define MATH32AS(opchar) arm32mathaddsub(as, op, addr, buf, len, handle, insn, pcdelta, str, opchar)
 
+// adc = rn + op2 + c, sbc = rn + ~op2 + c, rsc = op2 + ~rn + c
+static void arm32carry(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn, RStringShort str[32]) {
+	const bool three = OPCOUNT () > 2;
+	const char *rn = three? ARG (1): ARG (0);
+	const char *op2 = three? ARG (2): ARG (1);
+	const bool rev = insn->id == ARM_INS_RSC;
+	const char *comp = (insn->id == ARM_INS_ADC)? "": ",0xffffffff,^";
+	char sh[80];
+	if (OPCOUNT () > 3) { // the modified-immediate form carries its own rotate
+		snprintf (sh, sizeof (sh), "%s,%s,ROR", ARG (3), op2);
+		op2 = sh;
+	}
+	r_strbuf_appendf (&op->esil, "cf,%s%s,+,%s,+,0xffffffff,&,%s,=",
+		rev? rn: op2, comp, rev? op2: rn, ARG (0));
+}
+
 static void arm32math(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf, int len,
 	csh *handle, cs_insn *insn, int pcdelta, RStringShort str[32], const char *opchar, int negate) {
 	const char *dest = ARG(0);
@@ -2781,11 +2797,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 		MATH32 ("+");
 		break;
 	case ARM_INS_ADC:
-		if (OPCOUNT () == 2) {
-			r_strbuf_appendf (&op->esil, "cf,%s,+=,%s,%s,+=", ARG (0), ARG (1), ARG (0));
-		} else {
-			r_strbuf_appendf (&op->esil, "cf,%s,+=,%s,%s,+,%s,+=", ARG (0), ARG (2), ARG (1), ARG (0));
-		}
+	case ARM_INS_SBC:
+	case ARM_INS_RSC:
+		arm32carry (as, op, handle, insn, str);
 		break;
 	case ARM_INS_SSUB16:
 	case ARM_INS_SSUB8:
@@ -2794,13 +2808,6 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 	case ARM_INS_SUBW:
 	case ARM_INS_SUB:
 		MATH32 ("-");
-		break;
-	case ARM_INS_SBC:
-		if (OPCOUNT () == 2) {
-			r_strbuf_appendf (&op->esil, "cf,%s,-=,%s,%s,-=", ARG (0), ARG (1), ARG (0));
-		} else {
-			r_strbuf_appendf (&op->esil, "cf,%s,-=,%s,%s,+,%s,-=", ARG (0), ARG (2), ARG (1), ARG (0));
-		}
 		break;
 	case ARM_INS_MUL:
 		MATH32 ("*");
@@ -3547,6 +3554,7 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 			break;
 		case ARM_INS_ADD:
 		case ARM_INS_RSB:
+		case ARM_INS_RSC:
 		case ARM_INS_SUB:
 		case ARM_INS_SBC:
 		case ARM_INS_ADC:

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -3377,8 +3377,9 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 				if (ISWRITEBACK32 ()) {
 					if (ISPOSTINDEX32 ()) {
 						if (ISIMM (2)) {
-							r_strbuf_appendf (&op->esil, ",%s,%d,+,%s,=",
-								MEMBASE (1), IMM (2), MEMBASE (1));
+							const char op_index = ISMEMINDEXSUB (2)? '-': '+';
+							r_strbuf_appendf (&op->esil, ",%d,%s,%c,%s,=",
+								IMM (2), MEMBASE (1), op_index, MEMBASE (1));
 						} else {
 							const char op_index = ISMEMINDEXSUB (2)? '-': '+';
 							r_strbuf_appendf (&op->esil, ",%d,%s,<<,%s,%c,%s,=",

--- a/subprojects/capstone-v5.mk
+++ b/subprojects/capstone-v5.mk
@@ -4,7 +4,7 @@ WRAP_wrap_git_url:=https://github.com/capstone-engine/capstone.git
 WRAP_wrap_git_revision:=49e5aef5bc8b1abb1840f56db4340a9051397df7
 WRAP_wrap_git_patch_directory:=capstone-v5
 WRAP_wrap_git_directory:=capstone-v5
-WRAP_wrap_git_diff_files:=capstone-v5/capstone-patches/fix-x86-16.patch
+WRAP_wrap_git_diff_files:=capstone-v5/capstone-patches/fix-x86-16.patch,capstone-v5/capstone-patches/fix-arm-post-index.patch
 WRAP_wrap_git_depth:=1
 
 .PHONY: capstone-v5_clean capstone-v5_all
@@ -17,7 +17,7 @@ capstone-v5_all:
 	cd capstone-v5 && git fetch --depth=1 origin 49e5aef5bc8b1abb1840f56db4340a9051397df7
 	cd capstone-v5 && git checkout FETCH_HEAD
 	cp -rf packagefiles/capstone-v5/* capstone-v5
-	for a in capstone-v5/capstone-patches/fix-x86-16.patch ; do echo "patch -d capstone-v5 -p1 < $$a" ; patch -d capstone-v5 -p1 < $$a ; done
+	for a in capstone-v5/capstone-patches/fix-x86-16.patch capstone-v5/capstone-patches/fix-arm-post-index.patch ; do echo "patch -d capstone-v5 -p1 < $$a" ; patch -d capstone-v5 -p1 < $$a ; done
 
 capstone-v5_clean:
 	rm -rf capstone-v5

--- a/subprojects/capstone-v5.wrap
+++ b/subprojects/capstone-v5.wrap
@@ -3,5 +3,5 @@ url = https://github.com/capstone-engine/capstone.git
 revision = 49e5aef5bc8b1abb1840f56db4340a9051397df7
 patch_directory = capstone-v5
 directory = capstone-v5
-diff_files = capstone-v5/capstone-patches/fix-x86-16.patch
+diff_files = capstone-v5/capstone-patches/fix-x86-16.patch, capstone-v5/capstone-patches/fix-arm-post-index.patch
 depth = 1

--- a/subprojects/packagefiles/capstone-v5/capstone-patches/fix-arm-post-index.patch
+++ b/subprojects/packagefiles/capstone-v5/capstone-patches/fix-arm-post-index.patch
@@ -1,0 +1,38 @@
+diff --git a/arch/ARM/ARMInstPrinter.c b/arch/ARM/ARMInstPrinter.c
+index a7a7bef..5cd2a23 100644
+--- a/arch/ARM/ARMInstPrinter.c
++++ b/arch/ARM/ARMInstPrinter.c
+@@ -376,6 +376,9 @@ void ARM_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
+ 			case ARM_LDC_POST:
+ 
+ 			case ARM_LDRBT_POST:
++			case ARM_LDRBT_POST_IMM:
++			case ARM_LDRBT_POST_REG:
++			case ARM_LDRB_POST_REG:
+ 			case ARM_LDRD_POST:
+ 			case ARM_LDRH_POST:
+ 			case ARM_LDRSB_POST:
+@@ -387,14 +390,23 @@ void ARM_post_printer(csh ud, cs_insn *insn, char *insn_asm, MCInst *mci)
+ 			case ARM_STC_POST:
+ 
+ 			case ARM_STRBT_POST:
++			case ARM_STRBT_POST_IMM:
++			case ARM_STRBT_POST_REG:
++			case ARM_STRB_POST_REG:
+ 			case ARM_STRD_POST:
+ 			case ARM_STRH_POST:
+ 
+ 			case ARM_LDRB_POST_IMM:
++			case ARM_LDRT_POST:
++			case ARM_LDRT_POST_IMM:
++			case ARM_LDRT_POST_REG:
+ 			case ARM_LDR_POST_IMM:
+ 			case ARM_LDR_POST_REG:
+ 			case ARM_STRB_POST_IMM:
+ 
++			case ARM_STRT_POST:
++			case ARM_STRT_POST_IMM:
++			case ARM_STRT_POST_REG:
+ 			case ARM_STR_POST_IMM:
+ 			case ARM_STR_POST_REG:
+ 				insn->detail->arm.writeback = true;

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3296,3 +3296,47 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=the unprivileged loads write back their post-index offset
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 11223344 @ 0x40
+wx 0100f3e4 @ 0
+aei
+aeim
+aer r3=0x40
+aer PC=0
+aes
+aer r0
+aer r3
+wx 0400b3e4 @ 0
+aer r3=0x40
+aer PC=0
+aes
+aer r0
+aer r3
+wx 0100b3e6 @ 0
+aer r3=0x40
+aer r1=4
+aer PC=0
+aes
+aer r0
+aer r3
+wx 040013e4 @ 0
+aer r3=0x40
+aer PC=0
+aes
+aer r0
+aer r3
+EOF
+EXPECT=<<EOF
+0x00000011
+0x00000041
+0x44332211
+0x00000044
+0x44332211
+0x00000044
+0x44332211
+0x0000003c
+EOF
+RUN

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3224,3 +3224,75 @@ EXPECT=<<EOF
 0x00001234
 EOF
 RUN
+
+NAME=adc sbc and rsc assign their result instead of accumulating it
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 0200a1e0
+aer cpsr=0x20000000
+aer r0=0x1000
+aer r1=9
+aer r2=3
+aer PC=0
+aes
+aer r0
+wx 0200c1e0
+aer cpsr=0x20000000
+aer r0=0x1000
+aer r1=9
+aer r2=3
+aer PC=0
+aes
+aer r0
+wx 0200e1e0
+aer cpsr=0x20000000
+aer r0=0x1000
+aer r1=9
+aer r2=3
+aer PC=0
+aes
+aer r0
+wx 010da1e2
+aer cpsr=0x20000000
+aer r0=0x1000
+aer r1=9
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x0000000d
+0x00000006
+0xfffffffa
+0x0000004a
+EOF
+RUN
+
+NAME=sbc and rsc borrow the complement of the carry flag
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+wx 0200c1e0
+aer cpsr=0
+aer r0=0x1000
+aer r1=9
+aer r2=3
+aer PC=0
+aes
+aer r0
+wx 0200e1e0
+aer cpsr=0
+aer r0=0x1000
+aer r1=9
+aer r2=3
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x00000005
+0xfffffff9
+EOF
+RUN
+


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Six arm32 esil defects, found by differential runs against the Unicorn engine.

**In r2** (`libr/arch/p/arm/plugin_cs.c`):

- `adc`/`sbc` accumulated onto the old destination (`cf,r0,+=,r2,r1,+,r0,+=`), which is only correct when `rd` already held 0. They now assign.
- `sbc` had the carry polarity backwards — ARM computes `Rn + ~Op2 + C`.
- `rsc` had no case at all, so it computed nothing.
- All three dropped the rotate of the modified-immediate form.
- The post-index immediate writeback ignored the subtract bit, so `ldr r0,[fp],-4` moved the base the wrong way. Pre-existing for plain `ldr`.

The three carry forms are now one helper instead of three copies of the same `OPCOUNT()` branch.

**In capstone patch**: the T-suffix (unprivileged) loads never reported writeback at all. `ARMInstPrinter.c`'s post-index opcode list has `ARM_LDRBT_POST` and `ARM_STRBT_POST` but not the `_IMM`/`_REG` encodings LLVM actually emits, so this fixes it there rather than working around it in r2 — vendored as`capstone-patches/fix-arm-post-index.patch`. That one hunk takes the arm load/store class from 7/12 to 11/12 with no r2 change at all. Note it only reaches the bundled capstone-v5, not `--with-syscapstone` / `--with-capstone4` / `USE_CSNEXT=1` builds.

Three `db/esil/arm_32` emulation tests (assign-not-accumulate, the borrow polarity, and the unprivileged-load writeback), each confirmed to fail before the fix. Differential suites against Unicorn: arm width, branch and operand-alias runs are unchanged from master, and the operand-shape suite goes 59/60 — the remaining failure is the known `adds r0,r1,r2` carry-flag model, which is separate and untouched here. 