### PR TITLE
Model the mips shift, bitfield, byte-swap and hi/lo esil ##esil

### DIFF
--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -154,22 +154,35 @@ static inline void es_sign_n_64(RArchSession *as, RAnalOp *op, const char *arg, 
 	}
 }
 
-// the m/u bitfield forms encode a field 32 wider or 32 higher than capstone says
-static ut64 es_bitmask(int size) {
-	return (size >= 64)? UT64_MAX: (1ULL << size) - 1;
-}
-
-// a mips64 arithmetic shift fills from bit 63, and esil ASR rewrites a big count
-static void es_dsra(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
+// a mips64 arithmetic shift fills from bit 63, and esil ASR rewrites the count
+static inline void es_dsra(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
 	r_strbuf_appendf (&op->esil,
 		"%s,%s,>>,63,%s,>>,?{,%s,64,-,0xffffffffffffffff,<<,}{,0,},|,%s,=",
 		cnt, rt, rt, cnt, rd);
 }
 
 // esil ROR takes its width from the config, so the rotate is spelled out here
-static void es_drotr(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
+static inline void es_drotr(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
 	r_strbuf_appendf (&op->esil, "%s,%s,>>,%s,64,-,%s,<<,|,%s,=",
 		cnt, rt, cnt, rt, rd);
+}
+
+// the quotient goes to lo and the remainder to hi, sharing one narrowing shape
+static inline void es_div(RArchSession *as, RAnalOp *op, int id, const char *rs, const char *rt, bool mod) {
+	const bool sign = id == MIPS_INS_DIV || id == MIPS_INS_DDIV;
+	const char *aop = mod? (sign? "~%": "%"): (sign? "~/": "/");
+	const char *dst = mod? "hi": "lo";
+	if (id == MIPS_INS_DDIV || id == MIPS_INS_DDIVU) {
+		r_strbuf_appendf (&op->esil, "%s,%s,%s,%s,=,", rt, rs, aop, dst);
+		return;
+	}
+	if (sign) {
+		r_strbuf_appendf (&op->esil, ES_W ("32,%s,~,32,%s,~,%s") ",%s,=", rt, rs, aop, dst);
+	} else {
+		r_strbuf_appendf (&op->esil, ES_W (ES_W ("%s") "," ES_W ("%s") ",%s") ",%s,=",
+			rt, rs, aop, dst);
+	}
+	es_sign_n_64 (as, op, dst, 32);
 }
 
 static inline void es_add_ck(RAnalOp *op, const char *a1, const char *a2, const char *re, int bit) {
@@ -359,22 +372,69 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 					|| id == MIPS_INS_DSRAV || id == MIPS_INS_DROTRV;
 				const bool wide = id == MIPS_INS_DSLL32 || id == MIPS_INS_DSRL32
 					|| id == MIPS_INS_DSRA32 || id == MIPS_INS_DROTR32;
-				char cnt[48];
+				const char *rt = ARG (1);
+				const char *rd = ARG (0);
+				char cnt[sizeof (str[0]) + 8];
 				if (var) {
 					snprintf (cnt, sizeof (cnt), "0x3f,%s,&", ARG (2));
 				} else {
 					snprintf (cnt, sizeof (cnt), "%d", (int)IMM (2) + (wide? 32: 0));
 				}
 				if (id == MIPS_INS_DSRA || id == MIPS_INS_DSRA32 || id == MIPS_INS_DSRAV) {
-					es_dsra (op, cnt, ARG (1), ARG (0));
+					es_dsra (op, cnt, rt, rd);
 				} else if (id == MIPS_INS_DROTR || id == MIPS_INS_DROTR32 || id == MIPS_INS_DROTRV) {
-					es_drotr (op, cnt, ARG (1), ARG (0));
+					es_drotr (op, cnt, rt, rd);
 				} else {
 					const bool left = id == MIPS_INS_DSLL || id == MIPS_INS_DSLL32
 						|| id == MIPS_INS_DSLLV;
 					r_strbuf_appendf (&op->esil, "%s,%s,%s,%s,=",
-						cnt, ARG (1), left? "<<": ">>", ARG (0));
+						cnt, rt, left? "<<": ">>", rd);
 				}
+			}
+			break;
+		case MIPS_INS_DIV:
+		case MIPS_INS_DIVU:
+		case MIPS_INS_DDIV:
+		case MIPS_INS_DDIVU:
+			{
+				const char *rs = ARG (0);
+				const char *rt = ARG (1);
+				es_div (as, op, insn->id, rs, rt, false);
+				es_div (as, op, insn->id, rs, rt, true);
+			}
+			break;
+		case MIPS_INS_DMULT:
+		case MIPS_INS_DMULTU:
+			// L* is unsigned: hi needs each sign out
+			r_strbuf_appendf (&op->esil, "%s,%s,L*,lo,=", ARG (0), ARG (1));
+			if (insn->id == MIPS_INS_DMULT) {
+				r_strbuf_appendf (&op->esil, ",63,%s,>>,%s,*,SWAP,-,63,%s,>>,%s,*,SWAP,-",
+					ARG (0), ARG (1), ARG (1), ARG (0));
+			}
+			r_strbuf_append (&op->esil, ",hi,=");
+			break;
+		case MIPS_INS_MADD:
+		case MIPS_INS_MADDU:
+		case MIPS_INS_MSUB:
+		case MIPS_INS_MSUBU:
+			// the dsp form names its own accumulator, which r2 has no register for
+			if (OPCOUNT () != 2) {
+				break;
+			}
+			// hi must be built before lo is overwritten
+			{
+				const int id = insn->id;
+				const char *aop = (id == MIPS_INS_MSUB || id == MIPS_INS_MSUBU)? "-": "+";
+				const char *ext = (id == MIPS_INS_MADDU || id == MIPS_INS_MSUBU)
+					? "0xffffffff,%s,&,0xffffffff,%s,&,*": "32,%s,~,32,%s,~,*";
+				char prod[80];
+				snprintf (prod, sizeof (prod), ext, ARG (0), ARG (1));
+				r_strbuf_appendf (&op->esil,
+					"32,%s,32,hi,<<,0xffffffff,lo,&,+,%s,>>,hi,=", prod, aop);
+				ES_SIGN32_64 ("hi");
+				r_strbuf_appendf (&op->esil,
+					"0xffffffff,%s,0xffffffff,lo,&,%s,&,lo,=", prod, aop);
+				ES_SIGN32_64 ("lo");
 			}
 			break;
 		case MIPS_INS_SEB:
@@ -394,7 +454,6 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				ARG (1), ARG (1), ARG (0));
 			break;
 		case MIPS_INS_DSHD:
