### PR TITLE
Record per-function analysis assumptions ##analysis

### DIFF
--- a/libr/anal/function.c
+++ b/libr/anal/function.c
@@ -131,6 +131,7 @@ R_API void r_anal_function_free(RAnalFunction *fcn) {
 
 	free (fcn->name);
 	free (fcn->realname);
+	free (fcn->assumptions_json);
 	free (fcn->pin);
 	fcn->bbs = NULL;
 	free (fcn->fingerprint);
@@ -224,6 +225,52 @@ R_API RAnalFunction *r_anal_get_function_at(RAnal *anal, ut64 addr) {
 		return f;
 	}
 	return NULL;
+}
+
+R_API char *r_anal_function_get_assumptions_json(RAnal *anal, RAnalFunction *fcn) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn, NULL);
+	return strdup (R_STR_ISNOTEMPTY (fcn->assumptions_json)? fcn->assumptions_json: "[]");
+}
+
+R_API bool r_anal_function_set_assumptions_json(RAnal *anal, RAnalFunction *fcn, const char *json) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn && json, false);
+	char *trimmed = r_str_trim_dup (json);
+	if (!trimmed) {
+		return false;
+	}
+	if (R_STR_ISEMPTY (trimmed)) {
+		free (trimmed);
+		trimmed = strdup ("[]");
+		if (!trimmed) {
+			return false;
+		}
+	}
+	RJson *parsed = r_json_parsedup (trimmed);
+	if (!parsed || parsed->type != R_JSON_ARRAY) {
+		r_json_free (parsed);
+		free (trimmed);
+		return false;
+	}
+	const RJson *child;
+	for (child = parsed->children.first; child; child = child->next) {
+		if (child->type != R_JSON_OBJECT) {
+			r_json_free (parsed);
+			free (trimmed);
+			return false;
+		}
+	}
+	r_json_free (parsed);
+	free (fcn->assumptions_json);
+	fcn->assumptions_json = trimmed;
+	R_DIRTY_SET (anal);
+	return true;
+}
+
+R_API bool r_anal_function_clear_assumptions(RAnal *anal, RAnalFunction *fcn) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn, false);
+	R_FREE (fcn->assumptions_json);
+	R_DIRTY_SET (anal);
+	return true;
 }
 
 R_API bool r_anal_function_relocate(RAnalFunction *fcn, ut64 addr) {

--- a/libr/core/canal.c
+++ b/libr/core/canal.c
@@ -3241,6 +3241,9 @@ static int fcn_print_detail(RCore *core, RAnalFunction *fcn) {
 	if (fcn->bits != 0) {
 		r_cons_printf (cons, "'@0x%08"PFMT64x"'afB %d\n", fcn->addr, fcn->bits);
 	}
+	if (R_STR_ISNOTEMPTY (fcn->assumptions_json) && strcmp (fcn->assumptions_json, "[]")) {
+		r_cons_printf (cons, "'@0x%08"PFMT64x"'afAj %s\n", fcn->addr, fcn->assumptions_json);
+	}
 	if (fcn->callconv || defaultCC) {
 		char *cc = r_str_sanitize_r2 (fcn->callconv? fcn->callconv: defaultCC);
 		if (cc) {

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -577,6 +577,8 @@ static RCoreHelpMessage help_msg_af = {
 	"af-", " [addr]", "clean all function analysis data (or function at addr)",
 	"afa", "", "analyze function arguments in a call (afal honors dbg.funcarg)",
 	"afB", " 16", "set current function as thumb (change asm.bits)",
+	"afAj", " [json-array]", "get or set user-owned function analysis assumptions",
+	"afA-", "", "clear user-owned function analysis assumptions",
 	"afb", "[?] [addr]", "List basic blocks of given function",
 	"afc", "[?] type @[addr]", "set calling convention for function",
 	"afC", "[?] ([addr])@[addr]", "calculate the Cycles (afC) or Cyclomatic Complexity (afCc)",
@@ -6209,6 +6211,44 @@ static void cmd_afla(RCore *core, const char *input) {
 	ht_up_free (ht);
 }
 
+static void cmd_af_assumptions(RCore *core, const char *input) {
+	RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, 0);
+	if (!fcn) {
+		R_LOG_ERROR ("No function at current address");
+		return;
+	}
+	if (input[2] == '?') {
+		r_cons_cmd_help_match (core->cons, help_msg_af, "afA", 0, true);
+		return;
+	}
+	if (input[2] == '-') {
+		if (!r_anal_function_clear_assumptions (core->anal, fcn)) {
+			R_LOG_ERROR ("Failed to clear function assumptions");
+		}
+		return;
+	}
+	if (input[2] != 'j') {
+		r_cons_cmd_help_match (core->cons, help_msg_af, "afA", 0, true);
+		return;
+	}
+	const char *arg = r_str_trim_head_ro (input + 3);
+	if (R_STR_ISEMPTY (arg)) {
+		char *assumptions = r_anal_function_get_assumptions_json (core->anal, fcn);
+		r_cons_println (core->cons, assumptions? assumptions: "[]");
+		free (assumptions);
+		return;
+	}
+	char *json = strdup (arg);
+	if (!json) {
+		R_LOG_ERROR ("Failed to allocate assumptions payload");
+		return;
+	}
+	if (!r_anal_function_set_assumptions_json (core->anal, fcn, json)) {
+		R_LOG_ERROR ("Invalid function assumptions; expected a JSON array");
+	}
+	free (json);
+}
+
 static int cmd_af(RCore *core, const char *input) {
 	r_cons_break_timeout (core->cons, r_config_get_i (core->config, "anal.timeout"));
 	switch (input[1]) {
@@ -7049,6 +7089,9 @@ static int cmd_af(RCore *core, const char *input) {
 		} else {
 			r_cons_cmd_help_match (core->cons, help_msg_af, "afB", 0, true);
 		}
+		break;
+	case 'A': // "afA"
+		cmd_af_assumptions (core, input);
 		break;
 	case 'b': // "afb"
 		switch (input[2]) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -348,6 +348,9 @@ R_VEC_TYPE (RVecAnalVarPtr, RAnalVar *);
 typedef struct r_anal_function_t {
 	// TODO R2_600 Use RBinName here
 	char *name;
+	// JSON array of user- or plugin-owned analysis assumptions for this
+	// function; empty or absent means none. Saved with the project.
+	char *assumptions_json;
 	char *realname; // R2_590: add realname for the mangled one
 	char *pin; // user-defined pin string (emoji or any utf-8) to mark this function; NULL if not pinned
 	int bits; // ((> bits 0) (set-bits bits))
@@ -1120,6 +1123,9 @@ R_API bool r_anal_function_delete(RAnal *anal, RAnalFunction *fcn);
 
 // rhange the entrypoint of fcn
 // This can fail (and return false) if there is already another function at the new address
+R_API char *r_anal_function_get_assumptions_json(RAnal *anal, RAnalFunction *fcn);
+R_API bool r_anal_function_set_assumptions_json(RAnal *anal, RAnalFunction *fcn, const char *json);
+R_API bool r_anal_function_clear_assumptions(RAnal *anal, RAnalFunction *fcn);
 R_API bool r_anal_function_relocate(RAnalFunction *fcn, ut64 addr);
 
 // rename the given function

--- a/test/db/cmd/cmd_af
+++ b/test/db/cmd/cmd_af
@@ -699,3 +699,43 @@ EXPECT=<<EOF
 1
 EOF
 RUN
+
+NAME=afA user-owned function assumptions
+FILE=malloc://32
+ARGS=-a x86 -b 64
+CMDS=<<EXPECT_EOF
+wx 554889e5c3
+af
+afAj
+afAj [{"reg":"rdi","value":4}]
+afAj
+afl*~afAj
+afA-
+afAj
+EXPECT_EOF
+EXPECT=<<EXPECT_EOF
+[]
+[{"reg":"rdi","value":4}]
+'@0x00000000'afAj [{"reg":"rdi","value":4}]
+[]
+EXPECT_EOF
+RUN
+
+NAME=afA refuses anything that is not a JSON array of objects
+FILE=malloc://32
+ARGS=-a x86 -b 64
+CMDS=<<EXPECT_EOF
+wx 554889e5c3
+af
+afAj {"reg":"rdi"}
+afAj [1,2]
+afAj
+EXPECT_EOF
+EXPECT=<<EXPECT_EOF
+[]
+EXPECT_EOF
+EXPECT_ERR=<<EXPECT_EOF
+ERROR: Invalid function assumptions; expected a JSON array
+ERROR: Invalid function assumptions; expected a JSON array
+EXPECT_EOF
+RUN


### PR DESCRIPTION
Nothing lets a user or an analysis plugin say "at this function, `rdi` is 4" and have radare2 remember it. `ahr` and friends pin a value at an address for ESIL; there is no per-function statement that survives a project and that another analysis pass can read back.

`afAj` reads and writes one, as a JSON array of objects stored on the function.

```
afAj                              # []
afAj [{"reg":"rdi","value":4}]
afAj                              # [{"reg":"rdi","value":4}]
afl*~afAj                         # '@0x00000000'afAj [{"reg":"rdi","value":4}]
afA-                              # cleared
```

The content is deliberately not interpreted: radare2 validates that it is an array of objects, stores it, prints it back and saves it with the project through `af*`. What the objects mean is for whoever wrote them, which is what makes it useful to more than one producer — a user pinning a value by hand, or an analysis plugin recording what it assumed.

`afA-` clears, an empty payload reads as `[]`, and anything that is not an array of objects is refused rather than stored.

Tests in `db/cmd/cmd_af` cover the round trip, the project replay line, the clear and the two refusals. `db/anal` and `db/cmd` are green at 3,994 passing.

Disclosure of interest: this comes out of an analysis plugin that needs somewhere to record its assumptions, and I would rather propose the general facility than carry a private field. If you would rather it stayed out of tree, say so and I will keep it in the plugin.