### PR TITLE
Fix NULL deref in PDB TPI type printing with malformed types ##crash

### DIFF
--- a/libr/bin/format/pdb/tpi.c
+++ b/libr/bin/format/pdb/tpi.c
@@ -1664,6 +1664,7 @@ static void get_bitfield_print_type(STpiStream *ss, void *type, char **name) {
 	SLF_BITFIELD *bitfeild_info = (SLF_BITFIELD *)ti->type_info;
 
 	ti->get_base_type (ss, ti, (void **)&t);
+	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
 	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
@@ -1775,6 +1776,7 @@ static void get_nesttype_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = 0;
 
 	ti->get_index (ss, ti, (void **)&t);
+	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
 	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
@@ -1806,6 +1808,7 @@ static void get_member_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_index (ss, ti, (void **)&t);
+	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
 	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
@@ -1825,6 +1828,7 @@ static void get_onemethod_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_index (ss, ti, (void **)&t);
+	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
 	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);

--- a/libr/bin/format/pdb/tpi.c
+++ b/libr/bin/format/pdb/tpi.c
@@ -1592,16 +1592,15 @@ static void get_array_print_type(STpiStream *ss, void *type, char **name) {
 
 	SType *t = NULL;
 	ti->get_element_type (ss, ti, (void **)&t);
-
-	// XXX asserts are bad
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
 	int size = 0;
 	if (ti->get_val) {
@@ -1617,14 +1616,15 @@ static void get_pointer_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_utype (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
 	*name = r_str_newf ("%s*", tmp_name? tmp_name: "");
 	free (tmp_name);
@@ -1664,14 +1664,15 @@ static void get_bitfield_print_type(STpiStream *ss, void *type, char **name) {
 	SLF_BITFIELD *bitfeild_info = (SLF_BITFIELD *)ti->type_info;
 
 	ti->get_base_type (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
 
 	*name = r_str_newf ("bitfield%s%s : %d",
@@ -1691,14 +1692,15 @@ static void get_enum_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_utype (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // This shouldn't happen?, TODO explore this situation
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) { // BaseType
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) { // BaseType
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
 
 	*name = r_str_newf ("enum %s", tmp_name? tmp_name: "");
@@ -1776,18 +1778,14 @@ static void get_nesttype_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = 0;
 
 	ti->get_index (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
 		if (ti->get_print_type) {
 			ti->get_print_type (ss, ti, &tmp_name);
-		} else {
-			// TODO: this shouldnt happen because it means corrupted or invalid type
-			// R_LOG_WARN ("strange for nesttype");
 		}
 	}
 
@@ -1808,18 +1806,17 @@ static void get_member_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_index (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
-	if (tmp_name) {
-		*name = tmp_name;
-	}
+	*name = tmp_name? tmp_name: strdup ("unknown_t");
 }
 
 static void get_onemethod_print_type(STpiStream *ss, void *type, char **name) {
@@ -1828,14 +1825,15 @@ static void get_onemethod_print_type(STpiStream *ss, void *type, char **name) {
 	char *tmp_name = NULL;
 
 	ti->get_index (ss, ti, (void **)&t);
-	R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?
-	if (t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
+	if (t && t->type_data.leaf_type == eLF_SIMPLE_TYPE) {
 		SLF_SIMPLE_TYPE *base_type = t->type_data.type_info;
 		tmp_name = strdup (base_type->type);
 		free_simple_type (t);
-	} else {
+	} else if (t) {
 		ti = &t->type_data;
-		ti->get_print_type (ss, ti, &tmp_name);
+		if (ti->get_print_type) {
+			ti->get_print_type (ss, ti, &tmp_name);
+		}
 	}
 
 	*name = r_str_newf ("onemethod %s", tmp_name? tmp_name: "");

--- a/libr/bin/format/pdb/tpi.c
+++ b/libr/bin/format/pdb/tpi.c
@@ -1642,7 +1642,9 @@ static void get_modifier_print_type(STpiStream *ss, void *type, char **name) {
 		free_simple_type (stype);
 	} else if (stype) {
 		STypeInfo *refered_type_info = &stype->type_data;
-		refered_type_info->get_print_type (ss, refered_type_info, &tmp_name);
+		if (refered_type_info->get_print_type) {
+			refered_type_info->get_print_type (ss, refered_type_info, &tmp_name);
+		}
 	}
 	SLF_MODIFIER *modifier = stype_info->type_info;
 	*name = r_str_newf ("%s%s%s%s",


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes #26593

Adds the missing NULL guards to four PDB TPI type-printing helpers in
`libr/bin/format/pdb/tpi.c` (`get_bitfield_print_type`,
`get_nesttype_print_type`, `get_member_print_type`,
`get_onemethod_print_type`), mirroring the existing checks in their sibling
functions (`get_array_print_type`, `get_pointer_print_type`,
`get_enum_print_type` — same `R_RETURN_IF_FAIL (t);` idiom and comment).

**Problem**

The four helpers dereference the `SType *t` returned by
`get_base_type`/`get_index` without checking it first. A malformed PDB whose
type records reference an out-of-range TPI index makes the lookup return NULL,
and `t->type_data.leaf_type` crashes `radare2` with SIGSEGV. Reproduced with

```sh
radare2 -nn -q -c 'idp attack_member_oob.pdb' /bin/true   # SIGSEGV before
radare2 -nn -q -c 'idp attack_bitfield_oob.pdb' /bin/true  # SIGSEGV before
```

on crafted `LF_MEMBER` (member index 0x2000) and `LF_BITFIELD`
(base_type 0x2000) records. This is a migration omission from the 2026 PDB
hardenings: the stream-level guard added there bounds the record count but not
the in-record reference indices. Any analyst loading an untrusted PDB crashes;
no impact beyond a NULL dereference.

**Fix**

Add `R_RETURN_IF_FAIL (t); // t == NULL indicates malformed PDB?` right after
each of the four lookup calls (4 one-line changes). Callers already tolerate a
NULL output name (e.g. `bin_pdb.c` only appends members when name and type are
both non-NULL).

**Validation**

- Malformed inputs (member index / bitfield base type out of range):
  SIGSEGV (rc 139) before, exit 0 after.
- Control inputs (valid member, simple type): exit 0 before and after, printed
  output byte-identical (no behavior change).

**Changelog**

`##crash` entry: crash fix on malformed PDB input. Fixes #26593

