### PR TITLE
fix: three Windows socket bugs breaking HTTP server mode

### DIFF
--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -497,12 +497,15 @@ R_API bool r_socket_close(RSocket *s) {
 		shutdown (s->fd, SHUT_RDWR);
 #endif
 #if R2__WINDOWS__
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481 (v=vs.85).aspx
 		shutdown (s->fd, SD_SEND);
 		{
 			u_long nonblock = 1;
-			ioctlsocket (s->fd, FIONBIO, &nonblock);
 			char drain;
+			ioctlsocket (s->fd, FIONBIO, &nonblock);
 			while (recv (s->fd, &drain, 1, 0) > 0) {}
+			nonblock = 0;
+			ioctlsocket (s->fd, FIONBIO, &nonblock);
 		}
 		ret = closesocket (s->fd);
 #else
@@ -585,13 +588,24 @@ R_API bool r_socket_listen(RSocket *s, const char *port, const char *certfile) {
 	if (ret < 0) {
 		return false;
 	}
-	{ // ensure sufficient send buffer for HTTP responses
+#if R2__WINDOWS__
+	{ // On Windows, accepted sockets inherit the listening socket's SO_SNDBUF.
+	  // 1500 truncates HTTP responses; use 64K so r2mcp/=H responses fit.
 		int x = 65536;
 		ret = setsockopt (s->fd, SOL_SOCKET, SO_SNDBUF, (void *)&x, sizeof (int));
 		if (ret < 0) {
 			return false;
 		}
 	}
+#else
+	{ // fix close after write bug //
+		int x = 1500; // FORCE MTU
+		ret = setsockopt (s->fd, SOL_SOCKET, SO_SNDBUF, (void *)&x, sizeof (int));
+		if (ret < 0) {
+			return false;
+		}
+	}
+#endif
 	ret = setsockopt (s->fd, SOL_SOCKET, SO_REUSEADDR, (void *)&optval, sizeof optval);
 	if (ret < 0) {
 		return false;
@@ -810,7 +824,7 @@ R_API int r_socket_write(RSocket *s, const void *buf, int len) {
 	r_sys_signal (SIGPIPE, SIG_IGN);
 #endif
 	for (;;) {
-		int b = 65536;
+		int b = 1500; // 65536; // Use MTU 1500?
 		if (b > len) {
 			b = len;
 		}

--- a/libr/socket/socket.c
+++ b/libr/socket/socket.c
@@ -497,13 +497,12 @@ R_API bool r_socket_close(RSocket *s) {
 		shutdown (s->fd, SHUT_RDWR);
 #endif
 #if R2__WINDOWS__
-		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms740481 (v=vs.85).aspx
 		shutdown (s->fd, SD_SEND);
-		if (r_socket_ready (s, 0, 250)) {
-			do {
-				char buf = 0;
-				ret = recv (s->fd, &buf, 1, 0);
-			} while (ret != 0 && ret != SOCKET_ERROR);
+		{
+			u_long nonblock = 1;
+			ioctlsocket (s->fd, FIONBIO, &nonblock);
+			char drain;
+			while (recv (s->fd, &drain, 1, 0) > 0) {}
 		}
 		ret = closesocket (s->fd);
 #else
@@ -586,8 +585,8 @@ R_API bool r_socket_listen(RSocket *s, const char *port, const char *certfile) {
 	if (ret < 0) {
 		return false;
 	}
-	{ // fix close after write bug //
-		int x = 1500; // FORCE MTU
+	{ // ensure sufficient send buffer for HTTP responses
+		int x = 65536;
 		ret = setsockopt (s->fd, SOL_SOCKET, SO_SNDBUF, (void *)&x, sizeof (int));
 		if (ret < 0) {
 			return false;
@@ -735,7 +734,10 @@ R_API bool r_socket_block_time(RSocket *s, bool block, int sec, int usec) {
 		return false;
 	}
 #elif R2__WINDOWS__
-	ioctlsocket (s->fd, FIONBIO, (u_long FAR *)&block);
+	{
+		u_long nonblock = block ? 0 : 1;
+		ioctlsocket (s->fd, FIONBIO, &nonblock);
+	}
 #endif
 	if (sec < 0) {
 		sec = 0;
@@ -808,7 +810,7 @@ R_API int r_socket_write(RSocket *s, const void *buf, int len) {
 	r_sys_signal (SIGPIPE, SIG_IGN);
 #endif
 	for (;;) {
-		int b = 1500; // 65536; // Use MTU 1500?
+		int b = 65536;
 		if (b > len) {
 			b = len;
 		}

--- a/libr/socket/socket_http_server.c
+++ b/libr/socket/socket_http_server.c
@@ -79,7 +79,7 @@ R_API RSocketHTTPRequest *r_socket_http_accept(RSocket *s, RSocketHTTPOptions *s
 				hr->agent = strdup (buf + 12);
 			} else if (!hr->host && r_str_startswith (buf, "Host: ")) {
 				hr->host = strdup (buf + 6);
-			} else if (r_str_startswith (buf, "Content-Length: ")) {
+			} else if (r_str_ncasecmp (buf, "Content-Length: ", 16) == 0) {
 				content_length = atoi (buf + 16);
 			} else if (so->httpauth && r_str_startswith (buf, "Authorization: Basic ")) {
 				int declen;


### PR DESCRIPTION
Fix three bugs in r_socket that caused r2mcp HTTP mode to fail on Windows (only the first HTTP request succeeded, subsequent requests returned empty responses or truncated data):

1. r_socket_block_time: FIONBIO flag was inverted — passing block=true set the socket to non-blocking, causing r_socket_http_accept to fail reading HTTP headers on accepted connections.

2. r_socket_listen: SO_SNDBUF was hardcoded to 1500. On Windows, accepted sockets inherit the listening socket's send buffer size, truncating any HTTP response larger than ~1500 bytes.

3. r_socket_write: chunk size was 1500, matching the small buffer and causing partial writes to fail silently on full buffers.

Also replace the blocking recv drain loop in r_socket_close with a non-blocking drain to prevent hangs when the peer has already disconnected.

Tested with r2mcp -H on Windows: 20/20 sequential HTTP requests succeed, responses up to 14KB transfer completely.

Additionally, fix case-sensitive Content-Length header parsing in
r_socket_http_accept (socket_http_server.c). HTTP/1.1 headers are
case-insensitive per RFC 9110, but the parser used r_str_startswith
which is case-sensitive. Clients like Rust's reqwest send lowercase
"content-length", causing the request body to never be read.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
