### PR TITLE
Fix nondeterministic instruction iteration in CLLf

### DIFF
--- a/libr/core/cmd.c
+++ b/libr/core/cmd.c
@@ -6394,13 +6394,8 @@ static void atat_i(RCore *core, const char *cmd) {
 	if (fcn) {
 		r_list_sort (fcn->bbs, bb_cmp);
 		r_list_foreach (fcn->bbs, iter, bb) {
-			r_core_seek (core, bb->addr, true);
-			r_core_cmd (core, cmd, 0);
-			for (i = 0; i < bb->op_pos_size; i++) {
-				if (!bb->op_pos[i]) {
-					break;
-				}
-				ut64 addr = bb->addr + bb->op_pos[i];
+			for (i = 0; i < bb->ninstr; i++) {
+				ut64 addr = r_anal_block_ninstr (bb, i);
 				if (!r_bitset_set (seen, addr)) {
 					continue;
 				}

--- a/test/unit/test_cmd_str.c
+++ b/test/unit/test_cmd_str.c
@@ -206,7 +206,34 @@ bool test_registered_command_autocomplete(void) {
 	mu_end;
 }
 
+bool test_foreach_instruction_bounds(void) {
+	RCore *core = r_core_new ();
+	mu_assert_notnull (r_core_file_open (core, "malloc://512", R_PERM_RW, 0), "open test buffer");
+	RAnalFunction *fcn = r_anal_create_function (core->anal, "test", 0x100, 0, NULL);
+	RAnalBlock *bb = r_anal_create_block (core->anal, 0x100, 12);
+	r_anal_function_add_block (fcn, bb);
+	bb->ninstr = 3;
+	r_anal_bb_set_offset (bb, 1, 4);
+	r_anal_bb_set_offset (bb, 2, 8);
+	// Spare capacity is not a zero-terminated list of instruction offsets.
+	bb->op_pos[2] = 12;
+	r_core_seek (core, 0x100, true);
+
+	char *output = r_core_cmd_str (core, "?v $$ @@i; ?v $$ @@Fi");
+	ut64 addr = core->addr;
+	bb->ninstr = 0;
+	char *empty = r_core_cmd_str (core, "?v $$ @@i");
+	r_unref (bb);
+	r_core_free (core);
+	mu_assert_streq_free (output, "0x100\n0x104\n0x108\n0x100\n0x104\n0x108\n",
+		"both iterators visit only the recorded instructions");
+	mu_assert_streq_free (empty, "", "empty blocks have no instructions to visit");
+	mu_assert_eq (addr, 0x100, "iteration restores the seek");
+	mu_end;
+}
+
 int all_tests(void) {
+	mu_run_test (test_foreach_instruction_bounds);
 	mu_run_test (test_cmd_str_issue_18799);
 	mu_run_test (test_multiple_cores_share_terminal);
 	mu_run_test (test_echo_context_binding_and_depth);


### PR DESCRIPTION
`db/cmd/dwarf2` intermittently prints an extra source line at `0x100003f98` in `CLLf`. The underlying `@@i` iterator treats `RAnalBlock.op_pos_size` (allocated capacity) as an instruction count and assumes the offsets are zero-terminated. Spare slots after `realloc` can contain uninitialized or stale offsets, so it sometimes visits addresses beyond the function's last instruction. This is an uninitialized read, not a scheduling race.

Iterate up to `bb->ninstr` and obtain instruction addresses through `r_anal_block_ninstr()`. The first instruction now goes through the same deduplication and empty blocks produce no visits. No changes to the DWARF golden output.

Add one deterministic regression with a nonzero spare offset, checking `@@i`, its `@@Fi` alias, seek restoration, and an empty block. It fails against the original implementation.

Validation:
- `make -j` succeeded on Linux/GCC.
- `test_cmd_str`: 10/10 passed.
- `r2r -u db/cmd/dwarf2 db/cmd/cmd_foreach db/cmd/cmd_CL`: 13/13 passed.
- 128 runs of the original DWARF command sequence plus exact `@@i` address checks, varying `MALLOC_PERTURB_` with 8 concurrent workers: 119 failures before, 0 after.