### PR TITLE
Fix dalvik cmpl NaN sign and widen the double compares ##arch

### DIFF
--- a/libr/arch/p/dalvik/plugin.c
+++ b/libr/arch/p/dalvik/plugin.c
@@ -1370,16 +1370,27 @@ static bool decode(RArchSession *as, RAnalOp *op, RArchDecodeMask mask) {
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		if (mask & R_ARCH_OP_MASK_ESIL) {
 			format23x(len, data, &vA, &vB, &vC);
-			esilprintf (op, "32,v%u,F2D,32,v%u,F2D,F<=,?{,32,v%u,F2D,32,v%u,F2D,F==,!,-1,*,}{,1,},v%u,=", vC, vB, vC, vB, vA);
+			// cmpl yields -1 for an unordered compare, cmpg yields 1
+			if (data[0] == 0x2d) {
+				esilprintf (op, "32,v%u,F2D,32,v%u,F2D,F<=,?{,32,v%u,F2D,32,v%u,F2D,F==,!,}{,-1,},v%u,=", vB, vC, vC, vB, vA);
+			} else {
+				esilprintf (op, "32,v%u,F2D,32,v%u,F2D,F<=,?{,32,v%u,F2D,32,v%u,F2D,F==,!,-1,*,}{,1,},v%u,=", vC, vB, vC, vB, vA);
+			}
 		}
 		break;
 	case 0x2f: // cmpl-double
-	case 0x30: // cmlg-double
+	case 0x30: // cmpg-double
 		op->type = R_ANAL_OP_TYPE_CMP;
 		op->family = R_ANAL_OP_FAMILY_FPU;
 		if (mask & R_ARCH_OP_MASK_ESIL) {
 			format23x(len, data, &vA, &vB, &vC);
-			esilprintf (op, "v%u,v%u,F<=,?{,v%u,v%u,F==,!,-1,*,}{,1,},v%u,=", vC, vB, vC, vB, vA);
+			if (data[0] == 0x2f) {
+				esilprintf (op, GETWIDE "," GETWIDE ",F<=,?{," GETWIDE "," GETWIDE ",F==,!,}{,-1,},v%u,=",
+					vB+1, vB, vC+1, vC, vC+1, vC, vB+1, vB, vA);
+			} else {
+				esilprintf (op, GETWIDE "," GETWIDE ",F<=,?{," GETWIDE "," GETWIDE ",F==,!,-1,*,}{,1,},v%u,=",
+					vC+1, vC, vB+1, vB, vC+1, vC, vB+1, vB, vA);
+			}
 		}
 		break;
 	case 0x31: // cmp-long

--- a/test/db/esil/dalvik
+++ b/test/db/esil/dalvik
@@ -1,0 +1,108 @@
+NAME=dalvik cmpl-float
+FILE=malloc://0x200
+ARGS=-a dalvik
+CMDS=<<EOF
+wx 2d000204
+aei
+aeim
+ar v0=0xa5a5a5a5; ar v2=0x7fc00000; ar v4=0x3f800000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x7fc00000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x40000000; ar v4=0x3f800000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x40000000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x3f800000; aeip; aes; ar v0
+EOF
+EXPECT=<<EOF
+0xffffffff
+0xffffffff
+0x00000001
+0xffffffff
+0x00000000
+EOF
+RUN
+
+NAME=dalvik cmpg-float
+FILE=malloc://0x200
+ARGS=-a dalvik
+CMDS=<<EOF
+wx 2e000204
+aei
+aeim
+ar v0=0xa5a5a5a5; ar v2=0x7fc00000; ar v4=0x3f800000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x7fc00000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x40000000; ar v4=0x3f800000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x40000000; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v2=0x3f800000; ar v4=0x3f800000; aeip; aes; ar v0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000001
+0xffffffff
+0x00000000
+EOF
+RUN
+
+NAME=dalvik cmpl-double
+FILE=malloc://0x200
+ARGS=-a dalvik
+CMDS=<<EOF
+wx 2f000204
+aei
+aeim
+ar v0=0xa5a5a5a5; ar v3=0x7ff80000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x7ff80000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x40000000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x40000000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+EOF
+EXPECT=<<EOF
+0xffffffff
+0xffffffff
+0x00000001
+0xffffffff
+0x00000000
+EOF
+RUN
+
+NAME=dalvik cmpg-double
+FILE=malloc://0x200
+ARGS=-a dalvik
+CMDS=<<EOF
+wx 30000204
+aei
+aeim
+ar v0=0xa5a5a5a5; ar v3=0x7ff80000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x7ff80000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x40000000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x40000000; ar v4=0; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=0; ar v5=0x3ff00000; ar v4=0; aeip; aes; ar v0
+EOF
+EXPECT=<<EOF
+0x00000001
+0x00000001
+0x00000001
+0xffffffff
+0x00000000
+EOF
+RUN
+
+NAME=dalvik cmp-double reads the register pair
+FILE=malloc://0x200
+ARGS=-a dalvik
+CMDS=<<EOF
+wx 2f000204
+aei
+aeim
+ar v0=0xa5a5a5a5; ar v3=0x40000000; ar v2=0; ar v5=0x3ff00000; ar v4=7; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=7; ar v5=0x40000000; ar v4=0; aeip; aes; ar v0
+wx 30000204
+ar v0=0xa5a5a5a5; ar v3=0x40000000; ar v2=0; ar v5=0x3ff00000; ar v4=7; aeip; aes; ar v0
+ar v0=0xa5a5a5a5; ar v3=0x3ff00000; ar v2=7; ar v5=0x40000000; ar v4=0; aeip; aes; ar v0
+EOF
+EXPECT=<<EOF
+0x00000001
+0xffffffff
+0x00000001
+0xffffffff
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Dalvik defines `cmpl-*` as -1 and `cmpg-*` as +1 when either operand is NaN, but the plugin emits one shared ESIL string per pair, so `cmpl` answers +1 too. Separately, `cmp*-double` reads a single `v` register as a whole double, though `v0..v255` are 32-bit and a Dalvik double is a register pair:

```
$ r2 -N -a dalvik -q -c 'wx 2d000204; ar v2=0x7fc00000; ar v4=0x3f800000; aei; aeim; aeip; aes; ar v0' malloc://0x200
0x00000001      # cmpl-float, v2 = NaN; want 0xffffffff

$ r2 -N -a dalvik -q -c 'wx 2f000204; ar v3=0x40000000; ar v2=0; ar v5=0x3ff00000; ar v4=7; aei; aeim; aeip; aes; ar v0' malloc://0x200
0xffffffff      # cmpl-double, 2.0 vs 1.0; only the low words got compared
```

## The fix

- One `esilprintf` per opcode. `cmpg` keeps its expression; `cmpl` swaps the operand order into `F<=` so the else arm — where any NaN lands, since `F<=` pushes 0 for every unordered pair — yields -1.
- Read the double operands through the file's existing `GETWIDE` macro, as `cmp-long` and every `OP_DOUBLE` op in this plugin already do.

## The tests

New `db/esil/dalvik` runs all four opcodes over NaN in either operand, greater, less and equal. Four of the five fail against master; `cmpg-float` passes, which is right — its expression is unchanged.