### PR TITLE
Render a bare DWARF qualifier as qualified void ##anal

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -285,8 +285,26 @@ static void parse_array_type(Context *ctx, int idx, RStrBuf *strbuf) {
 static st32 parse_type(Context *ctx, const ut64 offset, RStrBuf *strbuf, ut64 *size, HtUP **visited) {
 	R_RETURN_VAL_IF_FAIL (strbuf, -1);
 	RBinDwarfDie *die = ht_up_find (ctx->die_map, offset, NULL);
-	if (!die || !die->attr_values) {
+	if (!die) {
 		return -1;
+	}
+	if (!die->attr_values) {
+		// A qualifier with no attribute at all qualifies `void`, which DWARF
+		// spells by omission; returning nothing here left `const void *`
+		// rendered as a bare ` *`.
+		switch (die->tag) {
+		case DW_TAG_const_type:
+			r_strbuf_append (strbuf, "void const");
+			return 0;
+		case DW_TAG_volatile_type:
+			r_strbuf_append (strbuf, "void volatile");
+			return 0;
+		case DW_TAG_restrict_type:
+			r_strbuf_append (strbuf, "void restrict");
+			return 0;
+		default:
+			return -1;
+		}
 	}
 	bool root = false;
 


### PR DESCRIPTION
DWARF spells `void` by omitting `DW_AT_type`, so `const void *` is a pointer to a `DW_TAG_const_type` DIE that carries no attributes at all. `parse_type` rejected any DIE without attributes before looking at its tag and returned -1, so the pointer's target contributed nothing and the type came out as a bare ` *`.

This spells the qualified void for the three qualifier tags.

### Reproducing

zlib's `minigzip`, where `voidpc` is `typedef const void *voidpc` and `voidp` is `typedef void *voidp`:

```
$ radare2 -q -N -c 'aaa; tk typedef.voidpc; tk typedef.voidp' minigzip
```

| query | before | after |
| --- | --- | --- |
| `typedef.voidpc` | ` *` | `void const *` |
| `typedef.voidp` | `void *` | `void *` |

The `voidp` row is there to show the ordinary pointer path is untouched. Every function taking a `const void *` -- `gzwrite`, `gzfwrite` and `gz_write` among them -- had an unusable type for that argument.

### Tests

`r2r db` passes; the type and DWARF suites are 239/239 green.