### PR TITLE
Record and answer an enum's declared width ##analysis

### DIFF
--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -271,6 +271,9 @@ static RAnalBaseType *get_enum_type(RAnal *anal, const char *sname) {
 	if (!base_type) {
 		return NULL;
 	}
+	// the width the declaration recorded, else the width C gives an enum
+	const ut64 recorded = sdb_num_getf (anal->sdb_types, NULL, "type.%s.size", sname);
+	base_type->size = recorded? recorded: 32;
 
 	char *members = get_type_data (anal->sdb_types, "enum", sname);
 	if (!members) {
@@ -614,6 +617,10 @@ static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	*/
 	char *sname = r_str_sanitize_sdb_key (type->name);
 	sdb_set (anal->sdb_types, sname, "enum", 0);
+	// an enum has the width its declaration gave it, and DWARF records that width
+	if (type->size) {
+		sdb_num_setf (anal->sdb_types, type->size, 0, "type.%s.size", sname);
+	}
 
 	RStrBuf *arglist = r_strbuf_new ("");
 	int i = 0;

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -271,7 +271,6 @@ static RAnalBaseType *get_enum_type(RAnal *anal, const char *sname) {
 	if (!base_type) {
 		return NULL;
 	}
-	// the width the declaration recorded, else the width C gives an enum
 	const ut64 recorded = sdb_num_getf (anal->sdb_types, NULL, "type.%s.size", sname);
 	base_type->size = recorded? recorded: 32;
 
@@ -617,7 +616,6 @@ static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	*/
 	char *sname = r_str_sanitize_sdb_key (type->name);
 	sdb_set (anal->sdb_types, sname, "enum", 0);
-	// an enum has the width its declaration gave it, and DWARF records that width
 	if (type->size) {
 		sdb_num_setf (anal->sdb_types, type->size, 0, "type.%s.size", sname);
 	}

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -305,7 +305,6 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 		return mt && !strcmp (mt, "func")? type_ptr_bitsize (TDB): 0;
 	}
 	if (!strcmp (t, "enum")) {
-		// the declared width when it was recorded; C makes an enum int-sized otherwise
 		const ut64 size = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);
 		return size? size: 32;
 	}

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -304,6 +304,11 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 		const char *mt = sdb_const_getf (TDB, NULL, "type.%s", tmptype);
 		return mt && !strcmp (mt, "func")? type_ptr_bitsize (TDB): 0;
 	}
+	if (!strcmp (t, "enum")) {
+		// the declared width when it was recorded; C makes an enum int-sized otherwise
+		const ut64 size = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);
+		return size? size: 32;
+	}
 	if (!strcmp (t, "typedef")) {
 		// a typedef is as wide as the type it names: recorded width first, else the alias
 		ut64 size = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);


### PR DESCRIPTION
An enumeration has the width its declaration gives it, and DWARF records that width in `DW_AT_byte_size`. The parser carries it into the base type, and three places then drop it:

- `save_enum` never writes `type.<name>.size`,
- `get_enum_type` never reads one back, so a loaded enum has size zero,
- `r_type_get_bitsize` has no arm for kind `enum` and falls through to its final `return 0`.

Asking for the width of an enum therefore answered zero, and so did asking for any typedef of one. Note the existing `enum ` prefix branch a few lines up in `r_type_get_bitsize` already answers 32 for a spelling that is not in the database at all, so the zero was inconsistent as well as wrong.

This writes the recorded width, reads it back, and answers with it. Where nothing was recorded, C makes an enum as wide as an int, which is what the spelled-out form already answered.

### Reproducing

zlib's `minigzip`, whose `block_state` is a typedef of an anonymous enum that DWARF records as `DW_AT_byte_size (0x04)`:

```
$ radare2 -q -N -c 'aaa; tk type_0x3548; tk enum.type_0x3548; tk type.type_0x3548.size' minigzip
```

| query | before | after |
| --- | --- | --- |
| `type_0x3548` | `enum` | `enum` |
| `enum.type_0x3548` | `need_more,block_done,finish_started,finish_done` | unchanged |
| `type.type_0x3548.size` | *(absent)* | `32` |

### Tests

`r2r db` passes; the type and DWARF suites are 239/239 green.