### PR TITLE
Fix m680x jsr/jmp/bsr and branch targets so calls get xrefs ##arch

### DIFF
--- a/libr/arch/p/m680x_cs/plugin.c
+++ b/libr/arch/p/m680x_cs/plugin.c
@@ -44,6 +44,26 @@ static int m680xmode(const char *str) {
 
 #define IMM(x) insn->detail->m680x.operands[x].imm
 #define REL(x) insn->detail->m680x.operands[x].rel
+#define OPX(x) insn->detail->m680x.operands[x]
+
+static void set_abs_target(RAnalOp *op, const cs_m680x_op *o, bool call) {
+	switch (o->type) {
+	case M680X_OP_EXTENDED:
+		if (o->ext.indirect) {
+			op->type = call? R_ANAL_OP_TYPE_UCALL: R_ANAL_OP_TYPE_UJMP;
+			op->ptr = o->ext.address;
+		} else {
+			op->jump = o->ext.address;
+		}
+		break;
+	case M680X_OP_DIRECT:
+		op->jump = o->direct_addr;
+		break;
+	default:
+		op->type = call? R_ANAL_OP_TYPE_RCALL: R_ANAL_OP_TYPE_RJMP;
+		break;
+	}
+}
 
 static inline csh cs_handle_for_session (RArchSession *as) {
 	R_RETURN_VAL_IF_FAIL (as && as->data, 0);
@@ -176,22 +196,12 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		break;
 	case M680X_INS_BAND:
 		break;
-	case M680X_INS_BCC: ///< or BHS
-		op->type = R_ANAL_OP_TYPE_CJMP;
-		break;
 	case M680X_INS_BCLR:
-		break;
-	case M680X_INS_BCS: ///< or BLO
-		op->type = R_ANAL_OP_TYPE_CJMP;
 		break;
 	case M680X_INS_BEOR:
 		break;
 	case M680X_INS_BIAND:
 	case M680X_INS_BIEOR:
-		break;
-	case M680X_INS_BIH:
-	case M680X_INS_BIL:
-		op->type = R_ANAL_OP_TYPE_CJMP;
 		break;
 	case M680X_INS_BIOR:
 	case M680X_INS_BIT:
@@ -201,10 +211,13 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case M680X_INS_BITMD:
 		break;
 	case M680X_INS_BRA:
+	case M680X_INS_LBRA:
 		op->type = R_ANAL_OP_TYPE_JMP;
 		op->jump = addr + op->size + REL(0).offset;
 		op->fail = UT64_MAX;
 		break;
+	case M680X_INS_BCC: ///< or BHS
+	case M680X_INS_BCS: ///< or BLO
 	case M680X_INS_BEQ:
 	case M680X_INS_BGE:
 	case M680X_INS_BGND:
@@ -212,6 +225,8 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case M680X_INS_BHCC:
 	case M680X_INS_BHCS:
 	case M680X_INS_BHI:
+	case M680X_INS_BIH:
+	case M680X_INS_BIL:
 	case M680X_INS_BLE:
 	case M680X_INS_BLS:
 	case M680X_INS_BLT:
@@ -228,12 +243,16 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		op->fail = addr + op->size;
 		break;
 	case M680X_INS_BRN:
+	case M680X_INS_LBRN:
 		op->type = R_ANAL_OP_TYPE_NOP;
 		break;
 	case M680X_INS_BSET:
 		break;
 	case M680X_INS_BSR:
-		op->type = R_ANAL_OP_TYPE_RCALL;
+	case M680X_INS_LBSR:
+		op->type = R_ANAL_OP_TYPE_CALL;
+		op->jump = addr + op->size + REL(0).offset;
+		op->fail = addr + op->size;
 		break;
 	case M680X_INS_BVC:
 	case M680X_INS_BVS:
@@ -357,9 +376,12 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		break;
 	case M680X_INS_JMP:
 		op->type = R_ANAL_OP_TYPE_JMP;
+		set_abs_target (op, &OPX (0), false);
 		break;
 	case M680X_INS_JSR:
 		op->type = R_ANAL_OP_TYPE_CALL;
+		op->fail = addr + op->size;
+		set_abs_target (op, &OPX (0), true);
 		break;
 	case M680X_INS_LBCC: ///< or LBHS
 	case M680X_INS_LBCS: ///< or LBLO
@@ -373,11 +395,12 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 	case M680X_INS_LBMI:
 	case M680X_INS_LBNE:
 	case M680X_INS_LBPL:
-	case M680X_INS_LBRA:
-	case M680X_INS_LBRN:
-	case M680X_INS_LBSR:
 	case M680X_INS_LBVC:
 	case M680X_INS_LBVS:
+		op->type = R_ANAL_OP_TYPE_CJMP;
+		op->jump = addr + op->size + REL(0).offset;
+		op->fail = addr + op->size;
+		break;
 	case M680X_INS_LDA:
 	case M680X_INS_LDAA: ///< M6800/1/2/3
 	case M680X_INS_LDAB: ///< M6800/1/2/3

--- a/test/db/anal/m680x
+++ b/test/db/anal/m680x
@@ -14,3 +14,82 @@ f bb.00027 = 0x00000027
 f bb.0002c = 0x0000002c
 EOF
 RUN
+
+NAME=m680x jsr/jmp/bsr set jump targets
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=m680x
+wx bd7e1e8d107e123424102510
+aoj 5~{}~"opcode","jump","fail","type"
+EOF
+EXPECT=<<EOF
+    "opcode": "jsr 0x7e1e",
+    "jump": 32286,
+    "fail": 3,
+    "type": "call",
+    "opcode": "bsr 0x0015",
+    "jump": 21,
+    "fail": 5,
+    "type": "call",
+    "opcode": "jmp 0x1234",
+    "jump": 4660,
+    "type": "jmp",
+    "opcode": "bcc 0x001a",
+    "jump": 26,
+    "fail": 10,
+    "type": "cjmp",
+    "opcode": "bcs 0x001c",
+    "jump": 28,
+    "fail": 12,
+    "type": "cjmp",
+EOF
+RUN
+
+NAME=m680x jsr creates callee function and xref
+FILE=malloc://32
+CMDS=<<EOF
+e asm.arch=m680x
+wx bd001039 @ 0
+wx 4f39 @ 0x10
+af
+afl
+axl
+EOF
+EXPECT=<<EOF
+0x00000000    1      4 fcn.00000000
+0x00000010    1      2 fcn.00000010
+                            fcn.00000000 0x0 > CALL:--x > 0x10 fcn.00000010
+EOF
+RUN
+
+NAME=m6809 direct/indexed/indirect jsr and long branches
+FILE=malloc://32
+ARGS=-a m680x -e asm.cpu=6809
+CMDS=<<EOF
+wx 9d12ad846e9f123417001c1600031026000a
+aoj 6~{}~"opcode","jump","fail","ptr","type"
+EOF
+EXPECT=<<EOF
+    "opcode": "jsr 0x12",
+    "jump": 18,
+    "fail": 2,
+    "type": "call",
+    "opcode": "jsr , x",
+    "fail": 4,
+    "type": "rcall",
+    "opcode": "jmp [0x1234]]",
+    "ptr": 4660,
+    "type": "ujmp",
+    "opcode": "lbsr 0x0027",
+    "jump": 39,
+    "fail": 11,
+    "type": "call",
+    "opcode": "lbra 0x0011",
+    "jump": 17,
+    "type": "jmp",
+    "opcode": "lbne 0x001c",
+    "jump": 28,
+    "fail": 18,
+    "type": "cjmp",
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

From discord discussion on mc6800 binary: iaito's "Add flag at ... (referenced)" resolved `jsr $7e1e` to `0x07` under `asm.syntax=att` and function labels never landed.

Root cause was not syntax: `libr/arch/p/m680x_cs/plugin.c` set only `op->type` for `jsr`/`jmp`/`bsr`/`bcc`/`bcs`/`bih`/`bil` and every 6809 `lb*` long branch; `op->jump` stayed `UT64_MAX`, so `af`/`aac` never created callees or xrefs. Iaito then fell back to parsing the disasm text, which only works when the plugin's pseudo-intel filter has rewritten `$7e1e` to `0x7e1e`.

Fix (branch `m680x-jsr-jump`, `e017a94f5e`): `set_abs_target` reads the capstone operand (`ext.address` / `direct_addr`; indexed -> RJMP/RCALL, extended-indirect -> UJMP/UCALL + `ptr`), `bsr`/`lbsr` become CALL with a target, all short/long conditional branches get jump+fail. Tests in `test/db/anal/m680x` (3 new, all XX on master). Gate clean, full suite.

Residuals: direct-page targets assume DP=0 (6809 only); `jmp [$1234]]` double bracket is a pre-existing `filter_intel_syntax` quirk; `e asm.cpu=6809` only takes effect via `-e` at load, not from a later `e` command.