### PR TITLE
Count a dirty epoch on functions and on the type database ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -122,6 +122,7 @@ R_API const char *r_anal_function_cc(RAnalFunction *fcn) {
 		resolved = "reg";
 	}
 	fcn->callconv = r_str_constpool_get (&anal->constpool, resolved);
+	r_anal_function_bump_dirty_epoch (fcn);
 	return fcn->callconv;
 }
 
@@ -2544,6 +2545,7 @@ R_API bool r_anal_function_del_signature(RAnal *a, const char *name) {
 	free (sdb_noreturn);
 	free (sdb_args);
 	free (sdb_func);
+	r_anal_types_bump_dirty_epoch (a);
 	return true;
 }
 
@@ -2990,6 +2992,8 @@ R_API bool r_anal_function_set_signature(RAnal *anal, RAnalFunction *fcn, const 
 			function_signature_sync (fcn, signature);
 			r_anal_function_signature_free (signature);
 		}
+		r_anal_types_bump_dirty_epoch (anal);
+		r_anal_function_bump_dirty_epoch (fcn);
 	}
 	return ok;
 }

--- a/libr/anal/function.c
+++ b/libr/anal/function.c
@@ -237,6 +237,7 @@ R_API bool r_anal_function_relocate(RAnalFunction *fcn, ut64 addr) {
 	ht_up_delete (fcn->anal->ht_addr_fun, fcn->addr);
 	fcn->addr = addr;
 	ht_up_insert (fcn->anal->ht_addr_fun, addr, fcn);
+	r_anal_function_bump_dirty_epoch (fcn);
 	return true;
 }
 
@@ -265,6 +266,7 @@ R_API bool r_anal_function_rename(RAnalFunction *fcn, const char *name) {
 			REventFunction event = { .addr = fcn->addr, .fcn = fcn };
 			r_event_send (anal->ev, R_EVENT_FUNCTION_RENAMED, &event);
 		}
+		r_anal_function_bump_dirty_epoch (fcn);
 		return true;
 	}
 	return false;
@@ -410,6 +412,38 @@ R_API int r_anal_function_coverage(RAnalFunction *fcn) {
 		}
 	}
 	return (traced * 100) / total;
+}
+
+R_API ut64 r_anal_function_dirty_epoch(const RAnalFunction *fcn) {
+	R_RETURN_VAL_IF_FAIL (fcn, 0);
+	return fcn->dirty_epoch;
+}
+
+R_API ut64 r_anal_function_bump_dirty_epoch(RAnalFunction *fcn) {
+	R_RETURN_VAL_IF_FAIL (fcn, 0);
+	fcn->dirty_epoch++;
+	if (!fcn->dirty_epoch) {
+		fcn->dirty_epoch++;
+	}
+	fcn->has_changed = true;
+	return fcn->dirty_epoch;
+}
+
+R_API bool r_anal_function_set_callconv(RAnal *anal, RAnalFunction *fcn, const char *callconv) {
+	R_RETURN_VAL_IF_FAIL (anal && fcn && R_STR_ISNOTEMPTY (callconv), false);
+	if (!r_anal_cc_exist (anal, callconv)) {
+		return false;
+	}
+	const char *pooled = r_str_constpool_get (&anal->constpool, callconv);
+	if (!pooled) {
+		return false;
+	}
+	if (fcn->callconv && !strcmp (fcn->callconv, pooled)) {
+		return true;
+	}
+	fcn->callconv = pooled;
+	r_anal_function_bump_dirty_epoch (fcn);
+	return true;
 }
 
 static void fcn_context_reg_arg_free(RAnalFcnRegArg *arg) {

--- a/libr/anal/global.c
+++ b/libr/anal/global.c
@@ -32,7 +32,7 @@ R_API bool r_anal_global_add(RAnal *anal, ut64 addr, const char *type_name, cons
 	}
 	r_meta_set (anal, R_META_TYPE_FORMAT, addr, fmtsize, fmtstr);
 	// implicit
-	r_type_set_link (anal->sdb_types, fmtstr, addr);
+	r_anal_types_set_link (anal, fmtstr, addr);
 	return true;
 }
 
