### PR TITLE
Record the struct width dwarf and pdb know so tss reads it instead of walking the members ##types

### DIFF
--- a/libr/anal/p/tp/synth.c
+++ b/libr/anal/p/tp/synth.c
@@ -832,7 +832,7 @@ void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec *recs)
 			char *croot = synth_root_name (fname, clabel);
 			cbt->name = r_str_newf ("%s_0x%" PFMT64x, croot, coff);
 			free (croot);
-			cbt->size = ccur;
+			cbt->size = ccur * 8; // the base type holds bits
 			SynthRec *rec = RVecSynthRec_emplace_back (recs);
 			if (rec) {
 				*rec = (SynthRec){ .arg = carg, .argno = clabel, .child = true, .off = coff, .bt = cbt };
@@ -931,7 +931,7 @@ void type_synth(RAnal *anal, RAnalFunction *fcn, bool apply, RVecSynthRec *recs)
 		if (emit) {
 			cur = synth_pad_tail (bt, &arrs, cur, aw->size);
 			bt->name = synth_root_name (fname, label);
-			bt->size = cur;
+			bt->size = cur * 8; // the base type holds bits
 			rec = RVecSynthRec_emplace_back (recs);
 		}
 		if (rec) {
@@ -1045,7 +1045,7 @@ char *synth_json(RVecSynthRec *recs) {
 		if (rec->var) {
 			pj_ks (pj, "var", rec->var);
 		}
-		pj_kn (pj, "size", rec->bt->size);
+		pj_kn (pj, "size", rec->bt->size / 8); // bytes, like the offsets
 		if (rec->hint_fn) {
 			// the size came from a size function, so scripts can match it against a known type
 			pj_ko (pj, "sizehint");

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -341,6 +341,8 @@ static RAnalBaseType *get_composite_type(RAnal *anal, const char *sname, RAnalBa
 	if (!sdb_members) {
 		goto error;
 	}
+	// carry the recorded width along so a re-save keeps it
+	base_type->size = sdb_num_getf (anal->sdb_types, NULL, "type.%s.size", sname);
 
 	RVecAnalTypeMember *members = r_anal_base_type_members (base_type);
 	if (!RVecAnalTypeMember_reserve (members, (size_t)sdb_alen (sdb_members))) {
@@ -574,6 +576,13 @@ static void save_composite(const RAnal *anal, const RAnalBaseType *type) {
 	}
 	// name=struct
 	sdb_set (db, sname, kind, 0);
+	// type.name.size=bits, when the importer knew it, so r_type_get_bitsize need not walk the members
+	r_strf_var (sk, KSZ, "type.%s.size", sname);
+	if (type->size) {
+		sdb_num_set (db, sk, type->size, 0);
+	} else {
+		sdb_unset (db, sk, 0);
+	}
 
 	RStrBuf *arglist = r_strbuf_new ("");
 

--- a/libr/anal/type_pdb.c
+++ b/libr/anal/type_pdb.c
@@ -208,7 +208,7 @@ static void parse_structure(const RAnal *anal, STpiStream *ss, SType *type, RLis
 	}
 	char *sname = r_str_sanitize_sdb_key (name);
 	base_type->name = sname;
-	base_type->size = size;
+	base_type->size = (ut64)size * CHAR_BIT; // pdb records bytes, the base type holds bits
 	r_anal_save_base_type (anal, base_type);
 	if (to_free_name) {
 		R_FREE (name);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -329,6 +329,11 @@ static ut64 type_bitsize(Sdb *TDB, const char *type, const char **chain, int dep
 		return size;
 	}
 	if (!strcmp (t, "struct") || !strcmp (t, "union")) {
+		// an importer that knew the width (dwarf, pdb) recorded it, which spares the member walk
+		const ut64 recorded = sdb_num_getf (TDB, NULL, "type.%s.size", tmptype);
+		if (recorded) {
+			return recorded;
+		}
 		int i;
 		for (i = 0; i < depth; i++) {
 			if (!strcmp (chain[i], tmptype)) {
@@ -901,6 +906,7 @@ R_API void r_type_del(Sdb *TDB, const char *name) {
 			free (p);
 		}
 		sdb_unset (TDB, elements_key, 0);
+		sdb_unset (TDB, r_strf ("type.%s.size", name), 0);
 		sdb_unset (TDB, name, 0);
 		free (elements_key);
 	} else if (!strcmp (kind, "func")) {

--- a/test/db/formats/dwarf
+++ b/test/db/formats/dwarf
@@ -5332,14 +5332,16 @@ addr: 0x08003797
 EOF
 RUN
 
-NAME=a struct that names itself measures 0 instead of recursing
+NAME=a struct that names itself measures the width dwarf recorded
 FILE=bins/elf/dwarf_rust_bubble
 CMDS=<<EOF
 k anal/types/struct.ExitCode.__0
+k anal/types/type.ExitCode.size
 tss ExitCode
 EOF
 EXPECT=<<EOF
 ExitCode,0,0
-0
+0x8
+1
 EOF
 RUN

--- a/test/unit/test_anal_types.c
+++ b/test/unit/test_anal_types.c
@@ -772,6 +772,62 @@ static bool test_anal_type_bitsize_struct_cycle(void) {
 	mu_end;
 }
 
+static bool test_anal_type_bitsize_struct_recorded(void) {
+	RAnal *anal = r_anal_new ();
+	Sdb *TDB = anal->sdb_types;
+	sdb_set (TDB, "int32_t", "type", 0);
+	sdb_num_set (TDB, "type.int32_t.size", 32, 0);
+	// an importer that knows the real width, padding included, saves it with the members
+	RAnalBaseType *base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("padded");
+	base->size = 128;
+	RAnalStructMember member = {
+		.offset = 0,
+		.type = strdup ("int32_t"),
+		.name = strdup ("a")
+	};
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	member.offset = 8;
+	member.type = strdup ("int32_t");
+	member.name = strdup ("b");
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_eq (sdb_num_get (TDB, "type.padded.size", NULL), 128, "The struct width is saved beside its members");
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 128, "A recorded width wins over the member sum");
+	mu_assert_eq (r_type_get_bitsize (TDB, "struct padded"), 128, "The keyword spelling reads the same record");
+	// a re-save of what was read back keeps the width
+	base = r_anal_get_base_type (anal, "padded");
+	mu_assert_notnull (base, "The saved struct reads back");
+	mu_assert_eq (base->size, 128, "The width reads back with the members");
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 128, "A re-save keeps the recorded width");
+	// a struct that names itself still measures when the importer recorded its width
+	sdb_set (TDB, "self", "struct", 0);
+	sdb_set (TDB, "struct.self", "inner", 0);
+	sdb_set (TDB, "struct.self.inner", "self,0,0", 0);
+	sdb_num_set (TDB, "type.self.size", 8, 0);
+	mu_assert_eq (r_type_get_bitsize (TDB, "self"), 8, "A recorded width answers for a self-naming struct");
+	// a definition without a width drops a stale record and walks the members again
+	base = r_anal_base_type_new (R_ANAL_BASE_TYPE_KIND_STRUCT);
+	base->name = strdup ("padded");
+	member.offset = 0;
+	member.type = strdup ("int32_t");
+	member.name = strdup ("a");
+	RVecAnalTypeMember_push_back (&base->struct_data.members, &member);
+	r_anal_save_base_type (anal, base);
+	r_anal_base_type_free (base);
+	mu_assert_null (sdb_const_get (TDB, "type.padded.size", NULL), "A save without a width drops the stale record");
+	mu_assert_eq (r_type_get_bitsize (TDB, "padded"), 32, "Without a record the members are measured");
+	// deleting the type drops its width too
+	sdb_num_set (TDB, "type.padded.size", 64, 0);
+	r_type_del (TDB, "padded");
+	mu_assert_null (sdb_const_get (TDB, "type.padded.size", NULL), "Deleting the struct drops its width");
+	r_anal_free (anal);
+	mu_end;
+}
+
 int all_tests(void) {
 	mu_run_test (test_anal_get_base_type_struct);
 	mu_run_test (test_anal_save_base_type_struct);
@@ -791,6 +847,7 @@ int all_tests(void) {
 	mu_run_test (test_anal_save_base_type_enum);
 	mu_run_test (test_anal_get_base_type_typedef);
 	mu_run_test (test_anal_type_bitsize_struct_cycle);
+	mu_run_test (test_anal_type_bitsize_struct_recorded);
 	mu_run_test (test_anal_save_base_type_typedef);
 	mu_run_test (test_anal_get_base_type_atomic);
 	mu_run_test (test_anal_save_base_type_atomic);


### PR DESCRIPTION
- [x] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to [#26658](https://github.com/radareorg/radare2/pull/26658). `r_type_get_bitsize` recomputed every struct and union size from scratch by walking the members on each call, and `type_get_memb` calls it once per member, so a lookup into a deep DWARF type was quadratic in sdb queries. The DWARF importer already parses `DW_AT_byte_size` into `base_type->size` and PDB does the same from the leaf, but `save_composite` dropped it on the floor.

- `save_composite` now writes `type.<name>.size` in bits next to the members when the importer knew the width, and clears a stale record when it did not, the same way `save_enum` already does.
- `get_composite_type` reads it back so a re-save (as the `tp` plugin does) keeps it.
- The struct/union branch of `r_type_get_bitsize` returns the recorded width before touching the members, so imported aggregates are one sdb lookup and the cycle guard only runs for cparse-defined structs where no width was recorded.
- `r_type_del` drops the record with the rest of the aggregate.
- The PDB importer stored bytes in a field documented as bits, and the synth plugin did the same. Both now hold bits; the `afts` JSON still prints bytes.

A side effect is that `ExitCode` in `dwarf_rust_bubble`, the struct that names itself, now measures the 1 byte DWARF recorded instead of the fail-closed 0, and the same holds for the other aggregates that hit the importer's bare-name collision. The r2r case from the previous PR is updated accordingly, and a unit test covers the save, the read-back, the re-save, the stale-record cleanup and the delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HQ5ufLpbgUVPkGrt8YFay

---
_Generated by [Claude Code](https://claude.ai/code/session_012HQ5ufLpbgUVPkGrt8YFay)_