### PR TITLE
Emulate pdc blocks once in CFG order ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -23,6 +23,7 @@ typedef struct {
 	ut64 bb_jump; // edges of the block being rendered, owned by its region in structured mode
 	ut64 bb_fail;
 	HtUP *conds; // block addr => recovered condition, recovered once per block
+	HtUP *bbtext; // block addr => raw disasm text, emulated once in CFG order
 	const char *r0;
 	ut64 last_addr; // anchor of the last printed line
 	char *transfer; // pending transfer the current block's own jump renders
@@ -969,8 +970,13 @@ static char *render_bb_raw(RCore *core, RAnalBlock *bb) {
 	return code;
 }
 
+static const char *cached_bb_raw(PDCState *state, RAnalBlock *bb) {
+	return ht_up_find (state->bbtext, bb->addr, NULL);
+}
+
 static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
-	char *code = render_bb_raw (state->core, bb);
+	const char *raw = cached_bb_raw (state, bb);
+	char *code = raw? strdup (raw): NULL;
 	if (R_STR_ISEMPTY (code)) {
 		free (code);
 		return NULL;
@@ -986,6 +992,115 @@ static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
 	code[len - 1] = 0;
 	find_and_change (code, len);
 	return fold_resolved_refs (state->core, code);
+}
+
+static void seed_block(PDCState *state, RBitset *vis, ut64 addr) {
+	RAnal *anal = state->core->anal;
+	if (addr == UT64_MAX || r_bitset_test (vis, addr) || !anal->last_disasm_reg) {
+		return;
+	}
+	RAnalBlock *bb = r_anal_get_block_at (anal, addr);
+	if (!bb || bb->parent_reg_arena || !r_list_contains (bb->fcns, state->fcn)) {
+		return;
+	}
+	bb->parent_reg_arena = r_reg_arena_dup (anal->reg, anal->last_disasm_reg);
+	bb->parent_reg_arena_size = anal->last_disasm_reg_size;
+}
+
+static void emulate_block(PDCState *state, RAnalBlock *bb, const ut8 *saved, int len) {
+	RReg *reg = state->core->anal->reg;
+	if (bb->parent_reg_arena) {
+		r_reg_arena_poke (reg, bb->parent_reg_arena, bb->parent_reg_arena_size);
+		R_FREE (bb->parent_reg_arena);
+	} else {
+		r_reg_arena_poke (reg, saved, len);
+	}
+	char *raw = render_bb_raw (state->core, bb);
+	if (raw) {
+		ht_up_insert (state->bbtext, bb->addr, raw);
+	}
+}
+
+static void emulate_dfs(PDCState *state, RBitset *vis, ut64 addr, const ut8 *saved, int len) {
+	RAnalBlock *bb = (addr == UT64_MAX)? NULL: r_anal_get_block_at (state->core->anal, addr);
+	if (!bb || r_bitset_test (vis, addr) || !r_list_contains (bb->fcns, state->fcn)) {
+		return;
+	}
+	r_bitset_set (vis, addr);
+	emulate_block (state, bb, saved, len);
+	RAnalSwitchOp *sop = bb->switch_op;
+	RListIter *iter;
+	RAnalCaseOp *co;
+	seed_block (state, vis, bb->jump);
+	seed_block (state, vis, bb->fail);
+	if (sop) {
+		r_list_foreach (sop->cases, iter, co) {
+			seed_block (state, vis, co->jump);
+		}
+		seed_block (state, vis, sop->def_val);
+	}
+	emulate_dfs (state, vis, bb->jump, saved, len);
+	emulate_dfs (state, vis, bb->fail, saved, len);
+	if (sop) {
+		r_list_foreach (sop->cases, iter, co) {
+			emulate_dfs (state, vis, co->jump, saved, len);
+		}
+		emulate_dfs (state, vis, sop->def_val, saved, len);
+	}
+}
+
+// emulate once in CFG order so the text does not depend on render order
+static void pdc_emulate_blocks(PDCState *state) {
+	RReg *reg = state->core->anal->reg;
+	int len = 0;
+	ut8 *saved = r_reg_arena_peek (reg, &len);
+	RBitset *vis = r_bitset_new ();
+	emulate_dfs (state, vis, state->fcn->addr, saved, len);
+	RListIter *iter;
+	RAnalBlock *bb;
+	r_list_foreach (state->fcn->bbs, iter, bb) {
+		if (!r_bitset_test (vis, bb->addr)) {
+			r_bitset_set (vis, bb->addr);
+			emulate_block (state, bb, saved, len);
+		}
+		R_FREE (bb->parent_reg_arena);
+	}
+	r_bitset_free (vis);
+	r_reg_arena_poke (reg, saved, len);
+	free (saved);
+}
+
+// the cached render carries an address column; the orphan pass may not want it
+static char *orphan_text(PDCState *state, RAnalBlock *bb) {
+	const char *raw = cached_bb_raw (state, bb);
+	if (!raw) {
+		return strdup ("");
+	}
+	if (state->show_addr) {
+		return strdup (raw);
+	}
+	RStrBuf *sb = r_strbuf_new ("");
+	const char *p = raw;
+	while (*p) {
+		const char *end = p + strcspn (p, "\n");
+		const char *q = p;
+		if (r_str_startswith (q, "0x")) {
+			q += 2;
+			while (q < end && IS_HEXCHAR (*q)) {
+				q++;
+			}
+			while (q < end && *q == ' ') {
+				q++;
+			}
+		}
+		r_strbuf_append_n (sb, q, end - q);
+		if (!*end) {
+			break;
+		}
+		r_strbuf_append (sb, "\n");
+		p = end + 1;
+	}
+	return r_strbuf_drain (sb);
 }
 
 static bool is_known_loop_header(PDCState *state, ut64 addr) {
@@ -2308,8 +2423,10 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	r_config_set (core->config, "asm.syntax", "intel");
 	r_config_set (core->config, "asm.addr.relto", "");
 	r_config_set_i (core->config, "asm.addr.base", 16);
+	state.bbtext = ht_up_new (NULL, cond_kvfree, NULL);
 	r_io_cache_push (core->io);
 	r_core_cmd0 (core, "aeim");
+	pdc_emulate_blocks (&state);
 
 	r_strf_buffer (64);
 	RAnalBlock *bb = r_list_first (state.fcn->bbs);
@@ -2612,7 +2729,6 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 		}
 	}
 	RListIter *iter;
