### PR TITLE
Fix heap buffer overflow when truncating the bytes column ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -4269,20 +4269,24 @@ static void ds_print_bytes(RDisasmState *ds) {
 						}
 					}
 				}
-				char *p = (char *)r_str_ansi_chrn (nstr, nb);
-				if (p) {
-					off = true;
-					if (!core->print->bytespace) {
-						p--;
+				const char *cp = r_str_ansi_chrn (nstr, nb);
+				if (cp) {
+					if (cp > nstr && !core->print->bytespace) {
+						cp--;
 					}
-				//	eprintf ("PP(%s)=(%s) %d\n", nstr, p, r_str_ansi_len (p));
-					p[0] = '.';
-					p[1] = '.';
-					if (ds->show_bytes_align) {
-						p[2] = '\0';
-					} else {
-						if (core->print->bytespace) {
-							int pos = ds->nbytes + 2;
+					const size_t cut = cp - nstr;
+					// the ellipsis and padding land after the cut
+					char *tmp = realloc (nstr, cut + ds->nbytes + 4);
+					if (tmp) {
+						off = true;
+						nstr = tmp;
+						char *p = nstr + cut;
+						p[0] = '.';
+						p[1] = '.';
+						if (ds->show_bytes_align) {
+							p[2] = '\0';
+						} else if (core->print->bytespace) {
+							const int pos = ds->nbytes + 2;
 							memset (p + 2, ' ', pos - 2);
 							p[pos] = 0;
 						} else {


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`ds_print_bytes` truncates the bytes column by writing `..` plus padding *after* the cut point of the string returned by `r_print_hexpair`. That used to be safe by accident — the buffer was `calloc ((strlen (str) + 2), 32)` — but since b4de670c7a it is exactly sized by RStrBuf, so the writes run past the end.

Repro under ASan (this is `db/cmd/cmd_pd3`'s `bytes.space` and `bytes.space 2`, which fail in the `linux-tinyasan-fuzz` job on master):

```
$ r2 -NN -Qc '-e asm.nbytes=3; -e asm.bytes.space=1; pd 5' bins/elf/intof_mod
ERROR: AddressSanitizer: heap-buffer-overflow
    #2 ds_print_bytes libr/core/disasm.c:4286
```

The string is now grown to fit the ellipsis and padding before they are written; if that allocation fails the column is left untruncated instead. Verified with an ASan build over every asm.nbytes / asm.bytes.space / asm.bytes.align combination, and the goldens are unchanged.
