### PR TITLE
Record the width a struct or union was declared with ##types

### DIFF
--- a/libr/anal/p/tp/synth.c
+++ b/libr/anal/p/tp/synth.c
@@ -832,7 +832,7 @@ void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec *recs)
 			char *croot = synth_root_name (fname, clabel);
 			cbt->name = r_str_newf ("%s_0x%" PFMT64x, croot, coff);
 			free (croot);
-			cbt->size = ccur;
+			cbt->size = ccur * 8; // the base type holds bits
 			SynthRec *rec = RVecSynthRec_emplace_back (recs);
 			if (rec) {
 				*rec = (SynthRec){ .arg = carg, .argno = clabel, .child = true, .off = coff, .bt = cbt };
@@ -931,7 +931,7 @@ void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec *recs)
 		if (emit) {
 			cur = synth_pad_tail (bt, &arrs, cur, aw->size);
 			bt->name = synth_root_name (fname, label);
-			bt->size = cur;
+			bt->size = cur * 8; // the base type holds bits
 			rec = RVecSynthRec_emplace_back (recs);
 		}
 		if (rec) {
@@ -1045,7 +1045,7 @@ char *synth_json(RVecSynthRec *recs) {
 		if (rec->var) {
 			pj_ks (pj, "var", rec->var);
 		}
-		pj_kn (pj, "size", rec->bt->size);
+		pj_kn (pj, "size", rec->bt->size / 8); // bytes, like the offsets
 		if (rec->hint_fn) {
 			// the size came from a size function, so scripts can match it against a known type
 			pj_ko (pj, "sizehint");

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -372,6 +372,7 @@ static RAnalBaseType *get_composite_type(RAnal *anal, const char *sname, RAnalBa
 		sdb_aforeach_next (cur);
 	}
 	free (sdb_members);
+	base_type->size = sdb_num_getf (anal->sdb_types, NULL, "type.%s.size", sname);
 
 	return base_type;
 
@@ -574,6 +575,12 @@ static void save_composite(const RAnal *anal, const RAnalBaseType *type) {
 	}
 	// name=struct
 	sdb_set (db, sname, kind, 0);
+	// a DWARF definition carries its width; a C one is measured by walking the members
+	if (type->size) {
+		sdb_num_setf (db, type->size, 0, "type.%s.size", sname);
+	} else {
+		sdb_unsetf (db, 0, "type.%s.size", sname);
+	}
 
 	RStrBuf *arglist = r_strbuf_new ("");
 

--- a/libr/anal/type_pdb.c
+++ b/libr/anal/type_pdb.c
@@ -208,7 +208,7 @@ static void parse_structure(const RAnal *anal, STpiStream *ss, SType *type, RLis
 	}
 	char *sname = r_str_sanitize_sdb_key (name);
 	base_type->name = sname;
-	base_type->size = size;
+	base_type->size = (ut64)size * CHAR_BIT; // pdb records bytes, the base type holds bits
 	r_anal_save_base_type (anal, base_type);
 	if (to_free_name) {
 		R_FREE (name);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -329,6 +329,10 @@ static ut64 type_bitsize(Sdb *TDB, const char *type, const char **chain, int dep
 		return size;
 	}
 	if (!strcmp (t, "struct") || !strcmp (t, "union")) {
+		const ut64 recorded = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);
+		if (recorded) {
+			return recorded;
+		}
 		int i;
 		for (i = 0; i < depth; i++) {
 			if (!strcmp (chain[i], tmptype)) {
@@ -901,6 +905,7 @@ R_API void r_type_del(Sdb *TDB, const char *name) {
 			free (p);
 		}
 		sdb_unset (TDB, elements_key, 0);
+		sdb_unsetf (TDB, 0, "type.%s.size", name);
 		sdb_unset (TDB, name, 0);
 		free (elements_key);
 	} else if (!strcmp (kind, "func")) {

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -5332,14 +5332,16 @@ addr: 0x08003797
 EOF
 RUN
 
-NAME=a struct that names itself measures 0 instead of recursing
+NAME=a struct that names itself keeps the width DWARF declared
 FILE=bins/elf/dwarf_rust_bubble
 CMDS=<<EOF
 k anal/types/struct.ExitCode.__0
+k anal/types/type.ExitCode.size
 tss ExitCode
 EOF
 EXPECT=<<EOF
 ExitCode,0,0
-0
+0x8
+1
 EOF
 RUN

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -744,6 +744,62 @@ static bool test_anal_cparse_multiline_fnptr(void) {
 	mu_end;
 }
 
+static bool test_anal_type_bitsize_struct_recorded(void) {
+	RAnal *anal = r_anal_new ();
+	Sdb *TDB = anal->sdb_types;
+	sdb_set (TDB, "int32_t", "type", 0);
+	sdb_num_set (TDB, "type.int32_t.size", 32, 0);
+	// an importer that knows the real width, padding included, saves it with the members
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("padded");
+	base->size = 128;
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("a")
+	};
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	member.offset = 8;
+	member.type = strdup ("int32_t");
+	member.name = strdup ("b");
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_eq (sdb_num_get (TDB, "type.padded.size", NULL), 128, "The struct width is saved beside its members");
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 128, "A recorded width wins over the member sum");
+	mu_assert_eq (r_type_get_bitsize (TDB, "struct padded"), 128, "The keyword spelling reads the same record");
+	// a re-save of what was read back keeps the width
+	base = r_anal_get_base_type (anal, "padded");
+	mu_assert_notnull (base, "The saved struct reads back");
+	mu_assert_eq (base->size, 128, "The width reads back with the members");
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 128, "A re-save keeps the recorded width");
+	// a struct that names itself still measures when the importer recorded its width
+	sdb_set (TDB, "self", "struct", 0);
+	sdb_set (TDB, "struct.self", "inner", 0);
+	sdb_set (TDB, "struct.self.inner", "self,0,0", 0);
+	sdb_num_set (TDB, "type.self.size", 8, 0);
+	mu_assert_eq (r_type_get_bitsize (TDB, "self"), 8, "A recorded width answers for a self-naming struct");
+	// a definition without a width drops a stale record and walks the members again
+	base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("padded");
+	member.offset = 0;
+	member.type = strdup ("int32_t");
+	member.name = strdup ("a");
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_null (sdb_const_get (TDB, "type.padded.size", NULL), "A save without a width drops the stale record");
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 32, "Without a record the members are measured");
+	// deleting the type drops its width too
+	sdb_num_set (TDB, "type.padded.size", 64, 0);
+	r_type_del (TDB, "padded");
+	mu_assert_null (sdb_const_get (TDB, "type.padded.size", NULL), "Deleting the struct drops its width");
+	r_anal_free (anal);
+	mu_end;
+}
+
 static bool test_anal_type_bitsize_struct_cycle(void) {
 	RAnal *anal = r_anal_new ();
 	Sdb *TDB = anal->sdb_types;
@@ -791,6 +847,7 @@ int all_tests(void) {
 	mu_run_test (test_anal_save_base_type_enum);
 	mu_run_test (test_anal_get_base_type_typedef);
 	mu_run_test (test_anal_type_bitsize_struct_cycle);
+	mu_run_test (test_anal_type_bitsize_struct_recorded);
 	mu_run_test (test_anal_save_base_type_typedef);
 	mu_run_test (test_anal_get_base_type_atomic);
 	mu_run_test (test_anal_save_base_type_atomic);


### PR DESCRIPTION
Follow-up to #26658 as suggested there: `save_composite` now persists the DWARF `DW_AT_byte_size` it was already handed as `type.<name>.size`, `get_composite_type` loads it back, and the struct/union branch of `r_type_get_bitsize` answers from it before walking members, so imported structs measure in O(1) with their real padded width and the self-referencing Rust `ExitCode` now reports 1 instead of 0. A struct defined from C without a width is still measured by its members.