### PR TITLE
Only read a callee prototype from a real import flag ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1658,7 +1658,7 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 		if (!f) {
 			RCore *core = (RCore *)anal->coreb.core;
 			RFlagItem *flag = r_flag_get_by_spaces (core->flags, false, offset, R_FLAGS_FS_IMPORTS, NULL);
-			if (flag) {
+			if (flag && flag->space && !strcmp (flag->space->name, R_FLAGS_FS_IMPORTS)) {
 				callee = r_type_func_guess (TDB, flag->name);
 				if (callee) {
 					const char *cc = r_anal_cc_func (anal, callee);


### PR DESCRIPTION
`r_flag_get_by_spaces` falls back to the first flag at the address when no flag exists in the space asked for, so a call to a local function could pick up an unrelated flag and guess a callee prototype from its name. `fcn.c` already guards its own lookup exactly this way.

Extracted unchanged from #26628. Verified on its own: full r2r clean apart from the two pre-existing `db/formats/ptx/info` failures.