### PR TITLE
Only a register move into bp establishes a frame pointer

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1281,7 +1281,8 @@ noskip:
 					last_is_mov_lr_pc = true;
 				}
 			}
-			if (has_stack_regs && op_is_set_bp (op_dst, op_src, bp_reg, sp_reg)) {
+			// a load or store through sp names sp as a base; only a register move makes bp the frame pointer
+			if (has_stack_regs && op_is_set_bp (op_dst, op_src, bp_reg, sp_reg) && !dst->memref && !src0->memref) {
 				fcn->bp_off = fcn->stack;
 			}
 			// Is this a mov of immediate value into a register?
@@ -2088,7 +2089,7 @@ analopfinish:
 			break;
 		}
 		if (has_stack_regs && op_dst_writeonly) {
-			if (op_is_set_bp (op_dst, op_src, bp_reg, sp_reg) && src1) {
+			if (op_is_set_bp (op_dst, op_src, bp_reg, sp_reg) && !dst->memref && !src0->memref && src1) {
 				switch (op->type & R_ANAL_OP_TYPE_MASK) {
 				case R_ANAL_OP_TYPE_ADD:
 					fcn->bp_off = fcn->stack - src1->imm;

--- a/test/db/anal/x86_64
+++ b/test/db/anal/x86_64
@@ -4281,3 +4281,17 @@ ptr: 0x00000007
 ptr: 0x0000000f
 EOF
 RUN
+
+NAME=a load through sp does not make bp a frame pointer
+FILE=malloc://64
+CMDS=<<EOF
+e asm.arch=x86
+e asm.bits=64
+wx 554889e54883ec20c745f801000000488b6c2418448b45f8c9c3
+af
+afv
+EOF
+EXPECT=<<EOF
+var int32_t var_8h @ rbp-0x8
+EOF
+RUN


### PR DESCRIPTION
Found while feeding radare2's stack variables into the r2sleigh decompiler: in bzip2 built at -O2, `BZ2_hbMakeCodeLengths` is frameless and uses rbp as a scratch register, yet radare2 reported `bp_off` equal to the whole frame size and placed its DWARF locals against rbp. The cause is `op_is_set_bp`, which compares operand register names only, so `mov rbp, qword [rsp + 0x50]` (a spill reload) matches like `mov rbp, rsp` and resets `fcn->bp_off` to the current stack depth.

The move and add/sub sites now also require both operands to be direct registers, using the `memref` width the arch plugins already fill for memory operands; the lea site is unchanged because its source is an address computation.

Test: a function with a real frame spills a value, reloads rbp from the stack, and reads through it again. Before, that produced a second variable and the first displayed as `rbp+0x18`; now both accesses belong to `var_8h @ rbp-0x8`. `db/anal`, `db/cmd/dwarf` and `db/cmd/types` pass as on master, and `afvj` over a 13-binary corpus is unchanged because a wrong `bp_off` cancels out of the displayed rbp offset; it only shows through consumers of the raw delta such as DWARF import, which a follow-up PR addresses.