### PR TITLE
Keep the load-time mach0 relocs when bin.relocs.apply is set ##bin

### DIFF
--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -559,6 +559,9 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 
 	ut64 offset = 0;
 	RIOBank *bank = iob->bank_get (io, io->bank);
+	if (!bank) {
+		goto beach;
+	}
 	RListIter *iter;
 	RIOMapRef *mapref;
 	r_list_foreach (bank->maprefs, iter, mapref) {
@@ -619,6 +622,16 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	}
 	if (RVecRBinReloc_empty (ret)) {
 		goto beach;
+	}
+	// this vector replaces the whole table, so move the load-time rows in
+	RVecRBinReloc *loaded = relocs (bf);
+	if (loaded) {
+		RBinReloc *r;
+		R_VEC_FOREACH (loaded, r) {
+			RVecRBinReloc_push_back (ret, r);
+			r->import = NULL;
+		}
+		RVecRBinReloc_free (loaded);
 	}
 	ht_uu_free (relocs_by_sym);
 	RVecExtReloc_fini (&ext_relocs);

--- a/libr/bin/p/bin_mach0.c
+++ b/libr/bin/p/bin_mach0.c
@@ -315,18 +315,12 @@ static bool imports_vec(RBinFile *bf) {
 	return true;
 }
 