-			// swap the halfwords inside each word, then swap the two words
 			r_strbuf_appendf (&op->esil,
 				"16,0xffff0000ffff0000,%s,&,>>,16,0x0000ffff0000ffff,%s,&,<<,|,%s,=,"
 				"32,%s,>>,32,0xffffffff,%s,&,<<,|,%s,=",
@@ -408,7 +467,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				const int pos = IMM (2) + ((insn->id == MIPS_INS_DEXTU)? 32: 0);
 				const int size = IMM (3) + ((insn->id == MIPS_INS_DEXTM)? 32: 0);
 				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%d,%s,>>,&,%s,=",
-					es_bitmask (size), pos, ARG (1), ARG (0));
+					r_num_bitmask (size), pos, ARG (1), ARG (0));
 				if (insn->id == MIPS_INS_EXT) {
 					ES_SIGN32_64 (ARG (0));
 				}
@@ -422,7 +481,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				const int pos = IMM (2) + ((insn->id == MIPS_INS_DINSU)? 32: 0);
 				const int size = IMM (3) + ((insn->id == MIPS_INS_DINSM)? 32: 0);
 				const bool word = insn->id == MIPS_INS_INS;
-				const ut64 mask = es_bitmask (size) << pos;
+				const ut64 mask = r_num_bitmask (size) << pos;
 				const ut64 keep = word? (~mask & UT32_MAX): ~mask;
 				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%s,&,0x%"PFMT64x",%d,%s,<<,&,|,%s,=",
 					keep, ARG (0), mask, pos, ARG (1), ARG (0));
