### PR TITLE
Read DT_INIT and DT_FINI from the dynamic section ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -681,7 +681,11 @@ static void fill_dynamic_entries(ELFOBJ *eo, ut64 loaded_offset, ut64 dyn_size) 
 			RVecElfOff_push_back (&di->dt_needed, &d.d_un.d_val);
 			break;
 		case DT_INIT:
+			di->dt_init = d.d_un.d_ptr;
+			break;
 		case DT_FINI:
+			di->dt_fini = d.d_un.d_ptr;
+			break;
 		case DT_DEBUG:
 		case DT_INIT_ARRAY:
 		case DT_FINI_ARRAY:
@@ -1926,6 +1930,14 @@ ut64 Elf_(get_boffset)(ELFOBJ *eo) {
 
 ut64 Elf_(get_init_offset)(ELFOBJ *eo) {
 	R_RETURN_VAL_IF_FAIL (eo, UT64_MAX);
+	// DT_INIT names the initialization hook outright, on every architecture.
+	// The scan below only recognizes a 32-bit x86 startup idiom.
+	if (eo->dyn_info.dt_init) {
+		ut64 offset = Elf_(v2p) (eo, eo->dyn_info.dt_init);
+		if (offset != UT64_MAX) {
+			return offset;
+		}
+	}
 	if (is_intel (eo)) { // push // x86 only
 		ut64 entry = Elf_(get_entry_offset) (eo);
 		if (entry == UT64_MAX) {
@@ -1945,6 +1957,13 @@ ut64 Elf_(get_init_offset)(ELFOBJ *eo) {
 
 ut64 Elf_(get_fini_offset)(ELFOBJ *eo) {
 	R_RETURN_VAL_IF_FAIL (eo, UT64_MAX);
+	// DT_FINI is the finalization hook the loader itself uses.
+	if (eo->dyn_info.dt_fini) {
+		ut64 offset = Elf_(v2p) (eo, eo->dyn_info.dt_fini);
+		if (offset != UT64_MAX) {
+			return offset;
+		}
+	}
 	if (is_intel (eo)) { // push // x86 only
 		ut64 entry = Elf_(get_entry_offset) (eo);
 		if (entry == UT64_MAX) {

--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -101,6 +101,7 @@ typedef struct Elf_(dynamic_info) {
 	Elf_(Xword) dt_relaent;
 	Elf_(Xword) dt_strsz;
 	Elf_(Xword) dt_syment;
+	Elf_(Addr) dt_init;
 	Elf_(Addr) dt_fini;
 	Elf_(Addr) dt_rel;
 	Elf_(Xword) dt_relsz;


### PR DESCRIPTION
r2 reports no `init` or `fini` binsym for essentially every modern ELF, and the cause is that neither is read from where the ELF says it.

`Elf_(get_init_offset)` and `Elf_(get_fini_offset)` recognise exactly one shape: a `push <imm32>` at a fixed offset inside `_start`, which is how a 32-bit x86 crt0 passed the two hook addresses to `__libc_start_main`. On x86-64 the entry loads them with `lea`, and on every other architecture the sequence does not exist at all, so both return `UT64_MAX` and `R_BIN_SYM_INIT` / `R_BIN_SYM_FINI` come back empty.

The dynamic section already carries the answer. `DT_INIT` and `DT_FINI` name the two hooks the loader itself calls, they are present on every ELF with a `PT_DYNAMIC` segment, and the parser already walks past both tags — `DT_FINI` was listed among the entries it deliberately ignores, and `DT_INIT` fell through to the default. Recording them costs one field each in `RBinElfDynamicInfo`, and the lookup becomes exact rather than a heuristic. The existing scan stays as the fallback for a static binary with no dynamic section.

On a stock x86-64 `gcc -O0` build:

```
$ readelf -d ./minigzip | grep -E "INIT|FINI"
 0x000000000000000c (INIT)               0x1000
 0x000000000000000d (FINI)               0x148ec
```

Before, `R_BIN_SYM_INIT` and `R_BIN_SYM_FINI` are both empty. After, they are `0x1000` and `0x148ec` — what `DT_INIT` and `DT_FINI` have pointed at all along.

Found while trying to recognise a loader hook by address, which is not possible today outside 32-bit x86.