### PR TITLE
Let an explicit anal.cc override the autodetected one ##core

### DIFF
--- a/libr/core/cconfig.c
+++ b/libr/core/cconfig.c
@@ -3534,6 +3534,8 @@ static bool cb_analcc(RCore *core, RConfigNode *node) {
 			r_core_call (core, "afcl");
 			return false;
 		}
+		// an explicit anal.cc overrides whatever the language autodetect picked
+		sdb_unset (core->anal->sdb_cc, "default.cc.autolang", 0);
 		r_anal_set_cc_default (core->anal, node->value);
 	}
 	return true;


### PR DESCRIPTION
Setting `anal.cc` left `default.cc.autolang` in place, so the convention the language autodetect had chosen could be applied again afterwards and take the value the user just asked for back out.

Extracted unchanged from #26628. Verified on its own: full r2r clean apart from the two pre-existing `db/formats/ptx/info` failures.