### PR TITLE
Test aarch64 ET_REL GOT relocs ignore the addend ##bin

### DIFF
--- a/test/db/formats/elf/elf-relarm64
+++ b/test/db/formats/elf/elf-relarm64
@@ -126,3 +126,14 @@ EXPECT=<<EOF
             0x08000084      00a842f9       ldr x0, [x0, 0x550]
 EOF
 RUN
+
+NAME=ELF: aarch64 ET_REL GOT relocs ignore the addend
+FILE=bins/elf/aarch64-got-etrel-addend.o
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+p8 24 @ 0x08000040
+EOF
+EXPECT=<<EOF
+0100009021ac40f90200009042ac40f943080058c0035fd6
+EOF
+RUN


### PR DESCRIPTION
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

For an aarch64 ET_REL object, a GOT reference written `:got:sym+N` carries the addend `N`, but for a GOT reloc the addend selects the entry — it is not an offset from it. #26651 already zeroes the addend for these types; this adds the missing golden so the rule cannot silently regress.

```
$ r2 -N -e bin.relocs.apply=true -qc 'p8 24 @ 0x08000040' \
      bins/elf/aarch64-got-etrel-addend.o
0100009021ac40f90200009042ac40f943080058c0035fd6
```

The three `+8` forms (`adrp :got:`, `ldr :got_lo12:`, `ldr` literal) resolve to the same slot as plain `:got:gundef`. Dropping the `A = 0` line encodes the next import's slot instead (`21b040f9` / `83080058`), which is what the test catches.

## Test

`db/formats/elf/elf-relarm64`: one case on the new `bins/elf/aarch64-got-etrel-addend.o` fixture (testbins #138). Verified it fails against a tree with the `A = 0` line removed.

