### PR TITLE
Fix ELF import addresses and dropped CREL relocations ##bin

### DIFF
--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3682,14 +3682,16 @@ static size_t get_num_relocs_approx(ELFOBJ *eo) {
 
 static size_t populate_relocs_record_from_android(ELFOBJ *eo, size_t pos, size_t num_relocs) {
 	const RBinElfDynamicInfo *di = &eo->dyn_info;
-	if (di->dt_android_rel == R_BIN_ELF_ADDR_MAX || di->dt_android_relsz < 5) {
+	const ut64 relsz = di->dt_android_relsz;
+	// relsz is unvalidated file data, cap it before it narrows to int
+	if (di->dt_android_rel == R_BIN_ELF_ADDR_MAX || relsz < 5 || relsz > r_buf_size (eo->b)) {
 		return pos;
 	}
 	ut64 paddr = Elf_(v2p) (eo, di->dt_android_rel);
 	if (paddr == UT64_MAX) {
 		return pos;
 	}
-	const int size = (int)di->dt_android_relsz;
+	const int size = (int)relsz;
 	ut8 *buf = malloc (size);
 	if (!buf) {
 		return pos;

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3315,17 +3315,6 @@ typedef struct {
 	bool header_read; // Whether header has been read
 } CrelInfo;
 
-// Helper function to initialize a CrelInfo structure
-static bool init_crel_info(ELFOBJ *eo, ut64 section_offset, CrelInfo *info) {
-	R_RETURN_VAL_IF_FAIL (eo && info, false);
-	memset (info, 0, sizeof (CrelInfo));
-	info->section_offset = section_offset;
-	info->current_pos = section_offset;
-	info->header_read = false;
-	return true;
-}
-
-// Function to read a CREL header
 static bool read_crel_header(ELFOBJ *eo, CrelInfo *info) {
 	if (!info || info->header_read) {
 		return false;
@@ -3346,45 +3335,37 @@ static bool read_crel_header(ELFOBJ *eo, CrelInfo *info) {
 	return true;
 }
 
-// Function to read a CREL relocation entry
-static bool read_crel_reloc(ELFOBJ *eo, RBinElfReloc *r, ut64 vaddr, ut64 *next_offset) {
-	static CrelInfo crel_info = {0};
-	static ut64 last_section_offset = 0;
+// decodes one entry of the CREL stream that info is positioned in
+static bool read_crel_reloc(ELFOBJ *eo, CrelInfo *info, RBinElfReloc *r, ut64 vaddr, ut64 *next_offset) {
 	ut64 offset = Elf_(v2p) (eo, vaddr);
 	if (offset == UT64_MAX) {
 		return false;
 	}
-	// Check if we're processing a new section
-	if (offset != last_section_offset && offset != crel_info.current_pos) {
-		init_crel_info(eo, offset, &crel_info);
-		last_section_offset = offset;
+	// vaddr is neither the stream start nor its cursor: a new stream
+	if (offset != info->section_offset && offset != info->current_pos) {
+		memset (info, 0, sizeof (*info));
+		info->section_offset = offset;
+		info->current_pos = offset;
 	}
-	// Read the CREL header if we haven't already
-	if (!crel_info.header_read) {
-		if (!read_crel_header(eo, &crel_info)) {
+	if (!info->header_read) {
+		if (!read_crel_header (eo, info)) {
 			return false;
 		}
 	}
-	// Make sure we have relocations left to read
-	if (crel_info.count <= 0) {
+	if (info->count <= 0) {
 		return false;
 	}
-	// Read the next relocation entry
-	ut8 buf[64] = {0}; // Buffer for reading relocation data
-	int res = r_buf_read_at (eo->b, crel_info.current_pos, buf, sizeof (buf));
+	ut8 buf[64] = {0};
+	int res = r_buf_read_at (eo->b, info->current_pos, buf, sizeof (buf));
 	if (res <= 0) {
 		return false;
 	}
-	// Parse delta offset and flags
 	int read_pos = 0;
 	ut8 b = buf[read_pos++];
-	// Extract flags
-	int flag_bits = crel_info.addend_bit ? 3 : 2;
+	int flag_bits = info->addend_bit ? 3 : 2;
 	ut8 flags = b & ((1 << flag_bits) - 1);
-	// Extract delta offset
 	ut64 delta_offset = b >> flag_bits;
 	if (b & 0x80) {
-		// Handle large delta_offset
 		int bytes_read = 0;
 		ut64 high_bits = 0;
 		read_uleb128 (&buf[read_pos], sizeof (buf) - read_pos, &high_bits, &bytes_read);
@@ -3392,46 +3373,40 @@ static bool read_crel_reloc(ELFOBJ *eo, RBinElfReloc *r, ut64 vaddr, ut64 *next_
 		delta_offset = delta_offset | (high_bits << (7 - flag_bits));
 		delta_offset -= (0x80 >> flag_bits);
 	}
-	// Apply shift to delta_offset
-	crel_info.offset += (delta_offset << crel_info.shift);
-	// Handle delta symbol index if present
+	info->offset += (delta_offset << info->shift);
 	if (flags & 1) {
 		st64 delta_symidx = 0;
 		int bytes_read = 0;
 		read_sleb128 (&buf[read_pos], sizeof (buf) - read_pos, &delta_symidx, &bytes_read);
 		read_pos += bytes_read;
-		crel_info.symidx += delta_symidx;
+		info->symidx += delta_symidx;
 	}
-	// Handle delta type if present
 	if (flags & 2) {
 		st64 delta_type = 0;
 		int bytes_read = 0;
 		read_sleb128 (&buf[read_pos], sizeof (buf) - read_pos, &delta_type, &bytes_read);
 		read_pos += bytes_read;
-		crel_info.type += delta_type;
+		info->type += delta_type;
 	}
-	// Handle delta addend if present and addend_bit is set
-	if ((flags & 4) && crel_info.addend_bit) {
+	if ((flags & 4) && info->addend_bit) {
 		st64 delta_addend = 0;
 		int bytes_read = 0;
 		read_sleb128 (&buf[read_pos], sizeof (buf) - read_pos, &delta_addend, &bytes_read);
 		read_pos += bytes_read;
-		crel_info.addend += delta_addend;
+		info->addend += delta_addend;
 	}
-	// Update position for next read
-	crel_info.current_pos += read_pos;
-	crel_info.count--;
-	// Fill in the relocation structure
+	info->current_pos += read_pos;
+	info->count--;
 	r->mode = DT_CREL;
-	r->implicit_addend = !crel_info.addend_bit;
-	r->offset = crel_info.offset;  // This is the file offset
-	r->rva = crel_info.offset;     // Also store as RVA for now, will be adjusted in fix_rva_and_offset
-	r->sym = crel_info.symidx;
-	r->type = crel_info.type;
-	r->addend = crel_info.addend_bit ? crel_info.addend : 0;
-	// Return next offset if requested
+	r->implicit_addend = !info->addend_bit;
+	r->offset = info->offset;
+	// a file offset, not an rva yet: the callers fix it up
+	r->rva = info->offset;
+	r->sym = info->symidx;
+	r->type = info->type;
+	r->addend = info->addend_bit ? info->addend : 0;
 	if (next_offset) {
-		*next_offset = crel_info.current_pos - offset;
+		*next_offset = info->current_pos - offset;
 	}
 	return true;
 }
@@ -3549,12 +3524,11 @@ static size_t populate_relr_at(ELFOBJ *eo, ut64 vaddr, ut64 vsize, size_t pos, s
 
 static bool read_reloc(ELFOBJ *eo, RBinElfReloc *r, Elf_(Xword) rel_mode, ut64 vaddr) {
 	// RELR is fully expanded by populate_relr_at, not one entry at a time
-	// Handle CREL entries differently
 	if (rel_mode == DT_CREL) {
-		ut64 next_offset = 0;
-		return read_crel_reloc (eo, r, vaddr, &next_offset);
+		// one entry only, so decoder state does not outlive the call
+		CrelInfo crel = {0};
+		return read_crel_reloc (eo, &crel, r, vaddr, NULL);
 	}
-	// Regular REL/RELA processing
 	ut64 offset = Elf_(v2p) (eo, vaddr);
 	if (offset == UT64_MAX) {
 		return false;
@@ -3858,15 +3832,15 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 	// parse crel - Compact Relocations
 	if (di->dt_crel != R_BIN_ELF_ADDR_MAX) {
 		// CREL uses variable-length encoding, so we can't use the same approach as above
+		CrelInfo crel = {0};
 		ut64 next_offset = 0;
 		while (pos < num_relocs) {
 			RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
-			if (!read_crel_reloc (eo, reloc, di->dt_crel + next_offset, &next_offset)) {
+			if (!read_crel_reloc (eo, &crel, reloc, di->dt_crel + next_offset, &next_offset)) {
 				RVecRBinElfReloc_pop_back (&eo->g_relocs);
 				break;
 			}
 			rel_cache_add (eo, reloc);
-			// For CREL relocations from dynamic table, we need to convert offset to address
 			ut64 vaddr = Elf_(p2v) (eo, reloc->offset);
 			if (vaddr != UT64_MAX) {
 				reloc->rva = vaddr;
@@ -3996,40 +3970,41 @@ static size_t populate_relocs_record_from_section(ELFOBJ *eo, size_t pos, size_t
 			i++;
 			continue;
 		}
-		// Handle CREL sections differently since they use variable-length encoding
 		if (rel_mode == DT_CREL) {
+			const RBinElfDynamicInfo *di = &eo->dyn_info;
+			// already decoded by the dynamic dt_crel pass
+			bool aliases_dynamic = di->dt_crel != R_BIN_ELF_ADDR_MAX
+				&& di->dt_crel >= section->rva
+				&& di->dt_crel < section->rva + section->size;
+			if (aliases_dynamic) {
+				i++;
+				continue;
+			}
+			CrelInfo crel = {0};
 			ut64 next_offset = 0;
 			ut64 j = 0;
-			// Process all CREL relocations in the section
 			while (j < section->size && pos <= num_relocs) {
 				RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
-				if (!read_crel_reloc (eo, reloc, section->rva + j, &next_offset)) {
-					// If read_crel_reloc returns false, either we're done or encountered an error
-					// In either case, break the loop
+				if (!read_crel_reloc (eo, &crel, reloc, section->rva + j, &next_offset)) {
 					RVecRBinElfReloc_pop_back (&eo->g_relocs);
 					break;
 				}
 
 				rel_cache_add (eo, reloc);
-				// For CREL relocations from sections, make sure rva is properly set
 				if (is_bin_etrel (eo)) {
-					// For relocatable files, find target section
+					// ET_REL offsets are section-relative
 					if (has_valid_section_header (eo, i)) {
 						RBinElfSection *target_section = RVecRBinElfSection_at (&eo->g_sections, i);
 						size_t idx = target_section->info;
 						if (idx < eo->ehdr.e_shnum) {
-							// Map file offset to virtual address in target section
 							reloc->rva = eo->shdr[idx].sh_addr + reloc->offset;
 						}
 					}
 				} else {
-					// For executables, offset is target address
 					reloc->rva = reloc->offset;
 				}
 				fix_rva_and_offset (eo, reloc, i);
 				pos++;
-
-				// Move to next relocation
 				j += next_offset;
 			}
 		} else {

--- a/libr/bin/format/elf/elf.c
+++ b/libr/bin/format/elf/elf.c
@@ -3495,16 +3495,19 @@ static int relr_reloc_type(ut16 machine) {
 	return 0;
 }
 
+static void rel_cache_add(ELFOBJ *eo, const RBinElfReloc *reloc) {
+	// sym is unvalidated file data, widen before +1 to avoid overflow
+	ht_uu_insert (eo->rel_cache, (ut64)reloc->sym + 1, RVecRBinElfReloc_length (&eo->g_relocs));
+}
+
 static size_t add_relr_reloc(ELFOBJ *eo, ut64 vaddr, int type, size_t pos) {
 	RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
-	memset (reloc, 0, sizeof (*reloc));
 	reloc->mode = DT_RELR;
 	reloc->implicit_addend = true;
 	reloc->type = type;
 	reloc->offset = vaddr;
 	reloc->rva = vaddr;
-	int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-	ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+	rel_cache_add (eo, reloc);
 	fix_rva_and_offset_exec_file (eo, reloc);
 	return pos + 1;
 }
@@ -3780,15 +3783,13 @@ static size_t populate_relocs_record_from_android(ELFOBJ *eo, size_t pos, size_t
 				r_addend = 0;
 			}
 			RBinElfReloc *reloc = RVecRBinElfReloc_emplace_back (&eo->g_relocs);
-			memset (reloc, 0, sizeof (*reloc));
 			reloc->mode = is_rela? DT_RELA: DT_REL;
 			reloc->offset = r_offset;
 			reloc->rva = r_offset;
 			reloc->sym = ELF_R_SYM ((Elf_(Xword))info);
 			reloc->type = ELF_R_TYPE ((Elf_(Xword))info);
 			reloc->addend = is_rela? r_addend: 0;
-			int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-			ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+			rel_cache_add (eo, reloc);
 			fix_rva_and_offset_exec_file (eo, reloc);
 			pos++;
 		}
@@ -3820,8 +3821,7 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 		}
 
 		// XXX reloc is a weak pointer we can't own it!
-		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-		ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+		rel_cache_add (eo, reloc);
 		fix_rva_and_offset_exec_file (eo, reloc);
 	}
 	// parse relr - Relative relocations
@@ -3839,8 +3839,7 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 			RVecRBinElfReloc_pop_back (&eo->g_relocs);
 			break;
 		}
-		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-		ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+		rel_cache_add (eo, reloc);
 		fix_rva_and_offset_exec_file (eo, reloc);
 	}
 
@@ -3853,8 +3852,7 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 			RVecRBinElfReloc_pop_back (&eo->g_relocs);
 			break;
 		}
-		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-		ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+		rel_cache_add (eo, reloc);
 		fix_rva_and_offset_exec_file (eo, reloc);
 	}
 	// parse crel - Compact Relocations
@@ -3867,8 +3865,7 @@ static size_t populate_relocs_record_from_dynamic(ELFOBJ *eo, size_t pos, size_t
 				RVecRBinElfReloc_pop_back (&eo->g_relocs);
 				break;
 			}
-			int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-			ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+			rel_cache_add (eo, reloc);
 			// For CREL relocations from dynamic table, we need to convert offset to address
 			ut64 vaddr = Elf_(p2v) (eo, reloc->offset);
 			if (vaddr != UT64_MAX) {
@@ -3901,15 +3898,13 @@ static size_t populate_relocs_record_from_mips_got(ELFOBJ *eo, size_t pos, size_
 		if (!reloc) {
 			break;
 		}
-		memset (reloc, 0, sizeof (*reloc));
 		reloc->sym = (int)i;
 		reloc->type = R_MIPS_REL32;
 		reloc->mode = DT_REL;
 		reloc->implicit_addend = true;
 		reloc->offset = global_got + (i - gotsym) * wordsize;
 		fix_rva_and_offset_exec_file (eo, reloc);
-		int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-		ht_uu_insert (eo->rel_cache, reloc->sym + 1, index + 1);
+		rel_cache_add (eo, reloc);
 		pos++;
 	}
 	return pos;
@@ -4015,8 +4010,7 @@ static size_t populate_relocs_record_from_section(ELFOBJ *eo, size_t pos, size_t
 					break;
 				}
 
-				int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-				ht_uu_insert (eo->rel_cache, reloc->sym, index);
+				rel_cache_add (eo, reloc);
 				// For CREL relocations from sections, make sure rva is properly set
 				if (is_bin_etrel (eo)) {
 					// For relocatable files, find target section
@@ -4060,8 +4054,7 @@ static size_t populate_relocs_record_from_section(ELFOBJ *eo, size_t pos, size_t
 					break;
 				}
 
-				int index = (int)RVecRBinElfReloc_length (&eo->g_relocs) - 1;
-				ht_uu_insert (eo->rel_cache, reloc->sym, index);
+				rel_cache_add (eo, reloc);
 				fix_rva_and_offset (eo, reloc, i);
 				scount++;
 				pos++;

--- a/test/db/formats/elf/crelocs
+++ b/test/db/formats/elf/crelocs
@@ -18,6 +18,7 @@ nth paddr       size vaddr       vsize perm flags type     name
 vaddr      paddr      type   ntype name
 ---------------------------------------
 0x08000048 0x00000048 ADD_64 283   callee
+0x0800008c 0x0000008c ADD_64 261   .text
             ;-- section..text:
 / 20: sym.caller ();
 |           0x08000040      fd7bbfa9       stp x29, x30, [sp, -0x10]!  ; [02] -r-x section size 20 named .text
@@ -42,5 +43,34 @@ EXPECT=<<EOF
 0x08000035  0x00000006                                   ....
 0x0800003a  0x08000044                                   D...
 0x08000048  0x08000048                                   H...
+EOF
+RUN
+
+NAME=ELF: CREL relocs are parsed again for a second bin object
+FILE=bins/elf/new/compact-relocs.oo
+CMDS=<<EOF
+o bins/elf/new/compact-relocs.oo
+ob 1
+ir~ADD_64?
+EOF
+EXPECT=<<EOF
+2
+EOF
+RUN
+
+NAME=ELF: CREL ET_REL import pinned (no dynstr, no phdr: plt lookup masked)
+FILE=bins/elf/new/compact-relocs.oo
+CMDS=<<EOF
+ii
+ir
+EOF
+EXPECT=<<EOF
+nth vaddr      bind   type   lib name
+-------------------------------------
+7   ---------- GLOBAL NOTYPE     callee
+vaddr      paddr      type   ntype name
+---------------------------------------
+0x08000048 0x00000048 ADD_64 283   callee
+0x0800008c 0x0000008c ADD_64 261   .text
 EOF
 RUN

--- a/test/db/formats/elf/reloc
+++ b/test/db/formats/elf/reloc
@@ -1081,3 +1081,21 @@ EXPECT=<<EOF
 349
 EOF
 RUN
+
+NAME=ELF: .rela.plt reached only through the section pass keys imports by own symbol
+FILE=bins/fuzzed/elf8
+CMDS=<<EOF
+ii~raise,strncmp,sigemptyset,wcwidth,__fprintf_chk,__ctype_tolower_loc,_ITM_deregisterTMCloneTable,__gmon_start__,_ITM_registerTMCloneTable
+EOF
+EXPECT=<<EOF
+5   0x004021e0       GLOBAL FUNC       raise
+10  0x00402240       GLOBAL FUNC       strncmp
+11  ----------       WEAK   NOTYPE     _ITM_deregisterTMCloneTable
+65  0x004025a0       GLOBAL FUNC       sigemptyset
+66  ----------       WEAK   NOTYPE     __gmon_start__
+74  0x00402630       GLOBAL FUNC       wcwidth
+104 0x00402810       GLOBAL FUNC       __fprintf_chk
+105 ----------       WEAK   NOTYPE     _ITM_registerTMCloneTable
+111 0x00402870       GLOBAL FUNC       __ctype_tolower_loc
+EOF
+RUN

--- a/test/db/formats/sbpf/relocations
+++ b/test/db/formats/sbpf/relocations
@@ -34,3 +34,69 @@ vaddr      paddr      type   ntype name
 0x10000cd8 0x00000cd8 SET_64 8
 EOF
 RUN
+
+NAME=sBPF: imports resolve to their own first reloc site via the section pass
+FILE=bins/elf/sbpf_example.so
+ARGS=-B 0x10000000
+CMDS=<<EOF
+ii
+EOF
+EXPECT=<<EOF
+nth vaddr      bind   type   lib name
+-------------------------------------
+3   0x10002888 GLOBAL NOTYPE     abort
+4   0x10004ca8 GLOBAL NOTYPE     sol_log_
+5   0x10012b48 GLOBAL NOTYPE     sol_memcpy_
+6   0x10017288 GLOBAL NOTYPE     sol_get_rent_sysvar
+7   0x10018968 GLOBAL NOTYPE     sol_invoke_signed_rust
+8   0x10018f88 GLOBAL NOTYPE     sol_memset_
+9   0x1001db30 GLOBAL NOTYPE     sol_try_find_program_address
+10  0x1001dbf8 GLOBAL NOTYPE     sol_log_pubkey
+11  0x10020158 GLOBAL NOTYPE     sol_sha256
+12  0x10028ba0 GLOBAL NOTYPE     sol_memcmp_
+EOF
+RUN
+
+NAME=sBPF: v1 imports resolve to their own first reloc site via the section pass
+FILE=bins/elf/sbpf_example_v1.so
+ARGS=-B 0x10000000
+CMDS=<<EOF
+ii
+EOF
+EXPECT=<<EOF
+nth vaddr      bind   type   lib name
+-------------------------------------
+3   0x10002918 GLOBAL NOTYPE     abort
+4   0x10004d10 GLOBAL NOTYPE     sol_log_
+5   0x10012d68 GLOBAL NOTYPE     sol_memcpy_
+6   0x10017508 GLOBAL NOTYPE     sol_get_rent_sysvar
+7   0x10018c30 GLOBAL NOTYPE     sol_invoke_signed_rust
+8   0x10019268 GLOBAL NOTYPE     sol_memset_
+9   0x1001de98 GLOBAL NOTYPE     sol_try_find_program_address
+10  0x1001df68 GLOBAL NOTYPE     sol_log_pubkey
+11  0x100204e0 GLOBAL NOTYPE     sol_sha256
+12  0x10029178 GLOBAL NOTYPE     sol_memcmp_
+EOF
+RUN
+
+NAME=sBPF: v2 imports resolve to their own first reloc site via the section pass
+FILE=bins/elf/sbpf_example_v2.so
+ARGS=-B 0x10000000
+CMDS=<<EOF
+ii
+EOF
+EXPECT=<<EOF
+nth vaddr      bind   type   lib name
+-------------------------------------
+3   0x100028c0 GLOBAL NOTYPE     abort
+4   0x10004c58 GLOBAL NOTYPE     sol_log_
+5   0x10012f10 GLOBAL NOTYPE     sol_memcpy_
+6   0x100176f0 GLOBAL NOTYPE     sol_get_rent_sysvar
+7   0x10018dd8 GLOBAL NOTYPE     sol_invoke_signed_rust
+8   0x10019418 GLOBAL NOTYPE     sol_memset_
+9   0x1001e008 GLOBAL NOTYPE     sol_try_find_program_address
+10  0x1001e0d8 GLOBAL NOTYPE     sol_log_pubkey
+11  0x10020580 GLOBAL NOTYPE     sol_sha256
+12  0x10029130 GLOBAL NOTYPE     sol_memcmp_
+EOF
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

```
$ r2 -N -qc ii bins/elf/sbpf_example.so
3   0x00021330 GLOBAL NOTYPE     abort
4   0x00021310 GLOBAL NOTYPE     sol_log_
```

abort's first relocation site is 0x2888, sol_log_'s is 0x4ca8. rel_cache was written in two key conventions: the two section-pass writers stored a bare sym/index where both readers decode sym + 1/index + 1, so a lookup for symbol N found N+1's entry and then read one slot early. A rel_cache_add() helper now owns the encoding for all nine writers.

Dropped CREL relocations. ir on bins/elf/new/compact-relocs.oo prints one relocation; llvm-readelf -r reports two. read_crel_reloc() kept its decode cursor in function-static variables, so every CREL section after the first was treated as a continuation of the previous one and lost. The state is now caller-owned.

dt_android_relsz is narrowed to a signed int before malloc; it is capped against r_buf_size() first.

## Tests

db/formats/sbpf/relocations and db/formats/elf/reloc pin the import addresses; both fail on master. The crelocs golden gains the .crel.eh_frame row it should always have had — that move is the CREL bug being fixed, and it matches llvm-readelf. The android cap is a malformed-input guard with no fixture.
