### PR TITLE
Fix #26600 - Reject non-scheme bytes in RBinInfo->bclass URI redirect

### DIFF
--- a/libr/bin/p/bin_io.c
+++ b/libr/bin/p/bin_io.c
@@ -41,10 +41,9 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->file = strdup (bf->file);
 	ret->type = strdup ("IO");
 	ret->machine = strdup ("IO");
-	ut8 tmp[32];
-	r_buf_read_at (bf->buf, 0x100, tmp, sizeof (tmp));
-	ret->bclass = r_str_ndup ((char *)tmp, 32);
-	r_str_sanitize (ret->bclass);
+	// CVE-fix: never place attacker-controlled bytes in bclass — it is
+    // interpreted as an IO URI scheme in r_core_file_load_for_io_plugin.
+    ret->bclass = strdup ("io");
 	ret->os = strdup ("io");
 	ret->arch = strdup ("arm");
 	ret->bits = 64;

--- a/libr/bin/p/bin_pebble.c
+++ b/libr/bin/p/bin_pebble.c
@@ -200,8 +200,9 @@ static RBinInfo* info(RBinFile *bf) {
 	RBinInfo *ret = R_NEW0 (RBinInfo);
 	ret->file = strdup (bf->file);
 	ret->type = strdup ("pebble");
-	ret->bclass = r_str_ndup (pai.name, 32);
-	r_str_sanitize (ret->bclass);
+	// CVE-fix: never place attacker-controlled bytes in bclass — it is
+    // interpreted as an IO URI scheme in r_core_file_load_for_io_plugin.
+	ret->bclass = strdup ("app");
 	ret->rclass = r_str_ndup (pai.company, 32);
 	ret->os = strdup ("pebble");
 	ret->subsystem = strdup ("pebble");

--- a/libr/bin/p/bin_smd.c
+++ b/libr/bin/p/bin_smd.c
@@ -113,10 +113,9 @@ static RBinInfo *info(RBinFile *bf) {
 	ret->file = strdup (bf->file);
 	ret->type = strdup ("ROM");
 	ret->machine = strdup ("Sega Megadrive");
-	ut8 tmp[32];
-	r_buf_read_at (bf->buf, 0x100, tmp, sizeof (tmp));
-	ret->bclass = r_str_ndup ((char *)tmp, 32);
-	r_str_sanitize (ret->bclass);
+	// CVE-fix: never place attacker-controlled bytes in bclass — it is
+    // interpreted as an IO URI scheme in r_core_file_load_for_io_plugin.
+    ret->bclass = strdup ("rom");
 	ret->os = strdup ("smd");
 	ret->arch = strdup ("m68k");
 	ret->bits = 32;

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -539,94 +539,102 @@ static int r_core_file_load_for_debug(RCore *r, ut64 baseaddr, const char * R_NU
 }
 
 static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr) {
-	RIODesc *cd = r->io->desc;
-	int fd = cd ? cd->fd : -1;
-	int xtr_idx = 0; // if 0, load all if xtr is used
-	RBinPlugin *plugin;
+    RIODesc *cd = r->io->desc;
+    int fd = cd ? cd->fd : -1;
+    int xtr_idx = 0; // if 0, load all if xtr is used
+    RBinPlugin *plugin;
 
-	if (fd < 0) {
-		return false;
-	}
-	R_CRITICAL_ENTER (r);
-	r_io_use_fd (r->io, fd);
-	if (baseaddr == UT64_MAX) {
-		if (r->bin->options.aslr) {
-			baseaddr = ((ut64)r_num_rand (32)) << 24;
-			r_config_set_i (r->config, "bin.baddr", baseaddr);
-		}
-	}
-	RBinFileOptions opt;
-	r_bin_file_options_init (&opt, fd, baseaddr, loadaddr, r->bin->options.rawstr);
-	// opt.fd = fd;
-	opt.xtr_idx = xtr_idx;
-	if (!r_bin_open_io (r->bin, &opt)) {
-		R_CRITICAL_LEAVE (r);
-		return false;
-	}
-	RBinFile *bf = r_bin_cur (r->bin);
-	if (r_core_bin_set_env (r, bf)) {
-		if (r->anal->verbose && !sdb_const_get (r->anal->sdb_cc, "default.cc", 0)) {
-			R_LOG_WARN ("No calling convention defined for this file, analysis may be inaccurate");
-		}
-	}
-	if (bf) {
-		const char *bclass = R_UNWRAP4 (bf, bo, info, bclass);
-		if (bclass && strstr (bclass, "://")) {
-			if (bf->file && strstr (bf->file, "://")) {
-				R_LOG_ERROR ("Skipping IO redirection for already-redirected file");
-				R_CRITICAL_LEAVE (r);
-				return false;
-			}
-			char *uri = r_str_newf ("%s%s", bclass, bf->file);
-			RIOPlugin *iop = r_io_plugin_resolve (r->io, uri, false);
-			if (iop && strcmp (iop->meta.name, "default")) {
-				r_bin_file_delete_all (r->bin);
-				RIODesc *desc = r_core_file_open (r, uri, R_PERM_R, 0);
-				if (desc) {
-					r_core_bin_load (r, uri, UT64_MAX);
-					free (uri);
-					R_CRITICAL_LEAVE (r);
-					return true;
-				}
-			} else {
-				R_LOG_WARN ("bclass URI scheme has no matching IO plugin");
-			}
-			free (uri);
-			R_CRITICAL_LEAVE (r);
-			return false;
-		}
-	}
-	plugin = r_bin_file_cur_plugin (bf);
-	if (plugin && !strcmp (plugin->meta.name, "null")) {
-		RBinObject *obj = r_bin_cur_object (r->bin);
-		RBinInfo *info = obj? obj->info: NULL;
-		if (!info) {
-			R_CRITICAL_LEAVE (r);
-			return false;
-		}
-		// set use of raw strings
-		// r_config_set_i (r->config, "io.va", false);
-		// r_config_set_b (r->config, "bin.str.raw", true);
-		// get bin.str.min
-		r->bin->options.minstrlen = r_config_get_i (r->config, "bin.str.min");
-		r->bin->options.maxstrbuf = r_config_get_i (r->config, "bin.str.maxbuf");
-	} else if (bf) {
-		RBinObject *obj = r_bin_cur_object (r->bin);
-		RBinInfo *info = obj? obj->info: NULL;
-		if (!info) {
-			R_CRITICAL_LEAVE (r);
-			return false;
-		}
-		if (plugin) {
-			r_core_bin_set_arch_bits (r, bf->file, info->arch, info->bits);
-		}
-	}
+    if (fd < 0) {
+        return false;
+    }
+    R_CRITICAL_ENTER (r);
+    r_io_use_fd (r->io, fd);
+    if (baseaddr == UT64_MAX) {
+        if (r->bin->options.aslr) {
+            baseaddr = ((ut64)r_num_rand (32)) << 24;
+            r_config_set_i (r->config, "bin.baddr", baseaddr);
+        }
+    }
+    RBinFileOptions opt;
+    r_bin_file_options_init (&opt, fd, baseaddr, loadaddr, r->bin->options.rawstr);
+    opt.xtr_idx = xtr_idx;
+    if (!r_bin_open_io (r->bin, &opt)) {
+        R_CRITICAL_LEAVE (r);
+        return false;
+    }
+    RBinFile *bf = r_bin_cur (r->bin);
+    if (r_core_bin_set_env (r, bf)) {
+        if (r->anal->verbose && !sdb_const_get (r->anal->sdb_cc, "default.cc", 0)) {
+            R_LOG_WARN ("No calling convention defined for this file, analysis may be inaccurate");
+        }
+    }
+    if (bf) {
+        const char *bclass = R_UNWRAP4 (bf, bo, info, bclass);
+        if (bclass && r_str_endswith (bclass, "://")) {
+            const char *sep = strstr (bclass, "://");
+            bool scheme_only = true;
+            for (const char *p = bclass; p < sep; p++) {
+                if (!(isalnum ((unsigned char)*p) || *p == '+' || *p == '-' || *p == '.')) {
+                    scheme_only = false;
+                    break;
+                }
+            }
+            if (!scheme_only || sep == bclass) {
+                R_LOG_WARN ("Ignoring bclass URI redirect: not a bare scheme://");
+                R_CRITICAL_LEAVE (r);
+                return false;
+            }
+            if (bf->file && strstr (bf->file, "://")) {
+                R_LOG_ERROR ("Skipping IO redirection for already-redirected file");
+                R_CRITICAL_LEAVE (r);
+                return false;
+            }
+            char *uri = r_str_newf ("%s%s", bclass, bf->file);
+            RIOPlugin *iop = r_io_plugin_resolve (r->io, uri, false);
+            if (iop && strcmp (iop->meta.name, "default")) {
+                r_bin_file_delete_all (r->bin);
+                RIODesc *desc = r_core_file_open (r, uri, R_PERM_R, 0);
+                if (desc) {
+                    r_core_bin_load (r, uri, UT64_MAX);
+                    free (uri);
+                    R_CRITICAL_LEAVE (r);
+                    return true;
+                }
+            } else {
+                R_LOG_WARN ("bclass URI scheme has no matching IO plugin");
+            }
+            free (uri);
+            R_CRITICAL_LEAVE (r);
+            return false;
+        }
+    }
+    plugin = r_bin_file_cur_plugin (bf);
+    if (plugin && !strcmp (plugin->meta.name, "null")) {
+        RBinObject *obj = r_bin_cur_object (r->bin);
+        RBinInfo *info = obj? obj->info: NULL;
+        if (!info) {
+            R_CRITICAL_LEAVE (r);
+            return false;
+        }
+        r->bin->options.minstrlen = r_config_get_i (r->config, "bin.str.min");
+        r->bin->options.maxstrbuf = r_config_get_i (r->config, "bin.str.maxbuf");
+    } else if (bf) {
+        RBinObject *obj = r_bin_cur_object (r->bin);
+        RBinInfo *info = obj? obj->info: NULL;
+        if (!info) {
+            R_CRITICAL_LEAVE (r);
+            return false;
+        }
+        if (plugin) {
+            r_core_bin_set_arch_bits (r, bf->file, info->arch, info->bits);
+        }
+    }
 
-	if (plugin && !strcmp (plugin->meta.name, "dex")) {
-		r_core_cmd0 (r, "'(fix-dex;wx `ph sha1 $s-32 @32` @12 ; wx `ph adler32 $s-12 @12` @8)");
-	}
-	R_CRITICAL_LEAVE (r);
-	return true;
+    if (plugin && !strcmp (plugin->meta.name, "dex")) {
+        r_core_cmd0 (r, "'(fix-dex;wx `ph sha1 $s-32 @32` @12 ; wx `ph adler32 $s-12 @12` @8)");
+    }
+    R_CRITICAL_LEAVE (r);
+    return true;
 }
 
 static bool try_loadlib(RCore *core, const char *lib, ut64 addr) {


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

## Description

In order to fix the RCE caused by unsanitized bytes flowing from Pebble/SMD/IO bin plugins into `RBinInfo->bclass`, the URI redirect in `r_core_file_load_for_io_plugin` (`libr/core/cfile.c`) now accepts a `bclass` value only when it is a bare `scheme://` — validated with `r_str_endswith("://")` plus an RFC 3986 scheme-char check (`ALPHA / DIGIT / "+" / "-" / "."`). Any payload after `://` is rejected with a WARN log. `bin_uf2`'s legitimate `"uf2://"` redirect still passes.

As a second layer, three bin plugins (`bin_pebble`, `bin_smd`, `bin_io`) no longer place attacker-controlled bytes in `bclass`. They now emit fixed short labels (`"app"`, `"rom"`, `"io"`), matching the convention already used by `bin_coff`, `bin_pe`, `bin_kernelcache`, etc.

The chain (also described in issue #26600):

1. `libr/bin/p/bin_pebble.c` copies 32 raw bytes of `PebbleAppInfo.name` into `bclass`.
2. `r_str_sanitize` denylist misses `:`, `/`, and space.
3. `libr/core/cfile.c` treats any `bclass` containing `://` as an IO URI and re-opens `bclass + bf->file`.
4. `dbg://<cmd>` reaches `io_debug`'s `fork_and_ptraceme` → `r_str_argv` → `execvp`.

Default sandbox is off, so no user command or flag is required — plain `r2 <untrusted.pbl>` is enough.

I have a 160-byte PoC `.pbl` that spawns `mate-calc`. Happy to attach it if useful.

## Before
```
$ r2 -q -c q /tmp/r2poc/poc.pbl &
$ pgrep -af mate-calc
2028132       1 /bin/sh -c mate-calc /tmp/r2poc/poc.pbl
2028141 2028132 mate-calc
```

## After

```
$ ./build/binr/radare2/radare2 -q -c q /tmp/r2poc/poc.pbl
$ pgrep -c mate-calc
0
$ ./build/binr/radare2/radare2 -q -c 'i~format' /tmp/r2poc/poc.pbl
format   pebble
```

the `poc.pbl` can also be generated from issue #26600
[poc.pbl.zip](https://github.com/user-attachments/files/31588722/poc.pbl.zip)
