### PR TITLE
Number DWARF locals whose names repeat within a function ##analysis

### DIFF
--- a/libr/anal/dwarf_process.c
+++ b/libr/anal/dwarf_process.c
@@ -1886,6 +1886,12 @@ static void sdb_save_dwarf_function(Context *ctx, Function *dwarf_fcn, const cha
 	int formal_index = 0;
 	RListIter *iter;
 	Variable *var;
+	HtPP *taken = ht_pp_new0 ();
+	r_list_foreach (variables, iter, var) {
+		if (var->name && var->kind == VARIABLE_KIND_FORMAL_PARAMETER) {
+			ht_pp_insert (taken, var->name, var);
+		}
+	}
 	r_list_foreach (variables, iter, var) {
 		const bool is_formal = var->kind == VARIABLE_KIND_FORMAL_PARAMETER
 			&& !var->is_result;
@@ -1908,11 +1914,25 @@ static void sdb_save_dwarf_function(Context *ctx, Function *dwarf_fcn, const cha
 			free (arg_val);
 			arg_index++;
 		} else if (var->kind == VARIABLE_KIND_LOCAL) {
+			// the function has one namespace while DWARF scopes each inlined
+			// call and lexical block, so a local that repeats a name is numbered
+			char *numbered = NULL;
+			int n = 1;
+			while (ht_pp_find (taken, numbered? numbered: var->name, NULL)) {
+				free (numbered);
+				numbered = r_str_newf ("%s_%d", var->name, n++);
+			}
+			if (numbered) {
+				free (var->name);
+				var->name = numbered;
+			}
+			ht_pp_insert (taken, var->name, var);
 			sdb_setf (sdb, meta, 0, "fcn.%s.var.%s", sname, var->name);
 			r_strbuf_appendf (&vars_buf, "%s,", var->name);
 		}
 		free (meta);
 	}
+	ht_pp_free (taken);
 	if (vars_buf.len > 0) {
 		r_strbuf_slice (&vars_buf, 0, vars_buf.len - 1);
 	}

--- a/test/db/cmd/dwarf
+++ b/test/db/cmd/dwarf
@@ -326,10 +326,10 @@ EXPECT=<<EOF
 |           ; var int64_t var_200h @ rsp+0x200
 |           ; var int64_t var_208h @ rsp+0x208
 |           ; var int64_t var_210h @ rsp+0x210
-|           ; var int64_t var_218h @ rsp+0x218
-|           ; var int64_t var_220h @ rsp+0x220
-|           ; var int64_t var_228h @ rsp+0x228
-|           ; var &str[5] *arg0 @ rsp+0x230
+|           ; var i32[10] *arg0 @ rsp+0x218
+|           ; var i32[10] *arg0_1 @ rsp+0x220
+|           ; var &str[5] *arg0_2 @ rsp+0x228
+|           ; var &str[5] *arg0_3 @ rsp+0x230
 |           0x00005750      4881ec3802..   sub rsp, 0x238              ; void main();
 |           0x00005757      c784248000..   mov dword [numbers], 8
 |           0x00005762      c784248400..   mov dword [numbers[1]], 7
@@ -345,7 +345,7 @@ EXPECT=<<EOF
 |           0x000057cc      488d8c2480..   lea rcx, [numbers]
 |           0x000057d4      48898c24e8..   mov qword [var_e8h], rcx
 |           0x000057dc      488b8c24e8..   mov rcx, qword [var_e8h]
-|           0x000057e4      48898c2418..   mov qword [var_218h], rcx
+|           0x000057e4      48898c2418..   mov qword [arg0], rcx
 |           0x000057ec      4889cf         mov rdi, rcx                ; int64_t arg1
 |           0x000057ef      488d35da0f..   lea rsi, [sym.core::array::__impl_core::fmt::Debug_for__T_____::fmt::h894a83bd2e78b654] ; 0x67d0 ; "H\x83\xecHH\x89|$8H\x89t$@\xb8\n" ; int64_t arg2
 |           0x000057f6      4889442478     mov qword [var_78h], rax
@@ -375,7 +375,7 @@ EXPECT=<<EOF
 |           0x00005881      488d8c2480..   lea rcx, [numbers]
 |           0x00005889      48898c2430..   mov qword [var_130h], rcx
 |           0x00005891      488b8c2430..   mov rcx, qword [var_130h]
-|           0x00005899      48898c2420..   mov qword [var_220h], rcx
+|           0x00005899      48898c2420..   mov qword [arg0[2]], rcx
 |           0x000058a1      4889cf         mov rdi, rcx                ; int64_t arg1
 |           0x000058a4      488d35250f..   lea rsi, [sym.core::array::__impl_core::fmt::Debug_for__T_____::fmt::h894a83bd2e78b654] ; 0x67d0 ; "H\x83\xecHH\x89|$8H\x89t$@\xb8\n" ; int64_t arg2
 |           0x000058ab      4889442458     mov qword [var_58h], rax


### PR DESCRIPTION
The DWARF importer walks every variable under a subprogram, including the variables of inlined calls and nested lexical blocks, and stores each under `fcn.<name>.var.<varname>`. That gives a function one namespace where DWARF has one per scope, so a repeated name overwrote the earlier slot.

Found while running the r2sleigh decompiler over bzip2 at -O2: `compress` lost its own `struct stat statBuf` because `countHardLinks` was inlined into it with a `statBuf` of its own, so the reads of `statBuf.st_mode` had no declaration to land in. The existing rust test binary shows the same thing: `main` kept one of four inlined `arg0` slots.

A local whose name is already taken by a parameter or an earlier local is now stored as `name_1`, `name_2` and so on, in DIE order, so the function's own variables keep their bare names. The rust test expectation gains the three slots that were dropped.

One thing the new expectation shows and this change does not touch: the disassembler labels the slot at `rsp+0x220` as `arg0[2]` although `arg0_1` is declared there, because the size of the type `i32[10] *` is taken as the array's rather than the pointer's. That is a separate defect in the type size lookup.
