### PR TITLE
Stop pdc from inlining other functions and losing the final return ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pdc_ast.c
+++ b/libr/core/p/pseudo/pdc_ast.c
@@ -10,6 +10,7 @@
 
 typedef struct {
 	RAnal *anal;
+	RAnalFunction *fcn;
 	HtUU *idom;	// block addr => immediate dominator addr (entry => UT64_MAX)
 	HtUU *ipdom;	// block addr => immediate post-dominator addr (UT64_MAX => exit)
 	HtUP *loops;	// natural-loop header addr => HtUU* member set
@@ -244,7 +245,8 @@ static PdcRegion *build_region(PdcCtx *ctx, ut64 cur, ut64 stop, ut64 *next) {
 		return region_new (PDC_R_GOTO, cur);
 	}
 	RAnalBlock *bb = r_anal_get_block_at (ctx->anal, cur);
-	if (!bb) {
+	// a tail call or a jump into a neighbour would splice its blocks in here
+	if (!bb || !r_anal_function_contains (ctx->fcn, cur)) {
 		return region_new (PDC_R_GOTO, cur);
 	}
 	ht_uu_update (ctx->emitted, cur, 1);
@@ -392,6 +394,7 @@ PdcPlan *pdc_plan_build(RCore *core, RAnalFunction *fcn) {
 	}
 	PdcCtx ctx = {
 		.anal = core->anal,
+		.fcn = fcn,
 		.idom = ht_uu_new0 (),
 		.ipdom = ht_uu_new0 (),
 		.loops = ht_up_new0 (),

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -1772,6 +1772,15 @@ static void render_ifelse(PDCState *state, PdcRegion *r, RAnalBlock *bb, int ind
 	free (cond);
 }
 
+// a block that falls off the end of the function still returns
+static void render_exit_return(PDCState *state, RAnalBlock *bb, int indent) {
+	if (bb->jump != UT64_MAX || bb->fail != UT64_MAX
+			|| bb_ends_with_terminator (state->core, bb)) {
+		return;
+	}
+	print_line (state, bb->addr, indent, state->r0? "return %s;": "return;", state->r0);
+}
+
 static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *gotos) {
 	if (r->type == PDC_R_SEQ) {
 		PdcRegion **it;
@@ -1809,6 +1818,7 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		return;
 	default:
 		render_bb_body_lines (state, bb, indent);
+		render_exit_return (state, bb, indent);
 		return;
 	}
 }
@@ -1853,6 +1863,7 @@ static bool pdc_structured_body(PDCState *state, int indent) {
 	ht_up_free (state->conds);
 	state->conds = NULL;
 	pdc_plan_free (plan);
+	R_LOG_DEBUG ("pdc: structured=%d 0x%08" PFMT64x, reducible, state->fcn->addr);
 	return reducible;
 }
 

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1221,3 +1221,43 @@ EXPECT=<<EOF
     lr = pc + 4; goto 0xdae0
 EOF
 RUN
+
+NAME=pdc structured keeps a jump into another function as a transfer
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx b801000000eb09 @ 0
+wx b802000000c3 @ 0x10
+af @ 0x10
+af+ 0 fcn.caller
+afb+ 0 0 7 0x10
+pdc @ 0
+EOF
+EXPECT=<<EOF
+// callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+void fcn.caller (void) {
+    eax = 1
+    goto loc_0x00000010;
+}
+
+EOF
+RUN
+
+NAME=pdc structured returns from a block that ends without a terminator
+FILE=malloc://64
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx b805000000f4 @ 0
+af
+pdc
+EOF
+EXPECT=<<EOF
+// callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, xmm0, xmm1, xmm2, xmm3, xmm4);
+void fcn.00000000 (void) {
+    eax = 5
+    hlt
+    return rax;
+}
+
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Two fidelity bugs in the structured pdc renderer (pdc.structured=1), both found while measuring it against the linear one across architectures.

Another function's code is rendered inline. build_region resolved successors with r_anal_get_block_at and no membership check, so any edge leaving the function spliced the target function's blocks into this one's body. On bins/elf/ppc64v1-libz.so 232 blocks have such an edge; entry0 renders two blocks of the PLT trampoline at 0x194a0 inside an if. Now the successor is a goto when it is not  r_anal_function_containsed by the function being decompiled. Repro:

    r2 -a x86 -b 64 -e pdc.structured=1 -c 'wx b801000000eb09 @ 0; \
      wx b802000000c3 @ 0x10; af @ 0x10; af+ 0 fcn.caller; afb+ 0 0 7 0x10; pdc @ 0' malloc://64

The final return goes missing. A block that ends without a terminator and has no successors gets no return, which the linear walk and the orphan pass both emit. Visible on bins/elf/ioli/crackme0x00 entry0.

Measured over 35 binaries in 19 architecture families, comparing both renderers per basic block: inlined foreign statements 76596 -> 139, functions left without a return 3885 -> 1458. Structure recovery itself is unchanged.

Two tests in db/cmd/cmd_pdc, both malloc:// so no new test binary, each checked to fail before the fix and again under a second unrelated break. Full test suite run against master: no regressions.

Groundwork for enabling pdc.structured by default; the remaining blockers are that pdcj/pdca/pdc* still bypass the structured renderer, and a few architectures whose pseudo tables cannot express their branch conditions.