### PR TITLE
Add r_esil_define to implement esil ops as word definitions ##esil

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -459,6 +459,7 @@ static RCoreHelpMessage help_detail_ae = {
 	"DUP", "", "duplicate last value in stack",
 	"NUM", "", "evaluate last item in stack to number",
 	"SWAP", "", "swap last two values in stack",
+	"ROT", "", "rotate the third element in the stack to the top",
 	"TRAP", "", "stop execution",
 	"BITS", "", "16,BITS  # change bits, useful for arm/thumb",
 	"TODO", "", "the instruction is not yet esilized",

--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -65,6 +65,7 @@ static void esil_voyeurs_fini(REsil *esil) {
 // key is embedded in value (REsilOp.name); freeing value reclaims both
 static void esil_ops_kv_free(HtPPKv *kv) {
 	if (R_LIKELY (kv)) {
+		free (((REsilOp *)kv->value)->tokens);
 		free (kv->value);
 	}
 }
@@ -332,6 +333,63 @@ R_API bool r_esil_set_op(REsil *esil, const char *op, REsilOpCb code, ut32 push,
 	eop->pop = pop;
 	eop->type = type;
 	eop->info = info;
+	// overriding a defined op with a native one drops its expansion
+	R_FREE (eop->tokens);
+	eop->body = NULL;
+	eop->ntokens = 0;
+	return true;
+}
+
+R_API bool r_esil_define(REsil *esil, const char *op, const char *body, ut32 push, ut32 pop, ut32 type) {
+	R_RETURN_VAL_IF_FAIL (esil && esil->ops && R_STR_ISNOTEMPTY (op) && R_STR_ISNOTEMPTY (body), false);
+	ut32 n = 1;
+	const char *p;
+	for (p = body; *p; p++) {
+		if (*p == ',') {
+			n++;
+		}
+	}
+	// slice the body in place — like op names, `body` must outlive esil,
+	// so this array is the definition's only allocation
+	RStrs *tokens = R_NEWS (RStrs, n);
+	if (!tokens) {
+		return false;
+	}
+	ut32 i = 0;
+	const char *a = body;
+	for (p = body;; p++) {
+		if (*p == ',' || !*p) {
+			tokens[i].a = a;
+			tokens[i].b = p;
+			i++;
+			if (!*p) {
+				break;
+			}
+			a = p + 1;
+		}
+	}
+	const RStrs k = r_strs_from (op);
+	REsilOp *eop = ht_pp_find (esil->ops, &k, NULL);
+	if (!eop) {
+		eop = R_NEW0 (REsilOp);
+		eop->name = k; // points at caller's const char* — must outlive esil
+		if (!ht_pp_insert (esil->ops, &eop->name, eop)) {
+			R_LOG_ERROR ("Cannot define esil op %s", op);
+			free (tokens);
+			free (eop);
+			return false;
+		}
+	} else {
+		free (eop->tokens);
+	}
+	eop->code = NULL;
+	eop->body = body;
+	eop->tokens = tokens;
+	eop->ntokens = n;
+	eop->push = push;
+	eop->pop = pop;
+	eop->type = type;
+	eop->info = body; // listings show the expansion
 	return true;
 }
 
@@ -1075,7 +1133,23 @@ static bool runword(REsil *esil, RStrs w) {
 			} while (r_id_storage_get_next (&esil->voyeur[R_ESIL_VOYEUR_OP], &i));
 		}
 		esil->current_opstr = (char *)name;
-		const bool ret = op->code (esil);
+		bool ret;
+		if (R_LIKELY (op->code)) {
+			ret = op->code (esil);
+		} else {
+			// defined op: run the pre-tokenized expansion in place
+			ret = true;
+			ut32 mi;
+			for (mi = 0; mi < op->ntokens; mi++) {
+				if (!runword (esil, op->tokens[mi])) {
+					ret = false;
+					break;
+				}
+				if (esil->parse_stop) {
+					break;
+				}
+			}
+		}
 		esil->current_opstr = NULL;
 		if (!ret) {
 			R_LOG_DEBUG ("%s returned 0", name);

--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -2008,6 +2008,24 @@ static bool esil_swap(REsil *esil) {
 	return true;
 }
 
+/* rotate the third element to the top: [x,y,z] -> [y,z,x] */
+static bool esil_rot(REsil *esil) {
+	R_RETURN_VAL_IF_FAIL (esil, false);
+	const int sp = esil->stackptr;
+	if (!esil->stack || sp < 3) {
+		return false;
+	}
+	if (r_strs_empty (esil->stack[sp - 1]) || r_strs_empty (esil->stack[sp - 2]) || r_strs_empty (esil->stack[sp - 3])) {
+		return false;
+	}
+	// rotate slot metadata -- strings stay in the arena
+	const RStrs tmp = esil->stack[sp - 3];
+	esil->stack[sp - 3] = esil->stack[sp - 2];
+	esil->stack[sp - 2] = esil->stack[sp - 1];
+	esil->stack[sp - 1] = tmp;
+	return true;
+}
+
 static bool esil_smaller(REsil *esil) { // 'dst < src' => 'src,dst,<'
 	ut64 num, num2;
 	bool ret = false;
@@ -2675,6 +2693,7 @@ R_API bool r_esil_setup_ops(REsil *esil) {
 	ret &= OP ("DUP", esil_dup, 2, 1, OT_UNK);
 	ret &= OP ("NUM", esil_num, 1, 1, OT_UNK);
 	ret &= OP ("SWAP", esil_swap, 2, 2, OT_UNK);
+	ret &= OP ("ROT", esil_rot, 3, 3, OT_UNK);
 	ret &= OP ("TRAP", esil_trap, 0, 2, OT_UNK); // syscall?
 	ret &= OP ("BITS", esil_bits, 1, 0, OT_UNK);
 	ret &= OP ("SETJT", esil_set_jump_target, 0, 1, OT_UNK);

--- a/libr/include/r_esil.h
+++ b/libr/include/r_esil.h
@@ -370,6 +370,12 @@ typedef struct r_esil_operation_t {
 	// const char* (string literal) and is NUL-terminated for compat with
 	// callbacks that take `const char *`. Also used as the HT key.
 	RStrs name;
+	// Defined op: when `code` is NULL the op runs `tokens` instead —
+	// slices into `body`, a caller-owned string that must outlive esil,
+	// exactly like `name`. Only `tokens` is owned by the op (freed with it).
+	const char *body;
+	RStrs *tokens;
+	ut32 ntokens;
 } REsilOp;
 
 // esil2c
@@ -386,6 +392,7 @@ R_API char *r_esil_toc(REsilC *esil, const char *expr);
 R_API char*r_esil_opstr(REsil*, int mode);
 
 R_API bool r_esil_set_op(REsil *esil, const char *op, REsilOpCb code, ut32 push, ut32 pop, ut32 type, const char *info);
+R_API bool r_esil_define(REsil *esil, const char *op, const char *body, ut32 push, ut32 pop, ut32 type);
 R_API REsilOp *r_esil_get_op(REsil *esil, RStrs w);
 R_API void r_esil_del_op(REsil *esil, const char *op);
 R_API void r_esil_stack_free(REsil *esil);

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -527,6 +527,7 @@ EXPECT=<<EOF
 | DUP     duplicate last value in stack
 | NUM     evaluate last item in stack to number
 | SWAP    swap last two values in stack
+| ROT     rotate the third element in the stack to the top
 | TRAP    stop execution
 | BITS    16,BITS  # change bits, useful for arm/thumb
 | TODO    the instruction is not yet esilized
@@ -563,5 +564,13 @@ EXPECT=<<EOF
 0x8000000000000000
 0
 0xfffffffffffffffd
+EOF
+RUN
+
+NAME=esil rot
+FILE=-
+CMDS=ae 1,2,3,ROT
+EXPECT=<<EOF
+2,3,1
 EOF
 RUN

--- a/test/unit/test_esil.c
+++ b/test/unit/test_esil.c
@@ -151,9 +151,37 @@ bool test_reg_alias_op(void) {
 	mu_end;
 }
 
+bool test_define_op(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "r_anal_new failed");
+	bool profile = r_reg_set_profile_string (anal->reg,
+		"=PC r0\n"
+		"=A0 r0\n"
+		"gpr r0 .16 0 0\n"
+		"gpr r1 .16 16 0");
+	mu_assert_true (profile, "failed to set reg profile");
+
+	bool defined = r_esil_define (anal->esil, "TRIPLE", "DUP,DUP,+,+", 1, 1, R_ESIL_OP_TYPE_MATH);
+	mu_assert_true (defined, "failed to define op");
+	bool parsed = r_esil_parse (anal->esil, "5,TRIPLE,r1,=");
+	mu_assert_true (parsed, "failed to parse defined op");
+	mu_assert_eq (r_reg_getv (anal->reg, "r1"), 15, "defined op computed wrong value");
+
+	// redefining replaces the expansion in place
+	defined = r_esil_define (anal->esil, "TRIPLE", "1,+", 1, 1, R_ESIL_OP_TYPE_MATH);
+	mu_assert_true (defined, "failed to redefine op");
+	parsed = r_esil_parse (anal->esil, "5,TRIPLE,r1,=");
+	mu_assert_true (parsed, "failed to parse redefined op");
+	mu_assert_eq (r_reg_getv (anal->reg, "r1"), 6, "redefined op computed wrong value");
+
+	r_anal_free (anal);
+	mu_end;
+}
+
 int main(int argc, char **argv) {
 	mu_run_test (test_setup_keeps_custom_interfaces);
 	mu_run_test (test_setup_installs_default_interfaces);
 	mu_run_test (test_reg_alias_op);
+	mu_run_test (test_define_op);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Adds `r_esil_define (esil, op, body, push, pop, type)`: register an esil op whose implementation is a comma-separated expansion of other ops instead of a C callback — the Forth notion of a colon definition, next to the native ops acting as primitives. ~70 lines in `esil.c`, machinery only; the first in-tree consumer is the follow-up PR that rewrites the compound ops as definitions (#26556, see also #26555).

- Defined ops live in the same hashtable as native ops: same lookup, same `aeo` listing (the body shows as the op's `info`), same `r_esil_del_op` for removal, and overriding works in both directions — `r_esil_set_op` over a definition drops its expansion and vice versa, so esil2c/esil_dfg/arch-plugin overrides keep working unchanged.
- **No runtime cost**: the body is tokenized once at registration into an array of `RStrs` slices; execution walks that array through the same `runword()` dispatch as the outer expression. No re-parsing, no allocation — running a defined op costs exactly what the hand-inlined expansion would.
- **No leaks, no strdups**: `name` and `body` are borrowed literals with the same must-outlive-esil contract op names already have; the token array is the definition's only allocation, owned by the `REsilOp` and freed by the existing ops-hashtable finalizer.
- Recursion (definitions invoking definitions) is bounded by the existing `parse_goto_count` budget; `GOTO` indexes keep referring to the outer expression, since expansion never rewrites the parsed string.

Covered by a new unit test in `test/unit/test_esil.c` exercising definition, execution through `r_esil_parse`, and in-place redefinition.

Based on the ROT PR (#26559) only for stacking convenience — the API itself does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019giJF59A9k1gRD6Mqb2Lxa

---
_Generated by [Claude Code](https://claude.ai/code/session_019giJF59A9k1gRD6Mqb2Lxa)_