### PR TITLE
Stop running the same test suite in three jobs per PR ##test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,12 +270,6 @@ jobs:
       with:
         name: linux-acr-deb-${{ matrix.arch }}
         path: radare2*.deb
-    - name: Pub i386 test results
-      if: matrix.arch == 'i386'
-      uses: actions/upload-artifact@v7
-      with:
-        name: linux-acr-deb-i386-tests
-        path: test/results-i386.json
 
 ## RPM PACKAGES DISABLED
 #  linux-meson-rpm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,12 @@ jobs:
       run: sys/mipsbe.sh build && sudo make install
     - name: Run mipsbe unit tests
       run: sys/mipsbe.sh unit
+    # the cross build and the unit tests run on every PR, the 1854-case r2r
+    # smoke run costs 20 minutes under qemu and only rarely says anything new.
+    # head_ref is the source branch on a pull_request, where github.ref is the
+    # merge ref and can never carry the branch name
     - name: Run mipsbe r2r smoke tests
+      if: contains(github.ref, 'master') || contains(github.head_ref, 'ci-')
       run: sys/mipsbe.sh smoke
   linux-uefi:
     name: linux-uefi
@@ -310,7 +315,7 @@ jobs:
         export R2R_TIMEOUT=3600
         export R2R_SKIP_ARCHOS=1
         export R2R_SHALLOW=25 # Run 3/4 of the test suite
-        export JOBS=4         # Limit to -j4
+        export R2R_JOBS=4     # r2r reads R2R_JOBS, not JOBS
         export LD_LIBRARY_PATH=/usr/local/lib
         export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8
         status=0
@@ -349,7 +354,7 @@ jobs:
         export R2R_SKIP_ARCHOS=1
         export R2R_TIMEOUT=3600
         export R2R_SHALLOW=25 # Run 3/4 of the test suite
-        export JOBS=4         # Limit to -j4
+        export R2R_JOBS=4     # r2r reads R2R_JOBS, not JOBS
         export LD_LIBRARY_PATH=/usr/local/lib
         export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.8
         status=0

--- a/.github/workflows/tcc.yml
+++ b/.github/workflows/tcc.yml
@@ -96,6 +96,8 @@ jobs:
           make -j
           sudo make install
 
+    # ubuntu-tcc-test already runs all of db on a tcc build; what this job adds
+    # is that a tcc configured --without-debugger still builds a working r2
     - name: Run tests
       env:
         PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig
@@ -104,7 +106,7 @@ jobs:
         r2r -v
         export R2R_SKIP_ASM=1
         export R2R_SKIP_ARCHOS=1
-        make -j -C test
+        cd test && r2r -L db/cmd
   r2pm:
     name: r2pm-tcc
     runs-on: ubuntu-24.04


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Follow-up to #26703: the other half, jobs redoing work another job already did. `make -C test` with no argument is all of `db`, and two tcc jobs ask for it:

```
$ grep -n 'make -j -C test' .github/workflows/tcc.yml
59:        make -j -C test RUNTEST=...   # ubuntu-tcc-test
107:        make -j -C test               # ubuntu-tcc-nodbg
```

A PR costs **149 runner-minutes over 47 jobs** (#26709's run, via `/actions/runs/<id>/jobs`). Three items in that bill buy nothing.

## The change

- **`mipsbe` smoke runs on master, or from a `ci-…` branch** (~20 min, 1854 cases under qemu, serial). Every PR still cross-builds mips32be and runs the unit tests, so a build break is still caught; a behavioural one waits for the master push. Trimming the list instead would be worse: 1236 of those cases are `db/formats`, where endian bugs live.

It tests `github.head_ref`, not `github.ref` as the other gated jobs do: on a `pull_request` that is `refs/pull/<n>/merge` and never carries the branch name, so the `ci-` hatch in `macos-test` and `build-rpath-*` cannot fire today. Can obviously easily fix those here too?
- **`ubuntu-tcc-nodbg` runs `db/cmd`, not all of `db`** (~4 min). Both tcc jobs set the same skip flags and reach `r2r` with no path argument; they differ only in how *tinycc* is configured, which cannot change an r2 test result. That a `--without-debugger` tcc builds a working r2, one scope shows as well.
- **`JOBS=4` in the asan jobs is dead**, so `# Limit to -j4` was untrue: `JOBS` is read only by `Makefile:418`, which neither job goes through, while r2r reads `R2R_JOBS` (`r2r.c:307-322`, default 8). Renamed, so they stop running eight ASan workers on a four-core runner.
- Dropped `build.yml`'s upload of `test/results-i386.json`; the line that would write it is commented out.

## What this does not do

It cuts machine time, not waiting time: a PR waits ~17 min, set by `mipsbe` (17.0) and `linux-wasi` (16.7), so gating one moves it by seconds. With mipsbe gated, `linux-wasi` alone caps the wait — and its siblings `linux-wasi-api` and
`linux-wasi-browser` already carry `if: github.event_name != 'pull_request'`. Giving `linux-wasi` the same line would take a PR to ~12.7 min; again, I can update that here too?

Noticed while measuring, left alone: `R2R_SKIP_ASM`'s load-time branch never fires (its path test wants `/asm/`, the directory is `db/asm`), so those tests are counted **OK** rather than skipped; `R2R_SKIP_UNIT` is read nowhere; and the two tcc jobs pin different tinycc revisions — deliberate?
