### PR TITLE
Reroute the capstone v6 ppc overflow-form ids onto their base cases ##arch

### DIFF
--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -1322,10 +1322,38 @@ static bool ppc6_branch(RAnalOp *op, csh handle, cs_insn *insn, const char *targ
 	return true;
 }
 
+// cs6 ids every overflow form separately, so addo misses the add case
+static unsigned int ppc6_oe_base_id(unsigned int id) {
+	switch (id) {
+	case PPC_INS_ADDO: return PPC_INS_ADD;
+	case PPC_INS_ADDCO: return PPC_INS_ADDC;
+	case PPC_INS_ADDEO: return PPC_INS_ADDE;
+	case PPC_INS_ADDMEO: return PPC_INS_ADDME;
+	case PPC_INS_ADDZEO: return PPC_INS_ADDZE;
+	case PPC_INS_SUBFO: return PPC_INS_SUBF;
+	case PPC_INS_SUBFCO: return PPC_INS_SUBFC;
+	case PPC_INS_SUBFEO: return PPC_INS_SUBFE;
+	case PPC_INS_SUBFMEO: return PPC_INS_SUBFME;
+	case PPC_INS_SUBFZEO: return PPC_INS_SUBFZE;
+	case PPC_INS_NEGO: return PPC_INS_NEG;
+	case PPC_INS_MULLWO: return PPC_INS_MULLW;
+	case PPC_INS_MULLDO: return PPC_INS_MULLD;
+	case PPC_INS_DIVWO: return PPC_INS_DIVW;
+	case PPC_INS_DIVWUO: return PPC_INS_DIVWU;
+	case PPC_INS_DIVDO: return PPC_INS_DIVD;
+	case PPC_INS_DIVDUO: return PPC_INS_DIVDU;
+	case PPC_INS_DIVWEO: return PPC_INS_DIVWE;
+	case PPC_INS_DIVWEUO: return PPC_INS_DIVWEU;
+	case PPC_INS_DIVDEO: return PPC_INS_DIVDE;
+	case PPC_INS_DIVDEUO: return PPC_INS_DIVDEU;
+	}
+	return id;
+}
+
 // cs6 reports alias-shaped operands under the parent id (li -> addi), so reroute onto the alias-id case; branch aliases stay generic
 static unsigned int ppc6_case_id(cs_insn *insn) {
 	if (!CS6_ALIAS (insn)) {
-		return insn->id;
+		return ppc6_oe_base_id (insn->id);
 	}
 	switch (insn->alias_id) {
 	case PPC_INS_ALIAS_LI:


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Capstone v6 gives every PowerPC overflow-enabled (OE) form its **own** id — `PPC_INS_ADDO` is 43, distinct from `PPC_INS_ADD` at 42, and likewise for the other twenty. They therefore reach no case arm at all:

    addo r4,r5,r6   ->  type: null   (no esil)
    addo r4,r5,r6   ->  type: add    esil: r6,r5,+,r4,=     (with this patch)

So this maps the 21 OE ids onto their base ids in `ppc6_case_id()`, the existing v6 normalisation point, and `addo`/`subfo`/`nego`/`mullwo`/`divwo`/… pick up the base form's semantics. `addo.` carries Rc through `update_cr0` on the same id, so the record-form CR0 side effect starts working for them too, for free.

The mapping is a pure passthrough for every other id, so nothing else can move, and `mulhw` with the OE bit set stays `invalid` as the ISA requires.

OE forms do not decode under capstone v5, so this is `#if CS_API_MAJOR >= 6` and inert in a default build — no r2r test can reach it. Verified on a `USE_CSNEXT=1` build at the pinned capstone-next revision: the ppc ESIL differential against qemu goes 1347/1347 to **1358/1358 OK**, with `muldiv/mullwo` moving from NOESIL to passing — i.e. the inherited expression produces values qemu agrees with.