### PR TITLE
Keep the block scan inside executable memory unless anal.in allows data

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -922,8 +922,9 @@ static int fcn_recurse(RAnal *anal, RAnalFunction *fcn, ut64 addr, ut64 len, int
 		r_sys_usleep (anal->sleep);
 	}
 
-	// check if address is readable //:
-	if (anal->iob.io && !anal->iob.is_valid_offset (anal->iob.io, addr, 0)) {
+	// code lives in executable memory unless anal.in says data is fair game too
+	const int code_perm = anal->opt.noncode? 0: R_PERM_X;
+	if (anal->iob.io && !anal->iob.is_valid_offset (anal->iob.io, addr, code_perm)) {
 		if (addr != UT64_MAX && !anal->iob.io->va) {
 			R_LOG_DEBUG ("Invalid address 0x%"PFMT64x ". Try with io.va=true", addr);
 		}
@@ -1060,7 +1061,7 @@ repeat:
 		if (flagbounds && bb->size > 0 && anal->flb.get_at && anal->flb.get_at (anal->flb.f, at, false)) {
 			gotoBeach (R_ANAL_RET_END);
 		}
-		if (!anal->iob.is_valid_offset (anal->iob.io, at, 0)) {
+		if (!anal->iob.is_valid_offset (anal->iob.io, at, code_perm)) {
 			gotoBeach (R_ANAL_RET_END);
 		}
 		ut64 bytes_read = R_MIN (len - at_delta, sizeof (buf));

--- a/test/db/anal/arm64
+++ b/test/db/anal/arm64
@@ -56369,3 +56369,23 @@ EXPECT=<<EOF
 =SN	x16
 EOF
 RUN
+
+NAME=af ends a block at the edge of executable memory
+FILE=malloc://64
+CMDS=<<EOF
+e asm.arch=arm
+e asm.bits=64
+o malloc://64 0x40 rw-
+b 64
+wow 200080d2 @ 0
+b 60
+wow 1f2003d5 @ 0x40
+wx c0035fd6 @ 0x7c
+s 0
+af
+afb
+EOF
+EXPECT=<<EOF
+0x00000000 0x00000040 00:0000 64
+EOF
+RUN


### PR DESCRIPTION
Found through the fuzz corpus while removing the walk's depth limit (#26717): `bins/fuzzed/r2_ir_r_read_me32_arc` maps a null-backed `rw-` segment over most of the address space, the scan's per-instruction check only asks whether the address is mapped and readable, and once a block runs off the end of the executable map it keeps decoding the zero fill. On ARC that decodes as a branch chain, so the walk built a 14MB function of one-instruction blocks (3.6M of them before it was stopped); the old depth limit truncated that at 128 blocks and hid it.

`anal.in` already states the rule (executable maps unless the user widens it, which sets `opt.noncode`), and `__core_anal_fcn` honours it for a function's start address. The scan now honours it for every instruction: both mapped-offset checks in the walk ask for `R_PERM_X` when `opt.noncode` is clear, and stay permission-free otherwise, so debugger sessions (`anal.in=dbg.map`) are unchanged.

Test: executable code runs up to the edge of a `rw-` map that holds more instructions and a `ret`; the block now ends at the edge (`0x0..0x40`, 64 bytes) instead of continuing to the `ret` in data (128 bytes before). `db/anal`, `db/cmd`, `db/formats` and `db/esil` pass as on master. With this on top of #26717 the fuzz input analyses in 0.09s (0.73s on master, where the limit was still doing the truncating).