### PR TITLE
Fix psj misclassifying ascii strings with zero padding as wide ##print

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -1481,6 +1481,13 @@ static char get_string_type(const ut8 *buf, ut64 len) {
 				needle++;
 				break;
 			}
+			if (!r) {
+				/* The classification describes the string at the start of
+				 * the buffer, so its NUL terminator ends the scan. Walking
+				 * on would reclassify the trailing zero padding as a wide
+				 * string and hide an ordinary ascii string. */
+				return str_type;
+			}
 			needle += rc;
 		}
 	}

--- a/test/db/cmd/cmd_psj
+++ b/test/db/cmd/cmd_psj
@@ -41,3 +41,14 @@ EXPECT=<<EOF
 {"string":"Hello World","offset":33624,"section":".rodata","length":11,"type":"ascii"}
 EOF
 RUN
+
+NAME=psj ascii with zero padding tail
+FILE=malloc://128
+CMDS=<<EOF
+wx 48656c6c6f20257300000000ffffffff
+psj
+EOF
+EXPECT=<<EOF
+{"string":"Hello %s","offset":0,"section":"unknown","length":8,"type":"ascii"}
+EOF
+RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
