### PR TITLE
Fix a one-byte heap overflow in ps with a zero length ##core

### DIFF
--- a/libr/core/cmd_print.inc.c
+++ b/libr/core/cmd_print.inc.c
@@ -6454,7 +6454,8 @@ static void cmd_pxr(RCore *core, int len, int mode, int wordsize, const char *ar
 
 #define USE_PREAD 0
 static ut8 *R_NULLABLE decode_text(RCore *core, ut64 offset, size_t len, bool zeroend) {
-	ut8 *out = calloc (len, 10);
+	// out[len] is always written, so len 0 still needs a byte for it
+	ut8 *out = calloc (len + 1, 10);
 	if (!out) {
 		return NULL;
 	}

--- a/test/db/cmd/print
+++ b/test/db/cmd/print
@@ -120,6 +120,27 @@ EOF
 RUN
 
 # merged: mac ls pfc.fmt
+NAME=ps with a zero length
+FILE=malloc://64
+CMDS=<<EOF
+wx 41424344
+?e --
+ps 0
+?e --
+psj 0
+?e --
+ps 4
+EOF
+EXPECT=<<EOF
+--
+
+--
+{"string":"","offset":0,"section":"unknown","length":0,"type":"unknown"}
+--
+ABCD
+EOF
+RUN
+
 NAME=mac ls pdsf
 FILE=bins/mach0/mac-ls
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

`ps` with a length of zero writes its terminator one byte past a zero-size allocation. It lands in malloc slack, so it is silent on a normal build and only shows under a sanitizer:

```
$ r2 -NN -Qc 'ps 0' malloc://64
ERROR: AddressSanitizer: heap-buffer-overflow on address 0xf5c930270b30
WRITE of size 1 at 0xf5c930270b30 thread T0
    #0 in decode_text libr/core/cmd_print.inc.c:6502
    #1 in cmd_print libr/core/cmd_print.inc.c:8564
0xf5c930270b30 is located 0 bytes inside of 1-byte region
allocated by thread T0 here:
    #0 in calloc
    #1 in decode_text libr/core/cmd_print.inc.c:6457
```

`decode_text` allocates `calloc (len, 10)` and always finishes with `out[len] = 0`. `psz` is guarded against a zero length, `ps` and `psj` are not.

## The fix

`calloc (len + 1, 10)`, so the buffer covers the terminator it is always given. The guard belongs at the allocation rather than at the callers because `len` is reassigned from `maxlen` after entry.

## The tests

One case in `db/cmd/print` covers `ps 0`, `psj 0` and a non-zero `ps` on `malloc://64`. It passes on master too — a one-byte write into slack is invisible without a sanitizer — so it is coverage of the zero-length path rather than a pin. What fails before the fix is the run above; with it, an ASan build runs `db/cmd/print` with no report.