### PR TITLE
Allow to use SOURCE_DATE_EPOCH as seed

### DIFF
--- a/libr/egg/p/sc/scmangle.py
+++ b/libr/egg/p/sc/scmangle.py
@@ -287,12 +287,14 @@ def main(argv: List[str]) -> int:
     args = ap.parse_args(argv)
 
     # Seed selection
-    if args.seed is None:
-        import time
-        seed = (os.getpid() * 0x9E3779B1) ^ int(time.time_ns() & 0xFFFFFFFF)
-        seed &= 0xFFFFFFFF
+    if args.seed is not None:
+        seed = args.seed
+    elif os.environ.get('SOURCE_DATE_EPOCH') is not None:
+        seed = int(os.environ['SOURCE_DATE_EPOCH'])
     else:
-        seed = args.seed & 0xFFFFFFFF
+        import time
+        seed = (os.getpid() * 0x9E3779B1) ^ time.time_ns()
+    seed &= 0xFFFFFFFF
 
     rng = LCG(seed)
     ops = choose_ops(rng)


### PR DESCRIPTION

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->

Allow to use `SOURCE_DATE_EPOCH` as seed to make default builds more reproducible.

See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Without this patch, openSUSE's radare2-6.2.0 package had different build results on every build.

This patch was done while working on reproducible builds for openSUSE.
