### PR TITLE
Take DW_AT_count as the extent it already is ##anal

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -244,8 +244,14 @@ static void parse_array_type(Context *ctx, int idx, RStrBuf *strbuf) {
 				R_VEC_FOREACH(child_die->attr_values, value) {
 					switch (value->attr_name) {
 					case DW_AT_upper_bound:
-					case DW_AT_count:
+						// The last index, so the extent is one more than it.
 						r_strbuf_appendf (strbuf, "[%" PFMT64d "]", value->uconstant + 1);
+						break;
+					case DW_AT_count:
+						// Already the extent. Adding one to it as well made every
+						// clang-built array import one element too large, so
+						// `int32_t r[8]` came back as `int32_t[9]`.
+						r_strbuf_appendf (strbuf, "[%" PFMT64d "]", value->uconstant);
 						break;
 					default:
 						break;

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -304,7 +304,8 @@ EXPECT=<<EOF
 |           ; var int64_t var_68h @ rsp+0x68
 |           ; var int64_t var_70h @ rsp+0x70
 |           ; var int64_t var_78h @ rsp+0x78
-|           ; var i32[11] numbers @ rsp+0x80
+|           ; var i32[10] numbers @ rsp+0x80
+|           ; var int64_t var_a8h @ rsp+0xa8
 |           ; var int64_t var_d8h @ rsp+0xd8
 |           ; var int64_t var_e0h @ rsp+0xe0
 |           ; var int64_t var_e8h @ rsp+0xe8
@@ -312,7 +313,7 @@ EXPECT=<<EOF
 |           ; var int64_t var_120h @ rsp+0x120
 |           ; var int64_t var_128h @ rsp+0x128
 |           ; var int64_t var_130h @ rsp+0x130
-|           ; var &str[6] strings @ rsp+0x138
+|           ; var &str[5] strings @ rsp+0x138
 |           ; var int64_t var_140h @ rsp+0x140
 |           ; var int64_t var_148h @ rsp+0x148
 |           ; var int64_t var_150h @ rsp+0x150
@@ -333,7 +334,7 @@ EXPECT=<<EOF
 |           ; var int64_t var_218h @ rsp+0x218
 |           ; var int64_t var_220h @ rsp+0x220
 |           ; var int64_t var_228h @ rsp+0x228
-|           ; var &str[6] *arg0 @ rsp+0x230
+|           ; var &str[5] *arg0 @ rsp+0x230
 |           0x00005750      4881ec3802..   sub rsp, 0x238              ; void main();
 |           0x00005757      c784248000..   mov dword [numbers], 8
 |           0x00005762      c784248400..   mov dword [numbers[1]], 7
@@ -361,7 +362,7 @@ EXPECT=<<EOF
 |           0x00005817      488b4c2468     mov rcx, qword [var_68h]
 |           0x0000581c      48898c24e0..   mov qword [var_e0h], rcx
 |           0x00005824      488d9424d8..   lea rdx, [var_d8h]
-|           0x0000582c      488dbc24a8..   lea rdi, [numbers[10]]      ; int64_t arg1
+|           0x0000582c      488dbc24a8..   lea rdi, [var_a8h]          ; int64_t arg1
 |           0x00005834      488b742478     mov rsi, qword [var_78h]    ; int64_t arg2
 |           0x00005839      41b802000000   mov r8d, 2
 |           0x0000583f      4889542460     mov qword [var_60h], rdx
@@ -369,7 +370,7 @@ EXPECT=<<EOF
 |           0x00005847      488b4c2460     mov rcx, qword [var_60h]    ; int64_t arg4
 |           0x0000584c      41b801000000   mov r8d, 1                  ; int64_t arg5
 |           0x00005852      e8591b0000     call dbg.new_v1             ; core::fmt::Arguments::new_v1::h2673b5bf555c0288 ; Arguments new_v1(&[&str] pieces, &[core::fmt::ArgumentV1] args)
-|           0x00005857      488dbc24a8..   lea rdi, [numbers[10]]
+|           0x00005857      488dbc24a8..   lea rdi, [var_a8h]
 |           0x0000585f      ff15b3430300   call qword [dbg._print]     ; [0x39c18:8]=0xa2d0 dbg._print
 |           0x00005865      488d842480..   lea rax, [numbers]
 |           0x0000586d      4889c7         mov rdi, rax                ; int64_t arg1

--- a/test/unit/test_dwarf_integration.c
+++ b/test/unit/test_dwarf_integration.c
@@ -282,8 +282,8 @@ static bool test_dwarf_function_parsing_rust(void) {
 
 	check_kv ("fcn.main.addr", "0x5750");
 	check_kv ("fcn.main.name", "main");
-	check_kv ("fcn.main.var.numbers", "s,128,i32[11]");
-	check_kv ("fcn.main.var.strings", "s,312,&str[6]");
+	check_kv ("fcn.main.var.numbers", "s,128,i32[10]");
+	check_kv ("fcn.main.var.strings", "s,312,&str[5]");
 	// check_kv ("fcn.main.vars", "numbers,arg0,arg0,strings,arg0,arg0"); Fix these collision by unique renaming in future
 	check_kv ("fcn.lang_start_internal.sig", "isize lang_start_internal(&Fn<()> main,isize argc,u8 ** argv);");
 


### PR DESCRIPTION
DW_AT_upper_bound is the last valid index, so an extent is one more than it; DW_AT_count is already the extent. Both went through the same `case` and both had one added, so every array whose producer emits DW_AT_count imports one element too large — and the phantom element swallows whatever local sits behind the array.

`bins/elf/dwarf_rust_bubble`, where the DIE reads:

```
DW_TAG_subrange_type
  DW_AT_lower_bound (0x00)
  DW_AT_count       (0x0a)
```

Before, the `int64_t` at `rsp+0xa8` is inside `numbers` and gets addressed past the end of it:

```
; var i32[11] numbers @ rsp+0x80
0x0000582c  lea rdi, [numbers[10]]
```

After, it is its own variable again:

```
; var i32[10] numbers @ rsp+0x80
; var int64_t var_a8h @ rsp+0xa8
0x0000582c  lea rdi, [var_a8h]
```

`strings` moves from `&str[6]` to `&str[5]` in the same fixture; both now match the DWARF, and the callee the code already names is `dbg.new<[i32; 10]>`.

Goldens in `db/cmd/dwarf` and `test_dwarf_integration` follow the fixed extents. Full r2r is green apart from the two `db/formats/ptx/info` tests that already fail on master here, and the unit suite passes.