### PR TITLE
Fix the mips.gnu rotate, shift and sign-fill esil ##esil

### DIFF
--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -769,6 +769,8 @@ typedef struct gnu_insn {
 #define R_REG(x) ((const char *)insn->r_reg.x)
 #define I_REG(x) ((const char *)insn->i_reg.x)
 #define J_REG(x) ((const char *)insn->j_reg.x)
+// shift amount: the rs register for the v-forms, else the sa immediate
+#define R_SHAMT (R_REG (rs)? R_REG (rs): R_REG (sa))
 
 #define ESIL_LOAD(size) \
 	r_strbuf_appendf (&op->esil, "%s,%s,+,["size"],%s,=",\
@@ -892,13 +894,22 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 	case MIPS_INS_SRL:
 		// srl shifts the zero-extended low word, not the whole register
 		r_strbuf_appendf (&op->esil, "0x1f,%s,&," ES_W ("%s") ",>>,%s,=",
-			R_REG (rs) ? R_REG (rs) : R_REG (sa), R_REG (rt), R_REG (rd));
+			R_SHAMT, R_REG (rt), R_REG (rd));
+		ES_SIGN32_64 (R_REG (rd));
+		break;
+	case MIPS_INS_ROTRV:
+	case MIPS_INS_ROTR:
+		// open-coded: esil ROR rotates at register width, 64-bit on mips64
+		r_strbuf_appendf (&op->esil,
+			"0x1f,%s,&," ES_W ("%s") ",>>,0x1f,%s,&,32,-,"
+			ES_W ("%s") ",<<,0xffffffff,&,|,%s,=",
+			R_SHAMT, R_REG (rt), R_SHAMT, R_REG (rt), R_REG (rd));
 		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_SLLV:
 	case MIPS_INS_SLL:
 		r_strbuf_appendf (&op->esil, "0x1f,%s,&,%s,<<,%s,=",
-			R_REG (rs) ? R_REG (rs) : R_REG (sa), R_REG (rt), R_REG (rd));
+			R_SHAMT, R_REG (rt), R_REG (rd));
 		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_BALC:
@@ -1442,17 +1453,21 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 			insn.id = MIPS_INS_SLL;
 			insn.r_reg.rs = NULL;
 			op->val = sa;
+			op->type = R_ANAL_OP_TYPE_SHL;
+			break;
 		case 4: // sllv
 			insn.id = MIPS_INS_SLLV;
 			op->type = R_ANAL_OP_TYPE_SHL;
 			break;
-		case 2: // srl
-			insn.id = MIPS_INS_SRL;
+		case 2: // srl, or rotr when the rs field selects the rotate
+			insn.id = (rs == 1)? MIPS_INS_ROTR: MIPS_INS_SRL;
 			insn.r_reg.rs = NULL;
 			op->val = sa;
-		case 6: // srlv
-			insn.id = MIPS_INS_SRLV;
-			op->type = R_ANAL_OP_TYPE_SHR;
+			op->type = (rs == 1)? R_ANAL_OP_TYPE_ROR: R_ANAL_OP_TYPE_SHR;
+			break;
+		case 6: // srlv, or rotrv when the sa field selects the rotate
+			insn.id = (sa == 1)? MIPS_INS_ROTRV: MIPS_INS_SRLV;
+			op->type = (sa == 1)? R_ANAL_OP_TYPE_ROR: R_ANAL_OP_TYPE_SHR;
 			break;
 		case 3: // sra
 			insn.id = MIPS_INS_SRA;

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -899,7 +899,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_ROTRV:
 	case MIPS_INS_ROTR:
