### PR TITLE
Stop the typo lint from flagging every correct 'unknown' ##ci

### DIFF
--- a/sys/lint.py
+++ b/sys/lint.py
@@ -282,7 +282,7 @@ CHECKS = [
 		[L(b"strbuf_append (")],
 		filters=[(rb"\"", True), (rb"%", True)]),
 	Check("typo-unkown",
-		[L(b"unknown")], icase=True),
+		[L(b"unkown")], icase=True),
 	Check("eq-zero",
 		[L(b"=0")],
 		filters=[(rb"c:", True), (rb"\"", False), (rb"//", False), (rb"=0x", False)]),


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

bc8a18cb70eb ("docs: fix typo unkown -> unknown") applied the typo fix to the linter's own search pattern, so the `typo-unkown` check now matches the *correct* spelling. `sys/lint.sh` reports 1184 findings on a clean tree and exits 1, which makes `linux-nocs` red on master and on every open PR.

```
$ sys/lint.sh | wc -l
1184
$ sys/lint.sh | head -1
libr/anal/c/tccgen.c:2625: error [typo-unkown] typo: 'unkown' should be 'unknown' -- /* If unknown size, we must evaluate it before
```

This restores the needle to `unkown`. With it, `sys/lint.sh --all` exits 0, and the check still fires on a real typo (planting `// this is an unkown thing` in `libr/util/str.c` is reported as expected).