### PR TITLE
Pin the fat macho slice where the test output depends on it ##test

### DIFF
--- a/test/db/cmd/cmd_i
+++ b/test/db/cmd/cmd_i
@@ -3458,6 +3458,7 @@ RUN
 
 NAME=ik-macho
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=ik info/mach0.entry.vaddr~?0x100000ef8
 EXPECT=<<EOF
 1
@@ -3466,6 +3467,7 @@ RUN
 
 NAME=ikv
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=ikv info/mach0.entry.vaddr
 EXPECT=<<EOF
 0x100000ef8
@@ -3474,6 +3476,7 @@ RUN
 
 NAME=ik.
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=ik. info/mach0.entry.vaddr
 EXPECT=<<EOF
 0x100000ef8
@@ -3482,7 +3485,7 @@ RUN
 
 NAME=ik*
 FILE=bins/mach0/fatmach0-3true
-ARGS=-e bin.types=true
+ARGS=-e bin.types=true -a x86 -b 64
 CMDS=ik*~?mach0_segment64_0
 EXPECT=<<EOF
 1
@@ -3500,6 +3503,7 @@ RUN
 
 NAME=iS=
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=iS=
 EXPECT=<<EOF
 0*  0x100000ef8 ######------------------------ 0x100000f3f r-x   71    0.__TEXT.__text
@@ -3517,6 +3521,7 @@ RUN
 
 NAME=iSq.
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=iSq.
 EXPECT=<<EOF
 0x100000ef8 0x100000f3f -r-x 0.__TEXT.__text

--- a/test/db/cmd/relocs
+++ b/test/db/cmd/relocs
@@ -1,6 +1,6 @@
 NAME=macho relocs
-BROKEN=1
 FILE=bins/mach0/ls-m1
+ARGS=-a arm -b 64
 CMDS=<<EOF
 x 32 @ 0x1000081d8
 wc
@@ -13,9 +13,8 @@ EOF
 RUN
 
 NAME=macho relocs bin.cache
-BROKEN=1
 FILE=bins/mach0/ls-m1
-ARGS=-e bin.cache=true
+ARGS=-e bin.cache=true -a arm -b 64
 CMDS=<<EOF
 x 32 @ 0x1000081d8
 wc
@@ -137,9 +136,8 @@ EOF
 RUN
 
 NAME=macho relocs bin.relocs.apply
-BROKEN=1
 FILE=bins/mach0/ls-m1
-ARGS=-e bin.relocs.apply=true
+ARGS=-e bin.relocs.apply=true -a arm -b 64
 CMDS=<<EOF
 x 32 @ 0x1000081d8
 wc

--- a/test/db/formats/mach0/fatmach0
+++ b/test/db/formats/mach0/fatmach0
@@ -137,6 +137,7 @@ RUN
 
 NAME=fatmach0 entry0
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=?v entry0
 EXPECT=<<EOF
 0x100000ef8
@@ -145,6 +146,7 @@ RUN
 
 NAME=fatmach0 entry0 data
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=p8 16 @ entry0
 EXPECT=<<EOF
 6a004889e54883e4f0488b7d08488d75
@@ -418,6 +420,7 @@ RUN
 
 NAME=fatmacho o- refuses to close mounted fd
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 o~?
 o-3
@@ -431,6 +434,7 @@ RUN
 
 NAME=fatmacho o- works after umount
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 m-/bin
 o-3
@@ -443,6 +447,7 @@ RUN
 
 NAME=fatmacho mo loads binfile for slice
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 mo /bin/ppc_32.2
 ob~?

--- a/test/db/tools/rabin2
+++ b/test/db/tools/rabin2
@@ -369,8 +369,10 @@ paddr      vaddr      phaddr     vhaddr     type
 EOF
 RUN
 
+# rabin2 reads x86_32 here, r2 x86_64: the two tables differ on purpose
 NAME=rabin2 -a x86 -b 32 -i fatmach0
 FILE=bins/mach0/fatmach0-3true
+ARGS=-a x86 -b 64
 CMDS=<<EOF
 !rabin2 -a x86 -b 32 -i ${R2_FILE}
 ii


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A test that opens a universal Mach-O without `-a` reads whichever slice the build host prefers (`opt->arch = arch? arch: R_SYS_ARCH`, `libr/bin/bin.c:145`), so its result depends on the machine running it. Fifteen cases are decided that way today. Six of them print a different table on a 32-bit x86 build:

```
$ r2 -N -q -c 'iS=' bins/mach0/fatmach0-3true                  # 64-bit host
$ r2 -N -q -a x86 -b 32 -c 'iS=' bins/mach0/fatmach0-3true     # 32-bit host
```

and three in `db/cmd/relocs` are marked `BROKEN=1` yet *pass* on an arm64 host, because `bins/mach0/ls-m1` has an arm64e slice and the goldens were written for it. It reads as a code regression either way; the same shape made an `ls-m1` case in #26700 pass locally and fail on three CI jobs.

## The change

- The fifteen cases name their slice in `ARGS`, and one `!rabin2` command names t in the command, since that is what chooses the slice there.
- The three `db/cmd/relocs` cases are pinned to the arm64 slice they were written against and lose `BROKEN=1`: they pass there, so the marker was recording a test that compared arm goldens against x86 output, not a bug.
- **No golden is regenerated.** Each pin is the slice that already reproduces the case's golden, established by running every case against every slice.
- Cases whose output does not depend on the slice are left alone. A pin on a path that never selects one - `-n` skips bin loading, `rabin2 -G` slices the buffer before the fat header is read, `-A` enumerates every slice, `-OC` hardcodes index 0 - would claim a determinism it does not provide.

## Tests

`185 OK / 5 BR / 0 XX / 3 FX` becomes `188 OK / 5 BR / 0 XX / 0 FX` over the four touched files: the three unexpected passes become real ones and nothing else moves. A full `db` run is clean.