### PR TITLE
Regenerate the windows type table when a fragment changes ##build

### DIFF
--- a/libr/anal/d/Makefile
+++ b/libr/anal/d/Makefile
@@ -12,7 +12,7 @@ linux-x86-32.sdb: linux-x86-32
 
 %.sdb:%.sdb.txt $(EXTRA_FILES)
 
-types-windows.sdb.txt:
+types-windows.sdb.txt: $(wildcard windows/*.txt)
 	cat windows/*.txt > types-windows.sdb.txt
 
 clean:


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`libr/anal/d/Makefile` concatenates `windows/*.txt` into the Windows type table under a rule with no prerequisites, so make treats the output as up to date the moment it exists and a fragment edit never reaches it. Below, the tracked fragment says `LONG=type`, make reports success, and the generated table still says `LONG=typedef`:

```
$ grep -n '^LONG=' libr/anal/d/windows/types-windows_base.sdb.txt
236:LONG=type
$ make -C libr/anal/d
SDBTOOL (mirror=0) from=. to=.
$ sed -n 236p libr/anal/d/types-windows.sdb.txt
LONG=typedef
```

To reach that state from a clean tree — it is what any checkout older than `fa896f0d7b` is already in:

```
git checkout fa896f0d7b~1 -- libr/anal/d/windows/
rm -f libr/anal/d/types-windows.sdb.txt && make -C libr/anal/d
git checkout master -- libr/anal/d/windows/
make -C libr/anal/d
```

The effect is that the Windows fixed-width integer aliases stop resolving: `LONG` keeps its old `typedef` spelling instead of the 32-bit type, `l_timeval` sizes to 16 rather than 8, and `db/cmd/types`'s *Windows fixed-width integer aliases resolve in CIL binaries* fails. Only `make clean` or a fresh clone recovers, which is why CI has never shown it.

## The fix

- Declare the fragments as prerequisites of the table: `types-windows.sdb.txt: $(wildcard windows/*.txt)`. A fragment edit or a new fragment now regenerates it; a second `make` is still a no-op.
- `libr/anal/d/meson.build` already passes the fragments as `input` to its `custom_target`, so just updating make.

## The tests

No new case: `db/cmd/types`'s *Windows fixed-width integer aliases resolve in CIL binaries* already asserts the outcome, and it already fails in a tree whose table is stale. 
