### PR TITLE
Don't analyze uninitialized stack bytes after a partial read ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -357,11 +357,14 @@ static bool is_delta_pointer_table(ReadAhead *ra, RAnal *anal, RAnalFunction *fc
 	const char *reg_src = NULL;
 	const char *o_reg_dst = NULL;
 	RAnalValue cur_scr, cur_dst = {0};
-	read_ahead (ra, anal, addr, (ut8*)buf, sizeof (buf));
+	const int nread = read_ahead (ra, anal, addr, (ut8*)buf, sizeof (buf));
+	if (nread < 1) {
+		return false;
+	}
 	bool isValid = false;
-	for (i = 0; i + 8 < JMPTBL_LEA_SEARCH_SZ; i++) {
+	for (i = 0; i + 8 < nread; i++) {
 		ut64 at = addr + i;
-		int left = JMPTBL_LEA_SEARCH_SZ - i;
+		int left = nread - i;
 		int len = r_anal_op (anal, aop, at, buf + i, left, R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_HINT | R_ARCH_OP_MASK_VAL);
 		if (len < 1) {
 			len = 1;
@@ -1066,7 +1069,12 @@ repeat:
 			R_LOG_ERROR ("Failed to read");
 			break;
 		}
-		// ret is the max length of bytes available
+		if (ret < 1) {
+			R_LOG_DEBUG ("Nothing to read at 0x%08"PFMT64x, at);
+			gotoBeach (R_ANAL_RET_END);
+		}
+		// only the first `ret` bytes were filled, the rest of buf is uninitialized
+		bytes_read = ret;
 		// eprintf("%02x %02x\n", buf[0], buf[1]);
 		const bool check_invalid_fill = bb->size < sizeof (buf) || anal->opt.nonull > 0;
 		const bool bits_unknown = !anal->config->bits || anal->config->bits > 64 || !fcn->bits || fcn->bits > 64;


### PR DESCRIPTION
read_ahead() returns how many bytes it copied, which can be fewer than
asked for near the end of a map. fcn_recurse kept passing the requested
length to r_anal_is_invalid_code() and r_anal_op(), so both looked at the
tail of an uninitialized stack buffer.

The zero-fill heuristic needs 32 leading 0x00 to call a region invalid
code, so whatever junk sat in those bytes decided whether a trailing run
of zeros ended a basic block. On bins/mz/unzip.exe the last block of
fcn.00015ce8 is 30 bytes when the junk is nonzero and 2 bytes when it is
zero, and anal.hasnext then picks up the remainder as a 35th function.
An asan build with detect_stack_use_after_return=1 hits the second case
because frames move to a fake stack, which is why db/cmd/slow only fails
there.

is_delta_pointer_table() dropped the return value entirely and
disassembled its whole 64 byte buffer, same defect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KwVDrvD7RGzdscYQkxVcMd