### PR TITLE
Fix the addresses of the bin info when using -m ##bin

### DIFF
--- a/libr/main/radare2.c
+++ b/libr/main/radare2.c
@@ -668,14 +668,8 @@ static RThreadFunctionRet th_binload(RThread *th) {
 	ThreadData *td = (ThreadData *)th->user;
 	RCore *r = td->core;
 	const char *filepath = td->filepath;
-	const ut64 baddr = UT64_MAX;
+	const ut64 baddr = td->baddr;
 	(void)r_core_bin_load (r, filepath, baddr);
-	// check if bin info is loaded and complain if -B was used
-	RBinFile *bi = r_bin_cur (r->bin);
-	bool haveBinInfo = bi && bi->bo && bi->bo->info && bi->bo->info->type;
-	if (!haveBinInfo && baddr != UT64_MAX) {
-		R_LOG_WARN ("Don't use -B on unknown files. Consider using -m");
-	}
 	free (td->filepath);
 	r_cons_free (cons);
 	R_FREE (th->user);
@@ -683,12 +677,12 @@ static RThreadFunctionRet th_binload(RThread *th) {
 	return false;
 }
 
-static void binload(RCore *r, const char *filepath, ut64 baddr) {
+static void binload(RCore *r, const char *filepath, ut64 baddr, bool baddr_set) {
 	(void)r_core_bin_load (r, filepath, baddr);
 	// check if bin info is loaded and complain if -B was used
 	RBinFile *bi = r_bin_cur (r->bin);
 	bool haveBinInfo = bi && bi->bo && bi->bo->info && bi->bo->info->type;
-	if (!haveBinInfo && baddr != UT64_MAX) {
+	if (!haveBinInfo && baddr_set) {
 		R_LOG_WARN ("Don't use -B on unknown files. Consider using -m");
 	}
 }
@@ -717,6 +711,7 @@ typedef struct {
 	int perms;
 	bool sandbox;
 	ut64 baddr;
+	bool baddr_set;
 	ut64 seek;
 	bool do_list_io_plugins;
 	bool do_list_core_plugins;
@@ -983,6 +978,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			break;
 		case 'B':
 			mr.baddr = r_num_math (r->num, opt.arg);
+			mr.baddr_set = true;
 			break;
 		case 'X':
 			r_config_set_b (r->config, "bin.usextr", false);
@@ -1599,6 +1595,14 @@ R_API int r_main_radare2(int argc, const char **argv) {
 			}
 		}
 		if (!mr.debug || mr.debug == 2) {
+			// `-m` maps the file at the given address, so rbin must use it as
+			// base address too. otherwise the addresses of the bin objects
+			// (strings, symbols, sections, ...) are relative to the base
+			// address stored in the binary, while the contents of the file
+			// are mapped somewhere else, so they point outside of the maps
+			if (mr.mapaddr && r_config_get_b (r->config, "file.info")) {
+				mr.baddr = mr.mapaddr;
+			}
 			if (opt.ind == argc && mr.pfile) {
 				if (R_STR_ISEMPTY (mr.pfile)) {
 					R_LOG_ERROR ("Missing file to open");
@@ -1680,7 +1684,7 @@ R_API int r_main_radare2(int argc, const char **argv) {
 									mr.th_bin = r_th_new (th_binload, td, false);
 									r_th_start (mr.th_bin);
 								} else {
-									binload (r, filepath, mr.baddr);
+									binload (r, filepath, mr.baddr, mr.baddr_set);
 								}
 							}
 						} else {
@@ -1713,13 +1717,6 @@ R_API int r_main_radare2(int argc, const char **argv) {
 						}
 					}
 				}
-			}
-			// XXX use UT64_MAX?
-			if (mr.mapaddr && r_config_get_b (r->config, "file.info")) {
-				R_LOG_WARN ("using oba to load the syminfo from different mapaddress");
-				// load symbols when using r2 -m 0x1000 /bin/ls
-				r_core_cmdf (r, "oba 0 0x%" PFMT64x, mr.mapaddr);
-				r_core_cmd0 (r, ".ie*");
 			}
 		} else if (mr.pfile) {
 			RIODesc *f = r_core_file_open (r, mr.pfile, mr.perms, mr.mapaddr);

--- a/test/db/tools/r2
+++ b/test/db/tools/r2
@@ -270,3 +270,16 @@ INFO: Use -AA or aaaa to perform additional experimental analysis
 EOF
 EXPECT=
 RUN
+
+NAME=r2 -m rebases the bin info to the map address
+FILE=bins/elf/bomb
+CMDS=<<EOF
+!!r2 -m 0x100000 -qc 'izq 1' bins/elf/bomb
+!!r2 -m 0x100000 -qc 'ps @ 0x1022b6' bins/elf/bomb
+EOF
+EXPECT=<<EOF
+0x1022b6 29 28 %s: Error: Couldn't open %s\n
+%s: Error: Couldn't open %s
+
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`r2 -m <mapaddr>` maps the contents of the file at the given address, but the bin information was loaded using the base address stored in the binary and rebased afterwards with `oba 0 <mapaddr>`.

That rebases the bin object but not the io maps, so for any binary with sections every address reported by rbin ends up pointing outside of them:

```console
$ r2 -m 0x100000 /bin/ls -qc 'izq~KMGT'
WARN: using oba to load the syminfo from different mapaddress
0x1195e9 11 10 KMGTPEZYRQ

$ r2 -m 0x100000 /bin/ls -qc 'ps @ 0x1195e9'   # nothing mapped there
$ r2 -m 0x100000 /bin/ls -qc 'ps @ 0x195e9'    # the string is really here
KMGTPEZYRQ
```

`om` confirms the maps were never moved: they stay at `0x0-0x24517` while the strings, symbols and sections are reported at `0x100000+`.

This uses the map address as base address when loading the bin instead, so the maps and the addresses of the bin objects (strings, symbols, sections, imports, ...) are both relative to it, and drops the `oba` call along with its warning. Headerless files, which the `oba` rebase already handled correctly, keep reporting the same addresses (there the map follows `bin.laddr`, and the base address shift matches it).

After the change:

```console
$ r2 -m 0x100000 /bin/ls -qc 'izq~KMGT; ps @ 0x1195e9'
0x1195e9 11 10 KMGTPEZYRQ
KMGTPEZYRQ
```

The "Don't use -B on unknown files" warning now tracks whether `-B` was really passed in the command line, otherwise using `-m` alone on a headerless file would complain about a flag the user never used.

**Testing**

Added a regression test in `test/db/tools/r2` that checks a string reported with `-m 0x100000` can be read back at the address it reports. It fails on `master` (only the address line is printed, `ps` reads nothing) and passes with this change.

`r2r db/tools db/io db/cmd/cmd_i db/cmd/cmd_iz db/cmd/cmd_is db/cmd/cmd_ie db/cmd/cmd_io db/cmd/section-mapping` gives the same results before and after (865 OK, 28 BR, 0 XX, 1 FX), except for the new test flipping from XX to OK.

Manually checked that `r2 <file>`, `r2 -B <addr> <file>`, `r2 -m <addr> <headerless>` and `r2 -n -m <addr> <file>` are unchanged.

This came up while looking at radareorg/iaito#306, which turned out to be a separate iaito-side bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLJrULbyG9tsTSPYP7Kqi1)_