### PR TITLE
Rebuild shlr objects when the headers they include change ##build

### DIFF
--- a/shlr/java/Makefile
+++ b/shlr/java/Makefile
@@ -46,4 +46,7 @@ out: ${OBJS} main.o
 		-lr_util ../sdb/src/libsdb.$(EXT_AR) ${LINK} -o out
 
 clean:
-	rm -f ${OBJS} main.o a.out $(LIBAR) out
+	rm -f ${OBJS} ${OBJS:.o=.d} main.o a.out $(LIBAR) out
+
+# autodetect dependencies object
+-include $(OBJS:.o=.d)

--- a/shlr/winkd/Makefile
+++ b/shlr/winkd/Makefile
@@ -26,3 +26,6 @@ ${LIBAR}: $(OFILES)
 
 clean:
 	rm -f $(OBJS) ${LIBAR} $(OFILES)
+
+# autodetect dependencies object
+-include $(OFILES:.o=.d)


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`shlr/java` and `shlr/winkd` compile with `-MD` but never include the `.d` files they generate, so their objects are rebuilt only when their own `.c` changes:

```
$ touch libr/include/r_bin.h && make -C shlr/java -n | grep -c class.c
0
```

An incremental build across a `libr/include` change then links objects compiled against a different struct layout. When `RBinSymbol` last gained a field, `class.o` kept writing the old one, so `RBinSymbol.name` held a `char *` where an `RBinName *` belonged and every `.class` file segfaulted at bin load in `r_bin_lang_from_symbol_name`. CI never sees this because CI builds clean.

Fix is `-include $(OBJS:.o=.d)`, as `libr/rules.mk` already does. The command above then prints 1, and `shlr/winkd` goes 0 -> 5 on `r_socket.h`. `shlr/spp` already includes its own and is unchanged.