### PR TITLE
Fix RAnalOp leaks in the disasm, diff and debugger decode loops ##analysis

### DIFF
--- a/libr/anal/diff.c
+++ b/libr/anal/diff.c
@@ -71,8 +71,9 @@ R_API int r_anal_diff_fingerprint_bb(RAnal *anal, RAnalBlock *bb) {
 					memset (bb->fingerprint+idx+op->nopcode, 0, oplen-op->nopcode);
 				}
 				idx += oplen;
+				r_anal_op_fini (op);
 			}
-			free (op);
+			r_anal_op_free (op);
 		}
 	}
 	free (buf);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -10882,6 +10882,7 @@ static void cmd_anal_opcode(RCore *core, const char *input) {
 			} else {
 				R_LOG_WARN ("Unable to analyze instruction");
 			}
+			r_anal_op_fini (&aop);
 		}
 		break;
 	case '?':

--- a/libr/core/cmd_debug.inc.c
+++ b/libr/core/cmd_debug.inc.c
@@ -1514,6 +1514,7 @@ static bool step_until_optype(RCore *core, const char *_optypes) {
 		// To improve this, the function r_anal_optype_string_to_int should be implemented
 		// I also don't check if the opcode type exists.
 		const char *optype_str = r_anal_optype_tostring (op.type);
+		r_anal_op_fini (&op);
 		r_list_foreach (optypes_list, iter, optype) {
 			if (!strcmp (optype_str, optype)) {
 				goto cleanup_after_push;
@@ -1781,7 +1782,7 @@ static void cmd_debug_pid(RCore *core, const char *input) {
 }
 
 static void cmd_debug_backtrace(RCore *core, const char *input) {
-	RAnalOp analop;
+	RAnalOp analop = {0};
 	ut64 addr, len = r_num_math (core->num, input);
 	if (!len) {
 		r_bp_traptrace_list (core->dbg->bp);
@@ -1808,8 +1809,10 @@ static void cmd_debug_backtrace(RCore *core, const char *input) {
 			/* XXX Bottleneck..we need to reuse the bytes read by traptrace */
 			// XXX Do asm.arch should define the max size of opcode?
 			r_io_read_at (core->io, addr, buf, 32); // XXX longer opcodes?
+			r_anal_op_fini (&analop);
 			r_anal_op (core->anal, &analop, addr, buf, sizeof (buf), R_ARCH_OP_MASK_BASIC);
 		} while (r_bp_traptrace_at (core->dbg->bp, addr, analop.size));
+		r_anal_op_fini (&analop);
 		r_bp_traptrace_enable (core->dbg->bp, false);
 	}
 }
@@ -4893,6 +4896,7 @@ static void do_debug_trace_calls(RCore *core, ut64 from, ut64 to, ut64 final_add
 #endif
 			break;
 		}
+		r_anal_op_fini (&aop);
 	}
 }
 
@@ -5743,9 +5747,12 @@ static int cmd_debug_step(RCore *core, const char *input) {
 			addr = r_debug_reg_get (core->dbg, "PC");
 			r_io_read_at (core->io, addr, buf, sizeof (buf));
 			r_anal_op (core->anal, &aop, addr, buf, sizeof (buf), R_ARCH_OP_MASK_BASIC);
-			if (aop.type == R_ANAL_OP_TYPE_CALL) {
+			const bool call = aop.type == R_ANAL_OP_TYPE_CALL;
+			const ut64 jump = aop.jump;
+			r_anal_op_fini (&aop);
+			if (call) {
 				RBinObject *o = r_bin_cur_object (core->bin);
-				RBinSection *s = r_bin_get_section_at (o, aop.jump, true);
+				RBinSection *s = r_bin_get_section_at (o, jump, true);
 				if (!s) {
 					r_debug_step_over (core->dbg, times);
 					continue;
@@ -5772,6 +5779,7 @@ static int cmd_debug_step(RCore *core, const char *input) {
 				}
 #endif
 				addr += aop.size;
+				r_anal_op_fini (&aop);
 			}
 			r_debug_reg_set (core->dbg, "PC", addr);
 			r_reg_setv (core->anal->reg, "PC", addr);

--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -8562,6 +8562,7 @@ toro:
 					r_cons_println (core->cons, opstr);
 				}
 				free (tmpopstr);
+				r_anal_op_fini (&analop);
 			} else {
 				char *asm_str = strdup (asmop.mnemonic);
 				if (asm_ucase) {
@@ -8601,6 +8602,7 @@ toro:
 				}
 			}
 		}
+		r_anal_op_fini (&asmop);
 		i += ret;
 	}
 	r_anal_op_fini (&asmop);

