### PR TITLE
Add r2r tests for the ppc32 _SDA_BASE_ agree/disagree gp seed ##test

### DIFF
--- a/test/db/cmd/cmd_eval
+++ b/test/db/cmd/cmd_eval
@@ -102,6 +102,22 @@ EXPECT=<<EOF
 EOF
 RUN
 
+NAME=e anal.gp(ppc32 _SDA_BASE_ agrees with .sdata+0x8000)
+FILE=bins/elf/ppc32-sda-agree
+CMDS=e anal.gp
+EXPECT=<<EOF
+0x1000801c
+EOF
+RUN
+
+NAME=e anal.gp(ppc32 _SDA_BASE_ disagrees with .sdata+0x8000, not seeded)
+FILE=bins/elf/ppc32-sda-disagree
+CMDS=e anal.gp
+EXPECT=<<EOF
+0
+EOF
+RUN
+
 NAME=e asm.os
 FILE=bins/elf/analysis/hello-linux-x86_64
 CMDS=e asm.os=?


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`ppc32_sda_base` seeds `anal.gp` from `.sdata + 0x8000` only when a `_SDA_BASE_` symbol, if present, agrees with it; toolchains that use r2 as the TLS pointer define it elsewhere and must not be seeded. The seed and no-`.sdata` paths have tests, the agree/disagree guard has none, because no testbin carried both `.sdata` and `_SDA_BASE_`:

```
$ r2 -qc 'e anal.gp' bins/elf/ppc32-sda-agree
0x1000801c
$ r2 -qc 'e anal.gp' bins/elf/ppc32-sda-disagree
0
```

## Tests

Two `e anal.gp` cases in `db/cmd/cmd_eval` on `elf/ppc32-sda-{agree,disagree}` (radare2-testbins, linked from one stub with `_SDA_BASE_` at `.sdata + 0x8000` and `+ 0x100`). Dropping the guard or the symbol lookup fails the disagree case; inverting the guard fails both. The `loc._SDA_BASE_` arm (NOTYPE symbol) stays uncovered, both fixtures define it as OBJECT.