### PR TITLE
Apply PPC32 ADDR32 and RELATIVE dynamic relocs ##bin

### DIFF
--- a/libr/bin/p/bin_elf.inc.c
+++ b/libr/bin/p/bin_elf.inc.c
@@ -1506,6 +1506,32 @@ static void _patch_reloc(RBinFile *bf, ELFOBJ *bo, ut16 e_machine, RIOBind *iob,
 		r_write_ble32 (buf, V, bo->endian);
 		iob->overlay_write_at (iob->io, P, buf, 4);
 		break;
+	case EM_PPC: {
+		// R_PPC_RELATIVE addend: RELA field, else the in-place REL word
+		ut64 pA = A;
+		if (rel->implicit_addend) {
+			if (iob->read_at (iob->io, P, buf, 4) != 4) {
+				return;
+			}
+			pA = r_read_ble32 (buf, bo->endian);
+		}
+		switch (rel->type) {
+		case R_PPC_ADDR32:
+			V = S + pA;
+			break;
+		case R_PPC_RELATIVE:
+			V = pA + (B - bo->baddr);
+			break;
+		case R_PPC_DTPMOD32:
+		case R_PPC_DTPREL32:
+			return; // tls slots are the runtime linker's to fill
+		default:
+			return; // GLOB_DAT/JMP_SLOT need weak/plt rules first
+		}
+		r_write_ble32 (buf, V, bo->endian);
+		iob->overlay_write_at (iob->io, P, buf, 4);
+		}
+		break;
 	case EM_X86_64: {
 		int word = 0;
 		switch (rel->type) {

--- a/test/db/formats/elf/ppc32-reloc-apply
+++ b/test/db/formats/elf/ppc32-reloc-apply
@@ -1,0 +1,64 @@
+NAME=ELF PPC32: RELA RELATIVE addend rebased into the slot
+FILE=bins/elf/dropbear_powerpc-linux-gnu_gcc_-O2
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pv4 @ 0x4eb14
+pv4 @ 0x502bc
+EOF
+EXPECT=<<EOF
+0x0002f6e2
+0x00004ad8
+EOF
+RUN
+
+NAME=ELF PPC32: REL RELATIVE slot word rebased by the load bias
+FILE=bins/elf/ppc32-relative-nonzero-base.so
+ARGS=-B 0x10000000 -e bin.relocs.apply=true
+CMDS=pv4 @ 0x10020184
+EXPECT=<<EOF
+0x10020180
+EOF
+RUN
+
+NAME=ELF PPC32: GLOB_DAT and JMP_SLOT slots are left unpatched
+FILE=bins/elf/hello.ppc
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pv4 @ 0x10020008
+pv4 @ 0x10020064
+pv4 @ 0x1002006c
+pv4 @ 0x10020074
+EOF
+EXPECT=<<EOF
+0x00000000
+0x00000000
+0x00000000
+0x00000000
+EOF
+RUN
+
+NAME=ELF PPC32: ADDR32 slot holds symbol value plus addend
+FILE=bins/elf/dropbear_powerpc-linux-gnu_gcc_-O2
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pv4 @ 0x4f210
+pv4 @ 0x4f538
+EOF
+EXPECT=<<EOF
+0x00051bec
+0x00050bb4
+EOF
+RUN
+
+NAME=ELF PPC32: JMP_SLOT plt slots keep their nonzero stub words unpatched
+FILE=bins/elf/dropbear_powerpc-linux-gnu_gcc_-O2
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+pv4 @ 0x4fe00
+pv4 @ 0x4fe04
+EOF
+EXPECT=<<EOF
+0x0002f1b0
+0x0002f1b4
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`bin.relocs.apply=true` does nothing on ppc32. `_patch_reloc` has arms for s390/ARM/AArch64/PPC64/386/x86-64/BPF but none for `EM_PPC`, so r2 allocates the `.got.r2` slots and moves import vaddrs into them, then writes no byte.

```
$ r2 -N -e bin.relocs.apply=true -qc 'pv4 @ 0x4eb14; pv4 @ 0x502bc' \
      bins/elf/dropbear_powerpc-linux-gnu_gcc_-O2
0x00000000
0x00000000
```

Both are `R_PPC_RELATIVE` sites that should read `0x2f6e2` and `0x4ad8`.

## The fix

- Add an `EM_PPC` arm patching `R_PPC_RELATIVE` (the link-time vaddr, mapped by the load bias) and `R_PPC_ADDR32` (`S + A`), with `R_PPC_DTPMOD32`/`DTPREL32` as explicit no-ops. Big-endian safe via `r_write_ble32`.
- `RELATIVE` reads its addend from the RELA field, or the in-place word for REL (`implicit_addend`); the value is `A + (B - baddr)`, i.e. the addend mapped into the view, not `B + A` — the latter double-counts the base on a non-zero image base.
- `GLOB_DAT` and `JMP_SLOT` are deliberately left unpatched: the corpus's only ppc32 `GLOB_DAT` is an undefined-weak `__gmon_start__` slot that must stay `0`, and `JMP_SLOT` depends on the PLT flavour. Both are follow-ups.

## Tests

`db/formats/elf/ppc32-reloc-apply`: `RELATIVE` (RELA on dropbear, REL under `-B 0x10000000` on the new `ppc32-relative-nonzero-base.so`) and `ADDR32`, each `0` on master; plus two exclusion witnesses that `GLOB_DAT`/`JMP_SLOT` stay unpatched. The `-B` case is the real discriminator — unrebased the slot already holds the answer.