### PR TITLE
Invalidate cached function ref counts with an xref generation counter ##analysis

### DIFF
--- a/libr/anal/xrefs.c
+++ b/libr/anal/xrefs.c
@@ -27,6 +27,7 @@ CWISS_DECLARE_FLAT_HASHMAP_DEFAULT(AdjacencyList, ut64, Edges*);
 typedef struct r_ref_manager_t {
 	R_ALIGNED(16) AdjacencyList refs;   // forward refs
 	R_ALIGNED(16) AdjacencyList xrefs;  // backward refs
+	ut64 gen; // bumped on every change, cached per-function counts compare against it
 } RefManager;
 
 static inline int compare_ref(const RAnalRef *a, const RAnalRef *b) {
@@ -49,6 +50,7 @@ static RefManager *ref_manager_new(void) {
 	RefManager *rm = R_NEW0 (RefManager);
 	rm->refs = AdjacencyList_new (INITIAL_CAPACITY);
 	rm->xrefs = AdjacencyList_new (INITIAL_CAPACITY);
+	rm->gen = 1;
 	return rm;
 }
 
@@ -97,6 +99,7 @@ static void _add_ref(AdjacencyList *adj_list, ut64 from, ut64 to, RAnalRefType t
 static void ref_manager_add_entry(RefManager *rm, ut64 from, ut64 to, RAnalRefType type) {
 	_add_ref (&rm->refs, from, to, type);
 	_add_ref (&rm->xrefs, to, from, type);
+	rm->gen++;
 }
 
 static void _delete_ref(AdjacencyList *adj_list, ut64 from, ut64 to) {
@@ -116,6 +119,7 @@ static void _delete_ref(AdjacencyList *adj_list, ut64 from, ut64 to) {
 static void ref_manager_remove_entry(RefManager *rm, ut64 from, ut64 to) {
 	_delete_ref (&rm->refs, from, to);
 	_delete_ref (&rm->xrefs, to, from);
+	rm->gen++;
 }
 
 static ut64 ref_manager_count_xrefs(RefManager *rm) {
@@ -220,8 +224,13 @@ static inline RVecAnalRef *ref_manager_get_xrefs(RefManager *rm, ut64 to) {
 R_API bool r_anal_xrefs_init(RAnal *anal) {
 	R_RETURN_VAL_IF_FAIL (anal, false);
 
+	// keep the generation moving so counts cached before the reset stay stale
+	const ut64 gen = anal->rm? anal->rm->gen + 1: 1;
 	r_anal_xrefs_free (anal);
 	anal->rm = ref_manager_new ();
+	if (anal->rm) {
+		anal->rm->gen = gen;
+	}
 	return !!anal->rm;
 }
 
@@ -248,7 +257,7 @@ static inline RAnalRefType xref_resolve_type(const RAnalRefType _type) {
 }
 
 // set a reference from FROM to TO and a cross-reference(xref) from TO to FROM.
-// when fcn is known (the function containing FROM), pass it to skip hash lookups.
+// fcn is kept for API compatibility and unused: invalidation is by generation.
 R_API bool r_anal_xrefs_setf(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 to, const RAnalRefType _type) {
 	R_RETURN_VAL_IF_FAIL (anal && anal->rm, false);
 
@@ -268,21 +277,6 @@ R_API bool r_anal_xrefs_setf(RAnal *anal, RAnalFunction *fcn, ut64 from, ut64 to
 	ref_manager_add_entry (anal->rm, from, to, type);
 	R_DIRTY_SET (anal);
 
-	// Invalidate function ref counts
-	if (fcn) {
-		fcn->meta.numcallrefs = -1;
-		fcn->meta.numrefs = -1;
-	} else {
-		RAnalFunction *fcn_from = r_anal_get_function_at (anal, from);
-		if (fcn_from) {
-			fcn_from->meta.numcallrefs = -1;
-		}
-		RAnalFunction *fcn_to = r_anal_get_function_at (anal, to);
-		if (fcn_to) {
-			fcn_to->meta.numrefs = -1;
-		}
-	}
-
 	return true;
 }
 
@@ -294,16 +288,6 @@ R_API bool r_anal_xref_del(RAnal *anal, ut64 from, ut64 to) {
 	R_RETURN_VAL_IF_FAIL (anal, false);
 	ref_manager_remove_entry (anal->rm, from, to);
 	R_DIRTY_SET (anal);
-
-	// Invalidate function ref counts
-	RAnalFunction *fcn_from = r_anal_get_function_at (anal, from);
-	if (fcn_from) {
-		fcn_from->meta.numcallrefs = -1;
-	}
-	RAnalFunction *fcn_to = r_anal_get_function_at (anal, to);
-	if (fcn_to) {
-		fcn_to->meta.numrefs = -1;
-	}
 
 	return true;
 }
@@ -660,9 +644,19 @@ static ut64 fcn_count_refs(RAnalFunction *fcn, RefManager *rm, CountFn count_ref
 	return total;
 }
 
+// Any xref added or removed since the counts were cached makes them stale.
+static void fcn_sync_ref_counts(RAnalFunction *fcn, RefManager *rm) {
+	if (fcn->meta.refsgen != rm->gen) {
+		fcn->meta.numrefs = -1;
+		fcn->meta.numcallrefs = -1;
+		fcn->meta.refsgen = rm->gen;
+	}
+}
+
 // Count refs of a specific type from a function (use R_ANAL_REF_TYPE_ANY to count all)
 R_API ut64 r_anal_function_count_refs(RAnalFunction *fcn, RAnalRefType type) {
 	R_RETURN_VAL_IF_FAIL (fcn, 0);
+	fcn_sync_ref_counts (fcn, fcn->anal->rm);
 	if (type == R_ANAL_REF_TYPE_CALL && fcn->meta.numcallrefs != -1) {
 		return fcn->meta.numcallrefs;
 	}
@@ -676,6 +670,7 @@ R_API ut64 r_anal_function_count_refs(RAnalFunction *fcn, RAnalRefType type) {
 // Count xrefs to a function (optionally filtered by type)
 R_API ut64 r_anal_function_count_xrefs(RAnalFunction *fcn, RAnalRefType type) {
 	R_RETURN_VAL_IF_FAIL (fcn, 0);
+	fcn_sync_ref_counts (fcn, fcn->anal->rm);
 	if (type == R_ANAL_REF_TYPE_ANY && fcn->meta.numrefs != -1) {
 		return fcn->meta.numrefs;
 	}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -340,6 +340,7 @@ typedef struct r_anal_function_meta_t {
 
 	int numrefs;        // number of cross references
 	int numcallrefs;    // number of calls
+	ut64 refsgen;       // PRIVATE, xref generation numrefs/numcallrefs were computed at
 	int stack_pop;      // PRIVATE, inferred callee-popped argument bytes
 } RAnalFcnMeta;
 

--- a/test/db/anal/xrefs
+++ b/test/db/anal/xrefs
@@ -122,3 +122,71 @@ EXPECT=<<EOF
                sym.doEventInternal+38908 0x4a102c > CALL:--x > 0x523760 sym.readInfo_log
 EOF
 RUN
+
+NAME=cached ref counts see an xref added or removed inside a function
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx 554889e5e800000000c3
+af
+afll~^0x[10]
+axC 0x20 @ 0x1
+afll~^0x[10]
+ax- 0x20 @ 0x1
+afll~^0x[10]
+EOF
+EXPECT=<<EOF
+1
+2
+1
+EOF
+RUN
+
+NAME=cached xref counts see an xref to a function with no blocks
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+af+ 0x20 foo
+afll~^0x[13]
+axC 0x20 @ 0x1
+afll~^0x[13]
+EOF
+EXPECT=<<EOF
+0
+1
+EOF
+RUN
+
+NAME=cached xref counts see the call a later analysis discovers
+FILE=malloc://64
+ARGS=-a x86 -b 64
+CMDS=<<EOF
+wx c3 @ 0
+wx e8ebffffffc3 @ 0x10
+af @ 0
+afll~^0x0000000000000000[13]
+af @ 0x10
+afll~^0x0000000000000000[13]
+EOF
+EXPECT=<<EOF
+0
+1
+EOF
+RUN
+
+NAME=xrefs: cached counts stay stale across an xref manager reset
+FILE=malloc://64
+CMDS=<<EOF
+wx 554889e5e800000000c3
+af
+afll~^0x[10]
+ax-*
+axd 0x21 @ 0x1
+axd 0x22 @ 0x1
+afll~^0x[10]
+EOF
+EXPECT=<<EOF
+1
+0
+EOF
+RUN


### PR DESCRIPTION
`afll`'s `numcallrefs` and `numrefs` columns are cached on `RAnalFunction::meta` and were invalidated by looking each xref endpoint up with `r_anal_get_function_at`, which matches only a function whose entry is exactly that address. An xref's source is almost always an instruction inside a function rather than its first one, so the common case invalidated nothing and the columns kept reporting the count from before the change.

```
wx 554889e5e800000000c3
af
afll          # call-refs column reads 1
axC 0x20 @ 0x1
afll          # still 1, though the table now holds two CALL refs
axq           # 0x00000001 -> 0x00000020  CALL:--x
              # 0x00000004 -> 0x00000009  CALL:--x
```

Nothing is looked up on the write path now. The ref manager carries a `gen` bumped in `ref_manager_add_entry` and `ref_manager_remove_entry`, `RAnalFcnMeta` remembers the generation its counts were computed at, and `r_anal_function_count_refs` / `count_xrefs` recompute when the two disagree. That covers the cases a lookup could not: a block shared by several functions, a function with no blocks, and a callee whose count has to see a call a later `af` discovers.

`r_anal_xrefs_init` frees the manager and builds a new one, so the generation is carried across the reset; otherwise it restarts at 1 and lines up with a stale `refsgen` once the same number of xrefs is added again.

`r_anal_xrefs_setf` keeps its `fcn` argument for API compatibility; it is unused.

Four tests in `db/anal/xrefs` cover an xref added and removed inside a function, a function with no blocks, a callee whose count must see a later `af`, and the manager reset. `aa; ?t aar` on `/bin/bash` is 0.333s here, against 0.65s for the lookup-based version and 0.56s for master.
