### PR TITLE
Do not invent a stack variable from an address inside another one ##analysis

### DIFF
--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -1156,7 +1156,18 @@ R_API R_OWNED char *r_anal_function_autoname_var(RAnalFunction *fcn, char kind, 
 	return varname;
 }
 
-static RAnalVar *get_stack_var(RAnalFunction *fcn, int delta, int access_size, int var_size, bool fuzzy) {
+// Whether an access ever stored to this variable, which is what fixes its extent.
+static bool var_is_written(const RAnalVar *var) {
+	RAnalVarAccess *acc;
+	R_VEC_FOREACH ((RVecAnalVarAccess *)&var->accesses, acc) {
+		if (acc->type & R_PERM_W) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static RAnalVar *get_stack_var(RAnal *anal, RAnalFunction *fcn, int delta, int access_size, int var_size, bool fuzzy, bool addr_taken) {
 	RAnalVar **it;
 	R_VEC_FOREACH (&fcn->vars, it) {
 		RAnalVar *var = *it;
@@ -1166,6 +1177,15 @@ static RAnalVar *get_stack_var(RAnalFunction *fcn, int delta, int access_size, i
 		}
 		if (fuzzy && is_stack && access_size > 0 && access_size < var_size && delta > var->delta && delta < var->delta + var_size) {
 			return var;
+		}
+		// An address taken inside a variable the function stores to belongs to
+		// that variable: the store fixed the extent, and lea establishes none.
+		if (is_stack && addr_taken && delta > var->delta
+			&& R_STR_ISNOTEMPTY (var->type) && var_is_written (var)) {
+			const int extent = (int)(r_anal_type_bitsize (anal, var->type) / 8);
+			if (extent > 0 && delta < var->delta + extent) {
+				return var;
+			}
 		}
 	}
 	return NULL;
@@ -1360,6 +1380,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 
 	const int maxarg = 32; // TODO: use maxarg ?
 	int rw = (op->direction == R_ANAL_OP_DIR_WRITE) ? R_PERM_W : R_PERM_R;
+	const bool addr_taken = op->direction == R_ANAL_OP_DIR_REF;
 	// fcn->stack already incorporates this op's stackptr; for stack-adjusting
 	// ops the access happens before the adjustment, so undo it locally.
 	const st64 fcn_stack = (op->stackop == R_ANAL_STACK_INC)
@@ -1378,14 +1399,14 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 		const int var_size = anal->config->bits / 8;
 		const bool fuzzy = !strcmp (anal->config->arch, "arm");
-		RAnalVar *var = get_stack_var (fcn, frame_off, access_size, var_size, fuzzy);
+		RAnalVar *var = get_stack_var (anal, fcn, frame_off, access_size, var_size, fuzzy, addr_taken);
 		if (var) {
 			r_anal_var_set_access (anal, var, reg, op->addr, rw, ptr);
 			return;
 		}
 		if (isarg && type == R_ANAL_VAR_KIND_SPV && fcn->maxstack > fcn->stack && ptr < fcn->maxstack) {
 			const st64 local_frame_off = ptr - fcn->maxstack;
-			var = get_stack_var (fcn, local_frame_off, access_size, var_size, fuzzy);
+			var = get_stack_var (anal, fcn, local_frame_off, access_size, var_size, fuzzy, addr_taken);
 			if (var && !var->isarg) {
 				r_anal_var_set_access (anal, var, reg, op->addr, rw, ptr);
 				return;
@@ -1449,7 +1470,7 @@ static void extract_arg(RAnal *anal, RAnalFunction *fcn, RAnalOp *op, const char
 		}
 		const int var_size = anal->config->bits / 8;
 		const bool fuzzy = !strcmp (anal->config->arch, "arm");
-		RAnalVar *var = get_stack_var (fcn, frame_off, access_size, var_size, fuzzy);
+		RAnalVar *var = get_stack_var (anal, fcn, frame_off, access_size, var_size, fuzzy, addr_taken);
 		if (var) {
 			r_anal_var_set_access (anal, var, reg, op->addr, rw, -ptr);
 			return;

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -711,25 +711,22 @@ EXPECT=<<EOF
 \ 0x004873c4      e937f1ffff     jmp fcn.00486500
 | // true: 0x00486500
 afvR
-var_bp_38h  0x40f790,0x40f839
+var_bp_38h  0x40f790,0x40f7a6,0x40f839
    var_28h  0x40f7c1
 var_bp_30h  0x40f78c,0x40f835
    var_3ch  0x40f86e
 var_bp_20h  0x40f7d4
-    var_fh  0x40f7a6
 afvW
 var_bp_38h  0x40f728
    var_28h  0x40f735
 var_bp_30h  0x40f79b,0x40f843
    var_3ch  0x40f866
 var_bp_20h
-    var_fh
 var var_bp_38h = 0x00177fc0 = (qword)0x1111111111111111
 var var_28h = 0x00177fd0 = (qword)0x0000000000000000
 var var_bp_30h = 0x00177fc8 = (qword)0x0000000000000000
 var var_3ch = 0x00177fbc = 0x00000000
 var var_bp_20h = 0x00177fd8 = (qword)0x0000000000000000
-var var_fh = 0x00177fc7 = (qword)0x0000000000000011
 EOF
 RUN
 


### PR DESCRIPTION
`lea` reads no memory, so `extract_arg` has no access width for it and
`inferred_var_size` falls back to the pointer size. A `lea` into the middle of a
slot the function already stores to therefore creates a second variable that
overlaps the first.

glibc's own `_itoa` loop, in `test/bins/elf/static-glibc-2.27`:

```
0x40f728  mov qword [rbp - 0x38], rsi   ; the 8-byte value
0x40f7a6  lea rbx, [rsp + 0xf]          ; the address of its last byte
```

`rsp+0xf` is `rbp-0x31`, one byte inside `var_bp_38h`, and recovery named it
`var_fh` with a guessed 8-byte width. `afvd` then prints two variables for one
piece of storage:

```
var var_bp_38h = 0x00177fc0 = (qword)0x1111111111111111
var var_fh     = 0x00177fc7 = (qword)0x0000000000000011
```

`get_stack_var` now folds an address taken strictly inside a variable **the
function stores to** into that variable. The write is what fixes the extent;
taking an address does not. Requiring the write matters: a variable whose own
width was also guessed cannot absorb its neighbours, which is what
`db/anal/vars afvx2` and the `anal vars` tests check.

`db/anal/x86_64` "block takeover" asserted the phantom and is updated to record
the `lea` against `var_bp_38h`. `db/anal` and `db/cmd` are 3993 OK / 0 XX,
unchanged from before the patch.