### PR TITLE
Fix #23362 silent math errors in cmd_seek by utilizing r_num_math_err ##refactor

### DIFF
--- a/libr/core/cmd_seek.inc.c
+++ b/libr/core/cmd_seek.inc.c
@@ -442,12 +442,9 @@ static void cmd_sf(RCore *core, const char *input) {
 	if (sp) {
 		const char *err = NULL;
 		ut64 naddr = r_num_math_err (core->num, sp + 1, &err);
-		if (err) {
-			R_LOG_ERROR ("Invalid address: %s", err);
-			return;
+		if (!err) {
+			fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
 		}
-		fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
-		// TODO: check if function doesnt exist maybe?
 	}
 	switch (input[1]) {
 	case '\0': // "sf"
@@ -457,12 +454,12 @@ static void cmd_sf(RCore *core, const char *input) {
 			R_LOG_ERROR ("Cannot find function here");
 		}
 		break;
-	case 'x': // "sf0"
+	case '0': // "sf0"
 		if (input[2] == 'x') {
 			const char *err = NULL;
 			ut64 naddr = r_num_math_err (core->num, input + 1, &err);
 			if (err) {
-				R_LOG_ERROR ("Invalid address: %s", err);
+				R_LOG_ERROR ("Cannot seek to unknown address '%s' (%s)", input + 1, err);
 				return;
 			}
 			fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
@@ -480,7 +477,7 @@ static void cmd_sf(RCore *core, const char *input) {
 			const char *err = NULL;
 			ut64 naddr = r_num_math_err (core->num, input + 2, &err);
 			if (err) {
-				R_LOG_ERROR ("Invalid address: %s", err);
+				R_LOG_ERROR ("Cannot seek to unknown address '%s' (%s)", input + 2, err);
 				return;
 			}
 			fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
@@ -623,8 +620,25 @@ static int cmd_seek(void *data, const char *input) {
 	}
 	const char *inputnum = strchr (input, ' ');
 	if (!r_str_startswith (input, "ort")) { // hack to handle Invalid Argument for sort
-		const char *u_num = inputnum? inputnum + 1: input + 1;
-		off = r_num_math (core->num, u_num);
+		const char *u_num;
+		if (inputnum) {
+			u_num = inputnum + 1;
+		} else if (input[0] == '+' || input[0] == '-' || input[0] == '*' || input[0] == '/' || input[0] == 'b') {
+			u_num = input + 1;
+		} else {
+			u_num = input;
+		}
+		const char *err = NULL;
+		off = r_num_math_err (core->num, u_num, &err);
+		if (err && (*input == ' ' || *input == '+' || *input == '-' || *input == 'b' || (*input >= '0' && *input <= '9'))) {
+			if (strchr (u_num, '?') != NULL) {
+				off = 0; // Fall through for help queries like s+?
+			} else {
+				R_LOG_ERROR ("Cannot seek to unknown address '%s' (%s)", u_num, err);
+				r_core_return_value (core, R_CMD_RC_FAILURE);
+				return 0;
+			}
+		}
 		if (*u_num == '-') {
 			off = -(st64)off;
 		}
@@ -751,19 +765,10 @@ static int cmd_seek(void *data, const char *input) {
 	case '9': // "s9"
 	case ' ': // "s "
 	{
-		const char *trimin = r_str_trim_head_ro (input);
-		const char *err = NULL;
-		ut64 addr = r_num_math_err (core->num, trimin, &err);
-		if (err) {
-			if (core->cons->context->is_interactive) {
-				R_LOG_ERROR ("Cannot seek to unknown address '%s'", trimin);
-			}
-			break;
-		}
 		if (!silent) {
 			r_io_sundo_push (core->io, core->addr, r_print_get_cursor (core->print));
 		}
-		r_core_seek (core, addr, true);
+		r_core_seek (core, off, true);
 		r_core_block_read (core);
 	}
 	break;

--- a/libr/core/cmd_seek.inc.c
+++ b/libr/core/cmd_seek.inc.c
@@ -440,8 +440,12 @@ static void cmd_sf(RCore *core, const char *input) {
 	const char *sp = strchr (input, ' ');
 	RAnalFunction *fcn = NULL;
 	if (sp) {
-		ut64 naddr = r_num_math (core->num, sp + 1);
-		// TODO: check for rnum errors and break early
+		const char *err = NULL;
+		ut64 naddr = r_num_math_err (core->num, sp + 1, &err);
+		if (err) {
+			R_LOG_ERROR ("Invalid address: %s", err);
+			return;
+		}
 		fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
 		// TODO: check if function doesnt exist maybe?
 	}
@@ -455,8 +459,12 @@ static void cmd_sf(RCore *core, const char *input) {
 		break;
 	case 'x': // "sf0"
 		if (input[2] == 'x') {
-			ut64 naddr = r_num_math (core->num, input + 1);
-			// TODO: check for rnum errors and break early
+			const char *err = NULL;
+			ut64 naddr = r_num_math_err (core->num, input + 1, &err);
+			if (err) {
+				R_LOG_ERROR ("Invalid address: %s", err);
+				return;
+			}
 			fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
 			if (fcn) {
 				r_core_seek (core, fcn->addr, true);
@@ -469,8 +477,12 @@ static void cmd_sf(RCore *core, const char *input) {
 		break;
 	case ' ': // "sf "
 		if (input[2] == '0') {
-			ut64 naddr = r_num_math (core->num, input + 2);
-			// TODO: check for rnum errors and break early
+			const char *err = NULL;
+			ut64 naddr = r_num_math_err (core->num, input + 2, &err);
+			if (err) {
+				R_LOG_ERROR ("Invalid address: %s", err);
+				return;
+			}
 			fcn = r_anal_get_fcn_in (core->anal, naddr, 0);
 		} else {
 			fcn = r_anal_get_function_byname (core->anal, input + 2);
@@ -740,8 +752,9 @@ static int cmd_seek(void *data, const char *input) {
 	case ' ': // "s "
 	{
 		const char *trimin = r_str_trim_head_ro (input);
-		ut64 addr = r_num_math (core->num, trimin);
-		if (core->num->nc.errors) { // TODO expose an api for this char *r_num_failed();
+		const char *err = NULL;
+		ut64 addr = r_num_math_err (core->num, trimin, &err);
+		if (err) {
 			if (core->cons->context->is_interactive) {
 				R_LOG_ERROR ("Cannot seek to unknown address '%s'", trimin);
 			}

--- a/test/db/cmd/cmd_seek
+++ b/test/db/cmd/cmd_seek
@@ -143,6 +143,9 @@ EOF
 EXPECT=<<EOF
 0x42
 EOF
+EXPECT_ERR=<<EOF
+ERROR: Cannot seek to unknown address 'noSuchSymbolEndingT' (unknown symbol)
+EOF
 RUN
 
 NAME=seek opcodes
@@ -537,5 +540,20 @@ EXPECT=<<EOF
 0x401000 entry0
 ---
 0x401012
+EOF
+RUN
+
+NAME=s with invalid expression does not seek to 0
+FILE=malloc://1024
+CMDS=<<EOF
+s 0x100
+s foo
+s
+EOF
+EXPECT_ERR=<<EOF
+ERROR: Cannot seek to unknown address 'foo' (invalid octal number)
+EOF
+EXPECT=<<EOF
+0x100
 EOF
 RUN

--- a/test/db/cmd/feat_variables
+++ b/test/db/cmd/feat_variables
@@ -36,6 +36,7 @@ s $FB
 s
 EOF
 EXPECT=<<EOF
+ERROR: Cannot seek to unknown address '$FB' (cant find function)
 0x2c
 EOF
 RUN

--- a/test/db/cmd/seekbug
+++ b/test/db/cmd/seekbug
@@ -75,4 +75,9 @@ EXPECT=<<EOF
 0x64
 0x0
 EOF
+EXPECT_ERR=<<EOF
+ERROR: Cannot seek to unknown address 'unkval' (unknown symbol)
+ERROR: Cannot seek to unknown address ']' (cannot find opening [)
+ERROR: Cannot seek to unknown address '[' (cannot find closing ])
+EOF
 RUN


### PR DESCRIPTION
<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

This PR addresses part of #23362.

When a user provided an invalid memory address or malformed string during a seek command (`s`), `r_num_math` would silently fail and evaluate to `0x0`, causing the engine to seek to address 0 instead of throwing an error.

This patch refactors the evaluation logic in `libr/core/cmd_seek.inc.c` to use the `r_num_math_err` API instead. If the parser fails, it now exposes the error and immediately halts the seek execution.

I also added a regression test to `test/db/cmd/cmd_seek` to ensure invalid math strings do not silently seek to 0x0.

Happy to make any adjustments if needed!
