### PR TITLE
Do not recover frame-pointer variables in a function that has no frame ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1851,7 +1851,12 @@ R_API void r_anal_extract_rarg(RAnal *anal, RAnalOp *op, RAnalFunction *fcn, int
 R_API void r_anal_extract_vars(RAnal *anal, RAnalFunction *fcn, RAnalOp *op) {
 	R_RETURN_IF_FAIL (anal && fcn && op);
 
-	const char *bpreg = r_reg_alias_getname (anal->reg, R_REG_ALIAS_BP);
+	// A function that never sets up a frame uses the base pointer as an
+	// ordinary register, and an access through it is a field of whatever
+	// it holds, not a stack variable. `r_core_anal_fcn` deletes the
+	// variables this would create once the frame check has run, but every
+	// later extraction (`afva`, type propagation) recreated them.
+	const char *bpreg = fcn->bp_frame? r_reg_alias_getname (anal->reg, R_REG_ALIAS_BP): NULL;
 	if (bpreg) {
 		extract_arg (anal, fcn, op, bpreg, "+", R_ANAL_VAR_KIND_BPV);
 		extract_arg (anal, fcn, op, bpreg, "-", R_ANAL_VAR_KIND_BPV);

--- a/test/db/anal/x86_32
+++ b/test/db/anal/x86_32
@@ -96,7 +96,7 @@ e asm.var=false
 pdb
 EOF
 EXPECT=<<EOF
-/ 337: entry0 (int32_t arg_ch, int32_t arg_1dh, int8_t arg_31h, int32_t arg_0h, int32_t arg_4h, int32_t arg_18h, int32_t arg_1ch, int32_t arg_28h, int32_t arg_2ch, int32_t arg_30h, int32_t arg_44h, int32_t arg_50h, int32_t arg_78h, int32_t arg_7ch, int32_t arg_80h, int32_t arg_84h, int32_t arg_c8h);
+/ 337: entry0 (int32_t arg_0h, int32_t arg_4h, int32_t arg_18h, int32_t arg_1ch, int32_t arg_28h, int32_t arg_2ch, int32_t arg_30h, int32_t arg_44h, int32_t arg_50h, int32_t arg_78h, int32_t arg_7ch, int32_t arg_80h, int32_t arg_84h, int32_t arg_c8h);
 |           0x006453a1      e8d8170000     call fcn.00646b7e
 |           0x006453a6      8d642444       lea esp, [arg_44h]
 |       ,=< 0x006453aa      0f85a6300000   jne 0x648456


### PR DESCRIPTION
A function that never sets up a frame uses the base pointer as an ordinary register, and an access through it is a field of whatever the register holds, not a stack variable. `r_core_anal_fcn` already knows this: after `r_anal_function_check_bp_use` it deletes every `R_ANAL_VAR_KIND_BPV` variable of a function without a frame. Every later extraction did not, so `afva` and the type-propagation passes `aaa` runs recreated them, and a function compiled at -O2 that keeps a struct pointer in `rbp` came out with a dozen arguments at `rbp+0x50`, `rbp+0x58` and so on (zlib's `longest_match` grows eight).

This gates the extraction itself (`r_anal_extract_vars`) on `fcn->bp_frame`, so no caller has to remember to clean up. The flag defaults to true and is only ever cleared by the x86 frame check, so other architectures are unaffected.

The `db/anal/x86_32` expectation for `entry0` carried three of these phantom arguments (`arg_ch`, `arg_1dh`, `arg_31h`) and now lists only the stack-pointer-relative ones.

- [x] Test expectation updated (`db/anal/x86_32`)