### PR TITLE
Rename default register arguments once when recovery ends ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1952,12 +1952,25 @@ static void assign_reg_argnums(RAnal *anal, RAnalFunction *fcn, RVecAnalVarPtr *
 			continue;
 		}
 		var->argnum = dense++;
-		if (r_anal_var_is_default_argname (var->name)) {
+	}
+}
+
+// Name the register arguments after their convention order; runs once when recovery is done
+R_API void r_anal_function_rename_default_args(RAnalFunction *fcn) {
+	R_RETURN_IF_FAIL (fcn && fcn->anal);
+	RAnal *anal = fcn->anal;
+	RVecAnalVarPtr *rvars = r_anal_var_vec (anal, fcn, R_ANAL_VAR_KIND_REG);
+	assign_reg_argnums (anal, fcn, rvars);
+	RAnalVar **it;
+	R_VEC_FOREACH (rvars, it) {
+		RAnalVar *var = *it;
+		if (var->argnum >= 0 && r_anal_var_is_default_argname (var->name)) {
 			char *newname = r_str_newf ("arg%d", var->argnum + 1);
 			r_anal_var_rename (anal, var, newname);
 			free (newname);
 		}
 	}
+	RVecAnalVarPtr_free (rvars);
 }
 
 static void anal_var_ptr_append_kind(RVecAnalVarPtr *dst, RAnalFunction *fcn, int kind) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3930,7 +3930,8 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly) {
 
 	// Try plugin-based variable recovery first
 	if (r_anal_function_recover_vars_plugin (core->anal, fcn)) {
-		return;  // Done, skip ESIL-based recovery
+		r_anal_function_rename_default_args (fcn);
+		return;
 	}
 
 	// Fall back to existing ESIL-based recovery
@@ -3960,6 +3961,7 @@ R_API void r_core_recover_vars(RCore *core, RAnalFunction *fcn, bool argonly) {
 	RVecIntPtr_fini (&ctx.reg_set);
 	free (ctx.buf);
 	fcn->stack = saved_stack;
+	r_anal_function_rename_default_args (fcn);
 }
 
 // Collect plugin-provided data refs for all functions and add them as xrefs

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1336,6 +1336,7 @@ R_API R_UNOWNED RAnalVar *r_anal_function_get_var_byname(RAnalFunction *fcn, con
 R_API void r_anal_function_delete_vars_by_kind(RAnalFunction *fcn, RAnalVarKind kind);
 R_API void r_anal_function_delete_all_vars(RAnalFunction *fcn);
 R_API void r_anal_function_delete_unused_vars(RAnalFunction *fcn);
+R_API void r_anal_function_rename_default_args(RAnalFunction *fcn);
 R_API void r_anal_function_delete_var(RAnalFunction *fcn, RAnalVar *var);
 R_API bool r_anal_function_rebase_vars(RAnal *a, RAnalFunction *fcn);
 R_API st64 r_anal_function_get_var_stackptr_at(RAnalFunction *fcn, st64 delta, ut64 addr);

--- a/test/db/anal/vars
+++ b/test/db/anal/vars
@@ -729,3 +729,43 @@ void sym.setwrap ();
 void sym.top_set ();
 EOF
 RUN
+
+NAME=the signature and the variable list agree no matter which one is read first
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 4889f84889f04889d0c3
+af+ 0 myfcn
+afb+ 0 0 10
+afvr rdx arg0 int64_t
+afsq
+afvr
+afsq
+EOF
+EXPECT=<<EOF
+void myfcn (int64_t arg0);
+arg int64_t arg0 @ rdx
+void myfcn (int64_t arg0);
+EOF
+RUN
+
+NAME=float register arguments keep the same order in the signature and in the variable list
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 4889f84889f04889d0c3
+af+ 0 myfcn
+afb+ 0 0 10
+afvr xmm1 f2 double
+afvr xmm0 f1 double
+afvr rdi i1 int64_t
+afsq
+afvr
+EOF
+EXPECT=<<EOF
+void myfcn (int64_t i1, double f1, double f2);
+arg int64_t i1 @ rdi
+arg double f1 @ xmm0
+arg double f2 @ xmm1
+EOF
+RUN

--- a/test/db/cmd/cmd_zignature
+++ b/test/db/cmd/cmd_zignature
@@ -1953,7 +1953,7 @@ _start:
   next: deregister_tm_clones
   types: void entry0 (int64_t arg1)
   refs: sym.__libc_csu_fini, sym.__libc_csu_init, sym.main
-  vars: tr73:arg3:int64_t
+  vars: tr73:arg1:int64_t
   bbhash: 77ece050bbc234ae3b587a8ef8da536b640f0b000414d63490214c47b18021d2
 18
 EOF


### PR DESCRIPTION
A signature read went through `r_anal_function_vars`, which renamed default register arguments as a side effect, so a getter mutated the function. The rename now runs once at the tail of `r_core_recover_vars`; every reader is pure, `afs` and `afvr` agree, and `cc_reg_index` stays the one slot lookup (the `cmd_zignature` golden had `arg3` in vars beside `arg1` in types for that reason).