### PR TITLE
Stop walking pc-relative indirect jumps as jump tables ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -327,6 +327,15 @@ static bool is_symbol_flag(const char *name) {
 		|| !strcmp (name, "main");
 }
 
+// a pc-relative slot holds one pointer, so it is never a table
+static bool is_pcrel_jmp(RAnal *anal, const RAnalOp *op) {
+	if (op->ireg || !op->reg) {
+		return false;
+	}
+	const char *pc = r_reg_alias_getname (anal->reg, R_REG_ALIAS_PC);
+	return pc && !strcmp (op->reg, pc);
+}
+
 static bool next_instruction_is_symbol(RAnal *anal, RAnalOp *op) {
 	if (!anal->flb.get_at) {
 		return false;
@@ -1819,7 +1828,8 @@ noskip:
 				gotoBeach (R_ANAL_RET_END);
 			}
 			// switch statement
-			if (anal->opt.jmptbl && anal->lea_jmptbl_ip != op->addr) {
+			// gates every case: movdisp walks these too (bash 0x432b1)
+			if (anal->opt.jmptbl && anal->lea_jmptbl_ip != op->addr && !is_pcrel_jmp (anal, op)) {
 				ut8 buf[32]; // 32 bytes is enough to hold any instruction.
 					// op->ireg since rip relative addressing produces way too many false positives otherwise
 					// op->ireg is 0 for rip relative, "rax", etc otherwise

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -856,3 +856,35 @@ EXPECT=<<EOF
 j=0x200,e=4,n=1,s=0,b=0x0,d=0xffffffffffffffff,v=0xffffffffffffffff,V=0,L=0,F=0x300,r=reg_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
 EOF
 RUN
+
+NAME=pc-relative indirect jmp is not a jump table
+FILE=malloc://0x1000
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 4839f77406ff25f5000000c3 @ 0x100
+wx c3 @ 0x300
+wx 0003000000000000000300000000000000030000000000000003000000000000 @ 0x200
+af @ 0x100
+f~case.~?
+afbj @ 0x100~switch_op~?
+afi @ 0x100~num-bbs
+EOF
+EXPECT=<<EOF
+0
+0
+num-bbs: 3
+EOF
+RUN
+
+NAME=pc-relative tail call after a scaled load is not a jump table
+FILE=bins/elf/bash
+CMDS=<<EOF
+af @ 0x43290
+f~case.~?
+pdf @ 0x43290~switch table?
+EOF
+EXPECT=<<EOF
+0
+0
+EOF
+RUN


### PR DESCRIPTION
Analyzing a `-fno-plt` library with `bin.relocs.apply=true` treated every `jmp qword [rip+X]` tail call through the GOT as a switch jump table rooted at the GOT slot: `fcn.c` enters the table code through the `op->reg` branch with `reg="rip"`, `try_get_jmptbl_info` accepts a register-only `cmp` as a bound of 0, and the walk autosizes to 512 entries. With relocs applied the GOT holds real function addresses, so every entry is a valid "case" and the caller absorbs the callee's blocks.

On `bins/elf/libstdc++.so.6` (1184 such sites) that produced 427 switch ops with their table in `.got`, 57924 bogus cases, 210 functions spanning the whole `.text`, and `aaa` going from 11 s to 331 s because every var-recovery pass walked the inflated block sets. A single `af` on a 66-byte destructor created 6532 `case.*` flags. With relocs not applied the first zero slot stopped the walk, which is why it went unnoticed.

A pc-relative memory jump has no index register, so it can never be a table dispatch; skip the table detection for it. After the change `aaa` on the same file takes 11 s under both settings with the same 4069 functions and 42 switch ops (none in `.got`). Arch table dispatchers that use the pc as a base with an index register (`ldr pc, [pc, r0, lsl #2]`, thumb `tbb`) keep their `ireg` and are unaffected.

The test builds the pattern in a `malloc://` map: `cmp` + `je` + `jmp [rip+slot]` with non-zero slot entries must yield no `case.*` flags and three blocks.