### PR TITLE
Patch aarch64 ET_REL GOT relocs against the import slot ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -115,7 +115,7 @@ static bool sections_vec(RBinFile *bf) {
 	return true;
 }
 
-static bool reloc_is_import(ELFOBJ *eo, const RBinElfReloc *rel) {
+static inline bool reloc_is_import(ELFOBJ *eo, const RBinElfReloc *rel) {
 	return rel->sym && rel->sym < eo->imports_by_ord_size && eo->imports_by_ord[rel->sym];
 }
 

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -115,6 +115,10 @@ static bool sections_vec(RBinFile *bf) {
 	return true;
 }
 
+static bool reloc_is_import(ELFOBJ *eo, const RBinElfReloc *rel) {
+	return rel->sym && rel->sym < eo->imports_by_ord_size && eo->imports_by_ord[rel->sym];
+}
+
 #ifndef R_BIN_CGC
 #include "../format/swift/swift.h"
 
@@ -141,7 +145,7 @@ static char *swift_elf_slot(void *user, ut64 va, ut64 *target) {
 	RBinElfReloc *rel = ctx->relocs_ht? ht_up_find (ctx->relocs_ht, va, NULL): NULL;
 	if (rel) {
 		if (rel->sym > 0) {
-			if (rel->sym < eo->imports_by_ord_size && eo->imports_by_ord[rel->sym]) {
+			if (reloc_is_import (eo, rel)) {
 				return strdup (r_bin_name_tostring2 (eo->imports_by_ord[rel->sym]->name, 'o'));
 			}
 			if (rel->sym < eo->symbols_by_ord_size && eo->symbols_by_ord[rel->sym]) {
@@ -511,12 +515,10 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr, RV
 		}
 		r->additive = !rel->implicit_addend;
 	}
-	if (rel->sym) {
-		if (rel->sym < eo->imports_by_ord_size && eo->imports_by_ord[rel->sym]) {
-			r->import = r_bin_import_clone (eo->imports_by_ord[rel->sym]);
-		} else if (rel->sym < eo->symbols_by_ord_size && eo->symbols_by_ord[rel->sym]) {
-			r->symbol = eo->symbols_by_ord[rel->sym];
-		}
+	if (reloc_is_import (eo, rel)) {
+		r->import = r_bin_import_clone (eo->imports_by_ord[rel->sym]);
+	} else if (rel->sym && rel->sym < eo->symbols_by_ord_size && eo->symbols_by_ord[rel->sym]) {
+		r->symbol = eo->symbols_by_ord[rel->sym];
 	}
 
 	ut64 sym_vaddr = r->symbol ? r->symbol->vaddr : (rel->sym ? rel->rva : 0);
@@ -684,6 +686,9 @@ static RBinReloc *reloc_convert(ELFOBJ* eo, RBinElfReloc *rel, ut64 got_addr, RV
 		case R_AARCH64_LDST128_ABS_LO12_NC:
 		case R_AARCH64_ADR_PREL_LO21:
 		case R_AARCH64_LD_PREL_LO19:
+		case R_AARCH64_GOT_LD_PREL19:
+		case R_AARCH64_ADR_GOT_PAGE:
+		case R_AARCH64_LD64_GOT_LO12_NC:
 		case R_AARCH64_TSTBR14:
 		case R_AARCH64_CONDBR19:
 		// a type patched here but unconverted aliases onto the next import slot
@@ -1026,6 +1031,11 @@ static void aarch64_patch_adr(RIOBind *iob, ut64 at, st64 imm) {
 		((ut32)(imm & 3) << 29) | ((ut32)(imm >> 2) << 5));
 }
 
+static bool aarch64_got_reloc(int type) {
+	return type == R_AARCH64_ADR_GOT_PAGE || type == R_AARCH64_LD64_GOT_LO12_NC
+		|| type == R_AARCH64_GOT_LD_PREL19;
+}
+
 static void aarch64_patch_branch(RIOBind *iob, RBinElfReloc *rel, ut64 at, st64 disp, int nbits, int shift) {
 	// a truncated branch invents a call target, worse than leaving it
 	if ((disp & 3) || !disp_fits (disp, nbits + 2)) {
@@ -1238,12 +1248,21 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 		break;
 	case EM_AARCH64: {
 		int word = 0;
+		// only an import has a GOT entry here: the .got.r2 slot that S names
+		if (aarch64_got_reloc (rel->type)) {
+			if (!reloc_is_import (bo, rel)) {
+				R_LOG_DEBUG ("unpatched aarch64 got reloc %d at 0x%"PFMT64x, rel->type, rel->rva);
+				break;
+			}
+			A = 0; // the addend selects the entry, it is no offset from it
+		}
 		switch (rel->type) {
+		case R_AARCH64_ADR_GOT_PAGE:
 		case R_AARCH64_ADR_PREL_PG_HI21:
 		case R_AARCH64_ADR_PREL_PG_HI21_NC: {
 			const st64 imm = (((st64)(S + A) & ~(st64)0xfff) - ((st64)P & ~(st64)0xfff)) >> 12;
-			// the _NC variant is defined to wrap, so only the checked one is refused
-			if (rel->type == R_AARCH64_ADR_PREL_PG_HI21 && !disp_fits (imm, 21)) {
+			// the _NC variant is defined to wrap, so only the checked ones are refused
+			if (rel->type != R_AARCH64_ADR_PREL_PG_HI21_NC && !disp_fits (imm, 21)) {
 				R_LOG_DEBUG ("unencodable aarch64 reloc %d at 0x%"PFMT64x, rel->type, rel->rva);
 				break;
 			}
@@ -1255,6 +1274,7 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 		case R_AARCH64_LDST16_ABS_LO12_NC:
 		case R_AARCH64_LDST32_ABS_LO12_NC:
 		case R_AARCH64_LDST64_ABS_LO12_NC:
+		case R_AARCH64_LD64_GOT_LO12_NC:
 		case R_AARCH64_LDST128_ABS_LO12_NC: {
 			int shift = 0;
 			switch (rel->type) {
@@ -1265,6 +1285,7 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 				shift = 2;
 				break;
 			case R_AARCH64_LDST64_ABS_LO12_NC:
+			case R_AARCH64_LD64_GOT_LO12_NC:
 				shift = 3;
 				break;
 			case R_AARCH64_LDST128_ABS_LO12_NC:
@@ -1282,6 +1303,7 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 			break;
 		case R_AARCH64_CONDBR19:
 		case R_AARCH64_LD_PREL_LO19:
+		case R_AARCH64_GOT_LD_PREL19:
 			aarch64_patch_branch (iob, rel, P, (st64)(S + A) - (st64)P, 19, 5);
 			break;
 		case R_AARCH64_TSTBR14:
@@ -1654,7 +1676,7 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 			ut64 sym_addr = 0;
 			if (rel->sym) {
 				// Check imports first
-				if (rel->sym < bo->imports_by_ord_size && bo->imports_by_ord[rel->sym]) {
+				if (reloc_is_import (bo, rel)) {
 					RBinImport *import = bo->imports_by_ord[rel->sym];
 					if (import && import->name) {
 						sym_name = r_bin_name_tostring (import->name);
@@ -1808,8 +1830,7 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	R_VEC_FOREACH (relocs, reloc) {
 		ut64 plt_entry_addr = vaddr;
 		ut64 sym_addr = UT64_MAX;
-		const bool is_import = reloc->sym && reloc->sym < eo->imports_by_ord_size
-			&& eo->imports_by_ord[reloc->sym];
+		const bool is_import = reloc_is_import (eo, reloc);
 
 		if (is_import) {
 			bool found;

--- a/test/db/formats/elf/elf-relarm64
+++ b/test/db/formats/elf/elf-relarm64
@@ -92,3 +92,37 @@ EXPECT=<<EOF
 sym.branch_relocs 0x8000044 [CALL:--x] bl sym.local_target
 EOF
 RUN
+
+NAME=ELF: aarch64 ET_REL GOT relocs patch an import slot but not a defined symbol
+FILE=bins/elf/aarch64-got-etrel.o
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir
+p8 20 @ 0x08000040
+EOF
+EXPECT=<<EOF
+vaddr      paddr      type   ntype name
+---------------------------------------
+0x08000040 0x00000040 ADD_32 311   gdef
+0x08000044 0x00000044 ADD_32 312   gdef
+0x08000188 0x00000048 ADD_32 311   gundef
+0x08000188 0x0000004c ADD_32 312   gundef
+00000090000040f90100009021c440f9c0035fd6
+EOF
+RUN
+
+NAME=ELF: aarch64 ET_REL ADR_GOT_PAGE encodes the page of the import slot
+FILE=bins/elf/ptx/ptx_ops.o
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~__stack_chk_guard:0
+p8 8 @ 0x08000080
+pd 2 @ 0x08000080
+EOF
+EXPECT=<<EOF
+0x08003550 0x00000080 ADD_32 311   __stack_chk_guard
+000000f000a842f9
+            0x08000080      000000f0       adrp x0, 0x8003000
+            0x08000084      00a842f9       ldr x0, [x0, 0x550]
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

An aarch64 ET_REL object built with `-fPIC` reaches its globals through `adrp :got:` / `ldr :got_lo12:` pairs. r2 neither lists those relocations nor patches them, so with `bin.relocs.apply=true` the load still goes through the ELF header:

```
$ r2 -N -q -e bin.relocs.apply=true -c 'ir; pd 4 @ 0x08000040' bins/elf/aarch64-got-etrel.o
vaddr paddr type ntype name
---------------------------
            0x08000040      00000090       adrp x0, segment.ehdr       ; 0x8000000
            0x08000044      000040f9       ldr x0, [x0]
            0x08000048      01000090       adrp x1, segment.ehdr       ; 0x8000000
            0x0800004c      210040f9       ldr x1, [x1]
```

With this change the second pair (an undefined symbol) resolves to its `.got.r2` slot, `ldr x1, [x1, 0x188]`, and all four relocations show in `ir`.

## The fix

- `R_AARCH64_ADR_GOT_PAGE`, `LD64_GOT_LO12_NC` and `GOT_LD_PREL19` are converted like the other instruction relocations and patched through the existing ADRP, LDST64 and LD_PREL19 bodies, with the addend dropped: for a GOT relocation it selects the entry, it is not an offset from it.
- They are patched only when the symbol is an import. For an import the `.got.r2` slot r2 hands `_patch_reloc` really is the GOT entry; for a defined symbol `S` is the symbol's own storage, and patching would make the pair compute `&g` and then dereference it. Those stay unpatched and keep their `RELOC` comment.
- The import test that four sites spelled out by hand moves into one helper so the patcher can ask the same question.
- An import referenced only through the GOT now takes a `.got.r2` slot, so later import slots in such an object move by one slot.

## Tests

Two cases in `db/formats/elf/elf-relarm64`: `elf/aarch64-got-etrel.o` pins the reloc list and bytes of a defined and an undefined GOT pair, `elf/ptx/ptx_ops.o` pins a non-zero ADRP page delta. Neither has a non-zero GOT addend; that was checked on an `llvm-mc` object with `:got:sym+8`.