### PR TITLE
Count only jumps and definition nesting toward esil.gotolimit ##esil

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -4207,7 +4207,7 @@ R_API int r_core_config_init(RCore *core) {
 	SETICB ("esil.maxbacksteps", 256, &cb_esilmaxbacksteps, "esil back step capacity");
 	SETB ("esil.stepover.force", "false", "force PC to the return address when ESIL step-over stops before returning");
 	SETS ("esil.fillstack", "", "initialize ESIL stack with (random, debruijn, sequence, zeros, ...)");
-	SETICB ("esil.gotolimit", core->anal->esil_goto_limit, &cb_gotolimit, "maximum number of gotos per ESIL expression");
+	SETICB ("esil.gotolimit", core->anal->esil_goto_limit, &cb_gotolimit, "maximum number of gotos and nested definitions per ESIL expression");
 	SETICB ("esil.stack.depth", 256, &cb_esilstackdepth, "number of elements that can be pushed on the esilstack");
 	SETI ("esil.stack.size", 0xf0000, "set stack size in ESIL VM");
 	SETI ("esil.stack.addr", 0x100000, "set stack address in ESIL VM");

--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -1067,13 +1067,6 @@ R_API bool r_esil_dumpstack(REsil *esil) {
 }
 
 static bool runword(REsil *esil, RStrs w) {
-	esil->parse_goto_count--;
-	if (esil->parse_goto_count < 1) {
-		R_LOG_DEBUG ("ESIL infinite loop detected");
-		esil->trap = 1;       // INTERNAL ERROR
-		esil->parse_stop = 1; // INTERNAL ERROR
-		return false;
-	}
 	// Brace checks inlined — r_strs_equals_str wouldn't inline at -O0.
 	const size_t wlen = (size_t)(w.b - w.a);
 	if (wlen == 0) {
@@ -1118,8 +1111,15 @@ static bool runword(REsil *esil, RStrs w) {
 		bool ret;
 		if (R_LIKELY (op->code)) {
 			ret = op->code (esil);
+		} else if (esil->parse_goto_count < 1) {
+			// definition nesting shares the goto budget to bound recursion
+			R_LOG_DEBUG ("ESIL definition nesting too deep");
+			esil->trap = 1;
+			esil->parse_stop = 1;
+			ret = false;
 		} else {
 			// defined op: run the pre-tokenized expansion in place
+			esil->parse_goto_count--;
 			ret = true;
 			ut32 mi;
 			for (mi = 0; mi < op->ntokens; mi++) {
@@ -1131,6 +1131,7 @@ static bool runword(REsil *esil, RStrs w) {
 					break;
 				}
 			}
+			esil->parse_goto_count++;
 		}
 		esil->current_opstr = NULL;
 		if (!ret) {
@@ -1168,7 +1169,13 @@ static const char *goto_word(const char *str, int n) {
 // Return: 0=restart loop, 1=stop, 2=continue (no separator advance), 3=normal.
 static int eval_word(REsil *esil, const char *ostr, const char **str) {
 	if (esil->parse_goto != -1) {
-		// TODO: detect infinite loop
+		if (esil->parse_goto_count < 1) {
+			R_LOG_DEBUG ("ESIL goto limit reached");
+			esil->trap = 1;
+			esil->parse_stop = 1;
+			return 1;
+		}
+		esil->parse_goto_count--;
 		*str = goto_word (ostr, esil->parse_goto);
 		if (*str) {
 			esil->parse_goto = -1;

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -654,3 +654,28 @@ EXPECT=<<EOF
 0x40
 EOF
 RUN
+
+NAME=esil.gotolimit counts jumps, not words
+FILE=-
+ARGS=-a x86 -b 64 -e esil.gotolimit=4
+CMDS=<<EOF
+'ae 1,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+,1,+
+'ae 0,rax,=,rax,1,+,rax,=,rax,4,==,$z,!,?{,3,GOTO,},rax
+EOF
+EXPECT=<<EOF
+0x15
+rax
+EOF
+RUN
+
+NAME=esil.gotolimit traps a runaway loop
+FILE=-
+ARGS=-a x86 -b 64 -e esil.gotolimit=2
+CMDS=<<EOF
+'ae 0,rax,=,rax,1,+,rax,=,rax,4,==,$z,!,?{,3,GOTO,},rax
+'ae 1,0,GOTO
+EOF
+EXPECT=<<EOF
+1,1,1
+EOF
+RUN

--- a/test/unit/test_esil.c
+++ b/test/unit/test_esil.c
@@ -178,10 +178,24 @@ bool test_define_op(void) {
 	mu_end;
 }
 
+bool test_define_recursion(void) {
+	RAnal *anal = r_anal_new ();
+	mu_assert_notnull (anal, "r_anal_new failed");
+	// a self-referencing definition must trap instead of overflowing the C stack
+	bool defined = r_esil_define (anal->esil, "LOOP", "1,LOOP", 1, 0, R_ESIL_OP_TYPE_MATH);
+	mu_assert_true (defined, "failed to define recursive op");
+	bool parsed = r_esil_parse (anal->esil, "LOOP");
+	mu_assert_false (parsed, "recursive definition did not stop");
+	mu_assert_eq (anal->esil->trap, 1, "recursive definition did not trap");
+	r_anal_free (anal);
+	mu_end;
+}
+
 int main(int argc, char **argv) {
 	mu_run_test (test_setup_keeps_custom_interfaces);
 	mu_run_test (test_setup_installs_default_interfaces);
 	mu_run_test (test_reg_alias_op);
 	mu_run_test (test_define_op);
+	mu_run_test (test_define_recursion);
 	return tests_passed != tests_run;
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`esil.gotolimit` is documented as "maximum number of gotos per ESIL expression", but `runword()` decremented the budget on **every word**, so it was really a 4096-word cap. That used to be invisible: no arch emits an expression anywhere near that length. With `r_esil_define` (#26560/#26556) it no longer is, because every token of an expanded definition counts too — `+=` now costs 6 words of budget instead of 1, and a long straight-line definition (a stack-only `CLZ` is ~100 tokens) traps as an "infinite loop" after a few dozen uses in one expression.

This makes the limit mean what its name says:

- the budget is consumed only when a `GOTO` is actually taken (`eval_word`), so straight-line expressions of any length run;
- definition nesting draws on the same budget (decrement on entry, restore on exit), which keeps the recursion bound that #26560 relied on the word counter for — a self-referencing definition still traps instead of overflowing the C stack;
- `esil.gotolimit=N` now allows exactly N jumps; before, the `< 1` check made it N-1.

Tests: `db/esil/esil` gets an 80-word straight-line expression and a counted `GOTO` loop under `esil.gotolimit=4` (both trapped before), plus a runaway `0,GOTO` that must trap; `test/unit/test_esil.c` gets a recursive-definition case. `db/esil` and `db/anal` are unchanged otherwise.