@@ -433,7 +492,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 			break;
 		case MIPS_INS_ROTR:
 		case MIPS_INS_ROTRV:
-			// a 32-bit rotate, so the halves have to be masked back into a word
+			// a 32-bit rotate, masked back to a word
 			r_strbuf_appendf (&op->esil,
 				"0x1f,%s,&," ES_W ("%s") ",>>,0x1f,%s,&,32,-," ES_W ("%s")
 				",<<,0xffffffff,&,|,%s,=",
@@ -899,18 +958,6 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				r_strbuf_appendf (&op->esil, "%s,hi,=", REG (0));
 				ES_SIGN32_64 ("hi");
 				break;
-#if 0
-	// could not test div
-	case MIPS_INS_DIV:
-	case MIPS_INS_DIVU:
-	case MIPS_INS_DDIV:
-	case MIPS_INS_DDIVU:
-		PROTECT_ZERO () {
-			// 32 bit needs sign extend
-			r_strbuf_appendf (&op->esil, "%s,%s,/,lo,=,%s,%s,%%,hi,=", REG(1), REG(0), REG(1), REG(0));
-		}
-		break;
-#endif
 		default:
 			return -1;
 		}
@@ -1397,6 +1444,18 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		op->sign = insn->id == MIPS_INS_SUB;
 		op->type = R_ANAL_OP_TYPE_SUB;
 		break;
+	case MIPS_INS_ROTR:
+	case MIPS_INS_ROTRV:
+	case MIPS_INS_DROTR:
+	case MIPS_INS_DROTR32:
+	case MIPS_INS_DROTRV:
+		op->type = R_ANAL_OP_TYPE_ROR;
+		SET_VAL (op, 2);
+		break;
+	case MIPS_INS_MADD:
+	case MIPS_INS_MADDU:
+	case MIPS_INS_MSUB:
+	case MIPS_INS_MSUBU:
 	case MIPS_INS_MULV:
 	case MIPS_INS_MULT:
 	case MIPS_INS_MULSA:
@@ -1530,17 +1589,26 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case MIPS_INS_SHRA_R:
 	case MIPS_INS_SRA:
 	case MIPS_INS_SRAV:
+	case MIPS_INS_DSRA:
+	case MIPS_INS_DSRA32:
+	case MIPS_INS_DSRAV:
 		op->type = R_ANAL_OP_TYPE_SAR;
 		SET_VAL (op,2);
 		break;
 	case MIPS_INS_SHRL:
 	case MIPS_INS_SRLV:
 	case MIPS_INS_SRL:
+	case MIPS_INS_DSRL:
+	case MIPS_INS_DSRL32:
+	case MIPS_INS_DSRLV:
 		op->type = R_ANAL_OP_TYPE_SHR;
 		SET_VAL (op,2);
 		break;
 	case MIPS_INS_SLLV:
 	case MIPS_INS_SLL:
+	case MIPS_INS_DSLL:
+	case MIPS_INS_DSLL32:
+	case MIPS_INS_DSLLV:
 		op->type = R_ANAL_OP_TYPE_SHL;
 		SET_VAL (op,2);
 		break;

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -377,6 +377,29 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 				}
 			}
 			break;
