### PR TITLE
Update the dex symbol golden for the flags field in is.j ##test

### DIFF
--- a/test/db/formats/dex
+++ b/test/db/formats/dex
@@ -2065,9 +2065,9 @@ s method.public.final.Landroid_arch_a_a_a_1.Landroid_arch_a_a_a_1.method.execute
 pd 2
 EOF
 EXPECT=<<EOF
-{"name":"Landroid/arch/a/a/a$1.method.<init>()V","flagname":"sym.Landroid_arch_a_a_a_1.method._init___V","realname":"Landroid/arch/a/a/a$1.method.<init>()V","ordinal":0,"bind":"LOCAL","size":8,"type":"FUNC","arg_first":0,"arg_count":1,"cc_arg_count":0,"ret_count":0,"arg_prefix":"v","vaddr":874156,"paddr":69220,"is_imported":false}
+{"name":"Landroid/arch/a/a/a$1.method.<init>()V","flagname":"sym.Landroid_arch_a_a_a_1.method._init___V","realname":"Landroid/arch/a/a/a$1.method.<init>()V","ordinal":0,"bind":"LOCAL","size":8,"type":"FUNC","flags":["constructor"],"arg_first":0,"arg_count":1,"cc_arg_count":0,"ret_count":0,"arg_prefix":"v","vaddr":874156,"paddr":69220,"is_imported":false}
 {}
-{"name":"Landroid/arch/a/a/a$1.method.execute(Ljava/lang/Runnable;)V","flagname":"sym.Landroid_arch_a_a_a_1.method.execute_Ljava_lang_Runnable__V","realname":"Landroid/arch/a/a/a$1.method.execute(Ljava/lang/Runnable;)V","ordinal":1,"bind":"GLOBAL","size":16,"type":"FUNC","arg_first":1,"arg_count":2,"cc_arg_count":0,"ret_count":0,"arg_prefix":"v","vaddr":874180,"paddr":69244,"is_imported":false}
+{"name":"Landroid/arch/a/a/a$1.method.execute(Ljava/lang/Runnable;)V","flagname":"sym.Landroid_arch_a_a_a_1.method.execute_Ljava_lang_Runnable__V","realname":"Landroid/arch/a/a/a$1.method.execute(Ljava/lang/Runnable;)V","ordinal":1,"bind":"GLOBAL","size":16,"type":"FUNC","flags":["public final"],"arg_first":1,"arg_count":2,"cc_arg_count":0,"ret_count":0,"arg_prefix":"v","vaddr":874180,"paddr":69244,"is_imported":false}
             ;-- method.public.final.Landroid_arch_a_a_a_1.Landroid_arch_a_a_a_1.method.execute_Ljava_lang_Runnable__V:
             0x000d56c4      710024000000   invoke-static {}, Landroid/arch/a/a/a.a()Landroid/arch/a/a/a; ; 0x24
             0x000d56ca      0c00           move-result-object v0


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Master is red on `linux-test`, `ubuntu-tcc-test` and `ubuntu-tcc-nodbg` since e6937fb2c2 (`Add async and generator flags to symbol JSON`): `is.j` now emits a `"flags"` array for symbols that carry attributes, and `db/formats/dex` `APK multidex is.j rebasing` still expected the old objects. The r2r artifacts of the three jobs show it is the only failing test, on master and on every open PR. This refreshes the two affected lines with the current output (`"flags":["constructor"]` and `"flags":["public final"]`).

Not changed here: the array carries the attributes as one space-joined element, which is the existing `icj` convention (`db/cmd/cmd_ic` "ic+ attributes" pins `"static getter"`, `"final late"`). Splitting it into one element per attribute would be a small follow-up if wanted, touching `r_core_bin_attr_tostring` and those two goldens together.