### PR TITLE
Make esil shifts total and fill ASR with the sign at any count ##esil

### DIFF
--- a/doc/esil.md
+++ b/doc/esil.md
@@ -234,6 +234,12 @@ on that width. CLZ does: the count for the value 1 is 31 at width 32 and 63 at
 width 64. POPCNT does not, because a caller wanting a narrower count masks the
 value first.
 
+The shifts are total in the count: LSL and LSR push 0 for a count of 64 or
+more. ASR takes the sign of its value from the top bit of the register that
+holds it (bit 7 of `al`, bit 15 of `ax`, bit 31 of `eax`); a literal is 32
+bits wide under `asm.bits=32` and 64 bits wide otherwise. A count of that width
+or more pushes the sign fill, 0 or 0xffffffffffffffff.
+
 # Floating point
 
 _TODO_

--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1107,12 +1107,7 @@ static const char *arg(RArchSession *as, csh *handle, cs_insn *insn, char *buf, 
 						cs_reg_name(*handle, LSHIFT2(n)),
 						REG (n), DECODE_SHIFT (n));
 			} else {
-				// asr #32 is encodable, but esil ASR rewrites a count above 31
-				unsigned int sh = LSHIFT2 (n);
-				if (SHIFTTYPE (n) == ARM_SFT_ASR) {
-					sh = R_MIN (sh, 31);
-				}
-				snprintf (buf, buf_sz, "%u,%s,%s", sh, REG (n), DECODE_SHIFT (n));
+				snprintf (buf, buf_sz, "%u,%s,%s", LSHIFT2 (n), REG (n), DECODE_SHIFT (n));
 			}
 		} else {
 			snprintf (buf, buf_sz, "%s",
@@ -2716,9 +2711,8 @@ static bool arm32shiftreg(RArchSession *as, RAnalOp *op, csh *handle, cs_insn *i
 		res = "0xff,%s,&,%s,>>,0xffffffff,&,%s,=";
 		break;
 	case ARM_INS_ASR:
-		cf = "0xff,%s,&,!,!,?{,1,1,0xff,%s,&,-,32,%s,~,>>,&,cf,:=,},";
-		// esil ASR rewrites an out-of-range count, so saturate at 31 here
-		res = "0xff,%s,&,DUP,5,SWAP,>>,!,!,0x1f,*,SWAP,0x1f,&,|,%s,ASR,%s,=";
+		cf = "0xff,%s,&,!,!,?{,1,1,0xff,%s,&,-,%s,ASR,&,cf,:=,},";
+		res = "0xff,%s,&,%s,ASR,%s,=";
 		break;
 	default:
 		cf = "0xff,%s,&,!,!,?{,1,0x1f,1,0xff,%s,&,-,&,%s,>>,&,cf,:=,},";
@@ -3115,12 +3109,11 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 						}
 						break;
 					case ARM_SFT_ASR:
-						// esil ASR rewrites a count above 31
 						r_strbuf_appendf (&op->esil, "%s,%s,%d,%s,ASR,+,0xffffffff,&,=[%d]",
-								  REG(0), MEMBASE(1), R_MIN (SHIFTVALUE(1), 31), MEMINDEX(1), str_ldr_bytes);
+								  REG(0), MEMBASE(1), SHIFTVALUE(1), MEMINDEX(1), str_ldr_bytes);
 						if (ISWRITEBACK32 ()) {
 							r_strbuf_appendf (&op->esil, ",%s,%d,%s,ASR,+,%s,=",
-										MEMBASE(1), R_MIN (SHIFTVALUE(1), 31), MEMINDEX(1), MEMBASE(1));
+										MEMBASE(1), SHIFTVALUE(1), MEMINDEX(1), MEMBASE(1));
 						}
 						break;
 					case ARM_SFT_ROR:
@@ -3165,9 +3158,8 @@ r6,r5,r4,3,sp,[*],12,sp,+=
 							       REG(0), MEMBASE(1), str_ldr_bytes, MEMBASE(1), SHIFTVALUE(2), REG(2), MEMBASE(1));
 						break;
 					case ARM_SFT_ASR:
