### PR TITLE
Fix the memory leak and quadratic cost of aoj with many opcodes ##analysis

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -474,7 +474,7 @@ R_API ut8 *r_anal_mask(RAnal *anal, int size, const ut8 *data, ut64 at) {
 		}
 		idx += oplen;
 		at += oplen;
-		R_FREE (op->mnemonic);
+		r_anal_op_fini (op);
 	}
 
 	r_anal_op_free (op);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -2870,11 +2870,14 @@ static void core_anal_bytes(RCore *core, const ut8 *buf, int len, int nops, int 
 				pj_ks (pj, "mask", maskstr);
 				free (maskstr);
 			} else {
-				ut8 *mask = r_anal_mask (core->anal, len - idx, buf + idx, core->addr + idx);
-				char *maskstr = r_hex_bin2strdup (mask, size);
-				pj_ks (pj, "mask", maskstr);
-				free (mask);
-				free (maskstr);
+				const int instlen = R_MIN (size, len - idx);
+				ut8 *mask = r_anal_mask (core->anal, instlen, buf + idx, core->addr + idx);
+				if (mask) {
+					char *maskstr = r_hex_bin2strdup (mask, instlen);
+					pj_ks (pj, "mask", maskstr);
+					free (mask);
+					free (maskstr);
+				}
 			}
 			if (hint && hint->opcode) {
 				pj_ks (pj, "ophint", hint->opcode);


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`aoj N` with large N leaked memory quadratically: `r_anal_mask` reused one `RAnalOp` across `r_anal_op` calls (which memsets it) without `r_anal_op_fini`, and `aoj` ran it over the whole remaining block for every record.

`r2 -a gb -b 8 -c 'wx <random bytes>; aoj 4000' malloc://0x108100` went past 23 GB; now 0.44s / 33 MB, JSON output byte-identical.