-static RVecRBinReloc *relocs(RBinFile *bf) {
-	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
-	struct MACH0_(obj_t) *mo = bf->bo->bin_obj;
-	const RSkipList *relocs = MACH0_(load_relocs) (mo);
-	if (!relocs) {
-		return NULL;
-	}
-	RVecRBinReloc *ret = RVecRBinReloc_new ();
-
+// the load-time rows: every non-external reloc, then the chained fixups
+static void append_load_relocs(RBinFile *bf, RBinObject *bo, const RSkipList *relocs, RVecRBinReloc *ret) {
+	struct MACH0_(obj_t) *mo = bo->bin_obj;
 	RVecRBinImport *imports = mo->imports_loaded
 		? &mo->imports_cache
-		: &bf->bo->imports_vec;
+		: &bo->imports_vec;
 	RSkipListNode *it;
 	struct reloc_t *reloc;
 	r_skiplist_foreach (relocs, it, reloc) {
@@ -358,6 +352,17 @@ static RVecRBinReloc *relocs(RBinFile *bf) {
 		ptr->paddr = r->vaddr;
 		ptr->addend = r->vaddr;
 	}
+}
+
+static RVecRBinReloc *relocs(RBinFile *bf) {
+	R_RETURN_VAL_IF_FAIL (bf && bf->bo && bf->bo->bin_obj, NULL);
+	struct MACH0_(obj_t) *mo = bf->bo->bin_obj;
+	const RSkipList *relocs = MACH0_(load_relocs) (mo);
+	if (!relocs) {
+		return NULL;
+	}
+	RVecRBinReloc *ret = RVecRBinReloc_new ();
+	append_load_relocs (bf, bf->bo, relocs, ret);
 	return ret;
 }
 
@@ -623,19 +628,11 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 	if (RVecRBinReloc_empty (ret)) {
 		goto beach;
 	}
-	// this vector replaces the whole table, so move the load-time rows in
-	RVecRBinReloc *loaded = relocs (bf);
-	if (loaded) {
-		RBinReloc *r;
-		R_VEC_FOREACH (loaded, r) {
-			RVecRBinReloc_push_back (ret, r);
-			r->import = NULL;
-		}
-		RVecRBinReloc_free (loaded);
-	}
+	// this vector replaces the whole table, so it carries the load-time rows
+	append_load_relocs (bf, obj, all_relocs, ret);
 	ht_uu_free (relocs_by_sym);
 	RVecExtReloc_fini (&ext_relocs);
-	// XXX r_io_desc_free (gotr2desc);
+	// io owns gotr2desc from here: its map serves the patched slots
 	return ret;
 
 beach:

--- a/test/db/formats/mach0/relocs
+++ b/test/db/formats/mach0/relocs
@@ -1,0 +1,85 @@
+NAME=mach0 relocs apply keeps the load-time table, its flags and the slot writes
+FILE=bins/mach0/FileDP
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+ir~0x[0,1,2,3,4]
+f~reloc.[0,2]
+p8 4 @ 0x4074
+p8 4 @ 0x4084
+p8 4 @ 0x40a4
+EOF
+EXPECT=<<EOF
+0x00000000 0x00000000 SET_32 6 NSAutoreleasePool
+0x00003020 0x00002020 SET_32 6 exit
+0x00003024 0x00002024 SET_32 6 NSFileProtectionKey
+0x00003028 0x00002028 SET_32 6 NSLog
+0x0000302c 0x0000202c SET_32 6 objc_enumerationMutation
+0x00003030 0x00002030 SET_32 6 objc_msgSend
+0x00003034 0x00002034 SET_32 6 puts
+0x00003038 0x00002038 SET_32 6 strcmp
+0x00006000 0x00000000 UNKNOWN 0 NSAutoreleasePool
+0x00006004 0x00000000 UNKNOWN 0 NSFileManager
+0x00006008 0x00000000 UNKNOWN 0 NSString
+0x0000600c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+0x0000600c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+0x0000600c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+0x00003020 reloc.exit
+0x00003024 reloc.NSFileProtectionKey
+0x00003028 reloc.NSLog
+0x0000302c reloc.objc_enumerationMutation
+0x00003030 reloc.objc_msgSend
+0x00003034 reloc.puts
+0x00003038 reloc.strcmp
+0x00006000 reloc.NSAutoreleasePool
+0x00006004 reloc.NSFileManager
+0x00006008 reloc.NSString
+0x0000600c reloc.__CFConstantStringClassReference
+00600000
+0c604002
+0c600000
+EOF
+RUN
+
+NAME=mach0 relocs apply bin.limit truncates the combined table, slots first
+FILE=bins/mach0/FileDP
+ARGS=-e bin.relocs.apply=true -e bin.limit=8
+CMDS=ir~0x[0,1,2,3,4]
+EXPECT=<<EOF
+0x00000000 0x00000000 SET_32 6 NSAutoreleasePool
+0x00003020 0x00002020 SET_32 6 exit
+0x00006030 0x00000000 UNKNOWN 0 NSAutoreleasePool
+0x00006034 0x00000000 UNKNOWN 0 NSFileManager
+0x00006038 0x00000000 UNKNOWN 0 NSString
+0x0000603c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+0x0000603c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+0x0000603c 0x00000000 UNKNOWN 0 __CFConstantStringClassReference
+EOF
+RUN
+
+NAME=mach0 relocs apply with no io bank
+FILE=bins/mach0/FileDP
+CMDS=<<EOF
+omb-0
+e bin.relocs.apply=true
+ir~0x[0,1,2,3,4]
+EOF
+EXPECT=<<EOF
+0x00000000 0x00000000 SET_32 6 NSAutoreleasePool
+0x00003020 0x00002020 SET_32 6 exit
+0x00003024 0x00002024 SET_32 6 NSFileProtectionKey
+0x00003028 0x00002028 SET_32 6 NSLog
+0x0000302c 0x0000202c SET_32 6 objc_enumerationMutation
+0x00003030 0x00002030 SET_32 6 objc_msgSend
+0x00003034 0x00002034 SET_32 6 puts
+0x00003038 0x00002038 SET_32 6 strcmp
+EOF
+RUN
+
+NAME=mach0 relocs apply is inert without external relocs
+FILE=bins/mach0/ls-m1
+ARGS=-a arm -b 64 -e bin.relocs.apply=true
+CMDS=ir~?
+EXPECT=<<EOF
+201
+EOF
+RUN

--- a/test/db/leak/open
+++ b/test/db/leak/open
@@ -64,6 +64,19 @@ hello
 EOF
 RUN
 
+NAME=leak macho patched relocs
+FILE=bins/mach0/FileDP
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF
+?e hello
+EOF
+EXPECT=<<EOF
+hello
+EOF
+# the harness only parses LEAK SUMMARY, so an invalid free needs its own check
+REGEXP_ERR=ERROR SUMMARY: 0 errors
+RUN
+
 NAME=leak opening java class
 FILE=bins/java/Hello.class
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

On a Mach-O with classic external relocations, `bin.relocs.apply=true` does not add the patched entries to the reloc table, it replaces the table — so every relocation the loader found disappears from `ir`, from the `reloc.` flags and from `r_bin_reloc_at`:

```
$ r2 -N -e bin.relocs.apply=false -qc ir bins/mach0/FileDP
vaddr      paddr      type   ntype name
---------------------------------------
0x00000000 0x00000000 SET_32 6     NSAutoreleasePool
0x00003020 0x00002020 SET_32 6     exit
0x00003024 0x00002024 SET_32 6     NSFileProtectionKey
0x00003028 0x00002028 SET_32 6     NSLog
0x0000302c 0x0000202c SET_32 6     objc_enumerationMutation
0x00003030 0x00002030 SET_32 6     objc_msgSend
0x00003034 0x00002034 SET_32 6     puts
0x00003038 0x00002038 SET_32 6     strcmp

$ r2 -N -e bin.relocs.apply=true -qc ir bins/mach0/FileDP
vaddr      paddr      type    ntype name
----------------------------------------
0x00006000 0x00000000 UNKNOWN 0     NSAutoreleasePool
0x00006004 0x00000000 UNKNOWN 0     NSFileManager
0x00006008 0x00000000 UNKNOWN 0     NSString
0x0000600c 0x00000000 UNKNOWN 0     __CFConstantStringClassReference
0x0000600c 0x00000000 UNKNOWN 0     __CFConstantStringClassReference
0x0000600c 0x00000000 UNKNOWN 0     __CFConstantStringClassReference
```

## The fix

- `relocs()` skips `reloc->external` and `patch_relocs()` returns only those, so the two callbacks build disjoint tables. `patch_relocs` now moves the load-time rows into the vector it returns, which is the one that replaces `bo->relocs`.
- Rows own their `RBinImport`, so the move nulls the source pointer before the source vector is freed.
- It happens after the `RVecRBinReloc_empty (ret)` bail-out, so "no slot survived, keep the load-time table" still returns NULL, and the `.got.r2` rows stay first in the vector, which is what `bin.limit` truncates from.
- `bank_get` can return NULL and was dereferenced on the next line.

Two visible choices worth confirming: under `bin.limit` the truncation keeps the `.got.r2` rows, as it does today; and where a load-time row and a slot row share an import, `ir` lists both while `f` keeps one `reloc.<name>`, at the slot.

## Tests

New `db/formats/mach0/relocs`: three cases on `FileDP`, the only file in `test/bins/mach0` with external relocs, and one on `ls-m1` where the fix must be inert. Reverting `bin_mach0.c` turns the three XX; the `bin.limit` case also fails if the merge is placed before the bail-out instead of after it. `db/leak/open` gains a patched-relocs open, asserting `ERROR SUMMARY: 0 errors` because the harness's leak check reads only the LEAK summary.