### PR TITLE
Parse the PE SEH scope tables, the CLR and the MSVC C++ exception regions ##bin

### DIFF
--- a/libr/bin/format/pe/dotnet.h
+++ b/libr/bin/format/pe/dotnet.h
@@ -388,6 +388,7 @@ typedef struct {
 	char *name;
 	ut64 vaddr;
 	ut64 paddr;
+	ut64 eh_paddr;    // methoddef: paddr of the IL exception handling sections (0 if none)
 	ut32 size;
 	char *namespace;  // For types
 	char *classname;  // Declaring class for methods and fields

--- a/libr/bin/p/bin_pe.c
+++ b/libr/bin/p/bin_pe.c
@@ -468,6 +468,7 @@ RBinPlugin r_bin_plugin_pe = {
 	.strings = &strings,
 	.libs = &libs,
 	.relocs = relocs,
+	.trycatch = &pe_trycatch,
 	.minstrlen = 4,
 	.create = &create,
 	.get_vaddr = &get_vaddr,

--- a/libr/bin/p/bin_pe.inc.c
+++ b/libr/bin/p/bin_pe.inc.c
@@ -65,6 +65,18 @@ static const char *get_cc(RBinFile *bf, ut64 vaddr) {
 	return ret;
 }
 
+// ECMA-335 II.25.4.4 method body header flags
+#define CIL_METHOD_MORE_SECTS 0x8
+// ECMA-335 II.25.4.5 method data section kinds
+#define CIL_SECT_EHTABLE 0x1
+#define CIL_SECT_FATFORMAT 0x40
+#define CIL_SECT_MORESECTS 0x80
+// ECMA-335 II.25.4.6 exception clause flags
+#define CIL_EH_CATCH 0x0
+#define CIL_EH_FILTER 0x1
+#define CIL_EH_FINALLY 0x2
+#define CIL_EH_FAULT 0x4
+
 static void normalize_dotnet_method_bodies(RBinFile *bf, RBinPEObj *pe, RList *symbols) {
 	R_RETURN_IF_FAIL (bf && bf->buf && pe && symbols);
 	const ut64 file_size = r_buf_size (bf->buf);
@@ -84,6 +96,7 @@ static void normalize_dotnet_method_bodies(RBinFile *bf, RBinPEObj *pe, RList *s
 		}
 		ut32 header_size = 0;
 		ut32 code_size = 0;
+		bool more_sects = false;
 		if ((header[0] & 3) == 2) {
 			header_size = 1;
 			code_size = header[0] >> 2;
@@ -92,6 +105,8 @@ static void normalize_dotnet_method_bodies(RBinFile *bf, RBinPEObj *pe, RList *s
 			ut16 flags_size = r_read_le16 (header);
 			header_size = ((flags_size >> 12) & 0xf) * 4;
 			code_size = r_read_le32 (header + 4);
+			// CorILMethod_MoreSects: the exception clauses follow the code
+			more_sects = (flags_size & CIL_METHOD_MORE_SECTS) != 0;
 			if (header_size < sizeof (header)) {
 				header_size = 0;
 			}
@@ -103,6 +118,13 @@ static void normalize_dotnet_method_bodies(RBinFile *bf, RBinPEObj *pe, RList *s
 		sym->paddr += header_size;
 		sym->vaddr += header_size;
 		sym->size = code_size;
+		if (more_sects) {
+			// the section headers are aligned to a 4 byte boundary
+			ut64 at = (sym->paddr + code_size + 3) & ~(ut64)3;
+			if (at >= sym->paddr && at + 4 <= file_size) {
+				sym->eh_paddr = at;
+			}
+		}
 	}
 }
 
@@ -463,6 +485,139 @@ static char *dotnet_symbol_name_by_token(RList *symbols, ut32 token) {
 			? r_str_newf ("%s.%s", sym->namespace, sym->name): strdup (sym->name);
 	}
 	return NULL;
+}
+
+// the type of a CIL catch clause is a TypeDef, TypeRef or TypeSpec token
+static char *clr_class_name(RList *symbols, ut32 token) {
+	switch (token >> 24) {
+	case 0x01: // TypeRef
+	case 0x02: // TypeDef
+	case 0x1b: // TypeSpec
+		return dotnet_symbol_name_by_token (symbols, token);
+	}
+	return NULL;
+}
+
+// ECMA-335 II.25.4.6 - parse the exception clauses of a single IL method body
+static void clr_trycatch_method(RBinFile *bf, RList *list, RList *symbols, DotNetSymbol *sym, ut64 image_base) {
+	const ut64 file_size = r_buf_size (bf->buf);
+	const ut64 source = sym->vaddr + image_base;
+	ut64 at = sym->eh_paddr;
+	int section;
+	// a method carries a handful of data sections at most, but a crafted
+	// binary may chain them forever, so bound the walk
+	for (section = 0; section < 8; section++) {
+		ut8 shdr[4];
+		if (at + sizeof (shdr) > file_size
+				|| r_buf_read_at (bf->buf, at, shdr, sizeof (shdr)) != sizeof (shdr)) {
+			return;
+		}
+		const ut8 kind = shdr[0];
+		const bool fat = (kind & CIL_SECT_FATFORMAT) != 0;
+		const ut32 data_size = fat
+			? (ut32)shdr[1] | ((ut32)shdr[2] << 8) | ((ut32)shdr[3] << 16)
+			: (ut32)shdr[1];
+		const ut32 entry_size = fat? 24: 12;
+		if (data_size < 4 + entry_size || at + data_size > file_size) {
+			return;
+		}
+		if (kind & CIL_SECT_EHTABLE) {
+			ut32 count = (data_size - 4) / entry_size;
+			ut64 clause = at + 4;
+			ut32 i;
+			for (i = 0; i < count; i++, clause += entry_size) {
+				ut8 buf[24];
+				if (r_buf_read_at (bf->buf, clause, buf, entry_size) != (int)entry_size) {
+					return;
+				}
+				ut32 flags, try_off, try_len, handler_off, handler_len, extra;
+				if (fat) {
+					flags = r_read_le32 (buf);
+					try_off = r_read_le32 (buf + 4);
+					try_len = r_read_le32 (buf + 8);
+					handler_off = r_read_le32 (buf + 12);
+					handler_len = r_read_le32 (buf + 16);
+					extra = r_read_le32 (buf + 20);
+				} else {
+					flags = r_read_le16 (buf);
+					try_off = r_read_le16 (buf + 2);
+					try_len = buf[4];
+					handler_off = r_read_le16 (buf + 5);
+					handler_len = buf[7];
+					extra = r_read_le32 (buf + 8);
+				}
+				// every offset is relative to the start of the method body
+				if (try_off > sym->size || try_len > sym->size - try_off
+						|| handler_off > sym->size || handler_len > sym->size - handler_off) {
+					continue;
+				}
+				RBinTrycatch *tc = r_bin_trycatch_new (source,
+					source + try_off, source + try_off + try_len,
+					source + handler_off,
+					(flags & CIL_EH_FILTER) && extra <= sym->size? source + extra: 0);
+				if (!tc) {
+					return;
+				}
+				switch (flags & 7) {
+				case CIL_EH_FILTER:
+					tc->kind = R_BIN_TRYCATCH_FILTER;
+					break;
+				case CIL_EH_FINALLY:
+				case CIL_EH_FAULT:
+					tc->kind = R_BIN_TRYCATCH_CLEANUP;
+					break;
+				case CIL_EH_CATCH:
+					tc->kind = R_BIN_TRYCATCH_CATCH;
+					tc->type_filter = extra;
+					tc->type = clr_class_name (symbols, extra);
+					// catching System.Object catches everything
+					tc->catch_all = tc->type && !strcmp (tc->type, "System.Object");
+					break;
+				default:
+					break;
+				}
+				r_list_append (list, tc);
+			}
+		}
+		if (!(kind & CIL_SECT_MORESECTS)) {
+			return;
+		}
+		at = (at + data_size + 3) & ~(ut64)3;
+	}
+}
+
+// collect the exception clauses of every managed method in the assembly
+static void clr_trycatch(RBinFile *bf, RList *list) {
+	RBinPEObj *pe = PE_(get) (bf);
+	if (!pe || !pe->clr_hdr) {
+		return;
+	}
+	RList *symbols = get_dotnet_symbols (bf);
+	if (!symbols) {
+		return;
+	}
+	const ut64 image_base = PE_(r_bin_pe_get_image_base) (pe);
+	RListIter *iter;
+	DotNetSymbol *sym;
+	r_list_foreach (symbols, iter, sym) {
+		if (sym->eh_paddr && sym->type && !strcmp (sym->type, "methoddef")) {
+			clr_trycatch_method (bf, list, symbols, sym, image_base);
+		}
+	}
+}
+
+static RList *pe_trycatch(RBinFile *bf) {
+	RBinPEObj *pe = PE_(get) (bf);
+	if (!pe) {
+		return NULL;
+	}
+	if (!pe->trycatch_list) {
+		pe->trycatch_list = r_list_newf ((RListFree)r_bin_trycatch_free);
+		if (pe->trycatch_list) {
+			clr_trycatch (bf, pe->trycatch_list);
+		}
+	}
+	return pe->trycatch_list;
 }
 
 static RList* classes(RBinFile *bf) {

--- a/libr/bin/p/bin_pe64.c
+++ b/libr/bin/p/bin_pe64.c
@@ -375,7 +375,194 @@ static bool read_scope_record_at(RIO *io, ut64 addr, PE64_SCOPE_RECORD *scope) {
 }
 
 #define PE64_UNWIND_CHAIN_LIMIT 32
+#define PE64_SCOPE_LIMIT 0x10000
+// magic numbers of the MSVC FuncInfo structure used by __CxxFrameHandler3
+#define PE64_CXX_MAGIC_MIN 0x19930520
+#define PE64_CXX_MAGIC_MAX 0x19930522
 
+static inline bool is_cxx_magic(ut32 magic) {
+	return magic >= PE64_CXX_MAGIC_MIN && magic <= PE64_CXX_MAGIC_MAX;
+}
+
+// read the name of an RTTI type descriptor: `struct { void *vft; void *spare; char name[]; }`
+static char *read_type_descriptor_name(RBinFile *bf, RIO *io, ut64 addr) {
+	char name[256];
+	size_t i;
+	for (i = 0; i < sizeof (name) - 1; i++) {
+		ut8 ch;
+		if (!read_at_checked (io, addr + 16 + i, &ch, 1) || !ch) {
+			break;
+		}
+		name[i] = (char)ch;
+	}
+	if (!i) {
+		return NULL;
+	}
+	name[i] = 0;
+	// type descriptor names look like `.?AVFoo@@`, demangle them when possible
+	char *dem = r_bin_demangle (bf, "msvc", name, addr, false);
+	if (R_STR_ISEMPTY (dem)) {
+		free (dem);
+		return strdup (name);
+	}
+	char *sp = strchr (dem, ' ');
+	if (sp && R_STR_ISNOTEMPTY (sp + 1)) {
+		char *res = strdup (sp + 1);
+		free (dem);
+		return res;
+	}
+	return dem;
+}
+
+// map the [low, high] state range of a try block into an address range using
+// the ip-to-state map of the function
+static bool cxx_state_range(const ut32 *ipmap, ut32 ip_count, ut64 baseAddr,
+		st32 low, st32 high, const PE64_RUNTIME_FUNCTION *rfcn, ut64 *from, ut64 *to) {
+	ut32 i;
+	bool found = false;
+	for (i = 0; i < ip_count; i++) {
+		const st32 state = (st32)ipmap[i * 2 + 1];
+		if (state >= low && state <= high) {
+			if (!found) {
+				*from = baseAddr + ipmap[i * 2];
+				found = true;
+			}
+		} else if (found) {
+			*to = baseAddr + ipmap[i * 2];
+			return *to > *from;
+		}
+	}
+	if (found) {
+		*to = baseAddr + rfcn->EndAddress;
+	}
+	return found && *to > *from;
+}
+
+// parse the MSVC FuncInfo of a __CxxFrameHandler3 protected function
+static void cxx_trycatch(RBinFile *bf, RIO *io, RList *tclist, ut64 baseAddr,
+		const PE64_RUNTIME_FUNCTION *rfcn, ut32 funcinfo) {
+	const ut64 fi = baseAddr + funcinfo;
+	ut32 try_count, try_map, ip_count, ip_map;
+	if (!read_u32_at (io, fi + 12, &try_count) || !read_u32_at (io, fi + 16, &try_map)
+			|| !read_u32_at (io, fi + 20, &ip_count) || !read_u32_at (io, fi + 24, &ip_map)) {
+		return;
+	}
+	if (!try_count || !try_map || !ip_count || !ip_map
+			|| try_count > 0x1000 || ip_count > 0x10000) {
+		return;
+	}
+	// IptoStateMapEntry: ip rva, state
+	ut32 *ipmap = calloc (ip_count, sizeof (ut32) * 2);
+	if (!ipmap) {
+		return;
+	}
+	ut32 i;
+	for (i = 0; i < ip_count; i++) {
+		const ut64 at = baseAddr + ip_map + (ut64)i * 8;
+		if (!read_u32_at (io, at, &ipmap[i * 2]) || !read_u32_at (io, at + 4, &ipmap[i * 2 + 1])) {
+			free (ipmap);
+			return;
+		}
+	}
+	const ut64 source = baseAddr + rfcn->BeginAddress;
+	for (i = 0; i < try_count; i++) {
+		// TryBlockMapEntry: tryLow, tryHigh, catchHigh, nCatches, dispHandlerArray
+		const ut64 tb = baseAddr + try_map + (ut64)i * 20;
+		ut32 try_low, try_high, catch_count, handlers;
+		if (!read_u32_at (io, tb, &try_low) || !read_u32_at (io, tb + 4, &try_high)
+				|| !read_u32_at (io, tb + 12, &catch_count) || !read_u32_at (io, tb + 16, &handlers)) {
+			break;
+		}
+		if (!catch_count || !handlers || catch_count > 0x100
+				|| (st32)try_low > (st32)try_high) {
+			continue;
+		}
+		ut64 from = 0, to = 0;
+		if (!cxx_state_range (ipmap, ip_count, baseAddr,
+				(st32)try_low, (st32)try_high, rfcn, &from, &to)) {
+			continue;
+		}
+		ut32 j;
+		for (j = 0; j < catch_count; j++) {
+			// HandlerType: adjectives, dispType, dispCatchObj, addressOfHandler, dispFrame
+			const ut64 ht = baseAddr + handlers + (ut64)j * 20;
+			ut32 type_rva, handler_rva;
+			if (!read_u32_at (io, ht + 4, &type_rva) || !read_u32_at (io, ht + 12, &handler_rva)) {
+				break;
+			}
+			if (!handler_rva) {
+				continue;
+			}
+			RBinTrycatch *tc = r_bin_trycatch_new (source, from, to, baseAddr + handler_rva, 0);
+			if (!tc) {
+				break;
+			}
+			tc->kind = R_BIN_TRYCATCH_CATCH;
+			if (type_rva) {
+				tc->type = read_type_descriptor_name (bf, io, baseAddr + type_rva);
+			} else {
+				// a null type descriptor is `catch (...)`
+				tc->catch_all = true;
+			}
+			r_list_append (tclist, tc);
+		}
+	}
+	free (ipmap);
+}
+
+// parse the scope table of a __C_specific_handler protected function
+static void seh_trycatch(RIO *io, RList *tclist, ut64 baseAddr,
+		const PE64_RUNTIME_FUNCTION *rfcn, ut64 scopeTableOff) {
+	ut32 scope_count;
+	if (!read_u32_at (io, scopeTableOff, &scope_count)
+			|| !scope_count || scope_count > PE64_SCOPE_LIMIT) {
+		return;
+	}
+	const ut64 source = baseAddr + rfcn->BeginAddress;
+	ut64 scopeRecOff = scopeTableOff + sizeof (ut32);
+	ut32 i;
+	for (i = 0; i < scope_count; i++, scopeRecOff += sizeof (PE64_SCOPE_RECORD)) {
+		PE64_SCOPE_RECORD scope;
+		if (!read_scope_record_at (io, scopeRecOff, &scope)) {
+			return;
+		}
+		if (scope.BeginAddress > scope.EndAddress
+			|| scope.BeginAddress == UT32_MAX || scope.EndAddress == UT32_MAX
+			|| !scope.BeginAddress || !scope.EndAddress) {
+			return;
+		}
+		if (!(scope.BeginAddress >= rfcn->BeginAddress - 1 && scope.BeginAddress < rfcn->EndAddress
+			&& scope.EndAddress <= rfcn->EndAddress + 1 && scope.EndAddress > rfcn->BeginAddress)) {
+			continue;
+		}
+		const ut64 from = baseAddr + scope.BeginAddress;
+		const ut64 to = baseAddr + scope.EndAddress;
+		RBinTrycatch *tc;
+		if (scope.JumpTarget) {
+			// __except: HandlerAddress is the filter, 1 means EXCEPTION_EXECUTE_HANDLER
+			const ut64 filter = scope.HandlerAddress > 1? baseAddr + scope.HandlerAddress: 0;
+			tc = r_bin_trycatch_new (source, from, to, baseAddr + scope.JumpTarget, filter);
+			if (tc) {
+				tc->kind = filter? R_BIN_TRYCATCH_FILTER: R_BIN_TRYCATCH_CATCH;
+			}
+		} else {
+			// __finally: HandlerAddress is the termination handler
+			if (!scope.HandlerAddress || scope.HandlerAddress == 1) {
+				continue;
+			}
+			tc = r_bin_trycatch_new (source, from, to, baseAddr + scope.HandlerAddress, 0);
+			if (tc) {
+				tc->kind = R_BIN_TRYCATCH_CLEANUP;
+			}
+		}
+		if (!tc) {
+			return;
+		}
+		r_list_append (tclist, tc);
+	}
+}
+
+// walk the exception directory collecting the SEH and C++ exception regions
 static RList *trycatch(RBinFile *bf) {
 	RIO *io = bf->rbin->iob.io;
 	ut64 baseAddr = bf->bo->baddr;
@@ -383,6 +570,9 @@ static RList *trycatch(RBinFile *bf) {
 	ut32 c_handler = 0;
 
 	struct PE_(r_bin_pe_obj_t) * bin = bf->bo->bin_obj;
+	if (bin->trycatch_list) {
+		return bin->trycatch_list;
+	}
 	if (!bin->nt_headers || bin->nt_headers->file_header.Machine != PE_IMAGE_FILE_MACHINE_AMD64) {
 		// The exception directory of ARM64 and other machines does not
 		// use the x86-64 RUNTIME_FUNCTION/UNWIND_INFO format parsed here
@@ -391,9 +581,6 @@ static RList *trycatch(RBinFile *bf) {
 	PE_(image_data_directory) *expdir = &bin->optional_header->DataDirectory[PE_IMAGE_DIRECTORY_ENTRY_EXCEPTION];
 	if (!expdir->Size) {
 		return NULL;
-	}
-	if (bin->trycatch_list) {
-		return bin->trycatch_list;
 	}
 	ut64 dirsize = expdir->Size;
 	const ut64 filesize = bin->b? r_buf_size (bin->b): 0;
@@ -435,7 +622,11 @@ static RList *trycatch(RBinFile *bf) {
 		}
 		PE64_UNWIND_INFO info;
 		suc = read_unwind_info_at (io, rfcn.UnwindData + baseAddr, &info);
-		if (!suc || info.Version != 1 || (!(info.Flags & PE64_UNW_FLAG_EHANDLER) && !(info.Flags & PE64_UNW_FLAG_CHAININFO))) {
+		// UHANDLER shares the layout of EHANDLER, functions with a __finally
+		// and no __except only get the unwind handler flag
+		const ut8 handler_flags = PE64_UNW_FLAG_EHANDLER | PE64_UNW_FLAG_UHANDLER;
+		if (!suc || info.Version != 1
+				|| (!(info.Flags & handler_flags) && !(info.Flags & PE64_UNW_FLAG_CHAININFO))) {
 			continue;
 		}
 
@@ -478,7 +669,7 @@ static RList *trycatch(RBinFile *bf) {
 			if (!suc) {
 				continue;
 			}
-			if (!(info.Flags & PE64_UNW_FLAG_EHANDLER)) {
+			if (!(info.Flags & handler_flags)) {
 				continue;
 			}
 			rfcn.BeginAddress = savedBeginOff;
@@ -489,58 +680,27 @@ static RList *trycatch(RBinFile *bf) {
 		if (!read_u32_at (io, exceptionDataOff, &handler)) {
 			continue;
 		}
+		exceptionDataOff += sizeof (ut32);
+
+		if (handler != c_handler) {
+			// __CxxFrameHandler3 and __GSHandlerCheck_EH are followed by the
+			// rva of a FuncInfo structure describing the C++ try blocks
+			ut32 magic, rva_to_fcninfo;
+			if (read_u32_at (io, exceptionDataOff, &rva_to_fcninfo)
+					&& read_u32_at (io, baseAddr + rva_to_fcninfo, &magic)
+					&& is_cxx_magic (magic)) {
+				cxx_trycatch (bf, io, tclist, baseAddr, &rfcn, rva_to_fcninfo);
+				continue;
+			}
+		}
 		if (c_handler && c_handler != handler) {
 			continue;
 		}
-		exceptionDataOff += sizeof (ut32);
-
-		if (!c_handler) {
-			ut32 magic, rva_to_fcninfo;
-			if (read_u32_at (io, exceptionDataOff, &rva_to_fcninfo) &&
-				read_u32_at (io, baseAddr + rva_to_fcninfo, &magic)) {
-				if (magic >= 0x19930520 && magic <= 0x19930522) {
-					// __CxxFrameHandler3 or __GSHandlerCheck_EH
-					continue;
-				}
-			}
-		}
-
-		ut32 scope_count;
-		if (!read_u32_at (io, exceptionDataOff, &scope_count)) {
-			continue;
-		}
-
-		PE64_SCOPE_RECORD scope;
-		ut64 scopeRecOff = exceptionDataOff + sizeof (ut32);
-		ut32 i;
-		for (i = 0; i < scope_count; i++) {
-			if (!read_scope_record_at (io, scopeRecOff, &scope)) {
-				break;
-			}
-			if (scope.BeginAddress > scope.EndAddress
-				|| scope.BeginAddress == UT32_MAX || scope.EndAddress == UT32_MAX
-				|| !scope.BeginAddress || !scope.EndAddress) {
-				break;
-			}
-			if (!(scope.BeginAddress >= rfcn.BeginAddress - 1 && scope.BeginAddress < rfcn.EndAddress
-				&& scope.EndAddress <= rfcn.EndAddress + 1 && scope.EndAddress > rfcn.BeginAddress)) {
-				continue;
-			}
-			if (!scope.JumpTarget) {
-				// scope.HandlerAddress == __finally block
-				continue;
-			}
-			ut64 handlerAddr = scope.HandlerAddress == 1 ? 0 : scope.HandlerAddress + baseAddr;
-			RBinTrycatch *tc = r_bin_trycatch_new (
-				rfcn.BeginAddress + baseAddr,
-				scope.BeginAddress + baseAddr,
-				scope.EndAddress + baseAddr,
-				scope.JumpTarget + baseAddr,
-				handlerAddr
-			);
+		const int before = r_list_length (tclist);
+		seh_trycatch (io, tclist, baseAddr, &rfcn, exceptionDataOff);
+		if (r_list_length (tclist) != before) {
+			// the language specific handler of this binary is now known
 			c_handler = handler;
-			r_list_append (tclist, tc);
-			scopeRecOff += sizeof (PE64_SCOPE_RECORD);
 		}
 	}
 	return tclist;

--- a/libr/bin/p/bin_pe64.c
+++ b/libr/bin/p/bin_pe64.c
@@ -573,25 +573,25 @@ static RList *trycatch(RBinFile *bf) {
 	if (bin->trycatch_list) {
 		return bin->trycatch_list;
 	}
+	// managed methods carry their own exception clauses
+	RList *tclist = pe_trycatch (bf);
+	if (!tclist) {
+		return NULL;
+	}
 	if (!bin->nt_headers || bin->nt_headers->file_header.Machine != PE_IMAGE_FILE_MACHINE_AMD64) {
 		// The exception directory of ARM64 and other machines does not
 		// use the x86-64 RUNTIME_FUNCTION/UNWIND_INFO format parsed here
-		return NULL;
+		return tclist;
 	}
 	PE_(image_data_directory) *expdir = &bin->optional_header->DataDirectory[PE_IMAGE_DIRECTORY_ENTRY_EXCEPTION];
 	if (!expdir->Size) {
-		return NULL;
+		return tclist;
 	}
 	ut64 dirsize = expdir->Size;
 	const ut64 filesize = bin->b? r_buf_size (bin->b): 0;
 	if (dirsize > filesize) {
 		// RUNTIME_FUNCTION entries beyond the file contents can only be padding or garbage
 		dirsize = filesize;
-	}
-
-	RList *tclist = bin->trycatch_list = r_list_newf ((RListFree)r_bin_trycatch_free);
-	if (!tclist) {
-		return NULL;
 	}
 
 	for (offset = expdir->VirtualAddress; offset < (ut64)expdir->VirtualAddress + dirsize; offset += sizeof (PE64_RUNTIME_FUNCTION)) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -697,15 +697,21 @@ static void core_anal_fcn_trycatch(RCore *core, RAnalFunction *fcn) {
 	if (!core->anal->opt.trycatch) {
 		return;
 	}
-	char *suffix = r_str_newf (".%"PFMT64x".catch", fcn->addr);
-	if (!suffix) {
-		return;
-	}
-	TrycatchHandlerCollector ctx = {
-		.suffix = suffix,
-	};
+	// catch and filter handlers are entrypoints of the owning function, the
+	// cleanup ones only run while unwinding so they are left out on purpose
+	const char *kinds[] = { "catch", "filter" };
+	TrycatchHandlerCollector ctx = { 0 };
 	RVecUT64_init (&ctx.handlers);
-	r_flag_foreach_prefix (core->flags, "try.", 4, collect_trycatch_handler, &ctx);
+	size_t i;
+	for (i = 0; i < R_ARRAY_SIZE (kinds); i++) {
+		char *suffix = r_str_newf (".%"PFMT64x".%s", fcn->addr, kinds[i]);
+		if (!suffix) {
+			break;
+		}
+		ctx.suffix = suffix;
+		r_flag_foreach_prefix (core->flags, "try.", 4, collect_trycatch_handler, &ctx);
+		free (suffix);
+	}
 	ut64 *handler;
 	R_VEC_FOREACH (&ctx.handlers, handler) {
 		if (*handler == fcn->addr || r_anal_function_contains (fcn, *handler)) {
@@ -717,7 +723,6 @@ static void core_anal_fcn_trycatch(RCore *core, RAnalFunction *fcn) {
 		}
 	}
 	RVecUT64_fini (&ctx.handlers);
-	free (suffix);
 }
 
 static bool __core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth) {

--- a/test/db/anal/windows
+++ b/test/db/anal/windows
@@ -27,5 +27,7 @@ EXPECT=<<EOF
 |       :   0x7ff5d4981a7      5f             pop rdi
 |       `=< 0x7ff5d4981a8      e9cffdffff     jmp 0x7ff5d497f7c
 ..
+      ||    ;-- try.64.7ff5d49823c.from:
+      ||    ;-- try.64.7ff5d49823c.to:
 EOF
 RUN

--- a/test/db/formats/dotnet/trycatch
+++ b/test/db/formats/dotnet/trycatch
@@ -1,0 +1,174 @@
+NAME=dotnet: HelloWorld.dll - IL finally clauses
+FILE=bins/dotnet/HelloWorld.dll
+CMDS=<<EOF
+iwj~{}
+EOF
+EXPECT=<<EOF
+[
+  {
+    "index": 0,
+    "source": 268444096,
+    "from": 268444112,
+    "to": 268444139,
+    "handler": 268444139,
+    "filter": 0,
+    "kind": "cleanup"
+  },
+  {
+    "index": 1,
+    "source": 268444196,
+    "from": 268444285,
+    "to": 268444372,
+    "handler": 268444372,
+    "filter": 0,
+    "kind": "cleanup"
+  }
+]
+EOF
+RUN
+
+NAME=dotnet: HelloWorld.dll - trycatch flags
+FILE=bins/dotnet/HelloWorld.dll
+CMDS=<<EOF
+iw
+EOF
+EXPECT=<<EOF
+f try.0.100021c0.from=0x100021d0
+f try.0.100021c0.to=0x100021eb
+f try.0.100021c0.cleanup=0x100021eb
+f try.1.10002224.from=0x1000227d
+f try.1.10002224.to=0x100022d4
+f try.1.10002224.cleanup=0x100022d4
+EOF
+RUN
+
+NAME=dotnet: AStyleWhore.exe - typed IL catch clauses
+FILE=bins/cil/AStyleWhore.exe
+CMDS=<<EOF
+iwj~{}
+EOF
+EXPECT=<<EOF
+[
+  {
+    "index": 0,
+    "source": 4203244,
+    "from": 4203250,
+    "to": 4203298,
+    "handler": 4203298,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777278,
+    "type": "System.BadImageFormatException"
+  },
+  {
+    "index": 1,
+    "source": 4203244,
+    "from": 4203250,
+    "to": 4203298,
+    "handler": 4203325,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777280,
+    "type": "System.DllNotFoundException"
+  },
+  {
+    "index": 2,
+    "source": 4203244,
+    "from": 4203250,
+    "to": 4203298,
+    "handler": 4203345,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777279,
+    "type": "System.Exception"
+  },
+  {
+    "index": 3,
+    "source": 4203416,
+    "from": 4203422,
+    "to": 4203450,
+    "handler": 4203450,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777278,
+    "type": "System.BadImageFormatException"
+  },
+  {
+    "index": 4,
+    "source": 4203416,
+    "from": 4203422,
+    "to": 4203450,
+    "handler": 4203477,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777280,
+    "type": "System.DllNotFoundException"
+  },
+  {
+    "index": 5,
+    "source": 4203416,
+    "from": 4203422,
+    "to": 4203450,
+    "handler": 4203497,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 16777279,
+    "type": "System.Exception"
+  }
+]
+EOF
+RUN
+
+NAME=dotnet: ch22.exe - IL filter clause
+FILE=bins/pe/ch22.exe
+CMDS=<<EOF
+iwj~{[1]}
+EOF
+EXPECT=<<EOF
+{"index":1,"source":4204484,"from":4204592,"to":4204600,"handler":4204636,"filter":4204600,"kind":"filter","typeFilter":0}
+EOF
+RUN
+
+NAME=dotnet: mitigation_nothing.exe - IL exception clause kinds
+FILE=bins/pe/mitigation_nothing.exe
+CMDS=<<EOF
+iw~from~?
+iw~catch=~?
+iw~filter=~?
+iw~cleanup=~?
+EOF
+EXPECT=<<EOF
+22
+7
+4
+11
+EOF
+RUN
+
+NAME=dotnet: mscorlib.dll - IL exception clause kinds
+FILE=bins/pe/mscorlib.dll
+CMDS=<<EOF
+iw~from~?
+iw~catch=~?
+iw~filter=~?
+iw~cleanup=~?
+EOF
+EXPECT=<<EOF
+835
+323
+0
+512
+EOF
+RUN
+
+NAME=dotnet: mscorlib.dll - catch all and typed clauses
+FILE=bins/pe/mscorlib.dll
+CMDS=<<EOF
+iwj~{[3]}
+iwj~{[18]}
+EOF
+EXPECT=<<EOF
+{"index":3,"source":4204700,"from":4204728,"to":4204744,"handler":4204744,"filter":0,"kind":"catch","typeFilter":33554659,"type":"System.NullReferenceException"}
+{"index":18,"source":4240192,"from":4240206,"to":4240617,"handler":4240617,"filter":0,"kind":"catch","typeFilter":33554822,"type":"System.Object","catchAll":true}
+EOF
+RUN

--- a/test/db/formats/pe/seh_x64
+++ b/test/db/formats/pe/seh_x64
@@ -9,7 +9,15 @@ NAME=PE: seh_x64.exe - Get trycatchs as JSON
 FILE=bins/pe/seh_x64.exe
 CMDS=iwj~{[0]}
 EXPECT=<<EOF
-{"index":0,"source":5368713232,"from":5368713292,"to":5368713318,"handler":5368713318,"filter":0}
+{"index":0,"source":5368713232,"from":5368713292,"to":5368713318,"handler":5368713318,"filter":0,"kind":"catch","typeFilter":0}
+EOF
+RUN
+
+NAME=PE: seh_x64.exe - __except with a filter function
+FILE=bins/pe/seh_x64.exe
+CMDS=iwj~{[2]}
+EXPECT=<<EOF
+{"index":2,"source":5368713232,"from":5368713348,"to":5368713364,"handler":5368713364,"filter":5368716592,"kind":"filter","typeFilter":0}
 EOF
 RUN
 
@@ -25,18 +33,18 @@ f try.1.140001010.to=0x140001076
 f try.1.140001010.catch=0x140001076
 f try.2.140001010.from=0x140001084
 f try.2.140001010.to=0x140001094
-f try.2.140001010.catch=0x140001094
+f try.2.140001010.filter=0x140001094
 f try.3.140001170.from=0x140001192
 f try.3.140001170.to=0x1400011c6
-f try.3.140001170.catch=0x1400011c6
+f try.3.140001170.filter=0x1400011c6
 f try.4.14000132c.from=0x140001355
 f try.4.14000132c.to=0x14000145a
-f try.4.14000132c.catch=0x14000145a
+f try.4.14000132c.filter=0x14000145a
 f try.5.14000132c.from=0x14000148e
 f try.5.14000132c.to=0x1400014a0
-f try.5.14000132c.catch=0x14000145a
+f try.5.14000132c.filter=0x14000145a
 f try.6.1400015d0.from=0x1400015d7
 f try.6.1400015d0.to=0x140001661
-f try.6.1400015d0.catch=0x140001661
+f try.6.1400015d0.filter=0x140001661
 EOF
 RUN

--- a/test/db/formats/pe/trycatch
+++ b/test/db/formats/pe/trycatch
@@ -1,0 +1,107 @@
+NAME=PE64: kernel32.dll - SEH scope table kinds
+FILE=bins/pe/kernel32.dll
+CMDS=<<EOF
+iw~from~?
+iw~catch=~?
+iw~filter=~?
+iw~cleanup=~?
+EOF
+EXPECT=<<EOF
+148
+7
+52
+89
+EOF
+RUN
+
+NAME=PE64: dhcpssvc.dll - SEH scope table kinds
+FILE=bins/pe/dhcpssvc.dll
+CMDS=<<EOF
+iw~from~?
+iw~catch=~?
+iw~filter=~?
+iw~cleanup=~?
+EOF
+EXPECT=<<EOF
+66
+46
+9
+11
+EOF
+RUN
+
+NAME=PE64: kernel32.dll - __except and __finally regions
+FILE=bins/pe/kernel32.dll
+CMDS=<<EOF
+iwj~{[0]}
+iwj~{[3]}
+iwj~{[6]}
+EOF
+EXPECT=<<EOF
+{"index":0,"source":6442456588,"from":6442456666,"to":6442456816,"handler":6442605238,"filter":0,"kind":"cleanup"}
+{"index":3,"source":6442461416,"from":6442461499,"to":6442461725,"handler":6442605354,"filter":0,"kind":"cleanup"}
+{"index":6,"source":6442464484,"from":6442464538,"to":6442464679,"handler":6442464679,"filter":6442605461,"kind":"filter","typeFilter":0}
+EOF
+RUN
+
+NAME=PE64: hello_gs_x64.exe - __GSHandlerCheck_SEH regions
+FILE=bins/pe/hello_gs_x64.exe
+CMDS=<<EOF
+iwj~{[0]}
+iwj~{[4]}
+iwj~{[10]}
+EOF
+EXPECT=<<EOF
+{"index":0,"source":5368713676,"from":5368713717,"to":5368713978,"handler":5368713978,"filter":5368783488,"kind":"filter","typeFilter":0}
+{"index":4,"source":5368720976,"from":5368721006,"to":5368721016,"handler":5368783692,"filter":0,"kind":"cleanup"}
+{"index":10,"source":5368731884,"from":5368731902,"to":5368731910,"handler":5368731910,"filter":0,"kind":"catch","typeFilter":0}
+EOF
+RUN
+
+NAME=PE64: synthetic __CxxFrameHandler3 try/catch blocks
+FILE=malloc://2048
+CMDS=<<EOF
+wx 4d5a @ 0x0
+wx 4000000050450000648602 @ 0x3c
+wx f00022000b020e00000200000004000000000000001000000010000000000040010000000010000000020000060000000000000006000000000000000030000000040000000000000300000000001000000000000010000000000000000010000000000000100000000000000000000010 @ 0x54
+wx 2000000c @ 0xe1
+wx 2e746578740000000010000000100000000200000004 @ 0x148
+wx 200000602e726461746100000010000000200000000200000006 @ 0x16c
+wx 40000040 @ 0x194
+wx c3 @ 0x400
+wx 100000001100001020000000000000090000000012000020200000000000002205931902000000000000000100000050200000030000007020 @ 0x601
+wx 01000000020000009020 @ 0x658
+wx 100000ffffffff101000000000000040100000ffffffff000000000000000000000000b82000002000000060100000300000004000000000000000000000008010000030 @ 0x671
+wx 2e3f41564d794572726f724040 @ 0x6c8
+wtf .tmp_pe64cxx.exe 2048
+o .tmp_pe64cxx.exe
+iwj~{}
+rm .tmp_pe64cxx.exe
+EOF
+EXPECT=<<EOF
+[
+  {
+    "index": 0,
+    "source": 5368713216,
+    "from": 5368713232,
+    "to": 5368713280,
+    "handler": 5368713312,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 0,
+    "type": "MyError"
+  },
+  {
+    "index": 1,
+    "source": 5368713216,
+    "from": 5368713232,
+    "to": 5368713280,
+    "handler": 5368713344,
+    "filter": 0,
+    "kind": "catch",
+    "typeFilter": 0,
+    "catchAll": true
+  }
+]
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Review and fix of the PE side of `iw` now that the DWARF LSDA trycatch parser landed for ELF and Mach-O. The PE plugins only understood a subset of the x86-64 scope tables and reported everything as an unspecified `catch`, and `.NET` assemblies had no exception information at all.

**SEH scope tables (`bin_pe64.c`)**

- Fix the scope record cursor: `scopeRecOff` was only advanced when a record produced an entry, so the first skipped record made the walk re-read the same offset for the rest of the table and silently dropped everything after it. On `kernel32.dll` this went from 79 to 148 regions.
- Emit the `__finally` scopes (`JumpTarget == 0`) as `R_BIN_TRYCATCH_CLEANUP` instead of skipping them.
- Set the kind of the `__except` scopes: `HandlerAddress == 1` is `EXCEPTION_EXECUTE_HANDLER` so it is a plain `catch`, anything else is a `filter` and the filter function address is reported in the `filter` field (it used to resolve to the image base when the address was zero).
- Accept `UNW_FLAG_UHANDLER`, which shares the layout of `UNW_FLAG_EHANDLER` and is what a function with a `__finally` and no `__except` gets.
- Bound the scope count and split the walk into `seh_trycatch()`.

**MSVC C++ exception regions (`bin_pe64.c`)**

Functions protected by `__CxxFrameHandler3` / `__GSHandlerCheck_EH` used to be detected by their `FuncInfo` magic and then skipped. They are parsed now: the try block map gives the catch handlers, the ip-to-state map turns the `tryLow`/`tryHigh` state range into an address range, and the RTTI type descriptor gives the caught type (demangled when possible). A null type descriptor is reported as `catchAll`, matching what the LSDA parser does for `catch (...)`.

**CLR exception clauses (`bin_pe.inc.c`)**

New parser for the ECMA-335 II.25.4.5 method data sections, wired into both the `pe` and `pe64` plugins so 32 bit assemblies get it too. `normalize_dotnet_method_bodies()` already walked the IL method headers, so it now also records where the extra sections of a fat header start. Both the small and the fat clause formats are handled, and every clause kind is mapped: `catch` resolves the class token to a type name through the metadata (`System.Object` is reported as `catchAll`), `filter` reports the filter offset, and `finally` / `fault` become `cleanup`. `mscorlib.dll` yields 835 clauses.

**Analysis (`canal.c`)**

`core_anal_fcn_trycatch()` only collected the `try.*.catch` flags, so the `__except` bodies of a scope table stopped being analyzed once they got the `filter` kind. It looks at both kinds now. The `cleanup` handlers are deliberately left out: they only run while unwinding and folding them into the owning function changes the shape of every ELF and Mach-O function that has a destructor.

**Tests**

- `test/db/formats/pe/trycatch`: scope table kind counts on `kernel32.dll` and `dhcpssvc.dll`, the `__except` / `__finally` regions of `kernel32.dll` and `hello_gs_x64.exe`, and a synthetic `__CxxFrameHandler3` binary built with `wx` so the C++ path has coverage (no binary in radare2-testbins has a `FuncInfo`).
- `test/db/formats/dotnet/trycatch`: the finally clauses of `HelloWorld.dll`, the typed catch clauses of `AStyleWhore.exe`, the filter clause of `ch22.exe`, and the clause kinds plus a `catchAll` of `mscorlib.dll`.
- `test/db/formats/pe/seh_x64` updated for the new kinds and extended with a filter case.

Full suite: 16751 OK, no new failures against master on this machine.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Sw7nQWVoZ4hmorbTEm3Sm)_