### PR TITLE
Take the arm32 immediate shift carry from the source register ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -2840,7 +2840,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 			break;
 		}
 		if (insn->detail->arm.update_flags) {
-			if (OPCOUNT () == 2) {
+			if (OPCOUNT () == 2 && ISSHIFTED (1)) {
+				r_strbuf_appendf (&op->esil, "%s,1,%u,-,0x1,<<,&,!,!,cf,:=,", REG (1), LSHIFT2 (1));
+			} else if (OPCOUNT () == 2) {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<,&,!,!,cf,:=,},", ARG (1), ARG (0), ARG (1));
 			} else {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<,&,!,!,cf,:=,},", ARG (2), ARG (1), ARG (2));
@@ -2853,7 +2855,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 			break;
 		}
 		if (insn->detail->arm.update_flags) {
-			if (OPCOUNT () == 2) {
+			if (OPCOUNT () == 2 && ISSHIFTED (1)) {
+				r_strbuf_appendf (&op->esil, "%s,%u,32,-,0x1,<<,&,!,!,cf,:=,", REG (1), LSHIFT2 (1));
+			} else if (OPCOUNT () == 2) {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,32,-,%s,>>,cf,:=,},", ARG (1), ARG (1), ARG (0));
 			} else {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,32,-,%s,>>,cf,:=,},", ARG (2), ARG (2), ARG (1));
@@ -2874,7 +2878,9 @@ static int analop_esil(RArchSession *as, RAnalOp *op, ut64 addr, const ut8 *buf,
 			break;
 		}
 		if (insn->detail->arm.update_flags) {
-			if (OPCOUNT () == 2) {
+			if (OPCOUNT () == 2 && ISSHIFTED (1)) {
+				r_strbuf_appendf (&op->esil, "%s,1,%u,-,0x1,<<,&,!,!,cf,:=,", REG (1), LSHIFT2 (1));
+			} else if (OPCOUNT () == 2) {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,LSL,&,!,!,cf,:=,},", ARG (1), ARG (0), ARG (1));
 			} else {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,LSL,&,!,!,cf,:=,},", ARG (2), ARG (1), ARG (2));
@@ -2974,7 +2980,9 @@ PUSH { r4, r5, r6, r7, lr }
 		}
 		// suffix 'S' forces conditional flag to be updated
 		if (insn->detail->arm.update_flags) {
-			if (OPCOUNT () == 2) {
+			if (OPCOUNT () == 2 && ISSHIFTED (1)) {
+				r_strbuf_appendf (&op->esil, "%s,1,%u,-,0x1,<<,&,!,!,cf,:=,", REG (1), LSHIFT2 (1));
+			} else if (OPCOUNT () == 2) {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<,&,!,!,cf,:=,},", ARG (1), ARG (0), ARG (1));
 			} else if (OPCOUNT () == 3) {
 				r_strbuf_appendf (&op->esil, "%s,!,!,?{,%s,1,%s,-,0x1,<<,&,!,!,cf,:=,},", ARG (2), ARG (1), ARG (2));

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3575,3 +3575,59 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=immediate shifts with the s suffix take the carry from the source register
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+aei
+aeim
+aer r1=0x20000004
+wx a101b0e1 @ 0
+aer PC=0
+aes
+aer r0
+aer cf
+wx c101b0e1 @ 0
+aer PC=0
+aes
+aer r0
+aer cf
+wx 8101b0e1 @ 0
+aer PC=0
+aes
+aer r0
+aer cf
+wx e101b0e1 @ 0
+aer PC=0
+aes
+aer r0
+aer cf
+aer r1=0x80000008
+wx c101b0e1 @ 0
+aer PC=0
+aes
+aer r0
+aer cf
+wx a101b0e1 @ 0
+aer cf=1
+aer PC=0
+aes
+aer r0
+aer cf
+EOF
+EXPECT=<<EOF
+0x04000000
+0x00000001
+0x04000000
+0x00000001
+0x00000020
+0x00000001
+0x84000000
+0x00000001
+0xf0000001
+0x00000000
+0x10000001
+0x00000000
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

In ARM mode an S-suffixed immediate shift computes its carry from the destination register with the shifted expression as the count, so cf is wrong and, because that garbage count runs `<<` off the end of its range, the value write is lost too.

```
$ r2 -N -a arm -b 32 -qc 'wx a101b0e1; ao~esil; aei; aeim; aer r1=0x20000004; aes; aer r0; aer cf' malloc://0x100
esilcost: 0
esil: 3,r1,>>,!,!,?{,r0,1,3,r1,>>,-,0x1,<<,&,!,!,cf,:=,},3,r1,>>,0xffffffff,&,r0,=,$z,zf,:=,31,$s,nf,:=
0x00000000
0x00000000
```

That is `lsrs r0, r1, #3`: r0 should be 0x04000000 and cf the shifted-out bit, 1. `asrs` and `rors` fail the same way; `lsls` keeps its value but not the carry.

- capstone hands these forms to the shift cases as two operands with a shifted second one, so `ARG (1)` is the whole `3,r1,>>` expression. The two-operand carry arm now tests for that shape and reads the bit straight from the source register: bit `imm-1` for LSR, ASR and ROR, bit `32-imm` for LSL.
- The register-count forms are three operands, and the Thumb immediate forms are three plain operands, so neither reaches the new arm.

Tests: one `db/esil/arm_32` case covers the four mnemonics with the carry set and clear and a negative `asrs` source. It fails on master on every row.