### PR TITLE
Hand an analysis plugin's init the RAnal it is declared to take ##analysis

### DIFF
--- a/libr/anal/anal.c
+++ b/libr/anal/anal.c
@@ -336,7 +336,7 @@ R_API void r_anal_set_user_ptr(RAnal *anal, void *user) {
 R_API bool r_anal_plugin_add(RAnal *anal, RAnalPlugin *foo) {
 	R_RETURN_VAL_IF_FAIL (anal && foo, false);
 	if (foo->init) {
-		foo->init (anal->user);
+		foo->init (anal);
 	}
 	r_list_append (anal->libstore->plugins, foo);
 	return true;


### PR DESCRIPTION
The callback is declared

```c
bool (*init)(RAnal *a);
```

and `r_anal_plugin_add` called it as

```c
foo->init (anal->user);
```

`anal->user` is set by `r_core_init` (`r_anal_set_user_ptr (core->anal, core)`)
to the `RCore`, so every analysis plugin's `init` received an `RCore` through an
`RAnal` parameter. A plugin that used the argument read `RCore` fields as
`RAnal` ones; a plugin that only wanted to know which analysis it had been added
to could not find out.

Found while writing an out-of-tree analysis plugin whose `init` needs
`anal->coreb.core` and got a pointer that was not an `RAnal` at all.

No analysis plugin in tree defines `init`, so nothing depends on the old value.

`r_anal_plugin_free` one function up has the same shape — it calls
`p->fini (NULL)` — but it is an `RListFree` callback with no `RAnal` in hand, so
fixing that means plumbing the analysis into plugin teardown. Left alone here
rather than half-changed.
