### PR TITLE
Render sparc cmp and branches in the v pseudo vocabulary ##disasm

### DIFF
--- a/libr/arch/p/sparc/pseudo.c
+++ b/libr/arch/p/sparc/pseudo.c
@@ -39,9 +39,22 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ "st", "2 = .byte 1", 2},
 		{ "sla", "3 = 1 << 2", 3},
 		{ "sll", "3 = 1 << 2", 3},
-		{ "be", "if equal goto 1", 1},
-		{ "bne", "if not_equal goto 1", 1},
-		{ "cmp", "compare 1, 2", 2},
+		{ "cmp", "v = 1 - 2", 2},
+		{ "ba", "goto 1", 1},
+		{ "be", "if (!v) goto 1", 1},
+		{ "bne", "if (v) goto 1", 1},
+		{ "bg", "if (v > 0) goto 1", 1},
+		{ "bge", "if (v >= 0) goto 1", 1},
+		{ "bl", "if (v < 0) goto 1", 1},
+		{ "ble", "if (v <= 0) goto 1", 1},
+		{ "bgu", "if (((unsigned) v) > 0) goto 1", 1},
+		{ "bcc", "if (((unsigned) v) >= 0) goto 1", 1},
+		{ "bcs", "if (((unsigned) v) < 0) goto 1", 1},
+		{ "bleu", "if (((unsigned) v) <= 0) goto 1", 1},
+		{ "bpos", "if (v >= 0) goto 1", 1},
+		{ "bneg", "if (v < 0) goto 1", 1},
+		{ "bvs", "if (overflow) goto 1", 1},
+		{ "bvc", "if (!overflow) goto 1", 1},
 		{ "nop", ""},
 		{ "ret", "return", 0},
 #if 0
@@ -50,8 +63,20 @@ static int replace(int argc, const char *argv[], char *newstr) {
 		{ NULL }
 	};
 
+	// hints (be,a be,pn) and the v9 cc (bne xcc, x) keep the condition
+	char mn[16];
+	r_str_ncpy (mn, argv[0], sizeof (mn));
+	char *hint = strchr (mn, ',');
+	if (hint) {
+		*hint = 0;
+	}
+	const char *branch[2] = { mn, argv[argc - 1] };
+	const bool cc = argc == 3 && mn[0] == 'b' && r_str_endswith (argv[1], "cc");
 	for (i = 0; ops[i].op; i++) {
-		if (!strcmp (ops[i].op, argv[0])) {
+		if (!strcmp (ops[i].op, mn)) {
+			if (cc) {
+				argv = branch;
+			}
 			if (newstr) {
 				for (j = k = 0; ops[i].str[j] != '\0'; j++, k++) {
 					if (can_replace (ops[i].str, j, ops[i].max_operands)) {

--- a/test/db/anal/sparc
+++ b/test/db/anal/sparc
@@ -673,3 +673,20 @@ g1,g2,g3,g4,g5,o0,o1,o2,o3,o4,o5,o7,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f1
 l0,l1,l2,l3,l4,l5,l6,l7,i0,i1,i2,i3,i4,i5,i6,i7,o6,sp,fp
 EOF
 RUN
+
+NAME=asm pseudo for sparc branches
+FILE=malloc://64
+ARGS=-a sparc -b 32 -e cfg.bigendian=true -e asm.pseudo=true
+CMDS=<<EOF
+wx 80a22000 22800005 12680005 10800005 08800005 1c800005 @ 0
+pi 6
+EOF
+EXPECT=<<EOF
+v = o0 - 0
+if (!v) goto 0x18
+if (v) goto 0x1c
+goto 0x20
+if (((unsigned) v) <= 0) goto 0x24
+if (v >= 0) goto 0x28
+EOF
+RUN

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1279,3 +1279,21 @@ EXPECT=<<EOF
 0
 EOF
 RUN
+
+NAME=pdc structured recovers sparc b<cc> operands from the cmp
+FILE=malloc://64
+ARGS=-a sparc -b 32 -e cfg.bigendian=true -e pdc.structured=1
+CMDS=<<EOF
+wx 80a20009 04800005 01000000 90102001 81c3e008 01000000 90102002 81c3e008 01000000 @ 0
+af @ 0
+pdc~if (,o0 =,else
+pdc~cond_0x~?
+EOF
+EXPECT=<<EOF
+    if (o0 > o1) {
+        o0 = 1
+    } else {
+        o0 = 2
+0
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

The sparc pseudo table rendered cmp as compare a, b and only knew be/bne, so pdc could not recover any sparc branch condition: every if came out as a cond_0x... placeholder (4685 on elf-solaris-sparc-ls + sparc-1 under pdc.structured=1).

Move sparc onto the v vocabulary x86/arm use: cmp -> v = a - b, the integer branch family tests v, ba -> goto. Annul/prediction hints (be,a, be,pn) and the v9 cc operand (bne xcc, x) are stripped before the lookup since they do not change the condition.

    $ r2 -a sparc -b 32 -e cfg.bigendian=true -e asm.pseudo=1 -qc 'wx 80a22000 22800005 12680005 10800005; pi 4' malloc://64
    v = o0 - 0
    if (!v) goto 0x18
    if (v) goto 0x1c
    goto 0x20

Placeholders 4685 -> 1113; the rest are blocks ending in a plain ba, which the analysis types as a conditional jump (capstone v5 reports no cc for the v8 form) - a separate analysis issue.

Tests in db/anal/sparc and db/cmd/cmd_pdc, both failing before the change.