### PR TITLE
Lay ET_REL NOBITS sections past the image and its import slots ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -1582,6 +1582,50 @@ static bool init_dynstr(ELFOBJ *eo) {
 
 static const RVecRBinElfSection *_load_elf_sections(ELFOBJ *eo);
 
+// NOBITS own no file bytes: put them past the file image and the import slots
+static void etrel_place_nobits(ELFOBJ *eo) {
+	if (!eo->shdr) {
+		return;
+	}
+	ut64 end = 0;
+	RBinElfSection *s;
+	R_VEC_FOREACH (&eo->g_sections, s) {
+		if (s->type == SHT_NOBITS || s->size > UT64_MAX - s->offset) {
+			continue;
+		}
+		end = R_MAX (end, s->offset + s->size);
+	}
+	eo->etrel_slots = end? end: eo->size;
+	// slots are at most 8 bytes; the spare one absorbs the base rounding
+	const ut64 slots = ((ut64)eo->g_reloc_num + 1) * 8;
+	if (eo->etrel_slots > UT64_MAX - slots) {
+		return;
+	}
+	ut64 at = R_MAX (eo->etrel_slots + slots, eo->size);
+	R_VEC_FOREACH (&eo->g_sections, s) {
+		if (s->type != SHT_NOBITS) {
+			continue;
+		}
+		const ut64 a = s->align;
+		if (a > 1 && a <= 0x100000 && at <= UT64_MAX - a) {
+			at = R_ROUND (at, a);
+		}
+		if (at > UT64_MAX - s->size || at > UT64_MAX - eo->baddr) {
+			break;
+		}
+		s->offset = at;
+		s->rva = eo->baddr + at;
+		at += s->size;
+	}
+}
+
+static ut64 etrel_symbol_offset(ELFOBJ *eo, Elf_(Sym) *sym) {
+	if (sym->st_shndx < RVecRBinElfSection_length (&eo->g_sections)) {
+		return sym->st_value + RVecRBinElfSection_at (&eo->g_sections, sym->st_shndx)->offset;
+	}
+	return sym->st_value + eo->shdr[sym->st_shndx].sh_offset;
+}
+
 static void relro_insdb(ELFOBJ *eo) {
 	int r = Elf_(has_relro) (eo);
 	switch (r) {
@@ -1643,6 +1687,9 @@ static bool elf_init(ELFOBJ *eo) {
 	eo->boffset = Elf_(get_boffset) (eo);
 	eo->rel_cache = ht_uu_new0 ();
 	(void) Elf_(load_relocs) (eo);
+	if (is_bin_etrel (eo)) {
+		etrel_place_nobits (eo);
+	}
 	sdb_ns_set (eo->kv, "versioninfo", store_versioninfo (eo));
 	reloc_fill_local_address (eo);
 	return true;
@@ -5450,7 +5497,7 @@ static bool _process_symbols_and_imports_in_section(ELFOBJ *eo, int type, Proces
 
 		if (is_bin_etrel (eo)) {
 			if (sym.st_shndx < eo->ehdr.e_shnum) {
-				offset = sym.st_value + eo->shdr[sym.st_shndx].sh_offset;
+				offset = etrel_symbol_offset (eo, &sym);
 			}
 		} else {
 			offset = Elf_(v2p) (eo, toffset);

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -194,6 +194,7 @@ struct Elf_(obj_t) {
 	ut64 ppc32_nthunks;
 	bool ppc32_thunks_done;
 	ut32 g_reloc_num;
+	ut64 etrel_slots; // ET_REL: file offset of the import slot area
 	bool relocs_loaded;
 	RVecRBinElfReloc g_relocs;
 	bool sections_loaded;

--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1755,6 +1755,10 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 		return NULL;
 	}
 	ut64 n_vaddr = g->itv.addr + g->itv.size;
+	// the loader put the slot area below its NOBITS block; 0 without shdr
+	if (eo->ehdr.e_type == ET_REL && eo->etrel_slots) {
+		n_vaddr = elf_io_addr (bf, eo, eo->baddr + eo->etrel_slots);
+	}
 	// branch and lo12 relocs cannot encode a misaligned import slot address
 	if (eo->ehdr.e_type == ET_REL && (eo->ehdr.e_machine == EM_PPC64
 			|| eo->ehdr.e_machine == EM_PPC || eo->ehdr.e_machine == EM_AARCH64

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -872,7 +872,7 @@ CMDS=<<EOF
 ir~__fentry__
 EOF
 EXPECT=<<EOF
-0x100000500 0x0000007d ADD_32 4     __fentry__ - 0x08000081
+0x100000b0f 0x0000007d ADD_32 4     __fentry__ - 0x08000081
 EOF
 RUN
 
@@ -955,5 +955,76 @@ EOF
 EXPECT=<<EOF
 0051004000000000
 0001004000000000
+EOF
+RUN
+
+NAME=ELF: ET_REL NOBITS section is laid out past the file image, not over the next section
+FILE=bins/elf/random_39855/random_39855.oo
+CMDS=<<EOF
+iS~NOBITS
+iS~PROGBITS .rodata$
+is~crc32_tab
+EOF
+EXPECT=<<EOF
+6   0x00012af8     0x0 0x08012af8   0x400 -rw- 0x3   NOBITS   .bss
+7   0x000057f8   0x168 0x080057f8   0x168 -r-- 0x2   PROGBITS .rodata
+9   0x00012af8 0x08012af8 LOCAL  OBJ    1024     crc32_tab
+EOF
+RUN
+
+NAME=ELF: ET_REL adrp/add to a .bss symbol lands in the bss map under a custom base
+FILE=bins/elf/random_39855/random_39855.oo
+ARGS=-B 0x1000 -e bin.relocs.apply=true
+CMDS=<<EOF
+pd 2 @ 0x1168
+om~mmap..bss[4,6]
+EOF
+EXPECT=<<EOF
+            0x00001168      890000d0       adrp x9, 0x13000
+            0x0000116c      29e12b91       add x9, x9, 0xaf8
+0x00013af8 0x00013ef7
+EOF
+RUN
+
+NAME=ELF: ET_REL import slots stay below the NOBITS block
+FILE=bins/elf/radare2.c.obj
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+om~.got.r2[4,6]
+iS~NOBITS
+is~rabin_cmd
+EOF
+EXPECT=<<EOF
+0x080384db 0x08040e2a
+4   0x00040e40      0x0 0x08040e40  0x618a0 -rw- 0x3   NOBITS   .bss
+8   0x00040e40 0x08040e40 LOCAL  OBJ    8          rabin_cmd
+EOF
+RUN
+
+NAME=ELF: ET_REL import slots sit below the .bss flag under a custom base
+FILE=bins/elf/test.ko
+ARGS=-B 0x100000000 -e bin.relocs.apply=true
+CMDS=<<EOF
+om~.got.r2[4,6]
+f~section..bss
+EOF
+EXPECT=<<EOF
+0x100000b0f 0x100000b5e
+0x100001050 0 section..bss
+EOF
+RUN
+
+NAME=ELF: ELF32 ET_REL NOBITS section is laid out past the import slots
+FILE=bins/elf/pngrutil_o
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+iS~NOBITS
+iS~PROGBITS .rodata$
+om~.got.r2[4,6]
+EOF
+EXPECT=<<EOF
+4   0x00009a83     0x0 0x08009a83     0x0 -rw- 0x3   NOBITS   .bss
+5   0x000055c8   0xe64 0x080055c8   0xe64 -r-- 0x2   PROGBITS .rodata
+0x08008703 0x080090be
 EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

For a relocatable object r2 lays every section out at `baddr + sh_offset`. A NOBITS section has no file bytes, so the assembler gives it the same `sh_offset` as the section that follows it, and r2 puts both at one address:

```
$ r2 -qc 'iS~NOBITS; iS~PROGBITS .rodata$; is~crc32_tab' bins/elf/random_39855/random_39855.oo
6   0x000057f4     0x0 0x080057f4   0x400 -rw- 0x3   NOBITS   .bss
7   0x000057f8   0x168 0x080057f8   0x168 -r-- 0x2   PROGBITS .rodata
9   0x000057f4 0x080057f4 LOCAL  OBJ    1024     crc32_tab
```

Every `.bss` symbol then resolves to the bytes of the section behind it, and under `-B` with `bin.relocs.apply=true` a patched `adrp`/`add` pair against `crc32_tab` targets `.rodata`'s moved address instead of the `.bss` map.

## The fix

- The ELF loader lays every ET_REL NOBITS section out past the last file byte, each rounded to its own `sh_addralign`, and a symbol in one takes its section's new offset instead of `sh_offset`.
- The gap between the file image and the NOBITS block is reserved for the `.got.r2` import slots, and `patch_relocs` places them there for ET_REL instead of after the highest io map. Otherwise the slots would trail a large `.bss` and short-range call relocs (`R_ARM_CALL`, `CALL26`) could no longer reach them; with the reservation their address is unchanged on every object in the test corpus.
- One spare slot in the reservation covers the up-to-7-byte rounding `patch_relocs` applies to the slot base on aarch64, arm and ppc.

## Tests

Five cases in `db/formats/elf/reloc`: layout and symbols on `random_39855.oo`, its `adrp`/`add` target under `-B`, slot placement below `radare2.c.obj`'s large `.bss`, the `test.ko` slot area under `-B`, and an ELF32 object. One golden moves: the `test.ko` slot, which used to sit on the `.bss` flag. Alignment, oversized `.bss` and CREL corner cases were checked on objects outside the corpus.