### PR TITLE
Add a read-only function signature query that loads nothing ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -2574,17 +2574,21 @@ static char *function_signature_try_type_name(Sdb *types, const char *candidate)
 	return r_type_func_prototype_exist (types, candidate)? strdup (candidate): NULL;
 }
 
-static char *function_signature_address_type_name(Sdb *types, ut64 addr) {
-	R_RETURN_VAL_IF_FAIL (types, NULL);
-	char *name = r_type_link_at (types, addr);
-	if (name && r_type_kind (types, name) == R_TYPE_FUNCTION) {
-		return name;
+R_IPI const char *r_anal_function_type_link_at(RAnal *anal, ut64 addr) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types, NULL);
+	return sdb_const_getf (anal->sdb_types, NULL, "fcnlink.%08" PFMT64x, addr);
+}
+
+static char *function_signature_address_type_name(RAnal *anal, RAnalFunction *fcn) {
+	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn, NULL);
+	char *typelinked = r_type_link_at (anal->sdb_types, fcn->addr);
+	if (typelinked && r_type_kind (anal->sdb_types, typelinked) == R_TYPE_FUNCTION) {
+		return typelinked;
 	}
-	free (name);
-	const char *dwarf_name = sdb_const_getf (types, NULL,
-		"fcnlink.%08" PFMT64x, addr);
-	if (dwarf_name && r_type_kind (types, dwarf_name) == R_TYPE_FUNCTION) {
-		return strdup (dwarf_name);
+	free (typelinked);
+	const char *linked = r_anal_function_type_link_at (anal, fcn->addr);
+	if (linked && r_type_kind (anal->sdb_types, linked) == R_TYPE_FUNCTION) {
+		return strdup (linked);
 	}
 	return NULL;
 }
