### PR TITLE
Fix the dfg handling of esil control flow and comparisons ##anal

### DIFF
--- a/libr/anal/esil_dfg.c
+++ b/libr/anal/esil_dfg.c
@@ -658,6 +658,18 @@ static RGraphNode *_edf_var_get(RAnalEsilDFG *dfg, const char *var) {
 	return ret;
 }
 
+// resolve a popped operand to the node that defines it
+static RGraphNode *_edf_operand_get(RAnalEsilDFG *dfg, REsil *esil, RStrs s) {
+	switch (r_esil_get_parm_type (esil, s)) {
+	case R_ESIL_PARM_REG:
+		return _edf_reg_get (dfg, s.a);
+	case R_ESIL_PARM_NUM:
+		return _edf_const_get (dfg, s.a);
+	default:
+		return _edf_var_get (dfg, s.a);
+	}
+}
+
 static bool edf_consume_2_set_reg(REsil *esil);
 static bool edf_consume_2_push_1(REsil *esil);
 static bool edf_consume_1_push_1(REsil *esil);
@@ -794,33 +806,95 @@ static bool edf_consume_2_set_reg(REsil *esil) {
 	return _edf_consume_2_set_reg (esil, true);
 }
 
-// TODO: not properly implemented
-static bool edf_pop(REsil *esil) {
+// A comparison stores nothing. It only leaves old/cur behind for the flag ops.
+static bool edf_consume_2_set_cur(REsil *esil) {
 	const char *op_string = esil->current_opstr;
 	RAnalEsilDFG *edf = (RAnalEsilDFG *)esil->user;
+	const RStrs dst_s = r_esil_pop (esil);
 	const RStrs src_s = r_esil_pop (esil);
-	if (r_strs_empty (src_s)) {
+	if (r_strs_empty (dst_s) || r_strs_empty (src_s)) {
 		return false;
 	}
-	const char *src = src_s.a;
-	const int src_type = r_esil_get_parm_type (esil, src_s);
-	RGraphNode *src_node = NULL;
-	if (src_type == R_ESIL_PARM_REG) {
-		src_node = _edf_reg_get (edf, src);
-	} else if (src_type == R_ESIL_PARM_NUM) {
-		src_node = _edf_const_get (edf, src);
-	} else {
-		src_node = _edf_var_get (edf, src);
-	}
-	if (!src_node) {
+	RGraphNode *dst_node = _edf_operand_get (edf, esil, dst_s);
+	RGraphNode *src_node = _edf_operand_get (edf, esil, src_s);
+	if (!dst_node || !src_node) {
 		return false;
 	}
-	RAnalEsilDFGNode *eop_node = r_anal_esil_dfg_node_new (edf, src);
+	RAnalEsilDFGNode *eop_node = r_anal_esil_dfg_node_new (edf, src_s.a);
+	r_strbuf_appendf (eop_node->content, ",%s,%s", dst_s.a, op_string);
+	eop_node->type = R_ANAL_ESIL_DFG_TAG_GENERATIVE;
+	RGraphNode *op_node = r_graph_add_node (edf->flow, eop_node);
+	r_graph_add_edge (edf->flow, dst_node, op_node);
+	r_graph_add_edge (edf->flow, src_node, op_node);
+	RAnalEsilDFGNode *result = r_anal_esil_dfg_node_new (edf, "result_");
+	result->type = R_ANAL_ESIL_DFG_TAG_RESULT;
+	r_strbuf_appendf (result->content, "%d", edf->idx++);
+	RGraphNode *result_node = r_graph_add_node (edf->flow, result);
+	r_graph_add_edge (edf->flow, op_node, result_node);
+	_edf_var_set (edf, r_strbuf_get (result->content), result_node);
+	edf->old = dst_node;
+	edf->cur = result_node;
+	return true;
+}
+
+// read-modify-write of a single register operand, e.g. "eax,--="
+static bool edf_consume_1_set_reg(REsil *esil) {
+	const char *op_string = esil->current_opstr;
+	RAnalEsilDFG *edf = (RAnalEsilDFG *)esil->user;
+	const RStrs dst_s = r_esil_pop (esil);
+	if (r_strs_empty (dst_s) || r_esil_get_parm_type (esil, dst_s) != R_ESIL_PARM_REG) {
+		return false;
+	}
+	const char *dst = dst_s.a;
+	RGraphNode *dst_node = _edf_reg_get (edf, dst);
+	if (!dst_node) {
+		return false;
+	}
+	RAnalEsilDFGNode *eop_node = r_anal_esil_dfg_node_new (edf, dst);
 	r_strbuf_appendf (eop_node->content, ",%s", op_string);
 	eop_node->type = R_ANAL_ESIL_DFG_TAG_GENERATIVE;
 	RGraphNode *op_node = r_graph_add_node (edf->flow, eop_node);
-	r_graph_add_edge (edf->flow, src_node, op_node);
+	r_graph_add_edge (edf->flow, dst_node, op_node);
+	RAnalEsilDFGNode *result = r_anal_esil_dfg_node_new (edf, dst);
+	result->type = R_ANAL_ESIL_DFG_TAG_RESULT | R_ANAL_ESIL_DFG_TAG_VAR | R_ANAL_ESIL_DFG_TAG_REG |
+		(((RAnalEsilDFGNode *)dst_node->data)->type & R_ANAL_ESIL_DFG_TAG_CONST);
+	r_strbuf_appendf (result->content, ":var_%d", edf->idx++);
+	edf->old = dst_node;
+	dst_node = r_graph_add_node (edf->flow, result);
+	r_graph_add_edge (edf->flow, op_node, dst_node);
+	_edf_reg_set (edf, dst, dst_node);
+	edf->cur = dst_node;
 	return true;
+}
+
+// The graph records what an instruction may write, so the guarded body has to
+// be walked rather than skipped. "}{" still toggles esil->skip, so only the
+// first branch is taken.
+static bool edf_if(REsil *esil) {
+	if (esil->skip) {
+		esil->skip++;
+		return true;
+	}
+	return !r_strs_empty (r_esil_pop (esil));
+}
+
+// A backward jump would close a cycle, and this graph holds none. Drop the
+// target and fall through, walking a loop body exactly once. That shows which
+// registers and memory the loop touches, but not the remaining iterations.
+static bool edf_goto(REsil *esil) {
+	(void)r_esil_pop (esil);
+	return true;
+}
+
+// Carry on past an early exit so the rest of the expression reaches the graph.
+static bool edf_break(REsil *esil) {
+	return true;
+}
+
+// POP throws away the top of the stack. Whatever produced that value is
+// already in the graph, and dropping it here just leaves it with no consumer.
+static bool edf_pop(REsil *esil) {
+	return !r_strs_empty (r_esil_pop (esil));
 }
 
 #if 1
@@ -1632,7 +1706,7 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *R_NULLABLE d
 
 	r_esil_set_op (esil, "=", edf_consume_2_set_reg, 0, 2, R_ESIL_OP_TYPE_REG_WRITE, NULL);
 	r_esil_set_op (esil, ":=", edf_eq_weak, 0, 2, R_ESIL_OP_TYPE_REG_WRITE, NULL);
-	r_esil_set_op (esil, "$s", edf_sf, 1, 0, R_ESIL_OP_TYPE_UNKNOWN, NULL); // XXX TODO
+	r_esil_set_op (esil, "$s", edf_sf, 1, 1, R_ESIL_OP_TYPE_UNKNOWN, NULL); // XXX TODO
 	r_esil_set_op (esil, "$z", edf_zf, 1, 0, R_ESIL_OP_TYPE_UNKNOWN, NULL);
 	r_esil_set_op (esil, "$p", edf_pf, 1, 0, R_ESIL_OP_TYPE_UNKNOWN, NULL);
 	r_esil_set_op (esil, "$c", edf_cf, 1, 1, R_ESIL_OP_TYPE_UNKNOWN, NULL);
@@ -1645,6 +1719,24 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *R_NULLABLE d
 	r_esil_set_op (esil, "&=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
 	r_esil_set_op (esil, "|=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
 	r_esil_set_op (esil, "^=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "%=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "<<=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, ">>=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "~=", edf_consume_2_use_set_reg, 0, 2, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "!=", edf_consume_1_set_reg, 0, 1, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "++=", edf_consume_1_set_reg, 0, 1, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "--=", edf_consume_1_set_reg, 0, 1, R_ESIL_OP_TYPE_MATH | R_ESIL_OP_TYPE_REG_WRITE, NULL);
+	r_esil_set_op (esil, "==", edf_consume_2_set_cur, 0, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "?{", edf_if, 0, 1, R_ESIL_OP_TYPE_CONTROL_FLOW, NULL);
+	r_esil_set_op (esil, "GOTO", edf_goto, 0, 1, R_ESIL_OP_TYPE_CONTROL_FLOW, NULL);
+	r_esil_set_op (esil, "BREAK", edf_break, 0, 0, R_ESIL_OP_TYPE_CONTROL_FLOW, NULL);
+	r_esil_set_op (esil, "<", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, ">", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "<=", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, ">=", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "~", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "~/", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
+	r_esil_set_op (esil, "~%", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "+", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "-", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "&", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
@@ -1654,9 +1746,9 @@ R_API RAnalEsilDFG *r_anal_esil_dfg_expr(RAnal *anal, RAnalEsilDFG *R_NULLABLE d
 	r_esil_set_op (esil, "*", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "/", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, ">>", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
-	r_esil_set_op (esil, "POP", edf_pop, 1, 0, R_ESIL_OP_TYPE_UNKNOWN, NULL);
+	r_esil_set_op (esil, "POP", edf_pop, 0, 1, R_ESIL_OP_TYPE_UNKNOWN, NULL);
 #if 1
-	r_esil_set_op (esil, "DUP", edf_dup, 1, 2, R_ESIL_OP_TYPE_UNKNOWN, NULL);
+	r_esil_set_op (esil, "DUP", edf_dup, 2, 1, R_ESIL_OP_TYPE_UNKNOWN, NULL);
 #endif
 	r_esil_set_op (esil, "<<", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);
 	r_esil_set_op (esil, "LSL", edf_consume_2_push_1, 1, 2, R_ESIL_OP_TYPE_MATH, NULL);

--- a/test/unit/test_esil_dfg_filter.c
+++ b/test/unit/test_esil_dfg_filter.c
@@ -79,8 +79,133 @@ bool test_lemon_const_folder(void) {
 	mu_end;
 }
 
+static RAnal *dfg_anal_new(RIO **io) {
+	RAnal *anal = r_anal_new ();
+	r_anal_use (anal, "x86");
+	r_anal_set_bits (anal, 32);
+	r_anal_set_reg_profile (anal, NULL);
+	*io = r_io_new ();
+	r_io_bind (*io, &anal->iob);
+	return anal;
+}
+
+static bool filter_is(RAnal *anal, const char *expr, const char *reg, const char *expected) {
+	RStrBuf *filtered = r_anal_esil_dfg_filter_expr (anal, expr, reg, false, false);
+	const bool ok = filtered && !strcmp (r_strbuf_get (filtered), expected);
+	if (!ok) {
+		eprintf ("%s [%s] => '%s', expected '%s'\n", expr, reg,
+			filtered? r_strbuf_get (filtered): "(null)", expected);
+	}
+	r_strbuf_free (filtered);
+	return ok;
+}
+
+// the guarded body of a conditional must reach the graph, dropping a
+// predicated write loses the dependency entirely
+bool test_dfg_conditional(void) {
+	RIO *io;
+	RAnal *anal = dfg_anal_new (&io);
+
+	const bool body = filter_is (anal, "zf,?{,1,eax,+=,}", "eax", "1,eax,+=");
+	const bool assign = filter_is (anal, "zf,?{,3,eax,=,}", "eax", "3,eax,=");
+	// "}{" toggles esil->skip, so only the first branch is taken
+	const bool taken = filter_is (anal, "zf,?{,1,eax,=,}{,2,eax,=,}", "eax", "1,eax,=");
+
+	r_anal_free (anal);
+	r_io_free (io);
+
+	mu_assert_true (body, "conditional body was dropped");
+	mu_assert_true (assign, "conditional assignment was dropped");
+	mu_assert_true (taken, "conditional followed the branch not taken");
+	mu_end;
+}
+
+// comparisons must build nodes instead of folding operands to a concrete
+// boolean, and must feed the flag ops through old/cur
+bool test_dfg_compare(void) {
+	RIO *io;
+	RAnal *anal = dfg_anal_new (&io);
+
+	const bool cmp = filter_is (anal, "ebx,eax,<,ecx,=", "ecx", "ebx,eax,<,ecx,=");
+	const bool keep = filter_is (anal, "ebx,eax,==,7,ecx,=", "ecx", "7,ecx,=");
+	RStrBuf *zf = r_anal_esil_dfg_filter_expr (anal, "ebx,eax,==,$z,zf,=", "zf", false, false);
+	const bool flag = zf && r_strbuf_length (zf) > 0;
+	r_strbuf_free (zf);
+
+	r_anal_free (anal);
+	r_io_free (io);
+
+	mu_assert_true (cmp, "comparison was folded to a constant");
+	mu_assert_true (keep, "comparison truncated the expression");
+	mu_assert_true (flag, "comparison did not feed the zero flag");
+	mu_end;
+}
+
+// BREAK and GOTO must not truncate or unroll the graph
+bool test_dfg_control_flow(void) {
+	RIO *io;
+	RAnal *anal = dfg_anal_new (&io);
+
+	const bool brk = filter_is (anal, "ecx,!,?{,BREAK,},7,eax,=", "eax", "7,eax,=");
+	const bool jmp = filter_is (anal, "eax,--=,zf,!,?{,0,GOTO,}", "eax", "eax,--=");
+
+	r_anal_free (anal);
+	r_io_free (io);
+
+	mu_assert_true (brk, "BREAK truncated the graph");
+	mu_assert_true (jmp, "GOTO broke the graph");
+	mu_end;
+}
+
+// read-modify-write ops on a register operand must update the register
+bool test_dfg_reg_rmw(void) {
+	RIO *io;
+	RAnal *anal = dfg_anal_new (&io);
+
+	const bool shr = filter_is (anal, "3,eax,>>=", "eax", "3,eax,>>=");
+	const bool shl = filter_is (anal, "3,eax,<<=", "eax", "3,eax,<<=");
+	const bool neg = filter_is (anal, "eax,!=", "eax", "eax,!=");
+
+	r_anal_free (anal);
+	r_io_free (io);
+
+	mu_assert_true (shr, ">>= did not write the register");
+	mu_assert_true (shl, "<<= did not write the register");
+	mu_assert_true (neg, "!= did not write the register");
+	mu_end;
+}
+
+// POP discards a value, so it must not contribute anything to the graph
+bool test_dfg_pop(void) {
+	RIO *io;
+	RAnal *anal = dfg_anal_new (&io);
+
+	const bool before = filter_is (anal, "ebx,POP,3,eax,=", "eax", "3,eax,=");
+	const bool after = filter_is (anal, "3,eax,=,ebx,POP", "eax", "3,eax,=");
+
+	RAnalEsilDFG *plain = r_anal_esil_dfg_expr (anal, NULL, "3,eax,=", false, false);
+	RAnalEsilDFG *popped = r_anal_esil_dfg_expr (anal, NULL, "3,eax,=,ebx,POP", false, false);
+	const bool same = r_list_length (r_graph_get_nodes (plain->flow))
+		== r_list_length (r_graph_get_nodes (popped->flow));
+	r_anal_esil_dfg_free (plain);
+	r_anal_esil_dfg_free (popped);
+
+	r_anal_free (anal);
+	r_io_free (io);
+
+	mu_assert_true (before, "POP cut the expression short");
+	mu_assert_true (after, "POP changed the filtered expression");
+	mu_assert_true (same, "POP added nodes for a discarded value");
+	mu_end;
+}
+
 int main(int argc, char **argv) {
 	mu_run_test (test_filter_regs);
 	mu_run_test (test_lemon_const_folder);
+	mu_run_test (test_dfg_conditional);
+	mu_run_test (test_dfg_compare);
+	mu_run_test (test_dfg_control_flow);
+	mu_run_test (test_dfg_reg_rmw);
+	mu_run_test (test_dfg_pop);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The dfg shares its esil interpreter with the emulator but only replaced 91 of
153 ops. Everything left untouched ran its concrete implementation over a stack
that holds node names rather than values, and the damage was silent: `aeg` and
`aegf` returned a plausible but wrong answer with exit 0.

What was broken, all reproducible on master:

| expression | filter | before | after |
|---|---|---|---|
| `zf,?{,1,eax,+=,}` | `eax` | *(empty)* | `1,eax,+=` |
| `zf,?{,1,eax,=,}{,2,eax,=,}` | `eax` | `2,eax,=` | `1,eax,=` |
| `ebx,eax,<,ecx,=` | `ecx` | `0,ecx,=` | `ebx,eax,<,ecx,=` |
| `ebx,eax,==,$z,zf,=` | `zf` | *(empty)* | `$z,zf,=` |
| `ecx,!,?{,BREAK,},7,eax,=` | `eax` | *(empty)* | `7,eax,=` |
| `eax,--=,zf,!,?{,0,GOTO,}` | `eax` | *(empty)* | `eax,--=` |
| `3,eax,>>=` | `eax` | *(empty)* | `3,eax,>>=` |

Two of those are worse than a missing edge. `zf,?{,1,eax,=,}{,2,eax,=,}` recorded
the branch that is *not* taken, because the stock `?{` sets `esil->skip` and `}{`
toggles it back on. And `ebx,eax,<` reduced its operands to a concrete boolean and
pushed it as a literal, so the dfg stored an invented constant that reads like real
data.

Changes:

- `?{` walks the guarded body instead of skipping it. Dropping a predicated write
  loses the dependency entirely. `}{` still toggles `esil->skip`, so only the first
  branch is taken and the brace bookkeeping, nesting included, is unchanged.
- `==` builds nodes for both operands and leaves `old`/`cur` behind, so the flag ops
  attach to the compare they belong to rather than to a stale assignment.
- `<`, `>`, `<=`, `>=`, `~`, `~/`, `~%` reuse the existing `edf_consume_2_push_1`
  and stop collapsing into constants.
- `GOTO` consumes its target and falls through. A backward jump would close a cycle
  this graph cannot hold, so a loop body is walked exactly once. That is enough to
  see which registers and memory a loop touches, but it does not account for the
  remaining iterations, and the comment says so.
- `BREAK` no longer ends the expression early, so the fallthrough still reaches the
  graph.
- `>>=`, `<<=`, `~=`, `%=` reuse `edf_consume_2_use_set_reg`; `!=`, `++=`, `--=` get
  a small unary read-modify-write handler. None of these updated the register map
  before, which is why `--=`, present in every rep-prefixed x86 instruction, was lost.
- `POP` built a generative node for a value it throws away. The node carried no
  result and no outgoing edge, so no reverse walk could ever reach it, and resolving
  the discarded operand allocated further nodes on the side. It now just drops the
  stack entry, which removes the `not properly implemented` comment that sat on it.
- `POP`, `DUP` and `$s` declared push and pop counts that contradict their own
  callbacks (`POP` claimed to push one and pop none while doing the opposite).
  Nothing reads those fields for the dfg's private esil today, but `esil_cfg.c`
  reads them in general and the table should not lie.

Tested: 5 new unit tests, each checked to fail on master and pass here. No
regressions, `db/esil` (1350 tests) and `db/anal` (988 tests) give identical tallies
before and after, the `aof` test is unchanged, and 95/96 unit tests pass
(`test_r2pipe` fails in this environment because it spawns `radare2` by name, which
is unrelated and pre-existing).

Two alternatives were prototyped and rejected. A generic arity-driven fallback
covering all 62 missing ops in one handler cannot express `_edf_reg_set` or the flag
cursor from push and pop counts alone, so it left `>>=`, `--=` and `==` broken while
costing more code. A fail-loud bailout marking the dfg incomplete was 19 lines and
removed the invented constants, but returned NULL for every predicated instruction,
compare and rep prefix.

Not addressed here: `$z` and friends still emit `$z` rather than splicing the compare
into the filtered expression, since the resolver does not re-expand the constraint
string. `GOTO` targets also remain raw token indices that arch plugins count by hand,
which breaks whenever a conditional prefix or an operand rewrite shifts the comma
count.