+		case MIPS_INS_SEB:
+		case MIPS_INS_SEH:
+			r_strbuf_appendf (&op->esil, "%d,%s,~,%s,=",
+				(insn->id == MIPS_INS_SEB)? 8: 16, ARG (1), ARG (0));
+			break;
+		case MIPS_INS_WSBH:
+			r_strbuf_appendf (&op->esil,
+				"8,0xff00ff00,%s,&,>>,8,0x00ff00ff,%s,&,<<,|,%s,=",
+				ARG (1), ARG (1), ARG (0));
+			ES_SIGN32_64 (ARG (0));
+			break;
+		case MIPS_INS_DSBH:
+			r_strbuf_appendf (&op->esil,
+				"8,0xff00ff00ff00ff00,%s,&,>>,8,0x00ff00ff00ff00ff,%s,&,<<,|,%s,=",
+				ARG (1), ARG (1), ARG (0));
+			break;
+		case MIPS_INS_DSHD:
+			// swap the halfwords inside each word, then swap the two words
+			r_strbuf_appendf (&op->esil,
+				"16,0xffff0000ffff0000,%s,&,>>,16,0x0000ffff0000ffff,%s,&,<<,|,%s,=,"
+				"32,%s,>>,32,0xffffffff,%s,&,<<,|,%s,=",
+				ARG (1), ARG (1), ARG (0), ARG (0), ARG (0), ARG (0));
+			break;
 		case MIPS_INS_EXT:
 		case MIPS_INS_DEXT:
 		case MIPS_INS_DEXTM:

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -154,6 +154,19 @@ static inline void es_sign_n_64(RArchSession *as, RAnalOp *op, const char *arg, 
 	}
 }
 
+// a mips64 arithmetic shift fills from bit 63, and esil ASR rewrites a big count
+static void es_dsra(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
+	r_strbuf_appendf (&op->esil,
+		"%s,%s,>>,63,%s,>>,?{,%s,64,-,0xffffffffffffffff,<<,}{,0,},|,%s,=",
+		cnt, rt, rt, cnt, rd);
+}
+
+// esil ROR takes its width from the config, so the rotate is spelled out here
+static void es_drotr(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
+	r_strbuf_appendf (&op->esil, "%s,%s,>>,%s,64,-,%s,<<,|,%s,=",
+		cnt, rt, cnt, rt, rd);
+}
+
 static inline void es_add_ck(RAnalOp *op, const char *a1, const char *a2, const char *re, int bit) {
 	ut64 mask = 1ULL << (bit-1);
 	r_strbuf_appendf (&op->esil,
@@ -323,10 +336,50 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 		case MIPS_INS_CMPI:
 			r_strbuf_appendf (&op->esil, "%s,%s,==", ARG (1), ARG (0));
 			break;
+		case MIPS_INS_DSLL:
+		case MIPS_INS_DSLL32:
+		case MIPS_INS_DSLLV:
+		case MIPS_INS_DSRL:
+		case MIPS_INS_DSRL32:
+		case MIPS_INS_DSRLV:
 		case MIPS_INS_DSRA:
+		case MIPS_INS_DSRA32:
+		case MIPS_INS_DSRAV:
+		case MIPS_INS_DROTR:
+		case MIPS_INS_DROTR32:
+		case MIPS_INS_DROTRV:
+			{
+				const int id = insn->id;
+				const bool var = id == MIPS_INS_DSLLV || id == MIPS_INS_DSRLV
+					|| id == MIPS_INS_DSRAV || id == MIPS_INS_DROTRV;
+				const bool wide = id == MIPS_INS_DSLL32 || id == MIPS_INS_DSRL32
+					|| id == MIPS_INS_DSRA32 || id == MIPS_INS_DROTR32;
+				char cnt[48];
+				if (var) {
+					snprintf (cnt, sizeof (cnt), "0x3f,%s,&", ARG (2));
+				} else {
+					snprintf (cnt, sizeof (cnt), "%d", (int)IMM (2) + (wide? 32: 0));
+				}
+				if (id == MIPS_INS_DSRA || id == MIPS_INS_DSRA32 || id == MIPS_INS_DSRAV) {
+					es_dsra (op, cnt, ARG (1), ARG (0));
+				} else if (id == MIPS_INS_DROTR || id == MIPS_INS_DROTR32 || id == MIPS_INS_DROTRV) {
+					es_drotr (op, cnt, ARG (1), ARG (0));
+				} else {
+					const bool left = id == MIPS_INS_DSLL || id == MIPS_INS_DSLL32
+						|| id == MIPS_INS_DSLLV;
+					r_strbuf_appendf (&op->esil, "%s,%s,%s,%s,=",
+						cnt, ARG (1), left? "<<": ">>", ARG (0));
+				}
+			}
+			break;
+		case MIPS_INS_ROTR:
+		case MIPS_INS_ROTRV:
+			// a 32-bit rotate, so the halves have to be masked back into a word
 			r_strbuf_appendf (&op->esil,
-				"%s,%s,>>,31,%s,>>,?{,32,%s,32,-,0xffffffff,<<,0xffffffff,&,<<,}{,0,},|,%s,=",
-				ARG (2), ARG (1), ARG (1), ARG (2), ARG (0));
+				"0x1f,%s,&," ES_W ("%s") ",>>,0x1f,%s,&,32,-," ES_W ("%s")
+				",<<,0xffffffff,&,|,%s,=",
+				ARG (2), ARG (1), ARG (2), ARG (1), ARG (0));
+			ES_SIGN32_64 (ARG (0));
 			break;
 		case MIPS_INS_SHRAV:
 		case MIPS_INS_SHRAV_R:

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -154,6 +154,11 @@ static inline void es_sign_n_64(RArchSession *as, RAnalOp *op, const char *arg, 
 	}
 }
 
