### PR TITLE
Fix dex and cil test regressions, honor dyncc argcount in call comments ##test

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -6222,6 +6222,13 @@ static void ds_comment_call(RDisasmState *ds) {
 	if (fcn) {
 		// @TODO: fcn->nargs should be updated somewhere and used here instead
 		nargs = r_anal_var_count_args (fcn);
+		if (nargs < 1) {
+			// arg vars may not be recovered yet, but a dyncc carries the argcount
+			const char *fcncc = r_anal_function_cc (fcn);
+			if (fcncc && r_str_startswith (fcncc, "dyncc:")) {
+				nargs = r_anal_cc_max_arg (core->anal, fcncc);
+			}
+		}
 	}
 	if (nargs > 0) {
 		ds_comment_esil (ds, true, false, "%s", ds->show_color? ds->pal_comment : "");

--- a/test/db/asm/dalvik
+++ b/test/db/asm/dalvik
@@ -57,7 +57,7 @@ d "const-wide/16 v0, 0000" 16000000
 d "const-wide/32 v2:v3, 0x00bc614e" 17024e61bc00
 d "const-wide/high16 v0:v1, 0x40240000" 19002440
 d "const/16 v0, 0x0a" 13000A00
-d "const/4 v1, 0x2" 1221
+d "const/4 v1, 2" 1221
 d "const/high16 v0, 0x41200000" 15002041
 d "div-double v6, v0, v2" AE060002
 d "div-double/2addr v0, v2" CE20

--- a/test/db/cmd/cmd_anal_dyncc
+++ b/test/db/cmd/cmd_anal_dyncc
@@ -164,9 +164,9 @@ REQUIRE=x86
 FILE=bins/cil/hello.exe
 CMDS=<<EOF
 e anal.cc
-af @ method.HelloWorld..ctor
-afi @ method.HelloWorld..ctor~callconv,args
-afv @ method.HelloWorld..ctor
+af @ method.public.constructor.HelloWorld..ctor
+afi @ method.public.constructor.HelloWorld..ctor~callconv,args
+afv @ method.public.constructor.HelloWorld..ctor
 EOF
 EXPECT=<<EOF
 dyncc
@@ -181,12 +181,12 @@ REQUIRE=x86
 FILE=bins/cil/AStyleWhore.exe
 CMDS=<<EOF
 e anal.cc
-af @ method.AStyleWhore.Properties.Settings.get_Default
-afi @ method.AStyleWhore.Properties.Settings.get_Default~name,callconv,args
+af @ method.public.static.AStyleWhore.Properties.Settings.get_Default
+afi @ method.public.static.AStyleWhore.Properties.Settings.get_Default~name,callconv,args
 EOF
 EXPECT=<<EOF
 dyncc
-name: method.AStyleWhore.Properties.Settings.get_Default
+name: method.public.static.AStyleWhore.Properties.Settings.get_Default
 callconv: dyncc::r0+1
 args: 0
 EOF
@@ -238,8 +238,8 @@ REQUIRE=x86
 FILE=bins/cil/hello.exe
 CMDS=<<EOF
 aaa
-afi @ method.HelloWorld..ctor~callconv
-afv @ method.HelloWorld..ctor
+afi @ method.public.constructor.HelloWorld..ctor~callconv
+afv @ method.public.constructor.HelloWorld..ctor
 EOF
 EXPECT=<<EOF
 callconv: dyncc:a0+1:!T0

--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -302,9 +302,9 @@ NAME=DEX HelloWorld.dex debug info
 FILE=bins/dex/HelloWorld.dex
 CMDS=e io.va=0; pd 1 @0x00000290|grep Hello.java; pd 1 @0x000002f4|grep World.java; pd 1 @0x00000318|grep World.java;
 EXPECT=<<EOF
-            0x00000290      62000400       sget-object v0, Ljava/lang/System;->out Ljava/io/PrintStream; ; Hello.java:9 ; 0x180
+            0x00000290      62000400       sget-object v0, Ljava/lang/System;->out Ljava/io/PrintStream; ; Hello.java:9 ; [0x180:4]=0x30008
             0x000002f4      701008000100   invoke-direct {v1}, Ljava/lang/Object.<init>()V ; 0x8 ; World.java:5
-            0x00000318      62000400       sget-object v0, Ljava/lang/System;->out Ljava/io/PrintStream; ; World.java:11 ; 0x180
+            0x00000318      62000400       sget-object v0, Ljava/lang/System;->out Ljava/io/PrintStream; ; World.java:11 ; [0x180:4]=0x30008
 EOF
 RUN
 
@@ -1992,7 +1992,7 @@ NAME=DEX test.dex
 FILE=bins/dex/test.dex
 CMDS=pd 1 @ 0x000001c4
 EXPECT=<<EOF
-            0x000001c4      1234           const/4 v4, 0x3
+            0x000001c4      1234           const/4 v4, 3
 EOF
 RUN
 

--- a/test/db/perf/dex
+++ b/test/db/perf/dex
@@ -14,24 +14,28 @@ EXPECT=<<EOF
 | `- args(v8, v9)
 |           0x000155b8      1207           const/4 v7, 0
 |           0x000155ba      6f2003009800   invoke-super {v8, v9}, Landroid/app/Activity.onCreate(Landroid/os/Bundle;)V ; 0x3
-|           0x000155c0      1214           const/4 v4, 0x1
+|           0x000155c0      1214           const/4 v4, 1
 |           0x000155c2      6a04ba00       sput-boolean v4, Lcom/stericson/RootTools/RootTools;->debugMode Z ; field.class.Lcom_stericson_RootTools_RootTools.var.Lcom_stericson_RootTools_RootTools.sfield_debugMode:Z
-|                                                                      ; 0x44c8 ; "f"
+|                                                                      ; [0x44c8:1]=102 ; "f"
 |           0x000155c6      22043d00       new-instance v4, Landroid/widget/TextView; ; SanityCheckRootTools.java:52 ; 0x2828
 |           0x000155ca      702082008400   invoke-direct {v4, v8}, Landroid/widget/TextView.<init>(Landroid/content/Context;)V ; 0x82
 |           0x000155d0      5b84d300       iput-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mTextView Landroid/widget/TextView; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mTextView:Landroid_widget_TextView_
-|                                                                      ; 0x4590 ; u"n=\u0724"
-|           0x000155d4      5484d300       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mTextView Landroid/widget/TextView; ; SanityCheckRootTools.java:54
+|                                                                      ; [0x4590:4]=0x3d006e ; u"n=\u0724"
+|           0x000155d4      5484d300       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mTextView Landroid/widget/TextView; ; SanityCheckRootTools.java:54 ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mTextView:Landroid_widget_TextView_
+|                                                                      ; [0x4590:4]=0x3d006e ; u"n=\u0724"
 |           0x000155d8      1a050000       const-string v5, 0x2b120
 |           0x000155dc      6e2085005400   invoke-virtual {v4, v5}, Landroid/widget/TextView.setText(Ljava/lang/CharSequence;)V ; 0x85
 |           0x000155e2      22043b00       new-instance v4, Landroid/widget/ScrollView; ; SanityCheckRootTools.java:61 ; 0x2820
 |           0x000155e6      70207d008400   invoke-direct {v4, v8}, Landroid/widget/ScrollView.<init>(Landroid/content/Context;)V ; 0x7d
 |           0x000155ec      5b84d200       iput-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mScrollView Landroid/widget/ScrollView; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mScrollView:Landroid_widget_ScrollView_
-|                                                                      ; 0x4588 ; u"n;\u0723"
-|           0x000155f0      5484d200       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mScrollView Landroid/widget/ScrollView;
-|           0x000155f4      5485d300       iget-object v5, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mTextView Landroid/widget/TextView;
+|                                                                      ; [0x4588:4]=0x3b006e ; u"n;\u0723"
+|           0x000155f0      5484d200       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mScrollView Landroid/widget/ScrollView; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mScrollView:Landroid_widget_ScrollView_
+|                                                                      ; [0x4588:4]=0x3b006e ; u"n;\u0723"
+|           0x000155f4      5485d300       iget-object v5, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mTextView Landroid/widget/TextView; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mTextView:Landroid_widget_TextView_
+|                                                                      ; [0x4590:4]=0x3d006e ; u"n=\u0724"
 |           0x000155f8      6e207e005400   invoke-virtual {v4, v5}, Landroid/widget/ScrollView.addView(Landroid/view/View;)V ; 0x7e
-|           0x000155fe      5484d200       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mScrollView Landroid/widget/ScrollView;
+|           0x000155fe      5484d200       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mScrollView Landroid/widget/ScrollView; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mScrollView:Landroid_widget_ScrollView_
+|                                                                      ; [0x4588:4]=0x3b006e ; u"n;\u0723"
 |           0x00015602      6e2028024800   invoke-virtual {v8, v4}, Lcom/stericson/RootTools/SanityCheckRootTools.setContentView(Landroid/view/View;)V ; 0x228
 |           0x00015608      1a03f100       const-string v3, 0x2c3e0
 |           0x0001560c      6e1024020800   invoke-virtual {v8}, Lcom/stericson/RootTools/SanityCheckRootTools.getPackageManager()Landroid/content/pm/PackageManager; ; 0x224 ; SanityCheckRootTools.java:84
@@ -41,7 +45,7 @@ EXPECT=<<EOF
 |           0x0001561c      1206           const/4 v6, 0
 |           0x0001561e      6e3035005406   invoke-virtual {v4, v5, v6}, Landroid/content/pm/PackageManager.getPackageInfo(Ljava/lang/String;I)Landroid/content/pm/PackageInfo; ; 0x35 ; SanityCheckRootTools.java:79
 |           0x00015624      0c02           move-result-object v2
-|           0x00015626      54230200       iget-object v3, v2, Landroid/content/pm/PackageInfo;->versionName Ljava/lang/String;
+|           0x00015626      54230200       iget-object v3, v2, Landroid/content/pm/PackageInfo;->versionName Ljava/lang/String; ; [0x3f08:4]=0xd90013
 |           0x0001562a      2204db00       new-instance v4, Ljava/lang/StringBuilder; ; 0x2aa0
 |           0x0001562e      1a056703       const-string v5, str.SanityCheckRootTools_v_ ; SanityCheckRootTools.java:94 ; 0x30435
 |           0x00015632      702085035400   invoke-direct {v4, v5}, Ljava/lang/StringBuilder.<init>(Ljava/lang/String;)V ; 0x385
@@ -65,10 +69,12 @@ EXPECT=<<EOF
 |    :`---> 0x000156a4      22040b00       new-instance v4, Landroid/app/ProgressDialog; ; 0x2760
 |    :      0x000156a8      702012008400   invoke-direct {v4, v8}, Landroid/app/ProgressDialog.<init>(Landroid/content/Context;)V ; 0x12
 |    :      0x000156ae      5b84d100       iput-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mPDialog Landroid/app/ProgressDialog; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mPDialog:Landroid_app_ProgressDialog_
-|    :                                                                 ; 0x4580 ; u"n\v\u0722"
-|    :      0x000156b2      5484d100       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mPDialog Landroid/app/ProgressDialog;
+|    :                                                                 ; [0x4580:4]=0xb006e ; u"n\v\u0722"
+|    :      0x000156b2      5484d100       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mPDialog Landroid/app/ProgressDialog; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mPDialog:Landroid_app_ProgressDialog_
+|    :                                                                 ; [0x4580:4]=0xb006e ; u"n\v\u0722"
 |    :      0x000156b6      6e2014007400   invoke-virtual {v4, v7}, Landroid/app/ProgressDialog.setCancelable(Z)V ; 0x14
-|    :      0x000156bc      5484d100       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mPDialog Landroid/app/ProgressDialog;
+|    :      0x000156bc      5484d100       iget-object v4, v8, Lcom/stericson/RootTools/SanityCheckRootTools;->mPDialog Landroid/app/ProgressDialog; ; field.class.Lcom_stericson_RootTools_SanityCheckRootTools.var.Lcom_stericson_RootTools_SanityCheckRootTools.ifield_mPDialog:Landroid_app_ProgressDialog_
+|    :                                                                 ; [0x4580:4]=0xb006e ; u"n\v\u0722"
 |    :      0x000156c0      6e2016007400   invoke-virtual {v4, v7}, Landroid/app/ProgressDialog.setProgressStyle(I)V ; 0x16
 |    :      0x000156c6      22046c00       new-instance v4, Lcom/stericson/RootTools/SanityCheckRootTools$SanityCheckThread; ; 0x28e4
 |    :      0x000156ca      22056d00       new-instance v5, Lcom/stericson/RootTools/SanityCheckRootTools$TestHandler; ; 0x28e8


### PR DESCRIPTION
* Update CIL dyncc tests for the new dotnet method flag names
* Update dex tests for signed const/4 and field refptr comments
* Fallback to the dyncc argcount in emu call comments when the
  callee function has no recovered argument variables yet

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DiLJyFcikZ7nbtsSNgrZkT