### PR TITLE
Fold case when matching a convention location against a register

### DIFF
--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -1267,8 +1267,12 @@ static bool cc_location_range(const char *loc, const char **s, const char **end)
 
 R_IPI bool r_anal_cc_location_uses(RAnal *anal, const char *loc, const char *reg) {
 	R_RETURN_VAL_IF_FAIL (anal && loc && reg, false);
+	// Register profiles and convention tables do not agree on case, the same
+	// disagreement r_anal_cc_preserves_reg already tolerates below: an arch
+	// plugin may name the carrier RDX where the convention lists rdx, and a
+	// case-sensitive compare here silently drops that argument.
 	if (*loc && *loc != '{') {
-		return !strcmp (loc, reg);
+		return !r_str_casecmp (loc, reg);
 	}
 	const char *s, *end;
 	if (!cc_location_range (loc, &s, &end)) {
@@ -1279,7 +1283,7 @@ R_IPI bool r_anal_cc_location_uses(RAnal *anal, const char *loc, const char *reg
 		if (!name) {
 			return false;
 		}
-		if (!strcmp (name, reg)) {
+		if (!r_str_casecmp (name, reg)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## Problem

`r_anal_cc_location_uses` compared a register name against a calling convention's location with `strcmp`. Its sibling `r_anal_cc_preserves_reg` already case-folds, and carries a comment recording why: register profiles and convention tables do not agree on case.

This one had no such handling, so an arch plugin whose register profile is spelled in upper case lost every register argument the convention named — `RDX` never matched `rdx`, and the argument was dropped from the recovered prototype while stack-passed ones survived. A Ghidra-Sleigh-backed arch plugin (upper-case profile) is where I hit it: `murmur3_32(const uint8_t *, size_t, uint32_t)` came back as a two-argument function.

## Change

One function, two comparisons, folded the same way the sibling already folds.

Profiles already spelled in lower case are unaffected: a case-insensitive compare of two lower-case strings is the compare that was there before. That is why no test moves.

## What I removed from this PR after CI

The first revision also widened `get_regname` to resolve *any* sub-register to its parent, not only a 32-bit one, so that 8- and 16-bit spills would match the convention. CI caught a real problem with that half, and I've dropped it rather than paper over it:

- `db/cmd/dwarf` — `dbg.palya` already carries a DWARF prototype `(SmallInt szel, SmallInt mag)`, and the callee spills its incoming `di`/`si` into exactly those DWARF-named slots. With 16-bit spills resolving to their parents, the same two parameters were then recovered a second time as register arguments, and the signature rendered as `(int64_t arg1, int64_t arg2, SmallInt szel, SmallInt mag)` — four parameters for a two-parameter function.
- `db/cmd/midflags` — a synthetic blob whose only instruction reads `dl` before writing it now recovers an argument. That one is the documented trade of accepting narrower evidence and would just be a golden update.

The duplication against a debug-info prototype needs a guard I did not want to guess at inside this PR, so the widening will come separately once that is settled. The case-folding fix stands on its own and is what the upper-case-profile problem actually