### PR TITLE
Add string type filter flags for iz/izz commands

### DIFF
--- a/libr/core/cbin.c
+++ b/libr/core/cbin.c
@@ -347,7 +347,7 @@ R_API bool r_core_bin_set_cur(RCore *core, RBinFile *binfile) {
 	return true;
 }
 
-static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, int va, ut64 skip, ut64 count, int type_filter) {
 	RTable *table = r_core_table_new (core, "strings");
 	if (!table) {
 		return;
@@ -388,6 +388,9 @@ static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, 
 			continue;
 		}
 		if (maxstr && string->length > maxstr) {
+			continue;
+		}
+		if (type_filter && string->type != type_filter) {
 			continue;
 		}
 #if FALSE_POSITIVES
@@ -600,7 +603,7 @@ static void _print_strings(RCore *core, RVecRBinString *list, PJ *pj, int mode, 
 	R_CRITICAL_LEAVE (core);
 }
 
-R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, int type_filter) {
 	RBinFile *bf = r_bin_cur (core->bin);
 	bool new_bf = false;
 	if (bf && bf->file && strstr (bf->file, "malloc://")) {
@@ -643,7 +646,7 @@ R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut6
 		va = false;
 	}
 	RVecRBinString *strings = r_bin_raw_strings (bf, 0);
-	_print_strings (core, strings, pj, mode, va, skip, count);
+	_print_strings (core, strings, pj, mode, va, skip, count, type_filter);
 	RVecRBinString_free (strings);
 	if (new_bf) {
 		r_unref (bf->buf);
@@ -654,7 +657,7 @@ R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut6
 	return true;
 }
 
-R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count) {
+R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, int type_filter) {
 	RBinFile *binfile = r_bin_cur (core->bin);
 	RBinPlugin *plugin = r_bin_file_cur_plugin (binfile);
 	int rawstr = r_config_get_i (core->config, "bin.str.raw");
@@ -676,7 +679,7 @@ R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 co
 	}
 	RVecRBinString *list = r_bin_get_strings (core->bin);
 	if (list) {
-		_print_strings (core, list, pj, mode, va, skip, count);
+		_print_strings (core, list, pj, mode, va, skip, count, type_filter);
 		return true;
 	}
 	return false;
