### PR TITLE
Fix esil_peek_some regsize handling and esil_poke_some return value ##esil

### DIFF
--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -1326,7 +1326,6 @@ static bool esil_poke16(REsil *esil) {
 }
 
 static bool esil_poke_some(REsil *esil) {
-	bool ret = false;
 	int i, regsize;
 	ut64 ptr, regs = 0, tmp;
 	const RStrs dst = r_esil_pop (esil);
@@ -1358,7 +1357,7 @@ static bool esil_poke_some(REsil *esil) {
 					ptr += size_bytes;
 				}
 			}
-			return ret;
+			return true;
 		}
 	}
 	return false;
@@ -1427,7 +1426,7 @@ static bool esil_peek16(REsil *esil) {
 
 static bool esil_peek_some(REsil *esil) {
 	int i;
-	ut64 ptr, regs;
+	ut64 ptr, regs, tmp;
 	// pop ptr
 	const RStrs dst = r_esil_pop (esil);
 	if (!r_strs_empty (dst)) {
@@ -1437,27 +1436,34 @@ static bool esil_peek_some(REsil *esil) {
 		if (!r_strs_empty (count)) {
 			isregornum (esil, count, &regs);
 			if (regs > 0) {
-				ut8 a[4];
+				ut8 a[8] = {0};
 				for (i = 0; i < regs; i++) {
 					const RStrs foo = r_esil_pop (esil);
 					if (r_strs_empty (foo)) {
 						R_LOG_DEBUG ("Cannot pop in peek");
 						return false;
 					}
-					bool oks = r_esil_mem_read (esil, ptr, a, 4);
+					int regsize = 0;
+					r_esil_get_parm_size (esil, foo, &tmp, &regsize);
+					const int size_bytes = regsize / 8;
+					if (size_bytes < 1 || size_bytes > (int)sizeof (a)) {
+						R_LOG_DEBUG ("Invalid register size in peek");
+						return false;
+					}
+					bool oks = r_esil_mem_read (esil, ptr, a, size_bytes);
 					if (!oks) {
 						R_LOG_DEBUG ("Cannot peek from 0x%08" PFMT64x, ptr);
 						return false;
 					}
-					ut32 num32 = r_read_ble32 (a, esil_is_big_endian (esil));
-					r_esil_reg_write (esil, foo.a, num32);
-					ptr += 4;
+					const ut64 num = esil_read_ble (a, regsize, esil_is_big_endian (esil));
+					r_esil_reg_write (esil, foo.a, num);
+					ptr += size_bytes;
 				}
 			}
-			return 1;
+			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 /* OREQ */

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -257,6 +257,40 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=esil peek some (32-bits ARM little endian)
+FILE=-
+ARGS=-a arm -b 32
+CMDS=<<EOF
+e cfg.bigendian=false
+aeim
+e io.cache=true
+wx 66676869 @ 0x00100000
+ar r0=0x00100000
+"ae r1,1,r0,[*]"
+ar r1
+EOF
+EXPECT=<<EOF
+0x69686766
+EOF
+RUN
+
+NAME=esil peek some (64-bits ARM little endian)
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+e cfg.bigendian=false
+aeim
+e io.cache=true
+wx 6667686900000080 @ 0x00100000
+ar x0=0x00100000
+"ae x1,1,x0,[*]"
+ar x1
+EOF
+EXPECT=<<EOF
+0x8000000069686766
+EOF
+RUN
+
 NAME=rol
 FILE=-
 CMDS=<<EOF


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Two fixes for the `[*]` / `=[*]` esil ops in `libr/esil/esil_ops.c`:

- `esil_poke_some` (`=[*]`) initialized `ret = false` and never set it, so it reported failure even after successfully writing all registers to memory. It now returns true on the success path.
- `esil_peek_some` (`[*]`) hardcoded 4-byte memory reads and `r_read_ble32`, truncating loads into registers wider than 32 bits. It now queries each target register's size (like `esil_poke_some` already does), reads the right amount of bytes, and rejects sub-byte or oversized register sizes.

Added two regression tests to `test/db/esil/esil`: the 32-bit arm case (unchanged behavior) and a 64-bit case that fails without this patch (`x1` was truncated to the low 32 bits) and passes with it. Verified against `db/esil`, `db/anal/arm`, `db/anal/arm-esil` and `db/anal/arm64`: the only result change vs master is the new 64-bit test going from failed to ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019giJF59A9k1gRD6Mqb2Lxa

---
_Generated by [Claude Code](https://claude.ai/code/session_019giJF59A9k1gRD6Mqb2Lxa)_