### PR TITLE
Pick the cc from the COFF machine word, not the arch default ##bin

### DIFF
--- a/libr/bin/p/bin_coff.c
+++ b/libr/bin/p/bin_coff.c
@@ -811,6 +811,7 @@ static RBinInfo *info(RBinFile *bf) {
  		ret->machine = strdup ("mips");
  		ret->arch = strdup ("mips");
  		ret->bits = 32;
+		ret->default_cc = strdup ("o32"); // these words are NT, and NT mips is o32
  		break;
 	case COFF_FILE_MACHINE_I386:
 		ret->machine = strdup ("i386");
@@ -836,6 +837,7 @@ static RBinInfo *info(RBinFile *bf) {
 		ret->machine = strdup ("AMD64");
 		ret->arch = strdup ("x86");
 		ret->bits = 64;
+		ret->default_cc = strdup ("ms"); // x86-64 coff is windows or uefi
 		break;
 	case COFF_FILE_MACHINE_H8300:
 		ret->machine = strdup ("H8300");

--- a/test/db/formats/coff
+++ b/test/db/formats/coff
@@ -76,7 +76,7 @@ RUN
 
 NAME=tiny coff
 FILE=bins/coff/coff.obj
-CMDS=om;is;ir
+CMDS=om;is;ir;e anal.cc;afci
 EXPECT=<<EOF
 * 2 fd: 3 +0x00000064 0x00000000 - 0x00000026 r-x r-x fmap..text_0
 - 1 fd: 3 +0x0000008b 0x00000030 - 0x0000004b r-- rw- fmap..data_1
@@ -93,6 +93,8 @@ vaddr      paddr      type   ntype name
 0x00000010 0x00000074 ADD_32 4     .data
 0x0000001c 0x00000080 ADD_32 4     MessageBoxA
 0x00000023 0x00000087 ADD_32 4     ExitProcess
+ms
+rax ms (rcx, rdx, r8, r9, stack);
 EOF
 RUN
 
@@ -101,6 +103,7 @@ NAME=tiny coff2 symbol language
 FILE=bins/coff/coff2.obj
 CMDS=<<EOF
 e bin.lang
+e anal.cc
 ?e --
 om
 is~text
@@ -109,6 +112,7 @@ pd 2
 EOF
 EXPECT=<<EOF
 msvc
+cdecl
 --
 - 9 fd: 3 +0x0000017c 0x00000000 - 0x000000ee --- --- fmap..drectve_0
 - 8 fd: 3 +0x0000026b 0x000000f0 - 0x00000b9f r-- r-- fmap..debug_S_1
@@ -189,6 +193,8 @@ i~^format
 e asm.arch
 e asm.bits
 pi 7 @ 0
+e anal.cc
+afci
 EOF
 EXPECT=<<EOF
 format   coff
@@ -201,6 +207,8 @@ nop
 lw ra, 0x14(sp)
 jr ra
 addiu sp, sp, 0x18
+o32
+v0 o32 (a0, a1, a2, a3, stack);
 EOF
 RUN
 
@@ -211,12 +219,14 @@ CMDS=<<EOF
 i~^format
 e asm.arch
 e asm.bits
+e anal.cc
 pi 9 @ 0
 EOF
 EXPECT=<<EOF
 format   coff
 ppc
 32
+ppc-32
 stw r31, -4(r1)
 stwu r1, -0x40(r1)
 mflr r31


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

A COFF object gets the calling convention of its arch, not the one its machine word declares. An x86-64 COFF object is Windows or UEFI code, so its arguments are in `rcx`/`rdx`/`r8`/`r9`:

```
$ r2 -N -q -c 'e anal.cc' -c afci test/bins/coff/coff.obj 2>/dev/null
amd64
rax amd64 (rdi, rsi, rdx, rcx, r8, r9, stack);
```

Same for the Microsoft MIPS words. `VC40AMIPS_SETARGV.OBJ` is a Visual C++ 4.0 object with an o32 frame, so four of those register arguments do not exist and o32's 16-byte home area is missed:

```
$ r2 -N -q -c 'e anal.cc' -c afci test/bins/coff/VC40AMIPS_SETARGV.OBJ 2>/dev/null
n32
v0 n32 (a0, a1, a2, a3, a4, a5, a6, a7, stack);
```

## The fix

- `default_cc = "ms"` for `COFF_FILE_MACHINE_AMD64` and `"o32"` for the `R4000`/`MIPS16`/`MIPSFPU`/`MIPSFPU16` group — two lines, in switch arms `info()` already has. `bin_pe` and `bin_elf` set `default_cc` already; COFF was the format still deriving it from the arch default.
- i386 COFF needs no arm: `cc-x86-32.sdb.txt` already defaults to `cdecl`.
- An object built `-mabi=sysv` inside an `0x8664` container is now wrong by default, and nothing in the container separates it from MS-ABI code (`.pdata` is per-function, absent from leaf functions and from all three `0x8664` objects in `test/bins`). Override with `e anal.cc=amd64`.

## The tests

Four existing per-binary cases in `db/formats/coff` grew the assertion, so the suite opens no extra binaries. Remove either line and one test fails. The `coff2.obj` (`cdecl`) and `VC40APPC_SETARGV.OBJ` (`ppc-32`) cases pass before and after.