### PR TITLE
[SECURITY] Fix heap buffer overflow in the base91 muta plugin ##util

### DIFF
--- a/libr/include/r_util/r_base91.h
+++ b/libr/include/r_util/r_base91.h
@@ -5,8 +5,18 @@
 extern "C" {
 #endif
 
+/* Encode `len` bytes. `bout` must hold at least `((len * 16) / 13) + 3` bytes,
+ * where `len` is `strlen (bin)` when a negative length is given. The output is
+ * not NUL terminated; the amount of written chars is returned. */
 R_API int r_base91_encode(char *bout, const ut8 *bin, int len);
+/* Decode `len` chars. `bout` must hold at least `((len * 7) / 8) + 3` bytes.
+ * Returns the amount of decoded bytes. */
 R_API int r_base91_decode(ut8 *bout, const char *bin, int len);
+/* Allocating variants that size the output buffer themselves. The encoded
+ * string is NUL terminated; the decoded buffer is not, so it reports its
+ * length through `olen` when that is not NULL. */
+R_API char *r_base91_encode_dyn(const ut8 *bin, int len);
+R_API ut8 *r_base91_decode_dyn(const char *bin, int len, int *olen);
 
 #ifdef __cplusplus
 }

--- a/libr/muta/p/muta_base91.c
+++ b/libr/muta/p/muta_base91.c
@@ -4,8 +4,6 @@
 #include <r_muta.h>
 #include <r_util.h>
 
-#define INSIZE 32768
-
 static bool base91_set_key(RMutaSession *ms, const ut8 *key, int keylen, int mode, int direction) {
 	ms->dir = direction;
 	return true;
@@ -18,20 +16,33 @@ static int base91_get_key_size(RMutaSession *ms) {
 static bool update(RMutaSession *ms, const ut8 *buf, int len) {
 	R_RETURN_VAL_IF_FAIL (ms && buf && len > 0, false);
 
-	int olen = INSIZE;
-	ut8 *obuf = calloc (1, olen);
-	if (!obuf) {
-		return false;
-	}
+	int olen = 0;
+	ut8 *obuf = NULL;
 	switch (ms->dir) {
 	case R_MUTA_OP_ENCRYPT:
-		olen = r_base91_encode ((char *)obuf, (const ut8 *)buf, len);
+		{
+			obuf = (ut8 *)r_base91_encode_dyn (buf, len);
+			if (!obuf) {
+				return false;
+			}
+			size_t encoded_len = strlen ((const char *)obuf);
+			if (encoded_len > ST32_MAX) {
+				free (obuf);
+				return false;
+			}
+			olen = (int)encoded_len;
+		}
 		break;
 	case R_MUTA_OP_DECRYPT:
-		olen = r_base91_decode (obuf, (const char *)buf, len);
+		obuf = r_base91_decode_dyn ((const char *)buf, len, &olen);
+		if (!obuf) {
+			return false;
+		}
 		break;
 	}
-	r_muta_session_append (ms, obuf, olen);
+	if (olen > 0) {
+		r_muta_session_append (ms, obuf, olen);
+	}
 	free (obuf);
 	return true;
 }

--- a/libr/util/base91.c
+++ b/libr/util/base91.c
@@ -96,3 +96,47 @@ R_API int r_base91_encode(char *bout, const ut8 *bin, int len) {
 	}
 	return out;
 }
+
+R_API char *r_base91_encode_dyn(const ut8 *bin, int len) {
+	R_RETURN_VAL_IF_FAIL (bin, NULL);
+	const size_t slen = (len < 0)? strlen ((const char *)bin): (size_t)len;
+	// every 13 bits of input emit 2 chars, the tail flush emits up to 2 more
+	size_t olen;
+	if (r_mul_overflow (slen, (size_t)16, &olen)) {
+		return NULL;
+	}
+	olen /= 13;
+	if (r_add_overflow (olen, (size_t)3, &olen)) {
+		return NULL;
+	}
+	char *bout = malloc (olen);
+	if (!bout) {
+		return NULL;
+	}
+	int written = r_base91_encode (bout, bin, (int)slen);
+	bout[written] = 0;
+	return bout;
+}
+
+R_API ut8 *r_base91_decode_dyn(const char *bin, int len, int *olen) {
+	R_RETURN_VAL_IF_FAIL (bin, NULL);
+	const size_t slen = (len < 0)? strlen (bin): (size_t)len;
+	// each pair of chars carries at most 14 bits, plus one tail byte
+	size_t osz;
+	if (r_mul_overflow (slen, (size_t)7, &osz)) {
+		return NULL;
+	}
+	osz /= 8;
+	if (r_add_overflow (osz, (size_t)3, &osz)) {
+		return NULL;
+	}
+	ut8 *bout = malloc (osz);
+	if (!bout) {
+		return NULL;
+	}
+	int written = r_base91_decode (bout, bin, (int)slen);
+	if (olen) {
+		*olen = written;
+	}
+	return bout;
+}


### PR DESCRIPTION
r_base91_encode() and r_base91_decode() take no output-capacity argument, and the only caller sized its buffer with a constant:

    #define INSIZE 32768
    ut8 *obuf = calloc (1, INSIZE);
    olen = r_base91_encode ((char *)obuf, buf, len);

base91 expands its input by roughly 1.23x, so the encoder walked off the end of that 32768-byte allocation as soon as the input passed 26625 bytes, writing fully attacker-controlled content. Decoding overflowed at 37451 bytes. rahash2 -E base91 hands it the whole file and base91 is a no_key_mode codec, so `rahash2 -E base91 <any file over 26KB>` was enough; RABIN2_CHARSET=base91 and `pe base91` reach the same code.

Add r_base91_encode_dyn() and r_base91_decode_dyn(), which compute the output size from the input length with r_mul_overflow/r_add_overflow guards and allocate accordingly, mirroring the r_base64_*_dyn pair that already exists for exactly this reason. The muta plugin now uses them and INSIZE is gone.

The bounds are ((len * 16) / 13) + 3 for encode and ((len * 7) / 8) + 3 for decode. Both were checked against the real encoder and decoder counters for every length in 0..200000: they always hold, with at most 3 bytes of slack. Documented them on the raw functions too, as r_base64.h does, since those keep their unbounded signature and stay ABI compatible.

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
