### PR TITLE
docs: fix typo unkown -> unknown

### DIFF
--- a/sys/lint.py
+++ b/sys/lint.py
@@ -282,7 +282,7 @@ CHECKS = [
 		[L(b"strbuf_append (")],
 		filters=[(rb"\"", True), (rb"%", True)]),
 	Check("typo-unkown",
-		[L(b"unkown")], icase=True),
+		[L(b"unknown")], icase=True),
 	Check("eq-zero",
 		[L(b"=0")],
 		filters=[(rb"c:", True), (rb"\"", False), (rb"//", False), (rb"=0x", False)]),


### PR DESCRIPTION
Corrects the misspelling `unkown` -> `unknown` in `sys/lint.py`.

Documentation only, no behaviour change.