### PR TITLE
[SECURITY] Fix integer overflow in the swift demangler bounds check ##bin

### DIFF
--- a/libr/bin/mangling/swift-sd.c
+++ b/libr/bin/mangling/swift-sd.c
@@ -1324,7 +1324,10 @@ R_API char *r_bin_demangle_swift_typeref(const ut8 *p, int len, ut64 va, RBinSwi
 				while (i < len && isdigit (p[i])) {
 					i++;
 				}
-				if (n < 1 || i + n > len) {
+				// n comes from the mangled name, so `i + n` would wrap for a
+				// large digit run and let the check pass. i <= len here, so
+				// subtracting instead cannot overflow.
+				if (n < 1 || n > len - i) {
 					break;
 				}
 				if (r_strbuf_length (nb) > 0) {

--- a/libr/util/strbuf.c
+++ b/libr/util/strbuf.c
@@ -157,7 +157,7 @@ R_API bool r_strbuf_reserve(RStrBuf *sb, size_t len) {
 
 R_API bool r_strbuf_setbin(RStrBuf *sb, const ut8 *s, size_t l) {
 	R_RETURN_VAL_IF_FAIL (sb && s, false);
-	if (l > ST32_MAX) {
+	if (l >= ST32_MAX) {
 		return false;
 	}
 	if (l >= sizeof (sb->buf)) {
@@ -289,7 +289,7 @@ R_API bool r_strbuf_append(RStrBuf *sb, const char *s) {
 
 R_API bool r_strbuf_append_n(RStrBuf *sb, const char *s, size_t l) {
 	R_RETURN_VAL_IF_FAIL (sb && s, false);
-	if (l > ST32_MAX) {
+	if (l >= ST32_MAX) {
 		R_LOG_WARN ("Negative length used in r_strbuf_append_n");
 		return false;
 	}
@@ -387,7 +387,7 @@ R_API bool r_strbuf_prependf(RStrBuf *sb, const char *fmt, ...) {
 
 R_API bool r_strbuf_prepend_n(RStrBuf *sb, const char *s, size_t l) {
 	R_RETURN_VAL_IF_FAIL (sb && s, false);
-	if (l > ST32_MAX) {
+	if (l >= ST32_MAX) {
 		R_LOG_WARN ("Negative length used in r_strbuf_prepend_n");
 		return false;
 	}


### PR DESCRIPTION
The identifier-segment loop validated an attacker-supplied length with

    int n = atoi ((const char *)p + i);
    if (n < 1 || i + n > len) { break; }
    r_strbuf_append_n (nb, (const char *)p + i, n);

Both operands are int, so a mangled name carrying the digit run "2147483647" produced n = INT_MAX and, with i = 10, made `i + n` evaluate to -2147483639. The guard passed and r_strbuf_append_n() was asked to memcpy 2GB out of the 256-byte stack buffer that swift.c:194 fills from the file, which is reached by simply opening a crafted Swift Mach-O or ELF. Symbol strings hit the same code through swift.c:83.

Compare with subtraction instead. The inner digit-skipping loop keeps i <= len, so `len - i` is non-negative and `n > len - i` cannot wrap.

The backstop inside RStrBuf did not catch this either: r_strbuf_setbin(), r_strbuf_append_n() and r_strbuf_prepend_n() all rejected `l > ST32_MAX`, which is off by one and accepts l == ST32_MAX exactly, the very value produced here. Their intent is to catch a negative int widened to size_t, so `l >= ST32_MAX` keeps that behaviour while also refusing a 2GB append that no real caller performs.

Checked the sibling atoi() sites in this file and left them alone: 985, 1045, 1478 and 1511 already compare without adding, 485 only rejects, and 459 passes its length to r_str_ndup(), which clamps with r_str_nlen().

<!--
Read https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md
* PR title must be capitalized, concise and use ##tags
* If the PR is fixing a ticket use 'Fix #1234 - ..' in the commit message
* Follow the coding style, add tests and documentation if necessary
-->

- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

<!-- explain your changes if necessary -->
