### PR TITLE
Give DW_OP_call_frame_cfa its own location kind instead of faking a bp offset

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -2,6 +2,7 @@
 
 #include <ctype.h>
 #include <r_anal.h>
+#include <r_anal_priv.h>
 #include <r_bin_dwarf.h>
 
 typedef struct dwarf_parse_context_t {
@@ -35,6 +36,7 @@ typedef enum dwarf_location_kind {
 	LOCATION_BP = 2,
 	LOCATION_SP = 3,
 	LOCATION_REGISTER = 4,
+	LOCATION_CFA = 5,
 } VariableLocationKind;
 
 typedef struct dwarf_var_location_t {
@@ -1452,12 +1454,9 @@ static VariableLocation *parse_dwarf_location(Context *ctx, const RBinDwarfAttrV
 			kind = LOCATION_GLOBAL; // address
 			break;
 		}
-		case DW_OP_call_frame_cfa: {
-			// REMOVE XXX
-			kind = LOCATION_BP;
-			offset += 16;
+		case DW_OP_call_frame_cfa:
+			kind = LOCATION_CFA;
 			break;
-		}
 		default:
 			break;
 		}
@@ -1683,6 +1682,8 @@ static char *sdb_variable_data(const Variable *var) {
 		return r_str_newf ("b,%" PFMT64d ",%s", var->location->offset, var->type);
 	case LOCATION_SP:
 		return r_str_newf ("s,%" PFMT64d ",%s", var->location->offset, var->type);
+	case LOCATION_CFA:
+		return r_str_newf ("c,%" PFMT64d ",%s", var->location->offset, var->type);
 	case LOCATION_GLOBAL:
 		return r_str_newf ("g,%" PFMT64u ",%s", var->location->address, var->type);
 	case LOCATION_REGISTER:
@@ -2244,6 +2245,18 @@ static bool integrate_dwarf_var(RAnal *anal, RFlag *flags, RAnalFunction *fcn, c
 	}
 	if (*kind == 's') {
 		r_anal_function_set_var (fcn, offset - fcn->maxstack, *kind, type, 4, is_arg, var_name);
+		return true;
+	}
+	if (*kind == 'c') {
+		// the CFA sits one return slot above the entry stack pointer, which is where stack deltas count from
+		const int delta = offset + r_anal_cc_raslot (anal, r_anal_cc_wordsize (anal, fcn->callconv));
+		// a slot recovery already named keeps its kind so the declaration takes it over instead of doubling it
+		RAnalVar *found = r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_BPV, delta);
+		if (!found) {
+			found = r_anal_function_get_var (fcn, R_ANAL_VAR_KIND_SPV, delta);
+		}
+		const char frame_kind = fcn->bp_off? R_ANAL_VAR_KIND_BPV: R_ANAL_VAR_KIND_SPV;
+		r_anal_function_set_var (fcn, delta, found? found->kind: frame_kind, type, 4, is_arg, var_name);
 		return true;
 	}
 	if (*kind == 'r') {

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -723,3 +723,22 @@ type
 8
 EOF
 RUN
+
+NAME=dwarf cfa frame base places locals against the entry stack pointer
+FILE=bins/elf/pigz
+CMDS=<<EOF
+e asm.dwarf=false
+aaa
+afv @ dbg.ZopfliLZ77GetHistogram
+EOF
+EXPECT=<<EOF
+arg ZopfliLZ77Store const * lz77 @ rdi
+arg size_t lstart @ rsi
+arg size_t lend @ rdx
+arg size_t * ll_counts @ rcx
+arg size_t * d_counts @ r8
+var size_t[32] d_counts2 @ rsp+0x0
+var size_t[288] ll_counts2 @ rsp+0x100
+var int64_t var_a00h @ rsp+0xa00
+EOF
+RUN


### PR DESCRIPTION
Found while feeding radare2's DWARF-imported variables into the r2sleigh decompiler: every declared aggregate in every frameless function landed one word off, and in bzip2 at -O2 `BZ2_hbMakeCodeLengths` had its three arrays placed against rbp even though rbp is an ordinary register there. The importer maps `DW_OP_call_frame_cfa` onto `LOCATION_BP` with a hard-coded `offset += 16` (marked `// REMOVE XXX`), which is the saved-rbp to CFA distance on x86-64 and is right only in a function that made rbp its frame pointer; on i386 the distance is 8 and on link-register targets it is 0.

The CFA is the stack pointer before the call, one return-address slot above the entry stack pointer, and radare2's stack variable deltas already count from the entry stack pointer for both the sp and bp kinds. So `DW_OP_call_frame_cfa` now becomes `LOCATION_CFA`, serialized as `c,<offset>,<type>`, and `integrate_dwarf_var` turns it into `delta = offset + r_anal_cc_raslot()` with no frame-pointer assumption. The variable takes the kind of a stack variable recovery already placed at that delta, so the declaration takes over the slot (and `shadow_interior_vars` then drops the scalar fragments inside an array) instead of doubling it; with nothing there it is a bp variable when the function established a frame pointer and an sp variable otherwise.

Framed x86-64 functions land on the same deltas as before, so no existing expectation changes: `db/anal`, `db/cmd/dwarf*`, `db/cmd/types`, `db/cmd/cmd_CL`, `db/formats/elf` and `db/formats/dwarf` pass as on master. The new test uses pigz's frameless `ZopfliLZ77GetHistogram`: `d_counts2` and `ll_counts2` move from `rbp-0xa20`/`rbp-0x920` to `rsp+0x0`/`rsp+0x100`, where the function's own accesses are, and the sixteen `int64_t` fragments recovery had named inside them disappear. Over a 13-binary corpus, 40 functions change and all of them are frameless or hold a local recovery could not reach; every framed function is byte-identical.

#26718 is related: it stops a spill reload such as `mov rbp, [rsp+0x50]` from setting `bp_off`, which this PR's fallback kind consults when recovery has no variable at the slot.