### PR TITLE
Fix float args read from the integer argument registers ##analysis

### DIFF
--- a/libr/anal/p/tp/match.c
+++ b/libr/anal/p/tp/match.c
@@ -46,12 +46,16 @@ static void type_match(TPState *tps, char *fcn_name, ut64 addr, ut64 baddr, cons
 
 	RVecString types;
 	RVecString_init (&types);
+	const int fp_prefix = tp_fparg_prefix (anal, cc, fcn_name, max);
 	const ut32 opmask = R_ARCH_OP_MASK_BASIC | R_ARCH_OP_MASK_VAL | R_ARCH_OP_MASK_ESIL;
 	for (i = 0; i < max; i++) {
 		int arg_num = stack_rev? (max - 1 - i): i;
+		// fp_prefix counted declared types, not ones a format yields
+		const bool fp_home = !format && arg_num < fp_prefix;
 		// one lookup answers both where the arg lives and its slot offset, so the two cannot disagree
 		RAnalCCArgSlot slot;
-		const bool resolved = r_anal_cc_argslot (anal, cc, arg_num, max, false, &slot);
+		const bool resolved = r_anal_cc_argslot (anal, cc,
+			fp_home? R_ANAL_CC_MAXARG + arg_num: arg_num, max, false, &slot);
 		const bool in_stack = resolved && !slot.reg;
 		const st64 soff = in_stack? slot.off: -1; // a register-homed arg occupies no stack slot
 		const char *place = resolved? slot.reg: NULL;

--- a/libr/anal/p/tp/tp.h
+++ b/libr/anal/p/tp/tp.h
@@ -274,6 +274,7 @@ R_VEC_TYPE (RVecSynthField, SynthField);
 R_VEC_TYPE_WITH_FINI (RVecSynthRec, SynthRec, synth_rec_fini);
 
 bool tp_argloc_val(TPState *tps, const char *cc, int argno, int argc, ut64 *val);
+int tp_fparg_prefix(RAnal *anal, const char *cc, const char *fcn_name, int max);
 
 ut64 etrace_addrof(TypeTrace *etrace, ut32 idx);
 const TypeTraceAccess *etrace_find_access(TypeTrace *etrace, ut32 idx, AccessPredicate pred, void *user);

--- a/libr/anal/p/tp/types.c
+++ b/libr/anal/p/tp/types.c
@@ -610,6 +610,42 @@ static char *tp_unwrap_typedef(RAnal *anal, const char *name) {
 	return cur;
 }
 
+// not tp_is_float_type: long double's fparg slot cost varies by abi
+static bool tp_fparg_scalar(RAnal *anal, const char *type) {
+	if (R_STR_ISEMPTY (type)) {
+		return false;
+	}
+	char *name = tp_unwrap_typedef (anal, tp_skip_kind_prefix (type));
+	if (!name) {
+		return false;
+	}
+	const bool fp = !strcmp (name, "float") || !strcmp (name, "double");
+	free (name);
+	return fp;
+}
+
+// NULL unless the cc spells parameter n's fp home as a single register
+static const char *tp_fparg_loc(RAnal *anal, const char *cc, int n) {
+	const char *loc = r_anal_cc_argloc (anal, cc, R_ANAL_CC_MAXARG + n, 0, -1);
+	return (R_STR_ISEMPTY (loc) || *loc == '{' || *loc == '^')? NULL: loc;
+}
+
+int tp_fparg_prefix(RAnal *anal, const char *cc, const char *fcn_name, int max) {
+	int n;
+	for (n = 0; n < max; n++) {
+		if (!tp_fparg_loc (anal, cc, n)) {
+			break;
+		}
+		char *type = r_type_func_args_type (anal->sdb_types, fcn_name, n);
+		const bool fp = tp_fparg_scalar (anal, type);
+		free (type);
+		if (!fp) {
+			break;
+		}
+	}
+	return n;
+}
+
 // r_anal_type_bitsize handles the pointer width, this adds the typedef unwrap
 static ut64 tp_type_bits(RAnal *anal, const char *t) {
 	if (R_STR_ISEMPTY (t)) {
@@ -951,12 +987,16 @@ static char *tp_fcn_reg_type(RAnal *anal, RAnalFunction *fcn, const char *reg) {
 	RAnalFunctionSignature *sig = r_anal_function_get_signature (fcn);
 	if (sig && R_STR_ISNOTEMPTY (sig->callconv)) {
 		const int argc = r_list_length (sig->params);
+		bool fp_home = true;
 		int i;
 		for (i = 0; i < argc; i++) {
-			const char *loc = r_anal_cc_argloc (anal,
-				sig->callconv, i, 0, argc);
+			RAnalFunctionParam *param = r_list_get_n (sig->params, i);
+			// the fp run is a prefix: one non-fp arg ends it
+			const char *fploc = fp_home? tp_fparg_loc (anal, sig->callconv, i): NULL;
+			fp_home = fploc && param && tp_fparg_scalar (anal, param->type);
+			const char *loc = fp_home? fploc
+				: r_anal_cc_argloc (anal, sig->callconv, i, 0, argc);
 			if (loc && r_anal_cc_location_uses (anal, loc, reg)) {
-				RAnalFunctionParam *param = r_list_get_n (sig->params, i);
 				char *type = param && R_STR_ISNOTEMPTY (param->type)
 					? strdup (param->type): NULL;
 				r_anal_function_signature_free (sig);

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3319,6 +3319,33 @@ var mydouble b @ rbp-0x10
 EOF2
 RUN
 
+NAME=aaft homes a float parameter declared without an arity key
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wa mov rdi, qword [rbp - 8] @ 8
+wx f20f1045f0 @ 12
+wa call 0x100 @ 17
+wa leave @ 22
+wa ret @ 23
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 1
+af @ 0
+tk sq=func
+tk func.sq.arg.0=double,x
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var int64_t var_8h @ rbp-0x8
+var double x @ rbp-0x10
+EOF2
+RUN
+
 NAME=aaft keeps the integer index of an argument after a float one
 FILE=malloc://512
 ARGS=-a x86 -b 64 -e anal.cc=amd64

--- a/test/db/cmd/types
+++ b/test/db/cmd/types
@@ -3291,12 +3291,175 @@ var void * f @ rbp-0x8
 EOF2
 RUN
 
+NAME=aaft homes leading float-class parameters on the float registers
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wx f20f1045f8 @ 8
+wx f20f104df0 @ 13
+wa call 0x100 @ 18
+wa leave @ 23
+wa ret @ 24
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 1
+af @ 0
+td typedef double mydouble;
+td double sq(const double a, mydouble b);
+tk func.sq.cc=amd64
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var double a @ rbp-0x8
+var mydouble b @ rbp-0x10
+EOF2
+RUN
+
+NAME=aaft keeps the integer index of an argument after a float one
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wx f20f1045f8 @ 8
+wa mov rsi, qword [rbp - 0x10] @ 13
+wa mov rdi, qword [rbp - 0x18] @ 17
+wa call 0x100 @ 21
+wa leave @ 26
+wa ret @ 27
+wa ret @ 0x100
+af+ 0x100 f3
+afb+ 0x100 0x100 1
+af @ 0
+td int f3(double a, int b);
+tk func.f3.cc=amd64
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var double a @ rbp-0x8
+var int64_t b @ rbp-0x10
+var int64_t var_18h @ rbp-0x18
+EOF2
+RUN
+
+NAME=aaft leaves a long double parameter on the integer sequence
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wa mov rdi, qword [rbp - 8] @ 8
+wx f20f1045f0 @ 12
+wa call 0x100 @ 17
+wa leave @ 22
+wa ret @ 23
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 1
+af @ 0
+td double sq(long double x);
+tk func.sq.cc=amd64
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var long double x @ rbp-0x8
+var int64_t var_10h @ rbp-0x10
+EOF2
+RUN
+
+NAME=aaft keeps the integer sequence for a cc with no float sequence
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=ms
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wa mov rcx, qword [rbp - 8] @ 8
+wx f20f1045f0 @ 12
+wa call 0x100 @ 17
+wa leave @ 22
+wa ret @ 23
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 1
+af @ 0
+td double sq(double x);
+tk func.sq.cc=ms
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var double x @ rbp-0x8
+var int64_t var_10h @ rbp-0x10
+EOF2
+RUN
+
+NAME=aaft keeps the integer sequence for a grouped float location
+FILE=malloc://512
+ARGS=-a arm -b 64 -e anal.cc=arm64
+CMDS=<<EOF2
+wa sub sp, sp, 0x20 @ 0
+wa ldr x0, [sp, 8] @ 4
+wx e00b40fd @ 8
+wa bl 0x100 @ 12
+wx ff830091 @ 16
+wa ret @ 20
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 4
+af @ 0
+td double sq(double x);
+tk func.sq.cc=arm64
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var double x @ sp+0x8
+var int64_t var_10h @ sp+0x10
+EOF2
+RUN
+
+NAME=aaft keeps the integer sequence for a stack-spelled float location
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa sub rsp, 0x20 @ 4
+wa mov rdi, qword [rbp - 8] @ 8
+wx f20f1045f0 @ 12
+wa call 0x100 @ 17
+wa leave @ 22
+wa ret @ 23
+wa ret @ 0x100
+af+ 0x100 sq
+afb+ 0x100 0x100 1
+afc dyncc:rdi,rsi:rax!F^0 @ 0x100
+af @ 0
+td double sq(double x);
+aaft
+afv @ 0
+EOF2
+EXPECT=<<EOF2
+var double x @ rbp-0x8
+var int64_t var_10h @ rbp-0x10
+EOF2
+RUN
+
 NAME=aaft float and double facts from parallel branches meet to double
 FILE=malloc://512
 ARGS=-a x86 -b 64
 CMDS=<<EOF2
-wx 554889e54883ec2085ff7424488b7df8e84b000000eb39 @ 0
-wx 488b7df8e837000000eb15 @ 0x30
+wx 554889e54883ec2085ff74240f1245f8e84b000000eb39 @ 0
+wx 0f1245f8e837000000eb15 @ 0x30
 wx c9c3 @ 0x50
 wx c3 @ 0x60
 wx c3 @ 0x70
@@ -3312,6 +3475,71 @@ EOF2
 EXPECT=<<EOF2
 arg int64_t arg1 @ rdi
 var double v @ rbp-0x8
+EOF2
+RUN
+
+NAME=aft frees the first integer register for a caller's leading double
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa mov rax, qword [rdi + 8] @ 4
+wa call rax @ 8
+wa leave @ 10
+wa ret @ 11
+af @ 0
+afn c @ 0
+afvt arg1 "struct S *" @ 0
+td int cb(int v);
+tk S=struct
+tk struct.S=x,fp
+tk struct.S.x=int,0,0
+tk struct.S.fp=cb,8,0
+td void c(double a, struct S *p);
+aei
+aeim
+aft @ 0
+afv @ 0
+?e calllink
+tk calllink.00000008
+EOF2
+EXPECT=<<EOF2
+arg struct S * arg1 @ rdi
+calllink
+cb
+EOF2
+RUN
+
+NAME=aft keeps the first integer register for a caller's leading long
+FILE=malloc://512
+ARGS=-a x86 -b 64 -e anal.cc=amd64
+CMDS=<<EOF2
+wa push rbp @ 0
+wa mov rbp, rsp @ 1
+wa mov rax, qword [rdi + 8] @ 4
+wa call rax @ 8
+wa leave @ 10
+wa ret @ 11
+af @ 0
+afn c @ 0
+afvt arg1 "struct S *" @ 0
+td int cb(int v);
+tk S=struct
+tk struct.S=x,fp
+tk struct.S.x=int,0,0
+tk struct.S.fp=cb,8,0
+td void c(long a, struct S *p);
+aei
+aeim
+aft @ 0
+afv @ 0
+?e calllink
+tk calllink.00000008
+EOF2
+EXPECT=<<EOF2
+arg struct S * arg1 @ rdi
+calllink
 EOF2
 RUN
 


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`aaft` matches parameter *i* against the convention's *i*-th **integer** argument register, so a `double` parameter is looked for in `rdi` and its type lands on whatever variable last fed that register. `sq`'s `double x` arrives in `xmm0`:

```
$ cat sq.r2
wa push rbp @ 0
wa mov rbp, rsp @ 1
wa sub rsp, 0x20 @ 4
wa mov rdi, qword [rbp - 8] @ 8
wx f20f1045f0 @ 12
wa call 0x100 @ 17
wa leave @ 22
wa ret @ 23
wa ret @ 0x100
af+ 0x100 sq
afb+ 0x100 0x100 1
af @ 0
td double sq(double x);
tk func.sq.cc=amd64
aaft
afv @ 0
$ r2 -NN -q -a x86 -b 64 -e anal.cc=amd64 -i sq.r2 malloc://512
var double x @ rbp-0x8          <- fed rdi, typed anyway
var int64_t var_10h @ rbp-0x10  <- fed xmm0, left alone
```

The `fparg` sequence has been in the cc data since `a925d6fd3` and `af`-time recovery reads it; the type matcher never did.

## The fix

- A parameter spelled exactly `float` or `double` costs one float slot, and the *k*-th such parameter is homed in `fparg<k>` — through the `r_anal_cc_argslot` call the matcher already makes, so the register, the stack flag and the offset cannot disagree.
- Only a leading run counts, and integer parameters keep their positional slot: an sret pointer, C++ `this` or a static chain takes an integer slot, so reducing the integer index by the float count is wrong.
- Everything else is excluded rather than guessed — x87 `long double` costs zero fp slots on amd64 and one on arm64, `_Complex` costs two — and the rule applies only where `fparg<k>` names a single register, so `cc.ms`, which defines none, and arm64's `{d0,s0,v0,q0}` both decline. arm64 is a follow-up.
- `a:callargs`, `carg.c`'s emu comments and `afsq` still resolve parameter *i* through the integer sequence, so they report `rdi` where the matcher now reports `xmm0`. A follow-up PR will move the rule to the layer that owns it.

## The tests

Nine cases in `db/cmd/types`, one per thing pinned: the slot index, the qualifier skip, the typedef chase, a parameter typed while `func.<n>.args` is unset (two independent sdb keys, and the type is what decides), integer indices staying unshifted, and the two decline paths. Two `aft` cases cover the caller-side map; `long double` and a convention with no float sequence are the inverse cases. Reverting the matcher hunk turns three cases red, the caller-side hunk one.

`aaft float and double facts from parallel branches meet to double` passed its `double` in `rdi`; its bytes now pass it in `xmm0`, golden unchanged.