### PR TITLE
Invalidate the AMD64 variadic marker through register aliases ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2117,12 +2117,14 @@ analopfinish:
 			variadic_reg = "rax";
 #if 1
 			// XXX arm_cs plugin
+			bool dst_overlaps_variadic = false;
 			bool dst_is_variadic = dst && dst->reg && variadic_reg;
 			if (dst_is_variadic) {
 				dst_is_variadic = false;
 				RRegItem *ri0 = r_reg_get (anal->reg, dst->reg, R_REG_TYPE_GPR);
 				RRegItem *ri1 = r_reg_get (anal->reg, variadic_reg, R_REG_TYPE_GPR);
 				if (ri0 && ri1 && ri0->offset == ri1->offset) {
+					dst_overlaps_variadic = true;
 					// the convention passes the vector-register count in the low subregister, so only that one marks a variadic
 					int lowest = ri1->size;
 					RList *gprs = r_reg_get_list (anal->reg, R_REG_TYPE_GPR);
@@ -2139,10 +2141,11 @@ analopfinish:
 				}
 			}
 #else
+			bool dst_overlaps_variadic = dst && dst->reg && variadic_reg && !strcmp (dst->reg, variadic_reg);
 			bool dst_is_variadic = dst && dst->reg && variadic_reg && !strcmp (dst->reg, variadic_reg);
 #endif
 			bool op_is_cmp = (op->type == R_ANAL_OP_TYPE_CMP) || op->type == R_ANAL_OP_TYPE_ACMP;
-			if (dst_is_variadic && !op_is_cmp) {
+			if (dst_overlaps_variadic && !op_is_cmp) {
 				has_variadic_reg = false;
 			} else if (op_is_cmp) {
 				if (dst_is_variadic && src0 && src0->reg && (dst->reg == src0->reg)) {

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -706,6 +706,7 @@ afvr @ 0x0048a1b0
 EOF
 EXPECT=<<EOF
 arg int64_t arg1 @ rdi
+arg int64_t arg2 @ rsi
 arg int prec @ r8
 var []uint8 dst @ rdx
 var int i @ rcx

--- a/test/unit/test_anal_function.c
+++ b/test/unit/test_anal_function.c
@@ -249,6 +249,47 @@ bool test_r_core_anal_fcn_prefers_exact_start_match(void) {
 	mu_end;
 }
 
+bool test_r_core_anal_fcn_variadic_marker_requires_unclobbered_al(void) {
+	const ut64 addr = 0x1000;
+	const ut8 bytes[] = {
+		0x0f, 0xb6, 0x07, // movzx eax, byte [rdi]
+		0x84, 0xc0, // test al, al
+		0xc3, // ret
+		0x84, 0xc0, // test al, al
+		0x74, 0x01, // je +1
+		0xc3, // ret
+		0xc3, // ret
+	};
+	RCore *core = r_core_new ();
+	mu_assert_notnull (core, "Couldn't create new RCore");
+	core->io->va = true;
+	mu_assert_notnull (r_io_open_at (core->io, "malloc://12",
+		R_PERM_RWX, 0, addr), "open variadic marker test map");
+	mu_assert_true (r_io_write_at (core->io, addr, bytes, sizeof (bytes)),
+		"write variadic marker test bytes");
+	r_config_set (core->config, "asm.arch", "x86");
+	r_config_set_i (core->config, "asm.bits", 64);
+	r_config_set_b (core->config, "anal.esil", false);
+
+	mu_assert_true (r_core_anal_fcn (core, addr, UT64_MAX,
+		R_ANAL_REF_TYPE_NULL, 1), "analyze clobbered marker function");
+	RAnalFunction *clobbered = r_anal_get_function_at (core->anal, addr);
+	mu_assert_notnull (clobbered, "analysis creates clobbered marker function");
+	mu_assert_false (clobbered->is_variadic,
+		"writing eax invalidates the incoming al variadic marker");
+
+	const ut64 preserved_addr = addr + 6;
+	mu_assert_true (r_core_anal_fcn (core, preserved_addr, UT64_MAX,
+		R_ANAL_REF_TYPE_NULL, 1), "analyze preserved marker function");
+	RAnalFunction *preserved = r_anal_get_function_at (core->anal, preserved_addr);
+	mu_assert_notnull (preserved, "analysis creates preserved marker function");
+	mu_assert_true (preserved->is_variadic,
+		"an unclobbered test of al remains a variadic marker");
+
+	r_core_free (core);
+	mu_end;
+}
+
 bool test_r_anal_function_get_signature(void) {
 	RAnal *anal = r_anal_new ();
 	mu_assert_notnull (anal, "Couldn't create new RAnal");
@@ -662,6 +703,7 @@ int all_tests(void) {
 	mu_run_test (test_r_anal_function_labels);
 	mu_run_test (test_r_anal_str_to_fcn_returns_status);
 	mu_run_test (test_r_core_anal_fcn_prefers_exact_start_match);
+	mu_run_test (test_r_core_anal_fcn_variadic_marker_requires_unclobbered_al);
 	mu_run_test (test_r_anal_function_get_signature);
 	mu_run_test (test_r_anal_function_get_signature_prefers_exact_type_link);
 	mu_run_test (test_r_anal_function_set_signature_uses_canonical_type_name);


### PR DESCRIPTION
The AMD64 variadic heuristic remembers the incoming SysV vector-register count in `al` until that register is overwritten. After #26486 it correctly accepts only `test al, al` as the marker, but it also uses that exact-low-byte predicate to detect clobbers.

A write to `eax` or `rax` clobbers `al` too. Consequently this ordinary fixed-arity sequence is still classified as variadic:

```asm
movzx eax, byte [rax + 0x2c]
test  al, al
```

This occurs in the fixed-prototype `BZ2_bzDecompress` from a bzip2 `-O0` build. The false `is_variadic` flag also reaches callsite consumers and makes fixed callers treat the call as variadic.

Keep two facts in the scan: any destination in the `rax` alias family invalidates the incoming marker, while only the lowest subregister can prove the marker. The analysis remains a single linear instruction walk.

The unit regression analyzes real x86-64 bytes and checks both directions: `movzx eax` followed by `test al, al` stays non-variadic, while an unclobbered `test al, al` remains variadic.

Validation:

- `test/unit/bin/test_anal_function`: all 15 tests pass
- r2sleigh bzip2 integration: 49/154 functions rendered before, 58/154 after; nine refusal recoveries and zero render regressions