### PR TITLE
Fix nested esil conditionals running the wrong else arm ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1762,8 +1762,9 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	case ARM64_INS_FCMPE:
 	case ARM64_INS_FCCMP:
 	case ARM64_INS_FCCMPE:
+		// setf would wipe the cond guard emitted before the switch
 		if (ISREG64 (1)) {
-			r_strbuf_setf (&op->esil,
+			r_strbuf_appendf (&op->esil,
 				"%d,%s,F2D,NAN,%d,%s,F2D,NAN,|,vf,:="
 				",%d,%s,F2D,%d,%s,F2D,F==,vf,|,zf,:="
 				",%d,%s,F2D,%d,%s,F2D,F<,vf,|,nf,:=",
@@ -1772,7 +1773,7 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 				REGBITS64 (1), REG64 (1), REGBITS64 (1), REG64 (0)
 			);
 		} else {
-			r_strbuf_setf (&op->esil,
+			r_strbuf_appendf (&op->esil,
 				"%d,%s,F2D,NAN,vf,:="
 				",0,I2D,%d,%s,F2D,F==,vf,|,zf,:="
 				",0,I2D,%d,%s,F2D,F<,vf,|,nf,:=",
@@ -1782,10 +1783,9 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 			);
 		}
 
-		if (insn->id == ARM64_INS_FCCMP || insn->id == ARM64_INS_FCCMPE) {
-			r_strbuf_append (&op->esil, ",");
-			arm_prefix_cond (op, insn->detail->arm64.cc);
-			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,0x%"PFMT64x",|,pstate,:=", IMM64(2) << 28);
+		// an AL cond opens no ?{, so there is no else arm
+		if (*postfix && (insn->id == ARM64_INS_FCCMP || insn->id == ARM64_INS_FCCMPE)) {
+			r_strbuf_appendf (&op->esil, ",}{,pstate,1,28,1,<<,-,&,0x%"PFMT64x",|,pstate,:=", IMM64 (2) << 28);
 		}
 		break;
 	case ARM64_INS_FCVT:
@@ -2164,10 +2164,9 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		ARG64_APPEND (&op->esil, 0);
 		r_strbuf_append (&op->esil, ",^,&,>>,vf,:=");
 
-		if (insn->id == ARM64_INS_CCMP || insn->id == ARM64_INS_CCMN) {
-			r_strbuf_append (&op->esil, ",");
-			arm_prefix_cond (op, insn->detail->arm64.cc);
-			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));
+		// an AL cond opens no ?{, so there is no else arm
+		if (*postfix && insn->id == ARM64_INS_CCMP) {
+			r_strbuf_appendf (&op->esil, ",}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));
 		}
 		break;
 	case ARM64_INS_CMN:
@@ -2180,10 +2179,9 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 		r_strbuf_appendf (&op->esil, ",==,$z,zf,:=,%d,$s,nf,:=,%d,$c,cf,:=,%d,$o,vf,:=",
 			REGBITS64 (0) - 1, REGBITS64 (0) - 1, REGBITS64 (0) - 1);
 
-		if (insn->id == ARM64_INS_CCMN) {
-			r_strbuf_append (&op->esil, ",");
-			arm_prefix_cond (op, insn->detail->arm64.cc);
-			r_strbuf_appendf (&op->esil, "}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));
+		// an AL cond opens no ?{, so there is no else arm
+		if (*postfix && insn->id == ARM64_INS_CCMN) {
+			r_strbuf_appendf (&op->esil, ",}{,pstate,1,28,1,<<,-,&,28,%"PFMT64d",<<,|,pstate,:=", IMM64 (2));
 		}
 		break;
 	case ARM64_INS_TST: // tst w8, 0xd

--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -1074,7 +1074,10 @@ static bool runword(REsil *esil, RStrs w) {
 	}
 	const char c0 = w.a[0];
 	if (wlen == 2 && c0 == '}' && w.a[1] == '{') {
-		esil->skip = (esil->skip == 0);
+		// skip counts nesting depth, not a boolean
+		if (esil->skip < 2) {
+			esil->skip = (esil->skip == 0);
+		}
 		return true;
 	}
 	if (wlen == 1 && c0 == '}') {

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -1986,3 +1986,116 @@ EXPECT=<<EOF
 0x00000013
 EOF
 RUN
+
+NAME=ccmp emits a balanced conditional
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 000041fa
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: zf,?{,x1,x0,==,$z,zf,:=,63,$s,nf,:=,64,$b,!,cf,:=,63,x1,x0,^,x1,x0,-,x0,^,&,>>,vf,:=,}{,pstate,1,28,1,<<,-,&,28,0,<<,|,pstate,:=,}
+EOF
+RUN
+
+NAME=ccmp with an always condition has no else arm
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 07e041fa
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: x1,x0,==,$z,zf,:=,63,$s,nf,:=,64,$b,!,cf,:=,63,x1,x0,^,x1,x0,-,x0,^,&,>>,vf,:=
+EOF
+RUN
+
+NAME=ccmn emits a balanced conditional
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 000041ba
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: zf,?{,x1,-1,*,x0,==,$z,zf,:=,63,$s,nf,:=,63,$c,cf,:=,63,$o,vf,:=,}{,pstate,1,28,1,<<,-,&,28,0,<<,|,pstate,:=,}
+EOF
+RUN
+
+NAME=ccmn with an always condition has no else arm
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 07e041ba
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: x1,-1,*,x0,==,$z,zf,:=,63,$s,nf,:=,63,$c,cf,:=,63,$o,vf,:=
+EOF
+RUN
+
+NAME=fccmp guards the compare with its condition
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 0044611e
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=,}{,pstate,1,28,1,<<,-,&,0x0,|,pstate,:=,}
+EOF
+RUN
+
+NAME=fccmp with an always condition has no else arm
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 07e4611e
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: 64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=
+EOF
+RUN
+
+NAME=conditional compares encode the nzcv immediate
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 0a0041fa
+ao 1~esil:
+wx 0a0041ba
+ao 1~esil:
+wx 0a44611e
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: zf,?{,x1,x0,==,$z,zf,:=,63,$s,nf,:=,64,$b,!,cf,:=,63,x1,x0,^,x1,x0,-,x0,^,&,>>,vf,:=,}{,pstate,1,28,1,<<,-,&,28,10,<<,|,pstate,:=,}
+esil: zf,?{,x1,-1,*,x0,==,$z,zf,:=,63,$s,nf,:=,63,$c,cf,:=,63,$o,vf,:=,}{,pstate,1,28,1,<<,-,&,28,10,<<,|,pstate,:=,}
+esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=,}{,pstate,1,28,1,<<,-,&,0xa0000000,|,pstate,:=,}
+EOF
+RUN
+
+NAME=ccmp else arm lands the nzcv immediate in the flags
+FILE=malloc://32
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 0a0041fa
+aer zf=0
+aer pc=0
+s 0
+aes
+aer nf
+aer zf
+aer cf
+aer vf
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000000
+0x00000001
+0x00000000
+EOF
+RUN

--- a/test/db/esil/cond
+++ b/test/db/esil/cond
@@ -37,3 +37,67 @@ EXPECT=<<EOF
 2,3
 EOF
 RUN
+
+NAME=nested cond skipped branch
+FILE=-
+CMDS=ae 0,?{,1,?{,7,}{,9,},},3
+EXPECT=<<EOF
+3
+EOF
+RUN
+
+NAME=nested cond else arm
+FILE=-
+CMDS=ae 1,?{,0,?{,7,}{,9,},},3
+EXPECT=<<EOF
+9,3
+EOF
+RUN
+
+NAME=nested cond then arm
+FILE=-
+CMDS=ae 1,?{,1,?{,7,}{,9,},},3
+EXPECT=<<EOF
+7,3
+EOF
+RUN
+
+NAME=triple nested cond skipped branch
+FILE=-
+CMDS=ae 0,?{,1,?{,1,?{,7,}{,9,},},},3
+EXPECT=<<EOF
+3
+EOF
+RUN
+
+NAME=nested cond followed by outer else arm
+FILE=-
+CMDS=ae 0,?{,1,?{,7,}{,9,},5,}{,4,},3
+EXPECT=<<EOF
+4,3
+EOF
+RUN
+
+NAME=nested cond in v850 satadd
+FILE=-
+ARGS=-a v850
+CMDS=<<EOF
+e asm.cpu=e0
+wx c110
+aei
+aeim
+ar r1=1
+ar r2=1
+aes
+ar r2
+ar r1=0x7fffffff
+ar r2=1
+ar pc=0
+aes
+ar r2
+EOF
+EXPECT=<<EOF
+0x00000002
+0x7fffffff
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`}{` did not respect conditional nesting. `esil_if` maintains `esil->skip` as a nesting **count** — it increments both when already skipping and when a condition is false (`libr/esil/esil_ops.c:606-620`) — and the `}` arm decrements it, but `}{` assigned a boolean:

```c
esil->skip = (esil->skip == 0);
```

At depth 2 or more that flattens the counter to 0, so the else arm of an inner conditional runs even though the enclosing `?{` was not taken. On current master:

```
$ r2 -q -a x86 -b 64 -c 'aei; ar rbx=0; ae 0,?{,1,?{,7,rax,=,}{,9,rbx,=,},}; ar rbx' malloc://64
0x00000009      # should be 0 - the outer condition is false
```

Only the innermost level may flip on `}{`, so the fix is to leave the counter alone when it is already skipping an outer level.

## Why the arm64 change is in the same PR

The arm64 conditional compares emit an **unbalanced** expression: `arm_prefix_cond` is called once before the switch (opening `?{` and returning the closing `,}`), and the `CCMP`/`CCMN`/`FCCMP` arms called it a *second* time and discarded the postfix — two `?{`, one `}{`, one `}`. That only worked because `}{` used to flatten the counter, so fixing the interpreter alone silently drops the architecturally required "condition fails → NZCV := the #nzcv immediate" write.

The first commit therefore emits the else arm against the conditional that is already open, and skips it entirely for an `AL` condition (which opens no `?{` at all). Neither commit leaves the tree in a broken state: the arm64 commit is a no-op under master's interpreter semantics, and the interpreter commit is safe once it has landed.

`FCMP`/`FCCMP` also used `r_strbuf_setf`, which wiped the conditional guard emitted before
the switch; it now appends.

## Test

`test/db/esil/cond` gains four nested cases and `test/db/esil/arm_64` gains the conditional-compare forms. Reverting both source files and rebuilding fails exactly the new cases:

The triple-nested case is deliberate: a `== 2` special case instead of the depth test would pass the depth-2 case and fail this one. The `nested cond else arm` / `then arm` cases pass either way — they are coverage, not regression pins.