### PR TITLE
Read the in-place addend for implicit-addend crel relocations ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3357,6 +3357,7 @@ static bool read_crel_reloc(ELFOBJ *eo, RBinElfReloc *r, ut64 vaddr, ut64 *next_
 	crel_info.count--;
 	// Fill in the relocation structure
 	r->mode = DT_CREL;
+	r->implicit_addend = !crel_info.addend_bit;
 	r->offset = crel_info.offset;  // This is the file offset
 	r->rva = crel_info.offset;     // Also store as RVA for now, will be adjusted in fix_rva_and_offset
 	r->sym = crel_info.symidx;
@@ -3432,6 +3433,7 @@ static size_t add_relr_reloc(ELFOBJ *eo, ut64 vaddr, int type, size_t pos) {
 	RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
 	memset (reloc, 0, sizeof (*reloc));
 	reloc->mode = DT_RELR;
+	reloc->implicit_addend = true;
 	reloc->type = type;
 	reloc->offset = vaddr;
 	reloc->rva = vaddr;
@@ -3503,6 +3505,7 @@ static bool read_reloc(ELFOBJ *eo, RBinElfReloc *r, Elf_(Xword) rel_mode, ut64 v
 		r->addend = reloc_info.r_addend;
 	}
 	r->mode = rel_mode;
+	r->implicit_addend = rel_mode != DT_RELA;
 	r->offset = reloc_info.r_offset;
 	r->sym = ELF_R_SYM (reloc_info.r_info);
 	r->type = ELF_R_TYPE (reloc_info.r_info);
@@ -3823,6 +3826,7 @@ static size_t populate_relocs_record_from_mips_got(ELFOBJ *eo, size_t pos, size_
 		reloc->sym = (int)i;
 		reloc->type = R_MIPS_REL32;
 		reloc->mode = DT_REL;
+		reloc->implicit_addend = true;
 		reloc->offset = global_got + (i - gotsym) * wordsize;
 		fix_rva_and_offset_exec_file (eo, reloc);
 		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -70,6 +70,7 @@ typedef struct r_bin_elf_reloc_t {
 	int sym;
 	int type;
 	Elf_(Xword) mode;
+	bool implicit_addend;
 	st64 addend;
 	ut64 offset;
 	ut64 rva;

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -509,7 +509,7 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr, RV
 		} else {
 			r->type = R_BIN_RELOC_64;
 		}
-		r->additive = true;
+		r->additive = !rel->implicit_addend;
 	}
 	if (rel->sym) {
 		if (rel->sym < eo->imports_by_ord_size && eo->imports_by_ord[rel->sym]) {
@@ -522,7 +522,7 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr, RV
 	ut64 sym_vaddr = r->symbol ? r->symbol->vaddr : (rel->sym ? rel->rva : 0);
 
 	#define SET(T) r->type = R_BIN_RELOC_ ## T; r->additive = 0; return r
-	#define ADD(T, A) do { r->type = R_BIN_RELOC_ ## T; st32 _tmp; if (!r_add_overflow_st32 (r->addend, A, &_tmp)) { r->addend = _tmp; } r->additive = rel->mode == DT_RELA || rel->mode == DT_CREL; return r; } while (0)
+	#define ADD(T, A) do { r->type = R_BIN_RELOC_ ## T; st32 _tmp; if (!r_add_overflow_st32 (r->addend, A, &_tmp)) { r->addend = _tmp; } r->additive = !rel->implicit_addend; return r; } while (0)
 
 	// Early return if it's a CREL relocation - it was already set up in the initialization above
 	if (rel->mode == DT_CREL) {
@@ -1047,7 +1047,7 @@ static void _patch_reloc(ELFOBJ *bo, ut16 e_machine, RIOBind *iob, RBinElfReloc 
 		if (iob->read_at (iob->io, rel->rva, slot, ws) != ws) {
 			return;
 		}
-		if (rel->mode == DT_RELR || rel->mode == DT_REL) {
+		if (rel->implicit_addend) {
 			A = r_read_ble (slot, bo->endian, 8 * ws);
 		}
 	}

--- a/test/db/formats/elf/crelocs
+++ b/test/db/formats/elf/crelocs
@@ -29,3 +29,18 @@ vaddr      paddr      type   ntype name
 EOF
 RUN
 
+
+NAME=ELF: i386 implicit-addend crel patches with the in-place word
+FILE=bins/elf/i386-crel-implicit.o
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pxw 4 @ 0x08000035
+pxw 4 @ 0x0800003a
+pxw 4 @ 0x08000048
+EOF
+EXPECT=<<EOF
+0x08000035  0x00000006                                   ....
+0x0800003a  0x08000044                                   D...
+0x08000048  0x08000048                                   H...
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A CREL relocation whose header has the addend bit clear keeps its addend in the slot (REL-style), but r2 records `addend = 0` and never reads the slot, so `bin.relocs.apply=true` patches the wrong value:

```
$ r2 -N -q -e bin.relocs.apply=true -c 'pxw 4 @ 0x0800003a' bins/elf/i386-crel-implicit.o
0x0800003a  0x08000040        <- S + 0; the in-place addend (+4) was dropped
# with this fix: 0x08000044
```

- `RBinElfReloc` gains `implicit_addend`, set by all four readers (REL, RELR, CREL from the header bit, RELA false).
- `_patch_reloc`'s i386 prologue and `reloc_convert`'s `additive` key on the flag instead of enumerating modes — RELR/REL behavior is unchanged.

Test: one case on the new `i386-crel-implicit.o` fixture asserting the three patched words; it fails without the fix, and flipping the flag's polarity also breaks the existing aarch64 `compact relocs` case, so both flavors are pinned. The fixture is in testbins master (radareorg/radare2-testbins#135).

Not addressed here: relocs in a second `.crel.*` section are still dropped (file-global decoder state); that is a separate report.