### PR TITLE
Link libr_java in the wasi tool link list ##build

### DIFF
--- a/binr/rules.mk
+++ b/binr/rules.mk
@@ -74,6 +74,8 @@ LINK+=$(LIBR)/lang/libr_lang.a
 LINK+=$(LIBR)/config/libr_config.a
 LINK+=$(LIBR)/muta/libr_muta.a
 LINK+=$(LIBR)/main/libr_main.a
+# libr_anal and libr_bin members reference the java class parser
+LINK+=$(SHLR)/java/libr_java.a
 # extra libs required by XPS static plugins (e.g. libc++ for r2ghidra)
 LINK+=$(EXTERNAL_LINK)
 else ifeq (${COMPILER},wasm)

--- a/libr/anal/p/anal_jni.c
+++ b/libr/anal/p/anal_jni.c
@@ -2,6 +2,7 @@
 
 #include <r_anal.h>
 #include <r_anal_priv.h>
+#include "../../../shlr/java/descriptor.h"
 
 #define JNI_MIN_TABLE_METHODS 2
 #define JNI_MAX_DATA_SECTION (64 * 1024 * 1024)
@@ -15,7 +16,7 @@ typedef struct {
 	ut64 function_addr;
 	char *name;
 	char *descriptor;
-	RBinJavaMember *member;
+	RJavaMember *member;
 } JniMethod;
 
 typedef struct {
@@ -160,7 +161,7 @@ static void jni_function_set_signature(JniScanContext *ctx,
 	// A native table alone cannot tell instance and static receivers apart.
 	jni_function_add_param (params, "jobject", strdup ("receiver"));
 	RListIter *iter;
-	RBinJavaType *argument;
+	RJavaType *argument;
 	int argument_index = 0;
 	r_list_foreach (method->member->arguments, iter, argument) {
 		char *name = r_str_newf ("arg%d", argument_index++);
@@ -217,7 +218,7 @@ static void jni_method_free(void *ptr) {
 	if (method) {
 		free (method->name);
 		free (method->descriptor);
-		r_bin_java_member_free (method->member);
+		r_java_member_free (method->member);
 		free (method);
 	}
 }
@@ -359,8 +360,8 @@ static JniMethod *jni_parse_method(JniScanContext *ctx, const ut8 *buf, ut64 rec
 		free (descriptor);
 		return NULL;
 	}
-	RBinJavaMember *member = r_bin_java_member_parse (NULL, name, descriptor,
-		R_BIN_JAVA_MEMBER_METHOD, 0);
+	RJavaMember *member = r_java_member_parse (NULL, name, descriptor,
+		R_JAVA_MEMBER_METHOD, 0);
 	if (!member) {
 		free (name);
 		free (descriptor);

--- a/libr/bin/mangling/java.c
+++ b/libr/bin/mangling/java.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2011-2026 - pancake */
 
 #include <r_bin.h>
+#include "../../../shlr/java/descriptor.h"
 
 R_API char *r_bin_demangle_java(const char *str) {
 	if (R_STR_ISEMPTY (str)) {
@@ -11,14 +12,14 @@ R_API char *r_bin_demangle_java(const char *str) {
 		return NULL;
 	}
 	char *name = descriptor == str? NULL: r_str_ndup (str, descriptor - str);
-	RBinJavaMember *member = r_bin_java_member_parse (NULL, name, descriptor,
-		R_BIN_JAVA_MEMBER_METHOD, 0);
+	RJavaMember *member = r_java_member_parse (NULL, name, descriptor,
+		R_JAVA_MEMBER_METHOD, 0);
 	free (name);
 	if (!member) {
 		return NULL;
 	}
 	char *result = member->definition;
 	member->definition = NULL;
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	return result;
 }

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -251,51 +251,6 @@ typedef struct r_bin_attr_t {
 } RBinAttr;
 
 typedef enum {
-	R_BIN_JAVA_TYPE_INVALID,
-	R_BIN_JAVA_TYPE_VOID,
-	R_BIN_JAVA_TYPE_BOOLEAN,
-	R_BIN_JAVA_TYPE_BYTE,
-	R_BIN_JAVA_TYPE_CHAR,
-	R_BIN_JAVA_TYPE_SHORT,
-	R_BIN_JAVA_TYPE_INT,
-	R_BIN_JAVA_TYPE_LONG,
-	R_BIN_JAVA_TYPE_FLOAT,
-	R_BIN_JAVA_TYPE_DOUBLE,
-	R_BIN_JAVA_TYPE_OBJECT,
-} RBinJavaTypeKind;
-
-typedef enum {
-	R_BIN_JAVA_MEMBER_CLASS,
-	R_BIN_JAVA_MEMBER_FIELD,
-	R_BIN_JAVA_MEMBER_METHOD,
-} RBinJavaMemberKind;
-
-typedef struct r_bin_java_type_t {
-	RBinJavaTypeKind kind;
-	char *class_name; // JVM internal name for object types
-	char *name; // Java display name
-	char *jni_name;
-	ut16 slots;
-	ut8 array_dimensions;
-} RBinJavaType;
-
-typedef struct r_bin_java_member_t {
-	RBinJavaMemberKind kind;
-	char *class_name;
-	char *name;
-	char *descriptor;
-	ut32 access_flags; // raw JVM access_flags
-	RBinAttr attr; // access_flags normalized to R_BIN_ATTR_*
-	RBinJavaType *type; // field type or method return type
-	RList/*<RBinJavaType *>*/ *arguments; // method arguments
-	char *visibility;
-	char *definition;
-	char *jni_definition;
-	ut16 argument_slots;
-	ut16 return_slots;
-} RBinJavaMember;
-
-typedef enum {
 	R_BIN_RELOC_1 = 1,
 	R_BIN_RELOC_2 = 2,
 	R_BIN_RELOC_4 = 4,
@@ -1094,8 +1049,6 @@ R_API void r_bin_mem_free(void *data);
 // demangle functions
 R_API char *r_bin_demangle(RBinFile *binfile, const char *lang, const char *str, ut64 vaddr, bool libs);
 R_API char *r_bin_demangle_java(const char *str);
-R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char *name, const char *descriptor, RBinJavaMemberKind kind, ut32 access_flags);
-R_API void r_bin_java_member_free(RBinJavaMember *member);
 R_API char *r_bin_demangle_freepascal(const char *str);
 R_API char *r_bin_demangle_cxx(RBinFile *binfile, const char *str, ut64 vaddr);
 R_API char *r_bin_demangle_msvc(const char *str);

--- a/shlr/java/class.c
+++ b/shlr/java/class.c
@@ -4,6 +4,7 @@
 
 #include <math.h>
 #include "class.h"
+#include "descriptor.h"
 
 static inline RBinName *bn_new(const char *name) {
 	R_RETURN_VAL_IF_FAIL (name, NULL);
@@ -156,7 +157,7 @@ static char *r_bin_java_print_unknown_cp_stringify(RBinJavaCPTypeObj *obj);
 static char *r_bin_java_print_utf8_cp_stringify(RBinJavaCPTypeObj *obj);
 static char *r_bin_java_resolve(RBinJavaObj *BIN_OBJ, int idx, ut8 spacy);
 static void r_bin_java_set_imports(RBinJavaObj *bin);
-static char *r_bin_java_unmangle(ut32 flags, const char *name, const char *descriptor, RBinJavaMemberKind kind);
+static char *r_bin_java_unmangle(ut32 flags, const char *name, const char *descriptor, RJavaMemberKind kind);
 
 R_API int r_bin_java_new_bin(RBinJavaObj *bin, ut64 loadaddr, Sdb *kv, const ut8 *buf, ut64 len);
 static ut8 *r_bin_java_cp_get_4bytes(ut8 tag, ut32 *out_sz, const ut8 *buf, const ut64 len);
@@ -655,14 +656,14 @@ static void r_bin_java_reset_bin_info(RBinJavaObj *bin) {
 	bin->interfaces_list = r_list_newf (r_bin_java_interface_free);
 }
 
-static char *r_bin_java_unmangle(ut32 flags, const char *name, const char *descriptor, RBinJavaMemberKind kind) {
-	RBinJavaMember *member = r_bin_java_member_parse (NULL, name, descriptor, kind, flags);
+static char *r_bin_java_unmangle(ut32 flags, const char *name, const char *descriptor, RJavaMemberKind kind) {
+	RJavaMember *member = r_java_member_parse (NULL, name, descriptor, kind, flags);
 	if (!member) {
 		return NULL;
 	}
 	char *result = member->definition;
 	member->definition = NULL;
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	return result;
 }
 
@@ -852,7 +853,7 @@ static void r_bin_java_get_fm_type_definition_json(RBinJavaObj *bin, RBinJavaFie
 	pj_ks (pj, "fq_name", fq_name);
 	free (fq_name);
 
-	const RBinJavaMemberKind kind = is_method? R_BIN_JAVA_MEMBER_METHOD: R_BIN_JAVA_MEMBER_FIELD;
+	const RJavaMemberKind kind = is_method? R_JAVA_MEMBER_METHOD: R_JAVA_MEMBER_FIELD;
 	char *prototype = r_bin_java_unmangle (fm_type->flags, fm_type->name, fm_type->descriptor, kind);
 	pj_ks (pj, "prototype", prototype);
 	free (prototype);
@@ -2162,14 +2163,14 @@ static ut16 r_bin_java_get_method_max_locals(RBinJavaField *fm_type) {
 	return 0;
 }
 
-static RBinJavaMember *r_bin_java_fm_member(RBinJavaField *fm_type) {
-	const RBinJavaMemberKind kind = fm_type->type == R_BIN_JAVA_FIELD_TYPE_METHOD
-		? R_BIN_JAVA_MEMBER_METHOD: R_BIN_JAVA_MEMBER_FIELD;
-	return r_bin_java_member_parse (fm_type->class_name, fm_type->name,
+static RJavaMember *r_bin_java_fm_member(RBinJavaField *fm_type) {
+	const RJavaMemberKind kind = fm_type->type == R_BIN_JAVA_FIELD_TYPE_METHOD
+		? R_JAVA_MEMBER_METHOD: R_JAVA_MEMBER_FIELD;
+	return r_java_member_parse (fm_type->class_name, fm_type->name,
 		fm_type->descriptor, kind, fm_type->flags);
 }
 
-static void r_bin_java_sym_method_info(RBinSymbol *sym, RBinJavaMember *member) {
+static void r_bin_java_sym_method_info(RBinSymbol *sym, RJavaMember *member) {
 	const bool instance = !(member->attr.flags & R_BIN_ATTR_STATIC);
 	if (!instance || member->argument_slots < UT16_MAX) {
 		sym->cc_arg_count = member->argument_slots + (instance? 1: 0);
@@ -2184,11 +2185,11 @@ static void r_bin_java_fill_rbinfield_from_field(RBinField *field, RBinJavaField
 	field->paddr = fm_type->file_offset + baddr;
 	field->attr.kind = R_BIN_FIELD_KIND_FIELD;
 	field->attr.lang = R_BIN_LANG_JAVA;
-	RBinJavaMember *member = r_bin_java_fm_member (fm_type);
+	RJavaMember *member = r_bin_java_fm_member (fm_type);
 	if (member) {
 		field->attr.flags = member->attr.flags;
 		field->type = bn_new (member->type->name);
-		r_bin_java_member_free (member);
+		r_java_member_free (member);
 	}
 }
 
@@ -2198,7 +2199,7 @@ static RBinSymbol *r_bin_java_create_new_symbol_from_field(RBinJavaField *fm_typ
 	}
 	RBinSymbol *sym = R_NEW0 (RBinSymbol);
 	sym->name = bn_new (fm_type->name);
-	RBinJavaMember *member = r_bin_java_fm_member (fm_type);
+	RJavaMember *member = r_bin_java_fm_member (fm_type);
 	if (member) {
 		sym->attr.flags = member->attr.flags;
 		sym->attr.lang = R_BIN_LANG_JAVA;
@@ -2229,7 +2230,7 @@ static RBinSymbol *r_bin_java_create_new_symbol_from_field(RBinJavaField *fm_typ
 	sym->forwarder = "NONE";
 	sym->classname = strdup (r_str_get_fail (fm_type->class_name, "UNKNOWN"));
 	sym->ordinal = fm_type->metas->ord;
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	return sym;
 }
 
@@ -2238,7 +2239,7 @@ static RBinSymbol *r_bin_java_create_new_symbol_from_fm_type_meta(RBinJavaField 
 		return NULL;
 	}
 	RBinSymbol *sym = R_NEW0 (RBinSymbol);
-	RBinJavaMember *member = r_bin_java_fm_member (fm_type);
+	RJavaMember *member = r_bin_java_fm_member (fm_type);
 	char *s = r_str_newf ("meta_%s", fm_type->name);
 	sym->name = bn_new (s);
 	free (s);
@@ -2259,7 +2260,7 @@ static RBinSymbol *r_bin_java_create_new_symbol_from_fm_type_meta(RBinJavaField 
 		sym->attr.flags = member->attr.flags;
 		sym->attr.lang = R_BIN_LANG_JAVA;
 	}
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	return sym;
 }
 
@@ -2383,8 +2384,8 @@ static void r_bin_java_enum_class_methods(RBinJavaObj *bin, ut16 class_idx, RVec
 	RListIter *iter;
 	RBinJavaField *field;
 	r_list_foreach (bin->methods_list, iter, field) {
-		RBinJavaMember *member = r_bin_java_member_parse (class_name, field->name,
-			field->descriptor, R_BIN_JAVA_MEMBER_METHOD, field->flags);
+		RJavaMember *member = r_java_member_parse (class_name, field->name,
+			field->descriptor, R_JAVA_MEMBER_METHOD, field->flags);
 		if (!member) {
 			continue;
 		}
@@ -2398,7 +2399,7 @@ static void r_bin_java_enum_class_methods(RBinJavaObj *bin, ut16 class_idx, RVec
 		sym->paddr = r_bin_java_get_method_code_offset (field);
 		sym->vaddr = sym->paddr;
 		r_bin_java_sym_method_info (sym, member);
-		r_bin_java_member_free (member);
+		r_java_member_free (member);
 	}
 	free (class_name);
 }
@@ -2491,12 +2492,12 @@ R_API RList *r_bin_java_get_classes(RBinJavaObj *bin) {
 	RVecRBinField_init (&k->fields);
 	k->origin = R_BIN_CLASS_ORIGIN_BIN;
 	char *kname = r_bin_java_get_this_class_name (bin);
-	RBinJavaMember *class_member = r_bin_java_member_parse (NULL, kname, NULL,
-		R_BIN_JAVA_MEMBER_CLASS, bin->cf2.access_flags);
+	RJavaMember *class_member = r_java_member_parse (NULL, kname, NULL,
+		R_JAVA_MEMBER_CLASS, bin->cf2.access_flags);
 	if (class_member) {
 		k->attr.flags = class_member->attr.flags;
 		k->visibility_str = strdup (class_member->visibility);
-		r_bin_java_member_free (class_member);
+		r_java_member_free (class_member);
 	}
 	if (!names_only) {
 		r_bin_java_enum_class_methods (bin, bin->cf2.this_class, &k->methods);
@@ -7283,28 +7284,28 @@ R_API RList *r_bin_java_extract_all_bin_type_values(RBinJavaObj *bin_obj) {
 	RBinJavaField *fm_type;
 	// get all field types
 	r_list_foreach (bin_obj->fields_list, fm_type_iter, fm_type) {
-		RBinJavaMember *member = r_bin_java_fm_member (fm_type);
+		RJavaMember *member = r_bin_java_fm_member (fm_type);
 		if (!member) {
 			r_list_free (all_types);
 			return NULL;
 		}
 		r_list_append (all_types, strdup (member->type->name));
-		r_bin_java_member_free (member);
+		r_java_member_free (member);
 	}
 	// get all method types
 	r_list_foreach (bin_obj->methods_list, fm_type_iter, fm_type) {
-		RBinJavaMember *member = r_bin_java_fm_member (fm_type);
+		RJavaMember *member = r_bin_java_fm_member (fm_type);
 		if (!member) {
 			r_list_free (all_types);
 			return NULL;
 		}
 		RListIter *arg_iter;
-		RBinJavaType *argument;
+		RJavaType *argument;
 		r_list_foreach (member->arguments, arg_iter, argument) {
 			r_list_append (all_types, strdup (argument->name));
 		}
 		r_list_append (all_types, strdup (member->type->name));
-		r_bin_java_member_free (member);
+		r_java_member_free (member);
 	}
 	return all_types;
 }
@@ -7321,7 +7322,7 @@ R_API RList *r_bin_java_get_method_definitions(RBinJavaObj *bin) {
 	}
 	r_list_foreach (bin->methods_list, iter, fm_type) {
 		char *definition = r_bin_java_unmangle (fm_type->flags, fm_type->name,
-			fm_type->descriptor, R_BIN_JAVA_MEMBER_METHOD);
+			fm_type->descriptor, R_JAVA_MEMBER_METHOD);
 		r_list_append (the_list, definition);
 	}
 	return the_list;
@@ -7339,7 +7340,7 @@ R_API RList *r_bin_java_get_field_definitions(RBinJavaObj *bin) {
 	}
 	r_list_foreach (bin->fields_list, iter, fm_type) {
 		char *definition = r_bin_java_unmangle (fm_type->flags, fm_type->name,
-			fm_type->descriptor, R_BIN_JAVA_MEMBER_FIELD);
+			fm_type->descriptor, R_JAVA_MEMBER_FIELD);
 		r_list_append (the_list, definition);
 	}
 	return the_list;

--- a/shlr/java/descriptor.c
+++ b/shlr/java/descriptor.c
@@ -1,6 +1,7 @@
 /* radare - LGPL - Copyright 2011-2026 - pancake */
 
 #include <r_bin.h>
+#include "descriptor.h"
 
 // JVM access_flags shared by classes, fields and methods.
 #define JAVA_ACC_PUBLIC 0x0001
@@ -25,7 +26,7 @@ typedef enum {
 	JAVA_STYLE_JNI,
 } JavaTypeStyle;
 
-// indexed by RBinJavaTypeKind - R_BIN_JAVA_TYPE_VOID
+// indexed by RJavaTypeKind - R_JAVA_TYPE_VOID
 static const struct {
 	char tag;
 	ut8 slots;
@@ -43,21 +44,21 @@ static const struct {
 	{ 'D', 2, "double", "jdouble" },
 };
 
-static const char *java_type_name(RBinJavaTypeKind kind, JavaTypeStyle style) {
-	const int idx = (int)kind - R_BIN_JAVA_TYPE_VOID;
+static const char *java_type_name(RJavaTypeKind kind, JavaTypeStyle style) {
+	const int idx = (int)kind - R_JAVA_TYPE_VOID;
 	if (idx < 0 || idx >= (int)R_ARRAY_SIZE (java_primitives)) {
 		return NULL;
 	}
 	return style == JAVA_STYLE_JNI? java_primitives[idx].jni_name: java_primitives[idx].name;
 }
 
-static char *java_type_tostring(const RBinJavaType *type, JavaTypeStyle style) {
+static char *java_type_tostring(const RJavaType *type, JavaTypeStyle style) {
 	if (style == JAVA_STYLE_JNI && type->array_dimensions) {
 		const char *elem = type->array_dimensions == 1? java_type_name (type->kind, JAVA_STYLE_JNI): NULL;
 		return elem? r_str_newf ("%sArray", elem): strdup ("jobjectArray");
 	}
 	char *result = NULL;
-	if (type->kind == R_BIN_JAVA_TYPE_OBJECT) {
+	if (type->kind == R_JAVA_TYPE_OBJECT) {
 		if (style == JAVA_STYLE_JNI) {
 			const char *cn = type->class_name;
 			return strdup (!strcmp (cn, "java/lang/String")? "jstring"
@@ -86,7 +87,7 @@ static char *java_type_tostring(const RBinJavaType *type, JavaTypeStyle style) {
 }
 
 static void java_type_free(void *ptr) {
-	RBinJavaType *type = ptr;
+	RJavaType *type = ptr;
 	if (type) {
 		free (type->class_name);
 		free (type->name);
@@ -112,21 +113,21 @@ static bool java_class_name_valid(const char *name, size_t len) {
 	return true;
 }
 
-static RBinJavaType *java_type_new(RBinJavaTypeKind kind, char *class_name, ut32 dimensions) {
-	RBinJavaType *type = R_NEW0 (RBinJavaType);
+static RJavaType *java_type_new(RJavaTypeKind kind, char *class_name, ut32 dimensions) {
+	RJavaType *type = R_NEW0 (RJavaType);
 	type->kind = kind;
 	type->class_name = class_name;
 	type->array_dimensions = dimensions;
 	type->slots = 1;
-	if (!dimensions && kind != R_BIN_JAVA_TYPE_OBJECT) {
-		type->slots = java_primitives[kind - R_BIN_JAVA_TYPE_VOID].slots;
+	if (!dimensions && kind != R_JAVA_TYPE_OBJECT) {
+		type->slots = java_primitives[kind - R_JAVA_TYPE_VOID].slots;
 	}
 	type->name = java_type_tostring (type, JAVA_STYLE_DISPLAY);
 	type->jni_name = java_type_tostring (type, JAVA_STYLE_JNI);
 	return type;
 }
 
-static RBinJavaType *java_type_parse(const char **cursor, bool allow_void) {
+static RJavaType *java_type_parse(const char **cursor, bool allow_void) {
 	const char *p = *cursor;
 	ut32 dimensions = 0;
 	while (*p == '[') {
@@ -142,7 +143,7 @@ static RBinJavaType *java_type_parse(const char **cursor, bool allow_void) {
 			return NULL;
 		}
 		*cursor = end + 1;
-		return java_type_new (R_BIN_JAVA_TYPE_OBJECT, r_str_ndup (name, end - name), dimensions);
+		return java_type_new (R_JAVA_TYPE_OBJECT, r_str_ndup (name, end - name), dimensions);
 	}
 	size_t i;
 	for (i = 0; i < R_ARRAY_SIZE (java_primitives); i++) {
@@ -150,17 +151,17 @@ static RBinJavaType *java_type_parse(const char **cursor, bool allow_void) {
 			break;
 		}
 	}
-	const RBinJavaTypeKind kind = R_BIN_JAVA_TYPE_VOID + i;
-	if (i == R_ARRAY_SIZE (java_primitives) || (kind == R_BIN_JAVA_TYPE_VOID && (!allow_void || dimensions))) {
+	const RJavaTypeKind kind = R_JAVA_TYPE_VOID + i;
+	if (i == R_ARRAY_SIZE (java_primitives) || (kind == R_JAVA_TYPE_VOID && (!allow_void || dimensions))) {
 		return NULL;
 	}
 	*cursor = p + 1;
 	return java_type_new (kind, NULL, dimensions);
 }
 
-#define JK_C (1 << R_BIN_JAVA_MEMBER_CLASS)
-#define JK_F (1 << R_BIN_JAVA_MEMBER_FIELD)
-#define JK_M (1 << R_BIN_JAVA_MEMBER_METHOD)
+#define JK_C (1 << R_JAVA_MEMBER_CLASS)
+#define JK_F (1 << R_JAVA_MEMBER_FIELD)
+#define JK_M (1 << R_JAVA_MEMBER_METHOD)
 #define JK_ANY (JK_C | JK_F | JK_M)
 
 // the same JVM bit maps to different attributes depending on the member kind
@@ -187,7 +188,7 @@ static const struct {
 	{ JAVA_ACC_HIDDEN, R_BIN_ATTR_HIDDEN, JK_C },
 };
 
-static RBinAttribute java_access_flags(RBinJavaMemberKind kind, ut32 access_flags) {
+static RBinAttribute java_access_flags(RJavaMemberKind kind, ut32 access_flags) {
 	RBinAttribute attr = R_BIN_ATTR_NONE;
 	if (access_flags & JAVA_ACC_PUBLIC) {
 		attr |= R_BIN_ATTR_PUBLIC;
@@ -237,7 +238,7 @@ static void java_member_attributes_tostring(RStrBuf *sb, RBinAttribute attr) {
 	}
 }
 
-static char *java_member_name(const RBinJavaMember *member) {
+static char *java_member_name(const RJavaMember *member) {
 	// '/' only occurs in class names; unqualified member names cannot contain it
 	const char *dot = R_STR_ISNOTEMPTY (member->class_name)? ".": "";
 	char *name = r_str_newf ("%s%s%s", r_str_get (member->class_name), dot, r_str_get (member->name));
@@ -245,11 +246,11 @@ static char *java_member_name(const RBinJavaMember *member) {
 	return name;
 }
 
-static char *java_member_tostring(const RBinJavaMember *member, JavaTypeStyle style) {
+static char *java_member_tostring(const RJavaMember *member, JavaTypeStyle style) {
 	RStrBuf *sb = r_strbuf_new (NULL);
 	java_member_attributes_tostring (sb, member->attr.flags);
 	char *name = java_member_name (member);
-	if (member->kind == R_BIN_JAVA_MEMBER_CLASS) {
+	if (member->kind == R_JAVA_MEMBER_CLASS) {
 		const RBinAttribute flags = member->attr.flags;
 		const char *keyword = (flags & R_BIN_ATTR_ANNOTATION)? "@interface"
 			: (flags & R_BIN_ATTR_INTERFACE)? "interface"
@@ -264,10 +265,10 @@ static char *java_member_tostring(const RBinJavaMember *member, JavaTypeStyle st
 		r_strbuf_appendf (sb, " %s", name);
 	}
 	free (name);
-	if (member->kind == R_BIN_JAVA_MEMBER_METHOD) {
+	if (member->kind == R_JAVA_MEMBER_METHOD) {
 		r_strbuf_append (sb, " (");
 		RListIter *iter;
-		RBinJavaType *argument;
+		RJavaType *argument;
 		r_list_foreach (member->arguments, iter, argument) {
 			const char *comma = iter->p? ", ": "";
 			r_strbuf_appendf (sb, "%s%s", comma, style == JAVA_STYLE_JNI? argument->jni_name: argument->name);
@@ -277,7 +278,7 @@ static char *java_member_tostring(const RBinJavaMember *member, JavaTypeStyle st
 	return r_strbuf_drain (sb);
 }
 
-R_API void r_bin_java_member_free(RBinJavaMember *member) {
+R_API void r_java_member_free(RJavaMember *member) {
 	if (member) {
 		free (member->class_name);
 		free (member->name);
@@ -292,17 +293,17 @@ R_API void r_bin_java_member_free(RBinJavaMember *member) {
 	}
 }
 
-static RBinJavaMember *java_member_finish(RBinJavaMember *member) {
+static RJavaMember *java_member_finish(RJavaMember *member) {
 	member->definition = java_member_tostring (member, JAVA_STYLE_DISPLAY);
 	member->jni_definition = java_member_tostring (member, JAVA_STYLE_JNI);
 	return member;
 }
 
-R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char *name, const char *descriptor, RBinJavaMemberKind kind, ut32 access_flags) {
-	if (kind < R_BIN_JAVA_MEMBER_CLASS || kind > R_BIN_JAVA_MEMBER_METHOD) {
+R_API RJavaMember *r_java_member_parse(const char *class_name, const char *name, const char *descriptor, RJavaMemberKind kind, ut32 access_flags) {
+	if (kind < R_JAVA_MEMBER_CLASS || kind > R_JAVA_MEMBER_METHOD) {
 		return NULL;
 	}
-	RBinJavaMember *member = R_NEW0 (RBinJavaMember);
+	RJavaMember *member = R_NEW0 (RJavaMember);
 	member->kind = kind;
 	member->class_name = R_STR_ISNOTEMPTY (class_name)? strdup (class_name): NULL;
 	member->name = R_STR_ISNOTEMPTY (name)? strdup (name): NULL;
@@ -310,7 +311,7 @@ R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char
 	member->attr.flags = java_access_flags (kind, access_flags);
 	member->attr.lang = R_BIN_LANG_JAVA;
 	member->visibility = strdup (java_visibility (member->attr.flags));
-	if (kind == R_BIN_JAVA_MEMBER_CLASS) {
+	if (kind == R_JAVA_MEMBER_CLASS) {
 		if (!member->name || R_STR_ISNOTEMPTY (descriptor)) {
 			goto beach;
 		}
@@ -321,7 +322,7 @@ R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char
 	}
 	member->descriptor = strdup (descriptor);
 	const char *p = descriptor;
-	if (kind == R_BIN_JAVA_MEMBER_FIELD) {
+	if (kind == R_JAVA_MEMBER_FIELD) {
 		member->type = java_type_parse (&p, false);
 		if (!member->type || *p) {
 			goto beach;
@@ -333,7 +334,7 @@ R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char
 	}
 	member->arguments = r_list_newf (java_type_free);
 	while (*p && *p != ')') {
-		RBinJavaType *argument = java_type_parse (&p, false);
+		RJavaType *argument = java_type_parse (&p, false);
 		if (!argument || member->argument_slots > UT16_MAX - argument->slots) {
 			java_type_free (argument);
 			goto beach;
@@ -356,6 +357,6 @@ R_API RBinJavaMember *r_bin_java_member_parse(const char *class_name, const char
 	}
 	return java_member_finish (member);
 beach:
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	return NULL;
 }

--- a/test/unit/test_bin_demangle.c
+++ b/test/unit/test_bin_demangle.c
@@ -1,4 +1,5 @@
 #include <r_bin.h>
+#include "../../shlr/java/descriptor.h"
 #include "minunit.h"
 
 static char *unit_demangle(RBinFile *bf, const char *symbol, ut64 vaddr) {
@@ -87,10 +88,10 @@ static bool test_demangle_registry(void) {
 }
 
 static bool test_java_descriptor(void) {
-	RBinJavaMember *member = r_bin_java_member_parse (NULL, "nLoadSO",
-		"(ZILjava/lang/String;)Z", R_BIN_JAVA_MEMBER_METHOD, 0x109);
+	RJavaMember *member = r_java_member_parse (NULL, "nLoadSO",
+		"(ZILjava/lang/String;)Z", R_JAVA_MEMBER_METHOD, 0x109);
 	mu_assert_notnull (member, "parse JNI method descriptor");
-	mu_assert_eq (member->kind, R_BIN_JAVA_MEMBER_METHOD, "method kind");
+	mu_assert_eq (member->kind, R_JAVA_MEMBER_METHOD, "method kind");
 	mu_assert_streq (member->name, "nLoadSO", "method name");
 	mu_assert_streq (member->visibility, "public", "method visibility");
 	mu_assert_true (member->attr.flags & R_BIN_ATTR_PUBLIC, "public attribute");
@@ -105,39 +106,39 @@ static bool test_java_descriptor(void) {
 	mu_assert_streq (member->jni_definition,
 		"public static native jboolean nLoadSO (jboolean, jint, jstring)",
 		"JNI definition");
-	RBinJavaType *argument = r_list_get_n (member->arguments, 2);
+	RJavaType *argument = r_list_get_n (member->arguments, 2);
 	mu_assert_notnull (argument, "object argument");
-	mu_assert_eq (argument->kind, R_BIN_JAVA_TYPE_OBJECT, "object kind");
+	mu_assert_eq (argument->kind, R_JAVA_TYPE_OBJECT, "object kind");
 	mu_assert_streq (argument->class_name, "java/lang/String", "internal class name");
 	mu_assert_streq (argument->name, "java.lang.String", "Java class name");
 	mu_assert_streq (argument->jni_name, "jstring", "JNI class name");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 
-	member = r_bin_java_member_parse (NULL, "nativeGreater", "(J[J[JJ)V",
-		R_BIN_JAVA_MEMBER_METHOD, 0);
+	member = r_java_member_parse (NULL, "nativeGreater", "(J[J[JJ)V",
+		R_JAVA_MEMBER_METHOD, 0);
 	mu_assert_notnull (member, "parse primitive arrays");
 	mu_assert_eq (member->argument_slots, 6, "wide primitive argument slots");
 	mu_assert_eq (member->return_slots, 0, "void return slots");
 	mu_assert_streq (member->definition,
 		"void nativeGreater (long, long[], long[], long)", "array definition");
 	argument = r_list_get_n (member->arguments, 1);
-	mu_assert_eq (argument->kind, R_BIN_JAVA_TYPE_LONG, "array element kind");
+	mu_assert_eq (argument->kind, R_JAVA_TYPE_LONG, "array element kind");
 	mu_assert_eq (argument->array_dimensions, 1, "array dimensions");
 	mu_assert_streq (argument->jni_name, "jlongArray", "JNI primitive array");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 
-	member = r_bin_java_member_parse (NULL, "primitives", "(ZBCSIJFD)V",
-		R_BIN_JAVA_MEMBER_METHOD, 0);
+	member = r_java_member_parse (NULL, "primitives", "(ZBCSIJFD)V",
+		R_JAVA_MEMBER_METHOD, 0);
 	mu_assert_notnull (member, "parse every primitive type");
 	mu_assert_eq (r_list_length (member->arguments), 8, "primitive argument count");
 	mu_assert_eq (member->argument_slots, 10, "primitive argument slots");
 	mu_assert_streq (member->definition,
 		"void primitives (boolean, byte, char, short, int, long, float, double)",
 		"primitive definition");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 
-	member = r_bin_java_member_parse ("pkg/C", "values", "[[I",
-		R_BIN_JAVA_MEMBER_FIELD, 0x59);
+	member = r_java_member_parse ("pkg/C", "values", "[[I",
+		R_JAVA_MEMBER_FIELD, 0x59);
 	mu_assert_notnull (member, "parse field descriptor");
 	mu_assert_streq (member->definition,
 		"public static final volatile int[][] pkg.C.values", "field definition");
@@ -145,24 +146,24 @@ static bool test_java_descriptor(void) {
 		"public static final volatile jobjectArray pkg.C.values", "JNI field definition");
 	mu_assert_eq (member->type->array_dimensions, 2, "multidimensional field");
 	mu_assert_eq (member->type->slots, 1, "array reference slot");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 
-	member = r_bin_java_member_parse (NULL, "pkg/C", NULL,
-		R_BIN_JAVA_MEMBER_CLASS, 0x31);
+	member = r_java_member_parse (NULL, "pkg/C", NULL,
+		R_JAVA_MEMBER_CLASS, 0x31);
 	mu_assert_notnull (member, "parse class metadata");
 	mu_assert_streq (member->definition, "public final class pkg.C", "class definition");
 	mu_assert_true (member->attr.flags & R_BIN_ATTR_SUPER, "class super attribute");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 
 	char array_descriptor[258];
 	memset (array_descriptor, '[', 255);
 	array_descriptor[255] = 'I';
 	array_descriptor[256] = 0;
-	member = r_bin_java_member_parse (NULL, "maximumArray", array_descriptor,
-		R_BIN_JAVA_MEMBER_FIELD, 0);
+	member = r_java_member_parse (NULL, "maximumArray", array_descriptor,
+		R_JAVA_MEMBER_FIELD, 0);
 	mu_assert_notnull (member, "accept 255 array dimensions");
 	mu_assert_eq (member->type->array_dimensions, 255, "maximum array dimensions");
-	r_bin_java_member_free (member);
+	r_java_member_free (member);
 	mu_end;
 }
 
@@ -175,22 +176,22 @@ static bool test_java_descriptor_rejects_malformed(void) {
 	};
 	size_t i;
 	for (i = 0; i < R_ARRAY_SIZE (bad_methods); i++) {
-		RBinJavaMember *member = r_bin_java_member_parse (NULL, "bad",
-			bad_methods[i], R_BIN_JAVA_MEMBER_METHOD, 0);
+		RJavaMember *member = r_java_member_parse (NULL, "bad",
+			bad_methods[i], R_JAVA_MEMBER_METHOD, 0);
 		mu_assert_null (member, bad_methods[i]);
 	}
 	const char *bad_fields[] = { "V", "Igarbage", "Ljava/lang/String" };
 	for (i = 0; i < R_ARRAY_SIZE (bad_fields); i++) {
-		RBinJavaMember *member = r_bin_java_member_parse (NULL, "bad",
-			bad_fields[i], R_BIN_JAVA_MEMBER_FIELD, 0);
+		RJavaMember *member = r_java_member_parse (NULL, "bad",
+			bad_fields[i], R_JAVA_MEMBER_FIELD, 0);
 		mu_assert_null (member, bad_fields[i]);
 	}
 	char too_many_dimensions[259];
 	memset (too_many_dimensions, '[', 256);
 	too_many_dimensions[256] = 'I';
 	too_many_dimensions[257] = 0;
-	RBinJavaMember *member = r_bin_java_member_parse (NULL, "bad",
-		too_many_dimensions, R_BIN_JAVA_MEMBER_FIELD, 0);
+	RJavaMember *member = r_java_member_parse (NULL, "bad",
+		too_many_dimensions, R_JAVA_MEMBER_FIELD, 0);
 	mu_assert_null (member, "reject more than 255 array dimensions");
 	char *demangled = r_bin_demangle_java ("nativeGreater(J[J[JJ)V");
 	mu_assert_streq (demangled, "void nativeGreater (long, long[], long[], long)",


### PR DESCRIPTION
The wasi-api reactor build (--export-all) resolves libr_anal/libr_bin
members that reference r_bin_java_member_parse and r_bin_java_member_free
in every tool, so link libr_java.a from binr/rules.mk after the libr
archives instead of relying on per-tool deps.mk includes, which r2pm,
rafs2 and r2r lack.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011JCuLZZhGusXKkLboiRwjT