### PR TITLE
Do not install a file over a symlink pointing back at it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,8 @@ install: install-doc install-man install-panels install-www install-pkgconfig
 	cp -f doc/hud "${DESTDIR}${DATADIR}/radare2/${VERSION}/hud/main"
 	mkdir -p "${DESTDIR}${DATADIR}/radare2/${VERSION}/"
 	$(SHELL) ./configure-plugins --rm-static $(DESTDIR)$(LIBDIR)/radare2/last/
+	# symstall leaves a symlink here; install(1) refuses to copy a file onto itself
+	rm -f "${DESTDIR}${BINDIR}/r2sdb${BUILD_EXT_EXE}"
 	${INSTALL_PROGRAM} "subprojects/sdb/sdb${BUILD_EXT_EXE}" "${DESTDIR}${BINDIR}/r2sdb${BUILD_EXT_EXE}"
 
 install-panels:
@@ -308,6 +310,7 @@ symstall-www: $(WWW_UI_INDEXES)
 install-pkgconfig pkgconfig-install:
 	@${INSTALL_DIR} "${DESTDIR}${LIBDIR}/pkgconfig"
 	for FILE in $(shell cd pkgcfg ; ls *.pc) ; do \
+		rm -f "${DESTDIR}${LIBDIR}/pkgconfig/$$FILE" ; \
 		cp -f "$(PWD)/pkgcfg/$$FILE" "${DESTDIR}${LIBDIR}/pkgconfig/$$FILE" ; done
 
 install-pkgconfig-symlink pkgconfig-symstall symstall-pkgconfig:

--- a/libr/arch/d/Makefile
+++ b/libr/arch/d/Makefile
@@ -11,7 +11,8 @@ clean:
 
 install:
 	mkdir -p "${OPDIR}"
-	cp -f *.r2 "${OPDIR}"
+	# symstall leaves symlinks here; cp refuses to copy a file onto itself
+	for f in *.r2 ; do rm -f "${OPDIR}/$$f" ; cp -f "$$f" "${OPDIR}" ; done
 
 # that sed is a workaround for mingw's pwd
 CWD=$(shell pwd)

--- a/libr/magic/d/Makefile
+++ b/libr/magic/d/Makefile
@@ -6,7 +6,8 @@ all: $(F_SDB)
 
 install: ${F_SDB}
 	mkdir -p "$(MAGICDIR)"
-	for a in default/* ; do readlink "$(MAGICDIR)";  if [ $$? != 0 ]; then cp -f $$a "${MAGICDIR}" ; fi ; done
+	# symstall leaves symlinks here; cp refuses to copy a file onto itself
+	for a in default/* ; do readlink "$(MAGICDIR)";  if [ $$? != 0 ]; then rm -f "${MAGICDIR}/$$(basename $$a)" ; cp -f $$a "${MAGICDIR}" ; fi ; done
 
 CWD=$(shell pwd)
 symstall install-symlink: ${F_SDB}


### PR DESCRIPTION
`make symstall` leaves the magic files, the platform scripts, the pkgconfig entries and r2sdb as symlinks into the source tree, so a later `make install` asks cp and install(1) to copy each one onto itself; BSD tools refuse and the install aborts before the libraries. Each destination is removed first.