### PR TITLE
Run plugin post-analysis hooks from aa and aaa with a depth ##analysis

### DIFF
--- a/libr/core/cmd_anal.inc.c
+++ b/libr/core/cmd_anal.inc.c
@@ -170,7 +170,7 @@ static RCoreHelpMessage help_msg_aaf = {
 static RCoreHelpMessage help_msg_aaa = {
 	"Usage:", "aaa[a[a]]", " # automatically analyze the whole program",
 	"aaa", "", "perform deeper analysis, most common use",
-	"aaaa", "", "same as aaa but adds a bunch of experimental iterations",
+	"aaaa", "", "same as aaa plus aggressive plugin post-analysis",
 	"aaaaa", "", "refine the analysis to find more functions after aaaa",
 	NULL
 };
@@ -15176,6 +15176,13 @@ static int cmpfn_bw(const void *a, const void *b) {
 	return 0;
 }
 
+static void core_anal_plugin_post_analysis(RCore *core, RAnalPluginAnalysisDepth depth) {
+	RAnalPluginAnalysisDepth saved_depth = core->anal->plugin_analysis_depth;
+	core->anal->plugin_analysis_depth = depth;
+	r_anal_plugin_action (core->anal, R_ANAL_PLUGIN_ACTION_POST_ANALYSIS, NULL);
+	core->anal->plugin_analysis_depth = saved_depth;
+}
+
 static bool cmd_aa(RCore *core, bool aaa) {
 	const RList *list;
 	RListIter *iter;
@@ -15303,6 +15310,10 @@ static bool cmd_aa(RCore *core, bool aaa) {
 					fcni->type = R_ANAL_FCN_TYPE_SYM;
 				}
 			}
+		}
+		if (!r_cons_is_breaked (core->cons)) {
+			logline (core, 24, "Running basic plugin post-analysis hooks");
+			core_anal_plugin_post_analysis (core, R_ANAL_PLUGIN_ANALYSIS_DEPTH_BASIC);
 		}
 	}
 	r_config_set_b (core->config, "log.hints", log_hints);
@@ -15571,8 +15582,8 @@ static void cmd_aaa(RCore *core, const char *input) {
 			logline (core, 96, "Enable types.constraint for experimental type propagation");
 			r_config_set_b (core->config, "types.constraint", true);
 			// Plugin post-analysis hooks (for advanced analysis like taint, symbolic)
-			logline (core, 97, "Running plugin post-analysis hooks");
-			r_anal_plugin_action (core->anal, R_ANAL_PLUGIN_ACTION_POST_ANALYSIS, NULL);
+			logline (core, 97, "Running aggressive plugin post-analysis hooks");
+			core_anal_plugin_post_analysis (core, R_ANAL_PLUGIN_ANALYSIS_DEPTH_AGGRESSIVE);
 			if (input[2] == 'a') { // "aaaaa"
 				logline (core, 97, "Reanalyzing graph references to adjust functions count (aarr)");
 				r_core_call (core, "aarr");
@@ -15581,6 +15592,7 @@ static void cmd_aaa(RCore *core, const char *input) {
 				r_core_cmd0 (core, ".afna@@c:afla");
 			}
 		} else {
+			core_anal_plugin_post_analysis (core, R_ANAL_PLUGIN_ANALYSIS_DEPTH_BALANCED);
 			R_LOG_INFO ("Use -AA or aaaa to perform additional experimental analysis");
 		}
 		if (!r_str_startswith (asm_arch, "x86") && !r_str_startswith (asm_arch, "hex")) {

--- a/libr/include/r_anal.h
+++ b/libr/include/r_anal.h
@@ -511,6 +511,14 @@ typedef struct {
 
 typedef struct r_ref_manager_t RefManager;
 
+// how much work a post-analysis hook should do, set by aa, aaa and aaaa
+typedef enum {
+	R_ANAL_PLUGIN_ANALYSIS_DEPTH_UNSPECIFIED = 0,
+	R_ANAL_PLUGIN_ANALYSIS_DEPTH_BASIC,
+	R_ANAL_PLUGIN_ANALYSIS_DEPTH_BALANCED,
+	R_ANAL_PLUGIN_ANALYSIS_DEPTH_AGGRESSIVE,
+} RAnalPluginAnalysisDepth;
+
 typedef struct r_anal_t {
 	RArchConfig *config;
 	int lineswidth; // asm.lines.width
@@ -564,6 +572,7 @@ typedef struct r_anal_t {
 	Sdb *sdb_classes_attrs;
 	RAnalCallbacks cb;
 	RAnalOptions opt;
+	RAnalPluginAnalysisDepth plugin_analysis_depth;
 	RList *reflines;
 	RList *reflines2;
 	RListComparator columnSort;
@@ -929,7 +938,7 @@ typedef RVecAnalRef *(*RAnalDataRefsCallback)(RAnal *a, RAnalFunction *fcn);
 // Pre-analysis callback (called early in aaa, after aa, before per-function work)
 typedef bool (*RAnalPreAnalysisCallback)(RAnal *a);
 
-// Post-analysis callback (called at end of aaaa)
+// Post-analysis callback (called at end of aa, aaa and aaaa)
 typedef bool (*RAnalPostAnalysisCallback)(RAnal *a);
 
 typedef struct r_anal_plugin_t {
@@ -966,7 +975,7 @@ typedef struct r_anal_plugin_t {
 
 	// Pre-analysis hook (called early in aaa, filtered by eligible)
 	RAnalPreAnalysisCallback pre_analysis;
-	// Post-analysis hook (for aaaa)
+	// Post-analysis hook (for aa, aaa and aaaa; see RAnal.plugin_analysis_depth)
 	RAnalPostAnalysisCallback post_analysis;
 } RAnalPlugin;
 
@@ -1173,7 +1182,7 @@ typedef enum {
 	R_ANAL_PLUGIN_ACTION_ANALYZE_FCN,   // af hook: call analyze_fcn on all eligible plugins
 	R_ANAL_PLUGIN_ACTION_RECOVER_VARS,  // afva hook: first plugin returning vars wins
 	R_ANAL_PLUGIN_ACTION_GET_DATA_REFS, // aar hook: merge data refs from all eligible plugins
-	R_ANAL_PLUGIN_ACTION_POST_ANALYSIS, // aaaa hook: call post_analysis on all eligible plugins
+	R_ANAL_PLUGIN_ACTION_POST_ANALYSIS, // aa/aaa/aaaa hook: call post_analysis on all eligible plugins
 } RAnalPluginAction;
 
 // Unified plugin action dispatcher (replaces per-action APIs)


### PR DESCRIPTION
`post_analysis` hooks run only at the end of `aaaa`, so an analysis plugin that wants to contribute to `aa` or `aaa` has no place to do it, and a plugin that does expensive work cannot tell `aaa` from `aaaa`.

- `RAnal.plugin_analysis_depth` is set to `BASIC` for `aa`, `BALANCED` for `aaa` and `AGGRESSIVE` for `aaaa` around the `R_ANAL_PLUGIN_ACTION_POST_ANALYSIS` dispatch, and restored afterwards. A hook reads it to size its work.
- `aa` and `aaa` now dispatch the hook at their end, where `aaaa` already did. Plugins without the callback are unaffected, and plugins that only wanted `aaaa` can check the depth.

This touches how plugins take part in analysis, so if it needs a design discussion first I am happy to move it to an issue; the change itself is one field, one enum and one helper.

Split out of #26701.