--- a/libr/debug/debug.c
+++ b/libr/debug/debug.c
@@ -887,6 +887,7 @@ R_API bool r_debug_step_soft(RDebug *dbg) {
 		return false;
 	}
 	if (op.type == R_ANAL_OP_TYPE_ILL) {
+		r_anal_op_fini (&op);
 		return false;
 	}
 	switch (op.type) {
@@ -942,6 +943,7 @@ R_API bool r_debug_step_soft(RDebug *dbg) {
 		br = 1;
 		break;
 	}
+	r_anal_op_fini (&op);
 
 	for (i = 0; i < br; i++) {
 		RBreakpointItem *bpi = r_bp_add_sw (dbg->bp, next[i], dbg->options.bpsize, R_BP_PROT_EXEC);
@@ -1144,13 +1146,16 @@ R_API int r_debug_step_over(RDebug *dbg, int steps) {
 			// Use op.fail here instead of pc+op.size to enforce anal backends to fill in this field
 			ins_size = op.fail;
 		}
+		const bool overable = isStepOverable (op.type);
+		const bool rep = op.prefix & (R_ANAL_OP_PREFIX_REP | R_ANAL_OP_PREFIX_REPNE | R_ANAL_OP_PREFIX_LOCK);
+		r_anal_op_fini (&op);
 		// Skip over all the subroutine calls
-		if (isStepOverable (op.type)) {
+		if (overable) {
 			if (!r_debug_continue_until (dbg, ins_size)) {
 				R_LOG_ERROR ("Could not step over call @ 0x%"PFMT64x, pc);
 				return steps_taken;
 			}
-		} else if ((op.prefix & (R_ANAL_OP_PREFIX_REP | R_ANAL_OP_PREFIX_REPNE | R_ANAL_OP_PREFIX_LOCK))) {
+		} else if (rep) {
 			//R_LOG_ERROR ("REP: skip to next instruction");
 			if (!r_debug_continue_until (dbg, ins_size)) {
 				R_LOG_ERROR ("step over failed over rep");
@@ -1377,9 +1382,11 @@ repeat:
 			ut64 pc = r_debug_reg_get (dbg, "PC");
 			dbg->iob.read_at (dbg->iob.io, pc, buf, sizeof (buf));
 			r_anal_op (dbg->anal, &op, pc, buf, sizeof (buf), R_ARCH_OP_MASK_BASIC);
-			if (op.size > 0) {
+			const int opsize = op.size;
+			r_anal_op_fini (&op);
+			if (opsize > 0) {
 				const char *signame = r_signal_tostring (dbg->reason.signum);
-				r_debug_reg_set (dbg, "PC", pc+op.size);
+				r_debug_reg_set (dbg, "PC", pc + opsize);
 				R_LOG_INFO ("Skip signal %d handler %s",
 					dbg->reason.signum, signame);
 				goto repeat;
@@ -1466,7 +1473,9 @@ R_API bool r_debug_continue_until_optype(RDebug *dbg, int type, bool over) {
 			R_LOG_ERROR ("Decode error at %"PFMT64x, pc);
 			return false;
 		}
-		if (op.type == type) {
+		const int optype = op.type;
+		r_anal_op_fini (&op);
+		if (optype == type) {
 			switch (type) {
 			case R_ANAL_OP_TYPE_CALL:
 			case R_ANAL_OP_TYPE_UCALL:

--- a/libr/debug/p/native/bt/fuzzy_all.c
+++ b/libr/debug/p/native/bt/fuzzy_all.c
@@ -54,8 +54,10 @@ static int iscallret(RDebug *dbg, ut64 addr) {
 		// Try different positions
 		for (i = maxdist - 1; i >= maxdist - 8 && i >= 0; i--) {
 			if (r_anal_op (dbg->anal, &op, addr - (maxdist - i), buf + i, maxdist - i, R_ARCH_OP_MASK_BASIC) > 0) {
-				if ((op.type == R_ANAL_OP_TYPE_CALL || op.type == R_ANAL_OP_TYPE_UCALL) &&
-				    (addr - (maxdist - i) + op.size == addr)) {
+				const bool call = op.type == R_ANAL_OP_TYPE_CALL || op.type == R_ANAL_OP_TYPE_UCALL;
+				const bool adjacent = addr - (maxdist - i) + op.size == addr;
+				r_anal_op_fini (&op);
+				if (call && adjacent) {
 					return 1;
 				}
 			}


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #26563. Decoding allocates into the op (esil/opex strbufs, the srcs/dsts vectors, the mnemonic), and `r_anal_op` starts by zeroing the op without freeing any of that, so decoding into the same `RAnalOp` again without `r_anal_op_fini` orphans what the previous decode allocated.

Measured: the `pie`/`pid` loop decodes with `R_ARCH_OP_MASK_ALL` and never finis `analop`, and reuses `asmop` across `r_asm_disassemble` calls — gb `pie 20000` goes from 73 MB to 35 MB RSS, output identical. The bb diff fingerprint had the same shape.

Hygiene: the debugger step loops (`dso`, `dss`, `dsu`, `dtc`, `dbt`, step-over/soft-step, signal skip, fuzzy backtrace) decode with `MASK_BASIC`, where x86/arm/mips/ppc/riscv allocate nothing per op today; they only leak on plugins that fill srcs/dsts unconditionally (gb and the small 8-bit arches). "Fixed for the contract, not for a measured number."
