### PR TITLE
Fix hex string leak and hexpairs input with no code in the visual assembler ##core

### DIFF
--- a/libr/core/vasm.c
+++ b/libr/core/vasm.c
@@ -53,6 +53,9 @@ static int readline_callback(RCons *cons, void *_a, const char *str) {
 		size_t len = 0;
 		ut8 *out = r_hex_str2bin_dup (str, &len);
 		if (out) {
+			if (!a->acode) {
+				a->acode = r_asm_code_new ();
+			}
 			if (a->acode) {
 				free (a->acode->bytes);
 				a->acode->bytes = out;
@@ -63,7 +66,8 @@ static int readline_callback(RCons *cons, void *_a, const char *str) {
 		}
 		a->codebuf[0] = 0;
 	}
-	const char *hex = a->acode? r_asm_code_get_hex (a->acode): "";
+	char *hexstr = a->acode? r_asm_code_get_hex (a->acode): NULL;
+	const char *hex = r_str_get (hexstr);
 	r_cons_printf (core->cons, "[%s:%d]> %s\n",
 		a->amode? "ASM": "HEX",
 		a->acode? a->acode->len: 0, str);
@@ -92,6 +96,7 @@ static int readline_callback(RCons *cons, void *_a, const char *str) {
 	r_cons_println (core->cons, msg);
 	free (msg);
 	free (res);
+	free (hexstr);
 	r_cons_flush (core->cons);
 	return 1;
 }


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #26633 with two more issues found in the same `readline_callback` in `libr/core/vasm.c`:

- `r_asm_code_get_hex()` returns a freshly allocated string, but the callback never freed it, so the visual assembler leaked one hex string per keystroke. The string is now kept in a `char *` and released before returning, using `r_str_get()` for the empty fallback so the rest of the code is unchanged.
- In hexpairs mode the decoded bytes were silently dropped when `a->acode` was NULL (which happens if the assembler returned NULL for the previous assembly input before toggling with `!`). The callback now creates the code object with `r_asm_code_new()` in that case so the typed bytes are kept and can be written.

Syntax-checked the file with gcc -Wall -Wextra against the current headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrpL2Yti2UsnxytYdHu6GZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrpL2Yti2UsnxytYdHu6GZ)_