-						// esil ASR rewrites a count above 31
 						r_strbuf_appendf (&op->esil, "%s,%s,0xffffffff,&,=[%d],%s,%d,%s,ASR,+,%s,=",
-								      REG(0), MEMBASE(1), str_ldr_bytes, MEMBASE(1), R_MIN (SHIFTVALUE(2), 31), REG(2), MEMBASE(1));
+								      REG(0), MEMBASE(1), str_ldr_bytes, MEMBASE(1), SHIFTVALUE(2), REG(2), MEMBASE(1));
 						break;
 					case ARM_SFT_ROR:
 						r_strbuf_appendf (&op->esil, "%s,%s,0xffffffff,&,=[%d],%s,%d,%s,ROR,+,%s,=",

--- a/libr/arch/p/mips/plugin_cs.c
+++ b/libr/arch/p/mips/plugin_cs.c
@@ -154,7 +154,7 @@ static inline void es_sign_n_64(RArchSession *as, RAnalOp *op, const char *arg, 
 	}
 }
 
-// a mips64 arithmetic shift fills from bit 63, and esil ASR rewrites the count
+// spelled out with >> so the fill does not depend on the ASR width rule
 static inline void es_dsra(RAnalOp *op, const char *cnt, const char *rt, const char *rd) {
 	r_strbuf_appendf (&op->esil,
 		"%s,%s,>>,63,%s,>>,?{,%s,64,-,0xffffffffffffffff,<<,}{,0,},|,%s,=",

--- a/libr/esil/esil_ops.c
+++ b/libr/esil/esil_ops.c
@@ -142,6 +142,17 @@ static bool esil_popcount(REsil *esil) {
 	return r_esil_pushnum (esil, r_bits_popcount64 (val));
 }
 
+static ut64 sext(ut64 v, ut64 bits) {
+	if (bits == 0) {
+		return 0;
+	}
+	if (bits > 63) {
+		return v;
+	}
+	const ut64 m = 1ULL << (bits - 1);
+	return ((v & r_num_bitmask (bits)) ^ m) - m;
+}
+
 // Sign-extend n-bit value to 64 bits. Example: "ae 8,0x81,~" -> 0xffffffffffffff81.
 static bool esil_signext(REsil *esil) {
 	ut64 src, dst;
@@ -164,15 +175,7 @@ static bool esil_signext(REsil *esil) {
 		return false;
 	}
 
-	// Make sure the other bits are 0
-	ut64 m = 0;
-	if (dst > 0 && dst < 64) {
-		src &= UT64_MAX >> (64 - dst);
-		m = 1ULL << (dst - 1);
-	} else if (dst == 0) {
-		src = 0;
-	}
-	return r_esil_pushnum (esil, ((src ^ m) - m));
+	return r_esil_pushnum (esil, sext (src, dst));
 }
 
 static bool esil_zf(REsil *esil) {
@@ -627,13 +630,8 @@ static bool esil_lsl(REsil *esil) {
 	const RStrs src = r_esil_pop (esil);
 	if (!r_strs_empty (dst) && r_esil_get_parm (esil, dst, &num)) {
 		if (!r_strs_empty (src) && r_esil_get_parm (esil, src, &num2)) {
-			if (num2 > sizeof (ut64) * 8) {
-				R_LOG_DEBUG ("esil_lsl: shift is too big");
-			} else {
-				const ut64 shift = (num2 > 63)? 0: num << num2;
-				r_esil_pushnum (esil, shift);
-				ret = true;
-			}
+			r_esil_pushnum (esil, (num2 > 63)? 0: num << num2);
+			ret = true;
 		} else {
 			R_LOG_DEBUG ("esil_lsl: empty stack");
 		}
@@ -648,8 +646,7 @@ static bool esil_lsr(REsil *esil) {
 	const RStrs src = r_esil_pop (esil);
 	if (!r_strs_empty (dst) && r_esil_get_parm (esil, dst, &num)) {
 		if (!r_strs_empty (src) && r_esil_get_parm (esil, src, &num2)) {
-			ut64 res = num >> R_MIN (num2, 63);
-			r_esil_pushnum (esil, res);
+			r_esil_pushnum (esil, (num2 > 63)? 0: num >> num2);
 			ret = true;
 		} else {
 			R_LOG_DEBUG ("esil_lsr: empty stack");
@@ -661,43 +658,19 @@ static bool esil_lsr(REsil *esil) {
 static bool esil_asr(REsil *esil) {
 	bool ret = false;
 	int regsize = 0;
-	ut64 op_num = 0, param_num = 0;
-	const RStrs op = r_esil_pop (esil);
-	const RStrs param = r_esil_pop (esil);
-	if (!r_strs_empty (op) && r_esil_get_parm_size (esil, op, &op_num, &regsize)) {
-		if (!r_strs_empty (param) && r_esil_get_parm (esil, param, &param_num)) {
-			if (param_num > regsize - 1) {
-				// capstone bug?
-				R_LOG_DEBUG ("Invalid asr shift of %"PFMT64d" at 0x%"PFMT64x, param_num, esil->addr);
-				param_num = 30;
+	ut64 num, num2;
+	const RStrs dst = r_esil_pop (esil);
+	const RStrs src = r_esil_pop (esil);
+	if (!r_strs_empty (dst) && r_esil_get_parm_size (esil, dst, &num, &regsize)) {
+		if (!r_strs_empty (src) && r_esil_get_parm (esil, src, &num2)) {
+			// a literal is 32 bits wide under asm.bits=32, else 64
+			const bool narrow = regsize > 0 && regsize < 64 &&
+				(regsize == 32 || r_esil_get_parm_type (esil, dst) == R_ESIL_PARM_REG);
+			if (narrow) {
+				num = sext (num, regsize);
 			}
-			bool isNegative;
-			if (regsize == 32) {
-				isNegative = ((st32)op_num) < 0;
-				st32 snum = op_num;
-				op_num = snum;
-			} else {
-				isNegative = ((st64)op_num) < 0;
-			}
-			if (isNegative) {
-				ut64 mask = (regsize - 1);
-				param_num &= mask;
-				ut64 left_bits = 0;
-				if (regsize <= 64) {
-					if (op_num & (1ULL << (regsize - 1))) {
-						if (regsize - param_num >= 64) {
-							left_bits = 0;
-						} else {
-							left_bits = (1ULL << param_num) - 1;
-							left_bits <<= regsize - param_num;
-						}
-					}
-				}
-				op_num = left_bits | (op_num >> param_num);
-			} else {
-				op_num >>= param_num;
-			}
-			ut64 res = op_num;
+			const ut64 fill = ((st64)num < 0)? UT64_MAX: 0;
+			const ut64 res = (num2 > 63)? fill: (num >> num2) | (fill & ~(UT64_MAX >> num2));
 			r_esil_pushnum (esil, res);
 			ret = true;
 		} else {

--- a/man/esil.7
+++ b/man/esil.7
@@ -154,7 +154,7 @@ ROL - Rotate left
 .It
 ROR - Rotate right
 .It
-ASR - Arithmetic shift right
+ASR - Arithmetic shift right, signed at the width of the value's register
 .It
 CLZ - Count leading zeros of a value within an explicit width
 .It
@@ -164,6 +164,10 @@ POPCNT - Count the set bits of a value
 An operation takes an explicit leading width operand only when its result depends
 on that width: CLZ does (the count for 1 is 31 at width 32 and 63 at width 64),
 POPCNT does not.
+.Pp
+The shifts are total: <<, >> and ASR by a count of 64 or more push 0, 0 and
+the sign fill respectively, and ASR of a register by its width or more pushes
+the sign fill.
 .Pp
 .It Cm Comparison operations
 Compare values and set flags:

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3536,3 +3536,42 @@ EXPECT=<<EOF
 0x00000001
 EOF
 RUN
+NAME=asr by the register width or more is the sign fill and asrs keeps the carry
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+aei
+aeim
+aer r1=0x80000005
+ae 32,r1,ASR
+ae 40,r1,ASR
+wx 5102b0e1 @ 0
+aer r2=255
+aer cf=0
+aer PC=0
+aes
+aer cf
+aer r0
+aer r2=64
+aer cf=0
+aer PC=0
+aes
+aer cf
+aer r1=0x7fffffff
+aer r2=255
+aer cf=1
+aer PC=0
+aes
+aer cf
+aer r0
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0xffffffffffffffff
+0x00000001
+0xffffffff
+0x00000001
+0x00000000
+0x00000000
+EOF
+RUN

--- a/test/db/esil/esil
+++ b/test/db/esil/esil
@@ -936,3 +936,113 @@ EXPECT=<<EOF
 0x50000000000
 EOF
 RUN
+
+NAME=a shift count of 64 or more pushes zero
+FILE=-
+CMDS=<<EOF
+ae 65,1,LSL
+ae 64,1,LSL
+ae 63,1,LSL
+ae 64,0xffffffffffffffff,LSR
+ae 100,0xffffffffffffffff,LSR
+ae 63,0xffffffffffffffff,LSR
+EOF
+EXPECT=<<EOF
+0
+0
+0x8000000000000000
+0
+0
+0x1
+EOF
+RUN
+
+NAME=asr by the width or more is the sign fill
+FILE=-
+CMDS=<<EOF
+ae 64,0x8000000000000000,ASR
+ae 100,0x8000000000000000,ASR
+ae 63,0x8000000000000000,ASR
+ae 64,1,ASR
+ae 100,0x7fffffffffffffff,ASR
+ae 1,0x8000000000000000,ASR
+ae 0,0x8000000000000000,ASR
+ae 0,0xffffffffffffffff,ASR
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0xffffffffffffffff
+0xffffffffffffffff
+0
+0
+0xc000000000000000
+0x8000000000000000
+0xffffffffffffffff
+EOF
+RUN
+
+NAME=asr at 32 bits takes its sign from bit 31
+FILE=-
+ARGS=-b 32
+CMDS=<<EOF
+ae 33,0x80000000,ASR
+ae 1,0x80000000,ASR
+ae 31,0x80000000,ASR
+ae 16,16,0x8000,LSL,ASR
+ae 1,0x40000000,ASR
+EOF
+EXPECT=<<EOF
+0xffffffffffffffff
+0xffffffffc0000000
+0xffffffffffffffff
+0xffffffffffff8000
+0x20000000
+EOF
+RUN
+
+NAME=asr takes its sign from the register width and a literal keeps its own
+FILE=malloc://0x10
+ARGS=-a x86 -b 16
+CMDS=<<EOF
+ar ax=0x8000
+ae 1,ax,ASR
+ar al=0x80
+ae 8,al,ASR
+ae 9,al,ASR
+ae 1,0x8000,ASR
+ae 1,0x80000000,ASR
+ae 1,0x8000000000000000,ASR
+EOF
+EXPECT=<<EOF
+0xffffffffffffc000
+0xffffffffffffffff
+0xffffffffffffffff
+0x4000
+0x40000000
+0xc000000000000000
+EOF
+RUN
+
+NAME=the assign forms inherit total shifts
+FILE=malloc://0x10
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+ar rax=1
+'ae 65,rax,<<=
+ar rax
+ar rbx=0xffffffffffffffff
+'ae 64,rbx,>>=
+ar rbx
+ar rbx=0x8000000000000000
+'ae 70,rbx,>>=
+ar rbx
+ar eax=0x80000000
+ae 31,eax,ASR
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000000
+0x00000000
+0xffffffffffffffff
+EOF
+RUN

--- a/test/db/esil/x86_16
+++ b/test/db/esil/x86_16
@@ -18,3 +18,48 @@ EXPECT=<<EOF
 0x0000000c
 EOF
 RUN
+
+NAME=sar keeps the sign of a word register and shifts a dword memory operand
+FILE=malloc://0x200
+ARGS=-a x86 -b 16
+CMDS=<<EOF
+aei
+aeim
+wx d1f8 @ 0
+ar ax=0x8000
+aes
+ar ax
+ar sf
+wx 66d138 @ 0
+ar bx=0x100
+ar si=0
+wv4 0x00008000 @ 0x100
+ar ip=0
+aes
+pxw 4 @ 0x100
+EOF
+EXPECT=<<EOF
+0x0000c000
+0x00000001
+0000:0100  0x00004000                                   .@..
+EOF
+RUN
+
+NAME=sar keeps the sign of a negative dword memory operand
+BROKEN=1
+FILE=malloc://0x200
+ARGS=-a x86 -b 16
+CMDS=<<EOF
+aei
+aeim
+wx 66d138 @ 0
+ar bx=0x100
+ar si=0
+wv4 0x80000000 @ 0x100
+aes
+pxw 4 @ 0x100
+EOF
+EXPECT=<<EOF
+0000:0100  0xc0000000                                   ....
+EOF
+RUN

--- a/test/db/esil/x86_64
+++ b/test/db/esil/x86_64
@@ -2089,3 +2089,48 @@ EXPECT=<<EOF
 0x00000023
 EOF
 RUN
+
+NAME=sar on a byte or word register keeps its sign
+FILE=malloc://0x100
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+aei
+aeim
+wx d0f8 @ 0
+ar rax=0xa5a5000300000080
+ar cf=1
+aes
+ar al
+ar rax
+ar sf
+ar cf
+wx 66d1f8 @ 0
+ar rax=0xa5a5000300008000
+ar rip=0
+aes
+ar ax
+ar sf
+wx c0f808 @ 0
+ar rax=0xa5a5000300000080
+ar rip=0
+aes
+ar al
+ar cf
+wx c0f809 @ 0
+ar rax=0xa5a5000300000080
+ar rip=0
+aes
+ar al
+EOF
+EXPECT=<<EOF
+0x000000c0
+0xa5a50003000000c0
+0x00000001
+0x00000000
+0x0000c000
+0x00000001
+0x000000ff
+0x00000001
+0x000000ff
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`<<` pushes nothing for a count above 64, `>>` clamps the count to 63, and `ASR` rewrites any count at or above the operand width to 30. Since #26556 the compound ops are definitions on top of these three, so every one of them inherits it.

```
$ r2 -N -qc "'ae 65,1,<<" --
$ r2 -N -qc "'ae 64,0xffffffffffffffff,>>" --
0x1
$ r2 -N -qc "'ae 64,0x8000000000000000,ASR" --
0xfffffffe00000000
$ r2 -N -a x86 -b 64 -c 'ar rax=1' -c "'ae 65,rax,<<=" -c 'ar rax' -q --
rax
0x00000001
```

The first prints nothing, the last leaves `rax` on the stack and the register untouched. `sar al,1` on 0x80 gives 0x40, because an 8-bit register was read as a positive 64-bit value.

- `<<` and `>>` push 0 for a count of 64 or more.
- `ASR` sign-extends a register operand from its declared width, then shifts; a count at or above the width pushes the sign fill. The count-30 rewrite and the `left_bits` arithmetic go, and `~` shares the new `sext` helper.
- A literal keeps today's width, 32 under `asm.bits=32` and 64 otherwise. Making it `asm.bits` wide breaks 16-bit x86 with an operand-size prefix (`66 d1 38`, `sar dword [bx+si],1`), and making it 64 breaks 32-bit `sar dword [eax]` and nds32 `seh`.
- The one emitter that relied on the `>>` clamp, the arm32 `asrs` by-register carry, reads the bit through `ASR` instead, and its value template loses the saturate-at-31 chain. The three `R_MIN (…, 31)` saturations on arm immediate `asr` counts and their comments go with the rewrite.
- 8- and 16-bit registers now carry their sign, so `sar al,1` and `sar ax,1` move to the correct value; no existing test covered them.

Tests: `db/esil/esil` pins the three ops at counts 63, 64, 100 and the definitions through `<<=`/`>>=`; `db/esil/x86_16` and `x86_64` pin the byte, word and dword register forms plus the `66 d1 38` case that must not move; `db/esil/arm_32` pins `asrs` by register at counts 32, 64 and 255. The `arm_32` case passes on master only through the old clamp and fails with the core change alone, so it guards the emitter move. The 16-bit `sar dword` memory case is `BROKEN=1`: it is wrong on master for a different reason (the load is a literal narrower than its width) and is not touched here.