### PR TITLE
Cut the analysis and test costs behind the tcc CI slowdown ##analysis

### DIFF
--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -671,24 +671,73 @@ static void warn_nonexec_map(RCore *core, ut64 at) {
 	}
 }
 
-typedef struct {
-	const char *suffix;
-	RVecUT64 handlers;
-} TrycatchHandlerCollector;
+static void trycatch_handlers_free(HtUPKv *kv) {
+	RVecUT64 *handlers = kv->value;
+	if (handlers) {
+		RVecUT64_free (handlers);
+	}
+}
 
+/* The try.* flags are named try.<idx>.<source>.<kind>, collect the catch and
+ * filter handlers of every source address in a single pass over the flags.
+ * Cleanup handlers only run while unwinding, so they are left out on purpose. */
 static bool collect_trycatch_handler(RFlagItem *flag, void *user) {
-	TrycatchHandlerCollector *ctx = user;
-	if (!r_str_endswith (flag->name, ctx->suffix)) {
+	HtUP *by_source = user;
+	const char *p = flag->name + strlen ("try.");
+	p = strchr (p, '.');
+	if (!p) {
 		return true;
 	}
+	p++;
+	char *end = NULL;
+	ut64 source = strtoull (p, &end, 16);
+	if (!end || *end != '.') {
+		return true;
+	}
+	const char *kind = end + 1;
+	if (strcmp (kind, "catch") && strcmp (kind, "filter")) {
+		return true;
+	}
+	RVecUT64 *handlers = ht_up_find (by_source, source, NULL);
+	if (!handlers) {
+		handlers = RVecUT64_new ();
+		if (!handlers || !ht_up_insert (by_source, source, handlers)) {
+			RVecUT64_free (handlers);
+			return true;
+		}
+	}
 	ut64 *handler;
-	R_VEC_FOREACH (&ctx->handlers, handler) {
+	R_VEC_FOREACH (handlers, handler) {
 		if (*handler == flag->addr) {
 			return true;
 		}
 	}
-	RVecUT64_push_back (&ctx->handlers, &flag->addr);
+	RVecUT64_push_back (handlers, &flag->addr);
 	return true;
+}
+
+R_API void r_core_anal_trycatch_index_reset(RCore *core) {
+	R_RETURN_IF_FAIL (core);
+	RCoreTrycatchIndex *idx = &core->trycatch_index;
+	ht_up_free (idx->by_source);
+	idx->by_source = NULL;
+	idx->bf = NULL;
+}
+
+static HtUP *trycatch_index_get(RCore *core) {
+	RCoreTrycatchIndex *idx = &core->trycatch_index;
+	RBinFile *bf = r_bin_cur (core->bin);
+	if (idx->by_source && idx->bf == bf) {
+		return idx->by_source;
+	}
+	r_core_anal_trycatch_index_reset (core);
+	idx->by_source = ht_up_new (NULL, trycatch_handlers_free, NULL);
+	if (!idx->by_source) {
+		return NULL;
+	}
+	idx->bf = bf;
+	r_flag_foreach_prefix (core->flags, "try.", 4, collect_trycatch_handler, idx->by_source);
+	return idx->by_source;
 }
 
 /* Exception handlers are not ordinary CFG successors. Analyze their entry
@@ -697,23 +746,16 @@ static void core_anal_fcn_trycatch(RCore *core, RAnalFunction *fcn) {
 	if (!core->anal->opt.trycatch) {
 		return;
 	}
-	// catch and filter handlers are entrypoints of the owning function, the
-	// cleanup ones only run while unwinding so they are left out on purpose
-	const char *kinds[] = { "catch", "filter" };
-	TrycatchHandlerCollector ctx = { 0 };
-	RVecUT64_init (&ctx.handlers);
-	size_t i;
-	for (i = 0; i < R_ARRAY_SIZE (kinds); i++) {
-		char *suffix = r_str_newf (".%"PFMT64x".%s", fcn->addr, kinds[i]);
-		if (!suffix) {
-			break;
-		}
-		ctx.suffix = suffix;
-		r_flag_foreach_prefix (core->flags, "try.", 4, collect_trycatch_handler, &ctx);
-		free (suffix);
+	HtUP *by_source = trycatch_index_get (core);
+	if (!by_source) {
+		return;
+	}
+	RVecUT64 *handlers = ht_up_find (by_source, fcn->addr, NULL);
+	if (!handlers) {
+		return;
 	}
 	ut64 *handler;
-	R_VEC_FOREACH (&ctx.handlers, handler) {
+	R_VEC_FOREACH (handlers, handler) {
 		if (*handler == fcn->addr || r_anal_function_contains (fcn, *handler)) {
 			continue;
 		}
@@ -722,7 +764,6 @@ static void core_anal_fcn_trycatch(RCore *core, RAnalFunction *fcn) {
 			R_LOG_DEBUG ("Cannot analyze exception handler at 0x%08"PFMT64x, *handler);
 		}
 	}
-	RVecUT64_fini (&ctx.handlers);
 }
 
 static bool __core_anal_fcn(RCore *core, ut64 at, ut64 from, int reftype, int depth) {

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -4065,6 +4065,8 @@ static bool bin_trycatch(RCore *core, PJ *pj, int mode) {
 	}
 	if (IS_MODE_SET (mode)) {
 		r_flag_space_pop (core->flags);
+		// the analysis caches these flags, they just changed under it
+		r_core_anal_trycatch_index_reset (core);
 	}
 	if (IS_MODE_JSON (mode)) {
 		pj_end (pj);

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -4065,7 +4065,6 @@ static bool bin_trycatch(RCore *core, PJ *pj, int mode) {
 	}
 	if (IS_MODE_SET (mode)) {
 		r_flag_space_pop (core->flags);
-		// the analysis caches these flags, they just changed under it
 		r_core_anal_trycatch_index_reset (core);
 	}
 	if (IS_MODE_JSON (mode)) {

--- a/libr/core/cmd_flag.inc.c
+++ b/libr/core/cmd_flag.inc.c
@@ -2339,6 +2339,7 @@ static int cmd_flag(void *data, const char *input) {
 		r_core_return_invalid_command (core, "f", *input);
 		break;
 	}
+	r_core_anal_trycatch_index_reset (core);
 	free (str);
 	return 0;
 }

--- a/libr/core/core.c
+++ b/libr/core/core.c
@@ -2849,6 +2849,7 @@ R_API void r_core_fini(RCore *c) {
 	free (c->theme);
 	free (c->themepath);
 	r_search_free (c->search);
+	r_core_anal_trycatch_index_reset (c);
 	r_flag_free (c->flags);
 	r_fs_free (c->fs);
 	r_egg_free (c->egg);

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -373,6 +373,14 @@ typedef struct r_core_esil_t {
 #define	R_CORE_ESIL_TRAP_REVERT	0x4
 #define	R_CORE_ESIL_TRAP_REVERT_CONFIG	0x8
 
+/* Lookup table for the exception handlers described by the try.* flags, so the
+ * analysis does not have to walk the whole flag table once per function. It is
+ * rebuilt whenever the trycatch flags are (re)generated for a bin file. */
+typedef struct r_core_trycatch_index_t {
+	RBinFile *bf; // bin file the index was built from, NULL when never built
+	HtUP *by_source; // ut64 source address -> RVecUT64 of handler addresses
+} RCoreTrycatchIndex;
+
 struct r_core_t {
 	RBin *bin;
 	RConfig *config;
@@ -404,6 +412,7 @@ struct r_core_t {
 	RLang *lang;
 	RDebug *dbg;
 	RFlag *flags;
+	RCoreTrycatchIndex trycatch_index;
 	RSearch *search;
 	RFS *fs;
 	RFSShell *rfs;
@@ -890,6 +899,7 @@ R_API void r_core_sysenv_end(RCore *core, const char *cmd);
 
 R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly);
 R_API void r_core_anal_plugin_data_refs(RCore *core);
+R_API void r_core_anal_trycatch_index_reset(RCore *core);
 // XXX dupe from r_bin.h
 /* bin.c */
 #define R_CORE_BIN_ACC_STRINGS	0x001

--- a/libr/include/r_core.h
+++ b/libr/include/r_core.h
@@ -374,8 +374,7 @@ typedef struct r_core_esil_t {
 #define	R_CORE_ESIL_TRAP_REVERT_CONFIG	0x8
 
 /* Lookup table for the exception handlers described by the try.* flags, so the
- * analysis does not have to walk the whole flag table once per function. It is
- * rebuilt whenever the trycatch flags are (re)generated for a bin file. */
+ * analysis does not have to walk the whole flag table once per function. */
 typedef struct r_core_trycatch_index_t {
 	RBinFile *bf; // bin file the index was built from, NULL when never built
 	HtUP *by_source; // ut64 source address -> RVecUT64 of handler addresses

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -4333,3 +4333,22 @@ ptr: 0x00000007
 ptr: 0x0000000f
 EOF
 RUN
+
+NAME=trycatch index follows flag changes
+FILE=malloc://32
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx c3 @ 0
+wx c3 @ 0x10
+f owner=0
+af @ 0
+f try.0.0.catch=0x10
+af-*
+af @ 0
+afbq @ 0
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000010
+EOF
+RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Three independent changes from digging into why the tcc jobs got slower. They can be reviewed separately.

---

### 1. `Index the trycatch flags instead of rescanning them per function ##analysis`

`aa61bab` added `core_anal_fcn_trycatch()`, which runs for every analyzed function and calls `r_flag_foreach_prefix()` twice. That helper is a linear walk of the whole flag table — `FOREACH_BODY` (`libr/flag/flag.c:1317`) traverses the `by_addr` skiplist and every flag list hanging off it — so analysis became `O(functions * flags)`, paid even by binaries with no exception regions at all.

Measured with `aaa`, against `8eb1011` (Aug 14):

| binary | fns / flags | before `aa61bab` | master | this PR |
|---|---|---|---|---|
| `/usr/lib/git-core/git` | 3332 / 19873 | 31.2s | 41.0s (+32%) | **30.0s** |
| `/usr/bin/python3.12` | 4322 / 59115 | 26.5s | 52.2s (+97%) | **25.5s** |

`git` spent 132M flag visits to find 4 `try.*` flags; `python3.12` 511M to find 19. Handlers are now collected in one pass keyed by bin file and looked up by function address. Which flags are honored does not change.

### 2. `Skip variable analysis in the glibc plt-local tests ##test`

`db/anal/plt-local` (added Aug 14) is the **slowest file in the suite**: 21s of the ~510s the db costs single threaded, 17s of it one test running `aa` over a 2.1MB `libc-2.31.so` to assert five `sym.plt.*` names. `aa` spends 79% of its time in `r_anal_extract_vars()` there. Disabling `anal.vars` for the two large glibc binaries leaves the output byte-identical: **21.0s → 7.7s**, 26 OK.

### 3. `Don't size the print block from a pf/pm/pa argument ##print`

`cmd_print()` parses whatever follows the first space as a length via `r_num_math()` and allocates that many bytes. `pf`/`pm`/`pa` take a format string or a filename — not a length — and `[N]` is r2's dereference operator, so the size gets read out of the target:

```
b 16
w ABCDEFGHIJKLMNOPQRSTUVWXYZ
pf [20]b
```

`[20]` derefs offset 0x14, now holding `"UVWXYZ\0\0"`; truncated to `int` that is **1482118741**, so printing 20 bytes of a 64-byte file callocs and faults in **1.48GB** (massif confirms the peak is exactly 1482118741 B). Without the write it derefs zeroes and costs nothing, which is why it only appears in tests that write first.

None of these three handlers read the block, so the length is clamped back to the blocksize for them. `pf [20]b`: **4.88s / 364k faults → 0.02s / 2.2k faults**, same output. `pi` and `pt` have the same shape but genuinely use the value as an extent of the block, so they are left alone — `pi [20]b` currently hangs while holding ~5GB, and `pt [20]b` still peaks at ~1.4GB.

---

**Testing**

Full `r2r db` results are unchanged across all three changes. The 2 XX are `db/cmd/cmd_pipe` and `db/cmd/shell`, which fail identically on an unpatched Aug-14 build here (environment-dependent), and the FX set is pre-existing.

**Honest accounting of the tcc times**

Since this started from "3m20s → 4m30s":

- **Test corpus growth dominates.** Same binary, Aug 5 corpus vs today's: `5m37s → 6m31s` user, **+16% CPU**, against only +5.5% more cases (7531 → 7944). `plt-local` alone was ~39% of that growth, which change 2 mostly reclaims.
- **r2 itself has barely moved.** Same corpus, Aug 14 binary vs today's: `5m37s → 5m48s`. Startup and load are identical, and `aa` on libc was already 16.3s on Aug 5 (16.7s Aug 14, 17.7s now) — long-standing, not a regression; `plt-local` merely started exercising it.
- **Change 3 is a correctness/robustness fix first.** Only a couple of tests deref onto non-zero data, so its suite-level effect is inside the noise; the value is removing an unbounded allocation driven by target contents.
- **Machine variance swamps all of it.** This box went from `8m25s` to `12m17s` user on identical committed code between runs today — so only paired back-to-back measurements above are meaningful. The same applies to CI: the `Run tests` step of `ubuntu-tcc-test` ranges 3m04s–4m36s across master pushes regardless of these commits, and `Checkout our Testsuite Binaries` alone swings from 10s to 3m50s.
- Capstone (`7996257`) is not implicated: rebuilt with its exact before/after pins, ~2% on a disassembly-heavy `aaa`.

So ~3m20s × 1.16 ≈ 3m52s from tests, and the rest is scheduling noise. The remaining levers are the corpus itself and caching the `test/bins` checkout, not the analysis code.