### PR TITLE
Correct the arm64 float compare flags and immediate width ##esil

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1764,22 +1764,26 @@ static int analop64_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *bu
 	case ARM64_INS_FCCMPE:
 		// setf would wipe the cond guard emitted before the switch
 		if (ISREG64 (1)) {
+			// an unordered compare sets NZCV=0011, so vf feeds cf
 			r_strbuf_appendf (&op->esil,
 				"%d,%s,F2D,NAN,%d,%s,F2D,NAN,|,vf,:="
-				",%d,%s,F2D,%d,%s,F2D,F==,vf,|,zf,:="
-				",%d,%s,F2D,%d,%s,F2D,F<,vf,|,nf,:=",
+				",%d,%s,F2D,%d,%s,F2D,F==,zf,:="
+				",%d,%s,F2D,%d,%s,F2D,F<,nf,:="
+				",nf,!,vf,|,cf,:=",
 				REGBITS64 (1), REG64 (1), REGBITS64 (1), REG64 (0),
 				REGBITS64 (1), REG64 (1), REGBITS64 (1), REG64 (0),
 				REGBITS64 (1), REG64 (1), REGBITS64 (1), REG64 (0)
 			);
 		} else {
+			// operand 1 is an fp immediate, width comes from op 0
 			r_strbuf_appendf (&op->esil,
 				"%d,%s,F2D,NAN,vf,:="
-				",0,I2D,%d,%s,F2D,F==,vf,|,zf,:="
-				",0,I2D,%d,%s,F2D,F<,vf,|,nf,:=",
-				REGBITS64 (1), REG64 (0),
-				REGBITS64 (1), REG64 (0),
-				REGBITS64 (1), REG64 (0)
+				",0,I2D,%d,%s,F2D,F==,zf,:="
+				",0,I2D,%d,%s,F2D,F<,nf,:="
+				",nf,!,vf,|,cf,:=",
+				REGBITS64 (0), REG64 (0),
+				REGBITS64 (0), REG64 (0),
+				REGBITS64 (0), REG64 (0)
 			);
 		}
 

--- a/test/db/esil/arm_64
+++ b/test/db/esil/arm_64
@@ -2043,7 +2043,7 @@ wx 0044611e
 ao 1~esil:
 EOF
 EXPECT=<<EOF
-esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=,}{,pstate,1,28,1,<<,-,&,0x0,|,pstate,:=,}
+esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,zf,:=,64,d1,F2D,64,d0,F2D,F<,nf,:=,nf,!,vf,|,cf,:=,}{,pstate,1,28,1,<<,-,&,0x0,|,pstate,:=,}
 EOF
 RUN
 
@@ -2055,7 +2055,22 @@ wx 07e4611e
 ao 1~esil:
 EOF
 EXPECT=<<EOF
-esil: 64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=
+esil: 64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,zf,:=,64,d1,F2D,64,d0,F2D,F<,nf,:=,nf,!,vf,|,cf,:=
+EOF
+RUN
+
+NAME=fcmp against the zero immediate uses the register width
+FILE=-
+ARGS=-a arm -b 64
+CMDS=<<EOF
+wx 0820201e
+ao 1~esil:
+wx 0820601e
+ao 1~esil:
+EOF
+EXPECT=<<EOF
+esil: 32,s0,F2D,NAN,vf,:=,0,I2D,32,s0,F2D,F==,zf,:=,0,I2D,32,s0,F2D,F<,nf,:=,nf,!,vf,|,cf,:=
+esil: 64,d0,F2D,NAN,vf,:=,0,I2D,64,d0,F2D,F==,zf,:=,0,I2D,64,d0,F2D,F<,nf,:=,nf,!,vf,|,cf,:=
 EOF
 RUN
 
@@ -2073,7 +2088,7 @@ EOF
 EXPECT=<<EOF
 esil: zf,?{,x1,x0,==,$z,zf,:=,63,$s,nf,:=,64,$b,!,cf,:=,63,x1,x0,^,x1,x0,-,x0,^,&,>>,vf,:=,}{,pstate,1,28,1,<<,-,&,28,10,<<,|,pstate,:=,}
 esil: zf,?{,x1,-1,*,x0,==,$z,zf,:=,63,$s,nf,:=,63,$c,cf,:=,63,$o,vf,:=,}{,pstate,1,28,1,<<,-,&,28,10,<<,|,pstate,:=,}
-esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,vf,|,zf,:=,64,d1,F2D,64,d0,F2D,F<,vf,|,nf,:=,}{,pstate,1,28,1,<<,-,&,0xa0000000,|,pstate,:=,}
+esil: nf,?{,64,d1,F2D,NAN,64,d0,F2D,NAN,|,vf,:=,64,d1,F2D,64,d0,F2D,F==,zf,:=,64,d1,F2D,64,d0,F2D,F<,nf,:=,nf,!,vf,|,cf,:=,}{,pstate,1,28,1,<<,-,&,0xa0000000,|,pstate,:=,}
 EOF
 RUN
 
@@ -2097,5 +2112,29 @@ EXPECT=<<EOF
 0x00000000
 0x00000001
 0x00000000
+EOF
+RUN
+
+NAME=fcmp with a nan operand sets nzcv to 0011
+FILE=malloc://64
+ARGS=-a arm -b 64
+CMDS=<<EOF
+aei
+wx 0020611e
+ar d0=0x7ff8000000000000
+ar d1=0x3ff0000000000000
+aer pc=0
+s 0
+aes
+aer nf
+aer zf
+aer cf
+aer vf
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000000
+0x00000001
+0x00000001
 EOF
 RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

An arm64 `fcmp` with a NaN operand sets the wrong flags. AArch64 defines an unordered compare as `NZCV = 0b0011`, but the ESIL OR-ed the unordered flag into `nf` and `zf` and never wrote `cf` at all, so comparing NaN against 1.0 gives `1101` where the architecture requires `0011`:

```
$ r2 -N -q -a arm -b 64 -c 'aei; wx 0020611e; ar d0=0x7ff8000000000000; ar d1=0x3ff0000000000000; ar pc=0; s 0; aes; ar pstate' malloc://64
0xd0000000
```

NZCV is `pstate[31:28]`, so that is N=1 Z=1 C=0 V=1; it should be `0x30000000`. `cf` is also wrong for every ordered case, because nothing writes it.

**The fix**:

- Write `zf` and `nf` from the comparison alone instead of OR-ing `vf` into both, so an unordered compare leaves them 0.
- Derive the carry as `!nf | vf`, which gives the architectural NZCV in all four cases: unordered `0011`, equal `0110`, less than `1000`, greater than `0010`.
- Take the width of the immediate form from operand 0. `FCMP <Vn>, #0.0` has an FP immediate as operand 1, whose `.reg` union member is not a register, so `REGBITS64 (1)` did not describe the compared value.

**Tests**

`test/db/esil/arm_64` gains the NZCV case above, which emulates the compare and reads the four flags, plus one pinning the immediate form's width at both `s` and `d`. The three conditional-compare goldens move to the corrected flag model. 