@@ -42,7 +42,7 @@ R_API bool r_anal_global_del(RAnal *anal, ut64 addr) {
 		RFlag *flags = anal->flb.f;
 		r_meta_del (anal, R_META_TYPE_FORMAT, addr, 0);
 		r_flag_unset (flags, fi);
-		r_type_unlink (anal->sdb_types, addr);
+		r_anal_types_unlink (anal, addr);
 		return true;
 	}
 	return false;

--- a/libr/anal/type.c
+++ b/libr/anal/type.c
@@ -106,6 +106,7 @@ R_IPI void r_anal_types_ensure_loaded(RAnal *anal) {
 	load_types_from (anal, "types-%s-%s-%d", arch, os, bits);
 	priv->types_dirty = false;
 	priv->types_loaded_bits = bits;
+	r_anal_types_bump_dirty_epoch (anal);
 }
 
 R_API void r_anal_types_reload(RAnal *anal, const char *dir_prefix, const char *os, const char *subsystem) {
@@ -150,11 +151,13 @@ R_API void r_anal_types_reload(RAnal *anal, const char *dir_prefix, const char *
 	load_types_from (anal, "types-%s-%s-%d", arch, os, bits);
 	priv->types_dirty = false;
 	priv->types_loaded_bits = bits;
+	r_anal_types_bump_dirty_epoch (anal);
 }
 
 R_API void r_anal_types_load_sdb(RAnal *anal, const char *name) {
 	R_RETURN_IF_FAIL (anal && name);
 	load_types_from (anal, "%s", name);
+	r_anal_types_bump_dirty_epoch (anal);
 }
 
 // a pointer is one target word wide, which r_type_get_bitsize cannot know from the sdb alone
@@ -195,6 +198,7 @@ R_API void r_anal_remove_parsed_type(RAnal *anal, const char *name) {
 	}
 	ls_free (l);
 	free (subkey);
+	r_anal_types_bump_dirty_epoch (anal);
 }
 
 // RENAME TO r_anal_types_save(); // parses the string and imports the types
@@ -223,6 +227,7 @@ R_API void r_anal_save_parsed_type(RAnal *anal, const char *parsed) {
 
 	// Now add the type to sdb.
 	sdb_query_lines (anal->sdb_types, parsed);
+	r_anal_types_bump_dirty_epoch (anal);
 }
 
 R_API bool r_anal_import_c_decls(RAnal *anal, const char *decls, char **errmsg) {
@@ -611,6 +616,47 @@ static void save_composite(const RAnal *anal, const RAnalBaseType *type) {
 	free (sname);
 }
 
+R_API ut64 r_anal_types_dirty_epoch(const RAnal *anal) {
+	R_RETURN_VAL_IF_FAIL (anal, 0);
+	return anal->type_dirty_epoch;
+}
+
+R_API ut64 r_anal_types_bump_dirty_epoch(RAnal *anal) {
+	R_RETURN_VAL_IF_FAIL (anal, 0);
+	anal->type_dirty_epoch++;
+	if (!anal->type_dirty_epoch) {
+		anal->type_dirty_epoch++;
+	}
+	return anal->type_dirty_epoch;
+}
+
+R_API bool r_anal_types_set_link(RAnal *anal, const char *type, ut64 addr) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && R_STR_ISNOTEMPTY (type), false);
+	if (r_type_set_link (anal->sdb_types, type, addr) <= 0) {
+		return false;
+	}
+	r_anal_types_bump_dirty_epoch (anal);
+	return true;
+}
+
+R_API bool r_anal_types_set_link_offset(RAnal *anal, const char *type, ut64 addr) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && R_STR_ISNOTEMPTY (type), false);
+	if (r_type_link_offset (anal->sdb_types, type, addr) <= 0) {
+		return false;
+	}
+	r_anal_types_bump_dirty_epoch (anal);
+	return true;
+}
+
+R_API bool r_anal_types_unlink(RAnal *anal, ut64 addr) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types, false);
+	if (r_type_unlink (anal->sdb_types, addr) <= 0) {
+		return false;
+	}
+	r_anal_types_bump_dirty_epoch (anal);
+	return true;
+}
+
 static void save_enum(const RAnal *anal, const RAnalBaseType *type) {
 	R_RETURN_IF_FAIL (anal && type && type->name);
 	R_RETURN_IF_FAIL (type->kind == R_ANAL_BASE_TYPE_KIND_ENUM);
@@ -783,4 +829,5 @@ R_API void r_anal_save_base_type(const RAnal *anal, const RAnalBaseType *type) {
 	default:
 		break;
 	}
+	r_anal_types_bump_dirty_epoch ((RAnal *)anal);
 }