@@ -2593,7 +2597,7 @@ static char *function_signature_type_name(RAnal *anal, RAnalFunction *fcn) {
 	const char *basename;
 
 	R_RETURN_VAL_IF_FAIL (anal && anal->sdb_types && fcn && fcn->name, NULL);
-	char *name = function_signature_address_type_name (anal->sdb_types, fcn->addr);
+	char *name = function_signature_address_type_name (anal, fcn);
 	if (name) {
 		return name;
 	}
@@ -2641,7 +2645,8 @@ static char *function_signature_type_name(RAnal *anal, RAnalFunction *fcn) {
 	return strdup (lookup_name);
 }
 
-static const char *function_signature_callconv(RAnal *anal, RAnalFunction *fcn, const char *type_name) {
+// resolve_dynamic lets a lazy dyncc marker be resolved, which writes the function
+static const char *function_signature_callconv(RAnal *anal, RAnalFunction *fcn, const char *type_name, bool resolve_dynamic) {
 	const char *callconv = NULL;
 
 	R_RETURN_VAL_IF_FAIL (anal && fcn, NULL);
@@ -2651,7 +2656,7 @@ static const char *function_signature_callconv(RAnal *anal, RAnalFunction *fcn, 
 	if (R_STR_ISNOTEMPTY (callconv) && r_anal_cc_exist (anal, callconv)) {
 		return callconv;
 	}
-	const char *fcncc = r_anal_function_cc (fcn);
+	const char *fcncc = resolve_dynamic? r_anal_function_cc (fcn): fcn->callconv;
 	if (R_STR_ISNOTEMPTY (fcncc) && r_anal_cc_exist (anal, fcncc)) {
 		callconv = fcncc;
 	}
@@ -2872,7 +2877,7 @@ R_API void r_anal_function_signature_free(RAnalFunctionSignature *signature) {
 	}
 }
 
-R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *function) {
+static RAnalFunctionSignature *function_get_signature(RAnalFunction *function, bool load_types) {
 	char *type_name;
 	int i;
 	RAnal *anal;
@@ -2880,7 +2885,9 @@ R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *funct
 
 	R_RETURN_VAL_IF_FAIL (function && function->anal && function->anal->sdb_types, NULL);
 	anal = function->anal;
-	r_anal_types_ensure_loaded (anal);
+	if (load_types) {
+		r_anal_types_ensure_loaded (anal);
+	}
 	type_name = function_signature_type_name (anal, function);
 	if (!type_name) {
 		return NULL;
@@ -2917,7 +2924,7 @@ R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *funct
 	if (!signature->signature) {
 		goto beach;
 	}
-	const char *callconv = function_signature_callconv (anal, function, type_name);
+	const char *callconv = function_signature_callconv (anal, function, type_name, load_types);
 	if (callconv) {
 		signature->callconv = strdup (callconv);
 		if (!signature->callconv) {
@@ -2932,6 +2939,29 @@ beach:
 	free (type_name);
 	r_anal_function_signature_free (signature);
 	return NULL;
+}
+
+R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *function) {
+	return function_get_signature (function, true);
+}
+
+R_API RAnalFunctionSignature *r_anal_function_get_signature_current(RAnalFunction *function) {
+	return function_get_signature (function, false);
+}
+
+R_API bool r_anal_function_has_address_linked_signature_current(RAnalFunction *function) {
+	R_RETURN_VAL_IF_FAIL (function && function->anal && function->anal->lock
+		&& function->anal->sdb_types, false);
+	RAnal *anal = function->anal;
+	r_th_lock_enter (anal->lock);
+	const char *linked = r_anal_function_type_link_at (anal, function->addr);
+	char *type_name = R_STR_ISNOTEMPTY (linked)
+		? function_signature_address_type_name (anal, function): NULL;
+	bool exists = R_STR_ISNOTEMPTY (type_name)
+		&& r_type_func_prototype_exist (anal->sdb_types, type_name);
+	free (type_name);
+	r_th_lock_leave (anal->lock);
+	return exists;
 }
 
 R_API char *r_anal_function_get_signature_string(RAnalFunction *fcn) {
@@ -2970,7 +3000,7 @@ R_API bool r_anal_function_set_signature(RAnal *anal, RAnalFunction *fcn, const 
 	resolved_ret_type = R_STR_ISNOTEMPTY (signature->ret_type)? signature->ret_type: "void";
 	const char *callconv = R_STR_ISNOTEMPTY (signature->callconv)
 		? signature->callconv
-		: function_signature_callconv (anal, fcn, type_name);
+		: function_signature_callconv (anal, fcn, type_name, true);
 	if (callconv) {
 		resolved_callconv = strdup (callconv);
 	}

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -1267,6 +1267,9 @@ R_API void r_anal_trim_jmprefs(RAnal *anal, RAnalFunction *fcn);
 R_API void r_anal_del_jmprefs(RAnal *anal, RAnalFunction *fcn);
 R_API RAnalFunction *r_anal_function_next(RAnal *anal, ut64 addr);
 R_API RAnalFunctionSignature *r_anal_function_get_signature(RAnalFunction *function);
+// same, without loading type databases; for callers that already hold the analysis lock
+R_API RAnalFunctionSignature *r_anal_function_get_signature_current(RAnalFunction *function);
+R_API bool r_anal_function_has_address_linked_signature_current(RAnalFunction *function);
 R_API void r_anal_function_signature_free(RAnalFunctionSignature *signature);
 R_API char *r_anal_function_get_signature_string(RAnalFunction *function);
 R_API bool r_anal_function_set_signature(RAnal *anal, RAnalFunction *fcn, const RAnalFunctionSignature *signature);

--- a/libr/include/r_anal_priv.h
+++ b/libr/include/r_anal_priv.h
@@ -28,6 +28,7 @@ typedef struct r_leaddr_pair_t {
 #define R_ANAL_CC_STACK_POP_UNKNOWN (-1)
 
 R_IPI void r_anal_types_ensure_loaded(RAnal *anal);
+R_IPI const char *r_anal_function_type_link_at(RAnal *anal, ut64 addr);
 R_IPI bool r_anal_var_is_default_argname(const char *name);
 R_IPI bool r_anal_function_materialize_switch_case(RAnal *anal, RAnalFunction *fcn, ut64 case_addr, int depth);
 R_IPI int r_anal_cc_stack_pop(RAnal *anal, const char *convention);


### PR DESCRIPTION
`r_anal_function_get_signature` calls `r_anal_types_ensure_loaded`, which may load type databases from disk, and `r_anal_function_cc`, which may resolve a lazy dyncc marker and write the function. A caller that already holds the analysis lock, or that only wants to inspect what is currently known, needs the same answer without either side effect.

- `r_anal_function_get_signature_current`: the signature from what the type database holds now. Same code path as `r_anal_function_get_signature`, minus the load and the dyncc resolution.
- `r_anal_function_has_address_linked_signature_current`: true when a prototype is linked to the function's address (a `tl` link or a DWARF `fcnlink`), as opposed to found by name. A consumer treats an address-linked prototype as belonging to this function and a name-matched one as evidence.
- `r_anal_function_type_link_at` (internal): the `fcnlink` lookup that two places spelled out inline.

No behaviour change for the existing entry point.

Split out of #26701.
