### PR TITLE
Stop the type-matching pass turning pointers into uint32_t ##analysis

### DIFF
--- a/libr/anal/p/tp/match.c
+++ b/libr/anal/p/tp/match.c
@@ -412,6 +412,31 @@ static bool tp_canary_from_guard(TPState *tps, RAnalBlock *guard, ut64 addr) {
 	return false;
 }
 
+// `int *ret; *ret = strlen (s);` makes the variable a pointer only when the
+// next instruction stores through a register this one wrote.
+static bool esil_stores_through(const char *esil, const char *regs) {
+	if (!esil || R_STR_ISEMPTY (regs)) {
+		return false;
+	}
+	const char *p = regs;
+	while (*p) {
+		const char *end = strchr (p, ',');
+		const size_t len = end? (size_t)(end - p): strlen (p);
+		char needle[40];
+		if (len > 0 && len < sizeof (needle) - 4) {
+			snprintf (needle, sizeof (needle), ",%.*s,=[", (int)len, p);
+			if (strstr (esil, needle)) {
+				return true;
+			}
+		}
+		if (!end) {
+			break;
+		}
+		p = end + 1;
+	}
+	return false;
+}
+
 // every conditional predecessor is a candidate: one failure block can guard several checks
 static void tp_canary_rename(TPState *tps, RAnalFunction *fcn, ut64 bb_addr, ut64 addr) {
 	RListIter *iter;
@@ -528,12 +553,12 @@ static void type_match_op_cb(void *user, RAnalOp *aop, RAnalOp *next_op, ut64 ad
 				|| reg_token_contains (c->tp.ret_reg, tmp? tmp + 1: NULL)) {
 				c->tp.resolved = true;
 			} else if (type == R_ANAL_OP_TYPE_MOV && (next_op && next_op->type == R_ANAL_OP_TYPE_MOV)) {
-				// Progate return type passed using pointer
-				// int *ret; *ret = strlen (s);
-				// TODO: memref check , dest and next src match
+				// return type propagated through a pointer the variable holds
 				char nsrc[REGNAME_SIZE] = { 0 };
 				get_src_regname_from_esil (anal, r_strbuf_get (&next_op->esil), next_op->addr, nsrc, sizeof (nsrc));
-				if (reg_token_contains (c->tp.ret_reg, nsrc) && var && aop->direction == R_ANAL_OP_DIR_READ) {
+				if (reg_token_contains (c->tp.ret_reg, nsrc) && var
+						&& aop->direction == R_ANAL_OP_DIR_READ
+						&& esil_stores_through (r_strbuf_get (&next_op->esil), cur_dest)) {
 					tp_var_retype (tps, bb_addr, var, NULL, c->tp.ret_type, true, false);
 				}
 			}

--- a/libr/anal/p/tp/types.c
+++ b/libr/anal/p/tp/types.c
@@ -150,7 +150,13 @@ static char *tp_built_type(RAnalVar *var, const char *vname, const char *type, i
 	r_strbuf_init (&sb);
 	if (pfx) {
 		if (tmp && !r_str_startswith (var->type, "signed")) {
-			r_strbuf_setf (&sb, "%s %s", type, tmp);
+			if (isdigit ((ut8)tmp[3])) {
+				// intN_t spells its signedness with a leading u, so
+				// prefixing a word here would build "unsigned int64_t"
+				r_strbuf_setf (&sb, "%s%s", (*type == 'u')? "u": "", tmp);
+			} else {
+				r_strbuf_setf (&sb, "%s %s", type, tmp);
+			}
 		} else {
 			r_strbuf_fini (&sb);
 			return NULL;

--- a/libr/anal/p/tp/types.c
+++ b/libr/anal/p/tp/types.c
@@ -187,13 +187,17 @@ static char *tp_built_type(RAnalVar *var, const char *vname, const char *type, i
 		ref++;
 	}
 
+	// A pointer is not an integer, so it keeps its spelling: collapsing it
+	// loses the pointee and, on a 64-bit target, half of the variable's width.
 	char *tmp1 = r_strbuf_get (&sb);
-	if (r_str_startswith (tmp1, "unsigned long long")) {
-		r_strbuf_set (&sb, "uint64_t");
-	} else if (r_str_startswith (tmp1, "unsigned")) {
-		r_strbuf_set (&sb, "uint32_t");
-	} else if (r_str_startswith (tmp1, "int")) {
-		r_strbuf_set (&sb, "int32_t");
+	if (tmp1 && !strchr (tmp1, '*')) {
+		if (r_str_startswith (tmp1, "unsigned long long")) {
+			r_strbuf_set (&sb, "uint64_t");
+		} else if (r_str_startswith (tmp1, "unsigned")) {
+			r_strbuf_set (&sb, "uint32_t");
+		} else if (r_str_startswith (tmp1, "int")) {
+			r_strbuf_set (&sb, "int32_t");
+		}
 	}
 	r_strbuf_trim (&sb);
 	// a dereferenced void pointer carries no fact, and a void variable is unusable

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -1672,7 +1672,7 @@ aaft
 afv
 EOF
 EXPECT=<<EOF
-var uint32_t canary @ rbp-0x8
+var uint64_t canary @ rbp-0x8
 EOF
 RUN
 
@@ -1757,7 +1757,7 @@ var char * var_20h @ rbp-0x20
 var char * var_28h @ rbp-0x28
 var char * s @ rbp-0x30
 var char * s1 @ rbp-0x38
-var uint32_t var_40h @ rbp-0x40
+var uint64_t var_40h @ rbp-0x40
 var char * var_48h @ rbp-0x48
 var char * var_50h @ rbp-0x50
 var char * var_58h @ rbp-0x58
@@ -2157,7 +2157,7 @@ txt mbstate_t *
 EOF
 EXPECT=<<EOF
 int64_t
-uint32_t
+uint8_t
 char *
 int16_t
 int8_t
@@ -2168,6 +2168,8 @@ int64_t
 char *
 uint32_t
 int32_t
+uint64_t
+uint8_t
 size_t
 void *
 mbstate_t *
@@ -2489,7 +2491,7 @@ a:tp
 afv~var_18h
 EOF
 EXPECT=<<EOF
-var uint32_t var_18h @ rbp-0x18
+var uint64_t var_18h @ rbp-0x18
 EOF
 RUN
 
@@ -3284,7 +3286,7 @@ aaft
 afv @ 0
 EOF2
 EXPECT=<<EOF2
-arg uint32_t arg1 @ rdi
+arg uint64_t arg1 @ rdi
 var void * p @ rbp-0x8
 EOF2
 RUN
@@ -3311,7 +3313,7 @@ aaft
 afv @ 0
 EOF2
 EXPECT=<<EOF2
-arg uint32_t arg1 @ rdi
+arg uint64_t arg1 @ rdi
 var void * f @ rbp-0x8
 EOF2
 RUN

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -2153,7 +2153,7 @@ txf fcn.00011b90
 ?e =
 txt size_t
 ?e =
-txt size_t *
+txt mbstate_t *
 EOF
 EXPECT=<<EOF
 int64_t
@@ -2173,11 +2173,11 @@ void *
 mbstate_t *
 wint_t
 int8_t
-size_t *
 =
 fcn.0000f770
 fcn.00011b90
 fcn.00010010
+fcn.00014d50
 fcn.0000e780
 fcn.0000c0f0
 =


### PR DESCRIPTION
Two defects in `libr/anal/p/tp`, found while tracing why a stack slot holding a
pointer parameter came out four bytes wide.

### 1. A pointer collapsed to `uint32_t`

`tp_built_type` canonicalises the type it derives so `tp_expand_int` can invert
it, and it decided by prefix-matching the whole built string:

```c
if (r_str_startswith (tmp1, "unsigned long long")) {
	r_strbuf_set (&sb, "uint64_t");
} else if (r_str_startswith (tmp1, "unsigned")) {
	r_strbuf_set (&sb, "uint32_t");
```

`unsigned int *` starts with `unsigned`, so the pointee is discarded and, on a
64-bit target, so is half the variable's width.

An x86-64 `-O0` build of zlib shows it. `syncsearch` homes its pointer
parameters with 8-byte stores:

```
0x0000dd1e      mov qword [var_18h], rdi    ; have
0x0000dd22      mov qword [var_20h], rsi    ; buf
```

`aa` types both slots `int64_t`, correctly, and `aaft` derives
`unsigned int *` and `unsigned char const *` for them, also correctly. The
canonicalisation then rewrote both to `uint32_t`, leaving the recovered
variable disagreeing with the instruction that created it.

The collapse now runs only when the built spelling has no `*` in it. The
integer names are matched exactly as before, so nothing else in the mapping
moves.

### 2. The return-through-a-pointer branch had no memref test

The first commit is a prerequisite for the second: with pointers no longer
flattened, an unverified candidate from this branch became visible.

The forward propagation of a call's return type has a branch for

```c
int *ret; *ret = strlen (s);
```

where the variable holds a pointer and the return value is written through it.
The branch asked only that the next instruction *reads* the return register,
and its own comment recorded the missing test:
`TODO: memref check , dest and next src match`.

On `bins/elf/ls.odd` it fires on pairs like

```
movzx r8d, byte [rsp+0x30]     ; a one-byte load out of the variable
mov   rcx, qword [rax]         ; a load through rax, not a store
```

and types that variable from `__ctype_b_loc`'s `const unsigned short **` with a
further `*` added. Neither instruction stores anything, and the variable is
read a byte at a time.

The added test is the one the TODO asks for, phrased against ESIL because that
is what this pass has: the next instruction must contain `,<reg>,=[` for a
register the current instruction wrote. The intended shape still matches, since
`mov rax, qword [var]; mov dword [rax], edx` lowers to `rax,[8],...` followed by
`edx,rax,=[4]`, and `db/cmd/types` `ret type pointer` stays green.

### Tests

`r2r` on this branch has exactly the same 5 failures as `master` on the same
machine (all pre-existing and unrelated: 3 ELF reloc tests, 2 PTX). One
expectation moves, in `type xrefs`: a stack slot at `rsp+0x50` that `ls.odd`
reuses for one-byte and eight-byte values loses the `size_t *` the unverified
branch gave it and keeps `size_t`. The `txt size_t *` lookup in that test is
repointed at `mbstate_t *`, which returns the same two functions, so the
command still covers a pointer type with a real result.
