### PR TITLE
Add the CLZ and POPCNT esil operations ##esil

### DIFF
--- a/doc/esil.md
+++ b/doc/esil.md
@@ -226,6 +226,13 @@ What to do with them? What about bit arithmetic if use variables instead of regi
 7. ROL  "ROL"
 8. ROR  "ROR"
 9. NEG  "!"
+10. CLZ  "CLZ" (count leading zeros: "w,x,CLZ")
+11. POPCNT "POPCNT" (count set bits: "x,POPCNT")
+
+An operation takes an explicit leading width operand only when its result depends
+on that width. CLZ does: the count for the value 1 is 31 at width 32 and 63 at
+width 64. POPCNT does not, because a caller wanting a narrower count masks the
+value first.
 
 # Floating point
 

--- a/libr/anal/esil_dfg.c
+++ b/libr/anal/esil_dfg.c
@@ -1740,6 +1740,8 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *R_NULLABLE d
 	r_esil_set_op (esil, "ROR", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "ROL", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "ASR", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "CLZ", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "POPCNT", edf_consume_1_push_1, 1, 1, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "!", edf_consume_1_push_1, 1, 1, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "++", edf_consume_1_push_1, 1, 1, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "--", edf_consume_1_push_1, 1, 1, R_ESIL_OP_TYPE_MATH, NULL);

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1942,48 +1942,9 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		r_strbuf_setf (&op->esil, "pc,lr,:=,%s,pc,:=", REG64 (0));
 		break;
 	case ARM64_INS_CLZ:
-	{
-		/*
-		from https://en.wikipedia.org/wiki/Find_first_set modified for up to size 64
-		function clz3 (x)
-			if x = 0 return 32
-			n ← 0
-			if (x & 0xFFFF0000) = 0: n ← n + 16, x ← x << 16
-			if (x & 0xFF000000) = 0: n ← n +  8, x ← x <<  8
-			if (x & 0xF0000000) = 0: n ← n +  4, x ← x <<  4
-			if (x & 0xC0000000) = 0: n ← n +  2, x ← x <<  2
-			if (x & 0x80000000) = 0: n ← n +  1
-			return n
-		*/
-
-		int size = 8 * REGSIZE64 (0);
-		const char *r0 = REG64 (0);
-		const char *r1 = REG64 (1);
-
-		if (size == 32) {
-			r_strbuf_setf (&op->esil,
-			"%s,tmp,=,0,"
-			"tmp,0xffff0000,&,!,?{,16,tmp,<<=,16,+,},"
-			"tmp,0xff000000,&,!,?{,8,tmp,<<=,8,+,},"
-			"tmp,0xf0000000,&,!,?{,4,tmp,<<=,4,+,},"
-			"tmp,0xc0000000,&,!,?{,2,tmp,<<=,2,+,},"
-			"tmp,0x80000000,&,!,?{,1,+,},"
-			"%s,!,?{,32,%s,=,}{,%s,=,}",
-			r1, r1, r0, r0);
-		} else {
-			r_strbuf_setf (&op->esil,
-			"%s,tmp,=,0,"
-			"tmp,0xffffffff00000000,&,!,?{,32,tmp,<<=,32,+,},"
-			"tmp,0xffff000000000000,&,!,?{,16,tmp,<<=,16,+,},"
-			"tmp,0xff00000000000000,&,!,?{,8,tmp,<<=,8,+,},"
-			"tmp,0xf000000000000000,&,!,?{,4,tmp,<<=,4,+,},"
-			"tmp,0xc000000000000000,&,!,?{,2,tmp,<<=,2,+,},"
-			"tmp,0x8000000000000000,&,!,?{,1,+,},"
-			"%s,!,?{,64,%s,=,}{,%s,=,}",
-			r1, r1, r0, r0);
-		}
+		r_strbuf_setf (&op->esil, "%d,%s,CLZ,%s,=",
+			8 * REGSIZE64 (0), REG64 (1), REG64 (0));
 		break;
-	}
 	case ARM64_INS_LDRH:
 	case ARM64_INS_LDUR:
 	case ARM64_INS_LDURB:
