### PR TITLE
Chop a noreturn call that ends its block ##analysis

### DIFF
--- a/libr/anal/block.c
+++ b/libr/anal/block.c
@@ -951,7 +951,12 @@ static bool noreturn_get_blocks_cb(void *user, const ut64 k, const void *v) {
 
 R_API RAnalBlock *r_anal_block_chop_noreturn(RAnalBlock *block, ut64 addr) {
 	R_RETURN_VAL_IF_FAIL (block, NULL);
-	if (!r_anal_block_contains (block, addr) || addr == block->addr) {
+	// A noreturn call that is the block's last instruction chops at the block
+	// end, which is not "contained". The size is already right; the edges out
+	// of it are not, and control does not reach them.
+	const bool ends_the_block = addr == block->addr + block->size;
+	if ((!r_anal_block_contains (block, addr) && !ends_the_block)
+			|| addr == block->addr) {
 		return block;
 	}
 	block = r_ref (block);

--- a/test/db/cmd/cmd_pdc
+++ b/test/db/cmd/cmd_pdc
@@ -1058,21 +1058,21 @@ s 0x400f43
 pdc~case ,goto loc_0x00400fbe
 EOF
 EXPECT=<<EOF
-            case 0: // 0x00400f7c
-            case 1: // 0x00400fb9
-                goto loc_0x00400fbe;
-            case 2: // 0x00400f83
-                goto loc_0x00400fbe;
-            case 3: // 0x00400f8a
-                goto loc_0x00400fbe;
-            case 4: // 0x00400f91
-                goto loc_0x00400fbe;
-            case 5: // 0x00400f98
-                goto loc_0x00400fbe;
-            case 6: // 0x00400f9f
-                goto loc_0x00400fbe;
-            case 7: // 0x00400fa6
-                goto loc_0x00400fbe;
+                case 0: // 0x00400f7c
+                case 1: // 0x00400fb9
+                    goto loc_0x00400fbe;
+                case 2: // 0x00400f83
+                    goto loc_0x00400fbe;
+                case 3: // 0x00400f8a
+                    goto loc_0x00400fbe;
+                case 4: // 0x00400f91
+                    goto loc_0x00400fbe;
+                case 5: // 0x00400f98
+                    goto loc_0x00400fbe;
+                case 6: // 0x00400f9f
+                    goto loc_0x00400fbe;
+                case 7: // 0x00400fa6
+                    goto loc_0x00400fbe;
 EOF
 RUN
 

--- a/test/db/cmd/cmd_pdc_ast
+++ b/test/db/cmd/cmd_pdc_ast
@@ -203,17 +203,15 @@ aaa
 pdct @ 0x400f43
 EOF
 EXPECT=<<EOF
-seq 0x00400f43
-  if 0x00400f43
-    bb 0x00400f65
+if-else 0x00400f43
   if-else 0x00400f6a
     bb 0x00400fad
     switch 0x00400f71
       seq 0x00400f7c
         bb 0x00400f7c
-        if 0x00400fbe
+        if-else 0x00400fbe
+          bb 0x00400fc9
           bb 0x00400fc4
-        bb 0x00400fc9
       seq 0x00400fb9
         bb 0x00400fb9
         goto 0x00400fbe
@@ -236,6 +234,7 @@ seq 0x00400f43
         bb 0x00400fa6
         goto 0x00400fbe
       goto 0x00400fad
+  bb 0x00400f65
 EOF
 RUN
 


### PR DESCRIPTION
`r_core_anal_propagate_noreturn` chops the caller's block after a call to a noreturn function, so control does not appear to continue past it. The chop is skipped whenever the call is the block's *last* instruction, which is the common case: `chop_addr` is then exactly `block->addr + block->size`, and `r_anal_block_contains` is a half-open test, so `r_anal_block_chop_noreturn` returns before clearing anything.

The block keeps the `jump`/`fail` it was built with, and the graph says control reaches the instruction after a call that never returns.

Repro on any binary where a noreturn function is discovered after its caller is analysed. In bzip2 compiled `-O2`, `cleanUpAndFail` calls `exit` and is reported `noreturn: true`, and its caller `mySIGSEGVorSIGBUScatcher` still has an edge out of the calling block:

```
$ r2 -qq -A -c 's 0x34f0; afbj~{}' bzip2 | grep -A2 3536
  { "addr": 13622, "size": 10, "jump": 13632, ...

$ r2 -qq -A -c 'af- 0x34f0; af @ 0x34f0; s 0x34f0; afbj~{}' bzip2 | grep -A2 3536
  { "addr": 13622, "size": 10, ...        # no jump
```

Re-analysing the function alone, after the propagation has run, gives the block no successor. During `-A` the caller's graph is built first and the propagation never revisits it.

Here the stale edge is a second entry into the loop `0x3524 -> 0x3536 -> 0x3540 -> 0x3524`, which makes it irreducible; without it those blocks do not form a cycle at all. Anything that structures loops sees a false irreducible region.

The size is already right when the call ends the block, so this only lets the function through to clear the outgoing edges and prune the successors that are no longer reachable. `r_anal_block_set_size` returns early on an unchanged size.
