### PR TITLE
Fix #26600 - Restrict bclass IO redirection to a bare URI scheme ##bin

### DIFF
--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -538,38 +538,6 @@ static int r_core_file_load_for_debug(RCore *r, ut64 baseaddr, const char * R_NU
 	return true;
 }
 
-// A bin plugin may request IO redirection by exposing a URI scheme in
-// RBinInfo.bclass (see bin_uf2.c: "uf2://"). Only a self-contained scheme
-// token is trusted here: an identifier-only scheme immediately followed by
-// "://" at the end of the string. This is deliberately strict: some bin
-// plugins fill bclass with raw, attacker-controlled bytes from the parsed
-// file (name/company/header fields), and treating those as an openable URI
-// allowed a crafted file to inject arguments into IO plugins such as
-// dbg:// -> execvp (arbitrary command execution). Requiring a bare scheme
-// makes it impossible to smuggle spaces, extra path components or a command
-// payload through bclass, regardless of which plugin the scheme resolves to.
-static bool is_bin_redirect_scheme(const char *s) {
-	if (R_STR_ISEMPTY (s)) {
-		return false;
-	}
-	const char *p = s;
-	// scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), non-empty
-	if (!isalpha ((unsigned char)*p)) {
-		return false;
-	}
-	for (; *p; p++) {
-		const char c = *p;
-		if (c == ':') {
-			break;
-		}
-		if (!isalnum ((unsigned char)c) && c != '+' && c != '-' && c != '.') {
-			return false;
-		}
-	}
-	// must be exactly "<scheme>://" with nothing trailing
-	return !strcmp (p, "://");
-}
-
 static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr) {
 	RIODesc *cd = r->io->desc;
 	int fd = cd ? cd->fd : -1;
@@ -603,15 +571,16 @@ static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr
 	}
 	if (bf) {
 		const char *bclass = R_UNWRAP4 (bf, bo, info, bclass);
-		if (bclass && strstr (bclass, "://") && !is_bin_redirect_scheme (bclass)) {
-			// bclass contains "://" but is not a bare, trusted URI scheme
-			// (likely raw bytes from the parsed file: an app/company name,
-			// header field, etc). Do not open it as a URI: fall through to
-			// normal loading of the already-opened file.
-			R_LOG_DEBUG ("Ignoring untrusted bclass IO redirection: %s", bclass);
-			bclass = NULL;
-		}
-		if (bclass && strstr (bclass, "://")) {
+		if (bclass && r_str_endswith (bclass, "://")) {
+			// only redirect on a bare "scheme://": r_name_check rejects attacker bytes with shell or uri metachars
+			char *scheme = r_str_ndup (bclass, strlen (bclass) - 3);
+			bool bare = scheme && r_name_check (scheme);
+			free (scheme);
+			if (!bare) {
+				R_LOG_WARN ("Ignoring bclass IO redirect: not a bare scheme://");
+				R_CRITICAL_LEAVE (r);
+				return false;
+			}
 			if (bf->file && strstr (bf->file, "://")) {
 				R_LOG_ERROR ("Skipping IO redirection for already-redirected file");
 				R_CRITICAL_LEAVE (r);

--- a/libr/core/cfile.c
+++ b/libr/core/cfile.c
@@ -538,6 +538,38 @@ static int r_core_file_load_for_debug(RCore *r, ut64 baseaddr, const char * R_NU
 	return true;
 }
 
+// A bin plugin may request IO redirection by exposing a URI scheme in
+// RBinInfo.bclass (see bin_uf2.c: "uf2://"). Only a self-contained scheme
+// token is trusted here: an identifier-only scheme immediately followed by
+// "://" at the end of the string. This is deliberately strict: some bin
+// plugins fill bclass with raw, attacker-controlled bytes from the parsed
+// file (name/company/header fields), and treating those as an openable URI
+// allowed a crafted file to inject arguments into IO plugins such as
+// dbg:// -> execvp (arbitrary command execution). Requiring a bare scheme
+// makes it impossible to smuggle spaces, extra path components or a command
+// payload through bclass, regardless of which plugin the scheme resolves to.
+static bool is_bin_redirect_scheme(const char *s) {
+	if (R_STR_ISEMPTY (s)) {
+		return false;
+	}
+	const char *p = s;
+	// scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), non-empty
+	if (!isalpha ((unsigned char)*p)) {
+		return false;
+	}
+	for (; *p; p++) {
+		const char c = *p;
+		if (c == ':') {
+			break;
+		}
+		if (!isalnum ((unsigned char)c) && c != '+' && c != '-' && c != '.') {
+			return false;
+		}
+	}
+	// must be exactly "<scheme>://" with nothing trailing
+	return !strcmp (p, "://");
+}
+
 static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr) {
 	RIODesc *cd = r->io->desc;
 	int fd = cd ? cd->fd : -1;
@@ -571,6 +603,14 @@ static int r_core_file_load_for_io_plugin(RCore *r, ut64 baseaddr, ut64 loadaddr
 	}
 	if (bf) {
 		const char *bclass = R_UNWRAP4 (bf, bo, info, bclass);
+		if (bclass && strstr (bclass, "://") && !is_bin_redirect_scheme (bclass)) {
+			// bclass contains "://" but is not a bare, trusted URI scheme
+			// (likely raw bytes from the parsed file: an app/company name,
+			// header field, etc). Do not open it as a URI: fall through to
+			// normal loading of the already-opened file.
+			R_LOG_DEBUG ("Ignoring untrusted bclass IO redirection: %s", bclass);
+			bclass = NULL;
+		}
 		if (bclass && strstr (bclass, "://")) {
 			if (bf->file && strstr (bf->file, "://")) {
 				R_LOG_ERROR ("Skipping IO redirection for already-redirected file");


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Fixes #26600 — RCE via a crafted file whose parsed metadata reaches `execvp` through IO redirection.

### Root cause

A bin plugin can request IO redirection by exposing a URI scheme in `RBinInfo.bclass` — the intended user is `bin_uf2` (`bclass = "uf2://"`). `r_core_file_load_for_io_plugin()` trusted **any** `bclass` containing `://`, concatenated it with the file path and reopened the result as an IO URI:

```c
char *uri = r_str_newf ("%s%s", bclass, bf->file);   // bclass + path
RIODesc *desc = r_core_file_open (r, uri, R_PERM_R, 0);
```

But several plugins fill `bclass` with **raw, attacker-controlled bytes** from the parsed file:
- `bin_pebble.c` — 32-byte app `name` field
- `bin_smd.c` — Megadrive header
- `bin_io.c` — 32 bytes at buffer offset `0x100`

`r_str_sanitize()` is a denylist that does not strip `:`, `/` or space. So a crafted file can set `bclass` to e.g. `dbg:///bin/sh -c CMD ` and, on a plain `r2 file` open (no flags, no user commands), reach `io_debug`'s `fork()` + `execvp()` with attacker-chosen arguments. The sandbox is off by default, so nothing blocks it — arbitrary command execution. Any tool that runs `r2` on untrusted input (Cutter, iaito, r2ai, CI pipelines) inherits it.

### Fix

Restrict `bclass` IO redirection to a **self-contained URI scheme token**: an identifier-only scheme (`[A-Za-z][A-Za-z0-9+.-]*`) immediately followed by `://` at the very end of the string. A new helper `is_bin_redirect_scheme()` gates the redirection; a `bclass` that contains `://` but fails the check is treated as untrusted data and the loader falls through to normal loading of the already-opened file.

This is a generic, root-cause fix rather than a per-plugin patch:
- After it, the only part of the redirect URI an attacker can influence is a bare scheme name — every path/argument comes solely from the victim's own file path (`bf->file`). Argument/command injection is structurally impossible for **any** IO plugin (`dbg://` included), covering the three reported plugins and any future one.
- The intended `uf2://` handoff is preserved unchanged.

### Testing

Verified the vulnerable chain and the fix by source analysis. The diff is a single, self-contained change to `libr/core/cfile.c` (+40 lines, no existing lines modified). Note: this branch was prepared in an environment where a local build could not be run, so please let CI confirm the build; the new code uses only APIs already present in `libr/core` (`isalpha`/`isalnum`, `R_STR_ISEMPTY`, `R_LOG_DEBUG`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBoyx4U1HWLZCxZupQrD5H)_