### PR TITLE
Print pdc gotos to another function by its name ##pseudo

### DIFF
--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -26,6 +26,7 @@ typedef struct {
 	Sdb *db;
 	RBitset *marked;
 	RBitset *switch_addrs;
+	RBitset *labelable; // addrs this rendering can label, NULL when it cannot
 	RAnalFunction *fcn;
 	ut64 bb_jump; // edges of the block being rendered, owned by its region in structured mode
 	ut64 bb_fail;
@@ -868,9 +869,21 @@ static bool pdc_is_ret_only_bb(RCore *core, ut64 addr) {
 	return t == R_ANAL_OP_TYPE_RET || t == R_ANAL_OP_TYPE_CRET;
 }
 
+// a target this rendering prints no label for reads as its function
+static char *goto_str(PDCState *state, ut64 addr) {
+	if (valid_addr (addr) && state->labelable && !r_bitset_test (state->labelable, addr)) {
+		RAnalFunction *f = r_anal_get_function_at (state->core->anal, addr);
+		// a loc is a jump table case body, named by its case label
+		if (f && f->type != R_ANAL_FCN_TYPE_LOC) {
+			return r_str_newf ("goto %s;", f->name);
+		}
+	}
+	return r_str_newf ("goto loc_0x%08" PFMT64x ";", addr);
+}
+
 static char *goto_or_return(PDCState *state, ut64 dst_addr) {
 	if (!pdc_is_ret_only_bb (state->core, dst_addr)) {
-		return r_str_newf ("goto loc_0x%08" PFMT64x ";", dst_addr);
+		return goto_str (state, dst_addr);
 	}
 	return state->r0? r_str_newf ("return %s;", state->r0): strdup ("return;");
 }
@@ -1953,6 +1966,8 @@ static bool case_table_has(const PDCSwCase *arr, int n, ut64 target) {
 static void collect_goto_targets(PDCState *state, PdcRegion *r, RBitset *gotos) {
 	if (r->type == PDC_R_GOTO) {
 		r_bitset_set (gotos, r->addr);
+	} else if (r->type != PDC_R_BREAK && r->type != PDC_R_CONTINUE) {
+		r_bitset_set (state->labelable, r->addr);
 	}
 	if (r->type == PDC_R_SWITCH) {
 		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
@@ -2241,14 +2256,14 @@ static bool region_is_transfer(PdcRegion *r) {
 	return r->type == PDC_R_BREAK || r->type == PDC_R_CONTINUE || r->type == PDC_R_GOTO;
 }
 
-static char *transfer_str(PdcRegion *r) {
+static char *transfer_str(PDCState *state, PdcRegion *r) {
 	switch (r->type) {
 	case PDC_R_BREAK:
 		return strdup ("break;");
 	case PDC_R_CONTINUE:
 		return strdup ("continue;");
 	case PDC_R_GOTO:
-		return r_str_newf ("goto loc_0x%08" PFMT64x ";", r->addr);
+		return goto_str (state, r->addr);
 	default:
 		return NULL;
 	}
@@ -2265,7 +2280,7 @@ static void render_seq(PDCState *state, PdcRegion *r, int indent, RBitset *gotos
 			continue;
 		}
 		if (c->type == PDC_R_BB && i + 1 < n) {
-			state->transfer = transfer_str (*RVecPdcRegionPtr_at (&r->children, i + 1));
+			state->transfer = transfer_str (state, *RVecPdcRegionPtr_at (&r->children, i + 1));
 		}
 		const bool handoff = state->transfer != NULL;
 		render_region (state, c, indent, gotos, from);
@@ -2286,7 +2301,7 @@ static void render_region(PDCState *state, PdcRegion *r, int indent, RBitset *go
 		return;
 	}
 	if (region_is_transfer (r)) {
-		char *s = transfer_str (r);
+		char *s = transfer_str (state, r);
 		print_line (state, (from == UT64_MAX)? state->last_addr: from, indent, "%s", s);
 		free (s);
 		return;
@@ -2349,7 +2364,14 @@ static bool pdc_structured_body(PDCState *state, int indent) {
 		const bool was_structured = state->structured;
 		state->structured = true;
 		RBitset *gotos = r_bitset_new ();
+		// both label emitters: regions here, blocks for the orphan pass
+		state->labelable = r_bitset_new ();
 		collect_goto_targets (state, root, gotos);
+		RListIter *bit;
+		RAnalBlock *b;
+		r_list_foreach (state->fcn->bbs, bit, b) {
+			r_bitset_set (state->labelable, b->addr);
+		}
 		render_region (state, root, indent, gotos, UT64_MAX);
 		r_bitset_free (gotos);
 		state->structured = was_structured;
@@ -2421,6 +2443,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 			R_LOG_ERROR ("Cannot find function in 0x%08" PFMT64x, core->addr);
 		}
 		r_config_hold_free (hc);
+		pj_free (state.pj);
 		sdb_free (state.db);
 		sdb_free (state.goto_cache);
 		r_bitset_free (state.marked);
@@ -2759,7 +2782,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 				}
 				bb = r_anal_bb_from_offset (core->anal, addr);
 				nindent = sdb_num_getf (state.db, NULL, "loc.%" PFMT64x, addr);
-				if (indent > nindent) {
+				if (bb && indent > nindent) {
 					emit_close_braces (&state, bb->addr, indent, nindent);
 				}
 				print_newline (&state, addr, nindent, true);
@@ -2930,6 +2953,7 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	free (state.transfer);
 	sdb_free (state.db);
 	sdb_free (state.goto_cache);
+	r_bitset_free (state.labelable);
 	r_bitset_free (state.marked);
 	if (state.switch_addrs) {
 		r_bitset_free (state.switch_addrs);

--- a/libr/core/p/pseudo/pseudo.c
+++ b/libr/core/p/pseudo/pseudo.c
@@ -26,7 +26,7 @@ typedef struct {
 	Sdb *db;
 	RBitset *marked;
 	RBitset *switch_addrs;
-	RBitset *labelable; // addrs this rendering can label, NULL when it cannot
+	bool named_gotos; // structured walk done: a goto out of the function reads as its name
 	RAnalFunction *fcn;
 	ut64 bb_jump; // edges of the block being rendered, owned by its region in structured mode
 	ut64 bb_fail;
@@ -869,10 +869,14 @@ static bool pdc_is_ret_only_bb(RCore *core, ut64 addr) {
 	return t == R_ANAL_OP_TYPE_RET || t == R_ANAL_OP_TYPE_CRET;
 }
 
-// a target this rendering prints no label for reads as its function
+// a target this rendering prints no label for reads as its function; both label
+// emitters (regions and the orphan pass) label block starts the function contains
 static char *goto_str(PDCState *state, ut64 addr) {
-	if (valid_addr (addr) && state->labelable && !r_bitset_test (state->labelable, addr)) {
-		RAnalFunction *f = r_anal_get_function_at (state->core->anal, addr);
+	RAnal *anal = state->core->anal;
+	const bool labeled = r_anal_get_block_at (anal, addr)
+		&& r_anal_function_contains (state->fcn, addr);
+	if (state->named_gotos && valid_addr (addr) && !labeled) {
+		RAnalFunction *f = r_anal_get_function_at (anal, addr);
 		// a loc is a jump table case body, named by its case label
 		if (f && f->type != R_ANAL_FCN_TYPE_LOC) {
 			return r_str_newf ("goto %s;", f->name);
@@ -1966,8 +1970,6 @@ static bool case_table_has(const PDCSwCase *arr, int n, ut64 target) {
 static void collect_goto_targets(PDCState *state, PdcRegion *r, RBitset *gotos) {
 	if (r->type == PDC_R_GOTO) {
 		r_bitset_set (gotos, r->addr);
-	} else if (r->type != PDC_R_BREAK && r->type != PDC_R_CONTINUE) {
-		r_bitset_set (state->labelable, r->addr);
 	}
 	if (r->type == PDC_R_SWITCH) {
 		RAnalBlock *bb = r_anal_get_block_at (state->core->anal, r->addr);
@@ -2364,14 +2366,8 @@ static bool pdc_structured_body(PDCState *state, int indent) {
 		const bool was_structured = state->structured;
 		state->structured = true;
 		RBitset *gotos = r_bitset_new ();
-		// both label emitters: regions here, blocks for the orphan pass
-		state->labelable = r_bitset_new ();
+		state->named_gotos = true;
 		collect_goto_targets (state, root, gotos);
-		RListIter *bit;
-		RAnalBlock *b;
-		r_list_foreach (state->fcn->bbs, bit, b) {
-			r_bitset_set (state->labelable, b->addr);
-		}
 		render_region (state, root, indent, gotos, UT64_MAX);
 		r_bitset_free (gotos);
 		state->structured = was_structured;
@@ -2953,7 +2949,6 @@ R_IPI bool pdc_decompile(RCore *core, const char *input) {
 	free (state.transfer);
 	sdb_free (state.db);
 	sdb_free (state.goto_cache);
-	r_bitset_free (state.labelable);
 	r_bitset_free (state.marked);
 	if (state.switch_addrs) {
 		r_bitset_free (state.switch_addrs);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1237,7 +1237,7 @@ EXPECT=<<EOF
 // callconv: rax amd64 (rdi, rsi, rdx, rcx, r8, r9, stack);
 void fcn.caller (void) {
     eax = 1
-    goto loc_0x00000010;
+    goto fcn.00000010;
 }
 
 EOF
@@ -1781,4 +1781,241 @@ EXPECT=<<EOF2
         rdi = rbp     // rsp
         rdi = rbp     // rsp
 EOF2
+RUN
+
+NAME=pdc structured names a goto leaving the function
+FILE=malloc://128
+ARGS=-a arm -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wa cbz x0, 0x20
+wa mov x0, 1 @ 4
+wa ret @ 8
+wa mov x0, 2 @ 0x20
+wa ret @ 0x24
+af+ 0 wrapper
+afb+ 0 0 4 0x20 0x4
+afb+ 0 0x4 8
+af+ 0x20 helper
+afb+ 0x20 0x20 8
+pdc
+EOF
+EXPECT=<<EOF
+// callconv: x0 arm64 (x0, x1, x2, x3, x4, x5, x6, x7, stack);
+void wrapper (void) {
+    if (!x0) {
+        goto helper;
+    }
+    x0 = 1
+    return x0;
+}
+
+EOF
+RUN
+
+NAME=pdc structured names a foreign switch target the same in every arm
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 4883f8027700ff24c50001000000 @ 0
+wx 770a @ 4
+wx c3 @ 0x10
+wx b805000000c3 @ 0x20
+wx b807000000eb0e @ 0x40
+wx c3 @ 0x50
+wv8 0x40 @ 0x100
+wv8 0x20 @ 0x108
+wv8 0x40 @ 0x110
+af @ 0
+afb- 0x40
+af+ 0x40 helper
+afb+ 0x40 0x40 7 0x50
+afb+ 0x40 0x50 1
+pdc @ 0~goto,loc_0x00000010:
+EOF
+EXPECT=<<EOF
+                goto helper;
+                goto helper;
+                goto loc_0x00000010;
+        loc_0x00000010:
+EOF
+RUN
+
+NAME=pdc structured keeps loc for a jump table case body
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 4883f8027700ff24c50001000000 @ 0
+wx 770a @ 4
+wx c3 @ 0x10
+wx b805000000c3 @ 0x20
+wx b807000000eb0e @ 0x40
+wx c3 @ 0x50
+wv8 0x40 @ 0x100
+wv8 0x20 @ 0x108
+wv8 0x40 @ 0x110
+af @ 0
+afb- 0x40
+af+ 0x40 case.0x0.2 l
+afb+ 0x40 0x40 7 0x50
+afb+ 0x40 0x50 1
+pdc @ 0~goto,loc_0x00000010:
+wx 83ff0190c3 @ 0x180
+wx b82a000000c3 @ 0x190
+af+ 0x180 wfun
+afb+ 0x180 0x180 3 0x190 0x183
+afb+ 0x180 0x183 2
+af+ 0x190 hfun
+afb+ 0x190 0x190 6
+pdc @ 0x180~goto
+EOF
+EXPECT=<<EOF
+                goto loc_0x00000040;
+                goto loc_0x00000040;
+                goto loc_0x00000010;
+        loc_0x00000010:
+        goto hfun;
+EOF
+RUN
+
+NAME=pdc structured keeps loc where the same rendering prints the label
+FILE=malloc://0x200
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 83ff01 @ 0
+wx 89f8 @ 8
+wx b82a00000090c3 @ 0x40
+af+ 0x40 gfunc
+afb+ 0x40 0x40 8 0x48
+afb+ 0x40 0x48 8
+af+ 0x0 ffunc
+afb+ 0x0 0x0 8 0x40 8
+afb+ 0x0 0x8 8 0x40
+afb+ 0x0 0x30 0x20
+pdc @ 0~goto,loc_0x00000040:
+wx 83ff0190c3 @ 0x180
+wx b82a000000c3 @ 0x190
+af+ 0x180 wfun
+afb+ 0x180 0x180 3 0x190 0x183
+afb+ 0x180 0x183 2
+af+ 0x190 hfun
+afb+ 0x190 0x190 6
+pdc @ 0x180~goto
+EOF
+EXPECT=<<EOF
+        goto loc_0x00000040;
+        loc_0x00000040:
+        goto hfun;
+EOF
+RUN
+
+NAME=pdc structured keeps loc for an orphan labelled block
+FILE=malloc://0x2000
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+af+ 0 F
+afb+ 0 0 0x10 0x10
+afb+ 0 0x10 0x10
+afbe 0 $$ @@s:0x1000 0x1490 0x10
+af+ 0x10 helper
+pdc @ 0~loc_0x00000010
+wx 83ff0190c3 @ 0x1500
+wx b82a000000c3 @ 0x1510
+af+ 0x1500 wfun
+afb+ 0x1500 0x1500 3 0x1510 0x1503
+afb+ 0x1500 0x1503 2
+af+ 0x1510 hfun
+afb+ 0x1510 0x1510 6
+pdc @ 0x1500~goto
+EOF
+EXPECT=<<EOF
+    goto loc_0x00000010;
+    loc_0x00000010: // orphan
+        goto hfun;
+EOF
+RUN
+
+NAME=pdc structured names a hoisted switch arm like the rest of the rendering
+FILE=malloc://0x2000
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+af+ 0 F
+afb+ 0 0 0x10 0x10
+afb+ 0 0x10 0x10
+afbe 0 $$ @@s:0x1000 0x1490 0x10
+afbe 0x10 0x1000
+af+ 0x1000 helper2
+pdc @ 0~helper2
+EOF
+EXPECT=<<EOF
+            goto helper2;
+                goto helper2;
+EOF
+RUN
+
+NAME=pdc structured never names a goto to address zero
+FILE=bins/elf/ppc64v1-libz.so
+ARGS=-e pdc.structured=1
+CMDS=<<EOF
+aaa
+af+ 0 zerofn
+af+ 0x194a0 named_target
+s sym.plt.crc32_combine_gen64
+pdc~goto
+EOF
+EXPECT=<<EOF
+        goto named_target;
+        goto loc_0x00000000;
+EOF
+RUN
+
+NAME=pdc structured keeps a loop exit out of the labels it prints
+FILE=malloc://0x100
+ARGS=-a x86 -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wx 85c07510 @ 0
+wx 85c074ec @ 0x10
+wx eb0e @ 0x30
+wx b82a000000c3 @ 0x40
+af+ 0 F
+afb+ 0 0 4 0x10 0x30
+afb+ 0 0x10 4 0 0x40
+afb+ 0 0x30 2 0x40
+af+ 0x40 helper
+afb+ 0x40 0x40 6
+pdc @ 0~goto,break,continue
+EOF
+EXPECT=<<EOF
+        if (v) goto loc_0x14 // unlikely
+            break;
+            goto helper;
+            continue;
+    goto helper;
+EOF
+RUN
+
+NAME=pdc structured keeps loc where no function starts at the target
+FILE=malloc://128
+ARGS=-a arm -b 64 -e pdc.structured=1
+CMDS=<<EOF
+wa cbz x0, 0x24
+wa cbz x1, 0x40 @ 4
+wa cbz x2, 0x20 @ 8
+wa mov x0, 1 @ 0xc
+wa ret @ 0x10
+wa mov x0, 2 @ 0x20
+wa ret @ 0x24
+af+ 0 wrapper
+afb+ 0 0 4 0x24 0x4
+afb+ 0 0x4 4 0x40 0x8
+afb+ 0 0x8 4 0x20 0xc
+afb+ 0 0xc 8
+af+ 0x20 helper
+afb+ 0x20 0x20 8
+pdc~goto loc_0x,goto helper
+EOF
+EXPECT=<<EOF
+        goto loc_0x00000024;
+        goto loc_0x00000040;
+        goto helper;
+EOF
 RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Under `pdc.structured=1` a goto leaving the function prints a `loc_` label that the rendering never emits, discarding the name the target carries. The linear renderer resolves it.

```
$ r2 -N -a arm -b 64 -e scr.color=0 -e pdc.structured=1 -qc \
    'wa cbz x0, 0x20; wa mov x0, 1 @ 4; wa ret @ 8; wa mov x0, 2 @ 0x20; wa ret @ 0x24;
     af+ 0 wrapper; afb+ 0 0 4 0x20 0x4; afb+ 0 0x4 8;
     af+ 0x20 helper; afb+ 0x20 0x20 8; pdc' malloc://128
void wrapper (void) {
    if (!x0) {
        goto loc_0x00000020;
    }
```

`0x20` is `helper`, and no `loc_0x00000020:` appears anywhere in the output. With `pdc.structured=0` the same jump prints `goto helper`.

- One `goto_str` helper builds the goto text for both producers that can emit it in a structured rendering, so one address is never spelled two ways in one output. A switch reaching a foreign target from several arms was the case that forced this.
- A target is named only when the rendering prints no label for it. That set is the union of the two label emitters' conditions: the addresses of the plan's non-transfer regions, and the block starts of the function being rendered, which is what the orphan pass labels. Both are computed before rendering, so the two can never disagree.
- The name comes from the function at the address, never from a flag: on `ppc64v1-libz.so` 49 foreign gotos target address 0, where 77 flags live and the pick would be `obj.ZLIB_1.2.2`, data named as code.
- A `loc`-typed function is skipped. Those are jump-table case bodies, already named by their case line, plus auto-names that restate the address.
- Scoped to the structured renderer; the linear one is unchanged.

Tests: nine cases in `db/cmd/cmd_pdc`, six of them guards that pin what must keep its `loc_` spelling. Each guard carries a renamed goto in the same golden, so it fails both when the fix is reverted and when its own guard is removed. One existing golden moves: `goto loc_0x00000010;` becomes `goto fcn.00000010;`, the auto-named function at that address, which is what `pd` prints there.