### PR TITLE
[SECURITY] Fix copy_string reporting success after freeing its buffer ##bin

### DIFF
--- a/libr/bin/mangling/microsoft.c
+++ b/libr/bin/mangling/microsoft.c
@@ -212,26 +212,24 @@ static int copy_string(STypeCodeStr *type_code_str, const char *str_for_copy, si
 	if (free_space < str_for_copy_len) {
 		int newlen = type_code_str->type_str_len + (str_for_copy_len << 1) + 1;
 		if (newlen < 1 || newlen > UT16_MAX) {
-			R_FREE (type_code_str->type_str);
-			goto copy_string_err;
-		}
-		type_code_str->type_str_len = newlen;
-		char *type_str = (char *) realloc (type_code_str->type_str, newlen);
-		if (!type_str) {
-			R_FREE (type_code_str->type_str);
-			goto copy_string_err;
-		}
-		type_code_str->type_str = type_str;
-		if (!type_code_str->type_str) {
 			res = 0;
 			goto copy_string_err;
 		}
+		char *type_str = (char *) realloc (type_code_str->type_str, newlen);
+		if (!type_str) {
+			res = 0;
+			goto copy_string_err;
+		}
+		// publish the new length only once the buffer really grew, so that
+		// type_str_len never describes an allocation that does not exist
+		type_code_str->type_str = type_str;
+		type_code_str->type_str_len = newlen;
 	}
 
-	char *dst = type_code_str->type_str + type_code_str->curr_pos;
-	if (!dst) {
+	if (!type_code_str->type_str) {
 		return 0;
 	}
+	char *dst = type_code_str->type_str + type_code_str->curr_pos;
 
 	if (str_for_copy) {
 		r_str_ncpy  (dst, str_for_copy, str_for_copy_len + 1);
@@ -239,11 +237,17 @@ static int copy_string(STypeCodeStr *type_code_str, const char *str_for_copy, si
 		memset (dst, 0, str_for_copy_len);
 	}
 	type_code_str->curr_pos += str_for_copy_len;
-	if (type_code_str->type_str) {
-		type_code_str->type_str[type_code_str->curr_pos] = '\0';
-	}
+	type_code_str->type_str[type_code_str->curr_pos] = '\0';
 
 copy_string_err:
+	if (!res) {
+		// the buffer is unusable from here on. Drop it and reset the
+		// bookkeeping so any later call bails out at the curr_pos check
+		// above rather than writing through a stale offset.
+		R_FREE (type_code_str->type_str);
+		type_code_str->type_str_len = 0;
+		type_code_str->curr_pos = 0;
+	}
 	return res;
 }
 


### PR DESCRIPTION
copy_string() initialises res to 1 and both of its failure paths jumped to the return label without clearing it:

    int res = 1; // all is OK
    if (newlen < 1 || newlen > UT16_MAX) {
        R_FREE (type_code_str->type_str);   // type_str = NULL
        goto copy_string_err;               // res is still 1
    }
    type_code_str->type_str_len = newlen;   // never reached
    ...
    copy_string_err:
        return res;                         // reports success

So the buffer was freed while type_str_len and curr_pos kept their old, mutually consistent values. The next call passed the `curr_pos >= type_str_len` guard, computed `dst = NULL + curr_pos`, survived the `if (!dst)` test because curr_pos is nonzero, and wrote through it. curr_pos is attacker influenced (below 65535), so the faulting address was partly chosen by the input. The realloc failure path had the same shape, and callers such as the one at line 870 do check the return value, so they were actively misled.

Reaching it needs an MSVC mangled symbol from a PE symbol table whose nested templates or repeated modifiers expand the output past 64KB.

Set res = 0 on both failures and do the teardown once, at the label, guarded by !res so the success fallthrough is unaffected. Freeing there also resets type_str_len and curr_pos to zero, which makes every later call bail out at the existing curr_pos check instead of writing through a stale offset. On the realloc path the original block is still owned by type_code_str, since realloc does not free on failure, so freeing it here is correct and not a double free.

Two related cleanups: type_str_len is now assigned only after the realloc succeeds, so it can no longer describe an allocation that was never made, and the meaningless `if (!dst)` test on a pointer derived from type_str is replaced by a check on type_str itself.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
