### PR TITLE
Fix a double free when closing a python3 pyc file ##crash

### DIFF
--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -544,6 +544,7 @@ static pyc_object *get_ascii_object_generic(PycUnmarshalCtx *ctx, RBuffer *buffe
 				R_FREE (ret);
 				return NULL;
 			}
+			ret->type = TYPE_INTERNED; // the table owns the bytes, not us
 		}
 		return ret;
 	}

--- a/test/db/formats/pyc
+++ b/test/db/formats/pyc
@@ -36,6 +36,13 @@ EXPECT=
 EXPECT_ERR=
 RUN
 
+NAME=pyc closing a file frees interned strings once
+FILE=bins/pyc/py37.pyc
+CMDS=o-*
+EXPECT=
+EXPECT_ERR=
+RUN
+
 NAME=pyc load version38
 FILE=bins/pyc/py38.pyc
 CMDS=<<EOF


### PR DESCRIPTION
- [X] Mark this if you consider it ready to merge
- [X] I've added tests (optional)
- [ ] I wrote some lines in the [book](https://github.com/radareorg/radare2book) (optional)

**Description**

Closing a python3 `.pyc` frees its interned strings twice. Any py3 file does it, the names in a code object are interned short-ASCII strings:

```
$ r2 -NN -Qc 'o-*' test/bins/pyc/py37.pyc
free(): double free detected in tcache 2
Aborted (core dumped)
```

py36, py38 and py39 abort the same way; py27 does not. `interned_table` is an `r_list_newf (free)`, so it owns the bytes it holds, and the object that registered them is tagged `TYPE_ASCII`, which `free_object` also frees.

## The fix

- A string registered in `interned_table` is tagged `TYPE_INTERNED`, the tag whose free arm already reads *data is borrowed from interned_table, don't free* and whose copy arm already shares the pointer. Both registration sites now agree: everything in the table is owned by the table.
- Not a new borrowed tag for the ASCII codes, because `TYPE_ASCII_INTERNED` and `TYPE_SHORT_ASCII_INTERNED` are stream codes that no object ever carries, and the code-object name check already accepts `TYPE_INTERNED`.

## The tests

One case in `db/formats/pyc` closes `py37.pyc` with `o-*`. It has to close the file in-session: r2r runs r2 as `-Qc`, which skips teardown, so the existing "does not crash" cases never reach the plugin's `destroy` and stayed green over this. Reverting the fix reddens that case alone, and so does tagging the string with any other owned type. The py2.7 cases are the side this cannot touch, and the py37 symbol/section goldens are unchanged.