### PR TITLE
Make the esil stack arena a ring instead of a bump allocator ##esil

### DIFF
--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -95,7 +95,8 @@ static bool esil_stack_alloc(REsil *esil, int stacksize) {
 		R_FREE (esil->stack);
 		return false;
 	}
-	esil->stack_buf_len = 0;
+	esil->stack_buf_head = 0;
+	esil->stack_buf_tail = 0;
 	return true;
 }
 
@@ -775,6 +776,83 @@ static bool setup_esil_set_bits(void *user, int bits) {
 	return true;
 }
 
+// The arena is a ring. Bytes are handed out at `head` and the span of live
+// data runs forward from `tail`; both only ever move forward, wrapping at the
+// end, so nothing is ever relocated and the buffer stays exactly the size it
+// was allocated with. r_esil_pop cannot release bytes itself — an op reads the
+// operands it popped while it pushes its result, which is what lets the stack
+// hand out slices instead of strdup'ing — so the space a dead value held is
+// recovered by walking `tail` forward between words instead.
+//
+// Strings are handed to ops as plain NUL-terminated char*, so an entry may
+// never straddle the wrap: when the run to the end of the buffer is too short
+// the allocation restarts at 0 and the tail end is left as slack for this
+// expression. Exhaustion is `head` meeting `tail`.
+static char *esil_arena_alloc(REsil *esil, size_t need) {
+	const ut32 cap = esil->stack_buf_cap;
+	const ut32 head = esil->stack_buf_head;
+	const ut32 tail = esil->stack_buf_tail;
+	// The ring is never filled to the last byte, so head meeting tail always
+	// means empty and can never be a full ring mistaken for one.
+	if (need > 0 && need < cap) {
+		if (head >= tail) {
+			const ut32 run = (cap - head) - (tail == 0);
+			if (run >= need) {
+				esil->stack_buf_head = head + need;
+				return esil->stack_buf + head;
+			}
+			if (tail > need) { // wrap, abandoning the short run at the end
+				esil->stack_buf_head = need;
+				return esil->stack_buf;
+			}
+		} else if (tail - head > need) {
+			esil->stack_buf_head = head + need;
+			return esil->stack_buf + head;
+		}
+	}
+	R_LOG_DEBUG ("esil stack arena exhausted");
+	return NULL;
+}
+
+// Shrink the live span onto what the stack still references: `tail` forward to
+// the oldest value still live, `head` back to the end of the newest. Both only
+// move within the ring, so no value is ever relocated. Distances are measured
+// forward from `tail` to stay correct across the wrap. Called between words,
+// where no op is mid-flight still reading a slice it popped.
+static void esil_arena_sync(REsil *esil) {
+	const int n = esil->stackptr;
+	if (n < 1) {
+		esil->stack_buf_head = 0;
+		esil->stack_buf_tail = 0;
+		return;
+	}
+	const ut32 cap = esil->stack_buf_cap;
+	const ut32 tail = esil->stack_buf_tail;
+	// Usually the bottom of the stack still owns the oldest bytes and the top
+	// owns the newest, which pins both ends and leaves nothing to release.
+	if ((ut32)(esil->stack[0].a - esil->stack_buf) == tail
+			&& (ut32)(esil->stack[n - 1].b + 1 - esil->stack_buf) == esil->stack_buf_head) {
+		return;
+	}
+	ut32 first = UT32_MAX;
+	ut32 last = 0;
+	int i;
+	for (i = 0; i < n; i++) {
+		const ut32 a = (ut32)(esil->stack[i].a - esil->stack_buf);
+		const ut32 b = (ut32)(esil->stack[i].b + 1 - esil->stack_buf);
+		const ut32 da = (a >= tail)? a - tail: a + cap - tail;
+		const ut32 db = (b > tail)? b - tail: b + cap - tail;
+		if (da < first) {
+			first = da;
+		}
+		if (db > last) {
+			last = db;
+		}
+	}
+	esil->stack_buf_tail = (tail + first) % cap;
+	esil->stack_buf_head = (tail + last) % cap;
+}
+
 // Push a slice. Arena-backed slices are stored by reference; external ones
 // are copied into the arena (fixed-size, never reallocs).
 R_API bool r_esil_push(REsil *esil, RStrs s) {
@@ -782,35 +860,35 @@ R_API bool r_esil_push(REsil *esil, RStrs s) {
 		return false;
 	}
 	const char *const bufbeg = esil->stack_buf;
-	const char *const bufend = bufbeg + esil->stack_buf_len;
-	if (s.a >= bufbeg && s.b <= bufend) {
+	if (s.a >= bufbeg && s.b < bufbeg + esil->stack_buf_cap) {
 		esil->stack[esil->stackptr++] = s;
 		return true;
 	}
 	const size_t n = (size_t)(s.b - s.a);
-	if (esil->stack_buf_len + n + 1 > esil->stack_buf_cap) {
-		R_LOG_DEBUG ("esil stack arena exhausted");
+	char *const dst = esil_arena_alloc (esil, n + 1);
+	if (!dst) {
 		return false;
 	}
-	char *const dst = esil->stack_buf + esil->stack_buf_len;
 	memcpy (dst, s.a, n);
 	dst[n] = '\0';
 	esil->stack[esil->stackptr].a = dst;
 	esil->stack[esil->stackptr].b = dst + n;
 	esil->stackptr++;
-	esil->stack_buf_len += (ut32)(n + 1);
 	return true;
 }
 
 R_API bool r_esil_pushnum(REsil *esil, ut64 num) {
-	if (esil->stackptr >= esil->stacksize
-			|| esil->stack_buf_len + 20 > esil->stack_buf_cap) {
+	if (esil->stackptr >= esil->stacksize) {
 		return false;
 	}
-	char *const dst = esil->stack_buf + esil->stack_buf_len;
+	char *const dst = esil_arena_alloc (esil, 20);
+	if (!dst) {
+		return false;
+	}
 	const RStrs s = r_strs_u64hex (dst, 20, num);
 	esil->stack[esil->stackptr++] = s;
-	esil->stack_buf_len += (ut32)((s.b - s.a) + 1);
+	// hand back what the number did not need
+	esil->stack_buf_head = (ut32)(s.b + 1 - esil->stack_buf);
 	return true;
 }
 
@@ -1133,6 +1211,7 @@ static bool runword(REsil *esil, RStrs w) {
 				if (esil->parse_stop) {
 					break;
 				}
+				esil_arena_sync (esil);
 			}
 			esil->parse_goto_count++;
 		}
@@ -1225,7 +1304,8 @@ R_API bool r_esil_parse(REsil *esil, const char *str) {
 	// Fresh stack+arena per parse — slices come from the input directly
 	// and are copied into the arena on push to guarantee NUL-termination.
 	esil->stackptr = 0;
-	esil->stack_buf_len = 0;
+	esil->stack_buf_head = 0;
+	esil->stack_buf_tail = 0;
 	const bool in_delay = esil->delay > 0;
 	const char *ostr = str;
 	int rc = 0;
@@ -1247,6 +1327,7 @@ loop:
 			if (!runword (esil, tok)) {
 				goto step_out;
 			}
+			esil_arena_sync (esil);
 			switch (eval_word (esil, ostr, &str)) {
 			case 0: goto loop;
 			case 1: goto step_out;
@@ -1283,7 +1364,8 @@ R_API bool r_esil_runword(REsil *esil, RStrs word) {
 R_API void r_esil_stack_free(REsil *esil) {
 	R_RETURN_IF_FAIL (esil);
 	esil->stackptr = 0;
-	esil->stack_buf_len = 0;
+	esil->stack_buf_head = 0;
+	esil->stack_buf_tail = 0;
 }
 
 R_API int r_esil_condition(REsil *esil, const char *str) {

--- a/libr/esil/esil.c
+++ b/libr/esil/esil.c
@@ -81,22 +81,22 @@ static HtPP *esil_ops_new(void) {
 	return ht_pp_new_opt (&opt);
 }
 
-// Average token width for sizing the stack arena (stacksize * 32 bytes).
-#define R_ESIL_STACK_ARENA_WIDTH 32
+// Average token width for sizing the string ring (stacksize * 32 bytes).
+#define R_ESIL_RING_WIDTH 32
 
 static bool esil_stack_alloc(REsil *esil, int stacksize) {
 	esil->stack = calloc (stacksize, sizeof (RStrs));
 	if (!esil->stack) {
 		return false;
 	}
-	esil->stack_buf_cap = (ut32)stacksize * R_ESIL_STACK_ARENA_WIDTH;
-	esil->stack_buf = malloc (esil->stack_buf_cap);
-	if (!esil->stack_buf) {
+	esil->ring_size = (ut32)stacksize * R_ESIL_RING_WIDTH;
+	esil->ring = malloc (esil->ring_size);
+	if (!esil->ring) {
 		R_FREE (esil->stack);
 		return false;
 	}
-	esil->stack_buf_head = 0;
-	esil->stack_buf_tail = 0;
+	esil->ring_head = 0;
+	esil->ring_tail = 0;
 	return true;
 }
 
@@ -254,7 +254,7 @@ ops_setup_fail:
 	ht_pp_free (esil->ops);
 	esil->ops = NULL;
 	free (esil->stack);
-	free (esil->stack_buf);
+	free (esil->ring);
 	return false;
 }
 
@@ -425,7 +425,7 @@ R_API void r_esil_fini(REsil *esil) {
 	esil->stats = NULL;
 	r_esil_stack_free (esil);
 	R_FREE (esil->stack);
-	R_FREE (esil->stack_buf);
+	R_FREE (esil->ring);
 	r_esil_trace_free (esil->trace);
 	esil->trace = NULL;
 	R_FREE (esil->cmd_intr);
@@ -776,72 +776,53 @@ static bool setup_esil_set_bits(void *user, int bits) {
 	return true;
 }
 
-// The arena is a ring. Bytes are handed out at `head` and the span of live
-// data runs forward from `tail`; both only ever move forward, wrapping at the
-// end, so nothing is ever relocated and the buffer stays exactly the size it
-// was allocated with. r_esil_pop cannot release bytes itself — an op reads the
-// operands it popped while it pushes its result, which is what lets the stack
-// hand out slices instead of strdup'ing — so the space a dead value held is
-// recovered by walking `tail` forward between words instead.
-//
-// Strings are handed to ops as plain NUL-terminated char*, so an entry may
-// never straddle the wrap: when the run to the end of the buffer is too short
-// the allocation restarts at 0 and the tail end is left as slack for this
-// expression. Exhaustion is `head` meeting `tail`.
-static char *esil_arena_alloc(REsil *esil, size_t need) {
-	const ut32 cap = esil->stack_buf_cap;
-	const ut32 head = esil->stack_buf_head;
-	const ut32 tail = esil->stack_buf_tail;
-	// The ring is never filled to the last byte, so head meeting tail always
-	// means empty and can never be a full ring mistaken for one.
-	if (need > 0 && need < cap) {
-		if (head >= tail) {
-			const ut32 run = (cap - head) - (tail == 0);
-			if (run >= need) {
-				esil->stack_buf_head = head + need;
-				return esil->stack_buf + head;
-			}
-			if (tail > need) { // wrap, abandoning the short run at the end
-				esil->stack_buf_head = need;
-				return esil->stack_buf;
-			}
-		} else if (tail - head > need) {
-			esil->stack_buf_head = head + need;
-			return esil->stack_buf + head;
-		}
+// Allocate a contiguous NUL-terminated string from the fixed-size ring.
+static char *esil_ring_alloc(REsil *esil, size_t need) {
+	const ut32 size = esil->ring_size;
+	const ut32 head = esil->ring_head;
+	const ut32 tail = esil->ring_tail;
+	if (!need || need >= size) {
+		R_LOG_DEBUG ("esil ring exhausted");
+		return NULL;
 	}
-	R_LOG_DEBUG ("esil stack arena exhausted");
+	if (head >= tail && size - head - !tail >= need) {
+		esil->ring_head = (head + need) % size;
+		return esil->ring + head;
+	}
+	if (head >= tail && tail > need) {
+		esil->ring_head = need;
+		return esil->ring;
+	}
+	if (head < tail && tail - head > need) {
+		esil->ring_head = head + need;
+		return esil->ring + head;
+	}
+	R_LOG_DEBUG ("esil ring exhausted");
 	return NULL;
 }
 
-// Shrink the live span onto what the stack still references: `tail` forward to
-// the oldest value still live, `head` back to the end of the newest. Both only
-// move within the ring, so no value is ever relocated. Distances are measured
-// forward from `tail` to stay correct across the wrap. Called between words,
-// where no op is mid-flight still reading a slice it popped.
-static void esil_arena_sync(REsil *esil) {
+// Release slices no longer referenced by the stack after a complete ESIL word.
+static void esil_ring_reclaim(REsil *esil) {
 	const int n = esil->stackptr;
 	if (n < 1) {
-		esil->stack_buf_head = 0;
-		esil->stack_buf_tail = 0;
+		esil->ring_head = 0;
+		esil->ring_tail = 0;
 		return;
 	}
-	const ut32 cap = esil->stack_buf_cap;
-	const ut32 tail = esil->stack_buf_tail;
-	// Usually the bottom of the stack still owns the oldest bytes and the top
-	// owns the newest, which pins both ends and leaves nothing to release.
-	if ((ut32)(esil->stack[0].a - esil->stack_buf) == tail
-			&& (ut32)(esil->stack[n - 1].b + 1 - esil->stack_buf) == esil->stack_buf_head) {
+	const ut32 size = esil->ring_size;
+	const ut32 tail = esil->ring_tail;
+	if ((ut32)(esil->stack[0].a - esil->ring) == tail
+			&& (ut32)(esil->stack[n - 1].b + 1 - esil->ring) % size == esil->ring_head) {
 		return;
 	}
 	ut32 first = UT32_MAX;
 	ut32 last = 0;
 	int i;
 	for (i = 0; i < n; i++) {
-		const ut32 a = (ut32)(esil->stack[i].a - esil->stack_buf);
-		const ut32 b = (ut32)(esil->stack[i].b + 1 - esil->stack_buf);
-		const ut32 da = (a >= tail)? a - tail: a + cap - tail;
-		const ut32 db = (b > tail)? b - tail: b + cap - tail;
+		const ut32 a = (ut32)(esil->stack[i].a - esil->ring);
+		const ut32 b = (ut32)(esil->stack[i].b + 1 - esil->ring);
+		const ut32 da = (a >= tail)? a - tail: a + size - tail;
+		const ut32 db = (b > tail)? b - tail: b + size - tail;
 		if (da < first) {
 			first = da;
 		}
@@ -849,8 +830,8 @@ static void esil_arena_sync(REsil *esil) {
 			last = db;
 		}
 	}
-	esil->stack_buf_tail = (tail + first) % cap;
-	esil->stack_buf_head = (tail + last) % cap;
+	esil->ring_tail = (tail + first) % size;
+	esil->ring_head = (tail + last) % size;
 }
 
 // Push a slice. Arena-backed slices are stored by reference; external ones
@@ -859,13 +840,13 @@ R_API bool r_esil_push(REsil *esil, RStrs s) {
 	if (esil->stackptr >= esil->stacksize || s.a >= s.b) {
 		return false;
 	}
-	const char *const bufbeg = esil->stack_buf;
-	if (s.a >= bufbeg && s.b < bufbeg + esil->stack_buf_cap) {
+	const char *const ring = esil->ring;
+	if (s.a >= ring && s.b < ring + esil->ring_size) {
 		esil->stack[esil->stackptr++] = s;
 		return true;
 	}
 	const size_t n = (size_t)(s.b - s.a);
-	char *const dst = esil_arena_alloc (esil, n + 1);
+	char *const dst = esil_ring_alloc (esil, n + 1);
 	if (!dst) {
 		return false;
 	}
@@ -881,14 +862,14 @@ R_API bool r_esil_pushnum(REsil *esil, ut64 num) {
 	if (esil->stackptr >= esil->stacksize) {
 		return false;
 	}
-	char *const dst = esil_arena_alloc (esil, 20);
+	char *const dst = esil_ring_alloc (esil, 20);
 	if (!dst) {
 		return false;
 	}
 	const RStrs s = r_strs_u64hex (dst, 20, num);
 	esil->stack[esil->stackptr++] = s;
-	// hand back what the number did not need
-	esil->stack_buf_head = (ut32)(s.b + 1 - esil->stack_buf);
+	// Return the unused part of the formatting buffer to the ring.
+	esil->ring_head = (ut32)(s.b + 1 - esil->ring) % esil->ring_size;
 	return true;
 }
 
@@ -1211,7 +1192,7 @@ static bool runword(REsil *esil, RStrs w) {
 				if (esil->parse_stop) {
 					break;
 				}
-				esil_arena_sync (esil);
+				esil_ring_reclaim (esil);
 			}
 			esil->parse_goto_count++;
 		}
@@ -1304,8 +1285,8 @@ R_API bool r_esil_parse(REsil *esil, const char *str) {
 	// Fresh stack+arena per parse — slices come from the input directly
 	// and are copied into the arena on push to guarantee NUL-termination.
 	esil->stackptr = 0;
-	esil->stack_buf_head = 0;
-	esil->stack_buf_tail = 0;
+	esil->ring_head = 0;
+	esil->ring_tail = 0;
 	const bool in_delay = esil->delay > 0;
 	const char *ostr = str;
 	int rc = 0;
@@ -1327,7 +1308,7 @@ loop:
 			if (!runword (esil, tok)) {
 				goto step_out;
 			}
-			esil_arena_sync (esil);
+			esil_ring_reclaim (esil);
 			switch (eval_word (esil, ostr, &str)) {
 			case 0: goto loop;
 			case 1: goto step_out;
@@ -1357,15 +1338,17 @@ step_out:
 
 R_API bool r_esil_runword(REsil *esil, RStrs word) {
 	R_RETURN_VAL_IF_FAIL (esil, false);
-	return runword (esil, word);
+	const bool ret = runword (esil, word);
+	esil_ring_reclaim (esil);
+	return ret;
 }
 
 // TODO rename to clearstack() or reset_stack()
 R_API void r_esil_stack_free(REsil *esil) {
 	R_RETURN_IF_FAIL (esil);
 	esil->stackptr = 0;
-	esil->stack_buf_head = 0;
-	esil->stack_buf_tail = 0;
+	esil->ring_head = 0;
+	esil->ring_tail = 0;
 }
 
 R_API int r_esil_condition(REsil *esil, const char *str) {

--- a/libr/include/r_esil.h
+++ b/libr/include/r_esil.h
@@ -235,13 +235,17 @@ typedef enum {
 
 typedef struct r_esil_t {
 	struct r_anal_t *anal; // required for io, reg, and call esil_init/fini of the selected arch plugin
-	// Heapless stack: entries are RStrs slices into `stack_buf`, an append-only
-	// arena that is reset on r_esil_stack_free. Within one expression, popped
-	// slices stay valid across subsequent pushes — the arena never moves.
+	// Heapless stack: entries are RStrs slices into `stack_buf`, a fixed-size
+	// ring. Bytes are handed out at `head`, the live span runs forward from
+	// `tail`, and both only move forward and wrap, so the buffer never moves,
+	// grows or shrinks and no value is ever relocated. Within one word popped
+	// slices stay valid across subsequent pushes; their bytes are released
+	// between words. Exhaustion is head meeting tail.
 	RStrs *stack;
 	char *stack_buf;
 	ut32 stack_buf_cap;
-	ut32 stack_buf_len;
+	ut32 stack_buf_head;
+	ut32 stack_buf_tail;
 	ut64 addrmask;
 	int stacksize;
 	int stackptr;

--- a/libr/include/r_esil.h
+++ b/libr/include/r_esil.h
@@ -235,17 +235,12 @@ typedef enum {
 
 typedef struct r_esil_t {
 	struct r_anal_t *anal; // required for io, reg, and call esil_init/fini of the selected arch plugin
-	// Heapless stack: entries are RStrs slices into `stack_buf`, a fixed-size
-	// ring. Bytes are handed out at `head`, the live span runs forward from
-	// `tail`, and both only move forward and wrap, so the buffer never moves,
-	// grows or shrinks and no value is ever relocated. Within one word popped
-	// slices stay valid across subsequent pushes; their bytes are released
-	// between words. Exhaustion is head meeting tail.
+	// Fixed-size NUL-terminated ESIL string ring; reclaim popped values between words.
 	RStrs *stack;
-	char *stack_buf;
-	ut32 stack_buf_cap;
-	ut32 stack_buf_head;
-	ut32 stack_buf_tail;
+	char *ring;
+	ut32 ring_size;
+	ut32 ring_head;
+	ut32 ring_tail;
 	ut64 addrmask;
 	int stacksize;
 	int stackptr;

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -745,3 +745,41 @@ EXPECT=<<EOF
 1,1,1
 EOF
 RUN
+
+NAME=esil arena is reclaimed between words, not just slots
+FILE=-
+ARGS=-e esil.stack.depth=3
+CMDS=<<EOF
+aei
+'ae 0x1122334455667788,POP,0x1122334455667788,POP,0x1122334455667788,POP,0x1122334455667788,POP,0x1122334455667788,POP,0x1122334455667788,POP,7
+EOF
+EXPECT=<<EOF
+7
+EOF
+RUN
+
+NAME=esil loop runs to the goto limit, not to the arena size
+FILE=-
+ARGS=-a x86 -b 64 -e esil.stack.depth=3 -e esil.gotolimit=4096
+CMDS=<<EOF
+aei
+ae 5,rax,=,0,rbx,=
+ae 1,rax,-,rax,=,1,rbx,+,rbx,=,rax,?{,0,GOTO,}
+ar rbx
+EOF
+EXPECT=<<EOF
+0x00000005
+EOF
+RUN
+
+NAME=esil arena wraps under a value that stays live
+FILE=-
+ARGS=-e esil.stack.depth=3
+CMDS=<<EOF
+aei
+'ae 3,2,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+,DUP,+
+EOF
+EXPECT=<<EOF
+0x50000000000
+EOF
+RUN


### PR DESCRIPTION
## The bug

`stack_buf_len` doubled as the arena allocation pointer but was only ever incremented, so it measured the bytes an expression had *ever* pushed rather than the bytes it still holds.

`r_esil_pop` cannot release them itself: an op reads the operands it popped while it pushes its result — which is exactly what lets the stack hand out slices instead of `strdup`'ing. So the bytes stayed charged until the next `r_esil_parse`. Since the arena is sized `stacksize * 32`, `esil.stack.depth` silently became a budget on an expression's *length* as well as on its depth, and length is not what it bounds.

Expressions that never nest deeper than two die on it. At the default `esil.stack.depth=256` a `GOTO` loop stops after 221 of its 4000 iterations, and the count tracks the knob linearly — 27 at 32, 3456 at 4096. It is also silent: the `r_esil_pushnum` that no longer fits raises no trap, so `r_esil_parse (...) || !esil->trap` in `core_esil.c` reads as success and the caller keeps a half-executed instruction.

## The fix

Hand bytes out at a `head` that wraps, and walk a `tail` forward between words onto the oldest value the stack still references.

**The arena stays exactly the size it was allocated with.** Both ends only move within the buffer — no trimming, no growing, no compaction, and no value is ever relocated.

Freeing at the tail while the head wraps is what recovers the space *under* a value that stays live. Walking a single high-water mark back cannot do that without moving the value; a ring can, because it reaches that space from the other side.

Two constraints fall out of the design and are handled explicitly:

- Entries are handed to ops as plain NUL-terminated `char*`, so none may straddle the wrap. A too-short run at the end of the buffer is abandoned as slack for that expression and reclaimed with everything else.
- The ring is never filled to its last byte, so `head == tail` always means empty and can never be a full ring mistaken for one.

## Results

Random expressions bounded to ten live values, run in a 1024-byte arena where the live data never exceeds ~200 bytes, checked against the same expression in a 128 KB arena:

| | expressions that ran out (of 200000) | wrong results |
|---|---|---|
| master | 149156 | 0 |
| high-water mark only | 62898 | 0 |
| ring (this PR) | **13682** | 0 |

Concrete cases, by `esil.stack.depth`:

| | 3 | 32 | 256 |
|---|---|---|---|
| `GOTO` loop, 4000 requested — master | 2 | 27 | 221 |
| `GOTO` loop — this PR | 4000 | 4000 | 4000 |
| `DUP,+` under a live value — master | 12 | 181 | 3765 |
| `DUP,+` — this PR | no limit found | no limit found | no limit found |

The second row is the case a high-water mark cannot fix: the dead bytes are underneath a live value, so only wrapping reaches them.

## Performance

`-O2`, median of 5, ns per `r_esil_parse`:

| | master | this PR |
|---|---|---|
| `1,5,+` | 149 | 167 |
| x86 `add rax,rbx` (25 words) | 1623 | 1687 |
| 32 values live, 132 words | 6877 | 7084 |
| 128 values live, 228 words | 8978 | 9113 |

`esil_arena_sync` returns in O(1) when the bottom of the stack still owns the oldest bytes and the top owns the newest, which pins both ends and is the common case.

## Note on ABI

`stack_buf_len` becomes `stack_buf_head` + `stack_buf_tail`, so `REsil` grows by 8 bytes. It is embedded by value in `RAnal` and `RCore`, so this needs a full rebuild, not just `libr/esil`. If that is unwanted mid-cycle, `stack_buf_cap` is derivable from `stacksize * 32` and can be dropped to keep the struct the same size — say the word and I will do it.

## Tests

Three cases in `db/esil/esil`, all failing on master and passing here, all at `esil.stack.depth=3` — the smallest legal value, a 96-byte arena — so they stay small instead of leaning on bulk:

- six wide push/pop pairs; master fails on the fifth push.
- a five-iteration `GOTO` loop; master stops after two.
- forty `DUP,+` doublings under a value that never leaves the stack; master stops after twelve.

`db/esil` + `db/anal` otherwise unchanged: 2142 OK before, 2145 OK after, same 190 pre-existing failures in a no-capstone build.

Beyond that, two scratch harnesses (not part of this diff), both under ASAN:

- a differential fuzzer — 200000 random expressions in a small ring versus a 128 KB arena with identical slot counts, comparing the resulting stack byte for byte. It found two real bugs during development: mid-word rewinding of the ring clobbering operands an op was still reading, and `head == tail` being read as empty when the ring was full.
- a stress harness covering live depths 4→512, `DUP` aliasing, `ROT`/`SWAP` so stack order differs from arena order, 3000 push/pop pairs at every depth 3–64, and 500 nested definition-shaped expansions at depths 3–32.

## Related

Supersedes #26568, which compacts the arena between words. Compaction fixes the same cases but moves live slices and rewrites their pointers, and its scan is O(depth²) — measured 58x slower than master at depth 32 and 711x at depth 128.

Separately, and not addressed here: `esil.stack.depth` is ignored by `core->esil.esil`, the RCoreEsil instance `ae`/`aes` use on a loaded binary — `core_esil.c` builds it from bare `r_esil_options (NULL, NULL)`, hardcoded to 4096, while the `aei` path reads the config. That is why the tests here need `aei` to reproduce.

- [x] I've added tests