### PR TITLE
Keep non-import ELF relocs at their site when bin.relocs.apply is on ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1690,48 +1690,39 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_VEC_FOREACH (relocs, reloc) {
 		ut64 plt_entry_addr = vaddr;
 		ut64 sym_addr = UT64_MAX;
+		const bool is_import = reloc->sym && reloc->sym < eo->imports_by_ord_size
+			&& eo->imports_by_ord[reloc->sym];
 
-		if (reloc->sym) {
-			if (reloc->sym < eo->imports_by_ord_size && eo->imports_by_ord[reloc->sym]) {
-				bool found;
-				sym_addr = ht_uu_find (relocs_by_sym, reloc->sym, &found);
-				if (found) {
-					plt_entry_addr = sym_addr;
-				}
-			} else if (reloc->sym < eo->symbols_by_ord_size && eo->symbols_by_ord[reloc->sym]) {
-				sym_addr = eo->symbols_by_ord[reloc->sym]->vaddr;
+		if (is_import) {
+			bool found;
+			sym_addr = ht_uu_find (relocs_by_sym, reloc->sym, &found);
+			if (found) {
 				plt_entry_addr = sym_addr;
 			}
+		} else if (reloc->sym && reloc->sym < eo->symbols_by_ord_size && eo->symbols_by_ord[reloc->sym]) {
+			sym_addr = eo->symbols_by_ord[reloc->sym]->vaddr;
+			plt_entry_addr = sym_addr;
 		}
-		// ut64 raddr = sym_addr? sym_addr: vaddr;
-		// For sBPF, use rel->rva for relocations without symbols (like R_BPF_64_RELATIVE)
-		ut64 raddr;
-		if (sym_addr && sym_addr != UT64_MAX) {
-			raddr = sym_addr;
-		} else {
-			raddr = vaddr;
-		}
+		const bool resolved = sym_addr && sym_addr != UT64_MAX;
+		const ut64 raddr = resolved? sym_addr: vaddr;
 		_patch_reloc (eo, eo->ehdr.e_machine, &b->iob, reloc, raddr, eo->baddr, plt_entry_addr, toc_base);
 		ptr = reloc_convert (eo, reloc, n_vaddr, ret);
 		if (!ptr) {
 			continue;
 		}
 
-		if (sym_addr && sym_addr != UT64_MAX) {
-			// PPC64 ET_REL only: S + A so multiple .rela.opd entries don't
-			// collapse onto the section base. Other architectures emit ET_REL
-			// relocs against section symbols + addend on every reference, and
-			// folding A in would alias ptr->vaddr onto unrelated instruction
-			// addresses (showing up as phantom RELOC comments mid-function).
-			const bool ppc64_etrel = eo->ehdr.e_type == ET_REL && eo->ehdr.e_machine == EM_PPC64;
-			ptr->vaddr = ppc64_etrel ? sym_addr + reloc->addend : sym_addr;
-		} else {
-			// In sBPF, symbol relocations are handled independently as R_BPF_64_64
-			if (eo->ehdr.e_machine != EM_SBPF) {
-				ptr->vaddr = vaddr;
-				ht_uu_insert (relocs_by_sym, reloc->sym, vaddr);
-				vaddr += cdsz;
+		// only imports move to their .got.r2 slot, where the patched bytes
+		// point; everything else is reported at its site
+		if (resolved) {
+			if (is_import) {
+				ptr->vaddr = sym_addr;
 			}
+		} else if (eo->ehdr.e_machine != EM_SBPF) {
+			if (is_import) {
+				ptr->vaddr = vaddr;
+			}
+			ht_uu_insert (relocs_by_sym, reloc->sym, vaddr);
+			vaddr += cdsz;
 		}
 	}
 	ht_uu_free (relocs_by_sym);

--- a/test/db/anal/plt-local
+++ b/test/db/anal/plt-local
@@ -329,3 +329,15 @@ EXPECT=<<EOF
 0x000014f0 17 sym.plt.sub2
 EOF
 RUN
+
+NAME=x86_64 plt stubs keep their names with bin.relocs.apply
+FILE=bins/elf/pltrel/add.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+aaa
+afl~sym.plt.
+EOF
+EXPECT=<<EOF
+0x00001050    1     10 sym.plt.add2
+EOF
+RUN

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -72,16 +72,16 @@ EOF
 EXPECT=<<EOF
 366
             ;-- section..init_array:
-            0x000b58c4      .dword 0x00004560 ; reloc..datadiv_decode1794556967687044894 ; sym..datadiv_decode1794556967687044894 ; [15] -rw- section size 364 named .init_array
-            0x000b58c8      .dword 0x00004570 ; reloc..datadiv_decode12875440098136793118 ; sym..datadiv_decode12875440098136793118
-            0x000b58cc      .dword 0x00098028 ; reloc..datadiv_decode11893604691534341392 ; sym..datadiv_decode11893604691534341392
-            0x000b58d0      .dword 0x00008115 ; entry.init0
-            0x000b58d4      .dword 0x00055049 ; entry.init1
-            0x000b58d8      .dword 0x00098b44 ; reloc..datadiv_decode668687990735969933 ; sym..datadiv_decode668687990735969933
-            0x000b58dc      .dword 0x00098b48 ; reloc..datadiv_decode16868916699024037624 ; sym..datadiv_decode16868916699024037624
-            0x000b58e0      .dword 0x00098b4c ; reloc..datadiv_decode12802097292201864397 ; sym..datadiv_decode12802097292201864397
-            0x000b58e4      .dword 0x00098b50 ; reloc..datadiv_decode12428479046606065387 ; sym..datadiv_decode12428479046606065387
-            0x000b58e8      .dword 0x00098b54 ; reloc..datadiv_decode7496105736011033460 ; sym..datadiv_decode7496105736011033460
+            0x000b58c4      .dword 0x00004560 ; sym..datadiv_decode1794556967687044894; RELOC 32 .datadiv_decode1794556967687044894 @ 0x00004560 ; [15] -rw- section size 364 named .init_array
+            0x000b58c8      .dword 0x00004570 ; sym..datadiv_decode12875440098136793118; RELOC 32 .datadiv_decode12875440098136793118 @ 0x00004570
+            0x000b58cc      .dword 0x00098028 ; sym..datadiv_decode11893604691534341392; RELOC 32 .datadiv_decode11893604691534341392 @ 0x00098028
+            0x000b58d0      .dword 0x00008115 ; entry.init0            ; RELOC 32 
+            0x000b58d4      .dword 0x00055049 ; entry.init1            ; RELOC 32 
+            0x000b58d8      .dword 0x00098b44 ; sym..datadiv_decode668687990735969933; RELOC 32 .datadiv_decode668687990735969933 @ 0x00098b44
+            0x000b58dc      .dword 0x00098b48 ; sym..datadiv_decode16868916699024037624; RELOC 32 .datadiv_decode16868916699024037624 @ 0x00098b48
+            0x000b58e0      .dword 0x00098b4c ; sym..datadiv_decode12802097292201864397; RELOC 32 .datadiv_decode12802097292201864397 @ 0x00098b4c
+            0x000b58e4      .dword 0x00098b50 ; sym..datadiv_decode12428479046606065387; RELOC 32 .datadiv_decode12428479046606065387 @ 0x00098b50
+            0x000b58e8      .dword 0x00098b54 ; sym..datadiv_decode7496105736011033460; RELOC 32 .datadiv_decode7496105736011033460 @ 0x00098b54
 EOF
 RUN
 
@@ -121,15 +121,23 @@ EXPECT=<<EOF
 264
             ;-- section..init_array:
             ;-- segment.LOAD1:
-            0x00126510      .qword 0x0000000000005a6c ; reloc..datadiv_decode9958896245423089702 ; sym..datadiv_decode9958896245423089702 ; [13] -rw- section size 728 named .init_array
-            0x00126518      .qword 0x0000000000005a80 ; reloc..datadiv_decode10476194973746341988 ; sym..datadiv_decode10476194973746341988
-            0x00126520      .qword 0x00000000000efddc ; reloc..datadiv_decode16323044921667855934 ; sym..datadiv_decode16323044921667855934
-            0x00126528      .qword 0x0000000000009080 ; entry.init0
-            0x00126530      .qword 0x0000000000077d14 ; entry.init1
-            0x00126538      .qword 0x00000000000f22e0 ; reloc..datadiv_decode667225052219618748 ; sym..datadiv_decode667225052219618748
-            0x00126540      .qword 0x00000000000f22e4 ; reloc..datadiv_decode8132880250332170398 ; sym..datadiv_decode8132880250332170398
-            0x00126548      .qword 0x00000000000f22e8 ; reloc..datadiv_decode3655886617018729963 ; sym..datadiv_decode3655886617018729963
-            0x00126550      .qword 0x00000000000f22ec ; reloc..datadiv_decode16406252260792032531 ; sym..datadiv_decode16406252260792032531
-            0x00126558      .qword 0x00000000000f22f0 ; reloc..datadiv_decode13403071575248320347 ; sym..datadiv_decode13403071575248320347
+            ;-- reloc..datadiv_decode9958896245423089702:
+            0x00126510      .qword 0x0000000000005a6c ; sym..datadiv_decode9958896245423089702; RELOC 64 .datadiv_decode9958896245423089702 @ 0x00005a6c ; [13] -rw- section size 728 named .init_array
+            ;-- reloc..datadiv_decode10476194973746341988:
+            0x00126518      .qword 0x0000000000005a80 ; sym..datadiv_decode10476194973746341988; RELOC 64 .datadiv_decode10476194973746341988 @ 0x00005a80
+            ;-- reloc..datadiv_decode16323044921667855934:
+            0x00126520      .qword 0x00000000000efddc ; sym..datadiv_decode16323044921667855934; RELOC 64 .datadiv_decode16323044921667855934 @ 0x000efddc
+            0x00126528      .qword 0x0000000000009080 ; entry.init0    ; RELOC 64 
+            0x00126530      .qword 0x0000000000077d14 ; entry.init1    ; RELOC 64 
+            ;-- reloc..datadiv_decode667225052219618748:
+            0x00126538      .qword 0x00000000000f22e0 ; sym..datadiv_decode667225052219618748; RELOC 64 .datadiv_decode667225052219618748 @ 0x000f22e0
+            ;-- reloc..datadiv_decode8132880250332170398:
+            0x00126540      .qword 0x00000000000f22e4 ; sym..datadiv_decode8132880250332170398; RELOC 64 .datadiv_decode8132880250332170398 @ 0x000f22e4
+            ;-- reloc..datadiv_decode3655886617018729963:
+            0x00126548      .qword 0x00000000000f22e8 ; sym..datadiv_decode3655886617018729963; RELOC 64 .datadiv_decode3655886617018729963 @ 0x000f22e8
+            ;-- reloc..datadiv_decode16406252260792032531:
+            0x00126550      .qword 0x00000000000f22ec ; sym..datadiv_decode16406252260792032531; RELOC 64 .datadiv_decode16406252260792032531 @ 0x000f22ec
+            ;-- reloc..datadiv_decode13403071575248320347:
+            0x00126558      .qword 0x00000000000f22f0 ; sym..datadiv_decode13403071575248320347; RELOC 64 .datadiv_decode13403071575248320347 @ 0x000f22f0
 EOF
 RUN

--- a/test/db/formats/elf/elf-relarm64
+++ b/test/db/formats/elf/elf-relarm64
@@ -41,10 +41,10 @@ CMDS=<<EOF
 pd 6 @ 0x08000044
 EOF
 EXPECT=<<EOF
-            0x08000044      06000094       bl sym.local_target
+            0x08000044      06000094       bl sym.local_target         ; RELOC 32 local_target @ 0x0800005c
             0x08000048      b6000094       bl reloc.extern_target
-        ,=< 0x0800004c      80001836       tbz w0, 3, sym.local_target
-       ,==< 0x08000050      60000054       b.eq sym.local_target
+        ,=< 0x0800004c      80001836       tbz w0, 3, sym.local_target ; RELOC 32 local_target @ 0x0800005c
+       ,==< 0x08000050      60000054       b.eq sym.local_target       ; RELOC 32 local_target @ 0x0800005c
        ||   0x08000054      fd7bc1a8       ldp x29, x30, [sp], 0x10
       ,===< 0x08000058      b4000014       b reloc.extern_tail
 EOF
@@ -59,11 +59,11 @@ EOF
 EXPECT=<<EOF
 vaddr      paddr      type   ntype name
 ---------------------------------------
-0x0800005c 0x00000044 ADD_32 283   local_target
-0x0800005c 0x0000004c ADD_32 279   local_target
-0x0800005c 0x00000050 ADD_32 280   local_target
-0x0800005c 0x0000006c ADD_32 258   local_target
-0x0800005c 0x00000070 ADD_64 257   local_target
+0x08000044 0x00000044 ADD_32 283   local_target
+0x0800004c 0x0000004c ADD_32 279   local_target
+0x08000050 0x00000050 ADD_32 280   local_target
+0x0800006c 0x0000006c ADD_32 258   local_target
+0x08000070 0x00000070 ADD_64 257   local_target
 0x08000320 0x00000048 ADD_32 283   extern_target
 0x08000320 0x00000068 ADD_32 261   extern_target + 0x08000000
 0x08000328 0x00000058 ADD_32 282   extern_tail

--- a/test/db/formats/elf/elf-relro
+++ b/test/db/formats/elf/elf-relro
@@ -946,3 +946,12 @@ EXPECT=<<EOF
 \      `==< 0x0002e080      abffffea       b 0x2df34
 EOF
 RUN
+
+NAME=ELF: relocs.apply does not flag a defined symbol reloc on its function
+FILE=bins/elf/libcurl.so.4.2.0
+ARGS=-e bin.relocs.apply=true
+CMDS=f~0x0001de5c
+EXPECT=<<EOF
+0x0001de5c 604 sym.Curl_close
+EOF
+RUN

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -69,23 +69,14 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=PPC64 ELFv1 ET_REL: .opd ADDR64 relocs resolve to distinct vaddrs (S + A, not collapsed)
+NAME=PPC64 ELFv1 ET_REL: .opd ADDR64 relocs are reported at their .opd slot
 FILE=bins/elf/ppc64v1-crc32_generic.ko
 ARGS=-e bin.relocs.apply=true
 CMDS=ir~SET_64[0]
 EXPECT=<<EOF
-0x080000b0
-0x080000f0
-0x08000130
-0x080001a0
-0x080001f0
-0x08000270
-0x080002f0
-0x08000358
-0x0800038c
+0x08000700
 0x08000708
 0x08000720
-0x08000738
 0x08000738
 0x08000750
 0x08000768
@@ -93,9 +84,18 @@ EXPECT=<<EOF
 0x08000798
 0x080007b0
 0x080007c8
-0x080007c8
 0x080007e0
-0x08000a00
+0x080007e8
+0x080007f0
+0x080007f8
+0x08000800
+0x08000818
+0x080009a0
+0x080009b8
+0x080009c0
+0x080009c8
+0x08000b38
+0x08000db0
 EOF
 RUN
 
@@ -164,21 +164,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=aarch64 ET_REL (regression): section-symbol relocs collapse to base, not S + A
+NAME=aarch64 ET_REL: section-symbol relocs are reported at their site, not at S + A
 FILE=bins/elf/random_39855/random_39855.oo
 ARGS=-e bin.relocs.apply=true
-CMDS=ir~ADD_32[0]|sort -u
+CMDS=ir~0x000101c4
 EXPECT=<<EOF
-0x08000040
-0x080057dc
-0x080057f0
-0x080057f4
-0x080057f8
-0x08005960
-0x08005978
-0x08005988
-0x08012678
-0x08012680
+0x080101c4 0x000101c4 ADD_32 261   .text + 0x08000000
 EOF
 RUN
 

--- a/test/db/formats/elf/random
+++ b/test/db/formats/elf/random
@@ -53,8 +53,8 @@ EXPECT=<<EOF
 |           0x08000828      011d00f9       str x1, [x8, 0x38]          ; arg2
 |           0x0800082c      031900f9       str x3, [x8, 0x30]          ; arg4
 |           0x08000830      041500f9       str x4, [x8, 0x28]          ; arg5
-|           0x08000834      280000b0       adrp x8, 0x8005000
-|           0x08000838      08412091       add x8, x8, 0x810           ; str.O_n_
+|           0x08000834      280000b0       adrp x8, 0x8005000          ; RELOC 32 .rodata @ 0x080057f8 + 0x18
+|           0x08000838      08412091       add x8, x8, 0x810           ; RELOC 32 .rodata @ 0x080057f8 + 0x18 ; str.O_n_
 |           0x0800083c      0001c03d       ldr q0, [x8]                ; str.O_n_
 |           0x08000840      2001803d       str q0, [x9]
 |           0x08000844      080940f9       ldr x8, [x8, 0x10]

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -200,16 +200,24 @@ EOF
 EXPECT=<<EOF
             ;-- section..init_array:
             ;-- segment.LOAD1:
-            0x00126510      .qword 0x0000000000005a6c ; reloc..datadiv_decode9958896245423089702 ; sym..datadiv_decode9958896245423089702 ; [13] -rw- section size 728 named .init_array
-            0x00126518      .qword 0x0000000000005a80 ; reloc..datadiv_decode10476194973746341988 ; sym..datadiv_decode10476194973746341988
-            0x00126520      .qword 0x00000000000efddc ; reloc..datadiv_decode16323044921667855934 ; sym..datadiv_decode16323044921667855934
-            0x00126528      .qword 0x0000000000009080 ; entry.init0
-            0x00126530      .qword 0x0000000000077d14 ; entry.init1
-            0x00126538      .qword 0x00000000000f22e0 ; reloc..datadiv_decode667225052219618748 ; sym..datadiv_decode667225052219618748
-            0x00126540      .qword 0x00000000000f22e4 ; reloc..datadiv_decode8132880250332170398 ; sym..datadiv_decode8132880250332170398
-            0x00126548      .qword 0x00000000000f22e8 ; reloc..datadiv_decode3655886617018729963 ; sym..datadiv_decode3655886617018729963
-            0x00126550      .qword 0x00000000000f22ec ; reloc..datadiv_decode16406252260792032531 ; sym..datadiv_decode16406252260792032531
-            0x00126558      .qword 0x00000000000f22f0 ; reloc..datadiv_decode13403071575248320347 ; sym..datadiv_decode13403071575248320347
+            ;-- reloc..datadiv_decode9958896245423089702:
+            0x00126510      .qword 0x0000000000005a6c ; sym..datadiv_decode9958896245423089702; RELOC 64 .datadiv_decode9958896245423089702 @ 0x00005a6c ; [13] -rw- section size 728 named .init_array
+            ;-- reloc..datadiv_decode10476194973746341988:
+            0x00126518      .qword 0x0000000000005a80 ; sym..datadiv_decode10476194973746341988; RELOC 64 .datadiv_decode10476194973746341988 @ 0x00005a80
+            ;-- reloc..datadiv_decode16323044921667855934:
+            0x00126520      .qword 0x00000000000efddc ; sym..datadiv_decode16323044921667855934; RELOC 64 .datadiv_decode16323044921667855934 @ 0x000efddc
+            0x00126528      .qword 0x0000000000009080 ; entry.init0    ; RELOC 64 
+            0x00126530      .qword 0x0000000000077d14 ; entry.init1    ; RELOC 64 
+            ;-- reloc..datadiv_decode667225052219618748:
+            0x00126538      .qword 0x00000000000f22e0 ; sym..datadiv_decode667225052219618748; RELOC 64 .datadiv_decode667225052219618748 @ 0x000f22e0
+            ;-- reloc..datadiv_decode8132880250332170398:
+            0x00126540      .qword 0x00000000000f22e4 ; sym..datadiv_decode8132880250332170398; RELOC 64 .datadiv_decode8132880250332170398 @ 0x000f22e4
+            ;-- reloc..datadiv_decode3655886617018729963:
+            0x00126548      .qword 0x00000000000f22e8 ; sym..datadiv_decode3655886617018729963; RELOC 64 .datadiv_decode3655886617018729963 @ 0x000f22e8
+            ;-- reloc..datadiv_decode16406252260792032531:
+            0x00126550      .qword 0x00000000000f22ec ; sym..datadiv_decode16406252260792032531; RELOC 64 .datadiv_decode16406252260792032531 @ 0x000f22ec
+            ;-- reloc..datadiv_decode13403071575248320347:
+            0x00126558      .qword 0x00000000000f22f0 ; sym..datadiv_decode13403071575248320347; RELOC 64 .datadiv_decode13403071575248320347 @ 0x000f22f0
             0x0800009f      ff             unaligned
 EOF
 RUN
@@ -689,5 +697,15 @@ vaddr      paddr      type   ntype name
 ;-- reloc.dcngettext:
 ;-- dcngettext:
 0x000ec0b0      sethi 0x9c, g1                                         ; RELOC 32 dcngettext
+EOF
+RUN
+
+NAME=ELF: relocs.apply keeps symbol-less relocs at their site
+FILE=bins/elf/ls
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~ADD_64:0..2
+EXPECT=<<EOF
+0x00021050 0x00020050 ADD_64 8      0x00005bd0
+0x00021058 0x00020058 ADD_64 8      0x00005b80
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With `bin.relocs.apply=true`, `patch_relocs()` reported every reloc somewhere other than its site: defined-symbol relocs at the symbol, symbol-less ones (RELATIVE, section, fixup) at a `.got.r2` slot. That moved the `reloc.*` flags off the GOT/`.init_array` words, dropped the `; RELOC` comments and `reloc.fixup.*` names, put a `reloc.Curl_close` flag on the first instruction of the function, and made the `anal.plt` stub scan miss its lookup at the GOT slot, so `sym.plt.*` names disappeared on x86-64 and aarch64.

Only imports need the synthetic slot (the patched branches and GOT words point there), so now only imports are reported at it; everything else keeps the site. Byte patching is untouched: the slot counter and every `_patch_reloc` input are the same, verified bit-identical across the whole testbins corpus.

- `ir`, `reloc.*` flags, `; RELOC` comments and `sym.plt.*` naming match the `apply=false` placement; the `; [addr]=… reloc.X` comments keep resolving
- goldens updated where a reloc now sits on its real address; three new tests

Follow-up: import GOT slots still lose the `[reloc.X]` operand name, since the import's only flag is on its slot.