@@ -5677,9 +5680,9 @@ R_API bool r_core_bin_info(RCore *core, ut64 action, PJ *pj, int mode, int va, R
 		}
 	}
 	if ((action & R_CORE_BIN_ACC_RAW_STRINGS)) {
-		ret &= bin_raw_strings (core, pj, mode, va, 0, 0);
+		ret &= bin_raw_strings (core, pj, mode, va, 0, 0, 0);
 	} else if ((action & R_CORE_BIN_ACC_STRINGS)) {
-		ret &= bin_strings (core, pj, mode, va, 0, 0);
+		ret &= bin_strings (core, pj, mode, va, 0, 0, 0);
 	}
 	if ((action & R_CORE_BIN_ACC_INFO)) {
 		ret &= bin_info (core, pj, mode, loadaddr);

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -7,8 +7,8 @@
 
 #include "../bin/format/pdb/pdb_downloader.h"
 
-R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count);
-R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count);
+R_IPI bool bin_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, int type_filter);
+R_IPI bool bin_raw_strings(RCore *core, PJ *pj, int mode, int va, ut64 skip, ut64 count, int type_filter);
 
 // clang-format off
 static RCoreHelpMessage help_msg_ih = {
@@ -141,21 +141,29 @@ static RCoreHelpMessage help_msg_iy = {
 };
 
 static RCoreHelpMessage help_msg_iz = {
-	"Usage: iz", "[?jq*] ([skip] [count])", "List strings",
+	"Usage: iz", "[?jq*auwW] ([skip] [count])", "List strings",
 	"iz", " ([skip]) ([count])", "strings in data sections (skip N strings, show count)",
 	"iz.", "", "show string at current address",
 	"iz,", "[:help]", "perform a table query on strings listing",
 	"iz-", " ([addr]) ([len]) ([type])", "delete string at address (uses current seek if addr not specified, len/type for matching)",
 	"iz+", " [addr] ([len]) ([type])", "add string manually (len=auto, type=auto-detect)",
 	"iz*", "", "print flags and comments r2 commands for all the strings",
+	"iza", "", "show only ascii strings",
 	"izc", "", "count the strings in data sections",
 	"izj", "", "strings in data sections in JSON format",
 	"izj.", "", "show string at current address in JSON",
 	"izjq", "", "strings in data sections in quiet JSON (just vaddr and string)",
 	"izq", "[q]", "strings in data sections in quiet (and quieter) mode",
 	"izq.", "", "show string at current address (quiet)",
-	"izz", "[jq*] ([skip]) ([count])", "search for strings in the whole binary",
+	"izu", "", "show only utf8 strings",
+	"izw", "", "show only wide (utf16) strings",
+	"izW", "", "show only wide32 (utf32) strings",
+	"izz", "[jq*auwW] ([skip]) ([count])", "search for strings in the whole binary",
+	"izza", "", "show only ascii strings in the whole binary",
 	"izzc", "", "count the strings in the whole binary",
+	"izzu", "", "show only utf8 strings in the whole binary",
+	"izzw", "", "show only wide (utf16) strings in the whole binary",
+	"izzW", "", "show only wide32 (utf32) strings in the whole binary",
 	"izzz", "[jq]", "dump strings from whole binary to r2 shell (for huge files)",
 	"izzzc", "", "count the strings dumped from the whole binary",
 	NULL
@@ -1942,12 +1950,13 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		r_cons_printf (core->cons, "%" PFMT64u "\n", total);
 		return;
 	}
-	// Parse command: iz[z][z][jq*] [skip] [count]
+	// Parse command: iz[z][z][jq*auwW] [skip] [count]
 	const char *p = input + 1;
 	bool raw = false; // izz = raw strings from whole binary
 	bool rdump = false; // izzz = dump mode
 	ut64 skip = 0;
 	ut64 count = 0;
+	int type_filter = 0; // 0 = no filter, 'a'=ascii, 'u'=utf8, 'w'=wide, 'W'=wide32
 	// Count 'z' characters
 	while (*p == 'z') {
 		if (!raw) {
@@ -1966,6 +1975,20 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			RVecRBinString_free (strings);
 		}
 		return;
+	}
+	// Parse type filter suffix (a, u, w, W)
+	if (*p == 'a') {
+		type_filter = R_STRING_TYPE_ASCII;
+		p++;
+	} else if (*p == 'u') {
+		type_filter = R_STRING_TYPE_UTF8;
+		p++;
+	} else if (*p == 'w') {
+		type_filter = R_STRING_TYPE_WIDE;
+		p++;
+	} else if (*p == 'W') {
+		type_filter = R_STRING_TYPE_WIDE32;
+		p++;
 	}
 	// Parse suffix (j, jq, qj, q, qq, *, ,)
 	bool local_pj = false;
@@ -2070,7 +2093,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 			RVecRBinString_free (res);
 		}
 	} else if (raw) {
-		bin_raw_strings (core, pj, mode, va, skip, count);
+		bin_raw_strings (core, pj, mode, va, skip, count, type_filter);
 	} else {
 		RList *bfiles = r_core_bin_files (core);
 		RListIter *iter;
@@ -2078,7 +2101,7 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		RBinFile *cur = core->bin->cur;
 		r_list_foreach (bfiles, iter, bf) {
 			core->bin->cur = bf;
-			bin_strings (core, pj, mode, va, skip, count);
+			bin_strings (core, pj, mode, va, skip, count, type_filter);
 		}
 		core->bin->cur = cur;
 		r_list_free (bfiles);

--- a/libr/core/cmd_info.inc.c
+++ b/libr/core/cmd_info.inc.c
@@ -141,29 +141,23 @@ static RCoreHelpMessage help_msg_iy = {
 };
 
 static RCoreHelpMessage help_msg_iz = {
-	"Usage: iz", "[?jq*auwW] ([skip] [count])", "List strings",
+	"Usage: iz", "[?jq*auwWb] ([skip] [count])", "List strings",
 	"iz", " ([skip]) ([count])", "strings in data sections (skip N strings, show count)",
 	"iz.", "", "show string at current address",
 	"iz,", "[:help]", "perform a table query on strings listing",
 	"iz-", " ([addr]) ([len]) ([type])", "delete string at address (uses current seek if addr not specified, len/type for matching)",
 	"iz+", " [addr] ([len]) ([type])", "add string manually (len=auto, type=auto-detect)",
 	"iz*", "", "print flags and comments r2 commands for all the strings",
-	"iza", "", "show only ascii strings",
+	"iz[auwWb]", "", "filter by string type (ascii, utf8, utf16, utf32, base64)",
 	"izc", "", "count the strings in data sections",
 	"izj", "", "strings in data sections in JSON format",
 	"izj.", "", "show string at current address in JSON",
 	"izjq", "", "strings in data sections in quiet JSON (just vaddr and string)",
 	"izq", "[q]", "strings in data sections in quiet (and quieter) mode",
 	"izq.", "", "show string at current address (quiet)",
-	"izu", "", "show only utf8 strings",
-	"izw", "", "show only wide (utf16) strings",
-	"izW", "", "show only wide32 (utf32) strings",
-	"izz", "[jq*auwW] ([skip]) ([count])", "search for strings in the whole binary",
-	"izza", "", "show only ascii strings in the whole binary",
+	"izz", "[jq*auwWb] ([skip]) ([count])", "search for strings in the whole binary",
+	"izz[auwWb]", "", "filter by string type (ascii, utf8, utf16, utf32, base64)",
 	"izzc", "", "count the strings in the whole binary",
-	"izzu", "", "show only utf8 strings in the whole binary",
-	"izzw", "", "show only wide (utf16) strings in the whole binary",
-	"izzW", "", "show only wide32 (utf32) strings in the whole binary",
 	"izzz", "[jq]", "dump strings from whole binary to r2 shell (for huge files)",
 	"izzzc", "", "count the strings dumped from the whole binary",
 	NULL
@@ -1950,13 +1944,13 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		r_cons_printf (core->cons, "%" PFMT64u "\n", total);
 		return;
 	}
-	// Parse command: iz[z][z][jq*auwW] [skip] [count]
+	// Parse command: iz[z][z][jq*auwWb] [skip] [count]
 	const char *p = input + 1;
 	bool raw = false; // izz = raw strings from whole binary
 	bool rdump = false; // izzz = dump mode
 	ut64 skip = 0;
 	ut64 count = 0;
-	int type_filter = 0; // 0 = no filter, 'a'=ascii, 'u'=utf8, 'w'=wide, 'W'=wide32
+	int type_filter = 0; // 0 = no filter, 'a'=ascii, 'u'=utf8, 'w'=wide, 'W'=wide32, 'b'=base64
 	// Count 'z' characters
 	while (*p == 'z') {
 		if (!raw) {
@@ -1976,19 +1970,24 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		}
 		return;
 	}
-	// Parse type filter suffix (a, u, w, W)
-	if (*p == 'a') {
-		type_filter = R_STRING_TYPE_ASCII;
-		p++;
-	} else if (*p == 'u') {
-		type_filter = R_STRING_TYPE_UTF8;
-		p++;
-	} else if (*p == 'w') {
-		type_filter = R_STRING_TYPE_WIDE;
-		p++;
-	} else if (*p == 'W') {
-		type_filter = R_STRING_TYPE_WIDE32;
-		p++;
+	// Parse type filter suffix (a, u, w, W, b) — not supported in izzz dump mode
+	if (!rdump) {
+		if (*p == 'a') {
+			type_filter = R_STRING_TYPE_ASCII;
+			p++;
+		} else if (*p == 'u') {
+			type_filter = R_STRING_TYPE_UTF8;
+			p++;
+		} else if (*p == 'w') {
+			type_filter = R_STRING_TYPE_WIDE;
+			p++;
+		} else if (*p == 'W') {
+			type_filter = R_STRING_TYPE_WIDE32;
+			p++;
+		} else if (*p == 'b') {
+			type_filter = R_STRING_TYPE_BASE64;
+			p++;
+		}
 	}
 	// Parse suffix (j, jq, qj, q, qq, *, ,)
 	bool local_pj = false;
@@ -2038,9 +2037,12 @@ static void cmd_iz(RCore *core, PJ *pj, int mode, int is_array, bool va, const c
 		if (list) {
 			ut64 addr = core->addr;
 			RBinString *string;
-			R_VEC_FOREACH (list, string) {
-				ut64 vaddr = va? string->vaddr: string->paddr;
-				if (vaddr == addr || string->paddr == addr) {
+		R_VEC_FOREACH (list, string) {
+			ut64 vaddr = va? string->vaddr: string->paddr;
+			if (type_filter && string->type != type_filter) {
+				continue;
+			}
+			if (vaddr == addr || string->paddr == addr) {
 					if (mode & R_MODE_JSON) {
 						PJ *lpj = r_core_pj_new (core);
 						pj_o (lpj);

--- a/test/db/cmd/cmd_iz
+++ b/test/db/cmd/cmd_iz
@@ -782,3 +782,71 @@ EXPECT=<<EOF
 [{"vaddr":22915,"paddr":22915,"ordinal":2,"size":13,"length":12,"section":".rodata","type":"ascii","string":"socket %x %x"}]
 EOF
 RUN
+
+NAME=iza (ascii only)
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=iza
+EXPECT=<<EOF
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+EOF
+RUN
+
+NAME=izu (utf8 only)
+FILE=bins/elf/strenc
+CMDS=<<EOF
+izu~en_US
+EOF
+EXPECT=<<EOF
+0   0x000021f4 0x004021f4 10  11   .rodata ascii en_US.utf8
+EOF
+RUN
+
+NAME=izw (wide/utf16 only)
+FILE=bins/elf/strenc
+CMDS=<<EOF
+izw~wall
+EOF
+EXPECT=<<EOF
+007 0x000022c8 0x004022c8  33  68 (.rodata) utf16le is a wall with no embedded zeros\n
+EOF
+RUN
+
+NAME=izW (wide32/utf32 only)
+FILE=bins/elf/strenc
+CMDS=<<EOF
+izW~Mountain
+EOF
+EXPECT=<<EOF
+18  0x0000266c 0x0040266c 48  196  .rodata utf32le Mountain range with embedded quad zeros: 𐌀A𐌀A𐌀A\n
+EOF
+RUN
+
+NAME=izza (ascii only, whole binary)
+FILE=bins/elf/analysis/hello-linux-x86_64
+CMDS=izza~puts
+EXPECT=<<EOF
+4   0x000002fa 0x000002fa 4   5            ascii   puts
+65  0x00001953 0x00001953 17  18           ascii   puts@@GLIBC_2.2.5
+EOF
+RUN
+
+NAME=izaj (ascii only, JSON)
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=izaj
+EXPECT=<<EOF
+[{"vaddr":134513840,"paddr":1200,"ordinal":0,"size":13,"length":12,"section":".rodata","type":"ascii","string":"Hello world!"}]
+EOF
+RUN
+
+NAME=iz - no match for wrong type
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=<<EOF
+izw
+EOF
+EXPECT=<<EOF
+nth paddr vaddr len size section type string
+--------------------------------------------
+EOF
+RUN

--- a/test/db/cmd/cmd_iz
+++ b/test/db/cmd/cmd_iz
@@ -793,42 +793,42 @@ nth paddr      vaddr      len size section type  string
 EOF
 RUN
 
-NAME=izu (utf8 only)
-FILE=bins/elf/strenc
+NAME=izu (utf8 only) - ascii string excluded
+FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
-izu~en_US
+izu
 EOF
 EXPECT=<<EOF
-0   0x000021f4 0x004021f4 10  11   .rodata ascii en_US.utf8
+nth paddr vaddr len size section type string
+--------------------------------------------
 EOF
 RUN
 
-NAME=izw (wide/utf16 only)
-FILE=bins/elf/strenc
-CMDS=<<EOF
-izw~wall
-EOF
+NAME=izw (wide/utf16 only) - no wide strings in this binary
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=izw
 EXPECT=<<EOF
-007 0x000022c8 0x004022c8  33  68 (.rodata) utf16le is a wall with no embedded zeros\n
+nth paddr vaddr len size section type string
+--------------------------------------------
 EOF
 RUN
 
-NAME=izW (wide32/utf32 only)
-FILE=bins/elf/strenc
-CMDS=<<EOF
-izW~Mountain
-EOF
+NAME=izW (wide32/utf32 only) - no wide32 strings in this binary
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=izW
 EXPECT=<<EOF
-18  0x0000266c 0x0040266c 48  196  .rodata utf32le Mountain range with embedded quad zeros: 𐌀A𐌀A𐌀A\n
+nth paddr vaddr len size section type string
+--------------------------------------------
 EOF
 RUN
 
 NAME=izza (ascii only, whole binary)
-FILE=bins/elf/analysis/hello-linux-x86_64
-CMDS=izza~puts
+FILE=bins/elf/analysis/x86-helloworld-gcc
+CMDS=izza
 EXPECT=<<EOF
-4   0x000002fa 0x000002fa 4   5            ascii   puts
-65  0x00001953 0x00001953 17  18           ascii   puts@@GLIBC_2.2.5
+nth paddr      vaddr      len size section type  string
+-------------------------------------------------------
+0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
 EOF
 RUN
 
@@ -840,7 +840,7 @@ EXPECT=<<EOF
 EOF
 RUN
 
-NAME=iz - no match for wrong type
+NAME=iz - no match for wrong type (wide in ascii-only binary)
 FILE=bins/elf/analysis/x86-helloworld-gcc
 CMDS=<<EOF
 izw

--- a/test/db/cmd/cmd_iz
+++ b/test/db/cmd/cmd_iz
@@ -824,11 +824,9 @@ RUN
 
 NAME=izza (ascii only, whole binary)
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=izza
+CMDS=izza~Hello
 EXPECT=<<EOF
-nth paddr      vaddr      len size section type  string
--------------------------------------------------------
-0   0x000004b0 0x080484b0 12  13   .rodata ascii Hello world!
+11  0x000004b0 0x080484b0 12  13   .rodata   ascii Hello world!
 EOF
 RUN
 

--- a/test/db/cmd/cmd_iz
+++ b/test/db/cmd/cmd_iz
@@ -832,19 +832,8 @@ RUN
 
 NAME=izaj (ascii only, JSON)
 FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=izaj
+CMDS=izaj~Hello
 EXPECT=<<EOF
 [{"vaddr":134513840,"paddr":1200,"ordinal":0,"size":13,"length":12,"section":".rodata","type":"ascii","string":"Hello world!"}]
-EOF
-RUN
-
-NAME=iz - no match for wrong type (wide in ascii-only binary)
-FILE=bins/elf/analysis/x86-helloworld-gcc
-CMDS=<<EOF
-izw
-EOF
-EXPECT=<<EOF
-nth paddr vaddr len size section type string
---------------------------------------------
 EOF
 RUN


### PR DESCRIPTION
Add `-a`, `-u`, `-w`, `-W` flags to filter strings by type in `iz` and `izz` commands.

## Problem

There was no way to filter `iz`/`izz` output by string type without using the `bin.strfilter` config variable, which only supports a single type at a time.

## Solution

New suffix flags on `iz` and `izz`:

| Flag | Type | Description |
|------|------|-------------|
| `a` | ASCII | Show only ASCII strings |
| `u` | UTF-8 | Show only UTF-8 strings |
| `w` | UTF-16LE | Show only wide strings |
| `W` | UTF-32LE | Show only wide32 strings |

These work across all output modes (normal, JSON, quiet, radare commands):

```
iza     - ASCII strings only
izuq    - UTF-8 strings in quiet mode
izaj    - ASCII strings in JSON
izzw    - wide strings from whole binary scan
```

## Implementation

- `_print_strings()` in `libr/core/cbin.c`: Added `type_filter` parameter, checks `string->type` against filter before printing
- `bin_strings()` / `bin_raw_strings()`: Pass filter through to `_print_strings()`
- `cmd_iz()` in `libr/core/cmd_info.inc.c`: Parse `a`/`u`/`w`/`W` suffixes after `z` count and before mode specifier

## Tests

Added 7 test cases in `test/db/cmd/cmd_iz`:
- `iza` (ascii only)
- `izu` (utf8 only)
- `izw` (wide only)
- `izW` (wide32 only)
- `izza` (ascii, whole binary)
- `izaj` (ascii + JSON)
- `iz - no match for wrong type` (empty result)

Fixes #18821