### PR TITLE
Add the ROT esil op to rotate the third stack element to the top ##esil

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -459,6 +459,7 @@ static RCoreHelpMessage help_detail_ae = {
 	"DUP", "", "duplicate last value in stack",
 	"NUM", "", "evaluate last item in stack to number",
 	"SWAP", "", "swap last two values in stack",
+	"ROT", "", "rotate the third element in the stack to the top",
 	"TRAP", "", "stop execution",
 	"BITS", "", "16,BITS  # change bits, useful for arm/thumb",
 	"TODO", "", "the instruction is not yet esilized",

--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -2008,6 +2008,21 @@ static bool esil_swap(REsil *esil) {
 	return true;
 }
 
+/* rotate the third element to the top: [x,y,z] -> [y,z,x] */
+static bool esil_rot(REsil *esil) {
+	R_RETURN_VAL_IF_FAIL (esil, false);
+	const int sp = esil->stackptr;
+	if (!esil->stack || sp < 3) {
+		return false;
+	}
+	// rotate slot metadata -- strings stay in the arena
+	const RStrs tmp = esil->stack[sp - 3];
+	esil->stack[sp - 3] = esil->stack[sp - 2];
+	esil->stack[sp - 2] = esil->stack[sp - 1];
+	esil->stack[sp - 1] = tmp;
+	return true;
+}
+
 static bool esil_smaller(REsil *esil) { // 'dst < src' => 'src,dst,<'
 	ut64 num, num2;
 	bool ret = false;
@@ -2675,6 +2690,7 @@ R_API bool r_esil_setup_ops(REsil *esil) {
 	ret &= OP ("DUP", esil_dup, 2, 1, OT_UNK);
 	ret &= OP ("NUM", esil_num, 1, 1, OT_UNK);
 	ret &= OP ("SWAP", esil_swap, 2, 2, OT_UNK);
+	ret &= OP ("ROT", esil_rot, 3, 3, OT_UNK);
 	ret &= OP ("TRAP", esil_trap, 0, 2, OT_UNK); // syscall?
 	ret &= OP ("BITS", esil_bits, 1, 0, OT_UNK);
 	ret &= OP ("SETJT", esil_set_jump_target, 0, 1, OT_UNK);

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -527,6 +527,7 @@ EXPECT=<<EOF
 | DUP     duplicate last value in stack
 | NUM     evaluate last item in stack to number
 | SWAP    swap last two values in stack
+| ROT     rotate the third element in the stack to the top
 | TRAP    stop execution
 | BITS    16,BITS  # change bits, useful for arm/thumb
 | TODO    the instruction is not yet esilized
@@ -563,5 +564,13 @@ EXPECT=<<EOF
 0x8000000000000000
 0
 0xfffffffffffffffd
+EOF
+RUN
+
+NAME=esil rot
+FILE=malloc://8
+CMDS=ae 1,2,3,ROT
+EXPECT=<<EOF
+2,3,1
 EOF
 RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds `ROT`, the classic Forth stack word (`[x,y,z] -> [y,z,x]`): rotate the third element in the esil stack to the top. Like `SWAP`, it only shuffles slot metadata — strings stay in the arena — so it costs nothing beyond the dispatch.

This is the one missing depth-3 primitive in the stack-manipulation set: `DUP` and `SWAP` alone can only reach the top two elements, so nothing can move an item past two others. With `ROT` the set becomes complete for the top three — `OVER` is `SWAP,DUP,ROT,SWAP`, `TUCK` is `DUP,ROT,SWAP`, `NIP` is `SWAP,POP` — which is what makes compound assignment expressible as a word sequence (the destination name must be used twice: once evaluated, once as the store target).

First of a three-PR series: this op, then the `r_esil_define` API, then the rewrite of the compound ops as definitions (currently #26556, see also #26555).

Includes an `ae??` help entry and a test.