@@ -2810,13 +2771,7 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 
 	switch (insn->id) {
 	case ARM_INS_CLZ:
-		{
-			// counts on the stack, so the source may be the destination
-			const ut32 head = r_str_char_count (r_strbuf_get (&op->esil), ',') + 12;
-			r_strbuf_appendf (&op->esil, "%s,!,?{,32,%s,=,BREAK,},"
-				"%s,%s,:=,0,%s,0x80000000,&,!,?{,1,%s,<<=,++,%d,GOTO,},%s,=",
-				REG (1), REG (0), REG (1), REG (0), REG (0), REG (0), head, REG (0));
-		}
+		r_strbuf_appendf (&op->esil, "32,%s,CLZ,%s,=", REG (1), REG (0));
 		break;
 	case ARM_INS_IT:
 		r_strbuf_appendf (&op->esil, "0x%"PFMT64x",pc,:=", addr + 2);

--- a/libr/arch/p/ppc_cs/plugin.c
+++ b/libr/arch/p/ppc_cs/plugin.c
@@ -2326,8 +2326,32 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		case PPC_INS_CNTLZW:
 		case PPC_INS_CNTLZD:
 			op->type = R_ANAL_OP_TYPE_MOV;
-			// type only: ESIL has no count-leading-zeros operator
+			esilprintf (op, "%d,%s,CLZ,%s,=",
+				(insn->id == PPC_INS_CNTLZD)? 64: 32, ARG (1), ARG (0));
 			break;
+		case PPC_INS_POPCNTD:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "%s,POPCNT,%s,=", ARG (1), ARG (0));
+			break;
+		case PPC_INS_POPCNTW:
+			op->type = R_ANAL_OP_TYPE_MOV;
+			esilprintf (op, "32,32,%s,>>,POPCNT,<<,0xffffffff,%s,&,POPCNT,|,%s,=",
+				ARG (1), ARG (1), ARG (0));
+			break;
+#if CS_API_MAJOR > 4
+		case PPC_INS_POPCNTB:
+			{
+				op->type = R_ANAL_OP_TYPE_MOV;
+				esilprintf (op, "0xff,%s,&,POPCNT", ARG (1));
+				int i;
+				for (i = 1; i < 8; i++) {
+					r_strbuf_appendf (&op->esil, ",%d,0xff,%d,%s,>>,&,POPCNT,<<,|",
+						i * 8, i * 8, ARG (1));
+				}
+				r_strbuf_appendf (&op->esil, ",%s,=", ARG (0));
+			}
+			break;
+#endif
 		case PPC_INS_MULLI:
 			op->sign = true;
 		case PPC_INS_MULLD:

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -441,6 +441,8 @@ static RCoreHelpMessage help_detail_ae = {
 	"ASR", "", "a asr b => b,a,ASR  # arithmetic shift right",
 	"ROR", "", "a ror b => b,a,ROR  # rotate right",
 	"ROL", "", "a rol b => b,a,ROL  # rotate left",
+	"CLZ", "", "leading zeros of b in a bits => a,b,CLZ  # a when b is 0",
+	"POPCNT", "", "count the set bits => a,POPCNT",
 	"?{", "", "if popped value != 0 run the block until }",
 	"}{", "", "else block",
 	"}", "", "end of conditional block",

--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -126,6 +126,7 @@ static bool esil_clz(REsil *esil) {
 		return false;
 	}
 	if (width > 64) {
+		R_LOG_WARN ("CLZ width %"PFMT64u" clamped to 64", width);
 		width = 64;
 	}
 	val &= r_num_bitmask (width);
@@ -1828,8 +1829,14 @@ R_API bool r_esil_setup_ops(REsil *esil) {
 	ret &= OP ("ASR", esil_asr, 1, 2, OT_MATH);
 	ret &= OP ("ROR", esil_ror, 1, 2, OT_MATH);
 	ret &= OP ("ROL", esil_rol, 1, 2, OT_MATH);
-	ret &= OP ("CLZ", esil_clz, 1, 2, OT_MATH);
-	ret &= OP ("POPCNT", esil_popcount, 1, 1, OT_MATH);
+#if 1 // ESIL_NATIVE_BITOPS
+	ret &= OP2 ("CLZ", esil_clz, 1, 2, OT_MATH, "w,x,CLZ: leading zeros of x in its low w bits, w if x is 0");
+	ret &= OP2 ("POPCNT", esil_popcount, 1, 1, OT_MATH, "x,POPCNT: number of set bits in x");
+#else
+	// plain esil fallbacks for engines without the native ops (w in 1..64)
+	ret &= OPD ("CLZ", "SWAP,DUP,64,-,ROT,<<,0,SWAP,DUP,32,SWAP,>>,!,?{,SWAP,32,+,SWAP,32,SWAP,<<,},DUP,48,SWAP,>>,!,?{,SWAP,16,+,SWAP,16,SWAP,<<,},DUP,56,SWAP,>>,!,?{,SWAP,8,+,SWAP,8,SWAP,<<,},DUP,60,SWAP,>>,!,?{,SWAP,4,+,SWAP,4,SWAP,<<,},DUP,62,SWAP,>>,!,?{,SWAP,2,+,SWAP,2,SWAP,<<,},DUP,63,SWAP,>>,!,?{,SWAP,1,+,SWAP,1,SWAP,<<,},!,?{,POP,}{,SWAP,POP,}", 1, 2, OT_MATH);
+	ret &= OPD ("POPCNT", "DUP,1,SWAP,>>,0x5555555555555555,&,SWAP,-,DUP,0x3333333333333333,&,SWAP,2,SWAP,>>,0x3333333333333333,&,+,DUP,4,SWAP,>>,+,0x0f0f0f0f0f0f0f0f,&,0x0101010101010101,*,56,SWAP,>>", 1, 1, OT_MATH);
+#endif
 	ret &= OP ("&", esil_and, 1, 2, OT_MATH);
 	ret &= OPD ("&=", "DUP,ROT,SWAP,&,SWAP,=", 0, 2, OT_MATH | OT_REGW);
 	ret &= OP ("}", esil_nop, 0, 0, OT_CTR); // just to avoid push

--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -2,6 +2,7 @@
 
 #include <r_esil.h>
 #include <r_anal.h>
+#include <r_util/r_bits.h>
 
 #if __wasi__ || EMSCRIPTEN
 #define FE_OVERFLOW 0
@@ -111,6 +112,34 @@ static ut32 esil_internal_packed_size_reg(REsil *esil, const char *r) {
 		return 0;
 	}
 	return esil->reg_if.reg_packed_size (esil->reg_if.reg, r);
+}
+
+// width,value,CLZ: leading zeros of value in the low width bits (width if 0)
+static bool esil_clz(REsil *esil) {
+	ut64 val, width;
+	const RStrs p_val = r_esil_pop (esil);
+	if (r_strs_empty (p_val) || !r_esil_get_parm (esil, p_val, &val)) {
+		return false;
+	}
+	const RStrs p_width = r_esil_pop (esil);
+	if (r_strs_empty (p_width) || !r_esil_get_parm (esil, p_width, &width)) {
+		return false;
+	}
+	if (width > 64) {
+		width = 64;
+	}
+	val &= r_num_bitmask (width);
+	const ut64 res = val? (ut64)r_bits_clz64 (val) - (64 - width): width;
+	return r_esil_pushnum (esil, res);
+}
+
+static bool esil_popcount(REsil *esil) {
+	ut64 val;
+	const RStrs p_val = r_esil_pop (esil);
+	if (r_strs_empty (p_val) || !r_esil_get_parm (esil, p_val, &val)) {
+		return false;
+	}
+	return r_esil_pushnum (esil, r_bits_popcount64 (val));
 }
 
 // Sign-extend n-bit value to 64 bits. Example: "ae 8,0x81,~" -> 0xffffffffffffff81.
@@ -1799,6 +1828,8 @@ R_API bool r_esil_setup_ops(REsil *esil) {
 	ret &= OP ("ASR", esil_asr, 1, 2, OT_MATH);
 	ret &= OP ("ROR", esil_ror, 1, 2, OT_MATH);
 	ret &= OP ("ROL", esil_rol, 1, 2, OT_MATH);
+	ret &= OP ("CLZ", esil_clz, 1, 2, OT_MATH);
+	ret &= OP ("POPCNT", esil_popcount, 1, 1, OT_MATH);
 	ret &= OP ("&", esil_and, 1, 2, OT_MATH);
 	ret &= OPD ("&=", "DUP,ROT,SWAP,&,SWAP,=", 0, 2, OT_MATH | OT_REGW);
 	ret &= OP ("}", esil_nop, 0, 0, OT_CTR); // just to avoid push

--- a/man/esil.7
+++ b/man/esil.7
@@ -155,7 +155,15 @@ ROL - Rotate left
 ROR - Rotate right
 .It
 ASR - Arithmetic shift right
+.It
+CLZ - Count leading zeros of a value within an explicit width
+.It
+POPCNT - Count the set bits of a value
 .El
+.Pp
+An operation takes an explicit leading width operand only when its result depends
+on that width: CLZ does (the count for 1 is 31 at width 32 and 63 at width 64),
+POPCNT does not.
 .Pp
 .It Cm Comparison operations
 Compare values and set flags:

--- a/test/db/anal/ppc
+++ b/test/db/anal/ppc
@@ -1037,9 +1037,11 @@ esil: 0x8000000000000000,r4,&,!,!,0x7,r4,&,0xffffffffffffffff,&,!,!,&,ca,=,0x3,r
 --
 mnemonic: cntlzw
 type: mov
+esil: 32,r3,CLZ,r3,=
 --
 mnemonic: cntlzd
 type: mov
+esil: 64,r3,CLZ,r3,=
 --
 mnemonic: stbx
 type: store

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3204,7 +3204,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=a conditional clz jumps to its own loop head
+NAME=a conditional clz keeps its condition
 FILE=malloc://0x200
 ARGS=-a arm -b 32
 CMDS=<<EOF

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1949,3 +1949,40 @@ EXPECT=<<EOF
 0x9abcdef0
 EOF
 RUN
+
+NAME=clz counts at the register width
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 2010c05a
+aer x1=0x00001000
+aer pc=0
+s 0
+aes
+aer x0
+wx 2010c0da
+aer x1=0x00001000
+aer pc=0
+s 0
+aes
+aer x0
+aer x1=0
+aer pc=0
+s 0
+aes
+aer x0
+wx 2010c05a
+aer x1=0xffffffff00001000
+aer pc=0
+s 0
+aes
+aer x0
+EOF
+EXPECT=<<EOF
+0x00000013
+0x00000033
+0x00000040
+0x00000013
+EOF
+RUN

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -510,6 +510,8 @@ EXPECT=<<EOF
 | ASR     a asr b => b,a,ASR  # arithmetic shift right
 | ROR     a ror b => b,a,ROR  # rotate right
 | ROL     a rol b => b,a,ROL  # rotate left
+| CLZ     leading zeros of b in a bits => a,b,CLZ  # a when b is 0
+| POPCNT  count the set bits => a,POPCNT
 | ?{      if popped value != 0 run the block until }
 | }{      else block
 | }       end of conditional block
@@ -614,5 +616,41 @@ e io.cache=true
 EOF
 EXPECT=<<EOF
 0x1
+EOF
+RUN
+
+NAME=clz counts within the given width and masks the value to it
+FILE=-
+CMDS=<<EOF
+ae 32,0x80000000,CLZ
+ae 32,1,CLZ
+ae 32,0,CLZ
+ae 64,0,CLZ
+ae 32,0xffffffff00000001,CLZ
+ae 8,0x10,CLZ
+ae 70,1,CLZ
+EOF
+EXPECT=<<EOF
+0
+0x1f
+0x20
+0x40
+0x1f
+0x3
+0x3f
+EOF
+RUN
+
+NAME=popcnt counts the set bits
+FILE=-
+CMDS=<<EOF
+ae 0xf0f0,POPCNT
+ae 0,POPCNT
+ae 0xffffffffffffffff,POPCNT
+EOF
+EXPECT=<<EOF
+0x8
+0
+0x40
 EOF
 RUN

--- a/test/db/esil/ppc_32
+++ b/test/db/esil/ppc_32
@@ -807,3 +807,27 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+
+NAME=cntlzw and popcntb
+FILE=malloc://32
+ARGS=-a ppc -b 32 -e cfg.bigendian=true
+CMDS=<<EOF
+aei
+wx 7c830034
+aer r4=0x00001000
+aer pc=0
+s 0
+aes
+aer r3
+wx 7c8300f4
+aer r4=0xf0f0ff01
+aer pc=0
+s 0
+aes
+aer r3
+EOF
+EXPECT=<<EOF
+0x00000013
+0x04040801
+EOF
+RUN

--- a/test/db/esil/ppc_64
+++ b/test/db/esil/ppc_64
@@ -2471,3 +2471,58 @@ EXPECT=<<EOF
 0x00000005
 EOF
 RUN
+
+NAME=cntlzw, cntlzd and the popcnt family
+FILE=malloc://32
+ARGS=-a ppc -b 64 -e cfg.bigendian=true
+CMDS=<<EOF
+aei
+wx 7c830034
+aer r4=0x00001000
+aer pc=0
+s 0
+aes
+aer r3
+wx 7c830035
+aer r4=0
+aer cr0=0
+aer pc=0
+s 0
+aes
+aer r3
+aer cr0
+wx 7c830074
+aer r4=0x00001000
+aer pc=0
+s 0
+aes
+aer r3
+wx 7c8300f4
+aer r4=0xf0f0ff01
+aer pc=0
+s 0
+aes
+aer r3
+wx 7c8302f4
+aer r4=0xf0f0ff01
+aer pc=0
+s 0
+aes
+aer r3
+wx 7c8303f4
+aer r4=0xf0f0ff01
+aer pc=0
+s 0
+aes
+aer r3
+EOF
+EXPECT=<<EOF
+0x00000013
+0x00000020
+0x00000001
+0x00000033
+0x04040801
+0x00000011
+0x00000011
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds two esil operations and pays them off in three arches at once:

- CLZ — w,x,CLZ pushes the count of leading zeros of x within its low w bits (w when x is 0). The value is masked to the width inside the op, so callers need no pre-masking, and the width is an explicit operand following ~ — not taken from the operand or the config, which is what keeps the register-width ops from expressing sub-width operations.
- POPCNT — x,POPCNT pushes the number of set bits.

Both are backed by the portable helpers in r_util/r_bits.h, registered in the esil DFG, documented in ae??, and pinned by direct ae tests including the edge cases (zero value, width clamp, high-garbage masking).

 Consumers, one commit each:

- ppc — cntlzw/cntlzd stop being type-only, and popcntb/popcntw/popcntd are modelled (per-byte and per-word lanes built from POPCNT).  The record form cntlzw. picks up cr0 through the existing generic Rc handling. Verified against the qemu differential. 
- arm32 — the GOTO-loop clz is deleted: it clobbered its destination as scratch and derived its jump target by counting commas in the emitted buffer. Now 32,rm,CLZ,rd,=, still under the conditional prefix.
- arm64 — the 40-line unrolled binary-search clz is deleted for w,rn,CLZ,rd,= at the register width; it also stops using tmp as scratch.

All arm suites of the unicorn differential are unchanged too.

This unblocks the same modelling for mips clz/clo/dclz/dclo (follows separately — the mips esil switch is being touched by an open PR) and would let x86's popcnt/lzcnt drop their SWAR and smear loops later. Also, the two remaining bug groups the extended qemu differential found:

* arm64 extended-register operands — the last wrong-value group: uxtb/sxth extenders dropped, bfxil/extr/smulh wrong, smsubl NOESIL, plus the core ~/ INT_MIN/-1 edge.
* rasm2 assembler bugs — LOW: mis-encodings the harness routes around via llvm-mc, so they only bite rasm2/wa users.
