### PR TITLE
Keep import GOT relocs at their site when bin.relocs.apply is on ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1751,17 +1751,19 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 		if (!ptr) {
 			continue;
 		}
-
-		// only imports move to their .got.r2 slot, where the patched bytes
-		// point; everything else is reported at its site
-		if (resolved) {
-			if (is_import) {
-				ptr->vaddr = sym_addr;
+		// a patched code site branches to the slot, so the slot is what the
+		// reloc describes; a data site holds the value and keeps its own vaddr
+		if (is_import) {
+			RBinSection *s = r_bin_get_section_at (bf->bo, ptr->vaddr, true);
+			if (s && (s->perm & R_PERM_X)) {
+				if (resolved) {
+					ptr->vaddr = sym_addr;
+				} else if (eo->ehdr.e_machine != EM_SBPF) {
+					ptr->vaddr = vaddr;
+				}
 			}
-		} else if (eo->ehdr.e_machine != EM_SBPF) {
-			if (is_import) {
-				ptr->vaddr = vaddr;
-			}
+		}
+		if (!resolved && eo->ehdr.e_machine != EM_SBPF) {
 			ht_uu_insert (relocs_by_sym, reloc->sym, vaddr);
 			vaddr += cdsz;
 		}

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -1512,7 +1512,8 @@ EXPECT=<<EOF
 |    ||||   0x00011411      cmp sil, cl
 |   ,=====< 0x00011414      jne 0x11424
 |   |||||   0x00011416      lea rbx, [rax + 4]
-|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; [0x1f2d0:8]=0x221f0 reloc.program_invocation_short_name
+|   |||||   0x0001141a      mov rax, qword [rip + 0xdeaf]              ; reloc.program_invocation_short_name
+|   |||||                                                              ; [0x1f2d0:8]=0x221f0
 |   |||||   0x00011421      mov qword [rax], rbx
 |   |||||   ; CODE XREFS from fcn.00011390 @ 0x113d0(x), 0x113e0(x), 0x113f4(x), 0x11414(x)
 |   ````--> 0x00011424      mov rax, qword [rip + 0xde3d]              ; [0x1f268:8]=0x21680

--- a/test/db/formats/elf/elf-relarm64
+++ b/test/db/formats/elf/elf-relarm64
@@ -62,10 +62,10 @@ vaddr      paddr      type   ntype name
 0x08000044 0x00000044 ADD_32 283   local_target
 0x0800004c 0x0000004c ADD_32 279   local_target
 0x08000050 0x00000050 ADD_32 280   local_target
+0x08000068 0x00000068 ADD_32 261   extern_target + 0x08000000
 0x0800006c 0x0000006c ADD_32 258   local_target
 0x08000070 0x00000070 ADD_64 257   local_target
 0x08000320 0x00000048 ADD_32 283   extern_target
-0x08000320 0x00000068 ADD_32 261   extern_target + 0x08000000
 0x08000328 0x00000058 ADD_32 282   extern_tail
 EOF
 RUN

--- a/test/db/formats/elf/ppc64v1-etrel
+++ b/test/db/formats/elf/ppc64v1-etrel
@@ -147,12 +147,12 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=PPC64 ELFv1 (regression): shared lib JMP_SLOT vaddr unchanged by ET_REL gating
+NAME=PPC64 ELFv1: shared lib JMP_SLOT import keeps its got.plt site
 FILE=bins/elf/ppc64v1-libz.so
 ARGS=-e bin.relocs.apply=true
 CMDS=ir~strlen[0]
 EXPECT=<<EOF
-0x000304d8
+0x00030048
 EOF
 RUN
 

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -729,3 +729,43 @@ EXPECT=<<EOF
 0x00078030 0x00078030 SET_64 22
 EOF
 RUN
+
+NAME=ELF: import GOT site keeps its reloc flag under bin.relocs.apply
+FILE=bins/elf/analysis/ls-linux64
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~_ITM_deregisterTMCloneTable
+fd @ 0x21cf88
+pi 1 @ 0x5c6b
+EOF
+EXPECT=<<EOF
+0x0021cf88 0x0001cf88 SET_64 6     _ITM_deregisterTMCloneTable
+reloc._ITM_deregisterTMCloneTable
+mov rax, qword [reloc._ITM_deregisterTMCloneTable]
+EOF
+RUN
+
+NAME=ELF: call graph names an import called through its GOT slot under bin.relocs.apply
+FILE=bins/elf/ls
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+af @ entry0
+agcj~{[0].imports}
+EOF
+EXPECT=<<EOF
+["reloc.__libc_start_main"]
+EOF
+RUN
+
+NAME=ELF: patched ET_REL branch keeps naming its got.r2 target
+FILE=bins/elf/random_39855/random_39855.oo
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pi 1 @ 0x0800007c
+ir~strcmp[0]
+EOF
+EXPECT=<<EOF
+bl reloc.strcmp
+0x08012678
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With `bin.relocs.apply=true` an ELF import reloc whose site is a GOT **data** word was reported at the synthetic `.got.r2` slot instead of at the word itself. The only flag a reloc gets, `reloc.<name>`, therefore sat on the slot and the site was left unnamed:

```
$ r2 -N -q -e bin.relocs.apply=true  -c 's 0x5c50; af; pif~ITM' bins/elf/analysis/ls-linux64
$ r2 -N -q -e bin.relocs.apply=false -c 's 0x5c50; af; pif~ITM' bins/elf/analysis/ls-linux64
mov rax, qword [reloc._ITM_deregisterTMCloneTable]
```

`agcj` on `bins/elf/ls` listed `unk.0x21e18` instead of `reloc.__libc_start_main`, and 22 tests differ between the two settings for this reason alone (`db/anal/x86_64`, `cmd_ag`, `cmd_agc`, `zignature`, `flags`, `noreturn`/`entry0` sizes). #26545 already keeps every non-import reloc at its site; this extends it to imports, but only where it is correct to do so:

- a **data** site holds the patched pointer value, so the reloc describes that word and stays there — this is the case above;
- a **code** site had its branch immediate rewritten to point at the slot, so the slot is the branch target and is what the reloc describes. Those keep reporting the slot, exactly as before, which is what names `bl reloc.strcmp` / `call reloc.printk` in ET_REL objects for `pd`, `pdi`, `axt` and `agc` alike.

`r_bin_get_section_at()` answers which one a site is. Slot allocation and the patched bytes are unchanged (corpus A/B over the ELF files in test/bins: reloc tables move, 0 byte differences), and reloc flags are now placed identically under both settings on ls-linux64, ls, ppc64v1-more, ppc64v1-libz.so, r2pay-arm64.so and the pltrel fixtures.

Three goldens move, each because `apply=true` now agrees with `apply=false`: `db/anal/x86_64 reflines offset 2` puts the flag comment on its own line; `elf-relarm64` reports an aarch64 `PREL32` row at its site, since that one lives in a data section unlike the CALL26/JUMP26 rows beside it; and the ppc64v1 shared-lib JMP_SLOT row moves from the slot to its `.got.plt` site, so that test was renamed to say what it pins. 