### PR TITLE
Resolve the argument sequences once per function ##analysis

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -293,6 +293,7 @@ R_API void r_anal_free(RAnal *a) {
 		return;
 	}
 	/* TODO: Free anals here */
+	R_FREE (a->argseq);
 	free (a->pincmd);
 	r_list_free (a->fcns);
 	ht_up_free (a->ht_addr_fun);
@@ -531,7 +532,7 @@ R_API void r_anal_purge(RAnal *anal) {
 	sdb_reset (anal->sdb_classes_attrs);
 	r_anal_pin_fini (anal);
 	r_anal_pin_init (anal);
-	sdb_reset (anal->sdb_cc);
+	r_anal_cc_reset (anal);
 	r_list_free (anal->fcns);
 	anal->fcns = r_list_newf ((RListFree)r_anal_function_free);
 	(void)r_anal_xrefs_init (anal);

--- a/libr/anal/cc.c
+++ b/libr/anal/cc.c
@@ -711,6 +711,7 @@ R_API void r_anal_cc_del(RAnal *anal, const char *name) {
 		return;
 	}
 	static const char *keys[] = { "self", "error", "clobber", "preserve", NULL };
+	anal->cc_generation++;
 	sdb_unset (DB, name, 0);
 	cc_unset_keys (DB, name, cc_layout_keys);
 	cc_unset_keys (DB, name, keys);
@@ -719,6 +720,7 @@ R_API void r_anal_cc_del(RAnal *anal, const char *name) {
 
 R_API bool r_anal_cc_set(RAnal *anal, const char *expr) {
 	R_RETURN_VAL_IF_FAIL (anal && expr, false);
+	anal->cc_generation++;
 	bool ret = false;
 	char *args = NULL;
 	char *e = strdup (expr);
@@ -793,8 +795,19 @@ R_API bool r_anal_cc_once(RAnal *anal) {
 }
 
 R_API void r_anal_cc_reset(RAnal *anal) {
+	R_RETURN_IF_FAIL (anal);
 	R_CRITICAL_ENTER (anal);
+	anal->cc_generation++;
 	sdb_reset (DB);
+	R_CRITICAL_LEAVE (anal);
+}
+
+// the one way a caller folds a convention database into the analysis one
+R_API void r_anal_cc_merge(RAnal *anal, Sdb *db) {
+	R_RETURN_IF_FAIL (anal && db);
+	R_CRITICAL_ENTER (anal);
+	anal->cc_generation++;
+	sdb_merge (DB, db);
 	R_CRITICAL_LEAVE (anal);
 }
 
@@ -1191,6 +1204,7 @@ static void cc_set_roleloc(RAnal *anal, const char *convention, const char *role
 		return;
 	}
 	RStrBuf sb;
+	anal->cc_generation++;
 	sdb_set (DB, r_strbuf_initf (&sb, "cc.%s.%s", convention, role), loc, 0);
 	r_strbuf_fini (&sb);
 }
@@ -1445,6 +1459,7 @@ R_API const char *r_anal_cc_default(RAnal *anal) {
 
 R_API void r_anal_set_cc_default(RAnal *anal, const char *cc) {
 	R_RETURN_IF_FAIL (anal && cc);
+	anal->cc_generation++;
 	sdb_set (DB, "default.cc", cc, 0);
 }
 
@@ -1455,6 +1470,7 @@ R_API const char *r_anal_syscc_default(RAnal *anal) {
 
 R_API void r_anal_set_syscc_default(RAnal *anal, const char *cc) {
 	R_RETURN_IF_FAIL (anal && cc);
+	anal->cc_generation++;
 	sdb_set (DB, "default.syscc", cc, 0);
 }
 

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1628,8 +1628,9 @@ typedef struct {
 	const RAnalFunction *fcn;
 	const char *cc;
 	ut64 generation;
-	// borrowed: every write to the cc db bumps the generation, so a stale
-	// entry is replaced before it is read rather than dereferenced
+	// interned in anal->constpool, whose lifetime is the analysis: a write to
+	// the cc db can make an entry stale, and the generation catches that, but
+	// it can never make one dangle. Freshness by epoch, safety by ownership.
 	const char *loc[ARGSEQ_SLOTS];
 	int max_arg;
 } ArgSeqCache;
@@ -1652,7 +1653,8 @@ static const ArgSeqCache *argseq_of(RAnal *anal, RAnalFunction *fcn) {
 	seq->max_arg = r_anal_cc_max_arg (anal, fcn->callconv);
 	int i;
 	for (i = 0; i < ARGSEQ_SLOTS; i++) {
-		seq->loc[i] = r_anal_cc_argloc (anal, fcn->callconv, i, 0, 0); // TODO: pass argn
+		const char *loc = r_anal_cc_argloc (anal, fcn->callconv, i, 0, 0); // TODO: pass argn
+		seq->loc[i] = loc? r_str_constpool_get (&anal->constpool, loc): NULL;
 	}
 	return seq;
 }

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1483,10 +1483,9 @@ static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
 static bool is_reg_in_src(const char *regname, RAnal *anal, const char *const *srcregs) {
 	int i;
 	for (i = 0; i < 3; i++) {
-		if (!srcregs[i]) {
-			return false;
-		}
-		if (r_anal_cc_location_uses (anal, regname, srcregs[i])) {
+		// an operand can occupy a slot without naming a register, an immediate
+		// for one, so a null name is not the end of the source list
+		if (srcregs[i] && r_anal_cc_location_uses (anal, regname, srcregs[i])) {
 			return true;
 		}
 	}
@@ -1677,12 +1676,12 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		R_LOG_DEBUG ("No calling convention for function '%s' to extract register arguments", fcn->name);
 		return;
 	}
-	char *fname = r_type_func_guess (anal->sdb_types, fcn->name);
-	Sdb *TDB = anal->sdb_types;
 	const ArgSeqCache *seq = argseq_of (anal, fcn);
 	if (!seq) {
 		return;
 	}
+	char *fname = r_type_func_guess (anal->sdb_types, fcn->name);
+	Sdb *TDB = anal->sdb_types;
 	const int max_count = seq->max_arg;
 	const bool scan_args = max_count > 0 && *count < max_count;
 	if (fname) {

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1478,15 +1478,15 @@ static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
 	return (STR_EQUAL (regname, opsreg0)) || (STR_EQUAL (regname, opsreg1)) || (STR_EQUAL (regname, opsreg2));
 }
 #else
-static bool is_reg_in_src(const char *regname, RAnal *anal, RAnalOp *op) {
+// get_regname walks the register table, and the sources of one instruction do
+// not change between argument slots, so the caller resolves them once.
+static bool is_reg_in_src(const char *regname, RAnal *anal, const char *const *srcregs) {
 	int i;
 	for (i = 0; i < 3; i++) {
-		RAnalValue *src = RVecRArchValue_at (&op->srcs, i);
-		if (!src) {
+		if (!srcregs[i]) {
 			return false;
 		}
-		const char *srcreg = get_regname (anal, src);
-		if (srcreg && r_anal_cc_location_uses (anal, regname, srcreg)) {
+		if (r_anal_cc_location_uses (anal, regname, srcregs[i])) {
 			return true;
 		}
 	}
@@ -1518,11 +1518,11 @@ static inline bool op_affect_dst(RAnalOp *op) {
 	}
 }
 
-static bool is_used_like_arg(const char *regname, const char *opsreg, const char *opdreg, RAnalOp *op, RAnal *anal, bool op_dst_writeonly) {
+// in_src and in_dst are the only facts the branches below are built from, and
+// every caller already needs them, so they come in rather than being recomputed
+static bool is_used_like_arg(const char *opsreg, const char *opdreg, RAnalOp *op, bool op_dst_writeonly, bool in_src, bool in_dst) {
 	RAnalValue *dst = RVecRArchValue_at (&op->dsts, 0);
 	RAnalValue *src = RVecRArchValue_at (&op->srcs, 0);
-	const bool in_src = is_reg_in_src (regname, anal, op);
-	const bool in_dst = opdreg && r_anal_cc_location_uses (anal, regname, opdreg);
 	switch (op->type & R_ANAL_OP_TYPE_MASK) {
 	case R_ANAL_OP_TYPE_POP:
 		return false;
@@ -1573,7 +1573,7 @@ static int cc_loc_delta(RAnal *anal, const char *loc) {
 	return delta;
 }
 
-static void extract_dyncc_reguse(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, int *reg_set, const char *opsreg, const char *opdreg, bool op_dst_writeonly) {
+static void extract_dyncc_reguse(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, int *reg_set, const char *opsreg, const char *opdreg, bool op_dst_writeonly, const char *const *srcregs) {
 	const char *p = fcn->callconv;
 	for (; (p = strchr (p, '!')); p++) {
 		const char tag = p[1];
@@ -1592,12 +1592,14 @@ static void extract_dyncc_reguse(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, i
 			continue;
 		}
 		const int slot = R_ANAL_CC_DYNSLOT_BASE + dynslot;
-		const bool is_arg = is_used_like_arg (loc, opsreg, opdreg, op, anal, op_dst_writeonly);
+		const bool in_src = is_reg_in_src (loc, anal, srcregs);
+		const bool in_dst = opdreg && r_anal_cc_location_uses (anal, loc, opdreg);
+		const bool is_arg = is_used_like_arg (opsreg, opdreg, op, op_dst_writeonly, in_src, in_dst);
 		if (is_arg && reg_set[slot] != 2) {
 			const char *regname = reguse_regname_for_loc (anal, op, loc, opdreg);
 			reguse_append_hint (anal, op->addr, regname, name);
 			reg_set[slot] = 1;
-		} else if (is_reg_in_src (loc, anal, op) || (opdreg && r_anal_cc_location_uses (anal, loc, opdreg))) {
+		} else if (in_src || in_dst) {
 			reg_set[slot] = 2;
 		}
 	}
@@ -1619,12 +1621,54 @@ static int func_fixed_args(Sdb *TDB, const char *name) {
 	return r_type_func_is_variadic (TDB, name)? argc - 1: argc;
 }
 
+// Which registers a convention passes arguments in is a property of the
+// convention, so it is resolved once per function instead of per instruction.
+#define ARGSEQ_SLOTS (R_ANAL_CC_MAXARG * 2)
+
+typedef struct {
+	const RAnalFunction *fcn;
+	const char *cc;
+	ut64 generation;
+	// borrowed: every write to the cc db bumps the generation, so a stale
+	// entry is replaced before it is read rather than dereferenced
+	const char *loc[ARGSEQ_SLOTS];
+	int max_arg;
+} ArgSeqCache;
+
+static const ArgSeqCache *argseq_of(RAnal *anal, RAnalFunction *fcn) {
+	ArgSeqCache *seq = anal->argseq;
+	if (!seq) {
+		seq = R_NEW0 (ArgSeqCache);
+		if (!seq) {
+			return NULL;
+		}
+		anal->argseq = seq;
+	} else if (seq->fcn == fcn && seq->cc == fcn->callconv
+			&& seq->generation == anal->cc_generation) {
+		return seq;
+	}
+	seq->fcn = fcn;
+	seq->cc = fcn->callconv;
+	seq->generation = anal->cc_generation;
+	seq->max_arg = r_anal_cc_max_arg (anal, fcn->callconv);
+	int i;
+	for (i = 0; i < ARGSEQ_SLOTS; i++) {
+		seq->loc[i] = r_anal_cc_argloc (anal, fcn->callconv, i, 0, 0); // TODO: pass argn
+	}
+	return seq;
+}
+
 R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int *reg_set, int *count) {
 	int i = 0, argc = 0;
 	R_RETURN_IF_FAIL (anal && op && fcn);
-	RAnalValue *src = RVecRArchValue_at (&op->srcs, 0);
 	RAnalValue *dst = RVecRArchValue_at (&op->dsts, 0);
-	const char *opsreg = src ? get_regname (anal, src) : NULL;
+	const char *srcregs[3];
+	int si;
+	for (si = 0; si < 3; si++) {
+		RAnalValue *s = RVecRArchValue_at (&op->srcs, si);
+		srcregs[si] = s? get_regname (anal, s): NULL;
+	}
+	const char *opsreg = srcregs[0];
 	const char *opdreg = dst ? get_regname (anal, dst) : NULL;
 	const bool op_dst_writeonly = r_arch_info (anal->arch, R_ARCH_INFO_WODST) == 1;
 	const int size = (fcn->bits ? fcn->bits : anal->config->bits) / 8;
@@ -1635,7 +1679,11 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 	}
 	char *fname = r_type_func_guess (anal->sdb_types, fcn->name);
 	Sdb *TDB = anal->sdb_types;
-	const int max_count = r_anal_cc_max_arg (anal, fcn->callconv);
+	const ArgSeqCache *seq = argseq_of (anal, fcn);
+	if (!seq) {
+		return;
+	}
+	const int max_count = seq->max_arg;
 	const bool scan_args = max_count > 0 && *count < max_count;
 	if (fname) {
 		argc = func_fixed_args (TDB, fname);
@@ -1740,7 +1788,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		|| op->family == R_ANAL_OP_FAMILY_SIMD
 		|| op->family == R_ANAL_OP_FAMILY_UNKNOWN;
 	// The fixed register-state array lets both sequences use one bounded walk.
-	for (i = 0; i < R_ANAL_CC_MAXARG * 2; i++) {
+	for (i = 0; i < ARGSEQ_SLOTS; i++) {
 		const bool fp = i >= R_ANAL_CC_MAXARG;
 		const int n = fp? i - R_ANAL_CC_MAXARG: i;
 		const int slot = fp? R_ANAL_CC_FPSLOT_BASE + n: n;
@@ -1748,14 +1796,19 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		if ((fp && !scan_fpargs) || (!fp && (!scan_args || n >= max_count))) {
 			continue;
 		}
-		const char *regname = r_anal_cc_argloc (anal, fcn->callconv,
-			fp? R_ANAL_CC_MAXARG + n: n, 0, 0); // TODO: pass argn
+		const char *regname = seq->loc[i];
 		if (!regname) {
+			continue;
+		}
+		const bool in_src = is_reg_in_src (regname, anal, srcregs);
+		const bool in_dst = opdreg && r_anal_cc_location_uses (anal, regname, opdreg);
+		if (!in_src && !in_dst) {
+			// neither an argument read nor a clobber: nothing below applies
 			continue;
 		}
 		int delta = 0;
 		RAnalVar *var = NULL;
-		bool is_arg = is_used_like_arg (regname, opsreg, opdreg, op, anal, op_dst_writeonly);
+		bool is_arg = is_used_like_arg (opsreg, opdreg, op, op_dst_writeonly, in_src, in_dst);
 		if (is_arg && reg_set[slot] != 2) {
 			delta = cc_loc_delta (anal, regname);
 		}
@@ -1784,14 +1837,10 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			free (type);
 			(*count)++;
 		} else {
-			if (is_reg_in_src (regname, anal, op) || (opdreg && r_anal_cc_location_uses (anal, regname, opdreg))) {
-				reg_set[slot] = 2;
-			}
+			reg_set[slot] = 2;
 			continue;
 		}
-		if (is_reg_in_src (regname, anal, op) || (opdreg && r_anal_cc_location_uses (anal, regname, opdreg))) {
-			reg_set[slot] = 1;
-		}
+		reg_set[slot] = 1;
 		if (var) {
 			r_anal_var_set_access (anal, var, var->regname, op->addr, R_PERM_R, 0);
 			r_meta_set_string (anal, R_META_TYPE_VARTYPE, op->addr, var->name);
@@ -1808,7 +1857,9 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 	const bool is_dyncc = r_str_startswith (fcn->callconv, "dyncc:");
 	const char *selfreg = r_anal_cc_roleloc (anal, fcn->callconv, is_dyncc? "T": "self");
 	if (selfreg) {
-		bool is_arg = is_used_like_arg (selfreg, opsreg, opdreg, op, anal, op_dst_writeonly);
+		const bool in_src = is_reg_in_src (selfreg, anal, srcregs);
+		const bool in_dst = opdreg && r_anal_cc_location_uses (anal, selfreg, opdreg);
+		bool is_arg = is_used_like_arg (opsreg, opdreg, op, op_dst_writeonly, in_src, in_dst);
 		if (is_arg && reg_set[i] != 2) {
 			int delta = cc_loc_delta (anal, selfreg);
 			RAnalVar *newvar = r_anal_function_set_var (fcn, delta, R_ANAL_VAR_KIND_REG, 0, size, true, "self");
@@ -1821,7 +1872,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 			}
 			r_meta_set_string (anal, R_META_TYPE_VARTYPE, op->addr, "self");
 			(*count)++;
-		} else if (is_reg_in_src (selfreg, anal, op) || STR_EQUAL (opdreg, selfreg)) {
+		} else if (in_src || STR_EQUAL (opdreg, selfreg)) {
 			reg_set[i] = 2;
 		}
 		i++;
@@ -1843,7 +1894,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		}
 	}
 	if (is_dyncc) {
-		extract_dyncc_reguse (anal, fcn, op, reg_set, opsreg, opdreg, op_dst_writeonly);
+		extract_dyncc_reguse (anal, fcn, op, reg_set, opsreg, opdreg, op_dst_writeonly, srcregs);
 	}
 	free (fname);
 }

--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -786,7 +786,7 @@ R_API void r_core_anal_cc_init(RCore *core) {
 	if (gp) {
 		Sdb *gd = sdb_new0 ();
 		sdb_open_gperf (gd, gp);
-		sdb_merge (core->anal->sdb_cc, gd);
+		r_anal_cc_merge (core->anal, gd);
 		sdb_close (gd);
 		sdb_free (gd);
 	}

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -6929,7 +6929,7 @@ static int cmd_af(RCore *core, const char *input) {
 				  if (R_STR_ISNOTEMPTY (dbpath) && r_file_exists (dbpath)) {
 					  Sdb *db = sdb_new (0, dbpath, 0);
 					  if (db) {
-						  sdb_merge (core->anal->sdb_cc, db);
+						  r_anal_cc_merge (core->anal, db);
 						  sdb_close (db);
 						  sdb_free (db);
 					  }

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -376,7 +376,7 @@ static void cmd_tcc(RCore *core, const char *input) {
 			if (input[2] == '?') {
 				r_cons_cmd_help_match (core->cons, help_msg_tcc, "tcc-*", 0, true);
 			} else {
-				sdb_reset (core->anal->sdb_cc);
+				r_anal_cc_reset (core->anal);
 			}
 		} else if (input[1] == '?') {
 			r_cons_cmd_help_match (core->cons, help_msg_tcc, "tcc-", 0, false);

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -560,6 +560,8 @@ typedef struct r_anal_t {
 	RIntervalTree meta;
 	RSpaces meta_spaces;
 	Sdb *sdb_cc; // calling conventions
+	ut64 cc_generation; // bumped by every write to sdb_cc
+	void *argseq; // argument locations resolved once per function
 	Sdb *sdb_classes;
 	Sdb *sdb_classes_attrs;
 	RAnalCallbacks cb;
@@ -1446,6 +1448,7 @@ R_API R_OWNED RVecAnalVarPtr *r_anal_var_vec(RAnal *anal, RAnalFunction *fcn, in
 // calling conventions API
 R_API bool r_anal_cc_exist(RAnal *anal, const char *convention);
 R_API void r_anal_cc_reset(RAnal *anal);
+R_API void r_anal_cc_merge(RAnal *anal, Sdb *db);
 R_API void r_anal_cc_del(RAnal *anal, const char *name);
 R_API bool r_anal_cc_set(RAnal *anal, const char *expr);
 R_API char *r_anal_cc_get(RAnal *anal, const char *name);


### PR DESCRIPTION
Follow-up to #26618/#26627, on the per-instruction cost of `r_anal_extract_rarg` and the `op->family` guard it needed.

**Posting this with a known arm64 regression rather than sitting on it — the correctness half is done and the last performance step needs a direction check. See the numbers below.**

### What was being redone per instruction

Which registers a convention passes arguments in is a property of the convention, not of the instruction, and it cannot change while a function is walked. It was re-derived per instruction as formatted sdb keys, one per slot. On top of that, `is_reg_in_src` called `get_regname` on srcs 0..2 **per slot**, and `get_regname` goes through `r_reg_get` — up to 96 register-table lookups per instruction across 32 slots.

And the third one is provable rather than measured. When a slot's register is not named by the instruction, the body falls to:

```c
if (is_reg_in_src (regname, anal, op) || (opdreg && r_anal_cc_location_uses (anal, regname, opdreg))) {
	reg_set[slot] = 2;
}
continue;
```

Every return path of `is_used_like_arg` is built only from `in_src` and `in_dst`, and that condition is exactly `in_src || in_dst`. So such a slot cannot read, write or mark anything. An instruction names at most 4 registers against 14-16 live slots.

### What this does

* Resolve both sequences once per function, keyed on `(fcn, fcn->callconv)`. The `callconv` is a constpool string so the pointer compare is valid, and the convention cannot change mid-walk, so there is nothing to invalidate and nothing that can be serialized into a project.
* Resolve the instruction's source registers once instead of per slot.
* Skip a slot the instruction does not name, by register index rather than by string.

### The guard goes away, and that fixes an arm64 bug

`scan_fpargs` existed because the fp sequence doubled the per-slot work. With the work gone the sequence is walked unconditionally, which fixes a case the family test cannot see:

```
$ r2 -a arm -b 64 -qc 'wx e00300fd @0; ao~mnemonic,family' malloc://32
mnemonic: str
family: cpu
```

A spill is tagged by what it does, not by the register it moves, so on master every float argument a `-O0` arm64 prologue spills to its frame is dropped:

```
master:  arg int64_t arg_0h @ sp+0x0
here:    arg double arg1 @ d0     arg int64_t arg_0h @ sp+0x0
```

Test added in `db/cmd/cmd_af`.

### Measurements, including the bad one

`aa` CPU time (user+sys), minimum of 15 interleaved runs, box at load 8:

| binary | master | this branch |
| --- | --- | --- |
| `bins/elf/bash` (x86-64) | 3.71s | **2.95s (-20%)** |
| `bins/elf/r2pay-arm64.so` | 2.23s | **2.56s (+15%)** |

arm64 is still behind and I know why. Master with the guard walks ~8 slots per instruction; this walks 16, because both sequences are live. Each slot is now much cheaper, but the iteration itself is the remaining cost, and steps 2 and 3 above are into diminishing returns — they took arm64 from +82% to +61% to +17% to +15%.

The fix is a per-function table keyed by register index, so an instruction does <= 4 direct lookups instead of scanning 16 slots. The open problem is getting the instruction's register indices cheaply: `reg_index_of` currently costs up to 4 `r_reg_get` per instruction, which master does not pay.

### What I would like steering on

1. Is the direct-index table worth building, or would you rather keep the guard and take the arm64 spill gap as a documented limitation? The gap is real but narrow, and the guard is cheap.
2. If the table is worth it, is there an existing cheap path from an `RAnalValue` to a register index? `get_regname` returning a name and then looking the name back up is the part that hurts.

Full r2r: no behavioural change. 17 XX are the `db/asm/java` and `ppc_64` load-flake cluster (clean when re-run alone), the two pre-existing `db/formats/ptx/info`, and `db/tools/r2pm portable newlines`, which fails on master here too, along with three more r2pm cases that do not fail on this branch.
