### PR TITLE
Restore the java descriptor.h missing from the r_bin split ##bin

### DIFF
--- a/shlr/java/descriptor.h
+++ b/shlr/java/descriptor.h
@@ -1,0 +1,64 @@
+/* radare - LGPL - Copyright 2011-2026 - pancake */
+
+#ifndef R2_JAVA_DESCRIPTOR_H
+#define R2_JAVA_DESCRIPTOR_H
+
+#include <r_bin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+	R_JAVA_TYPE_INVALID,
+	R_JAVA_TYPE_VOID,
+	R_JAVA_TYPE_BOOLEAN,
+	R_JAVA_TYPE_BYTE,
+	R_JAVA_TYPE_CHAR,
+	R_JAVA_TYPE_SHORT,
+	R_JAVA_TYPE_INT,
+	R_JAVA_TYPE_LONG,
+	R_JAVA_TYPE_FLOAT,
+	R_JAVA_TYPE_DOUBLE,
+	R_JAVA_TYPE_OBJECT,
+} RJavaTypeKind;
+
+typedef enum {
+	R_JAVA_MEMBER_CLASS,
+	R_JAVA_MEMBER_FIELD,
+	R_JAVA_MEMBER_METHOD,
+} RJavaMemberKind;
+
+typedef struct r_java_type_t {
+	RJavaTypeKind kind;
+	char *class_name; // JVM internal name for object types
+	char *name; // Java display name
+	char *jni_name;
+	ut16 slots;
+	ut8 array_dimensions;
+} RJavaType;
+
+typedef struct r_java_member_t {
+	RJavaMemberKind kind;
+	char *class_name;
+	char *name;
+	char *descriptor;
+	ut32 access_flags; // raw JVM access_flags
+	RBinAttr attr; // access_flags normalized to R_BIN_ATTR_*
+	RJavaType *type; // field type or method return type
+	RList/*<RJavaType *>*/ *arguments; // method arguments
+	char *visibility;
+	char *definition;
+	char *jni_definition;
+	ut16 argument_slots;
+	ut16 return_slots;
+} RJavaMember;
+
+R_API RJavaMember *r_java_member_parse(const char *class_name, const char *name, const char *descriptor, RJavaMemberKind kind, ut32 access_flags);
+R_API void r_java_member_free(RJavaMember *member);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Fixes #26539.

8a7433b5be moved the Java member-descriptor API out of `libr/include/r_bin.h` into `shlr/java/` and updated `shlr/java/class.c`, `shlr/java/descriptor.c`, `libr/anal/p/anal_jni.c`, `libr/bin/mangling/java.c` to `#include "descriptor.h"` / `#include "../../../shlr/java/descriptor.h"`, but never committed the new header itself.

Result on any clean checkout of `master`:

```
shlr/java/descriptor.c:4:10: fatal error: descriptor.h: No such file or directory
libr/anal/p/anal_jni.c:5:10: fatal error: ../../../shlr/java/descriptor.h: No such file or directory
```

`sys/install.sh` (and `make` / `meson`) fails at `sys/build.sh` stage. Dirty worktrees with a stale `shlr/java/descriptor.h` on disk mask the failure (`git ls-tree origin/master -- shlr/java/` shows no `descriptor.h`).

This PR restores `shlr/java/descriptor.h` reconstructed from the block removed from `r_bin.h` with the `RBinJava*` → `RJava*` renames applied in 8a7433b5be (`RJavaTypeKind`, `RJavaMemberKind`, `RJavaType`, `RJavaMember`, `r_java_member_parse`/`r_java_member_free`). Verified `gcc -c` for both `descriptor.c` and `anal_jni.c` succeeds.