### PR TITLE
Let a function keep its prototype when a struct tag shares its name ##types

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2563,19 +2563,15 @@ static const char *function_signature_lookup_name(RAnal *anal, RAnalFunction *fc
 
 static char *function_signature_try_type_name(Sdb *types, const char *candidate) {
 	R_RETURN_VAL_IF_FAIL (types && candidate && *candidate, NULL);
+	// the prototype namespace decides: a struct tag may have overwritten the shared kind key
 	char *name = r_type_func_key (types, candidate);
 	if (name) {
-		const char *kind = sdb_const_get (types, name, 0);
-		if (kind && !strcmp (kind, "func")) {
+		if (r_type_func_prototype_exist (types, name)) {
 			return name;
 		}
 		free (name);
 	}
-	const char *kind = sdb_const_get (types, candidate, 0);
-	if (kind && !strcmp (kind, "func")) {
-		return strdup (candidate);
-	}
-	return NULL;
+	return r_type_func_prototype_exist (types, candidate)? strdup (candidate): NULL;
 }
 
 static char *function_signature_address_type_name(Sdb *types, ut64 addr) {

--- a/libr/include/r_util/r_type.h
+++ b/libr/include/r_util/r_type.h
@@ -44,6 +44,8 @@ R_API R_OWNED char *r_type_resolve_typedef(Sdb * R_NONNULL TDB, const char * R_N
 
 // Function prototypes api
 R_API int r_type_func_exist(Sdb *TDB, const char *func_name);
+// whether a prototype is recorded under func.NAME.*, whatever the kind key says
+R_API bool r_type_func_prototype_exist(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_cc(Sdb *TDB, const char *func_name);
 R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name);
 R_API int r_type_func_args_count(Sdb *TDB, const char * R_NONNULL func_name);

--- a/libr/util/utype.c
+++ b/libr/util/utype.c
@@ -957,6 +957,12 @@ R_API int r_type_func_exist(Sdb *TDB, const char *func_name) {
 	return fcn && !strcmp (fcn, "func");
 }
 
+R_API bool r_type_func_prototype_exist(Sdb *TDB, const char *func_name) {
+	R_RETURN_VAL_IF_FAIL (TDB && func_name, false);
+	// struct stat overwrites stat=func, but the prototype under func.stat.* is still there
+	return sdb_const_getf (TDB, NULL, "func.%s.ret", trim_lodashes (TDB, func_name)) != NULL;
+}
+
 R_API const char *r_type_func_ret(Sdb *TDB, const char *func_name) {
 	return sdb_const_getf (TDB, NULL, "func.%s.ret", trim_lodashes (TDB, func_name));
 }
@@ -1131,20 +1137,18 @@ R_API R_OWNED char *r_type_func_guess(Sdb *TDB, const char *R_NONNULL func_name)
 	return result;
 }
 
-// walks name, then the last dotted component, then the fuzzy guesser. When
-// `key` is set the db key the match went through is returned instead of the
-// name that was matched, because r_type_func_exist trims leading lodashes
+// walks name, then the last dotted component, then the fuzzy guesser; `key` returns the db key matched
 static char *type_func_lookup(Sdb *types, const char *fname, bool key) {
 	const char *str = fname;
 	const char *name = fname;
-	if (r_type_func_exist (types, fname)) {
+	if (r_type_func_prototype_exist (types, fname)) {
 		return strdup (key? trim_lodashes (types, fname): fname);
 	}
 	while ( (str = strchr (str, '.'))) {
 		str++;
 		name = str;
 	}
-	if (r_type_func_exist (types, name)) {
+	if (r_type_func_prototype_exist (types, name)) {
 		return strdup (key? trim_lodashes (types, name): name);
 	}
 	return r_type_func_guess (types, fname);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -4079,3 +4079,22 @@ func.fprintf_chk.arg.3=,...
 func.longjmp_chk.noreturn=true
 EOF
 RUN
+
+NAME=a function keeps its prototype when a struct tag shares its name
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+tk func.stat.ret=int
+tk func.stat.args=2
+tk func.stat.arg.0=const char *,path
+tk func.stat.arg.1=void *,buf
+tk stat=struct
+tk struct.stat=st_dev,st_ino
+af+ 0 sym.imp.stat
+afb+ 0 0 10
+afsq @ 0
+EOF
+EXPECT=<<EOF
+int sym.imp.stat (const char *path, void *buf);
+EOF
+RUN


### PR DESCRIPTION
C keeps struct tags and ordinary identifiers in separate namespaces; the type database keeps one kind key per name. A program that declares `struct stat` and calls `stat()` -- every program that calls `stat` -- has `stat=struct` written over `stat=func` once its DWARF is read, and the prototype still recorded under `func.stat.*` went unfound: `afcf sym.imp.stat` came out as `stat ()`.

`r_type_func_exist` now answers from the prototype's own namespace (`func.NAME.ret`) and consults the kind key only where that namespace is silent; `function_signature_try_type_name` uses it instead of re-checking the kind key.

The unit test builds exactly that database -- `func.stat.*` beside `stat=struct` -- and checks that the prototype exists, that `sym.imp.stat` resolves to it, that a name with neither still does not, and that an import function named `sym.imp.stat` renders its two-parameter signature.

- [x] Unit test added (`test/unit/test_anal_types.c`)