--- a/libr/anal/var.c
+++ b/libr/anal/var.c
@@ -297,6 +297,7 @@ R_API RAnalVar *r_anal_function_set_var(RAnalFunction *fcn, int delta, char kind
 		free (var->type);
 	}
 	R_DIRTY_SET (fcn->anal);
+	r_anal_function_bump_dirty_epoch (fcn);
 	var->name = strdup (name);
 	var->regname = reg? strdup (reg->name): NULL; // TODO: no strdup here? pool? or not keep regname at all?
 	var->type = strdup (type);
@@ -325,6 +326,7 @@ R_API void r_anal_var_set_type(RAnal *anal, RAnalVar *var, const char * const ty
 	if (nt) {
 		free (var->type);
 		var->type = nt;
+		r_anal_function_bump_dirty_epoch (var->fcn);
 		R_LOG_DEBUG ("set type %s for %s", type, var->name);
 		shadow_interior_vars (anal, var);
 		{
@@ -760,6 +762,7 @@ R_API bool r_anal_var_rename(RAnal *anal, RAnalVar *var, const char *new_name) {
 	}
 	free (var->name);
 	var->name = nn;
+	r_anal_function_bump_dirty_epoch (var->fcn);
 	{
 		REventVariable event = { .fcn = var->fcn, .var = var, .name = nn };
 		r_event_send (anal->ev, R_EVENT_VARIABLE_NAME_CHANGED, &event);

--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -6878,15 +6878,13 @@ static int cmd_af(RCore *core, const char *input) {
 			r_cons_println (core->cons, r_anal_function_cc (fcn));
 			break;
 		case ' ': { // "afc "
-				  char *cc = r_str_trim_dup (input + 3);
-				  if (!r_anal_cc_exist (core->anal, cc)) {
-					  const char *asmOs = r_config_get (core->config, "asm.os");
-					  R_LOG_ERROR ("afc: Unknown calling convention '%s' for '%s'. See afcl for available types", cc, asmOs);
-				  } else {
-					  fcn->callconv = r_str_constpool_get (&core->anal->constpool, cc);
-				  }
-				  free (cc);
-			  }
+			char *cc = r_str_trim_dup (input + 3);
+			if (!r_anal_function_set_callconv (core->anal, fcn, cc)) {
+				const char *asmOs = r_config_get (core->config, "asm.os");
+				R_LOG_ERROR ("afc: Unknown calling convention '%s' for '%s'. See afcl for available types", cc, asmOs);
+			}
+			free (cc);
+		}
 			break;
 		case 'i':
 			if (input[3] == 'j') {
@@ -7035,6 +7033,7 @@ static int cmd_af(RCore *core, const char *input) {
 			if (fcn) { // bits = 0 means unset
 				int nbits = atoi (input + 3);
 				int obits = core->anal->config->bits;
+				int oldbits = fcn->bits;
 				if (nbits > 0) {
 					r_anal_hint_set_bits (core->anal, r_anal_function_min_addr (fcn), nbits);
 					r_anal_hint_set_bits (core->anal, r_anal_function_max_addr (fcn), obits);
@@ -7042,6 +7041,9 @@ static int cmd_af(RCore *core, const char *input) {
 				} else {
 					r_anal_hint_unset_bits (core->anal, r_anal_function_min_addr (fcn));
 					fcn->bits = 0;
+				}
+				if (oldbits != fcn->bits) {
+					r_anal_function_bump_dirty_epoch (fcn);
 				}
 			} else {
 				R_LOG_ERROR ("afB: Cannot find function to set bits at 0x%08"PFMT64x, core->addr);
@@ -7138,7 +7140,11 @@ static int cmd_af(RCore *core, const char *input) {
 		{
 			RAnalFunction *fcn = r_anal_get_fcn_in (core->anal, core->addr, -1);
 			if (fcn) {
-				fcn->maxstack = r_num_math (core->num, input + 3);
+				st64 maxstack = r_num_math (core->num, input + 3);
+				if (fcn->maxstack != maxstack) {
+					fcn->maxstack = maxstack;
+					r_anal_function_bump_dirty_epoch (fcn);
+				}
 			} else {
 				R_LOG_ERROR ("Cannot find function at 0x%08"PFMT64x, core->addr);
 			}
@@ -12725,7 +12731,7 @@ static void cmd_anal_hint(RCore *core, const char *input) {
 						// TODO: I don't think we should silently error, it is confusing
 						if (!strcmp (type, otype)) {
 							//eprintf ("Adding type offset %s\n", type);
-							r_type_link_offset (a->sdb_types, type, addr);
+							r_anal_types_set_link_offset (a, type, addr);
 							r_anal_hint_set_offset (a, addr, otype);
 							break;
 						}

--- a/libr/core/cmd_type.inc.c
+++ b/libr/core/cmd_type.inc.c
@@ -2977,7 +2977,7 @@ static int cmd_type(void *data, const char *input) {
 			r_str_trim (type);
 			char *tmp = sdb_get (TDB, type, 0);
 			if (R_STR_ISNOTEMPTY (tmp)) {
-				r_type_set_link (TDB, type, addr);
+				r_anal_types_set_link (core->anal, type, addr);
 				RList *fcns = r_anal_get_functions_in (core->anal, core->addr);
 				if (r_list_length (fcns) > 1) {
 					R_LOG_ERROR ("Multiple functions found in here");
@@ -3015,7 +3015,7 @@ static int cmd_type(void *data, const char *input) {
 			case ' ': {
 				const char *ptr = input + 3;
 				ut64 addr = r_num_math (core->num, ptr);
-				r_type_unlink (TDB, addr);
+				r_anal_types_unlink (core->anal, addr);
 				break;
 			}
 			}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -359,6 +359,7 @@ typedef struct r_anal_function_t {
 	RVecAnalVarPtr vars;
 	HtUP/*<st64, RVecAnalVarPtr *>*/ *inst_vars; // offset of instructions => the variables they access
 	ut64 reg_save_area; // size of stack area pre-reserved for saving registers
+	ut64 dirty_epoch; // incremented when typed function metadata changes
 	st64 bp_off; // offset of bp inside owned stack frame
 	st64 stack;  // stack frame size
 	int maxstack;
@@ -562,6 +563,7 @@ typedef struct r_anal_t {
 	Sdb *sdb_cc; // calling conventions
 	Sdb *sdb_classes;
 	Sdb *sdb_classes_attrs;
+	ut64 type_dirty_epoch; // incremented when global typed metadata changes
 	RAnalCallbacks cb;
 	RAnalOptions opt;
 	RList *reflines;
@@ -1271,6 +1273,9 @@ R_API void r_anal_function_signature_free(RAnalFunctionSignature *signature);
 R_API char *r_anal_function_get_signature_string(RAnalFunction *function);
 R_API bool r_anal_function_set_signature(RAnal *anal, RAnalFunction *fcn, const RAnalFunctionSignature *signature);
 R_API bool r_anal_function_del_signature(RAnal *a, const char *name);
+R_API ut64 r_anal_function_dirty_epoch(const RAnalFunction *fcn);
+R_API ut64 r_anal_function_bump_dirty_epoch(RAnalFunction *fcn);
+R_API bool r_anal_function_set_callconv(RAnal *anal, RAnalFunction *fcn, const char *callconv);
 R_API RAnalFcnContext *r_anal_function_context_collect(RAnal *anal, RAnalFunction *fcn);
 R_API void r_anal_function_context_free(RAnalFcnContext *ctx);
 R_API int r_anal_str_to_fcn(RAnal *a, RAnalFunction *f, const char *_str);
@@ -1817,6 +1822,11 @@ R_API bool r_anal_esil_dfg_reg_is_const(RAnalEsilDFG *dfg, const char *reg);
 R_API RList *r_anal_types_from_fcn(RAnal *anal, RAnalFunction *fcn);
 
 R_API RAnalBaseType *r_anal_get_base_type(RAnal *anal, const char *name);
+R_API ut64 r_anal_types_dirty_epoch(const RAnal *anal);
+R_API ut64 r_anal_types_bump_dirty_epoch(RAnal *anal);
+R_API bool r_anal_types_set_link(RAnal *anal, const char *type, ut64 addr);
+R_API bool r_anal_types_set_link_offset(RAnal *anal, const char *type, ut64 addr);
+R_API bool r_anal_types_unlink(RAnal *anal, ut64 addr);
 R_API RList *r_anal_types_baselist(RAnal *anal);
 R_API void r_parse_pdb_types(const RAnal *anal, const RBinPdb *pdb);
 R_API void r_anal_save_base_type(const RAnal *anal, const RAnalBaseType *type);

--- a/test/unit/test_anal_function.c
+++ b/test/unit/test_anal_function.c
@@ -117,11 +117,19 @@ bool test_r_anal_function_relocate(void) {
 	assert_invariants (anal);
 	mu_assert_false (success, "failed relocate");
 	mu_assert_eq (fa->addr, 0x1337, "failed relocate addr");
+	ut64 revision_epoch = r_anal_function_dirty_epoch (fa);
 
 	success = r_anal_function_relocate (fa, 0x1234);
 	assert_invariants (anal);
 	mu_assert_true (success, "successful relocate");
 	mu_assert_eq (fa->addr, 0x1234, "successful relocate addr");
+	mu_assert_neq (r_anal_function_dirty_epoch (fa), revision_epoch,
+		"relocation bumps the function revision epoch");
+	revision_epoch = r_anal_function_dirty_epoch (fa);
+	mu_assert_true (r_anal_function_rename (fa, "relocated_function"),
+		"rename relocated function");
+	mu_assert_neq (r_anal_function_dirty_epoch (fa), revision_epoch,
+		"rename bumps the function revision epoch");
 
 	assert_leaks (anal);
 	r_anal_free (anal);


### PR DESCRIPTION
Anything that caches work derived from a function's typed metadata, or from the type database, needs to know when that input changed. `has_changed` is a flag that one consumer clears, so a second consumer never sees the change. An epoch is a counter that only moves forward, and every consumer keeps the value it last saw.

- `RAnalFunction.dirty_epoch`, bumped by `r_anal_function_bump_dirty_epoch`, on: relocate, rename, variable set/rename/retype, signature set, calling convention change, `afB`, `afS`, and when `r_anal_function_cc` resolves a lazy dyncc marker. Zero is never a valid value, so a consumer that starts from zero always sees the first change.
- `RAnal.type_dirty_epoch`, bumped by `r_anal_types_bump_dirty_epoch`, on: type database loads and reloads, parsed type save and remove, base type save, signature delete, and type links. The link writers (`r_type_set_link`, `r_type_link_offset`, `r_type_unlink`) do not see `RAnal`, so `r_anal_types_set_link`, `r_anal_types_set_link_offset` and `r_anal_types_unlink` wrap them and the three core callers go through the wrappers.
- `r_anal_function_set_callconv` validates the convention and bumps; `afc` uses it instead of writing `fcn->callconv` directly.

The function bump also sets `has_changed`, so existing readers of that flag keep working. `test_anal_function` checks that relocate and rename move the epoch.

Split out of #26701.
