### PR TITLE
Fix #26547 - encode thumb branch relocs instead of a raw word ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1016,7 +1016,7 @@ static void aarch64_patch_insn(RIOBind *iob, ut64 at, ut32 mask, ut32 val) {
 	iob->overlay_write_at (iob->io, at, buf, sizeof (buf));
 }
 
-static bool aarch64_disp_fits(st64 x, int bits) {
+static bool disp_fits(st64 x, int bits) {
 	return x >= -(1LL << (bits - 1)) && x < (1LL << (bits - 1));
 }
 
@@ -1028,7 +1028,7 @@ static void aarch64_patch_adr(RIOBind *iob, ut64 at, st64 imm) {
 
 static void aarch64_patch_branch(RIOBind *iob, RBinElfReloc *rel, st64 disp, int nbits, int shift) {
 	// a truncated branch invents a call target, worse than leaving it
-	if ((disp & 3) || !aarch64_disp_fits (disp, nbits + 2)) {
+	if ((disp & 3) || !disp_fits (disp, nbits + 2)) {
 		R_LOG_DEBUG ("unencodable aarch64 reloc %d at 0x%"PFMT64x, rel->type, rel->rva);
 		return;
 	}
@@ -1069,6 +1069,22 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 				addend = imm;
 				break;
 			}
+			case R_ARM_THM_PC22:
+			case R_ARM_THM_JUMP24: {
+				const ut32 hi = r_read_ble16 (buf, bo->endian);
+				const ut32 lo = r_read_ble16 (buf + 2, bo->endian);
+				const ut32 sb = (hi >> 10) & 1;
+				// i1/i2 are stored inverted against the sign
+				const ut32 i1 = ((lo >> 13) & 1) ^ sb ^ 1;
+				const ut32 i2 = ((lo >> 11) & 1) ^ sb ^ 1;
+				st32 imm = (sb << 24) | (i1 << 23) | (i2 << 22)
+					| ((hi & 0x3ff) << 12) | ((lo & 0x7ff) << 1);
+				if (sb) {
+					imm |= ~0x01ffffff;
+				}
+				addend = imm;
+				break;
+			}
 			case R_ARM_MOVW_ABS_NC:
 			case R_ARM_MOVW_PREL_NC:
 				addend = ((insn >> 4) & 0xf000) | (insn & 0x0fff);
@@ -1103,6 +1119,25 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			insn &= 0xff000000;
 			insn |= imm24 & 0x00ffffff;
 			r_write_ble32 (buf, insn, bo->endian);
+			break;
+		}
+		case R_ARM_THM_PC22:
+		case R_ARM_THM_JUMP24: {
+			const st64 target = S + addend - P;
+			ut32 hi = r_read_ble16 (buf, bo->endian);
+			ut32 lo = r_read_ble16 (buf + 2, bo->endian);
+			// blx switches to arm state, so it needs 4 alignment
+			const st64 amask = (lo & 0x1000)? 1: 3;
+			// a thumb branch reaches +-16MB, leave the rest alone
+			if ((target & amask) || !disp_fits (target, 25)) {
+				return;
+			}
+			const ut32 sb = (target >> 24) & 1;
+			hi = (hi & 0xf800) | (sb << 10) | ((target >> 12) & 0x3ff);
+			lo = (lo & 0xd000) | ((((target >> 23) & 1) ^ sb ^ 1) << 13)
+				| ((((target >> 22) & 1) ^ sb ^ 1) << 11) | ((target >> 1) & 0x7ff);
+			r_write_ble16 (buf, hi, bo->endian);
+			r_write_ble16 (buf + 2, lo, bo->endian);
 			break;
 		}
 		case R_ARM_MOVW_ABS_NC:
@@ -1148,7 +1183,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 		case R_AARCH64_ADR_PREL_PG_HI21_NC: {
 			const st64 imm = (((st64)(S + A) & ~(st64)0xfff) - ((st64)P & ~(st64)0xfff)) >> 12;
 			// the _NC variant is defined to wrap, so only the checked one is refused
-			if (rel->type == R_AARCH64_ADR_PREL_PG_HI21 && !aarch64_disp_fits (imm, 21)) {
+			if (rel->type == R_AARCH64_ADR_PREL_PG_HI21 && !disp_fits (imm, 21)) {
 				R_LOG_DEBUG ("unencodable aarch64 reloc %d at 0x%"PFMT64x, rel->type, rel->rva);
 				break;
 			}
@@ -1194,7 +1229,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			break;
 		case R_AARCH64_ADR_PREL_LO21: {
 			const st64 disp = (st64)(S + A) - (st64)P;
-			if (aarch64_disp_fits (disp, 21)) {
+			if (disp_fits (disp, 21)) {
 				aarch64_patch_adr (iob, rel->rva, disp);
 			} else {
 				R_LOG_DEBUG ("unencodable aarch64 reloc %d at 0x%"PFMT64x, rel->type, rel->rva);

--- a/test/db/formats/elf/elf-relarm
+++ b/test/db/formats/elf/elf-relarm
@@ -34,6 +34,21 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=ELF: arm thumb relocs keep a valid branch when applied
+FILE=bins/elf/analysis/arm-relocs
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pi 5 @ 0x08000034
+EOF
+EXPECT=<<EOF
+bl reloc.r0
+bl reloc.r1
+bl reloc.r2
+bl reloc.r3
+bl reloc.r4
+EOF
+RUN
+
 NAME=ELF: ppc relocs
 FILE=bins/elf/hello.ppc
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

EM_ARM's default: case wrote S + addend as a flat 32-bit word over every R_ARM_THM_* site, destroying the instruction: under bin.relocs.apply=true the five Thumb bls in bins/elf/analysis/arm-relocs decode as invalid.

R_ARM_THM_PC22 and R_ARM_THM_JUMP24 share one encoding, so one case handles both on the extract and the write side. It reads and writes two 16-bit halfwords — a Thumb pair read as a single 32-bit word swaps them — recovers the implicit addend from the S:I1:I2:imm10:imm11 split immediate, and puts it back with the opcode bits preserved. Out-of-range or unencodable targets are now skipped instead of corrupted: ±16MB (through the file's existing disp_fits, renamed from aarch64_disp_fits since its body was never arch-specific), 2-byte aligned, and 4-byte aligned for the BLX form, which switches to ARM state.

Checked against an external decoder rather than r2's own: objdump disassembles the five patched sites as branches to exactly the five reloc.r0..reloc.r4 addresses. A defined Thumb callee works too — its st_value carries the Thumb marker bit, but r2 normalises the symbol vaddr to even, so the alignment guard does not reject it.

Left alone deliberately: R_ARM_THM_MOVW_ABS_NC, R_ARM_THM_MOVT_ABS and R_ARM_THM_JUMP19 still fall to default:. Nothing in the test corpus reaches them — arm-relocs is the only file carrying any R_ARM_THM_* reloc, since these only survive in unlinked objects — so need to submit a testbin.

Fix #26547