### PR TITLE
Mask the arm32 shifted-operand count to its low byte ##arch

### DIFF
--- a/libr/arch/p/arm/plugin_cs.c
+++ b/libr/arch/p/arm/plugin_cs.c
@@ -1103,7 +1103,8 @@ static const char *arg(RArchSession *as, csh *handle, cs_insn *insn, char *buf, 
 	case ARM_OP_REG:
 		if (ISSHIFTED (n)) {
 			if (SHIFTTYPEREG (n)) {
-				snprintf (buf, buf_sz, "%s,%s,%s",
+				// the shift count is Rs[7:0]
+				snprintf (buf, buf_sz, "0xff,%s,&,%s,%s",
 						cs_reg_name(*handle, LSHIFT2(n)),
 						REG (n), DECODE_SHIFT (n));
 			} else {

--- a/test/db/esil/arm_32
+++ b/test/db/esil/arm_32
@@ -3575,3 +3575,54 @@ EXPECT=<<EOF
 0x00000000
 EOF
 RUN
+
+NAME=register shifted operand uses only the low byte of the shift register
+FILE=malloc://0x200
+ARGS=-a arm -b 32
+CMDS=<<EOF
+aei
+aeim
+aer r1=1
+aer r2=0x80000005
+aer r3=0x100
+wx 520381e0 @ 0
+aer PC=0
+aes
+aer r0
+wx 120381e0 @ 0
+aer PC=0
+aes
+aer r0
+wx 320381e0 @ 0
+aer PC=0
+aes
+aer r0
+aer r3=0x105
+wx 520381e0 @ 0
+aer PC=0
+aes
+aer r0
+aer r3=0x20
+wx 520381e0 @ 0
+aer PC=0
+aes
+aer r0
+wx 120381e0 @ 0
+aer PC=0
+aes
+aer r0
+wx 320381e0 @ 0
+aer PC=0
+aes
+aer r0
+EOF
+EXPECT=<<EOF
+0x80000006
+0x80000006
+0x80000006
+0xfc000001
+0x00000000
+0x00000001
+0x00000001
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

ARM uses only the low byte of a register that supplies a shift count, but the shifted-operand form of a data instruction passes the whole register, so a count with anything set above bit 7 shifts by the wrong amount.

```
$ r2 -N -a arm -b 32 -e scr.color=0 -qc \
    'wx 520381e0; aei; aeim; aer r1=1; aer r2=0x80000005; aer r3=0x105; aes; aer r0' malloc://0x200
0xfc000001
```

That is `add r0, r1, r2, asr r3` with r3 = 0x105. ARM shifts by 5 and gives 0x04000001; r2 shifts by 261.

- The standalone shift emitter already masks with `0xff`; this applies the same mask in `arg()`, where the shifted-operand form builds its ESIL.
- The mask adds two tokens per arm32 register-shifted operand, so `esil_cost_diff` reports growth there. That growth is the fix.

Tests: one `db/esil/arm_32` case covers `asr`, `lsl` and `lsr` by a register holding 0x100, 0x105 and 0x20, checking both the masked count and that a count of 32 still sign-fills. It fails on master.