+// the m/u bitfield forms encode a field 32 wider or 32 higher than capstone says
+static ut64 es_bitmask(int size) {
+	return (size >= 64)? UT64_MAX: (1ULL << size) - 1;
+}
+
 // a mips64 arithmetic shift fills from bit 63, and esil ASR rewrites a big count
 static void es_dsra(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
 	r_strbuf_appendf (&op->esil,
@@ -369,6 +374,37 @@ static int analop_esil(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *insn
 						|| id == MIPS_INS_DSLLV;
 					r_strbuf_appendf (&op->esil, "%s,%s,%s,%s,=",
 						cnt, ARG (1), left? "<<": ">>", ARG (0));
+				}
+			}
+			break;
+		case MIPS_INS_EXT:
+		case MIPS_INS_DEXT:
+		case MIPS_INS_DEXTM:
+		case MIPS_INS_DEXTU:
+			{
+				const int pos = IMM (2) + ((insn->id == MIPS_INS_DEXTU)? 32: 0);
+				const int size = IMM (3) + ((insn->id == MIPS_INS_DEXTM)? 32: 0);
+				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%d,%s,>>,&,%s,=",
+					es_bitmask (size), pos, ARG (1), ARG (0));
+				if (insn->id == MIPS_INS_EXT) {
+					ES_SIGN32_64 (ARG (0));
+				}
+			}
+			break;
+		case MIPS_INS_INS:
+		case MIPS_INS_DINS:
+		case MIPS_INS_DINSM:
+		case MIPS_INS_DINSU:
+			{
+				const int pos = IMM (2) + ((insn->id == MIPS_INS_DINSU)? 32: 0);
+				const int size = IMM (3) + ((insn->id == MIPS_INS_DINSM)? 32: 0);
+				const bool word = insn->id == MIPS_INS_INS;
+				const ut64 mask = es_bitmask (size) << pos;
+				const ut64 keep = word? (~mask & UT32_MAX): ~mask;
+				r_strbuf_appendf (&op->esil, "0x%"PFMT64x",%s,&,0x%"PFMT64x",%d,%s,<<,&,|,%s,=",
+					keep, ARG (0), mask, pos, ARG (1), ARG (0));
+				if (word) {
+					ES_SIGN32_64 (ARG (0));
 				}
 			}
 			break;

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2452,3 +2452,34 @@ EXPECT=<<EOF
 0xfffff00f
 EOF
 RUN
+
+NAME=seb, seh and wsbh
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 2044097c
+ar t1=0x000000f6
+ar pc=0
+s 0
+aes
+ar t0
+wx 2046097c
+ar t1=0x00008056
+ar pc=0
+s 0
+aes
+ar t0
+wx a040097c
+ar t1=0x12345678
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0xfffffff6
+0xffff8056
+0x34127856
+EOF
+RUN

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2403,3 +2403,27 @@ EXPECT=<<EOF
 0x76543210
 EOF
 RUN