-	bool use_html = r_config_get_b (core->config, "scr.html");
 	// hoist unconsumed switch dispatchers before orphan labels
 	r_list_foreach (state.fcn->bbs, iter, bb) {
 		if (!bb->switch_op) {
@@ -2643,13 +2759,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			RAnalBlock *nbb = (RAnalBlock *) (nit->data);
 			nextbbaddr = nbb->addr;
 		}
-		if (use_html) {
-			r_config_set_b (core->config, "scr.html", false);
-		}
-		char *s = r_core_cmd_strf (state.core, "pdb@0x%08" PFMT64x "@e:asm.addr=%d", bb->addr, state.show_addr);
-		if (use_html) {
-			r_config_set_b (core->config, "scr.html", true);
-		}
+		char *s = orphan_text (&state, bb);
 		s = comments_to_c (s);
 		s = r_str_replace (s, "goto ", "// goto loc_", true);
 		s = cleancomments (s);
@@ -2747,6 +2857,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	print_line (&state, state.last_addr, indent, "}");
 	PRINTF ("\n");
 	r_io_cache_pop (core->io);
+	ht_up_free (state.bbtext);
 	r_config_hold_restore (hc);
 	r_config_hold_free (hc);
 	if (state.pj) {

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -947,14 +947,30 @@ static bool bb_ends_with_terminator(RCore *core, RAnalBlock *bb) {
 		|| t == R_ANAL_OP_TYPE_RET || t == R_ANAL_OP_TYPE_CRET;
 }
 
-static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
-	RCons *cons = r_core_get_cons (state->core);
+// pD would shrink the blocksize to bb->size, which clips string arguments
+static char *render_bb_raw(RCore *core, RAnalBlock *bb) {
+	ut8 *buf = malloc (bb->size);
+	if (!buf) {
+		return NULL;
+	}
+	r_io_read_at (core->io, bb->addr, buf, bb->size);
+	RCons *cons = r_core_get_cons (core);
+	const ut64 oaddr = core->addr;
+	const bool html = r_config_get_b (core->config, "scr.html");
+	r_config_set_b (core->config, "scr.html", false);
+	r_core_seek (core, bb->addr, true);
 	r_cons_push (cons);
-	bool html = r_config_get_b (state->core->config, "scr.html");
-	r_config_set_b (state->core->config, "scr.html", false);
-	char *code = r_core_cmd_strf (state->core, "pD %" PFMT64d " @ 0x%08" PFMT64x, bb->size, bb->addr);
+	r_core_print_disasm (core, bb->addr, buf, bb->size, bb->size, 0, NULL, true, false, NULL, NULL);
+	char *code = strdup (r_str_get (r_cons_get_buffer (cons, NULL)));
 	r_cons_pop (cons);
-	r_config_set_b (state->core->config, "scr.html", html);
+	r_core_seek (core, oaddr, true);
+	r_config_set_b (core->config, "scr.html", html);
+	free (buf);
+	return code;
+}
+
+static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
+	char *code = render_bb_raw (state->core, bb);
 	if (R_STR_ISEMPTY (code)) {
 		free (code);
 		return NULL;

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -2267,6 +2267,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	r_config_hold (hc, "asm.functions", "asm.section", "asm.cmt.col", "asm.sub.names", NULL);
 	r_config_hold (hc, "scr.color", "emu.str", "asm.emu", "emu.write", NULL);
 	r_config_hold (hc, "io.cache", "asm.syntax", "asm.addr.relto", "asm.addr.base", NULL);
+	r_config_hold (hc, "emu.pre", "emu.bb", NULL);
 	r_config_set_i (core->config, "scr.color", 0);
 	r_config_set_b (core->config, "asm.stackptr", false);
 	r_config_set_b (core->config, "asm.pseudo", true);
@@ -2279,6 +2280,8 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	r_config_set_b (core->config, "asm.emu", true);
 	r_config_set_b (core->config, "emu.str", true);
 	r_config_set_b (core->config, "emu.write", true);
+	r_config_set_b (core->config, "emu.pre", false);
+	r_config_set_b (core->config, "emu.bb", false);
 	r_config_set_b (core->config, "asm.lines.fcn", false);
 	r_config_set_b (core->config, "asm.comments", true);
 	r_config_set_b (core->config, "asm.functions", false);
@@ -2289,6 +2292,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	r_config_set (core->config, "asm.syntax", "intel");
 	r_config_set (core->config, "asm.addr.relto", "");
 	r_config_set_i (core->config, "asm.addr.base", 16);
+	r_io_cache_push (core->io);
 	r_core_cmd0 (core, "aeim");
 
 	r_strf_buffer (64);
@@ -2726,6 +2730,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	indent = 0;
 	print_line (&state, state.last_addr, indent, "}");
 	PRINTF ("\n");
+	r_io_cache_pop (core->io);
 	r_config_hold_restore (hc);
 	r_config_hold_free (hc);
 	if (state.pj) {

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -8,6 +8,13 @@
 R_VEC_TYPE (RVecPdcTrycatch, RBinTrycatch *);
 
 typedef struct {
+	ut64 addr;
+	bool enter; // the block gets a cache layer of its own
+	bool leave; // pops it once the subtree below is emulated
+} PdcEmuStep;
+R_VEC_TYPE (RVecPdcEmuStep, PdcEmuStep);
+
+typedef struct {
 	RCore *core;
 	RStrBuf *out;
 	RStrBuf *codestr;
@@ -23,7 +30,7 @@ typedef struct {
 	ut64 bb_jump; // edges of the block being rendered, owned by its region in structured mode
 	ut64 bb_fail;
 	HtUP *conds; // block addr => recovered condition, recovered once per block
-	HtUP *bbtext; // block addr => raw disasm text, emulated once in CFG order
+	HtUP *bbtext; // block addr => raw disasm text, emulated in CFG order
 	const char *r0;
 	ut64 last_addr; // anchor of the last printed line
 	char *transfer; // pending transfer the current block's own jump renders
@@ -948,13 +955,12 @@ static bool bb_ends_with_terminator(RCore *core, RAnalBlock *bb) {
 		|| t == R_ANAL_OP_TYPE_RET || t == R_ANAL_OP_TYPE_CRET;
 }
 
+static void kvfree(HtUPKv *kv) {
+	free (kv->value);
+}
+
 // pD would shrink the blocksize to bb->size, which clips string arguments
-static char *render_bb_raw(RCore *core, RAnalBlock *bb) {
-	ut8 *buf = malloc (bb->size);
-	if (!buf) {
-		return NULL;
-	}
-	r_io_read_at (core->io, bb->addr, buf, bb->size);
+static char *render_bb_raw(RCore *core, RAnalBlock *bb, ut8 *buf) {
 	RCons *cons = r_core_get_cons (core);
 	const ut64 oaddr = core->addr;
 	const bool html = r_config_get_b (core->config, "scr.html");
@@ -966,7 +972,6 @@ static char *render_bb_raw(RCore *core, RAnalBlock *bb) {
 	r_cons_pop (cons);
 	r_core_seek (core, oaddr, true);
 	r_config_set_b (core->config, "scr.html", html);
-	free (buf);
 	return code;
 }
 
@@ -976,9 +981,8 @@ static const char *cached_bb_raw(PDCState *state, RAnalBlock *bb) {
 
 static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
 	const char *raw = cached_bb_raw (state, bb);
-	char *code = raw? strdup (raw): NULL;
-	if (R_STR_ISEMPTY (code)) {
-		free (code);
+	char *code = R_STR_ISEMPTY (raw)? NULL: strdup (raw);
+	if (!code) {
 		return NULL;
 	}
 	code = r_str_replace (code, "\n\n", "\n", true);
@@ -994,20 +998,16 @@ static char *fetch_bb_pseudo(PDCState *state, RAnalBlock *bb) {
 	return fold_resolved_refs (state->core, code);
 }
 
-static void seed_block(PDCState *state, RBitset *vis, ut64 addr) {
-	RAnal *anal = state->core->anal;
-	if (addr == UT64_MAX || r_bitset_test (vis, addr) || !anal->last_disasm_reg) {
-		return;
+// a block the walk still owes: unvisited and belonging to the function
+static RAnalBlock *pending_block(PDCState *state, RBitset *vis, ut64 addr) {
+	RAnalBlock *bb = r_anal_get_block_at (state->core->anal, addr);
+	if (!bb || r_bitset_test (vis, addr) || !r_list_contains (bb->fcns, state->fcn)) {
+		return NULL;
 	}
-	RAnalBlock *bb = r_anal_get_block_at (anal, addr);
-	if (!bb || bb->parent_reg_arena || !r_list_contains (bb->fcns, state->fcn)) {
-		return;
-	}
-	bb->parent_reg_arena = r_reg_arena_dup (anal->reg, anal->last_disasm_reg);
-	bb->parent_reg_arena_size = anal->last_disasm_reg_size;
+	return bb;
 }
 
-static void emulate_block(PDCState *state, RAnalBlock *bb, const ut8 *saved, int len) {
+static void emulate_block(PDCState *state, RAnalBlock *bb, HtUP *bytes, const ut8 *saved, int len) {
 	RReg *reg = state->core->anal->reg;
 	if (bb->parent_reg_arena) {
 		r_reg_arena_poke (reg, bb->parent_reg_arena, bb->parent_reg_arena_size);
@@ -1015,91 +1015,143 @@ static void emulate_block(PDCState *state, RAnalBlock *bb, const ut8 *saved, int
 	} else {
 		r_reg_arena_poke (reg, saved, len);
 	}
-	char *raw = render_bb_raw (state->core, bb);
+	ut8 *buf = ht_up_find (bytes, bb->addr, NULL);
+	char *raw = buf? render_bb_raw (state->core, bb, buf): NULL;
 	if (raw) {
 		ht_up_insert (state->bbtext, bb->addr, raw);
 	}
 }
 
-static void emulate_dfs(PDCState *state, RBitset *vis, ut64 addr, const ut8 *saved, int len) {
-	RAnalBlock *bb = (addr == UT64_MAX)? NULL: r_anal_get_block_at (state->core->anal, addr);
-	if (!bb || r_bitset_test (vis, addr) || !r_list_contains (bb->fcns, state->fcn)) {
+static void push_step(RVecPdcEmuStep *steps, ut64 addr, bool enter, bool leave) {
+	PdcEmuStep step = { addr, enter, leave };
+	RVecPdcEmuStep_push_back (steps, &step);
+}
+
+// the target starts from the registers its predecessor just left behind
+static void push_successor(PDCState *state, RVecPdcEmuStep *steps, RBitset *vis, ut64 addr, bool enter) {
+	RAnal *anal = state->core->anal;
+	RAnalBlock *bb = pending_block (state, vis, addr);
+	if (!bb) {
 		return;
 	}
-	r_bitset_set (vis, addr);
-	emulate_block (state, bb, saved, len);
+	if (anal->last_disasm_reg && !bb->parent_reg_arena) {
+		bb->parent_reg_arena = r_reg_arena_dup (anal->reg, anal->last_disasm_reg);
+		bb->parent_reg_arena_size = anal->last_disasm_reg_size;
+	}
+	push_step (steps, addr, enter, false);
+}
+
+// pushed in reverse so the walk pops jump, fail, cases, default in order
+static void push_successors(PDCState *state, RVecPdcEmuStep *steps, RBitset *vis, RAnalBlock *bb) {
 	RAnalSwitchOp *sop = bb->switch_op;
-	RListIter *iter;
-	RAnalCaseOp *co;
-	seed_block (state, vis, bb->jump);
-	seed_block (state, vis, bb->fail);
+	// only the arms of a fork need keeping apart; a chain shares one layer
+	const bool fork = sop || (bb->fail != UT64_MAX && bb->jump != UT64_MAX && bb->jump != bb->fail);
 	if (sop) {
-		r_list_foreach (sop->cases, iter, co) {
-			seed_block (state, vis, co->jump);
+		push_successor (state, steps, vis, sop->def_val, fork);
+		RListIter *iter;
+		RAnalCaseOp *co;
+		r_list_foreach_prev (sop->cases, iter, co) {
+			push_successor (state, steps, vis, co->jump, fork);
 		}
-		seed_block (state, vis, sop->def_val);
 	}
-	emulate_dfs (state, vis, bb->jump, saved, len);
-	emulate_dfs (state, vis, bb->fail, saved, len);
-	if (sop) {
-		r_list_foreach (sop->cases, iter, co) {
-			emulate_dfs (state, vis, co->jump, saved, len);
+	push_successor (state, steps, vis, bb->fail, fork);
+	push_successor (state, steps, vis, bb->jump, fork);
+}
+
+// each arm of a fork stores into a cache layer its siblings never see
+static void emulate_dfs(PDCState *state, RBitset *vis, HtUP *bytes, const ut8 *saved, int len) {
+	RIO *io = state->core->io;
+	RVecPdcEmuStep steps;
+	RVecPdcEmuStep_init (&steps);
+	push_step (&steps, state->fcn->addr, false, false);
+	PdcEmuStep *top;
+	while ((top = RVecPdcEmuStep_last (&steps))) {
+		const PdcEmuStep step = *top;
+		RVecPdcEmuStep_pop_back (&steps);
+		if (step.leave) {
+			r_io_cache_pop (io);
+			continue;
 		}
-		emulate_dfs (state, vis, sop->def_val, saved, len);
+		RAnalBlock *bb = pending_block (state, vis, step.addr);
+		if (!bb) {
+			continue;
+		}
+		r_bitset_set (vis, step.addr);
+		if (step.enter) {
+			r_io_cache_push (io);
+			push_step (&steps, step.addr, false, true);
+		}
+		emulate_block (state, bb, bytes, saved, len);
+		push_successors (state, &steps, vis, bb);
 	}
+	RVecPdcEmuStep_fini (&steps);
 }
 
 // emulate once in CFG order so the text does not depend on render order
 static void pdc_emulate_blocks(PDCState *state) {
-	RReg *reg = state->core->anal->reg;
+	RCore *core = state->core;
+	RReg *reg = core->anal->reg;
 	int len = 0;
 	ut8 *saved = r_reg_arena_peek (reg, &len);
 	RBitset *vis = r_bitset_new ();
-	emulate_dfs (state, vis, state->fcn->addr, saved, len);
+	HtUP *bytes = ht_up_new (NULL, kvfree, NULL);
 	RListIter *iter;
 	RAnalBlock *bb;
 	r_list_foreach (state->fcn->bbs, iter, bb) {
+		// a seed left behind by another command would outrank the walk
+		R_FREE (bb->parent_reg_arena);
+		// stores may hit code; disassemble the bytes as they were
+		ut8 *buf = malloc (bb->size);
+		if (buf) {
+			r_io_read_at (core->io, bb->addr, buf, bb->size);
+			ht_up_insert (bytes, bb->addr, buf);
+		}
+	}
+	emulate_dfs (state, vis, bytes, saved, len);
+	r_list_foreach (state->fcn->bbs, iter, bb) {
 		if (!r_bitset_test (vis, bb->addr)) {
 			r_bitset_set (vis, bb->addr);
-			emulate_block (state, bb, saved, len);
+			emulate_block (state, bb, bytes, saved, len);
 		}
 		R_FREE (bb->parent_reg_arena);
 	}
+	ht_up_free (bytes);
 	r_bitset_free (vis);
 	r_reg_arena_poke (reg, saved, len);
 	free (saved);
 }
 
-// the cached render carries an address column; the orphan pass may not want it
-static char *orphan_text(PDCState *state, RAnalBlock *bb) {
-	const char *raw = cached_bb_raw (state, bb);
-	if (!raw) {
-		return strdup ("");
+// the raw render leads each line with the address column pdc strips
+static const char *line_after_addr(const char *line, ut64 * R_NULLABLE addr) {
+	if (*line != '0') {
+		return line;
 	}
-	if (state->show_addr) {
+	if (addr) {
+		ut64 at = r_num_get (NULL, line);
+		if (at && at != UT64_MAX) {
+			*addr = at;
+		}
+	}
+	const char *s = strchr (line, ' ');
+	return s? r_str_trim_head_ro (s + 1): "";
+}
+
+static char *orphan_text(PDCState *state, RAnalBlock *bb) {
+	const char *raw = r_str_get (cached_bb_raw (state, bb));
+	if (state->show_addr || !*raw) {
 		return strdup (raw);
 	}
 	RStrBuf *sb = r_strbuf_new ("");
-	const char *p = raw;
-	while (*p) {
-		const char *end = p + strcspn (p, "\n");
-		const char *q = p;
-		if (r_str_startswith (q, "0x")) {
-			q += 2;
-			while (q < end && IS_HEXCHAR (*q)) {
-				q++;
-			}
-			while (q < end && *q == ' ') {
-				q++;
-			}
+	RList *lines = r_str_split_duplist (raw, "\n", false);
+	RListIter *iter;
+	const char *line;
+	r_list_foreach (lines, iter, line) {
+		r_strbuf_append (sb, line_after_addr (line, NULL));
+		if (iter->n) {
+			r_strbuf_append (sb, "\n");
 		}
-		r_strbuf_append_n (sb, q, end - q);
-		if (!*end) {
-			break;
-		}
-		r_strbuf_append (sb, "\n");
-		p = end + 1;
 	}
+	r_list_free (lines);
 	return r_strbuf_drain (sb);
 }
 
@@ -1200,14 +1252,7 @@ static void emit_code_lines(PDCState *state, char *code, ut64 start_addr, int in
 	ut64 jump_at = UT64_MAX;
 	ut64 mark_at = start_addr;
 	r_list_foreach (lines, iter, line) {
-		if (*line == '0') {
-			ut64 at = r_num_get (NULL, line);
-			if (at && at != UT64_MAX) {
-				addr = at;
-			}
-			const char *s = strchr (line, ' ');
-			line = s? r_str_trim_head_ro (s + 1): "";
-		}
+		line = line_after_addr (line, &addr);
 		if (addr != mark_at) {
 			emit_trycatch_marks (state, addr, indent);
 			mark_at = addr;
@@ -1546,10 +1591,6 @@ static char *extract_loop_cond(PDCState *state, RAnalBlock *test_bb, ut64 back_t
 	}
 	free (vexpr);
 	return result;
-}
-
-static void cond_kvfree(HtUPKv *kv) {
-	free (kv->value);
 }
 
 // recovery costs a pi command and a parse, and every caller wants the same one
@@ -2301,7 +2342,7 @@ static bool pdc_structured_body(PDCState *state, int indent) {
 		return false;
 	}
 	PdcRegion *root = plan->root;
-	state->conds = ht_up_new (NULL, cond_kvfree, NULL);
+	state->conds = ht_up_new (NULL, kvfree, NULL);
 	const bool reducible = plan->complete && regions_have_blocks (state, root);
 	if (reducible) {
 		// scoped to this walk: the later orphan switch pass renders blocks no region owns
@@ -2423,7 +2464,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	r_config_set (core->config, "asm.syntax", "intel");
 	r_config_set (core->config, "asm.addr.relto", "");
 	r_config_set_i (core->config, "asm.addr.base", 16);
-	state.bbtext = ht_up_new (NULL, cond_kvfree, NULL);
+	state.bbtext = ht_up_new (NULL, kvfree, NULL);
 	r_io_cache_push (core->io);
 	r_core_cmd0 (core, "aeim");
 	pdc_emulate_blocks (&state);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -135,11 +135,11 @@ void entry0 (void) {
     loc_0x00402042:
         eax = dword [puts] // [0x4030dc:4]=0x30e8 reloc.crtdll.dll_puts // reloc.crtdll.dll_puts
         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
-        eax ()        // (pstr 0x0040100e) "LABEL" // reloc.crtdll.dll_puts // int puts("Hello, World!")
-        dword [GetProcessHeap] () // 0x403088 // (pstr 0x00401000) "Hello, World!" // reloc.kernel32.dll_GetProcessHeap // HANDLE GetProcessHeap(void)
+        eax ()        // reloc.crtdll.dll_puts // int puts("Hello, World!")
+        dword [GetProcessHeap] () // 0x403088 // reloc.kernel32.dll_GetProcessHeap // HANDLE GetProcessHeap(void)
         push (eax)
         push (">%p\\n") // 0x401014 // (pstr 0x00401014) ">%p\n"
-        dword [printf] () // 0x4030e0 // (pstr 0x0040100e) "LABEL" // reloc.crtdll.dll_printf // int printf(">%p\n", 0x30e8)
+        dword [printf] () // 0x4030e0 // reloc.crtdll.dll_printf // int printf(">%p\n", 0x30e8)
         push (0)
         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
@@ -159,7 +159,7 @@ void entry0 (void) {
  0x0040201a |         push ("LABEL") // 0x40100e // (pstr 0x0040100e) "LABEL"
  0x0040201f |         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
  0x00402024 |         push (0)
- 0x00402026 |         dword [MessageBoxA] () // 0x4030b8 // (pstr 0x00401014) ">%p\n" // reloc.user32.dll_MessageBoxA // int MessageBoxA(0, 0x401000, 0x40100e, 0)
+ 0x00402026 |         dword [MessageBoxA] () // 0x4030b8 // reloc.user32.dll_MessageBoxA // int MessageBoxA(0, 0x401000, 0x40100e, 0)
  0x0040202c |         push ("LABEL") // 0x40100e // (pstr 0x0040100e) "LABEL"
  0x00402031 |         dword [puts] () // 0x4030dc // reloc.crtdll.dll_puts // int puts("LABEL")
  0x00402037 |         esp += 4      // (pstr 0x0040100e) "LABEL"
@@ -169,16 +169,16 @@ void entry0 (void) {
  0x00402042 |     loc_0x00402042:
  0x00402042 |         eax = dword [puts] // [0x4030dc:4]=0x30e8 reloc.crtdll.dll_puts // reloc.crtdll.dll_puts
  0x00402047 |         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
- 0x0040204c |         eax ()        // (pstr 0x0040100e) "LABEL" // reloc.crtdll.dll_puts // int puts("Hello, World!")
- 0x0040204e |         dword [GetProcessHeap] () // 0x403088 // (pstr 0x00401000) "Hello, World!" // reloc.kernel32.dll_GetProcessHeap // HANDLE GetProcessHeap(void)
+ 0x0040204c |         eax ()        // reloc.crtdll.dll_puts // int puts("Hello, World!")
+ 0x0040204e |         dword [GetProcessHeap] () // 0x403088 // reloc.kernel32.dll_GetProcessHeap // HANDLE GetProcessHeap(void)
  0x00402054 |         push (eax)
  0x00402055 |         push (">%p\\n") // 0x401014 // (pstr 0x00401014) ">%p\n"
- 0x0040205a |         dword [printf] () // 0x4030e0 // (pstr 0x0040100e) "LABEL" // reloc.crtdll.dll_printf // int printf(">%p\n", 0x30e8)
+ 0x0040205a |         dword [printf] () // 0x4030e0 // reloc.crtdll.dll_printf // int printf(">%p\n", 0x30e8)
  0x00402060 |         push (0)
  0x00402062 |         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
  0x00402067 |         push ("Hello, World!") // section..data // 0x401000 // (pstr 0x00401000) "Hello, World!"
  0x0040206c |         push (0)
- 0x0040206e |         dword [MessageBoxA] () // 0x4030b8 // (pstr 0x00402074) "j" // reloc.user32.dll_MessageBoxA // int MessageBoxA(0, 0x401000, 0x401000, 0)
+ 0x0040206e |         dword [MessageBoxA] () // 0x4030b8 // reloc.user32.dll_MessageBoxA // int MessageBoxA(0, 0x401000, 0x401000, 0)
  0x00402074 |         push (0)
  0x00402076 |         dword [ExitProcess] () // 0x403084 // reloc.kernel32.dll_ExitProcess // VOID ExitProcess(0)
  0x00402076 | }
@@ -322,7 +322,7 @@ void fcn.00000000 (int64_t arg1) {
         r3 = 0
         return
     loc_0x00000008: // orphan
-        r3 = 1                   // "#"
+        r3 = 1        // "#"
         return
 
 }
@@ -698,7 +698,7 @@ pdc~printf("Results
 pdc~printf("msg
 EOF2
 EXPECT=<<EOF2
-        sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 21)
+        sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 30, 0x2710)
         sym.imp.printf () // int printf("msg : %s\n", "")
 EOF2
 RUN
@@ -1483,7 +1483,7 @@ CCu base64:Z290byBsb2NfMHgwMDAwMDAwZDs= @ 0x00000008
 CCu base64:cmV0dXJuIHJheDs= @ 0x00000008
 CCu base64:bG9jXzB4MDAwMDAwMGQ6 @ 0x0000000d
 CCu base64:ZWF4ID0gMQ== @ 0x0000000d
-CCu base64:Z290byBsb2NfMCAgICAvLyBmY24uMDAwMDAwMDAoMHgwKQ== @ 0x00000012
+CCu base64:Z290byBsb2NfMCAgICAvLyBmY24uMDAwMDAwMDAoMHgxKQ== @ 0x00000012
 CCu base64:YnJlYWs7 @ 0x0000000d
 CCu base64:bG9jXzB4MDAwMDAwMDg6IC8vIG9ycGhhbg== @ 0x00000008
 CCu base64:diA9IGVkaSAtIDkgICAvLyBhcmcx @ 0x00000008
@@ -1637,5 +1637,77 @@ pdc~catch (
 pdc~end try
 EOF
 EXPECT=<<EOF
+EOF
+RUN
+
+NAME=pdc emu string args are not clipped to the block size
+FILE=bins/elf/analysis/clark
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aa
+s main
+pdc~puts("Booh,puts("No no
+EOF
+EXPECT=<<EOF
+        sym.imp.puts () // int puts("Booh! Don't debug me!")
+            sym.imp.puts () // int puts("No no no! Don't patch me!")
+EOF
+RUN
+
+NAME=pdc leaves no emulated writes in the io cache
+FILE=bins/elf/format
+CMDS=<<EOF
+aa
+s main
+pdc~zzznomatch
+wc~?
+EOF
+EXPECT=<<EOF
+0
+EOF
+RUN
+
+NAME=pdc structured reports the same emulated args as linear
+FILE=bins/elf/format
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aa
+s main
+pdc~printf("Results
+EOF
+EXPECT=<<EOF
+    sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 30, 0x2710)
+EOF
+RUN
+
+NAME=pdc emulates each block once
+FILE=malloc://0x2000
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 488b1c2500080000488b0425000800004883c00148890425000800004883fb037c1e @ 0
+wx 488b1c2508080000488b0425080800004883c0014889042508080000eb20 @ 34
+wx 488b1c2510080000488b0425100800004883c0014889042510080000eb02 @ 64
+wx 9090 @ 94
+wx 488b1c2518080000488b0425180800004883c0014889042518080000c3 @ 96
+af @ 0
+pdc @ 0~0x808
+EOF
+EXPECT=<<EOF
+        rbx = qword [0x808] // [0x808:8]=0
+        rax = qword [0x808] // [0x808:8]=0
+        qword [0x808] = rax
+EOF
+RUN
+
+NAME=pdc renders a landing pad no edge reaches
+FILE=bins/elf/demangle-test-cpp
+CMDS=<<EOF
+aaa
+pdco @ 0x15aa~__cxa_begin_catch,loc_0x000017d8:,loc_0x000017b6:
+EOF
+EXPECT=<<EOF
+ 0x00001786 |             sym.imp.__cxa_begin_catch ()
+ 0x000017b6 |     loc_0x000017b6: // orphan
+ 0x000017d8 |     loc_0x000017d8: // orphan
 EOF
 RUN

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1656,14 +1656,20 @@ RUN
 
 NAME=pdc leaves no emulated writes in the io cache
 FILE=bins/elf/format
+ARGS=-e io.cache=true
 CMDS=<<EOF
 aa
 s main
+wx 41 @ main
+wc~?
 pdc~zzznomatch
 wc~?
+p8 1 @ main
 EOF
 EXPECT=<<EOF
-0
+1
+1
+41
 EOF
 RUN
 
@@ -1710,4 +1716,69 @@ EXPECT=<<EOF
  0x000017b6 |     loc_0x000017b6: // orphan
  0x000017d8 |     loc_0x000017d8: // orphan
 EOF
+RUN
+
+NAME=pdc seeds jump table cases from the dispatcher state
+FILE=bins/elf/ls
+ARGS=-e pdc.structured=1
+CMDS=<<EOF2
+aaa
+s 0x145b0
+pdc~rdx = rax
+EOF2
+EXPECT=<<EOF2
+                rdx = rax     // case.0x14659.0
+                rdx = rax     // case.0x14659.0
+                rdx = rax     // case.0x14659.0
+                rdx = rax     // case.0x14659.0
+                rdx = rax     // case.0x14659.0
+        rdx = rax
+EOF2
+RUN
+
+NAME=pdc disassembles the bytes an emulated store overwrote
+FILE=malloc://0x2000
+ARGS=-a x86 -b 64
+CMDS=<<EOF2
+wx c604251100000002eb06909090909090b801000000c3 @ 0
+af @ 0
+pdc @ 0~eax =
+EOF2
+EXPECT=<<EOF2
+        eax = 1
+EOF2
+RUN
+
+NAME=pdc keeps a branch's stores from the sibling branch
+FILE=malloc://0x2000
+ARGS=-a x86 -b 64
+CMDS=<<EOF2
+wx 4885ff740a488b1c2500080000eb0c48c704250008000001000000c3 @ 0
+af @ 0
+pdc @ 0~0x800]
+EOF2
+EXPECT=<<EOF2
+        qword [0x800] = 1
+        rbx = qword [0x800] // [0x800:8]=0
+EOF2
+RUN
+
+NAME=pdc ignores the seeds another command left on the blocks
+FILE=bins/elf/ls
+ARGS=-e asm.emu=true -e graph.few=true
+CMDS=<<EOF2
+aaa
+s 0x145b0
+agf~zzznomatch
+pdc~rdi = rbp
+EOF2
+EXPECT=<<EOF2
+                rdi = rbp     // rsp
+                rdi = rbp     // rsp
+                rdi = rbp     // rsp
+        rdi = rbp     // rsp
+        rdi = rbp     // rsp
+        rdi = rbp     // rsp
+        rdi = rbp     // rsp
+EOF2
 RUN

--- a/test/db/formats/jni
+++ b/test/db/formats/jni
@@ -240,7 +240,7 @@ JNINativeInterface.GetDirectBufferAddress
         JNINativeInterface.GetDirectBufferAddress (x0, x1) // void *JNINativeInterface.GetDirectBufferAddress(0, 0)
         JNINativeInterface.GetDirectBufferAddress (x0, x1) // void *JNINativeInterface.GetDirectBufferAddress(0, 0)
         JNINativeInterface.GetDirectBufferAddress (x0, x1) // void *JNINativeInterface.GetDirectBufferAddress(0, 0)
-void *JNINativeInterface.GetDirectBufferAddress(0x0, 0x0)
+void *JNINativeInterface.GetDirectBufferAddress(?, ?)
 EOF
 RUN
 
@@ -350,8 +350,8 @@ JNINativeInterface.RegisterNatives
  0x00000244 => offset='JNIInvokeInterface.GetEnv'
  0x00000270 => offset='JNINativeInterface.FindClass'
  0x00000294 => offset='JNINativeInterface.RegisterNatives'
-        JNINativeInterface.FindClass (x0, x1) // jclass JNINativeInterface.FindClass(0, "BD.\x91\xeb")
-        JNINativeInterface.RegisterNatives (x0, x1, x2, x3) // jint JNINativeInterface.RegisterNatives(0, 0, 0xd008, 0x5d)
+        JNINativeInterface.FindClass (x0, x1) // jclass JNINativeInterface.FindClass(0xffffffff, "BD.\x91\xeb")
+        JNINativeInterface.RegisterNatives (x0, x1, x2, x3) // jint JNINativeInterface.RegisterNatives(0, 0xffffffff, 0xd008, 0x5d)
 jclass JNINativeInterface.FindClass(0x0, "androidx/renderscript/RenderScript")
 jint JNINativeInterface.RegisterNatives(0x0, 0x0, 0xd008, 0x5d)
 EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`pdc` prints different program content depending on `pdc.structured`, and leaks its emulated writes into the session.

```
$ cd test
$ r2 -e scr.color=0 -NN -e pdc.structured=0 -Qc 'aa; s main; pdc' bins/elf/format | grep -E 'int puts\("Inside|int printf\("Results'
        sym.imp.puts () // int puts("Inside for loop !")
        sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 21)
$ r2 -e scr.color=0 -NN -e pdc.structured=1 -Qc 'aa; s main; pdc' bins/elf/format | grep -E 'int puts\("Inside|int printf\("Results'
        sym.imp.puts () // int puts("Inside for loop ")
    sym.imp.printf () // int printf("Results : a : %u , b: %ld\n", 21, 1)
$ r2 -NN -Qc 'ps @ 0x822' bins/elf/format
Inside for loop !
$ r2 -NN -Qc 'aa; s main; wc~?; pdc~zzz; wc~?' bins/elf/format
0
21
```

- Render blocks with `r_core_print_disasm` instead of `pD`, which shrank the blocksize to the block size and clipped string arguments to it.
- Push an io cache layer before `aeim` and pop it at teardown, so emulated stores no longer leak, and hold `emu.pre`/`emu.bb`.
- Emulate every block once, jump-first from the entry, each block starting from its predecessor's registers as `pdr` does, and let both renderers read the cached text. Each fork arm stores into its own cache layer, so siblings never see each other's writes.

Tests: nine new cases in `db/cmd/cmd_pdc`. Without the fix the linear/structured pair reads `21, 21` and `21, 1`, the string case is clipped, and the cache count is 21. Six goldens move, each away from a value that came from leaked or render-order state. Over 35 binaries, blocks whose emulated values differ between the two renderers go from 3934 to 0. 