### PR TITLE
Fix stack SBO in hexpairs mode ##core

### DIFF
--- a/libr/core/vasm.c
+++ b/libr/core/vasm.c
@@ -50,12 +50,16 @@ static int readline_callback(RCons *cons, void *_a, const char *str) {
 		r_asm_code_free (a->acode);
 		a->acode = r_asm_assemble (core->rasm, str);
 	} else {
-		ut8 out[1024];
-		int len = r_hex_str2bin (str, out);
-		if (len > 0 && a->acode) {
-			free (a->acode->bytes);
-			a->acode->bytes = r_mem_dup (out, len);
-			a->acode->len = len;
+		size_t len = 0;
+		ut8 *out = r_hex_str2bin_dup (str, &len);
+		if (out) {
+			if (a->acode) {
+				free (a->acode->bytes);
+				a->acode->bytes = out;
+				a->acode->len = (int)len;
+			} else {
+				free (out);
+			}
 		}
 		a->codebuf[0] = 0;
 	}


### PR DESCRIPTION
The visual assembler hex input (V -> A -> !) decoded into a fixed ut8 out[1024] via r_hex_str2bin, which has no size arg and writes one byte per hex pair with no bound. The readline callback runs on every keystroke with the raw 4096-byte line buffer, so anything over 2048 hex chars runs off the end of out, onto the saved return address.

Swapped in r_hex_str2bin_dup it allocates (strlen+1)/2 and can't overrun. The buffer goes straight into acode->bytes (already freed in r_asm_code_free), so no extra copy and r_mem_dup is gone.

Checked with a small harness on libr_util, same 4096-char input:

r_hex_str2bin  -> ASAN stack-buffer-overflow at hex.c:416
 r_hex_str2bin_dup -> 2048 bytes into a 2048 buffer, clean