+
+NAME=rotr and rotrv rotate the low word
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 02412900
+ar t1=0x12345678
+ar pc=0
+s 0
+aes
+ar t0
+wx 46404901
+ar t2=4
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x81234567
+0x81234567
+EOF
+RUN

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2427,3 +2427,28 @@ EXPECT=<<EOF
 0x81234567
 EOF
 RUN
+
+NAME=the ext and ins bitfield forms
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 0039287d
+ar t1=0x89abcdef
+ar pc=0
+s 0
+aes
+ar t0
+wx 0459287d
+ar t0=0xffffffff
+ar t1=0
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x000000de
+0xfffff00f
+EOF
+RUN

--- a/test/db/esil/mips_32
+++ b/test/db/esil/mips_32
@@ -2483,3 +2483,83 @@ EXPECT=<<EOF
 0x34127856
 EOF
 RUN
+
+NAME=div, divu, madd and msub write hi and lo
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 1a002a01
+ar t1=0xfffffff9
+ar t2=2
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+wx 1b002a01
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+wx 00002a71
+ar hi=1
+ar lo=5
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+wx 04002a71
+ar hi=1
+ar lo=5
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+EOF
+EXPECT=<<EOF
+0xfffffffd
+0xffffffff
+0x7ffffffc
+0x00000001
+0x00000000
+0xfffffff7
+0x00000001
+0x00000013
+EOF
+RUN
+
+NAME=maddu and msubu accumulate the unsigned product
+FILE=malloc://32
+ARGS=-a mips -b 32
+CMDS=<<EOF
+aei
+wx 01002a71
+ar t1=0xffffffff
+ar t2=2
+ar hi=1
+ar lo=5
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+wx 05002a71
+ar hi=1
+ar lo=5
+ar pc=0
+s 0
+aes
+ar hi
+ar lo
+EOF
+EXPECT=<<EOF
+0x00000003
+0x00000003
+0xffffffff
+0x00000007
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -361,3 +361,88 @@ EXPECT=<<EOF
 0xf800000000000000
 EOF
 RUN
+
+NAME=the mips64 shift and rotate forms
+FILE=malloc://32
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 38410900
+ar t1=0x8000000000000005
+ar pc=0
+s 0
+aes
+ar t0
+wx 3c410900
+ar pc=0
+s 0
+aes
+ar t0
+wx 14404901
+ar t2=4
+ar pc=0
+s 0
+aes
+ar t0
+wx 3a410900
+ar pc=0
+s 0
+aes
+ar t0
+wx 3e410900
+ar pc=0
+s 0
+aes
+ar t0
+wx 3b410900
+ar pc=0
+s 0
+aes
+ar t0
+wx 3f410900
+ar pc=0
+s 0
+aes
+ar t0
+wx 17404901
+ar pc=0
+s 0
+aes
+ar t0
+wx 3a412900
+ar pc=0
+s 0
+aes
+ar t0
+wx 3e412900
+ar pc=0
+s 0
+aes
+ar t0
+wx 56404901
+ar pc=0
+s 0
+aes
+ar t0
+wx 3b410900
+ar t1=0x80000000
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x00000050
+0x5000000000
+0x00000050
+0x800000000000000
+0x08000000
+0xf800000000000000
+0xfffffffff8000000
+0xf800000000000000
+0x5800000000000000
+0x58000000
+0x5800000000000000
+0x08000000
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -497,3 +497,33 @@ EXPECT=<<EOF
 0xfffff00fffffffff
 EOF
 RUN
+
+NAME=dsbh, dshd and the 64-bit reach of seb
+FILE=malloc://32
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx a440097c
+ar t1=0x0123456789abcdef
+ar pc=0
+s 0
+aes
+ar t0
+wx 6441097c
+ar pc=0
+s 0
+aes
+ar t0
+wx 2044097c
+ar t1=0x000000f6
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x23016745ab89efcd
+0xcdef89ab45670123
+0xfffffffffffffff6
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -446,3 +446,54 @@ EXPECT=<<EOF
 0x08000000
 EOF
 RUN
