### PR TITLE
Fail closed when a struct names itself in r_type_get_bitsize ##types

### DIFF
--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -279,8 +279,11 @@ static ut64 type_ptr_bitsize(Sdb *R_NONNULL TDB) {
 	return bits? bits: 32;
 }
 
-R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
-	R_RETURN_VAL_IF_FAIL (TDB && type, 0);
+// how many nested structs or unions a measurement follows before giving up
+#define TYPE_CHAIN_MAX 32
+
+// UT64_MAX means an aggregate reached itself; r_type_get_bitsize turns that into 0
+static ut64 type_bitsize(Sdb *TDB, const char *type, const char **chain, int depth) {
 	const char *type_view = type_skip_qualifiers (type);
 	if (strchr (type_view, '*')) {
 		return type_ptr_bitsize (TDB);
@@ -315,13 +318,23 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 			// still a typedef after the resolver bound means a cycle, so fail closed
 			const char *kind = sdb_const_get (TDB, resolved, 0);
 			if (!kind || strcmp (kind, "typedef")) {
-				size = r_type_get_bitsize (TDB, resolved);
+				size = type_bitsize (TDB, resolved, chain, depth);
 			}
 			free (resolved);
 		}
 		return size;
 	}
 	if (!strcmp (t, "struct") || !strcmp (t, "union")) {
+		int i;
+		for (i = 0; i < depth; i++) {
+			if (!strcmp (chain[i], tmptype)) {
+				return UT64_MAX;
+			}
+		}
+		if (depth >= TYPE_CHAIN_MAX) {
+			return UT64_MAX;
+		}
+		chain[depth] = tmptype;
 		const char *value = sdb_const_getf (TDB, NULL, "%s.%s", t, tmptype);
 		char *members = value? strdup (value): NULL;
 		char *next, *ptr = members;
@@ -342,13 +355,18 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 				if (elements == 0) {
 					elements = 1;
 				}
+				const ut64 member = type_bitsize (TDB, subtype, chain, depth + 1);
+				free (subtype);
+				if (member == UT64_MAX) {
+					ret = UT64_MAX;
+					break;
+				}
 				if (!strcmp (t, "struct")) {
-					ret += r_type_get_bitsize (TDB, subtype) * elements;
+					ret += member * elements;
 				} else {
-					ut64 sz = r_type_get_bitsize (TDB, subtype) * elements;
+					ut64 sz = member * elements;
 					ret = sz > ret ? sz : ret;
 				}
-				free (subtype);
 				ptr = next;
 			} while (next);
 			free (members);
@@ -356,6 +374,13 @@ R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
 		return ret;
 	}
 	return 0;
+}
+
+R_API ut64 r_type_get_bitsize(Sdb *R_NONNULL TDB, const char *R_NONNULL type) {
+	R_RETURN_VAL_IF_FAIL (TDB && type, 0);
+	const char *chain[TYPE_CHAIN_MAX];
+	const ut64 bits = type_bitsize (TDB, type, chain, 0);
+	return bits == UT64_MAX? 0: bits;
 }
 
 static const char *type_aggregate_kind(Sdb *R_NONNULL TDB, const char *R_NONNULL type, const char **R_NONNULL name) {

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -5331,3 +5331,15 @@ addr: 0x08003797
 --
 EOF
 RUN
+
+NAME=a struct that names itself measures 0 instead of recursing
+FILE=bins/elf/dwarf_rust_bubble
+CMDS=<<EOF
+k anal/types/struct.ExitCode.__0
+tss ExitCode
+EOF
+EXPECT=<<EOF
+ExitCode,0,0
+0
+EOF
+RUN

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -744,6 +744,34 @@ static bool test_anal_cparse_multiline_fnptr(void) {
 	mu_end;
 }
 
+static bool test_anal_type_bitsize_struct_cycle(void) {
+	RAnal *anal = r_anal_new ();
+	Sdb *TDB = anal->sdb_types;
+	sdb_set (TDB, "int32_t", "type", 0);
+	sdb_num_set (TDB, "type.int32_t.size", 32, 0);
+	sdb_set (TDB, "self", "struct", 0);
+	sdb_set (TDB, "struct.self", "n,inner", 0);
+	sdb_set (TDB, "struct.self.n", "int32_t,0,0", 0);
+	sdb_set (TDB, "struct.self.inner", "self,4,0", 0);
+	mu_assert_eq (r_type_get_bitsize (TDB, "self"), 0, "A struct containing itself fails closed");
+	sdb_set (TDB, "ping", "struct", 0);
+	sdb_set (TDB, "struct.ping", "pong", 0);
+	sdb_set (TDB, "struct.ping.pong", "pong_t,0,0", 0);
+	sdb_set (TDB, "pong_t", "typedef", 0);
+	sdb_set (TDB, "typedef.pong_t", "pong", 0);
+	sdb_set (TDB, "pong", "struct", 0);
+	sdb_set (TDB, "struct.pong", "ping", 0);
+	sdb_set (TDB, "struct.pong.ping", "ping,0,0", 0);
+	mu_assert_eq (r_type_get_bitsize (TDB, "ping"), 0, "A struct cycle through a typedef fails closed");
+	sdb_set (TDB, "pair", "struct", 0);
+	sdb_set (TDB, "struct.pair", "a,b", 0);
+	sdb_set (TDB, "struct.pair.a", "int32_t,0,0", 0);
+	sdb_set (TDB, "struct.pair.b", "int32_t,4,0", 0);
+	mu_assert_eq (r_type_get_bitsize (TDB, "pair"), 64, "An acyclic struct still measures its members");
+	r_anal_free (anal);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_struct);
 	mu_run_test (test_anal_save_base_type_struct);
@@ -762,6 +790,7 @@ int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_enum);
 	mu_run_test (test_anal_save_base_type_enum);
 	mu_run_test (test_anal_get_base_type_typedef);
+	mu_run_test (test_anal_type_bitsize_struct_cycle);
 	mu_run_test (test_anal_save_base_type_typedef);
 	mu_run_test (test_anal_get_base_type_atomic);
 	mu_run_test (test_anal_save_base_type_atomic);


### PR DESCRIPTION
The struct and union walk recursed into member types with no record of what it was measuring, so a struct that reaches itself, as `struct.ExitCode.__0=ExitCode` imported from the Rust DWARF in `bins/elf/dwarf_rust_bubble` does, recursed until the stack ran out. The walk now carries the chain of names it is inside and a repeat measures as 0, the closed answer a cyclic typedef already gives.