### PR TITLE
Save a base type under the spelling that refers to it ##types

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -416,8 +416,14 @@ static RAnalBaseType *get_atomic_type(RAnal *anal, const char *sname) {
 R_API RAnalBaseType *r_anal_get_base_type(RAnal *anal, const char *name) {
 	R_RETURN_VAL_IF_FAIL (anal && name, NULL);
 
-	char *sname = r_str_sanitize_sdb_key (name);
+	// a base type is saved under its C spelling; composites and typedefs still under the sanitized one
+	char *sname = strdup (name);
 	const char *type = sdb_const_get (anal->sdb_types, sname, NULL);
+	if (!type) {
+		free (sname);
+		sname = r_str_sanitize_sdb_key (name);
+		type = sdb_const_get (anal->sdb_types, sname, NULL);
+	}
 	if (!type) {
 		free (sname);
 		return NULL;
@@ -642,6 +648,14 @@ static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	free (sname);
 }
 
+// a base type's key is the C spelling typedefs and members refer to it by; only what sdb cannot key is refused
+static char *atomic_type_key(const char *name) {
+	if (R_STR_ISEMPTY (name) || strpbrk (name, "=,\n")) {
+		return NULL;
+	}
+	return strdup (name);
+}
+
 static void save_atomic_type(const RAnal *anal, const RAnalBaseType *type) {
 	r_strf_buffer (KSZ);
 	R_RETURN_IF_FAIL (anal && type && type->name);
@@ -653,7 +667,10 @@ static void save_atomic_type(const RAnal *anal, const RAnalBaseType *type) {
 		type.char=c
 		type.char.size=8
 	*/
-	char *sname = r_str_sanitize_sdb_key (type->name);
+	char *sname = atomic_type_key (type->name);
+	if (!sname) {
+		return;
+	}
 	sdb_set (anal->sdb_types, sname, "type", 0);
 #if 0
 	sdb_num_set (anal->sdb_types, r_strf ("type.%s.size", sname), type->size, 0);

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -714,3 +714,15 @@ var bool hasDecimalPoint @ r9
 var []uint8 tail @ r10
 EOF
 RUN
+
+NAME=a base type spelled with spaces keeps its width
+FILE=bins/elf/ppc64_sudoku_dwarf
+CMDS=<<EOF
+k anal/types/long unsigned int
+tss long unsigned int
+EOF
+EXPECT=<<EOF
+type
+8
+EOF
+RUN


### PR DESCRIPTION
The key a base type is saved under is the spelling every other record names it by: a typedef stores its target verbatim, and so does every variable and struct member typed with it. `save_atomic_type` ran the name through `r_str_sanitize_sdb_key` first, which rewrites spaces, so a base type imported from DWARF as `long unsigned int` was filed as `long_unsigned_int`.

Nothing ever looks that key up, so the type and its size became unreachable, and `r_type_get_bitsize` answered zero for the base type and for every typedef of it.

A base type name is a C spelling and may carry spaces. This saves it verbatim and refuses only what sdb cannot carry in a key (`=`, `,`, newline).

### Reproducing

Any binary with DWARF built by gcc: zlib's `minigzip` is the one used here.

```
$ radare2 -q -N -c 'aaa; tk long unsigned int; tk long_unsigned_int; tk type.long unsigned int.size; tk type.long_unsigned_int.size' minigzip
```

| query | before | after |
| --- | --- | --- |
| `long unsigned int` | *(absent)* | `type` |
| `long_unsigned_int` | `type` | *(absent)* |
| `type.long unsigned int.size` | *(absent)* | `64` |
| `type.long_unsigned_int.size` | `64` | *(absent)* |

Downstream, every zlib integer alias (`uLong`, `ulg`, `uInt`) had no width before this.

### Tests

`r2r db` passes; `db/cmd/types`, `db/cmd/types2`, `db/cmd/dwarf`, `db/cmd/dwarf2` and `db/cmd/cmd_writedwarf` are 239/239 green.