+
+NAME=the mips64 bitfield forms and their wider field encodings
+FILE=malloc://32
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 0339287d
+ar t1=0x0123456789abcdef
+ar pc=0
+s 0
+aes
+ar t0
+wx 0139287d
+ar pc=0
+s 0
+aes
+ar t0
+wx 0239287d
+ar pc=0
+s 0
+aes
+ar t0
+wx 0759287d
+ar t0=0xffffffffffffffff
+ar t1=0
+ar pc=0
+s 0
+aes
+ar t0
+wx 0559287d
+ar t0=0xffffffffffffffff
+ar pc=0
+s 0
+aes
+ar t0
+wx 0659287d
+ar t0=0xffffffffffffffff
+ar pc=0
+s 0
+aes
+ar t0
+EOF
+EXPECT=<<EOF
+0x000000de
+0x56789abcde
+0x00000056
+0xfffffffffffff00f
+0xfffff0000000000f
+0xfffff00fffffffff
+EOF
+RUN

--- a/test/db/esil/mips_64
+++ b/test/db/esil/mips_64
@@ -527,3 +527,49 @@ EXPECT=<<EOF
 0xfffffffffffffff6
 EOF
 RUN
+
+NAME=the mips64 divide and wide multiply forms
+FILE=malloc://32
+ARGS=-a mips -b 64
+CMDS=<<EOF
+aei
+wx 1e002a01
+ar t1=0xfffffffffffffff9
+ar t2=2
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+wx 1f002a01
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+wx 1c002a01
+ar t1=0xffffffffffffffff
+ar t2=2
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+wx 1d002a01
+ar pc=0
+s 0
+aes
+ar lo
+ar hi
+EOF
+EXPECT=<<EOF
+0xfffffffffffffffd
+0xffffffffffffffff
+0x7ffffffffffffffc
+0x00000001
+0xfffffffffffffffe
+0xffffffffffffffff
+0xfffffffffffffffe
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Models the mips instructions that reached the ESIL default: and emitted nothing. One commit per family:

- mips64 shifts and rotates — dsll dsll32 dsllv dsrl dsrl32 dsrlv dsra32 dsrav drotr drotr32 drotrv, plus 32-bit rotr/rotrv. Rather than handed to ASR/ROR: esil_asr rewrites an out-of-range count to 30, and esil_ror takes its width from the config rather than the operand.
- Bitfield — ext ins dext dextm dextu dins dinsm dinsu. Capstone reports the raw encoded fields for the m/u variants, so the +32 on size or position is applied here.
- Sign-extend and byte-swap — seb seh wsbh dsbh dshd.
- hi/lo writers — div divu ddiv ddivu dmult dmultu madd maddu msub msubu. L* is an unsigned 128-bit multiply, so dmult takes the sign of each source back out of the high half; madd/msub accumulate over {hi,lo} as one 64-bit value, so hi is built before lo is overwritten. Also deletes the #if 0 "could not test div" draft that had been sitting in the plugin.

Two defects surfaced while filling the gaps:

- dsra filled from bit 31 and built a 32-bit mask, so a positive 64-bit value with bit 31 set (0x0000000080000000) came back as 0xf000000008000000. The existing case seeds 0x8000000000000005, where "bit 63 set" and "value >> 31 nonzero" agree — the new ctl_dsra_hi31 case fails on master.
- dsra32 fed esil_lsl a count of 32 - 36, a huge unsigned number, so the shift pushed nothing and the rest of the expression ran on a corrupt stack.

The madd family skips capstone's three-operand DSP form (madd $ac1, rs, rt): ac0..ac3 are not in the mips register profile, so modelling it as a hi/lo write would be wrong. It stays unmodelled instead.

Every expected value comes from the differential, not from reading the code. 9 r2r tests; the new forms also gain the op->type they were missing (shl/shr/sar/ror/mul).

clz/clo/dclz/dclo are deliberately left out — ESIL has no count-leading-zeros primitive, and the only in-tree workaround is arm's GOTO loop, which clobbers its destination as scratch and derives its jump target by counting commas in the emitted buffer. 