### PR TITLE
Expose the relocation at an address and the named symbols through RBinBind ##bin

### DIFF
--- a/libr/bin/bin.c
+++ b/libr/bin/bin.c
@@ -1053,6 +1053,13 @@ R_API RBinReloc *r_bin_reloc_at(RVecRBinReloc *relocs, ut64 vaddr, int size) {
 	return (lo < len && a[lo].vaddr < vaddr + size)? &a[lo]: NULL;
 }
 
+// the relocation recorded against exactly vaddr, or NULL
+static RBinReloc *get_reloc_at(RBin *bin, ut64 vaddr) {
+	R_RETURN_VAL_IF_FAIL (bin, NULL);
+	RVecRBinReloc *relocs = r_bin_get_relocs (bin);
+	return relocs? r_bin_reloc_at (relocs, vaddr, 1): NULL;
+}
+
 R_API RVecRBinSection *r_bin_get_sections_vec(RBin *bin) {
 	R_RETURN_VAL_IF_FAIL (bin, NULL);
 	RBinObject *o = r_bin_cur_object (bin);
@@ -1801,6 +1808,8 @@ R_API void r_bin_bind(RBin *bin, RBinBind *b) {
 		b->get_vsect_at = __get_vsection_at;
 		b->get_symbols_vec = r_bin_get_symbols_vec;
 		b->get_symbol_at = r_bin_get_symbol_at;
+		b->get_sym = r_bin_get_sym;
+		b->get_reloc_at = get_reloc_at;
 		b->demangle = r_bin_demangle;
 	}
 }

--- a/libr/include/r_bin.h
+++ b/libr/include/r_bin.h
@@ -910,7 +910,9 @@ typedef char *(*RBinDemangle)(RBinFile *bf, const char *def, const char *str, ut
 typedef ut64 (*RBinBaddr)(RBinFile *bf, ut64 addr);
 typedef RVecRBinSymbol *(*RBinGetSymbolsVec)(RBin *bin);
 typedef RBinSymbol *(*RBinGetSymbolAt)(RBin *bin, ut64 addr);
+typedef RBinReloc *(*RBinGetRelocAt)(RBin *bin, ut64 vaddr);
 typedef const char *(*RBinGetCC)(RBin *bin, ut64 vaddr);
+typedef RBinAddr *(*RBinGetSym)(RBin *bin, int sym);
 
 typedef struct r_bin_bind_t {
 	RBin *bin;
@@ -921,11 +923,14 @@ typedef struct r_bin_bind_t {
 	RBinGetSectionAt get_vsect_at;
 	RBinGetSymbolsVec get_symbols_vec;
 	RBinGetSymbolAt get_symbol_at;
+	RBinGetSym get_sym;
 	RBinDemangle demangle;
 	RBinAddrLineAdd addrline_add;
 	RBinAddrLineGet addrline_get;
 	RBinBaddr baddr;
 	ut32 visibility;
+	// the relocation recorded against exactly this address, if any
+	RBinGetRelocAt get_reloc_at;
 } RBinBind;
 
 R_API void r_bin_info_free(RBinInfo *rb);


### PR DESCRIPTION
Two lookups an analysis holding only the `RBinBind` could not make.

- `get_reloc_at (bin, vaddr)`: the relocation recorded against exactly that address, or NULL. A jump through a slot that a relocation fills is a call to whatever the relocation names; without this, `libr/anal` sees only a load from an address and cannot say what it loads.
- `get_sym (bin, sym)`: the named binary symbols (`R_BIN_SYM_MAIN`, `R_BIN_SYM_ENTRY`, ...), the same `r_bin_get_sym` core already uses.

Both are thin binders over existing `RBin` functions; no new logic.

Split out of #26701.
