### PR TITLE
Stop listing ELF relocs found in both JMPREL and RELA ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3799,6 +3799,12 @@ done:
 	return pos;
 }
 
+// JMPREL usually points inside RELA/REL, so its entries reparse in that pass
+static inline bool in_pltrel_range(const RBinElfDynamicInfo *di, ut64 addr) {
+	return di->dt_jmprel != R_BIN_ELF_ADDR_MAX && di->dt_pltrelsz
+		&& addr >= di->dt_jmprel && addr < di->dt_jmprel + di->dt_pltrelsz;
+}
+
 static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t num_relocs) {
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
 	const size_t size = get_size_rel_mode (di->dt_pltrel);
@@ -3824,6 +3830,10 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 	}
 	// parse rela
 	for (offset = 0; offset < di->dt_relasz && pos < num_relocs; offset += di->dt_relaent, pos++) {
+		// skip re-read but keep pos++ so the num_relocs budget stays intact
+		if (in_pltrel_range (di, di->dt_rela + offset)) {
+			continue;
+		}
 		RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
 		if (!read_reloc (eo, reloc, DT_RELA, di->dt_rela + offset)) {
 			RVecRBinElfReloc_pop_back (&eo->g_relocs);
@@ -3835,6 +3845,9 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 	}
 
 	for (offset = 0; offset < di->dt_relsz && pos < num_relocs; offset += di->dt_relent, pos++) {
+		if (in_pltrel_range (di, di->dt_rel + offset)) {
+			continue;
+		}
 		RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
 		if (!read_reloc (eo, reloc, DT_REL, di->dt_rel + offset)) {
 			RVecRBinElfReloc_pop_back (&eo->g_relocs);
@@ -4080,7 +4093,7 @@ static bool populate_relocs_record(ELFOBJ *eo) {
 	i = populate_relocs_record_from_dynamic (eo, i, num_relocs);
 	i = populate_relocs_record_from_mips_got (eo, i, num_relocs);
 	i = populate_relocs_record_from_section (eo, i, num_relocs);
-	eo->g_reloc_num = i;
+	eo->g_reloc_num = RVecRBinElfReloc_length (&eo->g_relocs);
 	return true;
 }
 

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -1028,3 +1028,56 @@ EXPECT=<<EOF
 0x08008703 0x080090be
 EOF
 RUN
+
+NAME=ELF: JMPREL aliased over RELA reads each entry once
+FILE=bins/elf/pltrel/ppc32be.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir
+om~.got.r2
+EOF
+EXPECT=<<EOF
+vaddr      paddr      type   ntype name
+---------------------------------------
+0x00002000 0x00001000 ADD_32 21    mul2
+0x00002004 0x00001004 ADD_32 21    sub2
+0x00002008 0x00001008 ADD_32 21    add2
+- 3 fd: 4 +0x00000000 0x0000200c - 0x00002017 rw- rw- .got.r2
+EOF
+RUN
+
+NAME=ELF: JMPREL nested in RELA keeps the entries outside the plt range
+FILE=bins/elf/pltrel/ppc32be-align-tls.so
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir
+om~.got.r2
+EOF
+EXPECT=<<EOF
+vaddr      paddr      type   ntype name
+---------------------------------------
+0x00002000 0x00001000 ADD_32 21    mul2
+0x00002004 0x00001004 ADD_32 21    sub2
+0x00002008 0x00001008 ADD_32 21    __tls_get_addr_opt
+0x0000200c 0x0000100c ADD_32 21    add2
+- 3 fd: 4 +0x00000000 0x00002010 - 0x00002023 rw- rw- .got.r2
+EOF
+RUN
+
+NAME=ELF: applied relocs match the unapplied ones
+FILE=bins/elf/rv64/ls
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~ADD_64?
+EXPECT=<<EOF
+349
+EOF
+RUN
+
+NAME=ELF: unapplied relocs match the applied ones
+FILE=bins/elf/rv64/ls
+ARGS=-e bin.relocs.apply=false
+CMDS=ir~ADD_64?
+EXPECT=<<EOF
+349
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`ir` under `bin.relocs.apply=true` lists every ELF dynamic relocation twice. `DT_JMPREL` normally points inside the `DT_RELA`/`DT_REL` range, so an entry covered by both dynamic tags is read once per tag.

```
$ r2 -N -e bin.relocs.apply=true -qc ir bins/elf/pltrel/ppc32be.so
vaddr      paddr      type   ntype name
---------------------------------------
0x00002000 0x00001000 ADD_32 21    mul2
0x00002000 0x00001000 ADD_32 21    mul2
0x00002004 0x00001004 ADD_32 21    sub2
0x00002004 0x00001004 ADD_32 21    sub2
0x00002008 0x00001008 ADD_32 21    add2
0x00002008 0x00001008 ADD_32 21    add2
```

Three relocations, six rows. `apply=false` prints each once because `relocs()` dedups by rva downstream; the applied path has no such filter. Fixing the double *read* rather than adding an rva filter to `patch_relocs()` matters: ET_REL objects legitimately carry several relocs at one address (ARM MOVW/MOVT, MIPS HI16/LO16, ppc ADDR16_HA/LO), and an rva-keyed dedup would eat one of each.

## The fix

- The RELA and REL passes skip any entry whose address falls in the JMPREL window, which the pltrel pass already read. The keys are three contiguous arithmetic sequences, so this is an interval test, not a set — the same idiom `get_next_not_analysed_offset()` already uses for the section pass. No  allocation, no per-reloc cost.
- `g_reloc_num` takes the vector length rather than the loop counter, since skipped entries no longer grow the vector. It sizes the `.got.r2` map, which was inflated by every double-read entry. `pos` is still incremented on a skip, deliberately: the `num_relocs` budget was computed with the duplicates counted.

## Tests

`db/formats/elf/reloc`, four cases: the aliased layout (`ppc32be.so`, JMPREL == RELA) and the nested layout every real toolchain emits (`ppc32be-align-tls.so`, JMPREL at the tail of RELA — a fix that skipped the RELA pass wholesale would drop the non-plt entries), each also asserting the `.got.r2` map range that pins `g_reloc_num`; and `rv64/ls` (349 relocs) under both `apply` values, the invariant that was actually broken. Three fail on master; the `apply=false` case is the control. Corpus-wide, applied and unapplied `irj` row sets now match on all 625 ELF files in testbins.