### PR TITLE
Stop listing bflt relocs when the listing failed ##bin

### DIFF
--- a/libr/bin/p/bin_bflt.c
+++ b/libr/bin/p/bin_bflt.c
@@ -90,6 +90,10 @@ static RVecRBinReloc *patch_relocs(RBinFile *bf) {
 		}
 		R_FREE (bin->reloc_table);
 	}
+	if (RVecRBinReloc_empty (list)) {
+		RVecRBinReloc_free (list);
+		return NULL;
+	}
 	return list;
 }
 
@@ -217,6 +221,9 @@ static RVecRBinReloc *relocs(RBinFile *bf) {
 	}
 	return list;
 out_error:
+	// patch_relocs lists whatever survives here, so a failed listing leaves none
+	R_FREE (obj->got_table);
+	obj->n_got = 0;
 	RVecRBinReloc_free (list);
 	return NULL;
 }

--- a/test/db/formats/bflt
+++ b/test/db/formats/bflt
@@ -98,3 +98,25 @@ vaddr      paddr      type   ntype name
 0x00002fbc 0x00002fbc SET_32 0
 EOF
 RUN
+
+NAME=bflt relocs apply lists nothing when the listing bailed out
+FILE=bins/fuzzed/r2_hbo_relocs
+ARGS=-e bin.relocs.apply=true
+CMDS=<<EOF2
+i~^format
+ir~?
+EOF2
+EXPECT=<<EOF2
+format   bflt
+0
+EOF2
+RUN
+
+NAME=bflt relocs apply keeps the table of a valid binary
+FILE=bins/bflt/bin.bflt
+ARGS=-e bin.relocs.apply=true
+CMDS=ir~?
+EXPECT=<<EOF2
+94
+EOF2
+RUN


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

When the bFLT reloc listing gives up, it leaves the GOT table it had already built on the object, and the patching path then lists a row for each entry of it. On a corrupt header that means rows appear where the listing showed none:

```
$ r2 -N -q -e bin.relocs.apply=false -c 'ir~?' bins/fuzzed/r2_hbo_relocs
0
$ r2 -N -q -e bin.relocs.apply=true  -c 'ir~?' bins/fuzzed/r2_hbo_relocs
54
$ r2 -N -q -e bin.relocs.apply=true  -c ir bins/fuzzed/r2_hbo_relocs | head -4
vaddr      paddr      type   ntype name
---------------------------------------
0x30303030 0x30303030 SET_32 0
0x30303030 0x30303030 SET_32 0
```

That file's header says `reloc_count` is 0x30303030, which overflows the reloc table size check, so `relocs()` bails to its error label — after publishing `got_table`. The 54 addresses are the file's own `30303030` bytes, because `VALID_GOT_ENTRY` rejects only `UT32_MAX`.

It is not a memory error: under ASan the same run reports no bad access.

## The fix

- The error label drops the GOT table it built, so nothing downstream can list a table the listing abandoned.
- `patch_relocs` returns NULL rather than an empty vector, matching mach0 and the NULL check its caller already has, so an empty result prints nothing instead of a bare table header.

## The tests

Two cases in `db/formats/bflt`. The fuzzed binary asserts `ir~?` is 0 with patching on, and fails against the old code. The valid `bins/bflt/bin.bflt` asserts its 92 rows survive with patching on — the case where this must be inert, green either way; the file's existing case already covers the listing path with patching off.