### PR TITLE
Fix #26546 - stop zeroing relr relocs under bin.relocs.apply ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1040,6 +1040,12 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 	ut64 A = rel->addend;
 	ut64 P = rel->rva;
 	ut8 buf[8] = {0};
+	if (rel->mode == DT_RELR) {
+		// relr has no explicit addend: the slot's own word is it
+		ut8 slot[sizeof (Elf_(Addr))] = {0};
+		iob->read_at (iob->io, rel->rva, slot, sizeof (slot));
+		A = r_read_ble (slot, bo->endian, 8 * sizeof (slot));
+	}
 	switch (e_machine) {
 	case EM_S390:
 		switch (rel->type) {

--- a/test/db/formats/elf/reloc-arm64
+++ b/test/db/formats/elf/reloc-arm64
@@ -2214,3 +2214,16 @@ EXPECT=<<EOF
 0x0007b480  0x0000000000083bb1                       .;......
 EOF
 RUN
+
+NAME=elf/arm64 relr relocs keep their in-place addend when applied
+FILE=bins/elf/ls-toybox
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pxq 8 @ 0x00078030
+pxq 8 @ 0x0007ce88
+EOF
+EXPECT=<<EOF
+0x00078030  0x0000000000006385                       .c......
+0x0007ce88  0x0000000000008c25                       %.......
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

RELR relocations carry no explicit addend — the word already in the slot is the addend — but add_relr_reloc leaves addend at 0, so bin.relocs.apply=true wrote B + 0 at every RELR site. With a baddr of 0 that is a plain zeroing: on bins/elf/ls-toybox all 1748 relocated pointers become 0, costing 3620 xrefs and 3 functions versus apply=false.

The implicit addend is now read from the slot where the patch value is computed, which is what the EM_ARM DT_REL arm of the same function already does. That keeps it arch-generic — aarch64 and x86-64 RELR both go through it — and keeps the change out of the ELF reloc record: RBinReloc.addend also feeds the reloc-name string probe and its data xref, so filling it there would invent reloc.fixup.* flags and xrefs under apply=false too.

Verified by decoding the RELR table independently: all 1748 slots now hold B + <in-place word>, no mismatches, and every expected value is nonzero, so no slot passes by accident. One test, pinning a slot in each RW segment — the second one has a 0x1000 vaddr/paddr skew, so a paddr-based fix fails it.

Fix #26546