### PR TITLE
Don't print a string comment for a relocated pointer slot ##disasm

### DIFF
--- a/libr/core/disasm.c
+++ b/libr/core/disasm.c
@@ -5195,6 +5195,12 @@ static bool flag_name_in_opstr(RFlagItem *f, const char *opstr) {
 	return f && opstr && (strstr (opstr, f->name) || (f->realname && strstr (opstr, f->realname)));
 }
 
+// a reloc here means the slot holds an address, not text
+static bool ds_is_ptr_slot(RDisasmState *ds, ut64 addr) {
+	return r_core_getreloc (ds->core, addr, 1)
+		&& !r_meta_get_in (ds->core->anal, addr, R_META_TYPE_STRING);
+}
+
 /* convert numeric value in opcode to ascii char or number */
 static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 	R_RETURN_IF_FAIL (ds);
@@ -5333,7 +5339,9 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					r_io_read_at (ds->core->io, ds->analop.ptr,
 						      (ut8 *)str, sizeof (str) - 1);
 					str[sizeof (str) - 1] = 0;
-					if (!string_printed && str[0] && r_str_is_printable_incl_newlines (str)) {
+					if (!string_printed && str[0]
+						&& r_str_is_printable_incl_newlines (str)
+						&& !ds_is_ptr_slot (ds, ds->analop.ptr)) {
 						ds_print_str (ds, str, sizeof (str), ds->analop.ptr);
 						string_printed = true;
 					}
@@ -5447,7 +5455,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 				}
 			}
 			if (print_msg) {
-				if (!string_printed) {
+				if (!string_printed && !ds_is_ptr_slot (ds, refaddr)) {
 					ds_print_str (ds, msg, len, refaddr);
 					string_printed = true;
 				}
@@ -5490,7 +5498,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 					}
 				} else {
 					if (r_core_anal_address (core, refaddr) & R_ANAL_ADDR_TYPE_ASCII) {
-						if (!string_printed && print_msg) {
+						if (!string_printed && print_msg && !ds_is_ptr_slot (ds, refaddr)) {
 							ds_print_str (ds, msg, len, refaddr);
 							string_printed = true;
 						}
@@ -5501,7 +5509,7 @@ static void ds_print_ptr(RDisasmState *ds, int len, int idx) {
 			kind = r_anal_data_kind (core->anal, refaddr, (const ut8*)msg, len - 1);
 			if (kind) {
 				if (!strcmp (kind, "text")) {
-					if (!string_printed && print_msg) {
+					if (!string_printed && print_msg && !ds_is_ptr_slot (ds, refaddr)) {
 						ds_print_str (ds, msg, len, refaddr);
 						string_printed = true;
 					}

--- a/test/db/cmd/cmd_pd2
+++ b/test/db/cmd/cmd_pd2
@@ -667,7 +667,7 @@ EXPECT=<<EOF
         ,=< 0x000041e0      je 0x421a
         |   0x000041e2      mov ecx, 4
         |   0x000041e7      lea rdx, [0x0001b980]
-        |   0x000041ee      lea rsi, reloc.fixup.literal               ; 0x21a40 ; "1\x8d\x01"
+        |   0x000041ee      lea rsi, reloc.fixup.literal               ; 0x21a40
         |   0x000041f5      mov rdi, rax
         |   0x000041f8      call 0xc660
         |   0x000041fe      test eax, eax
@@ -682,14 +682,14 @@ EXPECT=<<EOF
        |    0x00004225      lea rdi, str.COLUMNS                       ; 0x18a22 ; "COLUMNS"
 
             0x000041ee      lea rsi, [rip + 0x1d84b]                   ; reloc.fixup.literal
-                                                                       ; 0x21a40 ; "1\x8d\x01"
+                                                                       ; 0x21a40
             0x00004225      lea rdi, [rip + 0x147f6]                   ; str.COLUMNS
                                                                        ; 0x18a22 ; "COLUMNS"
 
         [36m,[0m[36m=[0m[36m<[0m [32m0x000041e0[0m      [32mje[33m [32m0x421a[0m[0m
         [36m|[0m   [32m0x000041e2[0m      [36mmov[37m ecx[0m,[37m [32m4[0m[0m
         [36m|[0m   [32m0x000041e7[0m      [36mlea[37m rdx[0m,[33m[33m [0m[[32m0x0001b980[0m][37m[0m[0m
-        [36m|[0m   [32m0x000041ee[0m      [36mlea[37m rsi[0m,[33m[33m reloc.fixup.literal[0m[31m               [31m; 0x21a40[31m [31m; "1\x8d\x01"[0m
+        [36m|[0m   [32m0x000041ee[0m      [36mlea[37m rsi[0m,[33m[33m reloc.fixup.literal[0m[31m               [31m; 0x21a40[0m
         [36m|[0m   [32m0x000041f5[0m      [36mmov[37m rdi[0m,[37m rax[0m[0m
         [36m|[0m   [32m0x000041f8[0m      [1;32mcall[33m [32m0xc660[0m[0m
         [36m|[0m   [32m0x000041fe[0m      [36mtest[37m eax[0m,[37m eax[0m[0m
@@ -704,14 +704,14 @@ EXPECT=<<EOF
        [36m|[0m    [32m0x00004225[0m      [36mlea[37m rdi[0m,[33m[33m str.COLUMNS[0m[31m                       [31m; 0x18a22[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [36mlea[37m rsi[0m,[37m [0m[[37mrip [0m+[33m[33m [32m0x1d84b[0m][37m[0m[31m                   [31m; reloc.fixup.literal
-            [31m                                                           [31m; 0x21a40[31m [31m; "1\x8d\x01"[0m
+            [31m                                                           [31m; 0x21a40[0m
             [32m0x00004225[0m      [36mlea[37m rdi[0m,[37m [0m[[37mrip [0m+[33m[33m [32m0x147f6[0m][37m[0m[31m                   [31m; str.COLUMNS
             [31m                                                           [31m; 0x18a22[31m [31m; "COLUMNS"[0m
 
         ,=< 0x000041e0      je 0x421a
         |   0x000041e2      mov ecx, 4
         |   0x000041e7      mov rax, qword [0x0001b980]                ; [0x1b980:8]=0x100000000
-        |   0x000041ee      mov rax, qword [reloc.fixup.literal]       ; [0x21a40:8]=0x18d31 str.literal ; "1\x8d\x01"
+        |   0x000041ee      mov rax, qword [reloc.fixup.literal]       ; [0x21a40:8]=0x18d31 str.literal
         |   0x000041f5      mov rdi, rax
         |   0x000041f8      call 0xc660
         |   0x000041fe      test eax, eax
@@ -726,14 +726,14 @@ EXPECT=<<EOF
        |    0x00004225      mov rax, qword [str.COLUMNS]               ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
 
             0x000041ee      mov rax, qword [rip + 0x1d84b]             ; reloc.fixup.literal
-                                                                       ; [0x21a40:8]=0x18d31 str.literal ; "1\x8d\x01"
+                                                                       ; [0x21a40:8]=0x18d31 str.literal
             0x00004225      mov rax, qword [rip + 0x147f6]             ; str.COLUMNS
                                                                        ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
 
         [36m,[0m[36m=[0m[36m<[0m [32m0x000041e0[0m      [32mje[33m [32m0x421a[0m[0m
         [36m|[0m   [32m0x000041e2[0m      [36mmov[37m ecx[0m,[37m [32m4[0m[0m
         [36m|[0m   [32m0x000041e7[0m      [36mmov[37m rax[0m,[33m qword[33m [0m[[32m0x0001b980[0m][37m[0m[31m                [31m; [[31m0x1b980[31m:8]=0x100000000[0m
-        [36m|[0m   [32m0x000041ee[0m      [36mmov[37m rax[0m,[33m qword[33m [0m[[33mreloc.fixup.literal[0m][37m[0m[31m       [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[31m [31m; "1\x8d\x01"[0m
+        [36m|[0m   [32m0x000041ee[0m      [36mmov[37m rax[0m,[33m qword[33m [0m[[33mreloc.fixup.literal[0m][37m[0m[31m       [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
         [36m|[0m   [32m0x000041f5[0m      [36mmov[37m rdi[0m,[37m rax[0m[0m
         [36m|[0m   [32m0x000041f8[0m      [1;32mcall[33m [32m0xc660[0m[0m
         [36m|[0m   [32m0x000041fe[0m      [36mtest[37m eax[0m,[37m eax[0m[0m
@@ -748,14 +748,14 @@ EXPECT=<<EOF
        [36m|[0m    [32m0x00004225[0m      [36mmov[37m rax[0m,[33m qword[33m [0m[[33mstr.COLUMNS[0m][37m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [36mmov[37m rax[0m,[33m qword [0m[[37mrip [0m+[33m[33m [32m0x1d84b[0m][37m[0m[31m             [31m; reloc.fixup.literal
-            [31m                                                           [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[31m [31m; "1\x8d\x01"[0m
+            [31m                                                           [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [36mmov[37m rax[0m,[33m qword [0m[[37mrip [0m+[33m[33m [32m0x147f6[0m][37m[0m[31m             [31m; str.COLUMNS
             [31m                                                           [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 
         ,=< 0x000041e0      je 0x421a
         |   0x000041e2      mov ecx, 4
         |   0x000041e7      cmp rdx, qword [0x0001b980]                ; [0x1b980:8]=0x100000000
-        |   0x000041ee      cmp rsi, qword [reloc.fixup.literal]       ; [0x21a40:8]=0x18d31 str.literal ; "1\x8d\x01"
+        |   0x000041ee      cmp rsi, qword [reloc.fixup.literal]       ; [0x21a40:8]=0x18d31 str.literal
         |   0x000041f5      mov rdi, rax
         |   0x000041f8      call 0xc660
         |   0x000041fe      test eax, eax
@@ -770,14 +770,14 @@ EXPECT=<<EOF
        |    0x00004225      cmp rdi, qword [str.COLUMNS]               ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
 
             0x000041ee      cmp rsi, qword [rip + 0x1d84b]             ; reloc.fixup.literal
-                                                                       ; [0x21a40:8]=0x18d31 str.literal ; "1\x8d\x01"
+                                                                       ; [0x21a40:8]=0x18d31 str.literal
             0x00004225      cmp rdi, qword [rip + 0x147f6]             ; str.COLUMNS
                                                                        ; [0x18a22:8]=0x534e4d554c4f43 ; "COLUMNS"
 
         [36m,[0m[36m=[0m[36m<[0m [32m0x000041e0[0m      [32mje[33m [32m0x421a[0m[0m
         [36m|[0m   [32m0x000041e2[0m      [36mmov[37m ecx[0m,[37m [32m4[0m[0m
         [36m|[0m   [32m0x000041e7[0m      [36mcmp[37m rdx[0m,[33m qword[33m [0m[[32m0x0001b980[0m][37m[0m[31m                [31m; [[31m0x1b980[31m:8]=0x100000000[0m
-        [36m|[0m   [32m0x000041ee[0m      [36mcmp[37m rsi[0m,[33m qword[33m [0m[[33mreloc.fixup.literal[0m][37m[0m[31m       [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[31m [31m; "1\x8d\x01"[0m
+        [36m|[0m   [32m0x000041ee[0m      [36mcmp[37m rsi[0m,[33m qword[33m [0m[[33mreloc.fixup.literal[0m][37m[0m[31m       [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
         [36m|[0m   [32m0x000041f5[0m      [36mmov[37m rdi[0m,[37m rax[0m[0m
         [36m|[0m   [32m0x000041f8[0m      [1;32mcall[33m [32m0xc660[0m[0m
         [36m|[0m   [32m0x000041fe[0m      [36mtest[37m eax[0m,[37m eax[0m[0m
@@ -792,7 +792,7 @@ EXPECT=<<EOF
        [36m|[0m    [32m0x00004225[0m      [36mcmp[37m rdi[0m,[33m qword[33m [0m[[33mstr.COLUMNS[0m][37m[0m[31m               [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 
             [32m0x000041ee[0m      [36mcmp[37m rsi[0m,[33m qword [0m[[37mrip [0m+[33m[33m [32m0x1d84b[0m][37m[0m[31m             [31m; reloc.fixup.literal
-            [31m                                                           [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[31m [31m; "1\x8d\x01"[0m
+            [31m                                                           [31m; [[31m0x21a40[31m:8]=0x18d31 str.literal[0m
             [32m0x00004225[0m      [36mcmp[37m rdi[0m,[33m qword [0m[[37mrip [0m+[33m[33m [32m0x147f6[0m][37m[0m[31m             [31m; str.COLUMNS
             [31m                                                           [31m; [[31m0x18a22[31m:8]=0x534e4d554c4f43[31m [31m; "COLUMNS"[0m
 EOF

--- a/test/db/cmd/cmd_pd_bugs
+++ b/test/db/cmd/cmd_pd_bugs
@@ -52,7 +52,7 @@ EXPECT=<<EOF
 |           entry0+0xd                     50             push rax
 |           entry0+0xe                     54             push rsp
 |           entry0+0xf                     4c8b05e693..   mov r8, qword [reloc.fixup.UHH_] ; [0x1f220:8]=0x16ee0
-|           entry0+0x16                    488b0de793..   mov rcx, qword [reloc.fixup.UHAWAVAUATSH8] ; [0x1f228:8]=0x16e60 ; "`n\x01"
+|           entry0+0x16                    488b0de793..   mov rcx, qword [reloc.fixup.UHAWAVAUATSH8] ; [0x1f228:8]=0x16e60
 |           entry0+0x1d                    488b3de893..   mov rdi, qword [reloc.fixup.UHAWAVAUATSHH] ; [0x1f230:8]=0x3bd0 main
 [36m/[0m 41: [33mentry0[0m (int64_t arg1, void *stack_end);
 [36m|[0m           [37m; [37marg [36mint64_t [33marg1 [32m@ rdx[0m
@@ -65,7 +65,7 @@ EXPECT=<<EOF
 [36m|[0m           [32mentry0[0m+0xd                      [33m50[0m             [35mpush[37m rax[0m[0m
 [36m|[0m           [32mentry0[0m+0xe                      [33m54[0m             [35mpush[37m rsp[0m[0m
 [36m|[0m           [32mentry0[0m+0xf                      [33m4c[36m8b[36m05[36me6[36m93[36m..   [36mmov[37m r8[0m,[33m qword[33m [0m[[33mreloc.fixup.UHH_[0m][37m[0m[31m [31m; [[31m0x1f220[31m:8]=0x16ee0[0m
-[36m|[0m           [32mentry0[0m+0x16                     [33m48[36m8b[36m0d[36me7[36m93[36m..   [36mmov[37m rcx[0m,[33m qword[33m [0m[[33mreloc.fixup.UHAWAVAUATSH8[0m][37m[0m[31m [31m; [[31m0x1f228[31m:8]=0x16e60[31m [31m; "`n\x01"[0m
+[36m|[0m           [32mentry0[0m+0x16                     [33m48[36m8b[36m0d[36me7[36m93[36m..   [36mmov[37m rcx[0m,[33m qword[33m [0m[[33mreloc.fixup.UHAWAVAUATSH8[0m][37m[0m[31m [31m; [[31m0x1f228[31m:8]=0x16e60[0m
 [36m|[0m           [32mentry0[0m+0x1d                     [33m48[36m8b[33m3d[36me8[36m93[36m..   [36mmov[37m rdi[0m,[33m qword[33m [0m[[33mreloc.fixup.UHAWAVAUATSHH[0m][37m[0m[31m [31m; [[31m0x1f230[31m:8]=0x3bd0 main[0m
 EOF
 RUN
@@ -447,5 +447,78 @@ nop
 nop
 nop
 nop
+EOF
+RUN
+
+NAME=pd got.plt stub slot not decoded as string
+FILE=bins/elf/analysis/ls-alxchk
+CMDS=pd 1 @ 0x3520
+EXPECT=<<EOF
+            ;-- fwrite_unlocked:
+            0x00003520      ff253abe0100   jmp qword [reloc.fwrite_unlocked] ; [0x1f360:8]=0x3526
+EOF
+RUN
+
+NAME=pd Cs string at a pointer slot is not overruled
+FILE=bins/elf/analysis/ls-alxchk
+ARGS=-e asm.bytes=0
+CMDS=<<EOF
+Cs 2 @ 0x1f228
+pd 1 @ 0x5e3a
+EOF
+EXPECT=<<EOF
+            0x00005e3a      mov rcx, qword [reloc.fixup.UHAWAVAUATSH8] ; [0x1f228:8]=0x16e60 ; "`n"
+EOF
+RUN
+
+NAME=pd Cs covering a pointer slot is not overruled
+FILE=bins/elf/analysis/ls-alxchk
+ARGS=-e asm.bytes=0
+CMDS=<<EOF
+Cs 16 @ 0x1f220
+pd 1 @ 0x5e3a
+EOF
+EXPECT=<<EOF
+            0x00005e3a      mov rcx, qword [reloc.fixup.UHAWAVAUATSH8] ; [0x1f228:8]=0x16e60 ; "`n\x01"
+EOF
+RUN
+
+NAME=pd string before a relocated slot keeps its comment
+FILE=bins/elf/ls
+ARGS=-e asm.bytes=0 -e io.cache=true
+CMDS=<<EOF
+wx 41424300 @ 0x21d74
+f str.ABC 4 @ 0x21d74
+wa lea rsi, [0x21d74] @ 0x5f9a
+pd 1 @ 0x5f9a
+EOF
+EXPECT=<<EOF
+            0x00005f9a      lea rsi, str.ABC                           ; 0x21d74 ; "ABC"
+EOF
+RUN
+
+NAME=pd unflagged got slot not decoded as string
+FILE=bins/elf/analysis/ls-alxchk
+ARGS=-e asm.bytes=0 -e io.cache=true
+CMDS=<<EOF
+wx 4142434445460000 @ 0x1f228
+f-*
+pd 1 @ 0x5e3a
+EOF
+EXPECT=<<EOF
+            0x00005e3a      mov rcx, qword [0x0001f228]                ; [0x1f228:8]=0x464544434241
+EOF
+RUN
+
+NAME=pd 32bit stub slot not decoded as string
+FILE=bins/mach0/hellocxx-osx-i386
+ARGS=-e asm.bytes=0
+CMDS=pd 1 @ 0x1dee
+EXPECT=<<EOF
+            ;-- section.2.__TEXT.__symbol_stub:
+            ;-- class.std::string:
+            ;-- sym.std::string._ZNKSs4sizeEv:
+            ;-- std::string::size() const:
+            0x00001dee      jmp dword [reloc.std::string::size___const] ; 0x2030 ; [02] -r-x section size 54 named 2.__TEXT.__symbol_stub
 EOF
 RUN


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

At a relocated pointer slot the bytes are an address, but `pd` decodes them as ASCII and prints the result as a string comment. Three identical GOT loads, and only the middle one gets one:

```
$ r2 -e scr.color=0 -q -c 'af; pd 11 @ entry0' bins/elf/analysis/ls-alxchk
mov r8,  qword [reloc.fixup.UHH_]          ; [0x1f220:8]=0x16ee0
mov rcx, qword [reloc.fixup.UHAWAVAUATSH8] ; [0x1f228:8]=0x16e60 ; "`n\x01"
mov rdi, qword [reloc.fixup.UHAWAVAUATSHH] ; [0x1f230:8]=0x3bd0 main
```

`0x16e60` starts with byte `0x60`, which is printable, so it decodes; the other two start with `0xe0` and `0xd0` and do not. One byte of a pointer decides it. The value is also already shown as `=0x16e60` on the same line.

**Fix**

- Suppress the string comment when a relocation starts at that address. The reloc is the evidence the slot holds an address, so nothing has to be guessed from the bytes; a value-based test cannot work, because `"ab"` and a small pointer are the same eight bytes.
- `Cs` at the address still wins, so an explicit user string is never hidden.
- The window is one byte, not the operand width: a string sitting just before a relocated slot keeps its comment.
- All four `ds_print_str` call sites in `ds_print_ptr` are gated, not only the flagged one, so the no-flag and `lea` paths behave the same.

Known limit: a `COPY` relocation relocates a data object that could genuinely be text, and is suppressed too. Telling those apart needs the per-machine reloc type, and no binary in `test/bins` shows the general rule failing.

**Tests**

Six cases in `db/cmd/cmd_pd_bugs`. Three fail without the fix: the got.plt stub slot, an unflagged slot and a 32-bit stub. The other three pin the limits rather than the fix - the two `Cs` cases fail if the metadata veto is dropped, and the string before a relocated slot fails if the window is widened from one byte to the operand width.

`db/cmd/cmd_pd2` and the `pd+reloff+colors` golden lose the junk decodes they
had pinned; no other expectation moves.