-		// open-coded: esil ROR rotates at register width, 64-bit on mips64
+		// esil ROR rotates at the register width
 		r_strbuf_appendf (&op->esil,
 			"0x1f,%s,&," ES_W ("%s") ",>>,0x1f,%s,&,32,-,"
 			ES_W ("%s") ",<<,0xffffffff,&,|,%s,=",
@@ -908,7 +908,8 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		break;
 	case MIPS_INS_SLLV:
 	case MIPS_INS_SLL:
-		r_strbuf_appendf (&op->esil, "0x1f,%s,&,%s,<<,%s,=",
+		// a 32-bit shift cannot keep high bits
+		r_strbuf_appendf (&op->esil, ES_W ("0x1f,%s,&,%s,<<") ",%s,=",
 			R_SHAMT, R_REG (rt), R_REG (rd));
 		ES_SIGN32_64 (R_REG (rd));
 		break;

--- a/libr/arch/p/mips_gnu/plugin.c
+++ b/libr/arch/p/mips_gnu/plugin.c
@@ -883,8 +883,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, gnu_insn *insn)
 		ES_SIGN32_64 (R_REG (rd));
 		break;
 	case MIPS_INS_DSRA:
+		// a 64-bit shift fills from bit 63, not bit 31
 		r_strbuf_appendf (&op->esil,
-			"%s,%s,>>,31,%s,>>,?{,32,%s,32,-,0xffffffff,<<,0xffffffff,&,<<,}{,0,},|,%s,=",
+			"%s,%s,>>,63,%s,>>,?{,%s,64,-,0xffffffffffffffff,<<,}{,0,},|,%s,=",
 			R_REG (sa), R_REG (rt), R_REG (rt), R_REG (sa), R_REG (rd));
 		break;
 	case MIPS_INS_SHRL:

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2354,3 +2354,36 @@ EXPECT=<<EOF
 type: store
 EOF
 RUN
+
+NAME=mips.gnu rotr and rotrv rotate instead of shifting
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 02412900
+ar t1=0x12345678
+ar pc=0
+s 0
+aes
+ar t0
+wx 46404901
+ar t1=0x12345678
+ar t2=4
+ar pc=0
+s 0
+aes
+ar t0
+wx 02410900
+ar t1=0x12345678
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x81234567
+0x81234567
+0x01234567
+EOF
+RUN
+

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2387,3 +2387,19 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=mips.gnu sll keeps its result inside 32 bits
+FILE=malloc://32
+ARGS=-a mips.gnu -b 32
+CMDS=<<EOF
+aei
+wx 00410900
+ar t1=0x87654321
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x76543210
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -338,3 +338,26 @@ EXPECT=<<EOF
 0xffffffff81234567
 EOF
 RUN
+
+NAME=mips.gnu dsra fills from bit 63
+FILE=malloc://32
+ARGS=-a mips.gnu -b 64
+CMDS=<<EOF
+aei
+wx 3b410900
+ar t1=0x80000000
+ar pc=0
+s 0
+aes
+ar t0
+ar t1=0x8000000000000005
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x08000000
+0xf800000000000000
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -313,3 +313,28 @@ EXPECT=<<EOF
 0x3344a7a8
 EOF
 RUN
+
+NAME=mips.gnu rotr sign-extends its 32-bit result
+FILE=malloc://32
+ARGS=-a mips.gnu -b 64
+CMDS=<<EOF
+aei
+wx 02412900
+ar t1=0x12345678
+ar pc=0
+s 0
+aes
+ar t0
+wx 46404901
+ar t1=0x12345678
+ar t2=4
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xffffffff81234567
+0xffffffff81234567
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three wrong-value defects in the mips.gnu shift ESIL, each found by the unicorn differential. mips-gnu goes 89/91 → 91/91 and  mips64-gnu 182/185 → 186/186, both 0 FAIL.

- rotr/rotrv were emulated as logical shifts. They are SPECIAL func=2 with rs == 1 and func=6 with sa == 1, and neither bit was looked at, so both fell onto the SRL/SRLV case: rotr t0, t1, 4 with t1 = 0x12345678 gave 0x01234567 instead of 0x81234567. They now get  their own ids, R_ANAL_OP_TYPE_ROR, and a 32-bit rotate that sign-extends on mips64.
- sll kept bits above 32. Its sibling srl narrows with ES_W and sll did not; the gpr profile is 64-bit wide even at -b 32, so sll t0, t1, 4 with t1 = 0x87654321 left 0x876543210.
- dsra filled from bit 31. A positive 64-bit value with bit 31 set (0x0000000080000000) came back as 0xf000000008000000. The capstone mips plugin carries a near-copy of the same expression with the same defect, fixed there separately.

Fixing the rotates also removed two implicit case fallthroughs that relabelled every sll as MIPS_INS_SLLV and every srl as MIPS_INS_SRLV; the fallthrough was carrying the op->type assignment, now explicit in both arms.

Note the disassembler still prints the raw word for rotr/rotrv — the binutils tables gate them behind ISA I33 and carry the immediate form only as an INSN_MACRO — so ao now reports ror with correct ESIL while pd shows hex. That is an opcode-table gap on the disasm side, left alone here.