### PR TITLE
End the block at an arm64 br whether or not it dispatches a jump table ##analysis

### DIFF
--- a/libr/anal/fcn.c
+++ b/libr/anal/fcn.c
@@ -1790,10 +1790,12 @@ noskip:
 				}
 			} else if (is_arm && anal->config->bits == 64 && anal->opt.jmptbl) {
 				// arm64 jmptbl dispatcher resolved in libr/anal/jmptbl.c.
+				// Resolved or not, the br ends the block: nothing after it is
+				// reached by falling through.
 				r_anal_jmptbl_arm64_from_br (anal, fcn, bb, depth, op, loadsize);
 				anal->cmpval = 0;
 				loadsize = 0;
-				break;
+				gotoBeach (R_ANAL_RET_NOP);
 			} else if (is_mips && anal->opt.jmptbl) {
 				// lw v1, -0x7fc4(gp) ; gp = 0x684c00 - 0x7fc4 // read 4 bytes at gp-0x7fc4
 				// sll v0, s0, 2   // select the case from the pointer table * 4

--- a/test/db/anal/arm
+++ b/test/db/anal/arm
@@ -436,7 +436,7 @@ af
 afl~[2]
 EOF
 EXPECT=<<EOF
-20
+12
 EOF
 RUN
 
@@ -451,7 +451,7 @@ af
 afl~[2]
 EOF
 EXPECT=<<EOF
-16
+8
 EOF
 RUN
 

--- a/test/db/anal/arm64-search
+++ b/test/db/anal/arm64-search
@@ -295,12 +295,11 @@ outputs: 2
 ninstr: 9
 traced: 0x0
 ---
-jump: 0x100003c64
 opaddr: 0x100003c44
 addr: 0x100003c44
 size: 32
 inputs: 1
-outputs: 90
+outputs: 89
 ninstr: 8
 traced: 0x0
 cases: 137

--- a/test/db/anal/autoname
+++ b/test/db/anal/autoname
@@ -117,7 +117,7 @@ EXPECT=<<EOF
 0x100007920    1     16 sym.imp.warn
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
-0x100007950    1     24 sym.imp.write
+0x100007950    1     16 sym.imp.write
 0x100003a90  182   2972 main
 0x100003830    1     12 sym.func.100003830
 0x10000383c    1     16 sym.func.10000383c
@@ -142,11 +142,8 @@ EXPECT=<<EOF
 0x100005638   82   1840 sub.printf_100005638
 0x100005d68    6    156 sub.printf_100005d68
 0x100005e04   34    740 sub.mbrtowc_100005e04
-0x100006184    1      4 fcn.100006184
-0x1000060e8   13    168 sym.func.1000060e8
-0x100006188    1      4 case.0x100006120.11
-0x10000618c    1     24 case.0x100006120.9
-0x1000069ec   21    456 sub.printf_1000069ec
+0x100006184    3     32 fcn.100006184
+0x1000060e8   15    196 sym.func.1000060e8
 0x1000061dc    7    180 sub.tputs_1000061dc
 0x100006290   16    176 sub.putchar_100006290
 0x10000636c   13    232 sub.printf_10000636c
@@ -156,6 +153,7 @@ EXPECT=<<EOF
 0x100006970    5     44 sub.abort_100006970
 0x10000699c    1     52 sub.write_10000699c
 0x1000069d0    1     28 sub.putchar_1000069d0
+0x1000069ec   21    456 sub.printf_1000069ec
 0x100006bb4   17    332 sub.putchar_100006bb4
 0x100006d00   17    348 sub.putchar_100006d00
 0x100006e5c   16    308 sub.mbrtowc_100006e5c
@@ -265,7 +263,7 @@ EXPECT=<<EOF
 0x100007920    1     16 sym.imp.warn
 0x100007930    1     16 sym.imp.warnx
 0x100007940    1     16 sym.imp.wcwidth
-0x100007950    1     24 sym.imp.write
+0x100007950    1     16 sym.imp.write
 0x100003a90  182   2972 main
 0x100003830    1     12 sym.func.100003830
 0x10000383c    1     16 sym.func.10000383c
@@ -290,11 +288,8 @@ EXPECT=<<EOF
 0x100005638   82   1840 sub.printf_100005638
 0x100005d68    6    156 sub.printf_100005d68
 0x100005e04   34    740 sub.mbrtowc_100005e04
-0x100006184    1      4 fcn.100006184
-0x1000060e8   13    168 sym.func.1000060e8
-0x100006188    1      4 case.0x100006120.11
-0x10000618c    1     24 case.0x100006120.9
-0x1000069ec   21    456 sub.printf_1000069ec
+0x100006184    3     32 sub.printf_100006184
+0x1000060e8   15    196 sub.printf_1000060e8
 0x1000061dc    7    180 sub.tputs_1000061dc
 0x100006290   16    176 sub.putchar_100006290
 0x10000636c   13    232 sub.printf_10000636c
@@ -304,6 +299,7 @@ EXPECT=<<EOF
 0x100006970    5     44 sub.abort_100006970
 0x10000699c    1     52 sub.write_10000699c
 0x1000069d0    1     28 sub.putchar_1000069d0
+0x1000069ec   21    456 sub.printf_1000069ec
 0x100006bb4   17    332 sub.putchar_100006bb4
 0x100006d00   17    348 sub.putchar_100006d00
 0x100006e5c   16    308 sub.mbrtowc_100006e5c

--- a/test/db/anal/jmptbl
+++ b/test/db/anal/jmptbl
@@ -34,7 +34,7 @@ EXPECT=<<EOF
 0x10000404c      ldrsw x11, [x9, x8, lsl 2]
 0x100004050      add x10, x10, x11
 0x100004054      br x10
-| // true: 0x100004058
+
 ;-- case 0:                                                            ; from 0x100004048
 ; CODE XREF from sym.func.100004000 @ 0x100004048(x)
 0x100004058      ubfx x25, x4, 0x30, 8                                 ; arg4
@@ -408,7 +408,7 @@ EXPECT=<<EOF
 0x100004174      ldrsw x10, [x8, x25, lsl 2]
 0x100004178      add x9, x9, x10
 0x10000417c      br x9
-| // true: 0x100004180
+
 ;-- case 0:                                                            ; from 0x100004170
 ; CODE XREF from sym.func.100004124 @ 0x100004170(x)
 0x100004180      ldr x8, [var_80h]

--- a/test/db/cmd/cmd_cmp
+++ b/test/db/cmd/cmd_cmp
@@ -457,6 +457,7 @@ match 1.000000 sym.imp.uuid_unparse_upper
 match 1.000000 sym.imp.warn
 match 1.000000 sym.imp.warnx
 match 1.000000 sym.imp.wcwidth
+match 1.000000 sym.imp.write
 --
 sym.func.100003a1c
 match 0.866667 sym.func.100003a54


### PR DESCRIPTION
The arm64 branch of the indirect-jump case in `fcn_recurse` runs the jump table dispatcher and then `break`s out of the switch, so the scan continues to the next instruction as if a `br` could fall through. A Mach-O import stub is `adrp`, `ldr`, `br` and then a `brk` of padding, and the padding ended up inside the stub's only block: `afb @ sym.imp.printf` gave one 16-byte block of four instructions.

Found while running the r2sleigh decompiler over a Mach-O arm64 binary: the decompiler correlates a tail transfer with the last operation of its block, and the trailing `brk` kept the stub from being recognised as the forwarding thunk it is.

A `br` now ends its block the way every other register jump does; the dispatcher has already deferred the cases it resolved. `test/db/anal/arm64` passes.
