### PR TITLE
Patch i386 GLOB_DAT, JMP_SLOT and RELATIVE dynamic relocs ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1040,13 +1040,16 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 	ut64 A = rel->addend;
 	ut64 P = rel->rva;
 	ut8 buf[8] = {0};
-	if (rel->mode == DT_RELR) {
-		// relr has no explicit addend: the slot's own word is it
-		ut8 slot[sizeof (Elf_(Addr))] = {0};
-		if (iob->read_at (iob->io, rel->rva, slot, sizeof (slot)) != sizeof (slot)) {
+	// rel/relr carry no explicit addend: the slot's own word is it
+	if (rel->mode == DT_RELR || e_machine == EM_386) {
+		ut8 slot[8] = {0};
+		const int ws = (e_machine == EM_386)? 4: (int)sizeof (Elf_(Addr));
+		if (iob->read_at (iob->io, rel->rva, slot, ws) != ws) {
 			return;
 		}
-		A = r_read_ble (slot, bo->endian, 8 * sizeof (slot));
+		if (rel->mode == DT_RELR || rel->mode == DT_REL) {
+			A = r_read_ble (slot, bo->endian, 8 * ws);
+		}
 	}
 	switch (e_machine) {
 	case EM_S390:
@@ -1284,6 +1287,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 			word = 8;
 			V = B + A;
 			break;
+			break;
 		case R_AARCH64_GLOB_DAT:
 		case R_AARCH64_JUMP_SLOT:
 		case R_AARCH64_ABS64:
@@ -1412,25 +1416,27 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 		break;
 	}
 	case EM_386:
- 		switch (rel->type) {
- 		case R_386_32:
- 		case R_386_PC32:
-			{
-			if (r_io_nread_at (iob->io, rel->rva, buf, 4) != 4) {
-				return;
-			}
- 			ut32 v = r_read_le32 (buf) + S + A;
- 			if (rel->type == R_386_PC32) {
- 				v -= P;
- 			}
- 			r_write_le32 (buf, v);
-			iob->overlay_write_at (iob->io, rel->rva, buf, 4);
-			}
+		switch (rel->type) {
+		case R_386_32:
+			V = S + A;
 			break;
- 		default:
- 			break;
- 		}
- 		break;
+		case R_386_PC32:
+			V = S + A - P;
+			break;
+		case R_386_GLOB_DAT:
+		case R_386_JMP_SLOT:
+			V = S;
+			break;
+		case R_386_RELATIVE:
+			// wants the load bias, which is 0 in an unrebased view
+			V = A;
+			break;
+		default:
+			return;
+		}
+		r_write_ble32 (buf, V, bo->endian);
+		iob->overlay_write_at (iob->io, rel->rva, buf, 4);
+		break;
 	case EM_X86_64: {
 		int word = 0;
 		switch (rel->type) {

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -769,3 +769,76 @@ bl reloc.strcmp
 0x08012678
 EOF
 RUN
+
+NAME=ELF: i386 GOT sites resolve under bin.relocs.apply
+FILE=bins/elf/libtest_32.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~printf
+pxw 4 @ 0x200c
+pxw 4 @ 0x1fec
+EOF
+EXPECT=<<EOF
+0x0000200c 0x0000100c SET_32 7     printf
+0x0000200c  0x00002018                                   . ..
+0x00001fec  0x00002028                                   ( ..
+EOF
+RUN
+
+NAME=ELF: i386 glob_dat resolves under bin.relocs.apply (fcn_in_test)
+FILE=bins/elf/fcn_in_test.elf
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~__libc_start_main
+pxw 4 @ 0x400c
+pxw 4 @ 0x3ff4
+EOF
+EXPECT=<<EOF
+0x0000400c 0x0000300c SET_32 7     __libc_start_main
+0x0000400c  0x0000401c                                   .@..
+0x00003ff4  0x00004038                                   8@..
+EOF
+RUN
+
+NAME=ELF: i386 full-relro slot resolves under bin.relocs.apply
+FILE=bins/elf/hello_world32
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~free
+pxw 4 @ 0x1fd0
+pxw 4 @ 0x1fe8
+EOF
+EXPECT=<<EOF
+0x00001fd0 0x00000fd0 SET_32 7     free
+0x00001fd0  0x0000200c                                   . ..
+0x00001fe8  0x00002024                                   $ ..
+EOF
+RUN
+
+NAME=ELF: i386 relative reloc keeps the link base out
+FILE=bins/elf/i386-base10000-rel.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pxw 4 @ 0x132c0
+pxw 4 @ 0x122b8
+pxw 4 @ 0x132d0
+EOF
+EXPECT=<<EOF
+0x000132c0  0x00011216                                   ....
+0x000122b8  0x000132bc                                   .2..
+0x000132d0  0x000132d4                                   .2..
+EOF
+RUN
+
+NAME=ELF: i386 rela relative materializes the addend
+FILE=bins/elf/i386-base10000-rela.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pxw 4 @ 0x132d0
+pxw 4 @ 0x122c8
+EOF
+EXPECT=<<EOF
+0x000132d0  0x00011222                                   "...
+0x000122c8  0x000132cc                                   .2..
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

With `bin.relocs.apply=true` on an i386 shared object, every GOT slot keeps its file content — JMP_SLOT entries keep the lazy PLT address, GLOB_DAT stays 0:

```
$ r2 -N -q -e bin.relocs.apply=true -c 'ir~printf; pxw 4 @ 0x200c' bins/elf/libtest_32.so
0x0000200c 0x0000100c SET_32 7     printf
0x0000200c  0x00000376        <- unwritten lazy PLT value
```

- `_patch_reloc`'s `EM_386` arm wrote only `R_386_32`/`PC32`; it now covers GLOB_DAT/JMP_SLOT (`S`) and RELATIVE, sharing one write tail.
- i386 dynamic relocs are REL: the implicit in-place addend is read up front (4-byte read, skipped safely when the slot is unmapped), replacing the old read-modify-write and the stray `r_io_nread_at`.
- RELATIVE writes `A`, not `baddr + A`: the spec's `B` is the load bias, which is 0 in an unrebased view. On an ET_DYN linked at a nonzero image base the old form wrote a doubled base.

Tests: three cases on existing testbins pin GLOB_DAT/JMP_SLOT resolution, and two on the new `i386-base10000-{rel,rela}.so` fixtures pin RELATIVE both ways (nonzero-base slot unchanged; RELA slot materializes its addend). All five fail without the fix, and the RELATIVE pair also fails under `V = B + A` and under a deleted write. 