### PR TITLE
lstat returns int ##types

### DIFF
--- a/libr/anal/d/types.sdb.txt
+++ b/libr/anal/d/types.sdb.txt
@@ -2605,7 +2605,7 @@ lstat=func
 func.lstat.args=2
 func.lstat.arg.0=const char *,path
 func.lstat.arg.1=void *,buf
-func.lstat.ret=void
+func.lstat.ret=int
 
 scanf=func
 func.scanf.args=2


### PR DESCRIPTION
The type database declared `lstat` as returning `void`, so a caller that tested its result read a clobbered register. It returns `int`, like `stat`, `fstat` and the `lstat64` entry beside it.