### PR TITLE
Declare the ++ esil op to push one value like -- ##esil

### DIFF
--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -2586,7 +2586,7 @@ R_API bool r_esil_setup_ops(REsil *esil) {
 	ret &= OP ("^=", esil_xoreq, 0, 2, OT_MATH | OT_REGW);
 	ret &= OP ("+", esil_add, 1, 2, OT_MATH);
 	ret &= OP ("+=", esil_addeq, 0, 2, OT_MATH | OT_REGW);
-	ret &= OP ("++", esil_inc, 0, 1, OT_MATH | OT_REGW);
+	ret &= OP ("++", esil_inc, 1, 1, OT_MATH);
 	ret &= OP ("++=", esil_inceq, 0, 1, OT_MATH | OT_REGW);
 	ret &= OP ("-", esil_sub, 1, 2, OT_MATH);
 	ret &= OP ("-=", esil_subeq, 0, 2, OT_MATH | OT_REGW);


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The op table registered `++` as `esil_inc, 0, 1` (push=0, pop=1) with the REG_WRITE type, but `esil_inc` pops one value and pushes one result via `r_esil_pushnum` without writing any register. Its counterpart `--` is already registered as `esil_dec, 1, 1, OT_MATH`, so this makes `++` match it. The wrong push count broke the stack modeling in `esil_cfg_gen` (which walks `op->push` to emit edges) and the inputs/outputs reported by the esil op listing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXgfdVzYccosjZjcxQpr16)_